### PR TITLE
docs(tools): de-historicize comments/docstrings — xray/story/machines-viz/pair-mcp/mcp-infra (rf2-kimk1q, rf2-t2azce, rf2-bton28, rf2-bjxj9n, rf2-p6i6t6)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -1,13 +1,10 @@
 (ns day8.re-frame2-machines-viz.chart
   "MachineChart — the xyflow-based state-chart component.
 
-  rf2-gpzb4 (2026-05-21 xyflow override) — Mike's override of the
-  2026-05-19 ELK+hand-rolled-SVG lock. The chart now sits on top of
-  `@xyflow/react` (the same render engine Stately Studio uses) with
-  custom Stately-style node + edge components from `chart.nodes` and
-  `chart.edges`. elkjs runs as xyflow's layout backend so the same
-  hierarchical-layered algorithm the previous engine used continues
-  to drive node positions.
+  The chart sits on top of `@xyflow/react` (the same render engine
+  Stately Studio uses) with custom Stately-style node + edge components
+  from `chart.nodes` and `chart.edges`. elkjs runs as xyflow's layout
+  backend, so a hierarchical-layered algorithm drives node positions.
 
   ## What this owns
 
@@ -23,13 +20,11 @@
     - **Topology parsing** — lives in `chart.layout`. This ns
       consumes the parsed graph but does not walk the definition
       tree.
-    - **`countdown-ring` / `sparkline` primitives** — moved to
+    - **`countdown-ring` / `sparkline` primitives** — live in
       `chart.primitives` since they are consumed OUTSIDE the chart
       (Xray overlays, cluster sparklines).
     - **Viewport state** — xyflow owns zoom/pan/fit internally;
-      hosts no longer manage `{:scale :tx :ty}` slots. The previous
-      `chart.controls` reducer + Xray's `machine_canvas` viewport
-      machinery are obsolete with this migration.
+      hosts do not manage `{:scale :tx :ty}` slots.
 
   ## Bundle isolation
 
@@ -85,11 +80,9 @@
 
 (def default-elk-options
   "Canonical elk.js `layoutOptions` for the chart. Tuned for state-
-  machine readability per the rf2-0yil0 audit cluster + rf2-gg7ws
-  visual-quality lift (kept across the xyflow migration since the
-  layout engine itself is unchanged; only the renderer swapped).
+  machine readability.
 
-  rf2-cz8v6 (G2 — bend-point edge routing): two routing-relevant keys.
+  Bend-point edge routing — two routing-relevant keys.
 
     - `elk.edgeRouting` is `ORTHOGONAL` (not `SPLINES`): the Layered
       algorithm then computes Manhattan bend-point routes that go
@@ -108,11 +101,11 @@
       in the same frame; `ROOT` makes elk do that rebasing for us
       (added ELK 0.9; elkjs 0.11 wraps a newer core).
 
-  rf2-rlq97 — edge-CLEARANCE + label-placement keys. ORTHOGONAL routing
-  (above) computes Manhattan routes, but without dedicated edge-to-node
-  spacing elk lets a route hug — or clip — a node box it passes, which
-  is the 'arrows route OVER state nodes' symptom Mike reported. Three
-  spacing knobs reserve the channels:
+  Edge-CLEARANCE + label-placement keys. ORTHOGONAL routing (above)
+  computes Manhattan routes, but without dedicated edge-to-node spacing
+  elk lets a route hug — or clip — a node box it passes (the 'arrows
+  route OVER state nodes' symptom). Three spacing knobs reserve the
+  channels:
 
     - `elk.spacing.edgeNode` (24) — the minimum gap elk keeps between an
       edge segment and ANY node box it routes past. This is the key that
@@ -124,39 +117,38 @@
       edge segments so bundled routes (several transitions between the
       same layers) read as distinct lines, not one fused thick stroke.
 
-  And the label-placement keys (the edge-label analogue of d9ro2's
-  node-measure feed; today the transition text is on the event-NODE so
-  edges carry empty labels, but the keys make elk reserve a channel for
-  any MEASURED edge label `projection/->elk-edge` feeds in future):
+  And the label-placement keys (the edge-label analogue of the node-
+  measure feed; the transition text is on the event-NODE so edges carry
+  empty labels, but the keys make elk reserve a channel for any MEASURED
+  edge label `projection/->elk-edge` feeds):
 
     - `elk.edgeLabels.placement` (CENTER) — elk places a non-empty edge
       label on the route, centred, and budgets space for it so two
       labels never overlap (the renderer then reads elk's computed label
-      position instead of the old middle-segment-midpoint heuristic).
+      position instead of a middle-segment-midpoint heuristic).
     - `elk.spacing.edgeLabel` (6) — gap between a label box and its
       edge.
 
-  rf2-ly51l — initial-state placement SOFT preference. `elk.layered.
-  cycleBreaking.strategy` is `DEPTH_FIRST` (was the implicit `GREEDY`).
-  This is the statechart-intent layer the bead asks for, expressed as a
-  soft bias rather than a forced layout (NOT `forceNodeModelOrder`):
+  Initial-state placement SOFT preference. `elk.layered.cycleBreaking.
+  strategy` is `DEPTH_FIRST`. This is a statechart-intent layer expressed
+  as a soft bias rather than a forced layout (NOT `forceNodeModelOrder`):
 
   A statechart graph is almost always CYCLIC (resets, retries, back
   transitions, machine-level `:on` fallbacks all loop back toward the
   initial state). The Layered algorithm must first make the graph
   ACYCLIC by reversing a set of edges; the layer ranking — and hence the
   top-to-bottom (or left-to-right) reading order — then follows the
-  forward edges. GREEDY picks the reversal set that minimises reversed
+  forward edges. `GREEDY` picks the reversal set that minimises reversed
   EDGE COUNT with no regard for where the flow STARTS, so for the door
   (`locked → closed → open → alarming`, with `alarming → locked` reset +
-  a root `:door/audit → locked` fallback) it reversed the wrong arcs and
-  ranked `open` at the TOP with `locked` (the initial) THIRD — the exact
-  observed-diff (the reference strongly prefers the initial near the
-  top). DEPTH_FIRST instead breaks cycles by a depth-first walk FROM THE
-  SOURCES (the initial state is a source — only its entry-marker points
-  in; the root-fallback anchor is the only other source), reversing just
-  the true back-edges, so the natural forward spine starting at the
-  initial state is honoured: `locked → closed → open → alarming`.
+  a root `:door/audit → locked` fallback) it reverses the wrong arcs and
+  ranks `open` at the TOP with `locked` (the initial) THIRD, whereas the
+  reference strongly prefers the initial near the top. DEPTH_FIRST
+  instead breaks cycles by a depth-first walk FROM THE SOURCES (the
+  initial state is a source — only its entry-marker points in; the
+  root-fallback anchor is the only other source), reversing just the
+  true back-edges, so the natural forward spine starting at the initial
+  state is honoured: `locked → closed → open → alarming`.
 
   It stays a PREFERENCE, not an invariant: DEPTH_FIRST only chooses WHICH
   edges are reversed to acyclic-ise the graph. ELK still runs full
@@ -172,53 +164,52 @@
   {"elk.algorithm"                              "layered"
    "elk.direction"                              "DOWN"
    "elk.spacing.nodeNode"                       "40"
-   ;; G-SHAPE compaction (rf2 layout-fidelity pass) — the between-layer
-   ;; gap was 70; tightened to 50 so a flat cyclic statechart reads as a
-   ;; tighter vertical column closer to the Stately/xstate reference
-   ;; (door / gate noticeably less stretched). Stays comfortably above the
-   ;; ORTHOGONAL route channel reserve (`edgeNodeBetweenLayers` 24 below)
-   ;; so routes don't crowd, and it only SHRINKS inter-layer whitespace —
-   ;; no node re-ranking — so nested / parallel / acyclic machines are
-   ;; visually unchanged (the inner ELK pass + container padding dominate
-   ;; those). It does NOT close the G-ROUTE back-edge detour (door/reset,
-   ;; gate/reset, brew back-edges sink to the deepest layer): that is
-   ;; STRUCTURAL to the events-as-nodes split + the DEPTH_FIRST initial-
-   ;; on-top preference and is not reachable via an ELK option — see the
-   ;; §Layout / G-ROUTE note in `001-Topology-Parity.md`.
+   ;; G-SHAPE compaction — the between-layer gap of 50 keeps a flat cyclic
+   ;; statechart a tighter vertical column close to the Stately/xstate
+   ;; reference (door / gate not over-stretched). It stays comfortably
+   ;; above the ORTHOGONAL route channel reserve (`edgeNodeBetweenLayers`
+   ;; 24 below) so routes don't crowd, and it only constrains inter-layer
+   ;; whitespace — no node re-ranking — so nested / parallel / acyclic
+   ;; machines are visually unchanged (the inner ELK pass + container
+   ;; padding dominate those). It does NOT close the G-ROUTE back-edge
+   ;; detour (door/reset, gate/reset, brew back-edges sink to the deepest
+   ;; layer): that is STRUCTURAL to the events-as-nodes split + the
+   ;; DEPTH_FIRST initial-on-top preference and is not reachable via an
+   ;; ELK option — see the §Layout / G-ROUTE note in
+   ;; `001-Topology-Parity.md`.
    "elk.layered.spacing.nodeNodeBetweenLayers"  "50"
    "elk.layered.crossingMinimization.strategy"  "LAYER_SWEEP"
-   ;; rf2-ly51l — break cycles by a depth-first walk from the sources
-   ;; (the initial state) rather than GREEDY min-reversed-count, so a
-   ;; cyclic statechart's forward spine starts at the initial state and
-   ;; ranks near the top/left. Soft: only changes WHICH edges are
-   ;; reversed to acyclic-ise; layer-sweep + node-placement still run.
-   ;; Identical to GREEDY for already-acyclic graphs. See the docstring.
+   ;; Break cycles by a depth-first walk from the sources (the initial
+   ;; state) rather than GREEDY min-reversed-count, so a cyclic
+   ;; statechart's forward spine starts at the initial state and ranks
+   ;; near the top/left. Soft: only changes WHICH edges are reversed to
+   ;; acyclic-ise; layer-sweep + node-placement still run. Identical to
+   ;; GREEDY for already-acyclic graphs. See the docstring.
    "elk.layered.cycleBreaking.strategy"         "DEPTH_FIRST"
-   ;; rf2-k504af — make ELK honour the input MODEL ORDER (nodes AND
-   ;; edges) as a tiebreaker through layering + crossing-minimisation,
-   ;; not just within-layer. Pairs with the per-edge
-   ;; `elk.layered.priority.direction` lever the projector sets on an
-   ;; INITIAL state's outgoing `__in` edge (`projection/->elk-edge`):
-   ;; together they pull the initial state to the START of its region's
-   ;; flow even in a PURE-CYCLIC parallel region (traffic's `red` /
-   ;; `walk`), where the soft DEPTH_FIRST + child-model-order preference
-   ;; alone SLIPS and the initial sinks to the bottom layer. This is the
-   ;; xstate-viz recipe (`considerModelOrder NODES_AND_EDGES` +
-   ;; per-initial-edge priority). General, not traffic-specific: a
-   ;; spine-ordered machine (door / brew / session) already ranks its
-   ;; initial first, so model-order agrees with the layout and nothing
-   ;; moves.
+   ;; Make ELK honour the input MODEL ORDER (nodes AND edges) as a
+   ;; tiebreaker through layering + crossing-minimisation, not just
+   ;; within-layer. Pairs with the per-edge `elk.layered.priority.
+   ;; direction` lever the projector sets on an INITIAL state's outgoing
+   ;; `__in` edge (`projection/->elk-edge`): together they pull the
+   ;; initial state to the START of its region's flow even in a PURE-
+   ;; CYCLIC parallel region (traffic's `red` / `walk`), where the soft
+   ;; DEPTH_FIRST + child-model-order preference alone SLIPS and the
+   ;; initial sinks to the bottom layer. This is the xstate-viz recipe
+   ;; (`considerModelOrder NODES_AND_EDGES` + per-initial-edge priority).
+   ;; General, not traffic-specific: a spine-ordered machine (door / brew
+   ;; / session) already ranks its initial first, so model-order agrees
+   ;; with the layout and nothing moves.
    "elk.layered.considerModelOrder"             "NODES_AND_EDGES"
    "elk.edgeRouting"                            "ORTHOGONAL"
    "elk.json.edgeCoords"                        "ROOT"
-   ;; rf2-rlq97 — edge-to-node + edge-to-edge clearance so ORTHOGONAL
-   ;; routes go AROUND node boxes (kills arrows-over-states) and bundled
-   ;; edges stay visually distinct.
+   ;; Edge-to-node + edge-to-edge clearance so ORTHOGONAL routes go AROUND
+   ;; node boxes (kills arrows-over-states) and bundled edges stay
+   ;; visually distinct.
    "elk.spacing.edgeNode"                       "24"
    "elk.layered.spacing.edgeNodeBetweenLayers"  "24"
    "elk.spacing.edgeEdge"                       "16"
-   ;; rf2-rlq97 — elk places + reserves space for any non-empty edge
-   ;; label (the renderer reads back elk's position; see `chart.edges`).
+   ;; elk places + reserves space for any non-empty edge label (the
+   ;; renderer reads back elk's position; see `chart.edges`).
    "elk.edgeLabels.placement"                   "CENTER"
    "elk.spacing.edgeLabel"                      "6"})
 
@@ -234,8 +225,8 @@
 (defn elk-layout-options
   "Pure root `layoutOptions` (a CLJS map) for the given parsed graph,
   host overrides, and direction — the input `->elk-input` `clj->js`-es
-  onto the elk root. Extracted as a named, directly-assertable fn so the
-  cross-hierarchy switch below is regression-guarded (rf2-gpa9k).
+  onto the elk root. A named, directly-assertable fn so the cross-
+  hierarchy switch below is regression-guarded.
 
   Layering on `default-elk-options`:
 
@@ -243,16 +234,15 @@
     2. `elk.direction` is forced from the `direction` arg (`:lr`/`:tb`);
     3. `elk.hierarchyHandling` is set to `INCLUDE_CHILDREN` — and ONLY
        set — when the graph nests: it is parallel (`:parallel?`) OR some
-       node has a `:parent-id` (parallel-region states rf2-lkwev OR
-       compound substates rf2-54s5a). This is the G5 cross-hierarchy
-       switch: `INCLUDE_CHILDREN` is what makes the Layered algorithm
-       route edges ACROSS nesting levels (its default,
-       `SEPARATE_CHILDREN`, lays each level out independently and never
-       routes cross-hierarchy edges). It pairs with G2's
-       `elk.edgeRouting ORTHOGONAL` + `elk.json.edgeCoords ROOT`
-       (rf2-cz8v6) so those cross-level routes come back as legible
-       absolute-coordinate bend-points. A FLAT, non-parallel graph keeps
-       the key absent so elk's per-level default stands."
+       node has a `:parent-id` (parallel-region states OR compound
+       substates). This is the cross-hierarchy switch:
+       `INCLUDE_CHILDREN` is what makes the Layered algorithm route edges
+       ACROSS nesting levels (its default, `SEPARATE_CHILDREN`, lays each
+       level out independently and never routes cross-hierarchy edges).
+       It pairs with `elk.edgeRouting ORTHOGONAL` + `elk.json.edgeCoords
+       ROOT` so those cross-level routes come back as legible absolute-
+       coordinate bend-points. A FLAT, non-parallel graph keeps the key
+       absent so elk's per-level default stands."
   [parsed layout-options direction]
   (-> default-elk-options
       (merge (or layout-options {}))
@@ -260,8 +250,8 @@
       (cond-> (or (:parallel? parsed)
                   (some :parent-id (:nodes parsed)))
         (assoc "elk.hierarchyHandling" "INCLUDE_CHILDREN"))
-      ;; rf2-p75kbg — a guarded fork whose branches lay out at the ROOT (the
-      ;; gate machine's `:gate/check` 3-way leaves the top-level `:idle`)
+      ;; A guarded fork whose branches lay out at the ROOT (the gate
+      ;; machine's `:gate/check` 3-way leaves the top-level `:idle`)
       ;; enables root `crossingMinimization.semiInteractive` so the branch
       ;; event-nodes' `elk.position` hints (projection/->elk-children) are
       ;; honoured and the dotted evaluation-order connector reads as a clean
@@ -272,20 +262,20 @@
         (assoc "elk.layered.crossingMinimization.semiInteractive" "true"))))
 
 (defn compute-layout-key
-  "rf2-9qbn0g — the memo key the chart uses to decide whether to re-run the
-  ELK layout pass. Pure; extracted as a directly-assertable fn so the cache-
-  invalidation contract is regression-guarded. (Named `compute-layout-key`,
-  not `layout-key`, because the component binds a local `layout-key` r/atom
-  that would shadow it.)
+  "The memo key the chart uses to decide whether to re-run the ELK layout
+  pass. Pure; a directly-assertable fn so the cache-invalidation contract
+  is regression-guarded. (Named `compute-layout-key`, not `layout-key`,
+  because the component binds a local `layout-key` r/atom that would
+  shadow it.)
 
   The key folds together every input that changes the laid-out result:
 
     - `definition`     — the machine topology;
     - `elk-direction`  — the RESOLVED direction ELK is fed (`:tb`/`:lr`);
     - `layout-options` — host ELK overrides;
-    - `density`        — drives the derived container padding (rf2-8q5pt);
-    - `context-rows`   — the root-container Context band height (rf2-8z1rca);
-    - `adaptive?`      — the post-ELK MODE flag (rf2-9qbn0g).
+    - `density`        — drives the derived container padding;
+    - `context-rows`   — the root-container Context band height;
+    - `adaptive?`      — the post-ELK MODE flag.
 
   `adaptive?` MUST be in the key even though `elk-direction` already is: the
   post-ELK transform (parallel transpose + back-edge reroute) is gated by the
@@ -302,48 +292,45 @@
 
 (defn- ->elk-input
   "Build an elk.js JS-side input graph for the given parsed nodes +
-  edges + direction. Parallel machines (rf2-lkwev) get a hierarchical
-  graph (region containers with nested state children) so elkjs sizes
-  + positions each orthogonal zone and its states; flat machines get
-  the original single-level child list. The root `layoutOptions` are
-  computed by the pure `elk-layout-options` (cross-hierarchy switch +
-  direction + host overrides) and `clj->js`-ed here.
+  edges + direction. Parallel machines get a hierarchical graph (region
+  containers with nested state children) so elkjs sizes + positions each
+  orthogonal zone and its states; flat machines get a single-level child
+  list. The root `layoutOptions` are computed by the pure
+  `elk-layout-options` (cross-hierarchy switch + direction + host
+  overrides) and `clj->js`-ed here.
 
-  rf2-qo5xy — the events-as-nodes paradigm decomposes each parsed
-  transition into TWO elk edges: source-state → event-node and
-  event-node → target-state (the second omitted for internal
-  transitions). elkjs lays out the synthetic event-node alongside
-  the source state's siblings (per `projection/->elk-children`); the
-  resulting positions land in `:positions` keyed by the event-node id
-  (`projection/event-node-id`) and the chart's xyflow projection picks
-  them up.
+  The events-as-nodes paradigm decomposes each parsed transition into TWO
+  elk edges: source-state → event-node and event-node → target-state (the
+  second omitted for internal transitions). elkjs lays out the synthetic
+  event-node alongside the source state's siblings (per
+  `projection/->elk-children`); the resulting positions land in
+  `:positions` keyed by the event-node id (`projection/event-node-id`)
+  and the chart's xyflow projection picks them up.
 
-  rf2-d9ro2 — the optional `measured-dims` `{node-id {:width :height}}`
-  map (xyflow's reported `node.measured` rendered boxes from a prior
-  render) is threaded into `projection/->elk-children` so leaf states +
-  event-nodes lay out at their REAL size, floored by the min constants.
-  nil on the first pass; the measure-then-relayout lifecycle in
-  `MachineChart` supplies it on the second pass.
+  The optional `measured-dims` `{node-id {:width :height}}` map (xyflow's
+  reported `node.measured` rendered boxes from a prior render) is threaded
+  into `projection/->elk-children` so leaf states + event-nodes lay out
+  at their REAL size, floored by the min constants. nil on the first
+  pass; the measure-then-relayout lifecycle in `MachineChart` supplies it
+  on the second pass.
 
-  rf2-rlq97 — the EDGES are projected by the pure
-  `projection/->elk-edges` (lifted out of an inline `mapcat` here so the
+  The EDGES are projected by the pure `projection/->elk-edges` (so the
   JVM corpus pins the edge-feed). They carry the events-as-nodes
   `__in` / `__out` split + optional MEASURED edge-label dims (the
-  edge-label analogue of d9ro2's node measure; nil today since the
-  transition text rides on the event-NODE — see `projection/->elk-edge`).
-  Feeding edges INTO elk (alongside the spacing + label-placement keys in
+  edge-label analogue of the node measure; nil since the transition text
+  rides on the event-NODE — see `projection/->elk-edge`). Feeding edges
+  INTO elk (alongside the spacing + label-placement keys in
   `default-elk-options`) is what makes elk's Layered algorithm route the
   edges AROUND node boxes instead of the renderer drawing geometric paths
   that cut across states.
 
-  rf2-8q5pt — `chart-vc` (the resolved density map from
-  `vc/chart-for-density`) is forwarded to `projection/->elk-children` so
-  each container's `elk.padding` tracks the active density's title-strip
-  + body-pad constants (was a regular-only literal). nil falls back to
-  the regular density inside the projection.
+  `chart-vc` (the resolved density map from `vc/chart-for-density`) is
+  forwarded to `projection/->elk-children` so each container's
+  `elk.padding` tracks the active density's title-strip + body-pad
+  constants. nil falls back to the regular density inside the projection.
 
-  rf2-8z1rca — `context-rows` (the count of context rows the root-container
-  Context band paints, derived from `:context-band`) is forwarded to
+  `context-rows` (the count of context rows the root-container Context
+  band paints, derived from `:context-band`) is forwarded to
   `projection/->elk-children` so the ROOT-CONTAINER frame's TOP padding
   reserves the variable-height Context band (children laid out below the
   title strip would otherwise sit UNDER the band). 0 ⇒ no band, no extra
@@ -354,16 +341,16 @@
                                                    direction))
        :children (clj->js (projection/->elk-children parsed measured-dims chart-vc
                                                      context-rows))
-       ;; rf2-rlq97 — edge-label dims share the `measured-dims` map (it is
-       ;; keyed by elk-edge-id for any labelled edge); under events-as-nodes
-       ;; the transition text is on the event-node so this is normally a
-       ;; no-op, but threading it keeps the edge-feed symmetric with the
-       ;; node-feed and ready for a labelled edge type.
+       ;; Edge-label dims share the `measured-dims` map (it is keyed by
+       ;; elk-edge-id for any labelled edge); under events-as-nodes the
+       ;; transition text is on the event-node so this is normally a no-op,
+       ;; but threading it keeps the edge-feed symmetric with the node-feed
+       ;; and ready for a labelled edge type.
        :edges (clj->js (projection/->elk-edges parsed measured-dims))})
 
 (defn elk-edge-points
-  "rf2-cz8v6 (G2) — lift one elk edge's routed bend-points into a flat
-  `[{:x :y} …]` vector of absolute (flow) coordinates.
+  "Lift one elk edge's routed bend-points into a flat `[{:x :y} …]`
+  vector of absolute (flow) coordinates.
 
   An elk edge carries one or more `sections`; each section has a
   `startPoint`, an `endPoint`, and an optional `bendPoints` array. We
@@ -396,19 +383,19 @@
       (vec pts))))
 
 (defn elk-edge-label-pos
-  "rf2-rlq97 — lift an elk edge's COMPUTED label position into a
-  `{:x :y}` map (absolute / flow coords under `elk.json.edgeCoords
-  ROOT`), or nil when elk placed no label (the events-as-nodes default,
-  where the transition text rides on the event-NODE so the edge's label
-  is empty and elk reserves no slot for it).
+  "Lift an elk edge's COMPUTED label position into a `{:x :y}` map
+  (absolute / flow coords under `elk.json.edgeCoords ROOT`), or nil when
+  elk placed no label (the events-as-nodes default, where the transition
+  text rides on the event-NODE so the edge's label is empty and elk
+  reserves no slot for it).
 
   elk attaches the placed label as the first entry of the edge's
   `labels` array with an `x` / `y` it computed (centred on the route per
   `elk.edgeLabels.placement CENTER`). A label with no `x` (elk did not
   place it — empty text) lifts to nil so the renderer keeps its
   geometric anchor. This is the LABEL analogue of `elk-edge-points`: elk
-  owns label PLACEMENT, the renderer just paints where elk says, killing
-  the old middle-segment-midpoint heuristic for any labelled edge."
+  owns label PLACEMENT, the renderer just paints where elk says, in place
+  of a middle-segment-midpoint heuristic for any labelled edge."
   [^js edge]
   (let [labels (or (.-labels edge) #js [])]
     (when (pos? (alength labels))
@@ -423,37 +410,36 @@
   :height}} :edge-points {edge-id [{:x :y} …]} :edge-labels {edge-id
   {:x :y}}}`.
 
-  rf2-rlq97 — `:edge-labels` carries elk's COMPUTED label position per
-  edge (the LABEL analogue of `:edge-points`'s routed bend-points). It is
-  empty under events-as-nodes (the transition text rides on the
-  event-NODE so edges carry no label for elk to place); a labelled edge
-  type would populate it and the renderer would paint at elk's position
-  instead of the geometric midpoint.
+  `:edge-labels` carries elk's COMPUTED label position per edge (the
+  LABEL analogue of `:edge-points`'s routed bend-points). It is empty
+  under events-as-nodes (the transition text rides on the event-NODE so
+  edges carry no label for elk to place); a labelled edge type would
+  populate it and the renderer would paint at elk's position instead of
+  the geometric midpoint.
 
   Public-by-convention as a test seam (mirrors `elk-edge-points` /
-  `invoke-elk-layout!`): the rf2-r636q regression bridges this PRODUCER
-  to the `projection/xyflow-graph` CONSUMER end-to-end, feeding a
-  stubbed elk result through here and asserting the projector attaches
-  the route — the integration the per-half pins (consumer-only /
-  producer-only) never exercised together, which is how the dead-G2
-  key-scheme mismatch shipped green. No production code outside this ns
-  calls it directly.
+  `invoke-elk-layout!`): a regression bridges this PRODUCER to the
+  `projection/xyflow-graph` CONSUMER end-to-end, feeding a stubbed elk
+  result through here and asserting the projector attaches the route —
+  the integration that the per-half pins (consumer-only / producer-only)
+  do not exercise together. No production code outside this ns calls it
+  directly.
 
   Used by `xyflow-graph` to merge xyflow-side node objects with
-  elk-laid-out positions, and (rf2-cz8v6 / G2) to route edges through
-  elk's computed bend-points.
+  elk-laid-out positions, and to route edges through elk's computed
+  bend-points.
 
   ## Positions
 
-  Walks nested elk children (rf2-lkwev — parallel machines nest each
-  region's states under the region container). elkjs reports a child's
-  `x`/`y` RELATIVE to its parent container, which is exactly what
-  xyflow's `parentId` sub-flow wants (rf2-xh1lm — xyflow v12 reads
-  `parentId`, not the pre-v12 `parentNode`) — so we record each node's
-  position AS elkjs gives it, no re-basing. Region containers get
-  their root-relative position + the size elkjs computed for the zone.
+  Walks nested elk children (parallel machines nest each region's states
+  under the region container). elkjs reports a child's `x`/`y` RELATIVE
+  to its parent container, which is exactly what xyflow's `parentId`
+  sub-flow wants (xyflow v12 reads `parentId`, not the pre-v12
+  `parentNode`) — so we record each node's position AS elkjs gives it, no
+  re-basing. Region containers get their root-relative position + the
+  size elkjs computed for the zone.
 
-  ## Edge points (rf2-cz8v6 / G2)
+  ## Edge points
 
   elk attaches each edge's routed `sections` to whichever node it lays
   the edge out under (the LCA of its endpoints). We walk EVERY node's
@@ -465,14 +451,13 @@
   map — the projector / edge component then falls back to the bezier
   path."
   [elk-result]
-  ;; Pure recursive walk threading a 3-key accumulator (rf2-crvxff —
-  ;; folded out three parallel `swap!`-accumulator atoms). `acc` carries
+  ;; Pure recursive walk threading a 3-key accumulator. `acc` carries
   ;; `:positions` (node-id → box), `:edge-points` (edge-id → routed
   ;; bend-points), and `:edge-labels` (edge-id → elk's COMPUTED label
   ;; position; the label analogue of `:edge-points`, empty under
   ;; events-as-nodes since the transition text rides on the event-NODE).
   ;; `array-seq` lifts elk's JS `.children`/`.edges` arrays in index
-  ;; order so `assoc` last-write-wins ordering matches the old walk.
+  ;; order so `assoc` last-write-wins ordering is deterministic.
   (letfn [(collect-edges [acc ^js node]
             (reduce (fn [acc ^js e]
                       (let [pts (elk-edge-points e)
@@ -483,10 +468,9 @@
                     acc
                     (array-seq (or (.-edges node) #js []))))
           (walk [acc ^js node]
-            ;; node's own edges first (matches the old walk!'s
-            ;; collect-edges!-then-recurse order), then each child:
-            ;; record its position, then walk it (which collects that
-            ;; child's edges + descends).
+            ;; node's own edges first (collect-edges-then-recurse order),
+            ;; then each child: record its position, then walk it (which
+            ;; collects that child's edges + descends).
             (reduce (fn [acc ^js c]
                       (-> acc
                           (assoc-in [:positions (.-id c)]
@@ -499,15 +483,10 @@
                     (array-seq (or (.-children node) #js []))))]
     (walk {:positions {} :edge-points {} :edge-labels {}} elk-result)))
 
-;; ---- error reporting (rf2-4lyvh) ----------------------------------------
+;; ---- error reporting ----------------------------------------------------
 ;;
-;; Before rf2-4lyvh, compute-layout! had two bare `(catch :default _ nil)`
-;; clauses (one sync around `.layout`, one async on the rejection branch)
-;; that discarded ELK errors entirely. The downstream `(when result ...)`
-;; guard in MachineChart then silently no-op'd, leaving `layout-state` at
-;; its initial `{:positions {} :edge-points {}}` — every node renders at
-;; the default origin, all stacked. The operator saw nothing in the
-;; console. The fix surfaces ELK failures three ways:
+;; An ELK layout failure must not silently leave every node stacked at the
+;; default origin. `compute-layout!` surfaces a failure three ways:
 ;;
 ;;   1. A `:rf.error/machines-viz-elk-layout-failed` trace event lands on
 ;;      the bus so tools (Xray Issues panel, off-box monitors) that
@@ -545,9 +524,9 @@
 (defn invoke-elk-layout!
   "Indirection over `(.layout elk-instance input)`. Lives at the
   public surface (not `^:private`) ONLY as a test seam: the
-  `compute-layout!` error-path tests (rf2-4lyvh) rebind this via
-  `set!` to stub elkjs's behaviour (sync throw / async reject / async
-  resolve) without reaching into the `defonce` elk instance. The
+  `compute-layout!` error-path tests rebind this via `set!` to stub
+  elkjs's behaviour (sync throw / async reject / async resolve) without
+  reaching into the `defonce` elk instance. The
   `defonce` is intentional — we want one elk instance per process —
   and reaching into its internals from a test is fragile.
 
@@ -559,18 +538,17 @@
   (.layout elk-instance input))
 
 (defn invoke-fit-view!
-  "rf2-set3x — indirection over `(.fitView instance opts)`. Same
-  test-seam shape as `invoke-elk-layout!` above: the regression test
-  rebinds this via `set!` to spy the call without needing a real
-  xyflow instance. No production code outside this ns should call it
-  directly; the chart's auto-fit lifecycle (`MachineChart`) is the
-  sole caller."
+  "Indirection over `(.fitView instance opts)`. Same test-seam shape as
+  `invoke-elk-layout!` above: the regression test rebinds this via `set!`
+  to spy the call without needing a real xyflow instance. No production
+  code outside this ns should call it directly; the chart's auto-fit
+  lifecycle (`MachineChart`) is the sole caller."
   [^js instance ^js opts]
   (.fitView instance opts))
 
 (defn invoke-project-definition!
-  "rf2-jl72i — indirection over `(layout/project-definition definition)`,
-  the topology parser. Same test-seam shape as `invoke-elk-layout!` /
+  "Indirection over `(layout/project-definition definition)`, the
+  topology parser. Same test-seam shape as `invoke-elk-layout!` /
   `invoke-fit-view!` above: the per-chart parse-cache regression rebinds
   this via `set!` to SPY parser calls (counting how many renders actually
   walk the definition) without re-stubbing the whole `layout` ns — the
@@ -587,10 +565,10 @@
   (layout/project-definition definition))
 
 (defn read-measured-dims
-  "rf2-d9ro2 — read xyflow's measured node boxes off a captured
-  ReactFlowInstance as a pure CLJS `{node-id {:width :height}}` map.
+  "Read xyflow's measured node boxes off a captured ReactFlowInstance as
+  a pure CLJS `{node-id {:width :height}}` map.
 
-  rf2-6v4ci5 — the measured box lives on the INTERNAL node, reached via
+  The measured box lives on the INTERNAL node, reached via
   `instance.getInternalNode(id)`, NOT on the user-facing `instance
   .getNodes()` objects. In xyflow v12 the store merges the DOM-measured
   `{width height}` onto its internal node representation after React
@@ -598,13 +576,11 @@
   we feed in as a controlled `:nodes` prop, returned unchanged by
   `getNodes()`) only carry `.measured` when dimension changes are
   applied back into that array — which this non-interactive chart
-  deliberately does NOT do (positions are ELK-owned). Reading
-  `(.-measured n)` off `getNodes()` therefore always saw nil, so the
-  whole measure-then-relayout pass never reached `ready?` and every node
-  laid out at its ELK floor — guard/action-widened event chips overran
-  their floor-spaced same-layer neighbours (`door/close IF may-close?`
-  over `door/hold`). Reading via `getInternalNode` feeds the REAL
-  rendered box (incl. guard + action row) back to ELK.
+  deliberately does NOT do (positions are ELK-owned). So `(.-measured n)`
+  off `getNodes()` is always nil; reading via `getInternalNode` feeds the
+  REAL rendered box (incl. guard + action row) back to ELK, so guard/
+  action-widened event chips lay out at their true width rather than
+  overrunning floor-spaced same-layer neighbours.
 
   We iterate `getNodes()` for the id set and look each id's measured box
   up via `getInternalNode`; we keep only ids that carry a positive
@@ -638,18 +614,18 @@
   `{:positions {node-id {:x :y :width :height}} :edge-points {edge-id
   [{:x :y} …]}}` on success.
 
-  On failure (rf2-4lyvh) the callback receives the SAME map shape with
-  empty `:positions` + `:edge-points` AND an extra `:layout-error
-  {:error … :input-summary …}` slot — the existing `(when result ...)`
-  guard at the callsite is preserved, the projector can read
-  `:layout-error` to render an in-panel indicator instead of silently
-  rendering every node stacked at origin. The failure also fires a
+  On failure the callback receives the SAME map shape with empty
+  `:positions` + `:edge-points` AND an extra `:layout-error {:error …
+  :input-summary …}` slot — the `(when result ...)` guard at the callsite
+  still holds, and the projector reads `:layout-error` to render an in-
+  panel indicator instead of silently rendering every node stacked at
+  origin. The failure also fires a
   `:rf.error/machines-viz-elk-layout-failed` trace event + (in dev
   builds, gated on `interop/debug-enabled?`) a `js/console.error`.
 
-  The `:edge-points` half (rf2-cz8v6 / G2) carries elk's routed bend-
-  points so the chart routes edges AROUND nested containers instead of
-  cutting across them. The async path is idiomatic xyflow + elkjs:
+  The `:edge-points` half carries elk's routed bend-points so the chart
+  routes edges AROUND nested containers instead of cutting across them.
+  The async path is idiomatic xyflow + elkjs:
 
     1. `(->elk-input parsed direction layout-options)` builds a JS
        graph.
@@ -661,22 +637,22 @@
   consumers (Xray Issues panel) can attribute the failure to a specific
   machine; nil when called without a machine id (e.g. unit tests).
 
-  rf2-d9ro2 — the longest arity takes `measured-dims` (an optional
-  `{node-id {:width :height}}` map of xyflow's reported rendered boxes),
-  fed into `->elk-input` so the second (relayout) pass sizes each node
-  to its real box. The shorter arities pass nil (first pass / unit
-  tests) — identical to the pre-rf2-d9ro2 single-pass.
+  The longest arity takes `measured-dims` (an optional `{node-id
+  {:width :height}}` map of xyflow's reported rendered boxes), fed into
+  `->elk-input` so the second (relayout) pass sizes each node to its real
+  box. The shorter arities pass nil (first pass / unit tests) — a single-
+  pass layout.
 
-  rf2-8q5pt — the longest arity also takes `chart-vc` (the resolved
-  density map from `vc/chart-for-density`), fed into `->elk-input` so
-  container `elk.padding` tracks the active density. The shorter arities
-  pass nil → the projection falls back to the regular density.
+  The longest arity also takes `chart-vc` (the resolved density map from
+  `vc/chart-for-density`), fed into `->elk-input` so container
+  `elk.padding` tracks the active density. The shorter arities pass nil →
+  the projection falls back to the regular density.
 
-  rf2-8z1rca — the longest arity also takes `context-rows` (the count of
-  Context-band rows the root-container frame paints, from `:context-band`),
-  fed into `->elk-input` so the ROOT-CONTAINER top padding reserves the
-  variable-height Context band. The shorter arities pass 0 → no band, no
-  extra reservation."
+  The longest arity also takes `context-rows` (the count of Context-band
+  rows the root-container frame paints, from `:context-band`), fed into
+  `->elk-input` so the ROOT-CONTAINER top padding reserves the variable-
+  height Context band. The shorter arities pass 0 → no band, no extra
+  reservation."
   ([parsed done-fn]
    (compute-layout! parsed :tb nil nil nil nil 0 done-fn))
   ([parsed direction layout-options done-fn]
@@ -707,28 +683,27 @@
 
 ;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
 ;;
-;; rf2-0gmwp — the pure projector (`xyflow-graph` / the elk `children`
-;; shape) moved to `chart.projection` so the JVM test corpus can pin it
-;; without loading xyflow/elkjs. `chart.cljs` retains only the JS-interop
-;; layout glue above + the React component below.
+;; The pure projector (`xyflow-graph` / the elk `children` shape) lives in
+;; `chart.projection` so the JVM test corpus can pin it without loading
+;; xyflow/elkjs. `chart.cljs` holds only the JS-interop layout glue above
+;; + the React component below.
 
 ;; ---- inline keyframes ---------------------------------------------------
 
 (def ^:private chart-stylesheet
   "Inline stylesheet carrying the transition-glow keyframes + the
-  prefers-reduced-motion override. Mirrors the previous SVG render's
-  `transition-glow-css` so the focused-edge animation continues to
-  work post-migration.
+  prefers-reduced-motion override, so the focused-edge animation works
+  without an external stylesheet.
 
-  rf2-4o43j8 — the fired/focused glow is an event-driven, FINITE
-  flash (per `spec/Principles.md` §chart animation): the consumers
-  (`chart.edges` / `chart.nodes.event-node`) play it as ONE iteration
-  via `tokens/glow-animation-css` (`… ease-out forwards`), NOT an
-  `infinite` loop. The `100%` frame settles to full opacity so the
-  static fired/focused affordance (stroke width / hue / glow ring)
-  reads at full strength once the flash completes. Duration flows
-  through `--rf-xray-motion-scale`, so `prefers-reduced-motion:
-  reduce` collapses the flash to a single settle frame."
+  The fired/focused glow is an event-driven, FINITE flash (per
+  `spec/Principles.md` §chart animation): the consumers (`chart.edges` /
+  `chart.nodes.event-node`) play it as ONE iteration via
+  `tokens/glow-animation-css` (`… ease-out forwards`), NOT an `infinite`
+  loop. The `100%` frame settles to full opacity so the static
+  fired/focused affordance (stroke width / hue / glow ring) reads at full
+  strength once the flash completes. Duration flows through
+  `--rf-xray-motion-scale`, so `prefers-reduced-motion: reduce` collapses
+  the flash to a single settle frame."
   (str
     ":root { --rf-xray-motion-scale: 1; }\n"
     "@media (prefers-reduced-motion: reduce) {\n"
@@ -746,29 +721,27 @@
 (def ^:private node-types-memo (nodes/node-types))
 (def ^:private edge-types-memo (edges/edge-types))
 
-;; ---- :overlays slot (rf2-7w4qr) -----------------------------------------
+;; ---- :overlays slot -----------------------------------------------------
 ;;
-;; Mike ruled (rf2-7w4qr): the host-fed, spec+tick+callbacks overlay
-;; family is wired through ONE `:overlays` slot instead of a flat prop
-;; per overlay. Each descriptor is a map `{:id <keyword> …}` keyed on
-;; `:id`; the chart dispatches it to its already-modular rendering
-;; namespace (`chart.overlays.after-rings` / `.spawn-all-join` /
-;; `.cancellation-cascade`) by `:id`. This ns owns ONLY the wiring — the
-;; overlay renderers (their per-overlay shapes + DOM walk + paint) are
-;; untouched.
+;; The host-fed, spec+tick+callbacks overlay family is wired through ONE
+;; `:overlays` slot rather than a flat prop per overlay. Each descriptor
+;; is a map `{:id <keyword> …}` keyed on `:id`; the chart dispatches it to
+;; its modular rendering namespace (`chart.overlays.after-rings` /
+;; `.spawn-all-join` / `.cancellation-cascade`) by `:id`. This ns owns
+;; ONLY the wiring — the overlay renderers (their per-overlay shapes + DOM
+;; walk + paint) live in those namespaces.
 ;;
-;; The `:tick` story is unified: a per-descriptor `:tick` replaces both
-;; the old `:after-ring-tick` and `:overlay-tick`. One rAF clock per
-;; chart stays host-owned (Lock #8); the host just delivers the tick on
-;; whichever descriptor(s) the clock drives.
+;; The `:tick` story is unified: a per-descriptor `:tick` drives every
+;; overlay. One rAF clock per chart stays host-owned (Lock #8); the host
+;; just delivers the tick on whichever descriptor(s) the clock drives.
 ;;
-;; What did NOT fold (stays on the trunk): `:fired-edge-ids` (a simple
-;; set, core to active-edge styling, not a spec+tick+callbacks overlay),
-;; `:current-state` / `:from-highlight` / `:to-highlight` (runtime
-;; highlight, not host-fed overlay specs), `:context-band` (a corner
-;; panel rendered inline, not a positioned DOM-walking overlay), and all
-;; structural props (`:definition`, `:direction`, `:layout-options`,
-;; parallel handling).
+;; What stays on the trunk (NOT in the `:overlays` slot): `:fired-edge-ids`
+;; (a simple set, core to active-edge styling, not a spec+tick+callbacks
+;; overlay), `:current-state` / `:from-highlight` / `:to-highlight`
+;; (runtime highlight, not host-fed overlay specs), `:context-band`
+;; (rendered inline in the frame header, not a positioned DOM-walking
+;; overlay), and all structural props (`:definition`, `:direction`,
+;; `:layout-options`, parallel handling).
 
 (def overlay-ids
   "The closed set of recognised `:overlays` descriptor `:id`s. A
@@ -782,8 +755,8 @@
   `:id`, returning the overlay's hiccup (or nil when the descriptor is
   dormant / its `:id` is unknown).
 
-  Per-overlay descriptor shapes (the renderers are unchanged — only the
-  wiring is lifted here, rf2-7w4qr):
+  Per-overlay descriptor shapes (this fn owns only the wiring; the
+  renderers live in the overlay namespaces):
 
     {:id :after-rings          :specs <vec> :tick <opaque>
                                :on-hover <fn> :on-leave <fn>}
@@ -854,8 +827,7 @@
                          no highlight.
     :from-highlight    — focused-event lens origin (`:state` value).
     :to-highlight      — focused-event lens landing (`:state` value).
-    :fired-edge-ids    — rf2-qeemm (closes parity gap G3). A SET of
-                         canonical edge-ids (the EXACT scheme
+    :fired-edge-ids    — A SET of canonical edge-ids (the EXACT scheme
                          `chart.layout` mints) that fired THIS epoch.
                          Each matching edge gets the FIRED treatment
                          (emphasised + animated stroke + `data-fired`)
@@ -867,41 +839,41 @@
                          (Xray) resolves it for the focused epoch via
                          `extract-fired-edge-ids`; nil / `#{}` → no fired
                          highlight (the standalone viewer / Story path).
-    :guard-blocked-edge-ids — rf2-fzrzlw / rf2-4nxgqq / rf2-tjm3u2. A SET
-                         of canonical edge-ids whose guard REJECTED the
-                         event this epoch (a guard-blocked no-op: the
-                         runtime emitted `:rf.machine/guard-evaluated`
-                         fail/threw but NO `:rf.machine/transition`). The
-                         matching EVENT-NODE and its `__in` (source-state →
-                         event-node) HALF get the PINK guard-blocked
-                         treatment (emphasised pink stroke + emphasised
-                         pink `IF <guard>` chip), winning over
-                         fired/focused/active so the attempted-and-rejected
-                         arm stands out. rf2-4nxgqq — the highlight STOPS at
-                         the guard event-node: the `__out` (event-node →
-                         target) half stays STATIC/resting (a no-op never
-                         reached the target; an onward pink arrow would
-                         falsely imply the transition progressed — the
-                         `__out` topology edge still renders, only the live
-                         overlay is withheld). Without any of this a blocked
-                         no-op gives ZERO signal which edge the event hit.
-                         The host (Xray) resolves the set by `(source-path,
-                         event, guard)` when trace state is available
+    :guard-blocked-edge-ids — A SET of canonical edge-ids whose guard
+                         REJECTED the event this epoch (a guard-blocked
+                         no-op: the runtime emitted
+                         `:rf.machine/guard-evaluated` fail/threw but NO
+                         `:rf.machine/transition`). The matching EVENT-NODE
+                         and its `__in` (source-state → event-node) HALF
+                         get the PINK guard-blocked treatment (emphasised
+                         pink stroke + emphasised pink `IF <guard>` chip),
+                         winning over fired/focused/active so the
+                         attempted-and-rejected arm stands out. The
+                         highlight STOPS at the guard event-node: the
+                         `__out` (event-node → target) half stays
+                         STATIC/resting (a no-op never reached the target;
+                         an onward pink arrow would falsely imply the
+                         transition progressed — the `__out` topology edge
+                         still renders, only the live overlay is withheld).
+                         Without this a blocked no-op gives ZERO signal
+                         which edge the event hit. The host (Xray) resolves
+                         the set by `(source-path, event, guard)` when trace
+                         state is available
                          (`extract-guard-blocked-edge-ids` reads the active
                          `:state` off the guard-evaluated trace + gates each
                          candidate by `:from-path`-prefix-of-active-path, so
                          a sibling state reusing the same `(event, guard)`
-                         is NOT lit, rf2-tjm3u2; no-`:state` traces fall back
-                         to the `(event, guard)` match). The canonical DOM
-                         pins are the event-node (`data-guard-blocked`) +
-                         chart-root (`data-guard-blocked-edge-ids`), NOT an
-                         edge-half attribute (rf2-bdwolc). nil / `#{}` → no
-                         guard-blocked highlight. SUPERSET of XState (which
-                         highlights nothing on a block).
+                         is NOT lit; no-`:state` traces fall back to the
+                         `(event, guard)` match). The canonical DOM pins are
+                         the event-node (`data-guard-blocked`) + chart-root
+                         (`data-guard-blocked-edge-ids`), NOT an edge-half
+                         attribute. nil / `#{}` → no guard-blocked
+                         highlight. SUPERSET of XState (which highlights
+                         nothing on a block).
     :sim?              — flips the highlight palette to amber for
                          the simulator path.
     :on-state-click    — `(fn [path] ...)` invoked on node click.
-    :on-edge-click     — rf2-u422r. `(fn [#js {:eventId :fromPath
+    :on-edge-click     — `(fn [#js {:eventId :fromPath
                          :toPath}] ...)` invoked when a transition edge's
                          label is clicked. Only edges with a fireable
                          event (plain `:on` transitions) are clickable;
@@ -912,48 +884,45 @@
     :read-only?        — when true all `:on-*` callbacks are no-op'd.
                          The viewer page sets this.
     :direction         — `:tb` (top-to-bottom, default) or `:lr`
-                         (left-to-right). **OPT-IN adaptive: `:auto`**
-                         (rf2-lamdfl + rf2-gnrkke). The DEFAULT `:tb` (and
-                         an explicit `:tb` / `:lr`) is byte-identical to the
-                         historical render: the post-ELK adaptive pass is NOT
-                         invoked. Pass `:auto` to OPT A MACHINE IN to the
-                         adaptive-aspect heuristic (`chart.post-elk/aspect-
-                         direction` — a branchy machine flows landscape
-                         `:lr`, a chain stays a column `:tb`, a parallel
-                         machine gets the region-stacking transpose) PLUS the
-                         back-edge return-route reroute (§4.3.1 + §4.3.2 of
+                         (left-to-right). **OPT-IN adaptive: `:auto`**. The
+                         DEFAULT `:tb` (and an explicit `:tb` / `:lr`) does
+                         NOT invoke the post-ELK adaptive pass. Pass `:auto`
+                         to OPT A MACHINE IN to the adaptive-aspect heuristic
+                         (`chart.post-elk/aspect-direction` — a branchy
+                         machine flows landscape `:lr`, a chain stays a
+                         column `:tb`, a parallel machine gets the region-
+                         stacking transpose) PLUS the back-edge return-route
+                         reroute (§4.3.1 + §4.3.2 of
                          `001-Topology-Parity.md`). A host resolves `:auto`
                          from a machine's `:layout {:aspect :adaptive}` hint
                          (or its own layout intent). Fed to elkjs as
                          `elk.direction` (resolved to `:tb`/`:lr` on the
                          `:auto` path).
-    :density           — rf2-k647w. `:compact` / `:regular` (default) /
-                         `:cosy`. Resolves the geometry + typography
-                         map via `visual-constants/chart-for-density`;
-                         the resolved map is threaded through the
-                         projector onto every node/edge `:data` so the
-                         xyflow node/edge components render at the
-                         chosen density. The chart root surfaces the
-                         resolved density as `data-density`. nil ≡
-                         `:regular` (pixel-identical to the historical
-                         render). An unknown density throws at render
-                         time (per `spec/API.md` §Density resolution
-                         rules) — picking outside the closed set is a
-                         programmer error, not a runtime fallback.
-    :theme             — rf2-az6e2. `:dark` (default) / `:light`.
-                         Resolves the chart palette + semantic token map
-                         ONCE per render (`theme/tokens/theme-palette` +
-                         `chart-tokens`), threaded through the projector
-                         onto every node/edge `:data {:palette}` so the
-                         renderers paint the ACTIVE theme — NOT the dark
-                         alias. The chart's own chrome (canvas surface,
-                         root title strip, Context panel, dot-grid,
-                         minimap, layout-error banner) reads the same
-                         palette. The resolved theme surfaces on the root
-                         as `data-theme`. INDEPENDENT of `:density`
+    :density           — `:compact` / `:regular` (default) / `:cosy`.
+                         Resolves the geometry + typography map via
+                         `visual-constants/chart-for-density`; the
+                         resolved map is threaded through the projector
+                         onto every node/edge `:data` so the xyflow
+                         node/edge components render at the chosen
+                         density. The chart root surfaces the resolved
+                         density as `data-density`. nil ≡ `:regular`. An
+                         unknown density throws at render time (per
+                         `spec/API.md` §Density resolution rules) —
+                         picking outside the closed set is a programmer
+                         error, not a runtime fallback.
+    :theme             — `:dark` (default) / `:light`. Resolves the chart
+                         palette + semantic token map ONCE per render
+                         (`theme/tokens/theme-palette` + `chart-tokens`),
+                         threaded through the projector onto every
+                         node/edge `:data {:palette}` so the renderers
+                         paint the ACTIVE theme. The chart's own chrome
+                         (canvas surface, root title strip, Context panel,
+                         dot-grid, minimap, layout-error banner) reads the
+                         same palette. The resolved theme surfaces on the
+                         root as `data-theme`. INDEPENDENT of `:density`
                          (geometry vs colour are orthogonal knobs). nil /
-                         unknown → `:dark`. This bead builds no light/dark
-                         toggle UI — hosts pass the prop.
+                         unknown → `:dark`. No light/dark toggle UI here —
+                         hosts pass the prop.
     :layout-options    — host-side elk.js `layoutOptions` overrides
                          merged on top of `default-elk-options`.
     :height            — outer wrapper height (CSS string; default
@@ -965,27 +934,22 @@
                          built-in zoom/pan/fit Controls.
     :show-background?  — when true (default true) render xyflow's
                          dot-pattern Background.
-    :overlays          — rf2-7w4qr. Optional vector of host-fed overlay
-                         DESCRIPTOR maps, each keyed on `:id`. Collapses
-                         the former flat overlay-wiring props (the
-                         `:after-ring-*` / `:spawn-all-*` /
-                         `:cancellation-cascade` / `:overlay-tick`
-                         family) into ONE slot; hosts compose overlays
-                         here instead of growing the trunk signature.
-                         The chart dispatches each descriptor to its
-                         already-modular rendering namespace by `:id`
-                         (`render-overlay`); the renderers are unchanged.
-                         A per-descriptor `:tick` unifies the old
-                         `:after-ring-tick` + `:overlay-tick` (one rAF
-                         clock per chart stays host-owned — Lock #8 —
-                         just delivered per-overlay). Unknown `:id` →
-                         ignored (dev-only console.warn). Recognised
-                         descriptors (see `render-overlay`):
+    :overlays          — Optional vector of host-fed overlay DESCRIPTOR
+                         maps, each keyed on `:id`. Hosts compose overlays
+                         here through this ONE slot instead of a flat prop
+                         per overlay. The chart dispatches each descriptor
+                         to its modular rendering namespace by `:id`
+                         (`render-overlay`). A per-descriptor `:tick`
+                         drives each overlay (one rAF clock per chart stays
+                         host-owned — Lock #8 — just delivered per-
+                         overlay). Unknown `:id` → ignored (dev-only
+                         console.warn). Recognised descriptors (see
+                         `render-overlay`):
 
                            {:id :after-rings :specs <vec> :tick <opaque>
                             :on-hover <fn> :on-leave <fn>}
-                             rf2-uv1on. Presentation-ready `:after`-timer
-                             ring-specs (each `{:node-id :fraction :color
+                             Presentation-ready `:after`-timer ring-specs
+                             (each `{:node-id :fraction :color
                              :cancelled? :tooltip :testid}`). When `:specs`
                              is non-empty the chart mounts the
                              `chart.overlays.after-rings` overlay as a
@@ -997,29 +961,28 @@
 
                            {:id :spawn-all-join :spec <map> :tick <opaque>
                             :on-child-click <fn>}
-                             rf2-3ow55. Presentation-ready `:spawn-all`
-                             join-spec (`{:node-id :join :children
-                             :resolved? :on-all-complete :on-any-failed}`).
-                             When `:spec` has a `:node-id` the chart mounts
-                             the `chart.overlays.spawn-all-join` inspector
+                             Presentation-ready `:spawn-all` join-spec
+                             (`{:node-id :join :children :resolved?
+                             :on-all-complete :on-any-failed}`). When
+                             `:spec` has a `:node-id` the chart mounts the
+                             `chart.overlays.spawn-all-join` inspector
                              beside the spawn-all-bearing state. `:on-child-
                              click` `(fn [child-key] ...)` fires on a child-
                              row click (Xray pivots to the child instance).
 
                            {:id :cancellation-cascade :spec <map>
                             :tick <opaque>}
-                             rf2-3ow55. Presentation-ready cascade-spec
+                             Presentation-ready cascade-spec
                              (`{:node-id :parent-label :from-state :steps}`).
                              When `:spec` has a `:node-id` and a non-empty
                              `:steps` the chart mounts the
                              `chart.overlays.cancellation-cascade` waterfall
                              beneath the parent state. nil / no steps →
                              dormant.
-    :context-band      — rf2-qo5xy; rf2-q129z8. Optional CLJS map fed into
-                         the Context BAND in the ROOT-CONTAINER frame header
-                         (pre-q129z8 a top-LEFT corner panel; now folded into
-                         the named frame that hugs the topology). Two host
-                         projections feed it: the live `:data`
+    :context-band      — Optional CLJS map fed into the Context BAND in the
+                         ROOT-CONTAINER frame header (the named frame that
+                         hugs the topology). Two host projections feed it:
+                         the live `:data`
                          (`:rf.machine/data`, key→value) OR — the sole
                          production feeder today — the STATIC context
                          shape INFERRED from the definition's `:data`
@@ -1028,7 +991,7 @@
                          Purely presentation — the host owns the projection;
                          `chart.projection/xyflow-graph` threads it onto the
                          frame node's `:data {:context}`.
-    :context-band-inferred? — rf2-5tz9p. Optional boolean (DEFAULT true).
+    :context-band-inferred? — Optional boolean (DEFAULT true).
                          When true the Context band shows a subtle
                          \"inferred from :data\" badge marking its
                          contents as a type shape INFERRED from one sample
@@ -1036,11 +999,11 @@
                          schema and NOT the live runtime `:data`. Set
                          false when the host feeds live `:data` VALUES.
                          Ignored when no band renders.
-    :fit-signal        — rf2-6tw7t. Optional opaque value (a nonce — any
+    :fit-signal        — Optional opaque value (a nonce — any
                          `=`-comparable). When its value CHANGES between
                          renders the chart re-fits the viewport to frame
                          the whole topology, ORTHOGONAL to the layout-key
-                         auto-fit (rf2-set3x). Hosts bump it on panel-
+                         auto-fit. Hosts bump it on panel-
                          entry / tab-activation so re-entering a panel
                          frames the graph rather than restoring a stale
                          (possibly off-screen) zoom/pan. A STEADY signal
@@ -1053,17 +1016,16 @@
     :testid            — root wrapper `data-testid`; defaults to
                          `\"rf-mv-chart\"` so tests + hosts find it."
   [_initial-props]
-  (let [;; rf2-cz8v6 (G2) — the layout atom now holds BOTH the node
-        ;; positions and elk's routed edge bend-points
-        ;; (`{:positions {…} :edge-points {…}}`) so the projector can
-        ;; route edges around nested containers. Starts empty (no
-        ;; positions, no routes) — the pre-layout render falls back to
-        ;; origin + bezier until the async elk pass resolves.
-        ;; rf2-rlq97 — `:edge-labels` (elk's computed label positions)
-        ;; joins the same atom; empty until the async elk pass resolves.
+  (let [;; The layout atom holds BOTH the node positions and elk's routed
+        ;; edge bend-points (`{:positions {…} :edge-points {…}}`) so the
+        ;; projector can route edges around nested containers. Starts empty
+        ;; (no positions, no routes) — the pre-layout render falls back to
+        ;; origin + bezier until the async elk pass resolves. `:edge-labels`
+        ;; (elk's computed label positions) shares the same atom; empty
+        ;; until the async elk pass resolves.
         layout-state  (r/atom {:positions {} :edge-points {} :edge-labels {}})
         layout-key    (r/atom nil)
-        ;; rf2-set3x — auto-fit lifecycle.
+        ;; Auto-fit lifecycle.
         ;;
         ;; xyflow's `:fitView true` prop fires ONCE on initial mount,
         ;; but mount happens BEFORE the async elk pass resolves: every
@@ -1085,8 +1047,8 @@
         ;; invalidation boundary, AND the manual `Fit` Controls
         ;; button) is the only thing that re-fits.
         ;;
-        ;; rf2-6tw7t — `:fit-sig` records the host-supplied `:fit-signal`
-        ;; value we last fit on. The layout-key gate above deliberately
+        ;; `:fit-sig` records the host-supplied `:fit-signal` value we last
+        ;; fit on. The layout-key gate above deliberately
         ;; PRESERVES the operator's manual zoom/pan across non-layout
         ;; re-renders (tab re-entry with the SAME machine doesn't change
         ;; the layout-key). `:fit-signal` is the ORTHOGONAL escape hatch:
@@ -1100,15 +1062,13 @@
         ;; re-fits, so a steady signal across non-entry re-renders is a
         ;; no-op (manual zoom/pan still survives those).
         fit-state     (r/atom {:instance nil :fit-key nil :fit-sig ::unfit})
-        ;; rf2-d9ro2 — measure-then-relayout lifecycle state.
+        ;; Measure-then-relayout lifecycle state.
         ;;
-        ;; The bug: ELK was fed CONSTANT node dimensions (the
-        ;; `state-node-min-{width,height}` floors), not the real rendered
-        ;; box. `chart.nodes/state-node` renders at CONTENT size (label +
-        ;; tag pills + entry/exit action pills, rf2-a2b55), so any node
-        ;; wider/taller than the floor overlapped its neighbours and the
-        ;; topology looked missized. The fix is the canonical React Flow +
-        ;; ELK two-pass: mount nodes at content size, let xyflow measure
+        ;; `chart.nodes/state-node` renders at CONTENT size (label + tag
+        ;; pills + entry/exit action pills), so feeding ELK constant floor
+        ;; dimensions would let a node wider/taller than the floor overlap
+        ;; its neighbours. Instead the chart runs the canonical React Flow
+        ;; + ELK two-pass: mount nodes at content size, let xyflow measure
         ;; them (`node.measured`), then re-run ELK with the measured box.
         ;;
         ;; `relayout-state` gates the second pass so it runs at most ONCE
@@ -1128,8 +1088,8 @@
         ;; signature comparison (it keys on measured dims, not position),
         ;; so xyflow applying the new ELK positions cannot re-trigger.
         relayout-state (r/atom {:key nil :measured nil})
-        ;; rf2-s5kyp — double-rAF deferral. A SINGLE rAF races
-        ;; xyflow's internal node measurement on the focused-machine-
+        ;; Double-rAF deferral. A SINGLE rAF races xyflow's internal node
+        ;; measurement on the focused-machine-
         ;; change path: by the time the chart re-renders with the new
         ;; `:definition`'s positions, React commits the new prop set, the
         ;; rAF fires, and xyflow may still be measuring the just-mounted
@@ -1153,16 +1113,15 @@
                                   (fn [_] (invoke-fit-view! instance opts)))))
                             ;; Test / Node fallback — fire immediately.
                             (invoke-fit-view! instance opts))))
-        ;; rf2-dnmbs — per-render graph-projection + JS-marshalling cache.
+        ;; Per-render graph-projection + JS-marshalling cache.
         ;;
         ;; `projection/xyflow-graph` (the parsed→xyflow node/edge
-        ;; projector) AND the deep `clj->js` of its node/edge arrays both
-        ;; used to run on EVERY MachineChart render — including renders
-        ;; that change nothing structural (a host `:tick` bump driving an
-        ;; after-ring or highlight flicker up to ~60Hz, a `:fit-signal`
-        ;; bump, a parent re-render). The ELK relayout is correctly gated;
-        ;; this JS marshalling was the OTHER per-render cost and it was
-        ;; ungated — landing on the animation hot path.
+        ;; projector) AND the deep `clj->js` of its node/edge arrays are
+        ;; both costly, and a render that changes nothing structural (a
+        ;; host `:tick` bump driving an after-ring or highlight flicker up
+        ;; to ~60Hz, a `:fit-signal` bump, a parent re-render) would
+        ;; otherwise pay that marshalling on the animation hot path. This
+        ;; cache keeps it off that path.
         ;;
         ;; The cache holds the LAST projected+converted result keyed on the
         ;; vector of inputs that actually change it. A render whose key
@@ -1175,21 +1134,18 @@
         ;; per-chart-instance and disposed with the component. The shape is
         ;; `{:key <input-vec> :js-nodes #js[…] :js-edges #js[…]}`.
         graph-cache   (atom nil)
-        ;; rf2-jl72i — per-chart parsed-topology cache.
+        ;; Per-chart parsed-topology cache.
         ;;
-        ;; The topology parser (`layout/project-definition`, the e0emp
-        ;; rename of the former `parse-definition`) walks the WHOLE
-        ;; definition and rebuilds the `{:nodes :edges :initial-path}`
-        ;; graph. rf2-dnmbs gated the DOWNSTREAM `xyflow-graph` projection
-        ;; + `clj->js` marshalling behind `graph-cache`, but the parse
-        ;; itself still ran at the TOP of EVERY render — so a decoration-
-        ;; only re-render (`:current-state` / `:from-highlight` /
-        ;; `:to-highlight` change, an overlay `:tick`, a `:fit-signal`
-        ;; bump, a bare parent re-render) paid the full O(topology)
-        ;; parse + allocation cost despite the API (spec/API.md §Lock #11,
-        ;; §Performance invariants) marking the topology and runtime-
-        ;; highlight planes as STRICTLY separate: decoration props must
-        ;; not reach the layout/topology pipeline.
+        ;; The topology parser (`layout/project-definition`) walks the
+        ;; WHOLE definition and rebuilds the `{:nodes :edges :initial-path}`
+        ;; graph. Without this cache the parse would run at the TOP of
+        ;; EVERY render — so a decoration-only re-render (`:current-state` /
+        ;; `:from-highlight` / `:to-highlight` change, an overlay `:tick`,
+        ;; a `:fit-signal` bump, a bare parent re-render) would pay the full
+        ;; O(topology) parse + allocation cost despite the API
+        ;; (spec/API.md §Lock #11, §Performance invariants) marking the
+        ;; topology and runtime-highlight planes as STRICTLY separate:
+        ;; decoration props must not reach the layout/topology pipeline.
         ;;
         ;; This cache memoises the parse keyed ONLY on `:definition`
         ;; (identity-or-value `=`). A render with the same `:definition`
@@ -1245,56 +1201,50 @@
                  show-minimap?     false
                  show-controls?    true
                  show-background?  true
-                 ;; rf2-27e38h (EP-0015) — Context-band egress defaults:
-                 ;; local-redacted ON (raw? false), empty classification
-                 ;; sets. A host feeding live `:data` declares the
-                 ;; sensitive/large slots; the value-free type-caption
-                 ;; production feeder is a redaction no-op.
+                 ;; Context-band egress defaults (EP-0015): local-redacted
+                 ;; ON (raw? false), empty classification sets. A host
+                 ;; feeding live `:data` declares the sensitive/large slots;
+                 ;; the value-free type-caption production feeder is a
+                 ;; redaction no-op.
                  context-band-sensitive #{}
                  context-band-large     #{}
                  context-band-raw?      false
-                 ;; rf2-5tz9p — the Context panel's sole production feeder is
-                 ;; the static INFERRED shape (Xray's `static-context-shape`,
-                 ;; key→type-caption). Default the inferred badge ON so the
-                 ;; panel reads honestly today; a host wiring live `:data`
-                 ;; values passes `:context-band-inferred? false`.
+                 ;; The Context panel's sole production feeder is the static
+                 ;; INFERRED shape (Xray's `static-context-shape`, key→type-
+                 ;; caption). Default the inferred badge ON so the panel
+                 ;; reads honestly; a host wiring live `:data` values passes
+                 ;; `:context-band-inferred? false`.
                  context-band-inferred? true
                  testid            "rf-mv-chart"}}]
-      (let [;; rf2-jl72i — route the SINGLE topology parse through the
-            ;; per-chart parse-cache (keyed only on `:definition`). A
-            ;; decoration-only re-render reuses the cached `parsed`
-            ;; identity, so neither the parser nor the downstream
-            ;; graph/layout/relayout caches (whose keys embed `parsed`)
-            ;; recompute. A changed `:definition` reparses once here and
-            ;; busts every downstream cache.
+      (let [;; Route the SINGLE topology parse through the per-chart parse-
+            ;; cache (keyed only on `:definition`). A decoration-only
+            ;; re-render reuses the cached `parsed` identity, so neither the
+            ;; parser nor the downstream graph/layout/relayout caches (whose
+            ;; keys embed `parsed`) recompute. A changed `:definition`
+            ;; reparses once here and busts every downstream cache.
             parsed     (parse-topology! definition)
-            ;; rf2-lkwev — exclude synthetic parallel-region container
-            ;; nodes from the state count + aria-label (they are zone
-            ;; chrome, not states).
-            ;; rf2-q129z8 — also exclude the synthetic ROOT-CONTAINER frame
-            ;; (the named box wrapping the whole machine — structural chrome,
-            ;; not a state).
+            ;; Exclude synthetic parallel-region container nodes (zone
+            ;; chrome, not states) AND the synthetic ROOT-CONTAINER frame
+            ;; (the named box wrapping the whole machine — structural
+            ;; chrome, not a state) from the state count + aria-label.
             n-states   (count (remove #(or (:region? %) (:root-container? %))
                                       (:nodes parsed)))
             n-regions  (count (filter :region? (:nodes parsed)))
             n-trans    (count (:edges parsed))
-            ;; rf2-8q5pt — resolve the density map ONCE so the ELK pass
-            ;; sizes container `elk.padding` from the active density's
-            ;; title-strip + body-pad constants (was a regular-only
-            ;; literal). `chart-for-density` maps nil → regular and throws
-            ;; on an unknown density (same total resolution the render body
-            ;; does for `chart-vc` at L1177).
+            ;; Resolve the density map ONCE so the ELK pass sizes container
+            ;; `elk.padding` from the active density's title-strip + body-
+            ;; pad constants. `chart-for-density` maps nil → regular and
+            ;; throws on an unknown density (the same resolution the render
+            ;; body does for `chart-vc`).
             elk-vc     (vc/chart-for-density density)
-            ;; rf2-lamdfl + rf2-gnrkke — the OPT-IN adaptive gate. The whole
-            ;; post-ELK subsystem (the per-machine aspect heuristic + the
-            ;; parallel-region transpose + the back-edge reroute) is invoked
-            ;; ONLY when the host opts a machine in with `:direction :auto`
-            ;; (`post-elk/adaptive?`). The default `:tb` (and an explicit
-            ;; `:tb`/`:lr`) takes the historical path: no heuristic
-            ;; resolution, no `apply-post-elk` — the ELK result flows to the
-            ;; projector byte-identical to main. The reverted #3453 made
-            ;; `:auto` the DEFAULT and re-laid every machine; this redo keeps
-            ;; every non-opted machine pixel-identical.
+            ;; The OPT-IN adaptive gate. The whole post-ELK subsystem (the
+            ;; per-machine aspect heuristic + the parallel-region transpose
+            ;; + the back-edge reroute) is invoked ONLY when the host opts a
+            ;; machine in with `:direction :auto` (`post-elk/adaptive?`).
+            ;; The default `:tb` (and an explicit `:tb`/`:lr`) skips
+            ;; heuristic resolution + `apply-post-elk` — the ELK result
+            ;; flows to the projector unchanged, so every non-opted machine
+            ;; lays out the same with or without the adaptive subsystem.
             adaptive?     (post-elk/adaptive? direction)
             ;; The direction ELK is actually fed. On the opt-in path the
             ;; `:auto` sentinel resolves to the per-machine heuristic
@@ -1306,61 +1256,59 @@
             ;; Trigger an elk layout pass when the (definition,
             ;; direction, layout-options, density) tuple changes. Keep the
             ;; previous positions during in-flight layout to avoid an
-            ;; empty-chart flash. rf2-8q5pt — `density` joins the key so a
-            ;; density switch (which changes the derived container padding)
-            ;; re-runs ELK rather than rendering the topology with the prior
-            ;; density's header gaps. rf2-lamdfl — the RESOLVED ELK direction
-            ;; keys the pass (identical to `direction` on the non-adaptive
-            ;; path, so the historical key is unchanged for default/forced
-            ;; machines) so an `:auto` machine whose heuristic verdict is
-            ;; stable does not re-lay needlessly.
-            ;; rf2-8z1rca — the count of Context-band rows the root-container
-            ;; frame paints (one per `:context-band` key). The band renders
-            ;; only when `:context-band` is non-empty (mirroring
-            ;; `root-container-node`'s `(when (seq context) …)`), so an empty /
-            ;; absent map is 0 rows — no band, no extra root top padding. Fed
-            ;; into `compute-layout!` so the root frame reserves the band's
+            ;; empty-chart flash. `density` is in the key so a density switch
+            ;; (which changes the derived container padding) re-runs ELK
+            ;; rather than rendering the topology with the prior density's
+            ;; header gaps. The RESOLVED ELK direction keys the pass
+            ;; (identical to `direction` on the non-adaptive path) so an
+            ;; `:auto` machine whose heuristic verdict is stable does not
+            ;; re-lay needlessly.
+            ;; The count of Context-band rows the root-container frame paints
+            ;; (one per `:context-band` key). The band renders only when
+            ;; `:context-band` is non-empty (mirroring `root-container-node`'s
+            ;; `(when (seq context) …)`), so an empty / absent map is 0 rows
+            ;; — no band, no extra root top padding. Fed into
+            ;; `compute-layout!` so the root frame reserves the band's
             ;; variable height ABOVE its title strip.
             context-rows (if (seq context-band) (count context-band) 0)
-            ;; rf2-8z1rca — `context-rows` joins the layout key so adding /
-            ;; removing context (which changes the reserved root top padding)
-            ;; re-runs ELK rather than rendering against the prior band height.
-            ;; rf2-9qbn0g — `adaptive?` (the post-ELK MODE flag) joins the key.
-            ;; The pass is keyed by the RESOLVED `elk-direction`, but the post-
-            ;; ELK transform (parallel transpose + back-edge reroute) is gated
-            ;; by the RAW `:auto` opt-in, not the resolved direction. When
-            ;; `:auto` resolves to the SAME direction as a forced/default `:tb`
-            ;; (a linear / parallel machine, where `aspect-direction` returns
-            ;; `:tb`), `elk-direction` is identical for `:direction :tb` and
-            ;; `:direction :auto`, so toggling the prop did NOT invalidate the
-            ;; cached layout — the back-edge reroute / parallel transpose never
-            ;; applied on opt-IN, and stale-stayed on opt-OUT. Folding the
-            ;; opt-in flag into the key makes a `:tb → :auto → :tb` flip re-run
-            ;; the pass (apply then remove the transform) while still feeding
-            ;; the resolved `elk-direction` to ELK.
+            ;; `context-rows` is in the layout key so adding / removing
+            ;; context (which changes the reserved root top padding) re-runs
+            ;; ELK rather than rendering against the prior band height.
+            ;; `adaptive?` (the post-ELK MODE flag) is in the key too. The
+            ;; pass is keyed by the RESOLVED `elk-direction`, but the post-
+            ;; ELK transform (parallel transpose + back-edge reroute) is
+            ;; gated by the RAW `:auto` opt-in, not the resolved direction.
+            ;; When `:auto` resolves to the SAME direction as a
+            ;; forced/default `:tb` (a linear / parallel machine, where
+            ;; `aspect-direction` returns `:tb`), `elk-direction` is
+            ;; identical for `:direction :tb` and `:direction :auto`, so
+            ;; without the flag toggling the prop would NOT invalidate the
+            ;; cached layout. Folding the opt-in flag into the key makes a
+            ;; `:tb → :auto → :tb` flip re-run the pass (apply then remove
+            ;; the transform) while still feeding the resolved
+            ;; `elk-direction` to ELK.
             this-key   (compute-layout-key definition elk-direction layout-options
                                            density context-rows adaptive?)
-            ;; rf2-d9ro2 — one ELK pass. `measured-dims` is nil on the
-            ;; FIRST pass (nodes not yet rendered/measured) and the
-            ;; xyflow-measured `{node-id {:width :height}}` map on the
-            ;; measure-then-relayout SECOND pass. The settle reuses the
-            ;; rf2-set3x auto-fit logic so BOTH passes frame the topology.
+            ;; One ELK pass. `measured-dims` is nil on the FIRST pass (nodes
+            ;; not yet rendered/measured) and the xyflow-measured `{node-id
+            ;; {:width :height}}` map on the measure-then-relayout SECOND
+            ;; pass. The settle reuses the auto-fit logic so BOTH passes
+            ;; frame the topology.
             run-layout!
             (fn [measured-dims]
               (compute-layout!
                 parsed elk-direction layout-options machine-id measured-dims elk-vc
                 context-rows
                 (fn [raw-result]
-                  ;; rf2-lamdfl + rf2-gnrkke — the OPT-IN post-ELK stage.
-                  ;; On the adaptive path ONLY (and only for a successful
-                  ;; result), after ELK settles + before the projector emits
-                  ;; xyflow nodes/edges, run the cohesive post-ELK pass: the
-                  ;; parallel-region stacking-axis transpose (§4.3.2) THEN the
-                  ;; back-edge return-route detour (§4.3.1). On the DEFAULT /
-                  ;; forced path `adaptive?` is false, so this is a no-op
-                  ;; pass-through — the result is byte-identical to main. An
-                  ;; error result is also passed through untouched (banner
-                  ;; path unchanged).
+                  ;; The OPT-IN post-ELK stage. On the adaptive path ONLY
+                  ;; (and only for a successful result), after ELK settles +
+                  ;; before the projector emits xyflow nodes/edges, run the
+                  ;; cohesive post-ELK pass: the parallel-region stacking-
+                  ;; axis transpose (§4.3.2) THEN the back-edge return-route
+                  ;; detour (§4.3.1). On the DEFAULT / forced path
+                  ;; `adaptive?` is false, so this is a no-op pass-through —
+                  ;; the result flows through unchanged. An error result is
+                  ;; also passed through untouched (banner path unchanged).
                   (let [result (if (and adaptive?
                                         raw-result
                                         (seq (:positions raw-result))
@@ -1370,25 +1318,25 @@
                                  raw-result)]
                   (when result
                     (reset! layout-state result)
-                    ;; rf2-set3x — after a successful layout settle
-                    ;; (positions present, no error), auto-fit the
-                    ;; viewport ONCE per layout-key change so the operator
-                    ;; sees the real topology framed. Gating on `:fit-key`
-                    ;; differs from `this-key` preserves a manual zoom/pan
-                    ;; across non-layout re-renders, and re-fits on every
-                    ;; layout invalidation (definition / direction /
-                    ;; layout-options change). The relayout pass shares
-                    ;; the same gate — it re-fits the corrected topology
-                    ;; (the measured box, not the floor-sized first pass).
+                    ;; After a successful layout settle (positions present,
+                    ;; no error), auto-fit the viewport ONCE per layout-key
+                    ;; change so the operator sees the real topology framed.
+                    ;; Gating on `:fit-key` differs from `this-key`
+                    ;; preserves a manual zoom/pan across non-layout
+                    ;; re-renders, and re-fits on every layout invalidation
+                    ;; (definition / direction / layout-options change). The
+                    ;; relayout pass shares the same gate — it re-fits the
+                    ;; corrected topology (the measured box, not the floor-
+                    ;; sized first pass).
                     (when-let [^js inst (and (seq (:positions result))
                                              (nil? (:layout-error result))
                                              (:instance @fit-state))]
                       (when (not= this-key (:fit-key @fit-state))
                         (swap! fit-state assoc :fit-key this-key)
                         (schedule-fit! inst))))))))
-            ;; rf2-d9ro2 — the ELK-measurable node-id set: leaf states +
-            ;; synthetic event-nodes. ELK sizes these from the rendered
-            ;; box (`->elk-children` consults `measured-dims` for them).
+            ;; The ELK-measurable node-id set: leaf states + synthetic
+            ;; event-nodes. ELK sizes these from the rendered box
+            ;; (`->elk-children` consults `measured-dims` for them).
             ;; CONTAINERS (region / compound) keep the floor seed — their
             ;; true extent comes from ELK laying out their measured
             ;; children, so a self-measurement would be circular — and
@@ -1403,9 +1351,9 @@
                        set)
                   (map projection/event-node-id)
                   (:edges parsed))
-            ;; rf2-d9ro2 — the measure-then-relayout trigger. xyflow calls
-            ;; this (via `:onNodesChange`) after it measures the rendered
-            ;; node DOM. We read the measured boxes off the captured
+            ;; The measure-then-relayout trigger. xyflow calls this (via
+            ;; `:onNodesChange`) after it measures the rendered node DOM. We
+            ;; read the measured boxes off the captured
             ;; instance and, when the WHOLE topology has been measured AND
             ;; the measured map differs from what ELK was last fed for the
             ;; current layout-key, re-run ELK with the real boxes. The
@@ -1432,9 +1380,9 @@
                   (when (and ready? changed?)
                     (reset! relayout-state {:key this-key :measured dims})
                     (run-layout! dims)))))
-            ;; rf2-6tw7t — fit-on-entry. Orthogonal to the layout-key
-            ;; auto-fit (rf2-set3x): that gate intentionally PRESERVES the
-            ;; operator's manual zoom/pan across non-layout re-renders, so
+            ;; Fit-on-entry. Orthogonal to the layout-key auto-fit: that
+            ;; gate intentionally PRESERVES the operator's manual zoom/pan
+            ;; across non-layout re-renders, so
             ;; re-entering the Machine tab with the SAME machine does NOT
             ;; refit and the graph can sit off-screen / wrongly scaled. The
             ;; host bumps `:fit-signal` (an opaque nonce) on panel-entry /
@@ -1460,15 +1408,15 @@
         (when (and (seq (:nodes parsed))
                    (not= this-key @layout-key))
           (reset! layout-key this-key)
-          ;; rf2-d9ro2 — a new topology starts a fresh measure cycle: drop
-          ;; the prior measured signature so `maybe-relayout!` treats the
-          ;; first measurement of the new machine as a change.
+          ;; A new topology starts a fresh measure cycle: drop the prior
+          ;; measured signature so `maybe-relayout!` treats the first
+          ;; measurement of the new machine as a change.
           (reset! relayout-state {:key this-key :measured nil})
           (run-layout! nil))
-        ;; rf2-6tw7t — react to a host fit-signal bump every render. When
-        ;; the signal changed AND the instance + positions are ready this
-        ;; re-fits the framed topology (panel-entry / tab-activation). When
-        ;; positions aren't ready yet the settle/onInit fit covers it.
+        ;; React to a host fit-signal bump every render. When the signal
+        ;; changed AND the instance + positions are ready this re-fits the
+        ;; framed topology (panel-entry / tab-activation). When positions
+        ;; aren't ready yet the settle/onInit fit covers it.
         (maybe-fit-on-signal!)
         (cond
           (nil? definition)
@@ -1501,36 +1449,33 @@
            "Machine has no states to render."]
 
           :else
-          ;; rf2-k647w — resolve the `:density` prop ONCE per render to
-          ;; its visual-constants map. `chart-for-density` throws on an
-          ;; unknown density (per spec/API.md §Density), maps nil →
-          ;; regular, and returns the closed-set map otherwise. The
-          ;; resolved map threads through the projector onto every
-          ;; node/edge `:data`; the resolved density name surfaces on
-          ;; the root as `data-density`.
+          ;; Resolve the `:density` prop ONCE per render to its visual-
+          ;; constants map. `chart-for-density` throws on an unknown density
+          ;; (per spec/API.md §Density), maps nil → regular, and returns
+          ;; the closed-set map otherwise. The resolved map threads through
+          ;; the projector onto every node/edge `:data`; the resolved
+          ;; density name surfaces on the root as `data-density`.
           (let [chart-vc          (vc/chart-for-density density)
                 ;; `:density` defaults to `:regular` at the destructure
                 ;; (the render `:or` map), so it is never nil here —
                 ;; `(name density)` is total without the `(or … :regular)`
                 ;; guard.
                 density-name      (name density)
-                ;; rf2-az6e2 — resolve the `:theme` prop to its palette
-                ;; + the chart-semantic token map ONCE per render
-                ;; (independent of `:density`). The token map threads
-                ;; through the projector onto every node/edge `:data` so
-                ;; the renderers paint the ACTIVE theme; the chart's own
-                ;; chrome (below) reads `theme-palette` / `ct` too. The
-                ;; resolved theme name surfaces on the root as
-                ;; `data-theme`.
+                ;; Resolve the `:theme` prop to its palette + the chart-
+                ;; semantic token map ONCE per render (independent of
+                ;; `:density`). The token map threads through the projector
+                ;; onto every node/edge `:data` so the renderers paint the
+                ;; ACTIVE theme; the chart's own chrome (below) reads
+                ;; `theme-palette` / `ct` too. The resolved theme name
+                ;; surfaces on the root as `data-theme`.
                 theme-palette     (tokens/theme-palette theme)
                 ct                (tokens/chart-tokens theme-palette)
                 theme-name        (name (or theme :dark))
-                ;; rf2-g2svr (G1) — `highlight-ids` resolves the WHOLE
-                ;; `:current-state` to the SET of active leaves, so a
-                ;; PARALLEL snapshot's N simultaneously-active leaves
-                ;; (one per region) ALL light up, not just one. Flat /
-                ;; compound snapshots resolve to a singleton set (same
-                ;; result the prior scalar `highlight-id` produced).
+                ;; `highlight-ids` resolves the WHOLE `:current-state` to
+                ;; the SET of active leaves, so a PARALLEL snapshot's N
+                ;; simultaneously-active leaves (one per region) ALL light
+                ;; up, not just one. Flat / compound snapshots resolve to a
+                ;; singleton set.
                 highlight-ids     (layout/highlight-ids current-state)
                 from-highlight-id (layout/highlight-id from-highlight)
                 to-highlight-id   (layout/highlight-id to-highlight)
@@ -1539,34 +1484,33 @@
                 {:keys [positions edge-points edge-labels layout-error]}
                 @layout-state
                 fired-edge-id-set (set fired-edge-ids)
-                ;; rf2-fzrzlw — the guard-blocked no-op edge-id set; the
-                ;; projector marks each matching edge + event-node
-                ;; `:guardBlocked`. nil → #{} default.
+                ;; The guard-blocked no-op edge-id set; the projector marks
+                ;; each matching edge + event-node `:guardBlocked`. nil →
+                ;; #{} default.
                 guard-blocked-edge-id-set (set guard-blocked-edge-ids)
-                ;; rf2-dnmbs — memoise the projection + JS marshalling
-                ;; (`xyflow-graph` then `clj->js`) on the inputs that
-                ;; actually change the projected graph. A tick-only /
-                ;; fit-signal-only / parent re-render hits the cache and
-                ;; reuses the converted `#js` arrays; a highlight, an ELK
-                ;; settle (new positions / routes), a new definition, a
-                ;; density/theme switch, or a callback change busts it.
-                ;; `chart-vc` / `ct` are pure functions of `density` /
-                ;; `theme`, so the cheaper keywords stand in for them in
-                ;; the key. The resolved (read-only-gated) callbacks are
-                ;; keyed directly so a changed handler identity rebuilds.
-                ;; rf2-q129z8 — `machine-id` / `context-band` /
-                ;; `context-band-inferred?` now feed the ROOT-CONTAINER frame
-                ;; header (the named box's machine name + Context band), so a
-                ;; change in any of them must rebuild the projected graph.
+                ;; Memoise the projection + JS marshalling (`xyflow-graph`
+                ;; then `clj->js`) on the inputs that actually change the
+                ;; projected graph. A tick-only / fit-signal-only / parent
+                ;; re-render hits the cache and reuses the converted `#js`
+                ;; arrays; a highlight, an ELK settle (new positions /
+                ;; routes), a new definition, a density/theme switch, or a
+                ;; callback change busts it. `chart-vc` / `ct` are pure
+                ;; functions of `density` / `theme`, so the cheaper keywords
+                ;; stand in for them in the key. The resolved (read-only-
+                ;; gated) callbacks are keyed directly so a changed handler
+                ;; identity rebuilds. `machine-id` / `context-band` /
+                ;; `context-band-inferred?` feed the ROOT-CONTAINER frame
+                ;; header (the named box's machine name + Context band), so
+                ;; a change in any of them must rebuild the projected graph.
                 cache-key  [parsed positions edge-points edge-labels
                             highlight-ids from-highlight-id to-highlight-id
                             fired-edge-id-set guard-blocked-edge-id-set
                             sim? callback edge-callback
                             density theme
                             machine-id context-band context-band-inferred?
-                            ;; rf2-27e38h — a change in the Context-band
-                            ;; egress classification / raw opt-in must
-                            ;; rebuild the projected band display.
+                            ;; A change in the Context-band egress
+                            ;; classification / raw opt-in must rebuild the
+                            ;; projected band display.
                             context-band-sensitive context-band-large
                             context-band-raw?]
                 {:keys [js-nodes js-edges]}
@@ -1581,48 +1525,46 @@
                                :sim?              sim?
                                :on-state-click    callback
                                :on-edge-click     edge-callback
-                               ;; rf2-cz8v6 (G2) — elk's routed bend-
-                               ;; points; the projector attaches each
-                               ;; edge's route to its :data {:points}.
+                               ;; elk's routed bend-points; the projector
+                               ;; attaches each edge's route to its
+                               ;; :data {:points}.
                                :edge-points       edge-points
-                               ;; rf2-rlq97 — elk's computed label
-                               ;; positions; the projector attaches each
-                               ;; labelled edge's position to :data
-                               ;; {:labelPos} (empty under events-as-nodes,
-                               ;; where the label rides on the event-node).
+                               ;; elk's computed label positions; the
+                               ;; projector attaches each labelled edge's
+                               ;; position to :data {:labelPos} (empty under
+                               ;; events-as-nodes, where the label rides on
+                               ;; the event-node).
                                :edge-labels       edge-labels
-                               ;; rf2-qeemm (G3) — the fired-this-epoch
-                               ;; edge-id set; the projector marks each
-                               ;; matching edge :fired. nil → #{} default.
+                               ;; The fired-this-epoch edge-id set; the
+                               ;; projector marks each matching edge :fired.
+                               ;; nil → #{} default.
                                :fired-edge-ids    fired-edge-id-set
-                               ;; rf2-fzrzlw — the guard-blocked no-op
-                               ;; edge-id set; the projector marks each
-                               ;; matching edge + event-node :guardBlocked.
+                               ;; The guard-blocked no-op edge-id set; the
+                               ;; projector marks each matching edge +
+                               ;; event-node :guardBlocked.
                                :guard-blocked-edge-ids guard-blocked-edge-id-set
                                :chart             chart-vc
-                               ;; rf2-az6e2 — the resolved chart-semantic
-                               ;; token map for the active theme; the
-                               ;; projector threads it onto every node/edge
-                               ;; `:data {:palette}`.
+                               ;; The resolved chart-semantic token map for
+                               ;; the active theme; the projector threads it
+                               ;; onto every node/edge `:data {:palette}`.
                                :palette           ct
-                               ;; rf2-q129z8 — the ROOT-CONTAINER frame's
-                               ;; header content. The projector overrides the
-                               ;; synthetic frame node's label with the machine
-                               ;; name and threads the inferred Context shape +
+                               ;; The ROOT-CONTAINER frame's header content.
+                               ;; The projector overrides the synthetic
+                               ;; frame node's label with the machine name
+                               ;; and threads the inferred Context shape +
                                ;; inferred flag onto its `:data` so
-                               ;; `nodes/root-container-node` paints the named
-                               ;; frame header + Context band (absorbing the old
-                               ;; corner-pinned title strip + Context overlay).
+                               ;; `nodes/root-container-node` paints the
+                               ;; named frame header + Context band.
                                :machine-id        machine-id
                                :context-band      context-band
                                :context-band-inferred? context-band-inferred?
-                               ;; rf2-27e38h (EP-0015) — local-redacted
-                               ;; Context-band egress contract. The band is
-                               ;; serialised into SVG/PNG/clipboard, so live
-                               ;; `:data` values are redacted by default; the
-                               ;; host declares which slots are sensitive/large
-                               ;; (from the machine's `:data-schema`) and may
-                               ;; opt into raw via `:context-band-raw?`.
+                               ;; Local-redacted Context-band egress contract
+                               ;; (EP-0015). The band is serialised into
+                               ;; SVG/PNG/clipboard, so live `:data` values
+                               ;; are redacted by default; the host declares
+                               ;; which slots are sensitive/large (from the
+                               ;; machine's `:data-schema`) and may opt into
+                               ;; raw via `:context-band-raw?`.
                                :context-band-sensitive context-band-sensitive
                                :context-band-large context-band-large
                                :context-band-raw? context-band-raw?})))
@@ -1637,27 +1579,25 @@
                                   (str " across " n-regions " parallel "
                                        (if (= 1 n-regions) "region" "regions")))
                                 ".")
-                ;; rf2-7w4qr — the `:overlays` descriptor vector. Each
-                ;; descriptor carries its own `:tick` (one rAF clock per
-                ;; chart, Lock #8 — the host's clock drives whichever
-                ;; overlay it ticks).
+                ;; The `:overlays` descriptor vector. Each descriptor
+                ;; carries its own `:tick` (one rAF clock per chart, Lock #8
+                ;; — the host's clock drives whichever overlay it ticks).
                 overlay-descriptors (filterv map? overlays)]
             [:div {:data-testid testid
                    :data-machine-id (str machine-id)
                    :data-node-count (str n-states)
                    :data-region-count (str n-regions)
                    :data-edge-count (str n-trans)
-                   ;; rf2-shv82 — `data-edge-count-projected` exposes the
-                   ;; xyflow-graph projector's edge-array length AFTER
-                   ;; entry edges + parent-level adjustments. Pairs with
-                   ;; the existing `data-edge-count` (parsed-transition
-                   ;; count) so visual-regression tests can pin the
-                   ;; parser→projector→DOM chain end to end and catch
-                   ;; silent drops (like the rf2-shv82 compound-endpoint
-                   ;; bug) at any layer.
+                   ;; `data-edge-count-projected` exposes the xyflow-graph
+                   ;; projector's edge-array length AFTER entry edges +
+                   ;; parent-level adjustments. Pairs with `data-edge-count`
+                   ;; (parsed-transition count) so visual-regression tests
+                   ;; can pin the parser→projector→DOM chain end to end and
+                   ;; catch silent edge drops (e.g. a compound-endpoint
+                   ;; drop) at any layer.
                    :data-edge-count-projected (str (alength js-edges))
-                   ;; rf2-8d7w1 — stash the export/share-relevant chart
-                   ;; state on the root DOM node as a JS property so the
+                   ;; Stash the export/share-relevant chart state on the
+                   ;; root DOM node as a JS property so the
                    ;; `export` namespace can derive a share-URL / alt-text
                    ;; summary from `chart-element` without re-stamping the
                    ;; (potentially large) definition into a data-attribute.
@@ -1684,60 +1624,56 @@
                                    :node-count    n-states
                                    :edge-count    n-trans
                                    :region-count  n-regions})))
-                   ;; rf2-k647w — the resolved density surfaces here so
-                   ;; hosts + tests read the active density without
-                   ;; re-reading the bound prop (per spec/API.md
-                   ;; §Density resolution rules).
+                   ;; The resolved density surfaces here so hosts + tests
+                   ;; read the active density without re-reading the bound
+                   ;; prop (per spec/API.md §Density resolution rules).
                    :data-density density-name
-                   ;; rf2-az6e2 — the resolved theme surfaces here so
-                   ;; hosts + tests read the active theme without
-                   ;; re-reading the bound prop. Dark remains the Xray
-                   ;; default. Independent of `data-density`.
+                   ;; The resolved theme surfaces here so hosts + tests read
+                   ;; the active theme without re-reading the bound prop.
+                   ;; Dark is the Xray default. Independent of
+                   ;; `data-density`.
                    :data-theme theme-name
-                   ;; rf2-g2svr (G1) — the FULL active set surfaces as a
-                   ;; sorted, space-joined attr so hosts + DOM tests can
-                   ;; read every active leaf (one for a flat/compound
-                   ;; snapshot, N for a parallel one).
+                   ;; The FULL active set surfaces as a sorted, space-joined
+                   ;; attr so hosts + DOM tests can read every active leaf
+                   ;; (one for a flat/compound snapshot, N for a parallel
+                   ;; one).
                    :data-highlight-ids (str/join " " (sort highlight-ids))
                    :data-from-highlight-id (or from-highlight-id "")
                    :data-to-highlight-id (or to-highlight-id "")
-                   ;; rf2-qeemm (G3) — the fired-this-epoch edge-id set
-                   ;; surfaces as a sorted, space-joined attr so hosts +
-                   ;; DOM tests can read every traversed arm at the chart
-                   ;; root (mirrors `data-highlight-ids`). "" when none.
+                   ;; The fired-this-epoch edge-id set surfaces as a sorted,
+                   ;; space-joined attr so hosts + DOM tests can read every
+                   ;; traversed arm at the chart root (mirrors
+                   ;; `data-highlight-ids`). "" when none.
                    :data-fired-edge-ids (str/join " " (sort (set fired-edge-ids)))
-                   ;; rf2-fzrzlw — the guard-blocked no-op edge-id set
-                   ;; surfaces as a sorted, space-joined attr so hosts +
-                   ;; DOM tests can read every attempted-and-rejected arm
-                   ;; at the chart root (mirrors `data-fired-edge-ids`).
-                   ;; "" when none.
+                   ;; The guard-blocked no-op edge-id set surfaces as a
+                   ;; sorted, space-joined attr so hosts + DOM tests can read
+                   ;; every attempted-and-rejected arm at the chart root
+                   ;; (mirrors `data-fired-edge-ids`). "" when none.
                    :data-guard-blocked-edge-ids (str/join " " (sort (set guard-blocked-edge-ids)))
-                   ;; rf2-4lyvh — surface ELK layout-failure as a root
-                   ;; data-attr so DOM tests + hosts can pin the failure
-                   ;; without inspecting the banner DOM. "true" / "false";
-                   ;; the visible banner below carries the human-readable
-                   ;; message.
+                   ;; Surface ELK layout-failure as a root data-attr so DOM
+                   ;; tests + hosts can pin the failure without inspecting
+                   ;; the banner DOM. "true" / "false"; the visible banner
+                   ;; below carries the human-readable message.
                    :data-layout-error (if layout-error "true" "false")
                    :role "application"
                    :aria-label aria-label
                    :style {:position "relative"
                            :width    "100%"
                            :height   height
-                           ;; rf2-az6e2 — the chart canvas reads the
-                           ;; ACTIVE theme's surface, not the dark alias.
+                           ;; The chart canvas reads the ACTIVE theme's
+                           ;; surface.
                            :background (:bg-1 theme-palette)
                            :border-radius "4px"
                            :overflow "hidden"}}
-             ;; Inline keyframes + reduced-motion seam — mirrors the
-             ;; previous SVG render's <style> block so the focused-edge
-             ;; glow continues to work without an external stylesheet.
+             ;; Inline keyframes + reduced-motion seam so the focused-edge
+             ;; glow works without an external stylesheet.
              [:style {:dangerouslySetInnerHTML {:__html chart-stylesheet}}]
              [:> ReactFlow
-              ;; rf2-dnmbs — `js-nodes` / `js-edges` are the memoised
-              ;; `clj->js` results from `project+convert!`; a tick-only /
-              ;; overlay-only re-render reuses the SAME `#js` arrays so the
-              ;; deep marshalling is skipped on the 60Hz hot path (and
-              ;; xyflow sees stable object identity, skipping its own diff).
+              ;; `js-nodes` / `js-edges` are the memoised `clj->js` results
+              ;; from `project+convert!`; a tick-only / overlay-only
+              ;; re-render reuses the SAME `#js` arrays so the deep
+              ;; marshalling is skipped on the 60Hz hot path (and xyflow
+              ;; sees stable object identity, skipping its own diff).
               {:nodes               js-nodes
                :edges               js-edges
                :nodeTypes           node-types-memo
@@ -1752,14 +1688,14 @@
                :minZoom             0.2
                :maxZoom             4.0
                :proOptions          #js {:hideAttribution true}
-               ;; rf2-set3x — capture the xyflow ReactFlowInstance so
-               ;; the compute-layout! settle can re-fit the viewport
-               ;; after the async elk pass resolves (the built-in
-               ;; `:fitView true` fires only once on mount, while
-               ;; every node still sits at the default origin). If
-               ;; positions have ALREADY arrived by the time onInit
-               ;; runs (fast layout / cached settle), fit immediately
-               ;; — the post-mount xyflow fit was equally degenerate.
+               ;; Capture the xyflow ReactFlowInstance so the
+               ;; compute-layout! settle can re-fit the viewport after the
+               ;; async elk pass resolves (the built-in `:fitView true`
+               ;; fires only once on mount, while every node still sits at
+               ;; the default origin). If positions have ALREADY arrived by
+               ;; the time onInit runs (fast layout / cached settle), fit
+               ;; immediately — the post-mount xyflow fit is equally
+               ;; degenerate.
                :onInit              (fn [^js instance]
                                       (let [{:keys [positions
                                                     layout-error]} @layout-state
@@ -1773,40 +1709,38 @@
                                         (when should-fit-now?
                                           (swap! fit-state assoc :fit-key key-now)
                                           (schedule-fit! instance))
-                                        ;; rf2-d9ro2 — xyflow may have
-                                        ;; already measured the nodes by the
-                                        ;; time onInit fires (fast commit).
-                                        ;; Kick the measure-then-relayout
-                                        ;; check too, in case no further
-                                        ;; dimension change fires.
+                                        ;; xyflow may have already measured
+                                        ;; the nodes by the time onInit
+                                        ;; fires (fast commit). Kick the
+                                        ;; measure-then-relayout check too,
+                                        ;; in case no further dimension
+                                        ;; change fires.
                                         (maybe-relayout!)
-                                        ;; rf2-6tw7t — a host `:fit-signal`
-                                        ;; may have been pending BEFORE the
-                                        ;; instance was captured (entry that
-                                        ;; arrived ahead of onInit). Now that
-                                        ;; the instance exists, honour it if
-                                        ;; positions have already settled.
+                                        ;; A host `:fit-signal` may have been
+                                        ;; pending BEFORE the instance was
+                                        ;; captured (entry that arrived ahead
+                                        ;; of onInit). Now that the instance
+                                        ;; exists, honour it if positions
+                                        ;; have already settled.
                                         (maybe-fit-on-signal!)))
-               ;; rf2-d9ro2 — measure-then-relayout signal. xyflow emits a
-               ;; `dimensions` NodeChange once it measures the rendered
-               ;; node DOM; that is our cue to read the real boxes back and
-               ;; re-run ELK with them (`maybe-relayout!` gates it to once
-               ;; per layout-key, no loop). We do NOT feed the changes back
-               ;; into `:nodes` (positions are ELK-owned, the chart is
-               ;; non-interactive) — the handler is purely a measurement
-               ;; trigger.
+               ;; Measure-then-relayout signal. xyflow emits a `dimensions`
+               ;; NodeChange once it measures the rendered node DOM; that is
+               ;; our cue to read the real boxes back and re-run ELK with
+               ;; them (`maybe-relayout!` gates it to once per layout-key, no
+               ;; loop). We do NOT feed the changes back into `:nodes`
+               ;; (positions are ELK-owned, the chart is non-interactive) —
+               ;; the handler is purely a measurement trigger.
                :onNodesChange       (fn [^js _changes] (maybe-relayout!))}
               (when show-background?
-                ;; rf2-k647w — dot-grid spacing + radius track the
-                ;; resolved density (`:dot-grid-spacing-px` /
-                ;; `:dot-grid-radius-px`); regular = 16 / 1.0, the
-                ;; historical hardcoded pair.
+                ;; Dot-grid spacing + radius track the resolved density
+                ;; (`:dot-grid-spacing-px` / `:dot-grid-radius-px`); regular
+                ;; = 16 / 1.0.
                 [:> Background {:variant (.-Dots BackgroundVariant)
                                 :gap (:dot-grid-spacing-px chart-vc)
                                 :size (:dot-grid-radius-px chart-vc)
-                                ;; rf2-az6e2 — dot colour resolves through
-                                ;; the active theme's accent (light hosts
-                                ;; get a darker dot).
+                                ;; Dot colour resolves through the active
+                                ;; theme's accent (light hosts get a darker
+                                ;; dot).
                                 :color (tokens/with-alpha :accent 0.4 theme-palette)}])
               (when show-controls?
                 [:> Controls {:showZoom true
@@ -1817,51 +1751,45 @@
                              :pannable true
                              :nodeColor (fn [_] (:bg-3 theme-palette))
                              :maskColor (tokens/with-alpha :bg-0 0.6 theme-palette)}])]
-             ;; rf2-q129z8 — the ROOT MACHINE CHROME (machine title strip +
-             ;; Context shape) no longer renders as a corner-pinned overlay
-             ;; here. It is now the HEADER of the synthetic ROOT-CONTAINER
-             ;; frame node (`chart.nodes/root-container-node`), an ELK-sized
-             ;; box that HUGS + TRACKS the whole topology and reflows on
-             ;; resize — eliminating the pre-q129z8 corner-pinning (the strip
-             ;; welded to the drawing surface while xyflow re-fit the
-             ;; topology) and the top-left chrome collision. The machine name
-             ;; + Context band are threaded onto the frame node's `:data` by
-             ;; `chart.projection/xyflow-graph`.
-             ;; rf2-7w4qr — host-fed overlays, composed through the
-             ;; single `:overlays` slot. Each descriptor map (keyed on
-             ;; `:id`) is dispatched to its rendering namespace by
-             ;; `render-overlay` (after-rings / spawn-all-join /
-             ;; cancellation-cascade); the renderers are unchanged — only
-             ;; the wiring is lifted here. Every overlay is a sibling of
-             ;; the xyflow canvas inside this position:relative wrapper
-             ;; and walks the rendered node DOM (`rf-mv-chart-node-<id>`)
-             ;; to anchor itself; the host owns the trace→spec projection
-             ;; + the per-descriptor `:tick` (Lock #8 — one rAF clock per
-             ;; chart). Dormant descriptors + unknown `:id`s render nil.
+             ;; The ROOT MACHINE CHROME (machine title strip + Context
+             ;; shape) is the HEADER of the synthetic ROOT-CONTAINER frame
+             ;; node (`chart.nodes/root-container-node`), an ELK-sized box
+             ;; that HUGS + TRACKS the whole topology and reflows on resize
+             ;; — so the strip rides with the topology rather than welding to
+             ;; the drawing surface and colliding with the top-left chrome.
+             ;; The machine name + Context band are threaded onto the frame
+             ;; node's `:data` by `chart.projection/xyflow-graph`.
+             ;; Host-fed overlays, composed through the single `:overlays`
+             ;; slot. Each descriptor map (keyed on `:id`) is dispatched to
+             ;; its rendering namespace by `render-overlay` (after-rings /
+             ;; spawn-all-join / cancellation-cascade); this wraps only the
+             ;; wiring. Every overlay is a sibling of the xyflow canvas
+             ;; inside this position:relative wrapper and walks the rendered
+             ;; node DOM (`rf-mv-chart-node-<id>`) to anchor itself; the host
+             ;; owns the trace→spec projection + the per-descriptor `:tick`
+             ;; (Lock #8 — one rAF clock per chart). Dormant descriptors +
+             ;; unknown `:id`s render nil.
              (map-indexed
                (fn [i descriptor]
                  ^{:key (str "rf-mv-overlay-" i "-"
                              (pr-str (:id descriptor)))}
                  [render-overlay descriptor])
                overlay-descriptors)
-             ;; rf2-q129z8 — the `:context-band` Context shape no longer
-             ;; renders as a corner-pinned overlay panel here; it is now the
-             ;; Context BAND in the synthetic ROOT-CONTAINER frame header
+             ;; The `:context-band` Context shape renders as the Context
+             ;; BAND in the synthetic ROOT-CONTAINER frame header
              ;; (`chart.nodes/root-container-node`), threaded onto the frame
-             ;; node's `:data {:context}` by `chart.projection/xyflow-graph`.
-             ;; This eliminates the top-left chrome collision (the panel used
-             ;; to weld to the corner under the title strip) — the Context now
-             ;; rides INSIDE the frame that hugs the topology.
-             ;; rf2-4lyvh — ELK layout-failure indicator. When
-             ;; `compute-layout!` surfaces a `:layout-error` slot the
-             ;; chart would otherwise render every node stacked at
-             ;; origin (no positions). Paint a small banner over the
-             ;; canvas so the operator sees the failure IN the panel,
-             ;; not just in the trace bus or DevTools console. The full
-             ;; structured failure lives on the `:rf.error/machines-
-             ;; viz-elk-layout-failed` trace event (tools/Xray Issues
-             ;; panel surfaces it from there); this banner is the dev-
-             ;; tool affordance for the operator running the live app.
+             ;; node's `:data {:context}` by `chart.projection/xyflow-graph`,
+             ;; so the Context rides INSIDE the frame that hugs the topology
+             ;; rather than welding to the corner under the title strip.
+             ;; ELK layout-failure indicator. When `compute-layout!`
+             ;; surfaces a `:layout-error` slot the chart would otherwise
+             ;; render every node stacked at origin (no positions). Paint a
+             ;; small banner over the canvas so the operator sees the failure
+             ;; IN the panel, not just in the trace bus or DevTools console.
+             ;; The full structured failure lives on the `:rf.error/machines-
+             ;; viz-elk-layout-failed` trace event (tools/Xray Issues panel
+             ;; surfaces it from there); this banner is the dev-tool
+             ;; affordance for the operator running the live app.
              (when layout-error
                [:div {:data-testid (str testid "-layout-error-banner")
                       :role "status"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/context_redaction.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/context_redaction.cljc
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-machines-viz.chart.context-redaction
-  "EP-0015 local-redacted projection for the chart's root Context band
-  (rf2-27e38h).
+  "EP-0015 local-redacted projection for the chart's root Context band.
 
   ## Why this exists
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -1,34 +1,31 @@
 (ns day8.re-frame2-machines-viz.chart.edges
   "Custom xyflow edge components for the MachineChart.
 
-  rf2-gpzb4 (2026-05-21 xyflow override) — edge components render the
-  xstate-style label (`event [guard] / action`) with a small backplate
-  for legibility against overlapping edges + the dot-grid background.
-  Active-state and focused-event lens highlighting are reflected in
-  stroke colour + width via the edge's `:data` payload.
+  Edge components render the xstate-style label (`event [guard] /
+  action`) with a small backplate for legibility against overlapping
+  edges + the dot-grid background. Active-state and focused-event lens
+  highlighting are reflected in stroke colour + width via the edge's
+  `:data` payload.
 
-  ## Edge kinds (per the bead's scope §Custom edges)
+  ## Edge kinds
 
     - `transition-edge` — the canonical (and only) edge type. Renders
       the route ELK computed (a smooth poly-path THROUGH ELK's bend-
-      points, rf2-cz8v6) with the event label sitting where ELK placed
-      it (rf2-rlq97 — `:labelPos`, ELK's reserved label channel) behind
-      a small backplate rect. When ELK placed no label (the events-as-
-      nodes default — the transition text rides on the event-NODE) the
-      anchor falls back to a geometric midpoint heuristic. Under events-
-      as-nodes EVERY projected edge is this type; `:after`-timer
-      specifics ride the event-NODE (`:variant \"after\"` + `:afterMs`),
-      not a distinct edge type, so the dead `after-edge` alias + the
-      `choose-edge-type` classifier were removed (rf2-dt5b1).
+      points) with the event label sitting where ELK placed it
+      (`:labelPos`, ELK's reserved label channel) behind a small
+      backplate rect. When ELK placed no label (the events-as-nodes
+      default — the transition text rides on the event-NODE) the anchor
+      falls back to a geometric midpoint heuristic. Under events-as-nodes
+      EVERY projected edge is this type; `:after`-timer specifics ride
+      the event-NODE (`:variant \"after\"` + `:afterMs`), not a distinct
+      edge type.
 
-  rf2-0gmwp — there is no `spawn` edge type. Per Spec 005 `:spawn` /
-  `:spawn-all` are state-entry actions that bring CHILD actor machines
-  into existence; they are NOT same-machine transitions, so the parse
-  (`chart.layout`) emits no spawn edge. Spawned children surface
-  through the `chart.overlays.spawn-all-join` inspector (anchored
-  beside the spawn-bearing state), not as an edge in this chart. The
-  previously-registered `spawn-edge` component was dead registration —
-  never reachable from any parsed edge — and was removed.
+  There is no `spawn` edge type. Per Spec 005 `:spawn` / `:spawn-all`
+  are state-entry actions that bring CHILD actor machines into existence;
+  they are NOT same-machine transitions, so the parse (`chart.layout`)
+  emits no spawn edge. Spawned children surface through the
+  `chart.overlays.spawn-all-join` inspector (anchored beside the
+  spawn-bearing state), not as an edge in this chart.
 
   ## Substrate posture
 
@@ -54,7 +51,7 @@
 (def ^:private BaseEdge        (.-BaseEdge xyflow))
 (def ^:private EdgeLabelRenderer (.-EdgeLabelRenderer xyflow))
 
-;; ---- elk bend-point routing (rf2-cz8v6, G2) ----------------------------
+;; ---- elk bend-point routing --------------------------------------------
 ;;
 ;; When elk hands us a multi-point route (start → bend… → end, in
 ;; absolute flow coords), we render the edge ALONG it instead of a
@@ -123,7 +120,7 @@
     [(/ (+ (.-x a) (.-x b)) 2)
      (/ (+ (.-y a) (.-y b)) 2)]))
 
-;; ---- cross-hierarchy label placement (rf2-shv82, Issue 3) --------------
+;; ---- cross-hierarchy label placement -----------------------------------
 ;;
 ;; A cross-hierarchy edge (source and target in different parent
 ;; containers) routed via elk's bend-points has a midpoint that can land
@@ -165,7 +162,7 @@
 
 (defn edge-path
   "Pure path-selection for a transition edge — the single source of
-  truth `transition-edge` renders + the test suite pins (rf2-cz8v6).
+  truth `transition-edge` renders + the test suite pins.
 
   Returns `{:d <svg-path-string> :label-x <px> :label-y <px> :routed?
   <bool>}`. Path selection, in priority order:
@@ -173,17 +170,16 @@
     1. elk route     → when `points` is a JS array of ≥ 2 `#js {:x :y}`,
        a smooth poly-path THROUGH the bends so the edge goes AROUND
        nested containers (`:routed? true`).
-       rf2-rlq97: the LABEL anchor is elk's COMPUTED label position
-       (`label-pos` `{:x :y}`, fed from `chart.edges`'s
-       `elk.edgeLabels.placement`) when elk placed one — so a labelled
-       edge's text sits in the collision-free channel elk reserved, NOT
-       at a renderer-side heuristic. When elk placed NO label (the
-       events-as-nodes default — the transition text rides on the
-       event-NODE so the edge carries no label), the anchor falls back
-       to the geometric heuristic:
-         rf2-shv82 (Issue 3): cross-hierarchy edges anchor near the
-         SOURCE-SIDE first bend point (just outside the container the
-         edge exits); other edges use the routed middle-segment midpoint.
+       The LABEL anchor is elk's COMPUTED label position (`label-pos`
+       `{:x :y}`, fed from `chart.edges`'s `elk.edgeLabels.placement`)
+       when elk placed one — so a labelled edge's text sits in the
+       collision-free channel elk reserved, NOT at a renderer-side
+       heuristic. When elk placed NO label (the events-as-nodes default
+       — the transition text rides on the event-NODE so the edge carries
+       no label), the anchor falls back to the geometric heuristic:
+         cross-hierarchy edges anchor near the SOURCE-SIDE first bend
+         point (just outside the container the edge exits); other edges
+         use the routed middle-segment midpoint.
     2. bezier        → `getBezierPath` between the handles (`:routed?
        false`) — the no-bend-point fallback.
 
@@ -197,7 +193,7 @@
     (cond
       routed?
       (let [[lx ly] (cond
-                      ;; rf2-rlq97 — elk placed the label: paint there.
+                      ;; elk placed the label: paint there.
                       (and label-pos
                            (number? (:x label-pos))
                            (number? (:y label-pos)))
@@ -221,65 +217,64 @@
 
 ;; ---- helpers ------------------------------------------------------------
 ;;
-;; rf2-k647w — edge typography (label font-size + backplate opacity)
-;; reads off the resolved density's `visual-constants` map, threaded
-;; onto the edge `:data` by the projector. `chart-constants` (the
-;; kebab-keyword recovery off `(.-chart d)`, `vc/chart-regular` fallback)
-;; and `palette-of` (the chart-semantic token recovery off `(.-palette d)`)
+;; Edge typography (label font-size + backplate opacity) reads off the
+;; resolved density's `visual-constants` map, threaded onto the edge
+;; `:data` by the projector. `chart-constants` (the kebab-keyword
+;; recovery off `(.-chart d)`, `vc/chart-regular` fallback) and
+;; `palette-of` (the chart-semantic token recovery off `(.-palette d)`)
 ;; are shared with the node renderers — both are `:refer`-ed from
-;; `chart.nodes.xyflow-node` rather than re-implemented here (rf2-91oga2).
+;; `chart.nodes.xyflow-node`.
 
 (defn- edge-stroke
-  "rf2-fzrzlw — `blocked?` (the edge's guard rejected the event this
-  epoch) wins OUTRIGHT so the pink guard-blocked hue overrides the
-  affordance-blue / fired / active on that specific edge (bead design
-  call (2): the attempted-and-rejected edge must stand out).
+  "`blocked?` (the edge's guard rejected the event this epoch) wins
+  OUTRIGHT so the pink guard-blocked hue overrides the affordance-blue /
+  fired / active on that specific edge: the attempted-and-rejected edge
+  must stand out.
 
-  rf2-qeemm (G3) — `fired?` (the edge traversed THIS epoch) wins over
-  `focused?` / `active?` so a fired arm reads as 'what just happened' in
-  the FIRED hue, distinct from the focused/active hue.
+  `fired?` (the edge traversed THIS epoch) wins over `focused?` /
+  `active?` so a fired arm reads as 'what just happened' in the FIRED
+  hue, distinct from the focused/active hue.
 
-  rf2-az6e2 — colours resolve through the active-theme chart-tokens
-  (`ct`): fired = `:edge-fired`, focused/active = `:edge-active`, resting
-  = `:edge-quiet`. The QUIET source→event segment (`quiet?`) paints the
-  quiet colour even when the route is otherwise resting so the pair reads
-  as one transition with the primary arrowhead on the event→target half.
+  Colours resolve through the active-theme chart-tokens (`ct`): fired =
+  `:edge-fired`, focused/active = `:edge-active`, resting = `:edge-quiet`.
+  The QUIET source→event segment (`quiet?`) paints the quiet colour even
+  when the route is otherwise resting so the pair reads as one transition
+  with the primary arrowhead on the event→target half.
 
-  G-START — the initial-marker entry edge (`entry?`) is the SCXML/Stately
+  The initial-marker entry edge (`entry?`) is the SCXML/Stately
   initial-state icon (filled dot + short arrow into the state's near
   edge). It paints the SAME neutral `:pseudo-marker` hue as the dot — NOT
   the near-invisible `:edge-quiet` resting hue — so the dot + arrow read
   as one clearly-visible unit, matching the projector's arrowhead
   `:markerEnd :color` (`:pseudo-marker`) for the same edge.
 
-  rf2-dt5b1 — otherwise delegates to the shared `tokens/edge-color`, the
-  SINGLE source the projector's arrowhead-`:markerEnd` colour also routes
+  Otherwise delegates to the shared `tokens/edge-color`, the SINGLE
+  source the projector's arrowhead-`:markerEnd` colour also routes
   through, so a stroke and its arrowhead can never resolve different
-  colours for the same edge state (rf2-fzrzlw — `:blocked?` resolves to
-  the pink guard-blocked hue there, winning over fired/active)."
+  colours for the same edge state (`:blocked?` resolves to the pink
+  guard-blocked hue there, winning over fired/active)."
   [ct {:keys [entry?] :as flags}]
   (if entry?
     (:pseudo-marker ct)
     (tokens/edge-color ct flags)))
 
 (defn- edge-stroke-width
-  "rf2-k647w — edge stroke widths read off the resolved density. The
-  active stroke sits midway between default + emphasis; the focused
-  stroke is the emphasis width (preserving the shipped regular
-  relationship 1.5 / 2.0 / 2.5).
+  "Edge stroke widths read off the resolved density. The active stroke
+  sits midway between default + emphasis; the focused stroke is the
+  emphasis width (the regular relationship is 1.5 / 2.0 / 2.5).
 
-  rf2-qeemm (G3) — `fired?` paints at the emphasis width (the heaviest
-  treatment), at least as prominent as `focused?`.
+  `fired?` paints at the emphasis width (the heaviest treatment), at
+  least as prominent as `focused?`.
 
-  rf2-fzrzlw — `blocked?` (the guard-blocked no-op edge) paints at the
-  emphasis width too so the pink rejected edge stands out as much as a
-  fired arm — the operator must not miss the attempted transition.
+  `blocked?` (the guard-blocked no-op edge) paints at the emphasis width
+  too so the pink rejected edge stands out as much as a fired arm — the
+  operator must not miss the attempted transition.
 
-  rf2-az6e2 — the QUIET source→event segment (`quiet?`) paints ONE notch
-  THINNER than the resting width (so the pair reads as one route: the
-  quiet inbound half + the primary outbound half). A quiet segment that
-  is itself fired/focused still picks up the emphasis width so a
-  traversed route lights BOTH segments together."
+  The QUIET source→event segment (`quiet?`) paints ONE notch THINNER
+  than the resting width (so the pair reads as one route: the quiet
+  inbound half + the primary outbound half). A quiet segment that is
+  itself fired/focused still picks up the emphasis width so a traversed
+  route lights BOTH segments together."
   [{:keys [active? focused? fired? blocked? quiet? chart]
     :or   {chart vc/chart-regular}}]
   (let [{:keys [stroke-width stroke-width-emphasis]} chart]
@@ -293,10 +288,10 @@
 ;; ---- transition-edge ----------------------------------------------------
 
 (defn- transition-edge*
-  "The non-entry transition-edge body (rf2-i9d2ob split). Renders the
-  routed path + label for a real transition edge. `transition-edge`
-  dispatches here for every edge except the initial-marker entry edge
-  (which now paints nothing — the glyph lives on the marker node)."
+  "The non-entry transition-edge body. Renders the routed path + label
+  for a real transition edge. `transition-edge` dispatches here for every
+  edge except the initial-marker entry edge (which paints nothing — the
+  glyph lives on the marker node)."
   [^js props]
   (let [src-x      (.-sourceX props)
         src-y      (.-sourceY props)
@@ -308,34 +303,34 @@
         d          (.-data props)
         vc         (chart-constants d)
         ct         (palette-of d)
-        ;; rf2-az6e2 — the quiet source→event half of the events-as-nodes
-        ;; route. Paints thinner so the pair reads as one transition.
+        ;; The quiet source→event half of the events-as-nodes route.
+        ;; Paints thinner so the pair reads as one transition.
         quiet?     (boolean (.-quietSegment d))
         label      (or (.-eventLabel d) "")
-        ;; rf2-a2b55 — Stately graph view convention. `eventLineLabel`
-        ;; is the visible-line text (`event [guard]`, no `/ action`);
-        ;; the action ride below as a `+ <action>` pill (`action-str`).
-        ;; Fall back to `label` when the projector didn't thread the
-        ;; line-text (legacy / direct construction).
+        ;; Stately graph view convention. `eventLineLabel` is the
+        ;; visible-line text (`event [guard]`, no `/ action`); the action
+        ;; rides below as a `+ <action>` pill (`action-str`). Falls back
+        ;; to `label` when the projector didn't thread the line-text
+        ;; (direct construction).
         line-label (or (.-eventLineLabel d) label)
         action-str (.-action d)
         active?    (boolean (.-active d))
         focused?   (boolean (.-focused d))
-        ;; rf2-qeemm (G3) — this edge traversed THIS epoch. Drives the
-        ;; FIRED treatment (emphasised + animated stroke, `data-fired`),
-        ;; winning over the focused/active styling per `edge-stroke`.
+        ;; This edge traversed THIS epoch. Drives the FIRED treatment
+        ;; (emphasised + animated stroke, `data-fired`), winning over the
+        ;; focused/active styling per `edge-stroke`.
         fired?     (boolean (.-fired d))
-        ;; rf2-fzrzlw — this edge's guard REJECTED the event this epoch
-        ;; (a guard-blocked no-op: the runtime emitted
+        ;; This edge's guard REJECTED the event this epoch (a guard-
+        ;; blocked no-op: the runtime emitted
         ;; `:rf.machine/guard-evaluated` fail/threw but NO transition).
         ;; Drives the PINK guard-blocked treatment (emphasised stroke +
         ;; emphasised guard label, `data-guard-blocked`), winning OUTRIGHT
         ;; over fired/focused/active per `edge-stroke` so the attempted-
-        ;; and-rejected edge stands out (bead design call (2)).
+        ;; and-rejected edge stands out.
         blocked?   (boolean (.-guardBlocked d))
         after-ms   (.-afterMs d)
-        ;; rf2-u422r — on-chart click wiring. `:onClick` is the host
-        ;; callback (e.g. Xray's on-chart sim → sim-step); `:eventId`
+        ;; On-chart click wiring. `:onClick` is the host callback (e.g.
+        ;; Xray's on-chart sim → sim-step); `:eventId`
         ;; is the raw fireable event keyword (nil for `:after` / `:always`
         ;; auto edges). A label is clickable only when BOTH a callback +
         ;; a fireable event-id are present, so auto edges stay inert.
@@ -344,18 +339,17 @@
         from-path  (.-fromPath d)
         to-path    (.-toPath d)
         clickable? (and (fn? on-click) (some? event-id))
-        ;; rf2-shv82 (Issue 3) — cross-hierarchy edge flag. When true +
-        ;; routed, `edge-path` anchors the label near the source-side
-        ;; first bend point (Stately convention) instead of the routed
-        ;; midpoint.
+        ;; Cross-hierarchy edge flag. When true + routed, `edge-path`
+        ;; anchors the label near the source-side first bend point
+        ;; (Stately convention) instead of the routed midpoint.
         cross-hierarchy? (boolean (.-crossHierarchy d))
-        ;; rf2-ee38b.21 — an INTERNAL self-transition (Spec 005:
-        ;; omit :target) runs only :action; :exit / :entry do NOT fire.
-        ;; Render it WITHOUT the re-entry arrowhead + with a dashed loop
-        ;; so it reads as "no exit/entry re-trigger" (Stately parity).
+        ;; An INTERNAL self-transition (Spec 005: omit :target) runs only
+        ;; :action; :exit / :entry do NOT fire. Render it WITHOUT the
+        ;; re-entry arrowhead + with a dashed loop so it reads as "no
+        ;; exit/entry re-trigger" (Stately parity).
         internal?  (boolean (.-internal d))
-        ;; rf2-o3rkq1 — the DECORATIVE dotted evaluation-order connector
-        ;; across a guarded fork's branches (gate's `:gate/check` 3-way).
+        ;; The DECORATIVE dotted evaluation-order connector across a
+        ;; guarded fork's branches (gate's `:gate/check` 3-way).
         ;; Render as a QUIET DOTTED line with NO arrowhead + NO label so it
         ;; reads as the order annotation Stately draws between the numbered
         ;; branches (1→2→3) — never a transition. The projector emits it
@@ -363,43 +357,42 @@
         ;; no route `:points` and falls back to a straight handle-to-handle
         ;; line painted dotted.
         fork-connector? (boolean (.-forkConnector d))
-        ;; G-START — the initial-marker entry edge (dot → initial state).
-        ;; Paints the neutral `:pseudo-marker` hue (matching the dot +
-        ;; the projector's arrowhead) so the dot + short arrow read as
-        ;; one clearly-visible unit, the SCXML/Stately initial icon.
+        ;; The initial-marker entry edge (dot → initial state). Paints the
+        ;; neutral `:pseudo-marker` hue (matching the dot + the
+        ;; projector's arrowhead) so the dot + short arrow read as one
+        ;; clearly-visible unit, the SCXML/Stately initial icon.
         entry?     (boolean (.-entry d))
-        ;; rf2-cz8v6 (G2) — elk's routed bend-points (absolute coords),
-        ;; a JS array of `#js {:x :y}`. Present only when elk computed a
-        ;; multi-point route; nil for a simple edge (bezier fallback).
+        ;; elk's routed bend-points (absolute coords), a JS array of
+        ;; `#js {:x :y}`. Present only when elk computed a multi-point
+        ;; route; nil for a simple edge (bezier fallback).
         points     (.-points d)
-        ;; rf2-rlq97 — elk's COMPUTED label position (a `#js {:x :y}`,
-        ;; absolute coords) for a labelled edge; nil under events-as-nodes
-        ;; (the label rides on the event-node so the edge carries none).
-        ;; When present, `edge-path` anchors the label here — elk's
-        ;; reserved channel — instead of the geometric midpoint heuristic.
+        ;; elk's COMPUTED label position (a `#js {:x :y}`, absolute coords)
+        ;; for a labelled edge; nil under events-as-nodes (the label rides
+        ;; on the event-node so the edge carries none). When present,
+        ;; `edge-path` anchors the label here — elk's reserved channel —
+        ;; instead of the geometric midpoint heuristic.
         label-pos  (let [lp (.-labelPos d)]
                      (when lp {:x (.-x lp) :y (.-y lp)}))
-        ;; rf2-o6vh7 — multi-event sibling-collapse RETIRED. Under
-        ;; events-as-nodes every parsed transition is its OWN event-node,
-        ;; so same-`[source target]` transitions stay DISTINCT edges (one
-        ;; arrow each). There is no leader/follower grouping; every edge
-        ;; renders its path + label at the geometric anchor.
+        ;; Under events-as-nodes every parsed transition is its OWN
+        ;; event-node, so same-`[source target]` transitions stay DISTINCT
+        ;; edges (one arrow each). There is no leader/follower grouping;
+        ;; every edge renders its path + label at the geometric anchor.
         {:keys [edge-label-px
                 action-pill-height action-pill-pad-x action-pill-px
                 action-pill-radius action-pill-row-gap]} vc
-        ;; rf2-cz8v6 (G2) — path selection lives in the pure `edge-path`
-        ;; helper (elk route → bezier), so the test suite pins the SAME
-        ;; geometry the renderer paints.
+        ;; Path selection lives in the pure `edge-path` helper (elk route
+        ;; → bezier), so the test suite pins the SAME geometry the
+        ;; renderer paints.
         {path :d label-x :label-x label-y :label-y routed? :routed?}
         (edge-path {:src-x src-x :src-y src-y
                     :tgt-x tgt-x :tgt-y tgt-y
                     :src-pos src-pos :tgt-pos tgt-pos
                     :points points
                     :cross-hierarchy? cross-hierarchy?
-                    ;; rf2-rlq97 — elk's computed label placement (nil →
-                    ;; geometric heuristic fallback).
+                    ;; elk's computed label placement (nil → geometric
+                    ;; heuristic fallback).
                     :label-pos label-pos})
-        ;; rf2-o3rkq1 — the decorative fork connector paints the neutral
+        ;; The decorative fork connector paints the neutral
         ;; `:pseudo-marker` hue (the same quiet order-annotation hue the
         ;; numbered badge uses), NOT a runtime edge colour; every other
         ;; edge resolves its hue from its runtime flags.
@@ -412,39 +405,40 @@
                                      :quiet? quiet? :chart vc})]
     (r/as-element
       [:<>
-       ;; rf2-o6vh7 — every edge renders its own SVG path + arrowhead.
-       ;; Sibling-collapse is retired: distinct event-nodes mean distinct
-       ;; arrows, so there is no path-suppression for "follower" edges.
+       ;; Every edge renders its own SVG path + arrowhead: distinct
+       ;; event-nodes mean distinct arrows, so there is no path-
+       ;; suppression for "follower" edges.
        [:> BaseEdge {:id (.-id props)
                      :path path
                      ;; Internal self-transitions suppress the arrowhead
-                     ;; (no exit/entry re-trigger to point back at);
-                     ;; rf2-o3rkq1 — the decorative fork connector likewise
-                     ;; carries NO arrowhead (it is an order annotation, not
-                     ;; a transition).
+                     ;; (no exit/entry re-trigger to point back at); the
+                     ;; decorative fork connector likewise carries NO
+                     ;; arrowhead (it is an order annotation, not a
+                     ;; transition).
                      :markerEnd (when-not (or internal? fork-connector?) marker-end)
                      :style #js {:stroke stroke
                                  :strokeWidth stroke-w
-                                 ;; rf2-o3rkq1 — the fork connector is DOTTED
-                                 ;; (a tight 1·3 dot pattern, distinct from
-                                 ;; the internal self-transition's 4·3 dash)
+                                 ;; The fork connector is DOTTED (a tight
+                                 ;; 1·3 dot pattern, distinct from the
+                                 ;; internal self-transition's 4·3 dash)
                                  ;; matching Stately's dotted order chain.
                                  :strokeDasharray (cond
                                                     fork-connector? "1 3"
                                                     internal?       "4 3"
                                                     :else           nil)
                                  :strokeLinecap (when fork-connector? "round")
-                                 ;; rf2-qeemm (G3) — the fired-this-epoch edge
-                                 ;; flashes the same glow as the focused lens
-                                 ;; (it traversed), so a fired arm that is NOT
-                                 ;; the focused FROM→TO still glows.
-                                 ;; rf2-4o43j8 — the glow is event-driven +
-                                 ;; FINITE: ONE motion-scaled iteration that
-                                 ;; settles to a stable end-state (no `infinite`
+                                 ;; The fired-this-epoch edge flashes the
+                                 ;; same glow as the focused lens (it
+                                 ;; traversed), so a fired arm that is NOT
+                                 ;; the focused FROM→TO still glows. The
+                                 ;; glow is event-driven + FINITE: ONE
+                                 ;; motion-scaled iteration that settles to
+                                 ;; a stable end-state (no `infinite`
                                  ;; strobe) and collapses to a settle frame
-                                 ;; under `prefers-reduced-motion`. The static
-                                 ;; fired/focused affordance (stroke width/hue
-                                 ;; above) persists after it completes.
+                                 ;; under `prefers-reduced-motion`. The
+                                 ;; static fired/focused affordance (stroke
+                                 ;; width/hue above) persists after it
+                                 ;; completes.
                                  :animation (when (or focused? fired?)
                                               (tokens/glow-animation-css))}}]
        (when (seq label)
@@ -453,37 +447,37 @@
                :data-event (when label label)
                :data-active (str active?)
                :data-focused-edge (str focused?)
-               ;; rf2-qeemm (G3) — DOM pin for the fired-this-epoch edge
-               ;; treatment; tests + hosts read it to find the traversed arm.
+               ;; DOM pin for the fired-this-epoch edge treatment; tests +
+               ;; hosts read it to find the traversed arm.
                :data-fired (str fired?)
-               ;; rf2-fzrzlw / rf2-bdwolc — this edge-LABEL `data-guard-
-               ;; blocked` attr is emitted ONLY when the edge carries a
-               ;; non-empty `:eventLabel` (this whole `<div>` is gated on
-               ;; `(when (seq label) …)`). Under events-as-nodes the
-               ;; `__in`/`__out` halves carry an EMPTY label (the text rides
-               ;; the event-NODE), so NO edge-half `data-guard-blocked` attr
-               ;; is emitted — it is NOT the canonical guard-blocked DOM pin.
-               ;; The CANONICAL pins are the event-node (`data-guard-blocked`,
-               ;; unconditional) + the chart root (`data-guard-blocked-edge-
-               ;; ids`); this attr only surfaces for a (rare) labelled edge.
+               ;; This edge-LABEL `data-guard-blocked` attr is emitted
+               ;; ONLY when the edge carries a non-empty `:eventLabel`
+               ;; (this whole `<div>` is gated on `(when (seq label) …)`).
+               ;; Under events-as-nodes the `__in`/`__out` halves carry an
+               ;; EMPTY label (the text rides the event-NODE), so NO edge-
+               ;; half `data-guard-blocked` attr is emitted — it is NOT the
+               ;; canonical guard-blocked DOM pin. The CANONICAL pins are
+               ;; the event-node (`data-guard-blocked`, unconditional) +
+               ;; the chart root (`data-guard-blocked-edge-ids`); this attr
+               ;; only surfaces for a (rare) labelled edge.
                :data-guard-blocked (str blocked?)
                :data-after-ms (when after-ms (str after-ms))
-               ;; rf2-ee38b.21 — surface internal / machine-level so the
-               ;; DOM suite + a host can distinguish self-transition kind
-               ;; + inherited fallbacks.
+               ;; Surface internal / machine-level so the DOM suite + a
+               ;; host can distinguish self-transition kind + inherited
+               ;; fallbacks.
                :data-internal (str internal?)
-               ;; rf2-cz8v6 (G2) — surface whether this edge rendered
-               ;; along elk's bend-point route (true) or fell back to
-               ;; the bezier (false), so the DOM suite can pin routing.
+               ;; Surface whether this edge rendered along elk's bend-point
+               ;; route (true) or fell back to the bezier (false), so the
+               ;; DOM suite can pin routing.
                :data-routed (str routed?)
-               ;; rf2-shv82 (Issue 3) — cross-hierarchy flag the label-
-               ;; placement adjustment reads; surfaced so the DOM suite
-               ;; can pin label-anchor-near-source-bend behaviour.
+               ;; Cross-hierarchy flag the label-placement adjustment
+               ;; reads; surfaced so the DOM suite can pin label-anchor-
+               ;; near-source-bend behaviour.
                :data-cross-hierarchy (str cross-hierarchy?)
                :data-machine-level (str (boolean (.-machineLevel d)))
-               ;; rf2-u422r — clickable edges surface their fireable
-               ;; event-id so a host (Xray on-chart sim) + tests can
-               ;; address them; inert (auto / no-callback) edges omit it.
+               ;; Clickable edges surface their fireable event-id so a host
+               ;; (Xray on-chart sim) + tests can address them; inert
+               ;; (auto / no-callback) edges omit it.
                :data-clickable (str clickable?)
                :data-event-id (when (and clickable? event-id)
                                 (str event-id))
@@ -507,12 +501,12 @@
                        :font-family    chart-label-stack
                        :font-size      (str edge-label-px "px")
                        :font-weight    (if (and clickable? focused?) 600 400)
-                       ;; rf2-az6e2 — the rare labelled-edge backplate
-                       ;; (entry / after edges; events ride the event-NODE
-                       ;; under events-as-nodes so most edges carry no
-                       ;; label) reads the neutral event-chip fill/border
-                       ;; from the active-theme tokens so it punches through
-                       ;; overlapping ink with the surrounding background.
+                       ;; The rare labelled-edge backplate (entry / after
+                       ;; edges; events ride the event-NODE under events-
+                       ;; as-nodes so most edges carry no label) reads the
+                       ;; neutral event-chip fill/border from the active-
+                       ;; theme tokens so it punches through overlapping ink
+                       ;; with the surrounding background.
                        :color          (:text-primary ct)
                        :background     (:event-chip-bg ct)
                        :padding        "2px 6px"
@@ -521,25 +515,24 @@
                                             (if clickable?
                                               (:sim ct)
                                               (:event-chip-border ct)))
-                       ;; rf2-j10sm (Phase 1, D) — z-index bump. The edge
-                       ;; label sits above edges + node borders but below
-                       ;; interactive controls (xyflow's Controls render at
-                       ;; z 6+). A modest 5 reads as "label is the focus
-                       ;; you must be able to scan" without blocking the
-                       ;; built-in chrome.
+                       ;; The edge label sits above edges + node borders
+                       ;; but below interactive controls (xyflow's Controls
+                       ;; render at z 6+). A modest 5 reads as "label is the
+                       ;; focus you must be able to scan" without blocking
+                       ;; the built-in chrome.
                        :z-index        5
                        :white-space    "nowrap"
                        :user-select    "none"
-                       ;; rf2-a2b55 — when an action pill rides below the
-                       ;; event line, stack them vertically inside the
-                       ;; backplate so the pill participates in the same
-                       ;; collision-avoidance unit as the line text.
+                       ;; When an action pill rides below the event line,
+                       ;; stack them vertically inside the backplate so the
+                       ;; pill participates in the same collision-avoidance
+                       ;; unit as the line text.
                        :display        "inline-flex"
                        :flex-direction "column"
                        :align-items    "center"
                        :gap            (when action-str (str action-pill-row-gap "px"))}}
-         ;; rf2-a2b55 — visible event line: event + guard, no
-         ;; `/ action`. The action paints as a pill on the row below.
+         ;; Visible event line: event + guard, no `/ action`. The action
+         ;; paints as a pill on the row below.
          [:span {:data-testid (str "rf-mv-chart-edge-event-" (.-id props))
                  :data-event-line line-label}
           line-label]
@@ -567,15 +560,15 @@
   + state flags. Returns a `<BaseEdge>` + a label renderer in a
   React fragment.
 
-  rf2-i9d2ob — the initial-marker ENTRY edge (`entry?`) paints NOTHING:
-  the whole initial-state glyph (filled dot + Q-hook + triangle arrow)
-  is now a FIXED node-local shape drawn by `chart.nodes/initial-marker`,
-  independent of ELK / xyflow edge routing (which bent the old bezier
-  entry edge oddly when the initial sat at an odd position). The edge is
-  retained in the projection ONLY for the every-edge `:data` invariants;
-  here it short-circuits to an empty fragment so no second arrow / curve
-  competes with the node glyph. Every other edge dispatches to
-  `transition-edge*` (the routed-path body)."
+  The initial-marker ENTRY edge (`entry?`) paints NOTHING: the whole
+  initial-state glyph (filled dot + Q-hook + triangle arrow) is a FIXED
+  node-local shape drawn by `chart.nodes/initial-marker`, independent of
+  ELK / xyflow edge routing (a bezier-routed entry edge bends oddly when
+  the initial sits at an odd position). The edge is retained in the
+  projection ONLY for the every-edge `:data` invariants; here it short-
+  circuits to an empty fragment so no second arrow / curve competes with
+  the node glyph. Every other edge dispatches to `transition-edge*` (the
+  routed-path body)."
   [^js props]
   (let [data0 (.-data props)]
     (if (and data0 (.-entry data0))
@@ -590,11 +583,9 @@
   component-construction time to avoid re-render churn.
 
   Only `transition` is registered — under events-as-nodes EVERY
-  projected edge is the canonical `transition` type (rf2-dt5b1). The
-  `:after`-timer specifics ride the event-NODE (`:variant \"after\"`
-  + `:afterMs`), not a distinct edge type; the dead `after` alias +
-  the `choose-edge-type` classifier it depended on were removed. There
-  is no `spawn` type either (rf2-0gmwp): spawns are state-entry
-  actions, not edges (see the ns docstring)."
+  projected edge is the canonical `transition` type. The `:after`-timer
+  specifics ride the event-NODE (`:variant \"after\"` + `:afterMs`), not
+  a distinct edge type. There is no `spawn` type either: spawns are
+  state-entry actions, not edges (see the ns docstring)."
   []
   #js {"transition" transition-edge})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout_error.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout_error.cljc
@@ -1,22 +1,20 @@
 (ns day8.re-frame2-machines-viz.chart.layout-error
-  "rf2-4lyvh — pure helpers for the ELK layout-failure surface.
+  "Pure helpers for the ELK layout-failure surface.
 
-  Before rf2-4lyvh, `chart/compute-layout!` swallowed both the sync
-  `(catch :default _ nil)` around `(.layout elk-instance input)` AND
-  the async `(.catch (fn [_e] (done-fn nil)))` on the returned promise.
-  The downstream `(when result ...)` guard at the callsite then no-
-  op'd, leaving `layout-state` at its initial empty shape; every
-  rendered node fell back to (0, 0). Operators saw stacked boxes with
-  no diagnostic.
+  When `chart/compute-layout!` hits an ELK error — either the sync
+  throw around `(.layout elk-instance input)` or an async promise
+  rejection — it hands `done-fn` a non-nil result-map carrying a
+  `:layout-error`, so the downstream `(when result ...)` guard still
+  fires and the projector paints an in-panel diagnostic banner rather
+  than silently falling back to (0, 0)-stacked boxes.
 
-  This namespace owns the pure side of the fix — the input-summary,
-  the JS-error → CLJS-data adapter, and the result-map builder the
-  `done-fn` callback receives on failure. The side-effects (trace
-  emit + dev-only `console.error`) stay in `chart.cljs` next to the
-  elkjs interop; this ns is split out so the .cljc test corpus can
-  pin the data shape without loading xyflow / elkjs (mirroring the
-  rf2-0gmwp split that moved the pure projector into
-  `chart.projection`).
+  This namespace owns the pure side of that surface — the
+  input-summary, the JS-error → CLJS-data adapter, and the result-map
+  builder the `done-fn` callback receives on failure. The side-effects
+  (trace emit + dev-only `console.error`) stay in `chart.cljs` next to
+  the elkjs interop; this ns is split out so the .cljc test corpus can
+  pin the data shape without loading xyflow / elkjs (the same split
+  posture that keeps the pure projector in `chart.projection`).
 
   ## Shapes
 
@@ -95,9 +93,9 @@
   commit) plus `:layout-error` so the chart can paint the in-panel
   indicator banner. Pure fn.
 
-  rf2-rlq97 — `:edge-labels` mirrors the success-path
-  `elk-result->positions` shape (elk's computed edge-label positions);
-  empty on failure, same as `:edge-points`."
+  `:edge-labels` mirrors the success-path `elk-result->positions` shape
+  (elk's computed edge-label positions); empty on failure, same as
+  `:edge-points`."
   [error parsed direction layout-options]
   {:positions    {}
    :edge-points  {}

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -1,10 +1,10 @@
 (ns day8.re-frame2-machines-viz.chart.nodes
   "Custom xyflow node components for the MachineChart.
 
-  rf2-gpzb4 (2026-05-21 xyflow override) — these components recover
-  the Xray visual identity (rounded-rect node body, state-tag pills,
-  final-state double border, active-state cyan tint + emphasised
-  stroke) on top of xyflow's React node-rendering pipeline.
+  These components carry the Xray visual identity (rounded-rect node
+  body, state-tag pills, final-state double border, active-state cyan
+  tint + emphasised stroke) on top of xyflow's React node-rendering
+  pipeline.
 
   Each component is a plain JS-compatible function that destructures
   the xyflow `:data` prop and renders Reagent hiccup wrapped in
@@ -13,7 +13,7 @@
   components sit invisibly on the node sides via the `:>` React-
   interop syntax so edges attach consistently.
 
-  ## Node kinds (per the bead's scope §Custom nodes)
+  ## Node kinds
 
     - `state-node` — the canonical state node. Reads `:data {:label
       :path :active? :final? :tags :on-click ...}` and renders
@@ -22,29 +22,26 @@
       large body containing nested children (xyflow's `parentId`
       mechanic handles the hierarchical layout; this node renders
       the outer container chrome). Carries invisible source+target
-      `Handle`s on all four sides (rf2-shv82) so xstate/Stately-style
-      PARENT-LEVEL TRANSITIONS (`:active → :disconnected`, `:active`
-      self-loop, `:failed → :active`) render as edges anchored to the
-      compound's BORDER. Without handles `getEdgePosition` returns
-      nil for any edge whose endpoint is a compound, and xyflow
-      silently drops the edge from the DOM — the gap rf2-shv82
-      closes.
+      `Handle`s on all four sides so xstate/Stately-style PARENT-LEVEL
+      TRANSITIONS (`:active → :disconnected`, `:active` self-loop,
+      `:failed → :active`) render as edges anchored to the compound's
+      BORDER. Without handles `getEdgePosition` returns nil for any edge
+      whose endpoint is a compound, and xyflow silently drops the edge
+      from the DOM.
     - `initial-marker` — a small glyph node paired with the initial
       state to mark the machine's entry transition. (Final states paint
-      a quiet doubled ring inline on `state-node` — no glyph
-      (rf2-az6e2 dropped the ✓); there is no separate final-marker
-      node — rf2-ee38b.21 removed the dead one.)
+      a quiet doubled ring inline on `state-node` — no glyph; there is
+      no separate final-marker node.)
 
   ## Token integration
 
   All colours read from `theme/tokens` so a future palette swap
-  flows through unchanged. Per the rf2-on4cm `var(--*)` landing the
-  tokens themselves resolve through CSS custom properties; no hex
-  literals appear in this ns.
+  flows through unchanged. The tokens themselves resolve through CSS
+  custom properties (`var(--*)`); no hex literals appear in this ns.
 
-  ## Substrate posture (Phase 1, per bead)
+  ## Substrate posture
 
-  Reagent-only. UIx and Helix adapters are follow-on beads — xyflow
+  Reagent-only. UIx and Helix adapters are follow-on work — xyflow
   is a React lib so the underlying React-class boundary is fine for
   every substrate; only the Reagent `as-element` glue needs a
   substrate-specific shim."
@@ -64,14 +61,14 @@
 
 ;; ---- density-resolved constants -----------------------------------------
 ;;
-;; rf2-k647w — the renderer no longer hardcodes geometry/typography. The
+;; The renderer reads geometry/typography from the resolved density. The
 ;; projector threads the resolved density's `visual-constants` map onto
 ;; every node payload as `:data {:chart {...}}`; xyflow `clj->js`-es the
 ;; node array, so the map arrives as a JS object. `chart-constants`
 ;; (shared via `chart.nodes.xyflow-node`) recovers a kebab-keyword CLJS
 ;; map, falling back to `vc/chart-regular` so a node payload without a
-;; `:chart` entry (legacy / direct construction) still renders the
-;; regular default.
+;; `:chart` entry (direct construction) still renders the regular
+;; default.
 
 ;; ---- xyflow Handle adapter ----------------------------------------------
 ;;
@@ -81,26 +78,26 @@
 
 ;; ---- node-size floor constants ------------------------------------------
 ;;
-;; rf2-kra7h — single-sourced from `chart.projection`. The elk projection
-;; and these CSS `min-width` / `min-height` floors MUST agree (the
-;; laid-out slot vs. the measured box), so they live in one canonical,
-;; JVM-readable home (`projection`, the pure layer the projection tests
-;; pin) and the renderer reads them via `projection/<name>`.
+;; Single-sourced from `chart.projection`. The elk projection and these
+;; CSS `min-width` / `min-height` floors MUST agree (the laid-out slot
+;; vs. the measured box), so they live in one canonical, JVM-readable
+;; home (`projection`, the pure layer the projection tests pin) and the
+;; renderer reads them via `projection/<name>`.
 
 ;; ---- helpers ------------------------------------------------------------
 ;;
-;; rf2-az6e2 — the structured grammar reads STRUCTURE, not annotation
-;; colour: a resting state node is neutral (body bg + neutral border),
-;; and runtime state (active / focused-event lens / sim) drives the
-;; BORDER + HEADER + GLOW, NOT the whole fill. So `node-border` swaps the
-;; resting border for the runtime accent while the body fill stays
-;; neutral; only `state-header-bg` picks up a faint runtime tint so the
-;; title strip reads as "this is where we are".
+;; The structured grammar reads STRUCTURE, not annotation colour: a
+;; resting state node is neutral (body bg + neutral border), and runtime
+;; state (active / focused-event lens / sim) drives the BORDER + HEADER +
+;; GLOW, NOT the whole fill. So `node-border` swaps the resting border
+;; for the runtime accent while the body fill stays neutral; only
+;; `state-header-bg` picks up a faint runtime tint so the title strip
+;; reads as "this is where we are".
 
 (defn- node-border
-  "rf2-az6e2 — the resting border is the neutral structural colour; a
-  runtime state (active / focus lens / sim) swaps it for the runtime
-  accent so the border carries the signal, not the fill."
+  "The resting border is the neutral structural colour; a runtime state
+  (active / focus lens / sim) swaps it for the runtime accent so the
+  border carries the signal, not the fill."
   [ct {:keys [active? from-highlight? to-highlight? sim?]}]
   (cond
     sim?            (:sim ct)
@@ -110,9 +107,9 @@
     :else           (:state-border ct)))
 
 (defn- header-bg
-  "rf2-az6e2 — the title strip's fill. Neutral by default; a faint
-  runtime wash when active / focused so the header reads the runtime
-  signal without flooding the whole node fill."
+  "The title strip's fill. Neutral by default; a faint runtime wash when
+  active / focused so the header reads the runtime signal without
+  flooding the whole node fill."
   [ct {:keys [active? from-highlight? to-highlight? sim?]}]
   (cond
     sim?            (:sim-wash ct)
@@ -122,11 +119,10 @@
     :else           (:state-header-bg ct)))
 
 (defn- tag-label
-  "rf2-vcnvj — render a state-tag's DECLARED identity as a string,
-  PRESERVING the namespace. A `:door/open` tag reads `door/open`, not
-  the truncated `open` — the bead's tag-identity fix. The pre-vcnvj
-  `(name tag)` dropped the namespace, collapsing `:door/open`,
-  `:lift/open`, … to the same visible `open`.
+  "Render a state-tag's DECLARED identity as a string, PRESERVING the
+  namespace. A `:door/open` tag reads `door/open`, not the truncated
+  `open`, so `:door/open`, `:lift/open`, … stay distinct rather than
+  collapsing to the same visible `open`.
 
   The projector (`chart.projection`) already stringifies each tag to
   its fully-qualified form (`\"door/open\"`) BEFORE xyflow `clj->js`-es
@@ -145,7 +141,7 @@
   "The `data-testid` segment for a tag chip. A `/` in a testid breaks
   CSS / Playwright selectors, so collapse a namespaced tag to its
   trailing `name` segment (`door/open` → `open`). The full identity
-  stays on `data-tag` / `title` for host introspection (rf2-vcnvj)."
+  stays on `data-tag` / `title` for host introspection."
   [tag]
   (let [label (tag-label tag)
         idx   (.lastIndexOf label "/")]
@@ -158,14 +154,13 @@
   introspection) attrs. Returns `nil` when the set is empty so the
   title attr is simply omitted (no \"\" tooltip flicker).
 
-  rf2-so5b0 retired the visible per-tag pill row; rf2-a2b55 reinstates
-  it BELOW the state name (Stately graph view convention) via the
-  `tag-pill` helper. The title + data-tags attrs remain so the host
-  inspector + DOM introspection still resolve a state's tags in
-  bulk without parsing the per-pill DOM.
+  The visible per-tag pill row sits BELOW the state name (Stately graph
+  view convention) via the `tag-pill` helper. The title + data-tags
+  attrs let the host inspector + DOM introspection resolve a state's tags
+  in bulk without parsing the per-pill DOM.
 
-  rf2-vcnvj — uses `tag-label` so the namespaced tag identity
-  (`door/open`) survives here too, matching the visible pill."
+  Uses `tag-label` so the namespaced tag identity (`door/open`) survives
+  here too, matching the visible pill."
   [tags]
   (when (seq tags)
     (->> tags
@@ -174,19 +169,18 @@
          (str/join " "))))
 
 (defn- tag-pill
-  "rf2-az6e2 — render a single state-tag chip in ONE NEUTRAL style.
-  Structure wins over annotation colour: the prior deterministic colour
-  rotation (rf2-a2b55) is dropped for the topology view so the eye reads
-  the chart's STRUCTURE (containment + transition flow), not a rainbow
-  of tag hues. Tag IDENTITY is preserved in the `data-tag` / `title`
-  attrs + the state-node's `data-tags` + the inspector surfaces, so host
-  introspection + hover still resolve every tag.
+  "Render a single state-tag chip in ONE NEUTRAL style. Structure wins
+  over annotation colour: the topology view uses no colour rotation so
+  the eye reads the chart's STRUCTURE (containment + transition flow),
+  not a rainbow of tag hues. Tag IDENTITY is preserved in the `data-tag`
+  / `title` attrs + the state-node's `data-tags` + the inspector
+  surfaces, so host introspection + hover still resolve every tag.
 
-  rf2-vcnvj — the VISIBLE label + the `data-tag` attr now preserve the
-  DECLARED tag identity (`door/open`, not the truncated `open`) via
-  `tag-label`. The `data-testid` keeps the namespace-collapsed `name`
-  segment (a `/` in a testid breaks CSS / Playwright selectors) — host
-  introspection reads the full identity off `data-tag` / `title`.
+  The VISIBLE label + the `data-tag` attr preserve the DECLARED tag
+  identity (`door/open`, not the truncated `open`) via `tag-label`. The
+  `data-testid` keeps the namespace-collapsed `name` segment (a `/` in a
+  testid breaks CSS / Playwright selectors) — host introspection reads
+  the full identity off `data-tag` / `title`.
 
   Geometry + typography read off the resolved density `vc` map; colour
   is the neutral container-header fill + the structural border + the
@@ -216,19 +210,19 @@
      label]))
 
 (defn- action-row
-  "rf2-az6e2 — render an entry / exit action METADATA ROW: a quiet
-  section caption (\"Entry actions\" / \"Exit actions\") plus a subdued
-  action chip carrying a bolt glyph + the action name. The chip stays
-  SUBORDINATE to the state title (quieter colour + smaller type). Reads
+  "Render an entry / exit action METADATA ROW: a quiet section caption
+  (\"Entry actions\" / \"Exit actions\") plus a subdued action chip
+  carrying a bolt glyph + the action name. The chip stays SUBORDINATE to
+  the state title (quieter colour + smaller type). Reads
   geometry/typography off the resolved density `vc` map and colour off
   the active-theme `ct`.
 
-  rf2-skhlw2.1 — when the named lifecycle action declares
-  `:rf.cofx/requires` (EP-0017 consumer attachment), append a quiet
-  `needs <id>` annotation + a `data-{entry,exit}-requires` DOM pin so a
-  reader sees the replay-critical host facts the action consumes. `requires`
-  is the CLJS vec of compact id strings, or nil — an action with no diet
-  renders exactly as before."
+  When the named lifecycle action declares `:rf.cofx/requires` (EP-0017
+  consumer attachment), append a quiet `needs <id>` annotation + a
+  `data-{entry,exit}-requires` DOM pin so a reader sees the replay-
+  critical host facts the action consumes. `requires` is the CLJS vec of
+  compact id strings, or nil — an action with no diet renders without the
+  annotation."
   [{:keys [kind name-str requires vc ct]}]
   (let [{:keys [action-pill-height action-pill-pad-x action-pill-px
                 action-pill-radius action-caption-px action-caption-gap]} vc
@@ -243,16 +237,14 @@
             (seq requires)
             (assoc (case kind :entry :data-entry-requires :exit :data-exit-requires)
                    (str/join " " requires)))
-     ;; rf2-vcnvj — quiet TITLE-CASE caption ("Entry actions" / "Exit
-     ;; actions"), NOT uppercase. The uppercase transform competed with
-     ;; the state title for attention against the structure-first grammar;
-     ;; the caption is a quiet section label, so it reads in natural case.
-     ;; rf2-ly51l — drop the 600 weight + 0.02em letter-spacing: the
-     ;; bolded, tracked caption still read as a loud label competing with
-     ;; the action chip below it. A normal-weight, un-tracked, tertiary-
-     ;; colour caption is the QUIETEST tier of the topology type hierarchy
-     ;; (state title > event chip > action chip > tag pill > section
-     ;; caption), so it reads as a section hint, not a heading.
+     ;; Quiet TITLE-CASE caption ("Entry actions" / "Exit actions"), NOT
+     ;; uppercase: the caption is a quiet section label, so it reads in
+     ;; natural case rather than competing with the state title for
+     ;; attention against the structure-first grammar. Normal weight, no
+     ;; letter-spacing, tertiary colour — the QUIETEST tier of the
+     ;; topology type hierarchy (state title > event chip > action chip >
+     ;; tag pill > section caption), so it reads as a section hint, not a
+     ;; heading.
      [:span {:style {:font-family    chart-label-stack
                      :font-size      (str action-caption-px "px")
                      :font-weight    400
@@ -277,11 +269,11 @@
       ;; subordinate bolt/action glyph (text convention — no icon dep)
       [:span {:style {:opacity 0.7}} "⚡"]
       name-str]
-     ;; rf2-skhlw2.1 — the consumer-attachment requirement annotation: a
-     ;; quiet italic `needs <id>` line surfacing the lifecycle action's
-     ;; declared `:rf.cofx/requires` (EP-0017). The QUIETEST tier (tertiary
-     ;; colour, caption type, italic), subordinate to the action chip;
-     ;; rendered ONLY when the action declared a non-empty diet.
+     ;; The consumer-attachment requirement annotation: a quiet italic
+     ;; `needs <id>` line surfacing the lifecycle action's declared
+     ;; `:rf.cofx/requires` (EP-0017). The QUIETEST tier (tertiary colour,
+     ;; caption type, italic), subordinate to the action chip; rendered
+     ;; ONLY when the action declared a non-empty diet.
      (when (seq requires)
        [:span {:data-testid (case kind
                               :entry "rf-mv-chart-state-entry-requires"
@@ -297,14 +289,14 @@
 ;; ---- state node ---------------------------------------------------------
 
 (defn state-node
-  "rf2-az6e2 — Reagent component for a leaf state node, rendered as a
-  STRUCTURED TITLE/BODY BOX (not a centred rounded pill). xyflow invokes
-  this via `nodeTypes={:state state-node}`; we read the projected `:data`
-  off the JS props.
+  "Reagent component for a leaf state node, rendered as a STRUCTURED
+  TITLE/BODY BOX (not a centred rounded pill). xyflow invokes this via
+  `nodeTypes={:state state-node}`; we read the projected `:data` off the
+  JS props.
 
   Structure:
 
-    - Square-ish box, low radius (the rf2-g6cig 6px lock).
+    - Square-ish box, low radius (6px).
     - A full-width TITLE STRIP carrying the state label, LEFT-aligned,
       sans font (`chart-label-stack`).
     - A title/body DIVIDER (hairline) when body content exists.
@@ -319,10 +311,9 @@
       glow ring.
     - from-highlight (focus lens origin): focus accent border + wash.
     - sim: amber accent.
-    - final: a QUIET double border (outer ring). The prior ✓ check glyph
-      is DROPPED (rf2-az6e2 decision recorded in the bead) — the doubled
-      border is the unambiguous final-state signal and the glyph competed
-      with the title for attention.
+    - final: a QUIET double border (outer ring), with no check glyph —
+      the doubled border is the unambiguous final-state signal and a
+      glyph would compete with the title for attention.
 
   Tag identity (`data-tags` / per-chip `data-tag` / `title`) + the
   `data-active*` / `data-state-path` attrs are PRESERVED for the DOM
@@ -338,19 +329,19 @@
         to-highlight?  (boolean (.-toHighlight d))
         sim?           (boolean (.-sim d))
         final?         (boolean (.-final d))
-        ;; rf2-b4loj — error-terminal KIND. An `:error?` final (a re-frame2
-        ;; EXTENSION that routes the spawning parent's `:on-error` rather
-        ;; than `:on-done`) paints its outer ring in the error hue so the
-        ;; chart does not hide a distinction the framework acts on. NOT
+        ;; Error-terminal KIND. An `:error?` final (a re-frame2 EXTENSION
+        ;; that routes the spawning parent's `:on-error` rather than
+        ;; `:on-done`) paints its outer ring in the error hue so the chart
+        ;; does not hide a distinction the framework acts on. NOT
         ;; XState/Stately parity — re-frame2 semantic clarity.
         error-final?   (boolean (.-errorFinal d))
         tags           (js->clj (.-tags d))
         tags-attr      (tag-title-attr tags)
         entry          (.-entry d)
         exit           (.-exit d)
-        ;; rf2-skhlw2.1 — the entry / exit lifecycle action's declared
-        ;; `:rf.cofx/requires` (EP-0017 consumer attachment), a JS array of
-        ;; compact id strings (nil when the action declares no facts).
+        ;; The entry / exit lifecycle action's declared `:rf.cofx/requires`
+        ;; (EP-0017 consumer attachment), a JS array of compact id strings
+        ;; (nil when the action declares no facts).
         entry-reqs     (some-> (.-entryRequires d) js->clj)
         exit-reqs      (some-> (.-exitRequires d) js->clj)
         on-click       (.-onClick d)
@@ -404,14 +395,14 @@
                                          (str "0 0 0 2px " (:glow ct))
                                          (str "0 1px " state-shadow-blur "px rgba(0,0,0,0.25)"))
                      :transition       "border-color 120ms ease, background 120ms ease"}}
-       ;; Final-state double-ring (outer). The ✓ glyph is dropped.
-       ;; rf2-b4loj — the ring COLOUR is conditional on terminal KIND:
-       ;; an `:error?` final paints the static `:final-error` error hue
-       ;; (re-frame2 semantic clarity — it routes the parent's `:on-error`);
-       ;; a success final keeps the QUIET runtime-coupled `border-col`.
-       ;; The main node border (above) STAYS `border-col` either way, so an
-       ;; active error-final composes: error ring + runtime main-border,
-       ;; neither clobbering the other.
+       ;; Final-state double-ring (outer), with no check glyph.
+       ;; The ring COLOUR is conditional on terminal KIND: an `:error?`
+       ;; final paints the static `:final-error` error hue (re-frame2
+       ;; semantic clarity — it routes the parent's `:on-error`); a success
+       ;; final keeps the QUIET runtime-coupled `border-col`. The main node
+       ;; border (above) STAYS `border-col` either way, so an active error-
+       ;; final composes: error ring + runtime main-border, neither
+       ;; clobbering the other.
        (when final?
          [:div {:data-testid (str "rf-mv-chart-final-ring-" (.-id props))
                 :data-error-final (str error-final?)
@@ -480,7 +471,7 @@
   this container; this component only renders the surrounding
   chrome.
 
-  ## Border handles (rf2-shv82)
+  ## Border handles
 
   Invisible source + target `<Handle>` elements sit on all four
   sides so xstate/Stately-style PARENT-LEVEL TRANSITIONS (an edge
@@ -490,8 +481,7 @@
   `getHandleBounds` returns null for the compound node, `isNodeInitialized`
   returns false, `getEdgePosition` returns null, and xyflow SILENTLY
   DROPS every edge incident on a compound from the DOM — even though
-  the projector emitted them and elk routed them (the 5-layer probe
-  trace in the rf2-shv82 bead proves this). Adding handles makes the
+  the projector emitted them and elk routed them. The handles make the
   compound an edge endpoint xstate-style (the edge anchors to the
   compound's BORDER, the way Stately Studio paints parent-level
   arrows). Handles are visually-hidden (`opacity: 0`) so they don't
@@ -502,23 +492,23 @@
         ct    (palette-of d)
         label (or (.-label d) "")
         path  (.-path d)
-        ;; rf2-34ff3 — a compound state is a real statechart state, so its
-        ;; TITLE STRIP is a clickable `:on-state-click` target ("this
-        ;; compound state"). The projector threads `:onClick` onto compound
-        ;; `:data` (leaf + compound only); the body stays pointer-transparent
-        ;; so child-leaf clicks still pass through.
+        ;; A compound state is a real statechart state, so its TITLE STRIP
+        ;; is a clickable `:on-state-click` target ("this compound state").
+        ;; The projector threads `:onClick` onto compound `:data` (leaf +
+        ;; compound only); the body stays pointer-transparent so child-leaf
+        ;; clicks still pass through.
         on-click (.-onClick d)
-        ;; rf2-80rm2 (G4) — a compound CONTAINER whose active descendant
-        ;; leaf lit it (the projector folds that into `:active` via the
-        ;; `:parent-id` chain) gets active chrome: the runtime accent
-        ;; border + glow ring. Inactive compounds read NEUTRAL.
+        ;; A compound CONTAINER whose active descendant leaf lit it (the
+        ;; projector folds that into `:active` via the `:parent-id` chain)
+        ;; gets active chrome: the runtime accent border + glow ring.
+        ;; Inactive compounds read NEUTRAL.
         active? (boolean (.-active d))
         {:keys [compound-radius container-title-height container-title-pad-x
                 container-title-px container-divider-width
                 stroke-width stroke-width-emphasis]} vc
-        ;; rf2-az6e2 — solid SUBTLE NEUTRAL border by default (no dashed,
-        ;; no accent wash — dashed/accent is reserved for parallel
-        ;; regions + runtime state). Active swaps to the runtime accent.
+        ;; Solid SUBTLE NEUTRAL border by default (no dashed, no accent
+        ;; wash — dashed/accent is reserved for parallel regions + runtime
+        ;; state). Active swaps to the runtime accent.
         border-col  (if active? (:active ct) (:container-border ct))
         border-w    (if active? stroke-width-emphasis stroke-width)]
     (r/as-element
@@ -526,23 +516,24 @@
              :data-node-id (.-id props)
              :data-state-path (when path (pr-str (js->clj path)))
              :data-active (str active?)
-             ;; rf2-44v8lq — the painted box FILLS the xyflow node box ELK
-             ;; sized (`width/height:100%`); it carries NO `min-width` /
+             ;; The painted box FILLS the xyflow node box ELK sized
+             ;; (`width/height:100%`); it carries NO `min-width` /
              ;; `min-height`. The compound size floor lives in the ELK input
              ;; (`projection/elk-child` seeds every compound at
              ;; `compound-node-min-{width,height}`, and ELK grows the box to
-             ;; enclose its laid-out children), so the xyflow box delivered via
-             ;; `:style {:width :height}` is already authoritative. A CSS `min-*`
-             ;; here SECOND-GUESSED that box: when ELK legitimately shrinks a
-             ;; deeply-nested compound below the 260×150 seed to HUG its narrow
-             ;; children (hvac `running`/`conditioning`, media `playing`), the
-             ;; `min-*` re-inflated the PAINTED div past its allocated box, so
-             ;; the border overflowed the box — and visually escaped the parent
-             ;; container — while the children (positioned in the real box) sat
-             ;; inside. Dropping the `min-*` lets the painted border track the
-             ;; box exactly, matching the parallel-region node (which never
-             ;; carried a `min-*`, which is why regions always enclosed) and
-             ;; Stately's full-enclosure nesting.
+             ;; enclose its laid-out children), so the xyflow box delivered
+             ;; via `:style {:width :height}` is already authoritative. A CSS
+             ;; `min-*` here would SECOND-GUESS that box: when ELK
+             ;; legitimately shrinks a deeply-nested compound below the
+             ;; 260×150 seed to HUG its narrow children (hvac
+             ;; `running`/`conditioning`, media `playing`), a `min-*` would
+             ;; re-inflate the PAINTED div past its allocated box so the
+             ;; border overflows — visually escaping the parent container —
+             ;; while the children (positioned in the real box) sit inside.
+             ;; Without a `min-*` the painted border tracks the box exactly,
+             ;; matching the parallel-region node (which carries no `min-*`,
+             ;; so regions always enclose) and Stately's full-enclosure
+             ;; nesting.
              :style {:position         "relative"
                      :width            "100%"
                      :height           "100%"
@@ -551,11 +542,11 @@
                      :border-radius    (str compound-radius "px")
                      :box-shadow       (when active?
                                          (str "0 0 0 2px " (:glow ct)))
-                     ;; rf2-shv82 — body stays pointer-transparent so
-                     ;; clicks pass through to nested leaves.
+                     ;; Body stays pointer-transparent so clicks pass
+                     ;; through to nested leaves.
                      :pointer-events   "none"}}
        ;; FULL-WIDTH TITLE STRIP at top — solid neutral header band.
-       ;; rf2-34ff3 — the title strip is the compound state's clickable
+       ;; The title strip is the compound state's clickable
        ;; `:on-state-click` target. It re-enables pointer-events (the body
        ;; sets them to "none" for leaf pass-through), carries the cursor +
        ;; title affordance, and fires `(on-click (js->clj path))` with the
@@ -589,31 +580,28 @@
                       :white-space "nowrap"
                       :overflow    "hidden"
                       :text-overflow "ellipsis"
-                      ;; rf2-34ff3 — re-enable pointer-events on the strip
-                      ;; ONLY (the parent body is `pointer-events:none`); the
-                      ;; cursor signals the affordance when wired.
+                      ;; Re-enable pointer-events on the strip ONLY (the
+                      ;; parent body is `pointer-events:none`); the cursor
+                      ;; signals the affordance when wired.
                       :pointer-events "auto"
                       :cursor      (if on-click "pointer" "default")
                       :user-select "none"}}
         label]
-       ;; rf2-shv82 — invisible xyflow attachment points.
+       ;; Invisible xyflow attachment points.
        (four-cardinal-handles)])))
 
 ;; ---- initial marker node ------------------------------------------------
 
-;; rf2-i9d2ob — fixed initial-state glyph geometry.
+;; Fixed initial-state glyph geometry.
 ;;
 ;; xstate-viz draws the start glyph as a SINGLE FIXED glyph anchored to
 ;; the node, NOT routed by ELK (`src/InitialEdgeViz.tsx`) — which is
-;; exactly why it reads clean in every position. Before this bead xray
-;; emitted the dot as one node + a SEPARATE `transition` entry edge that
-;; the renderer drew as a `getBezierPath` curve between the dot's source
-;; handle and the state's left handle; that bezier bends oddly when the
-;; initial lands in an odd position (e.g. traffic's bottom-anchored
-;; initials). The fix folds the WHOLE glyph (filled dot + single
-;; quadratic Q-hook + a small filled triangle arrowhead) into THIS node's
-;; own SVG, drawn in the node's local coordinate frame, so the geometry
-;; no longer depends on ELK / xyflow edge routing. The companion entry
+;; exactly why it reads clean in every position. The WHOLE glyph (filled
+;; dot + single quadratic Q-hook + a small filled triangle arrowhead)
+;; lives in THIS node's own SVG, drawn in the node's local coordinate
+;; frame, so the geometry does not depend on ELK / xyflow edge routing (a
+;; bezier-routed entry edge bends oddly when the initial lands in an odd
+;; position, e.g. traffic's bottom-anchored initials). The companion entry
 ;; edge still exists in the projection (every-edge `:data` invariants)
 ;; but `chart.edges/transition-edge` paints NO visible path for it
 ;; (`entry?` short-circuit) — the dot + hook + arrow you see is this
@@ -625,15 +613,15 @@
 ;; just OUTSIDE the state's near (left) edge regardless of where ELK placed
 ;; the state.
 ;;
-;; rf2-d5s7yg — the glyph's arrow tip is DECOUPLED from the node offset: the
-;; node sits `initial-marker-x-offset` (26, rf2-k7kiiq) px left of the state so
-;; the dot's CENTRE lands `(offset - dot-x)` px outside the edge — `state.x - 19`
-;; at regular density (`offset 26`, `dot-x = pseudo-radius + 1 = 7`) — but the
-;; tip is drawn at node-local x = `(offset - tip-gap)` so the ABSOLUTE tip lands
-;; at `state.x - tip-gap` — a clean ~`tip-gap`px gap OUTSIDE the edge, pointing
-;; AT it, never into the interior. Before rf2-d5s7yg the arm == offset == 48
-;; drew the tip at `state.x` (the edge) with a too-long arm; on nested initials
-;; xyflow's `:extent "parent"` clamp then shoved it INSIDE the state.
+;; The glyph's arrow tip is DECOUPLED from the node offset: the node sits
+;; `initial-marker-x-offset` (26) px left of the state so the dot's CENTRE
+;; lands `(offset - dot-x)` px outside the edge — `state.x - 19` at regular
+;; density (`offset 26`, `dot-x = pseudo-radius + 1 = 7`) — but the tip is
+;; drawn at node-local x = `(offset - tip-gap)` so the ABSOLUTE tip lands
+;; at `state.x - tip-gap` — a clean ~`tip-gap`px gap OUTSIDE the edge,
+;; pointing AT it, never into the interior. The short arm keeps the tip
+;; just outside the edge so a nested initial does not penetrate the state
+;; once xyflow's `:extent "parent"` clamp acts.
 
 (def ^:private initial-glyph-hook-drop
   "Vertical drop (px) of the Q-hook: the dot sits this far ABOVE the
@@ -643,22 +631,20 @@
   9)
 
 (defn initial-marker
-  "rf2-az6e2 / rf2-i9d2ob — Reagent component for the machine's initial-
-  state pseudo-state marker. The SCXML/xstate UML initial pseudo-state
-  glyph: a small NEUTRAL FILLED dot + a short hooked arrow into the
-  state's near edge. NOT an accent-blue runtime marker — the initial
-  pseudo-state is STATIC topology, so it reads in the neutral pseudo-
-  state colour (`:pseudo-marker`), reserving accent/active for runtime
-  state.
+  "Reagent component for the machine's initial-state pseudo-state marker.
+  The SCXML/xstate UML initial pseudo-state glyph: a small NEUTRAL FILLED
+  dot + a short hooked arrow into the state's near edge. NOT an accent-
+  blue runtime marker — the initial pseudo-state is STATIC topology, so
+  it reads in the neutral pseudo-state colour (`:pseudo-marker`),
+  reserving accent/active for runtime state.
 
-  rf2-i9d2ob / rf2-d5s7yg — the ENTIRE glyph (dot + Q-hook + triangle
-  arrowhead) is drawn here, in the node's own local SVG frame, as ONE fixed
-  SHORT hook:
+  The ENTIRE glyph (dot + Q-hook + triangle arrowhead) is drawn here, in
+  the node's own local SVG frame, as ONE fixed SHORT hook:
 
     - a FILLED circle on the left, centred at node-local `dot-x =
-      pseudo-radius + 1`. rf2-k7kiiq DISTINGUISHES two radii here: the
-      GEOMETRY radius (`:pseudo-radius`, the full radius the arm/arrowhead
-      math reads) and the PAINTED radius (`:pseudo-radius − 0.5px`, a tighter
+      pseudo-radius + 1`. Two radii are distinguished here: the GEOMETRY
+      radius (`:pseudo-radius`, the full radius the arm/arrowhead math
+      reads) and the PAINTED radius (`:pseudo-radius − 0.5px`, a tighter
       Stately-aligned dot, −1px diameter — `dot-paint-r`). So the dot's
       GEOMETRY-radius left edge is at node-local x=1 (`dot-x − pseudo-radius`)
       but its PAINTED left edge is at node-local x=1.5 (`dot-x − dot-paint-r`).
@@ -670,24 +656,22 @@
     - a small filled triangle arrowhead (the shared `M0,0 L0,10 L10,5 z`
       shape, sized by the `:ah` side `projection/initial-marker-glyph`
       returns — a SMALL Stately-sized head, ≈ `(pseudo-radius − 1)` clamped
-      to a 4–6px band, NOT the oversized `:arrow-width-entry` the pre-
-      rf2-wwyx1u read used) whose tip lands at node-local x = `(offset -
-      tip-gap)`, i.e. absolute `state.x - tip-gap` — a clean ~`tip-gap`px
+      to a 4–6px band, sized off `:pseudo-radius` rather than the entry-
+      EDGE `:arrow-width-entry`) whose tip lands at node-local x = `(offset
+      - tip-gap)`, i.e. absolute `state.x - tip-gap` — a clean ~`tip-gap`px
       GAP just OUTSIDE the state's left edge, pointing AT it.
 
-  rf2-d5s7yg — the tip is DECOUPLED from the node offset: the marker node
-  sits `initial-marker-x-offset` (26, rf2-k7kiiq) px left of the state, but the
-  tip is drawn at `(offset - tip-gap)` so it ends OUTSIDE the edge, never
-  on/through it. Before this bead the arm == offset == 48 put the tip at
-  `state.x` (the
-  edge) with a too-long arm; nested initials then penetrated once xyflow's
-  `:extent \"parent\"` clamp shoved the deeply-negative marker rightward (the
-  clamp is dropped in `chart.projection` — only `:parentId` is kept).
+  The tip is DECOUPLED from the node offset: the marker node sits
+  `initial-marker-x-offset` (26) px left of the state, but the tip is
+  drawn at `(offset - tip-gap)` so it ends OUTSIDE the edge, never
+  on/through it. The short arm keeps a nested initial from penetrating
+  the state under xyflow's `:extent \"parent\"` clamp (`chart.projection`
+  keeps only `:parentId`, not the clamp).
 
   Because the geometry is node-local + fixed, the glyph reads as one tidy
-  unit in EVERY position — it never depends on ELK edge routing (the
-  bezier-routed entry edge it replaced bent wonky when the initial sat at an
-  odd position). The companion entry edge (`chart.projection`) is kept for
+  unit in EVERY position — it never depends on ELK edge routing (a
+  bezier-routed entry edge bends wonky when the initial sits at an odd
+  position). The companion entry edge (`chart.projection`) is kept for
   the every-edge `:data` invariants but paints nothing
   (`chart.edges/transition-edge` `entry?` short-circuit).
 
@@ -701,14 +685,13 @@
   (let [d        (.-data props)
         vc       (chart-constants d)
         ct       (palette-of d)
-        ;; rf2-wwyx1u — only `:pseudo-radius` is read now; the small glyph
-        ;; arrowhead is sized off it (the prior `:arrow-width-entry` read
-        ;; produced an oversized head — see the `ah` binding below).
+        ;; Only `:pseudo-radius` is read; the small glyph arrowhead is
+        ;; sized off it (see the `ah` binding below).
         {:keys [pseudo-radius]} vc
         stroke   (:pseudo-marker ct)
         ;; Glyph in node-local coords. Row y=0 is the marker origin
-        ;; (== state.y + offset). rf2-d5s7yg — the marker node sits `offset`
-        ;; (26) px left of the state (`chart.projection/initial-marker-x-offset`),
+        ;; (== state.y + offset). The marker node sits `offset` (26) px
+        ;; left of the state (`chart.projection/initial-marker-x-offset`),
         ;; so node-local x=`offset` IS the state's left edge. The arrow tip
         ;; lands at (`offset - gap`, 0) — a clean ~`gap`px gap OUTSIDE the
         ;; edge; the dot CENTRE sits at node-local `dot-x = pseudo-radius + 1`
@@ -716,28 +699,27 @@
         ;; edge — absolute `state.x - 19`) and `hook-drop` ABOVE the arrow row
         ;; so the single Q hooks DOWN into the tip (xstate-viz signature).
         drop     initial-glyph-hook-drop
-        ;; rf2-k7kiiq — `dot-r` is the GEOMETRY radius (the FULL
-        ;; `pseudo-radius`) that feeds the glyph math + the forward-flow
-        ;; invariant; the PAINTED circle uses the tighter `dot-paint-r` below.
+        ;; `dot-r` is the GEOMETRY radius (the FULL `pseudo-radius`) that
+        ;; feeds the glyph math + the forward-flow invariant; the PAINTED
+        ;; circle uses the tighter `dot-paint-r` below.
         dot-r    pseudo-radius
-        ;; rf2-k7kiiq — the PAINTED dot radius, 0.5px SMALLER than the
-        ;; GEOMETRY radius `dot-r` (−1px diameter) for a tighter Stately-
-        ;; aligned dot, WITHOUT touching `dot-r` (the full `pseudo-radius`)
-        ;; that feeds the glyph geometry below — so the arm/arrowhead math +
-        ;; the forward-flow invariant stay anchored to the full radius. Only
+        ;; The PAINTED dot radius, 0.5px SMALLER than the GEOMETRY radius
+        ;; `dot-r` (−1px diameter) for a tighter Stately-aligned dot,
+        ;; WITHOUT touching `dot-r` (the full `pseudo-radius`) that feeds
+        ;; the glyph geometry below — so the arm/arrowhead math + the
+        ;; forward-flow invariant stay anchored to the full radius. Only
         ;; the painted circle shrinks: its painted LEFT EDGE is at node-local
         ;; `dot-x - dot-paint-r = 1.5` (vs the geometry-radius left edge at
         ;; `dot-x - pseudo-radius = 1`).
         dot-paint-r (- dot-r 0.5)
-        ;; rf2-wwyx1u — the glyph geometry is single-sourced from the pure
-        ;; `projection/initial-marker-glyph` (so the renderer + the projection
-        ;; test agree on the FORWARD-FLOW invariant). It returns a SMALL
-        ;; Stately-sized arrowhead (`:ah` ≈ dot diameter / 2, 4px floor) — the
-        ;; prior `(max 6 arrow-width-entry)` produced a ~10–13px head that, on
-        ;; the SHORTENED glyph, pushed `end-x` LEFT of `dot-x`, ran the hook
-        ;; BACKWARDS and let the oversized triangle dominate. With the small
-        ;; head + bumped offset `end-x > dot-x`: the single Q hooks dot →
-        ;; down-and-RIGHT into the head, which points RIGHT into the edge.
+        ;; The glyph geometry is single-sourced from the pure
+        ;; `projection/initial-marker-glyph` (so the renderer + the
+        ;; projection test agree on the FORWARD-FLOW invariant). It returns
+        ;; a SMALL Stately-sized arrowhead (`:ah` ≈ dot diameter / 2, 4px
+        ;; floor); with the small head + the offset `end-x > dot-x`, the
+        ;; single Q hooks dot → down-and-RIGHT into the head, which points
+        ;; RIGHT into the edge. (An oversized head would push `end-x` LEFT
+        ;; of `dot-x` and run the hook backwards.)
         {:keys [ah tip-x dot-x end-x]} (projection/initial-marker-glyph dot-r)
         ah-half  (/ ah 2.0)
         dot-y    (- drop)            ;; dot above the arrow row
@@ -785,18 +767,18 @@
        [:> Handle {:type "source" :position pos-right
                    :style {:opacity 0}}]])))
 
-;; ---- root-container node (rf2-q129z8) -----------------------------------
+;; ---- root-container node ------------------------------------------------
 
 (defn root-container-node
-  "rf2-q129z8 — the synthetic ROOT-CONTAINER frame: the Stately-Studio-style
-  NAMED box that wraps the WHOLE machine. xyflow places every top-level node
+  "The synthetic ROOT-CONTAINER frame: the Stately-Studio-style NAMED box
+  that wraps the WHOLE machine. xyflow places every top-level node
   (flat states, the `machine-root` chip, parallel regions) inside this
   container via the `parentId` mechanic (the same way `compound-node` holds
   its substates); ELK sizes the frame to HUG its children and reflows it on
-  resize, so the frame TRACKS the topology instead of the pre-q129z8
-  corner-pinned overlay that stuck to the drawing surface.
+  resize, so the frame TRACKS the topology rather than pinning to a corner
+  of the drawing surface.
 
-  The frame absorbs the old floating root chrome into a proper HEADER:
+  The frame carries the root chrome in a proper HEADER:
 
     - a full-width TITLE STRIP carrying the MACHINE NAME (`:machineName`,
       from the host's `:machine-id`), with a subtle `∥` glyph for a parallel
@@ -804,9 +786,8 @@
     - an optional CONTEXT band UNDER the title (`:context` — the key→type-
       caption shape the host feeds via `:context-band`), with a provenance
       badge: a quiet `inferred from :data` badge when `:contextInferred` is
-      true (the one-sample inference, rf2-5tz9p), or a positive `declared`
-      badge when false (the authoritative `:data-schema` shape, rf2-3q4k5b /
-      EP-0005).
+      true (the one-sample inference), or a positive `declared` badge when
+      false (the authoritative `:data-schema` shape, EP-0005).
 
   Structural chrome, not a state: NEUTRAL border (no runtime accent — the
   projector never marks it `:active`), no `:onClick`. The painted box FILLS
@@ -827,9 +808,9 @@
         {:keys [compound-radius container-title-height container-title-pad-x
                 container-title-px container-divider-width container-body-pad
                 stroke-width]} vc
-        ;; rf2-8z1rca — the ELK top padding the frame reserves for its
-        ;; header: the title strip + a body-pad band + the variable-height
-        ;; Context band (`projection/context-band-height` for this context's
+        ;; The ELK top padding the frame reserves for its header: the title
+        ;; strip + a body-pad band + the variable-height Context band
+        ;; (`projection/context-band-height` for this context's
         ;; row count). Single-sourced from the SAME helper `->elk-children`
         ;; feeds ELK, so the rendered header and the reservation can never
         ;; drift. Surfaced as `data-reserved-top` so the DOM regression can
@@ -853,7 +834,7 @@
                      :border         (str stroke-width "px solid "
                                           (:container-border ct))
                      :border-radius  (str compound-radius "px")
-                     ;; rf2-q129z8 — clicks fall through to nested states.
+                     ;; Clicks fall through to nested states.
                      :pointer-events "none"}}
        ;; FULL-WIDTH HEADER — machine name (+ ∥ for parallel) and, under it,
        ;; the optional Context band. The header sits at the top of the frame
@@ -896,12 +877,12 @@
                          :text-overflow "ellipsis"}}
           label]]
         ;; CONTEXT band (under the title) — the inferred key→type shape.
-        ;; rf2-8z1rca — the band's fixed-pixel geometry is single-sourced
-        ;; from the `chart.projection` Context-band constants so the painted
-        ;; height and the root-container ELK top-padding RESERVATION
+        ;; The band's fixed-pixel geometry is single-sourced from the
+        ;; `chart.projection` Context-band constants so the painted height
+        ;; and the root-container ELK top-padding RESERVATION
         ;; (`projection/context-band-height`, fed via `->elk-children`) can
         ;; never drift — a band taller than its reservation would lay the
-        ;; first child UNDER it (the rf2-8z1rca bug).
+        ;; first child UNDER it.
         (when (seq context)
           [:div {:data-testid (str "rf-mv-chart-root-container-context-" (.-id props))
                  :data-key-count (str (count context))
@@ -928,12 +909,12 @@
                             :text-transform "uppercase"
                             :color          (:text-tertiary ct)}}
              "Context"]
-            ;; rf2-5tz9p / rf2-3q4k5b — the provenance badge. The shape is
-            ;; either INFERRED from one sample of the machine's `:data` (the
-            ;; quiet caveat badge — a partial initial `:data` can mislead) OR
-            ;; AUTHORITATIVE from a declared `:data-schema` (EP-0005). When
-            ;; declared, the `inferred from :data` badge is dropped and a
-            ;; positive `declared` badge marks the shape as authoritative.
+            ;; The provenance badge. The shape is either INFERRED from one
+            ;; sample of the machine's `:data` (the quiet caveat badge — a
+            ;; partial initial `:data` can mislead) OR AUTHORITATIVE from a
+            ;; declared `:data-schema` (EP-0005). When declared, a positive
+            ;; `declared` badge marks the shape as authoritative in place of
+            ;; the `inferred from :data` badge.
             (if inferred?
               [:span {:data-testid (str "rf-mv-chart-root-container-context-inferred-"
                                         (.-id props))
@@ -964,14 +945,14 @@
               [:span {:style {:overflow "hidden" :text-overflow "ellipsis"}} v]])])]
        (four-cardinal-handles)])))
 
-;; ---- machine-root node (rf2-vcnvj) --------------------------------------
+;; ---- machine-root node --------------------------------------------------
 
 (defn machine-root-node
-  "rf2-vcnvj — the synthetic MACHINE-ROOT node: the in-graph source a
-  machine-level (top-level `:on`) fallback transition routes FROM, so
-  the fallback renders as exactly ONE route/chip into its target instead
-  of one back-edge per leaf state (the pre-vcnvj per-state repetition
-  that also scrambled ELK's main-column ordering).
+  "The synthetic MACHINE-ROOT node: the in-graph source a machine-level
+  (top-level `:on`) fallback transition routes FROM, so the fallback
+  renders as exactly ONE route/chip into its target instead of one back-
+  edge per leaf state (per-state repetition would also scramble ELK's
+  main-column ordering).
 
   Painted as a quiet ROOT-CONTEXT chip — a small neutral pill with a
   subtle root glyph (`◆`) + a `root` caption — NOT a state box, so it
@@ -1010,30 +991,28 @@
                    :id "right"
                    :style {:opacity 0}}]])))
 
-;; ---- history pseudo-state renderer (rf2-m285a — WIRED END-TO-END) -------
+;; ---- history pseudo-state renderer --------------------------------------
 ;;
-;; rf2-az6e2 defined the VISUAL rendering of history pseudo-states
-;; (shallow `H` / deep `H*`, small symbolic node inside the owning
-;; compound, direct incoming transitions, NO normal state-box styling).
-;; rf2-m285a then WIRED first-class history END-TO-END (Spec 005 §History
-;; states): `chart.layout/collect-nodes` detects a `:type :history` node
-;; and emits a single `{:history? true :deep? <bool> :default-target …}`
-;; marker (NEVER occupiable — layout.cljc:360-375); `chart.projection/
-;; xyflow-graph` maps a `:history?` node to xyflow type `"history-marker"`
-;; and threads `:data {:deep …}` (projection.cljc:731/785); this renderer
-;; paints `H` / `H*` (below, :696). History topology is therefore PARSED,
-;; EMITTED, and PAINTED — no longer a render-hook awaiting data. Constants
-;; (`:pseudo-*`) carry the shallow/deep variant.
+;; History pseudo-states render as a shallow `H` / deep `H*` small
+;; symbolic node inside the owning compound, with direct incoming
+;; transitions and NO normal state-box styling. First-class history is
+;; wired END-TO-END (Spec 005 §History states): `chart.layout/collect-
+;; nodes` detects a `:type :history` node and emits a single
+;; `{:history? true :deep? <bool> :default-target …}` marker (NEVER
+;; occupiable — layout.cljc:360-375); `chart.projection/xyflow-graph`
+;; maps a `:history?` node to xyflow type `"history-marker"` and threads
+;; `:data {:deep …}` (projection.cljc:731/785); this renderer paints `H`
+;; / `H*` (below, :696). History topology is therefore PARSED, EMITTED,
+;; and PAINTED. Constants (`:pseudo-*`) carry the shallow/deep variant.
 
 (defn history-marker
-  "rf2-az6e2 / rf2-m285a — small symbolic pseudo-state node for a history
-  marker. Shallow history renders `H`; deep history renders `H*`. Reads
-  `:data {:deep <bool>}`. NOT a normal state box — a small neutral
-  rounded square so it reads as a pseudo-state inside its owning
-  compound. WIRED END-TO-END (see the section comment above): the
-  projector emits `{:type \"history-marker\" :data {:deep …}}` for every
-  parsed `:type :history` node (Spec 005 §History states) and this
-  renderer paints it."
+  "Small symbolic pseudo-state node for a history marker. Shallow history
+  renders `H`; deep history renders `H*`. Reads `:data {:deep <bool>}`.
+  NOT a normal state box — a small neutral rounded square so it reads as
+  a pseudo-state inside its owning compound. Wired END-TO-END (see the
+  section comment above): the projector emits `{:type \"history-marker\"
+  :data {:deep …}}` for every parsed `:type :history` node (Spec 005
+  §History states) and this renderer paints it."
   [^js props]
   (let [d   (.-data props)
         vc  (chart-constants d)
@@ -1063,13 +1042,10 @@
        [:> Handle {:type "target" :position pos-left :id "left"
                    :style {:opacity 0}}]])))
 
-;; rf2-ee38b.21 — the dead `final-marker` component + its node-type
-;; registration were removed. The projector only ever emits
+;; There is no `final-marker` node type. The projector only ever emits
 ;; `initial-marker` nodes; final states paint the quiet doubled ring
-;; inline on `state-node` (no glyph — rf2-az6e2 dropped the ✓). The
-;; end-state-as-node `[*]` pattern,
-;; if it ever lands, files its own bead (same posture the codebase
-;; took when it removed the dead `spawn-edge` registration).
+;; inline on `state-node` (no glyph). An end-state-as-node `[*]` pattern,
+;; if it ever lands, would file its own bead.
 
 ;; ---- node-types map -----------------------------------------------------
 
@@ -1079,24 +1055,23 @@
   callers SHOULD memoise this map at component-construction time
   to avoid re-render churn.
 
-  rf2-qo5xy — `rf2-event` joins the registered set: events render as
-  first-class xyflow nodes (one per spec transition) rather than as
-  edge LABELS between state boxes. Same node-type pattern the state /
-  compound / region nodes use."
+  `rf2-event` is in the registered set: events render as first-class
+  xyflow nodes (one per spec transition) rather than as edge LABELS
+  between state boxes. Same node-type pattern the state / compound /
+  region nodes use."
   []
   #js {"state"           state-node
        "compound"        compound-node
        "parallel-region" parallel-region-node/parallel-region-node
-       ;; rf2-q129z8 — the synthetic ROOT-CONTAINER frame (the Stately-style
-       ;; named box wrapping the whole machine; absorbs the old corner-pinned
-       ;; root title strip + Context overlay into a proper frame header).
+       ;; The synthetic ROOT-CONTAINER frame (the Stately-style named box
+       ;; wrapping the whole machine; carries the root title strip +
+       ;; Context band in a proper frame header).
        "root-container"  root-container-node
        "initial-marker"  initial-marker
-       ;; rf2-vcnvj — the synthetic root-context chip a machine-level
-       ;; (top-level `:on`) fallback routes from (projected once, not
-       ;; per-state).
+       ;; The synthetic root-context chip a machine-level (top-level `:on`)
+       ;; fallback routes from (projected once, not per-state).
        "machine-root"    machine-root-node
-       ;; rf2-m285a — history pseudo-state renderer; the projector emits a
+       ;; History pseudo-state renderer; the projector emits a
        ;; `history-marker` node for every parsed `:type :history` pseudo-
        ;; state (wired end-to-end; see `history-marker` docstring).
        "history-marker"  history-marker

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
@@ -1,24 +1,23 @@
 (ns day8.re-frame2-machines-viz.chart.nodes.event-node
   "Custom xyflow node for an EVENT — the central artefact of the
-  events-as-nodes paradigm (rf2-qo5xy).
+  events-as-nodes paradigm.
 
   ## Why this exists
 
-  Pre-rf2-qo5xy the chart painted transitions as edge LABELS between
-  state boxes: `event [guard] / action` floated on the line. Multiple
-  candidates, long action names, or several stacked siblings degraded
-  legibility quickly, and action attribution was always a second-class
-  citizen of the line text.
+  Following Stately's graph view, the chart paints each transition as
+  its OWN box — `source-state → event-node → (optional) target-state` —
+  rather than as an edge LABEL floating on the line. Painting
+  transitions as line labels degrades legibility quickly with multiple
+  candidates, long action names, or several stacked siblings, and makes
+  action attribution a second-class citizen of the line text.
 
-  Stately's graph view paints each transition as its OWN box —
-  `source-state → event-node → (optional) target-state`. The event
-  box carries the event name (header), an optional `[guard]` chip,
-  and `+ action` pills for action attribution. Internal transitions
-  (no `:target`) get the event box but no outgoing edge — they read
-  as 'this dispatches an action and hangs here'.
+  The event box carries the event name (header), an optional `[guard]`
+  chip, and `+ action` pills for action attribution. Internal
+  transitions (no `:target`) get the event box but no outgoing edge —
+  they read as 'this dispatches an action and hangs here'.
 
-  rf2-qo5xy adopts that paradigm: every spec transition emits exactly
-  one xyflow node of `type \"rf2-event\"` plus one or two edges.
+  Under this paradigm every spec transition emits exactly one xyflow
+  node of `type \"rf2-event\"` plus one or two edges.
 
   ## What this owns
 
@@ -46,8 +45,8 @@
              :refer [chart-label-stack]]))
 
 (defn- variant-glyph
-  "rf2-qo5xy — convention-glyph variants for the event-node header. The
-  three xstate/Stately conventions:
+  "Convention-glyph variants for the event-node header. The three
+  xstate/Stately conventions:
 
     - `:after`  → `⌚` clock glyph + `<ms>` (e.g. `⌚ 1000ms`)
     - `:always` → `∞` continuation glyph
@@ -59,8 +58,8 @@
     event-label))
 
 (defn- fork-badge
-  "rf2-uw3vmi — the numbered PRIORITY badge for one branch of a guarded
-  multi-branch fork. Stately renders a guarded fork (the gate machine's
+  "The numbered PRIORITY badge for one branch of a guarded multi-branch
+  fork. Stately renders a guarded fork (the gate machine's
   `:gate/check` 3-way) with a small circled number (①②③) on each branch
   chip, communicating the DETERMINISTIC ORDER the engine evaluates the
   guards in (first-pass-wins). The projector
@@ -101,8 +100,8 @@
        order])))
 
 (defn requires-chip
-  "rf2-skhlw2.1 — a compact `needs <id>, <id>` chip surfacing a guard /
-  action consumer's declared `:rf.cofx/requires` (EP-0017 consumer
+  "A compact `needs <id>, <id>` chip surfacing a guard / action
+  consumer's declared `:rf.cofx/requires` (EP-0017 consumer
   attachment): the replay-critical host facts the named callback reads
   before it runs. The QUIETEST tier (tertiary colour, smallest type) — a
   subordinate annotation on the event chip, never competing with the event
@@ -135,8 +134,8 @@
 
 (defn event-node
   "Reagent component for an event-node. The xyflow chart projector
-  emits ONE event-node per spec transition (event-as-node paradigm,
-  rf2-qo5xy): state → event-node → (optional) target state.
+  emits ONE event-node per spec transition (event-as-node paradigm):
+  state → event-node → (optional) target state.
 
   Reads from `:data`:
 
@@ -150,13 +149,13 @@
     :action        — action name as a string, or nil.
     :focused       — focused-event lens hit; emphasised border.
     :fired         — this event fired THIS epoch; FIRED treatment.
-    :guardBlocked  — rf2-fzrzlw — this transition's guard REJECTED the
-                     event this epoch (a guard-blocked no-op: the runtime
-                     emitted `:rf.machine/guard-evaluated` fail/threw but
-                     NO transition). PINK guard-blocked treatment: pink
+    :guardBlocked  — this transition's guard REJECTED the event this
+                     epoch (a guard-blocked no-op: the runtime emitted
+                     `:rf.machine/guard-evaluated` fail/threw but NO
+                     transition). PINK guard-blocked treatment: pink
                      border + an EMPHASISED pink `IF <guard>` chip so the
-                     node reads as the guard that rejected it (bead design
-                     call (1)). Wins over fired/focused on this node.
+                     node reads as the guard that rejected it. Wins over
+                     fired/focused on this node.
     :clickable     — host wired an on-click for this event (the
                      on-chart sim path).
     :eventId       — raw fireable event keyword the host receives on
@@ -166,9 +165,9 @@
     :internal      — internal self-transition (no :target). Visual
                      hint: dashed border ring under the header (the
                      'this action runs and we hang here' affordance).
-    :reenter       — rf2-9dj21r — the EXTERNAL restart axis (`:reenter?
-                     true`, Spec 005 §Self-transitions / XState v5). A
-                     targeted transition is internal by DEFAULT; only
+    :reenter       — the EXTERNAL restart axis (`:reenter? true`, Spec
+                     005 §Self-transitions / XState v5). A targeted
+                     transition is internal by DEFAULT; only
                      `:reenter?` re-runs the target's `:exit`/`:entry` +
                      restarts its `:after` timers / `:spawn` children.
                      Visual hint: a `↻` reenter chip on the header so a
@@ -185,20 +184,20 @@
         after-ms    (.-afterMs d)
         guard       (.-guard d)
         action      (.-action d)
-        ;; rf2-skhlw2.1 — the guard / action consumer's declared
-        ;; `:rf.cofx/requires` (EP-0017 consumer attachment), a JS array of
-        ;; compact id strings (nil when the named callback declares no facts).
-        ;; `js->clj` back to a CLJS vec for rendering; nil stays nil so an
-        ;; undeclared callback is visually unchanged.
+        ;; The guard / action consumer's declared `:rf.cofx/requires`
+        ;; (EP-0017 consumer attachment), a JS array of compact id strings
+        ;; (nil when the named callback declares no facts). `js->clj` back
+        ;; to a CLJS vec for rendering; nil stays nil so an undeclared
+        ;; callback is visually unchanged.
         guard-reqs  (some-> (.-guardRequires d) js->clj)
         action-reqs (some-> (.-actionRequires d) js->clj)
         focused?    (boolean (.-focused d))
         fired?      (boolean (.-fired d))
-        ;; rf2-fzrzlw — this transition's guard rejected the event this
-        ;; epoch (guard-blocked no-op). Drives the PINK guard-blocked
-        ;; treatment (pink border + emphasised pink `IF <guard>` chip),
-        ;; winning over fired/focused on this node so the rejected
-        ;; transition stands out (bead design call (1) + (2)).
+        ;; This transition's guard rejected the event this epoch (guard-
+        ;; blocked no-op). Drives the PINK guard-blocked treatment (pink
+        ;; border + emphasised pink `IF <guard>` chip), winning over
+        ;; fired/focused on this node so the rejected transition stands
+        ;; out.
         blocked?    (boolean (.-guardBlocked d))
         fork-order  (.-forkOrder d)
         internal?   (boolean (.-internal d))
@@ -218,13 +217,12 @@
                 action-pill-radius stroke-width stroke-width-emphasis]} vc
         emphasised? (or focused? fired? blocked?)
         stroke-w    (if emphasised? stroke-width-emphasis stroke-width)
-        ;; rf2-az6e2 — the route chip is SUBORDINATE to states: a quiet
-        ;; neutral fill + neutral border by default. Runtime state
-        ;; (focused lens / fired-this-epoch) swaps the border to the
-        ;; runtime accent; a clickable (sim) chip gets a faint amber wash.
-        ;; rf2-fzrzlw — a guard-blocked no-op swaps the border to the PINK
-        ;; guard-blocked hue (winning over fired/focused) so the rejected
-        ;; transition stands out.
+        ;; The route chip is SUBORDINATE to states: a quiet neutral fill +
+        ;; neutral border by default. Runtime state (focused lens / fired-
+        ;; this-epoch) swaps the border to the runtime accent; a clickable
+        ;; (sim) chip gets a faint amber wash. A guard-blocked no-op swaps
+        ;; the border to the PINK guard-blocked hue (winning over
+        ;; fired/focused) so the rejected transition stands out.
         stroke-col  (cond
                       blocked?  (:edge-guard-blocked ct)
                       fired?    (:edge-fired ct)
@@ -236,14 +234,14 @@
                       clickable? (:sim-wash ct)
                       :else      (:event-chip-bg ct))]
     (r/as-element
-      ;; rf2-az6e2 — route chip / card grammar. NO title bar (the bead is
-      ;; explicit: event nodes must NOT read as peer state boxes). The
-      ;; event label + guard ride the FIRST line; the action row appears
-      ;; only when an action exists; an internal / action-only transition
-      ;; (no outgoing target segment — the projector omits the `__out`
-      ;; edge) keeps a dashed border ring so it reads as "runs an action
-      ;; and hangs here". Machine-level is muted: NO loud label, only the
-      ;; `data-machine-level` attr for host introspection.
+      ;; Route chip / card grammar. NO title bar: event nodes must NOT
+      ;; read as peer state boxes. The event label + guard ride the FIRST
+      ;; line; the action row appears only when an action exists; an
+      ;; internal / action-only transition (no outgoing target segment —
+      ;; the projector omits the `__out` edge) keeps a dashed border ring
+      ;; so it reads as "runs an action and hangs here". Machine-level is
+      ;; muted: NO loud label, only the `data-machine-level` attr for host
+      ;; introspection.
       [:div {:data-testid (str "rf-mv-chart-event-" (.-id props))
              :data-node-id (.-id props)
              :data-event-id (when event-id (str event-id))
@@ -255,18 +253,18 @@
              :data-fork-order (when fork-order (str fork-order))
              :data-machine-level (str machine-level?)
              :data-fired (str fired?)
-             ;; rf2-fzrzlw — DOM pin for the guard-blocked no-op event
-             ;; treatment; tests + hosts read it to find the attempted-
-             ;; and-rejected transition (the pink chip whose guard declined).
+             ;; DOM pin for the guard-blocked no-op event treatment; tests
+             ;; + hosts read it to find the attempted-and-rejected
+             ;; transition (the pink chip whose guard declined).
              :data-guard-blocked (str blocked?)
              :data-focused (str focused?)
              :data-clickable (str clickable?)
              :data-after-ms (when after-ms (str after-ms))
              :data-guard (when guard (str guard))
              :data-action (when action (str action))
-             ;; rf2-skhlw2.1 — DOM pins for the guard / action consumer's
-             ;; declared `:rf.cofx/requires` (space-joined id strings) so
-             ;; tests + hosts read the replay-critical facts off the node.
+             ;; DOM pins for the guard / action consumer's declared
+             ;; `:rf.cofx/requires` (space-joined id strings) so tests +
+             ;; hosts read the replay-critical facts off the node.
              :data-guard-requires (when (seq guard-reqs) (str/join " " guard-reqs))
              :data-action-requires (when (seq action-reqs) (str/join " " action-reqs))
              :data-from-path (when from-path (pr-str from-path))
@@ -307,19 +305,19 @@
                                               blocked? (:edge-guard-blocked ct)
                                               fired?   (:glow-fired ct)
                                               :else    (:glow ct))))
-                     ;; rf2-4o43j8 — event-driven + FINITE glow: ONE
-                     ;; motion-scaled iteration that settles to a stable
-                     ;; end-state (no `infinite` strobe) and collapses to a
-                     ;; settle frame under `prefers-reduced-motion`. The
-                     ;; static fired affordance (the `:glow-fired` box-shadow
-                     ;; above) persists after it completes.
+                     ;; Event-driven + FINITE glow: ONE motion-scaled
+                     ;; iteration that settles to a stable end-state (no
+                     ;; `infinite` strobe) and collapses to a settle frame
+                     ;; under `prefers-reduced-motion`. The static fired
+                     ;; affordance (the `:glow-fired` box-shadow above)
+                     ;; persists after it completes.
                      :animation      (when fired?
                                        (tokens/glow-animation-css))
                      :transition     "border-color 120ms ease, background 120ms ease"}}
        ;; First line: optional fork priority-badge + event name / ⌚ <ms> /
-       ;; ∞ + optional `IF <guard>`. rf2-uw3vmi — the numbered badge LEADS
-       ;; the line (Stately convention) so a guarded-fork branch reads as
-       ;; "branch N: event IF guard"; nil for non-fork events.
+       ;; ∞ + optional `IF <guard>`. The numbered badge LEADS the line
+       ;; (Stately convention) so a guarded-fork branch reads as "branch
+       ;; N: event IF guard"; nil for non-fork events.
        [:span {:data-testid (str "rf-mv-chart-event-header-" (.-id props))
                :data-event-line (cond-> header
                                   guard (str " IF " guard))
@@ -331,10 +329,10 @@
         (fork-badge (.-id props) fork-order ct event-chip-px)
         header
         (when guard
-          ;; rf2-fzrzlw — a guard-blocked no-op EMPHASISES the guard chip
-          ;; in the pink guard-blocked hue (bold pink `IF <guard>`) so the
-          ;; node reads "this guard rejected it"; the resting guard chip
-          ;; stays quiet tertiary.
+          ;; A guard-blocked no-op EMPHASISES the guard chip in the pink
+          ;; guard-blocked hue (bold pink `IF <guard>`) so the node reads
+          ;; "this guard rejected it"; the resting guard chip stays quiet
+          ;; tertiary.
           [:span {:data-testid (str "rf-mv-chart-event-guard-" (.-id props))
                   :data-guard guard
                   :data-guard-blocked (str blocked?)
@@ -344,10 +342,10 @@
                                    (:text-tertiary ct))
                           :font-weight (if blocked? 700 600)}}
            (str "IF " guard)])
-        ;; rf2-9dj21r — the EXTERNAL restart marker. A targeted transition
-        ;; is internal by default (XState v5 / Spec 005); a `↻` reenter chip
-        ;; makes a `:reenter? true` transition read DISTINCTLY from its
-        ;; internal default (re-runs `:exit`/`:entry`, restarts `:after` /
+        ;; The EXTERNAL restart marker. A targeted transition is internal
+        ;; by default (XState v5 / Spec 005); a `↻` reenter chip makes a
+        ;; `:reenter? true` transition read DISTINCTLY from its internal
+        ;; default (re-runs `:exit`/`:entry`, restarts `:after` /
         ;; `:spawn`), which is otherwise topologically identical.
         (when reenter?
           [:span {:data-testid (str "rf-mv-chart-event-reenter-" (.-id props))
@@ -357,13 +355,13 @@
                           :color (:text-tertiary ct)
                           :font-weight 600}}
            "↻"])]
-       ;; Action row — appears ONLY when an action exists. rf2-fokezq —
-       ;; render the bolt + action name as a subdued ENCLOSED action CHIP
-       ;; (subtle fill + border + padding + rounding), matching the
-       ;; state-node entry/exit action chip (`nodes/action-row`) and
-       ;; Stately's quiet action treatment, so it reads as a contained
-       ;; annotation subordinate to the event line — NOT loose free-floating
-       ;; text inside the trigger box. Geometry reads off the density's
+       ;; Action row — appears ONLY when an action exists. Render the bolt
+       ;; + action name as a subdued ENCLOSED action CHIP (subtle fill +
+       ;; border + padding + rounding), matching the state-node entry/exit
+       ;; action chip (`nodes/action-row`) and Stately's quiet action
+       ;; treatment, so it reads as a contained annotation subordinate to
+       ;; the event line — NOT loose free-floating text inside the trigger
+       ;; box. Geometry reads off the density's
        ;; `:action-pill-*` constants (shared with the state-node chip);
        ;; font-size keeps the density-aware `:event-chip-action-px`. Colour
        ;; is the neutral container-header fill + structural border + tertiary
@@ -387,11 +385,12 @@
                          :white-space   "nowrap"}}
           [:span {:style {:opacity 0.7}} "⚡"]
           action])
-       ;; rf2-skhlw2.1 — the guard / action consumer-attachment requirement
-       ;; rows: a quiet `needs <id>` annotation surfacing the replay-critical
-       ;; host facts the named guard / action declares via `:rf.cofx/requires`
-       ;; (EP-0017). Each renders ONLY when its callback declared a non-empty
-       ;; diet, so an ordinary fact-free transition is visually unchanged.
+       ;; The guard / action consumer-attachment requirement rows: a quiet
+       ;; `needs <id>` annotation surfacing the replay-critical host facts
+       ;; the named guard / action declares via `:rf.cofx/requires`
+       ;; (EP-0017). Each renders ONLY when its callback declared a non-
+       ;; empty diet, so an ordinary fact-free transition is visually
+       ;; unchanged.
        (requires-chip :guard guard-reqs (.-id props) ct event-chip-action-px)
        (requires-chip :action action-reqs (.-id props) ct event-chip-action-px)
        ;; xyflow attachment points. Handles on every side so elkjs can

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -1,15 +1,13 @@
 (ns day8.re-frame2-machines-viz.chart.nodes.parallel-region-node
   "xyflow node component for a parallel-region (orthogonal-zone)
-  container (rf2-lkwev · xyflow Phase 2).
+  container.
 
   ## Why this exists
 
-  xyflow Phase 1 (#1806) projected only the FIRST region of a
-  `{:type :parallel :regions {...}}` machine — full parallel layout
-  was deferred. This component completes the deferral: every region
-  renders as a distinct orthogonal zone with its own dashed boundary
-  (Stately Studio parity — Stately paints parallel regions as
-  side-by-side panes separated by a dashed divider).
+  A `{:type :parallel :regions {...}}` machine renders every region as
+  a distinct orthogonal zone with its own dashed boundary (Stately
+  Studio parity — Stately paints parallel regions as side-by-side panes
+  separated by a dashed divider).
 
   ## How it works with xyflow
 
@@ -17,21 +15,19 @@
   node per region; `chart.projection/xyflow-graph` projects it as a
   `type: \"parallel-region\"` xyflow node and assigns every state in
   the region a `parentId` pointing at the region node (xyflow's
-  sub-flow mechanic — rf2-xh1lm: xyflow v12 reads `parentId`, NOT the
-  pre-v12 `parentNode`). This component renders the region's CHROME —
+  sub-flow mechanic — xyflow v12 reads `parentId`, NOT the pre-v12
+  `parentNode`). This component renders the region's CHROME —
   a large translucent box with a dashed border + the region label in
   the header strip. The child state nodes sit inside via xyflow's
   `parentId` positioning; this component only paints the surround.
 
-  ## Region identity comes from layout, not colour (rf2-az6e2)
+  ## Region identity comes from layout, not colour
 
   Regions are distinguished by CONTAINMENT + LAYOUT (side-by-side dashed
-  zones), NOT a rotating border colour. The prior per-region
-  `region-boundary-palette` rotation is removed: static colour rotation
-  is not the topology signal — structure wins. Every region's boundary
-  is the SAME neutral dashed treatment; the dashed style itself (vs the
-  compound container's solid neutral) is what marks a zone as a parallel
-  region.
+  zones), NOT a rotating border colour: static colour rotation is not the
+  topology signal — structure wins. Every region's boundary is the SAME
+  neutral dashed treatment; the dashed style itself (vs the compound
+  container's solid neutral) is what marks a zone as a parallel region.
 
   ## Token integration
 
@@ -41,7 +37,7 @@
   state (`:active` accent + glow), so an active region reads live without
   the static identity competing for the accent.
 
-  ## Border handles (rf2-shv82)
+  ## Border handles
 
   Invisible source + target `<Handle>` elements sit on all four
   sides so xstate/Stately-style edges incident on the region
@@ -49,9 +45,8 @@
   render through xyflow normally. Without them xyflow's
   `getHandleBounds` returns null, `isNodeInitialized` returns false,
   and `getEdgePosition` returns null — every edge whose endpoint is a
-  region container is SILENTLY DROPPED from the DOM. The same
-  mechanic the compound-node fix uses; the region-node mirrors it for
-  consistency."
+  region container is SILENTLY DROPPED from the DOM. The compound-node
+  uses the same mechanic; the region-node mirrors it for consistency."
   (:require [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
              :refer [four-cardinal-handles chart-constants palette-of]]
@@ -61,7 +56,7 @@
 ;; ---- parallel-region node ----------------------------------------------
 
 (defn parallel-region-node
-  "rf2-az6e2 — Reagent component for a parallel-region container. xyflow
+  "Reagent component for a parallel-region container. xyflow
   invokes this via `nodeTypes={:parallel-region parallel-region-node}`.
   Reads `:data {:label :regionIndex :regionId ...}` off the xyflow props.
 
@@ -69,9 +64,8 @@
   neutral is the compound container):
 
     - DASHED NEUTRAL rounded boundary. Region identity comes from
-      CONTAINMENT + LAYOUT, NOT a rotating border colour (the prior
-      per-region `region-boundary-palette` rotation is REMOVED — static
-      colour rotation is not the topology signal).
+      CONTAINMENT + LAYOUT, NOT a rotating border colour — static colour
+      rotation is not the topology signal.
     - A full-width REGION TITLE STRIP carrying the uppercased label, with
       a subtle `∥` parallel glyph (small, never dominating).
     - Active / focus colour is reserved for RUNTIME state: an active
@@ -88,7 +82,7 @@
         {:keys [compound-radius region-title-height region-title-pad-x
                 container-title-px container-divider-width
                 stroke-width stroke-width-emphasis]} vc
-        ;; rf2-az6e2 — NEUTRAL boundary by default (no rotation colour).
+        ;; NEUTRAL boundary by default (no rotation colour).
         ;; Active swaps the dashed neutral to a solid runtime accent.
         border-color (if active? (:active ct) (:region-border ct))
         border-style (if active? "solid" "dashed")
@@ -104,7 +98,7 @@
                      :height         "100%"
                      :background     (:container-body-bg ct)
                      ;; Dashed NEUTRAL orthogonal-zone delineation; solid
-                     ;; runtime-accent when active (rf2-80rm2 / rf2-az6e2).
+                     ;; runtime-accent when active.
                      :border         (str border-w "px " border-style " " border-color)
                      :border-radius  (str compound-radius "px")
                      :box-shadow     (when active?
@@ -141,8 +135,8 @@
                         :font-family mono-stack}}
          "∥"]
         label]
-       ;; rf2-shv82 — invisible xyflow attachment points so an edge
-       ;; whose endpoint is a region container has a handle to anchor
-       ;; to. Without them xyflow silently drops the edge (same
-       ;; mechanic as the compound-node fix).
+       ;; Invisible xyflow attachment points so an edge whose endpoint
+       ;; is a region container has a handle to anchor to. Without them
+       ;; xyflow silently drops the edge (same mechanic as the
+       ;; compound-node).
        (four-cardinal-handles)])))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/xyflow_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/xyflow_node.cljs
@@ -9,9 +9,8 @@
   `Handle` React class + the four `Position` constants for its
   invisible edge-attachment points, and (for the geometry-bearing
   nodes) recovers the resolved density's `visual-constants` map off the
-  `clj->js`-ed node `:data`. That preamble was byte-identical in each
-  node ns; consolidating it here removes the copy-paste while keeping
-  the rendered output pixel-identical.
+  `clj->js`-ed node `:data`. This ns owns that shared preamble once, so
+  every node ns shares one implementation.
 
   This ns deliberately requires NOTHING from `chart.nodes` (which
   requires the per-kind node nss), so there is no dependency cycle —
@@ -39,15 +38,15 @@
 
 ;; ---- four-cardinal edge-attachment Handles ------------------------------
 ;;
-;; rf2-idx41 — the leaf state, compound container, parallel-region
-;; container, and event nodes all attach edges the SAME way: an invisible
-;; `Handle` on each cardinal side, with the LEFT + TOP as targets and the
-;; RIGHT + BOTTOM as sources (the left/right handles carry the `"left"` /
+;; The leaf state, compound container, parallel-region container, and
+;; event nodes all attach edges the SAME way: an invisible `Handle` on
+;; each cardinal side, with the LEFT + TOP as targets and the RIGHT +
+;; BOTTOM as sources (the left/right handles carry the `"left"` /
 ;; `"right"` ids the entry-edge `:targetHandle` + the routed sources
-;; address). That four-`Handle` cluster was copy-pasted in each node ns;
-;; this fragment owns it once. Handles are `opacity 0` (xyflow still
-;; measures them for `handleBounds` so an edge has a slot to anchor to —
-;; the rf2-shv82 compound/region drop fix) without adding visible chrome.
+;; address). This fragment owns that four-`Handle` cluster once. Handles
+;; are `opacity 0` (xyflow still measures them for `handleBounds` so an
+;; edge has a slot to anchor to — without a handle xyflow silently drops
+;; an edge incident on a compound/region) without adding visible chrome.
 
 (defn four-cardinal-handles
   "A React fragment of the four invisible cardinal `Handle`s every
@@ -70,9 +69,9 @@
   "Recover the resolved visual-constants map off a node's `:data`
   (`(.-chart d)`). The projector emits a CLJS map; xyflow `clj->js`-es
   it into a JS object, so we `js->clj` it back with keyword keys.
-  Returns `vc/chart-regular` when absent so the regular density stays
-  pixel-identical to the pre-rf2-k647w hardcoded numbers (legacy /
-  direct construction also lands on the regular default)."
+  Returns `vc/chart-regular` when absent so a node payload without a
+  `:chart` entry (direct construction) still renders the regular
+  density."
   [^js d]
   (let [c (.-chart d)]
     (if (some? c)
@@ -80,7 +79,7 @@
       vc/chart-regular)))
 
 (defn palette-of
-  "rf2-az6e2 — recover the resolved chart-semantic token map off a
+  "Recover the resolved chart-semantic token map off a
   node's `:data` (`(.-palette d)`). The projector threads
   `theme/tokens/chart-tokens` of the active `:theme` palette here; xyflow
   `clj->js`-es it into a JS object so we `js->clj` it back with keyword

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
@@ -1,19 +1,14 @@
 (ns day8.re-frame2-machines-viz.chart.overlays.after-rings
-  "xyflow `:after`-timer countdown-ring overlay (rf2-uv1on · xyflow
-  Phase 2).
+  "xyflow `:after`-timer countdown-ring overlay.
 
   ## Why this exists
 
-  The rf2-gpzb4 xyflow migration ported the MachineChart from
-  ELK+hand-rolled-SVG to `@xyflow/react`. Under the old renderer the
-  chart published a positioned graph (`{:nodes [{:x :y :width
-  :height}]}`) and the after-rings overlay (Xray-side) read positions
-  straight off that data. xyflow owns node positions in the rendered
-  DOM instead — so the overlay can no longer read a positioned graph;
-  it must WALK THE DOM to find each bearing node's bounding box.
+  xyflow owns node positions in the rendered DOM, so the overlay
+  cannot read a positioned graph off the chart data; it WALKS THE DOM
+  to find each bearing node's bounding box.
 
-  This ns is the machines-viz home for that overlay (per the bead's
-  Surface §). It is pure presentation + DOM measurement:
+  This ns is the machines-viz home for that overlay. It is pure
+  presentation + DOM measurement:
 
     - It takes a vector of presentation-ready `ring-specs` (each
       carrying `:node-id` + the `countdown-ring` payload — `:fraction`
@@ -43,9 +38,8 @@
   xyflow lays the DOM out in final on-screen coordinates (its pan +
   zoom are baked into the rendered node rects), so the overlay reads
   the rects AS RENDERED and positions rings at those exact screen
-  positions. The rf2-obp4z `translate(tx,ty) scale(s)` machinery the
-  SVG renderer needed is gone — there is no separate viewport to
-  mirror.
+  positions. There is no separate viewport to mirror — no
+  `translate(tx,ty) scale(s)` transform is needed.
 
   ## Re-measure triggers (Lock #8 — 60Hz when visible)
 
@@ -84,7 +78,7 @@
   `[data-testid=\"rf-mv-chart-node-<id>\"]`. Returns the rect map or
   nil when the node isn't in the DOM (off-screen / not yet mounted /
   compound parent without a leaf). Uses the shared `overlay-anchor`
-  DOM seam (rf2-ed099)."
+  DOM seam."
   [^js root node-id]
   (when (and root node-id)
     (anchor/query-node-rect-by-testid root (anchor/node->testid node-id))))
@@ -196,10 +190,10 @@
          (reset! latest-specs (vec (or ring-specs [])))
          (when (seq ring-specs)
            (let [rings @positioned]
-             ;; rf2-idx41 — the after-rings overlay sits at z-index 3 (one
-             ;; below the card overlays) so the rings tuck under any
-             ;; anchored card; `:pointer-events none` lets clicks fall
-             ;; through to the chart, and individual rings opt back in.
+             ;; The after-rings overlay sits at z-index 3 (one below the
+             ;; card overlays) so the rings tuck under any anchored card;
+             ;; `:pointer-events none` lets clicks fall through to the
+             ;; chart, and individual rings opt back in.
              [:div (merge (scaffold/overlay-root-props root-ref 3)
                           {:data-testid     testid
                            :data-ring-count (str (count ring-specs))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry.cljc
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-machines-viz.chart.overlays.after-rings-geometry
-  "Pure geometry for the xyflow `:after`-timer countdown-ring overlay
-  (rf2-uv1on · xyflow Phase 2).
+  "Pure geometry for the xyflow `:after`-timer countdown-ring overlay.
 
   ## Why a separate .cljc
 
@@ -21,9 +20,8 @@
   in overlay-local space is the node's viewport centre MINUS the
   container's viewport origin. xyflow's internal pan/zoom is already
   baked into the rendered rects, so the overlay needs no separate
-  viewport-transform (the rf2-obp4z `translate(tx,ty) scale(s)`
-  machinery the SVG renderer needed is obsolete — xyflow lays the
-  DOM out in final on-screen coordinates).
+  viewport-transform — xyflow lays the DOM out in final on-screen
+  coordinates, with no `translate(tx,ty) scale(s)` transform to mirror.
 
   ## Ring radius
 
@@ -88,10 +86,9 @@
         :cy (- ncy cy-origin)
         :r  (ring-radius node-rect zoom)}))))
 
-;; rf2-ee38b.21 — the byte-identical `state->node-testid` helper that
-;; lived here was removed; the canonical node-id → testid helper is
-;; `overlay-anchor/node->testid` (the shared overlay seam). `after_rings`
-;; calls it directly.
+;; The canonical node-id → testid helper is `overlay-anchor/node->testid`
+;; (the shared overlay seam); `after_rings` calls it directly. This ns
+;; keeps no testid helper of its own — one source of truth for the string.
 
 (defn overlay-rings
   "Pure projection: for each `{:node-id ...}`-bearing ring spec, merge

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
@@ -1,16 +1,14 @@
 (ns day8.re-frame2-machines-viz.chart.overlays.cancellation-cascade
-  "xyflow cancellation-cascade visualiser overlay (rf2-3ow55 · xyflow
-  Phase 2).
+  "xyflow cancellation-cascade visualiser overlay.
 
   ## Why this exists
 
-  xyflow Phase 1 (#1806) deferred the cross-cutting Xray machine
-  surfaces. This overlay restores the cancellation-cascade visualiser
-  (Xray 003 §M.3 — cancellation cascade ambiguity): when a parent
-  transition cancels child machines, the scattered abort/destroy
-  traces become ONE decision laid out vertically — the parent's exit
-  → each destroyed child / aborted request, indented as a waterfall
-  beneath the parent state.
+  This overlay is the cancellation-cascade visualiser (Xray 003 §M.3 —
+  cancellation cascade ambiguity): when a parent transition cancels
+  child machines, the scattered abort/destroy traces become ONE
+  decision laid out vertically — the parent's exit → each destroyed
+  child / aborted request, indented as a waterfall beneath the parent
+  state.
 
   ## Pure-presentation, host-projected (mirrors after-rings)
 
@@ -46,8 +44,8 @@
 ;; ---- DOM measurement ----------------------------------------------------
 ;;
 ;; The waterfall anchors BELOW the parent state; the DOM walk + container
-;; re-base is the shared `anchor/measure-anchor` seam (rf2-jkake.16) — this
-;; overlay supplies only the `anchor-below` placement.
+;; re-base is the shared `anchor/measure-anchor` seam — this overlay
+;; supplies only the `anchor-below` placement.
 
 ;; ---- cascade-step glyph -------------------------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
@@ -1,7 +1,7 @@
 (ns day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
   "Pure anchoring geometry shared by the xyflow chart's HTML/SVG
-  overlays (rf2-3ow55 · xyflow Phase 2 — the `:spawn-all` join
-  inspector + the cancellation-cascade visualiser).
+  overlays (the `:spawn-all` join inspector + the cancellation-cascade
+  visualiser).
 
   ## Why a separate .cljc
 
@@ -35,9 +35,8 @@
   <id>\")` contract. Returns nil for a nil / blank node-id so the
   overlay skips rather than querying a garbage selector.
 
-  rf2-ee38b.21 — this is the SINGLE canonical helper for the
-  node-id → testid string. `after_rings_geometry` previously carried a
-  byte-identical `state->node-testid`; it now points here."
+  This is the SINGLE canonical helper for the node-id → testid string;
+  every overlay routes through it so the selector is minted one way."
   [node-id]
   (when (and node-id (not (str/blank? (str node-id))))
     (str "rf-mv-chart-node-" node-id)))
@@ -46,7 +45,7 @@
    (defn rect->map
      "JS `DOMRect` → the `{:left :top :width :height}` map the anchoring
      helpers consume. Returns nil for a nil rect. CLJS-only (DOM
-     interop); the overlays share this single seam (rf2-ed099)."
+     interop); the overlays share this single seam."
      [^js dom-rect]
      (when dom-rect
        {:left   (.-left dom-rect)
@@ -60,8 +59,7 @@
      the matched element's bounding rect as a `rect->map`, or nil when
      `root` / `testid` is missing or the node isn't in the DOM
      (off-screen / not yet mounted / compound parent without a leaf).
-     CLJS-only; the shared DOM-measurement seam for every chart overlay
-     (rf2-ed099)."
+     CLJS-only; the shared DOM-measurement seam for every chart overlay."
      [^js root testid]
      (when (and root testid)
        (let [el (.querySelector root (str "[data-testid=\"" testid "\"]"))]
@@ -76,7 +74,7 @@
      Returns nil when `root` / `node-id` is missing or the node isn't
      in the DOM. CLJS-only (DOM interop); the shared measurement seam
      the card overlays (cancellation-cascade, spawn-all-join) share so
-     each ns keeps only its anchor-fn choice (rf2-jkake.16)."
+     each ns keeps only its anchor-fn choice."
      [anchor-fn ^js root node-id]
      (when (and root node-id)
        (let [container (rect->map (.getBoundingClientRect root))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_scaffold.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_scaffold.cljs
@@ -2,7 +2,7 @@
   "Shared Reagent form-3 scaffold for the xyflow chart's DOM-measuring
   overlays (`after-rings`, `spawn-all-join`, `cancellation-cascade`).
 
-  ## Why this exists (rf2-idx41 — dedup)
+  ## Why this exists
 
   Every chart overlay is a Reagent form-3 component with a byte-identical
   measure-on-mount/update/resize lifecycle and an absolutely-positioned
@@ -10,8 +10,8 @@
   walk shares the chart wrapper's coordinate origin. That scaffold —
   the `root-ref` atom, the `remeasure!`-on-resize listener, the three
   `create-class` lifecycle hooks, and the overlay root `<div>` style —
-  was copy-pasted across the three overlay nss. This ns owns it ONCE so
-  each overlay keeps only its measurement strategy + paint.
+  lives here ONCE so each overlay keeps only its measurement strategy +
+  paint.
 
   CLJS-only: the lifecycle + DOM ref plumbing is browser-specific
   (`reagent.core/create-class`, `js/window`, `offsetParent`). The PURE

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
@@ -1,15 +1,13 @@
 (ns day8.re-frame2-machines-viz.chart.overlays.spawn-all-join
-  "xyflow `:spawn-all` join-inspector overlay (rf2-3ow55 · xyflow
-  Phase 2).
+  "xyflow `:spawn-all` join-inspector overlay.
 
   ## Why this exists
 
-  xyflow Phase 1 (#1806) deferred the cross-cutting Xray machine
-  surfaces. This overlay restores the `:spawn-all` join inspector
-  (Xray 003 §M.4 — `:spawn-all` never joins): when a state declares
-  `:spawn-all`, the inspector shows the N spawned children + their
-  per-child join state (done / running / failed) and whether the join
-  condition has resolved, anchored beside the spawn-all-bearing state.
+  This overlay is the `:spawn-all` join inspector (Xray 003 §M.4 —
+  `:spawn-all` never joins): when a state declares `:spawn-all`, the
+  inspector shows the N spawned children + their per-child join state
+  (done / running / failed) and whether the join condition has
+  resolved, anchored beside the spawn-all-bearing state.
 
   ## Pure-presentation, host-projected (mirrors after-rings)
 
@@ -45,9 +43,8 @@
 ;; ---- DOM measurement ----------------------------------------------------
 ;;
 ;; The join card anchors to the RIGHT of the bearing state; the DOM walk +
-;; container re-base is the shared `anchor/measure-anchor` seam
-;; (rf2-jkake.16) — this overlay supplies only the `anchor-right-of`
-;; placement.
+;; container re-base is the shared `anchor/measure-anchor` seam — this
+;; overlay supplies only the `anchor-right-of` placement.
 
 ;; ---- child-row glyph ----------------------------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
@@ -1,8 +1,8 @@
 (ns day8.re-frame2-machines-viz.chart.post-elk
   "Post-ELK layout subsystem for the MachineChart — the adaptive-aspect
   rebalance + back-edge return-route detour that close the two structural
-  Stately-parity residuals ELK alone cannot reach (rf2-lamdfl + rf2-gnrkke;
-  `001-Topology-Parity.md` §4.3.1 + §4.3.2).
+  Stately-parity residuals ELK alone cannot reach (`001-Topology-Parity.md`
+  §4.3.1 + §4.3.2).
 
   ## OPT-IN — the default render is UNTOUCHED
 
@@ -11,10 +11,9 @@
   for the adaptive pass via `:direction :auto`. With the DEFAULT
   `:direction :tb` (or an explicit `:tb` / `:lr`), `chart.cljs` does NOT
   resolve a heuristic direction and does NOT run `apply-post-elk` — the ELK
-  result flows to the projector byte-for-byte the way it does on main. The
-  reverted first build (#3453) made `:auto` the DEFAULT and re-laid EVERY
-  machine; this redo keeps every existing machine pixel-identical unless it
-  opts in. `chart.post-elk/adaptive?` is the single gate predicate.
+  result flows to the projector byte-for-byte. The #1 contract here is that
+  a machine's render is unchanged unless it explicitly opts in.
+  `chart.post-elk/adaptive?` is the single gate predicate.
 
   ## Why a SEPARATE stage (the §4.3 verdict)
 
@@ -30,14 +29,14 @@
       (column vs landscape per machine) PLUS a post-ELK coordinate
       transpose for parallel regions.
 
-    - **§4.3.1 G-ROUTE** — under events-as-nodes (rf2-qo5xy) a back-edge
+    - **§4.3.1 G-ROUTE** — under events-as-nodes a back-edge
       `alarming → reset → locked` is two ELK edges through a synthetic
       `reset` event-node; ELK ranks `reset` one layer BELOW the deepest
       state (it is a forward target of the already-deepest source), so the
       return reads as a long detour to the canvas bottom. GREEDY cycle-
-      breaking lifts it but inverts the initial-on-top spine (rf2-ly51l).
-      The only non-regressing path is a CUSTOM post-ELK reroute of the
-      back-edge's segments.
+      breaking lifts it but inverts the initial-on-top spine. The only
+      non-regressing path is a CUSTOM post-ELK reroute of the back-edge's
+      segments.
 
   ## What this ns owns — the opt-in gate + three PURE composable steps
 
@@ -92,41 +91,41 @@
   (:require [day8.re-frame2-machines-viz.chart.projection :as projection]))
 
 ;; ============================================================================
-;; Step 0 — the OPT-IN gate (rf2-lamdfl + rf2-gnrkke redo)
+;; Step 0 — the OPT-IN gate
 ;; ============================================================================
 ;;
-;; The #1 acceptance criterion of this redo: the DEFAULT render is byte-
-;; identical to main. So the whole post-ELK subsystem is gated behind an
-;; explicit opt-in `:direction :auto`. `chart.cljs` calls `adaptive?` once;
-;; on a falsey result it takes the historical path (no heuristic, no
+;; The #1 contract: the DEFAULT render is byte-identical to a plain ELK
+;; layout. So the whole post-ELK subsystem is gated behind an explicit
+;; opt-in `:direction :auto`. `chart.cljs` calls `adaptive?` once; on a
+;; falsey result it takes the non-adaptive path (no heuristic, no
 ;; apply-post-elk). Only `:auto` opts in. An explicit `:tb` / `:lr` is a
 ;; FORCED direction (the host's layout intent) — it skips the heuristic AND
-;; the transpose/reroute, exactly as a default `:tb` does today.
+;; the transpose/reroute, exactly as a default `:tb` does.
 
 (def adaptive-direction
   "The single sentinel `:direction` value that OPTS A MACHINE IN to the
-  adaptive post-ELK pass (rf2-lamdfl + rf2-gnrkke). A host passes
-  `:direction :auto` (e.g. resolved from a machine's `:layout {:aspect
-  :adaptive}` hint) to request per-machine aspect + the parallel-region
-  transpose + the back-edge reroute. Every other value (`:tb`, `:lr`, nil,
-  the default) takes the historical non-adaptive path."
+  adaptive post-ELK pass. A host passes `:direction :auto` (e.g. resolved
+  from a machine's `:layout {:aspect :adaptive}` hint) to request
+  per-machine aspect + the parallel-region transpose + the back-edge
+  reroute. Every other value (`:tb`, `:lr`, nil, the default) takes the
+  non-adaptive path."
   :auto)
 
 (defn adaptive?
-  "rf2-lamdfl + rf2-gnrkke — the OPT-IN predicate: does this `:direction`
-  prop value request the adaptive post-ELK pass? True ONLY for the explicit
-  `:auto` sentinel. Pure.
+  "The OPT-IN predicate: does this `:direction` prop value request the
+  adaptive post-ELK pass? True ONLY for the explicit `:auto` sentinel.
+  Pure.
 
   This is the single gate `chart.cljs` consults: a falsey result means the
   ENTIRE post-ELK subsystem (heuristic direction + parallel transpose +
-  back-edge reroute) is skipped and the render is byte-identical to main.
-  The default `:direction :tb`, an explicit `:tb` / `:lr`, and nil all
-  return false (non-adaptive); only `:auto` returns true."
+  back-edge reroute) is skipped and the render is a plain ELK layout. The
+  default `:direction :tb`, an explicit `:tb` / `:lr`, and nil all return
+  false (non-adaptive); only `:auto` returns true."
   [host-direction]
   (= host-direction adaptive-direction))
 
 ;; ============================================================================
-;; Step 1 — adaptive layout aspect: the orientation heuristic (rf2-lamdfl)
+;; Step 1 — adaptive layout aspect: the orientation heuristic
 ;; ============================================================================
 ;;
 ;; §4.3.2 wall 1: there is no ELK *balance* lever for Layered, and wrapping a
@@ -151,9 +150,9 @@
 ;; agrees with the Stately reference per the §4.3.2 measurements.
 
 (def landscape-branch-threshold
-  "rf2-lamdfl — the max single-state out-degree (distinct transition
-  TARGETS leaving one state) at or above which a flat machine is judged
-  BRANCHY enough to read better landscape (`:lr`) than as a column.
+  "The max single-state out-degree (distinct transition TARGETS leaving
+  one state) at or above which a flat machine is judged BRANCHY enough to
+  read better landscape (`:lr`) than as a column.
 
   3 captures the genuinely-branchy corpus machines (the gate `:gate/check`
   3-way guarded fork; the quiz / modal hubs that fan to several distinct
@@ -173,9 +172,8 @@
   (or (:target edge) (:source edge)))
 
 (defn max-out-degree
-  "rf2-lamdfl — the maximum, over all REAL statechart states, of the number
-  of DISTINCT transition targets leaving that state. Pure: parsed graph →
-  int.
+  "The maximum, over all REAL statechart states, of the number of DISTINCT
+  transition targets leaving that state. Pure: parsed graph → int.
 
   Counts only edges leaving a genuine state node (a synthetic machine-root /
   parallel-root anchor's machine-level fallback is not a state's own fan-out,
@@ -201,10 +199,10 @@
          (reduce max 0))))
 
 (defn aspect-direction
-  "rf2-lamdfl — the adaptive-aspect ORIENTATION heuristic: choose the ELK
-  layout direction for `parsed` so a large machine reads in a screen-
-  friendly proportion (the §4.3.2 G-ASPECT close). Pure: parsed graph →
-  `:tb` (column / DOWN) or `:lr` (landscape / RIGHT).
+  "The adaptive-aspect ORIENTATION heuristic: choose the ELK layout
+  direction for `parsed` so a large machine reads in a screen-friendly
+  proportion (the §4.3.2 G-ASPECT close). Pure: parsed graph → `:tb`
+  (column / DOWN) or `:lr` (landscape / RIGHT).
 
   Only consulted on the OPT-IN path (`adaptive?` true). Rules (in order):
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/primitives.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/primitives.cljc
@@ -1,10 +1,8 @@
 (ns day8.re-frame2-machines-viz.chart.primitives
   "Reusable SVG glyph primitives — `countdown-ring` and `sparkline`.
 
-  rf2-gpzb4 (2026-05-21) — relocated from the now-deleted
-  `chart/svg.cljc` in the xyflow migration. The xyflow chart owns
-  node + edge rendering; these primitives remain because they are
-  consumed OUTSIDE the chart canvas:
+  The xyflow chart owns node + edge rendering; these primitives live
+  here because they are consumed OUTSIDE the chart canvas:
 
     - `countdown-ring` — Xray's `panels/machine_after_rings.cljs`
       overlay paints rings ON TOP of the chart for the focused
@@ -19,7 +17,7 @@
   Both fns produce hiccup forms; substrate-agnostic; JVM-testable.
 
   Per `tools/machines-viz/spec/000-Vision.md` §Decision trace
-  §Interactive renderer (2026-05-21 xyflow override)."
+  §Interactive renderer."
   (:require [clojure.string :as str]
             [day8.re-frame2-machines-viz.theme.tokens :as tokens]))
 
@@ -65,11 +63,11 @@
         arc-len   (* f circ)
         gap-len   (- circ arc-len)
         token-key (get ring-color->token color :text-tertiary)
-        ;; rf2-uv1on — resolve through `var(--rf-xray-<key>, <hex>)`
-        ;; so light + dark themes both flow through the host's CSS
-        ;; custom-property surface (the xyflow overlay paints from the
-        ;; same palette the chart + host do). Falls back to the dark-
-        ;; palette hex for standalone embeds + the JVM hiccup tests.
+        ;; Resolve through `var(--rf-xray-<key>, <hex>)` so light + dark
+        ;; themes both flow through the host's CSS custom-property surface
+        ;; (the xyflow overlay paints from the same palette the chart +
+        ;; host do). Falls back to the dark-palette hex for standalone
+        ;; embeds + the JVM hiccup tests.
         stroke    (tokens/css-var token-key)
         opacity   (if cancelled? 0.4 0.85)]
     [:g {:data-testid    (or testid "rf-mv-chart-countdown-ring")

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -2,12 +2,11 @@
   "Pure-data projection layer for the MachineChart — the parsed graph
   → xyflow `:nodes` / `:edges` arrays + the elk.js `children` shape.
 
-  rf2-0gmwp (2026-05-21) — extracted from `chart.cljs` so the pure
-  projector is JVM-runnable. `chart.cljs` `:require`s `@xyflow/react`
-  + `elkjs`, which makes the WHOLE ns JVM-unloadable; the projection
-  itself is pure CLJS data → data with no DOM, React, or JS-interop,
-  so it lives here where the JVM test corpus can pin it directly
-  (mirroring the `chart.layout` parse split).
+  The projector is pure CLJS data → data with no DOM, React, or
+  JS-interop, so it lives here where the JVM test corpus can pin it
+  directly. (`chart.cljs` `:require`s `@xyflow/react` + `elkjs`, which
+  would make the whole ns JVM-unloadable.) This mirrors the
+  `chart.layout` parse split.
 
   ## What this owns
 
@@ -42,8 +41,8 @@
 ;; The elk projection (`elk-child`) and the node renderers
 ;; (`chart.nodes`) share these floors so a state's measured box and
 ;; its laid-out slot agree. This is their single canonical home (pure,
-;; JVM-readable, so the projection tests can reference them); rf2-kra7h
-;; — `chart.nodes` `:require`s this ns and reads them via
+;; JVM-readable, so the projection tests can reference them):
+;; `chart.nodes` `:require`s this ns and reads them via
 ;; `projection/<name>` for the renderer's CSS `min-width` /
 ;; `min-height` rather than re-declaring its own copies.
 
@@ -52,45 +51,41 @@
   based on their measured size; this floor gives every node a
   consistent rhythm without overflowing labels.
 
-  rf2-az6e2 — lifted 140 → 152 to match the title/body box grammar (the
-  full-width title strip wants a touch more horizontal rhythm than the
-  prior centred-pill body)."
+  152px matches the title/body box grammar — the full-width title strip
+  wants a touch more horizontal rhythm than a centred-pill body would."
   152)
 
 (def state-node-min-height
   "Minimum height in px for a state node body.
 
-  rf2-az6e2 — lifted 44 → 58 to match the title-strip + body geometry
-  (title strip ~24px + a body band for tags / action rows)."
+  58px matches the title-strip + body geometry (title strip ~24px + a
+  body band for tags / action rows)."
   58)
 
 (def machine-root-node-min-width
-  "rf2-vcnvj — minimum width for the synthetic MACHINE-ROOT chip (the
-  source of a machine-level top-level `:on` fallback). A compact root-
-  context chip, narrower than a state box so it reads as the root anchor
-  rather than a peer state."
+  "Minimum width for the synthetic MACHINE-ROOT chip (the source of a
+  machine-level top-level `:on` fallback). A compact root-context chip,
+  narrower than a state box so it reads as the root anchor rather than a
+  peer state."
   120)
 
 (def machine-root-node-min-height
-  "rf2-vcnvj — minimum height for the synthetic MACHINE-ROOT chip. A
-  single header line — no body band."
+  "Minimum height for the synthetic MACHINE-ROOT chip. A single header
+  line — no body band."
   30)
 
 (def compound-node-min-width
-  "Minimum width for a compound container.
-
-  rf2-az6e2 — lifted 220 → 260 so the solid title-strip container has
-  room for the strip label + the body band above its children."
+  "Minimum width for a compound container. 260px gives the solid
+  title-strip container room for the strip label + the body band above
+  its children."
   260)
 
 (def compound-node-min-height
-  "Minimum height for a compound container.
-
-  rf2-az6e2 — lifted 120 → 150 so the title strip + optional metadata
-  band do not crowd the nested children."
+  "Minimum height for a compound container. 150px keeps the title strip
+  + optional metadata band from crowding the nested children."
   150)
 
-;; ---- initial-marker glyph offsets (rf2-i9d2ob / rf2-d5s7yg) -------------
+;; ---- initial-marker glyph offsets --------------------------------------
 ;;
 ;; The initial-state marker node is positioned at a FIXED, SMALL offset from
 ;; its state so the fixed glyph (`chart.nodes/initial-marker` — dot + Q-hook
@@ -98,46 +93,40 @@
 ;; near (left) edge — the Stately/xstate-viz `InitialEdgeViz` signature (a
 ;; visible gap pointing AT the edge, NOT penetrating it).
 ;;
-;; rf2-d5s7yg — the dot offset is DECOUPLED from the arrow-tip position. The
-;; node sits `initial-marker-x-offset` (26) px left of the state (so the dot
-;; CENTRE lands `offset - dot-x` px outside the edge — `state.x - 19` at
-;; regular density), but the glyph's arrowhead tip is drawn at
-;; node-local x = `(offset - initial-marker-tip-gap)`, so the absolute tip
-;; lands at `state.x - gap` — a clean ~`gap`px gap OUTSIDE the edge. Before
-;; rf2-d5s7yg the offset (48) equalled the glyph arm and the tip landed at
-;; `state.x` (the edge) — overshooting INTO nested states once xyflow's
-;; `:extent "parent"` clamped the deeply-negative marker position rightward.
+;; The dot offset is DECOUPLED from the arrow-tip position. The node sits
+;; `initial-marker-x-offset` (26) px left of the state (so the dot CENTRE
+;; lands `offset - dot-x` px outside the edge — `state.x - 19` at regular
+;; density), but the glyph's arrowhead tip is drawn at node-local x =
+;; `(offset - initial-marker-tip-gap)`, so the absolute tip lands at
+;; `state.x - gap` — a clean ~`gap`px gap OUTSIDE the edge. The decoupling
+;; keeps the tip from landing on `state.x` (the edge) and overshooting INTO
+;; nested states once xyflow's `:extent "parent"` clamps a deeply-negative
+;; marker position rightward.
 
 (def initial-marker-x-offset
-  "rf2-i9d2ob / rf2-d5s7yg / rf2-wwyx1u — horizontal offset (px) of the
-  initial-marker node LEFT of its state. SMALL (the Stately short-hook
-  span): the filled dot's CENTRE lands `(offset - dot-x)` px outside the
-  state's left edge — `state.x - 19` at regular density (offset 26, `dot-x =
-  pseudo-radius + 1 = 7`). The arrow tip is drawn further right in the glyph
-  (`offset - initial-marker-tip-gap`) so the tip ends just OUTSIDE the edge,
-  not on/through it.
+  "Horizontal offset (px) of the initial-marker node LEFT of its state.
+  SMALL (the Stately short-hook span): the filled dot's CENTRE lands
+  `(offset - dot-x)` px outside the state's left edge — `state.x - 19` at
+  regular density (offset 26, `dot-x = pseudo-radius + 1 = 7`). The arrow
+  tip is drawn further right in the glyph (`offset - initial-marker-tip-gap`)
+  so the tip ends just OUTSIDE the edge, not on/through it.
 
-  rf2-wwyx1u — bumped 20 → 22 so the glyph has room for a SMALL Stately-
-  sized arrowhead AND a short FORWARD-flowing hook (dot → down-right curve
-  → arrowhead). At 20 with the old oversized arrowhead the hook ran
-  BACKWARDS; the extra 2px (paired with the small arrowhead in
-  `chart.nodes/initial-marker`) restores a clean dot → forward-hook →
-  small-arrow-into-edge unit. (At the rf2-wwyx1u offset 22 the dot centre
-  landed at `state.x - 15`, matching Stately's `startPoint.x = node.x - 15`;
-  rf2-k7kiiq below bumps the offset to 26, moving the centre to
-  `state.x - 19`.)
+  26 gives the glyph room for a SMALL Stately-sized arrowhead AND a short
+  FORWARD-flowing hook (dot → down-right curve → arrowhead). Paired with
+  the small arrowhead in `chart.nodes/initial-marker`, it yields a clean
+  dot → forward-hook → small-arrow-into-edge unit (a tighter offset with
+  an oversized arrowhead would run the hook BACKWARDS).
 
-  rf2-k7kiiq — bumped 22 → 26 to LENGTHEN the visible hook arm (Stately-
-  aligned glyph tuning). The arm length is `end-x - dot-x`; with the
-  arrowhead-ceiling raised to 6 (below) a longer `tip-x` (= offset −
-  tip-gap) is REQUIRED to keep `end-x = tip-x − ah > dot-x` in every
-  density. The +4px lands a clearly-visible arm AND a larger arrowhead
-  clear of the dot."
+  The offset also LENGTHENS the visible hook arm (Stately-aligned glyph
+  tuning). The arm length is `end-x - dot-x`; with the arrowhead-ceiling at
+  6 (below) a longer `tip-x` (= offset − tip-gap) is REQUIRED to keep
+  `end-x = tip-x − ah > dot-x` in every density — so 26 lands a clearly-
+  visible arm AND a larger arrowhead clear of the dot."
   26)
 
 (def initial-marker-tip-gap
-  "rf2-d5s7yg / rf2-wwyx1u — the visible GAP (px) between the initial-glyph
-  arrow tip and the state's left edge. The tip is drawn at node-local x =
+  "The visible GAP (px) between the initial-glyph arrow tip and the state's
+  left edge. The tip is drawn at node-local x =
   `(initial-marker-x-offset - initial-marker-tip-gap)`, so its ABSOLUTE x is
   `state.x - initial-marker-tip-gap` — a small clean gap OUTSIDE the edge,
   the Stately/xstate-viz `endPoint.x = node.x - 10` signature. The glyph
@@ -145,16 +134,16 @@
   7)
 
 (def initial-marker-y-offset
-  "rf2-i9d2ob — vertical offset (px) of the initial-marker node BELOW its
-  state's top edge — roughly the title-strip centre, so the glyph's arrow
-  points into the state's near edge near its title row."
+  "Vertical offset (px) of the initial-marker node BELOW its state's top
+  edge — roughly the title-strip centre, so the glyph's arrow points into
+  the state's near edge near its title row."
   14)
 
 (def initial-marker-left-extent
-  "rf2-lxk3h3 — the px the initial-state glyph extends LEFT of its target
-  state's near (left) edge — i.e. how far a container must reserve on its
-  LEFT so a NESTED initial substate's marker sits fully INSIDE the
-  container border instead of spilling past it.
+  "The px the initial-state glyph extends LEFT of its target state's near
+  (left) edge — i.e. how far a container must reserve on its LEFT so a
+  NESTED initial substate's marker sits fully INSIDE the container border
+  instead of spilling past it.
 
   The marker node is positioned at `state.x - initial-marker-x-offset`
   (it sits that far left of the state). Inside that node's local frame the
@@ -162,8 +151,8 @@
   reservation anchors to the dot's GEOMETRY-radius left edge — node-local
   x = `dot-x - pseudo-radius = (pseudo-radius + 1) - pseudo-radius = 1`
   (`initial-marker-glyph`) — NOT the slightly-narrower PAINTED left edge at
-  x = `dot-x - dot-paint-r = 1.5` (the dot is painted at `pseudo-radius − 0.5`,
-  rf2-k7kiiq). Anchoring to the geometry-radius edge is the conservative
+  x = `dot-x - dot-paint-r = 1.5` (the dot is painted at `pseudo-radius − 0.5`).
+  Anchoring to the geometry-radius edge is the conservative
   choice: it reserves the wider extent, so the painted ink (which only
   reaches x=1.5) always lands INSIDE the reservation. So the dot's
   geometry-radius left edge lands at absolute
@@ -181,12 +170,12 @@
   initial-marker-x-offset)
 
 (defn initial-marker-glyph
-  "rf2-wwyx1u — PURE geometry of the initial-state glyph (filled dot +
-  single Q-hook + small triangle arrowhead), in the marker node's LOCAL
-  coordinate frame, given the active density's `pseudo-radius` (the dot
-  radius). Single-sources the math the `chart.nodes/initial-marker`
-  renderer paints AND the projection test asserts, so the FORWARD-FLOW
-  invariant (`end-x > dot-x`) cannot silently regress again.
+  "PURE geometry of the initial-state glyph (filled dot + single Q-hook +
+  small triangle arrowhead), in the marker node's LOCAL coordinate frame,
+  given the active density's `pseudo-radius` (the dot radius). Single-
+  sources the math the `chart.nodes/initial-marker` renderer paints AND the
+  projection test asserts, so the FORWARD-FLOW invariant (`end-x > dot-x`)
+  cannot silently regress.
 
   Layout (node-local x; the state's left edge is at x=`initial-marker-x-
   offset`, since the node sits that far LEFT of the state):
@@ -195,8 +184,8 @@
     - `tip-x` — the arrowhead tip, at `offset - tip-gap`, so its ABSOLUTE x
       is `state.x - tip-gap` (a small gap OUTSIDE the edge, pointing AT it);
     - `ah`    — the SMALL Stately-sized arrowhead side (≈ dot diameter / 2,
-      clamped to a 4–6px band, rf2-k7kiiq) — NOT the oversized
-      `arrow-width-entry` that drove the backwards-hook regression;
+      clamped to a 4–6px band) — NOT the oversized `arrow-width-entry`,
+      which would drive a backwards hook;
     - `end-x` — the arrowhead BASE (`tip-x - ah`), where the stroked hook
       meets the triangle. The glyph reads as ONE clean unit IFF
       `end-x > dot-x` (the hook flows dot → down-and-RIGHT into the head).
@@ -206,10 +195,10 @@
   (let [;; SMALL Stately-sized head: ≈ dot diameter / 2, but CLAMPED to a
         ;; 4–6px band so it stays Stately-small in EVERY density (Stately's
         ;; marker is a fixed ~5×6 regardless of node size). An uncapped
-        ;; `pseudo-radius`-scaled head squeezed the forward hook run in cosy.
-        ;; rf2-k7kiiq — ceiling raised 5 → 6 for a slightly LARGER arrowhead;
-        ;; the paired offset bump (22 → 26) keeps `end-x > dot-x` (the bigger
-        ;; head lowers `end-x = tip-x − ah`, so the two MUST tune together).
+        ;; `pseudo-radius`-scaled head would squeeze the forward hook run in
+        ;; cosy. The 6px ceiling gives a slightly larger arrowhead; it tunes
+        ;; with `initial-marker-x-offset` (the bigger head lowers
+        ;; `end-x = tip-x − ah`, so the offset must keep `end-x > dot-x`).
         ah    (-> (dec pseudo-radius) (max 4) (min 6))
         tip-x (- initial-marker-x-offset initial-marker-tip-gap)
         dot-x (+ pseudo-radius 1)
@@ -218,7 +207,7 @@
 
 ;; ---- synthetic event-node helpers --------------------------------------
 ;;
-;; rf2-qo5xy events-as-nodes paradigm: each parsed transition emits ONE
+;; Under the events-as-nodes paradigm each parsed transition emits ONE
 ;; synthetic xyflow node sitting between source and target states. These
 ;; two tiny pure helpers bucket the variant + mint the stable id, and are
 ;; consumed by BOTH the elk children projection (`elk-event-child` below)
@@ -226,11 +215,11 @@
 ;; above both rather than buried inside the graph-projection section.
 
 (defn event-variant
-  "rf2-qo5xy — bucket a parsed edge by its event variant for the
-  events-as-nodes paradigm: `:after` (clock glyph), `:always`
-  (infinity glyph), `:on-done` (completion ✓ done chip — rf2-41goo, the
-  XState `onDone` compound/parallel completion transition), or `:on`
-  (regular event keyword). Pure data → keyword."
+  "Bucket a parsed edge by its event variant for the events-as-nodes
+  paradigm: `:after` (clock glyph), `:always` (infinity glyph),
+  `:on-done` (completion ✓ done chip — the XState `onDone`
+  compound/parallel completion transition), or `:on` (regular event
+  keyword). Pure data → keyword."
   [edge]
   (cond
     (:on-done? edge) :on-done
@@ -239,16 +228,16 @@
     :else            :on))
 
 (defn event-node-id
-  "rf2-qo5xy — stable string id for an event-node. The xyflow node
-  inserted between the source state and the (optional) target state
-  in the events-as-nodes paradigm. Derived from the canonical edge-id
-  (`chart.layout/edge-id`) so two transitions sharing source/target/
-  event/guard/action keep distinct event-node ids — the same
-  collision-tiebreak `chart.layout/project-flat` applies."
+  "Stable string id for an event-node. The xyflow node inserted between
+  the source state and the (optional) target state in the events-as-nodes
+  paradigm. Derived from the canonical edge-id (`chart.layout/edge-id`) so
+  two transitions sharing source/target/event/guard/action keep distinct
+  event-node ids — the same collision-tiebreak `chart.layout/project-flat`
+  applies."
   [edge]
   (str "event__" (:id edge)))
 
-;; ---- guarded-fork branch-order (rf2-uw3vmi) -----------------------------
+;; ---- guarded-fork branch-order -----------------------------------------
 ;;
 ;; Stately renders a guarded multi-branch fork — the gate machine's
 ;; `:gate/check` 3-way (`[{:guard :gate-high? …} {:guard :gate-low? …}
@@ -263,13 +252,13 @@
 ;; This helper derives, from the ORDERED `:edges` vector, a
 ;; `{edge-id → 1-based-priority}` map for every edge that is one branch of
 ;; a GENUINE guarded fork. The numbered badge is the additive Stately
-;; affordance; the per-branch `IF <guard>` wording is the SETTLED IF-guard
+;; affordance; the per-branch `IF <guard>` wording is the IF-guard
 ;; divergence (parity spec §3.2) and is untouched.
 
 (defn fork-trigger-key
-  "rf2-uw3vmi — the grouping key that decides whether two edges leaving
-  the SAME source belong to the SAME guarded fork: they must share the
-  same TRIGGER. A trigger is one of:
+  "The grouping key that decides whether two edges leaving the SAME source
+  belong to the SAME guarded fork: they must share the same TRIGGER. A
+  trigger is one of:
 
     - an `:on` event keyword (`:gate/check`)         → `[:on <event>]`
     - an `:after` timer delay (`5000`)               → `[:after <ms>]`
@@ -289,12 +278,12 @@
     :else           [:on (:event edge)]))
 
 (defn fork-groups
-  "rf2-uw3vmi — the SHARED definition of a genuine guarded multi-branch
-  fork, returned as a seq of ORDERED candidate-edge groups (each group is
-  the same-source / same-trigger candidate vector, in first-pass-wins
-  order). The single source of truth `fork-order-by-edge-id` (the numbered
-  badges) AND `fork-connector-edges` (rf2-o3rkq1 — the dotted evaluation-
-  order connector) both build on.
+  "The SHARED definition of a genuine guarded multi-branch fork, returned
+  as a seq of ORDERED candidate-edge groups (each group is the same-source
+  / same-trigger candidate vector, in first-pass-wins order). The single
+  source of truth `fork-order-by-edge-id` (the numbered badges) AND
+  `fork-connector-edges` (the dotted evaluation-order connector) both build
+  on.
 
   A guarded fork is a group of edges sharing the SAME source AND the SAME
   `fork-trigger-key` with:
@@ -329,9 +318,8 @@
                       (some :guard group))))))
 
 (defn fork-order-by-edge-id
-  "rf2-uw3vmi — map each edge-id to its 1-based branch-priority index
-  WHEN that edge is one branch of a genuine guarded multi-branch fork
-  (`fork-groups`).
+  "Map each edge-id to its 1-based branch-priority index WHEN that edge is
+  one branch of a genuine guarded multi-branch fork (`fork-groups`).
 
   Within a qualifying group the priority is the candidate's position in
   the ORDERED `:edges` vector — which `chart.layout` preserves from the
@@ -347,17 +335,16 @@
              (mapcat (fn [group]
                        (map-indexed (fn [i e] [(:id e) (inc i)]) group))))))
 
-;; ---- guarded-fork branch LAYOUT ORDER (rf2-p75kbg) ----------------------
+;; ---- guarded-fork branch LAYOUT ORDER ----------------------------------
 ;;
-;; rf2-p75kbg — Stately stacks a guarded fork's branches in PRIORITY ORDER
-;; (1, 2, 3) so the dotted evaluation-order connector (rf2-o3rkq1) reads as
-;; a clean monotonic line. ELK's LAYER_SWEEP crossing-minimisation, by
-;; contrast, freely REORDERS the same-rank branch event-nodes (the gate
-;; fork lands 3,1,2 left-to-right), so the connector — which links the
-;; branches in priority order 1→2→3 — has to cross over itself (a bow-tie
-;; weave).
+;; Stately stacks a guarded fork's branches in PRIORITY ORDER (1, 2, 3) so
+;; the dotted evaluation-order connector reads as a clean monotonic line.
+;; ELK's LAYER_SWEEP crossing-minimisation, by contrast, freely REORDERS
+;; the same-rank branch event-nodes (the gate fork lands 3,1,2 left-to-
+;; right), so the connector — which links the branches in priority order
+;; 1→2→3 — would otherwise have to cross over itself (a bow-tie weave).
 ;;
-;; The fix pins each fork-branch EVENT-NODE's within-layer order to its
+;; Each fork-branch EVENT-NODE's within-layer order is pinned to its
 ;; priority index via the `elk.position` hint, paired with the container's
 ;; `elk.layered.crossingMinimization.semiInteractive` (`fork-branch-
 ;; container-ids` flags the holding containers). semiInteractive constrains
@@ -366,8 +353,8 @@
 ;; branches and touches nothing else.
 
 (defn fork-branch-event-positions
-  "rf2-p75kbg — map each GUARDED-FORK branch EVENT-NODE id to its 1-based
-  priority index, for the `elk.position` within-layer ordering hint. Reuses
+  "Map each GUARDED-FORK branch EVENT-NODE id to its 1-based priority
+  index, for the `elk.position` within-layer ordering hint. Reuses
   `fork-order-by-edge-id` (the single source of fork-branch priority — same
   index as the numbered badge + the dotted connector) and re-keys it from
   the spec edge-id to the synthetic event-node id ELK actually lays out.
@@ -381,9 +368,9 @@
                (fork-order-by-edge-id edges))))
 
 (defn fork-branch-container-ids
-  "rf2-p75kbg — the SET of container ids (the `:parent-id` each fork's
-  branch event-nodes lay out under; `nil` == the root container) that hold
-  at least one guarded multi-branch fork. A container in this set gets
+  "The SET of container ids (the `:parent-id` each fork's branch
+  event-nodes lay out under; `nil` == the root container) that hold at
+  least one guarded multi-branch fork. A container in this set gets
   `elk.layered.crossingMinimization.semiInteractive = true` so the
   `elk.position` hints on its fork-branch event-nodes are honoured; every
   other container keeps the default (full crossing-minimisation), so the
@@ -402,8 +389,8 @@
          (into #{}))))
 
 (defn fork-connector-edges
-  "rf2-o3rkq1 — DECORATIVE dotted evaluation-order connector edges across
-  the branches of a guarded multi-branch fork (`fork-groups`).
+  "DECORATIVE dotted evaluation-order connector edges across the branches
+  of a guarded multi-branch fork (`fork-groups`).
 
   Stately joins the branches of a guarded fork (the gate machine's
   `:gate/check` 3-way) with a DOTTED connector linking the numbered
@@ -441,12 +428,12 @@
                    :source (event-node-id from)
                    :target (event-node-id to)
                    :type   "transition"
-                   ;; rf2-4vvywg — ANCHOR the connector to EXPLICIT handles
-                   ;; rather than relying on xyflow's default handle pick.
-                   ;; The branch event-nodes lay out LEFT-TO-RIGHT in
-                   ;; priority order (1→2→3, the within-layer cross-axis
-                   ;; under the chart's DOWN direction; rf2-p75kbg), so the
-                   ;; order chain must read side-to-side: it leaves each
+                   ;; ANCHOR the connector to EXPLICIT handles rather than
+                   ;; relying on xyflow's default handle pick. The branch
+                   ;; event-nodes lay out LEFT-TO-RIGHT in priority order
+                   ;; (1→2→3, the within-layer cross-axis under the chart's
+                   ;; DOWN direction), so the order chain must read side-to-
+                   ;; side: it leaves each
                    ;; branch from its RIGHT source handle (id `\"right\"`,
                    ;; `four-cardinal-handles`) and enters the next from its
                    ;; LEFT target handle (id `\"left\"`). Without these,
@@ -468,14 +455,14 @@
                                :height (:arrow-width-quiet chart)}
                    :data   {:eventLabel ""
                             :eventLineLabel ""
-                            ;; rf2-o3rkq1 — the decorative-connector flag
-                            ;; `edges.cljs` keys the dotted, arrowhead-less,
-                            ;; label-less render off.
+                            ;; the decorative-connector flag `edges.cljs`
+                            ;; keys the dotted, arrowhead-less, label-less
+                            ;; render off.
                             :forkConnector true
                             :active false :focused false :fired false
-                            ;; rf2-fzrzlw — the decorative connector is never
-                            ;; a guard-blocked transition; false keeps the
-                            ;; every-edge :data shape whole.
+                            ;; the decorative connector is never a guard-
+                            ;; blocked transition; false keeps the every-edge
+                            ;; :data shape whole.
                             :guardBlocked false
                             :afterMs nil :guard nil :action nil
                             :crossHierarchy false
@@ -498,42 +485,38 @@
   "elk.js layout width for an event-node — narrower than a state node
   so two adjacent events do not crowd the state row, but wide enough
   for the `event-segment` text + optional `[guard]` chip + `+ action`
-  pill (rf2-qo5xy).
+  pill.
 
-  rf2-az6e2 — pulled 120 → 96 so the route chip lays out as a
-  SUBORDINATE node, not a peer state box. The event chip's CSS min-width
-  (`:event-chip-min-w` 92 regular) sits just under this floor; the
-  measure-then-relayout pass still sizes the chip to its real content
-  via `(max measured floor)`, but the LAYOUT WEIGHT (the seed ELK uses
-  before measurement, and the floor a content-light chip lands on) is
-  lower so event chips don't push state rows apart like peers."
+  96px lays the route chip out as a SUBORDINATE node, not a peer state
+  box. The event chip's CSS min-width (`:event-chip-min-w` 92 regular)
+  sits just under this floor; the measure-then-relayout pass still sizes
+  the chip to its real content via `(max measured floor)`, but the LAYOUT
+  WEIGHT (the seed ELK uses before measurement, and the floor a content-
+  light chip lands on) is low enough that event chips don't push state
+  rows apart like peers."
   96)
 
 (def event-node-elk-height
   "elk.js layout height for an event-node — taller than a single text
-  line so the action-pill row has space underneath the header
-  (rf2-qo5xy).
+  line so the action-pill row has space underneath the header.
 
-  rf2-az6e2 — pulled 46 → 34 (the route chip is a compact card, not a
-  title/body box). Subordinate layout weight relative to a state node's
-  58px floor."
+  34px keeps the route chip a compact card, not a title/body box —
+  subordinate layout weight relative to a state node's 58px floor."
   34)
 
 (defn leaf-elk-size
-  "rf2-d9ro2 — the elk.js layout size for a LEAF state node, given the
-  optional `measured` `{:width :height}` map xyflow reported for that
-  node on a prior render (`node.measured`).
+  "The elk.js layout size for a LEAF state node, given the optional
+  `measured` `{:width :height}` map xyflow reported for that node on a
+  prior render (`node.measured`).
 
   The first ELK pass has no measurement yet (`measured` is nil), so the
-  node falls back to the `state-node-min-{width,height}` FLOOR — the same
-  constant the old single-pass used. On the measure-then-relayout second
-  pass (`chart.cljs`) the host hands back the rendered box; we take the
-  MAX of the measured dimension and the floor so a node never lays out
-  SMALLER than its CSS `min-{width,height}`, but a node whose CONTENT
-  (long label + tag pills + entry/exit action pills, rf2-a2b55) exceeds
-  the floor gets the real box ELK must budget for — closing the
-  missized/overlapping-topology bug where ELK assumed every node was
-  exactly the floor.
+  node falls back to the `state-node-min-{width,height}` FLOOR. On the
+  measure-then-relayout second pass (`chart.cljs`) the host hands back the
+  rendered box; we take the MAX of the measured dimension and the floor so
+  a node never lays out SMALLER than its CSS `min-{width,height}`, but a
+  node whose CONTENT (long label + tag pills + entry/exit action pills)
+  exceeds the floor gets the real box ELK must budget for — so ELK never
+  assumes every node is exactly the floor and mis-sizes the topology.
 
   Returns a `{:width :height}` map (both positive)."
   [measured]
@@ -544,9 +527,9 @@
   "Build a single elk.js child descriptor for a parsed node (a plain
   CLJS map; `chart`'s `->elk-input` `clj->js`-es the whole tree).
 
-  rf2-d9ro2 — `measured-dims` is the optional `{node-id {:width :height}}`
-  map of xyflow-reported rendered boxes (`node.measured`) from a prior
-  render, threaded through `->elk-children`. A LEAF state takes
+  `measured-dims` is the optional `{node-id {:width :height}}` map of
+  xyflow-reported rendered boxes (`node.measured`) from a prior render,
+  threaded through `->elk-children`. A LEAF state takes
   `(max measured floor)` per dimension (`leaf-elk-size`) so ELK sizes
   each slot to the node's REAL rendered box rather than the fixed floor.
   COMPOUND containers keep the compound floor as their SEED size — their
@@ -555,15 +538,15 @@
   (the rendered compound box is `width:100% height:100%` of whatever ELK
   allocates, so feeding its measured DOM size back would be circular).
   When `measured-dims` is nil / empty (the first pass) every leaf falls
-  back to the floor — identical to the pre-rf2-d9ro2 single-pass."
+  back to the floor."
   ([n] (elk-child n nil))
   ([n measured-dims]
    (merge
      {:id     (:id n)
       :labels [{:text (:label n)}]}
      (cond
-       ;; rf2-vcnvj — the synthetic machine-root node is a compact root-
-       ;; context chip, not a full state box; it lays out at content size
+       ;; the synthetic machine-root node is a compact root-context chip,
+       ;; not a full state box; it lays out at content size
        ;; (`max measured floor`) against a small floor so it does not push
        ;; the main state column apart like a peer state.
        (:machine-root? n)
@@ -579,18 +562,17 @@
        (leaf-elk-size (get measured-dims (:id n)))))))
 
 (defn elk-event-child
-  "rf2-qo5xy — build an elk.js child descriptor for a SYNTHETIC
-  event-node. The events-as-nodes paradigm inserts one of these per
-  spec transition (between source state and target state); elkjs lays
-  it out alongside the source state's siblings inside the source's
-  parent container.
+  "Build an elk.js child descriptor for a SYNTHETIC event-node. The
+  events-as-nodes paradigm inserts one of these per spec transition
+  (between source state and target state); elkjs lays it out alongside
+  the source state's siblings inside the source's parent container.
 
-  rf2-d9ro2 — like a leaf state, an event-node renders at CONTENT size
-  (event header + optional `[guard]` chip + `+ action` pill row), so on
-  the measure-then-relayout second pass we take `(max measured floor)`
-  per dimension against the `event-node-elk-{width,height}` floor.
-  `measured-dims` is the optional `{node-id {:width :height}}` map; nil
-  on the first pass falls back to the floor (pre-rf2-d9ro2 behaviour)."
+  Like a leaf state, an event-node renders at CONTENT size (event header
+  + optional `[guard]` chip + `+ action` pill row), so on the measure-
+  then-relayout second pass we take `(max measured floor)` per dimension
+  against the `event-node-elk-{width,height}` floor. `measured-dims` is
+  the optional `{node-id {:width :height}}` map; nil on the first pass
+  falls back to the floor."
   ([parsed-edge] (elk-event-child parsed-edge nil))
   ([parsed-edge measured-dims]
    (let [id (event-node-id parsed-edge)
@@ -601,10 +583,10 @@
       :labels [{:text (or (:event-label parsed-edge) "")}]})))
 
 (defn order-state-children
-  "rf2-ly51l — order a container's STATE children so the initial state
-  LEADS its local model order, with the synthetic machine-root annotation
-  demoted LAST; every other state keeps its parse order. A stable sort on
-  a per-node rank:
+  "Order a container's STATE children so the initial state LEADS its local
+  model order, with the synthetic machine-root annotation demoted LAST;
+  every other state keeps its parse order. A stable sort on a per-node
+  rank:
 
     0  initial state            (`:initial?`)  — the preferred anchor
     1  ordinary state           (parse order kept by stable sort)
@@ -612,10 +594,10 @@
                                  anchor, never a flow start, so it sinks
                                  to the END of the model order
 
-  This is the model-order half of the rf2-ly51l initial-state placement
-  SOFT preference (the layout half is `chart.cljs`'s `cycleBreaking.
-  strategy DEPTH_FIRST`). It biases TWO ELK decisions toward the initial
-  state without forcing any position:
+  This is the model-order half of the initial-state placement SOFT
+  preference (the layout half is `chart.cljs`'s `cycleBreaking.strategy
+  DEPTH_FIRST`). It biases TWO ELK decisions toward the initial state
+  without forcing any position:
 
     - DEPTH_FIRST cycle-breaking walks from the SOURCES; an earlier
       model-order source is preferred as the walk root, so leading the
@@ -635,15 +617,15 @@
                      :else              1))
            state-nodes))
 
-;; ---- root-container Context-band height (rf2-8z1rca) --------------------
+;; ---- root-container Context-band height ---------------------------------
 ;;
-;; rf2-8z1rca — the synthetic ROOT-CONTAINER frame paints a TITLE strip
-;; PLUS an OPTIONAL Context band under it (`chart.nodes/root-container-node`
-;; — the key→type-caption shape the host feeds via `:context-band`). The
-;; band is a VARIABLE-height block: its height grows with the number of
-;; context rows. `container-elk-padding`'s plain TOP reservation only
-;; clears the title strip + a body-pad band, so with non-trivial context
-;; the children laid out at the reserved content edge sat UNDER the painted
+;; The synthetic ROOT-CONTAINER frame paints a TITLE strip PLUS an OPTIONAL
+;; Context band under it (`chart.nodes/root-container-node` — the
+;; key→type-caption shape the host feeds via `:context-band`). The band is
+;; a VARIABLE-height block: its height grows with the number of context
+;; rows. `container-elk-padding`'s plain TOP reservation only clears the
+;; title strip + a body-pad band, so with non-trivial context the children
+;; laid out at the reserved content edge would sit UNDER the painted
 ;; Context band. These constants model the band's rendered geometry so the
 ;; root-container's ELK top padding reserves it too.
 ;;
@@ -653,35 +635,35 @@
 ;; `root-container-node`) so the reservation and the paint can never drift.
 
 (def context-band-pad-top
-  "rf2-8z1rca — the Context band's TOP padding (px). Mirrors the
-  `padding 5px 10px 6px` top component in `root-container-node`."
+  "The Context band's TOP padding (px). Mirrors the `padding 5px 10px 6px`
+  top component in `root-container-node`."
   5)
 
 (def context-band-pad-bottom
-  "rf2-8z1rca — the Context band's BOTTOM padding (px). Mirrors the
+  "The Context band's BOTTOM padding (px). Mirrors the
   `padding 5px 10px 6px` bottom component in `root-container-node`."
   6)
 
 (def context-band-pad-x
-  "rf2-8z1rca — the Context band's HORIZONTAL padding (px). Mirrors the
+  "The Context band's HORIZONTAL padding (px). Mirrors the
   `padding 5px 10px 6px` left/right component in `root-container-node`."
   10)
 
 (def context-band-row-font-px
-  "rf2-8z1rca — the Context band's row `font-size` (px). Mirrors the band's
+  "The Context band's row `font-size` (px). Mirrors the band's
   `font-size 10px` (the row text; the caption + badge are smaller 8px but
   their row height is modelled by `context-band-header-height`)."
   10)
 
 (def context-band-row-line-height
-  "rf2-8z1rca — the Context band's `line-height` (unitless). Mirrors the
-  band's `line-height 1.3`. One row's rendered height is `ceil(font-px ·
+  "The Context band's `line-height` (unitless). Mirrors the band's
+  `line-height 1.3`. One row's rendered height is `ceil(font-px ·
   line-height)`."
   1.3)
 
 (def context-band-header-margin-bottom
-  "rf2-8z1rca — the `margin-bottom` (px) on the band's caption/badge header
-  row. Mirrors the header row's `margin-bottom 1px`."
+  "The `margin-bottom` (px) on the band's caption/badge header row.
+  Mirrors the header row's `margin-bottom 1px`."
   1)
 
 (defn- ceil-int
@@ -691,13 +673,13 @@
      :cljs (long (js/Math.ceil x))))
 
 (def context-band-row-height
-  "rf2-8z1rca — the rendered height (px) of ONE context key→type row: the
-  row font at the band's line-height, rounded up (`ceil(10 · 1.3) = 13`).
-  Single-sourced from the font + line-height constants the renderer reads."
+  "The rendered height (px) of ONE context key→type row: the row font at
+  the band's line-height, rounded up (`ceil(10 · 1.3) = 13`). Single-
+  sourced from the font + line-height constants the renderer reads."
   (ceil-int (* context-band-row-font-px context-band-row-line-height)))
 
 (def context-band-header-height
-  "rf2-8z1rca — the rendered height (px) of the band's `Context` caption +
+  "The rendered height (px) of the band's `Context` caption +
   provenance-badge header row: an 8px-caption line at the band line-height
   PLUS its `margin-bottom`. A fixed row independent of the context row
   count (`ceil(8 · 1.3) + 1 = 12`)."
@@ -705,14 +687,14 @@
      context-band-header-margin-bottom))
 
 (def context-band-row-gap
-  "rf2-8z1rca — the vertical `gap` (px) the band's column flex puts BETWEEN
-  adjacent children (the header row + each context row). Mirrors the band's
+  "The vertical `gap` (px) the band's column flex puts BETWEEN adjacent
+  children (the header row + each context row). Mirrors the band's
   `gap 2px`."
   2)
 
 (defn context-band-height
-  "rf2-8z1rca — the rendered height (px) the root-container Context band
-  occupies for `n-rows` context rows, modelling the fixed-pixel CSS in
+  "The rendered height (px) the root-container Context band occupies for
+  `n-rows` context rows, modelling the fixed-pixel CSS in
   `chart.nodes/root-container-node`:
 
     pad-top + header-row + n-rows · row-height
@@ -734,9 +716,9 @@
     0))
 
 (defn container-elk-padding
-  "rf2-8q5pt — the `elk.padding` string for a compound / region container,
-  derived from the active density's `visual-constants` rather than a
-  hardcoded literal.
+  "The `elk.padding` string for a compound / region container, derived
+  from the active density's `visual-constants` rather than a hardcoded
+  literal.
 
   The container reserves:
 
@@ -751,32 +733,31 @@
               NESTED initial substate's marker glyph (the dot + short
               hook, drawn `initial-marker-x-offset` px LEFT of the state)
               sits fully INSIDE the container border instead of spilling
-              past it (rf2-lxk3h3);
+              past it;
     - RIGHT / BOTTOM = `:container-body-pad` — the same inset.
 
   Both density keys are density-dependent (`chart-{compact,regular,cosy}`),
-  so a fixed literal reserved the wrong header gap in the non-regular
-  densities (children crowded the strip in `:cosy`, over-spaced it in
+  so a fixed literal would reserve the wrong header gap in the non-regular
+  densities (children crowding the strip in `:cosy`, over-spaced in
   `:compact`). Pass the resolved density map (`vc/chart-for-density`);
   defaults to `vc/chart` (regular) so the nil-arity stays stable.
 
-  rf2-lxk3h3 — `reserve-initial-marker?` (default false) widens ONLY the
-  LEFT side. `->elk-children` sets it per-container for every container
-  whose own initial substate carries a marker (the common case — a
-  compound / region always has an `:initial?` child), so the left inset
-  reserves room for the marker's leftward extent. The marker itself is
-  NOT in the ELK graph (it is a decorative xyflow-only glyph node), so its
-  extent cannot be measured into the container box by ELK's
-  `INCLUDE_CHILDREN` pass — the padding reservation is what grows the box
-  to enclose it.
+  `reserve-initial-marker?` (default false) widens ONLY the LEFT side.
+  `->elk-children` sets it per-container for every container whose own
+  initial substate carries a marker (the common case — a compound / region
+  always has an `:initial?` child), so the left inset reserves room for the
+  marker's leftward extent. The marker itself is NOT in the ELK graph (it
+  is a decorative xyflow-only glyph node), so its extent cannot be measured
+  into the container box by ELK's `INCLUDE_CHILDREN` pass — the padding
+  reservation is what grows the box to enclose it.
 
-  rf2-8z1rca — `extra-top` (default 0) is ADDED to the TOP reservation,
-  ABOVE the title-strip + body-pad band. The synthetic ROOT-CONTAINER frame
-  uses it to reserve the variable-height Context band the frame header
-  paints UNDER its title strip (`context-band-height`): without it, the
-  band — which is NOT an ELK child and so never grows the box via
-  `INCLUDE_CHILDREN` — would overlap the first child ELK laid out at the
-  plain reserved content edge. Every other container passes 0 (no band)."
+  `extra-top` (default 0) is ADDED to the TOP reservation, ABOVE the
+  title-strip + body-pad band. The synthetic ROOT-CONTAINER frame uses it
+  to reserve the variable-height Context band the frame header paints UNDER
+  its title strip (`context-band-height`): without it, the band — which is
+  NOT an ELK child and so never grows the box via `INCLUDE_CHILDREN` —
+  would overlap the first child ELK laid out at the plain reserved content
+  edge. Every other container passes 0 (no band)."
   ([] (container-elk-padding vc/chart false 0))
   ([chart-vc] (container-elk-padding chart-vc false 0))
   ([chart-vc reserve-initial-marker?]
@@ -794,61 +775,58 @@
 (defn ->elk-children
   "Project parsed nodes + parsed edges into elk.js's `children` shape.
 
-  Nesting is keyed on `:parent-id`: parallel-region states (rf2-lkwev)
-  AND compound substates carry it, so BOTH nest UNDER their container
-  and elkjs lays them out inside the container's bounding box (xyflow's
-  `parentId` sub-flow then renders them inside the dashed boundary —
-  rf2-xh1lm: xyflow v12 reads `parentId`, NOT the pre-v12 `parentNode`).
-  Nesting recurses — a compound inside a region, or a compound inside a
-  compound, lays out correctly. Each container (region OR compound) gets
-  its own `elk.algorithm`/`elk.padding` so the header strip has room and
-  the zone gets a clean internal layout; top-level nodes are laid out at
-  the root.
+  Nesting is keyed on `:parent-id`: parallel-region states AND compound
+  substates carry it, so BOTH nest UNDER their container and elkjs lays
+  them out inside the container's bounding box (xyflow's `parentId`
+  sub-flow then renders them inside the dashed boundary — xyflow v12 reads
+  `parentId`, NOT the pre-v12 `parentNode`). Nesting recurses — a compound
+  inside a region, or a compound inside a compound, lays out correctly.
+  Each container (region OR compound) gets its own
+  `elk.algorithm`/`elk.padding` so the header strip has room and the zone
+  gets a clean internal layout; top-level nodes are laid out at the root.
 
-  rf2-qo5xy — synthetic event-nodes (one per parsed edge) sit alongside
-  state-nodes as elk children of the SOURCE state's parent container
-  (top-level when the source has no parent). elk then lays them out
-  with the layered algorithm — events flow naturally between states
-  per the events-as-nodes paradigm. They carry no children of their
-  own.
+  Synthetic event-nodes (one per parsed edge) sit alongside state-nodes as
+  elk children of the SOURCE state's parent container (top-level when the
+  source has no parent). elk then lays them out with the layered
+  algorithm — events flow naturally between states per the events-as-nodes
+  paradigm. They carry no children of their own.
 
-  rf2-d9ro2 — the optional `measured-dims` `{node-id {:width :height}}`
-  map (xyflow's `node.measured` from a prior render, threaded by
-  `chart.cljs`'s measure-then-relayout pass) is forwarded to every
-  `elk-child` / `elk-event-child` so leaf states + event-nodes lay out
-  at their REAL rendered box rather than the fixed floor. nil / empty on
-  the first pass — identical to the pre-rf2-d9ro2 single-pass.
+  The optional `measured-dims` `{node-id {:width :height}}` map (xyflow's
+  `node.measured` from a prior render, threaded by `chart.cljs`'s measure-
+  then-relayout pass) is forwarded to every `elk-child` / `elk-event-child`
+  so leaf states + event-nodes lay out at their REAL rendered box rather
+  than the fixed floor. nil / empty on the first pass.
 
-  rf2-8q5pt — the optional `chart-vc` (the resolved density map from
+  The optional `chart-vc` (the resolved density map from
   `vc/chart-for-density`, threaded by `chart.cljs` alongside
   `measured-dims`) sizes each container's `elk.padding` from the active
   density's title-strip + body-pad constants via `container-elk-padding`,
   rather than a regular-only literal. nil falls back to `vc/chart`
   (regular).
 
-  rf2-8z1rca — the optional `context-rows` (the integer count of context
-  rows the root-container Context band paints, threaded by `chart.cljs`
-  from `:context-band`) ADDS the band's rendered height to the ROOT-
-  CONTAINER frame's TOP padding only (`context-band-height`), so the first
-  child ELK lays out below the title strip clears the painted Context band
-  too. 0 / nil ⇒ no band, no extra top reservation — every non-root
-  container is unaffected regardless."
+  The optional `context-rows` (the integer count of context rows the
+  root-container Context band paints, threaded by `chart.cljs` from
+  `:context-band`) ADDS the band's rendered height to the ROOT-CONTAINER
+  frame's TOP padding only (`context-band-height`), so the first child ELK
+  lays out below the title strip clears the painted Context band too. 0 /
+  nil ⇒ no band, no extra top reservation — every non-root container is
+  unaffected regardless."
   ([parsed] (->elk-children parsed nil nil 0))
   ([parsed measured-dims] (->elk-children parsed measured-dims nil 0))
   ([parsed measured-dims chart-vc] (->elk-children parsed measured-dims chart-vc 0))
   ([{:keys [nodes edges] :as parsed} measured-dims chart-vc context-rows]
   (let [resolved-vc   (or chart-vc vc/chart)
-        ;; rf2-8q5pt — the default container padding (no initial-marker
-        ;; reservation). rf2-lxk3h3 — a container whose own initial
-        ;; substate carries a marker takes the wider-LEFT variant instead
-        ;; (see `marker-container-pad` + `marker-container-ids` below).
+        ;; the default container padding (no initial-marker reservation). A
+        ;; container whose own initial substate carries a marker takes the
+        ;; wider-LEFT variant instead (see `marker-container-pad` +
+        ;; `marker-container-ids` below).
         container-pad (container-elk-padding resolved-vc)
-        ;; rf2-lxk3h3 — the LEFT-widened padding for a container that holds
-        ;; a NESTED initial substate, so the marker's leftward glyph extent
-        ;; sits inside the border instead of spilling past it.
+        ;; the LEFT-widened padding for a container that holds a NESTED
+        ;; initial substate, so the marker's leftward glyph extent sits
+        ;; inside the border instead of spilling past it.
         marker-container-pad (container-elk-padding resolved-vc true)
-        ;; rf2-8z1rca — the ROOT-CONTAINER frame ALSO reserves the variable-
-        ;; height Context band ON TOP of the title strip. The frame holds the
+        ;; the ROOT-CONTAINER frame ALSO reserves the variable-height
+        ;; Context band ON TOP of the title strip. The frame holds the
         ;; machine's top-level initial (so it is in `marker-container-ids`),
         ;; so the band reservation rides the LEFT-widened variant. The band
         ;; height is derived from the context-row count + the density's
@@ -857,28 +835,28 @@
         context-band-px (context-band-height (or context-rows 0)
                                              (:container-divider-width resolved-vc))
         root-container-pad (container-elk-padding resolved-vc true context-band-px)
-        ;; rf2-lxk3h3 — the set of container-ids (each `:parent-id` an
-        ;; `:initial?` state nests under) that therefore need the LEFT-
-        ;; widened padding. A compound / region always has an `:initial?`
-        ;; child, so this is the common case; a container with no initial
-        ;; child (none in a valid statechart, but cheap to be exact) keeps
-        ;; the plain body-pad inset. The synthetic ROOT-CONTAINER frame
-        ;; (rf2-q129z8) is the parent of the machine's TOP-LEVEL initial
-        ;; state (`wrap-in-root-container` re-parents every no-parent node
-        ;; to `root-container-id`), so it lands in the set too — the
-        ;; top-level initial marker is reserved against the frame border
-        ;; the same way a nested one is reserved against its compound.
+        ;; the set of container-ids (each `:parent-id` an `:initial?` state
+        ;; nests under) that therefore need the LEFT-widened padding. A
+        ;; compound / region always has an `:initial?` child, so this is the
+        ;; common case; a container with no initial child (none in a valid
+        ;; statechart, but cheap to be exact) keeps the plain body-pad
+        ;; inset. The synthetic ROOT-CONTAINER frame is the parent of the
+        ;; machine's TOP-LEVEL initial state (`wrap-in-root-container`
+        ;; re-parents every no-parent node to `root-container-id`), so it
+        ;; lands in the set too — the top-level initial marker is reserved
+        ;; against the frame border the same way a nested one is reserved
+        ;; against its compound.
         marker-container-ids (into #{}
                                    (comp (filter :initial?)
                                          (keep :parent-id))
                                    nodes)
         node-by-id (into {} (map (juxt :id identity)) nodes)
-        ;; rf2-p75kbg — the guarded-fork branch within-layer ORDER pins.
-        ;; `fork-positions` maps each fork-branch EVENT-NODE id to its
-        ;; 1-based priority index (the `elk.position` hint); `fork-containers`
-        ;; is the set of holding containers (`:parent-id`; nil == root) that
-        ;; therefore enable `crossingMinimization.semiInteractive`. Empty for
-        ;; any machine without a guarded fork — the pins are then a no-op.
+        ;; the guarded-fork branch within-layer ORDER pins. `fork-positions`
+        ;; maps each fork-branch EVENT-NODE id to its 1-based priority index
+        ;; (the `elk.position` hint); `fork-containers` is the set of holding
+        ;; containers (`:parent-id`; nil == root) that therefore enable
+        ;; `crossingMinimization.semiInteractive`. Empty for any machine
+        ;; without a guarded fork — the pins are then a no-op.
         fork-positions (fork-branch-event-positions edges)
         fork-containers (fork-branch-container-ids parsed)
         ;; The event-node's parent container == the source state's
@@ -888,37 +866,37 @@
                 (let [src (get node-by-id (:source e))
                       pid (:parent-id src)
                       ev-id (event-node-id e)
-                      ;; rf2-p75kbg — a fork-branch event-node carries an
-                      ;; `elk.position` ordering hint == its priority index,
-                      ;; so (under the container's semiInteractive) ELK stacks
-                      ;; the branches 1,2,3 and the dotted connector reads
-                      ;; monotonic instead of weaving.
+                      ;; a fork-branch event-node carries an `elk.position`
+                      ;; ordering hint == its priority index, so (under the
+                      ;; container's semiInteractive) ELK stacks the branches
+                      ;; 1,2,3 and the dotted connector reads monotonic
+                      ;; instead of weaving.
                       pos   (get fork-positions ev-id)]
                   (cond-> (elk-event-child e measured-dims)
                     pid (assoc ::event-parent pid)
-                    ;; rf2-p75kbg — `elk.position` is a KVector `(x,y)`. With
-                    ;; the chart's DOWN direction the layers stack vertically,
-                    ;; so the WITHIN-LAYER (cross) axis is X — the priority
-                    ;; index goes in x; y is left 0. semiInteractive reads this
-                    ;; to order the branches 1,2,3 left-to-right.
+                    ;; `elk.position` is a KVector `(x,y)`. With the chart's
+                    ;; DOWN direction the layers stack vertically, so the
+                    ;; WITHIN-LAYER (cross) axis is X — the priority index
+                    ;; goes in x; y is left 0. semiInteractive reads this to
+                    ;; order the branches 1,2,3 left-to-right.
                     pos (assoc :layoutOptions
                                {"elk.position" (str "(" pos ",0)")}))))
               edges)
         by-parent (group-by :parent-id nodes)
         events-by-parent (group-by ::event-parent event-children)
-        ;; rf2-p75kbg — container `layoutOptions`, with semiInteractive added
-        ;; ONLY when this container holds a guarded fork (so the branch
-        ;; `elk.position` hints are honoured; non-fork containers are
-        ;; untouched and keep full crossing-minimisation).
-        ;; rf2-lxk3h3 — a container holding a NESTED initial substate uses
-        ;; the LEFT-widened padding so the substate's initial-marker glyph
-        ;; sits inside the border instead of spilling past it; every other
-        ;; container keeps the plain body-pad inset.
-        ;; rf2-8z1rca — the ROOT-CONTAINER frame additionally reserves the
-        ;; Context band on TOP (it holds the top-level initial, so it ALSO
-        ;; takes the marker-widened LEFT). `root-container-pad` folds both;
-        ;; with 0 context rows it equals `marker-container-pad`, so a context-
-        ;; less root is byte-identical to the pre-rf2-8z1rca padding.
+        ;; container `layoutOptions`, with semiInteractive added ONLY when
+        ;; this container holds a guarded fork (so the branch `elk.position`
+        ;; hints are honoured; non-fork containers are untouched and keep
+        ;; full crossing-minimisation).
+        ;; A container holding a NESTED initial substate uses the LEFT-
+        ;; widened padding so the substate's initial-marker glyph sits inside
+        ;; the border instead of spilling past it; every other container
+        ;; keeps the plain body-pad inset.
+        ;; The ROOT-CONTAINER frame additionally reserves the Context band on
+        ;; TOP (it holds the top-level initial, so it ALSO takes the marker-
+        ;; widened LEFT). `root-container-pad` folds both; with 0 context
+        ;; rows it equals `marker-container-pad`, so a context-less root
+        ;; carries the plain marker-widened padding.
         container-opts (fn [parent-id]
                          (cond-> {"elk.algorithm" "layered"
                                   "elk.padding"   (cond
@@ -933,10 +911,10 @@
                            (assoc "elk.layered.crossingMinimization.semiInteractive"
                                   "true")))
         build (fn build [n]
-                (let [;; rf2-ly51l — the local initial state leads its
-                      ;; container's model order (machine-root sinks last);
-                      ;; biases ELK's DEPTH_FIRST source selection + the
-                      ;; within-layer tiebreak toward the initial state.
+                (let [;; the local initial state leads its container's model
+                      ;; order (machine-root sinks last); biases ELK's
+                      ;; DEPTH_FIRST source selection + the within-layer
+                      ;; tiebreak toward the initial state.
                       state-kids (order-state-children
                                    (get by-parent (:id n) []))
                       event-kids (get events-by-parent (:id n) [])
@@ -950,54 +928,49 @@
                                                     ;; before handing to elk.
                                                     (dissoc k ::event-parent)
                                                     (build k)))))
-                           ;; rf2-az6e2 / rf2-8q5pt — the container top
-                           ;; padding clears the solid title strip PLUS a
-                           ;; body-pad band (metadata row for compound tags
-                           ;; / entry-exit rows), so children never collide
-                           ;; with the header; side/bottom track the
-                           ;; `:container-body-pad` inset. Density-derived
-                           ;; via `container-elk-padding` (was a regular-only
-                           ;; literal `top=44,…16` — wrong gap in
-                           ;; compact/cosy). rf2-p75kbg adds semiInteractive
+                           ;; the container top padding clears the solid
+                           ;; title strip PLUS a body-pad band (metadata row
+                           ;; for compound tags / entry-exit rows), so
+                           ;; children never collide with the header;
+                           ;; side/bottom track the `:container-body-pad`
+                           ;; inset. Density-derived via `container-elk-
+                           ;; padding`. `container-opts` adds semiInteractive
                            ;; when this container holds a guarded fork.
                            :layoutOptions (container-opts (:id n))))))
-        ;; rf2-ly51l — top-level model order: initial state first,
-        ;; machine-root annotation last (see `order-state-children`).
+        ;; top-level model order: initial state first, machine-root
+        ;; annotation last (see `order-state-children`).
         top-state-children (mapv build (order-state-children
                                          (get by-parent nil)))
         top-event-children (->> (get events-by-parent nil [])
                                 (mapv #(dissoc % ::event-parent)))]
     (vec (concat top-state-children top-event-children)))))
 
-;; ---- elk.js EDGE projection (rf2-rlq97) ---------------------------------
+;; ---- elk.js EDGE projection --------------------------------------------
 ;;
-;; rf2-rlq97 — the elk EDGE descriptors are projected here (pure data),
-;; mirroring `->elk-children` for nodes. Before rf2-rlq97 the elk edge
-;; objects were built inline in `chart.cljs/->elk-input` (a `mapcat` over
-;; the parsed edges) — JS-side and JVM-unloadable, so the edges that ELK
-;; routes the topology AROUND were never pinned at the cheap JVM layer.
-;; Lifting them into `->elk-edge` here lets the projection test corpus
-;; assert the edge-feed (ids + endpoints + label dims) the same way it
-;; pins the node-feed.
+;; The elk EDGE descriptors are projected here (pure data), mirroring
+;; `->elk-children` for nodes. Keeping them in `->elk-edge` (rather than
+;; inline in `chart.cljs/->elk-input`, which is JS-side and JVM-unloadable)
+;; lets the projection test corpus assert the edge-feed — the edges ELK
+;; routes the topology AROUND — at the cheap JVM layer, the same way it
+;; pins the node-feed (ids + endpoints + label dims).
 ;;
-;; Each parsed transition is decomposed into the events-as-nodes
-;; (rf2-qo5xy) edge pair:
+;; Each parsed transition is decomposed into the events-as-nodes edge pair:
 ;;
 ;;   source-state ─→ event-node   (`<spec-edge-id>__in`)
 ;;   event-node   ─→ target-state (`<spec-edge-id>__out`; omitted for
 ;;                                  internal transitions, which have no
 ;;                                  `:target`)
 ;;
-;; ## Edge labels (rf2-rlq97)
+;; ## Edge labels
 ;;
 ;; The xstate-style transition text (`event [guard] / action`) rides on
 ;; the event-NODE (`xyflow-graph` event-nodes; the event-node is the
 ;; events-as-nodes analogue of a Stately edge label and is ALREADY
-;; measured + ELK-laid-out via `elk-event-child` + the d9ro2 measure
-;; pass). So the `__in` / `__out` edges themselves carry NO visible
-;; label, and ELK must reserve NO label channel for them — feeding label
-;; dims onto BOTH the event-node AND its incident edges would
-;; double-budget the same text.
+;; measured + ELK-laid-out via `elk-event-child` + the measure pass). So
+;; the `__in` / `__out` edges themselves carry NO visible label, and ELK
+;; must reserve NO label channel for them — feeding label dims onto BOTH
+;; the event-node AND its incident edges would double-budget the same
+;; text.
 ;;
 ;; `->elk-edge` therefore takes an optional `label-dims` map but uses it
 ;; ONLY for an edge that genuinely renders its OWN label in the renderer
@@ -1006,13 +979,13 @@
 ;; MEASURED `{:width :height}` here so ELK's `edgeLabels.placement`
 ;; reserves space). A nil entry emits an empty zero-size label, which
 ;; ELK treats as no label to place. This is the edge-label analogue of
-;; d9ro2's node measure: dims flow from the rendered DOM into the ELK
+;; the node measure pass: dims flow from the rendered DOM into the ELK
 ;; input rather than being a renderer-side heuristic.
 
 (defn elk-edge-label
-  "rf2-rlq97 — build the elk edge `labels` entry for an edge. `text` is
-  the visible label string (\"\" when the label rides on the event-node,
-  which is the events-as-nodes default). `dims` is the optional MEASURED
+  "Build the elk edge `labels` entry for an edge. `text` is the visible
+  label string (\"\" when the label rides on the event-node, which is the
+  events-as-nodes default). `dims` is the optional MEASURED
   `{:width :height}` of the rendered label; nil emits a zero-size label
   ELK treats as nothing to place. Returns a single-label vector (elk's
   `labels` is always an array)."
@@ -1022,16 +995,16 @@
      (assoc :width (:width dims) :height (:height dims)))])
 
 (def initial-edge-priority-direction
-  "rf2-k504af — the `elk.layered.priority.direction` value set on an
-  INITIAL state's outgoing `__in` edge (every other edge is unset / the
-  ELK default 0). xstate-viz uses this lever (with ELK's default GREEDY
-  cycle-breaking + root `considerModelOrder NODES_AND_EDGES`) to anchor
-  the initial state at the START of its region's flow. A higher
-  direction-priority edge is preferred when ELK orders layers, pulling
-  the edge's SOURCE (the initial state) toward the first layer — which
-  fixes the parallel/pure-cyclic regions (traffic's `red` / `walk`)
-  where the soft DEPTH_FIRST + model-order preference SLIPS and the
-  initial sinks to the bottom layer.
+  "The `elk.layered.priority.direction` value set on an INITIAL state's
+  outgoing `__in` edge (every other edge is unset / the ELK default 0).
+  xstate-viz uses this lever (with ELK's default GREEDY cycle-breaking +
+  root `considerModelOrder NODES_AND_EDGES`) to anchor the initial state at
+  the START of its region's flow. A higher direction-priority edge is
+  preferred when ELK orders layers, pulling the edge's SOURCE (the initial
+  state) toward the first layer — which fixes the parallel/pure-cyclic
+  regions (traffic's `red` / `walk`) where the soft DEPTH_FIRST + model-
+  order preference SLIPS and the initial would otherwise sink to the bottom
+  layer.
 
   General, not traffic-specific: it biases EVERY machine's initial
   state(s) toward flow-start. For an already-spine-ordered machine
@@ -1041,8 +1014,8 @@
   "1")
 
 (defn ->elk-edge
-  "rf2-rlq97 — project ONE parsed transition into its elk edge
-  descriptor(s) under the events-as-nodes paradigm (rf2-qo5xy):
+  "Project ONE parsed transition into its elk edge descriptor(s) under the
+  events-as-nodes paradigm:
 
     [{:id \"<spec-id>__in\"  :sources [src]   :targets [ev]    :labels …}
      {:id \"<spec-id>__out\" :sources [ev]    :targets [tgt]   :labels …}]
@@ -1058,23 +1031,23 @@
   visible text is on the event-NODE so these entries are normally absent
   and the edges carry empty labels — see the section comment above.
 
-  rf2-k504af — `initial-ids` is the optional SET of state node-ids that
-  are `:initial?`. When the `__in` edge LEAVES an initial state, it
-  carries `elk.layered.priority.direction = 1` (the
-  `initial-edge-priority-direction` lever) so ELK pulls the initial
-  state toward flow-start — fixing the parallel/pure-cyclic regions
-  where the soft initial-on-top preference slips. Empty / nil leaves
-  every edge unset (the pre-rf2-k504af behaviour)."
+  `initial-ids` is the optional SET of state node-ids that are
+  `:initial?`. When the `__in` edge LEAVES an initial state, it carries
+  `elk.layered.priority.direction = 1` (the
+  `initial-edge-priority-direction` lever) so ELK pulls the initial state
+  toward flow-start — fixing the parallel/pure-cyclic regions where the
+  soft initial-on-top preference slips. Empty / nil leaves every edge
+  unset."
   ([e] (->elk-edge e nil nil))
   ([e label-dims] (->elk-edge e label-dims nil))
   ([e label-dims initial-ids]
    (let [ev-id     (event-node-id e)
          in-id     (str (:id e) "__in")
          out-id    (str (:id e) "__out")
-         ;; rf2-k504af — the `__in` edge LEAVES the source state; when
-         ;; that state is initial, pull it to flow-start via ELK's
-         ;; direction priority. Only the OUTGOING edge from the initial
-         ;; gets it (the `__out` event→target edge is unaffected).
+         ;; the `__in` edge LEAVES the source state; when that state is
+         ;; initial, pull it to flow-start via ELK's direction priority.
+         ;; Only the OUTGOING edge from the initial gets it (the `__out`
+         ;; event→target edge is unaffected).
          from-initial? (contains? (or initial-ids #{}) (:source e))]
      (cond-> [(cond-> {:id      in-id
                        :sources [(:source e)]
@@ -1091,15 +1064,15 @@
               :labels  (elk-edge-label "" (get label-dims out-id))})))))
 
 (defn ->elk-edges
-  "rf2-rlq97 — project ALL parsed edges into the flat elk `edges` vector
+  "Project ALL parsed edges into the flat elk `edges` vector
   `chart.cljs/->elk-input` `clj->js`-es onto the elk root graph. The
   events-as-nodes split (`->elk-edge`) means N parsed transitions emit
   up to 2N elk edges. `label-dims` (optional measured-label map) is
   forwarded to every `->elk-edge`.
 
-  rf2-k504af — the set of `:initial?` node-ids is derived once from
-  `:nodes` and forwarded to every `->elk-edge` so an initial state's
-  outgoing `__in` edge carries ELK's flow-start direction priority."
+  The set of `:initial?` node-ids is derived once from `:nodes` and
+  forwarded to every `->elk-edge` so an initial state's outgoing `__in`
+  edge carries ELK's flow-start direction priority."
   ([parsed] (->elk-edges parsed nil))
   ([{:keys [edges nodes]} label-dims]
    (let [initial-ids (into #{} (comp (filter :initial?) (map :id)) nodes)]
@@ -1113,13 +1086,12 @@
 
   Options:
 
-    :highlight-ids       — rf2-g2svr (closes parity gap G1). A SET of
-                           active-leaf node-ids. A node is `:active`
-                           when its id ∈ this set. A PARALLEL machine's
-                           snapshot has N simultaneously-active leaves
-                           (one per region), so passing the set lights
-                           up EVERY active region at once — the multi-
-                           active highlight Stately renders (§1.2 of
+    :highlight-ids       — a SET of active-leaf node-ids (parity gap G1).
+                           A node is `:active` when its id ∈ this set. A
+                           PARALLEL machine's snapshot has N simultaneously-
+                           active leaves (one per region), so passing the
+                           set lights up EVERY active region at once — the
+                           multi-active highlight Stately renders (§1.2 of
                            `001-Topology-Parity.md`). Resolve it from a
                            snapshot `:state` via
                            `chart.layout/highlight-ids` (handles all
@@ -1132,10 +1104,10 @@
     :to-highlight-id     — node-id of the focused-event lens's
                            landing state.
     :sim?                — flips the highlight palette to amber.
-    :on-state-click      — rf2-34ff3. `(fn [path] ...)` invoked when a
-                           REAL statechart-state node is clicked: a LEAF
-                           state (its body) or a COMPOUND state (its TITLE
-                           STRIP only — the compound body stays
+    :on-state-click      — `(fn [path] ...)` invoked when a REAL
+                           statechart-state node is clicked: a LEAF state
+                           (its body) or a COMPOUND state (its TITLE STRIP
+                           only — the compound body stays
                            `pointer-events:none` so a click in the body
                            falls through to the nested leaf). Threaded onto
                            leaf + compound `:data` as `:onClick`. The
@@ -1145,7 +1117,7 @@
                            NOT thread `:onClick` onto their `:data` — no
                            node carries an `:onClick` its renderer would
                            never consume.
-    :on-edge-click       — rf2-u422r. `(fn [{:keys [event-id from-path
+    :on-edge-click       — `(fn [{:keys [event-id from-path
                            to-path]}] ...)` invoked when a transition
                            edge's label is clicked. Threaded onto every
                            edge `:data` as `:onClick` (+ the raw
@@ -1158,23 +1130,21 @@
                            `:always`) carry the callback too but a nil
                            `:eventId`; the host filters those out. nil
                            omits the wiring entirely (no-op edge labels).
-    :edge-points         — rf2-cz8v6 (closes parity gap G2); rf2-r636q
-                           (key-scheme fix). A map `{elk-edge-id
-                           [{:x :y} …]}` of elk's routed bend-points
-                           (absolute / flow coordinates; `chart`'s
-                           `compute-layout!` sets `elk.json.edgeCoords
-                           ROOT` so they share xyflow's frame). The KEYS
-                           are the elk edge ids `chart.cljs/->elk-input`
-                           emits — `<spec-edge-id>__in` (source-state →
+    :edge-points         — a map `{elk-edge-id [{:x :y} …]}` of elk's
+                           routed bend-points (parity gap G2; absolute /
+                           flow coordinates; `chart`'s `compute-layout!`
+                           sets `elk.json.edgeCoords ROOT` so they share
+                           xyflow's frame). The KEYS are the elk edge ids
+                           `chart.cljs/->elk-input` emits —
+                           `<spec-edge-id>__in` (source-state →
                            event-node) and `<spec-edge-id>__out`
                            (event-node → target-state) — under the
-                           events-as-nodes paradigm (rf2-qo5xy). The
-                           inbound xyflow edge (`<spec-edge-id>__in`)
-                           looks up the `__in` route and the outbound
-                           (`<spec-edge-id>__out`) looks up the `__out`
-                           route, so each edge draws exactly the segment
-                           it represents; the route attaches to that
-                           edge's `:data {:points}` and
+                           events-as-nodes paradigm. The inbound xyflow
+                           edge (`<spec-edge-id>__in`) looks up the `__in`
+                           route and the outbound (`<spec-edge-id>__out`)
+                           looks up the `__out` route, so each edge draws
+                           exactly the segment it represents; the route
+                           attaches to that edge's `:data {:points}` and
                            `chart.edges/transition-edge` draws a smooth
                            poly-path THROUGH those points — routing
                            AROUND nested/parallel containers rather than
@@ -1183,13 +1153,7 @@
                            entry (or a self-loop, which keeps its
                            dedicated loop path) falls back to the bezier
                            between handles. Defaults to `{}`.
-
-                           (Before rf2-r636q the lookup used the BARE
-                           `<spec-edge-id>`, which the producer never
-                           emits post-rf2-qo5xy, so every lookup missed
-                           and the whole feature silently fell back to
-                           beziers — a dead G2.)
-    :edge-labels         — rf2-rlq97. A map `{elk-edge-id {:x :y}}` of
+    :edge-labels         — a map `{elk-edge-id {:x :y}}` of
                            elk's COMPUTED label positions (absolute /
                            flow coords; the LABEL analogue of
                            `:edge-points`). Keyed by the same
@@ -1205,9 +1169,9 @@
                            the event-NODE, ELK-placed already), so this
                            is normally `{}` and the edge keeps its
                            geometric anchor. Defaults to `{}`.
-    :fired-edge-ids      — rf2-qeemm (closes parity gap G3). A SET of
-                           canonical edge-ids (the EXACT `:id` scheme
-                           `chart.layout` mints) that fired THIS epoch.
+    :fired-edge-ids      — a SET of canonical edge-ids (parity gap G3;
+                           the EXACT `:id` scheme `chart.layout` mints)
+                           that fired THIS epoch.
                            An edge is marked `:fired` when its id ∈ this
                            set; `chart.edges/transition-edge` then paints
                            the fired-this-epoch treatment (emphasised +
@@ -1224,8 +1188,8 @@
                            matches the EDGE directly, so it lights every
                            traversed arm (microsteps, guard-fork
                            candidates) the lens cannot. Defaults to `#{}`.
-    :guard-blocked-edge-ids — rf2-fzrzlw. A SET of canonical edge-ids
-                           whose guard REJECTED the event this epoch (a
+    :guard-blocked-edge-ids — a SET of canonical edge-ids whose guard
+                           REJECTED the event this epoch (a
                            guard-blocked no-op: the runtime emitted
                            `:rf.machine/guard-evaluated` fail/threw but NO
                            `:rf.machine/transition`). The event-node AND its
@@ -1235,8 +1199,7 @@
                            blocked treatment (emphasised pink stroke +
                            emphasised pink `IF <guard>` chip, `data-guard-
                            blocked`) which WINS over fired/focused/active so
-                           the attempted-and-rejected edge stands out (bead
-                           design calls (1) + (2)). rf2-4nxgqq — the
+                           the attempted-and-rejected edge stands out. The
                            highlight STOPS at the guard event-node: the
                            `__out` (event-node → target-state) half is NOT
                            marked, because a blocked transition is a no-op
@@ -1245,16 +1208,16 @@
                            would falsely imply the transition progressed. The
                            static `__out` topology edge still renders; only
                            the live blocked-overlay stops at the event-node.
-                           Without any of this the chart paints ALL of the
-                           active state's exits affordance-blue and gives
+                           Without any of this the chart would paint ALL of
+                           the active state's exits affordance-blue and give
                            ZERO signal which edge the event hit or that a
                            guard blocked it. The host (Xray) resolves the set
                            via
                            `panels.machines.trace-state/extract-guard-blocked-edge-ids`.
                            SUPERSET of XState/Stately (which highlights
                            nothing on a block). Defaults to `#{}`.
-    :chart               — rf2-k647w. The resolved visual-constants
-                           map for the active `:density`
+    :chart               — the resolved visual-constants map for the
+                           active `:density`
                            (`visual-constants/chart-for-density`).
                            Threaded into every node/edge `:data` as
                            `:chart` so the xyflow node/edge components
@@ -1264,10 +1227,9 @@
                            hardcoded literal. Defaults to
                            `visual-constants/chart-regular` so callers
                            that omit it (the JVM projection tests, a
-                           density-less host) get the regular density
-                           pixel-identical to pre-rf2-k647w.
-    :palette             — rf2-az6e2. The resolved chart-semantic token
-                           map for the active `:theme`
+                           density-less host) get the regular density.
+    :palette             — the resolved chart-semantic token map for the
+                           active `:theme`
                            (`theme/tokens/chart-tokens` of the
                            theme-palette). Threaded into every node/edge
                            `:data` as `:palette` so the xyflow node/edge
@@ -1289,12 +1251,12 @@
            context-band-inferred? true
            context-band-sensitive #{} context-band-large #{}
            context-band-raw? false}}]
-  (let [;; rf2-az6e2 — resolve the chart-semantic token map for the
-        ;; active theme ONCE. nil → dark chart-tokens (a theme-less
-        ;; caller keeps the dark surface). Threaded onto every node/edge
-        ;; `:data {:palette}` so the renderers paint the active theme.
+  (let [;; resolve the chart-semantic token map for the active theme
+        ;; ONCE. nil → dark chart-tokens (a theme-less caller keeps the
+        ;; dark surface). Threaded onto every node/edge `:data {:palette}`
+        ;; so the renderers paint the active theme.
         ct (or palette (tokens/chart-tokens))
-        ;; rf2-27e38h (EP-0015) — the Context band is serialised into the
+        ;; the Context band is serialised into the
         ;; SVG / PNG / clipboard export (export/chart-as-svg clones the
         ;; live viewport DOM). It defaults to a LOCAL-REDACTED projection:
         ;; a `:context-band-sensitive` key renders `:rf/redacted` and a
@@ -1315,28 +1277,28 @@
                                 [(if (keyword? k) (str (symbol k)) (str k))
                                  (ctx-redact/display-string v)])
                               redacted)))
-        ;; rf2-uw3vmi — guarded-fork branch-order. Derived ONCE from the
-        ;; ordered `:edges` vector (the parse preserves the source
-        ;; candidate vector order, which IS the engine's first-pass-wins
-        ;; priority); `{edge-id 1-based-index}` for every edge that is one
-        ;; branch of a genuine guarded multi-branch fork (2+ same-source /
-        ;; same-trigger candidates with at least one guard). Threaded onto
-        ;; each event-node's `:data {:forkOrder}` so `event-node` paints
-        ;; the numbered priority badge Stately shows on the gate `:check`
-        ;; 3-way; absent (→ nil) for every non-fork event, so a single
-        ;; transition carries no badge.
+        ;; guarded-fork branch-order. Derived ONCE from the ordered
+        ;; `:edges` vector (the parse preserves the source candidate vector
+        ;; order, which IS the engine's first-pass-wins priority);
+        ;; `{edge-id 1-based-index}` for every edge that is one branch of a
+        ;; genuine guarded multi-branch fork (2+ same-source / same-trigger
+        ;; candidates with at least one guard). Threaded onto each event-
+        ;; node's `:data {:forkOrder}` so `event-node` paints the numbered
+        ;; priority badge Stately shows on the gate `:check` 3-way; absent
+        ;; (→ nil) for every non-fork event, so a single transition carries
+        ;; no badge.
         fork-order (fork-order-by-edge-id edges)
-        ;; rf2-g2svr (G1) — the active set. A PARALLEL machine's snapshot
-        ;; has N simultaneously-active leaves; `:highlight-ids` carries
-        ;; them all so EVERY active region lights up at once. A flat /
-        ;; compound snapshot resolves (via `chart.layout/highlight-ids`)
-        ;; to a singleton set. A node is active when its id ∈ this set.
+        ;; the active set (G1). A PARALLEL machine's snapshot has N
+        ;; simultaneously-active leaves; `:highlight-ids` carries them all
+        ;; so EVERY active region lights up at once. A flat / compound
+        ;; snapshot resolves (via `chart.layout/highlight-ids`) to a
+        ;; singleton set. A node is active when its id ∈ this set.
         active-ids (set highlight-ids)
-        ;; rf2-80rm2 (G4) — container ACTIVE chrome. The active set above
-        ;; holds active LEAF ids; a parallel-region (or compound) CONTAINER
-        ;; reads as active when ANY descendant leaf is active, so an active
-        ;; region's chrome (the dashed box + header) emphasises — not just
-        ;; the leaf inside it (Stately parity §1.4 of `001-Topology-Parity.md`).
+        ;; container ACTIVE chrome (G4). The active set above holds active
+        ;; LEAF ids; a parallel-region (or compound) CONTAINER reads as
+        ;; active when ANY descendant leaf is active, so an active region's
+        ;; chrome (the dashed box + header) emphasises — not just the leaf
+        ;; inside it (Stately parity §1.4 of `001-Topology-Parity.md`).
         ;;
         ;; Reuses the G1 `active-ids` directly: walk each active leaf UP its
         ;; `:parent-id` chain (the same id every node already carries — region
@@ -1359,31 +1321,31 @@
                        (rest seeds))
                      (cond-> acc p (conj p))))
             acc))
-        ;; rf2-lkwev — container nodes (parallel regions AND compound
-        ;; parents) MUST precede their children in the xyflow nodes
-        ;; array (xyflow requires a parentId target to appear before any
-        ;; node that references it; the v12 `adoptUserNodes` walk warns
-        ;; otherwise — `Parent node ${parentId} not found. Please make
-        ;; sure that parent nodes are in front of their child nodes in
-        ;; the nodes array.`). The parse already emits parents first;
-        ;; sort defensively so the parent-before-child invariant holds.
+        ;; container nodes (parallel regions AND compound parents) MUST
+        ;; precede their children in the xyflow nodes array (xyflow requires
+        ;; a parentId target to appear before any node that references it;
+        ;; the v12 `adoptUserNodes` walk warns otherwise — `Parent node
+        ;; ${parentId} not found. Please make sure that parent nodes are in
+        ;; front of their child nodes in the nodes array.`). The parse
+        ;; already emits parents first; sort defensively so the parent-
+        ;; before-child invariant holds.
         proj-nodes
         (mapv (fn [n]
                 (let [pos      (get positions (:id n) {:x 0 :y 0})
                       region?  (boolean (:region? n))
-                      ;; rf2-80rm2 (G4) — a node is active when it is an
-                      ;; active leaf (G1) OR a container reaching an active
-                      ;; leaf via the `:parent-id` chain (the active-region
-                      ;; chrome). The two sets are disjoint by construction
-                      ;; (`active-ids` is leaves, `active-container-ids` is
-                      ;; their ancestor containers), so the union is the
-                      ;; whole active surface.
-                      ;; rf2-q129z8 — the synthetic ROOT-CONTAINER frame is
-                      ;; the ancestor of EVERY node, so the `active-container-
-                      ;; ids` parent-chain walk would always mark it active and
-                      ;; the whole frame would light up on every transition.
-                      ;; It is structural chrome, not a state, so it never picks
-                      ;; up active affordance — gate it out explicitly.
+                      ;; a node is active when it is an active leaf (G1) OR
+                      ;; a container reaching an active leaf via the
+                      ;; `:parent-id` chain (the active-region chrome). The
+                      ;; two sets are disjoint by construction (`active-ids`
+                      ;; is leaves, `active-container-ids` is their ancestor
+                      ;; containers), so the union is the whole active
+                      ;; surface.
+                      ;; The synthetic ROOT-CONTAINER frame is the ancestor
+                      ;; of EVERY node, so the `active-container-ids` parent-
+                      ;; chain walk would always mark it active and the whole
+                      ;; frame would light up on every transition. It is
+                      ;; structural chrome, not a state, so it never picks up
+                      ;; active affordance — gate it out explicitly.
                       active?  (and (not (:root-container? n))
                                     (or (contains? active-ids (:id n))
                                         (contains? active-container-ids (:id n))))
@@ -1392,53 +1354,44 @@
                       base
                       {:id       (:id n)
                        :type     (cond
-                                   ;; rf2-q129z8 — the synthetic ROOT-CONTAINER
-                                   ;; frame: the Stately-Studio-style NAMED box
-                                   ;; wrapping the WHOLE machine. A container
-                                   ;; (ELK-sized to hug its children) rendered by
+                                   ;; the synthetic ROOT-CONTAINER frame: the
+                                   ;; Stately-Studio-style NAMED box wrapping
+                                   ;; the WHOLE machine. A container (ELK-sized
+                                   ;; to hug its children) rendered by
                                    ;; `chart.nodes/root-container-node`, whose
                                    ;; header carries the machine name + Context
-                                   ;; shape (absorbing the old corner overlay).
-                                   ;; Checked BEFORE `:compound?` (it carries
-                                   ;; `:compound? true` for the ELK/xyflow
-                                   ;; container mechanics, but is NOT a compound
-                                   ;; state box).
+                                   ;; shape. Checked BEFORE `:compound?` (it
+                                   ;; carries `:compound? true` for the
+                                   ;; ELK/xyflow container mechanics, but is
+                                   ;; NOT a compound state box).
                                    (:root-container? n) "root-container"
-                                   ;; rf2-vcnvj — the synthetic root node a
-                                   ;; machine-level (top-level `:on`) fallback
-                                   ;; routes FROM. Painted as a quiet root-
-                                   ;; context chip (`chart.nodes/machine-root-
-                                   ;; node`), not a state box.
+                                   ;; the synthetic root node a machine-level
+                                   ;; (top-level `:on`) fallback routes FROM.
+                                   ;; Painted as a quiet root-context chip
+                                   ;; (`chart.nodes/machine-root-node`), not a
+                                   ;; state box.
                                    (:machine-root? n) "machine-root"
-                                   ;; rf2-dblqx — the synthetic PARALLEL-ROOT
-                                   ;; node (rf2-41goo) is the anchor the
-                                   ;; whole-parallel `:on-done` completion
-                                   ;; affordance hangs off — NOT a statechart
-                                   ;; state. Route it through the quiet
-                                   ;; root-context chip (`machine-root-node`)
-                                   ;; so it reads as the completion anchor, not
-                                   ;; a clickable state box. Pre-dblqx it fell
-                                   ;; through to `"state"` AND carried an
-                                   ;; `:onClick` (the click guard below excluded
-                                   ;; only machine-root + region), so a user
-                                   ;; could click a phantom `parallel` state and
-                                   ;; fire on-state-click against the rendering
-                                   ;; sentinel path. The SAME inert-synthetic-
-                                   ;; chip class rf2-34ff3 fixed for the
-                                   ;; machine-root + region containers.
+                                   ;; the synthetic PARALLEL-ROOT node is the
+                                   ;; anchor the whole-parallel `:on-done`
+                                   ;; completion affordance hangs off — NOT a
+                                   ;; statechart state. Route it through the
+                                   ;; quiet root-context chip
+                                   ;; (`machine-root-node`) so it reads as the
+                                   ;; completion anchor, not a clickable state
+                                   ;; box (its path is a rendering sentinel, so
+                                   ;; it must not be an on-state-click target).
+                                   ;; The SAME inert-synthetic-chip class as
+                                   ;; the machine-root + region containers.
                                    (:parallel-root? n) "machine-root"
-                                   ;; rf2-m285a — a `:type :history`
-                                   ;; PSEUDO-STATE (Spec 005 §History states)
-                                   ;; is NEVER occupiable: it is a transition
-                                   ;; target that resolves to the compound's
-                                   ;; recorded / default leaf, so the machine
-                                   ;; never sits in `[… :hist]`. Paint it as
-                                   ;; the small `history-marker` glyph (`H` /
-                                   ;; `H*`) inside its owning compound — NOT a
-                                   ;; clickable state box. The renderer
-                                   ;; (`chart.nodes/history-marker`) was a
-                                   ;; registered HOOK; this is the projector
-                                   ;; path that finally emits it.
+                                   ;; a `:type :history` PSEUDO-STATE (Spec 005
+                                   ;; §History states) is NEVER occupiable: it
+                                   ;; is a transition target that resolves to
+                                   ;; the compound's recorded / default leaf,
+                                   ;; so the machine never sits in `[… :hist]`.
+                                   ;; Paint it as the small `history-marker`
+                                   ;; glyph (`H` / `H*`) inside its owning
+                                   ;; compound — NOT a clickable state box. The
+                                   ;; renderer is `chart.nodes/history-marker`.
                                    (:history? n)  "history-marker"
                                    region?        "parallel-region"
                                    (:compound? n) "compound"
@@ -1452,89 +1405,85 @@
                                           :sim            (boolean (and active? sim?))
                                           :initial        (boolean (:initial? n))
                                           :final          (boolean (:final? n))
-                                          ;; rf2-b4loj — error-terminal KIND.
-                                          ;; `:error?` finals (a re-frame2
-                                          ;; extension routing the parent's
-                                          ;; `:on-error`) get the error-hue
-                                          ;; outer ring; success finals keep the
-                                          ;; quiet runtime-coupled ring.
+                                          ;; error-terminal KIND. `:error?`
+                                          ;; finals (a re-frame2 extension
+                                          ;; routing the parent's `:on-error`)
+                                          ;; get the error-hue outer ring;
+                                          ;; success finals keep the quiet
+                                          ;; runtime-coupled ring.
                                           :errorFinal     (boolean (:error? n))
                                           :compound       (boolean (:compound? n))
-                                          ;; rf2-vcnvj — serialise each tag
-                                          ;; to its FULLY-QUALIFIED string
-                                          ;; (`door/open`, not `open`) HERE,
-                                          ;; before xyflow `clj->js`-es the
-                                          ;; `:data` map. `clj->js`'s default
-                                          ;; keyword-fn is `name`, which drops
-                                          ;; the namespace — so a `:door/open`
-                                          ;; tag would arrive at the renderer
-                                          ;; as the truncated `"open"` and the
-                                          ;; `nodes/tag-label` identity fix
-                                          ;; (which runs AFTER the round-trip)
-                                          ;; could never recover it. Stringify
-                                          ;; via `symbol` so the namespace
-                                          ;; survives the boundary intact.
+                                          ;; serialise each tag to its FULLY-
+                                          ;; QUALIFIED string (`door/open`, not
+                                          ;; `open`) HERE, before xyflow
+                                          ;; `clj->js`-es the `:data` map.
+                                          ;; `clj->js`'s default keyword-fn is
+                                          ;; `name`, which drops the namespace —
+                                          ;; so a `:door/open` tag would arrive
+                                          ;; at the renderer as the truncated
+                                          ;; `"open"` and the `nodes/tag-label`
+                                          ;; identity fix (which runs AFTER the
+                                          ;; round-trip) could never recover it.
+                                          ;; Stringify via `symbol` so the
+                                          ;; namespace survives the boundary
+                                          ;; intact.
                                           :tags           (mapv (fn [t]
                                                                   (if (keyword? t)
                                                                     (str (symbol t))
                                                                     (str t)))
                                                                 (:tags n))
-                                          ;; rf2-ee38b.21 — :entry / :exit
-                                          ;; state actions (Spec 005
-                                          ;; §State nodes) ride the payload
-                                          ;; so state-node paints
+                                          ;; :entry / :exit state actions
+                                          ;; (Spec 005 §State nodes) ride the
+                                          ;; payload so state-node paints
                                           ;; `entry / <name>` rows. nil when
                                           ;; the state declares none.
                                           :entry          (:entry n)
                                           :exit           (:exit n)
-                                          ;; rf2-skhlw2.1 — the entry / exit
-                                          ;; lifecycle action's declared
-                                          ;; `:rf.cofx/requires` (EP-0017 consumer
-                                          ;; attachment), as compact display
-                                          ;; strings the action row paints as a
-                                          ;; `needs …` chip. nil when the action
-                                          ;; declares no facts. IDS only. camelCase
-                                          ;; so the JS-interop `(.-entryRequires d)`
-                                          ;; resolves after xyflow `clj->js`-es the
-                                          ;; `:data` map (a kebab key would not).
+                                          ;; the entry / exit lifecycle
+                                          ;; action's declared `:rf.cofx/requires`
+                                          ;; (EP-0017 consumer attachment), as
+                                          ;; compact display strings the action
+                                          ;; row paints as a `needs …` chip. nil
+                                          ;; when the action declares no facts.
+                                          ;; IDS only. camelCase so the JS-interop
+                                          ;; `(.-entryRequires d)` resolves after
+                                          ;; xyflow `clj->js`-es the `:data` map
+                                          ;; (a kebab key would not).
                                           :entryRequires  (:entry-requires n)
                                           :exitRequires   (:exit-requires n)
-                                          ;; rf2-m285a — a `:type :history`
-                                          ;; pseudo-state's variant. The
-                                          ;; `history-marker` renderer reads
-                                          ;; `(.-deep props)`: deep history
-                                          ;; paints `H*`, shallow `H`
-                                          ;; (Spec 005 §History states).
+                                          ;; a `:type :history` pseudo-state's
+                                          ;; variant. The `history-marker`
+                                          ;; renderer reads `(.-deep props)`:
+                                          ;; deep history paints `H*`, shallow
+                                          ;; `H` (Spec 005 §History states).
                                           :deep           (boolean (:deep? n))
                                           :chart          chart
                                           :palette        ct}
-                                   ;; rf2-34ff3 — `:onClick` (on-state-click)
-                                   ;; rides ONLY real statechart-state nodes:
-                                   ;; LEAF states (clickable body) and COMPOUND
-                                   ;; states (clickable TITLE STRIP; body stays
+                                   ;; `:onClick` (on-state-click) rides ONLY
+                                   ;; real statechart-state nodes: LEAF states
+                                   ;; (clickable body) and COMPOUND states
+                                   ;; (clickable TITLE STRIP; body stays
                                    ;; pointer-transparent so child-leaf clicks
                                    ;; pass through). The synthetic machine-root
                                    ;; chip, parallel-region containers, AND the
                                    ;; synthetic parallel-root completion anchor
-                                   ;; (rf2-dblqx) are NOT `:on-state-click`
-                                   ;; targets (no region-selection concept yet;
-                                   ;; the parallel-root is a completion
-                                   ;; affordance whose path is a rendering
-                                   ;; sentinel, not a real statechart state), so
-                                   ;; they carry no `:onClick` the renderer
-                                   ;; would never consume — the inverse of the
-                                   ;; original half-wired bug.
-                                   ;; rf2-m285a — a `:type :history`
-                                   ;; pseudo-state is also NOT an
-                                   ;; on-state-click target: it is never
+                                   ;; are NOT `:on-state-click` targets (no
+                                   ;; region-selection concept yet; the
+                                   ;; parallel-root is a completion affordance
+                                   ;; whose path is a rendering sentinel, not a
+                                   ;; real statechart state), so they carry no
+                                   ;; `:onClick` the renderer would never
+                                   ;; consume.
+                                   ;; A `:type :history` pseudo-state is also
+                                   ;; NOT an on-state-click target: it is never
                                    ;; occupied, so there is no state to select
                                    ;; (same inert-synthetic-chip posture as the
                                    ;; machine-root / parallel-root anchors).
-                                   ;; rf2-q129z8 — the synthetic ROOT-CONTAINER
-                                   ;; frame is structural chrome, not a
-                                   ;; statechart state, so (like the machine-
-                                   ;; root / region / parallel-root anchors) it
-                                   ;; carries no `:onClick`.
+                                   ;; The synthetic ROOT-CONTAINER frame is
+                                   ;; structural chrome, not a statechart state,
+                                   ;; so (like the machine-root / region /
+                                   ;; parallel-root anchors) it carries no
+                                   ;; `:onClick`.
                                    (not (or (:machine-root? n)
                                             (:parallel-root? n)
                                             (:history? n)
@@ -1545,20 +1494,19 @@
                                    region? (assoc :regionId    (:region n)
                                                   :regionIndex (:region-index n))
 
-                                   ;; rf2-q129z8 — the ROOT-CONTAINER frame's
-                                   ;; header content. The pure layer minted a
-                                   ;; neutral `:label` ("machine"); override it
-                                   ;; with the MACHINE NAME (the host's
-                                   ;; `:machine-id`) and thread the inferred
-                                   ;; Context shape + parallel flag so
-                                   ;; `chart.nodes/root-container-node` paints the
-                                   ;; named frame header + Context band —
-                                   ;; absorbing the pre-q129z8 corner-pinned
-                                   ;; title strip + Context overlay. Serialise
-                                   ;; the context map's keyword keys to fully-
-                                   ;; qualified strings BEFORE xyflow `clj->js`
-                                   ;; (whose default keyword-fn drops the
-                                   ;; namespace), mirroring the `:tags` handling.
+                                   ;; the ROOT-CONTAINER frame's header
+                                   ;; content. The pure layer minted a neutral
+                                   ;; `:label` ("machine"); override it with the
+                                   ;; MACHINE NAME (the host's `:machine-id`)
+                                   ;; and thread the inferred Context shape +
+                                   ;; parallel flag so
+                                   ;; `chart.nodes/root-container-node` paints
+                                   ;; the named frame header + Context band.
+                                   ;; Serialise the context map's keyword keys
+                                   ;; to fully-qualified strings BEFORE xyflow
+                                   ;; `clj->js` (whose default keyword-fn drops
+                                   ;; the namespace), mirroring the `:tags`
+                                   ;; handling.
                                    (:root-container? n)
                                    (assoc :label (if machine-id
                                                    (name machine-id)
@@ -1566,16 +1514,16 @@
                                           :machineName (when machine-id
                                                          (name machine-id))
                                           :parallel    (boolean parallel?)
-                                          ;; rf2-27e38h — the local-redacted
-                                          ;; band display rows (computed once
-                                          ;; above; never the raw values unless
+                                          ;; the local-redacted band display
+                                          ;; rows (computed once above; never the
+                                          ;; raw values unless
                                           ;; `:context-band-raw?` opted in).
                                           :context     ctx-display
                                           :contextInferred (boolean
                                                              context-band-inferred?)))
                        :draggable false
                        :selectable false}]
-                  ;; rf2-a64bi — BOTH region AND compound containers receive
+                  ;; BOTH region AND compound containers receive
                   ;; `:style {:width :height}` from elk's measured position.
                   ;; The parallel-region renderer (`parallel_region_node`)
                   ;; AND the compound renderer (`compound_node`) both fill
@@ -1583,56 +1531,49 @@
                   ;; allocate the box elk measured — otherwise it falls back
                   ;; to `compound-node-min-{width,height}` (220×120), and
                   ;; substates whose parent-relative coords elk computed
-                  ;; against the FULL measured extent overflow the smaller
-                  ;; fallback box and visually escape the container. The
-                  ;; asymmetry (region styled, compound not) was the bug;
-                  ;; mirroring the region path here keeps containment.
+                  ;; against the FULL measured extent would overflow the
+                  ;; smaller fallback box and visually escape the container.
+                  ;; Styling both (not just the region) keeps containment.
                   (cond-> base
                     (or region? (:compound? n))
                     (assoc :style {:width  (:width pos)
                                    :height (:height pos)})
 
-                    ;; rf2-xh1lm — xyflow v12 reads `parentId` (NOT
-                    ;; `parentNode`, the pre-v12 name retained only in
-                    ;; xyflow's CHANGELOG). Without `parentId` xyflow
-                    ;; does NOT recognise the child as nested: it
-                    ;; interprets `:position` as ABSOLUTE flow coords
-                    ;; and ignores `:extent "parent"` clamping, so an
-                    ;; ELK parent-relative child (e.g. `{:x 14 :y 34}`
-                    ;; under an `:active` container at `{:x 22 :y 240}`)
-                    ;; renders at root `(14, 34)` — visually OUTSIDE
-                    ;; the parent. Emit `:parentId` so xyflow's
+                    ;; xyflow v12 reads `parentId` (NOT `parentNode`,
+                    ;; the pre-v12 name retained only in xyflow's
+                    ;; CHANGELOG). Without `parentId` xyflow does NOT
+                    ;; recognise the child as nested: it interprets
+                    ;; `:position` as ABSOLUTE flow coords and ignores
+                    ;; `:extent "parent"` clamping, so an ELK parent-
+                    ;; relative child (e.g. `{:x 14 :y 34}` under an
+                    ;; `:active` container at `{:x 22 :y 240}`) would
+                    ;; render at root `(14, 34)` — visually OUTSIDE the
+                    ;; parent. Emit `:parentId` so xyflow's
                     ;; `adoptUserNodes` path adopts the child + uses
                     ;; the parent's absolute origin as the offset.
                     (and (not region?) (:parent-id n))
                     (assoc :parentId (:parent-id n)
                            :extent   "parent"))))
-              ;; rf2-vcnvj — the machine-root node leads (it is the source
-              ;; of a machine-level fallback's `__in` edge + event-node, and
+              ;; the machine-root node leads (it is the source of a
+              ;; machine-level fallback's `__in` edge + event-node, and
               ;; xyflow wants a source-node before any edge that references
               ;; it), alongside region/compound parents.
               (sort-by #(if (or (:machine-root? %) (:region? %) (:compound? %)) 0 1) nodes))
 
-        ;; rf2-qo5xy — events-as-nodes paradigm. Each parsed transition
-        ;; emits ONE event-node (xyflow `type "rf2-event"`) plus one or
-        ;; two edges:
+        ;; events-as-nodes paradigm. Each parsed transition emits ONE
+        ;; event-node (xyflow `type "rf2-event"`) plus one or two edges:
         ;;
         ;;   source-state ─→ event-node ─→ target-state  (regular external)
         ;;   source-state ─→ event-node                 (internal: no :target)
         ;;
-        ;; Pre-rf2-qo5xy the chart painted transitions as edge LABELS
-        ;; between state boxes (event + guard + action floated on the
-        ;; line). The events-as-nodes paradigm hoists the event into a
-        ;; first-class box so the action attribution (+ guard chip)
-        ;; reads cleanly even with several stacked candidates — the
-        ;; Stately graph view convention (rf2-qo5xy bead §Shift 1).
+        ;; The event is hoisted into a first-class box (rather than floated
+        ;; as an edge LABEL between state boxes) so the action attribution
+        ;; (+ guard chip) reads cleanly even with several stacked
+        ;; candidates — the Stately graph view convention.
         ;;
-        ;; The legacy single-edge `:edges` shape (state → state with
-        ;; event/guard/action on the label) is dropped: tests that used
-        ;; to assert on the edge `:data {:eventLabel ...}` now address
-        ;; the event-node's `:data {:eventLabel ...}` instead. The
-        ;; cross-hierarchy / sibling / self-loop / fired / focused
-        ;; treatments still apply to the incoming + outgoing edges, but
+        ;; The event-node — not the edge — carries the `:data {:eventLabel
+        ;; ...}`; the cross-hierarchy / sibling / self-loop / fired /
+        ;; focused treatments apply to the incoming + outgoing edges, but
         ;; the visible label rides on the event-node.
         cross-hierarchy?-of
         (fn [src tgt]
@@ -1646,47 +1587,47 @@
         (mapv (fn [e]
                 (let [src          (:source e)
                       tgt          (:target e)
-                      ;; rf2-vd3q1i — SOURCE-active only. The name is now
-                      ;; honest: an edge is `from-active?` iff its SOURCE
-                      ;; is an active state (the outgoing "available
-                      ;; transitions from here" fan). The dropped
-                      ;; `(contains? active-ids tgt)` clause used to also
-                      ;; light INCOMING edges (target active) — noise that
-                      ;; misrepresented what a focused event did (e.g. a
-                      ;; rejected no-op guard lit every way you COULD have
-                      ;; arrived at the resting state). The actually-
-                      ;; traversed edge of a real transition still lights
-                      ;; via `fired?` (matched by edge-id, direction-
-                      ;; agnostic), so no fired arm relies on this clause.
+                      ;; SOURCE-active only: an edge is `from-active?` iff
+                      ;; its SOURCE is an active state (the outgoing
+                      ;; "available transitions from here" fan). Target-
+                      ;; active is deliberately NOT lit — it would light
+                      ;; INCOMING edges, noise that misrepresents what a
+                      ;; focused event did (e.g. a rejected no-op guard
+                      ;; lighting every way you COULD have arrived at the
+                      ;; resting state). The actually-traversed edge of a
+                      ;; real transition still lights via `fired?` (matched
+                      ;; by edge-id, direction-agnostic), so no fired arm
+                      ;; relies on this clause.
                       from-active? (contains? active-ids src)
                       focused?     (and (some? from-highlight-id)
                                         (some? to-highlight-id)
                                         (= src from-highlight-id)
                                         (= tgt to-highlight-id))
                       fired?       (contains? fired-edge-ids (:id e))
-                      ;; rf2-fzrzlw — this edge's guard rejected the event
-                      ;; this epoch (guard-blocked no-op). Drives the PINK
-                      ;; guard-blocked treatment on the event-node and the
-                      ;; `__in` (source→event-node) half, winning over
-                      ;; fired/focused/active. rf2-4nxgqq — the highlight
-                      ;; STOPS at the event-node: the `__out` (event-node→
-                      ;; target) half stays static/resting (`half-blocked?`
-                      ;; below gates the per-half overlay to `:in` only), so
-                      ;; the onward arrow does not imply the no-op progressed.
+                      ;; this edge's guard rejected the event this epoch
+                      ;; (guard-blocked no-op). Drives the PINK guard-blocked
+                      ;; treatment on the event-node and the `__in`
+                      ;; (source→event-node) half, winning over
+                      ;; fired/focused/active. The highlight STOPS at the
+                      ;; event-node: the `__out` (event-node→target) half
+                      ;; stays static/resting (`half-blocked?` below gates the
+                      ;; per-half overlay to `:in` only), so the onward arrow
+                      ;; does not imply the no-op progressed.
                       blocked?     (contains? guard-blocked-edge-ids (:id e))
                       internal?    (boolean (:internal? e))
-                      ;; rf2-9dj21r — the EXTERNAL restart axis (`:reenter?
-                      ;; true`). A targeted transition is internal by default
-                      ;; (XState v5 / Spec 005 §Self-transitions); `:reenter?`
-                      ;; re-runs the target's exit/entry + restarts its
+                      ;; the EXTERNAL restart axis (`:reenter? true`). A
+                      ;; targeted transition is internal by default (XState v5
+                      ;; / Spec 005 §Self-transitions); `:reenter?` re-runs
+                      ;; the target's exit/entry + restarts its
                       ;; `:after`/`:spawn`. Surfaced so a reentering
-                      ;; transition reads distinctly from its internal default.
+                      ;; transition reads distinctly from its internal
+                      ;; default.
                       reenter?     (boolean (:reenter? e))
                       ;; A `:*` wildcard `:on` arm is a real transition
                       ;; but NOT a fireable event (Spec 005 §Wildcard).
-                      ;; rf2-41goo — an `:on-done` completion edge carries
-                      ;; the reserved `:rf.machine/done` (an engine-RAISED
-                      ;; event, not user-fireable), so it is not click-to-send.
+                      ;; An `:on-done` completion edge carries the reserved
+                      ;; `:rf.machine/done` (an engine-RAISED event, not
+                      ;; user-fireable), so it is not click-to-send.
                       fireable?    (and (nil? (:after e))
                                         (not (:always? e))
                                         (not (:on-done? e))
@@ -1702,9 +1643,9 @@
                       ;; rest. Top-level states leave `:parent-id` nil.
                       parent-id    (get parent-of src)
                       cross-hier?  (cross-hierarchy?-of src tgt)
-                      ;; rf2-r636q — reconcile the producer/consumer
-                      ;; key scheme. `chart.cljs/->elk-input` splits each
-                      ;; parsed transition into TWO elk edges with ids
+                      ;; the producer/consumer key scheme.
+                      ;; `chart.cljs/->elk-input` splits each parsed
+                      ;; transition into TWO elk edges with ids
                       ;; `<spec-edge-id>__in` (source-state → event-node)
                       ;; and `<spec-edge-id>__out` (event-node → target),
                       ;; and `elk-result->positions` keys `:edge-points`
@@ -1714,16 +1655,13 @@
                       ;; draws exactly the segment it represents — the
                       ;; inbound edge gets the source→event-node route,
                       ;; the outbound edge gets the event-node→target
-                      ;; route. (Previously the lookup used the bare
-                      ;; canonical id, which the producer never emits, so
-                      ;; every lookup missed and the feature fell back to
-                      ;; beziers — silently dead post-rf2-qo5xy.)
+                      ;; route.
                       in-points    (get edge-points (str (:id e) "__in"))
                       out-points   (get edge-points (str (:id e) "__out"))
-                      ;; rf2-rlq97 — elk's computed label positions for
-                      ;; the two segments (LABEL analogue of the routes).
-                      ;; Empty under events-as-nodes (label is on the
-                      ;; event-node); present for any labelled edge.
+                      ;; elk's computed label positions for the two
+                      ;; segments (LABEL analogue of the routes). Empty
+                      ;; under events-as-nodes (label is on the event-node);
+                      ;; present for any labelled edge.
                       in-label-pos  (get edge-labels (str (:id e) "__in"))
                       out-label-pos (get edge-labels (str (:id e) "__out"))]
                   {:edge      e
@@ -1767,59 +1705,57 @@
                                        :afterMs     (:after edge)
                                        :guard       (layout/name-of (:guard edge))
                                        :action      (layout/name-of (:action edge))
-                                       ;; rf2-skhlw2.1 — the guard / action
-                                       ;; consumer's declared `:rf.cofx/requires`
-                                       ;; (EP-0017 consumer attachment), as
-                                       ;; compact display strings the event-node
-                                       ;; paints as a `needs …` chip. nil when the
+                                       ;; the guard / action consumer's
+                                       ;; declared `:rf.cofx/requires` (EP-0017
+                                       ;; consumer attachment), as compact
+                                       ;; display strings the event-node paints
+                                       ;; as a `needs …` chip. nil when the
                                        ;; named guard / action declares no facts
                                        ;; (so an undeclared callback is visually
-                                       ;; unchanged). IDS only — never the `:fn`.
-                                       ;; camelCase so the JS-interop
+                                       ;; unchanged). IDS only — never the
+                                       ;; `:fn`. camelCase so the JS-interop
                                        ;; `(.-guardRequires d)` resolves after
                                        ;; xyflow `clj->js`-es the `:data` map.
                                        :guardRequires  (:guard-requires edge)
                                        :actionRequires (:action-requires edge)
-                                       ;; rf2-uw3vmi — 1-based priority index
-                                       ;; WHEN this event-node is one branch of
-                                       ;; a genuine guarded multi-branch fork
-                                       ;; (gate's `:gate/check` 3-way → 1/2/3);
-                                       ;; nil for every non-fork event so a
-                                       ;; single transition carries no badge.
+                                       ;; 1-based priority index WHEN this
+                                       ;; event-node is one branch of a genuine
+                                       ;; guarded multi-branch fork (gate's
+                                       ;; `:gate/check` 3-way → 1/2/3); nil for
+                                       ;; every non-fork event so a single
+                                       ;; transition carries no badge.
                                        ;; `event-node` paints the numbered
                                        ;; priority badge Stately shows on the
                                        ;; fork branches.
                                        :forkOrder   (get fork-order (:id edge))
                                        :focused     focused?
                                        :fired       fired?
-                                       ;; rf2-fzrzlw — guard-blocked no-op:
-                                       ;; the event-node paints the PINK
-                                       ;; guard-blocked treatment (pink
-                                       ;; border + emphasised pink IF-guard
-                                       ;; chip).
+                                       ;; guard-blocked no-op: the event-node
+                                       ;; paints the PINK guard-blocked
+                                       ;; treatment (pink border + emphasised
+                                       ;; pink IF-guard chip).
                                        :guardBlocked blocked?
                                        :internal    internal?
-                                       ;; rf2-9dj21r — the external-restart
-                                       ;; axis surfaced to the event-node
-                                       ;; renderer (the `↻` reenter chip).
+                                       ;; the external-restart axis surfaced to
+                                       ;; the event-node renderer (the `↻`
+                                       ;; reenter chip).
                                        :reenter     reenter?
                                        :machineLevel (boolean (:machine-level? edge))
-                                       ;; rf2-41goo — the XState `onDone`
-                                       ;; completion edge (compound/parallel
-                                       ;; done.state). `:onDone` is the
-                                       ;; renderer hook for the ✓ done chip;
-                                       ;; `:doneState` is the SCXML-style
-                                       ;; `done.state.<id>` label (the node-id
-                                       ;; of the done node's path) so a reader
-                                       ;; sees WHICH sub-flow completed.
+                                       ;; the XState `onDone` completion edge
+                                       ;; (compound/parallel done.state).
+                                       ;; `:onDone` is the renderer hook for the
+                                       ;; ✓ done chip; `:doneState` is the
+                                       ;; SCXML-style `done.state.<id>` label
+                                       ;; (the node-id of the done node's path)
+                                       ;; so a reader sees WHICH sub-flow
+                                       ;; completed.
                                        ;;
-                                       ;; rf2-bs3us — the PARALLEL-ROOT done-
-                                       ;; path is the engine's root sentinel
-                                       ;; `[]`, whose `node-id` is the EMPTY
-                                       ;; string — so the naive form yielded a
-                                       ;; degenerate `"done.state."` (trailing
-                                       ;; dot, no id) that diverged from the
-                                       ;; SCXML emitter's
+                                       ;; The PARALLEL-ROOT done-path is the
+                                       ;; engine's root sentinel `[]`, whose
+                                       ;; `node-id` is the EMPTY string — the
+                                       ;; naive form would yield a degenerate
+                                       ;; `"done.state."` (trailing dot, no id)
+                                       ;; that diverges from the SCXML emitter's
                                        ;; `"done.state.rf2_parallel_root"`. Use
                                        ;; the shared canonical sentinel id for
                                        ;; the parallel-root so the chart label
@@ -1839,27 +1775,27 @@
                                        :palette     ct}
                            :draggable false
                            :selectable false}
-                    ;; rf2-xh1lm — the event-node nests inside the same
-                    ;; parent the source state nests in, so a transition
-                    ;; declared on a compound substate's child sits inside
-                    ;; the compound container rather than leaking to the
+                    ;; the event-node nests inside the same parent the
+                    ;; source state nests in, so a transition declared on a
+                    ;; compound substate's child sits inside the compound
+                    ;; container rather than leaking to the
                     ;; root.
                     parent-id
                     (assoc :parentId parent-id
                            :extent   "parent"))))
               edge-descriptors)
-        ;; rf2-idx41 — the two halves of the events-as-nodes route
-        ;; (source-state → event-node, event-node → target-state) emit
-        ;; structurally-identical xyflow edges: same `:type`, the same
+        ;; the two halves of the events-as-nodes route (source-state →
+        ;; event-node, event-node → target-state) emit structurally-
+        ;; identical xyflow edges: same `:type`, the same
         ;; resting/active/fired marker COLOUR cond, and a `:data` payload
         ;; that differs only in its routed `:points` / `:labelPos`, the
         ;; quiet-vs-primary flag, and the `:inbound`/`:outbound` marker.
         ;; `events-as-nodes-edge` builds one half from those few
-        ;; differing values so the shared shape lives in ONE place (the
-        ;; two were copy-pasted before, drifting risk on every `:data`
-        ;; key add). `half` is `:in` (quiet source→event, quiet
-        ;; arrowhead) or `:out` (primary event→target, primary arrowhead).
-        ;; rf2-dt5b1 — the arrowhead COLOUR routes through the shared
+        ;; differing values so the shared shape lives in ONE place (rather
+        ;; than copy-pasted, with drift risk on every `:data` key add).
+        ;; `half` is `:in` (quiet source→event, quiet arrowhead) or `:out`
+        ;; (primary event→target, primary arrowhead).
+        ;; The arrowhead COLOUR routes through the shared
         ;; `tokens/edge-color` (the SAME helper `chart.edges/edge-stroke`
         ;; uses for the SVG path) so the head + stroke cannot disagree;
         ;; the arrowhead SIZE reads off the resolved density `chart` map
@@ -1875,19 +1811,19 @@
         (fn [half {:keys [edge ev-node-id from-active? focused? fired? blocked?
                           cross-hier?] :as desc} points label-pos]
           (let [in? (= half :in)
-                ;; rf2-4nxgqq — a guard-BLOCKED transition is a no-op: the
-                ;; guard declined, the machine STAYED in the source state,
-                ;; the target was NEVER reached. So the guard-blocked
-                ;; HIGHLIGHT must stop at the guard event-node — it covers
-                ;; the `__in` (source→event-node) half ONLY, never the
-                ;; `__out` (event-node→target) half. Lighting the onward
-                ;; arrow would falsely imply the transition progressed to
-                ;; the target. The STATIC `__out` topology edge still
-                ;; renders (the transition exists in the definition); only
-                ;; the live blocked-overlay is withheld from it. General to
-                ;; ALL guard-blocked transitions (each guarded-fork branch's
-                ;; own `__out` half independently drops the overlay). The
-                ;; event-node itself + the `__in` half stay PINK (unchanged).
+                ;; a guard-BLOCKED transition is a no-op: the guard
+                ;; declined, the machine STAYED in the source state, the
+                ;; target was NEVER reached. So the guard-blocked HIGHLIGHT
+                ;; must stop at the guard event-node — it covers the `__in`
+                ;; (source→event-node) half ONLY, never the `__out`
+                ;; (event-node→target) half. Lighting the onward arrow would
+                ;; falsely imply the transition progressed to the target. The
+                ;; STATIC `__out` topology edge still renders (the transition
+                ;; exists in the definition); only the live blocked-overlay
+                ;; is withheld from it. General to ALL guard-blocked
+                ;; transitions (each guarded-fork branch's own `__out` half
+                ;; independently drops the overlay). The event-node itself +
+                ;; the `__in` half stay PINK.
                 half-blocked? (and blocked? in?)
                 w   (if in?
                       (:arrow-width-quiet chart)
@@ -1896,15 +1832,15 @@
              :source    (if in? (:source edge) ev-node-id)
              :target    (if in? ev-node-id (:target edge))
              :type      "transition"
-             ;; rf2-az6e2 — the `__in` (source→event) half is the QUIET
-             ;; segment: a SMALLER `:arrow-width-quiet` head in the quiet
-             ;; colour so the PRIMARY `:arrow-width` head reads on the
-             ;; `__out` (event→target) half and the pair reads as ONE
-             ;; transition route. Both sizes ride the resolved density map
-             ;; (trimmed toward Stately's small/thin heads).
-             ;; rf2-4nxgqq — `half-blocked?` (not the raw `blocked?`) drives
-             ;; the arrowhead colour so the onward `__out` head is NOT pink
-             ;; for a guard-blocked no-op (the head + stroke agree per half).
+             ;; the `__in` (source→event) half is the QUIET segment: a
+             ;; SMALLER `:arrow-width-quiet` head in the quiet colour so the
+             ;; PRIMARY `:arrow-width` head reads on the `__out`
+             ;; (event→target) half and the pair reads as ONE transition
+             ;; route. Both sizes ride the resolved density map (trimmed
+             ;; toward Stately's small/thin heads).
+             ;; `half-blocked?` (not the raw `blocked?`) drives the arrowhead
+             ;; colour so the onward `__out` head is NOT pink for a guard-
+             ;; blocked no-op (the head + stroke agree per half).
              :markerEnd {:type   "arrowclosed"
                          :color  (marker-color (assoc desc :blocked? half-blocked?))
                          :width  w
@@ -1914,27 +1850,25 @@
                          :active     from-active?
                          :focused    focused?
                          :fired      fired?
-                         ;; rf2-fzrzlw + rf2-4nxgqq — guard-blocked no-op: the
-                         ;; PINK guard-blocked stroke (winning over
-                         ;; fired/focused/active) covers the `__in`
-                         ;; (source→event-node) half ONLY. The `__out`
-                         ;; (event-node→target) half stays resting — the
-                         ;; target was never reached, so the onward arrow must
-                         ;; NOT imply the transition progressed. `half-blocked?`
-                         ;; is `blocked?` AND `in?`.
+                         ;; guard-blocked no-op: the PINK guard-blocked
+                         ;; stroke (winning over fired/focused/active) covers
+                         ;; the `__in` (source→event-node) half ONLY. The
+                         ;; `__out` (event-node→target) half stays resting —
+                         ;; the target was never reached, so the onward arrow
+                         ;; must NOT imply the transition progressed.
+                         ;; `half-blocked?` is `blocked?` AND `in?`.
                          :guardBlocked half-blocked?
                          :afterMs    nil
                          :guard      nil
                          :action     nil
                          :crossHierarchy cross-hier?
-                         ;; rf2-r636q — the elk route for THIS half
-                         ;; (`__in`: source-state → event-node; `__out`:
-                         ;; event-node → target-state). nil when elk
-                         ;; emitted no route (bezier fallback).
+                         ;; the elk route for THIS half (`__in`: source-state
+                         ;; → event-node; `__out`: event-node → target-state).
+                         ;; nil when elk emitted no route (bezier fallback).
                          :points     points
-                         ;; rf2-rlq97 — elk's computed label position (nil
-                         ;; under events-as-nodes; renderer falls back to
-                         ;; its geometric anchor).
+                         ;; elk's computed label position (nil under events-
+                         ;; as-nodes; renderer falls back to its geometric
+                         ;; anchor).
                          :labelPos   label-pos
                          :internal   false
                          :machineLevel (boolean (:machine-level? edge))
@@ -1946,9 +1880,9 @@
                          :palette    ct
                          :inbound    in?
                          :outbound   (not in?)
-                         ;; rf2-az6e2 — the `__in` half paints thinner + in
-                         ;; the quiet colour so the pair reads as one
-                         ;; transition with the primary arrowhead on `__out`.
+                         ;; the `__in` half paints thinner + in the quiet
+                         ;; colour so the pair reads as one transition with
+                         ;; the primary arrowhead on `__out`.
                          :quietSegment in?
                          :eventNodeId ev-node-id
                          :spec-edge-id (:id edge)}}))
@@ -1991,25 +1925,25 @@
                                        :palette ct}
                            :draggable false
                            :selectable false}
-                    ;; rf2-xh1lm — see compound substate :parentId comment
-                    ;; above. xyflow v12 reads `parentId`, which gives the
-                    ;; marker the container's coordinate frame so it sits
-                    ;; just left of a NESTED initial inside its box.
+                    ;; see compound substate :parentId comment above. xyflow
+                    ;; v12 reads `parentId`, which gives the marker the
+                    ;; container's coordinate frame so it sits just left of a
+                    ;; NESTED initial inside its box.
                     ;;
-                    ;; rf2-d5s7yg — but NO `:extent "parent"` on the marker.
-                    ;; The marker is a decorative glyph that sits a few px to
-                    ;; the LEFT of (and slightly outside) the state; for a
-                    ;; nested initial near its container's left padding the
-                    ;; marker's `state.x - offset` position is legitimately
-                    ;; just outside the container content area. `:extent
-                    ;; "parent"` would CLAMP that position rightward (so the
-                    ;; node box stays inside the parent), shoving the whole
-                    ;; glyph — dot, hook AND arrow tip — INTO the state. That
-                    ;; clamp is the root cause of the nested-initial overshoot
-                    ;; (`red`/`walk` penetrated while top-level `door` did
-                    ;; not): only nested markers carry a parent to clamp
-                    ;; against. Dropping `:extent` lets the short hook end the
-                    ;; same clean gap outside the edge at every nesting level.
+                    ;; But NO `:extent "parent"` on the marker. The marker is
+                    ;; a decorative glyph that sits a few px to the LEFT of
+                    ;; (and slightly outside) the state; for a nested initial
+                    ;; near its container's left padding the marker's
+                    ;; `state.x - offset` position is legitimately just
+                    ;; outside the container content area. `:extent "parent"`
+                    ;; would CLAMP that position rightward (so the node box
+                    ;; stays inside the parent), shoving the whole glyph —
+                    ;; dot, hook AND arrow tip — INTO the state (only nested
+                    ;; markers carry a parent to clamp against, so a top-level
+                    ;; initial like `door` would be unaffected while nested
+                    ;; ones like `red`/`walk` overshoot). Dropping `:extent`
+                    ;; lets the short hook end the same clean gap outside the
+                    ;; edge at every nesting level.
                     (:parent-id n)
                     (assoc :parentId (:parent-id n)))))
               initial-nodes)
@@ -2043,44 +1977,43 @@
                  ;; so the "every edge has X" projection invariants hold.
                  :data        {:eventLabel "" :eventLineLabel "" :entry true
                                :active false :focused false :fired false
-                               ;; rf2-fzrzlw — the initial-marker entry edge
-                               ;; is never a guard-blocked transition; false
-                               ;; keeps the every-edge :data shape whole.
+                               ;; the initial-marker entry edge is never a
+                               ;; guard-blocked transition; false keeps the
+                               ;; every-edge :data shape whole.
                                :guardBlocked false
                                :afterMs nil
                                :guard nil :action nil
-                               ;; rf2-shv82 — entry edges are never cross-
-                               ;; hierarchy (a marker→leaf hop inside one
-                               ;; container); false keeps the every-edge
-                               ;; :data shape whole.
+                               ;; entry edges are never cross-hierarchy (a
+                               ;; marker→leaf hop inside one container); false
+                               ;; keeps the every-edge :data shape whole.
                                :crossHierarchy false
-                               ;; rf2-cz8v6 (G2) — entry edges keep the
-                               ;; bezier (a short marker→state hop never
-                               ;; crosses a container); :points nil so
-                               ;; the every-edge :data shape stays whole.
+                               ;; entry edges keep the bezier (G2; a short
+                               ;; marker→state hop never crosses a container);
+                               ;; :points nil so the every-edge :data shape
+                               ;; stays whole.
                                :points nil
-                               ;; rf2-rlq97 — entry edges carry no label
-                               ;; (unlabelled marker→state hop), so no elk
-                               ;; label position; nil keeps the shape whole.
+                               ;; entry edges carry no label (unlabelled
+                               ;; marker→state hop), so no elk label position;
+                               ;; nil keeps the shape whole.
                                :labelPos nil
                                :internal false :machineLevel false
                                :eventId nil :fromPath nil :toPath nil
                                :quietSegment false
                                :onClick on-edge-click :chart chart :palette ct}})
               initial-nodes)
-        ;; rf2-o3rkq1 — DECORATIVE dotted evaluation-order connector across
-        ;; the branches of a guarded multi-branch fork (gate's `:gate/check`
-        ;; 3-way), linking each branch's event-node to the next IN PRIORITY
-        ;; ORDER (1→2→3). RENDER-ONLY: emitted HERE, after the ELK layout
-        ;; pass, and NEVER fed to ELK (ELK's input edges come from
-        ;; `->elk-edges`, the parsed graph alone), so the connector cannot
-        ;; move a single node — it reinforces the first-pass-wins order the
-        ;; numbered badges already annotate (the Stately dotted order chain).
-        ;; Empty when no guarded fork exists.
+        ;; DECORATIVE dotted evaluation-order connector across the branches
+        ;; of a guarded multi-branch fork (gate's `:gate/check` 3-way),
+        ;; linking each branch's event-node to the next IN PRIORITY ORDER
+        ;; (1→2→3). RENDER-ONLY: emitted HERE, after the ELK layout pass, and
+        ;; NEVER fed to ELK (ELK's input edges come from `->elk-edges`, the
+        ;; parsed graph alone), so the connector cannot move a single node —
+        ;; it reinforces the first-pass-wins order the numbered badges
+        ;; already annotate (the Stately dotted order chain). Empty when no
+        ;; guarded fork exists.
         connector-edges (fork-connector-edges edges ct chart)]
-    ;; rf2-qo5xy — order matters for xyflow: parent containers must
-    ;; precede any node that references them via `:parentId`. State /
-    ;; region / compound nodes are already sorted parent-first; the
+    ;; order matters for xyflow: parent containers must precede any node
+    ;; that references them via `:parentId`. State / region / compound nodes
+    ;; are already sorted parent-first; the
     ;; event-nodes nest into the same parents (we set `:parent-id` to
     ;; the source state's parent), so appending them AFTER `proj-nodes`
     ;; keeps the parent-before-child invariant.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -1,6 +1,6 @@
 (ns day8.re-frame2-machines-viz.scxml
   "SCXML (W3C State Chart XML) import/export for re-frame2 machine
-  definitions (rf2-6urjd · v1.1).
+  definitions.
 
   SCXML is the W3C standard for statecharts. Round-tripping through
   SCXML lets re-frame2 machines be shared with non-CLJS tooling —
@@ -41,20 +41,20 @@
   | `:final? true`                        | `<final id=\"...\">` |
   | `:on {:event :target}`                | `<transition event=\"event\" target=\"target\"/>` |
   | `:on {:event {:target ... :guard G}}` | `<transition cond=\"G\" .../>` |
-  | `:on {:event {:action A}}` — INTERNAL (no `:target`) | `<transition event=\"event\"><!-- action: A --></transition>` — round-trips to `{:action A}`, NOT the `{}` forbidden block (rf2-mnp93.5) |
-  | Self-target (`:target :same-state`, or a keyword naming the state's OWN key) (rf2-0pp6as) | `<transition … target=\"<source-id>\" type=\"internal\"/>` — references the SOURCE state's REAL declared id (NEVER the dangling `same_2dstate` phantom); `type=\"internal\"` is the explicit XState-v5 internal default. Round-trips to the canonical `:same-state`. |
-  | `:reenter? true` (any target) (rf2-9dj21r) | `type=\"external\"` — the EXTERNAL restart axis (re-run `:exit`+`:entry`). A target-bearing transition WITHOUT `:reenter?` carries `type=\"internal\"`. |
+  | `:on {:event {:action A}}` — INTERNAL (no `:target`) | `<transition event=\"event\"><!-- action: A --></transition>` — round-trips to `{:action A}`, NOT the `{}` forbidden block |
+  | Self-target (`:target :same-state`, or a keyword naming the state's OWN key) | `<transition … target=\"<source-id>\" type=\"internal\"/>` — references the SOURCE state's REAL declared id; `type=\"internal\"` is the explicit XState-v5 internal default. Round-trips to the canonical `:same-state`. |
+  | `:reenter? true` (any target) | `type=\"external\"` — the EXTERNAL restart axis (re-run `:exit`+`:entry`). A target-bearing transition WITHOUT `:reenter?` carries `type=\"internal\"`. |
   | `:after {ms :target}`                 | `<transition event=\"after.ms\" target=\"target\"/>` |
   | `:always [...]`                       | `<transition target=\"...\"/>` (eventless) |
   | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
-  | Parallel-ROOT `:on` / `:after` (the ancestor fallback — rf2-656ivk / rf2-m3otj2) | `<transition event=\"event\"\\|\"after.ms\" target=\"a___x b___y\"/>` as a DIRECT `<parallel>` child. A MULTI-region target is a SPACE-SEPARATED id list (W3C `target` grammar); a targetless / action-only root transition emits NO `target`. Round-trips back to the region-qualified grammar (`[:a :x]` / `[[:a :x] [:b :y]]`). |
-  | `{:type :history :deep? <b> :default-target <t>}` (rf2-m285a) | W3C `<history type=\"shallow\\|deep\">` inside the owning compound; a `:default-target` rides a default `<transition target=\"…\"/>`. Round-trips back to `:type :history`. A history pseudo-state is NEVER occupiable — it is a transition TARGET that resolves to the recorded/default leaf — so it emits `<history>`, never `<state>`/`<final>`. |
+  | Parallel-ROOT `:on` / `:after` (the ancestor fallback) | `<transition event=\"event\"\\|\"after.ms\" target=\"a___x b___y\"/>` as a DIRECT `<parallel>` child. A MULTI-region target is a SPACE-SEPARATED id list (W3C `target` grammar); a targetless / action-only root transition emits NO `target`. Round-trips back to the region-qualified grammar (`[:a :x]` / `[[:a :x] [:b :y]]`). |
+  | `{:type :history :deep? <b> :default-target <t>}` | W3C `<history type=\"shallow\\|deep\">` inside the owning compound; a `:default-target` rides a default `<transition target=\"…\"/>`. Round-trips back to `:type :history`. A history pseudo-state is NEVER occupiable — it is a transition TARGET that resolves to the recorded/default leaf — so it emits `<history>`, never `<state>`/`<final>`. |
   | Namespaced ids (`:auth/login`)        | `auth__login` (hex-escaped; `__` separates ns/name) |
   | Multi-dot-ns ids (`:my.app/login`)    | `my_2eapp__login` (dots in the ns are escaped to `_2e`) |
   | Vector-path targets (`[:parent :child]`) | `parent___child` (`___` joins path segments) |
   | Nested-state ids                      | FULLY QUALIFIED (root→leaf, `___`-joined) — unique xsd:ID |
 
-  ## Id codec — injective, xsd:ID-conformant (rf2-mnp93.1/.7)
+  ## Id codec — injective, xsd:ID-conformant
 
   SCXML state ids are `xsd:ID` (XML NCName): letters / digits / `-` `.`
   `_`, NO `:`. The codec hex-escapes every keyword ns/name char to
@@ -64,36 +64,35 @@
 
   - ANY keyword round-trips EXACTLY, regardless of how many dots its
     namespace or name has (`:my.app.auth/login` ≠ `:my/app.auth.login`
-    now produce DISTINCT ids — the pre-mnp93.1 `.`-as-ns/name scheme
-    collided them; csq75's `:`-as-path was not a valid xsd:ID char).
+    produce DISTINCT ids).
   - State ids are FULLY QUALIFIED with their nesting path, so two
     same-named nested states emit UNIQUE xsd:IDs and transition targets
-    reference those same unique ids (rf2-mnp93.7 — conformant for
-    external SCXML tooling).
-  - User events named `after.*` / `done.state.*` no longer collide with
+    reference those same unique ids — conformant for external SCXML
+    tooling.
+  - User events named `after.*` / `done.state.*` do not collide with
     the synthetic timer / `:on-done` encodings: those carry a LITERAL
-    `.` the codec never emits for a real keyword (rf2-mnp93.3).
+    `.` the codec never emits for a real keyword.
 
   ## Not supported (lossy or omitted)
 
   - `:spawn-all` rows — omitted; the parent state renders without
     spawn affordances.
   - INTERNAL-default self / proper-ancestor SELF-TRANSITION semantics
-    (rf2-0pp6as) — re-frame2 / XState v5 make a targeted transition
-    INTERNAL by default (the targeted state's OWN `:exit` / `:entry` do
-    NOT re-run); W3C SCXML's `type=\"internal\"` only changes the
-    transition domain for a COMPOUND source whose target is a PROPER
-    DESCENDANT (the one case where the export IS the exact equivalent).
-    For a self-target (source == target) or a proper-ancestor target,
-    SCXML ALWAYS re-enters the source regardless of `type`, so the
-    re-frame2 internal default has no exact SCXML equivalent. The export
-    emits `type=\"internal\"` to record the intended axis and references
-    the source state's REAL declared id (never the pre-fix dangling
-    `same_2dstate` phantom), and the local `scxml->spec` round-trips the
-    `:same-state` sentinel exactly — but a STRICT external SCXML engine
-    executing the imported chart will re-run the source's exit/entry on
-    the self-target where re-frame2 would not. This is the irreducible
-    loss; it is documented here rather than papered over.
+    — re-frame2 / XState v5 make a targeted transition INTERNAL by
+    default (the targeted state's OWN `:exit` / `:entry` do NOT re-run);
+    W3C SCXML's `type=\"internal\"` only changes the transition domain
+    for a COMPOUND source whose target is a PROPER DESCENDANT (the one
+    case where the export IS the exact equivalent). For a self-target
+    (source == target) or a proper-ancestor target, SCXML ALWAYS
+    re-enters the source regardless of `type`, so the re-frame2 internal
+    default has no exact SCXML equivalent. The export emits
+    `type=\"internal\"` to record the intended axis and references the
+    source state's REAL declared id, and the local `scxml->spec`
+    round-trips the `:same-state` sentinel exactly — but a STRICT
+    external SCXML engine executing the imported chart will re-run the
+    source's exit/entry on the self-target where re-frame2 would not.
+    This is the irreducible loss; it is documented here rather than
+    papered over.
   - Machine-level (top-level) `:on` fallback transitions — W3C SCXML
     has no clean root-fallback slot (`<scxml>` does not host
     `<transition>` children per the schema, and the import side drops
@@ -104,23 +103,23 @@
     `cond=\"name\"` for guards; a transition `:action` name rides an
     `<!-- action: name -->` comment, the only SCXML-tolerable slot, since
     SCXML proper has no transition-action-id attribute). An INLINE-FN
-    `:guard` / `:action` (the Spec 005 escape hatch) is LOSSY-not-crash
-    (rf2-m285a): `ref->label` surfaces the fn's `:name` meta or a stable
-    `\"fn\"` fallback (consistent with chart/Mermaid; matches the API
-    promise that fn bodies are lossy, not unsupported) — it does NOT
-    round-trip back to the original fn. The action name
-    **round-trips** (rf2-mnp93.5): `scxml->spec` lifts the action comment
-    back into the candidate's `:action` BEFORE comments are stripped, so an
-    internal `:on {:tick {:action :log}}` returns `{:action :log}` — a valid
-    Spec-005 internal action transition — NOT the empty `{}` FORBIDDEN BLOCK
-    a naive comment-strip would synthesise (a semantic inversion). FN
-    BODIES are still lost (only the name survives). Entry/exit actions would
-    require an evaluation context, so their names are preserved as XML
-    comments but are not part of this round-trip.
+    `:guard` / `:action` (the Spec 005 escape hatch) is LOSSY-not-crash:
+    `ref->label` surfaces the fn's `:name` meta or a stable `\"fn\"`
+    fallback (consistent with chart/Mermaid; matches the API promise that
+    fn bodies are lossy, not unsupported) — it does NOT round-trip back to
+    the original fn. The action name **round-trips**: `scxml->spec` lifts
+    the action comment back into the candidate's `:action` BEFORE comments
+    are stripped, so an internal `:on {:tick {:action :log}}` returns
+    `{:action :log}` — a valid Spec-005 internal action transition — NOT
+    the empty `{}` FORBIDDEN BLOCK a naive comment-strip would synthesise
+    (a semantic inversion). FN BODIES are still lost (only the name
+    survives). Entry/exit actions would require an evaluation context, so
+    their names are preserved as XML comments but are not part of this
+    round-trip.
   - Source-coord metadata — stripped at export time (same posture as
     share-URL encoding; see `Principles.md` §No session data in shares).
   - Consumer-attachment `:rf.cofx/requires` (EP-0017 — the replay-critical
-    host facts a named guard / action / entry / exit consumes; rf2-skhlw2.1):
+    host facts a named guard / action / entry / exit consumes):
     INTENTIONALLY OMITTED. W3C SCXML has no native attribute for re-frame2
     coeffect requirements, and the requirements ride the `:guards` /
     `:actions` named-entry registry, which SCXML does not carry (only the
@@ -140,20 +139,20 @@
   Per [`API.md`](../../spec/API.md) §SCXML import/export."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
-            ;; rf2-b2ygd2 — the SHARED grammar walker + injective id codec
-            ;; the three emitters route through, so they address every node
-            ;; identically (one escape codec, one source of truth). The SCXML
-            ;; DECODE side (unescape / decode-target) + the root-grammar-aware
+            ;; The SHARED grammar walker + injective id codec the three
+            ;; emitters route through, so they address every node identically
+            ;; (one escape codec, one source of truth). The SCXML DECODE side
+            ;; (unescape / decode-target) + the root-grammar-aware
             ;; `root-transition-candidates` stay LOCAL — they are genuinely
             ;; distinct from the shared emit-side walker.
             [day8.re-frame2-machines-viz.grammar :as g]
-            ;; rf2-bs3us — share the canonical parallel-root done-state id
-            ;; with the chart projector so the two emitters agree on the
-            ;; `done.state.<id>` label (single source of truth).
+            ;; Share the canonical parallel-root done-state id with the chart
+            ;; projector so the two emitters agree on the `done.state.<id>`
+            ;; label (single source of truth).
             [day8.re-frame2-machines-viz.chart.layout :as layout]))
 
 ;; ---------------------------------------------------------------------------
-;; Value-free error diagnostics (rf2-8nzxib)
+;; Value-free error diagnostics
 ;;
 ;; EP-0015 / Spec 015 §exception-path residual — a thrown error must NOT
 ;; carry the raw rejected payload. A machine spec can carry a `:data`
@@ -182,26 +181,24 @@
     {:type (cond (nil? input) :nil (map? input) :map :else :value)}))
 
 ;; ---------------------------------------------------------------------------
-;; Id codec — FULLY INJECTIVE, xsd:ID-conformant (rf2-mnp93.1)
+;; Id codec — FULLY INJECTIVE, xsd:ID-conformant
 ;;
 ;; Re-frame2 ids are keywords (`:idle`, `:auth/login-flow`,
 ;; `:my.app.auth/login`) or vector paths (`[:authenticated :browsing]`).
 ;; SCXML state ids are `xsd:ID` (XML NCName): the leading char must be a
 ;; letter / `_`, subsequent chars letters / digits / `-` `.` `_`. A `:`
-;; is NOT a valid NCName char — so the pre-mnp93.1 `:`-as-path-separator
-;; scheme (rf2-csq75) emitted non-conformant ids that strict external
-;; SCXML consumers reject (rf2-mnp93.7), and the `.`-as-ns/name scheme
-;; was NON-INJECTIVE: a keyword namespace may itself contain dots
-;; (`:my.app.auth/login` → `"my.app.auth.login"`), so the decoder could
-;; not recover where the namespace ended (rf2-mnp93.1).
+;; is NOT a valid NCName char, and a `.`-as-ns/name scheme would be
+;; NON-INJECTIVE: a keyword namespace may itself contain dots
+;; (`:my.app.auth/login` → `"my.app.auth.login"`), so a decoder could not
+;; recover where the namespace ended.
 ;;
-;; FIX — hex-escape codec (the same injective scheme `chart/layout`'s
-;; `node-id` uses for xyflow ids). EVERY non-alphanumeric char in a
-;; segment is escaped to `_<2-hex>` (so a literal `_` → `_5f`, `.` →
-;; `_2e`, `?` → `_3f`). After escaping, an `_` appears ONLY as the lead
-;; of a `_XX` hex triple — never two underscores in a row — so we can use
-;; consecutive-underscore RESERVED MARKERS the escaper can provably never
-;; emit:
+;; The hex-escape codec (the same injective scheme `chart/layout`'s
+;; `node-id` uses for xyflow ids) handles this. EVERY non-alphanumeric
+;; char in a segment is escaped to `_<2-hex>` (so a literal `_` → `_5f`,
+;; `.` → `_2e`, `?` → `_3f`). After escaping, an `_` appears ONLY as the
+;; lead of a `_XX` hex triple — never two underscores in a row — so we can
+;; use consecutive-underscore RESERVED MARKERS the escaper can provably
+;; never emit:
 ;;
 ;; - `__`  (DOUBLE underscore) joins a keyword's NAMESPACE and NAME:
 ;;   `:auth/login`         → `"auth__login"`
@@ -220,28 +217,24 @@
 ;; the codec is fully injective and every emitted id is a valid xsd:ID.
 
 (def ^:private ns-name-sep
-  "rf2-mnp93.1 — the keyword NAMESPACE↔NAME boundary in an SCXML id. `__`
-  (double underscore) is impossible for `escape-id-segment` to emit (it
-  only ever emits `_` + 2 hex digits), so it is the injective ns/name
-  marker. Supersedes csq75's `.`-as-ns/name (non-injective for multi-dot
-  namespaces)."
+  "The keyword NAMESPACE↔NAME boundary in an SCXML id. `__` (double
+  underscore) is impossible for `escape-id-segment` to emit (it only ever
+  emits `_` + 2 hex digits), so it is the injective ns/name marker."
   "__")
 
 (def ^:private path-segment-sep
-  "rf2-mnp93.1 — the vector-PATH segment boundary in an SCXML id. `___`
-  (triple underscore) the escaper can never emit and is distinct from the
-  `__` ns/name marker, so a vector path can never collide with a single
-  namespaced keyword. Supersedes csq75's `:` (not a valid xsd:ID char —
-  rf2-mnp93.7)."
+  "The vector-PATH segment boundary in an SCXML id. `___` (triple
+  underscore) the escaper can never emit and is distinct from the `__`
+  ns/name marker, so a vector path can never collide with a single
+  namespaced keyword. A valid xsd:ID."
   "___")
 
-;; rf2-b2ygd2 — the xsd:ID-safe injective escape is the SHARED
-;; `grammar/escape-id-segment` (every char outside `[A-Za-z0-9]` → `_<2-hex>`,
-;; the underscore itself → `_5f`; no two consecutive underscores, so the
-;; `__` / `___` reserved markers can never arise from segment content). The
-;; SINGLE injective scheme across all machines-viz id emitters, so the SCXML
-;; codec mints byte-identical segment escapes to the chart `node-id` + mermaid
-;; `sanitise-id`.
+;; The xsd:ID-safe injective escape is the SHARED `grammar/escape-id-segment`
+;; (every char outside `[A-Za-z0-9]` → `_<2-hex>`, the underscore itself →
+;; `_5f`; no two consecutive underscores, so the `__` / `___` reserved markers
+;; can never arise from segment content). The SINGLE injective scheme across
+;; all machines-viz id emitters, so the SCXML codec mints byte-identical
+;; segment escapes to the chart `node-id` + mermaid `sanitise-id`.
 (def ^:private escape-id-segment g/escape-id-segment)
 
 (defn- unescape-id-segment
@@ -258,26 +251,22 @@
   "Map a single keyword to its injective, xsd:ID-conformant SCXML id
   string. Namespace and name are each `escape-id-segment`-escaped and
   joined with `__` (`ns-name-sep`); a bare keyword emits just its escaped
-  name. rf2-mnp93.1 — exact round-trip for ANY keyword (multi-dot ns,
-  dotted name, `?`/`-`/`_` in either)."
+  name. Exact round-trip for ANY keyword (multi-dot ns, dotted name,
+  `?`/`-`/`_` in either)."
   [k]
   (if-let [ns (namespace k)]
     (str (escape-id-segment ns) ns-name-sep (escape-id-segment (name k)))
     (escape-id-segment (name k))))
 
 (defn- ref->label
-  "rf2-m285a — render a transition `:guard` / `:action` REF as an SCXML
-  attribute label, tolerating inline fns the SAME way `chart/layout` +
-  `mermaid` already do.
+  "Render a transition `:guard` / `:action` REF as an SCXML attribute
+  label, tolerating inline fns the SAME way `chart/layout` + `mermaid` do.
 
   A keyword ref keeps the injective, round-tripping `keyword->id-string`
   codec (the supported subset). An INLINE FN ref is LOSSY by design — the
   machine grammar permits `:guard (fn …)` / `:action (fn …)` (Spec 005
   §Guards / §Actions), and the API promise is that fn BODIES are
-  lossy/opaque, NOT unsupported. Pre-fix, `spec->scxml` passed the fn
-  straight to `keyword->id-string`, which calls `(namespace f)` on it and
-  throws a `ClassCastException` — crashing SCXML export for a valid
-  machine. We instead surface the fn's `:name` meta (a named
+  lossy/opaque, NOT unsupported. We surface the fn's `:name` meta (a named
   `(fn name […] …)` / `defn`) or a stable `\"fn\"` fallback, mirroring
   `chart/layout/name-of`. No attempt is made to serialise the executable
   body."
@@ -293,7 +282,7 @@
   string. A keyword uses `keyword->id-string`; a vector path joins its
   per-segment id strings with `___` (`path-segment-sep`). The `__`
   ns/name and `___` path markers never collide with each other or with
-  segment content (rf2-mnp93.1), so the codec is fully injective."
+  segment content, so the codec is fully injective."
   [id]
   (cond
     (keyword? id) (keyword->id-string id)
@@ -306,8 +295,8 @@
   path separator). Splits on the `__` ns/name marker (at most once),
   `_XX`-unescaping each part: `\"auth__login\"` → `:auth/login`,
   `\"my_2eapp_2eauth__login\"` → `:my.app.auth/login`, bare
-  `\"name\"` → `:name`. rf2-mnp93.1 / rf2-mnp93.2 — the symmetric inverse
-  used by BOTH the id decoder and the guard `cond=` decoder."
+  `\"name\"` → `:name`. The symmetric inverse used by BOTH the id decoder
+  and the guard `cond=` decoder."
   [s]
   (when s
     (let [idx (str/index-of s ns-name-sep)]
@@ -333,7 +322,7 @@
   [depth]
   (apply str (repeat depth "  ")))
 
-;; rf2-b2ygd2 — the generic per-state transition-spec walker is the SHARED
+;; The generic per-state transition-spec walker is the SHARED
 ;; `grammar/transition-candidates` (chart + mermaid share it). NOTE the
 ;; parallel-ROOT SCXML emitter uses its OWN `root-transition-candidates`
 ;; (below) instead — there a vector-of-VECTORS is a SINGLE multi-region
@@ -341,25 +330,24 @@
 ;; walker. That divergence is PRESERVED.
 (def ^:private transition-candidates g/transition-candidates)
 
-;; --- path qualification (rf2-mnp93.7) ------------------------------------
+;; --- path qualification --------------------------------------------------
 ;;
 ;; W3C SCXML state ids are `xsd:ID` — they MUST be unique across the whole
-;; document. The pre-mnp93.7 emitter wrote BARE local-state names, so two
-;; states sharing a name under different compound parents collided
-;; (duplicate `<state id="idle">`) — invalid SCXML a conformant external
-;; consumer rejects. We now emit the FULLY-QUALIFIED path id (root → leaf,
-;; `___`-joined via `path->id-string`) for every state, `initial`, and
-;; transition `target`, so every id is unique. The decoder reverses the
-;; qualification: a state block's local `:states` key is the LAST segment
-;; of its qualified id, and a target resolves back to the relative form
-;; (a sibling keyword when it shares the source's parent, else the
-;; absolute vector path) so the round-trip is exact.
+;; document. Two states sharing a name under different compound parents
+;; would collide on a bare local-state name (duplicate `<state id="idle">`)
+;; — invalid SCXML a conformant external consumer rejects. We emit the
+;; FULLY-QUALIFIED path id (root → leaf, `___`-joined via `path->id-string`)
+;; for every state, `initial`, and transition `target`, so every id is
+;; unique. The decoder reverses the qualification: a state block's local
+;; `:states` key is the LAST segment of its qualified id, and a target
+;; resolves back to the relative form (a sibling keyword when it shares the
+;; source's parent, else the absolute vector path) so the round-trip is
+;; exact.
 
-;; rf2-b2ygd2 — grammar primitives aliased from the SHARED `grammar` ns. W3C
-;; SCXML emits a first-class `<history>` element for a `:type :history`
-;; pseudo-state (Spec 005 §History states); pre-fix `emit-state` emitted a
-;; `<state>` / `<final>`, losing the history semantics + making round-trip
-;; produce a DIFFERENT machine.
+;; Grammar primitives aliased from the SHARED `grammar` ns. W3C SCXML emits
+;; a first-class `<history>` element for a `:type :history` pseudo-state
+;; (Spec 005 §History states), so `emit-state` routes a history child to
+;; `<history>` rather than `<state>` / `<final>` to keep round-trip exact.
 (def ^:private target-path? g/target-path?)
 (def ^:private history-node? g/history-node?)
 (def ^:private parent-path g/parent-path)
@@ -373,17 +361,11 @@
     (`re-frame.machines.transition/target-path`) and the chart / Mermaid
     projectors (`chart.layout/resolve-target-path`,
     `mermaid/resolve-target-path`), which ALL special-case `:same-state`
-    to the declaring state's own path. rf2-0pp6as — pre-fix the SCXML
-    resolver had NO `:same-state` arm, so the sentinel fell through to the
-    keyword branch and produced the ABSOLUTE path `[:same-state]` — a
-    DANGLING `target=\"same_2dstate\"` referencing a state the document
-    never declares. The local `scxml->spec` decoded that phantom id back
-    to `:same-state`, so the round-trip oracle false-greened over invalid
-    W3C SCXML. Resolving to `source-path` emits the SOURCE state's real
-    unique id, exactly as a sibling-keyword self-target (`:target :a` on
-    state `:a`) already did — the two are the SAME self-transition per
-    Spec 005, and SCXML has no self-sentinel, only a target referencing
-    the state's own id.
+    to the declaring state's own path. Resolving to `source-path` emits
+    the SOURCE state's real unique id, exactly as a sibling-keyword
+    self-target (`:target :a` on state `:a`) does — the two are the SAME
+    self-transition per Spec 005, and SCXML has no self-sentinel, only a
+    target referencing the state's own id.
   - a keyword target is a SIBLING of the source state (Spec 005).
   - a vector-path target is absolute."
   [source-path target]
@@ -394,27 +376,26 @@
     :else                  nil))
 
 (defn- qualified-id
-  "The unique xsd:ID for a state at absolute `path` (rf2-mnp93.7)."
+  "The unique xsd:ID for a state at absolute `path`."
   [path]
   (path->id-string (vec path)))
 
 (defn- emit-transition
   "Emit a `<transition>` line for one candidate. `source-path` is the
   absolute path of the OWNING state; targets are path-qualified against
-  it so the emitted `target` is the unique xsd:ID of the destination
-  (rf2-mnp93.7).
+  it so the emitted `target` is the unique xsd:ID of the destination.
 
-  rf2-9dj21r / rf2-0pp6as — the re-frame2 `:reenter? true` axis (Spec 005
-  §Self-transitions / XState v5: a TARGETED transition is INTERNAL by
-  default; `:reenter?` opts into the EXTERNAL restart) maps onto W3C
-  SCXML's `<transition type=\"internal|external\">`, which is the SAME
-  external-vs-internal axis. Spec 005 §Self-transitions L332 records the
-  inversion: SCXML's targeted-transition DEFAULT is `external`
-  (`type=\"internal\"` opts out); XState v5 / re-frame2 FLIPPED it
-  (internal default, `:reenter?` opts IN). So a target-bearing re-frame2
-  transition must be EXPLICIT about the type — leaving it absent would let
-  the export silently inherit SCXML's EXTERNAL default and mis-state the
-  re-frame2 internal-default intent (the rf2-0pp6as drift). We therefore:
+  The re-frame2 `:reenter? true` axis (Spec 005 §Self-transitions /
+  XState v5: a TARGETED transition is INTERNAL by default; `:reenter?`
+  opts into the EXTERNAL restart) maps onto W3C SCXML's `<transition
+  type=\"internal|external\">`, which is the SAME external-vs-internal
+  axis. Spec 005 §Self-transitions L332 records the inversion: SCXML's
+  targeted-transition DEFAULT is `external` (`type=\"internal\"` opts
+  out); XState v5 / re-frame2 use the opposite convention (internal
+  default, `:reenter?` opts IN). So a target-bearing re-frame2 transition
+  must be EXPLICIT about the type — leaving it absent would let the export
+  silently inherit SCXML's EXTERNAL default and mis-state the re-frame2
+  internal-default intent. We therefore:
 
   - emit `type=\"external\"` for a target-bearing `:reenter? true`
     candidate (the external restart — re-run exit/entry); and
@@ -443,22 +424,22 @@
         parts (cond-> []
                 event-name (conj (str "event=\"" (escape-xml-attr event-name) "\""))
                 target-id  (conj (str "target=\"" (escape-xml-attr target-id) "\""))
-                ;; rf2-9dj21r — the external-restart axis. Emitted ONLY for a
+                ;; The external-restart axis. Emitted ONLY for a
                 ;; target-bearing `:reenter? true` candidate (a targetless
                 ;; transition has no state to re-enter; SCXML's `external` is
                 ;; meaningless without a target).
                 (and target reenter?)
                 (conj "type=\"external\"")
-                ;; rf2-0pp6as — the internal default is EXPLICIT. A
-                ;; target-bearing transition WITHOUT `:reenter?` emits
-                ;; `type=\"internal\"` so the export does NOT inherit SCXML's
-                ;; EXTERNAL targeted-transition default (which would mis-state
-                ;; the re-frame2 / XState-v5 internal default — see docstring).
+                ;; The internal default is EXPLICIT. A target-bearing
+                ;; transition WITHOUT `:reenter?` emits `type=\"internal\"` so
+                ;; the export does NOT inherit SCXML's EXTERNAL
+                ;; targeted-transition default (which would mis-state the
+                ;; re-frame2 / XState-v5 internal default — see docstring).
                 (and target (not reenter?))
                 (conj "type=\"internal\"")
-                ;; rf2-m285a — `ref->label` tolerates an inline-fn guard
-                ;; (lossy name/`fn` label) instead of crashing in
-                ;; `keyword->id-string` on a non-keyword.
+                ;; `ref->label` tolerates an inline-fn guard (lossy name/`fn`
+                ;; label) rather than calling `keyword->id-string` on a
+                ;; non-keyword.
                 guard      (conj (str "cond=\"" (escape-xml-attr (ref->label guard)) "\"")))
         attrs (str/join " " parts)
         self-close? (nil? action)]
@@ -466,7 +447,7 @@
          (if self-close?
            (str "<transition " attrs "/>")
            (str "<transition " attrs ">"
-                ;; rf2-m285a — likewise tolerate an inline-fn action.
+                ;; Likewise tolerate an inline-fn action.
                 "<!-- action: " (escape-xml-attr (ref->label action)) " -->"
                 "</transition>")))))
 
@@ -493,24 +474,24 @@
        (map #(emit-transition nil % source-path depth))))
 
 (defn- emit-transitions-for-on-done
-  "rf2-41goo — emit the compound / parallel `:on-done` (XState `onDone`)
-  as W3C SCXML's `<transition event=\"done.state.<id>\" .../>`, placed
-  inside the done node's own `<state>` element (SCXML §3.7: reaching a
-  `<final>` child generates `done.state.<id>` into the internal queue; an
-  enclosing transition takes it). `done-event` is the precomputed
+  "Emit the compound / parallel `:on-done` (XState `onDone`) as W3C
+  SCXML's `<transition event=\"done.state.<id>\" .../>`, placed inside
+  the done node's own `<state>` element (SCXML §3.7: reaching a `<final>`
+  child generates `done.state.<id>` into the internal queue; an enclosing
+  transition takes it). `done-event` is the precomputed
   `\"done.state.<id-str>\"` for THIS node. A target-less candidate
   (action/fx-only — the parallel-root shape) emits a transition with NO
   `target` (the action survives as the emitter's `<!-- action -->`
   comment), faithful to the action-only completion the engine fires.
-  `source-path` qualifies any target (rf2-mnp93.7)."
+  `source-path` qualifies any target."
   [done-event on-done source-path depth]
   (->> (transition-candidates on-done)
        (map #(emit-transition done-event % source-path depth))))
 
 (defn- emit-history
-  "rf2-m285a — emit a W3C SCXML `<history>` pseudo-state element for a
-  re-frame2 `:type :history` node (Spec 005 §History states). `path` is
-  the history node's absolute path (its unique xsd:ID).
+  "Emit a W3C SCXML `<history>` pseudo-state element for a re-frame2
+  `:type :history` node (Spec 005 §History states). `path` is the history
+  node's absolute path (its unique xsd:ID).
 
   W3C SCXML §3.10: `<history type=\"shallow|deep\">` carries an OPTIONAL
   default `<transition target=\"…\"/>` used when the parent has no stored
@@ -520,8 +501,7 @@
   `type=\"shallow\"`. The `:default-target` resolves relative to the
   history node's own level (a keyword target is a sibling — i.e. a direct
   child of the owning compound — per Spec 005), path-qualified to the
-  destination's unique id (rf2-mnp93.7), and round-trips back via
-  `decode-target`."
+  destination's unique id, and round-trips back via `decode-target`."
   [path {:keys [deep? default-target]} depth]
   (let [id-str    (qualified-id path)
         type-str  (if deep? "deep" "shallow")
@@ -552,10 +532,10 @@
 (defn- emit-state
   "Emit a `<state>` (or `<final>`) block for one state-node. `path` is
   the absolute path (root → this state) used to emit unique xsd:IDs and
-  to qualify transition targets (rf2-mnp93.7).
+  to qualify transition targets.
 
-  rf2-m285a — a `:type :history` child of this state is emitted as a W3C
-  `<history>` element (`emit-history`), NOT a nested `<state>`.
+  A `:type :history` child of this state is emitted as a W3C `<history>`
+  element (`emit-history`), NOT a nested `<state>`.
 
   EP-0011 — a `:final? true :error? true` leaf is an ERROR terminal; its
   `<final>` carries the `data_rf_error_final=\"true\"` carrier so the
@@ -567,8 +547,8 @@
         tag    (if final? "final" "state")
         attrs  (cond-> (str "id=\"" (escape-xml-attr id-str) "\"")
                  (and (not final?) initial)
-                 ;; rf2-mnp93.7 — `initial` references a CHILD by its
-                 ;; unique qualified id (the child's absolute path).
+                 ;; `initial` references a CHILD by its unique qualified id
+                 ;; (the child's absolute path).
                  (str " initial=\"" (escape-xml-attr (qualified-id (conj (vec path) initial))) "\"")
                  ;; EP-0011 — a `:final? true :error? true` leaf is an ERROR
                  ;; terminal: it lowers to the uniform reply envelope as
@@ -588,14 +568,14 @@
           (emit-transitions-for-on on path (inc depth))
           (emit-transitions-for-after after path (inc depth))
           (emit-transitions-for-always always path (inc depth))
-          ;; rf2-41goo — the `done.state.<this-id>` completion transition
-          ;; (XState `onDone`). Emitted INSIDE this node's own <state>.
+          ;; The `done.state.<this-id>` completion transition (XState
+          ;; `onDone`). Emitted INSIDE this node's own <state>.
           (when on-done
             (emit-transitions-for-on-done (str "done.state." id-str)
                                           on-done path (inc depth)))
           (mapcat (fn [[child-id child-node]]
-                    ;; rf2-m285a — a `:type :history` child is a W3C
-                    ;; `<history>` pseudo-state, not a nested `<state>`.
+                    ;; A `:type :history` child is a W3C `<history>`
+                    ;; pseudo-state, not a nested `<state>`.
                     (if (history-node? child-node)
                       (emit-history (conj (vec path) child-id) child-node (inc depth))
                       (emit-state (conj (vec path) child-id) child-node (inc depth))))

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -39,7 +39,7 @@
 (def ^:private int-string-re
   "Strict integer-string grammar: optional sign + one-or-more digits,
   nothing else. Trailing garbage (`\"12abc\"`) is rejected so the
-  string arm parses byte-identically across hosts (rf2-ee38b.19) —
+  string arm parses byte-identically across hosts —
   `Long/parseLong` (JVM) already rejects trailing garbage; raw
   `js/parseInt` (CLJS) parses a numeric PREFIX (`\"12abc\"` ⇒ 12),
   which would diverge from the JVM default-fallback. Guarding both
@@ -47,16 +47,16 @@
   #"[-+]?\d+")
 
 ;; ---------------------------------------------------------------------------
-;; Cross-runtime finite/range guard (rf2-ykv9a0).
+;; Cross-runtime finite/range guard.
 ;;
 ;; `(long raw)` is UNSAFE on out-of-domain numerics: on the JVM `##Inf`,
 ;; `##NaN`, and finite values past the long range (`1.0E20`) THROW
 ;; `IllegalArgumentException`, while `##NaN` quietly truncates to `0` — a
-;; real, non-sentinel cap that locks the agent out. The string arm
-;; diverged too: a digit string above the JS safe-integer ceiling parsed
-;; on the JVM (`Long/parseLong "9007199254740992"`) but defaulted on
-;; CLJS (`Number.isSafeInteger` rejects it), so the SAME wire arg behaved
-;; differently per host.
+;; real, non-sentinel cap that locks the agent out. The string arm has
+;; the same hazard: a digit string above the JS safe-integer ceiling
+;; parses on the JVM (`Long/parseLong "9007199254740992"`) but defaults
+;; on CLJS (`Number.isSafeInteger` rejects it), so without a shared guard
+;; the SAME wire arg would behave differently per host.
 ;;
 ;; The cross-runtime-safe domain is the JS safe-integer range
 ;; (`±(2^53 − 1)`). It is the strictest of the two hosts (a JVM long is
@@ -80,7 +80,7 @@
   "Coerce a number to a `long` IFF it is finite and within the JS
   safe-integer window `[-(2^53−1), 2^53−1]`; otherwise return `nil`.
 
-  This is the cross-runtime arg-boundary guard (rf2-ykv9a0). It must be
+  This is the cross-runtime arg-boundary guard. It must be
   called BEFORE `(long raw)` on any caller-supplied numeric, because
   `(long ##Inf)` / `(long 1.0E20)` THROW on the JVM and `(long ##NaN)`
   truncates to a real `0`. A fractional in-range value is floored toward
@@ -107,7 +107,7 @@
   value); a string `raw` is strict-parsed (must match `int-string-re`
   end-to-end, then sit inside the same safe-integer window — trailing
   garbage and out-of-range magnitudes fall back to `default`, identically
-  on JVM and CLJS, rf2-ee38b.19 + rf2-ykv9a0). Every other shape falls
+  on JVM and CLJS). Every other shape falls
   back to `default`."
   [raw default floor]
   (cond
@@ -125,9 +125,9 @@
         default
         ;; Parse to a number, then route through the SAME finite/range
         ;; guard the numeric arm uses so the string and numeric arms agree
-        ;; AND the two hosts agree (rf2-ykv9a0). On the JVM a digit string
-        ;; past the long range threw `NumberFormatException`; on CLJS a
-        ;; digit string past the safe-integer ceiling silently became a
+        ;; AND the two hosts agree. Without it, on the JVM a digit string
+        ;; past the long range throws `NumberFormatException`; on CLJS a
+        ;; digit string past the safe-integer ceiling silently becomes a
         ;; lossy float. Reading both as a BigInteger / BigInt and feeding
         ;; the safe-integer guard gives one cross-host rejection threshold
         ;; (the JS safe-integer window) instead of two divergent ones.
@@ -162,7 +162,7 @@
   (parse-int* raw default 0))
 
 ;; ---------------------------------------------------------------------------
-;; Keyword coercion — bounded-allowlist gate (rf2-ih7g4)
+;; Keyword coercion — bounded-allowlist gate
 ;; ---------------------------------------------------------------------------
 ;;
 ;; JVM keywords are interned in a global table that NEVER shrinks. A
@@ -189,13 +189,11 @@
 ;;                       allocation cost — typically an operator-gated
 ;;                       write path (`--allow-writes`) whose registrar
 ;;                       enforces a grammar over the input. The
-;;                       positive-named successor to the retired
-;;                       `parse-keyword` (rf2-xxtrz); the fresh-id
-;;                       posture is on the name rather than in a
-;;                       warning-laden docstring.
+;;                       fresh-id posture is carried on the name itself
+;;                       rather than in a warning-laden docstring.
 ;;
-;; `parse-mode` is fixed here — every existing caller passes a finite
-;; `recognised` set, so the gate lifts cleanly with no surface change.
+;; `parse-mode` routes through `safe-keyword` — every caller passes a
+;; finite `recognised` set, so the bounded gate fits cleanly.
 
 (defn- normalise-keyword-string
   "Internal: strip a leading `:` from a string and split a namespaced
@@ -225,7 +223,7 @@
   Returns the matching keyword from `allowed`, or `nil` when the input
   is outside the set.
 
-  ## Why this exists (rf2-ih7g4)
+  ## Why this exists
 
   JVM keywords are interned in a global table that never shrinks.
   Calling `(keyword raw-agent-string)` on caller-supplied input lets an
@@ -283,7 +281,7 @@
 
   Namespaced keywords are supported (`\"ns/name\"` ⇒ `:ns/name`).
 
-  ## When to call (rf2-ih7g4 / rf2-xxtrz)
+  ## When to call
 
   JVM keywords are interned in a never-shrinking global table. Every
   `fresh-keyword` call permanently grows that table by one slot for a
@@ -330,7 +328,7 @@
   "Like `fresh-keyword`, but validate the DECOMPOSED `[ns-part name-part]`
   string shape against `shape-ok?` (and a length cap) BEFORE interning —
   so an id that fails the caller's grammar leaves NO keyword in the JVM
-  table (rf2-tag30h). Returns the interned keyword on success, or `nil`
+  table. Returns the interned keyword on success, or `nil`
   when the input is nil / blank / over-long / fails `shape-ok?` (the
   caller maps `nil` to its own structured error).
 
@@ -377,14 +375,13 @@
   `recognised` is a set of accepted keywords (e.g. `#{:diff :full}`)
   — the bounded allowlist.
 
-  ## Bounded-allowlist gate (rf2-ih7g4)
+  ## Bounded-allowlist gate
 
   Routes through `safe-keyword` so an unrecognised agent-supplied
-  string never interns a fresh JVM keyword. An earlier implementation
-  interned every input first and membership-checked after; the fix
-  flipped the order so the bounded check happens BEFORE the intern,
-  eliminating the unbounded-growth DoS path for mode-shaped args
-  (which are the vast majority of finite-set MCP args)."
+  string never interns a fresh JVM keyword. The bounded membership
+  check happens BEFORE any intern, so there is no unbounded-growth DoS
+  path for mode-shaped args (which are the vast majority of finite-set
+  MCP args)."
   [raw default recognised]
   (cond
     (nil? raw)                       default

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.cap
-  "Wire-boundary token-budget cap pipeline (rf2-rvyzy / rf2-eyelu).
+  "Wire-boundary token-budget cap pipeline.
 
   Per `spec/Principles.md` §\"Tight token budget per response\", every
   MCP `tools/call` response is bounded at ~5,000 tokens by default. When
@@ -24,13 +24,13 @@
   3. Under-budget responses pass through unchanged; over-budget
      responses are replaced with a fresh result carrying the marker.
 
-  Until rf2-eyelu this pipeline was duplicated near-identically in
-  re-frame2-pair-mcp (CLJS, `#js {:content #js [...]}`-shaped results) and
-  story-mcp (CLJ, `{:content [...] :structuredContent ...}`-shaped
-  results). The only structural difference between the two
-  implementations was the SHAPE of the result map and the platform-
-  appropriate accessor used to read its `:text` slots. The algorithm
-  itself was a single design.
+  This pipeline is the single shared implementation both servers route
+  through: re-frame2-pair-mcp (CLJS, `#js {:content #js [...]}`-shaped
+  results) and story-mcp (CLJ, `{:content [...] :structuredContent
+  ...}`-shaped results). The only structural difference between the two
+  is the SHAPE of the result map and the platform-appropriate accessor
+  used to read its `:text` slots; the algorithm is one design, factored
+  behind the `ResultIO` protocol.
 
   ## Per-server specialisation hook — the `ResultIO` protocol
 
@@ -56,11 +56,10 @@
   ## Single strategy today: truncate-with-marker
 
   The only strategy wired is drop-the-payload-and-emit-the-overflow-
-  marker. When future strategies land (path-slicing rf2-tygdv, lazy
-  summary rf2-u2029, diff encoding rf2-rl7y) the pluggable hook gets
-  reintroduced here. Until then `apply-cap` calls
-  `build-overflow-result` directly — no `case` dispatcher pretending
-  there's more than one branch (pre-alpha YAGNI).
+  marker. Future strategies (path-slicing, lazy summary, diff encoding)
+  would add a pluggable hook here. For the single strategy `apply-cap`
+  calls `build-overflow-result` directly — no `case` dispatcher
+  pretending there's more than one branch (pre-alpha YAGNI).
 
   ## Cross-platform
 
@@ -96,8 +95,8 @@
     without a `:text` slot are skipped. Implementations stay nil-safe:
     a nil `result` or empty content yields an empty seq.
 
-    CONTRACT — count every payload-bearing slot, not only `:content`
-    (rf2-mzndx / rf2-13wbe): a consumer whose result envelope DUPLICATES
+    CONTRACT — count every payload-bearing slot, not only `:content`:
+    a consumer whose result envelope DUPLICATES
     the payload into a second wire slot — most commonly a
     `:structuredContent` JSON projection emitted alongside the
     `:content[*].text` EDN on EVERY result (both re-frame2-pair-mcp's
@@ -127,16 +126,16 @@
 
 (def ^:const invalid-arg-hint
   "Recovery hint embedded in the `:rf.mcp/invalid-arg` rejection when a
-  caller supplies an out-of-domain `:max-tokens` — a negative (rf2-5rdit),
-  a fractional positive in (0,1) that would floor to a 0-cap lockout
-  (rf2-li6y2.2), or a non-finite / out-of-range value (`##Inf`, `##NaN`,
-  `1.0E20`) that would crash or truncate `(long raw)` (rf2-ykv9a0).
+  caller supplies an out-of-domain `:max-tokens` — a negative,
+  a fractional positive in (0,1) that would floor to a 0-cap lockout,
+  or a non-finite / out-of-range value (`##Inf`, `##NaN`,
+  `1.0E20`) that would crash or truncate `(long raw)`.
   States the valid domain AND the disable sentinel so the agent's next
   call is correct."
   "max-tokens must be an integer >= 1; 0 disables the cap")
 
 (defn invalid-arg-marker
-  "Build the `{:rf.mcp/invalid-arg {...}}` rejection payload (rf2-5rdit)
+  "Build the `{:rf.mcp/invalid-arg {...}}` rejection payload
   for a malformed per-call argument. `arg` is the offending arg keyword,
   `value` the rejected value, `hint` the recovery prose.
 
@@ -163,10 +162,10 @@
   "Resolve the per-call cap from an ALREADY-EXTRACTED raw value.
   Returns the integer cap in tokens, `nil` when the cap is disabled
   (caller passed `0`), `overflow/default-max-tokens` when absent or
-  not a number, or — for an out-of-domain number (a NEGATIVE, rf2-5rdit;
-  a fractional positive in (0,1) that would floor to a 0-cap lockout,
-  rf2-li6y2.2; or a NON-FINITE / OUT-OF-RANGE value — `##Inf`, `##NaN`,
-  `1.0E20` — that would crash or truncate `(long raw)`, rf2-ykv9a0) — an
+  not a number, or — for an out-of-domain number (a NEGATIVE;
+  a fractional positive in (0,1) that would floor to a 0-cap lockout;
+  or a NON-FINITE / OUT-OF-RANGE value — `##Inf`, `##NaN`,
+  `1.0E20` — that would crash or truncate `(long raw)`) — an
   `{:rf.mcp/invalid-arg {...}}` REJECTION marker.
 
   Each consumer extracts the raw value from its platform-specific args
@@ -184,25 +183,25 @@
     OR supplied a non-number. The default applies.
   - positive integer return ⇒ caller supplied a custom cap.
   - `{:rf.mcp/invalid-arg {...}}` return ⇒ caller supplied an out-of-domain
-    number: a NEGATIVE (rf2-5rdit), a fractional positive in (0,1) that
-    would floor to a real 0-cap lockout (rf2-li6y2.2), or a NON-FINITE /
-    OUT-OF-RANGE value (`##Inf` / `##NaN` / past the safe-integer window —
-    rf2-ykv9a0). The consumer surfaces this as an `isError: true` result
+    number: a NEGATIVE, a fractional positive in (0,1) that
+    would floor to a real 0-cap lockout, or a NON-FINITE /
+    OUT-OF-RANGE value (`##Inf` / `##NaN` / past the safe-integer
+    window). The consumer surfaces this as an `isError: true` result
     (test via `invalid-arg?`) and MUST NOT
     pass it to `apply-cap`.
 
-  ## Why negatives are rejected, not clamped (rf2-5rdit)
+  ## Why negatives are rejected, not clamped
 
-  A negative cap used to fall through to `(long raw)`, producing a
-  negative ceiling. `apply-cap`'s `over-cap?` then trips on ANY
-  non-negative token count, so every response — even a 2-character
-  one — was replaced by the `:rf.mcp/overflow` marker, locking the
+  A negative cap, left unguarded, would fall through to `(long raw)`,
+  producing a negative ceiling. `apply-cap`'s `over-cap?` then trips on
+  ANY non-negative token count, so every response — even a 2-character
+  one — would be replaced by the `:rf.mcp/overflow` marker, locking the
   agent out of all tool data until it changed the arg, and emitting a
-  nonsensical `:cap-tokens -1`. Mike ruled (2026-06-01) for an honest,
-  recoverable rejection at the AI/MCP boundary over silently clamping
-  or treating-as-default — the masterpiece CORRECTNESS posture: a
-  malformed cap is an agent error worth telling the agent about, not a
-  value to paper over."
+  nonsensical `:cap-tokens -1`. So the resolver makes an honest,
+  recoverable rejection at the AI/MCP boundary rather than silently
+  clamping or treating-as-default — the masterpiece CORRECTNESS
+  posture: a malformed cap is an agent error worth telling the agent
+  about, not a value to paper over."
   [raw]
   (cond
     (nil? raw)                       overflow/default-max-tokens
@@ -212,10 +211,10 @@
     ;; A fractional positive in (0,1) — e.g. 0.5 — would `(long …)` floor
     ;; to a REAL 0 cap (non-nil, NOT the disable sentinel). `apply-cap`
     ;; then over-trips on EVERY non-empty payload, locking the agent out —
-    ;; the exact lockout class rf2-5rdit rejected for negatives (rf2-li6y2.2).
-    ;; Reject it honestly rather than silently flooring to a 0-cap lockout.
+    ;; the same lockout class negatives hit. Reject it honestly rather
+    ;; than silently flooring to a 0-cap lockout.
     (< raw 1)                        (invalid-arg-marker :max-tokens raw invalid-arg-hint)
-    ;; Finite/range guard BEFORE `(long raw)` (rf2-ykv9a0). `##Inf` and a
+    ;; Finite/range guard BEFORE `(long raw)`. `##Inf` and a
     ;; finite magnitude past the safe-integer window (`1.0E20`) THROW
     ;; `IllegalArgumentException` on `(long raw)` (JVM); `##NaN` truncates
     ;; to a real `0` cap — the exact 0-cap lockout this resolver exists to
@@ -266,7 +265,7 @@
   "Sum the character count across every wire payload string the
   consumer's `wire-payload-strings` surfaces for `result` (every
   serialized payload-bearing slot, not only `:text`), accessed via `io`.
-  Used by the secondary byte cap (rf2-ih7g4) — the primary
+  Used by the secondary byte cap — the primary
   `sum-payload-tokens` divides by 4 (Anthropic's English-rule-of-thumb),
   which materially undercounts CJK, emoji, base64, and dense code. A
   char-count secondary gate catches payloads that escape the quotient
@@ -280,7 +279,7 @@
   (sum-payload-by io result count))
 
 (def ^:const byte-cap-multiplier
-  "Secondary byte-cap multiplier (rf2-ih7g4). `cap * multiplier` is the
+  "Secondary byte-cap multiplier. `cap * multiplier` is the
   hard char-count ceiling — a defence-in-depth gate against payloads
   that escape the primary `(quot count 4)` token heuristic (CJK,
   emoji, base64, dense code). Set high enough that an English / EDN
@@ -294,7 +293,7 @@
 ;; Over-budget decision — extracted from `apply-cap`'s inline `let` so the
 ;; two-stage gate is unit-trippable in isolation.
 ;;
-;; ## Why the secondary char gate is load-bearing today (rf2-of2cd)
+;; ## Why the secondary char gate is load-bearing today
 ;;
 ;; `apply-cap` derives BOTH sums from the SAME `wire-payload-strings` seq:
 ;; `tokens = Σ (token-estimate s)`, `chars = Σ (count s)`. A NAIVE reading
@@ -332,13 +331,13 @@
 ;; ---------------------------------------------------------------------------
 
 (defn over-cap?
-  "Two-stage over-budget predicate (rf2-ih7g4). True when EITHER the
+  "Two-stage over-budget predicate. True when EITHER the
   token sum exceeds `cap` OR the char sum exceeds `cap *
   byte-cap-multiplier`. Pure over already-summed counts so the
   secondary char gate is unit-trippable in isolation (see the comment
   block above for why the per-string floor in `token-estimate` makes
   this gate load-bearing through the live `apply-cap` path today —
-  rf2-of2cd — not merely a future-proofing branch)."
+  not merely a future-proofing branch)."
   [tokens chars cap]
   (or (> tokens cap)
       (> chars (* cap byte-cap-multiplier))))
@@ -349,7 +348,7 @@
   number for the payload that escaped the token heuristic), else the
   token sum. Pure companion to `over-cap?` — unit-tested directly in
   isolation AND reached through the live `apply-cap` path by a content
-  vector of many sub-4-char strings (rf2-of2cd)."
+  vector of many sub-4-char strings."
   [tokens chars cap]
   (if (> chars (* cap byte-cap-multiplier))
     chars
@@ -384,9 +383,8 @@
     ;; the `over-cap?` comment block above for why the char disjunct is
     ;; load-bearing through this very path (the per-string `token-estimate`
     ;; floor lets many sub-4-char slots trip the char gate while the token
-    ;; sum stays quiet — rf2-of2cd), and rf2-hyp0z for why both sums fold
-    ;; in ONE walk (avoids materialising story-mcp's `:structuredContent`
-    ;; twice).
+    ;; sum stays quiet). Both sums fold in ONE walk to avoid materialising
+    ;; story-mcp's `:structuredContent` twice.
     (let [{:keys [tokens chars]}
           (transduce (filter string?)
                      (completing

--- a/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.cursor
-  "Shared cursor-pagination machinery for the MCP pair (rf2-ee38b.19).
+  "Shared cursor-pagination machinery for the MCP pair.
 
   Per `spec/Principles.md` §Pagination and `spec/Tool-Pair.md`
   §Cursor pagination, every read tool whose return size is a function
@@ -10,23 +10,20 @@
 
   ## Why this ns
 
-  Both servers previously hand-rolled the SAME machinery:
+  Both servers need the SAME machinery:
 
-    - `tools/story-mcp/.../cursor.cljc`     (offset/total/sig over
-                                             append-mostly registries)
-    - `tools/re-frame2-pair-mcp/.../cursor.cljs` (after-id/ms over the
-                                             bounded epoch ring)
+    - story-mcp     — offset/total/sig over append-mostly registries
+    - re-frame2-pair-mcp — after-id/ms over the bounded epoch ring
 
   The cursor PAYLOAD differs by domain — story carries
   `{:offset :total :sig}`, pair carries `{:after-id :ms :until-ms
   :frame}` — but the base64 codec, the EDN read with ALL-tagged-literal
   rejection (built-in `#inst`/`#uuid` included) + size guard, the
   `::malformed` recovery contract, the `:limit` clamp, and the
-  `cursor-stale-result` envelope are identical.
-  Earlier the README argued the codec was consumer-side because
-  `js/Buffer` vs `java.util.Base64` differ — but story-mcp's
-  `cursor.cljc` already proved the codec lifts cleanly as a `.cljc`
-  reader-conditional, so it lives here now.
+  `cursor-stale-result` envelope are identical, so they live here once.
+  The codec is a `.cljc` reader-conditional even though `js/Buffer` and
+  `java.util.Base64` differ — the reader-conditional bridges the two
+  hosts cleanly, so the codec stays shared rather than consumer-side.
 
   ## What is parameterised vs fixed
 
@@ -178,7 +175,7 @@
   `:rf.error/mcp-cursor-bad-edn-tag` on every remaining unregistered
   tag.
 
-  ## One form, EOF-exhausted (rf2-ykv9a0, hardened rf2-rtg9t1)
+  ## One form, EOF-exhausted
 
   A cursor is ONE opaque payload map; a token whose decoded text is a
   valid map FOLLOWED by a second form — e.g.
@@ -188,14 +185,14 @@
   trailing object and weaken the opacity / corruption guard). A plain
   `read-string` reads only the FIRST form and never checks exhaustion.
 
-  The earlier fix wrapped the text in `[ … ]` and accepted a
-  ONE-element vector. That guard was bypassable by `]`-INJECTION
-  (rf2-rtg9t1): attacker text `{…valid map…}] <junk>` wraps to
-  `[{…}] <junk>]`, where the injected `]` closes the wrapper early —
-  `read-string` reads the clean 1-element vector `[{…}]`, returns the
-  inner map, and SILENTLY DISCARDS everything after the injected `]`.
+  A naive guard that wrapped the text in `[ … ]` and accepted a
+  ONE-element vector would be bypassable by `]`-INJECTION: attacker text
+  `{…valid map…}] <junk>` wraps to `[{…}] <junk>]`, where the injected
+  `]` closes the wrapper early — `read-string` reads the clean
+  1-element vector `[{…}]`, returns the inner map, and SILENTLY DISCARDS
+  everything after the injected `]`.
 
-  We close that by asserting reader EXHAUSTION via an appended sentinel:
+  So instead this asserts reader EXHAUSTION via an appended sentinel:
   wrap as `[ <text> <eof-sentinel> ]` and require the read to yield
   EXACTLY `[<one-form> <eof-sentinel>]` — a 2-element vector whose
   SECOND element is the sentinel. The sentinel can only land as the
@@ -234,7 +231,7 @@
                       `valid?`-passing payload map: it failed to
                       base64/EDN-decode, carried a tagged literal,
                       decoded to MORE THAN ONE EDN form (a trailing
-                      object after the payload map — rf2-ykv9a0),
+                      object after the payload map),
                       exceeded `max-cursor-bytes`, or its payload map
                       failed the consumer's `valid?` predicate. Callers
                       treat `::malformed` exactly like a STALE cursor —

--- a/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
@@ -1,7 +1,6 @@
 (ns re-frame.mcp-base.dedup
   "Structural dedup at the wire boundary — the cross-MCP forward
-  (encode) direction (rf2-obpa9 / rf2-90eft, lifted to the base by
-  rf2-ttspi7).
+  (encode) direction, shared in the base by both servers.
 
   ## Why dedup at the wire boundary
 
@@ -45,8 +44,9 @@
 
   ## What does NOT live here — the inverse (`dedup-expand`)
 
-  The forward direction is byte-identical, so it is lifted. The INVERSE
-  (`dedup-expand`) is NOT — neither MCP server calls it at runtime (the
+  The forward direction is byte-identical, so it is shared here. The
+  INVERSE (`dedup-expand`) is NOT — neither MCP server calls it at
+  runtime (the
   wire contract is that the agent host calls `de-dupe.core/expand`
   directly), so it is test-only, and each consumer's placement reflects
   its own test-corpus topology rather than a shared shape:
@@ -59,8 +59,8 @@
     ceremony than the helper costs — it is harmlessly available at
     runtime and never invoked by the server).
 
-  Lifting only the forward direction keeps each inverse's placement
-  decision local and intact (rf2-ttspi7)."
+  Sharing only the forward direction keeps each inverse's placement
+  decision local and intact."
   (:require [de-dupe.core :as dd]
             [re-frame.mcp-base.vocab :as vocab]))
 

--- a/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.mcp-base.descriptor-manifest
-  "Shared MCP tool-descriptor manifest generator + drift-check (rf2-sofwv —
-  follow-on to the rf2-3nbl5.2 API-governance keystone).
+  "Shared MCP tool-descriptor manifest generator + drift-check, a
+  companion to the API-governance keystone.
 
   THE PROBLEM. Each MCP server has ONE truth — its tool registry (the
   ordered `tools` / `tool-registry` vector that bundles every tool's
@@ -38,15 +38,16 @@
   size-conscious args. That is precisely the surface that goes stale
   when a tool is added / removed / renamed, its input surface changes,
   an argument silently flips required↔optional, or a token-budget hint
-  drifts — the drift the bead targets. The full descriptor's wire
+  drifts — the drift this gate targets. The full descriptor's wire
   validity is already pinned by the MCP-SDK conformance harness
   (`tools/mcp-conformance/`); this manifest pins the catalogue identity.
 
-  REQUIRED + TYPICALTOKENS (rf2-cwhod2). `:required` and `:typicalTokens`
-  join the projection so the gate guards the live API-semantics facets
-  the narrow `:input-keys` / `:output?` / `:annotations` set missed: a
-  tool could silently move an argument between required and optional, or
-  drift its token-budget hint, without tripping drift. `:required` is
+  REQUIRED + TYPICALTOKENS. `:required` and `:typicalTokens`
+  are part of the projection so the gate guards the live API-semantics
+  facets alongside `:input-keys` / `:output?` / `:annotations`: without
+  them a tool could silently move an argument between required and
+  optional, or drift its token-budget hint, without tripping drift.
+  `:required` is
   the SORTED subset of input keys the descriptor's `:inputSchema
   :required` marks mandatory (empty when none); `:typicalTokens` is the
   integer ballpark of the response payload size (nil when a tool
@@ -58,7 +59,7 @@
   raw shape forces it, since the two slots are read from independent
   descriptor sources.
 
-  WIRE-SPLICED INPUTS (rf2-cwhod2). re-frame2-pair-mcp splices the
+  WIRE-SPLICED INPUTS. re-frame2-pair-mcp splices the
   universal `max-tokens` (and, for read tools, `cache`) knobs onto every
   descriptor's `:inputSchema :properties` at `tools/list` time, AFTER
   the raw registry descriptor (`tools/descriptors.cljs` —
@@ -72,16 +73,16 @@
   `schemas/with-max-tokens`, so its raw descriptor already carries it —
   no generator-side splice needed.)
 
-  GATED INPUTS (rf2-qo3wvp). A descriptor input key can be present on a
+  GATED INPUTS. A descriptor input key can be present on a
   PRIVILEGED `tools/list` profile yet stripped from the DEFAULT one by an
   operator-only gate. story-mcp's `:include-sensitive` knob is the live
   case: six value-surfacing tools bake it into their static descriptor,
   but `registry/tool-descriptors` strips it from the default wire surface
   whenever the `--allow-sensitive-reads` gate is closed (the closed-by-
-  default posture). Projecting the raw descriptor put `:include-sensitive`
-  in `:input-keys`, so the governance artefact advertised an input the
-  DEFAULT surface deliberately hides — the manifest disagreed with the
-  surface it claims to guard.
+  default posture). Projecting the raw descriptor would put
+  `:include-sensitive` in `:input-keys`, so the governance artefact would
+  advertise an input the DEFAULT surface deliberately hides — the
+  manifest disagreeing with the surface it claims to guard.
 
   The row models that explicitly with `:gated-input-keys` — the SORTED
   subset of `:input-keys` that the default profile gates OFF. `:input-keys`
@@ -98,7 +99,7 @@
   deterministic. Generators pass the gated-key set as the optional 3rd arg
   to `build-manifest` (story-mcp passes `#{\"include-sensitive\"}`; pair-mcp
   passes nothing → the empty default). A drift in which inputs are gated —
-  a tool newly gating an input, or a gate lifted — now trips the gate.
+  a tool newly gating an input, or a gate lifted — trips the gate.
 
   DRIFT-CHECK. `check` regenerates the manifest in memory from the live
   registry and compares it to the committed file (LF-normalised). Any
@@ -158,17 +159,17 @@
   carry these slots (story-mcp lifts :outputSchema + :annotations via
   cond->; pair-mcp declares them per-tool).
 
-  `:required` (rf2-cwhod2) is the SORTED subset of input keys the
+  `:required` is the SORTED subset of input keys the
   descriptor marks mandatory via `:inputSchema :required` — empty when
   the tool declares none. Guarding it surfaces an argument silently
   flipping required↔optional.
 
-  `:typicalTokens` (rf2-cwhod2) is the integer response-payload token
+  `:typicalTokens` is the integer response-payload token
   hint, passed through verbatim (nil when a tool declares no hint —
   forward-compatible; the slot still renders so every row shares one
   shape). Guarding it surfaces a token-budget hint drifting.
 
-  `:gated-input-keys` (rf2-qo3wvp) is the SORTED subset of `:input-keys`
+  `:gated-input-keys` is the SORTED subset of `:input-keys`
   the DEFAULT `tools/list` profile gates off behind an operator-only gate
   (the intersection of the descriptor's actual input keys with the
   caller-supplied `gated-keys` set). The default surface is therefore
@@ -194,7 +195,7 @@
   inconsistent row (`:input-keys [\"known\"]` with `:required
   [\"missing\"]`), blessing a mandatory argument the input surface never
   declares and breaking the default/gate-open surface derivation
-  downstream. This fn now ENFORCES the invariant: a descriptor whose
+  downstream. This fn ENFORCES the invariant: a descriptor whose
   required keys are not a subset of its property keys is REJECTED with an
   `ex-info` naming the offending tool + the missing keys, rather than
   emitting a self-inconsistent row."
@@ -224,7 +225,7 @@
   ordering, is what this gate guards; the wire-surface ordering is
   pinned separately by the per-server order-sensitive tests).
 
-  The optional `gated-keys` set (rf2-qo3wvp) names the input keys the
+  The optional `gated-keys` set names the input keys the
   server's DEFAULT `tools/list` profile gates off (e.g. story-mcp's
   `#{\"include-sensitive\"}`); it is threaded to every row's
   `descriptor->row` so each `:gated-input-keys` is the per-tool
@@ -316,7 +317,7 @@
   descriptor maps + a server id keyword/string. The value `render-edn`
   serialises and `check` compares.
 
-  The optional `gated-keys` set (rf2-qo3wvp) names the input keys the
+  The optional `gated-keys` set names the input keys the
   server's DEFAULT `tools/list` profile gates off (story-mcp passes
   `#{\"include-sensitive\"}`); it is threaded to `build-rows` so each
   row's `:gated-input-keys` distinguishes the default surface from the
@@ -361,17 +362,17 @@
   failure message names exactly which tool drifted — same affordance
   the keystone's `check!` prints.
 
-  ## Row-level `:changed` identity (rf2-y3qpv)
+  ## Row-level `:changed` identity
 
   `:added` / `:removed` only name tools whose IDENTITY entered or left
   the catalogue. When an EXISTING tool's `:description`, `:input-keys`,
   `:gated-input-keys`, `:required`, `:output?`, `:annotations`, or
-  `:typicalTokens` drifts, neither set names it — the CI
-  guard went red with `{:ok? false :added [] :removed []}` and the
-  consumer generator could only print a generic \"tool set identical;
-  descriptor changed\" message, forcing a maintainer to manually diff
-  the whole manifest. `:changed` closes that gap: for every name present
-  in BOTH manifests whose row differs, it carries
+  `:typicalTokens` drifts, neither set names it — without a row-level
+  diff the CI guard would go red with `{:ok? false :added [] :removed []}`
+  and the consumer generator could only print a generic \"tool set
+  identical; descriptor changed\" message, forcing a maintainer to
+  manually diff the whole manifest. `:changed` closes that gap: for
+  every name present in BOTH manifests whose row differs, it carries
   `{:name <str> :old <committed-row> :new <generated-row>}` so the
   failure message can name exactly which existing tool drifted and how.
   An in-sync manifest (`:ok? true`) and a missing-file result both carry

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.mcp-base.diff-encode
-  "Path-keyed structural diff for epoch records (rf2-1wdzp) projected
-  into path-headed cluster sections (rf2-qeous).
+  "Path-keyed structural diff for epoch records projected
+  into path-headed cluster sections.
 
   ## What this does
 
@@ -30,16 +30,15 @@
   patch in order via `assoc-in` / `update-in` to reconstruct
   `:db-after`.
 
-  ## Why sections-per-cluster (rf2-qeous)
+  ## Why sections-per-cluster
 
   Agent queries like 'what did this cascade do?' want scoped
   cluster summaries — the path breadcrumb signals 'these N changes
-  belong together'. The flat patch list (the predecessor shape)
-  forced agents to re-cluster mentally. The sections projection
-  mirrors Xray's panel `sections-per-cluster` decomposition
-  (rf2-gfxmk Phase 1 of rf2-abts7) — same path-headed clusters; only
-  the per-section body shape differs (patches here vs annotated
-  subtree there).
+  belong together', so an agent reads cluster intent without
+  re-clustering a flat patch list mentally. The sections projection
+  mirrors Xray's panel `sections-per-cluster` decomposition — same
+  path-headed clusters; only the per-section body shape differs
+  (patches here vs annotated subtree there).
 
   The patch list is preserved per-section as the round-trip
   primitive: concatenating every section's `:patches` reproduces
@@ -65,7 +64,7 @@
   INDEX path (`[[:items 0 :qty] :assoc 2]`), which carries the position
   explicitly and never relies on a positional `nil` sentinel.
 
-  ## Vectors: same-length structural diff, length changes whole-leaf (rf2-cwhod2)
+  ## Vectors: same-length structural diff, length changes whole-leaf
 
   Maps recurse key-by-key; SAME-LENGTH vectors recurse element-by-element
   under numeric-INDEX paths. A single item update inside a large
@@ -82,7 +81,7 @@
   grammar's numeric `:assoc` reaches an index via `assoc-in` (which only
   overwrites-in-place or grows by one at the tail — it has no shift
   primitive) and `[<index-path> :dissoc]` is a documented no-op against a
-  vector parent (`dissoc-in` dissocs only into a MAP parent, rf2-ykv9a0).
+  vector parent (`dissoc-in` dissocs only into a MAP parent).
   Same-length diffing is lossless for in-place updates; a length delta
   falls back to the unambiguous whole-vector replacement rather than ship
   a half-designed splice encoding. Non-vector sequentials (lists, lazy
@@ -92,11 +91,11 @@
   ## Cross-MCP vocabulary
 
   The `:rf.mcp/diff-from` marker key follows the same `:rf.mcp/*`
-  namespace convention as `:rf.mcp/overflow` (rf2-rvyzy),
-  `:rf.mcp/summary` (rf2-tygdv), and `:rf.mcp/dedup-table` (rf2-lwgg8
-  mechanism 5). Agents recognise the family once.
+  namespace convention as `:rf.mcp/overflow`,
+  `:rf.mcp/summary`, and `:rf.mcp/dedup-table`. Agents recognise the
+  family once.
 
-  ## Patch grammar pinned via Malli (rf2-rgg7d)
+  ## Patch grammar pinned via Malli
 
   The patch tuple grammar is pinned as a Malli schema (`patch-schema`).
   Each `collect-patches` emission is validated at the encoder boundary
@@ -158,8 +157,7 @@
   [:sequential patch-schema])
 
 (def section-schema
-  "Malli schema for one section in the path-headed cluster projection
-  (rf2-qeous).
+  "Malli schema for one section in the path-headed cluster projection.
 
   Shape:
 
@@ -269,7 +267,7 @@
 
   `where` is the calling-site symbol threaded through to the ex-info
   `:where` slot so it reflects the ACTUAL wire boundary that tripped
-  (rf2-4ypau) rather than a hardcoded one side.
+  rather than a hardcoded one side.
 
   ## Egress-safe diagnostics (EP-0015)
 
@@ -309,8 +307,8 @@
   validator).
 
   `where` is the calling-site symbol threaded in by the caller so the
-  ex-info `:where` reflects the ACTUAL wire boundary that tripped
-  (rf2-4ypau): `'mcp-base/diff-encode-db-after` from the encoder,
+  ex-info `:where` reflects the ACTUAL wire boundary that tripped:
+  `'mcp-base/diff-encode-db-after` from the encoder,
   `'mcp-base/apply-patches` from the decoder. Both boundaries call
   this; hardcoding one side misattributes a decode-side throw to the
   encoder and misleads operator triage about which side of the wire
@@ -328,9 +326,9 @@
   `validate-patches!`.
 
   `where` is the calling-site symbol threaded in by the caller so the
-  ex-info `:where` reflects the ACTUAL wire boundary that tripped
-  (rf2-4ypau): `'mcp-base/diff-encode-db-after` from the encoder
-  (after the section-grouping pass, rf2-qeous), `'mcp-base/decode-db-after`
+  ex-info `:where` reflects the ACTUAL wire boundary that tripped:
+  `'mcp-base/diff-encode-db-after` from the encoder
+  (after the section-grouping pass), `'mcp-base/decode-db-after`
   from the decoder. Both boundaries call this; hardcoding one side
   misattributes a decode-side throw to the encoder. The thrown
   diagnostic is value-free (EP-0015): it reports the first bad section's
@@ -350,13 +348,13 @@
   patches for added / changed keys (recursing on map/map pairs), then
   walks `a` once to emit `:dissoc` patches for keys absent from `b`.
 
-  Threading the accumulator (rf2-c2k9k / F12) avoids the intermediate
-  patches vector each recursion site previously allocated for `into
-  acc` — on deep app-db diffs (5-10 nesting levels typical) every
-  recursion now `conj`s directly into the parent accumulator rather
-  than allocating a fresh vector and copying it back. Big-O is
-  unchanged; the saving is allocation pressure, mostly visible on the
-  hot `watch-epochs` / `trace-window` slice."
+  Threading the accumulator avoids an intermediate patches vector at
+  each recursion site — on deep app-db diffs (5-10 nesting levels
+  typical) every recursion `conj`s directly into the parent
+  accumulator rather than allocating a fresh vector and copying it
+  back. Big-O is the same as a copy-back approach; the saving is
+  allocation pressure, mostly visible on the hot `watch-epochs` /
+  `trace-window` slice."
   [acc a b path]
   (let [after-assocs
         (reduce-kv
@@ -369,8 +367,8 @@
                 (conj acc [p :assoc bv])
                 ;; A changed EXISTING key: delegate to `collect-patches-into`
                 ;; so the dispatch is decided in ONE place — two maps recurse
-                ;; key-by-key, two same-length vectors recurse element-wise
-                ;; (rf2-cwhod2), anything else (incl. an unchanged value,
+                ;; key-by-key, two same-length vectors recurse element-wise,
+                ;; anything else (incl. an unchanged value,
                 ;; which short-circuits to a no-op) is a single leaf
                 ;; `[p :assoc bv]` replacement.
                 :else
@@ -387,7 +385,7 @@
 
 (defn- collect-vector-patches-into
   "Structurally diff two SAME-LENGTH vectors element-by-element, threading
-  the accumulator (rf2-cwhod2). Each element pair recurses through
+  the accumulator. Each element pair recurses through
   `collect-patches-into` under the numeric-INDEX path `(conj path i)`, so
   a single changed element inside a long vector yields an index-headed
   `[[:items 0 :qty] :assoc 2]` patch instead of replacing the whole
@@ -403,7 +401,7 @@
   numeric `:assoc` reaches an index via `assoc-in` (which both grows a
   vector by one at the tail and overwrites in place) but has no shift
   primitive, and `[<index-path> :dissoc]` is a documented no-op against a
-  vector parent (`dissoc-in` dissocs only into a MAP parent, rf2-ykv9a0).
+  vector parent (`dissoc-in` dissocs only into a MAP parent).
   Same-length diffing covers the dominant in-place-update case losslessly;
   a length delta falls back to the unambiguous whole-vector replacement
   rather than risk a half-designed shift/splice encoding.
@@ -437,7 +435,7 @@
   call this for each map-into-map / same-length-vector descent, sharing
   the parent's accumulator rather than allocating a fresh sub-vector.
 
-  Recursion arms (rf2-cwhod2 added the same-length-vector arm):
+  Recursion arms:
     - two maps                       → `collect-map-patches-into`
     - two SAME-LENGTH vectors        → `collect-vector-patches-into`
       (element-wise, numeric-index paths)
@@ -454,7 +452,7 @@
 (defn collect-patches
   "Patch-list factory. Two maps recurse via `collect-map-patches-into`;
   two same-length vectors recurse element-wise via
-  `collect-vector-patches-into` (numeric-index paths, rf2-cwhod2); any
+  `collect-vector-patches-into` (numeric-index paths); any
   other shape change (a length-changed vector, a non-vector sequential,
   a scalar↔collection flip, the root) is a single whole-leaf `:assoc`
   replacement. Exposed for tests and for advanced consumers that want to
@@ -464,7 +462,7 @@
 
 (defn- dissoc-in
   "Remove the key at `path` (a non-empty path vector) from `m`, a
-  no-op when the path's parent is absent or is not a map (rf2-ykv9a0).
+  no-op when the path's parent is absent or is not a map.
 
   The spec contract for `[<path> :dissoc]` is 'remove the key at
   `path`; a no-op if it does not exist'. The naive
@@ -502,7 +500,7 @@
   "Set the value at `path` (a non-empty path vector) in `m` to `v`,
   raising a structured `:rf.error/bad-diff-replay` ex-info — never a
   raw host exception — when an intermediate parent is present but
-  non-associative (rf2-glybzz).
+  non-associative.
 
   The spec contract for `[<path> :assoc v]` is 'set the value at
   `path`, creating the slot if it didn't exist'. The naive `assoc-in`
@@ -519,14 +517,14 @@
       `IllegalArgumentException` (`(assoc-in {:a [1 2]} [:a :b] 9)`).
 
   This is the `:assoc` peer of `dissoc-in`'s missing-/scalar-parent
-  guard (rf2-ykv9a0): `apply-patches`'s grammar gate pins the patch
+  guard: `apply-patches`'s grammar gate pins the patch
   SHAPE but cannot prove a patch's parent path is associative in THIS
   `base`. A malformed / corrupt / third-party diff replayed against a
   mismatched base is exactly the case this guards — including via
   `decode-db-after`, whose non-validating `apply-patches*` replay
   routes here.
 
-  Policy (acceptance, rf2-glybzz): a non-associative intermediate
+  Policy (acceptance): a non-associative intermediate
   parent is a base/patch MISMATCH, not a no-op. Unlike `:dissoc`
   (where 'remove a key from a non-map' is naturally a no-op), silently
   dropping an `:assoc` would discard the requested change (data loss),
@@ -534,7 +532,7 @@
   base into a shape neither encoder side emitted (data corruption).
   Neither silent outcome is safe, so we surface the drift as a
   structured failure rather than guess. The ex-info names the ACTUAL
-  decode-side boundary via `where` (rf2-4ypau — `'mcp-base/apply-patches`
+  decode-side boundary via `where` (`'mcp-base/apply-patches`
   from the public validating decoder, `'mcp-base/decode-db-after` from
   the section decoder), carries `:recovery :no-recovery`, and reports
   the offending `:patch-path` plus the `:at` prefix where traversal hit
@@ -577,9 +575,9 @@
   outright (for `:assoc`) or are a no-op (for `:dissoc`, by
   convention). Nested `:dissoc` routes through `dissoc-in`, whose
   missing-/scalar-parent no-op honours the spec contract (no
-  nil-branch manufacture, no host `ClassCastException` — rf2-ykv9a0).
+  nil-branch manufacture, no host `ClassCastException`).
   Nested `:assoc` routes through `assoc-in-safe`, the `:assoc` peer
-  guard (rf2-glybzz): a missing parent auto-vivifies (intended
+  guard: a missing parent auto-vivifies (intended
   create-if-absent grammar), but a PRESENT non-associative intermediate
   parent raises a structured `:rf.error/bad-diff-replay` ex-info rather
   than leak the raw host `ClassCastException` `assoc-in` would throw.
@@ -589,14 +587,14 @@
   gate walks each section's nested `:patches` against `patches-schema`
   via `section-schema`) replay through here directly rather than
   re-validating the flattened list a second time on the JVM decode hot
-  path (rf2-pfy8e). The public `apply-patches` validates first, then
+  path. The public `apply-patches` validates first, then
   delegates here.
 
-  `where` (rf2-glybzz) is the boundary symbol threaded into a
+  `where` is the boundary symbol threaded into a
   `:rf.error/bad-diff-replay` ex-info if a nested `:assoc` lands on a
   non-associative intermediate parent, so the error attributes the
   ACTUAL decode-side boundary that replayed the mismatched patch
-  (rf2-4ypau) — `'mcp-base/apply-patches` from the public decoder,
+  — `'mcp-base/apply-patches` from the public decoder,
   `'mcp-base/decode-db-after` from the section decoder. The 2-arity
   defaults to the public-decoder boundary."
   ([base patches] (apply-patches* base patches 'mcp-base/apply-patches))
@@ -621,7 +619,7 @@
   patches (path `[]`) replace `base` outright (for `:assoc`) or are a
   no-op (for `:dissoc`, by convention).
 
-  ## Decoder-boundary validation (rf2-8e61v)
+  ## Decoder-boundary validation
 
   `apply-patches` is the wire-decoder entry point: a malformed patch
   reaching this fn is a contract violation by an upstream encoder (a
@@ -629,14 +627,13 @@
   shape, a transport corruption). Mirror `diff-encode-db-after`'s
   encoder-boundary gate: validate `patches` against `patches-schema`
   and throw `:rf.error/bad-diff-patches` ex-info on mismatch. The
-  ex-info names `'mcp-base/apply-patches` as the decode-side boundary
-  (rf2-4ypau).
+  ex-info names `'mcp-base/apply-patches` as the decode-side boundary.
 
-  The encoder side already pinned the grammar; this is the symmetric
+  The encoder side pins the grammar; this is the symmetric
   decode-side gate so the cross-MCP wire convention surfaces the
-  drift rather than silently no-op'ing on the malformed tuple (the
-  previous behaviour fell through the `cond` to `:else acc` and
-  dropped corrupted patches without a peep).
+  drift rather than silently no-op'ing on the malformed tuple.
+  Without the gate, a malformed tuple would fall through the `cond` to
+  `:else acc` and drop corrupted patches without a peep.
 
   Soft-pass behaviour mirrors the encoder: when Malli is not
   resolvable on the runtime classpath, validation is skipped. The
@@ -647,7 +644,7 @@
   `:sections` (whose nested `:patches` are walked against the same
   `patches-schema`) and replays via the non-validating `apply-patches*`
   to avoid a redundant second Malli walk of every patch tuple on the
-  JVM decode hot path (rf2-pfy8e)."
+  JVM decode hot path."
   [base patches]
   (validate-patches! patches 'mcp-base/apply-patches)
   (apply-patches* base patches))
@@ -655,7 +652,7 @@
 (defn diff-encode-db-after
   "Replace an epoch's `:db-after` with a path-headed cluster
   projection of a path-keyed structural diff against its own
-  `:db-before` (rf2-qeous). Returns the epoch with `:db-after`
+  `:db-before`. Returns the epoch with `:db-after`
   shaped as
   `{:rf.mcp/diff-from :db-before :sections [{...}{...}]}`.
 
@@ -677,8 +674,8 @@
           _        (validate-patches! patches 'mcp-base/diff-encode-db-after)
           ;; Thread `:db-before` so section classification can prove a
           ;; container is genuinely NEW before claiming `:added` — patch
-          ;; shape alone cannot (`:assoc` covers both insert and change,
-          ;; rf2-ykv9a0). Without this an existing parent whose direct
+          ;; shape alone cannot (`:assoc` covers both insert and
+          ;; change). Without this an existing parent whose direct
           ;; child changed would be mislabelled `:added` to the agent.
           sections (sg/group-patches-into-sections
                      patches {:db-before (:db-before epoch)})
@@ -689,7 +686,7 @@
 
 (defn- validate-diff-marker-body!
   "Enforce the CLOSED marker-body contract on a `:db-after` map that
-  carries `vocab/diff-from-key` (rf2-71kxvb). A structural check — pure
+  carries `vocab/diff-from-key`. A structural check — pure
   Clojure, no Malli — so it fires on BOTH hosts regardless of Malli
   presence or the `validate-patches?` `goog-define` (mirroring
   `assoc-in-safe`'s replay guard, not the Malli `validate-sections!`
@@ -698,26 +695,25 @@
   The wire contract (mcp-conformance `DiffFromBody`, a CLOSED map) is:
   a diff marker is EXACTLY `{:rf.mcp/diff-from :db-before, :sections [...]}` —
   two top-level keys, the marker value restricted to `:db-before`.
-  `decode-db-after` previously recognized a marker ONLY when the value
-  was exactly `:db-before` and then validated ONLY the raw `:sections`
-  slot. Two boundary gaps followed (both forbidden by the conformance
-  contract, both silent):
+  Presence of the marker key signals INTENT to be a diff marker, so the
+  body must satisfy the closed two-key contract. The guard closes two
+  boundary cases the conformance contract forbids (both otherwise
+  silent):
 
     - an EXTRA sibling key — `{:rf.mcp/diff-from :db-before :sections []
-      :sneaky :key}` — slipped past, the `:sections` gate ignoring the
-      stray key entirely (a mixed-envelope `:db-after` the encoder never
+      :sneaky :key}` — a `:sections`-only gate would ignore the stray
+      key entirely (a mixed-envelope `:db-after` the encoder never
       emits);
     - an UNSUPPORTED marker value — `{:rf.mcp/diff-from :db-later ...}` —
-      was treated as 'not a diff' and passed THROUGH unchanged, so a
-      corrupt / third-party marker survived the decoder unflagged rather
-      than surfacing a decoder-boundary contract error.
+      treating it as 'not a diff' would pass it THROUGH unchanged, so a
+      corrupt / third-party marker would survive the decoder unflagged
+      rather than surfacing a decoder-boundary contract error.
 
-  This guard closes both: presence of the marker key signals INTENT to be
-  a diff marker, so the body must satisfy the closed two-key contract or
-  the decode boundary surfaces a structured `:rf.error/bad-diff-marker`
-  ex-info naming the actual decode-side `where` (rf2-4ypau),
-  `:recovery :no-recovery`, and value-free diagnostics only (the offending
-  key set / marker-value type — never the app-db payload, EP-0015)."
+  On either case the decode boundary surfaces a structured
+  `:rf.error/bad-diff-marker` ex-info naming the actual decode-side
+  `where`, `:recovery :no-recovery`, and value-free diagnostics only
+  (the offending key set / marker-value type — never the app-db
+  payload, EP-0015)."
   [db-after where]
   (let [ks       (set (keys db-after))
         expected #{vocab/diff-from-key :sections}
@@ -749,29 +745,28 @@
   input unchanged when `:db-after` isn't a diff). Provided for
   agent-host round-trip parity and for the unit tests.
 
-  ## Decoder-boundary section validation (rf2-j6oay / rf2-y3qpv)
+  ## Decoder-boundary section validation
 
   Mirrors the encoder's `validate-sections!` gate. `sections->patches`
   is a permissive `mapcat :patches` — a section with malformed
   `:section-path` / `:section-kind` slots, or extra/missing slots,
   would slip through to a patch replay whose grammar gate only covers
   the flattened `:patches` list. Validating `sections` here gives
-  encoder/decoder symmetry per the rf2-8e61v argument: the cross-MCP
+  encoder/decoder symmetry: the cross-MCP
   wire convention surfaces drift on the receiving side too, rather
   than silently passing the cosmetic `:section-kind` / `:section-path`
   slots through to an agent-host UI that paints them as truth. The
-  ex-info names `'mcp-base/decode-db-after` as the decode-side boundary
-  (rf2-4ypau).
+  ex-info names `'mcp-base/decode-db-after` as the decode-side boundary.
 
   The gate validates the RAW `:sections` slot — it does NOT default a
-  missing / `nil` / `false` slot to `[]` (rf2-y3qpv). A diff marker
+  missing / `nil` / `false` slot to `[]`. A diff marker
   always carries an explicit `:sections` vector; coercing an absent or
-  falsey slot to an empty vector before the gate let a malformed
+  falsey slot to an empty vector before the gate would let a malformed
   `{:rf.mcp/diff-from :db-before}` marker decode to a no-op (an empty
   seq satisfies `[:sequential section-schema]`), silently ERASING the
   epoch's real `:db-after` change in diagnostics — the exact silent
   pass-through this boundary posture forbids. `sections-schema`
-  rejects `nil` / `false` (neither is sequential), so wire drift now
+  rejects `nil` / `false` (neither is sequential), so wire drift
   trips `:rf.error/bad-diff-sections` when Malli is present. An
   explicit `:sections []` — a genuine no-change diff — still validates
   and replays to `:db-before` unchanged.
@@ -779,7 +774,7 @@
   Soft-pass + `goog-define`-elidable by construction — reuses the
   same `validate-sections!` helper as the encoder.
 
-  ## Single validation pass (rf2-pfy8e)
+  ## Single validation pass
 
   `section-schema` nests `patches-schema`, so the `validate-sections!`
   gate above already Malli-walks every section's `:patches` against the
@@ -790,7 +785,7 @@
   `apply-patches*` rather than the public `apply-patches`."
   [epoch]
   (let [db-after (when (map? epoch) (:db-after epoch))]
-    ;; rf2-71kxvb — a map is a diff marker iff it carries `diff-from-key`.
+    ;; A map is a diff marker iff it carries `diff-from-key`.
     ;; Detect on the KEY's PRESENCE (intent), not on the value being exactly
     ;; `:db-before`: a marker whose value is unsupported (or which carries an
     ;; extra sibling key) is corrupt wire drift the decoder MUST flag, not a
@@ -800,21 +795,21 @@
                  (contains? db-after vocab/diff-from-key))
       epoch
       ;; The map intends to be a diff marker: enforce the CLOSED two-key body
-      ;; contract + the supported `:db-before` marker value FIRST (rf2-71kxvb),
+      ;; contract + the supported `:db-before` marker value FIRST,
       ;; so an extra sibling key or an unsupported marker value surfaces a
       ;; structured `:rf.error/bad-diff-marker` rather than slipping through.
       (do
         (validate-diff-marker-body! db-after 'mcp-base/decode-db-after)
         ;; Validate the RAW `:sections` value — do NOT default a
-        ;; missing / nil / false slot to `[]` before the gate (rf2-y3qpv).
+        ;; missing / nil / false slot to `[]` before the gate.
         ;; A diff marker carries an EXPLICIT `:sections` vector; coercing
-        ;; an absent or falsey slot to an empty vector slipped a malformed
+        ;; an absent or falsey slot to an empty vector would slip a malformed
         ;; `{:rf.mcp/diff-from :db-before}` marker past `validate-sections!`
         ;; (an empty seq satisfies `[:sequential section-schema]`) and
-        ;; replayed it as a no-op, silently ERASING the epoch's real
+        ;; replay it as a no-op, silently ERASING the epoch's real
         ;; `:db-after` change in diagnostics. `sections-schema` rejects
         ;; `nil` / `false` (neither is sequential) so the decoder-boundary
-        ;; gate now trips `:rf.error/bad-diff-sections` on wire drift, while
+        ;; gate trips `:rf.error/bad-diff-sections` on wire drift, while
         ;; an explicit `:sections []` (a genuine no-change diff) still
         ;; validates and replays to `:db-before` unchanged.
         (let [sections  (:sections db-after)
@@ -833,7 +828,7 @@
 
   `mode` is one of:
     :diff — default. Each `:db-after` becomes a structural diff.
-    :full — pass through (legacy behaviour, opt-in)."
+    :full — pass through unchanged (opt-in)."
   [epochs mode]
   (if (= mode :full)
     epochs

--- a/tools/mcp-base/src/re_frame/mcp_base/egress.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/egress.cljc
@@ -1,10 +1,10 @@
 (ns re-frame.mcp-base.egress
   "Cross-MCP `:rf.egress/*` profile vocabulary + a pure-data resolver
-  (EP-0015 §10, rf2-qus09h).
+  (EP-0015 §10).
 
   ## Why this ns
 
-  EP-0015 graduates the named-egress model: an off-box surface chooses
+  EP-0015 defines the named-egress model: an off-box surface chooses
   *which boundary is this?* — a named `:rf.egress/*` profile — not *which
   combination of `:rf.size/*` booleans did I remember?*. The framework
   owns the authoritative table in `re-frame.projection/profile-size-opts`
@@ -29,7 +29,7 @@
   drift (a profile rename / opt-set change in the framework that does not
   land here fails the gate).
 
-  ## The six profiles (EP-0015 §10, ruled CLOSED enum)
+  ## The six profiles (EP-0015 §10, CLOSED enum)
 
   | Profile | `:rf.size/*` floor |
   |---|---|

--- a/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.elision
-  "Wire-boundary elision-marker walker (rf2-9fz64).
+  "Wire-boundary elision-marker walker.
 
   Per `spec/009` §Size elision in traces, the framework's
   `rf/elide-wire-value` walker substitutes over-threshold leaves with
@@ -8,15 +8,15 @@
   surfaces a scalar count of those substitutions on its response
   envelope (the unqualified `:elided-large` slot — see
   `vocab/elided-large-key` and Conventions §Cross-MCP indicator-field
-  vocabulary, MUST-level per rf2-2499j).
+  vocabulary, MUST-level).
 
   ## Why this ns
 
   `vocab.cljc` is the constants catalogue — namespaced keys, JSON-RPC
-  codes, envelope-slot names. A runtime tree-walker is not a constant
-  and was crowding the catalogue's mandate. The walker lives here so
-  the elision concern has a clear home; sibling elision-side runtime
-  fns land here too as the vocabulary grows.
+  codes, envelope-slot names. A runtime tree-walker is not a constant,
+  so it lives here instead, giving the elision concern a clear home;
+  sibling elision-side runtime fns land here too as the vocabulary
+  grows.
 
   ## Cousin to `re-frame.mcp-base.sensitive`
 
@@ -24,8 +24,8 @@
   `:dropped-sensitive` envelope slot; `count-elided-markers` returns
   the integer for the `:elided-large` slot. Both indicators ride the
   response envelope together per the cross-MCP indicator-field
-  parity (one without the other is the round-2 audit fix the
-  conformance gate enforces).
+  parity — emitting one without the other is the failure the
+  conformance gate catches.
 
   ## Cross-platform
 

--- a/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.envelope
-  "Cross-MCP response-envelope helpers (rf2-ee38b.19).
+  "Cross-MCP response-envelope helpers.
 
   The MCP servers decorate their tool-response envelopes with two
   cross-cutting concerns that are pure data and identical across the
@@ -14,13 +14,12 @@
        that the cache + cap boundary steps emit themselves, so later
        boundary steps don't re-walk a sub-cap-by-construction marker.
 
-  Both indicator KEYS already live in `vocab.cljc`; the producers of
+  Both indicator KEYS live in `vocab.cljc`; the producers of
   the counts (`elision/count-elided-markers`,
-  `sensitive/strip-sensitive`) already live in the base. This ns adds
-  the helper that SPLICES them onto the envelope — previously
-  pair-mcp-only despite being pure data — so the single emit-path the
-  spec mandates lives in one place the conformance gate can test
-  directly.
+  `sensitive/strip-sensitive`) live in the base. This ns adds
+  the helper that SPLICES them onto the envelope — pure data shared by
+  both servers — so the single emit-path the spec mandates lives in one
+  place the conformance gate can test directly.
 
   ## Cross-platform
 
@@ -66,7 +65,7 @@
     (pos? (or elided  0)) (assoc vocab/elided-large-key      elided)))
 
 ;; ---------------------------------------------------------------------------
-;; Wire-bounded marker detection (rf2-gktyn, rf2-3z0zi, rf2-3xd9i9).
+;; Wire-bounded marker detection.
 ;;
 ;; The `:rf.mcp/cache-hit` and `:rf.mcp/overflow` envelopes are
 ;; replacement results the cache + cap boundary steps emit themselves.
@@ -84,7 +83,7 @@
 ;; `pr-str` emits by default for a single-namespace map). Matching both
 ;; keeps the detector host- and print-setting-agnostic.
 ;;
-;; EXACT key, not a prefix (rf2-3xd9i9). A bare `starts-with?` on the
+;; EXACT key, not a prefix. A bare `starts-with?` on the
 ;; marker key would wrongly classify a LOOKALIKE first key whose name
 ;; merely begins with a marker key — e.g. `:rf.mcp/overflowed` or
 ;; `:rf.mcp/cache-hit-extra`. That is a correctness hole: an over-budget
@@ -134,7 +133,7 @@
 (defn- key-terminator?
   "Is the 1-char string `ch` a character that cannot continue an EDN
   keyword/symbol token — i.e. a valid terminator immediately following a
-  marker key in rendered text (rf2-3xd9i9)? `nil` (end-of-string) does
+  marker key in rendered text? `nil` (end-of-string) does
   NOT count: a complete marker map always has a value after the key, so
   a key flush against EOS is a truncated / lookalike form, not a real
   marker."
@@ -144,7 +143,7 @@
 (defn- exact-marker-prefix?
   "Does `text` begin with marker `prefix` AND end the marker key exactly
   there — i.e. the character at index `(count prefix)` is a token
-  terminator (rf2-3xd9i9)? This rejects lookalike first keys like
+  terminator? This rejects lookalike first keys like
   `:rf.mcp/overflowed` whose name merely starts with a marker key."
   [text prefix]
   (let [plen (count prefix)]
@@ -163,7 +162,7 @@
   here; this fn owns only the leading-token match logic, shared across
   hosts.
 
-  Matches the EXACT marker key, not merely a prefix of it (rf2-3xd9i9):
+  Matches the EXACT marker key, not merely a prefix of it:
   a lookalike leading key such as `:rf.mcp/overflowed` or
   `:rf.mcp/cache-hit-extra` is NOT a marker. The match requires the
   marker key to be terminated by an EDN token terminator (the space

--- a/tools/mcp-base/src/re_frame/mcp_base/overflow.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/overflow.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.overflow
-  "Wire-boundary token-budget cap (rf2-rvyzy) shape builder.
+  "Wire-boundary token-budget cap shape builder.
 
   Per `spec/Principles.md` §Tight token budget per response, every MCP
   `tools/call` response is bounded at ~5,000 tokens by default. When
@@ -24,7 +24,7 @@
 
 (def ^:const default-max-tokens
   "The convention's documented cap. Sized for a typical 5K-token MCP
-  response envelope after diff-encode + dedup. Per rf2-rvyzy."
+  response envelope after diff-encode + dedup."
   5000)
 
 (defn token-estimate

--- a/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
@@ -1,13 +1,12 @@
 (ns re-frame.mcp-base.section-grouping
-  "Patch-list → path-headed cluster sections (rf2-qeous).
+  "Patch-list → path-headed cluster sections.
 
   ## What this is
 
-  The MCP wire boundary's `:db-after` shape evolves from flat patches
-  to path-headed cluster sections — the same sections-per-cluster
-  decomposition Xray's panel renderer ships (rf2-gfxmk Phase 1 of
-  rf2-abts7), but projected from the patch list rather than from the
-  annotated-tree.
+  The MCP wire boundary's `:db-after` shape is path-headed cluster
+  sections — the same sections-per-cluster decomposition Xray's panel
+  renderer ships, but projected from the patch list rather than from
+  the annotated-tree.
 
   An agent that asks 'what did this cascade do?' gets N scoped
   cluster summaries — each headed by a path breadcrumb — instead of
@@ -56,7 +55,7 @@
   `:modified`. The agent uses this to skim cluster intent without
   walking every patch. (`:added` requires `:db-before` context —
   see §Classify each section for why patch shape alone can't prove
-  it; rf2-ykv9a0.)
+  it.)
 
   ## Algorithm
 
@@ -104,7 +103,7 @@
        default; the agent reads `:modified` and knows the cluster
        carries a mix of inserts / changes / deletes.
 
-     ## Why `:added` needs `:db-before` (rf2-ykv9a0)
+     ## Why `:added` needs `:db-before`
 
      The patch grammar uses `:assoc` for BOTH inserted and changed
      leaves, so patch SHAPE alone cannot distinguish a newly-added
@@ -151,7 +150,7 @@
 (def default-opts
   "Tunable knobs. Mirrors `tools/xray/.../section_grouping.cljc`'s
   defaults so the agent sees the same cluster shape Xray's panel
-  renders. Tune against a real corpus in rf2-ogkh0."
+  renders."
   {:max-coalesce-depth 3})
 
 ;; ---- coalescence -------------------------------------------------------
@@ -258,7 +257,7 @@
 
 (def ^:private absent
   "Private sentinel for `get-in` miss detection — distinguishes a stored
-  `nil` from an absent key (rf2-ykv9a0)."
+  `nil` from an absent key."
   #?(:clj (Object.) :cljs (js-obj)))
 
 (defn- path-present?
@@ -279,7 +278,7 @@
   ALREADY exist in `:db-before`?'. The patch grammar uses `:assoc` for
   BOTH inserted and changed leaves, so patch shape ALONE cannot tell a
   newly-added container from an existing one whose direct children
-  changed (rf2-ykv9a0): `{:user {:name \"bob\"}}` →
+  changed: `{:user {:name \"bob\"}}` →
   `{:user {:name \"ada\" :email \"…\"}}` emits the SAME all-`:assoc`
   direct-child cluster under `[:user]` as a genuinely new `[:user]`
   subtree would. `:added` is therefore claimed ONLY when the patches are
@@ -341,7 +340,7 @@
                 `:db-before` — the pre-change value the patches diff
                 from. When supplied, `:section-kind :added` is claimed
                 only for an all-`:assoc` direct-child cluster whose
-                container was ABSENT in `:db-before` (rf2-ykv9a0).
+                container was ABSENT in `:db-before`.
                 When absent, the classifier cannot prove addition and
                 errs to `:modified` for every all-`:assoc` cluster.
 
@@ -351,7 +350,7 @@
    (let [{:keys [max-coalesce-depth db-before]} (merge default-opts opts)
          ;; `:added` requires PROOF the container is newly introduced —
          ;; patch shape alone cannot supply it (`:assoc` covers both
-         ;; insert and change, rf2-ykv9a0). When `:db-before` is threaded
+         ;; insert and change). When `:db-before` is threaded
          ;; in (the `diff-encode-db-after` caller has it in hand), a
          ;; cluster is `:added` only if its section-path was ABSENT
          ;; before. Without it (standalone projection) every cluster's
@@ -394,7 +393,7 @@
   trips `:rf.error/bad-diff-sections` on such a marker; this fn only
   runs after that gate (or its soft-pass when Malli is absent), so the
   non-sequential branch is the soft-pass safety net, not the primary
-  validation (rf2-y3qpv)."
+  validation."
   [sections]
   (if (sequential? sections)
     (vec (mapcat :patches sections))

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -5,8 +5,7 @@
   ## What spec/009 mandates
 
   Framework-published forwarders — Sentry / Honeybadger, re-frame2-pair server,
-  Story-MCP (xray-mcp was dropped in rf2-bu21t; xray now ships as a
-  Clojars-only library, not an MCP server) — MUST default-drop trace events whose
+  Story-MCP — MUST default-drop trace events whose
   registration declared `:sensitive? true`. The runtime stamps the
   flag at the top level of every emitted trace event inside such a
   registration's handler scope; the forwarder's job is to gate egress
@@ -24,9 +23,8 @@
   predicate-style `?` is rejected there. The predicate FUNCTION name
   `include-sensitive?` retains its `?` (the idiom belongs on the
   predicate, not on a data key whose wire form disallows it).
-  Both servers now ship the unqualified wire-key: story-mcp (rf2-y710n)
-  and re-frame2-pair-mcp (rf2-ihq4d) — the cross-server arg name is
-  uniform.
+  Both servers ship the unqualified wire-key — story-mcp and
+  re-frame2-pair-mcp alike — so the cross-server arg name is uniform.
 
   ## Why this ns is zero-dep
 
@@ -36,26 +34,22 @@
   (`(and (map? ev) (sensitive-stamp? (:sensitive? ev)))`) is
   conservative and matches the spirit of `re-frame.privacy/sensitive?`.
   Per the spec the runtime always stamps the literal boolean; if a
-  transport bug delivers any other truthy value (rf2-ih7g4 fail-closed
+  transport bug delivers any other truthy value (fail-closed
   posture) we drop the event AND log so the contract drift is
   visible.")
 
 ;; ---------------------------------------------------------------------------
-;; Fail-closed predicate (rf2-ih7g4)
+;; Fail-closed predicate
 ;; ---------------------------------------------------------------------------
 ;;
-;; Spec/009 declares `:sensitive?` as a boolean. The previous
-;; implementation matched only the literal `true` — any other truthy
-;; value (string `\"true\"`, keyword `:yes`, non-empty collection,
-;; number) passed through as if the event were non-sensitive. That is
-;; fail-OPEN on contract drift: an upstream serialisation bug that
-;; coerces the boolean into a string silently leaks every sensitive
-;; event past the wire-egress filter.
-;;
-;; The fix is fail-CLOSED: any truthy non-boolean stamp is treated as
+;; Spec/009 declares `:sensitive?` as a boolean. The predicate is
+;; fail-CLOSED: any truthy non-boolean stamp is treated as
 ;; "claim to be sensitive, but malformed" — we drop AND log so the
 ;; drift surfaces in operator output. Only an explicit `false` /
-;; absent / nil stamp passes.
+;; absent / nil stamp passes. Matching only the literal `true` would
+;; fail OPEN on contract drift: an upstream serialisation bug that
+;; coerces the boolean into a string would silently leak every
+;; sensitive event past the wire-egress filter.
 
 #?(:clj  (defonce ^:private ^java.util.concurrent.atomic.AtomicLong
            malformed-counter
@@ -65,17 +59,15 @@
 (defn malformed-count
   "Read the count of malformed `:sensitive?` stamps observed since
   process start (or since the last `reset-malformed-count!`). The
-  fail-closed posture (rf2-ih7g4) is silent on the wire — the counter
+  fail-closed posture is silent on the wire — the counter
   is the operator-surface observability hook. Public so operator
   dashboards and tests can read the gate's activity.
 
-  This is a faithful PER-EVENT metric (rf2-el9sw): the egress walkers
+  This is a faithful PER-EVENT metric: the egress walkers
   (`strip-sensitive` / `scrub-snapshot`) classify each event exactly
   once, so a single dropped malformed event bumps the counter exactly
-  once. (Pre-rf2-el9sw `strip-sensitive` ran the predicate twice per
-  event — `some` pre-scan + `filterv` drop-scan — so one malformed
-  event over-counted ~2×.) Direct `sensitive-event?` / `sensitive-stamp?`
-  calls still bump once per call, as before.
+  once. Direct `sensitive-event?` / `sensitive-stamp?` calls bump once
+  per call.
 
   Returns a non-negative integer."
   []
@@ -102,7 +94,7 @@
 (defn- stamp-type-tag
   "A NON-sensitive, value-free class/type tag for a malformed stamp.
   Logged in place of the raw stamp so the contract-drift warning stays
-  fail-CLOSED at the log boundary (rf2-el9sw): an operator sees the
+  fail-CLOSED at the log boundary: an operator sees the
   shape of the drift (`String`, `Keyword`, …) and a fixed reason, but
   never the payload, which on a serialisation bug could carry a secret.
   Returns a short type-name string — never any of the stamp's data."
@@ -128,7 +120,7 @@
   the source. Stderr / `console.warn` keep the warning out of the MCP
   wire response.
 
-  FAIL-CLOSED AT THE LOG BOUNDARY (rf2-el9sw): logs are an egress
+  FAIL-CLOSED AT THE LOG BOUNDARY: logs are an egress
   boundary on this privacy surface. A malformed stamp is wire-adjacent,
   untrusted data; if a serialisation bug puts a secret-bearing
   string/map/vector in `:sensitive?`, echoing it with `pr-str` would
@@ -150,7 +142,7 @@
                       "type=" tag " value=:rf/redacted"))))))
 
 (defn sensitive-stamp?
-  "Classify a sensitive-rollup slot value. Fail-closed posture (rf2-ih7g4):
+  "Classify a sensitive-rollup slot value. Fail-closed posture:
 
     - boolean `true`           ⇒ drop (the documented spec/009 path).
     - boolean `false` / nil    ⇒ pass (non-sensitive).
@@ -160,7 +152,7 @@
 
   Public so consumers that read a DIFFERENT rollup key than the
   trace-event `:sensitive?` stamp — e.g. re-frame2-pair-mcp's epoch-record
-  rollup `:rf.epoch/sensitive?` (rf2-5613h) — can route their stamp
+  rollup `:rf.epoch/sensitive?` — can route their stamp
   through the SAME fail-closed classifier rather than re-deriving a
   divergent `(true? ...)` check that fails OPEN on contract drift.
   `sensitive-event?` is the convenience wrapper that reads the
@@ -183,7 +175,7 @@
   "Does this event carry the top-level `:sensitive? true` stamp (or a
   fail-closed malformed-truthy variant)?
 
-  Fail-closed (rf2-ih7g4): the literal `true` value drops (the
+  Fail-closed: the literal `true` value drops (the
   spec/009 path), AND any other truthy non-boolean value drops too
   (with a stderr warning). The `:rf/trace-event` schema types
   `:sensitive?` as a boolean (Spec 009 + Spec-Schemas); a non-boolean
@@ -203,7 +195,7 @@
   §Privacy. Apply it to any vector of trace-event-shaped maps before
   the result crosses the MCP boundary into the agent surface.
 
-  ## Fast-path + single-classification (rf2-0q30r, rf2-el9sw)
+  ## Fast-path + single-classification
 
   The docstring promises identical-vector return when no events drop.
   The implementation honours that with a SINGLE linear pass that
@@ -211,12 +203,9 @@
   tracking whether anything dropped, and returns the original `events`
   (identity preserved, no `filterv` allocation) when nothing dropped.
 
-  Why exactly once matters (rf2-el9sw): `sensitive-event?` is
+  Why exactly once matters: `sensitive-event?` is
   SIDE-EFFECTING on the malformed-truthy path — it bumps
-  `malformed-count` and logs a contract-drift warning. The previous
-  two-pass shape (`some` pre-scan THEN `filterv` drop-scan) ran the
-  predicate over each event up to twice, so a single malformed event
-  bumped the counter ~2× and emitted the warning twice. One pass ⇒ one
+  `malformed-count` and logs a contract-drift warning. One pass ⇒ one
   classification ⇒ one bump + one warning per malformed event, so
   `malformed-count` is a faithful per-event metric for operator
   dashboards.
@@ -258,22 +247,22 @@
   snapshot privacy boundary. Sensitive trace events are stripped from
   the `:traces` and `:epochs` slices, but the value-carrying slices
   `:app-db`, `:sub-cache`, and `:machines` are LEFT ALONE: the walk is
-  shallow by design (rf2-zq0n1 / rf2-3cted) and does NOT descend into
+  shallow by design and does NOT descend into
   arbitrary sub-trees or redact app-db values.
 
   Consequently the OUTPUT is NOT already-projected full-snapshot output.
   Per EP-0015 the public privacy model is registration-owned `:sensitive`
   / `:large` classification plus centralized `project-egress` (under a
-  named `:rf.egress/*` profile) at the egress boundary — the write-time
-  `redact-interceptor` that earlier owned app-db payload redaction has
-  been REMOVED. So the CALLER's egress pipeline must run `project-egress`
+  named `:rf.egress/*` profile) at the egress boundary — app-db payload
+  redaction is owned by `project-egress`, not by any write-time
+  interceptor. So the CALLER's egress pipeline must run `project-egress`
   over the non-trace slices with the frame's known policy BEFORE the
   snapshot crosses an MCP/tool boundary; do not treat `scrub-snapshot`
   output as sufficient and do not look for a write-time interceptor to
   have handled it. Re-asserted by the snapshot-scrubber tests in every
   MCP that emits per-frame snapshots.
 
-  ## Strip-fn parameter (rf2-zpmmr)
+  ## Strip-fn parameter
 
   Two-arity form `[snapshot include?]` uses the base
   `strip-sensitive` predicate (spec/009 §Privacy stamp check).
@@ -284,7 +273,7 @@
   sensitive-epoch?`). The default arity preserves the
   trace-event-only filter for story-mcp consumers.
 
-  ## Slice-shape discipline + fail-closed (rf2-wm9kp)
+  ## Slice-shape discipline + fail-closed
 
   A `:traces` / `:epochs` slice is a SEQUENTIAL batch of trace-event maps
   (a vector in the typical runtime emission, or a lazy seq when composed
@@ -292,11 +281,11 @@
   runs `strip-fn` on a genuinely `sequential?` slice. A non-sequential
   slice (nil, a scalar, a string, or a single event MAP) is NOT a batch,
   so it passes through UNCHANGED — honouring the documented contract
-  (`Non-map slices … pass through unchanged`). The prior unconditional
-  `(vec …)` mangled these shapes: `nil → []`, `\"oops\" → [\\o \\o …]`, and
-  a single event map → a vector of map-entries — which silently lost the
-  event shape, reported zero drops, AND carried any secret in that map
-  straight past the filter.
+  (`Non-map slices … pass through unchanged`). Guarding on `sequential?`
+  matters: an unconditional `(vec …)` would mangle these shapes
+  (`nil → []`, `\"oops\" → [\\o \\o …]`, a single event map → a vector of
+  map-entries), silently losing the event shape, reporting zero drops,
+  AND carrying any secret in that map straight past the filter.
 
   Fail-CLOSED exception: a single MAP slice that the caller-supplied
   `strip-fn` classifies as sensitive is DROPPED, not passed through —
@@ -307,7 +296,7 @@
   union-signal sensitivity the caller's predicate catches (e.g.
   re-frame2-pair-mcp's `:rf.epoch/sensitive? true` epoch rollup, carrying
   no unqualified `:sensitive?` stamp) is honoured on the single-map shape
-  too (rf2-li6y2.1)."
+  too."
   ([snapshot include?]
    (scrub-snapshot snapshot include? strip-sensitive))
   ([snapshot include? strip-fn]
@@ -337,14 +326,14 @@
                    ;; event is NOT a batch and would leak its secret if
                    ;; shipped raw — drop it (empty batch) and count it.
                    ;; Classify via the SAME caller-supplied `strip-fn` the
-                   ;; sequential branch uses (rf2-li6y2.1) — NOT the base
+                   ;; sequential branch uses — NOT the base
                    ;; `sensitive-event?`. Otherwise a single-map slice that
                    ;; is sensitive ONLY by a union signal the caller's
                    ;; predicate catches (e.g. re-frame2-pair-mcp's epoch
                    ;; rollup `:rf.epoch/sensitive? true`, with no unqualified
                    ;; `:sensitive?` stamp) would slip past this guard to the
-                   ;; `:else` arm and ship RAW — the rf2-5613h leak class
-                   ;; re-surfacing inside the rf2-wm9kp defensive guard.
+                   ;; `:else` arm and ship RAW — leaking past the defensive
+                   ;; single-map guard.
                    (map? slice)
                    (let [[_ n] (strip-fn [slice] false)]
                      (if (pos? n)

--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -52,31 +52,30 @@
   Shape (per the shared `mcp-base.cap/apply-cap` → `overflow/overflow-payload`
   builder, emitted by BOTH re-frame2-pair-mcp and story-mcp):
     `{:rf.mcp/overflow {:limit :reached :token-count N :cap-tokens M
-                        :tool \"<name>\" :hint \"...\"}}`.
-  Per rf2-rvyzy."
+                        :tool \"<name>\" :hint \"...\"}}`."
   :rf.mcp/overflow)
 
 (def dedup-table-key
   "Top-level marker on a structurally-deduped payload. The value is the
   de-dupe library's flat cache map; the agent expands locally via
   `de-dupe.core/expand`.
-  Shape: `{:rf.mcp/dedup-table <cache-map>}`. Per rf2-obpa9."
+  Shape: `{:rf.mcp/dedup-table <cache-map>}`."
   :rf.mcp/dedup-table)
 
 (def diff-from-key
   "Marker on an epoch's `:db-after` slot indicating it is a structural
   diff against a sibling slot. The value names the source slot
-  (`:db-before`). Shape (path-headed cluster projection, rf2-qeous):
+  (`:db-before`). Shape (path-headed cluster projection):
     `{:db-after {:rf.mcp/diff-from :db-before
                  :sections [{:section-path [...] :section-kind <kw>
                              :patches [...]} ...]}}`.
-  Per rf2-1wdzp / rf2-qeous. See `re-frame.mcp-base.diff-encode` and
+  See `re-frame.mcp-base.diff-encode` and
   `re-frame.mcp-base.section-grouping`."
   :rf.mcp/diff-from)
 
 (def cursor-stale-reason
   "Structured error-result `:reason` value indicating the cursor's
-  epoch-id is no longer in the runtime ring. Per rf2-kbqq3.
+  epoch-id is no longer in the runtime ring.
 
   Agents pattern-match on this `:reason` to either drop the cursor
   and restart, or widen the window to recover."
@@ -84,7 +83,7 @@
 
 (def cache-hit-key
   "Top-level marker on a response that short-circuited via the
-  per-session cache (rf2-3rt1f, rf2-36xod). Shape:
+  per-session cache. Shape:
     `{:rf.mcp/cache-hit {:tool ... :digest ... :hint ...}}`. The agent
   re-uses the previously-shipped payload (the marker is content-free —
   the agent host correlates by cache key)."
@@ -92,7 +91,7 @@
 
 (def summary-key
   "Top-level marker on a lazy-summary response (snapshot mode
-  `:summary`). Per rf2-tygdv / rf2-u2029. Shape:
+  `:summary`). Shape:
     `{:rf.mcp/summary {...tree-summary...}}`. The summary is a
   deliberately small tree-keyed projection; agents drill in via
   `get-path` once they know the key of interest."
@@ -100,7 +99,7 @@
 
 (def invalid-arg-key
   "Top-level marker on an error-result rejecting a malformed per-call
-  argument at the wire boundary (rf2-5rdit). Shape:
+  argument at the wire boundary. Shape:
     `{:rf.mcp/invalid-arg {:arg <kw> :value <supplied> :hint <str>}}`.
 
   Unlike `:rf.mcp/cursor-stale` (a `:reason` value on a generic
@@ -108,7 +107,7 @@
   payload of an `isError: true` tool-result — an honest, recoverable
   rejection the agent reads and corrects, not a server fault.
 
-  First emitter (rf2-5rdit): `cap/max-tokens` rejects a NEGATIVE
+  First emitter: `cap/max-tokens` rejects a NEGATIVE
   `:max-tokens` arg here rather than resolving it to a negative cap
   (which would over-trip `apply-cap` and lock the agent out of every
   response). The cross-MCP `:rf.mcp/*` namespace reserves the key for
@@ -116,8 +115,8 @@
   :rf.mcp/invalid-arg)
 
 (def result-key
-  "Top-level discriminator key for a wire-FIDELITY typed result envelope
-  (rf2-qobqy). Where the size markers above shrink an over-budget
+  "Top-level discriminator key for a wire-FIDELITY typed result envelope.
+  Where the size markers above shrink an over-budget
   payload, this one TYPES the outcome of an evaluation so a genuine
   `nil`, a thrown eval-error, and an unserializable value
   (`#object`/`#js`/Function) stop collapsing to a bare `null`. Shape:
@@ -145,7 +144,7 @@
     `{:rf.size/large-elided {:bytes N :type \"...\"
                              :handle [:rf.elision/at <path>]}}`.
   Agents drill back into the slot via `get-path` using the handle's
-  path. Reserved per Conventions §Reserved namespaces. Per rf2-urjnc."
+  path. Reserved per Conventions §Reserved namespaces."
   :rf.size/large-elided)
 
 (def redacted-sentinel
@@ -181,8 +180,8 @@
 (def include-sensitive-opt
   "The framework opt that controls whether sensitive payloads emit
   the marker. Surfaced by every MCP server uniformly as the
-  `:include-sensitive` wire-arg (story-mcp per rf2-y710n,
-  re-frame2-pair-mcp per rf2-ihq4d). Per the Anthropic tool-input-schema regex
+  `:include-sensitive` wire-arg (story-mcp and re-frame2-pair-mcp
+  alike). Per the Anthropic tool-input-schema regex
   `^[a-zA-Z0-9_.-]{1,64}$`, wire-keys MUST omit the trailing `?`.
   The walker option keyword (this one, `:rf.size/include-sensitive?`)
   is a NAMESPACED framework key — internal, not a wire-key — so it
@@ -204,7 +203,8 @@
 ;; ---------------------------------------------------------------------------
 ;; Envelope indicator-field slots (Conventions §Cross-MCP indicator-field
 ;; vocabulary; Spec 009 §Size elision in traces — Indicator field on tool
-;; responses). MUST-level pin per rf2-2499j: every tool that returns a
+;; responses). MUST-level pin per Conventions §Cross-MCP indicator-field
+;; vocabulary: every tool that returns a
 ;; structured response map and walks a tree-typed payload carries BOTH
 ;; counts on the envelope (omit when zero, alongside the qualified wire
 ;; markers `:rf/redacted` / `:rf.size/large-elided` at the leaf-

--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.args-test
-  "Tests for the shared MCP argument-coercion helpers (rf2-vw4sq)."
+  "Tests for the shared MCP argument-coercion helpers."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.mcp-base.args :as args]))
 
@@ -72,11 +72,11 @@
   (is (zero? (args/parse-non-negative-int -5 5000))))
 
 ;; ---------------------------------------------------------------------------
-;; Cross-host strict-parse contract (rf2-ee38b.19).
+;; Cross-host strict-parse contract.
 ;;
-;; Pin the trailing-garbage case that previously diverged: JVM
-;; `Long/parseLong` threw on a non-numeric tail and fell back to the
-;; default, while raw CLJS `js/parseInt` parsed a numeric PREFIX
+;; Pin the trailing-garbage case where the hosts could diverge: JVM
+;; `Long/parseLong` throws on a non-numeric tail and falls back to the
+;; default, while raw CLJS `js/parseInt` parses a numeric PREFIX
 ;; (`"12abc"` ⇒ 12). The strict `int-string-re` guard makes both hosts
 ;; fall back to `default`. The mirror CLJS assertions live in
 ;; `re-frame.mcp-base.cljs-branches-cljs-test` so the same expectations
@@ -109,14 +109,14 @@
   (is (= 50 (args/parse-positive-int "99999999999999999999999999" 50))))
 
 ;; ---------------------------------------------------------------------------
-;; Cross-runtime finite/range guard (rf2-ykv9a0).
+;; Cross-runtime finite/range guard.
 ;;
-;; The numeric arm called `(long raw)` with no finite/range guard. On the
+;; A bare `(long raw)` with no finite/range guard is unsafe. On the
 ;; JVM `(long ##Inf)` / `(long 1.0E20)` THROW IllegalArgumentException and
 ;; `(long ##NaN)` truncates to a real `0` — neither the recoverable
-;; default nor a crash-free, host-consistent result. The string arm
-;; diverged across hosts at the JS safe-integer ceiling. The fix routes
-;; both arms through one safe-integer-windowed guard so an out-of-domain
+;; default nor a crash-free, host-consistent result; and the string arm
+;; would diverge across hosts at the JS safe-integer ceiling. Both arms
+;; route through one safe-integer-windowed guard so an out-of-domain
 ;; numeric / string DEFAULTS (never throws, never truncates to a real
 ;; value) identically on JVM and CLJS. The CLJS mirror lives in
 ;; cljs_branches_cljs_test.
@@ -143,20 +143,19 @@
       "the safe-integer ceiling itself is in-domain"))
 
 (deftest parse-positive-int-string-threshold-aligns-to-safe-integer
-  ;; rf2-ykv9a0 — the string arm previously diverged: the JVM
-  ;; `Long/parseLong` accepted "9007199254740992" (a valid long, just
-  ;; past the JS safe-integer ceiling) while CLJS rejected it via
-  ;; Number.isSafeInteger. Aligning the JVM arm to the SAME safe-integer
-  ;; window makes the two hosts agree (the cross-runtime contract). The
-  ;; CLJS mirror asserts the identical value in cljs_branches_cljs_test.
+  ;; The string arm could diverge: the JVM `Long/parseLong` accepts
+  ;; "9007199254740992" (a valid long, just past the JS safe-integer
+  ;; ceiling) while CLJS rejects it via Number.isSafeInteger. The JVM
+  ;; arm is held to the SAME safe-integer window so the two hosts agree
+  ;; (the cross-runtime contract). The CLJS mirror asserts the identical
+  ;; value in cljs_branches_cljs_test.
   (is (= 50 (args/parse-positive-int "9007199254740992" 50))
       "one past the safe-integer ceiling defaults on BOTH hosts now (was parsed on JVM)")
   (is (= 9007199254740991 (args/parse-positive-int "9007199254740991" 50))
       "exactly the safe-integer ceiling is still accepted on both hosts"))
 
 ;; ---------------------------------------------------------------------------
-;; fresh-keyword — positive-named intern for operator-gated write paths
-;; (rf2-xxtrz, the successor to the retired `parse-keyword`).
+;; fresh-keyword — positive-named intern for operator-gated write paths.
 ;; ---------------------------------------------------------------------------
 
 (deftest fresh-keyword-passes-through-keywords
@@ -200,7 +199,7 @@
         "fresh-keyword MUST intern — that's the entire point of the primitive")))
 
 ;; ---------------------------------------------------------------------------
-;; fresh-keyword-checked — grammar-gated intern (rf2-tag30h). Validates the
+;; fresh-keyword-checked — grammar-gated intern. Validates the
 ;; STRING shape BEFORE interning so a rejected id leaves NO keyword.
 ;; ---------------------------------------------------------------------------
 
@@ -257,11 +256,11 @@
   (is (= :full (args/parse-mode "full" :diff #{:diff :full}))))
 
 (deftest parse-mode-strips-leading-colon
-  ;; Regression pin (rf2-wnyy9 / round-2 F2): `parse-mode` must accept
+  ;; Regression pin: `parse-mode` must accept
   ;; agent-supplied `":diff"` the same way the read path accepts
-  ;; `":foo"`. Before the fix this silently default-fell-back — the
-  ;; agent saw `:diff` returned but the value was the function's
-  ;; default, not a recognised match.
+  ;; `":foo"`. Without the leading-colon strip this would silently
+  ;; default-fall-back — the agent would see `:diff` returned but the
+  ;; value would be the function's default, not a recognised match.
   (is (= :diff (args/parse-mode ":diff" :full #{:diff :full})))
   (is (= :full (args/parse-mode ":full" :diff #{:diff :full})))
   (is (= :rf/foo (args/parse-mode ":rf/foo" :default #{:rf/foo :rf/bar}))
@@ -275,7 +274,7 @@
   (is (= :diff (args/parse-mode :unknown :diff #{:diff :full}))))
 
 ;; ---------------------------------------------------------------------------
-;; safe-keyword — bounded-allowlist gate (rf2-ih7g4).
+;; safe-keyword — bounded-allowlist gate.
 ;; ---------------------------------------------------------------------------
 
 (deftest safe-keyword-allowed-keyword-passes
@@ -312,9 +311,9 @@
   (is (nil? (args/safe-keyword ":" #{:diff :full}))))
 
 (deftest safe-keyword-disallowed-NAMESPACED-string-returns-nil-and-does-not-intern
-  ;; Coverage gap (rf2-ynjts.17): the existing no-intern pin
+  ;; The companion no-intern pin
   ;; (`safe-keyword-disallowed-string-returns-nil-and-does-not-intern`)
-  ;; exercises only the BARE-name arm (`find-keyword name-part`). The
+  ;; exercises the BARE-name arm (`find-keyword name-part`). The
   ;; NAMESPACED arm (`find-keyword ns-part name-part`) is a distinct
   ;; branch in `normalise-keyword-string` → `safe-keyword`, and it is
   ;; the branch the registry-backed frame-id / `:rf.assert/*` coercions
@@ -355,15 +354,14 @@
   (is (nil? (args/safe-keyword {:k :diff} #{:diff :full}))))
 
 ;; ---------------------------------------------------------------------------
-;; parse-mode no-intern on rejection (rf2-ih7g4).
+;; parse-mode no-intern on rejection.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-mode-unknown-string-does-not-intern
-  ;; Regression pin (rf2-ih7g4): `parse-mode` previously routed every
-  ;; string input through an interning helper and then membership-
-  ;; checked the result. With the fix, the membership check happens
-  ;; BEFORE intern. A rejected string MUST leave the keyword table
-  ;; untouched.
+  ;; Regression pin: `parse-mode` routes string input so the membership
+  ;; check happens BEFORE any intern. A rejected string MUST leave the
+  ;; keyword table untouched — routing through an interning helper first
+  ;; and membership-checking after would grow the table on every typo.
   (let [novel-name "rf2-ih7g4-parse-mode-novel-name-do-not-intern"]
     (is (nil? (find-keyword novel-name))
         "precondition: the novel name is not in the keyword table")

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.cap-test
-  "Unit tests for the cross-MCP cap pipeline (rf2-eyelu).
+  "Unit tests for the cross-MCP cap pipeline.
 
   Exercises the algorithm via a mock `ResultIO` reifying the protocol
   over CLJ maps. The per-server IO instances (re-frame2-pair-mcp's JS-object
@@ -54,8 +54,8 @@
 
 (deftest max-tokens-only-zero-disables-not-other-numbers
   ;; ONLY a literal `0` disables the cap (returns nil). A NEGATIVE number
-  ;; is neither a disable signal nor a passthrough cap — per Mike's
-  ;; rf2-5rdit ruling it is REJECTED as an out-of-domain arg (see
+  ;; is neither a disable signal nor a passthrough cap — it is REJECTED
+  ;; as an out-of-domain arg (see
   ;; `max-tokens-negative-rejected-with-invalid-arg` below). Smallest
   ;; positive passes through unchanged.
   (is (nil? (cap/max-tokens 0)) "0 is the sole disable signal")
@@ -64,13 +64,14 @@
       "a negative number is NOT a disable signal and NOT a cap — it is rejected"))
 
 (deftest max-tokens-negative-rejected-with-invalid-arg
-  ;; rf2-5rdit — Mike ruled A (REJECT). A negative `:max-tokens` used to
+  ;; A negative `:max-tokens` is REJECTED. Left unguarded it would
   ;; fall through to `(long raw)`, producing a negative cap that
-  ;; over-tripped `apply-cap`'s `over-cap?` so EVERY response (even a
-  ;; 2-char one) was replaced by the overflow marker — locking the agent
-  ;; out of all tool data and emitting a nonsensical `:cap-tokens -1`.
-  ;; The resolver now returns an `{:rf.mcp/invalid-arg {...}}` rejection
-  ;; the consumer surfaces as an `isError: true` result.
+  ;; over-trips `apply-cap`'s `over-cap?` so EVERY response (even a
+  ;; 2-char one) would be replaced by the overflow marker — locking the
+  ;; agent out of all tool data and emitting a nonsensical
+  ;; `:cap-tokens -1`. The resolver returns an `{:rf.mcp/invalid-arg
+  ;; {...}}` rejection the consumer surfaces as an `isError: true`
+  ;; result.
   (let [out (cap/max-tokens -1)]
     (is (cap/invalid-arg? out)
         "negative max-tokens resolves to an :rf.mcp/invalid-arg rejection, NOT a negative cap")
@@ -85,12 +86,12 @@
   (is (cap/invalid-arg? (cap/max-tokens -1.5)) "negative doubles reject too"))
 
 (deftest max-tokens-fractional-positive-rejected-with-invalid-arg
-  ;; rf2-li6y2.2 — a fractional positive in (0,1) — e.g. 0.5 — is neither
-  ;; caught by (zero? raw) nor (neg? raw); pre-fix it fell to (long raw),
-  ;; flooring to a REAL 0 cap (non-nil, NOT the disable sentinel). That 0
-  ;; then over-tripped `apply-cap`'s `over-cap?` on EVERY non-empty payload,
-  ;; locking the agent out — the exact lockout class rf2-5rdit rejected for
-  ;; negatives. The resolver now rejects it honestly as an
+  ;; A fractional positive in (0,1) — e.g. 0.5 — is neither
+  ;; caught by (zero? raw) nor (neg? raw); left unguarded it would fall
+  ;; to (long raw), flooring to a REAL 0 cap (non-nil, NOT the disable
+  ;; sentinel). That 0 would then over-trip `apply-cap`'s `over-cap?` on
+  ;; EVERY non-empty payload, locking the agent out — the same lockout
+  ;; class negatives hit. The resolver rejects it honestly as an
   ;; `{:rf.mcp/invalid-arg {...}}` marker rather than flooring to a 0-cap
   ;; lockout.
   (let [out (cap/max-tokens 0.5)]
@@ -130,11 +131,11 @@
   (is (integer? (cap/max-tokens 1000.0))))
 
 (deftest max-tokens-non-finite-out-of-range-rejected-not-crash-not-0-cap
-  ;; rf2-ykv9a0 — `(long raw)` is UNSAFE on non-finite / out-of-range
-  ;; numerics. Pre-fix, on the JVM `##Inf` and `1.0E20` THREW
+  ;; `(long raw)` is UNSAFE on non-finite / out-of-range
+  ;; numerics. On the JVM `##Inf` and `1.0E20` THROW
   ;; IllegalArgumentException (a crash at the wire boundary), and `##NaN`
-  ;; truncated to a real `0` cap — the exact 0-cap lockout shape rf2-5rdit
-  ;; / rf2-li6y2.2 refused. The resolver now rejects each honestly as an
+  ;; truncates to a real `0` cap — the same 0-cap lockout shape negatives
+  ;; and fractionals hit. The resolver rejects each honestly as an
   ;; {:rf.mcp/invalid-arg} marker, the recoverable cross-runtime posture.
   (doseq [[label raw] [["##Inf" ##Inf]
                        ["##NaN" ##NaN]
@@ -249,7 +250,7 @@
     (is (contains? (:marker out) vocab/overflow-key))))
 
 ;; ---------------------------------------------------------------------------
-;; Secondary char-byte cap (rf2-ih7g4) — defence in depth against the
+;; Secondary char-byte cap — defence in depth against the
 ;; `(quot count 4)` token undercount on CJK / emoji / base64 / dense
 ;; code. `sum-payload-tokens` divides by 4; a payload where 1 char ≈ 2-3
 ;; tokens still trips the cap because the secondary char check uses
@@ -274,9 +275,8 @@
   ;; rule but each glyph carries ~2-3 tokens on a real tokenizer ⇒
   ;; the heuristic under-reports. The cap MUST still trip over-budget
   ;; CJK content under the current rule (the heuristic is not exact,
-  ;; but the absolute count grows with input size). Regression pin
-  ;; for rf2-ih7g4: a CJK payload of 5000 glyphs at cap=100 trips
-  ;; overflow.
+  ;; but the absolute count grows with input size). Regression pin:
+  ;; a CJK payload of 5000 glyphs at cap=100 trips overflow.
   (let [big-cjk (apply str (repeat 5000 \日))
         r       {:content [{:type "text" :text big-cjk}]}
         out     (cap/apply-cap map-io r {:tool "cjk-test" :cap 100})
@@ -285,7 +285,7 @@
     (is (pos? (:token-count body)))))
 
 (deftest byte-cap-multiplier-and-char-sum-are-pinned
-  ;; Defence-in-depth shape pin (rf2-ih7g4 / rf2-8cpsg / F18). The
+  ;; Defence-in-depth shape pin. The
   ;; secondary byte cap is `cap * byte-cap-multiplier` and reads from
   ;; the same `wire-payload-strings` seq the token sum does.
   ;;
@@ -298,25 +298,23 @@
     (is (= 25 (cap/sum-payload-tokens map-io r)))))
 
 ;; ---------------------------------------------------------------------------
-;; Two-stage gate, unit-trippable in isolation (rf2-80y2h) + reachable
-;; through the live `apply-cap` path (rf2-of2cd).
+;; Two-stage gate, unit-trippable in isolation + reachable through the
+;; live `apply-cap` path.
 ;;
 ;; The `over-cap?` / `reported-count` predicates are extracted as pure fns
 ;; over already-summed tokens/chars so the secondary char gate is
 ;; trippable in ISOLATION (feed decoupled sums directly), independent of
 ;; how `apply-cap` happens to derive the sums.
 ;;
-;; rf2-of2cd CORRECTION: an earlier comment here claimed the char gate was
-;; NOT genuinely reachable through `apply-cap` because "an IO cannot
-;; return chars without proportional tokens". That is WRONG. `token-estimate`
-;; floors PER STRING, so `Σ (quot len_i 4)` collapses toward 0 for a
-;; content vector of many sub-4-char slots while the char sum stays large.
-;; `apply-cap-many-short-strings-trips-char-gate` below exercises the
-;; char-gated arm THROUGH the live `apply-cap` path — no custom-sum trick,
-;; just a realistic many-small-slots payload (the `watch-epochs` /
-;; `trace-window` slice shape). The isolation tests remain valuable (they
-;; pin both disjuncts crisply); the char gate is simply load-bearing now,
-;; not merely future defence-in-depth.
+;; The char gate IS genuinely reachable through `apply-cap`:
+;; `token-estimate` floors PER STRING, so `Σ (quot len_i 4)` collapses
+;; toward 0 for a content vector of many sub-4-char slots while the char
+;; sum stays large. `apply-cap-many-short-strings-trips-char-gate` below
+;; exercises the char-gated arm THROUGH the live `apply-cap` path — no
+;; custom-sum trick, just a realistic many-small-slots payload (the
+;; `watch-epochs` / `trace-window` slice shape). The isolation tests
+;; remain valuable (they pin both disjuncts crisply); the char gate is
+;; load-bearing, not merely future defence-in-depth.
 ;; ---------------------------------------------------------------------------
 
 (deftest over-cap?-primary-token-gate-trips
@@ -372,9 +370,8 @@
         "apply-cap's reported :token-count matches reported-count over the same sums")))
 
 (deftest apply-cap-many-short-strings-trips-char-gate
-  ;; rf2-of2cd regression pin. The secondary char gate is reachable
-  ;; through the LIVE `apply-cap` path, contradicting the earlier
-  ;; "structurally dominated / not reachable by construction" claim.
+  ;; Regression pin: the secondary char gate is reachable through the
+  ;; LIVE `apply-cap` path, not merely in isolation.
   ;;
   ;; `token-estimate` floors PER STRING: 3000 slots of 3 chars each give
   ;; `tokens = Σ (quot 3 4) = 0` while `chars = 9000`. With `cap = 1` the
@@ -400,7 +397,7 @@
       (is (= cap-toks (:cap-tokens body))))))
 
 ;; ---------------------------------------------------------------------------
-;; structuredContent counted toward the budget (rf2-ih7g4) — story-mcp
+;; structuredContent counted toward the budget — story-mcp
 ;; pattern: its reify surfaces `:structuredContent` as one extra
 ;; `pr-str`-ed string in `wire-payload-strings`. Pin the contract via a
 ;; mirror reify here.

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -1,11 +1,11 @@
 (ns re-frame.mcp-base.cljs-branches-cljs-test
-  "CLJS-only coverage for re-frame2-mcp-base (rf2-80y2h).
+  "CLJS-only coverage for re-frame2-mcp-base.
 
   mcp-base ships as `.cljc` and both MCP servers consume it in CLJS
   (re-frame2-pair-mcp is a Node script). The canonical JVM suite
-  (`clojure -M:test`) can only exercise the `:clj` reader-conditional
-  arms, AND it always has Malli on the classpath — so three CLJS
-  behaviours had ZERO executing coverage on any platform:
+  (`clojure -M:test`) only exercises the `:clj` reader-conditional
+  arms, AND it always has Malli on the classpath — so this suite owns
+  three CLJS behaviours that only run here:
 
     1. The library actually loads and the diff algorithm round-trips
        under a CLJS runtime (not just the JVM).
@@ -105,7 +105,7 @@
         "no Malli ⇒ no section-validation throw; patches replay regardless")))
 
 ;; ---------------------------------------------------------------------------
-;; 4. The cap pipeline (the extracted two-stage gate, rf2-80y2h) runs
+;; 4. The cap pipeline (the extracted two-stage gate) runs
 ;;    under CLJS too. `over-cap?` / `reported-count` are pure CLJC; pin
 ;;    that the secondary char gate trips in isolation on the CLJS side
 ;;    as well — both servers cap on the wire.
@@ -139,11 +139,11 @@
       (is (identical? r out)))))
 
 ;; ---------------------------------------------------------------------------
-;; 4b. structuredContent must count toward the budget on the CLJS/pair path
-;;     (rf2-13wbe). re-frame2-pair-mcp's `wire/ok-text` / `err-text` emit
+;; 4b. structuredContent must count toward the budget on the CLJS/pair path.
+;;     re-frame2-pair-mcp's `wire/ok-text` / `err-text` emit
 ;;     a `:structuredContent` JS projection alongside the `:content[*].text`
 ;;     EDN on EVERY result — the SAME payload, twice on the wire. The
-;;     mcp-base `wire-payload-strings` contract (rf2-mzndx / rf2-13wbe) requires a
+;;     mcp-base `wire-payload-strings` contract requires a
 ;;     dual-coding consumer to surface a stable string of that slot too;
 ;;     otherwise the cap undercounts by ~50% and a small-`:content` /
 ;;     huge-`:structuredContent` response slips past the overflow marker.
@@ -167,8 +167,8 @@
   "Pair-shaped reify that HONOURS the dual-slot contract: `wire-payload-strings`
   surfaces both the `#js`-array `:text` slots AND a `js/JSON.stringify`
   of the `:structuredContent` JS object — the exact bytes the npm SDK
-  serialises. This is the shape pair-mcp's `result-io` must adopt
-  (rf2-13wbe). Mirrors story-mcp's `structured-io` on the JS side."
+  serialises. This is the shape pair-mcp's `result-io` must adopt.
+  Mirrors story-mcp's `structured-io` on the JS side."
   (reify cap/ResultIO
     (wire-payload-strings [_ result]
       (let [sc      (.-structuredContent ^js result)
@@ -180,10 +180,9 @@
            :structuredContent (clj->js marker)})))
 
 (def ^:private content-only-pair-io
-  "Pair-shaped reify that IGNORES `:structuredContent` (the pre-rf2-13wbe
-  pair-mcp behaviour). Used only to demonstrate the undercount the
-  contract forbids — the same payload passes the cap here while
-  `structured-pair-io` trips it."
+  "Pair-shaped reify that IGNORES `:structuredContent`. Used only to
+  demonstrate the undercount the contract forbids — the same payload
+  passes the cap here while `structured-pair-io` trips it."
   (reify cap/ResultIO
     (wire-payload-strings [_ result]
       (js-text-slots (.-content ^js result)))
@@ -214,8 +213,8 @@
           "structuredContent-blind reify under-counts and lets the over-budget payload through unchanged"))))
 
 ;; ---------------------------------------------------------------------------
-;; 5. Cross-host strict integer-parse contract (rf2-ee38b.19). The string
-;;    arm of `parse-int*` previously diverged: raw `js/parseInt` parses a
+;; 5. Cross-host strict integer-parse contract. The string
+;;    arm of `parse-int*` could diverge: raw `js/parseInt` parses a
 ;;    numeric PREFIX (`"12abc"` ⇒ 12) while JVM `Long/parseLong` rejects
 ;;    trailing garbage and falls back to default. This pins the CLJS half
 ;;    of the contract; the JVM half lives in args_test.clj. Both MUST
@@ -237,10 +236,10 @@
     (is (= 50 (args/parse-positive-int "99999999999999999999999999" 50)))))
 
 ;; ---------------------------------------------------------------------------
-;; 5b. Cross-runtime finite/range guard on numeric arg coercion (rf2-ykv9a0).
-;;     The numeric arm previously called `(long raw)` with no guard:
+;; 5b. Cross-runtime finite/range guard on numeric arg coercion.
+;;     A bare `(long raw)` with no guard is unsafe:
 ;;     on the JVM `##Inf` / `1.0E20` THROW and `##NaN` truncates to a real
-;;     value, while CLJS would silently coerce. The fix routes both hosts
+;;     value, while CLJS would silently coerce. Both hosts route
 ;;     through one safe-integer-windowed guard so out-of-domain numerics
 ;;     DEFAULT (never crash, never become a real value) IDENTICALLY. These
 ;;     CLJS assertions mirror the JVM ones in args_test / cap_test.

--- a/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.cursor-test
-  "Tests for the shared cursor-pagination machinery (rf2-ee38b.19).
+  "Tests for the shared cursor-pagination machinery.
   The base64 codec, the EDN-read-with-tagged-literal-rejection, the
   `::malformed` recovery contract, the `:limit` clamp, and the
   `cursor-stale-result` envelope are the cross-MCP pieces both servers
@@ -75,14 +75,13 @@
            (cursor/decode-cursor (cursor/encode-cursor {:wrong :shape}) offset-cursor?)))))
 
 (deftest decode-cursor-non-map-edn-is-malformed-without-consulting-predicate
-  ;; Coverage gap (rf2-ynjts.17): a cursor that base64+EDN-decodes to a
-  ;; well-formed but NON-MAP value (`"5"` ⇒ 5, `"[1 2 3]"` ⇒ vector,
-  ;; `":kw"` ⇒ keyword) hits the `(map? v)` short-circuit in
-  ;; `decode-cursor` — `valid?` is never consulted. The existing tests
-  ;; only exercised a map that FAILS `valid?`; the non-map arm (where
-  ;; `valid?` would throw if called on, say, a number) had no pin. We
-  ;; pass a `valid?` that THROWS on non-map input to prove the guard
-  ;; runs first: a throw here would mean `valid?` was reached.
+  ;; A cursor that base64+EDN-decodes to a well-formed but NON-MAP
+  ;; value (`"5"` ⇒ 5, `"[1 2 3]"` ⇒ vector, `":kw"` ⇒ keyword) hits
+  ;; the `(map? v)` short-circuit in `decode-cursor` — `valid?` is
+  ;; never consulted. This pins the non-map arm (where `valid?` would
+  ;; throw if called on, say, a number): we pass a `valid?` that THROWS
+  ;; on non-map input to prove the guard runs first — a throw here
+  ;; would mean `valid?` was reached.
   (let [strict-map-pred (fn [m]
                           ;; would explode on a non-map if reached
                           (and (map? m) (pos? (count m))))
@@ -100,13 +99,13 @@
         "string EDN cursor ⇒ ::malformed")))
 
 (deftest decode-cursor-at-inclusive-size-boundary-is-not-rejected
-  ;; Coverage gap (rf2-ynjts.17): the size guard is a STRICT `>`
-  ;; (`(> (count s) max-cursor-bytes)` ⇒ ::malformed). The existing
-  ;; oversize test only feeds `(inc max-cursor-bytes)` chars — the
-  ;; over-limit side. The INCLUSIVE side (a real cursor whose token
-  ;; length is `<= max-cursor-bytes`) was never pinned. A regression
-  ;; that flipped the guard to `>=` would reject a legitimate at-or-near-
-  ;; cap cursor; this test trips on that flip.
+  ;; The size guard is a STRICT `>`
+  ;; (`(> (count s) max-cursor-bytes)` ⇒ ::malformed). This pins the
+  ;; INCLUSIVE side (a real cursor whose token length is
+  ;; `<= max-cursor-bytes`), complementing the oversize test that feeds
+  ;; `(inc max-cursor-bytes)` chars. A regression that flipped the guard
+  ;; to `>=` would reject a legitimate at-or-near-cap cursor; this test
+  ;; trips on that flip.
   ;;
   ;; Build the largest real, decodable cursor whose token length is
   ;; still `<= max-cursor-bytes` (grow the payload's `:sig` to the cap).
@@ -145,17 +144,17 @@
     (is (= ::cursor/malformed (cursor/decode-cursor evil-map offset-cursor?)))))
 
 (deftest decode-cursor-rejects-builtin-tags-inside-valid-map
-  ;; rf2-13wbe: the BUILT-IN EDN tags `#inst` / `#uuid` have registered
+  ;; The BUILT-IN EDN tags `#inst` / `#uuid` have registered
   ;; readers (`clojure.edn` / `cljs.reader` resolve them from
   ;; `*data-readers*` / the tag-table) and BYPASS the `:default`
-  ;; handler entirely. Before the fix they decoded to a host
+  ;; handler entirely. Without an override they would decode to a host
   ;; `java.util.Date` / `UUID` (JVM) / `js/Date` / `cljs.core/UUID`
   ;; (CLJS), smuggling a host object through the cursor boundary inside
   ;; an OTHERWISE-VALID payload map. Pair-mcp's predicate is permissive
   ;; (`some? :after-id`), so the tagged value would survive validation
   ;; instead of being treated as malformed.
   ;;
-  ;; The `:readers` overrides now throw on `#inst` / `#uuid`, so EVERY
+  ;; The `:readers` overrides throw on `#inst` / `#uuid`, so EVERY
   ;; tag is rejected. Covered for both a story-style strict predicate
   ;; and a pair-style permissive predicate; both expect ::malformed.
   (let [permissive? (fn [m] (and (map? m) (some? (:after-id m))))
@@ -181,14 +180,13 @@
                                    permissive?))))))
 
 (deftest decode-cursor-rejects-trailing-forms
-  ;; rf2-ykv9a0 — a cursor is ONE opaque EDN payload map. Before the fix
-  ;; `read-edn-no-tags` used `read-string`, which reads only the FIRST
-  ;; form and never checks the input is exhausted: a token whose decoded
-  ;; text is a valid map FOLLOWED by a second form decoded as the valid
-  ;; map, silently IGNORING the trailing object — accepting mutated
-  ;; multi-form cursor text and weakening the opacity / corruption guard.
-  ;; The reader now requires the decoded text to be exactly one form;
-  ;; any trailing form ⇒ ::malformed.
+  ;; A cursor is ONE opaque EDN payload map. A plain `read-string`
+  ;; reads only the FIRST form and never checks the input is exhausted:
+  ;; a token whose decoded text is a valid map FOLLOWED by a second form
+  ;; would decode as the valid map, silently IGNORING the trailing
+  ;; object — accepting mutated multi-form cursor text and weakening the
+  ;; opacity / corruption guard. `read-edn-no-tags` requires the decoded
+  ;; text to be exactly one form; any trailing form ⇒ ::malformed.
   (testing "valid map + trailing #inst ⇒ ::malformed (not the silently-accepted first form)"
     (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"} #inst \"2024-01-01\"")]
       (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
@@ -201,11 +199,11 @@
   (testing "valid map + trailing scalar ⇒ ::malformed"
     (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"} 42")]
       (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
-  ;; rf2-rtg9t1 — `]`-injection. The earlier wrap-in-`[…]` guard accepted
-  ;; a ONE-element vector; attacker text `{…}] <junk>` wraps to
-  ;; `[{…}] <junk>]` where the injected `]` closes the wrapper EARLY, so
-  ;; `read-string` reads the clean 1-element vector `[{…}]` and silently
-  ;; discards the trailing junk → the cursor was ACCEPTED. The
+  ;; `]`-injection. A naive wrap-in-`[…]` guard that accepted a
+  ;; ONE-element vector would be bypassable: attacker text `{…}] <junk>`
+  ;; wraps to `[{…}] <junk>]` where the injected `]` closes the wrapper
+  ;; EARLY, so `read-string` reads the clean 1-element vector `[{…}]`
+  ;; and silently discards the trailing junk → the cursor accepted. The
   ;; EOF-sentinel exhaustion check rejects it: the injected `]` truncates
   ;; the read before the appended sentinel, so the result no longer ends
   ;; with the sentinel ⇒ ::malformed.

--- a/tools/mcp-base/test/re_frame/mcp_base/dedup_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/dedup_test.clj
@@ -1,7 +1,7 @@
 (ns re-frame.mcp-base.dedup-test
-  "Tests for the lifted wire-boundary dedup encode step (rf2-ttspi7).
+  "Tests for the shared wire-boundary dedup encode step.
 
-  Pins the byte-identical forward direction both MCP servers now
+  Pins the byte-identical forward direction both MCP servers
   delegate to: the `empty-payload?` short-circuit, the cross-MCP wrap
   shape, the opt-out, and round-trip exactness via `de-dupe.core/expand`
   (the inverse the agent host calls — NOT a base surface)."

--- a/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.mcp-base.descriptor-manifest-test
   "Tests for the shared MCP tool-descriptor manifest serialiser +
-  drift-check (rf2-sofwv). The serialiser is consumed by BOTH MCP
+  drift-check. The serialiser is consumed by BOTH MCP
   servers' generators; this corpus pins its determinism + diff
   semantics on the JVM (the algorithm is platform-agnostic `.cljc`)."
   (:require [clojure.edn :as edn]
@@ -12,7 +12,7 @@
   "Two descriptors in the on-the-registry shape both servers emit —
   story-mcp lifts :outputSchema/:annotations via cond->, pair-mcp
   declares them per-tool, but the slot SHAPE is identical. Both carry
-  `:required` (inside :inputSchema) + `:typicalTokens` (rf2-cwhod2) so
+  `:required` (inside :inputSchema) + `:typicalTokens` so
   the corpus exercises every governed slot."
   [{:name        "beta"
     :description "Second tool."
@@ -46,7 +46,7 @@
     (is (= 600 (:typicalTokens row)) "typicalTokens passed through verbatim")))
 
 (deftest descriptor->row-projects-required-and-typical-tokens
-  ;; rf2-cwhod2: the two live facets the original narrow projection missed.
+  ;; The two live API-semantics facets: :required + :typicalTokens.
   (let [row (dm/descriptor->row (second sample-descriptors))] ; alpha
     (is (= ["event"] (:input-keys row)))
     (is (= ["event"] (:required row)) ":required projects the mandatory input subset")
@@ -114,7 +114,7 @@
         "rows sorted by name regardless of input order")))
 
 ;; ---------------------------------------------------------------------------
-;; Gated-input profiles (rf2-qo3wvp)
+;; Gated-input profiles
 ;;
 ;; A descriptor input key can sit on a PRIVILEGED (gate-open) `tools/list`
 ;; profile yet be stripped from the DEFAULT one by an operator-only gate
@@ -148,9 +148,8 @@
         ":gated-input-keys names the default-stripped subset")))
 
 (deftest default-vs-gate-open-surfaces-are-derivable
-  ;; The bead's core requirement: the default profile excludes
-  ;; include-sensitive; the gate-open profile includes it. Both are
-  ;; derivable from one byte-stable row.
+  ;; The default profile excludes include-sensitive; the gate-open
+  ;; profile includes it. Both are derivable from one byte-stable row.
   (let [row          (dm/descriptor->row gated-descriptor #{"include-sensitive"})
         gate-open    (:input-keys row)
         default-surf (remove (set (:gated-input-keys row)) gate-open)]
@@ -230,12 +229,12 @@
     (is (= :test (-> parsed :meta :server)))
     (is (= 2 (-> parsed :meta :tool-count)))
     (is (= ["alpha" "beta"] (mapv :name (:tools parsed))))
-    ;; rf2-cwhod2: the new facets survive the EDN round-trip.
+    ;; The :required + :typicalTokens facets survive the EDN round-trip.
     (is (= ["event"] (:required (by-name "alpha"))))
     (is (= [] (:required (by-name "beta"))))
     (is (= 300 (:typicalTokens (by-name "alpha"))))
     (is (= 600 (:typicalTokens (by-name "beta"))))
-    ;; rf2-qo3wvp: the gated-input slot survives + renders uniformly.
+    ;; The gated-input slot survives + renders uniformly.
     (is (= [] (:gated-input-keys (by-name "alpha"))) "empty gated slot round-trips")
     (is (= [] (:gated-input-keys (by-name "beta"))))))
 
@@ -299,11 +298,12 @@
       (is (= ["beta"] (:removed res)) "beta was dropped"))))
 
 (deftest check-detects-changed-existing-tool
-  ;; rf2-y3qpv: when an EXISTING tool's catalogue row drifts (here alpha
-  ;; gains an input key) the identity sets stay empty — neither :added
-  ;; nor :removed names it. The CI guard previously went red with no
-  ;; row-level identity of WHAT changed, forcing a manual whole-manifest
-  ;; diff. `:changed` now names the drifted tool and carries old/new rows.
+  ;; When an EXISTING tool's catalogue row drifts (here alpha gains an
+  ;; input key) the identity sets stay empty — neither :added nor
+  ;; :removed names it. Without a row-level diff the CI guard would go
+  ;; red with no identity of WHAT changed, forcing a manual
+  ;; whole-manifest diff. `:changed` names the drifted tool and carries
+  ;; old/new rows.
   (testing "an existing tool that gains an input key is :changed, not :added/:removed"
     (let [committed-m   (dm/build-manifest :test sample-descriptors)
           committed-edn (dm/render-edn committed-m)
@@ -328,8 +328,8 @@
   ;; Every catalogue-surface slot the manifest governs trips :changed in
   ;; isolation (description / output? / annotations / required /
   ;; typicalTokens, plus the input-keys case above). One row mutated per
-  ;; case; beta untouched. rf2-cwhod2 added the :required + :typicalTokens
-  ;; cases — the live API-semantics facets the original gate missed.
+  ;; case; beta untouched. The :required + :typicalTokens cases cover
+  ;; the live API-semantics facets alongside the others.
   (let [base (second sample-descriptors)] ; alpha
     (doseq [[label mutate] [["description"   #(assoc % :description "Changed prose.")]
                             ["output?"       #(assoc % :outputSchema {:type "object"})]

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.mcp-base.diff-encode-test
   "Tests for the path-keyed structural diff used at the MCP wire
-  boundary (rf2-1wdzp, shared across both servers via rf2-vw4sq)."
+  boundary, shared across both servers."
   (:require [clojure.string]
             [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
@@ -38,7 +38,7 @@
          (de/collect-patches {:a {:b 1}} {:a [1 2 3]} []))))
 
 ;; ---------------------------------------------------------------------------
-;; collect-patches — same-length vectors diff structurally (rf2-cwhod2).
+;; collect-patches — same-length vectors diff structurally.
 ;; ---------------------------------------------------------------------------
 
 (deftest collect-patches-diffs-vector-element-map-update
@@ -102,7 +102,7 @@
       (is (= b (de/apply-patches a p))))))
 
 (deftest apply-patches-round-trips-vector-diffs
-  ;; rf2-cwhod2: every same-length-vector diff shape round-trips through
+  ;; Every same-length-vector diff shape round-trips through
   ;; the existing assoc-in replay (integer index paths), and every
   ;; length-change whole-leaf replacement does too.
   (doseq [[label a b]
@@ -125,7 +125,7 @@
   (is (= {:a 1} (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]]))))
 
 (deftest apply-patches-applies-in-order-for-same-path
-  ;; Regression pin (rf2-cwqc8 / round-2 F18): when two patches target
+  ;; Regression pin: when two patches target
   ;; the same path, the later one wins — `reduce` over the patch
   ;; sequence applies them in order so a later `:assoc` overrides an
   ;; earlier one, and a `:dissoc` after an `:assoc` clears the value.
@@ -147,7 +147,7 @@
                                      [[:a] :assoc 7]])))))
 
 (deftest apply-patches-nested-dissoc-missing-or-scalar-parent-is-noop
-  ;; rf2-ykv9a0 — `[<path> :dissoc]` is a no-op when the key does not
+  ;; `[<path> :dissoc]` is a no-op when the key does not
   ;; exist (per the spec). The naive `(update-in acc parent dissoc k)`
   ;; violated this: a MISSING parent manufactured nil branches, and a
   ;; SCALAR parent threw a host ClassCastException at the decoder
@@ -171,7 +171,7 @@
     (is (= {:a 1} (de/apply-patches {:a 1} [[[:z] :dissoc]])))))
 
 (deftest apply-patches-nested-assoc-into-scalar-parent-is-structured-error
-  ;; rf2-glybzz — the `:assoc` PEER of the rf2-ykv9a0 dissoc guard.
+  ;; The `:assoc` PEER of the dissoc guard.
   ;; A grammar-valid patch like `[[[:a :b] :assoc 2]]` against base
   ;; `{:a 1}` used to delegate straight to `assoc-in`, which throws a
   ;; raw host `ClassCastException` with nil ex-data at the wire decoder
@@ -236,7 +236,7 @@
     (is (= {:y 9} (de/apply-patches {:x 1} [[[] :assoc {:y 9}]])))))
 
 (deftest decode-db-after-nested-assoc-mismatched-base-is-structured-error
-  ;; rf2-glybzz — the same guard reached via the section-decoder hot
+  ;; The same guard reached via the section-decoder hot
   ;; path. `decode-db-after` replays through the non-validating
   ;; `apply-patches*`; a section whose `:patches` assoc into a path that
   ;; is non-associative in THIS record's `:db-before` (a corrupt /
@@ -268,8 +268,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest diff-encode-db-after-emits-sections-shape
-  ;; rf2-qeous: the encoder now emits path-headed cluster sections
-  ;; instead of a flat patch list.
+  ;; The encoder emits path-headed cluster sections, not a flat patch
+  ;; list.
   (let [epoch    {:db-before {:a 1 :b 2}
                   :db-after  {:a 1 :b 3}}
         encoded  (de/diff-encode-db-after epoch)
@@ -283,7 +283,7 @@
       (is (= [[[:b] :assoc 3]] (:patches s))))))
 
 (deftest diff-encode-db-after-classifies-modified-not-false-added
-  ;; rf2-ykv9a0 — the encoder threads :db-before into section
+  ;; The encoder threads :db-before into section
   ;; classification so an all-:assoc direct-child cluster is :added ONLY
   ;; when its container was genuinely absent before. Patch shape alone
   ;; can't tell an insert from a change (both are :assoc), so an existing
@@ -381,7 +381,7 @@
             "non-:db-after fields unchanged on decode")))))
 
 ;; ---------------------------------------------------------------------------
-;; Patch grammar — Malli schema pin (rf2-rgg7d).
+;; Patch grammar — Malli schema pin.
 ;;
 ;; The schema is published as `de/patch-schema` (single tuple) and
 ;; `de/patches-schema` (sequential of tuples). The encoder boundary
@@ -609,20 +609,20 @@
           (is (= 0 (:bad-index data))))))))
 
 ;; ---------------------------------------------------------------------------
-;; Decoder-boundary validation (rf2-8e61v / F17).
+;; Decoder-boundary validation.
 ;;
 ;; `apply-patches` is the wire-decoder entry point. A malformed patch
-;; reaching this fn is a contract violation — the previous behaviour
-;; silently no-op'd on the offending tuple (fell through the `cond` to
-;; `:else acc` and dropped the corrupted patch without a peep). Mirror
-;; the encoder boundary's gate: validate against `patches-schema` and
-;; throw `:rf.error/bad-diff-patches`.
+;; reaching this fn is a contract violation. The gate mirrors the
+;; encoder boundary's: validate against `patches-schema` and throw
+;; `:rf.error/bad-diff-patches`. Without it the offending tuple would
+;; silently no-op (fall through the `cond` to `:else acc` and drop the
+;; corrupted patch without a peep).
 ;; ---------------------------------------------------------------------------
 
 (deftest apply-patches-rejects-malformed-tuples
   (testing "missing op (2-element tuple with no op) throws"
-    ;; Pre-fix: silently no-op'd because the destructure put `nil` in
-    ;; `op` and the cond fell through to `:else acc`. Post-fix: the
+    ;; Without the gate this would silently no-op: the destructure puts
+    ;; `nil` in `op` and the cond falls through to `:else acc`. The
     ;; validate-patches! gate trips on the malformed tuple BEFORE the
     ;; reduce starts.
     (is (thrown-with-msg?
@@ -663,19 +663,15 @@
   (is (= {:a 1} (de/apply-patches {:a 1} []))))
 
 ;; ---------------------------------------------------------------------------
-;; Decoder-boundary SECTION validation (rf2-j6oay / rf2-80y2h).
+;; Decoder-boundary SECTION validation.
 ;;
 ;; `decode-db-after` validates the `:sections` vector via
 ;; `validate-sections!` BEFORE flattening + replaying — encoder/decoder
-;; symmetry per the rf2-8e61v argument. The encoder boundary
-;; (`diff-encode-db-after`) was tested negatively
-;; (`diff-encode-db-after-emits-schema-conformant-sections` +
-;; `validate-patches!` direct), and `validate-sections!` was tested
-;; only positively (it never throws on a real encode). This pins the
-;; SYMMETRIC decode-side gate: a marker carrying malformed `:sections`
-;; reaching `decode-db-after` MUST throw `:rf.error/bad-diff-sections`
-;; rather than slip cosmetic `:section-kind` / `:section-path` slots
-;; through to an agent-host UI that paints them as truth.
+;; symmetry. This pins the SYMMETRIC decode-side gate: a marker carrying
+;; malformed `:sections` reaching `decode-db-after` MUST throw
+;; `:rf.error/bad-diff-sections` rather than slip cosmetic
+;; `:section-kind` / `:section-path` slots through to an agent-host UI
+;; that paints them as truth.
 ;; ---------------------------------------------------------------------------
 
 (deftest decode-db-after-rejects-malformed-sections
@@ -726,17 +722,18 @@
               "ex-info names the DECODE-side boundary, not the encoder (rf2-4ypau)"))))))
 
 (deftest decode-db-after-rejects-malformed-sections-slot
-  ;; rf2-y3qpv: a diff marker whose `:sections` slot is `nil` or `false`
-  ;; previously decoded to a no-op via `(or sections [])` — an empty seq
-  ;; satisfies `[:sequential section-schema]`, so the gate never tripped
-  ;; and the epoch's real `:db-after` change was silently ERASED back to
-  ;; `:db-before`. The raw slot is now validated, so a PRESENT non-sequential
-  ;; `:sections` trips `:rf.error/bad-diff-sections` (Malli present).
-  ;; `:db-before` carries a real change so a regression (silent no-op) would
-  ;; observably hand back `{:a 1}` instead of throwing.
+  ;; A diff marker whose `:sections` slot is `nil` or `false` must not
+  ;; decode to a no-op. Coercing it via `(or sections [])` would let an
+  ;; empty seq satisfy `[:sequential section-schema]`, so the gate would
+  ;; never trip and the epoch's real `:db-after` change would be silently
+  ;; ERASED back to `:db-before`. The raw slot is validated, so a PRESENT
+  ;; non-sequential `:sections` trips `:rf.error/bad-diff-sections`
+  ;; (Malli present). `:db-before` carries a real change so a regression
+  ;; (silent no-op) would observably hand back `{:a 1}` instead of
+  ;; throwing.
   ;;
-  ;; rf2-71kxvb: a MISSING `:sections` key is now a marker-BODY shape
-  ;; violation (the closed two-key contract), so it trips the structural
+  ;; A MISSING `:sections` key is a marker-BODY shape violation (the
+  ;; closed two-key contract), so it trips the structural
   ;; `:rf.error/bad-diff-marker` gate FIRST (see
   ;; `decode-db-after-rejects-malformed-marker-body`). A PRESENT-but-falsey
   ;; `:sections` still satisfies the closed key set, so the body gate passes
@@ -769,15 +766,17 @@
           (is (= 'mcp-base/decode-db-after (:where (ex-data e)))))))))
 
 (deftest decode-db-after-rejects-malformed-marker-body
-  ;; rf2-71kxvb — the decoder recognizes a diff marker on the PRESENCE of
+  ;; The decoder recognizes a diff marker on the PRESENCE of
   ;; the `:rf.mcp/diff-from` key (intent), then enforces the CLOSED
   ;; marker-body contract (mcp-conformance `DiffFromBody`): EXACTLY
   ;; `{:rf.mcp/diff-from :db-before, :sections [...]}` — two top-level keys,
   ;; the marker value restricted to `:db-before`. A pure STRUCTURAL gate
-  ;; (no Malli), so it fires regardless of Malli presence. Previously:
-  ;;   - an extra sibling key slipped past (only `:sections` was checked);
-  ;;   - an unsupported marker value was treated as 'not a diff' and passed
-  ;;     THROUGH unchanged, letting a corrupt/third-party marker survive.
+  ;; (no Malli), so it fires regardless of Malli presence. It closes two
+  ;; cases a `:sections`-only check would miss:
+  ;;   - an extra sibling key would slip past (only `:sections` checked);
+  ;;   - an unsupported marker value would be treated as 'not a diff' and
+  ;;     pass THROUGH unchanged, letting a corrupt/third-party marker
+  ;;     survive.
   (testing "an extra sibling top-level key rejects (closed two-key contract)"
     (let [epoch {:db-before {:a 1}
                  :db-after  {:rf.mcp/diff-from :db-before
@@ -832,7 +831,7 @@
       (is (= epoch (de/decode-db-after epoch))))))
 
 (deftest decode-db-after-explicit-empty-sections-is-valid-no-change
-  ;; rf2-y3qpv companion: an EXPLICIT `:sections []` is a legitimate
+  ;; Companion: an EXPLICIT `:sections []` is a legitimate
   ;; no-change diff (db-before == db-after) and MUST still validate and
   ;; replay to `:db-before` unchanged — the gate guards malformed shape,
   ;; it does not reject a real empty diff.

--- a/tools/mcp-base/test/re_frame/mcp_base/elision_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/elision_test.clj
@@ -1,10 +1,10 @@
 (ns re-frame.mcp-base.elision-test
-  "Pins the elision-marker walker (rf2-9fz64). The walker counts every
+  "Pins the elision-marker walker. The walker counts every
   `{:rf.size/large-elided ...}` marker in a wire-bound payload — the
   count rides the response envelope as the `:elided-large` slot
-  (Conventions §Cross-MCP indicator-field vocabulary, MUST-level per
-  rf2-2499j). A regression here is a drift in the envelope's elision-
-  indicator parity with `:dropped-sensitive`."
+  (Conventions §Cross-MCP indicator-field vocabulary, MUST-level).
+  A regression here is a drift in the envelope's elision-indicator
+  parity with `:dropped-sensitive`."
   (:require [clojure.test :refer [deftest is]]
             [re-frame.mcp-base.elision :as elision]))
 
@@ -55,10 +55,10 @@
           "Marker body is opaque; nested marker-shape isn't double-counted."))))
 
 (deftest count-elided-markers-handles-lazy-seq-input
-  ;; Mirror sensitive_test.clj's lazy-seq pin (rf2-cwqc8 / round-2 F17).
+  ;; Mirror sensitive_test.clj's lazy-seq pin.
   ;; The walker accepts `seq?` per `elision.cljc` so a slice composed via
   ;; `concat` / `map` / `filter` (lazy seqs) must count the same as the
-  ;; equivalent vector. Regression pin for rf2-jj46n / F20.
+  ;; equivalent vector.
   (let [marker {:rf.size/large-elided
                 {:path   [:user :pdf]
                  :bytes  102400

--- a/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.envelope-test
-  "Tests for the shared response-envelope helpers (rf2-ee38b.19) —
+  "Tests for the shared response-envelope helpers —
   the indicator-field 'omit when zero' splice and the wire-bounded
   marker detection."
   (:require [clojure.test :refer [deftest is testing]]
@@ -63,7 +63,7 @@
   (is (some #(= % "#:rf.mcp{:cache-hit") envelope/marker-prefixes)))
 
 (deftest marker-text?-only-matches-leading-marker-not-embedded-key
-  ;; Coverage gap (rf2-ynjts.17): `marker-text?` is `starts-with?`, not
+  ;; `marker-text?` is `starts-with?`, not
   ;; `includes?` — the marker key must be the LEADING top-level key for
   ;; the text to count as a boundary marker. The comment block in
   ;; envelope.cljc justifies the prefix-match precisely on this ground:
@@ -87,7 +87,7 @@
           "overflow key present but not the leading key ⇒ not a marker"))))
 
 (deftest marker-text?-empty-and-blank-strings-are-not-markers
-  ;; Boundary pin (rf2-ynjts.17): the empty string and whitespace are
+  ;; Boundary pin: the empty string and whitespace are
   ;; strings (so they pass the `string?` guard) but match no prefix.
   (is (false? (envelope/marker-text? "")))
   (is (false? (envelope/marker-text? "   ")))
@@ -107,13 +107,12 @@
     (is (true? (envelope/marker-text? "{:rf.mcp/cache-hit {:tool \"x\"}}")))))
 
 (deftest marker-text?-requires-exact-marker-key-not-prefix
-  ;; rf2-3xd9i9 regression: the detector matched on `starts-with?` of the
-  ;; marker-key PREFIX, so a LOOKALIKE leading key whose name merely
-  ;; begins with a real marker key (`:rf.mcp/overflowed`,
-  ;; `:rf.mcp/cache-hit-extra`) was wrongly classified as an already-
-  ;; bounded marker — letting an over-budget payload bypass cap
-  ;; enforcement. The fix requires the marker key to END exactly at the
-  ;; prefix (terminated by an EDN token terminator), so a strict
+  ;; A bare `starts-with?` of the marker-key PREFIX would classify a
+  ;; LOOKALIKE leading key whose name merely begins with a real marker
+  ;; key (`:rf.mcp/overflowed`, `:rf.mcp/cache-hit-extra`) as an
+  ;; already-bounded marker — letting an over-budget payload bypass cap
+  ;; enforcement. The detector requires the marker key to END exactly at
+  ;; the prefix (terminated by an EDN token terminator), so a strict
   ;; prefix-superset key is NOT a marker.
   (testing "strict prefix-superset of a marker key ⇒ NOT a marker (flat form)"
     (is (false? (envelope/marker-text? "{:rf.mcp/overflowed {:x 1}}"))
@@ -121,7 +120,7 @@
     (is (false? (envelope/marker-text? "{:rf.mcp/cache-hit-extra {:x 1}}"))
         "':rf.mcp/cache-hit-extra' merely starts with ':rf.mcp/cache-hit'")
     ;; A real payload over budget whose first key is a lookalike: the
-    ;; exact realistic cap-bypass shape the bead calls out.
+    ;; realistic cap-bypass shape this guard prevents.
     (is (false? (envelope/marker-text?
                   (pr-str (array-map :rf.mcp/overflowed {:limit :reached :token-count 9000}))))))
   (testing "strict prefix-superset of a marker key ⇒ NOT a marker (namespaced-map form)"

--- a/tools/mcp-base/test/re_frame/mcp_base/overflow_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/overflow_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.overflow-test
-  "Tests for the overflow-marker shape (rf2-rvyzy / rf2-vw4sq)."
+  "Tests for the overflow-marker shape."
   (:require [clojure.test :refer [deftest is]]
             [re-frame.mcp-base.overflow :as overflow]
             [re-frame.mcp-base.vocab :as vocab]))

--- a/tools/mcp-base/test/re_frame/mcp_base/section_grouping_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/section_grouping_test.clj
@@ -1,11 +1,10 @@
 (ns re-frame.mcp-base.section-grouping-test
   "Tests for the path-headed cluster projection used at the MCP wire
-  boundary (rf2-qeous). The pass takes the flat patch list produced
+  boundary. The pass takes the flat patch list produced
   by `re-frame.mcp-base.diff-encode/collect-patches` and projects it
   into N path-headed clusters — the same `sections-per-cluster`
-  decomposition Xray ships in its panel renderer (rf2-gfxmk Phase 1
-  of rf2-abts7), recast over patches so mcp-base stays free of the
-  xray dep."
+  decomposition Xray ships in its panel renderer, recast over patches
+  so mcp-base stays free of the xray dep."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.mcp-base.diff-encode :as de]
             [re-frame.mcp-base.section-grouping :as sg]))
@@ -99,7 +98,7 @@
         "raising the budget admits the previously-rejected coalescence")))
 
 ;; ---------------------------------------------------------------------------
-;; Worked examples — the three rf2-gfxmk cases recast over patches.
+;; Worked examples — the three Xray cluster cases recast over patches.
 ;; ---------------------------------------------------------------------------
 
 (deftest cart-cascade-projects-to-3-cart-and-non-cart-sections
@@ -155,7 +154,7 @@
     (is (= :removed (:section-kind (first sections))))))
 
 (deftest all-assoc-direct-children-classify-as-added-only-with-db-before-proof
-  ;; rf2-ykv9a0 — the patch grammar uses :assoc for BOTH inserted and
+  ;; The patch grammar uses :assoc for BOTH inserted and
   ;; changed leaves, so all-:assoc direct-child shape alone CANNOT prove
   ;; a container is newly added. `:added` is claimed only when :db-before
   ;; proves the container was absent.
@@ -175,7 +174,7 @@
           "existing [:user] whose direct children changed is a modification, not an addition"))))
 
 (deftest synthetic-direct-child-cluster-under-absent-container-classifies-as-added
-  ;; rf2-ykv9a0 — the genuine :added shape. An advanced consumer
+  ;; The genuine :added shape. An advanced consumer
   ;; supplies a synthetic patch list (NOT from collect-patches, which
   ;; emits a whole-subtree singleton for a brand-new key): direct-child
   ;; :assoc patches under a container that :db-before proves was absent.

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.mcp-base.sensitive-test
   "Tests for the spec/009 §Privacy default-suppress filter shared
-  across the MCP pair (rf2-vw4sq). The predicate and the filter
+  across the MCP pair. The predicate and the filter
   must stay byte-identical across re-frame2-pair-mcp and story-mcp
   — these tests pin the contract."
   (:require [clojure.string]
@@ -22,15 +22,15 @@
   (is (not (sensitive/sensitive-event? {:operation :rf.event/dispatched}))))
 
 (deftest sensitive-event?-non-true-truthy-drops-fail-closed
-  ;; Fail-closed (rf2-ih7g4): the literal `true` drops AND any
+  ;; Fail-closed: the literal `true` drops AND any
   ;; non-boolean truthy value drops too. The `:rf/trace-event` schema
   ;; types `:sensitive?` as a boolean; a string `"true"` or keyword
   ;; `:yes` is a contract violation that means an upstream
   ;; serialisation bug has coerced the boolean into the wrong shape.
-  ;; The previous fail-OPEN posture silently leaked sensitive events
-  ;; on such drift. The fix is fail-CLOSED: drop AND log.
+  ;; A fail-OPEN posture would silently leak sensitive events on such
+  ;; drift; fail-CLOSED drops AND logs.
   ;; The expected contract-drift WARN is quieted by the central quiet
-  ;; runner's stderr buffer (rf2-nrk066) — no local `*err*` sink needed;
+  ;; runner's stderr buffer — no local `*err*` sink needed;
   ;; it stays buffered on green and replays on red.
   (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? "true"}))
   (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? :yes}))
@@ -43,20 +43,20 @@
   (is (not (sensitive/sensitive-event? "anything"))))
 
 (deftest sensitive-event?-explicit-false-passes
-  ;; Fail-closed posture (rf2-ih7g4) does NOT change the explicit-false
+  ;; Fail-closed posture does NOT change the explicit-false
   ;; / nil path — those remain non-sensitive. Only truthy non-boolean
-  ;; values get the new fail-closed drop.
+  ;; values get the fail-closed drop.
   (is (not (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? false})))
   (is (not (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? nil}))))
 
 (deftest strip-sensitive-fail-closed-drops-malformed-truthy
-  ;; rf2-ih7g4: a transport bug that coerces `:sensitive? true` into
+  ;; A transport bug that coerces `:sensitive? true` into
   ;; `:sensitive? "true"` (string) or `:sensitive? :yes` (keyword) MUST
   ;; NOT silently leak the event. The fail-closed posture drops the
   ;; malformed-truthy event (with a stderr warning) so the contract
   ;; drift is visible to operators.
   ;; Expected WARN quieted by the central quiet-runner stderr buffer
-  ;; (rf2-nrk066) — no local `*err*` sink needed.
+  ;; — no local `*err*` sink needed.
   (let [evts [{:id 1 :sensitive? false}
               {:id 2 :sensitive? "true"} ; malformed-truthy → drop
               {:id 3}
@@ -171,7 +171,7 @@
            (get-in out [:rf/default :machines])))))
 
 (deftest scrub-snapshot-is-not-a-full-snapshot-projector
-  ;; rf2-cj75yv: a consumer must not mistake `scrub-snapshot` output for
+  ;; A consumer must not mistake `scrub-snapshot` output for
   ;; already-projected full-snapshot output. The function does ONE thing —
   ;; filter sensitive trace events out of :traces / :epochs — and leaves
   ;; the value-carrying slices (:app-db / :sub-cache / :machines) exactly
@@ -207,15 +207,14 @@
     (is (zero? dropped))))
 
 (deftest scrub-snapshot-non-map-frame-values-pass-through-untouched
-  ;; Coverage gap (rf2-ynjts.17): `scrub-snapshot`'s per-frame reduce-kv
-  ;; only scrubs a frame value when `(map? v)`; a non-map value rides
-  ;; the `:else v` arm untouched. The runtime snapshot is a map of
-  ;; frame-id → frame-map, but the helper is defensive against a slot
-  ;; whose value isn't a frame map (a scalar marker, a nil sentinel).
-  ;; That else-arm had ZERO executing coverage — a regression that
-  ;; mangled non-map slots (e.g. `(scrub-frame v)` unconditionally)
-  ;; would NPE/throw rather than pass through, and no test would catch
-  ;; it. Pin the leave-alone guarantee for every non-map shape.
+  ;; `scrub-snapshot`'s per-frame reduce-kv only scrubs a frame value
+  ;; when `(map? v)`; a non-map value rides the `:else v` arm untouched.
+  ;; The runtime snapshot is a map of frame-id → frame-map, but the
+  ;; helper is defensive against a slot whose value isn't a frame map
+  ;; (a scalar marker, a nil sentinel). This pins the leave-alone
+  ;; guarantee for every non-map shape, so a regression that mangled
+  ;; non-map slots (e.g. `(scrub-frame v)` unconditionally) and
+  ;; NPE'd/threw rather than passing through would be caught.
   (let [snap {:rf/default {:traces [{:id 1 :sensitive? true} {:id 2}]}
               :meta-count  7              ;; scalar — must survive verbatim
               :flag        :rf.size/large-elided ;; keyword — survives
@@ -232,13 +231,12 @@
     (is (= [1 2 3] (:listslot out)) "vector frame value untouched")))
 
 (deftest scrub-snapshot-frame-without-trace-or-epoch-slices-is-no-op
-  ;; Coverage gap (rf2-ynjts.17): `scrub-frame`'s `cond->` only updates
-  ;; `:traces` / `:epochs` when present. A frame map carrying NEITHER
-  ;; slice (an `:app-db`-only frame, or a frame whose only slices are
-  ;; the left-alone `:sub-cache` / `:machines`) must return byte-equal
-  ;; — the `cond->` falls through both clauses. The existing
-  ;; strip-from-traces test always carried at least one of the two
-  ;; slices, so the both-absent fall-through was never exercised.
+  ;; `scrub-frame`'s `cond->` only updates `:traces` / `:epochs` when
+  ;; present. A frame map carrying NEITHER slice (an `:app-db`-only
+  ;; frame, or a frame whose only slices are the left-alone
+  ;; `:sub-cache` / `:machines`) must return byte-equal — the `cond->`
+  ;; falls through both clauses. This exercises that both-absent
+  ;; fall-through.
   (let [snap {:rf/default {:app-db    {:user/name "ada"}
                            :sub-cache {:user/profile {:data "x"}}
                            :machines  {:auth {:state :idle}}}}
@@ -262,7 +260,7 @@
         "only-:epochs frame has its epoch slice scrubbed")))
 
 (deftest scrub-snapshot-handles-lazy-seq-slice-values
-  ;; Regression pin (rf2-cwqc8 / round-2 F17): `:traces` and `:epochs`
+  ;; Regression pin: `:traces` and `:epochs`
   ;; arrive as vectors in the typical runtime emission, but the
   ;; instrumentation API doesn't guarantee that — a slice composed via
   ;; `concat` / `map` / `filter` produces a lazy seq. The `(vec items)`
@@ -284,7 +282,7 @@
            (get-in out [:rf/default :epochs])))))
 
 (deftest scrub-snapshot-strip-fn-arity-delegates-to-custom-predicate
-  ;; rf2-zpmmr: the three-arity form admits a caller-supplied strip-fn
+  ;; The three-arity form admits a caller-supplied strip-fn
   ;; matching the `[items include?] => [kept dropped]` contract. Pin
   ;; the contract so a future refactor of the helper can't silently
   ;; drop the delegation.
@@ -298,19 +296,20 @@
     (is (= [{:id 1} {:id 3}] (get-in out [:rf/default :traces])))))
 
 ;; ---------------------------------------------------------------------------
-;; Slice-shape discipline + fail-closed for malformed slices (rf2-wm9kp
-;; Finding 2). `scrub-snapshot` USED to `(vec …)` any present `:traces` /
-;; `:epochs` value unconditionally — even non-sequential ones. That
-;; mangled the shape (`nil → []`, `"oops" → [\o \o …]`, a single event
-;; map → a vector of map-entries) AND, for a malformed single SENSITIVE
-;; event map, reported zero drops while carrying the secret straight
-;; through (fail-OPEN). The fix only normalises + scrubs a genuinely
-;; `sequential?` batch; non-sequential shapes pass through byte-identical,
-;; and a single sensitive-event map is DROPPED fail-closed.
+;; Slice-shape discipline + fail-closed for malformed slices.
+;; `scrub-snapshot` only normalises + scrubs a genuinely `sequential?`
+;; `:traces` / `:epochs` batch; non-sequential shapes pass through
+;; byte-identical, and a single sensitive-event map is DROPPED
+;; fail-closed. An unconditional `(vec …)` of any present value would
+;; mangle non-sequential shapes (`nil → []`, `"oops" → [\o \o …]`, a
+;; single event map → a vector of map-entries) AND, for a malformed
+;; single SENSITIVE event map, report zero drops while carrying the
+;; secret straight through (fail-OPEN) — which the `sequential?` guard
+;; prevents.
 ;; ---------------------------------------------------------------------------
 
 (deftest scrub-snapshot-nil-slice-passes-through-unchanged
-  ;; rf2-wm9kp F2 — a nil `:traces` / `:epochs` slice is not a batch; it
+  ;; A nil `:traces` / `:epochs` slice is not a batch; it
   ;; must survive as nil, not be coerced to `[]`.
   (let [snap {:rf/default {:traces nil :epochs nil}}
         [out dropped] (sensitive/scrub-snapshot snap false)]
@@ -322,7 +321,7 @@
         "nil :epochs survives as nil")))
 
 (deftest scrub-snapshot-scalar-slice-passes-through-unchanged
-  ;; rf2-wm9kp F2 — a scalar slice is not a batch.
+  ;; A scalar slice is not a batch.
   (let [snap {:rf/default {:traces 7 :epochs :marker}}
         [out dropped] (sensitive/scrub-snapshot snap false)]
     (is (zero? dropped))
@@ -330,8 +329,8 @@
     (is (= :marker (get-in out [:rf/default :epochs])))))
 
 (deftest scrub-snapshot-string-slice-passes-through-unchanged
-  ;; rf2-wm9kp F2 — a string is `seqable?` but NOT a trace-event batch.
-  ;; The old `(vec "oops")` produced `[\o \o \p \s]`.
+  ;; A string is `seqable?` but NOT a trace-event batch.
+  ;; An unconditional `(vec "oops")` would produce `[\o \o \p \s]`.
   (let [snap {:rf/default {:traces "oops"}}
         [out dropped] (sensitive/scrub-snapshot snap false)]
     (is (zero? dropped))
@@ -339,7 +338,7 @@
         "string slice survives verbatim (no char-vector mangle)")))
 
 (deftest scrub-snapshot-non-sensitive-single-map-slice-passes-through
-  ;; rf2-wm9kp F2 — a single (non-sensitive) event MAP is not a batch; it
+  ;; A single (non-sensitive) event MAP is not a batch; it
   ;; passes through byte-identical rather than becoming a vec of entries.
   (let [snap {:rf/default {:traces {:id 1 :op :something}}}
         [out dropped] (sensitive/scrub-snapshot snap false)]
@@ -348,11 +347,11 @@
         "non-sensitive single map survives verbatim (no entry-vec mangle)")))
 
 (deftest scrub-snapshot-sensitive-single-map-slice-dropped-fail-closed
-  ;; rf2-wm9kp F2 (the leak) — a single MAP slice that is itself a
-  ;; sensitive event must be DROPPED, not shipped raw. Pre-fix the
-  ;; unconditional `(vec …)` turned `{:id 1 :sensitive? true}` into
-  ;; `[[:id 1] [:sensitive? true]]`, reported zero drops, and carried the
-  ;; secret across the boundary. Fail-closed: drop + count.
+  ;; A single MAP slice that is itself a sensitive event must be
+  ;; DROPPED, not shipped raw. An unconditional `(vec …)` would turn
+  ;; `{:id 1 :sensitive? true}` into `[[:id 1] [:sensitive? true]]`,
+  ;; report zero drops, and carry the secret across the boundary.
+  ;; Fail-closed: drop + count.
   (let [snap {:rf/default {:traces {:id 1 :sensitive? true :payload "SECRET"}}}
         [out dropped] (sensitive/scrub-snapshot snap false)]
     (is (= 1 dropped) "the malformed sensitive single-map is counted as a drop")
@@ -363,8 +362,8 @@
         "no trace of the secret survives in the scrubbed snapshot")))
 
 (deftest scrub-snapshot-sensitive-single-map-epochs-dropped-fail-closed
-  ;; rf2-wm9kp F2 — the exact bead probe shape: nil `:traces` (passes
-  ;; through) + a malformed sensitive single-map `:epochs` (dropped).
+  ;; The probe shape: nil `:traces` (passes through) + a malformed
+  ;; sensitive single-map `:epochs` (dropped).
   (let [snap {:rf/default {:traces nil :epochs {:id 1 :sensitive? true}}}
         [out dropped] (sensitive/scrub-snapshot snap false)]
     (is (= 1 dropped))
@@ -373,9 +372,8 @@
         "sensitive single-map :epochs dropped fail-closed")))
 
 (deftest scrub-snapshot-sequential-batch-still-scrubbed
-  ;; rf2-wm9kp F2 — the legitimate path is unchanged: a vector batch is
-  ;; normalised + scrubbed. (Companion to the existing lazy-seq test which
-  ;; pins the seq case.)
+  ;; The legitimate path: a vector batch is normalised + scrubbed.
+  ;; (Companion to the lazy-seq test which pins the seq case.)
   (let [snap {:rf/default {:traces [{:id 1 :sensitive? true} {:id 2}]
                            :epochs [{:event-id :a :sensitive? true} {:event-id :b}]}}
         [out dropped] (sensitive/scrub-snapshot snap false)]
@@ -384,15 +382,14 @@
     (is (= [{:event-id :b}] (get-in out [:rf/default :epochs])))))
 
 ;; ---------------------------------------------------------------------------
-;; Single-map fail-closed branch routes through the caller-supplied strip-fn
-;; (rf2-li6y2.1). The rf2-wm9kp guard classified a single-map slice with the
-;; BASE `sensitive-event?` instead of the caller's `strip-fn`. So a single-map
-;; slice sensitive ONLY by a UNION signal the caller's predicate catches
-;; (re-frame2-pair-mcp's epoch rollup `:rf.epoch/sensitive? true`, carrying no
-;; unqualified `:sensitive?` stamp) slipped past the guard to the `:else` arm
-;; and shipped RAW with dropped=0 — the rf2-5613h leak class re-surfacing
-;; inside the rf2-wm9kp defensive guard. The single-map branch now classifies
-;; via the SAME strip-fn the sequential branch uses.
+;; Single-map fail-closed branch routes through the caller-supplied strip-fn.
+;; The single-map branch classifies via the SAME `strip-fn` the sequential
+;; branch uses, NOT the base `sensitive-event?`. Classifying with the base
+;; predicate instead would let a single-map slice sensitive ONLY by a UNION
+;; signal the caller's predicate catches (re-frame2-pair-mcp's epoch rollup
+;; `:rf.epoch/sensitive? true`, carrying no unqualified `:sensitive?` stamp)
+;; slip past the guard to the `:else` arm and ship RAW with dropped=0 —
+;; leaking past the defensive single-map guard.
 ;; ---------------------------------------------------------------------------
 
 ;; The pair-mcp UNION strip-fn (mirrors tools/re-frame2-pair-mcp
@@ -407,13 +404,13 @@
     [kept (- (count items) (count kept))]))
 
 (deftest scrub-snapshot-single-map-sensitive-by-union-signal-dropped
-  ;; rf2-li6y2.1 (the leak) — a single-MAP :epochs slice sensitive ONLY by
-  ;; the union signal (`:rf.epoch/sensitive? true`, NO unqualified
-  ;; `:sensitive?` stamp). Pre-fix the single-map branch hardcoded the base
-  ;; `sensitive-event?` (which returns false here — no `:sensitive?` stamp),
-  ;; so the slice fell to the `:else` arm and PASSED THROUGH RAW with
-  ;; dropped=0, leaking the secret. The branch now routes through the
-  ;; caller-supplied union strip-fn, so the union sensitivity is honoured.
+  ;; A single-MAP :epochs slice sensitive ONLY by the union signal
+  ;; (`:rf.epoch/sensitive? true`, NO unqualified `:sensitive?` stamp).
+  ;; Hardcoding the base `sensitive-event?` in the single-map branch
+  ;; (which returns false here — no `:sensitive?` stamp) would let the
+  ;; slice fall to the `:else` arm and PASS THROUGH RAW with dropped=0,
+  ;; leaking the secret. The branch routes through the caller-supplied
+  ;; union strip-fn, so the union sensitivity is honoured.
   (let [snap {:rf/default {:epochs {:rf.epoch/sensitive? true
                                     :event-id :auth/sign-in
                                     :secret "TOKEN_LEAK"}}}
@@ -432,10 +429,10 @@
     (is (not (clojure.string/includes? (pr-str out) "TRACE_LEAK")))))
 
 (deftest scrub-snapshot-single-map-not-sensitive-by-union-passes-through
-  ;; rf2-li6y2.1 — symmetric safety: a single-map slice the union strip-fn
+  ;; Symmetric safety: a single-map slice the union strip-fn
   ;; does NOT classify as sensitive (no `:sensitive?` stamp, no
   ;; `:rf.epoch/sensitive?` rollup) still passes through byte-identically.
-  ;; The fix must not over-drop benign single maps.
+  ;; The single-map branch must not over-drop benign single maps.
   (let [snap {:rf/default {:epochs {:event-id :ui/click :data 42}}}
         [out dropped] (sensitive/scrub-snapshot snap false union-strip)]
     (is (zero? dropped))
@@ -444,21 +441,20 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Malformed counter — operator-surface observability for the fail-
-;; closed gate (rf2-8cpsg / F19).
+;; closed gate.
 ;; ---------------------------------------------------------------------------
 
 (deftest malformed-count-increments-on-fail-closed-drop
-  ;; The fail-closed posture (rf2-ih7g4) drops a non-boolean truthy
+  ;; The fail-closed posture drops a non-boolean truthy
   ;; `:sensitive?` stamp AND increments a process-wide counter so
-  ;; operator surfaces can see the contract drift. Pre-fix, the
-  ;; counter was private and untestable; now `malformed-count` /
+  ;; operator surfaces can see the contract drift. `malformed-count` /
   ;; `reset-malformed-count!` are public so this regression pin
-  ;; exists.
+  ;; can read the gate's activity.
   (sensitive/reset-malformed-count!)
   (is (zero? (sensitive/malformed-count))
       "precondition: counter starts at zero after reset")
   ;; Expected WARNs quieted by the central quiet-runner stderr buffer
-  ;; (rf2-nrk066) — no local `*err*` sink needed.
+  ;; — no local `*err*` sink needed.
   (sensitive/sensitive-event? {:sensitive? "true"})
   (sensitive/sensitive-event? {:sensitive? :yes})
   (sensitive/sensitive-event? {:sensitive? 1})
@@ -475,7 +471,7 @@
 
 (deftest reset-malformed-count!-zeroes-the-counter
   ;; Expected WARN quieted by the central quiet-runner stderr buffer
-  ;; (rf2-nrk066) — no local `*err*` sink needed.
+  ;; — no local `*err*` sink needed.
   (sensitive/sensitive-event? {:sensitive? "true"})
   (is (pos? (sensitive/malformed-count))
       "precondition: a fail-closed drop has bumped the counter")
@@ -485,21 +481,20 @@
       "reset zeroes the counter for the next test"))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-el9sw — the malformed-stamp diagnostic must not LEAK and must not
+;; The malformed-stamp diagnostic must not LEAK and must not
 ;; OVERCOUNT. Logs are an egress boundary on this privacy surface: a
 ;; malformed truthy `:sensitive?` stamp is wire-adjacent, untrusted data,
 ;; and a serialisation bug could carry a secret in it. The fail-closed
 ;; posture drops the event from MCP output; the diagnostic must NOT then
 ;; re-leak the value across the log boundary, and the malformed counter
 ;; must be a faithful PER-EVENT metric (one bump per dropped malformed
-;; event), not a scan-strategy-dependent over-count. Subsumes rf2-lxm3e
-;; (leak) and rf2-5uqwa (over-count).
+;; event), not a scan-strategy-dependent over-count.
 ;; ---------------------------------------------------------------------------
 
 (deftest malformed-warning-redacts-raw-stamp-value
-  ;; rf2-el9sw / rf2-lxm3e: the contract-drift warning must carry a
-  ;; value-free type tag + a fixed `:rf/redacted` sentinel — NEVER the
-  ;; raw stamp, which could be a secret-bearing string / map / vector.
+  ;; The contract-drift warning must carry a value-free type tag + a
+  ;; fixed `:rf/redacted` sentinel — NEVER the raw stamp, which could
+  ;; be a secret-bearing string / map / vector.
   (sensitive/reset-malformed-count!)
   (doseq [[stamp leak-needle] [["sk_live_SECRET_TOKEN_abc123" "sk_live_SECRET_TOKEN_abc123"]
                                [:secret/api-key-VALUE          "api-key-VALUE"]
@@ -521,14 +516,14 @@
   (sensitive/reset-malformed-count!))
 
 (deftest strip-sensitive-malformed-count-is-exactly-one-per-event
-  ;; rf2-el9sw / rf2-5uqwa: `sensitive-event?` is side-effecting on the
-  ;; malformed path (bump + log). The OLD `strip-sensitive` ran the
-  ;; predicate twice per event (`some` pre-scan + `filterv` drop-scan),
-  ;; so a single malformed event bumped the counter ~2×. The single-pass
-  ;; classifier fixes this: each event is classified exactly once, so the
-  ;; counter is a faithful per-event metric.
+  ;; `sensitive-event?` is side-effecting on the malformed path
+  ;; (bump + log). The single-pass classifier classifies each event
+  ;; exactly once, so the counter is a faithful per-event metric. A
+  ;; two-pass shape (`some` pre-scan + `filterv` drop-scan) would run
+  ;; the predicate twice per event and bump the counter ~2× per
+  ;; malformed event.
   ;; Expected WARNs quieted by the central quiet-runner stderr buffer
-  ;; (rf2-nrk066) — no local `*err*` sink needed.
+  ;; — no local `*err*` sink needed.
   (sensitive/reset-malformed-count!)
   (let [evts          [{:id 1 :sensitive? false}
                        {:id 2 :sensitive? "true"} ; malformed → drop, bump 1
@@ -543,9 +538,8 @@
   (sensitive/reset-malformed-count!))
 
 (deftest strip-sensitive-malformed-warning-emitted-once-per-event
-  ;; rf2-el9sw / rf2-lxm3e: the over-count bug also doubled the WARNING.
   ;; One malformed event ⇒ exactly one warning line on stderr through
-  ;; `strip-sensitive` (single-pass classification).
+  ;; `strip-sensitive` (single-pass classification) — no double-log.
   (sensitive/reset-malformed-count!)
   (let [sw (java.io.StringWriter.)]
     (binding [*err* sw]
@@ -559,12 +553,12 @@
   (sensitive/reset-malformed-count!))
 
 (deftest scrub-snapshot-malformed-count-is-exactly-one-per-event
-  ;; rf2-el9sw / rf2-5uqwa: `scrub-snapshot` delegates each slice to
+  ;; `scrub-snapshot` delegates each slice to
   ;; `strip-sensitive`, so the per-event count guarantee must hold
   ;; through the snapshot scrubber too — one malformed trace event in a
   ;; `:traces` slice bumps the counter exactly once.
   ;; Expected WARNs quieted by the central quiet-runner stderr buffer
-  ;; (rf2-nrk066) — no local `*err*` sink needed.
+  ;; — no local `*err*` sink needed.
   (sensitive/reset-malformed-count!)
   (let [snap {:rf/default {:traces [{:id 1 :sensitive? "true"}  ; malformed → 1 bump
                                     {:id 2}]
@@ -576,9 +570,9 @@
   (sensitive/reset-malformed-count!))
 
 (deftest strip-sensitive-no-drop-preserves-identity
-  ;; rf2-el9sw: the single-pass rewrite must keep the rf2-0q30r fast-path
-  ;; identity guarantee — when nothing drops, return the ORIGINAL vector
-  ;; (no fresh allocation).
+  ;; The single-pass classifier keeps the fast-path identity guarantee
+  ;; — when nothing drops, return the ORIGINAL vector (no fresh
+  ;; allocation).
   (let [evts [{:id 1} {:id 2 :sensitive? false} {:id 3}]
         [kept dropped] (sensitive/strip-sensitive evts false)]
     (is (identical? evts kept)
@@ -593,7 +587,7 @@
   ;; existing tests — those only exercise the 2-arity form's outputs
   ;; against trace-event-stamp inputs, never the parity-with-3-arity
   ;; contract directly. Pin it: the 2-arity output MUST equal the
-  ;; 3-arity call with `strip-sensitive` explicit (rf2-jj46n / F21).
+  ;; 3-arity call with `strip-sensitive` explicit.
   (let [snap {:rf/default
               {:traces [{:id 1 :sensitive? false}
                         {:id 2 :sensitive? true}

--- a/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.mcp-base.vocab-test
-  "Pins the wire-vocabulary constants (rf2-vw4sq). The marker keys are
+  "Pins the wire-vocabulary constants. The marker keys are
   the cross-MCP convention that an agent learns once — a rename here
   is a wire-protocol break. These tests fail loud when that happens."
   (:require [clojure.test :refer [deftest is]]
@@ -12,12 +12,11 @@
   (is (= :rf.mcp/cursor-stale  vocab/cursor-stale-reason))
   (is (= :rf.mcp/cache-hit     vocab/cache-hit-key))
   (is (= :rf.mcp/summary       vocab/summary-key))
-  ;; rf2-y3qpv: the test stopped at :summary and omitted these two
-  ;; reserved wire-vocabulary markers, so a rename could slip past the
-  ;; base unit gate. :rf.mcp/invalid-arg is the per-call arg-rejection
-  ;; wrapper (rf2-5rdit); :rf.mcp/result is the wire-fidelity typed
-  ;; eval/handler result envelope (rf2-qobqy) that pair-mcp actively
-  ;; emits — both are cross-MCP convention an agent learns once.
+  ;; These two reserved wire-vocabulary markers are pinned too, so a
+  ;; rename cannot slip past the base unit gate. :rf.mcp/invalid-arg is
+  ;; the per-call arg-rejection wrapper; :rf.mcp/result is the
+  ;; wire-fidelity typed eval/handler result envelope that pair-mcp
+  ;; actively emits — both are cross-MCP convention an agent learns once.
   (is (= :rf.mcp/invalid-arg   vocab/invalid-arg-key))
   (is (= :rf.mcp/result        vocab/result-key)))
 
@@ -32,7 +31,7 @@
 
 (deftest envelope-indicator-slots-pinned
   ;; Cross-MCP indicator-field vocabulary per Conventions §Cross-MCP
-  ;; indicator-field vocabulary (rf2-2499j). The two slots are
+  ;; indicator-field vocabulary. The two slots are
   ;; **unqualified** — they ride the tool's own envelope, not under a
   ;; reserved namespace. A drift to `:rf.size/elided-large` or
   ;; `:elided-large?` is a wire-protocol break.

--- a/tools/mcp-conformance/lib/dedup-envelope.cjs
+++ b/tools/mcp-conformance/lib/dedup-envelope.cjs
@@ -1,4 +1,4 @@
-// Wire-side decoder for the `:rf.mcp/dedup-table` envelope (rf2-90eft).
+// Wire-side decoder for the `:rf.mcp/dedup-table` envelope.
 //
 // ## Why this lives here
 //
@@ -12,13 +12,13 @@
 // reconstructed payload is what user code sees.
 //
 // The conformance harness drives the servers from Node, so it does
-// not have `de-dupe.core/expand` reachable. Per the rf2-90eft
-// post-mortem (CI run 26403312986), the story-mcp end-to-end test
-// asserted `:lifecycle` at the top level of `:structuredContent` —
-// a SEMANTIC contract — but the literal JSON shape after dedup wraps
-// the slot inside `cache-0` of the dedup table. We were checking the
-// wire shape, but conformance MUST validate the semantic contract a
-// real client sees.
+// not have `de-dupe.core/expand` reachable. A server may wrap a
+// semantic slot (e.g. `:lifecycle` at the top level of
+// `:structuredContent`) inside `cache-0` of the dedup table, so the
+// literal JSON shape on the wire differs from what a real client sees
+// after expansion. Conformance MUST validate the semantic contract a
+// real client sees, not the pre-expansion wire shape — this decoder
+// supplies the Node-side expansion the harness needs to do that.
 //
 // `decodeDedupEnvelope` is the Node-side mirror of
 // `de-dupe.core/expand`: given a structuredContent value that may be
@@ -63,7 +63,7 @@ function isCacheRefString(v) {
   return typeof v === 'string' && v.startsWith(CACHE_NS_PREFIX);
 }
 
-// Distinct in-progress sentinel (rf2-87h71e LOW). Installed in the memo
+// Distinct in-progress sentinel. Installed in the memo
 // while a cache entry is mid-expansion so a cyclic ref that re-enters
 // `expandEntry` resolves to THIS sentinel rather than to `undefined` —
 // letting the cycle be detected and rejected LOUDLY instead of silently
@@ -102,7 +102,7 @@ function expandCache(cache) {
       // caches are acyclic — refs always point at strictly-smaller
       // subtrees — so a cycle is a malformed / adversarial table. Fail
       // LOUD rather than returning `undefined` (silent corruption); a
-      // conformance decoder must reject malformed input (rf2-87h71e LOW).
+      // conformance decoder must reject malformed input.
       if (memoized === EXPANDING) {
         throw new Error(
           'dedup-envelope: cyclic dedup cache — reference ' + cacheId +

--- a/tools/mcp-conformance/lib/exec-safety.cjs
+++ b/tools/mcp-conformance/lib/exec-safety.cjs
@@ -1,9 +1,9 @@
 // Cross-platform exec-resolution and filesystem-cleanup safety helpers
-// for the mcp-conformance harness. Source: rf2-33vvc.
+// for the mcp-conformance harness.
 //
 // ## Why this exists
 //
-// Two accident classes the audit (rf2-33vvc) flagged:
+// These helpers gate two accident classes:
 //
 //   1. **Windows command-hijack accident** — bare executable names
 //      (`npm`, `npx`, `clojure`) invoked with `shell: true` and `cwd`
@@ -37,7 +37,7 @@
 //
 // `resolveTrustedExe` only matters for **system-wide binaries** that
 // the OS finds via PATH walk. Two postures sit alongside the helper in
-// this artefact (rf2-i3ffz F-COUPLE-1):
+// this artefact:
 //
 //   - **`story-mcp` harness** uses `resolveTrustedExe('clojure', ...)`.
 //     The JVM binary lives in `/usr/local/bin/clojure` (or wherever
@@ -81,8 +81,8 @@
 //       the file doesn't exist. Throws on symlink-escape — the SAME
 //       containment check `safeUnlinkInside` enforces, so a candidate the
 //       cleanup step refused to unlink can NEVER be silently trusted as a
-//       read source (rf2-khav7l: the "refuse-delete-but-trust-read"
-//       split). Read failures other than ENOENT (e.g. EACCES) propagate.
+//       read source (the "refuse-delete-but-trust-read" split). Read
+//       failures other than ENOENT (e.g. EACCES) propagate.
 //
 // All three helpers are pure-Node, no external deps; they're test-only
 // fixtures (bundle-isolated by construction — `tools/mcp-conformance/`
@@ -260,7 +260,7 @@ function resolveTrustedExe(name, opts) {
  * and verify it stays under `realpath(allowedRoot)`. This is the SINGLE
  * containment check both `safeUnlinkInside` (cleanup) and
  * `safeReadFileInside` (port-file read) share — keeping them in one
- * place is what closes the rf2-khav7l "refuse-delete-but-trust-read"
+ * place is what closes the "refuse-delete-but-trust-read"
  * split: a candidate the cleanup step refused to unlink resolves to the
  * exact same escaped path here, so the read MUST refuse it too.
  *
@@ -378,7 +378,7 @@ function safeUnlinkInside(candidatePath, allowedRoot) {
  * `realpath(allowedRoot)`. Symlink-safe via the SAME containment check
  * `safeUnlinkInside` enforces (`resolveContainedLeaf`), so a candidate
  * the cleanup step refused to unlink cannot be silently trusted as a
- * read source — the rf2-khav7l "refuse-delete-but-trust-read" split.
+ * read source — the "refuse-delete-but-trust-read" split.
  *
  * @param {string} candidatePath
  * @param {string} allowedRoot

--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /*
- * Hermetic orchestrator for the re-frame2-pair LIVE conformance SUITE
- * (rf2-uw6d6, follow-on from rf2-ynaoc).
+ * Hermetic orchestrator for the re-frame2-pair LIVE conformance SUITE.
  *
  * This is the CI entry point for the WHOLE hermetic live suite — it runs
  * EVERY live inner test in the `INNER_TESTS` inventory (see ~:200), not
@@ -44,10 +43,11 @@
  *   7. Tearing down browser + shadow-cljs cleanly on success, failure,
  *      or signal.
  *
- * Per rf2-kp1d8: pre-fix the script only waited on the nREPL port file
- * (at the wrong path) and the browser sentinel; the missing bundle-
- * compile and shadow-runtime gates surfaced as a 6-minute timeout on
- * CI even after rf2-papcw landed the deterministic catalogue fix.
+ * All six boot gates (port file at the right path, TCP listener, fixture
+ * HTTP, bundle compile, browser sentinel, shadow-runtime addressable) are
+ * required: each one closes a window in which the live path would fire
+ * before the runtime is genuinely ready, which would surface as a long CI
+ * timeout rather than a clean conformance result.
  *
  * Exit codes:
  *   0  hermetic conformance passed
@@ -60,14 +60,14 @@
  * browser are killed in the `finally`; SIGINT/SIGTERM also wire to the
  * same cleanup.
  *
- * Per rf2-wqi4n4 finding 2: the fixture `npm install` setup runs under an
- * ASYNC spawn with its own `SETUP_COMMAND_TIMEOUT_MS` cap (see
- * `runTrusted`). A synchronous `crossSpawn.sync` there would block the
- * event loop for the install's whole lifetime — during which the
- * HERMETIC_TIMEOUT_MS watchdog (and signal handlers) physically cannot
- * fire — so a hung `npm install` would have wedged the run past the outer
- * CI job timeout. The async spawn keeps the loop live so BOTH the
- * per-command timeout AND the whole-run watchdog stay armed across setup.
+ * The fixture `npm install` setup runs under an ASYNC spawn with its own
+ * `SETUP_COMMAND_TIMEOUT_MS` cap (see `runTrusted`). A synchronous
+ * `crossSpawn.sync` there would block the event loop for the install's
+ * whole lifetime — during which the HERMETIC_TIMEOUT_MS watchdog (and
+ * signal handlers) physically cannot fire — so a hung `npm install` would
+ * wedge the run past the outer CI job timeout. The async spawn keeps the
+ * loop live so BOTH the per-command timeout AND the whole-run watchdog
+ * stay armed across setup.
  */
 'use strict';
 
@@ -89,8 +89,8 @@ const {
 // `shell: false` since the CVE-2024-27980 fix (EINVAL). cross-spawn
 // dispatches to cmd.exe under the hood when the resolved target ends
 // in `.cmd`, escapes arguments correctly, and — load-bearing for the
-// rf2-33vvc audit fix — does NOT do a cwd-prefixed PATH walk when the
-// command argument is an absolute path (see `which`'s
+// command-hijack accident-gating — does NOT do a cwd-prefixed PATH walk
+// when the command argument is an absolute path (see `which`'s
 // `cmd.match(/\//)` short-circuit). The accident-gating contract is
 // preserved by passing an absolute path resolved via the host's
 // PATH-only scan (see `lib/exec-safety.cjs`).
@@ -119,7 +119,7 @@ const {
 const VERBOSE_TESTS = isVerboseTests();
 const DIAGNOSTICS = createDiagnosticBuffer();
 
-// Module-scope handle to the in-flight teardown closure (rf2-e6enf).
+// Module-scope handle to the in-flight teardown closure.
 // `main()` assigns this once it has spawned shadow-cljs / Chromium so
 // the hard watchdog below can tear those children down BEFORE
 // `process.exit` — without it, a watchdog-elapse would orphan the
@@ -133,10 +133,9 @@ let activeCleanup = null;
 // configs used `target/shadow-cljs/`; nrepl itself drops `.nrepl-port`.
 // re-frame2-pair-mcp's runtime probe (`re_frame2_pair_mcp/nrepl.cljs`
 // `port-file-candidates`) walks the same list — keep them in lockstep.
-// Per rf2-kp1d8: the orchestrator previously only watched the legacy
-// `target/shadow-cljs/nrepl.port` path; shadow-cljs 3.4.10 wrote to
-// `.shadow-cljs/nrepl.port` and the harness timed out at 360s waiting
-// for a file that was never going to arrive.
+// The orchestrator watches every candidate path so it binds to whichever
+// one the active shadow-cljs version writes (shadow-cljs 3.x defaults to
+// `.shadow-cljs/nrepl.port`), rather than gambling on a single location.
 const NREPL_PORT_FILE_CANDIDATES = [
   path.join(FIXTURE_DIR, '.shadow-cljs', 'nrepl.port'),
   path.join(FIXTURE_DIR, 'target', 'shadow-cljs', 'nrepl.port'),
@@ -154,18 +153,18 @@ const FIXTURE_BUNDLE_PATH = path.join(FIXTURE_DIR, 'public', 'out', 'main.js');
 // fixture's :local/root deps (core + reagent + epoch + schemas +
 // machines + Reagent/Malli trees). The CI workflow's
 // `mcp-conformance-re-frame2-pair` job hashes those
-// inputs into its actions/cache key (rf2-c565x), so this stopgap only
+// inputs into its actions/cache key, so this headroom only
 // kicks in on the truly cold path; warm-cache runs still bind the
 // nREPL port in <60s.
 const SHADOW_BOOT_TIMEOUT_MS = 360_000;
 const RUNTIME_PRELOAD_TIMEOUT_MS = 60_000;
 const HERMETIC_TIMEOUT_MS = 540_000;
-// Bounded waits for the async teardown (rf2-7ckmwx finding 1). `cleanup`
+// Bounded waits for the async teardown. `cleanup`
 // awaits Playwright's promise-returning `browser.close()` (capped so a
 // wedged browser-close can't hang the teardown) and SIGTERM→exit of the
 // shadow-cljs child (escalating to SIGKILL after the grace, then observing
 // the final exit). `$HERMETIC_CLEANUP_*_MS` shrink these caps for the
-// finding-1 regression harness only (`runner-cleanup.test.cjs`); production
+// teardown regression harness only (`runner-cleanup.test.cjs`); production
 // CI never sets them.
 const CLEANUP_BROWSER_CLOSE_TIMEOUT_MS =
   Number(process.env.HERMETIC_CLEANUP_BROWSER_MS) || 15_000;
@@ -182,10 +181,10 @@ const CLEANUP_HARD_CAP_MS =
 // listener, fixture HTTP, bundle compile, runtime sentinel, shadow
 // runtime addressable). Each gate latches as soon as it flips, so the
 // poll interval is pure resolution latency on the critical path: a warm
-// cache boot is gated by `~6 * POLL_MS` of cumulative wait. Per rf2-i3ffz
-// F-PERF-2: 500 → 100 trims ~2-3s off warm-cache CI runs (the gates
-// check cheap filesystem/TCP probes — increased poll rate doesn't
-// meaningfully raise cold-cache load).
+// cache boot is gated by `~6 * POLL_MS` of cumulative wait. A tight 100ms
+// cadence keeps warm-cache CI runs fast (the gates check cheap
+// filesystem/TCP probes, so the high poll rate doesn't meaningfully raise
+// cold-cache load).
 const POLL_MS = 100;
 
 // Inner tests the orchestrator boots shadow-cljs for. Each runs with
@@ -193,13 +192,12 @@ const POLL_MS = 100;
 // and the live path fires. Run sequentially against the same booted
 // runtime — the cold-boot cost amortises across every test.
 //
-// Per rf2-i3ffz F-GAP-1: `live-re-frame2-pair-subscribe.cjs` joined the suite
-// to pin the `notifications/progress` streaming wire surface
-// (rf2-zb5z6). The orchestrator's name keeps `overflow` for backward
-// compatibility with the workflow YAML's script reference; the
-// `INNER_TESTS` list IS the authoritative inventory.
+// `live-re-frame2-pair-subscribe.cjs` pins the `notifications/progress`
+// streaming wire surface. The orchestrator's name keeps `overflow` to
+// match the workflow YAML's script reference; the `INNER_TESTS` list IS
+// the authoritative inventory.
 //
-// Per rf2-ybiz0: each entry carries the test's success `sentinel` — the
+// Each entry carries the test's success `sentinel` — the
 // `... CONFORMANCE GREEN` line it prints ONLY on a real (non-skipped)
 // pass. The hermetic env guarantees `$SHADOW_CLJS_NREPL_PORT` is set, so
 // the inner test's SKIP gate MUST NOT fire here — yet a SKIP still
@@ -221,31 +219,30 @@ const INNER_TESTS = [
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE SUBSCRIBE CONFORMANCE GREEN',
   },
   {
-    // rf2-q4o83 — egress-protection regression net for the pull-mode
-    // epoch tools (trace-window / watch-epochs). Drives a declared-
-    // sensitive app-db slot through both tools across the MCP wire and
-    // asserts the sensitive epoch is WHOLE-DROPPED gate-OFF (default,
-    // rf2-5613h) / shipped gate-ON. This is the gate that would have
-    // caught rf2-6wvh5 RED (and now pins the rf2-5613h whole-drop).
+    // Egress-protection regression net for the pull-mode epoch tools
+    // (trace-window / watch-epochs). Drives a declared-sensitive app-db
+    // slot through both tools across the MCP wire and asserts the
+    // sensitive epoch is WHOLE-DROPPED gate-OFF (the default) and shipped
+    // gate-ON. This is the gate that pins the whole-drop behaviour.
     name: 'live egress-protection conformance (pull-mode epoch tools)',
     path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-redaction.cjs'),
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE EGRESS-PROTECTION CONFORMANCE GREEN',
   },
   {
-    // rf2-87h71e — pin the universal `:ok? false ⇒ isError:true` contract
+    // Pin the universal `:ok? false ⇒ isError:true` contract
     // on the read-family GENUINE error envelopes (read-dom/read-ui
     // bad-selector). Drives a malformed CSS selector against the live
     // runtime so `querySelectorAll` throws and the runtime fn returns a
     // structured `{:ok? false :reason :rf.error/...-bad-selector}` — then
     // asserts the SDK response is isError. This is the live SDK-boundary
-    // gate that would have caught rf2-q7cavs RED (the degraded walk only
-    // ever exercised the :nrepl-port-not-found shape).
+    // gate for the error path; the degraded walk only exercises the
+    // :nrepl-port-not-found shape, so the live runtime is required here.
     name: 'live isError-on-:ok?-false conformance (read-dom/read-ui bad selector)',
     path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-iserror.cjs'),
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE ISERROR-ON-OK-FALSE CONFORMANCE GREEN',
   },
   {
-    // rf2-jyxmtq — EP-0017 recordable-coeffects (`cofx`) over the live MCP
+    // EP-0017 recordable-coeffects (`cofx`) over the live MCP
     // wire. Dispatches the fixture's [:counter/stamp] (a reg-event
     // declaring `:rf.cofx/requires [:rf/time-ms]`) with a scripted
     // `cofx "{:rf/time-ms <N>}"` and proves the supplied fact reaches the
@@ -260,12 +257,13 @@ const INNER_TESTS = [
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE COFX CONFORMANCE GREEN',
   },
   {
-    // rf2-z0owya — EP-0018 unified event-registration metadata over the
+    // EP-0018 unified event-registration metadata over the
     // live MCP wire. Inspects a fixture `rf/reg-event` id (`:counter/inc`)
     // via `list-handlers`/`handler-meta {kind "event"}` and pins the
     // unified shape (`:ok? true`, `:kind :event`, `:id`, the
-    // `:rf/event-handler` wrapper) AND the absence of every retired marker
-    // (`:event/kind`, `:rf/db-handler`/`:rf/fx-handler`/`:rf/ctx-handler`).
+    // `:rf/event-handler` wrapper) AND the absence of any of the markers
+    // that must not appear (`:event/kind`,
+    // `:rf/db-handler`/`:rf/fx-handler`/`:rf/ctx-handler`).
     // The degraded gate only proves the descriptor/CallToolResult wiring —
     // this proves the live event-metadata wire reflects EP-0018.
     name: 'live EP-0018 event-metadata conformance (unified reg-event shape)',
@@ -327,7 +325,6 @@ function sleep(ms) {
 // teardown step that rejects is treated as "settled" (we tried, we move
 // on), not as a reason to abandon the rest of cleanup. The timeout timer is
 // unref'd so it can't itself keep the loop alive past a clean exit.
-// rf2-7ckmwx finding 1.
 function settledWithin(promise, ms) {
   return new Promise((resolve) => {
     let done = false;
@@ -347,8 +344,7 @@ function settledWithin(promise, ms) {
 // Resolve when `child` has emitted `exit` (or already has). Returns a
 // promise that never rejects; pair it with `settledWithin` for a bounded
 // wait. `hasExited` is the caller's already-tracked exit flag so a child
-// that exited before we attach still resolves immediately. rf2-7ckmwx
-// finding 1.
+// that exited before we attach still resolves immediately.
 function waitForChildExit(child, hasExited) {
   if (hasExited()) return Promise.resolve();
   return new Promise((resolve) => {
@@ -356,8 +352,8 @@ function waitForChildExit(child, hasExited) {
   });
 }
 
-// Build the idempotent async teardown (rf2-7ckmwx finding 1). Extracted to
-// module scope so the finding-1 regression harness
+// Build the idempotent async teardown. Lives at
+// module scope so the teardown regression harness
 // (`runner-cleanup.test.cjs`) can drive the REAL teardown logic against a
 // fake promise-returning browser and a slow-exiting fake child — proving
 // the awaited-close + SIGTERM→exit→SIGKILL contract holds without booting
@@ -446,7 +442,7 @@ function makeCleanup(deps) {
 // resolves OUTSIDE FIXTURE_DIR) from a benign fs failure (EACCES, EBUSY
 // — a Windows lock, a permission quirk). The exec-safety helpers tag
 // every escape with the `symlink-escape accident-gating` marker; benign
-// failures carry an errno `code` and no such marker. rf2-khav7l: only an
+// failures carry an errno `code` and no such marker. Only an
 // escape is fatal — a transient lock must not abort the whole run.
 function isContainmentEscape(e) {
   return !!(e && typeof e.message === 'string' &&
@@ -454,7 +450,7 @@ function isContainmentEscape(e) {
 }
 
 // `candidates` + `fixtureDir` are parameterised (defaulting to the
-// module constants) so the rf2-khav7l call-site regression test can drive
+// module constants) so the call-site regression test can drive
 // this exact function against a temp fixture with a symlinked
 // `.shadow-cljs` — proving the poller refuses an external port file
 // without booting shadow-cljs + Chromium.
@@ -468,18 +464,17 @@ function readPortFile(
   // satisfied the wait — useful when shadow-cljs's default cache-root
   // moves between versions.
   //
-  // Per rf2-khav7l: route the read through `safeReadFileInside` — the
+  // Route the read through `safeReadFileInside` — the
   // SAME containment check the cleanup loop's `safeUnlinkInside` uses.
-  // Pre-fix this did a raw `fs.readFileSync` with NO realpath check, so
-  // a candidate (or candidate parent) symlinked OUTSIDE FIXTURE_DIR that
-  // the cleanup step CORRECTLY refused to delete could still be trusted
-  // as the live nREPL source — a stale external `nrepl.port` could then
-  // satisfy the port-file wait and steer the inner conformance tests at
-  // an unrelated runtime (false-red / false-green). `safeReadFileInside`
-  // THROWS on a containment escape; we let that propagate so an escaped
-  // candidate is a FATAL orchestration error, not a silently-trusted
-  // read. A candidate that simply doesn't exist yet returns `null` —
-  // try the next.
+  // This refuses any candidate (or candidate parent) symlinked OUTSIDE
+  // FIXTURE_DIR: such a file is exactly what the cleanup step refuses to
+  // delete, and trusting it as the live nREPL source would let a stale
+  // external `nrepl.port` satisfy the port-file wait and steer the inner
+  // conformance tests at an unrelated runtime (false-red / false-green).
+  // `safeReadFileInside` THROWS on a containment escape; we let that
+  // propagate so an escaped candidate is a FATAL orchestration error, not
+  // a silently-trusted read. A candidate that simply doesn't exist yet
+  // returns `null` — try the next.
   for (const p of candidates) {
     let txt;
     try {
@@ -525,7 +520,7 @@ function probeHttp(port, hostname = '127.0.0.1') {
 // for unknown paths. Used to wait for the bundle to compile before
 // Chromium navigates; without this gate the page loads while shadow is
 // still on its first compile, the runtime preload never runs, and the
-// sentinel-wait times out (rf2-kp1d8).
+// sentinel-wait times out.
 //
 // We accept the response iff the Content-Type starts with
 // `application/javascript` (shadow's dev-http sets this for .js files
@@ -663,7 +658,7 @@ async function waitUntil(label, predicate, timeoutMs) {
 // Resolve `npm` / `npx` / etc. to a single trusted absolute path via
 // PATH search, refusing any candidate that resolves under REPO_ROOT.
 // Cached per-name so the PATH walk runs once. See `lib/exec-safety.cjs`
-// for the rationale (rf2-33vvc Windows command-hijack accident-gating).
+// for the rationale (Windows command-hijack accident-gating).
 const TRUSTED_EXE_CACHE = new Map();
 function trustedExe(name) {
   if (TRUSTED_EXE_CACHE.has(name)) return TRUSTED_EXE_CACHE.get(name);
@@ -675,13 +670,13 @@ function trustedExe(name) {
 // Hard cap on any trusted SETUP command (fixture `npm install`). Generous
 // enough for a cold-cache install of the tiny fixture's deps on a slow CI
 // runner, but bounded so a wedged package-manager child can't wedge the
-// whole hermetic run (rf2-wqi4n4 finding 2). Distinct from
+// whole hermetic run. Distinct from
 // `HERMETIC_TIMEOUT_MS` (the whole-run cap) — this is the per-setup-command
 // cap that the whole-run watchdog physically CANNOT enforce while a
 // synchronous child blocks the event loop.
 //
-// `$HERMETIC_SETUP_TIMEOUT_MS` overrides the cap for the rf2-wqi4n4
-// finding-2 regression harness ONLY (`hermetic-setup-timeout.test.cjs`
+// `$HERMETIC_SETUP_TIMEOUT_MS` overrides the cap for the
+// setup-timeout regression harness ONLY (`hermetic-setup-timeout.test.cjs`
 // drives `runTrusted` against a never-exiting child under a tiny cap to
 // prove the timeout/kill path fires and the loop stays live). Production
 // CI never sets it, so the 300s cap stands.
@@ -689,7 +684,7 @@ const SETUP_COMMAND_TIMEOUT_MS =
   Number(process.env.HERMETIC_SETUP_TIMEOUT_MS) || 300_000;
 
 // Grace between the timeout SIGTERM and the SIGKILL escalation for a hung
-// setup child (rf2-i4d5wr). A well-behaved child reaps on SIGTERM within
+// setup child. A well-behaved child reaps on SIGTERM within
 // this window; a SIGTERM-ignoring child gets SIGKILLed after it. This grace
 // is AWAITED (not a fire-and-forget `setTimeout` that the reject could
 // cancel), so a setup child that ignores SIGTERM is GUARANTEED to receive
@@ -703,16 +698,15 @@ const SETUP_SIGKILL_GRACE_MS =
 // workspace via `trustedExe`) under an ASYNC spawn with an explicit
 // child-level timeout/kill.
 //
-// Per rf2-wqi4n4 finding 2: the pre-fix shape used `crossSpawn.sync`, which
-// SYNCHRONOUSLY blocks the Node event loop for the child's entire lifetime.
+// The spawn is ASYNC (not `crossSpawn.sync`): a synchronous spawn would
+// SYNCHRONOUSLY block the Node event loop for the child's entire lifetime.
 // While blocked, Node delivers no signals and runs no timers — so the
 // `HERMETIC_TIMEOUT_MS` `setTimeout` watchdog (and the SIGINT/SIGTERM
-// handlers) CANNOT fire. A hung `npm install` (stuck registry fetch, a
-// package-manager prompt, a lock contention) would therefore wedge the
+// handlers) could NOT fire, and a hung `npm install` (stuck registry
+// fetch, a package-manager prompt, a lock contention) would wedge the
 // whole hermetic job until the OUTER CI job timeout, bypassing this
-// script's own hard time-cap and diagnostics. This is the SAME failure
-// mode the inner-test spawn already documents + avoids (rf2-i3ffz F-PERF-1,
-// `crossSpawn(...)` async there); the setup command had the same hole.
+// script's own hard time-cap and diagnostics. The inner-test spawn uses
+// the same async shape for the same reason.
 //
 // The async spawn keeps the event loop live, so both the per-command
 // timeout below AND the whole-run watchdog stay armed. On timeout we
@@ -721,17 +715,14 @@ const SETUP_SIGKILL_GRACE_MS =
 // — surfacing as exit 2 (orchestration failure) shortly after
 // `SETUP_COMMAND_TIMEOUT_MS` rather than the multi-minute CI job timeout.
 //
-// rf2-i4d5wr: the pre-fix shape armed the SIGKILL as a fire-and-forget
-// `setTimeout` (`killTimer`) and then immediately `settle(reject, ...)`d.
-// But `settle` cleared `killTimer`, so the SIGKILL fallback was CANCELLED
-// on the very path that scheduled it. A setup child that ignored SIGTERM
-// would survive after the orchestrator reported "setup command hung —
-// killed", leaking npm/node children that hold locks/pipes. The fix makes
-// the SIGTERM→SIGKILL escalation an AWAITED sequence (the same shape the
-// teardown `makeCleanup` uses): the child is reaped (or has demonstrably
-// received SIGKILL) BEFORE the timeout promise rejects, and the reject no
-// longer cancels the kill. The happy path still settles promptly the moment
-// the child exits normally.
+// The SIGTERM→SIGKILL escalation is an AWAITED sequence (the same shape
+// the teardown `makeCleanup` uses): the child is reaped (or has
+// demonstrably received SIGKILL) BEFORE the timeout promise rejects, and
+// the reject does not cancel the kill. A setup child that ignores SIGTERM
+// is therefore guaranteed to receive SIGKILL — the orchestrator never
+// reports "setup command hung — killed" while leaking a still-alive
+// npm/node child that holds locks/pipes. The happy path still settles
+// promptly the moment the child exits normally.
 function runTrusted(name, args, cwd) {
   const bin = trustedExe(name);
   // cross-spawn (async) handles the `.cmd` -> cmd.exe dispatch on Windows
@@ -764,7 +755,7 @@ function runTrusted(name, args, cwd) {
     // bounded by a grace, SIGKILL if it ignored SIGTERM, then reject as an
     // orchestration failure.
     //
-    // rf2-i4d5wr: the escalation is an AWAITED sequence, NOT a fire-and-
+    // The escalation is an AWAITED sequence, NOT a fire-and-
     // forget `setTimeout` that `settle(reject)` could cancel. A child that
     // ignores SIGTERM is therefore GUARANTEED to receive SIGKILL before the
     // promise rejects; we never report "killed" while the child is still
@@ -826,13 +817,13 @@ function runTrusted(name, args, cwd) {
     child.on('exit', (code, signal) => {
       // Record the exit so the timeout path's awaited grace
       // (`waitForChildExit(child, () => childExited)`) sees a child that
-      // exited before/while we waited and stops escalating. rf2-i4d5wr.
+      // exited before/while we waited and stops escalating.
       childExited = true;
       if (timedOut) {
         // Our own timeout SIGTERM/SIGKILL reaped it. Defer the rejection to
         // the timeout IIFE so the attribution is the timeout message, and so
         // the awaited escalation observes this exit (it `await`s
-        // `waitForChildExit`, which resolves on this event). rf2-i4d5wr.
+        // `waitForChildExit`, which resolves on this event).
         return;
       }
       if (signal) {
@@ -905,18 +896,16 @@ async function main() {
   // ALL candidate paths so a stale entry at one location can't shadow
   // the fresh file at another.
   //
-  // Per rf2-33vvc: route every unlink through `safeUnlinkInside` so a
+  // Route every unlink through `safeUnlinkInside` so a
   // symlinked candidate (or symlinked parent directory) that escapes
   // FIXTURE_DIR can't be coerced into deleting a file outside the
   // fixture tree.
   //
-  // Per rf2-khav7l: a symlink-ESCAPE refusal on a load-bearing stale
+  // A symlink-ESCAPE refusal on a load-bearing stale
   // port candidate is FATAL — we do NOT log-and-continue and then later
-  // read that same escaped file as the live nREPL source. (Pre-fix the
-  // cleanup logged "continuing" on the escape and `readPortFile` then
-  // raw-read the same path with no containment check.) A BENIGN unlink
+  // read that same escaped file as the live nREPL source. A BENIGN unlink
   // failure (EACCES / EBUSY — a Windows file lock, a permission quirk)
-  // is still tolerated: it doesn't widen trust, and the read path now
+  // is tolerated: it doesn't widen trust, and the read path
   // re-checks containment regardless. `isContainmentEscape` discriminates
   // the two so a transient lock doesn't abort the whole run while a real
   // escape does.
@@ -949,10 +938,10 @@ async function main() {
   }
 
   // ---- Install fixture deps --------------------------------------------
-  // `await` the async spawn (rf2-wqi4n4 finding 2): the setup command now
-  // runs under a live event loop with its own hard timeout, so a hung
-  // `npm install` is bounded by `SETUP_COMMAND_TIMEOUT_MS` instead of
-  // wedging the whole run past the outer CI job cap.
+  // `await` the async spawn: the setup command runs under a live event
+  // loop with its own hard timeout, so a hung `npm install` is bounded by
+  // `SETUP_COMMAND_TIMEOUT_MS` instead of wedging the whole run past the
+  // outer CI job cap.
   if (!exists(path.join(FIXTURE_DIR, 'node_modules'))) {
     log(`installing fixture deps in ${FIXTURE_DIR}`);
     await runTrusted('npm', ['install', '--no-audit', '--no-fund'], FIXTURE_DIR);
@@ -962,9 +951,9 @@ async function main() {
   // Resolve `npx` to a trusted absolute path (rejected if it lives
   // inside REPO_ROOT) and route the spawn through cross-spawn so the
   // `.cmd`-on-Windows shape works without re-introducing the shell.
-  // Per rf2-33vvc: the pre-fix shape passed `npx.cmd` + `shell: true`
-  // + `cwd = FIXTURE_DIR`, which would have happily executed a
-  // fixture-local `npx.cmd` if one ever landed in the checkout.
+  // Passing the trusted absolute path (rather than a bare `npx.cmd` with
+  // `shell: true` + `cwd = FIXTURE_DIR`) means a fixture-local `npx.cmd`
+  // that ever landed in the checkout can never be executed.
   const npxBin = trustedExe('npx');
   log(`spawning shadow-cljs watch app in ${FIXTURE_DIR} (npx=${npxBin})`);
   const shadow = crossSpawn(npxBin, ['shadow-cljs', 'watch', 'app'], {
@@ -986,23 +975,21 @@ async function main() {
 
   let browser = null;
 
-  // Idempotent async teardown (rf2-7ckmwx finding 1). The pre-fix `cleanup`
-  // was synchronous: it called Playwright's promise-returning
-  // `browser.close()` WITHOUT awaiting it and scheduled the shadow SIGKILL
-  // on an unref'd timer, so every caller (`finally`, signal handlers, the
-  // hard watchdog) could `process.exit` BEFORE the browser-close promise
-  // settled and BEFORE shadow-cljs had actually exited — abandoning exactly
-  // the children the teardown exists to reap. `makeCleanup` (module scope,
-  // unit-tested by `runner-cleanup.test.cjs`) returns an idempotent promise
-  // that awaits the browser close (bounded) and SIGTERM→exit→SIGKILL of
-  // shadow. `getBrowser`/`getShadow` read the live closure vars so the
-  // teardown sees `browser` even though it's assigned later in `main()`.
+  // Idempotent async teardown. `makeCleanup` (module scope, unit-tested by
+  // `runner-cleanup.test.cjs`) returns an idempotent promise that AWAITS
+  // the browser close (bounded) and SIGTERM→exit→SIGKILL of shadow, so
+  // every caller (`finally`, signal handlers, the hard watchdog) waits for
+  // the browser-close promise to settle and for shadow-cljs to actually
+  // exit before `process.exit` — the children the teardown exists to reap
+  // are reaped, not abandoned. `getBrowser`/`getShadow` read the live
+  // closure vars so the teardown sees `browser` even though it's assigned
+  // later in `main()`.
   const cleanup = makeCleanup({
     getBrowser: () => browser,
     getShadow: () => shadow,
     hasShadowExited: () => shadowExited,
   });
-  // Expose the teardown to the module-scope hard watchdog (rf2-e6enf)
+  // Expose the teardown to the module-scope hard watchdog
   // so a watchdog-elapse kills shadow-cljs + Chromium rather than
   // orphaning them.
   activeCleanup = cleanup;
@@ -1011,8 +998,8 @@ async function main() {
       logErr(`caught ${sig} — tearing down`);
       // Race the async cleanup against a hard cap: an interrupted run still
       // exits promptly (CLEANUP_HARD_CAP_MS) even if a child refuses to die,
-      // but we no longer fire-and-exit before the teardown has had any
-      // chance to settle (rf2-7ckmwx finding 1).
+      // while still giving the teardown a real chance to settle before the
+      // process exits.
       settledWithin(cleanup(), CLEANUP_HARD_CAP_MS).then((settled) => {
         if (!settled) {
           logErr(
@@ -1074,10 +1061,10 @@ async function main() {
     // public/index.html references `/out/main.js`; if Chromium navigates
     // before that file exists the bundle 404s, no CLJS runs, and the
     // preload sentinel never lands. We poll the asset URL until it
-    // returns 200, then navigate. The first cold compile on CI runs
-    // 10–20s after the watch is up; rebuilds on a warm cache are <1s.
-    // Per rf2-kp1d8 — the earlier shape navigated immediately and then
-    // waited 60s for the sentinel, which never arrived.
+    // returns 200, then navigate — so navigation always happens against a
+    // compiled bundle, and the sentinel wait can succeed. The first cold
+    // compile on CI runs 10–20s after the watch is up; rebuilds on a warm
+    // cache are <1s.
     await waitUntil(
       `fixture bundle at ${FIXTURE_URL}out/main.js`,
       () => probeBundleReady(FIXTURE_HTTP_PORT),
@@ -1133,7 +1120,7 @@ async function main() {
     // `:runtime-not-preloaded` (the .catch in `tools/probe.cljs`
     // swallows the underlying nREPL error). Poll the same probe re-frame2-pair-mcp
     // uses until it returns true, so we hand off to the live test only
-    // after the runtime is actually addressable. Per rf2-kp1d8.
+    // after the runtime is actually addressable.
     log('waiting for shadow :app runtime to register');
     await waitUntil(
       'shadow :app runtime addressable via cljs-eval',
@@ -1148,7 +1135,7 @@ async function main() {
     // booted runtime. Sequential execution keeps cold-boot cost
     // amortised; tests are short relative to shadow-cljs boot.
     //
-    // Per rf2-i3ffz F-PERF-1: spawn ASYNC, not via `crossSpawn.sync`.
+    // Spawn ASYNC, not via `crossSpawn.sync`.
     // The sync form synchronously blocks the event loop for the inner
     // test's entire watchdog window — during which the
     // `SIGINT`/`SIGTERM`/`SIGHUP` handlers wired above CANNOT fire (Node
@@ -1172,7 +1159,7 @@ async function main() {
       log(`running ${testFile} - ${test.name}`);
       // Capture the inner test's stdout so we can assert it actually RAN
       // (printed its GREEN sentinel) — not merely exited 0 (a SKIP also
-      // exits 0). Per rf2-ybiz0.
+      // exits 0).
       let stdoutText = '';
       const testStatus = await new Promise((resolve, reject) => {
         const child = crossSpawn(process.execPath, [test.path], {
@@ -1212,7 +1199,7 @@ async function main() {
         err.exitCode = testStatus;
         throw err;
       }
-      // ---- Observable-SKIP guard (rf2-ybiz0) ------------------------------
+      // ---- Observable-SKIP guard ------------------------------------------
       // The inner test exited 0 — but a SKIP also exits 0. The hermetic
       // env sets $SHADOW_CLJS_NREPL_PORT, so the inner test's SKIP gate
       // MUST NOT have fired. Assert it printed its success sentinel AND
@@ -1247,10 +1234,10 @@ async function main() {
     log('RE-FRAME2-PAIR-MCP LIVE HERMETIC CONFORMANCE GREEN (' +
       INNER_TESTS.length + ' inner tests)');
   } finally {
-    // Await the async teardown before `main()` resolves/rejects (rf2-7ckmwx
-    // finding 1): the normal-exit path must not report success and
-    // `process.exit(0)` while the browser-close promise is still settling or
-    // shadow-cljs has not yet exited.
+    // Await the async teardown before `main()` resolves/rejects: the
+    // normal-exit path must not report success and `process.exit(0)` while
+    // the browser-close promise is still settling or shadow-cljs has not
+    // yet exited.
     await cleanup();
   }
 }
@@ -1259,17 +1246,14 @@ async function main() {
 // so CI gets a deterministic failure instead of waiting on the job
 // timeout. Length set to cover cold Maven cache + cold chromium boot.
 //
-// Per rf2-e6enf: tear down shadow-cljs + Chromium BEFORE exiting. The
-// pre-fix watchdog called `process.exit(2)` directly, orphaning the
-// spawned JVM (and any launched Chromium); orphans that inherited the
-// step's stdio can keep the CI step's log pipes open past the node
-// exit, which is part of why the gate appeared to hang well past the
-// orchestrator's own cap.
+// On elapse it tears down shadow-cljs + Chromium BEFORE exiting, rather
+// than calling `process.exit(2)` directly: a direct exit would orphan the
+// spawned JVM (and any launched Chromium), and orphans that inherited the
+// step's stdio can keep the CI step's log pipes open past the node exit,
+// making the gate appear to hang well past the orchestrator's own cap.
 //
-// Per rf2-7ckmwx finding 1: `activeCleanup` is now async (awaited
-// browser.close + SIGTERM→exit→SIGKILL of shadow). The pre-fix watchdog
-// invoked it fire-and-forget and exited on a fixed 1s timer regardless of
-// whether the teardown had settled. We now RACE the async cleanup against
+// `activeCleanup` is async (awaited browser.close + SIGTERM→exit→SIGKILL
+// of shadow). The watchdog RACES the async cleanup against
 // `CLEANUP_HARD_CAP_MS`: the teardown gets a real chance to reap the
 // children, but the process still exits within the cap if a child refuses
 // to die. `activeCleanup` is null only if the watchdog fires before
@@ -1301,7 +1285,7 @@ const watchdog = setTimeout(() => {
 watchdog.unref();
 
 // Only auto-run the orchestrator when invoked as the entry-point. Required
-// as a module (by the rf2-wqi4n4 finding-2 `runTrusted` regression test),
+// as a module (by the `runTrusted` regression test),
 // it exports the unit under test WITHOUT kicking off the whole hermetic run
 // (which would spawn shadow-cljs + Chromium). Guarding the run here keeps
 // the watchdog timer from arming on `require` too.
@@ -1329,15 +1313,15 @@ if (require.main === module) {
   clearTimeout(watchdog);
 }
 
-// Exported for the rf2-wqi4n4 finding-2 + rf2-i4d5wr regression harness.
+// Exported for the setup-command regression harness.
 // `runTrusted` is the async, timeout-bounded setup-command spawn; the test
 // drives it against (a) a never-exiting child to prove a hung setup command
 // is killed within `SETUP_COMMAND_TIMEOUT_MS` instead of wedging the event
 // loop, and (b) a SIGTERM-IGNORING child to prove the timeout path AWAITS
-// the SIGTERM grace then SIGKILLs it (the reject no longer cancels the
+// the SIGTERM grace then SIGKILLs it (the reject does not cancel the
 // fallback) so the child is actually reaped, not leaked.
 //
-// `readPortFile` + `isContainmentEscape` are exported for the rf2-khav7l
+// `readPortFile` + `isContainmentEscape` are exported for the
 // call-site regression harness (`port-file-escape.test.cjs`): it drives
 // `readPortFile` against a temp fixture whose `.shadow-cljs` is symlinked
 // outside, proving the poller REFUSES an external port file (throws)
@@ -1345,7 +1329,7 @@ if (require.main === module) {
 // cleanup loop's escape-refusal be safe.
 //
 // `makeCleanup` + `settledWithin` + `waitForChildExit` are exported for the
-// rf2-7ckmwx finding-1 regression harness (`runner-cleanup.test.cjs`): it
+// teardown regression harness (`runner-cleanup.test.cjs`): it
 // drives the REAL teardown against a fake promise-returning browser and a
 // slow-exiting fake child, proving the awaited browser-close + the
 // SIGTERM→exit→SIGKILL escalation are WAITED for (or hard-capped), never

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -1,26 +1,14 @@
 #!/usr/bin/env node
 /*
- * Sequential orchestrator for the mcp-conformance test suite (rf2-i3ffz
- * F-HYG-3). Spawns each conformance test in sequence with structured
- * per-test exit-code reporting; replaces a five-deep `&&` chain in the
- * `npm test` script.
+ * Sequential orchestrator for the mcp-conformance test suite. Spawns each
+ * conformance test in sequence with structured per-test exit-code
+ * reporting; it is the implementation behind the `npm test` script.
  *
- * Why an orchestrator: the historical `npm test` was
- *
- *     node --test test/exec-safety.test.cjs
- *     && node test/end-to-end-re-frame2-pair.cjs
- *     && node test/live-re-frame2-pair-overflow.cjs
- *     && node test/end-to-end-story.cjs
- *
- * compressed into one quoted JSON string. Failure attribution required
- * reading the chain backwards from the exit code; a real failure in
- * `exec-safety.test.cjs` was the only thing the chain caught early,
- * with every downstream test hidden until the upstream link recovered.
- *
- * This orchestrator runs each test in sequence, records its exit
- * status, and prints a structured summary at the end. It still bails
- * on the first failure (so CI fails fast) but the summary makes
- * failure attribution one-glance instead of one-grep.
+ * Why an orchestrator: it runs each test in sequence, records its exit
+ * status, and prints a structured summary at the end. It bails on the
+ * first failure (so CI fails fast), and the summary makes failure
+ * attribution one-glance instead of one-grep — each test's pass/fail and
+ * exit code is listed by name rather than buried in a chained exit code.
  *
  * Exit codes:
  *   0  every test passed (some may have SKIPped — they still exit 0)
@@ -48,7 +36,7 @@ const ROOT = path.resolve(HERE, '..');
 // runners can select a subset without re-listing — notably
 // `scripts/test-unit.cjs`, which runs the pure-Node unit cluster
 // (every row whose `argv[0] === '--test'`) in one `node --test`
-// invocation for the PR CI Node-regression gate (rf2-md05gp). Because
+// invocation for the PR CI Node-regression gate. Because
 // that runner DERIVES its set from this array, a new `--test` row added
 // here is automatically picked up by PR CI — no second list to keep in
 // sync.
@@ -135,9 +123,8 @@ function main() {
   for (const test of TESTS) {
     banner('▶ ' + test.name + '\n  ' + test.argv.join(' '));
     // `process.execPath` is always absolute; `spawnSync` inherits stdio
-    // so the child's stdout/stderr stream through verbatim (matching
-    // every historical caller's posture). `shell: false` keeps the
-    // accident-gating from the lib/exec-safety.cjs preamble: no
+    // so the child's stdout/stderr stream through verbatim. `shell: false`
+    // keeps the accident-gating from the lib/exec-safety.cjs preamble: no
     // shell-interpolation of test names.
     const child = spawnSync(process.execPath, test.argv, {
       cwd: ROOT,

--- a/tools/mcp-conformance/scripts/test-unit.cjs
+++ b/tools/mcp-conformance/scripts/test-unit.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * PR-CI Node-regression gate (rf2-md05gp).
+ * PR-CI Node-regression gate.
  *
  * Runs the pure-Node UNIT cluster of the conformance inventory — every
  * row in `scripts/test-all.cjs`'s authoritative `TESTS` array whose
@@ -18,10 +18,8 @@
  * bundle), live (nREPL), story (JVM `clojure`), and hermetic
  * (shadow-cljs + Chromium) gates. Those are run by dedicated CI jobs
  * (`mcp-conformance-{re-frame2-pair,story}`) with their own toolchains
- * and caches. Pre-rf2-md05gp the PR CI for those jobs ran ONLY
- * `test:exec-safety` (+ the e2e / live / story steps); the other seven
- * `node --test` unit gates were in the local inventory but NEVER ran in
- * CI, so a regression they guard could ship green.
+ * and caches. This gate runs the full set of `node --test` unit gates in
+ * PR CI, so a regression any of them guards is caught before merge.
  *
  * This runner DERIVES its set from `test-all.cjs` rather than
  * re-listing, so it cannot drift: add a new `node --test` row to the

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -14,16 +14,15 @@
 //   - on watchdog: print the timeout, TEAR THE SPAWNED CHILD DOWN
 //     (`client.close()` closes its transport, killing the stdio child),
 //     then `process.exit(2)` — a hard-exit fallback fires after a short
-//     grace window so a hung close can't keep the process alive. Pre-fix
-//     the watchdog exited directly and orphaned the child (rf2-voux7
-//     finding 5; the hermetic orchestrator already fixes the same class
-//     via rf2-e6enf).
+//     grace window so a hung close can't keep the process alive. Tearing
+//     the child down on the timeout keeps it from being orphaned (the
+//     hermetic orchestrator guards the same class).
 //
-// Source: rf2-sems4. The split was originally three near-identical
-// ~40-LoC blocks of pure framing code; centralising the framing here
-// shrinks each test body to the workflow steps that actually differ.
-// Adding another Node-side conformance test (a third re-frame2-pair variant)
-// becomes ~30 LoC instead of ~110.
+// Centralising the framing here shrinks each test body to the workflow
+// steps that actually differ — the framing is otherwise a near-identical
+// ~40-LoC block of pure ceremony per test. Adding another Node-side
+// conformance test (a third re-frame2-pair variant) becomes ~30 LoC
+// instead of ~110.
 //
 // ## Contract
 //
@@ -42,11 +41,11 @@
 // The SDK `Client.version` slot is pinned at `'0.1.0'` for every
 // conformance harness — none of the callers override it and the
 // server's `initialize` handler treats client version as informational.
-// Promoting it to a parameter would be slot-soup (rf2-i3ffz F-GAP-6).
+// Promoting it to a parameter would be slot-soup.
 //
-// `runWithWatchdog` performs the SDK connect handshake itself (every
-// historical caller did it as the first line of the body) and passes
-// the connected `client` + `transport` to `body`. Tests that want to
+// `runWithWatchdog` performs the SDK connect handshake itself (so each
+// body starts already connected) and passes the connected `client` +
+// `transport` to `body`. Tests that want to
 // skip (no-op exit 0) call `runWithWatchdog.skip(reason)` BEFORE
 // invoking this function — that prints a uniform `SKIP <reason>`
 // banner and exits 0 without spawning a child or installing a
@@ -67,7 +66,7 @@
 // primitive — the exact spawn+stderr-pipe+Client+connect ceremony this
 // header describes — and tear down with `closeQuietly(client)`.
 // `runWithWatchdog` is itself just `connectServer` wrapped in the
-// watchdog + exit-code framing, so the framing has one home (rf2-0ogn7).
+// watchdog + exit-code framing, so the framing has one home.
 
 const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
 const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
@@ -77,7 +76,7 @@ const { decodeDedupEnvelope } = require('../lib/dedup-envelope.cjs');
 const CLIENT_VERSION = '0.1.0';
 
 // ---------------------------------------------------------------------
-// Shared SDK-spawn primitive (rf2-0ogn7 dedup).
+// Shared SDK-spawn primitive.
 //
 // Spawn one MCP server over a `StdioClientTransport`, pipe its stderr
 // to ours, construct an SDK `Client` with the pinned conformance
@@ -93,11 +92,11 @@ const CLIENT_VERSION = '0.1.0';
 //   - `live-re-frame2-pair-redaction.cjs` boots a second server with
 //     `--allow-sensitive-reads` to pin the gate-ON direction.
 //
-// Both previously hand-rolled this exact transport+client+stderr-pipe+
-// connect ceremony. Centralising it here means the framing the runner's
-// header documents has ONE home; a caller that needs a bare boot calls
-// `connectServer` + `closeQuietly`, and `runWithWatchdog` itself is just
-// `connectServer` wrapped in the watchdog + exit-code framing.
+// Centralising the transport+client+stderr-pipe+connect ceremony here
+// means the framing the runner's header documents has ONE home; a caller
+// that needs a bare boot calls `connectServer` + `closeQuietly`, and
+// `runWithWatchdog` itself is just `connectServer` wrapped in the
+// watchdog + exit-code framing.
 //
 //   - `transportSpec`  — `{ command, args, cwd, env }` forwarded to
 //                        `StdioClientTransport` (`stderr: 'pipe'` is
@@ -117,9 +116,9 @@ const CLIENT_VERSION = '0.1.0';
 //                        HANGS during the initialize handshake (connect
 //                        never resolving, never throwing) is still torn
 //                        down by the timeout path instead of orphaning
-//                        the child (rf2-2js41 finding 2; the connect
-//                        try/catch below only covers a connect that
-//                        THROWS — a connect that hangs never reaches it).
+//                        the child. The connect try/catch below only
+//                        covers a connect that THROWS — a connect that
+//                        hangs never reaches it.
 // ---------------------------------------------------------------------
 async function connectServer({ transportSpec, clientName, stderrPrefix = '[server]', onClient }) {
   const transport = new StdioClientTransport({ ...transportSpec, stderr: 'pipe' });
@@ -128,21 +127,18 @@ async function connectServer({ transportSpec, clientName, stderrPrefix = '[serve
   // BEFORE the connect handshake. The child has already been spawned by
   // the transport construction above, so a connect that hangs (server
   // boots but never finishes `initialize`) would otherwise leave the
-  // watchdog with no client to close (rf2-2js41 finding 2). `onClient`
-  // closes that window: the watchdog captures `client` here, not after
-  // `connect` resolves.
+  // watchdog with no client to close. `onClient` closes that window: the
+  // watchdog captures `client` here, not after `connect` resolves.
   if (onClient) onClient(client);
-  // Pipe the child's stderr to ours with the (prefixed) tag. Same shape
-  // every historical caller used; the closure captures the transport
-  // reference cleanly.
+  // Pipe the child's stderr to ours with the (prefixed) tag. The closure
+  // captures the transport reference cleanly.
   transport.stderr?.on('data', (d) => process.stderr.write(stderrPrefix + ' ' + d.toString()));
   // Initialize handshake. SDK validates the result against
   // InitializeResultSchema; a malformed envelope throws here. On a
   // connect-throw, tear the half-open transport down before re-throwing
-  // so the spawned child can't leak — the historical inline form reached
-  // the caller's `finally { client.close() }` on this path, and
-  // `client.close()` closes its transport. Mirror that here so callers
-  // need no transport handle to clean up a failed boot.
+  // so the spawned child can't leak — `client.close()` closes its
+  // transport, so callers need no transport handle to clean up a failed
+  // boot.
   try {
     await client.connect(transport);
   } catch (connectErr) {
@@ -156,7 +152,7 @@ async function connectServer({ transportSpec, clientName, stderrPrefix = '[serve
 // purely cosmetic — it's independent of whatever outcome the caller
 // already recorded — so we log it and swallow it. Shared by every
 // teardown path (the runner's `finally`, the flag-gate per-boot
-// `finally`, the redaction gate-ON arm's `finally`). rf2-0ogn7.
+// `finally`, the redaction gate-ON arm's `finally`).
 async function closeQuietly(client) {
   try {
     await client.close();
@@ -166,17 +162,18 @@ async function closeQuietly(client) {
 }
 
 // Module-scope set of SECONDARY MCP clients the watchdog must ALSO tear
-// down on a timeout (rf2-wqi4n4 finding 1). `runWithWatchdog` owns at most
-// ONE primary client (`activeClient`); but two gates boot ADDITIONAL
-// in-process servers via bare `connectServer` INSIDE the body
+// down on a timeout. `runWithWatchdog` owns at most ONE primary client
+// (`activeClient`); but two gates boot ADDITIONAL in-process servers via
+// bare `connectServer` INSIDE the body
 // (`live-re-frame2-pair-redaction.cjs`'s inner-projection + gate-ON arms),
-// and those were never reachable by the outer watchdog — a hang in a
-// secondary boot or a later secondary tool call orphaned that child despite
-// the harness reporting a watchdog timeout. A body registers each secondary
-// client here (via `registerAuxClient`, fired the instant the client is
-// constructed) and deregisters it on teardown; the watchdog drains every
-// surviving member so EVERY spawned child the conformance process owns is
-// reachable by the timeout path from the moment it can exist until teardown.
+// which the outer watchdog cannot reach through `activeClient` alone — a
+// hang in a secondary boot or a later secondary tool call would orphan
+// that child despite the harness reporting a watchdog timeout. A body
+// registers each secondary client here (via `registerAuxClient`, fired
+// the instant the client is constructed) and deregisters it on teardown;
+// the watchdog drains every surviving member so EVERY spawned child the
+// conformance process owns is reachable by the timeout path from the
+// moment it can exist until teardown.
 const AUX_CLIENTS = new Set();
 
 // Register a secondary client so the active watchdog reaps it on a timeout.
@@ -196,46 +193,43 @@ function unregisterAuxClient(client) {
 
 async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) {
   // The watchdog must OWN the active client so a timeout tears the
-  // spawned child down instead of orphaning it (rf2-voux7 finding 5).
-  // `activeClient` is the closure handle the watchdog reads; it is
-  // assigned via `connectServer`'s `onClient` callback the moment the
-  // client is constructed — BEFORE the `await client.connect()`
-  // handshake — so a hang ANYWHERE after spawn (during `initialize`,
-  // inside `body`, inside a slow tool call) is cleaned up. Pre-fix
-  // (rf2-2js41 finding 2) `activeClient` was assigned only AFTER
-  // `connectServer` RESOLVED, i.e. after `connect` completed; a server
-  // that spawned and then hung mid-handshake (connect never resolving,
-  // never throwing) left the watchdog with no client and the timeout
-  // path orphaned the child — the exact orphan class this watchdog
+  // spawned child down instead of orphaning it. `activeClient` is the
+  // closure handle the watchdog reads; it is assigned via
+  // `connectServer`'s `onClient` callback the moment the client is
+  // constructed — BEFORE the `await client.connect()` handshake — so a
+  // hang ANYWHERE after spawn (during `initialize`, inside `body`,
+  // inside a slow tool call) is cleaned up. Assigning at construction
+  // time (not after connect resolves) keeps a server that spawns and
+  // then hangs mid-handshake (connect never resolving, never throwing)
+  // reachable by the timeout path — the exact orphan class this watchdog
   // exists to prevent.
   //
-  // Pre-fix the watchdog called `process.exit(2)` directly, leaving the
-  // spawned MCP server (Node bundle or JVM) running — it can keep the
-  // CI step's log pipes / ports held past the node exit, the exact
-  // orphan class the hermetic orchestrator (rf2-e6enf) already fixes.
-  // `client.close()` closes its transport, which kills the stdio child
-  // (the same teardown `closeQuietly` performs on the normal paths). We
-  // hold the exit a short grace window so the close lands, then exit
-  // with code 2 regardless (a wedged child must not keep us alive).
+  // On a timeout the watchdog tears the spawned MCP server (Node bundle
+  // or JVM) down rather than letting it keep the CI step's log pipes /
+  // ports held past the node exit (the same orphan class the hermetic
+  // orchestrator guards). `client.close()` closes its transport, which
+  // kills the stdio child (the same teardown `closeQuietly` performs on
+  // the normal paths). We hold the exit a short grace window so the
+  // close lands, then exit with code 2 regardless (a wedged child must
+  // not keep us alive).
   let activeClient;
   // Install the watchdog FIRST so even a hang inside transport
   // construction (rare but possible: bad cwd, env corruption) gets
   // killed. The `finally` below clears the timer on every exit path —
-  // including the case where `client.close()` itself throws (per
-  // rf2-i3ffz F-CORR-3: the historical shape did cleanup inside the
-  // `try`, so a throw on the success-path teardown would invert the
-  // log to a FAIL and lose the body's success state).
+  // including the case where `client.close()` itself throws. Keeping the
+  // teardown out of the `try` means a throw on the success-path teardown
+  // does not invert the log to a FAIL and lose the body's success state.
   const watchdog = setTimeout(() => {
     console.error('FAIL: watchdog timeout (' + watchdogMs + 'ms)');
-    // Tear the spawned child down before exiting (rf2-voux7 finding 5).
-    // `closeQuietly` never throws; the `.then`/`.catch` both arm the
-    // hard-exit fallback so a hung close can't keep the process alive.
+    // Tear the spawned child down before exiting. `closeQuietly` never
+    // throws; the `.then`/`.catch` both arm the hard-exit fallback so a
+    // hung close can't keep the process alive.
     const hardExit = setTimeout(() => process.exit(2), 2000);
     hardExit.unref();
-    // Close the primary AND every registered secondary client (rf2-wqi4n4
-    // finding 1) so a hang in ANY in-process MCP child the body spawned is
-    // reaped, not just the runner-managed primary. `closeQuietly` never
-    // throws; wait for all closes to settle before the exit.
+    // Close the primary AND every registered secondary client so a hang
+    // in ANY in-process MCP child the body spawned is reaped, not just
+    // the runner-managed primary. `closeQuietly` never throws; wait for
+    // all closes to settle before the exit.
     const toClose = [];
     if (activeClient) toClose.push(activeClient);
     for (const aux of AUX_CLIENTS) toClose.push(aux);
@@ -250,7 +244,7 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
 
   // Spawn + connect via the shared primitive. A throw here (bad cwd, a
   // malformed initialize envelope) is caught below and surfaces as
-  // exit 1, exactly as the historical inline form did.
+  // exit 1.
   let client;
   let exitCode;
   let bodyError;
@@ -258,10 +252,10 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
     let transport;
     // Capture the teardown handle via `onClient` — fired the instant the
     // client is constructed, BEFORE connect awaits — so a hang during the
-    // initialize handshake is still reachable by the watchdog (rf2-2js41
-    // finding 2). The post-resolve `activeClient = client` below is now
-    // redundant on the happy path but kept as a belt-and-braces guarantee
-    // (and to leave `client` bound for the `finally` teardown).
+    // initialize handshake is still reachable by the watchdog. The
+    // post-resolve `activeClient = client` below is redundant on the
+    // happy path but kept as a belt-and-braces guarantee (and to leave
+    // `client` bound for the `finally` teardown).
     ({ client, transport } = await connectServer({
       transportSpec,
       clientName,
@@ -291,7 +285,7 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
 }
 
 // ---------------------------------------------------------------------
-// Pre-flight skip helper (rf2-i3ffz F-HYG-2).
+// Pre-flight skip helper.
 //
 // Conformance tests gate on environment / server-implementation status
 // (`live-re-frame2-pair-overflow.cjs` requires `$SHADOW_CLJS_NREPL_PORT`).
@@ -307,14 +301,14 @@ runWithWatchdog.skip = function skip(reason) {
 };
 
 // ---------------------------------------------------------------------
-// JSON-RPC error-code conformance gate (rf2-i3ffz F-GAP-3).
+// JSON-RPC error-code conformance gate.
 //
 // `mcp-base/vocab.cljc` pins the five JSON-RPC 2.0 §5.1 codes the
 // MCP servers route against (`-32700` ParseError, `-32600` InvalidRequest,
 // `-32601` MethodNotFound, `-32602` InvalidParams, `-32603`
-// InternalError). Before this gate landed no test asserted either
-// server's actual on-the-wire emission — a regression that swapped
-// `-32602` and `-32603` would have shipped unobserved.
+// InternalError). This gate asserts each server's actual on-the-wire
+// emission, so a regression that swapped `-32602` and `-32603` turns
+// RED rather than shipping unobserved.
 //
 // Coverage today: two of the five codes are reliably reachable from
 // the SDK Client.
@@ -411,32 +405,28 @@ async function assertJsonRpcErrorCodes(client) {
 }
 
 // ---------------------------------------------------------------------
-// Tool-descriptor shape gate (rf2-80y2h).
+// Tool-descriptor shape gate.
 //
-// Both `end-to-end-re-frame2-pair.cjs` and `end-to-end-story.cjs` ran four
-// near-identical `for (const t of listed.tools)` loops over the
-// catalogue, pinning cross-MCP-convention invariants the SDK's
-// ListToolsResultSchema does NOT model:
+// Both `end-to-end-re-frame2-pair.cjs` and `end-to-end-story.cjs` walk the
+// catalogue with this shared gate, pinning cross-MCP-convention
+// invariants the SDK's ListToolsResultSchema does NOT model:
 //
 //   1. inputSchema.type === 'object'        (NAMING.md catalogue surface)
 //   2. inputSchema.properties has max-tokens (TOKEN-BUDGETS.md MUST)
-//   3. an :outputSchema map is declared      (rf2-3l3be)
+//   3. an :outputSchema map is declared
 //   4. an :annotations map with at least one classification hint set
-//      (rf2-94p8q)
 //
-// The two copies (~60 LoC each) differed in EXACTLY one place: the
-// annotations classification set — whether `openWorldHint` counts as a
-// classifier. Both servers now pass `allowOpenWorld: true`:
-// re-frame2-pair-mcp's eval-cljs / dispatch tools touch an open world,
-// and story-mcp's `run-variant` / `preview-variant` run the variant
-// author's lifecycle events/fx which can reach external systems unless
-// stubbed (rf2-e6knrq finding 2 — story-mcp is no longer wholly
+// The two servers differ in EXACTLY one place: the annotations
+// classification set — whether `openWorldHint` counts as a classifier.
+// Both pass `allowOpenWorld: true`: re-frame2-pair-mcp's eval-cljs /
+// dispatch tools touch an open world, and story-mcp's `run-variant` /
+// `preview-variant` run the variant author's lifecycle events/fx which
+// can reach external systems unless stubbed (so story-mcp is not wholly
 // closed-world). The PER-TOOL open-world VALUES are pinned exactly by
 // `assertClassificationRatchet`'s `closed-world` list, so `allowOpenWorld`
 // only sets the "at-least-one-classifier" floor; it does not let a
-// closed-world tool flip open undetected. Extracting the loops here with
-// the flag collapses that drift to a single maintained gate; a new
-// invariant is added once, not twice.
+// closed-world tool flip open undetected. Sharing the loop here keeps the
+// gate single-maintained; a new invariant is added once, not twice.
 //
 // Throws on the first violation with a descriptive, server-agnostic
 // message (the tool name + the failed invariant). Returns nothing.
@@ -464,7 +454,7 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
     }
   }
 
-  // 3. outputSchema declared (rf2-3l3be).
+  // 3. outputSchema declared.
   for (const t of tools) {
     if (!t.outputSchema || typeof t.outputSchema !== 'object') {
       throw new Error(
@@ -474,7 +464,7 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
     }
   }
 
-  // 4. annotations map with at least one classification hint (rf2-94p8q).
+  // 4. annotations map with at least one classification hint.
   // openWorldHint counts as a classifier only when `allowOpenWorld` is
   // set — the single per-server difference between the two harnesses.
   for (const t of tools) {
@@ -502,7 +492,7 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
 }
 
 // ---------------------------------------------------------------------
-// Per-descriptor CONTENT ratchet (rf2-yi451).
+// Per-descriptor CONTENT ratchet.
 //
 // `assertDescriptorShape` (above) pins that EVERY descriptor carries
 // SOME classification hint and a `max-tokens` PROP — but never WHICH
@@ -531,7 +521,7 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
 //                      openWorldHint; pinning `neither` catches a
 //                      side-effecting tool that wrongly gained
 //                      readOnlyHint, masking its effect)
-//   - `closed-world`  — the EXHAUSTIVE open-world partition (rf2-ppk6hy):
+//   - `closed-world`  — the EXHAUSTIVE open-world partition:
 //                       tools listed here MUST carry `openWorldHint:false`
 //                       (inline / no-runtime-reach tools, e.g.
 //                       get-re-frame2-pair-instructions); EVERY tool NOT
@@ -630,15 +620,15 @@ function assertClassificationRatchet(tools, expected) {
       );
     }
 
-    // 2. openWorld posture — BOTH sides of the partition (rf2-ppk6hy).
-    // The fixture's `closed-world` list IS the exhaustive partition: a
-    // tool is closed-world (no runtime reach) OR open-world (reaches the
-    // live browser/nREPL — an external process). Asserting only the
-    // `false` side left a hole — a read-only/destructive tool that
-    // reaches the runtime could DROP `openWorldHint:true` (or set it
-    // false) and still ship GREEN, mislabelling a live-reaching tool as
-    // contained and weakening the MCP client trust/confirmation boundary.
-    // Pin both sides so the complement can't regress.
+    // 2. openWorld posture — BOTH sides of the partition. The fixture's
+    // `closed-world` list IS the exhaustive partition: a tool is
+    // closed-world (no runtime reach) OR open-world (reaches the live
+    // browser/nREPL — an external process). Pinning only the `false` side
+    // would leave a hole — a read-only/destructive tool that reaches the
+    // runtime could DROP `openWorldHint:true` (or set it false) and still
+    // ship GREEN, mislabelling a live-reaching tool as contained and
+    // weakening the MCP client trust/confirmation boundary. Pinning both
+    // sides means the complement can't regress.
     if (closedWorld.has(t.name)) {
       // 2a. Closed-world (inline / no runtime reach) — these ship static /
       // inline / server-local content; openWorldHint MUST be false so a
@@ -655,8 +645,7 @@ function assertClassificationRatchet(tools, expected) {
       // nREPL — an external process) — openWorldHint MUST be true so a
       // host applies the appropriate confirmation ceremony instead of
       // treating the call as contained on-box. A missing or false hint on
-      // a live-reaching tool is the exact false-green this side closes
-      // (rf2-ppk6hy).
+      // a live-reaching tool is the exact false-green this side closes.
       if (a.openWorldHint !== true) {
         throw new Error(
           'tool ' + t.name + ' is open-world (reaches the live browser / ' +
@@ -688,7 +677,7 @@ function assertClassificationRatchet(tools, expected) {
 }
 
 // ---------------------------------------------------------------------
-// SDK callTool() coverage ratchet (rf2-ke5n56).
+// SDK callTool() coverage ratchet.
 //
 // The name ratchet (`tool-names.json`) pins WHICH tools the catalogue
 // advertises; `assertDescriptorShape` / `assertClassificationRatchet`
@@ -697,10 +686,10 @@ function assertClassificationRatchet(tools, expected) {
 // so a regression in a tool's callTool envelope, outputSchema /
 // structuredContent shape, or argument handling ships GREEN for any
 // advertised tool the conformance workflow only LISTS but never CALLS.
-// This was the false-green class the senior review flagged: several
-// advertised Story + Pair tools were descriptor-only in conformance.
+// That is the false-green class this ratchet exists to catch: an
+// advertised Story or Pair tool that is descriptor-only in conformance.
 //
-// This ratchet closes it. The harness records every tool name it
+// The harness records every tool name it
 // drove through `callTool()` (in a `Set`), then calls this gate with:
 //
 //   - `advertised`  — the live `tools/list` names (sourced from the
@@ -792,11 +781,11 @@ function assertCallCoverageRatchet({ advertised, called, exclusions = {} }) {
 }
 
 // ---------------------------------------------------------------------
-// Envelope readers / coverage tracker (rf2-9hkwkp dedup).
+// Envelope readers / coverage tracker.
 //
-// Three SDK-envelope-shape helpers that every conformance body re-rolled
-// identically. None pins a per-test contract — they are pure mechanics
-// feeding the shared ratchets above, so they live here once.
+// Three SDK-envelope-shape helpers shared by every conformance body.
+// None pins a per-test contract — they are pure mechanics feeding the
+// shared ratchets above, so they live here once.
 // ---------------------------------------------------------------------
 
 // Concatenate the `.text` of every content block from an SDK callTool
@@ -811,7 +800,7 @@ function responseText(resp) {
     .join('\n');
 }
 
-// SDK callTool() coverage tracker (rf2-ke5n56). Wrap the raw SDK client
+// SDK callTool() coverage tracker. Wrap the raw SDK client
 // in a Proxy that records the tool name on each `callTool({name,…})` into
 // a fresh `called` Set and transparently delegates every other client
 // member (listTools, getServerVersion, request, close, …) to the real

--- a/tools/mcp-conformance/test/call-coverage-ratchet.test.cjs
+++ b/tools/mcp-conformance/test/call-coverage-ratchet.test.cjs
@@ -1,4 +1,4 @@
-// Unit test for the SDK callTool() coverage ratchet (rf2-ke5n56).
+// Unit test for the SDK callTool() coverage ratchet.
 //
 // `assertCallCoverageRatchet` is itself a conformance gate — it is the
 // teeth that turn a descriptor-only advertised tool (LISTED but never

--- a/tools/mcp-conformance/test/classification-ratchet.test.cjs
+++ b/tools/mcp-conformance/test/classification-ratchet.test.cjs
@@ -1,5 +1,4 @@
-// Unit test for the per-tool annotation CLASSIFICATION ratchet
-// (rf2-yi451; open-world complement closed in rf2-ppk6hy).
+// Unit test for the per-tool annotation CLASSIFICATION ratchet.
 //
 // `assertClassificationRatchet` is itself a conformance gate — it is the
 // teeth that turn a per-tool annotation regression (a flipped read-only /
@@ -14,11 +13,11 @@
 // The end-to-end harnesses (`end-to-end-story.cjs` /
 // `end-to-end-re-frame2-pair.cjs`) exercise the GREEN path live (every
 // advertised tool's real wire descriptor). This test pins the RED paths
-// the green runs never hit — in particular the rf2-ppk6hy open-world hole:
-// before the fix the ratchet asserted only the `closed-world` (false) side
-// of the openWorld partition, so a read-only or destructive tool that
-// reaches the live browser / nREPL could drop (or false) `openWorldHint`
-// and still ship GREEN, mislabelling a live-reaching tool as contained.
+// the green runs never hit — in particular the open-world side of the
+// partition: a read-only or destructive tool that reaches the live
+// browser / nREPL must carry `openWorldHint:true`. Dropping (or falsing)
+// that hint mislabels a live-reaching tool as contained, and the ratchet
+// must turn that RED.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
@@ -75,7 +74,7 @@ test('GREEN: the legitimate open/closed partition ⇒ no throw', () => {
   );
 });
 
-// --- rf2-ppk6hy: the open-world complement (the regression this fix adds) ---
+// --- the open-world complement: live-reaching tools MUST flag openWorldHint ---
 
 test('RED: a read-only live tool that DROPS openWorldHint ⇒ throws + names it', () => {
   const tools = greenTools();
@@ -99,7 +98,7 @@ test('RED: a read-only live tool with openWorldHint:false ⇒ throws (mislabelle
 test('RED: a DESTRUCTIVE live tool that drops openWorldHint ⇒ throws (the trust-boundary case)', () => {
   const tools = greenTools();
   // write-live is destructive AND reaches the runtime; dropping the
-  // open-world hint without this complement would ship GREEN pre-fix.
+  // open-world hint on a live-reaching destructive tool must trip the gate.
   tools[1].annotations = { destructiveHint: true };
   assert.throws(
     () => assertClassificationRatchet(tools, FIXTURE),
@@ -116,7 +115,7 @@ test('RED: a `neither` live tool that drops openWorldHint ⇒ throws', () => {
   );
 });
 
-// --- the closed-world (false) side still holds (rf2-yi451) ---
+// --- the closed-world (false) side holds: inline tools MUST NOT claim reach ---
 
 test('RED: a closed-world tool that flips openWorldHint:true ⇒ throws', () => {
   const tools = greenTools();
@@ -137,7 +136,7 @@ test('RED: a closed-world tool that drops openWorldHint ⇒ throws', () => {
   );
 });
 
-// --- the read-only / destructive posture axis still holds (rf2-yi451) ---
+// --- the read-only / destructive posture axis ---
 
 test('RED: a destructive tool re-labelled read-only ⇒ throws', () => {
   const tools = greenTools();

--- a/tools/mcp-conformance/test/dedup-envelope.test.cjs
+++ b/tools/mcp-conformance/test/dedup-envelope.test.cjs
@@ -1,29 +1,27 @@
-// Unit tests for the Node-side dedup-envelope decoder (rf2-87h71e LOW).
+// Unit tests for the Node-side dedup-envelope decoder.
 //
 // Uses Node's built-in `node:test` (same posture as the other
 // `*.test.cjs` unit suites — no extra dev-dependency).
 //
-// ## The bug this pins
+// ## The contract this pins
 //
 // `lib/dedup-envelope.cjs` `expandCache` reconstructs the day8/de-dupe
 // structural-dedup cache (`:rf.mcp/dedup-table`) the MCP servers emit on
-// the wire. Pre-fix, the cycle-guard set `memo.set(cacheId, undefined)`
-// before recursing, so a cache ref that re-entered an in-progress entry
-// (a CYCLE) resolved to `undefined` — SILENT corruption (a stray
-// `undefined` hole in the reconstruction) rather than a loud error. Real
-// de-dupe caches are acyclic (refs always point at strictly-smaller
-// subtrees), so this is latent — but a conformance decoder MUST fail loud
-// on malformed / adversarial input, not silently emit garbage.
-//
-// The fix installs a distinct in-progress sentinel and throws `cyclic
-// dedup cache` when a ref resolves to it. These tests pin:
+// the wire. The cycle-guard installs a distinct in-progress sentinel and
+// throws `cyclic dedup cache` when a ref resolves to it, so a cache ref
+// that re-enters an in-progress entry (a CYCLE) fails LOUD rather than
+// resolving to `undefined` (silent corruption — a stray `undefined` hole
+// in the reconstruction). Real de-dupe caches are acyclic (refs always
+// point at strictly-smaller subtrees), so a cycle is adversarial input —
+// and a conformance decoder MUST fail loud on malformed / adversarial
+// input, not silently emit garbage. These tests pin:
 //
 //   1. a cyclic cache table THROWS (with a `cyclic` message) — the
-//      regression this closes; the decoder no longer returns `undefined`.
-//   2. the acyclic happy path (shared subtrees, nested refs) still
-//      reconstructs correctly — the fix doesn't break real caches.
-//   3. a dangling ref (no matching entry) still throws its own distinct
-//      error (unchanged behaviour, pinned alongside).
+//      decoder rejects it rather than returning an `undefined` hole.
+//   2. the acyclic happy path (shared subtrees, nested refs)
+//      reconstructs correctly — real caches decode cleanly.
+//   3. a dangling ref (no matching entry) throws its own distinct
+//      error, pinned alongside.
 
 'use strict';
 

--- a/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
+++ b/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
@@ -1,30 +1,26 @@
 // End-to-end MCP-client conformance for the cross-MCP operator-opt-in
 // CLI flag vocabulary (NAMING.md §"Operator-opt-in CLI flag
-// vocabulary"). Source: rf2-ee38b.20 (review-remediation; the P1 gap the
-// completeness lens flagged — the flag vocabulary had no conformance
-// gate at all).
+// vocabulary").
 //
 // ## What this guards
 //
 // NAMING.md pins a cross-server flag contract: same operator semantic ⇒
 // same flag spelling, every authority-gate flag DEFAULT-OFF, and a
 // "hard rename, no aliases" rule (a legacy / unrecognised spelling stops
-// being recognised at the parser; it must NOT open the gate). Before this
-// harness those claims were pinned only by each server's OWN unit
-// fixtures — the cross-server, observable-over-the-wire contract was
-// unenforced. A regression that renamed story-mcp's write gate to
-// `--enable-writes`, or that flipped a default to ON, would have passed
-// every conformance test here.
+// being recognised at the parser; it must NOT open the gate). This
+// harness enforces the cross-server, observable-over-the-wire contract
+// that each server's OWN unit fixtures cannot reach. A regression that
+// renamed story-mcp's write gate to `--enable-writes`, or that flipped a
+// default to ON, turns RED here.
 //
 // This harness drives the contract through the official MCP SDK client —
 // the same path a real consumer (Claude Code, Continue, …) takes — for
 // the flag whose gated posture is observable WITHOUT a live runtime:
-// story-mcp's `--allow-writes`. (The pair-mcp eval-cljs gate flipped
-// to default-ON per rf2-a0z0h; the disabled envelope is reachable only
-// with the `--no-eval` opt-out against a live nREPL — see "Coverage
-// boundary" below; that wire check lives in
-// `live-re-frame2-pair-subscribe.cjs`, which boots a non-degraded
-// server with `--no-eval`.)
+// story-mcp's `--allow-writes`. (The pair-mcp eval-cljs gate is
+// default-ON; the disabled envelope is reachable only with the
+// `--no-eval` opt-out against a live nREPL — see "Coverage boundary"
+// below; that wire check lives in `live-re-frame2-pair-subscribe.cjs`,
+// which boots a non-degraded server with `--no-eval`.)
 //
 // ### story-mcp `--allow-writes` (default OFF, hard-rename rejection)
 //
@@ -35,9 +31,8 @@
 //      `structuredContent.tool` naming the tripping tool (the default-OFF
 //      posture per spec/003-Write-Surface-Gating.md §"What's gated"). This
 //      is the security-critical claim: a fresh / CI boot cannot mutate the
-//      registry by ANY gated path. (Pre-rf2-ke5n56 only `register-variant`
-//      was probed default-off, so a dropped gate-check on either of the
-//      other two shipped green.)
+//      registry by ANY gated path. Probing all three default-off means a
+//      dropped gate-check on any of them turns RED.
 //   1b. Boot WITHOUT the flag (well, WITH it to seed a fixture, then) ⇒
 //      `record-as-variant` WITHOUT `:write-back` SUCCEEDS — the
 //      intentionally UNGATED snippet-only recording path. Together with
@@ -52,11 +47,11 @@
 //      unrecognised flag does NOT open the gate (the parser logs+ignores
 //      it; no back-compat alias re-enables the surface).
 //
-// ## Coverage boundary (judgment, rf2-ee38b.20)
+// ## Coverage boundary (judgment)
 //
-// The completeness lens suggested "boot each server WITHOUT its opt-in
-// flag (no nREPL needed) and assert the gated tool returns the
-// disabled-default envelope." That holds for story-mcp (JVM server, no
+// One tempting design is "boot each server WITHOUT its opt-in flag (no
+// nREPL needed) and assert the gated tool returns the disabled-default
+// envelope." That holds for story-mcp (JVM server, no
 // degraded mode — `register-variant` always routes to the tool, which
 // checks the gate first). It does NOT hold for re-frame2-pair-mcp:
 // without a resolvable nREPL port pair-mcp boots in DEGRADED mode
@@ -65,10 +60,9 @@
 // `eval-cljs` never reaches its `--no-eval` gate and the
 // `:rf.error/eval-cljs-disabled` envelope is unreachable degraded. The
 // honest home for the pair-mcp eval-gate WIRE check is therefore the
-// live path: `live-re-frame2-pair-subscribe.cjs` already boots a
-// non-degraded server WITH `--no-eval` (the opt-out post-rf2-a0z0h),
-// so it observes the disabled envelope over the wire when a runtime is
-// attached. The pair-mcp parser
+// live path: `live-re-frame2-pair-subscribe.cjs` boots a non-degraded
+// server WITH `--no-eval` (the eval opt-out), so it observes the disabled
+// envelope over the wire when a runtime is attached. The pair-mcp parser
 // rename-rejection itself (`--allow-raw-state` legacy spelling ⇒ gate
 // stays closed) is pinned at the unit layer by
 // `re-frame2-pair-mcp/test/.../raw_state_test.cljs`
@@ -98,8 +92,8 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 
 // Resolve `clojure` to a trusted absolute path outside the workspace, or
 // honour the explicit STORY_MCP_CMD override (same posture as
-// end-to-end-story.cjs — rf2-33vvc accident-gating fires only on the
-// implicit-PATH path).
+// end-to-end-story.cjs — accident-gating fires only on the implicit-PATH
+// path).
 const CLOJURE = process.env.STORY_MCP_CMD
   ? process.env.STORY_MCP_CMD
   : resolveTrustedExe('clojure', { workspaceRoot: REPO_ROOT });
@@ -113,16 +107,16 @@ const FIXTURE_BODY_EDN = '{:doc "flag-gate conformance probe." :tags #{:dev}}';
 
 // Cold JVM boot is ~10-30s; each gate below boots a fresh JVM (the gate
 // is a boot-time atom — we can't flip it on a running server through the
-// MCP surface, which is exactly the point). rf2-ke5n56 grew the boot
-// count from 3 to 7 (default-off, snippet-only-ungated, record-as-variant
-// write-back gate OFF + ON, opt-in, two legacy spellings), so the cap is
-// lifted from 180s to 300s to keep comfortable margin on a cold CI worker.
+// MCP surface, which is exactly the point). The seven boots (default-off,
+// snippet-only-ungated, record-as-variant write-back gate OFF + ON,
+// opt-in, two legacy spellings) fit comfortably under the 300s cap on a
+// cold CI worker.
 //
 // `$FLAG_GATE_WATCHDOG_MS` overrides the cap for the hermetic
-// connect-hang regression harness ONLY (rf2-wqi4n4 finding 1's
-// `runner-watchdog.test.cjs` drives this module with a stubbed
-// never-resolving connect under a 200ms cap to prove the watchdog tears
-// the hung JVM down). Production CI never sets it, so the 300s cap stands.
+// connect-hang regression harness ONLY (`runner-watchdog.test.cjs` drives
+// this module with a stubbed never-resolving connect under a 200ms cap to
+// prove the watchdog tears the hung JVM down). Production CI never sets
+// it, so the 300s cap stands.
 const WATCHDOG_MS = Number(process.env.FLAG_GATE_WATCHDOG_MS) || 300000;
 
 // ---------------------------------------------------------------------------
@@ -133,29 +127,29 @@ const WATCHDOG_MS = Number(process.env.FLAG_GATE_WATCHDOG_MS) || 300000;
 // Each call spawns a fresh JVM so the boot-time gate atom reflects ONLY
 // the args passed here — no cross-contamination between the default-OFF,
 // opt-in, and rename-rejection probes. The spawn+connect+teardown
-// ceremony is the shared `connectServer` / `closeQuietly` primitive
-// (rf2-0ogn7) — `runWithWatchdog`'s single-boot-per-process form can't
-// serve this gate, which needs three fresh in-process JVM boots.
+// ceremony is the shared `connectServer` / `closeQuietly` primitive —
+// `runWithWatchdog`'s single-boot-per-process form can't serve this gate,
+// which needs several fresh in-process JVM boots.
 // ---------------------------------------------------------------------------
 // The watchdog (module scope below) must OWN whichever story-mcp JVM is
 // currently booted so a timeout tears it down instead of orphaning it
-// (rf2-voux7 finding 5 — same orphan class the shared `_runner.cjs`
-// watchdog and the hermetic orchestrator rf2-e6enf fix). `withStoryServer`
-// publishes its connected client here for the spawn's lifetime and clears
-// it on teardown; the boots are sequential so at most one is live at once.
+// (the same orphan class the shared `_runner.cjs` watchdog and the
+// hermetic orchestrator guard). `withStoryServer` publishes its connected
+// client here for the spawn's lifetime and clears it on teardown; the
+// boots are sequential so at most one is live at once.
 //
-// Per rf2-wqi4n4 finding 1: publish the handle via `connectServer`'s
-// `onClient` callback — fired the INSTANT the client is constructed,
-// BEFORE the `await client.connect()` handshake — not after `connectServer`
-// resolves. The transport spawns the JVM during construction, so a story-mcp
-// child that boots and then HANGS mid-`initialize` (connect never resolving,
-// never throwing) leaves `await connectServer(...)` blocked forever; the
-// post-resolve `activeFlagGateClient = client` below would never run, the
-// module-scope watchdog would fire with `activeFlagGateClient === null`, and
-// its `else` branch would `process.exit(2)` WITHOUT tearing the hung JVM
-// down — orphaning exactly the child the watchdog exists to reap. `onClient`
-// closes that window. (This is the bare-caller analogue of the rf2-2js41
-// finding-2 fix in `runWithWatchdog`, which these callers bypass.)
+// Publish the handle via `connectServer`'s `onClient` callback — fired
+// the INSTANT the client is constructed, BEFORE the `await
+// client.connect()` handshake — not after `connectServer` resolves. The
+// transport spawns the JVM during construction, so a story-mcp child that
+// boots and then HANGS mid-`initialize` (connect never resolving, never
+// throwing) leaves `await connectServer(...)` blocked forever; capturing
+// the handle only post-resolve would leave the module-scope watchdog with
+// `activeFlagGateClient === null`, and its `else` branch would
+// `process.exit(2)` WITHOUT tearing the hung JVM down — orphaning exactly
+// the child the watchdog exists to reap. `onClient` closes that window.
+// (This is the bare-caller analogue of the `onClient` capture in
+// `runWithWatchdog`, which these callers bypass.)
 let activeFlagGateClient = null;
 
 async function withStoryServer(extraArgs, body) {
@@ -168,9 +162,9 @@ async function withStoryServer(extraArgs, body) {
       env: { ...process.env },
     },
     // Capture the teardown handle BEFORE connect awaits, so a connect that
-    // hangs mid-handshake is still reachable by the module-scope watchdog
-    // (rf2-wqi4n4 finding 1). The post-resolve assignment below is now
-    // redundant on the happy path but kept belt-and-braces.
+    // hangs mid-handshake is still reachable by the module-scope watchdog.
+    // The post-resolve assignment below is redundant on the happy path but
+    // kept belt-and-braces.
     onClient: (c) => { activeFlagGateClient = c; },
   });
   activeFlagGateClient = client;
@@ -197,13 +191,10 @@ function callRegisterVariant(client) {
 // with the gate closed they refuse with a tool-execution error (NOT a
 // JSON-RPC protocol error — the agent's conversation survives) carrying
 // `structuredContent.gated === true` AND `structuredContent.tool` naming
-// the tripping tool (the `:tool` slot is per-tool, not hardcoded —
-// rf2-c52j0).
+// the tripping tool (the `:tool` slot is per-tool, not hardcoded).
 //
-// Pre-rf2-ke5n56 the flag-gate harness funnelled ALL default-off probes
-// through `register-variant` only; `unregister-variant` appeared solely
-// as positive-control cleanup, so a dropped gate-check on it shipped
-// green. These two rows close that gap. The THIRD gated tool,
+// Both tools are probed default-off here so a dropped gate-check on
+// either turns RED, not just `register-variant`. The THIRD gated tool,
 // `record-as-variant` (gated only when `:write-back true`), has a
 // different gate-ORDERING and is handled separately by
 // `assertRecordAsVariantWriteBackGate` — see the long note there.
@@ -223,11 +214,10 @@ const GATED_WRITE_PROBES = [
 // ---------------------------------------------------------------------------
 
 async function assertWriteGateClosedByDefault() {
-  // One fresh gate-OFF boot exercises ALL THREE gated write tools
-  // (rf2-ke5n56). Pre-rf2-ke5n56 only `register-variant` was probed
-  // default-off; `unregister-variant` and `record-as-variant`
-  // (write-back) had no default-off wire coverage despite the spec
-  // gating all three — a dropped gate-check on either shipped green.
+  // One fresh gate-OFF boot exercises ALL THREE gated write tools. The
+  // spec gates all three, so each gets default-off wire coverage here —
+  // `register-variant`, `unregister-variant`, and `record-as-variant`
+  // (write-back) — and a dropped gate-check on any of them turns RED.
   await withStoryServer([], async (client) => {
     for (const probe of GATED_WRITE_PROBES) {
       const resp = await client.callTool(probe);
@@ -249,10 +239,10 @@ async function assertWriteGateClosedByDefault() {
             'structuredContent.gated === true; got: ' + JSON.stringify(resp),
         );
       }
-      // The `:tool` slot names the tripping tool (rf2-c52j0 — it was once
-      // hardcoded and lied about its origin). Assert it matches the tool we
-      // called so a copy-paste regression that returned a sibling tool's
-      // refusal (still carrying `:gated true`) is caught.
+      // The `:tool` slot names the tripping tool (per-tool, not
+      // hardcoded). Assert it matches the tool we called so a copy-paste
+      // regression that returned a sibling tool's refusal (still carrying
+      // `:gated true`) is caught.
       if (struct.tool !== probe.name) {
         throw new Error(
           'story-mcp ' + probe.name + ' gated envelope MUST name the tripping ' +
@@ -276,7 +266,7 @@ async function assertWriteGateClosedByDefault() {
   });
 }
 
-// The intentional UNGATED path (rf2-ke5n56 + spec/003-Write-Surface-Gating.md
+// The intentional UNGATED path (spec/003-Write-Surface-Gating.md
 // §"What's gated"): `record-as-variant` WITHOUT `:write-back` is a
 // snippet-only recording — it returns the `(reg-variant …)` text snippet
 // and does NOT mutate the registry, so it is deliberately NOT gated
@@ -360,15 +350,13 @@ async function assertSnippetOnlyRecordIsUngated() {
   });
 }
 
-// `record-as-variant` write-back gate — VERIFIED ORDERING ASYMMETRY
-// (rf2-ke5n56, flagged for the server owner; see PR / follow-up bead).
+// `record-as-variant` write-back gate — ORDERING ASYMMETRY (flagged for
+// the server owner as a possible consistency fix).
 //
-// The bead's acceptance criterion asks for a DEFAULT-OFF gated refusal
-// (`gated:true` + `tool:"record-as-variant"`) for `record-as-variant`
-// with `:write-back true`, mirroring register/unregister. While wiring
-// it I verified the source and found it is NOT reachable in a clean
-// gate-OFF boot, because `record-as-variant`'s gate ORDERING differs from
-// its two siblings:
+// A DEFAULT-OFF gated refusal (`gated:true` + `tool:"record-as-variant"`)
+// for `record-as-variant` with `:write-back true` is NOT reachable in a
+// clean gate-OFF boot, because `record-as-variant`'s gate ORDERING
+// differs from its two siblings:
 //
 //   - register-variant / unregister-variant (write.cljc) check
 //     `assert-writes-allowed` as their FIRST expression — BEFORE any
@@ -394,22 +382,22 @@ async function assertSnippetOnlyRecordIsUngated() {
 //
 //   1. gate OFF, write-back:true, unregistered target ⇒ `Variant not
 //      found` (NOT `gated:true`). This documents + REGRESSION-LOCKS the
-//      verified ordering: if the server is later fixed to gate-first
-//      (the flagged change), this assertion flips to expect `gated:true`
-//      and `tool:"record-as-variant"` — the test is the executable record
-//      of the current contract and the seam for the fix.
+//      ordering: if the server is later fixed to gate-first (the flagged
+//      change), this assertion flips to expect `gated:true` and
+//      `tool:"record-as-variant"` — the test is the executable record of
+//      the current contract and the seam for the fix.
 //   2. gate ON, write-back:true ⇒ the positive control: the write-back
 //      path SUCCEEDS, reports `:written-back? true`, and mints the new
-//      variant id. This is the load-bearing write-back coverage the bead
-//      asked for (a regression that broke the write-back registration, or
-//      that gated it even with the flag ON, ships RED here) — just on the
-//      reachable gate state.
+//      variant id. This is the load-bearing write-back coverage (a
+//      regression that broke the write-back registration, or that gated
+//      it even with the flag ON, ships RED here) — just on the reachable
+//      gate state.
 async function assertRecordAsVariantWriteBackGate() {
   const NEW_VID = 'story.mcp-conformance/flag-gate.recorded';
 
   // 1. gate OFF — write-back:true against an unregistered target. The
-  // verified ordering means this surfaces `Variant not found`, NOT a
-  // gated envelope. We assert that precisely so the asymmetry is locked.
+  // gate ordering means this surfaces `Variant not found`, NOT a gated
+  // envelope. We assert that precisely so the asymmetry is locked.
   await withStoryServer([], async (client) => {
     const resp = await client.callTool({
       name: 'record-as-variant',
@@ -527,13 +515,11 @@ async function assertWriteGateOpensWithFlag() {
     const struct = resp.structuredContent || {};
     // Pin the SINGLE canonical key story-mcp emits: `:registered?`
     // (Cheshire keeps the `?` → JSON key `registered?`; pinned JVM-side
-    // by tools_test.clj and by the sibling end-to-end-story.cjs). The
-    // earlier `registered || registered?` alternation tolerated two
-    // spellings — masking exactly the envelope-key drift this harness
-    // family pins single-spelling (rf2-ee38b.20). A drift to bare
-    // `registered` would slip past here while end-to-end-story.cjs caught
-    // it RED; tighten to the one canonical spelling so this code path
-    // agrees with its sibling.
+    // by tools_test.clj and by the sibling end-to-end-story.cjs). Pinning
+    // exactly one spelling catches the envelope-key drift this harness
+    // family pins single-spelling; a drift to bare `registered` trips RED
+    // here, in agreement with its sibling. A tolerated second spelling
+    // would mask it.
     if (struct['registered?'] !== true) {
       throw new Error(
         'story-mcp register-variant with --allow-writes MUST report ' +
@@ -598,18 +584,17 @@ async function main() {
   console.log('\nMCP CLI FLAG-VOCABULARY CONFORMANCE GREEN');
 }
 
-// Watchdog so a hung JVM can't wedge CI. Three sequential cold boots +
+// Watchdog so a hung JVM can't wedge CI. The sequential cold boots +
 // one register round-trip each fit well under this.
 //
-// Per rf2-voux7 finding 5: tear the currently-booted story-mcp JVM down
-// BEFORE exiting. The pre-fix watchdog called `process.exit(2)` directly,
-// orphaning whichever JVM was live — a child that inherited the step's
-// stdio can keep the CI log pipes open past the node exit (the same
-// orphan class the shared `_runner.cjs` watchdog and the hermetic
-// orchestrator rf2-e6enf already fix). `closeQuietly` closes the client,
-// which closes its transport and kills the stdio JVM child; a hard-exit
-// fallback fires after a short grace window so a hung close can't keep us
-// alive.
+// On a timeout, tear the currently-booted story-mcp JVM down BEFORE
+// exiting rather than calling `process.exit(2)` directly — a bare exit
+// would orphan whichever JVM was live, and a child that inherited the
+// step's stdio can keep the CI log pipes open past the node exit (the
+// same orphan class the shared `_runner.cjs` watchdog and the hermetic
+// orchestrator guard). `closeQuietly` closes the client, which closes its
+// transport and kills the stdio JVM child; a hard-exit fallback fires
+// after a short grace window so a hung close can't keep us alive.
 const watchdog = setTimeout(() => {
   console.error('FAIL: watchdog timeout (' + WATCHDOG_MS + 'ms)');
   const hardExit = setTimeout(() => process.exit(2), 2000);

--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -24,7 +24,7 @@
 // The test runs in degraded mode (no nREPL on $SHADOW_CLJS_NREPL_PORT)
 // — same shape as the upstream stdio-roundtrip — so it stays
 // self-contained and reproducible on CI without needing a live
-// shadow-cljs runtime. Source: rf2-cum40.
+// shadow-cljs runtime.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -41,61 +41,59 @@ const {
 const RE_FRAME2_PAIR_MCP_DIR = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp');
 const SERVER = path.join(RE_FRAME2_PAIR_MCP_DIR, 'out', 'server.js');
 
-// Per-tool annotation-classification ratchet (rf2-yi451). Pins each
-// descriptor's EXACT readOnly/destructive posture + budget-hint prose so
-// a tool silently re-classified (a destructive write re-labelled
-// readOnly — a trust-boundary regression an agent host would auto-approve)
-// turns this gate RED for an unchanged tool-set. Sourced from this
-// slice's own fixture (mirrors tools/re-frame2-pair-mcp/tool-descriptors.edn).
+// Per-tool annotation-classification ratchet. Pins each descriptor's
+// EXACT readOnly/destructive posture + budget-hint prose so a tool
+// silently re-classified (a destructive write re-labelled readOnly — a
+// trust-boundary regression an agent host would auto-approve) turns this
+// gate RED for an unchanged tool-set. Sourced from this slice's own
+// fixture (mirrors tools/re-frame2-pair-mcp/tool-descriptors.edn).
 const EXPECTED_CLASSIFICATIONS = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'fixtures', 're-frame2-pair-classifications.json'), 'utf8'),
 );
 
 // Canonical tool-name list — sourced from re-frame2-pair-mcp's own fixture
-// (rf2-drke0, mirrors story-mcp's rf2-36upq TE7) so this conformance
-// harness and the upstream `tools/re-frame2-pair-mcp/test/stdio-roundtrip.js`
-// agree on the expected `tools/list` response without two hand-
-// maintained lists drifting. A registry change updates one file.
+// (mirrors story-mcp's fixture pattern) so this conformance harness and
+// the upstream `tools/re-frame2-pair-mcp/test/stdio-roundtrip.js` agree on
+// the expected `tools/list` response without two hand-maintained lists
+// drifting. A registry change updates one file.
 const EXPECTED_TOOLS = JSON.parse(
   fs.readFileSync(path.join(RE_FRAME2_PAIR_MCP_DIR, 'test', 'fixtures', 'tool-names.json'), 'utf8'),
 ).names;
 
 // Force degraded mode: empty out $SHADOW_CLJS_NREPL_PORT and boot from
-// a tmpdir so the port-file probe misses. Pre-rf2-umoz2 that was
-// sufficient; the cwd-relative file scan was the last discovery step.
-// rf2-umoz2 added a shadow HTTP probe (default port 9630) that would
-// otherwise resolve a port whenever shadow happens to be running on the
-// CI agent's loopback — so we pin --http-port to a port we know is
-// closed (port 1, IANA-reserved + never bound) which makes the probe's
-// ECONNREFUSED short-circuit deterministic on every host.
+// a tmpdir so the port-file probe misses. The server also runs a shadow
+// HTTP probe (default port 9630) that would otherwise resolve a port
+// whenever shadow happens to be running on the CI agent's loopback — so
+// we pin --http-port to a port we know is closed (port 1, IANA-reserved
+// + never bound) which makes the probe's ECONNREFUSED short-circuit
+// deterministic on every host.
 const env = { ...process.env };
 delete env.SHADOW_CLJS_NREPL_PORT;
 
-// SDK callTool() coverage tracking (rf2-ke5n56) via the shared `track`
-// helper (_runner.cjs): every tool driven through `Client.callTool()`
-// records its name into the returned `called` Set; the coverage ratchet at
-// the end of the body fails if any ADVERTISED tool is neither recorded nor
-// in the reviewed exclusion table.
+// SDK callTool() coverage tracking via the shared `track` helper
+// (_runner.cjs): every tool driven through `Client.callTool()` records
+// its name into the returned `called` Set; the coverage ratchet at the
+// end of the body fails if any ADVERTISED tool is neither recorded nor in
+// the reviewed exclusion table.
 
 // Advertised pair-mcp tools intentionally NOT SDK-call-covered by THIS
-// degraded harness, each with a rationale naming WHERE its coverage lives
-// (rf2-ke5n56). The pair-mcp conformance surface is split: this
-// end-to-end runs DEGRADED (no nREPL), where every tool returns the same
+// degraded harness, each with a rationale naming WHERE its coverage
+// lives. The pair-mcp conformance surface is split: this end-to-end runs
+// DEGRADED (no nREPL), where every tool returns the same
 // `:nrepl-port-not-found` envelope (except the two gated writes, refused
 // pre-connection) — so a degraded probe proves the descriptor reaches the
 // SDK, the dispatch-table entry is wired, the arg shape is accepted, and
 // the SDK's CallToolResultSchema parses the envelope. The genuinely
 // LIVE-only behaviours (streaming progress frames, overflow markers,
 // redaction, the eval/write gates' SUCCESS/refusal under a real runtime)
-// are pinned by the gated live harnesses. This table is currently EMPTY:
-// rf2-ke5n56 added a cheap degraded probe for every previously
-// descriptor-only tool, so all 28 advertised tools are now SDK-called
-// here. The table is wired through `assertCallCoverageRatchet` so a
-// FUTURE tool that is genuinely unreachable degraded has a reviewed home
-// (e.g. `{ 'some-live-only-tool': 'live-only; covered by
-// live-re-frame2-pair-<x>.cjs under a real nREPL' }`) instead of silently
-// dropping out of coverage. A blank/stale/contradictory row trips the
-// ratchet.
+// are pinned by the gated live harnesses. This table is EMPTY: the
+// degraded walk below drives a cheap probe for every advertised tool, so
+// all 28 are SDK-called here. The table is wired through
+// `assertCallCoverageRatchet` so a FUTURE tool that is genuinely
+// unreachable degraded has a reviewed home (e.g. `{ 'some-live-only-tool':
+// 'live-only; covered by live-re-frame2-pair-<x>.cjs under a real nREPL'
+// }`) instead of silently dropping out of coverage. A
+// blank/stale/contradictory row trips the ratchet.
 const PAIR_CALL_EXCLUSIONS = {};
 
 runWithWatchdog(
@@ -110,7 +108,7 @@ runWithWatchdog(
     },
   },
   async (rawClient) => {
-    // Wrap the SDK client in the coverage tracker (rf2-ke5n56): every
+    // Wrap the SDK client in the coverage tracker: every
     // `client.callTool({name,…})` below records `name` for the callTool
     // coverage ratchet at the end of this body. All other client members
     // delegate transparently.
@@ -137,21 +135,21 @@ runWithWatchdog(
     console.log('OK   tools/list -> ' + names.length + ' tools advertised:', names.join(', '));
 
     // 2b-2d. Descriptor-shape conformance — inputSchema type=object +
-    // max-tokens (rf2-i3ffz F-GAP-2 / TOKEN-BUDGETS.md), :outputSchema
-    // (rf2-3l3be), and an :annotations classification hint (rf2-94p8q).
-    // The shared `assertDescriptorShape` helper pins all three; pair-mcp
-    // permits `openWorldHint` as a classifier (its eval-cljs / dispatch
-    // tools touch an open world), so `allowOpenWorld: true`. See
-    // _runner.cjs for the per-invariant rationale (rf2-80y2h dedup).
+    // max-tokens (TOKEN-BUDGETS.md), :outputSchema, and an :annotations
+    // classification hint. The shared `assertDescriptorShape` helper pins
+    // all three; pair-mcp permits `openWorldHint` as a classifier (its
+    // eval-cljs / dispatch tools touch an open world), so
+    // `allowOpenWorld: true`. See _runner.cjs for the per-invariant
+    // rationale.
     assertDescriptorShape(listed.tools, { allowOpenWorld: true });
     console.log(
       'OK   every tool descriptor: inputSchema(type=object,max-tokens) + outputSchema + annotations hint',
     );
 
-    // 2e. Per-tool classification CONTENT ratchet (rf2-yi451). The shape
-    // check above pins that SOME classifier is set; this pins WHICH —
-    // the exact readOnly/destructive posture per tool + the budget-hint
-    // prose. A destructive write tool (dispatch, eval-cljs, restore-epoch,
+    // 2e. Per-tool classification CONTENT ratchet. The shape check above
+    // pins that SOME classifier is set; this pins WHICH — the exact
+    // readOnly/destructive posture per tool + the budget-hint prose. A
+    // destructive write tool (dispatch, eval-cljs, restore-epoch,
     // replace-app-db) silently re-classified readOnly would ship green
     // under the shape check (readOnlyHint alone satisfies "≥1 set") but
     // turns RED here. See _runner.cjs for the per-posture rationale.
@@ -178,29 +176,24 @@ runWithWatchdog(
     //
     //   - dispatch          write-shaped tool. The MCP inputSchema names
     //                        the slot `event` — a single EDN-vector
-    //                        string parsed server-side (rf2-vflrg).
-    //                        (Degraded-mode returns :nrepl-port-not-found
-    //                        regardless of args, so the pre-rf2-zb5z6
-    //                        `event-v` typo went unobserved here; the
-    //                        live subscribe gate surfaced it.)
+    //                        string parsed server-side. (Degraded-mode
+    //                        returns :nrepl-port-not-found regardless of
+    //                        args, so arg-shape regressions surface in the
+    //                        live subscribe gate, not here.)
     //   - watch-epochs       pull-mode tool.
     //   - snapshot           mega-op tool.
     //   - subscribe          streaming-shaped tool. In connected mode it
     //                        would open a notification stream; degraded it
     //                        returns the same error envelope.
     //   - list-subscriptions lists the LIVE reactive sub-cache for a frame
-    //                        (rf2-qicji repointed it here from the
-    //                        streaming-tap registry; it now reads the same
-    //                        source as `snapshot :sub-cache` via the
-    //                        runtime's `sub-cache-info` fn). Pure-read,
-    //                        optional :frame / :include-values.
-    //   - list-streams       the streaming-tap diagnostic list-subscriptions
-    //                        formerly carried (rf2-qicji split). Wraps
-    //                        `re-frame2-pair.runtime/subscription-info`
-    //                        (runtime fn keeps the historical name) so AI
-    //                        clients can list active streaming subscriptions
-    //                        without an eval-cljs round-trip. Pure-read,
-    //                        optional :topic / :sub-id filters.
+    //                        — the same source as `snapshot :sub-cache`,
+    //                        via the runtime's `sub-cache-info` fn.
+    //                        Pure-read, optional :frame / :include-values.
+    //   - list-streams       the streaming-tap diagnostic list. Wraps
+    //                        `re-frame2-pair.runtime/subscription-info` so
+    //                        AI clients can list active streaming
+    //                        subscriptions without an eval-cljs round-trip.
+    //                        Pure-read, optional :topic / :sub-id filters.
     const DEGRADED_TOOLS = [
       { name: 'dispatch', arguments: { event: '[:rf-conformance/probe]' } },
       { name: 'watch-epochs', arguments: { 'max-ms': 50 } },
@@ -208,25 +201,23 @@ runWithWatchdog(
       { name: 'subscribe', arguments: { topic: 'trace' } },
       { name: 'list-subscriptions', arguments: {} },
       { name: 'list-streams', arguments: {} },
-      // rf2-r5erl — read-dom (and its read-ui sibling + orient) MUST
-      // produce an SDK-valid result envelope, never a null
-      // structuredContent that the SDK's outputSchema validation rejects
-      // at the transport layer (`expected record at structuredContent,
-      // received null`). The bug surfaced on a LIVE read-dom whose
-      // browser eval came back blank; degraded mode exercises the same
-      // envelope-assembly path (the eval short-circuits at
-      // :nrepl-port-not-found through wire/err-text). Including them here
-      // pins the read-family envelope shape at the authoritative SDK
-      // layer, not just a unit proxy.
+      // read-dom (and its read-ui sibling + orient) MUST produce an
+      // SDK-valid result envelope, never a null structuredContent that the
+      // SDK's outputSchema validation rejects at the transport layer
+      // (`expected record at structuredContent, received null`). A LIVE
+      // read-dom whose browser eval comes back blank hits this path;
+      // degraded mode exercises the same envelope-assembly path (the eval
+      // short-circuits at :nrepl-port-not-found through wire/err-text).
+      // Including them here pins the read-family envelope shape at the
+      // authoritative SDK layer, not just a unit proxy.
       { name: 'read-dom', arguments: { selector: 'body', limit: 1 } },
       { name: 'read-ui', arguments: { selector: 'body' } },
       { name: 'orient', arguments: {} },
-      // rf2-ke5n56 — close the descriptor-only gap. Every advertised
-      // pair-mcp tool below was LISTED (descriptor + classification
-      // metadata checked) but never SDK-CALLED, so a regression in its
-      // callTool envelope / outputSchema / structuredContent shape /
-      // argument handling shipped green. In degraded mode (no nREPL) each
-      // routes through `ensure-connection!` first and returns the SAME
+      // Every advertised pair-mcp tool below is SDK-CALLED so a regression
+      // in its callTool envelope / outputSchema / structuredContent shape
+      // / argument handling turns RED rather than shipping green under a
+      // descriptor-only check. In degraded mode (no nREPL) each routes
+      // through `ensure-connection!` first and returns the SAME
       // `:nrepl-port-not-found` envelope — which still proves, per tool:
       // (a) the descriptor reaches the SDK, (b) the dispatch-table entry
       // is wired (an unwired name surfaces a different error), (c) the arg
@@ -240,13 +231,12 @@ runWithWatchdog(
       // appear here: dispatch still routes them through ensure-connection!,
       // which rejects degraded before the inline body runs.
       { name: 'discover-app', arguments: {} },
-      // eval-cljs is default-ON post-rf2-a0z0h (no pre-connection gate
-      // unless --no-eval), so degraded it routes through ensure-connection!
-      // and returns the shared :nrepl-port-not-found envelope. Its LIVE
-      // success / overflow behaviour is covered by
-      // live-re-frame2-pair-overflow.cjs and its --no-eval refusal by
-      // live-re-frame2-pair-subscribe.cjs; this degraded probe pins the
-      // callTool envelope + dispatch wiring.
+      // eval-cljs is default-ON (no pre-connection gate unless --no-eval),
+      // so degraded it routes through ensure-connection! and returns the
+      // shared :nrepl-port-not-found envelope. Its LIVE success / overflow
+      // behaviour is covered by live-re-frame2-pair-overflow.cjs and its
+      // --no-eval refusal by live-re-frame2-pair-subscribe.cjs; this
+      // degraded probe pins the callTool envelope + dispatch wiring.
       { name: 'eval-cljs', arguments: { form: '(+ 1 2)' } },
       { name: 'dispatch-dry-run', arguments: { event: '[:rf-conformance/probe]' } },
       { name: 'get-operating-frame', arguments: {} },
@@ -255,9 +245,9 @@ runWithWatchdog(
       { name: 'get-stream-controls', arguments: {} },
       { name: 'handler-meta', arguments: { kind: 'event', id: ':rf-conformance/probe' } },
       { name: 'list-handlers', arguments: { kind: 'event' } },
-      // rf2-jyxmtq — EP-0017 cofx introspection over the SDK wire. The
-      // `cofx` kind is one of the closed-v1 registrar kinds `handler-meta`
-      // / `list-handlers` advertise (tool-descriptors.edn). Degraded mode
+      // EP-0017 cofx introspection over the SDK wire. The `cofx` kind is
+      // one of the closed-v1 registrar kinds `handler-meta` /
+      // `list-handlers` advertise (tool-descriptors.edn). Degraded mode
       // routes both through `ensure-connection!` to the shared
       // :nrepl-port-not-found envelope — which still proves the `cofx` kind
       // is ACCEPTED into the envelope (an unsupported kind would return
@@ -267,11 +257,12 @@ runWithWatchdog(
       // hermetic live-re-frame2-pair-cofx.cjs gate.
       { name: 'handler-meta', arguments: { kind: 'cofx', id: ':rf/time-ms' } },
       { name: 'list-handlers', arguments: { kind: 'cofx' } },
-      // rf2-srobm0 — describe-image reads a frame's running image generation
-      // over the public rf/frame-generation facade read. Degraded mode routes
-      // it through ensure-connection! to the shared :nrepl-port-not-found
-      // envelope (proving the callTool wiring); the LIVE generation projection
-      // is the runtime preload's concern, pinned by the bb structural test
+      // describe-image reads a frame's running image generation over the
+      // public rf/frame-generation facade read. Degraded mode routes it
+      // through ensure-connection! to the shared :nrepl-port-not-found
+      // envelope (proving the callTool wiring); the LIVE generation
+      // projection is the runtime preload's concern, pinned by the bb
+      // structural test
       // skills/re-frame2-pair/tests/runtime/frame_registrar_test.clj.
       { name: 'describe-image', arguments: { frame: ':rf/default' } },
       { name: 'read-recording', arguments: { 'recording-id': 'rf2-conformance-no-such' } },
@@ -288,16 +279,15 @@ runWithWatchdog(
       },
     ];
 
-    // Universal isError <-> :ok? cross-check (rf2-87h71e). The spec
-    // contract (spec/003-Tool-Catalogue.md §381) is universal: EVERY
-    // `:ok? false` structuredContent MUST carry `isError === true`, and
-    // every `:ok? true` MUST carry a falsy isError. Before this assertion
-    // every isError check in the corpus was tool-specific +
-    // outcome-specific, so the sibling pair-mcp read-dom/read-ui gap
-    // (rf2-q7cavs — an `:ok? false` runtime failure envelope shipping
-    // `isError:false`) shipped GREEN. This cross-check pins the contract
-    // for an ARBITRARY structured envelope at the SDK boundary, catching
-    // any tool that decouples its isError flag from its `:ok?` slot.
+    // Universal isError <-> :ok? cross-check. The spec contract
+    // (spec/003-Tool-Catalogue.md §381) is universal: EVERY `:ok? false`
+    // structuredContent MUST carry `isError === true`, and every
+    // `:ok? true` MUST carry a falsy isError. This cross-check pins the
+    // contract for an ARBITRARY structured envelope at the SDK boundary —
+    // a single gate covering every tool, rather than tool-specific +
+    // outcome-specific checks — catching any tool that decouples its
+    // isError flag from its `:ok?` slot (the class the pair-mcp
+    // read-dom/read-ui envelope belongs to).
     //
     // Reads `:ok?` from the namespace-faithful structuredContent slot
     // (`qualify-keywords` renders `:ok?` as the JS key "ok?"). Tolerates
@@ -350,24 +340,22 @@ runWithWatchdog(
       degradedResp[tool.name] = await assertDegraded(tool);
     }
 
-    // 3c. Gated WRITE tools — pre-connection refusal (rf2-ke5n56). The two
+    // 3c. Gated WRITE tools — pre-connection refusal. The two
     // state-mutating tools `restore-epoch` and `replace-app-db` are gated
-    // behind `--allow-writes` (default OFF, rf2-ee38b.18). This server
-    // booted WITHOUT the flag, so `writes/refuse-pre-connection` short-
-    // circuits BOTH to the `:rf.error/writes-disabled` envelope BEFORE
-    // `ensure-connection!` runs (rf2-wz66k7) — so unlike every other tool
-    // they do NOT return `:nrepl-port-not-found` in degraded mode; they
-    // return the write-gate refusal. These were advertised but never
-    // SDK-called by this harness. Probing them here pins the default-safe
-    // write posture at the real MCP boundary (the env that ships) — a
-    // regression that flipped the default ON, renamed the gate flag, or
-    // dropped the pre-connection guard surfaces RED. The args are
-    // well-formed but inert: the guard fires before the arg is read or any
-    // nREPL touched. (The LIVE, non-degraded refusal — gate-OFF with a
-    // runtime attached — is additionally pinned by
-    // live-re-frame2-pair-subscribe.cjs, which also asserts the `:tool`
-    // slot; here we pin the degraded/pre-connection path the live test
-    // cannot reach.)
+    // behind `--allow-writes` (default OFF). This server booted WITHOUT
+    // the flag, so `writes/refuse-pre-connection` short-circuits BOTH to
+    // the `:rf.error/writes-disabled` envelope BEFORE `ensure-connection!`
+    // runs — so unlike every other tool they do NOT return
+    // `:nrepl-port-not-found` in degraded mode; they return the write-gate
+    // refusal. Probing them here pins the default-safe write posture at
+    // the real MCP boundary (the env that ships) — a regression that
+    // flipped the default ON, renamed the gate flag, or dropped the
+    // pre-connection guard surfaces RED. The args are well-formed but
+    // inert: the guard fires before the arg is read or any nREPL touched.
+    // (The LIVE, non-degraded refusal — gate-OFF with a runtime attached —
+    // is additionally pinned by live-re-frame2-pair-subscribe.cjs, which
+    // also asserts the `:tool` slot; here we pin the degraded/pre-connection
+    // path the live test cannot reach.)
     for (const probe of [
       { name: 'restore-epoch', arguments: { 'epoch-id': '0' } },
       { name: 'replace-app-db', arguments: { db: '{}' } },
@@ -390,7 +378,7 @@ runWithWatchdog(
         );
       }
       // The pre-connection refusal must NOT leak a misleading
-      // :nrepl-port-not-found (rf2-wz66k7 — the guard runs before discovery).
+      // :nrepl-port-not-found — the guard runs before discovery.
       if (text.includes('nrepl-port-not-found')) {
         throw new Error(
           probe.name + ' write-gate refusal MUST NOT mention ' +
@@ -404,20 +392,19 @@ runWithWatchdog(
       );
     }
 
-    // 3c-quater. Unknown tool name — pre-connection refusal (rf2-4mc6q1).
-    // Symmetric with the gated-write pre-connection guard above: a name
-    // absent from the registry (a typo or a removed alias) is rejected by
+    // 3c-quater. Unknown tool name — pre-connection refusal. Symmetric
+    // with the gated-write pre-connection guard above: a name absent from
+    // the registry (a typo or a removed alias) is rejected by
     // `tools/refuse-unknown-tool` in `server.cljs/handle-call` BEFORE
     // `ensure-connection!` runs discovery. So in degraded mode (no nREPL)
     // an unknown tool returns the recovery-shaped `:unknown-tool` envelope,
-    // NOT `:nrepl-port-not-found`. Before this guard the discovery step
-    // rejected first and masked the unknown name behind a transport error,
-    // hiding the recovery affordances (`tools/list` hint + `:available-
-    // tools` catalogue) for exactly the fresh/misconfigured-session case
-    // they were built for — and the conformance harness, which drives the
-    // compiled server WITHOUT a live nREPL, would have shipped that drift
-    // green. A regression that drops the guard or re-orders it after
-    // discovery surfaces RED here.
+    // NOT `:nrepl-port-not-found`. The guard surfaces the recovery
+    // affordances (`tools/list` hint + `:available-tools` catalogue) for
+    // the fresh/misconfigured-session case they serve, even though this
+    // conformance harness drives the compiled server WITHOUT a live nREPL.
+    // A regression that drops the guard or re-orders it after discovery —
+    // which would mask the unknown name behind a transport error — surfaces
+    // RED here.
     {
       const resp = await client.callTool({
         name: 'no-such-tool-xyz',
@@ -456,8 +443,8 @@ runWithWatchdog(
     }
 
     // 3c-ter. EP-0017 reproducible-dispatch `cofx` argument — degraded
-    // accept (rf2-jyxmtq). The `dispatch` tool advertises a `cofx`
-    // input-key (an EDN map of scripted recordable coeffects, e.g.
+    // accept. The `dispatch` tool advertises a `cofx` input-key (an EDN
+    // map of scripted recordable coeffects, e.g.
     // `"{:rf/time-ms 1781078400123}"`) for deterministic replay. In
     // degraded mode the server's `degraded-handler` short-circuits the
     // tool to the shared `:nrepl-port-not-found` envelope BEFORE the tool
@@ -488,12 +475,12 @@ runWithWatchdog(
     }
 
     // 3c-bis. Universal isError <-> :ok? cross-check across the whole
-    // degraded walk (rf2-87h71e). Every degraded / write-gate envelope
-    // collected above carries `:ok? false` and MUST be isError:true; this
-    // sweeps them ALL through the contract assertion (not just the
-    // tool-specific :nrepl-port-not-found / :writes-disabled checks). A
-    // server that decoupled isError from `:ok?` on ANY tool — the class
-    // the sibling read-dom/read-ui gap belonged to — trips RED here.
+    // degraded walk. Every degraded / write-gate envelope collected above
+    // carries `:ok? false` and MUST be isError:true; this sweeps them ALL
+    // through the contract assertion (not just the tool-specific
+    // :nrepl-port-not-found / :writes-disabled checks). A server that
+    // decoupled isError from `:ok?` on ANY tool — the class the sibling
+    // read-dom/read-ui envelope belongs to — trips RED here.
     for (const [label, resp] of Object.entries(degradedResp)) {
       assertIsErrorMatchesOk('tools/call ' + label + ' (degraded)', resp);
     }
@@ -501,7 +488,7 @@ runWithWatchdog(
       'OK   every :ok? false envelope is isError:true (universal cross-check, rf2-87h71e)',
     );
 
-    // 3d. structuredContent dual-slot conformance (rf2-hj3pi). Every
+    // 3d. structuredContent dual-slot conformance. Every
     // pair-mcp result envelope MUST carry BOTH the wire-canonical
     // `:content [{:type "text"}]` slot AND a `:structuredContent`
     // slot — the canonical mcp-builder pattern. The SDK already
@@ -518,8 +505,8 @@ runWithWatchdog(
       'snapshot',
       'subscribe',
       'list-subscriptions',
-      // rf2-r5erl — the read-family envelopes must carry a non-null
-      // object structuredContent through the SDK like every other tool.
+      // the read-family envelopes must carry a non-null object
+      // structuredContent through the SDK like every other tool.
       'read-dom',
       'read-ui',
       'orient',
@@ -535,7 +522,7 @@ runWithWatchdog(
       // array. `typeof [] === 'object'`, so the bare typeof check admits
       // a vector `structuredContent`; the MCP `structuredContent` slot is
       // contractually a JSON object. Reject arrays explicitly so a server
-      // that regressed to emitting a vector there is caught (rf2-ee38b.20).
+      // that emits a vector there is caught.
       if (
         typeof resp.structuredContent !== 'object' ||
         Array.isArray(resp.structuredContent)
@@ -553,21 +540,20 @@ runWithWatchdog(
       'OK   every tool envelope carries :structuredContent (rf2-hj3pi)',
     );
 
-    // 4. JSON-RPC error-code conformance (rf2-i3ffz F-GAP-3). Asserts
-    // re-frame2-pair-mcp emits the canonical codes from `mcp-base/vocab.cljc`
-    // for unknown-method + malformed-params. The runner-side helper
-    // pins the shared contract; same call appears in end-to-end-story.
+    // 4. JSON-RPC error-code conformance. Asserts re-frame2-pair-mcp emits
+    // the canonical codes from `mcp-base/vocab.cljc` for unknown-method +
+    // malformed-params. The runner-side helper pins the shared contract;
+    // same call appears in end-to-end-story.
     await assertJsonRpcErrorCodes(client);
     console.log(
       'OK   JSON-RPC error codes -> MethodNotFound + (InvalidParams|InternalError)',
     );
 
-    // 4b. callTool() coverage ratchet (rf2-ke5n56). Every advertised
-    // pair-mcp tool MUST have been driven through `Client.callTool()`
-    // above (recorded in `called` by the `track` proxy) or carry a
-    // reviewed exclusion in `PAIR_CALL_EXCLUSIONS`. A NEW advertised tool
-    // the workflow forgets to probe trips RED here — closing the
-    // descriptor-only false-green the senior review flagged.
+    // 4b. callTool() coverage ratchet. Every advertised pair-mcp tool MUST
+    // have been driven through `Client.callTool()` above (recorded in
+    // `called` by the `track` proxy) or carry a reviewed exclusion in
+    // `PAIR_CALL_EXCLUSIONS`. A NEW advertised tool the workflow forgets
+    // to probe trips RED here — closing the descriptor-only false-green.
     assertCallCoverageRatchet({
       advertised: names,
       called,

--- a/tools/mcp-conformance/test/end-to-end-story.cjs
+++ b/tools/mcp-conformance/test/end-to-end-story.cjs
@@ -15,11 +15,10 @@
 //
 // Workflow (canonical write-loop with --allow-writes enabled). This is
 // the single agent-loop integration harness for story-mcp's write
-// surface — it absorbed the four smokes that the now-deleted
-// tools/story-mcp/test/live-server.js used to add on top of a
-// hand-rolled copy of this same loop (rf2-2mx0q). Running one SDK-driven
-// boot instead of two hand-rolled + SDK boots saves a full JVM start in
-// CI for no loss of coverage:
+// surface — one SDK-driven boot covers the full write loop plus the four
+// live smokes (register→read round-trip, lifecycle preview, stable-hash
+// identity, recorder bridge), saving a full JVM start in CI for no loss
+// of coverage:
 //
 //   1. connect (initialize + notifications/initialized via SDK)
 //   2. tools/list — confirm the advertised catalogue matches story-mcp's
@@ -27,29 +26,25 @@
 //      §"Single source of truth for tool counts")
 //   3. register-variant — write a fixture variant
 //   4. get-variant — read it back; assert the body :doc round-trips
-//      through the EDN text payload (ex-live-server smoke #1)
+//      through the EDN text payload (live smoke #1)
 //   5. preview-variant — exercise the run-variant lifecycle via the
-//      preview tool; assert a :lifecycle key surfaces (ex-live-server
-//      smoke #2)
+//      preview tool; assert a :lifecycle key surfaces (live smoke #2)
 //   6. run-variant — exercise lifecycle via the testing-category tool,
 //      assert the UNIFIED run-result shape (:status === "pass" for the
-//      vacuous run; the retired :passing? boolean is gone — rf2-ba86n.17)
+//      vacuous run; no :passing? boolean)
 //   7. read-failures — zero failures, run :status surfaces (unified shape)
 //   7b. explain-variant — the human Explain panel's data mirror; assert
 //      the source-chain / merge / runner-requirement slots round-trip
-//      (rf2-ba86n.17)
 //   8. snapshot-identity — same args ⇒ stable content-hash twice in a
-//      row (ex-live-server smoke #3)
+//      row (live smoke #3)
 //   9. record-as-variant — zero-duration capture; proves the recorder
-//      bridge (rf2-luhdu) is wired into dispatch (ex-live-server
-//      smoke #4)
+//      bridge is wired into dispatch (live smoke #4)
 //  10. unregister-variant — symmetric teardown + not-found verify
 //  11. JSON-RPC error-code conformance
 //  12. clean disconnect
 //
 // Run with: `node test/end-to-end-story.cjs` from this directory. Exits
-// 0 on success. Source: rf2-cum40 (loop) + rf2-2mx0q (live-server
-// absorption).
+// 0 on success.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -68,7 +63,7 @@ const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 // Resolve `clojure` to a trusted absolute path outside the workspace,
 // or honour the explicit STORY_MCP_CMD override (trust the invoker —
-// rf2-33vvc accident-gating only fires on the implicit-PATH path).
+// accident-gating only fires on the implicit-PATH path).
 // Without the override, spawning bare `clojure` with `cwd =
 // STORY_MCP_CWD` would let a workspace-local `clojure.cmd` hijack the
 // invocation on Windows; the resolved-absolute-path form prevents it.
@@ -76,8 +71,8 @@ const CLOJURE = process.env.STORY_MCP_CMD
   ? process.env.STORY_MCP_CMD
   : resolveTrustedExe('clojure', { workspaceRoot: REPO_ROOT });
 
-// Canonical tool-name list — sourced from story-mcp's own fixture
-// (rf2-36upq TE7) so this conformance harness and the upstream
+// Canonical tool-name list — sourced from story-mcp's own fixture so
+// this conformance harness and the upstream
 // `tools/story-mcp/test/stdio-roundtrip.js` / JVM `tools_test.clj`
 // agree on the expected `tools/list` response without three hand-
 // maintained lists drifting. A registry change updates one file.
@@ -85,10 +80,10 @@ const EXPECTED_TOOLS = JSON.parse(
   fs.readFileSync(path.join(STORY_MCP_CWD, 'test', 'fixtures', 'tool-names.json'), 'utf8'),
 ).names;
 
-// Per-tool annotation-classification ratchet (rf2-yi451). Pins each
-// descriptor's EXACT readOnly/destructive posture + budget-hint prose so
-// a tool silently re-classified turns this gate RED for an unchanged
-// tool-set. Sourced from this slice's own fixture (mirrors
+// Per-tool annotation-classification ratchet. Pins each descriptor's
+// EXACT readOnly/destructive posture + budget-hint prose so a tool
+// silently re-classified turns this gate RED for an unchanged tool-set.
+// Sourced from this slice's own fixture (mirrors
 // tools/story-mcp/tool-descriptors.edn).
 const EXPECTED_CLASSIFICATIONS = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'fixtures', 'story-classifications.json'), 'utf8'),
@@ -105,24 +100,24 @@ const FIXTURE_VARIANT = 'story.mcp-conformance/probe.primary';
 // `:lifecycle` on `preview-variant`'s structuredContent). Three of
 // story-mcp's tools (`preview-variant`, `run-variant`,
 // `record-as-variant`) ship their payloads wrapped in
-// `{:rf.mcp/dedup-table <cache>}` at the wire boundary (rf2-90eft) — a
-// real MCP client decodes via `de-dupe.core/expand` before user code sees
-// it. Routing every structuredContent read through `structured` mirrors
-// that (a no-op on payloads without the marker), so a future tool gaining
-// or losing dedup-eligibility doesn't break this suite.
+// `{:rf.mcp/dedup-table <cache>}` at the wire boundary — a real MCP
+// client decodes via `de-dupe.core/expand` before user code sees it.
+// Routing every structuredContent read through `structured` mirrors that
+// (a no-op on payloads without the marker), so a future tool gaining or
+// losing dedup-eligibility doesn't break this suite.
 //
-// SDK callTool() coverage tracking (rf2-ke5n56) via the shared `track`
-// helper (_runner.cjs): every tool the workflow drives through
+// SDK callTool() coverage tracking via the shared `track` helper
+// (_runner.cjs): every tool the workflow drives through
 // `Client.callTool()` records its name into the returned `called` Set; the
 // coverage ratchet at the end of the body fails if any ADVERTISED tool is
 // neither recorded nor in the reviewed exclusion table.
 
 // Tools intentionally NOT SDK-call-covered by THIS harness, each with the
-// rationale + where its alternative coverage lives (rf2-ke5n56). Today the
-// Story workflow below drives a probe for every advertised tool, so this
-// table is empty — but it is wired through `assertCallCoverageRatchet` so
-// a FUTURE runtime-heavy/live-only Story tool has a reviewed home instead
-// of silently dropping out of coverage. A blank rationale, a stale row, or
+// rationale + where its alternative coverage lives. The Story workflow
+// below drives a probe for every advertised tool, so this table is empty
+// — but it is wired through `assertCallCoverageRatchet` so a FUTURE
+// runtime-heavy/live-only Story tool has a reviewed home instead of
+// silently dropping out of coverage. A blank rationale, a stale row, or
 // an excluded-yet-called row trips the ratchet.
 const STORY_CALL_EXCLUSIONS = {};
 
@@ -142,7 +137,7 @@ runWithWatchdog(
     },
   },
   async (rawClient) => {
-    // Wrap the SDK client in the coverage tracker (rf2-ke5n56): every
+    // Wrap the SDK client in the coverage tracker: every
     // `client.callTool({name,…})` below records `name` for the callTool
     // coverage ratchet at the end of this body. All other client members
     // delegate transparently.
@@ -167,37 +162,36 @@ runWithWatchdog(
     console.log('OK   tools/list -> ' + names.length + ' tools advertised');
 
     // Descriptor-shape conformance — inputSchema type=object +
-    // max-tokens (rf2-i3ffz F-GAP-2 / TOKEN-BUDGETS.md), :outputSchema
-    // (rf2-3l3be), and an :annotations classification hint (rf2-94p8q).
-    // Shared `assertDescriptorShape` helper (rf2-80y2h dedup). story-mcp
+    // max-tokens (TOKEN-BUDGETS.md), :outputSchema, and an :annotations
+    // classification hint. Shared `assertDescriptorShape` helper. story-mcp
     // is MOSTLY closed-world (reads + fixture writes), but `run-variant`
     // and `preview-variant` run the variant author's lifecycle events/fx
-    // and so carry `openWorldHint:true` (rf2-e6knrq finding 2). Passing
-    // `allowOpenWorld: true` lets that hint count as a classifier; the
-    // PER-TOOL open-world VALUES are pinned exactly by the classification
-    // ratchet's `closed-world` list below + the JVM matrix, so this only
-    // relaxes the "at-least-one-classifier" floor — it does not let a
-    // closed-world tool silently flip open.
+    // and so carry `openWorldHint:true`. Passing `allowOpenWorld: true`
+    // lets that hint count as a classifier; the PER-TOOL open-world VALUES
+    // are pinned exactly by the classification ratchet's `closed-world`
+    // list below + the JVM matrix, so this only relaxes the
+    // "at-least-one-classifier" floor — it does not let a closed-world
+    // tool silently flip open.
     assertDescriptorShape(listed.tools, { allowOpenWorld: true });
     console.log(
       'OK   every tool descriptor: inputSchema(type=object,max-tokens) + outputSchema + annotations hint',
     );
 
-    // Per-tool classification CONTENT ratchet (rf2-yi451). Pins WHICH
-    // classifier per tool (the exact readOnly/destructive posture) +
-    // the budget-hint prose — not just that SOME classifier is set. A
-    // gated write tool (register-variant, unregister-variant,
-    // record-as-variant) silently re-classified readOnly turns RED here.
+    // Per-tool classification CONTENT ratchet. Pins WHICH classifier per
+    // tool (the exact readOnly/destructive posture) + the budget-hint
+    // prose — not just that SOME classifier is set. A gated write tool
+    // (register-variant, unregister-variant, record-as-variant) silently
+    // re-classified readOnly turns RED here.
     assertClassificationRatchet(listed.tools, EXPECTED_CLASSIFICATIONS);
     console.log(
       'OK   per-tool classification ratchet: readOnly/destructive posture + ' +
         'budget-hint prose pinned (rf2-yi451)',
     );
 
-    // Open-world VALUE conformance (rf2-e6knrq finding 2). The ratchet's
-    // `closed-world` list pins the closed-world tools to openWorldHint:false;
-    // this positively pins the OTHER direction over the SDK wire — the two
-    // lifecycle-run tools MUST advertise openWorldHint:true so an agent host
+    // Open-world VALUE conformance. The ratchet's `closed-world` list pins
+    // the closed-world tools to openWorldHint:false; this positively pins
+    // the OTHER direction over the SDK wire — the two lifecycle-run tools
+    // MUST advertise openWorldHint:true so an agent host
     // does not treat a call that can reach HTTP / analytics / websocket /
     // storage / navigation (any un-stubbed author fx) as contained on-box.
     // The annotation VALUE (not just the KEY presence the generated
@@ -227,25 +221,24 @@ runWithWatchdog(
         'openWorldHint:true + destructiveHint:true (rf2-e6knrq)',
     );
 
-    // 2e. Closed-world read-path SUCCESS-envelope conformance
-    // (rf2-ee38b.20). The completeness lens noted the harness walked
-    // only the write-loop tools and asserted error-only shapes elsewhere
-    // — no story-mcp `list-*` read was ever invoked, so a success-path
-    // `CallToolResultSchema` parse / structuredContent drift on the read
-    // surface (the exact bug class this harness exists to catch) could
-    // ship unobserved. story-mcp's `list-*` reads are closed-world (no
-    // runtime needed) and return a non-error envelope regardless of the
-    // write gate, so they cover the success path here with zero extra
-    // setup. Each routes through the SDK's `CallToolResultSchema` parse.
+    // 2e. Closed-world read-path SUCCESS-envelope conformance. The
+    // write-loop probes elsewhere assert error-only shapes; this walks
+    // story-mcp's `list-*` reads so a success-path `CallToolResultSchema`
+    // parse / structuredContent drift on the read surface (the exact bug
+    // class this harness exists to catch) turns RED rather than shipping
+    // unobserved. story-mcp's `list-*` reads are closed-world (no runtime
+    // needed) and return a non-error envelope regardless of the write
+    // gate, so they cover the success path here with zero extra setup.
+    // Each routes through the SDK's `CallToolResultSchema` parse.
     //
-    // `get-story-instructions` is walked here too (rf2-vyacl). It
-    // declares an `:outputSchema`, so the SDK's high-level `callTool`
-    // REJECTS a result with no structuredContent with `-32600` ("has an
-    // output schema but did not return structured content"). The handler
-    // now emits a matching `{:instructions <text>}` structuredContent
-    // (mirroring re-frame2-pair-mcp's sibling `get-re-frame2-pair-
-    // instructions`), so the SDK parse passes — this assertion pins that
-    // the latent defect stays fixed across the wire.
+    // `get-story-instructions` is walked here too. It declares an
+    // `:outputSchema`, so the SDK's high-level `callTool` REJECTS a result
+    // with no structuredContent with `-32600` ("has an output schema but
+    // did not return structured content"). The handler emits a matching
+    // `{:instructions <text>}` structuredContent (mirroring
+    // re-frame2-pair-mcp's sibling `get-re-frame2-pair-instructions`), so
+    // the SDK parse passes — this assertion pins that contract across the
+    // wire.
     for (const readTool of [
       'get-story-instructions',
       'list-substrates',
@@ -273,16 +266,16 @@ runWithWatchdog(
         'list-modes/list-tags) -> success envelopes',
     );
 
-    // 2f. Remaining closed-world LIST reads (rf2-ke5n56). The read loop
-    // above covered four of story-mcp's reads; `list-stories`,
-    // `list-assertions`, and `list-decorators` were advertised but never
-    // SDK-CALLED — descriptor-only in conformance, so a callTool-envelope
-    // / outputSchema / structuredContent regression on any of them shipped
-    // green. These three need no runtime and no fixture (they enumerate
-    // the canonical-vocabulary registry the server installs at boot), so
-    // each is a zero-arg success probe routed through the SDK's
-    // CallToolResultSchema + the declared outputSchema parse — the same
-    // success-path shape pin the four reads above carry.
+    // 2f. Remaining closed-world LIST reads. The read loop above covered
+    // four of story-mcp's reads; `list-stories`, `list-assertions`, and
+    // `list-decorators` are SDK-CALLED here so a callTool-envelope /
+    // outputSchema / structuredContent regression on any of them turns RED
+    // rather than passing under a descriptor-only check. These three need
+    // no runtime and no fixture (they enumerate the canonical-vocabulary
+    // registry the server installs at boot), so each is a zero-arg success
+    // probe routed through the SDK's CallToolResultSchema + the declared
+    // outputSchema parse — the same success-path shape pin the four reads
+    // above carry.
     for (const readTool of ['list-stories', 'list-assertions', 'list-decorators']) {
       const r = await client.callTool({ name: readTool, arguments: {} });
       if (r.isError) {
@@ -305,18 +298,18 @@ runWithWatchdog(
         ' -> success envelopes',
     );
 
-    // 2g. Refusal-path coverage for the two story-id read tools
-    // (rf2-ke5n56). `get-story` and `get-docs-markdown` were advertised
-    // but never SDK-called. Both REQUIRE a `:story-id` and resolve it via
-    // `safe-keyword` against the registered-stories set — an unregistered
-    // id short-circuits to a documented `Story not found` tool-execution
-    // error (isError:true, NOT a JSON-RPC protocol error). A default-off
-    // refusal probe is the cheap, fixture-free way to drive the callTool
-    // path: it pins the not-found envelope shape AND proves the tool is
-    // wired into dispatch (an unwired name would surface a different
-    // error). A success-path hit would need a registered STORY, but the
-    // conformance fixture is a VARIANT (the canonical vocabulary installs
-    // no stable story id to hit), so the refusal probe is the coverage.
+    // 2g. Refusal-path coverage for the two story-id read tools.
+    // `get-story` and `get-docs-markdown` both REQUIRE a `:story-id` and
+    // resolve it via `safe-keyword` against the registered-stories set —
+    // an unregistered id short-circuits to a documented `Story not found`
+    // tool-execution error (isError:true, NOT a JSON-RPC protocol error).
+    // A default-off refusal probe is the cheap, fixture-free way to drive
+    // the callTool path: it pins the not-found envelope shape AND proves
+    // the tool is wired into dispatch (an unwired name would surface a
+    // different error). A success-path hit would need a registered STORY,
+    // but the conformance fixture is a VARIANT (the canonical vocabulary
+    // installs no stable story id to hit), so the refusal probe is the
+    // coverage.
     const ABSENT_STORY = ':story.mcp-conformance/no-such-story';
     for (const storyTool of ['get-story', 'get-docs-markdown']) {
       const r = await client.callTool({
@@ -364,10 +357,10 @@ runWithWatchdog(
     // Pin the SINGLE canonical key story-mcp emits: `:registered?`
     // (Cheshire keeps the `?` on the keyword → JSON key `registered?`;
     // pinned JVM-side by tools_test.clj `(-> reg :structuredContent
-    // :registered?)`). The earlier `registered || registered?`
-    // alternation tolerated two spellings — masking exactly the
+    // :registered?)`). Pinning exactly one spelling catches the
     // envelope-key drift the rest of this harness pins single-spelling
-    // (`unregistered?`, `passing?`, `content-hash`). rf2-ee38b.20.
+    // (`unregistered?`, `content-hash`); a tolerated second spelling would
+    // mask it.
     if (regStruct['registered?'] !== true) {
       throw new Error(
         "register-variant did not report :registered? true: " + JSON.stringify(regResp),
@@ -377,9 +370,8 @@ runWithWatchdog(
 
     // 4. get-variant — round-trip the body. Cheshire coerces keys to
     // strings on the wire, so the comparison reads the :doc back from
-    // the text payload (EDN-encoded, keyword keys preserved). Absorbed
-    // from live-server.js (rf2-2mx0q) — proves the register→read
-    // round-trip the bare run/read loop did not.
+    // the text payload (EDN-encoded, keyword keys preserved). Proves the
+    // register→read round-trip end-to-end.
     const getResp = await client.callTool({
       name: 'get-variant',
       arguments: { 'variant-id': FIXTURE_VARIANT },
@@ -393,16 +385,13 @@ runWithWatchdog(
     }
     console.log('OK   get-variant -> body :doc round-trips through EDN text');
 
-    // 4b. variant->edn (rf2-ke5n56). Advertised but never SDK-called —
-    // and it is the EXACT latent-defect twin of get-story-instructions:
-    // it declares an :outputSchema, so the SDK's high-level callTool
-    // REJECTS a result with no structuredContent (-32600); rf2-vyacl
-    // notes variant->edn was the only OTHER tool still text-only before
-    // the fix. Driving it against the live fixture pins that the fix
-    // stays fixed across the wire. The text slot is the byte-stable
-    // pr-str EDN; assert the fixture :doc round-trips through it AND that
-    // a JSON-object structuredContent rides alongside (the slot the SDK
-    // outputSchema parse demands).
+    // 4b. variant->edn. The EXACT twin of get-story-instructions: it
+    // declares an :outputSchema, so the SDK's high-level callTool REJECTS
+    // a result with no structuredContent (-32600). Driving it against the
+    // live fixture pins that contract across the wire. The text slot is
+    // the byte-stable pr-str EDN; assert the fixture :doc round-trips
+    // through it AND that a JSON-object structuredContent rides alongside
+    // (the slot the SDK outputSchema parse demands).
     const ednResp = await client.callTool({
       name: 'variant->edn',
       arguments: { 'variant-id': FIXTURE_VARIANT },
@@ -427,11 +416,11 @@ runWithWatchdog(
     }
     console.log('OK   variant->edn -> :doc round-trips through EDN text + structuredContent present');
 
-    // 4c. read-a11y-violations (rf2-ke5n56). Advertised but never SDK-called. The
-    // axe-core run is CLJS-in-browser only; from this JVM-standalone boot
-    // the tool READS the (empty) violations atom and returns a success
-    // envelope with `:violations []` + a JVM-standalone `:note` — so it
-    // is a cheap, fixture-backed, runtime-free success probe (NOT a live
+    // 4c. read-a11y-violations. The axe-core run is CLJS-in-browser only;
+    // from this JVM-standalone boot the tool READS the (empty) violations
+    // atom and returns a success envelope with `:violations []` + a
+    // JVM-standalone `:note` — so it is a cheap, fixture-backed,
+    // runtime-free success probe (NOT a live
     // browser dependency). Pins the callTool envelope + structuredContent
     // shape for the testing-category read against the registered fixture.
     const a11yResp = await client.callTool({
@@ -459,8 +448,7 @@ runWithWatchdog(
     // 5. preview-variant — exercise the full lifecycle via the preview
     // tool. With no :play events the run is vacuously passing; the
     // contract is that a :lifecycle key surfaces (loaders → events →
-    // render → play wiring is live). Absorbed from live-server.js
-    // (rf2-2mx0q).
+    // render → play wiring is live).
     const prevResp = await client.callTool({
       name: 'preview-variant',
       arguments: { 'variant-id': FIXTURE_VARIANT },
@@ -477,9 +465,9 @@ runWithWatchdog(
     console.log('OK   preview-variant -> lifecycle=' + prevStruct.lifecycle);
 
     // 6. run-variant — exercise lifecycle; vacuous pass since :script
-    // is empty. The UNIFIED run-result (rf2-ba86n.17 clean break) returns
-    // the top-level :status verdict + unified :assertions records (each
-    // with a :status) + :checks — NOT the retired :passing? boolean.
+    // is empty. The UNIFIED run-result returns the top-level :status
+    // verdict + unified :assertions records (each with a :status) +
+    // :checks — and carries no :passing? boolean.
     const runResp = await client.callTool({
       name: 'run-variant',
       arguments: { 'variant-id': FIXTURE_VARIANT },
@@ -536,11 +524,11 @@ runWithWatchdog(
           JSON.stringify(failResp),
       );
     }
-    // rf2-koq5m — egress indicator omit-when-zero MUST: a clean read
-    // (no sensitive records dropped, nothing elided) carries NEITHER
-    // `:dropped-sensitive` nor `:elided-large`. The positive-count side
-    // is pinned by the JVM `tools_test.clj` indicator deftests; the live
-    // SDK driver pins the omit-when-zero contract end-to-end.
+    // Egress indicator omit-when-zero MUST: a clean read (no sensitive
+    // records dropped, nothing elided) carries NEITHER `:dropped-sensitive`
+    // nor `:elided-large`. The positive-count side is pinned by the JVM
+    // `tools_test.clj` indicator deftests; the live SDK driver pins the
+    // omit-when-zero contract end-to-end.
     if ('dropped-sensitive' in failStruct || 'elided-large' in failStruct) {
       throw new Error(
         'read-failures clean read must OMIT indicator slots when zero ' +
@@ -552,10 +540,10 @@ runWithWatchdog(
       'OK   read-failures -> total=0, failures=[], :status="pass", indicators omitted (omit-when-zero)',
     );
 
-    // 7b. explain-variant — the agent mirror of the human Explain panel
-    // (rf2-ba86n.17). Assert the source-chain / merge / runner-requirement
-    // slots round-trip — a structuredContent shape pin, exactly like the
-    // existing reads. New net-additive Docs tool over story/explain.
+    // 7b. explain-variant — the agent mirror of the human Explain panel.
+    // Assert the source-chain / merge / runner-requirement slots
+    // round-trip — a structuredContent shape pin, exactly like the other
+    // reads. A Docs tool over story/explain.
     const explainResp = await client.callTool({
       name: 'explain-variant',
       arguments: { 'variant-id': FIXTURE_VARIANT },
@@ -583,9 +571,8 @@ runWithWatchdog(
     }
     console.log('OK   explain-variant -> source-chain + merge + required-runner round-trip');
 
-    // 8. snapshot-identity — same args ⇒ same content-hash. Absorbed
-    // from live-server.js (rf2-2mx0q): proves the stable-hash identity
-    // contract the bare loop did not exercise.
+    // 8. snapshot-identity — same args ⇒ same content-hash. Proves the
+    // stable-hash identity contract.
     const snap1 = await client.callTool({
       name: 'snapshot-identity',
       arguments: { 'variant-id': FIXTURE_VARIANT },
@@ -607,8 +594,7 @@ runWithWatchdog(
     console.log('OK   snapshot-identity -> stable hash: ' + h1);
 
     // 9. record-as-variant — zero-duration capture; empty :play
-    // snippet. Proves the recorder bridge (rf2-luhdu) is wired into
-    // dispatch. Absorbed from live-server.js (rf2-2mx0q).
+    // snippet. Proves the recorder bridge is wired into dispatch.
     const recResp = await client.callTool({
       name: 'record-as-variant',
       arguments: { 'variant-id': FIXTURE_VARIANT },
@@ -656,9 +642,9 @@ runWithWatchdog(
     }
     console.log('OK   unregister-variant -> teardown verified by subsequent get-variant -> not-found');
 
-    // 11. JSON-RPC error-code conformance (rf2-i3ffz F-GAP-3). Mirrors
-    // the assertion in end-to-end-re-frame2-pair.cjs — story-mcp MUST emit the
-    // same canonical codes from `mcp-base/vocab.cljc` for unknown-method
+    // 11. JSON-RPC error-code conformance. Mirrors the assertion in
+    // end-to-end-re-frame2-pair.cjs — story-mcp MUST emit the same
+    // canonical codes from `mcp-base/vocab.cljc` for unknown-method
     // + malformed-params (its JVM transport reuses the same SDK
     // server-side framing).
     await assertJsonRpcErrorCodes(client);
@@ -666,12 +652,12 @@ runWithWatchdog(
       'OK   JSON-RPC error codes -> MethodNotFound + (InvalidParams|InternalError)',
     );
 
-    // 12. callTool() coverage ratchet (rf2-ke5n56). Every advertised
-    // story-mcp tool MUST have been driven through `Client.callTool()`
-    // above (recorded in `called` by the `track` proxy) or carry a
-    // reviewed exclusion in `STORY_CALL_EXCLUSIONS`. A NEW advertised
-    // tool that the workflow forgets to probe trips RED here — closing
-    // the descriptor-only false-green the senior review flagged.
+    // 12. callTool() coverage ratchet. Every advertised story-mcp tool
+    // MUST have been driven through `Client.callTool()` above (recorded in
+    // `called` by the `track` proxy) or carry a reviewed exclusion in
+    // `STORY_CALL_EXCLUSIONS`. A NEW advertised tool that the workflow
+    // forgets to probe trips RED here — closing the descriptor-only
+    // false-green.
     assertCallCoverageRatchet({
       advertised: names,
       called,

--- a/tools/mcp-conformance/test/exec-safety.test.cjs
+++ b/tools/mcp-conformance/test/exec-safety.test.cjs
@@ -1,4 +1,4 @@
-// Unit tests for `lib/exec-safety.cjs` (rf2-33vvc).
+// Unit tests for `lib/exec-safety.cjs`.
 //
 // Uses Node's built-in `node:test` so the harness picks up no extra
 // dev-dependency. Runs quiet on success (per docs/quiet-tests.md):
@@ -379,7 +379,7 @@ test('safeUnlinkInside: rejects empty / missing inputs', () => {
 });
 
 // ---------------------------------------------------------------------
-// safeReadFileInside (rf2-khav7l)
+// safeReadFileInside
 //
 // The read-side counterpart to safeUnlinkInside: a port-file candidate
 // the cleanup step refused to UNLINK (because its realpath escapes the
@@ -427,7 +427,7 @@ test('safeReadFileInside: honors an encoding-string option', () => {
 });
 
 test('safeReadFileInside: rejects when realpath escapes allowed root (symlinked leaf)', { skip: process.platform === 'win32' }, () => {
-  // The exact rf2-khav7l shape: a leaf `nrepl.port` inside the allowed
+  // The hostile read shape: a leaf `nrepl.port` inside the allowed
   // root that is itself a symlink to an EXTERNAL port file. A naive
   // `fs.readFileSync` would follow the link and trust the external
   // port; safeReadFileInside must refuse, the same way safeUnlinkInside
@@ -481,7 +481,7 @@ test('safeReadFileInside: rejects when parent dir is a symlink escaping root', {
 });
 
 test('safeReadFileInside: a candidate refused by safeUnlinkInside is also refused on read (rf2-khav7l parity)', { skip: process.platform === 'win32' }, () => {
-  // The crux of rf2-khav7l: prove the SAME escaped candidate that
+  // The read/unlink parity contract: prove the SAME escaped candidate that
   // safeUnlinkInside refuses to delete is ALSO refused by
   // safeReadFileInside. A future cleanup refactor cannot reintroduce the
   // "refuse delete but trust read" split as long as this parity holds.

--- a/tools/mcp-conformance/test/flag-gates-hang-harness.cjs
+++ b/tools/mcp-conformance/test/flag-gates-hang-harness.cjs
@@ -1,16 +1,15 @@
-// Child harness for `runner-watchdog.test.cjs` (rf2-wqi4n4 finding 1).
+// Child harness for `runner-watchdog.test.cjs`.
 //
 // Pins the bare-`connectServer` connect-hang teardown contract in
 // `end-to-end-flag-gates.cjs`. That module does NOT use `runWithWatchdog`
 // (it needs three fresh in-process JVM boots, which the single-boot runner
 // can't serve); it runs its OWN module-scope watchdog over an
-// `activeFlagGateClient` handle. Pre-fix that handle was assigned only AFTER
-// `await connectServer(...)` RESOLVED — so a story-mcp JVM that spawns and
-// then HANGS mid-`initialize` (connect never resolving) left
-// `activeFlagGateClient === null` when the watchdog fired, and the
-// watchdog's `else` branch `process.exit(2)`'d WITHOUT tearing the hung JVM
-// down. The fix publishes the handle via `connectServer`'s `onClient`
-// callback BEFORE connect awaits.
+// `activeFlagGateClient` handle. That handle is published via
+// `connectServer`'s `onClient` callback BEFORE connect awaits, so a
+// story-mcp JVM that spawns and then HANGS mid-`initialize` (connect never
+// resolving) still leaves `activeFlagGateClient` set when the watchdog
+// fires — the watchdog tears the hung JVM down rather than `process.exit(2)`'ing
+// WITHOUT reaping it.
 //
 // This harness is HERMETIC: it stubs the SDK so the first (and only)
 // `connect()` NEVER resolves, points `$STORY_MCP_CMD` at the running node
@@ -69,7 +68,6 @@ process.env.FLAG_GATE_WATCHDOG_MS = '200';
 
 // Requiring the module runs its `main()` (the three gate probes). The first
 // `withStoryServer` boot's connect hangs, so `main()` never progresses; the
-// 200ms module-scope watchdog is the only exit path. With the fix it tears
-// the (stubbed) hung JVM client down — printing CLOSE_MARKER — before
-// `process.exit(2)`.
+// 200ms module-scope watchdog is the only exit path. It tears the (stubbed)
+// hung JVM client down — printing CLOSE_MARKER — before `process.exit(2)`.
 require(path.join(__dirname, 'end-to-end-flag-gates.cjs'));

--- a/tools/mcp-conformance/test/hermetic-setup-timeout.test.cjs
+++ b/tools/mcp-conformance/test/hermetic-setup-timeout.test.cjs
@@ -1,34 +1,31 @@
 // Regression test for the hermetic orchestrator's SETUP-command timeout
-// contract (rf2-wqi4n4 finding 2 + rf2-i4d5wr).
+// contract.
 //
 // Two arms:
-//   - rf2-wqi4n4: a hung setup command is killed within the per-command cap
-//     and the event loop stays live (proving the async-spawn shape).
-//   - rf2-i4d5wr: a SIGTERM-IGNORING setup child is actually SIGKILLed (the
-//     timeout reject must NOT cancel the SIGKILL fallback). See that test's
-//     own header for the leaked-child bug it pins.
+//   - per-command cap: a hung setup command is killed within the
+//     per-command cap and the event loop stays live (proving the
+//     async-spawn shape).
+//   - SIGKILL fallback: a SIGTERM-IGNORING setup child is actually
+//     SIGKILLed (the timeout reject must NOT cancel the SIGKILL fallback).
+//     See that test's own header for the leaked-child contract it pins.
 //
 // Uses Node's built-in `node:test` (same posture as
 // `runner-watchdog.test.cjs` / `exec-safety.test.cjs` — no extra
 // dev-dependency).
 //
-// ## The bug this pins
+// ## The contract this pins
 //
 // `scripts/run-re-frame2-pair-live-hermetic-suite.cjs` installs a
 // `HERMETIC_TIMEOUT_MS` `setTimeout` watchdog meant to bound the WHOLE run.
-// But the fixture dependency setup (`npm install`) ran through
-// `crossSpawn.sync` in `runTrusted` — a SYNCHRONOUS spawn that blocks the
-// Node event loop for the child's entire lifetime. While blocked, Node
-// delivers no signals and runs no timers, so neither the whole-run watchdog
-// nor the SIGINT/SIGTERM handlers could fire. A hung `npm install` (stuck
-// registry fetch, package-manager prompt, lock contention) would wedge the
-// hermetic job until the OUTER CI job timeout, bypassing the script's own
-// hard cap and diagnostics.
-//
-// The fix converts `runTrusted` to an ASYNC spawn with an explicit
-// per-command timeout/kill (`SETUP_COMMAND_TIMEOUT_MS`). The async spawn
-// keeps the event loop live, so both the per-command timeout AND the
-// whole-run watchdog stay armed across setup.
+// The fixture dependency setup (`npm install`) runs through an ASYNC spawn
+// in `runTrusted` with an explicit per-command timeout/kill
+// (`SETUP_COMMAND_TIMEOUT_MS`). The async spawn keeps the Node event loop
+// live for the child's entire lifetime, so Node still delivers signals and
+// runs timers — both the per-command timeout AND the whole-run watchdog
+// stay armed across setup. A synchronous spawn would instead block the
+// loop: a hung `npm install` (stuck registry fetch, package-manager
+// prompt, lock contention) would wedge the hermetic job until the OUTER CI
+// job timeout, bypassing the script's own hard cap and diagnostics.
 //
 // ## What this test drives
 //
@@ -65,8 +62,8 @@ const ORCH = path.join(
 
 // Shrink the per-command cap AND the post-SIGTERM SIGKILL grace BEFORE
 // requiring the orchestrator — it reads both env vars at module-load time.
-// The grace shrink keeps the rf2-i4d5wr SIGTERM-ignoring arm fast (it must
-// wait the grace, then SIGKILL) without slowing the rf2-wqi4n4 arm.
+// The grace shrink keeps the SIGTERM-ignoring arm fast (it must wait the
+// grace, then SIGKILL) without slowing the per-command-cap arm.
 process.env.HERMETIC_SETUP_TIMEOUT_MS = '750';
 process.env.HERMETIC_SETUP_SIGKILL_GRACE_MS = '400';
 
@@ -144,25 +141,22 @@ test('runTrusted kills a hung setup command within its timeout, loop stays live 
   );
 });
 
-// ── rf2-i4d5wr ───────────────────────────────────────────────────────────
+// ── SIGKILL fallback: the reject must not cancel the escalation ───────────
 //
-// Pins the SIGKILL-fallback bug: on the timeout path `runTrusted` armed the
-// SIGKILL as a fire-and-forget `setTimeout` (`killTimer`) and then
-// immediately `settle(reject, ...)`d. `settle` cleared `killTimer`, so the
-// SIGKILL fallback was CANCELLED on the very path that scheduled it. A setup
-// child that IGNORES SIGTERM survived after the orchestrator reported "setup
-// command hung — killed", leaking npm/node children that hold locks/pipes.
-//
-// The fix makes the SIGTERM→SIGKILL escalation an AWAITED sequence: the
-// child is reaped (SIGTERM grace, then SIGKILL, then a bounded final wait)
-// BEFORE the promise rejects, and the reject no longer cancels the kill.
+// On the timeout path `runTrusted` makes the SIGTERM→SIGKILL escalation an
+// AWAITED sequence: the child is reaped (SIGTERM grace, then SIGKILL, then a
+// bounded final wait) BEFORE the promise rejects, and the reject does NOT
+// cancel the kill. A fire-and-forget SIGKILL `setTimeout` that the reject
+// cleared would instead leave a SIGTERM-ignoring setup child alive after the
+// orchestrator reported "setup command hung — killed", leaking npm/node
+// children that hold locks/pipes — which is the leak this arm guards.
 //
 // This arm spawns a child that installs a SIGTERM handler (and SIGINT, for
 // good measure) which logs but does NOT exit, holding itself alive with a
 // ref'd interval. Under POSIX signal semantics that child cannot be reaped
 // by SIGTERM — only SIGKILL ends it. We then assert the child PID is GONE
 // after `runTrusted` rejects, which can ONLY be true if the SIGKILL
-// escalation actually fired (the pre-fix code would leave it alive).
+// escalation actually fired.
 //
 // Cross-platform note: Node on Windows maps BOTH `child.kill('SIGTERM')` and
 // `child.kill('SIGKILL')` to `TerminateProcess`, which is unconditional —
@@ -171,7 +165,7 @@ test('runTrusted kills a hung setup command within its timeout, loop stays live 
 // gone after reject") still holds on Windows; it just exercises the SIGTERM
 // leg rather than the SIGTERM→SIGKILL escalation. On Linux CI
 // (`ubuntu-latest`, the gate's runner) the SIGTERM handler is honoured, so
-// the escalation IS exercised — which is where the original bug bit.
+// the escalation IS exercised — which is where the leak would bite.
 test('runTrusted SIGKILLs a SIGTERM-ignoring setup child — the reject does not cancel the fallback (rf2-i4d5wr)', async () => {
   // PID handshake: the child writes its own PID to a temp file on startup so
   // the parent can poll for the child's liveness directly (independent of
@@ -258,11 +252,11 @@ test('runTrusted SIGKILLs a SIGTERM-ignoring setup child — the reject does not
   );
 
   // 2. THE LOAD-BEARING ASSERTION: the child is actually GONE after the
-  // reject. Pre-fix, `settle(reject)` cancelled the SIGKILL `killTimer`, so a
-  // SIGTERM-ignoring child stayed alive forever — this poll would never see
-  // ESRCH within the bound. Post-fix, the AWAITED SIGTERM→SIGKILL escalation
-  // reaps it before (or as) the promise rejects, so the PID is gone. Poll
-  // with a small bound to cover the OS reap latency after SIGKILL.
+  // reject. If `settle(reject)` cancelled the SIGKILL `killTimer`, a
+  // SIGTERM-ignoring child would stay alive forever and this poll would
+  // never see ESRCH within the bound. Because the AWAITED SIGTERM→SIGKILL
+  // escalation reaps it before (or as) the promise rejects, the PID is gone.
+  // Poll with a small bound to cover the OS reap latency after SIGKILL.
   async function waitGone(pid, deadlineMs) {
     const until = Date.now() + deadlineMs;
     while (Date.now() < until) {

--- a/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
@@ -1,11 +1,11 @@
 // Live-re-frame2-pair MCP-client conformance variant pinning the EP-0017
 // recordable-coeffects (`cofx`) paths over the real MCP SDK boundary.
-// Source: rf2-jyxmtq (senior-review coverage gap, tracking rf2-skhlw2).
 //
-// ## The hole this closes
+// ## What this test guards
 //
-// Before this gate, `tools/mcp-conformance` never exercised the EP-0017
-// reproducible-dispatch / `cofx` MCP paths against a LIVE runtime:
+// This gate exercises the EP-0017 reproducible-dispatch / `cofx` MCP
+// paths against a LIVE runtime — coverage the other harnesses cannot
+// reach:
 //
 //   - `end-to-end-re-frame2-pair.cjs` runs DEGRADED — the server's
 //     `degraded-handler` short-circuits `dispatch` (and every other

--- a/tools/mcp-conformance/test/live-re-frame2-pair-event-meta.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-event-meta.cjs
@@ -1,31 +1,31 @@
 // Live-re-frame2-pair MCP-client conformance variant pinning the EP-0018
 // unified event-registration metadata on the real MCP SDK boundary.
-// Source: rf2-z0owya (senior-review coverage gap, tracking rf2-6ktv66).
 //
-// ## The hole this closes
+// ## What this test guards
 //
-// EP-0018 consolidated public event registration to ONE `rf/reg-event`
-// (semantically reg-event-fx) and removed the event sub-kind split: a
-// `reg-event` entry is simply kind `:event`; the public `:event/kind :db
-// | :fx | :ctx` sub-tag is gone; the per-kind handler wrappers
-// (`:rf/db-handler` / `:rf/fx-handler` / `:rf/ctx-handler`) collapse to
-// ONE `:rf/event-handler` interceptor (carrying `:rf/default? true`). The
-// EP-0018 §Conformance clause requires `handler-meta :event id` to surface
-// the metadata + effective interceptor chain with that unified wrapper.
+// EP-0018 consolidates public event registration to ONE `rf/reg-event`
+// (semantically reg-event-fx) with no event sub-kind split: a `reg-event`
+// entry is simply kind `:event`; there is no public `:event/kind :db |
+// :fx | :ctx` sub-tag; the per-kind handler wrappers (`:rf/db-handler` /
+// `:rf/fx-handler` / `:rf/ctx-handler`) are one `:rf/event-handler`
+// interceptor (carrying `:rf/default? true`). The EP-0018 §Conformance
+// clause requires `handler-meta :event id` to surface the metadata +
+// effective interceptor chain with that unified wrapper.
 //
-// Before this gate, `tools/mcp-conformance` SDK-called `handler-meta` /
-// `list-handlers` ONLY in DEGRADED mode (`end-to-end-re-frame2-pair.cjs`),
-// where the server's `degraded-handler` short-circuits every live-runtime
-// tool to the SAME `:nrepl-port-not-found` envelope. That proves the
-// descriptor + CallToolResult wiring, but it NEVER inspects the live
-// pair-MCP wire output for event introspection — so a wire-layer
-// regression that reintroduced or decorated stale event-sub-kind metadata
-// (`:event/kind`) or an old wrapper id (`:rf/db-handler` …) on the MCP
-// response would ship GREEN.
+// The degraded-mode coverage (`end-to-end-re-frame2-pair.cjs`) SDK-calls
+// `handler-meta` / `list-handlers` where the server's `degraded-handler`
+// short-circuits every live-runtime tool to the SAME
+// `:nrepl-port-not-found` envelope — proving the descriptor +
+// CallToolResult wiring but never inspecting the live pair-MCP wire output
+// for event introspection. So a wire-layer regression that reintroduced
+// or decorated stale event-sub-kind metadata (`:event/kind`) or an old
+// wrapper id (`:rf/db-handler` …) on the MCP response would ship GREEN
+// there.
 //
-// This gate fills that gap: with a live runtime attached it drives the
-// EP-0018 event-metadata surface over the SDK boundary and pins both the
-// presence of the unified shape AND the absence of every retired marker.
+// This gate covers that surface: with a live runtime attached it drives
+// the EP-0018 event-metadata surface over the SDK boundary and pins both
+// the presence of the unified shape AND the absence of every retired
+// marker.
 //
 // ## What this test drives (across the MCP boundary, via the SDK Client)
 //

--- a/tools/mcp-conformance/test/live-re-frame2-pair-iserror.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-iserror.cjs
@@ -1,32 +1,30 @@
 // Live-re-frame2-pair MCP-client conformance variant pinning the
 // universal `:ok? false ⇒ isError:true` contract on the read-family
 // GENUINE error envelopes (read-dom / read-ui bad-selector).
-// Source: rf2-87h71e (pairs with the pair-mcp fix rf2-q7cavs).
 //
-// ## The hole this closes
+// ## What this test guards
 //
-// rf2-q7cavs was a spec-contract violation in pair-mcp:
-// `probe/map-result-or-blank` (the shared read-dom/read-ui `on-value`
-// projection) routed ANY map through `wire/ok-text`, so a GENUINE
+// pair-mcp's `probe/map-result-or-blank` (the shared read-dom/read-ui
+// `on-value` projection) branches its map arm on `:ok?`: a GENUINE
 // runtime failure envelope — `{:ok? false :reason
 // :rf.error/read-dom-bad-selector}` (a malformed CSS selector makes
 // `querySelectorAll` throw), the `:rf.error/ui-read-bad-selector`
-// equivalent, `:no-document`, `:no-element` — shipped with
-// `isError:false`. That violates spec/003-Tool-Catalogue.md §381
-// ("every `:ok? false` response is `isError:true`") AND makes the
-// failure CACHE-ELIGIBLE (cache eligibility bypasses isError), so a
-// transient failure could be cached and mask a later success.
+// equivalent, `:no-document`, `:no-element` — ships with
+// `isError:true`. This honours spec/003-Tool-Catalogue.md §381 ("every
+// `:ok? false` response is `isError:true`") AND keeps the failure
+// CACHE-INELIGIBLE (cache eligibility bypasses isError), so a transient
+// failure cannot be cached and mask a later success.
 //
-// It shipped GREEN at the conformance layer (rf2-87h71e) because
-// read-dom / read-ui were exercised ONLY in DEGRADED mode (the
-// `:nrepl-port-not-found` envelope, which routes through `wire/err-text`
-// directly and is isError by construction). NO test drove the GENUINE
-// live error path — a `querySelectorAll` throw inside the runtime fn —
-// through the SDK boundary. So a server returning `:ok? false` WITHOUT
-// `isError:true` on the read-family error path was never caught.
+// This is the live counterpart to the degraded-mode coverage: read-dom /
+// read-ui in DEGRADED mode return the `:nrepl-port-not-found` envelope
+// (which routes through `wire/err-text` directly and is isError by
+// construction). This test drives the GENUINE live error path — a
+// `querySelectorAll` throw inside the runtime fn — through the SDK
+// boundary, so a server returning `:ok? false` WITHOUT `isError:true` on
+// the read-family error path is caught.
 //
-// This test fills that gap. With a real nREPL + browser runtime
-// connected (the hermetic orchestrator boots both), it:
+// With a real nREPL + browser runtime connected (the hermetic
+// orchestrator boots both), it:
 //
 //   1. `tools/call read-dom` with a malformed CSS selector (`>>>`) so
 //      the runtime's `querySelectorAll` throws and the runtime fn
@@ -35,10 +33,10 @@
 //      `{:ok? false :reason :rf.error/ui-read-bad-selector}`.
 //   3. ASSERTS each response carries BOTH the structured failure reason
 //      (proving we reached the GENUINE runtime error path, not the
-//      degraded `:nrepl-port-not-found` envelope) AND `isError === true`
-//      (the contract rf2-q7cavs restored). Revert the q7cavs fix
-//      (`map-result-or-blank` back to a bare `wire/ok-text` map arm) and
-//      both arms go RED — the reason still rides, but `isError` is false.
+//      degraded `:nrepl-port-not-found` envelope) AND `isError === true`.
+//      Revert the `map-result-or-blank` map arm back to a bare
+//      `wire/ok-text` and both arms go RED — the reason still rides, but
+//      `isError` is false.
 //
 // This is the SDK-boundary counterpart to the unit
 // `bad-selector-error-forwarded` tests in
@@ -70,18 +68,17 @@ const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 
 // we must use a selector the parser REJECTS, not one that merely misses.)
 const BAD_SELECTOR = '>>>';
 
-// The load-bearing assertion (rf2-87h71e / rf2-q7cavs): a GENUINE
-// `:ok? false` runtime failure MUST carry `isError === true`. Three
-// conditions, each load-bearing:
+// The load-bearing assertion: a GENUINE `:ok? false` runtime failure
+// MUST carry `isError === true`. Three conditions, each load-bearing:
 //
 //   - the structured `reason` is the expected bad-selector reason: proves
 //     we drove the GENUINE runtime error path (a `querySelectorAll`
 //     throw), NOT the degraded `:nrepl-port-not-found` envelope (which
 //     would false-pass a bare isError check, since it is isError too).
 //   - `:ok? false`: the envelope is a fault, not a legitimate empty answer.
-//   - `isError === true`: the contract rf2-q7cavs restored. Pre-fix this
-//     was `false` (the shared projection routed every map through
-//     `ok-text`), so this is the assertion that goes RED on a revert.
+//   - `isError === true`: the universal contract. This is the assertion
+//     that goes RED if the shared projection routes every map through
+//     `ok-text`.
 function assertReadFailureIsError(resp, name, expectedReason) {
   const text = responseText(resp);
   if (!text.includes(expectedReason)) {

--- a/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
@@ -1,6 +1,5 @@
 // Live-re-frame2-pair MCP-client conformance variant exercising the wire-cap
 // overflow marker (:rf.mcp/overflow) under real over-budget conditions.
-// Source: rf2-ynaoc, follow-on from rf2-cum40 (PR #702).
 //
 // ## What this test guards
 //
@@ -49,10 +48,10 @@
 // re-frame2-pair-mcp server attaches, and this test runs the real-overflow
 // path.
 //
-// A follow-on bead (filed by rf2-ynaoc) tracks the "live overflow via
-// a worked example + auto-spawned shadow-cljs" variant. That gives
-// fully-hermetic CI coverage; this script gives Mike a one-command
-// local-runtime guard today.
+// A follow-on bead tracks the "live overflow via a worked example +
+// auto-spawned shadow-cljs" variant. That gives fully-hermetic CI
+// coverage; this script gives Mike a one-command local-runtime guard
+// today.
 //
 // ## How the cap is naturally tripped
 //
@@ -72,7 +71,7 @@
 // (same as the sibling harness). Exits 0 on success or SKIP. Exits 1
 // on any conformance violation.
 
-// ## DRY-on-3 resolution (rf2-1bwph → rf2-0ogn7)
+// ## DRY-on-3 resolution
 //
 // This file and its `live-re-frame2-pair-*.cjs` siblings (subscribe,
 // redaction) share the nREPL SKIP-gate (via $SHADOW_CLJS_NREPL_PORT) and
@@ -113,14 +112,11 @@ const DEFAULT_MAX_TOKENS = 5000;
 // path kicks in first).
 const FORM_OVER_BUDGET = '(apply str (repeat 25000 "x"))';
 
-// `edn-data` parse opts pinned for the whole harness (rf2-i3ffz
-// F-CORR-2): map → plain JS object, keyword → bare string (no `:`
-// prefix), set → array. The bare-string keyword form matches Node's
-// JSON-native sensibilities and makes assertions read directly
-// (`body.limit === 'reached'` vs the previous `body[':limit'] ===
-// ':reached'`). Drift in the EDN shape now surfaces as a parse
-// exception on a real EDN reader, not a hand-rolled tokeniser's
-// silent acceptance of an evolution it wasn't designed for.
+// `edn-data` parse opts pinned for the whole harness: map → plain JS
+// object, keyword → bare string (no `:` prefix), set → array. The
+// bare-string keyword form matches Node's JSON-native sensibilities and
+// makes assertions read directly (`body.limit === 'reached'`). Drift in
+// the EDN shape surfaces as a parse exception on a real EDN reader.
 const EDN_PARSE_OPTS = { mapAs: 'object', keywordAs: 'string', setAs: 'array' };
 
 // Required-field table for `:rf.mcp/overflow` (re-frame2-pair-mcp shape). Each
@@ -140,7 +136,7 @@ const REQUIRED_FIELDS = [
 ];
 
 // Validate the parsed `:rf.mcp/overflow` body against the canonical
-// `ReFrame2PairOverflowBody` shape (rf2-i3ffz F-HYG-4 data-driven refactor).
+// `ReFrame2PairOverflowBody` shape.
 function assertOverflowBody(body, ctx) {
   if (!body || typeof body !== 'object') {
     throw new Error(ctx + ': overflow body is not a map: ' + JSON.stringify(body));
@@ -165,14 +161,11 @@ function assertOverflowBody(body, ctx) {
   }
 }
 
-// Parse the canonical re-frame2-pair-mcp overflow marker from response text
-// (rf2-i3ffz F-CORR-2). The hand-rolled ~120-LoC tokeniser this
-// replaces was technically correct for today's shape but fragile under
-// nested-map / escape-sequence evolution; `edn-data` (~30KB, zero
-// transitive deps) is a real EDN reader that handles the cases the
-// hand-roll only handled by accident. Returns the inner body map (a
-// plain JS object with bare-string keys) or null when the marker is
-// absent / the text is unparseable.
+// Parse the canonical re-frame2-pair-mcp overflow marker from response
+// text. `edn-data` (~30KB, zero transitive deps) is a real EDN reader
+// that handles nested-map / escape-sequence shapes robustly. Returns the
+// inner body map (a plain JS object with bare-string keys) or null when
+// the marker is absent / the text is unparseable.
 function parseOverflowMarker(text) {
   let outer;
   try {
@@ -212,8 +205,7 @@ runWithWatchdog(
     clientName: 'mcp-conformance-re-frame2-pair-live-overflow',
     transportSpec: {
       command: process.execPath,
-      // eval-cljs is ON by default post-rf2-a0z0h (inverts the prior
-      // rf2-cxx5s default-OFF). This live-overflow harness's whole
+      // eval-cljs is ON by default. This live-overflow harness's whole
       // purpose is to trip the wire cap on a real eval response, so we
       // boot without `--no-eval` — the default-ON state is exactly
       // what we want. The disabled-envelope contract is pinned by the

--- a/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
@@ -1,11 +1,8 @@
 // Live-re-frame2-pair MCP-client conformance variant exercising egress
 // protection of a FRAME-OWNED `:sensitive {:app-db …}` slot through the
 // pull-mode epoch tools (`trace-window` + `watch-epochs`).
-// Source: rf2-q4o83 (regression net for rf2-6wvh5; correctness review
-// finding rf2-5t8mr.18). Updated for rf2-5613h (epoch-rollup whole-drop)
-// and rf2-2h7153 (drive the PUBLIC EP-0015 frame-owned route).
 //
-// ## EP-0015 — durable app-db policy is FRAME-OWNED (rf2-2h7153)
+// ## EP-0015 — durable app-db policy is FRAME-OWNED
 //
 // Durable app-db egress policy is declared on the FRAME, through the
 // public `reg-frame` route: `(reg-frame :id {:sensitive {:app-db
@@ -14,68 +11,51 @@
 // `reg-frame` validates the classification and installs it into the
 // frame's durable elision registry tagged `:source :frame`; the epoch
 // assembler's `sensitive-rollup` and the off-box `projected-record` both
-// read THAT registry. Schema-attached `:sensitive?` app-db classification
-// was REMOVED (EP-0015 §8): schemas describe shape, not durable app-db
-// egress policy, and the former `populate-sensitive-from-schemas!`
-// importer is gone.
+// read THAT registry. Schemas describe shape, not durable app-db egress
+// policy: there is no schema-attached `:sensitive?` app-db classification
+// (EP-0015 §8).
 //
 // The gate-OFF / gate-ON arms below therefore declare the sensitive slot
 // through the FRAME-OWNED `reg-frame` route — the same route an app
-// author uses — NOT by hand-seeding the elision registry. This is the
-// load-bearing change rf2-2h7153 fixes: the prior version wrote the
-// `:sensitive-declarations` slot directly via `swap-elision-slot!`, which
-// EP-0015 treats as internal projection plumbing, so the surface could
-// stay GREEN even if `reg-frame` `:sensitive {:app-db …}` policy stopped
-// reaching the epoch rollup / projected-record / pair-MCP wire egress.
-// Driving the public route proves the whole frame-owned path end-to-end.
+// author uses — NOT by hand-seeding the elision registry. Driving the
+// public route proves the whole frame-owned path end-to-end: a regression
+// where `reg-frame` `:sensitive {:app-db …}` policy stopped reaching the
+// epoch rollup / projected-record / pair-MCP wire egress goes RED here.
 //
-// ## The hole this closes
+// ## What this test guards
 //
-// rf2-6wvh5 was a HIGH-severity egress leak: the pull-mode epoch tools
-// `trace-window` and `watch-epochs` egressed whole `:rf/epoch-record`s
-// carrying `:db-before` / `:db-after` app-db snapshots over the MCP wire
-// WITHOUT routing them through the framework's off-box projection. A
-// schema-declared `:sensitive?` slot (e.g. `[:auth :password]`) rode the
-// wire verbatim even with the `--allow-sensitive-reads` gate OFF (the
-// published-build default). The original rf2-6wvh5 fix routed each
-// egressed record through `re-frame.core/projected-record` server-side —
-// value-redacting the sensitive slot to `:rf/redacted`.
+// The pull-mode epoch tools `trace-window` and `watch-epochs` egress
+// `:rf/epoch-record`s carrying `:db-before` / `:db-after` app-db snapshots
+// over the MCP wire. A FRAME-declared sensitive slot (e.g. `[:auth
+// :password]`) MUST be protected on egress even with the
+// `--allow-sensitive-reads` gate OFF (the published-build default). This
+// is the end-to-end wire gate that puts a sensitive value into a live
+// app-db and asserts it is protected on the wire through these tools —
+// coverage neither source-text greps (wire_vocab_test.clj) nor a
+// leaf-counter indicator gate provide, since neither asserts the
+// sensitive leaf is actually protected on egress.
 //
-// The leak shipped GREEN because the cross-server mcp-conformance gate
-// had NO scenario that put a sensitive value into a live app-db and
-// asserted it was protected on the wire through these tools. The only
-// `:rf/redacted` coverage in tools/mcp-conformance was source-text greps
-// (wire_vocab_test.clj) and a leaf-counter indicator gate — neither
-// asserts the sensitive leaf was actually protected on egress. This test
-// is the missing end-to-end wire gate: it would have caught rf2-6wvh5 RED.
+// ## Whole-epoch DROP for sensitive epochs
 //
-// ## rf2-5613h — the protection STRENGTHENED to a whole-epoch DROP
-//
-// rf2-5613h closed a second, related leak: pair-mcp's `sensitive-epoch?`
-// (the whole-epoch DROP predicate that `strip-sensitive` feeds in the
-// `:epoch-vector` wire-pipeline arm) was reading the UNqualified
-// `:sensitive?` key, which the runtime never writes on an epoch record —
-// the real record-level rollup is the qualified `:rf.epoch/sensitive?`
+// pair-mcp's `sensitive-epoch?` (the whole-epoch DROP predicate that
+// `strip-sensitive` feeds in the `:epoch-vector` wire-pipeline arm) reads
+// the qualified record-level rollup `:rf.epoch/sensitive?`
 // (`re-frame.epoch.assembly/sensitive-rollup`). The assembler sets that
-// rollup `true` whenever a schema-declared sensitive PATH holds a non-nil
-// leaf in `:db-before`/`:db-after` — exactly the scenario this test sets
-// up. Pre-rf2-5613h the mismatch meant the whole-drop never fired for a
-// schema-derived sensitive epoch, so its metadata (`:event-id`, timing,
-// `:redacted-modified-paths-count`, outcome) shipped across the wire
-// alongside the value-redacted `:db-*` slots — a default-DROP violation.
+// rollup `true` whenever a declared sensitive PATH holds a non-nil leaf in
+// `:db-before`/`:db-after` — exactly the scenario this test sets up.
 //
-// Post-rf2-5613h the default (gate-OFF) posture is fail-closed at the
-// RECORD level: a sensitive epoch is WHOLE-DROPPED before egress — it
-// never reaches the value-redaction stage at all. So the gate-OFF arm now
-// asserts the sentinel is ABSENT *and* the tool reports `:dropped-sensitive`
-// >= 1 with no record in `:epochs` (proving the strip-fn dropped it — not
-// that the window happened to exclude it or the slot was empty). The
-// previous "`:rf/redacted` PRESENT" assertion no longer applies on this
-// path: with the whole-drop firing, there is no surviving record to carry
-// a redacted slot. (`projected-record` value-redaction is still the
-// belt-and-braces inner layer for any sensitive material the record-level
-// rollup does NOT catch; this scenario's declared-sensitive non-nil leaf
-// DOES flag the rollup, so the outer whole-drop governs.)
+// The default (gate-OFF) posture is fail-closed at the RECORD level: a
+// sensitive epoch is WHOLE-DROPPED before egress — it never reaches the
+// value-redaction stage at all, so none of its metadata (`:event-id`,
+// timing, `:redacted-modified-paths-count`, outcome) crosses the wire. So
+// the gate-OFF arm asserts the sentinel is ABSENT *and* the tool reports
+// `:dropped-sensitive` >= 1 with no record in `:epochs` (proving the
+// strip-fn dropped it — not that the window happened to exclude it or the
+// slot was empty). With the whole-drop firing there is no surviving record
+// to carry a redacted slot. (`projected-record` value-redaction is still
+// the belt-and-braces inner layer for any sensitive material the
+// record-level rollup does NOT catch; this scenario's declared-sensitive
+// non-nil leaf DOES flag the rollup, so the outer whole-drop governs.)
 //
 // ## What this test drives (across the MCP boundary, via the SDK Client)
 //
@@ -92,7 +72,7 @@
 //           into that slot, landing it in the next epoch's `:db-after`
 //           (and flagging the epoch's `:rf.epoch/sensitive?` rollup true).
 //   3. `tools/call trace-window` AND `tools/call watch-epochs` — the two
-//      pull-mode epoch tools that leaked.
+//      pull-mode epoch tools whose egress this gate protects.
 //   4. ASSERT the sentinel does NOT appear ANYWHERE in either egress
 //      payload, AND that the tool reports `:dropped-sensitive` >= 1 (the
 //      whole sensitive epoch was dropped — proving the strip-fn fired, not
@@ -104,12 +84,13 @@
 //
 // ## Why this is a true regression net
 //
-// Revert the rf2-5613h key fix (point `sensitive-epoch?` back at the
-// UNqualified `:sensitive?`) and step 4 goes RED two ways: the whole-drop
-// stops firing (`:dropped-sensitive` falls to 0) AND — because the record
-// now survives into the value-redaction stage — its raw metadata ships.
-// Verified by reproduction during the rf2-5613h greening (the gate-OFF
-// trace-window returned `:dropped-sensitive 1, :epochs []` post-fix).
+// Point `sensitive-epoch?` at the UNqualified `:sensitive?` (which the
+// runtime never writes on an epoch record) and step 4 goes RED two ways:
+// the whole-drop stops firing (`:dropped-sensitive` falls to 0) AND —
+// because the record then survives into the value-redaction stage — its
+// raw metadata ships. Under the correct qualified `:rf.epoch/sensitive?`
+// read, the gate-OFF trace-window returns `:dropped-sensitive 1,
+// :epochs []`.
 //
 // ## Gating
 //
@@ -260,7 +241,7 @@ const SEED_FORM = `
 const VERIFY_WRITE_FORM =
   `(get (re-frame2-pair.runtime/snapshot (re-frame2-pair.runtime/current-frame)) ${SECRET_KEY})`;
 
-// ---- INNER projected-record value-redaction arm (rf2-ywn27.3) --------------
+// ---- INNER projected-record value-redaction arm --------------
 //
 // Egress under gate-OFF has TWO independent redaction layers:
 //
@@ -277,8 +258,8 @@ const VERIFY_WRITE_FORM =
 //
 // The gate-OFF arm above declares the path BEFORE dispatch, so the
 // rollup stamps true and the OUTER whole-drop governs — the INNER layer
-// is BYPASSED (no record survives to carry a redacted slot; the test's
-// own header, lines 42-53, confirms this).
+// is BYPASSED (no record survives to carry a redacted slot; the
+// whole-epoch DROP section of this header confirms this).
 //
 // This arm drives the shape where the INNER layer is the SOLE
 // protection: record a NON-sensitive epoch FIRST (no declaration ⇒
@@ -298,7 +279,7 @@ const VERIFY_WRITE_FORM =
 // + sentinel ABSENT + the `:rf/redacted` marker PRESENT in the surviving
 // record's `:db-after`.
 //
-// rf2-2h7153 — this arm ALSO drives the PUBLIC frame-owned route:
+// This arm ALSO drives the PUBLIC frame-owned route:
 // `reg-frame fid {}` (no `:sensitive` block) clears the prior frame-owned
 // `:source :frame` declarations, and `reg-frame fid {:sensitive {:app-db
 // …}}` installs the post-hoc declaration. So the inner-layer arm proves
@@ -406,14 +387,13 @@ function droppedSensitiveCount(text) {
   return m ? Number(m[1]) : null;
 }
 
-// The load-bearing assertion (rf2-5613h): the SENTINEL must be ABSENT AND
-// the tool must report `:dropped-sensitive` >= 1 — proving the whole
-// sensitive epoch was DROPPED by the strip-fn, not merely that the slot
-// was empty or the window excluded the record (a window-excludes-everything
-// regression reports `:dropped-sensitive 0` and would pass a bare absence
-// check while the drop never fired). Pre-rf2-5613h this asserted a
-// surviving record carried `:rf/redacted`; with the whole-drop now firing
-// for a schema-derived sensitive epoch, no record survives to carry it.
+// The load-bearing assertion: the SENTINEL must be ABSENT AND the tool
+// must report `:dropped-sensitive` >= 1 — proving the whole sensitive
+// epoch was DROPPED by the strip-fn, not merely that the slot was empty or
+// the window excluded the record (a window-excludes-everything regression
+// reports `:dropped-sensitive 0` and would pass a bare absence check while
+// the drop never fired). With the whole-drop firing for a declared-
+// sensitive epoch, no record survives to carry a `:rf/redacted` slot.
 function assertDropped(resp, name) {
   assertOk(resp, name);
   const text = responseText(resp);
@@ -440,7 +420,7 @@ function assertDropped(resp, name) {
   }
 }
 
-// The INNER-layer assertion (rf2-ywn27.3): the INNER_SENTINEL must be
+// The INNER-layer assertion: the INNER_SENTINEL must be
 // ABSENT, the surviving record must carry the `:rf/redacted` marker, AND
 // `:dropped-sensitive` MUST be 0 — proving the protection was the
 // SERVER-SIDE `projected-record` value-redaction (the inner layer), NOT
@@ -577,7 +557,7 @@ async function enableEpochRecording(client, label) {
   const enable = await client.callTool({ name: 'eval-cljs', arguments: { form: ENABLE_CONFIGURE_FORM } });
   assertOk(enable, label + ' eval-cljs configure-epoch');
   // Structured `:hook-installed? true` token, not a bare 'true' substring
-  // — same rationale as the seedRuntime check above (rf2-6r5qe.2).
+  // — same rationale as the seedRuntime check above.
   if (!/:hook-installed\?\s+true\b/.test(responseText(enable))) {
     throw new Error(
       label + ' eval-cljs configure-epoch did not install the :epoch/settle! hook ' +
@@ -587,7 +567,7 @@ async function enableEpochRecording(client, label) {
   }
 }
 
-// ---- INNER projected-record value-redaction arm (rf2-ywn27.3) --------------
+// ---- INNER projected-record value-redaction arm --------------
 //
 // A SECOND gate-OFF server (no `--allow-sensitive-reads`) so its ring
 // holds ONLY the one epoch we seed here — no other recorded epoch can
@@ -613,8 +593,7 @@ async function runInnerProjectionArm() {
     // Register with the outer watchdog the INSTANT this secondary child is
     // constructed — BEFORE connect awaits — so a hang in THIS arm's boot or
     // a later tool call is reaped by the outer timeout instead of orphaning
-    // the secondary Node child (rf2-wqi4n4 finding 1). The bare-caller
-    // analogue of the rf2-2js41 finding-2 fix.
+    // the secondary Node child.
     onClient: registerAuxClient,
   });
   try {
@@ -690,8 +669,8 @@ async function runInnerProjectionArm() {
     assertInnerRedacted(tw, 'trace-window (inner projected-record value-redaction)');
     console.log('OK   trace-window (gate OFF, inner layer SOLE) -> :db-after :rf/redacted + :dropped-sensitive 0');
 
-    // watch-epochs: the named focus of rf2-ywn27 — same inner-layer SOLE
-    // protection at its INDEPENDENT call site.
+    // watch-epochs: same inner-layer SOLE protection at its INDEPENDENT
+    // call site.
     const we = await client.callTool({
       name: 'watch-epochs',
       arguments: { 'epochs-mode': 'full', dedup: false },
@@ -700,7 +679,7 @@ async function runInnerProjectionArm() {
     console.log('OK   watch-epochs (gate OFF, inner layer SOLE) -> :db-after :rf/redacted + :dropped-sensitive 0');
   } finally {
     // Deregister before the explicit close so the watchdog set doesn't hold
-    // a stale handle past teardown (rf2-wqi4n4 finding 1).
+    // a stale handle past teardown.
     unregisterAuxClient(client);
     await closeQuietly(client);
   }
@@ -717,10 +696,10 @@ async function runInnerProjectionArm() {
 // would pass a gate-OFF-only test but break the operator's deliberate
 // raw-state read.
 async function runGateOnArm() {
-  // Stand up the second server via the shared spawn+connect primitive
-  // (rf2-0ogn7). The `[server:gate-on]` stderr prefix keeps this
-  // concurrent boot's logs distinguishable from the runner-managed
-  // gate-OFF server's `[server]` lines.
+  // Stand up the second server via the shared spawn+connect primitive.
+  // The `[server:gate-on]` stderr prefix keeps this concurrent boot's logs
+  // distinguishable from the runner-managed gate-OFF server's `[server]`
+  // lines.
   const { client } = await connectServer({
     clientName: 'mcp-conformance-re-frame2-pair-redaction-gate-on',
     stderrPrefix: '[server:gate-on]',
@@ -733,7 +712,7 @@ async function runGateOnArm() {
     // Register with the outer watchdog the INSTANT this secondary child is
     // constructed — BEFORE connect awaits — so a hang in this gate-ON boot
     // or a later tool call is reaped by the outer timeout instead of
-    // orphaning the secondary Node child (rf2-wqi4n4 finding 1).
+    // orphaning the secondary Node child.
     onClient: registerAuxClient,
   });
   try {
@@ -774,7 +753,7 @@ async function runGateOnArm() {
     console.log('OK   gate-ON watch-epochs (+:include-sensitive) -> sentinel SHIPS (opt-in honoured)');
   } finally {
     // Deregister before the explicit close so the watchdog set doesn't hold
-    // a stale handle past teardown (rf2-wqi4n4 finding 1).
+    // a stale handle past teardown.
     unregisterAuxClient(client);
     await closeQuietly(client);
   }
@@ -829,15 +808,15 @@ runWithWatchdog(
     }
     console.log('OK   eval-cljs verify-write -> sentinel confirmed live in app-db (raw, on-box)');
 
-    // 3a. trace-window — the first pull-mode tool that leaked. Wide window
-    // so the just-dispatched epoch is comfortably inside it. The sensitive
-    // epoch is WHOLE-DROPPED (rf2-5613h): sentinel ABSENT + :dropped-sensitive >= 1.
+    // 3a. trace-window — the first pull-mode tool. Wide window so the
+    // just-dispatched epoch is comfortably inside it. The sensitive epoch
+    // is WHOLE-DROPPED: sentinel ABSENT + :dropped-sensitive >= 1.
     const tw = await client.callTool({ name: 'trace-window', arguments: { ms: TRACE_WINDOW_MS } });
     assertDropped(tw, 'trace-window');
     console.log('OK   trace-window (gate OFF) -> sentinel ABSENT + sensitive epoch DROPPED');
 
-    // 3b. watch-epochs — the second pull-mode tool that leaked. No
-    // :since-id → the full ring (which includes the sentinel epoch).
+    // 3b. watch-epochs — the second pull-mode tool. No :since-id → the
+    // full ring (which includes the sentinel epoch).
     const we = await client.callTool({ name: 'watch-epochs', arguments: {} });
     assertDropped(we, 'watch-epochs');
     console.log('OK   watch-epochs (gate OFF) -> sentinel ABSENT + sensitive epoch DROPPED');
@@ -845,8 +824,8 @@ runWithWatchdog(
     // 3c. Hostile per-call opt-in MUST NOT defeat the gate. A caller
     // passing `:include-sensitive true` to a server booted WITHOUT
     // `--allow-sensitive-reads` cannot talk it into shipping raw state —
-    // the boot gate forces `incl? false` regardless (rf2-c2dtu). Pin that
-    // the per-call arg is powerless when the operator didn't opt in.
+    // the boot gate forces `incl? false` regardless. Pin that the per-call
+    // arg is powerless when the operator didn't opt in.
     const twHostile = await client.callTool({
       name: 'trace-window',
       arguments: { ms: TRACE_WINDOW_MS, 'include-sensitive': true },
@@ -856,10 +835,10 @@ runWithWatchdog(
       'OK   trace-window (gate OFF + hostile :include-sensitive true) -> still DROPPED',
     );
 
-    // 3d. watch-epochs hostile per-call opt-in — the SIBLING of 3c
-    // (rf2-ywn27.1). trace-window and watch-epochs compute `incl?` at
-    // SEPARATE call sites (trace_window.cljs:61-63 vs
-    // watch_epochs.cljs:61-63) — each is an independent
+    // 3d. watch-epochs hostile per-call opt-in — the SIBLING of 3c.
+    // trace-window and watch-epochs compute `incl?` at SEPARATE call sites
+    // (trace_window.cljs:61-63 vs watch_epochs.cljs:61-63) — each is an
+    // independent
     // `(if (raw-state-allowed?) (parse-bool-arg ... :include-sensitive)
     // false)`, NOT shared code. So a regression that drops the boot-gate
     // guard on watch-epochs ALONE (e.g. watch_epochs.cljs:61 simplified
@@ -868,9 +847,9 @@ runWithWatchdog(
     // WITHOUT --allow-sensitive-reads into shipping RAW epoch `:db-after`
     // — `incl? true` ⇒ `project? false` ⇒ no projected-record wrap AND
     // `strip-sensitive [items 0]` ⇒ the whole-drop is bypassed too. The
-    // pre-rf2-ywn27.1 suite stayed GREEN because it only ever sent
-    // watch-epochs the DEFAULT-args call gate-OFF (3b), which forces
-    // `incl? false` regardless. Pin the hostile arg is powerless here.
+    // default-args gate-OFF call (3b) forces `incl? false` regardless, so
+    // it cannot catch this; this hostile-arg call is the one that pins the
+    // boot-gate guard on watch-epochs's INDEPENDENT site.
     const weHostile = await client.callTool({
       name: 'watch-epochs',
       arguments: { 'include-sensitive': true },
@@ -881,7 +860,7 @@ runWithWatchdog(
     );
 
     // 3e. INNER projected-record value-redaction layer — the sole
-    // protection when the OUTER whole-drop does NOT fire (rf2-ywn27.3).
+    // protection when the OUTER whole-drop does NOT fire.
     // See `runInnerProjectionArm` for the two-layer model and why this
     // is distinguishable from the whole-drop scenarios above.
     await runInnerProjectionArm();

--- a/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
@@ -1,19 +1,18 @@
 // Live-re-frame2-pair MCP-client conformance variant exercising the
 // `notifications/progress` streaming wire surface.
-// Source: rf2-zb5z6 (rf2-i3ffz F-GAP-1 follow-on).
 //
 // ## What this test guards
 //
 // The sibling `end-to-end-re-frame2-pair.cjs` runs `subscribe` only in
 // *degraded* mode (no nREPL → every response is the same
 // `:nrepl-port-not-found` error envelope). The live overflow harness
-// (`live-re-frame2-pair-overflow.cjs`) only exercises `eval-cljs`. Before this
-// gate landed, **no test ever observed a real
-// `notifications/progress` frame from the server** — re-frame2-pair-mcp's
-// streaming surface (per NAMING.md §"subscribe / unsubscribe": one
-// progress frame per matching batch) had zero wire conformance.
+// (`live-re-frame2-pair-overflow.cjs`) only exercises `eval-cljs`. This
+// variant is the one that observes a real `notifications/progress` frame
+// from the server — pinning re-frame2-pair-mcp's streaming surface (per
+// NAMING.md §"subscribe / unsubscribe": one progress frame per matching
+// batch) on the wire.
 //
-// This variant fills that gap. With a real nREPL connected:
+// With a real nREPL connected:
 //
 //   1. We pass a request-scoped `onprogress` callback to the SDK
 //      `tools/call` — the same progress path a real MCP-aware
@@ -23,16 +22,16 @@
 //      terminal summary.
 //   3. While subscribe streams, we `tools/call dispatch` the fixture's
 //      `[:counter/inc "<NONCE>"]` event — repeatedly, on a short cadence,
-//      until a progress frame carrying that per-run NONCE is observed
-//      (rf2-x0pr0). The trace bus emission for the cascade WE caused flows
-//      back through subscribe's drain loop. Re-dispatching removes the
-//      timing race: the subscription is installed asynchronously
+//      until a progress frame carrying that per-run NONCE is observed.
+//      The trace bus emission for the cascade WE caused flows back through
+//      subscribe's drain loop. Re-dispatching removes the timing race:
+//      the subscription is installed asynchronously
 //      (ensure-runtime! → signal-runtime! → subscribe! eval), so the
 //      FIRST probe to land after registration produces the causal frame —
 //      readiness is PROVEN by the observed nonce, never assumed by a clock.
 //   4. We assert (a) the observed cascade is CAUSALLY ours — at least one
 //      frame's `:message` carries the dispatched NONCE, so an unrelated bus
-//      emission can no longer false-green the gate — and (b) every collected
+//      emission cannot false-green the gate — and (b) every collected
 //      progress frame passes the canonical
 //      `ReFrame2PairProgressNotificationParams` shape pinned by `wire-vocab/`
 //      (the JVM-side schema). A drift between the JS-side assertion
@@ -50,19 +49,19 @@
 //     mangled token fails to route and zero frames arrive, tripping the
 //     "at least one frame" gate. The slot is unobservable in the
 //     `onprogress` callback (the SDK strips it before invoking us), so a
-//     direct JS-side presence check would be vacuous (rf2-ee38b.20).
+//     direct JS-side presence check would be vacuous.
 //   - `_meta.data` slot shape drift (`:dropped-events`, `:dropped-bytes`,
 //     `:overflow-reason` are the documented contract slots).
 //   - subscribe entirely failing to emit a progress frame on a
 //     well-formed dispatch (e.g. drain loop regression).
 //   - the subscribe→dispatch→drain CAUSAL path silently breaking: a frame
 //     that does NOT correspond to our dispatched event (e.g. the cascade
-//     for `:counter/inc` never reaches the sub's queue) no longer passes,
+//     for `:counter/inc` never reaches the sub's queue) does not pass,
 //     because the NONCE assertion requires the observed frame to be the
-//     cascade we caused (rf2-x0pr0).
+//     cascade we caused.
 //   - a refused / failed dispatch silently passing: the probe's `isError`
-//     is now FATAL, so a dispatch that never landed fails the gate rather
-//     than riding alongside an unrelated frame (rf2-x0pr0).
+//     is FATAL, so a dispatch that never landed fails the gate rather
+//     than riding alongside an unrelated frame.
 //
 // ## Flag-gate WIRE riders (eval + writes)
 //
@@ -76,13 +75,12 @@
 // end-to-end never reaches these gates):
 //
 //   - `eval-cljs` with `--no-eval` ⇒ isError + `:rf.error/eval-cljs-disabled`
-//     (rf2-a0z0h — the opt-out post-default-ON eval gate).
+//     (the opt-out eval gate; eval-cljs is ON by default).
 //   - `restore-epoch` / `replace-app-db` with `--allow-writes` ABSENT ⇒
-//     isError + `:rf.error/writes-disabled` (rf2-ee38b.18 default-OFF
-//     write gate; coverage added rf2-6r5qe.1). This pins the pair-mcp
-//     half of the NAMING.md cross-server write-gate contract that was
-//     doc-only before — a default-flip / flag-rename / dropped gate-check
-//     for either state-mutating tool now ships RED.
+//     isError + `:rf.error/writes-disabled` (the default-OFF write gate).
+//     This pins the pair-mcp half of the NAMING.md cross-server write-gate
+//     contract — a default-flip / flag-rename / dropped gate-check for
+//     either state-mutating tool ships RED.
 //
 // ## Gating
 //
@@ -94,7 +92,7 @@
 // (`scripts/run-re-frame2-pair-live-hermetic-suite.cjs`) wires the env when
 // run as part of the hermetic suite.
 
-// ## DRY-on-3 resolution (rf2-1bwph → rf2-0ogn7)
+// ## DRY-on-3 resolution
 //
 // This file and its `live-re-frame2-pair-*.cjs` siblings (overflow,
 // redaction) share the nREPL SKIP-gate (via $SHADOW_CLJS_NREPL_PORT) and
@@ -124,16 +122,16 @@ const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 
 // re-frame2-pair-mcp's spec the four valid topics are `trace | epoch | fx | error`.
 const TOPIC = 'trace';
 
-// Per-run unique nonce (rf2-x0pr0). We dispatch `[:counter/inc
+// Per-run unique nonce. We dispatch `[:counter/inc
 // "<NONCE>"]` — the `:counter/inc` event-db handler ignores its event
 // args, so the extra string is inert, but the FULL event vector rides
 // into the trace cascade's `:event` slot and is `pr-str`'d into the
 // progress frame's `:message`. Asserting at least one progress frame's
 // `message` carries this nonce makes the gate CAUSAL: it proves the
 // observed frame is the cascade from OUR dispatch, not an unrelated bus
-// emission that happened to arrive during the window. Before this, the
-// gate accepted ANY progress frame (`frames.length > 0`), so a spurious
-// emission while our dispatch raced / failed could false-green it.
+// emission that happened to arrive during the window. A bare
+// `frames.length > 0` check would false-green on a spurious emission
+// while our dispatch raced / failed; requiring the nonce rules that out.
 const NONCE = 'rf2-subscribe-probe-' + crypto.randomUUID();
 const PROBE_EVENT = '[:counter/inc "' + NONCE + '"]';
 
@@ -151,8 +149,8 @@ const MAX_MS = 1500;
 // greps for each row's literal source form. A row renamed/deleted
 // trips the JVM gate.
 //
-// `progressToken` is deliberately ABSENT from this table (rf2-ee38b.20
-// correctness fix). The MCP SDK's `_onprogress` destructures
+// `progressToken` is deliberately ABSENT from this table. The MCP SDK's
+// `_onprogress` destructures
 // `progressToken` OUT of `notification.params` before invoking this
 // callback (`@modelcontextprotocol/sdk/.../shared/protocol.js`:
 // `const { progressToken, ...params } = notification.params`), so the
@@ -238,12 +236,12 @@ runWithWatchdog(
     transportSpec: {
       command: process.execPath,
       // re-frame2-pair-mcp's subscribe tool is unaffected by the eval
-      // gate. We boot with `--no-eval` (the opt-out post-rf2-a0z0h)
-      // because the eval-cljs WIRE check below asserts the
+      // gate. We boot with `--no-eval` (the opt-out; eval-cljs is ON by
+      // default) because the eval-cljs WIRE check below asserts the
       // disabled-envelope crosses the wire when eval has been opted
       // OUT — that is the only configuration where the disabled gate
-      // is reachable post-default-flip. The streaming bus surface is
-      // the load-bearing test target; the eval probe rides alongside.
+      // is reachable. The streaming bus surface is the load-bearing
+      // test target; the eval probe rides alongside.
       args: [SERVER, '--no-eval'],
       cwd: os.tmpdir(),
       env: { ...process.env },
@@ -268,7 +266,7 @@ runWithWatchdog(
       // implicitly by the "at least one frame arrived" gate below (a
       // renamed / dropped token fails the SDK's numeric correlation →
       // zero frames). See the REQUIRED_PARAMS comment for why a JS-side
-      // `progressToken` presence check would be vacuous (rf2-ee38b.20).
+      // `progressToken` presence check would be vacuous.
       frames.push(params);
     };
 
@@ -287,38 +285,36 @@ runWithWatchdog(
       { onprogress: onProgress },
     );
 
-    // ---- Causality-based readiness, NOT a fixed-sleep proxy (rf2-x0pr0) ----
+    // ---- Causality-based readiness, NOT a fixed-sleep proxy ----
     //
-    // Pre-fix, the test slept a fixed 100ms and then dispatched ONCE,
-    // TREATING the sleep as proof the subscription was installed. But the
-    // server only registers the runtime subscription after `ensure-runtime!`
-    // + `signal-runtime!` + the `subscribe!` nREPL eval all complete — on a
-    // cold runtime that can exceed 100ms. If the single dispatch raced ahead
-    // of registration its cascade was lost and the gate either flaked (zero
-    // frames) or, worse, false-greened on an unrelated frame.
+    // The server registers the runtime subscription only after
+    // `ensure-runtime!` + `signal-runtime!` + the `subscribe!` nREPL eval
+    // all complete — on a cold runtime that can exceed any fixed sleep, and
+    // a single dispatch that raced ahead of registration would lose its
+    // cascade (zero frames, or a false-green on an unrelated frame).
     //
-    // We now drive readiness CAUSALLY: re-dispatch the nonce-tagged probe
+    // So we drive readiness CAUSALLY: re-dispatch the nonce-tagged probe
     // event on a short cadence until a progress frame carrying our NONCE is
     // observed (`sawNonceFrame()`), or the subscribe window is nearly closed.
     // Each `[:counter/inc "<nonce>"]` is a harmless idempotent increment, so
     // repeating it is safe; the FIRST one to land after registration produces
     // the causal frame and the loop stops. There is no fixed-time assumption
     // — registration completing late just means a later probe is the one that
-    // lands. This is the "deterministic 'subscription installed' signal" the
-    // acceptance criterion asks for: the installed state is proven by the
-    // observed cascade, not assumed by a clock.
+    // lands. This is the deterministic "subscription installed" signal: the
+    // installed state is proven by the observed cascade, not assumed by a
+    // clock.
     const sawNonceFrame = () =>
       frames.some(
         (f) => typeof f.message === 'string' && f.message.includes(NONCE),
       );
 
     // The event arg slot is `event` (a single EDN-vector string parsed
-    // server-side per rf2-vflrg). The event-id MUST be a REGISTERED fixture
+    // server-side). The event-id MUST be a REGISTERED fixture
     // handler — `:counter/inc` (counter/core.cljs, a pure `(update :count
     // inc)`) — so the dispatch actually lands and the trace bus emits. An
     // unregistered id would be refused (no cascade). `:queued true` routes
     // through the runtime `pair-dispatch!` transport-ack path rather than the
-    // default `dispatch-consequence!` (rf2-3bu3d.2): the re-frame2-pair fixture
+    // default `dispatch-consequence!`: the re-frame2-pair fixture
     // boots with epoch recording at depth 0, so the consequence path would
     // report `:no-epoch-recorded` even though the event dispatched and the
     // TRACE cascade fired. The trace bus is independent of epoch recording, so
@@ -343,16 +339,15 @@ runWithWatchdog(
     while (Date.now() < RETRY_DEADLINE && !sawNonceFrame()) {
       lastDispatchResp = await dispatchProbe();
       dispatchCount++;
-      // ---- Dispatch result is FATAL on refusal (rf2-x0pr0) ----
+      // ---- Dispatch result is FATAL on refusal ----
       //
-      // Pre-fix a dispatch `isError` was logged-and-ignored ("non-fatal").
-      // That was a false-green vector: a REFUSED dispatch (parse error,
-      // `:runtime-not-preloaded`, nREPL flap, an unknown event-id) means OUR
-      // cascade never ran, yet the old "at least one frame" gate would still
-      // pass on an unrelated emission. `:queued` returns `{:ok? true
-      // :queued? true ...}` on a real enqueue; the server maps a runtime
-      // `:ok? false` (or any failure) to an `isError` envelope
-      // (`runtime-envelope->result`, rf2-ldfnx). So `isError` here is exactly
+      // A REFUSED dispatch (parse error, `:runtime-not-preloaded`, nREPL
+      // flap, an unknown event-id) means OUR cascade never ran, so treating
+      // `isError` as fatal stops the gate from limping on toward a frame
+      // assertion an unrelated emission could satisfy. `:queued` returns
+      // `{:ok? true :queued? true ...}` on a real enqueue; the server maps a
+      // runtime `:ok? false` (or any failure) to an `isError` envelope
+      // (`runtime-envelope->result`). So `isError` here is exactly
       // "the dispatch did not land" — fatal. (The benign
       // `:no-epoch-recorded`/`:settled? false` posture does NOT surface as
       // isError under `:queued`, so we stay decoupled from the fixture's
@@ -407,16 +402,15 @@ runWithWatchdog(
       'OK   notifications/progress -> ' + frames.length + ' frame(s) received',
     );
 
-    // ---- LOAD-BEARING CAUSALITY ASSERTION (rf2-x0pr0) ----
+    // ---- LOAD-BEARING CAUSALITY ASSERTION ----
     //
-    // Pre-fix the gate stopped at "at least one frame arrived" — which a
-    // spurious, unrelated bus emission during the window could satisfy
-    // even if OUR dispatch raced ahead of subscription registration or
-    // failed silently. The `:trace` topic carries EVERY dispatch on the
-    // runtime, so "a frame" is NOT proof the frame is the cascade we
-    // caused.
+    // "At least one frame arrived" alone is NOT proof the frame is the
+    // cascade we caused: a spurious, unrelated bus emission during the
+    // window could satisfy it even if OUR dispatch raced ahead of
+    // subscription registration or failed silently, because the `:trace`
+    // topic carries EVERY dispatch on the runtime.
     //
-    // We now require at least ONE frame whose `:message` (the EDN-printed
+    // So we require at least ONE frame whose `:message` (the EDN-printed
     // batch — on `:trace` a `:cascades` vector, each bundle carrying its
     // `:event` slot = the dispatched event vector) contains our per-run
     // NONCE. Since we dispatched `[:counter/inc "<NONCE>"]`, the cascade's
@@ -458,14 +452,14 @@ runWithWatchdog(
       'OK   every frame validates against ReFrame2PairProgressNotificationParams',
     );
 
-    // ---- Operator-opt-out flag-gate WIRE conformance (rf2-a0z0h) ----
+    // ---- Operator-opt-out flag-gate WIRE conformance ----
     //
     // This server booted WITH `--no-eval` (see transportSpec above) AND
     // has a live runtime attached — so it is NOT in degraded mode. The
-    // eval-cljs gate flipped to default-ON in rf2-a0z0h; the disabled
-    // envelope is now reachable only when the operator explicitly opts
-    // OUT. The call reaches the tool body, the gate (flipped OFF by
-    // --no-eval) short-circuits BEFORE touching nREPL, and the
+    // eval-cljs gate is default-ON; the disabled envelope is reachable
+    // only when the operator explicitly opts OUT. The call reaches the
+    // tool body, the gate (flipped OFF by --no-eval) short-circuits BEFORE
+    // touching nREPL, and the
     // canonical `:rf.error/eval-cljs-disabled` envelope crosses the
     // wire. (In degraded mode the server's `degraded-handler`
     // short-circuits every tool to `:nrepl-port-not-found` before the
@@ -499,9 +493,9 @@ runWithWatchdog(
         ':rf.error/eval-cljs-disabled (live, non-degraded)',
     );
 
-    // ---- Default-OFF write-gate WIRE conformance (rf2-6r5qe.1) ----
+    // ---- Default-OFF write-gate WIRE conformance ----
     //
-    // The pair-mcp `--allow-writes` gate (rf2-ee38b.18) guards the two
+    // The pair-mcp `--allow-writes` gate guards the two
     // state-mutating tools `restore-epoch` (time-travel undo) and
     // `replace-app-db` (state injection). It is DEFAULT-OFF — the
     // published-build posture — and this server booted WITHOUT
@@ -511,12 +505,11 @@ runWithWatchdog(
     // `{:ok? false :reason :rf.error/writes-disabled :tool "<name>"}`
     // envelope WITHOUT touching the nREPL socket.
     //
-    // Until this probe landed, that refusal had ZERO wire-level
-    // conformance coverage (rf2-6r5qe.1): NAMING.md §"Operator-opt-in CLI
-    // flag vocabulary" pins it as a cross-server contract (pair-mcp's
-    // half of the same gate story story-mcp's --allow-writes covers in
-    // end-to-end-flag-gates.cjs), yet no test asserted the pair-mcp
-    // envelope on the wire. The existing gates all miss it:
+    // This probe is the wire-level conformance coverage for that refusal:
+    // NAMING.md §"Operator-opt-in CLI flag vocabulary" pins it as a
+    // cross-server contract (pair-mcp's half of the same gate story
+    // story-mcp's --allow-writes covers in end-to-end-flag-gates.cjs).
+    // The other gates do not reach it:
     //   - end-to-end-re-frame2-pair.cjs runs DEGRADED — the
     //     degraded-handler short-circuits every tools/call to
     //     :nrepl-port-not-found in `ensure-connection!` BEFORE the tool

--- a/tools/mcp-conformance/test/port-file-escape.test.cjs
+++ b/tools/mcp-conformance/test/port-file-escape.test.cjs
@@ -1,23 +1,21 @@
-// Call-site regression for the hermetic orchestrator's port-file poller
-// (rf2-khav7l).
+// Call-site regression for the hermetic orchestrator's port-file poller.
 //
 // Uses Node's built-in `node:test` (same posture as
 // `exec-safety.test.cjs` / `hermetic-setup-timeout.test.cjs` — no extra
 // dev-dependency).
 //
-// ## The bug this pins
+// ## The contract this pins
 //
 // `scripts/run-re-frame2-pair-live-hermetic-suite.cjs` wipes stale
-// nREPL port files through `safeUnlinkInside`, which CORRECTLY refuses
-// (throws) when a candidate (or its parent dir) is a symlink whose
-// realpath escapes FIXTURE_DIR. Pre-fix, the cleanup logged that refusal
-// and CONTINUED; the poller's `readPortFile` then raw-read the SAME
-// candidate with a bare `fs.readFileSync` and NO containment check. A
-// stale `nrepl.port` living behind a symlinked `.shadow-cljs` (or any
-// escaped candidate) could therefore satisfy the port-file wait and
-// steer the inner conformance tests at an UNRELATED runtime — false-red
-// or false-green live conformance, undermining the accident-gating the
-// runner exists to provide ("refuse delete but trust read" split).
+// nREPL port files through `safeUnlinkInside`, which refuses (throws)
+// when a candidate (or its parent dir) is a symlink whose realpath
+// escapes FIXTURE_DIR. The poller's `readPortFile` applies the SAME
+// containment check on the READ side, so a stale `nrepl.port` living
+// behind a symlinked `.shadow-cljs` (or any escaped candidate) cannot
+// satisfy the port-file wait and steer the inner conformance tests at an
+// UNRELATED runtime. Both the delete and the read paths reject the same
+// escape — closing the "refuse delete but trust read" split that would
+// otherwise undermine the accident-gating the runner exists to provide.
 //
 // ## What this test drives
 //
@@ -106,7 +104,7 @@ test('readPortFile: refuses an external port file behind a symlinked .shadow-clj
       () => readPortFile([candidate], fixture),
       (err) => {
         thrown = err;
-        // Must name the candidate and the rf2-khav7l rationale.
+        // Must name the candidate and the containment-escape rationale.
         assert.match(err.message, /khav7l/);
         return true;
       },

--- a/tools/mcp-conformance/test/runner-aux-client-hang-harness.cjs
+++ b/tools/mcp-conformance/test/runner-aux-client-hang-harness.cjs
@@ -1,18 +1,15 @@
-// Child harness for `runner-watchdog.test.cjs` (rf2-wqi4n4 finding 1).
+// Child harness for `runner-watchdog.test.cjs`.
 //
 // Simulates the SECONDARY-client orphan the redaction live test could hit:
 // `runWithWatchdog` boots its primary client fine, but the body then boots
 // an ADDITIONAL in-process server (the inner-projection / gate-ON arms in
 // `live-re-frame2-pair-redaction.cjs`) whose connect HANGS during the
-// `initialize` handshake. Pre-fix, the outer watchdog only owned the
-// PRIMARY client — a hang in (or after) a secondary boot was unreachable by
-// the timeout path, so the secondary child was orphaned despite the harness
-// reporting a watchdog timeout.
-//
-// The fix registers each secondary client with the outer watchdog (via
-// `registerAuxClient`, fired from a bare `connectServer`'s `onClient`
-// BEFORE connect awaits), so the watchdog drains the primary AND every
-// secondary on a timeout.
+// `initialize` handshake. Each secondary client registers with the outer
+// watchdog (via `registerAuxClient`, fired from a bare `connectServer`'s
+// `onClient` BEFORE connect awaits), so the watchdog drains the primary AND
+// every secondary on a timeout — a hang in (or after) a secondary boot is
+// reachable by the timeout path rather than orphaning the secondary child
+// despite the harness reporting a watchdog timeout.
 //
 // This harness is HERMETIC: it stubs the three SDK specifiers `_runner.cjs`
 // requires. The PRIMARY connect resolves cleanly (so the body runs and gets

--- a/tools/mcp-conformance/test/runner-cleanup.test.cjs
+++ b/tools/mcp-conformance/test/runner-cleanup.test.cjs
@@ -1,36 +1,25 @@
-// Regression test for the hermetic orchestrator's ASYNC teardown contract
-// (rf2-7ckmwx finding 1).
+// Regression test for the hermetic orchestrator's ASYNC teardown contract.
 //
 // Uses Node's built-in `node:test` (same posture as
 // `runner-watchdog.test.cjs` / `hermetic-setup-timeout.test.cjs` — no extra
 // dev-dependency). Runs in-process: `makeCleanup` is a pure factory with no
 // `process.exit`, so unlike the watchdog harness it does NOT need a child.
 //
-// ## The bug this pins
+// ## The contract this pins
 //
-// The pre-fix `cleanup` in
-// `scripts/run-re-frame2-pair-live-hermetic-suite.cjs` was SYNCHRONOUS:
-//
-//   const cleanup = () => {
-//     if (browser) { try { browser.close(); } catch {} }   // NOT awaited
-//     if (shadow && !shadowExited) {
-//       shadow.kill('SIGTERM');
-//       setTimeout(() => shadow.kill('SIGKILL'), 5000).unref();  // fire-and-forget
-//     }
-//   };
-//
-// Every caller — the `finally` path, the SIGINT/SIGTERM handlers, and the
-// hard watchdog — invoked it and then `process.exit`'d immediately. So:
-//   - Playwright's promise-returning `browser.close()` could still be in
-//     flight when the process exited (the close never settled).
-//   - The shadow SIGKILL fallback was on an UNREF'd timer, so once
-//     `process.exit` ran it was abandoned: a shadow-cljs JVM that ignored
-//     SIGTERM was never actually SIGKILL'd by us.
-//
-// The fix (`makeCleanup`) returns an idempotent promise that AWAITS the
+// `cleanup` in `scripts/run-re-frame2-pair-live-hermetic-suite.cjs` is
+// ASYNC. `makeCleanup` returns an idempotent promise that AWAITS the
 // browser close (bounded) and the shadow SIGTERM→exit, escalating to a
-// SIGKILL it then ALSO awaits. Callers `await` it (the `finally` path) or
-// race it against a hard cap (signal / watchdog paths).
+// SIGKILL it then ALSO awaits. Every caller — the `finally` path, the
+// SIGINT/SIGTERM handlers, and the hard watchdog — `await`s it (the
+// `finally` path) or races it against a hard cap (signal / watchdog paths)
+// BEFORE `process.exit`. That ordering is the contract this guards:
+//   - Playwright's promise-returning `browser.close()` is awaited, so it
+//     settles before the process exits rather than being abandoned in
+//     flight.
+//   - The shadow SIGKILL fallback is awaited too, so a shadow-cljs JVM
+//     that ignores SIGTERM is actually SIGKILL'd by us rather than left to
+//     an unref'd timer that a synchronous `process.exit` would abandon.
 //
 // ## What this test drives
 //
@@ -111,7 +100,7 @@ test('makeCleanup AWAITS a slow promise-returning browser.close() (rf2-7ckmwx fi
 
   assert.ok(closeStarted, 'browser.close() was never called by cleanup');
   // THE load-bearing assertion: cleanup did not resolve until the
-  // promise-returning close had SETTLED. Pre-fix (sync, no await) cleanup
+  // promise-returning close had SETTLED. A synchronous, un-awaited cleanup
   // would have returned before this flag flipped.
   assert.ok(
     closeSettled,
@@ -144,8 +133,8 @@ test('makeCleanup escalates SIGTERM→SIGKILL and AWAITS the eventual exit (rf2-
       'signals seen: ' + JSON.stringify(shadow.killSignals),
   );
   // THE load-bearing assertion: cleanup awaited the post-SIGKILL exit.
-  // Pre-fix the SIGKILL was on an unref'd fire-and-forget timer that the
-  // immediate process.exit abandoned.
+  // An unref'd fire-and-forget SIGKILL timer would instead be abandoned by
+  // the immediate process.exit.
   assert.ok(
     shadow.exited,
     'cleanup resolved before the shadow child exited after SIGKILL — the ' +

--- a/tools/mcp-conformance/test/runner-watchdog-hang-harness.cjs
+++ b/tools/mcp-conformance/test/runner-watchdog-hang-harness.cjs
@@ -1,13 +1,12 @@
-// Child harness for `runner-watchdog.test.cjs` (rf2-2js41 finding 2).
+// Child harness for `runner-watchdog.test.cjs`.
 //
-// Simulates the exact failure mode finding 2 describes: an MCP server
-// that SPAWNS and then HANGS during the `initialize` handshake — i.e.
+// Simulates the connect-hang failure mode: an MCP server that SPAWNS and
+// then HANGS during the `initialize` handshake — i.e.
 // `client.connect(transport)` neither resolves nor rejects. The watchdog
-// in `runWithWatchdog` is the only escape from that hang; the bug was
-// that `activeClient` (the watchdog's teardown handle) was assigned only
-// AFTER `connectServer` resolved, so a connect that hangs left the
-// watchdog with no client and the timeout path orphaned the spawned
-// child.
+// in `runWithWatchdog` is the only escape from that hang. `activeClient`
+// (the watchdog's teardown handle) is published BEFORE the connect await,
+// so a connect that hangs still leaves the watchdog a client to tear down
+// rather than orphaning the spawned child on the timeout path.
 //
 // This harness is HERMETIC: it does NOT require the real
 // `@modelcontextprotocol/sdk` package. A `Module._load` override
@@ -25,14 +24,15 @@
 // The harness installs the override, requires the real `_runner.cjs`
 // (so the production teardown path under test is exercised verbatim),
 // and calls `runWithWatchdog` with a short `watchdogMs`. Expected
-// behaviour with the fix: the watchdog fires, sees `activeClient` (set
-// via the new `onClient` callback BEFORE connect awaited), calls
+// behaviour: the watchdog fires, sees `activeClient` (set via the
+// `onClient` callback BEFORE connect awaited), calls
 // `closeQuietly(activeClient)` which invokes our stub `close()` (printing
 // the marker), then `process.exit(2)`. The parent asserts exit code 2
 // AND the marker line — i.e. teardown ran before exit.
 //
-// Without the fix `activeClient` would be undefined when the watchdog
-// fires, the marker would NOT print, and the child would be orphaned.
+// Were `activeClient` undefined when the watchdog fires, the marker would
+// NOT print and the child would be orphaned — which is the regression
+// this harness guards against.
 
 'use strict';
 

--- a/tools/mcp-conformance/test/runner-watchdog.test.cjs
+++ b/tools/mcp-conformance/test/runner-watchdog.test.cjs
@@ -1,33 +1,27 @@
 // Regression test for the `runWithWatchdog` connect-hang teardown
-// contract (rf2-2js41 finding 2).
+// contract.
 //
 // Uses Node's built-in `node:test` so the harness picks up no extra
 // dev-dependency (same posture as `exec-safety.test.cjs`). Runs quiet
 // on success.
 //
-// ## The bug this pins
+// ## The contract this pins
 //
 // `runWithWatchdog` (in `_runner.cjs`) installs a watchdog `setTimeout`
 // whose timeout path tears the spawned MCP child down via
 // `closeQuietly(activeClient)` so a hung server can't be orphaned past
 // the runner's exit. The watchdog reads `activeClient` — a closure
-// handle.
-//
-// Pre-fix, `activeClient` was assigned only AFTER `connectServer`
-// RESOLVED, and `connectServer` resolves only after
-// `await client.connect(transport)` completes. So a server that spawns
-// and then HANGS during the `initialize` handshake (connect never
-// resolving, never throwing) left `activeClient` undefined when the
-// watchdog fired: the timeout path took its `else` branch and
-// `process.exit(2)`'d immediately WITHOUT calling `client.close()` /
-// tearing the transport down — orphaning exactly the child the watchdog
+// handle that is published the moment the client is constructed (via
+// `connectServer`'s `onClient` callback, fired BEFORE the connect await).
+// That ordering is the load-bearing property: a server that spawns and
+// then HANGS during the `initialize` handshake (connect never resolving,
+// never throwing) must still leave the watchdog a teardown handle, so the
+// timeout path can call `client.close()` / tear the transport down rather
+// than `process.exit(2)`'ing and orphaning exactly the child the watchdog
 // is meant to reap.
 //
-// The fix gives the watchdog a teardown handle the moment the client is
-// constructed (via `connectServer`'s `onClient` callback, fired BEFORE
-// the connect await). This test drives the real `runWithWatchdog`
-// through a hermetic child harness whose stubbed `client.connect()`
-// never resolves, and asserts:
+// This test drives the real `runWithWatchdog` through a hermetic child
+// harness whose stubbed `client.connect()` never resolves, and asserts:
 //
 //   1. the child exits with the watchdog's code 2 (the timeout fired —
 //      connect genuinely hung, so this is the only exit path), AND
@@ -35,9 +29,9 @@
 //      prints a marker from `close()`; its presence proves the watchdog
 //      had a teardown handle and used it).
 //
-// Without the fix, (1) still holds (the watchdog still exits 2) but (2)
-// fails — the marker never prints because `activeClient` was undefined.
-// So the marker assertion is the load-bearing one.
+// If `activeClient` were undefined when the watchdog fired, (1) would
+// still hold (the watchdog still exits 2) but (2) would fail — the marker
+// never prints. So the marker assertion is the load-bearing one.
 
 'use strict';
 
@@ -115,9 +109,9 @@ test('watchdog tears the child down when connect hangs mid-initialize (rf2-2js41
 
 test('watchdog tears the SECONDARY (body-booted) client down when its connect hangs (rf2-wqi4n4 finding 1)', () => {
   // The redaction live test boots ADDITIONAL in-process servers inside the
-  // runWithWatchdog body (inner-projection + gate-ON arms). Pre-fix the
-  // outer watchdog owned only the PRIMARY client, so a hang in a SECONDARY
-  // boot orphaned that child despite the harness reporting a timeout. The
+  // runWithWatchdog body (inner-projection + gate-ON arms). The outer
+  // watchdog owns the PRIMARY client AND every secondary registered with
+  // it, so a hang in a SECONDARY boot is still reaped on timeout. The
   // harness boots a primary (connect resolves) then a secondary (connect
   // hangs) via the real connectServer + registerAuxClient, and asserts the
   // watchdog reaps BOTH.
@@ -149,7 +143,7 @@ test('watchdog tears the SECONDARY (body-booted) client down when its connect ha
     'the secondary client was never constructed — the harness is not ' +
       'exercising the secondary-hang path.\n--- output ---\n' + out,
   );
-  // 1. The PRIMARY was torn down (the pre-existing rf2-voux7 guarantee).
+  // 1. The PRIMARY was torn down (the baseline single-client guarantee).
   assert.ok(
     out.includes(PRIMARY_CLOSE_MARKER),
     'the watchdog did NOT close the PRIMARY client on the secondary hang.\n' +
@@ -169,12 +163,12 @@ test('watchdog tears the SECONDARY (body-booted) client down when its connect ha
 
 test('flag-gates module watchdog tears the hung JVM client down on a connect-hang (rf2-wqi4n4 finding 1)', () => {
   // end-to-end-flag-gates.cjs runs its OWN module-scope watchdog (not
-  // runWithWatchdog) over `activeFlagGateClient`. Pre-fix that handle was
-  // set only AFTER `await connectServer(...)` resolved — so a story-mcp JVM
-  // that hung mid-initialize left it null and the watchdog exited WITHOUT
-  // tearing the JVM down. The harness stubs a never-resolving connect,
-  // bypasses resolveTrustedExe via $STORY_MCP_CMD, and shrinks the watchdog
-  // via $FLAG_GATE_WATCHDOG_MS.
+  // runWithWatchdog) over `activeFlagGateClient`. That handle is published
+  // via `connectServer`'s `onClient` callback BEFORE the connect await, so
+  // a story-mcp JVM that hangs mid-initialize is still torn down when the
+  // watchdog fires. The harness stubs a never-resolving connect, bypasses
+  // resolveTrustedExe via $STORY_MCP_CMD, and shrinks the watchdog via
+  // $FLAG_GATE_WATCHDOG_MS.
   const child = spawnSync(process.execPath, [FLAG_GATES_HARNESS], {
     cwd: path.resolve(__dirname, '..'),
     encoding: 'utf8',

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
@@ -6,12 +6,11 @@
   All three tests share the same surface posture: grep source files at
   the repo root for canonical literal strings, validate authored
   fixtures against Malli schemas, and pin per-server presence /
-  absence invariants. The classpath-derived `repo-root` and the
-  `read-source` slurp helper were duplicated verbatim across the
-  three test namespaces before this helper landed (rf2-113ti); the
-  `known-servers` set was duplicated across two of them. Centralising
-  here removes ~60 LoC of ceremony and reduces the per-new-test-ns
-  surface to one `:require`.
+  absence invariants. The classpath-derived `repo-root`, the
+  `read-source` slurp helper, and the `known-servers` set are
+  centralised here so each test namespace pulls them in via one
+  `:require` rather than re-deriving the classpath-walk + slurp
+  ceremony.
 
   ## What this ns owns
 
@@ -25,15 +24,14 @@
     needs the test to surface it.
   - **`known-servers`** — the canonical `#{:re-frame2-pair-mcp :story-mcp}`
     pair. A typo in any test's `:servers` set surfaces against this.
-    (xray-mcp was dropped in rf2-bu21t — xray now ships as a
-    Clojars-only library, not an MCP server.)
+    (xray ships as a Clojars-only library, not an MCP server.)
 
   ## What this ns does NOT own
 
   Per-marker schemas + the `canonical-markers` catalogue live in
   `wire_vocab/schemas.clj`; the shared source-text pin inventories +
-  near-miss helpers live in `wire_vocab/source_pins.clj` (both split out
-  of `wire_vocab_test.clj` by rf2-7ckmwx). Marker-family-LOCAL schemas +
+  near-miss helpers live in `wire_vocab/source_pins.clj`.
+  Marker-family-LOCAL schemas +
   fixtures (`ResultEnvelope`, `CascadeBundle`, and the per-family fixture
   maps) stay co-located with their tests in the focused `*_test.clj`
   namespaces — they ARE the contract for that family, not boilerplate.

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -1,11 +1,10 @@
 (ns re-frame.mcp-conformance.slot-name-test
-  "Cross-MCP slot-name conformance (rf2-zvv65).
+  "Cross-MCP slot-name conformance.
 
   Pins the cross-server **argument-slot vocabulary** that an agent
   learns once and recognises identically across every MCP server in
-  the re-frame2 pair (re-frame2-pair-mcp, story-mcp). (xray-mcp was dropped
-  in rf2-bu21t — xray now ships as a Clojars-only library, not an
-  MCP server.)
+  the re-frame2 pair (re-frame2-pair-mcp, story-mcp). (xray ships as a
+  Clojars-only library, not an MCP server.)
 
   Sibling to:
 
@@ -31,20 +30,19 @@
   ... and the same vocabulary works on every server. Cross-server
   divergence on any of these slot names breaks the agent's mental
   model in the cross-MCP workflow (chained re-frame2-pair-mcp + story-mcp in
-  one session). The audit (rf2-m9yoi §TE2) called out that the
-  cross-server promise was **unenforced** before this gate landed —
-  multiple Principles.md sections claim identity but no test
-  actually pinned the wire-level agreement.
+  one session). The cross-server promise needs this gate: multiple
+  Principles.md sections claim identity, and this test pins the
+  wire-level agreement that backs the claim.
 
-  Composes on the indicator-field gate pattern from rf2-6m8tq
-  (#866) and the wire-vocab marker gate from rf2-j2z7o.
+  Composes on the indicator-field gate pattern and the wire-vocab
+  marker gate.
 
   ## What this test guards
 
   1. **Tool-arg slot-name parity** — `:include-sensitive` /
      `:max-tokens` literals appear as INPUT-arg keys in every server's
      descriptor source and arg-parsing source. A rename on any server
-     trips this gate. The wire-key drops the trailing `?` (per rf2-y710n)
+     trips this gate. The wire-key drops the trailing `?`
      because Anthropic's tool-input-schema regex
      `^[a-zA-Z0-9_.-]{1,64}$` rejects `?`; the predicate FUNCTION name
      `include-sensitive?` keeps its `?` — the idiom belongs on the
@@ -76,8 +74,7 @@
             [re-frame.mcp-conformance.fixtures :as fx]))
 
 ;; ---------------------------------------------------------------------------
-;; Repo-root + slurp helpers live in `re-frame.mcp-conformance.fixtures`
-;; (rf2-113ti).
+;; Repo-root + slurp helpers live in `re-frame.mcp-conformance.fixtures`.
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
@@ -117,8 +114,8 @@
     :sources  {:re-frame2-pair-mcp ["tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/sensitive.cljs"
                            "tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors.cljs"]
                ;; story-mcp's `:include-sensitive` parsing lives in
-               ;; `args.cljc` (rf2-73wuj / rf2-8yvyp — the cross-MCP
-               ;; `args/parse-boolean` reader) and the slot schema lives in
+               ;; `args.cljc` (the cross-MCP `args/parse-boolean` reader)
+               ;; and the slot schema lives in
                ;; `schemas.cljc` (`include-sensitive-schema` injector).
                ;; No `sensitive.cljc` (the path was a stale guess from
                ;; the re-frame2-pair-mcp shape that doesn't apply to story-mcp).
@@ -152,13 +149,11 @@
                when the rendered payload exceeds the cap (cross-server)."}])
 
 ;; ---------------------------------------------------------------------------
-;; Historical note — the size-elision opt-out divergence pin
-;; (`:include-large?` vs re-frame2-pair-mcp's `:elision`) lived here while
-;; xray-mcp shipped as an MCP server (rf2-8xzoe T-Insp cluster). The
-;; rf2-bu21t drop reverted xray-mcp; the divergence collapsed to a
-;; single-server re-frame2-pair-mcp `:elision` form. If a future MCP server
-;; adopts `:include-large?` (per the canonical reserved spelling in
-;; `mcp-base/vocab.cljc`), restore the divergence pin so the
+;; Note — the size-elision opt-out is a single-server re-frame2-pair-mcp
+;; `:elision` form. xray is not an MCP server, so there is no second
+;; emitter to pin the `:include-large?` divergence against. If a future
+;; MCP server adopts `:include-large?` (per the canonical reserved
+;; spelling in `mcp-base/vocab.cljc`), add a divergence pin so the
 ;; cross-server choice surfaces explicitly instead of drifting
 ;; silently.
 ;; ---------------------------------------------------------------------------
@@ -183,7 +178,7 @@
   framework keys, NOT wire keys, so they retain the predicate `?`)
   PLUS the unqualified MCP-surface form (`:include-sensitive` — no
   `?` because the wire-key MUST omit `?` per Anthropic's tool input
-  schema regex `^[a-zA-Z0-9_.-]{1,64}$`; rf2-y710n)."
+  schema regex `^[a-zA-Z0-9_.-]{1,64}$`)."
   #{":rf.size/include-large?"
     ":rf.size/include-sensitive?"
     ":include-sensitive"})
@@ -236,8 +231,7 @@
 ;; that isn't a keyword-extender.
 ;; ---------------------------------------------------------------------------
 
-;; `variant-regex` lives in `re-frame.mcp-conformance.fixtures`
-;; (rf2-qnmne) — promoted from a private defn here so
+;; `variant-regex` lives in `re-frame.mcp-conformance.fixtures` so
 ;; `indicator_field_test.clj`'s inline-emit anti-pin can share the same
 ;; keyword-extender-aware pattern.
 
@@ -248,12 +242,12 @@
   list is curated so a docstring or unrelated symbol can't trip a
   false positive.
 
-  The `?`-suffix variant (rf2-ihq4d): for a slot whose canonical form
-  has NO trailing `?` (e.g. the wire-key `:include-sensitive` per
-  rf2-y710n), an added `?` is exactly the bug pattern that bricked
+  The `?`-suffix variant: for a slot whose canonical form
+  has NO trailing `?` (e.g. the wire-key `:include-sensitive`),
+  an added `?` is exactly the bug pattern that bricks
   re-frame2-pair-mcp's tool surface — Anthropic's tool-input-schema regex
   `^[a-zA-Z0-9_.-]{1,64}$` rejects `?`. Adding `:include-sensitive?`
-  back into any wire-surface source today trips this near-miss check."
+  into any wire-surface source trips this near-miss check."
   [slot]
   (let [nm       (name slot)
         nm-no-q  (str/replace nm #"\?$" "")           ; strip predicate `?`
@@ -268,8 +262,8 @@
       (str/ends-with? nm "?")
       (conj (str ":" nm-no-q))
 
-      ;; added predicate `?` (rf2-ihq4d) — fires when the canonical
-      ;; form does NOT end in `?`. Pins the rf2-y710n decision: the
+      ;; added predicate `?` — fires when the canonical
+      ;; form does NOT end in `?`. Pins the decision: the
       ;; wire-key must NEVER carry `?` because Anthropic's regex
       ;; rejects it.
       (not (str/ends-with? nm "?"))
@@ -300,16 +294,16 @@
 ;; FULL KEYWORD TOKEN in at least one of each server's named source
 ;; files.
 ;;
-;; Why full-token, not `str/includes?` (rf2-ihq4d): `str/includes?`
+;; Why full-token, not `str/includes?`: `str/includes?`
 ;; treats canonical literals as substrings. `:include-sensitive` is a
 ;; prefix of `:include-sensitive?`, so an `str/includes?` check passes
 ;; even when a server's wire-key still carries the trailing `?` —
-;; exactly the rf2-y710n bug that the rf2-ihq4d worker surfaced as
-;; latent in re-frame2-pair-mcp at the time of #1494. The full-token regex
+;; exactly the bug pattern this gate guards against in
+;; re-frame2-pair-mcp. The full-token regex
 ;; (via `fx/variant-regex`, the same keyword-extender-aware pattern
 ;; the near-miss gate uses) pins the literal as a complete keyword:
 ;; matched only when not immediately followed by a keyword-extender
-;; character. Adding `:include-sensitive?` to any wire-surface today
+;; character. Adding `:include-sensitive?` to any wire-surface
 ;; trips this gate.
 ;; ---------------------------------------------------------------------------
 
@@ -357,7 +351,7 @@
          ;; story-mcp's `:include-sensitive` parsing / schema lives in
          ;; `args.cljc` + `schemas.cljc` (no `sensitive.cljc` —
          ;; that's re-frame2-pair-mcp's shape). The canonical story-mcp
-         ;; tool-source inventory lives in `fixtures.clj` (rf2-ee38b.20)
+         ;; tool-source inventory lives in `fixtures.clj`
          ;; so a new tool file added in one tripwire's list can't escape
          ;; the others.
          :story-mcp fx/story-mcp-tool-source-files}]
@@ -378,16 +372,16 @@
                    "it in the divergence pin section of this test.")))))))
 
 ;; ---------------------------------------------------------------------------
-;; Gate 4 — divergence pin (HISTORICAL).
+;; Gate 4 — divergence pin.
 ;;
-;; This slot was the `:include-large?` (xray-mcp) vs `:elision`
-;; (re-frame2-pair-mcp) divergence pin. With xray-mcp removed in rf2-bu21t,
-;; re-frame2-pair-mcp is the sole live emitter; the divergence collapses to a
-;; single-server `:elision` spelling. The canonical
-;; `:rf.size/include-large?` form remains reserved in
-;; `mcp-base/vocab.cljc` for any future MCP server adoption — restore
-;; the divergence pin (data + assertion) when a second server lands
-;; on either spelling so the cross-server choice surfaces explicitly.
+;; The size-elision opt-out has a single live emitter: re-frame2-pair-mcp's
+;; `:elision` spelling. With only re-frame2-pair-mcp + story-mcp as MCP
+;; servers, there is no second emitter for an `:include-large?` vs
+;; `:elision` divergence. The canonical `:rf.size/include-large?` form
+;; remains reserved in `mcp-base/vocab.cljc` for any future MCP server
+;; adoption — add a divergence pin (data + assertion) when a second
+;; server lands on either spelling so the cross-server choice surfaces
+;; explicitly.
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
@@ -408,13 +402,11 @@
                  "the literal or update this test."))))))
 
 ;; ---------------------------------------------------------------------------
-;; Gate 6 — xray-mcp impl-landed pin (HISTORICAL).
+;; Gate 6 — no xray-mcp wire surface.
 ;;
-;; This row was a `xray-mcp-tools-directory-present` structural-floor
-;; assertion under the T-Insp tool cluster (rf2-8xzoe.14..22). The
-;; rf2-bu21t drop removed `tools/xray-mcp/` entirely; the directory
-;; is now legitimately absent and the assertion is no longer
-;; applicable.
+;; There is no `tools/xray-mcp/` directory: xray ships as a Clojars-only
+;; library, not an MCP server, so there is no xray-mcp tool surface to
+;; pin a structural-floor assertion against.
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
@@ -1,12 +1,11 @@
 (ns re-frame.mcp-conformance.wire-vocab.schemas
   "Canonical cross-MCP wire-marker schemas + the `canonical-markers`
-  catalogue (rf2-7ckmwx — extracted from `wire_vocab_test.clj`).
+  catalogue.
 
   This is the **contract data**, not boilerplate: a single Malli schema
   per cross-server wire marker, plus the ordered `canonical-markers`
   index binding each marker key to its schema, description, and
-  per-server fixtures. It was carved out of the ~2.8k-line
-  `wire_vocab_test.clj` so the several focused test namespaces that share
+  per-server fixtures. The several focused test namespaces that share
   these schemas (`wire_vocab_test`, `cursor_stale_test`,
   `progress_notification_test`, …) each `:require` ONE support ns rather
   than re-deriving the shapes. The marker-family-LOCAL schemas
@@ -36,19 +35,15 @@
   :reached` sentinel. Required-not-optional — an emit missing any of
   these is a contract break, not a degenerate but tolerated marker.
 
-  Multi-emitter as of rf2-yxgcsz: BOTH re-frame2-pair-mcp and story-mcp
-  emit this marker via the shared `mcp-base.cap/apply-cap` →
-  `overflow-payload` builder, so the body is byte-identical across both
-  — there is exactly one shape, not a per-server variant. (Historically
-  documented as a re-frame2-pair-mcp-only shape while story-mcp's cap
-  enforcement was still spec-pending; story-mcp's wire-boundary cap
-  landed — `tools/story-mcp/.../tools/wire_pipeline.cljc` calls
-  `base-cap/apply-cap` — making the marker a genuine cross-server
-  emission. The name keeps the `ReFrame2Pair` prefix as the historical
+  Multi-emitter: BOTH re-frame2-pair-mcp and story-mcp emit this marker
+  via the shared `mcp-base.cap/apply-cap` → `overflow-payload` builder,
+  so the body is byte-identical across both — there is exactly one
+  shape, not a per-server variant. (story-mcp's wire-boundary cap is
+  `tools/story-mcp/.../tools/wire_pipeline.cljc`, which calls
+  `base-cap/apply-cap`. The name keeps the `ReFrame2Pair` prefix as the
   shape-author; the SHAPE is the cross-MCP contract.) Cap renames
   (`cap-tokens` vs `cap_tokens`), field renames (`hint` vs `next-step`),
-  or empty bodies all trip the schema. Per rf2-kn8cj (refactor-audit r2
-  of rf2-azk9c §F-VOCAB-2)."
+  or empty bodies all trip the schema."
   [:map
    {:closed false}
    [:limit       [:enum :reached]]
@@ -60,7 +55,7 @@
 (def Overflow
   "`{:rf.mcp/overflow ReFrame2PairOverflowBody}` — the wrapper shape.
 
-  CLOSED single-key map (rf2-voux7 finding 2): a wire marker is ALWAYS a
+  CLOSED single-key map: a wire marker is ALWAYS a
   single reserved wrapper key (see the header — agents pattern-match on
   exactly one top-level key). A payload carrying the marker plus an
   unrelated sibling top-level key is a mixed-envelope emission a uniform
@@ -91,20 +86,18 @@
 
   `:counts` (a per-top-key map) is permitted as an alternate
   per-key shape: a single MAP marker MUST carry `:count` or `:counts`,
-  not neither. (Originally introduced for xray-mcp's
-  `Principles.md` example; preserved as a permitted schema variant
-  after the rf2-bu21t drop, so a future MCP server reviving
-  per-key counts validates without a schema bump.)
+  not neither. It is a permitted schema variant so a future MCP server
+  shipping per-key counts validates without a schema bump.
 
-  ## Type-specific shape (rf2-voux7 finding 1)
+  ## Type-specific shape
 
   The schema dispatches on `:type` and enforces the documented per-type
-  required slots — it no longer marks every shape-slot `{:optional true}`
-  with no type predicate. The pre-rf2-voux7 schema accepted
-  `{:type :map :bytes 1}` (a map summary carrying neither `:keys` nor a
-  count) and a `{:type :scalar :bytes 1}` (a scalar with no `:value`):
-  unusable markers a future server could ship while this gate stayed
-  green. Each arm is CLOSED to the documented slot set, so a scalar
+  required slots. It does not mark every shape-slot `{:optional true}`
+  with no type predicate — were it to, `{:type :map :bytes 1}` (a map
+  summary carrying neither `:keys` nor a count) and `{:type :scalar
+  :bytes 1}` (a scalar with no `:value`) would both validate: unusable
+  markers a future server could ship while this gate stayed green. Each
+  arm is CLOSED to the documented slot set, so a scalar
   carrying `:keys`, or a vector carrying `:value`, is now rejected too
   (a cross-type slot leak is a contract break, not a tolerated extra).
 
@@ -151,7 +144,7 @@
 
 (def Summary
   "`{:rf.mcp/summary SummaryBody}` — the wrapper shape. CLOSED single-key
-  map (rf2-voux7 finding 2 — see `Overflow`)."
+  map (see `Overflow`)."
   [:map {:closed true} [:rf.mcp/summary SummaryBody]])
 
 (def root-cache-id-name
@@ -163,7 +156,7 @@
   `cache-0` entry is therefore un-expandable — the Node-side decoder
   (`tools/mcp-conformance/lib/dedup-envelope.cjs` `ROOT_CACHE_ID`) throws
   on exactly that shape. Pinned here so the JVM schema and the Node
-  decoder agree on the required root (rf2-x0pr0 finding 2)."
+  decoder agree on the required root."
   "de-dupe.cache/cache-0")
 
 (defn dedup-cache-root-key?
@@ -212,19 +205,17 @@
   cache with no root is un-expandable and the Node-side decoder
   (`lib/dedup-envelope.cjs`) throws on it.
 
-  Pre-rf2-x0pr0 the schema was `[:map [:rf.mcp/dedup-table :map]]`,
-  which accepted `{}` and root-less caches that the Node decoder
-  rejects — the JVM contract was looser than the client-visible one.
-  The `has-dedup-root?` predicate closes that gap so both encodings
-  agree on the accepted cache shape (rf2-x0pr0 finding 2; acceptance
-  criteria 3 + 4).
+  The `has-dedup-root?` predicate requires that root entry so the JVM
+  contract is not looser than the client-visible one: an empty `{}` and
+  any root-less cache (which the Node decoder rejects) are rejected
+  here too, so both encodings agree on the accepted cache shape.
 
-  CLOSED single-key map (rf2-voux7 finding 2 — see `Overflow`)."
+  CLOSED single-key map (see `Overflow`)."
   [:map {:closed true} [:rf.mcp/dedup-table [:and :map [:fn has-dedup-root?]]]])
 
 (def DiffFromBody
   "An epoch's `:db-after` slot, diff-encoded against `:db-before` and
-  projected into path-headed cluster sections (rf2-qeous).
+  projected into path-headed cluster sections.
 
   Per `re-frame.mcp-base.diff-encode/diff-encode-db-after` and
   re-frame2-pair-mcp Principles §\"Cross-MCP vocabulary\". Shape:
@@ -247,11 +238,10 @@
   cluster intent; decoding flattens sections' `:patches` and
   replays them via `apply-patches` to reconstruct `:db-after`.
 
-  Pre-rf2-qeous shape carried a flat `:patches` slot directly under
-  the marker. This is a clean break (pre-alpha, no back-compat);
-  the marker key `:rf.mcp/diff-from` is unchanged.
+  The body slot is `:sections` (the path-headed cluster projection
+  above); the marker key `:rf.mcp/diff-from` heads it.
 
-  CLOSED map (rf2-voux7 finding 2): unlike the other markers,
+  CLOSED map: unlike the other markers,
   `:rf.mcp/diff-from` is NOT a single-key wrapper — the marker key and
   its `:sections` body slot ride as TWO top-level keys (the documented
   shape above; `diff-encode-db-after` emits exactly these two). Closing
@@ -288,7 +278,7 @@
 
 (def ElisionMarker
   "`{:rf.size/large-elided ElisionMarkerBody}` — the wrapper shape. CLOSED
-  single-key map (rf2-voux7 finding 2 — see `Overflow`)."
+  single-key map (see `Overflow`)."
   [:map {:closed true} [:rf.size/large-elided ElisionMarkerBody]])
 
 (def CacheHitBody
@@ -299,9 +289,9 @@
   args)` pair — the marker itself is content-free (no fresh state
   observed since `:unchanged-since`).
 
-  `:via` distinguishes the two hit paths: `:result-hash` (rf2-3rt1f
-  match-after-eval) ran the tool and discovered the hash matched;
-  `:precheck` (rf2-36xod) short-circuited the eval entirely. Same
+  `:via` distinguishes the two hit paths: `:result-hash`
+  (match-after-eval) ran the tool and discovered the hash matched;
+  `:precheck` short-circuited the eval entirely. Same
   vocabulary, different cost saved.
 
   Single-server today (re-frame2-pair-mcp); the `:rf.mcp/*` namespace reserves
@@ -317,7 +307,7 @@
 
 (def CacheHit
   "`{:rf.mcp/cache-hit CacheHitBody}` — the wrapper shape. CLOSED single-key
-  map (rf2-voux7 finding 2 — see `Overflow`)."
+  map (see `Overflow`)."
   [:map {:closed true} [:rf.mcp/cache-hit CacheHitBody]])
 
 (def ReFrame2PairProgressNotificationParams
@@ -339,7 +329,7 @@
   emits them on every tick (zero values are valid — the slot is the
   load-bearing shape). `:overflow-reason` is the `pr-str` of the
   runtime sentinel keyword (`:max-buffered-events` /
-  `:max-buffered-bytes` per rf2-ho4ve) or null when no overflow tripped
+  `:max-buffered-bytes`) or null when no overflow tripped
   this tick.
 
   Pinned cross-server today as a re-frame2-pair-mcp-only shape; if a future
@@ -377,7 +367,7 @@
   slots (`:requested-id`, `:head-id`, `:tool`, `:hint`) are open
   per-server.
 
-  ## MULTI-server reason value (rf2-2js41 finding 1)
+  ## MULTI-server reason value
 
   cursor-stale is emitted by BOTH MCP servers, for two distinct
   staleness causes that share the same agent recovery vocabulary:
@@ -397,9 +387,8 @@
   envelope (`{:content … :isError true :structuredContent <this shape>}`)
   — so it is the `:structuredContent` slot of story-mcp's emission that
   this schema validates (see `story-cursor-stale-emitted-live-by-canonical-builder`
-  below). Previously documented as pair-only; promoted to a multi-server
-  reason-value contract once story-mcp shipped cursor pagination for the
-  Docs `list-*` tools."
+  below). It is a multi-server reason-value contract: story-mcp emits it
+  for cursor pagination on the Docs `list-*` tools."
   [:map
    {:closed false}
    [:ok?    [:enum false]]
@@ -407,7 +396,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Envelope indicator-field slots (`:dropped-sensitive` / `:elided-large`).
-;; Per Conventions §Cross-MCP indicator-field vocabulary (rf2-2499j) and
+;; Per Conventions §Cross-MCP indicator-field vocabulary and
 ;; Spec 009 §Size elision in traces — Indicator field on tool responses
 ;; (MUST-level). Unqualified keys riding the tool's own envelope; integer
 ;; counters; omit when zero. These are NOT cross-server wire MARKERS

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/source_pins.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/source_pins.clj
@@ -1,6 +1,5 @@
 (ns re-frame.mcp-conformance.wire-vocab.source-pins
-  "Shared source-text pin inventories + near-miss helpers (rf2-7ckmwx —
-  extracted from `wire_vocab_test.clj`).
+  "Shared source-text pin inventories + near-miss helpers.
 
   The wire-vocab conformance corpus pins each canonical marker literal
   against the server source/spec files where it MUST (emit-sources) or
@@ -12,8 +11,7 @@
   `redacted_sentinel_test`) — they live here so a new marker family adds
   ONE `:require` rather than re-deriving the inventories.
 
-  ## The two-tier pin (rf2-vj8y3, refactor-audit r2 of rf2-azk9c
-  ## §F-VOCAB-1 + F-VOCAB-3)
+  ## The two-tier pin
 
   - **emit-sources** — source files where the literal MUST appear as
     actual data (not in a comment or docstring). Stripped via
@@ -25,13 +23,13 @@
     against raw text suffices; documentation reorganisation may move
     the mention around without tripping the gate.
 
-  The pre-rf2-vj8y3 pin grepped `tools.cljs` + `Principles.md` +
-  `003-Tool-Catalogue.md` with `some`, which passed because the spec
-  docs prose-referenced every marker — even though four of five
-  literals did not appear in any re-frame2-pair-mcp source code AT ALL (they
-  were imported via `re-frame.mcp-base.vocab/<key>`). A rename inside
-  `mcp-base/vocab.cljc` (the canonical home of every literal) didn't
-  trip the gate. The emit-side pin closes that hole."
+  The emit-side pin is the load-bearing one: a `some`-over-doc-sources
+  check would pass merely because the spec docs prose-reference every
+  marker, even though four of five literals never appear in
+  re-frame2-pair-mcp source code at all (they are imported via
+  `re-frame.mcp-base.vocab/<key>`), so a rename inside
+  `mcp-base/vocab.cljc` (the canonical home of every literal) would not
+  trip a doc-only gate. The emit-side pin closes that hole."
   (:require [clojure.string :as str]))
 
 (def emit-source-files
@@ -49,8 +47,8 @@
   is the right invariant; emit-sites that import from vocab.cljc
   cannot drift independently of the canonical declaration.
 
-  As of rf2-90eft story-mcp also consumes from `mcp-base/vocab.cljc`
-  (the `dedup-table-key` symbol — `tools/story-mcp/src/re_frame/
+  story-mcp also consumes from `mcp-base/vocab.cljc` (the
+  `dedup-table-key` symbol — `tools/story-mcp/src/re_frame/
   story_mcp/tools/dedup.cljc` `:require`s it). Same single-source-of-
   truth posture as pair-mcp; the emit-source path is the same file."
   {:re-frame2-pair-mcp ["tools/mcp-base/src/re_frame/mcp_base/vocab.cljc"]

--- a/tools/re-frame2-pair-mcp/scripts/descriptor-manifest-gen.cjs
+++ b/tools/re-frame2-pair-mcp/scripts/descriptor-manifest-gen.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * re-frame2-pair-mcp tool-descriptor manifest generator + drift-check
- * (rf2-sofwv) — Node wrapper.
+ * — Node wrapper.
  *
  * Compiles the `:descriptor-gen` shadow-cljs build (the CLJS generator
  * `re-frame2-pair-mcp.descriptor-manifest-gen`) and runs it, forwarding

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/cache.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/cache.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.cache
   "Per-session response cache keyed on a hash of the serialised wire
-  payload (rf2-3rt1f).
+  payload.
 
   ## What this is
 
@@ -30,31 +30,34 @@
 
   ## Why hash the result text, not app-db directly
 
-  The bead (rf2-3rt1f) proposes `(hash app-db)`. The framing here is
-  one step downstream: by the time the result is built, it has already
-  been path-sliced, summarised, diff-encoded, deduped, scrubbed, etc.
-  Two calls with the same args against an unchanged app-db produce the
-  same serialised text — so hashing the text catches the same hit and
-  is robust against every transform in the wire pipeline. It also lets
-  one cache cover every tool uniformly (snapshot, get-path,
-  trace-window, etc.) instead of needing per-tool hash strategies.
+  Hashing happens one step downstream of app-db: by the time the
+  result is built, it has already been path-sliced, summarised,
+  diff-encoded, deduped, scrubbed, etc. Two calls with the same args
+  against an unchanged app-db produce the same serialised text — so
+  hashing the text catches the same hit and is robust against every
+  transform in the wire pipeline. It also lets one cache cover every
+  tool uniformly (snapshot, get-path, trace-window, etc.) instead of
+  needing per-tool hash strategies.
 
-  The original (rf2-3rt1f) shape paid the full nREPL round-trip and
-  local transform pipeline; the cache only saved the *wire bytes*.
-  rf2-36xod added a **precheck** path on top: an entry can carry a
-  cheap `:precheck-hash` fetched via one bencode round-trip. rf2-9pe31
-  collapsed the precheck eval to `(re-frame2-pair.runtime/app-db-hash
-  frame)` — an O(1) accessor over a per-frame integer cache the
-  runtime keeps current via its epoch listener (every settled
-  mutation updates the cached hash). Before running the tool, the MCP
-  server fetches the current precheck-hash; if it matches the stored
-  `:precheck-hash` for `(tool, args)`, the server emits the
-  `:rf.mcp/cache-hit` marker WITHOUT running the tool. Saves both
-  wire bytes AND the heavyweight tool eval + transform pipeline.
+  Two paths can produce a hit:
+
+  - **Precheck** — an entry carries a cheap `:precheck-hash` fetched
+    via one bencode round-trip. The precheck eval is
+    `(re-frame2-pair.runtime/app-db-hash frame)` — an O(1) accessor
+    over a per-frame integer cache the runtime keeps current via its
+    epoch listener (every settled mutation updates the cached hash).
+    Before running the tool, the MCP server fetches the current
+    precheck-hash; if it matches the stored `:precheck-hash` for
+    `(tool, args)`, the server emits the `:rf.mcp/cache-hit` marker
+    WITHOUT running the tool. Saves both wire bytes AND the
+    heavyweight tool eval + transform pipeline.
+  - **Result-hash** — the match-after-eval backstop: run the tool,
+    hash the result text, and emit the marker only when it matches the
+    stored hash. Saves the wire bytes.
 
   See `precheck` (decide before running the tool) vs `apply-cache`
-  (decide after running the tool — the original behaviour, used as
-  the backstop for tools without a precheck wiring).
+  (decide after running the tool — the backstop for tools without a
+  precheck wiring).
 
   ## LRU policy
 
@@ -74,7 +77,7 @@
     arg) to opt in. Default-off keeps the contract simple for
     callers who haven't yet learned the `:rf.mcp/cache-hit` shape.
     The arg is parsed by the shared
-    `re-frame2-pair-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh).
+    `re-frame2-pair-mcp.tools.args/parse-bool-arg` table.
   - **Per-tool opt-out**: streaming / progress-bearing tools
     (`subscribe`, `dispatch` with `:trace`) bypass the cache. Their
     return value is the result of an action, not a read.
@@ -86,18 +89,18 @@
    {:hash             <integer>
     :unchanged-since  <ms-since-epoch>
     :tool             \"<tool-name>\"
-    :via              :precheck | :result-hash   ;; rf2-36xod
+    :via              :precheck | :result-hash
     :hint             \"<agent-host instruction string>\"}}
   ```
 
-  `:via :precheck` signals the hit short-circuited the full tool eval
-  (rf2-36xod path); `:via :result-hash` is the original rf2-3rt1f
-  match-after-eval path. Same wire vocabulary, different cost saved.
+  `:via :precheck` signals the hit short-circuited the full tool eval;
+  `:via :result-hash` is the match-after-eval path. Same wire
+  vocabulary, different cost saved.
 
   The `:rf.mcp/*` namespace matches the wire-vocabulary convention
-  used by `:rf.mcp/overflow` (rf2-rvyzy), `:rf.mcp/dedup-table`
-  (rf2-obpa9), `:rf.mcp/summary` (rf2-tygdv), `:rf.size/large-elided`
-  (rf2-urjnc). Agents that learned the family see one more slot."
+  used by `:rf.mcp/overflow`, `:rf.mcp/dedup-table`, `:rf.mcp/summary`,
+  and `:rf.size/large-elided`. Agents that learned the family see one
+  more slot."
   (:require [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.tools.registry :as registry]
             [re-frame2-pair-mcp.tools.wire :as wire]))
@@ -154,14 +157,14 @@
 (defn cache-key
   "Build the cache key tuple for a tool invocation.
 
-  rf2-olvr5 finding 3 — the key includes the resolved BUILD as well as
+  The key includes the resolved BUILD as well as
   `(tool, args-fingerprint)`. The same `(tool, args)` against two
   different shadow-cljs builds reachable over the one nREPL connection is
-  two distinct reads; keying on the build alone (the pre-fix shape)
-  meant a precheck-hash collision across builds could serve one build's
+  two distinct reads; folding the build into the key keeps a
+  precheck-hash collision across builds from serving one build's
   payload for the other. `build` is the resolved build-id keyword (from
-  `wire/arg-build`); a legacy call without one passes nil and keys on
-  `(tool, args)` exactly as before.
+  `wire/arg-build`); a call without one passes nil and keys on
+  `(tool, args)` alone.
 
   Note: the OPERATING FRAME for an omitted-`:frame` call is not knowable
   here (it resolves runtime-side), so it cannot be folded into the key.
@@ -256,8 +259,8 @@
 
 (defn cache-hit-payload
   "Build the structured wire marker that replaces a cached response.
-  `via` defaults to `:result-hash` (the rf2-3rt1f match-after-eval
-  path); pass `:precheck` for the rf2-36xod skip-the-tool-eval path."
+  `via` defaults to `:result-hash` (the match-after-eval path); pass
+  `:precheck` for the skip-the-tool-eval path."
   ([entry] (cache-hit-payload entry :result-hash))
   ([{:keys [tool hash sent-at]} via]
    {:rf.mcp/cache-hit {:hash            hash
@@ -268,16 +271,15 @@
 
 (defn cache-hit-result
   "Wrap `cache-hit-payload` in the MCP `{:content [{:type \"text\" ...}]}`
-  envelope plus the `:structuredContent` slot (rf2-hj3pi). `via`
-  annotates which cache path produced the hit (`:result-hash` =
-  rf2-3rt1f post-eval match; `:precheck` = rf2-36xod pre-eval
-  short-circuit)."
+  envelope plus the `:structuredContent` slot. `via` annotates which
+  cache path produced the hit (`:result-hash` = post-eval match;
+  `:precheck` = pre-eval short-circuit)."
   ([entry tool] (cache-hit-result entry tool :result-hash))
   ([entry tool via]
-   ;; rf2-or8s29 — route through `wire/result` so the cache-hit marker's
-   ;; structuredContent keeps its namespace: a raw `clj->js` truncated
+   ;; Route through `wire/result` so the cache-hit marker's
+   ;; structuredContent keeps its namespace: a raw `clj->js` truncates
    ;; the `:rf.mcp/cache-hit` marker key to `"cache-hit"`, so SDK-friendly
-   ;; hosts reading structuredContent missed the marker entirely.
+   ;; hosts reading structuredContent miss the marker entirely.
    (wire/result (cache-hit-payload (assoc entry :tool tool) via) false)))
 
 ;; ---------------------------------------------------------------------------
@@ -287,15 +289,15 @@
 (def cacheable?
   "Predicate — should this tool ever consult the cache?
 
-  Forwarded to `registry/cacheable?` (rf2-47g8l) — the cacheable-bool
-  is stored on each entry in the single-source-of-truth registry, so
-  cache.cljs doesn't redeclare the allowlist. Keeping the name here
-  preserves the call-site vocabulary (`cache/cacheable?`) for existing
-  tests and for the `apply-cache` / `precheck` use sites below."
+  Forwarded to `registry/cacheable?` — the cacheable-bool is stored on
+  each entry in the single-source-of-truth registry, so cache.cljs
+  doesn't redeclare the allowlist. Keeping the name here preserves the
+  call-site vocabulary (`cache/cacheable?`) for the tests and for the
+  `apply-cache` / `precheck` use sites below."
   registry/cacheable?)
 
 (defn apply-cache
-  "Wire-boundary cache check (rf2-3rt1f match-after-eval path). Returns
+  "Wire-boundary cache check (match-after-eval path). Returns
   either:
 
     - `result-js` unchanged (cache disabled, tool not cacheable,
@@ -309,9 +311,9 @@
   failure from masking a future successful read.
 
   If `:precheck-hash` is supplied (the value fetched from the runtime
-  via the rf2-36xod precheck wiring), it is stored alongside the
-  result hash so the NEXT call can short-circuit via `precheck`
-  without re-running the tool."
+  via the precheck wiring), it is stored alongside the result hash so
+  the NEXT call can short-circuit via `precheck` without re-running the
+  tool."
   [result-js {:keys [tool args enabled? precheck-hash build]}]
   (cond
     (not enabled?)               result-js
@@ -331,11 +333,11 @@
             result-js)))))
 
 ;; ---------------------------------------------------------------------------
-;; Precheck — rf2-36xod. Decide cache-hit BEFORE running the tool.
+;; Precheck — decide cache-hit BEFORE running the tool.
 ;; ---------------------------------------------------------------------------
 
 (defn precheck
-  "Pre-eval cache check (rf2-36xod). Returns either:
+  "Pre-eval cache check. Returns either:
 
     - `nil` — no decision; the caller proceeds with the full tool eval
       and feeds the result back through `apply-cache`.
@@ -349,12 +351,11 @@
   `current-precheck-hash` argument matches it.
 
   `current-precheck-hash` is the value the MCP server fetched in a
-  single bencode round-trip (today: `(re-frame2-pair.runtime/app-db-hash
+  single bencode round-trip: `(re-frame2-pair.runtime/app-db-hash
   frame)` — an O(1) accessor over the runtime's per-frame cached
-  hash, kept current by its epoch listener — see rf2-9pe31). When
-  the caller has no precheck wiring for this tool (yet), it passes
-  `nil` and this fn returns `nil`, leaving the legacy post-eval path
-  in charge.
+  hash, kept current by its epoch listener. When the caller has no
+  precheck wiring for this tool (yet), it passes `nil` and this fn
+  returns `nil`, leaving the post-eval path in charge.
 
   This fn does NOT mutate the cache on a miss — the subsequent
   `apply-cache` call records the new result+precheck-hash together

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/config.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/config.cljs
@@ -1,9 +1,8 @@
 (ns re-frame2-pair-mcp.config
-  "Runtime configuration for the re-frame2-pair-mcp server (rf2-cibp8).
+  "Runtime configuration for the re-frame2-pair-mcp server.
 
-  Phase 1 owns one concern: the 'Open in editor' preference that
-  controls the URI scheme attached to every `:source-coord` map crossing
-  the wire (rf2-cibp8).
+  Owns one concern: the 'Open in editor' preference that controls the
+  URI scheme attached to every `:source-coord` map crossing the wire.
 
   ## Why a separate config ns
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/descriptor_manifest_gen.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/descriptor_manifest_gen.cljs
@@ -1,10 +1,9 @@
 (ns re-frame2-pair-mcp.descriptor-manifest-gen
-  "re-frame2-pair-mcp tool-descriptor manifest generator + drift-check
-  (rf2-sofwv).
+  "re-frame2-pair-mcp tool-descriptor manifest generator + drift-check.
 
-  Follow-on to the rf2-3nbl5.2 API-governance keystone, mirroring its
-  generate-then-drift-check shape on re-frame2-pair-mcp's MCP descriptor
-  surface — the CLJS/Node counterpart to story-mcp's JVM generator.
+  An API-governance keystone: a generate-then-drift-check over
+  re-frame2-pair-mcp's MCP descriptor surface — the CLJS/Node
+  counterpart to story-mcp's JVM generator.
 
   SOURCE OF TRUTH. `re-frame2-pair-mcp.tools.registry/tool-descriptors`
   — the ordered vector of raw `:descriptor` payloads projected from the
@@ -12,7 +11,7 @@
   and projects each into the stable catalogue row defined by
   `re-frame.mcp-base.descriptor-manifest`.
 
-  WIRE-SPLICED INPUTS (rf2-cwhod2). The raw registry descriptors do NOT
+  WIRE-SPLICED INPUTS. The raw registry descriptors do NOT
   carry the universal `max-tokens` / `cache` input knobs — those are
   spliced onto every descriptor's `:inputSchema :properties` at
   `tools/list` time by `tools/descriptors.cljs` (`with-budget-knob` /
@@ -28,9 +27,9 @@
   `tools/list` input surface, and the manifest stays deterministic +
   config-independent.
 
-  GATED INPUTS (rf2-qo3wvp). pair-mcp's `tools/list` surface gates NO
+  GATED INPUTS. pair-mcp's `tools/list` surface gates NO
   input key off behind an operator flag — its `eval-cljs` gate is
-  default-ON (rf2-a0z0h) and gates a whole TOOL, not an input property;
+  default-ON and gates a whole TOOL, not an input property;
   the `max-tokens` / `cache` splices above are deterministic, not gated.
   So this generator passes NO gated-key set to `dm/build-manifest`
   (defaulting to `#{}`), and every pair-mcp row carries
@@ -78,7 +77,7 @@
 
 (defn build
   "Build the manifest from the registry descriptors, with the universal
-  `max-tokens` / `cache` knobs spliced in FIRST (rf2-cwhod2) so the
+  `max-tokens` / `cache` knobs spliced in FIRST so the
   projected `:input-keys` reflect the actual `tools/list` input surface.
   Reuses the very composers `tools/descriptors/tool-descriptors-js`
   applies at `tools/list` time — `with-cache-knob` ∘ `with-budget-knob`,

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -1,16 +1,11 @@
 (ns re-frame2-pair-mcp.nrepl
   "Persistent nREPL client over a TCP socket.
 
-  This is what the bash-shim chain replaces. Each shim previously paid:
-    - bash startup       (~50ms on Windows, less elsewhere)
-    - babashka startup   (~50-100ms)
-    - fresh nREPL connect (~200-500ms cold)
-    - bencode round-trip
-    - process teardown
-
-  The MCP server pays the cold connect once at boot; every subsequent
-  call is just a bencode round-trip on the existing socket. Per-op
-  latency drops from ~700ms to ~5-50ms.
+  One socket lives for the whole session. The MCP server pays the cold
+  connect once at boot; every subsequent call is just a bencode
+  round-trip on the existing socket — per-op latency is ~5-50ms (a
+  per-call connect would instead pay process startup + a ~200-500ms
+  cold nREPL connect + teardown each time, ~700ms total).
 
   ## Reconnect protocol
 
@@ -25,8 +20,8 @@
   the next bundle load, so the runtime ns and its global marker
   reappear automatically. Every tool that needs the runtime probes
   the marker via `tools/ensure-runtime!`; missing marker surfaces a
-  structured `:reason :runtime-not-preloaded` error. No cljs-eval
-  inject fallback (rf2-7dvg).
+  structured `:reason :runtime-not-preloaded` error. There is no
+  cljs-eval inject fallback — the preload is the single load path.
 
   ## Concurrency
 
@@ -82,12 +77,12 @@
   platform-correct on Windows + POSIX without each call site building
   paths by string-concat.
 
-  rf2-ww877w — the result carries the WINNING candidate path, not just
-  the parsed port. The server caches that exact path so the per-tool-call
-  re-read (`ensure-connection!`) checks the file that actually won the
-  candidate scan, instead of server.cljs deriving a fixed
-  `.shadow-cljs/nrepl.port` that may not be the candidate that hit (which
-  then reads as 'file disappeared' and forces a needless reconnect)."
+  The result carries the WINNING candidate path, not just the parsed
+  port. The server caches that exact path so the per-tool-call re-read
+  (`ensure-connection!`) checks the file that actually won the candidate
+  scan, instead of deriving a fixed `.shadow-cljs/nrepl.port` that may
+  not be the candidate that hit (which would then read as 'file
+  disappeared' and force a needless reconnect)."
   [base]
   (when (and base (seq base))
     (some (fn [rel]
@@ -108,8 +103,8 @@
 
   ## Precedence (highest first)
 
-    1. `--port-file <path>`   explicit, cwd-independent escape hatch
-                              (rf2-3dbwh). Passed as `explicit-port-file`.
+    1. `--port-file <path>`   explicit, cwd-independent escape hatch.
+                              Passed as `explicit-port-file`.
     2. `$SHADOW_CLJS_NREPL_PORT` env var.
     3. `target/shadow-cljs/nrepl.port`  ┐
     4. `.shadow-cljs/nrepl.port`        ├ cwd-relative scan (steps 3-5).
@@ -133,17 +128,17 @@
   (`server.cljs`) consumes the richer shape to drive the elicitation
   branch on ambiguity.
 
-  ## Precedence (highest first; rf2-3grub adds step 3)
+  ## Precedence (highest first)
 
-    1. `--port-file <path>`   explicit, cwd-independent override
-                              (rf2-3dbwh). Wins outright WHEN READABLE;
+    1. `--port-file <path>`   explicit, cwd-independent override.
+                              Wins outright WHEN READABLE;
                               `:project-home` is the dirname of the port
                               file and `:port-file` is the EXACT path the
-                              caller named (rf2-ww877w — so the server
-                              caches it verbatim rather than deriving a
-                              `.shadow-cljs/nrepl.port` that may not exist).
+                              caller named — so the server caches it
+                              verbatim rather than deriving a
+                              `.shadow-cljs/nrepl.port` that may not exist.
                               An explicit-but-unreadable / non-numeric file
-                              falls through to steps 2-5 (rf2-olvr5) —
+                              falls through to steps 2-5 —
                               mirroring `read-port-from-fs` — so a stale
                               port file can't strand a live port reachable
                               via env / roots / HTTP / cwd.
@@ -151,7 +146,7 @@
                               (env-overridden discovery doesn't surface a
                               root); the per-tool-call port-file re-read
                               is skipped on this path.
-    3. **MCP `roots/list` walk** (rf2-3grub) — when `roots-discovery-fn`
+    3. **MCP `roots/list` walk** — when `roots-discovery-fn`
                               is supplied (post-MCP-init, lazy on first
                               tool call), ask the client for its
                               workspace roots, walk each one for
@@ -161,16 +156,16 @@
                               `:ambiguous` (caller drives elicitation).
                               `:workspace-discovery-unsupported` →
                               proceed to step 4.
-    4. **Shadow HTTP probe** (rf2-umoz2) — `shadow-probe-fn` returns the
+    4. **Shadow HTTP probe** — `shadow-probe-fn` returns the
                               consumer project's absolute `:project-home`;
                               we then read `port-file-candidates` resolved
                               against that root. The result surfaces the
                               WINNING candidate path as `:port-file`
-                              (rf2-ww877w) so the server caches the exact
+                              so the server caches the exact
                               file that hit, not a derived one. Cwd-robust
-                              legacy fallback for clients without
+                              fallback for clients without
                               `roots/list`.
-    5. CWD-relative scan of `port-file-candidates` — legacy fallback for
+    5. CWD-relative scan of `port-file-candidates` — final fallback for
                               environments without the shadow HTTP API. No
                               `:port-file` is surfaced (no project-home
                               anchor for a stable absolute path).
@@ -203,21 +198,20 @@
     ;; reads a port. An explicit-but-unreadable / non-numeric port file
     ;; (a stale leftover, a typo'd path) MUST fall through to env →
     ;; roots → HTTP → cwd — exactly the precedence `read-port-from-fs`
-    ;; (the sync slice) already implements via its leading `or`. The
-    ;; pre-fix shape hard-resolved `{:port nil}` here, so a stale
-    ;; `--port-file` short-circuited the whole cascade even when the env
-    ;; var / configured roots / shadow HTTP endpoint / cwd scan would
-    ;; have found a live port (rf2-olvr5 finding 4).
+    ;; (the sync slice) implements via its leading `or`. A stale
+    ;; `--port-file` must NOT short-circuit the whole cascade when the env
+    ;; var / configured roots / shadow HTTP endpoint / cwd scan could
+    ;; find a live port.
     (and explicit-port-file (seq explicit-port-file)
          (some? (read-port-file explicit-port-file)))
-    ;; rf2-ww877w — return the EXACT explicit port-file path the caller
-    ;; named, so the server caches it verbatim. The pre-fix shape omitted
-    ;; `:port-file`; server.cljs then DERIVED `<project-home>/.shadow-cljs/
-    ;; nrepl.port` (= dirname-of-explicit-file + .shadow-cljs/nrepl.port),
-    ;; which for an explicit `target/shadow-cljs/nrepl.port` resolves to a
-    ;; non-existent `target/shadow-cljs/.shadow-cljs/nrepl.port`. The next
-    ;; ensure-connection! read that derived path as missing and forced a
-    ;; needless reconnect + per-connection cache reset.
+    ;; Return the EXACT explicit port-file path the caller named, so the
+    ;; server caches it verbatim. Omitting `:port-file` would force
+    ;; server.cljs to DERIVE `<project-home>/.shadow-cljs/nrepl.port`
+    ;; (= dirname-of-explicit-file + .shadow-cljs/nrepl.port), which for an
+    ;; explicit `target/shadow-cljs/nrepl.port` resolves to a non-existent
+    ;; `target/shadow-cljs/.shadow-cljs/nrepl.port`; the next
+    ;; ensure-connection! would read that derived path as missing and force
+    ;; a needless reconnect + per-connection cache reset.
     (js/Promise.resolve {:port         (read-port-file explicit-port-file)
                          :project-home (node-path/dirname explicit-port-file)
                          :port-file    explicit-port-file})
@@ -235,11 +229,10 @@
         (.then
           (fn [r]
             (case (:status r)
-              ;; rf2-ww877w — the roots candidate carries its own
-              ;; `:port-file` (the `.shadow-cljs/nrepl.port` adjacent to
-              ;; the discovered `shadow-cljs.edn`); thread it through so the
-              ;; server caches the exact discovered file rather than
-              ;; re-deriving one.
+              ;; The roots candidate carries its own `:port-file` (the
+              ;; `.shadow-cljs/nrepl.port` adjacent to the discovered
+              ;; `shadow-cljs.edn`); thread it through so the server caches
+              ;; the exact discovered file rather than re-deriving one.
               :one  (let [c (:candidate r)]
                       {:port (:port c) :project-home (:project-home c)
                        :port-file (:port-file c)})
@@ -251,11 +244,11 @@
                     (or http-port shadow-discovery/default-http-port))
                   (.then (fn [project-home]
                            (if-let [{:keys [port port-file]} (read-port-at-base project-home)]
-                             ;; rf2-ww877w — thread the WINNING candidate
-                             ;; file through so the server caches the exact
-                             ;; path that hit (target/shadow-cljs/nrepl.port
-                             ;; vs .shadow-cljs/nrepl.port vs .nrepl-port),
-                             ;; not a derived one.
+                             ;; Thread the WINNING candidate file through so
+                             ;; the server caches the exact path that hit
+                             ;; (target/shadow-cljs/nrepl.port vs
+                             ;; .shadow-cljs/nrepl.port vs .nrepl-port), not
+                             ;; a derived one.
                              {:port port :project-home project-home :port-file port-file}
                              ;; Step 5 — cwd-relative scan, last resort. No
                              ;; project-home to anchor a stable port-file, so
@@ -272,9 +265,8 @@
   callers without an initialized MCP client omit it; post-init callers
   thread it in so step 3 (roots-list) is reachable.
 
-  Legacy 0-/2-arity wrappers preserve the prior boot path (rf2-umoz2 +
-  rf2-3dbwh). Net-new callers should use the 3-arity that takes the
-  roots fn."
+  The 0-/2-arity wrappers cover boot-time callers without an MCP client;
+  the 3-arity takes the roots fn for post-init discovery."
   ([] (discover-port nil nil nil))
   ([explicit-port-file http-port]
    (discover-port explicit-port-file http-port nil))
@@ -324,8 +316,8 @@
             ;; remain in this chunk — the alternative (recur on the
             ;; un-advanced `b`) is an infinite loop. This is a defensive
             ;; branch, not an observed path (`position` is reliable for
-            ;; the real frame shapes; see comment above). rf2-ee38b.18:
-            ;; if a multi-frame chunk ever DID hit this, the trailing
+            ;; the real frame shapes; see comment above). If a
+            ;; multi-frame chunk ever DID hit this, the trailing
             ;; complete frames would be silently lost and their pending
             ;; nREPL ids would hang until timeout — so we log to stderr
             ;; (never stdout — reserved for MCP) when the dropped trailer
@@ -358,24 +350,24 @@
   set when the socket terminates so subsequent calls re-open.
 
   `:probed-builds` is the set of build-ids for which the re-frame2-pair runtime
-  preload has been confirmed live on this socket generation (rf2-sjpx0).
+  preload has been confirmed live on this socket generation.
   Cleared by `close!` (operator-initiated teardown) and reborn empty
   whenever `ensure-connection!` builds a fresh conn for a new port — but
-  NOT on a same-port socket reopen (rf2-c3dsr; see `connect!`). The
+  NOT on a same-port socket reopen (see `connect!`). The
   `__re_frame2_pair_runtime` marker lives in the browser CLJS heap, which
   a JVM-side socket hiccup doesn't destroy, so the cache stays valid
   across a reopen; a page reload that DID destroy the marker leaves the
   JVM nREPL socket up, so a negative probe re-runs downstream anyway.
 
-  `:resolved-build-id` is the build-id `discover-app` last resolved
-  (rf2-l9ixp). Subsequent tool calls without an explicit `:build` arg
+  `:resolved-build-id` is the build-id `discover-app` last resolved.
+  Subsequent tool calls without an explicit `:build` arg
   default to it instead of the `SHADOW_CLJS_BUILD_ID` env-var fallback —
   removing the pair-debug friction of re-passing the build on every call.
   Same invalidation lifecycle as `:probed-builds`: cleared by `close!`
   and by a fresh `ensure-connection!` conn, PRESERVED across a transient
-  same-port reopen (rf2-c3dsr).
+  same-port reopen.
 
-  `:build-alias` is the forgiving-resolution cache (rf2-qda59):
+  `:build-alias` is the forgiving-resolution cache:
   `{requested-keyword canonical-keyword}`. A `:build` arg that names a
   running build by a unique SUFFIX (`:machine-epochs` ⇒
   `:examples/machine-epochs`) resolves to the canonical running id the
@@ -385,7 +377,7 @@
   cleared by `close!` and a fresh conn, preserved across a same-port
   reopen — a genuine build restart (which changes the running set) lands
   on a new port (fresh conn) or an operator `close!`, so a stale alias
-  never survives a real build change (rf2-c3dsr)."
+  never survives a real build change."
   [port host]
   (atom {:port              port
          :host              (or host "127.0.0.1")
@@ -413,7 +405,7 @@
   Public (not `defn-`) so `nrepl_test.cljs` can drive the data-folding
   + pending-id dispatch with a fake socket — feeding synthetic chunks
   and asserting pending handlers fire — without opening a real TCP
-  socket (rf2-wnrpi). The fake socket need only implement an `on`
+  socket. The fake socket need only implement an `on`
   method that records the callback per event name; see the test's
   `fake-socket` helper. This mirrors the `decode-all-frames`
   public-for-test precedent above."
@@ -452,7 +444,7 @@
   Idempotent — if a socket is already open and healthy, resolves
   immediately.
 
-  ## Why the reopen path does NOT touch the build-id caches (rf2-c3dsr)
+  ## Why the reopen path does NOT touch the build-id caches
 
   `connect!` is a pure *transport* concern: open the socket, reset the
   framing buffer, wire the handlers. It must NOT clear the session
@@ -462,8 +454,8 @@
   mere transient socket hiccup WITHOUT changing the target build. The
   next op's `connect!` would then reopen the SAME port and — if it also
   wiped the caches — silently drop a valid same-session sticky build,
-  so a follow-up no-`:build` call falls back to `:app` (the rf2-c3dsr
-  live symptom: `orient {}` mis-routing after a successful discover).
+  so a follow-up no-`:build` call would fall back to `:app` (e.g.
+  `orient {}` mis-routing after a successful discover).
 
   The caches' invalidation lives with the layer that actually knows the
   build *identity* changed:
@@ -471,8 +463,8 @@
     - `close!` (operator-initiated teardown) clears all three.
     - `server.cljs/ensure-connection!` builds a FRESH conn (empty caches)
       when shadow's nREPL port vanishes or changes — the common shape of
-      the rf2-l9ixp \"operator restarted shadow against a different
-      build\" case (a restart almost always grabs a new ephemeral port).
+      the \"operator restarted shadow against a different build\" case (a
+      restart almost always grabs a new ephemeral port).
 
   A same-port reopen of the SAME conn within one session is, by
   construction, a reconnect to the SAME build — so preserving the caches
@@ -494,8 +486,8 @@
                 ;; Transport-only: swap in the live socket, clear the
                 ;; closed flag, and reset the framing buffer. The build-id
                 ;; caches are deliberately PRESERVED across a same-port
-                ;; reopen (rf2-c3dsr) — see the fn docstring for why and
-                ;; for where the genuine-different-build reset lives.
+                ;; reopen — see the fn docstring for why and for where the
+                ;; genuine-different-build reset lives.
                 (swap! conn-atom assoc :socket sock :closed? false
                        :buf (js/Buffer.alloc 0))
                 (attach-handlers! conn-atom sock)
@@ -508,9 +500,9 @@
 (defn close!
   "Close the persistent socket. Idempotent. Drops the per-socket probe
   cache (`:probed-builds`) so a fresh connect re-probes the preload.
-  Also drops `:resolved-build-id` (rf2-l9ixp) — the cached default for
-  tool calls without an explicit `:build` arg — and `:build-alias`
-  (rf2-qda59), the forgiving suffix→canonical resolution cache — so a
+  Also drops `:resolved-build-id` — the cached default for
+  tool calls without an explicit `:build` arg — and `:build-alias`,
+  the forgiving suffix→canonical resolution cache — so a
   reconnect doesn't carry a stale build-id from the previous session."
   [conn-atom]
   (when-let [^js sock (:socket @conn-atom)]
@@ -539,10 +531,10 @@
 
   Auto-(re)connects if the socket has dropped. The runtime ships via the
   shadow-cljs `:devtools :preloads` mechanism, so no per-op reinjection is
-  needed (the per-session inject fallback was cut for rf2-7dvg; tools probe
-  the preload marker via `tools.probe/ensure-runtime!`).
+  needed; tools probe the preload marker via
+  `tools.probe/ensure-runtime!`.
 
-  ## Options (rf2-ambfv)
+  ## Options
 
   Optional second arg:
 
@@ -585,7 +577,7 @@
                             (resolve @state)))))]
                 (swap! conn-atom assoc-in [:pending id] on-frame)
                 (let [op (j/assoc! (clj->js op-map) "id" id)
-                      ;; rf2-av5kl: re-read `:socket` immediately before the
+                      ;; Re-read `:socket` immediately before the
                       ;; write. `connect!` guarantees a live socket at resolve
                       ;; time, but the close/error handlers (attach-handlers!)
                       ;; can fire in the window between resolve and this write —
@@ -655,7 +647,7 @@
   heavy forms (full-epoch-ring walks) can raise it past the 30s
   default.
 
-  ## Compile warnings/errors surface — never swallowed as nil (rf2-mvdwv)
+  ## Compile warnings/errors surface — never swallowed as nil
 
   shadow's `cljs-eval` returns its `{:results :err :out :ns}` map as the
   JVM eval value (the `outer` map below). A form with an UNRESOLVED
@@ -668,14 +660,13 @@
   genuine compile error (`:eval-compile-error`) takes the same shape:
   `:err` carries the report, `:results` carries `\"nil\"`.
 
-  The pre-rf2-mvdwv branch order peeked `:results` FIRST whenever it was
-  a vector, so the `\"nil\"` won and the populated `:err` was never read
-  — the form silently nil'd out as `{:ok? true :value nil}`, corrupting
-  debugging (the agent reads the nil as a real value). So a non-blank
-  `:err` on the shadow outer map now takes PRECEDENCE over the `:results`
-  peek: it rejects with a structured `:rf.error/eval-cljs-compile-error`
-  ex-info carrying the warning/error text, which `probe/err->result`
-  surfaces verbatim as `{:ok? false :reason ... :err ...}`."
+  A non-blank `:err` on the shadow outer map takes PRECEDENCE over the
+  `:results` peek (which would otherwise read the `\"nil\"` shadow pushes
+  and silently nil the form out as `{:ok? true :value nil}`, corrupting
+  debugging — the agent reads the nil as a real value). It rejects with a
+  structured `:rf.error/eval-cljs-compile-error` ex-info carrying the
+  warning/error text, which `probe/err->result` surfaces verbatim as
+  `{:ok? false :reason ... :err ...}`."
   ([conn-atom build-id form-str] (cljs-eval-value conn-atom build-id form-str nil))
   ([conn-atom build-id form-str opts]
   (-> (cljs-eval conn-atom build-id form-str opts)
@@ -693,8 +684,8 @@
             :else
             (let [outer (read-edn-safe (str (:value resp)))]
               (cond
-                ;; rf2-mvdwv — a populated :err on shadow's outer response
-                ;; is an analyzer warning (unresolved symbol) or a compile
+                ;; A populated :err on shadow's outer response is an
+                ;; analyzer warning (unresolved symbol) or a compile
                 ;; error. It MUST surface, even though shadow also pushed a
                 ;; \"nil\" into :results: peeking :results first would swallow
                 ;; the compile failure as a silent nil. Reject with a

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/roots_discovery.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/roots_discovery.cljs
@@ -1,21 +1,20 @@
 (ns re-frame2-pair-mcp.roots-discovery
-  "Workspace-roots–based discovery of the consumer project's nREPL port file
-  (rf2-3grub). The proper generic solution to the cwd-leak the rf2-umoz2
-  HTTP probe partially addressed.
+  "Workspace-roots–based discovery of the consumer project's nREPL port file.
+  The generic solution to the cwd-leak: zero hardcoding, no shadow-specific
+  port probing.
 
-  ## The problem one more time
+  ## The problem
 
   shadow-cljs writes its nREPL port to a relative path inside the consumer
   project (`target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`,
   `.nrepl-port`). The MCP server runs as a subprocess of the agent host
   (Claude Code / Cursor / Copilot); the host picks its own cwd, frequently
-  `$HOME` or the host's install dir. Three pre-existing escape hatches
-  worked but each carried hardcoding (operator config) or shadow-specific
-  port probing:
+  `$HOME` or the host's install dir. Other escape hatches exist, but each
+  carries hardcoding (operator config) or shadow-specific port probing:
 
-  - `--port-file <absolute-path>`    (rf2-3dbwh) — operator config.
+  - `--port-file <absolute-path>`    — operator config.
   - `$SHADOW_CLJS_NREPL_PORT`        — operator config.
-  - Shadow HTTP probe at `:9630`     (rf2-umoz2) — shadow-specific.
+  - Shadow HTTP probe at `:9630`     — shadow-specific.
 
   ## What this namespace adds
 
@@ -42,7 +41,7 @@
   ## Fallbacks for older clients
 
   If `roots/list` rejects (older client, no capability), the caller
-  (`nrepl.cljs`) falls through to the rf2-umoz2 HTTP probe + cwd-scan
+  (`nrepl.cljs`) falls through to the HTTP probe + cwd-scan
   cascade. The fallback path is observable: `discover-via-roots` resolves
   to `:reason :workspace-discovery-unsupported` (vs the
   `:no-running-shadow-in-workspace` branch where roots WAS supported but
@@ -62,7 +61,7 @@
   root + one or two levels below — enough for the typical layouts
   (root-level edn, `<root>/implementation/edn`, monorepo `<root>/<pkg>/edn`)
   without scanning arbitrary deep trees. A monorepo with deeper nesting
-  can still use the rf2-umoz2 HTTP probe fallback, or pass `--port-file`."
+  can still use the HTTP probe fallback, or pass `--port-file`."
   3)
 
 (def ^:const ^:private skip-dir-names
@@ -125,7 +124,7 @@
   returning a JS array of Dirent-shaped objects with `.name` and
   `.isDirectory()`.
 
-  Public-for-test (rf2-3grub) — the bedrock primitive every higher-level
+  Public-for-test — the bedrock primitive every higher-level
   fn here depends on; pinning it directly is what gives the discovery
   cascade unit coverage without a live shadow + Claude Code session."
   [readdir-fn start-dir]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -7,23 +7,23 @@
 
   1. boot: parse launch flags, build the MCP `Server`, connect the
      stdio transport. The persistent nREPL socket is NOT opened
-     here — discovery is lazy (rf2-3grub) so it can ask the MCP
-     client for workspace roots after initialization completes.
+     here — discovery is lazy so it can ask the MCP client for
+     workspace roots after initialization completes.
   2. `initialize`: standard MCP handshake. Server learns the client's
      capabilities (`roots`, `elicitation`).
   3. `tools/list`: returns the full tool catalogue — see
      `tools.registry/tools` for the authoritative list (the single
      source of truth).
-  4. `tools/call` (first time): runs the port-discovery cascade
-     (rf2-3grub) — the five-step precedence:
+  4. `tools/call` (first time): runs the port-discovery cascade —
+     the five-step precedence:
 
-        1. `--port-file <path>` explicit override (rf2-3dbwh)
+        1. `--port-file <path>` explicit override
         2. `$SHADOW_CLJS_NREPL_PORT` env var
         3. MCP `roots/list` → walk for `shadow-cljs.edn` → port-file
-        4. Shadow HTTP probe at `:9630` → `/api/project-info` (rf2-umoz2)
-        5. CWD-relative scan (legacy fallback)
+        4. Shadow HTTP probe at `:9630` → `/api/project-info`
+        5. CWD-relative scan (final fallback)
 
-     Step 3 is the rf2-3grub primary path — generic, zero-config, no
+     Step 3 is the primary path — generic, zero-config, no
      port-range guessing. On ambiguity (2+ shadow builds in the
      workspace), the server drives `elicitation/create` to ask the user
      which project. The result (port + project-home) is cached for the
@@ -90,7 +90,7 @@
        "(the cwd-independent escape hatch)."))
 
 ;; ---------------------------------------------------------------------------
-;; Session-cache for the lazy-discovered project (rf2-3grub).
+;; Session-cache for the lazy-discovered project.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private session-state
@@ -108,11 +108,10 @@
        :discovery-error <ex-info | nil>}   ;; LAST failure, diagnostic only
 
   Resetting `:discovered? false` triggers a full re-discovery on the
-  next tool call — used by the operator-initiated re-attach branch
-  (deferred to a follow-up bead).
+  next tool call — used by the operator-initiated re-attach branch.
 
   `:discovery-error` records the most recent failed-discovery rejection
-  for diagnostics; it does NOT gate (rf2-r6yly). While `:discovered?` is
+  for diagnostics; it does NOT gate. While `:discovered?` is
   false, every tool call re-runs the cascade, so a recoverable failure
   (shadow not up at the first call) self-heals on a later call once the
   operator starts the build."
@@ -125,14 +124,15 @@
 
 (defn session-state-snapshot
   "Deref the private `session-state` for tests — read-only window onto
-  the resolved-endpoint cache (rf2-r6yly retry regression)."
+  the resolved-endpoint cache (exercises the lazy-discovery retry
+  contract)."
   []
   @session-state)
 
 (defn reset-session-state-for-tests!
   "Reset `session-state` to the pristine pre-discovery shape. Exposed for
   tests so the lazy-discovery retry contract can be exercised from a
-  known slate (rf2-r6yly)."
+  known slate."
   []
   (reset! session-state {:project-home    nil
                          :port-file       nil
@@ -145,14 +145,14 @@
   "Stand in for `discover-and-cache!`'s success side effect — record a
   resolved conn (no port-file, so the per-call re-read fast-path returns
   it verbatim) and flip `:discovered?`. Exposed so a stub discovery thunk
-  can mimic a successful attach without the npm SDK (rf2-r6yly)."
+  can mimic a successful attach without the npm SDK."
   [conn]
   (swap! session-state assoc :conn conn :discovered? true :discovery-error nil))
 
 (defn set-discovered-for-tests!
   "Record a FULLY-discovered session (conn + port + the exact cached
   port-file) and flip `:discovered?`. Exposed so the port-file-stability
-  contract (rf2-ww877w) can be exercised: a second `ensure-connection!`
+  contract can be exercised: a second `ensure-connection!`
   call must stay on the cached conn when the cached port-file still reads
   the same port — without re-deriving a `.shadow-cljs/nrepl.port` that
   may not be the file discovery actually resolved."
@@ -244,7 +244,7 @@
   (nrepl/make-conn port "127.0.0.1"))
 
 (defn- discover-and-cache!
-  "First-tool-call discovery (rf2-3grub). Run the five-step cascade in
+  "First-tool-call discovery. Run the five-step cascade in
   `nrepl/discover-port` with the captured Server's `listRoots` as the
   injected roots-discovery fn. On `:ambiguous` (2+ shadow candidates),
   drive `elicitation/create` to ask the user. Cache the chosen port +
@@ -266,19 +266,18 @@
                     conn (new-conn-for-port port)]
                 (swap! session-state assoc
                        :project-home ph
-                       ;; rf2-ww877w — PREFER the exact port-file discovery
-                       ;; resolved (explicit `--port-file`, roots candidate,
-                       ;; or the winning HTTP-probe candidate). Every
-                       ;; discovery mode that yields a `:project-home` now
-                       ;; also yields the `:port-file` that actually read, so
-                       ;; the derived `.shadow-cljs/nrepl.port` below is a
-                       ;; pure defensive backstop — never reached for those
-                       ;; modes. The pre-fix shape DERIVED unconditionally
-                       ;; from `ph`, producing e.g.
+                       ;; PREFER the exact port-file discovery resolved
+                       ;; (explicit `--port-file`, roots candidate, or the
+                       ;; winning HTTP-probe candidate). Every discovery mode
+                       ;; that yields a `:project-home` also yields the
+                       ;; `:port-file` that actually read, so the derived
+                       ;; `.shadow-cljs/nrepl.port` below is a pure defensive
+                       ;; backstop — never reached for those modes. Deriving
+                       ;; unconditionally from `ph` would produce e.g.
                        ;; `target/shadow-cljs/.shadow-cljs/nrepl.port` for an
-                       ;; explicit `target/shadow-cljs/nrepl.port`; the next
-                       ;; `ensure-connection!` saw that path missing and
-                       ;; forced a needless reconnect + per-conn cache reset.
+                       ;; explicit `target/shadow-cljs/nrepl.port`, which the
+                       ;; next `ensure-connection!` would see as missing and
+                       ;; force a needless reconnect + per-conn cache reset.
                        :port-file    (or (:port-file result)
                                          (when ph
                                            (node-path/join ph ".shadow-cljs/nrepl.port")))
@@ -335,38 +334,36 @@
      restarted; close the stale socket, swap in a NEW conn for the new
      port (or force re-discovery).
 
-  Path 3 is where the genuine rf2-l9ixp \"operator restarted shadow
-  against a different build\" reset happens: a restart almost always
-  grabs a new ephemeral port, so the new conn from `new-conn-for-port`
-  starts with EMPTY build-id caches (`:probed-builds` /
-  `:resolved-build-id` / `:build-alias`). The transport-layer
-  `nrepl/connect!` deliberately does NOT clear those caches on a
-  same-port reopen (rf2-c3dsr) — that would wipe a valid sticky build on
-  a transient socket hiccup — so this layer (which actually observes the
-  port change) owns the invalidation, alongside operator `close!`.
+  Path 3 is where the genuine \"operator restarted shadow against a
+  different build\" reset happens: a restart almost always grabs a new
+  ephemeral port, so the new conn from `new-conn-for-port` starts with
+  EMPTY build-id caches (`:probed-builds` / `:resolved-build-id` /
+  `:build-alias`). The transport-layer `nrepl/connect!` deliberately
+  does NOT clear those caches on a same-port reopen — that would wipe a
+  valid sticky build on a transient socket hiccup — so this layer (which
+  actually observes the port change) owns the invalidation, alongside
+  operator `close!`.
 
-  ## Discovery failure is RETRIED, never sticky (rf2-r6yly)
+  ## Discovery failure is RETRIED, never sticky
 
   A failed discovery (`discover-and-cache!` rejected: no nREPL port yet,
   shadow not started, ambiguous-and-declined) leaves `:discovered? false`
   and records `:discovery-error` for diagnostics — but it does NOT wedge
-  the session. Each subsequent tool call RE-RUNS the cascade. The earlier
-  shape short-circuited on a cached `:discovery-error`, so once discovery
-  failed once (e.g. a tool call landed before `shadow-cljs watch` was up)
-  EVERY later call replayed the stale rejection forever — the operator
-  had to restart the whole MCP server even after starting shadow, because
-  nothing ever re-attempted. The cascade is bounded (sync env/flag steps;
-  the async roots/HTTP probes cap at `shadow-discovery/probe-timeout-ms`),
-  so re-running it per call on the failure path is cheap and is the only
+  the session. Each subsequent tool call RE-RUNS the cascade, so a
+  recoverable failure (e.g. a tool call landed before `shadow-cljs watch`
+  was up) self-heals once the operator starts the build — no MCP-server
+  restart needed. The cascade is bounded (sync env/flag steps; the async
+  roots/HTTP probes cap at `shadow-discovery/probe-timeout-ms`), so
+  re-running it per call on the failure path is cheap and is the only
   thing that lets a session self-heal when the operator fixes the
   underlying cause. `:discovery-error` is kept purely as a diagnostic
-  breadcrumb of the LAST failure; it no longer gates.
+  breadcrumb of the LAST failure; it does not gate.
 
   Returns a Promise resolving to the live conn atom, or rejecting with a
   fresh structured discovery error when the cascade still can't resolve.
 
   The 2-arity injects the discovery thunk so the retry contract can be
-  unit-tested without the npm SDK / a live shadow (rf2-r6yly); production
+  unit-tested without the npm SDK / a live shadow; production
   uses the 1-arity, which threads in `discover-and-cache!`."
   ([launch-flags] (ensure-connection! launch-flags discover-and-cache!))
   ([launch-flags discover-fn]
@@ -377,9 +374,9 @@
           (.then (fn [_] (:conn @session-state)))
           (.catch (fn [e]
                     ;; Record the last failure for diagnostics only — the
-                    ;; next tool call re-runs discovery (rf2-r6yly); a
-                    ;; recoverable failure (shadow not up yet) must not
-                    ;; permanently wedge the session.
+                    ;; next tool call re-runs discovery; a recoverable
+                    ;; failure (shadow not up yet) must not permanently
+                    ;; wedge the session.
                     (swap! session-state assoc :discovery-error e)
                     (js/Promise.reject e))))
 
@@ -420,9 +417,9 @@
         name   (j/get params :name)
         args   (or (j/get params :arguments) #js {})]
     (if-let [unknown (tools/refuse-unknown-tool name)]
-      ;; rf2-4mc6q1 — a name absent from the registry (a typo or a removed
-      ;; alias such as `registry-list`) is rejected HERE, before `ensure-
-      ;; connection!`. Otherwise a stock install with no nREPL port runs
+      ;; A name absent from the registry (a typo, or an alias the registry
+      ;; doesn't carry such as `registry-list`) is rejected HERE, before
+      ;; `ensure-connection!`. Otherwise a stock install with no nREPL port runs
       ;; discovery, REJECTS with `:nrepl-port-not-found`, and the request
       ;; never reaches `dispatch-tool*` — so the `:unknown-tool` recovery
       ;; affordances (`:hint` → tools/list, `:available-tools`,
@@ -432,8 +429,8 @@
       ;; depth (direct `tools/invoke` callers + the conformance corpus).
       (js/Promise.resolve unknown)
       (if-let [refusal (writes/refuse-pre-connection name)]
-        ;; rf2-wz66k7 — a gated write tool (restore-epoch / replace-app-db)
-        ;; with `--allow-writes` OFF is refused HERE, before `ensure-
+        ;; A gated write tool (restore-epoch / replace-app-db) with
+        ;; `--allow-writes` OFF is refused HERE, before `ensure-
         ;; connection!`. Otherwise a stock install with no nREPL port returns
         ;; a misleading `:nrepl-port-not-found` (or runs discovery /
         ;; elicitation) for a request that should be refused locally — the
@@ -443,7 +440,7 @@
         (handle-call* launch-flags name args extra)))))
 
 (defn handle-call-for-tests
-  "Test seam onto the private `handle-call` (rf2-wz66k7). Lets the
+  "Test seam onto the private `handle-call`. Lets the
   server-boundary test drive a `tools/call` request through the SAME
   pre-dispatch path the SDK invokes — proving a disabled write tool is
   refused with `:rf.error/writes-disabled` BEFORE `ensure-connection!`
@@ -457,18 +454,18 @@
 (defn- handle-call*
   "Normal tool-dispatch path: ensure the nREPL connection, then route to
   the tool dispatcher. Reached for every tool EXCEPT a gated write
-  refused at the pre-connection boundary (rf2-wz66k7)."
+  refused at the pre-connection boundary."
   [launch-flags name args extra]
   (-> (ensure-connection! launch-flags)
       (.then (fn [conn]
                (-> (tools/invoke conn name args extra)
                    (.catch (fn [err]
                              (log! "handler threw for" name "—" (.-message err))
-                             ;; rf2-or8s29 — route the server-level error
-                             ;; envelope through `wire/result` so the
-                             ;; structuredContent projection preserves
-                             ;; keyword namespaces (a raw `clj->js` here
-                             ;; truncated `:rf.error/*` reason values).
+                             ;; Route the server-level error envelope through
+                             ;; `wire/result` so the structuredContent
+                             ;; projection preserves keyword namespaces (a raw
+                             ;; `clj->js` here truncates `:rf.error/*` reason
+                             ;; values).
                              (wire/result {:ok?     false
                                            :reason  :handler-threw
                                            :message (.-message err)}
@@ -483,9 +480,9 @@
                 payload (if-let [cs (:candidates data)]
                           (assoc payload :candidates cs)
                           payload)]
-            ;; rf2-or8s29 — same namespace-preserving projection as the
-            ;; handler-threw path; a raw `clj->js` dropped the namespace
-            ;; on `:rf.error/*` reason values.
+            ;; Same namespace-preserving projection as the handler-threw
+            ;; path; a raw `clj->js` drops the namespace on `:rf.error/*`
+            ;; reason values.
             (wire/result payload true))))))
 
 ;; ---------------------------------------------------------------------------
@@ -497,7 +494,7 @@
   descriptors and `tools/call` routed to `call-handler` (a `(req,
   extra) → Promise<result>` fn).
 
-  Capabilities declared at construction (rf2-3grub):
+  Capabilities declared at construction:
 
   - `:tools`   — the tool catalogue (this is what we serve).
 
@@ -549,15 +546,15 @@
   Last occurrence wins (consistent with argv override semantics).
   Returns nil when the flag is absent or given without a value.
 
-  Used by both `--port-file` (rf2-3dbwh) and `--http-port` (rf2-umoz2);
-  one parser, one shape — so a future string-valued flag lands here
-  without growing a per-flag micro-parser.
+  Used by both `--port-file` and `--http-port`; one parser, one shape —
+  so a future string-valued flag lands here without growing a per-flag
+  micro-parser.
 
-  ## DRY-on-5 trigger (rf2-xnbvz)
+  ## DRY-on-5 trigger
 
-  Today two string-valued flags ride through this helper. If a fifth
-  lands, switch to a declared schema (vector of `{:flag :type :env}`
-  maps reduced over) — more elegant than five hand-rolled `parse-X-flag`
+  Two string-valued flags ride through this helper. If a fifth lands,
+  switch to a declared schema (vector of `{:flag :type :env}` maps
+  reduced over) — more elegant than five hand-rolled `parse-X-flag`
   helpers. Not needed at 2; the 3rd and 4th can ride through unchanged."
   [flag-name argv]
   (let [equals-prefix (str flag-name "=")]
@@ -589,7 +586,7 @@
   (parse-string-value-flag "--port-file" argv))
 
 (defn- parse-http-port-flag
-  "Pluck the value of the `--http-port` launch flag (rf2-umoz2) and
+  "Pluck the value of the `--http-port` launch flag and
   coerce to an int. Returns nil when absent / malformed.
 
   Shadow's web server is fixed by its own `:http :port` config; the
@@ -604,8 +601,7 @@
 (defn parse-launch-flags
   "Pluck the named launch flags out of the raw process argv. Flags today:
 
-    --no-eval                — opt OUT of the `eval-cljs` tool (rf2-a0z0h;
-                               inverts the prior rf2-cxx5s default). Default
+    --no-eval                — opt OUT of the `eval-cljs` tool. Default
                                is eval-cljs ENABLED — it is the REPL primitive
                                of a pair-debug session. The threat-model
                                rationale (eval expresses every write the
@@ -614,13 +610,12 @@
                                in `tools/eval_cljs.cljs`.
     --allow-sensitive-reads  — opt-in to raw state on snapshot / get-path /
                                subscribe AND raw-value `tap>` emissions from
-                               the preload's `app-db-reset!` (rf2-c2dtu).
-                               Default OFF. Canonical cross-MCP name
-                               (rf2-2x3ql) — matches story-mcp's identically
-                               named gate (rf2-g9fje / rf2-uaymx).
+                               the preload's `app-db-reset!`.
+                               Default OFF. Canonical cross-MCP name —
+                               matches story-mcp's identically named gate.
     --allow-writes           — opt-in to the state-mutating tools
                                `restore-epoch` (time-travel undo) and
-                               `replace-app-db` (state injection), rf2-ee38b.18.
+                               `replace-app-db` (state injection).
                                Default OFF. Without the flag both return
                                `{:ok? false :reason :rf.error/writes-disabled}`
                                without touching the nREPL socket. `dispatch`
@@ -630,12 +625,12 @@
                                against eval-driven writes (eval-cljs can
                                express the same writes).
     --port-file <path>       — explicit, cwd-independent nREPL port-file
-                               path (rf2-3dbwh). Highest precedence in the
+                               path. Highest precedence in the
                                port-discovery chain — see
                                `nrepl/discover-port`. Accepts both
                                `--port-file <path>` and `--port-file=<path>`.
     --http-port <n>          — override shadow-cljs's HTTP server port
-                               for the auto-discovery probe (rf2-umoz2).
+                               for the auto-discovery probe.
                                Defaults to 9630 (shadow's standard).
                                Only used when steps 1-2 of the cascade
                                miss; setting it has no effect when
@@ -644,8 +639,8 @@
 
   Returns `{:eval-allowed? bool :allow-raw-state? bool :allow-writes? bool
   :port-file str-or-nil :http-port int-or-nil}`.
-  `:eval-allowed?` is true by default (the published-build posture);
-  passing `--no-eval` flips it false. Unknown flags are ignored —
+  `:eval-allowed?` is true by default; passing `--no-eval` flips it
+  false. Unknown flags are ignored —
   node's shadow-cljs entry passes its own argv prelude (script path),
   and future flags can land here without breaking older invocations."
   [argv]
@@ -656,7 +651,7 @@
    :http-port        (parse-http-port-flag argv)})
 
 ;; ---------------------------------------------------------------------------
-;; Launch-config diagnostics (rf2-a0kxsb).
+;; Launch-config diagnostics.
 ;;
 ;; The parsers above are deliberately PERMISSIVE — they pluck the flags
 ;; they understand and silently ignore everything else (a typo, a stale
@@ -692,12 +687,13 @@
   #{"--port-file" "--http-port"})
 
 (def ^:private removed-launch-flags
-  "Legacy flag names that were renamed / removed (pre-alpha, no
-  back-compat shim). An operator carrying a stale `~/.claude.json`
-  gets an INTENTIONAL diagnostic naming the replacement rather than a
-  silent no-op that leaves the server in an unexpected posture.
-  `--allow-raw-state` → `--allow-sensitive-reads` (rf2-2x3ql);
-  `--allow-eval` → removed, eval now defaults ON (rf2-a0z0h)."
+  "Flag names this server does not accept, mapped to a diagnostic
+  naming the replacement (pre-alpha, no back-compat shim). An operator
+  carrying a stale `~/.claude.json` gets an INTENTIONAL diagnostic
+  naming the replacement rather than a silent no-op that leaves the
+  server in an unexpected posture. `--allow-raw-state` maps to
+  `--allow-sensitive-reads`; `--allow-eval` has no replacement — eval-cljs
+  defaults ON, so pass `--no-eval` to opt OUT."
   {"--allow-raw-state" "renamed to --allow-sensitive-reads (rf2-2x3ql)"
    "--allow-eval"      "removed — eval-cljs now defaults ENABLED; pass --no-eval to opt OUT (rf2-a0z0h)"})
 
@@ -723,7 +719,7 @@
   :rf.config/issue <kw> :rf.config/effect <string>}` — the rejected
   input, what's wrong, and the effective fallback the operator gets.
 
-  Detects, against the declared flag schema (rf2-a0kxsb):
+  Detects, against the declared flag schema:
 
     - `:removed-flag`        — a renamed / removed legacy flag (names the
                                replacement; pre-alpha, no silent no-op).
@@ -791,7 +787,7 @@
                     :rf.config/effect   "non-numeric --http-port — falling back to the default shadow HTTP port (9630)"}
 
                    ;; Resource-control flag in the SPACE form. The resource
-                   ;; parser only accepts `--name=N` (rf2-3ijbl), so a
+                   ;; parser only accepts `--name=N`, so a
                    ;; space-form `--max-concurrent-streams 20` is silently
                    ;; dropped — name it as a malformed usage.
                    (and (contains? resource/flag->key prefix)
@@ -855,21 +851,21 @@
   (raw-state/set-allow-raw-state! allow-raw-state?)
   (writes/set-allow-writes! allow-writes?)
   (log! "eval-cljs:" (if eval-allowed? "enabled (default; pass --no-eval to opt out)" "DISABLED (--no-eval)"))
-  ;; The "allowed" / "gated" wording matches the rf2-uaymx (b) story-mcp
-  ;; `--allow-sensitive-reads` shape (rf2-g9fje); rf2-2x3ql aligns
-  ;; pair-mcp on the same canonical CLI-flag name so operators reading
-  ;; multi-MCP logs see one vocabulary.
+  ;; The "allowed" / "gated" wording matches story-mcp's
+  ;; `--allow-sensitive-reads` shape — pair-mcp uses the same canonical
+  ;; CLI-flag name so operators reading multi-MCP logs see one
+  ;; vocabulary.
   (log! "Sensitive reads:" (if allow-raw-state? "allowed (--allow-sensitive-reads)" "gated (default; pass --allow-sensitive-reads to opt in)"))
-  ;; rf2-ee38b.18 — the state-mutating tool gate. Default OFF;
-  ;; restore-epoch / replace-app-db replace app-db wholesale and the
-  ;; gate keeps the named-write audit trail clean. Note: this gate
-  ;; does NOT defend against eval-driven writes (eval-cljs can
-  ;; express the same writes); see rf2-a0z0h for the rationale.
+  ;; The state-mutating tool gate. Default OFF; restore-epoch /
+  ;; replace-app-db replace app-db wholesale and the gate keeps the
+  ;; named-write audit trail clean. Note: this gate does NOT defend
+  ;; against eval-driven writes (eval-cljs can express the same
+  ;; writes); see `tools/eval_cljs.cljs` for the rationale.
   (log! "Writes:" (if allow-writes? "ENABLED (--allow-writes)" "disabled (default; pass --allow-writes to opt in)")))
 
 (defn- apply-resource-controls!
   "Read resource-control config from env + CLI flags and push it into
-  the resource-controls atoms (rf2-3ijbl). Logs the effective values
+  the resource-controls atoms. Logs the effective values
   so operators can confirm at startup which caps are in force."
   [argv]
   (let [env-cfg  (resource/read-resource-env)
@@ -884,10 +880,10 @@
 (defn main [& args]
   (let [argv         (vec args)
         launch-flags (parse-launch-flags argv)]
-    ;; rf2-a0kxsb — name any misconfigured launch input (typo'd flags,
-    ;; removed legacy names, malformed values, invalid env vars) BEFORE
-    ;; the gates are applied and the transport announces readiness, so a
-    ;; silent posture-mismatch surfaces in the boot log.
+    ;; Name any misconfigured launch input (typo'd flags, unaccepted
+    ;; legacy names, malformed values, invalid env vars) BEFORE the gates
+    ;; are applied and the transport announces readiness, so a silent
+    ;; posture-mismatch surfaces in the boot log.
     (log-launch-diagnostics! argv)
     (apply-launch-flags! launch-flags)
     (apply-resource-controls! argv)
@@ -895,7 +891,7 @@
       (log! "nREPL port-file (--port-file):" pf))
     (when-let [hp (:http-port launch-flags)]
       (log! "shadow HTTP port (--http-port):" hp))
-    ;; rf2-3grub — port discovery is LAZY (first tool call). We boot the
+    ;; Port discovery is LAZY (first tool call). We boot the
     ;; transport with the discovery cascade ready to fire on demand. This
     ;; matters because the MCP `roots/list` request can only succeed
     ;; AFTER the client's `initialize` handshake completes — i.e. after

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/shadow_discovery.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/shadow_discovery.cljs
@@ -74,7 +74,7 @@
   keys prefixed by `~:`. We walk the parsed array looking for the
   `~:project-home` sentinel and return the next element as the value.
 
-  Public so the unit tests can pin the parser shape directly (rf2-umoz2)
+  Public so the unit tests can pin the parser shape directly
   without standing up a fake HTTP server. A defensive parser — every
   branch where the shape disagrees collapses to nil so the caller falls
   through cleanly."

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -10,38 +10,36 @@
   | discover-app  | Verify nREPL + confirm the preloaded runtime + health     |
   | eval-cljs     | Eval a CLJS form, return the value                        |
   | dispatch      | Fire a re-frame2 event with :origin :pair                 |
-  | dispatch-dry-run | Simulate a cascade without committing it (rf2-17hvp)   |
+  | dispatch-dry-run | Simulate a cascade without committing it               |
   | restore-epoch | Time-travel undo — rewind a frame to a prior epoch        |
-  |               | (gated behind --allow-writes; rf2-ee38b.18)              |
+  |               | (gated behind --allow-writes)                            |
   | replace-app-db| State injection — replace a frame's app-db with EDN data  |
-  |               | (gated behind --allow-writes; rf2-ee38b.18)              |
+  |               | (gated behind --allow-writes)                            |
   | trace-window  | Epochs in the last N ms                                   |
   | watch-epochs  | Pull-mode live epoch streaming                            |
   | tail-build    | Wait for a hot-reload to land                             |
   | snapshot      | Coarse-grained per-frame state read (mega-op)             |
-  | get-path      | Direct read-by-path against a frame's app-db (rf2-tygdv)  |
+  | get-path      | Direct read-by-path against a frame's app-db             |
   | read-dom      | View-plane read — querySelector -> per-node text/attrs    |
-  |               | EDN; read-only, text/node-capped (rf2-nfjil)             |
+  |               | EDN; read-only, text/node-capped                         |
   | record        | Install a background signal recorder, return a            |
-  |               | :recording-id (rf2-zo4b9)                                 |
+  |               | :recording-id                                            |
   | read-recording| Read back a recorder's change-log; :drain / :stop         |
-  |               | (rf2-zo4b9)                                              |
-  | watch-until   | Block until a predicate over a signal holds (rf2-zo4b9)   |
-  | subscribe     | Streaming trace/epoch channel — push-mode replacement for |
-  |               | watch-epochs (rf2-hq49)                                   |
+  | watch-until   | Block until a predicate over a signal holds              |
+  | subscribe     | Streaming trace/epoch channel — push-mode counterpart to  |
+  |               | watch-epochs                                             |
   | unsubscribe   | Close a streaming subscription                            |
   | list-subscriptions | List the live reactive sub-cache for a frame —       |
-  |               | matches snapshot :sub-cache (rf2-qicji)                  |
+  |               | matches snapshot :sub-cache                              |
   | list-streams  | List active streaming-tap subscriptions + queue stats    |
-  |               | (rf2-qicji; the streaming diagnostic list-subscriptions  |
-  |               | formerly carried, wrapping subscription-info)            |
+  |               | (the streaming-diagnostic surface, wrapping              |
+  |               | subscription-info)                                       |
   | handler-meta  | Registration metadata for a (kind, id) — source-coord +   |
-  |               | :rf.source/uri (rf2-pctf8)                                |
-  | list-handlers | All registered ids under a kind (rf2-pctf8; renamed from  |
-  |               | registry-list per rf2-4y595)                              |
-  | get-re-frame2-pair-instructions | Inline agent-onboarding text (rf2-fnpqg)         |
+  |               | :rf.source/uri                                           |
+  | list-handlers | All registered ids under a kind                          |
+  | get-re-frame2-pair-instructions | Inline agent-onboarding text             |
 
-  ## Per-tool / per-concern layout (rf2-vrbwx, rf2-47g8l)
+  ## Per-tool / per-concern layout
 
   This namespace is the public façade — `invoke` glue, internal
   dispatch, and re-exported descriptor surface. The tool bodies and the
@@ -50,7 +48,7 @@
 
   - Concerns: `wire`, `probe`, `cap`, `dedup`, `elision`, `sensitive`,
     `cursor`, `args`, `summary`, `snapshot-pipeline`, `boundary-step`,
-    `writes` (the --allow-writes gate, rf2-ee38b.18).
+    `writes` (the --allow-writes gate).
   - Tools: `discover-app`, `eval-cljs`, `dispatch`, `dispatch-dry-run`,
     `restore-epoch`, `replace-app-db`, `trace-window`, `watch-epochs`,
     `tail-build`, `snapshot`, `get-path`, `read-dom`, `record`,
@@ -61,10 +59,10 @@
   - Descriptors: `descriptors-knobs` (universal knob property data),
     `descriptors-data` (per-tool descriptor maps), `descriptors`
     (`tool-descriptors-js` + the knob splicers).
-  - Registry (rf2-47g8l): `registry` — the single map binding name →
+  - Registry: `registry` — the single map binding name →
     descriptor + handler + cacheable?; the three downstream views are
     derived from it.
-  - Precheck: `precheck` (the rf2-36xod cheap-hash short-circuit).
+  - Precheck: `precheck` (the cheap-hash short-circuit).
 
   ## Result shape
 
@@ -129,8 +127,8 @@
       (when (and best (<= d cutoff)) best))))
 
 (defn- unknown-tool-envelope
-  "Build the `:unknown-tool` error envelope. Additive over the historical
-  `{:ok? false :reason :unknown-tool :tool name}` shape: carries a
+  "Build the `:unknown-tool` error envelope: `{:ok? false :reason
+  :unknown-tool :tool name}` plus a
   recovery-shaped `:hint` (the surface's honest-error standard — cf.
   cache.cljs `:rf.mcp/cache-hit` :hint, roots_discovery.cljs discovery
   hints, server.cljs port hints) pointing the agent at `tools/list` plus
@@ -153,14 +151,14 @@
   loop simple.
 
   Lookup is a single `(get registry/handler-for name)` — the registry
-  is the only place tool names are enumerated (rf2-47g8l). Every
+  is the only place tool names are enumerated. Every
   registered handler is a uniform 3-arity `(fn [conn args extra])`; the
   registry adapts 2-arity per-tool handlers internally.
 
   An unknown name returns the recovery-shaped `:unknown-tool` envelope
   (`unknown-tool-envelope`) — a `:hint` pointing at `tools/list` plus the
   live `:available-tools` catalogue and a `:did-you-mean` near-match, so a
-  model that typo'd a name (rf2-tkmik) can recover without a dead end."
+  model that typo'd a name can recover without a dead end."
   [conn name args extra]
   (if-let [handler (get registry/handler-for name)]
     (handler conn args extra)
@@ -168,14 +166,14 @@
       (wire/err-text (unknown-tool-envelope name)))))
 
 (defn refuse-unknown-tool
-  "Server-boundary pre-dispatch guard for unknown tool names (rf2-4mc6q1).
+  "Server-boundary pre-dispatch guard for unknown tool names.
   Returns the recovery-shaped `:unknown-tool` `wire/err-text` envelope
   when `name` is NOT a registered tool, so `server.cljs/handle-call` can
-  reject a typo or removed alias LOCALLY — BEFORE `ensure-connection!`
+  reject a typo or unrecognised name LOCALLY — BEFORE `ensure-connection!`
   runs any nREPL discovery. Returns `nil` for a registered name (it must
   proceed to normal dispatch).
 
-  Mirrors `writes/refuse-pre-connection` (rf2-wz66k7): the server runs
+  Mirrors `writes/refuse-pre-connection`: the server runs
   `ensure-connection!` for EVERY tool before the dispatcher is reached,
   so on a stock / misconfigured install with no nREPL port the discovery
   step REJECTS with `:nrepl-port-not-found` and an unknown name never
@@ -195,15 +193,14 @@
     (wire/err-text (unknown-tool-envelope name))))
 
 ;; ---------------------------------------------------------------------------
-;; Wire-boundary pipeline (rf2-3z0zi).
+;; Wire-boundary pipeline.
 ;;
-;; Four steps thread through `boundary-step/run-step-pipeline`. Each
+;; Steps thread through `boundary-step/run-step-pipeline`. Each
 ;; step's `:run` receives the live context (carrying `:result` and
 ;; `:precheck-hash`) and returns a Promise of the next context. The
 ;; `:skip-when?` predicates encode the per-step skip rules
-;; declaratively — no inline conditionals in the orchestrator
-;; (renamed from `:short-circuit?` per rf2-l0isf; the actual
-;; semantics are skip-this-step, not halt-the-chain).
+;; declaratively — no inline conditionals in the orchestrator. The
+;; predicate's semantics are skip-this-step, not halt-the-chain.
 ;;
 ;; Adding a future step (request-level redaction, metrics, path-prefix
 ;; slicing, per-call elision toggle) is one map-entry addition here
@@ -212,7 +209,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- canonicalize-build-step
-  "Step -1 — forgiving suffix→canonical build resolution (rf2-qda59).
+  "Step -1 — forgiving suffix→canonical build resolution.
   Runs BEFORE every other step so the conn's `:build-alias` cache is
   populated before any per-tool body reads `wire/arg-build`. Resolves the
   requested build (`wire/requested-build` — explicit `:build` arg, else
@@ -222,7 +219,7 @@
   so a no-`:build` follow-up call inherits the canonical form rather than
   the suffix `stick-build!` just stored.
 
-  ## Bare-default fast path (rf2-qda59 CI-race repair)
+  ## Bare-default fast path
 
   A no-`:build` call that falls through to the bare env / `:app` default
   (no explicit `:build` arg AND no sticky `:resolved-build-id`) is NOT
@@ -233,19 +230,18 @@
        (`SHADOW_CLJS_BUILD_ID` / `:app`) is a full build id by
        construction — never a suffix an operator typed — so it needs no
        suffix→canonical mapping. A default that isn't running surfaces via
-       the downstream `ensure-runtime!` diagnostic ladder exactly as
-       before; the alias step would only have round-tripped to re-derive
-       the id it was already handed.
-    2. **It un-breaks the streaming subscribe gate.** The pre-fix step
-       prepended a serial `active-builds` jvm-eval to EVERY first tool
-       call — including `subscribe`'s registration path. On a slow
-       hermetic CI runner that extra round-trip pushed `subscribe!`
-       registration past the live-subscribe conformance test's dispatch
-       head-start, so the dispatched cascade landed before the
-       subscription existed and zero `notifications/progress` frames
-       arrived (the bus only queues for already-registered subs). The
-       feature targets an operator who TYPES a build (`:build
-       machine-epochs`); the no-arg default never needed the trip.
+       the downstream `ensure-runtime!` diagnostic ladder; the alias step
+       would only round-trip to re-derive the id it was already handed.
+    2. **It keeps the streaming subscribe gate fast.** Prepending a
+       serial `active-builds` jvm-eval to EVERY first tool call —
+       including `subscribe`'s registration path — would, on a slow
+       hermetic CI runner, push `subscribe!` registration past the
+       live-subscribe conformance test's dispatch head-start, so the
+       dispatched cascade lands before the subscription exists and zero
+       `notifications/progress` frames arrive (the bus only queues for
+       already-registered subs). Suffix-forgiveness targets an operator
+       who TYPES a build (`:build machine-epochs`); the no-arg default
+       needs no trip.
 
   Suffix-forgiveness is fully preserved for the case it was built for:
   an explicit `:build` arg, or a sticky suffix stuck from a prior
@@ -280,7 +276,7 @@
           (.catch (fn [_] ctx))))))
 
 (defn- precheck-step
-  "Step 0 — rf2-36xod cheap-hash short-circuit. For precheck-eligible
+  "Step 0 — cheap-hash short-circuit. For precheck-eligible
   tools (cache enabled AND tool registers a precheck-target), fetches
   the runtime-side hash via one bencode round-trip and consults the
   cache. On a hit, writes the marker to `:result` (which trips
@@ -306,7 +302,7 @@
       (.then (fn [result-js] (assoc ctx :result result-js)))))
 
 (defn- apply-cache-step
-  "Step 2 — rf2-3rt1f post-eval result-hash cache. On a hash match
+  "Step 2 — post-eval result-hash cache. On a hash match
   replaces `:result` with the cache-hit marker; on a miss stores the
   new hash (plus the precheck-hash from step 0 if present) and leaves
   `:result` unchanged."
@@ -315,7 +311,7 @@
        (assoc ctx :result)))
 
 (defn- apply-cap-step
-  "Step 3 — rf2-rvyzy wire-boundary token-budget enforcement. When
+  "Step 3 — wire-boundary token-budget enforcement. When
   `:result` exceeds the per-call cap, replaces it with the
   `:rf.mcp/overflow` marker."
   [{:keys [result cap-opts] :as ctx}]
@@ -340,17 +336,16 @@
   | `:apply-cache`    | `:isError` result (errors must not poison cache) OR |
   |                   | result is already a wire-bounded marker             |
   | `:apply-cap`      | result is a wire-bounded marker (cache-hit /        |
-  |                   | overflow are sub-cap by construction — rf2-gktyn)   |
+  |                   | overflow are sub-cap by construction)               |
 
   Cache before cap is the right order: a cache hit emits a sub-100-
   byte marker that's trivially under any reasonable cap, so flipping
   the order would never change behaviour but would waste a token
   walk on the hit path.
 
-  `:skip-when?` is the per-step skip predicate (renamed from
-  `:short-circuit?` per rf2-l0isf — the prior name read as
-  halt-the-chain semantics; the actual semantics are skip-this-step
-  and continue to the next step's own predicate)."
+  `:skip-when?` is the per-step skip predicate: when it returns true the
+  step is skipped and the chain continues to the next step's own
+  predicate (skip-this-step, not halt-the-chain)."
   [{:name       :canonicalize-build
     :run        canonicalize-build-step}
    {:name       :precheck
@@ -375,7 +370,7 @@
   The four-step pipeline lives in `wire-boundary-pipeline` and is
   threaded by `boundary-step/run-step-pipeline`:
 
-  0. **`:precheck`** (`precheck/fetch-precheck-hash`, rf2-36xod) —
+  0. **`:precheck`** (`precheck/fetch-precheck-hash`) —
      for precheck-eligible tools, issue one cheap nREPL eval to
      compute the runtime-side hash and compare to the stored
      `:precheck-hash`. On a match, write the
@@ -388,7 +383,7 @@
   1. **`:dispatch`** — per-tool implementation. Skipped if the
      precheck step already produced a result.
 
-  2. **`:apply-cache`** (`cache/apply-cache`, rf2-3rt1f) —
+  2. **`:apply-cache`** (`cache/apply-cache`) —
      post-eval per-session response cache keyed on a hash of the
      result's text payload. On a hit the result is replaced with
      `{:rf.mcp/cache-hit ... :via :result-hash}` — the agent host
@@ -399,18 +394,18 @@
      0, it's recorded alongside the result hash so the NEXT call
      can short-circuit via the precheck path.
 
-  3. **`:apply-cap`** (`cap/apply-cap`, rf2-rvyzy) — responses
+  3. **`:apply-cap`** (`cap/apply-cap`) — responses
      whose serialised size exceeds the per-call cap (default 5,000
      tokens, configurable via the `max-tokens` MCP arg) are replaced
      with `{:rf.mcp/overflow ...}`. Silent truncation is not
      allowed. Already-marker results bypass — the marker envelopes
-     are sub-cap by construction (rf2-gktyn).
+     are sub-cap by construction.
 
   `extra` carries the MCP `extra` payload (signal + sendNotification +
   _meta.progressToken) for streaming tools. Non-streaming tools ignore
   it."
   [conn name args extra]
-  ;; rf2-lbm21 — session-sticky operating build. An explicit `:build` on
+  ;; Session-sticky operating build. An explicit `:build` on
   ;; any tool call (except `discover-app`, which owns its success-gated
   ;; cache lifecycle) becomes the sticky default for subsequent
   ;; no-`:build` calls. `arg-build` stays a pure read; the write lives
@@ -419,7 +414,7 @@
     (wire/stick-build! conn args))
   (let [cap (cap/max-tokens-arg args)]
     (if (cap/invalid-arg? cap)
-      ;; rf2-5rdit — a negative `:max-tokens` resolves to a
+      ;; A negative `:max-tokens` resolves to a
       ;; `{:rf.mcp/invalid-arg {...}}` rejection rather than a negative
       ;; cap. Short-circuit into an `isError: true` result BEFORE the
       ;; pipeline runs: the tool is never dispatched and the malformed
@@ -429,7 +424,7 @@
       ;; agent reads the actionable rejection and corrects the arg.
       (js/Promise.resolve (wire/err-text cap))
       (let [enabled? (args/parse-bool-arg args :cache)
-            ;; rf2-olvr5 finding 3 — fold the RESOLVED build into the
+            ;; Fold the RESOLVED build into the
             ;; cache identity so a precheck-hash collision across two
             ;; builds on the one nREPL connection can't serve the wrong
             ;; build's payload. `arg-build` is a pure read (runs AFTER
@@ -447,7 +442,7 @@
                       :cache-opts {:tool name :args args :enabled? enabled? :build build}
                       :cap-opts   {:tool name :cap cap}}]
         (-> (bs/run-and-extract wire-boundary-pipeline ctx)
-            ;; rf2-olvr5 finding 3 — a successful operating-frame mutation
+            ;; A successful operating-frame mutation
             ;; (set / reset) shifts where every omitted-`:frame` read
             ;; resolves, so any cached payload keyed only on `(tool, build,
             ;; args)` would be served against the WRONG frame (the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
@@ -3,7 +3,7 @@
   family — path vectors, frame ids, slice include lists, summary modes,
   per-slice mode maps, and the streaming filter map.
 
-  Path-arg parsing (rf2-tygdv): two tools take a `:path` argument:
+  Path-arg parsing: two tools take a `:path` argument:
   `snapshot` (slice the :app-db slice) and `get-path` (direct
   read-by-path). Same parser, same semantics so agents learn the shape
   once.
@@ -27,18 +27,16 @@
   #{:app-db :sub-cache :machines :epochs :traces})
 
 ;; ---------------------------------------------------------------------------
-;; Boolean-arg table (rf2-c4fmh).
+;; Boolean-arg table.
 ;;
 ;; The four boolean MCP args shared across re-frame2-pair-mcp tools each have one
 ;; load-bearing knob: their default posture. Their accept-shapes —
 ;; `true`/`false`, `"true"`/`"false"`/`"yes"`/`"no"`/`"1"`/`"0"` (case-
 ;; insensitive), `:true`/`:false`, unrecognised ⇒ default — are
-;; identical and come from `re-frame.mcp-base.args/parse-boolean`
-;; (rf2-vw4sq). Per-arg micro-wrappers were redundant friction: an
-;; agent that learned `:dedup "yes"` worked, but `:cache "yes"` had
-;; previously default-falsed because cache.cljs hand-rolled a smaller
-;; parser. This table is the single source of truth for both the
-;; default posture AND the accept-shape contract.
+;; identical and come from `re-frame.mcp-base.args/parse-boolean`.
+;; This table is the single source of truth for both the default posture
+;; AND the accept-shape contract: every boolean arg shares one parser, so
+;; an agent that learns `:dedup "yes"` knows `:cache "yes"` works too.
 ;;
 ;; Defaults:
 ;;
@@ -47,9 +45,8 @@
 ;;   :cache              false  — per-call cache is opt-in until agent
 ;;                                hosts have been taught the marker
 ;;   :include-sensitive  false  — spec/009 MUST default-suppress.
-;;                                Wire-key drops the trailing `?` per
-;;                                rf2-y710n + rf2-ihq4d: Anthropic's
-;;                                tool-input-schema regex
+;;                                The wire-key has no trailing `?`:
+;;                                Anthropic's tool-input-schema regex
 ;;                                `^[a-zA-Z0-9_.-]{1,64}$` rejects `?`.
 ;;                                The predicate FUNCTION name retains `?`
 ;;                                (idiom on predicates, not on data keys).
@@ -60,27 +57,27 @@
 ;; the args object is centralised here.
 
 (def bool-args
-  "Cross-tool boolean MCP args + their default postures (rf2-c4fmh)."
+  "Cross-tool boolean MCP args + their default postures."
   {:dedup             {:default true}
    :elision           {:default true}
    :cache             {:default false}
    :include-sensitive {:default false}
-   ;; rf2-6to9xj — dispatch-dry-run's :would-fire-effects[*].args are
+   ;; dispatch-dry-run's :would-fire-effects[*].args are
    ;; RAW fx-handler arguments (HTTP request bodies, dispatched event
    ;; vectors, payment maps). They are NOT rooted at the frame's app-db,
    ;; so the schema-path-keyed `elide-wire-value` walker cannot prove them
    ;; safe — the same leak class as an epoch record's :effects[].args,
-   ;; which `projected-record` fails closed (EP-0015 §13 residual). Off-box
+   ;; which `projected-record` fails closed (EP-0015 §13). Off-box
    ;; egress therefore FAILS CLOSED: :args redacts to :rf/redacted by
    ;; default. This knob is the trusted-local opt-in that keeps the raw
    ;; args, honoured only under --allow-sensitive-reads (same gate as
-   ;; :include-sensitive). Wire-key drops the trailing `?` per rf2-y710n.
+   ;; :include-sensitive). The wire-key has no trailing `?`.
    :include-fx-args   {:default false}
-   ;; rf2-qicji — list-subscriptions toggles its per-entry shape.
+   ;; list-subscriptions toggles its per-entry shape.
    ;; Default false: only the query-vectors ride the wire (the cheap
    ;; "what's subscribed" read); true also ships :value + :ref-count.
    :include-values    {:default false}
-   ;; rf2-zo4b9 — read-recording's two toggles. :drain consumes the
+   ;; read-recording's two toggles. :drain consumes the
    ;; buffered change-entries (the live-watch poll→consume→repeat idiom);
    ;; :stop tears the recording down after reading (read-and-close).
    ;; Both default false: a bare read is non-destructive.
@@ -91,7 +88,7 @@
   "Resolve a boolean MCP arg by name. Returns the per-arg default from
   `bool-args` when the slot is absent / nil / unrecognised; delegates
   recognised-value parsing to
-  `re-frame.mcp-base.args/parse-boolean` (rf2-vw4sq) — the cross-MCP
+  `re-frame.mcp-base.args/parse-boolean` — the cross-MCP
   accept-shape contract.
 
   `args` may be a JS args object, `nil`, or `js/undefined` — all three
@@ -107,7 +104,7 @@
    (`\"rf/default\"`) and EDN-shaped strings (`\":rf/default\"`) — strips
    a leading colon when present so callers can pass either form.
 
-   Delegates to `re-frame.mcp-base.args/fresh-keyword` (rf2-xxtrz) so
+   Delegates to `re-frame.mcp-base.args/fresh-keyword` so
    the slice-key / frame-key coercion is single-sourced across the
    re-frame2-pair-mcp wire surface — same helper underpins both
    `parse-frames-arg` and the per-slice-mode key coercion in
@@ -126,7 +123,7 @@
   Over the JSON-MCP wire a caller can only send a JSON object, so BOTH
   the override KEY and the override VALUE arrive as strings (`{\":http\":
   \":stub-http\"}` ⇒ key `\":http\"`, value `\":stub-http\"`). The naive
-  `(js->clj o :keywordize-keys true)` is doubly wrong here (rf2-hf7m9j):
+  `(js->clj o :keywordize-keys true)` is doubly wrong here:
   it leaves the value the string `\":stub-http\"`, AND it mints a
   MALFORMED key by calling `(keyword \":http\")` ⇒ `::http` (namespace
   literally `\"\"`), which matches no registered fx-id — the same colon-
@@ -231,7 +228,7 @@
 
 (defn parse-paths-arg
   "Normalise the plural `paths` MCP arg into a vector of path vectors —
-  the batch-read shape `get-path` consumes (rf2-lbm21). Each element is
+  the batch-read shape `get-path` consumes. Each element is
   itself a path (run through `parse-path-arg`), so a caller can read N
   app-db subtrees in ONE round-trip instead of N `get-path` calls.
 
@@ -284,7 +281,7 @@
    Returns one of three shapes the `snapshot-state` composer dispatches on:
 
      :app   — the APP frames only: every registered frame with the
-              reserved `:rf/*` TOOL frames removed (rf2-3bu3d.6). This is
+              reserved `:rf/*` TOOL frames removed. This is
               the DEFAULT (absent / nil / unrecognised arg). It is what a
               first investigate-read wants: the app the operator is
               pairing against, NOT the Xray / Story / SSR tool-frame
@@ -339,10 +336,10 @@
 (defn parse-mode-arg
   "Normalise the global `mode` MCP arg. Accepts strings (`\"summary\"`,
   `\"full\"`) or keywords. Defaults to `:summary` — the lazy-summary
-  default per rf2-u2029. Unrecognised values default to `:summary`
+  default. Unrecognised values default to `:summary`
   (budget-sensitive default).
 
-  Delegates to `re-frame.mcp-base.args/parse-mode` (rf2-vw4sq)."
+  Delegates to `re-frame.mcp-base.args/parse-mode`."
   [raw]
   (base-args/parse-mode raw :summary #{:summary :full}))
 
@@ -358,7 +355,7 @@
   through `re-frame.mcp-base.args/fresh-keyword`); per-slice mode
   coercion delegates to `re-frame.mcp-base.args/parse-mode` with a
   sentinel default so unrecognised values can be detected and
-  dropped rather than coerced to the global default (rf2-vw4sq)."
+  dropped rather than coerced to the global default."
   [raw]
   (let [as-clj (cond
                  (nil? raw)   nil
@@ -385,7 +382,7 @@
 
 (defn read-edn-arg
   "Read a single-value EDN MCP arg into the `[:ok parsed]` / `[:err reason]`
-  shape the write/introspection tools branch on (rf2-jkake.19).
+  shape the write/introspection tools branch on.
 
   Trims, then `read-string`s the value; an absent / blank value yields
   `[:err missing]`, an unreadable one `[:err invalid]`. `missing` /
@@ -397,7 +394,7 @@
   `handler-meta` (`:id`). The richer `dispatch` / `dispatch-dry-run`
   event parsers are deliberately NOT routed through here — they layer a
   vector-shape contract + parsed-type classification on top, and their
-  ns docstrings pin them as separately-evolving surfaces."
+  ns docstrings pin them as separate surfaces."
   [raw missing invalid]
   (let [trimmed (some-> raw str/trim)]
     (if (or (nil? trimmed) (str/blank? trimmed))
@@ -409,7 +406,7 @@
           [:ok parsed])))))
 
 ;; ---------------------------------------------------------------------------
-;; Numeric subscribe-control args (rf2-uvfph).
+;; Numeric subscribe-control args.
 ;;
 ;; `subscribe` forwards five integer knobs straight from the MCP args to
 ;; the runtime queue budget / poll loop / termination caps. The
@@ -444,18 +441,16 @@
   whole number. Accepts a JS/CLJS number (must be integral) or a numeric
   string. Fractional numbers and non-numeric junk are `::bad`.
 
-  Cross-runtime safe-integer guard (rf2-ykv9a0, routed here by
-  rf2-ttspi7): the numeric core goes through
+  Cross-runtime safe-integer guard: the numeric core goes through
   `base-args/coerce-finite-long`, which returns `nil` for `##NaN` /
   `##Inf` / `##-Inf` and for any finite magnitude outside the JS
-  safe-integer window `[-(2^53−1), 2^53−1]`. Previously a JS
+  safe-integer window `[-(2^53−1), 2^53−1]`. A JS
   `Number.isInteger` value above that ceiling (e.g. `9007199254740993`,
   representable as a JS integral double but NOT round-trippable through
-  a CLJS `long` / a JVM long without loss) passed straight through to
-  `(long raw)` here while `mcp-base` rejected the same value — the
-  divergence this routing closes. The tagged `[:ok]`/`[:err]` wrappers
-  (`parse-positive-int-arg` etc.) stay local; only the numeric core is
-  shared.
+  a CLJS `long` / a JVM long without loss) is therefore `::bad` here —
+  the same value `mcp-base` rejects, so the two runtimes agree. The
+  tagged `[:ok]`/`[:err]` wrappers (`parse-positive-int-arg` etc.) stay
+  local; only the numeric core is shared.
 
   A whole numeric below the safe-integer ceiling but outside the window
   on the string arm is caught by routing the parsed string back through
@@ -489,7 +484,7 @@
                       " (got " (pr-str raw) ").")}])
 
 (defn parse-positive-int-arg
-  "Validate an OPTIONAL positive-integer MCP arg value (rf2-uvfph).
+  "Validate an OPTIONAL positive-integer MCP arg value.
   `raw` is the already-extracted arg value (via `wire/arg`); `arg-name`
   is its wire key for the error message. Returns `[:ok nil]` when absent
   (`raw` nil), `[:ok n]` for an integer `>= 1`, and `[:err {…}]` (with
@@ -505,7 +500,7 @@
         (err-int arg-name raw "a positive integer (>= 1)")))))
 
 (defn parse-non-negative-int-arg
-  "Validate an OPTIONAL non-negative-integer MCP arg value (rf2-uvfph)
+  "Validate an OPTIONAL non-negative-integer MCP arg value
   where 0 is the documented unbounded sentinel. `raw` is the already-
   extracted arg value; `arg-name` is its wire key. Returns `[:ok nil]`
   when absent, `[:ok n]` for an integer `>= 0`, and `[:err {…}]` for a
@@ -520,7 +515,7 @@
         (err-int arg-name raw "a non-negative integer (>= 0; 0 = unbounded)")))))
 
 ;; ---------------------------------------------------------------------------
-;; Timeout / wait millisecond args (rf2-wz66k7).
+;; Timeout / wait millisecond args.
 ;;
 ;; Three NON-streaming tools thread a millisecond deadline straight from
 ;; the MCP args into an `(>= elapsed deadline)` poll comparison with NO
@@ -549,8 +544,8 @@
 ;; `[:ok nil]` — the caller falls back to its documented default.
 
 (defn parse-timeout-arg
-  "Validate an OPTIONAL positive-millisecond MCP timeout/wait arg value
-  (rf2-wz66k7). A thin alias over `parse-positive-int-arg` — the
+  "Validate an OPTIONAL positive-millisecond MCP timeout/wait arg value.
+  A thin alias over `parse-positive-int-arg` — the
   millisecond deadline knobs (`tail-build :wait-ms`, `eval-cljs` /
   `dispatch` `:timeout-ms`) share the positive-integer contract (>= 1).
   Named distinctly so the call sites read as a timeout check and a future
@@ -563,12 +558,12 @@
   (parse-positive-int-arg arg-name raw))
 
 ;; ---------------------------------------------------------------------------
-;; Recordable coeffects (rf2-q6s1nb / EP-0010 + EP-0017 agent-replay-determinism).
+;; Recordable coeffects (EP-0010 + EP-0017 agent-replay-determinism).
 ;;
 ;; `:rf.cofx` is an optional key of the PUBLIC `:rf/dispatch-opts` schema
-;; (spec/Spec-Schemas.md §:rf.cofx). EP-0017 renamed the field from the
-;; nested `:rf.world/inputs` (key `:time-ms`) to the flat `:rf.cofx` (key
-;; `:rf/time-ms`). The router preserves a caller-supplied map VERBATIM and
+;; (spec/Spec-Schemas.md §:rf.cofx) — a flat map of recordable coeffects
+;; keyed by owner-qualified keywords, the framework-required one being
+;; `:rf/time-ms`. The router preserves a caller-supplied map VERBATIM and
 ;; fills only the framework-required `:rf/time-ms` when absent — so an AI
 ;; agent that scripts a `:rf.cofx` map gets a REPRODUCIBLE resulting state (a
 ;; fixed `:rf/time-ms`, named owner-qualified recordable facts). This is the
@@ -576,7 +571,7 @@
 ;; tool-dispatch helpers.
 ;;
 ;; The MCP wire shape is an EDN STRING (the same data-not-source posture as
-;; the `event` arg, rf2-vflrg) — the agent passes `cofx
+;; the `event` arg) — the agent passes `cofx
 ;; "{:rf/time-ms 1781078400123}"` and we parse + shape-check it. The schema
 ;; requires `:rf/time-ms` to be an integer when present; we surface a bad
 ;; `:rf/time-ms` as a structured error rather than threading a value that the
@@ -585,7 +580,7 @@
 ;; runtime stamps `:rf/time-ms` itself, the ordinary live-dispatch path).
 
 (defn parse-cofx
-  "Parse the OPTIONAL `cofx` MCP arg (rf2-q6s1nb · EP-0017) into the CLJS map
+  "Parse the OPTIONAL `cofx` MCP arg (EP-0017) into the CLJS map
   threaded into the dispatch opts under `:rf.cofx`. Returns `[:ok nil]` when
   absent, `[:ok m]` for a well-shaped map, or `[:err {…}]` for a malformed
   one.
@@ -644,11 +639,11 @@
 
 (defn parse-filter-arg
   "MCP-side filter arg can be either a JS object or an EDN string. We
-  accept both for ergonomic parity with the bash-shim chain (`pred`
-  has been a JSON object there).
+  accept both for ergonomic parity with the bash-shim chain (`pred` is
+  a JSON object there).
 
   Returns the tagged `[:ok m]` / `[:err :invalid-filter-edn]` shape
-  (mirroring `read-edn-arg`, rf2-5kbkl) so the caller can surface a bad
+  (mirroring `read-edn-arg`) so the caller can surface a bad
   filter EDN as an honest `:ok? false` error rather than subscribing
   with a nonsense filter. The two success shapes:
 
@@ -657,14 +652,13 @@
                      a JS object keywordised.
 
   The lone failure shape `[:err :invalid-filter-edn]` is returned when
-  an EDN STRING fails to `read-string`. Pre-rf2-5kbkl this branch
-  returned a `{:invalid-filter-edn raw}` MAP that flowed straight into
-  the runtime `subscribe!` `:filter` slot — a typo'd filter silently
-  became a nonsense filter that streamed the wrong (likely empty) event
-  set with no corrective signal. The tag lets `subscribe-tool`
+  an EDN STRING fails to `read-string`. The tag lets `subscribe-tool`
   short-circuit to the same honest-error envelope `:unknown-topic`
   already uses, rather than swallowing the parse failure into a
-  broken-success path."
+  broken-success path: a typo'd filter that flowed straight into the
+  runtime `subscribe!` `:filter` slot would silently become a nonsense
+  filter streaming the wrong (likely empty) event set with no
+  corrective signal."
   [raw]
   (cond
     (nil? raw)        [:ok nil]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/await_promise.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/await_promise.cljs
@@ -1,12 +1,12 @@
 (ns re-frame2-pair-mcp.tools.await-promise
-  "Shared browser-side Promise-await machinery (rf2-gfu33).
+  "Shared browser-side Promise-await machinery.
 
   Two tools need the same capability: run a form over nREPL whose
   synchronous return is a JS Promise, then resolve to the Promise's
   eventual value rather than the `\"#object[Promise ...]\"` string a
-  raw `pr-str` would produce. `eval-cljs :await` (rf2-xn4f9) was the
-  first; `dispatch :await-render` (rf2-gfu33) is the second — it awaits
-  a render-settle Promise so `dispatch → observe` is a single
+  raw `pr-str` would produce. `eval-cljs :await` awaits a
+  caller-supplied async form; `dispatch :await-render` awaits a
+  render-settle Promise so `dispatch → observe` is a single
   deterministic step.
 
   The nREPL channel is request/response: the server sends a form and

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/boundary_step.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/boundary_step.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.boundary-step
-  "Pluggable wire-boundary step-pipeline (rf2-3z0zi).
+  "Pluggable wire-boundary step-pipeline.
 
   ## Why a step-pipeline
 
@@ -8,17 +8,16 @@
 
       precheck → dispatch → apply-cache → apply-cap
 
-  Before this ns landed the four phases were hardcoded inline in
-  `invoke` as a hand-threaded Promise chain. Each phase had its own
-  short-circuit rule (`apply-cache` skips `:isError`; `apply-cap`
-  skipped nothing). The ordering invariant was prose-only — the
-  `invoke` docstring described it; the impl had to be read top-to-
-  bottom to verify it.
+  Each phase carries its own short-circuit rule (`apply-cache` skips
+  `:isError`; `apply-cap` skips nothing). Expressing the sequence as
+  named, declarative data — rather than a hand-threaded Promise chain
+  — makes the ordering invariant explicit and inspectable instead of
+  prose-only.
 
-  This namespace is the round-2 parallel of round-1's named
-  wire-pipeline win (`tools/wire-pipeline.cljs`): the same lens
-  (turn an implicit ordering into named, declarative data) applied
-  one level up. Each step is a map:
+  This namespace mirrors the named wire-pipeline in
+  `tools/wire-pipeline.cljs`: the same lens (turn an implicit ordering
+  into named, declarative data) applied one level up. Each step is a
+  map:
 
   ```clojure
   {:name       :apply-cap
@@ -33,10 +32,9 @@
   - `:skip-when?` — optional predicate over the pre-`:run` context.
                     When truthy, THIS step is skipped (its `:run` is
                     not called) and the pipeline continues to the
-                    next step. Pure on the context; cheap. Renamed
-                    from `:short-circuit?` (rf2-l0isf) — the prior
-                    name read as halt-the-chain semantics; the
-                    actual semantics are skip-this-step.
+                    next step. Pure on the context; cheap. The name
+                    is deliberate: the semantics are skip-this-step,
+                    NOT halt-the-chain.
 
   ## Context shape
 
@@ -52,7 +50,7 @@
   Every step receives this context. The `:result` slot is the running
   payload — nil before `:dispatch` runs, populated thereafter. Steps
   that produce a result write it; steps that consume it read it. The
-  `:precheck-hash` slot is the cheap-hash from rf2-36xod; the
+  `:precheck-hash` slot is the cheap precheck hash; the
   `apply-cache` step consumes it to record on a miss.
 
   ## Skip-when semantics

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.cap
-  "Wire-boundary token-budget cap (rf2-rvyzy / rf2-eyelu).
+  "Wire-boundary token-budget cap.
 
   Per `spec/Principles.md` §\"Tight token budget per response\", every
   MCP `tools/call` response is bounded at ~5,000 tokens by default.
@@ -12,7 +12,7 @@
   ## Pipeline ownership
 
   The cap-enforcement ALGORITHM lives in `re-frame.mcp-base.cap`
-  (rf2-eyelu) — token-summing across `:text` slots, comparing against
+  — token-summing across `:text` slots, comparing against
   the per-call cap, and building the overflow result. This ns supplies
   the per-server specialisation:
 
@@ -39,9 +39,8 @@
   - **Pluggable strategy**: `base-cap/apply-cap` dispatches on a
     strategy keyword. Today only `:truncate-with-marker` is
     implemented — replace the payload with the overflow marker.
-    Future strategies (path-slicing rf2-tygdv, lazy summary
-    rf2-u2029, diff encoding rf2-rl7y, etc.) compose in the base
-    without rebuilding the wrapper here.
+    Future strategies (path-slicing, lazy summary, diff encoding,
+    etc.) compose in the base without rebuilding the wrapper here.
   - **Centralised**: applied as the final step in `invoke`. Per-tool
     functions are untouched; they emit the same shapes they always
     did. The wire-cap is a property of the egress boundary, not of
@@ -53,10 +52,9 @@
 
 ;; `default-max-tokens` and the character→token approximation
 ;; (`base-overflow/token-estimate`) come from `re-frame.mcp-base.overflow`
-;; (rf2-vw4sq) — both are cross-MCP conventions pinned once in the base.
+;; — both are cross-MCP conventions pinned once in the base.
 ;; `default-max-tokens` is re-exported here because production call sites
-;; reference `cap/default-max-tokens`; the test-only `token-estimate`
-;; re-export moved to `test-utils` (rf2-ttspi7) — production code calls
+;; reference `cap/default-max-tokens`; production code calls
 ;; `base-overflow/token-estimate` directly.
 (def default-max-tokens base-overflow/default-max-tokens)
 
@@ -74,7 +72,7 @@
 
 (defn invalid-arg?
   "True when `max-tokens-arg` rejected the per-call `:max-tokens` arg
-  (rf2-5rdit) — a negative value resolves to a
+  — a negative value resolves to a
   `{:rf.mcp/invalid-arg {...}}` rejection rather than a cap. The
   `invoke` chokepoint tests this and short-circuits into an
   `isError: true` result via `wire/err-text` instead of threading the
@@ -99,8 +97,7 @@
 ;; cross-MCP marker presents identically. Production reads it via
 ;; `base-overflow/overflow-hint-fallback` (or, more usually, lets
 ;; `base-cap/apply-cap` apply the fallback when a tool has no specific
-;; hint). The test-only `overflow-hint-fallback` re-export moved to
-;; `test-utils` (rf2-ttspi7).
+;; hint).
 
 (def ^:private result-io
   "ResultIO reify over re-frame2-pair-mcp's `#js {:content #js [...]}` shape
@@ -108,7 +105,7 @@
   overflow result with the same JS shape so the SDK can serialise it
   as a `tools/call` reply unchanged.
 
-  HOT PATH (rf2-ycfu1; mirrors story-mcp's rf2-mzndx fix): `wire/ok-text`
+  HOT PATH (mirrors story-mcp's structured-slot accounting): `wire/ok-text`
   / `wire/err-text` write the SAME payload into BOTH `:content[*].text`
   (the pr-str EDN) AND `:structuredContent` (the `clj->js` JSON
   projection) on EVERY result. Both slots ride the wire — the
@@ -142,17 +139,17 @@
                (and (some? sc) (not (undefined? sc)))
                (conj! (js/JSON.stringify sc))))))))
     (build-overflow-result [_ marker _original]
-      ;; rf2-or8s29 — route through `wire/result` so the overflow marker's
-      ;; structuredContent keeps its namespace: a raw `clj->js` truncated
-      ;; the `:rf.mcp/overflow` marker key to `"overflow"`, so SDK-friendly
-      ;; hosts reading structuredContent missed the marker.
+      ;; Route through `wire/result` so the overflow marker's
+      ;; structuredContent keeps its namespace: a raw `clj->js` would
+      ;; truncate the `:rf.mcp/overflow` marker key to `"overflow"`, so
+      ;; SDK-friendly hosts reading structuredContent would miss the marker.
       (wire/result marker false))))
 
 (defn sum-payload-tokens
   "Sum `token-estimate` across every wire-bearing slot in the MCP
   `{:content [{:type \"text\" :text ...} ...] :structuredContent ...}`
   result — both the `:content[*].text` strings AND the
-  `:structuredContent` JSON projection (rf2-ycfu1). Both ride the wire
+  `:structuredContent` JSON projection. Both ride the wire
   as the serialised tool-result body; the bounded JSON envelope keys
   are ignored.
 
@@ -174,9 +171,9 @@
   `base-cap/apply-cap`.
 
   Short-circuits on a wire-bounded marker (`:rf.mcp/cache-hit`,
-  `:rf.mcp/overflow` — rf2-gktyn). Such envelopes are sub-cap by
+  `:rf.mcp/overflow`). Such envelopes are sub-cap by
   construction; the token-sum walk would be wasted work. The
-  `invoke` pipeline (rf2-3z0zi) already short-circuits before this
+  `invoke` pipeline already short-circuits before this
   fn runs in the orchestrated path, but the guard here makes the
   invariant local to `apply-cap` too — direct callers (tests, future
   consumers) get the same skip.
@@ -189,7 +186,7 @@
   result in `:rf.mcp/overflow` like any other payload. An error
   response can itself carry an oversize `:message` blob (e.g. a
   stack trace pretty-printed from a deep CLJS exception) and silent
-  over-budget egress would violate the rf2-rvyzy contract that
+  over-budget egress would violate the wire-cap contract that
   every response is the wire-cap-respecting marker OR a sub-cap
   payload — never a verbatim over-budget body. The cache only
   cares about identity; the cap cares about byte count, and an
@@ -205,8 +202,8 @@
                          :strategy strategy})))
 
 (defn cap-message
-  "Per-notification wire-cap for a single serialised EDN message string
-  (rf2-wz66k7). Returns `message` unchanged when under the cap (or the
+  "Per-notification wire-cap for a single serialised EDN message string.
+  Returns `message` unchanged when under the cap (or the
   cap is disabled via `nil`), else the `pr-str` of the same
   `{:rf.mcp/overflow {...}}` marker the result path emits.
 
@@ -221,8 +218,8 @@
   notification\"; §Subscribe streaming: progress frames apply the same
   wrap per-tick; `003-Tool-Catalogue.md` §Universal dedup: the per-tick
   `:events` vector participates in the wire-cap discipline). This is the
-  same cap-completeness class as rf2-ycfu1 (count `:structuredContent`
-  toward the cap) — a wire-bearing payload that bypassed the gate.
+  same cap-completeness class as counting `:structuredContent`
+  toward the cap — every wire-bearing payload passes through the gate.
 
   Uses the SAME two-stage gate (`base-cap/over-cap?` — token sum OR the
   secondary char gate) and the SAME `overflow/overflow-payload` shape as

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cursor.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cursor.cljs
@@ -1,14 +1,14 @@
 (ns re-frame2-pair-mcp.tools.cursor
-  "Cursor pagination on epoch-shipping tools (rf2-kbqq3).
+  "Cursor pagination on epoch-shipping tools.
 
   `trace-window` and `watch-epochs` both surface unbounded epoch
   vectors. With default ring depth 50 and ~2× app-db per record (or ~1%
-  that, post-rf2-1wdzp diff-encode), a single call can blow the 5K
-  wire-cap (rf2-rvyzy). Lazy-summary (rf2-u2029) trims `snapshot` for
+  that, after diff-encode), a single call can blow the 5K
+  wire-cap. Lazy-summary trims `snapshot` for
   discovery; here the agent explicitly asked for the records — the
   right answer is to PAGE the slice, not to collapse it.
 
-  ## Shared codec (rf2-ee38b.19)
+  ## Shared codec
 
   The base64 codec, the tagged-literal-rejecting EDN reader, the size
   cap, the `::malformed` recovery contract, and the cursor-stale
@@ -42,17 +42,17 @@
                                      ; admit fresh epochs mid-page
      :frame <keyword-or-nil>}
 
-  ## Why `:after-id` is `:any`, not `string?` (rf2-ee38b.18)
+  ## Why `:after-id` is `:any`, not `string?`
 
   An epoch-id is OPAQUE — `spec/Spec-Schemas.md` declares `:epoch-id`
   as `:any` and the reference epoch runtime
   (`re-frame/epoch/state.cljc` `next-epoch-id`) emits **integers**
-  (`(swap! counter inc)`). A prior `(string? (:after-id v))` guard
-  rejected every integer-bearing second-page cursor as
+  (`(swap! counter inc)`). The `valid?` predicate requires only that
+  the slot be PRESENT (`some?`), not that it be a string — a `string?`
+  guard would reject every integer-bearing second-page cursor as
   `::malformed` → spurious `:rf.mcp/cursor-stale`, breaking pagination
-  against the real runtime. The `valid?` predicate now only requires
-  the slot be PRESENT (`some?`) — any EDN-printable id (integer,
-  keyword, string) round-trips losslessly through the base64-of-EDN
+  against the real runtime. Any EDN-printable id (integer, keyword,
+  string) round-trips losslessly through the base64-of-EDN
   codec. The codec, size cap, and tagged-literal rejection are the
   base's; only this shape predicate is the pair's.
 
@@ -85,8 +85,8 @@
             [re-frame2-pair-mcp.tools.wire :as wire]))
 
 (def default-limit
-  ;; Sized to fit a 5K-token cap after diff-encode (rf2-1wdzp) and
-  ;; dedup (rf2-obpa9). With diff-encode collapsing `:db-after` to ~1%
+  ;; Sized to fit a 5K-token cap after diff-encode and
+  ;; dedup. With diff-encode collapsing `:db-after` to ~1%
   ;; of `:db-before` and dedup pooling repeated `:db-before` references,
   ;; 50 epochs fit comfortably under 5K tokens for typical app-db sizes.
   ;; Agents that have explicit budget headroom raise via `:limit` arg.
@@ -103,16 +103,16 @@
 (defn parse-limit-arg
   "Normalise the `:limit` MCP arg into an integer in `[1, max-limit]`.
   Default `default-limit` (50). Delegates to
-  `re-frame.mcp-base.cursor/parse-limit-arg` (rf2-ee38b.19), which
+  `re-frame.mcp-base.cursor/parse-limit-arg`, which
   itself routes through `re-frame.mcp-base.args/parse-positive-int`
-  (rf2-vw4sq) for the shared string/number coercion."
+  for the shared string/number coercion."
   [raw]
   (base-cursor/parse-limit-arg raw default-limit max-limit))
 
 (defn- valid-payload?
   "The pair's cursor-payload shape predicate. A well-formed cursor is a
   map carrying a PRESENT `:after-id` of ANY type — per the `:any`
-  `:epoch-id` contract (rf2-ee38b.18), the reference runtime's epoch-ids
+  `:epoch-id` contract, the reference runtime's epoch-ids
   are integers, so a `string?` guard here would reject every legitimate
   second-page cursor. We require presence, not type."
   [v]
@@ -147,7 +147,7 @@
 (defn cursor-stale-result
   "Structured cursor-stale error result. The `:reason` value
   (`base-vocab/cursor-stale-reason`, namespaced `:rf.mcp/cursor-stale`)
-  is the cross-MCP convention agents pattern-match on (rf2-vw4sq);
+  is the cross-MCP convention agents pattern-match on;
   they either restart (drop the cursor) or rewind via a wider window.
 
   Shapes the envelope through `wire/err-text` (the pair's wire

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dedup.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dedup.cljs
@@ -1,8 +1,7 @@
 (ns re-frame2-pair-mcp.tools.dedup
-  "Diff-encoded epoch slice (rf2-1wdzp) + structural dedup at the wire
-  boundary (rf2-obpa9).
+  "Diff-encoded epoch slice + structural dedup at the wire boundary.
 
-  ## Diff-encoded epoch slice (rf2-1wdzp)
+  ## Diff-encoded epoch slice
 
   Each `:rf/epoch-record` carries `:db-before` and `:db-after` —
   near-identical full app-db snapshots. `pr-str` doesn't preserve
@@ -13,7 +12,7 @@
   without reference to siblings. Opt-back-in to the full pair via
   `:full` mode. Default is `:diff`.
 
-  ## Structural dedup (rf2-obpa9)
+  ## Structural dedup
 
   Persistent data structures share subtrees in memory; `pr-str` flattens
   the sharing. `day8/de-dupe` walks a persistent data structure,
@@ -47,7 +46,7 @@
 
   `dedup` MCP arg (boolean). Default `true`. `false` skips dedup
   entirely. The arg is parsed by the shared
-  `re-frame2-pair-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh).
+  `re-frame2-pair-mcp.tools.args/parse-bool-arg` table.
 
   ### Idempotence on no-dedup-opportunity
 
@@ -55,11 +54,11 @@
   (the wire shape is very slightly larger than the input). The encoder
   skips wrapping in that case via an `empty-payload?` short-circuit.
 
-  ### Where the dedup encode step lives (rf2-ttspi7)
+  ### Where the dedup encode step lives
 
-  `empty-payload?` and `dedup-value` were byte-identical to story-mcp's,
-  so they are lifted to `re-frame.mcp-base.dedup` and delegated here.
-  The diff-encode delegations are unchanged."
+  `empty-payload?` and `dedup-value` are identical to story-mcp's, so
+  they live in `re-frame.mcp-base.dedup` and are delegated here, as are
+  the diff-encode steps."
   (:require [re-frame.mcp-base.args :as base-args]
             [re-frame.mcp-base.dedup :as base-dedup]
             [re-frame.mcp-base.diff-encode :as base-diff]))
@@ -75,7 +74,7 @@
 
 (defn parse-epochs-mode
   "Normalise the `epochs-mode` MCP arg. Delegates to
-  `re-frame.mcp-base.args/parse-mode` (rf2-vw4sq)."
+  `re-frame.mcp-base.args/parse-mode`."
   [raw]
   (base-args/parse-mode raw :diff #{:diff :full}))
 
@@ -84,19 +83,19 @@
 ;; ---------------------------------------------------------------------------
 
 (defn empty-payload?
-  "Delegates to `re-frame.mcp-base.dedup/empty-payload?` (rf2-ttspi7)."
+  "Delegates to `re-frame.mcp-base.dedup/empty-payload?`."
   [v]
   (base-dedup/empty-payload? v))
 
 (defn dedup-value
-  "Delegates to `re-frame.mcp-base.dedup/dedup-value` (rf2-ttspi7). Uses
+  "Delegates to `re-frame.mcp-base.dedup/dedup-value`. Uses
   `de-dupe-eq` (equality-based) — see the section header for the
   identity-vs-equality rationale."
   [v enabled?]
   (base-dedup/dedup-value v enabled?))
 
-;; `dedup-expand` (the inverse of `dedup-value`) has moved to
-;; `re-frame2-pair-mcp.test-utils/dedup-expand` (rf2-ambfv). It's
+;; `dedup-expand` (the inverse of `dedup-value`) lives in
+;; `re-frame2-pair-mcp.test-utils/dedup-expand`. It's
 ;; never called by the MCP server itself — only by tests asserting
 ;; round-trip exactness. The agent host calls `de-dupe.core/expand`
 ;; directly on the wire payload.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/describe_image.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/describe_image.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.tools.describe-image
   "Tool: describe-image — describe the IMAGE GENERATION a frame is running
-  (rf2-srobm0; EP-0023 Use-Case 7 + Ref-Plan item 17).
+  (EP-0023 Use-Case 7 + Ref-Plan item 17).
 
   ## What this answers
 
@@ -13,7 +13,7 @@
   not the realm-wide registrar union.
 
   Routes through the runtime preload's `describe-image`, which reads ONLY
-  the PUBLIC facade `rf/frame-generation` read shipped by rf2-wkw8na.
+  the PUBLIC facade `rf/frame-generation` read.
   EP-0023 forbids tools from consuming `re-frame.live-frame` /
   `re-frame.image-assembly` internals directly; the facade re-surfaces the
   behaviour through the public read.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.descriptors
-  "MCP `tools/list` descriptor builder (rf2-vrbwx, rf2-47g8l).
+  "MCP `tools/list` descriptor builder.
 
   The descriptor *data* lives in `descriptors-data.cljs`; the *catalogue
   index* (name → descriptor + handler + cacheable?) lives in

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -6,10 +6,10 @@
   registry entry per tool, descriptor included by name) without
   forcing the registry to inline ~280 lines of descriptor blobs.
 
-  Per rf2-zkca8's carve-out for catalogue-shaped leaves, this file
-  is permitted to exceed the standard ≤250-line ceiling — splitting
-  it per-tool would force readers to chase across twelve files when
-  comparing descriptor shapes.
+  As a catalogue-shaped leaf, this file is permitted to exceed the
+  standard ≤250-line ceiling — splitting it per-tool would force
+  readers to chase across twelve files when comparing descriptor
+  shapes.
 
   Universal knobs (`max-tokens`, `cache`) are spliced via
   `descriptors-knobs/with-budget-knob` and `with-cache-knob` inside
@@ -17,19 +17,18 @@
   knobs (limit, cursor, dedup, elision) reach in by name below.
 
   Each entry carries `:name`, `:description`, `:inputSchema`,
-  `:outputSchema` (rf2-3l3be — describes the `:structuredContent`
-  payload shape; agent hosts use it to validate the result client-
-  side), and `:typicalTokens` (rf2-6sddv) — an informational
-  ballpark of the response-payload size in tokens that AI clients
-  use to budget calls and pick size-conscious args (`max-tokens`,
-  `cache`, `cursor`) without trial-and-error. Hint only; the real
-  cap is enforced separately."
+  `:outputSchema` (describes the `:structuredContent` payload shape;
+  agent hosts use it to validate the result client-side), and
+  `:typicalTokens` — an informational ballpark of the response-payload
+  size in tokens that AI clients use to budget calls and pick
+  size-conscious args (`max-tokens`, `cache`, `cursor`) without
+  trial-and-error. Hint only; the real cap is enforced separately."
   (:require [re-frame2-pair-mcp.tools.descriptors-knobs :as knobs]))
 
 ;; ---------------------------------------------------------------------------
-;; Recurring outputSchema fragments (rf2-3l3be).
+;; Recurring outputSchema fragments.
 ;;
-;; The `:structuredContent` payload (rf2-hj3pi) is `clj->js` of the
+;; The `:structuredContent` payload is `clj->js` of the
 ;; EDN payload — keywords become string keys (`:ok?` → `"ok?"`). Tool
 ;; results split into two coarse families:
 ;;
@@ -90,7 +89,7 @@
                      "§Universal: wire-boundary token cap.")})
 
 ;; ---------------------------------------------------------------------------
-;; Tool annotations (rf2-94p8q).
+;; Tool annotations.
 ;;
 ;; mcp_best_practices.md guidance: every tool descriptor SHOULD declare
 ;; annotation hints so agent hosts (Claude Code, Continue) can auto-
@@ -118,7 +117,7 @@
   "Read-only AND idempotent — `snapshot`, `get-path`, `discover-app`,
   `tail-build`, `list-subscriptions`, `handler-meta`, `list-handlers`
   return the same answer for the same args + same runtime state.
-  (`list-subscriptions` reads the live reactive sub-cache, rf2-qicji —
+  (`list-subscriptions` reads the live reactive sub-cache —
   idempotent across same-state calls just like `snapshot :sub-cache`.)"
   {:readOnlyHint   true
    :idempotentHint true
@@ -160,7 +159,7 @@
    :openWorldHint  true})
 
 (def ^:private stream-controls-annotations
-  "Annotations for `get-stream-controls` (rf2-a0kxsb) — pure read over
+  "Annotations for `get-stream-controls` — pure read over
   the server's IN-PROCESS resource-control atoms. Read-only and
   idempotent across same-state calls. `:openWorldHint false`: unlike
   `list-streams` it does NOT reach the browser runtime over nREPL — the
@@ -170,7 +169,7 @@
    :openWorldHint  false})
 
 (def ^:private record-annotations
-  "Annotations for `record` (rf2-zo4b9) — installs a read-only observer
+  "Annotations for `record` — installs a read-only observer
   on the runtime. `:readOnlyHint true` because the recorder never mutates
   app-db / the DOM (every signal sampler only reads), but NOT
   `:idempotentHint` (each call mints a fresh recording-id and starts a
@@ -183,7 +182,7 @@
 
 (def ^:private session-pin-annotations
   "Annotations for the session-mutating operating-frame ops
-  (`set-operating-frame`, `reset-operating-frame`, rf2-zomfq). They
+  (`set-operating-frame`, `reset-operating-frame`). They
   mutate the per-session frame pin in the runtime preload — NOT app-db,
   NOT the DOM — so `:readOnlyHint false` (they write *session* state)
   but NOT `:destructiveHint` (no irreversible app effect; a wrong pin is
@@ -218,9 +217,8 @@
 ;; One def per tool, in catalogue order (per
 ;; spec/003-Tool-Catalogue.md). Each section is bounded by a comment
 ;; rule so a reader scrolling through the file can land on a tool
-;; without grepping. The file's leaf-size exemption (rf2-zkca8 —
-;; catalogue-shaped leaves) earns the length; the section navigation
-;; (rf2-rk2c7) earns the scannability.
+;; without grepping. The catalogue-shaped-leaf size exemption earns
+;; the length; the section navigation earns the scannability.
 ;; ===========================================================================
 
 ;; ---------------------------------------------------------------------------
@@ -1777,7 +1775,7 @@
                  :additionalProperties false}})
 
 ;; ---------------------------------------------------------------------------
-;; describe-image (rf2-srobm0 — EP-0023 Use-Case 7 / Ref-Plan item 17)
+;; describe-image (EP-0023 Use-Case 7 / Ref-Plan item 17)
 ;; ---------------------------------------------------------------------------
 
 (def describe-image
@@ -1838,7 +1836,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; set-operating-frame / reset-operating-frame / get-operating-frame
-;; (rf2-zomfq — the three Tool-Pair §Tool-surface-obligations ops)
+;; (the three Tool-Pair §Tool-surface-obligations ops)
 ;; ---------------------------------------------------------------------------
 
 (def set-operating-frame

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_knobs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_knobs.cljs
@@ -22,11 +22,11 @@
                      "`{:rf.mcp/invalid-arg ...}` error (rf2-5rdit).")})
 
 (def limit-property
-  "Per-tool descriptor slot for the `:limit` cursor-pagination knob
-  (rf2-kbqq3). Applied to surfaces that ship epoch vectors and would
-  otherwise blow the wire-cap on a single call: `trace-window` and
-  `watch-epochs`. Default 50 — sized to fit the 5K-token cap after
-  diff-encode (rf2-1wdzp) + dedup (rf2-obpa9)."
+  "Per-tool descriptor slot for the `:limit` cursor-pagination knob.
+  Applied to surfaces that ship epoch vectors and would otherwise blow
+  the wire-cap on a single call: `trace-window` and `watch-epochs`.
+  Default 50 — sized to fit the 5K-token cap after diff-encode +
+  dedup."
   {:type        "integer"
    :description (str "Maximum number of epoch records in the response "
                      "(default 50). The default is sized to fit the "
@@ -36,8 +36,8 @@
                      "pass the cursor back to fetch the next page.")})
 
 (def cursor-property
-  "Per-tool descriptor slot for the opaque `:cursor` continuation token
-  (rf2-kbqq3). Applied to `trace-window` and `watch-epochs`."
+  "Per-tool descriptor slot for the opaque `:cursor` continuation token.
+  Applied to `trace-window` and `watch-epochs`."
   {:type        "string"
    :description (str "Opaque cursor returned by a previous call's "
                      "`:next-cursor`. Pass back verbatim to fetch the "
@@ -47,7 +47,7 @@
                      "drop the cursor and restart, or widen the window.")})
 
 (def dedup-property
-  "Per-tool descriptor slot for the `:dedup` opt-out (rf2-obpa9).
+  "Per-tool descriptor slot for the `:dedup` opt-out.
   Applied to surfaces that ship epoch slices (`snapshot`,
   `trace-window`, `watch-epochs`) and to the `subscribe` streaming
   channel — the surfaces where repeated subtrees dominate the wire
@@ -64,13 +64,13 @@
                      "`expand`.")})
 
 (def elision-property
-  "Per-tool descriptor slot for the `:elision` opt-out (rf2-urjnc).
+  "Per-tool descriptor slot for the `:elision` opt-out.
   Applied to every surface that egresses an `:app-db`-rooted VALUE through
   the per-slot walker: the direct-read app-db readers (`snapshot`,
   `get-path`, `read-sub`), `list-subscriptions :include-values`' per-sub
-  `:value` (rf2-f1ose), the streaming `subscribe` payload values (rf2-vr2hn),
+  `:value`, the streaming `subscribe` payload values,
   and the signal-recorder sample values — `record`'s `:app-db` / `:sub`
-  samples and `watch-until`'s `:sample` / `:last-sample` (rf2-8fin7.2) —
+  samples and `watch-until`'s `:sample` / `:last-sample` —
   surfaces where a declared-`:large?` slot or a declared-`:sensitive?` leaf
   would otherwise ride off-box verbatim. Default `true`. (The pull-mode
   epoch tools — `trace-window`, `watch-epochs`, and `dispatch`'s
@@ -108,7 +108,7 @@
                      "it.")})
 
 (def cache-property
-  "Per-tool descriptor slot for the `:cache` opt-in (rf2-3rt1f).
+  "Per-tool descriptor slot for the `:cache` opt-in.
   Applied to read-tool descriptors via `with-cache-knob`. Default
   `false` — opt-in until the agent host has been taught the
   `:rf.mcp/cache-hit` marker shape."

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
@@ -1,7 +1,7 @@
 (ns re-frame2-pair-mcp.tools.discover-app
   "Tool: discover-app — verify the stack and probe the preloaded runtime.
 
-  ## Freshness / liveness token (rf2-ertqw)
+  ## Freshness / liveness token
 
   Every `:ok? true` discover-app payload carries a `:freshness` token —
   the browser-side runtime-instance-id + load time merged with the
@@ -9,16 +9,15 @@
   age, plus a single `:liveness` verdict (`:fresh` / `:stale-build` /
   `:no-runtime` / `:unknown`). It makes 'the runtime I'm reading is
   stale / disconnected / serving a stale BUILD' obvious on the FIRST
-  call — the signal that would have killed the rf2-lo28u stale-build
-  false-alarm detour instantly. Assembled by
-  `re-frame2-pair-mcp.tools.freshness`."
+  call — so a stale-build symptom is diagnosed immediately rather than
+  chased. Assembled by `re-frame2-pair-mcp.tools.freshness`."
   (:require [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.freshness :as freshness]))
 
 (defn- port-unresolved-result
   "Error envelope for a `:port` arg that didn't resolve to a build via
-  the `:dev-http` map (rf2-fyf0h)."
+  the `:dev-http` map."
   [port]
   (wire/ok-text
     {:ok?    false
@@ -37,13 +36,13 @@
     1. Explicit `:build` arg (or a build cached by a prior discover-app)
        — `wire/arg-build` carries a deliberate choice; honour it
        verbatim, never auto-select. Wins over `:port`.
-    2. `:port` arg (rf2-fyf0h) — resolve the serving build from the
+    2. `:port` arg — resolve the serving build from the
        shadow-cljs `:dev-http` map so an agent that only knows the
        browser URL (e.g. http://localhost:8031/...) needn't grep the
        repo for the build-id. A `:port` that resolves to no build is a
        loud `:port-unresolved` error — NOT a silent fall-through to the
        `:app` default (the operator asked for that port specifically).
-    3. Single running build (rf2-v70kv) — exactly one → auto-select +
+    3. Single running build — exactly one → auto-select +
        flag it. Zero/many → keep the `:app` default so the diagnostic
        ladder surfaces `:build-not-running` with the running list.
 
@@ -73,7 +72,7 @@
 
 (defn- with-auto-selection
   "Annotate an `:ok? true` discover-app payload with the auto-selection
-  fact (rf2-v70kv). No-op when the build was NOT auto-selected (an
+  fact. No-op when the build was NOT auto-selected (an
   explicit / cached / default build). When auto-selected, records
   `:auto-selected-build` and either seeds or prepends an auto-selection
   sentence to `:note` so the operator sees which build the no-arg call
@@ -91,7 +90,7 @@
 (defn- with-frame-resolution
   "Annotate a healthy (non-ambiguous) discover-app payload with the
   resolved operating frame and, when applicable, the auto-resolution
-  fact (rf2-3bu3d.4).
+  fact.
 
   `health` carries `:operating-frame` (the runtime's resolved frame),
   `:frames` (all registered), and `:app-frames` (frames with `:rf/*`
@@ -115,7 +114,7 @@
 
 (defn- with-freshness
   "Attach the assembled freshness/liveness token to an `:ok? true`
-  health payload (rf2-ertqw). Async — reads the JVM-side build worker
+  health payload. Async — reads the JVM-side build worker
   state and merges with the browser half already on `health`. The
   payload-shaping fn `shape` takes the freshness-annotated health map
   and returns the final MCP envelope. On a stale-BUILD verdict the
@@ -123,7 +122,7 @@
   already set) so the alarm rides at the top level too.
 
   `opts` carries the optional `:port` (the browser URL port discover-app
-  resolved the build from, rf2-jkwu4) so a non-fresh hint names the EXACT
+  resolved the build from) so a non-fresh hint names the EXACT
   `http://localhost:<port>` the human reloads to wake / refresh a quiet
   runtime — the agent can't reload a browser, so this is the early,
   actionable, human-in-the-loop signal."
@@ -144,7 +143,7 @@
 
 (defn- port-opts
   "Build the freshness `opts` map carrying the browser URL `:port` the
-  caller passed (rf2-jkwu4), or nil when no `:port` arg is present. The
+  caller passed, or nil when no `:port` arg is present. The
   port lets a non-fresh liveness hint name the EXACT
   `http://localhost:<port>` the human reloads to wake a quiet runtime.
   The port may arrive as a string off the MCP wire; coerce to an int so
@@ -181,7 +180,7 @@
 
               (empty? (:frames health))
               (js/Promise.resolve
-                ;; EP-0002 (rf2-bd4div) — `rf/init!` installs adapters /
+                ;; EP-0002 — `rf/init!` installs adapters /
                 ;; runtime capabilities; it does NOT register `:rf/default`
                 ;; (the runtime never synthesises a default frame — Spec 002
                 ;; §`:rf/default` is an ordinary id). The app registers its
@@ -196,7 +195,7 @@
 
               (:ambiguous-frame? health)
               (do
-                ;; rf2-l9ixp: even on the ambiguous-frame warning the
+                ;; Even on the ambiguous-frame warning the
                 ;; build-id is resolved — record it so subsequent tool
                 ;; calls (with the frame disambiguator) don't need to
                 ;; re-specify `:build`.
@@ -204,7 +203,7 @@
                 (with-freshness conn build-id
                   (assoc health :ok? true
                                 :warning :ambiguous-frame
-                                ;; rf2-3bu3d.4 — point the operator at the
+                                ;; Point the operator at the
                                 ;; APP frames (the real choices). `:rf/*`
                                 ;; tool frames (`:rf/xray`, …) were already
                                 ;; excluded from the ambiguity count, so
@@ -236,14 +235,14 @@
 
               :else
               (do
-                ;; rf2-l9ixp: cache the resolved build-id session-wide so
+                ;; Cache the resolved build-id session-wide so
                 ;; subsequent tool calls without an explicit `:build` arg
                 ;; default to it instead of the `SHADOW_CLJS_BUILD_ID` /
                 ;; `:app` env-var fallback. Invalidates on nREPL reconnect.
                 (wire/mark-resolved-build-id! conn build-id)
                 (with-freshness conn build-id
-                  ;; rf2-8t3ct — echo the CANONICAL `:build` keyword
-                  ;; alongside the historical `:build-id`. The two carry
+                  ;; Echo the CANONICAL `:build` keyword
+                  ;; alongside `:build-id`. The two carry
                   ;; the same value; `:build` matches the INPUT arg name so
                   ;; an agent copies it straight back into a later tool's
                   ;; `:build` slot (round-trippable). `fresh-keyword` reads

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -1,16 +1,15 @@
 (ns re-frame2-pair-mcp.tools.dispatch
   "Tool: dispatch — fire an event.
 
-  ## Why parse the `event` arg as EDN (rf2-vflrg)
+  ## Why parse the `event` arg as EDN
 
   The MCP `dispatch` surface is intentionally narrower than `eval-cljs`:
   the contract is `dispatch {event '[:ev/id ...]'}` — an EDN event
-  vector, nothing else. An earlier shape inlined the caller's string
-  verbatim into the generated eval form via `rt-raw`, which made the
-  string a host-form expression rather than data. Any caller (or a
-  prompt-injected agent) could supply arbitrary CLJS — `(println :pwn)`
-  would have run — defeating the boundary that gates `eval-cljs`
-  separately. Pre-alpha posture: this is gating the accident
+  vector, nothing else. Inlining the caller's string verbatim into the
+  generated eval form (as a host-form expression rather than data) would
+  let any caller — or a prompt-injected agent — supply arbitrary CLJS
+  (`(println :pwn)` would run), defeating the boundary that gates
+  `eval-cljs` separately. Parsing as EDN gates both the accident
   (\"I meant to dispatch an event, not execute code\") and the trivial
   malicious-string injection.
 
@@ -21,13 +20,13 @@
   `:reason :not-an-event-vector` error rather than reaching the
   runtime.
 
-  ## Render-settle — `:await-render` (rf2-gfu33)
+  ## Render-settle — `:await-render`
 
   `pair-dispatch-sync!` returns once the handler has committed app-db,
   but the substrate (Reagent / the React spine) re-renders on a LATER
-  tick — so \"dispatch then observe the DOM\" previously needed a manual
-  `requestAnimationFrame` dance inside `eval-cljs`. The `:await-render`
-  option makes `dispatch → observe` one deterministic step: the tool
+  tick. The `:await-render` option makes \"dispatch then observe the
+  DOM\" one deterministic step without a manual `requestAnimationFrame`
+  dance inside `eval-cljs`: the tool
   resolves only AFTER the substrate has flushed the new state to the
   DOM and the next paint has been scheduled.
 
@@ -39,7 +38,7 @@
   hook (Spec 006 §Substrate adapter contract). Each adapter publishes
   its substrate-native impl: Reagent maps it to `r/after-render`
   (post-commit), the UIx / Helix spine to a `React.useLayoutEffect`-
-  backed queue drain (post-commit / pre-paint, rf2-334d9), plain-atom /
+  backed queue drain (post-commit / pre-paint), plain-atom /
   SSR to `next-tick`. `after-render` fires once the DOM reflects the new
   state; the form then chains ONE `requestAnimationFrame` so resolution
   lands at the paint boundary. The MCP server therefore stays
@@ -56,7 +55,7 @@
   uses). A render-settle that doesn't complete within `:timeout-ms`
   (default 5000) returns `:reason :rf.error/dispatch-await-render-timeout`.
 
-  ## Dispatch-and-settle — `:settle` (rf2-vk79g)
+  ## Dispatch-and-settle — `:settle`
 
   `:settle true` closes the observe→drive loop SYNCHRONOUSLY and returns
   the COMPLETE epoch in ONE call: dispatch → flush renders → return the
@@ -94,7 +93,7 @@
   `:trace` / `:queued` when set (it is the most complete single-call
   shape).
 
-  ## Epoch-egress privacy — boot-gate signal + projection (rf2-8fin7.3)
+  ## Epoch-egress privacy — boot-gate signal + projection
 
   `dispatch` egresses epoch-derived sensitive payloads on THREE paths,
   all governed by the `--allow-sensitive-reads` boot gate
@@ -111,7 +110,7 @@
   off-box projection (`epoch_egress/project-dispatch-result-src` →
   `re-frame.core/projected-record`) APP-SIDE before the result crosses
   the wire, gated on `raw-state-allowed?` + the `:include-sensitive`
-  two-key opt-in (rf2-olvr5 finding 1) — sensitive leaves land as
+  two-key opt-in — sensitive leaves land as
   `:rf/redacted`, large slots elide, the cascade stays structurally
   useful.
 
@@ -121,11 +120,11 @@
   redacts the `:event-vector` only when `(not (:allow-raw-state?
   @raw-state-config))`, and `raw-state-config` DEFAULTS to
   `{:allow-raw-state? true}` — it flips to the server's gate state ONLY
-  when a tool signals. `dispatch` was the lone state-emitting tool that
-  never signalled, so a FIRST-in-session sensitive dispatch ran with
-  the runtime still permissive and shipped its raw event vector even
-  under the OFF gate. The signal closes that. Posture parity with
-  `dispatch-dry-run` (signal-runtime! + projected egress, same gate)."
+  when a tool signals. Signalling before the dispatch eval means even a
+  first-in-session sensitive dispatch runs with the runtime at the
+  server's gate state, so its raw event vector redacts to `:rf/redacted`
+  under the OFF gate. Posture parity with `dispatch-dry-run`
+  (signal-runtime! + projected egress, same gate)."
   (:require [cljs.reader]
             [clojure.string :as str]
             [re-frame2-pair-mcp.tools.args :as args]
@@ -183,31 +182,27 @@
 (defn- runtime-envelope->result
   "Translate the runtime dispatch fn's return into the wire envelope.
 
-  rf2-ldfnx — the runtime (`pair-dispatch!` / `pair-dispatch-sync!` /
+  The runtime (`pair-dispatch!` / `pair-dispatch-sync!` /
   `dispatch-and-collect`) returns a structured envelope. On real
   success it carries `:ok? true` (sync/trace) or `:queued? true`
   (queued) plus the cascade slots. On a frame-targeting failure it
   carries `:ok? false` with a `:reason` (`:no-new-epoch`,
   `:no-epoch-recorded`, …) — the dispatch did NOT land.
 
-  The pre-fix shape merged `{:mode <m>}` over whatever the runtime
-  returned and ALWAYS emitted a success (`ok-text`) envelope. A
-  frame-targeted dispatch that no-op'd (the runtime reporting
-  `:ok? false`) therefore rode back as `{:mode :sync}` with no
-  `:isError` flag — a silent wrong-success. The `:mode` slot is the
-  caller's signal that the dispatch took effect, so it MUST appear
-  only on a genuine landing.
+  The `:mode` slot is the caller's signal that the dispatch took effect,
+  so it appears ONLY on a genuine landing — never merged over a runtime
+  `:ok? false` (which would read as a silent wrong-success).
 
   Contract:
     - runtime `:ok? false`  ⇒ `err-text` (`:isError true`), NO `:mode`
       slot. The failure rides through verbatim so the caller sees the
-      structured `:reason`/`:hint`. This covers the rf2-3bu3d.3
+      structured `:reason`/`:hint`. This covers the
       `:reason :unknown-id` validation miss too — an unknown event-id
       surfaces as an error envelope carrying `:nearest` matches, NEVER
       a silent success.
     - queued mode whose cascade hasn't drained yet
       (`:cascade-summary-pending? true`) ⇒ `ok-text` with `:settled?
-      false` merged in (rf2-3bu3d.2) so the agent knows to
+      false` merged in so the agent knows to
       `watch-epochs` the eventual settlement.
     - otherwise (success / settled queued / non-map degraded runtime) ⇒
       `ok-text` with `{:mode <m>}` merged in."
@@ -215,7 +210,7 @@
   (if (and (map? v) (false? (:ok? v)))
     (wire/err-text v)
     (let [base (merge {:mode mode} (when (map? v) v))
-          ;; rf2-3bu3d.2 — async/queued that hasn't settled rides back
+          ;; Async/queued that hasn't settled rides back
           ;; with `:settled? false` so the consequence-vs-ack distinction
           ;; is explicit (the default sync path carries the consequence).
           base (cond-> base
@@ -226,7 +221,7 @@
       (wire/ok-text base))))
 
 ;; ---------------------------------------------------------------------------
-;; Render-settle — `:await-render` (rf2-gfu33).
+;; Render-settle — `:await-render`.
 ;;
 ;; The settle form runs the dispatch synchronously (so app-db has
 ;; committed and the substrate has been invalidated), then returns a
@@ -252,7 +247,7 @@
   return) with `:settled? true` already merged in by the settle form —
   route it through `runtime-envelope->result` so a frame-targeting
   failure (`:ok? false`) still surfaces as an `:isError` envelope, never
-  a silent `{:mode :sync}` success (the rf2-ldfnx invariant). Timeout /
+  a silent `{:mode :sync}` success. Timeout /
   malformed-sentinel surface as structured dispatch errors."
   [mode]
   {:on-resolved (fn [{:keys [value]}] (runtime-envelope->result mode value))
@@ -298,14 +293,14 @@
 (defn dispatch-tool [conn args]
   (let [event-str    (wire/arg args :event)
         build-id     (wire/arg-build conn args)
-        ;; rf2-vk79g: `:settle` is the most complete single-call shape —
+        ;; `:settle` is the most complete single-call shape —
         ;; dispatch → SYNCHRONOUS flush-render! → return the settled epoch
         ;; WITH its `:rf.view/render` / `:rf.view/unmounted` entries. It
         ;; routes to the runtime `dispatch-and-settle!` (fully synchronous
         ;; — no Promise / mailbox), so it wins over every other mode flag.
         settle?      (boolean (wire/arg args :settle))
         await-render? (boolean (and (wire/arg args :await-render) (not settle?)))
-        ;; rf2-wz66k7 — validate `:timeout-ms` as a positive-millisecond
+        ;; Validate `:timeout-ms` as a positive-millisecond
         ;; integer BEFORE it threads into `await-promise/poll-mailbox!`'s
         ;; `(>= elapsed timeout-ms)` deadline (the `:await-render` path).
         ;; A non-numeric value (`"never"`) makes `(>= n NaN)` never true ⇒
@@ -314,33 +309,32 @@
         ;; default. Bad value short-circuits to an honest isError below.
         timeout-r    (args/parse-timeout-arg "timeout-ms" (wire/arg args :timeout-ms))
         timeout-ms   (or (second timeout-r) await-promise/default-timeout-ms)
-        ;; rf2-gfu33: `:await-render` forces synchronous dispatch — the
+        ;; `:await-render` forces synchronous dispatch — the
         ;; cascade must have committed before the render can settle
         ;; against the new state. `:settle` likewise forces sync. An
         ;; explicit `:trace` still wins for the non-settle modes (the
         ;; caller asked for the assembled epoch); otherwise sync.
         sync?        (boolean (or (wire/arg args :sync) await-render? settle?))
         trace?       (boolean (and (wire/arg args :trace) (not settle?)))
-        ;; rf2-3bu3d.2 — `:queued true` opts INTO the async transport-ack
+        ;; `:queued true` opts INTO the async transport-ack
         ;; shape (`{:settled? false}`). Without it the default is the
         ;; SYNC CONSEQUENCE (`dispatch-consequence!`) so a no-op is
         ;; VISIBLE (`:db-changed? false :effects-fired []`) instead of a
         ;; fake ack. `:trace` / `:sync` / `:await-render` still win.
         queued?      (boolean (and (wire/arg args :queued)
                                    (not trace?) (not sync?) (not settle?)))
-        ;; rf2-ldfnx — coerce `frame` via the colon-tolerant
-        ;; `->frame-keyword` (the shared `fresh-keyword` path), NOT the
-        ;; raw `(keyword ...)` of `wire/arg-keyword`. The documented
-        ;; `frame` arg is the colon-prefixed id (`":rf/xray"`, `":foo"`
-        ;; — Tool-Catalogue §Id representation, rf2-cg37y). Raw
-        ;; `(keyword ":rf/xray")` mints the MALFORMED `::rf/xray`
-        ;; (namespace literally `":rf"`), which matches no registered
-        ;; frame — the runtime then no-op'd while the tool reported
-        ;; `{:mode :sync}`. `->frame-keyword` strips the leading colon
-        ;; so the frame routes the same way `eval-cljs` / `snapshot` /
-        ;; `replace-app-db` already route it.
+        ;; Coerce `frame` via the colon-tolerant `->frame-keyword` (the
+        ;; shared `fresh-keyword` path), NOT the raw `(keyword ...)` of
+        ;; `wire/arg-keyword`. The documented `frame` arg is the
+        ;; colon-prefixed id (`":rf/xray"`, `":foo"` — Tool-Catalogue §Id
+        ;; representation). Raw `(keyword ":rf/xray")` would mint the
+        ;; MALFORMED `::rf/xray` (namespace literally `":rf"`), which
+        ;; matches no registered frame — the runtime would no-op while the
+        ;; tool reported `{:mode :sync}`. `->frame-keyword` strips the
+        ;; leading colon so the frame routes the same way `eval-cljs` /
+        ;; `snapshot` / `replace-app-db` route it.
         frame        (some-> (wire/arg args :frame) args/->frame-keyword)
-        ;; rf2-hf7m9j — coerce override VALUES too. A plain
+        ;; Coerce override VALUES too. A plain
         ;; `(js->clj o :keywordize-keys true)` keywordizes object keys
         ;; only, leaving a documented `{":http": ":stub-http"}` target as
         ;; the string `":stub-http"`. Core's `resolve-fx-with-overrides`
@@ -351,7 +345,7 @@
         ;; and REJECTS any other value with a structured error.
         fx-r         (args/parse-fx-overrides (wire/arg args :fx-overrides))
         fx-overrides (when (= :ok (first fx-r)) (second fx-r))
-        ;; rf2-q6s1nb / EP-0010 + EP-0017 — caller-scripted recordable
+        ;; EP-0010 + EP-0017 — caller-scripted recordable
         ;; coeffects. The agent supplies `cofx "{:rf/time-ms …}"` (EDN data,
         ;; same data-not-source gate as `event`); the router PRESERVES the
         ;; supplied map verbatim and stamps only the framework-required
@@ -363,7 +357,7 @@
         ;; would reject deep in the eval.
         cofx-r       (args/parse-cofx (wire/arg args :cofx))
         cofx         (when (= :ok (first cofx-r)) (second cofx-r))
-        ;; rf2-v52xsr · EP-0017 §6 / Tool-Pair §Replay — the named STRICT
+        ;; EP-0017 §6 / Tool-Pair §Replay — the named STRICT
         ;; REPLAY affordance. `cofx` alone is the LIVE scripted-coeffect path
         ;; (the router's `:live` default — a declared-but-absent
         ;; generator-backed fact is freshly MINTED). Replay is the other
@@ -381,7 +375,7 @@
         ;; fact absent from the (empty) record halts. Bare colon-tolerant
         ;; boolean — no value parse needed.
         replay?      (boolean (wire/arg args :replay))
-        ;; rf2-olvr5 finding 1 — `:trace` (`dispatch-and-collect`) and
+        ;; `:trace` (`dispatch-and-collect`) and
         ;; `:settle` (`dispatch-and-settle!`) return RAW epoch material
         ;; (`:epoch` carrying `:db-before`/`:db-after`/`:trigger-event`/
         ;; `:trace-events`; `:settle` also `:render-events`). Unlike the
@@ -389,35 +383,35 @@
         ;; app-db — these MUST route through the framework's off-box
         ;; projection (`re-frame.core/projected-record`) before crossing
         ;; the nREPL/MCP wire, exactly as the pull-mode `trace-window` /
-        ;; `watch-epochs` surfaces do (rf2-6wvh5). The `--allow-sensitive-
-        ;; reads` boot gate (`raw-state-allowed?`, positive sense — true
-        ;; only when the operator opted in at launch) governs whether the
-        ;; per-call `:include-sensitive true` is honoured.
-        ;; rf2-m9duxl — `incl?` (gate-ON + `:include-sensitive true`) NO
-        ;; LONGER bypasses the epoch projection: the `:trace` / `:settle`
-        ;; epoch ALWAYS routes through `projected-record`, and `incl?`
-        ;; threads `{:include-sensitive? true}` INTO it (app-db sensitive
-        ;; axis only). The orthogonal fx-args / runtime-db / large axes
-        ;; and the app `:redact-fn` stay fail-closed regardless of
+        ;; `watch-epochs` surfaces do. The `--allow-sensitive-reads` boot
+        ;; gate (`raw-state-allowed?`, positive sense — true only when the
+        ;; operator opted in at launch) governs whether the per-call
+        ;; `:include-sensitive true` is honoured.
+        ;; `incl?` (gate-ON + `:include-sensitive true`) does NOT bypass
+        ;; the epoch projection: the `:trace` / `:settle` epoch ALWAYS
+        ;; routes through `projected-record`, and `incl?` threads
+        ;; `{:include-sensitive? true}` INTO it (app-db sensitive axis
+        ;; only). The orthogonal fx-args / runtime-db / large axes and the
+        ;; app `:redact-fn` stay fail-closed regardless of
         ;; `:include-sensitive` (Security.md §Off-box egress).
         incl?        (if (raw-state/raw-state-allowed?)
                        (boolean (wire/arg args :include-sensitive))
                        false)
         [tag payload] (parse-event-edn event-str)]
     (cond
-      ;; rf2-wz66k7 — a malformed `:timeout-ms` short-circuits to an honest
+      ;; A malformed `:timeout-ms` short-circuits to an honest
       ;; isError BEFORE the dispatch eval, rather than threading a value
       ;; that would spin the `:await-render` mailbox poll loop unbounded.
       (= :err (first timeout-r))
       (js/Promise.resolve (wire/err-text (second timeout-r)))
 
-      ;; rf2-hf7m9j — an invalid fx-overrides target short-circuits to an
+      ;; An invalid fx-overrides target short-circuits to an
       ;; honest isError rather than silently falling through to the real
       ;; fx (which the documented stub recipe promised was inert).
       (= :err (first fx-r))
       (js/Promise.resolve (wire/err-text (second fx-r)))
 
-      ;; rf2-q6s1nb · EP-0017 — a malformed `cofx` map (non-map / unreadable /
+      ;; EP-0017 — a malformed `cofx` map (non-map / unreadable /
       ;; non-integer :rf/time-ms) short-circuits to an honest isError before
       ;; the dispatch eval, rather than threading a value the runtime would
       ;; reject.
@@ -434,13 +428,13 @@
             opts-form (cond-> {}
                         frame        (assoc :frame frame)
                         fx-overrides (assoc :fx-overrides fx-overrides)
-                        ;; rf2-q6s1nb · EP-0017 — thread the scripted
+                        ;; EP-0017 — thread the scripted
                         ;; recordable coeffects under the flat `:rf.cofx` opts
                         ;; key the router reads. The map is `pr-str`'d as an
                         ;; EDN literal by `rt-call`'s arg-emit path, exactly
                         ;; like `:fx-overrides`.
                         cofx         (assoc :rf.cofx cofx)
-                        ;; rf2-v52xsr · EP-0017 §6 / Tool-Pair §Replay — the
+                        ;; EP-0017 §6 / Tool-Pair §Replay — the
                         ;; named replay affordance HARD-WIRES the strict mint
                         ;; policy alongside the recorded `:rf.cofx`. The
                         ;; per-call opt is the most-specific binding point and
@@ -449,13 +443,13 @@
                         ;; whether or not a `cofx` token was supplied (a record
                         ;; with no scripted facts still re-drives strict).
                         replay?      (assoc :rf.cofx/mint-policy :strict))
-            ;; rf2-vflrg: the event is now a parsed CLJS vector. Pass it
-            ;; through `rt-call`'s normal arg-emit path so it is `pr-str`'d
-            ;; as an EDN literal — the runtime fn receives data, not host
-            ;; source. NO `rt-raw` splice on this surface.
+            ;; The event is a parsed CLJS vector. Pass it through
+            ;; `rt-call`'s normal arg-emit path so it is `pr-str`'d as an
+            ;; EDN literal — the runtime fn receives data, not host source.
+            ;; NO `rt-raw` splice on this surface.
             ;;
-            ;; rf2-3bu3d.2 / rf2-3bu3d.3 — the DEFAULT (and explicit
-            ;; `:sync` / `:await-render`) routes through
+            ;; The DEFAULT (and explicit `:sync` / `:await-render`) routes
+            ;; through
             ;; `dispatch-consequence!`, which (a) VALIDATES the event-id
             ;; against the live `:event` registrar and returns a
             ;; structured `:unknown-id` error WITHOUT dispatching on a
@@ -465,11 +459,11 @@
             ;; a genuine no-op is visible. `:queued` opts into the async
             ;; settled?-false transport ack; `:trace` returns the full
             ;; assembled epoch.
-            ;; rf2-vk79g — `:settle` routes to the synchronous
+            ;; `:settle` routes to the synchronous
             ;; `dispatch-and-settle!` (dispatch-sync → flush-render! →
             ;; re-read the settled epoch). It returns a map directly, so
             ;; it rides the non-await prelude (ensure-runtime! →
-            ;; signal-runtime! → eval, rf2-8fin7.3) — no Promise / mailbox,
+            ;; signal-runtime! → eval) — no Promise / mailbox,
             ;; unlike `:await-render`.
             fn-sym     (cond settle? 'dispatch-and-settle!
                              trace?  'dispatch-and-collect
@@ -477,23 +471,22 @@
                              :else   'dispatch-consequence!)
             mode (cond settle? :settle trace? :trace queued? :queued :else :sync)]
         (if await-render?
-          ;; rf2-gfu33 — render-settle path. The form's synchronous
-          ;; return is a Promise; await it through the shared mailbox so
+          ;; Render-settle path. The form's synchronous return is a
+          ;; Promise; await it through the shared mailbox so
           ;; `dispatch → observe` is one deterministic step.
           (let [settle-form (render-settle-form fn-sym event-vec opts-form)
                 mailbox-id  (await-promise/mailbox-key)
                 wrapped     (await-promise/wrap-form settle-form mailbox-id)]
-            ;; rf2-8fin7.3 — the signalled prelude flips the boot-gate
-            ;; posture BEFORE the dispatch eval, exactly as
-            ;; `dispatch-dry-run` does. This sets the runtime's
-            ;; `raw-state-config` to the server's gate state (OFF by
-            ;; default) so the cascade-summary's `:event-vector` (the raw
-            ;; `:trigger-event`) redacts to `:rf/redacted` for a sensitive
-            ;; epoch — closing the path-3 leak (a first-in-session
-            ;; sensitive dispatch shipping its raw event vector under the
-            ;; default OFF gate). Without the signal the runtime stays at
-            ;; its permissive `{:allow-raw-state? true}` default and the
-            ;; redaction never fires. See raw-state/signal-runtime!.
+            ;; The signalled prelude flips the boot-gate posture BEFORE
+            ;; the dispatch eval, exactly as `dispatch-dry-run` does. This
+            ;; sets the runtime's `raw-state-config` to the server's gate
+            ;; state (OFF by default) so the cascade-summary's
+            ;; `:event-vector` (the raw `:trigger-event`) redacts to
+            ;; `:rf/redacted` for a sensitive epoch — even a
+            ;; first-in-session sensitive dispatch. Without the signal the
+            ;; runtime stays at its permissive `{:allow-raw-state? true}`
+            ;; default and the redaction never fires. See
+            ;; raw-state/signal-runtime!.
             (probe/eval-after-runtime-signalled!
               conn build-id wrapped :dispatch-failed
               (fn [sentinel]
@@ -501,7 +494,7 @@
                   conn build-id timeout-ms sentinel
                   (await-render-callbacks mode)))))
           (let [call-src (ef/emit (ef/rt-call fn-sym event-vec opts-form))
-                ;; rf2-olvr5 finding 1 — only the epoch-bearing modes
+                ;; Only the epoch-bearing modes
                 ;; (`:trace` / `:settle`) carry raw `:epoch` /
                 ;; `:render-events`; wrap their emitted form so the
                 ;; projection runs APP-SIDE (where the frame's
@@ -512,19 +505,19 @@
                 form     (if (contains? #{:trace :settle} mode)
                            (egress/project-dispatch-result-src call-src incl?)
                            call-src)]
-            ;; rf2-8fin7.3 — the signalled prelude issues the boot-gate
-            ;; signal between the preload probe and the dispatch eval (the
-            ;; snapshot / get-path / dispatch-dry-run prelude shape, NOT
-            ;; the bare `eval-after-runtime!`). `signal-runtime!` flips the
+            ;; The signalled prelude issues the boot-gate signal between
+            ;; the preload probe and the dispatch eval (the snapshot /
+            ;; get-path / dispatch-dry-run prelude shape, NOT the bare
+            ;; `eval-after-runtime!`). `signal-runtime!` flips the
             ;; runtime's `raw-state-config` to the server's gate state so
             ;; the DEFAULT cascade-summary's `:event-vector` (the raw
-            ;; `:trigger-event`) redacts under the OFF gate — closing the
-            ;; path-3 leak where a first-in-session sensitive dispatch
-            ;; shipped its raw event vector because the runtime was still
-            ;; at its permissive `{:allow-raw-state? true}` default. The
+            ;; `:trigger-event`) redacts under the OFF gate — even a
+            ;; first-in-session sensitive dispatch, which would otherwise
+            ;; ship its raw event vector while the runtime sits at its
+            ;; permissive `{:allow-raw-state? true}` default. The
             ;; `:trace` / `:settle` epoch slots are ALSO projected
-            ;; (egress/project-dispatch-result-src above, rf2-olvr5) — the
-            ;; two protections compose, mirroring dispatch-dry-run.
+            ;; (egress/project-dispatch-result-src above) — the two
+            ;; protections compose, mirroring dispatch-dry-run.
             (probe/eval-after-runtime-signalled!
               conn build-id form :dispatch-failed
               (fn [v] (runtime-envelope->result mode v))))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.dispatch-dry-run
-  "Tool: dispatch-dry-run — simulate a cascade without committing it (rf2-17hvp).
+  "Tool: dispatch-dry-run — simulate a cascade without committing it.
 
   Wraps the preload runtime's `dispatch-dry-run` primitive
   (`(rf/dispatch-dry-run event-v opts)`), which composes the
@@ -16,7 +16,7 @@
   app-db AND trims the assembled would-be epoch from the ring. There
   is no state change for the `--allow-writes` gate to protect against.
 
-  ## Why this IS `--allow-sensitive-reads`-gated (rf2-z7roa)
+  ## Why this IS `--allow-sensitive-reads`-gated
 
   Dry-run mutates nothing, but it is an AI-facing READ surface: the
   happy-path envelope returns the would-be app-db verbatim under
@@ -26,10 +26,10 @@
   from app-db, so a stock MCP session could leak those to the model
   even though the `--allow-sensitive-reads` default is OFF.
 
-  The fix reuses the EXISTING read-surface posture (snapshot /
-  get-path / subscribe, rf2-c2dtu / rf2-vflrg) rather than minting a
-  new confirmation gate. The two egress slots egress under DIFFERENT
-  policies because they are different keyspaces:
+  It reuses the read-surface posture of snapshot / get-path /
+  subscribe rather than minting a new confirmation gate. The two egress
+  slots egress under DIFFERENT policies because they are different
+  keyspaces:
 
     - `:db-state-after-simulation` (the would-be app-db) is run
       through `re-frame.core/elide-wire-value` SERVER-SIDE (app-side,
@@ -51,7 +51,7 @@
       prove them safe. This is the same leak class as an epoch
       record's `:effects[*].args`, which `projected-record` already
       FAILS CLOSED off-box (`elide-effect-row`). Consistency wins
-      (rf2-6to9xj, EP-0015 §13 residual): off-box egress fails closed
+      (EP-0015 §13): off-box egress fails closed
       here too — `:args` redacts to `:rf/redacted` for EVERY recorded
       fx BY DEFAULT, while the value-free row structure (`:fx-id`, the
       effect kind) rides through so the operator still sees WHICH
@@ -66,9 +66,9 @@
     - `:cascade-summary` is a depth-bounded projection (path lists +
       counts, not verbatim values) so it rides through unwalked, the
       same way `dispatch` / `replace-app-db` / `restore-epoch` surface
-      it (rf2-6yqdl).
+      it.
 
-  ## Raw-state tap signal (rf2-z7roa / rf2-c2dtu)
+  ## Raw-state tap signal
 
   The dry-run primitive internally calls `restore-epoch` to roll back,
   and the preload's tap-emitting surfaces default to RAW payloads until
@@ -78,7 +78,7 @@
   the runtime's tap consumers see the gated (default-elided) posture
   too — not just the wire payload.
 
-  ## event arg is EDN data (rf2-vflrg posture)
+  ## event arg is EDN data
 
   Identical to `dispatch` — the `event` arg is parsed as EDN
   server-side and required to be a vector. Host-form source
@@ -95,7 +95,7 @@
   happen if the http call resolved to this stub response?') without
   losing the dry-run's roll-back guarantee.
 
-  ## Accepts scripted recordable coeffects (rf2-3q7gep · EP-0017)
+  ## Accepts scripted recordable coeffects (EP-0017)
 
   EP-0017 makes `:rf.cofx` a first-class dispatch edge for exact
   recordable facts (`:rf/time-ms`, provided boundary facts, and
@@ -157,7 +157,7 @@
 
 (defn- redact-fx-args-src
   "CLJS source for a fn that FAIL-CLOSES the `:would-fire-effects[*]
-  :args` slot of the runtime envelope (rf2-6to9xj, EP-0015 §13 residual).
+  :args` slot of the runtime envelope (EP-0015 §13).
 
   Each recorded fx call's `:args` is the RAW fx-handler argument — an
   HTTP request body, a dispatched event vector, a payment map. These are
@@ -198,7 +198,7 @@
 
 (defn- elide-envelope-src
   "CLJS source for a fn that walks the runtime envelope's app-db-rooted
-  egress slot through `re-frame.core/elide-wire-value` (rf2-z7roa):
+  egress slot through `re-frame.core/elide-wire-value`:
 
     - `:db-state-after-simulation` — the would-be app-db verbatim.
 
@@ -210,13 +210,13 @@
   The `:would-fire-effects[*].args` slot is NOT walked here — those are
   RAW fx-handler args (HTTP bodies, dispatched event vectors, payment
   maps) that are NOT app-db-rooted, so the walker cannot prove them safe.
-  They fail closed via `redact-fx-args-src` (rf2-6to9xj), matching
+  They fail closed via `redact-fx-args-src`, matching
   `projected-record`'s `:effects[*].args` posture, independently of
   whether this size-elision walker runs at all.
 
   `:cascade-summary` is a depth-bounded projection (path lists + counts,
   not verbatim values) and is intentionally NOT walked, matching the
-  other cascade-summary surfaces (rf2-6yqdl).
+  other cascade-summary surfaces.
 
   Only the happy-path envelope (`:ok? true`) carries the db slot, so a
   soft-failure envelope (`:no-epoch-recorded` / `:no-new-epoch`) flows
@@ -241,8 +241,8 @@
   (let [event-str    (wire/arg raw-args :event)
         build-id     (wire/arg-build conn raw-args)
         frame        (some-> (wire/arg raw-args :frame) args/->frame-keyword)
-        ;; rf2-hf7m9j — coerce override VALUES (colon-prefixed string ->
-        ;; keyword) and REJECT any other value. A raw `js->clj
+        ;; Coerce override VALUES (colon-prefixed string -> keyword) and
+        ;; REJECT any other value. A raw `js->clj
         ;; :keywordize-keys true` leaves a `{":http": ":stub-http"}`
         ;; target as the string `":stub-http"`, which core silently falls
         ;; through to the original fx — for dry-run that defeats the
@@ -250,8 +250,8 @@
         ;; recording stub and fire the real effect). See `parse-fx-overrides`.
         fx-r         (args/parse-fx-overrides (wire/arg raw-args :fx-overrides))
         fx-overrides (when (= :ok (first fx-r)) (second fx-r))
-        ;; rf2-3q7gep · EP-0017 — caller-scripted recordable coeffects, the
-        ;; same data-not-source gate `dispatch` already carries. The agent
+        ;; EP-0017 — caller-scripted recordable coeffects, the
+        ;; same data-not-source gate `dispatch` carries. The agent
         ;; supplies `cofx "{:rf/time-ms …}"` (EDN data, parsed by the SHARED
         ;; `args/parse-cofx`) so a dry-run of a time-dependent or
         ;; provided-cofx event runs against the EXACT causal token the
@@ -264,10 +264,10 @@
         ;; value the runtime's `:rf/dispatch-opts` validation would reject.
         cofx-r       (args/parse-cofx (wire/arg raw-args :cofx))
         cofx         (when (= :ok (first cofx-r)) (second cofx-r))
-        ;; rf2-z7roa — dry-run is an AI-facing READ surface (it returns
-        ;; the would-be app-db + recorded fx args). Gate its egress on
-        ;; the SAME `--allow-sensitive-reads` posture as snapshot /
-        ;; get-path / subscribe (rf2-c2dtu / rf2-vflrg). Gate OFF (the
+        ;; Dry-run is an AI-facing READ surface (it returns the would-be
+        ;; app-db + recorded fx args). Gate its egress on the SAME
+        ;; `--allow-sensitive-reads` posture as snapshot / get-path /
+        ;; subscribe. Gate OFF (the
         ;; default) forces the walker on (`elision` true) and forces
         ;; sensitive slots to redact (`include-sensitive` false); gate
         ;; ON lets the per-call args win.
@@ -277,7 +277,7 @@
         incl?        (if (raw-state/raw-state-allowed?)
                        (args/parse-bool-arg raw-args :include-sensitive)
                        false)
-        ;; rf2-6to9xj — :would-fire-effects[*].args are RAW fx-handler
+        ;; :would-fire-effects[*].args are RAW fx-handler
         ;; arguments NOT rooted at app-db, so `elide-wire-value` cannot
         ;; prove them safe (same leak class as an epoch record's
         ;; :effects[*].args). Off-box egress FAILS CLOSED: :args redacts to
@@ -288,30 +288,30 @@
         incl-fx-args? (if (raw-state/raw-state-allowed?)
                         (args/parse-bool-arg raw-args :include-fx-args)
                         false)
-        ;; rf2-suoj2 — `elision-opts-edn` takes the walker-aligned
-        ;; `include-large?` polarity directly. MCP `elision` true =
-        ;; emit markers = `:include-large?` false; hence `(not elision?)`.
+        ;; `elision-opts-edn` takes the walker-aligned `include-large?`
+        ;; polarity directly. MCP `elision` true = emit markers =
+        ;; `:include-large?` false; hence `(not elision?)`.
         elision-opts (elision/elision-opts-edn (not elision?) incl?)
-        ;; rf2-t55hxg.13 — fail-CLOSED: the size walker over the app-db-
-        ;; rooted `:db-state-after-simulation` slot runs UNLESS the caller
-        ;; opted into BOTH raw axes (`:elision false` AND `:include-sensitive
+        ;; Fail-CLOSED: the size walker over the app-db-rooted
+        ;; `:db-state-after-simulation` slot runs UNLESS the caller opted
+        ;; into BOTH raw axes (`:elision false` AND `:include-sensitive
         ;; true`). A bare `:elision false` still walks so a declared-
         ;; sensitive db slot redacts to `:rf/redacted` while large content
-        ;; passes. Pre-fix the walker gated on `elision?` alone, so a gate-
-        ;; ON `:elision false` leaked sensitive db state off-box. (The fx-
-        ;; args fail-close at stage 1 is independent and unaffected.)
+        ;; passes — a gate-ON `:elision false` must not leak sensitive db
+        ;; state off-box. (The fx-args fail-close at stage 1 is
+        ;; independent and unaffected.)
         walk?        (elision/walk-required? (not elision?) incl?)
         frame-edn    (if frame
                        (pr-str frame)
                        (ef/emit (ef/rt-call 'current-frame)))
         [tag payload] (parse-event-edn event-str)]
     (cond
-      ;; rf2-hf7m9j — reject an invalid fx-overrides target up front so a
+      ;; Reject an invalid fx-overrides target up front so a
       ;; string stub can't silently defeat the no-fx-execute guarantee.
       (= :err (first fx-r))
       (js/Promise.resolve (wire/err-text (second fx-r)))
 
-      ;; rf2-3q7gep · EP-0017 — a malformed `cofx` map (non-map / unreadable
+      ;; EP-0017 — a malformed `cofx` map (non-map / unreadable
       ;; / non-integer :rf/time-ms) short-circuits to an honest isError
       ;; before the dispatch eval, the same gate `dispatch` applies, rather
       ;; than threading a value the runtime would reject deep in the eval.
@@ -326,7 +326,7 @@
             opts-form (cond-> {}
                         frame        (assoc :frame frame)
                         fx-overrides (assoc :fx-overrides fx-overrides)
-                        ;; rf2-3q7gep · EP-0017 — thread the scripted
+                        ;; EP-0017 — thread the scripted
                         ;; recordable coeffects under the flat `:rf.cofx`
                         ;; opts key the router reads, exactly as `dispatch`
                         ;; does. The map is `pr-str`'d as an EDN literal by
@@ -339,7 +339,7 @@
             ;; transform it server-side in two composed stages (the walker
             ;; reaches the live elision registry only app-side):
             ;;
-            ;;   1. fx-args fail-close (rf2-6to9xj, ALWAYS) — the
+            ;;   1. fx-args fail-close (ALWAYS) — the
             ;;      `:would-fire-effects[*].args` slot carries RAW fx-handler
             ;;      arguments that are NOT app-db-rooted, so the size walker
             ;;      cannot prove them safe. Off-box egress fails closed:
@@ -348,7 +348,7 @@
             ;;      `:include-fx-args true`). This runs on BOTH the
             ;;      elision-on and elision-off paths — turning the size
             ;;      walker off must NOT re-leak the unprovable fx args.
-            ;;   2. size-elision walk (rf2-z7roa, when `elision?`) — the
+            ;;   2. size-elision walk (when `elision?`) — the
             ;;      app-db-rooted `:db-state-after-simulation` slot runs
             ;;      through `re-frame.core/elide-wire-value`; the marker
             ;;      count piggybacks on the same round-trip so the client
@@ -375,10 +375,10 @@
           conn build-id form :dispatch-dry-run-failed
           (fn [resp]
                      ;; Eval-form shape: `{:value <env> :elided-count N}`
-                     ;; (matching snapshot / get-path, rf2-e35a5). The
-                     ;; runtime fn ALWAYS returns a map, so an unwrapped
-                     ;; non-map `:value` means a degraded / pre-rf2-17hvp
-                     ;; runtime answered — surface it as `:unexpected-shape`.
+                     ;; (matching snapshot / get-path). The runtime fn
+                     ;; ALWAYS returns a map, so an unwrapped non-map
+                     ;; `:value` means a degraded runtime answered —
+                     ;; surface it as `:unexpected-shape`.
                      (let [new-shape? (and (map? resp) (contains? resp :elided-count))
                            env        (if new-shape? (:value resp) resp)
                            elided     (when new-shape? (:elided-count resp))
@@ -387,17 +387,16 @@
                                           (assoc env :elision elision?)
                                           {:elided (or elided 0)})
                                         {:ok? false :reason :unexpected-shape :value env})]
-                       ;; rf2-wdxyx3 finding 2 — a known-tool runtime
-                       ;; failure (`:ok? false`, e.g. the reducer rejected
-                       ;; the event / an interceptor early-returned →
-                       ;; `:no-new-epoch`, or a degraded runtime →
-                       ;; `:unexpected-shape`) MUST ride back as an
+                       ;; A known-tool runtime failure (`:ok? false`, e.g.
+                       ;; the reducer rejected the event / an interceptor
+                       ;; early-returned → `:no-new-epoch`, or a degraded
+                       ;; runtime → `:unexpected-shape`) rides back as an
                        ;; `isError` envelope, matching the dispatch /
                        ;; read-sub no-silent-success parity model and the
-                       ;; published wire contract. The old `ok-text` shape
-                       ;; let a non-landed dry-run read as green. The
-                       ;; structured `:reason`/`:hint` rides through
-                       ;; verbatim so the caller still sees why.
+                       ;; published wire contract — a non-landed dry-run
+                       ;; must not read as green. The structured
+                       ;; `:reason`/`:hint` rides through verbatim so the
+                       ;; caller still sees why.
                        (if (false? (:ok? result))
                          (wire/err-text result)
                          (wire/ok-text result)))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
@@ -1,13 +1,13 @@
 (ns re-frame2-pair-mcp.tools.elision
-  "Size-elision wire markers (rf2-urjnc).
+  "Size-elision wire markers.
 
-  The sixth wire-protocol mechanism — alongside `:rf.mcp/summary`,
+  One of the wire-protocol mechanisms — alongside `:rf.mcp/summary`,
   `:rf.mcp/overflow`, `:rf.mcp/diff-from`, `:rf.mcp/dedup-table`, and
-  `:rf.mcp/cache-hit` (rf2-3rt1f). After diff-encoding (rf2-1wdzp)
-  collapses each `:db-after`, and dedup (rf2-obpa9) pools repeated
+  `:rf.mcp/cache-hit`. After diff-encoding
+  collapses each `:db-after`, and dedup pools repeated
   subtrees, a single large slot — say a 100KB uploaded PDF base64 on
   `[:user :uploaded-pdf]` — still rides the wire verbatim. The
-  framework's size-elision walker (`rf/elide-wire-value`, rf2-v9tw2)
+  framework's size-elision walker (`rf/elide-wire-value`)
   substitutes such slots with a `{:rf.size/large-elided {...}}` marker
   carrying a fetch handle (`[:rf.elision/at <path>]`). Agents drill
   back into the slot via `get-path` using the handle's path.
@@ -27,12 +27,11 @@
   - `snapshot` tool: each frame's `:app-db` AND `:sub-cache` slices are
     run through the walker before slice-app-db-in-snapshot sees them.
     The `:sub-cache` arm pins the Tool-Pair contract that direct reads
-    of `(rf/sub-cache frame-id)` MUST route through `elide-wire-value`
-    (rf2-vflrg).
+    of `(rf/sub-cache frame-id)` MUST route through `elide-wire-value`.
   - `get-path` tool: the value at the requested path is run through
     the walker before pr-str.
   - `list-subscriptions :include-values` tool: each sub-cache entry's
-    `:value` is run through the walker server-side (rf2-f1ose), mirroring
+    `:value` is run through the walker server-side, mirroring
     `snapshot`'s `:sub-cache` slice — the two read the same reactive
     cache source, so both MUST redact alike off-box.
 
@@ -45,9 +44,9 @@
   ## `:elision` MCP arg
 
   Boolean opt-out. Default `true`. The arg is parsed by the shared
-  `re-frame2-pair-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh).
+  `re-frame2-pair-mcp.tools.args/parse-bool-arg` table.
 
-  ## `:include-sensitive` MCP arg (rf2-vflrg)
+  ## `:include-sensitive` MCP arg
 
   The same `:include-sensitive` flag that gates trace / epoch
   forwarding (spec/009 §Privacy) also gates whether the walker treats
@@ -56,12 +55,12 @@
   (`:rf.size/include-sensitive? false`, the default). Off-box default
   per Tool-Pair §`Direct-read privacy posture for sub-cache and
   get-path`: sensitive slots are dropped unless the caller opts in
-  explicitly. The MCP wire-key drops the trailing `?` per rf2-y710n +
-  rf2-ihq4d (Anthropic's tool-input-schema regex rejects `?`); the
+  explicitly. The MCP wire-key has no trailing `?` (Anthropic's
+  tool-input-schema regex rejects `?`); the
   walker-option keyword `:rf.size/include-sensitive?` is a namespaced
   framework key (not on the wire) and retains the predicate `?`.
 
-  ## Named `:rf.egress/*` profiles (EP-0015 §10, rf2-qus09h)
+  ## Named `:rf.egress/*` profiles (EP-0015 §10)
 
   The direct-read surfaces (`snapshot` / `get-path` / `subscribe` /
   `read-sub` / `list-subscriptions` / `record` / `watch-until`) are an
@@ -90,7 +89,7 @@
             [re-frame.mcp-base.egress :as base-egress]))
 
 ;; ---------------------------------------------------------------------------
-;; Named `:rf.egress/*` profile adoption (EP-0015 §10, rf2-qus09h).
+;; Named `:rf.egress/*` profile adoption (EP-0015 §10).
 ;;
 ;; The MCP posture (the `--allow-sensitive-reads` gate + the per-call
 ;; `:include-sensitive` opt-in, already collapsed to a single boolean
@@ -103,17 +102,17 @@
 (defn walk-required?
   "Decide whether an AI-facing read surface MUST run the per-slot egress
   walker (`re-frame.core/elide-wire-value`) over an app-db-rooted value
-  before it crosses the off-box MCP wire (EP-0015, rf2-t55hxg.13).
+  before it crosses the off-box MCP wire (EP-0015).
 
   The walker is the ONLY thing on the direct-read surfaces that redacts a
-  frame-declared-sensitive slot to `:rf/redacted`. Pre-rf2-t55hxg.13 every
-  call site gated the walker on `elision?` alone — the *large-slot* toggle
-  — so a caller under the trusted-local `--allow-sensitive-reads` gate
-  could pass `:elision false` WITHOUT the per-call `:include-sensitive
-  true` opt-in and still pull raw sensitive values off-box. That collapsed
-  EP-0015's two-key sensitive opt-in (`spec/015-Data-Classification.md`,
-  `spec/Tool-Pair.md`): the large toggle silently doubled as a sensitive
-  bypass.
+  frame-declared-sensitive slot to `:rf/redacted`. The walker decision is
+  gated on BOTH the large-slot toggle AND the sensitive opt-in — never on
+  `elision?` alone. That keeps EP-0015's two-key sensitive opt-in intact
+  (`spec/015-Data-Classification.md`, `spec/Tool-Pair.md`): the large
+  toggle never doubles as a sensitive bypass, so a caller under the
+  trusted-local `--allow-sensitive-reads` gate that passes `:elision
+  false` WITHOUT the per-call `:include-sensitive true` opt-in still
+  cannot pull raw sensitive values off-box.
 
   Fail-CLOSED invariant: the walker runs UNLESS the caller has explicitly
   opted into BOTH raw axes — large content (`:elision false`, so
@@ -142,7 +141,7 @@
 
 (defn posture->profile
   "Resolve the off-box egress POSTURE of a direct-read tool surface to a
-  named `:rf.egress/*` profile (EP-0015 §10, rf2-qus09h).
+  named `:rf.egress/*` profile (EP-0015 §10).
 
   `include-sensitive?` is the already-gated, already-opted-in boolean each
   tool computes (`(and (raw-state-allowed?) per-call-include-sensitive)`):
@@ -166,7 +165,7 @@
   "Render the elision opts map as an EDN string for inlining into a
   CLJS eval form sent over nREPL.
 
-  Resolution (EP-0015 §10, rf2-qus09h): the egress POSTURE
+  Resolution (EP-0015 §10): the egress POSTURE
   (`include-sensitive?`) names a `:rf.egress/*` profile via
   `posture->profile`; the framework's `re-frame.projection/profile-size-opts`
   resolves that profile to its `:rf.size/*` floor (the single source of
@@ -175,7 +174,7 @@
   it overlays `:rf.size/include-large? true` (a caller turning elision off
   keeps large content even under the off-box-tool floor).
 
-  Knobs (rf2-suoj2 — both follow the walker-opt polarity so the helper
+  Knobs (both follow the walker-opt polarity so the helper
   is symmetric across the two `:rf.size/*` opts):
 
   - `include-large?`      — when true, `:rf.size/include-large?` is
@@ -195,20 +194,17 @@
   switch (true = apply the walker = emit markers). The walker opt
   `:rf.size/include-large?` is the *walker-facing* pass-through switch
   (true = no marker). The two are inverse views of the same Boolean.
-  Pre-rf2-suoj2 the helper buried the inversion (`(not enabled?)`)
-  alongside the `include-sensitive?` arg's pass-through parsing —
-  sibling opts with opposite parsing rules. The helper now treats both
-  opts uniformly via the profile floor + the explicit `include-large?`
-  overlay; call sites compute `(not elision?)` once and pass
-  `include-large?` in directly.
+  The helper treats both opts uniformly via the profile floor + the
+  explicit `include-large?` overlay; call sites compute `(not elision?)`
+  once and pass `include-large?` in directly.
 
   Both knobs default off-box-safe per the Tool-Pair §Direct-read
   privacy posture contract — large slots elide, sensitive slots
   redact, unless the caller opts in explicitly.
 
-  Single-arity form retains the legacy default (`include-sensitive?`
-  false ⇒ `:rf.egress/off-box-tool`) so legacy call-sites don't need to
-  spell it out."
+  Single-arity form applies the off-box-safe default (`include-sensitive?`
+  false ⇒ `:rf.egress/off-box-tool`) so call-sites that don't reveal
+  sensitive data needn't spell it out."
   ([include-large?]
    (elision-opts-edn include-large? false))
   ([include-large? include-sensitive?]
@@ -225,7 +221,7 @@
 
 (defn elide-sub-value-src
   "CLJS source for a fn that walks ONE sub-cache entry's `:value` slot
-  through `re-frame.core/elide-wire-value` (rf2-f1ose).
+  through `re-frame.core/elide-wire-value`.
 
   Returns a source string for an anonymous fn `(fn [entry] ...)` that
   runs `entry`'s `:value` (the subscription's current deref) through the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/epoch_egress.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/epoch_egress.cljs
@@ -1,20 +1,20 @@
 (ns re-frame2-pair-mcp.tools.epoch-egress
-  "Off-box projection wrap for the pull-mode epoch tools (rf2-6wvh5).
+  "Off-box projection wrap for the pull-mode epoch tools.
 
   `trace-window` and `watch-epochs` egress full epoch records — each
   carrying `:db-before` / `:db-after` app-db snapshots (plus
-  `:trigger-event` / `:trace-events`) — over the MCP wire. Before
-  rf2-6wvh5 the page of records the runtime shipped rode the nREPL wire
-  verbatim: the `:epoch-vector` wire-pipeline arm
+  `:trigger-event` / `:trace-events`) — over the MCP wire. The
+  `:epoch-vector` wire-pipeline arm
   (`re-frame2-pair-mcp.tools.wire-pipeline`) only DROPS whole epochs
   STAMPED `:rf.epoch/sensitive?` and then diff-encodes / dedups the rest
   — none of which redact a declared-sensitive SLOT (e.g.
-  `[:auth :password]`) sitting inside `:db-before` / `:db-after`. So a
-  schema-declared `:sensitive?` slot rode off-box verbatim even with the
-  `--allow-sensitive-reads` gate OFF (the published default).
+  `[:auth :password]`) sitting inside `:db-before` / `:db-after`. Without
+  the projection this ns applies, a schema-declared `:sensitive?` slot
+  would ride off-box verbatim even with the `--allow-sensitive-reads`
+  gate OFF (the published default).
 
   The framework forbids exactly this hand-walk. `re-frame.core`
-  (core.cljc §projected egress, rf2-mrsck) names `projected-record` /
+  (core.cljc §projected egress) names `projected-record` /
   `projected-history` the single normative off-box-egress emission site
   and states that tools egressing the epoch ring MUST route through it
   rather than walking `(epoch-history frame-id)` and re-wrapping by hand
@@ -32,7 +32,7 @@
   the records the MCP server receives already carry `:rf/redacted` /
   `:rf.size/large-elided` markers in their payload slots.
 
-  ## Gate parity with snapshot / get-path / subscribe (rf2-c2dtu)
+  ## Gate parity with snapshot / get-path / subscribe
 
   The `--allow-sensitive-reads` boot gate (`raw-state/raw-state-allowed?`)
   governs whether a caller's `:include-sensitive true` is honoured. The
@@ -41,7 +41,7 @@
   - Gate OFF (default) — `include-sensitive` is forced false, so
     `project?` is true: every egressed record is routed through
     `projected-record` under the `:rf.egress/off-box-tool` profile
-    (rf2-nmjcll — sensitive slots redact, large slots elide WITH the
+    (sensitive slots redact, large slots elide WITH the
     structural digest the tool needs). A hostile per-call
     `:include-sensitive true` cannot talk an operator who did not pass
     `--allow-sensitive-reads` into shipping raw state.
@@ -50,7 +50,7 @@
     operator's explicit opt-in. This is the operator's deliberate choice
     to see verbatim state.
 
-  ## Named-egress profile: `:rf.egress/off-box-tool` (rf2-nmjcll)
+  ## Named-egress profile: `:rf.egress/off-box-tool`
 
   Pair-MCP is an OFF-BOX TOOL WIRE — epoch records cross to an external
   agent — so per Tool-Pair.md §Named-egress profile adoption (EP-0015 §10)
@@ -59,44 +59,44 @@
   default. Both share the redact/elide floor (sensitive → `:rf/redacted`,
   large → `:rf.size/large-elided`); off-box-tool additionally carries the
   `:rf.size/include-digests?` structural indicators a tool needs to reason
-  about an elided slot's shape. Omitting the profile shipped the
-  hosted-observability marker — a fail-degraded contract gap, closed by
-  `egress-opts-edn` naming the profile unconditionally.
+  about an elided slot's shape. `egress-opts-edn` names the profile
+  unconditionally, so the off-box wire always ships the tool marker, never
+  the less-informative hosted-observability one.
 
   `projected-record` is the framework's single off-box emission site — it
   carries hard `:include-sensitive? false` / `:include-large? false`
   defaults and handles all four payload-bearing slots
   (`:db-before`, `:db-after`, `:trigger-event`, `:trace-events`)
-  including the `:trace-events` per-event re-root (rf2-ta0y7). Using it
+  including the `:trace-events` per-event re-root. Using it
   directly (rather than a per-slot `elide-wire-value` hand-walk) keeps
   the projection single-sourced in the framework and removes the
   \"one missed slot\" leak surface the core docstring warns about.
 
-  ## `:include-sensitive` routes THROUGH projection, never around it (rf2-m9duxl)
+  ## `:include-sensitive` routes THROUGH projection, never around it
 
   The `--allow-sensitive-reads` boot gate + per-call `:include-sensitive
   true` opt-in does NOT disable `projected-record`. It is threaded as the
   `:include-sensitive? true` egress opt INTO the projection (composed OVER
-  the `:rf.egress/off-box-tool` profile floor — rf2-nmjcll), lifting ONLY
+  the `:rf.egress/off-box-tool` profile floor), lifting ONLY
   the app-db sensitive axis. The other independent projection axes stay at
   their fail-closed defaults regardless of `:include-sensitive`:
 
   - `:effects[*].args` (payload-bearing fx-handler input) stay
     `:rf/redacted` — they are a different keyspace from app-db sensitive
     values, governed by the orthogonal `:include-fx-args?` opt
-    (rf2-rlt3sv / Security.md §Off-box egress).
+    (Security.md §Off-box egress).
   - the `:rf.db/runtime` frame-state partition stays `:rf/redacted` —
-    governed by the orthogonal `:include-runtime-db?` opt (rf2-5w06uu).
+    governed by the orthogonal `:include-runtime-db?` opt.
   - app-db `:large?` slots stay `:rf.size/large-elided` — governed by the
     independent `:include-large?` opt.
   - the app-installed `:redact-fn` advanced override still runs over the
     projected record.
 
-  Pre-rf2-m9duxl these tools treated `:include-sensitive true` as a FULL
-  raw epoch bypass — `(not incl?)` disabled projection wholesale — which
-  conflated the app-db sensitive axis with every other axis and shipped
-  the raw fx-args / runtime-db partition / un-`:redact-fn`'d record. That
-  contradicted Security.md §98-108 (off-box epoch egress MUST route through
+  `:include-sensitive` lifts only the app-db sensitive axis — it is NOT a
+  full raw epoch bypass. The app-db sensitive axis is independent of every
+  other axis, so the raw fx-args / runtime-db partition / un-`:redact-fn`'d
+  record never ship merely because sensitive app-db values were requested.
+  This holds Security.md §98-108 (off-box epoch egress MUST route through
   `projected-record`; `:include-fx-args?` is orthogonal to app-db
   `:include-sensitive?` / `:include-large?`) and the EP-0015 projected-record
   contract. There is no app-db-`:include-sensitive`-implied raw escape
@@ -106,9 +106,9 @@
 
 (defn egress-opts-edn
   "Render the `projected-record` egress opts as an EDN string for inlining
-  into a CLJS eval form (rf2-m9duxl, rf2-nmjcll).
+  into a CLJS eval form.
 
-  ## Named-egress profile: `:rf.egress/off-box-tool` on EVERY path (rf2-nmjcll)
+  ## Named-egress profile: `:rf.egress/off-box-tool` on EVERY path
 
   Pair-MCP is an OFF-BOX TOOL WIRE — epoch records cross to an external
   agent — so per Tool-Pair.md §Named-egress profile adoption (EP-0015 §10)
@@ -120,11 +120,11 @@
   needs to reason about an elided slot's shape. The off-box-tool profile
   turns digests ON. Both boundaries fail-closed identically on the
   sensitive / large redaction axes (projection.cljc §profile->size-opts);
-  the ONLY difference the profile makes here is the digest indicators, so
-  this is a fail-degraded contract gap (the off-box wire shipped the
-  hosted-observability marker, less informative than the tool profile the
-  direct-read surfaces already resolve via `tools.elision`), not a raw-data
-  leak. The named selector is the framework's primary boundary answer —
+  the ONLY difference the profile makes here is the digest indicators —
+  the off-box-tool marker is more informative than the
+  hosted-observability one (the same tool profile the direct-read
+  surfaces resolve via `tools.elision`), and neither leaks raw data. The
+  named selector is the framework's primary boundary answer —
   *\"which boundary is this?\"* — and a pair-MCP epoch wire is always the
   tool boundary. So the profile is emitted UNCONDITIONALLY (default + the
   trusted-local sensitive opt-in path alike); it is never the
@@ -132,7 +132,7 @@
 
   `incl?` is the resolved `:include-sensitive` opt-in (the
   `--allow-sensitive-reads` boot gate AND the per-call arg — see each
-  tool's `incl?` derivation). When true it adds the legacy unqualified
+  tool's `incl?` derivation). When true it adds the unqualified
   `:include-sensitive? true` ADVANCED override on TOP of the profile floor
   — lifting ONLY the app-db sensitive axis through the projection (the
   override composes over the off-box-tool floor per
@@ -143,7 +143,7 @@
   orthogonal `:include-fx-args?` / `:include-runtime-db?` / `:include-large?`
   axes stay at their fail-closed off-box-tool floor — `:include-sensitive`
   alone never lifts fx-args, the runtime-db partition, or large-slot
-  elision (Security.md §Off-box egress; rf2-rlt3sv / rf2-5w06uu)."
+  elision (Security.md §Off-box egress)."
   [incl?]
   (if incl?
     "{:rf.egress/profile :rf.egress/off-box-tool :include-sensitive? true}"
@@ -151,22 +151,21 @@
 
 (defn project-dispatch-result-src
   "CLJS source that projects the epoch-bearing slots of a dispatch
-  `:trace` / `:settle` result map for off-box egress (rf2-olvr5
-  finding 1). `result-src` is a raw CLJS expression that evaluates to
-  the runtime dispatch fn's return (a map, or a non-map degraded value).
+  `:trace` / `:settle` result map for off-box egress. `result-src` is a
+  raw CLJS expression that evaluates to the runtime dispatch fn's return
+  (a map, or a non-map degraded value).
 
   `dispatch-and-collect` (`:trace`) returns the cascade envelope PLUS a
   full `:epoch` — the verbatim assembled `:rf/epoch-record` carrying
   `:db-before` / `:db-after` / `:trigger-event` / `:trace-events` app-db
   snapshots. `dispatch-and-settle!` (`:settle`) additionally returns
   `:render-events` — the view-lifecycle trace events folded out of that
-  epoch's `:trace-events`. Both rode the nREPL/MCP wire VERBATIM before
-  this fix, bypassing the framework's off-box projection: a schema-
-  declared `:sensitive?` slot inside `:db-before`/`:db-after` (or inside
-  a render event's `:rf.event/db` tag) leaked to the MCP/LLM boundary
-  with `--allow-sensitive-reads` OFF (the published default) — the same
-  hole rf2-6wvh5 closed for the pull-mode `trace-window` / `watch-epochs`
-  surfaces.
+  epoch's `:trace-events`. Both carry app-db material, so without this
+  projection a schema-declared `:sensitive?` slot inside
+  `:db-before`/`:db-after` (or inside a render event's `:rf.event/db`
+  tag) would leak to the MCP/LLM boundary with `--allow-sensitive-reads`
+  OFF (the published default) — the same surface the pull-mode
+  `trace-window` / `watch-epochs` tools guard.
 
   The emitted source ALWAYS routes `:epoch` through
   `re-frame.core/projected-record` (the single normative off-box-egress
@@ -179,7 +178,7 @@
 
   `incl?` (the resolved `:include-sensitive` opt-in) is threaded as the
   `{:include-sensitive? true}` egress opt INTO `projected-record` — NOT as a
-  projection bypass (rf2-m9duxl). It lifts ONLY the app-db sensitive axis;
+  projection bypass. It lifts ONLY the app-db sensitive axis;
   fx-args / runtime-db / large slots / `:redact-fn` stay at their
   fail-closed defaults. There is no `:include-sensitive`-implied raw escape
   hatch — the epoch always crosses the wire projected.
@@ -215,13 +214,13 @@
 
   The emitted source ALWAYS maps each record through
   `re-frame.core/projected-record` under the `:rf.egress/off-box-tool`
-  egress profile (rf2-nmjcll — Pair-MCP is an off-box tool wire; see
+  egress profile (Pair-MCP is an off-box tool wire; see
   `egress-opts-edn`) — sensitive payload slots land as `:rf/redacted`,
   large slots as `:rf.size/large-elided` markers CARRYING the structural
-  `:digest` the tool profile enables. There is no projection bypass
-  (rf2-m9duxl): a page NEVER crosses the off-box wire unprojected, and it
-  NEVER crosses under the bare 1-arity hosted-observability default (which
-  would omit the tool digests — rf2-nmjcll).
+  `:digest` the tool profile enables. There is no projection bypass: a
+  page NEVER crosses the off-box wire unprojected, and it NEVER crosses
+  under the bare 1-arity hosted-observability default (which would omit
+  the tool digests).
 
   `incl?` (the resolved `:include-sensitive` opt-in — the
   `--allow-sensitive-reads` boot gate AND the per-call arg) is threaded as
@@ -229,20 +228,19 @@
   composed OVER the off-box-tool floor, lifting ONLY the app-db sensitive
   axis. The orthogonal fx-args / runtime-db / large axes and the app
   `:redact-fn` stay at their fail-closed off-box-tool defaults regardless of
-  `:include-sensitive` (Security.md §Off-box egress; rf2-rlt3sv /
-  rf2-5w06uu). Before rf2-m9duxl `:include-sensitive true` disabled
-  projection wholesale, shipping the raw fx-args / runtime-db partition /
-  un-`:redact-fn`'d record — the conflation rf2-m9duxl closes.
+  `:include-sensitive` (Security.md §Off-box egress). `:include-sensitive`
+  never disables projection wholesale: the raw fx-args / runtime-db
+  partition / un-`:redact-fn`'d record stay redacted regardless.
 
   `projected-record` returns `nil` for non-map input; the page is a
   vector of epoch-record maps, so the `mapv` is total. The fn is a pure
-  data transform with no side effects. Both `incl?` branches now thread the
-  named profile through a fn literal — the bare 1-arity reference is gone
-  (it could not name the off-box-tool boundary — rf2-nmjcll)."
+  data transform with no side effects. Both `incl?` branches thread the
+  named profile through a fn literal so the off-box-tool boundary is named
+  on every record."
   [page-sym incl?]
   (let [p        (name page-sym)
         opts-edn (egress-opts-edn incl?)]
     ;; #(projected-record % {:rf.egress/profile :rf.egress/off-box-tool …}) via
     ;; a fn literal so the named off-box-tool boundary (+ any sensitive
-    ;; opt-in) rides into EVERY record's projection (rf2-nmjcll).
+    ;; opt-in) rides into EVERY record's projection.
     (str "(mapv (fn [r#] (re-frame.core/projected-record r# " opts-edn ")) " p ")")))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
@@ -1,7 +1,7 @@
 (ns re-frame2-pair-mcp.tools.eval-cljs
   "Tool: eval-cljs — evaluate one CLJS form.
 
-  ## Launch-flag gate (rf2-a0z0h; inverts the prior rf2-cxx5s default)
+  ## Launch-flag gate
 
   The eval-cljs tool is the REPL primitive of a pair-debug session —
   arbitrary form evaluation against the live re-frame2 runtime is the
@@ -13,14 +13,15 @@
 
   ### Threat-model rationale
 
-  The prior rf2-cxx5s gate (default OFF) parallelled `--allow-writes`
-  in shape but not in effect. `--allow-writes` is load-bearing because
+  A default-OFF eval gate would parallel `--allow-writes` in shape but
+  not in effect. `--allow-writes` is load-bearing because
   pair-tool writes can confuse the debug audit trail (\"did my app
-  produce this state change, or did the pair tool?\"). `--allow-eval`
-  did NOT parallel that protection: eval-cljs can express any write
+  produce this state change, or did the pair tool?\"). An eval gate
+  does NOT parallel that protection: eval-cljs can express any write
   the writes-gate would block. The two gates are not independent —
   once eval is on, writes are de-facto on. So a default-OFF eval
-  surface added friction without adding a separable protection.
+  surface would add friction without adding a separable protection,
+  which is why this surface defaults ON.
 
   The real defence is **don't expose this MCP to untrusted callers**.
   Once an operator has installed re-frame2-pair-mcp and wired it into
@@ -34,16 +35,17 @@
   `--no-eval` flips it to `false`. Tests flip the atom directly via
   `set-eval-allowed!`.
 
-  ## Opt-in Promise awaiting (rf2-xn4f9)
+  ## Opt-in Promise awaiting
 
   `cljs-eval` captures the synchronous return value of the form and
   `pr-str`'s it. When the form returns a JS Promise — any async work
   (`fetch`, `.layout()`, `async` fns, anything chained with `.then`) —
   the synchronous return IS the Promise object; `pr-str` produces a
   `\"#object[Promise ...]\"` string that says \"I'm a Promise\" with no
-  access to the eventually-resolved value. The historical workaround
-  was a two-call mailbox dance (stash on `js/window`, return a sentinel,
-  read the global on a second call, repeat-poll until resolved).
+  access to the eventually-resolved value. Resolving such a value by
+  hand is a two-call mailbox dance (stash on `js/window`, return a
+  sentinel, read the global on a second call, repeat-poll until
+  resolved).
 
   When the caller passes `:await true`, the server automates that
   dance:
@@ -81,20 +83,19 @@
       `Promise.resolve` or a multi-second layout computation; the
       server shouldn't pick.
 
-  The default `:await false` preserves today's semantics — the form's
-  synchronous return is `pr-str`'d and returned verbatim. Callers
+  The default `:await false` keeps the synchronous semantics — the
+  form's synchronous return is `pr-str`'d and returned verbatim. Callers
   who DO want to wait on a Promise opt in explicitly and pick the
   deadline.
 
-  ## Frame targeting (rf2-ntuzf)
+  ## Frame targeting
 
-  Every other structured op (`dispatch`, `snapshot`, `get-path`,
-  `trace-window`, `watch-epochs`, `subscribe`, `replace-app-db`)
-  accepts an optional `:frame` arg targeting a named frame. Pre-
-  rf2-ntuzf `eval-cljs` did NOT — the form ran against whatever
-  ambient frame context existed at the call site.
+  `eval-cljs`, like every other structured op (`dispatch`, `snapshot`,
+  `get-path`, `trace-window`, `watch-epochs`, `subscribe`,
+  `replace-app-db`), accepts an optional `:frame` arg targeting a named
+  frame.
 
-  EP-0002 (rf2-bd4div) — with no `:frame` arg the form carries NO frame
+  EP-0002 — with no `:frame` arg the form carries NO frame
   stamp, so a frame-scoped op inside it (`rf/subscribe` / `rf/dispatch` /
   `rf/current-frame-id`) raises the always-on `:rf.error/no-frame-context`
   rather than silently targeting a synthesised `:rf/default` (`:rf/default`
@@ -119,12 +120,12 @@
   capture a `frame-handle` (or wrap via `frame-bound-fn` /
   `frame-bound-fn*`) so the captured ops survive the boundary).
 
-  ## Mailbox machinery extracted (rf2-gfu33)
+  ## Mailbox machinery
 
   The browser-side Promise mailbox dance (`wrap-form`, the read/poll
-  forms, the sentinel dispatcher) moved to
+  forms, the sentinel dispatcher) lives in
   `re-frame2-pair-mcp.tools.await-promise` so `dispatch :await-render`
-  can reuse the SAME proven plumbing. This ns now supplies only the
+  reuses the SAME proven plumbing. This ns supplies only the
   eval-cljs result vocabulary (`:value` / `:rf.error/eval-cljs-*`) via
   the callback seam `await-promise/handle-sentinel` exposes."
   (:require [clojure.string :as str]
@@ -153,8 +154,8 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Await mode — wrap the user's form to detect thenables + automate the
-;; mailbox dance (rf2-xn4f9). The mailbox plumbing lives in
-;; `await-promise` (rf2-gfu33); this ns supplies only the eval-cljs
+;; mailbox dance. The mailbox plumbing lives in
+;; `await-promise`; this ns supplies only the eval-cljs
 ;; result vocabulary via the callback seam.
 ;; ---------------------------------------------------------------------------
 
@@ -203,8 +204,8 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- wrap-in-frame
-  "Wrap `form-str` in `(re-frame.core/with-frame <frame-kw> <form>)`
-  per rf2-ntuzf. Returns the wrapped source verbatim — callers feed
+  "Wrap `form-str` in `(re-frame.core/with-frame <frame-kw> <form>)`.
+  Returns the wrapped source verbatim — callers feed
   this into the await wrapper or send it straight over nREPL.
 
   `frame-kw` is emitted as an EDN literal via `pr-str` so a kebab-case
@@ -223,7 +224,7 @@
         build-id   (wire/arg-build conn args)
         explicit?  (wire/arg-build-explicit? conn args)
         await?     (boolean (wire/arg args :await))
-        ;; rf2-wz66k7 — validate `:timeout-ms` as a positive-millisecond
+        ;; Validate `:timeout-ms` as a positive-millisecond
         ;; integer BEFORE it threads into `await-promise/poll-mailbox!`'s
         ;; `(>= elapsed timeout-ms)` deadline. A non-numeric value
         ;; (`"never"`) makes `(>= n NaN)` never true ⇒ the mailbox poll
@@ -231,7 +232,7 @@
         ;; times out immediately. Absent ⇒ the documented default.
         timeout-r  (args/parse-timeout-arg "timeout-ms" (wire/arg args :timeout-ms))
         timeout-ms (or (second timeout-r) await-promise/default-timeout-ms)
-        ;; rf2-ntuzf — optional `:frame` arg targets a named frame for
+        ;; Optional `:frame` arg targets a named frame for
         ;; the form's lexical scope. Same coercion as dispatch/
         ;; snapshot/get-path: bare names (\"rf/default\") and EDN-
         ;; shaped strings (\":rf/default\") both accepted.
@@ -255,11 +256,11 @@
                         :hint "usage: eval-cljs {form '<cljs-form>' [build :app] [await true] [timeout-ms 5000] [frame :rf/xray]}"}))
 
       :else
-      ;; rf2-ivlb3: resolve the build (auto-detect the single running one
+      ;; Resolve the build (auto-detect the single running one
       ;; when no explicit :build was passed) and confirm a live runtime
       ;; BEFORE eval'ing. Never emit `:ok? true :value nil` for a build
       ;; with no runtime — that's indistinguishable from a genuine nil.
-      (let [;; rf2-ntuzf: apply the with-frame wrap before await
+      (let [;; Apply the with-frame wrap before await
             ;; wrapping. The await wrap operates on whatever source
             ;; we send over the wire; with-frame is just additional
             ;; outer-CLJS so it composes orthogonally with await.
@@ -268,7 +269,7 @@
             (.then (fn [resolved-build]
                      (if-not await?
                        ;; Default path — wrap the form in the typed
-                       ;; result codec (rf2-qobqy) so a genuine nil, an
+                       ;; result codec so a genuine nil, an
                        ;; unresolved-symbol throw, and an unserializable
                        ;; value are DISTINCT tagged outcomes instead of
                        ;; collapsing to a bare nil. The runtime
@@ -295,10 +296,10 @@
                                    (if (renv/error? result)
                                      (wire/err-text result)
                                      (wire/ok-text result)))))))
-                       ;; Await path (rf2-xn4f9) — wrap the form, dispatch
+                       ;; Await path — wrap the form, dispatch
                        ;; on the sentinel, poll the mailbox if needed. The
-                       ;; mailbox plumbing lives in `await-promise`
-                       ;; (rf2-gfu33); we supply the eval-cljs result
+                       ;; mailbox plumbing lives in `await-promise`;
+                       ;; we supply the eval-cljs result
                        ;; vocabulary via the callback seam.
                        (let [mailbox-id (await-promise/mailbox-key)
                              wrapped    (await-promise/wrap-form user-form mailbox-id)]
@@ -309,7 +310,7 @@
                                         (sentinel-callbacks resolved-build timeout-ms)))))))))
             (.catch
               (fn [err]
-                ;; rf2-mvdwv — a compile warning/error (unresolved symbol,
+                ;; A compile warning/error (unresolved symbol,
                 ;; syntax/arity error) rejects with a structured
                 ;; `:rf.error/eval-cljs-compile-error` ex-info from
                 ;; `cljs-eval-value`. Surface it as a proper `:isError`

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
@@ -1,20 +1,18 @@
 (ns re-frame2-pair-mcp.tools.eval-form
-  "Mini-DSL for composing the CLJS eval forms tools ship over nREPL
-  (rf2-dpzpe).
+  "Mini-DSL for composing the CLJS eval forms tools ship over nREPL.
 
-  Several call-sites — `dispatch`, `trace-window`, `watch-epochs`,
+  Many call-sites — `dispatch`, `trace-window`, `watch-epochs`,
   `snapshot`, `get-path`, `subscribe`, `subscribe`'s drain/unsubscribe
   loop forms, `list-subscriptions` (reactive sub-cache), `list-streams`
-  (streaming-tap registry), `unsubscribe`, plus `precheck-form` —
-  build CLJS source strings by raw `str` concatenation. Two costs:
+  (streaming-tap registry), `unsubscribe`, plus `precheck-form` — need
+  CLJS source strings. Building them by raw `str` concatenation carries
+  two costs this DSL avoids:
 
-  1. The runtime namespace prefix (`re-frame2-pair.runtime/`)
-     appeared verbatim at 17+ sites — one rename, seventeen edits.
-  2. Tests had to `cljs.reader/read-string` a substring back out
-     of the source to assert on the embedded EDN
-     (`subscribe-test.cljs` line 96-98). The string-as-IR shape
-     made the test fragile against whitespace / formatting drifts
-     in the form-builder.
+  1. The runtime namespace prefix (`re-frame2-pair.runtime/`) would
+     appear verbatim at every call-site, so a rename touches them all.
+  2. Tests would have to `cljs.reader/read-string` a substring back out
+     of the source to assert on the embedded EDN, making them fragile
+     against whitespace / formatting drifts in the form-builder.
 
   This namespace gives a tiny tagged-vector IR with a single
   `emit` recursion:
@@ -62,7 +60,7 @@
 
 (def runtime-ns
   "The CLJS namespace every `rt-call` resolves into. Centralised here so
-  a future runtime rename is one edit, not seventeen."
+  a runtime rename is a single edit."
   "re-frame2-pair.runtime")
 
 (defn rt-call
@@ -107,7 +105,7 @@
   (strings, keywords, numbers, scalar maps, scalar vectors, …) is
   `pr-str`'d as an EDN literal.
 
-  rf2-lbfzu — without the collection-recursion arm, a mixed
+  Without the collection-recursion arm, a mixed
   data-and-nodes vector like `(rt-call 'foo [bar (rt-raw \"x\")])`
   would `pr-str` the whole vector including the `[::raw \"x\"]` IR
   node, producing garbage source. The recursion lets callers mix
@@ -162,10 +160,9 @@
                       ")"))
 
         ::call* (let [[_ qsym args] form]
-                  ;; rf2-lbfzu — `(str qsym)` handles both shapes
+                  ;; `(str qsym)` handles both shapes
                   ;; uniformly: a symbol prints as its fully-qualified
-                  ;; name, a string prints verbatim. The prior `if`
-                  ;; had two identical arms.
+                  ;; name, a string prints verbatim.
                   (str "(" (str qsym)
                        (when (seq args)
                          (apply str (for [a args] (str " " (emit-arg a)))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/freshness.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/freshness.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.freshness
-  "Freshness / liveness token (rf2-ertqw).
+  "Freshness / liveness token.
 
   ## The problem this closes
 
@@ -14,8 +14,8 @@
       blank, indistinguishable from a form that genuinely returns nil;
     - a STALE incremental build is serving OLD code → the runtime is
       alive and answering, but it's running code from before your last
-      edit. THIS is the silent killer — the rf2-lo28u false-alarm detour
-      was ~30 min of debugging a 'bug' that was just a stale build.
+      edit. THIS is the silent killer — a stale build masquerades as a
+      runtime bug and can burn long debugging detours.
 
   The freshness token makes all three OBVIOUS up front, on the very
   first `discover-app` call (and optionally on any op result). The
@@ -39,8 +39,7 @@
       :compile-cycle        MONOTONIC build counter (shadow's
                             `::build/build-info :compile-cycle`). Bumps
                             on every successful compile. This is the
-                            'is my edit live?' monotonic id (subsumes
-                            rf2-3bu3d.5 — see the bead).
+                            'is my edit live?' monotonic id.
       :build-flushed-at     wall-clock ms of the build's last flush
                             (shadow's `:flush-complete`). The compile
                             that produced the bytes currently on disk.
@@ -57,8 +56,7 @@
     :fresh           runtime connected, heartbeat recent, build NOT
                      recompiled since the runtime loaded.
     :stale-build     the build flushed AFTER the runtime loaded — the
-                     browser is serving OLD code. RELOAD THE PAGE. (The
-                     rf2-lo28u killer.)
+                     browser is serving OLD code. RELOAD THE PAGE.
     :no-runtime      no REPL runtime connected for the build (WS dropped
                      / no tab open).
     :unknown         the JVM half couldn't be read after a retry — degrade
@@ -67,9 +65,9 @@
                      Ctrl-C'd without freeing its ports; the socket reaches
                      a runtime whose build worker is in a DIFFERENT JVM, so
                      the worker lookup misses). The hint names the
-                     `npx shadow-cljs stop` → single-watch remediation
-                     (rf2-646lr). Rarer: an old shadow without get-worker,
-                     or a transient socket hiccup.
+                     `npx shadow-cljs stop` → single-watch remediation.
+                     Rarer: an old shadow without get-worker, or a
+                     transient socket hiccup.
 
   Everything here is best-effort: a JVM probe failure degrades to the
   browser half plus `:liveness :unknown`. The token is a DIAGNOSTIC
@@ -148,7 +146,7 @@
   "One JVM round-trip reading the build-worker freshness half for
   `build-id`. Resolves to the parsed map or nil (unreadable / blank /
   non-map / socket hiccup). The single-attempt primitive
-  `jvm-build-freshness` retries over (rf2-jkwu4)."
+  `jvm-build-freshness` retries over this."
   [conn build-id]
   (-> (try
         (nrepl/jvm-eval conn (build-state-jvm-form build-id))
@@ -160,7 +158,7 @@
 
 (defn retry-once-on-nil
   "Run the Promise-returning thunk `read!`; if it resolves to a non-map
-  (nil / blank), run it ONCE more and return that (rf2-jkwu4). A nil read
+  (nil / blank), run it ONCE more and return that. A nil read
   of the build-worker state is most often a TRANSIENT socket hiccup, so
   one retry recovers the common case before the caller degrades to the
   non-actionable `:liveness :unknown`. The retry round-trip is paid only
@@ -182,7 +180,7 @@
   read), so a never-connected / stub conn never triggers a real TCP
   connect.
 
-  ## One retry before degrading (rf2-jkwu4)
+  ## One retry before degrading
 
   A `:liveness :unknown` verdict is degraded and non-actionable — the
   agent can't tell the runtime is live and only finds out when a later
@@ -222,7 +220,7 @@
     :fresh         runtime connected, heartbeat recent, build not
                    recompiled since load.
     :unknown       the JVM half is absent (couldn't read shadow state —
-                   most often a multiple/zombie-shadow JVM split, rf2-646lr).
+                   most often a multiple/zombie-shadow JVM split).
 
   Order matters: `:no-runtime` wins over `:stale-build` (you can't be
   serving stale code if nothing's connected), and both win over
@@ -249,8 +247,8 @@
     :fresh))
 
 (defn- reload-target
-  "The concrete thing the human reloads to wake/refresh the runtime
-  (rf2-jkwu4). Prefer the app URL when the port is known (the agent then
+  "The concrete thing the human reloads to wake/refresh the runtime.
+  Prefer the app URL when the port is known (the agent then
   relays ONE crisp instruction — `reload http://localhost:<port>`);
   otherwise name the build so `shadow-cljs watch <build>` is unambiguous."
   [{:keys [port build-id]}]
@@ -267,7 +265,7 @@
   resolved the build from) + `:build-id` so the `:no-runtime` / `:unknown`
   hints can name the EXACT thing the human reloads — the agent cannot
   reload a browser itself, so a non-fresh verdict is an early, crisp
-  human-in-the-loop instruction, not a self-heal (rf2-jkwu4)."
+  human-in-the-loop instruction, not a self-heal."
   [liveness {:keys [build-flushed-at runtime-loaded-at build-id] :as ctx}]
   (let [target (reload-target ctx)]
     (case liveness
@@ -323,7 +321,7 @@
 
   The optional 4-arity `opts` carries `:port` (the browser URL port the
   caller knows — discover-app's `:port` arg) so a non-fresh hint names
-  the EXACT `http://localhost:<port>` the human reloads (rf2-jkwu4).
+  the EXACT `http://localhost:<port>` the human reloads.
   `:port` rides on the token too, so the agent can relay it.
 
   Best-effort: a nil JVM half degrades to `:liveness :unknown` with the
@@ -367,10 +365,10 @@
 (defn token-from-health
   "Convenience: extract the browser half from a `health` map and
   assemble the full token. `health` carries `:runtime-instance-id`,
-  `:runtime-loaded-at`, and `:read-at` (rf2-ertqw added them). Returns a
+  `:runtime-loaded-at`, and `:read-at`. Returns a
   Promise of the token map.
 
-  The optional 4-arity `opts` carries `:port` (rf2-jkwu4) so a non-fresh
+  The optional 4-arity `opts` carries `:port` so a non-fresh
   hint can name `http://localhost:<port>` — the EXACT URL the human
   reloads to wake / refresh a quiet runtime."
   ([conn build-id health] (token-from-health conn build-id health nil))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -1,6 +1,5 @@
 (ns re-frame2-pair-mcp.tools.get-path
-  "Tool: get-path — direct read-by-path against a frame's app-db
-   (rf2-tygdv).
+  "Tool: get-path — direct read-by-path against a frame's app-db.
 
   Minimal, focused primitive. The `snapshot` tool is the right surface
   when the agent doesn't know yet which slice carries the answer;
@@ -11,25 +10,24 @@
 
   Path vocabulary mirrors `get-in`: a vector of keys / indices.
 
-  ## Batch read — the plural `paths` arg (rf2-lbm21)
+  ## Batch read — the plural `paths` arg
 
-  Reading N app-db paths used to need N `get-path` calls (or a
-  fallback `eval-cljs`). The `paths` arg (a vector of path vectors)
-  reads them all in ONE round-trip: the runtime resolves each path
-  server-side and returns `{:ok? true :results {<path> {:exists? bool
-  :value <subtree>}}}`. `:path` (singular) and `:paths` (plural) are
-  mutually exclusive surfaces on the same tool — passing both is a
-  usage error. Each value is elided server-side exactly as the
-  singular surface does; the batch reuses the same elision opts and the
-  same wire-pipeline `:scalar-value` arm (the whole `:results` map is
-  the scalar). Extending the existing tool (rather than minting a new
-  `get-paths`) keeps the catalogue, the skill allow-list, and the
-  wire-vocab surface unchanged — the agent that knows `get-path` knows
-  the batch form for free.
+  The `paths` arg (a vector of path vectors) reads N app-db paths in
+  ONE round-trip: the runtime resolves each path server-side and
+  returns `{:ok? true :results {<path> {:exists? bool :value
+  <subtree>}}}`. `:path` (singular) and `:paths` (plural) are mutually
+  exclusive surfaces on the same tool — passing both is a usage error.
+  Each value is elided server-side exactly as the singular surface
+  does; the batch reuses the same elision opts and the same
+  wire-pipeline `:scalar-value` arm (the whole `:results` map is the
+  scalar). Folding the batch into this tool (rather than minting a
+  separate `get-paths`) keeps the catalogue, the skill allow-list, and
+  the wire-vocab surface unchanged — the agent that knows `get-path`
+  knows the batch form for free.
 
   Post-eval shrink pipeline lives in
-  `re-frame2-pair-mcp.tools.wire-pipeline` (rf2-ae8ie). The eval form
-  ran `re-frame.core/elide-wire-value` server-side already; the
+  `re-frame2-pair-mcp.tools.wire-pipeline`. The eval form ran
+  `re-frame.core/elide-wire-value` server-side already; the
   `:scalar-value` arm of `run-wire-pipeline` just counts the
   resulting `:rf.size/large-elided` markers."
   (:require [re-frame2-pair-mcp.tools.eval-form :as ef]
@@ -59,10 +57,10 @@
   the frame) then `get-in` with a missing sentinel, so `path-not-found`
   is distinguishable from a path that legitimately points at nil. The
   deepest-valid-prefix loop is inlined so a stale runtime (no helper)
-  still answers correctly. Elision (rf2-urjnc) + server-side marker
-  count (rf2-e35a5) ride on the `:value` / `:elided-count` slots.
+  still answers correctly. Elision + server-side marker count ride on
+  the `:value` / `:elided-count` slots.
 
-  `walk?` (rf2-t55hxg.13) — whether the per-slot walker fires at all. It
+  `walk?` — whether the per-slot walker fires at all. It
   is NOT `elision?`: a bare `:elision false` still walks (sensitive
   redacts, large passes); only a deliberate full-raw opt-in
   (`:elision false` AND `:include-sensitive true`) skips it."
@@ -97,7 +95,7 @@
                "  {:ok? true :exists? true :path path :value elided-v :elided-count n})"))))))
 
 (defn batch-paths-form
-  "Eval form for the plural `:paths` batch read (rf2-lbm21). Resolves
+  "Eval form for the plural `:paths` batch read. Resolves
   the frame's db ONCE, then folds over the paths — each gets the same
   `get-in`-with-missing-sentinel + elision treatment as the singular
   form. Returns `{:results {<path> {:exists? bool :value <elided>}}
@@ -106,7 +104,7 @@
   order. The marker `:path` handle is the per-iteration path `p` so a
   drill-down via singular `get-path` lands on the right slot.
 
-  `walk?` (rf2-t55hxg.13) — see `single-path-form`: the walker fires
+  `walk?` — see `single-path-form`: the walker fires
   unless the caller opted into full-raw egress."
   [snapshot-call paths walk? frame-edn elision-opts]
   (let [elide-call (elide-call-src walk? "raw-v" "p" frame-edn elision-opts)]
@@ -132,43 +130,42 @@
         frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         path      (args/parse-path-arg (wire/arg raw-args :path))
         paths     (args/parse-paths-arg (wire/arg raw-args :paths))
-        ;; rf2-qef58 — wholesale-read backstop (built once; consulted in
-        ;; the `cond` below). nil when the read is allowed.
+        ;; Wholesale-read backstop (built once; consulted in the `cond`
+        ;; below). nil when the read is allowed.
         refused   (guard/get-path-refusal frame path paths)
-        ;; rf2-c2dtu — when the `--allow-sensitive-reads` boot gate is OFF,
-        ;; the per-call `:elision false` arg is overridden so the walker
-        ;; still fires. rf2-p1qli: single intention-naming predicate
+        ;; When the `--allow-sensitive-reads` boot gate is OFF, the
+        ;; per-call `:elision false` arg is overridden so the walker
+        ;; still fires. A single intention-naming predicate
         ;; `raw-state-allowed?` (positive sense — true when operator
         ;; opted in at launch); the gate-off branch forces elision true.
         elision?  (if (raw-state/raw-state-allowed?)
                     (args/parse-bool-arg raw-args :elision)
                     true)
-        ;; rf2-vflrg — `:include-sensitive` threads into the walker's
+        ;; `:include-sensitive` threads into the walker's
         ;; `:rf.size/include-sensitive?` opt. Off-box default per
         ;; Tool-Pair §`Direct-read privacy posture for sub-cache and
         ;; get-path`: declared-sensitive slots redact unless the caller
         ;; opts in explicitly. The shared `parse-bool-arg` table
-        ;; (rf2-c4fmh) gates the default at `false`.
+        ;; gates the default at `false`.
         ;;
-        ;; rf2-c2dtu — when the `--allow-sensitive-reads` boot gate is OFF,
-        ;; the per-call `:include-sensitive true` arg is dropped before
+        ;; When the `--allow-sensitive-reads` boot gate is OFF, the
+        ;; per-call `:include-sensitive true` arg is dropped before
         ;; reaching the walker.
         incl?     (if (raw-state/raw-state-allowed?)
                     (args/parse-bool-arg raw-args :include-sensitive)
                     false)
-        ;; rf2-suoj2 — `elision-opts-edn` takes walker-aligned
-        ;; `include-large?` polarity directly. MCP `elision` true =
-        ;; emit markers = `:include-large?` false; hence `(not elision?)`.
+        ;; `elision-opts-edn` takes walker-aligned `include-large?`
+        ;; polarity directly. MCP `elision` true = emit markers =
+        ;; `:include-large?` false; hence `(not elision?)`.
         elision-opts  (elision/elision-opts-edn (not elision?) incl?)
-        ;; rf2-t55hxg.13 — fail-CLOSED: the walker runs UNLESS the caller
-        ;; opted into BOTH raw axes (`:elision false` ⇒ include-large? true
-        ;; AND `:include-sensitive true` ⇒ incl? true). A bare `:elision
-        ;; false` still walks — `elision-opts` overlays include-large? true
-        ;; so large passes, but include-sensitive? stays false so a frame-
-        ;; declared-sensitive slot still redacts to `:rf/redacted`. Pre-fix
-        ;; the walker gated on `elision?` alone, so `:elision false` leaked
-        ;; sensitive slots off-box. The `:elision` echo below still reports
-        ;; the caller's large-slot intent.
+        ;; Fail-CLOSED: the walker runs UNLESS the caller opted into
+        ;; BOTH raw axes (`:elision false` ⇒ include-large? true AND
+        ;; `:include-sensitive true` ⇒ incl? true). A bare `:elision
+        ;; false` still walks — `elision-opts` overlays include-large?
+        ;; true so large passes, but include-sensitive? stays false so a
+        ;; frame-declared-sensitive slot still redacts to `:rf/redacted`.
+        ;; The `:elision` echo below still reports the caller's
+        ;; large-slot intent.
         walk?         (elision/walk-required? (not elision?) incl?)
         snapshot-call (if frame
                         (ef/rt-call 'snapshot frame)
@@ -179,7 +176,7 @@
         run-eval
         ;; Shared eval-then-shrink tail: both branches run a server-side
         ;; form, strip the literal value(s) through the wire-pipeline
-        ;; `:scalar-value` arm (rf2-6by5s), and rebuild the envelope.
+        ;; `:scalar-value` arm, and rebuild the envelope.
         ;; `pluck` lifts the literal value the pipeline should count;
         ;; `rebuild` reassembles the envelope from the pipelined value.
         (fn [form pluck rebuild]
@@ -196,39 +193,38 @@
                     rebuilt (wire/with-indicators
                               (rebuild (dissoc envelope :elided-count) value)
                               {:elided elided})]
-                ;; rf2-wdxyx3 finding 2 — a known-tool runtime
-                ;; failure (`:ok? false`, e.g. a singular
-                ;; `:path-not-found` miss) MUST ride back as an
+                ;; A known-tool runtime failure (`:ok? false`, e.g. a
+                ;; singular `:path-not-found` miss) MUST ride back as an
                 ;; `isError` envelope, per the published wire
                 ;; contract (spec/001-Wire-Protocol.md, API.md
                 ;; §isError) and the dispatch/read-sub
                 ;; no-silent-success parity model. An `ok-text`
-                ;; wrapper let the failure cache as a normal success
-                ;; (cache eligibility keys off `isError`, not
+                ;; wrapper would let the failure cache as a normal
+                ;; success (cache eligibility keys off `isError`, not
                 ;; `:ok?`) and read as green by the MCP host. The
                 ;; `:wholesale-read-of-reserved-frame` refusal is
                 ;; built upstream as its own `err-text` and never
-                ;; reaches this tail.)
+                ;; reaches this tail.
                 (if (false? (:ok? rebuilt))
                   (wire/err-text rebuilt)
                   (wire/ok-text rebuilt))))))]
     (cond
-      ;; rf2-qef58 — server-side backstop: refuse a WHOLESALE root read
+      ;; Server-side backstop: refuse a WHOLESALE root read
       ;; (`path: []`, or a `[]` element in a batch `paths`) of a reserved
       ;; `:rf/*` tool frame (esp. `:rf/xray`) BEFORE the eval round-trip.
-      ;; The skill steers (rf2-ihqpn) away from this; the guard enforces
-      ;; it so a stray full read can't blow the context window. A sliced
-      ;; read (any non-`[]` path) of a tool frame stays allowed.
+      ;; The skill steers away from this; the guard enforces it so a
+      ;; stray full read can't blow the context window. A sliced read
+      ;; (any non-`[]` path) of a tool frame stays allowed.
       (some? refused)
       (js/Promise.resolve refused)
 
-      ;; rf2-lbm21 — `:path` and `:paths` are mutually exclusive surfaces.
+      ;; `:path` and `:paths` are mutually exclusive surfaces.
       (and (some? path) (some? paths))
       (js/Promise.resolve
         (wire/err-text {:ok? false :reason :path-and-paths-both-supplied
                         :hint "pass EITHER path (singular, one read) OR paths (plural, batch read), not both"}))
 
-      ;; Batch read (rf2-lbm21): N paths, one round-trip. The whole
+      ;; Batch read: N paths, one round-trip. The whole
       ;; `:results` map is the scalar the pipeline counts elision over.
       (some? paths)
       (if (empty? paths)
@@ -247,8 +243,8 @@
         (wire/err-text {:ok? false :reason :missing-path
                         :hint "usage: get-path {path '[:cart :items 0 :sku]' [frame :rf/default]} — or paths '[[:a :b] [:c]]' for a batch read"}))
 
-      ;; Singular read (rf2-tygdv): one path, one round-trip.
-      ;; rf2-6by5s — `:path-not-found` results carry no `:value` slot, so
+      ;; Singular read: one path, one round-trip.
+      ;; `:path-not-found` results carry no `:value` slot, so
       ;; the pipeline runs over nil and reports zero elision; the
       ;; `:value` slot is only re-attached on a hit.
       :else

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_re_frame2_pair_instructions.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_re_frame2_pair_instructions.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.get-re-frame2-pair-instructions
-  "Tool: get-re-frame2-pair-instructions (rf2-fnpqg) — agent-onboarding text.
+  "Tool: get-re-frame2-pair-instructions — agent-onboarding text.
 
   Mirrors story-mcp's `get-story-instructions`. Returns an inline
   prose summary of re-frame2-pair-mcp's tool catalogue + the conventions an
@@ -11,17 +11,15 @@
   is self-contained — no resource read at boot, one MCP frame, zero
   socket bytes. The structural peer in story-mcp
   (`story-instructions-text` in `re-frame.story-mcp.tools.dev`) uses
-  the same inline-`(str ...)` shape, kept aligned per rf2-93cew so AI
-  pairs reading both servers see one answer to the onboarding-text
-  question."
+  the same inline-`(str ...)` shape, kept aligned so AI pairs reading
+  both servers see one answer to the onboarding-text question."
   (:require [re-frame2-pair-mcp.tools.wire :as wire]))
 
 (def instructions-text
   "Inline onboarding prose. Inline `(str ...)` of `\\n`-glued lines —
-  see the ns docstring for the rationale (mirrors story-mcp per
-  rf2-93cew). Edit this string when the catalogue changes; the
-  docstring on `re-frame2-pair-mcp.tools/tool-descriptors` is the
-  structural peer."
+  see the ns docstring for the rationale (mirrors story-mcp). Edit
+  this string when the catalogue changes; the docstring on
+  `re-frame2-pair-mcp.tools/tool-descriptors` is the structural peer."
   (str
     "re-frame2-pair-mcp agent quick reference.\n"
     "Full spec: tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md.\n"

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_stream_controls.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_stream_controls.cljs
@@ -1,16 +1,16 @@
 (ns re-frame2-pair-mcp.tools.get-stream-controls
   "Tool: get-stream-controls — read-only diagnostic over the SERVER-SIDE
-  streaming resource-control state (rf2-a0kxsb).
+  streaming resource-control state.
 
   ## What this answers
 
   When a stream is denied, quiet, throttled, or terminated for sustained
   overflow, the operator needs to ask the MCP surface what the
   server-side resource controller currently believes — effective caps,
-  active slot count, token-bucket pressure, abuse-window count. Before
-  this tool that state lived ONLY in code/test seams + a passive stderr
-  banner + the rejection envelopes themselves; there was no first-class
-  way to query it live.
+  active slot count, token-bucket pressure, abuse-window count. This
+  tool is the first-class way to query that state live, where it
+  otherwise surfaces only indirectly through code/test seams, a passive
+  stderr banner, and the rejection envelopes themselves.
 
   `list-streams` answers the complementary RUNTIME question (\"what
   trace/epoch/fx streams are open in the browser?\") — it wraps the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
@@ -1,11 +1,11 @@
 (ns re-frame2-pair-mcp.tools.handler-meta
-  "Tools: handler-meta + list-handlers (rf2-pctf8; list-handlers renamed
-  from registry-list per rf2-4y595 — NAMING.md `list-<things>` shape).
+  "Tools: handler-meta + list-handlers (the `list-<things>` shape per
+  NAMING.md).
 
   Direct introspection on the registrar — `where is `:user/login`
   registered?` answered without a wide-authority `eval-cljs` round-trip.
 
-  ## Frame-targeting — the EP-0023 forward direction (rf2-srobm0)
+  ## Frame-targeting — the EP-0023 forward direction
 
   A frame's inspectable registration set is its RESOLVED IMAGE GENERATION: the
   same `(kind, id)` can resolve DIFFERENTLY per frame (two frames running
@@ -15,7 +15,7 @@
   registrar path. PRESENT ⇒ the read routes through the per-frame runtime fns
   (`frame-registrar-describe` / `frame-registrar-list`), which consume the
   PUBLIC facade reads `(rf/handler-meta {:frame f :kind k :id id})` /
-  `(rf/handler-ids {:frame f :kind k})` (rf2-wkw8na) and resolve the
+  `(rf/handler-ids {:frame f :kind k})` and resolve the
   `(kind, id)` set through that frame's OWN sealed image generation —
   surfacing the resolved descriptor's `:rf.provenance/ns` + inline/image +
   `:standard` facts (plus a normalized `:rf.image/coordinate` rollup naming
@@ -30,17 +30,17 @@
   (per Spec-Schemas `:rf/source-coord-meta` — merged flat onto
   `:rf/registration-metadata`), plus `:doc`, `:tags`, the registrar
   kind, and (per Spec 001 §The public registrar query API) whatever
-  custom slots the `reg-*` macro emitted. The wire-pipeline (post-
-  rf2-cibp8) decorates every map that carries a usable source-coord
-  shape with an `:rf.source/uri` string — so the AI host renders an
-  immediate jump-to-editor link off the handler-meta response.
+  custom slots the `reg-*` macro emitted. The wire-pipeline decorates
+  every map that carries a usable source-coord shape with an
+  `:rf.source/uri` string — so the AI host renders an immediate
+  jump-to-editor link off the handler-meta response.
 
   Supported kinds: `event`, `sub`, `fx`, `cofx`, `interceptor`, `view`,
   `frame`, `route`, `flow`, `head`, `error-projector`, `resource`,
   `mutation`, `resource-scope`, `machine` — the closed v1 registrar set
   (per Spec 001 §Registry model; the three resources-artefact kinds are
-  EP-0016 / rf2-f8s9g6; `interceptor` is EP-0022). App-db schemas are NOT
-  a registrar kind (rf2-cq1ak); their metadata lives in the schemas
+  EP-0016; `interceptor` is EP-0022). App-db schemas are NOT
+  a registrar kind; their metadata lives in the schemas
   artefact's per-frame side-table, surfaced via `rf/app-schemas` /
   `rf/app-schema-meta-at`. The fourteen registrar kinds map directly to
   `rf/handler-meta`; `machine` routes
@@ -96,14 +96,14 @@
   table — the closed v1 registrar set (per Spec 001 §Registry model),
   including the three resources-artefact kinds `:resource` / `:mutation`
   / `:resource-scope` (Spec 001 §Registry model — `reg-resource` /
-  `reg-mutation` / `reg-resource-scope`; EP-0016 / rf2-f8s9g6). They
+  `reg-mutation` / `reg-resource-scope`; EP-0016). They
   enumerate / describe through the same kind-agnostic
   `re-frame2-pair.runtime/registrar-list` + `registrar-describe`
   accessors as every other kind — so `list-handlers {kind \"resource-scope\"}`
   enumerates the named scope resolvers and `handler-meta {kind
   \"resource-scope\" id …}` surfaces a resolver's declared `:inputs` +
   `:whole-db?` cost (the EP-0016 disposition-2 inspectability promise).
-  `registrar-describe`'s `strip-fns` (rf2-f8s9g6) keeps the nested handler
+  `registrar-describe`'s `strip-fns` keeps the nested handler
   fns (`:request` / `:tags` / `:invalidates` / `:populates` / `:resolve`)
   off the EDN wire so the serializable structure rides cleanly.
 
@@ -118,10 +118,10 @@
   so `list-handlers {kind \"interceptor\"}` enumerates the registered ids
   and `handler-meta {kind \"interceptor\" id …}` surfaces the descriptor
   (the `:rf/interceptor-descriptor` slot the registrar retains for tooling).
-  Without it, registered interceptors were not inspectable via the pair-MCP
-  handler-meta tool (flagged during rf2-0adhqs.2).
+  This is what makes registered interceptors inspectable via the pair-MCP
+  handler-meta tool.
 
-  App-db schemas (rf2-cq1ak) are intentionally absent — they are NOT
+  App-db schemas are intentionally absent — they are NOT
   a registrar kind; their metadata lives in the schemas artefact's
   per-frame side-table. `machine` is intentionally absent here too —
   it routes through `rf/machine-meta` (which inspects `:event`-kind
@@ -158,7 +158,7 @@
 
   Returns `[:ok parsed]` on success or `[:err reason]` on a read
   failure (`:missing-id` / `:invalid-id-edn`) — the shared
-  `args/read-edn-arg` readability core (rf2-jkake.19). A bare
+  `args/read-edn-arg` readability core. A bare
   keyword-shaped string (leading `:`) round-trips through `read-string`;
   a plain word like `\"foo\"` reads as a symbol — the caller's
   `:not-registered` lookup then surfaces that it isn't a registered id."
@@ -172,7 +172,7 @@
   (str/join ", " (sort (map name supported-kinds))))
 
 ;; ---------------------------------------------------------------------------
-;; Frame targeting — the EP-0023 forward direction (rf2-srobm0).
+;; Frame targeting — the EP-0023 forward direction.
 ;;
 ;; The OPTIONAL `:frame` arg addresses the OPERATING frame's resolved image
 ;; generation. ABSENT ⇒ nil ⇒ the byte-identical default-registrar path.
@@ -196,8 +196,8 @@
 ;; `re-frame2-pair.runtime/registrar-describe` (already published; carries
 ;; the `:not-registered` envelope on miss). For `:machine` we wrap
 ;; `re-frame.core/machine-meta` directly — the runtime ns has no
-;; machine-aware wrapper today, and adding one is out of scope (lives in
-;; rf2-pctf8's caller side, not the runtime preload).
+;; machine-aware wrapper, so the wrapping lives on the tool's caller
+;; side rather than in the runtime preload.
 ;; ---------------------------------------------------------------------------
 
 (defn- registrar-form
@@ -208,7 +208,7 @@
   carries the `:not-registered` envelope on a miss and the
   `:handler-fn-hash` augmentation.
 
-  EXPLICIT FRAME (`frame` set — rf2-srobm0): route through
+  EXPLICIT FRAME (`frame` set): route through
   `re-frame2-pair.runtime/frame-registrar-describe`, which resolves the
   `(kind, id)` through the frame's OWN sealed image generation (the PUBLIC
   `(rf/handler-meta {:frame f …})` read) and surfaces the resolved
@@ -226,11 +226,12 @@
   map or a structured `:not-registered` map. Keeps the tool's response
   shape uniform across kinds.
 
-  rf2-l7vnd: `dissoc :handler-fn` for the same reason `registrar-describe`
-  drops it — a raw Function ref is unreadable on the EDN wire and made
-  the tool envelope misreport :unexpected-shape. The machine surface
-  doesn't always carry one, but the dissoc is idempotent and cheap and
-  keeps the response shape EDN-clean by construction across both kinds.
+  `dissoc :handler-fn` for the same reason `registrar-describe`
+  drops it — a raw Function ref is unreadable on the EDN wire and would
+  make the tool envelope misreport :unexpected-shape. The machine
+  surface doesn't always carry one, but the dissoc is idempotent and
+  cheap and keeps the response shape EDN-clean by construction across
+  both kinds.
 
   The composed form is one expression so the eval is a single
   round-trip — composition is the same idiom every other tool uses."
@@ -264,7 +265,7 @@
                         :hint   (str "id must be an EDN-readable keyword, e.g. \":user/login\". "
                                      "For composite-key subs, pass the vector form.")}))
 
-      ;; rf2-srobm0 — machines are NOT registrar kinds and are absent from the
+      ;; Machines are NOT registrar kinds and are absent from the
       ;; image generation resolver (Spec 005 — derived from :event handlers); a
       ;; frame-targeted machine lookup has no resolution. Refuse loudly rather
       ;; than resolve to a confusing :not-registered.
@@ -280,12 +281,12 @@
                                      "frame-targeted read.")}))
 
       :else
-      ;; rf2-qobqy: wrap the runtime form in the typed result codec so
+      ;; Wrap the runtime form in the typed result codec so
       ;; an unserializable meta map (a `#object[Function]` slot that
       ;; slips past the runtime's `dissoc :handler-fn`, a `#js {…}`
       ;; literal) rides back as a STRUCTURED `:unserializable` envelope
-      ;; — never the stringly `:unexpected-shape` re-parse the prior
-      ;; shape carried, and never a meta map smuggled as a STRING in
+      ;; — never a stringly `:unexpected-shape` re-parse, and never a
+      ;; meta map smuggled as a STRING in
       ;; `:value`. `envelope->result`'s `on-value` receives the genuine
       ;; PARSED meta map (or nil), so the three logical shapes (hit /
       ;; miss / unserializable) each resolve cleanly.
@@ -346,7 +347,7 @@
   `re-frame.core/machines` (Spec 005 §Querying machines — every event handler
   with `:rf/machine? true`).
 
-  EXPLICIT FRAME (`frame` set — rf2-srobm0): route through
+  EXPLICIT FRAME (`frame` set): route through
   `re-frame2-pair.runtime/frame-registrar-list`, which enumerates only the
   ids the frame's OWN image generation carries for the kind (the PUBLIC
   `(rf/handler-ids {:frame f :kind k})` read). `:machine` is rejected before
@@ -371,7 +372,7 @@
                         :kind   kind-str
                         :hint   (str "kind must be one of: " (kinds-hint))}))
 
-      ;; rf2-srobm0 — machines are not in the image generation resolver.
+      ;; Machines are not in the image generation resolver.
       (and (some? frame-val) (= :machine kind))
       (js/Promise.resolve
         (wire/err-text {:ok?    false

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_streams.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_streams.cljs
@@ -1,7 +1,6 @@
 (ns re-frame2-pair-mcp.tools.list-streams
   "Tool: list-streams — list active STREAMING-tap subscriptions opened
-  via `subscribe` (rf2-qicji; the streaming diagnostic formerly carried
-  by `list-subscriptions`).
+  via `subscribe`.
 
   ## What this answers
 
@@ -18,15 +17,13 @@
   (confirm the sub is still registered, check `:queue-depth` /
   `:overflow-reason` for evidence of a dead consumer).
 
-  ## rf2-qicji rename
+  ## Relationship to list-subscriptions
 
-  This tool is the streaming-tap diagnostic that `list-subscriptions`
-  used to be. rf2-qicji repointed `list-subscriptions` at the LIVE
-  reactive sub-cache (the answer to \"what reactive subscriptions are
-  active?\", matching `snapshot :sub-cache`); the streaming-tap
-  diagnostic kept its behaviour and moved here under an accurate name.
-  The two distinct concepts — reactive sub-cache vs streaming tap — no
-  longer share one name. No back-compat shim (pre-alpha).
+  This tool is the streaming-tap diagnostic. Its sibling
+  `list-subscriptions` reads the LIVE reactive sub-cache (the answer to
+  \"what reactive subscriptions are active?\", matching `snapshot
+  :sub-cache`). The two are distinct concepts — reactive sub-cache vs
+  streaming tap — each with its own accurately-named tool.
 
   Args (all optional):
     :topic   keyword or string — filter to a single topic
@@ -46,7 +43,7 @@
 (defn- filter-form
   "Build the per-sub `filterv` body — `subs` when no filters apply, a
   one-predicate `filterv` when exactly one, an `and`-combined chain
-  when both. The form is composed Clojure-side (rf2-ambfv) so the
+  when both. The form is composed Clojure-side so the
   runtime never sees `(if nil ...)` no-op branches for absent
   filters."
   [topic sub-id]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.tools.list-subscriptions
   "Tool: list-subscriptions — list the LIVE reactive subscriptions
-  materialised in a frame's per-frame sub-cache (rf2-qicji).
+  materialised in a frame's per-frame sub-cache.
 
   ## What this answers
 
@@ -11,30 +11,22 @@
   `sub-cache` fn) — the SAME accessor `snapshot :sub-cache` uses, so the
   two never disagree.
 
-  ## rf2-qicji — wrong-source → right-source
+  ## Relationship to list-streams
 
-  Before rf2-qicji this tool wrapped `re-frame2-pair.runtime/
-  subscription-info`, which reads the STREAMING-tap registry (the
-  trace / epoch / fx / error queues opened by `subscribe`). That
-  registry is empty unless a streaming `subscribe` is open, so
-  `list-subscriptions {frame :rf/default}` returned `{:subs []}` even
-  when the frame had live reactive subscriptions — a false-empty
-  correctness bug (the live evidence: `snapshot :sub-cache` showed
-  `[[\"mounted?\"]]` for the same frame while this tool said `[]`).
-
-  The fix routes `list-subscriptions` through `sub-cache-info` so it
-  reports the live reactive cache. The streaming-tap diagnostic was NOT
-  lost — it moved to the accurately-named `list-streams` tool (which
-  still wraps `subscription-info`). The two distinct concepts no longer
-  share one name.
+  `list-subscriptions` routes through `sub-cache-info`, reporting the
+  live reactive cache — the SAME source `snapshot :sub-cache` reads, so
+  the two never disagree. The complementary streaming-tap diagnostic
+  (the trace / epoch / fx / error queues opened by `subscribe`, read via
+  `subscription-info`) lives in the accurately-named `list-streams`
+  tool. The two are distinct concepts — reactive sub-cache vs streaming
+  tap — each with its own tool.
 
   ## Disposal
 
   The reactive sub-cache is ref-counted and live: an entry appears the
   moment a view subscribes and DISAPPEARS when the last consumer
   disposes the reaction. So a sub that's been disposed (its view
-  unmounted, no other subscribers) no longer shows up here — the
-  acceptance contract per rf2-qicji.
+  unmounted, no other subscribers) no longer shows up here.
 
   ## Args (all optional)
 
@@ -56,7 +48,7 @@
            :input-kind k :realized-inputs [...]} ...]`). Empty `:subs`
   vector when nothing is subscribed in the frame.
 
-  ## rf2-e3acps — realized parametric input egress
+  ## Realized parametric input egress
 
   `:include-values true` also surfaces each live entry's `:input-kind`
   (`:db` / `:static` / `:parametric`) and `:realized-inputs` — the
@@ -71,7 +63,7 @@
   raw — only the per-sub `:value` slot is run through the egress
   redaction walker below.
 
-  ## rf2-f1ose — `:include-values` egress redaction
+  ## `:include-values` egress redaction
 
   `:include-values true` ships each subscription's current `:value`
   (the deref) over the MCP wire. That value reads the SAME reactive
@@ -98,10 +90,10 @@
   (let [build-id (wire/arg-build conn raw-args)
         frame    (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         ;; `:include-values` rides the shared bool-args accept-shape
-        ;; contract (rf2-c4fmh) — `true` / `"true"` / `"yes"` / ... all
+        ;; contract — `true` / `"true"` / `"yes"` / ... all
         ;; resolve; default false.
         incl-vals? (args/parse-bool-arg raw-args :include-values)
-        ;; rf2-f1ose — the `--allow-sensitive-reads` boot gate forces
+        ;; The `--allow-sensitive-reads` boot gate forces
         ;; `:elision true` + `:include-sensitive false` when OFF (the
         ;; default), mirroring snapshot / get-path. `incl-sensitive?`
         ;; threads into the walker's `:rf.size/include-sensitive?` opt;
@@ -125,13 +117,13 @@
                         (pr-str frame)
                         (ef/emit (ef/rt-call 'current-frame)))
         elision-opts  (elision/elision-opts-edn (not elision?) incl-sensitive?)
-        ;; rf2-t55hxg.13 — fail-CLOSED: walk UNLESS the caller opted into
+        ;; Fail-CLOSED: walk UNLESS the caller opted into
         ;; both raw axes (`:elision false` AND `:include-sensitive true`).
         ;; A bare `:elision false` still walks so a declared-sensitive sub
         ;; `:value` redacts to `:rf/redacted` while large content passes.
         walk?         (elision/walk-required? (not elision?) incl-sensitive?)
         base-call     (ef/emit (ef/rt-call 'sub-cache-info opts))
-        ;; rf2-f1ose — when values ride the wire AND the walker is
+        ;; When values ride the wire AND the walker is
         ;; required, map each `:subs` entry's `:value` through
         ;; `elide-wire-value` server-side before the result ships. The
         ;; query-vectors-only shape (`:include-values false`) carries no

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
@@ -1,6 +1,5 @@
 (ns re-frame2-pair-mcp.tools.operating-frame
-  "Tools: set-operating-frame + reset-operating-frame + get-operating-frame
-  (rf2-zomfq).
+  "Tools: set-operating-frame + reset-operating-frame + get-operating-frame.
 
   The three operating-frame ops the [Tool-Pair contract][1] mandates
   (§Tool-surface obligations) for any pair-shaped tool surface. They are
@@ -21,7 +20,7 @@
   So `set-operating-frame` pins a FRAME ID, full stop. `reset-operating-frame`
   clears the pin so a session resets to a clean posture.
 
-  ## The gap these close
+  ## Why these ops exist
 
   re-frame2 is multi-frame (Spec 002). Every frame-targeted read/write
   (`dispatch`, `snapshot`, `get-path`, `subscribe`, `list-subscriptions`,
@@ -33,12 +32,11 @@
   guessing (per Tool-Pair §Ambiguity surface — a write that lands in the
   wrong frame is unrecoverable without `restore-epoch`).
 
-  Before this tool, tier 2 was *unreachable from the MCP surface*: the
-  runtime exposed `select-frame!` / `current-frame` / `frames-list` but no
-  tool wired them onto the wire, so a multi-frame agent had to thread
-  `:frame` through every single call forever — defeating the
-  implicit-until-reset UX the contract designed. These three ops surface
-  the session pin so the agent declares it ONCE and escapes.
+  These three ops surface tier 2 — the session pin — on the MCP wire. The
+  runtime holds `select-frame!` / `current-frame` / `frames-list`; these
+  tools wire them onto the wire so a multi-frame agent declares its
+  operating frame ONCE and escapes the per-call `:frame` threading,
+  delivering the implicit-until-reset UX the contract designs for.
 
   ## The trio
 
@@ -86,21 +84,20 @@
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.reserved-frame-guard :as guard]))
 
-;; rf2-olvr5 finding 3 — the response cache key is `(tool, build,
-;; args-fingerprint)`; it deliberately can NOT include the resolved
-;; operating frame for an omitted-`:frame` call (that resolves runtime-
-;; side, after the key is built). So a `get-path {path X}` with no
-;; `:frame` arg, cached against operating frame A, would serve A's payload
-;; after the session switches to frame B if B happens to share A's
-;; app-db-hash (the multi-frame identical-initial-db case the bead
-;; reproduces). The fix flushes the WHOLE response cache whenever the
-;; operating frame changes — and to avoid a `cache → registry →
-;; operating-frame → cache` require cycle (registry wires these handlers,
-;; cache reads registry's `cacheable?`), the flush is driven from the
-;; `invoke` dispatch chokepoint in `re-frame2-pair-mcp.tools` (which
-;; already requires both `cache` and `registry`) rather than imported
-;; here. `operating-frame-mutating?` is the predicate that chokepoint
-;; consults.
+;; The response cache key is `(tool, build, args-fingerprint)`; it
+;; deliberately can NOT include the resolved operating frame for an
+;; omitted-`:frame` call (that resolves runtime-side, after the key is
+;; built). So a `get-path {path X}` with no `:frame` arg, cached against
+;; operating frame A, would serve A's payload after the session switches
+;; to frame B if B happens to share A's app-db-hash (the multi-frame
+;; identical-initial-db case). To prevent that, the WHOLE response cache
+;; flushes whenever the operating frame changes — and to avoid a
+;; `cache → registry → operating-frame → cache` require cycle (registry
+;; wires these handlers, cache reads registry's `cacheable?`), the flush
+;; is driven from the `invoke` dispatch chokepoint in
+;; `re-frame2-pair-mcp.tools` (which already requires both `cache` and
+;; `registry`) rather than imported here. `operating-frame-mutating?` is
+;; the predicate that chokepoint consults.
 
 ;; ---------------------------------------------------------------------------
 ;; set-operating-frame
@@ -150,18 +147,18 @@
                         "(EP-0023: image -> frame -> event stream); call "
                         "get-operating-frame to see the registered frames.")}))
 
-      ;; rf2-wdxyx3 finding 1 — refuse pinning a reserved `:rf/*` TOOL frame
-      ;; as the session's operating frame BEFORE any nREPL round-trip. A
-      ;; tool frame (Xray's `:rf/xray`, an SSR slot) is a devtool surface,
-      ;; NOT the app the operator is pairing against (Tool-Pair §Reserved
-      ;; tool frames are excluded from the ambiguity count). Were a pin
+      ;; Refuse pinning a reserved `:rf/*` TOOL frame as the session's
+      ;; operating frame BEFORE any nREPL round-trip. A tool frame
+      ;; (Xray's `:rf/xray`, an SSR slot) is a devtool surface, NOT the
+      ;; app the operator is pairing against (Tool-Pair §Reserved tool
+      ;; frames are excluded from the ambiguity count). Were a pin
       ;; allowed, the runtime's `current-frame` resolver would return the
       ;; tool frame at tier 2, and a later no-`:frame` `get-path {path []}`
       ;; would resolve the wholesale read through it — re-opening the exact
-      ;; context-window overflow the rf2-qef58 guard was introduced to
-      ;; close (the guard fires on the explicit `:frame` arg; an omitted
-      ;; `:frame` resolves runtime-side, where the client guard can't see
-      ;; the reserved pin). Closing the pin here removes the bypass at its
+      ;; context-window overflow the wholesale-read guard closes (that
+      ;; guard fires on the explicit `:frame` arg; an omitted `:frame`
+      ;; resolves runtime-side, where the client guard can't see the
+      ;; reserved pin). Closing the pin here removes the bypass at its
       ;; source: a reserved frame is never the operating frame, so the
       ;; nil-`:frame` resolution can never land on one. Sliced/explicit
       ;; reads of a tool frame stay available via the per-call `:frame`
@@ -187,7 +184,7 @@
         (probe/eval-after-runtime!
           conn build-id form :set-operating-frame-failed
           (fn [v]
-            ;; rf2-wdxyx3 finding 2 — a known-tool execution failure
+            ;; A known-tool execution failure
             ;; (`:ok? false`) MUST ride back as an `isError` envelope so the
             ;; MCP host routes recovery through the error channel and the
             ;; invoke chokepoint does not treat a non-pin as a cache-flushing
@@ -241,15 +238,15 @@
 
 (def operating-frame-mutating-tools
   "Tool names whose successful invocation changes the session's operating
-  frame, invalidating every omitted-`:frame` cached read (rf2-olvr5
-  finding 3). The `invoke` chokepoint flushes the response cache after
-  these run. `get-operating-frame` is a pure read and is NOT included."
+  frame, invalidating every omitted-`:frame` cached read. The `invoke`
+  chokepoint flushes the response cache after these run.
+  `get-operating-frame` is a pure read and is NOT included."
   #{"set-operating-frame" "reset-operating-frame"})
 
 (defn operating-frame-mutating?
-  "True iff `tool-name` is an operating-frame mutation (rf2-olvr5
-  finding 3) — the predicate `re-frame2-pair-mcp.tools/invoke` consults
-  to decide whether to flush the response cache after the call. Lives
+  "True iff `tool-name` is an operating-frame mutation — the predicate
+  `re-frame2-pair-mcp.tools/invoke` consults to decide whether to flush
+  the response cache after the call. Lives
   here (not in `cache`) so the cache ns stays free of an
   operating-frame require; lives as a name-set check (not a per-result
   inspection) so the chokepoint never has to parse the tool's envelope."

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/orient.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/orient.cljs
@@ -1,15 +1,15 @@
 (ns re-frame2-pair-mcp.tools.orient
-  "Tool: orient — app-shape orientation summary in one round-trip
-  (rf2-3bu3d.8).
+  "Tool: orient — app-shape orientation summary in one round-trip.
 
   ## What this answers
 
   \"What is this app and what can I drive?\" — the first-contact question
-  when an agent connects to an UNFAMILIAR app. Orienting otherwise took
-  several calls: `discover-app` (frames / health) + `snapshot` summary
-  (app-db top-keys) + `list-handlers` (event-ids) + `list-subscriptions`
-  (sub-ids) + machines / routes. `orient` composes those into ONE compact
-  map by reusing the existing introspection surfaces (runtime-side
+  when an agent connects to an UNFAMILIAR app. Without it, orienting
+  takes several calls: `discover-app` (frames / health) + `snapshot`
+  summary (app-db top-keys) + `list-handlers` (event-ids) +
+  `list-subscriptions` (sub-ids) + machines / routes. `orient` composes
+  those into ONE compact map by reusing the existing introspection
+  surfaces (runtime-side
   `orient` → `health` + `app-frame-ids` + `registrar-list` +
   `app-db-value` top-keys + `rf/machines`) — no reinvention.
 
@@ -34,8 +34,8 @@
 
   Reserved `:rf/*` tool frames (Xray's `:rf/xray`, SSR slots, …) are split
   out of `:frames` (`:app` vs `:all`) and EXCLUDED from `:app-db-top-keys`
-  (the rf2-3bu3d.6 posture) so a first-contact orientation doesn't
-  overflow on tool-frame inspection state.
+  so a first-contact orientation doesn't overflow on tool-frame
+  inspection state.
 
   Read-only + idempotent across same-state calls — no side-effect beyond
   the idempotent listener install `health` performs."
@@ -50,9 +50,9 @@
       conn build-id form :orient-failed
       (fn [v]
         (if (map? v)
-          ;; rf2-8t3ct / rf2-fmho5 — echo the canonical resolved `:build`
-          ;; so the agent sees which build this orientation ran against
-          ;; (the session-sticky target when `:build` was omitted) and can
+          ;; Echo the canonical resolved `:build` so the agent sees
+          ;; which build this orientation ran against (the
+          ;; session-sticky target when `:build` was omitted) and can
           ;; copy it straight into later calls.
           (wire/ok-text (assoc v :build build-id))
           (wire/err-text {:ok? false :reason :unexpected-shape :value v :build build-id}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
@@ -1,33 +1,32 @@
 (ns re-frame2-pair-mcp.tools.precheck
-  "Cache precheck — rf2-36xod. Server-side cheap-hash probe.
+  "Cache precheck — server-side cheap-hash probe.
 
-  The original rf2-3rt1f cache decides a hit AFTER running the tool by
-  hashing the result text. That saves wire bytes but still pays the
-  full nREPL round-trip + path-slice + transform pipeline. The rf2-36xod
-  precheck moves the decision EARLIER: one bencode round-trip asks the
-  runtime for `(hash (re-frame2-pair.runtime/snapshot frame))`. If the
-  hash matches the stored entry for `(tool, args)`, we emit the cache-
-  hit marker WITHOUT running the tool — saving both the wire bytes AND
-  the full tool eval.
+  The post-eval cache decides a hit AFTER running the tool by hashing
+  the result text. That saves wire bytes but still pays the full nREPL
+  round-trip + path-slice + transform pipeline. The precheck moves the
+  decision EARLIER: one bencode round-trip asks the runtime for
+  `(hash (re-frame2-pair.runtime/snapshot frame))`. If the hash matches
+  the stored entry for `(tool, args)`, we emit the cache-hit marker
+  WITHOUT running the tool — saving both the wire bytes AND the full
+  tool eval.
 
   Eligibility (today): single-frame `snapshot` whose resolved
   `:include` is app-db-derived only. Its result is a function of
   `(frame, args, app-db@frame)`; same frame + same args + same db-hash
   ⇒ same result. Multi-frame `snapshot` (`:frames :all` or a vector) is
   NOT eligible because we'd need to hash every frame's db separately and
-  combine — out of scope; the legacy post-eval `apply-cache` path still
-  catches those.
+  combine — out of scope; the post-eval `apply-cache` path catches
+  those.
 
-  Snapshot's `:include` slices split by what the precheck hash sees
-  (rf2-3ljsa). The precheck hash is `(re-frame2-pair.runtime/app-db-hash
+  Snapshot's `:include` slices split by what the precheck hash sees. The
+  precheck hash is `(re-frame2-pair.runtime/app-db-hash
   frame)` = `(hash app-db@frame)` only — it tracks `:db-after` at every
   settled mutation. So a slice is precheck-sound IFF it is a pure
   function of `app-db@frame`:
 
     - `:app-db`   — IS the frame db. Sound.
-    - `:machines` — runtime-db state (rf2-ww877w): EP-0001 (rf2-vzld77)
-                    moved machine snapshots OUT of app-db `:rf/runtime`
-                    into the durable runtime-db partition, read via
+    - `:machines` — runtime-db state. Machine snapshots live in the
+                    durable runtime-db partition (EP-0001), read via
                     `rf/runtime-db-value` at `[:rf.runtime/machines
                     :snapshots]` (see runtime.cljs `snapshot-frame-slice`).
                     A machine transition rewrites that runtime-db slot
@@ -50,7 +49,7 @@
   taken only when the caller narrows `:include` to the app-db-derived
   subset.
 
-  `get-path` is NOT precheck-eligible (rf2-ww877w). Although it reads an
+  `get-path` is NOT precheck-eligible. Although it reads an
   app-db subtree, its wire result is post-processed by
   `re-frame.core/elide-wire-value`, whose elision registry lives in the
   runtime-db partition (`[:rf.runtime/elision]` — see
@@ -73,19 +72,18 @@
             [re-frame2-pair-mcp.tools.args :as args]))
 
 (def app-db-derived-snapshot-slices
-  "Snapshot slices whose value is a pure function of `app-db@frame`
-  (rf2-3ljsa). Only these are precheck-sound under the
-  `(hash app-db@frame)` precheck hash;
-  `:machines`/`:sub-cache`/`:epochs`/`:traces` can change while that
-  hash stays constant, so a snapshot whose resolved `:include` is NOT a
-  subset of this set is precheck-ineligible and falls back to the
+  "Snapshot slices whose value is a pure function of `app-db@frame`.
+  Only these are precheck-sound under the `(hash app-db@frame)` precheck
+  hash; `:machines`/`:sub-cache`/`:epochs`/`:traces` can change while
+  that hash stays constant, so a snapshot whose resolved `:include` is
+  NOT a subset of this set is precheck-ineligible and falls back to the
   post-eval result-hash cache. See the ns docstring for the per-slice
   rationale.
 
-  rf2-ww877w dropped `:machines` from this set: EP-0001 (rf2-vzld77)
-  moved machine snapshots into the runtime-db partition, so a machine
-  transition rewrites the slice without an app-db write — the
-  `(hash app-db)` precheck hash can't see it move."
+  `:machines` is excluded: machine snapshots live in the runtime-db
+  partition (EP-0001), so a machine transition rewrites the slice
+  without an app-db write — the `(hash app-db)` precheck hash can't see
+  it move."
   #{:app-db})
 
 (defn precheck-target
@@ -95,27 +93,23 @@
     [:explicit <frame-keyword>]   — caller named a specific frame.
     nil                           — tool not precheck-eligible.
 
-  Tagged-tuple dispatch supersedes the prior sentinel-keyword shape
-  (`:rf.mcp.cache/operating-frame`) — `precheck-form` dispatches on
-  the tag rather than pattern-matching against a magic keyword, and
-  the eligibility distinction is now type-level, not value-level.
-  Future targets (e.g. multi-frame combined-hash, or an
+  `precheck-form` dispatches on the tag rather than pattern-matching
+  against a magic keyword, so the eligibility distinction is type-level,
+  not value-level. Future targets (e.g. multi-frame combined-hash, or an
   operating-frame-resolved hash) add a new tag without colliding with a
-  reserved keyword. The only live tag today is `:explicit`
-  (rf2-ww877w retired the `get-path` `:operating-frame` tag along with
-  its precheck eligibility — see the get-path note below).
+  reserved keyword. The only live tag is `:explicit`.
 
   `snapshot` is eligible only when BOTH (a) `:frames` resolves to a
   single frame (an explicit one-element vector or a single scalar) AND
   (b) the resolved `:include` is a subset of
-  `app-db-derived-snapshot-slices` (rf2-3ljsa) — i.e. `#{:app-db}`.
+  `app-db-derived-snapshot-slices` — i.e. `#{:app-db}`.
   `:all` or a multi-element vector — or an `:include` that retains
   `:machines`/`:sub-cache`/`:epochs`/`:traces` (including the default
   all-five include) — returns nil so the caller falls back to the
   post-eval cache, which hashes the full result text and so cannot serve
   stale non-app-db slices.
 
-  `get-path` is NOT precheck-eligible (rf2-ww877w). Its app-db subtree
+  `get-path` is NOT precheck-eligible. Its app-db subtree
   read is post-processed by `re-frame.core/elide-wire-value`, whose
   elision registry lives in the runtime-db partition; a later elision
   declaration (or sensitive/large classification flip) can change the
@@ -133,7 +127,7 @@
       (cond
         ;; an :include retaining a non-app-db-derived slice
         ;; (:machines/:sub-cache/:epochs/:traces) — the precheck hash
-        ;; can't see those move, so NOT eligible (rf2-3ljsa, rf2-ww877w).
+        ;; can't see those move, so NOT eligible.
         (not app-db-derived?)
         nil
         ;; explicit single-frame vector
@@ -147,29 +141,27 @@
         nil
         :else nil))
 
-    ;; get-path — NOT precheck-eligible (rf2-ww877w). The elision
-    ;; registry (runtime-db) can re-shape the egress of an unchanged
-    ;; app-db subtree, which the app-db precheck hash can't observe;
-    ;; the post-eval result-hash cache is the sound backstop.
+    ;; get-path — NOT precheck-eligible. The elision registry
+    ;; (runtime-db) can re-shape the egress of an unchanged app-db
+    ;; subtree, which the app-db precheck hash can't observe; the
+    ;; post-eval result-hash cache is the sound backstop.
     ;;
     ;; Other tools — not precheck-eligible yet.
     nil))
 
 (defn precheck-form
   "The CLJS eval form for the runtime-side cheap hash. Dispatches on
-  the tag in `target` (today only `[:explicit <kw>]`) — the keyword
-  sentinel of the prior shape is gone.
+  the tag in `target` (today only `[:explicit <kw>]`).
 
-  Threads through `re-frame2-pair.runtime/app-db-hash` (rf2-9pe31),
-  which returns the per-frame cached `(hash app-db)` integer in O(1).
-  The cache is maintained by the runtime's epoch listener at every
-  settled mutation; lazy-computed on the first read for a frame whose
-  hash hasn't been observed yet. The wire payload is a single integer
-  regardless of app-db size.
+  Threads through `re-frame2-pair.runtime/app-db-hash`, which returns
+  the per-frame cached `(hash app-db)` integer in O(1). The cache is
+  maintained by the runtime's epoch listener at every settled mutation;
+  lazy-computed on the first read for a frame whose hash hasn't been
+  observed yet. The wire payload is a single integer regardless of
+  app-db size.
 
-  A future operating-frame-resolved target would re-add a
-  `:operating-frame` arm emitting the 0-arity `app-db-hash` call; it was
-  removed with the `get-path` precheck retirement (rf2-ww877w)."
+  A future operating-frame-resolved target would add a
+  `:operating-frame` arm emitting the 0-arity `app-db-hash` call."
   [[tag frame :as _target]]
   (case tag
     :explicit

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.probe
-  "Preload probe + error translation (rf2-vrbwx split).
+  "Preload probe + error translation.
 
   The `re-frame2-pair.runtime` namespace ships into the consumer app via
   shadow-cljs's `:devtools :preloads` mechanism. Each tool that needs the
@@ -9,11 +9,10 @@
   the tool refuses with `:reason :runtime-not-preloaded` and a setup
   hint pointing at `skills/re-frame2-pair/SKILL.md`.
 
-  No cljs-eval inject path: the preload is the canonical setup. Earlier
-  drops shipped a per-session inject fallback; that path was cut for
-  rf2-7dvg.
+  No cljs-eval inject path: the preload is the canonical setup, with no
+  per-session inject fallback.
 
-  ## Probe caching (rf2-sjpx0)
+  ## Probe caching
 
   Once `runtime-preloaded?` resolves to true for a `(conn, build-id)`
   pair, the result is cached on the conn-atom (`:probed-builds`)
@@ -22,28 +21,27 @@
   The cache is cleared by `nrepl/close!` (operator-initiated teardown)
   and is reborn empty whenever `server.cljs/ensure-connection!` builds a
   fresh conn for a new shadow port. It is deliberately PRESERVED across a
-  transient same-port socket reopen (rf2-c3dsr) — the
-  `__re_frame2_pair_runtime` marker lives in the browser CLJS heap, which
-  a JVM-side socket hiccup doesn't destroy, so re-probing would be
-  wasteful. (A full page reload DOES destroy the marker, but it leaves
-  the JVM nREPL socket UP — so it never triggered a reconnect-reset
-  before rf2-c3dsr either; this path is unchanged. Negative probes aren't
-  cached, and the diagnostic ladder surfaces a genuinely-dead marker on
-  the next eval against the build.)
+  transient same-port socket reopen — the `__re_frame2_pair_runtime`
+  marker lives in the browser CLJS heap, which a JVM-side socket hiccup
+  doesn't destroy, so re-probing would be wasteful. (A full page reload
+  DOES destroy the marker, but it leaves the JVM nREPL socket UP, so it
+  doesn't trigger a reconnect-reset. Negative probes aren't cached, and
+  the diagnostic ladder surfaces a genuinely-dead marker on the next
+  eval against the build.)
 
   Negative results are NOT cached: a missing preload usually surfaces
   on the very first call, and re-probing on each subsequent call
   lets a freshly-added preload land without a server restart (e.g.
   the user edits `shadow-cljs.edn` and shadow-cljs hot-reloads).
 
-  ## Build resolution + fail-loud preflight (rf2-ivlb3)
+  ## Build resolution + fail-loud preflight
 
   `eval-cljs` (and any future read/eval tool) must NOT eval against a
   build with no live re-frame2-pair runtime — doing so returns
   `{:ok? true :value nil}` (shadow's `cljs-eval` against a non-running
   build yields a blank value, which `cljs-eval-value` reads as nil),
-  indistinguishable from a form that genuinely returns nil. ~30 min of
-  dead-end debugging in the wild.
+  indistinguishable from a form that genuinely returns nil — a silent
+  footgun that masks the real failure.
 
   Two helpers close the footgun:
 
@@ -73,14 +71,12 @@
        "is on :source-paths. See skills/re-frame2-pair/SKILL.md (§Setup)."))
 
 ;; ---------------------------------------------------------------------------
-;; Diagnostic-ladder vocabulary (rf2-7tgfk).
+;; Diagnostic-ladder vocabulary.
 ;;
-;; A failed preload probe used to surface ONE reason
-;; (`:runtime-not-preloaded`) whose hint always read "add the preload
-;; to your shadow-cljs.edn". In the 2026-05-25 pair-debug session that
-;; suggestion was misleading in three of the four failure modes the
-;; operator hit (~30 min of dead-end debugging). The ladder below
-;; distinguishes the cases the original single reason hid:
+;; A failed preload probe surfaces one of four distinct reasons, each
+;; with a targeted hint, rather than a single `:runtime-not-preloaded`
+;; whose "add the preload to your shadow-cljs.edn" hint fits only one of
+;; them. The ladder below distinguishes the failure modes:
 ;;
 ;;   :nrepl-unreachable             - JVM eval round-trip fails. The
 ;;                                    socket may be dead even though
@@ -95,8 +91,7 @@
 ;;                                    has connected (or the tab's ws
 ;;                                    is dead).
 ;;   :runtime-loaded-but-preload-missing
-;;                                  - the original meaning: a CLJS
-;;                                    runtime is alive but the
+;;                                  - a CLJS runtime is alive but the
 ;;                                    `__re_frame2_pair_runtime` marker
 ;;                                    is absent. The "add the preload"
 ;;                                    hint fits ONLY this case.
@@ -114,7 +109,7 @@
 
 (defn build-arg-form
   "Render a build-id keyword in EXACTLY the string form the `:build` MCP
-  arg accepts back (rf2-qda59). The arg coercer (`fresh-keyword`) is
+  arg accepts back. The arg coercer (`fresh-keyword`) is
   colon-tolerant, so the canonical round-trippable form is the keyword's
   own `pr-str` (`:examples/machine-epochs`) — copy-pasting it from an
   error into `:build` resolves to the same build. Used to keep the
@@ -125,7 +120,7 @@
 
 (defn running-build-arg-forms
   "Map the `running` build-id keywords to their round-trippable `:build`
-  arg forms (rf2-qda59) — the copy-paste-ready list for an error's
+  arg forms — the copy-paste-ready list for an error's
   guidance. `[:examples/machine-epochs :panel-gallery]` ⇒
   `[\":examples/machine-epochs\" \":panel-gallery\"]`."
   [running]
@@ -139,7 +134,7 @@
 
     :else
     ;; Render every running id in its round-trippable `:build` arg form
-    ;; (rf2-qda59) so the guidance can be copy-pasted straight back.
+    ;; so the guidance can be copy-pasted straight back.
     (str "shadow-cljs is running " (running-build-arg-forms running) " but not "
          (build-arg-form build-id) ". Pass --build=" (build-arg-form (first running))
          " (or set SHADOW_CLJS_BUILD_ID) — or restart the watch worker "
@@ -185,10 +180,10 @@
   marker set by the preloaded `re-frame2-pair.runtime` namespace.
   Resolves to true iff the marker is present.
 
-  Positive results are cached per `(conn, build-id)` on the conn-atom
-  (rf2-sjpx0). A cached hit resolves synchronously without an nREPL
-  round-trip; a miss runs one bencode round-trip and caches a positive
-  outcome before resolving."
+  Positive results are cached per `(conn, build-id)` on the conn-atom.
+  A cached hit resolves synchronously without an nREPL round-trip; a
+  miss runs one bencode round-trip and caches a positive outcome before
+  resolving."
   [conn build-id]
   (if (conn-has-probed? conn build-id)
     (js/Promise.resolve true)
@@ -208,7 +203,7 @@
 (declare running-builds)
 
 (defn diagnose-preload-failure!
-  "Run the failure-path diagnostic ladder (rf2-7tgfk). Called only when
+  "Run the failure-path diagnostic ladder. Called only when
   `runtime-preloaded?` returned false, so the cost is paid exactly when
   it matters. Resolves to a map `{:reason <kw> :hint <str> ...}` whose
   `:reason` distinguishes:
@@ -245,8 +240,8 @@
                         {:reason                  :build-not-running
                          :build                   build-id
                          :running-builds          running
-                         ;; rf2-qda59 — the round-trippable copy-paste list:
-                         ;; each running build in EXACTLY the `:build` arg
+                         ;; The round-trippable copy-paste list: each
+                         ;; running build in EXACTLY the `:build` arg
                          ;; form. `:running-builds` keeps the keyword vector
                          ;; (still round-trippable via colon-tolerance); this
                          ;; sibling makes the paste-ready strings explicit.
@@ -255,9 +250,8 @@
                       ;; Build IS running — distinguish "no runtime
                       ;; connected" (cljs-eval returns blank/nil) from
                       ;; "runtime present but marker absent" (cljs-eval
-                      ;; returns false). The original probe collapsed
-                      ;; both into "false"; here we re-evaluate the
-                      ;; raw form and inspect the shape.
+                      ;; returns false). Re-evaluate the raw form and
+                      ;; inspect the shape to tell them apart.
                       (-> (nrepl/cljs-eval-value
                             conn build-id
                             "(some? (and (exists? js/globalThis) (.-__re_frame2_pair_runtime js/globalThis)))")
@@ -272,8 +266,8 @@
                                  :hint           (no-runtime-connected-hint build-id)}
 
                                 ;; false → runtime is alive but marker
-                                ;; is absent — the case the original hint
-                                ;; was written for.
+                                ;; is absent — the case the preload hint
+                                ;; addresses.
                                 (false? v)
                                 {:reason :runtime-loaded-but-preload-missing
                                  :build  build-id
@@ -299,7 +293,7 @@
                                        :running-builds running
                                        :hint   (no-runtime-connected-hint build-id)})))))))))))
       (.catch (fn [_]
-                ;; Ladder itself threw — degrade to the original reason.
+                ;; Ladder itself threw — degrade to the blanket reason.
                 (js/Promise.resolve
                   {:reason :runtime-not-preloaded
                    :build  build-id
@@ -317,17 +311,15 @@
   runtime call this first.
 
   After the first positive probe per `(conn, build-id)`, this resolves
-  synchronously from cache — no nREPL round-trip per tool call
-  (rf2-sjpx0).
+  synchronously from cache — no nREPL round-trip per tool call.
 
-  rf2-7tgfk: on a failed probe the rejection no longer always reads
-  `:runtime-not-preloaded`. The diagnostic ladder
+  On a failed probe the diagnostic ladder
   (`diagnose-preload-failure!`) inspects the failure mode and rejects
   with one of four specific reasons — `:nrepl-unreachable`,
   `:build-not-running`, `:no-runtime-connected`, or
   `:runtime-loaded-but-preload-missing` — each with a targeted hint.
-  The original blanket `:runtime-not-preloaded` reason is reserved as
-  the degradation fallback if the ladder itself errors."
+  The blanket `:runtime-not-preloaded` reason is reserved as the
+  degradation fallback if the ladder itself errors."
   [conn build-id]
   (-> (runtime-preloaded? conn build-id)
       (.then (fn [ok?]
@@ -340,7 +332,7 @@
                                          diag))))))))))
 
 ;; ---------------------------------------------------------------------------
-;; Running-build enumeration + fail-loud build resolution (rf2-ivlb3).
+;; Running-build enumeration + fail-loud build resolution.
 ;; ---------------------------------------------------------------------------
 
 (defn running-builds
@@ -369,7 +361,7 @@
       (.catch (fn [_] []))))
 
 ;; ---------------------------------------------------------------------------
-;; URL/port → build resolution via the shadow-cljs :dev-http map (rf2-fyf0h).
+;; URL/port → build resolution via the shadow-cljs :dev-http map.
 ;;
 ;; A pair session naturally starts from the URL of the open browser tab
 ;; (e.g. http://localhost:8031/counter), but discover-app speaks build-
@@ -406,12 +398,12 @@
 
 (defn resolve-build-by-port
   "Resolve the shadow-cljs build-id serving `port` via the `:dev-http`
-  map (rf2-fyf0h). Returns a Promise resolving to the build-id keyword,
-  or nil when the port isn't in `:dev-http`, no build's `:output-dir`
-  matches its roots, or the JVM probe fails. `port` is an integer (a
-  string is coerced).
+  map. Returns a Promise resolving to the build-id keyword, or nil when
+  the port isn't in `:dev-http`, no build's `:output-dir` matches its
+  roots, or the JVM probe fails. `port` is an integer (a string is
+  coerced).
 
-  This removes the manual `grep shadow-cljs.edn for 8031` step: an agent
+  This saves the manual `grep shadow-cljs.edn for 8031` step: an agent
   that only knows the browser URL passes the port and gets the build."
   [conn port]
   (let [p (cond
@@ -430,17 +422,15 @@
           (.catch (fn [_] nil))))))
 
 ;; ---------------------------------------------------------------------------
-;; Forgiving suffix→canonical build resolution (rf2-qda59).
+;; Forgiving suffix→canonical build resolution.
 ;;
 ;; shadow-cljs build ids are namespaced keywords (`:examples/machine-epochs`).
 ;; An operator reading the app at a glance — or copying a name out of an
 ;; error / chat — naturally reaches for the short tail (`machine-epochs`).
-;; Before this, `discover-app` happened to normalise (it auto-selects a
-;; single build or resolves by port), but the read/action ops compared the
-;; requested id against `active-builds` by EXACT `=`, so a suffix form was
-;; rejected with `:build-not-running` even though the build it named was
-;; right there in the error's own `:running-builds` list. One shared
-;; forgiving resolver closes the asymmetry across every op.
+;; One shared forgiving resolver accepts a bare tail uniformly across
+;; every op, so a suffix form resolves to the running build it names
+;; rather than being rejected with `:build-not-running` even when that
+;; build sits right there in the error's own `:running-builds` list.
 ;;
 ;; Match rule (deterministic, no most-recent / fuzzy heuristics — those
 ;; are the silent-wrong-build footguns Mike rejected for `auto-select`):
@@ -458,7 +448,7 @@
 
 (defn match-running-build
   "Resolve `requested` (a build-id keyword) against the `running` vector of
-  build-id keywords by exact-or-unique-suffix match (rf2-qda59). Returns
+  build-id keywords by exact-or-unique-suffix match. Returns
   the canonical running keyword on a hit, else `requested` unchanged (so a
   no/ambiguous match falls through to the diagnostic ladder). Pure."
   [requested running]
@@ -473,7 +463,7 @@
         requested))))
 
 (defn canonicalize-build!
-  "Forgiving suffix→canonical build resolution (rf2-qda59). Resolves a
+  "Forgiving suffix→canonical build resolution. Resolves a
   Promise of the canonical running build-id for `requested`:
 
     - `requested` already in this socket's confirmed `:probed-builds`
@@ -513,7 +503,7 @@
 
 (defn auto-select-single-build
   "Resolve a build-id when EXACTLY ONE shadow-cljs build is running, else
-  nil (rf2-v70kv). Returns a Promise resolving to `[build-id true]` when
+  nil. Returns a Promise resolving to `[build-id true]` when
   one build was auto-selected, or `[nil false]` when zero or many run.
 
   Unlike `resolve-build!` (the eval-path resolver, which REJECTS on
@@ -545,7 +535,7 @@
     (str "pass --build=" (build-arg-form (first running)) " or set SHADOW_CLJS_BUILD_ID.")
 
     :else
-    ;; Round-trippable copy-paste forms (rf2-qda59).
+    ;; Round-trippable copy-paste forms.
     (str "multiple shadow-cljs builds are running " (running-build-arg-forms running)
          "; pass --build=<one-of-them> or set SHADOW_CLJS_BUILD_ID.")))
 
@@ -588,7 +578,7 @@
                                                          "not running.")}))))))))
 
 (defn resolve-and-preflight!
-  "The shared eval-path guard (rf2-ivlb3). Resolves the build then
+  "The shared eval-path guard. Resolves the build then
   confirms a live re-frame2-pair runtime for it. Resolves to the
   resolved build-id on success; rejects with a structured ex-info
   otherwise.
@@ -657,7 +647,7 @@
     (wire/err-text {:ok? false :reason fallback-reason :message (.-message err)})))
 
 ;; ---------------------------------------------------------------------------
-;; Shared eval-prelude (rf2-jkake.19).
+;; Shared eval-prelude.
 ;;
 ;; The single-eval read/write tools all wear the SAME four-step promise
 ;; chain: confirm the runtime is preloaded, send ONE form over nREPL,
@@ -671,7 +661,7 @@
 ;;
 ;; State-emitting tools wear the SAME chain plus ONE extra step: a
 ;; `raw-state/signal-runtime!` reconfigure between `ensure-runtime!` and
-;; the eval (the raw-state tap gate, rf2-c2dtu) so the runtime is in its
+;; the eval (the raw-state tap gate) so the runtime is in its
 ;; gated posture before the eval taps / egresses app-db.
 ;; `eval-after-runtime-signalled!` is the sibling combinator for that
 ;; shape — same prelude/postlude, the signal interposed.
@@ -689,7 +679,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn eval-after-runtime!
-  "The shared single-eval prelude (rf2-jkake.19). Confirm the runtime is
+  "The shared single-eval prelude. Confirm the runtime is
   preloaded for `(conn, build-id)`, eval `form` over nREPL, pass the
   resolved value to `on-value` (which returns the MCP envelope), and
   translate any rejection via `err->result` keyed by `fail-reason`.
@@ -712,7 +702,7 @@
   "The shared single-eval prelude for STATE-EMITTING tools. Identical to
   `eval-after-runtime!` except it interposes one extra step — a
   `raw-state/signal-runtime!` reconfigure between `ensure-runtime!` and
-  the eval (the raw-state tap gate, rf2-c2dtu) — so the runtime is in its
+  the eval (the raw-state tap gate) — so the runtime is in its
   gated (default-elided) posture before the eval taps / egresses app-db.
 
   Confirm the runtime is preloaded for `(conn, build-id)`, signal the
@@ -723,7 +713,7 @@
 
   `on-value` carries the part that genuinely differs per tool. The signal
   re-runs on every call rather than caching a per-build flag — the
-  runtime's posture resets on reload (rf2-olvr5 finding 2). As with
+  runtime's posture resets on reload. As with
   `eval-after-runtime!`, `nrepl/cljs-eval-value` is resolved per-call (a
   plain var reference) so the per-tool `set!`-based test seam keeps
   working through this helper."
@@ -735,10 +725,9 @@
       (.catch (fn [err] (err->result fail-reason err)))))
 
 ;; ---------------------------------------------------------------------------
-;; Map-envelope projection for the "runtime fn always returns a map" tools
-;; (rf2-u4s4x).
+;; Map-envelope projection for the "runtime fn always returns a map" tools.
 ;;
-;; `read-dom` and `read-ui` (rf2-q0r7e) both route a single
+;; `read-dom` and `read-ui` both route a single
 ;; `(re-frame2-pair.runtime/<dom-read|ui-read> {...})` form through
 ;; `eval-after-runtime!`. The runtime fn ALWAYS returns a map (its own
 ;; `{:ok? ...}` envelope, or a structured no-document / bad-selector
@@ -749,26 +738,25 @@
 ;;
 ;; Left unguarded, `(wire/ok-text nil)` projects to a `null`
 ;; structuredContent the npm SDK's outputSchema validation rejects at the
-;; transport layer (`expected record at structuredContent, received null`,
-;; rf2-r5erl) — bypassing the normal `{:ok? false}` error contract. Both
-;; read tools carried a byte-for-byte-identical map?/blank guard; this
-;; helper folds it onto ONE projection so a fix or regression-guard on the
-;; blank-result contract covers both. Only the per-tool `:reason`, `:hint`,
-;; and any extra error slots (read-dom echoes `:selector`) differ — those
-;; ride in as args.
+;; transport layer (`expected record at structuredContent, received null`)
+;; — bypassing the normal `{:ok? false}` error contract. This helper
+;; folds the shared map?/blank guard onto ONE projection so a fix or
+;; regression-guard on the blank-result contract covers both read tools.
+;; Only the per-tool `:reason`, `:hint`, and any extra error slots
+;; (read-dom echoes `:selector`) differ — those ride in as args.
 ;; ---------------------------------------------------------------------------
 
 (defn map-result-or-blank
   "Build the `on-value` callback for a tool whose runtime fn always
-  returns a MAP envelope (rf2-u4s4x — read-dom / read-ui). Returns a
+  returns a MAP envelope (read-dom / read-ui). Returns a
   1-arity fn suitable as `eval-after-runtime!`'s `on-value`:
 
     - a `:ok? true` MAP envelope ⇒
       `(wire/ok-text (assoc envelope :build build-id))`, echoing the
-      canonical resolved `:build` (rf2-8t3ct / rf2-fmho5).
+      canonical resolved `:build`.
     - a `:ok? false` MAP envelope ⇒ `(wire/err-text ...)` carrying the
-      runtime's own structured failure verbatim, `:build`-stamped
-      (rf2-q7cavs). The runtime fn returns `:ok? false` ONLY on a
+      runtime's own structured failure verbatim, `:build`-stamped.
+      The runtime fn returns `:ok? false` ONLY on a
       genuine fault — a thrown `:rf.error/read-dom-bad-selector` /
       `:rf.error/ui-read-bad-selector` (malformed CSS ⇒ querySelectorAll
       threw), `:rf.error/read-dom-no-document`, `:no-element`,
@@ -786,8 +774,8 @@
       a different layer).
     - a nil / non-map ⇒ `(wire/err-text {...})` carrying `:ok? false`,
       `:build`, the per-tool `:reason` / `:hint`, and any `error-extras`
-      (e.g. read-dom's `:selector`) — the rf2-r5erl-safe structured
-      blank-result error (never a `null` structuredContent).
+      (e.g. read-dom's `:selector`) — the structured blank-result error
+      (never a `null` structuredContent).
 
   `blank-reason` / `blank-hint` are the tool-specific blank-result
   vocabulary; `error-extras` is an optional map of extra slots merged

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/raw_state.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/raw_state.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.raw-state
-  "Raw-state boot-gate (rf2-c2dtu).
+  "Raw-state boot-gate.
 
   re-frame2-pair-mcp's direct-read surfaces (`snapshot`, `get-path`, `subscribe`
   on `:epoch`) can return verbatim slices of a live app's state. The
@@ -21,12 +21,11 @@
      nREPL round-trip issued before every state-emitting tool eval —
      re-signalled rather than cached-as-delivered, because the runtime's
      posture resets to its permissive default on every page/runtime
-     reload (rf2-olvr5 finding 2; see `signal-runtime!`).
+     reload (see `signal-runtime!`).
 
-  When `--allow-sensitive-reads` is ON, the per-call args win — the same
-  behaviour re-frame2-pair-mcp shipped pre-rf2-c2dtu.
+  When `--allow-sensitive-reads` is ON, the per-call args win.
 
-  ## Single intention-naming predicate (rf2-p1qli)
+  ## Single intention-naming predicate
 
   Call sites consume the gate state through ONE predicate:
 
@@ -46,24 +45,20 @@
 
   The predicate name asserts the operator's opt-in state directly —
   the truthy value means \"the operator opted in via --allow-sensitive-reads\".
-  This replaces the prior `force-redact?` / `force-elision?` pair which
-  returned `(not @allow-raw-state?)` and required three negations to
-  trace through (see rf2-p1qli / audit Finding #2).
+  Positive-sense and single-name, it answers \"did the operator opt
+  in?\" without negation gymnastics at the call site.
 
-  Symmetric with:
-    - rf2-uaymx (b) / rf2-g9fje `--allow-sensitive-reads` (story-mcp)
+  Symmetric with the story-mcp `--allow-sensitive-reads` flag.
 
-  Note: re-frame2-pair-mcp's `eval-cljs` gate was inverted in rf2-a0z0h
-  — eval-cljs now defaults ON, with `--no-eval` as the opt-out. The
-  raw-state gate keeps its default-OFF posture because privacy elision
-  IS a separable protection (eval-cljs surfaces what an operator asked
-  for; raw reads can pour the entire app-db into the wire log without
-  the operator ever typing the secret).
+  re-frame2-pair-mcp's `eval-cljs` gate defaults ON, with `--no-eval` as
+  the opt-out. The raw-state gate keeps a default-OFF posture because
+  privacy elision IS a separable protection (eval-cljs surfaces what an
+  operator asked for; raw reads can pour the entire app-db into the wire
+  log without the operator ever typing the secret).
 
-  Per rf2-2x3ql the pair-mcp CLI flag is `--allow-sensitive-reads`
-  (canonical cross-MCP name). The internal Clojure identifiers below
-  retain `raw-state` for legacy reasons; only the operator-facing flag
-  was renamed.
+  The pair-mcp CLI flag is `--allow-sensitive-reads` (the canonical
+  cross-MCP name). The internal Clojure identifiers below use
+  `raw-state`.
 
   The gate is a single atom (`allow-raw-state?`) set by `server.cljs/main`
   from `process.argv` before the dispatcher starts handling tools/call
@@ -88,7 +83,7 @@
   @allow-raw-state?)
 
 (defn raw-state-allowed?
-  "Single intention-naming predicate (rf2-p1qli).
+  "Single intention-naming predicate.
 
   Returns `true` when the operator opted in via `--allow-sensitive-reads`
   at server launch; `false` otherwise (the published-build default).
@@ -105,11 +100,9 @@
                  (args/parse-bool-arg raw-args :elision)
                  true)
 
-  Replaces the pre-rf2-p1qli `force-redact?` / `force-elision?`
-  predicate-pair, both of which returned `(not @allow-raw-state?)` and
-  required three negations at the call site to answer \"did the operator
-  opt in?\" The new predicate is positive-sense, single-name, and
-  matches its truth value to the operator's intent."
+  Positive-sense and single-name, this predicate matches its truth
+  value to the operator's intent, so a call site answers \"did the
+  operator opt in?\" with no negation gymnastics."
   []
   @allow-raw-state?)
 
@@ -122,19 +115,18 @@
 ;; consumer (10x, custom dev panels, the user's own `add-tap` call) sees
 ;; the full state. That bypasses re-frame2-pair-mcp's wire-boundary redaction.
 ;;
-;; The runtime exposes `configure-raw-state!` (rf2-c2dtu) which sets a
+;; The runtime exposes `configure-raw-state!` which sets a
 ;; per-runtime flag controlling whether `app-db-reset!` taps raw values or
 ;; redacts via `elide-wire-value`. The MCP server pushes its boot-gate
 ;; state into the runtime before every state-emitting eval — the
 ;; per-runtime flag resets to its permissive default on every page/runtime
-;; reload, so the posture is re-signalled rather than cached as delivered
-;; (rf2-olvr5 finding 2).
+;; reload, so the posture is re-signalled rather than cached as delivered.
 
 (defonce ^:private runtime-signalling
   ;; Per-build-id IN-FLIGHT configure-raw-state! Promise. A second
   ;; concurrent caller for the same build awaits the SAME Promise rather
   ;; than firing a duplicate signal OR racing ahead while the first
-  ;; signal is still in flight (rf2-z7roa). Cleared once resolved.
+  ;; signal is still in flight. Cleared once resolved.
   ;;
   ;; Build-keyed because re-frame2-pair-mcp can talk to multiple shadow-cljs
   ;; builds over the same nREPL connection; each build has its own
@@ -148,35 +140,34 @@
   through `tap>`.
 
   ## Why this re-signals on EVERY call rather than caching 'delivered'
-  per build (rf2-olvr5 finding 2)
+  per build
 
   The runtime's `raw-state-config` atom defaults to `:allow-raw-state?
   true` (the bare-CLJS-REPL posture) and is RE-MINTED on every full page
   reload / CLJS heap reset — a fresh preload evaluation re-`defonce`s it
-  back to the permissive default, and re-mints `session-id` too. The
-  pre-fix shape recorded the signal as DELIVERED once per `build-id` per
-  server lifetime and short-circuited thereafter. So after a reload, the
-  build-id was still in the resolved set, `signal-runtime!` returned a
-  no-op, the freshly-recreated runtime stayed at its permissive default,
-  and the next state-emitting tool (snapshot / get-path / subscribe /
-  replace-app-db / restore-epoch / dispatch-dry-run / record /
-  watch-until) could tap RAW prev/next app-db through `tap>` even with
-  `--allow-sensitive-reads` OFF.
+  back to the permissive default, and re-mints `session-id` too. Caching
+  the signal as DELIVERED once per `build-id` per server lifetime would
+  leave the build-id in the resolved set after a reload, so
+  `signal-runtime!` would no-op, the freshly-recreated runtime would stay
+  at its permissive default, and the next state-emitting tool (snapshot /
+  get-path / subscribe / replace-app-db / restore-epoch /
+  dispatch-dry-run / record / watch-until) could tap RAW prev/next app-db
+  through `tap>` even with `--allow-sensitive-reads` OFF.
 
   The server can't cheaply know the current `session-id` without a
   round-trip, and `configure-raw-state!` is idempotent + tiny (one
   bencode round-trip on the persistent socket — same shape every call).
-  So the correct fix is to NOT cache the posture across runtime identity:
-  always reconfigure before a tap-emitting write. The per-build IN-FLIGHT
-  `runtime-signalling` dedup is preserved — a burst of concurrent
-  state-emitting calls for the same build still share ONE configure
-  Promise (the rf2-z7roa race guard: no caller proceeds to its
-  state-emitting eval ahead of the posture landing) — but once that
-  Promise resolves the next call reconfigures afresh rather than skipping.
+  So the posture is NOT cached across runtime identity: always
+  reconfigure before a tap-emitting write. The per-build IN-FLIGHT
+  `runtime-signalling` dedup still applies — a burst of concurrent
+  state-emitting calls for the same build share ONE configure Promise
+  (the race guard: no caller proceeds to its state-emitting eval ahead of
+  the posture landing) — but once that Promise resolves the next call
+  reconfigures afresh rather than skipping.
 
-  Failure (a runtime predating rf2-c2dtu) is swallowed silently — the
-  wire-side enforcement still holds, so a degraded runtime just means
-  `tap>` consumers see raw values (the pre-rf2-c2dtu posture).
+  Failure (a runtime without `configure-raw-state!`) is swallowed
+  silently — the wire-side enforcement still holds, so a degraded runtime
+  just means `tap>` consumers see raw values.
 
   Called between `ensure-runtime!` and the first state-emitting eval in
   each tool body that taps / egresses app-db. Returns a Promise resolving
@@ -185,7 +176,7 @@
   (if (contains? @runtime-signalling build-id)
     ;; A configure is already in flight for this build — share it so a
     ;; concurrent caller never races ahead of the posture landing
-    ;; (rf2-z7roa) and we don't fire a duplicate round-trip in the burst.
+    ;; and we don't fire a duplicate round-trip in the burst.
     (get @runtime-signalling build-id)
     (let [form (ef/emit
                  (ef/rt-call 'configure-raw-state!
@@ -193,16 +184,16 @@
           ;; Drop the in-flight entry on BOTH the success and swallowed-
           ;; failure arms. We do NOT record a permanent 'delivered' flag:
           ;; the runtime's posture resets on reload, so a future call must
-          ;; reconfigure (rf2-olvr5 finding 2).
+          ;; reconfigure.
           finish! (fn []
                     (swap! runtime-signalling dissoc build-id)
                     nil)
           p       (-> (nrepl/cljs-eval-value conn build-id form)
                       (.then (fn [_] (finish!)))
                       (.catch (fn [_]
-                                ;; Degraded runtime — predates rf2-c2dtu.
-                                ;; Swallow; the wire-side gate still
-                                ;; enforces.
+                                ;; Degraded runtime — no
+                                ;; `configure-raw-state!`. Swallow; the
+                                ;; wire-side gate still enforces.
                                 (finish!))))]
       (swap! runtime-signalling assoc build-id p)
       p)))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.read-dom
-  "Tool: read-dom — the RAW DOM plane read (rf2-nfjil).
+  "Tool: read-dom — the RAW DOM plane read.
 
   ## The two DOM-read planes (read-dom vs read-ui)
 
@@ -21,19 +21,20 @@
 
   re-frame2-pair has rich DATA-plane reads — `snapshot` / `get-path`
   (app-db), `trace-window` / `watch-epochs` (epoch history),
-  `list-subscriptions` (the reactive sub-cache). What it lacked: a way to
-  ask what the app actually RENDERED, by an explicit selector, with no
-  re-frame2 awareness. Answering \"did the UI update?\", \"what does the
-  rendered node / attribute say?\" meant hand-rolling an `eval-cljs` form
-  around `js/document.querySelectorAll` on every call — fiddly, easy to
-  get wrong (text never capped → a multi-megabyte innerText blows the
-  wire cap), and not discoverable in the catalogue. The App-db
-  stale-frame bug (rf2-yng0y) was only diagnosable by reading the DOM
-  repeatedly; this op makes that a first-class gesture.
+  `list-subscriptions` (the reactive sub-cache). `read-dom` complements
+  them with a way to ask what the app actually RENDERED, by an explicit
+  selector, with no re-frame2 awareness. It answers \"did the UI
+  update?\", \"what does the rendered node / attribute say?\" as a
+  first-class, discoverable gesture — capping per-node text at the source
+  (so a multi-megabyte innerText never blows the wire cap) rather than
+  leaving the caller to hand-roll an `eval-cljs` form around
+  `js/document.querySelectorAll`. Diagnosing a stale-frame app-db bug by
+  reading the DOM repeatedly is exactly the kind of workflow it makes
+  cheap.
 
-  ## One shared DOM-read core with read-ui (rf2-q0r7e)
+  ## One shared DOM-read core with read-ui
 
-  Both planes now route through the SAME runtime ns
+  Both planes route through the SAME runtime ns
   (`re-frame2-pair.runtime`): read-dom emits
   `(re-frame2-pair.runtime/dom-read {...})` and read-ui emits
   `(re-frame2-pair.runtime/ui-read {...})`, via the SAME `eval-form` DSL
@@ -41,35 +42,29 @@
   (`probe/eval-after-runtime!`). The per-node projection (tag + capped
   text + attribute map) lives ONCE, in the runtime's `node->content`.
 
-  This folds away a maintenance hazard. read-dom previously INLINED its
-  whole browser-side core as a raw eval string, while read-ui called the
-  runtime fn — two divergent eval forms that rotted apart. rf2-w2mjm: the
-  inlined read-dom form lowered the tag with `(str/lower-case …)`, but
-  the BARE browser cljs-eval context the inlined string ran in aliases
-  NOTHING (no `:require`), so `str` was unresolved, the whole form nilled
-  out, and EVERY read-dom call came back `:read-dom-blank-result` — while
-  read-ui, calling the runtime ns (which DOES require `clojure.string`),
-  stayed green. Both ops gate on the preload runtime being present
-  (`ensure-runtime!`), so the inlining bought nothing; folding read-dom
-  onto the runtime fn removes the alias trap by construction — the core
-  now runs in a namespace with real requires.
+  Routing both planes through the runtime fn keeps a single core for both
+  ops and runs it in a namespace with real `:require`s — so helpers like
+  `clojure.string` resolve, unlike a bare browser cljs-eval context that
+  aliases nothing. Both ops gate on the preload runtime being present
+  (`ensure-runtime!`), so there is no value in inlining the browser-side
+  core as a raw eval string.
 
   ## Naming — the `read-` verb (NAMING.md §The verb table)
 
   Named `read-dom` (not `dom-read`) to ride the catalogued `read-<thing>`
   verb prefix: a cheap reflection of already-rendered state — the render
   already happened; this is a no-recompute read of its output, never a
-  fetch that triggers a render. (The runtime fn it calls keeps the
-  historical `dom-read` spelling — see the runtime ns's MCP-vs-runtime
-  naming table.) The verb-vocab conformance linter
+  fetch that triggers a render. (The runtime fn it calls uses the
+  `dom-read` spelling — see the runtime ns's MCP-vs-runtime naming
+  table.) The verb-vocab conformance linter
   (`tools/mcp-conformance/wire-vocab`) classifies tool names by prefix;
   `read-` is conformant with zero catalogue churn.
 
-  ## Pairs with `:await-render` (rf2-gfu33)
+  ## Pairs with `:await-render`
 
   `dispatch {:await-render true}` resolves only after the substrate
   has flushed the new state to the DOM. The natural follow-up is
-  `read-dom` — `dispatch → settle → read` is now a deterministic
+  `read-dom` — `dispatch → settle → read` is a deterministic
   three-step gesture with no manual requestAnimationFrame dance.
 
   ## Read-only by construction
@@ -86,11 +81,11 @@
   fn, so only the already-bounded EDN crosses the wire — a 5 MB `<pre>`
   blob never leaves the tab. Over-cap text is replaced with the
   framework's size-elision marker shape `{:rf.size/large-elided {...}}`
-  (the same convention `get-path` / `snapshot` emit, per rf2-urjnc) so
+  (the same convention `get-path` / `snapshot` emit) so
   the agent recognises an elision at a glance. The wire-boundary cap step
   (`tools.cljs` §`:apply-cap`) remains the backstop.
 
-  ## Privacy — value-redact derived content (rf2-p9scds)
+  ## Privacy — value-redact derived content
 
   Rendered DOM text / attribute values can carry a secret copied out of a
   declared-sensitive app-db slot — a non-app-db position the path-based
@@ -159,7 +154,7 @@
   "Per-node `textContent` character cap (default). Text longer than this
   is replaced with the `:rf.size/large-elided` marker carrying `:chars`
   — same shape `get-path` / `snapshot` emit for over-threshold app-db
-  slots (rf2-urjnc), so the agent recognises an elision uniformly."
+  slots, so the agent recognises an elision uniformly."
   2000)
 
 (defn- parse-attrs-arg
@@ -181,7 +176,7 @@
 
 (defn- read-dom-form
   "Compose a single `(re-frame2-pair.runtime/dom-read {...})` form via the
-  shared `eval-form` DSL (rf2-q0r7e) — the SAME plumbing read-ui uses. The
+  shared `eval-form` DSL — the SAME plumbing read-ui uses. The
   runtime fn does the whole read (querySelectorAll, per-node text cap,
   attribute collection, node `:limit`) in the tab, so only bounded EDN
   crosses the wire.
@@ -190,7 +185,7 @@
   names (no `data-*`/`aria-*` sweep); omitting it (nil) ⇒ the curated
   default set + the sweep, resolved runtime-side. A `frame` keyword (when
   supplied) names the frame whose declared-sensitive app-db values the
-  rendered nodes are value-redacted against (rf2-p9scds); omitting it lets
+  rendered nodes are value-redacted against; omitting it lets
   the runtime resolve the operating frame. The runtime fn is read-only
   (querySelectorAll + textContent + attribute strings)."
   [selector sub-selector limit max-text attrs frame]
@@ -220,7 +215,7 @@
         max-text     (let [m (wire/arg raw-args :max-text)]
                        (if (and (number? m) (pos? m)) (long m) default-max-text))
         attrs        (parse-attrs-arg (wire/arg raw-args :attrs))
-        ;; rf2-p9scds — the frame whose declared-sensitive app-db values the
+        ;; The frame whose declared-sensitive app-db values the
         ;; rendered nodes are value-redacted against (off-box gate). Omitted
         ;; ⇒ the runtime resolves the operating frame and fails closed on an
         ;; ambiguous one.
@@ -236,7 +231,7 @@
       :else
       (let [form (read-dom-form selector sub-selector limit max-text attrs frame)]
         ;; The runtime's `dom-read` ALWAYS returns a map, so a non-map at
-        ;; `on-value` means a BLANK eval (rf2-r5erl). The shared
+        ;; `on-value` means a BLANK eval. The shared
         ;; `probe/map-result-or-blank` projects a map → `ok-text` with the
         ;; `:build` echo, or a blank → a structured `:ok? false` error (so
         ;; `ok-text` never sees `nil` and emits the `null` structuredContent

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_sub.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_sub.cljs
@@ -1,8 +1,8 @@
 (ns re-frame2-pair-mcp.tools.read-sub
-  "Tool: read-sub — validated one-shot subscription read (rf2-3bu3d.7).
+  "Tool: read-sub — validated one-shot subscription read.
 
   Reading a subscription value is the SINGLE most common read on any
-  re-frame2 app, and the pre-existing options all leaked:
+  re-frame2 app. Two lower-level approaches each leak:
 
     (a) raw `eval-cljs` `@(re-frame.core/subscribe [:foo args])` — works,
         but stringly (the caller must know the ns alias), UNVALIDATED (a
@@ -13,7 +13,7 @@
         materialised in the cache; a not-yet-mounted sub is absent.
 
   `read-sub` is the first-class read with NO-SILENT-SWALLOW PARITY with
-  `dispatch` (rf2-3bu3d.2 / rf2-3bu3d.3 / rf2-vflrg):
+  `dispatch`:
 
     1. Parse the `sub` arg as EDN ONCE server-side and require a
        `vector?` shape — host-form source (`(rf/subscribe ...)`) is
@@ -22,7 +22,7 @@
        The payload is data, not host source.
     2. VALIDATE the sub-id against the live `:sub` registrar (runtime-side
        `read-sub!` → `validate-sub-id`): an unknown id returns the SAME
-       structured `:reason :unknown-id` + `:nearest` matches dispatch now
+       structured `:reason :unknown-id` + `:nearest` matches dispatch
        returns — never a silent nil.
     3. Subscribe + deref ONCE; a deref/computation throw returns
        `:reason :sub-error` (a structured error, not a bare nil).
@@ -98,7 +98,7 @@
   / `:sub-error` / `:not-a-sub-vector`) carry no `:value` slot, so the
   elision walk fires only on `(:ok? res)`.
 
-  `walk?` (rf2-t55hxg.13) — whether the walker fires at all. NOT
+  `walk?` — whether the walker fires at all. NOT
   `elision?`: a bare `:elision false` still walks (sensitive redacts,
   large passes via `elision-opts`); only a deliberate full-raw opt-in
   (`:elision false` AND `:include-sensitive true`) ships the value bare."
@@ -124,9 +124,9 @@
         frame    (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         sub-str  (wire/arg raw-args :sub)
         ;; Same `--allow-sensitive-reads` gate posture as snapshot's
-        ;; `:sub-cache` slice / get-path / list-subscriptions (rf2-c2dtu /
-        ;; rf2-vflrg / rf2-f1ose): gate OFF forces elision on + sensitive
-        ;; off; the per-call args win only when the operator opted in.
+        ;; `:sub-cache` slice / get-path / list-subscriptions: gate OFF
+        ;; forces elision on + sensitive off; the per-call args win only
+        ;; when the operator opted in.
         elision? (if (raw-state/raw-state-allowed?)
                    (args/parse-bool-arg raw-args :elision)
                    true)
@@ -136,7 +136,7 @@
         ;; `elision-opts-edn` takes walker-aligned `include-large?` — MCP
         ;; `elision` true = emit markers = `:include-large?` false.
         elision-opts (elision/elision-opts-edn (not elision?) incl?)
-        ;; rf2-t55hxg.13 — fail-CLOSED: walk UNLESS the caller opted into
+        ;; Fail-CLOSED: walk UNLESS the caller opted into
         ;; both raw axes (`:elision false` AND `:include-sensitive true`).
         ;; A bare `:elision false` still walks so a declared-sensitive sub
         ;; value redacts to `:rf/redacted` while large content passes.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
@@ -1,6 +1,5 @@
 (ns re-frame2-pair-mcp.tools.read-ui
-  "Tool: read-ui — the typed `ui/read` (a.k.a. `view/rendered`) op
-  (rf2-3bu3d.1).
+  "Tool: read-ui — the typed `ui/read` (a.k.a. `view/rendered`) op.
 
   ## The two DOM-read planes (read-ui vs read-dom)
 
@@ -31,11 +30,12 @@
   round-trip, return BOTH the rendered subtree AND the producing entity
   (view-id, source-coord, render-key, subs-read).
 
-  Before this op, that meant hand-rolling an `eval-cljs` querySelectorAll +
-  textContent slice with GUESSED selectors, then a SECOND round-trip to
-  map the node back to a view. `read-ui` first-classes the whole gesture.
+  `read-ui` first-classes the whole gesture, so there's no need to
+  hand-roll an `eval-cljs` querySelectorAll + textContent slice with
+  GUESSED selectors and then take a SECOND round-trip to map the node
+  back to a view.
 
-  ## One shared DOM-read core with read-dom (rf2-q0r7e)
+  ## One shared DOM-read core with read-dom
 
   Both planes route through the SAME runtime ns
   (`re-frame2-pair.runtime`): read-ui emits
@@ -45,9 +45,9 @@
   (`probe/eval-after-runtime!`). The per-node projection (tag + capped
   text + attribute map) lives ONCE, in the runtime's `node->content`; the
   view plane layers entity-resolution + privacy elision ON TOP of it. A
-  fix or a regression-guard on the shared form covers BOTH ops, so neither
-  can silently break alone (the rf2-w2mjm failure mode, where read-dom's
-  separately-inlined eval form nilled out while read-ui stayed green).
+  fix or a regression-guard on the shared form covers BOTH ops, so
+  neither can silently break alone — there is no separately-inlined eval
+  form for one op to rot apart from the other.
 
   ## Naming — the `ui/read` op, the `read-` verb
 
@@ -69,17 +69,18 @@
   works on ANY re-frame2 app with NO app-specific test ids — it never
   guesses a selector and never re-implements view discovery.
 
-  ## Privacy — value-redact derived content (rf2-p9scds)
+  ## Privacy — value-redact derived content
 
   The runtime value-redacts the WHOLE rendered `:content` (text AND attrs)
   through `re-frame.core/redact-derived-slots` against the frame's declared-
   `:sensitive?` app-db values, under the off-box egress posture (the
   published-build default). Rendered DOM text / attrs sit at a non-app-db
-  position the path-based `elide-wire-value` walker can never reach — a bare
-  `(elide-wire-value text {:frame …})` over the anonymous string was a no-op
-  for a secret copied INTO the DOM, and attrs were never touched. The value-
-  based dual catches both. A hard per-node `max-text` cap trims the common
-  large case first; raw content is the trusted-local read (launched with
+  position the path-based `elide-wire-value` walker can never reach — a path-
+  based `(elide-wire-value text {:frame …})` over an anonymous string is a
+  no-op for a secret copied INTO the DOM, and never touches attrs. The
+  value-based redaction catches both text and attrs. A hard per-node
+  `max-text` cap trims the common large case first; raw content is the
+  trusted-local read (launched with
   `--allow-sensitive-reads`); an unresolvable frame fails closed with
   `:ambiguous-frame`. The wire-boundary cap step (`tools.cljs` §`:apply-cap`)
   remains the backstop.
@@ -131,7 +132,7 @@
   "Per-node `textContent` character cap (default). Text longer than this
   is replaced with the `:rf.size/large-elided` marker carrying `:chars`
   — the same shape `get-path` / `snapshot` emit for over-threshold app-db
-  slots (rf2-urjnc), so the agent recognises an elision uniformly."
+  slots, so the agent recognises an elision uniformly."
   2000)
 
 (defn- frame-edn
@@ -143,7 +144,7 @@
 
 (defn- read-ui-form
   "Compose the single `(re-frame2-pair.runtime/ui-read {...})` form via the
-  shared `eval-form` DSL (rf2-q0r7e) — the SAME plumbing read-dom uses.
+  shared `eval-form` DSL — the SAME plumbing read-dom uses.
   Only present entry points / knobs ride (the runtime enforces the
   precedence view-id > point > selector). Pure form-builder, no
   connection: callable directly by the form-composition regression guard
@@ -199,12 +200,12 @@
                       (when (map? m) (select-keys m [:x :y]))))
             form  (read-ui-form vid pt selector max-text frame)]
         ;; The runtime's `ui-read` ALWAYS returns a map, so a non-map at
-        ;; `on-value` means a BLANK eval (rf2-r5erl, the sibling of
-        ;; read-dom's bug). The shared `probe/map-result-or-blank` projects
-        ;; a map → `ok-text` with the `:build` echo (rf2-8t3ct / rf2-fmho5),
-        ;; or a blank → a structured `:ok? false` error so `ok-text` never
-        ;; sees `nil` and emits the `null` structuredContent the SDK rejects.
-        ;; read-dom carries the identical projection.
+        ;; `on-value` means a BLANK eval. The shared
+        ;; `probe/map-result-or-blank` projects a map → `ok-text` with the
+        ;; `:build` echo, or a blank → a structured `:ok? false` error so
+        ;; `ok-text` never sees `nil` and emits the `null`
+        ;; structuredContent the SDK rejects. read-dom carries the
+        ;; identical projection.
         (probe/eval-after-runtime!
           conn build-id form :rf.error/read-ui-failed
           (probe/map-result-or-blank

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
@@ -1,15 +1,15 @@
 (ns re-frame2-pair-mcp.tools.record
-  "Tools: record + read-recording — first-class signal recorder (rf2-zo4b9).
+  "Tools: record + read-recording — first-class signal recorder.
 
   ## Why a recorder primitive
 
-  Intermittent / human-in-the-loop bugs (the rf2-yng0y render-timing
-  race, only reproducible under real mouse input) need a recorder:
-  install an observer, let the human interact, read back a change-log.
-  That move used to be hand-built each session — a `requestAnimationFrame`
-  loop pushing focus-slot + DOM snapshots into `window.__zoombug`. It was
-  decisive but bespoke and footgun-prone (rAF timing, change-dedup,
-  teardown). This first-classes it.
+  Intermittent / human-in-the-loop bugs (a render-timing race only
+  reproducible under real mouse input) need a recorder: install an
+  observer, let the human interact, read back a change-log. `record`
+  first-classes that move so it needn't be hand-built each session as a
+  bespoke, footgun-prone `requestAnimationFrame` loop pushing focus-slot
+  + DOM snapshots into a global (rAF timing, change-dedup, teardown all
+  solved once here).
 
   ## The op pair
 
@@ -46,7 +46,7 @@
   reaches the browser runtime and has an observable side-effect on the
   runtime's recording registry, but no app-state mutation).
 
-  ## Off-box-egress redaction (rf2-8fin7.2)
+  ## Off-box-egress redaction
 
   Read-only addresses no-MUTATION, NOT sensitive-VALUE egress. The
   `{:app-db [path]}` / `{:sub [query-v]}` signals sample raw app-db-derived
@@ -127,9 +127,9 @@
   into the runtime predicate below). Unknown keys are dropped.
 
   Returns the tagged `[:ok m]` / `[:err :invalid-stop-edn]` shape
-  (mirroring `parse-filter-arg`, rf2-5kbkl / rf2-e2i29) so the caller can
-  surface a malformed `stop` EDN as an honest `:ok? false` error rather
-  than recording with the silent default window. The success shapes:
+  (mirroring `parse-filter-arg`) so the caller can surface a malformed
+  `stop` EDN as an honest `:ok? false` error rather than recording with
+  the silent default window. The success shapes:
 
     - `[:ok {}]`   — absent `stop` (runtime applies its default
                      wall-clock window).
@@ -139,12 +139,11 @@
 
   The failure shape `[:err :invalid-stop-edn]` is returned when a `stop`
   EDN STRING fails to `read-string`, OR reads cleanly but is not a map
-  (e.g. `\"[:ms 5000]\"`). Pre-rf2-e2i29 both branches silently collapsed
-  to `{}` — a typo'd `stop {:ms 5000}` (wanting a 5s window) silently got
-  the default window with no corrective signal, the same broken-success
-  shape rf2-5kbkl eliminated for the filter arg. The tag lets `record-tool`
-  short-circuit to the same honest-error envelope `:no-signals` already
-  uses, before touching the nREPL socket."
+  (e.g. `\"[:ms 5000]\"`). Surfacing the error rather than silently
+  collapsing to `{}` means a typo'd `stop {:ms 5000}` (wanting a 5s
+  window) gets a corrective signal instead of the default window. The
+  tag lets `record-tool` short-circuit to the same honest-error envelope
+  `:no-signals` already uses, before touching the nREPL socket."
   [raw]
   (cond
     (nil? raw)    [:ok {}]
@@ -166,8 +165,8 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The MCP surface takes a DATA predicate (EDN), never host source — the
-;; same injection-closing posture `dispatch` / `replace-app-db` adopted
-;; (rf2-vflrg). We compile the data predicate into a CLJS fn server-side-
+;; same injection-closing posture `dispatch` / `replace-app-db` adopt.
+;; We compile the data predicate into a CLJS fn server-side-
 ;; emitted-into-the-form so the runtime's `start-recording!` / `watch-until`
 ;; receives a real `:pred-fn`. The predicate map is matched against the
 ;; positional sample map `{<signal-index> <value>}`:
@@ -192,7 +191,7 @@
   always DATA, never host source: a hostile `:equals (js/alert \"x\")`
   becomes `(quote (js/alert \"x\"))` — compared as a literal list, never
   evaluated. Same injection-closing posture as `dispatch` /
-  `replace-app-db` (rf2-vflrg). The `:path` vector and the `:signal` index
+  `replace-app-db`. The `:path` vector and the `:signal` index
   are quoted / integer-coerced for the same reason."
   [pred]
   (when (map? pred)
@@ -244,7 +243,7 @@
   slot carries synthesised CLJS source, which can't ride the EDN-literal
   arg path).
 
-  rf2-8fin7.2 — `elision-opts` is the rendered `elision-opts-edn` walker
+  `elision-opts` is the rendered `elision-opts-edn` walker
   map (the `--allow-sensitive-reads` gate + per-call `:include-sensitive`
   posture). It rides as `:elide-opts` so the runtime's sampler elides
   each `:app-db` / `:sub` value for off-box egress before it lands in the
@@ -268,29 +267,29 @@
   (let [build-id    (wire/arg-build conn raw-args)
         frame       (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         signals     (parse-signals-arg (wire/arg raw-args :signals))
-        ;; rf2-e2i29 — `parse-stop-arg` returns the tagged
+        ;; `parse-stop-arg` returns the tagged
         ;; `[:ok m]` / `[:err :invalid-stop-edn]` shape (mirroring
-        ;; `parse-filter-arg`, rf2-5kbkl). A malformed `stop` EDN
-        ;; short-circuits to an honest `:ok? false` envelope below rather
-        ;; than silently collapsing to `{}` (the default wall-clock
-        ;; window) — a typo'd `stop {:ms 5000}` would otherwise record
-        ;; with the wrong stop condition and no corrective signal.
+        ;; `parse-filter-arg`). A malformed `stop` EDN short-circuits to
+        ;; an honest `:ok? false` envelope below rather than silently
+        ;; collapsing to `{}` (the default wall-clock window) — a typo'd
+        ;; `stop {:ms 5000}` would otherwise record with the wrong stop
+        ;; condition and no corrective signal.
         [stop-tag stop] (parse-stop-arg (wire/arg raw-args :stop))
         max-entries (let [m (wire/arg raw-args :max-entries)]
                       (when (and (number? m) (pos? m)) (long m)))
-        ;; rf2-8fin7.2 — the `:app-db` / `:sub` samples this recorder ships
-        ;; back via `read-recording` must be elided for off-box egress.
-        ;; Same gate posture as snapshot / get-path / trace-window
-        ;; (rf2-c2dtu / rf2-p1qli): the `--allow-sensitive-reads` boot gate
-        ;; forces `:include-sensitive false` + `:elision true` when OFF
-        ;; (the published default); gate ON honours the per-call args.
+        ;; The `:app-db` / `:sub` samples this recorder ships back via
+        ;; `read-recording` must be elided for off-box egress. Same gate
+        ;; posture as snapshot / get-path / trace-window: the
+        ;; `--allow-sensitive-reads` boot gate forces `:include-sensitive
+        ;; false` + `:elision true` when OFF (the published default);
+        ;; gate ON honours the per-call args.
         elision?    (if (raw-state/raw-state-allowed?)
                       (args/parse-bool-arg raw-args :elision)
                       true)
         incl?       (if (raw-state/raw-state-allowed?)
                       (args/parse-bool-arg raw-args :include-sensitive)
                       false)
-        ;; rf2-suoj2 polarity — MCP `elision` true = emit markers =
+        ;; Polarity — MCP `elision` true = emit markers =
         ;; `:include-large?` false, hence `(not elision?)`.
         elision-opts (elision/elision-opts-edn (not elision?) incl?)]
     (cond
@@ -301,10 +300,10 @@
            :hint (str "usage: record {signals '[{:focus true} {:dom \"#count\"} "
                       "{:app-db [:cart :items]}]' [stop {:ms 30000}] [frame :rf/default]}")}))
 
-      ;; rf2-e2i29 — the `stop` EDN failed to parse (or read clean but
-      ;; non-map). Surface an honest `:ok? false` error (same
-      ;; one-cond-branch shape as `:no-signals` above) instead of
-      ;; recording with the silent default window. No nREPL socket touched.
+      ;; The `stop` EDN failed to parse (or read clean but non-map).
+      ;; Surface an honest `:ok? false` error (same one-cond-branch shape
+      ;; as `:no-signals` above) instead of recording with the silent
+      ;; default window. No nREPL socket touched.
       (= :err stop-tag)
       (js/Promise.resolve
         (wire/err-text
@@ -316,11 +315,11 @@
 
       :else
       (let [form (start-recording-form signals stop frame max-entries elision-opts)]
-        ;; rf2-8fin7.2 — the signalled prelude inserts `signal-runtime!`
-        ;; between `ensure-runtime!` and the eval (the raw-state tap gate,
-        ;; rf2-c2dtu) so the runtime is in the OFF posture before the
-        ;; background sampler ticks. The plain `eval-after-runtime!` skips
-        ;; the signal step, so this uses the `-signalled!` sibling.
+        ;; The signalled prelude inserts `signal-runtime!` between
+        ;; `ensure-runtime!` and the eval (the raw-state tap gate) so the
+        ;; runtime is in the OFF posture before the background sampler
+        ;; ticks. The plain `eval-after-runtime!` skips the signal step,
+        ;; so this uses the `-signalled!` sibling.
         (probe/eval-after-runtime-signalled!
           conn build-id form :record-failed
           (fn [envelope] (wire/ok-text envelope)))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
@@ -1,19 +1,19 @@
 (ns re-frame2-pair-mcp.tools.registry
-  "Single source of truth for the re-frame2-pair-mcp tool catalogue (rf2-47g8l).
+  "Single source of truth for the re-frame2-pair-mcp tool catalogue.
 
   ## Why one registry
 
-  Before this ns landed, three places enumerated the tool list with no
-  compile-time validation they agreed:
+  This ns is the ONE place the tool list is enumerated, so three
+  downstream views can never drift apart:
 
   - `tool-descriptors` in `descriptors.cljs` — the `tools/list` surface.
   - `dispatch-tool*` in `tools.cljs` — the `tools/call` dispatcher.
   - `cacheable-tools` in `cache.cljs` — the per-tool cache opt-in.
 
-  A new tool added to the dispatcher without a descriptor silently
-  vanished from `tools/list`; a tool added to the descriptor without a
-  `cacheable-tools` entry silently no-op'd the `:cache` knob. The drift
-  was always *possible* and only caught (at best) by hand-review.
+  Generating all three from one source makes the drift class structurally
+  impossible: a tool can't reach the dispatcher without a descriptor (and
+  vanish from `tools/list`), nor carry a descriptor without a cache
+  decision (and silently no-op the `:cache` knob).
 
   ## What's here
 
@@ -54,8 +54,8 @@
 
   Land *one* map entry in the `tools` vector below — name, handler,
   cacheable flag, descriptor. The three downstream views update
-  automatically; drift is structurally impossible. Per-tool ns provides
-  the handler implementation as before.
+  automatically; drift is structurally impossible. The per-tool ns
+  provides the handler implementation.
 
   ## Layout
 
@@ -98,7 +98,7 @@
 ;;
 ;; Handlers in the registry are LATE-BINDING — they call the per-tool fn
 ;; on each invocation rather than capturing a direct reference at load
-;; time. The `invoke-test` suite (rf2-nogok) stubs per-tool fns by
+;; time. The `invoke-test` suite stubs per-tool fns by
 ;; `set!`-ing their vars and expects subsequent dispatches to hit the
 ;; replacement. A captured reference would freeze the original and
 ;; break the seam. `ignoring-extra` takes a NAMESPACE-QUALIFIED var
@@ -114,7 +114,7 @@
 
   Callers wrap the per-tool fn in a `#(per-tool-fn %1 %2)` literal
   so the namespaced-symbol lookup happens per-call. That preserves
-  the test seam (rf2-nogok): `(set! snapshot/snapshot-tool ...)`
+  the test seam: `(set! snapshot/snapshot-tool ...)`
   updates the namespace's JS slot and the next dispatch finds the
   replacement."
   [f]
@@ -139,14 +139,14 @@
   inline `(fn [conn args extra] ...)` for `subscribe` (which
   uses `extra` for its progress-callback plumbing). Both shapes
   resolve the underlying fn per-call so test seams that `set!` the
-  var (rf2-nogok) take effect on the next dispatch."
+  var take effect on the next dispatch."
   [{:name       "discover-app"
     :handler    (ignoring-extra #(discover-app/discover-app %1 %2))
     :cacheable? true
     :descriptor data/discover-app}
    {:name       "orient"
     :handler    (ignoring-extra #(orient/orient-tool %1 %2))
-    ;; App-shape orientation summary (rf2-3bu3d.8) — registrar counts/ids +
+    ;; App-shape orientation summary — registrar counts/ids +
     ;; per-app-frame app-db top-keys + machines, composed from the existing
     ;; introspection surfaces. A pure function of the frame registry + app-db
     ;; state, idempotent across same-state calls — cacheable like the other
@@ -195,12 +195,12 @@
     :descriptor data/get-path}
    {:name       "read-sub"
     :handler    (ignoring-extra #(read-sub/read-sub-tool %1 %2))
-    ;; Validated one-shot subscription read (rf2-3bu3d.7). A function of
+    ;; Validated one-shot subscription read. A function of
     ;; frame state (the sub's deref) — idempotent across same-state calls,
     ;; cacheable like get-path / snapshot. The precheck-hash short-circuit
     ;; keys on (hash app-db); a sub value derives from app-db, so a cache
     ;; keyed on app-db is correct for the common case (the :cache default
-    ;; is opt-in per-call, rf2-c4fmh).
+    ;; is opt-in per-call).
     :cacheable? true
     :descriptor data/read-sub}
    {:name       "read-dom"
@@ -215,7 +215,7 @@
     :descriptor data/read-dom}
    {:name       "read-ui"
     :handler    (ignoring-extra #(read-ui/read-ui-tool %1 %2))
-    ;; The typed ui/read op (rf2-3bu3d.1) — rendered view content + the
+    ;; The typed ui/read op — rendered view content + the
     ;; producing entity, riding the view<->DOM map. Read of live rendered
     ;; DOM, same posture as read-dom: NOT cacheable — the precheck-hash
     ;; short-circuit keys on `(hash app-db)`, but the DOM (and the live
@@ -262,8 +262,8 @@
     :descriptor data/list-streams}
    {:name       "get-stream-controls"
     :handler    (ignoring-extra #(get-stream-controls/get-stream-controls-tool %1 %2))
-    ;; Pure read over the server's IN-PROCESS resource-control atoms
-    ;; (rf2-a0kxsb). NOT cacheable: the active-stream / token-bucket /
+    ;; Pure read over the server's IN-PROCESS resource-control atoms.
+    ;; NOT cacheable: the active-stream / token-bucket /
     ;; abuse-window state is volatile session-local state, not a function
     ;; of app-db — a precheck-hash cache keyed on app-db would serve stale
     ;; control readings. Same posture as `list-streams` (volatile
@@ -280,7 +280,7 @@
     :descriptor data/list-handlers}
    {:name       "describe-image"
     :handler    (ignoring-extra #(describe-image/describe-image-tool %1 %2))
-    ;; Pure read of a frame's resolved image generation (rf2-srobm0) — a
+    ;; Pure read of a frame's resolved image generation — a
     ;; function of the frame's sealed generation, cacheable like the other
     ;; read tools. The generation is inert until reload-images!, so the
     ;; precheck-hash cache opt-in is safe.
@@ -364,7 +364,7 @@
   True for read tools whose return value is a function of state
   (`snapshot`, `get-path`, `trace-window`, `watch-epochs`,
   `discover-app`, `list-subscriptions` — the last reads the live
-  reactive sub-cache, a pure function of frame state, rf2-qicji) and
+  reactive sub-cache, a pure function of frame state) and
   for the inline `get-re-frame2-pair-instructions` onboarding text
   (which is a pure-data function with no state whatsoever — once is
   forever). False for action tools (`dispatch`, `eval-cljs`,
@@ -372,7 +372,7 @@
   `list-streams`, `get-stream-controls`), and volatile runtime-state
   reads whose value can move without an app-db mutation —
   `get-operating-frame`, whose resolved triple is a function of the
-  live frame registry plus the per-session pin (rf2-flm0iz). Their
+  live frame registry plus the per-session pin. Their
   return value is the result of an action / a read of volatile
   process/runtime state, not frame app-db.
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/replace_app_db.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/replace_app_db.cljs
@@ -1,18 +1,18 @@
 (ns re-frame2-pair-mcp.tools.replace-app-db
-  "Tool: replace-app-db — state injection (rf2-ee38b.18).
+  "Tool: replace-app-db — state injection.
 
   The Tool-Pair `replace-app-db!` write primitive per
-  spec/Tool-Pair.md §Pair-tool writes (renamed from `reset-frame-db!`,
-  EP-0001 rf2-tfepxu — a db-shaped name never silently replaces
-  runtime-db): replace a frame's `app-db` with an arbitrary value the
-  runtime never recorded — the explicit JSON-loaded-bug-repro use case.
-  Wraps the preload runtime's `app-db-reset!`
-  (`(rf/replace-app-db! frame-id new-db)`), which bypasses the dispatch
-  loop, replaces the container directly, and records a synthetic
-  `:rf/epoch-record` (`:event-id :rf.epoch/db-replaced`) so a subsequent
-  `restore-epoch` can rewind past the injection.
+  spec/Tool-Pair.md §Pair-tool writes. Its db-shaped name reflects its
+  scope precisely — it replaces a frame's `app-db` (never silently the
+  runtime-db) with an arbitrary value the runtime never recorded — the
+  explicit JSON-loaded-bug-repro use case. Wraps the preload runtime's
+  `app-db-reset!` (`(rf/replace-app-db! frame-id new-db)`), which
+  bypasses the dispatch loop, replaces the container directly, and
+  records a synthetic `:rf/epoch-record`
+  (`:event-id :rf.epoch/db-replaced`) so a subsequent `restore-epoch`
+  can rewind past the injection.
 
-  ## Gate (rf2-ee38b.18)
+  ## Gate
 
   A write surface — gated behind `--allow-writes` (default OFF). When
   the gate is closed the tool returns `:rf.error/writes-disabled`
@@ -22,7 +22,7 @@
 
   The `db` arg is parsed as EDN and emitted into the runtime call via
   the normal `pr-str` path (NO `rt-raw` splice) — the same
-  injection-closing posture `dispatch` takes (rf2-vflrg). A
+  injection-closing posture `dispatch` takes. A
   prompt-injected `(println :pwn)` string is data, not code; it would
   read as a symbol/list literal and be injected verbatim (and almost
   certainly rejected by the frame's app-schema), never executed.
@@ -33,7 +33,7 @@
   `app-db-reset!` already returns a structured `{:ok? false :reason
   :reset-rejected ...}` on those soft failures; we pass it through.
 
-  ## Raw-state tap signal MUST precede app-db-reset! (rf2-z7roa)
+  ## Raw-state tap signal MUST precede app-db-reset!
 
   The preload's `app-db-reset!` taps BOTH the previous and the next
   app-db value through `tap>` so the human sees what the agent
@@ -46,11 +46,11 @@
   surface had a chance to signal the runtime.
 
   So this tool — like the direct-read surfaces (snapshot / get-path /
-  subscribe, rf2-c2dtu) — issues `raw-state/signal-runtime!` AFTER
+  subscribe) — issues `raw-state/signal-runtime!` AFTER
   `ensure-runtime!` and BEFORE the `app-db-reset!` eval. The signal
   reconfigures the runtime's posture before every state-emitting eval
-  (rf2-olvr5 finding 2 — the runtime's posture resets on reload, so a
-  cached 'delivered' flag would let a post-reload reset tap raw values);
+  (the runtime's posture resets on reload, so a cached 'delivered' flag
+  would let a post-reload reset tap raw values);
   concurrent calls for the same build still share ONE in-flight
   configure Promise, so a reset can never tap raw values ahead of the
   posture landing. This is why `replace-app-db` does NOT use the plain
@@ -65,7 +65,7 @@
 ;; The `db` arg has NO shape constraint — a frame's app-db is
 ;; conventionally a map but the runtime accepts any value the frame's
 ;; app-schema admits, so we only require readability. That's exactly the
-;; shared `args/read-edn-arg` core (rf2-jkake.19); the richer
+;; shared `args/read-edn-arg` core; the richer
 ;; vector-shape `dispatch` parser is deliberately not shared with it.
 
 (defn replace-app-db-tool [conn raw-args]
@@ -93,11 +93,11 @@
                      (ef/rt-call 'app-db-reset! new-db frame)
                      (ef/rt-call 'app-db-reset! new-db))
               form (ef/emit call)]
-          ;; rf2-z7roa — the signalled prelude lands `signal-runtime!`
+          ;; The signalled prelude lands `signal-runtime!`
           ;; between `ensure-runtime!` and the `app-db-reset!` eval so the
           ;; runtime's tap-emitting surface is in its gated (default-elided)
           ;; posture BEFORE the reset taps the pre-/post-reset app-db. This
-          ;; mirrors the direct-read surfaces' prelude (rf2-c2dtu) rather
+          ;; mirrors the direct-read surfaces' prelude rather
           ;; than the plain `probe/eval-after-runtime!` (no signal step).
           (probe/eval-after-runtime-signalled!
             conn build-id form :replace-app-db-failed
@@ -106,11 +106,11 @@
               ;; ({:ok? true :frame ...} / {:ok? false :reason
               ;; :reset-rejected ...}). Pass it through; default to a
               ;; generic shape if the runtime returned a non-map (degraded
-              ;; / pre-rf2-c2dtu runtime).
+              ;; runtime).
               (let [result (if (map? v)
                              v
                              {:ok? false :reason :unexpected-shape :value v :frame frame})]
-                ;; rf2-or8s29 — a soft failure (the runtime's
+                ;; A soft failure (the runtime's
                 ;; `{:ok? false :reason :reset-rejected ...}` OR the
                 ;; non-map `:unexpected-shape` fallback) means the
                 ;; injection did NOT land; it is not a terminal-empty

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reserved_frame_guard.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reserved_frame_guard.cljs
@@ -1,16 +1,15 @@
 (ns re-frame2-pair-mcp.tools.reserved-frame-guard
   "Server-side backstop: refuse a WHOLESALE (unsliced) read of a reserved
-  `:rf/*` TOOL frame (rf2-qef58).
+  `:rf/*` TOOL frame.
 
   ## Why a server guard, when the skill already steers
 
-  rf2-ihqpn (#2845) taught the `re-frame2-pair` skill to orient first and
-  never wholesale-read a tool frame, after a live pair session blew a
-  single read past 126K tokens reading the `:rf/xray` frame's entire
-  working set (epoch ring + trace buffer + panel state). The skill
-  STEERS; this guard ENFORCES — a stray `path: []` of `:rf/xray` can no
-  longer blow the context window regardless of agent judgment. Skill
-  steers, MCP guards.
+  The `re-frame2-pair` skill steers the agent to orient first and
+  never wholesale-read a tool frame — a single read of the `:rf/xray`
+  frame's entire working set (epoch ring + trace buffer + panel state)
+  can blow well past 100K tokens. The skill STEERS; this guard ENFORCES
+  — a stray `path: []` of `:rf/xray` can no longer blow the context
+  window regardless of agent judgment. Skill steers, MCP guards.
 
   ## What is refused
 
@@ -34,13 +33,13 @@
       `[:rf.xray/epochs 0]`) is exactly the targeted-drill the agent is
       steered toward, so it is always allowed.
     - The DEFAULT snapshot scope (`frames :app`) — reserved tool frames
-      are already excluded from it (rf2-3bu3d.6), so a default-scope read
+      are already excluded from it, so a default-scope read
       never reaches the guard.
 
   ## The reserved-frame predicate
 
   `reserved-tool-frame?` mirrors the runtime's predicate of the same name
-  (`re-frame2-pair.runtime/reserved-tool-frame?`, rf2-3bu3d.4): the rule
+  (`re-frame2-pair.runtime/reserved-tool-frame?`): the rule
   is the reserved-namespace CONVENTION (spec/Conventions.md §Reserved
   namespaces — framework-owned ids live under the single `:rf/*` root),
   NOT a hardcoded `:rf/xray` literal, so the guard holds for every `:rf/*`
@@ -50,7 +49,7 @@
   canonical APP frame, so it is never treated as a tool frame.
 
   This is the server-side mirror: the snapshot tool already filters the
-  LIVE registry through the runtime predicate app-side (rf2-3bu3d.6), but
+  LIVE registry through the runtime predicate app-side, but
   the guard must refuse BEFORE the eval round-trip — a refusal, not a
   transform — so it re-states the same rule over the keyword the agent
   named. The rule is one line; the two copies can't drift because they
@@ -61,7 +60,7 @@
   "True when `frame-id` names a framework-reserved `:rf/*` TOOL frame.
 
   Server-side mirror of `re-frame2-pair.runtime/reserved-tool-frame?`
-  (rf2-3bu3d.4) — the reserved-namespace convention (namespace = \"rf\"),
+  — the reserved-namespace convention (namespace = \"rf\"),
   minus the `:rf/default` carve-out (the canonical app frame). A
   non-keyword / un-namespaced id (a user's `:stories`, `:sandbox`) is an
   app frame and returns false."
@@ -78,7 +77,7 @@
 
 (defn- refusal
   "Build the `{:ok? false ...}` refusal envelope for a wholesale read of a
-  reserved tool frame. Echoes the skill's wording (rf2-ihqpn / ops.md):
+  reserved tool frame. Echoes the skill's wording (ops.md):
   names the frame, explains the cost, and redirects to `orient` (the
   bounded orientation op) plus a targeted slice. `frame-desc` is the human
   string for the scope being refused (a frame id like `:rf/xray`, or
@@ -117,7 +116,7 @@
        least one reserved frame (e.g. `[:rf/xray]`).
 
   The DEFAULT scope `:app` already excludes reserved tool frames
-  (rf2-3bu3d.6) so it never refuses. A sliced read (non-`[]` `path`) is
+  so it never refuses. A sliced read (non-`[]` `path`) is
   the targeted drill the agent is steered toward and is always allowed.
 
   `frames` is the parsed frames arg (`:app` / `:all` / a keyword vector);
@@ -157,7 +156,7 @@
   resolved frame here, so this client-side guard does not fire on the
   omitted-`:frame` path). That omitted-`:frame` case is NOT an escape
   hatch: `set-operating-frame` refuses to PIN a reserved `:rf/*` tool
-  frame (rf2-wdxyx3 finding 1), so the runtime's `current-frame` resolver
+  frame, so the runtime's `current-frame` resolver
   can never return a reserved frame at tier 2 — an omitted-`:frame` read
   resolves to an APP frame (or refuses with `:ambiguous-frame`), never a
   tool frame. So the only way to address a reserved frame is the explicit

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/resource_controls.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/resource_controls.cljs
@@ -1,9 +1,9 @@
 (ns re-frame2-pair-mcp.tools.resource-controls
-  "Session-wide resource controls for streaming surfaces (rf2-3ijbl).
+  "Session-wide resource controls for streaming surfaces.
 
   An MCP session is one stdio-attached server process — see
-  `cache.cljs` (rf2-3rt1f) for the equivalence. Per-sub queue caps and
-  drop-oldest-on-overflow already live runtime-side (rf2-ho4ve), but a
+  `cache.cljs` for the equivalence. Per-sub queue caps and
+  drop-oldest-on-overflow already live runtime-side, but a
   buggy or hostile client can still:
 
     1. Open many concurrent `subscribe` calls — each allocates a fresh
@@ -31,7 +31,7 @@
   ## Per-session event rate-limit (token bucket)
 
   `check-rate!` is called once per poll cycle BEFORE the destructive
-  drain (rf2-uvfph). The session-wide token bucket refills at
+  drain. The session-wide token bucket refills at
   `max-events-per-sec` (default 100) and caps at the same value. When a
   token is available the caller drains + emits; when the bucket is empty
   `check-rate!` returns `false` and the caller DEFERS the cycle — it
@@ -76,10 +76,10 @@
 
   ## Symmetry with sibling gates
 
-  Pre-existing re-frame2-pair-mcp gates:
-    - `eval-cljs/eval-allowed?` (`--no-eval` opt-out) — rf2-a0z0h
-      (inverts the prior rf2-cxx5s default-OFF posture)
-    - `raw-state/allow-raw-state?` (`--allow-sensitive-reads`) — rf2-c2dtu
+  Sibling re-frame2-pair-mcp gates:
+    - `eval-cljs/eval-allowed?` (`--no-eval` opt-out — eval is on by
+      default)
+    - `raw-state/allow-raw-state?` (`--allow-sensitive-reads`)
 
   This namespace adds:
     - `max-concurrent-streams` (`--max-concurrent-streams` /
@@ -379,7 +379,7 @@
 (def flag->key
   "Map of CLI-flag prefix → config key. Single source of truth; both
   the parser and the documentation reflect from this map. Public so
-  `server/launch-diagnostics` (rf2-a0kxsb) can recognise resource-control
+  `server/launch-diagnostics` can recognise resource-control
   flags as known when scanning argv for typos."
   {"--max-concurrent-streams"   :max-concurrent-streams
    "--max-events-per-sec"       :max-events-per-sec
@@ -389,7 +389,7 @@
 (def env->key
   "Map of env-var name → config key. Symmetric with `flag->key` — same
   four gates, different config surface. Public so
-  `server/resource-env-diagnostics` (rf2-a0kxsb) can name a set-but-invalid
+  `server/resource-env-diagnostics` can name a set-but-invalid
   env var at boot."
   {"RE_FRAME2_PAIR_MCP_MAX_STREAMS"              :max-concurrent-streams
    "RE_FRAME2_PAIR_MCP_MAX_EVENTS_PER_SEC"       :max-events-per-sec
@@ -458,9 +458,9 @@
 
   Returns the applied map — `set-config!`'s post-merge value so the
   caller sees the actual gates in force (with defaults filled in for
-  keys the operator didn't override). Returning the bare merge of
-  overrides (without defaults) caused a startup-banner regression
-  where unset gates printed as blank values."
+  keys the operator didn't override). The defaults must be present in
+  the returned map so the startup banner prints a value for every gate,
+  including the ones the operator left untouched."
   [env-cfg flag-cfg]
   (set-config! (merge env-cfg flag-cfg)))
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.restore-epoch
-  "Tool: restore-epoch — time-travel undo (rf2-ee38b.18).
+  "Tool: restore-epoch — time-travel undo.
 
   The canonical pair-tool undo gesture per spec/Tool-Pair.md
   §Time-travel: rewind a frame's whole `frame-state` — BOTH the app-db
@@ -13,13 +13,13 @@
   primitive the server is the canonical consumer of (000-Vision /
   003-Tool-Catalogue).
 
-  ## Gate (rf2-ee38b.18)
+  ## Gate
 
   A write surface — gated behind `--allow-writes` (default OFF). When
   the gate is closed the tool returns `:rf.error/writes-disabled`
   without touching the nREPL socket. See `tools/writes.cljs`.
 
-  ## Sensitive-read posture (rf2-6nks4, finding-2)
+  ## Sensitive-read posture
 
   Restore's success envelope carries a `:cascade-summary` whose
   `:event-vector` slot copies the TARGET epoch's raw `:trigger-event`.
@@ -38,7 +38,7 @@
 
   The `epoch-id` arg is parsed as EDN, not assumed `string?` — the
   reference epoch runtime emits INTEGER epoch-ids (the same `:any`
-  contract that drives the cursor fix). A bare integer string (\"7\")
+  contract the cursor uses). A bare integer string (\"7\")
   reads as the integer 7; a keyword reads as a keyword; an unreadable
   value returns `:invalid-epoch-id`.
 
@@ -56,7 +56,7 @@
 
 ;; The `epoch-id` arg is parsed as EDN with NO shape constraint — any
 ;; readable value (integer / keyword / string; `:epoch-id` is `:any`) is
-;; accepted, exactly the shared `args/read-edn-arg` core (rf2-jkake.19).
+;; accepted, exactly the shared `args/read-edn-arg` core.
 
 (defn restore-epoch-tool [conn raw-args]
   (if-not (writes/writes-allowed?)
@@ -84,11 +84,11 @@
               form (ef/emit call)
               on-value
               (fn [v]
-                ;; Per rf2-6yqdl: the runtime now returns a structured
+                ;; The runtime returns a structured
                 ;; envelope on success carrying `:ok? :restored? :epoch-id
                 ;; :frame :cascade-summary :unreplayable-effects`. Failure
-                ;; remains the legacy `false` so older runtimes still
-                ;; surface as a clean reject envelope here.
+                ;; surfaces as a bare `false`, which we turn into a clean
+                ;; reject envelope here.
                 (let [result
                       (cond
                         (map? v)
@@ -110,9 +110,9 @@
                                          "ring, or a drain is in flight. Read the structured reason "
                                          "with (re-frame.trace.tooling/trace-buffer {:op-type :error}) "
                                          "filtered to :rf.epoch/*.")})]
-                  ;; rf2-or8s29 — a soft failure (the legacy `false` reject
-                  ;; OR a structured `{:ok? false ...}` envelope from a newer
-                  ;; runtime) is NOT a terminal-empty outcome: the write did
+                  ;; A soft failure (the bare `false` reject
+                  ;; OR a structured `{:ok? false ...}` envelope) is NOT a
+                  ;; terminal-empty outcome: the write did
                   ;; not land. It MUST ride as an `isError: true` result so
                   ;; the MCP host sees the failure + reason rather than a
                   ;; success-shaped envelope (003-Tool-Catalogue §"Every
@@ -121,7 +121,7 @@
                   (if (false? (:ok? result))
                     (wire/err-text result)
                     (wire/ok-text result))))]
-          ;; rf2-6nks4 (finding-2): the signalled prelude signals the
+          ;; The signalled prelude signals the
           ;; raw-state posture to the runtime BEFORE the restore eval, so
           ;; the cascade-summary it builds redacts a sensitive
           ;; `:event-vector` under the default gate-OFF posture. Mirrors
@@ -129,7 +129,7 @@
           ;; primitive internally drives) — the plain `eval-after-runtime!`
           ;; has no `signal-runtime!` step, so this uses the `-signalled!`
           ;; sibling. The signal reconfigures the posture before every
-          ;; state-emitting eval (rf2-olvr5 finding 2 — the runtime's
+          ;; state-emitting eval (the runtime's
           ;; posture resets on reload, so a cached-delivered flag would
           ;; leave a post-reload restore tapping raw values).
           (probe/eval-after-runtime-signalled!

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/result_envelope.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/result_envelope.cljs
@@ -1,26 +1,27 @@
 (ns re-frame2-pair-mcp.tools.result-envelope
-  "Total, TAGGED result codec across the MCP↔runtime boundary (rf2-qobqy).
+  "Total, TAGGED result codec across the MCP↔runtime boundary.
 
-  ## The problem this closes
+  ## What this codec guarantees
 
-  The CLJS→wire value path had no total, tagged envelope, so distinct
-  outcomes collapsed to a bare `null` (or a stringly `:unexpected-shape`),
-  costing round-trips and producing wrong conclusions:
+  The CLJS→wire value path carries a total, tagged envelope so distinct
+  outcomes stay distinct instead of collapsing to a bare `null` (or a
+  stringly `:unexpected-shape`), which would cost round-trips and produce
+  wrong conclusions. Without the tag:
 
-    - `eval-cljs` returned `null` for (a) a genuine `nil`, (b) an
+    - `eval-cljs` would return `null` for (a) a genuine `nil`, (b) an
       UNRESOLVED symbol / wrong-ns guess (which looks identical to nil),
       and (c) an UNSERIALIZABLE value — a value `pr-str` can render but
       `cljs.reader/read-string` cannot read back (a raw `#object[...]`,
       a `#js {...}` literal, a Function ref). The blank-value path in
       `nrepl/cljs-eval-value` reads all three as `nil`.
-    - `handler-meta` returned `:ok? false :reason :unexpected-shape`
+    - `handler-meta` would return `:ok? false :reason :unexpected-shape`
       while the real meta sat in `:value` as a STRING the caller had to
       re-parse.
 
-  The project already has wire-SIZE machinery — elision, dedup, the
+  The project's wire-SIZE machinery — elision, dedup, the
   token-budget cap (`re-frame.mcp-base.*`, `tools.elision`,
-  `tools.dedup`, `tools.cap`). It did NOT have wire-FIDELITY/typing.
-  This namespace adds the typing layer and composes ON TOP of elision:
+  `tools.dedup`, `tools.cap`) — handles payload size; this namespace is
+  the wire-FIDELITY/typing layer and composes ON TOP of elision:
   the runtime-side wrap classifies the value, and the elision walker (if
   the caller routes through it) still runs over the `:value` payload —
   this codec never bypasses size machinery, it only tags the outcome.
@@ -79,9 +80,10 @@
     :eval-error     → `{:ok? false :reason :rf.error/eval-cljs-threw …}`.
     :unserializable → `{:ok? false :reason :rf.error/unserializable …}`.
 
-  Legacy untagged values (a runtime that hasn't been re-preloaded, or a
+  Untagged values (a runtime without the wrap preloaded, or a
   tool that doesn't wrap) flow through `envelope->result` unchanged via
-  the fall-through arm — the codec is additive, never a hard cutover."
+  the fall-through arm — the codec is additive: an untagged value is a
+  valid input and projects straight to `(on-value v)`."
   (:require [clojure.string :as str]
             [re-frame.mcp-base.vocab :as base-vocab]))
 
@@ -100,12 +102,12 @@
   wire as `:preview`. Long enough to identify the shape, short enough to
   stay well under the token cap on its own.
 
-  Public (rf2-ttspi7) so the test-only `test-utils/truncate-preview`
+  Public so the test-only `test-utils/truncate-preview`
   pins against the SAME single-sourced cap the runtime wrap embeds."
   240)
 
 ;; ---------------------------------------------------------------------------
-;; REPL-special pass-through (rf2-cum40 CI repair).
+;; REPL-special pass-through.
 ;;
 ;; shadow-cljs's `cljs-eval` compiles a handful of forms as REPL SPECIALS
 ;; — `require`, `require-macros`, `import`, `use`, `ns`, `in-ns`, `refer`,
@@ -117,15 +119,13 @@
 ;; statement into an expression slot and the browser REPL throws
 ;; `SyntaxError: Unexpected token ';'` → `:repl/exception!`. The require's
 ;; module never loads, and a follow-on form referencing the namespace dies
-;; with `Cannot read properties of undefined`. (Surfaced by the
-;; live-redaction conformance gate, whose seed `(require 're-frame.epoch)`
-;; broke the moment the typed codec actually executed.)
+;; with `Cannot read properties of undefined`.
 ;;
 ;; The codec can't classify a module-load side effect anyway — `require`
 ;; returns nil — so wrapping buys nothing here. `wrap-form` detects a
 ;; leading REPL-special and returns the form VERBATIM so shadow gives it
 ;; the top-level handling it needs; the untagged nil result then flows
-;; through `envelope->result`'s legacy passthrough arm as `(on-value nil)`,
+;; through `envelope->result`'s passthrough arm as `(on-value nil)`,
 ;; i.e. `:ok? true :value nil` — the correct shape for a require.
 ;; ---------------------------------------------------------------------------
 
@@ -137,7 +137,7 @@
 
 (defn repl-special?
   "True when `form-str` is a top-level call to a shadow REPL-special op
-  that must NOT be wrapped (rf2-cum40). Cheap textual probe: strip leading
+  that must NOT be wrapped. Cheap textual probe: strip leading
   whitespace + a single opening paren, then read the first token. A
   `(require ...)` / `(ns ...)` / etc. matches; `(+ 1 2)`, `(require-foo)`
   (not an exact match), and a bare value do not. Quote-prefixed forms
@@ -163,7 +163,7 @@
 
 (defn wrap-form
   "Wrap `form-str` so the runtime classifies its result into a tagged
-  `:rf.mcp/result` envelope (rf2-qobqy). The wrap:
+  `:rf.mcp/result` envelope. The wrap:
 
     1. Evaluates the user form inside a `try`. A throw → the
        `:eval-error` tag carrying the message + ex-data when present
@@ -180,17 +180,18 @@
   The probe is conservative: any throw from the round-trip read, OR a
   rendered text starting with an unreadable reader-macro token, counts
   as unserializable. This keeps a `#object[Function]` / `#js {…}` from
-  riding back as a bare nil (the historical collapse).
+  riding back as a bare nil — it rides back tagged `:unserializable`
+  instead, so the agent sees what it actually was.
 
   The whole wrap is itself wrapped in an outer `try` so a failure in the
   classification machinery degrades to an `:eval-error` envelope rather
   than throwing on the wire.
 
   REPL-special forms (`require` / `ns` / `import` / …) are returned
-  VERBATIM (rf2-cum40) — shadow only honours their special compilation at
+  VERBATIM — shadow only honours their special compilation at
   the top level, and burying them in the wrapper's expression context
   breaks them (`SyntaxError: Unexpected token ';'`). Their untagged result
-  flows through `envelope->result`'s legacy passthrough."
+  flows through `envelope->result`'s passthrough."
   [form-str]
   (if (repl-special? form-str)
     form-str
@@ -241,8 +242,8 @@
   (and (map? v) (contains? v result-key)))
 
 (defn envelope->result
-  "Project a tagged `:rf.mcp/result` envelope (or a legacy untagged
-  value) onto the calling tool's result map (rf2-qobqy).
+  "Project a tagged `:rf.mcp/result` envelope (or an untagged
+  value) onto the calling tool's result map.
 
   `on-value` is the tool's own success shaper — a 1-arity fn
   `(fn [genuine-value] => result-map)`. It is invoked for BOTH the
@@ -255,9 +256,8 @@
     :unserializable → {:ok? false :reason :rf.error/unserializable
                        :type … :preview … :hint …}
 
-  Legacy / untagged `v` (a runtime that predates the wrap, or a tool
-  that didn't wrap) flows straight to `(on-value v)` — the codec is
-  additive.
+  An untagged `v` (a runtime without the wrap, or a tool that didn't
+  wrap) flows straight to `(on-value v)` — the codec is additive.
 
   Returns the tool result map (NOT a wire envelope — the caller wraps
   it with `wire/ok-text` / `wire/err-text`). `error?` on the returned
@@ -313,13 +313,12 @@
   the tag. Reads the `::codec-error` metadata stamped by
   `envelope->result` — so an `on-value` result carrying `:ok? false`
   (a legitimate structured answer like `:not-registered`) is NOT an
-  error here and rides back as `wire/ok-text` exactly as before the
-  codec landed."
+  error here and rides back as `wire/ok-text`."
   [result-map]
   (boolean (some-> result-map meta ::codec-error)))
 
-;; `truncate-preview` (the test-only preview-shape helper) moved to
-;; `re-frame2-pair-mcp.test-utils/truncate-preview` (rf2-ttspi7) — the
+;; `truncate-preview` (the test-only preview-shape helper) lives in
+;; `re-frame2-pair-mcp.test-utils/truncate-preview` — the
 ;; MCP server never calls it; only tests assert the preview contract.
-;; It pins against the same `preview-cap` constant below (now public so
+;; It pins against the same `preview-cap` constant above (public so
 ;; the single source of truth stays here).

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/sensitive.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/sensitive.cljs
@@ -12,15 +12,15 @@
   any read/stream tool that surfaces trace-like data) removes the
   filter for that call. The default is off — apps that want sensitive
   cascades visible to the pair tool configure the policy explicitly.
-  The wire-key drops the trailing `?` per rf2-y710n + rf2-ihq4d —
+  The wire-key drops the trailing `?` because
   Anthropic's tool-input-schema regex `^[a-zA-Z0-9_.-]{1,64}$` rejects
   the predicate `?`. The arg is parsed by the shared
-  `re-frame2-pair-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh)."
+  `re-frame2-pair-mcp.tools.args/parse-bool-arg` table."
   (:require [re-frame.mcp-base.sensitive :as base-sensitive]))
 
 (defn sensitive-event?
-  "Delegates to `re-frame.mcp-base.sensitive/sensitive-event?`
-  (rf2-vw4sq). The predicate is the conservative spec/009 stamp
+  "Delegates to `re-frame.mcp-base.sensitive/sensitive-event?`.
+  The predicate is the conservative spec/009 stamp
   check: only the literal `true` value drops."
   [ev]
   (base-sensitive/sensitive-event? ev))
@@ -28,14 +28,14 @@
 (defn sensitive-epoch?
   "Does this projected epoch record carry — or transitively contain — a
   sensitive-rollup signal? Defense-in-depth on top of the per-event
-  filter (rf2-re2s3, key fix rf2-5613h).
+  filter.
 
   An epoch is considered sensitive if EITHER:
 
     1. The record-level rollup slot `:rf.epoch/sensitive?` is `true`
        (the spec/009 §Privacy / Security.md §Epoch privacy rollup, the
-       REAL qualified key the runtime epoch assembler writes once at
-       record-assembly time per rf2-isdwf / rf2-mrsck — see
+       qualified key the runtime epoch assembler writes once at
+       record-assembly time — see
        `re-frame.epoch.assembly` and the `projected-record` egress
        projection, which preserves the key verbatim). The rollup is
        classified through the SHARED fail-closed
@@ -46,18 +46,17 @@
        `(true? ...)` check that fails OPEN. OR
     2. ANY constituent `:trace-events` entry carries `:sensitive? true`
        — a belt-and-braces walk that catches a sensitive cascade even
-       if the record-level rollup is absent (older runtime, missing
-       late-bind hook, hand-built record in a test fixture).
+       if the record-level rollup is absent (a runtime missing the
+       late-bind hook, a hand-built record in a test fixture).
 
-  Pre-rf2-5613h this read the UNqualified `:sensitive?` top-level key,
-  which the runtime never writes on an epoch record. A schema-derived
-  sensitive epoch — sensitivity sourced from a declared sensitive
-  app-db path rather than a per-event stamp — therefore carried
-  `:rf.epoch/sensitive? true` but NO unqualified `:sensitive?` and NO
-  sensitive constituent trace event, so it survived `strip-sensitive`
-  and shipped its metadata (`:event-id`, timing, redacted-modified
-  count, outcome) across the MCP boundary in violation of the
-  default-DROP contract. Consuming the real rollup key closes that leak.
+  The qualified `:rf.epoch/sensitive?` rollup is the load-bearing key:
+  a schema-derived sensitive epoch — sensitivity sourced from a
+  declared sensitive app-db path rather than a per-event stamp —
+  carries `:rf.epoch/sensitive? true` with NO sensitive constituent
+  trace event. Classifying on the qualified rollup keeps such an epoch
+  from shipping its metadata (`:event-id`, timing, redacted-modified
+  count, outcome) across the MCP boundary, honouring the default-DROP
+  contract.
 
   The check is short-circuit-cheap on the common path: most epochs have
   a `false`/absent rollup and no sensitive `:trace-events`, so the
@@ -75,15 +74,15 @@
 
   Applies the union predicate `sensitive-event? OR sensitive-epoch?`
   so both trace-event vectors AND epoch-record vectors are gated by
-  the same call site (defense-in-depth per rf2-re2s3). A trace event
+  the same call site (defense-in-depth). A trace event
   has neither an `:rf.epoch/sensitive?` rollup nor a `:trace-events`
   slot, so `sensitive-epoch?` collapses to false on it and the
   trace-event arm (`sensitive-event?`'s `:sensitive?` check) governs;
   an epoch record drops on EITHER its `:rf.epoch/sensitive?` rollup
-  (the real key the runtime writes — rf2-5613h) OR a sensitive
+  (the qualified key the runtime writes) OR a sensitive
   constituent trace event, even when the other signal is absent.
 
-  Cross-MCP factoring (rf2-vw4sq): the predicate `sensitive-event?`
+  Cross-MCP factoring: the predicate `sensitive-event?`
   delegates to `re-frame.mcp-base.sensitive`. The epoch-level union
   check is re-frame2-pair-mcp-specific (story-mcp doesn't emit epoch records);
   the trace-event-only `strip-sensitive` in the base is the right fit
@@ -105,13 +104,12 @@
   :machines) pass through unchanged — redaction of those payloads is
   the `redact-interceptor` interceptor's job, not the forwarder's.
 
-  Epoch-record stamping is current contract per rf2-isdwf — the
-  epoch assembler computes the `:rf.epoch/sensitive?` rollup at
-  record-assembly time and the `sensitive-epoch?` defence-in-depth
-  check matches against that real key (rf2-5613h). Both vectors are
-  scrubbed by the same union strip-fn.
+  Epoch records carry a sensitivity stamp: the epoch assembler computes
+  the `:rf.epoch/sensitive?` rollup at record-assembly time and the
+  `sensitive-epoch?` defence-in-depth check matches against that
+  qualified key. Both vectors are scrubbed by the same union strip-fn.
 
-  Thin delegate (rf2-zpmmr) to
+  Thin delegate to
   `re-frame.mcp-base.sensitive/scrub-snapshot` with the re-frame2-pair-mcp
   union strip-fn (`strip-sensitive`, which gates both
   `sensitive-event?` and `sensitive-epoch?`). Story-mcp uses the base

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
@@ -6,7 +6,7 @@
   per-slice readers server-side and returns a per-frame map.
 
   Post-eval shrink pipeline lives in
-  `re-frame2-pair-mcp.tools.wire-pipeline` (rf2-ae8ie). This tool body
+  `re-frame2-pair-mcp.tools.wire-pipeline`. This tool body
   builds the eval form, awaits the runtime response, and routes the
   result through `run-wire-pipeline` with `:kind :snapshot-map`."
   (:require [re-frame2-pair-mcp.tools.eval-form :as ef]
@@ -24,11 +24,11 @@
   (let [build-id    (wire/arg-build conn raw-args)
         frames      (args/parse-frames-arg (wire/arg raw-args :frames))
         include     (args/parse-include-arg (wire/arg raw-args :include))
-        ;; rf2-c2dtu — the `--allow-sensitive-reads` boot gate forces both
+        ;; The `--allow-sensitive-reads` boot gate forces both
         ;; `:include-sensitive` to false AND `:elision` to true when
         ;; OFF (the default). The per-call args are still parsed (so the
         ;; response envelope reports the effective post-gate value), but
-        ;; the gate wins. rf2-p1qli: single intention-naming predicate
+        ;; the gate wins. Single intention-naming predicate
         ;; `raw-state-allowed?` (positive sense — true when operator
         ;; opted in at launch).
         incl?       (if (raw-state/raw-state-allowed?)
@@ -36,7 +36,7 @@
                       false)
         path        (args/parse-path-arg (wire/arg raw-args :path))
         mode        (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
-        ;; Global lazy-summary mode (rf2-u2029): `:summary` (default)
+        ;; Global lazy-summary mode: `:summary` (default)
         ;; replaces every rich slice with a tree-summary marker;
         ;; `:full` ships the full payload. Per-slice override via
         ;; `:modes` map takes precedence over the global mode.
@@ -47,7 +47,7 @@
                       (args/parse-bool-arg raw-args :elision)
                       true)
         opts        {:frames frames :include include}
-        ;; Eval form composition (rf2-urjnc + rf2-e35a5 + rf2-vflrg).
+        ;; Eval form composition.
         ;; The snapshot composer returns a per-frame map; we wrap each
         ;; frame's `:app-db` AND `:sub-cache` slices with
         ;; `re-frame.core/elide-wire-value` so large / sensitive slots
@@ -55,13 +55,13 @@
         ;; server-side, before the EDN crosses the wire.
         ;;
         ;; The walker reads the `[:rf.runtime/elision]` registry from the
-        ;; frame's durable runtime-db partition (EP-0001 — NOT the retired
-        ;; app-db `:rf/runtime` root) — it has to run app-side, where the
-        ;; registry is reachable. When elision is disabled the eval form skips the
-        ;; walk entirely (a value pass-through is cheaper than walking
-        ;; with `:rf.size/include-large? true`).
+        ;; frame's durable runtime-db partition (EP-0001) — it has to run
+        ;; app-side, where the registry is reachable. When elision is
+        ;; disabled the eval form skips the walk entirely (a value
+        ;; pass-through is cheaper than walking with
+        ;; `:rf.size/include-large? true`).
         ;;
-        ;; rf2-vflrg pins the Tool-Pair §`Direct-read privacy posture
+        ;; The Tool-Pair §`Direct-read privacy posture
         ;; for sub-cache and get-path` contract: BOTH the `:app-db` and
         ;; `:sub-cache` direct-read surfaces MUST honour
         ;; `:rf.size/include-sensitive?` (default false ⇒ sensitive
@@ -69,7 +69,7 @@
         ;; the walker's opt of the same shape via
         ;; `elision-opts-edn`'s two-arity form. Off-box defaults apply.
         ;;
-        ;; Per rf2-e35a5: the eval form now ALSO counts elision
+        ;; The eval form ALSO counts elision
         ;; markers server-side and returns `{:value <snap>
         ;; :elided-count N}`. The client-side wire-pipeline reads the
         ;; count from opts instead of re-walking the post-pipeline
@@ -79,49 +79,47 @@
         ;; `:sub-cache` slices (where elision fired) — it only
         ;; re-shapes `:epochs` — so the pre-dedup server count equals
         ;; the post-dedup client count.
-        ;; rf2-suoj2 — `elision-opts-edn` now takes the walker-aligned
+        ;; `elision-opts-edn` takes the walker-aligned
         ;; `include-large?` polarity directly (no in-helper inversion).
         ;; MCP arg `elision` true = emit markers = `:include-large?` false,
         ;; hence the local `(not elision?)`.
         elision-opts-form (elision/elision-opts-edn (not elision?) incl?)
-        ;; rf2-t55hxg.13 — fail-CLOSED: the per-slot walker over the app-db-
+        ;; Fail-CLOSED: the per-slot walker over the app-db-
         ;; rooted `:app-db` / `:sub-cache` slices runs UNLESS the caller
         ;; opted into BOTH raw axes (`:elision false` ⇒ `include-large?
-        ;; true` AND `:include-sensitive true` ⇒ `incl?`). Pre-fix these
-        ;; slices walked only on `elision?`, so a gate-ON `:elision false`
-        ;; caller who left `:include-sensitive` at its default shipped raw
-        ;; `:app-db` / `:sub-cache` slices — a frame-declared-sensitive slot
-        ;; leaked off-box. A bare `:elision false` now still walks (large
+        ;; true` AND `:include-sensitive true` ⇒ `incl?`). A gate-ON
+        ;; `:elision false` caller who leaves `:include-sensitive` at its
+        ;; default must NOT ship raw `:app-db` / `:sub-cache` slices — a
+        ;; frame-declared-sensitive slot would leak off-box. A bare
+        ;; `:elision false` therefore still walks (large
         ;; passes, sensitive redacts to `:rf/redacted`). The `:epochs`
         ;; projection + `:machines` redaction already gate on the sensitive
         ;; axis (`incl?`) and are unaffected.
         walk-slices?      (elision/walk-required? (not elision?) incl?)
-        ;; rf2-8fin7.1 — the `:epochs` slice ships whole `:rf/epoch-record`s
+        ;; The `:epochs` slice ships whole `:rf/epoch-record`s
         ;; (each carrying `:db-before` / `:db-after` app-db snapshots),
         ;; NOT bare app-db slices, so it MUST route through
         ;; `re-frame.core/projected-record` — the framework's single
         ;; normative off-box-egress emission site for epoch records — NOT
         ;; the per-slot `elide-wire-value` walker that handles `:app-db` /
-        ;; `:sub-cache`. Before this fix the `:epochs` slice rode the wire
-        ;; verbatim: the client-side sensitive scrub only DROPS whole
-        ;; epochs stamped `:rf.epoch/sensitive? true`; it never redacts a
-        ;; schema-declared-sensitive SLOT (e.g. `[:auth :token]`) sitting
-        ;; inside a NON-sensitive epoch's `:db-before` / `:db-after`. So a
-        ;; sensitive slot leaked off-box under the default
-        ;; `--allow-sensitive-reads` OFF posture whenever the slice
-        ;; expanded to `:full`. The `:epochs` slice ALWAYS projects —
-        ;; same posture trace-window / watch-epochs use (rf2-6wvh5,
-        ;; rf2-m9duxl). rf2-m9duxl — `incl?` (the sensitive opt-in) NO
-        ;; LONGER bypasses the projection: it threads
-        ;; `{:include-sensitive? true}` INTO `projected-record` (app-db
-        ;; sensitive axis only), so the orthogonal fx-args / runtime-db /
-        ;; large axes and the app `:redact-fn` stay fail-closed. An epoch
-        ;; record never crosses the wire as a raw fx-arg / runtime-db
-        ;; payload, gate ON or OFF.
+        ;; `:sub-cache`. Without the projection the client-side sensitive
+        ;; scrub only DROPS whole epochs stamped `:rf.epoch/sensitive? true`;
+        ;; it never redacts a schema-declared-sensitive SLOT (e.g.
+        ;; `[:auth :token]`) sitting inside a NON-sensitive epoch's
+        ;; `:db-before` / `:db-after`, so a sensitive slot would leak
+        ;; off-box under the default `--allow-sensitive-reads` OFF posture
+        ;; whenever the slice expanded to `:full`. The `:epochs` slice
+        ;; ALWAYS projects — same posture trace-window / watch-epochs use.
+        ;; `incl?` (the sensitive opt-in) does NOT bypass the projection:
+        ;; it threads `{:include-sensitive? true}` INTO `projected-record`
+        ;; (app-db sensitive axis only), so the orthogonal fx-args /
+        ;; runtime-db / large axes and the app `:redact-fn` stay
+        ;; fail-closed. An epoch record never crosses the wire as a raw
+        ;; fx-arg / runtime-db payload, gate ON or OFF.
         project-epochs?   true
-        ;; EP-0001 (rf2-jj1xer · Mike ruling #14) — the `:machines` slice is
-        ;; RUNTIME-DB-partition state (machine snapshots now live in the
-        ;; durable runtime-db partition, not app-db — rf2-vzld77). Per Spec
+        ;; EP-0001 (Mike ruling #14) — the `:machines` slice is
+        ;; RUNTIME-DB-partition state (machine snapshots live in the
+        ;; durable runtime-db partition). Per Spec
         ;; 011 §Off-box redaction the runtime-db partition is REDACTED/OMITTED
         ;; off-box by default. So default-redact the `:machines` slice to the
         ;; framework `:rf/redacted` sentinel unless the operator opted in to
@@ -148,7 +146,7 @@
         ;; frame can carry all transforms. The `opts` / `f`
         ;; (`elide-wire-value`) bindings are emitted ONLY in the
         ;; `walk-slices?` branch — `:epochs` projection + `:machines`
-        ;; redaction never touch the per-slot walker. Per rf2-t55hxg.13 a
+        ;; redaction never touch the per-slot walker. A
         ;; gate-ON `:elision false` read STILL walks the slices (sensitive
         ;; redacts, large passes); only a full-raw opt-in (`:elision false`
         ;; AND `:include-sensitive true`) emits NO `elide-wire-value`.
@@ -164,7 +162,7 @@
                                (if project-epochs?
                                  (str " fmap (if (contains? fmap :epochs)"
                                       "        (update fmap :epochs"
-                                      ;; rf2-m9duxl — thread `incl?` so the
+                                      ;; Thread `incl?` so the
                                       ;; `:include-sensitive` opt-in routes
                                       ;; THROUGH the projection (app-db
                                       ;; sensitive axis only), never around it.
@@ -175,12 +173,12 @@
                                       "        (assoc fmap :machines :rf/redacted) fmap)")
                                  "")
                                "] fmap)")
-        ;; rf2-3bu3d.6 — when the resolved scope is the DEFAULT `:app`
+        ;; When the resolved scope is the DEFAULT `:app`
         ;; (reserved `:rf/*` tool frames excluded), piggyback the list of
         ;; tool frames that the scope dropped onto the same round-trip, so
         ;; the response can tell the agent "you can opt into these via
         ;; frames \"all\"". The runtime owns the reserved-frame predicate
-        ;; (`reserved-tool-frame?`, rf2-3bu3d.4) — we filter the LIVE
+        ;; (`reserved-tool-frame?`) — we filter the LIVE
         ;; registry through it app-side rather than guessing server-side.
         ;; Off the `:app` path the slot is an empty vector (no extra cost
         ;; for an explicit-scope read).
@@ -209,10 +207,10 @@
                             (ef/emit (ef/rt-call 'snapshot-state opts))
                             " :elided-count 0"
                             " :tool-frames-excluded " tool-frames-form "}"))))]
-    ;; rf2-qef58 — server-side backstop: refuse a WHOLESALE (`path: []`
+    ;; Server-side backstop: refuse a WHOLESALE (`path: []`
     ;; or `mode :full` + no path) read of a reserved `:rf/*` tool frame
     ;; (esp. `:rf/xray`) BEFORE the eval round-trip. The skill steers
-    ;; (rf2-ihqpn) away from this; the guard enforces it so a stray full
+    ;; away from this; the guard enforces it so a stray full
     ;; read can't blow the context window. Sliced reads + the default
     ;; `:app` scope (reserved frames already excluded) pass through.
     (if-let [refused (guard/snapshot-refusal frames path mode)]
@@ -220,7 +218,7 @@
       (probe/eval-after-runtime-signalled!
         conn build-id form :snapshot-failed
         (fn [resp]
-                 ;; New eval-form shape (rf2-e35a5): `{:value <snap>
+                 ;; Eval-form shape: `{:value <snap>
                  ;; :elided-count N}`. Defensively fall back to the
                  ;; bare-snap shape — a degraded runtime / stubbed
                  ;; eval might return the raw per-frame map.
@@ -230,7 +228,7 @@
                  (let [new-shape?    (and (map? resp) (contains? resp :elided-count))
                        snap-value    (if new-shape? (:value resp) resp)
                        server-elided (when new-shape? (:elided-count resp))
-                       ;; rf2-3bu3d.6 — the eval form piggybacks the reserved
+                       ;; The eval form piggybacks the reserved
                        ;; `:rf/*` tool frames the `:app` default dropped (an
                        ;; empty vector off the `:app` path / on the bare-snap
                        ;; fallback shape).
@@ -251,7 +249,7 @@
                                        path                  :path-sliced
                                        (= :full app-db-mode) :full
                                        :else                 :summary)
-                       ;; rf2-3bu3d.6 — echo the resolved frame scope.
+                       ;; Echo the resolved frame scope.
                        ;; `:app` (the default) returns the APP frames only,
                        ;; with reserved `:rf/*` tool frames excluded; the
                        ;; returned snapshot's keys ARE those app frames, so
@@ -260,7 +258,7 @@
                        ;; excluded by the default scope, surface a note so
                        ;; the agent knows it can opt into them via
                        ;; `frames "all"` (or by naming one explicitly) —
-                       ;; this is the friction-cut: the first read no longer
+                       ;; this is the friction-cut: the first read never
                        ;; silently overflows on tool-frame state.
                        snap-frames   (vec (keys value))
                        echo-frames   (cond

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot_pipeline.cljs
@@ -8,13 +8,13 @@
      (`slice-app-db-in-snapshot`). The `:path` arg (when supplied)
      wins over the slice-level mode; an empty path `[]` is
      semantically equivalent to `:full`.
-  2. Diff-encoding (rf2-1wdzp) and structural dedup (rf2-obpa9) of
+  2. Diff-encoding and structural dedup of
      each frame's `:epochs` slice (`diff-encode-epochs-in-snapshot`,
      `dedup-epochs-in-snapshot`).
   3. Lazy-summary default for non-app-db rich slices
      (`summarise-other-slices-in-snapshot`).
 
-  ## Mode resolution (rf2-u2029)
+  ## Mode resolution
 
   The resolved mode for each slice is governed by:
 
@@ -60,10 +60,10 @@
 
 (def ^:const full-epochs-cap
   "Default record cap on the `:epochs` slice when it resolves to `:full`
-  mode (rf2-lbm21). `:full` mode ships each epoch record VERBATIM —
+  mode. `:full` mode ships each epoch record VERBATIM —
   including its `:db-before` / `:db-after` app-db pair — so an
-  unbounded 50-record history pr-strs to ~50× the app-db (the
-  171K-token overflow the bead reports). Capping to the most-recent N
+  unbounded 50-record history pr-strs to ~50× the app-db (a
+  multi-100K-token overflow). Capping to the most-recent N
   records keeps full mode usable for the common 'what just happened?'
   read while the wire-cap stays a backstop for the rest. An agent that
   needs the full history pages via `trace-window` / `watch-epochs`
@@ -103,21 +103,21 @@
           ;; status-entry-or-nil]`. The status entry is non-nil only on
           ;; a path miss; the fold below threads it into the `:status`
           ;; map. No side-channel atom — both outputs flow through the
-          ;; accumulator (rf2-k7otmg).
+          ;; accumulator.
           process-frame
           (fn [frame-map]
             (if-not (and (map? frame-map) (contains? frame-map :app-db))
               [frame-map nil]
               (let [db (:app-db frame-map)]
                 (cond
-                  ;; No path + summary mode (rf2-tygdv default): summarise.
+                  ;; No path + summary mode (the default): summarise.
                   (and (nil? path) (not full?))
                   [(update frame-map :app-db summary/tree-summary) nil]
-                  ;; No path + full mode: full slice (rf2-u2029 opt-in).
+                  ;; No path + full mode: full slice (opt-in).
                   (nil? path)
                   [frame-map nil]
                   ;; Root path (`[]`): return full db (agent opted in
-                  ;; explicitly). Equivalent to legacy default behaviour.
+                  ;; explicitly).
                   (empty? path)
                   [frame-map nil]
                   ;; Path supplied: get-in with missing sentinel.
@@ -172,14 +172,14 @@
 
 (defn cap-full-epochs-in-snapshot
   "Bound the `:epochs` slice to the most-recent `cap` records on every
-  frame whose `:epochs` resolved to `:full` mode (rf2-lbm21).
+  frame whose `:epochs` resolved to `:full` mode.
 
   Only fires in `:full` mode — in `:summary` mode the slice is already a
   one-line `{:rf.mcp/summary ...}` marker, and `:diff` epochs-mode has
   collapsed each `:db-after` to a small patch, so neither needs the cap.
   Full mode is the overflow path: each record carries a verbatim
   `:db-before` / `:db-after` app-db pair, so an unbounded history blows
-  the wire budget (the 171K-token report).
+  the wire budget.
 
   Keeps the LAST `cap` records (epoch-history is chronological,
   oldest→newest, so the tail is 'what just happened'). The `:epochs`
@@ -225,7 +225,7 @@
 
 (defn diff-encode-epochs-in-snapshot
   "Walk the per-frame snapshot map and diff-encode every frame's
-  `:epochs` slice (rf2-1wdzp). `mode :full` short-circuits — the
+  `:epochs` slice. `mode :full` short-circuits — the
   snapshot passes through unchanged. Other slices are untouched; only
   the `:epochs` slot of each frame map is rewritten."
   [snapshot mode]
@@ -243,7 +243,7 @@
 
 (defn dedup-epochs-in-snapshot
   "Walk the per-frame snapshot map and apply structural dedup
-  (rf2-obpa9) to every frame's `:epochs` slice. Dedup is per-frame —
+  to every frame's `:epochs` slice. Dedup is per-frame —
   cross-frame share-pooling would require a single table spanning
   every frame's slice, which is a follow-on optimisation; per-frame
   is the safe default and matches the table-reset policy

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/source_uri.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/source_uri.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.source-uri
-  "Source-URI decoration pass (rf2-cibp8).
+  "Source-URI decoration pass.
 
   Every re-frame2-pair-mcp tool whose response carries source-coord data walks
   the post-shrink payload through this transform. The decorator
@@ -15,7 +15,7 @@
   2. **Flat-key carrier** — `(rf/handler-meta kind id)` / `(rf/frame-
      meta id)` returns merge source-coords flat onto the registration-
      metadata map (`:ns` / `:line` / `:column` / `:file` at the top
-     level — per Spec-Schemas `:rf/source-coord-meta` and rf2-4h8ny).
+     level — per Spec-Schemas `:rf/source-coord-meta`).
      When the walker descends into a map that itself carries a usable
      `:file` string alongside other source-coord keys (`:ns`/`:line`/
      `:column`), the URI is spliced on THAT map at `:rf.source/uri`.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.subscribe
-  "Tool: subscribe — streaming trace + epoch channel (rf2-hq49).
+  "Tool: subscribe — streaming trace + epoch channel.
 
   The MCP `tools/call` request runs until either:
     (a) the client aborts (cancellation arrives via the MCP `extra.signal`
@@ -12,14 +12,14 @@
   `tools/call` result is a summary `{:ok? true :sub-id :delivered N
   :overflow N :reason <terminated-reason>}`.
 
-  The runtime queue is bounded by a byte+event budget (rf2-ho4ve):
+  The runtime queue is bounded by a byte+event budget:
   default 500 events OR ~5 MB of pr-str bytes, whichever trips first.
   On overflow the OLDEST queued events are evicted (drop-oldest FIFO).
   The drain payload carries `:dropped-events`, `:dropped-bytes`, and
   `:overflow-reason` (`:max-buffered-events` / `:max-buffered-bytes`)
   so the AI client knows which budget to tune.
 
-  ## Internal shape (rf2-w5etd)
+  ## Internal shape
 
   All rolling per-stream accounting lives in a single `state` atom
   holding a map `{:tick :delivered :dropped-events :dropped-bytes
@@ -30,16 +30,13 @@
   controller`, which closes over the atom and returns the `terminate`
   + `poll` fns — the streaming-loop body reads top-down.
 
-  ## Per-tick + final-summary emit (rf2-zkca8.3)
+  ## Per-tick + final-summary emit
 
   `progress-payload`, `emit-progress-tick!`, and `final-summary` live
-  in this same namespace. They were briefly split out as
-  `tools/subscribe-emit.cljs` to keep this body under the leaf-size
-  ceiling; the audit (rf2-zkca8.3) recognised the split was an
-  artificial seam — a single-consumer helper coupled to this loop's
-  state shape, with no independent tests and no reuse surface. Folded
-  back so the streaming-loop body reads top-down without bouncing
-  between two files when the state shape changes."
+  in this same namespace — single-consumer helpers coupled to this
+  loop's state shape, with no independent tests and no reuse surface.
+  Keeping them here lets the streaming-loop body read top-down without
+  bouncing between two files when the state shape changes."
   (:require [applied-science.js-interop :as j]
             [re-frame.mcp-base.elision :as base-elision]
             [re-frame2-pair-mcp.nrepl :as nrepl]
@@ -56,28 +53,27 @@
             [re-frame2-pair-mcp.tools.resource-controls :as resource]))
 
 (def ^:private default-poll-ms 100)
-;; `:max-buffered-events` / `:max-buffered-bytes` are NOT mirrored here
-;; (rf2-ambfv): the runtime applies its own defaults when the slot is
-;; nil, and mirroring forces a two-file sync on every runtime tweak
-;; (e.g. rf2-ho4ve raising the byte cap). Pass nil → runtime defaults.
+;; `:max-buffered-events` / `:max-buffered-bytes` are NOT mirrored here:
+;; the runtime applies its own defaults when the slot is nil, and
+;; mirroring would force a two-file sync on every runtime budget tweak.
+;; Pass nil → runtime defaults.
 
 (def ^:private initial-state
-  "The rolling per-stream accounting map (rf2-w5etd). Held inside one
+  "The rolling per-stream accounting map. Held inside one
   atom for the lifetime of a `subscribe-tool` call; merged once per
   drain. Indicator slots (`:dropped-sensitive`, `:elided-large`) feed
   `wire/with-indicators` at terminal-summary emit time.
 
-  rf2-3ijbl extends this with `:rate-dropped` — the count of poll
-  cycles the per-session rate-limit (resource-controls token bucket)
-  DEFERRED to keep the wire under the operator-configured events/sec
-  cap. Per rf2-uvfph a deferred cycle does NOT drain the runtime queue,
-  so its events ride a later cycle once a token refills — `:rate-dropped`
-  is a \"cap-tripped\" signal (raise `--max-events-per-sec`, or look at
-  why a consumer is sending so much), NOT a lost-event count. The count
-  surfaces on the final summary so the operator sees whether the cap
-  bit during the stream."
+  `:rate-dropped` is the count of poll cycles the per-session
+  rate-limit (resource-controls token bucket) DEFERRED to keep the wire
+  under the operator-configured events/sec cap. A deferred cycle does
+  NOT drain the runtime queue, so its events ride a later cycle once a
+  token refills — `:rate-dropped` is a \"cap-tripped\" signal (raise
+  `--max-events-per-sec`, or look at why a consumer is sending so much),
+  NOT a lost-event count. The count surfaces on the final summary so the
+  operator sees whether the cap bit during the stream."
   ;; :elided-large counts upstream-pre-elided markers per
-  ;; Spec 009 §Indicator field (rf2-8cntr) — cumulative across drains.
+  ;; Spec 009 §Indicator field — cumulative across drains.
   {:tick              0
    :delivered         0
    :dropped-events    0
@@ -103,7 +99,7 @@
 (defn merge-drain
   "Pure state update — fold one drain's contributions into the rolling
   accumulators. The drain reports `:ev-dropped`/`:by-dropped` for
-  queue-overflow eviction (rf2-ho4ve), `:dropped` for sensitive-strip,
+  queue-overflow eviction, `:dropped` for sensitive-strip,
   and `:tick-elided` for the count of `:rf.size/large-elided` markers
   on this batch. `:n` is the kept-event count after sensitive-strip.
 
@@ -125,8 +121,7 @@
     (pos? tick-elided) (update :elided-large      + tick-elided)))
 
 ;; ---------------------------------------------------------------------------
-;; Per-tick progress payload + final-summary emit (folded back from
-;; `tools/subscribe-emit.cljs` per rf2-zkca8.3).
+;; Per-tick progress payload + final-summary emit.
 ;; ---------------------------------------------------------------------------
 
 (defn progress-payload
@@ -134,7 +129,7 @@
   `events` is the EDN-printed string of the batch (kept as a string so
   the agent host sees the same shape as `tools/call` results). The
   `_meta.data` carries the structured drop counts and the
-  `:overflow-reason` keyword (per rf2-ho4ve) so AI clients can
+  `:overflow-reason` keyword so AI clients can
   pattern-match on which budget tripped without re-parsing the EDN
   message. The official MCP SDK strips unknown top-level progress
   params, but preserves `_meta`."
@@ -160,14 +155,14 @@
 (defn final-summary
   "The terminal `ok-text` result emitted when the subscription ends —
   client cancel, unsubscribe, max-events / max-ms hit, sub-gone, or
-  abuse-detected (rf2-3ijbl).
+  abuse-detected.
 
   `state` is the deref'd rolling accumulators map (see
   `initial-state`); `wire/with-indicators` splices the
   `:dropped-sensitive` / `:elided-large` counters onto the envelope
   per the cross-MCP indicator-field convention. `:rate-dropped`
   surfaces only when non-zero — same suppress-when-zero discipline
-  as the indicator-field MUSTs. Per rf2-uvfph `:rate-dropped` counts
+  as the indicator-field MUSTs. `:rate-dropped` counts
   poll cycles DEFERRED by the rate cap (events stayed queued for a
   later cycle), not lost events."
   [{:keys [sub-id topic state reason]}]
@@ -195,7 +190,7 @@
   `sendNotification`. Failures are swallowed — a flaky client must not
   collapse the stream.
 
-  rf2-mscih — the `:message`-slot EDN map carries the delivered payload
+  The `:message`-slot EDN map carries the delivered payload
   under one of two slots per the sub's topic:
     - `:cascades` (vector of cascade bundles) on cascade-bundle topics
       (`:trace`/`:fx`/`:error`);
@@ -205,7 +200,7 @@
   traces as a unit. The `:cascade?` flag on `tick-state` carries the
   topic-shape signal.
 
-  rf2-wz66k7 — the serialised `:message` EDN runs through
+  The serialised `:message` EDN runs through
   `cap/cap-message` BEFORE it crosses the notification wire, applying the
   SAME per-notification token budget (and `:rf.mcp/overflow` overflow
   marker) the `tools/call` result path enforces. Without this, a single
@@ -244,12 +239,10 @@
       (catch :default _ nil))))
 
 ;; ---------------------------------------------------------------------------
-;; Drain eval-form — server-side off-box projection (rf2-vr2hn + rf2-mscih
-;; + rf2-mahffz/EP-0015 §13).
+;; Drain eval-form — server-side off-box projection (EP-0015 §13).
 ;; ---------------------------------------------------------------------------
 ;;
-;; `drain-subscription!` returns one of two envelopes per the sub's topic
-;; (rf2-mscih):
+;; `drain-subscription!` returns one of two envelopes per the sub's topic:
 ;;
 ;;   - Cascade-bundle topics (`:trace`/`:fx`/`:error`) →
 ;;     `{:ok? :sub-id :cascades [<bundle> ...] :dropped-events ... :gone? ...}`
@@ -261,14 +254,14 @@
 ;;     `{:ok? :sub-id :events [...] :dropped-events ... :gone? ...}`.
 ;;
 ;; The delivered slots take DIFFERENT off-box-egress primitives, selected
-;; by topic (rf2-mahffz):
+;; by topic:
 ;;
 ;;   - TRACE-event slots — `:cascades` (cascade-bundle topics) + the
 ;;     `:frameless` topic's `:events` — are tree-shaped values rooted at
 ;;     the frame's app-db, so each flows through
 ;;     `re-frame.core/elide-wire-value` (the size-elision walker reading
 ;;     the live `[:rf.runtime/elision]` runtime-db registry — it runs
-;;     app-side). Gated by the `:elision` toggle (rf2-vr2hn / rf2-c2dtu):
+;;     app-side). Gated by the `:elision` toggle:
 ;;     gate-OFF forces it on; gate-ON + `:elision false` ships raw.
 ;;
 ;;   - The `:epoch` topic's `:events` carry whole `:rf/epoch-record`s,
@@ -301,10 +294,10 @@
   gate-OFF callers see redacted sensitive slots regardless of any
   per-call opt-in.
 
-  Per rf2-mscih the wrapper handles both delivery shapes (cascade-bundle
-  topics → `:cascades`; flat topics → `:events`).
+  The wrapper handles both delivery shapes (cascade-bundle topics →
+  `:cascades`; flat topics → `:events`).
 
-  ## Per-slot egress primitive — `topic` selects (rf2-mahffz, EP-0015 §13)
+  ## Per-slot egress primitive — `topic` selects (EP-0015 §13)
 
   The two delivered slots are NOT the same shape, so they take DIFFERENT
   egress primitives — selected by `topic`, not by slot presence:
@@ -333,8 +326,8 @@
     `:rf.egress/off-box-observability`. Per-tool reimplementation of the
     projection (the prior whole-record `elide-wire-value` walk) is
     prohibited. This mirrors `watch-epochs` / `trace-window`
-    (`epoch-egress/project-page-src`) and the snapshot `:epochs` slice
-    (rf2-8fin7.1): one off-box epoch-egress site, one projector.
+    (`epoch-egress/project-page-src`) and the snapshot `:epochs` slice:
+    one off-box epoch-egress site, one projector.
 
   The `:epoch` projection is gated on `(not incl?)` (the
   `--allow-sensitive-reads` opt-in axis, like the pull-mode epoch tools)
@@ -346,7 +339,7 @@
   PROJECTED epoch records, because epoch projection tracks the sensitive
   axis, not the large-slot toggle.
 
-  rf2-1we9fa / rf2-7737vq — the trace-walk arm resolves the elision
+  The trace-walk arm resolves the elision
   `:frame` PER ELEMENT inside the walk by LAYER: a cascade record's own
   top-level `:frame` slot (DERIVED records key frame at top level —
   cascade bundles are keyed by `[frame dispatch-id]`), else a frameless
@@ -360,7 +353,7 @@
   boundary). The operating frame is the genuinely-frameless FALLBACK
   only.
 
-  EP-0002 (rf2-bd4div) — the drain form runs on the nREPL eval thread,
+  EP-0002 — the drain form runs on the nREPL eval thread,
   which carries NO ambient `with-frame` scope, so a frameless
   `re-frame.core/elide-wire-value` would FAIL CLOSED and redact every
   slot to `:rf/redacted` (the carried-frame invariant). We resolve the
@@ -380,8 +373,8 @@
   (let [epoch?         (= :epoch topic)
         ;; Epoch records ALWAYS project — independent of the large-slot
         ;; `elision?` toggle AND of the sensitive opt-in (`incl?`).
-        ;; rf2-m9duxl — `:include-sensitive true` NO LONGER bypasses the
-        ;; epoch projection: it threads `{:include-sensitive? true}` INTO
+        ;; `:include-sensitive true` does NOT bypass the epoch
+        ;; projection: it threads `{:include-sensitive? true}` INTO
         ;; `projected-record` (app-db sensitive axis only), so the
         ;; orthogonal fx-args / runtime-db / large axes and the app
         ;; `:redact-fn` stay fail-closed. Mirrors watch-epochs /
@@ -394,25 +387,24 @@
         ;; `projected-record`, never the walker — so the walker arm is
         ;; suppressed for it.
         ;;
-        ;; rf2-t55hxg.13 — fail-CLOSED: the trace walker fires UNLESS the
-        ;; caller opted into BOTH raw axes (`:elision false` ⇒
-        ;; `include-large? true` AND `:include-sensitive true` ⇒ `incl?`).
-        ;; Pre-fix it gated on `elision?` alone, so a gate-ON `:elision
-        ;; false` caller who left `:include-sensitive` at its default
-        ;; shipped raw trace-event slots — a declared-sensitive frame slot
-        ;; inside a cascade leaked off-box. A bare `:elision false` now
-        ;; still walks (large passes via `elision-opts-edn`, sensitive
-        ;; redacts to `:rf/redacted`).
+        ;; Fail-CLOSED: the trace walker fires UNLESS the caller opted
+        ;; into BOTH raw axes (`:elision false` ⇒ `include-large? true`
+        ;; AND `:include-sensitive true` ⇒ `incl?`). Gating on `elision?`
+        ;; alone would let a gate-ON `:elision false` caller who left
+        ;; `:include-sensitive` at its default ship raw trace-event slots
+        ;; — a declared-sensitive frame slot inside a cascade leaking
+        ;; off-box. A bare `:elision false` still walks (large passes via
+        ;; `elision-opts-edn`, sensitive redacts to `:rf/redacted`).
         walk-trace?    (and (not epoch?)
                             (elision/walk-required? (not elision?) incl?))
         drain-call     (ef/rt-call 'drain-subscription! sub-id)]
     (cond
       ;; Nothing to project: gate-ON + `:elision false` on a NON-epoch
       ;; topic — the full-raw trace-event opt-in. Bare drain ships raw
-      ;; (the pre-rf2-vr2hn / operator-opt-in posture). The `:epoch` topic
-      ;; NEVER reaches this arm: `project-epoch?` is `epoch?`, always true
-      ;; for it (rf2-m9duxl — epoch records always project; the sensitive
-      ;; opt-in threads INTO the projection, it does not bypass it).
+      ;; (the operator-opt-in posture). The `:epoch` topic NEVER reaches
+      ;; this arm: `project-epoch?` is `epoch?`, always true for it (epoch
+      ;; records always project; the sensitive opt-in threads INTO the
+      ;; projection, it does not bypass it).
       (not (or walk-trace? project-epoch?))
       (ef/emit drain-call)
 
@@ -423,13 +415,13 @@
       ;; frame-state runtime-db partition, projects every payload slot
       ;; under `:rf.egress/off-box-observability`. `projected-record`
       ;; resolves the frame off each record's own `:frame` slot, so no
-      ;; `current-frame` thread is needed. Per-tool reimplementation (the
-      ;; prior whole-record `elide-wire-value` walk, which left
+      ;; `current-frame` thread is needed. Per-tool reimplementation (a
+      ;; whole-record `elide-wire-value` walk, which would leave
       ;; `:effects[].args` / `:sub-runs` / runtime-db raw) is prohibited.
-      ;; rf2-m9duxl — `incl?` threads `{:include-sensitive? true}` INTO
-      ;; the projection (app-db sensitive axis only); it does NOT disable
-      ;; it. fx-args / runtime-db / large slots / `:redact-fn` stay
-      ;; fail-closed regardless of `:include-sensitive`.
+      ;; `incl?` threads `{:include-sensitive? true}` INTO the projection
+      ;; (app-db sensitive axis only); it does NOT disable it. fx-args /
+      ;; runtime-db / large slots / `:redact-fn` stay fail-closed
+      ;; regardless of `:include-sensitive`.
       project-epoch?
       (let [opts-edn (egress/egress-opts-edn incl?)]
         (ef/emit
@@ -445,11 +437,10 @@
       ;; are tree-shaped trace events rooted at the frame's app-db, so the
       ;; size-elision walker is the correct primitive.
       ;;
-      ;; rf2-suoj2 — `elision-opts-edn` first arg is walker-aligned
-      ;; `include-large?` (subscribe always elides, so emit markers ⇒ pass
-      ;; `false`).
+      ;; `elision-opts-edn` first arg is walker-aligned `include-large?`
+      ;; (subscribe always elides, so emit markers ⇒ pass `false`).
       ;;
-      ;; rf2-1we9fa — the elision `:frame` is resolved PER ELEMENT inside
+      ;; The elision `:frame` is resolved PER ELEMENT inside
       ;; the walk, NOT once for the whole drain. Cascade bundles are keyed
       ;; by `[frame dispatch-id]` (group-cascades-with-events), so an
       ;; all-frame stream — or a filter frame that differs from the
@@ -459,13 +450,13 @@
       ;; frame's) registry mis-redacts — the sharp edge is UNDER-redaction
       ;; (frame-A values A marks sensitive but B does not would leak across
       ;; the off-box MCP→LLM boundary). Each element supplies its own
-      ;; frame BY LAYER (rf2-7737vq): a DERIVED cascade record's top-level
+      ;; frame BY LAYER: a DERIVED cascade record's top-level
       ;; `:frame` slot, else a frameless RAW event's frame via the
       ;; canonical `re-frame.trace/trace-event-frame` reader ([:tags
       ;; :frame]).
       ;;
-      ;; EP-0002 (rf2-bd4div): `current-frame` survives as the genuinely
-      ;; frameless FALLBACK only. The nREPL eval thread carries no ambient
+      ;; EP-0002: `current-frame` is the genuinely frameless FALLBACK
+      ;; only. The nREPL eval thread carries no ambient
       ;; frame scope, so a truly frameless element would otherwise fail
       ;; closed and redact every slot to `:rf/redacted`; resolving the
       ;; operating frame app-side preserves the deliberate frame-thread for
@@ -513,7 +504,7 @@
 
   Both fns close over the same atom. `terminate` issues the
   runtime-side `unsubscribe!`, releases the resource-controls
-  stream slot (rf2-3ijbl — must run on EVERY exit path so the
+  stream slot (must run on EVERY exit path so the
   concurrent-stream counter doesn't leak), then `resolve`s the outer
   `tools/call` Promise with the final-summary envelope. `poll` runs
   the rate-gate → drain → state-merge → progress-emit → reschedule
@@ -522,8 +513,8 @@
 
   Public (not `defn-`) so `subscribe_resource_controls_test.cljs` can
   drive a single `poll` invocation with a stubbed
-  `nrepl/cljs-eval-value` to pin the rf2-uvfph rate-gate-before-drain
-  ordering (a denied cycle MUST NOT call the destructive drain)."
+  `nrepl/cljs-eval-value` to pin the rate-gate-before-drain ordering
+  (a denied cycle MUST NOT call the destructive drain)."
   [{:keys [conn build-id sub-id topic resolve state
            signal send-note progress-tk poll-ms max-events
            incl? elision? dedup? cap]}]
@@ -557,21 +548,17 @@
                  (>= (:delivered @state) max-events))
             (terminate :max-events-reached)
 
-            ;; rf2-uvfph — per-session rate-limit gate, checked BEFORE the
-            ;; destructive drain. The token bucket holds at most
-            ;; `max-events-per-sec` tokens; one drain-and-emit cycle
-            ;; consumes one token. When the bucket is empty THIS poll
-            ;; cycle is deferred: we do NOT call `drain-subscription!`,
-            ;; so the runtime-side queue stays intact and its events ride
-            ;; the NEXT cycle once a token refills — no event loss.
+            ;; Per-session rate-limit gate, checked BEFORE the destructive
+            ;; drain. The token bucket holds at most `max-events-per-sec`
+            ;; tokens; one drain-and-emit cycle consumes one token. When
+            ;; the bucket is empty THIS poll cycle is deferred: we do NOT
+            ;; call `drain-subscription!`, so the runtime-side queue stays
+            ;; intact and its events ride the NEXT cycle once a token
+            ;; refills — no event loss. Gating the drain itself (rather
+            ;; than after it has popped + cleared the queue) is what keeps
+            ;; a denied tick from throwing an already-drained batch away.
             ;;
-            ;; Pre-rf2-uvfph the rate gate ran AFTER the drain had already
-            ;; popped + cleared the runtime queue, so a denied tick threw
-            ;; the already-drained batch away (silent data loss) despite
-            ;; the spec/comment promising "left in queue for later
-            ;; delivery". Gating the drain itself restores that contract.
-            ;;
-            ;; `:rate-dropped` now counts DEFERRED poll cycles, not lost
+            ;; `:rate-dropped` counts DEFERRED poll cycles, not lost
             ;; ticks — it is a "the cap was tripped, consider raising
             ;; --max-events-per-sec" signal, not a data-loss tally. Under
             ;; normal load (poll cadence ≪ refill rate) the bucket never
@@ -589,7 +576,7 @@
                   (fn [drain-resp]
                     (if (:gone? drain-resp)
                       (terminate :sub-gone)
-                      (let [;; rf2-mscih — the drain envelope carries the
+                      (let [;; The drain envelope carries the
                             ;; delivered slot per the sub's topic:
                             ;; `:cascades` for cascade-bundle topics
                             ;; (`:trace`/`:fx`/`:error`), `:events` for
@@ -607,7 +594,7 @@
                             [evts dropped] (sensitive/strip-sensitive
                                              (vec raw-items) incl?)
                             ;; :elided-large counts upstream-pre-elided markers per
-                            ;; Spec 009 §Indicator field (rf2-8cntr) — per-tick contribution.
+                            ;; Spec 009 §Indicator field — per-tick contribution.
                             tick-elided    (base-elision/count-elided-markers evts)
                             n              (count evts)
                             drain-delta    {:n           n
@@ -633,7 +620,7 @@
                              :ov-reason    ov-reason
                              :dropped      dropped
                              :tick-elided  tick-elided}))
-                        ;; rf2-3ijbl — abuse-detection: any drain that
+                        ;; Abuse-detection: any drain that
                         ;; reported a queue overflow contributes to the
                         ;; session's rolling window. Sustained overflow
                         ;; (the consumer can't keep up) terminates the
@@ -656,7 +643,7 @@
 
 (defn- run-acquired
   "Drive the subscription lifecycle once the resource-controls
-  stream slot is reserved (rf2-3ijbl). Returns a Promise resolving to
+  stream slot is reserved. Returns a Promise resolving to
   the MCP tool result; on any pre-controller exit path the slot is
   released here — the stream-controller's `terminate` only fires
   AFTER `make-stream-controller` wires up, so failures before that
@@ -669,7 +656,7 @@
           (ef/rt-call 'subscribe!
                       ;; Only inline slots the caller actually
                       ;; supplied — the runtime applies its own
-                      ;; defaults for absent budget knobs (rf2-ambfv).
+                      ;; defaults for absent budget knobs.
                       (cond-> {:topic topic}
                         max-buf-events (assoc :max-buffered-events max-buf-events)
                         max-buf-bytes  (assoc :max-buffered-bytes  max-buf-bytes)
@@ -708,21 +695,21 @@
 (defn subscribe-tool [conn raw-args extra]
   (let [build-id           (wire/arg-build conn raw-args)
         topic              (wire/arg-keyword raw-args :topic)
-        ;; rf2-5kbkl — `parse-filter-arg` returns the tagged
+        ;; `parse-filter-arg` returns the tagged
         ;; `[:ok m]` / `[:err :invalid-filter-edn]` shape (mirroring
         ;; `read-edn-arg`). A bad filter EDN short-circuits to an honest
         ;; `:ok? false` envelope below rather than riding into the
         ;; runtime `subscribe!` `:filter` slot as a nonsense filter that
         ;; would silently stream the wrong (likely empty) event set.
         [filter-tag filter-map] (args/parse-filter-arg (wire/arg raw-args :filter))
-        ;; rf2-uvfph — validate the five numeric subscribe controls
+        ;; Validate the five numeric subscribe controls
         ;; BEFORE they reach the runtime queue budget / poll loop /
         ;; termination caps. Buffer caps + poll cadence must be positive
         ;; integers; the termination caps must be non-negative (0 =
         ;; unbounded). A bad value short-circuits to an honest `:ok? false`
-        ;; envelope in the `cond` below — un-vetted negatives previously
-        ;; collapsed the queue budget (empty probe), spun the poll loop, or
-        ;; silently disabled the intended bound. Each is `[:ok n|nil]` /
+        ;; envelope in the `cond` below — un-vetted negatives would
+        ;; collapse the queue budget (empty probe), spin the poll loop, or
+        ;; silently disable the intended bound. Each is `[:ok n|nil]` /
         ;; `[:err {…}]`; `nil` (absent) falls back to the default.
         mbe-r              (args/parse-positive-int-arg "max-buffered-events" (wire/arg raw-args :max-buffered-events))
         mbb-r              (args/parse-positive-int-arg "max-buffered-bytes"  (wire/arg raw-args :max-buffered-bytes))
@@ -737,18 +724,17 @@
         poll-ms            (or (second pms-r) default-poll-ms)
         max-ms             (or (second mms-r) 0)
         max-events         (or (second mev-r) 0)
-        ;; rf2-c2dtu — the `--allow-sensitive-reads` boot gate forces
+        ;; The `--allow-sensitive-reads` boot gate forces
         ;; `:include-sensitive false` on every streamed event when OFF
-        ;; (the published-build default). `sensitive/strip-sensitive`
-        ;; below honours the post-gate value, so a caller's
-        ;; `:include-sensitive true` arg is dropped before reaching the
-        ;; runtime drain. rf2-p1qli: single intention-naming predicate
-        ;; `raw-state-allowed?` (positive sense — true when operator
-        ;; opted in at launch).
+        ;; (the default). `sensitive/strip-sensitive` below honours the
+        ;; post-gate value, so a caller's `:include-sensitive true` arg is
+        ;; dropped before reaching the runtime drain. The single
+        ;; intention-naming predicate `raw-state-allowed?` (positive sense
+        ;; — true when operator opted in at launch) governs it.
         incl?              (if (raw-state/raw-state-allowed?)
                              (args/parse-bool-arg raw-args :include-sensitive)
                              false)
-        ;; rf2-vr2hn — the `--allow-sensitive-reads` boot gate forces
+        ;; The `--allow-sensitive-reads` boot gate forces
         ;; `:elision true` on every streamed event when OFF, mirroring
         ;; the snapshot / get-path gate. Server-side, the drain envelope's
         ;; `:events` flow through `re-frame.core/elide-wire-value` before
@@ -759,7 +745,7 @@
                              (args/parse-bool-arg raw-args :elision)
                              true)
         dedup?             (args/parse-bool-arg raw-args :dedup)
-        ;; rf2-wz66k7 — the per-call wire-cap budget for the streamed
+        ;; The per-call wire-cap budget for the streamed
         ;; progress notifications. The `invoke` chokepoint (tools.cljs)
         ;; already validates `max-tokens` and short-circuits a NEGATIVE /
         ;; fractional value to an isError BEFORE this tool runs, so the
@@ -778,7 +764,7 @@
                         :given (wire/arg raw-args :topic)
                         :hint  "Recognised topics: trace, epoch, fx, error, frameless."}))
 
-      ;; rf2-5kbkl — the filter EDN failed to parse. Surface an honest
+      ;; The filter EDN failed to parse. Surface an honest
       ;; `:ok? false` error (same one-cond-branch shape as
       ;; `:unknown-topic` above) instead of subscribing with a garbage
       ;; filter. No nREPL socket touched.
@@ -788,7 +774,7 @@
                         :given (wire/arg raw-args :filter)
                         :hint  "filter must be an EDN-readable map (or a JSON object), e.g. \"{:op-type :error}\"."}))
 
-      ;; rf2-uvfph — a numeric control arg failed validation (zero /
+      ;; A numeric control arg failed validation (zero /
       ;; negative / fractional / non-numeric). Surface the honest
       ;; `:ok? false` envelope (same one-cond-branch shape as the topic /
       ;; filter checks) BEFORE reserving a stream slot or touching the
@@ -797,7 +783,7 @@
       (js/Promise.resolve (wire/err-text (second numeric-err)))
 
       :else
-      ;; rf2-3ijbl — reserve a session-wide stream slot BEFORE any
+      ;; Reserve a session-wide stream slot BEFORE any
       ;; runtime allocation. A rejection at this gate returns an
       ;; isError result without touching the nREPL socket — the
       ;; client must close an existing subscription first.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.summary
-  "Tree-summary marker primitive (rf2-tygdv, generalised rf2-u2029).
+  "Tree-summary marker primitive.
 
   Per the cross-MCP wire-protocol §\"4. Lazy summary\", the
   default response mode for a rich nested value is a *summary*, not the
@@ -17,26 +17,25 @@
   application of summarise / path-slice / diff-encode / dedup — lives
   in `tools/snapshot-pipeline.cljs`.
 
-  ## Approximate `:bytes` field (rf2-qta8j, sampled rf2-lbm21)
+  ## Approximate `:bytes` field
 
   The `:bytes` field is a *cheap* approximation, not a precise count.
-  Earlier shape computed `(count (pr-str v))` on every branch which
-  deeply serialised the full value just to discard the string — the
-  whole point of `tree-summary` is to AVOID shipping the deep value,
-  so paying for a full pr-str just to drop it contradicts the marker's
-  cost model. On a 54MB app-db slice (per `lazy_summary_test` fixture)
-  that's a 54MB string allocation + ~13M tokens of serialisation work
-  per summary.
+  It deliberately avoids `(count (pr-str v))`, which would deeply
+  serialise the full value just to discard the string — the whole
+  point of `tree-summary` is to AVOID shipping the deep value, so
+  paying for a full pr-str just to drop it would contradict the
+  marker's cost model. On a 54MB app-db slice (per `lazy_summary_test`
+  fixture) that would be a 54MB string allocation + ~13M tokens of
+  serialisation work per summary.
 
   The estimate is `~ entry-count × per-entry-bytes`. Per-entry-bytes is
-  SAMPLED from one representative entry (rf2-lbm21): the prior fixed
-  8-/16-byte constants assumed every entry was a scalar, which under-
-  reported a collection of deep entries by ~1000×. The dominant
-  offender was the `:epochs` slice — a vector of epoch records, each
-  carrying a full `:db-before` / `:db-after` app-db pair. A 20-record
-  slice estimated `20 × 8 = 160` bytes while the FULL expansion ran to
-  ~171K tokens; an agent reading the `:bytes` hint to decide whether to
-  drill (`mode full`) saw a slice that looked trivial and blew its
+  SAMPLED from one representative entry, so the hint reflects per-entry
+  depth rather than assuming every entry is a scalar. The depth matters
+  most for the `:epochs` slice — a vector of epoch records, each
+  carrying a full `:db-before` / `:db-after` app-db pair: a 20-record
+  slice expands to ~171K tokens, so a flat-scalar estimate
+  (`20 × 8 = 160` bytes) would look trivial and an agent reading the
+  `:bytes` hint to decide whether to drill (`mode full`) would blow its
   budget on expansion. Sampling one entry's serialised size captures
   the per-entry depth so the hint reflects the full-expansion cost.
 
@@ -57,21 +56,21 @@
   64)
 
 ;; ---------------------------------------------------------------------------
-;; Sampled `:bytes` estimator (rf2-qta8j, rf2-lbm21).
+;; Sampled `:bytes` estimator.
 ;;
 ;; `:bytes` ≈ entry-count × per-entry-bytes, where per-entry-bytes is
 ;; SAMPLED from one representative entry rather than assumed a flat
-;; scalar constant. The prior fixed constants (8 for coll entries, 16
-;; for map entries) under-reported a collection of DEEP entries — most
-;; egregiously the `:epochs` slice, where each vector entry is a full
-;; epoch record carrying a `:db-before` / `:db-after` app-db pair. A
-;; 20-record slice reported `20 × 8 = 160` bytes while the full
-;; expansion was ~171K tokens — the ~1000× miss rf2-lbm21 fixes.
+;; scalar constant. A flat constant would under-report a collection of
+;; DEEP entries — most egregiously the `:epochs` slice, where each
+;; vector entry is a full epoch record carrying a `:db-before` /
+;; `:db-after` app-db pair. A 20-record slice's full expansion runs to
+;; ~171K tokens; a flat `20 × 8 = 160` byte estimate would be a ~1000×
+;; under-report, which sampling avoids.
 ;;
 ;; Sampling reads ONE entry's serialised size (and, for maps, one
 ;; value's), so the cost is `O(one-entry-depth)` — independent of N.
-;; Floors keep tiny scalar entries from rounding to zero and preserve
-;; the old order-of-magnitude shape for shallow collections.
+;; Floors keep tiny scalar entries from rounding to zero and preserve a
+;; sensible order-of-magnitude shape for shallow collections.
 ;; ---------------------------------------------------------------------------
 
 (def ^:const ^:private map-key-overhead-bytes
@@ -82,7 +81,7 @@
 
 (def ^:const ^:private coll-entry-floor-bytes
   "Floor for a sampled vector / set / seq entry — a bare scalar entry
-  (`1`, `:x`) prints to ~1-4 chars; floor at 8 to keep the old shape
+  (`1`, `:x`) prints to ~1-4 chars; floor at 8 to keep a sensible shape
   for shallow collections and avoid zero-byte estimates."
   8)
 
@@ -121,15 +120,15 @@
   `summary-keys-cap` entries and flagged via `:keys-truncated? true`
   so the marker can never blow the wire cap.
 
-  The `:bytes` field is an APPROXIMATION (per rf2-qta8j). Earlier
-  shape deep-serialised the value with `(count (pr-str v))` — that
-  pays the very cost the summary marker exists to avoid (a 54MB
-  app-db slice burns a 54MB string allocation to compute a single
-  integer estimate). The current implementation multiplies the
-  entry count by a per-entry constant — see the namespace docstring
+  The `:bytes` field is an APPROXIMATION. It deliberately avoids
+  deep-serialising the value with `(count (pr-str v))` — that would
+  pay the very cost the summary marker exists to avoid (a 54MB
+  app-db slice would burn a 54MB string allocation to compute a single
+  integer estimate). Instead it multiplies the
+  entry count by a sampled per-entry size — see the namespace docstring
   for the constants and rationale.
 
-  Scalars are returned unchanged (rf2-ambfv): they already fit the
+  Scalars are returned unchanged: they already fit the
   wire cap by definition, so wrapping them in a summary marker would
   add tokens without saving any."
   [v]
@@ -140,7 +139,7 @@
           shown   (if (> n summary-keys-cap)
                     (vec (take summary-keys-cap ks))
                     (vec ks))
-          ;; Sample one value to capture per-value depth (rf2-lbm21).
+          ;; Sample one value to capture per-value depth.
           ;; `(first (vals v))` is O(1) — it doesn't realise the rest.
           first-val (when (pos? n) (val (first v)))]
       {:rf.mcp/summary (cond-> {:type   :map

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
@@ -1,7 +1,7 @@
 (ns re-frame2-pair-mcp.tools.tail-build
   "Tool: tail-build — wait for hot-reload to land.
 
-  ## Probe-value diagnostics (rf2-36awg)
+  ## Probe-value diagnostics
 
   When a probe form is supplied, both the success and timeout responses
   carry `:probe-values {:initial <v0> :final <v-last>}` — the two ends
@@ -18,11 +18,10 @@
     3. `:initial` present and `:final` errored consistently →
        `:probe-errored` envelope with `:probe-error <stringified ex>`.
 
-  Pre-rf2-36awg the timeout response carried only the misleading hint
-  \"Likely a compile error\". A pair-debug session 2026-05-25 hit the
-  case where the probe form itself was malformed and could not change;
-  with no value information returned the operator had to manually call
-  `handler-meta` to confirm the rebuild had actually landed."
+  Returning both ends of the comparison lets the operator distinguish a
+  malformed probe form (which can never change) from a genuinely stalled
+  rebuild directly from the envelope, instead of manually calling
+  `handler-meta` to confirm the rebuild landed."
   (:require [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.wire :as wire]))
@@ -49,8 +48,8 @@
   300)
 
 (def ^:private timeout-note
-  "Hint surfaced on the timeout envelope. With the probe-values now
-  riding back, the operator can read the values themselves to pick
+  "Hint surfaced on the timeout envelope. The probe-values ride back
+  alongside it, so the operator can read the values themselves to pick
   the actual cause from the listed candidates."
   (str "Probe value did not change within wait-ms. "
        "Possible causes: (a) compile error in shadow stalled the rebuild, "
@@ -66,7 +65,7 @@
 
 (defn tail-build-tool [conn args]
   (let [build-id (wire/arg-build conn args)
-        ;; rf2-wz66k7 — validate `:wait-ms` as a positive-millisecond
+        ;; Validate `:wait-ms` as a positive-millisecond
         ;; integer BEFORE it reaches the `(>= elapsed wait-ms)` poll
         ;; comparison. A non-numeric value (`"never"`) makes `(>= n NaN)`
         ;; never true ⇒ the probe-change loop polls the nREPL socket

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -1,24 +1,24 @@
 (ns re-frame2-pair-mcp.tools.trace-window
   "Tool: trace-window — epochs in the last N ms.
 
-  Cursor pagination (rf2-kbqq3): the response is bounded at `:limit`
+  Cursor pagination: the response is bounded at `:limit`
   items (default 50). When more remain, `:next-cursor` is non-nil. The
   cursor encodes a sticky `:until-ms` so subsequent pages see the same
   window the first call did — fresh epochs landing during pagination
   don't sneak in mid-iteration.
 
   Post-eval shrink pipeline lives in
-  `re-frame2-pair-mcp.tools.wire-pipeline` (rf2-ae8ie). This tool body
+  `re-frame2-pair-mcp.tools.wire-pipeline`. This tool body
   builds the eval form, awaits the runtime response, and routes the
   epoch vector through `run-wire-pipeline` with `:kind :epoch-vector`.
 
-  ## Empty-result advisory (rf2-fb4hn)
+  ## Empty-result advisory
 
   When the response would carry `:count 0` but the frame's
   per-frame epoch-history is non-empty, an `:advisory` rides on
   the envelope distinguishing \"nothing happened\" from \"events exist
-  but fell outside the time window\". Pre-rf2-fb4hn the operator had no
-  way to tell these apart and routinely misread \"empty window\" as
+  but fell outside the time window\". Without it the operator can't
+  tell these apart and may misread \"empty window\" as
   \"the MCP isn't capturing my events\". The advisory names the
   history count and points to `snapshot` as the historical-inspection
   surface."
@@ -35,29 +35,28 @@
 (defn trace-window-tool [conn raw-args]
   (let [ms        (or (wire/arg raw-args :ms) 1000)
         build-id  (wire/arg-build conn raw-args)
-        ;; rf2-lbm21 — coerce `:frame` via the colon-tolerant
+        ;; Coerce `:frame` via the colon-tolerant
         ;; `->frame-keyword` (the shared `fresh-keyword` path), not the
         ;; raw `(keyword ...)` of `arg-keyword`. A documented `:rf/default`
-        ;; / `:foo` frame-id passed with its leading colon used to mint
-        ;; the malformed `::rf/default`, matching no frame. Same fix
-        ;; rf2-ldfnx applied to dispatch.
+        ;; / `:foo` frame-id passed with its leading colon must resolve
+        ;; rather than minting the malformed `::rf/default`, which matches
+        ;; no frame. Same coercion `dispatch` uses.
         frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
-        ;; rf2-c2dtu / rf2-p1qli — the `--allow-sensitive-reads` boot gate
+        ;; The `--allow-sensitive-reads` boot gate
         ;; forces `:include-sensitive false` when OFF (the default), via
         ;; the single intention-naming predicate `raw-state-allowed?`
         ;; (positive sense — true when operator opted in at launch).
-        ;; rf2-6wvh5 — the
-        ;; pull-mode epoch ring egresses full epoch records carrying
+        ;; The pull-mode epoch ring egresses full epoch records carrying
         ;; `:db-before` / `:db-after` (and `:trigger-event` /
-        ;; `:trace-events`) app-db snapshots; before rf2-6wvh5 they rode
-        ;; the wire verbatim, leaking a declared-sensitive / declared-
-        ;; large slot. The fix routes each egressed record through
+        ;; `:trace-events`) app-db snapshots, any of which can hold a
+        ;; declared-sensitive / declared-large slot. Each egressed record
+        ;; routes through
         ;; `re-frame.core/projected-record` — the framework's SINGLE
         ;; normative off-box-egress emission site (Security.md §Epoch
         ;; privacy posture; core.cljc names the hand-walk an anti-pattern
         ;; "one missed `mapv projected-record` away from a leak").
-        ;; rf2-m9duxl — `incl?` (gate-ON + explicit `:include-sensitive
-        ;; true`) NO LONGER bypasses projection. It is threaded as the
+        ;; `incl?` (gate-ON + explicit `:include-sensitive
+        ;; true`) does NOT bypass projection. It is threaded as the
         ;; `{:include-sensitive? true}` egress opt INTO `projected-record`,
         ;; lifting ONLY the app-db sensitive axis; fx-args / runtime-db /
         ;; large slots / `:redact-fn` stay fail-closed. Every egressed page
@@ -86,12 +85,12 @@
             history-call (if sticky-frame
                            (ef/rt-call 'epoch-history sticky-frame)
                            (ef/rt-call 'epoch-history))
-            ;; rf2-6wvh5 — the egress slice (`page`) is the ONLY vector
+            ;; The egress slice (`page`) is the ONLY vector
             ;; that crosses the wire, so projection happens HERE, after
             ;; the cursor `:limit` cap, before the records ship. Each
             ;; record ALWAYS routes through `re-frame.core/projected-record`
             ;; (which reads `:frame` off the record itself and elides all
-            ;; four payload slots). rf2-m9duxl — `incl?` threads
+            ;; four payload slots). `incl?` threads
             ;; `{:include-sensitive? true}` INTO the projection (app-db
             ;; sensitive axis only); it does NOT disable projection.
             page-src       (str "(vec (take " limit " filtered))")
@@ -110,7 +109,7 @@
                                    (str "(filterv #(and (>= (or (:committed-at %) 0) " cutoff-ms ")"
                                         "                (<= (or (:committed-at %) 0) " until-ms "))"
                                         " sliced)"))
-                      ;; rf2-6wvh5 — `:page` is the egress slice, projected
+                      ;; `:page` is the egress slice, projected
                       ;; for off-box egress via `projected-record` (each
                       ;; record's `:db-before` / `:db-after` /
                       ;; `:trigger-event` / `:trace-events` slots elide

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -5,7 +5,7 @@
   aren't streaming — we return one bundle of matches per call. Callers
   that want a tight loop call us repeatedly with the same `since-id`.
 
-  Cursor pagination (rf2-kbqq3): a single poll's matches vector is
+  Cursor pagination: a single poll's matches vector is
   bounded by `:limit` (default 50). When more matches remain in the
   current ring, `:next-cursor` rides the response — the agent calls
   back with the cursor to consume the remainder. The cursor is the
@@ -13,11 +13,11 @@
   `:cursor` takes precedence (it carries sticky pred/frame state).
 
   Post-eval shrink pipeline lives in
-  `re-frame2-pair-mcp.tools.wire-pipeline` (rf2-ae8ie). This tool body
+  `re-frame2-pair-mcp.tools.wire-pipeline`. This tool body
   builds the eval form, awaits the runtime response, and routes the
   matches vector through `run-wire-pipeline` with `:kind :epoch-vector`.
 
-  ## Empty-result advisory (rf2-fb4hn)
+  ## Empty-result advisory
 
   When the response would carry `:count 0` but the frame's per-frame
   epoch-history is non-empty, an `:advisory` rides on the envelope
@@ -39,26 +39,24 @@
 
 (defn watch-epochs-tool [conn raw-args]
   (let [build-id  (wire/arg-build conn raw-args)
-        ;; rf2-lbm21 — colon-tolerant `:frame` coercion (the shared
+        ;; Colon-tolerant `:frame` coercion (the shared
         ;; `fresh-keyword` path) so a `:rf/default`-with-colon frame-id
         ;; resolves instead of minting the malformed `::rf/default`.
-        ;; Same fix rf2-ldfnx applied to dispatch.
+        ;; Same coercion `dispatch` uses.
         frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         since-id  (wire/arg raw-args :since-id)
-        ;; rf2-c2dtu / rf2-p1qli — the `--allow-sensitive-reads` boot gate
+        ;; The `--allow-sensitive-reads` boot gate
         ;; forces `:include-sensitive false` when OFF (the default), via
         ;; the single intention-naming predicate `raw-state-allowed?`
         ;; (positive sense — true when operator opted in at launch).
-        ;; rf2-6wvh5 — Pull-mode
-        ;; `watch-epochs` egresses full epoch records carrying
+        ;; Pull-mode `watch-epochs` egresses full epoch records carrying
         ;; `:db-before` / `:db-after` (and `:trigger-event` /
-        ;; `:trace-events`) app-db snapshots; before rf2-6wvh5 they rode
-        ;; the wire verbatim. The fix routes each egressed record through
-        ;; `re-frame.core/projected-record` — the framework's single
-        ;; normative off-box-egress emission site (Security.md §Epoch
-        ;; privacy posture).
-        ;; rf2-m9duxl — `incl?` (gate-ON + explicit `:include-sensitive
-        ;; true`) NO LONGER bypasses projection. It is threaded as the
+        ;; `:trace-events`) app-db snapshots. Each egressed record routes
+        ;; through `re-frame.core/projected-record` — the framework's
+        ;; single normative off-box-egress emission site (Security.md
+        ;; §Epoch privacy posture).
+        ;; `incl?` (gate-ON + explicit `:include-sensitive
+        ;; true`) does NOT bypass projection. It is threaded as the
         ;; `{:include-sensitive? true}` egress opt INTO `projected-record`,
         ;; lifting ONLY the app-db sensitive axis; the orthogonal fx-args /
         ;; runtime-db / large axes and the app `:redact-fn` stay
@@ -80,14 +78,14 @@
             ;; so the agent's continuation flow stays consistent.
             effective-after (or (:after-id cursor-in) since-id)
             sticky-frame    (or (:frame cursor-in) frame)
-            ;; rf2-mb17rj — sticky `:pred`, mirroring the
+            ;; Sticky `:pred`, mirroring the
             ;; `:frame`/`:after-id` pattern above and trace-window's
             ;; sticky `:ms`/`:until-ms`. The cursor encodes the
             ;; first-call predicate; a continuation that passes back
             ;; ONLY `:cursor` (the documented opaque-cursor flow)
-            ;; restores it here. Without this, page 2+ fell back to
+            ;; restores it here. Without it, page 2+ would fall back to
             ;; `(or pred-map {})` = `{}` = MATCH-ALL — every epoch
-            ;; after the watermark returned unfiltered, with an
+            ;; after the watermark would return unfiltered, with an
             ;; envelope identical to a correctly-filtered page so the
             ;; agent couldn't detect the drop.
             sticky-pred     (or (:pred cursor-in) pred-arg)
@@ -102,10 +100,10 @@
             history-call (if sticky-frame
                            (ef/rt-call 'epoch-history sticky-frame)
                            (ef/rt-call 'epoch-history))
-            ;; rf2-6wvh5 — the `:pred` filter runs on the RAW records
+            ;; The `:pred` filter runs on the RAW records
             ;; server-side (never egressed); the capped `:page` is the
             ;; egress slice, ALWAYS projected via `projected-record` for
-            ;; off-box egress. rf2-m9duxl — `incl?` threads
+            ;; off-box egress. `incl?` threads
             ;; `{:include-sensitive? true}` INTO the projection (app-db
             ;; sensitive axis only), it does NOT disable projection.
             page-src       (str "(vec (take " limit " matches))")
@@ -116,7 +114,7 @@
                       'page          (ef/rt-raw (egress/project-page-src page-src incl?))
                       'next-id       (ef/rt-raw
                                        "(when (< (count page) (count matches)) (:epoch-id (last page)))")
-                      ;; rf2-fb4hn: history-count surfaces the
+                      ;; history-count surfaces the
                       ;; per-frame ring depth so the tool can advise
                       ;; on the \"empty matches but non-empty history\"
                       ;; case the operator typically misreads as
@@ -157,7 +155,7 @@
                                          :ms       nil
                                          :until-ms nil
                                          :frame    sticky-frame
-                                         ;; rf2-mb17rj — carry the sticky
+                                         ;; Carry the sticky
                                          ;; predicate so page 2+ keeps
                                          ;; filtering. nil when no pred was
                                          ;; supplied (round-trips losslessly
@@ -166,7 +164,7 @@
                       remaining     (or (:remaining v) 0)
                       history-count (or (:history-count v) 0)
                       since-count   (or (:since-count v) 0)
-                      ;; rf2-fb4hn: two distinct empty-result
+                      ;; Two distinct empty-result
                       ;; explainers, picked by the runtime data:
                       ;;
                       ;;   - since-count = 0 + history-count > 0

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_until.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_until.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.watch-until
-  "Tool: watch-until — block until a predicate over a signal holds (rf2-zo4b9).
+  "Tool: watch-until — block until a predicate over a signal holds.
 
   ## Why a blocking watch primitive
 
@@ -7,8 +7,8 @@
   let the human interact, read back the change-log later. `watch-until` is
   the blocking half — the answer to \"wait until the focus lands on the
   modal\" / \"wait until app-db's `[:upload :status]` flips to `:done`\".
-  Pre-rf2-zo4b9 this was a hand-rolled `setTimeout` poll inside `eval-cljs`,
-  with the same timing/teardown footguns the recorder exists to kill.
+  It replaces a hand-rolled `setTimeout` poll inside `eval-cljs`, which
+  carried the same timing/teardown footguns the recorder exists to kill.
 
   ## How it blocks
 
@@ -24,7 +24,7 @@
   ## Predicate vocabulary — DATA, not host source
 
   The `pred` arg is an EDN data predicate (same injection-closing posture
-  as `dispatch` / `replace-app-db`, rf2-vflrg). It is compiled into a pure
+  as `dispatch` / `replace-app-db`). It is compiled into a pure
   value-comparison fn by `record/pred-source` — shared with `record`'s
   `:stop {:pred ...}` so the two surfaces read identically. Recognised
   shapes (matched against the positional sample map `{<signal-index>
@@ -71,7 +71,7 @@
   `:held? false` every tick (a no-predicate watch can only time out — the
   refusal is enforced at the tool boundary, so this is defensive).
 
-  rf2-8fin7.2 — `elision-opts` (the rendered `elision-opts-edn` walker
+  `elision-opts` (the rendered `elision-opts-edn` walker
   map) rides as the 3rd `sample-signals` arg so each sampled `:app-db` /
   `:sub` value is elided for off-box egress (the `:sample` slot is what
   the tool egresses on a hold AND the `:last-sample` on timeout). When no
@@ -93,7 +93,7 @@
          'held?   (ef/rt-raw (if pred-src
                                (str "(boolean ((" pred-src ") sample))")
                                "false"))]
-        ;; rf2-p9scds — `sample-signals` fails CLOSED with an
+        ;; `sample-signals` fails CLOSED with an
         ;; `:ambiguous-frame` refusal (`:ok? false`) when a frame-policy
         ;; signal can't resolve a frame under the off-box gate. Propagate
         ;; the refusal verbatim so the poll loop surfaces a clear error
@@ -120,19 +120,19 @@
         ;; Validate `:timeout-ms` as a positive-millisecond integer up
         ;; front, the SAME contract the other timeout-aware tools use
         ;; (`tail-build :wait-ms`, `eval-cljs` / `dispatch` `:timeout-ms`
-        ;; — all via `args/parse-timeout-arg`, rf2-wz66k7). A malformed,
-        ;; zero, negative, or fractional value used to silently become
-        ;; `default-timeout-ms`, hiding the caller's bad input behind a 30s
-        ;; wait; it now short-circuits to an honest `:invalid-numeric-arg`
-        ;; error (the `cond` below). An ABSENT arg ⇒ `[:ok nil]` ⇒ the
+        ;; — all via `args/parse-timeout-arg`). A malformed,
+        ;; zero, negative, or fractional value short-circuits to an honest
+        ;; `:invalid-numeric-arg` error (the `cond` below) rather than
+        ;; silently becoming `default-timeout-ms` and hiding the caller's
+        ;; bad input behind a 30s wait. An ABSENT arg ⇒ `[:ok nil]` ⇒ the
         ;; documented default.
         timeout-r  (args/parse-timeout-arg "timeout-ms" (wire/arg raw-args :timeout-ms))
         timeout-ms (or (second timeout-r) default-timeout-ms)
         pred-src   (record/pred-source pred)
-        ;; rf2-8fin7.2 — the `:sample` (on hold) and `:last-sample` (on
+        ;; The `:sample` (on hold) and `:last-sample` (on
         ;; timeout) slots ship raw `:app-db` / `:sub` values back to the
         ;; model. Elide them for off-box egress under the same gate posture
-        ;; as snapshot / get-path / record (rf2-c2dtu / rf2-p1qli): gate
+        ;; as snapshot / get-path / record: gate
         ;; OFF (the published default) forces `:include-sensitive false`
         ;; + `:elision true`; gate ON honours the per-call args.
         elision?   (if (raw-state/raw-state-allowed?)
@@ -146,7 +146,7 @@
       ;; A bad `:timeout-ms` is a caller error worth telling the agent
       ;; about, not a value to silently paper over with the default.
       ;; Short-circuit BEFORE the runtime preflight, like eval-cljs's
-      ;; `:timeout-ms` validation (rf2-wz66k7).
+      ;; `:timeout-ms` validation.
       (= :err (first timeout-r))
       (js/Promise.resolve (wire/err-text (second timeout-r)))
 
@@ -167,9 +167,9 @@
       :else
       (let [form (watch-form signals frame pred-src elision-opts)]
         (-> (probe/ensure-runtime! conn build-id)
-            ;; rf2-8fin7.2 — flip the runtime's raw-state gate to the OFF
-            ;; posture before the first poll (the raw-state tap gate,
-            ;; rf2-c2dtu) so the sampler is fail-closed even if the eval
+            ;; Flip the runtime's raw-state gate to the OFF
+            ;; posture before the first poll (the raw-state tap gate)
+            ;; so the sampler is fail-closed even if the eval
             ;; form's threaded opts were somehow bypassed — same prelude
             ;; step snapshot / get-path / record use.
             (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
@@ -197,7 +197,7 @@
                                           (fn [resp]
                                             (vreset! latest resp)
                                             (cond
-                                              ;; rf2-p9scds — a fail-closed
+                                              ;; A fail-closed
                                               ;; refusal from `sample-signals`
                                               ;; (`:ambiguous-frame` under the
                                               ;; off-box gate) is terminal:

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.wire
-  "MCP result helpers + per-call argument extraction (rf2-vrbwx split).
+  "MCP result helpers + per-call argument extraction.
 
   Every tool returns an MCP `{:content [{:type \"text\" :text <edn-string>}]}`
   envelope, success or error. This namespace owns that wire shape plus
@@ -36,7 +36,7 @@
 ;; Every result envelope carries BOTH the pr-str-rendered EDN text
 ;; (the wire-canonical form — `:content [{:type \"text\" :text ...}]`)
 ;; AND a `:structuredContent` slot carrying the same value as a JS
-;; object (rf2-hj3pi; mcp-builder canonical pattern). Agent hosts that
+;; object (mcp-builder canonical pattern). Agent hosts that
 ;; understand `:structuredContent` read the typed object directly; the
 ;; rest fall back to the EDN text. The two slots always agree on the
 ;; payload by construction — same `v`, two projections.
@@ -46,7 +46,7 @@
 ;; remains the source of truth for the cljs-readable round-trip; the
 ;; structured slot is the SDK-friendly view.
 ;;
-;; ## Namespaced keywords keep their namespace (rf2-t2n04)
+;; ## Namespaced keywords keep their namespace
 ;;
 ;; A bare `(clj->js v)` is namespace-LOSSY in two compounding ways, and
 ;; both silently corrupt key-bearing reads:
@@ -58,12 +58,11 @@
 ;;     values `:door/main :traffic/light` collapse to `"main" "light"`.
 ;;
 ;; The damage is not cosmetic: a `snapshot` whose `(keys app-db)` carries
-;; `:rf/runtime` projects to the name-only `"runtime"`, so an agent that
-;; reads the structured slot and threads `[:runtime ...]` back through
-;; `get-path` hits `nil` — the real key is `:rf/runtime`. (This sent a
-;; live 2026-06-04 session down a false "snapshots are empty" path.)
-;; Same defect class as the machines-viz `:door/open` → `"open"` tag
-;; truncation (#2922): stringify keywords to their FULLY-QUALIFIED form
+;; `:rf/runtime` would project to the name-only `"runtime"`, so an agent
+;; that reads the structured slot and threads `[:runtime ...]` back
+;; through `get-path` would hit `nil` — the real key is `:rf/runtime`.
+;; The same defect class would truncate a machines-viz `:door/open` tag
+;; to `"open"`. So stringify keywords to their FULLY-QUALIFIED form
 ;; at the `clj->js` boundary so the namespace survives.
 ;;
 ;; The fix pre-walks `v`, replacing every keyword (key OR value) with
@@ -71,17 +70,16 @@
 ;; (`:rf/runtime` → `"rf/runtime"`, `:ok?` → `"ok?"`) — BEFORE `clj->js`
 ;; sees it. `clj->js` then only structurally coerces the (now
 ;; keyword-free) tree; sets/vectors/maps coerce exactly as before. This
-;; is also what the spec's documented projection already PROMISED —
+;; is exactly the projection the spec documents —
 ;; `:structuredContent` "drops the leading colon — ["rf/default"]"
-;; (003-Tool-Catalogue §Id representation, rf2-cg37y); the code was
-;; merely failing to honour its own contract. The EDN text slot
+;; (003-Tool-Catalogue §Id representation). The EDN text slot
 ;; (`pr-str v`) is untouched: it stays the canonical, fully-typed,
 ;; cljs-`read`-able round-trip.
 ;;
-;; ## structuredContent must never be `null` (rf2-r5erl)
+;; ## structuredContent must never be `null`
 ;;
 ;; Every tool descriptor declares a map-shaped `:outputSchema`
-;; (`{:type "object" ...}`, rf2-3l3be). When a descriptor carries an
+;; (`{:type "object" ...}`). When a descriptor carries an
 ;; `:outputSchema`, the npm MCP SDK VALIDATES the result's
 ;; `structuredContent` against it — and a `null` is not an object, so
 ;; the SDK rejects the whole `tools/call` with a host-level
@@ -91,9 +89,8 @@
 ;;
 ;; A `null` reaches here exactly when `v` is `nil` — e.g. a tool that
 ;; threads a blank nREPL eval result straight into `ok-text`
-;; (`cljs-eval-value` returns `nil` for a blank value). `read-dom`
-;; hit this in the wild (rf2-r5erl); `read-ui` did not, by luck of
-;; always getting a map back. Rather than rely on every call-site
+;; (`cljs-eval-value` returns `nil` for a blank value), as a `read-dom`
+;; that finds no node can. Rather than rely on every call-site
 ;; guarding nil, we make the wire shape TOTAL: a `nil` payload
 ;; projects to a structured `{:rf.mcp/null true}` sentinel object so
 ;; `structuredContent` is always a record the SDK accepts. The EDN
@@ -103,7 +100,7 @@
 
 (def ^:private null-structured-sentinel
   "JS object substituted for `structuredContent` when the EDN payload is
-  `nil` (rf2-r5erl). A `null` structuredContent fails the SDK's
+  `nil`. A `null` structuredContent fails the SDK's
   outputSchema validation (`expected record ... received null`); this
   sub-object keeps the slot a record. Hosts that read the EDN text slot
   see the verbatim `nil`; hosts that read the structured slot see the
@@ -118,7 +115,7 @@
   non-keyword scalar and collection structure otherwise intact.
 
   Applied to a payload BEFORE `clj->js` so the structured projection
-  preserves keyword namespaces (rf2-t2n04). `clj->js`'s built-in
+  preserves keyword namespaces. `clj->js`'s built-in
   keyword handling is namespace-lossy for both keys (default
   `:keyword-fn` is `name`) and values (always `name`); pre-stringifying
   here is the single point that closes both holes. `clj->js` then sees
@@ -145,8 +142,7 @@
 
 (defn- structured-of
   "Project `v` to the `:structuredContent` JS value, guaranteeing a
-  non-null record (rf2-r5erl) AND preserving keyword namespaces
-  (rf2-t2n04).
+  non-null record AND preserving keyword namespaces.
 
   Keyword namespaces are kept by pre-walking `v` through
   `qualify-keywords` before `clj->js` — a bare `clj->js` drops the
@@ -174,22 +170,22 @@
 (defn structured-content
   "Public projection of `v` to the SDK-friendly `:structuredContent` JS
   value — the SAME namespace-preserving, null-safe projection `ok-text`
-  / `err-text` use (rf2-t2n04, rf2-r5erl).
+  / `err-text` use.
 
-  Exposed (rf2-or8s29) for the handful of result envelopes built OUTSIDE
+  Exposed for the handful of result envelopes built OUTSIDE
   the per-tool callbacks — server-level handler-threw / discovery
   errors (server.cljs), the cache-hit marker (cache.cljs), and the
-  overflow marker (cap.cljs). Those sites previously built
-  `:structuredContent (clj->js payload)` directly, which is
+  overflow marker (cap.cljs). A bare
+  `:structuredContent (clj->js payload)` at those sites would be
   namespace-LOSSY: `:rf.mcp/cache-hit` → `\"cache-hit\"`,
   `:rf.mcp/overflow` → `\"overflow\"`, and `:rf.error/*` reason VALUES
-  lose their namespace. Routing them through this single helper keeps
-  the structured-content round-trip contract intact everywhere."
+  would lose their namespace. Routing them through this single helper
+  keeps the structured-content round-trip contract intact everywhere."
   [v]
   (structured-of v))
 
 (defn result
-  "Build an arbitrary MCP result envelope (rf2-or8s29) carrying both the
+  "Build an arbitrary MCP result envelope carrying both the
   pr-str EDN `:content` text and the namespace-preserving
   `:structuredContent` projection of the SAME `v`. Sets `:isError true`
   when `error?` is truthy.
@@ -215,7 +211,7 @@
   `:structuredContent` read the typed object; others fall back to
   parsing the text slot.
 
-  `:structuredContent` is guaranteed a non-null record (rf2-r5erl) —
+  `:structuredContent` is guaranteed a non-null record —
   a `nil` payload projects to the `:rf.mcp/null` sentinel object so the
   SDK's outputSchema validation never rejects the result for a `null`
   structuredContent."
@@ -226,7 +222,7 @@
   "Error result envelope. Same dual-slot shape as `ok-text` plus
   `:isError true` so the agent client surfaces the failure to the
   LLM without aborting the conversation (per MCP §Error Handling).
-  `:structuredContent` is non-null by construction (rf2-r5erl)."
+  `:structuredContent` is non-null by construction."
   [v]
   (result v true))
 
@@ -243,7 +239,7 @@
   silently violate the MUST.
 
   Pure-data passthrough to `re-frame.mcp-base.envelope/with-indicators`
-  (rf2-ee38b.18 / rf2-ee38b.19) — the slot keys are
+  — the slot keys are
   `base-vocab/dropped-sensitive-key` / `elided-large-key`, pinned once
   in the shared vocab so a key change can't drift across the pair. This
   thin re-export keeps the per-tool call-sites reading
@@ -271,8 +267,8 @@
   (some-> (arg args k) keyword))
 
 (defn mark-resolved-build-id!
-  "Record the build-id that `discover-app` just resolved on the conn-atom
-  (rf2-l9ixp). Subsequent tool calls without an explicit `:build` arg
+  "Record the build-id that `discover-app` just resolved on the conn-atom.
+  Subsequent tool calls without an explicit `:build` arg
   default to this id instead of the `SHADOW_CLJS_BUILD_ID` / `:app`
   env-var fallback. Defensive against a non-atom `conn` (test stubs)."
   [conn build-id]
@@ -280,7 +276,7 @@
     (swap! conn assoc :resolved-build-id build-id)))
 
 (defn- conn-resolved-build-id
-  "Read the session-scoped resolved-build-id cache from `conn` (rf2-l9ixp).
+  "Read the session-scoped resolved-build-id cache from `conn`.
   Defensive against `nil` / non-atom conn — conformance tests pass a stub
   conn that doesn't carry the cache. Returns the cached keyword or nil."
   [conn]
@@ -289,7 +285,7 @@
 
 (defn- canonicalize-via-alias
   "Map `build-id` through the conn's `:build-alias` forgiving-resolution
-  cache (rf2-qda59). When the requested id has a recorded
+  cache. When the requested id has a recorded
   suffix→canonical alias (populated by `probe/canonicalize-build!` at the
   pipeline's first step), return the canonical running id; otherwise
   return `build-id` unchanged. Defensive against a nil / non-atom conn
@@ -307,22 +303,22 @@
     1. Explicit `:build` MCP arg — operator override always wins
        (no surprise from the cache).
     2. Session-scoped resolved-build-id cache on the conn-atom — populated
-       by `discover-app` after a successful preload probe (rf2-l9ixp) AND
+       by `discover-app` after a successful preload probe AND
        by `stick-build!` after an explicit `:build` on any non-discover
-       tool call (rf2-lbm21). Removes the friction of repeating
+       tool call. Removes the friction of repeating
        `build: foo` on every tool call. Cache resets on nREPL reconnect
        (same lifecycle as `:probed-builds`).
     3. `SHADOW_CLJS_BUILD_ID` env var, defaulting to `:app`.
 
   `arg-build` is a PURE READ — it never writes the cache. The
   session-sticky write happens at the `invoke` boundary via
-  `stick-build!` (rf2-lbm21), deliberately separated so `discover-app`
+  `stick-build!`, deliberately separated so `discover-app`
   (which resolves a build via `arg-build` to PROBE it, and caches only
   on a successful health check) is never forced to cache a build that
   turned out unusable.
 
   The explicit `:build` arg is coerced via
-  `re-frame.mcp-base.args/fresh-keyword` (rf2-8ohwv), which strips a
+  `re-frame.mcp-base.args/fresh-keyword`, which strips a
   leading colon: `\"examples/step-deck\"` and `\":examples/step-deck\"`
   resolve identically. A bare `keyword` on the colon form would mint the
   malformed `::examples/step-deck` (`cljs-eval` then renders it
@@ -333,7 +329,7 @@
   build registry, so the per-id intern cost is capped.
 
   The resolved id is finally mapped through the conn's `:build-alias`
-  forgiving-resolution cache (rf2-qda59): when the requested id named a
+  forgiving-resolution cache: when the requested id named a
   running build by a unique SUFFIX (`:machine-epochs` ⇒
   `:examples/machine-epochs`), the pipeline's first step recorded the
   canonical alias, so every op — explicit-arg or sticky-default —
@@ -354,7 +350,7 @@
 
 (defn requested-build
   "The build-id this call would resolve to BEFORE the forgiving
-  suffix→canonical alias is applied (rf2-qda59). Mirrors `arg-build`'s
+  suffix→canonical alias is applied. Mirrors `arg-build`'s
   precedence (explicit `:build` arg → sticky `:resolved-build-id` →
   env/`:app` default) but does NOT route through the alias cache — it is
   the INPUT to `probe/canonicalize-build!`, which the pipeline's first
@@ -365,7 +361,7 @@
       (default-build-id)))
 
 (defn stick-build!
-  "Session-sticky operating build (rf2-lbm21). When `args` carries an
+  "Session-sticky operating build. When `args` carries an
   explicit `:build`, write it into the `:resolved-build-id` cache on the
   conn-atom so subsequent no-`:build` tool calls inherit it. No-op when
   no explicit `:build` arg is present (an omitted build must not clobber
@@ -387,14 +383,14 @@
 (defn arg-build-explicit?
   "True iff a deliberate build-id is available without falling back to
   the bare `SHADOW_CLJS_BUILD_ID` / `:app` env default. The eval-path
-  build resolver (rf2-ivlb3) auto-detects the running build ONLY when
+  build resolver auto-detects the running build ONLY when
   the build is the bare default — a deliberate choice gets honoured
   verbatim (footgun-and-all; preflight catches typos).
 
   Two sources count as deliberate:
 
     - An explicit `:build` MCP arg on this call.
-    - A session-scoped resolved-build-id cached on `conn` (rf2-l9ixp) —
+    - A session-scoped resolved-build-id cached on `conn` —
       populated by a prior successful `discover-app`. Treating the cache
       as deliberate means a subsequent eval-cljs without `:build` routes
       to the resolved build instead of being auto-detect-rejected on a
@@ -410,8 +406,7 @@
        (some? (conn-resolved-build-id conn)))))
 
 ;; ---------------------------------------------------------------------------
-;; Wire-bounded marker detection (rf2-gktyn, rf2-3z0zi; lifted to
-;; mcp-base.envelope in rf2-ee38b.19 / rf2-ee38b.18).
+;; Wire-bounded marker detection.
 ;;
 ;; The `:rf.mcp/cache-hit` and `:rf.mcp/overflow` envelopes are
 ;; replacement results emitted by the wire-boundary steps themselves.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
@@ -1,19 +1,19 @@
 (ns re-frame2-pair-mcp.tools.wire-pipeline
-  "Named wire-shrink pipeline (rf2-ae8ie). One fn per call-site —
+  "Named wire-shrink pipeline. One fn per call-site —
   every tool that returns a payload over the MCP wire routes it
   through `run-wire-pipeline`, parameterised by the payload kind.
 
   ## Why a named pipeline
 
-  Before this ns each tool body re-derived its own subset of the
-  shrink steps inline in its `let` binding. The ordering invariant
+  Without it each tool body would re-derive its own subset of the
+  shrink steps inline in its `let` binding, and the ordering invariant
   (dedup-BEFORE-summary · elision-count-AFTER-dedup-BEFORE-summary ·
-  summary-BEFORE-cap) lived implicitly in `snapshot-tool`'s
-  let-sequence; the abbreviated trace-window / watch-epochs / get-path
-  pipelines each re-derived their own subset. Three local-obvious
-  copies of one rule cost nothing — until the rule changes. A named
-  pipeline encodes the invariant once; a future step (say a
-  `redact-interceptor` walker) lands here once instead of in three places.
+  summary-BEFORE-cap) would live implicitly across `snapshot-tool`'s
+  let-sequence and the abbreviated trace-window / watch-epochs /
+  get-path pipelines — several local-obvious copies of one rule, which
+  cost nothing until the rule changes. A named pipeline encodes the
+  invariant once; a future step (say a `redact-interceptor` walker)
+  lands here once instead of in three places.
 
   ## Ordering invariant
 
@@ -25,12 +25,12 @@
         → dedup               (structural sharing across the wire)
         → indicator-count     (count :rf.size/large-elided markers)
         → summary             (lazy-summary for non-app-db rich slices)
-        → source-uri          (rf2-cibp8: splice :rf.source/uri onto
+        → source-uri          (splice :rf.source/uri onto
                                every :source-coord map; runs after
                                shrink so no URI build is wasted on
                                summary-replaced subtrees)
 
-  ## Indicator counting (rf2-e35a5)
+  ## Indicator counting
 
   When the SERVER-SIDE eval form already counted markers (snapshot +
   get-path, where `elide-wire-value` ran app-side and the count flows
@@ -118,13 +118,13 @@
       → slice-app-db (path-slice or full)
       → diff-encode-epochs
       → dedup-epochs
-      → count elision markers (from `:server-elided` opt; rf2-e35a5)
+      → count elision markers (from `:server-elided` opt)
       → summarise other slices
 
   Returns `{:value snapshot :indicators {:dropped N :elided N
   :path-status M :resolved-modes M}}`.
 
-  Per rf2-e35a5: `:server-elided` rides in on opts when the
+  `:server-elided` rides in on opts when the
   `snapshot` eval form counted markers app-side. Dedup never
   touches `:app-db` (only `:epochs`), so the server-side count is
   exact post-pipeline. Falls back to a tree-walk when the opt is
@@ -133,7 +133,7 @@
   (let [app-db-mode           (pipeline/resolve-slice-mode :app-db slice-modes slice-mode)
         [scrubbed dropped]    (sensitive/scrub-snapshot-sensitive snapshot incl?)
         [sliced path-status]  (pipeline/slice-app-db-in-snapshot scrubbed path app-db-mode)
-        ;; rf2-lbm21 — cap the full-mode `:epochs` slice to the most-recent
+        ;; Cap the full-mode `:epochs` slice to the most-recent
         ;; N records BEFORE diff-encode + dedup so those operate on the
         ;; bounded set. Only fires when `:epochs` resolves to `:full`
         ;; (the verbatim-`:db-before`/`:db-after` overflow path); a no-op
@@ -145,7 +145,7 @@
         diff-encoded          (pipeline/diff-encode-epochs-in-snapshot capped mode)
         deduped               (pipeline/dedup-epochs-in-snapshot diff-encoded dedup?)
         ;; :elided-large counts upstream-pre-elided markers per
-        ;; Spec 009 §Indicator field (rf2-8cntr).
+        ;; Spec 009 §Indicator field.
         elided                (if (some? server-elided)
                                 server-elided
                                 (base-elision/count-elided-markers deduped))
@@ -179,10 +179,10 @@
         encoded        (dedup/diff-encode-epochs kept mode)
         deduped        (dedup/dedup-value encoded dedup?)
         ;; :elided-large counts upstream-pre-elided markers per
-        ;; Spec 009 §Indicator field (rf2-8cntr) — shared by
+        ;; Spec 009 §Indicator field — shared by
         ;; `trace-window` and `watch-epochs`.
         ;;
-        ;; rf2-mb17rj — count the markers over the PRE-dedup payload
+        ;; Count the markers over the PRE-dedup payload
         ;; (`encoded`), not `deduped`. `dedup-value` pools N identical
         ;; `:rf.size/large-elided` maps into ONE structural-sharing
         ;; cache entry, so walking `deduped` undercounts (1 instead of
@@ -211,7 +211,7 @@
   what's actually being shipped — a `:path-not-found` envelope (no
   `:value` slot) bypasses the walk entirely.
 
-  Per rf2-e35a5 the count is sourced from `:server-elided` on opts
+  The count is sourced from `:server-elided` on opts
   when the eval form counted markers app-side (the common path).
   Falls back to a local walk only when the opt is missing — a
   defensive seam for tests or a degraded eval-form shape.
@@ -219,7 +219,7 @@
   Returns `{:value v :indicators {:elided N}}`."
   [v {:keys [server-elided]}]
   ;; :elided-large counts upstream-pre-elided markers per
-  ;; Spec 009 §Indicator field (rf2-8cntr).
+  ;; Spec 009 §Indicator field.
   {:value      v
    :indicators {:elided (if (some? server-elided)
                           server-elided
@@ -242,7 +242,7 @@
   - `:slice-mode`     global `:summary` / `:full` mode for non-app-db slices.
   - `:slice-modes`    per-slice override map.
   - `:server-elided`  integer count of `:rf.size/large-elided` markers
-                      inserted server-side (rf2-e35a5). When present,
+                      inserted server-side. When present,
                       the `:snapshot-map` and `:scalar-value` arms use
                       this instead of re-walking the payload. Missing
                       ⇒ falls back to a local walk.
@@ -253,7 +253,7 @@
   pipeline is a fixed surface; a dynamic-dispatch fallback has no
   legitimate use.
 
-  After the per-kind arm returns, the source-URI decorator (rf2-cibp8)
+  After the per-kind arm returns, the source-URI decorator
   splices `:rf.source/uri` onto every `:source-coord`-bearing map in
   the result. Runs last so the decoration walks only the
   post-shrink tree — summary-replaced slices ship as `{:rf.mcp/summary

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/writes.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/writes.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.tools.writes
-  "Write-authority boot-gate (rf2-ee38b.18).
+  "Write-authority boot-gate.
 
   The Tool-Pair contract names two FIRST-CLASS write primitives the
   pair server is the canonical consumer of:
@@ -38,13 +38,13 @@
   requests. Tests flip the atom directly via `set-allow-writes!`.
 
   Symmetric with:
-    - rf2-c2dtu `--allow-sensitive-reads`  (raw reads; tools/raw_state.cljs)
+    - `--allow-sensitive-reads`  (raw reads; tools/raw_state.cljs)
 
-  ## Composition with eval-cljs (rf2-a0z0h)
+  ## Composition with eval-cljs
 
   This gate protects the named-write audit trail (\"did my app produce
   this state change, or did the pair tool?\"). It is NOT a defence
-  against eval-driven writes — `eval-cljs` (default ON post-rf2-a0z0h)
+  against eval-driven writes — `eval-cljs` (on by default)
   can express any write `--allow-writes` would block. For a true
   read-only debug session compose `--no-eval` with `--allow-writes`
   absent."
@@ -87,7 +87,7 @@
                   "to opt in. Read tools and dispatch are unaffected.")}))
 
 ;; ---------------------------------------------------------------------------
-;; Server-boundary pre-dispatch gate (rf2-wz66k7).
+;; Server-boundary pre-dispatch gate.
 ;;
 ;; The write-tool BODIES (`restore-epoch-tool` / `replace-app-db-tool`)
 ;; each refuse `:rf.error/writes-disabled` as their first action without
@@ -95,27 +95,27 @@
 ;; server handler (`server.cljs/handle-call`) calls `ensure-connection!`
 ;; for EVERY tool BEFORE the tool body runs. On a stock install with no
 ;; nREPL port available, that connection step REJECTS (`:nrepl-port-not-
-;; found`) and the tool body — and thus its write gate — NEVER fires. So a
-;; disabled `restore-epoch` / `replace-app-db` returned a misleading
-;; discovery error instead of the intended destructive-tool refusal, and
-;; (when discovery WAS available) performed unnecessary connect /
-;; elicitation work for a request that should be refused locally.
+;; found`) and the tool body — and thus its write gate — never fires; the
+;; refusal would surface as a misleading discovery error instead of the
+;; intended destructive-tool refusal, and (when discovery WAS available)
+;; the server would perform unnecessary connect / elicitation work for a
+;; request that should be refused locally.
 ;;
 ;; This set + predicate let the server refuse the gated writes at the
 ;; pre-dispatch boundary — BEFORE `ensure-connection!` — when writes are
-;; off, restoring the "default-safe write posture is observably true at
-;; the MCP boundary" contract (spec/Tool-Pair.md §Pair-tool writes;
+;; off, so the "default-safe write posture is observably true at the MCP
+;; boundary" contract holds (spec/Tool-Pair.md §Pair-tool writes;
 ;; tools/writes.cljs §Default-safe). The tool-body gates STAY (defence in
-;; depth + the direct-call test surface); this is the missing outer ring.
+;; depth + the direct-call test surface); this is the outer ring.
 
 (def gated-write-tools
-  "Tool names refused at the server boundary when `--allow-writes` is OFF
-  (rf2-wz66k7). These two MUTATE app-db wholesale and can be refused with
+  "Tool names refused at the server boundary when `--allow-writes` is OFF.
+  These two MUTATE app-db wholesale and can be refused with
   NO runtime connection — the gate is a pure function of the boot flag."
   #{"restore-epoch" "replace-app-db"})
 
 (defn refuse-pre-connection
-  "Server-boundary pre-dispatch guard (rf2-wz66k7). Returns the
+  "Server-boundary pre-dispatch guard. Returns the
   `:rf.error/writes-disabled` result when `tool` is a gated write tool
   AND `--allow-writes` is OFF — so `server.cljs/handle-call` can refuse it
   locally BEFORE `ensure-connection!` runs (no nREPL socket touched, no

--- a/tools/re-frame2-pair-mcp/test/post-merge-hook-test.cjs
+++ b/tools/re-frame2-pair-mcp/test/post-merge-hook-test.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Unit + smoke tests for the post-merge stale-MCP-binary hook (rf2-6jj3r).
+ * Unit + smoke tests for the post-merge stale-MCP-binary hook.
  *
  * Two layers, both POSIX-portable so they run under Git Bash on Windows
  * and native sh on macOS / Linux:

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/annotations_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/annotations_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.annotations-test
-  "Pin rf2-94p8q — every MCP tool descriptor MUST carry an
+  "Every MCP tool descriptor MUST carry an
   `:annotations` map advertising the MCP tool-annotation hints
   (`readOnlyHint`, `destructiveHint`, `idempotentHint`,
   `openWorldHint`). Agent hosts use these to auto-approve read-only
@@ -43,10 +43,9 @@
               (str "annotations on tool " name " is not a JS object")))))))
 
 (deftest classification-matrix-matches-bead
-  (testing "annotation matrix matches the rf2-94p8q matrix"
-    ;; Spot-check the key classifications from the bead. A future
-    ;; rebalance is a behaviour change, not an accident — this test
-    ;; surfaces it.
+  (testing "annotation matrix matches the classification matrix"
+    ;; Spot-check the key classifications. A future rebalance is a
+    ;; behaviour change, not an accident — this test surfaces it.
     (let [by-name (into {} (map (juxt :name :annotations)) tools/tool-descriptors)]
       ;; Read-only tools
       (doseq [n ["discover-app" "snapshot" "get-path" "trace-window"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.args-test
-  "Unit tests for the table-driven boolean-arg parser (rf2-c4fmh).
+  "Unit tests for the table-driven boolean-arg parser.
 
   Pins the four boolean MCP args shared across re-frame2-pair-mcp tools to the
   single `args/bool-args` table:
@@ -7,7 +7,7 @@
     :dedup             ⇒ default true
     :elision           ⇒ default true
     :cache             ⇒ default false
-    :include-sensitive ⇒ default false (rf2-ihq4d — wire-key drops `?`)
+    :include-sensitive ⇒ default false (wire-key carries no `?`)
 
   Accept-shape coverage (true/false bools, `\"true\"`/`\"yes\"`/`\"1\"`
   string forms, `:true`/`:false` keywords, case-insensitivity,
@@ -35,9 +35,8 @@
 (deftest bool-args-table-shape
   ;; The catalogued arg keys; their default postures are the cross-MCP
   ;; convention. Drift here = drift across consumers. `:include-values`
-  ;; was added by rf2-qicji for the reactive `list-subscriptions` tool;
-  ;; `:drain` / `:stop` by rf2-zo4b9 for `read-recording`;
-  ;; `:include-fx-args` by rf2-6to9xj for `dispatch-dry-run`'s
+  ;; serves the reactive `list-subscriptions` tool; `:drain` / `:stop`
+  ;; serve `read-recording`; `:include-fx-args` serves `dispatch-dry-run`'s
   ;; fail-closed :would-fire-effects[*].args.
   (is (= #{:dedup :elision :cache :include-sensitive :include-fx-args
            :include-values :drain :stop}
@@ -83,10 +82,8 @@
     (is (false? (args/parse-bool-arg off? :cache)))))
 
 (deftest parse-bool-arg-string-forms-accepted-uniformly
-  ;; Pre-rf2-c4fmh, `:cache "yes"` default-falsed because cache.cljs
-  ;; hand-rolled a smaller parser. The unified table delegates to
-  ;; `base-args/parse-boolean` for every key, so `"yes"` flips on
-  ;; uniformly across all four args.
+  ;; The unified table delegates to `base-args/parse-boolean` for every
+  ;; key, so `"yes"` flips on uniformly across all four args.
   (let [a (args-js {:dedup             "no"
                     :elision           "off"
                     :cache             "yes"
@@ -112,10 +109,10 @@
     (is (false? (args/parse-bool-arg a :cache)))))  ; default false
 
 (deftest parse-bool-arg-include-sensitive-name-is-stringified
-  ;; Post-rf2-ihq4d the keyword carries NO trailing `?`; the JS wire
-  ;; key is `"include-sensitive"`. The name coercion in `parse-bool-arg`
+  ;; The keyword carries NO trailing `?`; the JS wire key is
+  ;; `"include-sensitive"`. The name coercion in `parse-bool-arg`
   ;; round-trips the literal `(name k)` correctly — pin the contract so
-  ;; a future drift either way (re-adding `?`, snake_case, etc.) breaks
+  ;; a future drift either way (adding `?`, snake_case, etc.) breaks
   ;; here. Per Anthropic's tool-input-schema regex
   ;; `^[a-zA-Z0-9_.-]{1,64}$`, predicate-style `?` is rejected at the
   ;; agent host.
@@ -123,13 +120,12 @@
     (is (true? (args/parse-bool-arg a :include-sensitive)))))
 
 ;; ---------------------------------------------------------------------------
-;; read-edn-arg — the [:ok parsed] / [:err reason] EDN-arg helper
-;; (rf2-jkake.19). Factored out of replace-app-db (:db),
-;; restore-epoch (:epoch-id) and handler-meta (:id); each passes its own
-;; per-tool reason keywords so the error envelope stays specific. The
-;; three outcomes (missing / invalid / ok) were only exercised
-;; indirectly via the conformance corpus; pin the helper directly so a
-;; regression surfaces at the unit it lives in (rf2-ynjts.19).
+;; read-edn-arg — the [:ok parsed] / [:err reason] EDN-arg helper.
+;; Shared by replace-app-db (:db), restore-epoch (:epoch-id) and
+;; handler-meta (:id); each passes its own per-tool reason keywords so
+;; the error envelope stays specific. The three outcomes (missing /
+;; invalid / ok) are pinned directly here so a regression surfaces at
+;; the unit it lives in.
 ;; ---------------------------------------------------------------------------
 
 (deftest read-edn-arg-absent-returns-missing-reason
@@ -173,14 +169,14 @@
   (is (= [:ok 'nope] (args/read-edn-arg "nope(" :missing :invalid))))
 
 ;; ---------------------------------------------------------------------------
-;; parse-filter-arg — the streaming filter map (rf2-hq49). Returns the
-;; tagged `[:ok m]` / `[:err :invalid-filter-edn]` shape (rf2-5kbkl,
-;; mirroring `read-edn-arg`) so a bad filter EDN surfaces as an honest
+;; parse-filter-arg — the streaming filter map. Returns the tagged
+;; `[:ok m]` / `[:err :invalid-filter-edn]` shape (mirroring
+;; `read-edn-arg`) so a bad filter EDN surfaces as an honest
 ;; `:ok? false` error rather than a nonsense filter the runtime applies.
 ;; The nil / string / map arms are covered in subscribe_test; the
 ;; `:else` arm (a JS object that is neither a string nor a CLJS map —
 ;; the shape an MCP host sends a structured filter as) routes through
-;; `js->clj :keywordize-keys true` and was untested. Pin it (rf2-ynjts.19).
+;; `js->clj :keywordize-keys true` and is pinned here.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-filter-arg-js-object-keywordizes
@@ -198,7 +194,7 @@
     (is (= [:ok {:touches-path ["cart" "items"] :meta {:min-ms 50}}] out))))
 
 (deftest parse-filter-arg-malformed-edn-is-err-tagged
-  ;; rf2-5kbkl — the regression: an unparseable EDN string must NOT
+  ;; Regression: an unparseable EDN string must NOT
   ;; become a `{:invalid-filter-edn raw}` map that rides into the runtime
   ;; `:filter` slot. It returns the honest `[:err :invalid-filter-edn]`
   ;; tag (mirroring read-edn-arg's :invalid arm) so the caller can
@@ -208,7 +204,7 @@
       "unparseable filter EDN → honest :err tag, not a nonsense map"))
 
 ;; ---------------------------------------------------------------------------
-;; parse-timeout-arg — positive-millisecond deadline knobs (rf2-wz66k7).
+;; parse-timeout-arg — positive-millisecond deadline knobs.
 ;;
 ;; `tail-build :wait-ms` and `eval-cljs` / `dispatch :await-render`
 ;; `:timeout-ms` thread their value straight into an `(>= elapsed
@@ -231,8 +227,8 @@
       "MCP hosts sometimes stringify numbers"))
 
 (deftest parse-timeout-arg-rejects-non-numeric
-  ;; THE Finding-2 regression: "never" / "bogus" must NOT slip through as
-  ;; a deadline that makes `(>= elapsed NaN)` never true (unbounded poll).
+  ;; Regression: "never" / "bogus" must NOT slip through as a deadline
+  ;; that makes `(>= elapsed NaN)` never true (unbounded poll).
   (let [[tag env] (args/parse-timeout-arg "wait-ms" "never")]
     (is (= :err tag) "a non-numeric deadline is rejected, not threaded raw")
     (is (= :invalid-numeric-arg (:reason env)))
@@ -253,7 +249,7 @@
     (is (= :err tag) "a fractional millisecond is not a valid integer deadline")))
 
 ;; ---------------------------------------------------------------------------
-;; fx-overrides parse (rf2-hf7m9j) — over JSON-MCP the override VALUE
+;; fx-overrides parse — over JSON-MCP the override VALUE
 ;; arrives as a string. The documented colon-prefixed form coerces to a
 ;; keyword (so core honours it as an id-redirect); any other value is
 ;; rejected rather than silently falling through to the real fx.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
@@ -1,24 +1,23 @@
 (ns re-frame2-pair-mcp.build-id-cache-test
-  "Unit tests for the session-scoped `:resolved-build-id` cache (rf2-l9ixp).
+  "Unit tests for the session-scoped `:resolved-build-id` cache.
 
-  Adjacent to `probe_test.cljs`, which pins the `:probed-builds` cache
-  (rf2-sjpx0). The two caches share a lifecycle (cleared by `close!` and
-  reborn empty on a fresh `ensure-connection!` conn, but PRESERVED across
-  a transient same-port socket reopen — rf2-c3dsr); their semantics
-  differ:
+  Adjacent to `probe_test.cljs`, which pins the `:probed-builds` cache.
+  The two caches share a lifecycle (cleared by `close!` and reborn empty
+  on a fresh `ensure-connection!` conn, but PRESERVED across a transient
+  same-port socket reopen); their semantics differ:
 
     - `:probed-builds` is a set keyed by build-id, tracking which builds
       have had their `__re_frame2_pair_runtime` marker confirmed live.
     - `:resolved-build-id` is the single build-id `discover-app` last
       resolved — the default for tool calls that don't pass `:build`.
 
-  The cache removes a 2026-05-25 pair-debug friction: after a successful
+  The cache removes a pair-debug friction: without it, after a successful
   `discover-app` against `examples/step-deck`, every subsequent tool
-  call still needed `build: examples/step-deck` or it silently defaulted
-  to `:app` (the env-var fallback) and returned `:runtime-not-preloaded`
+  call still needs `build: examples/step-deck` or it silently defaults
+  to `:app` (the env-var fallback) and returns `:runtime-not-preloaded`
   looking like a fresh discovery failure.
 
-  The fix has three pieces, exercised by the deftests below:
+  The cache has three pieces, exercised by the deftests below:
 
     1. `discover-app` writes the resolved build-id into the conn-atom
        on success.
@@ -26,7 +25,7 @@
        when no explicit `:build` arg is passed.
     3. An explicit `:build` arg always wins (no surprise).
     4. nREPL `close!` clears the cache (a transport-only `connect!`
-       reopen of the same port deliberately PRESERVES it — rf2-c3dsr)."
+       reopen of the same port deliberately PRESERVES it)."
   (:require [cljs.test :refer-macros [deftest is async]]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools :as tools]
@@ -60,16 +59,14 @@
    :ambiguous-frame?           false})
 
 ;; ---------------------------------------------------------------------------
-;; `wire/arg-build` — colon tolerance (rf2-8ohwv).
+;; `wire/arg-build` — colon tolerance.
 ;; ---------------------------------------------------------------------------
 
 (deftest arg-build-tolerates-a-leading-colon
-  ;; rf2-8ohwv: the human-facing hint shows the colon form
-  ;; (`--build=:examples/step-deck`) but the MCP arg used to want the bare
-  ;; form — a leading colon double-prepended into the malformed
-  ;; `::examples/step-deck` and failed the round-trip. Both forms must now
-  ;; resolve to the SAME keyword, and a doubled colon must never reach the
-  ;; resolver.
+  ;; The human-facing hint shows the colon form
+  ;; (`--build=:examples/step-deck`); the MCP arg also accepts the bare
+  ;; form. Both forms resolve to the SAME keyword, and a doubled colon
+  ;; never reaches the resolver (no `::examples/step-deck`).
   (let [conn (fresh-conn)]
     (is (= :examples/step-deck
            (wire/arg-build conn (tu/args->js {:build "examples/step-deck"})))
@@ -82,9 +79,9 @@
         "the two forms are indistinguishable post-coercion")))
 
 (deftest arg-build-colon-tolerance-on-bare-build
-  ;; The non-namespaced case the original `keyword` mishandled too:
-  ;; `:app` → `::app` (a `user`-ns keyword) → probes a build that doesn't
-  ;; exist. Both forms must land on `:app`.
+  ;; The non-namespaced case: `app` and `:app` both land on `:app`,
+  ;; never the malformed `::app` (a `user`-ns keyword) that would probe a
+  ;; build that doesn't exist.
   (let [conn (fresh-conn)]
     (is (= :app (wire/arg-build conn (tu/args->js {:build "app"}))))
     (is (= :app (wire/arg-build conn (tu/args->js {:build ":app"}))))))
@@ -107,8 +104,8 @@
     (is (= :app (wire/arg-build conn args)))))
 
 (deftest arg-build-with-cache-uses-cached-build-id
-  ;; rf2-l9ixp contract: a cached resolved-build-id is the default when
-  ;; the operator omits `:build` — overrides the `:app` env fallback.
+  ;; The contract: a cached resolved-build-id is the default when the
+  ;; operator omits `:build` — overrides the `:app` env fallback.
   (let [conn (fresh-conn)
         args (tu/args->js {})]
     (swap! conn assoc :resolved-build-id :examples/step-deck)
@@ -135,9 +132,9 @@
 
 (deftest arg-build-explicit-predicate-treats-cache-as-deliberate
   ;; A session-cache hit is treated as a deliberate choice — the
-  ;; eval-path resolver (rf2-ivlb3) honours it verbatim rather than
-  ;; second-guessing via auto-detect. Without this, the cache would be
-  ;; useless on a multi-build workspace.
+  ;; eval-path resolver honours it verbatim rather than second-guessing
+  ;; via auto-detect. Without this, the cache would be useless on a
+  ;; multi-build workspace.
   (let [conn (fresh-conn)
         args (tu/args->js {})]
     (is (false? (wire/arg-build-explicit? conn args))
@@ -254,14 +251,13 @@
     (is (nil? (:resolved-build-id @conn)))))
 
 ;; ---------------------------------------------------------------------------
-;; Single-build auto-selection (rf2-v70kv).
+;; Single-build auto-selection.
 ;;
-;; discover-app used to default an omitted :build to :app; on a checkout
-;; where :app isn't the running watch, the first no-arg call failed by
-;; construction. When EXACTLY ONE build runs, discover-app now selects it
-;; and notes the choice. Zero/many running keeps the existing diagnostic
-;; (which lists the running builds) — never a silent most-recently-active
-;; pick.
+;; When EXACTLY ONE build runs, discover-app with an omitted :build
+;; selects that build and notes the choice — so a checkout where :app
+;; isn't the running watch still resolves on the first no-arg call.
+;; Zero/many running falls back to the diagnostic (which lists the
+;; running builds) — never a silent most-recently-active pick.
 ;; ---------------------------------------------------------------------------
 
 (defn- with-running-builds!
@@ -345,7 +341,7 @@
               (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Round-trippable build ids (rf2-8t3ct).
+;; Round-trippable build ids.
 ;;
 ;; The canonical build id is a keyword (`:examples/step-deck`). A value
 ;; copied out of a discover-app result's `:build` / `:build-id` slot must
@@ -365,8 +361,8 @@
           (.then
             (fn [result]
               (let [edn (tu/extract-edn result)]
-                ;; rf2-8t3ct — both the historical :build-id and the new
-                ;; input-name-matching :build carry the canonical keyword.
+                ;; Both :build-id and the input-name-matching :build carry
+                ;; the canonical keyword.
                 (is (= :examples/step-deck (:build-id edn)))
                 (is (= :examples/step-deck (:build edn))
                     "discover-app echoes a canonical :build matching the input arg name")
@@ -380,7 +376,7 @@
 (deftest canonical-build-round-trips-from-both-alias-forms
   ;; The echoed canonical keyword, re-serialised either as the bare
   ;; qualified string or the colon form, resolves identically — the
-  ;; deterministic alias contract (rf2-8t3ct). The two alias forms are
+  ;; deterministic alias contract. The two alias forms are
   ;; exactly the colon-tolerance axis: `subs (str kw) 1` (drop the
   ;; leading `:`) and `str kw` (keep it) both read back to `kw`.
   (let [conn      (fresh-conn)
@@ -397,7 +393,7 @@
         "the two alias forms are indistinguishable post-coercion")))
 
 ;; ---------------------------------------------------------------------------
-;; Per-session isolation (rf2-fmho5).
+;; Per-session isolation.
 ;;
 ;; The sticky target lives on the per-connection conn-atom, NOT in a
 ;; process-global. The MCP stdio model spawns one server process (and
@@ -435,7 +431,7 @@
         "the sticky target is per-conn-atom, never shared across sessions")))
 
 ;; ---------------------------------------------------------------------------
-;; Ambiguous-target / no-target structured error (rf2-fmho5).
+;; Ambiguous-target / no-target structured error.
 ;;
 ;; "If no session target exists and multiple runtimes are available, fail
 ;; with a clear ambiguous-target error listing candidates." The eval-path
@@ -453,7 +449,7 @@
     ;; NB restore `probe/running-builds` INLINE before calling `done` —
     ;; a `.finally`-scoped restore fires AFTER `done` advances to the next
     ;; test and would leak the multi-build stub into a neighbour (the
-    ;; rf2-wb06a race the orient/invoke suites document).
+    ;; cross-test stub race the orient/invoke suites document).
     (let [orig probe/running-builds
           restore! (fn [] (set! probe/running-builds orig))
           conn (fresh-conn)]
@@ -480,7 +476,7 @@
   ;; A session-sticky target (set by a prior discover-app) is treated as
   ;; deliberate — `resolve-build!` resolves to it verbatim even on a
   ;; multi-build workspace, so the sticky default actually removes the
-  ;; ambiguity instead of re-triggering it (rf2-fmho5 + rf2-l9ixp).
+  ;; ambiguity instead of re-triggering it.
   (async done
     (let [conn (fresh-conn)]
       ;; Cache a session target, then resolve with explicit? derived from
@@ -522,24 +518,23 @@
           (.then (fn [_] (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; :port-discover sticky path — faithful no-pre-probe end-to-end (rf2-hu6q0).
+;; :port-discover sticky path — faithful no-pre-probe end-to-end.
 ;;
-;; The live repro (2026-06-03/04, multi-build):
+;; The flow these tests guard (multi-build):
 ;;
 ;;   discover-app {port 8033} -> OK, resolves :examples/machine-epochs
-;;   orient {}  (NO :build)   -> FAILED :build-not-running :app   (the bug)
+;;   orient {}  (NO :build)   -> must target :examples/machine-epochs
 ;;
 ;; `sticky_build_invoke_test/port-discover-sticks-build-through-invoke`
-;; already drives discover-app{port} then a no-build call through
-;; `tools/invoke` — but it PRE-SEEDS `:probed-builds` with the resolved
-;; build, so `discover-app`'s own `ensure-runtime!` short-circuits without
-;; the real preload probe. In the LIVE flow the `:port`-resolved build is
-;; NOT pre-probed — discover-app must run the actual
-;; `runtime-preloaded?` round-trip (a DISTINCT eval form from the
-;; `(runtime/health)` read) and `mark-conn-probed!` itself before reaching
-;; the cache-writing branch.
+;; drives discover-app{port} then a no-build call through `tools/invoke`,
+;; but it PRE-SEEDS `:probed-builds` with the resolved build, so
+;; `discover-app`'s own `ensure-runtime!` short-circuits without the real
+;; preload probe. In the LIVE flow the `:port`-resolved build is NOT
+;; pre-probed — discover-app must run the actual `runtime-preloaded?`
+;; round-trip (a DISTINCT eval form from the `(runtime/health)` read) and
+;; `mark-conn-probed!` itself before reaching the cache-writing branch.
 ;;
-;; These tests close that gap: a form-DISCRIMINATING stub answers the
+;; These tests cover that path: a form-DISCRIMINATING stub answers the
 ;; preload-probe form with `true` and the health form with the health map
 ;; — exactly what a live runtime returns — so the `:port` branch exercises
 ;; the real probe-then-mark-then-cache sequence, then a no-build call
@@ -570,8 +565,8 @@
 (deftest port-discover-without-pre-probe-still-caches
   ;; discover-app{port} on a multi-build setup, with NO pre-seeded
   ;; `:probed-builds` — discover-app must probe the resolved build live,
-  ;; mark it probed, AND write `:resolved-build-id`. The faithful repro of
-  ;; the live first-contact call.
+  ;; mark it probed, AND write `:resolved-build-id`. The faithful model of
+  ;; a live first-contact call.
   (async done
     (let [conn         (fresh-conn)
           orig-running probe/running-builds

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_resolver_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_resolver_test.cljs
@@ -1,28 +1,27 @@
 (ns re-frame2-pair-mcp.build-id-resolver-test
   "Forgiving suffix→canonical build-id resolution + round-trippable
-  running-build guidance (rf2-qda59).
+  running-build guidance.
 
-  ## The bug (live-reproduced 2026-06-02 on the machine-epochs deck)
+  ## What this guards
 
   shadow build ids are namespaced keywords (`:examples/machine-epochs`).
-  `discover-app {:build \"examples/machine-epochs\"}` connected fine, but
-  the read ops were STRICT: `snapshot {:build \"machine-epochs\"}` (the
-  short tail an operator naturally reaches for) was rejected
-  `:build-not-running` — even though `machine-epochs` named the build
-  right there in the error's own `:running-builds` list. Four symptoms:
+  A short tail an operator naturally reaches for —
+  `snapshot {:build \"machine-epochs\"}` — must resolve to the unique
+  running build that ends in that tail rather than being rejected
+  `:build-not-running`. Four properties:
 
-    1. discover-app forgives but read ops are strict — a suffix form that
-       names a unique running build is rejected by the read/action ops.
-    2. The `:running-builds` error list was not round-trippable — it
-       named the valid set in a form the operator couldn't paste back.
-    3. Colon-prepend was non-idempotent (`:examples/…` ⇒ `::examples/…`).
-       (Fixed upstream by #2821's `fresh-keyword` colon-tolerance; pinned
-       here as a regression guard.)
-    4. The selected build did not stick — a discover-app'd build did not
-       transfer to the next read op. (Fixed by #2821's sticky
-       `:resolved-build-id`; pinned here.)
+    1. Read ops forgive a suffix the same way discover-app does — a
+       suffix form that names a unique running build resolves across the
+       read/action ops.
+    2. The `:running-builds` error list is round-trippable — it names the
+       valid set in a form the operator can paste straight back.
+    3. Colon-prepend is idempotent (`:examples/…` stays `:examples/…`,
+       never `::examples/…`). Carried by `fresh-keyword`'s
+       colon-tolerance; pinned here as a regression guard.
+    4. The selected build sticks — a discover-app'd build transfers to
+       the next read op via the sticky `:resolved-build-id`; pinned here.
 
-  The fix (rf2-qda59): ONE shared forgiving resolver
+  The mechanism: ONE shared forgiving resolver
   (`probe/canonicalize-build!` + `probe/match-running-build`) used across
   EVERY op via the conn `:build-alias` cache that `wire/arg-build`
   consults; a unique suffix match resolves to the canonical running id,
@@ -119,7 +118,7 @@
           (.then (fn [_] (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Symptom 1 — arg-build applies the alias so EVERY op forgives the suffix.
+;; Property 1 — arg-build applies the alias so EVERY op forgives the suffix.
 ;; ---------------------------------------------------------------------------
 
 (deftest arg-build-applies-the-suffix-alias
@@ -148,7 +147,7 @@
         "no alias recorded → id passes through unchanged")))
 
 ;; ---------------------------------------------------------------------------
-;; Symptom 2 — round-trippable running-build guidance.
+;; Property 2 — round-trippable running-build guidance.
 ;; ---------------------------------------------------------------------------
 
 (deftest running-build-arg-forms-are-round-trippable
@@ -208,7 +207,7 @@
           (.then (fn [_] (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Symptom 3 — colon idempotence (regression guard; fixed by #2821).
+;; Property 3 — colon idempotence (regression guard).
 ;; ---------------------------------------------------------------------------
 
 (deftest colon-prepend-is-idempotent
@@ -221,7 +220,7 @@
         "bare and colon forms are indistinguishable post-coercion")))
 
 ;; ---------------------------------------------------------------------------
-;; Symptom 4 — a stuck build transfers to subsequent ops (regression guard).
+;; Property 4 — a stuck build transfers to subsequent ops (regression guard).
 ;; ---------------------------------------------------------------------------
 
 (deftest stuck-build-transfers-to-subsequent-ops

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.cache-test
-  "Unit tests for the per-session response cache (rf2-3rt1f).
+  "Unit tests for the per-session response cache.
 
   Per `tools/re-frame2-pair-mcp/spec/Principles.md` §\"Per-session response
   cache\", every read-tool result passes through an 8-slot LRU keyed
@@ -38,8 +38,8 @@
   (cond-> #js {:content #js [#js {:type "text" :text text}]}
     error? (j/assoc! :isError true)))
 
-;; `args-js` + `extract-text` are the shared wire-envelope extractors
-;; (rf2-wnrpi) — one definition in `test-utils`, aliased here.
+;; `args-js` + `extract-text` are the shared wire-envelope extractors —
+;; one definition in `test-utils`, aliased here.
 (def ^:private args-js tu/args->js)
 (def ^:private extract-text tu/extract-text)
 
@@ -51,8 +51,8 @@
     (and (map? v) (contains? v :rf.mcp/cache-hit))))
 
 ;; ---------------------------------------------------------------------------
-;; `:cache` MCP-arg normalisation now lives on the shared table-driven
-;; parser — see `re-frame2-pair-mcp.args-test` (rf2-c4fmh).
+;; `:cache` MCP-arg normalisation lives on the shared table-driven
+;; parser — see `re-frame2-pair-mcp.args-test`.
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
@@ -78,7 +78,7 @@
   (is (not (cache/cacheable? "unknown-tool"))))
 
 (deftest cacheable-excludes-get-operating-frame
-  ;; rf2-flm0iz — `get-operating-frame` is a read of VOLATILE runtime
+  ;; `get-operating-frame` is a read of VOLATILE runtime
   ;; state (the live frame registry + the per-session pin), not a
   ;; function of frame app-db. Both axes can move WITHOUT an app-db
   ;; mutation and WITHOUT a `set-operating-frame` / `reset-operating-
@@ -143,7 +143,7 @@
     (is (not= (cache/hash-result ok) (cache/hash-result err)))))
 
 ;; ---------------------------------------------------------------------------
-;; The load-bearing scenarios from the bead.
+;; The load-bearing scenarios.
 ;; ---------------------------------------------------------------------------
 
 (deftest fresh-call-stores-and-returns-unchanged
@@ -233,7 +233,7 @@
         "action tools never poison the cache")))
 
 (deftest get-operating-frame-never-serves-stale-cache-hit
-  ;; rf2-flm0iz — the load-bearing scenario. Two byte-identical
+  ;; The load-bearing scenario. Two byte-identical
   ;; `get-operating-frame` responses MUST NOT collapse into a
   ;; `:rf.mcp/cache-hit` marker, because the resolved frame triple can
   ;; have changed underneath identical bytes (a frame mounted/unmounted,
@@ -392,10 +392,10 @@
           "cache-hit marker fits well under a 5K-token cap"))))
 
 (deftest cache-hit-marker-carries-via-slot
-  ;; rf2-36xod: the marker carries `:via` to distinguish a pre-eval
-  ;; short-circuit (`:precheck`) from the legacy post-eval match
-  ;; (`:result-hash`). Agents that read the marker can attribute the
-  ;; saving correctly; tooling can graph cache-hit volume by source.
+  ;; The marker carries `:via` to distinguish a pre-eval short-circuit
+  ;; (`:precheck`) from the post-eval match (`:result-hash`). Agents that
+  ;; read the marker can attribute the saving correctly; tooling can
+  ;; graph cache-hit volume by source.
   (let [args (args-js {:frame ":rf/default"})
         text "{:ok? true :app-db {:k :v}}"
         opts {:tool "snapshot" :args args :enabled? true}]
@@ -406,7 +406,7 @@
           "apply-cache hit annotates :via :result-hash"))))
 
 ;; ---------------------------------------------------------------------------
-;; Precheck — rf2-36xod. Decide cache-hit BEFORE running the tool.
+;; Precheck — decide cache-hit BEFORE running the tool.
 ;;
 ;; Same `apply-cache` contract — same `(tool, args)` key, same LRU
 ;; semantics, same marker shape — but with an extra `:precheck-hash`
@@ -452,7 +452,7 @@
 
 (deftest precheck-returns-nil-when-no-current-hash
   ;; Caller has no precheck wiring for this tool → passes nil → we
-  ;; return nil and let the legacy post-eval path take over.
+  ;; return nil and let the post-eval path take over.
   (let [args (args-js {:frame ":rf/default"})
         opts {:tool "snapshot" :args args :enabled? true}]
     ;; Prime the cache with a precheck-hash.
@@ -519,12 +519,11 @@
         "matching key → precheck hits")))
 
 (deftest precheck-build-discriminates-key
-  ;; rf2-olvr5 finding 3 — the cache key includes the resolved BUILD. A
-  ;; precheck-hash primed for (get-path, args, build-A) MUST NOT serve a
-  ;; lookup for (get-path, args, build-B) even when the hashes collide
-  ;; (two builds on one nREPL connection with the same app-db-hash). The
-  ;; pre-fix key was `(tool, args)` only — a cross-build collision served
-  ;; the wrong build's payload.
+  ;; The cache key includes the resolved BUILD. A precheck-hash primed
+  ;; for (get-path, args, build-A) MUST NOT serve a lookup for
+  ;; (get-path, args, build-B) even when the hashes collide (two builds
+  ;; on one nREPL connection with the same app-db-hash) — otherwise a
+  ;; cross-build collision would serve the wrong build's payload.
   (let [args   (args-js {:path "[:k]"})
         h      22222
         opts-a {:tool "get-path" :args args :enabled? true :build :app}
@@ -591,10 +590,9 @@
         "precheck-hash supplied at store time is queryable on the next call")))
 
 (deftest precheck-hash-absent-when-not-supplied
-  ;; Backwards-compat path. When `apply-cache` is called WITHOUT
-  ;; `:precheck-hash` (the rf2-3rt1f-era call sites), the stored
+  ;; When `apply-cache` is called WITHOUT `:precheck-hash`, the stored
   ;; entry doesn't carry one; future precheck attempts on that key
-  ;; return nil and the legacy post-eval cache catches the hit.
+  ;; return nil and the post-eval cache catches the hit.
   (let [args (args-js {:frame ":rf/default"})
         opts {:tool "snapshot" :args args :enabled? true}
         text "{:k :v}"]
@@ -602,7 +600,7 @@
     (cache/apply-cache (mcp-result text) opts)
     (is (nil? (cache/precheck opts 12345))
         "no stored :precheck-hash → precheck returns nil")
-    ;; Legacy post-eval path still works.
+    ;; Post-eval path still works.
     (let [hit (cache/apply-cache (mcp-result text) opts)]
       (is (cache-hit-result? hit)
           "post-eval cache-hit still fires when text matches")

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cljs_eval_value_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cljs_eval_value_test.cljs
@@ -1,20 +1,20 @@
 (ns re-frame2-pair-mcp.cljs-eval-value-test
   "Unit tests for `nrepl/cljs-eval-value` — the value-unwrap seam every
-  tool's runtime read flows through (rf2-ynjts.19).
+  tool's runtime read flows through.
 
   ## Why this suite exists
 
   `cljs-eval-value` is the single most load-bearing fn in the artefact:
   every tool that reads from the runtime (`snapshot`, `get-path`,
   `dispatch`, `eval-cljs`, the probe, …) calls it to turn shadow-cljs's
-  string-encoded `cljs-eval` response into the actual CLJS value. Yet
-  the whole existing corpus STUBS `cljs-eval-value` itself (see
+  string-encoded `cljs-eval` response into the actual CLJS value. The
+  rest of the corpus STUBS `cljs-eval-value` itself (see
   `test_utils/with-stubbed-eval!`, `eval_cljs_test`, `conformance_test`)
-  — so its own unwrap logic was never exercised by a unit test. A
-  regression in any of its branches (the `:results` peek, the
-  `:ex`-reject, the inner `:err`-reject, the blank→nil short-circuit, or
-  the `read-edn-safe` parse-failure fallback) would slip past 707
-  green tests because every one of them mocks the very fn under test.
+  — so its own unwrap logic needs a dedicated home. A regression in any
+  of its branches (the `:results` peek, the `:ex`-reject, the inner
+  `:err`-reject, the blank→nil short-circuit, or the `read-edn-safe`
+  parse-failure fallback) would slip past the suites that mock the very
+  fn under test; this one exercises it directly.
 
   ## Seam
 
@@ -166,8 +166,8 @@
 ;; Inner :err map → reject. When the OUTER EDN parses to a map carrying
 ;; a non-blank :err (a shadow-side cljs-eval compile warning/error,
 ;; distinct from an nREPL :ex), the unwrap rejects rather than returning
-;; the error map as a "value". rf2-mvdwv promotes this to a structured
-;; ex-info carrying `:reason :rf.error/eval-cljs-compile-error`.
+;; the error map as a "value". It surfaces as a structured ex-info
+;; carrying `:reason :rf.error/eval-cljs-compile-error`.
 ;; ---------------------------------------------------------------------------
 
 (deftest inner-err-map-rejects
@@ -189,13 +189,12 @@
                   (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-mvdwv — an UNRESOLVED SYMBOL is the headline regression. shadow
-;; emits an `:eval-compile-warnings` REPL message: the analyzer warning
-;; text lands in the response `:err`, yet shadow STILL pushes a "nil" into
-;; `:results`. The pre-fix branch order peeked `:results` first, so the
-;; "nil" won and the compile warning was swallowed as a silent
-;; `{:ok? true :value nil}`. The :err branch now takes precedence so the
-;; failure surfaces instead of nil'ing out.
+;; An UNRESOLVED SYMBOL is the headline case. shadow emits an
+;; `:eval-compile-warnings` REPL message: the analyzer warning text lands
+;; in the response `:err`, yet shadow STILL pushes a "nil" into
+;; `:results`. The :err branch takes precedence over the `:results` peek,
+;; so the failure surfaces as a rejection instead of being swallowed as a
+;; silent `{:ok? true :value nil}`.
 ;; ---------------------------------------------------------------------------
 
 (deftest unresolved-symbol-warning-rejects-not-silent-nil
@@ -227,7 +226,7 @@
 (deftest clean-results-with-blank-err-still-resolves-value
   ;; A clean eval leaves :err blank ("") — the :err branch must NOT fire
   ;; on a blank :err, so the value still unwraps normally. Pins that the
-  ;; rf2-mvdwv precedence flip doesn't hijack the happy path.
+  ;; :err precedence doesn't hijack the happy path.
   (async done
     (-> (with-stubbed-cljs-eval!
           {:value "{:results [\"42\"] :err \"\" :ns cljs.user}"}

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -1,23 +1,22 @@
 (ns re-frame2-pair-mcp.conformance-test
-  "Per rf2-xkxbv (audit rf2-7hie3 §TE3). Drives the re-frame2-pair-mcp tool catalogue
+  "Drives the re-frame2-pair-mcp tool catalogue
   through `tools/invoke` against a stub `conn` and asserts the recorded
   wire-shape EDN — the artefact's contract suite, sibling to:
 
-    - `re-frame.conformance-test`            (core fixtures; rf2-d0wem)
-    - `re-frame.ssr-conformance-test`        (ssr fixtures;  rf2-i3qc0)
-    - `re-frame.schemas-conformance-test`    (schemas;       rf2-2l08g)
-    - `re-frame.flows-conformance-test`      (flows;         rf2-4559c)
-    - `re-frame.machines-conformance-test`   (machines;      rf2-d0wem)
+    - `re-frame.conformance-test`            (core fixtures)
+    - `re-frame.ssr-conformance-test`        (ssr fixtures)
+    - `re-frame.schemas-conformance-test`    (schemas)
+    - `re-frame.flows-conformance-test`      (flows)
+    - `re-frame.machines-conformance-test`   (machines)
 
   ## Why a conformance corpus for re-frame2-pair-mcp
 
   The unit suite covers each tool's INNER logic in isolation
   (`get_path_test`, `snapshot_test`, `subscribe_test`, etc.) and the
-  pipeline wire-up (`invoke_test`, `cache_test`, `wire_cap_test`). What
-  was missing pre-rf2-xkxbv: a single corpus that pins the
-  *outer* shape — for each MCP tool, given a canonical `tools/call`
-  input and a deterministic stub `conn`, what wire envelope does
-  `tools/invoke` produce?
+  pipeline wire-up (`invoke_test`, `cache_test`, `wire_cap_test`). This
+  corpus pins the *outer* shape — for each MCP tool, given a canonical
+  `tools/call` input and a deterministic stub `conn`, what wire envelope
+  does `tools/invoke` produce?
 
   That's the contract the agent host actually consumes. Without a
   corpus pinning it, an accidental rename (`:reason :missing-event` →
@@ -139,13 +138,13 @@
 
   The `forms-seen` atom records every form-string the stub is asked to
   resolve so a fixture's `:fixture/eval-form-must-contain` slot can
-  pin the SHAPE of the form sent over nREPL — used by the rf2-c2dtu
-  raw-state fixtures to verify the gate forces
+  pin the SHAPE of the form sent over nREPL — used by the raw-state
+  fixtures to verify the gate forces
   `:rf.size/include-sensitive? false` server-side (the walker-option
   namespaced keyword, NOT the wire-key — the wire-key is the
-  unqualified `:include-sensitive` post-rf2-ihq4d).
+  unqualified `:include-sensitive`).
 
-  rf2-7tgfk: also stubs `nrepl/jvm-eval` so the preload-failure
+  Also stubs `nrepl/jvm-eval` so the preload-failure
   diagnostic ladder doesn't short-circuit to `:nrepl-unreachable` on
   every preload-missing fixture. The default JVM stub:
     - returns `{:value \"1\"}` for the `1` health-probe so
@@ -172,7 +171,7 @@
                       (js/Promise.resolve (run-eval-script eval-script form-str))))
          default-jvm-script
          ;; First-match wins; this is the failure-path default the
-         ;; rf2-7tgfk diagnostic ladder relies on.
+         ;; diagnostic ladder relies on.
          [["active-builds" {:value "[:app]"}]
           [:default        {:value "1"}]]
          effective-jvm-script (or jvm-eval-script default-jvm-script)
@@ -288,7 +287,7 @@
 (def corpus
   "Inline conformance corpus for re-frame2-pair-mcp's tool catalogue.
 
-  Coverage matrix today (rf2-xkxbv, rf2-fnpqg):
+  Coverage matrix:
 
     | Tool                   | Happy | Missing-arg | Degraded-runtime |
     |------------------------|-------|-------------|-------------------|
@@ -352,12 +351,12 @@
     {:edn-submap {:ok? false :reason :runtime-loaded-but-preload-missing}}}
 
    ;; ---------- eval-cljs --------------------------------------------------
-   ;; The launch-flag gate (rf2-a0z0h; inverts the prior rf2-cxx5s
-   ;; default) ships DEFAULT-ON in published builds — the operator
-   ;; passes `--no-eval` to opt OUT. Fixtures that drive the post-gate
-   ;; logical paths (`:happy`, `:missing-form`, `:no-runtime-for-build`)
-   ;; rely on the default ON state; the `:disabled-via-no-eval` fixture
-   ;; pins the opt-out envelope via `:fixture/eval-allowed? false`.
+   ;; The launch-flag gate ships DEFAULT-ON in published builds — the
+   ;; operator passes `--no-eval` to opt OUT. Fixtures that drive the
+   ;; post-gate logical paths (`:happy`, `:missing-form`,
+   ;; `:no-runtime-for-build`) rely on the default ON state; the
+   ;; `:disabled-via-no-eval` fixture pins the opt-out envelope via
+   ;; `:fixture/eval-allowed? false`.
    {:fixture/id    :eval-cljs/disabled-via-no-eval
     :fixture/doc   "eval-cljs with --no-eval (gate flipped OFF) returns :rf.error/eval-cljs-disabled."
     :fixture/tool  "eval-cljs"
@@ -372,8 +371,8 @@
    {:fixture/id    :eval-cljs/happy
     :fixture/doc   "eval-cljs (gate at default ON) with explicit :build returns {:ok? true :value v} on a successful runtime eval."
     :fixture/tool  "eval-cljs"
-    ;; Explicit :build short-circuits the rf2-ivlb3 auto-detect (which
-    ;; would jvm-eval `active-builds` — not stubbed by this cljs-eval-only
+    ;; Explicit :build short-circuits the auto-detect (which would
+    ;; jvm-eval `active-builds` — not stubbed by this cljs-eval-only
     ;; harness). The runtime-sentinel preflight still runs.
     :fixture/args  {:form "(+ 1 2)" :build "app"}
     :fixture/eval-script
@@ -384,10 +383,10 @@
     {:isError? false
      :edn-submap {:ok? true :value 3 :build :app}}}
 
-   ;; rf2-qobqy — the typed result envelope distinguishes a GENUINE nil,
-   ;; an eval-error, and an unserializable value where the old path
-   ;; collapsed all three to a bare null. The runtime classifies the
-   ;; result into a tagged `:rf.mcp/result` map; the server projects it.
+   ;; The typed result envelope distinguishes a GENUINE nil, an
+   ;; eval-error, and an unserializable value rather than collapsing all
+   ;; three to a bare null. The runtime classifies the result into a
+   ;; tagged `:rf.mcp/result` map; the server projects it.
    {:fixture/id    :eval-cljs/typed-nil
     :fixture/doc   "eval-cljs of a form that genuinely returns nil rides back as :ok? true :value nil — a tagged :rf.mcp/result :nil, NOT a collapsed null (rf2-qobqy)."
     :fixture/tool  "eval-cljs"
@@ -453,10 +452,9 @@
     {:isError? true
      :reason :missing-form}}
 
-   ;; ---- await opt-in (rf2-xn4f9) ----
-   ;; :await false (the default) MUST preserve the pre-rf2-xn4f9
-   ;; semantics — the form is sent verbatim, no await wrapper. Pin that
-   ;; via :fixture/eval-form-must-not-contain.
+   ;; ---- await opt-in ----
+   ;; :await false (the default) sends the form verbatim — no await
+   ;; wrapper. Pin that via :fixture/eval-form-must-not-contain.
    {:fixture/id    :eval-cljs/await-default-off-no-wrap
     :fixture/doc   "eval-cljs without :await sends the form verbatim — no await wrapper, no mailbox slot (rf2-xn4f9 default :await false)."
     :fixture/tool  "eval-cljs"
@@ -533,11 +531,11 @@
                   :build :app}}}
 
    ;; ---------- dispatch ---------------------------------------------------
-   ;; rf2-3bu3d.2 — the DEFAULT dispatch now returns the CONSEQUENCE via
+   ;; The DEFAULT dispatch returns the CONSEQUENCE via
    ;; `dispatch-consequence!`: `:db-changed? :changed-paths :effects-fired
    ;; :no-op?` so a no-op is VISIBLE, plus `:resolved` echoing the parsed
-   ;; event (rf2-3bu3d.3). The runtime fn is `dispatch-consequence!`, not
-   ;; the old `pair-dispatch!` transport ack.
+   ;; event. The runtime fn is `dispatch-consequence!`, distinct from the
+   ;; `pair-dispatch!` transport ack used by the :queued path.
    {:fixture/id    :dispatch/happy
     :fixture/doc   "default dispatch returns the consequence via dispatch-consequence! (rf2-3bu3d.2 / rf2-3bu3d.3)."
     :fixture/tool  "dispatch"
@@ -556,8 +554,8 @@
      :edn-submap {:mode :sync :ok? true :db-changed? true :no-op? false
                   :resolved [:counter/inc]}}}
 
-   ;; rf2-3bu3d.2 — a genuine NO-OP is now VISIBLE: `:db-changed? false
-   ;; :effects-fired [] :no-op? true` instead of a fake success ack.
+   ;; A genuine NO-OP is VISIBLE: `:db-changed? false :effects-fired []
+   ;; :no-op? true` rather than a bare success ack.
    {:fixture/id    :dispatch/no-op-visible
     :fixture/doc   "a no-op dispatch returns :db-changed? false :effects-fired [] :no-op? true (rf2-3bu3d.2)."
     :fixture/tool  "dispatch"
@@ -574,10 +572,10 @@
      :edn-submap {:mode :sync :ok? true :db-changed? false
                   :effects-fired [] :no-op? true}}}
 
-   ;; rf2-3bu3d.3 — an unknown event-id is VALIDATED at the wire boundary
-   ;; and returns a structured :unknown-id error with :nearest matches,
-   ;; WITHOUT dispatching (the runtime `dispatch-consequence!` short-
-   ;; circuits on the validation miss). No silent no-op success.
+   ;; An unknown event-id is VALIDATED at the wire boundary and returns a
+   ;; structured :unknown-id error with :nearest matches, WITHOUT
+   ;; dispatching (the runtime `dispatch-consequence!` short-circuits on
+   ;; the validation miss). No silent no-op success.
    {:fixture/id    :dispatch/unknown-id-validated
     :fixture/doc   "dispatch of an unregistered event-id surfaces :reason :unknown-id + :nearest, never a silent success (rf2-3bu3d.3)."
     :fixture/tool  "dispatch"
@@ -595,8 +593,8 @@
      :edn-submap {:ok? false :reason :unknown-id :id :rf/xrayy
                   :nearest [:rf/xray :rf/default] :resolved [:rf/xrayy]}}}
 
-   ;; rf2-3bu3d.2 — `:queued true` opts into the async transport-ack: the
-   ;; runtime `pair-dispatch!` return rides back with `:mode :queued` and
+   ;; `:queued true` opts into the async transport-ack: the runtime
+   ;; `pair-dispatch!` return rides back with `:mode :queued` and
    ;; `:settled? false` when the cascade hasn't drained.
    {:fixture/id    :dispatch/queued-settled-false
     :fixture/doc   "dispatch :queued true returns the async ack (:mode :queued :settled? false) (rf2-3bu3d.2)."
@@ -634,12 +632,12 @@
     :fixture/expect
     {:edn-submap {:ok? false :reason :runtime-loaded-but-preload-missing}}}
 
-   ;; rf2-ldfnx — frame-targeted dispatch routes to the named frame. The
-   ;; documented `frame` arg is the colon-prefixed id (":rf/xray";
-   ;; Tool-Catalogue §Id representation). The emitted runtime call MUST
-   ;; carry the well-formed `:frame :rf/xray` opt and MUST NOT mint the
-   ;; malformed `::rf/xray` (namespace ":rf") that raw `(keyword ...)`
-   ;; produced — the silent-no-op the bead targets.
+   ;; Frame-targeted dispatch routes to the named frame. The documented
+   ;; `frame` arg is the colon-prefixed id (":rf/xray"; Tool-Catalogue
+   ;; §Id representation). The emitted runtime call MUST carry the
+   ;; well-formed `:frame :rf/xray` opt and MUST NOT mint the malformed
+   ;; `::rf/xray` (namespace ":rf") that raw `(keyword ...)` would produce
+   ;; — which would be a silent no-op.
    {:fixture/id    :dispatch/frame-targeted-routes
     :fixture/doc   "dispatch frame ':rf/xray' emits {:frame :rf/xray} in the runtime opts — NOT the malformed ::rf/xray (rf2-ldfnx). Routes through dispatch-consequence! (rf2-3bu3d.2)."
     :fixture/tool  "dispatch"
@@ -657,12 +655,10 @@
     {:isError? false
      :edn-submap {:mode :sync :ok? true :frame :rf/xray}}}
 
-   ;; rf2-ldfnx — when the named frame cannot be targeted (head did not
-   ;; advance), the runtime returns {:ok? false :reason :no-new-epoch}.
-   ;; The tool MUST surface a structured ERROR envelope, never a
-   ;; {:mode :sync} success. The pre-fix shape merged {:mode :sync} over
-   ;; the failure and emitted a non-isError envelope — the silent
-   ;; wrong-success this bead fixes.
+   ;; When the named frame cannot be targeted (head did not advance), the
+   ;; runtime returns {:ok? false :reason :no-new-epoch}. The tool MUST
+   ;; surface a structured ERROR envelope, never a {:mode :sync} success
+   ;; merged over the failure (which would be a silent wrong-success).
    {:fixture/id    :dispatch/frame-untargetable-error
     :fixture/doc   "dispatch surfaces the runtime's {:ok? false :reason :no-new-epoch} as an :isError envelope with NO :mode slot (rf2-ldfnx)."
     :fixture/tool  "dispatch"
@@ -679,10 +675,10 @@
     {:isError? true
      :edn-submap {:ok? false :reason :no-new-epoch :frame :rf/xray}}}
 
-   ;; rf2-gfu33 — render-settle. `:await-render true` wraps the settle
-   ;; Promise in the await mailbox; the wrap-form eval returns the
-   ;; mailbox sentinel and the poll read resolves to the dispatch
-   ;; envelope with `:settled? true`. The emitted settle form MUST route
+   ;; Render-settle. `:await-render true` wraps the settle Promise in the
+   ;; await mailbox; the wrap-form eval returns the mailbox sentinel and
+   ;; the poll read resolves to the dispatch envelope with
+   ;; `:settled? true`. The emitted settle form MUST route
    ;; the flush through the substrate-agnostic adapter primitive
    ;; (`re-frame.interop/after-render`) + the paint boundary
    ;; (`requestAnimationFrame`) and force synchronous dispatch.
@@ -716,7 +712,7 @@
     {:isError? false
      :edn-submap {:ok? true :mode :sync :settled? true :epoch-id 9}}}
 
-   ;; ---------- dispatch-dry-run (rf2-17hvp) ------------------------------
+   ;; ---------- dispatch-dry-run ------------------------------------------
    ;; Dry-run is NOT --allow-writes-gated: the override-set ensures no
    ;; observable effect escapes, and restore-epoch rewinds the would-be
    ;; epoch. No gate needed because the contract IS "no state change".
@@ -770,13 +766,13 @@
     {:isError? true
      :reason :not-an-event-vector}}
 
-   ;; rf2-z7roa — dry-run is an AI-facing READ surface. Gate OFF (the
-   ;; default published posture) MUST run the app-db-rooted egress slot
+   ;; Dry-run is an AI-facing READ surface. Gate OFF (the default
+   ;; published posture) MUST run the app-db-rooted egress slot
    ;; (:db-state-after-simulation) through the elision walker server-side,
    ;; with sensitive slots forced to redact and large slots forced to
-   ;; elide. rf2-6to9xj — the :would-fire-effects[*].args slot is NOT
-   ;; app-db-rooted, so it FAILS CLOSED (assoc :rf/redacted) rather than
-   ;; running through the walker. The eval form must carry the walker call
+   ;; elide. The :would-fire-effects[*].args slot is NOT app-db-rooted, so
+   ;; it FAILS CLOSED (assoc :rf/redacted) rather than running through the
+   ;; walker. The eval form must carry the walker call
    ;; (for the db slot) + the safe walker opts + the fx-args redaction
    ;; (touching :would-fire-effects), and must signal the raw-state tap
    ;; posture (configure-raw-state!) before the dispatch.
@@ -809,11 +805,10 @@
     {:isError? false
      :edn-submap {:ok? true :dry-run? true :elision true}}}
 
-   ;; rf2-t55hxg.13 — fail-CLOSED. Gate ON + a BARE `:elision false` (no
+   ;; Fail-CLOSED. Gate ON + a BARE `:elision false` (no
    ;; `:include-sensitive true`) MUST still walk the app-db-rooted
    ;; `:db-state-after-simulation` slot: large content passes
    ;; (`include-large? true`) but a declared-sensitive db slot redacts.
-   ;; Pre-fix this asserted no walker wrap — that was the sensitive bypass.
    {:fixture/id    :dispatch-dry-run/gate-on-bare-elision-false-still-walks
     :fixture/doc   "dispatch-dry-run ON + :elision false (no sensitive opt-in) ⇒ form STILL runs :db-state-after-simulation through elide-wire-value with :rf.size/include-sensitive? false, :rf.size/include-large? true (rf2-t55hxg.13)."
     :fixture/tool  "dispatch-dry-run"
@@ -833,10 +828,10 @@
     {:isError? false
      :edn-submap {:ok? true :elision false}}}
 
-   ;; rf2-t55hxg.13 — the deliberate full-raw opt-in (`:elision false` AND
+   ;; The deliberate full-raw opt-in (`:elision false` AND
    ;; `:include-sensitive true`) is the ONLY combination that skips the db
-   ;; walker. With `:include-fx-args` unset the fx args still fail closed
-   ;; (rf2-6to9xj), so the form still touches `:would-fire-effects`.
+   ;; walker. With `:include-fx-args` unset the fx args still fail closed,
+   ;; so the form still touches `:would-fire-effects`.
    {:fixture/id    :dispatch-dry-run/gate-on-full-raw-opt-out
     :fixture/doc   "dispatch-dry-run ON + :elision false + :include-sensitive true ships the raw simulation details — NO walker wrap for the db slot (rf2-z7roa / rf2-t55hxg.13)."
     :fixture/tool  "dispatch-dry-run"
@@ -854,9 +849,9 @@
     {:isError? false
      :edn-submap {:ok? true :elision false}}}
 
-   ;; rf2-6to9xj — the :would-fire-effects[*].args slot carries RAW
-   ;; fx-handler arguments (HTTP bodies, dispatched event vectors, payment
-   ;; maps) NOT rooted at app-db, so the schema-path walker cannot prove
+   ;; The :would-fire-effects[*].args slot carries RAW fx-handler
+   ;; arguments (HTTP bodies, dispatched event vectors, payment maps) NOT
+   ;; rooted at app-db, so the schema-path walker cannot prove
    ;; them safe. Off-box egress FAILS CLOSED: :args redacts to :rf/redacted
    ;; for every fx by default, while :fx-id rides through. The emitted form
    ;; carries the fail-close (assoc :args :rf/redacted on :would-fire-effects).
@@ -898,7 +893,7 @@
     {:isError? true
      :edn-submap {:ok? false :reason :no-new-epoch}}}
 
-   ;; ---------- restore-epoch (rf2-ee38b.18 — gated write) ----------------
+   ;; ---------- restore-epoch (gated write) -------------------------------
    ;; The --allow-writes gate ships DEFAULT-OFF. The disabled fixture pins
    ;; the gate-closed envelope (no nREPL round-trip); the happy fixture
    ;; flips :fixture/allow-writes? and pins the success shape. epoch-id is
@@ -939,10 +934,10 @@
     {:isError? true
      :reason :missing-epoch-id}}
 
-   ;; rf2-or8s29 — a restore that the runtime REJECTS (legacy bare
-   ;; `false`: aged-out id, drain-in-flight) means the write did not land.
-   ;; It MUST ride as isError carrying :restore-rejected, NOT a
-   ;; success-shaped envelope the host reads as a landed write.
+   ;; A restore that the runtime REJECTS (a bare `false`: aged-out id,
+   ;; drain-in-flight) means the write did not land. It MUST ride as
+   ;; isError carrying :restore-rejected, NOT a success-shaped envelope
+   ;; the host reads as a landed write.
    {:fixture/id    :restore-epoch/rejected-false
     :fixture/doc   "restore-epoch with --allow-writes ON whose runtime returns false (rejected restore) rides as isError :restore-rejected (rf2-or8s29)."
     :fixture/tool  "restore-epoch"
@@ -957,7 +952,7 @@
     {:isError? true
      :edn-submap {:ok? false :restored? false :reason :restore-rejected :epoch-id 999}}}
 
-   ;; ---------- replace-app-db (rf2-ee38b.18 — gated write) ---------------
+   ;; ---------- replace-app-db (gated write) ------------------------------
    {:fixture/id    :replace-app-db/disabled-default
     :fixture/doc   "replace-app-db with --allow-writes OFF returns :rf.error/writes-disabled without touching the runtime."
     :fixture/tool  "replace-app-db"
@@ -981,9 +976,9 @@
      [:default                    nil]]
     :fixture/eval-form-must-contain
     ["app-db-reset! {:counter 0}"
-     ;; rf2-z7roa — the raw-state tap posture is signalled (the unit
-     ;; suite pins it lands BEFORE app-db-reset!; the corpus pins it
-     ;; IS emitted on the write path with the gate-OFF posture).
+     ;; The raw-state tap posture is signalled (the unit suite pins it
+     ;; lands BEFORE app-db-reset!; the corpus pins it IS emitted on the
+     ;; write path with the gate-OFF posture).
      "configure-raw-state!"
      ":allow-raw-state? false"]
     :fixture/expect
@@ -1001,7 +996,7 @@
     {:isError? true
      :reason :missing-db}}
 
-   ;; rf2-or8s29 — a replace the runtime REJECTS
+   ;; A replace the runtime REJECTS
    ;; ({:ok? false :reason :reset-rejected ...}: no-such-frame,
    ;; replace-during-drain, schema-mismatch) means the injection did NOT
    ;; land. It MUST ride as isError carrying the reason, NOT a
@@ -1075,7 +1070,7 @@
     :fixture/args  {:frames "all"}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  true]
-     ;; rf2-e35a5: the snapshot eval form now wraps its result as
+     ;; The snapshot eval form wraps its result as
      ;; `{:value <snap> :elided-count N}` so the elision count rides
      ;; back on the same nREPL round-trip; the wire-pipeline reads
      ;; the count from opts instead of re-walking client-side.
@@ -1101,9 +1096,9 @@
     :fixture/args  {:path "[:counter]"}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  true]
-     ;; rf2-e35a5: eval form pre-counts elision markers; the
-     ;; envelope carries `:elided-count` so the wire-pipeline reads
-     ;; the count from opts instead of re-walking the scalar.
+     ;; The eval form pre-counts elision markers; the envelope carries
+     ;; `:elided-count` so the wire-pipeline reads the count from opts
+     ;; instead of re-walking the scalar.
      [:default                    {:ok? true :exists? true :path [:counter]
                                    :value 42 :elided-count 0}]]
     :fixture/expect
@@ -1133,10 +1128,10 @@
     {:isError? true
      :edn-submap {:ok? false :reason :path-not-found}}}
 
-   ;; ---------- read-dom (rf2-nfjil — raw DOM plane read) -----------------
+   ;; ---------- read-dom (raw DOM plane read) -----------------------------
    ;; The whole read runs browser-side in the preloaded runtime fn
-   ;; (re-frame2-pair.runtime/dom-read — shared plumbing with read-ui since
-   ;; rf2-q0r7e); the corpus stubs the form's canned envelope, matching on
+   ;; (re-frame2-pair.runtime/dom-read — shared plumbing with read-ui);
+   ;; the corpus stubs the form's canned envelope, matching on
    ;; the `dom-read` runtime call. Pins the outer wire shape: matched
    ;; :count + per-node {:tag :text :attrs}, the large-text elision marker,
    ;; the missing-arg gate, and the bad-selector error reason.
@@ -1217,7 +1212,7 @@
     :fixture/expect
     {:isError? true}}
 
-   ;; ---------- list-subscriptions (reactive sub-cache, rf2-qicji) --------
+   ;; ---------- list-subscriptions (reactive sub-cache) -------------------
    {:fixture/id    :list-subscriptions/empty
     :fixture/doc   "list-subscriptions on a frame with no live reactive subs returns an empty list envelope. The runtime sentinel is present (only the sub-cache query is empty) — a missing sentinel would be a preflight failure (isError), not an empty success."
     :fixture/tool  "list-subscriptions"
@@ -1228,7 +1223,7 @@
     :fixture/expect
     {:isError? false}}
 
-   ;; ---------- list-streams (streaming-tap diagnostic, rf2-qicji) --------
+   ;; ---------- list-streams (streaming-tap diagnostic) -------------------
    {:fixture/id    :list-streams/empty
     :fixture/doc   "list-streams with no active streaming-tap subscriptions returns an empty list envelope. The runtime sentinel is present (only the subscription-info query is empty) — a missing sentinel would be a preflight failure (isError), not an empty success."
     :fixture/tool  "list-streams"
@@ -1239,7 +1234,7 @@
     :fixture/expect
     {:isError? false}}
 
-   ;; ---------- operating-frame trio (rf2-zomfq) --------------------------
+   ;; ---------- operating-frame trio --------------------------------------
    ;; The three Tool-Pair §Tool-surface-obligations ops. The runtime
    ;; surfaces them via `frames-list` (the {:frames :selected :operating}
    ;; triple) and `select-frame!`; the tools compose validate-then-pin /
@@ -1390,7 +1385,7 @@
      :edn-submap {:ok? true :selected nil :operating nil}}}
 
    ;; ---------- get-re-frame2-pair-instructions ------------------------------------
-   ;; Inline-text tool (rf2-fnpqg). No nREPL round-trip; the result is a
+   ;; Inline-text tool. No nREPL round-trip; the result is a
    ;; pure-data def in the bundle, so the eval-script is irrelevant.
    {:fixture/id    :get-re-frame2-pair-instructions/happy
     :fixture/doc   "get-re-frame2-pair-instructions returns {:ok? true :tool ... :text <prose>}."
@@ -1402,14 +1397,13 @@
     {:isError? false
      :edn-submap {:ok? true :tool "get-re-frame2-pair-instructions"}}}
 
-   ;; ---------- rf2-c2dtu raw-state boot-gate -----------------------------
+   ;; ---------- raw-state boot-gate ---------------------------------------
    ;; The default-OFF gate forces `:include-sensitive false` AND
    ;; `:elision true` on every snapshot / get-path / subscribe call,
    ;; regardless of the per-call arg. The gate-ON path defers to the
-   ;; caller's args (pre-rf2-c2dtu posture). The wire-key drops the
-   ;; trailing `?` post-rf2-ihq4d; the namespaced walker-option keyword
-   ;; `:rf.size/include-sensitive?` retains it (internal framework key,
-   ;; not on the wire).
+   ;; caller's args. The wire-key carries no trailing `?`; the namespaced
+   ;; walker-option keyword `:rf.size/include-sensitive?` retains it
+   ;; (internal framework key, not on the wire).
    {:fixture/id    :raw-state/snapshot-gated-default-forces-redact
     :fixture/doc   "Gate OFF + caller passes :include-sensitive true ⇒ form must carry :rf.size/include-sensitive? false."
     :fixture/tool  "snapshot"
@@ -1453,11 +1447,10 @@
     :fixture/expect
     {:isError? false}}
 
-   ;; rf2-t55hxg.13 — fail-CLOSED. A BARE `:elision false` (no
-   ;; `:include-sensitive true`) MUST still walk: large content passes
-   ;; (`include-large? true`) but a declared-sensitive `:app-db` /
-   ;; `:sub-cache` slot redacts to `:rf/redacted`. Pre-fix this fixture
-   ;; asserted the walker was skipped — that was the sensitive bypass.
+   ;; Fail-CLOSED. A BARE `:elision false` (no `:include-sensitive true`)
+   ;; MUST still walk: large content passes (`include-large? true`) but a
+   ;; declared-sensitive `:app-db` / `:sub-cache` slot redacts to
+   ;; `:rf/redacted`.
    {:fixture/id    :raw-state/snapshot-bare-elision-false-still-walks
     :fixture/doc   "Gate ON + :elision false (no sensitive opt-in) ⇒ form must STILL call elide-wire-value with include-sensitive? false (sensitive redacts, large passes)."
     :fixture/tool  "snapshot"
@@ -1474,9 +1467,9 @@
     :fixture/expect
     {:isError? false}}
 
-   ;; rf2-t55hxg.13 — the ONLY combination that skips the walker is the
-   ;; deliberate full-raw local opt-in: `:elision false` AND
-   ;; `:include-sensitive true` (the operator's `:rf.egress/local-raw` act).
+   ;; The ONLY combination that skips the walker is the deliberate
+   ;; full-raw local opt-in: `:elision false` AND `:include-sensitive true`
+   ;; (the operator's `:rf.egress/local-raw` act).
    {:fixture/id    :raw-state/snapshot-full-raw-opt-in-skips-walker
     :fixture/doc   "Gate ON + :elision false + :include-sensitive true ⇒ full-raw opt-in, form must NOT call elide-wire-value over the slices."
     :fixture/tool  "snapshot"
@@ -1536,11 +1529,10 @@
     :fixture/expect
     {:isError? false}}
 
-   ;; ---------- handler-meta (rf2-wnrpi, finding G7) ----------------------
-   ;; Previously handler-meta / list-handlers had NO outer-wire-shape pin
-   ;; in the corpus — their unit suite carried error paths only (and even
-   ;; those were silently skipped pre-rf2-wnrpi). These fixtures put both
-   ;; tools inside the "every tool" cross-tool ratchet the corpus promises.
+   ;; ---------- handler-meta ----------------------------------------------
+   ;; These fixtures put handler-meta / list-handlers inside the "every
+   ;; tool" cross-tool ratchet the corpus promises, pinning their
+   ;; outer-wire shape (the unit suite covers their error paths).
    {:fixture/id    :handler-meta/happy
     :fixture/doc   "handler-meta on a registered (kind,id) merges :ok? true + the requested kind/id onto the runtime meta map."
     :fixture/tool  "handler-meta"
@@ -1564,7 +1556,7 @@
     {:isError? true
      :reason :invalid-kind}}
 
-   ;; ---------- list-handlers (rf2-wnrpi, finding G7) ---------------------
+   ;; ---------- list-handlers ---------------------------------------------
    {:fixture/id    :list-handlers/happy
     :fixture/doc   "list-handlers returns the sorted id vector + :count for a kind, wrapped :ok? true."
     :fixture/tool  "list-handlers"
@@ -1588,7 +1580,7 @@
     {:isError? true
      :reason :invalid-kind}}
 
-   ;; ---------- get-stream-controls (rf2-a0kxsb) --------------------------
+   ;; ---------- get-stream-controls ---------------------------------------
    ;; Server-side resource-control diagnostic. No nREPL round-trip — the
    ;; tool reads in-process atoms — so the eval-script is a bare default
    ;; (the tool never asks the stub anything). Pins the outer envelope
@@ -1631,24 +1623,23 @@
   :failure ...}`.
 
   Honors `:fixture/eval-allowed?` — flips the eval-cljs launch-flag gate
-  (rf2-a0z0h; inverts the prior rf2-cxx5s default) for this fixture's
-  invocation and restores it afterward. Default ON mirrors the
-  published-build posture (eval-cljs is the REPL primitive); opt-out
-  fixtures (`:disabled-via-no-eval`) explicitly set `false` to exercise
-  the gate-closed envelope. When the key is absent, the fixture inherits
-  the default-ON state.
+  for this fixture's invocation and restores it afterward. Default ON
+  mirrors the published-build posture (eval-cljs is the REPL primitive);
+  opt-out fixtures (`:disabled-via-no-eval`) explicitly set `false` to
+  exercise the gate-closed envelope. When the key is absent, the fixture
+  inherits the default-ON state.
 
-  Honors `:fixture/allow-raw-state?` (rf2-c2dtu) — flips the raw-state
-  boot gate. Default OFF mirrors the published-build posture; opt-in
-  fixtures verify that an operator who passed `--allow-sensitive-reads`
-  gets the legacy per-call-arg-wins behaviour."
+  Honors `:fixture/allow-raw-state?` — flips the raw-state boot gate.
+  Default OFF mirrors the published-build posture; opt-in fixtures verify
+  that an operator who passed `--allow-sensitive-reads` gets the
+  per-call-arg-wins behaviour."
   [{:fixture/keys [id tool args eval-script expect eval-allowed?
                     allow-raw-state? allow-writes?
                     eval-form-must-contain eval-form-must-not-contain]}]
   (cache/clear!)
   (let [;; eval-allowed? defaults true (mirrors the published-build gate
-        ;; state post-rf2-a0z0h); a fixture sets `false` to exercise
-        ;; the --no-eval opt-out path.
+        ;; state); a fixture sets `false` to exercise the --no-eval
+        ;; opt-out path.
         eval-allowed?-effective (if (nil? eval-allowed?) true (boolean eval-allowed?))
         js-args         (args->js args)
         forms-seen      (atom [])
@@ -1669,10 +1660,9 @@
         (-> (tools/invoke nil tool js-args nil)
             (.then (fn [result]
                      (let [[ok? msg]    (check-fixture-result result expect)
-                           ;; rf2-c2dtu — pin the gate-induced shape of
-                           ;; the eval form sent over nREPL. A `must-
-                           ;; contain` substring missing from EVERY form
-                           ;; observed = fail.
+                           ;; Pin the gate-induced shape of the eval form
+                           ;; sent over nREPL. A `must-contain` substring
+                           ;; missing from EVERY form observed = fail.
                            form-strs    @forms-seen
                            any-has?     (fn [needle]
                                           (some #(str/includes? % needle) form-strs))
@@ -1736,8 +1726,7 @@
               (let [all     @results
                     passed  (filter :passed? all)
                     failed  (remove :passed? all)]
-                ;; Silent-on-success (rf2-try1x): summary prints only
-                ;; on failure.
+                ;; Silent-on-success: summary prints only on failure.
                 (when (seq failed)
                   (println)
                   (println "re-frame2-pair-mcp conformance corpus:")

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cursor_pagination_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cursor_pagination_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.cursor-pagination-test
   "Unit tests for the cursor-pagination mechanism on `trace-window`
-  and `watch-epochs` (rf2-kbqq3).
+  and `watch-epochs`.
 
   Both tools accept `:limit` (int, default 50) + `:cursor` (opaque
   string). Responses carry `:next-cursor`, `:has-more?` and
@@ -72,17 +72,16 @@
     (is (= payload decoded))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-ee38b.18 — INTEGER epoch-ids (the real-runtime fidelity fix).
+;; INTEGER epoch-ids (real-runtime fidelity).
 ;;
 ;; The reference epoch runtime (`re-frame/epoch/state.cljc`
 ;; `next-epoch-id` = `(swap! counter inc)`) emits INTEGER epoch-ids, and
-;; Spec-Schemas declares `:epoch-id` as `:any`. The prior local
-;; `decode-cursor` required `(string? (:after-id v))`, so an
-;; integer-bearing second-page cursor decoded as `::malformed` →
-;; spurious `:rf.mcp/cursor-stale`, breaking pagination against the
-;; actual runtime. These pin the contract to `:any` — the tests use REAL
-;; integer ids, not synthesised strings, so a regression to a `string?`
-;; guard fails here.
+;; Spec-Schemas declares `:epoch-id` as `:any`. `decode-cursor` must
+;; accept any `:after-id` shape: an integer-bearing second-page cursor
+;; round-trips intact rather than decoding as `::malformed` and tripping
+;; a spurious `:rf.mcp/cursor-stale`. These pin the contract to `:any` —
+;; the tests use REAL integer ids, not synthesised strings, so a
+;; regression to a `string?` guard fails here.
 ;; ---------------------------------------------------------------------------
 
 (deftest cursor-round-trips-integer-after-id
@@ -259,14 +258,13 @@
         "Records returned in original order")))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-ee38b.18 — second-page pagination with REAL integer epoch-ids.
+;; Second-page pagination with REAL integer epoch-ids.
 ;;
-;; This is the scenario the prior `string?` guard broke: the runtime
-;; emits integer epoch-ids, so the cursor carries an integer :after-id,
-;; and the second-page decode previously failed as `::malformed`. The
-;; `make-int-epoch` helper builds records keyed by INTEGER ids (mirroring
-;; `re-frame/epoch/state.cljc`'s `(swap! counter inc)`), so this walks
-;; the exact shape the real runtime produces.
+;; The runtime emits integer epoch-ids, so the cursor carries an integer
+;; :after-id and the second-page decode must accept it (never `::malformed`).
+;; The `make-int-epoch` helper builds records keyed by INTEGER ids
+;; (mirroring `re-frame/epoch/state.cljc`'s `(swap! counter inc)`), so
+;; this walks the exact shape the real runtime produces.
 ;; ---------------------------------------------------------------------------
 
 (defn- make-int-epoch [n]
@@ -304,9 +302,9 @@
 
 (deftest five-page-walk-over-integer-id-ring-returns-distinct-records-in-order
   ;; The full acceptance walk with REAL integer ids — pagination over 5
-  ;; batches returns 50 distinct integer-keyed records in order. Pre-fix
-  ;; this would have aborted after page 1 (the page-2 cursor decoding as
-  ;; stale).
+  ;; batches returns 50 distinct integer-keyed records in order. A
+  ;; page-2 cursor decoding as stale would abort the walk after page 1;
+  ;; this guards against that.
   (let [hist (vec (for [n (range 50)] (make-int-epoch n)))
         walk (loop [cursor-str nil
                     pages      []
@@ -406,15 +404,14 @@
         "Page 1 + page 2 = original 50 records, no admission of fresh ones")))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-mb17rj — watch-epochs carries the sticky :pred in the continuation
-;; cursor.
+;; watch-epochs carries the sticky :pred in the continuation cursor.
 ;;
-;; THE BUG: `watch-epochs`'s first-call `:next-cursor` encoded :after-id /
-;; :frame but NOT the predicate, and the host derived the filter ONLY from
-;; the `:pred` arg. An agent paginating via the documented opaque-cursor
-;; flow (pass back JUST `:cursor`, no `:pred`) kept the sticky frame but
-;; LOST the predicate → page 2+ ran `epoch-matches?` with `{}` = MATCH-ALL,
-;; returning every epoch after the watermark unfiltered, with an envelope
+;; `watch-epochs`'s first-call `:next-cursor` encodes :after-id / :frame
+;; AND the predicate. An agent paginating via the documented opaque-cursor
+;; flow (pass back JUST `:cursor`, no `:pred`) keeps both the sticky frame
+;; and the predicate, so page 2+ runs `epoch-matches?` with the original
+;; predicate rather than degrading to `{}` (MATCH-ALL) — which would
+;; return every epoch after the watermark unfiltered, with an envelope
 ;; identical to a correctly-filtered page so the agent couldn't detect it.
 ;;
 ;; These pins exercise BOTH ends of the round-trip:
@@ -515,14 +512,12 @@
                     (.then (fn [_result]
                              (let [form-str (first @forms)]
                                (is (some? form-str) "a runtime form was emitted")
-                               ;; THE REGRESSION ASSERTION: the emitted
-                               ;; epoch-matches? call carries the sticky
-                               ;; predicate from the cursor.
+                               ;; The emitted epoch-matches? call carries
+                               ;; the sticky predicate from the cursor.
                                (is (re-find #"epoch-matches\? \{:event-id :ev/login\}"
                                             form-str)
                                    "page-2 form filters by the sticky pred from the cursor")
-                               ;; And NOT the match-all empty map — the
-                               ;; pre-fix behaviour.
+                               ;; And NOT the match-all empty map.
                                (is (not (re-find #"epoch-matches\? \{\}" form-str))
                                    "page-2 form must NOT degrade to match-all {}")
                                (done))))))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_benchmark_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_benchmark_test.cljs
@@ -1,13 +1,11 @@
 (ns re-frame2-pair-mcp.dedup-benchmark-test
-  "Trace-burst structural-dedup compression benchmark (rf2-li2cw).
+  "Trace-burst structural-dedup compression benchmark.
 
   ## Why this benchmark
 
-  Earlier vibes-quoted claims that `day8/de-dupe` 'typically
-  compresses trace bursts 3-5× without semantic loss' were
-  approximate — no in-repo measurement bound them. The
-  catalogue-entry-contract that each tool declare its
-  typical-token hint would have inherited that imprecision.
+  The catalogue-entry-contract requires each tool to declare its
+  typical-token hint, and a `day8/de-dupe` compression claim needs an
+  in-repo measurement to bind it rather than an approximate figure.
 
   This benchmark exercises `day8/de-dupe` against a representative
   trace-event corpus at three scales (100 / 1,000 / 10,000 events)
@@ -35,10 +33,9 @@
   the path of least friction; the measured factors here are the
   in-repo source of truth.
 
-  ## Measured numbers (run 2026-05-14)
+  ## Measured numbers
 
-  The benchmark replaced an earlier vibes-only '3-5×' quote in
-  the spec. **Measured**:
+  The measured factors that bind the spec's compression figures:
 
   | Corpus                                | Reduction | Ratio  |
   |---------------------------------------|-----------|--------|
@@ -67,7 +64,7 @@
     benchmark): **5-10× compression** (80-90% reduction). The
     existing `dedup_test.cljs/reduction-ratio-shared-subtrees`
     pins 89.5% on a 10-epoch / 256-key shared-`:db-before`
-    payload — the load-bearing case for rf2-obpa9.
+    payload — the load-bearing structural-dedup case.
 
   The three regimes share the algorithm; their compression
   budgets differ because their shared-subtree cardinality differs.
@@ -227,8 +224,8 @@
        "  ratio=" (.toFixed (:ratio m) 2) "×"
        "  reduction=" (.toFixed (:reduction-pct m) 1) "%"))
 
-;; Silent-on-success (rf2-try1x): the benchmark prints its measured
-;; rows only when explicitly verbose. The row text is also folded into
+;; Silent-on-success: the benchmark prints its measured rows only when
+;; explicitly verbose. The row text is also folded into
 ;; each failing `is` message below, so triage still sees the numbers.
 ;; To surface the measurements on a green run for spec-tracking, flip
 ;; the goog-define `re-frame2-pair-mcp.dedup-benchmark-test/bench-verbose?`
@@ -240,11 +237,11 @@
     (println (row-str m))))
 
 ;; ---------------------------------------------------------------------------
-;; Benchmark fixtures — the three scales the bead names.
+;; Benchmark fixtures — the three scales on the measured scale axis.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private corpora
-  "Six corpora spanning the bead's stated scale axis (100 / 1k / 10k
+  "Six corpora spanning the scale axis (100 / 1k / 10k
   events) crossed with two structural-depth profiles (narrow cascade
   width = lower shared-subtree density; wide cascade width = higher
   density). These represent the **raw trace-burst regime** — events
@@ -265,8 +262,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest day8-de-dupe-trace-burst-compression-factor
-  ;; Pin the measured compression factor across the bead's stated scale
-  ;; axis. Floor is the **observed** lower bound minus a 5% slack margin
+  ;; Pin the measured compression factor across the scale axis. Floor is
+  ;; the **observed** lower bound minus a 5% slack margin
   ;; — currently 1.30× on raw trace bursts (observed range
   ;; 1.40-1.45×). The actual ratio prints to the test log only when
   ;; `bench-verbose?` is true (see goog-define above); on green the
@@ -323,9 +320,8 @@
 ;; A single handler firing repeatedly (polling tick, view-render, timer)
 ;; produces cascades whose body tags are identical across replays. The
 ;; deduper collapses the entire repeated cascade-body subtree, reaching
-;; the same compression neighbourhood the original '3-5×' vibes-quote
-;; was reaching for — but on a different corpus shape than the raw
-;; trace burst.
+;; a much higher compression factor than the raw trace burst — on a
+;; different corpus shape.
 ;; ---------------------------------------------------------------------------
 
 (deftest day8-de-dupe-high-share-burst-compression-factor
@@ -338,9 +334,9 @@
         m       (measure "high-share / 100 replays / cascade=24" (count payload) payload)]
     (print-row m)
     (testing "high-share burst exceeds the 8× pinned floor"
-      ;; The high-share corpus reaches the regime the original spec
-      ;; quote was reaching for. Observed ratio currently ~14×; the
-      ;; floor is set well below to surface only material regression.
+      ;; The high-share corpus reaches the upper-bound compression
+      ;; regime. Observed ratio currently ~14×; the floor is set well
+      ;; below to surface only material regression.
       (is (>= (:ratio m) 8.0)
           (str "high-share burst ratio " (.toFixed (:ratio m) 2)
                "× fell below the 8× pinned floor — re-measure and "

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_test.cljs
@@ -1,6 +1,5 @@
 (ns re-frame2-pair-mcp.dedup-test
-  "Unit tests for the structural-dedup wire-boundary transform
-  (rf2-obpa9).
+  "Unit tests for the structural-dedup wire-boundary transform.
 
   Per `tools/re-frame2-pair-mcp/spec/Principles.md` mechanism (Structural
   dedup), every `:rf/epoch-record` slice and each subscribe-tick
@@ -17,7 +16,7 @@
   contract drift.
 
   `:dedup` MCP-arg normalisation lives on the shared table-driven
-  parser (`re-frame2-pair-mcp.tools.args/parse-bool-arg`, rf2-c4fmh);
+  parser (`re-frame2-pair-mcp.tools.args/parse-bool-arg`);
   see `re-frame2-pair-mcp.args-test` for the coverage.
 
   Live end-to-end coverage runs against a real shadow-cljs build via
@@ -114,8 +113,8 @@
                           [(keyword (str "k" i))
                            {:v (str "value-" i)
                             :meta {:tags [:tag1 :tag2 :tag3]}}]))
-        ;; rf2-qeous: wire shape is sections-per-cluster. Each
-        ;; synthetic epoch carries a single-section :db-after.
+        ;; Wire shape is sections-per-cluster. Each synthetic epoch
+        ;; carries a single-section :db-after.
         epochs (vec (for [i (range 10)]
                       (let [path [(keyword (str "k" i)) :v]]
                         {:epoch-id (str "ep-" i)
@@ -149,23 +148,23 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Reduction-ratio sanity: 10-epoch window with shared map structure.
-;; The bead requires ≥50% reduction; we assert the actual value with
+;; The contract requires ≥50% reduction; we assert the actual value with
 ;; a generous floor because the precise ratio depends on subtree
 ;; cardinality + map layout.
 ;; ---------------------------------------------------------------------------
 
 (deftest reduction-ratio-shared-subtrees
-  ;; The load-bearing scenario rf2-obpa9 targets: a 10-epoch window
-  ;; whose records share their `:db-before` reference. The diff-
-  ;; encoder (rf2-1wdzp) already reduced :db-after to a tiny patch
-  ;; per record; the deduper now collapses the repeated :db-before.
+  ;; The load-bearing scenario: a 10-epoch window whose records share
+  ;; their `:db-before` reference. The diff-encoder reduces :db-after to
+  ;; a tiny patch per record; the deduper collapses the repeated
+  ;; :db-before.
   (let [;; Build a "big" app-db — 256 keys, each pointing at a 256-char
         ;; string value ⇒ ~80KB pr-str.
         big-db (into {} (for [i (range 256)]
                           [(keyword (str "k" i))
                            (apply str (repeat 256 \x))]))
         ;; 10 epochs, each sharing the same :db-before reference.
-        ;; rf2-qeous: sections-per-cluster wire shape.
+        ;; Sections-per-cluster wire shape.
         epochs (vec (for [i (range 10)]
                       (let [path [(keyword (str "k" i))]]
                         {:epoch-id (str "ep-" i)
@@ -179,13 +178,13 @@
         wrapped (dedup/dedup-value epochs true)
         wrapped-size (count (pr-str wrapped))]
     (testing "wrapped payload is much smaller than the raw vector"
-      ;; Silent-on-success (rf2-try1x): the measurement is folded into
-      ;; the failing-assertion messages below; agents reading green-run
+      ;; Silent-on-success: the measurement is folded into the
+      ;; failing-assertion messages below; agents reading green-run
       ;; output don't burn context on per-test diagnostics.
       (is (< wrapped-size raw-size)
           (str "wrapped >= raw — measurement: raw=" raw-size
                "chars deduped=" wrapped-size "chars"))
-      ;; Conservative: ≥50% reduction (the bead's floor). Actual
+      ;; Conservative: ≥50% reduction (the contract floor). Actual
       ;; should be much higher when the same :db-before reference
       ;; rides 10 times.
       (is (< wrapped-size (* 0.5 raw-size))
@@ -197,7 +196,7 @@
         (is (= epochs restored))))))
 
 ;; ---------------------------------------------------------------------------
-;; Edge cases per the bead.
+;; Edge cases.
 ;; ---------------------------------------------------------------------------
 
 (deftest edge-case-empty-payload-is-noop

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/describe_image_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/describe_image_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.describe-image-test
-  "Unit tests for the describe-image tool (rf2-srobm0) — the EP-0023
+  "Unit tests for the describe-image tool — the EP-0023
   Use-Case 7 read over a frame's resolved image generation.
 
   The tool is a thin wrapper over the runtime `describe-image` fn: it emits
@@ -17,7 +17,7 @@
   The runtime `describe-image` composition (the generation projection) is
   exercised by the runtime preload tests.
 
-  ## Stub lifetime — fixture-scoped (rf2-wb06a)
+  ## Stub lifetime — fixture-scoped
 
   Each test installs its `cljs-eval-value` stub via a bare `set!`; a
   `use-fixtures :each :after` step restores the pristine original. See

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/descriptor_egress_wording_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/descriptor_egress_wording_test.cljs
@@ -1,28 +1,28 @@
 (ns re-frame2-pair-mcp.descriptor-egress-wording-test
   "EP-0015 egress-posture wording gate for the generated MCP descriptors.
 
-  THE DRIFT. The pair-MCP tool catalogue is client-facing root metadata —
-  an AI host reads it to learn what each tool does and what its privacy
-  posture IS. Two descriptors had rotted against EP-0015's frame-owned
-  egress policy:
+  THE CONTRACT. The pair-MCP tool catalogue is client-facing root
+  metadata — an AI host reads it to learn what each tool does and what its
+  privacy posture IS. The descriptions must match EP-0015's frame-owned
+  egress policy on two points:
 
-    - `get-path` / `snapshot` told clients `elision false` \"bypasses the
-      walk and receives the raw value\". The landed implementation does NOT
-      bypass on a bare `:elision false` (`elision/walk-required?` fails
+    - `get-path` / `snapshot` must NOT tell clients that `elision false`
+      \"bypasses the walk and receives the raw value\". A bare
+      `:elision false` does NOT bypass (`elision/walk-required?` fails
       CLOSED — the walker still runs, large passes but declared-sensitive
-      slots redact). The wording trained clients/tests to treat a direct
-      read as a projection bypass rather than a profile/gate-controlled
-      egress (rf2-nu98y7).
-    - `snapshot` said the `:machines` slice \"passes through unchanged —
-      payload redaction there is the redact-interceptor interceptor's
-      job\". EP-0015 retired `redact-interceptor` from the public API, and
-      the landed snapshot impl default-redacts the `:machines` runtime-db
-      slice to `:rf/redacted` under the off-box-tool profile (rf2-e47yxs).
+      slots redact). The bypass wording would train clients/tests to treat
+      a direct read as a projection bypass rather than a profile/gate-
+      controlled egress.
+    - `snapshot` must NOT say the `:machines` slice \"passes through
+      unchanged — payload redaction there is the redact-interceptor
+      interceptor's job\". `redact-interceptor` is not part of the public
+      API, and the snapshot impl default-redacts the `:machines`
+      runtime-db slice to `:rf/redacted` under the off-box-tool profile.
 
   THE GATE. No MCP direct-read tool's published description may carry the
-  retired / ungated egress claims. The forbidden phrases are pinned here;
-  a future descriptor edit (or a regenerated manifest) that re-introduces
-  one trips a RED. The gate scans BOTH the raw registry descriptions (the
+  ungated egress claims. The forbidden phrases are pinned here; a
+  descriptor edit (or a regenerated manifest) that introduces one trips a
+  RED. The gate scans BOTH the raw registry descriptions (the
   `:description` source) so a drift is caught before the manifest is even
   regenerated, AND the committed `tool-descriptors.edn` once present
   (covered transitively by the `check:descriptors` drift gate, asserted
@@ -43,17 +43,17 @@
   (into {} (map (juxt :name :description)) registry/tool-descriptors))
 
 ;; ---------------------------------------------------------------------------
-;; Forbidden EP-0015-drift phrases. Each is a claim the landed
-;; implementation does NOT honour (an ungated raw bypass / a retired
-;; interceptor / a raw machine pass-through). A descriptor carrying one is
-;; stale metadata on the client-facing root surface.
+;; Forbidden EP-0015-drift phrases. Each is a claim the implementation
+;; does NOT honour (an ungated raw bypass / a non-public interceptor / a
+;; raw machine pass-through). A descriptor carrying one is stale metadata
+;; on the client-facing root surface.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private forbidden-phrases
-  ["bypass the walk and receive the raw value"  ; rf2-nu98y7 — get-path/snapshot
-   "to bypass elision and receive the raw value" ; rf2-nu98y7 — elision-property knob
-   "passes through unchanged"                    ; rf2-e47yxs — :machines slice
-   "redact-interceptor"])                        ; rf2-e47yxs — retired public API
+  ["bypass the walk and receive the raw value"  ; get-path/snapshot
+   "to bypass elision and receive the raw value" ; elision-property knob
+   "passes through unchanged"                    ; :machines slice
+   "redact-interceptor"])                        ; not part of the public API
 
 (deftest no-direct-read-descriptor-advertises-a-raw-bypass
   (testing "no published MCP description carries a retired / ungated egress claim"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/descriptor_privacy_knob_parity_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/descriptor_privacy_knob_parity_test.cljs
@@ -1,23 +1,23 @@
 (ns re-frame2-pair-mcp.descriptor-privacy-knob-parity-test
-  "Descriptor ↔ handler privacy-knob parity gate (rf2-mmd7o6).
+  "Descriptor ↔ handler privacy-knob parity gate.
 
-  THE BUG. Several egress tools' handlers consume privacy/egress knobs
-  (`:include-sensitive`, `:elision`) that govern whether app-db / sub /
-  epoch values cross the LLM-facing wire verbatim — but their published
-  MCP descriptors omitted those inputs. Because every descriptor declares
-  `:additionalProperties false`, a schema-aware client would never offer
-  (or could reject) the supported knob, and agents were taught an
-  INCOMPLETE privacy boundary: the live `tools/call` behaviour diverged
-  from `tools/list` / the generated `tool-descriptors.edn`.
+  THE CONTRACT. Several egress tools' handlers consume privacy/egress
+  knobs (`:include-sensitive`, `:elision`) that govern whether app-db /
+  sub / epoch values cross the LLM-facing wire verbatim. Every descriptor
+  declares `:additionalProperties false`, so a schema-aware client would
+  never offer (or could reject) a supported knob that the descriptor
+  omits, and agents would be taught an INCOMPLETE privacy boundary — the
+  live `tools/call` behaviour diverging from `tools/list` / the generated
+  `tool-descriptors.edn`. Every handler-consumed knob must therefore be
+  published on the descriptor.
 
   THE GATE. For every tool whose handler reads a privacy knob, the knob
   MUST appear as a boolean property on that tool's descriptor
   `:inputSchema :properties` — both on the raw registry descriptor AND on
   the spliced `tools/list` surface (`tool-descriptors-js`). The expected
-  set is pinned here from the handler source (file:line in the bead), so a
-  FUTURE egress-control addition that wires a handler knob without
-  publishing it trips this test rather than silently shipping an
-  unadvertised privacy control.
+  set is pinned here from the handler source, so a FUTURE egress-control
+  addition that wires a handler knob without publishing it trips this test
+  rather than silently shipping an unadvertised privacy control.
 
   WHY A STATIC EXPECTATION (not a source scrape). The handlers read the
   knobs via `(wire/arg args :include-sensitive)` / `(args/parse-bool-arg
@@ -37,8 +37,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Authoritative table — tool -> privacy knobs its HANDLER consumes.
 ;;
-;; Source of truth (rf2-mmd7o6 evidence; verify against the cited handler
-;; if you change this):
+;; Source of truth (verify against the cited handler if you change this):
 ;;   dispatch     :include-sensitive  — dispatch.cljs (`incl?`, :trace/:settle epoch egress)
 ;;   subscribe    :include-sensitive  — subscribe.cljs (`incl?`, top-level sensitive drop)
 ;;                :elision            — subscribe.cljs (`elision?`, per-event value walk)
@@ -48,10 +47,10 @@
 ;;                :elision            — watch_until.cljs (`elision?`, :sample / :last-sample)
 ;;
 ;; (snapshot / get-path / read-sub / list-subscriptions / dispatch-dry-run
-;; already published their knobs before this bead and are covered by the
-;; raw-state conformance fixtures; they are included here so the gate's
-;; coverage of the full structured-egress surface is explicit and a
-;; regression on them also trips.)
+;; publish their knobs and are covered by the raw-state conformance
+;; fixtures; they are included here so the gate's coverage of the full
+;; structured-egress surface is explicit and a regression on them also
+;; trips.)
 ;; ---------------------------------------------------------------------------
 
 (def ^:private handler-consumed-knobs

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/diff_encode_epochs_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/diff_encode_epochs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.diff-encode-epochs-test
-  "Unit tests for the diff-encoded epoch slice (rf2-1wdzp).
+  "Unit tests for the diff-encoded epoch slice.
 
   Per `tools/re-frame2-pair-mcp/spec/Principles.md` mechanism (Diff-encoded
   epoch slice), every `:rf/epoch-record` shipped over the wire has
@@ -60,11 +60,11 @@
          (diff/collect-patches {:a 1} :replaced []))))
 
 (deftest collect-patches-same-length-vector-diffs-element-wise
-  ;; rf2-cwhod2: same-length vectors now diff element-by-element under
-  ;; numeric index paths — a reorder of [1 2 3] → [3 2 1] differs at
-  ;; indices 0 and 2 and emits index-level patches, not a whole-vector
-  ;; replacement. This is the actionable item-level shape the token-budget
-  ;; premise needs for tables / cards / queues / logs.
+  ;; Same-length vectors diff element-by-element under numeric index
+  ;; paths — a reorder of [1 2 3] → [3 2 1] differs at indices 0 and 2
+  ;; and emits index-level patches, not a whole-vector replacement. This
+  ;; is the actionable item-level shape the token-budget premise needs
+  ;; for tables / cards / queues / logs.
   (is (= [[[:items 0] :assoc 3]
           [[:items 2] :assoc 1]]
          (diff/collect-patches {:items [1 2 3]} {:items [3 2 1]} [])))
@@ -118,9 +118,9 @@
                   :user {:id 7}}})
 
 (deftest diff-encode-db-after-replaces-db-after-with-marker
-  ;; rf2-qeous: the wire shape is path-headed cluster sections, not a
-  ;; flat patch list. The `:rf.mcp/diff-from` marker stays the same;
-  ;; the body slot moves from `:patches` to `:sections`.
+  ;; The wire shape is path-headed cluster sections, not a flat patch
+  ;; list. The `:rf.mcp/diff-from` marker tags the source slot; the body
+  ;; lives under `:sections`.
   (let [enc (diff/diff-encode-db-after fixture-epoch)
         da  (:db-after enc)]
     (is (= :db-before (:rf.mcp/diff-from da))
@@ -158,9 +158,8 @@
         "encode→decode round-trips the full epoch unchanged")))
 
 (deftest round-trip-identical-db-before-and-db-after
-  ;; Degenerate case: no change. Sections list is empty (per the
-  ;; rf2-qeous shape — empty patches → empty sections); decoder
-  ;; returns :db-before unchanged.
+  ;; Degenerate case: no change. Sections list is empty (empty patches →
+  ;; empty sections); decoder returns :db-before unchanged.
   (let [epoch (assoc fixture-epoch :db-after (:db-before fixture-epoch))
         enc   (diff/diff-encode-db-after epoch)
         dec   (diff/decode-db-after enc)]
@@ -180,12 +179,11 @@
 
 (deftest round-trip-deeply-nested-leaf-change
   ;; The load-bearing efficiency case: one tiny change in a deeply
-  ;; nested tree. Per rf2-qeous the wire shape is now sections-per-
-  ;; cluster — the encoded :db-after carries the section wrapper
-  ;; (~60-80 chars constant overhead per cluster) plus the patches
-  ;; themselves. The win still scales: when the unchanged parts
-  ;; truly dwarf the change, the encoded :db-after is a small
-  ;; fraction of the full one.
+  ;; nested tree. The wire shape is sections-per-cluster — the encoded
+  ;; :db-after carries the section wrapper (~60-80 chars constant
+  ;; overhead per cluster) plus the patches themselves. The win scales:
+  ;; when the unchanged parts truly dwarf the change, the encoded
+  ;; :db-after is a small fraction of the full one.
   (let [;; Build a wide map so the unchanged parts dwarf the change.
         ;; 200 keys × ~30 chars each ≈ 6KB of unchanged context.
         wide (into {} (for [i (range 200)]
@@ -228,8 +226,8 @@
           ":b was removed → surfaces as a :dissoc patch inside the section"))))
 
 (deftest round-trip-vector-reordering
-  ;; Same-length vectors diff element-wise (rf2-cwhod2) under index paths;
-  ;; the round-trip MUST still reconstruct exactly regardless of patch
+  ;; Same-length vectors diff element-wise under index paths; the
+  ;; round-trip MUST still reconstruct exactly regardless of patch
   ;; granularity.
   (let [epoch {:db-before {:items [1 2 3]}
                :db-after  {:items [3 2 1]}}
@@ -371,7 +369,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Wire-size impact: 10-epoch window with a 1MB app-db, single-key
-;; change per epoch — the load-bearing scenario rf2-jlq5j flagged.
+;; change per epoch — the load-bearing scenario.
 ;; ---------------------------------------------------------------------------
 
 (deftest ten-epoch-window-with-1mb-app-db-shrinks-dramatically

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_freshness_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_freshness_test.cljs
@@ -1,10 +1,10 @@
 (ns re-frame2-pair-mcp.discover-app-freshness-test
-  "discover-app attaches the freshness/liveness token (rf2-ertqw).
+  "discover-app attaches the freshness/liveness token.
 
   The token rides on every `:ok? true` discover-app payload so an agent
   sees 'this runtime is fresh / stale-build / disconnected' on the very
-  first call — the signal that would have killed the rf2-lo28u
-  stale-build false-alarm detour up front. These tests pin:
+  first call — the signal that heads off a stale-build false-alarm detour
+  up front. These tests pin:
 
     1. a healthy discover-app carries `:freshness` with `:liveness
        :fresh`;
@@ -27,7 +27,7 @@
 
 (def ^:private health-with-browser-half
   "A `(runtime/health)` payload carrying the browser-half freshness
-  fields the runtime preload now stamps (rf2-ertqw)."
+  fields the runtime preload stamps."
   {:ok?                        true
    :debug-enabled?             true
    :coord-annotation-enabled?  true

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_representation_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_representation_test.cljs
@@ -1,11 +1,11 @@
 (ns re-frame2-pair-mcp.discover-app-representation-test
-  "Pin the id-representation contract of discover-app's output (rf2-cg37y).
+  "Pin the id-representation contract of discover-app's output.
 
-  First live pair session (2026-05-29) surfaced that discover-app
-  responses mixed id forms WITHIN one payload — running-builds /
-  frames as short names (`step-deck`) in one place, full keywords
-  (`:examples/step-deck`) in the adjacent hint string. A first-time
-  caller had to guess which field used which form.
+  A discover-app response must use ONE id form throughout a payload —
+  never running-builds / frames as short names (`step-deck`) in one place
+  and full keywords (`:examples/step-deck`) in the adjacent hint string,
+  which would force a first-time caller to guess which field used which
+  form.
 
   ## The contract these tests pin
 
@@ -38,8 +38,8 @@
 
 (def ^:private multi-frame-health
   "An ambiguous-frame health payload — exercises the `:note` string
-  branch that embeds the frame ids, the place the representation mix
-  was first seen."
+  branch that embeds the frame ids, where representation consistency
+  matters most."
   {:ok?                        true
    :debug-enabled?             true
    :coord-annotation-enabled?  true

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_reserved_frame_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_reserved_frame_test.cljs
@@ -1,13 +1,12 @@
 (ns re-frame2-pair-mcp.discover-app-reserved-frame-test
-  "Pin discover-app's reserved-frame-aware operating-frame resolution
-  (rf2-3bu3d.4).
+  "Pin discover-app's reserved-frame-aware operating-frame resolution.
 
-  ROOT CAUSE this fixes: any app instrumented with Xray carries a
-  `:rf/xray` TOOL frame alongside its one app frame. The pre-fix
-  ambiguity logic counted ALL frames, so EVERY Xray-instrumented app (the
-  common pairing case) was reported `:ambiguous-frame` on discover-app —
-  forcing a `frames/select` + retry up front for a choice that didn't
-  exist (there is exactly ONE app frame).
+  CONTEXT: any app instrumented with Xray carries a `:rf/xray` TOOL frame
+  alongside its one app frame. The ambiguity logic excludes reserved
+  `:rf/*` tool frames from the count, so an Xray-instrumented app (the
+  common pairing case) with exactly ONE app frame is NOT reported
+  `:ambiguous-frame` on discover-app — no `frames/select` + retry tax for
+  a choice that doesn't exist.
 
   CONTRACT these tests pin (the runtime's `health` computes the
   reserved-frame-aware `:ambiguous-frame?` + `:app-frames`; discover-app

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
@@ -1,13 +1,13 @@
 (ns re-frame2-pair-mcp.dispatch-dry-run-test
-  "Unit tests for the dispatch-dry-run tool (rf2-17hvp + rf2-z7roa).
+  "Unit tests for the dispatch-dry-run tool.
 
   Simulate a re-frame2 cascade without committing — the framework's
-  existing `:fx-overrides` + `restore-epoch` primitives compose into a
-  true dry-run on the runtime side. The MCP tool is a thin wrapper
-  that parses the event-vector arg (same EDN-data posture as
-  `dispatch`, rf2-vflrg) and surfaces the structured runtime envelope.
+  `:fx-overrides` + `restore-epoch` primitives compose into a true
+  dry-run on the runtime side. The MCP tool is a thin wrapper that parses
+  the event-vector arg (same EDN-data posture as `dispatch`) and surfaces
+  the structured runtime envelope.
 
-  rf2-z7roa — dry-run is an AI-facing READ surface: its
+  Dry-run is an AI-facing READ surface: its
   `:db-state-after-simulation` (would-be app-db) and
   `:would-fire-effects[*].args` (fx-derived) slots are off-box egress.
   The tool runs them through the elision walker server-side BY DEFAULT
@@ -79,7 +79,7 @@
         (.finally (fn [] (raw-state/set-allow-raw-state! prev))))))
 
 ;; ---------------------------------------------------------------------------
-;; Arg parsing — mirrors dispatch's rf2-vflrg gate exactly.
+;; Arg parsing — mirrors dispatch's event-vector gate exactly.
 ;; ---------------------------------------------------------------------------
 
 (deftest rejects-arbitrary-cljs-source
@@ -148,8 +148,8 @@
 
 (deftest threads-fx-overrides-arg
   ;; User-supplied :fx-overrides ride into the runtime opts; the
-  ;; runtime merges them on top of the dry-run override set. rf2-hf7m9j —
-  ;; the documented colon-prefixed string target `":stub-http"` MUST
+  ;; runtime merges them on top of the dry-run override set. The
+  ;; documented colon-prefixed string target `":stub-http"` MUST
   ;; coerce to the KEYWORD `:stub-http` in the emitted opts, never the
   ;; raw string (which core silently falls through to the original fx,
   ;; defeating the no-fx-execute guarantee).
@@ -171,8 +171,8 @@
                    (done)))))))
 
 (deftest rejects-string-fx-overrides-target
-  ;; rf2-hf7m9j — a bare (non-colon) string override target can't redirect
-  ;; over the wire (core would silently fall it through to the real fx).
+  ;; A bare (non-colon) string override target can't redirect over the
+  ;; wire (core would silently fall it through to the real fx).
   ;; For dry-run that defeats the no-fx-execute guarantee, so reject it as
   ;; an :isError envelope BEFORE the eval rather than ship a broken stub.
   (async done
@@ -190,7 +190,7 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-3q7gep · EP-0017 — scripted recordable coeffects. Identical posture
+;; EP-0017 — scripted recordable coeffects. Identical posture
 ;; to `dispatch`'s `cofx`: the agent supplies a `cofx "{:rf/time-ms …}"`
 ;; EDN map (the shared `args/parse-cofx` gate), threaded into the simulated
 ;; dispatch opts under the flat `:rf.cofx` key. The router preserves it
@@ -200,7 +200,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest cofx-threaded-into-opts-under-flat-key
-  ;; The headline rf2-3q7gep case: `cofx "{:rf/time-ms 1781078400123}"`
+  ;; The headline case: `cofx "{:rf/time-ms 1781078400123}"`
   ;; must appear in the emitted runtime opts under the flat `:rf.cofx`
   ;; key, as DATA (the exact integer time), so the router preserves it
   ;; verbatim and the simulation is reproducible — NOT a freshly stamped
@@ -303,7 +303,7 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-z7roa — privacy gate. Gate OFF (default published posture) forces
+;; Privacy gate. Gate OFF (default published posture) forces
 ;; the elision walker on AND forces sensitive slots to redact; the form
 ;; must carry the walker call + the safe opts. The runtime envelope's
 ;; egress slots are walked server-side (the unit test stubs the runtime,
@@ -341,8 +341,8 @@
                    (done)))))))
 
 (deftest gate-off-signals-configure-raw-state-before-dispatch
-  ;; The raw-state tap posture (rf2-c2dtu) is signalled before the
-  ;; dispatch eval, so the dry-run's internal restore-epoch tap is gated.
+  ;; The raw-state tap posture is signalled before the dispatch eval, so
+  ;; the dry-run's internal restore-epoch tap is gated.
   (async done
     (let [forms (atom [])]
       (-> (with-raw-gate! false
@@ -364,12 +364,10 @@
                    (done)))))))
 
 (deftest gate-on-bare-elision-false-still-walks
-  ;; rf2-t55hxg.13 — fail-CLOSED. Pre-fix this asserted that gate-ON +
-  ;; `:elision false` shipped the db slot raw with NO walker — which let a
-  ;; declared-sensitive db slot leak off-box WITHOUT the per-call
-  ;; `:include-sensitive true` opt-in (the EP-0015 two-key gate collapse).
-  ;; A BARE `:elision false` now STILL walks: large content passes
-  ;; (`include-large? true`) but a declared-sensitive db slot redacts.
+  ;; Fail-CLOSED. A BARE `:elision false` (gate ON, no per-call
+  ;; `:include-sensitive true` opt-in) STILL walks: large content passes
+  ;; (`include-large? true`) but a declared-sensitive db slot redacts —
+  ;; never a raw off-box leak via the EP-0015 two-key gate.
   (async done
     (let [forms (atom [])]
       (-> (with-raw-gate! true
@@ -392,9 +390,9 @@
                    (done)))))))
 
 (deftest gate-on-full-raw-opt-in-skips-walker
-  ;; rf2-t55hxg.13 — the deliberate full-raw local opt-in (`:elision
-  ;; false` AND `:include-sensitive true`) is the ONLY combination that
-  ;; ships the db slot raw with no walker wrap.
+  ;; The deliberate full-raw local opt-in (`:elision false` AND
+  ;; `:include-sensitive true`) is the ONLY combination that ships the db
+  ;; slot raw with no walker wrap.
   (async done
     (let [forms (atom [])]
       (-> (with-raw-gate! true
@@ -432,7 +430,7 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-6to9xj — :would-fire-effects[*].args fail closed. The recorded fx
+;; :would-fire-effects[*].args fail closed. The recorded fx
 ;; args are RAW fx-handler arguments (HTTP bodies, dispatched event
 ;; vectors, payment maps) NOT rooted at app-db, so the schema-path
 ;; `elide-wire-value` walker cannot prove them safe — the same leak class
@@ -615,12 +613,12 @@
                    (done)))))))
 
 (deftest no-new-epoch-failure-rides-as-iserror
-  ;; rf2-wdxyx3 finding 2 — the reducer rejected the event or an
-  ;; interceptor early-returned, so the dry-run did NOT land. A known-tool
-  ;; runtime failure (`:ok? false`) MUST ride back as an isError envelope,
-  ;; matching the dispatch/read-sub no-silent-success parity model: the old
-  ;; ok-text shape let a non-landed dry-run read as green and be cache-
-  ;; eligible. The structured :reason/:hint rides through verbatim.
+  ;; The reducer rejected the event or an interceptor early-returned, so
+  ;; the dry-run did NOT land. A known-tool runtime failure (`:ok? false`)
+  ;; MUST ride back as an isError envelope, matching the
+  ;; dispatch/read-sub no-silent-success parity model (a non-landed
+  ;; dry-run must not read as green and become cache-eligible). The
+  ;; structured :reason/:hint rides through verbatim.
   (async done
     (let [env {:ok?    false
                :reason :no-new-epoch
@@ -638,10 +636,9 @@
                    (done)))))))
 
 (deftest non-map-runtime-result-surfaced-as-unexpected-shape
-  ;; A pre-rf2-17hvp runtime would not have `dispatch-dry-run` and the
-  ;; eval would return something other than the wrapped map. The tool
-  ;; surfaces that as a structured `:unexpected-shape` rather than
-  ;; silently returning the raw value.
+  ;; A runtime without `dispatch-dry-run` returns something other than
+  ;; the wrapped map. The tool surfaces that as a structured
+  ;; `:unexpected-shape` rather than silently returning the raw value.
   (async done
     (-> (with-captured-eval! (atom []) "not-a-map"
           (fn []

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.dispatch-test
-  "Unit tests for the dispatch tool's event-arg parsing (rf2-vflrg).
+  "Unit tests for the dispatch tool's event-arg parsing.
 
   The dispatch surface is intentionally narrower than `eval-cljs`:
   the contract is an EDN event vector, nothing else. These tests pin
@@ -13,7 +13,7 @@
 
       MCP arg (string) → read-string → vector check → rt-call data arg
                               ↑
-                              the security gate (rf2-vflrg)"
+                              the security gate"
   (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
             [cljs.reader]
             [clojure.string :as str]
@@ -22,22 +22,22 @@
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.dispatch :as dispatch]))
 
-;; ## Stub lifetime — fixture-scoped, not Promise-chain-scoped (rf2-wb06a)
+;; ## Stub lifetime — fixture-scoped, not Promise-chain-scoped
 ;;
 ;; `with-captured-eval!` installs its `cljs-eval-value` stub via a bare
 ;; `set!` (no per-test `.finally`); the `:after` fixture below restores
 ;; the pristine original captured at ns-load. A `.finally`-scoped restore
-;; fires AFTER cljs.test's `done` has advanced to the NEXT test (often the
-;; next NAMESPACE, e.g. orient-test), where it clobbers that neighbour's
-;; freshly-installed stub mid-eval — surfacing as a `captured = nil`
-;; (the orient-test failure) or a real-socket `EADDRNOTAVAIL`. The fixture
-;; boundary closes that race (the same fix orient_test / invoke_test carry).
+;; would fire AFTER cljs.test's `done` has advanced to the NEXT test
+;; (often the next NAMESPACE, e.g. orient-test), where it would clobber
+;; that neighbour's freshly-installed stub mid-eval — surfacing as a
+;; `captured = nil` or a real-socket `EADDRNOTAVAIL`. The fixture boundary
+;; closes that race (the same shape orient_test / invoke_test carry).
 ;;
 ;; The `--allow-sensitive-reads` boot gate is also module-level state: the
-;; rf2-olvr5 finding-1 tests set it SYNCHRONOUSLY inside each body-fn
-;; (immediately before the synchronous form build, no intervening await)
-;; and the `:after` fixture resets it to the published default (OFF) so a
-;; gate-ON test can't leak its posture into a neighbour.
+;; gate-ON tests set it SYNCHRONOUSLY inside each body-fn (immediately
+;; before the synchronous form build, no intervening await) and the
+;; `:after` fixture resets it to the published default (OFF) so a gate-ON
+;; test can't leak its posture into a neighbour.
 
 (def ^:private pristine-eval nrepl/cljs-eval-value)
 
@@ -45,11 +45,11 @@
   {:after (fn []
             (set! nrepl/cljs-eval-value pristine-eval)
             (raw-state/set-allow-raw-state! false)
-            ;; rf2-8fin7.3 — dispatch now issues `signal-runtime!` (the
-            ;; boot-gate posture push) before its eval, which records an
-            ;; in-flight entry in the per-build `runtime-signalling` map.
-            ;; Clear it between tests so a build-id can't leak a stale
-            ;; in-flight Promise into a neighbour.
+            ;; Dispatch issues `signal-runtime!` (the boot-gate posture
+            ;; push) before its eval, which records an in-flight entry in
+            ;; the per-build `runtime-signalling` map. Clear it between
+            ;; tests so a build-id can't leak a stale in-flight Promise
+            ;; into a neighbour.
             (raw-state/reset-runtime-signal-cache!))})
 
 ;; ---------------------------------------------------------------------------
@@ -67,16 +67,15 @@
 (defn- with-captured-eval!
   "Install a stub `cljs-eval-value` that records the DISPATCH form string
   into `captured*` and resolves to `canned-value`. Cleanup is the
-  `:after` fixture's job (rf2-wb06a) — NOT a per-call `.finally`, which
-  fires after `done` and races a neighbour's stub.
+  `:after` fixture's job — NOT a per-call `.finally`, which fires after
+  `done` and races a neighbour's stub.
 
-  rf2-8fin7.3 — dispatch now issues `configure-raw-state!`
-  (`signal-runtime!`) BEFORE the dispatch eval. That signal form is
-  resolved to nil (swallowed by signal-runtime!) and is NOT recorded
-  into `captured*`, so the single-capture tests below still see the
-  dispatch form (the one that mentions a dispatch runtime fn / the
-  await wrapper). The per-build signal cache is reset so the signal
-  always fires its eval."
+  Dispatch issues `configure-raw-state!` (`signal-runtime!`) BEFORE the
+  dispatch eval. That signal form resolves to nil (swallowed by
+  signal-runtime!) and is NOT recorded into `captured*`, so the
+  single-capture tests below still see the dispatch form (the one that
+  mentions a dispatch runtime fn / the await wrapper). The per-build
+  signal cache is reset so the signal always fires its eval."
   [captured* canned-value body-fn]
   (let [run (fn [form-str]
               ;; The boot-gate signal resolves to nil and is not captured —
@@ -96,10 +95,9 @@
 (defn- with-captured-forms!
   "Like `with-captured-eval!` but records EVERY form string (the
   `configure-raw-state!` signal AND the dispatch eval) into `forms*` in
-  order, so a test can assert their RELATIVE ordering (the rf2-8fin7.3
-  path-3 invariant: signal-runtime! fires BEFORE the dispatch eval). The
-  configure form resolves to nil; every other form resolves to
-  `canned-value`."
+  order, so a test can assert their RELATIVE ordering (the invariant that
+  signal-runtime! fires BEFORE the dispatch eval). The configure form
+  resolves to nil; every other form resolves to `canned-value`."
   [forms* canned-value body-fn]
   (let [run (fn [form-str]
               (swap! forms* conj form-str)
@@ -116,7 +114,7 @@
         (.then (fn [_] (body-fn))))))
 
 ;; `read-result-text` (EDN read of the wire envelope) and `err?` are the
-;; shared extractors (rf2-wnrpi) — aliased from `test-utils`.
+;; shared extractors — aliased from `test-utils`.
 (def ^:private read-result-text tu/extract-edn)
 (def ^:private err? tu/error?)
 
@@ -125,12 +123,10 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest rejects-arbitrary-cljs-source
-  ;; The headline rf2-vflrg case: an attacker / a prompt-injected
-  ;; agent supplies host-form source instead of an event vector. The
-  ;; pre-fix shape inlined this via `rt-raw`, so `(println :pwned)`
-  ;; would have run inside the runtime eval. Post-fix: the parser
-  ;; reads it as a list, the vector-check fails, the runtime is
-  ;; never contacted.
+  ;; The headline case: an attacker / a prompt-injected agent supplies
+  ;; host-form source instead of an event vector. The parser reads it as
+  ;; a list, the vector-check fails, the runtime is never contacted —
+  ;; `(println :pwned)` never runs inside the runtime eval.
   (async done
     (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "(println :pwned)"})
         (.then (fn [r]
@@ -176,13 +172,14 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-wz66k7 — `:timeout-ms` (the `:await-render` deadline) is validated
-;; as a positive-millisecond integer BEFORE the dispatch eval. A
-;; non-numeric value (`"bogus"`) made `await-promise/poll-mailbox!`'s
+;; `:timeout-ms` (the `:await-render` deadline) is validated as a
+;; positive-millisecond integer BEFORE the dispatch eval. A non-numeric
+;; value (`"bogus"`) would make `await-promise/poll-mailbox!`'s
 ;; `(>= elapsed timeout-ms)` deadline `(>= n NaN)` — never true — so the
-;; render-settle mailbox poll loop ran FOREVER. The tool now short-circuits
-;; to an honest validation error WITHOUT touching nREPL (the validation is
-;; the first `cond` branch, ahead of the event-parse + eval).
+;; render-settle mailbox poll loop would run FOREVER. The tool
+;; short-circuits to an honest validation error WITHOUT touching nREPL
+;; (the validation is the first `cond` branch, ahead of the event-parse
+;; + eval).
 ;; ---------------------------------------------------------------------------
 
 (deftest bogus-timeout-ms-rejected-before-touching-nrepl
@@ -238,8 +235,8 @@
 (deftest accepts-edn-vector-and-emits-data-arg
   ;; Happy path: `[:cart/checkout]` reads as a vector, flows into
   ;; `rt-call` as a normal data arg, and emits as a pr-str'd literal
-  ;; inside the runtime call. rf2-3bu3d.2 — the DEFAULT now routes
-  ;; through `dispatch-consequence!` (validate + echo + consequence).
+  ;; inside the runtime call. The DEFAULT routes through
+  ;; `dispatch-consequence!` (validate + echo + consequence).
   (async done
     (let [captured (atom nil)]
       (-> (with-captured-eval! captured {:ok? true :epoch-id 7 :db-changed? false
@@ -251,7 +248,7 @@
                    (is (not (err? r)))
                    (let [form @captured]
                      (is (string? form))
-                     ;; The default runtime call is now
+                     ;; The default runtime call is
                      ;; `(rt/dispatch-consequence! [:cart/checkout] {})`.
                      ;; The event vector rides as an EDN literal — pinned
                      ;; via the `pr-str` shape.
@@ -283,7 +280,7 @@
                    (done)))))))
 
 (deftest sync-mode-routes-to-dispatch-consequence
-  ;; rf2-3bu3d.2 — `:sync true` (like the default) routes through
+  ;; `:sync true` (like the default) routes through
   ;; `dispatch-consequence!`, the validate+echo+consequence surface.
   (async done
     (let [captured (atom nil)]
@@ -307,14 +304,14 @@
                    (done)))))))
 
 (deftest settle-mode-routes-to-dispatch-and-settle
-  ;; rf2-vk79g — `:settle true` routes to the SYNCHRONOUS runtime
+  ;; `:settle true` routes to the SYNCHRONOUS runtime
   ;; `dispatch-and-settle!` (dispatch-sync → flush-render! → re-read the
   ;; settled epoch). Unlike `:await-render`, the runtime fn returns a map
   ;; directly, so the emitted form is the ordinary `rt-call` (NOT the
   ;; await-promise mailbox wrapper).
   ;;
-  ;; rf2-m9duxl — gate ON + `:include-sensitive true` does NOT bypass the
-  ;; epoch projection. The settle form STILL wraps the runtime call in
+  ;; Gate ON + `:include-sensitive true` does NOT bypass the epoch
+  ;; projection. The settle form STILL wraps the runtime call in
   ;; `projected-record`, threading `{:include-sensitive? true}` as the
   ;; egress opt (app-db sensitive axis ONLY). The inner runtime fn is still
   ;; `dispatch-and-settle!` (no mailbox wrapper — synchronous). The
@@ -356,7 +353,7 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-olvr5 finding 1 — epoch-bearing dispatch modes project before egress.
+;; Epoch-bearing dispatch modes project before egress.
 ;;
 ;; `:trace` (dispatch-and-collect) and `:settle` (dispatch-and-settle!)
 ;; return RAW `:epoch` records (db-before / db-after / trigger-event /
@@ -364,9 +361,9 @@
 ;; `--allow-sensitive-reads` gate OFF (the published default) the emitted
 ;; form MUST route the result's epoch slots through
 ;; `re-frame.core/projected-record` APP-SIDE before crossing the wire —
-;; mirroring the pull-mode trace-window / watch-epochs egress (rf2-6wvh5).
-;; The default sync / queued consequence shapes carry no raw app-db, so
-;; they stay un-wrapped.
+;; mirroring the pull-mode trace-window / watch-epochs egress. The default
+;; sync / queued consequence shapes carry no raw app-db, so they stay
+;; un-wrapped.
 ;; ---------------------------------------------------------------------------
 
 (deftest settle-projects-epoch-by-default-when-gate-off
@@ -410,7 +407,7 @@
                    (done)))))))
 
 (deftest trace-include-sensitive-routes-through-projection-when-gate-on
-  ;; rf2-m9duxl — gate ON (--allow-sensitive-reads) AND explicit
+  ;; Gate ON (--allow-sensitive-reads) AND explicit
   ;; `:include-sensitive true` does NOT bypass the epoch projection. The
   ;; trace form STILL wraps the runtime call in `projected-record`,
   ;; threading `{:include-sensitive? true}` (app-db sensitive axis ONLY).
@@ -459,17 +456,18 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-8fin7.3 — boot-gate signal (path 3): the DEFAULT cascade-summary
-;; `:event-vector` redaction.
+;; Boot-gate signal: the DEFAULT cascade-summary `:event-vector`
+;; redaction.
 ;;
 ;; `redact-sensitive-event-vector` (runtime) redacts the cascade-summary's
 ;; `:event-vector` (the raw `:trigger-event`) ONLY when the runtime's
 ;; `raw-state-config` is at `{:allow-raw-state? false}`. That config
 ;; DEFAULTS to `:allow-raw-state? true` and flips to the server's gate
 ;; state ONLY when a tool calls `configure-raw-state!` via
-;; `raw-state/signal-runtime!`. Before this fix `dispatch` never signalled,
-;; so a FIRST-in-session sensitive dispatch ran with the runtime still
-;; permissive and shipped the raw event vector under the default OFF gate.
+;; `raw-state/signal-runtime!`. So `dispatch` MUST signal before its eval;
+;; otherwise a FIRST-in-session sensitive dispatch would run with the
+;; runtime still permissive and ship the raw event vector under the
+;; default OFF gate.
 ;;
 ;; These tests assert the WIRE BOUNDARY: that `dispatch` emits the
 ;; `configure-raw-state!` signal BEFORE its dispatch eval, carrying the
@@ -482,8 +480,8 @@
   ;; (no trace / settle) MUST signal `configure-raw-state!` with
   ;; `:allow-raw-state? false` BEFORE the dispatch-consequence! eval — so
   ;; the runtime flips out of its permissive default and the
-  ;; cascade-summary `:event-vector` redacts for a sensitive epoch. This is
-  ;; the rf2-8fin7.3 broadening: the leak is NOT trace-mode-only.
+  ;; cascade-summary `:event-vector` redacts for a sensitive epoch. The
+  ;; redaction covers the default path, not trace-mode only.
   (async done
     (let [forms (atom [])]
       (-> (with-captured-forms! forms {:ok? true :epoch-id 7 :db-changed? false}
@@ -621,7 +619,7 @@
 (deftest settle-runtime-failure-surfaces-as-error
   ;; A frame-untargetable settle (the runtime's pair-dispatch-sync!
   ;; :ok? false rides through dispatch-and-settle! verbatim) must surface
-  ;; as an :isError envelope WITHOUT a :mode slot — the rf2-ldfnx
+  ;; as an :isError envelope WITHOUT a :mode slot — the failure-envelope
   ;; invariant holds through the settle path too.
   (async done
     (let [runtime-result {:ok?    false
@@ -644,11 +642,11 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Dispatch CONSEQUENCE (rf2-3bu3d.2) + echo/validate (rf2-3bu3d.3) — the
-;; DEFAULT now returns the re-frame2 consequence, not a transport ack. A
-;; no-op is VISIBLE; an unknown event-id is VALIDATED at the boundary and
-;; returns a structured error with nearest matches, never a silent
-;; success; the resolved event is ECHOed back.
+;; Dispatch CONSEQUENCE + echo/validate — the DEFAULT returns the
+;; re-frame2 consequence, not a transport ack. A no-op is VISIBLE; an
+;; unknown event-id is VALIDATED at the boundary and returns a structured
+;; error with nearest matches, never a silent success; the resolved event
+;; is ECHOed back.
 ;; ---------------------------------------------------------------------------
 
 (deftest default-returns-consequence-shape
@@ -673,13 +671,13 @@
                      (is (= [:db] (:effects-fired edn)))
                      (is (false? (:no-op? edn)))
                      (is (= [:counter/inc] (:resolved edn))
-                         "the resolved event is echoed back (rf2-3bu3d.3)"))
+                         "the resolved event is echoed back"))
                    (done)))))))
 
 (deftest no-op-is-visible
-  ;; The headline rf2-3bu3d.2 fix: a dispatch that changed no app-db path
-  ;; and fired no effect returns :db-changed? false :effects-fired []
-  ;; :no-op? true — NOT a fake {:mode :sync} ack.
+  ;; The headline case: a dispatch that changed no app-db path and fired
+  ;; no effect returns :db-changed? false :effects-fired [] :no-op? true
+  ;; — NOT a bare {:mode :sync} ack.
   (async done
     (let [runtime-result {:ok? true :epoch-id 8
                           :db-changed? false :changed-paths []
@@ -699,9 +697,9 @@
                    (done)))))))
 
 (deftest unknown-event-id-validated-not-dispatched
-  ;; rf2-3bu3d.3 — the runtime dispatch-consequence! short-circuits on a
-  ;; validation miss, returning :reason :unknown-id with :nearest matches.
-  ;; The tool surfaces it as an :isError envelope (no silent success).
+  ;; The runtime dispatch-consequence! short-circuits on a validation
+  ;; miss, returning :reason :unknown-id with :nearest matches. The tool
+  ;; surfaces it as an :isError envelope (no silent success).
   (async done
     (let [runtime-result {:ok? false :reason :unknown-id :kind :event
                           :id :rf/xrayy :event [:rf/xrayy]
@@ -725,12 +723,12 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Cascade summary (rf2-6yqdl) — the runtime's `:cascade-summary` slot
-;; rides through the dispatch tool unchanged.
+;; Cascade summary — the runtime's `:cascade-summary` slot rides through
+;; the dispatch tool unchanged.
 ;; ---------------------------------------------------------------------------
 
 (deftest cascade-summary-passes-through-on-sync-mode
-  ;; The runtime now returns a structured envelope including
+  ;; The runtime returns a structured envelope including
   ;; `:cascade-summary`. The dispatch tool's merge path
   ;; `(merge {:mode mode} (when (map? v) v))` must thread the slot
   ;; through to the wire envelope unchanged.
@@ -767,19 +765,19 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Frame targeting (rf2-ldfnx) — the colon-prefixed `frame` arg must route
-;; to the named frame, NOT the malformed `::rf/xray` the raw `(keyword ...)`
-;; coercion minted. Reproduces the live silent-wrong-success: `frame
-;; ":rf/xray"` reported `{:mode :sync}` while no-op'ing on the named frame.
+;; Frame targeting — the colon-prefixed `frame` arg must route to the
+;; named frame, NOT the malformed `::rf/xray` that a raw `(keyword ...)`
+;; coercion would mint. A string-form frame must never become a
+;; `{:mode :sync}` success that silently no-op'd on the named frame.
 ;; ---------------------------------------------------------------------------
 
 (deftest colon-prefixed-frame-routes-to-named-frame
   ;; The documented `frame` arg form is colon-prefixed (`":rf/xray"` —
-  ;; Tool-Catalogue §Id representation, rf2-cg37y). Pre-fix the tool
-  ;; coerced it with raw `(keyword ":rf/xray")`, which mints the
-  ;; MALFORMED `::rf/xray` (namespace literally `":rf"`) — a frame the
-  ;; runtime never registered, so dispatch silently no-op'd. The emitted
-  ;; opts map MUST carry the well-formed `:rf/xray`.
+  ;; Tool-Catalogue §Id representation). A raw `(keyword ":rf/xray")`
+  ;; coercion would mint the MALFORMED `::rf/xray` (namespace literally
+  ;; `":rf"`) — a frame the runtime never registered, so dispatch would
+  ;; silently no-op. The emitted opts map MUST carry the well-formed
+  ;; `:rf/xray`.
   (async done
     (let [captured (atom nil)]
       (-> (with-captured-eval! captured {:ok? true :epoch-id 7}
@@ -837,11 +835,10 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Success-vs-error contract (rf2-ldfnx) — a runtime `{:ok? false ...}`
-;; (the frame-untargetable / no-epoch result) MUST surface as an :isError
-;; envelope WITHOUT a `:mode` slot. The pre-fix shape merged `{:mode :sync}`
-;; over the failure and emitted a success envelope — the silent
-;; wrong-success the bead targets.
+;; Success-vs-error contract — a runtime `{:ok? false ...}` (the
+;; frame-untargetable / no-epoch result) MUST surface as an :isError
+;; envelope WITHOUT a `:mode` slot, never a `{:mode :sync}` merged over
+;; the failure (which would be a silent wrong-success).
 ;; ---------------------------------------------------------------------------
 
 (deftest runtime-failure-surfaces-as-error-not-mode-success
@@ -896,8 +893,8 @@
                    (done)))))))
 
 (deftest cascade-summary-pending-passes-through-on-queued-mode
-  ;; Queued dispatch (`:queued true`, rf2-3bu3d.2) may return BEFORE the
-  ;; cascade drains. The runtime reports `:cascade-summary-pending? true`
+  ;; Queued dispatch (`:queued true`) may return BEFORE the cascade
+  ;; drains. The runtime reports `:cascade-summary-pending? true`
   ;; and `:before-epoch-id`; the tool surfaces them verbatim PLUS
   ;; `:settled? false` so callers poll watch-epochs from the recorded
   ;; pre-dispatch head.
@@ -927,7 +924,7 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Render-settle — `:await-render` (rf2-gfu33).
+;; Render-settle — `:await-render`.
 ;;
 ;; `dispatch :await-render true` resolves only AFTER the substrate has
 ;; flushed the new state to the DOM and the next paint is scheduled, so
@@ -991,9 +988,9 @@
                ([_conn _build-id form-str] (respond form-str))
                ([_conn _build-id form-str _opts] (respond form-str)))]
     (set! nrepl/cljs-eval-value stub)
-    ;; rf2-8fin7.3 — the configure-raw-state! signal hits the `:else`
-    ;; branch (it is neither the await wrapper nor a mailbox read) and
-    ;; resolves to nil; reset the signal cache so it fires each test.
+    ;; The configure-raw-state! signal hits the `:else` branch (it is
+    ;; neither the await wrapper nor a mailbox read) and resolves to nil;
+    ;; reset the signal cache so it fires each test.
     (raw-state/reset-runtime-signal-cache!)
     (-> (js/Promise.resolve nil)
         (.then (fn [_] (body-fn))))))
@@ -1027,7 +1024,7 @@
                          "no sleep — deterministic settle, not a timer")
                      ;; await-render forces sync dispatch (cascade must
                      ;; commit before the render can settle) — routed
-                     ;; through the consequence surface (rf2-3bu3d.2).
+                     ;; through the consequence surface.
                      (is (str/includes? form "dispatch-consequence!")
                          "await-render forces synchronous dispatch")
                      (is (str/includes? form ":settled? true")
@@ -1068,8 +1065,8 @@
 (deftest await-render-runtime-failure-surfaces-as-error
   ;; If the dispatch itself no-op'd (frame untargetable), the settle form
   ;; still resolves — but to the runtime's {:ok? false ...} envelope. The
-  ;; tool MUST surface that as an :isError (the rf2-ldfnx invariant holds
-  ;; through the settle path), never a {:mode :sync :settled? true}
+  ;; tool MUST surface that as an :isError (the failure-envelope invariant
+  ;; holds through the settle path), never a {:mode :sync :settled? true}
   ;; success.
   (async done
     (let [read-count* (atom 0)]
@@ -1119,15 +1116,15 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; fx-overrides wire shape (rf2-hf7m9j) — over JSON-MCP a caller can only
-;; send a JSON object, so an override TARGET arrives as a string
-;; (`{":http": ":stub-http"}` ⇒ value `":stub-http"`). The pre-fix parse
-;; (`js->clj :keywordize-keys true`) keywordized object KEYS only, leaving
-;; the value the string `":stub-http"`; core's `resolve-fx-with-overrides`
-;; then SILENTLY fell that string through to the original fx (the real
-;; http/navigate effect fires despite the recipe saying it was stubbed).
-;; The tool now coerces the documented colon-prefixed string target to a
-;; keyword and rejects any other value.
+;; fx-overrides wire shape — over JSON-MCP a caller can only send a JSON
+;; object, so an override TARGET arrives as a string
+;; (`{":http": ":stub-http"}` ⇒ value `":stub-http"`). A plain
+;; `js->clj :keywordize-keys true` parse keywordizes object KEYS only,
+;; leaving the value the string `":stub-http"`, which core's
+;; `resolve-fx-with-overrides` would SILENTLY fall through to the original
+;; fx (the real http/navigate effect firing despite the recipe saying it
+;; was stubbed). The tool coerces the documented colon-prefixed string
+;; target to a keyword and rejects any other value.
 ;; ---------------------------------------------------------------------------
 
 (deftest fx-overrides-colon-string-target-coerces-to-keyword
@@ -1182,21 +1179,20 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; cofx wire shape (rf2-q6s1nb / EP-0010 + EP-0017) — a scripted recordable-
-;; coeffect map is parsed as EDN data and threaded into the dispatch opts
-;; under the flat `:rf.cofx` key the router reads (which preserves a
-;; caller-supplied map verbatim). A dispatched event then carries the agent's
-;; exact `:rf/time-ms` / owner-qualified recordable facts, so the resulting
+;; cofx wire shape (EP-0010 + EP-0017) — a scripted recordable-coeffect
+;; map is parsed as EDN data and threaded into the dispatch opts under the
+;; flat `:rf.cofx` key the router reads (which preserves a caller-supplied
+;; map verbatim). A dispatched event then carries the agent's exact
+;; `:rf/time-ms` / owner-qualified recordable facts, so the resulting
 ;; state is REPRODUCIBLE — the agent-replay-determinism affordance the EP
-;; calls for. EP-0017 renamed the MCP arg `world-inputs` → `cofx`, the opts
-;; key `:rf.world/inputs` → `:rf.cofx`, and the time fact `:time-ms` →
-;; `:rf/time-ms`. A malformed value short-circuits to an :isError envelope
-;; before the eval rather than threading a value the runtime's
+;; calls for. The MCP arg is `cofx`, the opts key `:rf.cofx`, and the time
+;; fact `:rf/time-ms`. A malformed value short-circuits to an :isError
+;; envelope before the eval rather than threading a value the runtime's
 ;; :rf/dispatch-opts validation would reject.
 ;; ---------------------------------------------------------------------------
 
 (deftest cofx-threaded-into-opts-under-flat-key
-  ;; The headline rf2-q6s1nb case: `cofx "{:rf/time-ms 1781078400123}"`
+  ;; The headline case: `cofx "{:rf/time-ms 1781078400123}"`
   ;; must appear in the emitted runtime opts map under the flat `:rf.cofx`
   ;; key, as DATA (the exact integer time), so the router preserves it
   ;; verbatim and the dispatch is reproducible.
@@ -1304,7 +1300,7 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; Strict replay (rf2-v52xsr · EP-0017 §6 / Tool-Pair §Replay). Replay
+;; Strict replay (EP-0017 §6 / Tool-Pair §Replay). Replay
 ;; re-drives a recorded event through the app's own handlers by re-presenting
 ;; the recorded `:rf.cofx` UNDER `:rf.cofx/mint-policy :strict`, so a recorded
 ;; fact MISSING from the token fails LOUDLY (`:rf.error/missing-required-cofx`)
@@ -1314,7 +1310,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest replay-threads-strict-mint-policy-with-cofx
-  ;; The headline rf2-v52xsr case: `replay true` alongside a recorded `cofx`
+  ;; The headline case: `replay true` alongside a recorded `cofx`
   ;; must emit BOTH the recorded `:rf.cofx` AND `:rf.cofx/mint-policy :strict`
   ;; in the runtime opts — the per-call replay lever wins over the frame's
   ;; (default :live) config, so an incomplete record halts rather than mints.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dx_papercuts_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dx_papercuts_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.dx-papercuts-test
-  "Unit tests for the four re-frame2-pair DX papercuts (rf2-lbm21).
+  "Unit tests for four re-frame2-pair DX papercuts.
 
   1. Session-sticky operating build — an explicit `:build` on any
      non-discover tool call becomes the default for subsequent
@@ -11,7 +11,7 @@
      (`args/parse-paths-arg`) + the batch eval form
      (`get-path/batch-paths-form`) + the mutual-exclusion guard.
   4. Snapshot full-mode epoch overflow — `tree-summary`'s `:bytes`
-     hint now samples a representative entry so a slice of deep entries
+     hint samples a representative entry so a slice of deep entries
      (the `:epochs` slice) reports its full-expansion cost, and the
      `:epochs` slice is record-capped in full mode
      (`pipeline/cap-full-epochs-in-snapshot`).
@@ -210,8 +210,9 @@
 
 (deftest tree-summary-bytes-samples-deep-vector-entries
   ;; A vector of DEEP entries (each a fat map) must report a `:bytes`
-  ;; hint that reflects the per-entry depth — not the flat 8-per-entry
-  ;; constant that under-reported epoch slices ~1000x.
+  ;; hint that reflects the per-entry depth — sampling a representative
+  ;; entry, not a flat per-entry constant that would under-report epoch
+  ;; slices by orders of magnitude.
   (let [fat-entry (zipmap (map #(keyword (str "k" %)) (range 200)) (range 200))
         deep-vec  (vec (repeat 5 fat-entry))
         scalar-vec [1 2 3 4 5]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/egress_elision_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/egress_elision_test.cljs
@@ -1,28 +1,27 @@
 (ns re-frame2-pair-mcp.egress-elision-test
-  "Regression tests for the app-db egress-redaction fixes (rf2-6wvh5 +
-  rf2-f1ose) — same privacy class, shared fix.
+  "Regression tests for the app-db egress-redaction contract — same
+  privacy class across two pull-mode tools, one shared mechanism.
 
-  ## The bugs
+  ## What is guarded
 
-  Two pull-mode tools shipped raw slices of a live app's state off-box,
-  bypassing the redaction that snapshot / get-path / the `:epoch`
-  subscribe drain already route through:
+  Two pull-mode tools must NOT ship raw slices of a live app's state
+  off-box; they route through the same redaction that snapshot /
+  get-path / the `:epoch` subscribe drain use:
 
-    - rf2-6wvh5: `trace-window` / `watch-epochs` egress whole epoch
-      records carrying `:db-before` / `:db-after` (and `:trigger-event`
-      / `:trace-events`) app-db snapshots — a declared-sensitive slot
-      rode off-box verbatim because the pull-mode ring was never routed
-      through the framework's `re-frame.core/projected-record` egress
-      projection (the single normative off-box-egress emission site for
-      epoch records; core.cljc names the per-slot hand-walk an
-      anti-pattern \"one missed `mapv projected-record` away from a
-      leak\").
-    - rf2-f1ose: `list-subscriptions :include-values` ships each sub's
-      current `:value` (deref) raw — a value over a declared-sensitive
-      app-db slot leaked the same way. A sub-cache value is NOT an
-      epoch record, so its egress routes through the same
-      `re-frame.core/elide-wire-value` walker `snapshot`'s `:sub-cache`
-      slice uses (the two read the same reactive cache source).
+    - `trace-window` / `watch-epochs` egress whole epoch records carrying
+      `:db-before` / `:db-after` (and `:trigger-event` / `:trace-events`)
+      app-db snapshots — a declared-sensitive slot must NOT ride off-box
+      verbatim; the pull-mode ring routes through the framework's
+      `re-frame.core/projected-record` egress projection (the single
+      normative off-box-egress emission site for epoch records; core.cljc
+      names the per-slot hand-walk an anti-pattern \"one missed `mapv
+      projected-record` away from a leak\").
+    - `list-subscriptions :include-values` ships each sub's current
+      `:value` (deref) — a value over a declared-sensitive app-db slot
+      must not leak. A sub-cache value is NOT an epoch record, so its
+      egress routes through the same `re-frame.core/elide-wire-value`
+      walker `snapshot`'s `:sub-cache` slice uses (the two read the same
+      reactive cache source).
 
   ## What these tests pin
 
@@ -72,8 +71,8 @@
   {:before (fn []
              ;; The signal-runtime! cache is process-global; clear it so a
              ;; test's `configure-raw-state!` round-trip is never skipped by
-             ;; a prior test having already signalled the build (rf2-8fin7.2
-             ;; — snapshot / record / watch-until now issue signal-runtime!).
+             ;; a prior test having already signalled the build (snapshot /
+             ;; record / watch-until issue signal-runtime!).
              (raw-state/reset-runtime-signal-cache!))
    :after  (fn []
              (raw-state/set-allow-raw-state! false)
@@ -134,7 +133,7 @@
    :remaining     0})
 
 ;; ===========================================================================
-;; rf2-6wvh5 — trace-window epoch :db-* egress
+;; trace-window epoch :db-* egress
 ;; ===========================================================================
 
 (deftest trace-window-gate-off-projects-records
@@ -157,11 +156,11 @@
 
 (deftest trace-window-gate-on-include-sensitive-routes-through-projection
   (testing "gate ON + include-sensitive true: STILL projected, threading :include-sensitive? true under off-box-tool (rf2-m9duxl, rf2-nmjcll)"
-    ;; rf2-m9duxl — `:include-sensitive true` is NOT a raw bypass. It routes
-    ;; THROUGH `projected-record` as the `:include-sensitive? true` egress opt
+    ;; `:include-sensitive true` is NOT a raw bypass. It routes THROUGH
+    ;; `projected-record` as the `:include-sensitive? true` egress opt
     ;; (app-db sensitive axis only), composed OVER the off-box-tool profile
-    ;; floor (rf2-nmjcll). fx-args / runtime-db / large slots / `:redact-fn`
-    ;; stay fail-closed because we do NOT pass their opts.
+    ;; floor. fx-args / runtime-db / large slots / `:redact-fn` stay
+    ;; fail-closed because we do NOT pass their opts.
     (async done
       (raw-state/set-allow-raw-state! true)
       (let [forms (atom [])]
@@ -200,7 +199,7 @@
                        (done)))))))))
 
 ;; ===========================================================================
-;; rf2-6wvh5 — watch-epochs epoch record egress
+;; watch-epochs epoch record egress
 ;; ===========================================================================
 
 (deftest watch-epochs-gate-off-projects-records
@@ -243,21 +242,19 @@
 
 (deftest watch-epochs-gate-on-default-still-projects
   (testing "gate ON but include-sensitive omitted (default false): records STILL projected"
-    ;; rf2-ywn27.2 — the two-key opt-in fail-safe, the watch-epochs SIBLING
-    ;; of `trace-window-gate-on-default-still-projects` /
+    ;; The two-key opt-in fail-safe, the watch-epochs SIBLING of
+    ;; `trace-window-gate-on-default-still-projects` /
     ;; `snapshot-epochs-gate-on-default-still-projects`. The opt-in is
-    ;; TWO-KEY (epoch_egress.cljs:35-50): the launch flag
-    ;; --allow-sensitive-reads ALONE does NOT flip the per-call default.
-    ;; watch_epochs.cljs:61-63 computes `incl? (if (raw-state-allowed?)
-    ;; (parse-bool-arg ... :include-sensitive) false)` — gate-ON + omitted
-    ;; arg ⇒ parse-bool-arg false ⇒ incl? false ⇒ project? true. A
-    ;; regression that flipped the per-call default to true under the gate
-    ;; (e.g. `incl? (raw-state-allowed?)`, the plausible "the flag IS the
-    ;; opt-in" misreading) would leak raw epoch state on EVERY poll once an
-    ;; operator launched with the flag for ONE deliberate read. Pre-this
-    ;; the watch-epochs gate-ON coverage only asserted the
-    ;; include-sensitive:true case, so the flip shipped GREEN here while
-    ;; trace-window's identical regression WOULD be caught — asymmetric.
+    ;; TWO-KEY (epoch_egress.cljs): the launch flag --allow-sensitive-reads
+    ;; ALONE does NOT flip the per-call default. watch_epochs.cljs computes
+    ;; `incl? (if (raw-state-allowed?) (parse-bool-arg ... :include-sensitive)
+    ;; false)` — gate-ON + omitted arg ⇒ parse-bool-arg false ⇒ incl? false
+    ;; ⇒ project? true. A regression that flipped the per-call default to
+    ;; true under the gate (e.g. `incl? (raw-state-allowed?)`, the plausible
+    ;; "the flag IS the opt-in" misreading) would leak raw epoch state on
+    ;; EVERY poll once an operator launched with the flag for ONE deliberate
+    ;; read. This guards the watch-epochs gate-ON omitted-arg case
+    ;; symmetrically with trace-window.
     (async done
       (raw-state/set-allow-raw-state! true)
       (let [forms (atom [])]
@@ -272,7 +269,7 @@
                        (done)))))))))
 
 ;; ===========================================================================
-;; rf2-f1ose — list-subscriptions :include-values sub :value egress
+;; list-subscriptions :include-values sub :value egress
 ;; ===========================================================================
 
 (def ^:private sub-cache-canned
@@ -328,13 +325,12 @@
                        (done)))))))))
 
 (deftest list-subscriptions-gate-on-elision-false-still-redacts-sensitive
-  ;; rf2-t55hxg.13 — fail-CLOSED. Pre-fix this asserted that gate-ON +
-  ;; `:elision false` bypassed the walker entirely (raw value egress),
-  ;; which let a caller pull declared-sensitive sub values off-box WITHOUT
-  ;; the per-call `:include-sensitive true` opt-in — collapsing EP-0015's
-  ;; two-key sensitive gate. The contract is now: a BARE `:elision false`
-  ;; (no sensitive opt-in) STILL walks — large content passes
-  ;; (`include-large? true`) but a declared-sensitive value redacts.
+  ;; Fail-CLOSED. A BARE `:elision false` (no sensitive opt-in) STILL
+  ;; walks — large content passes (`include-large? true`) but a
+  ;; declared-sensitive value redacts. `:elision false` must NOT bypass
+  ;; the walker entirely, which would let a caller pull declared-sensitive
+  ;; sub values off-box WITHOUT the per-call `:include-sensitive true`
+  ;; opt-in — collapsing EP-0015's two-key sensitive gate.
   (testing "gate ON + include-values + elision false (no sensitive opt-in): STILL walks, sensitive redacts"
     (async done
       (raw-state/set-allow-raw-state! true)
@@ -353,9 +349,9 @@
                        (done)))))))))
 
 (deftest list-subscriptions-gate-on-full-raw-opt-in-ships-bare
-  ;; rf2-t55hxg.13 — the ONLY combination that skips the walker is the
-  ;; deliberate full-raw local opt-in: `:elision false` AND
-  ;; `:include-sensitive true` (the operator's `:rf.egress/local-raw` act).
+  ;; The ONLY combination that skips the walker is the deliberate
+  ;; full-raw local opt-in: `:elision false` AND `:include-sensitive true`
+  ;; (the operator's `:rf.egress/local-raw` act).
   (testing "gate ON + include-values + elision false + include-sensitive true: full-raw opt-in skips the walker"
     (async done
       (raw-state/set-allow-raw-state! true)
@@ -406,16 +402,16 @@
                        (done)))))))))
 
 ;; ===========================================================================
-;; rf2-8fin7.1 — snapshot :epochs slice raw :db-* egress
+;; snapshot :epochs slice raw :db-* egress
 ;; ===========================================================================
 ;;
-;; The snapshot eval form elided ONLY :app-db / :sub-cache; the :epochs
-;; slice rode raw. The client scrub merely DROPS whole sensitive epochs, so
-;; a schema-declared-sensitive SLOT inside a NON-sensitive epoch's
-;; :db-before / :db-after leaked off-box in :full mode under the gate-OFF
-;; default. The fix routes the :epochs slice through projected-record (the
-;; same projection trace-window / watch-epochs use), gated by the
-;; include-sensitive two-key opt-in — parity with rf2-6wvh5.
+;; The snapshot eval form must redact the :epochs slice too, not just
+;; :app-db / :sub-cache. The client scrub merely DROPS whole sensitive
+;; epochs, so a schema-declared-sensitive SLOT inside a NON-sensitive
+;; epoch's :db-before / :db-after would leak off-box in :full mode under
+;; the gate-OFF default. The :epochs slice routes through
+;; projected-record (the same projection trace-window / watch-epochs
+;; use), gated by the include-sensitive two-key opt-in.
 
 ;; The snapshot eval form returns {:value <snap> :elided-count N
 ;; :tool-frames-excluded []}. The slice content is irrelevant to the
@@ -497,11 +493,11 @@
     ;; the large-elision toggle (elision?). Turning elision off must not
     ;; re-open the epoch leak.
     ;;
-    ;; rf2-t55hxg.13 — and a BARE `:elision false` (no sensitive opt-in)
-    ;; must ALSO keep walking the `:app-db` / `:sub-cache` slices
-    ;; (fail-closed): large content passes but a declared-sensitive slot
-    ;; redacts. Pre-fix `:elision false` suppressed the per-slot walker,
-    ;; leaking sensitive `:app-db` / `:sub-cache` slots off-box.
+    ;; And a BARE `:elision false` (no sensitive opt-in) must ALSO keep
+    ;; walking the `:app-db` / `:sub-cache` slices (fail-closed): large
+    ;; content passes but a declared-sensitive slot redacts. `:elision
+    ;; false` must NOT suppress the per-slot walker, which would leak
+    ;; sensitive `:app-db` / `:sub-cache` slots off-box.
     (async done
       (raw-state/set-allow-raw-state! true)
       (let [forms (atom [])]
@@ -526,8 +522,8 @@
 
 (deftest snapshot-full-raw-opt-in-skips-slice-walker
   (testing "gate ON + elision false + include-sensitive true: full-raw opt-in skips the :app-db/:sub-cache walker"
-    ;; rf2-t55hxg.13 — the ONLY combination that skips the per-slot walker
-    ;; is the deliberate full-raw local opt-in.
+    ;; The ONLY combination that skips the per-slot walker is the
+    ;; deliberate full-raw local opt-in.
     (async done
       (raw-state/set-allow-raw-state! true)
       (let [forms (atom [])]
@@ -544,18 +540,17 @@
                        (done)))))))))
 
 ;; ===========================================================================
-;; rf2-8fin7.2 — record / watch-until raw :app-db & :sub signal egress
+;; record / watch-until raw :app-db & :sub signal egress
 ;; ===========================================================================
 ;;
 ;; record (read back via read-recording) and watch-until sample {:app-db
 ;; [path]} / {:sub [query-v]} signals and ship the SAMPLED VALUES back to
-;; the model. Before the fix neither routed the value through
-;; elide-wire-value / a raw-state gate, so a declared-sensitive slot leaked
-;; off-box under the gate-OFF default. The fix threads an elision-opts map
-;; (gate + per-call posture) into the runtime sampler via :elide-opts
-;; (record) / the 3rd sample-signals arg (watch-until), and issues
-;; signal-runtime! before sampling — parity with get-path / read-sub /
-;; snapshot.
+;; the model. Each routes the value through elide-wire-value behind a
+;; raw-state gate, so a declared-sensitive slot redacts off-box under the
+;; gate-OFF default. They thread an elision-opts map (gate + per-call
+;; posture) into the runtime sampler via :elide-opts (record) / the 3rd
+;; sample-signals arg (watch-until), and issue signal-runtime! before
+;; sampling — parity with get-path / read-sub / snapshot.
 
 (def ^:private record-canned
   {:ok? true :recording-id "rec-x" :signals [{:app-db [:auth :token]}]
@@ -628,7 +623,7 @@
                        (done)))))))))
 
 ;; ===========================================================================
-;; rf2-nmjcll — epoch egress names the :rf.egress/off-box-tool profile
+;; epoch egress names the :rf.egress/off-box-tool profile
 ;; ===========================================================================
 ;;
 ;; Pair-MCP is an OFF-BOX TOOL WIRE (epoch records cross to an external
@@ -636,10 +631,10 @@
 ;; epoch egress MUST name `:rf.egress/off-box-tool`, NOT lean on
 ;; `projected-record`'s `:rf.egress/off-box-observability` default (same
 ;; redact/elide floor, but OMITS the structural `:rf.size/include-digests?`
-;; indicators a tool needs to reason about an elided slot's shape). The fix
-;; lives in `egress-opts-edn`, so every epoch egress caller that threads
-;; through it (trace-window / watch-epochs / snapshot :epochs / dispatch
-;; :trace / :settle / subscribe epoch-topic drain) inherits the profile.
+;; indicators a tool needs to reason about an elided slot's shape). The
+;; profile lives in `egress-opts-edn`, so every epoch egress caller that
+;; threads through it (trace-window / watch-epochs / snapshot :epochs /
+;; dispatch :trace / :settle / subscribe epoch-topic drain) inherits it.
 ;;
 ;; These unit tests pin the helper directly — they PARSE the emitted EDN
 ;; (not just substring it) so the assertion is the actual data shape, and

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/elision_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/elision_test.cljs
@@ -1,9 +1,9 @@
 (ns re-frame2-pair-mcp.elision-test
-  "Unit tests for the size-elision wire-marker integration (rf2-urjnc).
+  "Unit tests for the size-elision wire-marker integration.
 
   Per `tools/re-frame2-pair-mcp/spec/Principles.md` §\"Size-elision wire markers\",
   the `snapshot` and `get-path` tools call
-  `re-frame.core/elide-wire-value` (rf2-v9tw2) server-side inside the
+  `re-frame.core/elide-wire-value` server-side inside the
   CLJS eval form before any payload crosses the wire. A declared
   `:large?` slot or an over-threshold leaf is substituted with a
   `{:rf.size/large-elided {:path [...] :handle [:rf.elision/at <path>]
@@ -18,7 +18,7 @@
   aren't surfaced as standalone public fns.
 
   `:elision` MCP-arg normalisation lives on the shared table-driven
-  parser (`re-frame2-pair-mcp.tools.args/parse-bool-arg`, rf2-c4fmh);
+  parser (`re-frame2-pair-mcp.tools.args/parse-bool-arg`);
   see `re-frame2-pair-mcp.args-test` for the coverage.
 
   Live end-to-end coverage runs against a real shadow-cljs build via
@@ -33,7 +33,7 @@
 ;; ---------------------------------------------------------------------------
 ;; elision-opts-edn — EDN-render the walker's opts map for inlining.
 ;;
-;; Post-rf2-suoj2: the helper takes walker-aligned `include-large?` /
+;; The helper takes walker-aligned `include-large?` /
 ;; `include-sensitive?` polarities (both pass-through booleans — true
 ;; ⇒ walker leaves the slot alone). Call sites convert from the MCP
 ;; arg `elision` (operator-facing on/off) via `(not elision?)`.
@@ -41,7 +41,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; walk-required? — the fail-CLOSED predicate gating the per-slot walker
-;; on every AI-facing read surface (EP-0015, rf2-t55hxg.13).
+;; on every AI-facing read surface (EP-0015).
 ;;
 ;; The walker is the ONLY thing on the direct-read surfaces that redacts a
 ;; frame-declared-sensitive slot. It MUST run unless the caller opted into
@@ -54,8 +54,8 @@
   (testing "off-box default (both false) ⇒ walk (sensitive + large redact)"
     (is (true? (elision/walk-required? false false))))
   (testing "bare :elision false (large in, sensitive NOT opted in) ⇒ STILL walk"
-    ;; This is the rf2-t55hxg.13 fix: pre-fix this combination skipped the
-    ;; walker and leaked sensitive slots off-box.
+    ;; Fail-closed: this combination walks the slot so sensitive content
+    ;; never leaks off-box.
     (is (true? (elision/walk-required? true false))))
   (testing "sensitive opt-in but large elides (include-large? false) ⇒ walk"
     (is (true? (elision/walk-required? false true))))
@@ -89,7 +89,7 @@
       (is (contains? parsed :rf.size/include-large?)))))
 
 ;; ---------------------------------------------------------------------------
-;; Eval-form composition for snapshot-tool (rf2-urjnc).
+;; Eval-form composition for snapshot-tool.
 ;;
 ;; The snapshot-tool builds a CLJS eval form sent over nREPL. With
 ;; elision enabled, the form wraps `(re-frame2-pair.runtime/snapshot-state
@@ -107,28 +107,28 @@
 (defn- build-snapshot-form
   "Mirror of the snapshot-tool's eval-form composition. Two arms:
   elision on/off. Keep in lockstep with `snapshot-tool` in
-  `tools/snapshot.cljs`. Post-rf2-e35a5 both arms wrap the snapshot
+  `tools/snapshot.cljs`. Both arms wrap the snapshot
   in `{:value <snap> :elided-count N}` so the count piggybacks on
   the same nREPL round-trip — no separate client-side walk.
 
-  Post-rf2-vflrg the walker fires on BOTH `:app-db` and `:sub-cache`
+  The walker fires on BOTH `:app-db` and `:sub-cache`
   slices and threads `include-sensitive?` into the walker's
   `:rf.size/include-sensitive?` opt.
 
-  Post-rf2-jj1xer (EP-0001 ruling #14) the elision-on branch ALSO
+  Per EP-0001 ruling #14 the elision-on branch ALSO
   default-redacts the `:machines` slice (runtime-db-partition state) to
   `:rf/redacted` unless the operator opted in (`include-sensitive?` true
   here mirrors the production `incl?` opt-in axis)."
   ([opts elision?] (build-snapshot-form opts elision? false))
   ([opts elision? include-sensitive?]
-   ;; rf2-suoj2 — helper takes walker-aligned `include-large?`; flip
+   ;; Helper takes walker-aligned `include-large?`; flip
    ;; from the MCP-arg `elision?` polarity here, mirroring the
    ;; production call site in `tools/snapshot.cljs`.
    (let [elision-opts-form (elision/elision-opts-edn (not elision?) include-sensitive?)
-         ;; rf2-jj1xer — runtime-db (`:machines`) is redacted off-box by
+         ;; Runtime-db (`:machines`) is redacted off-box by
          ;; default; the opt-in axis is `incl?` (here `include-sensitive?`).
          redact-runtime-db? (not include-sensitive?)
-         ;; rf2-t55hxg.13 — fail-CLOSED: the per-slot walker over
+         ;; Fail-CLOSED: the per-slot walker over
          ;; `:app-db` / `:sub-cache` runs UNLESS the caller opted into BOTH
          ;; raw axes (`:elision false` ⇒ include-large? true AND
          ;; `:include-sensitive true`). A bare `:elision false` still walks
@@ -136,7 +136,7 @@
          walk-slices?       (elision/walk-required? (not elision?) include-sensitive?)
          ;; The whole reduction fires when ANY transform is active.
          walk-snapshot?     (or walk-slices? redact-runtime-db?)
-         ;; rf2-3bu3d.6 — on the `:app` default scope the form piggybacks
+         ;; On the `:app` default scope the form piggybacks
          ;; the excluded reserved tool frames; off that path it is `[]`.
          tool-frames-form (if (= :app (:frames opts))
                             "(filterv re-frame2-pair.runtime/reserved-tool-frame? (re-frame.core/frame-ids))"
@@ -173,11 +173,11 @@
             " :tool-frames-excluded " tool-frames-form "}")))))
 
 (deftest snapshot-form-full-raw-opt-in-wraps-bare-snap-with-zero-count
-  ;; Post-rf2-e35a5: even with no transforms active, the form returns the
+  ;; Even with no transforms active, the form returns the
   ;; `{:value v :elided-count N}` envelope so the wire-pipeline doesn't
   ;; need a branched response shape.
   ;;
-  ;; rf2-t55hxg.13 — the bare-snap (no walker) path is reached ONLY on the
+  ;; The bare-snap (no walker) path is reached ONLY on the
   ;; full-raw opt-in: `:elision false` (include-large? true) AND
   ;; `:include-sensitive true`. A bare `:elision false` (the third arg
   ;; left false) STILL walks — see snapshot-form-bare-elision-false-still-walks.
@@ -195,11 +195,11 @@
     (is (not (re-find #":machines :rf/redacted" form)))))
 
 (deftest snapshot-form-bare-elision-false-still-walks
-  ;; rf2-t55hxg.13 — fail-CLOSED. A BARE `:elision false` (no sensitive
+  ;; Fail-CLOSED. A BARE `:elision false` (no sensitive
   ;; opt-in) STILL routes `:app-db` / `:sub-cache` through the walker:
   ;; large content passes (`include-large? true`) but a declared-sensitive
-  ;; slot redacts (`include-sensitive? false`). Pre-fix this skipped the
-  ;; walker entirely — the EP-0015 sensitive bypass.
+  ;; slot redacts (`include-sensitive? false`). This guards the EP-0015
+  ;; sensitive-bypass surface.
   (let [form (build-snapshot-form {:frames :all
                                    :include [:app-db :sub-cache]}
                                   false   ; elision off (include-large? true)
@@ -231,7 +231,7 @@
     (is (re-find #":rf\.size/include-large\? false" form))))
 
 (deftest snapshot-form-walks-both-app-db-and-sub-cache
-  ;; rf2-vflrg — the snapshot eval form now walks BOTH `:app-db` AND
+  ;; The snapshot eval form walks BOTH `:app-db` AND
   ;; `:sub-cache` slices through `elide-wire-value`. Per Tool-Pair
   ;; §Direct-read privacy posture, the `sub-cache` direct-read surface
   ;; MUST route through the wire walker with off-box defaults.
@@ -253,9 +253,9 @@
     (is (not (re-find #"contains\? fmap :epochs" form)))))
 
 (deftest snapshot-form-redacts-machines-runtime-db-off-box-by-default
-  ;; EP-0001 rf2-jj1xer / ruling #14 — the `:machines` slice is RUNTIME-DB
-  ;; state (machine snapshots moved to the runtime-db partition in
-  ;; rf2-vzld77). Per Spec 011 §Off-box redaction the runtime-db partition
+  ;; EP-0001 ruling #14 — the `:machines` slice is RUNTIME-DB
+  ;; state (machine snapshots live in the runtime-db partition).
+  ;; Per Spec 011 §Off-box redaction the runtime-db partition
   ;; is REDACTED/OMITTED off-box by default. So the elision-on form (the
   ;; default off-box posture, `include-sensitive?` false) substitutes the
   ;; `:machines` slice with `:rf/redacted`.
@@ -276,7 +276,7 @@
         "trusted-local opt-in ⇒ :machines is NOT redacted (richer diagnostics)")))
 
 (deftest snapshot-form-threads-include-sensitive
-  ;; rf2-vflrg — `:include-sensitive?` flows through to the walker's
+  ;; `:include-sensitive?` flows through to the walker's
   ;; `:rf.size/include-sensitive?` opt so the same MCP arg that opts
   ;; in to forwarding sensitive traces / epochs also opts in to seeing
   ;; the raw value at sensitive paths in the :app-db / :sub-cache
@@ -289,7 +289,7 @@
         "include-sensitive? true ⇒ sensitive slots pass through")))
 
 (deftest snapshot-form-counts-elision-markers-server-side
-  ;; rf2-e35a5: the eval form returns `{:value <snap> :elided-count N}`
+  ;; The eval form returns `{:value <snap> :elided-count N}`
   ;; so the elision count rides back on the same nREPL round-trip.
   ;; The wire-pipeline reads the count from opts instead of re-walking
   ;; client-side.
@@ -304,7 +304,7 @@
     (is (re-find #"tree-seq coll\? seq walked" form))))
 
 (deftest snapshot-form-app-scope-piggybacks-excluded-tool-frames
-  ;; rf2-3bu3d.6 — on the DEFAULT `:app` scope the eval form computes the
+  ;; On the DEFAULT `:app` scope the eval form computes the
   ;; reserved :rf/* tool frames it excluded (via the runtime predicate)
   ;; and rides them back on the same round-trip under
   ;; `:tool-frames-excluded`, so the wire response can name them in a
@@ -331,7 +331,7 @@
       (is (re-find #":tool-frames-excluded \[\]" form)))))
 
 ;; ---------------------------------------------------------------------------
-;; Eval-form composition for get-path-tool (rf2-urjnc).
+;; Eval-form composition for get-path-tool.
 ;;
 ;; The get-path-tool eval form does `(get-in db path)` then passes the
 ;; resolved value through the walker. The walker's `:path` opt is set
@@ -341,11 +341,11 @@
 
 (defn- build-get-path-form
   "Mirror of the get-path-tool's eval-form composition. Keep in
-  lockstep with `get-path-tool` in tools.cljs. Post-rf2-e35a5: the
+  lockstep with `get-path-tool` in tools.cljs. The
   happy-path envelope carries `:elided-count` so the wire-pipeline
   reads the count from opts instead of re-walking the scalar.
 
-  Post-rf2-vflrg the four-arity form takes `include-sensitive?` and
+  The four-arity form takes `include-sensitive?` and
   threads it into the walker's `:rf.size/include-sensitive?` opt."
   ([path frame elision?] (build-get-path-form path frame elision? false))
   ([path frame elision? include-sensitive?]
@@ -354,11 +354,11 @@
                          (str "(re-frame2-pair.runtime/snapshot " (pr-str frame) ")")
                          "(re-frame2-pair.runtime/snapshot)")
          frame-edn     (if frame (pr-str frame) "(re-frame2-pair.runtime/current-frame)")
-         ;; rf2-suoj2 — helper takes walker-aligned `include-large?`;
+         ;; Helper takes walker-aligned `include-large?`;
          ;; flip from the MCP-arg `elision?` polarity here, mirroring
          ;; the production call site in `tools/get_path.cljs`.
          elision-opts  (elision/elision-opts-edn (not elision?) include-sensitive?)
-         ;; rf2-t55hxg.13 — fail-CLOSED: walk UNLESS the caller opted into
+         ;; Fail-CLOSED: walk UNLESS the caller opted into
          ;; both raw axes (`:elision false` AND `:include-sensitive true`).
          ;; Mirrors `walk?` in tools/get_path.cljs.
          walk?         (elision/walk-required? (not elision?) include-sensitive?)
@@ -393,9 +393,9 @@
           "    {:ok? true :exists? true :path path :value elided-v :elided-count n}))"))))
 
 (deftest get-path-form-full-raw-opt-in-bypasses-walker
-  ;; rf2-t55hxg.13 — the raw value rides the wire ONLY on the full-raw
+  ;; The raw value rides the wire ONLY on the full-raw
   ;; opt-in: `:elision false` (include-large? true) AND
-  ;; `:include-sensitive true`. Post-rf2-e35a5 the value flows through the
+  ;; `:include-sensitive true`. The value flows through the
   ;; `elided-v` binding (a pass-through here) and the count is zero.
   (let [form (build-get-path-form [:user :uploaded-pdf] :rf/default false true)]
     (is (not (re-find #"elide-wire-value" form)))
@@ -404,10 +404,10 @@
     (is (re-find #"n 0" form))))
 
 (deftest get-path-form-bare-elision-false-still-walks
-  ;; rf2-t55hxg.13 — fail-CLOSED. A BARE `:elision false` (no sensitive
+  ;; Fail-CLOSED. A BARE `:elision false` (no sensitive
   ;; opt-in) STILL walks: large content passes (`include-large? true`) but
   ;; a declared-sensitive slot redacts (`include-sensitive? false`).
-  ;; Pre-fix this bypassed the walker — the EP-0015 sensitive bypass.
+  ;; This guards the EP-0015 sensitive-bypass surface.
   (let [form (build-get-path-form [:user :token] :rf/default false false)]
     (is (re-find #"re-frame\.core/elide-wire-value v" form)
         "bare :elision false MUST still walk — no sensitive bypass")
@@ -449,7 +449,7 @@
     (is (not= -1 (.indexOf form edn)))))
 
 (deftest get-path-form-threads-include-sensitive
-  ;; rf2-vflrg — `include-sensitive?` threads through to the walker's
+  ;; `include-sensitive?` threads through to the walker's
   ;; `:rf.size/include-sensitive?` opt. Default is off (sensitive paths
   ;; redact); opt in with `true`.
   (let [form-default  (build-get-path-form [:user :token] :rf/default true false)
@@ -460,13 +460,13 @@
         "include-sensitive? true ⇒ raw value at sensitive paths")))
 
 ;; ---------------------------------------------------------------------------
-;; Composition × wire-cap (rf2-rvyzy fallback).
+;; Composition × wire-cap fallback.
 ;;
 ;; Elision runs FIRST (server-side, inside the eval form). When elision
 ;; is on and a `:large?` path matches, the response shrinks to the
 ;; marker and the wire-cap stays a backstop. When elision is OFF, the
-;; raw payload rides and the wire-cap may still trip — that fallback
-;; is the existing rf2-rvyzy mechanism.
+;; raw payload rides and the wire-cap may still trip — that is the
+;; wire-cap fallback mechanism.
 ;;
 ;; The cap check itself is a pure function over the assembled MCP
 ;; result envelope; we test that elision-off still produces a payload
@@ -475,9 +475,9 @@
 
 (deftest wire-cap-composes-with-full-raw-opt-in
   ;; Sanity: the snapshot form on the full-raw opt-in (`:elision false`
-  ;; AND `:include-sensitive true`, rf2-t55hxg.13) is plain EDN — it has
+  ;; AND `:include-sensitive true`) is plain EDN — it has
   ;; no marker shape on the way out, so when the runtime returns a raw
-  ;; value the cap measures the raw bytes (the rf2-rvyzy fallback).
+  ;; value the cap measures the raw bytes (the wire-cap fallback).
   (let [form (build-snapshot-form {:frames :all :include [:app-db]} false true)]
     ;; No `:rf.size/*` shapes in the form when the walker is skipped; the
     ;; marker emission is entirely the walker's job.
@@ -502,7 +502,7 @@
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
-;; Wire-pipeline `:server-elided` opt (rf2-e35a5).
+;; Wire-pipeline `:server-elided` opt.
 ;;
 ;; The wire-pipeline's `:snapshot-map` and `:scalar-value` arms read
 ;; the elision count from the `:server-elided` opt instead of re-walking
@@ -524,7 +524,7 @@
     :reason :schema :handle [:rf.elision/at [:user :uploaded-pdf]]}})
 
 (deftest snapshot-map-arm-uses-server-elided-when-supplied
-  ;; rf2-e35a5: when `:server-elided` is on opts, the arm uses it
+  ;; When `:server-elided` is on opts, the arm uses it
   ;; directly. The payload might or might not actually contain
   ;; markers — we trust the server-side count because the walker
   ;; that inserted the markers was the one counting.
@@ -558,7 +558,7 @@
         "Missing :server-elided ⇒ local walk picks up the marker")))
 
 (deftest scalar-value-arm-uses-server-elided-when-supplied
-  ;; rf2-e35a5: `:scalar-value` arm reads `:server-elided` for the
+  ;; The `:scalar-value` arm reads `:server-elided` for the
   ;; common `get-path` path — the eval form pre-counts.
   (let [{:keys [indicators]}
         (wp/run-wire-pipeline marker
@@ -588,9 +588,9 @@
   ;; render this verbatim into the EDN sent over nREPL. The kw shape
   ;; is normative per the walker's docstring; a rename in the framework
   ;; surface needs a co-ordinated update here.
-  ;; Post-rf2-vflrg both opts ride the same map; assert against the
+  ;; Both opts ride the same map; assert against the
   ;; parsed form so map-key-order doesn't matter.
-  ;; Post-rf2-suoj2 helper params are walker-aligned: `include-large?
+  ;; Helper params are walker-aligned: `include-large?
   ;; false` = emit markers (the elision-ON call-site posture).
   (let [parsed-elide-on  (cljs.reader/read-string (elision/elision-opts-edn false))
         parsed-elide-off (cljs.reader/read-string (elision/elision-opts-edn true))]
@@ -600,11 +600,11 @@
     (is (false? (:rf.size/include-sensitive? parsed-elide-off)))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-vflrg — `:include-sensitive?` threads through `elision-opts-edn`.
+;; `:include-sensitive?` threads through `elision-opts-edn`.
 ;;
 ;; Per Tool-Pair §Direct-read privacy posture, the `snapshot` and
 ;; `get-path` direct-read surfaces MUST honour
-;; `:rf.size/include-sensitive?`. EP-0015 §10 (rf2-qus09h) reframes the
+;; `:rf.size/include-sensitive?`. EP-0015 §10 frames the
 ;; two-arity form as named-profile adoption: the `include-sensitive?`
 ;; posture names a `:rf.egress/*` profile (`off-box-tool` default /
 ;; `local-raw` opt-in) whose `:rf.size/*` floor the framework resolves;
@@ -620,8 +620,8 @@
 
 (deftest elision-opts-edn-include-sensitive-true-opts-in
   ;; The documented opt-in flow: `:include-sensitive? true` selects the
-  ;; trusted-local `:rf.egress/local-raw` boundary (EP-0015 §10,
-  ;; rf2-qus09h). Sensitive slots then pass through unmodified.
+  ;; trusted-local `:rf.egress/local-raw` boundary (EP-0015 §10).
+  ;; Sensitive slots then pass through unmodified.
   (let [parsed (cljs.reader/read-string (elision/elision-opts-edn false true))]
     (is (true? (:rf.size/include-sensitive? parsed))
         "two-arity true ⇒ local-raw ⇒ walker passes sensitive values through")))
@@ -633,7 +633,7 @@
     (is (= parsed-explicit parsed-default))))
 
 (deftest elision-opts-edn-resolves-named-egress-profiles
-  ;; EP-0015 §10 profile adoption (rf2-qus09h): the posture
+  ;; EP-0015 §10 profile adoption: the posture
   ;; (`include-sensitive?`) names a `:rf.egress/*` profile, resolved to its
   ;; `:rf.size/*` floor via the cross-MCP `mcp-base.egress` mirror (pinned
   ;; byte-identical to the framework table by the mcp-conformance
@@ -662,8 +662,8 @@
           "local-raw includes large too — the trusted-local boundary"))))
 
 (deftest posture->profile-maps-posture-to-named-boundary
-  ;; The posture→profile mapping is the explicit EP-0015 §10 naming
-  ;; (rf2-qus09h): off-box-tool is the off-box default; local-raw is the
+  ;; The posture→profile mapping is the explicit EP-0015 §10 naming:
+  ;; off-box-tool is the off-box default; local-raw is the
   ;; trusted-local opt-in.
   (is (= :rf.egress/off-box-tool (elision/posture->profile false))
       "not-opted-in ⇒ the MCP/AI tool wire boundary")

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_retry_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_retry_test.cljs
@@ -1,16 +1,12 @@
 (ns re-frame2-pair-mcp.ensure-connection-retry-test
-  "Regression for the sticky-discovery-error wedge (rf2-r6yly).
+  "Regression guard for the sticky-discovery-error wedge.
 
-  THE BUG: `server/ensure-connection!` short-circuited on a cached
-  `:discovery-error`. Once discovery failed ONCE — e.g. a tool call
-  landed before `shadow-cljs watch` was up — EVERY later call replayed
-  the stale rejection forever, with no path to re-attempt. The operator
-  had to restart the whole MCP server even after starting shadow.
-
-  THE FIX: discovery failure records `:discovery-error` for diagnostics
-  ONLY; while `:discovered?` is false, each tool call RE-RUNS the
-  cascade. A recoverable failure (shadow not up at the first call) now
-  self-heals on a later call once the operator starts the build.
+  The contract: discovery failure records `:discovery-error` for
+  diagnostics ONLY; while `:discovered?` is false, each tool call
+  RE-RUNS the cascade. A recoverable failure (shadow not up at the
+  first call) self-heals on a later call once the operator starts the
+  build — there is no permanent wedge that requires restarting the MCP
+  server.
 
   The 2-arity `ensure-connection!` injects the discovery thunk so the
   retry contract is unit-testable without the npm SDK / a live shadow."
@@ -51,9 +47,9 @@
                    "the failure is recorded for diagnostics")
                (is (false? (:discovered? (server/session-state-snapshot)))
                    "still not discovered — the session is not wedged")
-               ;; Second tool call: the OLD code replayed the cached error
-               ;; here without re-invoking discovery. The fix re-runs it,
-               ;; so this attempt reaches the (now-succeeding) thunk.
+               ;; Second tool call: while not discovered, the cascade
+               ;; re-runs discovery here rather than replaying the cached
+               ;; error, so this attempt reaches the (now-succeeding) thunk.
                (-> (server/ensure-connection! {} discover-fn)
                    (.then (fn [resolved-conn]
                             (is (= 2 @calls)

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
@@ -1,16 +1,14 @@
 (ns re-frame2-pair-mcp.eval-cljs-test
   "Unit tests for the eval-cljs tool.
 
-  ## rf2-ivlb3 (`no-runtime-for-build-fails-loud` cluster)
+  ## Fail-loud on a runtime-absent build (`no-runtime-for-build` cluster)
 
-  THE BUG: `eval-cljs` against a build with no live re-frame2-pair
-  runtime returned `{:ok? true :value nil}` for EVERY form — including
-  `(count ...)`, which can never be nil — because shadow's `cljs-eval`
-  against a non-running build yields a blank value that
-  `cljs-eval-value` reads as nil, indistinguishable from a genuine nil.
-  ~30 min of dead-end debugging in the wild.
-
-  THE FIX (shared with the bash shim via the same `probe` logic):
+  `eval-cljs` against a build with no live re-frame2-pair runtime must
+  NOT collapse to `{:ok? true :value nil}` for forms like `(count ...)`
+  that can never be nil — shadow's `cljs-eval` against a non-running
+  build yields a blank value that would otherwise read as a genuine
+  nil. The tool guards against that with two behaviours (shared with
+  the bash shim via the same `probe` logic):
     1. Fail loud — preflight the runtime sentinel; a runtime-absent
        build returns `{:ok? false :reason :no-runtime-for-build ...}`
        enumerating the running builds, NEVER `:ok? true :value nil`.
@@ -22,7 +20,7 @@
     - `nrepl/jvm-eval`         — the `active-builds` enumeration (JVM-side).
     - `nrepl/cljs-eval-value`  — the sentinel probe + the actual eval.
 
-  ## rf2-xn4f9 (`await-*` cluster)
+  ## Await mode (`await-*` cluster)
 
   Opt-in `:await true` arg awaits Promise-returning forms server-side.
   The browser-side wrapper either short-circuits with
@@ -38,10 +36,10 @@
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-cljs :as eval-cljs]))
 
-;; eval-cljs defaults ON post-rf2-a0z0h (the operator opts OUT via
-;; --no-eval). The suite leaves the gate at its default so we test the
-;; resolution path, not the gate (the gate's disabled-state coverage
-;; lives in conformance_test + `gate-closed-rejects-before-touching-nrepl`
+;; eval-cljs defaults ON (the operator opts OUT via --no-eval). The
+;; suite leaves the gate at its default so we test the resolution path,
+;; not the gate (the gate's disabled-state coverage lives in
+;; conformance_test + `gate-closed-rejects-before-touching-nrepl`
 ;; below).
 (use-fixtures :each
   {:before (fn [] (eval-cljs/set-eval-allowed! true))
@@ -92,7 +90,7 @@
                     (tu/restore-eval! cljs-stub orig-cljs))))))
 
 ;; ---------------------------------------------------------------------------
-;; Fail-loud — the headline regression (rf2-ivlb3).
+;; Fail-loud — a runtime-absent build never reports a silent nil.
 ;; ---------------------------------------------------------------------------
 
 (deftest no-runtime-for-build-fails-loud
@@ -203,7 +201,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest gate-closed-rejects-before-touching-nrepl
-  ;; Default ON post-rf2-a0z0h. To exercise the disabled envelope we
+  ;; The gate defaults ON. To exercise the disabled envelope we
   ;; flip the gate OFF (mimics `--no-eval` at launch), then restore the
   ;; default ON for downstream tests.
   (async done
@@ -226,11 +224,11 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-wz66k7 — `:timeout-ms` is validated as a positive-millisecond
-;; integer BEFORE the await-mailbox poll loop. A non-numeric value
-;; (`"bogus"`) made `await-promise/poll-mailbox!`'s `(>= elapsed
-;; timeout-ms)` deadline `(>= n NaN)` — never true — so an `:await` over a
-;; pending Promise polled FOREVER. The tool now short-circuits to an honest
+;; `:timeout-ms` is validated as a positive-millisecond integer BEFORE
+;; the await-mailbox poll loop. A non-numeric value (`"bogus"`) would
+;; make `await-promise/poll-mailbox!`'s `(>= elapsed timeout-ms)`
+;; deadline `(>= n NaN)` — never true — so an `:await` over a pending
+;; Promise would poll FOREVER. The tool short-circuits to an honest
 ;; validation error WITHOUT touching nREPL (validation is the first `cond`
 ;; branch, ahead of the eval).
 ;; ---------------------------------------------------------------------------
@@ -261,9 +259,9 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; Typed result envelope (rf2-qobqy) — the default (non-await) path wraps
-;; the form so a genuine nil, an eval-error, and an unserializable value
-;; are DISTINCT outcomes instead of collapsing to a bare null. The stub
+;; Typed result envelope — the default (non-await) path wraps the form
+;; so a genuine nil, an eval-error, and an unserializable value are
+;; DISTINCT outcomes instead of collapsing to a bare null. The stub
 ;; returns the TAGGED `:rf.mcp/result` envelope the runtime would emit;
 ;; the server projects it.
 ;; ---------------------------------------------------------------------------
@@ -348,10 +346,10 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-mvdwv — END-TO-END unresolved-symbol surfacing. The headline bug:
-;; eval'ing a form with an unresolved symbol (e.g. `re-frame.core/frame-db`,
-;; a fn that doesn't exist) returned `{:ok? true :value nil}` — the form
-;; silently nil'd out and the agent read the nil as a real value.
+;; END-TO-END unresolved-symbol surfacing. Eval'ing a form with an
+;; unresolved symbol (e.g. `re-frame.core/frame-db`, a fn that doesn't
+;; exist) must NOT return `{:ok? true :value nil}` — that would silently
+;; nil out the form and the agent would read the nil as a real value.
 ;;
 ;; Unlike the codec tests above (which stub `cljs-eval-value`, bypassing the
 ;; unwrap), this stubs ONE LAYER LOWER — `nrepl/cljs-eval` — so the REAL
@@ -415,7 +413,7 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Await mode (rf2-xn4f9) — the opt-in `:await true` arg awaits a
+;; Await mode — the opt-in `:await true` arg awaits a
 ;; Promise-returning form's resolved value, surfaces rejections as
 ;; `:rf.error/eval-cljs-rejected`, surfaces unbounded waits as
 ;; `:rf.error/eval-cljs-timeout`.
@@ -465,7 +463,7 @@
 
 (defn- with-stubbed-await!
   "Like `with-stubbed-runtime!` but additionally walks an in-test
-  mailbox state machine for the await wrapper + poll forms (rf2-xn4f9).
+  mailbox state machine for the await wrapper + poll forms.
 
   `:wrap-result` is the canned synchronous return of the await wrapper —
   either `{:rf.mcp/await-direct v}` (fast-path passthrough) or
@@ -641,7 +639,7 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Frame targeting (rf2-ntuzf) — `:frame` arg wraps the supplied form
+;; Frame targeting — `:frame` arg wraps the supplied form
 ;; in `(re-frame.core/with-frame <frame> <user-form>)` so subscribe /
 ;; dispatch inside the form target the named frame instead of the MCP
 ;; server's ambient :rf/default context.
@@ -675,9 +673,9 @@
                     (tu/restore-eval! cljs-stub orig-cljs))))))
 
 (deftest frame-arg-wraps-form-in-with-frame
-  ;; The headline rf2-ntuzf assertion: with :frame :rf/xray the user
-  ;; form is sent inside (re-frame.core/with-frame :rf/xray <form>),
-  ;; so subscribe / dispatch inside resolve to :rf/xray.
+  ;; With :frame :rf/xray the user form is sent inside
+  ;; (re-frame.core/with-frame :rf/xray <form>), so subscribe /
+  ;; dispatch inside resolve to :rf/xray.
   (async done
     (let [forms (atom [])]
       (-> (with-form-recorder! {:runtime? true :eval-value 42 :forms-atom forms}
@@ -798,7 +796,7 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Typed envelope — default path wraps the form (rf2-qobqy). Lives down
+;; Typed envelope — default path wraps the form. Lives down
 ;; here because it reuses `with-form-recorder!` (defined above in the
 ;; frame-targeting section).
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_form_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_form_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.eval-form-test
-  "Tests for the mini-DSL that composes CLJS eval forms (rf2-dpzpe).
+  "Tests for the mini-DSL that composes CLJS eval forms.
 
   Two assertion styles cover the surface:
 
@@ -9,7 +9,7 @@
     drift downstream.
   - **Emit output** — `emit` renders to a CLJS source string.
     Tests pin the exact output for a handful of representative
-    forms drawn from the six migrated tool sites; this is the
+    forms drawn from the six tool sites; this is the
     contract every tool body relies on."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [cljs.reader]
@@ -99,12 +99,12 @@
                             (ef/rt-raw "snap"))))))
 
 ;; ---------------------------------------------------------------------------
-;; Migration round-trips — the six tool sites pinned at the wire shape.
+;; Round-trips — the six tool sites pinned at the wire shape.
 ;; ---------------------------------------------------------------------------
 
 (deftest subscribe-form-shape
-  ;; Migrated from subscribe.cljs:69. Pin the wire shape — the runtime
-  ;; sees `(re-frame2-pair.runtime/subscribe! {opts-map})`.
+  ;; Pin the wire shape — the runtime sees
+  ;; `(re-frame2-pair.runtime/subscribe! {opts-map})`.
   (let [opts {:topic :trace
               :max-buffered-events 500
               :max-buffered-bytes  5000000}
@@ -115,7 +115,7 @@
                second)))))
 
 (deftest subscribe-form-carries-both-budgets
-  ;; rf2-ho4ve: regression — both budgets must round-trip.
+  ;; Regression: both budgets must round-trip.
   (let [opts {:topic :trace
               :max-buffered-events 1000
               :max-buffered-bytes  2000000}
@@ -133,17 +133,17 @@
          (ef/emit (ef/rt-call 'drain-subscription! "sub-xyz")))))
 
 (deftest precheck-form-shape-no-frame
-  ;; rf2-9pe31 — precheck routes through the O(1) cached accessor.
+  ;; Precheck routes through the O(1) cached accessor.
   (is (= "(re-frame2-pair.runtime/app-db-hash)"
          (ef/emit (ef/rt-call 'app-db-hash)))))
 
 (deftest precheck-form-shape-with-frame
-  ;; rf2-9pe31 — explicit-frame arm names the frame on the cheap accessor.
+  ;; Explicit-frame arm names the frame on the cheap accessor.
   (is (= "(re-frame2-pair.runtime/app-db-hash :rf/default)"
          (ef/emit (ef/rt-call 'app-db-hash :rf/default)))))
 
 (deftest snapshot-state-form-is-edn-readable
-  ;; Migrated from snapshot.cljs:62. The non-elision arm.
+  ;; The non-elision arm.
   (let [opts {:frames :all
               :include [:app-db :sub-cache :machines :epochs :traces]}
         form (ef/emit (ef/rt-call 'snapshot-state opts))
@@ -152,7 +152,7 @@
     (is (= opts (second edn)))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-lbfzu — `::call*` qsym handling + collection-recursion.
+;; `::call*` qsym handling + collection-recursion.
 ;; ---------------------------------------------------------------------------
 
 (deftest rt-call*-symbol-qsym-emits-fully-qualified
@@ -162,26 +162,23 @@
          (ef/emit (ef/rt-call* 're-frame.core/elide-wire-value)))))
 
 (deftest rt-call*-bare-symbol-emits-verbatim
-  ;; A bare symbol (no namespace) emits as just the name. Pre-rf2-9pe31
-  ;; the precheck-form built `(hash ...)` via this path; post-rf2-9pe31
-  ;; the precheck routes through `app-db-hash` (the cached O(1)
-  ;; accessor), but the bare-symbol arm remains useful for other
-  ;; future call sites that need an unqualified host fn.
+  ;; A bare symbol (no namespace) emits as just the name. The precheck
+  ;; routes through `app-db-hash` (the cached O(1) accessor), but the
+  ;; bare-symbol arm remains useful for other call sites that need an
+  ;; unqualified host fn.
   (is (= "(hash)" (ef/emit (ef/rt-call* 'hash)))))
 
 (deftest rt-call*-string-qsym-emits-verbatim
-  ;; Round-2 dead-branch fix: the previous impl had
-  ;; `(if (symbol? qsym) (str qsym) (str qsym))` — both arms
-  ;; identical. Pin that a string qsym renders the same way the
-  ;; symbol does (verbatim, no auto-quoting), so a future caller
-  ;; can pass a pre-qualified string and get correct source.
+  ;; A string qsym renders the same way the symbol does (verbatim, no
+  ;; auto-quoting), so a caller can pass a pre-qualified string and get
+  ;; correct source.
   (is (= "(some.ns/foo 1)"
          (ef/emit (ef/rt-call* "some.ns/foo" 1)))))
 
 (deftest emit-arg-recurses-into-vectors-of-nodes
-  ;; rf2-lbfzu / EF3 — a vector mixing scalar data and IR nodes
-  ;; previously `pr-str`'d the whole vector, including the IR
-  ;; literal. Now the recursion walks element-wise.
+  ;; A vector mixing scalar data and IR nodes is walked element-wise,
+  ;; so an IR node inside the vector emits as source rather than being
+  ;; `pr-str`'d as a literal.
   (is (= "(re-frame2-pair.runtime/foo [1 bar])"
          (ef/emit (ef/rt-call 'foo [1 (ef/rt-raw "bar")])))))
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/freshness_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/freshness_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.freshness-test
-  "Unit tests for the freshness / liveness token (rf2-ertqw).
+  "Unit tests for the freshness / liveness token.
 
   The token's job is to make 'the runtime I'm reading is stale /
   disconnected / serving a STALE BUILD' obvious up front. These tests
@@ -8,7 +8,7 @@
   graceful degradation when the JVM half can't be read.
 
   The load-bearing case is `:stale-build`: a build whose last flush is
-  newer than the moment the browser code loaded — the rf2-lo28u killer."
+  newer than the moment the browser code loaded."
   (:require [cljs.test :refer-macros [deftest is async]]
             [re-frame2-pair-mcp.tools.freshness :as fresh]))
 
@@ -198,7 +198,7 @@
               (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Actionable liveness on a quiet runtime (rf2-jkwu4).
+;; Actionable liveness on a quiet runtime.
 ;;
 ;; A `:liveness :unknown` / `:no-runtime` verdict is the agent's ONLY
 ;; early warning before a later read returns blank — and the agent can't
@@ -225,12 +225,11 @@
             (done))))))
 
 (deftest unknown-hint-diagnoses-the-zombie-shadow-case
-  ;; rf2-646lr field report: discover-app stayed :liveness :unknown for an
-  ;; entire session because MULTIPLE / ZOMBIE shadow-cljs JVMs held the
-  ;; ports — reads worked (the socket reached a runtime) but the build
-  ;; worker lived in a different JVM, so the worker lookup missed. The
-  ;; :unknown hint must NAME that case and recommend the `npx shadow-cljs
-  ;; stop` → single-watch remediation that actually frees the orphan ports.
+  ;; MULTIPLE / ZOMBIE shadow-cljs JVMs holding the ports keep discover-app
+  ;; at :liveness :unknown — reads work (the socket reaches a runtime) but
+  ;; the build worker lives in a different JVM, so the worker lookup misses.
+  ;; The :unknown hint must NAME that case and recommend the `npx shadow-cljs
+  ;; stop` → single-watch remediation that frees the orphan ports.
   (async done
     (-> (with-jvm-half! nil ; nil JVM half ⇒ :unknown
           (fn [] (fresh/assemble nil :examples/machine-epochs browser-half {:port 8033})))
@@ -260,7 +259,7 @@
             (done))))))
 
 (deftest no-runtime-hint-is-actionable-with-the-port
-  ;; The repro's quiet-runtime case: the WS heartbeat went stale → the
+  ;; The quiet-runtime case: the WS heartbeat is stale → the
   ;; verdict is :no-runtime. The hint must tell the human to reload the
   ;; exact URL, then re-run discover-app.
   (async done
@@ -294,7 +293,7 @@
               (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; retry-once-on-nil — one retry before degrading to :unknown (rf2-jkwu4).
+;; retry-once-on-nil — one retry before degrading to :unknown.
 ;;
 ;; A nil first read of the build-worker state is most often a transient
 ;; socket hiccup, not a genuinely-unreadable old shadow. One retry
@@ -303,7 +302,7 @@
 ;; retry pays a single extra round-trip only on the cold/degraded path.
 ;;
 ;; The combinator is pure (takes a Promise-returning thunk), so these
-;; tests need NO global var stub — sidestepping the rf2-wb06a
+;; tests need NO global var stub — sidestepping the
 ;; .finally-after-done stub-leak race entirely.
 ;; ---------------------------------------------------------------------------
 
@@ -351,7 +350,7 @@
 
 (deftest jvm-build-freshness-skips-retry-without-a-socket
   ;; A conn with no live socket short-circuits to nil with NO round-trip
-  ;; (and so no retry) — preserved from the original contract.
+  ;; (and so no retry).
   (async done
     (let [conn (atom {:socket nil :closed? true})]
       (-> (fresh/jvm-build-freshness conn :app)

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/get_stream_controls_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/get_stream_controls_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.get-stream-controls-test
-  "Unit tests for the `get-stream-controls` diagnostic tool (rf2-a0kxsb).
+  "Unit tests for the `get-stream-controls` diagnostic tool.
 
   The tool is a pure read over the server-side `resource-controls`
   atoms — no nREPL round-trip — so these tests drive the controller

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.handler-meta-test
-  "Unit tests for the `handler-meta` + `list-handlers` MCP tools (rf2-pctf8).
+  "Unit tests for the `handler-meta` + `list-handlers` MCP tools.
 
   Both tools build a CLJS form that calls into the preloaded runtime
   (`re-frame2-pair.runtime/registrar-describe` / `registrar-list` for
@@ -30,20 +30,19 @@
 ;; Helpers.
 ;;
 ;; The wire-envelope extractors live in `test-utils` (shared across
-;; suites, rf2-wnrpi). `args-js` is aliased to the shared `args->js`.
+;; suites). `args-js` is aliased to the shared `args->js`.
 ;;
-;; ## Stub lifetime — fixture-scoped, not Promise-chain-scoped (rf2-wb06a)
+;; ## Stub lifetime — fixture-scoped, not Promise-chain-scoped
 ;;
 ;; `with-canned-eval!` / `with-form-capture!` install a `cljs-eval-value`
-;; stub via a bare `set!` and DO NOT restore it in a per-call `.finally`;
-;; a `use-fixtures :each :after` step unconditionally restores the
-;; pristine original captured at ns-load. A `.finally`-scoped restore
-;; fires AFTER cljs.test's `done` has advanced to the next test, which in
-;; the full cross-namespace suite let a neighbour's late restore clobber
-;; another test's freshly-installed stub mid-eval — surfacing as a probe
-;; reaching the real socket fn (`first-positive-probe-runs-one-eval`
-;; flaking on `@calls = 0`). The fixture boundary closes that race — the
-;; same fix orient_test / invoke_test carry.
+;; stub via a bare `set!` and intentionally do NOT restore it in a
+;; per-call `.finally`; a `use-fixtures :each :after` step unconditionally
+;; restores the pristine original captured at ns-load. A `.finally`-scoped
+;; restore would fire AFTER cljs.test's `done` has advanced to the next
+;; test, which in the full cross-namespace suite would let a neighbour's
+;; late restore clobber another test's freshly-installed stub mid-eval —
+;; surfacing as a probe reaching the real socket fn. The fixture boundary
+;; closes that race; orient_test / invoke_test follow the same pattern.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private args-js tu/args->js)
@@ -119,14 +118,13 @@
 ;; The tool short-circuits on bad args BEFORE reaching `probe/ensure-runtime!`.
 ;; A nil conn never gets touched on these paths.
 ;;
-;; rf2-wnrpi: these six tests used to call `(.then p (fn [r] (is ...)))`
-;; from a SYNCHRONOUS deftest body — the deftest returned before the
-;; Promise resolved, so cljs.test recorded each as passed with ZERO
-;; assertions. The error-envelope contract for both tools was therefore
-;; effectively untested (a flipped `:invalid-kind` reason or an NPE on
-;; the nil conn would have passed green). Each now wraps the `.then` in
-;; `(async done ...)` so the assertions actually run before the test
-;; completes — mirroring `dispatch_test` / `probe_test`.
+;; Each test wraps its `.then` assertions in `(async done ...)` so the
+;; assertions actually run before the test completes — a synchronous
+;; deftest body would return before the Promise resolved, letting
+;; cljs.test record the test as passed with ZERO assertions. The
+;; error-envelope contract for both tools (a flipped `:invalid-kind`
+;; reason or an NPE on the nil conn) is therefore genuinely exercised,
+;; mirroring `dispatch_test` / `probe_test`.
 ;; ---------------------------------------------------------------------------
 
 (deftest handler-meta-rejects-missing-kind
@@ -215,22 +213,22 @@
           "drift here would make agents learn two vocabularies for one concept"))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-l7vnd regression — handler-meta returns :ok? true with the real
-;; data as top-level keys; the bug shape was :ok? false :reason
-;; :unexpected-shape with the actual map embedded as an EDN string.
+;; Regression — handler-meta returns :ok? true with the real data as
+;; top-level keys, never :ok? false :reason :unexpected-shape with the
+;; actual map embedded as an EDN string.
 ;;
-;; Pre-rf2-l7vnd path the runtime emitted a map containing
-;; `:handler-fn <Function>`; `pr-str` rendered that as
-;; `#object[Function ...]`; nrepl's `read-edn-safe` couldn't parse it
-;; back; the tool body fell into `(not (map? v))` and stuffed the raw
-;; string under `:value`. Two complementary defences pin the fix:
+;; The hazard: a runtime meta map containing `:handler-fn <Function>`
+;; renders via `pr-str` as `#object[Function ...]`, which nrepl's
+;; `read-edn-safe` cannot parse back; a naive tool body would then fall
+;; into `(not (map? v))` and stuff the raw string under `:value`. Two
+;; complementary defences guard against that:
 ;;
-;;   - Runtime side (skills/re-frame2-pair/preload/...): dissoc'd
+;;   - Runtime side (skills/re-frame2-pair/preload/...): dissocs
 ;;     :handler-fn before returning. Pinned structurally by the
 ;;     babashka test `registrar_describe_test.clj`.
 ;;
-;;   - MCP tool side (here): defensive re-parse so a future runtime
-;;     slip emitting a stringified map still surfaces as :ok? true.
+;;   - MCP tool side (here): defensive re-parse so a runtime slip
+;;     emitting a stringified map still surfaces as :ok? true.
 ;; ---------------------------------------------------------------------------
 
 (defn- with-canned-eval!
@@ -256,7 +254,7 @@
                     true
                     canned-handler-value))))]
     ;; Bare set!, NO per-call .finally restore — the :after fixture
-    ;; restores the pristine value (rf2-wb06a; see the ns header).
+    ;; restores the pristine value (see the ns header).
     (set! nrepl/cljs-eval-value stub)
     (-> (js/Promise.resolve nil)
         (.then (fn [_] (body-fn))))))
@@ -291,13 +289,12 @@
 
 (deftest handler-meta-unserializable-surfaces-structured
   (testing "rf2-qobqy: a runtime meta map that can't round-trip as EDN now rides back as a tagged :unserializable envelope — NOT a meta map smuggled as a STRING"
-    ;; The pre-rf2-qobqy path defensively re-parsed a stringified map.
-    ;; The typed result codec (rf2-qobqy) makes that obsolete: the
-    ;; RUNTIME classifies an unserializable meta map (a `#object`
-    ;; Function slot, a `#js {…}`) into a tagged `:rf.mcp/result
-    ;; :unserializable` envelope with a `:preview`. The tool surfaces
-    ;; the STRUCTURED error stamped with the requested kind/id — never
-    ;; the meta-map-as-string the old :unexpected-shape path carried.
+    ;; The typed result codec means the RUNTIME classifies an
+    ;; unserializable meta map (a `#object` Function slot, a `#js {…}`)
+    ;; into a tagged `:rf.mcp/result :unserializable` envelope with a
+    ;; `:preview`. The tool surfaces the STRUCTURED error stamped with
+    ;; the requested kind/id — never the meta-map-as-string a
+    ;; :unexpected-shape path would carry.
     (async done
       (let [tagged {:rf.mcp/result :unserializable
                     :type "object"
@@ -371,7 +368,7 @@
                   (js/Promise.resolve true)
                   (do (reset! form-atom form-str) (js/Promise.resolve canned)))))]
     ;; Bare set!, NO per-call .finally restore — the :after fixture
-    ;; restores the pristine value (rf2-wb06a; see the ns header).
+    ;; restores the pristine value (see the ns header).
     (set! nrepl/cljs-eval-value stub)
     (-> (js/Promise.resolve nil)
         (.then (fn [_] (body-fn))))))
@@ -408,26 +405,24 @@
             (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
 
 ;; ---------------------------------------------------------------------------
-;; EP-0016 resource kinds — happy-path EXECUTION coverage (rf2-uydhif).
+;; EP-0016 resource kinds — happy-path EXECUTION coverage.
 ;;
 ;; The descriptor tests above pin the resources kinds in the enum vocab.
-;; But every happy-path EXECUTION fixture used kind "event" — nothing
-;; proved that handler-meta / list-handlers actually accept "resource",
-;; "mutation", and "resource-scope", route them through the registrar
-;; (NOT the :machine wrapper or a wrong-kind path), and stamp the
-;; requested :kind / :id back onto the response. A renamed id, a kind
+;; These tests prove handler-meta / list-handlers actually accept
+;; "resource", "mutation", and "resource-scope", route them through the
+;; registrar (NOT the :machine wrapper or a wrong-kind path), and stamp
+;; the requested :kind / :id back onto the response. A renamed id, a kind
 ;; dropped from `registrar-kinds`, or a kind silently mis-routed through
-;; `machine-form` would have passed green. These close that gap by
-;; driving each EP-0016 kind through the tool with a canned runtime
-;; response and asserting (a) the kind is accepted (not :invalid-kind),
-;; (b) the emitted form routes through the registrar-describe /
-;; registrar-list path (never machine-meta / machines), and (c) the
-;; requested kind/id ride back stamped on the response.
+;; `machine-form` would fail here. Each EP-0016 kind is driven through
+;; the tool with a canned runtime response, asserting (a) the kind is
+;; accepted (not :invalid-kind), (b) the emitted form routes through the
+;; registrar-describe / registrar-list path (never machine-meta /
+;; machines), and (c) the requested kind/id ride back stamped on the
+;; response.
 ;;
-;; One focused test per (tool, kind) — the existing file's one-concern
-;; style. Each drives a single canned eval; no multi-case reduce/async
-;; interplay. The stubs restore via the fixture (rf2-wb06a), not a
-;; per-call .finally.
+;; One focused test per (tool, kind) — the file's one-concern style.
+;; Each drives a single canned eval; no multi-case reduce/async
+;; interplay. The stubs restore via the fixture, not a per-call .finally.
 ;; ---------------------------------------------------------------------------
 
 (defn- handler-meta-accepts-kind-test
@@ -594,7 +589,7 @@
     (async done (list-handlers-routes-through-registrar-list-test "resource-scope" ":resource-scope" done))))
 
 ;; ---------------------------------------------------------------------------
-;; Frame-targeting — the EP-0023 forward direction (rf2-srobm0).
+;; Frame-targeting — the EP-0023 forward direction.
 ;;
 ;; The OPTIONAL `:frame` arg re-keys the lookup through THAT frame's running
 ;; image generation — routing through the per-frame runtime fns

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
@@ -1,22 +1,21 @@
 (ns re-frame2-pair-mcp.invoke-test
-  "End-to-end orchestration test for `tools/invoke` (rf2-nogok).
+  "End-to-end orchestration test for `tools/invoke`.
 
   `invoke` is the single egress for every MCP `tools/call`. It glues
   four phases:
 
-    0. `precheck/fetch-precheck-hash` — cheap-hash short-circuit
-       (rf2-36xod). For precheck-eligible tools, fetches a runtime-
-       side hash. On a match against the stored entry, returns the
+    0. `precheck/fetch-precheck-hash` — cheap-hash short-circuit.
+       For precheck-eligible tools, fetches a runtime-side hash. On a
+       match against the stored entry, returns the
        `:rf.mcp/cache-hit :via :precheck` marker WITHOUT running the
        tool body.
     1. `dispatch-tool*` — per-tool dispatch. Runs the actual tool
        implementation when the precheck didn't short-circuit.
-    2. `cache/apply-cache` — post-eval result-hash cache (rf2-3rt1f).
+    2. `cache/apply-cache` — post-eval result-hash cache.
        On a result-hash match returns the `:via :result-hash` marker.
        `isError` results bypass entirely.
-    3. `cap/apply-cap` — wire-boundary token-budget enforcement
-       (rf2-rvyzy). Over-budget responses become
-       `:rf.mcp/overflow` markers.
+    3. `cap/apply-cap` — wire-boundary token-budget enforcement.
+       Over-budget responses become `:rf.mcp/overflow` markers.
 
   Each phase has unit-level coverage in `cache_test.cljs` /
   `wire_cap_test.cljs`. THIS suite pins the wire-up: that the phases
@@ -28,14 +27,13 @@
 
   `invoke` is async (returns a Promise). `cljs.core/with-redefs`
   restores its vars synchronously — by the time the Promise resolves
-  inside `(async done ...)`, the redefs are gone. An earlier shape
-  stubbed via direct `set!` and restored in a `.finally`; the
-  `.finally` could outrun the test's `(done)` call, so the NEXT
-  async test (in this or any later `-test` ns) could start while
-  the stubs were still installed — a hard-to-reproduce flake
-  (rf2-wb06a) that fired on otherwise-unrelated PRs.
+  inside `(async done ...)`, the redefs are gone. A `.finally`-scoped
+  restore is also unsafe: it can outrun the test's `(done)` call, so
+  the NEXT async test (in this or any later `-test` ns) could start
+  while the stubs are still installed — a hard-to-reproduce flake on
+  otherwise-unrelated PRs.
 
-  Current shape: each test does `(set-stubs! ...)` directly (no
+  Each test therefore does `(set-stubs! ...)` directly (no
   `.finally`), and a fixture's `:after` step unconditionally
   restores the pristine originals to ALL three vars. cljs.test's
   async-test contract guarantees `:after` fires synchronously after
@@ -69,7 +67,7 @@
 ;; `get-path/get-path-tool`, `snapshot/snapshot-tool`) are restored
 ;; UNCONDITIONALLY in `:after`. Originals are snapshot once at
 ;; ns-load. Cleanup is fixture-scoped, not Promise-chain-scoped —
-;; which closes the rf2-wb06a race.
+;; which closes the cross-test stub-leakage race.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private orig-fetch-precheck-hash precheck/fetch-precheck-hash)
@@ -130,7 +128,7 @@
 ;; `:after` fixture's job, which restores the pristine originals
 ;; (captured at ns-load) synchronously after `(done)` and before
 ;; the next test runs. The fixture-scoped lifetime is what makes
-;; this Promise-chain-independent (rf2-wb06a fix).
+;; this Promise-chain-independent.
 ;;
 ;; `kind` is the keyword the caller picked to identify which slot
 ;; to stub — `:fetch-precheck-hash`, `:get-path-tool`,
@@ -162,19 +160,19 @@
 
 (deftest precheck-hit-short-circuits-dispatch
   (async done
-    ;; rf2-ww877w — the precheck-eligible vehicle is a single-frame
-    ;; APP-DB-ONLY snapshot (get-path is no longer precheck-eligible). The
-    ;; pipeline mechanics under test (precheck hit ⇒ dispatch skipped) are
-    ;; tool-agnostic; we just need a tool whose `precheck-target` is
-    ;; non-nil so `precheck-step` issues the stubbed fetch.
+    ;; The precheck-eligible vehicle is a single-frame APP-DB-ONLY
+    ;; snapshot. The pipeline mechanics under test (precheck hit ⇒
+    ;; dispatch skipped) are tool-agnostic; we just need a tool whose
+    ;; `precheck-target` is non-nil so `precheck-step` issues the
+    ;; stubbed fetch.
     (let [args        (args-js {:cache "true"
                                 :frames #js ["rf/default"]
                                 :include #js ["app-db"]})
           dispatched? (atom false)
-          ;; rf2-olvr5 finding 3 — the cache key now includes the resolved
-          ;; build, so the priming MUST use the same build the `invoke`
-          ;; pipeline will derive (`arg-build nil args` = the env / `:app`
-          ;; default here) or the lookup key won't match.
+          ;; The cache key includes the resolved build, so the priming
+          ;; MUST use the same build the `invoke` pipeline derives
+          ;; (`arg-build nil args` = the env / `:app` default here) or
+          ;; the lookup key won't match.
           _ (cache/apply-cache (mcp-result "{:app-db {:k :v}}")
                                {:tool "snapshot"
                                 :args args
@@ -209,9 +207,9 @@
 
 (deftest precheck-miss-stores-hash-for-next-call
   (async done
-    ;; rf2-ww877w — vehicle is the single-frame app-db-only snapshot (the
-    ;; sole precheck-eligible surface now). The mechanics are unchanged:
-    ;; cold miss stores the precheck-hash; the next call short-circuits.
+    ;; Vehicle is the single-frame app-db-only snapshot (the sole
+    ;; precheck-eligible surface). The mechanics: cold miss stores the
+    ;; precheck-hash; the next call short-circuits.
     (let [args       (args-js {:cache "true"
                                :frames #js ["rf/default"]
                                :include #js ["app-db"]})
@@ -239,8 +237,8 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Phase-3 result-hash hit (post-eval). Tools that DON'T have precheck
-;; wiring (or whose precheck returns nil) fall through to the legacy
-;; rf2-3rt1f path: dispatch runs both times, the second result's text
+;; wiring (or whose precheck returns nil) fall through to the post-eval
+;; result-hash path: dispatch runs both times, the second result's text
 ;; hash matches the first, marker replaces it.
 ;;
 ;; `snapshot` with the default :all `frames` is precheck-ineligible —
@@ -325,12 +323,12 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-5rdit — negative :max-tokens is REJECTED at the invoke chokepoint,
-;; BEFORE the pipeline runs. The tool body is never dispatched and the
-;; result is an actionable `{:rf.mcp/invalid-arg ...}` error — NOT the
-;; `:rf.mcp/overflow` lock-out a negative cap used to cause (over-cap?
-;; trips on any non-negative token count against a negative ceiling, so
-;; even a tiny response was replaced by the overflow marker).
+;; Negative :max-tokens is REJECTED at the invoke chokepoint, BEFORE the
+;; pipeline runs. The tool body is never dispatched and the result is an
+;; actionable `{:rf.mcp/invalid-arg ...}` error — NOT an
+;; `:rf.mcp/overflow` lock-out (over-cap? trips on any non-negative token
+;; count against a negative ceiling, so a tiny response would otherwise
+;; be replaced by the overflow marker).
 ;; ---------------------------------------------------------------------------
 
 (deftest negative-max-tokens-rejected-not-overflow-lockout
@@ -341,8 +339,8 @@
         {:snapshot-tool (fn [_conn _args]
                           (reset! dispatched? true)
                           ;; A tiny payload — under any sane positive cap.
-                          ;; With the OLD negative-cap bug this still
-                          ;; overflowed; with the fix the tool never runs.
+                          ;; A negative cap rejects before dispatch, so
+                          ;; the tool body never runs.
                           (js/Promise.resolve (mcp-result (pr-str {:ok? true}))))})
       (-> (tools/invoke nil "snapshot" args nil)
           (.then (fn [result]
@@ -441,13 +439,13 @@
         (.then (fn [result]
                  (is (true? (j/get result :isError)))
                  (let [v (extract-edn result)]
-                   ;; Historical shape preserved (additive — rf2-tkmik).
+                   ;; The base error shape.
                    (is (false? (:ok? v)))
                    (is (= :unknown-tool (:reason v)))
                    (is (= "no-such-tool" (:tool v)))
                    ;; Recovery affordances: a :hint pointing at tools/list
                    ;; and the live catalogue, matching the surface's
-                   ;; honest-error standard (rf2-tkmik).
+                   ;; honest-error standard.
                    (is (string? (:hint v)))
                    (is (re-find #"tools/list" (:hint v))
                        "hint must point the agent at tools/list to recover")
@@ -460,7 +458,7 @@
 
 (deftest unknown-tool-hint-offers-nearest-match
   ;; A near-miss typo of a real tool name surfaces a :did-you-mean
-  ;; pointer (rf2-tkmik) so a model can self-correct without a round-trip.
+  ;; pointer so a model can self-correct without a round-trip.
   (async done
     (-> (tools/invoke nil "snapsho" (args-js {}) nil)
         (.then (fn [result]
@@ -473,7 +471,7 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-3ljsa — snapshot precheck eligibility is gated on `:include`.
+;; Snapshot precheck eligibility is gated on `:include`.
 ;;
 ;; The precheck hash is `(hash app-db@frame)` only. `:epochs`/`:traces`
 ;; accrue a record on EVERY event cascade (incl. no-`:db` handlers) and
@@ -496,10 +494,10 @@
     (is (nil? (precheck/precheck-target
                 "snapshot" (args-js {:frames #js ["rf/default"]
                                      :include #js ["app-db" "machines"]})))
-        ;; rf2-ww877w — :machines is RUNTIME-DB state (EP-0001 rf2-vzld77
-        ;; moved machine snapshots to the runtime-db partition). A machine
-        ;; transition rewrites the slice WITHOUT an app-db write, so the
-        ;; `(hash app-db)` precheck hash can't see it move ⇒ ineligible.
+        ;; :machines is RUNTIME-DB state (EP-0001 partitions machine
+        ;; snapshots into the runtime-db). A machine transition rewrites
+        ;; the slice WITHOUT an app-db write, so the `(hash app-db)`
+        ;; precheck hash can't see it move ⇒ ineligible.
         ":machines reads runtime-db — NOT app-db-derived ⇒ ineligible"))
   (testing "single-frame snapshot, default (all-five) include → ineligible"
     (is (nil? (precheck/precheck-target
@@ -509,8 +507,8 @@
     (doseq [slice [#js ["app-db" "epochs"]
                    #js ["app-db" "traces"]
                    #js ["app-db" "sub-cache"]
-                   ;; rf2-ww877w — :machines is now runtime-db-backed, so
-                   ;; an :include retaining it is precheck-ineligible too.
+                   ;; :machines is runtime-db-backed, so an :include
+                   ;; retaining it is precheck-ineligible too.
                    #js ["app-db" "machines"]
                    #js ["machines"]]]
       (is (nil? (precheck/precheck-target
@@ -521,9 +519,9 @@
                 "snapshot" (args-js {:frames #js ["a" "b"] :include #js ["app-db"]}))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-ww877w — get-path is NOT precheck-eligible. Its app-db subtree read
-;; is post-processed by `elide-wire-value`, whose elision registry lives in
-;; runtime-db; a later elision declaration / classification flip can re-shape
+;; get-path is NOT precheck-eligible. Its app-db subtree read is
+;; post-processed by `elide-wire-value`, whose elision registry lives in
+;; runtime-db; an elision declaration / classification flip can re-shape
 ;; the egress of an UNCHANGED app-db subtree, which the `(hash app-db)`
 ;; precheck hash can't observe. So get-path falls through to the post-eval
 ;; result-hash cache (which hashes the actual post-elision text).
@@ -544,11 +542,11 @@
         "batch get-path is ineligible too — same elision-registry hazard")))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-3ljsa — END-TO-END staleness guard. A single-frame DEFAULT-include
-;; snapshot is the precise bug shape: precheck would have served a hit
-;; while :epochs/:traces moved. With the fix it is precheck-ineligible,
-;; so the second call re-dispatches (and any change in the result text is
-;; caught by the post-eval cache instead of being silently hidden).
+;; END-TO-END staleness guard. A single-frame DEFAULT-include snapshot is
+;; the hazard shape: a precheck would serve a hit while :epochs/:traces
+;; moved. It is precheck-ineligible, so the second call re-dispatches
+;; (and any change in the result text is caught by the post-eval cache
+;; instead of being silently hidden).
 ;; ---------------------------------------------------------------------------
 
 (deftest single-frame-default-snapshot-does-not-precheck-hit
@@ -580,9 +578,9 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-3ljsa — NO over-invalidation. A single-frame APP-DB-ONLY snapshot
-;; is still precheck-eligible: an unchanged app-db hash serves the
-;; precheck hit (the optimisation is preserved for the sound case).
+;; NO over-invalidation. A single-frame APP-DB-ONLY snapshot is
+;; precheck-eligible: an unchanged app-db hash serves the precheck hit
+;; (the optimisation holds for the sound case).
 ;; ---------------------------------------------------------------------------
 
 (deftest single-frame-appdb-only-snapshot-still-precheck-hits
@@ -604,8 +602,8 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-olvr5 finding 3 — an operating-frame change FLUSHES the response
-;; cache. The cache key is `(tool, build, args)` and CANNOT include the
+;; An operating-frame change FLUSHES the response cache. The cache key
+;; is `(tool, build, args)` and CANNOT include the
 ;; resolved operating frame for an omitted-`:frame` call (it resolves
 ;; runtime-side). So a `get-path {path X}` cached against operating frame
 ;; A would be served against frame B after a frame switch if B shared A's
@@ -662,11 +660,10 @@
                        "an errored operating-frame call leaves the cache intact")
                    (done)))))))
 
-;; rf2-wdxyx3 finding 2 — the REAL set-operating-frame :no-such-frame path.
-;; The prior test stubbed an `:isError true` reset; this one runs the
-;; actual `set-operating-frame-tool` against a stubbed nREPL that answers
+;; The REAL set-operating-frame :no-such-frame path. This runs the actual
+;; `set-operating-frame-tool` against a stubbed nREPL that answers
 ;; :no-such-frame, then drives THAT real result through `invoke`'s
-;; chokepoint. It proves the failure now rides as `isError` (no silent
+;; chokepoint. It proves the failure rides as `isError` (no silent
 ;; ok-text) AND that the chokepoint's `(not (isError? result))` flush
 ;; guard therefore preserves the cache — the pin did NOT change, so a
 ;; no-`:frame` cached read stays valid.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/lazy_summary_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/lazy_summary_test.cljs
@@ -1,10 +1,9 @@
 (ns re-frame2-pair-mcp.lazy-summary-test
-  "Unit tests for the lazy-summary default generalised to every rich
-  snapshot slice (rf2-u2029).
+  "Unit tests for the lazy-summary default across every rich snapshot
+  slice.
 
-  rf2-tygdv landed a `{:rf.mcp/summary ...}` marker as the default for
-  the `:app-db` slice. rf2-u2029 generalises that default to every
-  rich slice in the snapshot response — `:sub-cache`, `:machines`,
+  A `{:rf.mcp/summary ...}` marker is the default for every rich slice
+  in the snapshot response — `:app-db`, `:sub-cache`, `:machines`,
   `:epochs`, `:traces` — so a discovery snapshot ('I don't know which
   slice carries the answer') stays under the wire cap by construction.
 
@@ -237,7 +236,7 @@
   "Build a fixture snapshot with realistically heavy slices: a 1MB
   app-db, a 100-entry sub-cache, 10 epoch records each carrying a full
   app-db `:db-before`, and a 200-entry trace ring buffer. Mirrors the
-  shape rf2-jlq5j's findings doc flagged as cap-blowing."
+  cap-blowing shape the lazy-summary default must tame."
   []
   (let [big-map (apply hash-map
                        (mapcat (fn [i] [(keyword (str "k" i))
@@ -259,10 +258,10 @@
                          :timestamp i}))}}))
 
 (deftest discovery-snapshot-fits-the-wire-cap
-  ;; rf2-jlq5j flagged the discovery snapshot ('I don't know which
-  ;; slice carries the answer') as the worst-case wire blow. With the
-  ;; lazy-summary default, every rich slice collapses to a marker —
-  ;; the entire response fits the 5,000-token cap.
+  ;; The discovery snapshot ('I don't know which slice carries the
+  ;; answer') is the worst-case wire blow. With the lazy-summary
+  ;; default, every rich slice collapses to a marker — the entire
+  ;; response fits the 5,000-token cap.
   (let [fat (make-fat-snapshot)
         ;; In the real pipeline, slice-app-db-in-snapshot runs upstream
         ;; and turns :app-db into a summary marker. Simulate that here.
@@ -277,9 +276,9 @@
              "Got " tokens " tokens, " (count wire) " chars."))))
 
 (deftest full-mode-blows-the-cap-as-expected
-  ;; The opt-in :full mode is the legacy behaviour — agents who pass
-  ;; it accept the wire cost. This test pins the budget POSTURE: the
-  ;; same fat snapshot under :full mode is dramatically larger.
+  ;; The opt-in :full mode ships the raw payload — agents who pass it
+  ;; accept the wire cost. This test pins the budget POSTURE: the same
+  ;; fat snapshot under :full mode is dramatically larger.
   (let [fat (make-fat-snapshot)
         with-app-db-full fat
         {:keys [snapshot]} (pipeline/summarise-other-slices-in-snapshot
@@ -293,8 +292,8 @@
 (deftest summary-vs-full-shrink-factor
   ;; Quantify the wire-byte impact. The summary marker scales with the
   ;; top-level shape (keys + count + bytes hint), not with the
-  ;; underlying payload. The shrink factor is the load-bearing claim
-  ;; the bead description ties acceptance to.
+  ;; underlying payload. The shrink factor is the load-bearing
+  ;; acceptance criterion.
   (let [fat                (make-fat-snapshot)
         with-app-db-summary (update-in fat [:rf/default :app-db] summary/tree-summary)
         with-app-db-full   fat
@@ -303,8 +302,8 @@
         full-wire    (pr-str (:snapshot (pipeline/summarise-other-slices-in-snapshot
                                           with-app-db-full {} :full)))
         ratio (/ (count full-wire) (count summary-wire))]
-    ;; Silent-on-success (rf2-try1x): the measured numbers ride on
-    ;; the failing-assertion message; agents on the green path don't
+    ;; Silent-on-success: the measured numbers ride on the
+    ;; failing-assertion message; agents on the green path don't
     ;; burn context on the per-test diagnostic.
     (is (> ratio 50)
         (str "Lazy-summary MUST shrink the discovery snapshot by at "

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/list_subscriptions_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/list_subscriptions_test.cljs
@@ -1,16 +1,16 @@
 (ns re-frame2-pair-mcp.list-subscriptions-test
   "Unit tests for the `list-subscriptions` + `list-streams` MCP tools.
 
-  ## rf2-qicji split
+  ## Two distinct sources
 
-  `list-subscriptions` used to wrap the streaming-tap registry
-  (`re-frame2-pair.runtime/subscription-info`) and returned
-  `{:subs []}` even when a frame had live reactive subscriptions — a
-  false-empty correctness bug. rf2-qicji repointed `list-subscriptions`
-  at the LIVE reactive sub-cache (via the runtime's `sub-cache-info` fn,
-  which reads the SAME `re-frame.subs.tooling/sub-cache-snapshot` source
-  `snapshot`'s `:sub-cache` slice reads), and moved the streaming-tap
-  diagnostic to the accurately-named `list-streams` tool.
+  `list-subscriptions` reads the LIVE reactive sub-cache (via the
+  runtime's `sub-cache-info` fn, which reads the SAME
+  `re-frame.subs.tooling/sub-cache-snapshot` source that `snapshot`'s
+  `:sub-cache` slice reads). `list-streams` wraps the streaming-tap
+  registry (`re-frame2-pair.runtime/subscription-info`). Keeping the
+  two separate means a frame with live reactive subscriptions reports
+  them accurately, with the streaming-tap diagnostic on its own
+  accurately-named tool.
 
   These tests pin:
    - the two descriptors (shape + arg contracts) so an accidental
@@ -38,7 +38,7 @@
   (some #(when (= nm (:name %)) %) tools/tool-descriptors))
 
 ;; ---------------------------------------------------------------------------
-;; list-subscriptions — reactive sub-cache descriptor (rf2-qicji)
+;; list-subscriptions — reactive sub-cache descriptor
 ;; ---------------------------------------------------------------------------
 
 (deftest list-subscriptions-descriptor-present
@@ -68,7 +68,7 @@
       (is (re-find #"rf2-qicji" desc)))))
 
 ;; ---------------------------------------------------------------------------
-;; list-subscriptions — wrong-source → right-source (the rf2-qicji fix)
+;; list-subscriptions — reads the reactive cache, not the streaming taps
 ;; ---------------------------------------------------------------------------
 
 (deftest list-subscriptions-eval-form-reads-reactive-sub-cache
@@ -122,7 +122,7 @@
           "snapshot's :sub-cache slice is the peer source list-subscriptions now reads"))))
 
 ;; ---------------------------------------------------------------------------
-;; list-streams — the relocated streaming-tap diagnostic (rf2-qicji)
+;; list-streams — the streaming-tap diagnostic
 ;; ---------------------------------------------------------------------------
 
 (deftest list-streams-descriptor-present

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/machine_slice_descriptor_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/machine_slice_descriptor_test.cljs
@@ -1,23 +1,19 @@
 (ns re-frame2-pair-mcp.machine-slice-descriptor-test
-  "EP-0015 drift gate for the `snapshot` tool's `:machines`-slice description
-  (rf2-scgnoe / rf2-i1h7tk).
+  "EP-0015 drift gate for the `snapshot` tool's `:machines`-slice description.
 
-  THE DRIFT. The generated MCP catalogue is what clients and skills read. The
-  `snapshot` descriptor used to say the `:machines` slice \"passes through
-  unchanged — payload redaction there is the `redact-interceptor` interceptor's
-  job.\" EP-0015 RETIRED `redact-interceptor` from the public API, and the
-  implementation has since moved machine snapshots into the durable runtime-db
-  partition, which fails closed to `:rf/redacted` off-box by default
-  (snapshot.cljs `redact-runtime-db?`). Documenting raw pass-through pointing at
-  a retired interceptor trains clients/tests to treat machine `:data` (durable
-  sensitive runtime state) as OUTSIDE EP-0015 projection.
+  THE CONTRACT. The generated MCP catalogue is what clients and skills read.
+  Machine snapshots live in the durable runtime-db partition, which fails
+  closed to `:rf/redacted` off-box by default (snapshot.cljs
+  `redact-runtime-db?`). The descriptor must reflect that posture so
+  clients/tests treat machine `:data` (durable sensitive runtime state) as
+  INSIDE EP-0015 projection — not as a raw pass-through.
 
-  THE GATE. The published `snapshot` descriptor must (a) carry NO retired
+  THE GATE. The published `snapshot` descriptor must (a) carry NO
   `redact-interceptor` wording and NOT claim the `:machines` slice passes
   through unchanged, and (b) describe the EP-0015 posture: the runtime-db
   `:machines` slice fails closed to `:rf/redacted` off-box by default and the
-  trusted-local gate threads through projection rather than bypassing it. A
-  future edit that re-introduces the raw-pass-through claim trips this test.
+  trusted-local gate threads through projection rather than bypassing it. An
+  edit that re-introduces the raw-pass-through claim trips this test.
 
   Behavioural redaction of the `:machines` slice itself (the server-side eval
   form's `redact-runtime-db?`) is covered in `sensitive_filter_test`."

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -1,10 +1,9 @@
 (ns re-frame2-pair-mcp.nrepl-test
   "Unit tests for the bencode framing helpers in nrepl.cljs.
 
-  The hard bug we fixed during the pilot — bencode@2 storing the
-  post-decode cursor on `bencode.decode.position` rather than the
-  module-level export — is the kind of regression that's easy to
-  reintroduce, so the multi-frame walker gets a thorough test.
+  bencode@2 stores the post-decode cursor on `bencode.decode.position`
+  rather than a module-level export — an easy detail to get wrong, so the
+  multi-frame walker gets a thorough test.
 
   Tests pin `decode-all-frames` directly from
   `re-frame2-pair-mcp.nrepl` — the source ns is the contract."
@@ -32,8 +31,9 @@
     (is (zero? (.-length rst)))))
 
 (deftest two-concatenated-frames-decode
-  ;; This is the case the bash-shim chain never had to handle (each
-  ;; call opened a fresh socket), and the one that bit us in the pilot.
+  ;; The persistent-socket case: two complete frames arrive in a single
+  ;; chunk and both must decode. (A fresh-socket-per-call design would
+  ;; never see this shape.)
   (let [buf      (js/Buffer.from "d3:foo3:bared3:baz3:quxe" "utf8")
         [fs rst] (decode-all buf)]
     (is (= 2 (count fs)))
@@ -63,8 +63,8 @@
     (is (zero? (.-length rst)))))
 
 (deftest incomplete-frame-retained-as-trailer
-  ;; rf2-ynjts.19 — the partial-frame branch directly on the public
-  ;; seam. A truncated bencode frame can't decode; `decode-all-frames`
+  ;; The partial-frame branch directly on the public seam. A truncated
+  ;; bencode frame can't decode; `decode-all-frames`
   ;; MUST return zero frames and hand the partial bytes back as the
   ;; trailer so the next TCP chunk can complete them. This is the
   ;; contract `attach-handlers!` relies on for its partial-frame
@@ -98,14 +98,14 @@
     (is (zero? (.-length rst)))))
 
 ;; ===========================================================================
-;; Port discovery — `read-port-from-fs` (rf2-wnrpi, finding G2).
+;; Port discovery — `read-port-from-fs`.
 ;;
 ;; The fn has a four-way precedence: the `SHADOW_CLJS_NREPL_PORT` env var
 ;; wins; failing that, three port-file candidates are tried in order; a
 ;; non-numeric value at any source is rejected via the `isNaN` guard; an
-;; all-miss returns nil. None of this was pinned — only `decode-all-frames`
-;; was. We stub `fs.readFileSync` + `process.env.SHADOW_CLJS_NREPL_PORT`
-;; to exercise every branch without touching the real filesystem.
+;; all-miss returns nil. We stub `fs.readFileSync` +
+;; `process.env.SHADOW_CLJS_NREPL_PORT` to exercise every branch without
+;; touching the real filesystem.
 ;; ===========================================================================
 
 (def ^:private env-key "SHADOW_CLJS_NREPL_PORT")
@@ -122,7 +122,7 @@
   value of `body`.
 
   Sync-only: the `finally` block restores the stub immediately after
-  `body` returns. The new async cascade tests use [[with-async-fs-stub!]]
+  `body` returns. The async cascade tests use [[with-async-fs-stub!]]
   which keeps the stub alive across Promise microtasks."
   [env-val stub-fn body]
   (let [orig-read (.-readFileSync fs)
@@ -146,9 +146,9 @@
 
   Always pair `install-fs-stub!` with its restoration call inside the
   final `.then` (BEFORE `(done)`) so the next test in the queue starts
-  with a pristine fs.readFileSync (rf2-umoz2). The local convention
-  here: bind the thunk in a `let`, do assertions in `.then`, call the
-  thunk, then call done."
+  with a pristine fs.readFileSync. The local convention here: bind the
+  thunk in a `let`, do assertions in `.then`, call the thunk, then call
+  done."
   [env-val stub-fn]
   (let [orig-read (.-readFileSync fs)
         orig-env  (j/get-in js/process [:env env-key])]
@@ -228,9 +228,9 @@
         (is (nil? (nrepl/read-port-from-fs)))))))
 
 ;; ---------------------------------------------------------------------------
-;; --port-file explicit override (rf2-3dbwh). The 1-arity `read-port-from-fs`
-;; takes an explicit, cwd-independent path that wins over BOTH the env var and
-;; the relative file-scan candidates. nil/blank ⇒ falls through to the normal
+;; --port-file explicit override. The 1-arity `read-port-from-fs` takes an
+;; explicit, cwd-independent path that wins over BOTH the env var and the
+;; relative file-scan candidates. nil/blank ⇒ falls through to the normal
 ;; precedence chain.
 ;; ---------------------------------------------------------------------------
 
@@ -283,15 +283,14 @@
             "0-arity stays equivalent")))))
 
 ;; ===========================================================================
-;; Transport data-handler — `attach-handlers!` (rf2-wnrpi, finding G3).
+;; Transport data-handler — `attach-handlers!`.
 ;;
 ;; The persistent-socket `data` handler folds each chunk into the conn's
-;; `:buf` and splits off complete frames in a SINGLE swap! (the framing-
-;; race fix), then dispatches every complete frame to its pending-id
-;; handler. That logic carried heavy rationale comments but no automated
-;; regression in the default gate (only the opt-in live-nrepl.js). It is
-;; pure buffer logic over a fed chunk — unit-testable with a fake socket
-;; that records its event callbacks rather than a real TCP connection.
+;; `:buf` and splits off complete frames in a SINGLE swap! (so framing is
+;; race-free), then dispatches every complete frame to its pending-id
+;; handler. It is pure buffer logic over a fed chunk — unit-testable with a
+;; fake socket that records its event callbacks rather than a real TCP
+;; connection.
 ;; ===========================================================================
 
 (defn- fake-socket
@@ -395,7 +394,7 @@
       (is (true? (:closed? @conn))))))
 
 ;; ===========================================================================
-;; `close!` — reconnect / probe-cache reset (rf2-wnrpi, finding G3).
+;; `close!` — reconnect / probe-cache reset.
 ;; ===========================================================================
 
 (deftest close!-resets-probe-cache-and-pending
@@ -414,14 +413,15 @@
           "probe cache cleared — a fresh connect must re-probe the preload"))))
 
 ;; ===========================================================================
-;; `send-op!` connect→write race nil-guard (rf2-av5kl).
+;; `send-op!` connect→write race nil-guard.
 ;;
 ;; `connect!`'s fast path resolves immediately when a live socket is present,
 ;; but the socket close/error handlers can fire in the window between that
-;; resolve and the actual `.write`. If `:socket` got nilled by `close!` in
-;; that window, a bare `(.write nil ...)` would throw an opaque native
-;; "Cannot read .write of null" AND strand the just-registered id in
-;; `:pending`. We simulate the race by nilling `:socket` synchronously after
+;; resolve and the actual `.write`. If `:socket` is nilled by `close!` in
+;; that window, the guard rejects with a structured retry-to-reconnect
+;; message rather than a bare `(.write nil ...)` (which would throw an opaque
+;; native "Cannot read .write of null" AND strand the just-registered id in
+;; `:pending`). We simulate the race by nilling `:socket` synchronously after
 ;; the send-op! call but before the `.then` microtask runs.
 ;; ===========================================================================
 
@@ -471,14 +471,13 @@
             (done)))))))
 
 ;; ===========================================================================
-;; `discover-port*` async cascade (rf2-umoz2 + rf2-3grub).
+;; `discover-port*` async cascade.
 ;;
 ;; The five-step cascade — explicit > env > MCP roots/list > shadow HTTP probe
-;; > cwd scan — promotes the cwd-bound file scan from highest-priority-after-
-;; env to a last-resort fallback. Steps 3 and 4 are async I/O; the others are
-;; sync.
+;; > cwd scan — runs the cwd-bound file scan as a last-resort fallback. Steps
+;; 3 and 4 are async I/O; the others are sync.
 ;;
-;; The cascade now returns a discovery-result map
+;; The cascade returns a discovery-result map
 ;; `{:port :project-home :ambiguous :workspace-roots ...}` so callers can
 ;; drive elicitation when roots/list returns 2+ candidates. Tests pass
 ;; stubs for the probe and roots fns to exercise each cascade branch
@@ -529,9 +528,9 @@
             (.then (fn [r]
                      (is (= 9001 (:port r))
                          "explicit --port-file wins the cascade")
-                     ;; rf2-ww877w — the explicit branch returns the EXACT
-                     ;; path the caller named, so the server caches it
-                     ;; verbatim (no derived `.shadow-cljs/nrepl.port`).
+                     ;; The explicit branch returns the EXACT path the caller
+                     ;; named, so the server caches it verbatim (no derived
+                     ;; `.shadow-cljs/nrepl.port`).
                      (is (= "explicit/nrepl.port" (:port-file r))
                          "explicit --port-file returns the exact path it read")
                      (is (false? @probed?)
@@ -542,11 +541,11 @@
                      (done))))))))
 
 (deftest discover-port-explicit-port-file-unreadable-falls-through-to-env
-  ;; rf2-olvr5 finding 4 — a stale / typo'd explicit --port-file must NOT
-  ;; short-circuit the cascade to `{:port nil}`. When the explicit file is
-  ;; unreadable (ENOENT) the cascade falls through to step 2 ($SHADOW_CLJS_
-  ;; NREPL_PORT) — mirroring `read-port-from-fs`'s leading `or`. Pre-fix
-  ;; this resolved `{:port nil}` and stranded a live env-provided port.
+  ;; A stale / typo'd explicit --port-file must NOT short-circuit the
+  ;; cascade to `{:port nil}`. When the explicit file is unreadable (ENOENT)
+  ;; the cascade falls through to step 2 ($SHADOW_CLJS_NREPL_PORT) —
+  ;; mirroring `read-port-from-fs`'s leading `or` — so a live env-provided
+  ;; port is honoured rather than stranded.
   (testing "explicit --port-file unreadable → fall through to env var"
     (async done
       (let [restore! (install-fs-stub! "7788" throwing-read)]
@@ -557,9 +556,9 @@
             (.finally (fn [] (restore!) (done))))))))
 
 (deftest discover-port-explicit-port-file-unreadable-falls-through-to-roots
-  ;; rf2-olvr5 finding 4 — with no env var, the unreadable explicit file
-  ;; falls all the way through to the MCP roots/list step (step 3). The
-  ;; explicit-but-stale path is fully transparent to the rest of the cascade.
+  ;; With no env var, the unreadable explicit file falls all the way
+  ;; through to the MCP roots/list step (step 3). The explicit-but-stale
+  ;; path is fully transparent to the rest of the cascade.
   (testing "explicit --port-file unreadable + no env → fall through to roots discovery"
     (async done
       (let [restore! (install-fs-stub! nil throwing-read)]
@@ -639,10 +638,10 @@
                          "step 4 caught the port after step 3 was unsupported")
                      (is (= "/abs/proj/root" (:project-home r))
                          "project-home flows through from shadow probe step")
-                     ;; rf2-ww877w — the HTTP-probe result surfaces the
-                     ;; WINNING candidate file (here target/shadow-cljs/
-                     ;; nrepl.port resolved against the shadow root) so the
-                     ;; server caches the exact path that read.
+                     ;; The HTTP-probe result surfaces the WINNING candidate
+                     ;; file (here target/shadow-cljs/nrepl.port resolved
+                     ;; against the shadow root) so the server caches the
+                     ;; exact path that read.
                      (is (re-find #"target[\\/]shadow-cljs[\\/]nrepl\.port$"
                                   (str (:port-file r)))
                          "winning candidate file (target/shadow-cljs/nrepl.port) is surfaced")
@@ -666,7 +665,7 @@
             (.then (fn [r]
                      (is (= 5550 (:port r))
                          "first candidate (target/shadow-cljs/nrepl.port) wins")
-                     ;; rf2-ww877w — the winning candidate's path is surfaced
+                     ;; The winning candidate's path is surfaced
                      ;; (target/shadow-cljs/nrepl.port, the first candidate).
                      (is (re-find #"target[\\/]shadow-cljs[\\/]nrepl\.port$"
                                   (str (:port-file r)))
@@ -674,12 +673,12 @@
                      (restore!)
                      (done))))))))
 
-;; rf2-ww877w — exhaustive port-file surfacing for the HTTP-probe path. For
-;; EACH candidate order (only the .shadow-cljs file present, only the
-;; .nrepl-port present), the SURFACED :port-file must be the candidate that
-;; actually read — NOT a fixed derivation. This is the drift the bead kills:
-;; the server caches whatever discovery resolved, so the per-tool-call
-;; re-read checks the right file and doesn't false-positive "file vanished".
+;; Exhaustive port-file surfacing for the HTTP-probe path. For EACH
+;; candidate order (only the .shadow-cljs file present, only the .nrepl-port
+;; present), the SURFACED :port-file must be the candidate that actually
+;; read — NOT a fixed derivation. The server caches whatever discovery
+;; resolved, so the per-tool-call re-read checks the right file and doesn't
+;; false-positive "file vanished".
 (deftest discover-port-shadow-probe-surfaces-each-candidate-file
   (testing ".shadow-cljs/nrepl.port wins → that exact file is surfaced"
     (async done
@@ -721,8 +720,8 @@
                      (restore!)
                      (done))))))))
 
-;; rf2-ww877w — the roots/list single-candidate path threads the candidate's
-;; own :port-file through (the `.shadow-cljs/nrepl.port` adjacent to the
+;; The roots/list single-candidate path threads the candidate's own
+;; :port-file through (the `.shadow-cljs/nrepl.port` adjacent to the
 ;; discovered shadow-cljs.edn), so the server caches the discovered file.
 (deftest discover-port-roots-single-candidate-surfaces-port-file
   (testing "step 3 single candidate → its :port-file flows through"
@@ -736,9 +735,9 @@
                      (restore!)
                      (done))))))))
 
-;; rf2-ww877w — the cwd-scan last resort (step 5) supplies NO :port-file:
-;; there is no project-home anchor for a stable absolute path, so the server
-;; must fall back to its derivation (or skip the per-call re-read).
+;; The cwd-scan last resort (step 5) supplies NO :port-file: there is no
+;; project-home anchor for a stable absolute path, so the server must fall
+;; back to its derivation (or skip the per-call re-read).
 (deftest discover-port-cwd-scan-surfaces-no-port-file
   (testing "step 5 (cwd scan) → :port-file is nil (no project-home anchor)"
     (async done
@@ -842,20 +841,18 @@
                      (done))))))))
 
 ;; ===========================================================================
-;; `connect!` reopen preserves the session build-id caches (rf2-c3dsr).
+;; `connect!` reopen preserves the session build-id caches.
 ;;
-;; THE BUG: `connect!` used to blank `:probed-builds` / `:resolved-build-id`
-;; / `:build-alias` every time it OPENED the socket (whenever `:closed?`
-;; was true). `send-op!` calls `connect!` on every nREPL op, and the
-;; close/error handlers flip `:closed? true` on a TRANSIENT socket hiccup
-;; without changing the target build — so the next op's `connect!` reopened
-;; the SAME port AND wiped a valid same-session sticky build. The next
-;; no-`:build` call then fell back to `:app` (the live orient-{} symptom).
+;; `connect!` is transport-only: it preserves `:probed-builds` /
+;; `:resolved-build-id` / `:build-alias` across a same-port reopen.
+;; `send-op!` calls `connect!` on every nREPL op, and the close/error
+;; handlers flip `:closed? true` on a TRANSIENT socket hiccup without
+;; changing the target build — so the next op's `connect!` reopens the SAME
+;; port and must keep the valid same-session sticky build (otherwise a
+;; no-`:build` call falls back to `:app`).
 ;;
-;; THE FIX (option a): `connect!` is transport-only — it preserves the
-;; caches across a same-port reopen. The genuine "operator restarted shadow
-;; against a DIFFERENT build" reset (rf2-l9ixp) is preserved at the layers
-;; that observe the build identity changing:
+;; The genuine "operator restarted shadow against a DIFFERENT build" reset
+;; is enforced at the layers that observe the build identity changing:
 ;;   - `close!` (operator-initiated teardown) clears all three; and
 ;;   - `server.cljs/ensure-connection!` builds a FRESH conn (empty caches)
 ;;     on a shadow port change/vanish — which is how a different build
@@ -902,10 +899,11 @@
     p))
 
 (deftest connect!-reopen-preserves-resolved-build-id-after-hiccup
-  ;; rf2-c3dsr core regression: a transient socket close+reopen of the
-  ;; SAME port mid-session PRESERVES the sticky `:resolved-build-id` (and
-  ;; the sibling `:probed-builds` / `:build-alias` caches). The bug wiped
-  ;; them, so a follow-up no-`:build` op fell back to `:app`.
+  ;; Core regression guard: a transient socket close+reopen of the SAME
+  ;; port mid-session PRESERVES the sticky `:resolved-build-id` (and the
+  ;; sibling `:probed-builds` / `:build-alias` caches), so a follow-up
+  ;; no-`:build` op keeps targeting the right build rather than falling
+  ;; back to `:app`.
   (async done
     (let [cbs*     (atom {})
           restore! (with-stubbed-create-connection! cbs*)
@@ -982,11 +980,10 @@
                    (done)))))))
 
 ;; ===========================================================================
-;; The l9ixp different-build reset is PRESERVED (rf2-c3dsr).
+;; The different-build reset is enforced.
 ;;
-;; The fix preserves the cache across a transient hiccup but must NOT
-;; regress the rf2-l9ixp guarantee that a genuine different-build reconnect
-;; clears the stale cache. That guarantee now lives in two places:
+;; The cache survives a transient hiccup, but a genuine different-build
+;; reconnect must clear the stale cache. That guarantee lives in two places:
 ;;
 ;;   1. `close!` (operator-initiated teardown) clears all three caches —
 ;;      so a reopen after an explicit close starts clean.
@@ -1000,7 +997,7 @@
 (deftest different-build-reconnect-after-close-resets-caches
   ;; The operator-teardown path: `close!` clears the caches, so a SUBSEQUENT
   ;; reopen of the (possibly same) socket starts with no stale build —
-  ;; exactly the rf2-l9ixp "restarted shadow against a different build" guard.
+  ;; the "restarted shadow against a different build" guard.
   (async done
     (let [cbs*     (atom {})
           restore! (with-stubbed-create-connection! cbs*)
@@ -1033,7 +1030,8 @@
   ;; `ensure-connection!` discards the old conn and builds a fresh one for
   ;; the new ephemeral port. A fresh conn has empty build-id caches by
   ;; construction — so the new build is re-discovered, never inheriting the
-  ;; old build's sticky id (l9ixp preserved without relying on connect!).
+  ;; old build's sticky id (the different-build reset holds without relying
+  ;; on connect!).
   (let [old-conn (nrepl/make-conn 6001 "127.0.0.1")]
     (swap! old-conn assoc
            :resolved-build-id :examples/old-build

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/onboarding_catalogue_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/onboarding_catalogue_test.cljs
@@ -1,22 +1,21 @@
 (ns re-frame2-pair-mcp.onboarding-catalogue-test
-  "Drift guard for the inline onboarding catalogue (rf2-eey14).
+  "Drift guard for the inline onboarding catalogue.
 
   `get-re-frame2-pair-instructions` ships a prose `## Tool catalogue`
   section (an inline string in `tools/get_re_frame2_pair_instructions`)
   that an AI agent reads to learn what tools exist. Unlike the
   `tools/list` descriptors — which are GENERATED from the single
   `registry/tools` source and so cannot drift — the onboarding prose is
-  hand-maintained. It HAD drifted: six registered tools (orient,
-  read-sub, read-ui, set/reset/get-operating-frame) were missing, so a
-  model following the catalogue reached for snapshot / raw eval instead
-  of the bounded reads, or guessed frame targeting instead of the
-  operating-frame ops.
+  hand-maintained, so it can drift out of sync with the registered tool
+  set. A missing tool (e.g. orient, read-sub, read-ui,
+  set/reset/get-operating-frame) leaves a model reaching for snapshot /
+  raw eval instead of the bounded reads, or guessing frame targeting
+  instead of the operating-frame ops.
 
-  The existing `scripts/check_skill_mcp_drift.py` cross-checks the
-  SKILL.md allowed-tools vs the descriptors — NOT this inline prose — so
-  it passed straight through the gap. This suite closes it at the source:
-  the catalogue MUST enumerate exactly the registered tool set, no
-  omissions and no phantom names.
+  `scripts/check_skill_mcp_drift.py` cross-checks the SKILL.md
+  allowed-tools vs the descriptors — NOT this inline prose — so this
+  suite guards the prose at the source: the catalogue MUST enumerate
+  exactly the registered tool set, no omissions and no phantom names.
 
   Parse contract: each tool is listed on its own line as
   `\"  <name>          — <one-liner>\"` — two leading spaces, the tool

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/orient_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/orient_test.cljs
@@ -1,6 +1,5 @@
 (ns re-frame2-pair-mcp.orient-test
-  "Unit tests for the orient tool (rf2-3bu3d.8) — the app-shape
-  orientation summary.
+  "Unit tests for the orient tool — the app-shape orientation summary.
 
   The tool is a thin wrapper over the runtime `orient` fn: it emits the
   `(re-frame2-pair.runtime/orient)` form and shapes the response. Here we
@@ -15,17 +14,17 @@
   The runtime `orient` composition is exercised by the bb structural pin
   (tests/runtime/orient_test.clj in the skill).
 
-  ## Stub lifetime — fixture-scoped, not Promise-chain-scoped (rf2-wb06a)
+  ## Stub lifetime — fixture-scoped, not Promise-chain-scoped
 
   Each test installs its `cljs-eval-value` stub via a bare `set!` (no
   per-test `.finally`); a `use-fixtures :each :after` step unconditionally
-  restores the pristine original captured at ns-load. This makes cleanup
+  restores the pristine original captured at ns-load. This keeps cleanup
   independent of the Promise chain: a `.finally`-scoped restore fires
-  AFTER cljs.test's `done` has already advanced to the next test, which
-  in the full suite let a neighbour's late restore clobber THIS test's
+  AFTER cljs.test's `done` has already advanced to the next test, which in
+  the full suite would let a neighbour's late restore clobber THIS test's
   freshly-installed stub mid-eval — surfacing as a flaky
   `connect EADDRNOTAVAIL` from the real socket fn. The fixture boundary
-  closes that race (the same fix invoke_test carries)."
+  closes that race (the same approach invoke_test uses)."
   (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.nrepl :as nrepl]
@@ -50,11 +49,10 @@
               :ambiguous-frame? false :runtime-instance-id "abc"}
    :frames   {:all [:rf/default :rf/xray] :app [:rf/default] :operating :rf/default}
    :app-db-top-keys {:rf/default [:cart :route :user]}
-   ;; rf2-uydhif: the runtime orient counts carry the three EP-0016
-   ;; resources-artefact kinds (:resource / :mutation / :resource-scope)
-   ;; — see the orient descriptor example in descriptors_data.cljs. The
-   ;; pre-EP-0016 sample omitted them, so a runtime that dropped a kind
-   ;; from the counts map would have passed green here.
+   ;; The runtime orient counts carry the three EP-0016 resources-artefact
+   ;; kinds (:resource / :mutation / :resource-scope) — see the orient
+   ;; descriptor example in descriptors_data.cljs. Including them here means
+   ;; a runtime that dropped a kind from the counts map fails this pin.
    :registry {:counts {:event 14 :sub 9 :fx 3 :cofx 1 :view 6
                        :frame 2 :route 4 :flow 0 :head 0 :error-projector 0
                        :resource 3 :mutation 2 :resource-scope 1}
@@ -65,7 +63,7 @@
 
 (defn- stub-eval!
   "Install a `cljs-eval-value` stub via a bare `set!` (NO `.finally` —
-  cleanup is the `:after` fixture's job, rf2-wb06a). Records the emitted
+  cleanup is the `:after` fixture's job). Records the emitted
   (non-probe) form into `captured*` and resolves it with `canned`.
   PROBE-AWARE: the preload-probe sentinel form (`__re_frame2_pair_runtime`)
   is answered with `true` so the tool's `ensure-runtime!` preflight passes
@@ -119,8 +117,8 @@
                  (done))))))
 
 (deftest excludes-tool-frames-from-app-db-top-keys
-  ;; The rf2-3bu3d.6 posture: :app-db-top-keys is keyed by APP frames
-  ;; only — a reserved :rf/xray tool frame is in :frames :all but NOT in
+  ;; The posture: :app-db-top-keys is keyed by APP frames only — a
+  ;; reserved :rf/xray tool frame is in :frames :all but NOT in
   ;; :app-db-top-keys (the runtime excludes it). We assert the tool
   ;; passes the runtime's shape through faithfully.
   (async done
@@ -146,9 +144,9 @@
                  (done))))))
 
 (deftest echoes-resolved-build-for-round-tripping
-  ;; rf2-8t3ct / rf2-fmho5 — orient echoes the canonical resolved :build
-  ;; (the session-sticky target when :build is omitted) so the agent sees
-  ;; which build it oriented against.
+  ;; orient echoes the canonical resolved :build (the session-sticky
+  ;; target when :build is omitted) so the agent sees which build it
+  ;; oriented against.
   (async done
     (stub-eval! nil sample-summary)
     (-> (orient/orient-tool (fresh-conn) #js {})
@@ -159,7 +157,7 @@
 
 (deftest echoes-session-sticky-build-when-omitted
   ;; With a session target cached (a prior discover-app), orient with no
-  ;; :build arg resolves to AND echoes that sticky target (rf2-fmho5).
+  ;; :build arg resolves to AND echoes that sticky target.
   (async done
     (stub-eval! nil sample-summary)
     (let [conn (fresh-conn)]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/output_schema_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/output_schema_test.cljs
@@ -1,8 +1,8 @@
 (ns re-frame2-pair-mcp.output-schema-test
-  "Pin rf2-3l3be — every MCP tool descriptor MUST carry an
-  `:outputSchema` map describing its `structuredContent` payload
-  shape. mcp-builder canonical pattern: 'Define outputSchema wherever
-  possible for structured responses.'
+  "Pin: every MCP tool descriptor MUST carry an `:outputSchema` map
+  describing its `structuredContent` payload shape. mcp-builder
+  canonical pattern: 'Define outputSchema wherever possible for
+  structured responses.'
 
   The slot rides next to `:inputSchema` in the static descriptor
   data and projects to the wire via `tool-descriptors-js` (which is

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/path_slicing_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/path_slicing_test.cljs
@@ -1,14 +1,14 @@
 (ns re-frame2-pair-mcp.path-slicing-test
-  "Unit tests for the path-slicing surfaces added under rf2-tygdv.
+  "Unit tests for the path-slicing surfaces.
 
   Two MCP surfaces share the same path vocabulary:
 
-    - The `snapshot` tool gained a `:path` arg that slices the
+    - The `snapshot` tool carries a `:path` arg that slices the
       `:app-db` slice. Without `:path`, the `:app-db` slice is
       replaced by a `{:rf.mcp/summary ...}` marker (default mode
       `:summary`) so the response stays under the wire cap.
-    - The new `get-path` tool returns the value at a single path —
-      a minimal primitive for targeted reads.
+    - The `get-path` tool returns the value at a single path — a
+      minimal primitive for targeted reads.
 
   Tests pin the public helpers directly from their owning namespaces:
   `tools.args/parse-path-arg`, `tools.summary/tree-summary`,
@@ -78,13 +78,13 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest tree-summary-map-records-top-level-keys-and-bytes-approx
-  ;; rf2-qta8j: `:bytes` is a cheap approximation, not a precise count.
-  ;; Earlier shape paid `(count (pr-str v))` per branch — a deep walk
-  ;; that contradicted the marker's "no-deep-walk" contract (54MB
-  ;; app-db slice burned a 54MB string allocation per summary). The
-  ;; field is now `count × per-entry constant`. Pin the contract: the
-  ;; estimate scales linearly with entry count, is non-negative, and
-  ;; is order-of-magnitude reasonable for tiny maps.
+  ;; `:bytes` is a cheap approximation, not a precise count. It is
+  ;; `count × per-entry constant`, never `(count (pr-str v))` — a
+  ;; deep walk would contradict the marker's "no-deep-walk" contract
+  ;; (a 54MB app-db slice would burn a 54MB string allocation per
+  ;; summary). Pin the contract: the estimate scales linearly with
+  ;; entry count, is non-negative, and is order-of-magnitude
+  ;; reasonable for tiny maps.
   (let [v {:a 1 :b 2 :nested {:deep {:value 42}}}
         s (summary/tree-summary v)
         marker (:rf.mcp/summary s)]
@@ -112,11 +112,10 @@
         "10-entry map's bytes estimate should be 10x a 1-entry map's")))
 
 (deftest tree-summary-bytes-is-cheap-on-large-values
-  ;; rf2-qta8j: the load-bearing property. Computing `:bytes` on a
-  ;; 50K-entry map MUST be effectively instant — the marker exists
-  ;; precisely to avoid serialising the deep value. Earlier shape
-  ;; paid `(count (pr-str v))` which would have burned ~megabytes
-  ;; of string allocation here.
+  ;; The load-bearing property. Computing `:bytes` on a 50K-entry map
+  ;; MUST be effectively instant — the marker exists precisely to avoid
+  ;; serialising the deep value. A `(count (pr-str v))` approach would
+  ;; burn ~megabytes of string allocation here.
   ;;
   ;; We don't time the call (test environments vary too much) but we
   ;; pin the structural property: the result is the entry count
@@ -157,10 +156,10 @@
         "Marker for a 5k-entry map MUST still fit the wire cap")))
 
 (deftest tree-summary-scalar-returns-value-unchanged
-  ;; rf2-ambfv: scalars already fit the wire cap by definition, so
-  ;; wrapping them in a summary marker would add tokens without saving
-  ;; any. The fn returns the scalar unchanged — no `:rf.mcp/summary`
-  ;; wrapper, no `:type :scalar` marker.
+  ;; Scalars already fit the wire cap by definition, so wrapping them in
+  ;; a summary marker would add tokens without saving any. The fn returns
+  ;; the scalar unchanged — no `:rf.mcp/summary` wrapper, no
+  ;; `:type :scalar` marker.
   (is (= 42 (summary/tree-summary 42)))
   (is (= "hello" (summary/tree-summary "hello")))
   (is (= :a-keyword (summary/tree-summary :a-keyword)))
@@ -302,11 +301,11 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest summary-mode-bounds-the-5mb-scenario
-  ;; rf2-jlq5j: a 5MB app-db pr-strs to ~5.6M chars ⇒ ~1.4M tokens,
-  ;; 290× the 5,000-token cap. With path slicing's :summary default,
-  ;; the same call replaces the slice with a small marker — fits the
-  ;; cap by construction. The wire-cap remains the backstop for the
-  ;; remaining slices, but :app-db alone no longer blows the budget.
+  ;; A 5MB app-db pr-strs to ~5.6M chars ⇒ ~1.4M tokens, 290× the
+  ;; 5,000-token cap. With path slicing's :summary default, the call
+  ;; replaces the slice with a small marker — fits the cap by
+  ;; construction. The wire-cap remains the backstop for the remaining
+  ;; slices, but :app-db alone never blows the budget.
   (let [big-app-db (apply hash-map
                           (mapcat (fn [i] [(keyword (str "k" i))
                                            (apply str (repeat 1024 "x"))])

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_file_stability_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_file_stability_test.cljs
@@ -1,20 +1,16 @@
 (ns re-frame2-pair-mcp.port-file-stability-test
-  "Regression for the port-file discovery drift (rf2-ww877w).
+  "Regression for port-file discovery stability.
 
-  THE BUG: discovery resolved a port via an explicit `--port-file` (or
-  the shadow HTTP probe) but did NOT surface WHICH file it read. The
-  server then DERIVED a fixed `<project-home>/.shadow-cljs/nrepl.port`
-  as the cached `:port-file`. For an explicit
-  `target/shadow-cljs/nrepl.port` that derivation produced the
-  non-existent `target/shadow-cljs/.shadow-cljs/nrepl.port`. The very
-  next `ensure-connection!` read that derived path as MISSING, treated
-  it as a shadow shutdown, closed the socket, forced rediscovery, and
-  reset the per-connection build/probe caches — on every tool call.
-
-  THE FIX: discovery surfaces the exact `:port-file` it resolved
-  (nrepl.cljs); the server caches that path verbatim instead of
-  deriving one. A second `ensure-connection!` then re-reads the SAME
-  file, sees the SAME port, and stays on the cached connection.
+  Discovery surfaces the exact `:port-file` it resolved (nrepl.cljs);
+  the server caches that path verbatim. A second `ensure-connection!`
+  re-reads the SAME file, sees the SAME port, and stays on the cached
+  connection — rather than deriving a fixed
+  `<project-home>/.shadow-cljs/nrepl.port`, which for an explicit
+  `target/shadow-cljs/nrepl.port` would point at a non-existent
+  `target/shadow-cljs/.shadow-cljs/nrepl.port` and make the next
+  `ensure-connection!` mis-read the path as missing, close the socket,
+  force rediscovery, and reset the per-connection build/probe caches on
+  every tool call.
 
   These tests exercise the server's `ensure-connection!` cached-path
   branch directly with a stubbed `fs.readFileSync`, asserting the
@@ -55,10 +51,9 @@
       (let [explicit-pf "C:/repo/target/shadow-cljs/nrepl.port"
             conn        (nrepl/make-conn 7001 "127.0.0.1")
             ;; The exact file discovery resolved is present and reads 7001;
-            ;; the bug's DERIVED path
+            ;; a DERIVED path
             ;; (C:/repo/target/shadow-cljs/.shadow-cljs/nrepl.port) does NOT
-            ;; exist, so if the server had cached THAT it would mis-fire the
-            ;; "vanished" branch.
+            ;; exist, so caching THAT would mis-fire the "vanished" branch.
             restore!    (with-fs-read (reads-port-at explicit-pf "7001"))]
         (server/set-discovered-for-tests!
           {:conn conn :port 7001 :port-file explicit-pf
@@ -83,7 +78,7 @@
 (deftest cached-probe-winning-candidate-stays-on-connection
   (testing "a winning HTTP-probe candidate (target/shadow-cljs/nrepl.port) is reused when unchanged (rf2-ww877w)"
     (async done
-      ;; The probe winner was target/shadow-cljs/nrepl.port, NOT the
+      ;; The probe winner is target/shadow-cljs/nrepl.port, NOT a
       ;; derived .shadow-cljs/nrepl.port. Cache the winning path; re-read
       ;; sees the same port ⇒ stay put.
       (let [winning-pf "/abs/proj/root/target/shadow-cljs/nrepl.port"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_to_build_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_to_build_test.cljs
@@ -1,11 +1,11 @@
 (ns re-frame2-pair-mcp.port-to-build-test
-  "URL/port -> build resolution via the shadow-cljs :dev-http map (rf2-fyf0h).
+  "URL/port -> build resolution via the shadow-cljs :dev-http map.
 
   A pair session starts from the browser URL of the open tab (e.g.
   http://localhost:8031/counter), but discover-app speaks build-ids. The
-  first live session (2026-05-29) had the agent grep the repo for 8031 to
-  learn that port maps to the step_deck testbed before connecting. These
-  tests pin the new `:port` arg path:
+  `:port` arg bridges the two: an operator passes the port from the URL
+  and discover-app resolves the build serving it. These tests pin the
+  `:port` arg path:
 
     - `probe/resolve-build-by-port` reads the :dev-http map JVM-side and
       returns the build whose :output-dir is served on that port.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
@@ -1,13 +1,12 @@
 (ns re-frame2-pair-mcp.probe-test
-  "Unit tests for the runtime preload probe + per-socket probe cache
-  (rf2-sjpx0).
+  "Unit tests for the runtime preload probe + per-socket probe cache.
 
   The probe runs one bencode round-trip per non-streaming tool entry
   to confirm the re-frame2-pair runtime is loaded into the consumer build
-  before any tool form is sent. Audit rf2-sjpx0 surfaced that this
-  fixed cost doubles cheap-read latency — once the preload is
-  confirmed for a given `(conn, build-id)` pair, it cannot un-load
-  without socket teardown, so subsequent probes are pure waste.
+  before any tool form is sent. That fixed cost would double cheap-read
+  latency on every call, so it is cached: once the preload is confirmed
+  for a given `(conn, build-id)` pair, it cannot un-load without socket
+  teardown, so subsequent probes would be pure waste.
 
   The cache:
 
@@ -40,12 +39,11 @@
   (returning a Promise) and restore in `.finally` so cleanup outlives
   async resolution. Mirror of `conformance_test/with-stubbed-eval!`.
 
-  rf2-7tgfk: also stubs `nrepl/jvm-eval` minimally so the preload-
-  failure diagnostic ladder runs to the `:runtime-loaded-but-preload-
-  missing` rung (the one that mirrors the OLD `:runtime-not-preloaded`
-  semantics — runtime alive, marker absent). Without the JVM stub the
-  ladder would short-circuit on `:nrepl-unreachable` for every
-  negative cljs probe."
+  Also stubs `nrepl/jvm-eval` minimally so the preload-failure
+  diagnostic ladder runs to the `:runtime-loaded-but-preload-missing`
+  rung (runtime alive, marker absent). Without the JVM stub the ladder
+  would short-circuit on `:nrepl-unreachable` for every negative cljs
+  probe."
   [canned-value call-count* body-fn]
   (let [orig-cljs nrepl/cljs-eval-value
         orig-jvm  nrepl/jvm-eval
@@ -109,9 +107,9 @@
           (.then (fn [_] (done)))))))
 
 (deftest second-positive-probe-is-cached
-  ;; rf2-sjpx0: a confirmed positive probe MUST short-circuit on the
-  ;; next call for the same (conn, build-id). The second call must
-  ;; resolve true WITHOUT incrementing the eval counter.
+  ;; A confirmed positive probe MUST short-circuit on the next call for
+  ;; the same (conn, build-id). The second call must resolve true
+  ;; WITHOUT incrementing the eval counter.
   (async done
     (let [conn  (fresh-conn)
           calls (atom 0)]
@@ -230,14 +228,12 @@
   ;; Negative path surfaces a structured ex-info — cache only
   ;; affects positive-result hot path.
   ;;
-  ;; rf2-7tgfk: the rejection reason is now
-  ;; `:runtime-loaded-but-preload-missing` (the specific rung of the
-  ;; diagnostic ladder for the case where the JVM is reachable, the
-  ;; build is running, a CLJS runtime is connected, and ONLY the
-  ;; marker is absent). The probe-test stub returns `false` for the
-  ;; marker query (runtime alive, marker absent) → the ladder lands
-  ;; on this rung. Pre-rf2-7tgfk a single `:runtime-not-preloaded`
-  ;; reason covered every failure mode regardless of root cause.
+  ;; The rejection reason is `:runtime-loaded-but-preload-missing` (the
+  ;; specific rung of the diagnostic ladder for the case where the JVM
+  ;; is reachable, the build is running, a CLJS runtime is connected,
+  ;; and ONLY the marker is absent). The probe-test stub returns
+  ;; `false` for the marker query (runtime alive, marker absent) → the
+  ;; ladder lands on this rung.
   (async done
     (let [conn  (fresh-conn)
           calls (atom 0)]
@@ -256,7 +252,7 @@
           (.then (fn [_] (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Diagnostic ladder — rf2-7tgfk. Pin each rung end-to-end.
+;; Diagnostic ladder — pin each rung end-to-end.
 ;; ---------------------------------------------------------------------------
 
 (defn- with-tri-stub!

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
@@ -1,11 +1,10 @@
 (ns re-frame2-pair-mcp.raw-state-test
-  "Unit tests for the `--allow-sensitive-reads` boot gate (rf2-c2dtu;
-  CLI flag aligned cross-MCP per rf2-2x3ql) and the single
-  intention-naming predicate `raw-state-allowed?` (rf2-p1qli).
+  "Unit tests for the `--allow-sensitive-reads` boot gate and the single
+  intention-naming predicate `raw-state-allowed?`.
 
   Internal Clojure identifiers (`allow-raw-state?` atom, `:allow-raw-state?`
-  keyword, `raw-state-allowed?` predicate) retain the legacy `raw-state`
-  naming; only the operator-facing CLI flag was renamed (rf2-2x3ql).
+  keyword, `raw-state-allowed?` predicate) use the `raw-state` naming;
+  the operator-facing CLI flag is `--allow-sensitive-reads`.
 
   Pins the three behaviours the gate guarantees:
 
@@ -13,7 +12,7 @@
        both return false; per-tool branches force redact + elide
        regardless of per-call args.
     2. Opt-in state — flipping the gate flips the predicate so the
-       per-call args win again (pre-rf2-c2dtu posture).
+       per-call args win again.
     3. `parse-launch-flags` parses `--allow-sensitive-reads` and rides
        alongside `--no-eval` without interference.
 
@@ -25,7 +24,7 @@
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]))
 
-;; rf2-wb06a — the signal-runtime! tests `set!` the module-level
+;; The signal-runtime! tests `set!` the module-level
 ;; `nrepl/cljs-eval-value`. Restore the pristine original in a
 ;; fixture-scoped `:after` (NOT a per-test `.finally`, which fires after
 ;; `done` and can clobber a neighbour namespace's stub mid-eval). Also
@@ -45,8 +44,8 @@
 
 (deftest default-gate-is-off
   ;; Pre-boot / freshly-loaded ns: the raw-state gate is OFF (default).
-  ;; The sibling eval-cljs gate defaults ON post-rf2-a0z0h; this test
-  ;; asserts only the raw-state surface.
+  ;; The sibling eval-cljs gate defaults ON; this test asserts only the
+  ;; raw-state surface.
   (raw-state/set-allow-raw-state! false)
   (is (false? (raw-state/allow-raw-state-enabled?)))
   (is (false? (raw-state/raw-state-allowed?))
@@ -57,7 +56,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest opt-in-flips-predicate
-  ;; --allow-sensitive-reads ⇒ per-call args win (pre-rf2-c2dtu posture).
+  ;; --allow-sensitive-reads ⇒ per-call args win.
   (raw-state/set-allow-raw-state! true)
   (is (true?  (raw-state/allow-raw-state-enabled?)))
   (is (true?  (raw-state/raw-state-allowed?))
@@ -66,12 +65,12 @@
   (raw-state/set-allow-raw-state! false))
 
 ;; ---------------------------------------------------------------------------
-;; raw-state-allowed? predicate semantics (rf2-p1qli).
+;; raw-state-allowed? predicate semantics.
 ;; ---------------------------------------------------------------------------
 
 (deftest raw-state-allowed-tracks-gate
-  ;; The single intention-naming predicate (rf2-p1qli) matches its truth
-  ;; value to the operator's opt-in state — positive sense, no inversion.
+  ;; The single intention-naming predicate matches its truth value to
+  ;; the operator's opt-in state — positive sense, no inversion.
   ;; Per-tool bodies branch on this directly:
   ;;
   ;;   (if (raw-state/raw-state-allowed?)
@@ -120,7 +119,7 @@
     (is (true? (:allow-raw-state? flags)))))
 
 (deftest parse-launch-flags-defaults
-  ;; Post-rf2-a0z0h: eval-cljs defaults ON; raw-state defaults OFF.
+  ;; eval-cljs defaults ON; raw-state defaults OFF.
   (let [flags (server/parse-launch-flags [])]
     (is (true? (:eval-allowed? flags))
         "eval-cljs gate defaults ON (rf2-a0z0h)")
@@ -130,38 +129,37 @@
 (deftest parse-launch-flags-ignores-unknown
   ;; The PARSER stays permissive — future flags + node/shadow wrapper
   ;; argv must not break the parse. The validation layer
-  ;; (`launch-diagnostics`, rf2-a0kxsb) is what NAMES the unknown flag at
-  ;; boot; see `launch-diagnostics-*` below. The parser itself just
-  ;; plucks what it understands and leaves the rest alone.
+  ;; (`launch-diagnostics`) is what NAMES the unknown flag at boot; see
+  ;; `launch-diagnostics-*` below. The parser itself just plucks what it
+  ;; understands and leaves the rest alone.
   (let [flags (server/parse-launch-flags ["--no-such-flag" "--allow-sensitive-reads"])]
     (is (true? (:allow-raw-state? flags)))))
 
 (deftest parse-launch-flags-old-name-rejected
-  ;; Hard rename (rf2-2x3ql): the legacy `--allow-raw-state` flag is no
-  ;; longer recognised. No back-compat shim — passing it must NOT enable
-  ;; the gate. (rf2-a0kxsb: it now ALSO earns a :removed-flag diagnostic
-  ;; naming the replacement — see `launch-diagnostics-names-removed-flag`.)
+  ;; The `--allow-raw-state` flag is not recognised. No back-compat shim
+  ;; — passing it does NOT enable the gate. It ALSO earns a :removed-flag
+  ;; diagnostic naming the replacement — see
+  ;; `launch-diagnostics-names-removed-flag`.
   (let [flags (server/parse-launch-flags ["--allow-raw-state"])]
     (is (false? (:allow-raw-state? flags))
-        "Legacy --allow-raw-state must not enable the gate post-rename")))
+        "--allow-raw-state must not enable the gate")))
 
 (deftest parse-launch-flags-legacy-allow-eval-is-noop
-  ;; Hard removal (rf2-a0z0h, pre-alpha): the legacy `--allow-eval`
-  ;; opt-in flag is no longer recognised because the default flipped to
-  ;; ON. No back-compat shim — passing it does not change the gate (the
-  ;; gate is on regardless). rf2-a0kxsb: rather than a SILENT no-op, the
-  ;; validation layer now emits an intentional :removed-flag diagnostic
+  ;; The `--allow-eval` opt-in flag is not recognised because the eval
+  ;; default is ON. No back-compat shim — passing it does not change the
+  ;; gate (the gate is on regardless). Rather than a SILENT no-op, the
+  ;; validation layer emits an intentional :removed-flag diagnostic
   ;; naming the replacement (see `launch-diagnostics-names-removed-flag`);
   ;; the parsed gate state is unchanged (still default ON).
   (let [flags (server/parse-launch-flags ["--allow-eval"])]
     (is (true? (:eval-allowed? flags))
-        "Legacy --allow-eval must NOT disable the gate (gate stays at default ON)")))
+        "--allow-eval must NOT disable the gate (gate stays at default ON)")))
 
 ;; ---------------------------------------------------------------------------
-;; Launch-config diagnostics (rf2-a0kxsb). The parsers stay permissive;
-;; this layer scans the SAME argv against the declared flag schema and
-;; returns structured diagnostics naming any rejected / suspicious input
-;; + its effective fallback. `main` logs each at boot before readiness.
+;; Launch-config diagnostics. The parsers stay permissive; this layer
+;; scans the SAME argv against the declared flag schema and returns
+;; structured diagnostics naming any rejected / suspicious input + its
+;; effective fallback. `main` logs each at boot before readiness.
 ;; ---------------------------------------------------------------------------
 
 (deftest launch-diagnostics-clean-config-empty
@@ -230,7 +228,7 @@
     (is (= [] (server/resource-env-diagnostics #js {})))))
 
 ;; ---------------------------------------------------------------------------
-;; --port-file launch flag (rf2-3dbwh) — explicit, cwd-independent port file.
+;; --port-file launch flag — explicit, cwd-independent port file.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-launch-flags-port-file-defaults-nil
@@ -270,10 +268,10 @@
         "later --port-file overrides earlier (argv override semantics)")))
 
 ;; ---------------------------------------------------------------------------
-;; --http-port (rf2-umoz2). Same parsing shape as --port-file (one shared
+;; --http-port. Same parsing shape as --port-file (one shared
 ;; `parse-string-value-flag` helper underneath); these tests pin the
 ;; cross-cutting accept-shape (space + equals + missing-value + numeric
-;; coercion) for the new flag.
+;; coercion) for the flag.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-launch-flags-http-port-defaults-nil
@@ -307,13 +305,12 @@
     (is (false? (:eval-allowed? flags)))))
 
 ;; ---------------------------------------------------------------------------
-;; signal-runtime! — re-signals before EVERY state-emitting eval
-;; (rf2-olvr5 finding 2). The runtime's raw-state posture resets to its
-;; permissive default on every page/runtime reload, so caching a per-build
-;; "delivered" flag (the pre-fix shape) left a post-reload runtime tapping
-;; RAW app-db. The signal now reconfigures each call; only a CONCURRENT
-;; in-flight configure for the same build is deduped (the rf2-z7roa race
-;; guard).
+;; signal-runtime! — re-signals before EVERY state-emitting eval. The
+;; runtime's raw-state posture resets to its permissive default on every
+;; page/runtime reload, so caching a per-build "delivered" flag would
+;; leave a post-reload runtime tapping RAW app-db. The signal
+;; reconfigures each call; only a CONCURRENT in-flight configure for the
+;; same build is deduped (the race guard).
 ;; ---------------------------------------------------------------------------
 
 (deftest signal-runtime-reconfigures-each-call
@@ -344,8 +341,7 @@
 
 (deftest signal-runtime-dedups-concurrent-in-flight
   ;; Two CONCURRENT signals for the same build (issued before the first
-  ;; configure resolves) share ONE in-flight Promise — the rf2-z7roa race
-  ;; guard, preserved across the rf2-olvr5 re-signal change.
+  ;; configure resolves) share ONE in-flight Promise — the race guard.
   (async done
     (let [calls (atom 0)
           ;; A configure that only resolves when we tell it to, so both

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_dom_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_dom_test.cljs
@@ -1,10 +1,10 @@
 (ns re-frame2-pair-mcp.read-dom-test
-  "Unit tests for the read-dom raw-DOM-plane read tool (rf2-nfjil).
+  "Unit tests for the read-dom raw-DOM-plane read tool.
 
   Two layers:
 
     1. Form composition — `read-dom-form` builds the browser-side CLJS
-       source. Since rf2-q0r7e it is a THIN runtime call —
+       source. It is a THIN runtime call —
        `(re-frame2-pair.runtime/dom-read {...})` — composed via the shared
        `eval-form` DSL (the SAME plumbing read-ui uses), not an inlined
        raw eval string. We assert it carries the load-bearing pieces (the
@@ -41,11 +41,11 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest form-is-thin-runtime-call
-  ;; rf2-q0r7e — read-dom no longer inlines its DOM-read core as a raw
-  ;; eval string; it emits `(re-frame2-pair.runtime/dom-read {...})` via
-  ;; the shared `eval-form` DSL, the SAME plumbing read-ui uses. The
-  ;; per-node projection lives in the runtime's `node->content`, shared
-  ;; with ui-read.
+  ;; read-dom emits `(re-frame2-pair.runtime/dom-read {...})` via the
+  ;; shared `eval-form` DSL, the SAME plumbing read-ui uses, rather than
+  ;; inlining its DOM-read core as a raw eval string. The per-node
+  ;; projection lives in the runtime's `node->content`, shared with
+  ;; ui-read.
   (let [form (#'read-dom/read-dom-form "#app .counter" nil
                                        read-dom/default-limit
                                        read-dom/default-max-text
@@ -70,31 +70,30 @@
           (str "read-dom form must be read-only — found mutator " mutator)))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-w2mjm / rf2-q0r7e — the unresolved-symbol-alias guard, now over the
-;; SHARED form (covers BOTH read-dom AND read-ui).
+;; The unresolved-symbol-alias guard, over the SHARED form (covers BOTH
+;; read-dom AND read-ui).
 ;;
-;; The bug it pins: the inlined eval string is sent over nREPL and
+;; The bug-class it pins: an inlined eval string is sent over nREPL and
 ;; evaluated in the BROWSER cljs-eval context, which aliases NOTHING
 ;; beyond cljs.core + JS interop (it is not a namespace that :requires
-;; anything). rf2-5ffuv: the original read-dom form lowered the tag with
-;; `(str/lower-case ...)` — `str` is unresolved there, so the whole form
-;; evaluated to nil (a compile-level miss, NOT a caught error), and EVERY
-;; read-dom call came back :read-dom-blank-result, while read-ui — which
-;; called a runtime fn rather than inlining source — stayed green.
+;; anything). A form that lowered a tag with `(str/lower-case ...)` —
+;; where `str` is unresolved there — would evaluate to nil (a
+;; compile-level miss, NOT a caught error), making EVERY such call come
+;; back :read-dom-blank-result.
 ;;
-;; rf2-w2mjm generalised the guard from a brittle alias BLOCKLIST to a
-;; PARSE-and-prove approach: parse the generated form, assert every PLAIN
-;; symbol resolves to a special form, a `cljs.core` name, a JS-interop
-;; form, a local binding, OR the runtime-ns-qualified call (the runtime
-;; preload provides that ns). Any residual require-only alias fails the
-;; test BY NAME.
+;; The guard is a PARSE-and-prove approach rather than a brittle alias
+;; BLOCKLIST: parse the generated form, assert every PLAIN symbol
+;; resolves to a special form, a `cljs.core` name, a JS-interop form, a
+;; local binding, OR the runtime-ns-qualified call (the runtime preload
+;; provides that ns). Any residual require-only alias fails the test BY
+;; NAME.
 ;;
-;; rf2-q0r7e folded read-dom onto the SAME runtime-call plumbing read-ui
-;; uses, so a SINGLE guard now covers BOTH ops: a fix or a break on the
-;; shared eval-form path cannot diverge between them. The guard runs over
-;; read-dom-form AND read-ui-form variants, and an adversarial case below
-;; proves it FIRES on an alias trap injected into either op's form — so it
-;; cannot silently rot into a no-op.
+;; read-dom and read-ui share the SAME runtime-call plumbing, so a SINGLE
+;; guard covers BOTH ops: a fix or a break on the shared eval-form path
+;; cannot diverge between them. The guard runs over read-dom-form AND
+;; read-ui-form variants, and an adversarial case below proves it FIRES
+;; on an alias trap injected into either op's form — so it cannot
+;; silently rot into a no-op.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private cljs-core+special
@@ -189,7 +188,7 @@
          set)))
 
 (deftest form-carries-no-unresolved-symbol-alias
-  ;; The bug-class guard, over the SHARED form for BOTH ops (rf2-q0r7e).
+  ;; The bug-class guard, over the SHARED form for BOTH ops.
   ;; A residual symbol is the alias trap that nils the form out.
   (doseq [[label form]
           [;; read-dom variants (raw DOM plane).
@@ -212,10 +211,10 @@
                (sort suspects))))))
 
 (deftest guard-fires-on-injected-alias-trap
-  ;; ADVERSARIAL — proves the guard is not a no-op (rf2-q0r7e). We forge
-  ;; the EXACT rf2-w2mjm failure on the SHARED eval-form path: a require-
-  ;; only alias (`str/lower-case`) reaching into either op's emitted form
-  ;; via the `rt-raw` escape hatch (the realistic vector — a hand-built raw
+  ;; ADVERSARIAL — proves the guard is not a no-op. We forge the alias-
+  ;; trap failure on the SHARED eval-form path: a require-only alias
+  ;; (`str/lower-case`) reaching into either op's emitted form via the
+  ;; `rt-raw` escape hatch (the realistic vector — a hand-built raw
   ;; source fragment that reaches for an aliased symbol). The guard MUST
   ;; surface `str/lower-case` (and the bare `sel`) as suspects for both the
   ;; dom-read- and ui-read-shaped injections — if it didn't, the live
@@ -341,13 +340,12 @@
                  (done))))))
 
 (deftest bad-selector-error-forwarded
-  ;; rf2-q7cavs — a genuine `:ok? false` runtime failure envelope (a
-  ;; thrown malformed-selector) MUST ride as `:isError true`, per
+  ;; A genuine `:ok? false` runtime failure envelope (a thrown
+  ;; malformed-selector) MUST ride as `:isError true`, per
   ;; spec/003-Tool-Catalogue.md §381 ("every `:ok? false` is
-  ;; `isError:true`"). Before the fix, `map-result-or-blank` routed ANY
-  ;; map through `ok-text`, so this failure shipped `isError:false` —
-  ;; violating the contract AND making the transient failure
-  ;; cache-eligible (could mask a later success).
+  ;; `isError:true`"). Routing any map through `ok-text` would ship
+  ;; `isError:false` — violating the contract AND making the transient
+  ;; failure cache-eligible (could mask a later success).
   (async done
     (let [canned {:ok? false :reason :rf.error/read-dom-bad-selector
                   :selector "###" :message "bad selector"}]
@@ -365,22 +363,21 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-r5erl — a BLANK eval result must NOT crash the MCP envelope.
+;; A BLANK eval result must NOT crash the MCP envelope.
 ;;
 ;; `cljs-eval-value` resolves to `nil` when shadow returns a blank value
-;; (the runtime didn't answer the eval). The original read-dom threaded
-;; that nil straight into `(wire/ok-text nil)`, whose `(clj->js nil)`
-;; structuredContent is JS `null` — and the SDK's outputSchema validation
-;; rejects a null structuredContent at the TRANSPORT layer
-;; (`expected record at structuredContent, received null`), bypassing the
-;; normal `{:ok? false}` error contract. read-dom now turns a blank
-;; result into a structured error; the envelope's structuredContent is a
-;; non-null record either way.
+;; (the runtime didn't answer the eval). Threading that nil straight into
+;; `(wire/ok-text nil)`, whose `(clj->js nil)` structuredContent is JS
+;; `null`, would have the SDK's outputSchema validation reject a null
+;; structuredContent at the TRANSPORT layer (`expected record at
+;; structuredContent, received null`), bypassing the normal `{:ok? false}`
+;; error contract. read-dom turns a blank result into a structured error;
+;; the envelope's structuredContent is a non-null record either way.
 ;; ---------------------------------------------------------------------------
 
 (deftest blank-eval-result-becomes-structured-error-not-host-failure
   (async done
-    ;; nil canned value = the blank shadow eval that triggered rf2-r5erl.
+    ;; nil canned value = a blank shadow eval.
     (-> (tu/with-stubbed-eval! nil
           (fn []
             (read-dom/read-dom-tool (fresh-conn) #js {:selector "body" :limit 1})))
@@ -392,8 +389,8 @@
                    (is (= :rf.error/read-dom-blank-result (:reason edn))
                        "structured reason, not a transport exception")
                    (is (= "body" (:selector edn)) "echoes the selector"))
-                 ;; The load-bearing rf2-r5erl assertion: structuredContent
-                 ;; is a NON-NULL record so the SDK outputSchema check passes.
+                 ;; The load-bearing assertion: structuredContent is a
+                 ;; NON-NULL record so the SDK outputSchema check passes.
                  (is (some? (j/get r :structuredContent))
                      "structuredContent must NOT be null (the rf2-r5erl crash)")
                  (is (object? (j/get r :structuredContent))
@@ -401,8 +398,8 @@
                  (done))))))
 
 (deftest happy-result-echoes-canonical-build
-  ;; rf2-8t3ct / rf2-fmho5 — a successful read-dom echoes the canonical
-  ;; resolved :build so the agent sees (and can round-trip) the target.
+  ;; A successful read-dom echoes the canonical resolved :build so the
+  ;; agent sees (and can round-trip) the target.
   (async done
     (let [canned {:ok? true :selector "body" :count 0 :truncated? false :nodes []}]
       (-> (tu/with-stubbed-eval! canned

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_sub_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_sub_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.read-sub-test
-  "Unit tests for the read-sub tool (rf2-3bu3d.7) — the validated
-  one-shot subscription read with no-silent-swallow parity with dispatch.
+  "Unit tests for the read-sub tool — the validated one-shot
+  subscription read with no-silent-swallow parity with dispatch.
 
   Two surfaces are pinned:
 
@@ -23,11 +23,11 @@
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.read-sub :as read-sub]))
 
-;; Stub lifetime is fixture-scoped, not Promise-chain-scoped (rf2-wb06a) —
-;; see orient_test for the rationale. Each test installs its stub via a
+;; Stub lifetime is fixture-scoped, not Promise-chain-scoped — see
+;; orient_test for the rationale. Each test installs its stub via a
 ;; bare `set!`; the `:after` fixture restores the pristine original
 ;; captured at ns-load. Closes the cross-test `connect EADDRNOTAVAIL`
-;; race a `.finally`-scoped restore otherwise opened.
+;; race a `.finally`-scoped restore otherwise opens.
 (def ^:private pristine-eval nrepl/cljs-eval-value)
 
 (use-fixtures :each
@@ -109,8 +109,8 @@
 
 (defn- stub-eval!
   "Install a `cljs-eval-value` stub via a bare `set!` (NO `.finally` —
-  cleanup is the `:after` fixture's job, rf2-wb06a). Records the READ-SUB
-  form string into `captured*` and resolves it with `canned`.
+  cleanup is the `:after` fixture's job). Records the READ-SUB form
+  string into `captured*` and resolves it with `canned`.
 
   read-sub's prelude fires up to three evals: the preload-probe sentinel
   (`__re_frame2_pair_runtime`), the `configure-raw-state!` signal-runtime
@@ -177,10 +177,10 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest unknown-sub-id-surfaces-as-error-with-nearest
-  ;; The headline rf2-3bu3d.7 fix: a typo'd sub-id must NOT silently
-  ;; subscribe to a non-existent sub and return nil. The runtime
-  ;; read-sub! validates first and returns :unknown-id + :nearest; the
-  ;; tool surfaces it as an :isError envelope.
+  ;; A typo'd sub-id must NOT silently subscribe to a non-existent sub
+  ;; and return nil. The runtime read-sub! validates first and returns
+  ;; :unknown-id + :nearest; the tool surfaces it as an :isError
+  ;; envelope.
   (async done
     (let [runtime-result {:ok? false :reason :unknown-id :kind :sub
                           :id :current-userr :query-v [:current-userr]
@@ -202,9 +202,9 @@
 
 (deftest ambiguous-frame-surfaces-as-error
   (async done
-    ;; rf2-n58jxo — the runtime now refuses with the enriched ambiguous-frame
-    ;; envelope (operation, query, available frames, current pin, fix-hint).
-    ;; The tool wrap must carry every slot back to the agent verbatim.
+    ;; The runtime refuses with the enriched ambiguous-frame envelope
+    ;; (operation, query, available frames, current pin, fix-hint). The
+    ;; tool wrap must carry every slot back to the agent verbatim.
     (let [runtime-result {:ok?              false
                           :reason           :ambiguous-frame
                           :operation        :read-sub

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_ui_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_ui_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.read-ui-test
-  "Unit tests for the typed ui/read op — read-ui (rf2-3bu3d.1).
+  "Unit tests for the typed ui/read op — read-ui.
 
   Two layers:
 
@@ -183,11 +183,11 @@
                  (done))))))
 
 (deftest bad-selector-error-forwarded
-  ;; rf2-q7cavs — a genuine `:ok? false` runtime failure (a thrown
-  ;; malformed-selector) MUST ride as `:isError true`, per
-  ;; spec/003-Tool-Catalogue.md §381. Before the fix the shared
-  ;; `map-result-or-blank` routed every map through `ok-text`, so this
-  ;; failure shipped `isError:false` and was cache-eligible.
+  ;; A genuine `:ok? false` runtime failure (a thrown malformed-selector)
+  ;; MUST ride as `:isError true`, per spec/003-Tool-Catalogue.md §381.
+  ;; Routing every map through the shared `map-result-or-blank` /
+  ;; `ok-text` path would ship this failure as `isError:false` and make
+  ;; it cache-eligible.
   (async done
     (let [canned {:ok? false :reason :rf.error/ui-read-bad-selector
                   :message "bad selector"}]
@@ -205,8 +205,8 @@
                    (done)))))))
 
 (deftest blank-eval-result-becomes-structured-error-not-host-failure
-  ;; rf2-r5erl sibling: a blank eval result (nil) must not produce a null
-  ;; structuredContent that the SDK rejects at the transport layer.
+  ;; A blank eval result (nil) must not produce a null structuredContent
+  ;; that the SDK rejects at the transport layer.
   (async done
     (-> (tu/with-stubbed-eval! nil
           (fn []
@@ -222,7 +222,7 @@
                  (done))))))
 
 (deftest happy-result-echoes-canonical-build
-  ;; rf2-8t3ct / rf2-fmho5 — read-ui echoes the resolved :build.
+  ;; read-ui echoes the resolved :build.
   (async done
     (let [canned {:ok? true :via :selector
                   :entity {:view-id :my.app/x :source-coord nil :render-key 1 :subs-read []}

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/record_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/record_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.record-test
   "Unit tests for the signal-recorder triplet — record / read-recording /
-  watch-until (rf2-zo4b9).
+  watch-until.
 
   Three layers, mirroring `read_dom_test`:
 
@@ -58,11 +58,10 @@
 ;; parse-stop-arg — keeps only the recognised keys.
 ;; ---------------------------------------------------------------------------
 
-;; rf2-e2i29 — `parse-stop-arg` returns the tagged `[:ok m]` /
-;; `[:err :invalid-stop-edn]` shape (mirroring `parse-filter-arg`,
-;; rf2-5kbkl). A malformed `stop` EDN surfaces as an honest `:err` tag
-;; rather than the pre-fix silent collapse to `{}` (the default
-;; wall-clock window).
+;; `parse-stop-arg` returns the tagged `[:ok m]` /
+;; `[:err :invalid-stop-edn]` shape (mirroring `parse-filter-arg`). A
+;; malformed `stop` EDN surfaces as an honest `:err` tag rather than
+;; silently collapsing to `{}` (the default wall-clock window).
 
 (deftest parse-stop-arg-shapes
   (is (= [:ok {:ms 5000}] (record/parse-stop-arg #js {:ms 5000})))
@@ -75,9 +74,9 @@
     (is (= [:ok {}] (record/parse-stop-arg nil)))))
 
 (deftest parse-stop-arg-malformed-edn-is-err-tagged
-  ;; The regression (rf2-e2i29): a malformed `stop` EDN string must NOT
-  ;; silently collapse to `{}` (the default window) — it returns the
-  ;; honest `[:err :invalid-stop-edn]` tag so the caller short-circuits.
+  ;; Regression: a malformed `stop` EDN string must NOT silently
+  ;; collapse to `{}` (the default window) — it returns the honest
+  ;; `[:err :invalid-stop-edn]` tag so the caller short-circuits.
   (testing "unbalanced delimiters ⇒ :err"
     (is (= [:err :invalid-stop-edn] (record/parse-stop-arg "{:ms 5000"))) ;; missing brace
     (is (= [:err :invalid-stop-edn] (record/parse-stop-arg "((("))))      ;; unbalanced
@@ -128,7 +127,7 @@
                {:ms 15000 :pred {:signal 0 :equals :done}}
                :rf/default
                2000
-               ;; rf2-8fin7.2 — the rendered elision-opts walker map.
+               ;; the rendered elision-opts walker map.
                "{:rf.size/include-large? false :rf.size/include-sensitive? false}")]
     (testing "calls the runtime start-recording! with the signals + stop"
       (is (str/includes? form "re-frame2-pair.runtime/start-recording!"))
@@ -194,8 +193,8 @@
                  (done))))))
 
 (deftest record-tool-malformed-stop-errors-honestly
-  ;; The headline regression (rf2-e2i29). A malformed `stop` EDN makes
-  ;; `record-tool` short-circuit to an honest `:ok? false` envelope
+  ;; Regression: a malformed `stop` EDN makes `record-tool`
+  ;; short-circuit to an honest `:ok? false` envelope
   ;; (`:reason :invalid-stop-edn`, `:isError true`) — the `cond` branch
   ;; fires BEFORE the `:else` arm reaches `ensure-runtime!` / the nREPL
   ;; socket, so this resolves synchronously with no live runtime and no

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/registry_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/registry_test.cljs
@@ -1,9 +1,8 @@
 (ns re-frame2-pair-mcp.registry-test
-  "Structural completeness of the single tool registry (rf2-47g8l;
-  ratchet added by rf2-wnrpi).
+  "Structural completeness of the single tool registry.
 
-  The whole point of the single `registry/tools` source (rf2-47g8l) is
-  that the three derived views — `tool-descriptors`, `handler-for`, and
+  The whole point of the single `registry/tools` source is that the
+  three derived views — `tool-descriptors`, `handler-for`, and
   `cacheable?` — cannot drift, because each is generated from the one
   vector. `cache_test` already pins `cacheable?` for the named tools;
   this suite pins the OTHER derived view that the dispatcher relies on:

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/replace_app_db_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/replace_app_db_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.replace-app-db-test
-  "Unit tests for the replace-app-db tool (rf2-ee38b.18).
+  "Unit tests for the replace-app-db tool.
 
   State injection — replaces a frame's app-db with an arbitrary EDN
   value via the Tool-Pair `replace-app-db!` write primitive. Pins:
@@ -24,14 +24,13 @@
     (swap! conn assoc :probed-builds #{:app})
     conn))
 
-;; rf2-z7roa — reset now issues `configure-raw-state!` (the raw-state
-;; tap signal) BEFORE `app-db-reset!`. The stub records EVERY form so a
-;; test can assert that ordering. `captured*` holds the LAST recorded
-;; form (the app-db-reset! form, since it runs after the signal) — the
-;; legacy single-form assertions still read it. The `configure-raw-
-;; state!` eval resolves to the same canned value (harmless — its
-;; result is swallowed). The signal cache is reset per test so the
-;; signal fires freshly.
+;; Reset issues `configure-raw-state!` (the raw-state tap signal) BEFORE
+;; `app-db-reset!`. The stub records EVERY form so a test can assert that
+;; ordering. `captured*` holds the LAST recorded form (the app-db-reset!
+;; form, since it runs after the signal) — the single-form assertions
+;; read it. The `configure-raw-state!` eval resolves to the same canned
+;; value (harmless — its result is swallowed). The signal cache is reset
+;; per test so the signal fires freshly.
 (defn- with-captured-eval!
   ([captured* canned-value body-fn]
    (with-captured-eval! captured* (atom []) canned-value body-fn))
@@ -40,8 +39,8 @@
          run  (fn [form-str]
                 (swap! forms* conj form-str)
                 ;; `captured*` mirrors the LAST app-db-reset! form for
-                ;; the legacy assertions (it overwrites on the signal
-                ;; form first, then the reset form).
+                ;; the single-form assertions (it overwrites on the
+                ;; signal form first, then the reset form).
                 (reset! captured* form-str)
                 (js/Promise.resolve canned-value))
          stub (fn
@@ -82,8 +81,8 @@
           (.finally (fn [] (writes/set-allow-writes! prev) (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-z7roa — raw-state tap signal ordering. `configure-raw-state!` MUST
-;; be evaluated BEFORE `app-db-reset!`, so the runtime's tap-emitting
+;; Raw-state tap signal ordering. `configure-raw-state!` MUST be
+;; evaluated BEFORE `app-db-reset!`, so the runtime's tap-emitting
 ;; surface is in its gated (default-elided) posture before the reset taps
 ;; the pre-/post-reset app-db. A write-path test FAILS if app-db-reset!
 ;; can run first.
@@ -206,11 +205,11 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest reset-rejected-envelope-rides-as-isError
-  ;; rf2-or8s29 — a `{:ok? false :reason :reset-rejected ...}` from the
-  ;; runtime means the injection did NOT land (no-such-frame,
-  ;; replace-during-drain, schema-mismatch). It is not a terminal-empty
-  ;; outcome, so it MUST ride as an isError result carrying the reason,
-  ;; not a success-shaped envelope the host reads as a landed write.
+  ;; A `{:ok? false :reason :reset-rejected ...}` from the runtime means
+  ;; the injection did NOT land (no-such-frame, replace-during-drain,
+  ;; schema-mismatch). It is not a terminal-empty outcome, so it MUST
+  ;; ride as an isError result carrying the reason, not a success-shaped
+  ;; envelope the host reads as a landed write.
   (async done
     (let [captured (atom nil)]
       (-> (with-writes-on!
@@ -229,10 +228,10 @@
                    (done)))))))
 
 (deftest unexpected-shape-fallback-rides-as-isError
-  ;; rf2-or8s29 — a degraded / pre-rf2-c2dtu runtime can return a
-  ;; non-map value; the tool synthesises `{:ok? false :reason
-  ;; :unexpected-shape ...}`. That too means the write did not land in a
-  ;; known-good shape, so it MUST ride as an isError result.
+  ;; A degraded runtime can return a non-map value; the tool synthesises
+  ;; `{:ok? false :reason :unexpected-shape ...}`. That too means the
+  ;; write did not land in a known-good shape, so it MUST ride as an
+  ;; isError result.
   (async done
     (let [captured (atom nil)]
       (-> (with-writes-on!
@@ -250,7 +249,7 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Cascade summary (rf2-6yqdl) — successful reset surfaces the synthetic
+;; Cascade summary — a successful reset surfaces the synthetic
 ;; `:rf.epoch/db-replaced` epoch via :cascade-summary.
 ;; ---------------------------------------------------------------------------
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/reserved_frame_guard_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/reserved_frame_guard_test.cljs
@@ -1,11 +1,11 @@
 (ns re-frame2-pair-mcp.reserved-frame-guard-test
-  "Tests for the wholesale-read backstop (rf2-qef58).
+  "Tests for the wholesale-read backstop.
 
-  A live pair session blew a single read past 126K tokens by reading the
-  `:rf/xray` frame wholesale. rf2-ihqpn (#2845) taught the SKILL to orient
-  first + never wholesale-read a tool frame; this guard adds the SERVER
-  backstop so a stray full read can't blow the context window regardless
-  of agent judgment. Skill steers, MCP guards.
+  A wholesale read of the `:rf/xray` frame can blow a single read past
+  126K tokens. The SKILL steers the agent to orient first + never
+  wholesale-read a tool frame; this guard adds the SERVER backstop so a
+  stray full read can't blow the context window regardless of agent
+  judgment. Skill steers, MCP guards.
 
   Three surfaces are pinned:
 
@@ -104,8 +104,8 @@
     (is (nil? (guard/get-path-refusal :stories [] nil)))
     (is (nil? (guard/get-path-refusal :rf/default [] nil))))
   (testing "a nil frame (defaulted operating frame) does not fire this client-side guard"
-    ;; rf2-wdxyx3 finding 1 — this is NOT an escape hatch. The client guard
-    ;; can't see the runtime-resolved frame for an omitted-:frame call, but
+    ;; This is NOT an escape hatch. The client guard can't see the
+    ;; runtime-resolved frame for an omitted-:frame call, but
     ;; set-operating-frame refuses to PIN a reserved :rf/* frame, so the
     ;; runtime's current-frame resolver can never return one at tier 2 — an
     ;; omitted-:frame read resolves to an APP frame (or refuses
@@ -116,8 +116,8 @@
 ;; ---------------------------------------------------------------------------
 ;; End-to-end: invoke the real tool bodies with a stubbed nREPL conn.
 ;;
-;; Stub lifetime is fixture-scoped (rf2-wb06a) — bare `set!` per test,
-;; `:after` restores the pristine original captured at ns-load.
+;; Stub lifetime is fixture-scoped — bare `set!` per test, `:after`
+;; restores the pristine original captured at ns-load.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private pristine-eval nrepl/cljs-eval-value)
@@ -263,15 +263,14 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-wdxyx3 finding 1 — the operating-frame bypass. The client-side
-;; get-path guard fires on the explicit `:frame` arg; an omitted `:frame`
-;; resolves runtime-side via `current-frame`, which returns the session
-;; pin at tier 2. If `set-operating-frame` let a reserved `:rf/*` TOOL
-;; frame be pinned, a later `get-path {path "[]"}` with no `:frame` would
-;; resolve the wholesale read through it — re-opening the overflow the
-;; guard was built to close. The fix refuses the reserved-frame PIN at its
-;; source, so the resolver can never return a tool frame for an
-;; omitted-:frame call.
+;; The operating-frame bypass. The client-side get-path guard fires on
+;; the explicit `:frame` arg; an omitted `:frame` resolves runtime-side
+;; via `current-frame`, which returns the session pin at tier 2. If
+;; `set-operating-frame` let a reserved `:rf/*` TOOL frame be pinned, a
+;; later `get-path {path "[]"}` with no `:frame` would resolve the
+;; wholesale read through it — re-opening the overflow the guard closes.
+;; The reserved-frame PIN is refused at its source, so the resolver can
+;; never return a tool frame for an omitted-:frame call.
 ;; ---------------------------------------------------------------------------
 
 (deftest set-operating-frame-refuses-reserved-tool-frame

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/resource_controls_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/resource_controls_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.resource-controls-test
-  "Unit tests for session-wide resource controls on streaming surfaces
-  (rf2-3ijbl). Pins each gate's contract:
+  "Unit tests for session-wide resource controls on streaming surfaces.
+  Pins each gate's contract:
 
     1. Concurrent-stream cap — acquire/release accounting, rejection
        shape, idempotent release floor.
@@ -33,8 +33,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest default-values-match-documented-shape
-  ;; The bead (rf2-3ijbl) names these four defaults. Each is exposed
-  ;; via `default-value` so the test isn't reaching into a private.
+  ;; These four defaults are exposed via `default-value` so the test
+  ;; isn't reaching into a private.
   (is (= 10    (resource/default-value :max-concurrent-streams))
       "10 streams: generous for normal use, tight enough to cap loops")
   (is (= 100   (resource/default-value :max-events-per-sec))
@@ -220,7 +220,7 @@
 
 (deftest parse-resource-flags-ignores-unknown
   ;; Future flags MUST not break older invocations. Symmetric with
-  ;; `parse-launch-flags` in server.cljs (rf2-c2dtu pattern).
+  ;; `parse-launch-flags` in server.cljs.
   (let [cfg (resource/parse-resource-flags
               ["--unknown-flag=foo"
                "--max-concurrent-streams=5"
@@ -263,11 +263,10 @@
     (is (empty? (resource/read-resource-env env-obj)))))
 
 (deftest apply-resource-config-flags-win-over-env-on-conflict
-  ;; Precedence contract (rf2-ee38b.18 — was the merge-config passthrough
-  ;; test): a CLI flag on the command line is the more deliberate choice
-  ;; than an inherited env var. Asserted end-to-end through
-  ;; `apply-resource-config!` + `current-config` rather than a named
-  ;; `merge` wrapper — the precedence IS `merge`'s rightmost-wins
+  ;; Precedence contract: a CLI flag on the command line is the more
+  ;; deliberate choice than an inherited env var. Asserted end-to-end
+  ;; through `apply-resource-config!` + `current-config` rather than a
+  ;; named `merge` wrapper — the precedence IS `merge`'s rightmost-wins
   ;; contract, so we pin the behaviour at the real call site.
   (let [env-cfg  {:max-concurrent-streams 5
                   :max-events-per-sec     50}

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/restore_epoch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/restore_epoch_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.restore-epoch-test
-  "Unit tests for the restore-epoch tool (rf2-ee38b.18).
+  "Unit tests for the restore-epoch tool.
 
   Time-travel undo — rewinds a frame's whole frame-state (BOTH app-db
   and runtime-db) to a recorded prior epoch's `:frame-state-after` via
@@ -25,13 +25,13 @@
     (swap! conn assoc :probed-builds #{:app})
     conn))
 
-;; The tool now issues TWO evals on the happy path: the
-;; `configure-raw-state!` signal (raw-state/signal-runtime!, rf2-6nks4)
-;; and the `restore-epoch` form. The stub matches by substring — the
-;; configure eval resolves to nil (swallowed); the restore eval resolves
-;; to `canned-value`. `captured*` records the LAST non-configure form
-;; (the restore form) so the existing form-shape assertions keep working;
-;; `with-captured-all!` (below) records EVERY form for ordering tests.
+;; The tool issues TWO evals on the happy path: the
+;; `configure-raw-state!` signal (raw-state/signal-runtime!) and the
+;; `restore-epoch` form. The stub matches by substring — the configure
+;; eval resolves to nil (swallowed); the restore eval resolves to
+;; `canned-value`. `captured*` records the LAST non-configure form (the
+;; restore form) so the form-shape assertions work; `with-captured-all!`
+;; (below) records EVERY form for ordering tests.
 (defn- with-captured-eval!
   [captured* canned-value body-fn]
   (let [orig nrepl/cljs-eval-value
@@ -51,7 +51,7 @@
 
 (defn- with-captured-all!
   "Record EVERY emitted form (configure + restore) in order, so a test
-  can assert the raw-state signal precedes the restore eval (rf2-6nks4)."
+  can assert the raw-state signal precedes the restore eval."
   [forms* canned-value body-fn]
   (let [orig nrepl/cljs-eval-value
         run  (fn [form-str]
@@ -167,10 +167,10 @@
 
 (deftest surfaces-restore-rejected-when-runtime-returns-false
   ;; restore-epoch returns false on any failure (aged-out id,
-  ;; drain-in-flight, …); the app-db is unchanged. rf2-or8s29: this
-  ;; soft failure is NOT a terminal-empty outcome — the write did not
-  ;; land — so it MUST ride as an isError result carrying the reason,
-  ;; not a success-shaped envelope the host reads as a landed write.
+  ;; drain-in-flight, …); the app-db is unchanged. This soft failure is
+  ;; NOT a terminal-empty outcome — the write did not land — so it MUST
+  ;; ride as an isError result carrying the reason, not a success-shaped
+  ;; envelope the host reads as a landed write.
   (async done
     (let [captured (atom nil)]
       (-> (with-writes-on!
@@ -188,11 +188,11 @@
                    (done)))))))
 
 (deftest surfaces-isError-when-runtime-returns-structured-failure-map
-  ;; rf2-or8s29 — a newer runtime can return a structured
-  ;; `{:ok? false :reason :restore-rejected ...}` map (not the legacy
-  ;; bare `false`). The tool MUST still route a `{:ok? false ...}` map
-  ;; to isError — passing the map through to `ok-text` would report a
-  ;; rejected restore as success.
+  ;; The runtime can return a structured
+  ;; `{:ok? false :reason :restore-rejected ...}` map (as well as a bare
+  ;; `false`). The tool MUST route a `{:ok? false ...}` map to isError —
+  ;; passing the map through to `ok-text` would report a rejected restore
+  ;; as success.
   (async done
     (let [failure-envelope {:ok? false :restored? false
                             :reason :restore-rejected
@@ -210,12 +210,11 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Cascade summary (rf2-6yqdl) — the runtime's restore-epoch helper now
-;; returns a structured envelope on success carrying :cascade-summary +
+;; Cascade summary — the runtime's restore-epoch helper returns a
+;; structured envelope on success carrying :cascade-summary +
 ;; :unreplayable-effects. The tool passes the runtime map through
-;; unchanged when the runtime returned a map; falls back to the legacy
-;; envelope when the runtime returned plain `true` (pre-rf2-6yqdl
-;; runtimes).
+;; unchanged when the runtime returned a map; falls back to a synthesised
+;; envelope when the runtime returned plain `true`.
 ;; ---------------------------------------------------------------------------
 
 (deftest cascade-summary-passes-through-on-success
@@ -253,7 +252,7 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-6nks4 (finding-2) — sensitive cascade-summary :event-vector egress.
+;; Sensitive cascade-summary :event-vector egress.
 ;;
 ;; The runtime's restore-cascade-summary redacts the target epoch's raw
 ;; :event-vector to :rf/redacted when the epoch is sensitive AND the
@@ -326,9 +325,9 @@
                    (done)))))))
 
 (deftest legacy-true-runtime-falls-back-to-stub-envelope
-  ;; A pre-rf2-6yqdl runtime returns plain `true` on success. The tool
-  ;; falls back to the historical synthesised envelope so the wire
-  ;; stays sane even against an out-of-date preload.
+  ;; A runtime that returns plain `true` on success. The tool falls back
+  ;; to a synthesised envelope so the wire stays sane even against an
+  ;; out-of-date preload.
   (async done
     (let [captured (atom nil)]
       (-> (with-writes-on!

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/result_envelope_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/result_envelope_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.result-envelope-test
-  "Unit tests for the typed result codec (rf2-qobqy).
+  "Unit tests for the typed result codec.
 
   Two halves:
 
@@ -13,8 +13,8 @@
     2. `envelope->result` / `error?` — the server-side projection. This
        is the load-bearing logic: a tagged envelope MUST project onto
        the tool's `:ok?` vocabulary so nil / eval-error / unserializable
-       are DISTINCT, and a legacy untagged value MUST flow through
-       unchanged (additive codec)."
+       are DISTINCT, and an untagged value MUST flow through unchanged
+       (additive codec)."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [re-frame2-pair-mcp.test-utils :as tu]
@@ -51,7 +51,7 @@
         "an outer try guards the classifier itself so it never throws on the wire")))
 
 ;; ---------------------------------------------------------------------------
-;; REPL-special pass-through (rf2-cum40 CI repair).
+;; REPL-special pass-through.
 ;;
 ;; shadow only honours `require` / `ns` / etc. special compilation at the
 ;; top level; wrapping them in the classifier's expression context breaks
@@ -136,7 +136,7 @@
     (is (renv/error? r))))
 
 ;; ---------------------------------------------------------------------------
-;; The three outcomes are DISTINCT — the headline rf2-qobqy invariant.
+;; The three outcomes are DISTINCT — the headline codec invariant.
 ;; ---------------------------------------------------------------------------
 
 (deftest nil-eval-error-unserializable-are-distinct
@@ -156,7 +156,7 @@
         "the genuine-nil success carries no failure reason")))
 
 ;; ---------------------------------------------------------------------------
-;; Legacy / untagged values flow through unchanged (additive codec).
+;; Untagged values flow through unchanged (additive codec).
 ;; ---------------------------------------------------------------------------
 
 (deftest untagged-value-flows-through-on-value

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/roots_discovery_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/roots_discovery_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.roots-discovery-test
-  "Unit tests for the workspace-roots discovery cascade (rf2-3grub).
+  "Unit tests for the workspace-roots discovery cascade.
 
   Three surfaces under test:
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sensitive_filter_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sensitive_filter_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.sensitive-filter-test
   "Unit tests for the spec/009 §Privacy default-suppress filter on
-  `:sensitive? true` events (rf2-zq0n1, follows rf2-a32kd).
+  `:sensitive? true` events.
 
   Spec 009 mandates that framework-published forwarders (Sentry /
   Honeybadger, re-frame2-pair server, Xray-MCP) MUST default-drop trace events
@@ -16,8 +16,8 @@
   The `wire-pipeline-epoch-vector-*` deftests at the foot drive the
   `:epoch-vector` arm of `run-wire-pipeline` — the SAME call site
   `trace-window` and `watch-epochs` route projected epoch vectors
-  through — so the fixed `sensitive-epoch?` predicate (rf2-5613h)
-  cannot be bypassed by the tool response path."
+  through — so the `sensitive-epoch?` predicate cannot be bypassed by
+  the tool response path."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame2-pair-mcp.tools.sensitive :as sensitive]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]))
@@ -37,15 +37,14 @@
   (is (not (sensitive/sensitive-event? {:operation :rf.event/dispatched}))))
 
 (deftest sensitive-event-non-true-truthy-drops-fail-closed
-  ;; Fail-closed (rf2-ih7g4): the literal `true` drops AND any
-  ;; non-boolean truthy value drops too. The `:rf/trace-event` schema
-  ;; types `:sensitive?` as a boolean; a string `"true"` or keyword
-  ;; `:yes` is a contract violation that means an upstream
-  ;; serialisation bug has coerced the boolean into the wrong shape.
-  ;; The previous fail-OPEN posture silently leaked sensitive events
-  ;; on such drift. re-frame2-pair-mcp delegates to
-  ;; `re-frame.mcp-base.sensitive/sensitive-event?` (rf2-vw4sq) so the
-  ;; contract is byte-identical across the MCP triplet.
+  ;; Fail-closed: the literal `true` drops AND any non-boolean truthy
+  ;; value drops too. The `:rf/trace-event` schema types `:sensitive?`
+  ;; as a boolean; a string `"true"` or keyword `:yes` is a contract
+  ;; violation that means an upstream serialisation bug has coerced the
+  ;; boolean into the wrong shape. A fail-OPEN posture would silently
+  ;; leak sensitive events on such drift. re-frame2-pair-mcp delegates
+  ;; to `re-frame.mcp-base.sensitive/sensitive-event?` so the contract
+  ;; is byte-identical across the MCP triplet.
   (with-redefs [js/console (clj->js {:warn (fn [& _])})] ; absorb the contract-drift warning
     (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? "true"}))
     (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? :yes}))
@@ -98,7 +97,7 @@
     (is (= 3 dropped))))
 
 (deftest strip-sensitive-fail-closed-drops-malformed-truthy
-  ;; rf2-ih7g4: a transport bug that coerces `:sensitive? true` into
+  ;; A transport bug that coerces `:sensitive? true` into
   ;; `:sensitive? "true"` (string) or `:sensitive? :yes` (keyword) MUST
   ;; NOT silently leak the event past the re-frame2-pair-mcp wire boundary. The
   ;; fail-closed posture (inherited from `re-frame.mcp-base.sensitive`)
@@ -139,8 +138,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest snapshot-scrubber-strips-sensitive-from-traces
-  ;; The epoch slice uses the REAL record-level rollup `:rf.epoch/sensitive?`
-  ;; (rf2-5613h) — the key the runtime epoch assembler writes — not the
+  ;; The epoch slice uses the record-level rollup `:rf.epoch/sensitive?`
+  ;; — the key the runtime epoch assembler writes — not the
   ;; trace-event-level unqualified `:sensitive?`.
   (let [snap {:rf/default
               {:app-db  {:user/name "ada" :password "secret"}
@@ -166,9 +165,9 @@
   ;; they reach this scrubber: :app-db / :sub-cache through
   ;; `re-frame.core/elide-wire-value`, and the :machines runtime-db slice
   ;; fail-closed to `:rf/redacted` by default (EP-0015 / EP-0001 — Spec 011
-  ;; §Off-box redaction; the retired `redact-interceptor` is NOT involved).
-  ;; Here the slices arrive already-projected, so the scrubber passes them
-  ;; through verbatim even when they carry literal "sensitive"-looking shapes.
+  ;; §Off-box redaction). Here the slices arrive already-projected, so the
+  ;; scrubber passes them through verbatim even when they carry literal
+  ;; "sensitive"-looking shapes.
   (let [snap {:rf/default
               {:app-db    {:password "still-here" :sensitive? true}
                :sub-cache {:user/profile {:sensitive? true :data "x"}}
@@ -195,26 +194,26 @@
     (is (zero? dropped))))
 
 ;; ---------------------------------------------------------------------------
-;; sensitive-epoch? — defense-in-depth on the epoch-record shape (rf2-re2s3).
+;; sensitive-epoch? — defense-in-depth on the epoch-record shape.
 ;;
 ;; Spec 009 §Privacy / Security.md §Epoch privacy mandate that the runtime's
 ;; epoch assembler computes a record-level `:rf.epoch/sensitive?` rollup at
-;; record-assembly time (rf2-isdwf / rf2-mrsck, the "epoch is sensitive iff
-;; any constituent trace event is sensitive OR a schema-declared sensitive
-;; app-db path resolves" rule). `projected-record` preserves that QUALIFIED
-;; key verbatim through off-box projection. This forwarder-side guard reads
-;; the real `:rf.epoch/sensitive?` key (rf2-5613h — pre-fix it wrongly read
-;; the UNqualified `:sensitive?`, which the runtime never writes on a record,
-;; leaking schema-derived sensitive epochs whose constituent traces are
-;; clean). It is also BELT-AND-BRACES: if the rollup is absent (older runtime,
+;; record-assembly time (the "epoch is sensitive iff any constituent trace
+;; event is sensitive OR a schema-declared sensitive app-db path resolves"
+;; rule). `projected-record` preserves that QUALIFIED key verbatim through
+;; off-box projection. This forwarder-side guard reads the
+;; `:rf.epoch/sensitive?` key — the runtime never writes the UNqualified
+;; `:sensitive?` on a record, so reading the unqualified key would leak
+;; schema-derived sensitive epochs whose constituent traces are clean. It
+;; is also BELT-AND-BRACES: if the rollup is absent (older runtime,
 ;; missing late-bind hook, hand-built record), it still detects sensitivity by
 ;; walking the record's `:trace-events` slot at egress.
 ;; ---------------------------------------------------------------------------
 
 (deftest sensitive-epoch-rollup-true-detected
-  ;; The REAL runtime rollup key (rf2-5613h): `:rf.epoch/sensitive? true`,
-  ;; NO unqualified `:sensitive?`, NO sensitive constituent trace event —
-  ;; the schema-derived-sensitive shape that pre-fix leaked.
+  ;; The runtime rollup key: `:rf.epoch/sensitive? true`, NO unqualified
+  ;; `:sensitive?`, NO sensitive constituent trace event — the
+  ;; schema-derived-sensitive shape.
   (is (sensitive/sensitive-epoch? {:epoch-id 1 :event-id :auth/sign-in :rf.epoch/sensitive? true})))
 
 (deftest sensitive-epoch-rollup-false-passes
@@ -232,9 +231,9 @@
   (is (not (sensitive/sensitive-epoch? {:epoch-id 1 :event-id :auth/sign-in :sensitive? true}))))
 
 (deftest sensitive-epoch-rollup-malformed-truthy-fails-closed
-  ;; rf2-5613h + rf2-ih7g4: a transport bug that coerces
-  ;; `:rf.epoch/sensitive? true` into a string/keyword MUST NOT leak the
-  ;; record. The rollup is classified through the shared fail-closed
+  ;; A transport bug that coerces `:rf.epoch/sensitive? true` into a
+  ;; string/keyword MUST NOT leak the record. The rollup is classified
+  ;; through the shared fail-closed
   ;; `mcp-base.sensitive/sensitive-stamp?`, so malformed-truthy drops.
   (with-redefs [js/console (clj->js {:warn (fn [& _])})] ; absorb the warning
     (is (sensitive/sensitive-epoch? {:epoch-id 1 :rf.epoch/sensitive? "true"}))
@@ -283,8 +282,8 @@
 
 ;; ---------------------------------------------------------------------------
 ;; strip-sensitive on epoch records — the streaming-surface defense-in-depth
-;; scenarios (rf2-re2s3). These match how trace-window-tool / watch-epochs-tool
-;; feed epoch vectors through the same helper.
+;; scenarios. These match how trace-window-tool / watch-epochs-tool feed
+;; epoch vectors through the same helper.
 ;; ---------------------------------------------------------------------------
 
 (deftest strip-sensitive-drops-epoch-with-sensitive-constituent
@@ -332,13 +331,13 @@
     (is (= 2 dropped))))
 
 (deftest strip-sensitive-drops-schema-derived-sensitive-epoch-rollup-only
-  ;; rf2-5613h REGRESSION — the leak. A schema-derived sensitive epoch:
-  ;; `:rf.epoch/sensitive? true` (the real runtime rollup), NO unqualified
-  ;; `:sensitive?`, and NO sensitive constituent trace event. Pre-fix this
-  ;; survived `strip-sensitive` (the predicate read `:sensitive?`, which is
-  ;; absent) and shipped its metadata across the MCP boundary. Post-fix it
-  ;; default-DROPs and increments `:dropped-sensitive` under the default
-  ;; `include-sensitive false` gate.
+  ;; Regression guard: a schema-derived sensitive epoch:
+  ;; `:rf.epoch/sensitive? true` (the runtime rollup), NO unqualified
+  ;; `:sensitive?`, and NO sensitive constituent trace event. A predicate
+  ;; that read `:sensitive?` (which is absent here) would let this survive
+  ;; `strip-sensitive` and ship its metadata across the MCP boundary.
+  ;; Instead it default-DROPs and increments `:dropped-sensitive` under
+  ;; the default `include-sensitive false` gate.
   (let [epochs [{:epoch-id 1
                  :event-id :auth/sign-in
                  :rf.epoch/sensitive? true
@@ -369,14 +368,14 @@
     (is (zero? dropped))))
 
 ;; ---------------------------------------------------------------------------
-;; Integration through the :epoch-vector wire pipeline (rf2-5613h).
+;; Integration through the :epoch-vector wire pipeline.
 ;;
 ;; `run-wire-pipeline` with `:kind :epoch-vector` is the EXACT call site
 ;; `trace-window` (trace_window.cljs:138) and `watch-epochs`
 ;; (watch_epochs.cljs) route projected epoch vectors through before the
 ;; payload crosses the MCP boundary. Its first step is `strip-sensitive`,
-;; so the fixed `sensitive-epoch?` predicate governs the tool response
-;; path — these tests assert the leak cannot be bypassed by the pipeline.
+;; so the `sensitive-epoch?` predicate governs the tool response path —
+;; these tests assert the leak cannot be bypassed by the pipeline.
 ;; The pipeline reports the drop count on `:indicators :dropped` (the
 ;; `:dropped-sensitive` indicator the tools surface on the envelope).
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/set_valued_app_db_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/set_valued_app_db_test.cljs
@@ -1,29 +1,24 @@
 (ns re-frame2-pair-mcp.set-valued-app-db-test
-  "Regression: set-valued app-db slots survive the wire walkers (rf2-ogqfe).
+  "Set-valued app-db slots survive the wire walkers.
 
   A consumer app whose app-db carries a `#{...}` set value — e.g. a
   state machine stamping `:tags #{:door/locked}` on every snapshot —
   must round-trip cleanly through every wire-shrink walker the
-  `snapshot` and `trace-window` tools run. The bead reported a live
-  `'me.cljs$core$IMapEntry$_key$arity$1 is not a function'` crash on a
-  machine-epochs runtime, hypothesising that a walker iterates every
-  collection as map-entries and calls `key`/`val` on a `PersistentHashSet`
-  element.
+  `snapshot` and `trace-window` tools run. The risk is a walker that
+  iterates every collection as map-entries and calls `key`/`val` on a
+  `PersistentHashSet` element, producing an
+  `'me.cljs$core$IMapEntry$_key$arity$1 is not a function'` crash.
 
-  Investigation found every walker in the path already set-aware
-  (`summary/tree-summary` and `source-uri/decorate` carry explicit
-  `set?` branches; `de-dupe-eq` routes a set through its generic
-  `(coll? form)` arm, not the map-entry arm; the framework's
-  server-side `elide-wire-value` / `projected-record` likewise branch
-  on `set?`). These tests PIN that set-safety as an enforced invariant
-  across the FULL client-side pipeline — both tools, both the summary
-  and the diff/dedup epoch paths — so a future refactor that drops a
-  `set?` branch from any walker trips this gate instead of shipping a
-  runtime crash to a consumer with set-valued state.
-
-  The crashing symptom on the live runtime is attributed to a stale
-  compiled build; no code path in the current pair-mcp + mcp-base +
-  framework walkers reproduces it.
+  Every walker in the path is set-aware: `summary/tree-summary` and
+  `source-uri/decorate` carry explicit `set?` branches; `de-dupe-eq`
+  routes a set through its generic `(coll? form)` arm, not the
+  map-entry arm; the framework's server-side `elide-wire-value` /
+  `projected-record` likewise branch on `set?`. These tests PIN that
+  set-safety as an enforced invariant across the FULL client-side
+  pipeline — both tools, both the summary and the diff/dedup epoch
+  paths — so a refactor that drops a `set?` branch from any walker
+  trips this gate instead of shipping a runtime crash to a consumer
+  with set-valued state.
 
   End-to-end via a substring-matching `cljs-eval-value` stub (mirrors
   `trace_window_test`'s `with-substr-eval!`): the stub stands in for the
@@ -137,7 +132,7 @@
 
 (defn- snapshot-response
   "The `{:value <per-frame-snap> :elided-count N :tool-frames-excluded
-  []}` envelope the snapshot eval form returns (rf2-e35a5)."
+  []}` envelope the snapshot eval form returns."
   [snap]
   {:value snap :elided-count 0 :tool-frames-excluded []})
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shadow_discovery_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shadow_discovery_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.shadow-discovery-test
-  "Unit tests for the shadow-cljs HTTP probe (rf2-umoz2).
+  "Unit tests for the shadow-cljs HTTP probe.
 
   Two surfaces under test:
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/snapshot_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/snapshot_test.cljs
@@ -12,7 +12,7 @@
   Tests require the public parsers directly from
   `re-frame2-pair-mcp.tools.args` — the source ns is the contract.
 
-  Production-form integration coverage for rf2-vflrg lives in
+  Production-form integration coverage for the elision walk lives in
   `re-frame2-pair-mcp.elision-test` (via the `build-snapshot-form`
   mirror); see the note at the bottom of this file."
   (:require [cljs.test :refer-macros [deftest is testing]]
@@ -21,9 +21,9 @@
             [re-frame2-pair-mcp.tools.eval-form :as ef]))
 
 (deftest frames-default-is-app-not-all
-  ;; rf2-3bu3d.6 — the DEFAULT scope (absent arg) is `:app` (app frames
-  ;; only, reserved :rf/* tool frames excluded), NOT `:all`. Explicit
-  ;; "all" is the opt-in to tool-frame state.
+  ;; The DEFAULT scope (absent arg) is `:app` (app frames only, reserved
+  ;; :rf/* tool frames excluded), NOT `:all`. Explicit "all" is the
+  ;; opt-in to tool-frame state.
   (is (= :app (args/parse-frames-arg nil))
       "absent frames arg defaults to :app (app frames only)")
   (is (= :all (args/parse-frames-arg "all"))
@@ -61,8 +61,8 @@
   (is (= [:app-db :sub-cache] (args/parse-include-arg #js ["app-db" "sub-cache"]))))
 
 (deftest snapshot-state-form-is-edn-readable
-  ;; The MCP server lifts the opts map into the eval-form DSL
-  ;; (rf2-dpzpe), which renders `(re-frame2-pair.runtime/snapshot-state
+  ;; The MCP server lifts the opts map into the eval-form DSL, which
+  ;; renders `(re-frame2-pair.runtime/snapshot-state
   ;; {:frames :all :include [...]})`. Assert against the parsed opts
   ;; map rather than regex-matching the source string.
   (let [opts {:frames :all
@@ -75,20 +75,18 @@
            (-> edn second :include)))))
 
 ;; ---------------------------------------------------------------------------
-;; Note on rf2-vflrg integration coverage:
+;; Note on elision integration coverage:
 ;;
-;; Eval-form composition for the snapshot tool (now walking BOTH `:app-db`
+;; Eval-form composition for the snapshot tool (walking BOTH `:app-db`
 ;; and `:sub-cache` through `re-frame.core/elide-wire-value`, threading
 ;; `:include-sensitive` into the walker's opt) is pinned in
 ;; `re-frame2-pair-mcp.elision-test` via the production `build-snapshot-form`
 ;; mirror — see `snapshot-form-walks-both-app-db-and-sub-cache` and
 ;; `snapshot-form-threads-include-sensitive`.
 ;;
-;; Historical note: `invoke-test` used to stub `snapshot/snapshot-tool`
-;; via direct `set!` with `.finally` restoration; the `.finally` could
-;; outrun the test's `(done)`, leaking the stub into the next async
-;; test (rf2-wb06a). Fixed by moving restoration to a `use-fixtures`
-;; `:after` step — cleanup is now Promise-chain-independent. The
-;; mirror approach here is still preferred for isolation, but it is
-;; no longer a race-safety necessity.
+;; Async stub isolation: tests that stub a tool fn restore it from a
+;; `use-fixtures` `:after` step rather than a Promise `.finally`, so
+;; cleanup is Promise-chain-independent and a `.finally` can't outrun a
+;; test's `(done)` and leak the stub into the next async test. The
+;; mirror approach here keeps this suite stub-free for full isolation.
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/source_uri_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/source_uri_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.source-uri-test
-  "Unit tests for the source-URI decorator (rf2-cibp8).
+  "Unit tests for the source-URI decorator.
 
   Pins three properties:
 
@@ -162,13 +162,13 @@
       (is (= v (source-uri/decorate v :vscode))))))
 
 ;; ---------------------------------------------------------------------------
-;; decorate — flat-key carrier (handler-meta / frame-meta shape; rf2-87wee).
+;; decorate — flat-key carrier (handler-meta / frame-meta shape).
 ;;
 ;; `(rf/handler-meta kind id)` and `(rf/frame-meta id)` return registration-
 ;; metadata maps with flat `:ns` / `:line` / `:column` / `:file` keys (per
-;; Spec-Schemas `:rf/source-coord-meta` and rf2-4h8ny). The decorator must
-;; recognise this carrier shape and splice :rf.source/uri onto the map
-;; itself — distinct from the trace-event :source-coord sub-map carrier.
+;; Spec-Schemas `:rf/source-coord-meta`). The decorator must recognise this
+;; carrier shape and splice :rf.source/uri onto the map itself — distinct
+;; from the trace-event :source-coord sub-map carrier.
 ;; ---------------------------------------------------------------------------
 
 (deftest decorate-splices-uri-on-flat-coord-carrier-map

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sticky_build_invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sticky_build_invoke_test.cljs
@@ -1,22 +1,22 @@
 (ns re-frame2-pair-mcp.sticky-build-invoke-test
-  "End-to-end one-step sticky-build pin (rf2-jkwu4).
+  "End-to-end one-step sticky-build pin.
 
   THE NORTH STAR: after a SINGLE `discover-app`, an agent should be able
   to call EVERY other pair tool with NO `build` arg and have it just
   work — even with several shadow builds running. The lower-level pieces
   are pinned elsewhere (`build_id_cache_test` for the `:resolved-build-id`
   cache + `arg-build` precedence; `port_to_build_test` for the `:port`
-  resolver writing the cache). This suite closes the loop the live repro
-  exercised: drive the REAL `discover-app` then a REAL no-`build` tool
-  call THROUGH `tools/invoke` (the single MCP egress) on the SAME conn,
-  and assert the second call's per-tool body resolves the build
-  `discover-app` stuck — NOT the `:app` env default.
+  resolver writing the cache). This suite closes the loop: drive the
+  REAL `discover-app` then a REAL no-`build` tool call THROUGH
+  `tools/invoke` (the single MCP egress) on the SAME conn, and assert
+  the second call's per-tool body resolves the build `discover-app`
+  stuck — NOT the `:app` env default.
 
-  The live repro (2026-06-03, 5 builds running):
+  The scenario guarded, with several builds running:
 
-    discover-app {port 8033} -> resolves :examples/machine-epochs, OK
-    orient {}                -> FAILED :build-not-running :app  (the bug)
-    read-dom {selector ...}  -> FAILED :build-not-running :app  (the bug)
+    discover-app {port 8033} -> resolves :examples/machine-epochs
+    orient {}                -> targets the resolved build, not :app
+    read-dom {selector ...}  -> targets the resolved build, not :app
 
   These tests prove the build STICKS across the `invoke` boundary so the
   follow-up no-`build` calls target the resolved build."
@@ -132,8 +132,8 @@
             (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; A later EXPLICIT :build overrides AND updates the sticky default
-;; (rf2-lbm21), so the NEXT no-build call inherits the override.
+;; A later EXPLICIT :build overrides AND updates the sticky default,
+;; so the NEXT no-build call inherits the override.
 ;; ---------------------------------------------------------------------------
 
 (deftest later-explicit-build-overrides-and-restickies

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/structured_content_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/structured_content_test.cljs
@@ -1,12 +1,12 @@
 (ns re-frame2-pair-mcp.structured-content-test
-  "Pin rf2-hj3pi — every MCP result envelope MUST carry both the
+  "Every MCP result envelope MUST carry both the
   wire-canonical `:content [{:type \"text\" :text ...}]` slot and a
   `:structuredContent` slot whose value is the JS-coerced projection
   of the same payload.
 
-  The change centralises in `tools.wire/ok-text` + `err-text` so the
-  dual-slot rule is enforced at one site; the test corpus pins the
-  shape on the four canonical paths:
+  The dual-slot rule is enforced at one site, in `tools.wire/ok-text`
+  + `err-text`; the test corpus pins the shape on the four canonical
+  paths:
 
     - Success envelope (`ok-text`).
     - Error envelope (`err-text`).
@@ -42,8 +42,8 @@
           "the :structuredContent slot is present (rf2-hj3pi)")
       ;; The structured slot should be a JS object whose shape mirrors
       ;; the input. Keywords lose their `:` prefix in the JSON-coercible
-      ;; projection but KEEP their namespace (rf2-t2n04 — `:rf/x` →
-      ;; "rf/x"); plain keys like `:ok?` become the bare "ok?".
+      ;; projection but KEEP their namespace (`:rf/x` → "rf/x"); plain
+      ;; keys like `:ok?` become the bare "ok?".
       (is (object? (j/get result :structuredContent))
           ":structuredContent is a JS object")
       (is (= true (j/get-in result [:structuredContent :ok?]))
@@ -91,11 +91,10 @@
       (is (object? (j/get result :structuredContent))))))
 
 (deftest cache-hit-marker-key-keeps-namespace-in-structured-slot
-  ;; rf2-or8s29 — the cache-hit marker is built OUTSIDE the per-tool
-  ;; callbacks; before the fix it used a raw namespace-lossy `clj->js`,
-  ;; so SDK-friendly hosts reading structuredContent saw `"cache-hit"`
-  ;; (the marker key truncated) and missed the marker. Now it routes
-  ;; through `wire/result`, preserving the fully-qualified token.
+  ;; The cache-hit marker is built OUTSIDE the per-tool callbacks. It
+  ;; routes through `wire/result` so SDK-friendly hosts reading
+  ;; structuredContent see the fully-qualified `"rf.mcp/cache-hit"`
+  ;; token rather than a namespace-truncated `"cache-hit"` key.
   (testing "the :rf.mcp/cache-hit marker KEY survives namespace-faithfully (rf2-or8s29)"
     (let [entry  {:hash 12345 :unchanged-since 1700000000000}
           result (cache/cache-hit-result entry "snapshot" :result-hash)]
@@ -105,16 +104,16 @@
           "the namespace-truncated \"cache-hit\" key must NOT appear (the lossy old shape)"))))
 
 ;; ---------------------------------------------------------------------------
-;; structuredContent is NEVER null (rf2-r5erl).
+;; structuredContent is NEVER null.
 ;;
 ;; Every tool descriptor declares a map-shaped `:outputSchema`
 ;; (`{:type "object"}`). The npm MCP SDK validates `structuredContent`
 ;; against it, and a `null` is not a record — the SDK rejects the whole
 ;; `tools/call` at the transport layer with
 ;; `Invalid tools/call result: expected record at structuredContent,
-;; received null`. read-dom hit this in the wild when its browser eval
-;; came back blank (`cljs-eval-value` → nil → `(wire/ok-text nil)` →
-;; `(clj->js nil)` → null). `ok-text` / `err-text` now make the slot a
+;; received null`. read-dom can produce this when its browser eval
+;; comes back blank (`cljs-eval-value` → nil → `(wire/ok-text nil)` →
+;; `(clj->js nil)` → null). `ok-text` / `err-text` make the slot a
 ;; total non-null record.
 ;; ---------------------------------------------------------------------------
 
@@ -151,15 +150,15 @@
             "the EDN text slot still carries the verbatim scalar")))))
 
 ;; ---------------------------------------------------------------------------
-;; Namespaced keywords keep their namespace over the wire (rf2-t2n04).
+;; Namespaced keywords keep their namespace over the wire.
 ;;
 ;; A bare `(clj->js v)` is namespace-lossy: the default `:keyword-fn` for
 ;; map KEYS is `name` (`:rf/runtime` → `"runtime"`), and keyword VALUES
 ;; always go through `name` too (`:door/main` → `"main"`). Both drop the
 ;; namespace AND the colon, so an agent reading the structured slot then
 ;; threading the name-only key back through `get-path` hits `nil`. The
-;; fix stringifies every keyword to its colon-less fully-qualified token
-;; (`"rf/runtime"`) before `clj->js`. The EDN text slot stays the
+;; wire layer stringifies every keyword to its colon-less fully-qualified
+;; token (`"rf/runtime"`) before `clj->js`. The EDN text slot stays the
 ;; namespace-faithful, fully-typed canonical round-trip.
 ;; ---------------------------------------------------------------------------
 
@@ -168,7 +167,7 @@
     (let [payload {:rf/runtime {:loaded? true} :step 3}
           result  (wire/ok-text payload)]
       ;; The structured slot key must be the fully-qualified token, NOT
-      ;; the name-only "runtime" the old clj->js produced.
+      ;; a name-only "runtime".
       (is (some? (j/get-in result [:structuredContent "rf/runtime"]))
           ":rf/runtime serialises to the \"rf/runtime\" key, not \"runtime\"")
       (is (nil? (j/get-in result [:structuredContent "runtime"]))
@@ -184,8 +183,8 @@
 
 (deftest namespaced-keyword-values-keep-namespace-in-structured-slot
   (testing "namespaced keyword VALUES (e.g. machine-ids) keep their namespace (rf2-t2n04)"
-    ;; clj->js's :keyword-fn applies to KEYS only; keyword values always
-    ;; went through `name`. This pins the value path too.
+    ;; clj->js's :keyword-fn applies to KEYS only; keyword values go
+    ;; through `name`. This pins the value path too.
     (let [payload {:machine-ids [:door/main :traffic/light :quiz/scorer]
                    :current     :door/open}
           result  (wire/ok-text payload)

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_resource_controls_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.subscribe-resource-controls-test
   "Integration tests pinning the wiring between `subscribe.cljs` and
-  `resource-controls.cljs` (rf2-3ijbl). The unit tests in
+  `resource-controls.cljs`. The unit tests in
   `resource_controls_test.cljs` cover the primitives in isolation; this
   file pins the subscribe-side contract:
 
@@ -9,7 +9,7 @@
        discipline).
     2. The initial-state map carries the `:rate-dropped` slot at zero
        so a stream that hits no rate-drops emits a clean envelope.
-    3. The `:reason` keyword vocabulary admits the new abuse-detected
+    3. The `:reason` keyword vocabulary admits the abuse-detected
        sentinel.
 
   The full stream-controller behaviour (acquire-on-subscribe,
@@ -19,7 +19,7 @@
   neither of which the node-test harness can drive without a live
   nREPL socket. The contracts pinned here cover the wire-shape side
   of the integration; the runtime side rides the existing per-sub
-  queue-cap tests + the rf2-3ijbl bead's manual smoke."
+  queue-cap tests + a manual smoke."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.test-utils :as tu]
@@ -56,7 +56,7 @@
 (deftest abuse-detected-keyword-is-namespaced
   ;; The reason rides on the final-summary envelope. Pin the keyword
   ;; shape — `:rf.error/stream-abuse-detected` per the rf.error/*
-  ;; convention (rf2-3ijbl + Conventions §reserved-namespaces).
+  ;; convention (Conventions §reserved-namespaces).
   (let [kw :rf.error/stream-abuse-detected]
     (is (qualified-keyword? kw))
     (is (= "rf.error" (namespace kw)))
@@ -87,9 +87,9 @@
 ;;
 ;; `final-summary` is private to subscribe.cljs; we exercise the
 ;; suppress-when-zero rule via the merge-drain shape it consumes. A
-;; downstream test in `with_indicators_test.cljs` already pins the
-;; broader indicator-field discipline; this file pins the per-slot
-;; rule for the new `:rate-dropped` slot.
+;; downstream test in `with_indicators_test.cljs` pins the broader
+;; indicator-field discipline; this file pins the per-slot rule for the
+;; `:rate-dropped` slot.
 
 (deftest initial-state-has-rate-dropped-zero
   ;; The fresh state map MUST carry `:rate-dropped` at zero. A merge-
@@ -105,15 +105,13 @@
     (is (zero? (:rate-dropped s')))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-uvfph — rate gate is checked BEFORE the destructive drain.
+;; Rate gate is checked BEFORE the destructive drain.
 ;;
-;; The headline regression: pre-rf2-uvfph the poll loop drained the
-;; runtime queue (`drain-subscription!` pops + clears it) and ONLY THEN
-;; checked the rate limit; a denied tick threw the already-drained batch
-;; away — silent event loss, despite the spec promising "left in queue
-;; for later delivery". The fix gates the drain itself: a denied cycle
-;; MUST NOT call `drain-subscription!`, so the queue stays intact for a
-;; later cycle once a token refills.
+;; The poll loop checks the rate limit BEFORE draining the runtime queue
+;; (`drain-subscription!` pops + clears it). A denied cycle MUST NOT call
+;; `drain-subscription!`, so the queue stays intact for a later cycle
+;; once a token refills — no silent event loss, honouring the spec
+;; promise of "left in queue for later delivery".
 ;;
 ;; We drive ONE `poll` invocation through `make-stream-controller` with a
 ;; stubbed `nrepl/cljs-eval-value` that records every form it's asked to

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.subscribe-test
-  "Unit tests for the streaming subscribe / unsubscribe tools (rf2-hq49).
+  "Unit tests for the streaming subscribe / unsubscribe tools.
 
   These tests cover the MCP-arg → runtime-form translation (the EDN
   shape we send over nREPL), the filter-arg parser (JSON object vs
@@ -22,10 +22,10 @@
 ;; public surface directly so a rename or signature change surfaces
 ;; as a failing test rather than a silent contract drift.
 ;;
-;; rf2-5kbkl — the parser returns the tagged `[:ok m]` /
+;; The parser returns the tagged `[:ok m]` /
 ;; `[:err :invalid-filter-edn]` shape (mirroring `read-edn-arg`). A
 ;; malformed filter EDN surfaces as an honest `:ok? false` error rather
-;; than the pre-fix `{:invalid-filter-edn raw}` MAP that flowed straight
+;; than a `{:invalid-filter-edn raw}` map that would flow straight
 ;; into the runtime `:filter` slot as a nonsense filter.
 
 (deftest filter-arg-nil-passes-through
@@ -40,8 +40,8 @@
          (args/parse-filter-arg "{:touches-path [:cart :items]}"))))
 
 (deftest filter-arg-malformed-edn-is-err-tagged
-  ;; The regression: an unparseable EDN string must NOT become a
-  ;; nonsense `{:invalid-filter-edn raw}` map — it returns the honest
+  ;; An unparseable EDN string must NOT become a nonsense
+  ;; `{:invalid-filter-edn raw}` map — it returns the honest
   ;; `[:err :invalid-filter-edn]` tag so the caller short-circuits.
   (is (= [:err :invalid-filter-edn]
          (args/parse-filter-arg "(((")))) ;; unbalanced delimiters
@@ -58,7 +58,7 @@
   (is (= [:ok {:op-type :error}]
          (args/parse-filter-arg {:op-type :error}))))
 
-;; rf2-5kbkl — end-to-end at the tool boundary: a malformed filter EDN
+;; End-to-end at the tool boundary: a malformed filter EDN
 ;; makes `subscribe-tool` short-circuit to an honest `:ok? false`
 ;; envelope (`:reason :invalid-filter-edn`, `:isError true`) WITHOUT
 ;; touching the nREPL socket or reserving a stream slot — rather than
@@ -67,7 +67,7 @@
 ;; subscribe-form tests above).
 
 (deftest subscribe-tool-malformed-filter-errors-honestly
-  ;; The headline regression. A malformed filter EDN makes
+  ;; A malformed filter EDN makes
   ;; `subscribe-tool` short-circuit to an honest `:ok? false` envelope
   ;; (`:reason :invalid-filter-edn`, `:isError true`) — the `cond`
   ;; branch fires BEFORE the `:else` arm reserves a stream slot or
@@ -86,11 +86,11 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-uvfph — numeric subscribe-control validation. The five integer
-;; knobs (buffer caps, poll-ms, max-ms, max-events) were forwarded raw to
-;; the runtime budget / poll loop / termination caps with NO lower bound.
-;; Negatives collapsed the queue budget (empty probe), spun the poll loop,
-;; or silently disabled the intended bound. The args helpers vet them.
+;; Numeric subscribe-control validation. The five integer knobs (buffer
+;; caps, poll-ms, max-ms, max-events) feed the runtime budget / poll loop
+;; / termination caps. The args helpers vet them so a negative can't
+;; collapse the queue budget (empty probe), spin the poll loop, or
+;; silently disable the intended bound.
 ;; ---------------------------------------------------------------------------
 
 (deftest positive-int-arg-absent-is-ok-nil
@@ -125,19 +125,19 @@
   (let [[tag _] (args/parse-positive-int-arg "max-events" "soon")]
     (is (= :err tag) "non-numeric junk is rejected")))
 
-;; rf2-ykv9a0 cross-runtime safe-integer guard, routed through
-;; `base-args/coerce-finite-long` by rf2-ttspi7. A whole numeric (or
-;; numeric string) ABOVE the JS safe-integer ceiling (2^53 − 1 =
+;; Cross-runtime safe-integer guard, routed through
+;; `base-args/coerce-finite-long`. A whole numeric (or numeric string)
+;; ABOVE the JS safe-integer ceiling (2^53 − 1 =
 ;; 9 007 199 254 740 991) is NOT losslessly representable across both
-;; hosts; before the routing it slipped past `coerce-int`'s
-;; `Number.isInteger` check (a double like 9007199254740993 is "integral"
-;; in JS) and reached the runtime budget, while mcp-base's `max-tokens`
-;; rejected the same value — the divergence this closes.
+;; hosts. A bare `Number.isInteger` check would admit such a value (a
+;; double like 9007199254740993 is "integral" in JS); the finite-long
+;; guard rejects it, keeping the runtime budget in lockstep with
+;; mcp-base's `max-tokens`, which rejects the same value.
 
 (deftest positive-int-arg-rejects-over-safe-integer
   ;; 2^53 + 1 — past the safe-integer window. `Number.isInteger` is true
-  ;; for it (it's a whole double), so it would have passed the OLD
-  ;; coerce-int; the finite/range guard now rejects it as a bad numeric.
+  ;; for it (it's a whole double), but the finite/range guard rejects it
+  ;; as a bad numeric.
   (let [over (+ 9007199254740992 1)
         [tag env] (args/parse-positive-int-arg "max-buffered-events" over)]
     (is (= :err tag) "an over-safe-integer numeric is rejected, not forwarded")
@@ -218,16 +218,15 @@
                    (is (= "max-events" (:arg edn))))
                  (done))))))
 
-;; The VALID-filter path "works unchanged" is pinned by the
+;; The VALID-filter path is pinned by the
 ;; `subscribe-form-with-trace-and-filter` / `-fx-topic` round-trip tests
 ;; above: a well-formed filter rides into the runtime `subscribe!`
-;; `:filter` opts slot. With the rf2-5kbkl change those still hold
-;; because `parse-filter-arg` now unwraps the `[:ok m]` tag back to the
-;; same `filter-map` the form constructor consumes.
+;; `:filter` opts slot. `parse-filter-arg` unwraps the `[:ok m]` tag
+;; back to the same `filter-map` the form constructor consumes.
 
 ;; The subscribe-form constructor is private. Re-implement here over
 ;; the eval-form DSL to pin the IR + emitted source we send to the
-;; runtime (rf2-dpzpe). Tests assert against opts-map data shape via
+;; runtime. Tests assert against opts-map data shape via
 ;; `cljs.reader/read-string` over the emitted form — no regex over
 ;; raw source, no whitespace fragility.
 
@@ -274,7 +273,7 @@
     (is (= {:event-id :http/get} (:filter opts)))))
 
 (deftest subscribe-form-carries-both-budgets
-  ;; rf2-ho4ve: the wire shape must always carry BOTH :max-buffered-events
+  ;; The wire shape must always carry BOTH :max-buffered-events
   ;; and :max-buffered-bytes — the runtime applies an OR-combined budget,
   ;; so half the pair would leak through to the runtime's default for the
   ;; missing slot. Pin the round-trip here.
@@ -286,10 +285,9 @@
 ;; subscribe! whitelist.
 
 (deftest recognised-topics
-  ;; Per rf2-mscih `:frameless` joins the recognised set as the
-  ;; explicit opt-in channel for events with no
-  ;; `:rf.trace/dispatch-id` — registration emits, REPL evals,
-  ;; lifecycle outside any cascade.
+  ;; `:frameless` is in the recognised set as the explicit opt-in
+  ;; channel for events with no `:rf.trace/dispatch-id` — registration
+  ;; emits, REPL evals, lifecycle outside any cascade.
   (let [recognised #{:trace :epoch :fx :error :frameless}]
     (is (contains? recognised :trace))
     (is (contains? recognised :epoch))
@@ -299,11 +297,11 @@
     (is (not (contains? recognised :unknown)))))
 
 ;; The progress payload shape — the MCP notifications/progress
-;; notification we emit on each batch tick. Per rf2-ho4ve `_meta.data`
-;; slot now carries `:dropped-events`, `:dropped-bytes`, and
-;; `:overflow-reason` (stringified keyword) so the AI client can
-;; pattern-match on WHICH budget tripped without re-parsing EDN. The
-;; official MCP SDK preserves `_meta` in progress callbacks.
+;; notification we emit on each batch tick. The `_meta.data` slot
+;; carries `:dropped-events`, `:dropped-bytes`, and `:overflow-reason`
+;; (stringified keyword) so the AI client can pattern-match on WHICH
+;; budget tripped without re-parsing EDN. The official MCP SDK
+;; preserves `_meta` in progress callbacks.
 
 (defn- progress-payload
   [progress-token tick events-edn dropped-events dropped-bytes overflow-reason]
@@ -339,8 +337,8 @@
     (is (= 12345 (j/get-in p [:_meta :data :dropped-bytes])))
     (is (= ":max-buffered-bytes" (j/get-in p [:_meta :data :overflow-reason])))))
 
-;; Unsubscribe + drain form pinning — built over the eval-form DSL
-;; (rf2-dpzpe). The expected source strings are the DSL's emit output;
+;; Unsubscribe + drain form pinning — built over the eval-form DSL.
+;; The expected source strings are the DSL's emit output;
 ;; a rename of the runtime ns flows through `ef/runtime-ns`.
 
 (defn- unsubscribe-form [sub-id]
@@ -358,7 +356,7 @@
          (drain-form "sub-xyz"))))
 
 ;; ---------------------------------------------------------------------------
-;; Byte+event overflow budget — rf2-ho4ve corner-matrix
+;; Byte+event overflow budget — corner-matrix
 ;; ---------------------------------------------------------------------------
 ;;
 ;; Parallel fixture of the runtime's `evict-oldest` / `enqueue!`
@@ -483,8 +481,8 @@
     (is (nil?  (:overflow-reason sub)))))
 
 ;; ---------------------------------------------------------------------------
-;; merge-drain — pure state update for the streaming-loop accumulators
-;; (rf2-c0h8p). The fn lives in `tools/subscribe.cljs`; it's the
+;; merge-drain — pure state update for the streaming-loop accumulators.
+;; The fn lives in `tools/subscribe.cljs`; it's the
 ;; single source of truth for how a drain's contributions fold into
 ;; the rolling per-stream state map.
 ;;
@@ -598,17 +596,16 @@
     (is (= 5 (:elided-large s2)))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-vr2hn — `--allow-sensitive-reads` boot gate on the drain eval form.
+;; `--allow-sensitive-reads` boot gate on the drain eval form.
 ;;
 ;; The drain envelope's `:events` slot rides the nREPL wire verbatim. For
 ;; the `:epoch` topic that means full epoch records (`:db-after` /
 ;; `:db-before` / `:app-db`) — a hostile per-call arg shouldn't be able
 ;; to talk an operator who didn't pass `--allow-sensitive-reads` into shipping
 ;; raw state. The gate mirrors the snapshot / get-path / trace-window
-;; pattern (rf2-c2dtu): when OFF, the drain form wraps `:events` with
+;; pattern: when OFF, the drain form wraps `:events` with
 ;; `re-frame.core/elide-wire-value` server-side, sensitive slots redact,
-;; large slots elide. When ON, the bare drain ships raw — the
-;; pre-rf2-vr2hn posture.
+;; large slots elide. When ON, the bare drain ships raw.
 ;; ---------------------------------------------------------------------------
 
 (deftest drain-form-gated-elision-wraps-events
@@ -631,24 +628,22 @@
         "sensitive slots redact when the caller did NOT opt in")))
 
 (deftest drain-form-resolves-elision-frame-per-element
-  ;; rf2-1we9fa / rf2-7737vq — the trace-walk arm resolves the elision
-  ;; `:frame` PER ELEMENT inside the walk BY LAYER, NOT once for the whole
-  ;; drain. Cascade bundles are keyed by `[frame dispatch-id]`, so an
-  ;; all-frame stream — or a filter frame that differs from the operating
-  ;; frame — carries cascades from several frames in one tick. Per EP-0015
-  ;; sensitive/large declarations are per-frame, so each element MUST be
-  ;; elided against its OWN frame: a DERIVED cascade record's top-level
-  ;; `:frame` slot, else a frameless RAW event's frame via the canonical
+  ;; The trace-walk arm resolves the elision `:frame` PER ELEMENT inside
+  ;; the walk BY LAYER, NOT once for the whole drain. Cascade bundles are
+  ;; keyed by `[frame dispatch-id]`, so an all-frame stream — or a filter
+  ;; frame that differs from the operating frame — carries cascades from
+  ;; several frames in one tick. Per EP-0015 sensitive/large declarations
+  ;; are per-frame, so each element MUST be elided against its OWN frame:
+  ;; a DERIVED cascade record's top-level `:frame` slot, else a frameless
+  ;; RAW event's frame via the canonical
   ;; `re-frame.trace/trace-event-frame` reader ([:tags :frame]). The
-  ;; operating frame (`(re-frame2-pair.runtime/current-frame)`) survives
-  ;; as the GENUINELY FRAMELESS FALLBACK only (EP-0002 rf2-bd4div: the
-  ;; nREPL eval thread carries no ambient `with-frame` scope, so a truly
-  ;; frameless element would otherwise fail closed and redact away).
+  ;; operating frame (`(re-frame2-pair.runtime/current-frame)`) serves
+  ;; as the GENUINELY FRAMELESS FALLBACK only (EP-0002: the nREPL eval
+  ;; thread carries no ambient `with-frame` scope, so a truly frameless
+  ;; element would otherwise fail closed and redact away).
   ;;
-  ;; This test REPLACES the prior `drain-form-threads-operating-frame`,
-  ;; which PINNED the buggy "one operating frame for every cascade"
-  ;; behaviour. Trace-event topic — the walker arm carries the per-element
-  ;; frame resolution.
+  ;; Trace-event topic — the walker arm carries the per-element frame
+  ;; resolution.
   (let [form (sub/drain-form "sub-frame" :trace true false)]
     (is (str/includes? form "(re-frame2-pair.runtime/current-frame)")
         "the operating frame is resolved app-side as the frameless fallback")
@@ -678,12 +673,12 @@
         "include-sensitive? true threads into the walker opts")))
 
 (deftest drain-form-bare-elision-false-still-walks-trace
-  ;; rf2-t55hxg.13 — fail-CLOSED. Pre-fix a gate-ON `:elision false` on a
-  ;; trace-event topic shipped the bare `drain-subscription!` call with NO
-  ;; walker — which let a declared-sensitive frame slot inside a cascade
-  ;; leak off-box WITHOUT the per-call `:include-sensitive true` opt-in (the
-  ;; EP-0015 two-key gate collapse). A BARE `:elision false` (incl? false)
-  ;; now STILL walks: large content passes (`include-large? true`) but a
+  ;; Fail-CLOSED. A gate-ON `:elision false` on a trace-event topic must
+  ;; NOT ship the bare `drain-subscription!` call with NO walker — that
+  ;; would let a declared-sensitive frame slot inside a cascade leak
+  ;; off-box WITHOUT the per-call `:include-sensitive true` opt-in (the
+  ;; EP-0015 two-key gate). A BARE `:elision false` (incl? false) STILL
+  ;; walks: large content passes (`include-large? true`) but a
   ;; declared-sensitive slot redacts to `:rf/redacted`.
   (let [form (sub/drain-form "sub-raw" :trace false false)]
     (is (str/includes? form "drain-subscription!"))
@@ -700,7 +695,7 @@
         "subscribe always emits large markers (the trace surface elides large slots)")))
 
 (deftest drain-form-full-raw-opt-in-bare-drain-trace
-  ;; rf2-t55hxg.13 — the deliberate full-raw local opt-in (`:elision
+  ;; The deliberate full-raw local opt-in (`:elision
   ;; false` AND `:include-sensitive true`) is the ONLY combination that
   ;; ships raw trace events with no walker (the operator's `local-raw` act).
   (let [form (sub/drain-form "sub-raw" :trace false true)]
@@ -722,7 +717,7 @@
         "embedded quotes survive as escaped EDN literals")))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-mahffz (EP-0015 §13) — the `:epoch` topic's `:events` slot egresses
+;; EP-0015 §13 — the `:epoch` topic's `:events` slot egresses
 ;; whole `:rf/epoch-record`s. Those carry the structured `:effects` rows
 ;; whose `:args` slot is payload-bearing fx input (an HTTP body, a payment
 ;; map) — NOT rooted at app-db, so the schema-path-keyed
@@ -730,10 +725,8 @@
 ;; Security.md §Epoch privacy posture, off-box epoch egress MUST route
 ;; through `re-frame.core/projected-record` — the single normative
 ;; emission site, which FAILS CLOSED on `:effects[].args` — NOT the
-;; per-slot wire-value walker. Pre-rf2-mahffz the streaming `:epoch`
-;; drain reused the cascade walker (`elide-wire-value`) on whole records,
-;; leaking `:effects[].args`. The fix routes the `:epoch` topic's
-;; `:events` through `projected-record`, mirroring `watch-epochs` /
+;; per-slot wire-value walker. The streaming `:epoch` drain routes the
+;; `:events` slot through `projected-record`, mirroring `watch-epochs` /
 ;; `trace-window`.
 ;; ---------------------------------------------------------------------------
 
@@ -768,7 +761,7 @@
         "elision? false does not disable epoch projection — sensitive axis governs")))
 
 (deftest drain-form-epoch-include-sensitive-routes-through-projection
-  ;; rf2-m9duxl — gate ON + `:include-sensitive true` (incl? true) does NOT
+  ;; Gate ON + `:include-sensitive true` (incl? true) does NOT
   ;; bypass the epoch projection. The `:events` slot STILL routes through
   ;; `projected-record`, threading `{:include-sensitive? true}` as the
   ;; egress opt (app-db sensitive axis ONLY). fx-args / runtime-db / large
@@ -799,18 +792,18 @@
         "frameless events are not epoch records — no projected-record")))
 
 ;; ---------------------------------------------------------------------------
-;; Cascade-bundle wire format (rf2-mscih) — drain envelope shape, slot
+;; Cascade-bundle wire format — drain envelope shape, slot
 ;; selection on the progress payload, and cross-frame `:dispatch-id`
 ;; merge.
 ;; ---------------------------------------------------------------------------
 
 (deftest drain-form-handles-both-cascade-and-events-slots
-  ;; rf2-mscih — for a TRACE-event topic (cascade-bundle `:trace`/`:fx`/
+  ;; For a TRACE-event topic (cascade-bundle `:trace`/`:fx`/
   ;; `:error` ship `:cascades`; `:frameless` ships `:events`), `drain-form`
   ;; with elision ON wraps WHICHEVER trace-event slot the runtime produced.
   ;; The walker arm uses `cond->` over slot presence so it's slot-agnostic
   ;; WITHIN the trace-event family; the runtime determines which slot the
-  ;; drain envelope carries. (rf2-mahffz: the `:epoch` topic's `:events`
+  ;; drain envelope carries. (The `:epoch` topic's `:events`
   ;; take a DIFFERENT primitive — `projected-record` — so they are NOT in
   ;; this walker arm; covered by `drain-form-epoch-*` above.)
   (let [form (sub/drain-form "sub-1" :trace true false)]
@@ -824,7 +817,7 @@
         "the walker is applied to whichever trace-event slot is present")))
 
 (deftest progress-payload-uses-cascades-slot-on-cascade-bundle-topics
-  ;; rf2-mscih — the progress payload's load slot is named per the
+  ;; The progress payload's load slot is named per the
   ;; topic's wire shape: `:cascades` for cascade-bundle topics
   ;; (`:trace`/`:fx`/`:error`), `:events` for flat topics
   ;; (`:epoch`/`:frameless`).
@@ -867,7 +860,7 @@
     (is (contains? bundle :parent-dispatch-id))))
 
 (deftest cross-frame-cascade-merge-by-dispatch-id
-  ;; rf2-mscih cross-frame contract — a single cascade can fan out
+  ;; Cross-frame contract — a single cascade can fan out
   ;; across frames; every emit on every frame shares the same
   ;; `:rf.trace/dispatch-id`. Consumers merge by `:dispatch-id` to
   ;; reconstruct the cross-frame view per Tool-Pair §Cross-frame
@@ -907,7 +900,7 @@
         "the merged slot exposes both frames' contributions")))
 
 (deftest frameless-channel-shape-is-flat-events-not-bundles
-  ;; rf2-mscih frameless contract — registration emits / REPL / boot
+  ;; Frameless contract — registration emits / REPL / boot
   ;; lifecycle ride under `:events` (flat) on the `:frameless` topic.
   ;; No cascade structure to bundle; the frameless events carry no
   ;; `:rf.trace/dispatch-id` tag.
@@ -930,15 +923,15 @@
         "frameless events MUST carry no :rf.trace/dispatch-id tag")))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-wz66k7 — the per-tick progress notification is wire-capped.
+;; The per-tick progress notification is wire-capped.
 ;;
 ;; `emit-progress-tick!` ships its per-tick payload as the `:message` of a
 ;; `notifications/progress` notification. That notification NEVER crosses
 ;; the `invoke` chokepoint where `apply-cap` runs on `tools/call` RESULTS,
-;; so before this fix an oversized drain shipped a multi-megabyte progress
-;; message un-capped — busting the per-notification token budget the spec
-;; pins. The fix runs the `:message` through `cap/cap-message` with the
-;; per-call cap threaded down from `subscribe-tool`.
+;; so without its own cap an oversized drain would ship a multi-megabyte
+;; progress message — busting the per-notification token budget the spec
+;; pins. The `:message` runs through `cap/cap-message` with the per-call
+;; cap threaded down from `subscribe-tool`.
 ;; ---------------------------------------------------------------------------
 
 (defn- capture-progress-message
@@ -978,10 +971,9 @@
         "the flat-topic payload rides under :events")))
 
 (deftest emit-progress-tick-oversized-payload-is-overflow-marked
-  ;; THE Finding-1 acceptance test (rf2-wz66k7): an oversized per-tick
-  ;; drain MUST emit an overflow marker on the progress channel, NOT a
-  ;; multi-megabyte raw message. FAILS before the fix (the notification
-  ;; bypassed the cap); PASSES after.
+  ;; An oversized per-tick drain MUST emit an overflow marker on the
+  ;; progress channel, NOT a multi-megabyte raw message — the
+  ;; per-notification cap applies to the progress channel too.
   (let [fat (apply str (repeat 4000 "x"))
         big-events (vec (repeat 50 {:payload fat}))
         msg (capture-progress-message big-events 500)
@@ -1009,11 +1001,10 @@
         "the full fat payload rides when the cap is disabled")))
 
 (deftest cursor-stale-does-not-apply-to-subscribe-streams
-  ;; rf2-mscih clarification — `:rf.mcp/cursor-stale` is a cursor-
-  ;; pagination concern (`trace-window` / `watch-epochs`), not a
-  ;; streaming concern. The `subscribe` surface is forward-only with
-  ;; no cursor; the cascade-bundle wire reshape introduces no new
-  ;; cursor surface.
+  ;; `:rf.mcp/cursor-stale` is a cursor-pagination concern
+  ;; (`trace-window` / `watch-epochs`), not a streaming concern. The
+  ;; `subscribe` surface is forward-only with no cursor; the
+  ;; cascade-bundle wire shape carries no cursor surface.
   (let [;; A streaming subscription's final summary — no cursor slot.
         subscribe-summary {:ok? true
                            :sub-id "sub-1"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
@@ -1,17 +1,14 @@
 (ns re-frame2-pair-mcp.tail-build-test
-  "Unit tests for the `tail-build` MCP tool — specifically the
-  probe-value diagnostics added in rf2-36awg.
+  "Unit tests for the `tail-build` MCP tool — specifically its
+  probe-value diagnostics.
 
-  Pre-rf2-36awg the tool returned `{:ok? true :soft? false}` on success
-  and `{:ok? false :reason :timed-out :note \"...likely a compile
-  error.\"}` on timeout. Neither response carried the probe values
-  themselves, so the operator could not tell:
+  The probe-value envelope lets the operator tell:
 
     - Did the probe form evaluate at all?
     - Did the probe return the same value before / after the reload?
     - Did the probe form raise on every iteration?
 
-  These tests pin the new envelope shape so the diagnostic stays
+  These tests pin the envelope shape so the diagnostic stays
   visible across refactors of the polling loop."
   (:require [cljs.test :refer-macros [deftest is testing async]]
             [re-frame2-pair-mcp.nrepl :as nrepl]
@@ -65,7 +62,7 @@
         (.finally (fn [] (tu/restore-eval! stub orig))))))
 
 ;; ---------------------------------------------------------------------------
-;; Soft delay — no probe supplied; envelope is unchanged from pre-rf2-36awg.
+;; Soft delay — no probe supplied; the envelope carries no probe-values.
 ;; ---------------------------------------------------------------------------
 
 (deftest no-probe-soft-resolves
@@ -151,10 +148,10 @@
           (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-wz66k7 — `:wait-ms` is validated as a positive-millisecond integer
-;; BEFORE the poll loop. A non-numeric value (`"bogus"`) made the
+;; `:wait-ms` is validated as a positive-millisecond integer
+;; BEFORE the poll loop. A non-numeric value (`"bogus"`) would make the
 ;; `(>= elapsed wait-ms)` comparison `(>= n NaN)` — never true — so a
-;; stuck probe polled the nREPL socket FOREVER. The tool now short-circuits
+;; stuck probe would poll the nREPL socket FOREVER. The tool short-circuits
 ;; to an honest validation error WITHOUT touching nREPL.
 ;; ---------------------------------------------------------------------------
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/test_utils.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/test_utils.cljs
@@ -1,33 +1,31 @@
 (ns re-frame2-pair-mcp.test-utils
-  "Shared test helpers (rf2-ambfv, rf2-wnrpi).
+  "Shared test helpers.
 
   Home for fns that only the test corpus uses but that conceptually
   sit alongside the production code.
 
-  ## Wire-envelope extractors (rf2-wnrpi)
+  ## Wire-envelope extractors
 
   The MCP tools return a `#js {:content #js [#js {:text \"...edn...\"}]}`
   envelope (with an optional `:isError true`). Four trivial extractors
-  used to walk that shape were copy-pasted privately across at least
-  five suites (`conformance_test`, `handler_meta_test`, `invoke_test`,
-  `cache_test`, `dispatch_test`). They are hoisted here so a wire-shape
-  change touches one definition rather than five drifting copies:
+  walk that shape, shared across the suites that need them
+  (`conformance_test`, `handler_meta_test`, `invoke_test`,
+  `cache_test`, `dispatch_test`) so a wire-shape change touches one
+  definition rather than several drifting copies:
 
     - `args->js`     — CLJS arg map → the `#js {}` object tools read.
     - `extract-text` — pull the first content item's `:text` string.
     - `extract-edn`  — `extract-text` then `edn/read-string`.
     - `error?`       — truthy `:isError` slot.
 
-  ## Stub installer (rf2-wnrpi)
+  ## Stub installer
 
   `with-stubbed-eval!` installs a Promise-returning stub over
   `nrepl/cljs-eval-value` and restores it in `.finally` so cleanup
-  outlives async resolution. Two suites (`probe_test`, `dispatch_test`)
-  hand-rolled near-identical copies; the corpus driver in
-  `conformance_test` keeps its own richer `eval-script`/`forms-seen`
-  variant (different contract), and `invoke_test` keeps its
-  fixture-scoped restore (rf2-wb06a race) deliberately — neither is
-  collapsed here.
+  outlives async resolution. The corpus driver in `conformance_test`
+  keeps its own richer `eval-script`/`forms-seen` variant (different
+  contract), and `invoke_test` keeps its fixture-scoped restore (race
+  avoidance) deliberately — neither is collapsed here.
 
   ## `dedup-expand`
 
@@ -37,13 +35,12 @@
   `de-dupe.core/expand`; the MCP server never calls the inverse, so the
   helper lives here, signalling \"test-only\" by location.
 
-  ## Test-only base re-exports (rf2-ttspi7)
+  ## Test-only base re-exports
 
   `token-estimate`, `overflow-hint-fallback`, and `truncate-preview`
-  used to be re-exported from the production `tools.cap` /
-  `tools.result-envelope` namespaces SOLELY so the test corpus could
-  reach them — production code calls `base-overflow` / `base-cap`
-  directly and never used the local aliases. Hosting them here (the
+  are test-only handles on the cross-MCP token rule, the
+  overflow-fallback hint, and the preview cap. Production code calls
+  `base-overflow` / `base-cap` directly; hosting these here (the
   test-only home) keeps the production surface lean while still pinning
   the cross-MCP token rule + overflow-fallback contract + preview cap in
   one shared test-side place."
@@ -90,18 +87,17 @@
 ;; ---------------------------------------------------------------------------
 ;; Stub installer — async-safe `cljs-eval-value` override.
 ;;
-;; ## Identity-guarded restore (rf2-j4d5ty)
+;; ## Identity-guarded restore
 ;;
 ;; `nrepl/cljs-eval-value` is a single shared-mutable global. Every stub
 ;; installer across the corpus mutates its root via `set!`. A `.finally`-
 ;; scoped restore resolves on a microtask that can land AFTER cljs.test's
 ;; `done` has advanced to a NEIGHBOURING namespace's test — which has
 ;; ALREADY installed ITS own stub. An unconditional `(set! global orig)`
-;; then clobbers that fresh stub back to a stale fn mid-eval, and the
-;; victim test reaches the real socket (`cached port file disappeared` /
-;; `re-find must match against a string`). The race is order-dependent,
-;; so it migrates with test ordering (rf2-wb06a's fixture-boundary fix
-;; narrowed but did not close it for the `.finally`-restore suites).
+;; would then clobber that fresh stub back to a stale fn mid-eval, and the
+;; victim test would reach the real socket (`cached port file disappeared`
+;; / `re-find must match against a string`). The race is order-dependent,
+;; so it migrates with test ordering.
 ;;
 ;; `restore-eval!` makes every restore IDENTITY-GUARDED: it restores
 ;; `orig` ONLY when the global is still the exact `stub` this installer
@@ -115,7 +111,7 @@
   ONLY when the current global is still `stub` (the fn this installer
   set). A late restore whose stub has already been superseded by a
   neighbouring test becomes a no-op, so it can never clobber a fresh
-  stub (rf2-j4d5ty)."
+  stub."
   [stub orig]
   (when (identical? nrepl/cljs-eval-value stub)
     (set! nrepl/cljs-eval-value orig)))
@@ -124,21 +120,21 @@
   "Identity-guarded restore of `nrepl/jvm-eval` — the `jvm-eval` twin of
   `restore-eval!`. Same shared-mutable-global hazard, same guard: a late
   `.finally` only restores when the global is still this installer's
-  `stub` (rf2-j4d5ty)."
+  `stub`."
   [stub orig]
   (when (identical? nrepl/jvm-eval stub)
     (set! nrepl/jvm-eval orig)))
 
 (defn restore-cljs-eval!
   "Identity-guarded restore of `nrepl/cljs-eval` — the lower-level
-  `cljs-eval` twin of `restore-eval!`. Same hazard + guard (rf2-j4d5ty)."
+  `cljs-eval` twin of `restore-eval!`. Same hazard + guard."
   [stub orig]
   (when (identical? nrepl/cljs-eval stub)
     (set! nrepl/cljs-eval orig)))
 
 (defn restore-freshness!
   "Identity-guarded restore of `freshness/jvm-build-freshness`. Same
-  hazard + guard as `restore-eval!` (rf2-j4d5ty)."
+  hazard + guard as `restore-eval!`."
   [stub orig]
   (when (identical? freshness/jvm-build-freshness stub)
     (set! freshness/jvm-build-freshness orig)))
@@ -149,7 +145,7 @@
   returns a Promise) and restore the original in `.finally` so cleanup
   outlives async resolution.
 
-  Restore is identity-guarded (rf2-j4d5ty): a late `.finally` cannot
+  Restore is identity-guarded: a late `.finally` cannot
   clobber a neighbouring test's freshly-installed stub.
 
   This is the simple, value-returning variant used by suites that don't
@@ -169,8 +165,8 @@
 
 (defn with-stubbed-freshness!
   "Stub `freshness/jvm-build-freshness` to resolve to `jvm-half` (a map
-  or nil) for the duration of `body-fn`, restoring in `.finally`
-  (rf2-ertqw). `discover-app` now assembles a freshness token, which
+  or nil) for the duration of `body-fn`, restoring in `.finally`.
+  `discover-app` assembles a freshness token, which
   reads the JVM-side shadow worker state via `jvm-eval`; in a unit test
   with no live nREPL that probe would attempt a real socket. Stub it so
   discover-app tests stay hermetic and deterministic.
@@ -201,32 +197,32 @@
     v))
 
 ;; ---------------------------------------------------------------------------
-;; Test-only base re-exports (rf2-ttspi7).
+;; Test-only base re-exports.
 ;;
 ;; Production code calls `base-overflow` / `base-cap` directly; these
-;; aliases existed only so the test corpus could reach the cross-MCP
-;; token rule, the overflow-fallback hint, and the preview cap. Hosting
-;; them here keeps the production namespaces lean.
+;; aliases let the test corpus reach the cross-MCP token rule, the
+;; overflow-fallback hint, and the preview cap. Hosting them here keeps
+;; the production namespaces lean.
 ;; ---------------------------------------------------------------------------
 
 (defn token-estimate
   "Delegates to `re-frame.mcp-base.overflow/token-estimate` — the
-  cross-MCP `(quot (count s) 4)` token approximation. Test-only home for
-  what `tools.cap` used to re-export (rf2-ttspi7)."
+  cross-MCP `(quot (count s) 4)` token approximation. Test-only handle
+  on the cross-MCP token rule."
   [s]
   (base-overflow/token-estimate s))
 
 (def overflow-hint-fallback
   "The cross-MCP overflow-marker fallback hint string, sourced from
-  `re-frame.mcp-base.overflow/overflow-hint-fallback`. Test-only home for
-  what `tools.cap` used to re-export (rf2-ttspi7)."
+  `re-frame.mcp-base.overflow/overflow-hint-fallback`. Test-only handle
+  on the overflow-fallback contract."
   base-overflow/overflow-hint-fallback)
 
 (defn truncate-preview
   "Truncate `text` to `result-envelope/preview-cap` chars with a
   char-count suffix — the same shape the runtime wrap emits. Test-only
-  home for what `tools.result-envelope` used to re-export (rf2-ttspi7);
-  pins the preview contract against the single-sourced production cap."
+  handle on the preview contract, pinned against the single-sourced
+  production cap."
   [text]
   (let [n (count text)]
     (if (> n renv/preview-cap)

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/trace_window_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/trace_window_test.cljs
@@ -1,25 +1,27 @@
 (ns re-frame2-pair-mcp.trace-window-test
   "Unit tests for the `trace-window` MCP tool — the authoritative-ring
-  read contract (rf2-ertqw) and the empty-result advisory (rf2-fb4hn).
+  read contract and the empty-result advisory.
 
-  ## Authoritative-ring read (rf2-ertqw)
+  ## Authoritative-ring read
 
   `trace-window` MUST read the framework's per-frame epoch-history RING
   — `(rf/epoch-history frame-id)`, the SAME source `eval-cljs` hits
   directly — NOT a parallel session-side capture buffer that only fills
-  while a listener is attached. The buffer-vs-ring split was the
-  silent-WRONG-read this bead kills: the buffer returned EMPTY while the
-  ring HELD epochs. `reads-the-authoritative-ring` pins that the emitted
-  eval form calls `epoch-history`, and `non-empty-ring-returns-epochs`
-  proves a populated ring's epochs ride back (not empty).
+  while a listener is attached. A session-side buffer can return EMPTY
+  while the ring HOLDS epochs, so reading the ring is the only
+  drift-free source. `reads-the-authoritative-ring` pins that the
+  emitted eval form calls `epoch-history`, and
+  `non-empty-ring-returns-epochs` proves a populated ring's epochs ride
+  back (not empty).
 
-  ## Empty-result advisory (rf2-fb4hn)
+  ## Empty-result advisory
 
-  Pre-rf2-fb4hn the tool returned `:count 0` with no explanation when
-  the time window excluded every event in the per-frame ring. Operators
-  routinely misread this as \"events aren't being captured\" when in
-  fact events existed but fell outside `:ms`. The advisory distinguishes
-  \"genuinely empty history\" from \"window excludes the history\"."
+  When the time window excludes every event in the per-frame ring the
+  tool returns `:count 0` WITH an advisory explaining why. Operators
+  otherwise misread a bare `:count 0` as \"events aren't being captured\"
+  when in fact events existed but fell outside `:ms`. The advisory
+  distinguishes \"genuinely empty history\" from \"window excludes the
+  history\"."
   (:require [cljs.test :refer-macros [deftest is testing async]]
             [clojure.string :as str]
             [re-frame2-pair-mcp.nrepl :as nrepl]
@@ -54,7 +56,7 @@
         (.finally (fn [] (tu/restore-eval! stub orig))))))
 
 ;; ---------------------------------------------------------------------------
-;; Authoritative-ring read contract (rf2-ertqw).
+;; Authoritative-ring read contract.
 ;; ---------------------------------------------------------------------------
 
 (defn- capturing-eval!

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/typical_tokens_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/typical_tokens_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.typical-tokens-test
-  "Sanity check for rf2-6sddv — every tool descriptor in re-frame2-pair-mcp's
+  "Sanity check that every tool descriptor in re-frame2-pair-mcp's
   `tool-descriptors` carries a positive-integer `:typicalTokens` hint
   and that hint survives the `clj->js` projection in
   `tool-descriptors-js` (so `tools/list` consumers see it on the wire

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/unknown_tool_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/unknown_tool_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.unknown-tool-test
-  "Server-boundary unknown-tool guard tests (rf2-4mc6q1).
+  "Server-boundary unknown-tool guard tests.
 
   The dispatcher's own `:unknown-tool` branch (`tools/dispatch-tool*`)
   resolves an unregistered name to the recovery-shaped `:unknown-tool`
@@ -8,15 +8,16 @@
   for EVERY tool BEFORE the dispatcher. On a stock / misconfigured install
   with NO nREPL port, that connection step REJECTS with
   `:nrepl-port-not-found` and the unknown name never reaches the
-  dispatcher — so a typo or removed alias (e.g. `registry-list`) returned a
-  misleading discovery error, MASKING the `:unknown-tool` recovery
-  affordances (`:hint` → tools/list, `:available-tools`, `:did-you-mean`).
+  dispatcher. Without an OUTER guard, a typo or absent alias (e.g.
+  `registry-list`) would surface a misleading discovery error and MASK
+  the `:unknown-tool` recovery affordances (`:hint` → tools/list,
+  `:available-tools`, `:did-you-mean`).
 
-  These tests pin the missing OUTER ring: the pre-connection guard
+  These tests pin the OUTER ring: the pre-connection guard
   (`tools/refuse-unknown-tool`) and the server `handle-call` ordering
   that proves the refusal precedes `ensure-connection!` — discovery never
-  runs; the session-state stays pristine. Mirrors `writes_test.cljs`
-  (rf2-wz66k7), the symmetric pre-connection write-gate."
+  runs; the session-state stays pristine. Mirrors `writes_test.cljs`,
+  the symmetric pre-connection write-gate."
   (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.test-utils :as tu]
@@ -57,7 +58,7 @@
 
 (deftest refuse-unknown-tool-offers-nearest-match
   ;; A near-miss typo of a real name surfaces a :did-you-mean pointer —
-  ;; the same recovery the dispatcher branch emits (rf2-tkmik).
+  ;; the same recovery the dispatcher branch emits.
   (let [result (tools/refuse-unknown-tool "snapsho")
         edn    (read-edn result)]
     (is (= :unknown-tool (:reason edn)))
@@ -105,9 +106,9 @@
         (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
 
 ;; ---------------------------------------------------------------------------
-;; Server-boundary regression guard: a removed alias such as `registry-list`
-;; (renamed to `list-handlers` per rf2-4y595) must diagnose as :unknown-tool
-;; at the boundary — the exact masking the bead reported.
+;; Server-boundary regression guard: an unregistered alias such as
+;; `registry-list` (the live name is `list-handlers`) must diagnose as
+;; :unknown-tool at the boundary — not a discovery error.
 ;; ---------------------------------------------------------------------------
 
 (deftest removed-alias-diagnoses-as-unknown-tool-not-discovery-error
@@ -119,22 +120,22 @@
                    (is (= :unknown-tool (:reason edn))
                        "a removed alias diagnoses as :unknown-tool, not :nrepl-port-not-found")
                    (is (= "registry-list" (:tool edn)))
-                   ;; `registry-list` is too far in edit distance from the
-                   ;; renamed `list-handlers` to trip the :did-you-mean
+                   ;; `registry-list` is too far in edit distance from
+                   ;; `list-handlers` to trip the :did-you-mean
                    ;; near-match cutoff — but the live catalogue still
-                   ;; carries the replacement, so the agent recovers via
+                   ;; carries `list-handlers`, so the agent recovers via
                    ;; the :available-tools list + the tools/list hint.
                    (is (some #{"list-handlers"} (:available-tools edn))
-                       "the renamed tool is enumerated in the live catalogue")
+                       "list-handlers is enumerated in the live catalogue")
                    (is (re-find #"tools/list" (:hint edn))))
                  (done)))
         (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
 
 ;; ---------------------------------------------------------------------------
 ;; structuredContent on the boundary refusal preserves the keyword
-;; namespace (rf2-or8s29) — the envelope rides through `wire/err-text`, the
-;; same dual-slot constructor the dispatcher uses, so the SDK-friendly slot
-;; is namespace-faithful (not a raw, namespace-lossy clj->js).
+;; namespace — the envelope rides through `wire/err-text`, the same
+;; dual-slot constructor the dispatcher uses, so the SDK-friendly slot is
+;; namespace-faithful (a raw clj->js would truncate the namespace).
 ;; ---------------------------------------------------------------------------
 
 (deftest unknown-tool-boundary-structured-content-is-faithful

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/watch_epochs_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/watch_epochs_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame2-pair-mcp.watch-epochs-test
   "Unit tests for the `watch-epochs` MCP tool — specifically the
-  empty-result advisory added in rf2-fb4hn.
+  empty-result advisory.
 
   watch-epochs returns matches that landed AFTER a :since-id AND
   satisfy an optional :pred. When matches is empty the operator wants
@@ -11,9 +11,9 @@
       point at the predicate.
     - Genuinely empty history — no advisory.
 
-  Pre-rf2-fb4hn these three cases all looked identical (empty matches +
-  no further detail), feeding a misread that the listener wasn't
-  capturing events."
+  Without the advisory these three cases all look identical (empty
+  matches + no further detail), feeding a misread that the listener
+  isn't capturing events; the advisory disambiguates them."
   (:require [cljs.test :refer-macros [deftest is testing async]]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.test-utils :as tu]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.wire-cap-test
-  "Unit tests for the wire-boundary token-budget cap (rf2-rvyzy).
+  "Unit tests for the wire-boundary token-budget cap.
 
   Per `tools/re-frame2-pair-mcp/spec/Principles.md` §\"Tight token budget per
   response\", every MCP `tools/call` response is bounded at ~5,000
@@ -10,9 +10,8 @@
   Tests pin the public helpers directly from
   `re-frame2-pair-mcp.tools.cap`: `max-tokens-arg`, `overflow-payload`,
   `sum-payload-tokens`, `apply-cap`, `overflow-hints`, `default-max-tokens`.
-  The two cross-MCP re-exports that production never used —
-  `token-estimate` and `overflow-hint-fallback` — moved to
-  `re-frame2-pair-mcp.test-utils` (rf2-ttspi7) and are pinned via `tu/`
+  The two test-only helpers `token-estimate` and `overflow-hint-fallback`
+  live in `re-frame2-pair-mcp.test-utils` and are pinned via `tu/`
   here. A rename or signature change surfaces as a failing test rather
   than a silent contract drift.
 
@@ -73,7 +72,7 @@
   (is (= cap/default-max-tokens (cap/max-tokens-arg #js {"max-tokens" "bogus"}))))
 
 (deftest max-tokens-arg-negative-rejected-with-invalid-arg
-  ;; rf2-5rdit — a negative `:max-tokens` resolves to an
+  ;; A negative `:max-tokens` resolves to an
   ;; `{:rf.mcp/invalid-arg {...}}` rejection, NOT a negative cap (which
   ;; would over-trip apply-cap and lock the agent out). The `invoke`
   ;; chokepoint surfaces it as an isError result via `wire/err-text`.
@@ -145,11 +144,11 @@
       (is (re-find #"Narrow scope" (:hint marker))))))
 
 (deftest apply-cap-overflow-marker-key-keeps-namespace-in-structured-slot
-  ;; rf2-or8s29 — the overflow marker is built OUTSIDE the per-tool
-  ;; callbacks (cap/result-io build-overflow-result); before the fix it
-  ;; used a raw namespace-lossy `clj->js`, so SDK-friendly hosts reading
-  ;; structuredContent saw `"overflow"` (the marker key truncated) and
-  ;; missed the marker. Now it routes through `wire/result`.
+  ;; The overflow marker is built OUTSIDE the per-tool callbacks
+  ;; (cap/result-io build-overflow-result) and routes through
+  ;; `wire/result`, so SDK-friendly hosts reading structuredContent see
+  ;; the fully-qualified marker key. A raw namespace-lossy `clj->js`
+  ;; would truncate it to `"overflow"` and the host would miss the marker.
   (let [big (apply str (repeat 4000 "x"))
         r   (ok-text-result {:huge big})
         out (cap/apply-cap r {:tool "snapshot" :cap 500})
@@ -197,16 +196,15 @@
     (is (identical? r out))))
 
 ;; ---------------------------------------------------------------------------
-;; :structuredContent counts toward the cap (rf2-ycfu1).
+;; :structuredContent counts toward the cap.
 ;;
 ;; `wire/ok-text` / `wire/err-text` write the SAME payload into BOTH
 ;; `:content[*].text` (pr-str EDN) and `:structuredContent` (clj->js JSON
 ;; projection) on EVERY result. Both ride the wire. The cap MUST size
 ;; the structured slot too — a small-:content / huge-:structuredContent
 ;; response that the text gate alone judges under-budget would otherwise
-;; bust the MCP token budget. story-mcp already fixed this class
-;; (rf2-mzndx); the mcp-base contract pins it (rf2-13wbe finding 2,
-;; `structured-content-counted-toward-budget`).
+;; bust the MCP token budget. The mcp-base contract pins this class
+;; (`structured-content-counted-toward-budget`).
 ;; ---------------------------------------------------------------------------
 
 (defn- dual-coded-result
@@ -228,11 +226,10 @@
         "structuredContent JSON bytes MUST be summed alongside the text slot")))
 
 (deftest apply-cap-trips-on-huge-structured-content-under-small-text
-  ;; THE acceptance test (rf2-ycfu1): a response whose `:content` text is
-  ;; tiny but whose `:structuredContent` is huge MUST trip the overflow
-  ;; marker. FAILS before the cap.cljs fix (the structured slot was never
-  ;; counted, so the text-only sum stayed under cap and the raw oversize
-  ;; body shipped); PASSES after.
+  ;; THE acceptance test: a response whose `:content` text is tiny but
+  ;; whose `:structuredContent` is huge MUST trip the overflow marker.
+  ;; Without counting the structured slot the text-only sum stays under
+  ;; cap and the raw oversize body would ship; counting it trips the cap.
   (let [r   (dual-coded-result {:ok? true} {:big-payload (big-string 30000)})
         out (cap/apply-cap r {:tool "snapshot" :cap 1000})
         edn (read-edn out)]
@@ -256,14 +253,14 @@
     (is (identical? r out))))
 
 ;; ---------------------------------------------------------------------------
-;; The load-bearing scenario: 5MB app-db snapshot — the failure mode
-;; flagged in rf2-jlq5j's findings doc.
+;; The load-bearing scenario: 5MB app-db snapshot — the worst-case
+;; payload size the cap must contain.
 ;; ---------------------------------------------------------------------------
 
 (deftest five-mb-snapshot-is-bounded-at-wire-boundary
-  ;; rf2-jlq5j: a 5MB app-db snapshot pr-strs to ~5.6M chars ⇒ ~1.4M
-  ;; tokens, 290× the 5,000-token cap. Today: silent context
-  ;; corruption. After this fix: structured marker, agent retries with
+  ;; A 5MB app-db snapshot pr-strs to ~5.6M chars ⇒ ~1.4M tokens, 290×
+  ;; the 5,000-token cap. Without the cap this is silent context
+  ;; corruption; with it, a structured marker so the agent retries with
   ;; narrower args.
   (let [big-app-db (apply str (repeat (* 5 1024 1024) "x"))  ;; 5 MB
         snapshot {:rf/default {:app-db big-app-db}}
@@ -298,7 +295,7 @@
           (str "Missing overflow hint for tool: " t)))))
 
 ;; ---------------------------------------------------------------------------
-;; apply-cap short-circuits on wire-bounded markers (rf2-gktyn).
+;; apply-cap short-circuits on wire-bounded markers.
 ;;
 ;; Cache-hit and overflow envelopes are emitted by the cache + cap
 ;; steps themselves; they are sub-cap by construction. Re-applying
@@ -339,13 +336,12 @@
         "non-marker payload over budget is still capped")))
 
 (deftest apply-cap-caps-over-budget-lookalike-marker-key
-  ;; rf2-3xd9i9 regression: the marker detector used to match on the
-  ;; marker-key PREFIX, so an over-budget payload whose LEADING key merely
-  ;; STARTS WITH a marker key — e.g. `:rf.mcp/overflowed` — was wrongly
-  ;; treated as an already-bounded marker and short-circuited PAST the cap
-  ;; walk, shipping the raw over-budget body. With the exact-key fix the
-  ;; lookalike is NOT a marker, so apply-cap still walks it and replaces
-  ;; the over-budget body with the real `:rf.mcp/overflow` marker.
+  ;; Regression guard: the marker detector matches on the EXACT marker
+  ;; key, not a prefix. An over-budget payload whose LEADING key merely
+  ;; STARTS WITH a marker key — e.g. `:rf.mcp/overflowed` — is NOT a
+  ;; marker, so apply-cap still walks it and replaces the over-budget
+  ;; body with the real `:rf.mcp/overflow` marker. A prefix match would
+  ;; wrongly short-circuit PAST the cap walk and ship the raw body.
   (let [big   (apply str (repeat 8000 "x"))
         ;; Single-key map ⇒ pr-str renders `:rf.mcp/overflowed` as the
         ;; leading top-level key, the precise cap-bypass shape.
@@ -361,7 +357,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; cap-message — per-notification wire-cap for a single serialised EDN
-;; message string (rf2-wz66k7).
+;; message string.
 ;;
 ;; The `subscribe` streaming loop ships its per-tick payload as the
 ;; `:message` of a `notifications/progress` notification — which NEVER
@@ -387,10 +383,10 @@
   (is (nil? (cap/cap-message nil {:tool "subscribe" :cap 500}))))
 
 (deftest cap-message-over-budget-emits-overflow-marker
-  ;; THE Finding-1 acceptance: an oversized per-tick message is REPLACED
-  ;; with the `:rf.mcp/overflow` marker EDN, not shipped raw. Before the
-  ;; fix the progress notification bypassed the cap entirely and a
-  ;; multi-megabyte tick busted the per-notification token budget.
+  ;; An oversized per-tick message is REPLACED with the
+  ;; `:rf.mcp/overflow` marker EDN, not shipped raw. Without this gate a
+  ;; progress notification bypasses the cap entirely and a multi-megabyte
+  ;; tick busts the per-notification token budget.
   (let [big (apply str (repeat 8000 "x"))
         msg (pr-str {:sub-id "s" :events [{:huge big}]})
         out (cap/cap-message msg {:tool "subscribe" :cap 500})

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_pipeline_benchmark_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_pipeline_benchmark_test.cljs
@@ -1,38 +1,35 @@
 (ns re-frame2-pair-mcp.wire-pipeline-benchmark-test
   "Wall-clock + structural micro-benchmarks for the wire-pipeline
-  hot paths (rf2-w92r8).
+  hot paths.
 
   ## Why this benchmark
 
-  Round-1 audit (rf2-7hie3) surfaced three perf suspicions on the
-  wire-pipeline. None were proven hot; each was a measurement task.
-  Round-2 (rf2-w92r8) lifted them to a single bead so the
-  conclusions are data-driven, not vibes-driven:
+  Three perf-sensitive spots on the wire-pipeline each warrant a
+  data-driven baseline rather than a guess:
 
     1. **Wire-pipeline intermediate allocations** —
        `run-snapshot-map` (in `wire_pipeline.cljs`) chains five
        per-frame transforms (sensitive-strip → slice-app-db →
        diff-encode-epochs → dedup-epochs → summarise-others). Each
        hop allocates a fresh per-frame map. For a 3-frame snapshot
-       under `:include :all`, that's ~15 intermediate maps. The
-       suspicion was that for high event-rate traffic (100/sec) the
-       intermediate-map churn would surface as GC pressure.
+       under `:include :all`, that's ~15 intermediate maps. Under
+       high event-rate traffic (100/sec) the intermediate-map churn
+       could surface as GC pressure.
 
     2. **`count-elided-markers` full-payload walk** at every emit-
-       site. Round-2 (rf2-e35a5) eliminated the walk for the
-       `:snapshot-map` and `:scalar-value` arms — the server-side
-       count rides back on the eval form. The `:epoch-vector` arm
-       (trace-window, watch-epochs) and the subscribe per-tick still
-       walk locally. This benchmark pins the per-walk cost so a
-       future optimisation (e.g. server-side count for runtime
-       drains) has a baseline.
+       site. The `:snapshot-map` and `:scalar-value` arms carry a
+       server-side count on the eval form and skip the walk; the
+       `:epoch-vector` arm (trace-window, watch-epochs) and the
+       subscribe per-tick walk locally. This benchmark pins the
+       per-walk cost so a future optimisation (e.g. server-side
+       count for runtime drains) has a baseline.
 
     3. **Dedup pass on 50-record epoch payloads** — equality-based
        structural dedup over a 50-epoch slice with a 256-key shared
-       `:db-before`. Already pinned at 89.5% reduction by
-       `dedup_test/reduction-ratio-shared-subtrees`. The wall-clock
-       cost is what we measure here — does the dedup pass fit in the
-       per-call budget (rough rule of thumb: < 10ms for an
+       `:db-before`. The compression ratio (89.5% reduction) is
+       pinned by `dedup_test/reduction-ratio-shared-subtrees`. The
+       wall-clock cost is what we measure here — does the dedup pass
+       fit in the per-call budget (rough rule of thumb: < 10ms for an
        interactive read-tool).
 
   ## Output shape
@@ -97,10 +94,10 @@
                       b (nth sorted (quot n 2))]
                   (/ (+ a b) 2)))))
 
-;; Silent-on-success (rf2-try1x): the bench report lines only emit
-;; when `bench-verbose?` is true. The raw min/median/max are also
-;; folded into each failing `is` message via `report-str` below so
-;; triage retains the numbers.
+;; Silent-on-success: the bench report lines only emit when
+;; `bench-verbose?` is true. The raw min/median/max are also folded
+;; into each failing `is` message via `report-str` below so triage
+;; retains the numbers.
 (goog-define bench-verbose? false)
 
 (defn- report-str
@@ -217,9 +214,9 @@
 ;; ---------------------------------------------------------------------------
 ;; Bench 2 — count-elided-markers walk over a marker-rich payload.
 ;;
-;; This is the walker rf2-e35a5 eliminated for snapshot+get-path. The
-;; `:epoch-vector` arm and subscribe per-tick still walk locally. The
-;; bench pins the per-walk cost so a future "server-side count for
+;; snapshot+get-path carry a server-side count and skip this walker;
+;; the `:epoch-vector` arm and subscribe per-tick still walk locally.
+;; The bench pins the per-walk cost so a future "server-side count for
 ;; runtime drains" optimisation has a baseline to claim against.
 ;; ---------------------------------------------------------------------------
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_pipeline_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_pipeline_test.cljs
@@ -1,23 +1,20 @@
 (ns re-frame2-pair-mcp.wire-pipeline-test
   "Correctness unit tests for `wire-pipeline/run-wire-pipeline`
-  indicator counting on the `:epoch-vector` arm (rf2-mb17rj).
+  indicator counting on the `:epoch-vector` arm.
 
   The `:epoch-vector` arm (trace-window / watch-epochs) walks the
   payload locally for the `:elided-large` indicator — the count is NOT
   pre-shipped from the runtime (unlike `:snapshot-map` / `:scalar-value`,
   which carry `:server-elided`).
 
-  THE BUG (rf2-mb17rj, LOW): the arm counted markers over the
-  POST-dedup payload. `day8/de-dupe` pools N identical
-  `:rf.size/large-elided` maps into ONE structural-sharing cache entry,
-  so a payload with N identical markers reported `:elided-large == 1`
-  instead of N. The markers themselves rode the wire intact (no
-  data-loss / leak) — only the scalar indicator undercounted.
-
-  THE FIX: count over the PRE-dedup (`encoded`) payload. The marker
-  SET is identical pre/post dedup (dedup only re-shapes structural
-  references; it never drops a marker), so the pre-dedup count is
-  exact.
+  THE CONTRACT: the arm counts markers over the PRE-dedup (`encoded`)
+  payload. `day8/de-dupe` pools N identical `:rf.size/large-elided` maps
+  into ONE structural-sharing cache entry, so counting over the
+  POST-dedup payload would report `:elided-large == 1` instead of N
+  (the markers themselves always ride the wire intact — only the scalar
+  indicator is at risk). The marker SET is identical pre/post dedup
+  (dedup only re-shapes structural references; it never drops a marker),
+  so the pre-dedup count is exact.
 
   These pin `run-wire-pipeline` directly — the pure transform — rather
   than through the live nREPL eval boundary (covered by the
@@ -50,7 +47,7 @@
    :db-after  {:slot marker}})
 
 ;; ---------------------------------------------------------------------------
-;; rf2-mb17rj — :elided-large counts EVERY marker, not the deduped count.
+;; :elided-large counts EVERY marker, not the deduped count.
 ;; ---------------------------------------------------------------------------
 
 (deftest epoch-vector-counts-all-elided-markers-pre-dedup
@@ -75,8 +72,8 @@
           epochs  (vec (for [n (range 3)] (epoch-with-marker n marker)))
           encoded (dedup/diff-encode-epochs epochs :diff)
           deduped (dedup/dedup-value encoded true)]
-      ;; The pre-fix code walked `deduped` and would have returned 1
-      ;; here; the fix walks `encoded` and returns 3.
+      ;; Walking `deduped` returns 1 here (the undercount); walking
+      ;; `encoded` — the pipeline's choice — returns the correct 3.
       (is (= 1 (base-elision/count-elided-markers deduped))
           "dedup pools the 3 equal markers → walking the deduped payload undercounts to 1 (the bug)")
       (is (= 3 (base-elision/count-elided-markers encoded))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/with_indicators_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/with_indicators_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.with-indicators-test
-  "Conformance gate for `wire/with-indicators` (rf2-n505f).
+  "Conformance gate for `wire/with-indicators`.
 
   ## The MUST rule
 
@@ -28,11 +28,7 @@
     that walks a tree-typed payload references `with-indicators`.
     A new tool that walks a payload but bypasses the helper would
     only be caught by hand-review today; this test makes the bypass
-    a build failure.
-
-  Round-1 TE8 (rf2-zjqh8) flagged the missing test; rf2-n505f
-  promoted it to P0 after round-2 confirmed the choke-point had
-  stabilised."
+    a build failure."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [re-frame2-pair-mcp.tools.wire :as wire]))
@@ -152,9 +148,9 @@
 (deftest subscribe-emit-site-routes-through-with-indicators
   ;; Subscribe emits indicators on each progress tick AND on the
   ;; final result. Either site routes through with-indicators; the
-  ;; module-level grep is fine. Post rf2-zkca8.3 the emit helpers
-  ;; (progress-payload, emit-progress-tick!, final-summary) live
-  ;; in subscribe.cljs alongside the streaming-loop body.
+  ;; module-level grep is fine. The emit helpers (progress-payload,
+  ;; emit-progress-tick!, final-summary) live in subscribe.cljs
+  ;; alongside the streaming-loop body.
   (let [src (read-source "src/re_frame2_pair_mcp/tools/subscribe.cljs")]
     (is (contains-with-indicators? src)
         "subscribe.cljs MUST route its envelope through wire/with-indicators")))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/writes_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/writes_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame2-pair-mcp.writes-test
-  "Server-boundary write-gate tests (rf2-wz66k7).
+  "Server-boundary write-gate tests.
 
   The write-tool BODIES (`restore-epoch-tool` / `replace-app-db-tool`)
   refuse `:rf.error/writes-disabled` as their first action without
@@ -7,13 +7,14 @@
   replace_app_db_test). But the real MCP server handler
   (`server.cljs/handle-call`) runs `ensure-connection!` for EVERY tool
   BEFORE the tool body. On a stock install with NO nREPL port, that
-  connection step REJECTS and the tool body's gate NEVER fires, so a
-  disabled `restore-epoch` / `replace-app-db` returned a misleading
-  `:nrepl-port-not-found` (or ran discovery / elicitation) instead of the
-  intended destructive-tool refusal — the default-safe write posture was
-  observably FALSE at the MCP boundary.
+  connection step REJECTS. Without an OUTER guard the tool body's gate
+  never fires, so a disabled `restore-epoch` / `replace-app-db` would
+  surface a misleading `:nrepl-port-not-found` (or run discovery /
+  elicitation) instead of the intended destructive-tool refusal — the
+  default-safe write posture would be observably FALSE at the MCP
+  boundary.
 
-  These tests pin the missing OUTER ring: the pre-connection guard
+  These tests pin the OUTER ring: the pre-connection guard
   (`writes/refuse-pre-connection`) and the server `handle-call` ordering
   that proves the refusal precedes `ensure-connection!` (discovery never
   runs; the session-state stays pristine)."
@@ -98,19 +99,17 @@
     (assert-refused-locally "replace-app-db" done)))
 
 ;; ---------------------------------------------------------------------------
-;; Server-level error envelope — namespace-preserving structuredContent
-;; (rf2-or8s29).
+;; Server-level error envelope — namespace-preserving structuredContent.
 ;;
 ;; The discovery-error / handler-threw envelopes are built in server.cljs
-;; OUTSIDE the per-tool callbacks. Before rf2-or8s29 they used a raw
-;; `(clj->js payload)` for structuredContent, which truncates the
-;; namespace on `:rf.error/*` reason VALUES (`:rf.error/foo` →
-;; `"foo"`). Routing them through `wire/result` preserves the
-;; fully-qualified token in the SDK-friendly structured slot. Here we
-;; drive a NON-write tool through the pristine, no-port harness so
-;; `ensure-connection!` rejects and `handle-call*` builds the
-;; discovery-error envelope; we assert both the EDN text slot AND the
-;; structured slot agree on the reason, namespace intact.
+;; OUTSIDE the per-tool callbacks, routed through `wire/result` so the
+;; fully-qualified token survives in the SDK-friendly structured slot. A
+;; raw `(clj->js payload)` would truncate the namespace on `:rf.error/*`
+;; reason VALUES (`:rf.error/foo` → `"foo"`). Here we drive a NON-write
+;; tool through the pristine, no-port harness so `ensure-connection!`
+;; rejects and `handle-call*` builds the discovery-error envelope; we
+;; assert both the EDN text slot AND the structured slot agree on the
+;; reason, namespace intact.
 ;; ---------------------------------------------------------------------------
 
 (deftest discovery-error-structured-content-preserves-reason-namespace

--- a/tools/story-mcp/src/re_frame/story_mcp/config.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/config.cljc
@@ -22,14 +22,13 @@
     value forces redaction regardless of any per-call `:include-sensitive`
     arg. The default-OFF posture matches the cross-MCP convention for
     privacy gates: an operator who genuinely needs raw sensitive state
-    opts in explicitly. (Note: re-frame2-pair-mcp's eval-cljs gate took
-    the opposite path in rf2-a0z0h — default ON with `--no-eval` as the
-    opt-out — because eval is the REPL primitive of a pair-debug
-    session and a default-OFF eval gate did not add a protection
-    separable from `--allow-writes`. Sensitive-reads here are NOT in
-    that position: raw reads can pour the entire app-db into a wire log
-    without the operator ever typing the secret, so the privacy gate
-    stays default-OFF.)
+    opts in explicitly. (Note: re-frame2-pair-mcp's eval-cljs gate takes
+    the opposite path — default ON with `--no-eval` as the opt-out —
+    because eval is the REPL primitive of a pair-debug session and a
+    default-OFF eval gate adds no protection separable from
+    `--allow-writes`. Sensitive-reads here are NOT in that position: raw
+    reads can pour the entire app-db into a wire log without the operator
+    ever typing the secret, so the privacy gate stays default-OFF.)
   - `set-allow-sensitive-reads!` — write helper. Same three input paths
     as `allow-writes?`: `--allow-sensitive-reads` CLI flag, JVM property
     `-Drf.story-mcp.allow-sensitive-reads=true`, or env var
@@ -41,8 +40,7 @@
   Symmetry with `re-frame.story.config` — keep the boolean knobs together
   so an agent host or test fixture can adjust them without reaching into
   the server / tools namespaces. Per IMPL-SPEC §13.2 #6 the
-  protocol-version target is a documented decision the implementation
-  bead (rf2-tgci) lands."
+  protocol-version target is a documented decision."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [re-frame.mcp-base.args :as args]))
@@ -128,11 +126,10 @@
   []
   (boolean @allow-writes?))
 
-;; ---- sensitive-read gate (rf2-g9fje) --------------------------------------
+;; ---- sensitive-read gate --------------------------------------------------
 ;;
-;; Per the rf2-uaymx (b) decision, raw sensitive-state reads are an
-;; operator-only opt-in. The wire-egress helpers
-;; (`args/include-sensitive?`) defer to this atom — when it is
+;; Raw sensitive-state reads are an operator-only opt-in. The wire-egress
+;; helpers (`args/include-sensitive?`) defer to this atom — when it is
 ;; `false` the per-call `:include-sensitive` arg is silently treated as
 ;; `false`, so a hostile or careless caller cannot exfiltrate declared-
 ;; sensitive `:app-db` slots / assertion records by flipping a JSON
@@ -140,18 +137,17 @@
 ;; flag, JVM sysprop `rf.story-mcp.allow-sensitive-reads=true`, or env
 ;; var `RF_STORY_MCP_ALLOW_SENSITIVE_READS=true`.
 ;;
-;; (Cross-MCP note: re-frame2-pair-mcp's eval-cljs gate flipped to
-;; default-ON in rf2-a0z0h — eval is the REPL primitive of a pair-debug
-;; session and a default-OFF eval gate did not add a protection
-;; separable from `--allow-writes`. The sensitive-reads gate here is
-;; NOT in that position: raw reads can pour the entire app-db into a
-;; wire log without the operator ever typing the secret, so this gate
-;; keeps the default-OFF posture.)
+;; (Cross-MCP note: re-frame2-pair-mcp's eval-cljs gate is default-ON —
+;; eval is the REPL primitive of a pair-debug session and a default-OFF
+;; eval gate adds no protection separable from `--allow-writes`. The
+;; sensitive-reads gate here is NOT in that position: raw reads can pour
+;; the entire app-db into a wire log without the operator ever typing the
+;; secret, so this gate keeps the default-OFF posture.)
 
 (defonce
-  ^{:doc "Atom holding the sensitive-read gate. Defaults to `false`. Per
-         the rf2-uaymx (b) decision the per-call `:include-sensitive`
-         arg is honoured ONLY when this atom is also `true`."}
+  ^{:doc "Atom holding the sensitive-read gate. Defaults to `false`. The
+         per-call `:include-sensitive` arg is honoured ONLY when this atom
+         is also `true`."}
   allow-sensitive-reads?
   (atom false))
 
@@ -211,7 +207,7 @@
   - Env var `RF_STORY_MCP_ALLOW_SENSITIVE_READS` — same shape.
 
   All sources are parsed via the cross-MCP `args/parse-boolean`
-  primitive (rf2-vw4sq) so the truthy-string vocabulary
+  primitive so the truthy-string vocabulary
   (`true`/`1`/`yes`/`y`/`on`, case-insensitive — and the `false`/`0`/
   `no`/`n`/`off` complement) is the same one an agent learns once.
 

--- a/tools/story-mcp/src/re_frame/story_mcp/descriptor_manifest_gen.clj
+++ b/tools/story-mcp/src/re_frame/story_mcp/descriptor_manifest_gen.clj
@@ -1,8 +1,8 @@
 (ns re-frame.story-mcp.descriptor-manifest-gen
-  "story-mcp tool-descriptor manifest generator + drift-check (rf2-sofwv).
+  "story-mcp tool-descriptor manifest generator + drift-check.
 
-  Follow-on to the rf2-3nbl5.2 API-governance keystone, mirroring its
-  generate-then-drift-check shape on story-mcp's MCP descriptor surface.
+  Mirrors the API-governance keystone's generate-then-drift-check shape
+  on story-mcp's MCP descriptor surface.
 
   SOURCE OF TRUTH. `re-frame.story-mcp.tools.registry/tool-registry` —
   the ordered vector that bundles every story-mcp tool's name,
@@ -13,16 +13,16 @@
   each entry into the stable catalogue row defined by
   `re-frame.mcp-base.descriptor-manifest`.
 
-  GATED INPUTS (rf2-qo3wvp). The raw registry descriptor carries the
+  GATED INPUTS. The raw registry descriptor carries the
   FULL `tools/list` input surface — including `:include-sensitive`, the
   knob the default profile strips behind `--allow-sensitive-reads`.
-  Projecting it as a flat `:input-keys` made the manifest claim
+  Projecting it as a flat `:input-keys` would make the manifest claim
   `:include-sensitive` is on the DEFAULT surface, which it is not
   (closed-by-default). The generator passes `registry/gated-input-keys`
   (the config-independent set of keys the server gates off by default —
   the SAME set `registry/strip-include-sensitive` removes at
   `tools/list` time) to `dm/build-manifest`, so each row records the
-  gated subset in `:gated-input-keys`. The committed manifest now
+  gated subset in `:gated-input-keys`. The committed manifest
   distinguishes the two deterministic profiles: the default surface is
   `:input-keys` minus `:gated-input-keys`; the gate-open surface is
   `:input-keys` verbatim. The set is static, so the manifest stays
@@ -42,8 +42,7 @@
   `:inputSchema :properties` at def-time (via `schemas/with-max-tokens`),
   so — unlike re-frame2-pair-mcp, which splices the knob at `tools/list`
   time — the raw registry descriptor already carries the actual
-  `tools/list` input surface; no generator-side knob splice is needed
-  (rf2-cwhod2).
+  `tools/list` input surface; no generator-side knob splice is needed.
 
   Run from tools/story-mcp/:
     clojure -M:gen                  ; regenerate tool-descriptors.edn

--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -31,7 +31,7 @@
   `tools/call` result shape with `isError: true` per the MCP spec §Error
   Handling guidance — they are NOT protocol-level errors.
 
-  ## Cross-MCP factoring (rf2-vw4sq)
+  ## Cross-MCP factoring
 
   The JSON-RPC error-code constants live in `re-frame.mcp-base.vocab`
   — the cross-MCP shared vocabulary artefact. The internal use-sites
@@ -52,7 +52,7 @@
   auto-namespaced `::eof` form across namespace boundaries."
   ::eof)
 
-;; ---- frame-length cap (rf2-g9fje, fix 3/3) -------------------------------
+;; ---- frame-length cap ----------------------------------------------------
 
 (def ^:const max-frame-bytes
   "Hard ceiling on a single newline-delimited JSON-RPC frame from the
@@ -97,8 +97,7 @@
   keywordised (`normalize-frame` does this — `read-frame` runs it after
   `parse-json`). This predicate is the single home for the
   request-vs-notification rule — `server/dispatch` calls it rather than
-  re-spelling the `(not (contains? message :id))` check inline
-  (rf2-ee38b.17)."
+  re-spelling the `(not (contains? message :id))` check inline."
   [message]
   (and (map? message)
        (not (contains? message :id))))
@@ -122,7 +121,7 @@
   payload (the run-loop catches it and writes a `-32700` parse-error
   response).
 
-  ## No-intern ingress (rf2-3luf3)
+  ## No-intern ingress
 
   Cheshire's `keywordize-keys` mode (`json/parse-string s true`)
   recursively interns EVERY object key — including arbitrary attacker-/
@@ -146,9 +145,9 @@
   (try
     (json/parse-string s false)
     (catch Throwable e
-      ;; rf2-vvixub — the message + canonical ex-data are derived from the
-      ;; builder helpers; the 3-arg ex-info form preserves the original
-      ;; parser throwable as the cause.
+      ;; The message + canonical ex-data are derived from the builder
+      ;; helpers; the 3-arg ex-info form preserves the original parser
+      ;; throwable as the cause.
       (let [reason "re-frame2-story-mcp could not parse the incoming JSON frame; send a well-formed JSON-RPC frame."]
         (throw (ex-info (error/human-message :rf.error/story-mcp-json-parse-failure reason)
                         {:rf.error/id :rf.error/story-mcp-json-parse-failure
@@ -158,7 +157,7 @@
                          :raw      (when s (subs s 0 (min 200 (count s))))}
                         e))))))
 
-;; ---- no-intern frame normalisation (rf2-3luf3) ---------------------------
+;; ---- no-intern frame normalisation ---------------------------------------
 
 (def envelope-keys
   "The finite JSON-RPC 2.0 / MCP envelope keys `normalize-frame`
@@ -233,11 +232,11 @@
 (def unknown-arg-keys-meta
   "Reserved METADATA key (NOT a map entry) under which `normalize-frame`
   records the RAW top-level `tools/call` argument-key STRINGS a caller
-  sent that fell outside the bounded `arg-keys` allowlist (rf2-ovmc5e).
+  sent that fell outside the bounded `arg-keys` allowlist.
 
   ## Why metadata, not a map entry
 
-  The no-intern ingress invariant (rf2-3luf3) is preserved verbatim: the
+  The no-intern ingress invariant is preserved verbatim: the
   unknown keys are kept as STRINGS and never converted to keywords, and
   they ride as Clojure metadata on the normalised arguments map rather
   than as map entries — so they never reach a handler's `(get args ...)`
@@ -255,7 +254,7 @@
   "Normalise a `tools/call` `arguments` map: keyword-keep the bounded
   `arg-keys` allowlist (dropping — and NOT interning — every other key),
   then record the RAW STRING keys that were dropped as metadata under
-  `unknown-arg-keys-meta` (rf2-ovmc5e). Returns the renamed map; the
+  `unknown-arg-keys-meta`. Returns the renamed map; the
   metadata is attached only when at least one top-level key was dropped,
   so the common (all-recognised) path adds no metadata.
 
@@ -278,7 +277,7 @@
 (defn normalize-frame
   "Normalise a string-keyed parsed JSON frame into the keyword-keyed
   shape the dispatcher + tool layer expect, WITHOUT interning any
-  attacker-controlled key (rf2-3luf3).
+  attacker-controlled key.
 
   Only the finite JSON-RPC envelope keys (`envelope-keys`), the finite
   `params` keys (`params-keys`), and the bounded top-level
@@ -295,7 +294,7 @@
 
   Top-level `:arguments` keys outside the allowlist are dropped (no
   intern) but their RAW STRING form is recorded as metadata under
-  `unknown-arg-keys-meta` (rf2-ovmc5e) so the dispatcher can surface an
+  `unknown-arg-keys-meta` so the dispatcher can surface an
   agent-recoverable diagnostic rather than silently dropping a typo'd
   control knob — see `normalize-arguments`."
   [parsed]
@@ -324,19 +323,18 @@
 (defn- utf8-byte-len
   "UTF-8 byte length of the Unicode code point `cp` (an int).
 
-  The stdio frame cap (rf2-sibl4f) is a WIRE-BYTE budget, but the reader
-  hands us UTF-8-decoded Java code points, so we re-derive each code
-  point's encoded byte width:
+  The stdio frame cap is a WIRE-BYTE budget, but the reader hands us
+  UTF-8-decoded Java code points, so we re-derive each code point's
+  encoded byte width:
 
     - `<= 0x7F`    → 1 byte   (ASCII)
     - `<= 0x7FF`   → 2 bytes
     - `<= 0xFFFF`  → 3 bytes  (rest of the BMP)
     - else         → 4 bytes  (supplementary planes / surrogate pairs)
 
-  Counting decoded *characters* instead (the pre-fix behaviour)
-  under-measured multibyte input, so a non-ASCII frame could exceed the
-  promised byte ceiling before being rejected — weakening the DoS bound
-  the spec + error message advertise."
+  Counting decoded *characters* would under-measure multibyte input, so a
+  non-ASCII frame could exceed the promised byte ceiling before being
+  rejected — weakening the DoS bound the spec + error message advertise."
   [^long cp]
   (cond
     (<= cp 0x7F)   1
@@ -358,7 +356,7 @@
                             starts on a fresh frame boundary.
 
   The cap is measured in UTF-8 BYTES — the actual unit of the stdio
-  frame budget (rf2-sibl4f). The `BufferedReader` has already decoded
+  frame budget. The `BufferedReader` has already decoded
   the wire bytes into Java `char` code units, so we re-derive each code
   point's UTF-8 byte width via `utf8-byte-len` and bound on the running
   byte total. Code points above the BMP arrive as a surrogate PAIR (two
@@ -368,8 +366,8 @@
 
   Unlike `BufferedReader.readLine`, which will happily allocate
   unbounded memory for a `readLine` that never sees a newline, this
-  helper enforces a hard ceiling — the rf2-g9fje DoS bound for the
-  stdio transport."
+  helper enforces a hard ceiling — the DoS bound for the stdio
+  transport."
   [^java.io.BufferedReader reader max-bytes]
   (let [sb (StringBuilder.)]
     (loop [n 0]
@@ -428,8 +426,8 @@
   throws an `ex-info` on malformed JSON / oversize frame.
 
   Empty / whitespace lines are silently consumed (some agent hosts emit
-  trailing newlines). Frames exceeding `max-frame-bytes` (rf2-g9fje)
-  throw with `:rf.error/frame-too-large`; the run-loop catches that
+  trailing newlines). Frames exceeding `max-frame-bytes` throw with
+  `:rf.error/frame-too-large`; the run-loop catches that
   and writes a parse-error response before continuing — one oversize
   frame can't park the loop."
   [^java.io.BufferedReader reader]

--- a/tools/story-mcp/src/re_frame/story_mcp/server.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/server.cljc
@@ -15,7 +15,7 @@
   4. Client sends `tools/list`, `tools/call`, etc.; we dispatch.
   5. Shutdown: client closes stdin → readLine returns nil → we exit.
 
-  ## Pre-initialize state enforcement (rf2-e6knrq, finding 1)
+  ## Pre-initialize state enforcement
 
   The lifecycle prose above is a CONTRACT, not just documentation. The
   dispatcher is stateful: each session carries a `lifecycle-state` atom
@@ -36,8 +36,7 @@
   Any OTHER request before initialization (`tools/list`, `tools/call`,
   `shutdown`, an unknown method) returns `-32600 invalid-request` with a
   message naming the violation — a malformed or hostile client cannot
-  enumerate or invoke tools before completing the handshake, closing the
-  protocol-compliance + state-leak gap the senior review flagged.
+  enumerate or invoke tools before completing the handshake.
 
   ## `notifications/initialized` relaxation (deliberate, tested)
 
@@ -102,10 +101,10 @@
 
 ;; ---- lifecycle state ------------------------------------------------------
 ;;
-;; rf2-e6knrq finding 1: the dispatcher is now stateful. Each session
-;; (one `run-loop!` invocation) owns a lifecycle-state atom; the
-;; `:initialized?` flag gates the method surface so a client cannot
-;; enumerate/call tools before completing the `initialize` handshake.
+;; The dispatcher is stateful: each session (one `run-loop!` invocation)
+;; owns a lifecycle-state atom; the `:initialized?` flag gates the method
+;; surface so a client cannot enumerate/call tools before completing the
+;; `initialize` handshake.
 
 (defn new-lifecycle-state
   "Fresh per-session lifecycle state for the stateful dispatcher. The
@@ -135,7 +134,7 @@
   whether to disconnect on a mismatch (we never inspect or echo the
   client's version).
 
-  rf2-e6knrq: flips `state`'s `:initialized?` to true as a side effect —
+  Flips `state`'s `:initialized?` to true as a side effect —
   the session is ready the moment the `initialize` response is built (the
   reference-SDK relaxation; we do NOT wait for
   `notifications/initialized`). A repeated `initialize` is idempotent on
@@ -165,14 +164,14 @@
 (defn- handle-tools-call
   "Invoke a tool. `params` shape: `{:name <string> :arguments <map>}`.
 
-  rf2-2zym5e — `arguments` is the JSON-RPC params container; per MCP it
+  `arguments` is the JSON-RPC params container; per MCP it
   MUST be a structured object (absent ⇒ no args). A scalar / array /
   string `arguments` is a params-SHAPE failure and surfaces as
   `-32602 invalid-params` here, at the wire boundary — NOT as a
-  `-32603 internal-error`. Without this guard a non-map `arguments`
-  survived `normalize-frame` (which only normalises a map) and reached
-  `invoke-tool`'s per-tool arg-key check (`(keys args)`), which threw on
-  the non-map and was caught into a misleading `-32603` server fault.
+  `-32603 internal-error`. This guard keeps a non-map `arguments` from
+  reaching `normalize-frame` (which only normalises a map) and
+  `invoke-tool`'s per-tool arg-key check (`(keys args)`), which would
+  throw on the non-map and surface as a misleading `-32603` server fault.
   Per-ARGUMENT validation (a wrong-typed / missing field WITHIN a
   well-formed arguments map) stays tool-level (`isError: true`); this
   guard is only about the container's shape."
@@ -224,7 +223,7 @@
     `run-loop!` drives. `state` is a `new-lifecycle-state` atom; before
     a successful `initialize` only `initialize` / `ping` requests (and
     any notification) are accepted, everything else returns
-    `-32600 invalid-request` (rf2-e6knrq finding 1).
+    `-32600 invalid-request`.
 
   - `(dispatch message)` — backward-compatible convenience that runs
     the message against a FRESH, ALREADY-INITIALIZED session. Method-
@@ -245,13 +244,13 @@
      ;; completion notification (`notifications/initialized`) and any
      ;; other notification silently — the absence of `:id` is the
      ;; complete dispatch rule (`proto/notification?` is its single
-     ;; home; rf2-ee38b.17). No defensive arm needed in the method
+     ;; home). No defensive arm needed in the method
      ;; `case` below. Notifications are accepted in EVERY lifecycle
      ;; posture (the gate below runs only on requests).
      (proto/notification? message)
      nil
 
-     ;; Pre-initialize gate (rf2-e6knrq finding 1). Before the handshake
+     ;; Pre-initialize gate. Before the handshake
      ;; completes, only `initialize` + `ping` requests are legal; any
      ;; other request (tools/list, tools/call, shutdown, unknown) is a
      ;; protocol violation — a hostile/malformed client must not be able
@@ -308,9 +307,9 @@
     3. Dispatch. Method-level errors are responses; tool-level errors
        are wrapped in the `tools/call` result with `isError: true`."
   [^java.io.BufferedReader reader ^java.io.Writer writer]
-  ;; rf2-e6knrq finding 1: one lifecycle-state atom per session. The
-  ;; pre-initialize gate in `dispatch` reads it; `handle-initialize`
-  ;; flips it. A new loop = a fresh handshake.
+  ;; One lifecycle-state atom per session. The pre-initialize gate in
+  ;; `dispatch` reads it; `handle-initialize` flips it. A new loop =
+  ;; a fresh handshake.
   (let [state (new-lifecycle-state)]
     (loop []
       (let [frame (try
@@ -341,14 +340,13 @@
   7. Supported flags:
 
   - `--allow-writes` — presence opens the write surface. There is no
-    `=true` / `=false` variant; a flag is either present or absent.
-    The earlier `--allow-writes=false` form was a footgun (an agent
-    host scripting it would expect the gate to close, but the parser
-    accepted-and-recorded `false` which then propagated through
-    `apply-config!` only when the absent default was already
-    `false`).
-  - `--allow-sensitive-reads` — presence opens the sensitive-read gate
-    (rf2-g9fje). Symmetric with `--allow-writes`: operator-only opt-in,
+    `=true` / `=false` variant; a flag is either present or absent. A
+    presence-only flag avoids the footgun of a `=false` form, where an
+    agent host scripting it would expect the gate to close but the
+    parser would record `false` and propagate it through
+    `apply-config!`.
+  - `--allow-sensitive-reads` — presence opens the sensitive-read gate.
+    Symmetric with `--allow-writes`: operator-only opt-in,
     no `=value` variant. Default off; when off, the wire-egress
     scrubbers silently ignore any `:include-sensitive true` per-call
     arg and `tools/list` omits the slot from advertised input schemas.
@@ -380,7 +378,7 @@
      (log! "booted; allow-writes?=" (config/writes-allowed?)
            " protocol=" config/protocol-version
            " server=" config/server-name)
-     ;; rf2-g9fje — one-line boot signal mirroring re-frame2-pair-mcp's
+     ;; One-line boot signal mirroring re-frame2-pair-mcp's
      ;; `eval-cljs:` line. Operators inspecting the launch stderr can
      ;; confirm the posture at a glance.
      (log! "Sensitive reads:"

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
@@ -1,20 +1,18 @@
 (ns re-frame.story-mcp.tools.args
-  "Story-MCP-specific argument readers + bounded-allowlist coercions
-  (rf2-8yvyp, split out of the former `tools.helpers`).
+  "Story-MCP-specific argument readers + bounded-allowlist coercions.
 
   The cross-MCP keyword / boolean / int parsers live in
-  `re-frame.mcp-base.args` — one canonical implementation per the
-  cross-MCP factoring (rf2-vw4sq). This ns adds the story-MCP-specific
-  shapes:
+  `re-frame.mcp-base.args` — one canonical implementation across MCPs.
+  This ns adds the story-MCP-specific shapes:
 
   - `include-sensitive?` — the operator+caller dual-gate on the
     `:include-sensitive` opt-in escape hatch.
   - `required-arg` — the missing-required-arg shape that returns an
     error-envelope rather than throwing.
   - `with-variant` / `with-variant-id` — the four-line variant-id
-    prelude shared by ten handlers (see rf2-f0zxa), routing the agent-
-    supplied id through the bounded variant-registry allowlist before
-    coercing to a keyword (rf2-lqjbk).
+    prelude shared by ten handlers, routing the agent-supplied id
+    through the bounded variant-registry allowlist before coercing to
+    a keyword.
   - `with-story-id` — the story-side peer of `with-variant-id`,
     resolving `:story-id` through the bounded story-registry allowlist
     (shared by `get-story` / `get-docs-markdown`).
@@ -23,7 +21,7 @@
     `snapshot-identity`, with each kw-typed slot routed through
     `safe-keyword` against its live bounded set.
 
-  ## Bounded-allowlist keyword resolution (rf2-lqjbk)
+  ## Bounded-allowlist keyword resolution
 
   A naive `(keyword raw-agent-string)` INTERNS on the JVM — a caller
   streaming unique random strings as `:variant-id`s would slowly grow
@@ -64,7 +62,7 @@
   (`^[a-zA-Z0-9_.-]{1,64}$`). The `?` belongs on the predicate, not on
   the data key.
 
-  ## Boot-time gate (rf2-g9fje)
+  ## Boot-time gate
 
   The operator-only gate `config/sensitive-reads-allowed?` (set by
   `--allow-sensitive-reads`) is the outer check: when it is `false`,
@@ -109,10 +107,10 @@
   cell-local overrides (`re-frame.story.args` §precedence: `… < mode-args
   < variant-args < cell-overrides`). Building the allowlist from the
   variant alone would drop a caller override for an arg introduced ONLY
-  by an active mode (rf2-to3q7), so the render would show the mode value
-  instead of the caller override. Used by `read-run-opts` to route each
+  by an active mode, so the render would show the mode value instead of
+  the caller override. Used by `read-run-opts` to route each
   caller-supplied override key through `args/safe-keyword` (no JVM intern
-  outside the set; rf2-3luf3). Returns `#{}` for an unresolvable variant
+  outside the set). Returns `#{}` for an unresolvable variant
   with no active modes — every override key then rejects, which is the
   honest answer (nothing to override)."
   [vk active-modes]
@@ -120,8 +118,8 @@
 
 (defn- safe-cell-overrides
   "Coerce a caller-supplied `:cell-overrides` map (string-keyed off the
-  JSON wire after the rf2-3luf3 no-intern ingress, or keyword-keyed from
-  a direct-invoke caller) into a keyword-keyed override map, routing
+  JSON wire via the no-intern ingress, or keyword-keyed from a
+  direct-invoke caller) into a keyword-keyed override map, routing
   every KEY through `args/safe-keyword` against `allowed` — the
   variant's declared arg-key set. A key outside the set is DROPPED (no
   intern), so an attacker cannot mint fresh keywords by streaming unique
@@ -149,38 +147,34 @@
   Shared by `tool-preview-variant`, `tool-run-variant`,
   `tool-snapshot-identity`, and `tool-variant-share-url` — all four
   advertise the same `:substrate` / `:active-modes` / `:cell-overrides`
-  tuple in their descriptors (rf2-09rfpu Finding 2 closed the
-  snapshot-identity gap: `:cell-overrides` is identity-bearing — it
-  perturbs the snapshot `:content-hash` via the resolved
-  `:effective-args`). The absent-slot-not-present rule keeps the helper
-  general. All call sites resolve `vk` via `with-variant` /
+  tuple in their descriptors. `:cell-overrides` is identity-bearing for
+  `snapshot-identity` — it perturbs the snapshot `:content-hash` via the
+  resolved `:effective-args`. The absent-slot-not-present rule keeps the
+  helper general. All call sites resolve `vk` via `with-variant` /
   `with-variant-id` before calling this, so the variant is always known
   here.
 
-  rf2-lqjbk: `:substrate` and each entry in `:active-modes` are
-  coerced through `args/safe-keyword` against the live registry's
-  bounded set — an unrecognised id surfaces as `nil` (which
-  `run-variant`'s opts contract already tolerates as 'no override')
-  rather than as a freshly-interned keyword. The substrates set is
-  CLJS-only (the JVM-standalone deploy reads `nil`); the modes set
-  is the registered-mode id set.
+  `:substrate` and each entry in `:active-modes` are coerced through
+  `args/safe-keyword` against the live registry's bounded set — an
+  unrecognised id surfaces as `nil` (which `run-variant`'s opts contract
+  tolerates as 'no override') rather than as a freshly-interned keyword.
+  The substrates set is CLJS-only (the JVM-standalone deploy reads
+  `nil`); the modes set is the registered-mode id set.
 
-  rf2-3luf3: `:cell-overrides` arrives string-keyed off the JSON wire
-  (the no-intern ingress no longer keywordises nested arg keys). Its
-  KEYS are routed through `args/safe-keyword` against the variant's
-  EFFECTIVE arg-key set under the active modes (`cell-override-key-set`)
-  — a bounded, registry-derived allowlist — so an override key outside
-  that set is dropped rather than interned. This is the read-side
-  counterpart to the operator-gated write-body keywordisation in
-  `tools.write`.
+  `:cell-overrides` arrives string-keyed off the JSON wire (the
+  no-intern ingress leaves nested arg keys as strings). Its KEYS are
+  routed through `args/safe-keyword` against the variant's EFFECTIVE
+  arg-key set under the active modes (`cell-override-key-set`) — a
+  bounded, registry-derived allowlist — so an override key outside that
+  set is dropped rather than interned. This is the read-side counterpart
+  to the operator-gated write-body keywordisation in `tools.write`.
 
-  rf2-to3q7: the active modes are coerced FIRST so the cell-override
-  allowlist is derived from the EFFECTIVE args for those modes
-  (`story/resolve-args` with `:active-modes`). Story's precedence merges
-  mode args before cell-local overrides, so an arg key introduced only
-  by an active mode is a legitimate override target; building the
-  allowlist from the bare variant (as before) dropped that override and
-  the render fell back to the mode value."
+  The active modes are coerced FIRST so the cell-override allowlist is
+  derived from the EFFECTIVE args for those modes (`story/resolve-args`
+  with `:active-modes`). Story's precedence merges mode args before
+  cell-local overrides, so an arg key introduced only by an active mode
+  is a legitimate override target, and deriving the allowlist from the
+  effective args keeps that override applicable."
   [vk arguments]
   (let [substrate-set (cljs-resolve/registered-substrates-set)
         mode-set      (story/list-modes)
@@ -200,16 +194,15 @@
                                                   (cell-override-key-set vk active-modes))))))
 
 ;; ---------------------------------------------------------------------------
-;; Shared lifecycle timeout (rf2-ovmc5e)
+;; Shared lifecycle timeout
 ;;
 ;; `run-variant` and `preview-variant` both block on the SAME
 ;; `story/run-variant` lifecycle via `async/deref-blocking`. The blocking
-;; ceiling is a single-threaded-stdio protection (rf2-g9fje): the MCP
-;; server's request loop is single-threaded, so an unbounded blocking
-;; deref on one tool parks every unrelated call. Both tools MUST share the
-;; same ceiling so they cannot drift by copy-paste — `preview-variant`
-;; previously hard-coded a hidden 5 s constant while `run-variant`
-;; advertised a tunable, capped `:timeout-ms`. One helper, one ceiling.
+;; ceiling is a single-threaded-stdio protection: the MCP server's
+;; request loop is single-threaded, so an unbounded blocking deref on one
+;; tool parks every unrelated call. Both tools share the same ceiling
+;; through one helper so they cannot drift by copy-paste — both advertise
+;; the same tunable, capped `:timeout-ms`. One helper, one ceiling.
 ;; ---------------------------------------------------------------------------
 
 (def ^:const max-timeout-ms
@@ -217,8 +210,8 @@
   `preview-variant`). The MCP server's request loop is single-threaded —
   a lifecycle call with an unbounded `:timeout-ms` parks the loop and
   starves unrelated tool calls. 30 s matches the `:rf.http/timeout-ms`
-  baseline rf2-it1cd pinned for the project's outbound HTTP fx, so an
-  agent that learns one ceiling sees the same one everywhere.
+  baseline for the project's outbound HTTP fx, so an agent that learns
+  one ceiling sees the same one everywhere.
   Caller-supplied values above this clamp DOWN to the ceiling rather than
   reject — a legitimate slow variant should still run, just capped."
   30000)
@@ -244,8 +237,8 @@
 
 (defn with-variant
   "Resolve `:variant-id` from `arguments` (required), resolve it against
-  the registered-variants set (no JVM intern outside the allowlist —
-  rf2-lqjbk), and probe `story/variant->edn` for the body. When both
+  the registered-variants set (no JVM intern outside the allowlist), and
+  probe `story/variant->edn` for the body. When both
   succeed, returns `(f vk body)`. Otherwise short-circuits with an
   error result:
 
@@ -273,8 +266,8 @@
 
 (defn with-story-id
   "Resolve `:story-id` from `arguments` (required), resolve it against
-  the registered-stories set (rf2-lqjbk — no JVM intern outside the
-  allowlist), and call `(f sk)` when it resolves. Otherwise short-
+  the registered-stories set (no JVM intern outside the allowlist), and
+  call `(f sk)` when it resolves. Otherwise short-
   circuits with an error result:
 
     - Missing/blank `:story-id` ⇒ `Missing required argument: …`
@@ -298,18 +291,16 @@
 
 (defn with-variant-id
   "Resolve `:variant-id` from `arguments` (required) against the
-  registered-variants set (rf2-lqjbk — no JVM intern outside the
-  allowlist). Returns `(f vk)` when the id resolves; otherwise an
-  error result.
+  registered-variants set (no JVM intern outside the allowlist).
+  Returns `(f vk)` when the id resolves; otherwise an error result.
 
   Used by tools whose reads tolerate an unregistered variant
-  (`read-a11y-violations`, `read-failures`, `unregister-variant`) — but per the
-  rf2-lqjbk bound, an UNREGISTERED variant id can't intern through
-  this surface either. The behavioural change: instead of returning
-  an empty result for a never-seen id, the tool returns the same
-  `Variant not found` error result `with-variant` emits. That is the
-  more honest answer — if the id was never registered, there's
-  nothing to read."
+  (`read-a11y-violations`, `read-failures`, `unregister-variant`) — but
+  the no-intern bound means an UNREGISTERED variant id can't resolve
+  through this surface either. A never-seen id returns the same
+  `Variant not found` error result `with-variant` emits — the honest
+  answer, since if the id was never registered there's nothing to
+  read."
   [arguments f]
   (let [[vid err] (required-arg arguments :variant-id)]
     (if err

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cljs_resolve.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cljs_resolve.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.story-mcp.tools.cljs-resolve
-  "Cross-platform CLJS-var resolution for the JVM-side MCP tools
-  (rf2-8yvyp, split out of the former `tools.helpers`).
+  "Cross-platform CLJS-var resolution for the JVM-side MCP tools.
 
   Several Story surfaces are CLJS-only (the registered-substrates
   registry, the in-browser a11y panel atom) — `def`s behind a
@@ -16,13 +15,11 @@
 
   ## Caching
 
-  `registered-substrates-var` is resolved ONCE at ns-load (rf2-ee38b.17
-  folded the duplicate `tools.dev/registered-substrates-var` into this
-  one). The substrate set is stable across the process lifetime, so
-  the cached var is the single resolution site for the whole story-mcp
-  surface — both the read-run-opts hot path (preview/run/snapshot) and
-  `dev/tool-list-substrates` deref the cached var rather than
-  re-resolving per call."
+  `registered-substrates-var` is resolved ONCE at ns-load, the single
+  resolution site for the whole story-mcp surface. The substrate set is
+  stable across the process lifetime, so both the read-run-opts hot path
+  (preview/run/snapshot) and `dev/tool-list-substrates` deref the cached
+  var rather than re-resolving per call."
   (:require [re-frame.story :as story]))
 
 (defn resolve-cljs-var
@@ -35,7 +32,7 @@
   alias-qualified symbol — even though `resolve` does honour the calling
   ns's aliases, passing the real ns keeps the contract self-describing
   and matches the sibling `'re-frame.story.ui.a11y/violations-by-frame`
-  resolution site (rf2-4sgak).
+  resolution site.
 
   Used by handlers that need a CLJS-side surface (the in-browser a11y
   panel atom, the CLJS substrate registry) — the JVM host reads an empty
@@ -46,17 +43,14 @@
 #?(:clj
    ;; `re-frame.story/registered-substrates` is CLJS-only — probed ONCE at
    ;; ns-load, here, as the single resolution site for the whole story-mcp
-   ;; surface (rf2-ee38b.17 folded the duplicate
-   ;; `tools.dev/registered-substrates-var` into this one). The substrate
-   ;; set is stable across the process lifetime, so `read-run-opts`
-   ;; (preview/run/snapshot hot path) and `dev/tool-list-substrates` both
-   ;; deref the cached var rather than re-probing per call. On a JVM host the
-   ;; CLJS-only Var doesn't exist, so the probe is nil and the set is empty;
-   ;; the `:cljs` accessor branch below reads the live registry directly when
-   ;; these namespaces are hosted in a CLJS runtime. (rf2-4sgak: was the
-   ;; alias-qualified `'story/registered-substrates` — `resolve` honoured the
-   ;; alias, but the fully-qualified form matches the docstring + the a11y
-   ;; site.)
+   ;; surface. The substrate set is stable across the process lifetime, so
+   ;; `read-run-opts` (preview/run/snapshot hot path) and
+   ;; `dev/tool-list-substrates` both deref the cached var rather than
+   ;; re-probing per call. On a JVM host the CLJS-only Var doesn't exist, so
+   ;; the probe is nil and the set is empty; the `:cljs` accessor branch below
+   ;; reads the live registry directly when these namespaces are hosted in a
+   ;; CLJS runtime. The fully-qualified symbol matches the docstring + the
+   ;; a11y resolution site.
    (defonce ^:private registered-substrates-var
      (resolve-cljs-var 're-frame.story/registered-substrates)))
 
@@ -78,7 +72,7 @@
 (defn registered-substrates-set
   "The set form of the CLJS-registered substrate ids — used by
   `args/read-run-opts` as the bounded allowlist when coercing the
-  agent-supplied `:substrate` arg through `safe-keyword` (rf2-lqjbk).
+  agent-supplied `:substrate` arg through `safe-keyword`.
 
   The JVM-standalone deploy reads `#{}`; the nREPL-attached CLJS
   deploy reads the live registry's keys. Mirrors `registered-substrates`

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.story-mcp.tools.cursor
-  "Cursor pagination for the Docs `list-*` tools (rf2-76sf6).
+  "Cursor pagination for the Docs `list-*` tools.
 
   Implements the spec/Principles.md §'Tight token budget' pagination
   MUST: every read tool whose return size is a function of registry
@@ -7,15 +7,14 @@
   continuation. The default `:limit` MUST keep the response under the
   cap (5,000 tokens).
 
-  ## Shared codec, story-specific shape (rf2-ee38b.17)
+  ## Shared codec, story-specific shape
 
   The base64 codec, the tagged-literal-rejecting EDN reader, the 1 KB
   size cap, the `::malformed` recovery posture, the `:limit` clamp, and
   the `cursor-stale-result` envelope all live in
   `re-frame.mcp-base.cursor` — one cross-MCP implementation shared with
-  re-frame2-pair-mcp (the clarity review's `mcp-base` deferral premise
-  went stale once story-mcp shipped its own copy). This ns now owns
-  only what is genuinely story-specific:
+  re-frame2-pair-mcp. This ns owns only what is genuinely
+  story-specific:
 
     - the cursor PAYLOAD shape (`{:v :offset :total :sig}`) + its
       `valid?` predicate,
@@ -73,7 +72,7 @@
   25)
 
 (def ^:const max-limit
-  "Hard ceiling on `:limit` (rf2-76sf6). The wire-boundary cap will
+  "Hard ceiling on `:limit`. The wire-boundary cap will
   catch oversize responses regardless, but we clamp the arg at the
   tool surface so the agent gets a deterministic per-page count rather
   than a `:rf.mcp/overflow` fallback. 200 is well past what any
@@ -105,7 +104,7 @@
   the shared `base-cursor/decode-cursor` so the codec is shared while
   the shape check stays story-specific.
 
-  rf2-to3q7 — wire-boundary range gate. `:offset` and `:total` MUST be
+  Wire-boundary range gate. `:offset` and `:total` MUST be
   NATURAL integers (a negative offset would feed `subvec` a negative
   start and throw a generic handler exception instead of the documented
   cursor-stale envelope), and `:offset` MUST NOT exceed `:total` (an
@@ -201,8 +200,8 @@
 
   Most callers don't touch this directly — they reach for the
   `paged-result` wrapper below, which folds the `[:ok …]` / `[:err …]`
-  branch + the `result/text-result` build into one call. `page` stays
-  public for the rare caller that wants the raw slice (none today)."
+  branch + the `result/text-result` build into one call. `page` is
+  public for the rare caller that wants the raw slice."
   [entries ids arguments tool-name]
   (let [limit         (parse-limit-arg (:limit arguments))
         cursor        (decode-cursor (:cursor arguments))
@@ -239,7 +238,7 @@
 
 (defn paged-result
   "Page `entries` and build the tool's `tools/call` result in one step —
-  the shape every Docs `list-*` handler shares (rf2-jkake.20). Pages via
+  the shape every Docs `list-*` handler shares. Pages via
   `page`; on a malformed/stale cursor returns the `cursor-stale-result`
   envelope directly; otherwise calls `(page->payload page-vec)` to build
   the tool-specific base payload, merges in the pagination metadata
@@ -251,9 +250,8 @@
   map (e.g. `(fn [p] {:stories p})` for `list-stories`, or the
   bifurcated `{:canonical … :registered p}` for `list-assertions`).
   This folds the four-line `(let [[res page meta] (page …)] (if (= res
-  :err) …))` boilerplate that previously sat inline in five handlers
-  into a single call, so each handler reads as 'compute entries, then
-  page them under this shape'."
+  :err) …))` boilerplate into a single call, so each handler reads as
+  'compute entries, then page them under this shape'."
   [entries ids arguments tool-name page->payload]
   (let [[res page-vec meta] (page entries ids arguments tool-name)]
     (if (= res :err)

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dedup.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dedup.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story-mcp.tools.dedup
-  "Structural dedup at the wire boundary (rf2-90eft) — JVM-side mirror
-  of `re-frame2-pair-mcp.tools.dedup` (rf2-obpa9).
+  "Structural dedup at the wire boundary — JVM-side mirror
+  of `re-frame2-pair-mcp.tools.dedup`.
 
   ## Why dedup at the wire boundary
 
@@ -26,7 +26,7 @@
   slot, BEFORE the wire-cap check (`re-frame.mcp-base.cap/apply-cap`).
   Ordering matters: dedup shrinks the payload first, so the cap-honest
   size is post-dedup. Same ordering invariant as pair-mcp's
-  `wire-pipeline` (rf2-rvyzy → rf2-obpa9 → cap).
+  `wire-pipeline` (dedup → cap).
 
   ## Why `de-dupe-eq` (equality), not `de-dupe` (identity)
 
@@ -51,7 +51,7 @@
 
   `:dedup` MCP arg (boolean). Default `true`. `false` skips dedup
   entirely. The arg is parsed by the shared `parse-boolean` table-
-  driven parser (rf2-c4fmh) so string-form booleans work alongside
+  driven parser so string-form booleans work alongside
   the JSON `true` / `false`.
 
   ## Idempotence on no-dedup-opportunity
@@ -61,11 +61,11 @@
   encoder skips wrapping in that case via an `empty-payload?` short-
   circuit — matching pair-mcp's behaviour byte-for-byte.
 
-  ## Where the dedup encode step lives (rf2-ttspi7)
+  ## Where the dedup encode step lives
 
-  `empty-payload?` and `dedup-value` were byte-identical to pair-mcp's,
-  so they are lifted to `re-frame.mcp-base.dedup` and delegated here.
-  Only the INVERSE (`dedup-expand`) stays local — see its docstring for
+  `empty-payload?` and `dedup-value` are byte-identical to pair-mcp's,
+  so they live in `re-frame.mcp-base.dedup` and are delegated here.
+  Only the INVERSE (`dedup-expand`) is local — see its docstring for
   why story-mcp keeps its inverse in production while pair-mcp keeps
   its inverse in test-utils."
   (:require [de-dupe.core :as dd]
@@ -73,12 +73,12 @@
             [re-frame.mcp-base.vocab :as base-vocab]))
 
 (defn empty-payload?
-  "Delegates to `re-frame.mcp-base.dedup/empty-payload?` (rf2-ttspi7)."
+  "Delegates to `re-frame.mcp-base.dedup/empty-payload?`."
   [v]
   (base-dedup/empty-payload? v))
 
 (defn dedup-value
-  "Delegates to `re-frame.mcp-base.dedup/dedup-value` (rf2-ttspi7). Uses
+  "Delegates to `re-frame.mcp-base.dedup/dedup-value`. Uses
   `de-dupe.core/de-dupe-eq` (equality-based) — see the namespace
   docstring for the identity-vs-equality rationale."
   [v enabled?]

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -7,7 +7,7 @@
   artefact is self-contained — no resource read at boot, one MCP
   frame, zero classpath / IO dependencies. The structural peer in
   pair-mcp (`get-re-frame2-pair-instructions`) uses the same inline-
-  `(str ...)` shape, kept aligned per rf2-93cew so AI pairs reading
+  `(str ...)` shape, kept aligned so AI pairs reading
   both servers see one answer to the onboarding-text question."
   (:require [re-frame.story :as story]
             [re-frame.story.async :as async]
@@ -20,7 +20,7 @@
 (def story-instructions-text
   "The agent-onboarding text returned by `get-story-instructions`.
   Inline `(str ...)` of `\\n`-glued lines — see the ns docstring for
-  the rationale (mirrors pair-mcp per rf2-93cew). Edit this string
+  the rationale (mirrors pair-mcp). Edit this string
   when the catalogue changes."
   (str
     "re-frame2-story authoring conventions (agent quick reference).\n"
@@ -85,7 +85,7 @@
   "Dev: return the Story authoring conventions in agent-friendly form.
 
   Emits BOTH the `:content` text slot AND a matching
-  `:structuredContent` map (rf2-vyacl). The descriptor declares an
+  `:structuredContent` map. The descriptor declares an
   `:outputSchema` (`s/default-output-schema`); the official MCP SDK's
   high-level `callTool` REJECTS a tool that declares an output schema
   but returns no `:structuredContent` with JSON-RPC -32600. Mirroring
@@ -105,18 +105,17 @@
   side has `async/deref-blocking`), and serialise the result map.
 
   `preview-variant` runs the SAME `story/run-variant` lifecycle as
-  `run-variant`, so it speaks the SAME unified run-result vocabulary
-  (rf2-ba86n.17) — it does NOT ship a third result dialect. It surfaces
+  `run-variant`, so it speaks the SAME unified run-result vocabulary —
+  it does NOT ship a third result dialect. It surfaces
   the unified `:status` verdict + the unified `:assertions` records (each
   with a derived `:status`) + `:checks`, and ADDS the preview-specific
   slots: the `:share-url` (per IMPL-SPEC §2.8.5 + Stage 6
   `story/variant-share-url`) so the agent can hand the cell to a human
   collaborator, plus `:rendered-hiccup` / `:effective-args`. `:lifecycle`
   here is the loader-lifecycle STATE (`:ready` / `:error`), not the run
-  verdict — the verdict is `:status` (the old `:passing?` boolean was
-  removed in the clean break).
+  verdict — the verdict is `:status`.
 
-  Blocking-timeout posture (rf2-ovmc5e): because preview and `run-variant`
+  Blocking-timeout posture: because preview and `run-variant`
   block on the SAME lifecycle, they share the SAME `:timeout-ms` knob +
   ceiling via `targs/resolve-timeout-ms` (default 10 s, hard ceiling
   30 s, caller values clamp DOWN). The MCP request loop is single-threaded
@@ -124,7 +123,7 @@
   helper means the two tools cannot drift by copy-paste, and an agent can
   discover + tune the ceiling from `tools/list` on either tool.
 
-  Wire-egress posture (rf2-73wuj): the `:app-db` slot is routed
+  Wire-egress posture: the `:app-db` slot is routed
   through `re-frame.core/elide-wire-value`; the `:assertions` vec is
   filtered through `strip-sensitive`. Off-box defaults apply unless
   the caller passes `:include-sensitive true`."
@@ -136,8 +135,8 @@
             share-url  (story/variant-share-url vk base-url opts)
             outcome    (try
                          (async/deref-blocking (story/run-variant vk opts)
-                                               ;; rf2-ovmc5e — shared lifecycle
-                                               ;; ceiling: tunable `:timeout-ms`
+                                               ;; Shared lifecycle ceiling:
+                                               ;; tunable `:timeout-ms`
                                                ;; (default 10s, clamped to 30s),
                                                ;; the SAME knob `run-variant` uses
                                                ;; so the two cannot drift.
@@ -167,11 +166,11 @@
                         :checks       (vec (:checks outcome))
                         ;; Derived trees re-key the same sensitive value at a
                         ;; non-app-db path, so the path-based walker can't
-                        ;; reach them — value-redact instead (rf2-ee38b.17).
+                        ;; reach them — value-redact instead.
                         :rendered-hiccup (egress/scrub-rendered (:rendered-hiccup outcome) raw-db vk incl?)
                         :snapshot     (egress/scrub-rendered (:snapshot outcome) raw-db vk incl?)
                         :effective-args (egress/scrub-rendered (:effective-args outcome) raw-db vk incl?)}]
-        ;; Surface the MUST-level egress indicator counts (rf2-koq5m):
+        ;; Surface the MUST-level egress indicator counts:
         ;; how many sensitive assertion records were dropped + how many
         ;; over-threshold leaves were elided across the payload. Omitted
         ;; when zero (Conventions §Cross-MCP indicator-field vocabulary).
@@ -190,8 +189,7 @@
   (no CLJS substrates are runnable from a JVM-only host).
 
   The CLJS var is resolved once, in `cljs-resolve` —
-  `cljs-resolve/registered-substrates` is the single accessor
-  (rf2-ee38b.17 removed the duplicate `defonce` that used to live here)."
+  `cljs-resolve/registered-substrates` is the single accessor."
   [_args]
   (result/edn-result {:substrates (vec (cljs-resolve/registered-substrates))}))
 
@@ -223,7 +221,7 @@
                          "3. Slow variant with an explicit timeout: {:variant-id \":story.slow/loader\" :timeout-ms 20000} -> runs against the 20s ceiling (clamped to 30s max); on overrun returns {:status :error :lifecycle :error :assertions [{:assertion :rf.error/run-failed :status :error ...}]}. "
                          "4. Not registered: {:variant-id \":story.no/such\"} -> {:isError true :content [{:text \"Variant not found: :story.no/such\"}]}.")
     :typicalTokens  2000
-    ;; rf2-90eft — `preview-variant` ships the variant's `:app-db`
+    ;; `preview-variant` ships the variant's `:app-db`
     ;; re-keyed into `:rendered-hiccup` / `:effective-args` /
     ;; `:snapshot`; structural dedup collapses those four references
     ;; into one cache slot at the wire boundary. Mirrors pair-mcp's
@@ -243,12 +241,12 @@
                   :required ["variant-id"]
                   :additionalProperties false}
     :outputSchema s/default-output-schema
-    ;; rf2-8h778 — `preview-variant` invokes the same `story/run-variant`
+    ;; `preview-variant` invokes the same `story/run-variant`
     ;; pipeline as `run-variant`: it dispatches events into the variant's
-    ;; frame, accumulates assertions, and mutates the runtime. The audit
-    ;; (rf2-3pn6c Finding #2) caught the asymmetry — `read-only-annotations`
-    ;; here would have allowed agent hosts to auto-approve a call that
-    ;; mutates the frame. The semantic distinction between the two tools
+    ;; frame, accumulates assertions, and mutates the runtime. So it carries
+    ;; the destructive run annotations, not `read-only-annotations` — the
+    ;; latter would let agent hosts auto-approve a call that mutates the
+    ;; frame. The semantic distinction between the two tools
     ;; (`preview-variant` adds the share URL + rendered view; `run-variant`
     ;; is the headline run/verdict call — both return the same unified
     ;; run-result `:status`) is real but doesn't change the destructive

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -4,7 +4,7 @@
   `list-stories`, `get-story`, `get-variant`, `list-tags`,
   `list-modes`, `list-assertions`, `variant->edn`.
 
-  ## Pagination (rf2-76sf6)
+  ## Pagination
 
   Per spec/Principles.md §'Tight token budget' MUST, every `list-*`
   tool accepts `:limit` + `:cursor`. Small registries fit on one
@@ -28,20 +28,20 @@
   `args`:
     :tags    — vector of tag ids (strings or `:keyword` forms); narrows
                the result to stories whose `:tags` set intersects this.
-    :limit   — optional, default 25. Per-page entry count (rf2-76sf6).
+    :limit   — optional, default 25. Per-page entry count.
     :cursor  — optional opaque continuation token from a previous call.
 
-  HOT PATH (rf2-d3iso): agents spam this tool. The variant-id slot per
+  HOT PATH: agents spam this tool. The variant-id slot per
   story is read from `story/variants-by-story` — a single O(V) pass
-  over the variant side-table — instead of the previous O(S × V) shape
-  of calling `variants-of` once per story.
+  over the variant side-table — rather than calling `variants-of`
+  once per story (an O(S × V) shape).
 
-  rf2-lqjbk: caller-supplied `:tags` entries route through
+  Caller-supplied `:tags` entries route through
   `args/safe-keyword` against the registered-tag set — unknown tag
   ids skip the intersection rather than interning a fresh JVM
   keyword.
 
-  rf2-wu1o2d: a SUPPLIED `:tags` filter is honoured even when every
+  A SUPPLIED `:tags` filter is honoured even when every
   entry is unknown. We track whether the caller supplied `:tags`
   SEPARATELY from the set of tags that resolved against the registry,
   so an unknown-only filter (a typo / stale tag such as `[\":docz\"]`)
@@ -53,7 +53,7 @@
   no-interning posture is preserved — `:ignored-tags` carries the raw
   supplied strings, the keyword table is untouched.
 
-  rf2-76sf6: pagination via `cursor/page`. The stable-sort key is the
+  Pagination via `cursor/page`. The stable-sort key is the
   story id (string projection). Small registries return the bare
   `{:stories [...]}` payload; once entries exceed `:limit` the
   response adds `:total :limit :has-more? :next-cursor`."
@@ -63,7 +63,7 @@
         supplied     (:tags args)
         supplied?    (some? supplied)
         ;; Resolve each supplied entry against the registered-tag set
-        ;; WITHOUT interning unknowns (rf2-lqjbk). Partition by whether
+        ;; WITHOUT interning unknowns. Partition by whether
         ;; it resolved so the unknown names can ride the `:ignored-tags`
         ;; diagnostic as their raw string forms.
         tags         (into #{} (keep #(args/safe-keyword % tag-set)) (or supplied []))
@@ -71,7 +71,7 @@
                        (into [] (remove #(args/safe-keyword % tag-set)) supplied))
         ;; A SUPPLIED filter always filters — even when nothing resolved
         ;; (unknown-only ⇒ empty intersection ⇒ empty result), so a typo
-        ;; never widens to the whole catalogue (rf2-wu1o2d). Only the
+        ;; never widens to the whole catalogue. Only the
         ;; no-`:tags` call returns the unfiltered registry.
         filtered     (if supplied?
                        (into {}
@@ -99,7 +99,7 @@
 (defn tool-get-story
   "Docs: one story's full body.
 
-  rf2-lqjbk: `:story-id` is resolved through `args/safe-keyword`
+  `:story-id` is resolved through `args/safe-keyword`
   against the registered-stories set — an unknown id returns the
   documented `Story not found` error without interning (via the shared
   `targs/with-story-id` prelude)."
@@ -120,9 +120,9 @@
 (defn tool-list-tags
   "Docs: canonical tags + custom tags.
 
-  rf2-76sf6: the bifurcated `{:canonical :custom :all}` shape is
-  retained; `:canonical` is always the full canonical set (the seven
-  spec/007 inclusion tags + the five rf2-k1k87 `:state/*` magnitude
+  The bifurcated `{:canonical :custom :all}` shape:
+  `:canonical` is always the full canonical set (the seven
+  spec/007 inclusion tags + the five `:state/*` magnitude
   tags = 12 entries total; bounded and not a function of registry
   size, so pagination does not apply). `:custom` (project-registered
   tags) and `:all` (their union) are paginated when the count exceeds
@@ -137,7 +137,7 @@
                          (fn [page]
                            ;; :all is the union of :canonical + the (page-sliced)
                            ;; :custom. When no pagination kicks in (small registry)
-                           ;; the result is byte-identical to the pre-rf2-76sf6 shape.
+                           ;; the result is the bare `{:canonical :custom :all}` shape.
                            {:canonical canonical
                             :custom    page
                             :all       (vec (sort-by str (into canonical page)))}))))
@@ -146,7 +146,7 @@
   "Docs: registered modes (from `reg-mode`). Returns each mode's id +
   body so agents can see the `:args` saved tuple.
 
-  rf2-76sf6: paginated per spec/Principles.md §'Tight token budget'."
+  Paginated per spec/Principles.md §'Tight token budget'."
   [args]
   (let [modes   (story/registrations :mode)
         sorted  (sort-by (comp str key) modes)
@@ -176,14 +176,14 @@
                                     :response (:response body)))))
 
 (def ^:private decorator-kinds
-  "Bounded enum allowlist for `tool-list-decorators` `:kind` filter
-  (rf2-lqjbk). Three legal values per spec/Stage-2 decorator kinds;
+  "Bounded enum allowlist for `tool-list-decorators` `:kind` filter.
+  Three legal values per spec/Stage-2 decorator kinds;
   an unrecognised string short-circuits through `safe-keyword` without
   interning."
   #{:hiccup :frame-setup :fx-override})
 
 (defn tool-list-decorators
-  "Docs: read-only enumeration of registered decorators (rf2-mqp1u).
+  "Docs: read-only enumeration of registered decorators.
   Returns each decorator's id, kind, and doc plus the kind-specific
   pure-data slots. The `:wrap` closure on `:hiccup` decorators is
   not transported — only a `:has-wrap?` boolean — because closures
@@ -197,25 +197,25 @@
   - `:kind` (string, optional) — narrow to one decorator kind. One
     of `\"hiccup\"`, `\"frame-setup\"`, `\"fx-override\"`. Resolved
     through `args/safe-keyword` against the bounded `decorator-kinds`
-    set (rf2-lqjbk) — no-intern: an unrecognised string never mints a
+    set — no-intern: an unrecognised string never mints a
     fresh JVM keyword.
 
-  rf2-cdavyf: a SUPPLIED `:kind` outside the bounded enum is an
+  A SUPPLIED `:kind` outside the bounded enum is an
   agent-recoverable error, NOT a silent widen to the full catalogue.
-  The enum is advertised as a filter; resolving a typo (`\"hicup\"`) to
-  `nil` and then treating `nil` as no-filter returned EVERY decorator —
-  hiding the caller's mistake behind a successful-looking full result.
-  An absent `:kind` (the slot was never sent) is still the legitimate
-  no-filter path; only a PRESENT-but-unrecognised value rejects.
+  The enum is advertised as a filter; treating a resolved-to-`nil` typo
+  (`\"hicup\"`) as no-filter would return EVERY decorator and hide the
+  caller's mistake behind a successful-looking full result. An absent
+  `:kind` (the slot was never sent) is the legitimate no-filter path;
+  only a PRESENT-but-unrecognised value rejects.
 
-  rf2-76sf6: pagination via `:limit` / `:cursor`. The filtered+sorted
+  Pagination via `:limit` / `:cursor`. The filtered+sorted
   entry vec is paged; the cursor's fingerprint is over the FILTERED
   id-set so a kind-filter change between pages reads as a stale
   cursor (different sig)."
   [args]
   (let [raw-kind    (:kind args)
         kind-filter (some-> raw-kind (args/safe-keyword decorator-kinds))]
-    ;; rf2-cdavyf — a present-but-unrecognised `:kind` is rejected rather
+    ;; A present-but-unrecognised `:kind` is rejected rather
     ;; than widened to all. `(some? raw-kind)` distinguishes "no filter
     ;; requested" (absent slot ⇒ `raw-kind` nil) from "filter requested
     ;; with a bad value" (`raw-kind` present but `safe-keyword` ⇒ nil).
@@ -240,7 +240,7 @@
 (def canonical-assertion-docs
   "Per spec/007 line 304 + IMPL-SPEC §3.5 the seven dispatched canonical
   assertions' arities, PLUS the tape-evaluated `:rf.assert/schema-error`
-  (rf2-5x1wt.21, spec/017 §Schema rule). `:rf.assert/schema-error` is the
+  (spec/017 §Schema rule). `:rf.assert/schema-error` is the
   one canonical assertion that is NOT dispatched into the frame — it
   declares an EXPECTED schema violation the runner exact-consumes against
   the projected epoch-tape evidence (a run FAILS on any schema violation
@@ -276,13 +276,13 @@
 (defn tool-list-assertions
   "Docs: the `:rf.assert/*` canonical vocabulary + arity docs.
 
-  rf2-76sf6: the bifurcated `{:canonical :registered}` shape is
-  retained; `:canonical` is the full 8-assertion doc vector — the seven
+  The bifurcated `{:canonical :registered}` shape:
+  `:canonical` is the full 8-assertion doc vector — the seven
   dispatched canonical assertions plus the tape-evaluated
   `:rf.assert/schema-error` (bounded and constant, so the pagination MUST
   does not apply).
 
-  rf2-4sgak: `:registered` is the FULL vocabulary the Story plan compiler
+  `:registered` is the FULL vocabulary the Story plan compiler
   accepts — `story/known-assertion-ids` (spec/017 §Assertions),
   the SAME set `plan.cljc` validates authored assertion atoms against via
   `assertion-id-known?`. That is the eight canonical ids PLUS the
@@ -290,11 +290,10 @@
   family (`:rf.assert/dom-visible|dom-hidden|dom-text`), the visual / a11y
   oracles (`:rf.assert/visual-snapshot`, `:rf.assert/a11y`,
   `:rf.assert/a11y-structural`), and the reactive-count assertions
-  (`:rf.assert/caused`, `:rf.assert/no-cascade-rerender`). Previously this
-  slot mirrored only `canonical-assertion-ids`, so an agent could not
-  discover the visual/a11y/DOM ids the compiler would have accepted and
-  fell back to stale prose. `:registered` is paginated when the count
-  exceeds `:limit`; small registries see no pagination metadata."
+  (`:rf.assert/caused`, `:rf.assert/no-cascade-rerender`). Surfacing the
+  full set lets an agent discover the visual/a11y/DOM ids the compiler
+  accepts rather than fall back to prose. `:registered` is paginated when
+  the count exceeds `:limit`; small registries see no pagination metadata."
   [args]
   (let [registered (sort-by str (story/known-assertion-ids))
         reg-vec    (vec registered)]
@@ -304,7 +303,7 @@
 
 (def ^:private explain-value-bearing-slots
   "The `explain` map slots that carry RUNTIME-RESOLVED / SEEDED VALUES
-  (rf2-12f2q, extended rf2-q8ebq.1) — the slots a value-redaction step
+  — the slots a value-redaction step
   must scrub against the variant frame's declared-sensitive values before
   the explain payload crosses the AI/off-box boundary:
 
@@ -325,7 +324,7 @@
     so a sensitive arg substituted into a setup/script step's payload
     rides these post-substitution sequences. Scrubbing `:substitutions`
     while leaving these raw is a clean bypass (the secret leaks via the
-    unscrubbed sibling), so they are scrubbed too (rf2-q8ebq.1).
+    unscrubbed sibling), so they are scrubbed too.
 
   Every OTHER explain slot is plan-STRUCTURE (source/parent chains,
   compose lineage, merge rules, strict conflicts, tags, platforms, runner
@@ -346,8 +345,8 @@
 
 (defn- scrub-explain
   "Value-scrub the runtime/seeded VALUE slots of an `explain` map against
-  `variant-id`'s frame declarations (rf2-12f2q) — on BOTH egress axes
-  (rf2-9o5ixx, EP-0015 peer axes): a leaf equal to a declared-`:sensitive?`
+  `variant-id`'s frame declarations — on BOTH egress axes
+  (EP-0015 peer axes): a leaf equal to a declared-`:sensitive?`
   value becomes `:rf/redacted`, a leaf equal to a declared-`:large` value
   becomes the `:rf.size/large-elided` marker (sensitive wins where both
   apply). Plan-structure slots pass through untouched — they are
@@ -357,7 +356,7 @@
   Delegates to `egress/scrub-explain-values`, which collects candidate
   secrets from BOTH the live variant-frame app-db AND the plan's own
   `:db-seed` slot. The plan-`:db-seed` source is the FAIL-CLOSED pre-frame
-  path (rf2-tag30h): `explain-variant` is a no-run path a caller can hit
+  path: `explain-variant` is a no-run path a caller can hit
   before any run allocates the frame, so a secret authored into `:db-seed`
   (and re-surfaced in `:effective-args` / `:network` / a step payload)
   must be value-matched against the plan's own seed, not just a live
@@ -368,9 +367,8 @@
 (defn tool-explain-variant
   "Docs: the variant-plan `:explain` projection for a variant — the SAME
   data the human Explain panel renders (spec/017 §Explain API). A thin
-  mirror over the already-shipped `re-frame.story/explain` data API
-  (rf2-ba86n.17): the single biggest agent↔human divergence today —
-  humans have the Explain panel, agents had no MCP reach to it.
+  mirror over the `re-frame.story/explain` data API: the agent's reach to
+  the same Explain data humans see in the panel.
 
   The `:explain` map answers 'why did the plan resolve this way':
   `:source-chain` / `:parent-chain` (the `:extends` lineage),
@@ -389,7 +387,7 @@
   payloads can carry a declared-sensitive value (a seeded token, a stubbed
   PII reply, a control-driven override, a setup-dispatched secret). Those
   value-bearing slots are value-redacted against the variant frame's
-  declared-sensitive values at egress (rf2-12f2q, rf2-q8ebq.1) via
+  declared-sensitive values at egress via
   `egress/scrub-frame-value` — the SAME value-based redaction the live
   tools apply to their derived trees. `:sub-overrides` /
   `:setup-order` / `:script-order` carry resolved arg VALUES (the SAME
@@ -414,13 +412,12 @@
   to `get-variant`; the text slot is the byte-stable `pr-str` EDN
   (keyword keys preserved) for agents that want strict EDN diffing.
 
-  Emits a matching `:structuredContent` too (rf2-vyacl). The descriptor
+  Emits a matching `:structuredContent` too. The descriptor
   declares an `:outputSchema`; the official MCP SDK's high-level
   `callTool` REJECTS an outputSchema-declaring tool that returns no
-  structuredContent with JSON-RPC -32600. (Same latent defect class as
-  `get-story-instructions` — `variant->edn` was the only other tool
-  still text-only.) The structured slot carries the same body map; the
-  text slot remains the byte-stable EDN source of truth."
+  structuredContent with JSON-RPC -32600. The structured slot carries
+  the same body map; the text slot remains the byte-stable EDN source of
+  truth."
   [args]
   (targs/with-variant args
     (fn [_vk body]
@@ -482,8 +479,8 @@
       "—\n")))
 
 (defn tool-get-docs-markdown
-  "Docs: render a story's documentation as GitHub-flavoured Markdown
-  (rf2-i0kyy). The existing `get-story` / `get-variant` tools return
+  "Docs: render a story's documentation as GitHub-flavoured Markdown.
+  The `get-story` / `get-variant` tools return
   EDN — useful for programmatic consumption but not the right shape
   when an agent wants to paste a docs blurb into an issue tracker or
   chat. This tool composes story `:doc` + per-variant `:doc` + args /

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.story-mcp.tools.recorder
-  "record-as-variant — the recorder's MCP surface (rf2-luhdu).
+  "record-as-variant — the recorder's MCP surface.
 
   Wraps `re-frame.story`'s recorder primitives (start-recording! →
   sleep for :duration-ms → stop-recording! → gen-play-snippet) per
@@ -14,13 +14,12 @@
   Optional `:write-back` re-registers the source variant with the
   captured recording translated to a live play slot. The emitted EDN
   uses the PUBLIC `:script` authoring spelling (spec/017 §Public
-  vocabulary; rf2-7mj4z — the rename is finished on every emission
-  surface). This is gated by the same `allow-writes?` flag as `register-variant`
+  vocabulary). This is gated by the same `allow-writes?` flag as `register-variant`
   (`tools.write/assert-writes-allowed`). This is
   the self-healing-loop hook the spec mentions: agent drives canvas →
   tool returns snippet AND patches the variant in place.
 
-  ## Wire-key shape (rf2-pmwgn)
+  ## Wire-key shape
 
   The wire-arg key is `:write-back` (no `?`) to satisfy Anthropic's
   `^[a-zA-Z0-9_.-]{1,64}$` constraint on tool input-schema property
@@ -41,7 +40,7 @@
             [re-frame.story-mcp.tools.write :as write]))
 
 (def ^:const max-duration-ms
-  "Ceiling on `:duration-ms` for `record-as-variant` (rf2-4yuhi). The
+  "Ceiling on `:duration-ms` for `record-as-variant`. The
   MCP server's request loop is single-threaded (`server/run-loop!`), so
   a `record-as-variant` call sleeps the whole loop for the full window.
   At 30s an abusive caller effectively DoS's the server; we reject any
@@ -73,16 +72,14 @@
   `:decorators` survive) and overwrites the play surface with the
   translated, replayable script.
 
-  Per rf2-7mj4z the write-back assocs the PUBLIC `:script` authoring slot
-  (spec/017 §Public vocabulary), not the transitional `:play-script`
-  spelling — the `:setup`/`:script` rename is finished on every emission
-  surface. (Both spellings store identically: `reg-variant*` lowers the
+  The write-back assocs the PUBLIC `:script` authoring slot
+  (spec/017 §Public vocabulary), not the `:play-script` spelling. (Both
+  spellings store identically: `reg-variant*` lowers the
   public `:script` to the shipping `:play-script` slot via
   `schemas/lower-public-vocabulary`, so `variant->edn` of the stored body
-  reads `:play-script` either way — the rename is an author-facing
-  intent, the stored shipping slot is unchanged. The legacy `:play` slot
-  was REMOVED in rf2-0wrud; a `:play` key would pass the open variant
-  `:map` validation but no runner executes it.) We translate the captured
+  reads `:play-script` either way — `:script` is an author-facing
+  intent, the stored shipping slot is `:play-script`. A `:play` key would
+  pass the open variant `:map` validation but no runner executes it.) We translate the captured
   `events` via `story/recording->script-body` (the live runtime
   counterpart to `gen-play-snippet`'s text output) — which returns a
   `{:script … :auto-run?}` play body — and write that under `:script`.
@@ -95,7 +92,7 @@
   dispatches frame-scoped and lands in the frame's own running environment
   by construction — the written-back body carries no separate realm key.
 
-  rf2-l2cn5d (EP-0017): the captured `:rf.cofx` maps (the parallel `cofx`
+  EP-0017: the captured `:rf.cofx` maps (the parallel `cofx`
   vector, index-aligned with `events` — framework `:rf/time-ms` plus any
   provided recordable facts) are threaded into `recording->script-body`'s
   `:cofx` opt so each written-back dispatch step carries its recorded
@@ -103,7 +100,7 @@
   RAW (unscrubbed) cofx is used here — the write-back is an operator-gated
   on-box registration (`--allow-writes`), not a wire egress, so replay keeps
   full fidelity. A recording with no captured coeffects threads an all-nil
-  cofx vector, so the body is byte-identical to the pre-EP-0017 shape.
+  cofx vector, so the body carries a bare 2-element dispatch step.
 
   Returns the structured success result on the happy path, or an
   `error-result` whose `:structuredContent` merges the base recorder
@@ -111,7 +108,7 @@
   [base body events cofx target-vid]
   (try
     (let [play-body (story/recording->script-body events {:cofx cofx})
-          ;; rf2-f4e1xs — REPLACE any existing play surface before adding the
+          ;; REPLACE any existing play surface before adding the
           ;; recorded `:script`. The source body may already carry a lowered
           ;; `:play-script` (a variant authored with public `:script` is
           ;; stored lowered) or `:plays`; the variant schema rejects a body
@@ -151,12 +148,11 @@
                               Hard ceiling `max-duration-ms` (30000 ms)
                               — the MCP server's request loop is single-
                               threaded; durations above the ceiling are
-                              rejected with a structured error
-                              (rf2-4yuhi).
+                              rejected with a structured error.
     :new-variant-id optional — when `:write-back` is true, register the
                               captured recording (translated to a live
                               `:script` body, the public phase-4 play
-                              surface — rf2-7mj4z) as a NEW variant with
+                              surface) as a NEW variant with
                               this id. Defaults to the source
                               `:variant-id` (overwrites in place).
     :doc           optional — docstring to embed in the snippet.
@@ -169,17 +165,17 @@
     :write-back    optional — when true, also re-register the variant
                               via `reg-variant*` with the captured
                               recording translated to a live `:script`
-                              body (the public phase-4 play surface —
-                              rf2-7mj4z). Requires `allow-writes?`
+                              body (the public phase-4 play surface).
+                              Requires `allow-writes?`
                               (same gate as `register-variant`).
-                              Wire-key shape per rf2-pmwgn: no `?` —
+                              Wire-key shape: no `?` —
                               Anthropic's input-schema property-name
                               regex rejects it.
     :include-sensitive optional — opt out of wire-egress redaction of the
-                              captured event payloads (default false;
-                              rf2-12f2q). Gated by --allow-sensitive-reads.
+                              captured event payloads (default false).
+                              Gated by --allow-sensitive-reads.
 
-  Wire-egress posture (rf2-12f2q): the captured event vectors cross the
+  Wire-egress posture: the captured event vectors cross the
   AI/off-box boundary in both the `:captured` slot and the `:play-snippet`
   text. They are value-redacted against the source variant frame's
   declared-`:sensitive?` values before egress (the SAME value-based
@@ -215,10 +211,10 @@
             duration-ms (args/parse-non-negative-int (:duration-ms arguments) 0)]
         (or (when write-back? (write/assert-writes-allowed "record-as-variant"))
             (when (> duration-ms max-duration-ms)
-              ;; rf2-4yuhi — the MCP server's request loop is single-
-              ;; threaded; a `record-as-variant` call sleeps the loop
-              ;; for the full window. Reject abusive durations rather
-              ;; than stalling unrelated tool calls.
+              ;; The MCP server's request loop is single-threaded; a
+              ;; `record-as-variant` call sleeps the loop for the full
+              ;; window. Reject abusive durations rather than stalling
+              ;; unrelated tool calls.
               (result/error-result
                 (str ":duration-ms " duration-ms " exceeds ceiling "
                      max-duration-ms "ms. The MCP server's request "
@@ -230,8 +226,7 @@
                  :tool          "record-as-variant"
                  :duration-ms   duration-ms
                  :max-allowed   max-duration-ms}))
-            ;; rf2-lqjbk: keyword resolution for the three caller-
-            ;; supplied id slots.
+            ;; Keyword resolution for the three caller-supplied id slots.
             ;;
             ;; - `:extends` is a read-side reference — it MUST point to
             ;;   a registered variant whose `:component` / `:args` the
@@ -264,14 +259,12 @@
                   {:rf.error :rf.story-mcp/extends-not-registered
                    :tool     "record-as-variant"
                    :extends  (:extends arguments)})
-                ;; rf2-tag30h: in the write-back arm the caller mints a
+                ;; In the write-back arm the caller mints a
                 ;; FRESH variant id, so validate its `:story.<path>/<name>`
                 ;; grammar on the STRING shape via `fresh-keyword-checked`
-                ;; BEFORE interning. `fresh-keyword` interned first and let
-                ;; `reg-variant*`'s `assert-id!` reject downstream — but the
-                ;; reject ran AFTER the intern AND after a recording window
-                ;; had already been driven, so an invalid id both grew the
-                ;; JVM keyword table and wasted the recording. A nil here
+                ;; BEFORE interning. Validating the string before interning
+                ;; means an invalid id neither grows the JVM keyword table
+                ;; nor wastes a driven recording window. A nil here
                 ;; (invalid grammar) short-circuits to an error before any
                 ;; recording starts. The non-write-back arm keeps its
                 ;; safe-keyword/default-to-vk resolution (no intern).
@@ -312,7 +305,7 @@
                       _           (sleep-ms duration-ms)
                       final-state (story/stop-recording!)
                       events      (vec (:events final-state))
-                      ;; rf2-l2cn5d (EP-0017): the parallel captured-cofx slot,
+                      ;; EP-0017: the parallel captured-cofx slot,
                       ;; index-aligned with `:events` — each member is the flat
                       ;; `:rf.cofx` map (framework `:rf/time-ms` + any provided
                       ;; recordable facts) the dispatch carried, or nil. Threaded
@@ -320,7 +313,7 @@
                       ;; recorded recordable coeffects rather than restamping or
                       ;; failing `:rf.error/missing-required-cofx`.
                       cofx        (vec (:cofx final-state))
-                      ;; rf2-12f2q — the captured event vectors cross the
+                      ;; The captured event vectors cross the
                       ;; AI/off-box boundary in BOTH the `:captured` slot
                       ;; and the `:play-snippet` text. A recorded event can
                       ;; carry a declared-sensitive value in its payload (an
@@ -338,7 +331,7 @@
                       ;; --allow-writes, not a wire egress) so replay keeps
                       ;; full fidelity.
                       wire-events (egress/scrub-frame-value events vk incl?)
-                      ;; rf2-l2cn5d (EP-0017): the captured `:rf.cofx` maps are
+                      ;; EP-0017: the captured `:rf.cofx` maps are
                       ;; value-bearing and cross the wire in the rendered snippet
                       ;; (and, for parity with the events, conceptually in
                       ;; `:captured`). Value-redact each captured-cofx leaf the
@@ -379,7 +372,7 @@
                          "2. With write-back (gate must be open): {:variant-id \":story.cart/full\" :duration-ms 1000 :write-back true :new-variant-id \":story.cart/recorded\"} -> {... :written-back? true :new-variant-id :story.cart/recorded}. "
                          "3. Duration too long: {:variant-id \":story.cart/full\" :duration-ms 60000} -> {:isError true :content [{:text \":duration-ms 60000 exceeds ceiling 30000ms...\"}] :structuredContent {:rf.error :rf.story-mcp/duration-ms-too-large :duration-ms 60000 :max-allowed 30000}}.")
     :typicalTokens  1500
-    ;; rf2-90eft — `record-as-variant` ships a `:captured` vector of
+    ;; `record-as-variant` ships a `:captured` vector of
     ;; event tuples; when an agent records a repetitive interaction
     ;; (e.g. ten `:cart/add` events with the same SKU payload) the
     ;; argument maps repeat across records, and structural dedup

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
@@ -39,7 +39,7 @@
   "Canonical ordered vector of every tool the server exposes. Dev →
   docs → testing → write. The recorder bridge
   (`record-as-variant`) lives in `tools.recorder` for leaf-size
-  reasons (rf2-zkca8) but belongs at the tail of the write category
+  reasons but belongs at the tail of the write category
   per IMPL-SPEC §7.3 — `recorder/descriptors` is a one-element vec
   so the assembly stays symmetric across every category ns."
   (into [] cat [dev/descriptors
@@ -49,7 +49,7 @@
                 recorder/descriptors]))
 
 ;; Load-time invariant: every registry entry MUST carry a positive-integer
-;; `:typicalTokens` hint (rf2-6sddv). The same shape is asserted by
+;; `:typicalTokens` hint. The same shape is asserted by
 ;; `typical-tokens-hint-on-every-tool` in the test corpus; pinning it at
 ;; load time lets `tool-descriptors` project a plain map literal without
 ;; a defensive `cond->` arm for the slot.
@@ -58,7 +58,7 @@
                 tool-registry)
         "tool-registry: every entry must carry positive-integer :typicalTokens")
 
-;; Load-time invariant (rf2-3l3be): every registry entry MUST carry an
+;; Load-time invariant: every registry entry MUST carry an
 ;; `:outputSchema` map describing the structuredContent payload shape.
 ;; mcp-builder canonical pattern: "Define outputSchema wherever possible
 ;; for structured responses." Asserted at load time so future tool
@@ -66,7 +66,7 @@
 (assert (every? (fn [t] (map? (:outputSchema t))) tool-registry)
         "tool-registry: every entry must carry an :outputSchema map (rf2-3l3be)")
 
-;; Load-time invariant (rf2-94p8q): every registry entry MUST carry an
+;; Load-time invariant: every registry entry MUST carry an
 ;; `:annotations` map advertising the MCP tool-annotation hints
 ;; (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`).
 ;; mcp_best_practices.md: agent hosts use these to auto-approve reads
@@ -77,7 +77,7 @@
 
 (def gated-input-keys
   "The input-property keys the DEFAULT `tools/list` profile gates off
-  behind an operator-only gate (rf2-qo3wvp). Today: `:include-sensitive`
+  behind an operator-only gate. Today: `:include-sensitive`
   — baked into six value-surfacing tools' descriptors at load time and
   stripped from the default wire surface by `strip-include-sensitive`
   when `--allow-sensitive-reads` is closed. As STRINGS (the
@@ -101,7 +101,7 @@
   `:include-sensitive`) from a tool's `:inputSchema` properties. The
   slot is baked into the descriptor at load time by
   `schemas/with-include-sensitive`; this fn runs at `tools/list` time
-  and removes it when the operator-only gate is closed (rf2-g9fje) so
+  and removes it when the operator-only gate is closed so
   the descriptor never advertises an opt-in the server is configured
   to ignore. Idempotent: tools whose schema never carried a gated slot
   are returned unchanged."
@@ -116,7 +116,7 @@
   MCP spec also allows a `title` field; we omit it (the names are
   already human-readable dash-separated forms).
 
-  `typicalTokens` (rf2-6sddv) is an informational hint — an integer
+  `typicalTokens` is an informational hint — an integer
   ballpark of the response payload size in tokens. AI clients use it
   to budget calls and pick size-conscious args without trial-and-error.
   Not a cap (the host enforces real budgets elsewhere); a hint only.
@@ -126,7 +126,7 @@
   assertion below, so the projection is a plain map literal rather
   than a defensive `cond->`.
 
-  ## Sensitive-read gate (rf2-g9fje)
+  ## Sensitive-read gate
 
   The `:include-sensitive` slot is stripped from every tool's input
   schema when the operator-only gate (`config/sensitive-reads-allowed?`)
@@ -145,18 +145,18 @@
                      :inputSchema   (cond-> inputSchema
                                       strip? strip-include-sensitive)
                      :typicalTokens typicalTokens}
-              ;; rf2-3l3be — surface :outputSchema when declared. Lifted
+              ;; Surface :outputSchema when declared. Lifted
               ;; via cond-> so omission is forward-compatible (e.g. a
               ;; future tool with no structured response).
               (some? outputSchema) (assoc :outputSchema outputSchema)
-              ;; rf2-94p8q — surface :annotations when declared. Agent
+              ;; Surface :annotations when declared. Agent
               ;; hosts read these to auto-approve reads and gate
               ;; destructive ops behind a confirmation ceremony.
               (some? annotations)  (assoc :annotations annotations)))
           tool-registry)))
 
 (defonce ^:private tool-by-name-index
-  ;; `defonce` (rf2-xa1oc) so a REPL `(require ... :reload)` of this ns
+  ;; `defonce` so a REPL `(require ... :reload)` of this ns
   ;; does NOT re-bind the index out from under callers that captured
   ;; the old map. The registry shape is frozen at load time
   ;; (`tool-registry` is a `def`), so re-binding adds nothing —

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.story-mcp.tools.result
-  "Result-envelope builders for MCP `tools/call` responses (rf2-8yvyp,
-  split out of the former `tools.helpers`).
+  "Result-envelope builders for MCP `tools/call` responses.
 
   `text-result` and `error-result` shape the MCP `tools/call` response
   envelope. The success / error split matches MCP §Error Handling — an
@@ -39,9 +38,9 @@
   `pr-edn`-stringified EDN in the `:content` text slot and the raw map
   in `:structuredContent`. The canonical success envelope for every
   data-returning story-mcp handler — `(edn-result payload)` is the dual-
-  coded `(text-result (pr-edn payload) payload)` pair the handlers
-  shared at fifteen call sites (rf2-jkake.20), named once so each
-  handler reads as 'return this payload' rather than re-spelling the
+  coded `(text-result (pr-edn payload) payload)` pair every handler
+  shares, named once so each handler reads as 'return this payload'
+  rather than re-spelling the
   stringify-into-text-plus-same-map-as-structured dance.
 
   The two slots are dual-coded on purpose (per `wire-pipeline`): the

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
@@ -13,10 +13,10 @@
 
 (def max-tokens-schema
   "Recurring fragment — every tool accepts a per-call `:max-tokens`
-  override of the wire-boundary cap (rf2-rvyzy / rf2-zavp5). `0`
+  override of the wire-boundary cap. `0`
   disables the cap; default is
   `re-frame.mcp-base.overflow/default-max-tokens` (5000). A NEGATIVE
-  value is rejected (rf2-5rdit): `:minimum 0` constrains it at
+  value is rejected: `:minimum 0` constrains it at
   schema-validating hosts, and the wire-egress backstop surfaces a
   `{:rf.mcp/invalid-arg {...}}` `isError` result for hosts that don't
   validate."
@@ -25,8 +25,8 @@
 
 (def dedup-schema
   "Recurring fragment — every tool accepts a per-call `:dedup` opt-out
-  of the wire-boundary structural-dedup transform (rf2-90eft, mirroring
-  re-frame2-pair-mcp's rf2-obpa9). Default `true`.
+  of the wire-boundary structural-dedup transform (mirroring
+  re-frame2-pair-mcp's `:dedup`). Default `true`.
 
   When deduped, the response's `:structuredContent` slot is wrapped as
   `{:rf.mcp/dedup-table <cache-map>}` and the agent host reconstructs
@@ -37,8 +37,7 @@
   Cross-MCP convention with re-frame2-pair-mcp's `:dedup` arg (same
   default, same wire shape, same opt-out semantics). The key is
   `:dedup` (no `?`) per the Anthropic
-  `^[a-zA-Z0-9_.-]{1,64}$` input-schema property-name regex
-  (rf2-pmwgn)."
+  `^[a-zA-Z0-9_.-]{1,64}$` input-schema property-name regex."
   {:type "boolean"
    :description (str "Apply structural dedup (day8/de-dupe) to the "
                      "response payload before the wire-cap check. "
@@ -53,14 +52,14 @@
 (def include-sensitive-schema
   "Recurring fragment — every tool that surfaces a live `:app-db`
   slice or assertion accumulator accepts the cross-MCP
-  `:include-sensitive` opt-in (rf2-73wuj). Default false:
+  `:include-sensitive` opt-in. Default false:
   declared-sensitive paths land `:rf/redacted` via `elide-wire-value`,
   and assertion records stamped `:sensitive? true` are dropped via
   `strip-sensitive`. Pass true to forward the raw values; per the
   cross-MCP convention from `re-frame.mcp-base.sensitive`.
 
   Honoured only when the server was started with
-  `--allow-sensitive-reads` (rf2-g9fje). When that operator-only gate
+  `--allow-sensitive-reads`. When that operator-only gate
   is closed, the slot is omitted from `tools/list` advertisements (so
   agents don't even see it) and any caller-supplied value is silently
   ignored at egress.
@@ -73,15 +72,14 @@
   Clojure idiom belongs on the predicate, not on the data key whose
   wire form disallows it).
 
-  This is the canonical rule for the **input-schema property side**
-  (rf2-pmwgn): every boolean tool input property MUST omit the
+  This is the canonical rule for the **input-schema property side**:
+  every boolean tool input property MUST omit the
   trailing `?` (today: `:include-sensitive` and `:write-back`).
   Response-payload keys (in `structuredContent`) are NOT bound by the
   Anthropic regex and retain the Clojure-idiomatic `?` — that's why
   `:registered?`, `:unregistered?`, `:written-back?`, `:has-wrap?`
-  survive on the response side. (The run/read tools' `:passing?` boolean
-  was retired in the unified-run-result clean break — rf2-ba86n.17; the
-  verdict is now the `?`-free `:status`.)"
+  carry the `?` on the response side. (The run/read tools' verdict is the
+  `?`-free `:status`, not a `:passing?` boolean.)"
   {:type "boolean"
    :description (str "Opt in to forwarding sensitive `:app-db` slots and "
                      "assertion records. Default false (declared-sensitive paths "
@@ -100,9 +98,9 @@
   "Inject the `:dedup` slot into a tool's `:properties` map. Applied
   only to tools whose descriptor carries `:dedup-eligible? true` —
   the surfaces where repeated subtrees dominate the wire cost
-  (`preview-variant`, `run-variant`, `record-as-variant`). Per
-  rf2-90eft and mirroring pair-mcp's selective `dedup-property`
-  assignment in `descriptors_data.cljs`.
+  (`preview-variant`, `run-variant`, `record-as-variant`). Mirrors
+  pair-mcp's selective `dedup-property` assignment in
+  `descriptors_data.cljs`.
 
   Tools that don't carry the slot ignore any caller-supplied
   `:dedup` value at the dispatch boundary
@@ -112,7 +110,7 @@
   (assoc props :dedup dedup-schema))
 
 ;; ---------------------------------------------------------------------------
-;; Pagination schema fragments (rf2-76sf6)
+;; Pagination schema fragments
 ;;
 ;; spec/Principles.md §'Tight token budget' MUST: every read tool whose
 ;; return size is a function of registry size MUST accept `:limit` and
@@ -147,7 +145,7 @@
                      ":rf.mcp/cursor-stale; drop the cursor and restart.")})
 
 ;; ---------------------------------------------------------------------------
-;; Lifecycle timeout schema fragment (rf2-ovmc5e)
+;; Lifecycle timeout schema fragment
 ;;
 ;; `run-variant` and `preview-variant` both block on the SAME
 ;; `story/run-variant` lifecycle. They MUST advertise the same `:timeout-ms`
@@ -161,8 +159,8 @@
 
 (def timeout-ms-schema
   "Recurring fragment — the lifecycle tools (`run-variant`,
-  `preview-variant`) accept a per-call `:timeout-ms` blocking ceiling
-  (rf2-g9fje / rf2-ovmc5e). The MCP server's request loop is
+  `preview-variant`) accept a per-call `:timeout-ms` blocking ceiling.
+  The MCP server's request loop is
   single-threaded, so an unbounded blocking deref on one call parks every
   unrelated call. Caller values above the hard ceiling clamp DOWN rather
   than reject. Bounds + default mirror `tools.args/max-timeout-ms` /
@@ -179,7 +177,7 @@
   "Inject the `:timeout-ms` slot into a lifecycle tool's `:properties`
   map. Applied to the two tools that block on the `story/run-variant`
   lifecycle (`run-variant`, `preview-variant`) so both advertise the same
-  tunable, capped blocking ceiling (rf2-ovmc5e). The runtime resolver
+  tunable, capped blocking ceiling. The runtime resolver
   `targs/resolve-timeout-ms` reads the same shared constants, so the
   advertised schema and the runtime policy stay in lockstep."
   [props]
@@ -188,7 +186,7 @@
 (defn with-pagination
   "Inject `:limit` and `:cursor` slots into a tool's `:properties`
   map. Used by every Docs `list-*` tool per spec/Principles.md
-  §'Tight token budget' (rf2-76sf6).
+  §'Tight token budget'.
 
   The `get-*` tools (`get-story`, `get-variant`, `get-docs-markdown`,
   `variant->edn`) are NOT paginated — their return is a single record
@@ -211,7 +209,7 @@
 
   The slot is baked into the static descriptor at load time and
   stripped at `tools/list` time by `registry/tool-descriptors` when the
-  server's `--allow-sensitive-reads` gate is closed (rf2-g9fje) — so a
+  server's `--allow-sensitive-reads` gate is closed — so a
   closed gate hides the opt-in from agents entirely, and an open gate
   surfaces it verbatim.
 
@@ -222,10 +220,10 @@
   (assoc props :include-sensitive include-sensitive-schema))
 
 ;; ---------------------------------------------------------------------------
-;; outputSchema fragments (rf2-3l3be)
+;; outputSchema fragments
 ;;
 ;; Story-mcp tools route through `result/text-result` / `error-result`,
-;; both of which emit a dual-slot envelope (rf2-vw4sq) — `:content` plus
+;; both of which emit a dual-slot envelope — `:content` plus
 ;; `:structuredContent`. The structuredContent slot carries the EDN
 ;; payload as a JS-coerced object; this fragment describes its shape so
 ;; agent hosts can validate the result client-side.
@@ -245,7 +243,7 @@
   Permissive (`additionalProperties: true`) so per-tool payload slots
   ride without us re-enumerating them; the catalogue prose carries
   the per-tool shape definitively. The wire-bounded `:rf.mcp/overflow`
-  marker (rf2-rvyzy) lands as an extra top-level key when the cap
+  marker lands as an extra top-level key when the cap
   fires; it satisfies `additionalProperties` and is documented in
   prose rather than encoded as a `oneOf` alternative (the MCP
   outputSchema contract pins `type` to the literal \"object\" and
@@ -264,7 +262,7 @@
                      "the cap step fires. See spec/002-Tool-Registry.md for the per-tool payload shape.")})
 
 ;; ---------------------------------------------------------------------------
-;; Tool annotations (rf2-94p8q)
+;; Tool annotations
 ;;
 ;; MCP `tools/list` advertises per-tool annotation hints so agent hosts
 ;; (Claude Code, Continue, …) can auto-approve reads and gate writes
@@ -272,17 +270,17 @@
 ;; `destructiveHint`, `idempotentHint`, `openWorldHint` — per
 ;; mcp_best_practices.md.
 ;;
-;; Story-mcp matrix (per the bead rf2-94p8q, refined per rf2-8h778):
+;; Story-mcp matrix:
 ;;
 ;;   - READ-ONLY tools: get-story-instructions, list-substrates,
 ;;     list-stories, get-story, get-variant, list-tags, list-modes,
 ;;     list-decorators, list-assertions, get-docs-markdown, variant->edn,
-;;     explain-variant (rf2-ba86n.17), snapshot-identity, read-a11y-violations,
+;;     explain-variant, snapshot-identity, read-a11y-violations,
 ;;     read-failures.
 ;;
 ;;   - DESTRUCTIVE tools: preview-variant (dispatches events into a
 ;;     variant's frame via the same `story/run-variant` lifecycle as
-;;     run-variant — rf2-8h778), run-variant, register-variant,
+;;     run-variant), run-variant, register-variant,
 ;;     unregister-variant, record-as-variant.
 ;; ---------------------------------------------------------------------------
 
@@ -310,7 +308,7 @@
   spec/Tool-Pair.md §Direct-read privacy posture the run is a write
   to the runtime, so `:destructiveHint true`.
 
-  ## Open-world (rf2-e6knrq finding 2)
+  ## Open-world
 
   `:openWorldHint true`. The events / fx these tools fire are the
   variant author's — `:setup` / `:script` event sequences run through
@@ -338,10 +336,9 @@
   writes the captured snippet to the on-box registry; the tool call
   itself does not run the variant lifecycle.
 
-  rf2-8h778: `preview-variant` originally shipped with
-  `read-only-annotations`; the audit (rf2-3pn6c Finding #2) caught
-  the asymmetry — both tools call `(story/run-variant vk opts)` and
-  derive their result from the lifecycle outcome. The annotations
+  `preview-variant` carries these destructive annotations, not
+  `read-only-annotations` — both tools call `(story/run-variant vk opts)`
+  and derive their result from the lifecycle outcome. The annotations
   must match the side-effect surface, not the verb gloss
   (`preview-variant`'s rendered URL output) at the wire."
   {:destructiveHint true

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -3,7 +3,7 @@
   `read-a11y-violations`, `read-failures`. Per IMPL-SPEC §7.2 these
   execute (or inspect the post-execution state of) variants.
 
-  ## Unified run-result mirror (rf2-ba86n.17)
+  ## Unified run-result mirror
 
   `run-variant` and `read-failures` speak the SAME unified
   `re-frame.story.result/run-result` model the human Story UI reads
@@ -15,18 +15,16 @@
   `:sub-runs` / `:renders` / `:narrative`). There is NO agent-only result
   vocabulary — the agent reads off the same verdict a human reads.
 
-  The pre-unification flat shape (`:passing?` / `:lifecycle` / a flat
-  `:assertions` vector) was REMOVED outright (pre-alpha clean break, Mike
-  2026-05-31): `:status` is the verdict; `:passing?` is gone (it could not
-  express the distinct `:cannot-run` third status, and re-derived a
-  green/red bit the result unification existed to fold out).
+  `:status` is the single verdict — it expresses the distinct
+  `:cannot-run` third status that a flat green/red `:passing?` bit
+  cannot, which is why the result vocabulary carries no such bit.
   `story/run-variant` already assembles the unified shape through
   `result/run-result`; these handlers project its slots rather than
   re-deriving a parallel verdict.
 
   Wire-egress posture: `run-variant` and `read-failures` route their
   `:app-db` / `:assertions` slots through
-  `re-frame.story-mcp.tools.egress` (rf2-73wuj)."
+  `re-frame.story-mcp.tools.egress`."
   (:require [re-frame.story :as story]
             [re-frame.story.async :as async]
             [re-frame.story-mcp.tools.args :as targs]
@@ -51,11 +49,9 @@
   `re-frame.story.result/run-result`; this handler projects its slots
   (scrubbing the value-bearing ones at egress) — it does NOT re-derive a
   parallel verdict. The headline an agent reads is the top-level
-  `:status` ∈ `#{:pass :fail :cannot-run :error}` (rf2-ba86n.17 clean
-  break — the old `:passing?` boolean / `:lifecycle` verdict were
-  removed; `:status` is the one verdict, and only it can express the
-  distinct `:cannot-run` third outcome an agent must handle as 'the
-  runner could not attempt this', NOT as a fail).
+  `:status` ∈ `#{:pass :fail :cannot-run :error}` — the one verdict, and
+  only it can express the distinct `:cannot-run` third outcome an agent
+  must handle as 'the runner could not attempt this', NOT as a fail.
 
   Payload slots:
     :status             #{:pass :fail :cannot-run :error} — the verdict
@@ -68,7 +64,7 @@
     :schema-violations / :warnings / :effects / :sub-runs / :renders /
     :narrative          the .4 evidence-slot projections (one tape, one
                         projection); ALL value-bearing — each is
-                        value-redacted at egress (rf2-j90sb: :narrative's
+                        value-redacted at egress (:narrative's
                         per-beat :db-before/:db-after, :warnings trace
                         events, :sub-runs sub :value all carry app-db
                         slices that would otherwise ship sensitive
@@ -86,11 +82,11 @@
     :active-modes   optional — coll of mode ids
     :cell-overrides optional — map of arg overrides
     :timeout-ms     optional — JVM blocking timeout; default 10000;
-                               clamped to `max-timeout-ms` (30000) per
-                               rf2-g9fje so one slow request can't park
-                               the single-threaded stdio loop.
+                               clamped to `max-timeout-ms` (30000) so one
+                               slow request can't park the single-threaded
+                               stdio loop.
     :include-sensitive optional — opt out of wire-egress redaction
-                                  (default false; rf2-73wuj)"
+                                  (default false)"
   [arguments]
   (targs/with-variant arguments
     (fn [vk _body]
@@ -126,14 +122,13 @@
                               ;; value-redacted against the frame's declared-
                               ;; sensitive values, same as :rendered-hiccup —
                               ;; a secret reappears there at a non-app-db path
-                              ;; the path walker can't reach (rf2-ee38b.17).
+                              ;; the path walker can't reach.
                               ;; :narrative is a two-level evidence tree whose
                               ;; inner beats carry :db-before/:db-after FULL
                               ;; app-db snapshots; :warnings are trace-event
                               ;; records; :sub-runs carry subscription :value —
                               ;; all three egressed RAW would ship a declared-
-                              ;; sensitive value off-box verbatim (rf2-j90sb,
-                              ;; sibling of pair-mcp's rf2-6wvh5). scrub-rendered
+                              ;; sensitive value off-box verbatim. scrub-rendered
                               ;; recurses the nested trees and the gate stays
                               ;; symmetric (incl? true forwards raw).
                               :schema-violations  (egress/scrub-rendered (:schema-violations outcome) raw-db vk incl?)
@@ -143,7 +138,7 @@
                               :renders            (egress/scrub-rendered (:renders outcome) raw-db vk incl?)
                               :narrative          (egress/scrub-rendered (:narrative outcome) raw-db vk incl?)
                               ;; Derived trees re-key the same sensitive value
-                              ;; at a non-app-db path — value-redact (rf2-ee38b.17).
+                              ;; at a non-app-db path — value-redact.
                               :rendered-hiccup    (egress/scrub-rendered (:rendered-hiccup outcome) raw-db vk incl?)
                               :elapsed-ms         (:elapsed-ms outcome)
                               :snapshot           (egress/scrub-rendered (:snapshot outcome) raw-db vk incl?)}
@@ -152,7 +147,7 @@
                        ;; attempt some expectation.
                        (contains? outcome :cannot-run)
                        (assoc :cannot-run (:cannot-run outcome)))]
-        ;; Surface the MUST-level egress indicator counts (rf2-koq5m):
+        ;; Surface the MUST-level egress indicator counts:
         ;; dropped sensitive assertion records + elided over-threshold
         ;; leaves across every value-bearing slot. Omitted when zero
         ;; (Conventions §Cross-MCP indicator-field vocabulary).
@@ -198,7 +193,7 @@
   When the server is JVM-standalone (no co-hosted CLJS runtime) this
   returns an empty result with a hint.
 
-  ## Wire-egress posture (rf2-q8ebq.2)
+  ## Wire-egress posture
 
   The `:violations` vec is LIVE RUNTIME observed state — the rendered DOM
   of the variant frame, normalised from axe-core's JS violation objects.
@@ -243,14 +238,14 @@
   inspect failures without re-running.
 
   The records ride the SAME unified shape `run-variant` emits
-  (spec/017 §Run result, rf2-ba86n.17): each record is normalized through
+  (spec/017 §Run result): each record is normalized through
   `re-frame.story/assertion-records` so it carries a derived
   `:status`, and the headline `:status` is the aggregate verdict over the
   records (`re-frame.story/aggregate-verdict` — the ONE rule:
-  `:error` > `:fail` > `:cannot-run` > `:pass`). The clean break removed
-  the re-derived `:passing?` boolean; `:status` is the one verdict, read
-  off the records rather than recomputed as a green/red bit. `:failures`
-  is filtered to the genuine failure statuses (`:fail` / `:error`) — a
+  `:error` > `:fail` > `:cannot-run` > `:pass`). `:status` is the one
+  verdict, read off the records rather than recomputed as a green/red bit.
+  `:failures` is filtered to the genuine failure statuses (`:fail` /
+  `:error`) — a
   `:cannot-run` record is not a failure (the runner proved nothing) and
   surfaces via the run-level `:status`, not the failures list.
 
@@ -260,7 +255,7 @@
   status is the assertion-record aggregate only; for the full run verdict
   (tape floor + refusals) re-run via `run-variant`.
 
-  Wire-egress posture (rf2-73wuj): assertion records carrying the
+  Wire-egress posture: assertion records carrying the
   top-level `:sensitive? true` stamp are dropped via `strip-sensitive`.
   The `:status` aggregate runs against the scrubbed vec so the agent's
   view of the verdict is consistent with the records it actually sees — a
@@ -281,7 +276,7 @@
                         :total      (count records)
                         :failures   failures
                         :assertions records}]
-        ;; Surface the MUST-level egress indicator counts (rf2-koq5m):
+        ;; Surface the MUST-level egress indicator counts:
         ;; how many sensitive assertion records were dropped at egress
         ;; (+ any elided leaves). Omitted when zero (Conventions
         ;; §Cross-MCP indicator-field vocabulary).
@@ -302,7 +297,7 @@
                          "3. Cannot-run (a causal assertion under a non-reactive runner): {:variant-id \":story.cart/caused\"} -> {:status :cannot-run :cannot-run [...] :assertions [{:status :cannot-run :cannot-run? true ...}]}. "
                          "4. Clamped timeout / error: {:variant-id \":story.slow/loader\" :timeout-ms 60000} -> runs with timeout clamped to 30000ms (max-timeout-ms ceiling); on overrun returns {:status :error :assertions [{:assertion :rf.error/run-failed :status :error ...}]}.")
     :typicalTokens  2000
-    ;; rf2-90eft — `run-variant` ships the variant's `:app-db` re-keyed
+    ;; `run-variant` ships the variant's `:app-db` re-keyed
     ;; into `:rendered-hiccup` and `:snapshot`; structural dedup
     ;; collapses those three references into one cache slot at the wire
     ;; boundary. Mirrors pair-mcp's selective `:dedup` knob on

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.story-mcp.tools.wire-pipeline
-  "Dispatcher + wire-boundary structural-dedup + token-budget cap
-  (rf2-rvyzy / rf2-zavp5 / rf2-eyelu / rf2-90eft).
+  "Dispatcher + wire-boundary structural-dedup + token-budget cap.
 
   Per `spec/Cross-Cutting-Designs.md §3 Token budgets` every MCP
   `tools/call` response is bounded at ~5,000 tokens by default. The cap
@@ -10,18 +9,18 @@
   exceed the cap, the payload is replaced with a structured
   `{:rf.mcp/overflow {...}}` marker.
 
-  ## Pipeline ordering (rf2-90eft mirroring pair-mcp's rf2-rvyzy → rf2-obpa9)
+  ## Pipeline ordering
 
   Two transforms compose at the wire boundary, in this order:
 
-  1. **Structural dedup** (`tools.dedup/dedup-value`, rf2-90eft) for
-     tools that opt in via `:dedup-eligible?` on the descriptor. The
+  1. **Structural dedup** (`tools.dedup/dedup-value`) for tools that opt
+     in via `:dedup-eligible?` on the descriptor. The
      `:structuredContent` slot is run through `day8/de-dupe` to
      collapse repeated subtrees into a flat cache map. Wrapped under
      `{:rf.mcp/dedup-table <cache>}`. The `:content[*].text` slot is
      re-stringified to match — both slots ride the same payload.
 
-  2. **Token-cap** (`re-frame.mcp-base.cap/apply-cap`, rf2-rvyzy). The
+  2. **Token-cap** (`re-frame.mcp-base.cap/apply-cap`). The
      deduped payload is sized; if still over the per-call cap, the
      payload is replaced with a `{:rf.mcp/overflow ...}` marker.
 
@@ -50,10 +49,10 @@
 
   ## Pipeline ownership
 
-  The cap-enforcement ALGORITHM lives in `re-frame.mcp-base.cap`
-  (rf2-eyelu) — token-summing across `:text` slots, comparing against
-  the per-call cap, and building the overflow result. This ns supplies
-  the per-server specialisation:
+  The cap-enforcement ALGORITHM lives in `re-frame.mcp-base.cap` —
+  token-summing across `:text` slots, comparing against the per-call
+  cap, and building the overflow result. This ns supplies the
+  per-server specialisation:
 
   - `result-io` reifies `mcp-base.cap/ResultIO` over the story-mcp
     result shape (`{:content [...] :structuredContent ...}` CLJ maps).
@@ -103,7 +102,7 @@
   agent client that prefers JSON data reads it directly without
   re-parsing the text).
 
-  HOT PATH (rf2-mzndx): `text-result` writes the same payload into BOTH
+  HOT PATH: `text-result` writes the same payload into BOTH
   `:content[*].text` AND `:structuredContent` on nearly every structured
   tool (`preview-variant`, `run-variant`, `list-stories`, `get-story`,
   `get-variant`, `read-failures`, `record-as-variant`, `get-docs-markdown`).
@@ -133,7 +132,7 @@
   `:structuredContent` slot is the structured JSON projection (agent
   hosts that prefer JSON data read it directly) and the
   `:content[*].text` slot is the `pr-str`-ed EDN (agent hosts that
-  prefer text read it). Per `cap/result-io` (rf2-mzndx) the cap
+  prefer text read it). Per `cap/result-io` the cap
   pipeline sums BOTH slots — if we deduped only `:structuredContent`
   the text slot would still ship the raw EDN at full size, and the
   cap would fire on a payload the agent only sees once. Re-stringifying
@@ -178,26 +177,26 @@
 
 (defn- unknown-arg-error
   "Build the tool-level `isError: true` diagnostic for unknown top-level
-  argument keys (rf2-ovmc5e / rf2-an95jj). `unknown` is the vec of RAW key
-  STRINGS the caller sent outside the tool's allowed set; `t` is the tool
-  descriptor. The result names the unknown keys, the tool, and that tool's
-  allowed key set — so a non-schema-validating host or hand-rolled agent
-  gets agent-recoverable feedback that its intended control knob was
-  ignored rather than a successful-looking call that silently defaulted.
-  The server is the authoritative backstop for the advertised
-  `additionalProperties false` contract; it no longer depends on the
-  client validating.
+  argument keys. `unknown` is the vec of RAW key STRINGS the caller sent
+  outside the tool's allowed set; `t` is the tool descriptor. The result
+  names the unknown keys, the tool, and that tool's allowed key set — so
+  a non-schema-validating host or hand-rolled agent gets
+  agent-recoverable feedback that its intended control knob was ignored
+  rather than a successful-looking call that silently defaulted. The
+  server is the authoritative backstop for the advertised
+  `additionalProperties false` contract, independent of whether the
+  client validates.
 
   Two call sites feed this builder, differing only in WHERE the unknown
   keys came from:
 
-  - rf2-ovmc5e — keys outside the GLOBAL `protocol/arg-keys` allowlist
-    (raw strings dropped + recorded as metadata at frame normalisation).
-  - rf2-an95jj — keys inside the global allowlist (so they survived
-    normalisation as keyword ENTRIES) but outside THIS tool's advertised
-    `inputSchema` properties (e.g. `:body` on `get-variant`,
-    `:write-back` on `run-variant`). Reported as their `name`-stringified
-    form so the diagnostic shape matches the global-unknown case."
+  - Keys outside the GLOBAL `protocol/arg-keys` allowlist (raw strings
+    dropped + recorded as metadata at frame normalisation).
+  - Keys inside the global allowlist (so they survived normalisation as
+    keyword ENTRIES) but outside THIS tool's advertised `inputSchema`
+    properties (e.g. `:body` on `get-variant`, `:write-back` on
+    `run-variant`). Reported as their `name`-stringified form so the
+    diagnostic shape matches the global-unknown case."
   [tool-name t unknown]
   (let [allowed (tool-allowed-arg-keys t)]
     (result/error-result
@@ -213,8 +212,8 @@
 (def ^:private wire-managed-arg-keys
   "Cross-cutting argument keys CONSUMED at the wire boundary
   (`invoke-tool`) rather than by a tool handler — so the per-tool schema
-  check (rf2-an95jj) must tolerate them on EVERY tool even when a given
-  tool's descriptor doesn't advertise them.
+  check must tolerate them on EVERY tool even when a given tool's
+  descriptor doesn't advertise them.
 
   - `:max-tokens` is injected on every tool (`schemas/with-max-tokens`),
     so it is always in the advertised set; listed here only for symmetry
@@ -229,8 +228,8 @@
   #{:max-tokens :dedup})
 
 (defn- tool-invalid-arg-keys
-  "rf2-an95jj — the keyword arg keys in `args` that are GLOBALLY known
-  (they survived `protocol/normalize-frame` as keyword entries against
+  "The keyword arg keys in `args` that are GLOBALLY known (they survived
+  `protocol/normalize-frame` as keyword entries against
   `protocol/arg-keys`) but are NOT valid for the SELECTED tool `t`: not
   in the tool's advertised `inputSchema` properties AND not a
   wire-managed cross-cutting knob (`wire-managed-arg-keys`). Returns the
@@ -241,9 +240,10 @@
   `additionalProperties false` contract at the PER-TOOL granularity: the
   global normalisation only rejects keys outside the UNION of every
   tool's args, so a key valid for ANOTHER tool (`:body`, `:write-back`,
-  `:dedup` on a non-eligible tool) used to survive and be silently
-  ignored. No-intern is preserved — every key here is already an interned
-  keyword (it passed the global allowlist), so `name` mints nothing."
+  `:dedup` on a non-eligible tool) is caught here rather than slipping
+  through to be silently ignored. No-intern is preserved — every key
+  here is already an interned keyword (it passed the global allowlist),
+  so `name` mints nothing."
   [t args]
   (let [advertised (set (-> t :inputSchema :properties keys))]
     (->> (keys args)
@@ -254,16 +254,16 @@
          vec)))
 
 (defn- cap-error
-  "rf2-p0eiq3 — route a pre-dispatch error envelope through the SAME
-  wire-boundary token cap (`base-cap/apply-cap`) that bounds every normal
-  tool response. Per `spec/Principles.md §Tight token budget`, EVERY MCP
-  tool response is bounded, error results included — but the
+  "Route a pre-dispatch error envelope through the SAME wire-boundary
+  token cap (`base-cap/apply-cap`) that bounds every normal tool
+  response. Per `spec/Principles.md §Tight token budget`, EVERY MCP tool
+  response is bounded, error results included — including the
   pre-dispatch rejection branches (`unknown-arg-error`, the
   invalid-`:max-tokens` rejection, the per-tool unknown-argument
-  diagnostic) used to return directly, BEFORE the cap. A caller can pack
-  many long unknown keys inside the 4 MB frame cap and receive an
-  UNCAPPED diagnostic echoing them all back — violating the response-cap
-  contract. Capping these envelopes closes that.
+  diagnostic). Without this, a caller could pack many long unknown keys
+  inside the 4 MB frame cap and receive an UNCAPPED diagnostic echoing
+  them all back — violating the response-cap contract. Capping these
+  envelopes closes that.
 
   `cap` is the resolved per-call cap (the output of `base-cap/max-tokens`):
   an integer ceiling, `nil` (caller disabled the cap with `:max-tokens 0`),
@@ -288,22 +288,21 @@
   Returns the tool's result map, or nil if no such tool. The caller
   serialises the result into a `tools/call` JSON-RPC response.
 
-  ## Wire-boundary pipeline (rf2-90eft)
+  ## Wire-boundary pipeline
 
   1. Dispatch the handler with `arguments`.
-  2. `apply-dedup` (rf2-90eft) — selective: runs only when the
-     descriptor carries `:dedup-eligible? true` AND the `:dedup` arg
-     is true (the default). Today the eligible set is
+  2. `apply-dedup` — selective: runs only when the descriptor carries
+     `:dedup-eligible? true` AND the `:dedup` arg is true (the default).
+     The eligible set is
      `{preview-variant, run-variant, record-as-variant}` — the three
      surfaces where repeated subtrees dominate the wire cost. The
      `:structuredContent` slot is run through `day8/de-dupe` to
      collapse repeated subtrees, and the `:content[*].text` slot is
      re-stringified to match. Per `tools.dedup`.
-  3. `base-cap/apply-cap` (rf2-rvyzy / rf2-zavp5 / rf2-eyelu) — when
-     the (post-dedup) response exceeds the per-call cap (`:max-tokens`
-     arg, default `mcp-base.overflow/default-max-tokens`, `0`
-     disables), the payload is replaced with a structured
-     `{:rf.mcp/overflow ...}` marker. Per
+  3. `base-cap/apply-cap` — when the (post-dedup) response exceeds the
+     per-call cap (`:max-tokens` arg, default
+     `mcp-base.overflow/default-max-tokens`, `0` disables), the payload
+     is replaced with a structured `{:rf.mcp/overflow ...}` marker. Per
      `spec/Cross-Cutting-Designs.md §3 Token budgets`.
 
   Ordering invariant: dedup BEFORE cap. Dedup shrinks the payload first
@@ -323,51 +322,50 @@
   (when-let [t (registry/tool-by-name tool-name)]
     (let [args    (or arguments {})
           cap     (base-cap/max-tokens (get args :max-tokens))
-          ;; rf2-ovmc5e — RAW string keys the caller sent outside the
-          ;; top-level allowlist, recorded as metadata by
+          ;; RAW string keys the caller sent outside the top-level
+          ;; allowlist, recorded as metadata by
           ;; `protocol/normalize-frame` (never interned, never a map
           ;; entry). A non-empty set means the agent typo'd a control
           ;; knob; we diagnose before dispatch rather than silently drop.
           unknown (get (meta args) proto/unknown-arg-keys-meta)
-          ;; rf2-an95jj — keys that ARE in the global allowlist (so they
-          ;; survived normalisation as keyword entries) but are NOT valid
-          ;; for THIS tool (e.g. `:body` on `get-variant`). The global
-          ;; check above only catches keys outside the UNION of every
-          ;; tool's args; this is the per-tool backstop.
+          ;; Keys that ARE in the global allowlist (so they survived
+          ;; normalisation as keyword entries) but are NOT valid for THIS
+          ;; tool (e.g. `:body` on `get-variant`). The global check above
+          ;; only catches keys outside the UNION of every tool's args;
+          ;; this is the per-tool backstop.
           tool-invalid (tool-invalid-arg-keys t args)]
       (cond
         (base-cap/invalid-arg? cap)
-        ;; rf2-5rdit — a negative `:max-tokens` resolves to a
+        ;; A negative `:max-tokens` resolves to a
         ;; `{:rf.mcp/invalid-arg {...}}` rejection rather than a negative
         ;; cap. Surface it as an `isError: true` tool-result so the agent
         ;; gets an actionable, recoverable error — NOT a silent lock-out
         ;; where the bad cap over-trips `apply-cap`'s `over-cap?` and
         ;; every response is replaced by the overflow marker. The handler
         ;; is never dispatched; the malformed cap never reaches the gate.
-        ;; rf2-p0eiq3 — the rejection envelope rides the response cap too
-        ;; (via the default cap, since the caller's cap was malformed).
+        ;; The rejection envelope rides the response cap too (via the
+        ;; default cap, since the caller's cap was malformed).
         (cap-error tool-name cap (result/error-result (result/pr-edn cap) cap))
 
-        ;; rf2-ovmc5e — an unknown top-level argument key is an
-        ;; agent-recoverable diagnostic, not a silent drop. The handler is
-        ;; never dispatched; the response names the unknown keys, the
-        ;; tool, and that tool's allowed key set so the model can retry
-        ;; with the corrected arg name. (The no-intern invariant holds —
-        ;; the unknown keys arrive as strings via metadata and are never
-        ;; keywordised.) rf2-p0eiq3 — the diagnostic rides the response
-        ;; cap so a caller packing many long unknown keys can't bypass
-        ;; the budget with an uncapped echo.
+        ;; An unknown top-level argument key is an agent-recoverable
+        ;; diagnostic, not a silent drop. The handler is never
+        ;; dispatched; the response names the unknown keys, the tool, and
+        ;; that tool's allowed key set so the model can retry with the
+        ;; corrected arg name. (The no-intern invariant holds — the
+        ;; unknown keys arrive as strings via metadata and are never
+        ;; keywordised.) The diagnostic rides the response cap so a
+        ;; caller packing many long unknown keys can't bypass the budget
+        ;; with an uncapped echo.
         (seq unknown)
         (cap-error tool-name cap (unknown-arg-error tool-name t unknown))
 
-        ;; rf2-an95jj — a globally-known but tool-invalid argument key is
-        ;; the per-tool backstop for each descriptor's
-        ;; `additionalProperties false` contract. A key valid for ANOTHER
-        ;; tool (`:body`, `:write-back`, `:dedup` on a non-eligible tool)
-        ;; would otherwise survive global normalisation and be silently
-        ;; ignored by the selected handler. Diagnose it with the same
-        ;; `:rf.story-mcp/unknown-arguments` shape before dispatch, capped
-        ;; per rf2-p0eiq3.
+        ;; A globally-known but tool-invalid argument key is the per-tool
+        ;; backstop for each descriptor's `additionalProperties false`
+        ;; contract. A key valid for ANOTHER tool (`:body`, `:write-back`,
+        ;; `:dedup` on a non-eligible tool) survives global normalisation;
+        ;; without this branch the selected handler would silently ignore
+        ;; it. Diagnose it with the same `:rf.story-mcp/unknown-arguments`
+        ;; shape before dispatch, capped on the same response cap.
         (seq tool-invalid)
         (cap-error tool-name cap (unknown-arg-error tool-name t tool-invalid))
 

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -8,8 +8,8 @@
   - `unregister-variant` — symmetric removal.
 
   The third write-surface tool, `record-as-variant` (the recorder
-  bridge, rf2-luhdu), lives in `re-frame.story-mcp.tools.recorder` —
-  it has enough body to warrant its own ns under the rf2-zkca8
+  bridge), lives in `re-frame.story-mcp.tools.recorder` —
+  it has enough body to warrant its own ns under the
   leaf-size ceiling. That ns exposes its own `descriptors` vec which
   `tools.registry/tool-registry` concatenates after `write/descriptors`
   so IMPL-SPEC §7.3 order survives the file split."
@@ -40,7 +40,7 @@
            "should leave it off.")
       {:gated true :tool tool-name})))
 
-;; ---- EDN reader hardening (rf2-g9fje, fix 2/3) ----------------------------
+;; ---- EDN reader hardening --------------------------------------------------
 ;;
 ;; `:body` arrives as either a JSON object (preferred — round-trippable map)
 ;; or an EDN string (legacy; needed because JSON has no native keyword type
@@ -50,8 +50,7 @@
 ;; variant via the EDN-string path — JSON's keyword-blind surface would
 ;; otherwise force a coercion pass the registrar isn't shaped for.
 ;;
-;; The hardening matches the rf2-uaymx audit's "if EDN strings must stay"
-;; remediation:
+;; The hardening posture for the retained EDN-string path:
 ;;
 ;;   1. Reject any tagged literal (`#<reader-tag> ...`) by setting both
 ;;      `:readers {}` (no custom tags admitted) AND `:default` to a
@@ -84,8 +83,8 @@
 
 (def ^:const ^:private max-body-string-keys
   "Hard ceiling on the TOTAL number of STRING keys across an object-form
-  `:body` tree, checked BEFORE `keywordize-body-keys` interns any of them
-  (rf2-tag30h). The depth cap alone bounds NESTING but not WIDTH: a single
+  `:body` tree, checked BEFORE `keywordize-body-keys` interns any of them.
+  The depth cap alone bounds NESTING but not WIDTH: a single
   shallow object with thousands of distinct unknown string keys would
   intern a fresh JVM keyword per key before the registrar's schema
   rejects the body. A legitimate variant body has a handful of top-level
@@ -116,7 +115,7 @@
 
 (defn- count-string-keys
   "Total count of STRING keys across the whole `v` tree — the keys
-  `keywordize-body-keys` would intern (rf2-tag30h). Walks maps (counting
+  `keywordize-body-keys` would intern. Walks maps (counting
   string keys and recursing into both keys and vals), vectors / lists /
   sets / seqs (recursing into elements). Already-keyword keys are not
   counted — they do not intern. Used to width-cap an object-form body
@@ -138,7 +137,7 @@
 
 (defn- read-edn-body
   "Parse an agent-supplied EDN string into a Clojure value with the
-  rf2-g9fje hardening posture. Returns the parsed value on success, or
+  EDN hardening posture. Returns the parsed value on success, or
   the `::edn-error` sentinel on failure (`coerce-body` maps it to an
   `error-result`):
 
@@ -177,8 +176,8 @@
 (defn- keywordize-body-keys
   "Recursively convert the STRING keys of an object-form `:body` (and
   its nested maps) into keywords, INTERNING as it goes. This is the
-  operator-gated write-path counterpart to the rf2-3luf3 no-intern
-  ingress: `protocol/parse-json` now parses the whole frame with string
+  operator-gated write-path counterpart to the no-intern
+  ingress: `protocol/parse-json` parses the whole frame with string
   keys, so the JSON object-form body arrives string-keyed. The
   registrar's variant schema demands keyword slots (`:doc` / `:args` /
   `:tags` / …), so this path re-keywordises the body — but the intern is
@@ -218,10 +217,10 @@
 
     `::edn-error` — `:body` was a string but `read-edn-body` threw or
                     the parsed value violated the size / depth /
-                    tagged-literal hardening (rf2-g9fje).
+                    tagged-literal hardening.
     `::not-a-map` — `:body` parsed (or was passed) but is not a map.
     `::too-wide`  — an object-form body carries more than
-                    `max-body-string-keys` total STRING keys (rf2-tag30h);
+                    `max-body-string-keys` total STRING keys;
                     rejected BEFORE `keywordize-body-keys` interns any of
                     them so a wide unknown-key body cannot grow the JVM
                     keyword table.
@@ -229,7 +228,7 @@
   Two input arms:
 
     - **Object-form body** (a JSON object) arrives STRING-keyed from
-      `protocol/parse-json` (rf2-3luf3 no-intern ingress). Its depth is
+      `protocol/parse-json` (no-intern ingress). Its depth is
       checked against `max-edn-depth`, then its keys are recursively
       keywordised via `keywordize-body-keys` — a bounded intern gated by
       `--allow-writes` (the handler reached this fn only past the
@@ -244,7 +243,7 @@
     (map? body)    (cond
                      (> (value-depth body) max-edn-depth)
                      ::edn-error
-                     ;; rf2-tag30h: width cap BEFORE interning. The depth
+                     ;; Width cap BEFORE interning. The depth
                      ;; cap bounds nesting but not the number of distinct
                      ;; string keys a shallow object can carry; a wide body
                      ;; would intern a fresh keyword per key here.
@@ -308,22 +307,19 @@
                        "abusive wide objects before keywordising.")
                   {:rf.error :rf.story-mcp/body-too-wide})
 
-                ;; rf2-lqjbk write-side exception: `register-variant`
+                ;; Write-side keyword exception: `register-variant`
                 ;; by definition extends the registry with a fresh
                 ;; keyword id, so `safe-keyword` against an existing
                 ;; bounded set would always reject. The intern here is
                 ;; gate-bounded by `--allow-writes` (operator-only opt-in).
                 ;;
-                ;; rf2-tag30h: validate the `:story.<path>/<name>` grammar
+                ;; Validate the `:story.<path>/<name>` grammar
                 ;; on the STRING shape via `fresh-keyword-checked` BEFORE
-                ;; interning. `fresh-keyword` interned first and let the
-                ;; registrar's downstream `assert-id!` reject on grammar —
-                ;; but that reject happened AFTER the intern, so an invalid
-                ;; id (which correctly returns an error) still permanently
-                ;; grew the JVM keyword table. The pre-intern shape check
-                ;; (`story/valid-variant-id?`, single-sourced with the
-                ;; registrar's keyword-level `variant-id?`) fails closed with
-                ;; no intern.
+                ;; interning, so an invalid id (which correctly returns an
+                ;; error) never permanently grows the JVM keyword table. The
+                ;; pre-intern shape check (`story/valid-variant-id?`, single-
+                ;; sourced with the registrar's keyword-level `variant-id?`)
+                ;; fails closed with no intern.
                 (if-let [vk (args/fresh-keyword-checked vid story/valid-variant-id?)]
                   (register-or-error vk body-v)
                   (result/error-result
@@ -338,7 +334,7 @@
 
   `:unregistered?` is always `true` on the success path: `with-variant-id`
   resolves `:variant-id` via `safe-keyword` against the LIVE
-  registered-variant set (rf2-lqjbk), so an unregistered id never reaches
+  registered-variant set, so an unregistered id never reaches
   this body — it short-circuits to a `Variant not found` error result
   upstream. The id therefore always names a currently-registered variant,
   and the subsequent `unregister!` always removes it. This matches the

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -36,10 +36,10 @@
 ;; ResultIO mirror over story-mcp's CLJ-map result shape — used by the
 ;; cap-honours-default test to sum tokens without reaching into cap's
 ;; private result-io reify. Mirrors the runtime IO instance in
-;; `re-frame.story-mcp.tools.wire-pipeline/result-io` (rf2-eyelu / rf2-mzndx) so
+;; `re-frame.story-mcp.tools.wire-pipeline/result-io` so
 ;; a drift on the consumer's content-shape would be caught by the
 ;; assertion sitting on this mirror — INCLUDING the `:structuredContent`
-;; sizing path added in rf2-mzndx.
+;; sizing path.
 (def ^:private test-io
   (reify base-cap/ResultIO
     (wire-payload-strings [_ result]
@@ -78,14 +78,14 @@
   (story/clear-all!)
   (story/install-canonical-vocabulary!)
   (config/set-allow-writes! false)
-  ;; rf2-g9fje — sensitive-read gate. Default off everywhere (mirrors
+  ;; Sensitive-read gate. Default off everywhere (mirrors
   ;; the `--allow-sensitive-reads` boot-time posture). Tests that
   ;; exercise the opt-in branch flip it explicitly.
   (config/set-allow-sensitive-reads! false)
   (schemas/clear-schemas-by-frame!)
   ;; Frame-owned classification accumulator is per-process — clear between
   ;; tests so a previous test's declared sensitive/large paths don't bleed
-  ;; in (EP-0015 §8, rf2-d2r3um).
+  ;; in (EP-0015 §8).
   (reset! declared-class {})
   ;; Recorder atom is per-process — clear between tests so a previous
   ;; test's captured events don't bleed in.
@@ -122,7 +122,7 @@
   (story/reg-mode :Mode.theme/dark
     {:doc  "Dark theme."
      :args {:theme :dark}})
-  ;; Decorator fixtures — one of each kind (rf2-mqp1u). The `:wrap`
+  ;; Decorator fixtures — one of each kind. The `:wrap`
   ;; closure on the hiccup decorator is the load-bearing case for
   ;; `list-decorators`: the projected EDN must NOT carry the fn, only
   ;; a `:has-wrap?` boolean.
@@ -139,11 +139,11 @@
      :doc      "Pin http effect to a known response."
      :fx-id    :http
      :response {:status 200 :body "ok"}})
-  ;; rf2-d2r3um (EP-0015 §8) reconciliation — a test helper event the
+  ;; EP-0015 §8 — a test helper event the
   ;; privacy tests wire into a variant's `:setup` so the frame-owned
   ;; durable classification (`:sensitive` / `:large {:app-db …}`) is
-  ;; RE-INSTALLED on every fresh run. rf2-294yq5.3 made `run-variant`
-  ;; reset the variant frame's state IN PLACE on each run, which
+  ;; RE-INSTALLED on every fresh run. `run-variant`
+  ;; resets the variant frame's state IN PLACE on each run, which
   ;; overwrites the runtime-db partition with `{}` — wiping the frame's
   ;; elision registry (the `[:rf.runtime/elision …]` slot frame
   ;; classification installs). For the wire-egress redaction to bite at
@@ -224,7 +224,7 @@
       (is (every? #(not (contains? % :category)) ds)))))
 
 (deftest typical-tokens-hint-on-every-tool
-  ;; rf2-6sddv — `:typicalTokens` is an informational ballpark of
+  ;; `:typicalTokens` is an informational ballpark of
   ;; response-payload size in tokens; AI clients use it to budget calls.
   ;; Not a cap. Required to be a positive integer on every tool.
   (testing "registry: every tool carries a positive-integer :typicalTokens"
@@ -239,7 +239,7 @@
       (is (every? #(pos? (:typicalTokens %)) ds)))))
 
 (deftest output-schema-on-every-tool
-  ;; rf2-3l3be — every tool descriptor MUST declare an `:outputSchema`
+  ;; Every tool descriptor MUST declare an `:outputSchema`
   ;; describing its `structuredContent` payload shape. Asserted at
   ;; load time in `registry.cljc` too; this test makes the contract
   ;; visible in the test corpus and pins the wire projection.
@@ -253,7 +253,7 @@
       (is (every? #(map? (:outputSchema %)) ds)))))
 
 (deftest annotations-on-every-tool
-  ;; rf2-94p8q — every tool descriptor MUST declare an `:annotations`
+  ;; Every tool descriptor MUST declare an `:annotations`
   ;; map carrying the MCP tool-annotation hints (`readOnlyHint`,
   ;; `destructiveHint`, `idempotentHint`, `openWorldHint`). Asserted
   ;; at load time in `registry.cljc` too; this test pins the wire
@@ -282,12 +282,11 @@
       (doseq [n ro-tools]
         (is (true? (get-in (by-name n) [:annotations :readOnlyHint]))
             (str n " should have readOnlyHint true (rf2-94p8q matrix)")))))
-  ;; rf2-8h778: preview-variant moves to the destructive list. It dispatches
+  ;; preview-variant is on the destructive list. It dispatches
   ;; events into the variant's frame via the same `story/run-variant`
-  ;; lifecycle as `run-variant`; the original `read-only-annotations`
-  ;; marking was a wire-mismatch with the actual side-effect surface and
-  ;; would have let agent-host auto-approval skip the destructive-write
-  ;; ceremony.
+  ;; lifecycle as `run-variant`; marking it read-only would be a
+  ;; wire-mismatch with the actual side-effect surface and would let
+  ;; agent-host auto-approval skip the destructive-write ceremony.
   (testing "matrix: destructive tools have destructiveHint"
     (let [by-name (into {} (map (juxt :name identity)) registry/tool-registry)
           dest-tools ["preview-variant" "run-variant" "register-variant"
@@ -295,7 +294,7 @@
       (doseq [n dest-tools]
         (is (true? (get-in (by-name n) [:annotations :destructiveHint]))
             (str n " should have destructiveHint true (rf2-94p8q matrix)")))))
-  ;; rf2-e6knrq finding 2 — the open-world axis is now LOAD-BEARING and
+  ;; The open-world axis is LOAD-BEARING and
   ;; must not drift silently. `run-variant` / `preview-variant` run the
   ;; author's lifecycle events/fx, which can reach external systems unless
   ;; the author stubbed them (fx-stubbing is an opt-in authoring surface,
@@ -319,7 +318,7 @@
                    "not run the author's lifecycle (rf2-e6knrq finding 2)")))))))
 
 (def ^:private tool-names-fixture
-  "Canonical tool-name list (rf2-36upq TE7). Single source of truth
+  "Canonical tool-name list. Single source of truth
   shared with `test/stdio-roundtrip.js` — a registry change updates one
   file, not two. The fixture sits at `test/fixtures/tool-names.json`;
   this def parses it once at ns-load."
@@ -370,7 +369,7 @@
                " registry-only=" (set/difference (set reg-names) (set tool-names-fixture)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Code ↔ skill drift guard (rf2-dxh2s)
+;; Code ↔ skill drift guard
 ;;
 ;; The `tool-names.json` net above guards code↔test↔conformance (JVM
 ;; corpus, `stdio-roundtrip.js`, `end-to-end-story.cjs`). The CONSUMING
@@ -386,8 +385,8 @@
 (defn- artefact-root
   "Resolve the `tools/story-mcp/` artefact root on disk, cwd-independently.
   The per-tool `:test` alias runs from `tools/story-mcp` (a cwd-relative
-  `(io/file …)` works), but the tools-root aggregate (`tools/deps.edn :test`,
-  rf2-f2tkbt) runs from `tools/`, where a cwd-relative `spec/API.md` /
+  `(io/file …)` works), but the tools-root aggregate (`tools/deps.edn :test`)
+  runs from `tools/`, where a cwd-relative `spec/API.md` /
   `../../skills/…` would miss. The repo-tree files `spec/API.md` and the
   consuming skill leaf are NOT on the classpath (story-mcp ships only `src`
   + `test`), so we anchor off a known classpath SOURCE resource
@@ -439,7 +438,7 @@
     (into table-names ["get-story-instructions" "snapshot-identity"])))
 
 (deftest skill-leaf-tool-names-match-registry
-  ;; rf2-dxh2s — code↔skill drift ratchet for the reference leaf prose.
+  ;; Code↔skill drift ratchet for the reference leaf prose.
   (let [leaf       @story-mcp-loop-leaf
         reg-names  (set (map :name registry/tool-registry))
         named      (skill-named-tools leaf)]
@@ -451,9 +450,9 @@
       ;; `skill-named-tools` folds in. Pinned explicitly so a table row
       ;; silently dropping a tool is caught even if the registry still
       ;; carries it. NOT pinned: `run-variant` / `read-failures` (and the
-      ;; other Testing-category run tools) — rf2-r2xswa reframed this leaf
-      ;; into an author/refine recipe and moved the run/self-heal loop to a
-      ;; `re-frame2-pair` handoff, so those live in pair's allow-list, not
+      ;; other Testing-category run tools) — this leaf is an author/refine
+      ;; recipe and the run/self-heal loop lives on a `re-frame2-pair`
+      ;; handoff, so those live in pair's allow-list, not
       ;; this skill's catalogue. The Testing-tools split is asserted below.
       (doseq [t ["register-variant" "unregister-variant" "preview-variant"
                  "get-variant" "explain-variant" "get-story-instructions"
@@ -517,13 +516,13 @@
       (is (re-find #"snapshot-identity" text)))))
 
 (deftest get-story-instructions-covers-the-full-registration-surface
-  ;; rf2-4537df — the onboarding text + descriptor are the agent-facing
-  ;; contract for the Story registration surface. They previously listed
-  ;; only the SEVEN reg-* macros and omitted the public `reg-fragment` /
-  ;; `reg-check` composition macros, so an agent following the onboarding
-  ;; would never discover the `:compose` reuse surface. These assertions
-  ;; pin all nine public macros + the count so a future macro-surface
-  ;; change can't silently drift the onboarding again.
+  ;; The onboarding text + descriptor are the agent-facing
+  ;; contract for the Story registration surface. They enumerate all nine
+  ;; public reg-* macros — including the `reg-fragment` / `reg-check`
+  ;; composition cohort — so an agent following the onboarding discovers
+  ;; the `:compose` reuse surface. These assertions pin all nine public
+  ;; macros + the count so a macro-surface change can't silently drift
+  ;; the onboarding.
   (testing "the onboarding text enumerates all nine reg-* macros, including the composition cohort"
     (let [text (-> (invoke "get-story-instructions" {}) :content first :text)]
       (doseq [m ["reg-story" "reg-variant" "reg-fragment" "reg-check"
@@ -547,7 +546,7 @@
       (is (re-find #"reg-check" desc) "descriptor names reg-check"))))
 
 (deftest get-story-instructions-emits-structured-content
-  ;; rf2-vyacl — the descriptor declares an `:outputSchema`, so the
+  ;; The descriptor declares an `:outputSchema`, so the
   ;; official MCP SDK's high-level callTool REJECTS a result with no
   ;; `:structuredContent` (JSON-RPC -32600). The handler MUST emit a
   ;; structuredContent slot. Mirrors re-frame2-pair-mcp's sibling
@@ -577,7 +576,7 @@
     (is (re-find #"story\.button(/|%2F)primary" (:share-url s)))
     ;; :lifecycle is the loader STATE (retained adjunct); the verdict is
     ;; the unified :status — preview speaks the same vocabulary run-variant
-    ;; does (rf2-ba86n.17), so a vacuous-pass preview reads :status :pass.
+    ;; does, so a vacuous-pass preview reads :status :pass.
     (is (some? (:lifecycle s)))
     (is (= :pass (:status s)) "no assertions ⇒ vacuously :pass")
     (is (vector? (:checks s)))))
@@ -597,9 +596,7 @@
     (is (success? r))
     (is (vector? (-> r :structuredContent :substrates)))))
 
-;; rf2-4sgak — pin the CLJS-var resolver contract. The senior-review
-;; finding suspected the substrate bridge resolved an ALIAS symbol that
-;; `clojure.core/resolve` would not honour. In fact `resolve` DOES honour
+;; Pin the CLJS-var resolver contract. `clojure.core/resolve` honours
 ;; the calling ns's aliases, and the substrate var is nil on the JVM purely
 ;; because it is CLJS-only (a `#?(:cljs …)` def with no JVM Var). These
 ;; tests pin both facts so the contract can't silently regress.
@@ -647,7 +644,7 @@
       (is (empty? (:stories s)))
       (is (not (contains? s :ignored-tags))
           "a REGISTERED tag that simply matches no story is not 'ignored'")))
-  ;; rf2-wu1o2d — an unknown-only tag filter (a typo / stale tag) MUST
+  ;; An unknown-only tag filter (a typo / stale tag) MUST
   ;; return an empty result, NOT silently widen to the full catalogue.
   ;; The supplied-but-unresolved name rides the `:ignored-tags` diagnostic.
   (testing "filtering by an UNKNOWN-only tag returns empty, never the full catalogue"
@@ -698,7 +695,7 @@
     (is (= "Primary button." (-> r :structuredContent :body :doc)))))
 
 (deftest explain-variant-happy
-  ;; rf2-ba86n.17 — the agent mirror of the human Explain panel: the
+  ;; The agent mirror of the human Explain panel: the
   ;; variant-plan `:explain` projection (spec/017 §Explain API), a thin
   ;; wrapper over the shipped `story/explain` data API.
   (let [r (invoke "explain-variant" {:variant-id "story.button/primary"})
@@ -739,7 +736,7 @@
     (is (= :Mode.theme/dark (-> ms first :id)))
     (is (= {:theme :dark} (-> ms first :args)))))
 
-;; rf2-mqp1u — `list-decorators` is a read-only enumeration. The
+;; `list-decorators` is a read-only enumeration. The
 ;; `:wrap` closure on `:hiccup` decorators must NOT cross the wire
 ;; (closures don't serialise); the projection drops the slot in
 ;; favour of a `:has-wrap?` boolean. The canonical vocabulary
@@ -788,7 +785,7 @@
   (let [r (invoke "list-assertions" {})
         s (:structuredContent r)]
     (is (success? r))
-    ;; rf2-5x1wt.21 — the seven dispatched assertions PLUS the tape-evaluated
+    ;; The seven dispatched assertions PLUS the tape-evaluated
     ;; :rf.assert/schema-error (the EXPECTED-schema-violation declaration).
     (is (= 8 (count (:canonical s))))
     (is (some #(= :rf.assert/path-equals (:id %)) (:canonical s)))
@@ -796,12 +793,11 @@
     (is (some #(= :rf.assert/schema-error (:id %)) (:canonical s)))))
 
 (deftest list-assertions-registered-covers-plan-compiler-vocabulary
-  ;; rf2-4sgak — :registered MUST advertise the FULL vocabulary the Story
+  ;; :registered MUST advertise the FULL vocabulary the Story
   ;; plan compiler accepts (`assertions/known-assertion-ids`, the SAME set
-  ;; `plan.cljc` validates authored assertion atoms against). Previously it
-  ;; mirrored only `canonical-assertion-ids`, so MCP agents could not
-  ;; discover the DOM / visual / a11y / reactive-count ids the compiler
-  ;; would accept and fell back to stale prose.
+  ;; `plan.cljc` validates authored assertion atoms against), so MCP agents
+  ;; can discover the DOM / visual / a11y / reactive-count ids the compiler
+  ;; accepts rather than falling back to prose.
   (testing ":registered == the plan compiler's known-assertion-ids set"
     (let [r (invoke "list-assertions" {})
           s (:structuredContent r)]
@@ -811,7 +807,7 @@
           ":registered must equal the plan compiler's known-assertion-ids"))))
 
 (deftest list-assertions-registered-surfaces-browser-tier-families
-  ;; rf2-4sgak — the specific browser-tier ids the canonical doc-vec does
+  ;; The specific browser-tier ids the canonical doc-vec does
   ;; NOT cover but the plan compiler accepts: DOM, visual, a11y,
   ;; reactive-count. A regression that re-narrowed :registered to the
   ;; canonical eight would drop these and fail here.
@@ -840,15 +836,15 @@
         (is (map? back))
         (is (= "Primary button." (:doc back))))))
   (testing "rf2-vyacl: variant->edn ALSO emits structuredContent (it declares an outputSchema, so the SDK requires it)"
-    ;; `variant->edn` was the only other tool besides get-story-instructions
-    ;; that returned text-only while declaring an :outputSchema — the same
-    ;; -32600 latent defect. It now mirrors the body into structuredContent.
+    ;; `variant->edn` declares an :outputSchema, so a text-only result
+    ;; would trip the SDK's -32600. It mirrors the body into
+    ;; structuredContent.
     (let [r (invoke "variant->edn" {:variant-id "story.button/primary"})]
       (is (some? (:structuredContent r))
           "an outputSchema-declaring tool MUST return structuredContent (SDK -32600)")
       (is (= "Primary button." (-> r :structuredContent :doc))))))
 
-;; rf2-i0kyy — `get-docs-markdown` is the agent-paste shape.
+;; `get-docs-markdown` is the agent-paste shape.
 (deftest get-docs-markdown-renders-story-and-variants
   (let [r  (invoke "get-docs-markdown" {:story-id "story.button"})
         s  (:structuredContent r)
@@ -879,13 +875,12 @@
     (is (re-find #"story-id" (-> r :content first :text)))))
 
 ;; ---------------------------------------------------------------------------
-;; Pagination on the Docs `list-*` tools (rf2-76sf6)
+;; Pagination on the Docs `list-*` tools
 ;;
 ;; spec/Principles.md §'Tight token budget' MUST: every read tool whose
 ;; return size is a function of registry size MUST accept `:limit` +
 ;; `:cursor`. These tests pin:
 ;;   - small registries return the bare shape (no pagination metadata)
-;;     — the pre-rf2-76sf6 wire shape is preserved
 ;;   - large registries (>= :limit) return :total :limit :has-more?
 ;;     :next-cursor
 ;;   - cursor round-trips across pages
@@ -1021,7 +1016,7 @@
     (let [r (invoke "list-assertions" {:limit 3})
           s (:structuredContent r)]
       (is (success? r))
-      ;; rf2-5x1wt.21 — eight: the seven dispatched + the tape-evaluated
+      ;; Eight: the seven dispatched + the tape-evaluated
       ;; :rf.assert/schema-error.
       (is (= 8 (count (:canonical s)))
           "the canonical-doc vec is the bounded reference; not subject to pagination")
@@ -1036,8 +1031,8 @@
         s (:structuredContent r)]
     (is (success? r))
     (is (= :story.button/primary (:frame s)))
-    ;; rf2-ba86n.17 clean break — the verdict is the unified :status, not
-    ;; the retired :passing? boolean. A zero-assertion run is vacuously :pass.
+    ;; The verdict is the unified :status; there is no :passing? boolean.
+    ;; A zero-assertion run is vacuously :pass.
     (is (= :pass (:status s)) "no assertions ⇒ vacuously :pass")
     (is (not (contains? s :passing?)) "the retired :passing? boolean is gone")
     (is (vector? (:assertions s)))
@@ -1049,9 +1044,9 @@
     (is (re-find #"not found" (-> r :content first :text)))))
 
 (deftest run-variant-cannot-run-reachable
-  ;; rf2-ba86n.17 — the distinct THIRD verdict `:cannot-run` must be
-  ;; reachable over the wire (the old :passing? boolean could not express
-  ;; it). A `:rf.assert/caused` expectation needs reactive evidence; run
+  ;; The distinct THIRD verdict `:cannot-run` must be
+  ;; reachable over the wire. A `:rf.assert/caused` expectation needs
+  ;; reactive evidence; run
   ;; under the default no-reactive headless runner, the causal matcher
   ;; fails closed to :cannot-run rather than silently passing against an
   ;; empty projection (spec/017 §Causal and cascade assertions).
@@ -1083,13 +1078,14 @@
   (let [r (invoke "snapshot-identity" {:variant-id "story.nope/missing"})]
     (is (error? r))))
 
-;; rf2-09rfpu Finding 2 — `snapshot-identity` forwards `:cell-overrides`
+;; `snapshot-identity` forwards `:cell-overrides`
 ;; into `story/snapshot-identity`, where it perturbs the `:content-hash`
-;; via the resolved `:effective-args`. The descriptor + API now advertise
-;; the slot (it was hidden behind `additionalProperties false`, so a
-;; validating client stripped a real identity input while a non-validating
-;; client got a different hash). These tests pin: (a) the slot is in the
-;; advertised input schema, and (b) an override actually changes the hash.
+;; via the resolved `:effective-args`. The descriptor + API advertise
+;; the slot, since it is a real identity input — hiding it behind
+;; `additionalProperties false` would let a validating client strip it
+;; while a non-validating client got a different hash. These tests pin:
+;; (a) the slot is in the advertised input schema, and (b) an override
+;; actually changes the hash.
 (deftest snapshot-identity-advertises-cell-overrides
   (testing "the snapshot-identity descriptor exposes :cell-overrides in its input schema"
     (let [desc  (first (filter #(= "snapshot-identity" (:name %)) registry/tool-registry))
@@ -1119,11 +1115,11 @@
       (is (re-find #"CLJS-only" (:note s))))))
 
 (deftest read-a11y-violations-co-hosted-surfaces-stored-violations
-  ;; rf2-ynjts.20 — the co-hosted (CLJS var resolved) branch of
-  ;; `tool-read-a11y-violations`. The existing test covers ONLY the JVM-standalone
-  ;; path (var unresolved ⇒ empty + :note). The populated path — the
-  ;; resolved violations atom carries findings for the frame — was
-  ;; untested. We stand in for the resolved CLJS var with a var-of-atom
+  ;; The co-hosted (CLJS var resolved) branch of
+  ;; `tool-read-a11y-violations`. This covers the populated path — the
+  ;; resolved violations atom carries findings for the frame (the
+  ;; JVM-standalone path, var unresolved ⇒ empty + :note, is covered
+  ;; above). We stand in for the resolved CLJS var with a var-of-atom
   ;; mirror: the handler does `(deref @violations-by-frame-var)`, so the
   ;; redef must hold a value whose deref is the per-frame violations atom.
   (testing "violations stored for the frame are surfaced; :note is nil"
@@ -1157,16 +1153,15 @@
       (is (= 0 (:total s)))
       (is (empty? (:failures s)))
       (is (empty? (:assertions s)))
-      ;; rf2-ba86n.17 clean break — :status is the unified verdict; the
-      ;; retired :passing? boolean is gone.
+      ;; :status is the unified verdict; there is no :passing? boolean.
       (is (= :pass (:status s)))
       (is (not (contains? s :passing?))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Self-healing loop — failing :rf.assert/* through run-variant → read-failures
 ;;
-;; Per rf2-6r441: existing tests cover the optimistic (vacuous-pass) flow only.
-;; This deftest drives a DELIBERATELY-FAILING `:rf.assert/path-equals` through
+;; While other tests cover the optimistic (vacuous-pass) flow, this
+;; deftest drives a DELIBERATELY-FAILING `:rf.assert/path-equals` through
 ;; the MCP tool surface and asserts the AI-visible failure shape — the wire-
 ;; side contract an agent would consume.
 ;;
@@ -1345,22 +1340,21 @@
       (is (= "Wire body." (:doc (story/variant->edn :story.button/wire)))))))
 
 ;; ---------------------------------------------------------------------------
-;; EDN reader hardening on register-variant :body (rf2-g9fje fix 2/3)
+;; EDN reader hardening on register-variant :body
 ;;
-;; The EDN-string path through `tool-register-variant` is locked down per
-;; the rf2-uaymx audit: no tagged literals, no custom readers, 64KB size
-;; cap, 64-level depth cap. Pre-fix, `(edn/read-string body)` would happily
-;; eval `#=(...)` evaluator forms (when `*read-eval*` was true) or invoke
-;; any data reader on the `*data-readers*` table; post-fix the reader is
-;; `:readers {}` with a throwing `:default`, so any tagged-literal form
-;; lands in `::edn-error`.
+;; The EDN-string path through `tool-register-variant` is locked down:
+;; no tagged literals, no custom readers, 64KB size cap, 64-level depth
+;; cap. The reader is `:readers {}` with a throwing `:default`, so any
+;; tagged-literal form — including a `#=(...)` evaluator form or any data
+;; reader on the `*data-readers*` table — lands in `::edn-error` rather
+;; than evaluating.
 ;; ---------------------------------------------------------------------------
 
 (deftest register-variant-rejects-tagged-literal
   (testing "EDN body containing a custom tagged literal is rejected (rf2-g9fje)"
     (config/set-allow-writes! true)
     ;; Custom tags (non-EDN-built-in: not #inst / #uuid) route through the
-    ;; reader's :default handler, which throws under the rf2-g9fje
+    ;; reader's :default handler, which throws under the EDN
     ;; hardening. The throw lands as ::edn-error → the "must be a map or
     ;; a valid EDN string" error message.
     (let [r (invoke "register-variant"
@@ -1418,12 +1412,12 @@
       (is (re-find #"(?i)Registration failed" (-> r :content first :text))))))
 
 (deftest register-variant-rejects-non-map-body
-  ;; rf2-ynjts.20 — the `coerce-body` `::not-a-map` branch (write.cljc).
+  ;; The `coerce-body` `::not-a-map` branch (write.cljc).
   ;; The hardening tests above all cover the `::edn-error` branch (tagged
   ;; literal, oversize, over-deep, malformed). The DISTINCT `::not-a-map`
   ;; branch — a `:body` that PARSES cleanly but isn't a map — emits a
-  ;; different error message ("must be a map; got <class>") and was
-  ;; untested. A vector/scalar body must not reach the registrar.
+  ;; different error message ("must be a map; got <class>"). A
+  ;; vector/scalar body must not reach the registrar.
   (testing "an EDN-string body that parses to a vector is rejected as not-a-map"
     (config/set-allow-writes! true)
     (let [r (invoke "register-variant"
@@ -1443,19 +1437,17 @@
       (is (re-find #"(?i):body must be a map" (-> r :content first :text))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-tag30h — write-side no-intern: an INVALID id that correctly returns
+;; Write-side no-intern: an INVALID id that correctly returns
 ;; an MCP error must leave NO keyword in the JVM keyword table.
 ;;
-;; The write paths minted the keyword via `fresh-keyword` (intern FIRST),
-;; then let the registrar's downstream `assert-id!` reject on grammar — so
-;; an invalid `:variant-id` / `:new-variant-id` was REJECTED but already
-;; INTERNED. A hostile/malfunctioning client could grow the never-shrinking
-;; JVM keyword table unboundedly through failed write attempts (a slow-burn
-;; DoS), and a wide object-form body could intern many arbitrary keys before
-;; the registrar normalised them. The fix validates the id grammar on the
-;; STRING shape (`fresh-keyword-checked` + `variant-id-shape?`) and caps the
-;; object-body string-key WIDTH — both BEFORE any intern. `find-keyword`
-;; (JVM, no-intern lookup) is the no-intern oracle.
+;; Interning an invalid id before rejecting it would let a
+;; hostile/malfunctioning client grow the never-shrinking JVM keyword
+;; table unboundedly through failed write attempts (a slow-burn DoS), and
+;; a wide object-form body could intern many arbitrary keys before the
+;; registrar normalised them. So the write paths validate the id grammar
+;; on the STRING shape (`fresh-keyword-checked` + `variant-id-shape?`)
+;; and cap the object-body string-key WIDTH — both BEFORE any intern.
+;; `find-keyword` (JVM, no-intern lookup) is the no-intern oracle.
 ;; ---------------------------------------------------------------------------
 
 (deftest register-variant-invalid-id-does-not-intern
@@ -1532,16 +1524,14 @@
     (is (nil? (story/variant->edn :story.button/primary)))))
 
 (deftest unregister-variant-unknown-is-error-not-no-op
-  ;; Correctness review (rf2-nce6f): `unregister-variant` resolves
-  ;; `:variant-id` via `safe-keyword` against the LIVE registered-variant
-  ;; set (rf2-lqjbk `with-variant-id`), so an unregistered id NEVER reaches
-  ;; the handler body — it short-circuits to a `Variant not found` error.
-  ;; The success path therefore always reports `:unregistered? true` (the
-  ;; old `:unregistered? false` "already-gone" branch was structurally
-  ;; unreachable dead code; the descriptor example documenting it was
-  ;; impossible). This pins the spec-conformant contract (spec/API.md
-  ;; §unregister-variant: error when not registered) so the dead branch
-  ;; cannot regress back in.
+  ;; `unregister-variant` resolves `:variant-id` via `safe-keyword`
+  ;; against the LIVE registered-variant set (`with-variant-id`), so an
+  ;; unregistered id NEVER reaches the handler body — it short-circuits to
+  ;; a `Variant not found` error. The success path therefore always
+  ;; reports `:unregistered? true`; there is no reachable
+  ;; `:unregistered? false` "already-gone" branch. This pins the
+  ;; spec-conformant contract (spec/API.md §unregister-variant: error when
+  ;; not registered).
   (testing "an unregistered :variant-id is a tool-execution error, never a false-no-op"
     (config/set-allow-writes! true)
     (let [r (invoke "unregister-variant" {:variant-id "story.no/such"})]
@@ -1557,12 +1547,12 @@
           "a resolved (hence registered) variant is always actually removed"))))
 
 (deftest gated-error-tool-slot-pins-caller
-  ;; Regression for rf2-c52j0. Pre-fix, `assert-writes-allowed` hardcoded
-  ;; `:tool "register-variant"` in its error payload, so the two other
-  ;; callers (`unregister-variant`, `record-as-variant`) returned a gated
-  ;; error whose `:structuredContent :tool` slot LIED about its origin.
-  ;; This test pins the slot to the actual tool name at each callsite so
-  ;; the lie cannot regress.
+  ;; `assert-writes-allowed` must stamp the gated-error payload with the
+  ;; ACTUAL invoking tool name. Hardcoding `:tool "register-variant"` would
+  ;; make the two other callers (`unregister-variant`, `record-as-variant`)
+  ;; return a gated error whose `:structuredContent :tool` slot LIED about
+  ;; its origin. This test pins the slot to the actual tool name at each
+  ;; callsite.
   (testing "gated error's :structuredContent :tool matches the invoking tool"
     (is (false? (config/writes-allowed?))
         "fixture must leave the gate closed for this test")
@@ -1592,9 +1582,9 @@
 
 (defn- drive-events-during-recording
   "Spawn a worker thread that polls for the recorder's open window, then
-  pushes `events` once `recording?` flips true. Replaces the
-  `Thread/sleep delay-ms` race the original helper had (TE5, rf2-36upq)
-  — on a slow CI runner the worker could either fire BEFORE
+  pushes `events` once `recording?` flips true. Polling `recording?`
+  avoids a `Thread/sleep delay-ms` race
+  — on a slow CI runner a fixed sleep could either fire BEFORE
   `start-recording!` (events dropped, capture truncated) or AFTER
   `stop-recording!` (same outcome). Polling `recording?` from the worker
   end means we never depend on a sleep window outlasting the tool.
@@ -1609,7 +1599,7 @@
   Most callers just spawn-and-forget — the `:duration-ms` window the
   tool sleeps in is more than long enough for the polled push.
 
-  rf2-l2cn5d (EP-0017): the 2-arity `(drive-events-during-recording
+  EP-0017: the 2-arity `(drive-events-during-recording
   events cofx-vec)` pushes a parallel, index-aligned vector of captured
   flat `:rf.cofx` maps (the framework `:rf/time-ms` + any provided facts
   a dispatch carried) via the recorder's 2-arity `record-event!`, so a
@@ -1621,10 +1611,10 @@
      (doto (Thread.
              ^Runnable
              (fn []
-               ;; Poll `recording?` with a 1ms park between probes — far
-               ;; finer-grained than the original 20ms sleep. Bails after
-               ;; 5s if the recorder never opens (a tool bug; the test
-               ;; assertions will catch it).
+               ;; Poll `recording?` with a 1ms park between probes — fine-
+               ;; grained so the worker fires promptly once the window opens.
+               ;; Bails after 5s if the recorder never opens (a tool bug;
+               ;; the test assertions will catch it).
                (let [deadline (+ (System/nanoTime) (* 5 1000000000))]
                  (loop []
                    (cond
@@ -1656,8 +1646,8 @@
 
 (deftest record-as-variant-zero-duration-empty-capture
   (testing "duration 0 with no in-flight dispatches ⇒ empty public :script snippet"
-    ;; rf2-7mj4z: the recorder's `gen-play-snippet` emits the PUBLIC
-    ;; `:script {:auto-run? true :script [...]}` body, NOT the transitional
+    ;; The recorder's `gen-play-snippet` emits the PUBLIC
+    ;; `:script {:auto-run? true :script [...]}` body, NOT the internal
     ;; `:play-script` spelling. With zero captured events the inner
     ;; `:script` vector is empty.
     (let [r (invoke "record-as-variant" {:variant-id "story.button/primary"})
@@ -1709,12 +1699,11 @@
       (is (true? (:written-back? s)))
       (is (= :story.button/primary (:new-variant-id s)))
       (is (pos? n) "the recorder captured at least one event")
-      ;; rf2-7mj4z: write-back assocs the PUBLIC `:script` authoring slot,
+      ;; Write-back assocs the PUBLIC `:script` authoring slot,
       ;; which `reg-variant*` lowers to the shipping `:play-script` slot —
       ;; so the STORED body (`variant->edn`) reads `:play-script` carrying
-      ;; the captured events as a LIVE, replayable script (NOT the dead
-      ;; `:play` slot the schema dropped in rf2-0wrud, which no runner
-      ;; executes). Each captured event becomes a `[:dispatch ...]` step.
+      ;; the captured events as a LIVE, replayable script. Each captured
+      ;; event becomes a `[:dispatch ...]` step.
       ;; The exact count is derived from `:recorded-event-count` because
       ;; the live-recorder capture races the :duration-ms window.
       (let [body (story/variant->edn :story.button/primary)]
@@ -1742,7 +1731,7 @@
       (is (true? (:written-back? s)))
       (is (= :story.button/recorded (:new-variant-id s)))
       (is (pos? n) "the recorder captured at least one event")
-      ;; rf2-7mj4z: write-back assocs the public `:script` slot, lowered to
+      ;; Write-back assocs the public `:script` slot, lowered to
       ;; the shipping `:play-script` slot in storage (count derived from
       ;; `:recorded-event-count` — capture races the :duration-ms window).
       (is (= {:script (vec (repeat n [:dispatch [:counter/inc]])) :auto-run? true}
@@ -1830,10 +1819,9 @@
 
 (deftest record-as-variant-write-back-round-trips-and-replays
   (testing "rf2-50jzf: a written-back recording's :script body ACTUALLY replays"
-    ;; The headline acceptance criterion for rf2-50jzf — the previous
-    ;; write-back wrote a dead `:play` slot the schema dropped in
-    ;; rf2-0wrud, so a round-tripped recording silently never replayed.
-    ;; This test closes the loop end-to-end: record real dispatches →
+    ;; The headline acceptance criterion: a round-tripped recording
+    ;; actually replays. This test closes the loop end-to-end: record
+    ;; real dispatches →
     ;; write them back under a fresh variant → run THAT variant through
     ;; the MCP `run-variant` tool → assert the captured dispatches fired
     ;; against the frame's app-db (proving the slot the runner executes
@@ -1979,7 +1967,7 @@
       (is (re-find #":extends :story\.button/primary" snippet)))))
 
 ;; ---------------------------------------------------------------------------
-;; :origin :story-mcp stamping (rf2-7dnct)
+;; :origin :story-mcp stamping
 ;;
 ;; Per spec/Cross-Cutting-Designs.md §5 — every write surface tags its
 ;; writes with a single `:origin` keyword so post-mortem queries can
@@ -2201,7 +2189,7 @@
           "a missing tool name is invalid-params (nil is not a string)"))))
 
 ;; ---------------------------------------------------------------------------
-;; Lifecycle state enforcement (rf2-e6knrq finding 1)
+;; Lifecycle state enforcement
 ;;
 ;; Before a successful `initialize`, the dispatcher MUST accept only
 ;; `initialize` + `ping` (and any notification); every other request —
@@ -2209,7 +2197,7 @@
 ;; protocol-level `-32600 invalid-request`. A malformed or hostile client
 ;; must not be able to enumerate or invoke tools before the handshake.
 ;; These deftests drive BOTH the direct stateful `dispatch` (2-arity) AND
-;; the full `run-loop!` stdio order, per the bead's acceptance criteria.
+;; the full `run-loop!` stdio order.
 ;; ---------------------------------------------------------------------------
 
 (deftest dispatch-rejects-tools-list-before-initialize
@@ -2364,7 +2352,7 @@
                        "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"ping\"}\n")
           reader (java.io.BufferedReader. (java.io.StringReader. in-text))
           sw     (java.io.StringWriter.)
-          ;; Silent-on-success (rf2-try1x): the server logs the parse
+          ;; Silent-on-success: the server logs the parse
           ;; error to *err* per MCP stdio rules; capture it into a
           ;; throwaway buffer so the green test run stays at the
           ;; canonical 3-line shape.
@@ -2398,7 +2386,7 @@
   ;; to *err* and skipped, leaving the config map untouched. Surrounding
   ;; recognised flags must still parse.
   (testing "an unknown flag leaves the config map empty"
-    ;; Silent-on-success (rf2-try1x): the log line goes to *err*; capture
+    ;; Silent-on-success: the log line goes to *err*; capture
     ;; it so the green run keeps the canonical reporter shape.
     (let [err (java.io.StringWriter.)]
       (binding [*err* err]
@@ -2439,7 +2427,7 @@
           "initialize echoes read-version into :serverInfo :version"))))
 
 ;; ---------------------------------------------------------------------------
-;; Wire-boundary token-budget cap (rf2-rvyzy / rf2-zavp5).
+;; Wire-boundary token-budget cap.
 ;;
 ;; The cap is applied at `invoke-tool` egress — the cumulative
 ;; `:text`-slot byte count is compared against `:max-tokens` (default
@@ -2486,15 +2474,15 @@
       (is (not (overflow-marker? r))))))
 
 (deftest cap-negative-max-tokens-rejected-not-overflow-lockout
-  ;; rf2-5rdit — a negative `:max-tokens` resolves to a
+  ;; A negative `:max-tokens` resolves to a
   ;; `{:rf.mcp/invalid-arg {...}}` rejection, NOT a negative cap. The
   ;; handler is never dispatched and the result is an actionable
-  ;; `isError: true` error — not the `:rf.mcp/overflow` lock-out a
-  ;; negative ceiling used to cause (over-cap? trips on any non-negative
-  ;; token count against a negative cap, so even a tiny response was
-  ;; replaced by the overflow marker). The wire `:minimum 0` schema is the
-  ;; first line of defence for validating hosts; this is the egress
-  ;; backstop for hosts that don't validate.
+  ;; `isError: true` error — not an `:rf.mcp/overflow` lock-out. Were a
+  ;; negative ceiling accepted, `over-cap?` would trip on any non-negative
+  ;; token count against it, so even a tiny response would be replaced by
+  ;; the overflow marker. The wire `:minimum 0` schema is the first line
+  ;; of defence for validating hosts; this is the egress backstop for
+  ;; hosts that don't validate.
   (testing "negative :max-tokens surfaces an :rf.mcp/invalid-arg error, not overflow"
     (let [r    (wire-pipeline/invoke-tool "list-tags" {:max-tokens -1})
           body (get-in r [:structuredContent vocab/invalid-arg-key])]
@@ -2537,14 +2525,14 @@
           (str "tool " (:name t) " :max-tokens slot is not integer-typed")))))
 
 ;; ---------------------------------------------------------------------------
-;; Wire-egress privacy posture (rf2-73wuj)
+;; Wire-egress privacy posture
 ;;
-;; Per spec/Tool-Pair.md §Direct-read privacy posture (lines 544-566) every
+;; Per spec/Tool-Pair.md §Direct-read privacy posture, every
 ;; pair-shaped tool that surfaces a live `:app-db` slice MUST route the
 ;; value through `re-frame.core/elide-wire-value` before egress, with
 ;; off-box defaults (`:rf.size/include-sensitive?` and
 ;; `:rf.size/include-large?` both default false). The cross-MCP
-;; `:include-sensitive` arg (rf2-vw4sq) is the documented escape hatch.
+;; `:include-sensitive` arg is the documented escape hatch.
 ;;
 ;; These tests pin the contract at the story-mcp surface: a sensitive
 ;; slot declared through app-schema metadata on the variant's frame must
@@ -2572,8 +2560,8 @@
    (frame-container variant-id)))
 
 (defn- replace-frame-db! [variant-id new-db]
-  ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via swap-frame-db! —
-  ;; `frame/app-db-container` is now a read-only projection over the one
+  ;; EP-0001: write the app-db PARTITION via swap-frame-db! —
+  ;; `frame/app-db-container` is a read-only projection over the one
   ;; physical frame-state container.
   ((requiring-resolve 're-frame.frame/swap-frame-db!)
    variant-id (constantly new-db)))
@@ -2613,8 +2601,7 @@
 (defn- declare-classification!
   "Accumulate `path` under `kind` (`:sensitive` / `:large`) for
   `variant-id` and install the full classification onto the variant's
-  frame, in a way that survives `run-variant`'s fresh-run boundary
-  (rf2-294yq5.3 → rf2-d2r3um).
+  frame, in a way that survives `run-variant`'s fresh-run boundary.
 
   Two seams, mirroring `seed-app-db!`:
 
@@ -2657,7 +2644,7 @@
   "Declare `path` frame-owned `:large` on the named variant's frame
   (EP-0015 §8). The egress walker substitutes the slot's value with the
   `:rf.size/large-elided` marker — the leaf the `:elided-large` indicator
-  counts (rf2-koq5m)."
+  counts."
   [variant-id path]
   (declare-classification! variant-id :large path))
 
@@ -2672,7 +2659,7 @@
      live frame right now.
 
   2. `:db-seed` REGISTRATION — for the lifecycle readers
-     (`run-variant` / `preview-variant`). rf2-294yq5.3 added a fresh-run
+     (`run-variant` / `preview-variant`). There is a fresh-run
      boundary: `run-phase-0!` `destroy!`s any pre-existing frame BEFORE
      allocation so a run never inherits a prior run's (or an externally
      hand-written) app-db. That correctly wipes the direct write above. So
@@ -2757,20 +2744,18 @@
         (is (= "TOPSECRET" (get-in s [:app-db :secret])))))))
 
 (deftest elide-app-db-include?-true-bypasses-walker
-  ;; rf2-brehq — the `include? true` branch of `egress/elide-app-db`
-  ;; skips `elide-wire-value` entirely. Pins behavioural equivalence
-  ;; with the previous walking-then-no-edit implementation:
+  ;; The `include? true` branch of `egress/elide-app-db`
+  ;; skips `elide-wire-value` entirely. Pins two invariants:
   ;;
-  ;;   1. The return is the input db itself (`identical?`) — the walker
-  ;;      would have rebuilt every map / vector via `reduce-kv` and
-  ;;      `mapv`, breaking identity even though value would be
-  ;;      preserved. The bypass returns the original reference.
+  ;;   1. The return is the input db itself (`identical?`) — walking would
+  ;;      rebuild every map / vector via `reduce-kv` and `mapv`, breaking
+  ;;      identity even though value is preserved. The bypass returns the
+  ;;      original reference.
   ;;
   ;;   2. The return is value-equal to running the walker with both
-  ;;      inclusion knobs flipped (the previous behaviour). Future
-  ;;      refactors that reintroduce walker work on this branch will
-  ;;      still pass (2) but break (1) — the load-bearing perf invariant
-  ;;      this bead fixes.
+  ;;      inclusion knobs flipped. Future refactors that reintroduce
+  ;;      walker work on this branch will still pass (2) but break (1) —
+  ;;      the load-bearing perf invariant.
   ;;
   ;; Calls `egress/elide-app-db` directly so the test pins the helper's
   ;; contract, not a downstream tool's composition of it. Avoids
@@ -2806,7 +2791,7 @@
               "nested sensitive slot rides through"))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-ee38b.17 (headline P1) — derived-tree wire-egress redaction.
+;; Derived-tree wire-egress redaction.
 ;;
 ;; `elide-app-db` scrubs the `:app-db` slot by PATH. But the same sensitive
 ;; value reappears, verbatim, in `:rendered-hiccup` / `:effective-args` /
@@ -2892,19 +2877,19 @@
               "no secrets ⇒ no walk, input ref returned"))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-g7cd1 — value-redaction over-scrub guard.
+;; Value-redaction over-scrub guard.
 ;;
 ;; The value-based walk substitutes EVERY derived-tree leaf `=` a
 ;; declared-sensitive value. When a sensitive path holds a short/common
 ;; scalar (`0`, `200`, `:ok`), naive matching scrubs every benign leaf that
 ;; merely equals it — degrading the agent's view AND leaking the secret's
 ;; value-CLASS. `sensitive-values` guards that: a candidate value that ALSO
-;; appears, verbatim, in the POST-elision `:app-db` (the actual wire bytes —
-;; hardened from the raw db in rf2-f3kf7) is dropped from the secret set,
-;; because the path-based `:app-db` egress already ships that value (it is
-;; provably already disclosed, so excluding it leaks nothing new). These tests
-;; pin BOTH the precision win AND the fail-SAFE invariant (a value that is
-;; UNIQUELY secret — absent from the elided db — stays redacted).
+;; appears, verbatim, in the POST-elision `:app-db` (the actual wire bytes)
+;; is dropped from the secret set, because the path-based `:app-db` egress
+;; already ships that value (it is provably already disclosed, so excluding
+;; it leaks nothing new). These tests pin BOTH the precision win AND the
+;; fail-SAFE invariant (a value that is UNIQUELY secret — absent from the
+;; elided db — stays redacted).
 ;; ---------------------------------------------------------------------------
 
 (deftest scrub-rendered-short-scalar-aliased-to-public-path-is-not-over-scrubbed
@@ -2974,18 +2959,19 @@
               "benign attribute values survive untouched"))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-f3kf7 — :large?-blind under-scrub (the headline fix).
+;; :large?-blind under-scrub guard.
 ;;
-;; The g7cd1 guard dropped any candidate that ALSO appeared at a non-sensitive
-;; app-db path, on the premise that elide-app-db ships such a value verbatim.
-;; That premise is FALSE for a :large?-declared non-sensitive path:
-;; elide-wire-value replaces the slot with the :rf.size/large-elided marker, so
-;; the value is NOT on the wire — yet the old guard walked the RAW db, saw the
-;; secret at the :large? position, classified it public, and dropped it from
-;; the secret set, leaking it VERBATIM into the derived trees. The fix
-;; classifies "public" against the POST-elision :app-db (the actual wire
-;; bytes), so a value masked by ANY elision class stays redacted. These tests
-;; pin the no-under-scrub invariant on the in-scope MCP egress.
+;; The over-scrub guard drops any candidate that ALSO appears at a
+;; non-sensitive app-db path, on the premise that elide-app-db ships such a
+;; value verbatim. That premise is FALSE for a :large?-declared non-sensitive
+;; path: elide-wire-value replaces the slot with the :rf.size/large-elided
+;; marker, so the value is NOT on the wire. Classifying "public" against the
+;; RAW db would see the secret at the :large? position, classify it public,
+;; and drop it from the secret set — leaking it VERBATIM into the derived
+;; trees. So the guard classifies against the POST-elision :app-db (the
+;; actual wire bytes), and a value masked by ANY elision class stays
+;; redacted. These tests pin the no-under-scrub invariant on the in-scope
+;; MCP egress.
 ;; ---------------------------------------------------------------------------
 
 (deftest scrub-rendered-secret-aliased-into-large-subtree-stays-redacted
@@ -3031,14 +3017,14 @@
   (testing "FAIL-SAFE (rf2-f3kf7 secondary): a seq-indexed :sensitive? declaration [:tokens 0] keeps its element redacted in derived trees — the set/seq same-path walk no longer misclassifies it public"
     (with-clean-frame [vid :story.button/primary]
       ;; [:tokens 0] is sensitive and is a UNIQUE value (no benign alias on
-      ;; the wire). The slot is a SEQ (list), the shape the old guard
-      ;; mis-walked: `collect-public-values!` walked set/seq elements at the
-      ;; PARENT path `[:tokens]`, so `under-prefix? [:tokens 0] [:tokens]`
-      ;; returned false (prefix longer than the walk-path) — the element was
-      ;; treated as non-governed/public and dropped from the secret set =>
-      ;; under-scrub. The fix classifies against the POST-elision db, where
-      ;; `elide-wire-value`'s walk-seq HAS indexed + redacted the element, so
-      ;; it never appears at a public wire position and stays in the set.
+      ;; the wire). The slot is a SEQ (list), a shape that needs care:
+      ;; walking set/seq elements at the PARENT path `[:tokens]` would make
+      ;; `under-prefix? [:tokens 0] [:tokens]` return false (prefix longer
+      ;; than the walk-path), treating the element as non-governed/public and
+      ;; dropping it from the secret set => under-scrub. Classifying against
+      ;; the POST-elision db avoids that: `elide-wire-value`'s walk-seq has
+      ;; indexed + redacted the element, so it never appears at a public wire
+      ;; position and stays in the set.
       (let [secret "uniq-seq-secret-TOPSECRET"
             db     {:public "ok"
                     :tokens (list secret "second-public-token")}
@@ -3080,11 +3066,12 @@
               "benign 0 leaves deep in the tree survive"))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-9o5ixx — frame-declared :large values must elide in derived slots, not
-;; only in :app-db. EP-0015 treats sensitive + large as peer egress axes; the
-;; derived-tree scrubber redacted only the sensitive axis, so a :large blob
-;; re-keyed into :rendered-hiccup / :snapshot / evidence / explain value slots
-;; crossed the off-box boundary RAW, and the :elided-large count under-reported.
+;; Frame-declared :large values must elide in derived slots, not
+;; only in :app-db. EP-0015 treats sensitive + large as peer egress axes, so
+;; the derived-tree scrubber elides BOTH axes: a :large blob re-keyed into
+;; :rendered-hiccup / :snapshot / evidence / explain value slots is masked
+;; before it crosses the off-box boundary, and the :elided-large count
+;; reflects it.
 ;; ---------------------------------------------------------------------------
 
 (deftest scrub-rendered-large-value-elides-in-derived-tree
@@ -3187,7 +3174,7 @@
   "A unified-run-result-shaped value whose :app-db carries the secret at a
   declared-sensitive path AND whose derived trees re-embed the same value
   at non-app-db positions. Carries the unified `:status` / `:checks`
-  slots (rf2-ba86n.17) so it is a faithful stand-in for what
+  slots so it is a faithful stand-in for what
   `story/run-variant` actually returns."
   [vid]
   {:status         :pass
@@ -3200,7 +3187,7 @@
    :rendered-hiccup [:input {:type "password" :value "TOPSECRET"}]
    :effective-args {:label "Save" :token "TOPSECRET"}
    :snapshot       {:db {:token "TOPSECRET"}}
-   ;; rf2-j90sb — the three evidence slots that previously egressed RAW.
+   ;; The three evidence slots that must be value-redacted at egress.
    ;; :narrative is a two-level evidence tree whose inner beats carry
    ;; full :db-before / :db-after app-db snapshots (evidence.cljc
    ;; epoch-beat) — the secret rides those verbatim. :warnings are
@@ -3267,16 +3254,15 @@
               "opt-in surfaces the raw value in rendered-hiccup"))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-j90sb (headline P1, privacy egress) — run-variant's :narrative /
-;; :warnings / :sub-runs evidence slots egressed RAW. :narrative is a
-;; two-level evidence tree whose inner beats carry FULL :db-before /
-;; :db-after app-db snapshots (evidence.cljc epoch-beat), so a declared-
-;; sensitive value — correctly redacted in the top-level :app-db slot —
-;; escaped the MCP wire verbatim inside the narrative tree. :warnings
-;; (trace-event records) and :sub-runs (sub :value) carry the same leak
-;; class. These pin that all three are now value-redacted at egress, with
-;; the same `:include-sensitive` opt-out as the sibling derived slots.
-;; Sibling of pair-mcp's rf2-6wvh5.
+;; run-variant's :narrative / :warnings / :sub-runs evidence slots must be
+;; value-redacted at egress. :narrative is a two-level evidence tree whose
+;; inner beats carry FULL :db-before / :db-after app-db snapshots
+;; (evidence.cljc epoch-beat), so a declared-sensitive value — redacted in
+;; the top-level :app-db slot — would otherwise escape the MCP wire
+;; verbatim inside the narrative tree. :warnings (trace-event records) and
+;; :sub-runs (sub :value) carry the same leak class. These pin that all
+;; three are value-redacted at egress, with the same `:include-sensitive`
+;; opt-out as the sibling derived slots.
 ;; ---------------------------------------------------------------------------
 
 (deftest run-variant-narrative-redacts-sensitive-by-default
@@ -3365,27 +3351,25 @@
         (is (= :fail (:status s)) "the visible failure drives :status :fail")))))
 
 ;; ---------------------------------------------------------------------------
-;; Non-live wire-egress privacy posture (rf2-12f2q) — closing the split
-;; contract.
+;; Non-live wire-egress privacy posture.
 ;;
 ;; The wire-elision contract in tools/story/spec/006-MCP-Surface.md
 ;; promises EVERY Story-MCP payload crosses elided (registry reads +
-;; recorder output included). Pre-fix, only the three live-state tools
-;; (`preview-variant` / `run-variant` / `read-failures`) routed their
-;; value-bearing slots through the egress scrubbers; the NON-live tools
-;; (`explain-variant`'s plan-resolved value slots, `record-as-variant`'s
-;; captured event vectors + the snippet derived from them) crossed RAW.
+;; recorder output included). This covers the NON-live tools alongside the
+;; three live-state ones (`preview-variant` / `run-variant` /
+;; `read-failures`): `explain-variant`'s plan-resolved value slots and
+;; `record-as-variant`'s captured event vectors + the snippet derived from
+;; them all route their value-bearing slots through the egress scrubbers.
 ;;
 ;; These tests plant a DISTINCTIVE sensitive literal in those non-live
 ;; payloads and assert the MCP wire response does NOT include it by
 ;; default, while the documented `:include-sensitive` opt-in (gated by
-;; --allow-sensitive-reads) reveals it. RED before the fix (the literal
-;; crossed verbatim); GREEN after.
+;; --allow-sensitive-reads) reveals it.
 ;;
-;; The proof that the WITHOUT-fix path leaks: each test's secret value
-;; reaches the wire slot directly from a captured event / plan-resolved
-;; arg, so without the value-redaction step it would appear verbatim in
-;; `:captured` / `:play-snippet` / the explain value slots.
+;; Each test's secret value reaches the wire slot directly from a captured
+;; event / plan-resolved arg, so without the value-redaction step it would
+;; appear verbatim in `:captured` / `:play-snippet` / the explain value
+;; slots — which is what the redaction prevents.
 ;; ---------------------------------------------------------------------------
 
 (deftest explain-variant-redacts-sensitive-effective-args-by-default
@@ -3445,21 +3429,20 @@
               "gate closed: the opt-in cannot exfiltrate the declared-sensitive value"))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-q8ebq.1 — explain-variant value-bearing slot COMPOSITION GAP.
+;; explain-variant value-bearing slot composition coverage.
 ;;
-;; rf2-12f2q scrubbed only [:effective-args :args :substitutions :network
-;; :db-seed], but the SAME `substitute-args` that feeds the scrubbed
-;; `:substitutions` also resolves arg values into `:sub-overrides` override
-;; values (plan.cljc:1297) and the `:setup-order` / `:script-order` step
-;; sequences (plan.cljc:1263/1269). A declared-sensitive arg substituted
-;; into any of those crossed the AI/MCP boundary RAW by default — leaving
-;; `:setup-order`/`:script-order` unscrubbed is a clean BYPASS of the
-;; `:substitutions` scrub (the secret rides the unscrubbed sibling).
+;; Beyond [:effective-args :args :substitutions :network :db-seed], the SAME
+;; `substitute-args` that feeds `:substitutions` also resolves arg values
+;; into `:sub-overrides` override values (plan.cljc:1297) and the
+;; `:setup-order` / `:script-order` step sequences (plan.cljc:1263/1269). A
+;; declared-sensitive arg substituted into any of those would cross the
+;; AI/MCP boundary RAW if those slots went unscrubbed — leaving
+;; `:setup-order`/`:script-order` unscrubbed would be a clean BYPASS of the
+;; `:substitutions` scrub (the secret rides the unscrubbed sibling). So all
+;; of these slots are in `explain-value-bearing-slots`.
 ;;
-;; These tests plant a DISTINCTIVE secret in each of the three newly-scrubbed
-;; slots and assert it is redacted on the wire by default. RED before the
-;; fix (the slot was absent from `explain-value-bearing-slots` so the literal
-;; crossed verbatim); GREEN after.
+;; These tests plant a DISTINCTIVE secret in each of those scrubbed slots
+;; and assert it is redacted on the wire by default.
 ;; ---------------------------------------------------------------------------
 
 (deftest explain-variant-redacts-sensitive-sub-overrides-and-step-order-by-default
@@ -3518,38 +3501,36 @@
               "and the raw setup-step value crosses too"))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-tag30h — explain-variant PRE-FRAME egress.
+;; explain-variant PRE-FRAME egress.
 ;;
 ;; `explain-variant` is a documented NO-RUN path (spec/API.md §explain-variant:
 ;; "Plan-derived data — no run, no live :app-db slice"): a caller can read it
-;; BEFORE any run-variant / preview-variant allocates the variant frame. The
-;; original value-redaction (`scrub-frame-value`) derived candidate secrets
-;; ONLY from the LIVE frame app-db (`rf/app-db-value`), which is nil pre-frame
-;; — so a declared-sensitive value authored into a plan slot (:db-seed seed
-;; data, a stubbed :network reply, a resolved :effective-args / step payload)
-;; crossed the AI/off-box boundary RAW with no live source to value-match.
+;; BEFORE any run-variant / preview-variant allocates the variant frame.
+;; Deriving candidate secrets ONLY from the LIVE frame app-db
+;; (`rf/app-db-value`) would miss this case — the live app-db is nil
+;; pre-frame, so a declared-sensitive value authored into a plan slot
+;; (:db-seed seed data, a stubbed :network reply, a resolved
+;; :effective-args / step payload) would have no live source to value-match.
 ;;
-;; The fix collects candidate secrets ALSO from the plan's OWN :db-seed slot
-;; at the variant's frame-declared-sensitive PATHS — read from the frame's
-;; durable elision registry, which frame-owned classification populates at
-;; `reg-frame` time (EP-0015 §8, rf2-d2r3um), so the paths are live from
+;; So value-redaction ALSO collects candidate secrets from the plan's OWN
+;; :db-seed slot at the variant's frame-declared-sensitive PATHS — read from
+;; the frame's durable elision registry, which frame-owned classification
+;; populates at `reg-frame` time (EP-0015 §8), so the paths are live from
 ;; frame creation onward without any RUN. These tests declare a sensitive
 ;; path PRE-RUN (frame allocated, no run-variant / preview-variant has
 ;; executed and seeded the live app-db), then assert the secret is redacted
-;; by default and surfaced only via the gated :include-sensitive opt-in. RED
-;; before the fix (the literal crossed verbatim); GREEN after.
+;; by default and surfaced only via the gated :include-sensitive opt-in.
 ;; ---------------------------------------------------------------------------
 
 (defn- declare-sensitive-prerun!
   "Install a frame-owned `:sensitive` `:app-db` declaration for a slot on
   the named variant's frame PRE-RUN — the no-run posture `explain-variant`
-  must defend (rf2-tag30h). Frame-owned classification lives in the frame's
+  must defend. Frame-owned classification lives in the frame's
   durable elision registry (its runtime-db partition), so the frame
   container must exist; we `ensure-variant-frame!` (allocate at reg-frame
   time) then `frame-class/install!`. No run-variant / preview-variant has
   executed, so the LIVE app-db is still empty — the candidate secrets come
-  from the plan's own :db-seed at these declared paths (EP-0015 §8,
-  rf2-d2r3um)."
+  from the plan's own :db-seed at these declared paths (EP-0015 §8)."
   [variant-id path]
   (ensure-variant-frame! variant-id)
   (frame-class/install! variant-id
@@ -3560,7 +3541,7 @@
     (with-clean-frame [vid :story.button/primary]
       ;; No RUN has executed — the live app-db is still empty, so the
       ;; candidate secrets must come from the plan's own :db-seed at the
-      ;; frame's declared-sensitive paths (EP-0015 §8, rf2-d2r3um).
+      ;; frame's declared-sensitive paths (EP-0015 §8).
       (declare-sensitive-prerun! vid [:auth :token])
       (is (empty? (rf/app-db-value vid))
           "precondition: no run has seeded the live app-db")
@@ -3620,14 +3601,14 @@
               "gate closed: the opt-in cannot exfiltrate the seeded secret pre-frame"))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-q8ebq.2 — read-a11y-violations shipped raw axe-core violation nodes (incl. node
-;; :html outerHTML) with NO egress scrub. A sensitive value rendered into
-;; the DOM (e.g. `<input value="<token>">`) lands verbatim in node :html and
-;; crossed the AI/off-box MCP boundary unredacted — and read-a11y-violations is
-;; :readOnlyHint true (agent hosts AUTO-APPROVE it), so an unscrubbed runtime
-;; read here is the wrong shape. The fix routes :violations through
-;; `egress/scrub-frame-value` (the same value-based primitive explain/record
-;; use), fail-closed by default + the :include-sensitive opt-in.
+;; read-a11y-violations egress scrub. axe-core violation nodes (incl. node
+;; :html outerHTML) must not cross the AI/off-box MCP boundary unredacted: a
+;; sensitive value rendered into the DOM (e.g. `<input value="<token>">`)
+;; lands verbatim in node :html, and read-a11y-violations is :readOnlyHint
+;; true (agent hosts AUTO-APPROVE it), so an unscrubbed runtime read would be
+;; the wrong shape. :violations route through `egress/scrub-frame-value`
+;; (the same value-based primitive explain/record use), fail-closed by
+;; default + the :include-sensitive opt-in.
 ;;
 ;; The helpers (`seed-app-db!` / `declare-sensitive!`) establish the frame's
 ;; declared-sensitive value; `scrub-frame-value` reads that frame's live
@@ -3765,23 +3746,21 @@
             "gate closed: the opt-in cannot exfiltrate the declared-sensitive value")))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-koq5m (headline P1, privacy/observability MUST at the AI boundary) —
-;; egress indicator counts (`:dropped-sensitive` / `:elided-large`).
+;; Egress indicator counts (`:dropped-sensitive` / `:elided-large`).
 ;;
 ;; story-mcp drops `:sensitive? true` assertion records and elides
-;; over-threshold / schema-`:large?` leaves at the wire egress, but
-;; surfaced NEITHER count — the canonical silent-swallow failure mode.
+;; over-threshold / schema-`:large?` leaves at the wire egress, and surfaces
+;; a count of each — avoiding the canonical silent-swallow failure mode.
 ;; spec/Conventions.md §Cross-MCP indicator-field vocabulary is MUST-
 ;; level: a tool walking a tree-typed payload MUST carry an
 ;; `:elided-large` count alongside the `:dropped-sensitive` count,
-;; omitting each slot when zero. The fix reuses the mcp-base primitives
+;; omitting each slot when zero. This reuses the mcp-base primitives
 ;; (`envelope/with-indicators` + `elision/count-elided-markers`) the
-;; sibling pair-mcp already wires.
+;; sibling pair-mcp also wires.
 ;;
-;; RED (pre-fix): the response carries no indicator slots even when a
-;; sensitive slot is dropped / a large value is elided.
-;; GREEN (post-fix): `:dropped-sensitive` / `:elided-large` present with
-;; the correct counts; omitted entirely on a clean read.
+;; `:dropped-sensitive` / `:elided-large` are present with the correct
+;; counts whenever a sensitive slot is dropped / a large value is elided,
+;; and omitted entirely on a clean read.
 ;; ---------------------------------------------------------------------------
 
 (deftest read-failures-surfaces-dropped-sensitive-indicator
@@ -3864,10 +3843,11 @@
 
 ;; The full set of tools that surface a value-bearing slot (live `:app-db`
 ;; / assertions OR a non-live runtime/captured value) and so must accept
-;; the `:include-sensitive` opt-in. The live three (rf2-73wuj) plus the
-;; non-live two closed in rf2-12f2q (`explain-variant`'s plan-resolved
-;; value slots, `record-as-variant`'s captured events), plus `read-a11y-violations`'s
-;; runtime DOM `:violations` (rf2-q8ebq.2).
+;; the `:include-sensitive` opt-in. The live three (`preview-variant` /
+;; `run-variant` / `read-failures`) plus the non-live two
+;; (`explain-variant`'s plan-resolved value slots, `record-as-variant`'s
+;; captured events), plus `read-a11y-violations`'s runtime DOM
+;; `:violations`.
 (def ^:private include-sensitive-tools
   ["preview-variant" "run-variant" "read-failures"
    "explain-variant" "record-as-variant" "read-a11y-violations"])
@@ -3881,10 +3861,10 @@
             (str tname " missing :include-sensitive slot"))
         (is (= "boolean" (-> props :include-sensitive :type))
             (str tname " :include-sensitive slot is not boolean-typed")))))
-  ;; rf2-wu1o2d — pin the EXACT include-sensitive tool set against the
-  ;; registry so the spec's "three affected tools" prose (now corrected to
-  ;; six) and the descriptor strip can't silently drift apart. The set is
-  ;; precisely the descriptors that carry the slot — no more, no less.
+  ;; Pin the EXACT include-sensitive tool set against the
+  ;; registry so the spec's affected-tools prose (six) and the descriptor
+  ;; strip can't silently drift apart. The set is precisely the
+  ;; descriptors that carry the slot — no more, no less.
   (testing "the include-sensitive set is EXACTLY the descriptors carrying the slot (no drift)"
     (let [carriers (->> registry/tool-registry
                         (filter #(contains? (-> % :inputSchema :properties) :include-sensitive))
@@ -3923,12 +3903,11 @@
           (subs after 0 end))))))
 
 (deftest api-md-tracks-include-sensitive-descriptor-set
-  ;; rf2-ovmc5e Finding #3 — the consolidated API page must list
+  ;; The consolidated API page must list
   ;; `:include-sensitive` for EVERY tool whose descriptor carries the
   ;; slot, so the summary can't silently under-document the gated
-  ;; privacy escape hatch (the original drift: read-a11y-violations's API.md input
-  ;; omitted it). Derives the expected set from the live registry, so a
-  ;; new value-surfacing tool that gains the slot must also gain the
+  ;; privacy escape hatch. Derives the expected set from the live registry,
+  ;; so a new value-surfacing tool that gains the slot must also gain the
   ;; API.md mention or this trips.
   (testing "API.md documents :include-sensitive for every descriptor that carries it"
     (let [carriers (->> registry/tool-registry
@@ -3944,9 +3923,9 @@
                    "(descriptor carries it; the consolidated page must not under-document it)")))))))
 
 ;; ---------------------------------------------------------------------------
-;; Sensitive-read boot gate (rf2-g9fje)
+;; Sensitive-read boot gate
 ;;
-;; Per the rf2-uaymx (b) decision: the per-call `:include-sensitive` arg
+;; The per-call `:include-sensitive` arg
 ;; is honoured ONLY when the operator opened the server-side gate at boot
 ;; (`--allow-sensitive-reads`). When the gate is closed:
 ;;
@@ -4083,7 +4062,7 @@
                  " — keep the onboarding doc in lockstep with `story/canonical-assertion-ids`"))))))
 
 ;; ---------------------------------------------------------------------------
-;; handle-frame! recovery write — nested catch (rf2-36upq TE2)
+;; handle-frame! recovery write — nested catch
 ;;
 ;; server.cljc's handle-frame! has a nested try around the recovery write
 ;; (the "even the recovery write failed" branch). It's unreachable from the
@@ -4120,13 +4099,13 @@
           "handle-frame! must not propagate writer-side throws"))))
 
 ;; ---------------------------------------------------------------------------
-;; Boot-config precedence — CLI > sysprop > env (rf2-36upq TE4)
+;; Boot-config precedence — CLI > sysprop > env
 ;;
 ;; Per spec/003-Write-Surface-Gating.md §91-94 the precedence is CLI flag >
-;; JVM sysprop > env var. The existing tests cover `parse-args` directly;
-;; this test asserts the merged behaviour: when all three sources supply
-;; conflicting values, CLI wins, sysprop overrides env, and the env-only
-;; case lands too.
+;; JVM sysprop > env var. Alongside the tests that cover `parse-args`
+;; directly, this test asserts the merged behaviour: when all three sources
+;; supply conflicting values, CLI wins, sysprop overrides env, and the
+;; env-only case lands too.
 ;; ---------------------------------------------------------------------------
 
 (deftest boot-config-precedence-cli-over-sysprop-over-env

--- a/tools/story/src/deps.cljs
+++ b/tools/story/src/deps.cljs
@@ -4,14 +4,10 @@
 ;; source tree is read at build time so consumers of this artefact pick
 ;; up npm requirements without re-declaring them.
 ;;
-;; Story currently declares no npm-deps from this file. The historic
-;; `qrcode-generator` entry was vendored to back the per-variant Share
-;; popover's local SVG QR encoder (rf2-20w5i security audit — pre-fix
-;; the QR rode in from a third-party image service, leaking author-typed
-;; `:cell-overrides` off-box). The share popover itself was retired in
-;; rf2-ymnfx Issue B because the variant URL is already the browser's
-;; address bar — Cmd-L / Cmd-A / Cmd-C copies it without a separate
-;; affordance. The npm dep retired with the popover.
+;; Story declares no npm-deps from this file. Variant sharing rides on
+;; the variant URL itself — it is already the browser's address bar, so
+;; Cmd-L / Cmd-A / Cmd-C copies it without any separate affordance or
+;; bundled encoder.
 ;;
 ;; axe-core is intentionally NOT vendored. The shadow-cljs / Closure
 ;; :advanced strict ECMAScript parser trips on axe-core's UMD wrapper.

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -14,35 +14,33 @@
   `snapshot-identity`), and the shell mount/unmount surface
   (`mount-shell!` / `unmount-shell!` / `active-shell`, CLJS-only).
 
-  Per the rf2-l8eso Phase-2 facade thinning, the implementation weight
-  for three cohesive surfaces lives in dedicated internal namespaces:
+  The implementation weight for three cohesive surfaces lives in
+  dedicated internal namespaces:
 
   - `re-frame.story.query` — the registry query API
   - `re-frame.story.canonical` — canonical-vocabulary boot
   - `re-frame.story.lifecycle` — Stage-3 variant lifecycle
 
-  Every public symbol on the facade still resolves under its existing
-  name; the bodies are thin re-exports / delegators.
+  Every public symbol on the facade resolves under its name; the bodies
+  are thin re-exports / delegators.
 
-  ## Why this file is ~1100 LoC (rf2-5hp3r — facade-size investigation)
+  ## Why this file is ~1100 LoC
 
-  The implementation weight has already been moved off the facade. Of
-  the LoC that remain: ~18% is code-only (thin defmacro wrappers and
-  delegator defns), ~56% is docstring, ~10% is inline structure
-  comments, ~15% is blank-line separation. The size is documentation,
-  not waste — and the docstrings belong on the macros (where authors'
-  IDEs surface them on hover) rather than on the `*`-suffix runtime
-  helpers (which authors don't call directly). Comparable author-
-  facing facades — `re-frame.core` (1.5 KLoC), `day8.re-frame2-xray.
-  config` (1.5 KLoC) — sit in the same range for the same reason.
-  Investigation outcome: structure justifies size; no further split
-  warranted at this stage.
+  The implementation weight lives off the facade. Of the LoC here: ~18%
+  is code-only (thin defmacro wrappers and delegator defns), ~56% is
+  docstring, ~10% is inline structure comments, ~15% is blank-line
+  separation. The size is documentation, not waste — and the docstrings
+  belong on the macros (where authors' IDEs surface them on hover)
+  rather than on the `*`-suffix runtime helpers (which authors don't
+  call directly). Comparable author-facing facades — `re-frame.core`
+  (1.5 KLoC), `day8.re-frame2-xray.config` (1.5 KLoC) — sit in the same
+  range for the same reason. The structure justifies the size.
 
   ## Boot
 
   The canonical Story vocabulary auto-installs on the first `reg-*`
-  call (per rf2-p1ydc + tools/story/spec/001-Authoring.md §Boot —
-  auto-install of the canonical vocabulary). Authors don't have to
+  call (per tools/story/spec/001-Authoring.md §Boot — auto-install of
+  the canonical vocabulary). Authors don't have to
   remember an explicit boot step; the first `(reg-story ...)` /
   `(reg-variant ...)` / etc. lands the seven canonical tags + the
   `:rf.assert/*` event handlers + the built-in
@@ -79,51 +77,49 @@
   Per `002-Runtime.md` §Four-phase lifecycle with `:loaders-complete-when`
   the boundary is: synchronous drain belongs to the
   test driver; the queue belongs to the application."
-  ;; rf2-bsk1d9 (EP-0015): Story does NOT re-export `add-marks` /
-  ;; `set-marks`. Durable app-db classification is a frame-creation
-  ;; concern — a variant declares `:sensitive` / `:large` on its body and
-  ;; the runtime threads them onto its `reg-frame` config
-  ;; (`re-frame.story.frames`). The `re-frame.marks` require is gone, and
-  ;; with the re-exports dropped the `re-frame.core` require has no live
-  ;; call site either, so it is removed (the docstring above still names
-  ;; `rf/dispatch-sync` etc. illustratively).
+  ;; EP-0015: Story does NOT re-export `add-marks` / `set-marks`. Durable
+  ;; app-db classification is a frame-creation concern — a variant
+  ;; declares `:sensitive` / `:large` on its body and the runtime threads
+  ;; them onto its `reg-frame` config (`re-frame.story.frames`). Story
+  ;; requires neither `re-frame.marks` nor `re-frame.core` (the docstring
+  ;; above names `rf/dispatch-sync` etc. illustratively).
   (:require [re-frame.story.config      :as config]
             [re-frame.story.registrar   :as registrar]
             ;; Phase-2 cohesive internal nss — own the implementation
             ;; weight for query / canonical-boot / lifecycle surfaces.
             [re-frame.story.canonical   :as canonical]
-            ;; rf2-5x1wt.3 — the single canonical projection + fingerprint
+            ;; The single canonical projection + fingerprint
             ;; primitive. Re-exported as `canonicalize` / `content-hash` /
             ;; `plan-hash` / `run-hash` below so every downstream call site
             ;; routes through one path (NOT `re-frame.story.canonical`,
             ;; which installs the canonical *vocabulary*).
             [re-frame.story.fingerprint :as fingerprint]
-            ;; rf2-5x1wt.4 — the run-evidence projection from the epoch tape.
+            ;; The run-evidence projection from the epoch tape.
             ;; Re-exported as `project-evidence` below so every downstream
             ;; run-result slot derives from ONE tape (NewTestStory §A0c).
             [re-frame.story.play.evidence :as evidence]
-            ;; rf2-5x1wt.7 — the `:rf.test/run-artifact` schema + replay.
+            ;; The `:rf.test/run-artifact` schema + replay.
             ;; Re-exported as `make-run-artifact` / `run-artifact?` /
             ;; `replay-run-artifact` below (spec/017 §Run artifact and replay).
             [re-frame.story.artifact    :as artifact]
-            ;; rf2-5x1wt.8 — the determinism gate. Re-exported as
+            ;; The determinism gate. Re-exported as
             ;; `assert-deterministic` below (spec/017 §Determinism gate).
             [re-frame.story.determinism :as determinism]
-            ;; rf2-5x1wt.9 — the semantic diff over canonical run artifacts.
+            ;; The semantic diff over canonical run artifacts.
             ;; Re-exported as `diff-run-artifacts` below (spec/017 §Semantic
             ;; diff). Builds read-only on `.7` replay + `.3`/`.8` canonicalize.
             [re-frame.story.diff        :as diff]
-            ;; rf2-5x1wt.32 — golden slices (the deferred P1.5 surface).
+            ;; Golden slices.
             ;; Re-exported as `capture-golden` / `golden-match?` /
             ;; `compare-golden` below (spec/017 §Golden slices). Builds
             ;; read-only on `.3`/`.8` canonicalize + `.7` replay + `.9` diff.
             [re-frame.story.golden      :as golden]
-            ;; rf2-5x1wt.25 — the run-artifact → variant promotion bridge.
+            ;; The run-artifact → variant promotion bridge.
             ;; Re-exported as `materialize-variant-plan` (pure) +
             ;; `promote-run-artifact!` (the explicit-only registration path)
             ;; below (spec/017 §Promotion — Promotion bridge).
             [re-frame.story.promotion   :as promotion]
-            ;; rf2-5x1wt.31 — generated / property-style runs that emit
+            ;; Generated / property-style runs that emit
             ;; seed-bearing run artifacts (+ shrink) and a fault-lattice
             ;; sweep. Re-exported as `check-property!` / `sweep-faults!`
             ;; below (spec/017 §Generated runs and artifacts). Builds
@@ -131,29 +127,29 @@
             ;; artifact slots; a generated failure feeds the promotion
             ;; bridge unchanged (artifacts first, curated promotion only).
             [re-frame.story.generate    :as generate]
-            ;; rf2-5x1wt.19 — the ONE unified run-result + the assertion /
+            ;; The ONE unified run-result + the assertion /
             ;; check record shapes + the clojure.test report projection.
             ;; Re-exported as `run-result` / `result-status` /
             ;; `result-passed?` and backs the `story/is` bridge below
             ;; (spec/017 §Run result + §Unified run result).
             [re-frame.story.result      :as result]
-            ;; rf2-jy92cr — the ONE verdict-aggregation rule
+            ;; The ONE verdict-aggregation rule
             ;; (`:error` > `:fail` > `:cannot-run` > `:pass`). Re-exported
             ;; as `aggregate-verdict` below so tooling (story-mcp) reads the
             ;; runner's verdict rule rather than re-implementing it.
             [re-frame.story.requirements :as requirements]
-            ;; rf2-5x1wt.19 — `story/is` blocks on the JVM run promise +
+            ;; `story/is` blocks on the JVM run promise +
             ;; chains the CLJS one (the headless-test bridge).
             [re-frame.story.async       :as async]
             [re-frame.story.lifecycle   :as lifecycle]
             [re-frame.story.query       :as query]
-            ;; rf2-5x1wt.24 — the variant-plan compiler (re-exported as
+            ;; The variant-plan compiler (re-exported as
             ;; `variant-plan` / `explain`) + the `render-variant` workshop
             ;; render verb that drives the SAME plan the runner consumes
             ;; (spec/017 §Args, controls, and `render-variant`).
             [re-frame.story.plan        :as plan]
             [re-frame.story.render      :as render]
-            ;; rf2-5x1wt.19 — `story/is` bridges per-assertion run-result
+            ;; `story/is` bridges per-assertion run-result
             ;; reports to clojure.test / cljs.test (spec/017 §Public
             ;; execution API — the three verbs). `do-report` is the one
             ;; seam both flavours expose for programmatic test reporting.
@@ -161,7 +157,7 @@
                :cljs [cljs.test    :as test])
             ;; Runtime modules — args resolution, decorators.
             [re-frame.story.args        :as args]
-            ;; rf2-jy92cr — the variant-id STRING-shape grammar. Re-exported
+            ;; The variant-id STRING-shape grammar. Re-exported
             ;; as `valid-variant-id?` below so the story-mcp write path
             ;; validates a caller id before interning via the facade.
             [re-frame.story.schemas     :as schemas]
@@ -172,7 +168,7 @@
             [re-frame.story.play        :as play]
             ;; Test Codegen recorder (pure-data state + snippet generator).
             [re-frame.story.recorder    :as recorder]
-            ;; Recording → live `:script` body translator (rf2-x9zsr).
+            ;; Recording → live `:script` body translator.
             ;; Re-exported as `recording->script-body` so the MCP write-back
             ;; path (story-mcp) can emit the canonical replayable slot.
             [re-frame.story.recorder.play-export :as play-export]
@@ -185,7 +181,7 @@
             ;; Reagent / reagent.dom.client into their classpath.
             #?(:cljs [re-frame.story.ui.shell :as ui-shell])
             #?(:cljs [re-frame.story.ui.multi-substrate :as ui-multi-substrate])
-            ;; rf2-r1uod — Story → Xray project-root bridge. `configure!`
+            ;; Story → Xray project-root bridge. `configure!`
             ;; calls `xray-preset/propagate-project-root!` so Xray-as-RHS
             ;; source-coord chips resolve coords against the same on-disk
             ;; root Story uses. CLJS-only require because the propagator
@@ -283,7 +279,7 @@
 
      `:extends` is stored RAW (intact, parents UNmerged) and resolved by
      the plan compiler — the single merge authority — when the variant is
-     compiled; see `re-frame.story.plan/compile-body` (rf2-f6z88)."
+     compiled; see `re-frame.story.plan/compile-body`."
      [id metadata]
      (macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
@@ -294,7 +290,7 @@
    (defmacro reg-fragment
      "Register a fragment — a reusable setup / script / world mixin a
      variant pulls in through `:compose`. Per spec/017 §Fragments +
-     §Strict composition (rf2-5x1wt.15).
+     §Strict composition.
 
      Fragment body shape — every key is data, no fn-valued slots:
 
@@ -330,7 +326,7 @@
 #?(:clj
    (defmacro reg-check
      "Register a check — a named, reusable assertion pack. Per spec/017
-     §Checks + §Strict composition (rf2-5x1wt.15).
+     §Checks + §Strict composition.
 
      Check body shape:
 
@@ -366,11 +362,11 @@
      Optional slots (per spec/001 §reg-workspace):
 
      - `:doc`       — string description.
-     - `:modes`     — future-reserved (rf2-q5e36); workspaces inherit
+     - `:modes`     — future-reserved; workspaces inherit
                       the chrome toolbar's `:active-modes` in v1 (see
                       spec/001 §Workspace `:modes` slot for the
                       authoritative wording + spec/010 §State location).
-     - `:isolation` — `:variants-grid` mount strategy (rf2-gqid4):
+     - `:isolation` — `:variants-grid` mount strategy:
                       `:isolated` (default — parallel cells with
                       per-variant frames) or `:shared` (serialised
                       mount, one cell at a time with prev/next nav,
@@ -475,7 +471,7 @@
 
      **`:axis`** — optional keyword classifier. The sidebar tag-filter UI
      groups registered tags by `:axis` into collapsible facet rows
-     (rf2-v05qb SB9 parity). Tags registered without `:axis` render in a
+     (SB9 parity). Tags registered without `:axis` render in a
      trailing un-grouped facet row. Query the axis grouping via
      `tags-by-axis` / `tags-without-axis`.
 
@@ -497,8 +493,7 @@
 ;; ---- query API (public) -------------------------------------------------
 ;;
 ;; Bodies live in `re-frame.story.query`. The facade re-exports each
-;; public symbol so callers see them under `re-frame.story/...` per the
-;; rf2-l8eso acceptance contract.
+;; public symbol so callers see them under `re-frame.story/...`.
 
 (defn registrations
   "Return the `{id → body}` map for `kind`, or `{}`. Stable shape across
@@ -507,8 +502,8 @@
 
   Mirror of the spec/001 §Public registrar query API for Story's
   side-table. The Story registry is logically a peer of the framework
-  registrar — see `001-Authoring.md` §Registration macros + bd rf2-7ho2
-  for the design rationale."
+  registrar — see `001-Authoring.md` §Registration macros for the
+  design rationale."
   [kind]
   (query/registrations kind))
 
@@ -543,8 +538,8 @@
   with zero registered variants land in the result with an empty set.
 
   HOT PATH: agents tend to spam `list-stories` (story-mcp's most-called
-  introspection tool); the single-pass index replaces the O(S × V)
-  walk of calling `variants-of` per story (rf2-d3iso)."
+  introspection tool); the single-pass index avoids the O(S × V)
+  walk of calling `variants-of` per story."
   []
   (query/variants-by-story))
 
@@ -570,7 +565,7 @@
   "Per spec/001 §reg-tag — return the set of registered tag ids whose
   body's `:axis` equals `axis-kw` (e.g. `:status` / `:role` / `:team` /
   `:feature`). The sidebar tag-filter UI uses this to group registered
-  tags into collapsible facet rows (rf2-v05qb SB9 parity). Returns the
+  tags into collapsible facet rows (SB9 parity). Returns the
   empty set if no tag carries that axis."
   [axis-kw]
   (query/tags-by-axis axis-kw))
@@ -597,8 +592,8 @@
 
 (def canonical-axes
   "Re-export of the canonical facet axes documented in spec/001
-  §reg-tag — `:status`, `:role`, `:team`, `:feature` (rf2-7ncf9 SB9
-  facet taxonomy) + `:state` (rf2-k1k87 operator-facing magnitude).
+  §reg-tag — `:status`, `:role`, `:team`, `:feature` (SB9 facet
+  taxonomy) + `:state` (operator-facing magnitude).
   Stable across hosts."
   query/canonical-axes)
 
@@ -611,20 +606,20 @@
   query/canonical-role-values)
 
 (def canonical-state-values
-  "Re-export of the canonical `:state` axis vocabulary (rf2-k1k87) —
+  "Re-export of the canonical `:state` axis vocabulary —
   `#{:empty :small :medium :large :special}`."
   query/canonical-state-values)
 
 (def canonical-state-tags
   "Re-export of the canonical `:state/*` faceted tags registered at
-  Story load (rf2-k1k87)."
+  Story load."
   query/canonical-state-tags)
 
 (defn tag->axis-index
   "Per spec/001 §reg-tag — return a `{tag-id → axis-kw}` map across
   every registered tag, in one O(T) pass. Tags without `:axis` map to
   `:re-frame.story.registrar/no-axis`. The sidebar's facet-grouped
-  filter row + the `:tag-filter` AND-across-axes predicate (rf2-7ncf9)
+  filter row + the `:tag-filter` AND-across-axes predicate
   consume this."
   []
   (query/tag->axis-index))
@@ -639,9 +634,9 @@
 
 (def reg-story*       registrar/reg-story*)
 (def reg-variant*     registrar/reg-variant*)
-;; rf2-5x1wt.15 — fragment + check runtime helpers, grouped with the
-;; other registrar re-exports (strict composition: `:compose` pulls these
-;; into a variant plan).
+;; Fragment + check runtime helpers, grouped with the other registrar
+;; re-exports (strict composition: `:compose` pulls these into a variant
+;; plan).
 (def reg-fragment*    registrar/reg-fragment*)
 (def reg-check*       registrar/reg-check*)
 (def reg-workspace*   registrar/reg-workspace*)
@@ -661,8 +656,8 @@
   decorator, layout-debug decorator trio, toolbar cofx + subs, and the
   v1.0 SOTA panel set (CLJS only).
 
-  Per rf2-p1ydc + tools/story/spec/001-Authoring.md §Boot — auto-install
-  of the canonical vocabulary, this fires automatically on the first
+  Per tools/story/spec/001-Authoring.md §Boot — auto-install of the
+  canonical vocabulary, this fires automatically on the first
   `reg-*` call; authors don't have to call it explicitly. The explicit
   call remains supported for hosts that prefer a literal boot step
   and for test fixtures that want to assert a known starting state.
@@ -681,14 +676,12 @@
 
 ;; ---- frame-owned classification — NO add-marks / set-marks re-export -----
 ;;
-;; rf2-bsk1d9 (EP-0015 issue, spec/015 §Frame-owned durable classification):
-;; Story does NOT publish `add-marks` / `set-marks` as author-facing privacy
-;; primitives. EP-0015 moved durable app-db classification onto the frame
-;; owner and explicitly SUPERSEDED the public post-creation `add-marks` /
-;; `set-marks` mutation surface (spec/015 §Supersession note; framework
-;; spec/API.md — the underlying fns are internal / test helpers only). A
-;; Story re-export would re-open that exact escape hatch and guide authors
-;; back to the pre-EP-0015 imperative mark-mutation model.
+;; Per spec/015 §Frame-owned durable classification: Story does NOT publish
+;; `add-marks` / `set-marks` as author-facing privacy primitives. Durable
+;; app-db classification belongs to the frame owner (spec/015 §Supersession
+;; note; framework spec/API.md — the underlying fns are internal / test
+;; helpers only). A Story re-export would open an imperative post-creation
+;; mark-mutation escape hatch that bypasses the frame owner.
 ;;
 ;; The EP-0015-compliant Story surface is FRAME-CREATION classification: a
 ;; variant declares its sensitive / large app-db paths at registration via
@@ -708,15 +701,13 @@
 ;; trace buffer, the recorder, DOM capture) with NO public post-creation
 ;; mark mutation. Per spec/015 §Frame-owned durable classification.
 
-;; ---- reg-global-decorator (rf2-835ey — preview.ts parity, F-1) ----------
+;; ---- reg-global-decorator (Storybook preview.ts parity) -----------------
 ;;
-;; Per ai/findings/2026-05-20-story-tutorial-set.md Finding F-1: Storybook's
-;; canonical "wrap every story in the design system's theme provider"
-;; recipe lives in `preview.ts` as `decorators: [...]`. Story had only
-;; story-level + variant-level decorators; without a global equivalent the
-;; tutorial chapter on decorators cannot offer the canonical recipe, and
-;; large projects end up listing the decorator id on every `reg-story`
-;; manually.
+;; Storybook's canonical "wrap every story in the design system's theme
+;; provider" recipe lives in `preview.ts` as `decorators: [...]`. The
+;; global-decorator stack is Story's parity surface: it carries that recipe
+;; once, so large projects need not list the decorator id on every
+;; `reg-story` manually (alongside story-level + variant-level decorators).
 ;;
 ;; `reg-global-decorator` registers a decorator body (delegating to
 ;; `reg-decorator*`) AND appends a `[<id> & args]` reference to the
@@ -732,8 +723,7 @@
 (defn reg-global-decorator
   "Register a decorator AND opt it into the global stack — every
   variant's resolved decorator chain is prefixed with this entry.
-  Per rf2-835ey + ai/findings/2026-05-20-story-tutorial-set.md Finding
-  F-1 (Storybook `preview.ts` `decorators: [...]` parity).
+  Storybook `preview.ts` `decorators: [...]` parity.
 
   Two-arity registration form (the common case):
 
@@ -775,8 +765,7 @@
 (defn global-decorators
   "Return the current ordered vector of global-decorator references
   (`[[decorator-id & args] ...]`). Earliest-registered first; this is
-  the prefix applied to every variant's resolved decorator stack per
-  rf2-835ey."
+  the prefix applied to every variant's resolved decorator stack."
   []
   (config/get-global-decorators))
 
@@ -790,12 +779,12 @@
 
   Every key lives under the `:rf.story/*` reserved sub-namespace per
   spec/Conventions.md §Reserved namespaces — the `:rf.<tool>/*`
-  convention introduced by Xray's rename (rf2-xea9u).
+  convention.
 
   `{:rf.story/global-args {...}}` — replace the global args map.
 
   `{:rf.story/global-decorators [[<dec-id> & ref-args] ...]}` — replace
-  the global-decorators ref vector per rf2-9qpk3 (Storybook `preview.ts`
+  the global-decorators ref vector (Storybook `preview.ts`
   `decorators: [...]` parity). Each entry is `[decorator-id & ref-args]`
   — same shape a `:decorators` slot on `reg-story` / `reg-variant`
   takes. The decorator BODIES must already be registered via
@@ -805,11 +794,10 @@
   `(concat globals story variant)`. Passing `nil` or `[]` clears the
   global stack. The args-precedence-chain analog already exists at
   Layer 1; this is the decorators analog — both are project-wide
-  defaults the host application sets once at boot. Per Feature-Parity-
-  Audit C-1 / Finding F-1.
+  defaults the host application sets once at boot.
 
-  `{:rf.story/editor <kw>}` — 'Open in editor' preference per
-  rf2-evgf5. One of `:vscode` (default) / `:cursor` / `:idea` /
+  `{:rf.story/editor <kw>}` — 'Open in editor' preference. One of
+  `:vscode` (default) / `:cursor` / `:idea` /
   `{:custom \"<template>\"}`. Drives the `vscode://` / `cursor://` /
   `idea://` URI scheme the source-coord open-button affordances emit.
   See `re-frame.source-coords.editor-uri/editor-uri` for the per-editor
@@ -817,7 +805,7 @@
 
   `{:rf.story/project-root <string>}` — on-disk root prepended to the
   source-coord's classpath-relative `:file` slot when building the
-  'Open in editor' URI per rf2-zfy1e. The host application sets this
+  'Open in editor' URI. The host application sets this
   once at boot — typically the directory above the build's
   source-paths, e.g. `\"C:/Users/me/code/my-app\"` joined to a
   source-coord file like `\"src/app/views.cljs\"` to produce
@@ -825,25 +813,24 @@
   (no prefix; source-coord file ships verbatim — useful when the
   classpath already resolves to absolute paths, and for tests).
 
-  Per rf2-r1uod the value is also bridged into Xray's
+  The value is also bridged into Xray's
   `:rf.xray/project-root` slot via
   `re-frame.story.xray-preset/propagate-project-root!` so Xray-as-RHS
   source-coord chips (open-in-editor on the Handler / Dispatch /
   Interceptor chips, Trace tab rows, Issues ribbon) resolve against the
   same on-disk root. The bridge is one-way; hosts that want Xray
   pointed at a different root call `xray-config/configure!` directly
-  AFTER `story/configure!`. Symmetric to shop's rf2-6jyf6.
+  AFTER `story/configure!`.
 
   `{:rf.story/egress-profile <kw>}` — Story's on-box dev-UI egress
-  profile per EP-0015 (frame-owned egress policy, rf2-3t26eh). One of
+  profile per EP-0015 (frame-owned egress policy). One of
   the six ruled `:rf.egress/*` profiles; in practice the two on-box
   members: `:rf.egress/local-redacted` (default — suppress sensitive
   display, FAIL-CLOSED) or `:rf.egress/local-raw` (the trusted-local
   opt-in — show path-marked-sensitive values verbatim on your own
-  machine). EP-0015 issue 7 retired the process-global
-  `:rf.privacy/show-sensitive?` boolean in favour of this named-boundary
-  choice: there is no single on/off toggle, the question is *which
-  boundary is this?* Story's value-bearing surfaces (the recorder, the
+  machine). Egress is a named-boundary choice (EP-0015), not a single
+  on/off toggle: the question is *which boundary is this?* Story's
+  value-bearing surfaces (the recorder, the
   per-variant trace-buffer listener consumed by the schema-validation
   panel, the play-assertion listeners) project through the centralized
   `re-frame.core/project-egress` walker under this profile and surface a
@@ -851,8 +838,8 @@
   raises `:rf.error/unknown-egress-profile`. `nil` resets to the
   redacting default.
 
-  Unrecognised keys raise `:rf.error/unknown-story-config-key` per
-  rf2-xwr1d. Pre-alpha posture: a typo (`:rf.story/edtior`) should
+  Unrecognised keys raise `:rf.error/unknown-story-config-key`.
+  Pre-alpha posture: a typo (`:rf.story/edtior`) should
   fail loudly at boot rather than silently no-op and leave the
   author chasing 'why isn't my editor preference taking effect?'
   across a session. The known-keys set is closed and small —
@@ -896,12 +883,12 @@
     (config/set-editor! editor))
   (when (contains? opts :rf.story/project-root)
     (config/set-project-root! project-root)
-    ;; rf2-r1uod — bridge into Xray's `:rf.xray/project-root` slot so
+    ;; Bridge into Xray's `:rf.xray/project-root` slot so
     ;; Xray-as-RHS source-coord chips share the same on-disk root.
     ;; Feature-detect-safe (no-op when Xray is not on the classpath).
     #?(:cljs (xray-preset/propagate-project-root!)))
   (when (contains? opts :rf.story/egress-profile)
-    ;; EP-0015 (rf2-3t26eh): the named-boundary enum is CLOSED. An unknown
+    ;; EP-0015: the named-boundary enum is CLOSED. An unknown
     ;; non-nil profile fails loudly at boot — mirroring `project-egress`'s
     ;; own `:rf.error/unknown-egress-profile` — rather than silently
     ;; coercing to the default. `nil` resets to the redacting default.
@@ -936,21 +923,20 @@
 
   Also:
   - resets every leakable process-global config atom via
-    `re-frame.story.config/reset-all!` (rf2-6ez1u) — `global-args`
+    `re-frame.story.config/reset-all!` — `global-args`
     (Layer 1 of args resolution), `global-decorators`, `editor`,
     `project-root`, `egress-profile`, and `suppressed-counters` — so
     a `configure!` (or any config mutation) in one test cannot leak
     into the next and silently perturb a later variant's effective
-    args. (Subsumes the earlier rf2-835ey global-decorators-only
-    clear; `toggle-off-callbacks` are deliberately left intact — they
+    args. (`toggle-off-callbacks` are deliberately left intact — they
     are load-time module registrations, not per-test state.)
-  - resets the rf2-p1ydc auto-install gate so the next `reg-*` call
+  - resets the auto-install gate so the next `reg-*` call
     after `clear-all!` re-installs the canonical vocabulary on demand
     (the registrar's side-table is now empty — the seven canonical
     tags etc. need to be re-registered before any tagged variant can
     be added).
   - resets the two per-process play atoms (`pending-exceptions` +
-    `stepper-state`) via `play/clear-all-play-state!` (rf2-eztym.2) — the
+    `stepper-state`) via `play/clear-all-play-state!` — the
     remaining un-reset per-process state, so a stepper / pending-exception
     session in one test cannot leak into the next on a reset path that
     bypasses per-frame `frames/destroy!` teardown."
@@ -963,7 +949,7 @@
 ;; ---- canonical test-fixture helper — DIRECT-REQUIRE, not on this facade -
 ;;
 ;; The canonical Story test-fixture helper lives in
-;; `re-frame.story.test-support` (rf2-lh99f) — `with-clean-registry` /
+;; `re-frame.story.test-support` — `with-clean-registry` /
 ;; `use-fixtures`. It is DELIBERATELY NOT re-exported on this facade:
 ;; `re-frame.story.test-support` requires `re-frame.test-support`, which
 ;; requires `cljs.test` / `clojure.test`; re-exporting it here would pull
@@ -1077,7 +1063,7 @@
   ([variant-id]       (lifecycle/snapshot-identity variant-id))
   ([variant-id opts]  (lifecycle/snapshot-identity variant-id opts)))
 
-;; ---- canonicalization / fingerprinting (rf2-5x1wt.3) --------------------
+;; ---- canonicalization / fingerprinting ----------------------------------
 ;;
 ;; The single canonical projection + hashing primitive lives in
 ;; `re-frame.story.fingerprint`. These are the public re-exports per
@@ -1119,7 +1105,7 @@
   [result]
   (fingerprint/run-hash result))
 
-;; ---- run-evidence projection (rf2-5x1wt.4) ------------------------------
+;; ---- run-evidence projection --------------------------------------------
 ;;
 ;; Per spec/017 §Run-result evidence projection — the single boundary from
 ;; the retained epoch tape to the API-stable run-result evidence slots. The
@@ -1146,7 +1132,7 @@
   ([epoch-tape]                     (evidence/tape-shows-failure? epoch-tape))
   ([epoch-tape consumed-selectors]  (evidence/tape-shows-failure? epoch-tape consumed-selectors)))
 
-;; ---- narrative navigation (rf2-5x1wt.23) --------------------------------
+;; ---- narrative navigation -----------------------------------------------
 ;;
 ;; Per spec/017 §Epoch tape and narrative — the pure scrub backbone. The
 ;; two-level `:narrative` is a tree (spans over beats); a Test-mode /
@@ -1183,7 +1169,7 @@
   [narrative]
   (evidence/beat-epoch-ids narrative))
 
-;; ---- run artifact + replay (rf2-5x1wt.7) --------------------------------
+;; ---- run artifact + replay ----------------------------------------------
 ;;
 ;; Per spec/017 §Run artifact and replay — the serializable
 ;; `:rf.test/run-artifact` record + the function that replays it into a
@@ -1213,7 +1199,7 @@
   ([art]      (artifact/replay-run-artifact art))
   ([art opts] (artifact/replay-run-artifact art opts)))
 
-;; ---- determinism gate (rf2-5x1wt.8) -------------------------------------
+;; ---- determinism gate ---------------------------------------------------
 ;;
 ;; Per spec/017 §Determinism gate — replay the plan/artifact into N FRESH
 ;; frames and compare the canonical run-slices. Builds on `.7` replay and
@@ -1233,7 +1219,7 @@
   ([plan-or-artifact]      (determinism/assert-deterministic plan-or-artifact))
   ([plan-or-artifact opts] (determinism/assert-deterministic plan-or-artifact opts)))
 
-;; ---- run-artifact → variant promotion bridge (rf2-5x1wt.25) -------------
+;; ---- run-artifact → variant promotion bridge ----------------------------
 ;;
 ;; Per spec/017 §Promotion — Promotion bridge: a curated run artifact
 ;; becomes a NAMED Story variant. Two surfaces: `materialize-variant-plan`
@@ -1267,7 +1253,7 @@
   [artifact opts]
   (promotion/promote-run-artifact! artifact opts))
 
-;; ---- generated / property-style runs (rf2-5x1wt.31) ---------------------
+;; ---- generated / property-style runs ------------------------------------
 ;;
 ;; Per spec/017 §Generated runs and artifacts — a property over N generated
 ;; event programs that emits a SEED-bearing `:rf.test/run-artifact` for every
@@ -1301,7 +1287,7 @@
   [base-program fault-lattice opts]
   (generate/sweep-faults! base-program fault-lattice opts))
 
-;; ---- semantic diff over run artifacts (rf2-5x1wt.9) ---------------------
+;; ---- semantic diff over run artifacts -----------------------------------
 ;;
 ;; Per spec/017 §Semantic diff — a readable diff between two runs, with the
 ;; per-run noise (frame ids, timestamps, dispatch / epoch / trace ids)
@@ -1325,7 +1311,7 @@
   ([baseline current]      (diff/diff-run-artifacts baseline current))
   ([baseline current opts] (diff/diff-run-artifacts baseline current opts)))
 
-;; ---- golden slices (rf2-5x1wt.32) ---------------------------------------
+;; ---- golden slices ------------------------------------------------------
 ;;
 ;; Per spec/017 §Golden slices — a curated canonicalized run regression
 ;; artifact: freeze a run's behavioural slice via `canonicalize` (the slice
@@ -1443,7 +1429,7 @@
   []
   assertions/known-assertion-ids)
 
-;; ---- unified run-result + the three verbs (rf2-5x1wt.19) ----------------
+;; ---- unified run-result + the three verbs -------------------------------
 ;;
 ;; Per spec/017 §Run result + §Unified run result + §Public execution API:
 ;; ONE run-result shape, and `story/is` bridges it to clojure.test /
@@ -1525,7 +1511,7 @@
   [records unmet]
   (requirements/aggregate-status records unmet))
 
-;; ---- the frozen, schema-backed run-result contract (rf2-3nbl5.6) --------
+;; ---- the frozen, schema-backed run-result contract ----------------------
 ;;
 ;; The unified run-result is a FROZEN public contract — the ONE result
 ;; language spoken IDENTICALLY across `run` / `is` / `render-variant`, the
@@ -1533,24 +1519,23 @@
 ;; re-export the executable Malli schema (`re-frame.story.result/RunResult`)
 ;; + its validators so any surface (CI, MCP, the test corpus) can prove a
 ;; result conforms without a parallel schema. The verdict is `:status`
-;; (`result-status` / `result-passed?`); there is NO `:passing?` boolean
-;; (the clean break, rf2-ba86n.17).
+;; (`result-status` / `result-passed?`); there is NO `:passing?` boolean.
 
 (def run-result-schema
-  "Per spec/017 §Run result (rf2-3nbl5.6) — the frozen Malli schema for the
+  "Per spec/017 §Run result — the frozen Malli schema for the
   unified run-result. The ONE schema-backed contract Story UI, CI,
   `clojure.test`, and story-mcp validate against (see
   `re-frame.story.result/RunResult`)."
   result/RunResult)
 
 (defn valid-run-result?
-  "Per spec/017 §Run result (rf2-3nbl5.6) — true iff `result` conforms to
+  "Per spec/017 §Run result — true iff `result` conforms to
   the frozen `run-result-schema`. Pure data → data."
   [result]
   (result/valid-run-result? result))
 
 (defn explain-run-result
-  "Per spec/017 §Run result (rf2-3nbl5.6) — Malli explanation of why
+  "Per spec/017 §Run result — Malli explanation of why
   `result` does NOT conform to the frozen `run-result-schema`, or nil when
   it conforms. Pure data → data."
   [result]
@@ -1575,7 +1560,7 @@
 
   - a **keyword** is a registered variant id — resolved through the Story
     side-table and run through the variant lifecycle;
-  - a **map** is an INLINE plan (rf2-5x1wt.20, spec/017 §Inline plan) —
+  - a **map** is an INLINE plan (spec/017 §Inline plan) —
     compiled, run against a fresh anonymous frame, and torn down on
     resolve. An inline plan is NOT registered in the side-table and is
     absent from Story navigation; it MAY compose registered fragments +
@@ -1594,7 +1579,7 @@
      (lifecycle/run-inline-plan target opts)
      (lifecycle/run-variant target opts))))
 
-;; ---- variant-plan / explain / render-variant (rf2-5x1wt.24) -------------
+;; ---- variant-plan / explain / render-variant ----------------------------
 ;;
 ;; The variant-plan compiler is the ONE normalization both the runner and
 ;; the workshop render path consume (spec/017 §Variant plan — every
@@ -1645,7 +1630,7 @@
   NOT execute `:script` or terminal `:expect` (rendering is not a test
   run). The `:plan-hash` is computed over the SAME normalized plan as
   `story/run`, so a runner and `render-variant` agree on it whenever the
-  behaviour-relevant inputs match (rf2-5x1wt.24). A control override that
+  behaviour-relevant inputs match. A control override that
   drives an invalid view input STOPS render before the view is called
   (`:invalid-args`); on the bare JVM (no host renderer) the verb returns
   `:cannot-run` rather than a silent empty render."
@@ -1670,7 +1655,7 @@
 
   `target` dispatches the same way `story/run` does: a keyword is a
   registered variant; a map (without a `:status` / `:assertions` pair) is
-  an INLINE plan (rf2-5x1wt.20) — compiled + run against a fresh anonymous
+  an INLINE plan — compiled + run against a fresh anonymous
   frame, then reported per assertion. (A map that ALREADY carries a
   `:status` + `:assertions` is treated as an already-resolved run-result
   and reported directly — the sync path, below.)
@@ -1686,7 +1671,7 @@
   `(async done …)` form) and call `(story/report-result! result)` when it
   resolves. `report-result!` is the pure-report seam both runtimes share.
 
-  ## `:timeout-ms` — the JVM block bound (rf2-zaklu)
+  ## `:timeout-ms` — the JVM block bound
 
   `opts` MAY carry `:timeout-ms` — the JVM blocking-deref bound, in
   milliseconds (default `30000`). A run that does not resolve inside the
@@ -1708,13 +1693,13 @@
          target)
 
      :else
-     ;; rf2-zaklu — `:timeout-ms` bounds the JVM blocking deref (default
+     ;; `:timeout-ms` bounds the JVM blocking deref (default
      ;; 30000), read on the `:clj` branch only (CLJS never blocks). Strip
      ;; it from the opts threaded into `run` so the runner / plan-compiler
      ;; does not see a key it does not own.
      (let [run-opts (not-empty (dissoc opts :timeout-ms))
            p        (run target run-opts)]
-       ;; rf2-ngwdf — both branches pass `(:variant/id result)`, matching
+       ;; Both branches pass `(:variant/id result)`, matching
        ;; the already-resolved sync branch above. `emit-reports!` ignores
        ;; its first arg TODAY, so this is behaviour-preserving; it removes
        ;; the latent trap of three call sites supplying three different
@@ -1798,7 +1783,7 @@
   layout-debug/id-pseudo)
 
 (defn variant-share-url
-  "Per `005-SOTA-Features.md` §Share URL (retired QR popover) — build a sharable URL for a variant against
+  "Per `005-SOTA-Features.md` §Share URL — build a sharable URL for a variant against
   `base-url`. Encodes active modes + cell-overrides + substrate so a
   scan-and-share session reproduces the cell.
 
@@ -1849,7 +1834,7 @@
   ([variant-id]       (decorators/resolve-decorators variant-id))
   ([variant-id opts]  (decorators/resolve-decorators variant-id opts)))
 
-;; ---- rf2-8wgpm: static-mode? probe --------------------------------------
+;; ---- static-mode? probe -------------------------------------------------
 
 (defn static-mode?
   "Per tools/story/spec/013-Static-Build.md — return true iff Story is
@@ -1882,10 +1867,9 @@
      - the main pane (selected variant's canvas or selected workspace)
      - a right panel — Xray embedded as the primary inspector,
        plus controls, dispatch console, and play status / viewport
-       / background chrome chips (rf2-sgdd3 — the Story-side
-       scrubber / trace / actions panels were retired; Xray's L1
-       ribbon + L2 event list + Trace tab + Event-tab cascade view
-       cover what they did)
+       / background chrome chips. Xray's L1 ribbon + L2 event list +
+       Trace tab + Event-tab cascade view cover scrubbing, trace, and
+       action inspection.
 
      Per `003-Render-Shell.md` §Shell lifecycle v1 supports one mounted shell at a time; calling
      `mount-shell!` while a shell is already mounted tears down the
@@ -1911,10 +1895,10 @@
      []
      (ui-shell/active-shell)))
 
-;; ---- rf2-5fc15 — Test Codegen recorder public surface --------------------
+;; ---- Test Codegen recorder public surface -------------------------------
 ;;
-;; Per bead rf2-5fc15 the recorder captures canvas-dispatched events as
-;; a `:play-script` body. Exposing the entry points here lets tests, MCP
+;; The recorder captures canvas-dispatched events as a `:play-script`
+;; body. Exposing the entry points here lets tests, MCP
 ;; tooling, and headless integrations drive recording programmatically
 ;; without going through the toolbar UI.
 
@@ -1959,12 +1943,11 @@
 (defn gen-play-snippet
   "Render an EDN snippet `(reg-variant <id> {... :script {...}})` for
   `events`. Pure data → string; round-trips through `read-string` and
-  re-frame's registrar machinery. Per rf2-7mj4z the emitted snippet uses
-  the PUBLIC `:script` authoring slot (spec/017 §Public vocabulary), not
-  the transitional `:play-script` spelling — each captured event vector
-  is wrapped as a `[:dispatch-sync <event-vec>]` step under the public
-  `:script` body's inner `:script` vector (rf2-0wrud — the one phase-4
-  step grammar).
+  re-frame's registrar machinery. The emitted snippet uses
+  the PUBLIC `:script` authoring slot (spec/017 §Public vocabulary) —
+  each captured event vector is wrapped as a `[:dispatch-sync
+  <event-vec>]` step under the public `:script` body's inner `:script`
+  vector (the one phase-4 step grammar).
 
   `opts` accepts:
     :variant-id  required — keyword id for the new variant.
@@ -1987,10 +1970,10 @@
   `{:script [...] :auto-run? bool}` map a runner executes. The MCP
   write-back path (`record-as-variant`) calls this to re-register the
   variant with a live `:script` slot — the canonical AND ONLY phase-4
-  replay surface per rf2-0wrud.
+  replay surface.
 
-  `events` may be the legacy bare-events vector OR the rich `:entries`
-  vector (rf2-d5u89). `opts` accepts `:auto-run?`, `:name`,
+  `events` may be the bare-events vector OR the rich `:entries`
+  vector. `opts` accepts `:auto-run?`, `:name`,
   `:auto-assert?` + `:final-db`/`:seed-db`/`:max-auto-assertions`, and
   `:wait-threshold-ms` — see `re-frame.story.recorder.play-export/
   recording->script-body` for the full contract.

--- a/tools/story/src/re_frame/story/args.cljc
+++ b/tools/story/src/re_frame/story/args.cljc
@@ -65,13 +65,11 @@
 ;; ---- parent-story lookup --------------------------------------------------
 ;;
 ;; Re-export from `re-frame.story.predicates` (the canonical leaf home).
-;; rf2-ee38b.3 dropped the docs / state / test-mode pure re-exports (which
-;; had ≤1 caller each); this `args/parent-story-id` alias survives because
-;; ~9 sibling namespaces (decorators, identity, runtime, canvas, controls,
-;; multi-substrate, panels, schema-validation, workspace) `:require` args
-;; already and call it through this alias. Folding those onto
-;; `pred/parent-story-id` directly is a mechanical follow-up; the alias is
-;; a thin pass-through, not new behaviour.
+;; This `args/parent-story-id` alias exists because ~9 sibling namespaces
+;; (decorators, identity, runtime, canvas, controls, multi-substrate,
+;; panels, schema-validation, workspace) `:require` args already and call
+;; it through this alias. The alias is a thin pass-through to
+;; `pred/parent-story-id`.
 
 (def parent-story-id
   "Derive the parent story id from a variant id. Per /spec/007-Stories.md
@@ -143,7 +141,7 @@
   ([variant-id] (resolve-args variant-id nil))
   ([variant-id opts] (resolve-args variant-id opts)))
 
-;; ---- ambient + run arg layers (rf2-2cpoo) ---------------------------------
+;; ---- ambient + run arg layers ---------------------------------------------
 ;;
 ;; The plan compiler resolves the variant-CHAIN `:args` (the `:extends`-merged
 ;; variant body args, the §Total resolution order variant layer) itself, but
@@ -155,9 +153,8 @@
 ;; its `arg-map` — and therefore every `[:arg key]` substitution in
 ;; setup/script/db-seed/network/sub-overrides, plus `[:world :effective-args]`
 ;; and the plan hash — uses the SAME effective args the run/render surfaces
-;; report (rf2-2cpoo: the run path used to compile with the variant layer
-;; ALONE, so a cell override / active mode reported one effective-args while
-;; the executed plan substituted another).
+;; report. This keeps a cell override / active mode reporting the same
+;; effective-args the executed plan substitutes.
 
 (defn run-arg-layers
   "Return the AMBIENT + per-RUN arg layers (everything `resolve-args` folds

--- a/tools/story/src/re_frame/story/artifact.cljc
+++ b/tools/story/src/re_frame/story/artifact.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.story.artifact
   "The `:rf.test/run-artifact` schema + `replay-run-artifact` — a
   serializable record of a Story run, and the function that replays it
-  into a fresh frame (NewTestStory rf2-5x1wt.7, spec/017-Testing-Story.md
+  into a fresh frame (spec/017-Testing-Story.md
   §Run artifact and replay + §Artifacts — Run artifact).
 
   ## What a run artifact is
@@ -53,7 +53,7 @@
   route map in `:network` lets replay RE-INSTALL those route stubs before
   replaying, so a replayed `:network` request matches its route and
   synthesises the recorded reply rather than fail-closing on
-  \"no stub matched\" (rf2-tymyh, spec/017 §The network surface).
+  \"no stub matched\" (spec/017 §The network surface).
 
   ## Replay
 
@@ -64,8 +64,8 @@
   (`re-frame.story.play.evidence/project-evidence`). The returned
   run-result is the SHARED run-result shape (spec/017 §Run result) — the
   same shape the runner returns and the same one `canonicalize` /
-  `run-hash` consume — so a later determinism gate (rf2-5x1wt.8) and
-  semantic diff (rf2-5x1wt.9) build directly on it.
+  `run-hash` consume — so a later determinism gate and semantic diff
+  build directly on it.
 
   ## Pure / JVM-testable
 
@@ -83,9 +83,10 @@
             [re-frame.story.play.runner           :as runner]
             [re-frame.story.play.settled-boundary :as boundary]
             ;; The raw HTTP stub pair lives in `re-frame.http.test-support`
-            ;; (rf2-ntwwyt — no longer a `re-frame.core` façade re-export).
-            ;; CLJS requires it directly; on the JVM it is resolved LAZILY at
-            ;; call time (`with-network-stubs!`) so requiring this ns from the
+            ;; (reached through its home namespace, not the `re-frame.core`
+            ;; façade). CLJS requires it directly; on the JVM it is resolved
+            ;; LAZILY at call time (`with-network-stubs!`) so requiring this
+            ;; ns from the
             ;; `re-frame.story` MACRO-ns does NOT drag the http artefact's
             ;; JVM-only transitive deps (e.g. cheshire) onto the macro
             ;; classpath. CLJS pulls only the CLJS-clean `.cljc` surface.
@@ -108,7 +109,7 @@
 
   `:network` is the per-route HTTP reply map (`{[method url] {:reply …}}`)
   carried so replay can re-install the managed-request stubs the
-  `:fx-decisions` redirect points at (rf2-tymyh, spec/017 §The network
+  `:fx-decisions` redirect points at (spec/017 §The network
   surface — \"the runner installs the route map via
   install-managed-request-stubs!\").
 
@@ -204,7 +205,7 @@
   and lets the boundary's `:cannot-run` / `:error` refusals fire
   unchanged.
 
-  EP-0017 replay fidelity (rf2-srgvzp): the wrapped `:dispatch!` is the
+  EP-0017 replay fidelity: the wrapped `:dispatch!` is the
   optional 3-arity `(replay-dispatch! frame-id event-vector dispatch-opts)`
   the boundary's 6-arity `dispatch-and-settle!` invokes when a step carries
   dispatch opts. `replay-into-frame!` builds those opts so every replayed
@@ -217,7 +218,7 @@
   `drain-sync!` merges them onto the dispatch envelope), alongside the
   lexical `fx-decisions` wrap — both survive whatever dispatch path the
   (possibly richer-adapter) inner hook owns. A 2-arity replay (no opts)
-  stays byte-identical to the pre-EP-0017 path."
+  stays byte-identical to the opts-free dispatch path."
   [base-hooks fx-decisions]
   (let [inner (or (:dispatch! base-hooks) boundary/drain-sync!)
         ;; Route the dispatch through `inner`, optionally with opts, always
@@ -252,8 +253,8 @@
   When the artifact carries no `:network` routes, `thunk` runs unchanged
   (no install, no uninstall) — so an artifact without HTTP stays clear of
   the test-support surface entirely. The install/uninstall pair lives in
-  `re-frame.http.test-support` (rf2-ntwwyt — no longer a `re-frame.core`
-  façade export; reached through its home namespace), which Story already
+  `re-frame.http.test-support` (reached through its home namespace, not
+  the `re-frame.core` façade), which Story already
   carries on its require closure via the `day8/re-frame2-http` dep."
   [artifact thunk]
   (let [network (:network artifact)]
@@ -274,7 +275,7 @@
 
 (defn- epoch-count
   "The current epoch-history length for `frame-id` — the append-only tape
-  cursor a replay settle boundary snapshots (rf2-rkd14). Tolerant: 0 when
+  cursor a replay settle boundary snapshots. Tolerant: 0 when
   the frame has no history / the epoch dep is absent (facade → `[]`)."
   [frame-id]
   (try (count (rf/epoch-history frame-id))
@@ -282,7 +283,7 @@
 
 (defn- step-dispatch-opts
   "Build the per-call dispatch opts a replayed `[:dispatch …]` step carries
-  (rf2-srgvzp, EP-0017 §6 / Tool-Pair §Replay). Replay is UNCONDITIONALLY
+  (EP-0017 §6 / Tool-Pair §Replay). Replay is UNCONDITIONALLY
   STRICT: every replayed dispatch stamps `:rf.cofx/mint-policy :strict`, so a
   generator-backed recordable fact that is ABSENT from the record fails loudly
   (`:rf.error/missing-required-cofx`) instead of minting a fresh, divergent
@@ -306,7 +307,7 @@
   per dispatch step), in program order — `{:status :settled :boundary …}`
   on success, a `cannot-run-refusal` / `{:status :error …}` otherwise.
 
-  rf2-rkd14 — the returned vector carries an `:attribution` metadata slot:
+  The returned vector carries an `:attribution` metadata slot:
   the epoch-history LENGTH snapshotted at the start of each dispatch step's
   settle, in dispatch-step order. `replay-result` reads it (via
   `(:attribution (meta outcomes))`) and hands it to `project-evidence` so
@@ -368,8 +369,8 @@
   [{:keys [epoch-tape artifact outcomes frame-id app-db]}]
   (let [evidence-slots (evidence/project-evidence
                          epoch-tape {:script      (:event-program artifact)
-                                     ;; rf2-rkd14 — the per-dispatch-step
-                                     ;; settle boundaries `replay-into-frame!`
+                                     ;; The per-dispatch-step settle
+                                     ;; boundaries `replay-into-frame!`
                                      ;; recorded (on the outcomes vector's
                                      ;; metadata) light up EXACT narrative
                                      ;; attribution. Absent (a hand-built
@@ -407,8 +408,7 @@
     after the program settles, NOT the artifact's captured tape.
   - Project that tape through the merged `.4` evidence boundary and return
     the shared run-result shape — stable + canonicalizable, so the
-    determinism gate (rf2-5x1wt.8) + semantic diff (rf2-5x1wt.9) build on
-    it directly.
+    determinism gate + semantic diff build on it directly.
 
   `opts` (all optional):
 
@@ -436,7 +436,7 @@
        ;; Re-install the artifact's `:network` route stubs (when any) for the
        ;; duration of the replay, so the `:fx-decisions` managed-stub redirect
        ;; resolves to a stub that matches the recorded routes rather than
-       ;; fail-closing (rf2-tymyh, spec/017 §The network surface).
+       ;; fail-closing (spec/017 §The network surface).
        (with-network-stubs! artifact
          (fn []
            (let [outcomes (replay-into-frame! frame-id artifact hooks)

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -18,9 +18,9 @@
   | `:rf.assert/no-warnings`       | `[]`                           | No `:warning` trace events since play start |
   | `:rf.assert/effect-emitted`    | `[fx-id (optional pred)]`      | fx-id emitted during play? |
 
-  A NET-NEW eighth canonical id — `:rf.assert/schema-error` (rf2-5x1wt.21)
-  — is *recognised* but is NOT one of the seven REGISTERED handlers: it is
-  tape-evaluated in `result.cljc`, never dispatched (see `canonical-assertion-ids`).
+  An eighth canonical id — `:rf.assert/schema-error` — is *recognised* but
+  is NOT one of the seven REGISTERED handlers: it is tape-evaluated in
+  `result.cljc`, never dispatched (see `canonical-assertion-ids`).
 
   ## Record, don't throw (per `004-Assertions.md` §Record-don't-throw semantics)
 
@@ -44,7 +44,7 @@
   `re-frame.story.config/enabled?` false) skip the registrations.
   An unknown assertion id FAILS plan construction with
   `:rf.error/story-unknown-assertion` (`assertion-id-known?` /
-  `known-assertion-ids`, rf2-5x1wt.18) — there is NO run-time
+  `known-assertion-ids`) — there is NO run-time
   `:rf.assert/unknown` pseudo-record; an unrecognised id never reaches
   a handler.
 
@@ -65,7 +65,7 @@
     consumer tests via the public `assertions-passing?`).
   - `canonical-assertion-ids` — the recognised canonical assertion ids:
     the seven REGISTERED `reg-event` handlers PLUS the tape-evaluated
-    `:rf.assert/schema-error` (rf2-5x1wt.21), which plan construction
+    `:rf.assert/schema-error`, which plan construction
     recognises but which is deliberately NEVER installed as a handler
     (it is evaluated against the epoch tape in `result.cljc`, not
     dispatched into the frame). So the set is eight ids, only seven of
@@ -92,19 +92,15 @@
 ;;   - `:rf.assert/effect-emitted` — which fx-ids the cascade emitted;
 ;;   - `:rf.assert/dispatched?`   — which event vectors were dispatched.
 ;;
-;; rf2-q651r — single source of truth. The framework RETAINS exactly these
-;; facts in the epoch tape (`re-frame.core/epoch-history`), and
-;; `re-frame.story.play.evidence` already PROJECTS them as the run-result
-;; `:warnings` / `:effects` evidence slots. Previously these three handlers
-;; read a SECOND, parallel per-frame accumulator (`trace-accumulators`),
-;; fed by a distinct trace listener in `re-frame.story.play` — a second
-;; capture path that could drift from the tape (different filtering),
-;; reintroducing the documented "false GREEN" the evidence boundary closed.
-;; Schema-error (rf2-5x1wt.21) and causal/cascade (rf2-5x1wt.31) assertions
-;; were already migrated to tape-evaluation in `result.cljc`; these three
-;; were the stragglers. They now read the SAME tape projection the
-;; run-result slots do, so an in-script `[:assert [:rf.assert/no-warnings]]`
-;; checkpoint cannot disagree with the run-result `:warnings` slot.
+;; Single source of truth. The framework RETAINS exactly these facts in
+;; the epoch tape (`re-frame.core/epoch-history`), and
+;; `re-frame.story.play.evidence` PROJECTS them as the run-result
+;; `:warnings` / `:effects` evidence slots. All eight assertions —
+;; including schema-error and the causal/cascade pair (tape-evaluated in
+;; `result.cljc`) — read the SAME tape projection the run-result slots do,
+;; so an in-script `[:assert [:rf.assert/no-warnings]]` checkpoint cannot
+;; disagree with the run-result `:warnings` slot. A single capture path
+;; (no parallel accumulator) means no drift and no "false GREEN".
 ;;
 ;; The projections are PURE (tape data → fact), so the handlers stay pure
 ;; data → data; the handler shell reads `rf/epoch-history` once and threads
@@ -115,15 +111,13 @@
 ;;
 ;; ## Privacy
 ;;
-;; The retired play-listener default-suppressed `:sensitive? true` events
-;; (Spec 009 §Privacy) before they reached the accumulator. The tape
-;; projections preserve that posture for the only fact that carries a
-;; payload — dispatched event vectors: `dispatched-events` drops the
-;; `:trigger-event` of any epoch flagged `:rf.epoch/sensitive?` while
-;; Story's local-render egress profile redacts (the
-;; `:rf.egress/local-redacted` default, EP-0015 rf2-3t26eh), so a
-;; sensitive event vector never lands raw on an assertion record's
-;; `:actual`. Warning records
+;; The tape projections enforce the Spec 009 §Privacy posture for the only
+;; fact that carries a payload — dispatched event vectors:
+;; `dispatched-events` drops the `:trigger-event` of any epoch flagged
+;; `:rf.epoch/sensitive?` while Story's local-render egress profile redacts
+;; (the `:rf.egress/local-redacted` default, EP-0015), so a sensitive event
+;; vector never lands raw on an assertion record's `:actual`. Warning
+;; records
 ;; carry only `:operation` / `:category` metadata (no payload), so the
 ;; `:warnings` projection — which agrees with the run-result slot — counts
 ;; them without a payload-leak risk.
@@ -149,10 +143,10 @@
 
   Assertion events (`:rf.assert/*`) are excluded — an `[:assert …]`
   checkpoint dispatches its wrapped atom, which commits an epoch, but a
-  verdict is not behaviour-under-test (mirrors the retired listener's
-  `assertion-event?` skip + `evidence/narrative`'s span-attribution rule).
+  verdict is not behaviour-under-test (the same `assertion-event?` skip
+  `evidence/narrative`'s span-attribution rule applies).
 
-  Privacy (Spec 009 §Privacy + EP-0015 issue 7, rf2-6z4znr): the
+  Privacy (Spec 009 §Privacy + EP-0015 issue 7): the
   `:trigger-event` of an epoch flagged `:rf.epoch/sensitive?` is dropped
   while the egress profile resolved FOR THIS FRAME redacts
   (`:rf.egress/local-redacted` — the default), so a sensitive event vector
@@ -171,8 +165,7 @@
 
 (defn- non-framework-fx?
   "True iff `fx-id` is a user fx (not the ubiquitous framework `:db` / `:fx`
-  aggregators). Mirrors the retired listener's `framework-fx-id?` gate so
-  `:rf.assert/effect-emitted` reflects USER fx only (rf2-ee38b.3)."
+  aggregators), so `:rf.assert/effect-emitted` reflects USER fx only."
   [fx-id]
   (not (contains? #{:db :fx} fx-id)))
 
@@ -209,30 +202,25 @@
 (defn warnings
   "Project the warning trace records emitted against `frame-id` from its
   epoch tape (`evidence/warnings`) — the SAME projection the run-result
-  `:warnings` slot reads, so `:rf.assert/no-warnings` and the slot AGREE
-  (rf2-q651r). Pure-ish (the only read is the late-bound tape)."
+  `:warnings` slot reads, so `:rf.assert/no-warnings` and the slot AGREE.
+  Pure-ish (the only read is the late-bound tape)."
   [frame-id]
   (evidence/warnings (frame-tape frame-id)))
 
 ;; ---------------------------------------------------------------------------
-;; Trace side-table — FULLY REMOVED (rf2-luzky)
+;; Where the trace-bus facts live (no parallel accumulator)
 ;;
-;; rf2-q651r retired the `trace-accumulators` atom AS THE EVIDENCE SOURCE
-;; for the three trace-bus assertions (they project from the epoch tape
-;; above); rf2-luzky removed the atom ENTIRELY. The facts it once mirrored
-;; (warnings / emitted-fx / dispatched) are answerable from the canonical
-;; tape + the stub-call log (the SSOT), so the parallel atom — and its
-;; `record-warning!` / `record-emitted-fx!` / `record-dispatched!` feeds +
-;; the `reset-trace-accumulators!` / `drop-trace-accumulators!` helpers —
-;; carried no fact the tape does not already hold. The three concerns that
-;; once rode through this module's listener feed now live where they belong:
+;; The three trace-bus assertions (warnings / emitted-fx / dispatched)
+;; project from the canonical epoch tape + the stub-call log (the SSOT)
+;; above — there is no separate accumulator atom to keep in sync. The three
+;; related concerns each live with the surface that owns them:
 ;;
 ;;   - PRIVACY suppression (default-drop `:sensitive? true` + the
 ;;     `config/note-suppressed!` redaction-counter bump) is the egress seam
-;;     in `re-frame.story.play`'s per-frame trace listener — it was always
-;;     the gate at the head of that listener, never a property of this atom;
+;;     in `re-frame.story.play`'s per-frame trace listener — the gate at the
+;;     head of that listener;
 ;;   - the synchronous handler-exception capture is `re-frame.story.play`'s
-;;     `pending-exceptions` atom (likewise never this side-table);
+;;     `pending-exceptions` atom;
 ;;   - stub-redirected fx-ids are the stub-call log's
 ;;     (`re-frame.story.fx-stubs/observed-fx-ids`, read via the
 ;;     `:stub-observed-fx-ids` late-bind hook above) — the one fact the tape
@@ -339,11 +327,11 @@
 
 (defn- frame-id-from-cofx
   "Return the frame the current dispatch targets. Per spec/002 §Event
-  context the cofx map's `:rf.frame/id` slot is the canonical source (the
+  context the cofx map's `:rf.frame/id` slot is the canonical source — the
   router threads the running frame's stamp onto the event context as the
-  `:rf.frame/id` coeffect — the bare `:frame` coeffect was retired,
-  rf2-1m6rf1). The play-runner additionally stamps `:rf/play-frame` for
-  play-authored assertions that may run outside a frame binding."
+  `:rf.frame/id` coeffect. The play-runner additionally stamps
+  `:rf/play-frame` for play-authored assertions that may run outside a
+  frame binding."
   [cofx]
   (or (:rf.frame/id cofx)
       (:rf/play-frame cofx)
@@ -363,18 +351,16 @@
     :else                    false))
 
 ;; ---------------------------------------------------------------------------
-;; Redaction projection (spec/004 §Privacy, rf2-shy6n / rf2-ee38b.3 /
-;; rf2-006y9b)
+;; Redaction projection (spec/004 §Privacy)
 ;;
 ;; An assertion record is a value-bearing OBSERVATION surface: it serialises
 ;; into the test-mode pane, MCP `read-assertions`, and JSON-log egress per
 ;; spec/015 §Data-Classification (which lists "Xray / Story panel rendering"
 ;; and "MCP / tool wire transport" as boundaries projection must guard). So
 ;; NO slot of the record may carry the raw secret for a sensitive path —
-;; not `:actual`, and (rf2-006y9b) not `:expected`, `:payload`, or `:reason`
-;; either.
+;; not `:actual`, and not `:expected`, `:payload`, or `:reason` either.
 ;;
-;; The contract (rf2-006y9b, aligning to EP-0015's frame-owned model):
+;; The contract (aligning to EP-0015's frame-owned model):
 ;;
 ;;   1. A value read from a sensitive path / sub projects to `:rf/redacted`
 ;;      in `:actual` (the captured observation).
@@ -411,15 +397,15 @@
 (defn- sentinel-expected?
   "True iff the author wrote the framework redaction sentinel
   (`:rf/redacted`) as the `:expected` value — the documented way to pin the
-  redaction contract for a sensitive path (rf2-006y9b). Such an expected is
+  redaction contract for a sensitive path. Such an expected is
   considered satisfied when the observed value at the path projects to the
   sentinel (i.e. the path is sensitive)."
   [expected]
   (= :rf/redacted expected))
 
 (defn- path-equals-passed?
-  "Pass/fail for an equality assertion against a sensitive-aware path
-  (rf2-006y9b). Passes iff the raw value equals the author's expected, OR
+  "Pass/fail for an equality assertion against a sensitive-aware path.
+  Passes iff the raw value equals the author's expected, OR
   the author pinned the `:rf/redacted` sentinel AND the path is sensitive
   (the projected `actual` is the sentinel). This makes the documented
   sentinel contract real: an author writing `:rf/redacted` against a
@@ -442,7 +428,7 @@
   (let [raw          (get-in db path)
         actual       (redact-at frame-id path raw)
         passed?      (path-equals-passed? raw expected actual)
-        ;; rf2-006y9b — project the author-supplied `:expected` against the
+        ;; Project the author-supplied `:expected` against the
         ;; same path so a raw secret pinned as the expected value does not
         ;; leak through `:expected` / `:payload` / `:reason`. The sentinel
         ;; passes through unchanged (it is the sentinel, not a path value).
@@ -463,7 +449,7 @@
                       " but got "  (pr-str actual)))}))
 
 (defn- resolve-fn-schema
-  "Rewrite a `[:fn sym]` schema (the rf2-5x1wt.18 `:assert-db :pred` fold's
+  "Rewrite a `[:fn sym]` schema (the `:assert-db :pred` fold's
   symbol form) into `[:fn resolved-fn]` so Malli can validate it without
   sci (`[:fn 'sym]` needs sci — unavailable). A `[:fn fn]` (the fn-direct
   fold) and every non-`:fn` schema pass through unchanged. Pure-ish — the
@@ -484,7 +470,7 @@
   both runtimes; production `:advanced` builds with Story disabled DCE
   the entire assertion vocabulary anyway.
 
-  rf2-5x1wt.19 — a `[:fn sym]` schema (the `:assert-db :pred` symbol fold,
+  A `[:fn sym]` schema (the `:assert-db :pred` symbol fold,
   §B5.9) is resolved to `[:fn resolved-fn]` first (`resolve-fn-schema`),
   because Malli's `[:fn 'sym]` form needs sci (unavailable). An
   unresolvable symbol reports a readable failure rather than an opaque
@@ -527,14 +513,14 @@
   ;; per Spec 008. Subscriptions registered against the variant's frame
   ;; resolve the same way they would in the running app.
   ;;
-  ;; EP-0001 (rf2-vzld77 / rf2-pecaxy): `frame-state` is the FULL frame-state
-  ;; value `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`, NOT the bare
+  ;; EP-0001: `frame-state` is the FULL frame-state value
+  ;; `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`, NOT the bare
   ;; app-db. `compute-sub` resolves a mixed app-db/runtime-db dependency
   ;; graph against a frame-state value (subs.cljc `partition-value-for-sub`
   ;; extracts `:rf.db/runtime` for a `:runtime-db` sub and `:rf.db/app` for a
-  ;; `:db` sub) — the faithful read the reactive subscribe path does. Handing
-  ;; it bare app-db (the pre-pecaxy bug) made every runtime-db-projection sub
-  ;; (e.g. `:rf/machine` and any app sub deriving off it) read nil.
+  ;; `:db` sub) — the faithful read the reactive subscribe path does. The
+  ;; full frame-state is required so a runtime-db-projection sub (e.g.
+  ;; `:rf/machine` and any app sub deriving off it) resolves its real value.
   ;;
   ;; Redaction: a sub reading a sensitive path propagates the sensitive
   ;; marker into its output value (spec/015 §reg-sub). We project the
@@ -554,7 +540,7 @@
                        :else   (redact-at frame-id sub-path raw))
         passed?      (and (not threw?)
                           (path-equals-passed? raw expected actual))
-        ;; rf2-006y9b — project the author-supplied `:expected` against the
+        ;; Project the author-supplied `:expected` against the
         ;; sub's args-path so a sensitive sub's expected value does not leak.
         exp-redacted (if (or threw? (sentinel-expected? expected))
                        expected
@@ -588,7 +574,7 @@
                       (pr-str needle)))}))
 
 (defn- evaluate-state-is
-  "EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state, so
+  "EP-0001: machine snapshots are durable runtime-db state, so
   the `:state-is` assertion reads the snapshot off the frame's runtime-db
   partition value (`runtime-db`), NOT app-db."
   [runtime-db [machine-id state]]
@@ -657,7 +643,7 @@
 (def ^:const id-effect-emitted  :rf.assert/effect-emitted)
 
 ;; ---------------------------------------------------------------------------
-;; Schema-error — the EXPECTED schema violation (rf2-5x1wt.21, NET-NEW)
+;; Schema-error — the EXPECTED schema violation
 ;;
 ;; `:rf.assert/schema-error` declares that the run is EXPECTED to emit one
 ;; schema validation failure on a named surface. Unlike the seven app-db /
@@ -677,9 +663,9 @@
 (def ^:const id-schema-error    :rf.assert/schema-error)
 
 (def canonical-assertion-ids
-  "The canonical assertion event ids the P1 vocabulary recognises. The
-  SHIPPING seven (/spec/007-Stories.md §Inclusion tags) the `.18` fold preserves, PLUS the
-  NET-NEW `:rf.assert/schema-error` (rf2-5x1wt.21, spec/017 §Schema rule —
+  "The canonical assertion event ids the P1 vocabulary recognises: the
+  seven (/spec/007-Stories.md §Inclusion tags) PLUS
+  `:rf.assert/schema-error` (spec/017 §Schema rule —
   the EXPECTED-schema-violation declaration). `:rf.assert/schema-error` is
   recognised (so plan construction accepts it) but is NOT installed as a
   `reg-event` handler: it is tape-evaluated in the result boundary, not
@@ -694,18 +680,15 @@
     id-schema-error})
 
 ;; ---------------------------------------------------------------------------
-;; DOM assertion family — the fold target for the shipping `:assert-dom`
-;; step (rf2-5x1wt.18, spec/017 §Assertions — one atom, two positions).
+;; DOM assertion family — the fold target for the `:assert-dom` step
+;; (spec/017 §Assertions — one atom, two positions).
 ;;
-;; These ids are NET-NEW (the shipping vocabulary had only the seven above
-;; plus the ad-hoc synthetic `:rf.assert/dom` record `:assert-dom` minted).
-;; The DOM runner that EVALUATES them lands later (the `:dom` capability is
-;; wired now via `re-frame.story.requirements`); the fold names them so an
-;; `:assert-dom` step lowers onto the SAME assertion atom shape as every
-;; other assertion, regardless of script position. A headless run that
-;; reaches one refuses with `:cannot-run` (the `:dom` capability gate),
-;; never a silent pass — that is the fail-closed contract, not this fold's
-;; concern.
+;; The `:dom` capability is wired via `re-frame.story.requirements`; the
+;; fold names these ids so an `:assert-dom` step lowers onto the SAME
+;; assertion atom shape as every other assertion, regardless of script
+;; position. A headless run that reaches one refuses with `:cannot-run`
+;; (the `:dom` capability gate), never a silent pass — that is the
+;; fail-closed contract, not this fold's concern.
 ;; ---------------------------------------------------------------------------
 
 (def ^:const id-dom-visible     :rf.assert/dom-visible)
@@ -713,7 +696,7 @@
 (def ^:const id-dom-text        :rf.assert/dom-text)
 
 (def dom-assertion-ids
-  "The DOM assertion family (rf2-5x1wt.18, NET-NEW). The shipping
+  "The DOM assertion family. The shipping
   `:assert-dom selector :visible|:hidden|:text` step folds onto these so
   a DOM expectation rides the ONE assertion atom. Each carries the `:dom`
   runner requirement via `re-frame.story.requirements/assertion-capabilities`
@@ -725,7 +708,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Browser-tier assertion family — visual snapshot + axe-style a11y +
-;; structural a11y (rf2-5x1wt.28, NET-NEW; spec/017 §Visual, a11y, and
+;; structural a11y (spec/017 §Visual, a11y, and
 ;; browser checks + §Canonical P1 assertions).
 ;;
 ;; These are NOT a separate visual-testing system — they are richer
@@ -751,7 +734,7 @@
 (def ^:const id-a11y-structural  :rf.assert/a11y-structural)
 
 (def browser-assertion-ids
-  "The browser-tier oracle assertion family (rf2-5x1wt.28). Visual snapshot
+  "The browser-tier oracle assertion family. Visual snapshot
   and axe-style a11y are browser-only (`:pixels` / `:a11y-engine`); the
   structural a11y check rides the `:hiccup` tier. All three ride the ONE
   assertion atom + the ONE assertion-record shape — they are runner-tiered
@@ -769,7 +752,7 @@
   visual / a11y / reactive-count ids whose runners land later or are
   browser-tiered). Plan construction validates authored assertion atoms
   against this set (`assertion-id-known?`); an unknown id FAILS plan
-  construction with a useful error (rf2-5x1wt.18, spec/017 §Assertions).
+  construction with a useful error (spec/017 §Assertions).
   Reading the requirement registry keeps this list a derived view of the
   ONE id source of truth rather than a hand-maintained parallel set."
   (into (into (into canonical-assertion-ids dom-assertion-ids)
@@ -780,19 +763,18 @@
   "True iff `id` is a recognised P1 assertion id (`known-assertion-ids`).
   Pure data → data. Used by the plan compiler to FAIL plan construction
   on an unknown assertion atom rather than letting it record a vacuous
-  `:rf.assert/unknown` pseudo-record at run time (rf2-5x1wt.18)."
+  `:rf.assert/unknown` pseudo-record at run time."
   [id]
   (contains? known-assertion-ids id))
 
 ;; ---------------------------------------------------------------------------
-;; Assertion-atom fold (rf2-5x1wt.18, spec/017 §Assertions — one atom,
-;; two positions)
+;; Assertion-atom fold (spec/017 §Assertions — one atom, two positions)
 ;;
 ;; The assertion atom is the data vector `[:rf.assert/id & args]`. It is
 ;; legal in exactly two positions: terminal `:assertions` and the in-script
 ;; `[:assert …]` checkpoint. Both positions produce ONE assertion-record
 ;; shape (the `[:assert …]` checkpoint dispatches the wrapped atom, whose
-;; reg-event handler records the canonical record — rf2-5x1wt.17).
+;; reg-event handler records the canonical record).
 ;;
 ;; The shipping ergonomic script steps `:assert-db` / `:assert-dom` are NOT
 ;; authoring-distinct assertion kinds — they are sugar that FOLDS onto the
@@ -806,10 +788,10 @@
 ;;
 ;; `fold-assert-step` returns the canonical `[:assert assertion-atom]`
 ;; checkpoint for a shipping `:assert-db` / `:assert-dom` step, so the plan
-;; compiler can rewrite a script uniformly to the ONE atom in its
-;; checkpoint position — collapsing the two parallel record-minting paths
-;; (`runner-events`' synthetic `:rf.assert/db` / `:rf.assert/dom` records)
-;; onto the canonical assertion handlers. Pure data → data.
+;; compiler rewrites a script uniformly to the ONE atom in its checkpoint
+;; position — every assertion mints its record through the canonical
+;; assertion handlers, with no parallel record-minting path. Pure data →
+;; data.
 ;; ---------------------------------------------------------------------------
 
 (defn- assert-db->atom
@@ -819,7 +801,7 @@
   `[:fn …]` schema (the one canonical way to express an arbitrary
   predicate against a path). A symbol predicate is preserved verbatim in
   the `[:fn …]` schema — the assertion handler's Malli path resolves it
-  the same way the shipping `:assert-db :pred` rail did."
+  the same way the `:assert-db :pred` rail does."
   [step]
   (let [path (nth step 1)]
     (if (and (= 4 (count step)) (= :pred (nth step 2)))
@@ -844,7 +826,7 @@
   "Fold a shipping ergonomic assertion step (`[:assert-db …]` /
   `[:assert-dom …]`) into the canonical `[:assert assertion-atom]`
   checkpoint, so terminal `:assertions` and EVERY in-script assertion
-  position resolve to the ONE assertion atom (rf2-5x1wt.18). Returns the
+  position resolve to the ONE assertion atom. Returns the
   rewritten `[:assert …]` step for a foldable step, or the step unchanged
   for any other step (`:dispatch`, `:wait`, an already-`[:assert …]`
   checkpoint, a bare event vector). Pure data → data — used by the plan
@@ -857,8 +839,8 @@
 
 (defn fold-script
   "Fold every shipping `:assert-db` / `:assert-dom` step in a coerced
-  `script` vector onto the canonical `[:assert assertion-atom]` checkpoint
-  (rf2-5x1wt.18). Leaves non-assertion steps and already-canonical
+  `script` vector onto the canonical `[:assert assertion-atom]` checkpoint.
+  Leaves non-assertion steps and already-canonical
   `[:assert …]` checkpoints untouched. Pure data → data."
   [script]
   (mapv fold-assert-step (or script [])))
@@ -875,7 +857,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Schema-error expectation — parse the declared atom into its surface
-;; selector (rf2-5x1wt.21, spec/017 §Schema rule)
+;; selector (spec/017 §Schema rule)
 ;;
 ;; The declared atom is `[:rf.assert/schema-error {:where <surface> …}]`.
 ;; The spec map's `:where` chooses the surface; the surface-specific keys
@@ -918,7 +900,7 @@
   "The surface SELECTOR a declared `:rf.assert/schema-error` expectation
   pairs on — mirroring `evidence/violation-selector` so a declared
   expectation and a projected violation produce the SAME vector for the same
-  surface (rf2-5x1wt.21, spec/017 §Schema rule). Pure data → data.
+  surface (spec/017 §Schema rule). Pure data → data.
 
   `spec` is the expectation map (`schema-error-spec`). An empty spec (a bare
   `[:rf.assert/schema-error]`) selects `[:any]` — the wildcard that consumes
@@ -943,7 +925,7 @@
   "Project a declared `[:rf.assert/schema-error spec]` atom into its
   expectation record `{:atom atom :spec spec :selector selector}` — the
   shape the result boundary's exact-consumption matcher pairs against the
-  projected violations (rf2-5x1wt.21). Pure data → data."
+  projected violations. Pure data → data."
   [assertion-atom]
   (let [spec (schema-error-spec assertion-atom)]
     {:atom     assertion-atom
@@ -952,15 +934,15 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Causal / cascade assertions — `:rf.assert/caused` +
-;; `:rf.assert/no-cascade-rerender` (rf2-5x1wt.31, spec/017 §Causal and
-;; cascade assertions). NET-NEW, tape-evaluated like `:rf.assert/schema-error`.
+;; `:rf.assert/no-cascade-rerender` (spec/017 §Causal and
+;; cascade assertions). Tape-evaluated like `:rf.assert/schema-error`.
 ;;
 ;; Both PROJECT a cause→effect relationship from the SAME reactive evidence
 ;; the framework already retains in the epoch tape — the `:rf.sub/run` /
 ;; `:rf.view/rendered` rows stamped with the dispatching cascade's
 ;; `:cause-event-id` (Spec 009 §`:rf.sub/cause-event-id`, surfaced in the
-;; `re-frame.story.play.evidence/reactive-counts` `:by-cause` projection,
-;; rf2-5x1wt.30). They add NO new trace op-type and NO new accumulator — the
+;; `re-frame.story.play.evidence/reactive-counts` `:by-cause` projection).
+;; They add NO new trace op-type and NO new accumulator — the
 ;; tape is the source of truth (spec/017 §Risks — "evidence projections
 ;; drift: use the epoch tape as source of truth").
 ;;
@@ -996,7 +978,7 @@
 (def ^:const id-no-cascade-rerender :rf.assert/no-cascade-rerender)
 
 (def causal-assertion-ids
-  "The causal / cascade assertion family (rf2-5x1wt.31, NET-NEW). Both are
+  "The causal / cascade assertion family. Both are
   tape-evaluated against the `:reactive-counts` `:by-cause` projection (NOT
   dispatched into the frame, NOT a parallel accumulator) and require the
   `:reactive-counts` capability via the requirement registry
@@ -1090,7 +1072,7 @@
   The three trace-bus-driven assertions (`:dispatched?` / `:no-warnings`
   / `:effect-emitted`) project their fact from the frame's EPOCH TAPE (the
   SSOT — `dispatched-events` / `warnings` / `emitted-fx`), the SAME source
-  the run-result evidence slots read (rf2-q651r). The prior committed
+  the run-result evidence slots read. The prior committed
   epochs (the play steps before this assertion's own dispatch) are already
   on the tape when this handler runs; the assertion's own epoch has not yet
   settled — and assertion events are excluded from the projection anyway."
@@ -1103,20 +1085,20 @@
           extras       (case evaluator-kind
                          :path-equals     (evaluate-path-equals     frame-id db payload)
                          :path-matches    (evaluate-path-matches    frame-id db payload)
-                         ;; EP-0001 (rf2-vzld77 / rf2-pecaxy): subs may project
+                         ;; EP-0001: subs may project
                          ;; runtime-db state (e.g. `:rf/machine`), so hand
                          ;; `compute-sub` the FULL frame-state value (app +
                          ;; runtime), not the bare app-db `:db` cofx — else
                          ;; runtime-db-projection subs read nil.
                          :sub-equals      (evaluate-sub-equals      frame-id {:rf.db/app db :rf.db/runtime rt} payload)
                          :dispatched?     (evaluate-dispatched?     (dispatched-events frame-id) payload)
-                         ;; EP-0001 (rf2-vzld77): machine snapshots live in
+                         ;; EP-0001: machine snapshots live in
                          ;; runtime-db; read the `:rf.db/runtime` coeffect.
                          :state-is        (evaluate-state-is        (or rt {}) payload)
                          :no-warnings     (evaluate-no-warnings     (warnings frame-id) payload)
                          :effect-emitted  (evaluate-effect-emitted  (emitted-fx frame-id) payload))
           elapsed-ms   (- (interop/now-ms) start-ms)
-          ;; rf2-006y9b — a value-comparing evaluator (`:path-equals` /
+          ;; A value-comparing evaluator (`:path-equals` /
           ;; `:sub-equals`) returns a REDACTED `:payload` rebuilt from the
           ;; projected expected, so the record's `:payload` slot never
           ;; carries the raw secret. Evaluators that introduce no

--- a/tools/story/src/re_frame/story/async.cljc
+++ b/tools/story/src/re_frame/story/async.cljc
@@ -7,8 +7,8 @@
   - On CLJS the return value is a native `js/Promise`.
   - On JVM the return value is a `java.util.concurrent.CompletableFuture`.
 
-  Stage 3 (rf2-von3) is the call: this namespace abstracts the two so
-  the rest of the runtime can write portable code.
+  This namespace abstracts the two so the rest of the runtime can write
+  portable code.
 
   ## API
 

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -6,10 +6,9 @@
   toolbar cofx + subs, and (CLJS only) the v1.0 SOTA panel set plus
   the multi-substrate Reagent default.
 
-  Per the rf2-l8eso Phase-2 facade thinning: the public entry
-  `install-canonical-vocabulary!` is re-exported from `re-frame.story`;
-  users call `(re-frame.story/install-canonical-vocabulary!)` at boot,
-  OR rely on the rf2-p1ydc auto-install hook — the first `reg-*` call
+  The public entry `install-canonical-vocabulary!` is re-exported from
+  `re-frame.story`; users call `(re-frame.story/install-canonical-vocabulary!)`
+  at boot, OR rely on the auto-install hook — the first `reg-*` call
   installs the canonical vocabulary on demand. See `ensure-installed!`
   below + spec/001 §Boot — auto-install of the canonical vocabulary.
   The implementation weight — the late-bind shim wiring, the ordered
@@ -42,35 +41,34 @@
   assertion + play modules without a circular require. The hub lives in
   `re-frame.story.late-bind` (mirroring the framework's pattern)."
   []
-  ;; rf2-q651r — `:rf.assert/effect-emitted` projects from the epoch tape,
+  ;; `:rf.assert/effect-emitted` projects from the epoch tape,
   ;; but a STUBBED fx lands on the tape under its REWRITTEN stub id, not its
   ;; original id. The authoritative record of which ORIGINAL fx-ids a
   ;; `force-fx-stub` redirected is the stub-call log `fx-stubs` owns; the
   ;; assertions module reads it via this hook (it cannot `:require`
   ;; fx-stubs / frames without a cycle).
   (late-bind/set-fn! :stub-observed-fx-ids fx-stubs/observed-fx-ids)
-  ;; rf2-luzky — the assertions side-table is gone; only the play module's
-  ;; per-frame `pending-exceptions` slot needs frame-teardown eviction.
+  ;; Only the play module's per-frame `pending-exceptions` slot needs
+  ;; frame-teardown eviction.
   ;;
-  ;; rf2-294yq5.4 — per-frame destroy must ALSO unregister the play-runner's
-  ;; per-frame trace listener (`play/install-trace-listener!` registered it
+  ;; Per-frame destroy must ALSO unregister the play-runner's per-frame
+  ;; trace listener (`play/install-trace-listener!` registered it
   ;; in `runtime/run-phase-0!`). Dropping only the `pending-exceptions` entry
-  ;; left the listener registered against a destroyed frame: `clear-all-play-
-  ;; state!` could no longer find it (it keys off `pending-exceptions` /
-  ;; `stepper-state`, both now empty for that frame), so long-running
-  ;; sessions / hot-reload cycles / large corpora accumulated stale listener
-  ;; closures inspecting every future trace event. `remove-trace-listener!`
-  ;; is idempotent, so destroying a frame that never installed a listener
-  ;; (or a double-destroy) is harmless.
+  ;; would leave the listener registered against a destroyed frame:
+  ;; `clear-all-play-state!` keys off `pending-exceptions` / `stepper-state`
+  ;; (both empty for a torn-down frame), so without this eviction long-running
+  ;; sessions / hot-reload cycles / large corpora would accumulate stale
+  ;; listener closures inspecting every future trace event.
+  ;; `remove-trace-listener!` is idempotent, so destroying a frame that never
+  ;; installed a listener (or a double-destroy) is harmless.
   (late-bind/set-fn! :drop-assertion-accumulators
     (fn [frame-id]
       (play/drop-pending-exceptions! frame-id)
       (play/remove-trace-listener! frame-id)))
-  ;; rf2-booyu — the play-runner's per-frame run-state (`run-state` /
-  ;; `runs-by-play` / `active-play` / `step-boundaries`) must be evicted on
-  ;; frame teardown too. `clear-state!` documented itself as "called from
-  ;; frame teardown" but was never wired, so a destroyed variant frame leaked
-  ;; its terminal play status + the toolbar's focused-play slot, and a
+  ;; The play-runner's per-frame run-state (`run-state` / `runs-by-play` /
+  ;; `active-play` / `step-boundaries`) is evicted on frame teardown via
+  ;; `clear-state!`: without it a destroyed variant frame would leak its
+  ;; terminal play status + the toolbar's focused-play slot, and a
   ;; re-allocated frame of the same id could observe the prior incarnation's
   ;; run-state. `frames` cannot `:require` `runner-events` (cycle), so the
   ;; eviction routes through this late-bind hook the same way the
@@ -87,16 +85,15 @@
      same carriage the canvas's `sub-overrides-scope` uses); the override
      never touches app-db / `compute-sub`.
 
-     Per rf2-hzhmv / rf2-ba86n.8 the host paints through the SHARED
+     The host paints through the SHARED
      `ui-multi-substrate/render-decorated-view` seam the canvas single-pane
      path uses, threading the compiled plan's `[:world :decorators]` refs
      (`render-inputs`' `:decorators`, the single-merge-authority output —
-     rf2-g74i9 / spec/017 §305-306). Before this consolidation the host
-     rendered the BARE view, so a decorated variant diverged from the canvas
-     (theme/provider/chrome dropped); now `render-variant` and the live shell
-     paint the SAME decorated tree.
+     spec/017 §305-306). `render-variant` and the live shell paint the
+     SAME decorated tree (theme / provider / chrome included), so a
+     decorated variant never diverges from the canvas.
 
-     rf2-7pgiz: the `:sub-overrides` carriage is a React CONTEXT, not a
+     The `:sub-overrides` carriage is a React CONTEXT, not a
      dynamic var — the var does not survive into the view's deferred React
      render (the view's `@(rf/subscribe)` runs in its own reaction). A
      descendant subscribe reads the override at deref time via the
@@ -110,16 +107,16 @@
 
 #?(:cljs
    (defn- install-render-host!
-     "Wire the `render-variant` host-render hook (rf2-5x1wt.24). The
+     "Wire the `render-variant` host-render hook. The
      render-prep core (`re-frame.story.render/prepare-render`) is host-free
      + JVM-testable; the actual painting of the active view is this CLJS
      hook. It renders the active `:view` under the host substrate's render
      fn, wrapped in the variant's `:hiccup` decorators via the SHARED
      `re-frame.story.ui.multi-substrate/render-decorated-view` seam the
-     canvas single-pane path also uses (rf2-hzhmv / rf2-ba86n.8), inside the
+     canvas single-pane path also uses, inside the
      `render-host-scope` component so the resolved `:sub-overrides` surface
-     at React render time via the override-context carriage (rf2-7pgiz;
-     spec/017 §View-state subscription overrides). The
+     at React render time via the override-context carriage
+     (spec/017 §View-state subscription overrides). The
      result is a hiccup tree (the Reagent default) — the SAME decorated
      render the canvas paints, so render-variant and the live shell agree.
 
@@ -150,7 +147,7 @@
               install-render-host!
               ui-panels/install-canonical-panels!])])
 
-;; ---- auto-install gate (rf2-p1ydc) ---------------------------------------
+;; ---- auto-install gate --------------------------------------------------
 ;;
 ;; Per spec/001 §Boot — auto-install of the canonical vocabulary, the
 ;; canonical vocabulary auto-installs on first `reg-*` call so authors
@@ -203,7 +200,7 @@
 
   Re-exported from the public facade as
   `re-frame.story/install-canonical-vocabulary!`. Authors may call this
-  explicitly at boot — or rely on the rf2-p1ydc auto-install hook,
+  explicitly at boot — or rely on the auto-install hook,
   which fires the same chain on the first `reg-*` call. Either path
   is idempotent.
 

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -30,18 +30,18 @@
   that accidentally requires a stories ns sees the namespace load but
   with no registrations, every Story query returns empty."
   (:require [re-frame.privacy    :as privacy]
-            ;; rf2-7737vq — the canonical RAW trace-event frame reader
-            ;; (`re-frame.trace/trace-event-frame`), replacing Story's
-            ;; hand-rolled `[:tags :frame]` read.
+            ;; the canonical RAW trace-event frame reader
+            ;; (`re-frame.trace/trace-event-frame`); Story reads the
+            ;; frame off a trace event through it.
             [re-frame.trace      :as trace]
-            ;; EP-0015 (rf2-3t26eh): the on-box dev visibility choice is a
-            ;; named `:rf.egress/*` profile resolved through the framework's
-            ;; centralized projection table — NOT a process-global on/off
-            ;; toggle. `re-frame.projection` is the pure-CLJC home of the
-            ;; six ruled profiles + their `:rf.size/*` resolution; requiring
-            ;; it directly (rather than the whole `re-frame.core` facade)
-            ;; keeps this config ns JVM-runnable for the test corpus and
-            ;; pins the egress vocabulary to the ONE canonical source.
+            ;; EP-0015: the on-box dev visibility choice is a named
+            ;; `:rf.egress/*` profile resolved through the framework's
+            ;; centralized projection table. `re-frame.projection` is the
+            ;; pure-CLJC home of the six ruled profiles + their
+            ;; `:rf.size/*` resolution; requiring it directly (rather than
+            ;; the whole `re-frame.core` facade) keeps this config ns
+            ;; JVM-runnable for the test corpus and pins the egress
+            ;; vocabulary to the ONE canonical source.
             [re-frame.projection :as projection])
   #?(:cljs (:require-macros [re-frame.story.config])))
 
@@ -59,7 +59,7 @@
            `:advanced`."
            true))
 
-;; ---- the static-export flag (rf2-8wgpm) ---------------------------------
+;; ---- the static-export flag ---------------------------------------------
 ;;
 ;; A second goog-define that flips Story's chrome into "static export"
 ;; mode — the bundle is intended to be served as a publishable HTML
@@ -109,11 +109,11 @@
 ;; with `enabled?` defined as `false`, Closure sees the boolean
 ;; constant and removes the branch. The macro layer (`re-frame.story.
 ;; macros`) lays down that `(when enabled? ...)` form inline; the
-;; closure compiler does the rest. (rf2-ee38b.3 removed a dead
-;; `elide-form` helper here — the macros open-code the wrapper and never
-;; called it.)
+;; closure compiler does the rest. The macros open-code the
+;; `(when enabled? ...)` wrapper inline; there is no separate
+;; `elide-form` helper.
 
-;; ---- *global-args* (Stage 3, rf2-von3) ----------------------------------
+;; ---- *global-args* (Stage 3) --------------------------------------------
 ;;
 ;; Per `002-Runtime.md` §Args resolution precedence the args-precedence chain starts with `global-args`:
 ;; defaults the story-tool's host application sets at boot (theme, locale).
@@ -142,10 +142,10 @@
   []
   @global-args)
 
-;; ---- *global-decorators* (rf2-835ey — preview.ts parity, F-1) -----------
+;; ---- *global-decorators* (preview.ts parity) ----------------------------
 ;;
-;; Per ai/findings/2026-05-20-story-tutorial-set.md Finding F-1 (P2) Story
-;; ships story-level + variant-level decorators only; Storybook's canonical
+;; Story ships story-level + variant-level decorators directly; Storybook's
+;; canonical
 ;; "wrap every story in the design system's theme provider" recipe lives in
 ;; `preview.ts` `decorators: [...]` and Story has no equivalent. Without
 ;; one, the tutorial chapter on decorators cannot offer the canonical
@@ -171,7 +171,7 @@
 
 (defonce
   ^{:doc "Atom holding the ordered vector of global decorator references.
-         Per rf2-835ey — Storybook `preview.ts` `decorators: [...]`
+         Storybook `preview.ts` `decorators: [...]`
          parity. Defaults to `[]`; the host calls
          `re-frame.story/reg-global-decorator` at boot to append.
          Each entry is a `[decorator-id & args]` vector, same shape as
@@ -223,7 +223,7 @@
          (fn [v] (vec (remove (fn [r] (= id (first r))) v))))
   nil)
 
-;; ---- *editor* (rf2-evgf5 — 'Open in editor' affordance) ----------------
+;; ---- *editor* ('Open in editor' affordance) ----------------------------
 ;;
 ;; Per Spec 005-SOTA-Features.md §'Open in editor' per variant, every
 ;; source-coord-bearing Story surface (variant canvas title, per-test
@@ -262,9 +262,9 @@
   []
   @editor)
 
-;; ---- *project-root* (rf2-zfy1e — 'Open in editor' path prefix) ----------
+;; ---- *project-root* ('Open in editor' path prefix) ---------------------
 ;;
-;; Per rf2-zfy1e: source-coords stamped at registration time are
+;; Source-coords stamped at registration time are
 ;; classpath-relative (the form-meta `:file` slot, e.g.
 ;; `"panel_gallery/event_detail_stories.cljs"`). Editor URI handlers
 ;; (`vscode://file/<path>...`, `cursor://...`, `idea://...`, etc.)
@@ -275,7 +275,7 @@
 ;; The host application sets this once at boot via
 ;; `(story/configure! {:rf.story/project-root "C:/Users/me/code/my-app/src"})`.
 ;; Default is nil — when unset, the source-coord file ships verbatim
-;; and the Open chip behaves exactly as it did pre-rf2-zfy1e (useful
+;; and the Open chip ships the path unprefixed (useful
 ;; for hosts whose source-paths are already absolute, and for tests).
 ;;
 ;; The atom is plain data; production builds with `enabled?` false DCE
@@ -292,7 +292,7 @@
   project-root
   (atom nil))
 
-;; ---- static-export project-root posture (rf2: static-export self-containment)
+;; ---- static-export project-root posture ---------------------------------
 ;;
 ;; The project-root is a DEV-time affordance: it turns a classpath-relative
 ;; source-coord into an absolute on-disk path so the open-in-editor chip can
@@ -332,8 +332,8 @@
   (atom false))
 
 (defn set-allow-static-project-root!
-  "Opt a static-export build IN to an absolute project-root (rf2 static-export
-  self-containment). Default is OFF — in `static-mode?` the open-in-editor
+  "Opt a static-export build IN to an absolute project-root. Default is
+  OFF — in `static-mode?` the open-in-editor
   project-root is fail-closed so a published bundle ships no build-machine
   checkout path. Call this (with `true`) BEFORE `configure!` only when the
   published site is meant to deep-link back into the author's editor and the
@@ -358,7 +358,7 @@
   project-root is IGNORED (the slot stays nil) unless the host has opted in
   via `set-allow-static-project-root!`. This stops a published `story:build`
   bundle from baking the build machine's checkout root into its
-  open-in-editor URIs (rf2 static-export self-containment). Dev builds
+  open-in-editor URIs. Dev builds
   (`static-mode?` false) are unaffected."
   [p]
   (let [suppress? (and static-mode? (not @allow-static-project-root?))]
@@ -371,13 +371,13 @@
   []
   @project-root)
 
-;; ---- per-(tool,frame) egress visibility (rf2-3t26eh / EP-0015 issue 7) ---
+;; ---- per-(tool,frame) egress visibility (EP-0015 issue 7) ---------------
 ;;
-;; EP-0015 (frame-owned egress policy, graduated 2026-06-11) retired the
-;; process-global privacy on/off toggle in favour of (a) frame-owned
-;; `:sensitive` / `:large` classification declared at frame creation, and
-;; (b) the centralized `re-frame.core/project-egress` boundary primitive
-;; resolved against one of the six ruled `:rf.egress/*` profiles.
+;; EP-0015 (frame-owned egress policy) bases on-box dev visibility on
+;; (a) frame-owned `:sensitive` / `:large` classification declared at
+;; frame creation, and (b) the centralized `re-frame.core/project-egress`
+;; boundary primitive resolved against one of the six ruled
+;; `:rf.egress/*` profiles.
 ;;
 ;; Issue 7 rules the on-box-visibility GRAIN explicitly (spec/015
 ;; §Cross-tool visibility grain): on-box visibility is per (tool, frame)
@@ -410,7 +410,7 @@
 ;; scrubs only THAT frame's buffered sensitive traces (see
 ;; `set-frame-egress-profile!` + the per-frame toggle-off callbacks), never
 ;; an unrelated frame's. This is exactly the per-(tool,frame) shape issue 7
-;; substitutes for the retired process-global toggle.
+;; rules.
 
 (def default-egress-profile
   "Story's default per-frame local-render egress profile (EP-0015 issue 7):
@@ -450,9 +450,7 @@
          another. The decision derives from the resolved profile's
          `:rf.size/include-sensitive?` floor via the framework projection
          table, the same table `project-egress` consumes (one source of
-         truth). Replaces the retired single process-global egress-profile
-         atom (rf2-6z4znr) and the predecessor `:rf.privacy/show-sensitive?`
-         boolean (rf2-bclgj)."}
+         truth)."}
   frame-egress-profiles
   (atom {}))
 
@@ -468,9 +466,9 @@
   session-egress-profile
   (atom default-egress-profile))
 
-;; ---- toggle-off callbacks (rf2-lqmje / rf2-6z4znr — retroactive scrub) ----
+;; ---- toggle-off callbacks (retroactive scrub) ---------------------------
 ;;
-;; Per Spec 009 §Privacy §Retroactive-scrub (rf2-lqmje), narrowing a frame's
+;; Per Spec 009 §Privacy §Retroactive-scrub, narrowing a frame's
 ;; egress profile from a sensitive-revealing boundary (`:rf.egress/local-raw`)
 ;; back to the redacting default MUST clear that frame's buffered sensitive
 ;; traces — the reveal is NOT a one-way trapdoor. The Story trace listener
@@ -480,7 +478,7 @@
 ;; consumer of that frame's buffer after the operator narrowed it back
 ;; expecting privacy to be restored.
 ;;
-;; Per EP-0015 issue 7 (rf2-6z4znr) the scrub is FRAME-SCOPED: narrowing
+;; Per EP-0015 issue 7 the scrub is FRAME-SCOPED: narrowing
 ;; frame A scrubs frame A's buffer and leaves every unrelated frame
 ;; untouched. Each callback receives the narrowed `frame-id`; a callback
 ;; whose buffer is keyed per-frame clears only that frame.
@@ -572,15 +570,15 @@
 
 (defn set-frame-egress-profile!
   "Set the per-frame local-render `:rf.egress/*` profile for `frame-id`
-  (EP-0015 issue 7, rf2-6z4znr — the per-(tool,frame) visibility act). This
+  (EP-0015 issue 7 — the per-(tool,frame) visibility act). This
   is the explicit trusted-local operator act that reveals ONE frame; it
   never changes any other frame's visibility.
 
   - `:rf.egress/local-raw` reveals `frame-id`'s sensitive trace/recorder/
     DOM-capture data.
   - `:rf.egress/local-redacted` (or `nil`) narrows `frame-id` back to the
-    fail-closed default and REMOVES its override entry. Per rf2-lqmje
-    (Spec 009 §Privacy §Retroactive-scrub) a reveal → redact narrowing for
+    fail-closed default and REMOVES its override entry. Per Spec 009
+    §Privacy §Retroactive-scrub a reveal → redact narrowing for
     this frame invokes the registered `toggle-off-callbacks` with
     `frame-id`, so that frame's buffered sensitive traces are scrubbed —
     other frames are untouched. The reveal is NOT a one-way trapdoor.
@@ -638,21 +636,21 @@
       (run-toggle-off-callbacks! nil)))
   nil)
 
-;; ---- legacy single-knob shim (deprecated; configure! + tests) ------------
+;; ---- single-knob session-pin shim (configure! + tests) -----------------
 ;;
-;; The pre-rf2-6z4znr single process-global setter (`set-egress-profile!`) is
-;; retained as a thin shim over the session-pin so the `configure!` session-
-;; default path + existing fixtures keep working. It operates on the SESSION-
+;; `set-egress-profile!` is a thin single-knob shim over the session-pin,
+;; serving the `configure!` session-default path + existing fixtures. It
+;; operates on the SESSION-
 ;; PIN, never on a per-frame override — the per-frame act is
 ;; `set-frame-egress-profile!`. To READ the session-pin, deref
 ;; `session-egress-profile`; for a frame's effective profile use
 ;; `resolve-egress-profile`.
 
 (defn set-egress-profile!
-  "DEPRECATED single-knob shim (rf2-6z4znr): sets the SESSION-PIN profile.
+  "Single-knob shim: sets the SESSION-PIN profile.
   Prefer `set-frame-egress-profile!` for the per-(tool,frame) operator act.
-  Retained so existing fixtures + the `configure!` session-default path keep
-  working. Delegates to `set-session-egress-profile!`."
+  Serves existing fixtures + the `configure!` session-default path.
+  Delegates to `set-session-egress-profile!`."
   [profile]
   (set-session-egress-profile! profile))
 
@@ -670,11 +668,10 @@
 (defn sensitive-event?
   "True iff the trace event `ev` carries `:sensitive? true` at the top
   level. Thin alias over the framework-published `re-frame.privacy/sensitive?`
-  predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn
-  / rf2-iwqu9, every consumer of `:sensitive?` (Xray, Story,
-  story-mcp, re-frame2-pair-mcp) composes against ONE framework
-  primitive rather than reimplementing the five-token check. Per Spec
-  009 §Privacy."
+  predicate (re-exported as `re-frame.core/sensitive?`) — every consumer
+  of `:sensitive?` (Xray, Story, story-mcp, re-frame2-pair-mcp) composes
+  against ONE framework primitive rather than reimplementing the
+  five-token check. Per Spec 009 §Privacy."
   [ev]
   (privacy/sensitive? ev))
 
@@ -683,7 +680,7 @@
   — or nil for a frameless emit (registration-time, outermost-dispatch
   lookup failures). The frame Story's listeners resolve the per-frame
   egress profile against (EP-0015 issue 7). Reads via the canonical
-  `re-frame.trace/trace-event-frame` reader (rf2-7737vq); the `map?`
+  `re-frame.trace/trace-event-frame` reader; the `map?`
   guard keeps the accessor total for the non-map inputs Story's
   defensive call sites may pass."
   [ev]
@@ -692,8 +689,8 @@
 
 (defn suppress-sensitive?
   "Should this trace event be suppressed by a Story-registered listener
-  under the egress profile resolved FOR THE EVENT'S FRAME (EP-0015 issue 7,
-  rf2-6z4znr)?
+  under the egress profile resolved FOR THE EVENT'S FRAME (EP-0015 issue
+  7)?
 
   Returns `true` iff (a) the event is `:sensitive? true` AND (b) the profile
   resolved for the frame does NOT reveal sensitive values
@@ -715,7 +712,7 @@
    (and (sensitive-event? ev)
         (not (include-sensitive? frame-id)))))
 
-;; ---- *suppressed-counters* (rf2-bclgj — UI redaction indicator) ----------
+;; ---- *suppressed-counters* (UI redaction indicator) --------------------
 ;;
 ;; The UI panels (trace, actions) render a `[● REDACTED]` hint when
 ;; sensitive events were suppressed for the focused variant. The hint
@@ -765,23 +762,23 @@
    (swap! suppressed-counters dissoc (or variant-id :global))
    nil))
 
-;; ---- *reset-all!* (rf2-6ez1u — config-leak test-isolation gap) -----------
+;; ---- *reset-all!* (config-leak test-isolation) -------------------------
 ;;
 ;; Every leakable process-global config atom above is a `defonce` that
-;; survives across tests in the same JVM run / browser page. The test
-;; fixtures (`re-frame.story/clear-all!`, `re-frame.story.test-support/
-;; story-reset!`) historically reset only the registrar side-table, the
-;; global-decorators vector, the canonical auto-install gate, and the
-;; play run-state — they did NOT touch these config atoms.
-;;
-;; That left a green-but-wrong footgun: a test that called
+;; survives across tests in the same JVM run / browser page. Without a
+;; reset, a test that called
 ;; `(story/configure! {:rf.story/global-args {...}})` or set
-;; `:rf.story/egress-profile` leaked that global state into every
+;; `:rf.story/egress-profile` would leak that global state into every
 ;; SUBSEQUENT test. Because `global-args` is Layer 1 of args resolution
 ;; (`re-frame.story.args/resolve-args` reads `(get-global-args)` at
 ;; resolve time), a leaked global arg silently changes the EFFECTIVE
 ;; args of an unrelated later variant — order-dependent, hard to debug,
-;; and exactly the footgun class `test_support` exists to close.
+;; and exactly the footgun class `test_support` exists to close. The
+;; test fixtures (`re-frame.story/clear-all!`,
+;; `re-frame.story.test-support/story-reset!`) call `reset-all!` so these
+;; config atoms join the registrar side-table, the global-decorators
+;; vector, the canonical auto-install gate, and the play run-state in
+;; being cleared between tests.
 ;;
 ;; `reset-all!` restores every leakable atom to its load-time default so
 ;; the test fixtures can call it once and guarantee a clean config slate.
@@ -813,7 +810,7 @@
   - `suppressed-counters`         → `{}`
 
   Deliberately leaves `toggle-off-callbacks` intact — those are
-  load-time module registrations, not per-test state (per rf2-6ez1u)."
+  load-time module registrations, not per-test state."
   []
   (reset! global-args {})
   (reset! global-decorators [])

--- a/tools/story/src/re_frame/story/error.cljc
+++ b/tools/story/src/re_frame/story/error.cljc
@@ -8,18 +8,13 @@
   to `re-frame.story.predicates` (pure data→data) and
   `re-frame.story.late-bind` (run-time fn resolution).
 
-  ## Why this exists (rf2-9kpsq)
+  ## Why this exists
 
   The reader-conditional Throwable→`{:message :stack :data}` projection
-  was copy-pasted VERBATIM across five sites in four namespaces, and the
-  wrapping `:rf.error/exception` assertion-record was duplicated three
-  times. The copies had begun to DRIFT — one site wrapped each accessor
-  in a `when`-guard, another dropped `:stack` / `:data` entirely. A
-  reader had to diff five near-identical blocks to confirm they agreed.
-
-  Consolidating to one tested projection both removes the drift surface
-  and FIXES the two accidental divergences toward the canonical full
-  shape: `:stack` and `:data` are always present (nil when unavailable),
+  and its wrapping `:rf.error/exception` assertion-record are defined
+  ONCE here so every capture site shares one tested projection — no
+  per-site copies to diff or drift. The canonical shape is the full
+  one: `:stack` and `:data` are always present (nil when unavailable),
   and a nil throwable is tolerated (the trace-event drain path may carry
   a pre-extracted message without the original exception).
 
@@ -40,7 +35,7 @@
   - `:data`    — `(ex-data e)` projected through
     `re-frame.elision/elide-wire-value` so author-keyed `ex-data`
     sourced from path-marked app-db slots records `:rf/redacted`
-    rather than the raw value (rf2-294yq5.5; spec/API.md §Error-projection
+    rather than the raw value (spec/API.md §Error-projection
     records, spec/002 §Error projection §Privacy). nil for a
     non-`ExceptionInfo` throwable and nil for a nil `e` (`ex-data`
     already guards the instance check, so no explicit `instance?` test
@@ -50,12 +45,13 @@
   `exception-record` wraps that projection in the full
   `:rf.error/exception` assertion record per `002-Runtime.md` §Error projection.
 
-  ## Pipeline-exception projection (rf2-294yq5.2)
+  ## Pipeline-exception projection
 
-  The framework router no longer collapses every interceptor-chain
-  failure into `:rf.error/handler-exception` — per
+  The framework router classifies every interceptor-chain failure by
+  its TRUE failing component rather than collapsing it into
+  `:rf.error/handler-exception` — per
   `implementation/core/src/re_frame/router.cljc` §classify-pipeline-exception
-  it classifies the captured throw into the TRUE failing component:
+  the captured throw is classified into:
 
   - a coeffect-injection throw  → `:rf.error/coeffect-exception`
   - a user-interceptor throw    → `:rf.error/interceptor-exception`
@@ -63,17 +59,18 @@
 
   All three carry `:op-type :error` and the same tag shape
   (`:event` / `:exception` / `:failing-id`). Story's phase-capture
-  listeners had drifted: they matched ONLY `:rf.error/handler-exception`,
-  so a loader/event/play/teardown path whose cofx injector or user
-  interceptor threw was a silent false-green. `pipeline-exception-event?`
-  is the ONE projection predicate every capture site now consults —
-  any of the three operations targeting the frame is a captured
-  failure (spec/009 §Error contract; rf2-294yq5)."
+  listeners match all three: a loader/event/play/teardown path whose
+  cofx injector or user interceptor throws is captured with the same
+  fidelity as a handler throw, never a silent false-green.
+  `pipeline-exception-event?` is the ONE projection predicate every
+  capture site consults — any of the three operations targeting the
+  frame is a captured failure (spec/009 §Error contract)."
   (:require [re-frame.elision :as elision]
-            ;; rf2-7737vq — the canonical RAW trace-event frame reader
-            ;; (`re-frame.trace/trace-event-frame`), replacing Story's
-            ;; hand-rolled `[:tags :frame]` read. Core framework leaf, so
-            ;; the require keeps this ns at the leaf of the cycle graph.
+            ;; The canonical RAW trace-event frame reader
+            ;; (`re-frame.trace/trace-event-frame`) — read the raw event's
+            ;; frame through it, not a hand-rolled `[:tags :frame]` walk.
+            ;; Core framework leaf, so the require keeps this ns at the
+            ;; leaf of the cycle graph.
             [re-frame.trace   :as trace])
   (:refer-clojure :exclude [error]))
 
@@ -81,10 +78,10 @@
   "The framework `:rf.error/*` operations that represent an
   interceptor-chain (event-pipeline) exception Story projects onto the
   variant's `:rf.story/assertions`. Per the router's
-  `classify-pipeline-exception` (rf2-mszrz) a chain throw is attributed
+  `classify-pipeline-exception` a chain throw is attributed
   to its true failing component — a cofx injector, a user interceptor,
   or the event handler itself — so Story must capture all three rather
-  than only `:rf.error/handler-exception` (rf2-294yq5.2)."
+  than only `:rf.error/handler-exception`."
   #{:rf.error/handler-exception
     :rf.error/coeffect-exception
     :rf.error/interceptor-exception})
@@ -94,10 +91,10 @@
   `pipeline-exception-operations`) targeting `frame-id`. The ONE
   predicate every Story phase-capture site (runtime loaders/events,
   play, frame setup/teardown) consults so a cofx / user-interceptor
-  failure is captured with the same fidelity as a handler throw
-  (rf2-294yq5.2). Reads the raw event's frame via the canonical
+  failure is captured with the same fidelity as a handler throw.
+  Reads the raw event's frame via the canonical
   `re-frame.trace/trace-event-frame` reader (`[:tags :frame]` — spec/009
-  §Frame identity on the raw event, rf2-7737vq)."
+  §Frame identity on the raw event)."
   [frame-id ev]
   (and (contains? pipeline-exception-operations (:operation ev))
        (= frame-id (trace/trace-event-frame ev))))
@@ -106,7 +103,7 @@
   "Project an `ex-data` map through `re-frame.elision/elide-wire-value`
   keyed on `frame-id`, so author-keyed slots sourced from path-marked
   app-db paths record `:rf/redacted` rather than the raw value
-  (rf2-294yq5.5; spec/002 §Error projection §Privacy). Tolerant
+  (spec/002 §Error projection §Privacy). Tolerant
   (record-don't-throw): any elision error returns the raw value
   unchanged so redaction failure never breaks error recording.
 
@@ -130,7 +127,7 @@
 (defn throwable->error-map
   "Project a (possibly nil) Throwable into the canonical
   `{:message :stack :data}` error map. Reader-conditional, pure on both
-  runtimes EXCEPT for the frame-aware `:data` wire-elision (rf2-294yq5.5).
+  runtimes EXCEPT for the frame-aware `:data` wire-elision.
 
   `opts` (optional):
     :message — an explicit message string used in place of the
@@ -148,11 +145,11 @@
                  #?(:clj  (when err (.getMessage ^Throwable err))
                     :cljs (when err (str err))))
     ;; `with-out-str` rebinds Clojure's `*out*`, but the no-arg
-    ;; `Throwable.printStackTrace()` writes to `System/err` — so the
-    ;; trace LEAKED to stderr (trailing every green test run with a bare
-    ;; stack trace) while `:stack` captured the empty string (rf2-qk0h9).
-    ;; Hand `printStackTrace` an explicit `PrintWriter` so the trace
-    ;; lands in `:stack` and nothing escapes to the console.
+    ;; `Throwable.printStackTrace()` writes to `System/err` — so it would
+    ;; leak the trace to stderr (a bare stack trace trailing a green test
+    ;; run) while `:stack` captured the empty string. Hand `printStackTrace`
+    ;; an explicit `PrintWriter` so the trace lands in `:stack` and nothing
+    ;; escapes to the console.
     :stack   #?(:clj  (when err
                         (let [sw (java.io.StringWriter.)]
                           (.printStackTrace ^Throwable err (java.io.PrintWriter. sw))
@@ -161,8 +158,8 @@
     ;; `ex-data` already returns nil for a non-ExceptionInfo (and a nil)
     ;; throwable, so no explicit `instance?` guard is needed. The raw
     ;; ex-data is projected through the frame-aware wire-elision walker
-    ;; (rf2-294yq5.5) so sensitive author-keyed slots redact before the
-    ;; record reaches any observation surface.
+    ;; so sensitive author-keyed slots redact before the record reaches
+    ;; any observation surface.
     :data    (elide-ex-data frame (ex-data err))}))
 
 (defn exception-record
@@ -183,14 +180,13 @@
                   `:rf.error/coeffect-exception` /
                   `:rf.error/interceptor-exception`), preserved on the
                   record so a consumer can tell a cofx failure from a
-                  handler failure (rf2-294yq5.2). Absent ⇒ omitted.
+                  handler failure. Absent ⇒ omitted.
     :failing-id — the true failing component id the router attributed
                   (the cofx id, the interceptor id, or the event id),
                   preserved alongside `:operation`. Absent ⇒ omitted.
 
   `variant-id` is threaded as the `:frame` for the `:data` wire-elision
-  (rf2-294yq5.5) so a Story error record redacts under that frame's
-  marks."
+  so a Story error record redacts under that frame's marks."
   ([variant-id phase event err] (exception-record variant-id phase event err nil))
   ([variant-id phase event err {:keys [operation failing-id] :as opts}]
    (cond-> {:assertion  :rf.error/exception

--- a/tools/story/src/re_frame/story/extends.cljc
+++ b/tools/story/src/re_frame/story/extends.cljc
@@ -102,9 +102,9 @@
   key in that group from `inherited` before the merge. This lets a child
   override a parent's alternative encoding wholesale — e.g. a parent's
   `:play-script` and a child's `:plays` are sibling encodings of the
-  same play surface (rf2-tl7zk); without this the straight merge would
-  carry BOTH keys and the schema's mutual-exclusion `:fn` would reject a
-  body the author never wrote with both keys (rf2-ee38b.3)."
+  same play surface; without this the straight merge would carry BOTH
+  keys and the schema's mutual-exclusion `:fn` would reject a body the
+  author never wrote with both keys."
   [inherited child exclusive-groups]
   (reduce
     (fn [acc group]
@@ -130,9 +130,9 @@
   `exclusive-groups` (optional) is a coll of key-sets that are mutually-
   exclusive ENCODINGS of one slot — when the child declares any key in a
   group, the whole group is stripped from every inherited layer before
-  the merge so the child's encoding wins wholesale (per rf2-ee38b.3 the
-  Story play surface `#{:play-script :plays}` is one such group). Layers
-  closer to the child still shadow farther ones key-by-key as usual.
+  the merge so the child's encoding wins wholesale (the Story play surface
+  `#{:play-script :plays}` is one such group). Layers closer to the child
+  still shadow farther ones key-by-key as usual.
 
   Per /spec/007-Stories.md §Composed variants: 'Resolution at registration time. Cycles raise
   `:rf.error/extends-cycle`.' (The implemented error id is namespaced

--- a/tools/story/src/re_frame/story/fingerprint.cljc
+++ b/tools/story/src/re_frame/story/fingerprint.cljc
@@ -8,12 +8,11 @@
 
   It deliberately does NOT live in `re-frame.story.canonical` (that ns
   installs the canonical *vocabulary* — tags + the lifecycle machine).
-  This ns is the fingerprinting path, and it folds the former
-  `re-frame.story.identity` `canonical-form` / `content-hash` /
-  `snapshot-tuple` hashing into one place so there are no near-duplicate
-  canonicalisers to drift apart. `re-frame.story.identity` now delegates
-  its projection + hash to this ns (see that ns for the snapshot-identity
-  migration path).
+  This ns is the fingerprinting path: it is the single home for the
+  `canonical-form` / `content-hash` / `snapshot-tuple` hashing, so there
+  are no near-duplicate canonicalisers to drift apart.
+  `re-frame.story.identity` delegates its projection + hash to this ns
+  (see that ns for the snapshot-identity path).
 
   ## The public surface
 
@@ -24,9 +23,8 @@
     per-slot ordering imposed, and key spellings reconciled.
   - `content-hash` — stable 8-char hex hash of an exact value's ordered
     canonical form (NO volatile strip). This is the low primitive the
-    shipping snapshot-identity tuple hashes; preserving the no-strip
-    semantics keeps existing visual-regression baselines byte-identical
-    across the fold.
+    snapshot-identity tuple hashes; the no-strip semantics keep
+    visual-regression baselines byte-identical.
   - `canonical-hash` — stable 8-char hex hash of the `canonicalize`d
     projection (volatile strip applied). This is the determinism /
     semantic-diff / run-equivalence hash.
@@ -55,12 +53,12 @@
 
   ## Hash function
 
-  The hash is the same portable hash the former identity ns used: a
-  stable string serialisation (deterministic key order; sets/vectors
-  written in stable order; each collection wrapped under a reserved
-  structural type-tag so the four collection kinds are distinguishable —
-  rf2-lvrqa; functions folded to the `opaque-fn` sentinel so a hashed slot
-  carrying a fn is deterministic across processes — rf2-4gwja) hashed with
+  The hash is a portable hash: a stable string serialisation
+  (deterministic key order; sets/vectors written in stable order; each
+  collection wrapped under a reserved structural type-tag so the four
+  collection kinds are distinguishable; functions folded to the
+  `opaque-fn` sentinel so a hashed slot carrying a fn is deterministic
+  across processes) hashed with
   `hash` (JVM `clojure.lang.Util/hasheq`, CLJS `cljs.core/hash`), rendered
   as an 8-char lowercase hex string. It is 32-bit and per-artefact, not
   cryptographic; callers that need collision-resistance against an
@@ -81,19 +79,14 @@
   structure, so a canonical-form revision bumps it and old baselines are
   detectably stale rather than silently mis-compared.
 
-  Bumped `:rf/snapshot-canonical-v1` → `:rf/snapshot-canonical-v2`
-  (rf2-lvrqa) for the soundness fix that type-tags the canonical form: maps
-  / sets / vectors / seqs are now wrapped under reserved structural tags
-  (`map-tag` / `set-tag` / `vec-tag` / `seq-tag`) plus functions fold to the
-  `opaque-fn` sentinel (rf2-4gwja). Both change the byte shape of the
-  canonical form, so EVERY hash this primitive emits — `content-hash`
-  (snapshot identity), `canonical-hash`, `plan-hash`, `run-hash` — changes
-  value. Pre-alpha: re-stamping baselines is cheap, and there are NO
-  in-repo stored hash fixtures (every consumer asserts hash STABILITY /
-  SENSITIVITY relationally, never a pinned hex literal — verified
-  rf2-lvrqa), so the bump invalidates only EXTERNAL visual-regression
-  baselines, which re-stamp on their next capture. The v1 → v2 bump is
-  exactly the signal that drives that external re-stamp."
+  The canonical form type-tags its collections: maps / sets / vectors /
+  seqs are wrapped under reserved structural tags (`map-tag` / `set-tag` /
+  `vec-tag` / `seq-tag`) and functions fold to the `opaque-fn` sentinel.
+  Every consumer asserts hash STABILITY / SENSITIVITY relationally, never
+  a pinned hex literal, and there are NO in-repo stored hash fixtures, so a
+  version bump invalidates only EXTERNAL visual-regression baselines, which
+  re-stamp on their next capture. The version tag is exactly the signal
+  that drives that external re-stamp."
   :rf/snapshot-canonical-v2)
 
 ;; ===========================================================================
@@ -114,7 +107,7 @@
   The hashes still key the artifact at the call site; they simply do not
   feed the canonical value recursively.)
 
-  ### Per-run stamp fields (rf2-5x1wt.8 — the determinism strip)
+  ### Per-run stamp fields (the determinism strip)
 
   `:epoch-id`, `:dispatch-id`, `:trace-id`, `:committed-at`, and
   `:schema-digest` are the per-RUN bookkeeping stamps the framework writes
@@ -123,10 +116,10 @@
   counter are PROCESS-GLOBAL monotonic atoms (never reset per frame), and
   `:committed-at` is wall-clock — so two semantically-equal runs replayed
   into FRESH frames (`re-frame.story.artifact/replay-run-artifact`, spec
-  §Run artifact and replay) stamp DIFFERENT values for each. The `.7`
-  worker deliberately left this strip to the determinism gate
-  (rf2-5x1wt.8): a replay into a fresh frame stamps different epoch /
-  dispatch / trace ids, and THIS strip — together with the structural
+  §Run artifact and replay) stamp DIFFERENT values for each. This strip
+  belongs to the determinism gate: a replay into a fresh frame stamps
+  different epoch / dispatch / trace ids, and THIS strip — together with
+  the structural
   `:id` / `:time` / `:frame` strip in `strip-run-stamps` below — is what
   normalizes them so two semantically-equal runs canonicalize `=` and hash
   equal.
@@ -215,7 +208,7 @@
     :else           x))
 
 ;; ===========================================================================
-;; STRUCTURAL RUN-STAMP STRIP  (rf2-5x1wt.8 — the determinism layer)
+;; STRUCTURAL RUN-STAMP STRIP  (the determinism layer)
 ;; ===========================================================================
 ;;
 ;; `:id`, `:time`, and `:frame` are per-RUN stamps on a trace event / epoch
@@ -273,12 +266,10 @@
 (def ^:private volatile-cofx-keys
   "The per-run volatile facts nested INSIDE the flat `:rf.cofx` recordable-
   coeffect map that rides a `:rf.event/dispatched` trace event's `:tags`
-  (rf2-jt854w — EP-0010 observability completion: the router dev-stamps the
-  envelope's `:rf.cofx` onto the enqueue trace so Xray's Event lens can render
-  the COEFFECTS surface; EP-0017 / rf2-alc1lf renamed the envelope field from
-  the nested `:rf.world/inputs` to the flat `:rf.cofx` map — one fact per
-  owner-qualified key, no grouping sub-maps — and the framework time fact from
-  the nested `:time-ms` to the flat `:rf/time-ms`).
+  (the router dev-stamps the envelope's `:rf.cofx` onto the enqueue trace
+  so Xray's Event lens can render the COEFFECTS surface). The `:rf.cofx`
+  map holds one fact per owner-qualified key, with no grouping sub-maps,
+  and the framework time fact rides the flat `:rf/time-ms` key.
 
   The `:rf.cofx` MAP is semantic — caller-supplied owner-qualified facts (the
   app's `:counter/delta`, a subsystem's `:rf.route/location`, …) are the
@@ -303,12 +294,12 @@
   `strip-cofx-stamps` must reach into to drop the volatile fact:
 
   - `:rf.cofx` — the envelope's flat recordable-coeffect map. Rides a
-    `:rf.event/dispatched` trace event's `:tags` (rf2-jt854w — the router
-    dev-stamps it onto the enqueue trace) AND, per rf2-1xdotm, sits as the
-    top-level POST-generation replay-token slot on an `:rf/epoch-record`.
+    `:rf.event/dispatched` trace event's `:tags` (the router dev-stamps it
+    onto the enqueue trace) AND sits as the top-level POST-generation
+    replay-token slot on an `:rf/epoch-record`.
   - `:rf.event/cofx` — the POST-generation flat replay token the router
     dev-stamps onto the `:rf.event/run-start` trace event's `:tags`
-    (rf2-1xdotm, Spec 009 §Trace event shape). It is the SAME post-generation
+    (Spec 009 §Trace event shape). It is the SAME post-generation
     cofx map the epoch record's `:rf.cofx` slot is sourced from
     (`find-trigger-event` reads it off this tag), so it carries the same
     framework `:rf/time-ms` and false-drifts the `:epoch-tape` slice
@@ -330,8 +321,8 @@
   "Drop the per-run volatile facts (`volatile-cofx-keys` — the framework-stamped
   wall-clock `:rf/time-ms`) from EVERY flat recordable-coeffect map `m` carries
   under a `cofx-carrier-keys` slot (`:rf.cofx` / `:rf.event/cofx`), leaving the
-  semantic caller-supplied owner-qualified facts intact (rf2-jt854w / EP-0017
-  rf2-alc1lf / rf2-1xdotm). A slot that is absent or not a map is left untouched.
+  semantic caller-supplied owner-qualified facts intact. A slot that is
+  absent or not a map is left untouched.
   Pure data → data; idempotent.
 
   Three carriers route through here, all sharing the SAME post-generation /
@@ -340,11 +331,11 @@
   `:rf/time-ms`, so the determinism gate / semantic-diff / `:run-hash`
   false-drifts (`:epoch-tape` slice) unless it is stripped here:
 
-  - a `:rf.event/dispatched` TRACE EVENT's `:tags` `:rf.cofx` (rf2-jt854w);
-  - a `:rf.event/run-start` TRACE EVENT's `:tags` `:rf.event/cofx` (rf2-1xdotm —
-    the post-generation replay token the epoch record is sourced from);
-  - an `:rf/epoch-record`'s top-level `:rf.cofx` slot (rf2-1xdotm — the pinned
-    replay token a Tool-Pair replay supplies under `:rf.cofx/mint-policy
+  - a `:rf.event/dispatched` TRACE EVENT's `:tags` `:rf.cofx`;
+  - a `:rf.event/run-start` TRACE EVENT's `:tags` `:rf.event/cofx` (the
+    post-generation replay token the epoch record is sourced from);
+  - an `:rf/epoch-record`'s top-level `:rf.cofx` slot (the pinned replay
+    token a Tool-Pair replay supplies under `:rf.cofx/mint-policy
     :strict`). Same volatile class as the trace-event carriers, one slot up."
   [m]
   (reduce (fn [acc carrier-k]
@@ -358,8 +349,7 @@
   "Drop the per-run stamp keys (`volatile-trace-tag-keys`) from a trace
   event's `:tags` sub-map, leaving the semantic tags, and strip the per-run
   volatile `:rf/time-ms` nested inside the flat `:rf.cofx` recordable-coeffect
-  tag (rf2-jt854w / EP-0017 rf2-alc1lf). No-op when `:tags` is absent. Pure
-  data → data."
+  tag. No-op when `:tags` is absent. Pure data → data."
   [trace-event]
   (if (map? (:tags trace-event))
     (update trace-event :tags
@@ -384,8 +374,8 @@
 (defn strip-run-stamps
   "Strip the per-run stamps that ride a trace event (`:id`, `:time`) or an
   epoch record (`:frame`, plus the volatile `:rf/time-ms` in its top-level
-  `:rf.cofx` replay token — rf2-1xdotm) — the common-key stamps `project`
-  cannot strip globally without erasing app-db data (rf2-5x1wt.8). Recursive
+  `:rf.cofx` replay token) — the common-key stamps `project` cannot strip
+  globally without erasing app-db data. Recursive
   across maps, vectors, sets, and seqs, so it reaches trace events nested in an
   epoch record's `:trace-events` and epoch records nested in a run-result's
   `:epoch-tape`. Pure data → data; idempotent.
@@ -400,8 +390,8 @@
               (trace-event? x) (-> (dissoc :id :time) strip-trace-tags)
               ;; An epoch record loses its per-run `:frame` stamp AND the
               ;; framework-stamped `:rf/time-ms` nested in its top-level
-              ;; `:rf.cofx` replay token (rf2-1xdotm) — the latter is per-RUN
-              ;; volatile, the same class `strip-trace-tags` strips off the
+              ;; `:rf.cofx` replay token — the latter is per-RUN volatile,
+              ;; the same class `strip-trace-tags` strips off the
               ;; trace-event `:tags` carrier; without it the `:epoch-tape`
               ;; slice false-drifts on a fresh-frame replay.
               (epoch-record? x) (-> (dissoc :frame) strip-cofx-stamps))]
@@ -419,66 +409,66 @@
 ;; CANONICAL FORM — stable ordering + host-portable serialisation
 ;; ===========================================================================
 ;;
-;; Folded from the former `re-frame.story.identity` canonical-form path
-;; (rf2-ee38b.3) and hardened for soundness (rf2-lvrqa + rf2-4gwja):
+;; The canonical-form path is sound across collection kinds and fn values:
 ;;
-;; - STRUCTURAL TYPE TAGS (rf2-lvrqa). Each collection is wrapped in a
+;; - STRUCTURAL TYPE TAGS. Each collection is wrapped in a
 ;;   `[<type-tag> [<canon-elems> …]]` vector keyed by a reserved sentinel
 ;;   keyword, so the four collection types are mutually distinguishable
-;;   AFTER `pr-str`. The former code flattened a map `{:a 1}` to the bare
+;;   AFTER `pr-str`. Without tagging, a map `{:a 1}` flattened to the bare
 ;;   vector `[:a 1]` and a set `#{}` to `[]`, so `{}` / `#{}` / `[]` and
-;;   `{:a 1}` / `[:a 1]` collapsed to byte-identical canonical forms and
-;;   hashed equal — a soundness hole every downstream consumer (determinism
-;;   gate, semantic diff, golden, snapshot identity) inherited. Tagging
-;;   closes it: a map<->vector or set<->vector flip now perturbs the hash.
-;; - OPAQUE FN SENTINEL (rf2-4gwja). A function value is canonicalised to
-;;   the stable `:rf/opaque-fn` sentinel rather than passing through the
-;;   Object/default branch, where `pr-str` would embed the fn's per-process
-;;   object identity (`#object[…0x4a2f…]`) and make any hashed slice
-;;   carrying a raw fn NON-DETERMINISTIC across processes. The sentinel is
-;;   the deliberate trade-off (see `-canon` for fns): two plans/runs that
-;;   differ ONLY in fn identity hash EQUAL — determinism is the requirement,
-;;   so fn identity is intentionally NOT discriminated.
+;;   `{:a 1}` / `[:a 1]` would collapse to byte-identical canonical forms
+;;   and hash equal — a soundness hole every downstream consumer
+;;   (determinism gate, semantic diff, golden, snapshot identity) would
+;;   inherit. Tagging closes it: a map<->vector or set<->vector flip
+;;   perturbs the hash.
+;; - OPAQUE FN SENTINEL. A function value is canonicalised to the stable
+;;   `:rf/opaque-fn` sentinel rather than passing through the Object/default
+;;   branch, where `pr-str` would embed the fn's per-process object identity
+;;   (`#object[…0x4a2f…]`) and make any hashed slice carrying a raw fn
+;;   NON-DETERMINISTIC across processes. The sentinel is the deliberate
+;;   trade-off (see `-canon` for fns): two plans/runs that differ ONLY in fn
+;;   identity hash EQUAL — determinism is the requirement, so fn identity is
+;;   intentionally NOT discriminated.
 ;;
 ;; Maps sort entries by the canonicalised key's `pr-str`; sets sort
 ;; elements by a total comparator (`stable-canon-order` — `pr-str` primary
-;; with a deterministic equal-`pr-str` tiebreak, rf2-vvqeo); vectors/seqs keep
+;; with a deterministic equal-`pr-str` tiebreak); vectors/seqs keep
 ;; producer order and recurse. Integer scalars, strings, keywords, symbols,
 ;; booleans, and nil pass through — their `pr-str` is host-identical. Host-
 ;; DIVERGENT numbers (ratios + fractional/special doubles) are normalised to a
-;; bit-stable form by `canon-number` BELOW (rf2-vvqeo), so `pr-str` over every
+;; bit-stable form by `canon-number` BELOW, so `pr-str` over every
 ;; canonical value is host-identical across JVM + CLJS and the ordering — and
 ;; the tags — are stable across hosts.
 
 (def map-tag
-  "Reserved structural type-tag prefixing a map's canonical form
-  (rf2-lvrqa). A map `{:a 1}` canonicalises to `[:rf/map [:a 1]]`, never
+  "Reserved structural type-tag prefixing a map's canonical form.
+  A map `{:a 1}` canonicalises to `[:rf/map [:a 1]]`, never
   the bare `[:a 1]`, so it cannot collide with a literal vector of the same
   flattened shape."
   :rf/map)
 
 (def set-tag
-  "Reserved structural type-tag prefixing a set's canonical form
-  (rf2-lvrqa). A set `#{:a}` canonicalises to `[:rf/set [:a]]`, never the
+  "Reserved structural type-tag prefixing a set's canonical form.
+  A set `#{:a}` canonicalises to `[:rf/set [:a]]`, never the
   bare `[:a]`, so it cannot collide with a vector or a one-entry map."
   :rf/set)
 
 (def vec-tag
-  "Reserved structural type-tag prefixing a vector's canonical form
-  (rf2-lvrqa). A vector `[:a]` canonicalises to `[:rf/vec [:a]]`, so it is
+  "Reserved structural type-tag prefixing a vector's canonical form.
+  A vector `[:a]` canonicalises to `[:rf/vec [:a]]`, so it is
   distinguishable from a list/seq of the same elements and from a tagged
   map/set."
   :rf/vec)
 
 (def seq-tag
-  "Reserved structural type-tag prefixing a seq/list's canonical form
-  (rf2-lvrqa). A list `(:a)` canonicalises to `[:rf/seq [:a]]`, so seq vs
+  "Reserved structural type-tag prefixing a seq/list's canonical form.
+  A list `(:a)` canonicalises to `[:rf/seq [:a]]`, so seq vs
   vector is a distinguishable structural difference."
   :rf/seq)
 
 (def opaque-fn
-  "Stable opaque sentinel a function value canonicalises to (rf2-4gwja).
-  Replaces the per-process object-identity `pr-str` of a raw fn so any
+  "Stable opaque sentinel a function value canonicalises to. Replaces the
+  per-process object-identity `pr-str` of a raw fn so any
   hashed slice carrying a fn (a `:fx-overrides` plan slot,
   an app-db closure-as-value, an effect `:args` callback) hashes
   DETERMINISTICALLY across processes. The deliberate trade-off: two values
@@ -487,14 +477,15 @@
   :rf/opaque-fn)
 
 ;; ===========================================================================
-;; CROSS-HOST SCALAR STABILITY  (rf2-vvqeo)
+;; CROSS-HOST SCALAR STABILITY
 ;; ===========================================================================
 ;;
-;; SCALARS used to pass through `-canon` verbatim and be serialised by raw
+;; Most scalars pass through `-canon` verbatim and are serialised by raw
 ;; `pr-str`. For integers, strings, keywords, symbols, booleans, and nil that
 ;; is host-identical and stays untouched. But two number sub-kinds are NOT
-;; host-portable through `pr-str`, silently breaking the byte-stable-across-
-;; hosts contract that is the whole point of the fingerprint primitive:
+;; host-portable through `pr-str`, which would silently break the
+;; byte-stable-across-hosts contract that is the whole point of the
+;; fingerprint primitive, so they are normalised:
 ;;
 ;; 1. RATIOS. JVM Clojure has `clojure.lang.Ratio` — `(pr-str 1/3)` => "1/3".
 ;;    CLJS has NO Ratio type: the reader collapses `1/3` to the double
@@ -514,12 +505,12 @@
 ;;   verbatim — `Long` / `BigInt` / `BigInteger` on the JVM, integer-valued
 ;;   `number` on CLJS. Their `pr-str` is host-identical, so ordinary-value
 ;;   hashes are UNCHANGED (no golden rebase).
-;; - 3. LARGE INTEGERS (rf2-7w1vp). An integer whose magnitude EXCEEDS the
+;; - 3. LARGE INTEGERS. An integer whose magnitude EXCEEDS the
 ;;   safe-integer range (2^53-1) is NOT host-portable: JavaScript's `Number`
 ;;   cannot represent it exactly, so CLJS rounds it to the nearest double,
 ;;   while a JVM `Long` / `BigInt` keeps full precision and `pr-str`s it
 ;;   verbatim ("100000000000000000000N"). The same logical integer therefore
-;;   canonicalised to a bare integer string on the JVM but `[:rf/double <hex>]`
+;;   canonicalises to a bare integer string on the JVM but `[:rf/double <hex>]`
 ;;   on CLJS → divergent hash. POLICY: route such an integer through the SAME
 ;;   lossy IEEE-754 `double->bits-hex` path on BOTH hosts. Both agree on the
 ;;   double approximation (CLJS has no other option; the JVM converts via
@@ -552,14 +543,14 @@
 
 (def double-tag
   "Reserved structural tag prefixing a non-integer (or out-of-integer-range)
-  number's canonical form (rf2-vvqeo). A double `1.5` canonicalises to
+  number's canonical form. A double `1.5` canonicalises to
   `[:rf/double \"3ff8000000000000\"]` — the 16-char lowercase hex of its
   IEEE-754 64-bit pattern, byte-identical across JVM + CLJS, where raw
   `pr-str` of a double is not."
   :rf/double)
 
 (def nan-tag
-  "Stable sentinel every NaN canonicalises to (rf2-vvqeo). All NaN bit-
+  "Stable sentinel every NaN canonicalises to. All NaN bit-
   patterns fold to this ONE value so a `##NaN` slot hashes deterministically
   and never perturbs a hash by bit-pattern, and so `canon-set`'s
   `(sort-by pr-str)` ordering is stable in the presence of NaN (which is not
@@ -571,7 +562,7 @@
   (`js/Number.MAX_SAFE_INTEGER`). An integer of greater magnitude has no
   exact `js/Number` representation, so CLJS rounds it to the nearest double
   and the canonical form must take the lossy IEEE-754 bit path on BOTH hosts
-  to agree (rf2-7w1vp). Integers within ±this range `pr-str` host-identically
+  to agree. Integers within ±this range `pr-str` host-identically
   and pass through verbatim — no golden rebase."
   9007199254740991)
 
@@ -579,7 +570,7 @@
   "Return the 16-char lowercase hex of the IEEE-754 64-bit pattern of double
   `d`, identically on JVM + CLJS. The bit pattern of a given logical double
   is host-invariant, so this is the host-portable canonical double form where
-  `pr-str` is not (rf2-vvqeo)."
+  `pr-str` is not."
   [d]
   #?(:clj
      (format "%016x" (Double/doubleToLongBits d))
@@ -599,13 +590,13 @@
          (str (hx hi) (hx lo))))))
 
 (defn- canon-number
-  "Canonicalise a number to a host-portable form (rf2-vvqeo + rf2-7w1vp).
+  "Canonicalise a number to a host-portable form.
   An integer WITHIN the IEEE-754 safe-integer range (±2^53-1, `max-safe-
   integer`) passes through verbatim — its `pr-str` is host-identical. An
   integer OUTSIDE that range (a large `Long` / `BigInt` / `BigInteger` /
   `js/Number`) takes the SAME lossy `[double-tag <16-hex bits>]` IEEE-754
-  path on BOTH hosts (rf2-7w1vp — CLJS cannot represent it exactly anyway,
-  so JVM exactness is traded for cross-host agreement). A fractional / out-
+  path on BOTH hosts (CLJS cannot represent it exactly anyway, so JVM
+  exactness is traded for cross-host agreement). A fractional / out-
   of-integer-range double becomes `[double-tag <16-hex bits>]`; an integer-
   valued double within 64-bit integer range folds to that integer (CLJS
   cannot distinguish it from the integer anyway); a ratio is coerced to its
@@ -627,7 +618,7 @@
            (long d)
            :else [double-tag (double->bits-hex d)]))
        ;; An INTEGER whose magnitude exceeds the IEEE-754 safe-integer range
-       ;; (2^53-1) is NOT host-portable through `pr-str` (rf2-7w1vp): CLJS has
+       ;; (2^53-1) is NOT host-portable through `pr-str`: CLJS has
        ;; no exact integer past 2^53 — a `js/Number` rounds it to the nearest
        ;; double, and the CLJS branch below already routes it through
        ;; `double->bits-hex`. So a JVM `Long` / `BigInt` / `BigInteger` of the
@@ -654,11 +645,11 @@
 (defprotocol Canonicalise
   "Render a value into a canonical form: stable key order in maps, stable
   element order in sets, structural type tags distinguishing the four
-  collection kinds (rf2-lvrqa), function values folded to a stable opaque
-  sentinel (rf2-4gwja), host-divergent numbers normalised to a bit-stable
-  form (rf2-vvqeo — ratios + fractional/special doubles fold to a `:rf/double`
-  / `:rf/nan` tag; safe-range integers are unchanged, integers beyond ±2^53-1
-  take the same lossy `:rf/double` path on both hosts — rf2-7w1vp), and the
+  collection kinds, function values folded to a stable opaque sentinel,
+  host-divergent numbers normalised to a bit-stable form (ratios +
+  fractional/special doubles fold to a `:rf/double` / `:rf/nan` tag;
+  safe-range integers are unchanged, integers beyond ±2^53-1 take the same
+  lossy `:rf/double` path on both hosts), and the
   remaining terminal types
   (strings, keywords, booleans, nil) unchanged. Returns a value that
   round-trips through `pr-str` deterministically across hosts and processes."
@@ -668,7 +659,7 @@
   "Map canon: sort by the canonicalised key (via `pr-str` of the
   canon-key), flatten into a `[k v k v ...]` vector, then wrap under the
   reserved `map-tag` so a map is never byte-identical to a vector / set of
-  the same flattened shape (rf2-lvrqa). Symmetric across JVM + CLJS because
+  the same flattened shape. Symmetric across JVM + CLJS because
   `pr-str` over canonical scalars is host-identical."
   [m]
   (let [entries (->> m
@@ -677,14 +668,14 @@
     [map-tag (into [] (mapcat identity) entries)]))
 
 (defn- stable-canon-order
-  "A TOTAL, host-portable comparator over ALREADY-canonical set elements
-  (rf2-vvqeo). Primary key is `pr-str` (the historical order — so an ordinary
-  set of distinct-`pr-str` elements sorts EXACTLY as before, no hash rebase).
-  The secondary key is the SECOND `pr-str` only when the primaries tie, giving
-  a deterministic tiebreak for two DISTINCT elements that canonicalise to the
-  same `pr-str` (e.g. two `:rf/opaque-fn` sentinels) — previously `sort-by`
-  left their relative order comparator-unstable, a latent hole in the
-  byte-stable claim. Comparing the same string to itself yields 0, which
+  "A TOTAL, host-portable comparator over ALREADY-canonical set elements.
+  Primary key is `pr-str`, so an ordinary set of distinct-`pr-str` elements
+  sorts by it directly. The secondary key is the SECOND `pr-str` only when
+  the primaries tie, giving a deterministic tiebreak for two DISTINCT
+  elements that canonicalise to the same `pr-str` (e.g. two
+  `:rf/opaque-fn` sentinels), where a bare `sort-by` would leave their
+  relative order comparator-unstable — a latent hole in the byte-stable
+  claim. Comparing the same string to itself yields 0, which
   `sort` then orders deterministically, so even a genuine duplicate-`pr-str`
   pair is stable. The comparison is pure string compare, identical on JVM +
   CLJS."
@@ -701,24 +692,22 @@
 
 (defn- canon-set
   "Set canon: sort canonicalised elements into a stable vector via the total
-  `stable-canon-order` comparator (rf2-vvqeo — `pr-str` primary with a
-  deterministic equal-`pr-str` tiebreak, replacing the bare
-  `(sort-by pr-str)` whose order was comparator-unstable for two distinct
-  elements sharing a `pr-str`), then wrap under the reserved `set-tag` so a
-  set is never byte-identical to a vector / map (rf2-lvrqa)."
+  `stable-canon-order` comparator (`pr-str` primary with a deterministic
+  equal-`pr-str` tiebreak, so two distinct elements sharing a `pr-str`
+  order deterministically), then wrap under the reserved `set-tag` so a
+  set is never byte-identical to a vector / map."
   [s]
   [set-tag (vec (sort stable-canon-order (map -canon s)))])
 
 (defn- canon-vector
   "Vector canon: recurse over elements (producer order preserved — it is
-  semantic) and wrap under the reserved `vec-tag` (rf2-lvrqa)."
+  semantic) and wrap under the reserved `vec-tag`."
   [v]
   [vec-tag (mapv -canon v)])
 
 (defn- canon-seq
   "Seq/list canon: realise + recurse (producer order preserved) and wrap
-  under the reserved `seq-tag`, so a seq is distinguishable from a vector
-  (rf2-lvrqa)."
+  under the reserved `seq-tag`, so a seq is distinguishable from a vector."
   [s]
   [seq-tag (mapv -canon s)])
 
@@ -729,7 +718,7 @@
   #?(:clj  java.lang.Boolean :cljs boolean)
   (-canon [x] x)
 
-  ;; NUMBER → host-portable canonical number form (rf2-vvqeo). Integers pass
+  ;; NUMBER → host-portable canonical number form. Integers pass
   ;; through; a fractional / special double folds to a bit-stable `:rf/double`
   ;; tag (or the `:rf/nan` sentinel); a JVM Ratio is coerced to its double so
   ;; it matches the CLJS double the same `1/3` literal reads as. Ordinary
@@ -746,7 +735,7 @@
   #?(:clj  clojure.lang.Symbol  :cljs Symbol)
   (-canon [x] x)
 
-  ;; FUNCTION → stable opaque sentinel (rf2-4gwja). `clojure.lang.Fn` is the
+  ;; FUNCTION → stable opaque sentinel. `clojure.lang.Fn` is the
   ;; marker interface fns / closures implement but keywords, symbols, maps,
   ;; vectors, and sets do NOT (they are IFn but not Fn), so this extension
   ;; catches only genuine functions and does not shadow the collection
@@ -773,7 +762,7 @@
     ;; with canonical recursion. A raw fn reaching here (an `IFn` host type
     ;; the `Fn` / `function` branch above did not match) is mapped to the
     ;; opaque sentinel BEFORE the collection branches, so it can never fall
-    ;; through to an object-identity `pr-str` (rf2-4gwja). `pr-str` over the
+    ;; through to an object-identity `pr-str`. `pr-str` over the
     ;; result is deterministic across hosts AND processes.
     (cond
       (fn? x)         opaque-fn
@@ -820,7 +809,7 @@
   Projection composes two strips before ordering: the recursive reserved-key
   strip (`project` — volatile + `:rf.story/*` accumulator keys) and the
   structural per-run-stamp strip (`strip-run-stamps` — `:id` / `:time` /
-  `:frame` only on their trace-event / epoch-record carriers, rf2-5x1wt.8).
+  `:frame` only on their trace-event / epoch-record carriers).
   Together they erase every per-run stamp a fresh-frame replay writes, so
   two semantically-equal runs canonicalize `=` (the determinism gate's
   `test/assert-deterministic` is exactly this equality over N replays)."
@@ -845,18 +834,17 @@
                  hs)))))
 
 (defn hash-canonical
-  "Hash an ALREADY-canonical value (rf2-lvrqa). Prepends `canonical-version`
+  "Hash an ALREADY-canonical value. Prepends `canonical-version`
   as the first hashed slot and renders the `[version canonical-value]` pair
   to an 8-char-hex hash via a SINGLE `pr-str` — it does NOT re-run
   `canonical-form` over its input.
 
   This is the load-bearing primitive `content-hash` and `canonical-hash`
-  share. The former code re-applied `canonical-form` to the already-canonical
-  value before hashing; that was harmless only while `canonical-form` was
-  idempotent, but the rf2-lvrqa type-tags make it NON-idempotent (a second
-  pass would re-wrap `[:rf/map …]` as `[:rf/vec [:rf/map …]]`), so the
-  double-canon is removed. A consequence the determinism gate + golden rely
-  on: a caller holding an already-`canonicalize`d value `c` gets
+  share. It does NOT re-apply `canonical-form` to its already-canonical
+  input: the type-tags make `canonical-form` NON-idempotent (a second pass
+  would re-wrap `[:rf/map …]` as `[:rf/vec [:rf/map …]]`), so a single
+  canon pass is the contract. A consequence the determinism gate + golden
+  rely on: a caller holding an already-`canonicalize`d value `c` gets
   `(hash-canonical c)` == `(canonical-hash <the raw value>)` == `run-hash`,
   with no second canonicalization pass and no idempotence assumption."
   [canonical-value]
@@ -870,14 +858,13 @@
   (`:rf/snapshot-canonical-v2`) as the first hashed slot, so a
   canonical-form revision bumps the version and old baselines are
   detectably stale. Map key order does not affect the hash; a semantic
-  difference — including a map<->vector / set<->vector type flip
-  (rf2-lvrqa) — does.
+  difference — including a map<->vector / set<->vector type flip — does.
 
-  This is the low primitive the shipping `re-frame.story.identity`
-  snapshot tuple hashes. The rf2-lvrqa canonical-version bump
-  (`:rf/snapshot-canonical-v2`) re-stamps the snapshot content-hash, so
-  external visual-regression baselines re-capture on their next run (there
-  are no in-repo stored hash fixtures). Determinism / run-equivalence
+  This is the low primitive the `re-frame.story.identity` snapshot tuple
+  hashes. The canonical-version (`:rf/snapshot-canonical-v2`) keys the
+  snapshot content-hash, so external visual-regression baselines re-capture
+  whenever it bumps (there are no in-repo stored hash fixtures).
+  Determinism / run-equivalence
   callers want the strip — use `canonical-hash` (or `plan-hash` /
   `run-hash`) there."
   [x]

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -44,7 +44,7 @@
   registered body changed. Stage 3 surfaces the entry point; the
   trigger lives in Stage 4."
   (:require [re-frame.core             :as rf]
-            ;; rf2-294yq5 — `reset-state!` reaches the raw frame-state
+            ;; `reset-state!` reaches the raw frame-state
             ;; write boundary (`frame/replace-frame-state!`) directly so an
             ;; in-place fresh-run reset preserves frame IDENTITY + sub-cache
             ;; + the app-db/runtime-db projection reactions. The epoch-backed
@@ -62,7 +62,7 @@
             [re-frame.story.late-bind  :as late-bind]
             [re-frame.story.loaders    :as loaders]
             [re-frame.story.registrar  :as registrar]
-            ;; rf2-dg2uh — trace-listener pattern for the teardown
+            ;; Trace-listener pattern for the teardown
             ;; exception-projection path: re-frame's interceptor chain
             ;; catches handler exceptions internally and emits
             ;; `:rf.error/handler-exception` trace events rather than
@@ -80,9 +80,7 @@
 ;;                                  per-frame `pending-exceptions` slot
 ;;                                  evicts its entry.
 ;;
-;; (rf2-luzky removed the `:tap-stub-event` hook — the stub-call log below
-;; is already the SSOT for stub-redirected fx-ids, so the dev-mirror tap it
-;; drove is gone.)
+;; The stub-call log below is the SSOT for stub-redirected fx-ids.
 ;;
 ;; `re-frame.story/install-canonical-vocabulary!` is the producer side.
 
@@ -127,8 +125,7 @@
   The fx handler runs synchronously inside re-frame's `do-fx` walk
   with signature `(ctx args)` per Spec 002 §Effect handlers; `ctx`
   carries `:frame` and (optionally) `:event`. All bookkeeping lives
-  in process-level atoms rather than the frame's app-db. Stage 5
-  (rf2-h8et)."
+  in process-level atoms rather than the frame's app-db."
   [stub-id fx-id response]
   (rf/reg-fx
     stub-id
@@ -159,25 +156,22 @@
   failure (the play / variant pane renders it inline).
 
   `phase` is the originating phase: `:phase-0-setup` (`:frame-setup`
-  decorator `:init` events — rf2-294yq5.1), `:phase-loaders-teardown`
-  (variant body's `:loaders-teardown` events — rf2-lqs0b), or
-  `:phase-teardown` (`:frame-setup` decorator `:teardown` events —
-  rf2-dg2uh).
+  decorator `:init` events), `:phase-loaders-teardown`
+  (variant body's `:loaders-teardown` events), or
+  `:phase-teardown` (`:frame-setup` decorator `:teardown` events).
 
   Thin wrapper over the shared `re-frame.story.error/exception-record`
-  (rf2-9kpsq) — the Throwable→`{:message :stack :data}` projection + the
+  — the Throwable→`{:message :stack :data}` projection + the
   `:rf.error/exception` shape are the ONE canonical form. `opts`
   (optional) is threaded through so a drained pipeline-exception trace
-  event preserves its originating `:operation` / `:failing-id`
-  (rf2-294yq5.2)."
+  event preserves its originating `:operation` / `:failing-id`."
   ([variant-id phase event err] (phase-exception-record variant-id phase event err nil))
   ([variant-id phase event err opts]
    (story-error/exception-record variant-id phase event err opts)))
 
 (defn- pipeline-event-opts
   "Pull the `:operation` / `:failing-id` attribution off a captured
-  pipeline-exception trace event for `phase-exception-record`
-  (rf2-294yq5.2)."
+  pipeline-exception trace event for `phase-exception-record`."
   [tev]
   {:operation  (:operation tev)
    :failing-id (get-in tev [:tags :failing-id])})
@@ -191,7 +185,7 @@
   0-arg thunk), then remove the listener in a `finally`. Returns
   `body-fn`'s return value. Mirrors `with-teardown-trace-listener`;
   used to bracket the `:frame-setup` `:init` dispatch walk so a
-  setup-phase pipeline exception is captured (rf2-294yq5.1)."
+  setup-phase pipeline exception is captured."
   [listener body-fn]
   (let [cb-id (keyword "re-frame.story.frames"
                        (str "setup-capture-" (swap! setup-capture-counter inc)))]
@@ -209,19 +203,15 @@
   `:app-db-patch` (a `path → value` map) is merged into the frame's
   app-db via a registered helper event.
 
-  Exception handling (rf2-294yq5.1). Previously the `:init` dispatch
-  walk ran INSIDE `allocate!` before the runtime's per-frame trace
-  listener existed, so re-frame's interceptor chain captured a
-  throwing `:init` handler into a trace event that nothing observed —
-  `run-variant` reported `:pass` / `:ready` against a frame whose
-  declared preconditions never installed (a false green). We now
-  bracket the walk in its OWN scoped trace listener (symmetric with
-  `apply-frame-teardown!`): a pipeline exception (handler / coeffect /
-  interceptor — rf2-294yq5.2) targeting the frame is captured and
+  Exception handling. The walk runs inside its OWN scoped trace listener
+  (symmetric with `apply-frame-teardown!`): a pipeline exception (handler
+  / coeffect / interceptor) targeting the frame is captured and
   projected onto `[:rf.story/assertions]` as a `:rf.error/exception`
-  record with `:phase :phase-0-setup`, so the run aggregates as failed.
-  Synchronous throws from outside the interceptor chain are caught
-  directly. The walk continues so every setup failure is recorded."
+  record with `:phase :phase-0-setup`, so the run aggregates as failed —
+  a throwing `:init` handler whose declared preconditions never installed
+  surfaces rather than reporting a false green. Synchronous throws from
+  outside the interceptor chain are caught directly. The walk continues
+  so every setup failure is recorded."
   [frame-id frame-setup-decorators]
   (when (seq frame-setup-decorators)
     (let [pending  (atom [])
@@ -359,10 +349,11 @@
                                              {:frame variant-id})
                            (catch #?(:clj Throwable :cljs :default) _ nil))))))
         listener (fn [ev]
-                   ;; rf2-294yq5.2 — capture every pipeline exception
+                   ;; Capture every pipeline exception
                    ;; (handler / coeffect / interceptor), not just
                    ;; handler-exception: a teardown event whose cofx
-                   ;; injector or user interceptor throws was a false-green.
+                   ;; injector or user interceptor throws is a first-class
+                   ;; failure too.
                    (when (story-error/pipeline-exception-event? variant-id ev)
                      (swap! pending conj ev)))]
     (with-teardown-trace-listener
@@ -405,7 +396,7 @@
 
 ;; ---- variant body :loaders-teardown walk --------------------------------
 ;;
-;; rf2-lqs0b — symmetric counterpart of `:loaders` on the variant body. A
+;; Symmetric counterpart of `:loaders` on the variant body. A
 ;; long-lived fx (websocket subscription, polling interval, geolocation
 ;; watch) opened by a `:loaders` event needs a matching cancel-event at
 ;; variant teardown. `:loaders-teardown` is the lightweight path for
@@ -458,7 +449,7 @@
                                              {:frame variant-id})
                            (catch #?(:clj Throwable :cljs :default) _ nil))))))
         listener (fn [ev]
-                   ;; rf2-294yq5.2 — capture every pipeline exception
+                   ;; Capture every pipeline exception
                    ;; (handler / coeffect / interceptor), not just
                    ;; handler-exception (a loaders-teardown event whose
                    ;; cofx injector / user interceptor throws is a
@@ -501,9 +492,8 @@
 
   Mirrors the `install-canonical-<X>!` shape used by every sibling
   installer in `canonical/canonical-installers` (`install-canonical-tags!`,
-  `install-canonical-assertions!`, `install-canonical-fx-stubs!`, …). Was
-  the vague `install-helpers!` (rf2-152jq inline rename) — the new name
-  states what's installed."
+  `install-canonical-assertions!`, `install-canonical-fx-stubs!`, …); the
+  name states what's installed."
   []
   (when config/enabled?
     (rf/reg-event
@@ -533,9 +523,9 @@
   Per `002-Runtime.md` §Per-variant frame allocation we stamp `:rf/story?` and `:rf/variant` so tools
   can recognise variant frames from their `frame-meta`.
 
-  rf2-bsk1d9 — a variant's EP-0015 frame-owned `:sensitive` / `:large`
-  declarations (the owner model that REPLACES the removed public
-  `add-marks` / `set-marks` surface) are threaded straight onto the
+  A variant's EP-0015 frame-owned `:sensitive` / `:large`
+  declarations (the frame-owner classification model) are threaded
+  straight onto the
   `reg-frame` config so the framework's `re-frame.frame-classification`
   validates + installs them atomically as part of frame creation, BEFORE
   `:on-create`. Story does not fork the classification validation; a
@@ -550,9 +540,9 @@
     (some? large)      (assoc :large large)
     ;; EP-0023 §Stories — report the IMAGE ids this behaviour-variant frame
     ;; resolves behaviour against, on frame-meta, so Test mode / MCP / Xray can
-    ;; surface which behaviour set ran (rf2-fpr0b5 item 4). The actual image
+    ;; surface which behaviour set ran. The actual image
     ;; GENERATION rides the frame's record (the `:generation` slot), written by
-    ;; `rf/make-frame` in `allocate!` (EP-0024, rf2-tu2vr7); this slot carries
+    ;; `rf/make-frame` in `allocate!` (EP-0024); this slot carries
     ;; the authored ids for tooling read-back.
     (seq image-ids)    (assoc :rf/images (vec image-ids))))
 
@@ -571,12 +561,12 @@
   `decorator-stack` is the result of `decorators/resolve-decorators`;
   the runtime computes it upstream.
 
-  Lifecycle dispatch (rf2-043cm):
+  Lifecycle dispatch:
 
   - **Events-only variants** (no `:loaders`, no `:frame-setup`
     decorators, no `:loaders-complete-when`) take the fast-path:
     `:pre-mount → :ready` in one transition via `mount-ready!`. The
-    canvas's loading skeleton (rf2-0s4p1) never engages for these
+    canvas's loading skeleton never engages for these
     variants because the lifecycle never reports a loading phase.
   - **All other variants** take the classical four-phase path:
     `mount!` drives `:pre-mount → :mounting`; the runtime then
@@ -596,25 +586,25 @@
           fx-overrides   (register-fx-overrides! fx-stack)
           ;; Inline the variant-body lookup (`variant-body` is defined
           ;; lower in this ns) — go through the registrar directly so
-          ;; the events-only classification (rf2-043cm) doesn't depend
+          ;; the events-only classification doesn't depend
           ;; on the file's declaration order.
           v-body         (registrar/handler-meta :variant variant-id)
           ;; EP-0023 §Stories — the variant's behaviour-variant IMAGES (the
           ;; `rf/image` registration-set values its frame resolves behaviour
           ;; against). A vector of image VALUES; nil/empty for an ordinary
           ;; state variant (which resolves against the shared default
-          ;; registrar). rf2-fpr0b5.
+          ;; registrar).
           images         (:images v-body)
-          ;; rf2-bsk1d9 — thread the variant's EP-0015 frame-owned
-          ;; `:sensitive` / `:large` classification onto the reg-frame config.
-          ;; rf2-fpr0b5 — plus the image ids (for frame-meta tooling read-back).
+          ;; Thread the variant's EP-0015 frame-owned
+          ;; `:sensitive` / `:large` classification onto the reg-frame config,
+          ;; plus the image ids (for frame-meta tooling read-back).
           config-map     (variant-frame-config
                            variant-id fx-overrides
                            (assoc (select-keys v-body [:sensitive :large])
                                   :image-ids (keep image-id images)))
           events-only?   (loaders/events-only-variant? v-body decorator-stack)]
       ;; EP-0023 §Stories / §Frame-derived live registration resolution
-      ;; (rf2-fpr0b5 item 1) — when the variant declares behaviour-variant
+      ;; — when the variant declares behaviour-variant
       ;; `:images`, the frame carries the resolved, sealed image GENERATION so
       ;; `process-event!`'s `call-with-frame-resolution` routes the whole cascade
       ;; (event-handler lookup, cofx, fx) for any `{:frame variant-id}` dispatch
@@ -626,18 +616,14 @@
       ;; validation — a malformed image or a zero-match `:include-ns` glob FAILS
       ;; LOUDLY here at frame creation.
       ;;
-      ;; EP-0024 (rf2-tu2vr7) — ONE `make-frame` call. The create-twice idiom +
-      ;; ORDER footgun (formerly: `make-frame {:id … :images …}` FIRST to create
-      ;; the backing record empty, then `reg-frame` to surgical-update its config,
-      ;; because the two-registry split meant `make-frame`'s internal
-      ;; `reg-frame …{}` would clobber a config registered first) is GONE: the
-      ;; unified constructor accepts BOTH the image-selection opts AND the full
-      ;; record-config in one call over the one registry. `:images` is supplied
-      ;; only when the variant declares them (absent ⇒ no generation).
+      ;; EP-0024 — ONE `make-frame` call. The unified constructor accepts
+      ;; BOTH the image-selection opts AND the full record-config in one
+      ;; call over the one registry. `:images` is supplied only when the
+      ;; variant declares them (absent ⇒ no generation).
       (rf/make-frame (cond-> {:id variant-id}
                        (seq images) (assoc :images (vec images))
                        :always      (merge config-map)))
-      ;; rf2-043cm — drive the lifecycle by variant shape. Events-only
+      ;; Drive the lifecycle by variant shape. Events-only
       ;; variants jump straight to :ready (no skeleton ever shows);
       ;; everything else takes the classical four-phase route through
       ;; :mounting → :loading → :ready.
@@ -651,7 +637,7 @@
       (apply-frame-setup! variant-id (:frame-setup decorator-stack))
       variant-id)))
 
-;; ---- inline-plan allocation (rf2-5x1wt.20) -------------------------------
+;; ---- inline-plan allocation ----------------------------------------------
 ;;
 ;; An inline plan (spec/017 §Inline plan) is an executable plan map that is
 ;; NOT registered as a Story variant — so `allocate!`'s side-table reads
@@ -678,8 +664,8 @@
     (seq fx-overrides) (assoc :fx-overrides fx-overrides)))
 
 (defn allocate-inline!
-  "Allocate an anonymous frame for an inline plan run (rf2-5x1wt.20,
-  spec/017 §Inline plan). Registry-free twin of `allocate!`:
+  "Allocate an anonymous frame for an inline plan run (spec/017
+  §Inline plan). Registry-free twin of `allocate!`:
 
   - `frame-id` — the anonymous frame id the runtime minted (NOT a
     registered variant id);
@@ -688,7 +674,7 @@
   - `plan-fx-overrides` — the plan's `[:world :frame :fx-overrides]` lowered
     map (e.g. the managed-HTTP stub the compiler folded `:network` into);
   - `events-only?` — whether the plan drives no loaders / frame-setup, so
-    the lifecycle takes the `:pre-mount → :ready` fast-path (rf2-043cm).
+    the lifecycle takes the `:pre-mount → :ready` fast-path.
 
   Registers the `:fx-override`-decorator stubs, drives the lifecycle by the
   supplied shape, applies any `:frame-setup` decorators' `:init` events, and
@@ -711,7 +697,7 @@
       frame-id)))
 
 (defn destroy-inline!
-  "Tear down an inline-plan frame (rf2-5x1wt.20). The registry-free twin of
+  "Tear down an inline-plan frame. The registry-free twin of
   `destroy!`: an inline frame has no registered body, so the side-table
   reads `destroy!` makes (the variant `:loaders-teardown`, the decorator
   re-resolution) have nothing to read. `decorator-stack` is the SAME stack
@@ -728,7 +714,7 @@
     (clear-stub-call-log! frame-id)
     (when-let [drop (late-bind/get-fn :drop-assertion-accumulators)]
       (try (drop frame-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
-    ;; rf2-booyu — evict the play-runner's per-frame run-state on teardown
+    ;; Evict the play-runner's per-frame run-state on teardown
     ;; (symmetric with `destroy!`); an inline frame that drove a script
     ;; leaves no stale run-state behind once it is torn down.
     (when-let [drop (late-bind/get-fn :drop-run-state)]
@@ -750,16 +736,16 @@
 
   1. Clear lifecycle watchers + per-frame stub-call log; drop the
      per-variant assertion accumulators + the play-runner's per-frame
-     run-state (rf2-booyu) via the late-bind hooks.
+     run-state via the late-bind hooks.
   2. Dispatch-sync the variant body's `:loaders-teardown` events
-     (declared order, rf2-lqs0b) — cleans up loader-installed narrower
+     (declared order) — cleans up loader-installed narrower
      state. BEFORE the decorator teardown.
   3. Dispatch-sync the `:frame-setup` decorator `:teardown` events
      (reverse-declaration order) — cleans up decorator-installed wider
      state.
 
   Shared by `destroy!` (which follows with `rf/destroy-frame!`) and the
-  in-place `reset-state!` (rf2-294yq5, which follows with a frame-state
+  in-place `reset-state!` (which follows with a frame-state
   reset instead) so both paths run the SAME symmetric external-resource
   cleanup. Exceptions in each walk are caught + projected onto the
   variant's `[:rf.story/assertions]`; the walks never abort."
@@ -768,14 +754,14 @@
   (clear-stub-call-log! variant-id)
   (when-let [drop (late-bind/get-fn :drop-assertion-accumulators)]
     (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
-  ;; rf2-booyu — evict the play-runner's per-frame run-state on teardown
+  ;; Evict the play-runner's per-frame run-state on teardown
   ;; (run-state / runs-by-play / active-play / step-boundaries) so a
   ;; torn-down frame leaves no stale terminal play status behind. Routed
   ;; through the `:drop-run-state` late-bind hook (frames cannot :require
   ;; runner-events — cycle).
   (when-let [drop (late-bind/get-fn :drop-run-state)]
     (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
-  ;; Step 3 (rf2-lqs0b) — variant body :loaders-teardown. Runs BEFORE
+  ;; Step 3 — variant body :loaders-teardown. Runs BEFORE
   ;; decorator teardown so loader-installed narrower state is cleaned
   ;; up before decorator-installed wider state.
   (try
@@ -801,7 +787,7 @@
      late-bind shim) + per-frame stub-call log.
   2. Clear lifecycle watchers (`loaders/clear-watchers!`).
   3. Dispatch-sync the variant body's `:loaders-teardown` events in
-     declared order (rf2-lqs0b). Exceptions are caught and projected
+     declared order. Exceptions are caught and projected
      into the variant frame's `:rf.story/assertions` as
      `:rf.error/exception` records with
      `:phase :phase-loaders-teardown`. The walk never aborts.
@@ -828,30 +814,28 @@
     (rf/destroy-frame! variant-id)
     nil))
 
-;; ---- in-place fresh-run reset (rf2-294yq5) --------------------------------
+;; ---- in-place fresh-run reset --------------------------------------------
 
 (defn reset-state!
   "Reset an EXISTING variant frame to fresh state IN PLACE — preserving
   the frame's IDENTITY, sub-cache, and app-db/runtime-db projection
   reactions — instead of `destroy!` + re-`allocate!`.
 
-  Why this exists (rf2-294yq5, the PR #3672 last-red fix). `run-variant`
-  must enforce a fresh-run boundary so a second run on the same id does
-  NOT inherit the first run's app-db and so loader variants re-run their
-  loaders (the lifecycle machine must leave `:ready`). The first cut
-  (`ensure-fresh-frame!` → `destroy!` + `allocate!`) achieved fresh state
-  but DESTROYED the frame: `destroy-frame!` tears down the sub-cache and
+  Why this exists. `run-variant` must enforce a fresh-run boundary so a
+  second run on the same id does NOT inherit the first run's app-db and
+  so loader variants re-run their loaders (the lifecycle machine must
+  leave `:ready`). A `destroy!` + `allocate!` would achieve fresh state
+  but DESTROY the frame: `destroy-frame!` tears down the sub-cache and
   the partition projections. When the canvas has ALREADY mounted the
   variant view under `frame-provider-existing {:frame variant-id}` (its
   `@(subscribe …)` reactions wired to THIS frame's sub-cache) before
-  `:component-did-mount` → `run-variant` runs, that destroy ORPHANS every
-  live reaction: a subsequent `:counter/set 42` updates the freshly
-  re-allocated frame's app-db, but the stale reaction never observes it,
-  so the DOM never re-renders (count-display stuck at \"0\"). Invisible to
-  the JVM (no React reconciliation), which is why a JVM-validated fix
-  missed it.
+  `:component-did-mount` → `run-variant` runs, a destroy would ORPHAN
+  every live reaction: a subsequent `:counter/set 42` would update the
+  freshly re-allocated frame's app-db, but the stale reaction would never
+  observe it, so the DOM would never re-render. This is invisible to the
+  JVM (no React reconciliation).
 
-  The fix: reset in place. We run the SAME teardown walks `destroy!`
+  Instead we reset in place. We run the SAME teardown walks `destroy!`
   runs (so loader/decorator-installed external resources are cleaned up
   symmetrically), then overwrite BOTH frame-state partitions with `{}`
   via the raw `frame/replace-frame-state!` write boundary — the same
@@ -884,12 +868,12 @@
 
 (defn reset-frame!
   "Destroy the variant frame and re-allocate it. Mirrors the framework's
-  `re-frame.core/reset-frame!` naming (rf2-noizc — aligning Story's
+  `re-frame.core/reset-frame!` naming (aligning Story's
   frame helpers with the framework `*-frame!` convention). The caller
   is responsible for re-running the four-phase lifecycle (loaders →
   events → render → play) after.
 
-  NOTE the in-place `reset-state!` (rf2-294yq5) is the path
+  NOTE the in-place `reset-state!` is the path
   `run-variant`'s fresh-run boundary takes when a frame already exists —
   it preserves live view reactions. This destroy + re-allocate helper is
   the explicit full-teardown variant retained for callers that genuinely
@@ -914,7 +898,7 @@
   an in-flight inline frame out of the live-frame enumeration during the
   window between `allocate-inline!` and `destroy-inline!`, closing the
   transient gap that side-table absence alone (no registration) does not
-  cover (rf2-r16iv)."
+  cover."
   [frame-id]
   (let [m (rf/frame-meta frame-id)]
     (and (true? (:rf/story? m))
@@ -930,7 +914,7 @@
 
 (defn variant-image-ids
   "Return the vector of behaviour-variant IMAGE ids a variant frame resolves
-  behaviour against (EP-0023 §Stories, rf2-fpr0b5), or nil for an ordinary
+  behaviour against (EP-0023 §Stories), or nil for an ordinary
   state variant that resolves against the shared default registrar. Reads the
   `:rf/images` slot `allocate!` stamps onto frame-meta. The companion read for
   Test mode / MCP / Xray to surface WHICH behaviour set ran."

--- a/tools/story/src/re_frame/story/generate/test_check.cljc
+++ b/tools/story/src/re_frame/story/generate/test_check.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story.generate.test-check
   "OPTIONAL `clojure.test.check` adapter for the generator-agnostic property
-  runner (rf2-6nk6d; spec/017-Testing-Story.md §Generator-agnostic — a
+  runner (spec/017-Testing-Story.md §Generator-agnostic — a
   generated run is driven by a caller-supplied `gen-fn` and `clojure.test.check`
   is named there as a fit 'by wrapping its draw in a `gen-fn`'). This namespace
   IS that wrapping, made concrete + reusable.
@@ -10,7 +10,7 @@
   `re-frame.story.generate/check-property!` is driven by a pure
   `(fn [seed] event-program)` over the self-contained splitmix64 PRNG
   (`seed-seq`) and bundles NO generator library — that dependency-free path is
-  and remains the DEFAULT (rf2-5x1wt.31). This adapter is pure additive sugar:
+  and remains the DEFAULT. This adapter is pure additive sugar:
   it lets a caller who ALREADY has `org.clojure/test.check` on the classpath
   hand a `test.check` generator of event programs and get back the same
   `gen-fn` shape `check-property!` already takes. Nothing about the seed-bearing

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -9,44 +9,41 @@
   the body changes, the hash changes; when it doesn't, the hash is
   stable across hosts and runs.
 
-  ## Migration path (rf2-5x1wt.3 — single canonical primitive)
+  ## Single canonical primitive
 
-  The canonical projection + hashing that used to live here
-  (`canonical-form` / `content-hash`) has been **folded into the single
-  fingerprinting primitive** `re-frame.story.fingerprint`, per
-  tools/story/spec/017-Testing-Story.md §Canonicalization. There is now
+  The canonical projection + hashing lives in the single fingerprinting
+  primitive `re-frame.story.fingerprint`, per
+  tools/story/spec/017-Testing-Story.md §Canonicalization. There is
   exactly one canonical path; `:plan-hash`, `:run-hash`, determinism, and
   semantic-diff share it with snapshot identity.
 
-  This ns keeps its public surface (`snapshot-tuple`, `snapshot-identity`)
-  so the shipping watch-mode + visual-regression call sites keep working
-  unchanged. Snapshot identity hashes its tuple through the fingerprint
-  `content-hash` low primitive — the **strip-free** ordered hash.
+  This ns exposes its public surface (`snapshot-tuple`, `snapshot-identity`)
+  for the watch-mode + visual-regression call sites. Snapshot identity
+  hashes its tuple through the fingerprint `content-hash` low primitive —
+  the **strip-free** ordered hash.
 
-  The rf2-5x1wt.3 *fold* was a pure relocation of the hashing code (no
-  value change). The later rf2-lvrqa *soundness* fix is a deliberate
-  canonical-form REVISION: it type-tags the canonical form (so `{}` ≠ `[]`,
-  `{:k 1}` ≠ `[:k 1]`) and folds functions to a stable sentinel, and BUMPS
-  the canonical-version tag `re-frame.story.fingerprint/canonical-version`
-  `:rf/snapshot-canonical-v1` → `:rf/snapshot-canonical-v2`. That tag is the
-  single source of truth for the version: `fingerprint/hash-canonical`
-  prepends it as the first hashed slot of EVERY hash (`content-hash`,
-  `canonical-hash`, `plan-hash`, `run-hash`), so the snapshot content-hash
-  VALUE changes with the bump. External visual-regression baselines
-  therefore re-capture on their next run (the bump is the re-stamp signal);
-  there are no in-repo stored hash fixtures to migrate. The hashing CODE
-  lives in the single fingerprint primitive; this ns hashes its snapshot
-  tuple through it. The snapshot tuple also carries a `:rf/snapshot-canonical` data slot,
-  which reads its value straight from `fingerprint/canonical-version` (it is
-  NOT a second, independently-versioned marker — it tracks the one tag).
+  The canonical form is sound: it type-tags the canonical form (so `{}` ≠
+  `[]`, `{:k 1}` ≠ `[:k 1]`) and folds functions to a stable sentinel. The
+  canonical-version tag `re-frame.story.fingerprint/canonical-version`
+  (`:rf/snapshot-canonical-v2`) is the single source of truth for the
+  version: `fingerprint/hash-canonical` prepends it as the first hashed
+  slot of EVERY hash (`content-hash`, `canonical-hash`, `plan-hash`,
+  `run-hash`), so a canonical-form revision changes the snapshot
+  content-hash VALUE. External visual-regression baselines re-capture on
+  their next run (a version bump is the re-stamp signal); there are no
+  in-repo stored hash fixtures. The hashing CODE lives in the single
+  fingerprint primitive; this ns hashes its snapshot tuple through it. The
+  snapshot tuple also carries a `:rf/snapshot-canonical` data slot, which
+  reads its value straight from `fingerprint/canonical-version` (it is NOT
+  a second, independently-versioned marker — it tracks the one tag).
 
   The volatile-field strip + `:variant-id` → `:variant/id` reconciliation
   live in the fingerprint `canonicalize` path that backs determinism /
   semantic-diff / `:plan-hash` / `:run-hash`; they do NOT touch the
   strip-free snapshot `content-hash`, so the snapshot tuple keeps its
-  `:variant-id` slot exactly as before. The deliberate path for any *new*
-  consumer is to call `re-frame.story.fingerprint/canonicalize` (or
-  `content-hash` / `canonical-hash` / `plan-hash` / `run-hash`) directly.
+  `:variant-id` slot. The path for any *new* consumer is to call
+  `re-frame.story.fingerprint/canonicalize` (or `content-hash` /
+  `canonical-hash` / `plan-hash` / `run-hash`) directly.
 
   ## What's in the hash
 
@@ -55,7 +52,7 @@
 
   - Variant id
   - `:events` setup dispatches and the `:play-script` / `:plays` play
-    surfaces (in order) — rf2-0wrud removed the legacy `:play` slot
+    surfaces (in order)
   - `:loaders` / `:loaders-complete-when` / `:loaders-teardown`
     (in declared order; canonicalised)
   - Effective `:args` (post-`:extends`-merge with story + active modes)
@@ -90,7 +87,7 @@
   collision-resistance.
 
   The canonical-form version tag `fingerprint/canonical-version`
-  (now `:rf/snapshot-canonical-v2`, bumped by rf2-lvrqa) is prepended by
+  (`:rf/snapshot-canonical-v2`) is prepended by
   `fingerprint/hash-canonical` as the first slot of the hashed structure, so
   a canonical-form revision bumps the version and old baselines are
   detectably stale rather than silently mis-compared."
@@ -110,18 +107,16 @@
   participate in the hash — watch-mode auto-rerun keys off this identity
   so a decorator-only edit MUST perturb it.
 
-  ## Slice membership (rf2-bgwnf)
+  ## Slice membership
 
   A key belongs in the slice iff editing it changes the variant's
   *settled rendered/tested state* — the thing a visual-regression
-  baseline or watch-mode rerun must invalidate on. Audited 2026-05-21:
+  baseline or watch-mode rerun must invalidate on.
 
   Included:
   - `:play-script` / `:plays` — the post-render interaction sequences.
     A play edit changes the asserted/driven state, so it MUST perturb
-    the hash. (rf2-0wrud removed the legacy `:play` slot; this slice
-    tracked `:play`, which silently no longer existed — the bug
-    rf2-bgwnf fixes.)
+    the hash.
   - `:events` — pre-render setup dispatches.
   - `:loaders` / `:loaders-complete-when` / `:loaders-teardown` — async
     setup + the symmetric teardown; both shape the frame's settled state.
@@ -178,7 +173,7 @@
   variant snapshot identity — exactly the invalidation visual-regression
   baselines need on schema changes.
 
-  EP-0002 (rf2-bd4div) — app-db schemas are CONTEXT-REQUIRED FRAME-LOCAL,
+  EP-0002 — app-db schemas are CONTEXT-REQUIRED FRAME-LOCAL,
   so the digest hook resolves a TARGET frame; absence is
   `:rf.error/no-frame-context`, NEVER a synthesised `:rf/default`. Story
   computes snapshot identity for a specific variant, so the variant frame
@@ -215,7 +210,7 @@
          effective    (args/resolve-args variant-id
                                          {:active-modes   active-modes
                                           :cell-overrides cell-overrides})
-         ;; EP-0002 (rf2-bd4div) — the variant frame is the explicit
+         ;; EP-0002 — the variant frame is the explicit
          ;; target for the frame-local app-db schema digest (no ambient
          ;; resolution / no `:rf/default` synthesis).
          schema-digest (view-schema-digest variant-id)]
@@ -225,7 +220,7 @@
       :story                 story
       :effective-args        effective
       :view-schema-digest    schema-digest
-      ;; rf2-z86vu — `:active-modes` already perturbs identity via
+      ;; `:active-modes` already perturbs identity via
       ;; `:effective-args` (mode args are merged in by `resolve-args`),
       ;; so this top-level slot is intentionally belt-and-braces: it
       ;; keeps the mode-id SET part of the identity so two distinct modes

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -22,8 +22,8 @@
                                      (read from the stub-call log). The
                                      assertions module unions it with the
                                      epoch tape's effects for
-                                     `:rf.assert/effect-emitted` (rf2-q651r
-                                     — a stubbed fx lands on the tape under
+                                     `:rf.assert/effect-emitted`
+                                     (a stubbed fx lands on the tape under
                                      its rewritten stub id, not its
                                      original). Signature: `(f frame-id) →
                                      #{fx-id …}`.

--- a/tools/story/src/re_frame/story/lifecycle.cljc
+++ b/tools/story/src/re_frame/story/lifecycle.cljc
@@ -3,8 +3,7 @@
   variant lifecycle (loaders → events → render → play), the snapshot-
   identity helper, and the frame teardown / enumeration helpers.
 
-  Per the rf2-l8eso Phase-2 facade thinning: these symbols are
-  re-exported from `re-frame.story` so users continue calling
+  These symbols are re-exported from `re-frame.story`, so users call
   `re-frame.story/run-variant` etc. The implementation weight — the
   delegators into `re-frame.story.runtime`, `re-frame.story.frames`,
   and `re-frame.story.loaders` — lives here.
@@ -79,7 +78,7 @@
   ([variant-id opts]  (runtime/reset-variant variant-id opts)))
 
 (defn run-inline-plan
-  "Per spec/017 §Inline plan (rf2-5x1wt.20) — run an inline plan MAP and
+  "Per spec/017 §Inline plan — run an inline plan MAP and
   return a promise/future of the unified run-result (the SAME shape a
   registered-variant run returns). The plan is compiled, run against a
   fresh anonymous frame, and the frame is torn down on resolve; it is

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -29,7 +29,7 @@
   tracking. The machine is registered at Story-boot under the id
   `:rf.story.lifecycle/machine`. Each variant frame holds its own
   snapshot at `[:rf.runtime/machines :snapshots :rf.story.lifecycle/machine]`
-  in the runtime-db partition (EP-0001 rf2-vzld77 — machine snapshots are
+  in the runtime-db partition (EP-0001 — machine snapshots are
   durable framework state) and mirrors the discrete state at
   `[:rf.story/lifecycle]` (in app-db) for direct read access.
 
@@ -67,7 +67,7 @@
   "Stable id for Story's lifecycle machine. One registration; per-
   variant snapshots live at
   `[:rf.runtime/machines :snapshots :rf.story.lifecycle/machine]` inside each
-  variant frame's runtime-db partition (EP-0001 rf2-vzld77)."
+  variant frame's runtime-db partition (EP-0001)."
   :rf.story.lifecycle/machine)
 
 (def state-mirror-path
@@ -79,11 +79,11 @@
 ;; ---- transition vocabulary -----------------------------------------------
 
 (def event-mount             :rf.story.lifecycle/mount)
-;; rf2-043cm — events-only variant fast-path. A variant with NO loaders,
+;; Events-only variant fast-path. A variant with NO loaders,
 ;; NO frame-setup decorators, and NO `:loaders-complete-when` predicate
 ;; has nothing to wait for between mount and render; the runtime drives
 ;; the lifecycle from `:pre-mount` straight to `:ready` via this event
-;; so the canvas's loading skeleton (rf2-0s4p1) never engages. The
+;; so the canvas's loading skeleton never engages. The
 ;; classical four-phase path (`mount → loaders-started → loaders-complete`)
 ;; stays in place for variants that legitimately have loader work.
 (def event-mount-ready       :rf.story.lifecycle/mount-ready)
@@ -101,7 +101,7 @@
 
 (def ^:private pre-mount-node
   "Initial state. Accepts :mount (→ :mounting), :mount-ready (→ :ready,
-  the rf2-043cm events-only fast-path) and :errored (→ :error)."
+  the events-only fast-path) and :errored (→ :error)."
   {:on {event-mount             :mounting
         event-mount-ready       :ready
         event-errored           :error}})
@@ -138,7 +138,7 @@
 
   Transitions:
     :pre-mount  --mount-->            :mounting
-    :pre-mount  --mount-ready-->      :ready        (rf2-043cm fast-path)
+    :pre-mount  --mount-ready-->      :ready        (events-only fast-path)
     :pre-mount  --errored-->          :error
     :mounting   --loaders-started-->  :loading
     :mounting   --errored-->          :error
@@ -191,7 +191,7 @@
   partition. Returns `{:state <state-kw> :data {...}}` or nil if the
   machine hasn't fired yet on this frame.
 
-  EP-0001 (rf2-vzld77): machine snapshots are durable framework state and
+  EP-0001: machine snapshots are durable framework state and
   live in the `:rf.db/runtime` partition at
   `[:rf.runtime/machines :snapshots <machine-id>]`, NOT in app-db.
   `rf/runtime-db-value` returns the value-form runtime-db map (per Spec 002
@@ -303,7 +303,7 @@
   (dispatch-lifecycle-event! frame-id (into [event-id] args)))
 
 (defn mount!          [frame-id]     (transition! frame-id event-mount))
-;; rf2-043cm — events-only variant fast-path. Drives :pre-mount → :ready
+;; Events-only variant fast-path. Drives :pre-mount → :ready
 ;; in a single transition for variants whose body declares no `:loaders`,
 ;; no `:frame-setup` decorators, and no `:loaders-complete-when`
 ;; predicate. The runtime (`frames/allocate!`) selects this path via
@@ -315,10 +315,10 @@
 (defn finish-events!  [frame-id]     (transition! frame-id event-events-complete))
 (defn error!          [frame-id err] (transition! frame-id event-errored err))
 
-;; ---- events-only classifier (rf2-043cm) ----------------------------------
+;; ---- events-only classifier ----------------------------------------------
 
 (defn events-only-variant?
-  "Per rf2-043cm — is the variant 'events-only'? A variant is events-
+  "Is the variant 'events-only'? A variant is events-
   only when:
 
   - its body declares no `:loaders` AND no `:loaders-complete-when`,
@@ -334,11 +334,10 @@
 
   Events-only variants take the lifecycle fast-path: `:pre-mount →
   :ready` on mount with no intervening `:mounting`/`:loading` states.
-  This keeps the rf2-0s4p1 loading skeleton off for variants that have
-  nothing to wait for — the regression PR #1574 surfaced via the
-  retired `xray-rhs-smoke` testbed; the events-only loader-body shape
-  is now pinned by `:story.counter/events-only-loaded` inside
-  `tools/story/testbeds/counter_with_stories/` (rf2-9jfo1.2).
+  This keeps the loading skeleton off for variants that have
+  nothing to wait for. The events-only loader-body shape is pinned by
+  `:story.counter/events-only-loaded` inside
+  `tools/story/testbeds/counter_with_stories/`.
 
   Returns a boolean. Pure — no app-db reads."
   [variant-body decorator-stack]
@@ -365,7 +364,7 @@
 (defn- predicate-event?
   "Per `002-Runtime.md` §Four-phase lifecycle with `:loaders-complete-when` — a registered predicate-event handler is a plain
   re-frame event whose `:db` effect returns a value-form map containing
-  `[:rf.story/loaders-complete? <bool>]`. Stage 5 (rf2-h8et) accepts
+  `[:rf.story/loaders-complete? <bool>]`. The runtime accepts
   this shape by dispatching the event then reading the slot from the
   frame's app-db.
 
@@ -384,8 +383,7 @@
 (defn- dispatched-events-set
   "Read the dispatched-events set for `frame-id` from the epoch tape (the
   SSOT — `assertions/dispatched-events` projects each committed epoch's
-  `:trigger-event`). rf2-q651r migrated this off the retired
-  `trace-accumulators` parallel path onto the SAME tape projection the
+  `:trigger-event`). This reads the SAME tape projection the
   run-result evidence + `:rf.assert/dispatched?` read."
   [frame-id]
   (try
@@ -396,7 +394,7 @@
   "Per `002-Runtime.md` §Four-phase lifecycle with `:loaders-complete-when` — a vector of event vectors form is interpreted
   as 'loaders complete when ALL listed events have fired against the
   variant's frame'. We consult the epoch-tape dispatched-events projection
-  (`dispatched-events-set`, the SSOT since rf2-q651r)."
+  (`dispatched-events-set`, the SSOT)."
   [frame-id events-required]
   (let [observed (or (dispatched-events-set frame-id) #{})]
     (every? (fn [needle] (contains? observed needle)) events-required)))
@@ -418,9 +416,7 @@
     Interpreted as 'loaders complete when ALL listed events have fired
     against the variant's frame.' The runtime checks the epoch-tape
     dispatched-events projection (`assertions/dispatched-events`, the
-    SSOT since rf2-q651r — the SAME tape the run-result evidence reads).
-
-  Stage 5 (rf2-h8et)."
+    SSOT — the SAME tape the run-result evidence reads)."
   [frame-id variant-body]
   (let [pred (:loaders-complete-when variant-body)]
     (cond

--- a/tools/story/src/re_frame/story/macros.clj
+++ b/tools/story/src/re_frame/story/macros.clj
@@ -25,7 +25,7 @@
   `(story/handler-meta kind id)`.
 
   `:file` resolution prefers `(:file (meta &form))` over `*file*` —
-  see `coords-form` for the rationale (rf2-ulxi). The short version:
+  see `coords-form` for the rationale. The short version:
   the CLJS analyzer never binds Clojure's `*file*` during macro
   expansion, so reading it returns `\"NO_SOURCE_PATH\"`; the reader-
   attached `:file` on the form's metadata is the portable answer.
@@ -51,7 +51,7 @@
   evaluates to the map at runtime. Mirrors
   `re-frame.core/reg-event`'s coord-capture pattern.
 
-  ## :file resolution (rf2-ulxi)
+  ## :file resolution
 
   `:file` comes from `(:file form-meta)` first — the CLJS analyzer reads
   source files via `tools.reader/indexing-push-back-reader` with the
@@ -113,8 +113,7 @@
   (<reg-fn> id body)))` wrapper. `coords` is a pre-computed coords FORM
   (per `coords-form`); `reg-fn-sym` is a fully-qualified registrar helper
   like `re-frame.story.registrar/reg-story*`. The single place the
-  elision-gate + source-coord binding shape is laid down (rf2-ee38b.3 —
-  was open-coded in three sites)."
+  elision-gate + source-coord binding shape is laid down."
   [coords reg-fn-sym id body]
   `(when re-frame.story.config/enabled?
      (binding [re-frame.story.registrar/*pending-coords* ~coords]

--- a/tools/story/src/re_frame/story/malli_schema.cljc
+++ b/tools/story/src/re_frame/story/malli_schema.cljc
@@ -4,14 +4,12 @@
   CLJS-only) and the schema-validation panel's args-violation walk
   (`re-frame.story.ui.schema-validation`, `.cljc`).
 
-  Used to live as private mirrors in both consumer namespaces — the
-  schema-validation copy carried a comment acknowledging the dup. The
-  shape is canonical Malli vector-schema decoding: optional properties
-  map at index 1, then ordered child schemas. Lives at the leaf of the
-  require graph (depends on `clojure.core` only) so any sibling
-  namespace can `:require` it without cycle risk.
-
-  See rf2-x77hd / audit rf2-cgqam round-2 P1 #2.")
+  This is the single shared home for the introspection helpers both
+  consumers use, so the two panels decode schemas through one
+  implementation. The shape is canonical Malli vector-schema decoding:
+  optional properties map at index 1, then ordered child schemas. Lives
+  at the leaf of the require graph (depends on `clojure.core` only) so
+  any sibling namespace can `:require` it without cycle risk.")
 
 (defn properties?
   "Is `x` the optional Malli properties map at index 1 of a vector
@@ -68,16 +66,16 @@
 ;; consumers agree on the slots WITHOUT a require cycle (view-args requires
 ;; plan; plan must not require view-args).
 ;;
-;; Per the rf2-p5ivc (b) ruling: first match wins over `[:rf/props :schema]`;
-;; `:rf/props` is canonical and wins over `:schema` (no composition). `:spec`
-;; is NOT here — it is dead post-M-54 (the framework reads `:schema` only on
-;; `reg-*` metadata; see migration/from-re-frame-v1/README.md §M-54).
+;; First match wins over `[:rf/props :schema]`: `:rf/props` is canonical
+;; and wins over `:schema` (no composition). `:spec` is NOT a key here —
+;; the framework reads `:schema` only on `reg-*` metadata; see
+;; migration/from-re-frame-v1/README.md §M-54.
 
 (def view-args-schema-keys
   "View-metadata keys carrying the explicit-input (props) schema, in
   resolution order (first present wins): `:rf/props` (canonical) then
-  `:schema` (the post-M-54 alternative location). `:spec` is deliberately
-  ABSENT — it is dead post-M-54 (no framework reads it)."
+  `:schema` (the alternative location). `:spec` is deliberately
+  ABSENT — no framework reads it."
   [:rf/props :schema])
 
 (defn view-args-schema

--- a/tools/story/src/re_frame/story/modes/standard.cljc
+++ b/tools/story/src/re_frame/story/modes/standard.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.story.modes.standard
   "Canonical `reg-mode` registrations for the Storybook-parity addons —
   viewports + backgrounds. Per spec/010 §Interaction with Storybook
-  addons (rf2-wk41 follow-on to the toolbar substrate rf2-p0mv).
+  addons.
 
   Storybook 8 ships dedicated Backgrounds + Viewport addons as part of
   its default install. Story's equivalent is **opt-in registrations**:

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -12,7 +12,7 @@
   placeholders, computing the required-runner capability set, and
   producing `explain` data during compilation.
 
-  ## What this layer DOES (rf2-5x1wt.10)
+  ## What this layer DOES
 
   - Read a registered variant body (or accept an inline map).
   - Resolve the `:extends` parent chain root-to-child, bounded with cycle
@@ -27,11 +27,11 @@
   - Preserve platforms / tags / workshop context under `:world`.
   - Compute the `:required-runner` capability set from the script steps
     and the declared assertions, through the capability-token registry in
-    `re-frame.story.requirements` (rf2-5x1wt.16 — the single home for the
+    `re-frame.story.requirements` (the single home for the
     per-step / per-assertion requirement maps).
   - Attach `:source-chain` and an `:explain` map.
 
-  ## View arg schemas (rf2-5x1wt.12)
+  ## View arg schemas
 
   When a variant's `:component` resolves to a registered view that
   carries a props schema on its view metadata, the compiler copies that
@@ -49,7 +49,7 @@
   subscriptions / `:sub-overrides` (§View-state subscription overrides);
   the two MUST NOT be conflated.
 
-  ## View-state subscription overrides (rf2-5x1wt.13)
+  ## View-state subscription overrides
 
   A variant whose goal is rendering / design exploration MAY author
   `:sub-overrides` — a map of exact subscription query vectors to data
@@ -70,7 +70,7 @@
   lower-fidelity rung of the fidelity ladder; the `:fidelity` set labels
   it so a reviewer can tell at a glance which evidence a variant rests on.
 
-  ## Network world slot (rf2-5x1wt.14)
+  ## Network world slot
 
   When a variant authors `:network` (a `{[method url] {:reply …}}` route
   map), the compiler keeps the per-route reply data at `[:world :network]`
@@ -85,7 +85,7 @@
   conflict (`:rf.error/story-network-fx-conflict`) — `:network` is the
   dedicated affordance for that fx. See §Network world slot below.
 
-  ## Strict `:compose` composition (rf2-5x1wt.15) + capability inference (rf2-5x1wt.16)
+  ## Strict `:compose` composition + capability inference
 
   Strict `:compose` fragment/check composition AND its conflict resolution
   land HERE (§`:compose` / §Merge rules / §Conflict resolution): see the
@@ -93,9 +93,9 @@
   variant-owned-wins, the flat-fragment guard
   (`:rf.error/story-compose-nested-fragment`), and the silent-conflict
   failure (`:rf.error/story-compose-conflict`). The capability-token
-  registry is no longer scaffolded inline either: the `:required-runner`
-  slot is filled through `re-frame.story.requirements` (the single home for
-  the per-step / per-assertion requirement maps).
+  registry lives in `re-frame.story.requirements`: the `:required-runner`
+  slot is filled through it (the single home for the per-step /
+  per-assertion requirement maps).
 
   ## What this layer DEFERS
 
@@ -103,10 +103,9 @@
   This layer keeps the per-route `:network` reply map at `[:world :network]`
   and lowers it to the managed-stub fx-override the runner installs. The
   run-artifact wiring that threads `[:world :network]` onto the artifact's
-  `:network` slot so replay RE-INSTALLS the route stubs landed in
-  `re-frame.story.determinism/->artifact` + `re-frame.story.artifact`
-  (rf2-tymyh, on top of the run-artifact ns rf2-5x1wt.7) — without
-  reshaping the plan, exactly as this layer anticipated.
+  `:network` slot so replay RE-INSTALLS the route stubs lives in
+  `re-frame.story.determinism/->artifact` + `re-frame.story.artifact` —
+  without reshaping the plan, exactly as this layer anticipates.
 
   ## Purity / elision
 
@@ -202,10 +201,9 @@
 ;; Field merge (foundation: context-flows-down / verdict-is-local)
 ;; ============================================================================
 ;;
-;; rf2-5x1wt.10 implements the *parent-chain* slice of §Merge rules — the
-;; foundation that .11/.12 build the strict `:compose` conflict machinery
-;; on. The principle from §`:extends`: context flows down, verdict is
-;; local.
+;; The *parent-chain* slice of §Merge rules — the foundation the strict
+;; `:compose` conflict machinery builds on. The principle from §`:extends`:
+;; context flows down, verdict is local.
 ;;
 ;;   - inherited through :extends — world context (setup, args, frame,
 ;;     platforms, tags, workshop slots) AND checks (the inheritable
@@ -271,7 +269,7 @@
 (defn- reject-malformed-steps!
   "FAIL plan construction when any COERCED (but not-yet-folded) script step
   is structurally malformed — an unknown step tag or a tag with the wrong
-  arity/shape (rf2-zha5z, spec/017 §Script step grammar). Reuses the
+  arity/shape (spec/017 §Script step grammar). Reuses the
   runner's `validate-script` (`runner/step-arity-ok?` + `known-step?`) — the
   ONE encoding of the per-tag shape constraints — so the plan compiler and
   the runtime runner agree on what a well-formed step is.
@@ -305,12 +303,12 @@
   runner's canonical coercion. The primary `:script` is the first play.
 
   Each play's coerced script is first SHAPE-VALIDATED
-  (`reject-malformed-steps!`, rf2-zha5z) so a malformed `:assert-db` /
-  `:assert-dom` (or any step) FAILS with a structured `:rf.error/story-bad-
-  step` BEFORE the fold — the fold helpers assume well-formed input.
+  (`reject-malformed-steps!`) so a malformed `:assert-db` / `:assert-dom`
+  (or any step) FAILS with a structured `:rf.error/story-bad-step` BEFORE
+  the fold — the fold helpers assume well-formed input.
 
-  After validation every play's script is FOLDED (`assertions/fold-script`,
-  rf2-5x1wt.18): a shipping `:assert-db` / `:assert-dom` step rewrites to
+  After validation every play's script is FOLDED (`assertions/fold-script`):
+  a shipping `:assert-db` / `:assert-dom` step rewrites to
   the canonical `[:assert assertion-atom]` checkpoint, so EVERY in-script
   assertion — whatever sugar the author typed — resolves to the ONE
   assertion atom shape (spec/017 §Assertions — one atom, two positions).
@@ -333,8 +331,8 @@
      :scripts plays}))
 
 (defn- assert-step?
-  "True iff `step` is an `[:assert assertion-vector]` in-script checkpoint
-  (rf2-5x1wt.17). Per spec/017 §Script step grammar the `[:assert …]`
+  "True iff `step` is an `[:assert assertion-vector]` in-script checkpoint.
+  Per spec/017 §Script step grammar the `[:assert …]`
   step is legal in `:script` but ILLEGAL in `:setup` — setup establishes
   preconditions, it does not judge."
   [step]
@@ -344,8 +342,8 @@
 
 (defn- reject-assert-in-setup!
   "FAIL plan construction when any resolved `:setup` step is an
-  `[:assert …]` checkpoint (rf2-5x1wt.17, spec/017 §Script step grammar +
-  §Setup). `:assert` is the mid-script verdict atom; placing one in
+  `[:assert …]` checkpoint (spec/017 §Script step grammar + §Setup).
+  `:assert` is the mid-script verdict atom; placing one in
   `:setup` confuses precondition with judgement. The variant resolves it
   by moving the assertion to `:script` (as an `[:assert …]` checkpoint)
   or to the terminal `:assertions` slot. The reject runs at plan-compile
@@ -364,12 +362,12 @@
            {:variant/id id :offending-steps (vec offenders)})))
 
 ;; ============================================================================
-;; Assertion-id validation (rf2-5x1wt.18)
+;; Assertion-id validation
 ;; ============================================================================
 
 (defn- script-assertion-atoms
   "Collect the assertion atoms an `[:assert assertion-atom]` checkpoint
-  carries from a folded `script` (rf2-5x1wt.18). The shipping
+  carries from a folded `script`. The shipping
   `:assert-db` / `:assert-dom` steps are already folded to `[:assert …]`
   by `normalize-scripts`, so this single walk covers every in-script
   assertion position uniformly. Pure data → data."
@@ -380,7 +378,7 @@
   "FAIL plan construction when any authored assertion atom — terminal
   `:assertions` OR an in-script `[:assert …]` checkpoint — names an id
   that is not in the recognised P1 vocabulary
-  (`assertions/known-assertion-ids`, rf2-5x1wt.18, spec/017 §Assertions).
+  (`assertions/known-assertion-ids`, spec/017 §Assertions).
   Catching it at compile time surfaces the typo before any run, the same
   way the other `:rf.error/story-*` plan errors do — never letting an
   unknown id record a vacuous `:rf.assert/unknown` pseudo-record at run
@@ -481,7 +479,7 @@
 ;;
 ;; The capability-token registry + cost-ordered concrete runners + the
 ;; per-step / per-assertion requirement maps live in
-;; `re-frame.story.requirements` (rf2-5x1wt.16) — the single home so the
+;; `re-frame.story.requirements` — the single home so the
 ;; runner-selection, `:cannot-run` refusal, and post-run evidence-slot
 ;; validation all read ONE source of truth. The plan compiler computes the
 ;; `:required-runner` slot through that registry. Per §Runner requirements
@@ -498,7 +496,7 @@
   (requirements/plan-required-runner setup script assertions))
 
 ;; ============================================================================
-;; View arg schemas (rf2-5x1wt.12)
+;; View arg schemas
 ;; ============================================================================
 ;;
 ;; Per spec §View arg schemas: a registered view MAY expose a schema for
@@ -512,13 +510,13 @@
 ;; `:rf/args` for macro-captured argument *symbols* (introspection, NOT a
 ;; validation schema — so it is never consumed here). The first-match key
 ;; order — `:rf/props` (canonical, `spec/Spec-Schemas.md`
-;; §`:rf/registration-metadata`) then `:schema` (the post-M-54 `reg-*`
+;; §`:rf/registration-metadata`) then `:schema` (the alternative `reg-*`
 ;; metadata key) — is the canonical resolution shared with every Story
 ;; consumer through `re-frame.story.malli-schema/view-args-schema`. `:rf/props`
 ;; wins over `:schema`; there is NO composition (a view's only schema
-;; surface is its props — the rf2-p5ivc (b) ruling). `:spec` is NOT a slot:
-;; it is dead post-M-54 (the framework reads `:schema` only on `reg-*`
-;; metadata — see migration/from-re-frame-v1/README.md §M-54).
+;; surface is its props). `:spec` is NOT a slot: the framework reads
+;; `:schema` only on `reg-*` metadata (see
+;; migration/from-re-frame-v1/README.md §M-54).
 ;;
 ;; **Boundary.** This validates EXPLICIT view inputs only. Values
 ;; returned from subscriptions are validated by subscription-output
@@ -630,7 +628,7 @@
        {:status :ok :schema schema :missing [] :malformed []}))))
 
 ;; ============================================================================
-;; View-state subscription overrides (rf2-5x1wt.13)
+;; View-state subscription overrides
 ;; ============================================================================
 ;;
 ;; Per spec §View-state subscription overrides. `:sub-overrides` is a map
@@ -724,7 +722,7 @@
          :violations violations}))))
 
 ;; ============================================================================
-;; Fidelity ladder (rf2-5x1wt.13)
+;; Fidelity ladder
 ;; ============================================================================
 ;;
 ;; Per spec §View-state subscription overrides — the fidelity ladder is:
@@ -737,10 +735,9 @@
 ;;   :real-setup    — the variant has setup events (or a script) that
 ;;                    drive real state into the frame;
 ;;   :db-seed       — a schema-checked direct app-db seed (the world
-;;                    `:db-seed` slot; rf2-blw1q — wired end-to-end: the
-;;                    compiler lowers it to `[:world :db-seed]` and the
-;;                    runtime seeds + schema-validates the frame's app-db
-;;                    BEFORE the script);
+;;                    `:db-seed` slot, wired end-to-end: the compiler lowers
+;;                    it to `[:world :db-seed]` and the runtime seeds +
+;;                    schema-validates the frame's app-db BEFORE the script);
 ;;   :sub-overrides — one or more view-state subscription overrides.
 
 (defn compute-fidelity
@@ -752,7 +749,7 @@
                      events drive the frame's state;
   - `:db-seed`       when `db-seed` resolves any entry (a schema-checked
                      direct app-db seed merged into the frame BEFORE the
-                     script — rf2-blw1q);
+                     script);
   - `:sub-overrides` when `sub-overrides` resolves any entry.
 
   A plain events-driven variant yields `#{:real-setup}`; a pure design
@@ -769,7 +766,7 @@
     (seq sub-overrides)           (conj :sub-overrides)))
 
 ;; ============================================================================
-;; Network world slot (rf2-5x1wt.14)
+;; Network world slot
 ;; ============================================================================
 ;;
 ;; Per spec §The network surface + §Network stubs: managed HTTP stubbing is
@@ -782,7 +779,7 @@
 ;; The compiler keeps the per-route reply data at `[:world :network]` (the
 ;; source of truth that feeds `:plan-hash` via `plan-hash-input-keys`'s
 ;; `:world` slot, `explain`, and — threaded onto the artifact's `:network`
-;; slot by `re-frame.story.determinism/->artifact`, rf2-tymyh — the run
+;; slot by `re-frame.story.determinism/->artifact` — the run
 ;; artifact) AND **lowers** it to the existing managed-request stub
 ;; machinery: the variant frame overrides `:rf.http/managed` with the stub
 ;; fx that `re-frame.http.test-support/install-managed-request-stubs!`
@@ -807,7 +804,7 @@
   `stub-fx-id` constant (Spec 014 §Testing); naming it here lets the plan
   declare the lowering without depending on the http artefact at compile
   time (the actual `install-…!` call is a RUNTIME concern, run when the
-  variant frame is created — see the runtime-migration bead)."
+  variant frame is created)."
   :rf.http/managed-test-stub)
 
 (defn lower-network
@@ -854,7 +851,7 @@
             :fx-overrides author-fx-overrides})))
 
 ;; ============================================================================
-;; Strict composition — `:compose` fragments + checks (rf2-5x1wt.15)
+;; Strict composition — `:compose` fragments + checks
 ;; ============================================================================
 ;;
 ;; Per spec/017 §`:compose` / §Total resolution order / §Merge rules /
@@ -1052,14 +1049,14 @@
   "Default subscription-metadata lookup — reads the **framework** `:sub`
   registrar slot (where `reg-sub` stamps a sub's metadata, incl. any
   `:schema` output-schema slot). Resolves the OUTPUT-schema source for
-  `:sub-overrides` value validation (rf2-5x1wt.13). Production bundles
+  `:sub-overrides` value validation. Production bundles
   that elide subs return nil; pure tests thread an explicit `:sub-lookup`."
   [sub-id]
   (framework-registrar/handler-meta :sub sub-id))
 
 (defn- default-fragment-lookup
   "Default fragment-body lookup — reads the Story side-table `:fragment`
-  kind (rf2-5x1wt.15). Production bundles elide the side-table; pure tests
+  kind. Production bundles elide the side-table; pure tests
   thread an explicit `:fragment-lookup`."
   [fragment-id]
   (registrar/handler-meta :fragment fragment-id))
@@ -1071,7 +1068,7 @@
 
 (defn- default-global-decorators
   "Default global-decorators ref vector — reads the project-wide
-  `config/get-global-decorators` (rf2-835ey — Storybook `preview.ts`
+  `config/get-global-decorators` (Storybook `preview.ts`
   `decorators: [...]` parity, the outermost wrap layer). Production
   bundles with Story elided register no globals, so the vector is empty
   there; pure tests thread an explicit `:global-decorators`."
@@ -1091,7 +1088,7 @@
 (defn expand-checks
   "Expand a plan's `:expect :checks` ids into the
   `{check-id [assertion-atom …]}` map the unified run-result groups its
-  check records by (rf2-5x1wt.19, spec/017 §Total resolution order step 8
+  check records by (spec/017 §Total resolution order step 8
   — \"expand checks into grouped assertions\"; §Checks — a failed check
   shows BOTH the check id AND the underlying records). Pure data → data.
 
@@ -1128,21 +1125,20 @@
     schemas). With no validator only required-key presence is checked
     (the host-free floor).
   - `:fragment-lookup` / `:check-lookup` — a 1-arg fn `(id) → body` OR a
-    `{id → body}` map resolving the bodies named in `:compose`
-    (rf2-5x1wt.15). Default to the Story side-table `:fragment` / `:check`
-    kinds.
+    `{id → body}` map resolving the bodies named in `:compose`.
+    Default to the Story side-table `:fragment` / `:check` kinds.
   - `:sub-lookup` — a 1-arg fn `(sub-id) → sub-meta` OR a `{sub-id →
     sub-meta}` map resolving a subscription's registration metadata (for
-    its OUTPUT schema, against which `:sub-overrides` values are validated
-    — rf2-5x1wt.13). Defaults to the framework `:sub` registrar.
+    its OUTPUT schema, against which `:sub-overrides` values are
+    validated). Defaults to the framework `:sub` registrar.
   - `:global-decorators` — the project-wide global-decorators ref vector
     (or a 0-arg fn returning one) prepended to `[:world :decorators]` as
-    the outermost wrap layer (rf2-5fibj / rf2-835ey). Defaults to
+    the outermost wrap layer). Defaults to
     `config/get-global-decorators`; pure tests pass an explicit vector.
   - `:story-decorators` — a 1-arg fn `(story-id) → decorators-vec` OR a
     `{story-id → decorators-vec}` map resolving the parent story's
-    `:decorators` slot (folded between globals and the variant chain —
-    rf2-5fibj). Defaults to the Story side-table `:story` kind."
+    `:decorators` slot (folded between globals and the variant chain).
+    Defaults to the Story side-table `:story` kind."
   ([id body lookup] (compile-body id body lookup nil))
   ([id body lookup {:keys [view-lookup validator-fns sub-lookup
                            fragment-lookup check-lookup
@@ -1154,12 +1150,12 @@
                                          default-fragment-lookup)
         chk-lookup   (coerce-kind-lookup :check-lookup check-lookup
                                          default-check-lookup)
-        ;; ---- ambient decorator layers (rf2-5fibj) ----
+        ;; ---- ambient decorator layers ----
         ;; The full decorator stack folded into `[:world :decorators]` is
         ;; `(concat globals story variant-chain)` — the SAME set
-        ;; `decorators/collect-decorator-refs` used to assemble at resolve
-        ;; time. Folding it HERE makes the compiled plan the single source
-        ;; of truth (rf2-din8u): the canvas (via `resolve-decorators`) and
+        ;; `decorators/collect-decorator-refs` assembles at resolve time.
+        ;; Folding it HERE makes the compiled plan the single source of
+        ;; truth: the canvas (via `resolve-decorators`) and
         ;; `render-variant` (via `render-inputs`' `:decorators`) both read
         ;; `[:world :decorators]`, so they paint the IDENTICAL decorator
         ;; tree. Globals + story decorators are AMBIENT (not part of the
@@ -1176,7 +1172,7 @@
         bodies       (map :body chain)         ; root-first
         inherited    (vec (butlast bodies))    ; root → immediate parent
         child        (:body (last chain))
-        ;; ---- :compose resolution (rf2-5x1wt.15, §Total resolution order
+        ;; ---- :compose resolution (§Total resolution order
         ;; step 3 — applied BETWEEN the parent merge and the variant-owned
         ;; values). `:compose` is a child-only directive (like `:extends`);
         ;; it is not inherited. Each entry resolves to a fragment OR a
@@ -1222,12 +1218,12 @@
         ;; setup APPENDS: inherited (root→parent), THEN composed fragments
         ;; (declared order), THEN the variant's own setup — variant-owned
         ;; values land last (§Merge rules + §Total resolution order). Each
-        ;; layer's setup is coerced through the runner's `coerce-script`
-        ;; (rf2-5x1wt.17): a bare event-vector shorthand normalizes to
-        ;; `[:dispatch event-vector]` during migration, so the stored
-        ;; `[:world :setup]` carries tagged steps uniformly (the same
-        ;; coercion `:script` gets) — bare vectors are the migration
-        ;; shorthand, never the P1 public form.
+        ;; layer's setup is coerced through the runner's `coerce-script`:
+        ;; a bare event-vector shorthand normalizes to
+        ;; `[:dispatch event-vector]`, so the stored `[:world :setup]`
+        ;; carries tagged steps uniformly (the same coercion `:script`
+        ;; gets) — bare vectors are an authoring shorthand, never the P1
+        ;; public form.
         setup-raw    (vec (concat
                             (mapcat (fn [l] (runner/coerce-script (pick-setup l))) inherited)
                             (mapcat (fn [l] (runner/coerce-script (pick-setup l))) frag-layers)
@@ -1253,10 +1249,10 @@
         ;; order variant layer). This is the ONLY arg layer the plan body
         ;; carries; the ambient (global / story) + per-run (active-modes /
         ;; cell-overrides) layers live OUTSIDE the body and arrive via the
-        ;; `:run-args` opt (rf2-2cpoo).
+        ;; `:run-args` opt.
         variant-arg-map (merge-key :args)
-        ;; rf2-2cpoo — fold the ambient + per-run layers AROUND the variant
-        ;; layer so the effective `arg-map` (and therefore every `[:arg key]`
+        ;; Fold the ambient + per-run layers AROUND the variant layer so
+        ;; the effective `arg-map` (and therefore every `[:arg key]`
         ;; substitution below, `[:world :args]` / `[:world :effective-args]`,
         ;; and the plan hash) matches `args/resolve-args` for the SAME
         ;; `:active-modes` / `:cell-overrides`. `:run-args` is the
@@ -1264,7 +1260,7 @@
         ;; `re-frame.story.args/run-arg-layers` produces: `:pre` is lower
         ;; precedence than the variant layer, `:post` higher. Absent (a pure
         ;; plan-compile / explain / render-prep with no run opts) ⇒ the
-        ;; variant layer alone, exactly as before.
+        ;; variant layer alone.
         arg-map      (if run-args
                        (args/deep-merge-all
                          (concat (:pre run-args)
@@ -1275,25 +1271,25 @@
         ;; ---- arg substitution ----
         subs!        (atom [])
         setup        (substitute-args setup-raw arg-map subs!)
-        ;; rf2-5x1wt.17 — an `[:assert …]` checkpoint is ILLEGAL in :setup
+        ;; An `[:assert …]` checkpoint is ILLEGAL in :setup
         ;; (spec/017 §Script step grammar). Reject at plan-compile time,
         ;; on the fully-resolved setup (inherited ⧺ composed ⧺ own), so a
         ;; misplaced verdict surfaces before any run.
         _            (reject-assert-in-setup! id setup)
         script*      (substitute-args script arg-map subs!)
-        ;; rf2-2cpoo — the RUNTIME executes `[:world :scripts]` (the named
-        ;; plays from `normalize-scripts`), NOT the top-level `:script` slot.
+        ;; The RUNTIME executes `[:world :scripts]` (the named plays from
+        ;; `normalize-scripts`), NOT the top-level `:script` slot.
         ;; `normalize-scripts` ran on the RAW body, so each play's `:script`
         ;; still carries unresolved `[:arg key]` placeholders. Substitute them
         ;; against the SAME `arg-map` the top-level `:script` resolved against
-        ;; (which now folds the run-opts layers), so the executed plays use the
-        ;; effective args the result reports — not the raw placeholder. (Before
-        ;; this, `[:world :scripts]` was never `[:arg]`-substituted at all, so a
-        ;; `[:arg …]` in a script reached the dispatched event verbatim.)
+        ;; (which folds the run-opts layers), so the executed plays use the
+        ;; effective args the result reports — not the raw placeholder. Without
+        ;; this, an `[:arg …]` in a play script would reach the dispatched
+        ;; event verbatim.
         scripts*     (mapv (fn [p]
                              (update p :script substitute-args arg-map subs!))
                            scripts)
-        ;; rf2-5x1wt.18 — every authored assertion atom (terminal
+        ;; Every authored assertion atom (terminal
         ;; `:assertions` AND an in-script `[:assert …]` checkpoint, incl.
         ;; the folded `:assert-db` / `:assert-dom` steps) MUST name a
         ;; recognised :rf.assert/* id. An unknown id FAILS plan
@@ -1302,7 +1298,7 @@
         ;; the `[:assert …]` checkpoints covers every in-script position.
         _            (reject-unknown-assertions!
                        id (script-assertion-atoms script*) assertions)
-        ;; ---- view-state subscription overrides (rf2-5x1wt.13) ----
+        ;; ---- view-state subscription overrides ----
         ;; `:sub-overrides` composes like `:network`: composed-fragment
         ;; override maps merge in declared order (a later fragment wins a
         ;; query key), THEN the variant chain (`ctx`, where `:extends`
@@ -1314,14 +1310,14 @@
         frag-sub-ovr (reduce (fn [m l] (merge m (:sub-overrides l))) {} frag-layers)
         ;; The RAW merged overrides BEFORE `[:arg key]` substitution — kept
         ;; on the plan (`[:world :render :sub-overrides-raw]`) so the render
-        ;; path (rf2-5x1wt.24 `render-variant`) can RE-resolve the
+        ;; path (`render-variant`) can RE-resolve the
         ;; placeholders against the POST-control effective args (a control
         ;; that drives an override value, e.g. `{[:login/error] [:arg
         ;; :message]}`, must reflect the live control). The plan-time
         ;; resolved overrides below feed validation + the run path.
         sub-overrides-raw (merge frag-sub-ovr (:sub-overrides ctx))
         sub-overrides (substitute-args sub-overrides-raw arg-map subs!)
-        ;; ---- :db-seed world slot (rf2-blw1q) ----
+        ;; ---- :db-seed world slot ----
         ;; The MIDDLE fidelity rung: a direct app-db state seed
         ;; (`{path → value}`). Composes through the parent chain (ctx,
         ;; deep-merged via `merge-context` through `:extends`) + composed
@@ -1334,7 +1330,7 @@
         ;; `:rf.error/story-db-seed-invalid`.
         frag-db-seed (reduce (fn [m l] (merge m (:db-seed l))) {} frag-layers)
         db-seed      (substitute-args (merge frag-db-seed (:db-seed ctx)) arg-map subs!)
-        ;; ---- strict-conflict composition (rf2-5x1wt.15) ----
+        ;; ---- strict-conflict composition ----
         ;; The strict-conflict override MAPS (`:fx-overrides` /
         ;; `:interceptor-overrides`) compose per-KEY: the variant chain
         ;; OWNS any key it set (variant-owned-wins), composed fragments
@@ -1369,7 +1365,7 @@
         composed-ic  (get-in strict-res [:interceptor-overrides :merged])
         ctx-fx       (merge composed-fx (:fx-overrides ctx))
         ctx-ic       (merge composed-ic (:interceptor-overrides ctx))
-        ;; ---- network world slot (rf2-5x1wt.14) ----
+        ;; ---- network world slot ----
         ;; Per-route replies may carry `[:arg key]` placeholders (e.g. a
         ;; stubbed id driven by a control), so substitute before lowering.
         ;; `:network` composes through the parent chain (ctx) + composed
@@ -1388,7 +1384,7 @@
         fx-overrides (merge (when network-low (:fx-overrides network-low))
                             ctx-fx)
         interceptor-overrides ctx-ic
-        ;; ---- view arg schema + effective-args validation (rf2-5x1wt.12) ----
+        ;; ---- view arg schema + effective-args validation ----
         ;; `:effective-args` at plan time IS the resolved arg-map; the
         ;; render path layers control-panel overrides on top later. We
         ;; copy the view's explicit-input schema into the plan, validate
@@ -1415,7 +1411,7 @@
                                :missing         (:missing validation)
                                :malformed       (:malformed validation)
                                :effective-args  eff-args}))
-        ;; ---- :sub-overrides output-schema validation (rf2-5x1wt.13) ----
+        ;; ---- :sub-overrides output-schema validation ----
         ;; Each resolved override value is validated against its
         ;; subscription's OUTPUT schema (distinct from the view-args
         ;; schema above). A sub with no output schema soft-passes; a value
@@ -1433,7 +1429,7 @@
                                    (pr-str (mapv :query-v (:violations sub-ovr-val))))
                               {:variant/id id
                                :violations (:violations sub-ovr-val)}))
-        ;; ---- fidelity ladder (rf2-5x1wt.13) ----
+        ;; ---- fidelity ladder ----
         ;; Computed from the resolved world inputs so authors never type
         ;; it. `:real-setup` (events/script) > `:db-seed` (reserved world
         ;; slot) > `:sub-overrides` — the rung(s) a reviewer reads to know
@@ -1448,14 +1444,14 @@
         ;; ---- source coords ----
         source       (:source child)
         platforms    (or (:platforms ctx) #{:client})
-        ;; ---- full decorator stack (rf2-5fibj) ----
+        ;; ---- full decorator stack ----
         ;; `(concat globals story variant-chain)` — globals outermost, then
         ;; the parent story's `:decorators`, then the variant-chain slot
         ;; (`(:decorators ctx)` — the `:extends`-merged, child-wins refs).
-        ;; The SAME ordered set `decorators/collect-decorator-refs` used to
-        ;; assemble at resolve time; folding it onto `[:world :decorators]`
+        ;; The SAME ordered set `decorators/collect-decorator-refs`
+        ;; assembles at resolve time; folding it onto `[:world :decorators]`
         ;; here makes the compiled plan the single source of truth, so the
-        ;; canvas + render-variant resolve the identical stack (rf2-din8u).
+        ;; canvas + render-variant resolve the identical stack.
         ;; Each layer falls through to `[]` when absent — the empty-collection
         ;; concat is render-transparent.
         story-decos  (vec (when-let [sid (args/parent-story-id id)]
@@ -1471,19 +1467,19 @@
                               :platforms      platforms}
                        (some? schema)        (assoc :view-args-schema schema)
                        (some? sub-overrides) (assoc-in [:render :sub-overrides] sub-overrides)
-                       ;; rf2-blw1q — the resolved direct app-db seed
+                       ;; The resolved direct app-db seed
                        ;; (`{path → value}`, `[:arg]` placeholders
                        ;; substituted). In `:world` so it participates in
                        ;; `:plan-hash` (the seed IS part of the variant's
-                       ;; identity) and feeds the now-LIVE `:fidelity`
-                       ;; `:db-seed` rung. Present only when non-empty; a
+                       ;; identity) and feeds the `:fidelity` `:db-seed`
+                       ;; rung. Present only when non-empty; a
                        ;; variant with no seed carries no slot. The runtime
                        ;; reads `[:world :db-seed]`, merges it into the
                        ;; frame's app-db BEFORE the script, and
                        ;; schema-validates the seeded app-db (spec/017
                        ;; §Setup).
                        (seq db-seed)         (assoc :db-seed db-seed)
-                       ;; rf2-5x1wt.13 — the fidelity ladder, computed from
+                       ;; The fidelity ladder, computed from
                        ;; the resolved world inputs. In `:world` so it
                        ;; participates in `:plan-hash` (fingerprint's
                        ;; `plan-hash-input-keys` hashes `:world`). Present
@@ -1492,23 +1488,23 @@
                        (seq fidelity)        (assoc :fidelity fidelity)
                        ;; `:network` keeps the per-route reply data (source
                        ;; of truth, feeds :plan-hash via :world); the
-                       ;; lowering (rf2-5x1wt.14) folds its managed-stub fx
+                       ;; lowering folds its managed-stub fx
                        ;; override into the frame's `:fx-overrides` below.
                        (seq network)          (assoc :network network)
                        (seq fx-overrides)     (assoc-in [:frame :fx-overrides] fx-overrides)
                        (seq interceptor-overrides) (assoc-in [:frame :interceptor-overrides] interceptor-overrides)
                        (contains? ctx :loaders)     (assoc :loaders (:loaders ctx))
-                       ;; rf2-5x1wt.20 — carry `:loaders-complete-when` onto
+                       ;; Carry `:loaders-complete-when` onto
                        ;; the plan's `:world` (it inherits through `:extends`
                        ;; into `ctx`) so the inline-plan run path (which has
                        ;; no registered body) drives phase-1 loaders + the
                        ;; completion predicate from the plan alone.
                        (contains? ctx :loaders-complete-when) (assoc :loaders-complete-when (:loaders-complete-when ctx))
                        (contains? ctx :loaders-teardown) (assoc :loaders-teardown (:loaders-teardown ctx))
-                       ;; rf2-5fibj — the FULL stack (globals + story +
-                       ;; variant chain), not just `(:decorators ctx)`. Folded
-                       ;; when non-empty so a bare variant carries no slot
-                       ;; (render-transparent), exactly as before.
+                       ;; The FULL stack (globals + story + variant chain),
+                       ;; not just `(:decorators ctx)`. Folded when non-empty
+                       ;; so a bare variant carries no slot
+                       ;; (render-transparent).
                        (seq full-decos)             (assoc :decorators full-decos)
                        (contains? ctx :modes)       (assoc :modes (:modes ctx))
                        (contains? ctx :substrates)  (assoc :substrates (:substrates ctx))
@@ -1519,7 +1515,7 @@
         resolved-conflicts (vec (mapcat :resolved (vals strict-res)))
         explain      {:source-chain (mapv :variant/id chain)
                       :parent-chain (mapv :variant/id (butlast chain))
-                      ;; rf2-5x1wt.15 — the resolved `:compose` entries, in
+                      ;; The resolved `:compose` entries, in
                       ;; declared order, classified fragment vs check (§Explain
                       ;; API — composed fragments/checks).
                       :compose      (mapv (fn [{:keys [kind id]}] {:kind kind :id id})
@@ -1549,13 +1545,13 @@
                                               {:status    (:status validation)
                                                :missing   (:missing validation)
                                                :malformed (:malformed validation)})
-                      ;; rf2-5x1wt.14 — per-route network stubs + the
+                      ;; Per-route network stubs + the
                       ;; managed-stub fx the routes lower to (§Network
                       ;; stubs — ":network participates in explain").
                       :network      (when (seq network)
                                       {:routes       network
                                        :lowered-to   (:fx-overrides network-low)})
-                      ;; rf2-5x1wt.13 — view-state subscription overrides +
+                      ;; View-state subscription overrides +
                       ;; the resolved fidelity ladder. `explain` surfaces
                       ;; the resolved override map (post `[:arg]`
                       ;; substitution) and the validation outcome so a
@@ -1571,7 +1567,7 @@
                                         :validation (when sub-ovr-val
                                                       {:status     (:status sub-ovr-val)
                                                        :violations (:violations sub-ovr-val)})})
-                      ;; rf2-blw1q — the resolved direct app-db seed (post
+                      ;; The resolved direct app-db seed (post
                       ;; `[:arg]` substitution). `explain` surfaces it so a
                       ;; reviewer / doc page sees exactly which app-db
                       ;; slices the variant seeds; `:fidelity` labels it the
@@ -1601,7 +1597,7 @@
                                       #{} bodies)
              :explain         explain}
       source (assoc :source source)
-      ;; rf2-5x1wt.24 — the RAW (pre-`[:arg]`-substitution) sub-overrides.
+      ;; The RAW (pre-`[:arg]`-substitution) sub-overrides.
       ;; A SIBLING of `:world` (NOT inside it) so it stays OUT of
       ;; `plan-hash-input-keys` — it is fully derivable from the resolved
       ;; `[:world :render :sub-overrides]` + `:effective-args`, so hashing
@@ -1634,20 +1630,20 @@
     malformed-value checking of `:effective-args`; with none supplied
     only required-key presence is checked.
   - `:fragment-lookup` / `:check-lookup` — a 1-arg fn `(id) → body` OR a
-    `{id → body}` map resolving the bodies named in `:compose`
-    (rf2-5x1wt.15). Default to the side-table `:fragment` / `:check` kinds.
+    `{id → body}` map resolving the bodies named in `:compose`.
+    Default to the side-table `:fragment` / `:check` kinds.
   - `:sub-lookup` — a 1-arg fn `(sub-id) → sub-meta` OR a `{sub-id →
     sub-meta}` map resolving a subscription's registration metadata for
-    its OUTPUT schema, against which `:sub-overrides` values are validated
-    (rf2-5x1wt.13). Defaults to the framework `:sub` registrar.
+    its OUTPUT schema, against which `:sub-overrides` values are validated.
+    Defaults to the framework `:sub` registrar.
   - `:global-decorators` / `:story-decorators` — the ambient decorator
-    layers folded into the FULL `[:world :decorators]` stack (rf2-5fibj):
+    layers folded into the FULL `[:world :decorators]` stack:
     a global-decorators ref vector (or 0-arg fn) defaulting to
     `config/get-global-decorators`, and a `(story-id) → decorators-vec`
     lookup defaulting to the Story side-table `:story` kind. Pure tests
     thread explicit values; the live runtime uses the defaults.
   - `:run-args` — the ambient + per-run arg layers to fold AROUND the
-    `:extends`-merged variant arg layer (rf2-2cpoo), in the
+    `:extends`-merged variant arg layer, in the
     `{:pre [global story mode] :post [cell-overrides]}` shape
     `re-frame.story.args/run-arg-layers` produces. With it the compiled
     `[:world :args]` / `[:world :effective-args]`, every `[:arg key]`
@@ -1655,8 +1651,8 @@
     plan hash all use the SAME effective args as `args/resolve-args` for
     those `:active-modes` / `:cell-overrides`. Absent (a bare
     compile / `explain` / render-prep) ⇒ the variant arg layer alone, so
-    the controls/render path keeps layering its overrides on top of the
-    plan-time effective args exactly as before.
+    the controls/render path layers its overrides on top of the plan-time
+    effective args.
 
   Returns the normalized plan map: `:variant/id`, `:source-chain`,
   `:world` (incl. `:effective-args` and `:view-args-schema` when a view

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -1,26 +1,22 @@
 (ns re-frame.story.play
   "Phase 4 — play-script trace listener + stepper helpers.
 
-  rf2-0wrud (2026-05-20): the variant body's legacy `:play`
-  event-vector slot was REMOVED. `:play-script` is the canonical AND
-  ONLY phase-4 surface. This module retains the per-frame trace
-  listener and the step-by-step play-stepper helpers. The rich-DSL
-  execution itself lives in `re-frame.story.play.runner-events`.
+  `:play-script` is the canonical and ONLY phase-4 surface. This module
+  holds the per-frame trace listener and the step-by-step play-stepper
+  helpers. The rich-DSL execution itself lives in
+  `re-frame.story.play.runner-events`.
 
-  rf2-q651r: `:rf.assert/dispatched?` / `:rf.assert/effect-emitted` /
+  `:rf.assert/dispatched?` / `:rf.assert/effect-emitted` /
   `:rf.assert/no-warnings` PROJECT their fact from the epoch tape (the
   SSOT, `re-frame.story.assertions/dispatched-events` / `warnings` /
   `emitted-fx`), the same source the run-result evidence slots read.
 
-  rf2-luzky: the per-frame listener's `trace-accumulators` dev-mirror feed
-  (the `record-warning!` / `record-emitted-fx!` / `record-dispatched!`
-  calls) is REMOVED along with the side-table itself — those facts are
-  answerable from the tape + stub-call log, so the mirror carried nothing
-  the SSOT does not. The listener is retained PURELY as the egress seam:
-  the load-bearing PRIVACY-suppression gate (Spec 009 §Privacy —
-  default-dropping `:sensitive?` events + the `config/note-suppressed!`
-  redaction counter) and the synchronous handler-exception capture
-  (`pending-exceptions`). It no longer touches any assertions accumulator.
+  The per-frame listener is PURELY the egress seam: the load-bearing
+  PRIVACY-suppression gate (Spec 009 §Privacy — default-dropping
+  `:sensitive?` events + the `config/note-suppressed!` redaction counter)
+  and the synchronous handler-exception capture (`pending-exceptions`). It
+  touches no assertions accumulator — warnings / fx / dispatched are all
+  answerable from the epoch tape + stub-call log, the SSOT.
 
   ## What this module does
 
@@ -44,10 +40,9 @@
   - synchronous handler-exception capture into `pending-exceptions`
     (drained into the assertions list between dispatches).
 
-  rf2-luzky removed this listener's former `trace-accumulators` dev-mirror
-  feed: `:rf.assert/no-warnings` / `:rf.assert/effect-emitted` /
-  `:rf.assert/dispatched?` project from the epoch tape + stub-call log (the
-  SSOT), so the parallel mirror was redundant.
+  The listener feeds no assertions accumulator: `:rf.assert/no-warnings` /
+  `:rf.assert/effect-emitted` / `:rf.assert/dispatched?` project from the
+  epoch tape + stub-call log (the SSOT).
 
   ## Async surface
 
@@ -67,13 +62,12 @@
   - `play-stepper-active?` / `step-once!` — UI hooks (Stage 4's
                                             play-stepper slot)."
   (:require [re-frame.core             :as rf]
-            ;; rf2-qwm0a — the listener surface
-            ;; (`register-listener!` / `unregister-listener!`) lives in
-            ;; `re-frame.trace.tooling` (production-DCE split).
+            ;; The listener surface (`register-listener!` /
+            ;; `unregister-listener!`) lives in `re-frame.trace.tooling`
+            ;; (production-DCE split).
             [re-frame.trace.tooling    :as trace-tooling]
-            ;; rf2-7737vq — the canonical RAW trace-event frame reader
-            ;; (`re-frame.trace/frame-of`), replacing Story's hand-rolled
-            ;; `[:tags :frame]` read.
+            ;; The canonical RAW trace-event frame reader
+            ;; (`re-frame.trace/frame-of`) reads the frame off a trace event.
             [re-frame.trace            :as trace]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async]
@@ -90,8 +84,8 @@
 ;; (per spec/009 §Dispatch correlation) and (a) drops `:sensitive?`
 ;; events + bumps the redaction counter, (b) captures synchronous
 ;; handler-exceptions into `pending-exceptions`. Idempotent. It does NOT
-;; feed any assertions accumulator (rf2-luzky — the dev-mirror is gone;
-;; assertions project from the epoch tape + stub-call log).
+;; feed any assertions accumulator — assertions project from the epoch
+;; tape + stub-call log.
 ;; ---------------------------------------------------------------------------
 
 (defn- listener-id [frame-id]
@@ -124,11 +118,10 @@
   re-enters dispatch-sync — it stores side-effects in atoms and lets
   the play-runner drain them between events.
 
-  Two LOAD-BEARING jobs (rf2-luzky — the `trace-accumulators` dev mirror
-  this listener once also fed is removed; warnings / fx / dispatched are
-  answered from the epoch tape + stub-call log, the SSOT):
+  Two LOAD-BEARING jobs (warnings / fx / dispatched are answered from the
+  epoch tape + stub-call log, the SSOT — not from this listener):
 
-  1. PRIVACY (Spec 009 §Privacy + EP-0015 rf2-3t26eh): events whose
+  1. PRIVACY (Spec 009 §Privacy + EP-0015): events whose
      `:sensitive?` flag is true are DROPPED here when Story's local-render
      egress profile redacts (`:rf.egress/local-redacted` — the default).
      The suppressed-events counter bumps (`config/note-suppressed!`) for the
@@ -138,21 +131,20 @@
 
   2. Synchronous pipeline-exception capture: a non-suppressed pipeline
      exception (`:rf.error/handler-exception` /
-     `:rf.error/coeffect-exception` / `:rf.error/interceptor-exception` —
-     rf2-294yq5.2) is stashed into `pending-exceptions`, which the
-     play-runner drains AFTER each dispatch-sync settles (so it can
-     record an assertion via dispatch-sync without re-entering the
-     in-flight drain). Capturing only `:rf.error/handler-exception` was
-     a false-green: a play-script event whose cofx injector or user
-     interceptor threw would not surface. The shared
-     `story-error/pipeline-exception-event?` predicate is the single
+     `:rf.error/coeffect-exception` / `:rf.error/interceptor-exception`)
+     is stashed into `pending-exceptions`, which the play-runner drains
+     AFTER each dispatch-sync settles (so it can record an assertion via
+     dispatch-sync without re-entering the in-flight drain). The capture
+     spans the WHOLE pipeline — a play-script event whose cofx injector or
+     user interceptor throws surfaces just as a handler throw does. The
+     shared `story-error/pipeline-exception-event?` predicate is the single
      projection."
   [frame-id]
   (fn [ev]
     (when (= frame-id (trace/frame-of ev))
       (cond
-        ;; rf2-6z4znr — resolve the suppress decision against THIS frame's
-        ;; egress profile (the listener is already frame-scoped). Revealing a
+        ;; Resolve the suppress decision against THIS frame's egress
+        ;; profile (the listener is already frame-scoped). Revealing a
         ;; sibling frame never opens this frame's gate.
         (config/suppress-sensitive? ev frame-id)
         (config/note-suppressed! frame-id)
@@ -174,11 +166,11 @@
   `:phase-2-events`, or `:phase-4-play` to match the originating phase.
   Clears the pending slot on exit.
 
-  Public (rf2-z2dq8) so the new rich-DSL runner (`runner-events`) and
-  the runtime's loader/events drivers can drain between dispatches. The
-  legacy `:rf.story/assertions` contract is load-bearing — the test-mode
-  pane, the chrome-level widget, and the Xray assertions panel all
-  read off this slot."
+  Public so the rich-DSL runner (`runner-events`) and the runtime's
+  loader/events drivers can drain between dispatches. The
+  `:rf.story/assertions` contract is load-bearing — the test-mode pane,
+  the chrome-level widget, and the Xray assertions panel all read off this
+  slot."
   [frame-id phase]
   (let [evs (get @pending-exceptions frame-id [])]
     (when (seq evs)
@@ -186,13 +178,13 @@
         (let [event-vec (get-in ev [:tags :event])
               msg       (get-in ev [:tags :exception-message])
               exc       (get-in ev [:tags :exception])]
-          ;; rf2-9kpsq — the trace event may carry a pre-extracted
+          ;; The trace event may carry a pre-extracted
           ;; `:exception-message` (and a possibly-nil `:exception`); thread
           ;; it as the explicit `:message` override on the shared
           ;; projection so the message survives even without the throwable.
-          ;; rf2-294yq5.2 — preserve the originating `:operation` /
-          ;; `:failing-id` so a captured cofx / interceptor failure is
-          ;; distinguishable from a handler throw on the record.
+          ;; Preserve the originating `:operation` / `:failing-id` so a
+          ;; captured cofx / interceptor failure is distinguishable from a
+          ;; handler throw on the record.
           (assertions/record!
             frame-id
             (story-error/exception-record frame-id phase event-vec exc
@@ -256,10 +248,9 @@
 (defn variant-play-events
   "Resolve a flat event-vector list for `variant-id`'s phase-4 play.
 
-  rf2-0wrud (2026-05-20): the legacy `:play` event-vector slot has been
-  removed. This fn now derives a flat event-vector list from the
-  variant's `:play-script` body by extracting events from the
-  `:dispatch` / `:dispatch-sync` steps. Other step types (`:wait`,
+  Derives a flat event-vector list from the variant's `:play-script`
+  body by extracting events from the `:dispatch` / `:dispatch-sync`
+  steps. Other step types (`:wait`,
   `:click`, `:type`, `:assert-db`, `:assert-dom`) have no event-vector
   representation and are skipped here — the rich-DSL runner
   (`re-frame.story.play.runner-events`) is the canonical executor.
@@ -318,35 +309,33 @@
              ;; A failure inside execute-play itself (not the dispatched
              ;; events) becomes a phase-4-setup record. The play has not
              ;; necessarily completed but we still resolve the promise so
-             ;; the caller sees the accumulator. rf2-9kpsq — routed through
-             ;; the shared projection (was a drifted message-only copy that
-             ;; dropped :stack / :data); :event is nil (the failure is in
-             ;; the play harness, not a dispatched event).
+             ;; the caller sees the accumulator. Routed through the shared
+             ;; projection so :stack / :data survive on the record; :event
+             ;; is nil (the failure is in the play harness, not a
+             ;; dispatched event).
              (assertions/record!
                variant-id
                (story-error/exception-record variant-id :phase-4-setup nil e))
              (resolve (read-assertions-after variant-id)))))))))
 
 ;; ---------------------------------------------------------------------------
-;; UI play-stepper hook (Stage 4 placeholder, finalised here)
+;; UI play-stepper hook
 ;;
-;; rf2-ee38b.3 re-base: the stepper now walks the FULL coerced
-;; `:play-script` (every step type — `:dispatch` / `:dispatch-sync` /
-;; `:wait` / `:click` / `:type` / `:assert-db` / `:assert-dom`), driving
-;; each step through the SAME rich-DSL executor the canvas auto-run path
-;; uses (`runner-events/run-step!`, fetched via the `:run-play-step`
-;; late-bind hook to avoid the play ↔ runner-events cycle). Previously it
-;; dispatched only the `:dispatch`/`:dispatch-sync` events from
-;; `variant-play-events` and silently dropped the rest — so the cursor /
-;; total were wrong and assert outcomes never surfaced during a stepped
-;; run. The slot now holds STEPS, not bare event vectors.
+;; The stepper walks the FULL coerced `:play-script` (every step type —
+;; `:dispatch` / `:dispatch-sync` / `:wait` / `:click` / `:type` /
+;; `:assert-db` / `:assert-dom`), driving each step through the SAME
+;; rich-DSL executor the canvas auto-run path uses
+;; (`runner-events/run-step!`, fetched via the `:run-play-step` late-bind
+;; hook to avoid the play ↔ runner-events cycle). The slot holds STEPS,
+;; not bare event vectors, so the cursor / total stay honest and assert
+;; outcomes surface during a stepped run.
 ;; ---------------------------------------------------------------------------
 
 (defonce
   ^{:doc "Per-frame play-stepper state. `{frame-id → {:remaining vec,
          :ran vec, :results vec}}` where `:remaining` / `:ran` carry
-         coerced `:play-script` STEPS (rf2-ee38b.3 — was bare event
-         vectors) and `:results` carries the per-step result records the
+         coerced `:play-script` STEPS and `:results` carries the per-step
+         result records the
          rich-DSL executor returned. The UI shell consumes this to
          render the stepper widget. Used only when the play sequence is
          being driven step-by-step rather than via `execute-play!`."}
@@ -355,14 +344,14 @@
 
 (defn variant-play-steps
   "Resolve the FULL coerced `:play-script` step vector for `variant-id`'s
-  default play (rf2-ee38b.3). Unlike `variant-play-events` (which drops
-  every non-dispatch step) this returns EVERY step the rich-DSL runner
+  default play. Unlike `variant-play-events` (which drops every
+  non-dispatch step) this returns EVERY step the rich-DSL runner
   recognises, in order, so the step-debugger walks the same sequence the
   auto-run path executes.
 
   Pure data → data; works on JVM + CLJS.
 
-  rf2-5x1wt.19 — the script is FOLDED (`assertions/fold-script`) so the
+  The script is FOLDED (`assertions/fold-script`) so the
   stepper walks the SAME canonical `[:assert …]` checkpoints the auto-run
   path drives: a shipping `:assert-db` / `:assert-dom` step is rewritten to
   the one assertion atom before the stepper executes it."
@@ -379,13 +368,12 @@
   "Initialise a step-by-step play run for `frame-id`. The UI's
   play-stepper widget calls `step-once!` to advance one step.
 
-  rf2-ee38b.3: seeds the FULL coerced script (all step types), not just
-  the dispatch-bearing events."
+  Seeds the FULL coerced script (every step type)."
   [frame-id]
   (when config/enabled?
     (swap! pending-exceptions assoc frame-id [])
     (install-trace-listener! frame-id)
-    ;; rf2-vkdam — reset the per-dispatch-step settle boundaries at the START
+    ;; Reset the per-dispatch-step settle boundaries at the START
     ;; of a fresh stepping session (the stepper analogue of `run!`'s reset),
     ;; so `step-once!`'s per-step appends window onto THIS session's epoch tape
     ;; rather than accumulating onto a previous run's boundaries. Fetched via
@@ -405,11 +393,10 @@
   debugger exactly as it does on the live canvas. Returns the step that
   ran, or nil when no steps remain.
 
-  rf2-ee38b.3: previously this dispatched only `:dispatch`/`:dispatch-
-  sync` events and dropped the rest. If the executor hook is absent (a
-  Stage-3-only build where `runner-events` never loaded) it falls back
-  to the legacy `dispatch-one!` for dispatch steps and a no-op record
-  for the rest, so the cursor stays honest."
+  Every step type runs through the executor. If the executor hook is
+  absent (a Stage-3-only build where `runner-events` never loaded) it
+  falls back to `dispatch-one!` for dispatch steps and a no-op record for
+  the rest, so the cursor stays honest."
   [frame-id]
   (when config/enabled?
     (let [{:keys [remaining]} (get @stepper-state frame-id)
@@ -421,8 +408,8 @@
                         run-fn (run-fn frame-id idx step)
 
                         ;; Fallback: executor unavailable. Drive dispatch
-                        ;; steps the legacy way; record nothing for the
-                        ;; other step types but still advance the cursor.
+                        ;; steps directly via `dispatch-one!`; record nothing
+                        ;; for the other step types but still advance the cursor.
                         (#{:dispatch :dispatch-sync} (runner/step-type step))
                         (do (dispatch-one! frame-id (runner/step-event step))
                             (runner/step-skip idx step))
@@ -440,10 +427,10 @@
   recorded result, so a subsequent `step-once!` re-runs it cleanly. The
   UI's step-back also restores the prior epoch (db state); this keeps the
   substrate's remaining/ran/results cursor consistent with that restore.
-  No-op when no step has run. rf2-ee38b.3."
+  No-op when no step has run."
   [frame-id]
   (when config/enabled?
-    ;; rf2-booyu — guard against a missing entry: `update` on a missing key
+    ;; Guard against a missing entry: `update` on a missing key
     ;; would associate the fn's nil/`s` return (a `{frame-id nil}` entry),
     ;; which flips `play-stepper-active?` (a `contains?` check) to true for a
     ;; frame whose stepper was never begun. Only touch an existing,
@@ -463,15 +450,13 @@
 (defn stepper-rewind!
   "Reset the substrate's run cursor to the start: every step back into
   `:remaining`, `:ran` + `:results` emptied. The UI's rewind also
-  restores the pre-play epoch + clears the assertion accumulator.
-  rf2-ee38b.3."
+  restores the pre-play epoch + clears the assertion accumulator."
   [frame-id]
   (when config/enabled?
-    ;; rf2-booyu — guard against a missing entry: the prior `(when s …)`
-    ;; returned nil for a missing key, and `update` then associated that nil
-    ;; (a `{frame-id nil}` entry), making `play-stepper-active?` report true
-    ;; for a frame whose stepper was never begun. Only rewind an existing,
-    ;; non-nil slot.
+    ;; Guard against a missing entry: an `update` whose fn returns nil for
+    ;; a missing key would associate that nil (a `{frame-id nil}` entry),
+    ;; making `play-stepper-active?` report true for a frame whose stepper
+    ;; was never begun. Only rewind an existing, non-nil slot.
     (when (some? (get @stepper-state frame-id))
       (swap! stepper-state update frame-id
              (fn [s]
@@ -508,9 +493,8 @@
   otherwise leave both atoms populated — a stale `stepper-state` entry makes
   `play-stepper-active?` report a session a later test never began, and a
   stale `pending-exceptions` entry could drain into a fresh frame's
-  assertions (rf2-eztym.2). This is the remaining un-reset per-process play
-  state alongside the config atoms (rf2-6ez1u) and the runner-events run
-  atoms (rf2-booyu).
+  assertions. This is the remaining un-reset per-process play state
+  alongside the config atoms and the runner-events run atoms.
 
   Also unregisters every per-frame trace listener `begin-stepper!` /
   `install-trace-listener!` registered (keyed by frame-id across both

--- a/tools/story/src/re_frame/story/play/browser.cljc
+++ b/tools/story/src/re_frame/story/play/browser.cljc
@@ -1,8 +1,7 @@
 (ns re-frame.story.play.browser
   "Browser-tier assertion oracles — visual snapshot, axe-style a11y, and
-  structural a11y (NewTestStory rf2-5x1wt.28,
-  `tools/story/spec/017-Testing-Story.md` §Visual, a11y, and browser
-  checks + §Canonical P1 assertions).
+  structural a11y (`tools/story/spec/017-Testing-Story.md` §Visual, a11y,
+  and browser checks + §Canonical P1 assertions).
 
   ## Not a separate visual-testing system
 
@@ -212,13 +211,12 @@
 
 (defn- violation-targets
   "The CSS selector(s) axe-core attached to a violation's `:nodes`, in
-  document order (rf2-ffu8t — the SOURCE LINK a11y findings MUST carry,
+  document order (the SOURCE LINK a11y findings MUST carry,
   tools/story/spec/021 §4 + §5). Each axe node carries `:target` — a vector
   of CSS selectors pointing at the offending element(s); `re-frame.story.ui.
   a11y/record-violation-overlay!` already queries against exactly these to
-  decorate the DOM. `select-keys [:id :impact :help]` DISCARDED `:nodes`,
-  so the finding could only surface the rule id as its locus; this recovers
-  the selectors so the result UI can link to the source element.
+  decorate the DOM. The finding recovers these selectors so the result UI
+  can link to the source element.
 
   Returns a flat vector of selector strings (deduped, order-preserving); an
   empty vector when the violation carries no `:nodes` / `:target`. Pure data
@@ -232,8 +230,8 @@
         (:nodes violation)))
 
 (defn- axe-finding
-  "Project ONE axe violation into the finding map the result UI renders
-  (rf2-ffu8t). Carries the axe surface (`:id` / `:impact` / `:help`) plus the
+  "Project ONE axe violation into the finding map the result UI renders.
+  Carries the axe surface (`:id` / `:impact` / `:help`) plus the
   recovered source-link selectors:
 
   - `:selector` — the FIRST target selector (the primary source link, nil

--- a/tools/story/src/re_frame/story/play/ci_runner.cljc
+++ b/tools/story/src/re_frame/story/play/ci_runner.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.story.play.ci-runner
-  "CI-as-test discovery + driver glue for Story's `:play-script` slot
-  (rf2-3qcxk).
+  "CI-as-test discovery + driver glue for Story's `:play-script` slot.
 
   The companion to `re-frame.story.play.runner` (pure step state
   machine) and `re-frame.story.play.runner-events` (re-frame-side
@@ -66,15 +65,15 @@
       :else          false)))
 
 (defn has-plays?
-  "True iff `variant-body` carries a non-empty `:plays` vector.
-  rf2-tl7zk multi-play. Pure data → data."
+  "True iff `variant-body` carries a non-empty `:plays` vector
+  (multi-play). Pure data → data."
   [variant-body]
   (let [plays (:plays variant-body)]
     (boolean (and (vector? plays) (pos? (count plays))))))
 
 (defn has-any-play?
   "True iff `variant-body` carries EITHER a non-empty `:play-script`
-  or a non-empty `:plays` vector. rf2-tl7zk multi-play."
+  or a non-empty `:plays` vector (multi-play)."
   [variant-body]
   (or (has-play-script? variant-body)
       (has-plays? variant-body)))
@@ -87,8 +86,8 @@
   Sorted so the CI runner walks variants in a deterministic order —
   helpful when comparing run logs across runs / branches.
 
-  rf2-tl7zk: the name kept its `play-scripts` plural for back-compat;
-  it now includes `:plays`-carrying variants too. The CI runner uses
+  The name keeps the `play-scripts` plural; it includes both
+  `:play-script` and `:plays`-carrying variants. The CI runner uses
   `ci-rows` to enumerate per-PLAY rows."
   ([]
    (variants-with-play-scripts (registrar/registrations :variant)))
@@ -100,7 +99,7 @@
         (vec))))
 
 (defn ci-rows
-  "rf2-tl7zk multi-play: enumerate the CI runner's per-row catalogue.
+  "Enumerate the CI runner's per-row catalogue (multi-play).
   Each row is one play; a variant with `:plays` of size N yields N
   rows; a single-script `:play-script` variant yields ONE row.
 
@@ -108,7 +107,7 @@
 
   Shape (one entry per row):
       {:variant-id <kw>
-       :play-key   <string or nil>     ; play's :name (nil for legacy)
+       :play-key   <string or nil>     ; play's :name (nil for single-script)
        :name       <string or nil>     ; same as :play-key, for parity
        :script-len <int>
        :auto-run?  <bool>}
@@ -147,9 +146,8 @@
 
 (defn terminal?
   "True iff `state` represents a run that has reached a terminal verdict —
-  `:pass` / `:fail` / `:cannot-run` (rf2-5x1wt.19 — `:cannot-run` is the
-  unified distinct THIRD status, spec/017 §`:cannot-run`). Pure data →
-  data."
+  `:pass` / `:fail` / `:cannot-run` (`:cannot-run` is the unified distinct
+  THIRD status, spec/017 §`:cannot-run`). Pure data → data."
   [state]
   (boolean (#{:pass :fail :cannot-run} (:status state))))
 
@@ -237,9 +235,9 @@
      (passed as a fully-qualified string) and return the projected
      shape as JSON-safe JS. Returns nil when no run has been started.
 
-     rf2-tl7zk: this reads the LATEST run-state for the variant —
-     whichever play was most recently driven. CI runners that want a
-     specific play's outcome should use `readPlayRunState`."
+     This reads the LATEST run-state for the variant — whichever play
+     was most recently driven. CI runners that want a specific play's
+     outcome should use `readPlayRunState`."
      [variant-id-str]
      (let [vid   (->variant-id variant-id-str)
            state (runner-events/current-state vid)]
@@ -247,7 +245,7 @@
 
 #?(:cljs
    (defn- read-play-run-state-js
-     "rf2-tl7zk multi-play: read the per-(variant, play-key) run state.
+     "Read the per-(variant, play-key) run state (multi-play).
      `play-key-str` is the play's `:name` string, or null/empty for the
      single-script `:play-script` slot. Returns the projected JSON-safe
      shape, or nil when no run has been started for that play."
@@ -261,7 +259,7 @@
 
 #?(:cljs
    (defn- run-play-js
-     "rf2-tl7zk multi-play: trigger a run for `(variant-id, play-key)`.
+     "Trigger a run for `(variant-id, play-key)` (multi-play).
      Used by the CI runner when the auto-run default doesn't fire the
      intended play (e.g. the second play of a multi-play variant whose
      `:auto-run?` defaults to false)."
@@ -285,7 +283,7 @@
      install when re-frame.story.config/enabled? is true since the
      hook is inert until polled).
 
-     rf2-tl7zk multi-play: the hook object grows two new entry points:
+     The hook object carries two per-play entry points (multi-play):
      - `readPlayRunState(variantId, playKey)` — per-play state read.
      - `runPlay(variantId, playKey)` — trigger a run for a specific
        play (used by the CI runner for non-auto-run plays)."

--- a/tools/story/src/re_frame/story/play/dom.cljc
+++ b/tools/story/src/re_frame/story/play/dom.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story.play.dom
   "DOM-side helpers for the play runner's `:click`, `:type`, and
-  `:assert-dom` steps (rf2-8i2a9).
+  `:assert-dom` steps.
 
   The DOM is impure / browser-only; we abstract the calls behind a
   tiny dispatcher so the rest of the runner stays pure-data and
@@ -147,8 +147,8 @@
 (defn focus!
   "Focus the element matched by `selector-or-node` and dispatch a
   synthetic `focus` + `focusin` event so handlers wired to either
-  observe it (rf2-5x1wt.17). Returns true on success, false on
-  no-such-node or no-DOM. JVM → false.
+  observe it. Returns true on success, false on no-such-node or no-DOM.
+  JVM → false.
 
   `[:focus selector]` is a DOM step (spec/017 §Script step grammar): a
   headless runner refuses it with `:cannot-run` (the capability registry

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -1,21 +1,18 @@
 (ns re-frame.story.play.evidence
   "Project run evidence from the retained epoch tape — the single source of
-  truth for what a Story run proved (NewTestStory rf2-5x1wt.4,
-  spec/017-Testing-Story.md §Run-result evidence projection +
-  §Epoch tape and narrative).
+  truth for what a Story run proved (spec/017-Testing-Story.md
+  §Run-result evidence projection + §Epoch tape and narrative).
 
   ## One tape, many projections
 
   Spec/017 §Run result says the run-result slots are *projections from the
   epoch tape wherever possible*: the result shape is API-stable, but the
   storage / source of truth is ONE tape so Story UI, CI, docs, agents, and
-  the future golden/diff tools cannot disagree about what happened. Before
-  this ns, schema failures, warnings, and effects were captured into a
-  parallel per-frame accumulator (the former `re-frame.story.assertions`
-  `trace-accumulators` side-table, removed in rf2-luzky), which could drift
-  from the trace evidence the Xray UI already reads — a second capture path
-  that could report green while the tape showed a failure (the documented
-  \"false GREEN\").
+  the future golden/diff tools cannot disagree about what happened. Schema
+  failures, warnings, and effects all project from this ONE tape — the
+  same trace evidence the Xray UI already reads — so there is no second
+  capture path that could report green while the tape showed a failure
+  (the \"false GREEN\" hazard a parallel accumulator invites).
 
   This ns makes the epoch tape the evidence boundary. Given the vector of
   `:rf/epoch-record` maps the framework retains for a frame
@@ -185,12 +182,10 @@
 ;; ===========================================================================
 ;;
 ;; A warning is any trace event whose `:op-type` is `:warning` (Spec 009
-;; §Trace event shape / §Op-type vocabulary — `:warning`, NOT `:warn`; the
-;; same stream the former `re-frame.story.assertions` `record-warning!`
-;; side-table feed used to siphon — that siphon keyed off `:op-type
-;; :warning`, and every framework emit site uses `(trace/emit! :warning …)`.
-;; rf2-luzky removed the side-table; this is now the only projection, read
-;; by `:rf.assert/no-warnings`).
+;; §Trace event shape / §Op-type vocabulary — `:warning`, NOT `:warn`).
+;; Every framework emit site uses `(trace/emit! :warning …)`. This
+;; projection is the single warning source, read by
+;; `:rf.assert/no-warnings`.
 
 (def warning-operation
   "The trace `:op-type` that marks a warning severity. Spec 009 §Trace event
@@ -533,7 +528,7 @@
 ;; ---- exact stamping from runner-recorded settle boundaries ---------------
 ;;
 ;; This is the PRODUCER-side bridge that lights up `explicit-beats?` /
-;; `spans-from-stamps` (rf2-rkd14). The runner / replay path records, per
+;; `spans-from-stamps`. The runner / replay path records, per
 ;; dispatch-opening step (in executed-script order), the epoch-history
 ;; LENGTH at the moment that step's settle began (`settle-boundaries`). The
 ;; epoch tape is append-only during a run, so dispatch step K owns the
@@ -564,7 +559,7 @@
   The stamp is a `:rf.story/*` accumulator key, so the deterministic
   projection (`re-frame.story.fingerprint/project`) strips it before the
   run-hash is taken — it is evidence-fidelity metadata on the narrative
-  projection, NOT a behavioural slice (rf2-rkd14 determinism guard).
+  projection, NOT a behavioural slice (the determinism guard).
 
   Degrades gracefully: with no `boundaries` (a bare tape — replay/live
   paths that did not record settle boundaries) the tape is returned
@@ -617,7 +612,7 @@
     PRODUCER feeds: the runner / replay path records each dispatch step's
     settle boundary (the epoch-history length at the start of its settle),
     and `project-evidence` stamps the tape via `stamp-tape` before handing
-    it here (rf2-rkd14). A re-dispatch step that settles to N committed
+    it here. A re-dispatch step that settles to N committed
     epochs has all N attributed to the one authored step — exactly.
   - EVEN — absent stamps (a bare `epoch-history` tape with no recorded
     attribution — e.g. a hand-built tape or a host that did not record
@@ -795,8 +790,7 @@
     `(seq unconsumed-violations)` — no set-subtraction, so N>1 same-selector
     violations partially consumed by M<N expectations correctly leave (N−M)
     unconsumed and trip the floor. The `run-result` assembly uses this path
-    so a partially-consumed schema violation is NOT falsely excused
-    (rf2-5mrnwx)."
+    so a partially-consumed schema violation is NOT falsely excused."
   ([epoch-tape violations effects consumed-selectors]
    (let [unconsumed (remove #(contains? consumed-selectors (:selector %)) violations)]
      (evidence-shows-failure? epoch-tape unconsumed effects nil :unconsumed)))
@@ -859,7 +853,7 @@
     step's settle, in dispatch-step order). When present, the
     `:narrative` is attributed EXACTLY via these boundaries
     (`stamp-tape` → `spans-from-stamps`); absent, the narrative falls
-    back to the EVEN forward partition (rf2-rkd14). The stamp lands ONLY
+    back to the EVEN forward partition. The stamp lands ONLY
     on the records the narrative projection consumes — the verbatim
     `:epoch-tape` slot stays RAW — and is a `:rf.story/*` key the
     determinism projection strips, so the run-hash is unaffected.
@@ -899,9 +893,9 @@
          sub-rows    (sub-runs tape)
          render-rows (renders tape)
          rc          (reactive-counts sub-rows render-rows)
-         ;; rf2-rkd14 — when the runner / replay path recorded per-dispatch-
-         ;; step settle boundaries, stamp the tape so the narrative is
-         ;; attributed EXACTLY (`spans-from-stamps`). The stamp lives ONLY on
+         ;; When the runner / replay path recorded per-dispatch-step settle
+         ;; boundaries, stamp the tape so the narrative is attributed EXACTLY
+         ;; (`spans-from-stamps`). The stamp lives ONLY on
          ;; the narrative's input records; the `:epoch-tape` slot below stays
          ;; the verbatim raw tape. (`stamp-tape` returns the tape unchanged
          ;; when `attribution` is absent → EVEN fallback.)

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story.play.runner
   "Pure step executor for Story's `:play-script` slot — the Storybook
-  `play()`-equivalent rich DSL (rf2-8i2a9).
+  `play()`-equivalent rich DSL.
 
   ## What this module does
 
@@ -29,10 +29,10 @@
   (`re-frame.story.play.settled-boundary`) governs settlement and the
   capability registry (`re-frame.story.requirements`) governs which
   runner can prove it. Bare event-vector shorthand is NOT the public form
-  — it is normalized to `[:dispatch event-vector]` during migration
-  (`coerce-script`) because an app event genuinely named `:dispatch` /
-  `:click` / `:wait` / `:focus` would otherwise be silently
-  un-dispatchable (a reserved-word hazard).
+  — it is normalized to `[:dispatch event-vector]` (`coerce-script`)
+  because an app event genuinely named `:dispatch` / `:click` / `:wait` /
+  `:focus` would otherwise be silently un-dispatchable (a reserved-word
+  hazard).
 
   `[:wait-until predicate-spec]` advances when a queue/state predicate
   becomes true, so it is DETERMINISTIC (the determinism gate accepts it;
@@ -83,8 +83,8 @@
                                 `{:script :auto-run? :name}` map.
   - `step-type`               — first element of a step vector.
   - `step-arity-ok?`          — validate step shape (pre-flight).
-  - `coerce-script`           — normalise mixed shapes (legacy bare
-                                event vectors become `[:dispatch evec]`).
+  - `coerce-script`           — normalise mixed shapes (bare event
+                                vectors become `[:dispatch evec]`).
   - `initial-state` / `advance-state` — pure state-machine driving the
                                 run-status (`:idle`/`:running`/`:pass`/`:fail`).
   - `step-summary`            — human-readable string for log/trace.
@@ -101,7 +101,7 @@
 (def step-types
   "The canonical step-type tags the runner recognises — the one tagged
   step grammar across `:setup` and `:script` (spec/017 §Script step
-  grammar, rf2-5x1wt.17). `:assert` is the in-script checkpoint atom
+  grammar). `:assert` is the in-script checkpoint atom
   (the wrapped `:rf.assert/*` assertion); `:wait-until` is the
   deterministic settle-on-condition; `:focus` is the DOM focus step."
   #{:dispatch :dispatch-sync :wait :wait-until
@@ -110,7 +110,7 @@
 
 (def assertion-step-types
   "Steps whose outcome contributes to the play's pass/fail status —
-  including the `[:assert …]` in-script checkpoint (rf2-5x1wt.17), which
+  including the `[:assert …]` in-script checkpoint, which
   evaluates a `:rf.assert/*` atom at this exact point in the script."
   #{:assert :assert-db :assert-dom})
 
@@ -121,19 +121,18 @@
   explicitly). The driver yields one tick AFTER these steps so the
   queued effects drain before the next step runs.
 
-  `:dispatch` is NOT in this set as of rf2-5x1wt.2: a `[:dispatch …]`
-  step now settles through `settled-boundary` (spec/017) — in headless
-  the `dispatch-sync*` run-to-fixed-point drain — so it is synchronous
-  at the step boundary, exactly like `:dispatch-sync`. Yielding between
-  synchronous steps is what let concurrent `auto-run!` calls interleave
-  and overshoot counter increments in the Playwright matrix (rf2-ftow6);
-  settling `:dispatch` synchronously removes that hazard for the queued
-  authoring form too.
+  `:dispatch` is not in this set: a `[:dispatch …]` step settles through
+  `settled-boundary` (spec/017) — in headless the `dispatch-sync*`
+  run-to-fixed-point drain — so it is synchronous at the step boundary,
+  exactly like `:dispatch-sync`. Yielding between synchronous steps would
+  let concurrent `auto-run!` calls interleave and overshoot counter
+  increments; settling `:dispatch` synchronously removes that hazard for
+  the queued authoring form too.
 
   `:wait-until` is NOT here either: in headless the predicate is checked
-  synchronously once the preceding dispatch has settled (rf2-5x1wt.17),
-  so it recurs synchronously like the assertion steps. A richer runner's
-  bounded poll handles its own scheduling.
+  synchronously once the preceding dispatch has settled, so it recurs
+  synchronously like the assertion steps. A richer runner's bounded poll
+  handles its own scheduling.
 
   Steps NOT in this set (`:dispatch`, `:dispatch-sync`, `:wait-until`,
   `:assert`, `:assert-db`, `:assert-dom`) recur synchronously on CLJS."
@@ -169,11 +168,11 @@
   `coerce-script` to pre-flight a script before driving it."
   [step]
   (case (step-type step)
-    ;; rf2-l2cn5d (EP-0017): a `:dispatch` / `:dispatch-sync` step is
-    ;; either the bare 2-element `[:dispatch evec]` or the 3-element
-    ;; `[:dispatch evec opts]` carrying a recordable-coeffect envelope
-    ;; (`{:rf.cofx <map>}`) the runner threads into the dispatch opts.
-    ;; The opts slot, when present, MUST be a map.
+    ;; A `:dispatch` / `:dispatch-sync` step is either the bare 2-element
+    ;; `[:dispatch evec]` or the 3-element `[:dispatch evec opts]` carrying
+    ;; a recordable-coeffect envelope (`{:rf.cofx <map>}`) the runner
+    ;; threads into the dispatch opts. The opts slot, when present, MUST be
+    ;; a map.
     :dispatch       (boolean
                       (and (<= 2 (count step) 3)
                            (vector? (nth step 1))
@@ -192,8 +191,8 @@
                            (not (neg? (nth step 1)))))
     ;; `[:wait-until predicate-spec]` — deterministic settle-on-condition.
     ;; The predicate-spec is `[:db path expected]`, `[:db path :pred fn]`,
-    ;; or `[:queue-empty]` (rf2-5x1wt.17). A 2-arity vector whose payload
-    ;; is itself a tagged predicate-spec vector.
+    ;; or `[:queue-empty]`. A 2-arity vector whose payload is itself a
+    ;; tagged predicate-spec vector.
     :wait-until     (boolean
                       (and (= 2 (count step))
                            (let [pspec (nth step 1)]
@@ -214,7 +213,7 @@
                                     :queue-empty (= 1 (count pspec))
                                     false)))))
     ;; `[:assert assertion-vector]` — the in-script checkpoint atom. The
-    ;; wrapped form is a `:rf.assert/*` event vector (rf2-5x1wt.17).
+    ;; wrapped form is a `:rf.assert/*` event vector.
     :assert         (boolean
                       (and (= 2 (count step))
                            (let [a (nth step 1)]
@@ -258,11 +257,11 @@
                            (string? (nth step 1))))
     false))
 
-;; ---- legacy bare-event-vector lift --------------------------------------
+;; ---- bare-event-vector lift ---------------------------------------------
 
 (defn- bare-event-vector?
   "True iff `v` looks like a re-frame event vector but is NOT a known
-  step. We treat these as legacy sugar for `[:dispatch v]`."
+  step. These are sugar for `[:dispatch v]`."
   [v]
   (and (vector? v)
        (pos? (count v))
@@ -319,7 +318,7 @@
     (cond-> {:script script :auto-run? auto-run?}
       nm (assoc :name nm))))
 
-;; ---- :plays multi-play resolution (rf2-tl7zk) ----------------------------
+;; ---- :plays multi-play resolution ----------------------------------------
 
 (defn- parse-named-play
   "Normalise ONE `:plays` entry. Auto-run defaults differ for the first
@@ -386,7 +385,7 @@
 
 (defn play-key
   "Stable key for ONE play within a variant. The empty / single-script
-  shape uses `nil` (the legacy `:play-script` slot has no per-play
+  shape uses `nil` (the `:play-script` slot has no per-play
   identifier). Multi-play entries use the play's `:name` string.
 
   Used by the runner-events ns to key per-(variant, play) run-state
@@ -397,7 +396,7 @@
 
 (defn find-play
   "Return the play at `play-key` (a name string) in `plays`, or nil.
-  `play-key` of nil matches the single-entry case (the legacy
+  `play-key` of nil matches the single-entry case (the single-script
   `:play-script` wrap)."
   [plays play-key]
   (when (seq plays)
@@ -506,7 +505,7 @@
   not be attempted, not a fail), so it must NOT bump `:failures` — otherwise
   `finish`'s `:status :cannot-run` verdict and this `:failures` count
   disagree, and a CI consumer keying off `:failures > 0` would flag a
-  cannot-run-only run as red (rf2-eztym.1). This uses the same predicate
+  cannot-run-only run as red. This uses the same predicate
   (`cannot-run-step?`) `finish` consults for `real-failures`."
   [state result]
   (-> state
@@ -519,8 +518,8 @@
 
 (defn finish
   "Transition `state` to the terminal `:pass` / `:fail` / `:cannot-run`
-  status (rf2-5x1wt.19 — `:cannot-run` is the unified distinct THIRD
-  status, spec/017 §`:cannot-run`).
+  status (`:cannot-run` is the unified distinct THIRD status, spec/017
+  §`:cannot-run`).
 
   - A genuine failure (an exception, or a failing assertion that is NOT a
     `:cannot-run` refusal) → `:fail`.
@@ -550,7 +549,7 @@
 (defn run-state-refusals
   "The `:cannot-run` refusal records carried by a settled run-`state`'s
   per-step `:results` — the same step-results `finish` inspects to decide
-  the run-state status (rf2-q5jw4). Pure data → data.
+  the run-state status. Pure data → data.
 
   A refusal is a step-result a runner could not even ATTEMPT for its
   declared capability (a no-DOM `[:assert-dom …]` / `[:click …]` skip, or a
@@ -567,9 +566,9 @@
 
   This is the SINGLE bridge from the run-state's refusal facts to the
   unified result, so the run-state and the unified `:status` cannot disagree
-  — the false-GREEN class rf2-5x1wt.19 set out to kill (a DOM-skip-only
-  variant read `:pass` via the unified result while the run-state read
-  `:cannot-run`). Empty when no step refused."
+  — closing the false-GREEN class where a DOM-skip-only variant would read
+  `:pass` via the unified result while the run-state read `:cannot-run`.
+  Empty when no step refused."
   [state]
   (into []
         (comp (filter cannot-run-step?)
@@ -757,7 +756,7 @@
 (defn step-cofx
   "Return the captured flat `:rf.cofx` map from a 3-element
   `[:dispatch evec opts]` / `[:dispatch-sync evec opts]` step
-  (rf2-l2cn5d, EP-0017), or nil. The opts map's `:rf.cofx` is the
+  (EP-0017), or nil. The opts map's `:rf.cofx` is the
   recordable-coeffect envelope the recorder captured; the executor
   threads it into the dispatch opts so replay re-presents the recorded
   values (provided facts + the framework `:rf/time-ms`)."
@@ -775,8 +774,8 @@
 
 (defn step-assertion
   "Return the wrapped `:rf.assert/*` assertion atom from an
-  `[:assert assertion-vector]` checkpoint step, or nil (rf2-5x1wt.17).
-  This is the ONE assertion atom in its in-script position — the same
+  `[:assert assertion-vector]` checkpoint step, or nil. This is the ONE
+  assertion atom in its in-script position — the same
   vector the terminal `:assertions` slot carries."
   [step]
   (when (= :assert (step-type step))
@@ -785,8 +784,8 @@
 (defn step-wait-until
   "Decompose a `[:wait-until predicate-spec]` step into
   `{:kind :db|:queue-empty :path <vec> :mode :equals|:pred :expected <val>
-  :pred-ref <fn-or-sym> :pred-fn? <bool>}` (rf2-5x1wt.17). Returns nil
-  for a non-`:wait-until` step.
+  :pred-ref <fn-or-sym> :pred-fn? <bool>}`. Returns nil for a
+  non-`:wait-until` step.
 
   - `[:db path expected]`       → `{:kind :db :path … :mode :equals :expected …}`
   - `[:db path :pred fn-or-sym]`→ `{:kind :db :path … :mode :pred :pred-ref … :pred-fn? …}`

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -1,12 +1,12 @@
 (ns re-frame.story.play.runner-events
-  "re-frame-side driver for the rich-DSL play runner (rf2-8i2a9).
+  "re-frame-side driver for the rich-DSL play runner.
 
   The pure step state machine + script parsing lives in
   `re-frame.story.play.runner`. This namespace owns the impure seams
   the step types reach for:
 
   - `:dispatch` → dispatch + settle through `settled-boundary`
-    (`boundary/dispatch-and-settle!`, rf2-5x1wt.2) against the variant's
+    (`boundary/dispatch-and-settle!`) against the variant's
     frame; in headless this drains via `dispatch-sync*` to a fixed point
     (richer runners supply reactive / DOM flushes through flush-hooks).
     `:dispatch-sync` → the low-level `rf/dispatch-sync*` escape.
@@ -16,7 +16,7 @@
     handed in directly is called as-is (advanced-CLJS-safe); a SYMBOL
     is resolved at run time via `requiring-resolve` (JVM) or a
     best-effort `goog.global` walk (CLJS — fragile under advanced
-    compilation, see rf2-inbad).
+    compilation).
   - `:click` / `:type` / `:assert-dom` → delegate to
     `re-frame.story.play.dom` (no-op on JVM / no-DOM).
 
@@ -119,8 +119,8 @@
 
 (defn settle-boundaries
   "Read the recorded per-dispatch-step settle boundaries for `frame-id`,
-  or nil. rf2-rkd14 — the runner-recorded narrative attribution the
-  evidence projection consumes to stamp `:rf.story/script-idx`."
+  or nil. The runner-recorded narrative attribution the evidence
+  projection consumes to stamp `:rf.story/script-idx`."
   [frame-id]
   (get @step-boundaries frame-id))
 
@@ -134,15 +134,15 @@
 
 (defn- record-settle-boundary!
   "Snapshot the epoch-history length at the START of a dispatch-opening
-  `step`'s settle (rf2-rkd14). No-op for non-dispatch steps (assert / wait
-  / unknown) — those commit no span of their own; their epochs roll into
+  `step`'s settle. No-op for non-dispatch steps (assert / wait / unknown)
+  — those commit no span of their own; their epochs roll into
   the preceding dispatch span (the narrative's forward-attribution model).
   The boundaries accumulate in dispatch-step execution order, which — for
   both the single-play and multi-play (sequential) runner — is exactly the
   order the dispatch steps appear in the concatenated executed-script the
   narrative spans. For multi-play this holds ONLY because the sequencer
-  clears once up front and drives each play with `:clear-boundaries? false`
-  (rf2-76l69l): the boundaries from play K+1 (absolute epoch-history
+  clears once up front and drives each play with `:clear-boundaries? false`:
+  the boundaries from play K+1 (absolute epoch-history
   lengths) tail play K's, so the full vector zips positionally against the
   concatenated script. A per-play clear would drop every earlier play's
   boundaries, leaving only the last play's to be mis-zipped."
@@ -152,35 +152,35 @@
   nil)
 
 (defn current-state-for-play
-  "Read the run-state for `(frame-id, play-key)`, or nil. rf2-tl7zk:
-  exposes per-play state for the dropdown's per-row status badges +
-  the CI runner's per-play outcome read."
+  "Read the run-state for `(frame-id, play-key)`, or nil. Exposes
+  per-play state for the dropdown's per-row status badges + the CI
+  runner's per-play outcome read."
   [frame-id play-key]
   (get @runs-by-play [frame-id play-key]))
 
 (defn active-play-key
   "Return the play-key the toolbar is currently focused on for
-  `frame-id`, or nil. rf2-tl7zk multi-play."
+  `frame-id`, or nil (multi-play)."
   [frame-id]
   (get @active-play frame-id))
 
 (defn set-active-play!
-  "Set the toolbar's focused play for `frame-id`. rf2-tl7zk multi-play.
+  "Set the toolbar's focused play for `frame-id` (multi-play).
   Idempotent — re-setting the same key is a no-op."
   [frame-id play-key]
   (swap! active-play assoc frame-id play-key)
   nil)
 
 (defn clear-step-boundaries!
-  "Reset the per-dispatch-step settle boundaries for `frame-id` (rf2-rkd14).
+  "Reset the per-dispatch-step settle boundaries for `frame-id`.
   Called at the START of a fresh script run so the narrative attribution
   windows onto THIS run's epoch tape, not a previous run's boundaries.
 
-  rf2-vkdam — owned by every entry that WRITES boundaries: the public driver
+  Owned by every entry that WRITES boundaries: the public driver
   `run!`, the orchestrator `runtime/run-phase-4!` (which also covers its
   no-auto-plays branch), and the stepper start `play/begin-stepper!` (via the
   `:clear-step-boundaries` late-bind seam). So a non-orchestrator re-run /
-  replay-in-place / stepping session no longer inherits stale accumulated
+  replay-in-place / stepping session never inherits stale accumulated
   offsets that would mis-attribute the exact narrative."
   [frame-id]
   (swap! step-boundaries dissoc frame-id)
@@ -190,7 +190,7 @@
   "Wipe the run-state for `frame-id` across all four process-global atoms
   (`run-state` / `runs-by-play` / `active-play` / `step-boundaries`).
   Wired into frame teardown via the `:drop-run-state` late-bind hook
-  (`frames/destroy!` + `destroy-inline!`, rf2-booyu) so a destroyed variant
+  (`frames/destroy!` + `destroy-inline!`) so a destroyed variant
   frame leaves no stale terminal play status behind."
   [frame-id]
   (swap! run-state dissoc frame-id)
@@ -204,16 +204,15 @@
 (defn clear-all-runs!
   "Wipe ALL per-variant run-state across every frame — the four
   per-process atoms (`run-state` / `runs-by-play` / `active-play` /
-  `step-boundaries`) AND the `warned-both-slots` one-shot warning cache
-  (rf2-a1lvd). Used by the Story test-fixture helper (rf2-lh99f) so a
-  fresh test doesn't observe a previous test's play outcomes;
-  `clear-state!` is the per-frame counterpart called from teardown.
+  `step-boundaries`) AND the `warned-both-slots` one-shot warning cache.
+  Used by the Story test-fixture helper so a fresh test doesn't observe a
+  previous test's play outcomes; `clear-state!` is the per-frame
+  counterpart called from teardown.
 
   Clearing `warned-both-slots` here re-arms the both-`:play-script`-and-
-  `:plays` console warning per test and per hot-reload reset, mirroring
-  the established warn-once-clear pattern (cf. rf2-4edk / qy6cl): a
-  warn-once cache that is never reset suppresses the affordance across
-  test order + hot-reload."
+  `:plays` console warning per test and per hot-reload reset, following
+  the warn-once-clear pattern: a warn-once cache that is never reset
+  suppresses the affordance across test order + hot-reload."
   []
   (reset! run-state      {})
   (reset! runs-by-play   {})
@@ -253,33 +252,30 @@
 ;; ---- replay target (EP-0023) ---------------------------------------------
 ;;
 ;; A recording's replay address is the variant FRAME (`{:frame variant-id}`).
-;; EP-0023 collapses the old EP-0013 public `(realm, frame)` address to that
-;; single frame target: the runner dispatches frame-scoped, and the framework
-;; derives the running environment from the targeted frame, so replay lands in
-;; the frame's own image generation by construction. Realm survives only as the
-;; framework's internal installation substrate — the runner carries no separate
-;; realm key on the replay address.
+;; The public address is that single frame target: the runner dispatches
+;; frame-scoped, and the framework derives the running environment from the
+;; targeted frame, so replay lands in the frame's own image generation by
+;; construction. Realm is the framework's internal installation substrate —
+;; the runner carries no separate realm key on the replay address.
 
-;; ---- folded-plan consumption (rf2-5x1wt.19) ------------------------------
+;; ---- folded-plan consumption --------------------------------------------
 ;;
-;; The runtime CONSUMES the `.18`-folded plan: every play's script is folded
+;; The runtime CONSUMES the folded plan: every play's script is folded
 ;; through `assertions/fold-script` at resolution time, so a shipping
 ;; `:assert-db` / `:assert-dom` step is rewritten to the canonical
 ;; `[:assert assertion-atom]` checkpoint BEFORE the run loop drives it
-;; (spec/017 §Assertions — one atom, two positions; NewTestStory rf2-5x1wt.19
-;; §B5.9). The `.18` worker deferred runtime consumption to this bead; this
-;; is where it lands. After folding, `exec-step!` only ever sees the ONE
-;; assertion atom in its `[:assert …]` checkpoint position — there is no
-;; longer a synthetic `:rf.assert/db` / `:rf.assert/dom` rail (a folded
-;; `:assert-db` dispatches the real `:rf.assert/path-equals` handler; a
-;; folded `:assert-dom` routes through the DOM executor recording a
-;; canonical `:rf.assert/dom-*` record). One assertion-record vocabulary,
-;; not two.
+;; (spec/017 §Assertions — one atom, two positions). After folding,
+;; `exec-step!` only ever sees the ONE assertion atom in its `[:assert …]`
+;; checkpoint position — there is no synthetic `:rf.assert/db` /
+;; `:rf.assert/dom` rail (a folded `:assert-db` dispatches the real
+;; `:rf.assert/path-equals` handler; a folded `:assert-dom` routes through
+;; the DOM executor recording a canonical `:rf.assert/dom-*` record). One
+;; assertion-record vocabulary, not two.
 
 (defn- fold-spec
   "Fold a parsed play spec's `:script` through `assertions/fold-script` so
   shipping `:assert-db` / `:assert-dom` steps become canonical
-  `[:assert …]` checkpoints (rf2-5x1wt.19). Pure data → data; preserves
+  `[:assert …]` checkpoints. Pure data → data; preserves
   `:auto-run?` / `:name`."
   [spec]
   (cond-> spec
@@ -287,15 +283,15 @@
 
 (defn variant-play-script
   "Resolve the `:play-script` body on `variant-id`, parse it, and FOLD its
-  script (rf2-5x1wt.19). Returns the normalised spec map per
-  `runner/parse-spec` with every shipping `:assert-db` / `:assert-dom` step
-  rewritten to the canonical `[:assert …]` checkpoint. Variants without
-  `:play-script` return `{:script [] :auto-run? true}`.
+  script. Returns the normalised spec map per `runner/parse-spec` with
+  every shipping `:assert-db` / `:assert-dom` step rewritten to the
+  canonical `[:assert …]` checkpoint. Variants without `:play-script`
+  return `{:script [] :auto-run? true}`.
 
-  Note (rf2-tl7zk): variants declaring `:plays` resolve to the FIRST
-  play's spec — preserves legacy single-script call sites + matches the
-  toolbar's 'default play' behaviour. Callers that need the full plays
-  vector should use `variant-plays` instead."
+  Note: variants declaring `:plays` resolve to the FIRST play's spec —
+  matching the single-script call sites + the toolbar's 'default play'
+  behaviour. Callers that need the full plays vector should use
+  `variant-plays` instead."
   [variant-id]
   (let [body  (handler-meta variant-id)
         plays (runner/variant-body->plays body)]
@@ -305,7 +301,7 @@
         (and (seq plays) (contains? body :plays))
         (first plays)
 
-        ;; Single-script (:play-script slot) — legacy path.
+        ;; Single-script (:play-script slot).
         :else
         (runner/parse-spec (when body (:play-script body)))))))
 
@@ -330,7 +326,7 @@
 
 (defn variant-plays
   "Resolve the canonical vector of parsed plays for `variant-id`. Pure
-  data → data; works on JVM + CLJS. rf2-tl7zk multi-play.
+  data → data; works on JVM + CLJS (multi-play).
 
   - `:plays` present → returns the parsed plays vector (size >= 1).
   - `:play-script` present → returns a single-entry vector wrapping the
@@ -343,17 +339,16 @@
                (contains? body :play-script)
                (contains? body :plays))
       (warn-both-slots-once! variant-id))
-    ;; rf2-5x1wt.19 — FOLD every resolved play's script so the runtime
-    ;; consumes the `.18`-folded plan: `:assert-db` / `:assert-dom` steps
-    ;; become canonical `[:assert …]` checkpoints before the run loop.
+    ;; FOLD every resolved play's script so the runtime consumes the
+    ;; folded plan: `:assert-db` / `:assert-dom` steps become canonical
+    ;; `[:assert …]` checkpoints before the run loop.
     (mapv fold-spec (runner/variant-body->plays body))))
 
 (defn resolve-play
   "Resolve a `(variant-id, play-key)` pair to the parsed, FOLDED play spec,
   or nil. `play-key` may be nil — meaning 'the default play' (first
   entry for multi-play, the single script for `:play-script`).
-  rf2-tl7zk multi-play. The script is folded (rf2-5x1wt.19) via
-  `variant-plays`."
+  Multi-play. The script is folded via `variant-plays`."
   [variant-id play-key]
   (let [plays (variant-plays variant-id)]
     (if (nil? play-key)
@@ -387,7 +382,7 @@
         (merge {:frame variant-id} payload)))
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
-;; ---- settled-boundary flush hooks (rf2-5x1wt.2) --------------------------
+;; ---- settled-boundary flush hooks ---------------------------------------
 ;;
 ;; `[:dispatch event-vector]` settles through `settled-boundary` (spec/017
 ;; §Script and `settled-boundary`). The runner takes its flush-hooks from
@@ -478,9 +473,9 @@
 
 (defn- exec-dispatch!
   "Execute a `:dispatch` step — dispatch the event and settle through
-  `settled-boundary` (spec/017 §Script and `settled-boundary`,
-  rf2-5x1wt.2). In headless this is the existing `dispatch-sync*`
-  run-to-fixed-point drain, named via `settled-boundary`; richer runners
+  `settled-boundary` (spec/017 §Script and `settled-boundary`).
+  In headless this is the `dispatch-sync*` run-to-fixed-point drain,
+  named via `settled-boundary`; richer runners
   supply reactive / DOM flushes through their flush-hooks. The runner
   NEVER hard-codes `dispatch-sync` — it routes through the boundary's
   caller-supplied hooks (`current-flush-hooks`).
@@ -492,7 +487,7 @@
 
   Drains any handler-exception trace events captured by the play
   listener into `:rf.story/assertions` so the test-mode pane + Xray
-  assertions panel see the failure (rf2-z2dq8). The re-frame router
+  assertions panel see the failure. The re-frame router
   catches handler exceptions and emits `:rf.error/handler-exception`
   rather than re-throwing, so the local catch fires only for
   exceptions that escape the interceptor chain entirely.
@@ -503,10 +498,10 @@
   terminal status flips to `:fail`."
   [frame-id idx step]
   (let [evec     (runner/step-event step)
-        ;; rf2-l2cn5d (EP-0017): a replayed `[:dispatch evec {:rf.cofx …}]`
-        ;; step carries a captured recordable-coeffect envelope. Pass it to
-        ;; the boundary as dispatch-opts so the handler's declared coeffects
-        ;; replay from the recorded value instead of being restamped.
+        ;; A replayed `[:dispatch evec {:rf.cofx …}]` step carries a
+        ;; captured recordable-coeffect envelope. Pass it to the boundary
+        ;; as dispatch-opts so the handler's declared coeffects replay from
+        ;; the recorded value instead of being restamped.
         cofx     (runner/step-cofx step)
         dopts    (when (and (map? cofx) (seq cofx)) {:rf.cofx cofx})
         prev     (assertion-count frame-id)
@@ -525,12 +520,12 @@
 (defn- exec-dispatch-sync!
   [frame-id idx step]
   (let [evec   (runner/step-event step)
-        ;; rf2-l2cn5d (EP-0017): when the step carries a captured `:rf.cofx`
-        ;; envelope, thread it into the dispatch opts so the handler's
-        ;; declared recordable coeffects (provided facts + the framework
-        ;; `:rf/time-ms`) replay from the recorded value instead of being
-        ;; restamped / failing `:rf.error/missing-required-cofx`. Absent
-        ;; cofx dispatches with the bare frame opts (pre-EP-0017 behaviour).
+        ;; When the step carries a captured `:rf.cofx` envelope, thread it
+        ;; into the dispatch opts so the handler's declared recordable
+        ;; coeffects (provided facts + the framework `:rf/time-ms`) replay
+        ;; from the recorded value instead of being restamped / failing
+        ;; `:rf.error/missing-required-cofx`. Absent cofx dispatches with
+        ;; the bare frame opts.
         cofx   (runner/step-cofx step)
         opts   (cond-> {:frame frame-id}
                  (and (map? cofx) (seq cofx)) (assoc :rf.cofx cofx))
@@ -553,17 +548,17 @@
     (rf/app-db-value frame-id)
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
-;; ---- DOM-family assertion atom executor (rf2-5x1wt.19) -------------------
+;; ---- DOM-family assertion atom executor ---------------------------------
 ;;
 ;; The DOM family (`:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /
 ;; `:rf.assert/dom-text`) is the fold target for the shipping `:assert-dom`
-;; step (`.18`). It has no reg-event handler yet (the DOM runner that
-;; PROVES it lands later — the `:dom` capability is wired now via
-;; `requirements`), so an `[:assert [:rf.assert/dom-* …]]` checkpoint is
-;; EVALUATED directly through the DOM executor (`dom/assert-visible` /
-;; `dom/assert-text`) and records a CANONICAL `:rf.assert/dom-*` record on
-;; the frame's `:rf.story/assertions` slot. There is no synthetic
-;; `:rf.assert/dom` id — the canonical folded id is the one recorded.
+;; step. It has no reg-event handler (the DOM runner that PROVES it is the
+;; `:dom` capability wired via `requirements`), so an
+;; `[:assert [:rf.assert/dom-* …]]` checkpoint is EVALUATED directly through
+;; the DOM executor (`dom/assert-visible` / `dom/assert-text`) and records a
+;; CANONICAL `:rf.assert/dom-*` record on the frame's `:rf.story/assertions`
+;; slot. There is no synthetic `:rf.assert/dom` id — the canonical folded id
+;; is the one recorded.
 
 (def ^:private dom-atom->mode
   "Map a DOM-family assertion id to the `dom/assert-visible` mode it
@@ -574,7 +569,7 @@
 
 (defn- exec-assert-dom-atom!
   "Evaluate a folded DOM-family assertion atom `[:rf.assert/dom-* selector
-  & args]` at this checkpoint (rf2-5x1wt.19). Drives the DOM executor,
+  & args]` at this checkpoint. Drives the DOM executor,
   records the CANONICAL `:rf.assert/dom-*` record on the frame slot (so the
   unified result's `:assertions` carries the real folded id, not a
   synthetic one), and returns the runner step-result. A no-DOM headless
@@ -642,7 +637,7 @@
                         {:message (str "type failed — no node matched " (pr-str selector))}))))
 
 (defn- exec-focus!
-  "Execute a `[:focus selector]` step — a DOM focus event (rf2-5x1wt.17).
+  "Execute a `[:focus selector]` step — a DOM focus event.
   Parallels `exec-click!`: a no-DOM headless runner records a
   `{:skipped? true}` no-op (the capability registry already refuses the
   step at preflight, so this is the belt-and-braces runtime guard); a
@@ -664,17 +659,12 @@
 
 (declare exec-assert-dom-atom!)
 
-;; ---- browser-tier assertion atom executor (rf2-9ikj0) --------------------
+;; ---- browser-tier assertion atom executor -------------------------------
 ;;
 ;; The browser-tier oracle family (`:rf.assert/visual-snapshot` /
 ;; `:rf.assert/a11y` / `:rf.assert/a11y-structural`) has its dedicated pure
-;; executor in `re-frame.story.play.browser` (`eval-browser-assertion`,
-;; rf2-5x1wt.28) — but until now that executor was ORPHANED from the run
-;; path: `exec-assert!` routed EVERY browser-tier atom to a no-op step-skip
-;; via `tape-evaluated-assertion?`, so a `[:assert [:rf.assert/a11y-structural
-;; …]]` checkpoint recorded nothing and a headless run never surfaced the
-;; honest `:cannot-run` for the browser-only pair. rf2-9ikj0 wires the
-;; executor IN, mirroring how the DOM family is routed to
+;; executor in `re-frame.story.play.browser` (`eval-browser-assertion`). The
+;; run path wires that executor IN, mirroring how the DOM family is routed to
 ;; `exec-assert-dom-atom!`:
 ;;
 ;;   - `:rf.assert/a11y-structural` is the `:hiccup` rung — it walks the
@@ -737,8 +727,8 @@
 (defn- exec-assert-browser-atom!
   "Evaluate a browser-tier oracle assertion atom `[:rf.assert/visual-snapshot
   | :rf.assert/a11y | :rf.assert/a11y-structural & args]` at this checkpoint
-  (rf2-9ikj0 — wire the previously-orphaned `browser/eval-browser-assertion`
-  into the run path). Mirrors `exec-assert-dom-atom!`: drives the pure
+  (drives `browser/eval-browser-assertion` from the run path). Mirrors
+  `exec-assert-dom-atom!`: drives the pure
   executor, records the CANONICAL assertion record on the frame slot (so the
   unified result's `:assertions` carries the real browser-tier id), and
   returns the runner step-result.
@@ -792,17 +782,16 @@
 (defn- tape-evaluated-assertion?
   "True iff the assertion atom `atom-v` (`[:rf.assert/id & args]`) is
   evaluated AGAINST THE EPOCH TAPE in the result boundary rather than by
-  dispatching a `reg-event` handler into the frame (rf2-8y47c +
-  rf2-fh7g4).
+  dispatching a `reg-event` handler into the frame.
 
   Two assertion families carry NO `reg-event` handler and are minted
   by the result boundary (`re-frame.story.result`), not by a dispatch:
 
   - `:rf.assert/schema-error` — paired against the projected
-    `:rf.error/schema-validation-failure` evidence (rf2-5x1wt.21).
+    `:rf.error/schema-validation-failure` evidence.
   - the causal / cascade family (`:rf.assert/caused` /
     `:rf.assert/no-cascade-rerender`) — paired against the
-    `:reactive-counts` `:by-cause` projection (rf2-5x1wt.31).
+    `:reactive-counts` `:by-cause` projection.
 
   This is the SINGLE classifier the in-script `[:assert …]` executor
   consults so a tape-evaluated checkpoint is NEVER dispatched into the
@@ -815,27 +804,23 @@
 
   Two families are NOT here — each has its own inline executor routed
   AHEAD of this classifier: the DOM family (`exec-assert-dom-atom!`) and
-  the browser-tier oracle family (`exec-assert-browser-atom!`, rf2-9ikj0).
-  The browser-tier family was PREVIOUSLY mis-classified here, which made
-  `browser/eval-browser-assertion` dead weight w.r.t. the run path: a
-  `:rf.assert/a11y-structural` checkpoint recorded a no-op step-skip
-  instead of evaluating the rendered hiccup tree, and the browser-only
-  pair never surfaced their honest `:cannot-run`. They are now routed to
-  the dedicated executor, so they are NO LONGER tape-evaluated."
+  the browser-tier oracle family (`exec-assert-browser-atom!`). The
+  browser-tier family is routed to its dedicated executor (which evaluates
+  the rendered hiccup tree and surfaces the honest `:cannot-run` for the
+  browser-only pair), so it is NOT tape-evaluated."
   [atom-v]
   (or (assertions/schema-error? atom-v)
       (assertions/causal? atom-v)))
 
 (defn- exec-assert!
-  "Execute an `[:assert [:rf.assert/id & args]]` in-script checkpoint
-  (rf2-5x1wt.17). Evaluates the wrapped assertion atom at THIS point in
-  the script (spec/017 §Inline script assertions vs terminal
-  assertions). This is the SINGLE in-script assertion executor — after
-  the `.18` fold the runtime consumes (rf2-5x1wt.19), a shipping
-  `:assert-db` / `:assert-dom` step has already been rewritten to this
-  `[:assert …]` checkpoint, so there is no longer a parallel `:assert-db`
-  / `:assert-dom` executor minting synthetic `:rf.assert/db` /
-  `:rf.assert/dom` records.
+  "Execute an `[:assert [:rf.assert/id & args]]` in-script checkpoint.
+  Evaluates the wrapped assertion atom at THIS point in the script
+  (spec/017 §Inline script assertions vs terminal assertions). This is
+  the SINGLE in-script assertion executor — after the fold the runtime
+  consumes, a shipping `:assert-db` / `:assert-dom` step has already been
+  rewritten to this `[:assert …]` checkpoint, so there is no parallel
+  `:assert-db` / `:assert-dom` executor minting synthetic `:rf.assert/db`
+  / `:rf.assert/dom` records.
 
   Four routes, by atom family:
 
@@ -846,8 +831,8 @@
     `:rf.assert/dom-*` record on the slot.
   - The browser-tier oracle family (`:rf.assert/visual-snapshot` /
     `:rf.assert/a11y` / `:rf.assert/a11y-structural`) is EVALUATED directly
-    through `exec-assert-browser-atom!` (rf2-9ikj0 — the previously-orphaned
-    `browser/eval-browser-assertion` wired into the run path). At the
+    through `exec-assert-browser-atom!` (driving
+    `browser/eval-browser-assertion`). At the
     `:hiccup` tier `:rf.assert/a11y-structural` walks the rendered hiccup
     tree and records a real `:pass` / `:fail`; with no tree (the headless
     floor) it records `:cannot-run`. The browser-only pair record
@@ -857,8 +842,7 @@
     minted by the result boundary against the epoch tape, not by a dispatch.
     An in-script checkpoint for one of these records a no-op step-skip (the
     boundary owns its verdict); dispatching it would mint a spurious
-    `:rf.error/no-such-handler` trace AND skip the real tape evaluation
-    (rf2-8y47c + rf2-fh7g4).
+    `:rf.error/no-such-handler` trace AND skip the real tape evaluation.
   - Every other (dispatchable) `:rf.assert/*` atom dispatches the event
     through `settled-boundary` — the standard reg-event handler records
     the `:passed?` record on the frame's `:rf.story/assertions` slot — and
@@ -870,17 +854,15 @@
       (contains? assertions/dom-assertion-ids (first atom-v))
       (exec-assert-dom-atom! frame-id idx step atom-v)
 
-      ;; Browser-tier oracle family — route to the dedicated executor
-      ;; (rf2-9ikj0). a11y-structural runs at :hiccup; visual / a11y fail
-      ;; closed to :cannot-run headless. NEVER a no-op skip (which is what
-      ;; left the executor orphaned).
+      ;; Browser-tier oracle family — route to the dedicated executor.
+      ;; a11y-structural runs at :hiccup; visual / a11y fail closed to
+      ;; :cannot-run headless. NEVER a no-op skip.
       (contains? assertions/browser-assertion-ids (first atom-v))
       (exec-assert-browser-atom! frame-id idx step atom-v)
 
       ;; Tape-evaluated families carry no reg-event handler; the result
       ;; boundary owns their verdict. Record a no-op step-skip — never a
-      ;; dispatch (which would hit :rf.error/no-such-handler) (rf2-8y47c +
-      ;; rf2-fh7g4).
+      ;; dispatch (which would hit :rf.error/no-such-handler).
       (tape-evaluated-assertion? atom-v)
       (runner/step-skip idx step)
 
@@ -914,7 +896,7 @@
                 :else                 (runner/step-pass idx step))))))))
 
 (defn- queue-empty?
-  "True iff `frame-id`'s event queue has drained (rf2-5x1wt.17). Under a
+  "True iff `frame-id`'s event queue has drained. Under a
   settled-boundary runner the preceding `[:dispatch …]` step ran the
   router to a FIXED POINT (`settled-boundary` — the `dispatch-sync*`
   run-to-completion drain in headless), so by the time a following
@@ -930,8 +912,8 @@
 
 (defn- wait-until-satisfied?
   "Evaluate a decomposed `:wait-until` predicate against `frame-id`'s
-  current state (rf2-5x1wt.17). Pure-ish — reads the frame snapshot, no
-  dispatch. Returns a boolean."
+  current state. Pure-ish — reads the frame snapshot, no dispatch.
+  Returns a boolean."
   [frame-id {:keys [kind path mode expected pred-ref pred-fn?]}]
   (case kind
     :db          (let [db     (read-frame-db frame-id)
@@ -946,8 +928,8 @@
     false))
 
 (defn- exec-wait-until!
-  "Execute a `[:wait-until predicate-spec]` step (rf2-5x1wt.17) — the
-  DETERMINISTIC settle-on-condition. In headless the preceding
+  "Execute a `[:wait-until predicate-spec]` step — the DETERMINISTIC
+  settle-on-condition. In headless the preceding
   `[:dispatch …]` already drained to a fixed point, so the predicate is
   checked once synchronously: satisfied → step-skip (advance);
   unsatisfied → step-fail TIMING OUT READABLY with the unmet
@@ -975,8 +957,8 @@
   `:wait` is special-cased OUT of this fn — it requires an async
   yield (`setTimeout` / `Thread/sleep`) the driver schedules around.
 
-  rf2-5x1wt.19 — the runtime consumes the `.18`-folded plan: every script
-  is folded at resolution time (`runner-events/variant-plays` /
+  The runtime consumes the folded plan: every script is folded at
+  resolution time (`runner-events/variant-plays` /
   `play/variant-play-steps`), so a shipping `:assert-db` / `:assert-dom`
   step has already become the canonical `[:assert assertion-atom]`
   checkpoint by the time it reaches here. A raw `:assert-db` / `:assert-dom`
@@ -1001,16 +983,15 @@
       :wait           (runner/step-skip idx step)   ; driver handles the actual sleep
       (runner/unknown-step idx step))))
 
-;; ---- terminal assertions (rf2-nyjoa) -------------------------------------
+;; ---- terminal assertions ------------------------------------------------
 ;;
 ;; A variant's terminal `:assertions` are the handler-backed "check the
 ;; FINAL settled state" surface (spec/017 §Inline script assertions vs
 ;; terminal assertions): each is the SAME assertion atom an in-script
 ;; `[:assert …]` checkpoint wraps, but evaluated ONCE after the script
-;; phase has settled rather than at a mid-script point. Mike RULED B
-;; (rf2-nyjoa): they AUTO-RUN — they contribute `:pass` / `:fail` verdicts
-;; recorded as assertion-records on `:rf.story/assertions`, exactly like an
-;; in-script checkpoint.
+;; phase has settled rather than at a mid-script point. They AUTO-RUN —
+;; they contribute `:pass` / `:fail` verdicts recorded as assertion-records
+;; on `:rf.story/assertions`, exactly like an in-script checkpoint.
 ;;
 ;; This reuses the ONE in-script executor (`exec-assert!`) rather than a
 ;; parallel evaluator: each terminal atom is wrapped in its `[:assert …]`
@@ -1027,13 +1008,13 @@
 ;;     are NEVER dispatched — the result boundary owns their verdict against
 ;;     the epoch tape. So this path does NOT double-process the schema /
 ;;     causal kinds the plan collector already feeds to `result/run-result`'s
-;;     tape matchers (rf2-nyjoa critical guard — the `exec-assert!`
+;;     tape matchers (the critical guard — the `exec-assert!`
 ;;     `tape-evaluated-assertion?` branch is the single source of truth for
 ;;     that split).
 
 (defn run-terminal-assertions!
   "Evaluate `frame-id`'s terminal handler-backed `:assertions` against the
-  FINAL settled state, AFTER the script phase (rf2-nyjoa). `atoms` is the
+  FINAL settled state, AFTER the script phase. `atoms` is the
   plan's `[:expect :assertions]` vector — the bare assertion atoms
   (`[:rf.assert/id & args]`), the same atoms an in-script `[:assert …]`
   checkpoint wraps.
@@ -1059,16 +1040,14 @@
       (exec-assert! frame-id idx [:assert atom-v])))
   nil)
 
-;; ---- single-step driver (rf2-ee38b.3 — step-debugger re-base) ------------
+;; ---- single-step driver -------------------------------------------------
 ;;
 ;; The play step-debugger (`re-frame.story.ui.test-mode.stepper-state`)
-;; used to drive ONLY `:dispatch` / `:dispatch-sync` steps via the
-;; legacy `play/variant-play-events` projection — `:wait` / `:click` /
-;; `:type` / `:assert-db` / `:assert-dom` steps were silently dropped, so
-;; the stepper walked a TRUNCATED sequence with a wrong cursor/total and
-;; no assert outcomes. `run-step!` re-bases the stepper on the SAME rich-
-;; DSL executor the canvas auto-run path uses, so every step type runs in
-;; the debugger exactly as it does live.
+;; drives every rich-DSL step type via `run-step!`, which bases the stepper
+;; on the SAME executor the canvas auto-run path uses — so every step type
+;; (`:dispatch` / `:dispatch-sync` / `:wait` / `:click` / `:type` /
+;; `:assert-db` / `:assert-dom`) runs in the debugger exactly as it does
+;; live, with the right cursor/total and assert outcomes.
 
 (defn run-step!
   "Execute ONE coerced rich-DSL `step` (at index `idx`) against
@@ -1090,9 +1069,9 @@
                    (runner/step-exception idx step
                                           #?(:clj  (.getMessage ^Throwable e)
                                              :cljs (str e)))))]
-    ;; rf2-5x1wt.19 — `exec-step!` (via `exec-assert!`) already wrote the
-    ;; canonical assertion record onto `:rf.story/assertions`; no synthetic
-    ;; slot mirror here.
+    ;; `exec-step!` (via `exec-assert!`) already wrote the canonical
+    ;; assertion record onto `:rf.story/assertions`; no synthetic slot
+    ;; mirror here.
     (emit-trace! frame-id nil idx step result)
     result))
 
@@ -1108,31 +1087,31 @@
                (f)
                nil)))
 
-;; ---- assertion-slot recording (rf2-5x1wt.19) ----------------------------
+;; ---- assertion-slot recording -------------------------------------------
 ;;
-;; ONE assertion-record vocabulary. After the runtime consumes the `.18`-
-;; folded plan (`variant-plays` / `variant-play-steps` fold every script),
-;; every in-script assertion arrives as the canonical `[:assert
-;; assertion-atom]` checkpoint, and `exec-assert!` is the SOLE recorder:
+;; ONE assertion-record vocabulary. The runtime consumes the folded plan
+;; (`variant-plays` / `variant-play-steps` fold every script), so every
+;; in-script assertion arrives as the canonical `[:assert assertion-atom]`
+;; checkpoint, and `exec-assert!` is the SOLE recorder:
 ;;
 ;;   - a non-DOM `:rf.assert/*` atom dispatches its reg-event handler,
 ;;     which writes the canonical record onto `:rf.story/assertions`;
 ;;   - a DOM-family atom is evaluated by `exec-assert-dom-atom!`, which
 ;;     writes a canonical `:rf.assert/dom-*` record.
 ;;
-;; There is no longer a synthetic `:rf.assert/db` / `:rf.assert/dom` slot-
-;; mirror bridge: the folded checkpoint's OWN record IS the slot record, so
+;; There is no synthetic `:rf.assert/db` / `:rf.assert/dom` slot-mirror
+;; bridge: the folded checkpoint's OWN record IS the slot record, so
 ;; mirroring the step-result on top would double-count. `record-result!`
 ;; therefore only updates the run-state + emits the trace event; the slot
-;; write already happened inside `exec-assert!`. This is the move that
-;; collapsed the documented "false GREEN" — run-state and the
-;; `:rf.story/assertions` slot now derive from the ONE canonical record.
+;; write already happened inside `exec-assert!`. This is what keeps
+;; run-state and the `:rf.story/assertions` slot deriving from the ONE
+;; canonical record — closing the "false GREEN" hazard.
 
 (defn- record-result!
   "Append `result` to the run-state for `frame-id` and emit the per-step
   trace event. The `:rf.story/assertions` slot write already happened
-  inside `exec-assert!` (the canonical folded-atom record), so this no
-  longer mirrors a synthetic record on top (rf2-5x1wt.19)."
+  inside `exec-assert!` (the canonical folded-atom record), so this does
+  not mirror a synthetic record on top."
   [frame-id play-key name idx step result]
   (update-state! frame-id play-key runner/record-step-result result)
   (emit-trace! frame-id name idx step result)
@@ -1150,9 +1129,9 @@
 (defn- settle-abort!
   "Settle `done-cb` for a run-loop that ABORTED before finishing — the frame
   was torn down mid-run (run-state vanished) or a newer `run!` took over the
-  state slot (token mismatch, rf2-ftow6). rf2-9x5fm: every exit path of the
-  run loop MUST settle the awaiting continuation, otherwise the play-promise
-  (and the outer `run-variant` promise chained off it) hangs forever. The
+  state slot (token mismatch). Every exit path of the run loop MUST settle
+  the awaiting continuation, otherwise the play-promise (and the outer
+  `run-variant` promise chained off it) hangs forever. The
   abort is reachable on CLJS, where an async `:wait` yield gives a hot-reload
   reset / concurrent `run!` / teardown a window to mutate the shared
   run-state between steps.
@@ -1177,7 +1156,7 @@
 
   `done-cb` is invoked with the final run-state once the loop ends.
 
-  rf2-ftow6 (race fix): each call to `run!` stamps a unique
+  Each call to `run!` stamps a unique
   `:run-token` on the state map. The loop carries the token it started
   with and aborts if a fresh `run!` has overwritten the state with a
   newer token — that way a concurrent `runner-events/run!`
@@ -1188,28 +1167,27 @@
   Sync-class steps (`:dispatch-sync`, `:assert-db`, `:assert-dom`)
   recur synchronously; async-class steps (`:dispatch`, `:click`,
   `:type`, `:wait`) yield one tick so the queued effects drain before
-  the next step runs. The blanket setTimeout-0 between every step that
-  the original (rf2-8i2a9) implementation used was the source of the
-  re-mount race — see `runner/async-yield?`."
+  the next step runs. A blanket setTimeout-0 between every step would
+  reintroduce the re-mount race the async-class split avoids — see
+  `runner/async-yield?`."
   [frame-id play-key token done-cb]
   (let [state (current-state-for-play frame-id play-key)]
     (cond
       ;; abort if state has gone missing (frame torn down mid-run).
-      ;; rf2-9x5fm: still settle `done-cb` so the awaiting continuation
-      ;; advances and the play-promise (and the outer `run-variant`
-      ;; promise) resolves rather than hanging forever. We do NOT
-      ;; `finish!` here — the run-state slot is gone, so there is nothing
-      ;; to transition; we only release the continuation.
+      ;; Still settle `done-cb` so the awaiting continuation advances and
+      ;; the play-promise (and the outer `run-variant` promise) resolves
+      ;; rather than hanging forever. We do NOT `finish!` here — the
+      ;; run-state slot is gone, so there is nothing to transition; we only
+      ;; release the continuation.
       (nil? state)
       (settle-abort! frame-id play-key done-cb)
 
       ;; abort if a newer run! has taken over the state slot — the
       ;; newer loop owns continuation now, so the stale loop bails
-      ;; rather than racing it. rf2-ftow6. rf2-9x5fm: the stale loop
-      ;; must STILL settle ITS OWN `done-cb` (the continuation/promise
-      ;; for THIS run) so it does not strand the chain — but via
-      ;; `settle-abort!` (no `update-state!`), so it never clobbers the
-      ;; newer run's run-state slot.
+      ;; rather than racing it. The stale loop must STILL settle ITS OWN
+      ;; `done-cb` (the continuation/promise for THIS run) so it does not
+      ;; strand the chain — but via `settle-abort!` (no `update-state!`),
+      ;; so it never clobbers the newer run's run-state slot.
       (and token (some? (:run-token state)) (not= token (:run-token state)))
       (settle-abort! frame-id play-key done-cb)
 
@@ -1238,8 +1216,7 @@
             (record-result! frame-id play-key nm idx step result)
             ;; Sync-class step → recur synchronously so the next step
             ;; observes the just-committed effects atomically (the
-            ;; legacy `execute-play!`/`doseq` semantics rf2-ftow6
-            ;; restores).
+            ;; `doseq`-style sequential semantics).
             ;;
             ;; Async-class step → yield one tick on CLJS so the
             ;; queued router work / synthetic DOM event handlers drain
@@ -1266,11 +1243,11 @@
   takes over the run-state slot).
 
   Arities:
-  - `[variant-id]`                — run the default play (rf2-tl7zk:
-                                    the first play of `:plays`, or the
-                                    single `:play-script`).
+  - `[variant-id]`                — run the default play (the first
+                                    play of `:plays`, or the single
+                                    `:play-script`).
   - `[variant-id done-cb]`        — as above + completion callback.
-  - `[variant-id play-key spec done-cb]` — rf2-tl7zk multi-play form:
+  - `[variant-id play-key spec done-cb]` — multi-play form:
                                     drive a specific play. `play-key`
                                     is the play's `:name` string (or
                                     nil for the single-script case);
@@ -1280,7 +1257,7 @@
                                     map. `{:clear-boundaries? false}`
                                     SUPPRESSES the per-run settle-boundary
                                     reset, for a caller SEQUENCING several
-                                    plays against one frame (rf2-76l69l):
+                                    plays against one frame:
                                     the sequencer clears ONCE up front and
                                     each subsequent play APPENDS its
                                     absolute boundaries, so the
@@ -1299,41 +1276,39 @@
                                       :or   {clear-boundaries? true}}]
    (let [spec  (or spec
                    (resolve-play variant-id play-key)
-                   ;; Fall back to the legacy single-script path so the
-                   ;; default play of a `:play-script` variant Just Works.
+                   ;; Fall back to the single-script path so the default
+                   ;; play of a `:play-script` variant Just Works.
                    (variant-play-script variant-id))
          pk    (or play-key (:name spec))
          init  (runner/initial-state spec)
-         ;; rf2-ftow6: stamp a fresh token on every run. The loop
-         ;; reads it back from the state map; if a concurrent run!
-         ;; replaces the state mid-loop, the stale loop sees a
-         ;; mismatched token and aborts before re-dispatching.
+         ;; Stamp a fresh token on every run. The loop reads it back from
+         ;; the state map; if a concurrent run! replaces the state mid-loop,
+         ;; the stale loop sees a mismatched token and aborts before
+         ;; re-dispatching.
          token   #?(:clj (java.util.UUID/randomUUID)
                     :cljs (.toString (js/Math.random)))
          started (-> (runner/start init (now-ms))
                      (assoc :run-token token))]
-     ;; rf2-vkdam — reset the per-dispatch-step settle boundaries here, in the
-     ;; SAME public entry that resets run-state and then writes boundaries via
-     ;; `run-loop!`/`record-settle-boundary!`. Previously only the orchestrator
-     ;; (`runtime/run-phase-4!`) cleared, so an interactive re-run / replay-in-
-     ;; place driving `run!` directly accumulated boundaries until teardown.
-     ;; Owning the reset alongside the write keeps the attribution windowed
-     ;; onto THIS run's epoch tape. The leading-nil-span semantics still hold:
-     ;; the boundaries snapshot the ABSOLUTE epoch-history length, so any setup
-     ;; epochs already on the tape precede the first boundary (in the
-     ;; orchestrator path setup runs in phase-2, before phase-4 drives `run!`).
+     ;; Reset the per-dispatch-step settle boundaries here, in the SAME
+     ;; public entry that resets run-state and then writes boundaries via
+     ;; `run-loop!`/`record-settle-boundary!`. Owning the reset alongside the
+     ;; write keeps the attribution windowed onto THIS run's epoch tape. The
+     ;; leading-nil-span semantics hold: the boundaries snapshot the ABSOLUTE
+     ;; epoch-history length, so any setup epochs already on the tape precede
+     ;; the first boundary (in the orchestrator path setup runs in phase-2,
+     ;; before phase-4 drives `run!`).
      ;;
-     ;; rf2-76l69l — a MULTI-PLAY sequencer (`run-plays-sequentially!`, the
-     ;; orchestrator `runtime/run-phase-4!`) passes `:clear-boundaries? false`
-     ;; for the 2nd…Nth play so the boundaries ACCUMULATE across the whole
-     ;; auto-run sequence. The narrative spans the CONCATENATED script
+     ;; A MULTI-PLAY sequencer (`run-plays-sequentially!`, the orchestrator
+     ;; `runtime/run-phase-4!`) passes `:clear-boundaries? false` for the
+     ;; 2nd…Nth play so the boundaries ACCUMULATE across the whole auto-run
+     ;; sequence. The narrative spans the CONCATENATED script
      ;; (`(mapcat :script auto-plays)`), and the epoch tape is append-only
      ;; across the run (no per-play reset), so each play's absolute boundaries
      ;; tail the previous play's — keeping the positional zip in `stamp-tape`
-     ;; aligned. Clearing per-play (the old behaviour) dropped every earlier
-     ;; play's boundaries, leaving only the LAST play's absolute boundaries to
-     ;; be mis-zipped against the concatenated script's leading dispatch steps
-     ;; — a false-green evidence-provenance failure.
+     ;; aligned. Clearing per-play would drop every earlier play's boundaries,
+     ;; leaving only the LAST play's absolute boundaries to be mis-zipped
+     ;; against the concatenated script's leading dispatch steps — a
+     ;; false-green evidence-provenance failure.
      (when clear-boundaries?
        (clear-step-boundaries! variant-id))
      (set-state! variant-id pk started)
@@ -1346,9 +1321,9 @@
   `run!` — distinct fn name so the toolbar's `[Re-run]` button has a
   one-call API.
 
-  rf2-tl7zk: with no explicit `play-key`, re-runs the currently active
-  play (set by the dropdown). For single-script variants the active
-  play is nil, so this matches the legacy behaviour."
+  With no explicit `play-key`, re-runs the currently active play (set by
+  the dropdown). For single-script variants the active play is nil, so
+  this re-runs the single script."
   ([variant-id]
    (re-run! variant-id nil))
   ([variant-id done-cb]
@@ -1356,8 +1331,8 @@
      (run! variant-id pk nil done-cb))))
 
 (defn run-play!
-  "rf2-tl7zk multi-play: run the play identified by `play-key` (a
-  play's `:name`) for `variant-id`. Passing nil picks the default
+  "Run the play identified by `play-key` (a play's `:name`) for
+  `variant-id` (multi-play). Passing nil picks the default
   play (first entry for multi-play, the single script for
   `:play-script`)."
   ([variant-id play-key]
@@ -1366,9 +1341,9 @@
    (run! variant-id play-key nil done-cb)))
 
 (defn select-play!
-  "rf2-tl7zk: set `variant-id`'s active play to `play-key` WITHOUT
-  running it. Used by the toolbar dropdown when the user picks a play
-  but the user hasn't pressed Re-run yet."
+  "Set `variant-id`'s active play to `play-key` WITHOUT running it. Used
+  by the toolbar dropdown when the user picks a play but hasn't pressed
+  Re-run yet."
   [variant-id play-key]
   (set-active-play! variant-id play-key))
 
@@ -1379,8 +1354,8 @@
   after the variant mounts. No-op when the variant has no
   `:play-script` / `:plays` slot or no play declares `:auto-run? true`.
 
-  rf2-tl7zk multi-play: every play with `:auto-run? true` is run in
-  ORDER (sequentially) so they don't race against the same frame. By
+  Multi-play: every play with `:auto-run? true` is run in ORDER
+  (sequentially) so they don't race against the same frame. By
   the per-play default (first play true, rest false) only the first
   play auto-runs on mount; subsequent plays opt in explicitly."
   ([variant-id]
@@ -1393,8 +1368,8 @@
          (empty? auto-plays)
          nil
 
-         ;; Single auto-run play — direct fire so the legacy
-         ;; single-script callers keep their existing run shape.
+         ;; Single auto-run play — direct fire so the single-script
+         ;; callers keep their run shape.
          (= 1 (count auto-plays))
          (let [spec (first auto-plays)]
            (run! variant-id (:name spec) spec done-cb))
@@ -1404,21 +1379,21 @@
          :else
          (run-plays-sequentially! variant-id auto-plays done-cb))))))
 
-;; ---- run-all (sequential) — rf2-tl7zk ------------------------------------
+;; ---- run-all (sequential) -----------------------------------------------
 
 (defn- run-plays-sequentially!
   "Internal: run `plays` against `variant-id` one after another.
   Resolves `done-cb` with a vector of terminal states once every play
   has finished (or the loop is interrupted by a missing frame).
 
-  rf2-76l69l — clears the per-dispatch-step settle boundaries ONCE up
-  front, then drives each play with `:clear-boundaries? false` so the
-  boundaries ACCUMULATE across the sequence. The evidence narrative spans
-  the CONCATENATED play scripts, and the epoch tape is append-only across
+  Clears the per-dispatch-step settle boundaries ONCE up front, then
+  drives each play with `:clear-boundaries? false` so the boundaries
+  ACCUMULATE across the sequence. The evidence narrative spans the
+  CONCATENATED play scripts, and the epoch tape is append-only across
   the run, so each play's absolute boundaries must tail the previous
   play's for the positional `stamp-tape` zip to stay aligned. Letting each
-  `run!` clear (the old behaviour) left only the last play's boundaries,
-  mis-attributing later-play effects to earlier-play steps."
+  `run!` clear would leave only the last play's boundaries, mis-attributing
+  later-play effects to earlier-play steps."
   [variant-id plays done-cb]
   (let [acc (atom [])]
     (clear-step-boundaries! variant-id)
@@ -1437,8 +1412,8 @@
       (step! plays))))
 
 (defn run-all-plays!
-  "rf2-tl7zk multi-play: run every play declared on `variant-id` in
-  order, sequentially. Calls `done-cb` with a vector of per-play
+  "Run every play declared on `variant-id` in order, sequentially
+  (multi-play). Calls `done-cb` with a vector of per-play
   terminal states once every play has completed. Returns nil.
 
   No-op when the variant carries no plays."
@@ -1449,7 +1424,7 @@
      (when (seq plays)
        (run-plays-sequentially! variant-id (vec plays) done-cb)))))
 
-;; ---- step-debugger seam (rf2-ee38b.3) ------------------------------------
+;; ---- step-debugger seam -------------------------------------------------
 ;;
 ;; `play.cljc` owns the step-debugger substrate but cannot `:require`
 ;; this ns (the cycle: runner-events → play). It fetches `run-step!` via
@@ -1458,8 +1433,8 @@
 
 (late-bind/set-fn! :run-play-step run-step!)
 
-;; rf2-vkdam — the stepper appends a settle boundary per `run-step!`, so a
-;; fresh stepping session (`play/begin-stepper!`) must reset the frame's
+;; The stepper appends a settle boundary per `run-step!`, so a fresh
+;; stepping session (`play/begin-stepper!`) must reset the frame's
 ;; boundaries first — the stepper analogue of `run!`'s reset. Exposed via the
 ;; same late-bind seam since `play.cljc` cannot `:require` this ns.
 

--- a/tools/story/src/re_frame/story/play/settled_boundary.cljc
+++ b/tools/story/src/re_frame/story/play/settled_boundary.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.story.play.settled-boundary
   "The `settled-boundary` contract — the single name for what
   `[:dispatch event-vector]` waits for before the runner advances to the
-  next script step (NewTestStory rf2-5x1wt.2, spec/017-Testing-Story.md
+  next script step (spec/017-Testing-Story.md
   §Script and `settled-boundary` + §Shared primitive lock).
 
   ## What a settled boundary is
@@ -52,9 +52,8 @@
   `headless-flush-hooks` is the default the JVM / node-runtime headless
   runner uses: `:provides :headless`, `:dispatch!` and the `:headless`
   flush both routed through `re-frame.core/dispatch-sync*` so a queued
-  `[:dispatch …]` step settles to fixed point synchronously — the
-  behaviour the legacy `:dispatch` step approximated with a `setTimeout`
-  yield, now named and deterministic.
+  `[:dispatch …]` step settles to fixed point synchronously, named and
+  deterministic.
 
   Adapter-aware callers (the Reagent/UIx/Helix shell, a future `:dom`
   browser runner) register richer hooks declaring a higher `:provides`
@@ -193,11 +192,11 @@
   `dispatch-sync` issued from inside a running drain surfaces
   `:rf.error/dispatch-sync-in-handler` through the trace bus, as usual).
 
-  rf2-l2cn5d (EP-0017): the optional 3-arity `(drain-sync! frame-id
-  event-vector opts)` merges caller-supplied dispatch opts (e.g. a
-  captured `{:rf.cofx <map>}` envelope) over `{:frame frame-id}` so a
-  replayed `[:dispatch evec {:rf.cofx …}]` step re-presents its recorded
-  recordable coeffects. The 2-arity is the pre-EP-0017 bare path."
+  The optional 3-arity `(drain-sync! frame-id event-vector opts)` merges
+  caller-supplied dispatch opts (e.g. a captured `{:rf.cofx <map>}`
+  envelope) over `{:frame frame-id}` so a replayed `[:dispatch evec
+  {:rf.cofx …}]` step re-presents its recorded recordable coeffects. The
+  2-arity is the bare path with no captured opts."
   ([frame-id event-vector]
    (drain-sync! frame-id event-vector nil))
   ([frame-id event-vector opts]
@@ -292,9 +291,9 @@
    (dispatch-and-settle! frame-id event-vector hooks required nil))
   ([frame-id event-vector hooks required step]
    (dispatch-and-settle! frame-id event-vector hooks required step nil))
-  ;; rf2-l2cn5d (EP-0017): the 6-arity threads `dispatch-opts` (e.g. a
-  ;; captured `{:rf.cofx <map>}` envelope) into the dispatch! hook so a
-  ;; replayed step re-presents its recorded recordable coeffects.
+  ;; The 6-arity threads `dispatch-opts` (e.g. a captured `{:rf.cofx <map>}`
+  ;; envelope) into the dispatch! hook so a replayed step re-presents its
+  ;; recorded recordable coeffects.
   ([frame-id event-vector hooks required step dispatch-opts]
    (let [required (if (boundary? required) required :headless)
          provided (hooks-provided-boundary hooks)]
@@ -314,14 +313,13 @@
                ;; a no-op; the richer flushes carry the adapter's reactive /
                ;; DOM work.
                levels     (take-while #(boundary>= required %) boundary-levels)
-               ;; rf2-l2cn5d (EP-0017): a replayed `[:dispatch evec {:rf.cofx …}]`
-               ;; step carries a captured recordable-coeffect envelope. The
-               ;; caller (`exec-dispatch!`) extracts it off the step and passes
-               ;; it as `dispatch-opts`; thread it into the dispatch opts (via
-               ;; the hook's optional 3-arity) so the handler's declared
-               ;; recordable coeffects replay from the recorded value rather than
-               ;; being restamped. Absent cofx uses the bare 2-arity call (the
-               ;; pre-EP-0017 hook contract, unchanged).
+               ;; A replayed `[:dispatch evec {:rf.cofx …}]` step carries a
+               ;; captured recordable-coeffect envelope. The caller
+               ;; (`exec-dispatch!`) extracts it off the step and passes it as
+               ;; `dispatch-opts`; thread it into the dispatch opts (via the
+               ;; hook's optional 3-arity) so the handler's declared recordable
+               ;; coeffects replay from the recorded value rather than being
+               ;; restamped. Absent cofx uses the bare 2-arity call.
                ]
            (if (and (map? dispatch-opts) (seq dispatch-opts))
              (dispatch! frame-id event-vector dispatch-opts)
@@ -338,7 +336,7 @@
                ;; it returns. Checking here — not only at the top of the next
                ;; iteration — means an over-budget terminal flush refuses with
                ;; a fail-closed `:flush-timeout` instead of a settled pass it
-               ;; did not earn (rf2-65bnwl).
+               ;; did not earn.
                (and deadline (> (interop/now-ms) deadline))
                (flush-timeout-result required provided step)
 

--- a/tools/story/src/re_frame/story/predicates.cljc
+++ b/tools/story/src/re_frame/story/predicates.cljc
@@ -7,10 +7,10 @@
   Companion leaf to `re-frame.story.late-bind` (run-time function
   resolution) — both are pure namespaces the rest of Story consumes.
 
-  The five micro-fns here used to live as private mirrors across
-  ~9 sites (args / assertions / recorder / docs / state / test-mode/pure).
-  Each mirror was justified locally by a cycle dodge, but the systemic
-  shape is one canonical leaf. See rf2-pzzbw / audit rf2-cgqam."
+  The five micro-fns here are the single canonical home for helpers the
+  rest of the tree consumes (args / assertions / recorder / docs / state /
+  test-mode/pure), so each cycle-sensitive consumer requires one leaf
+  rather than carrying a private mirror."
   (:require [clojure.string :as str]))
 
 (def reserved-assertion-ns
@@ -21,7 +21,7 @@
 (def assertion-glyph
   "Canonical assertion-outcome glyph map — the single source of truth for
   the three assertion verdicts shared by the assertion strip, the test-
-  mode result table, and the step-through scrubber (rf2-8fr3yd). `:skip`
+  mode result table, and the step-through scrubber. `:skip`
   is an assertion-level verdict distinct from `theme.status/:cannot-run`
   (which is a runner-tier status), so it is NOT a `theme.status` descriptor
   — this is the assertion vocabulary, not the tool-wide status vocabulary.
@@ -78,7 +78,7 @@
       ;; => \"   :script [item1\\n             item2]\"
       ;;                    ^---------- item2 aligns under item1
 
-  Lives in the predicates leaf (rf2-ar0t9) so producers
+  Lives in the predicates leaf so producers
   (recorder / save-variant) don't have to `:require` the consumer
   (review-dialog) just for this 4-line helper."
   [prefix]
@@ -94,9 +94,9 @@
   assembles `body-str` (Shape-A builders via `reg-variant-form` below;
   play-export / view-state / schema-form via their own body shape).
 
-  Byte-identical to the hand-rolled envelope the builders previously
-  carried (rf2-8fr3yd). Builders that derive a default id or alias resolve
-  those at the call site and pass the resolved values in."
+  Emits the exact envelope every codegen builder shares. Builders that
+  derive a default id or alias resolve those at the call site and pass the
+  resolved values in."
   [alias variant-id body-str]
   (str "(" alias "/reg-variant "
        (pr-str variant-id)
@@ -117,9 +117,8 @@
                                                   [:args \"{}\"]])
       ;; => \"(story/reg-variant :story.saved/x\\n  {:extends :story/a\\n   :args {}})\"
 
-  Byte-identical to the hand-rolled builders (rf2-8fr3yd). Lives in the
-  predicates leaf so every producer can `:require` it without cycle risk
-  (they already `:require` `indent-after` from here)."
+  Lives in the predicates leaf so every producer can `:require` it
+  without cycle risk (they already `:require` `indent-after` from here)."
   [alias variant-id body-keys]
   (reg-variant-envelope
     alias variant-id
@@ -141,12 +140,12 @@
   path is to pass the predicate as a FN DIRECTLY in the
   `:wait-until [:db path :pred <fn>]` predicate (or the `:assert-db …
   :pred <fn>` form, which folds to `:rf.assert/path-matches [:fn fn]`); the
-  resolver is only reached for the symbol escape-hatch (rf2-inbad).
+  resolver is only reached for the symbol escape-hatch.
 
   Shared by `assertions/resolve-fn-schema` (the `[:fn sym]` schema fold)
   and `runner-events/exec-wait-until` (the `:pred sym` form). Lives in this
   leaf so `assertions` resolves a symbol pred at validation time without a
-  require into the impure `runner-events` ns (rf2-le0p4 dedup)."
+  require into the impure `runner-events` ns."
   [sym]
   (when sym
     (try

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -1,15 +1,14 @@
 (ns re-frame.story.recorder
   "Test Codegen — record canvas-dispatched events as a `:script` body.
 
-  Per bead rf2-5fc15: Storybook 9's killer feature is the record-and-save
-  workflow — the user interacts with the canvas, the tool watches the
-  event bus, and on 'stop' it emits a code snippet the user appends to
-  a new variant. The emitted snippet uses the PUBLIC `:script` authoring
-  slot (rf2-7mj4z — the recorder emits the public spelling, not the
-  transitional `:play-script`); the `:script` body wraps each captured
-  event vector as a `[:dispatch-sync <event-vec>]` step (rf2-0wrud), so
-  the captured trace is the codegen output verbatim — no Testing Library /
-  page-object translation layer is needed.
+  Storybook 9's killer feature is the record-and-save workflow — the user
+  interacts with the canvas, the tool watches the event bus, and on 'stop'
+  it emits a code snippet the user appends to a new variant. The emitted
+  snippet uses the PUBLIC `:script` authoring slot (the recorder emits the
+  public spelling); the `:script` body wraps each captured event vector as
+  a `[:dispatch-sync <event-vec>]` step, so the captured trace is the
+  codegen output verbatim — no Testing Library / page-object translation
+  layer is needed.
 
   ## What this namespace does
 
@@ -37,13 +36,12 @@
   - The listener consults `recording?` per emit — toggling off STOPS
     recording without tearing down anything else.
 
-  ## `:sensitive?` events — record-but-redact (rf2-hdadz)
+  ## `:sensitive?` events — record-but-redact
 
-  Per rf2-hdadz (pragmatic stance, 2026-05-14): events flagged
-  `:sensitive? true` are STILL captured into the `:play-script` body, but the
-  event payload is replaced with the framework's `:rf/redacted`
-  sentinel so the credential / PII / auth-token doesn't ride into the
-  snippet text. Mirrors rf2-vnjfg's enforcement on the always-on
+  Events flagged `:sensitive? true` are STILL captured into the
+  `:play-script` body, but the event payload is replaced with the
+  framework's `:rf/redacted` sentinel so the credential / PII / auth-token
+  doesn't ride into the snippet text. This mirrors the always-on
   error-emit path — record-but-redact, don't refuse-to-record. Two
   reasons:
 
@@ -66,19 +64,18 @@
   opt into the trusted-local boundary via
   `(story/configure! {:rf.story/egress-profile :rf.egress/local-raw})`;
   with that profile active the listener captures the verbatim event
-  vector (existing behaviour, unchanged).
+  vector.
 
-  ## EP-0015 fold (rf2-3t26eh)
+  ## EP-0015 egress profile
 
-  The whole-event `:sensitive?` redact/pass decision above is now driven
-  by Story's local-render EGRESS PROFILE — `:rf.egress/local-redacted`
+  The whole-event `:sensitive?` redact/pass decision above is driven by
+  Story's local-render EGRESS PROFILE — `:rf.egress/local-redacted`
   (the fail-closed default) redacts; `:rf.egress/local-raw` (the
   trusted-local opt-in) passes — resolved through the framework's
   centralized projection table (`config/suppress-sensitive?` →
   `project-egress`'s `:rf.size/include-sensitive?` floor), NOT a
-  process-global boolean. EP-0015 retired the cross-tool
-  `:rf.privacy/show-sensitive?` toggle (rf2-bclgj) in favour of this
-  named-boundary, frame-owned model.
+  process-global boolean. EP-0015 defines this named-boundary,
+  frame-owned model.
 
   ## Pure / impure split
 
@@ -88,7 +85,7 @@
   Reagent / toolbar UI surface live in `re-frame.story.ui.recorder`
   (CLJS-only).
 
-  ## Mid-recording assertion insertion (rf2-39u9e)
+  ## Mid-recording assertion insertion
 
   Recording captures user dispatches. Assertions are the dual — the
   user wants to say 'after I click this button, the counter shows 3'.
@@ -127,8 +124,8 @@
             [re-frame.story.config :as config]
             [re-frame.story.predicates :as pred]
             [re-frame.story.review-dialog :as review-dialog]
-            ;; rf2-qwm0a — listener surface lives in
-            ;; `re-frame.trace.tooling` (production-DCE split).
+            ;; The listener surface lives in `re-frame.trace.tooling`
+            ;; (production-DCE split).
             [re-frame.trace.tooling :as trace-tooling]))
 
 ;; ---------------------------------------------------------------------------
@@ -165,8 +162,8 @@
 (def ^:const redacted-event
   "The placeholder event vector the recorder appends in place of a
   `:sensitive? true` event when the local-render profile redacts (the
-  `:rf.egress/local-redacted` default, EP-0015 rf2-3t26eh). Per rf2-hdadz:
-  record-but-redact preserves the row's temporal position in the captured
+  `:rf.egress/local-redacted` default, EP-0015). Record-but-redact
+  preserves the row's temporal position in the captured
   `:play-script` body without leaking the
   credential / PII / auth-token. The single-element vector keeps the
   captured-events shape (vector-of-event-vectors) intact so the snippet
@@ -180,49 +177,46 @@
 ;; A recording targets a FRAME (EP-0023)
 ;;
 ;; A recording's address is the variant FRAME it was captured against
-;; (`:variant-id`). EP-0023 collapses the old EP-0013 public `(realm, frame)`
-;; address to that single frame target: a recording carries no separate realm
-;; key, and replay dispatches frame-scoped (`{:frame variant-id}`), so it lands
-;; in the frame's own running environment by construction. Realm survives only
-;; as the framework's INTERNAL installation substrate (EP-0023 §Public surface)
-;; — Story neither stamps it on a recording nor carries it on the replay
-;; address. The captured state map is therefore the bare
+;; (`:variant-id`). Per EP-0023 that single frame target IS the address: a
+;; recording carries no separate realm key, and replay dispatches
+;; frame-scoped (`{:frame variant-id}`), so it lands in the frame's own
+;; running environment by construction. Realm is purely the framework's
+;; INTERNAL installation substrate (EP-0023 §Public surface) — Story
+;; neither stamps it on a recording nor carries it on the replay address.
+;; The captured state map is therefore the bare
 ;; `{:recording? :variant-id :events :cofx :entries :started-ms}` shape.
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: dispatch-only code-gen — `(reg-variant ... :script {...})` snippet
 ;;
-;; NOTE (rf2-nkjkj): this is the LEGACY dispatch-only codegen. It reads
-;; the bare `:events` stream, so it sees dispatched events + inserted
-;; assertions ONLY — it is BLIND to DOM interactions (which live in
-;; `:entries`). The interactive recorder's PRIMARY save dialog no longer
-;; uses this path; it renders the rich `:play-script` translation off
-;; `:entries` (`recorder.play-export/recording->script-body` +
-;; `render-variant-form`) so canvas clicks/types/submits are never
-;; dropped. `gen-play-snippet` survives ONLY as the codegen for the MCP
+;; This is the dispatch-only codegen. It reads the bare `:events` stream,
+;; so it sees dispatched events + inserted assertions ONLY — it is BLIND
+;; to DOM interactions (which live in `:entries`). The interactive
+;; recorder's PRIMARY save dialog renders the rich `:play-script`
+;; translation off `:entries` (`recorder.play-export/recording->script-body`
+;; + `render-variant-form`) so canvas clicks/types/submits are never
+;; dropped. `gen-play-snippet` is the codegen for the MCP
 ;; `record-as-variant` record-and-sleep flow, whose capture path produces
-;; no DOM entries (so the dispatch-only view is complete there) and for
+;; no DOM entries (so the dispatch-only view is complete there), and for
 ;; the `story/gen-play-snippet` public re-export.
 ;;
-;; rf2-7mj4z: `gen-play-snippet` emits the PUBLIC `:script` authoring slot
-;; (spec/017 §Public vocabulary), NOT the transitional `:play-script`
-;; spelling. It wraps each captured event vector as a `[:dispatch-sync
-;; <event-vec>]` step under the `:script` body's inner `:script` vector
-;; (rf2-0wrud — the one phase-4 step grammar). Assertion events
+;; `gen-play-snippet` emits the PUBLIC `:script` authoring slot
+;; (spec/017 §Public vocabulary). It wraps each captured event vector as a
+;; `[:dispatch-sync <event-vec>]` step under the `:script` body's inner
+;; `:script` vector (the one phase-4 step grammar). Assertion events
 ;; (`:rf.assert/*`) ride the same dispatch-sync rail — the assertion
 ;; handler is registered, so dispatch-sync runs it and the result lands
-;; in `:rf.story/assertions` exactly as it did under the legacy `:play` slot.
+;; in `:rf.story/assertions` like any other assertion checkpoint.
 ;; ---------------------------------------------------------------------------
 
 (defn- event->step
-  "Wrap a captured event vector as a `:play-script` step. Per
-  rf2-0wrud the canonical wrapping is `:dispatch-sync` — preserves the
-  legacy `:play`'s drain-to-completion ordering and lets `:rf.assert/*`
-  events record on the very next step.
+  "Wrap a captured event vector as a `:play-script` step. The canonical
+  wrapping is `:dispatch-sync` — it drains to completion in declared
+  order and lets `:rf.assert/*` events record on the very next step.
 
   The 2-arity `(event->step event-vec cofx)` carries a captured flat
-  `:rf.cofx` map (rf2-l2cn5d, EP-0017) onto the step as a trailing opts
+  `:rf.cofx` map (EP-0017) onto the step as a trailing opts
   map — `[:dispatch-sync evec {:rf.cofx <map>}]` — so a pasted /
   written-back snippet replays the recorded recordable coeffects
   (provided facts + the framework `:rf/time-ms`) rather than restamping.
@@ -241,7 +235,7 @@
   the PUBLIC phase-4 authoring slot (spec/017 §Public vocabulary); the
   recorder emits the public spelling so pasted code reads the way the
   docs teach. Each captured event vector is wrapped as
-  `[:dispatch-sync <event-vec>]` inside the script body (rf2-0wrud — the
+  `[:dispatch-sync <event-vec>]` inside the script body (the
   one phase-4 step grammar).
 
   Opts:
@@ -254,7 +248,7 @@
       :alias       optional — short alias to use in the form
                               (default `\"story\"`)
       :cofx        optional — a parallel vector of captured flat
-                              `:rf.cofx` maps (rf2-l2cn5d, EP-0017),
+                              `:rf.cofx` maps (EP-0017),
                               index-aligned with `events`. Non-empty
                               entries render as `[:dispatch-sync evec
                               {:rf.cofx …}]` so a pasted snippet replays
@@ -286,8 +280,8 @@
                                        (map pr-str steps))
                              "]")
                         "[]")
-        ;; The public `:script` slot accepts the same `{:script …
-        ;; :auto-run?}` PlaySpec map the transitional `:play-script` took.
+        ;; The public `:script` slot accepts a `{:script …
+        ;; :auto-run?}` PlaySpec map.
         script-map-str (str "{:auto-run? true\n"
                             "                     :script    " script-str "}")
         body-keys   (cond-> []
@@ -433,7 +427,7 @@
           (map (fn [{:keys [key]}] (get payload key)) fields))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-d5u89 — timestamp + entry helpers (used by both append /
+;; Timestamp + entry helpers (used by both append /
 ;; append-assertion / append-dom). Defined here so the forward
 ;; references resolve cleanly.
 ;; ---------------------------------------------------------------------------
@@ -462,7 +456,7 @@
   event if no recording is in flight) and against malformed inputs
   (must be a vector with an `:rf.assert/*` keyword head).
 
-  Per rf2-d5u89 the assertion also lands in the parallel `:entries`
+  The assertion also lands in the parallel `:entries`
   stream as an `:event/dispatch` entry tagged with the current
   timestamp, so the `:play-script` translator (which consumes
   `:entries`) sees the inserted assertion alongside the captured
@@ -477,7 +471,7 @@
           (vector? event)
           (pred/assertion-event? event))
      (-> (update :events (fnil conj []) (vec event))
-         ;; rf2-l2cn5d: keep the parallel :cofx slot index-aligned with
+         ;; Keep the parallel :cofx slot index-aligned with
          ;; :events — an inserted assertion carries no captured cofx.
          (update :cofx (fnil conj []) nil)
          (conj-entry {:kind  :event/dispatch
@@ -488,7 +482,7 @@
   "The recorder's idle state shape. `:recording?` flips true while a
   capture is in flight; `:events` accumulates the captured event
   vectors in declared order (oldest first, ready for `gen-play-snippet`
-  to wrap as `:play-script` `:dispatch-sync` steps); `:entries` (rf2-d5u89) accumulates the richer
+  to wrap as `:play-script` `:dispatch-sync` steps); `:entries` accumulates the richer
   per-entry maps (`:event/dispatch` + `:dom/click` / `:dom/type` /
   `:dom/submit`) with per-event timestamps — consumed by the
   `:play-script` translator; `:variant-id` records which frame the
@@ -501,7 +495,7 @@
   {:recording? false
    :variant-id nil
    :events     []
-   ;; rf2-l2cn5d (EP-0017): the captured flat `:rf.cofx` map per event,
+   ;; EP-0017: the captured flat `:rf.cofx` map per event,
    ;; index-aligned with `:events` (nil where the event carried no
    ;; recordable coeffects). The bare-`:events` MCP path zips this in.
    :cofx       []
@@ -557,24 +551,23 @@
   {:recording? true
    :variant-id variant-id
    :events     []
-   ;; rf2-l2cn5d (EP-0017): parallel captured-cofx slot, index-aligned
+   ;; EP-0017: parallel captured-cofx slot, index-aligned
    ;; with :events.
    :cofx       []
    :entries    []
    :started-ms now-ms})
 
 ;; ---------------------------------------------------------------------------
-;; rf2-d5u89 — per-event timestamps + DOM-event entries
+;; Per-event timestamps + DOM-event entries
 ;;
-;; The original recorder model carried `:events` (a vector of event
-;; vectors) — sufficient for a dispatch-only codegen which wraps each
-;; as a `:dispatch-sync` step, but blind to TIMING and DOM INTERACTION
-;; which the rich `:play-script` DSL needs to emit `:click` / `:type` /
-;; `:wait` steps.
+;; The recorder carries `:events` (a vector of event vectors) for the
+;; dispatch-only codegen which wraps each as a `:dispatch-sync` step, and
+;; `:entries` for TIMING and DOM INTERACTION which the rich `:play-script`
+;; DSL needs to emit `:click` / `:type` / `:wait` steps.
 ;;
-;; `:entries` is the recorder's SINGLE SOURCE OF TRUTH for codegen
-;; (rf2-nkjkj): the primary save dialog renders the `:play-script`
-;; translation off this stream. Each entry is one of:
+;; `:entries` is the recorder's SINGLE SOURCE OF TRUTH for codegen:
+;; the primary save dialog renders the `:play-script` translation off
+;; this stream. Each entry is one of:
 ;;
 ;;   {:kind :event/dispatch :event <vec> :t <ms>}
 ;;   {:kind :dom/click      :selector <str> :t <ms>}
@@ -586,10 +579,10 @@
 ;; assertion`), but DOM interactions (via `append-dom`) land in
 ;; `:entries` ONLY — `:events` never sees them. The two streams are
 ;; therefore NOT index-aligned the moment any DOM event is captured;
-;; `:entries` carries strictly >= the rows `:events` does. `:events`
-;; survives as the bare-dispatch view consumed by the legacy MCP
-;; record-and-sleep codegen (`gen-play-snippet`), whose capture path
-;; never produces DOM entries, so the asymmetry is invisible there.
+;; `:entries` carries strictly >= the rows `:events` does. `:events` is
+;; the bare-dispatch view consumed by the MCP record-and-sleep codegen
+;; (`gen-play-snippet`), whose capture path never produces DOM entries, so
+;; the asymmetry is invisible there.
 ;;
 ;; `:t` is ms since `:started-ms`; pure helpers accept a `now-ms`
 ;; argument for deterministic testing. (Helper fns `now-ms*`,
@@ -602,13 +595,13 @@
   state is recording and the event is recordable. Returns the new
   state. Idempotent against bad inputs.
 
-  Per rf2-d5u89 the call ALSO appends a parallel `:entries` entry
+  The call ALSO appends a parallel `:entries` entry
   `{:kind :event/dispatch :event <vec> :t <ms>}` so the
   `:play-script` translator sees the timing alongside the event.
   `:events` (bare event vectors) stays as-is for the simple
   `gen-play-snippet` codegen.
 
-  Per rf2-l2cn5d (EP-0017): the optional `cofx` arg is the captured flat
+  EP-0017: the optional `cofx` arg is the captured flat
   recordable-coeffect map from the same `:rf.event/dispatched` trace
   event (`:rf.cofx` tag — framework `:rf/time-ms` plus any provided
   facts). When non-empty it is stored in TWO index-aligned places: the
@@ -638,7 +631,7 @@
                          cofx* (assoc :rf.cofx cofx*))))))))
 
 ;; ---------------------------------------------------------------------------
-;; DOM-event capture (rf2-d5u89)
+;; DOM-event capture
 ;;
 ;; The DOM-capture layer (`re-frame.story.recorder.dom-capture`,
 ;; CLJS-only) emits one of three entry kinds per observed interaction:
@@ -702,7 +695,7 @@
 
 (defn append-dom-buffered
   "Pure: append an ALREADY-CAPTURED DOM-event `entry` onto the recorder
-  state's `:entries` slot REGARDLESS of `:recording?` (rf2-eztym.3).
+  state's `:entries` slot REGARDLESS of `:recording?`.
 
   Unlike `append-dom`, this does NOT re-check `:recording?`. It exists for
   the type-debounce drain: a keystroke buffered WHILE recording carries its
@@ -731,7 +724,7 @@
   initial-state)
 
 ;; ---------------------------------------------------------------------------
-;; Pure: save-as-variant dialog open/close transitions (rf2-8x9nb)
+;; Pure: save-as-variant dialog open/close transitions
 ;;
 ;; The dialog snapshots `{:variant-id :events}` from the recorder atom
 ;; AT OPEN TIME so a subsequent `start-recording!` (which resets the
@@ -766,9 +759,9 @@
 
   The snapshot is stored on the dialog state itself — NOT read live
   off the recorder atom — so a fresh `start-recording!` after the
-  dialog opens does not mutate the dialog's snippet (rf2-8x9nb).
+  dialog opens does not mutate the dialog's snippet.
 
-  Per rf2-d5u89 the dialog also snapshots `entries` (the rich
+  The dialog also snapshots `entries` (the rich
   `:entries` slot) so the export dialog can drive the `:play-script`
   translator with the full DOM+timing record; pass `nil` when no rich
   entries are available."
@@ -848,11 +841,11 @@
   internal helpers) — the predicate filter is in `append`.
 
   The 2-arity `(record-event! event cofx)` carries the captured flat
-  `:rf.cofx` map (rf2-l2cn5d, EP-0017) — read off the same
+  `:rf.cofx` map (EP-0017) — read off the same
   `:rf.event/dispatched` trace event's `:rf.cofx` tag — so the recorded
   step can re-present the recordable coeffects (provided facts + the
   framework `:rf/time-ms`) on replay rather than restamping. A nil /
-  empty cofx records the byte-identical pre-EP-0017 trace."
+  empty cofx records a cofx-less trace."
   ([event] (record-event! event nil))
   ([event cofx]
    (when config/enabled?
@@ -861,7 +854,7 @@
 
 (defn record-dom-event!
   "Append a DOM-event entry to the recorder's `:entries` slot iff a
-  recording is in flight (rf2-d5u89). Called by the DOM-capture
+  recording is in flight. Called by the DOM-capture
   layer (`re-frame.story.recorder.dom-capture`) for every observed
   click / typed-input / form-submit on the canvas root.
 
@@ -878,8 +871,8 @@
   nil)
 
 (defn record-dom-event-buffered!
-  "Append an ALREADY-CAPTURED DOM-event `entry` REGARDLESS of `:recording?`
-  (rf2-eztym.3). The type-debounce drain path uses this so a keystroke
+  "Append an ALREADY-CAPTURED DOM-event `entry` REGARDLESS of `:recording?`.
+  The type-debounce drain path uses this so a keystroke
   buffered WHILE recording (and carrying its own capture-time `:t`) survives
   the flush even when the flush fires after `stop-recording!` has cleared
   `:recording?`. Idempotent against malformed inputs; no-op under elision."
@@ -891,7 +884,7 @@
 (defn insert-assertion!
   "Insert an `:rf.assert/*` assertion into the captured `:events` of
   the active recording. Drives the mid-recording 'add assertion'
-  picker (rf2-39u9e). Two arities:
+  picker. Two arities:
 
   - `(insert-assertion! event-vec)` — caller has already built the
     event vector (e.g. `[:rf.assert/path-equals [:n] 3]`).
@@ -932,21 +925,19 @@
        traffic — interactions in another canvas shouldn't show up).
     3. Must carry an event vector on `:tags :rf.event/v`.
 
-  Sensitive events (`:sensitive? true`) are RECORDED-BUT-REDACTED per
-  rf2-hdadz: the placeholder `redacted-event` vector replaces the
-  event payload so the credential / PII / auth-token doesn't ride into
-  the captured `:play-script` body, while the row's temporal position is
-  preserved for correlation. The suppressed-events counter is still
-  bumped (Spec 009 §Privacy + rf2-bclgj — Story is a framework-
-  published trace consumer that default-suppresses sensitive events)
-  so the UI's redaction-indicator hint stays accurate.
+  Sensitive events (`:sensitive? true`) are RECORDED-BUT-REDACTED: the
+  placeholder `redacted-event` vector replaces the event payload so the
+  credential / PII / auth-token doesn't ride into the captured
+  `:play-script` body, while the row's temporal position is preserved for
+  correlation. The suppressed-events counter is bumped (Spec 009 §Privacy
+  — Story is a framework-published trace consumer that default-suppresses
+  sensitive events) so the UI's redaction-indicator hint stays accurate.
 
   Hosts that opted into the trusted-local boundary via
   `(story/configure! {:rf.story/egress-profile :rf.egress/local-raw})`
-  get the verbatim event vector — existing in-box debug behaviour,
-  unchanged. The redact/pass decision is the profile's, resolved through
-  the centralized projection table (EP-0015, rf2-3t26eh) — NOT a
-  process-global boolean.
+  get the verbatim event vector — in-box debug behaviour. The redact/pass
+  decision is the profile's, resolved through the centralized projection
+  table (EP-0015) — NOT a process-global boolean.
 
   `record-event!` applies the `recordable-event?` filter (assertion
   events, internal helpers) before appending; the redact path also
@@ -954,9 +945,8 @@
   `:rf.assert/*` event still gets dropped, not redacted-and-recorded,
   because assertions are an authored not observed surface).
 
-  Per rf2-hdadz cross-reference: this mirrors the always-on error
-  path's enforcement in rf2-vnjfg — sensitive events are not warning-
-  only at this consumer."
+  This mirrors the always-on error path's enforcement — sensitive events
+  are not warning-only at this consumer."
   [ev]
   (when (recording?)
     (let [{:keys [op-type operation tags]} ev]
@@ -966,7 +956,7 @@
                  (vector? (:rf.event/v tags)))
         (if (config/suppress-sensitive? ev (:frame tags))
           (do
-            ;; Record-but-redact (rf2-hdadz): append the redacted
+            ;; Record-but-redact: append the redacted
             ;; placeholder so the row's position survives, and bump the
             ;; suppressed-events counter so the UI's REDACTED hint
             ;; reflects the count of placeholder rows. The placeholder
@@ -976,7 +966,7 @@
             ;; thing being suppressed.
             (config/note-suppressed! (:frame tags))
             (record-event! redacted-event))
-          ;; rf2-l2cn5d (EP-0017): carry the same trace event's flat
+          ;; EP-0017: carry the same trace event's flat
           ;; `:rf.cofx` map (the framework-stamped `:rf/time-ms` plus any
           ;; provided recordable facts — see router.cljc §:rf.event/dispatched
           ;; emit, dev-gated) onto the recording so replay re-presents the

--- a/tools/story/src/re_frame/story/recorder/dom_capture.cljs
+++ b/tools/story/src/re_frame/story/recorder/dom_capture.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.story.recorder.dom-capture
-  "DOM-event capture for the recorder (rf2-d5u89).
+  "DOM-event capture for the recorder.
 
   Listens on the story canvas root for `click` / `input` / `change` /
   `submit` events while a recording is in flight, picks a selector
@@ -47,16 +47,16 @@
   only capture interactions the user is making against the
   variant under test.
 
-  ## Sensitive input redaction (rf2-0qoi0 — record-but-redact for DOM)
+  ## Sensitive input redaction (record-but-redact for DOM)
 
   The dispatched-event rail redacts `:sensitive? true` events
   (`recorder/trace-listener` → `config/suppress-sensitive?` →
-  `recorder/redacted-event`) per the rf2-hdadz record-but-redact
-  policy. The DOM-capture rail is the SECOND egress and carries the
-  SAME obligation: a user recording a login flow types a real password,
-  and (post rf2-nkjkj, with `:entries` the primary codegen source) that
-  plaintext would otherwise ride verbatim into the generated
-  `:play-script` `[:type selector \"…\"]` step.
+  `recorder/redacted-event`) per the record-but-redact policy. The
+  DOM-capture rail is the SECOND egress and carries the SAME obligation:
+  a user recording a login flow types a real password, and (with
+  `:entries` the primary codegen source) that plaintext would otherwise
+  ride verbatim into the generated `:play-script` `[:type selector \"…\"]`
+  step.
 
   So `handle-input!` / `handle-change!` detect a SENSITIVE input —
   `<input type=password|email|tel>` or one whose `autocomplete` token
@@ -69,7 +69,7 @@
   UI's REDACTED hint reflects the scrubbed rows, exactly as the dispatch
   rail does. Hosts debugging redaction policy opt into the trusted-local
   boundary via `(story/configure! {:rf.story/egress-profile
-  :rf.egress/local-raw})` for the verbatim path (EP-0015 rf2-3t26eh) —
+  :rf.egress/local-raw})` for the verbatim path (EP-0015) —
   the SAME profile the dispatch rail honours.
 
   `<select>` is NOT treated as sensitive (a choice from visible options
@@ -119,7 +119,7 @@
   ;; `:t` is the recording-relative timestamp stamped at BUFFER time (while
   ;; `:recording?` is true), so the drain can flush the buffered keystroke
   ;; with its capture-time `:t` even when the flush fires AFTER the recording
-  ;; was stopped (rf2-eztym.3).
+  ;; was stopped.
   (atom {}))
 
 (defn- now-ms []
@@ -171,7 +171,7 @@
   Each buffered entry is appended with its capture-time `:t` (stamped at
   BUFFER time, while `:recording?` was true) via
   `recorder/record-dom-event-buffered!` — NOT via `record-dom-type!`'s
-  `recording-now-ms` re-read (rf2-eztym.3). This is what lets the final
+  `recording-now-ms` re-read. This is what lets the final
   keystroke survive a flush that fires AFTER the recording was stopped: the
   debounce timer (or the `remove!`/stop drain) can run once `:recording?` is
   already false without the entry being silently dropped. A defensive
@@ -210,7 +210,7 @@
   The capture-time `:t` is stamped HERE (while `:recording?` is true, since
   this only runs under `should-capture?`), so the flush can append the
   buffered keystroke with its real capture timestamp even when the flush
-  fires after the recording was stopped (rf2-eztym.3)."
+  fires after the recording was stopped."
   [selector value]
   (when (some? selector)
     (let [existing (get @type-buffer selector)]
@@ -241,11 +241,11 @@
   [el]
   (or (.-value el) ""))
 
-;; ---- sensitive-input redaction (rf2-0qoi0) ------------------------------
+;; ---- sensitive-input redaction -----------------------------------------
 
 (def ^:const redacted-type-text
   "The placeholder text the DOM rail substitutes for a SENSITIVE input's
-  typed value (rf2-0qoi0). The STRING mirror of the dispatch rail's
+  typed value. The STRING mirror of the dispatch rail's
   `recorder/redacted-event` `[:rf/redacted]` placeholder — a string
   because the `:dom/type` → `[:type selector text]` play-step requires a
   string `text` slot (the runner's `step-arity-ok?`). Reads the same way
@@ -255,15 +255,15 @@
   "[:rf/redacted]")
 
 (def ^:private sensitive-input-types
-  "`<input type=…>` values whose typed value is presumed sensitive
-  (rf2-0qoi0). `password` is the obvious credential field; `email` and
+  "`<input type=…>` values whose typed value is presumed sensitive.
+  `password` is the obvious credential field; `email` and
   `tel` are PII the record-but-redact policy scrubs by default. Compared
   case-insensitively against the element's `type` attribute."
   #{"password" "email" "tel"})
 
 (def ^:private sensitive-autocomplete-tokens
   "`autocomplete` attribute tokens that mark a field as a credential or
-  payment input (rf2-0qoi0, WHATWG autofill detail tokens). A field
+  payment input (WHATWG autofill detail tokens). A field
   carrying any of these is scrubbed even when its `type` is plain `text`
   (e.g. a one-time-code or a card number rendered as `type=text`)."
   #{"current-password" "new-password" "one-time-code"
@@ -288,7 +288,7 @@
 
 (defn- sensitive-element?
   "True iff typed input into `el` is presumed sensitive and MUST be
-  redacted out of the recording (rf2-0qoi0): a `<input>` whose `type` is
+  redacted out of the recording: a `<input>` whose `type` is
   password / email / tel, OR whose `autocomplete` names a credential /
   payment token. `<select>` / `<textarea>` are NOT sensitive — a choice
   from visible options or free-form prose is not a typed secret."
@@ -301,18 +301,18 @@
                                     (autocomplete-tokens el)))))))
 
 (defn- capture-value
-  "Read the value to RECORD for `el` (rf2-0qoi0). For a non-sensitive
-  field, the verbatim `.value`. For a SENSITIVE field, the redacted
-  placeholder — UNLESS Story's local-render egress profile reveals
-  sensitive values (the trusted-local `:rf.egress/local-raw` opt-in, the
-  same posture the dispatch rail honours per EP-0015 rf2-3t26eh), in
+  "Read the value to RECORD for `el`. For a non-sensitive field, the
+  verbatim `.value`. For a SENSITIVE field, the redacted placeholder —
+  UNLESS Story's local-render egress profile reveals sensitive values
+  (the trusted-local `:rf.egress/local-raw` opt-in, the same posture the
+  dispatch rail honours per EP-0015), in
   which case the verbatim value flows through. Bumps the suppressed
   counter for the recording's variant when it redacts, so the UI's
   REDACTED hint stays accurate."
   [el]
   (let [v       (target-value el)
         variant (recorder/recording-variant)]
-    ;; rf2-6z4znr — resolve the reveal decision against the RECORDING's frame
+    ;; Resolve the reveal decision against the RECORDING's frame
     ;; (per-(tool,frame) visibility). Revealing a sibling frame never reveals
     ;; this capture; a nil recording-variant fails closed (redacts).
     (if (and (sensitive-element? el) (not (config/include-sensitive? variant)))
@@ -345,7 +345,7 @@
 (defn- handle-input!
   "input / change handler — stashes the latest value into the
   per-selector type buffer + (re)arms the debounce timer. A SENSITIVE
-  input's value is redacted at the capture boundary (rf2-0qoi0) via
+  input's value is redacted at the capture boundary via
   `capture-value`, so the secret never reaches the recorder atom."
   [ev]
   (when (should-capture?)
@@ -367,8 +367,8 @@
           ;; Stash the most-recent value FIRST (so a `change` on a
           ;; `<select>` — which never fires `input` — still has a
           ;; value to flush). Sensitive `<input>` values are redacted at
-          ;; the capture boundary (rf2-0qoi0); `<select>` is never
-          ;; sensitive, so its choice flows through verbatim.
+          ;; the capture boundary; `<select>` is never sensitive, so its
+          ;; choice flows through verbatim.
           (when sel
             (buffer-type! sel (capture-value el))
             (flush-type-buffer! sel)))))))

--- a/tools/story/src/re_frame/story/recorder/play_export.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.story.recorder.play-export
-  "Translate a captured recording into a `:script` body (rf2-x9zsr).
+  "Translate a captured recording into a `:script` body.
 
   ## Why
 
@@ -7,11 +7,11 @@
   during a canvas session and surfaces them in a save-as-variant
   dialog as a `(reg-variant ... :script {...})` EDN snippet — the simple
   `gen-play-snippet` codegen, which wraps each captured event vector as
-  a `[:dispatch-sync <event-vec>]` step (rf2-0wrud). Per rf2-7mj4z the
-  emitted snippet uses the PUBLIC `:script` authoring slot (spec/017
-  §Public vocabulary), NOT the transitional `:play-script` spelling.
+  a `[:dispatch-sync <event-vec>]` step. The emitted snippet uses the
+  PUBLIC `:script` authoring slot (spec/017 §Public vocabulary) rather
+  than the internal `:play-script` slot.
 
-  The rich `:script` step DSL landed in rf2-8i2a9 — tagged steps
+  The rich `:script` step DSL provides tagged steps
   (`[:dispatch ...]`, `[:wait ms]`, `[:assert-db ...]`,
   `[:assert-dom ...]`, `[:click ...]`, `[:type ...]`) the runner
   executes sequentially with PASS/FAIL bookkeeping. This is the
@@ -24,9 +24,9 @@
 
   ## What gets translated
 
-  Per rf2-d5u89 the recorder now captures BOTH dispatched events
-  (off the trace bus) AND DOM interactions (off the canvas root
-  via `re-frame.story.recorder.dom-capture`). Each captured entry
+  The recorder captures BOTH dispatched events (off the trace bus)
+  AND DOM interactions (off the canvas root via
+  `re-frame.story.recorder.dom-capture`). Each captured entry
   rides on the recorder's `:entries` slot as one of four shapes;
   the translator maps them to `:script` steps:
 
@@ -48,13 +48,12 @@
   next state transition. The pure runner accepts either tag for any
   event; this is a translation convention, not a runtime requirement.
 
-  ## Legacy entry shape (pre-rf2-d5u89)
+  ## Bare-events input shape
 
-  Callers that pass a bare `events` vector (the old `:events` slot)
-  still work — the translator coerces each bare event vector into
-  an `:event/dispatch` entry with `:t 0`. This keeps the JVM tests
-  from rf2-x9zsr (which exercise `recording->script-body` with a
-  bare vector) running unchanged.
+  Callers that pass a bare `events` vector (the `:events` slot) are
+  tolerated — the translator coerces each bare event vector into an
+  `:event/dispatch` entry with `:t 0`, so the JVM tests that exercise
+  `recording->script-body` with a bare vector run unchanged.
 
   ## Auto-assert
 
@@ -100,8 +99,8 @@
 
 (def ^:const redacted-event-id
   "The framework sentinel id the recorder uses to replace sensitive
-  event payloads (rf2-hdadz). Translator drops these from the
-  generated script + adds a comment in the output."
+  event payloads. Translator drops these from the generated script +
+  adds a comment in the output."
   :rf/redacted)
 
 ;; ---------------------------------------------------------------------------
@@ -166,11 +165,11 @@
        :else        [tag event]))))
 
 ;; ---------------------------------------------------------------------------
-;; Pure: entry-shape translation (rf2-d5u89)
+;; Pure: entry-shape translation
 ;;
 ;; Each `:entries` entry is one of four shapes (see recorder.cljc
-;; §dom-event-kinds + §rf2-d5u89). `entry->step` maps the rich shape
-;; to a runner step OR nil (the caller filters).
+;; §dom-event-kinds). `entry->step` maps the rich shape to a runner
+;; step OR nil (the caller filters).
 ;; ---------------------------------------------------------------------------
 
 (defn entry->step
@@ -192,10 +191,10 @@
   [entry]
   (case (and (map? entry) (:kind entry))
     :event/dispatch
-    ;; rf2-l2cn5d (EP-0017): the entry carries the captured flat `:rf.cofx`
-    ;; map (recorder appends it alongside the event vector). Thread it onto
-    ;; the dispatch step so replay re-presents the recorded recordable
-    ;; coeffects. Absent / empty cofx emits the bare 2-element step.
+    ;; The entry carries the captured flat `:rf.cofx` map (recorder appends
+    ;; it alongside the event vector). Thread it onto the dispatch step so
+    ;; replay re-presents the recorded recordable coeffects. Absent / empty
+    ;; cofx emits the bare 2-element step.
     (event->step (:event entry) (:rf.cofx entry))
 
     :dom/click
@@ -215,15 +214,15 @@
 
 (defn- coerce-entry
   "Normalise an arbitrary `events`-vector member to an `:entries`-shape
-  map. Pure data → data; tolerates the legacy bare-event-vector
-  shape (`[:my/event ...]`) by lifting it into
+  map. Pure data → data; tolerates the bare-event-vector shape
+  (`[:my/event ...]`) by lifting it into
   `{:kind :event/dispatch :event <vec> :t 0}`.
 
-  `cofx` (rf2-l2cn5d, EP-0017) is the captured flat recordable-coeffect
-  map for THIS member of a parallel bare-events / cofx pair; when
-  non-empty it rides onto the lifted entry under `:rf.cofx` so the bare
-  `:events` path (the MCP `record-as-variant` surface) preserves cofx
-  the same way the rich `:entries` path does."
+  `cofx` (EP-0017) is the captured flat recordable-coeffect map for THIS
+  member of a parallel bare-events / cofx pair; when non-empty it rides
+  onto the lifted entry under `:rf.cofx` so the bare `:events` path (the
+  MCP `record-as-variant` surface) preserves cofx the same way the rich
+  `:entries` path does."
   ([x] (coerce-entry x nil))
   ([x cofx]
    (cond
@@ -237,11 +236,11 @@
      :else nil)))
 
 (defn- bare-events->entries
-  "Coerce a legacy bare-events vector to the new `:entries` shape so
-  the translator's wait-insertion + entry walker work uniformly.
+  "Coerce a bare-events vector to the `:entries` shape so the
+  translator's wait-insertion + entry walker work uniformly.
 
-  `cofx-vec` (rf2-l2cn5d, EP-0017) is an OPTIONAL parallel vector of
-  captured `:rf.cofx` maps, index-aligned with `events`. When supplied,
+  `cofx-vec` (EP-0017) is an OPTIONAL parallel vector of captured
+  `:rf.cofx` maps, index-aligned with `events`. When supplied,
   each bare event is lifted carrying its captured coeffect map. Already-
   rich `:entries` members carry their own `:rf.cofx`, so the parallel
   vector is consulted only for bare members."
@@ -253,7 +252,7 @@
           (filterv some?)))))
 
 ;; ---------------------------------------------------------------------------
-;; Pure: wait-step insertion (rf2-d5u89)
+;; Pure: wait-step insertion
 ;;
 ;; Walk the entries in order, compare consecutive `:t` stamps, and
 ;; inject a `[:wait Δt]` step whenever the gap exceeds the
@@ -376,13 +375,12 @@
 
   Inputs:
 
-    `events`  — either the legacy vector of recorded event vectors
-                (the `:events` slot of the recorder state) OR the
-                rich `:entries` vector of per-entry maps (rf2-d5u89).
-                Mixed input is tolerated — each member is coerced
-                via `coerce-entry`. The bare-event-vector branch
-                stamps `:t 0` on every entry, so no `:wait` steps
-                are emitted (back-compat for v1 callers).
+    `events`  — either the vector of recorded event vectors (the
+                `:events` slot of the recorder state) OR the rich
+                `:entries` vector of per-entry maps. Mixed input is
+                tolerated — each member is coerced via `coerce-entry`.
+                The bare-event-vector branch stamps `:t 0` on every
+                entry, so no `:wait` steps are emitted.
     `opts`:
       :name              optional — `:name` field for the play-script.
       :auto-assert?      bool, default false — when true, derive
@@ -402,7 +400,7 @@
                          inserts a `[:wait Δt]` step between entries.
                          Default `default-wait-threshold-ms` (50ms).
       :cofx              optional — a parallel vector of captured flat
-                         `:rf.cofx` maps (rf2-l2cn5d, EP-0017), index-aligned
+                         `:rf.cofx` maps (EP-0017), index-aligned
                          with a BARE `events` vector. Each non-empty entry rides
                          onto its dispatch step as `[:dispatch evec {:rf.cofx …}]`
                          so replay re-presents the recorded recordable coeffects
@@ -493,11 +491,11 @@
   pastes into source. `variant-id` defaults to
   `:story.recorded/play-export`; `alias` defaults to `\"story\"`.
 
-  rf2-7mj4z — the emitted body uses the PUBLIC `:script` authoring slot
-  (spec/017 §Public vocabulary), NOT the transitional `:play-script`
-  spelling, so pasted recorder output reads the way the docs teach. The
-  public `:script` slot accepts the same `{:script … :auto-run?}` body
-  shape `render-script-body` produces.
+  The emitted body uses the PUBLIC `:script` authoring slot (spec/017
+  §Public vocabulary) rather than the internal `:play-script` slot, so
+  pasted recorder output reads the way the docs teach. The public
+  `:script` slot accepts the same `{:script … :auto-run?}` body shape
+  `render-script-body` produces.
 
   Pure data → string. The form survives `read-string` round-trip and
   registers cleanly via `re-frame.story/reg-variant`."

--- a/tools/story/src/re_frame/story/recorder/play_export_events.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export_events.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.story.recorder.play-export-events
   "re-frame integration seam for the recorder → :play-script export
-  flow (rf2-x9zsr). Owns the side-effecty entry points the export
-  dialog UI reaches for:
+  flow. Owns the side-effecty entry points the export dialog UI
+  reaches for:
 
   - **Replay the generated script in-place** — dispatch the just-
     -exported `:play-script` through the runner so the user can

--- a/tools/story/src/re_frame/story/recorder/selector.cljc
+++ b/tools/story/src/re_frame/story/recorder/selector.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.story.recorder.selector
-  "Pure selector picker — DOM element → best-effort CSS selector string
-  (rf2-d5u89).
+  "Pure selector picker — DOM element → best-effort CSS selector string.
 
   Used by the recorder's DOM-capture layer to turn a `click` /
   `input` / `change` event target into a stable selector the

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -8,12 +8,12 @@
   by Story kind, living inside the `tools/story/` artefact and never
   reaching a production bundle (via the §6 elision contract).
 
-  ## Stage 2 design tension noted in bd rf2-7ho2
+  ## Closed framework registrar, Story-owned side-table
 
   /spec/007-Stories.md §Story-tool extension hook says 'the framework registrar already supports new
-  kinds via the existing reg- machinery' — but the implementation's
+  kinds via the existing reg- machinery', while the implementation's
   registrar (`re-frame.registrar/kinds`) is a **closed** set. The
-  side-table here is the chosen reconciliation: Story-only registrations
+  side-table here is the reconciliation: Story-only registrations
   live in Story's own atom; the framework registrar stays closed. A
   bridge (`story/registrations`) preserves the /spec/007-Stories.md §Public-query-surfaces
   contract without crossing the framework boundary.
@@ -42,11 +42,10 @@
      `*pending-coords*` dynamic var (mirroring `re-frame.source-coords`).
   4. Writes the RAW body into the side-table.
 
-  `:extends` is NOT resolved here (rf2-f6z88 — Mike RULED (a)): the raw
-  variant body is stored with `:extends` intact and the plan compiler
-  (`re-frame.story.plan`) is the SINGLE merge authority, walking the
-  parent chain per spec/017 §8.4 (setup APPENDS, checks INHERIT). See
-  `reg-variant*` below.
+  `:extends` is NOT resolved here: the raw variant body is stored with
+  `:extends` intact and the plan compiler (`re-frame.story.plan`) is the
+  SINGLE merge authority, walking the parent chain per spec/017 §8.4
+  (setup APPENDS, checks INHERIT). See `reg-variant*` below.
 
   Hot-reload semantics mirror `re-frame.registrar`: re-registering the
   same id replaces the slot atomically; nothing in the runtime is
@@ -123,7 +122,7 @@
   kind->id->body
   (atom (fresh-table)))
 
-;; ---- mutation tick (rf2-zrswb) -------------------------------------------
+;; ---- mutation tick -------------------------------------------------------
 ;;
 ;; Every write through the side-table bumps `mutation-tick`. Consumers that
 ;; do expensive registry-derived work (e.g. the shell's watch-mode hot-loop
@@ -206,14 +205,14 @@
 
 ;; ---- shape validation -----------------------------------------------------
 
-;; rf2-mantt — the Story authoring-body schemas are now `{:closed true}`
-;; (re-frame.story.schemas), so a removed / typo'd slot fails validation
+;; The Story authoring-body schemas are `{:closed true}`
+;; (re-frame.story.schemas), so an unknown / typo'd slot fails validation
 ;; with a `:malli.core/extra-key` error rather than being silently
 ;; swallowed. The helpers below turn that structural error into an
 ;; actionable `:reason` that NAMES the unknown key(s) and the nearest
-;; declared slot ('did you mean :plays?') — the swallow-class fix's
-;; trust-boundary payoff: an author who typos or carries a removed slot
-;; gets told exactly what to fix, at the `reg-*` call site.
+;; declared slot ('did you mean :plays?'): an author who typos or carries
+;; an unrecognised slot gets told exactly what to fix, at the `reg-*` call
+;; site.
 
 (defn- edit-distance
   "Levenshtein edit distance between keyword/string names. Clean,
@@ -286,11 +285,11 @@
   "Validate `body` against the schema for `kind`. Throws `:rf.error/<kind>-shape`
   on a miss. Returns the body unchanged on success.
 
-  rf2-mantt — when the failure is an unknown / removed slot (the closed-
-  schema `:malli.core/extra-key` error) the `:reason` names the offending
-  key(s) and the nearest declared slot; otherwise it falls back to the
-  generic schema-mismatch message. The full malli `:explain` rides
-  `ex-data` either way."
+  When the failure is an unknown slot (the closed-schema
+  `:malli.core/extra-key` error) the `:reason` names the offending key(s)
+  and the nearest declared slot; otherwise it falls back to the generic
+  schema-mismatch message. The full malli `:explain` rides `ex-data`
+  either way."
   [kind id body]
   (when-let [explain (schemas/validate kind body)]
     (let [error-kw (keyword "rf.error" (str (name kind) "-shape"))
@@ -367,7 +366,7 @@
                          :kind     kind
                          :id       id}))))))
 
-;; ---- auto-install hook (rf2-p1ydc) ---------------------------------------
+;; ---- auto-install hook ---------------------------------------------------
 ;;
 ;; Every `reg-*!` helper calls `maybe-auto-install!` at entry. If the
 ;; canonical vocabulary hasn't been installed in the current registrar
@@ -446,8 +445,7 @@
 
 (defn reg-variant*
   "Runtime helper for `reg-variant` macro. Per `001-Authoring.md` §Registration macros + spec/017
-  §8.4 (rf2-f6z88 — Mike RULED (a): the plan compiler is the SINGLE
-  `:extends` merge authority):
+  §8.4 (the plan compiler is the SINGLE `:extends` merge authority):
 
   1. Validate the AUTHORED body shape.
   2. Lower the public vocabulary into the shipping slots.
@@ -456,31 +454,28 @@
   5. Write the RAW body — `:extends` INTACT, parents UNmerged — to the
      side-table.
 
-  `:extends` is NOT resolved here. The straight registration-time merge
-  (`extends/resolve-extends`, a child-wins-wholesale REPLACE that also
-  STRIPPED `:extends`) used to pre-fold the parent body, which left the
-  plan compiler's per-field merge logic (setup APPENDS, checks INHERIT —
-  spec/017 §8.4) dead for every registered variant: it saw a single-
-  element `:extends` chain. By storing the raw body we make the compiler's
-  `resolve-source-chain` walk the chain on the default side-table lookup,
-  so registered variants and explicit-`:lookup` tests share ONE merge
-  engine (`re-frame.story.plan/compile-body`). There is no second merge
-  here to diverge."
+  `:extends` is NOT resolved here. Storing the raw body lets the
+  compiler's `resolve-source-chain` walk the parent chain on the default
+  side-table lookup, so the plan compiler's per-field merge logic (setup
+  APPENDS, checks INHERIT — spec/017 §8.4) applies to every registered
+  variant. Registered variants and explicit-`:lookup` tests share ONE
+  merge engine (`re-frame.story.plan/compile-body`); there is no second
+  merge here to diverge."
   [id body]
   (maybe-auto-install!)
   (assert-id! :variant id)
-  ;; rf2-5x1wt.11 — validate the AUTHORED body first so the public-
-  ;; vocabulary mutual-exclusion (`:setup` xor `:events`, `:script` xor
-  ;; `:play-script` xor `:plays`) fires on what the author actually
-  ;; wrote, before `lower-public-vocabulary` folds the public spellings
-  ;; into the shipping slots.
+  ;; Validate the AUTHORED body first so the public-vocabulary mutual-
+  ;; exclusion (`:setup` xor `:events`, `:script` xor `:play-script` xor
+  ;; `:plays`) fires on what the author actually wrote, before
+  ;; `lower-public-vocabulary` folds the public spellings into the
+  ;; shipping slots.
   (validate-shape! :variant id body)
   (let [;; Lower `:setup`→`:events` and `:script`→`:play-script` so the
         ;; stored body carries the shipping slots every downstream
-        ;; consumer reads (per spec/017 §Public vocabulary; removed when
-        ;; the runtime reads the normalized plan — rf2-5x1wt.17 / .22).
+        ;; consumer reads (per spec/017 §Public vocabulary; stripped when
+        ;; the runtime reads the normalized plan).
         ;; `:extends` is preserved verbatim — the plan compiler resolves
-        ;; it (rf2-f6z88).
+        ;; it.
         lowered  (schemas/lower-public-vocabulary body)
         body     (-> lowered
                      merge-coords
@@ -489,7 +484,7 @@
     (store! :variant id body)))
 
 (defn reg-fragment*
-  "Runtime helper for `reg-fragment` macro (rf2-5x1wt.15). A fragment is a
+  "Runtime helper for `reg-fragment` macro. A fragment is a
   reusable setup/script/world mixin a variant pulls in through `:compose`.
 
   Validates the body against the `Fragment` schema — which enforces the
@@ -502,7 +497,7 @@
   (reg-simple! :fragment id body))
 
 (defn reg-check*
-  "Runtime helper for `reg-check` macro (rf2-5x1wt.15). A check is a named,
+  "Runtime helper for `reg-check` macro. A check is a named,
   reusable assertion pack — the inheritable expectation form. Validates the
   body against the `Check` schema (`:assertions` required, no
   world/behaviour). Check identity (the id) is preserved by the plan
@@ -545,7 +540,7 @@
 
 (defn install-canonical-tags!
   "Register the seven canonical inclusion tags from /spec/007-Stories.md §Inclusion
-  tags AND the canonical `:state/*` magnitude axis (rf2-k1k87) — five
+  tags AND the canonical `:state/*` magnitude axis — five
   faceted tags (`:state/empty`, `:state/small`, `:state/medium`,
   `:state/large`, `:state/special`) on the `:state` axis. The `:state`
   axis communicates operator-facing fixture richness — a reviewer can
@@ -592,9 +587,10 @@
   Stories with zero registered variants land in the result with an empty
   set — the caller decides whether to elide them.
 
-  Replaces the O(S × V) pattern of calling `variants-of` per story (used
-  e.g. by `tool-list-stories` in story-mcp, rf2-d3iso). Variant ids whose
-  namespace doesn't match any registered story id are skipped — they're
+  Builds the index in one pass instead of the O(S × V) pattern of calling
+  `variants-of` per story (used e.g. by `tool-list-stories` in story-mcp).
+  Variant ids whose namespace doesn't match any registered story id are
+  skipped — they're
   orphans (the registrar's reg-time validation forbids them under normal
   use, but the index stays defensive)."
   []
@@ -609,7 +605,7 @@
             seed
             (ids :variant))))
 
-;; ---- variants-with-tags (memoised on mutation-tick, rf2-c5nwl) ----------
+;; ---- variants-with-tags (memoised on mutation-tick) --------------------------
 ;;
 ;; The hot path is the sidebar compose loop + the SOTA assertions/play
 ;; flows: every render computes
@@ -641,7 +637,7 @@
   "Return the variant ids whose `:tags` set intersects `query-tags`. Per
   `002-Runtime.md` §Programmatic API — the public `variants-with-tags` wraps this.
 
-  Memoised on the registrar mutation-tick (rf2-c5nwl): repeated calls
+  Memoised on the registrar mutation-tick: repeated calls
   with the same query between two registrar writes return the same
   cached set in O(1)."
   [query-tags]
@@ -674,8 +670,8 @@
 (defn tags-by-axis
   "Return the set of registered tag ids whose body's `:axis` equals
   `axis-kw`. Per spec/001 §reg-tag the optional `:axis` slot groups
-  tags into facet rows in the sidebar tag-filter UI (rf2-v05qb SB9
-  parity). Tags registered without `:axis` are excluded from every
+  tags into facet rows in the sidebar tag-filter UI (SB9 parity).
+  Tags registered without `:axis` are excluded from every
   axis-keyed result."
   [axis-kw]
   (query-tags-by #(= axis-kw (:axis %))))
@@ -693,7 +689,7 @@
   []
   (query-tags-by #(= :exclude (:default-filter %))))
 
-;; ---- faceted tag-filter helpers (rf2-7ncf9) ------------------------------
+;; ---- faceted tag-filter helpers ------------------------------------------------
 
 (def ^:private no-axis-key
   "Sentinel axis key for tags that have no `:axis` slot. Lives in
@@ -718,7 +714,7 @@
   "Pure data → data: build the `{tag-id → axis-kw}` index across every
   registered tag in one O(T) pass. Tags without `:axis` map to
   `::no-axis`. Used by the sidebar's facet-grouped filter row + the
-  `state/variant-tag-match?` AND-across-axes predicate (rf2-7ncf9)."
+  `state/variant-tag-match?` AND-across-axes predicate."
   []
   (reduce-kv (fn [acc tid body]
                (assoc acc tid (or (:axis body) no-axis-key)))

--- a/tools/story/src/re_frame/story/render.cljc
+++ b/tools/story/src/re_frame/story/render.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.story.render
   "`render-variant` — the workshop render verb that drives the SAME
-  variant-plan the test runner consumes (NewTestStory rf2-5x1wt.24,
-  `tools/story/spec/017-Testing-Story.md` §Args, controls, and
+  variant-plan the test runner consumes
+  (`tools/story/spec/017-Testing-Story.md` §Args, controls, and
   `render-variant` + §Storytelling superset).
 
   ## One plan, two outputs
@@ -57,7 +57,7 @@
   - `:error`       — carries the thrown ex-data when the host render fn
                      throws.
 
-  ## Plan-hash agreement (acceptance — rf2-5x1wt.24)
+  ## Plan-hash agreement (acceptance)
 
   The `:plan-hash` is `re-frame.story.fingerprint/plan-hash` over the SAME
   normalized plan, so a runner (`story/run`) and `render-variant` agree on
@@ -127,7 +127,7 @@
   (late-bind/get-fn render-host-hook-key))
 
 ;; ===========================================================================
-;; Effective-args control overrides (rf2-5x1wt.24)
+;; Effective-args control overrides
 ;; ===========================================================================
 ;;
 ;; spec/017 §Args: `:effective-args` are *the args after control-panel
@@ -239,9 +239,8 @@
          validation   (when schema
                         (plan/validate-effective-args schema eff-args validator-fns))
          ;; The plan-hash is over the normalized plan — render + run agree
-         ;; on it (rf2-5x1wt.24 acceptance). When controls change the
-         ;; effective args, reflect them in the hashed plan so the hash
-         ;; tracks what is actually rendered.
+         ;; on it. When controls change the effective args, reflect them in
+         ;; the hashed plan so the hash tracks what is actually rendered.
          render-plan  (assoc-in plan [:world :effective-args] eff-args)
          plan-hash    (fingerprint/plan-hash render-plan)
          base         {:plan           render-plan
@@ -282,20 +281,18 @@
   threw. Carries the structured ex-data so tools surface the failure the
   same way a run error surfaces.
 
-  rf2-9kpsq — the `:error` sub-map is the shared
-  `re-frame.story.error/throwable->error-map` projection (was a drifted
-  copy that dropped `:stack`; consolidation restores the canonical
-  `{:message :stack :data}` shape).
+  The `:error` sub-map is the shared
+  `re-frame.story.error/throwable->error-map` projection — the canonical
+  `{:message :stack :data}` shape.
 
-  rf2-jh42p — when the throw happened AFTER `prepare-render` succeeded
-  (the host render fn threw), the prepared `:plan` / `:plan-hash` /
-  `:effective-args` already exist, so thread them onto the result to match
-  the documented shape (spec/017 §Args — P1 render API: those slots are
-  always present once prepared). The `:frame` slot prefers the prepared
-  frame id (an inline-map target has no keyword frame, but the plan still
-  resolved one) and falls back to the keyword target. When `prepared` is
-  nil (plan CONSTRUCTION threw — no plan exists), only `:frame` + `:error`
-  carry, as before."
+  When the throw happened AFTER `prepare-render` succeeded (the host render
+  fn threw), the prepared `:plan` / `:plan-hash` / `:effective-args`
+  already exist, so thread them onto the result to match the documented
+  shape (spec/017 §Args — P1 render API: those slots are always present
+  once prepared). The `:frame` slot prefers the prepared frame id (an
+  inline-map target has no keyword frame, but the plan still resolved one)
+  and falls back to the keyword target. When `prepared` is nil (plan
+  CONSTRUCTION threw — no plan exists), only `:frame` + `:error` carry."
   ([target e] (error-result target e nil))
   ([target e prepared]
    (cond-> {:status :error
@@ -359,7 +356,7 @@
                      (assoc :status :rendered :rendered rendered)))
                ;; Host render threw — `prepared` already carries
                ;; :plan/:plan-hash/:effective-args, so thread them onto the
-               ;; :error result (rf2-jh42p) rather than dropping the context.
+               ;; :error result rather than dropping the context.
                (catch #?(:clj Throwable :cljs :default) e
                  (error-result target e prepared)))
              ;; No host render hook (the bare JVM / a pre-boot CLJS build):

--- a/tools/story/src/re_frame/story/requirements.cljc
+++ b/tools/story/src/re_frame/story/requirements.cljc
@@ -1,8 +1,8 @@
 (ns re-frame.story.requirements
   "The runner capability / requirement registry — the keystone that decides
   WHICH concrete runner a Story plan needs, and REFUSES (`:cannot-run`)
-  rather than faking proof a runner cannot supply (NewTestStory
-  rf2-5x1wt.16, `tools/story/spec/017-Testing-Story.md` §Runner model +
+  rather than faking proof a runner cannot supply
+  (`tools/story/spec/017-Testing-Story.md` §Runner model +
   §Runner requirements).
 
   ## Capabilities are SETS, not a tier scalar
@@ -224,8 +224,7 @@
 ;;
 ;; Each STEP and ASSERTION declares the capability TOKENS it requires. These
 ;; are the single source of truth the plan compiler (`re-frame.story.plan`)
-;; reads to compute `:required-runner`; the inline maps that used to live in
-;; plan.cljc are lifted here so the registry has ONE home.
+;; reads to compute `:required-runner`. The registry has ONE home here.
 
 (def step-capabilities
   "Capability tokens each SCRIPT/SETUP step tag requires (spec/017 §Script
@@ -582,7 +581,7 @@
   - `:pixels` / `:a11y-engine` — browser-only oracle streams; empty = no
     screenshot / no axe scan = no proof.
 
-  ## Tokens DELIBERATELY absent (empty-is-HEALTHY — rf2-qoxw7)
+  ## Tokens DELIBERATELY absent (empty-is-HEALTHY)
 
   Tokens whose slot is empty in the NORMAL passing case must NOT be listed —
   keying a fail-closed presence check on them emits a FALSE `:cannot-run`

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -1,25 +1,18 @@
 (ns re-frame.story.result
   "The ONE unified run-result — the single shape every Story runner,
-  Test mode, CI, `clojure.test`, and MCP consume (NewTestStory
-  rf2-5x1wt.19, `tools/story/spec/017-Testing-Story.md` §Run result +
+  Test mode, CI, `clojure.test`, and MCP consume
+  (`tools/story/spec/017-Testing-Story.md` §Run result +
   §Unified run result).
 
   ## One result, one source of truth
 
   Spec/017 §Run result: *all runners MUST return the same shape*, and the
   evidential slots are *projections from one retained epoch tape*, not a
-  second capture path. Before this ns three result vocabularies coexisted:
+  second capture path. Every runner — `story/run`, the per-step runner,
+  artifact replay — speaks this ONE result language, so a verdict and the
+  assertions slot can never disagree (the \"false GREEN\" class).
 
-  - `runtime.cljc`'s `record-result-map` (`:lifecycle`, a flat
-    `:assertions` vector, no top-level `:status`);
-  - `runner.cljc`'s per-step `run-state` machine (`:pass` / `:fail` /
-    per-step `:results`, read directly by the toolbar chip + CI runner);
-  - `artifact.cljc`'s `replay-result` (the FIRST unified shape — top-level
-    `:status`, the `.4` tape projection, a `:run-artifact` back-link).
-
-  The documented \"false GREEN\" was exactly the disagreement between
-  run-state and the assertions slot. This ns folds the three onto ONE
-  shape, derived — wherever the tape carries the evidence — from `.4`'s
+  The shape is derived — wherever the tape carries the evidence — from
   `re-frame.story.play.evidence/project-evidence` (the single tape
   projection; this ns does NOT add a parallel accumulator). The assertion
   outcomes that are NOT in the tape (the `:rf.assert/*` records the
@@ -83,7 +76,7 @@
   #{:pass :fail :cannot-run :error})
 
 ;; ===========================================================================
-;; THE SCHEMA-BACKED CONTRACT  (rf2-3nbl5.6 — API governance freeze)
+;; THE SCHEMA-BACKED CONTRACT  (API governance freeze)
 ;; ===========================================================================
 ;;
 ;; The unified run-result is a FROZEN, schema-backed public contract: the ONE
@@ -96,8 +89,8 @@
 ;; (plain data), and run on both JVM + CLJS.
 ;;
 ;; The verdict is `:status` (an `Status` enum) — there is NO `:passing?`
-;; boolean and NO lifecycle-as-verdict (the clean break, rf2-ba86n.17): a
-;; boolean could not express the distinct `:cannot-run` THIRD outcome, and a
+;; boolean and NO lifecycle-as-verdict: a boolean could not express the
+;; distinct `:cannot-run` THIRD outcome, and a
 ;; lifecycle state (`:ready` / `:error`) is the frame's mount state, not the
 ;; run's judgement. The accessors are `result-status` / `result-passed?`
 ;; (re-exported from `re-frame.story`); a green/red bit is DERIVED from
@@ -113,14 +106,14 @@
 (def Status
   "The frozen verdict enum (spec/017 §Run result). The ONE field every
   run / assertion / check carries — `:pass` | `:fail` | `:cannot-run` |
-  `:error`. Replaces the retired `:passing?` boolean (it could not express
-  the `:cannot-run` THIRD status)."
+  `:error`. A single verdict enum rather than a `:passing?` boolean,
+  which could not express the `:cannot-run` THIRD status."
   (into [:enum] statuses))
 
 (def AssertionRecord
   "Malli schema for ONE evaluated assertion record (spec/017 §Run result —
-  Assertion record). `:status` is the frozen verdict; `:passed?` is the
-  legacy boolean kept ONLY as a diagnostic mirror (the verdict is
+  Assertion record). `:status` is the frozen verdict; `:passed?` is a
+  diagnostic-mirror boolean ONLY (the verdict is
   `:status`). Open map — the `.18` atom fields and source-coords ride
   along."
   [:map {:closed false}
@@ -192,8 +185,8 @@
    [:cannot-run {:optional true} [:sequential :any]]])
 
 (defn valid-run-result?
-  "True iff `result` conforms to the frozen `RunResult` contract
-  (rf2-3nbl5.6). Pure data → data — the executable check Test mode / CI /
+  "True iff `result` conforms to the frozen `RunResult` contract.
+  Pure data → data — the executable check Test mode / CI /
   MCP / the test corpus run to prove a result speaks the ONE language."
   [result]
   (m/validate RunResult result))
@@ -329,7 +322,7 @@
         (or check->atoms [])))
 
 ;; ===========================================================================
-;; SCHEMA-ERROR EXACT CONSUMPTION  (spec/017 §Schema rule, rf2-5x1wt.21)
+;; SCHEMA-ERROR EXACT CONSUMPTION  (spec/017 §Schema rule)
 ;; ===========================================================================
 ;;
 ;; The §Schema-rule invariant: any emitted
@@ -428,7 +421,7 @@
 (defn match-schema-expectations
   "EXACT-consumption match of declared `:rf.assert/schema-error`
   expectations against the tape's projected schema violations (spec/017
-  §Schema rule, rf2-5x1wt.21). Pure data → data — the boundary the
+  §Schema rule). Pure data → data — the boundary the
   `run-result` assembly consumes.
 
   `schema-expectations` is the vector of declared `:rf.assert/schema-error`
@@ -472,15 +465,15 @@
       :unconsumed         unconsumed})))
 
 ;; ===========================================================================
-;; CAUSAL / CASCADE EXPECTATIONS  (spec/017 §Causal and cascade assertions,
-;; rf2-5x1wt.31)
+;; CAUSAL / CASCADE EXPECTATIONS  (spec/017 §Causal and cascade
+;; assertions)
 ;; ===========================================================================
 ;;
 ;; `:rf.assert/caused` and `:rf.assert/no-cascade-rerender` PROJECT a
 ;; cause→effect relationship from the SAME reactive evidence the tape already
 ;; carries — the `:rf.sub/run` / `:rf.view/rendered` rows stamped with the
 ;; dispatching cascade's `:cause-event-id` (Spec 009), surfaced in the
-;; `evidence/reactive-counts` `:by-cause` projection (rf2-5x1wt.30). They are
+;; `evidence/reactive-counts` `:by-cause` projection. They are
 ;; tape-evaluated like `:rf.assert/schema-error`: NOT dispatched into the
 ;; frame, NOT a parallel accumulator — the tape is the source of truth
 ;; (spec/017 §Risks — "evidence projections drift").
@@ -585,8 +578,8 @@
 
 (defn match-causal-expectations
   "Evaluate declared causal / cascade expectations against the run's
-  projected reactive `evidence` (spec/017 §Causal and cascade assertions,
-  rf2-5x1wt.31). Pure data → data — the boundary the `run-result` assembly
+  projected reactive `evidence` (spec/017 §Causal and cascade
+  assertions). Pure data → data — the boundary the `run-result` assembly
   consumes.
 
   `causal-atoms` is the vector of declared `[:rf.assert/caused …]` /
@@ -654,7 +647,7 @@
                           `[:assert …]` checkpoints). Tape-evaluated against
                           the projected `:reactive-counts` `:by-cause` /
                           `:sub-runs` / `:renders` projection (§Causal and
-                          cascade assertions, rf2-5x1wt.31) — NOT dispatched,
+                          cascade assertions) — NOT dispatched,
                           NOT a parallel accumulator. The minted records are
                           appended to `:assertions`. These are PURE
                           expectations, not floor signals (an over-render is a
@@ -692,7 +685,7 @@
            schema-expectations causal-expectations unmet app-db attribution]
     :as   parts}]
   (let [tape           (vec (or epoch-tape []))
-        ;; rf2-rkd14 — `:attribution` (the runner / replay-recorded
+        ;; `:attribution` (the runner / replay-recorded
         ;; per-dispatch-step settle boundaries) lights up EXACT narrative
         ;; attribution. Absent → EVEN fallback, unchanged. The stamp rides
         ;; only the narrative projection; the `:epoch-tape` slot stays raw
@@ -708,7 +701,7 @@
         ;; floor and the schema matcher read the SAME projected evidence the
         ;; result's slots carry, never a second derivation.
         violations     (:schema-violations evidence-slots)
-        ;; EXACT schema-error consumption (§Schema rule, rf2-5x1wt.21): pair
+        ;; EXACT schema-error consumption (§Schema rule): pair
         ;; each declared `:rf.assert/schema-error` against the tape's
         ;; projected violations. The minted records (a `:pass` for each
         ;; matched expectation, a `:fail` for each unmatched — a MISSING
@@ -717,8 +710,8 @@
         ;; while an UNCONSUMED violation keeps its selector OUT of the set so
         ;; the floor still fails the run on it.
         schema-match   (match-schema-expectations schema-expectations violations :projected)
-        ;; Causal / cascade expectations (§Causal and cascade assertions,
-        ;; rf2-5x1wt.31): project each declared `:rf.assert/caused` /
+        ;; Causal / cascade expectations (§Causal and cascade
+        ;; assertions): project each declared `:rf.assert/caused` /
         ;; `:rf.assert/no-cascade-rerender` against the SAME reactive
         ;; evidence the tape already carries (`:reactive-counts` `:by-cause`,
         ;; `:sub-runs`, `:renders`). Pure expectations, NOT floor signals —
@@ -745,7 +738,7 @@
         ;; over `consumed-selectors`. A set collapses duplicate selectors, so
         ;; M<N expectations of a selector with N violations would falsely
         ;; excuse ALL N — a partially-consumed schema violation reading green
-        ;; (rf2-5mrnwx false-green). Threading the matcher's already-correct
+        ;; (false-green). Threading the matcher's already-correct
         ;; `:unconsumed` (pinned by result_test, pair-expectations) reuses the
         ;; verified pairing rather than re-deriving, so the floor trips on the
         ;; (N−M) genuinely-unconsumed violations.

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1,8 +1,8 @@
 (ns re-frame.story.runtime
   "Story runtime orchestration. Per `002-Runtime.md` §Programmatic API + §Four-phase lifecycle with `:loaders-complete-when`.
 
-  Stage 3 (rf2-von3) lands the runtime that consumes Stage 2's
-  registered artefacts and resolves them into a runnable variant:
+  The runtime consumes the registered artefacts and resolves them into a
+  runnable variant:
 
   - `run-variant`     — allocate frame; run four-phase lifecycle;
                         return a promise/future of the result map.
@@ -25,9 +25,8 @@
        :effective-args  {...}
        :lifecycle       :ready | :error}
 
-  Stage 5 (rf2-h8et) lands the play-sequence runtime that populates
-  `:assertions` with full assertion semantics. Stage 3 leaves the slot
-  present and empty.
+  The play-sequence runtime populates `:assertions` with full assertion
+  semantics.
 
   ## Elision
 
@@ -59,10 +58,9 @@
             [re-frame.story.result    :as result]
             [re-frame.interop         :as interop]
             [re-frame.trace           :as trace]
-            ;; rf2-qwm0a — listener API lives in
-            ;; `re-frame.trace.tooling` (production-DCE split). The
-            ;; hot-path emit fast-path (`trace/emit!`) stays in
-            ;; `re-frame.trace`.
+            ;; The listener API lives in `re-frame.trace.tooling`
+            ;; (production-DCE split). The hot-path emit fast-path
+            ;; (`trace/emit!`) stays in `re-frame.trace`.
             [re-frame.trace.tooling   :as trace-tooling]))
 
 ;; ---- empty / disabled result ---------------------------------------------
@@ -72,7 +70,7 @@
   rather than an exception. The shape matches a successful run with
   no registrations to act on."
   [variant-id]
-  {:status          :pass            ; rf2-5x1wt.19 — the unified verdict; a
+  {:status          :pass            ; the unified verdict; a
                                      ; no-registration run is vacuously green
    :frame           variant-id
    :app-db          {}
@@ -122,17 +120,16 @@
   a phase-tagged assertion via `record-error!`. Returns `body-fn`'s
   return value.
 
-  rf2-294yq5.2 — the capture set is every operation in
+  The capture set is every operation in
   `story-error/pipeline-exception-operations` (handler-exception,
   coeffect-exception, interceptor-exception), not just
   `:rf.error/handler-exception`. A loader/event phase whose cofx
-  injector or user interceptor throws was previously a silent
-  false-green; the shared `pipeline-exception-event?` predicate closes
-  that gap and the originating `:operation` / `:failing-id` are
-  preserved onto the record so a cofx failure is distinguishable from a
-  handler failure.
+  injector or user interceptor throws is caught by the shared
+  `pipeline-exception-event?` predicate, and the originating
+  `:operation` / `:failing-id` are preserved onto the record so a cofx
+  failure is distinguishable from a handler failure.
 
-  Per Spec 009 §Privacy + EP-0015 rf2-3t26eh: pipeline-exception trace
+  Per Spec 009 §Privacy + EP-0015: pipeline-exception trace
   events whose `:sensitive?` flag is true are dropped from the capture
   set when Story's local-render egress profile redacts
   (`:rf.egress/local-redacted` — the default). A counter bump is recorded
@@ -141,8 +138,8 @@
   (let [collected (atom [])
         listener  (fn [ev]
                     (cond
-                      ;; rf2-6z4znr — resolve the suppress decision against
-                      ;; the event's own frame (per-(tool,frame) visibility).
+                      ;; Resolve the suppress decision against the event's
+                      ;; own frame (per-(tool,frame) visibility).
                       (config/suppress-sensitive? ev)
                       (config/note-suppressed! (trace/trace-event-frame ev))
 
@@ -208,7 +205,7 @@
   (resolved by id-grammar, NOT part of the variant plan — the plan
   compiler only resolves the `:extends` chain + composed fragments)
   prepended to the NORMALIZED PLAN's `[:world :setup]` steps
-  (rf2-5x1wt.22, §B8 — phase 2 consumes the plan's `:setup`).
+  (§B8 — phase 2 consumes the plan's `:setup`).
 
   The story-level events keep their existing id-grammar resolution so
   `story.foo/bar` still inherits `story.foo`'s preconditions; the
@@ -216,7 +213,7 @@
   `:extends` setup APPENDS root→child and `:setup` / `:events` are both
   lowered to the one slot (spec/017 §Merge rules).
 
-  An INLINE plan (rf2-5x1wt.20) has no parent story (it is unregistered),
+  An INLINE plan has no parent story (it is unregistered),
   so `story-id` resolves nil and only the plan's own `[:world :setup]`
   drives phase 2 — the plan is already the complete setup program.
 
@@ -227,9 +224,9 @@
   headless phase-2 path can only `dispatch-sync` — it cannot honour a
   DOM/reactive boundary. Per spec/017 §Script and settled-boundary a
   step a runner cannot honour FAILS CLOSED (`:cannot-run`); silently
-  dropping it (the prior `(keep …)` behaviour) is the forbidden
-  under-run that vanishes a precondition the author wrote. The throw is
-  caught by the orchestrator and projected as an `:error` run result."
+  dropping it is the forbidden under-run that vanishes a precondition the
+  author wrote. The throw is caught by the orchestrator and projected as
+  an `:error` run result."
   [variant-id plan]
   (let [story-id     (args/parent-story-id variant-id)
         story-body   (when story-id (registrar/handler-meta :story story-id))
@@ -257,12 +254,12 @@
   "Phase 2: dispatch every phase-2 event into the variant's frame,
   draining between each. Per `002-Runtime.md` §Four-phase lifecycle with `:loaders-complete-when` phase 2.
 
-  rf2-5x1wt.22 (§B8) — the variant-chain + composed-fragment setup now
-  comes from the NORMALIZED PLAN's `[:world :setup]` (the tagged dispatch
-  steps the compiler lowered `:setup` / `:events` into), routed through
+  §B8 — the variant-chain + composed-fragment setup comes from the
+  NORMALIZED PLAN's `[:world :setup]` (the tagged dispatch steps the
+  compiler lowered `:setup` / `:events` into), routed through
   `plan-setup-events`. The parent story's `:events` (resolved by id
   grammar, not part of the plan) are prepended. The `dispatch-sync` +
-  per-event exception-drain semantics are preserved verbatim."
+  per-event exception-drain semantics apply per event."
   [variant-id plan]
   (let [all-events (plan-setup-events variant-id plan)]
     (capture-phase-errors
@@ -276,9 +273,9 @@
               ;; usually catches and re-emits via trace) record here.
               (record-error! variant-id :phase-2-events ev e))
             (finally
-              ;; rf2-z2dq8 — drain handler-exception trace events that
-              ;; the router caught into the assertions list so phase-2
-              ;; throws land where the test-mode UI looks for them.
+              ;; Drain handler-exception trace events that the router
+              ;; caught into the assertions list so phase-2 throws land
+              ;; where the test-mode UI looks for them.
               (play/drain-pending-exceptions! variant-id :phase-2-events))))))))
 
 ;; ---- phase-1 loaders execution -------------------------------------------
@@ -295,8 +292,8 @@
   `:loaders-complete-when` to override; Stage 3 routes those through
   the predicate evaluator (Stage 5 adds the full assertion runtime).
 
-  rf2-043cm — events-only fast-path: when `frames/allocate!` drives
-  the lifecycle straight to `:ready` (no loaders / no frame-setup /
+  Events-only fast-path: when `frames/allocate!` drives the lifecycle
+  straight to `:ready` (no loaders / no frame-setup /
   no `:loaders-complete-when`), this fn short-circuits with `true`
   rather than firing `start-loaders!`/`finish-loaders!` against a
   machine that's already terminal-for-mount. Both helpers would
@@ -304,7 +301,7 @@
   routing past them keeps the phase reads honest: `current-state`
   stays `:ready` end-to-end.
 
-  rf2-5x1wt.20 — the loader BODY (`:loaders` + `:loaders-complete-when`)
+  The loader BODY (`:loaders` + `:loaders-complete-when`)
   defaults to the registered variant body but MAY be supplied explicitly,
   so the inline-plan path (which has no registration) feeds the loader
   slots the compiler carried onto the plan's `:world`. The default keeps
@@ -312,7 +309,7 @@
   ([variant-id] (run-loaders! variant-id (frames/variant-body variant-id)))
   ([variant-id loader-body]
    (if (= :ready (loaders/current-state variant-id))
-    ;; Events-only fast-path (rf2-043cm). Lifecycle already terminal-
+    ;; Events-only fast-path. Lifecycle already terminal-
     ;; for-mount; the loader cascade has nothing to do.
     true
     (let [variant-body loader-body
@@ -327,9 +324,9 @@
               (catch #?(:clj Throwable :cljs :default) e
                 (record-error! variant-id :phase-1-loaders ev e))
               (finally
-                ;; rf2-z2dq8 — drain handler-exception trace events the
-                ;; router caught into the assertions list so phase-1
-                ;; loader throws surface in the test-mode UI / Xray.
+                ;; Drain handler-exception trace events the router caught
+                ;; into the assertions list so phase-1 loader throws
+                ;; surface in the test-mode UI / Xray.
                 (play/drain-pending-exceptions! variant-id :phase-1-loaders))))))
       ;; Evaluate :loaders-complete-when. In Stage 3 the predicate
       ;; resolves synchronously; Stage 6+ might add an async-retry shape.
@@ -365,7 +362,7 @@
   `opts` (optional) is threaded to `story-error/exception-record` —
   callers draining a pipeline-exception trace event pass `:operation`
   / `:failing-id` so the originating component attribution survives
-  onto the record (rf2-294yq5.2)."
+  onto the record."
   ([variant-id phase event err] (record-error! variant-id phase event err nil))
   ([variant-id phase event err opts]
    (let [record (story-error/exception-record variant-id phase event err opts)]
@@ -400,18 +397,17 @@
   "Register the runtime's internal helper events: `::append-assertion`
   for projecting exception captures + assertion records onto the
   variant frame's `:rf.story/assertions` accumulator, and `::apply-db-seed`
-  for the `:db-seed` fidelity rung (rf2-blw1q). Idempotent.
+  for the `:db-seed` fidelity rung. Idempotent.
 
   Mirrors the `install-canonical-<X>!` shape used by every sibling
-  installer in `canonical/canonical-installers`. Was the vague
-  `install-helpers!` (rf2-152jq inline rename)."
+  installer in `canonical/canonical-installers`."
   []
   (when config/enabled?
     (rf/reg-event
       ::append-assertion
       (fn [{:keys [db]} [_ record]]
         {:db (update db :rf.story/assertions (fnil conj []) record)}))
-    ;; rf2-blw1q — the `:db-seed` direct app-db seed. Merges the resolved
+    ;; The `:db-seed` direct app-db seed. Merges the resolved
     ;; `{path → value}` seed map into the frame's app-db via `assoc-in`
     ;; (a top-level keyword path is normalised to a 1-element vector), the
     ;; SAME merge `::apply-app-db-patch` (the `:frame-setup` decorator
@@ -441,18 +437,17 @@
 ;; `run-variant` is the engine's hot path. Per `002-Runtime.md` §Four-phase lifecycle with `:loaders-complete-when` it drives the
 ;; four-phase lifecycle (phase-0 setup → phase-1 loaders → phase-2 events →
 ;; phase-4 play); phase-3 render is Stage 4's UI-shell concern. To keep the
-;; orchestrator readable each phase lives in its own named fn — the audit
-;; (rf2-dd5ze, RT1) flagged the inline 70-line let/try wall the orchestrator
-;; used to be. The named-phase decomposition also gives tests a finer entry
-;; surface: a primed ctx can be fed into a single phase fn in isolation.
+;; orchestrator readable each phase lives in its own named fn. The
+;; named-phase decomposition also gives tests a finer entry surface: a
+;; primed ctx can be fed into a single phase fn in isolation.
 
 (defn- plan-checks
   "Resolve a normalized PLAN's `[:expect :checks]` ids into the
-  `{check-id [assertion-atom …]}` map the unified result groups by
-  (rf2-5x1wt.19). Expands each check id through the Story side-table
+  `{check-id [assertion-atom …]}` map the unified result groups by.
+  Expands each check id through the Story side-table
   `:check` kind (`plan/expand-checks`). Sourcing the check ids from the
   plan (rather than re-reading the variant body) means a REGISTERED
-  variant and an INLINE plan (rf2-5x1wt.20 — unregistered) resolve their
+  variant and an INLINE plan (unregistered) resolve their
   checks identically: the compiler already merged inherited + composed
   check ids into `[:expect :checks]`. Tolerant — any resolution failure
   yields an empty map (checks then group nothing; the run-level
@@ -472,9 +467,9 @@
 
   This is the SINGLE collector; the predicate-specific helpers
   (`plan-schema-expectations`, `plan-causal-expectations`) are each a
-  `filterv` over its output (rf2-2zncm). Feeds the tape-evaluated
+  `filterv` over its output. Feeds the tape-evaluated
   expectation matchers (`:rf.assert/schema-error`, `:rf.assert/caused` /
-  `:rf.assert/no-cascade-rerender`, rf2-5x1wt.31) that — unlike a
+  `:rf.assert/no-cascade-rerender`) that — unlike a
   `reg-event`-backed assertion — carry NO handler and so must be
   collected from the plan, not the `:rf.story/assertions` accumulator."
   [plan executed-script]
@@ -492,7 +487,7 @@
 
 (defn- plan-schema-expectations
   "Collect every declared `[:rf.assert/schema-error spec]` atom for a
-  normalized PLAN (rf2-5x1wt.21, spec/017 §Schema rule). These declare the
+  normalized PLAN (spec/017 §Schema rule). These declare the
   EXPECTED schema violations the result boundary exactly-consumes against
   the projected tape evidence — so a missing/different violation fails the
   run, an exactly-expected violation passes.
@@ -502,7 +497,7 @@
   atoms here is the single path that feeds the consumption matcher.
 
   Defined as a FILTER over the shared `plan-assertion-atoms` collector —
-  the same pattern `plan-causal-expectations` uses (rf2-2zncm). The
+  the same pattern `plan-causal-expectations` uses. The
   collector already wraps the three positions in a tolerant try/catch, so
   `filterv` over its `(vec (concat …))` output is identical to filtering
   the bare `concat` (filterv ignores the extra vec)."
@@ -511,7 +506,7 @@
 
 (defn- plan-causal-expectations
   "Collect every declared `:rf.assert/caused` / `:rf.assert/no-cascade-
-  rerender` atom for a normalized PLAN (rf2-5x1wt.31, spec/017 §Causal and
+  rerender` atom for a normalized PLAN (spec/017 §Causal and
   cascade assertions). These are tape-evaluated against the projected
   `:reactive-counts` `:by-cause` projection (NOT dispatched into the frame,
   NOT a parallel accumulator), so — like `:rf.assert/schema-error` —
@@ -524,7 +519,7 @@
   "The `requirements/select-runner` refusal as a one-element `:unmet` vector
   when no runner could be chosen (`:auto` and NO concrete runner satisfies
   the plan's required tokens — `:reason :no-runner-satisfies`), or `[]` when
-  a runner WAS chosen (`{:status :ok …}`). rf2-baah3. Pure data → data."
+  a runner WAS chosen (`{:status :ok …}`). Pure data → data."
   [runner-selection]
   (if (= :cannot-run (:status runner-selection))
     [runner-selection]
@@ -532,8 +527,7 @@
 
 (defn- requirements-unmet
   "The per-requirement `:cannot-run` refusals derived from the requirements
-  registry for a run (rf2-baah3 — wire `re-frame.story.requirements` into the
-  run path). Pure data → data. Three sources, unioned:
+  registry for a run. Pure data → data. Three sources, unioned:
 
   1. the `select-runner` refusal, when `:auto` selection found NO capable
      runner (`selection-refusal`);
@@ -574,8 +568,8 @@
                  (or post-run [])))))
 
 (defn- record-result-map
-  "Build the unified run-result returned by `run-variant` (rf2-5x1wt.19,
-  spec/017 §Run result + §Unified run result). Gathers whatever the
+  "Build the unified run-result returned by `run-variant` (spec/017
+  §Run result + §Unified run result). Gathers whatever the
   runtime accumulated against the variant's frame and assembles the ONE
   shared shape via `result/run-result`:
 
@@ -589,18 +583,18 @@
     unified records + groups them under their check ids;
   - the top-level `:status` is the unified verdict.
 
-  The legacy `:lifecycle` / `:frame` / `:snapshot` / `:decorators` /
+  The `:lifecycle` / `:frame` / `:snapshot` / `:decorators` /
   `:effective-args` / `:rendered-hiccup` slots are PRESERVED (API stable,
-  spec/017 §1a — `:status` is NET-NEW alongside `:lifecycle`), so existing
-  consumers keep reading their slots while the unified shape lands.
+  spec/017 §1a — `:status` sits alongside `:lifecycle`), so consumers can
+  read those slots and the unified shape from the one result.
 
-  Checks + schema-expectations are sourced from the compiled `:plan`
-  (rf2-5x1wt.20), so a registered variant and an INLINE plan assemble the
+  Checks + schema-expectations are sourced from the compiled `:plan`,
+  so a registered variant and an INLINE plan assemble the
   same result through one path."
   [{:keys [variant-id decorator-stack effective-args snapshot executed-script
            plan runner-selection]} start-ms]
   (let [app-db   (rf/app-db-value variant-id)
-        ;; rf2-5x1wt.19 follow-through — read the epoch tape through the
+        ;; Read the epoch tape through the
         ;; late-bound `re-frame.core/epoch-history` facade (mirroring
         ;; `re-frame.story.artifact`'s replay-path read), NOT a hard
         ;; `[re-frame.epoch …]` require. Story's published surface (and
@@ -609,28 +603,28 @@
         ;; (per `re-frame.core/epoch-history`'s contract) while the
         ;; `:test`-alias epoch dep makes it the live tape under the gate.
         tape     (vec (rf/epoch-history variant-id))
-        ;; rf2-rkd14 — the runner-recorded per-dispatch-step settle
-        ;; boundaries light up the EXACT narrative attribution
-        ;; (`evidence/spans-from-stamps`) instead of the EVEN heuristic. The
+        ;; The runner-recorded per-dispatch-step settle boundaries light
+        ;; up the EXACT narrative attribution
+        ;; (`evidence/spans-from-stamps`). The
         ;; stamp is a `:rf.story/*` key the determinism projection strips, so
         ;; the run-hash is unaffected (the `:epoch-tape` slot stays raw).
         attribution (runner-events/settle-boundaries variant-id)
-        ;; rf2-baah3 — project the tape ONCE here so the post-run evidence
+        ;; Project the tape ONCE here so the post-run evidence
         ;; validation (`requirements-unmet` → `validate-run-evidence`) reads
         ;; the SAME projected slots `result/run-result` derives the result
         ;; slots from. One tape, one projection — a duplicate accumulator
         ;; cannot report a proof present while the tape's slot is empty.
         evidence (evidence/project-evidence tape {:script      executed-script
                                                   :attribution attribution})
-        ;; rf2-q5jw4 — the run-state's `:cannot-run` refusals (a no-DOM
+        ;; The run-state's `:cannot-run` refusals (a no-DOM
         ;; `[:assert-dom …]` skip, a boundary `:cannot-run?`): steps that
-        ;; recorded NO `:rf.story/assertions` entry, so without this fold the
-        ;; unified result aggregated to `:pass` (vacuous green) while the
+        ;; recorded NO `:rf.story/assertions` entry. Without this fold the
+        ;; unified result would aggregate to `:pass` (vacuous green) while the
         ;; run-state read `:cannot-run`. The facade degrades to nil run-state
         ;; (empty refusals) on a host with no runner-events run-state.
         run-state-unmet (runner/run-state-refusals
                           (runner-events/current-state variant-id))
-        ;; rf2-baah3 — the requirements-registry refusals: the `:auto`
+        ;; The requirements-registry refusals: the `:auto`
         ;; no-capable-runner refusal, the fixed-runner per-unit capability
         ;; gaps (`unmet-assertions` / `unmet-steps`), and the post-run
         ;; fail-closed evidence-slot validation (`validate-run-evidence`).
@@ -643,26 +637,26 @@
         unified  (result/run-result
                    {:variant/id          variant-id
                     :epoch-tape          tape
-                    ;; rf2-rkd14 — the runner-recorded per-dispatch-step settle
+                    ;; The runner-recorded per-dispatch-step settle
                     ;; boundaries (above) so `run-result`'s ONE evidence
                     ;; projection attributes the `:narrative` EXACTLY.
                     :attribution         attribution
                     :assertions          (or (:rf.story/assertions app-db) [])
                     :script              executed-script
                     :check->atoms        (plan-checks plan)
-                    ;; rf2-baah3 — the CHOSEN runner + the plan's required
+                    ;; The CHOSEN runner + the plan's required
                     ;; capability set, surfaced on the result so Test mode /
                     ;; CI / MCP read which runner ran + what it needed.
                     :runner              (:runner runner-selection)
                     :required-runner     (get plan :required-runner #{})
-                    ;; rf2-5x1wt.21 — the declared `:rf.assert/schema-error`
+                    ;; The declared `:rf.assert/schema-error`
                     ;; expectations, EXACT-consumed against the projected
                     ;; tape violations (§Schema rule). Tape-evaluated, NOT
                     ;; dispatched — collected from the plan, not the
                     ;; `:rf.story/assertions` accumulator.
                     :schema-expectations (plan-schema-expectations
                                            plan executed-script)
-                    ;; rf2-5x1wt.31 — the declared causal / cascade
+                    ;; The declared causal / cascade
                     ;; expectations (`:rf.assert/caused` /
                     ;; `:rf.assert/no-cascade-rerender`), tape-evaluated
                     ;; against the projected `:reactive-counts` `:by-cause`
@@ -671,7 +665,7 @@
                     ;; dispatched — collected from the plan.
                     :causal-expectations (plan-causal-expectations
                                            plan executed-script)
-                    ;; rf2-q5jw4 — the per-requirement `:cannot-run` refusals
+                    ;; The per-requirement `:cannot-run` refusals
                     ;; the runner could not even attempt (above). Folded into
                     ;; the verdict + surfaced on `:cannot-run` by
                     ;; `result/run-result`.
@@ -685,7 +679,7 @@
                     :decorators      decorator-stack
                     :effective-args  effective-args
                     :lifecycle       (loaders/current-state variant-id)})
-      ;; EP-0023 §Stories (rf2-fpr0b5 item 4) — surface the behaviour-variant
+      ;; EP-0023 §Stories — surface the behaviour-variant
       ;; IMAGE ids the run resolved behaviour against, so Test mode / MCP /
       ;; Xray can show WHICH behaviour set ran. Present only for a behaviour
       ;; variant (one that declared `:images`); omitted for an ordinary state
@@ -694,8 +688,7 @@
       (assoc :images (frames/variant-image-ids variant-id)))))
 
 (defn- resolve-runner-selection
-  "Normalize the run `opts` and SELECT the runner for `plan` (rf2-baah3 —
-  wire `re-frame.story.requirements` into the run path). Returns the
+  "Normalize the run `opts` and SELECT the runner for `plan`. Returns the
   `requirements/select-runner` outcome — either `{:status :ok :runner …
   :unmet …}` (a runner was chosen; under `:auto` it satisfies all, under
   fixed `:headless` its `:unmet` may be non-empty) or a
@@ -721,41 +714,36 @@
   PLAN, the decorator stack, the effective args, and the identity
   snapshot. Returns a map; pure aside from the registrar reads.
 
-  rf2-5x1wt.22 (§B8 — Runtime Migration) — the shipping run-variant path
-  now routes through the variant-plan compiler (`re-frame.story.plan`).
-  `prepare-context` compiles the normalized plan ONCE and threads it
-  down the phase pipeline (spec/017 §Variant plan — every registered
-  variant MUST be normalized before execution). Phase 2 consumes the
-  plan's `[:world :setup]` (the tagged setup steps); phase 4 consumes
-  its `[:world :scripts]` (the named scripts — `:plays` preserved). A
-  plan-construction failure (an unknown variant, a missing `[:arg …]`,
-  a misplaced `[:assert …]` in setup, …) throws here; the orchestrator's
-  try/catch (`handle-run-error!`) projects it onto the run result so the
-  error reports the same way it did before the routing.
+  §B8 — the run-variant path routes through the variant-plan compiler
+  (`re-frame.story.plan`). `prepare-context` compiles the normalized plan
+  ONCE and threads it down the phase pipeline (spec/017 §Variant plan —
+  every registered variant MUST be normalized before execution). Phase 2
+  consumes the plan's `[:world :setup]` (the tagged setup steps); phase 4
+  consumes its `[:world :scripts]` (the named scripts — `:plays`
+  preserved). A plan-construction failure (an unknown variant, a missing
+  `[:arg …]`, a misplaced `[:assert …]` in setup, …) throws here; the
+  orchestrator's try/catch (`handle-run-error!`) projects it onto the run
+  result.
 
-  rf2-0wrud (2026-05-20): the legacy `:play` event-vector slot was
-  removed; phase-4 drives the rich-DSL step executor through
-  `runner-events/run!`."
+  Phase-4 drives the rich-DSL step executor through `runner-events/run!`."
   [variant-id variant-body opts]
-  (let [;; rf2-2cpoo — compile the plan WITH the per-run arg layers
+  (let [;; Compile the plan WITH the per-run arg layers
         ;; (`:active-modes` / `:cell-overrides`) so the substituted
         ;; setup/script/db-seed/network/sub-overrides, `[:world :effective-args]`,
         ;; and the plan hash all use the SAME effective args the result
-        ;; reports. Previously the plan compiled with the static variant args
-        ;; while the result reported the override/mode-aware
-        ;; `args/resolve-args`, so a cell override or active mode executed a
-        ;; different scenario than the one reported.
+        ;; reports. The plan and the result thus run the SAME scenario the
+        ;; cell override or active mode describes.
         plan (plan/variant-plan variant-id
                                 {:run-args (args/run-arg-layers variant-id opts)})]
     {:variant-id       variant-id
      :variant-body     variant-body
      :plan             plan
-     ;; rf2-baah3 — select the runner for this plan up front (the cheapest
+     ;; Select the runner for this plan up front (the cheapest
      ;; capable runner under :auto, or the fixed runner the caller asked for).
      ;; Threaded down so `record-result-map` can surface the chosen runner +
      ;; fold UNMET requirements into the unified result's :cannot-run.
      :runner-selection (resolve-runner-selection plan opts)
-     ;; rf2-2cpoo — resolve the decorator stack from the ALREADY-compiled
+     ;; Resolve the decorator stack from the ALREADY-compiled
      ;; plan's `[:world :decorators]` refs (the twin of the inline path's
      ;; `prepare-inline-context`), NOT via `decorators/resolve-decorators`
      ;; which recompiles the plan WITHOUT `:run-args`. Reusing this plan
@@ -767,7 +755,7 @@
      ;; so `:active-modes` does not perturb the decorator refs.
      :decorator-stack  (decorators/resolve-decorator-refs
                          (get-in plan [:world :decorators] []))
-     ;; rf2-2cpoo — report the SAME effective args the plan was compiled
+     ;; Report the SAME effective args the plan was compiled
      ;; with (the plan is the single source of truth). The plan folds the
      ;; ambient + run layers around its `:extends`-aware variant layer, so
      ;; `[:world :effective-args]` equals `args/resolve-args` for a variant
@@ -777,7 +765,7 @@
      :snapshot         (ident/snapshot-identity variant-id opts)}))
 
 (defn- ensure-fresh-frame!
-  "Enforce a FRESH-RUN boundary for `variant-id` (rf2-294yq5.3). Per
+  "Enforce a FRESH-RUN boundary for `variant-id`. Per
   spec/002-Runtime §`run-variant` step 1 — `run-variant` allocates OR
   resets the variant frame; it never reuses an existing one.
 
@@ -792,18 +780,17 @@
   When a frame already exists under `variant-id` we reset it to fresh
   state IN PLACE via `frames/reset-state!` — overwriting both frame-state
   partitions with `{}` through the one physical container so the frame's
-  IDENTITY, sub-cache, and projection reactions all survive. This is the
-  rf2-294yq5 PR #3672 last-red fix: the prior cut `destroy!`d the frame
-  here, but the canvas mounts the variant view (establishing its
-  `@(subscribe …)` reactions on this frame's sub-cache) BEFORE
-  `:component-did-mount` → `run-variant` runs — so a destroy orphaned
-  every live reaction and a subsequent `:counter/set 42` never re-rendered
-  the DOM (count-display stuck at \"0\"), invisible to the JVM. The in-place
-  reset gives the same fresh app-db AND drops the lifecycle machine
-  snapshot (runtime-db → `{}`) so loaders re-run — without breaking the
-  live reactions. When no frame exists this is a no-op and the subsequent
-  `allocate!` builds the clean frame. Determinism by default; an
-  intentionally-persistent mode would be an explicit opt, not the default."
+  IDENTITY, sub-cache, and projection reactions all survive. The in-place
+  reset matters because the canvas mounts the variant view (establishing
+  its `@(subscribe …)` reactions on this frame's sub-cache) BEFORE
+  `:component-did-mount` → `run-variant` runs — so a `destroy!` would
+  orphan every live reaction and a subsequent `:counter/set 42` would
+  never re-render the DOM. The in-place reset gives a fresh app-db AND
+  drops the lifecycle machine snapshot (runtime-db → `{}`) so loaders
+  re-run — without breaking the live reactions. When no frame exists this
+  is a no-op and the subsequent `allocate!` builds the clean frame.
+  Determinism by default; an intentionally-persistent mode would be an
+  explicit opt, not the default."
   [variant-id]
   (when (contains? (set (rf/frame-ids)) variant-id)
     (frames/reset-state! variant-id)))
@@ -813,21 +800,21 @@
   with its decorator stack, then install the play-runner's privacy
   egress listener.
 
-  rf2-294yq5.3 — `ensure-fresh-frame!` resets any pre-existing frame
-  under `variant-id` to fresh state IN PLACE BEFORE allocation so two
-  consecutive `run-variant` calls on the same id produce the same fresh
-  app-db and loader variants rerun their loaders on the second call
-  (spec/002 §`run-variant` step 1). The in-place reset (rf2-294yq5 PR
-  #3672) preserves frame identity + sub-cache so a live mounted view's
+  `ensure-fresh-frame!` resets any pre-existing frame under `variant-id`
+  to fresh state IN PLACE BEFORE allocation so two consecutive
+  `run-variant` calls on the same id produce the same fresh app-db and
+  loader variants rerun their loaders on the second call
+  (spec/002 §`run-variant` step 1). The in-place reset
+  preserves frame identity + sub-cache so a live mounted view's
   reactions survive the re-run — a `destroy!` here would orphan them.
 
-  The listener install order matters (rf2-v2g9): it must be in place
+  The listener install order matters: it must be in place
   BEFORE phase-1 loaders fire so the privacy gate suppresses sensitive
   loader-phase events and loader-phase handler-exceptions are captured.
   We clear the per-frame `pending-exceptions` slot so the listener has a
   clean slot; `execute-play!` clears it again at play start.
 
-  rf2-luzky: the `:loaders-complete-when` vector form now reads the epoch
+  The `:loaders-complete-when` vector form reads the epoch
   tape (`assertions/dispatched-events`, the SSOT) rather than a side-table
   accumulator, so there is no accumulator to seed here."
   [{:keys [variant-id decorator-stack] :as ctx}]
@@ -839,13 +826,13 @@
 
 (defn- db-seed-violations
   "Validate the seeded `db` against the frame's REGISTERED app-db schemas
-  (rf2-blw1q + spec/017 §Setup — direct seeding bypasses event / cofx
+  (spec/017 §Setup — direct seeding bypasses event / cofx
   validation but MUST validate the affected app-db schema). Returns a
   (possibly empty) vector of `{:path :value :explain}` violations.
 
   REUSES the existing schemas late-bind seam — the SAME
   `:schemas/validate-with-registered-fn` / `:schemas/explain-with-registered-fn`
-  the `:sub-return` path + the rf2-7pgiz `:sub-override` fold-in reach, and
+  the `:sub-return` path + the `:sub-override` fold-in reach, and
   `:schemas/frame-schema-entries` to enumerate the frame's registered
   `{path → schema-meta}`. No new validation mechanism, and no hard dep on
   the schemas artefact: when it is absent every hook resolves nil and the
@@ -874,7 +861,7 @@
             (entries-fn frame-id)))))
 
 (defn- run-db-seed!
-  "Phase 0.5 (rf2-blw1q): seed the variant frame's app-db from the plan's
+  "Phase 0.5: seed the variant frame's app-db from the plan's
   `[:world :db-seed]` slot, then SCHEMA-VALIDATE the seeded app-db — BEFORE
   any loaders (phase 1) or setup events (phase 2) run. The MIDDLE fidelity
   rung: a direct app-db state seed merged into the frame ahead of the
@@ -917,7 +904,7 @@
   "Phase 1: drive loaders to completion. Thin wrapper that returns
   `ctx` so the orchestrator stays a clean threaded pipeline.
 
-  rf2-5x1wt.20 — the loader body defaults to the registered variant body
+  The loader body defaults to the registered variant body
   (`run-loaders!` 1-arity); an inline run threads `:loader-body` on the
   ctx (the plan's `:world` loader slots), so an inline plan's loaders run
   through the SAME phase fn without reading the side-table."
@@ -930,7 +917,7 @@
 (defn- run-phase-2!
   "Phase 2: dispatch the plan's `[:world :setup]` (+ the parent story's
   `:events`), then mark events complete on the lifecycle machine.
-  rf2-5x1wt.22 (§B8) — setup is sourced from the normalized plan."
+  §B8 — setup is sourced from the normalized plan."
   [{:keys [variant-id loaders-complete? plan] :as ctx}]
   (when loaders-complete?
     (run-events! variant-id plan)
@@ -939,8 +926,8 @@
 
 (defn- settle-terminal-assertions!
   "Evaluate the plan's terminal handler-backed `:assertions` against the
-  FINAL settled state (rf2-nyjoa — Mike RULED B: terminal `:assertions`
-  AUTO-RUN). Called AFTER the script phase settles (after the auto-plays
+  FINAL settled state (terminal `:assertions` AUTO-RUN). Called AFTER the
+  script phase settles (after the auto-plays
   complete, or — for a variant with no script — after phase-2 setup), so the
   terminal atoms read 'check the FINAL settled state' while an in-script
   `[:assert …]` checkpoint stays 'check here, now'.
@@ -959,8 +946,8 @@
   for them and never dispatches — `result/run-result` already evaluates them
   against the epoch tape from the plan's `:schema-expectations` /
   `:causal-expectations` (collected by `plan-schema-expectations` /
-  `plan-causal-expectations`). Only the handler-backed terminal atoms (the
-  previously-inert surface) are evaluated here. Tolerant — any failure is
+  `plan-causal-expectations`). Only the handler-backed terminal atoms are
+  evaluated here. Tolerant — any failure is
   swallowed (record-don't-throw)."
   [variant-id plan]
   (try
@@ -972,23 +959,22 @@
 (defn- run-phase-4!
   "Phase 4: run the play-script. Returns `[ctx' play-promise]` — `ctx'`
   carries `:executed-script` (the folded steps the auto-plays ran, for the
-  unified result's two-level narrative — rf2-5x1wt.19), and the
+  unified result's two-level narrative), and the
   orchestrator chains `then` on the promise to know when to build the
   result.
 
-  rf2-0wrud (2026-05-20): drives the rich-DSL `:play-script` runner via
+  Drives the rich-DSL `:play-script` runner via
   `runner-events/run!`. Variants without `:play-script` / `:plays`
-  resolve to an empty script and the promise resolves immediately. The
-  legacy `:play` event-vector slot was removed — author event sequences
-  by wrapping each entry in `[:dispatch-sync <event-vec>]` inside a
-  `:play-script` body.
+  resolve to an empty script and the promise resolves immediately. Author
+  event sequences by wrapping each entry in `[:dispatch-sync <event-vec>]`
+  inside a `:play-script` body.
 
-  rf2-5x1wt.19 — the resolved play scripts are FOLDED (shipping
+  The resolved play scripts are FOLDED (shipping
   `:assert-db` / `:assert-dom` rewritten to the canonical `[:assert …]`
   checkpoint), so the executed-script narrative carries the one
   assertion atom.
 
-  rf2-5x1wt.22 (§B8) — the play set now comes from the NORMALIZED PLAN's
+  §B8 — the play set comes from the NORMALIZED PLAN's
   `[:world :scripts]` (the named scripts the compiler's `normalize-scripts`
   produces — `:plays` preserved as named scripts, spec/017 §Public
   vocabulary), NOT a second `runner-events/variant-plays` read of the
@@ -1007,7 +993,7 @@
           ;; the script the unified result's two-level narrative spans.
           executed   (vec (mapcat :script auto-plays))
           ctx'       (assoc ctx :executed-script executed)
-          ;; rf2-rkd14 — reset the per-dispatch-step settle boundaries before
+          ;; Reset the per-dispatch-step settle boundaries before
           ;; the auto-plays drive, so the narrative attribution windows onto
           ;; THIS run's epoch tape. The boundaries snapshot the ABSOLUTE
           ;; epoch-history length at each dispatch step (setup-phase epochs
@@ -1017,7 +1003,7 @@
       (if (empty? auto-plays)
         ;; No script ran, but the world settled (phase-2 setup committed).
         ;; The terminal `:assertions` check the FINAL settled state, so they
-        ;; still auto-run here (rf2-nyjoa).
+        ;; still auto-run here.
         [ctx' (async/resolved (do (settle-terminal-assertions! variant-id plan)
                                   (read-assertions variant-id)))]
         [ctx'
@@ -1028,14 +1014,14 @@
              ;; `:rf.story/assertions` on the frame via the standard
              ;; assertion handlers. Once every auto-play has finished, the
              ;; terminal `:assertions` are evaluated against the FINAL
-             ;; settled state (rf2-nyjoa) and the orchestrator builds the
+             ;; settled state and the orchestrator builds the
              ;; result map from the frame's accumulated assertions.
              (letfn [(step! [remaining]
                        (if (empty? remaining)
                          (do (settle-terminal-assertions! variant-id plan)
                              (resolve (read-assertions variant-id)))
                          (let [spec (first remaining)]
-                           ;; rf2-76l69l — the orchestrator cleared the settle
+                           ;; The orchestrator cleared the settle
                            ;; boundaries ONCE above (before the loop). Drive
                            ;; every auto-play with `:clear-boundaries? false`
                            ;; so the per-play absolute boundaries ACCUMULATE
@@ -1050,9 +1036,9 @@
 
 (defn- finalise-run!
   "Build and deliver the result map once phase 4's promise settles.
-  Stage 5 (rf2-h8et) makes this chain load-bearing: `execute-play!`
-  resolves the promise to the assertions vector, and we want the
-  result map to read the post-play app-db."
+  This chain is load-bearing: `execute-play!` resolves the promise to the
+  assertions vector, and we want the result map to read the post-play
+  app-db."
   [resolve play-promise ctx start-ms]
   (-> play-promise
       (async/then
@@ -1064,7 +1050,7 @@
   "True iff `e` is a plan-construction failure — an `ex-info` `re-frame.
   story.plan/fail!` threw. `fail!` stamps `:where 'rf.story/variant-plan`
   on every `:rf.error/story-*` failure, so that marker (NOT the bare
-  presence of `:rf.error/id`) is the discriminator. rf2-5x1wt.22 (§B8):
+  presence of `:rf.error/id`) is the discriminator. §B8 —
   the runtime compiles the plan in `prepare-context`, BEFORE the frame is
   allocated, so a malformed variant (a missing `[:arg …]`, an `[:assert …]`
   in `:setup`, a `:compose` of an unknown fragment, …) throws here. Such
@@ -1079,8 +1065,7 @@
   `reg-frame` → `make-state-container` when the host installed no
   adapter (the JVM-standalone story-mcp server). Those land after the
   frame exists at `:pre-mount`, so they must take the frame-bound
-  record/transition branch, NOT `plan-error-result` (rf2-5x1wt.22
-  follow-through)."
+  record/transition branch, NOT `plan-error-result`."
   [e]
   (= 'rf.story/variant-plan (:where (ex-data e))))
 
@@ -1090,7 +1075,7 @@
 
 (defn- plan-error-result
   "The error result returned when `re-frame.story.plan/variant-plan`
-  FAILS to compile the variant (rf2-5x1wt.22, §B8). The frame is not
+  FAILS to compile the variant (§B8). The frame is not
   allocated when plan construction throws, so the result is built
   directly from the exception — mirroring `unknown-variant-result`'s
   frame-free shape. The `:rf.error/story-*` id rides the assertion record
@@ -1110,7 +1095,7 @@
 
 (defn- db-seed-error?
   "True iff `e` is the structured `:db-seed` schema-validation failure
-  `run-db-seed!` throws (rf2-blw1q). Discriminated on `:rf.error/id` —
+  `run-db-seed!` throws. Discriminated on `:rf.error/id` —
   the seed throw stamps `:rf.error/story-db-seed-invalid` with a
   `:violations` vector. The frame IS allocated when it throws (the seed
   ran against it), so it takes the frame-bound branch, but we record it as
@@ -1122,7 +1107,7 @@
 
 (defn- record-seed-error!
   "Append the structured `:rf.error/story-db-seed-invalid` assertion to the
-  variant frame's `:rf.story/assertions` accumulator (rf2-blw1q). The
+  variant frame's `:rf.story/assertions` accumulator. The
   record carries the `:violations` vector (`{:path :value :explain}` per
   violating slice) so the result surfaces the exact schema misses the seed
   produced (spec/017 §Setup). `:passed? false` makes the run aggregate to
@@ -1149,32 +1134,26 @@
   the unified result's `:assertions`, so the aggregation reports `:fail`
   (the error record is a failed expectation) even when the tape is sparse.
 
-  rf2-5x1wt.22 (§B8) — a plan-construction failure (thrown in
+  §B8 — a plan-construction failure (thrown in
   `prepare-context`, before frame allocation) cannot be recorded onto a
   frame, so it is projected directly via `plan-error-result`. Every other
   throw lands after the frame exists and routes through the frame-bound
   record/transition path.
 
-  rf2-blw1q — a `:db-seed` schema-validation failure (`run-db-seed!`)
+  A `:db-seed` schema-validation failure (`run-db-seed!`)
   throws AFTER the frame is allocated, so it takes the frame-bound branch,
   but is recorded as its own structured `:rf.error/story-db-seed-invalid`
   assertion (carrying the path/value/explain violations) rather than the
   opaque `:rf.error/exception` shape.
 
-  rf2-5fv445 — the plan-construction branch is gated SOLELY on
+  The plan-construction branch is gated SOLELY on
   `plan-construction-error?` (the `:where 'rf.story/variant-plan` marker
-  that `re-frame.story.plan/fail!` stamps). The earlier `:pre-mount`
-  lifecycle guard was redundant AND stale-frame-sensitive: a plan compiled
-  in `prepare-context` ALWAYS throws before this run allocates/resets its
-  frame, but if a PRIOR `run-variant` on the same id had already driven the
-  frame to `:ready`, `loaders/current-state` returns `:ready` (not
-  `:pre-mount`), so the guard fell through to the `:else` frame-bound
-  branch — recording an opaque `:rf.error/exception` and reading the PRIOR
-  run's stale `:app-db` into this run's result (violating spec/017's
-  contract that `:app-db` is THIS run's final db). The `:where` discriminator
-  already separates plan-compiler failures from later framework/runtime
+  that `re-frame.story.plan/fail!` stamps). The `:where` discriminator
+  separates plan-compiler failures from later framework/runtime
   errors (which carry `:rf.error/id` but not the plan marker), so the
-  lifecycle state is not needed to route correctly."
+  lifecycle state is not needed to route correctly — gating on lifecycle
+  state would be stale-frame-sensitive (a PRIOR `:ready` run on the same
+  id leaves `loaders/current-state` at `:ready`, not `:pre-mount`)."
   [resolve variant-id e start-ms]
   (cond
     (plan-construction-error? e)
@@ -1247,7 +1226,7 @@
                  (catch #?(:clj Throwable :cljs :default) e
                    (handle-run-error! resolve variant-id e start-ms)))))))))))
 
-;; ---- inline plan execution (rf2-5x1wt.20) --------------------------------
+;; ---- inline plan execution -----------------------------------------------
 ;;
 ;; An inline plan (spec/017 §Inline plan) is an executable plan MAP that is
 ;; NOT registered as a Story variant: it MUST NOT appear in Story
@@ -1255,8 +1234,8 @@
 ;; return the SAME run-result shape as a registered variant. `story/run`,
 ;; `story/is`, and `story/explain` already accept a map target (the verbs
 ;; dispatch on target type — a keyword is a registry lookup, a map is an
-;; inline plan); `variant-plan` / `explain` compile a map directly
-;; (rf2-5x1wt.24). This is the RUN path for a map target.
+;; inline plan); `variant-plan` / `explain` compile a map directly.
+;; This is the RUN path for a map target.
 ;;
 ;; The design reuses the registered run pipeline rather than forking it:
 ;;
@@ -1287,7 +1266,7 @@
 
 (defn- prepare-inline-context
   "Resolve the per-run inputs an inline-plan run needs from its COMPILED
-  `plan` (rf2-5x1wt.20). Registry-free twin of `prepare-context`:
+  `plan`. Registry-free twin of `prepare-context`:
 
   - `:variant-id`      — the minted anonymous frame id (the run's frame);
   - `:plan`            — the supplied compiled plan, threaded down the
@@ -1308,7 +1287,7 @@
   Pure aside from the decorator-body registrar reads (a decorator is a
   registered artefact even when the plan is not).
 
-  rf2-baah3 — `:runner-selection` is selected from the SAME compiled plan +
+  `:runner-selection` is selected from the SAME compiled plan +
   run `opts` a registered run uses (`resolve-runner-selection`), so an inline
   plan threads requirements selection identically — an UNMET requirement
   surfaces `:cannot-run` on the inline path too."
@@ -1327,7 +1306,7 @@
 (defn- inline-events-only?
   "True iff the inline `plan` drives no loaders / loaders-complete-when and
   carries no `:frame-setup` decorators — so the lifecycle takes the
-  `:pre-mount → :ready` fast-path (rf2-043cm). Mirrors
+  `:pre-mount → :ready` fast-path. Mirrors
   `loaders/events-only-variant?`, reading the loader slots off the plan's
   `:world` rather than a registered body."
   [plan decorator-stack]
@@ -1339,7 +1318,7 @@
   "Phase 0 for an inline run: allocate the ANONYMOUS frame from the plan
   (registry-free), then clear the per-frame `pending-exceptions` slot +
   install the play-runner privacy egress listener — the same ordering
-  `run-phase-0!` uses so loader-phase events are captured (rf2-luzky: no
+  `run-phase-0!` uses so loader-phase events are captured (no
   side-table to seed)."
   [{:keys [variant-id plan decorator-stack] :as ctx}]
   (frames/allocate-inline! variant-id
@@ -1351,7 +1330,7 @@
   ctx)
 
 (defn run-inline-plan
-  "Execute an inline plan MAP (rf2-5x1wt.20, spec/017 §Inline plan) and
+  "Execute an inline plan MAP (spec/017 §Inline plan) and
   return a promise/future of the unified run-result — the SAME shape a
   registered variant run returns.
 
@@ -1389,16 +1368,13 @@
                frame-id (mint-inline-frame-id)]
            (async/promise
              (fn [resolve]
-               ;; rf2-7u3eja — the SUCCESS path tears the inline frame down
+               ;; The SUCCESS path tears the inline frame down
                ;; with the decorator stack used for allocation + the plan's
-               ;; `:loaders-teardown`; the FAILURE path MUST converge on the
-               ;; SAME teardown. Previously the catch ran
-               ;; `(destroy-inline! frame-id nil nil)` — the frame was removed
-               ;; but `:loaders-teardown` + frame-setup decorator `:teardown`
-               ;; were SKIPPED, so any resource opened by an inline-plan loader
-               ;; or `:frame-setup` decorator leaked on precisely the failure
-               ;; path (db-seed / phase 1 / phase 2 / phase 4 setup) where
-               ;; cleanup matters.
+               ;; `:loaders-teardown`; the FAILURE path converges on the
+               ;; SAME teardown, so any resource opened by an inline-plan
+               ;; loader or `:frame-setup` decorator is released on every
+               ;; failure path (db-seed / phase 1 / phase 2 / phase 4 setup)
+               ;; where cleanup matters.
                ;;
                ;; The decorator stack is fixed at `prepare-inline-context`
                ;; time (resolved once, constant across phases), so `teardown!`
@@ -1420,7 +1396,7 @@
                                         (get-in plan [:world :loaders-teardown]))
                                       (catch #?(:clj Throwable :cljs :default) _ nil))))
                      fail!      (fn [e]
-                                  ;; rf2-blw1q — a `:db-seed` schema-validation
+                                  ;; A `:db-seed` schema-validation
                                   ;; failure records as its own structured
                                   ;; assertion; every other throw stays the
                                   ;; opaque `:rf.error/exception` shape.

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -1,9 +1,9 @@
 (ns re-frame.story.save-variant
   "Save-current-canvas-state-as-new-variant — the SB9 'Save' affordance
-  (rf2-one3t; SB9 story-from-UI parity per rf2-v05qb §2.2).
+  (SB9 story-from-UI parity).
 
   Story-from-UI in two affordances: (a) record-as-`:play-script` (Test Codegen,
-  rf2-5fc15 — `re-frame.story.recorder`); (b) snapshot-args-as-`:args`
+  `re-frame.story.recorder`); (b) snapshot-args-as-`:args`
   (this namespace). Both surface the captured state through the same
   review-then-commit modal pattern — Story emits an EDN snippet the user
   copies into source. Source is never written directly; the modal-preview
@@ -81,7 +81,7 @@
 (defn snapshot-violations
   "Project `args-snapshot` against `schema` using the validator-fn pair.
   Thin pass-through to `schema-validation/args-violations` exposed here
-  for the save-as-variant flow (rf2-lancu) — the save dialog reads the
+  for the save-as-variant flow — the save dialog reads the
   result to render a non-blocking 'Args do not match the variant's
   Spec 010 schema' hint above the snippet, so the user catches a
   drifted-args paste before it hits source.
@@ -93,7 +93,7 @@
   (schema-validation/args-violations args-snapshot schema validator-fns))
 
 ;; ---------------------------------------------------------------------------
-;; Pure: the eight-slice capture model (rf2-ba86n.6)
+;; Pure: the eight-slice capture model
 ;;
 ;; spec/019 §3 lists the slices a save-current-state flow MAY have to
 ;; project — args, sub-overrides, db-seed, route, network, fx-overrides,
@@ -169,7 +169,7 @@
 (defn capture-slices
   "Return the eight-slice capture report for a save-current-state flow.
   Pure data → vector of slice descriptors in `slice-order`. The HONESTY
-  FLOOR (rf2-ba86n.6): each slice is classified honestly — a slice is
+  FLOOR: each slice is classified honestly — a slice is
   only `:projectable` when a LIVE controls projection exists; otherwise
   it is `:captured-as-declared` (the source body declares a value we
   carry forward via `:extends`) or `:not-wired` (nothing to capture, and
@@ -224,8 +224,8 @@
        (not-wired :sub-overrides (slice-labels :sub-overrides)
                   "No live View-State controls and none declared on the source — sub-overrides are not yet projectable (rf2-7pgiz)."))
 
-     ;; db-seed: the schema-checked app-db seed fidelity rung is not wired
-     ;; (rf2-blw1q). The closest declared analogue on the source body is
+     ;; db-seed: the schema-checked app-db seed fidelity rung is not wired.
+     ;; The closest declared analogue on the source body is
      ;; `:setup` (real setup events) — surfaced as captured-as-declared so
      ;; the report is honest about what carries forward via :extends.
      (if (some? setup)
@@ -325,12 +325,11 @@
 ;; Default-id derivation + dialog state shape
 ;;
 ;; The dialog state machine + the default-id derivation live in the
-;; shared `re-frame.story.review-dialog` ns (rf2-7jpky); the save-
-;; variant flow's only flavour is the `\"saved-\"` prefix on the auto-
-;; derived id and the `{:args <snapshot>}` shape stashed in the
-;; dialog's `:context` slot. Thin re-exports below for ergonomics +
-;; the legacy `:args` key in the opened state (preserved for callers
-;; that read it via the open-dialog callback).
+;; shared `re-frame.story.review-dialog` ns; the save-variant flow's
+;; only flavour is the `\"saved-\"` prefix on the auto-derived id and
+;; the `{:args <snapshot>}` shape stashed in the dialog's `:context`
+;; slot. Thin re-exports below for ergonomics + the `:args` key in the
+;; opened state (read by callers via the open-dialog callback).
 ;; ---------------------------------------------------------------------------
 
 (def ^:const default-id-prefix
@@ -356,16 +355,15 @@
   "Open the save-variant dialog against `source-variant-id` with the
   captured `args-snapshot`. `now-ms` seeds the default id. The args
   ride in the dialog state's `:context` slot (per the review-dialog
-  contract); a top-level `:args` key is preserved so callers reading
-  the legacy slot keep working.
+  contract); a top-level `:args` key is also exposed for callers that
+  read the snapshot directly off the state.
 
-  3-arity arity preserved for back-compat callers that don't yet pass
-  violations; defaults to no violations. 4-arity stamps the violations
-  vector onto the dialog state so the save dialog can render the
-  rf2-lancu 'Args do not match the variant's Spec 010 schema' hint
-  pre-paste. 5-arity (rf2-ba86n.6) additionally stamps the eight-slice
-  capture report so the dialog can render the per-slice honesty-floor
-  warnings (which slices are captured-as-declared / not-yet-projectable)."
+  3-arity omits violations and defaults to none. 4-arity stamps the
+  violations vector onto the dialog state so the save dialog can render
+  the 'Args do not match the variant's Spec 010 schema' hint
+  pre-paste. 5-arity additionally stamps the eight-slice capture
+  report so the dialog can render the per-slice honesty-floor warnings
+  (which slices are captured-as-declared / not-yet-projectable)."
   ([state source-variant-id args-snapshot now-ms]
    (open state source-variant-id args-snapshot now-ms nil nil))
   ([state source-variant-id args-snapshot now-ms violations]
@@ -421,8 +419,8 @@
   as `(callback source-variant-id args-snapshot now-ms violations slices)`
   where `violations` is the vector returned by
   `schema-validation/args-violations` against the live component schema
-  (rf2-lancu — may be empty/nil) and `slices` is the eight-slice capture
-  report from `capture-slices` (rf2-ba86n.6 — carries the per-slice
+  (may be empty/nil) and `slices` is the eight-slice capture report
+  from `capture-slices` (carries the per-slice
   honesty-floor warnings the dialog renders). Idempotent — calling again
   replaces. The registered callback is invoked with all five positional
   args, so it must accept arity-5 (a variadic `& _` tail is the easy way
@@ -466,7 +464,7 @@
                             target
                             {:active-modes   (:active-modes shell)
                              :cell-overrides (get-in shell [:cell-overrides target])})
-               ;; rf2-lancu — validate the snapshot against the variant's
+               ;; Validate the snapshot against the variant's
                ;; Spec 010 schema BEFORE opening the dialog so the user
                ;; gets a non-blocking 'paste at your own risk' hint when
                ;; the live args have drifted into a non-conforming state.
@@ -477,7 +475,7 @@
                                      (schema-validation/resolve-component-schema target)
                                      (schema-validation/validator-fns))
                              :clj  [])
-               ;; rf2-ba86n.6 — the eight-slice capture report. The honesty
+               ;; The eight-slice capture report. The honesty
                ;; floor: every slice without a live projection is captured-
                ;; as-declared (carried via :extends) or not-wired, and warned
                ;; about. Never fabricated. Read the resolved source body so

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -73,7 +73,7 @@
 
   Single-sources the variant-id grammar at the STRING level so an MCP
   write path can validate a caller-supplied id string BEFORE interning a
-  keyword (rf2-tag30h) — the keyword-level `variant-id?` delegates here.
+  keyword — the keyword-level `variant-id?` delegates here.
   Per /spec/007-Stories.md §Canonical id grammar."
   [[ns-part name-part]]
   (boolean
@@ -94,7 +94,7 @@
   `(namespace) = \"story.auth.login-form\"` and `(name) = \"empty\"`.
 
   Delegates to `variant-id-shape?` so the keyword-level check and the
-  string-level pre-intern check (used by the MCP write paths, rf2-tag30h)
+  string-level pre-intern check (used by the MCP write paths)
   cannot drift."
   [id]
   (and (keyword? id)
@@ -127,7 +127,7 @@
                        (= (subs ns 0 5) "Mode.")))))))
 
 (defn fragment-id?
-  "True iff `id` is a keyword id for a `reg-fragment` (rf2-5x1wt.15). The
+  "True iff `id` is a keyword id for a `reg-fragment`. The
   spec/017 §Strict composition example shape is
   `:fragment.<path>/<name>` (e.g. `:fragment.checkout/cart-with-sku`),
   but fragments are anonymous reusable mixins with no story lineage, so
@@ -137,7 +137,7 @@
   (keyword? id))
 
 (defn check-id?
-  "True iff `id` is a keyword id for a `reg-check` (rf2-5x1wt.15). The
+  "True iff `id` is a keyword id for a `reg-check`. The
   spec/017 §Strict composition example shape is `:check/<name>` (e.g.
   `:check/no-runtime-errors`); like fragment ids the grammar is left open
   — any keyword is accepted. Checks preserve identity in run results, so
@@ -155,13 +155,13 @@
   `:rf.error/unknown-tag` at registration."
   #{:dev :docs :test :screenshot :experimental :internal :agent})
 
-;; ---- canonical facet axes (rf2-7ncf9 — SB9 facet taxonomy) ---------------
+;; ---- canonical facet axes (SB9 facet taxonomy) --------------------------
 
 (def canonical-axes
   "Pure data → data: the canonical facet axes Story documents for
   the sidebar tag-filter UI. Mirrors Storybook 9's status / role /
-  team / feature axes (rf2-v05qb SB9 parity) plus the operator-
-  facing `:state` magnitude axis (rf2-k1k87).
+  team / feature axes (SB9 parity) plus the operator-
+  facing `:state` magnitude axis.
 
   Three axes ship with a recommended vocabulary:
 
@@ -210,14 +210,14 @@
   (get-in canonical-axes [:role :values]))
 
 (def canonical-state-values
-  "The canonical `:state` axis vocabulary (rf2-k1k87) — operator-
+  "The canonical `:state` axis vocabulary — operator-
   facing state magnitude / fixture richness classifications. The
   faceted-tag shape is `:state/<value>`."
   (get-in canonical-axes [:state :values]))
 
 (def canonical-state-tags
-  "The canonical `:state/*` faceted tags Story registers at load
-  (rf2-k1k87). Built from `canonical-state-values` by namespacing
+  "The canonical `:state/*` faceted tags Story registers at load.
+  Built from `canonical-state-values` by namespacing
   each value under `:state` — `:empty` → `:state/empty`, etc.
 
   These tags are projected onto variant `:tags` sets by gallery
@@ -282,8 +282,7 @@
   "Subset of the recognised substrate ids. The framework supplies the
   closed set; Story validates membership. `:reagent-slim` is reserved
   for future use — it is not yet on the canonical substrate enum (the
-  renderer hasn't shipped). See spec/000-Vision + the rf2-tb0ga
-  cleanup."
+  renderer hasn't shipped). See spec/000-Vision."
   [:set [:enum :reagent :uix :helix]])
 
 (def PlatformSet
@@ -294,7 +293,7 @@
   "A set of registered mode ids the artefact opts into."
   [:set :keyword])
 
-;; ---- viewport + background (rf2-zll4h) -----------------------------------
+;; ---- viewport + background -----------------------------------------------
 
 (def ViewportSlot
   "Schema for the optional `:viewport` slot on a story / variant body.
@@ -344,30 +343,28 @@
 (def XrayPreset
   "Schema for the optional `:xray` slot on a story / variant body —
   per-story Xray pre-configuration applied when Xray mounts inside
-  the rendered variant's frame (rf2-q9kv5).
+  the rendered variant's frame.
 
   All slots are optional. The preset is plain data; the runtime side
   (`re-frame.story.xray-preset`) feature-detects Xray and the optional
   filters API, no-opping gracefully when absent.
 
   - `:open?`   — when truthy, auto-open the Xray shell on variant mount.
-                 Under the per-panel embed (rf2-v1ach) this is largely
+                 Under the per-panel embed this is largely
                  superseded by `:panel` — the chip-row + selected panel
                  are the default RHS surface; `:open?` survives for the
                  popout / whole-shell escape hatch only.
-  - `:panel`   — rf2-v1ach. The Xray panel to mount in the RHS Xray
-                 host. Post rf2-5gl5r + rf2-gbz39, one of:
-                   `:epoch` (default — supersedes the retired
-                              `:event-detail`)
+  - `:panel`   — the Xray panel to mount in the RHS Xray
+                 host. One of:
+                   `:epoch` (default)
                    `:app-db`
                    `:views`
                    `:trace`
                    `:machines`
                    `:routing`
-                 (rf2-gbz39 removed `:issues` alongside the Xray Issues
-                 tab per Mike's Option (c) ruling; issues surface inline
-                 in the Epoch panel + the L2 event-row pink-wash + the
-                 always-on issues ribbon signal.)
+                 (Issues surface inline in the Epoch panel + the L2
+                 event-row pink-wash + the always-on issues ribbon
+                 signal.)
                  Authors choose the panel-id that fits the story's
                  diagnostic question (`:counter/at-five` → `:app-db`,
                  `:routing-demo/*` → `:routing`, etc.). The user can
@@ -376,7 +373,7 @@
   - `:filters` — `{:out [event-id ...] :in [event-id ...]}` — Xray
                  auto-filter pills to pre-populate. Both axes are
                  optional. Skipped with a console warning when
-                 `day8.re-frame2-xray.filters` (rf2-ak4ms) is not on
+                 `day8.re-frame2-xray.filters` is not on
                  the classpath.
   - `:focus`   — optional pre-focus coordinates. `{:event-pos N}` selects
                  the Nth event in the current cascade. Rare; usually you
@@ -410,19 +407,19 @@
     into N independent `reg-variant` calls.
   - `:dispatch-console?` — Story-shell dispatch console panel opt-in.
     Default false (panel hidden). Set true to surface the per-variant
-    dispatch console for this story / its variants (rf2-q9kv5). Toolbar
+    dispatch console for this story / its variants. Toolbar
     real-estate is precious; the chrome-level toolbar chip lets the user
     flip the chrome-toggle without editing the story body.
   - `:xray` — per-story Xray preset (auto-open, panel focus, filter
     pre-population). See `XrayPreset` schema. The preset is read on
     variant mount and applied via `re-frame.story.xray-preset/
-    apply-preset!`. (rf2-q9kv5).
+    apply-preset!`.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
-  The `:map` is `{:closed true}`: a removed / typo'd slot is rejected at
+  The `:map` is `{:closed true}`: a typo'd slot is rejected at
   `reg-story` call-time with `:rf.error/story-shape` rather than silently
-  swallowed and dropped on the floor. `:source` is the registrar's
+  accepted. `:source` is the registrar's
   source-coord stamp (declared so the closed map accepts it)."
   [:map {:closed true}
    [:doc        {:optional true} :string]
@@ -431,17 +428,15 @@
    [:decorators {:optional true} DecoratorRefs]
    [:args       {:optional true} ArgMap]
    [:argtypes   {:optional true} ArgtypesMap]
-   ;; rf2-hwcdh2 — a story body carries NO `:rf/props` / `:schema`
-   ;; props-schema slot. The view-args (props) schema lives ONLY on the
-   ;; registered `:component` view's `reg-view` metadata (canonical
-   ;; first-match `[:rf/props :schema]` — see `re-frame.story.malli-schema/
+   ;; A story body carries NO `:rf/props` / `:schema` props-schema slot.
+   ;; The view-args (props) schema lives ONLY on the registered
+   ;; `:component` view's `reg-view` metadata (canonical first-match
+   ;; `[:rf/props :schema]` — see `re-frame.story.malli-schema/
    ;; view-args-schema-keys`). The plan compiler
    ;; (`re-frame.story.plan/compile-body`) resolves it off the view-meta
-   ;; via `view-lookup`, never off the story/variant body — so a body-level
-   ;; slot passed closed-shape validation but was silently UNREAD (an
-   ;; accepted-but-dead authoring surface). The slots are removed so a
-   ;; props schema authored on the body now FAILS closed-shape validation
-   ;; with `:rf.error/story-shape`, naming the dead key, rather than being
+   ;; via `view-lookup`, never off the story/variant body. A props schema
+   ;; authored on the body FAILS closed-shape validation with
+   ;; `:rf.error/story-shape`, naming the unknown key, rather than being
    ;; swallowed with no effect.
    [:tags       {:optional true} TagSet]
    [:modes      {:optional true} ModeRefSet]
@@ -449,12 +444,12 @@
    [:platforms  {:optional true} PlatformSet]
    [:dispatch-console? {:optional true} :boolean]
    [:xray      {:optional true} XrayPreset]
-   ;; rf2-mantt — story-level `:xray-panel` (rf2-6qm77): the default Xray
+   ;; Story-level `:xray-panel`: the default Xray
    ;; panel-id a variant inherits unless it carries its own `:xray-panel`
    ;; (the variant slot beats the story slot — `effective-panel` reads
    ;; variant-first then story). A registered panel-id keyword.
    [:xray-panel {:optional true} :keyword]
-   ;; rf2-zll4h — viewport + background switchers. Per-story override
+   ;; Viewport + background switchers. Per-story override
    ;; that wins over the chrome toolbar selection at canvas mount time.
    ;; Both slots are optional; absent means 'inherit the toolbar
    ;; selection' (or the neutral default).
@@ -467,7 +462,7 @@
 
 ;; ---- :rf/variant ----------------------------------------------------------
 
-;; ---- :play-script step DSL (rf2-8i2a9) -----------------------------------
+;; ---- :play-script step DSL -----------------------------------------------
 
 (def PlayStep
   "A single step in a rich `:script` body — the one tagged step grammar
@@ -511,9 +506,9 @@
 
   Per `tools/story/spec/017-Testing-Story.md` §Public vocabulary the
   public authoring key for ordered behaviour-under-test is `:script`;
-  `:play-script` is the transitional spelling accepted during the
-  pre-alpha rename and lowered to the shipping slot by the registrar
-  (`lower-public-vocabulary`). Both spellings share this body shape."
+  `:play-script` is the transitional spelling, accepted and lowered to
+  the shipping slot by the registrar (`lower-public-vocabulary`). Both
+  spellings share this body shape."
   [:or
    PlayScript
    [:map
@@ -521,7 +516,7 @@
     [:auto-run? {:optional true} :boolean]
     [:name      {:optional true} :string]]])
 
-;; ---- :plays — multi-play extension (rf2-tl7zk) ---------------------------
+;; ---- :plays — multi-play extension --------------------------------------
 
 (def NamedPlaySpec
   "A single entry in a `:plays` vector. Same shape as `PlaySpec` (map
@@ -550,7 +545,7 @@
     (fn [v] (or (empty? v)
                 (= (count v) (count (distinct (map :name v))))))]])
 
-;; ---- :compose — strict fragment/check composition (rf2-5x1wt.15) ---------
+;; ---- :compose — strict fragment/check composition -----------------------
 
 (def AssertionVector
   "A terminal/checkpoint assertion atom — the data vector
@@ -561,8 +556,8 @@
   (keyword-headed-vector "assertion must be a vector starting with a keyword id"))
 
 (def ComposeRefs
-  "Schema for the `:compose` slot on a variant / inline plan (rf2-5x1wt.15
-  + spec/017 §`:compose`). A vector of registered fragment-ids and
+  "Schema for the `:compose` slot on a variant / inline plan
+  (spec/017 §`:compose`). A vector of registered fragment-ids and
   check-ids, applied in declared order. Each entry is a bare keyword — the
   reference is by id; the fragment/check body lives at its registration
   site. The plan compiler resolves a fragment-id against the fragment
@@ -570,7 +565,7 @@
   FAILS plan construction."
   [:vector :keyword])
 
-;; ---- :network — managed HTTP request stubs (rf2-5x1wt.14) ----------------
+;; ---- :network — managed HTTP request stubs ------------------------------
 
 (def NetworkRoute
   "A single `:network` route key — a `[method url]` pair matching the
@@ -609,7 +604,7 @@
    [:fn {:error/message ":network route value must carry a :reply"}
     (fn [m] (contains? m :reply))]])
 
-;; ---- :sub-overrides — view-state subscription overrides (rf2-5x1wt.13) ---
+;; ---- :sub-overrides — view-state subscription overrides -----------------
 
 (def SubQueryVector
   "A `:sub-overrides` key — an exact subscription query vector
@@ -624,8 +619,8 @@
 
 (def SubOverridesMap
   "Schema for the `:sub-overrides` slot on a variant / fragment body —
-  the deliberate lower-fidelity view-state affordance (rf2-5x1wt.13 +
-  spec/017 §View-state subscription overrides). A map of exact
+  the deliberate lower-fidelity view-state affordance (spec/017
+  §View-state subscription overrides). A map of exact
   subscription query vectors to the data values the renderer should
   surface for them.
 
@@ -644,7 +639,7 @@
 
 (def DbSeed
   "Schema for the `:db-seed` slot on a variant / fragment body — the
-  MIDDLE rung of the fidelity ladder (rf2-blw1q + spec/017 §View-state
+  MIDDLE rung of the fidelity ladder (spec/017 §View-state
   subscription overrides — `#{:real-setup :db-seed :sub-overrides}`). A
   direct app-db state seed: a `path → value` map merged into the variant
   frame's app-db BEFORE script execution.
@@ -668,7 +663,7 @@
 
 (def NetworkSpec
   "Schema for the `:network` slot on a story / variant / fragment body —
-  first-class managed-HTTP request stubs (rf2-5x1wt.14). A map of
+  first-class managed-HTTP request stubs. A map of
   `[method url]` route keys to `{:reply {:ok|:failure …}}` reply specs.
 
   Per `tools/story/spec/017-Testing-Story.md` §Network world the plan
@@ -695,7 +690,7 @@
   their own keys without registration ceremony (per Spec-Schemas's
   open-by-default convention).
 
-  ## Public vocabulary (rf2-5x1wt.11)
+  ## Public vocabulary
 
   Per `tools/story/spec/017-Testing-Story.md` §Public vocabulary the P1
   public authoring vocabulary is:
@@ -703,8 +698,7 @@
   - `:setup`  — preconditions (a vector of event vectors).
   - `:script` — ordered behaviour under test (a `PlaySpec` body).
 
-  These supersede the shipping spellings as a **clean pre-alpha rename,
-  not a long-lived compatibility layer**:
+  These are the public spellings of the shipping slots:
 
   | Public (target) | Transitional (shipping) |
   |-----------------|-------------------------|
@@ -712,14 +706,12 @@
   | `:script`       | `:play-script`          |
   | named `:plays`  | `:plays` (kept as named scripts) |
 
-  The schema accepts BOTH spellings so the tree can migrate incrementally
-  while existing tests stay green. The registrar's `lower-public-vocabulary`
+  The schema accepts BOTH spellings. The registrar's `lower-public-vocabulary`
   step folds `:setup` → `:events` and `:script` → `:play-script` into the
   stored body so every downstream consumer (runtime phase-2, the play
   runner, snapshot identity, the workspace/canvas readers, the recorder)
-  reads the shipping slot unchanged until the runtime is routed through
-  the variant-plan compiler (rf2-5x1wt.17 / .22). `:plays` is preserved
-  as named scripts in the normalized plan; it is not dropped.
+  reads the shipping slot. `:plays` is preserved
+  as named scripts in the normalized plan.
 
   ## Setup surface — `:setup` xor `:events`
 
@@ -727,7 +719,7 @@
   `:setup` and `:events` is a schema-level error (the author picks one
   during migration), validated by the `:fn` clause below.
 
-  ## Play surface — `:script` xor `:play-script` xor `:plays` (rf2-tl7zk)
+  ## Play surface — `:script` xor `:play-script` xor `:plays`
 
   A variant declares ONE play surface:
 
@@ -739,20 +731,17 @@
   clause below). For `:plays` the toolbar surfaces a dropdown and the CI
   runner enumerates each play as its own result row.
 
-  ## :play was REMOVED (rf2-0wrud, 2026-05-20)
+  ## `:play` is not a slot
 
-  Pre-alpha posture: the legacy `:play` slot (vector of event vectors)
-  has been removed entirely — there is no transitional dual-acceptance.
-  Authors migrate event-vector lists by wrapping each entry as
-  `[:dispatch-sync <event-vec>]` in a `:script` body.
+  There is no `:play` slot. An event-vector list is authored by wrapping
+  each entry as `[:dispatch-sync <event-vec>]` in a `:script` body.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
-  The `:map` is `{:closed true}`: a removed slot (the REMOVED `:play`
-  above) or a typo'd slot is rejected at `reg-variant` call-time with
+  The `:map` is `{:closed true}`: an unrecognised slot (such as `:play`)
+  or a typo'd slot is rejected at `reg-variant` call-time with
   `:rf.error/variant-shape`, naming the unknown key, rather than being
-  silently accepted and then dropped on the floor at runtime (the
-  swallow-class bug rf2-1774m bit the scaffolded template with). Two
+  silently accepted and then dropped on the floor at runtime. Two
   registrar-stamped slots are declared so the closed map accepts them:
   `:source` (the source-coord stamp) and `:origin` (the write-surface tag
   the story-mcp `register-variant` / `record-as-variant` tools stamp per
@@ -761,12 +750,12 @@
    [:map {:closed true}
     [:doc                   {:optional true} :string]
     [:source                {:optional true} SourceCoords]
-    ;; rf2-mantt — `:origin` is the write-surface tag stamped by the
+    ;; `:origin` is the write-surface tag stamped by the
     ;; story-mcp write tools (`reg-variant*` with `:origin config/origin`)
     ;; per spec/Cross-Cutting-Designs.md §5 Origin tagging. Declared so
     ;; the closed map accepts a programmatically-written variant body.
     [:origin                {:optional true} :keyword]
-    ;; rf2-mantt — `:run-artifact` is the framework-stamped source-artifact
+    ;; `:run-artifact` is the framework-stamped source-artifact
     ;; back-link a PROMOTED variant carries (spec/017 §Promotion;
     ;; `re-frame.story.promotion/provenance-link`). Not author-facing — the
     ;; promotion path writes it into the registered body. A trimmed
@@ -776,28 +765,28 @@
     ;; evolving internal shape.
     [:run-artifact          {:optional true} [:map-of :any :any]]
     [:extends               {:optional true} :keyword]
-    ;; rf2-5x1wt.15 — `:compose` includes registered fragments + checks
+    ;; `:compose` includes registered fragments + checks
     ;; explicitly, applied in declared order (spec/017 §`:compose`).
     ;; Fragments contribute world context + setup/script; checks
     ;; contribute inheritable assertion packs. See `ComposeRefs`.
     [:compose               {:optional true} ComposeRefs]
-    ;; rf2-5x1wt.11 — `:setup` is the PUBLIC precondition slot; `:events`
+    ;; `:setup` is the PUBLIC precondition slot; `:events`
     ;; is the transitional spelling lowered to `:setup`'s shipping slot
     ;; by the registrar. Mutually exclusive (the `:fn` clause below).
     [:setup                 {:optional true} [:vector EventVector]]
     [:events                {:optional true} [:vector EventVector]]
-    ;; rf2-5x1wt.11 — `:script` is the PUBLIC play slot (per spec/017
-    ;; §Public vocabulary). rf2-8i2a9 — the rich Storybook-style play
+    ;; `:script` is the PUBLIC play slot (per spec/017
+    ;; §Public vocabulary) — the rich Storybook-style play
     ;; script body shape. Each step is a tagged vector (`[:dispatch ...]`,
     ;; `[:dispatch-sync ...]`, `[:wait ms]`, `[:assert-db path value]`,
     ;; `[:assert-dom selector ...]`, `[:click selector]`, `[:type selector
     ;; text]`). See `PlaySpec`.
     [:script                {:optional true} PlaySpec]
     ;; `:play-script` — the transitional spelling of `:script`, lowered
-    ;; to `:script`'s shipping slot by the registrar. rf2-0wrud
-    ;; (2026-05-20): the legacy `:play` slot is REMOVED.
+    ;; to `:script`'s shipping slot by the registrar. There is no
+    ;; `:play` slot.
     [:play-script           {:optional true} PlaySpec]
-    ;; rf2-tl7zk — multi-play: a vector of named plays. Mutually
+    ;; Multi-play: a vector of named plays. Mutually
     ;; exclusive with `:script` / `:play-script` (validated by the `:fn`
     ;; clause below). The toolbar surfaces a dropdown when `:plays` has
     ;; more than one entry; the CI runner enumerates each play as its own
@@ -805,21 +794,19 @@
     [:plays                 {:optional true} PlaysSpec]
     [:args                  {:optional true} ArgMap]
     [:argtypes              {:optional true} ArgtypesMap]
-    ;; rf2-hwcdh2 — a variant body carries NO `:rf/props` / `:schema`
-    ;; props-schema slot. The view-args (props) schema lives ONLY on the
-    ;; registered `:component` view's `reg-view` metadata (canonical
-    ;; first-match `[:rf/props :schema]`; see `re-frame.story.malli-schema/
+    ;; A variant body carries NO `:rf/props` / `:schema` props-schema
+    ;; slot. The view-args (props) schema lives ONLY on the registered
+    ;; `:component` view's `reg-view` metadata (canonical first-match
+    ;; `[:rf/props :schema]`; see `re-frame.story.malli-schema/
     ;; view-args-schema-keys`). The plan compiler resolves it off the
     ;; view-meta of the resolved `:component` (`[:world :view-args-schema]`),
     ;; never off the variant body — and `:rf/props` / `:schema` are NOT in
-    ;; `re-frame.story.plan/context-keys`, so they would not even inherit
-    ;; through `:extends`. A body-level slot was an accepted-but-dead
-    ;; authoring surface (passed closed-shape validation, silently unread),
-    ;; so it is removed: a props schema on a variant body now FAILS
+    ;; `re-frame.story.plan/context-keys`, so they do not inherit
+    ;; through `:extends`. A props schema on a variant body FAILS
     ;; closed-shape validation with `:rf.error/variant-shape`. A variant
     ;; that wants a narrower props schema does it on the per-variant
     ;; `:component` view's metadata, not on the variant body.
-    ;; rf2-5x1wt.14 — first-class managed-HTTP request stubs. A map of
+    ;; First-class managed-HTTP request stubs. A map of
     ;; `[method url]` → `{:reply {:ok|:failure …}}`. The plan compiler
     ;; lowers `:network` to `[:world :network]` and on to the managed-
     ;; request stub fx (`re-frame.http.test-support`). The higher-level
@@ -827,7 +814,7 @@
     ;; serves non-HTTP effects. See `NetworkSpec` + spec/017 §Network
     ;; world.
     [:network               {:optional true} NetworkSpec]
-    ;; rf2-5x1wt.13 — view-state subscription overrides. A map of exact
+    ;; View-state subscription overrides. A map of exact
     ;; subscription query vectors → data values the renderer surfaces
     ;; for design/view-state exploration. The plan compiler resolves
     ;; `[:arg key]` placeholders in the values, validates each resolved
@@ -838,7 +825,7 @@
     ;; `:rf.assert/sub-equals`. See `SubOverridesMap` + spec/017
     ;; §View-state subscription overrides.
     [:sub-overrides         {:optional true} SubOverridesMap]
-    ;; rf2-blw1q — `:db-seed` is the MIDDLE fidelity rung (spec/017
+    ;; `:db-seed` is the MIDDLE fidelity rung (spec/017
     ;; §View-state subscription overrides — `#{:real-setup :db-seed
     ;; :sub-overrides}`): a direct app-db state seed (a `path → value`
     ;; map) merged into the variant frame's app-db BEFORE script
@@ -850,7 +837,7 @@
     ;; §Setup). A seed that violates a registered schema FAILS the run
     ;; with `:rf.error/story-db-seed-invalid`. See `DbSeed`.
     [:db-seed               {:optional true} DbSeed]
-    ;; rf2-5x1wt.15 — strict-conflict effect/interceptor override slots.
+    ;; Strict-conflict effect/interceptor override slots.
     ;; `:fx-overrides` is the first-class fx-override surface (spec/017
     ;; §The effect-override surface); `:interceptor-overrides` the
     ;; interceptor analog. Both are strict-conflict fields: a variant that
@@ -860,7 +847,7 @@
     ;; resolution).
     [:fx-overrides          {:optional true} [:map-of :keyword :any]]
     [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
-    ;; rf2-5x1wt.15 — `:checks` is the inheritable expectation form (a
+    ;; `:checks` is the inheritable expectation form (a
     ;; vector of registered check-ids, expanded by the plan compiler);
     ;; `:assertions` is own-only terminal judgement (spec/017 §Checks and
     ;; assertions). Both ride the variant body alongside `:compose`.
@@ -873,7 +860,7 @@
      [:or
       :keyword                                ; registered predicate-event id
       [:vector EventVector]]]                 ; literal data form
-    ;; rf2-lqs0b — `:loaders-teardown` is the symmetric counterpart of
+    ;; `:loaders-teardown` is the symmetric counterpart of
     ;; `:loaders` on the variant body itself. Vector of event vectors
     ;; dispatched into the variant frame on `destroy-variant!` BEFORE
     ;; the frame's `:frame-setup` decorator `:teardown` walk runs. Used
@@ -885,46 +872,45 @@
     [:platforms             {:optional true} PlatformSet]
     [:substrates            {:optional true} SubstrateSet]
     [:modes                 {:optional true} ModeRefSet]
-    ;; rf2-q9kv5: per-variant overrides for the dispatch-console panel +
+    ;; Per-variant overrides for the dispatch-console panel +
     ;; Xray preset. A variant may opt out of the dispatch-console panel
     ;; (default true at story level) or carry a Xray preset that
     ;; overrides the parent story's preset.
     [:dispatch-console?     {:optional true} :boolean]
     [:xray                 {:optional true} XrayPreset]
-    ;; rf2-mantt — `:component` is the per-variant view-id override. A
+    ;; `:component` is the per-variant view-id override. A
     ;; variant inherits its parent story's `:component` but MAY name its
     ;; own; the renderer resolves variant-first, then story
     ;; (`re-frame.story.ui.canvas` / `multi-substrate` / `workspace`:
     ;; `(or (:component variant-body) (:component story-body))`).
     [:component             {:optional true} :keyword]
-    ;; rf2-mantt — `:xray-panel` (rf2-6qm77) is the per-variant Xray
+    ;; `:xray-panel` is the per-variant Xray
     ;; panel-id override the RHS embed reads variant-first then story
     ;; (`re-frame.story.ui.xray-embed/effective-panel`); a registered
     ;; panel-id keyword (`:app-db` / `:routing` / …). Membership is not
     ;; enforced here — the embed falls back to the default panel on an
     ;; unknown id (its own runtime guard).
     [:xray-panel            {:optional true} :keyword]
-    ;; rf2-mantt — `:frame-binding` (`#{:fresh :attached}`) + `:mcp-bound`
+    ;; `:frame-binding` (`#{:fresh :attached}`) + `:mcp-bound`
     ;; (boolean) drive the sidebar frame-binding chip
     ;; (`re-frame.story.ui.sidebar-signals/frame-binding-signal`). MCP is
     ;; a binding, not a runner tier — `:mcp-bound` is the UI affordance
     ;; on top of an `:attached` binding.
     [:frame-binding         {:optional true} [:enum :fresh :attached]]
     [:mcp-bound             {:optional true} :boolean]
-    ;; rf2-zll4h — viewport + background per-variant overrides. Resolved
+    ;; Viewport + background per-variant overrides. Resolved
     ;; with variant-first, then story-level, then chrome toolbar.
     [:viewport              {:optional true} ViewportSlot]
     [:background            {:optional true} BackgroundSlot]
-    ;; rf2-bsk1d9 — EP-0015 frame-owned durable classification. A variant
+    ;; EP-0015 frame-owned durable classification. A variant
     ;; declares which of ITS app-db paths are sensitive / large at frame
     ;; creation, the SAME owner model the framework's `reg-frame` uses
     ;; (`{:app-db [[:auth :token]] :http {...}}`). The runtime threads these
     ;; straight onto the variant's `reg-frame` config (`frames/variant-
     ;; frame-config`), so the framework's `re-frame.frame-classification`
     ;; validates + installs them atomically as part of frame creation —
-    ;; BEFORE `:on-create`. This is the EP-0015-compliant replacement for
-    ;; the removed public post-creation `story/add-marks` / `set-marks`
-    ;; mutation surface (spec/015 §Frame-owned durable classification).
+    ;; BEFORE `:on-create`. Classification is owned at frame creation, not
+    ;; mutated post-creation (spec/015 §Frame-owned durable classification).
     ;;
     ;; Loose `:map` here on purpose: the framework's frame-classification
     ;; layer owns the rigorous shape validation (malformed paths, unknown
@@ -953,7 +939,7 @@
     ;; SAME image with different `:setup` / `:db-seed`; only a BEHAVIOUR
     ;; variant declares different `:images`.
     [:images                {:optional true} [:vector :any]]]
-   ;; rf2-5x1wt.11 — setup-surface mutual-exclusion. `:setup` is the
+   ;; Setup-surface mutual-exclusion. `:setup` is the
    ;; public spelling, `:events` the transitional one; an author picks
    ;; ONE during migration. Mixing both is a schema-level error so the
    ;; rejection lands at `reg-variant*` rather than the registrar's
@@ -963,7 +949,7 @@
     (fn [body]
       (not (and (contains? body :setup)
                 (contains? body :events))))]
-   ;; rf2-tl7zk + rf2-5x1wt.11 — play-surface mutual-exclusion. Authors
+   ;; Play-surface mutual-exclusion. Authors
    ;; pick ONE play surface per variant from `:script` (public) /
    ;; `:play-script` (transitional) / `:plays` (named scripts); mixing
    ;; any two is a schema-level error so the rejection lands at
@@ -974,7 +960,7 @@
     (fn [body]
       (<= (count (filter #(contains? body %) [:script :play-script :plays]))
           1))]
-   ;; rf2-5x1wt.15 — P1 ships NO `:resolve-conflicts` escape hatch. The
+   ;; P1 ships NO `:resolve-conflicts` escape hatch. The
    ;; variant owns its end-state: a strict-conflict field set directly in
    ;; the variant body wins, and the only hard error is two composed
    ;; fragments conflicting while the variant is silent — resolved by the
@@ -988,7 +974,7 @@
     (fn [body]
       (not (contains? body :resolve-conflicts)))]])
 
-;; ---- :rf/fragment + :rf/check (rf2-5x1wt.15) ------------------------------
+;; ---- :rf/fragment + :rf/check --------------------------------------------
 
 (def Fragment
   "Schema for the body of `reg-fragment` (spec/017 §Fragments + §Strict
@@ -1018,7 +1004,7 @@
   naming the check-id in the variant's `:compose`, not by nesting it in a
   fragment.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
   `{:closed true}`: a typo'd fragment slot rejects at `reg-fragment`
   call-time rather than silently no-opping. `:source` is the registrar's
@@ -1034,12 +1020,12 @@
     [:script                {:optional true} PlaySpec]
     [:play-script           {:optional true} PlaySpec]
     [:network               {:optional true} NetworkSpec]
-    ;; rf2-5x1wt.13 — a fragment MAY contribute `:sub-overrides`; they
+    ;; A fragment MAY contribute `:sub-overrides`; they
     ;; deep-merge into the composing variant's override map (a later
     ;; fragment / the variant wins per key) and mark the resolved plan
     ;; `:fidelity` with `:sub-overrides`. See `SubOverridesMap`.
     [:sub-overrides         {:optional true} SubOverridesMap]
-    ;; rf2-blw1q — a fragment MAY contribute `:db-seed`; the seeds
+    ;; A fragment MAY contribute `:db-seed`; the seeds
     ;; deep-merge into the composing variant's seed map (a later fragment
     ;; / the variant wins per key) and mark the resolved plan `:fidelity`
     ;; with `:db-seed`. See `DbSeed`.
@@ -1082,7 +1068,7 @@
   through `:compose`. A check carries no world/behaviour — no setup,
   script, args, or overrides — so the body is intentionally tight.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
   `{:closed true}`: a typo'd check slot rejects at `reg-check` call-time.
   `:source` is the registrar's source-coord stamp."
@@ -1108,33 +1094,31 @@
   "Schema for the body of `reg-workspace`. Per `001-Authoring.md` §Registration macros.
   Five layouts: `:grid`, `:prose`, `:variants-grid`, `:tabs`, `:custom`.
 
-  The optional `:isolation` slot (rf2-gqid4) tunes how `:variants-grid`
+  The optional `:isolation` slot tunes how `:variants-grid`
   mounts its cells. `:isolated` (the default) mounts every variant
   cell in parallel, each scoped to its own variant frame — the
   baseline frame-isolation contract. `:shared` mounts ONE cell at a
   time with a prev/next navigator, serialising the renderer. This is
   the load-bearing affordance for views that internally hardcode a
-  frame-provider (the rf2-sszlr / `gallery_chrome.cljs` pattern):
+  frame-provider (the `gallery_chrome.cljs` pattern):
   parallel cells of such views share their interior state because the
   last-seeded cell's app-db clobbers the others. Only honoured by
   `:variants-grid`; ignored on other layouts.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
-  The `:map` is `{:closed true}`: a typo'd or removed workspace slot is
-  rejected at `reg-workspace` call-time with `:rf.error/workspace-shape`
-  rather than silently swallowed. Closing the schema surfaced four slots
-  that the canonical testbed + both example apps + spec/001-Authoring.md
-  §reg-workspace ALREADY author but the open `:map` never declared
-  (rf2-mantt per-key triage). They are declared optional here so closing
-  does NOT drop intended authoring:
+  The `:map` is `{:closed true}`: a typo'd or unrecognised workspace slot
+  is rejected at `reg-workspace` call-time with `:rf.error/workspace-shape`
+  rather than silently accepted. The canonical testbed + both example apps
+  + spec/001-Authoring.md §reg-workspace author these slots, so they are
+  declared optional here:
 
   - `:columns` — `:grid` / `:variants-grid` fixed column-count
-    (spec/001-Authoring.md §`:columns`). rf2-ugmrg: renderer-honoured —
+    (spec/001-Authoring.md §`:columns`). Renderer-honoured —
     when present the grid emits `repeat(N, minmax(280px,1fr))`; absent it
     keeps the responsive `auto-fit` default.
   - `:for` — `:variants-grid` auto-enumerate anchor story-id
-    (spec/001-Authoring.md §`:variants-grid`). rf2-ugmrg:
+    (spec/001-Authoring.md §`:variants-grid`):
     `resolve-layout` reads `:for` first, then the namespace derivation.
   - `:tags` — workspace tag set (the canonical testbed + examples author
     `:tags #{:docs}`).
@@ -1146,11 +1130,11 @@
     [:source    {:optional true} SourceCoords]
     [:layout    [:enum :grid :prose :variants-grid :tabs :custom]]
     [:variants  {:optional true} [:vector :keyword]]
-    ;; rf2-mantt + rf2-ugmrg — `:for` names the `:variants-grid`
+    ;; `:for` names the `:variants-grid`
     ;; auto-enumerate parent story
     ;; (see `re-frame.story.ui.workspace/resolve-layout`).
     [:for       {:optional true} :keyword]
-    ;; rf2-mantt + rf2-ugmrg — `:columns` is a `:grid` / `:variants-grid`
+    ;; `:columns` is a `:grid` / `:variants-grid`
     ;; fixed column-count (renderer-honoured; see docstring).
     [:columns   {:optional true} [:int {:min 1}]]
     [:content   {:optional true} [:vector WorkspaceContentItem]]
@@ -1170,7 +1154,7 @@
         :prose         (vector? content)
         :custom        (keyword? render)
         false))]
-   ;; rf2-mantt — `:variants` (explicit list) and `:for` (auto-enumerate
+   ;; `:variants` (explicit list) and `:for` (auto-enumerate
    ;; anchor) are ALTERNATIVES on a `:variants-grid`, not co-equals
    ;; (spec/001-Authoring.md §`:variants-grid` — "Declaring both raises
    ;; :rf.error/workspace-shape at registration"). Enforce that documented
@@ -1196,7 +1180,7 @@
   render in a trailing un-grouped section with multi-select semantics.
   The schema change is additive — unchanged bodies remain valid.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
   `{:closed true}`: a typo'd mode slot rejects at `reg-mode` call-time.
   `:source` is the registrar's source-coord stamp."
@@ -1212,7 +1196,7 @@
   "Schema for the body of `reg-story-panel`. Per /spec/007-Stories.md §Story-tool
   extension hook and `001-Authoring.md` §Registration macros.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
   `{:closed true}`: a typo'd story-panel slot rejects at
   `reg-story-panel` call-time. `:source` is the registrar's source-coord
@@ -1238,7 +1222,7 @@
   The fn-shape is enforced behaviourally (`(fn? wrap)`) and structurally
   via the schema below. Both JVM and CLJS recognise `(fn? ...)`.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
   `{:closed true}`: a typo'd decorator slot rejects at `reg-decorator`
   call-time. `:source` is the registrar's source-coord stamp."
@@ -1261,7 +1245,7 @@
   decorator's `:teardown` runs first. The slot is optional; only `:init`,
   `:app-db-patch`, or `:teardown` need be present (any combination).
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
   `{:closed true}`: a typo'd decorator slot rejects at `reg-decorator`
   call-time. `:source` is the registrar's source-coord stamp."
@@ -1295,7 +1279,7 @@
     Stage 5 decorator-resolution layer expands the ref-args into a
     per-reference body.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
   Both branches are `{:closed true}`: a typo'd decorator slot rejects at
   `reg-decorator` call-time. `:source` is the registrar's source-coord
@@ -1333,7 +1317,7 @@
   - `:axis` — keyword classifier (e.g. `:status`, `:role`, `:team`,
     `:feature`). Per spec/001 §reg-tag — the sidebar tag-filter UI
     groups registered tags by `:axis` into collapsible facet rows
-    (rf2-v05qb SB9 parity). Tags without `:axis` render in a trailing
+    (SB9 parity). Tags without `:axis` render in a trailing
     un-grouped row.
   - `:default-filter` — `:include` | `:exclude`. Pre-applied to the
     sidebar tag filter at boot. `:exclude` hides variants carrying
@@ -1341,7 +1325,7 @@
     `:experimental` start excluded so they don't crowd the dev shell).
     Tags without `:default-filter` default to `:include` semantics.
 
-  ## Closed shape (rf2-mantt)
+  ## Closed shape
 
   `{:closed true}`: a typo'd tag slot rejects at `reg-tag` call-time.
   `:source` is the registrar's source-coord stamp (absent for the
@@ -1381,27 +1365,24 @@
     (when-not (m/validate schema body)
       (m/explain schema body))))
 
-;; ---- public-vocabulary lowering (rf2-5x1wt.11) ---------------------------
+;; ---- public-vocabulary lowering -----------------------------------------
 
 (defn lower-public-vocabulary
   "Fold the public Story authoring vocabulary (`:setup` / `:script`) into
   the shipping body slots (`:events` / `:play-script`). Pure data → data.
 
-  Per `tools/story/spec/017-Testing-Story.md` §Public vocabulary the
-  pre-alpha rename makes `:setup` / `:script` the public authoring keys.
-  The variant-plan compiler (`re-frame.story.plan`) already normalizes
-  both spellings, but the shipping RUNTIME — phase-2 events, the play
+  Per `tools/story/spec/017-Testing-Story.md` §Public vocabulary
+  `:setup` / `:script` are the public authoring keys.
+  The variant-plan compiler (`re-frame.story.plan`) normalizes
+  both spellings, while the shipping RUNTIME — phase-2 events, the play
   runner's `variant-body->plays`, snapshot identity, the workspace /
-  canvas readers, the recorder — still reads the `:events` / `:play-script`
-  / `:plays` slots. Until the runtime is routed through the plan compiler
-  (rf2-5x1wt.17 / .22) the registrar lowers the public spellings into the
+  canvas readers, the recorder — reads the `:events` / `:play-script`
+  / `:plays` slots. The registrar lowers the public spellings into the
   shipping slots so a variant authored with `:setup` / `:script` runs
   unchanged.
 
-  This is the sanctioned 'temporarily normalize current terms while the
-  tree is migrated' step (spec/017 §Public vocabulary), NOT a long-lived
-  compatibility layer — it is removed when the runtime reads the
-  normalized plan directly.
+  This is the 'normalize the public terms into the shipping slots' step
+  (spec/017 §Public vocabulary).
 
   Lowering rules (only when the public key is present and the shipping
   sibling is absent — the schema's mutual-exclusion `:fn` already

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -1,19 +1,19 @@
 (ns re-frame.story.share
   "Per-variant share URL — pure URL builder + parser. Per
-  `005-SOTA-Features.md` §Share URL (retired QR popover) + Stage 6 (rf2-zhwd). Phase-2 §5.2 #6.
+  `005-SOTA-Features.md` §Share URL + Stage 6 + Phase-2 §5.2 #6.
 
   Each variant has a sharable URL that encodes the active modes and
   any cell-overrides so a teammate pasting the URL lands on the exact
   same cell the author is looking at. The URL is the browser's
   address-bar URL — `re-frame.story.ui.url-state` wires pushState /
   popstate against this encoder so back-button + bookmark + Cmd-L /
-  Cmd-A / Cmd-C preserve state. Per rf2-ymnfx Issue B there is no
-  separate Share button or QR popover — the affordance was redundant
-  with the live URL surface.
+  Cmd-A / Cmd-C preserve state. There is no separate Share button or
+  QR popover — the live address-bar URL is the whole sharability
+  surface.
 
   ## URL scheme
 
-  Per `005-SOTA-Features.md` §Share URL (retired QR popover) + rf2-o4u18 the scheme is:
+  Per `005-SOTA-Features.md` §Share URL the scheme is:
 
       <base>?variant=<id>
             &workspace=<id>
@@ -29,7 +29,7 @@
   - `<id>` for mode-tab — one of `dev` / `docs` / `test`
   - `<list>` for modes / tag-filter — comma-separated keyword ids
   - `<map>` for overrides — one `pr-str`-printed EDN map of
-                            `{arg-key value}` (rf2-j0hwf — delimiter-safe;
+                            `{arg-key value}` (delimiter-safe;
                             a string value may contain commas).
   - `<id-or-WxH>` for viewport — preset keyword (`tablet`) or
                                   `WxH` custom (e.g. `800x600`)
@@ -38,8 +38,8 @@
   - `<s>` — substrate id, namespace-preserving like `<id>`
             (`:my.lib/uix` → `my.lib/uix`); omitted when `:reagent` default
 
-  Per rf2-o4u18 the URL is the sharability surface of the testbed: a
-  teammate pasting a URL must land on the exact same view (workspace
+  The URL is the sharability surface of the testbed: a teammate
+  pasting a URL must land on the exact same view (workspace
   + mode-tab + viewport + background + tag-filter + modes + overrides
   + substrate).
 
@@ -129,7 +129,7 @@
   [modes registered?]
   (vec (filter registered? (or modes []))))
 
-;; ---- rf2-o4u18: workspace / mode-tab / viewport / background / tag-filter
+;; ---- workspace / mode-tab / viewport / background / tag-filter -----------
 
 (defn parse-workspace-param
   "Parse the `workspace=` URLSearchParams value as a workspace id.
@@ -224,7 +224,7 @@
     (catch #?(:clj Exception :cljs :default) _
       [false nil])))
 
-;; ---- overrides codec (rf2-j0hwf) ----------------------------------------
+;; ---- overrides codec ----------------------------------------------------
 ;;
 ;; The overrides payload is a single EDN map, `pr-str`-printed then
 ;; percent-encoded as one token (`build-overrides-token`). Decoding
@@ -265,7 +265,7 @@
 
 (defn build-overrides-token
   "Encode a `{arg-key → value}` cell-overrides map into the single
-  percent-encoded `overrides=` wire token (rf2-j0hwf). The map is
+  percent-encoded `overrides=` wire token. The map is
   printed via `pr-str` (keys sorted for deterministic output) so any
   EDN value round-trips faithfully — including string values that
   carry the list separator. Returns nil for an empty/nil map."
@@ -282,11 +282,11 @@
   keys always present so callers can pattern-match without an
   else-branch.
 
-  The wire form (rf2-j0hwf) is the EDN-map form: the whole payload is
+  The wire form is the EDN-map form: the whole payload is
   one `pr-str`-printed map, read back as one EDN map (delimiter-safe —
   string values may contain commas).
 
-  Powers the share-import hint (rf2-9jthx): the share UI surfaces a
+  Powers the share-import hint: the share UI surfaces a
   non-blocking note when N>0 overrides from a stale share URL no
   longer apply (variant args refactored, renamed, removed). Pure;
   JVM-testable."
@@ -307,8 +307,8 @@
 (defn drop-stale-overrides
   "Second-stage filter over a `parse-overrides-param*` result: drop every
   parsed override whose TOP-LEVEL arg-key is NOT in `declared-keys` —
-  the set of arg-keys the currently selected variant still declares
-  (rf2-76l69l). `parse-overrides-param*` only drops UNPARSEABLE entries
+  the set of arg-keys the currently selected variant still declares.
+  `parse-overrides-param*` only drops UNPARSEABLE entries
   (malformed EDN, non-keyword keys); it has no view of the live variant
   contract, so an override for an arg the variant RENAMED or REMOVED
   parses fine and — without this filter — gets installed as a live arg
@@ -398,9 +398,9 @@
 
 (defn build-params
   "Pure: build the ordered vector of `k=v` URL params for a share URL.
-  Keys are stable across calls so the QR encoding is deterministic.
+  Keys are stable across calls so the generated URL is deterministic.
 
-  Per rf2-o4u18 the param set covers the full sharability surface:
+  The param set covers the full sharability surface:
 
   - `:variant`    — the focused variant id (when set)
   - `:workspace`  — the focused workspace id (when set)
@@ -410,7 +410,7 @@
   - `:viewport`   — chrome-wide viewport selection (preset kw or `WxH`)
   - `:background` — chrome-wide background selection (preset kw or hex)
   - `:tag-filter` — comma-separated stable list of active tag-filter keys
-  - `:overrides`  — one `pr-str`-printed EDN map (delimiter-safe; rf2-j0hwf)
+  - `:overrides`  — one `pr-str`-printed EDN map (delimiter-safe)
   - `:substrate`  — substrate id (omitted when `:reagent` default)
 
   Returns a vector of `k=v` URL fragments. Pure data → data;
@@ -504,11 +504,8 @@
      (or base-url "")
      (build-params (assoc opts :variant-id variant-id)))))
 
-;; Historic note (rf2-20w5i § High): a pre-Stage-6 build of the per-
-;; variant share popover sourced its QR image from a third-party QR-
-;; image service with the share URL (including author-typed
-;; `:cell-overrides`) embedded as a query param — leaking that data
-;; off-box. The QR popover was first replaced with a local SVG encoder
-;; (rf2-20w5i), then retired entirely in rf2-ymnfx Issue B because the
-;; share URL is already the browser's address bar. The redirect-free
-;; URL-builder above is the surviving surface.
+;; Privacy: the URL-builder above is redirect-free and never reaches a
+;; third-party service. The share URL is the browser's own address bar,
+;; so author-typed `:cell-overrides` stay on-box — there is no QR image
+;; fetch or external encoder to leak the URL (or its embedded overrides)
+;; off the machine.

--- a/tools/story/src/re_frame/story/theme/colors.cljc
+++ b/tools/story/src/re_frame/story/theme/colors.cljc
@@ -1,20 +1,17 @@
 (ns re-frame.story.theme.colors
-  "Story color palette + semantic tokens (rf2-i3i5j).
+  "Story color palette + semantic tokens.
 
-  Story is a developer-facing workshop / playground UI. The previous
-  chrome literally adopted VS-Code Dark+ hexes (`#1e1e1e` / `#252526`
-  / `#0e639c` / `#9cdcfe` / `#dcdcaa` / `#4ec9b0` / `#f48771` / …) —
-  the rubric's 'cookie-cutter design that lacks context-specific
-  character' anti-pattern. Worse: Xray (which Story embeds in the
-  RHS) ships its own cool slate palette around violet `#7C5CFF`, and
-  the two render with a visible palette seam where they meet.
+  Story is a developer-facing workshop / playground UI with its own
+  palette, distinct from the cookie-cutter editor look. Xray (which
+  Story embeds in the RHS) ships its own cool slate palette around
+  violet `#7C5CFF`; Story's warmer palette sits cleanly alongside it
+  rather than blurring into one undifferentiated surface.
 
   This namespace defines Story's own palette — warmer slate grounds,
   an **amber accent (#F5A524)** that contrasts but does not clash
   with Xray's cool violet, and a semantic palette that maps each
   feedback-state to the hex resolution. Hex literals at use-sites are
-  banned (rf2-i3i5j acceptance criterion #3); call sites consume the
-  `tokens` map.
+  banned; call sites consume the `tokens` map.
 
   ## Why amber
 
@@ -29,7 +26,7 @@
     complementary contrast (amber yellow ↔ violet purple) without
     landing on the AI-slop 'purple gradient' floor.
   - WCAG-AA contrast preserved across every foreground/background
-    pairing (rf2-2uwv contrast baseline). Amber on `#0F1115` ground
+    pairing. Amber on `#0F1115` ground
     scores ~8:1; `#1A1D24` ground ~6.5:1.
 
   ## How call sites consume tokens
@@ -62,9 +59,9 @@
 
 (def tokens
   "Story's semantic colour tokens. All hex literals in `tools/story/src`
-  resolve through here (rf2-i3i5j contract). Phase 1 uses inline styles
-  so the foundation ships without a CSS asset pipeline; a v1.0 styling
-  pass replaces these with CSS variables.
+  resolve through here; hex literals at use-sites are banned. The
+  foundation ships as inline styles without a CSS asset pipeline; a
+  v1.0 styling pass replaces these with CSS variables.
 
   ## Categories
 
@@ -83,8 +80,7 @@
   - **tag-*** — per-tag palette for the sidebar badge row.
   - **mono-*** — neutral greys for tertiary chrome.
 
-  Values picked so foreground/background pairings preserve WCAG-AA
-  (rf2-2uwv baseline)."
+  Values picked so foreground/background pairings preserve WCAG-AA."
   {;; ── surfaces ──
    :bg-0           "#0B0D11"   ; deepest — outer canvas matte / behind everything
    :bg-1           "#13161D"   ; sidebar / right rail base
@@ -127,7 +123,7 @@
    :mono-2         "#5C594F"   ; tertiary chrome
    :mono-3         "#3E3C36"   ; tertiary chrome ground
 
-   ;; ── play step-debugger (rf2-ulw5m) — amber breakpoint highlights ──
+   ;; ── play step-debugger — amber breakpoint highlights ──
    :breakpoint-bg      "#3A2A0F"   ; row carrying a breakpoint (amber tint)
    :breakpoint-active  "#5A3A18"   ; currently-paused row (deeper amber)
    :breakpoint-ring    "#FFD680"   ; outline / glyph for armed control
@@ -164,12 +160,11 @@
    :tag-agent-bg        "#173533"
    :tag-agent-fg        "#67CFC2"})
 
-;; ── sweep audit (rf2-i3i5j) ─────────────────────────────────────────
+;; ── hex-literal contract ─────────────────────────────────────────────
 ;;
-;; The rf2-i3i5j commit swept VS-Code-Dark+ literals to semantic tokens
-;; across 30+ source files. The substitution was mechanical: each
-;; legacy hex maps to one canonical token (e.g. `#1e1e1e` → `:bg-canvas`,
-;; `#0e639c` → `:accent-amber`). Where one legacy hex carried multiple
-;; meanings at different call sites the sweep accepts a small loss of
-;; per-site semantic precision in exchange for zero hex literals — a
-;; follow-on pass can refine individual call sites case-by-case.
+;; Every colour across `tools/story/src` resolves through one canonical
+;; token in this map; hex literals at use-sites are banned. Each token
+;; carries a single semantic meaning (e.g. `:bg-canvas` for the variant
+;; render surface, `:accent-amber` for the hero accent), so call sites
+;; name the role rather than a raw colour and the palette stays a single
+;; point of truth.

--- a/tools/story/src/re_frame/story/theme/depth.cljc
+++ b/tools/story/src/re_frame/story/theme/depth.cljc
@@ -1,11 +1,10 @@
 (ns re-frame.story.theme.depth
-  "Story depth + atmospheric background tokens (rf2-ypd6h).
+  "Story depth + atmospheric background tokens.
 
-  The pre-rf2-ypd6h chrome shipped flat solid backgrounds — toolbar /
-  sidebar / canvas / right-panel all rendered on identical `#252526`
-  grounds with no `box-shadow` declarations on any surface. The canvas
-  frame (the focal workshop region) was visually indistinguishable
-  from every inspector panel; the eye had nowhere to land.
+  Story's surfaces are layered so the eye has somewhere to land: the
+  canvas frame (the focal workshop region) sits forward of the
+  inspector panels via elevation shadows + atmospheric backdrops,
+  rather than every region rendering on one flat slate ground.
 
   This namespace ships:
 

--- a/tools/story/src/re_frame/story/theme/glyphs.cljc
+++ b/tools/story/src/re_frame/story/theme/glyphs.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.story.theme.glyphs
-  "Story iconography (rf2-p0wur).
+  "Story iconography.
 
   Inline-SVG glyph set used by the sidebar (and elsewhere) so the
   three sidebar row types parse visually without reading text:

--- a/tools/story/src/re_frame/story/theme/motion.cljc
+++ b/tools/story/src/re_frame/story/theme/motion.cljc
@@ -1,11 +1,11 @@
 (ns re-frame.story.theme.motion
-  "Story motion tokens + entrance choreography (rf2-3lt89).
+  "Story motion tokens + entrance choreography.
 
-  The pre-rf2-3lt89 chrome shipped ZERO motion. Hover states snapped,
-  the help overlay opened with no fade, and the shell threw every
-  region onto the page in one synchronous render. The audit (rf2-s1r9a
-  RED 2/10) called this out as the rubric's 'predictable layout that
-  lacks context-specific character' anti-pattern.
+  Story's chrome moves with intent: hover states transition, the help
+  overlay fades in, and the shell mount staggers its regions into view
+  rather than throwing them onto the page in one synchronous render.
+  This namespace owns the timing, easing, and choreography that carry
+  that motion register.
 
   This namespace introduces:
 
@@ -169,7 +169,7 @@
     focus ring + author-encoded accents onto Windows HCM system tokens
     (`Highlight`, `CanvasText`, `ButtonText`, `LinkText`, `Mark`,
     `GrayText`) so HCM users keep operator-grade signal — see the
-    `forced-colors` block below for the rule rationale (rf2-ubhmn)."
+    `forced-colors` block below for the rule rationale."
   "@keyframes rf-story-mount-in{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:translateY(0)}}
 @keyframes rf-story-overlay-in{from{opacity:0;transform:translateY(8px) scale(0.985)}to{opacity:1;transform:translateY(0) scale(1)}}
 @keyframes rf-story-overlay-out{from{opacity:1;transform:translateY(0) scale(1)}to{opacity:0;transform:translateY(4px) scale(0.99)}}

--- a/tools/story/src/re_frame/story/theme/space.cljc
+++ b/tools/story/src/re_frame/story/theme/space.cljc
@@ -3,13 +3,12 @@
   information density with stable spacing; strong alignment and
   grouping').
 
-  Before this namespace the chrome's padding / gap / radius values were
-  scattered raw `\"6px\"` / `\"12px\"` / `\"3px\"` strings at call sites,
-  so the spacing rhythm was implicit and drifted between regions — one
-  panel padded `12px`, its sibling `10px`, with no rule. A workshop UI
-  the user leaves open all day lives or dies on stable spacing; this
-  namespace makes the rhythm a constructed 4px scale rather than a
-  per-call-site guess.
+  Every padding / gap / radius value in the chrome resolves through
+  this namespace's constructed 4px scale rather than a per-call-site
+  raw string, so the spacing rhythm is explicit and regions align to
+  a shared grid — no panel padded `12px` while its sibling sits at
+  `10px`. A workshop UI the user leaves open all day lives or dies on
+  stable spacing.
 
   ## The 4px scale
 

--- a/tools/story/src/re_frame/story/theme/status.cljc
+++ b/tools/story/src/re_frame/story/theme/status.cljc
@@ -10,14 +10,12 @@
 
   ## Why a shared status layer
 
-  Before this namespace each region encoded its own
-  status→colour map (the sidebar's `:signal-status-*` keys, the
-  test-mode view's pass/fail pills, the play-status banner's tints).
-  The maps agreed by convention, not by construction — a drift in one
-  region produced a tool that read `:fail` as one red in the sidebar
-  and a different red in the result row. Spec/018 §12.6 makes the
-  vocabulary normative and tool-wide; this namespace makes it
-  *constructed* rather than *conventional*.
+  This namespace is the one construction every region keys off, so a
+  `:fail` reads as the same red in the sidebar, the test-mode result
+  row, and the play-status banner — the vocabulary is *constructed*
+  tool-wide rather than each region agreeing its own status→colour map
+  by convention (which drifts). Spec/018 §12.6 makes the vocabulary
+  normative and tool-wide.
 
   ## The contract (spec/018 §12.6)
 
@@ -28,7 +26,7 @@
   So each status carries FOUR discriminators, not one:
 
   - `:fg` / `:bg` / `:border` — the colour treatment (resolved from
-    `theme.colors/tokens`; zero raw hex per rf2-i3i5j).
+    `theme.colors/tokens`; zero raw hex).
   - `:glyph` — a single structural character (`✓ ✗ ! ⊘ ▣ ● ◌ ◐ ▢`) so
     the state survives colour-blindness AND Windows High-Contrast Mode
     (where `forced-colors` strips the inline colour — see
@@ -99,7 +97,7 @@
   "The canonical status → descriptor map. Each descriptor carries the
   four discriminators spec/018 §12.6 mandates (colour / glyph / shape /
   label) plus an `:emphasis` presentation hint. Colours resolve through
-  `theme.colors/tokens` — zero raw hex (rf2-i3i5j).
+  `theme.colors/tokens` — zero raw hex.
 
   Shape vocabulary (each renders a DISTINCT border — see
   `shape-decoration`):

--- a/tools/story/src/re_frame/story/theme/typography.cljc
+++ b/tools/story/src/re_frame/story/theme/typography.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.story.theme.typography
-  "Story typography token system (rf2-2rwdc).
+  "Story typography token system.
 
   Story is a developer-facing **workshop / playground** UI — the
   surface where component authors hover over their work-in-progress
@@ -36,8 +36,7 @@
       {:font-family sans-stack}                  ; chrome / labels / prose
       {:font-family mono-stack}                  ; code / EDN / variant ids
 
-  Zero raw `font-family` strings outside this ns is the contract
-  (rf2-2rwdc acceptance criterion #5).
+  Zero raw `font-family` strings outside this ns is the contract.
 
   ## Web font delivery
 
@@ -114,7 +113,7 @@
    :bold     700})
 
 (def type-scale
-  "Story type scale tokens (rf2-juxha).
+  "Story type scale tokens.
 
   Stepped scale tuned for an info-dense workshop UI — Story's chrome
   packs sidebar / toolbar / controls / inspector / canvas-title
@@ -172,14 +171,13 @@
   visible before the webfont resolves — the shell never ships
   invisible text waiting on a network request.
 
-  Per rf2-2rwdc + the rf2-s1r9a Phase 1 browser-gate trace: the
-  auto-injected `@font-face` rules are `local()`-only — an
+  The auto-injected `@font-face` rules are `local()`-only — an
   OS-installed Plex picks up automatically, otherwise the fallback
   chain in `sans-stack` / `mono-stack` (Optima / Avenir Next /
   ui-sans-serif; ui-monospace / SF Mono / Cascadia Code) takes over.
   No `url()` entry is emitted because the testbed (and most consuming
-  projects) does not vendor the woff2 files at `/fonts/plex/...` —
-  every missing URL surfaced as a console 404 the browser-gate test
+  projects) does not vendor the woff2 files at `/fonts/plex/...`, and
+  attempting a fetch would surface a console 404 the browser-gate test
   runner counts as a failure. Consuming projects that DO want
   self-hosted or CDN webfonts inject their own `@font-face`
   declarations with `url()` entries pointing at their vendored

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -1,7 +1,5 @@
 (ns re-frame.story.ui.a11y
-  "Accessibility (axe-core) panel. Per `005-SOTA-Features.md` §a11y
-  (axe-core) panel (v1.0 item 2)
-  + Stage 6 (rf2-zhwd). Phase-2 §5.1 #2.
+  "Accessibility (axe-core) panel. Per `005-SOTA-Features.md` §a11y.
 
   Runs axe-core against the variant's rendered DOM and surfaces
   violations:
@@ -14,15 +12,14 @@
   active variant's frame so a play sequence with
   `[:rf.assert/no-warnings]` records the violation as a failure.
 
-  ## axe-core source: opt-in CDN (rf2-20w5i)
+  ## axe-core source: opt-in CDN
 
-  Per rf2-20w5i (security audit): axe-core is **opt-in only**. Pre-fix
-  the panel injected `axe.min.js` from a public CDN on first panel
-  open, unconditionally. Post-fix the CDN fetch is **default-OFF**;
-  the panel surfaces a clear consent prompt explaining that running
-  the scan loads remote JS with full DOM access to the dev's session,
-  and the dev must click 'enable' to proceed. The opt-in survives
-  reloads (persisted in `localStorage` under `:rf.story.a11y/cdn-opt-in`).
+  Per the security audit, axe-core is **opt-in only**: the CDN fetch is
+  **default-OFF** and the panel surfaces a clear consent prompt
+  explaining that running the scan loads remote JS with full DOM access
+  to the dev's session, and the dev must click 'enable' (via
+  `set-cdn-opt-in!`) to proceed. The opt-in survives reloads (persisted
+  in `localStorage` under `:rf.story.a11y/cdn-opt-in`).
 
   Why not vendor axe-core directly? The audit's preferred fix
   (`:require [\"axe-core\" ...]` static-bundling) trips Closure
@@ -69,8 +66,7 @@
 (defonce
   ^{:doc "Per-frame run state.
          `{frame-id → :idle|:loading|:running|:done|:error|:no-root|:no-consent}`.
-         `:no-consent` means the dev hasn't approved the CDN load yet
-         (per rf2-20w5i)."}
+         `:no-consent` means the dev hasn't approved the CDN load yet."}
   run-state
   (r/atom {}))
 
@@ -83,7 +79,7 @@
   nil)
 
 ;; Register this panel's violations atom into the below-the-UI browser-tier
-;; executor's one-way seam (rf2-5x1wt.28), so `:rf.assert/a11y` can reuse the
+;; executor's one-way seam, so `:rf.assert/a11y` can reuse the
 ;; SAME axe-core findings the panel accumulated WITHOUT the executor needing
 ;; a compile-time dependency on this CLJS-only UI ns. Read-only — the
 ;; executor only reads `frame-id` → violations.
@@ -93,12 +89,11 @@
 ;; (`select-keys` / `:nodes` / `:target` keyword access — see
 ;; `browser/axe-finding`). So the reader NORMALISES each violation to CLJS
 ;; data at this boundary via `js->clj :keywordize-keys`, recovering the
-;; `:nodes` → `:target` selector(s) the source-link projection needs
-;; (rf2-ffu8t — `select-keys [:id :impact :help]` formerly discarded them).
+;; `:nodes` → `:target` selector(s) the source-link projection needs.
 (defn- ->clj-violations
   "Normalise the per-frame violations bag to CLJS data for the executor seam.
   `nil` (no run yet) passes through as nil so the executor falls back to its
-  supplied `:violations` / `:cannot-run`. rf2-ffu8t."
+  supplied `:violations` / `:cannot-run`."
   [vs]
   (when (some? vs)
     (js->clj vs :keywordize-keys true)))
@@ -118,15 +113,14 @@
   (reset! run-state {})
   nil)
 
-;; ---- axe-core CDN load (opt-in per rf2-20w5i) ---------------------------
+;; ---- axe-core CDN load (opt-in) -----------------------------------------
 ;;
 ;; Per the security audit, axe-core is loaded from a public CDN only
 ;; when the dev explicitly opts in. The opt-in is persisted in
 ;; `localStorage` under `cdn-opt-in-key` so a single click per session
 ;; (and not per panel-open) gives consent. The pinned version is
-;; `axe-core@4.10.0`; the URL uses the `integrity` attribute pre-fix
-;; was omitted, post-fix is added so a compromised mirror is detected
-;; client-side.
+;; `axe-core@4.10.0`; the URL carries an `integrity` attribute so a
+;; compromised mirror is detected client-side.
 
 (def ^:const axe-cdn-url
   "URL the panel loads axe-core from when the dev has opted in. Pinned
@@ -262,7 +256,7 @@
 ;; ---- running axe --------------------------------------------------------
 
 (defn emit-warning-for-violation
-  "Per `005-SOTA-Features.md` §a11y (axe-core) panel: axe-core violations integrate with
+  "Per `005-SOTA-Features.md` §a11y: axe-core violations integrate with
   `:rf.assert/no-warnings`. We emit a `:warning` trace event into the
   variant's frame so the play-runner's per-frame trace listener
   captures it and `:rf.assert/no-warnings` records a failure.
@@ -279,8 +273,8 @@
      :help   (.-help violation)}))
 
 (defn variant-root-selector
-  "CSS selector for the variant root element of `frame-id`. Per
-  rf2-qgms1: canvas.cljs / workspace.cljc stamp
+  "CSS selector for the variant root element of `frame-id`.
+  canvas.cljs / workspace.cljc stamp
   `data-rf-story-variant-root` (with the variant id pr-str'd) on the
   immediate wrapper around the user-authored decorated view, so a11y
   can scope axe-core's scan to ONLY the variant's tree — excluding
@@ -303,9 +297,9 @@
 (defn find-variant-root
   "Resolve the DOM element marked as `frame-id`'s variant root, or nil
   if not mounted (e.g. the user is viewing the variant in :docs or
-  :test mode, or has selected a workspace). Per rf2-qgms1 the canvas /
-  workspace stamp `data-rf-story-variant-root` on the wrapper around
-  the user-authored tree.
+  :test mode, or has selected a workspace). The canvas / workspace stamp
+  `data-rf-story-variant-root` on the wrapper around the user-authored
+  tree.
 
   Wrapped in a try/catch so the helper is safe to call in node-runtime
   test contexts where `js/document` is undefined (raw access throws
@@ -323,7 +317,7 @@
   highlights them. Each axe-core node has `:target` (a CSS selector
   list); we attach `data-rf-a11y-violation` to each matching element.
 
-  Per rf2-qgms1 the query is rooted at `scope-el` (the variant root)
+  The query is rooted at `scope-el` (the variant root)
   so we never decorate Story-chrome nodes — even if axe-core somehow
   returned a selector matching outside the scope, the overlay stays
   inside the variant.
@@ -349,7 +343,7 @@
   resolved (e.g. the user is in :docs/:test mode, or the variant is
   not currently mounted).
 
-  Per rf2-qgms1 the default scope is the variant's
+  The default scope is the variant's
   `data-rf-story-variant-root` element, NOT `document.body`. Scanning
   the whole body flagged Story's OWN chrome (sidebar buttons, toolbar
   tabs, side-rail items) as violations — which is wrong: Story chrome
@@ -359,7 +353,7 @@
   tests). Pass an Element, a CSS-selector string, or an axe-core
   context object.
 
-  Per `005-SOTA-Features.md` §a11y (axe-core) panel surfaces violations into `:rf.assert/no-warnings`
+  Per `005-SOTA-Features.md` §a11y, violations surface into `:rf.assert/no-warnings`
   via the trace-warning hook."
   ([frame-id]
    (run-axe! frame-id (find-variant-root frame-id)))
@@ -376,7 +370,7 @@
          "— switch to :dev mode to mount the variant, or pass an explicit context.")
        (js/Promise.resolve nil))
 
-     ;; CDN opt-in gate (rf2-20w5i): surface the consent prompt instead
+     ;; CDN opt-in gate: surface the consent prompt instead
      ;; of silently triggering the load. Callers must call `set-cdn-opt-in!`
      ;; (typically wired to a 'enable axe-core' button in the panel
      ;; that explains the egress) before re-invoking `run-axe!`.
@@ -522,8 +516,8 @@
       (str ":" (.-id v) " · " (or impact "moderate"))]]))
 
 (defn- consent-prompt
-  "Rendered when the dev hasn't yet opted in to the CDN load (per
-  rf2-20w5i). Clicking 'enable' persists the approval to
+  "Rendered when the dev hasn't yet opted in to the CDN load.
+  Clicking 'enable' persists the approval to
   `localStorage` so subsequent panel opens re-use it. The text is
   load-bearing — it describes the egress in plain words so the dev
   can decide whether their environment permits it."
@@ -559,8 +553,8 @@
     "enable axe-core + scan"]])
 
 (defn panel
-  "The a11y panel. Renders into the right panel of the shell. Stage 6
-  (rf2-zhwd) — registers as `:rf.story.panel/a11y`."
+  "The a11y panel. Renders into the right panel of the shell. Registers
+  as `:rf.story.panel/a11y`."
   [variant-id]
   (ensure-stylesheet!)
   (let [vs    (get @violations-by-frame variant-id [])
@@ -621,7 +615,7 @@
 (defn install-canonical-a11y!
   "Register the a11y panel under `:rf.story.panel/a11y` via
   `reg-story-panel*`. The panel renders in the `:right` placement
-  (the canonical right-panel slot). Stage 6 (rf2-zhwd).
+  (the canonical right-panel slot).
 
   The panel registration is opt-in by the consumer via the shell's
   `:panel-visibility` map. By default the a11y slot is off (don't
@@ -641,7 +635,7 @@
     ;; (which walks up to the nearest `[data-rf2-source-coord]`
     ;; ancestor — without the attribute the panel is skipped). DO NOT
     ;; remove this wrap without first checking that Spec 006 has
-    ;; changed to permit bare-component roots. (rf2-iwny7)
+    ;; changed to permit bare-component roots.
     (rf/reg-view* panel-render-id (fn [variant-id] [:div [panel variant-id]]))
     ;; Register the story-panel itself.
     (story-registrar/reg-story-panel*

--- a/tools/story/src/re_frame/story/ui/a11y_dialog.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y_dialog.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.story.ui.a11y-dialog
-  "Shared a11y helpers for Story's modal dialogs (rf2-p1ai7).
+  "Shared a11y helpers for Story's modal dialogs.
 
   Modal dialogs need a coherent a11y posture:
 
@@ -14,9 +14,9 @@
 
   Story's command palette and help overlay already do the role + aria
   bits inline; this ns centralises the focus-trap + return-focus + key
-  handling so the three dialogs covered by rf2-p1ai7 (recorder
+  handling so the dialogs it covers (recorder
   assertion picker, recorder save dialog, recorder export dialog,
-  save-variant dialog — all four since the save flows share
+  save-variant dialog — the save flows share
   `review-dialog`) get the same posture without per-dialog drift.
 
   Per the pre-alpha posture: each affordance is complete or not at all

--- a/tools/story/src/re_frame/story/ui/assertion_strip.cljs
+++ b/tools/story/src/re_frame/story/ui/assertion_strip.cljs
@@ -2,13 +2,13 @@
   "Structured assertion-row treatment for inline canvas / workspace
   strips.
 
-  The canvas + workspace cells previously `pr-str`-d raw assertion maps
-  into one verbose row per assertion — hard-to-parse EDN. The `:test`
-  mode pane (`re-frame.story.ui.test-mode.view`) already lifts the
-  Storybook-inspired shape — status glyph + label + collapsible
-  detail — but the inline strip never adopted it. This namespace lifts
-  that shape into a small, dependency-free leaf the inline strip + the
-  workspace cell share.
+  The canvas + workspace cells need a compact assertion display: raw
+  `pr-str`-d assertion maps read as hard-to-parse EDN, one verbose row
+  per assertion. The `:test` mode pane
+  (`re-frame.story.ui.test-mode.view`) carries the Storybook-inspired
+  shape — status glyph + label + collapsible detail. This namespace
+  lifts that shape into a small, dependency-free leaf the inline strip
+  + the workspace cell share.
 
   ## What 'Storybook-inspired' means here
 
@@ -33,7 +33,7 @@
 
   The canvas inline strip (`re-frame.story.ui.canvas/render-assertions`)
   and the workspace cell's trailing strip (`re-frame.story.ui.workspace`)
-  both `pr-str`-ed raw records into a divs-of-one-line shape. Two call
+  both render the same compact assertion shape. Two call
   sites · one component = lift, don't duplicate. The `:test` mode pane
   keeps its richer per-row table (it has space for `:expected` /
   `:actual` / `:reason` columns); the inline strip is the compact
@@ -495,7 +495,7 @@
                       ^{:key (str gi "/" ri "/" rkey)}
                       [render-row row open? toggle])))]))])))))
 
-;; ---- authored-expectation strip (rf2-ba86n.12) ---------------------------
+;; ---- authored-expectation strip -----------------------------------------
 ;;
 ;; The component above renders RUN-RESULT assertion records (each carries a
 ;; `:passed?` verdict). This strip renders AUTHORED expectations — canonical

--- a/tools/story/src/re_frame/story/ui/author_expectations.cljc
+++ b/tools/story/src/re_frame/story/ui/author_expectations.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story.ui.author-expectations
   "Expectation-authoring UX — add EXPECTATIONS to a story so a useful story
-  becomes a regression test (rf2-ba86n.12, spec/021 §S5, spec/019).
+  becomes a regression test (spec/021 §S5, spec/019).
 
   ## What this surface is — and is NOT
 

--- a/tools/story/src/re_frame/story/ui/backgrounds_switcher.cljs
+++ b/tools/story/src/re_frame/story/ui/backgrounds_switcher.cljs
@@ -1,6 +1,5 @@
 (ns re-frame.story.ui.backgrounds-switcher
-  "Toolbar chip + dropdown for the chrome-wide backgrounds switcher
-  (rf2-zll4h).
+  "Toolbar chip + dropdown for the chrome-wide backgrounds switcher.
 
   Mirrors Storybook's `addon-backgrounds` toolbar surface. The chip
   shows a small swatch + the currently-selected preset label; clicking

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.story.ui.canvas
-  "Variant render area. Per Stage 4 (rf2-ekai) `003-Render-Shell.md` §Shell lifecycle.
+  "Variant render area. Per `003-Render-Shell.md` §Shell lifecycle.
 
   The canvas is the surface where one variant renders. It:
 
@@ -9,15 +9,15 @@
   - Renders the variant's `:component` (registered re-frame view) under
     the `:hiccup` decorator stack from `resolve-decorators` — which reads
     the FULL stack (globals + story + variant chain) off the compiled
-    plan's `[:world :decorators]` (rf2-5fibj / rf2-din8u), the SAME refs
+    plan's `[:world :decorators]`, the SAME refs
     `render-variant`'s host applies, so canvas + render-variant paint the
     identical decorated tree.
   - Surfaces variant-level errors inline (per `002-Runtime.md` §Substrate hooks +
     `:assertions`).
 
-  Stage 4 reads the registered `:component` keyword and renders via
+  The canvas reads the registered `:component` keyword and renders via
   `(re-frame.core/view <id>)` — this is the late-bind view lookup that
-  spec/004 / rf2-piag exposes. The view must be registered against the
+  spec/004 exposes. The view must be registered against the
   variant's frame; the runtime allocates the frame, so any
   frame-scoped subscriptions resolve through it correctly."
   (:require [clojure.string :as str]
@@ -44,14 +44,14 @@
 
 ;; ---- namespace-preserving frame-provider --------------------------------
 ;;
-;; Per rf2-c5jz / rf2-zme7: stock Reagent's `convert-prop-value` calls
+;; Stock Reagent's `convert-prop-value` calls
 ;; `(name kw)` on named prop values, so a `[:> Provider {:value
 ;; :story.counter/clicked-three-times}]` reaches React with
 ;; `value="clicked-three-times"` — the namespace is dropped before the
 ;; subscribe-time `coerce-context-value` can read it. The reagent-slim
-;; adapter (rf2-6hyy) narrows this so non-HTML props pass keywords
+;; adapter narrows this so non-HTML props pass keywords
 ;; through unchanged, but Story's reference example targets stock
-;; Reagent (and the rf2-zme7 repro IS on stock Reagent).
+;; Reagent (and the repro is on stock Reagent).
 ;;
 ;; The fix: bypass Reagent's prop conversion by emitting the React
 ;; element directly via `adapter-context/provider-element`, which uses
@@ -77,7 +77,7 @@
   `React.createElement` directly. Reagent treats fn-returning-element
   as a valid render result, so this drops into normal hiccup trees."
   [props child]
-  ;; EP-0002 (rf2-bd4div) — the provider scopes the EXPLICIT variant frame
+  ;; EP-0002 — the provider scopes the EXPLICIT variant frame
   ;; (every caller passes `{:frame variant-id}`). The `:frame` prop is
   ;; threaded through verbatim; there is NO `:rf/default` synthesis when it
   ;; is absent (a frame-scoped render must name its frame — under the
@@ -99,7 +99,7 @@
               :overflow "auto"
               :color (:text-primary colors/tokens)
               :font-family sans-stack}
-   :frame    {;; rf2-ypd6h: the workshop region. Atmospheric amber-halo
+   :frame    {;; The workshop region. Atmospheric amber-halo
               ;; backdrop + amber inset edge so the variant render lifts
               ;; visibly above the surrounding chrome — the user's eye
               ;; lands here automatically.
@@ -116,10 +116,7 @@
    ;; portion and the trailing affordances (open-in-editor chip) sit
    ;; anchored to the right via `:title-trailing`'s `margin-left:
    ;; auto`. `flex-wrap` keeps the row from cramping on narrow
-   ;; canvases. (Up to v1 the trailing cluster also carried a per-
-   ;; variant share-button + popover; rf2-ymnfx Issue B retired both
-   ;; because the variant URL is already the browser's live address
-   ;; bar.)
+   ;; canvases.
    :title    {:font-weight "bold"
               :margin-bottom "8px"
               :color (:info colors/tokens)
@@ -146,7 +143,7 @@
               :font-family mono-stack
               :font-size (:caption typography/type-scale)
               :border-radius "3px"}
-   ;; rf2-0s4p1 — identity-bearing loading skeleton during the
+   ;; Identity-bearing loading skeleton during the
    ;; four-phase loader lifecycle. Reads as "workshop loading" — amber-
    ;; shimmer pulse on a slate ground — not the generic Storybook
    ;; skeleton-row pattern.
@@ -184,7 +181,7 @@
                     :letter-spacing "0.12em"
                     :color (:accent-amber colors/tokens)
                     :margin-bottom "4px"}
-   ;; rf2-zgu68 — viewport-px indicator chip. Shows e.g. "375 × 667"
+   ;; Viewport-px indicator chip. Shows e.g. "375 × 667"
    ;; at canvas bottom-right when a viewport mode is active.
    :viewport-chip {:position "absolute"
                    :bottom "12px"
@@ -200,17 +197,16 @@
                    :pointer-events "none"
                    :user-select "none"}})
 
-;; ---- loading skeleton (rf2-0s4p1) ---------------------------------------
+;; ---- loading skeleton -----------------------------------------------------
 
 (defn loading-phase?
   "Pure: is the variant in a phase where the loading skeleton should
   render? True when the lifecycle machine is in `:pre-mount`,
   `:mounting`, or `:loading` AND no first render has been committed
   yet AND the runtime has not recorded any assertions against the
-  variant frame AND the variant is NOT 'events-only' (rf2-043cm).
+  variant frame AND the variant is NOT 'events-only'.
 
-  The `assertions-recorded?` arm closes a regression window introduced
-  with the skeleton (rf2-qrk2s / Phase 3 cluster): the
+  The `assertions-recorded?` arm closes a window where the
   `:loaders-complete-when` predicate may declare the loaders incomplete
   (e.g. `:story.counter-matrix/loader-never-completes`), or a loader
   event may throw a deterministic rejection
@@ -222,8 +218,7 @@
   the proof that `run-loaders!` returned; pin the skeleton off so the
   view layer takes over.
 
-  The `events-only?` arm (rf2-043cm) closes the regression PR #1574
-  introduced for variants whose body declares only `:events` (no
+  The `events-only?` arm covers variants whose body declares only `:events` (no
   `:loaders`, no `:frame-setup` decorators, no `:loaders-complete-
   when`). Their lifecycle takes the runtime's fast-path
   (`:pre-mount → :ready` on mount via `loaders/mount-ready!`), so by
@@ -245,8 +240,8 @@
           (contains? #{:pre-mount :mounting :loading} phase)))))
 
 (defn loading-skeleton
-  "Hiccup component rendering the identity-bearing loading skeleton
-  per rf2-0s4p1. Three amber-shimmer bars on a slate ground with the
+  "Hiccup component rendering the identity-bearing loading skeleton.
+  Three amber-shimmer bars on a slate ground with the
   inset amber edge that matches the canvas-frame chrome — reads as
   'workshop loading' rather than generic skeleton-row.
 
@@ -267,7 +262,7 @@
    [:div {:style (:skeleton-edge styles)
           :aria-hidden "true"}]])
 
-;; ---- viewport-px indicator chip (rf2-zgu68) ------------------------------
+;; ---- viewport-px indicator chip -----------------------------------------
 
 (defn- viewport-indicator-text
   "Pure: render the chip text e.g. `\"375 × 667\"` from a resolved
@@ -278,8 +273,8 @@
     (str width " × " height)))
 
 (defn viewport-indicator
-  "Hiccup component rendering the bottom-right viewport-px chip per
-  rf2-zgu68. Hidden when no viewport mode is active.
+  "Hiccup component rendering the bottom-right viewport-px chip.
+  Hidden when no viewport mode is active.
 
   Takes the resolved viewport preset map produced by
   `viewport/resolve`. The chip is `pointer-events: none` so it never
@@ -307,7 +302,7 @@
     (or (:component variant-body)
         (:component story-body))))
 
-;; ---- view-state subscription overrides (rf2-5x1wt.13) -------------------
+;; ---- view-state subscription overrides ----------------------------------
 ;;
 ;; A variant whose goal is rendering / design exploration MAY author
 ;; `:sub-overrides` — a map of exact subscription query vectors → data
@@ -319,7 +314,7 @@
 ;; render extent. The binding never touches app-db or `compute-sub`, so
 ;; it can never satisfy a subscription assertion (`:rf.assert/sub-equals`).
 ;;
-;; STATUS (rf2-7pgiz): WIRED. The carriage is a React context
+;; The carriage is a React context
 ;; (`re-frame.adapter.sub-override-context`), not a dynamic var — the var
 ;; does not survive into the view's deferred render. `sub-overrides-scope`
 ;; wraps the view in the override-context Provider; a descendant
@@ -337,8 +332,8 @@
 
   Routes through the COMPILED variant-plan (`plan/variant-plan`) and the
   SHARED `render/resolve-render-sub-overrides` resolver — the SAME source
-  `render-variant` reads — NOT the bare registrar body (rf2-45zvx /
-  rf2-bhaqt, rf2-din8u invariant). Reading `(:sub-overrides body)` off the
+  `render-variant` reads — NOT the bare registrar body (the shared
+  resolver invariant). Reading `(:sub-overrides body)` off the
   side-table saw ONLY the variant's OWN slot, dropping overrides contributed
   by a `:compose`d fragment or an `:extends` parent (the plan compiler
   COMPOSES them into `[:render-raw :sub-overrides]` — plan.cljc §sub-overrides
@@ -355,7 +350,7 @@
 
 (defn sub-overrides-scope
   "A Reagent component that wraps `child`'s render in the override-context
-  Provider carrying the variant's resolved `:sub-overrides` map (rf2-7pgiz).
+  Provider carrying the variant's resolved `:sub-overrides` map.
   A descendant view's `@(rf/subscribe)` reads the override at deref time
   via the `:subs/resolve-sub-override` core hook. The override never
   touches app-db / `compute-sub`, so it can never satisfy a subscription
@@ -379,9 +374,9 @@
   "Wrap `view-hiccup` with the variant's `:hiccup`-kind decorators, catching
   any exception a `:wrap` fn throws so the canvas never bubbles into a
   render-tree crash that blanks the shell (`002-Runtime.md` §Substrate hooks + §Error projection — failures
-  render inline; the rf2-zme7 'never blank the canvas' rule).
+  render inline; the 'never blank the canvas' rule).
 
-  rf2-hzhmv / rf2-ba86n.8 — the decorate-and-render primitive is the SHARED
+  The decorate-and-render primitive is the SHARED
   seam in `re-frame.story.ui.multi-substrate`, called by BOTH the canvas
   single-pane path (below), the workspace cell, AND the `render-variant`
   host hook (`re-frame.story.canonical/render-host-scope`), so the live
@@ -432,7 +427,7 @@
   initialisation events as if they were user actions.
 
   Public so the workspace renderer (`ui/workspace.cljc`) can mirror the
-  canvas's trigger condition for its per-cell run loop (rf2-c56hr).
+  canvas's trigger condition for its per-cell run loop.
   Both surfaces re-run when ANY of `:variant-id` / `:hot-reload-tick` /
   `:active-modes` / `:cell-overrides` / `:substrate` changes — keeping
   them lockstep prevents the workspace cell from rendering against
@@ -448,7 +443,7 @@
 (defonce ^:private canvas-last-run-key
   (atom nil))
 
-;; rf2-0s4p1 — per-variant first-render sentinel. Once a variant has
+;; Per-variant first-render sentinel. Once a variant has
 ;; committed its first render, the skeleton never re-appears (a hot-
 ;; reload re-run is brief enough that re-flashing the skeleton would
 ;; read as a glitch).
@@ -486,8 +481,7 @@
   "Resolve the variant's effective substrate set. Per `001-Authoring.md` §Registration macros
   the variant body's `:substrates` wins, otherwise the parent story's
   `:substrates`, otherwise the shell's host substrate. The canvas uses
-  this to decide single-substrate vs side-by-side rendering. Stage 6
-  (rf2-zhwd)."
+  this to decide single-substrate vs side-by-side rendering."
   [variant-id]
   (let [vb (registrar/handler-meta :variant variant-id)
         sid (args/parent-story-id variant-id)
@@ -500,21 +494,21 @@
   out so the outer `canvas` component can wrap with a lifecycle for
   run-variant + tear-down.
 
-  Per Stage 6 (rf2-zhwd) the inner render branches on
+  The inner render branches on
   `(count (variant-substrate-set variant-id))`:
-  - 1 substrate → single-pane render (Stage 4 path)
+  - 1 substrate → single-pane render
   - >1 substrate → multi-substrate side-by-side grid (`002-Runtime.md` §Substrate hooks)."
   [variant-id]
   (let [view-id        (variant-component variant-id)
         variant-body   (registrar/handler-meta :variant variant-id)
-        ;; rf2-eyrpr — the SAME per-run opts the `eff-args` resolve below
+        ;; The SAME per-run opts the `eff-args` resolve below
         ;; uses, threaded into `resolve-decorators` so the plan it
         ;; recompiles to read `[:world :decorators]` substitutes `[:arg]`
         ;; keys with the mode/cell-aware args. Without this an `[:arg key]`
         ;; resolvable ONLY through an active-mode / cell-override layer
         ;; (never the variant chain) throws `:rf.error/story-missing-arg`
-        ;; here even though the runtime's plan compile (rf2-2cpoo) handled
-        ;; it — the canvas decorator recompile was the remaining gap.
+        ;; here even though the runtime's plan compile handles it — the
+        ;; canvas decorator recompile needs the same opts.
         run-opts       {:active-modes
                         (:active-modes @state/shell-state-atom)
                         :cell-overrides
@@ -523,12 +517,12 @@
         decorator-pack (decorators/resolve-decorators variant-id run-opts)
         eff-args       (args/resolve-args variant-id run-opts)
         assertions     (runtime/read-assertions variant-id)
-        ;; rf2-5x1wt.13 — resolve the variant's view-state subscription
+        ;; Resolve the variant's view-state subscription
         ;; overrides (arg-substituted) for the render-path binding below.
         sub-ovr        (resolve-sub-overrides variant-id eff-args)
         substrates     (variant-substrate-set variant-id)
         multi?         (and variant-id (> (count substrates) 1))
-        ;; rf2-0s4p1 — skeleton gating. The lifecycle machine reports
+        ;; Skeleton gating. The lifecycle machine reports
         ;; :pre-mount / :mounting / :loading while the four-phase
         ;; loader cascade runs; once :ready / :error lands, the
         ;; first-rendered sentinel flips (in component-did-mount /
@@ -536,7 +530,7 @@
         lifecycle-phase (try (story-loaders/current-state variant-id)
                              (catch :default _ nil))
         first?         (variant-first-rendered? variant-id)
-        ;; rf2-043cm — events-only variants take the lifecycle fast-
+        ;; Events-only variants take the lifecycle fast-
         ;; path (`mount-ready!` jumps :pre-mount → :ready directly) so
         ;; the skeleton must not engage even on the brief render
         ;; window before `frames/allocate!` runs. Pure-data check
@@ -544,7 +538,7 @@
         ;; `loaders/events-only-variant?`.
         events-only?   (story-loaders/events-only-variant?
                          variant-body decorator-pack)
-        ;; rf2-qrk2s — a recorded assertion proves the loader cascade
+        ;; A recorded assertion proves the loader cascade
         ;; resolved its outcome (success path → :ready; failure paths
         ;; like loader-never-completes / loader-rejects park at
         ;; :loading but record an incomplete/rejection assertion). In
@@ -569,16 +563,15 @@
       ;; right end of the title row via the `:title-trailing` style's
       ;; `margin-left: auto`. The variant URL is already in the browser's
       ;; address bar (Cmd-L / Cmd-A / Cmd-C copies it); there is no Share
-      ;; button (rf2-ymnfx Issue B — the affordance was redundant with
-      ;; the live URL state surface).
+      ;; button — the live URL is already the canonical state surface.
       (when variant-id
         [:span {:style (:title-trailing styles)}
-         ;; rf2-evgf5: per-variant 'Open in editor' chip. Reads :source
+         ;; Per-variant 'Open in editor' chip. Reads :source
          ;; off the variant body and routes through the user's configured
          ;; editor URI scheme. Renders nothing when no source-coord was
          ;; captured at registration.
          (open-in-editor/open-chip-for-variant variant-body)])]
-     ;; rf2-9jthx: share-import hint surfaces a non-blocking note when
+     ;; The share-import hint surfaces a non-blocking note when
      ;; a hydrated share URL dropped one or more overrides (variant
      ;; args refactored/renamed/removed). Renders nil when nothing
      ;; dropped, so this is unconditional-safe.
@@ -592,7 +585,7 @@
        [:div {:style (:empty styles)}
         "variant has no :component registered — register one on the story or variant body"]
 
-       ;; rf2-0s4p1: identity-bearing skeleton while the lifecycle
+       ;; Identity-bearing skeleton while the lifecycle
        ;; machine is still draining loaders AND no first render has
        ;; committed. Hides immediately once :ready / :error lands and
        ;; the lifecycle hook flips `first-rendered?`.
@@ -600,7 +593,7 @@
        [loading-skeleton]
 
        multi?
-       ;; Stage 6: multi-substrate side-by-side grid. Per `002-Runtime.md` §Substrate hooks
+       ;; Multi-substrate side-by-side grid. Per `002-Runtime.md` §Substrate hooks
        ;; failures render inline rather than aborting. The grid still
        ;; renders user views, so it needs the same frame context as the
        ;; single-substrate path; otherwise Reagent subscriptions fall
@@ -616,12 +609,12 @@
            ;; rendered view's subscribe / dispatch to it (scope-only,
            ;; like `rf/frame-provider-existing`) via a provider that
            ;; preserves the namespace of a `:story.x/y`-shaped
-           ;; variant id (per rf2-c5jz; the rf2-zme7 fix path). The
+           ;; variant id (the namespace-preserving provider). The
            ;; standard `rf/frame-provider-existing` uses Reagent's `:>`
            ;; interop which calls `(name kw)` on prop values and drops
            ;; the namespace before React sees it.
            ;;
-           ;; Per rf2-qgms1: stamp `data-rf-story-variant-root` on the
+           ;; Stamp `data-rf-story-variant-root` on the
            ;; immediate wrapper around the user-authored decorated view
            ;; so the a11y panel (ui/a11y.cljs) can scope axe-core's
            ;; scan to ONLY the variant's rendered tree — excluding the
@@ -635,7 +628,7 @@
            [frame-provider-ns-safe {:frame variant-id}
             [:div {:key (str "variant-root:" (pr-str variant-id))
                    :data-rf-story-variant-root (pr-str variant-id)}
-             ;; rf2-5x1wt.13 — bind the variant's resolved view-state
+             ;; Bind the variant's resolved view-state
              ;; subscription overrides for the view-render extent (a no-op
              ;; wrapper when the variant authors none).
              [sub-overrides-scope sub-ovr
@@ -652,11 +645,11 @@
   "Lifecycle helper: flip the first-rendered sentinel for the focused
   variant when the lifecycle machine reports `:ready` / `:error`, OR
   when the runtime has recorded an assertion against the variant
-  frame (rf2-qrk2s). An assertion means the loader cascade resolved
+  frame. An assertion means the loader cascade resolved
   its outcome — either by a `:loaders-complete-when` predicate
   reporting incomplete or by a loader event throwing a deterministic
   rejection. In those paths the machine parks at `:loading`, but the
-  user view must still render. The skeleton (rf2-0s4p1) hides on the
+  user view must still render. The skeleton hides on the
   next render pass."
   []
   (when config/enabled?
@@ -683,18 +676,18 @@
         (mark-rendered-if-ready!))
       :component-did-update
       (fn [_this _old-argv]
-        ;; Re-run only when the variant runtime inputs change. The old
-        ;; unconditional update path re-fired `:events` on every app-db
+        ;; Re-run only when the variant runtime inputs change. An
+        ;; unconditional update would re-fire `:events` on every app-db
         ;; render, resetting interactive state and polluting recorder
         ;; output with fixture setup events.
         (run-if-needed!)
-        ;; rf2-0s4p1 — flip the first-rendered sentinel once the
+        ;; Flip the first-rendered sentinel once the
         ;; lifecycle machine reports :ready / :error.
         (mark-rendered-if-ready!))
       :component-will-unmount
       (fn [_this]
         (reset! canvas-last-run-key nil)
-        ;; rf2-0s4p1 — clear the first-rendered sentinel on unmount so a
+        ;; Clear the first-rendered sentinel on unmount so a
         ;; re-mount sees the skeleton for the appropriate loader window.
         (reset-first-rendered!))
      :reagent-render
@@ -707,20 +700,19 @@
              snapshot   (when variant-id
                           (runtime/snapshot-identity variant-id opts))
              _tick      (:hot-reload-tick shell)]   ;; deref to subscribe
-         ;; Per rf2-xc65: the canvas wrap is the scrollable container
+         ;; The canvas wrap is the scrollable container
          ;; for variant content; `tab-index "0"` makes it keyboard-
          ;; focusable so axe-core's `scrollable-region-focusable` rule
          ;; passes. The `<section>` element + aria-label give it a
          ;; landmark name (it's nested inside the shell's <main> so
          ;; landmark structure remains: main > section).
          ;;
-         ;; Per rf2-9la06: also stamp `data-test-variant` with the
-         ;; active variant id so Playwright specs can scope selectors
-         ;; to the canvas of a specific variant.
-         ;; (Per rf2-hscut clicking a variant in the sidebar now clears
-         ;; `:selected-workspace`, so the canvas no longer competes with
-         ;; a stale workspace pane for the main slot. The stamp is
-         ;; retained for cross-route test scoping.)
+         ;; Also stamp `data-test-variant` with the active variant id
+         ;; so Playwright specs can scope selectors to the canvas of a
+         ;; specific variant. Clicking a variant in the sidebar clears
+         ;; `:selected-workspace`, so the canvas never competes with a
+         ;; stale workspace pane for the main slot; the stamp also serves
+         ;; cross-route test scoping.
         [:section (cond-> {:style      (:wrap styles)
                            :aria-label "Variant canvas"
                            :tab-index  "0"}

--- a/tools/story/src/re_frame/story/ui/chrome_a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/chrome_a11y.cljs
@@ -1,13 +1,12 @@
 (ns re-frame.story.ui.chrome-a11y
   "Chrome accessibility (axe-core) panel — companion to
-  `re-frame.story.ui.a11y` (rf2-18t6p, parent rf2-4w88j).
+  `re-frame.story.ui.a11y`.
 
-  The existing `ui/a11y.cljs` panel scans VARIANT trees only (per
-  rf2-qgms1) — chrome a11y is Story's concern, not the variant
-  author's. But Story didn't dogfood the scanner against its OWN
-  chrome. This panel closes that gap: it runs the same axe-core engine
-  scoped to the chrome root element (`[data-rf-story-root]` stamped by
-  `shell.cljs`) so Story-chrome a11y regressions surface during dev.
+  The sibling `ui/a11y.cljs` panel scans VARIANT trees only — chrome
+  a11y is Story's concern, not the variant author's. This panel runs
+  the same axe-core engine scoped to the chrome root element
+  (`[data-rf-story-root]` stamped by `shell.cljs`) so Story-chrome a11y
+  regressions surface during dev.
 
   ## Relationship to ui/a11y.cljs
 
@@ -106,7 +105,7 @@
   (reset! run-state :idle)
   nil)
 
-;; ---- Use-system-colors? toggle (rf2-846h2) ------------------------------
+;; ---- Use-system-colors? toggle ------------------------------------------
 ;;
 ;; Operator-controlled opt-in for the same system-token chrome the
 ;; `@media (forced-colors: active)` block in `theme/motion.cljc` paints
@@ -392,7 +391,7 @@
     "enable axe-core + scan"]])
 
 (defn- force-colors-toggle
-  "rf2-846h2 — 'Use system colors' opt-in toggle. Renders a checkbox
+  "'Use system colors' opt-in toggle. Renders a checkbox
   + hint inside the Chrome A11y panel so the operator can preview /
   live in the system-token chrome on demand. Mirrors the in-memory
   ratom so the checkbox state stays in lockstep with the live
@@ -441,7 +440,7 @@
   for signature parity with other story-panel `:render` views but is
   unused — chrome a11y is single-instance and not per-variant.
 
-  Per rf2-18t6p: scans `[data-rf-story-root]` (the chrome wrapper
+  Scans `[data-rf-story-root]` (the chrome wrapper
   stamped by `shell.cljs`), NOT the variant root. Variant a11y lives
   in the sibling `re-frame.story.ui.a11y` panel."
   [_variant-id]
@@ -488,7 +487,7 @@
        [:div {:data-test "story-chrome-a11y-violations"}
         (for [[i v] (map-indexed vector vs)]
           ^{:key i} [a11y/violation-row v])])
-     ;; rf2-846h2 — 'Use system colors' toggle rendered at the foot of
+     ;; 'Use system colors' toggle rendered at the foot of
      ;; the panel so the operator-controlled HCM preview shares the
      ;; same accessibility surface as the axe-core consent + run knobs.
      [force-colors-toggle]]))
@@ -496,7 +495,7 @@
 ;; ---- panel registration --------------------------------------------------
 
 (def ^:const panel-id
-  "Registered story-panel id for the chrome-a11y panel (rf2-18t6p)."
+  "Registered story-panel id for the chrome-a11y panel."
   :rf.story.panel/chrome-a11y)
 
 (def ^:const panel-render-id
@@ -507,12 +506,12 @@
 (defn install-canonical-chrome-a11y!
   "Register the chrome-a11y panel under `:rf.story.panel/chrome-a11y`
   via `reg-story-panel*`. The panel renders in the `:right` placement
-  alongside the variant a11y panel (rf2-18t6p).
+  alongside the variant a11y panel.
 
   Idempotent. Production builds with `:rf.story/enabled?` false skip
   registration via the `config/enabled?` gate.
 
-  rf2-846h2 — also schedules a one-tick `bootstrap-force-colors!`
+  Also schedules a one-tick `bootstrap-force-colors!`
   so the persisted 'Use system colors' opt-in re-applies to the live
   DOM as soon as the chrome root mounts. The setTimeout matches the
   recorder-dom / element-inspector shape in `shell.cljs` so the
@@ -525,7 +524,7 @@
     ;; `re-frame.story.ui.a11y`. Per Spec 006 §Source-coord annotation
     ;; the annotator needs a hiccup DOM root to attach
     ;; `data-rf2-source-coord` to; a bare `[panel variant-id]` root
-    ;; silences Story / Xray Inspect Mode for this panel. (rf2-iwny7)
+    ;; silences Story / Xray Inspect Mode for this panel.
     (rf/reg-view* panel-render-id (fn [variant-id] [:div [panel variant-id]]))
     (story-registrar/reg-story-panel*
       panel-id

--- a/tools/story/src/re_frame/story/ui/cofx.cljc
+++ b/tools/story/src/re_frame/story/ui/cofx.cljc
@@ -18,12 +18,10 @@
 
   ## Generalisation note
 
-  Spec/010 §`with-mode` accessor §Single-mode call sites — the spec
-  formerly carried `:story/mode` (singular) but no implementation ever
-  registered it. This is the replacement landing point — the cofx
-  pair lands here as `:story/active-modes` (plural) + `:story/active-
-  args`. Pre-alpha, no shim for the singular name (per AGENTS.md
-  `pre-alpha-no-back-compat`).
+  Per Spec/010 §`with-mode` accessor §Single-mode call sites, the cofx
+  pair is `:story/active-modes` (plural) + `:story/active-args`. Modes
+  are plural throughout the shell, so there is no singular `:story/mode`
+  accessor.
 
   ## Registration
 

--- a/tools/story/src/re_frame/story/ui/command_palette.cljc
+++ b/tools/story/src/re_frame/story/ui/command_palette.cljc
@@ -16,7 +16,7 @@
 
 (def commands
   "Synthetic palette entries that run a UI action rather than navigate
-  the registry (rf2-ba86n.9). Each carries an `:action` keyword the
+  the registry. Each carries an `:action` keyword the
   impure `select-entry!` dispatches. Kept tiny + data-only so the JVM
   search corpus can rank them alongside registry entries; the action →
   side-effect mapping lives in the CLJS view.
@@ -24,13 +24,13 @@
   - `:explain` — open the Explain panel (provenance + lowering over
     `story/explain`) and scroll it into view. Reachable here AND from
     the RHS inspector rail per spec/020 §4.
-  - `:save-current-as-variant` (rf2-ba86n.6) — capture the focused
+  - `:save-current-as-variant` — capture the focused
     variant's live canvas state as a new variant. The SAME flow as the
     Controls-panel 'save as new variant…' button (spec/019 §3 — the flow
     is available from Controls AND the palette). A no-op when no variant
     is focused; the action handler guards on the live selection.
 
-  - `:author-expectations` (rf2-ba86n.12) — author EXPECTATIONS onto the
+  - `:author-expectations` — author EXPECTATIONS onto the
     focused story so a useful story becomes a regression test (spec/021
     §S5). Distinct from `:save-current-as-variant` (state authoring) and
     failure promotion (a captured artifact). A no-op when no variant is
@@ -77,7 +77,7 @@
   [:story :variant :workspace :mode :decorator])
 
 (defn command-entries
-  "Build the synthetic command entries (rf2-ba86n.9) in palette-entry
+  "Build the synthetic command entries in palette-entry
   shape. Pure data → data so the search corpus can include them."
   []
   (mapv (fn [{:keys [kind id action doc]}]

--- a/tools/story/src/re_frame/story/ui/command_palette/view.cljs
+++ b/tools/story/src/re_frame/story/ui/command_palette/view.cljs
@@ -37,15 +37,15 @@
     :command
     (do
       (case (:action entry)
-        ;; rf2-ba86n.9 — open the Explain panel + scroll it into view.
+        ;; Open the Explain panel + scroll it into view.
         :explain (explain-panel/open!)
-        ;; rf2-ba86n.6 — capture the focused variant's live canvas state
+        ;; Capture the focused variant's live canvas state
         ;; as a new variant. Same flow as the Controls-panel button
         ;; (spec/019 §3). `save-current-as-variant!` reads the live
         ;; selection from shell-state and no-ops (returns nil) when no
         ;; variant is focused, so the palette action needs no extra guard.
         :save-current-as-variant (save-variant/save-current-as-variant!)
-        ;; rf2-ba86n.12 — author EXPECTATIONS onto the focused story
+        ;; Author EXPECTATIONS onto the focused story
         ;; (spec/021 §S5). Same dialog as the Controls-panel 'add
         ;; expectations…' button. Distinct from save-current-state.
         ;; `open-for-focused-variant!` reads the live selection and no-ops
@@ -245,7 +245,7 @@
        :reagent-render
        (fn []
          ;; The palette overlay is conditional on its own `@open?`; the
-         ;; author-expectations modal (rf2-ba86n.12) is rendered
+         ;; author-expectations modal is rendered
          ;; UNCONDITIONALLY as a sibling so it surfaces whether opened from
          ;; the controls-panel button OR a `:author-expectations` palette
          ;; action — and regardless of whether the controls panel is

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -1,8 +1,8 @@
 (ns re-frame.story.ui.controls
-  "Controls panel — args editor, decorator toggles. Per Stage 4
-  (rf2-ekai) `003-Render-Shell.md` §Shell lifecycle + `001-Authoring.md`
-  §Controls — schema-derived, zero-`:argtypes`. Per rf2-xi9zk the per-variant mode
-  picker moved to the chrome-level toolbar
+  "Controls panel — args editor, decorator toggles. Per
+  `003-Render-Shell.md` §Shell lifecycle + `001-Authoring.md`
+  §Controls — schema-derived, zero-`:argtypes`. The per-variant mode
+  picker lives on the chrome-level toolbar
   (`re-frame.story.ui.toolbar`); the controls panel keeps args /
   decorator sections only.
 
@@ -17,7 +17,7 @@
 
   - **Scalar forms** — `:string` / `:int` / `:double` / `:boolean` /
     `:keyword` / `[:enum ...]`. Each becomes a single widget.
-  - **Collection forms (rf2-agshe)** — `[:map ...]` / `[:vector X]` /
+  - **Collection forms** — `[:map ...]` / `[:vector X]` /
     `[:tuple X Y ...]` / `[:set X]`. Each renders as an expandable group
     whose child rows are recursively derived from the entry schemas.
     Editing a nested control writes through to the cell-override map at
@@ -36,7 +36,7 @@
   refinement when the decorator stack grows more complex; today the
   toggle is informational.
 
-  ## Inline validation, diff-from-saved, summarise-before-expand (rf2-ba86n.5)
+  ## Inline validation, diff-from-saved, summarise-before-expand
 
   Per spec/019-Story-UI-Controls-And-View-States §1/§2/§4/§6 the args
   editor distinguishes a committed value that *violates the component's
@@ -158,7 +158,7 @@
   - `:keyword`            → `{:widget :text}` (keyword-coercion at edit)
   - `[:enum a b c]`       → `{:widget :select :options [a b c]}`
 
-  Collection shapes (rf2-agshe):
+  Collection shapes:
 
   - `[:map [k1 s1] [k2 s2] ...]`
         → `{:widget :group :kind :map
@@ -254,11 +254,11 @@
   slot per /spec/007-Stories.md §argtypes; `normalize-argtypes` translates
   them to the internal `:widget` shape before merge.
 
-  Per rf2-agshe the inference recurses into nested `:map` / `:vector` /
+  The inference recurses into nested `:map` / `:vector` /
   `:set` / `:tuple` shapes, producing widget descriptors the renderer
   expands into nested rows.
 
-  HOT PATH (rf2-wb4y3): `args-editor` is keystroke-sensitive — every
+  HOT PATH: `args-editor` is keystroke-sensitive — every
   controls-panel edit re-renders, which re-runs this fn. The optional
   `eff-args` arg threads the caller's already-resolved args through so
   we don't re-run `args/resolve-args` (which itself deep-merges five
@@ -266,15 +266,13 @@
   overload preserves the canonical surface for tests + non-render
   callers; the render path threads its own resolution.
 
-  SCHEMA SOURCE (rf2-vnedo / rf2-din8u): the auto-derivation schema is
+  SCHEMA SOURCE: the auto-derivation schema is
   the COMPILED variant-plan's `[:world :view-args-schema]`, read through
   the ONE shared resolver `view-args/compiled-view-args-schema` (memoized
   per variant + registrar tick). This is the SAME slot the schema-
-  validation panel validates against, so a `:rf/props`-declared view now
-  gets BOTH derived controls AND validation from one source — the
-  divergence where this fn read `:schema`-only off the bare body (missing
-  `:rf/props`, and any `:extends`-inherited / `:compose`-d `:component`)
-  is gone."
+  validation panel validates against, so a `:rf/props`-declared view
+  gets BOTH derived controls AND validation from one source — including
+  any `:extends`-inherited / `:compose`-d `:component`."
   ([variant-id]
    (resolve-argtypes variant-id (args/resolve-args variant-id)))
   ([variant-id eff-args]
@@ -286,7 +284,7 @@
          ;; The view-args (props) schema off the COMPILED plan — the
          ;; single source of truth (`[:world :view-args-schema]`), resolved
          ;; first-match `[:rf/props :schema]` through the shared resolver.
-         ;; Per spec/001 §Schema-derivation pipeline + the rf2-din8u
+         ;; Per spec/001 §Schema-derivation pipeline + the
          ;; compiled-plan invariant.
          derive-schema (view-args/compiled-view-args-schema variant-id)
          schema-entries (when (and (vector? derive-schema)
@@ -388,7 +386,7 @@
   "Derive an accessible name for an input from its `path`. The path tail
   is the user-visible label sibling (rendered in the `:label` span at
   row level); we mirror it as `aria-label` so screen readers announce
-  the input by name. Per rf2-u01y5: the visible span is purely visual
+  the input by name. The visible span is purely visual
   — without this association screen readers announce 'edit, blank'.
 
   Nested paths produce a slash-joined breadcrumb (`outer/inner`) so a
@@ -438,7 +436,7 @@
      [:option {:value (str opt)} (str opt)])])
 
 (defn- render-radio [variant-id path value {:keys [options]}]
-  ;; rf2-u01y5: the radio-set wraps each input in a parent <label>, so
+  ;; The radio-set wraps each input in a parent <label>, so
   ;; the inner <input type="radio"> already inherits an accessible name
   ;; from the wrapping label's text (the option's value). We add
   ;; role="radiogroup" + aria-label on the container so screen readers
@@ -507,7 +505,7 @@
     [:span {:style (:empty styles)}
      (str "unsupported widget " widget)]))
 
-;; ---- flat-panel row cap (rf2-ba86n.18 / C2) -----------------------------
+;; ---- flat-panel row cap --------------------------------------------------
 ;;
 ;; A controls panel whose top-level arg count exceeds
 ;; `budgets/controls-flat-row-cap` (60) renders the first `cap` rows and a
@@ -533,7 +531,7 @@
   [entries expanded?]
   (budgets/bound-cells entries budgets/controls-flat-row-cap (boolean expanded?)))
 
-;; ---- summarise-before-expand (rf2-ba86n.5) ------------------------------
+;; ---- summarise-before-expand --------------------------------------------
 ;;
 ;; Nested controls render a one-line summary with a disclosure toggle and
 ;; lazily render their child rows only when expanded (spec/019 §4 deep-

--- a/tools/story/src/re_frame/story/ui/controls_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/controls_styles.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.story.ui.controls-styles
   "Style map for `re-frame.story.ui.controls`. Pure data; no Reagent
-  dependency. Extracted from `controls.cljs` per rf2-gv5kq so the
-  controls ns trends toward the 250-LoC leaf-size ceiling (rf2-zkca8).
+  dependency. A separate leaf so the controls ns stays within the
+  250-LoC leaf-size ceiling.
 
   CLJS-only."
   (:require [re-frame.story.theme.typography :as typography :refer [mono-stack]]
@@ -101,7 +101,7 @@
                  :font-size (:micro typography/type-scale)
                  :margin-left "4px"}
    :empty       {:color (:text-tertiary colors/tokens) :font-style "italic"}
-   ;; ---- rf2-ba86n.5: validation, diff-from-saved, summarise-before-expand
+   ;; ---- validation, diff-from-saved, summarise-before-expand
    ;;
    ;; Inline schema error rendered under a control whose committed value
    ;; violates the component's Spec 010 schema. The danger-bg ground +
@@ -140,7 +140,7 @@
                  :font-size (:micro typography/type-scale)}
    ;; The summarise-before-expand toggle for nested (group / repeater /
    ;; tuple) controls. The disclosure triangle + the one-line summary of
-   ;; the collapsed value sit in the group header row (rf2-ba86n.5 / the
+   ;; the collapsed value sit in the group header row (the
    ;; deep-controls perf risk in spec 019 §4).
    :disclosure  {:cursor "pointer"
                  :user-select "none"
@@ -156,7 +156,7 @@
                  :font-style "italic"
                  :margin-left "4px"
                  :font-size (:micro typography/type-scale)}
-   ;; rf2-ba86n.18 — flat-panel row cap (C2, budgets/controls-flat-row-cap).
+   ;; Flat-panel row cap (budgets/controls-flat-row-cap).
    ;; A controls panel whose top-level arg count exceeds the cap renders the
    ;; first `cap` rows and a "+N more" expander rather than flooding the
    ;; panel (spec/018 §10 — cap or page; fail by summarizing, not flooding).

--- a/tools/story/src/re_frame/story/ui/dispatch_console.cljc
+++ b/tools/story/src/re_frame/story/ui/dispatch_console.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.story.ui.dispatch-console
   "Dispatch Console panel — free-form event dispatch into the running
   variant's frame. The re-frame2-flavoured equivalent of Storybook's
-  args/controls, fitted to events (rf2-q9kv5).
+  args/controls, fitted to events.
 
   ## What it is
 
@@ -209,7 +209,7 @@
 ;; ---- pure: history shaping -----------------------------------------------
 
 (def ^:const history-max
-  "Cap the per-variant history at 20 entries (per the rf2-q9kv5 brief)."
+  "Cap the per-variant history at 20 entries."
   20)
 
 (defn clamp-history
@@ -236,8 +236,7 @@
   `cofx` (EP-0017) is the flat `:rf.cofx` map supplied at dispatch time
   (or nil). It is recorded alongside the event so a history REPLAY can
   re-present the EXACT recordable facts — a faithful re-run rather than a
-  fresh mint. Stored only when non-nil so legacy / cofx-free rows stay
-  byte-identical to the pre-EP-0017 shape."
+  fresh mint. Stored only when non-nil so cofx-free rows stay terse."
   ([event-id payload kind ms]
    (build-history-entry event-id payload kind ms nil))
   ([event-id payload kind ms cofx]
@@ -342,7 +341,7 @@
 #?(:cljs
    (def ^:const ls-key-prefix
      "localStorage key prefix per-variant — full key is
-     `story.dispatch-history/<variant-id>`. Per the rf2-q9kv5 brief."
+     `story.dispatch-history/<variant-id>`."
      "story.dispatch-history/"))
 
 #?(:cljs

--- a/tools/story/src/re_frame/story/ui/dispatch_console_events.cljc
+++ b/tools/story/src/re_frame/story/ui/dispatch_console_events.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.story.ui.dispatch-console-events
-  "Event-id query surface for the Dispatch Console panel's autocomplete
-  (rf2-q9kv5).
+  "Event-id query surface for the Dispatch Console panel's autocomplete.
 
   Story does not own the registered events — the framework registrar
   (`re-frame.registrar`) does — so this namespace is a thin query
@@ -42,7 +41,7 @@
                                             data → data; the autocomplete /
                                             requirement-hint reads it.
 
-  ## Why expose the metadata, not just ids (rf2-wpy6eu)
+  ## Why expose the metadata, not just ids
 
   EP-0017 makes a handler's `:rf.cofx/requires` declaration part of its
   dispatch contract: a provided recordable fact must be supplied under

--- a/tools/story/src/re_frame/story/ui/docs.cljc
+++ b/tools/story/src/re_frame/story/ui/docs.cljc
@@ -1,10 +1,9 @@
 (ns re-frame.story.ui.docs
   "The `:docs` mode pane — read-only AutoDocs-equivalent for one variant.
-  Per rf2-rodx + spec/008.
+  Per spec/008.
 
-  Replaces the `mode-tabs/docs-placeholder` stub that landed with the
-  mode-tabs primitive (rf2-9hc8). The pane composes six sections, in
-  the order Storybook 8's MDX/AutoDocs page presents them:
+  The pane composes six sections, in the order Storybook 8's MDX/AutoDocs
+  page presents them:
 
       ┌──────────────────────────────────────────────────────┐
       │  Header — variant id · parent story · tags chips      │
@@ -174,16 +173,15 @@
         ts       (or (:tags vb) (:tags sb) #{})]
     (vec (sort ts))))
 
-;; rf2-ee38b.3: the `docs/parent-story-id` re-export was dropped; the
-;; header chips now call `pred/parent-story-id` directly.
+;; The header chips call `pred/parent-story-id` directly.
 
 ;; ---- pure: status / fidelity / schema / evidence excerpt ----------------
 ;;
-;; rf2-ba86n.14 (spec/022 §1 + §2) — Docs mode SHOULD add fidelity badges,
-;; world-input / runner-requirement chips, a view-arg schema table, a current
-;; test-status summary, and a SPARSE evidence excerpt that links into
-;; Inspector/Xray. The contract that load-bears this whole section: Docs and
-;; Test MUST agree because they read the SAME plan/result. So:
+;; spec/022 §1 + §2 — Docs mode adds fidelity badges, world-input /
+;; runner-requirement chips, a view-arg schema table, a current test-status
+;; summary, and a SPARSE evidence excerpt that links into Inspector/Xray. The
+;; contract that load-bears this whole section: Docs and Test MUST agree
+;; because they read the SAME plan/result. So:
 ;;
 ;;   - the status verdict is `test-pure/run-status` over the SAME unified
 ;;     run-result Test mode wrote (the `evidence-spine/result-for` slot) —
@@ -449,7 +447,7 @@
       :empty         {:color            (:text-tertiary colors/tokens)
                       :font-style       "italic"
                       :padding          "6px 0"}
-      ;; ---- status / fidelity / evidence excerpt (rf2-ba86n.14, spec/022) ----
+      ;; ---- status / fidelity / evidence excerpt (spec/022) ----
       :badge-row     {:display          "flex"
                       :flex-wrap        "wrap"
                       :gap              "6px"
@@ -658,7 +656,7 @@
      `resolve-decorators` semantics."
      [variant-id]
      (let [shell @state/shell-state-atom
-           ;; rf2-eyrpr — thread the active-modes into `resolve-decorators`
+           ;; Thread the active-modes into `resolve-decorators`
            ;; so the plan recompile substitutes `[:arg]` keys resolvable
            ;; only through a mode layer. Mirrors `args-section` (docs is
            ;; read-only — overrides deliberately excluded; the variant's
@@ -917,8 +915,8 @@
                    :data-test "story-docs-evidence-attributed"}
             "attributed only"])
          ;; Per-beat link into Xray — reuses the evidence-spine's host-facing
-         ;; `focus-beat!` (the closed rf2-crtmq focus seam). Docs LINKS to the
-         ;; detailed diagnostics; it never inlines the beat tree / app-db diff.
+         ;; `focus-beat!` focus seam. Docs LINKS to the detailed diagnostics;
+         ;; it never inlines the beat tree / app-db diff.
          [:button {:style     (:excerpt-link styles)
                    :data-test "story-docs-evidence-focus"
                    :data-precise (str (boolean precise?))
@@ -971,12 +969,12 @@
                       :on-click  (fn [_] (spine/open! variant-id nil))}
              "Open full evidence in Inspector"]]])])))
 
-;; ---- pure: TOC entries (rf2-8c7tk) --------------------------------------
+;; ---- pure: TOC entries --------------------------------------------------
 
 (def docs-toc-entries
-  "Canonical TOC entry table for the `:docs` mode pane (rf2-8c7tk, extended
-  for rf2-ba86n.14 / spec/022). Pure data → data so JVM tests can assert the
-  table shape. The header section renders as the variant's `<h1>` and is
+  "Canonical TOC entry table for the `:docs` mode pane (spec/022). Pure data
+  → data so JVM tests can assert the table shape. The header section renders
+  as the variant's `<h1>` and is
   intentionally NOT in the TOC list — it sits beside that h1 and would
   self-reference.
 
@@ -1066,8 +1064,8 @@
 
 #?(:cljs
    (defn- responsive-toc?
-     "Spec rf2-8c7tk: TOC auto-hides below 1024px (more aggressive than
-     Storybook's 1200px since our RHS is already present)."
+     "TOC auto-hides below 1024px (more aggressive than Storybook's
+     1200px since our RHS is already present)."
      []
      (boolean
        (when (exists? js/window)
@@ -1134,11 +1132,11 @@
      "Top-level `:docs` mode pane for `variant-id`.
 
      Renders the docs sections inside a flex layout alongside a sticky TOC
-     pane on the right edge (rf2-8c7tk; auto-hides below 1024px). Per
-     rf2-ba86n.14 / spec/022 the page now also carries a Status & fidelity
-     summary (the SAME run-result Test mode reads, projected through the
-     SAME `run-status` — Docs and Test agree), a view-arg schema table, and
-     a SPARSE evidence excerpt that links into the Inspector/Xray. The
+     pane on the right edge (auto-hides below 1024px). Per spec/022 the page
+     also carries a Status & fidelity summary (the SAME run-result Test mode
+     reads, projected through the SAME `run-status` — Docs and Test agree), a
+     view-arg schema table, and a SPARSE evidence excerpt that links into the
+     Inspector/Xray. The
      status + schema sections compile the variant's plan ONCE here and thread
      it down so the page does not recompile it per section. A variant whose
      plan does not compile degrades to a 'plan unavailable' status line
@@ -1171,12 +1169,11 @@
            [:section {:id "docs-tags"} [tags-section variant-id]]]
           [toc-pane variant-id]]))))
 
-;; ---- per-story rollup docs page (rf2-8j7wg, audit C-4) -----------------
+;; ---- per-story rollup docs page ---------------------------------------
 ;;
 ;; Storybook ships `Component.docs` — a parent-level docs page that
-;; aggregates every variant's docs. Story v1 had no equivalent (spec/008
-;; line 217-220 listed it as v2 scope). The rollup view fills that
-;; gap: click a story header in the sidebar → see ALL variants' docs
+;; aggregates every variant's docs. The rollup view is the re-frame2
+;; equivalent: click a story header in the sidebar → see ALL variants' docs
 ;; sections stacked in one scrollable pane, with the parent story's
 ;; `:doc` blurb at the top.
 
@@ -1210,8 +1207,8 @@
      "Render one variant's docs sections in the rollup. Mirrors `docs-view`
      minus the per-variant `<h1>` (each variant gets an h2 instead — the
      rollup's h1 is the story id at the top). Carries the Status & fidelity
-     summary (the same docs↔Test-agreed projection, rf2-ba86n.14) so a
-     reviewer scanning the rollup sees each variant's verdict + fidelity at a
+     summary (the same docs↔Test-agreed projection) so a reviewer scanning
+     the rollup sees each variant's verdict + fidelity at a
      glance; the full SPARSE evidence excerpt stays on the single-variant
      `docs-view` to keep the rollup terse (documentation, not a debug log)."
      [variant-id]
@@ -1235,7 +1232,7 @@
 
 #?(:cljs
    (defn docs-rollup-view
-     "Top-level rollup docs pane for `story-id` (rf2-8j7wg, audit C-4).
+     "Top-level rollup docs pane for `story-id`.
 
      Aggregates every registered variant of `story-id` into a single
      scrollable pane: the parent story header at the top, then one

--- a/tools/story/src/re_frame/story/ui/element_inspector.cljc
+++ b/tools/story/src/re_frame/story/ui/element_inspector.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.story.ui.element-inspector
-  "Element-level click-to-code (rf2-h0jc0) — React-Devtools-style.
+  "Element-level click-to-code — React-Devtools-style.
 
   Story's per-variant Open-in-editor chip opens the *story-spec* source;
   this inspector extends the same gesture to *every rendered element on
@@ -10,8 +10,8 @@
 
   re-frame2's `reg-view` macro injects
   `data-rf2-source-coord=\"<ns>:<sym>:<line>:<col>\"` on the rendered
-  root of every registered view (per Spec 006 §Source-coord annotation
-  / rf2-z7f7 / rf2-z9n1). The annotation is dev-only; production
+  root of every registered view (per Spec 006 §Source-coord annotation).
+  The annotation is dev-only; production
   builds elide via the universal `interop/debug-enabled?` gate. This
   inspector reads that attribute off the hovered / clicked DOM node
   (walking ancestor chain when the literal target doesn't carry one —
@@ -27,9 +27,9 @@
   ## Inspector mode
 
   - **Toggle**: a toolbar chip flips a per-process atom. `aria-haspopup`
-    not `aria-pressed` per the rf2-zll4h reset-gate convention (the
-    recorder's reset assertion counts `[aria-pressed=\"true\"]` and we
-    don't want the inspect chip to trip it).
+    not `aria-pressed` per the reset-gate convention (the recorder's reset
+    assertion counts `[aria-pressed=\"true\"]` and we don't want the
+    inspect chip to trip it).
   - **Hover**: a `mousemove` listener on the canvas root walks up from
     the event target to the nearest `[data-rf2-source-coord]` ancestor.
     The overlay component draws an absolute-positioned outline +
@@ -101,10 +101,9 @@
 
   Alias of the canonical `re-frame.source-coords/parse-source-coord` (the
   source-coord contract owner) — the inverse of `format-source-coord`. The
-  parser used to be reimplemented near-byte-for-byte here and in the
-  re-frame2-pair preload runtime; rf2-nr7vf2 collapsed both onto the one
-  canonical parser. Returns nil for malformed input (too few / too many
-  segments, empty ns or handler-id, non-string input). Never throws."
+  one canonical parser also backs the re-frame2-pair preload runtime.
+  Returns nil for malformed input (too few / too many segments, empty ns or
+  handler-id, non-string input). Never throws."
   source-coords/parse-source-coord)
 
 (defn coord->handler-keyword
@@ -122,10 +121,10 @@
      comes from the registered view's metadata (see
      `re-frame.source-coords` / `docs/xray/05-click-to-source.md`).
 
-     Falls back to the always-on `error-coords-by-id` registry
-     (rf2-3un2g) when the public meta has been stripped by production
-     elision — that registry survives `:advanced` + `goog.DEBUG=false`
-     and keeps the `:file` slot reachable for tooling."
+     Falls back to the always-on `error-coords-by-id` registry when the
+     public meta has been stripped by production elision — that registry
+     survives `:advanced` + `goog.DEBUG=false` and keeps the `:file` slot
+     reachable for tooling."
      [parsed]
      (when-let [view-id (coord->handler-keyword parsed)]
        (let [meta (rf/handler-meta :view view-id)
@@ -424,9 +423,9 @@
    (defn inspect-chip
      "The toolbar chip. Click → toggle inspect mode. Uses
      `aria-haspopup`/`aria-expanded` (NOT `aria-pressed`) per the
-     rf2-zll4h reset-gate convention — the toolbar's reset assertion
-     in the e2e suite counts `[aria-pressed=\"true\"]` and we don't
-     want the inspect chip to trip it.
+     reset-gate convention — the toolbar's reset assertion in the e2e
+     suite counts `[aria-pressed=\"true\"]` and we don't want the
+     inspect chip to trip it.
 
      Hidden when production-elided: the chip lives in the Story bundle
      and the entire shell ns is gated on `config/enabled?`."

--- a/tools/story/src/re_frame/story/ui/evidence_spine.cljc
+++ b/tools/story/src/re_frame/story/ui/evidence_spine.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story.ui.evidence-spine
   "The evidence spine — the Story-owned narrative/evidence DISPLAY over the
-  retained epoch tape (rf2-ba86n.10, spec/020 §3 + spec/021 §2).
+  retained epoch tape (spec/020 §3 + spec/021 §2).
 
   ## What it is
 
@@ -18,7 +18,7 @@
   violation, or a cannot-run row SELECTS the matching span/beat so the
   investigation follows the failure-state hierarchy. The selected beat
   offers an *open-in-Xray* link that FOCUSES the relevant Xray panel via the
-  closed `rf2-crtmq` focus API.
+  host-facing focus API.
 
   ## The ownership boundary (load-bearing — spec/020 §1)
 
@@ -28,7 +28,7 @@
   the user wants the deep diagnostic it builds a focus COMMAND (which panel,
   which epoch/cascade, which app-db path) plus opaque `:source` provenance
   and calls `day8.re-frame2-xray.core/focus!` — the host-facing focus
-  entry point (rf2-crtmq, spec/020 §2.1). Xray owns what each field means
+  entry point (spec/020 §2.1). Xray owns what each field means
   and routes it to its canonical `:rf.xray/*` write surfaces. The spine
   LINKS; it never embeds Xray panel interiors.
 
@@ -100,14 +100,13 @@
 ;; it speaks to the host-facing focus API, not the embed chip-row. We mirror
 ;; the set here as pure data so `panel-for-row` can validate a selector
 ;; before building a command (a typo'd panel would otherwise land Xray's
-;; unknown-tab stub). (rf2-gbz39 — `:issues` was removed alongside the
-;; Xray Issues tab per Mike's Option (c) ruling.)
+;; unknown-tab stub).
 
 (def focus-panels
   "The canonical host-facing Xray panel ids a focus command may target
   (mirrors `day8.re-frame2-xray.focus/valid-panels`). Pure data — the
   spine validates its panel selector against this set before building a
-  focus command. (rf2-gbz39 dropped `:issues` with the Xray Issues tab.)"
+  focus command."
   #{:epoch :app-db :views :trace :machines :routes})
 
 ;; ===========================================================================
@@ -765,7 +764,7 @@
 
 ;; ---- the result→spine entry point ----------------------------------------
 ;;
-;; Test mode (rf2-ba86n.11) renders a graceful 'evidence pending' row; the
+;; Test mode renders a graceful 'evidence pending' row; the
 ;; spine is its target. The spine reads the same result slot Test mode wrote
 ;; (`test-state/results-atom`), so it shows the SAME run's narrative — Story
 ;; never re-runs the variant for the spine.

--- a/tools/story/src/re_frame/story/ui/explain_panel.cljc
+++ b/tools/story/src/re_frame/story/ui/explain_panel.cljc
@@ -1,7 +1,6 @@
 (ns re-frame.story.ui.explain-panel
   "The Explain panel — a read-only provenance + lowering surface over
-  the `story/explain` data (rf2-ba86n.9, spec/020 §4 / spec/017
-  §Explain API).
+  the `story/explain` data (spec/020 §4 / spec/017 §Explain API).
 
   ## What it is — and is NOT
 

--- a/tools/story/src/re_frame/story/ui/help.cljs
+++ b/tools/story/src/re_frame/story/ui/help.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.story.ui.help
-  "First-time-user help overlay for the Story playground (rf2-381i).
+  "First-time-user help overlay for the Story playground.
 
   Renders a modal-style overlay that explains the playground UI:
 
@@ -25,9 +25,9 @@
   ## Voice + colour
 
   Matches the rest of the Story shell chrome: `#252526` panel ground,
-  `#cccccc` body text, `#b0b0b0` muted labels (post rf2-2uwv contrast
-  fixes — all foreground colours meet WCAG AA against the panel
-  ground). Tight bulleted copy — no paragraphs.
+  `#cccccc` body text, `#b0b0b0` muted labels — all foreground colours
+  meet WCAG AA against the panel ground. Tight bulleted copy — no
+  paragraphs.
 
   ## Bundle isolation
 
@@ -325,11 +325,11 @@
        ;; the shell mid-session (e.g. via hot-reload) doesn't pop the
        ;; modal again — only fires when no flag is persisted.
        ;;
-       ;; Per rf2-8wgpm (static-build): suppress the auto-open in
-       ;; static-export mode. A visitor landing on a published docs
-       ;; site already arrived with intent; the dev-time onboarding
-       ;; overlay just gets in their way. The manual ? chip is still
-       ;; rendered so on-demand help remains reachable.
+       ;; Static-build: suppress the auto-open in static-export mode.
+       ;; A visitor landing on a published docs site already arrived
+       ;; with intent; the dev-time onboarding overlay just gets in their
+       ;; way. The manual ? chip is still rendered so on-demand help
+       ;; remains reachable.
        (when (and (not config/static-mode?)
                   (not (seen?)))
          (reset! open? true)))

--- a/tools/story/src/re_frame/story/ui/keybindings.cljs
+++ b/tools/story/src/re_frame/story/ui/keybindings.cljs
@@ -1,15 +1,15 @@
 (ns re-frame.story.ui.keybindings
-  "Story global keyboard-shortcut registry (rf2-g8l8x / rf2-p3i0t).
+  "Story global keyboard-shortcut registry.
 
   Owns the single `window#keydown` capture-phase listener that backs
   every chrome-level muscle-memory hotkey:
 
-      f  →  toggle full-screen      (rf2-p3i0t)
-      s  →  toggle sidebar          (rf2-g8l8x)
-      a  →  toggle RHS / addons     (rf2-g8l8x)
-      t  →  toggle toolbar          (rf2-g8l8x)
+      f  →  toggle full-screen
+      s  →  toggle sidebar
+      a  →  toggle RHS / addons
+      t  →  toggle toolbar
 
-  Cmd-K / Ctrl-K (the command palette, rf2-9hc8) ships its own
+  Cmd-K / Ctrl-K (the command palette) ships its own
   listener in `re-frame.story.ui.command-palette.view` — palette is a
   modal surface, hotkeys here are inline chrome toggles. The two
   listeners co-exist; both install on the capture phase so they
@@ -17,11 +17,10 @@
 
   ## Why a registry
 
-  Pre-rf2-g8l8x the chrome had ONE global hotkey (Cmd-K) wired
-  inline in `command_palette/view.cljs`. Adding `f` / `s` / `a` / `t`
-  as inline listeners on shell.cljs would scatter four nearly-
-  identical capture-phase listeners across the codebase with no
-  central inventory of bound keys. The registry pattern centralises:
+  Wiring `f` / `s` / `a` / `t` as inline listeners on shell.cljs would
+  scatter four nearly-identical capture-phase listeners across the
+  codebase with no central inventory of bound keys. The registry pattern
+  centralises:
 
   - The canonical `[key → handler]` table (one map, one source of
     truth for what's bound).
@@ -47,8 +46,8 @@
   The chrome-visibility toggles persist to localStorage under
   `re-frame.story/chrome-visibility` so a refresh keeps the user's
   layout intent. Hydration runs once at shell mount. `:embed?` is
-  intentionally excluded — embed-mode is URL-driven (rf2-pucku) and
-  must not carry across navigations.
+  intentionally excluded — embed-mode is URL-driven and must not carry
+  across navigations.
 
   ## Elision
 
@@ -89,8 +88,8 @@
 
 (defn save-to-storage!
   "Persist the chrome-visibility map. `:embed?` is stripped — embed
-  is URL-driven (rf2-pucku) and persisting it would leak between
-  navigations. Idempotent; silent on storage unavailability."
+  is URL-driven and persisting it would leak between navigations.
+  Idempotent; silent on storage unavailability."
   [chrome-vis]
   (when-let [ls (safe-local-storage)]
     (try
@@ -161,7 +160,7 @@
 ;; ---- canonical hotkey table --------------------------------------------
 
 (defn full-screen-toggle!
-  "Handler for the `f` key (rf2-p3i0t). Flips
+  "Handler for the `f` key. Flips
   `[:chrome-visibility :full-screen?]` + persists. Escape exits via the
   separate `Escape`-listener in the canvas's full-screen overlay (see
   `canvas/full-screen-overlay`)."
@@ -170,21 +169,21 @@
   (save-to-storage! (state/chrome-visibility (state/get-state))))
 
 (defn sidebar-toggle!
-  "Handler for the `s` key (rf2-g8l8x). Flips
+  "Handler for the `s` key. Flips
   `[:chrome-visibility :sidebar?]` + persists."
   []
   (state/swap-state! state/toggle-chrome-visibility :sidebar?)
   (save-to-storage! (state/chrome-visibility (state/get-state))))
 
 (defn rhs-toggle!
-  "Handler for the `a` key (rf2-g8l8x — `a` for 'addons' per Storybook
+  "Handler for the `a` key (`a` for 'addons' per Storybook
   convention). Flips `[:chrome-visibility :rhs?]` + persists."
   []
   (state/swap-state! state/toggle-chrome-visibility :rhs?)
   (save-to-storage! (state/chrome-visibility (state/get-state))))
 
 (defn toolbar-toggle!
-  "Handler for the `t` key (rf2-g8l8x). Flips
+  "Handler for the `t` key. Flips
   `[:chrome-visibility :toolbar?]` + persists."
   []
   (state/swap-state! state/toggle-chrome-visibility :toolbar?)
@@ -230,8 +229,8 @@
         shell     (state/get-state)
         chrome    (state/chrome-visibility shell)]
     (cond
-      ;; Escape exits full-screen (rf2-p3i0t acceptance criterion). We
-      ;; gate the Escape branch on `editable?` so typing Escape into a
+      ;; Escape exits full-screen. We gate the Escape branch on
+      ;; `editable?` so typing Escape into a
       ;; focused input (e.g. the sidebar search) cancels the input
       ;; rather than exiting full-screen — that's the search's intent.
       ;; When full-screen is active there's NO visible input that would

--- a/tools/story/src/re_frame/story/ui/markdown.cljc
+++ b/tools/story/src/re_frame/story/ui/markdown.cljc
@@ -1,13 +1,10 @@
 (ns re-frame.story.ui.markdown
-  "Minimal CommonMark-subset markdown → hiccup renderer (rf2-wl7yr,
-  audit C-2).
+  "Minimal CommonMark-subset markdown → hiccup renderer.
 
   Story's `:docs` mode pane (`re-frame.story.ui.docs/prose-section`)
-  and `:prose`-layout workspaces previously rendered prose as
-  `pre-wrap` plain text. Authors write prose in markdown — backticks,
-  bullets, headings — and seeing the raw syntax is a perpetual
-  papercut. This namespace lifts that text into hiccup so the prose
-  pane reads as docs, not source.
+  and `:prose`-layout workspaces render prose written in markdown —
+  backticks, bullets, headings. This namespace lifts that text into
+  hiccup so the prose pane reads as docs, not raw source syntax.
 
   ## What we render
 

--- a/tools/story/src/re_frame/story/ui/mode_tabs.cljs
+++ b/tools/story/src/re_frame/story/ui/mode_tabs.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.story.ui.mode-tabs
-  "Render-shell `:dev` / `:docs` / `:test` mode-tabs primitive (rf2-9hc8).
+  "Render-shell `:dev` / `:docs` / `:test` mode-tabs primitive.
 
   Storybook's chrome ships a top-of-canvas tab strip that switches the
   variant view between three canonical modes:
@@ -7,13 +7,12 @@
   - `:dev`  — Canvas. The interactive variant render (Story v1 default).
   - `:docs` — Docs. The read-only AutoDocs-equivalent: prose + args
               table + decorator stack + parameters + tags. Implemented
-              in `re-frame.story.ui.docs` (rf2-rodx); this primitive
-              owns the chip strip only.
+              in `re-frame.story.ui.docs`; this primitive owns the chip
+              strip only.
   - `:test` — Tests. The in-canvas aggregated pass/fail summary for the
               variant's interactions / assertions. Implemented in
-              `re-frame.story.ui.test-mode.view` (rf2-qmjo, split per rf2-8n2fz);
-              this primitive
-              owns the chip strip only.
+              `re-frame.story.ui.test-mode.view`; this primitive owns
+              the chip strip only.
 
   ## Primitive surface
 
@@ -29,16 +28,15 @@
   The shell's `main-pane` consults `(state/active-mode-tab state vid)`
   to decide which pane renders below the strip:
 
-  - `:dev`  → existing canvas / workspace path (unchanged).
-  - `:docs` → `re-frame.story.ui.docs/docs-view` (rf2-rodx).
-  - `:test` → `re-frame.story.ui.test-mode.view/test-view` (rf2-qmjo).
+  - `:dev`  → the canvas / workspace path.
+  - `:docs` → `re-frame.story.ui.docs/docs-view`.
+  - `:test` → `re-frame.story.ui.test-mode.view/test-view`.
 
   ## Visual style
 
-  Matches the existing render-shell chrome (rf2-2uwv contrast fixes):
-  `#b0b0b0` inactive foreground, white active foreground, `#1e1e1e`
-  active background. Reuses the shape of the tab-bar/tab/tab-active
-  styles already defined in `re-frame.story.ui.shell`."
+  Matches the render-shell chrome: `#b0b0b0` inactive foreground, white
+  active foreground, `#1e1e1e` active background. Reuses the shape of the
+  tab-bar/tab/tab-active styles defined in `re-frame.story.ui.shell`."
   (:require [re-frame.story.local-storage :refer [safe-local-storage]]
             [re-frame.story.ui.state :as state]
             [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
@@ -110,9 +108,8 @@
 
 ;; ---- styling -------------------------------------------------------------
 ;;
-;; Same visual register as the existing render-shell chrome — see
-;; rf2-2uwv for the contrast fixes that landed `#b0b0b0` as the standard
-;; inactive foreground.
+;; Same visual register as the render-shell chrome — `#b0b0b0` is the
+;; standard inactive foreground.
 
 (def ^:private styles
   {:strip       {:display          "flex"
@@ -121,14 +118,14 @@
                  :font-family      mono-stack
                  :font-size        (:caption typography/type-scale)
                  :padding          "0"}
-   ;; rf2-c4m8x: longhand-only border sides on every chip. The
-   ;; `:tab-active` overlay below adds a `:border-bottom`; mixing the
-   ;; shorthand `:border "none"` with longhand `:border-bottom` on the
-   ;; same React element across renders triggers React's reconcile
-   ;; warning ("Removing a style property during rerender (borderBottom)
-   ;; when a conflicting property is set (border) can lead to styling
-   ;; bugs"). Spell every side longhand so React reconciles a stable
-   ;; set of keys. Same shape as the trace.cljs fix in rf2-fq1yg.
+   ;; Longhand-only border sides on every chip. The `:tab-active`
+   ;; overlay below adds a `:border-bottom`; mixing the shorthand
+   ;; `:border "none"` with longhand `:border-bottom` on the same React
+   ;; element across renders triggers React's reconcile warning
+   ;; ("Removing a style property during rerender (borderBottom) when a
+   ;; conflicting property is set (border) can lead to styling bugs").
+   ;; Spell every side longhand so React reconciles a stable set of keys.
+   ;; Same shape as the trace.cljs border styling.
    :tab         {:padding             "6px 14px"
                  :cursor              "pointer"
                  :color               (:text-secondary colors/tokens)
@@ -164,8 +161,8 @@
   carries a `data-mode-tab=\"<id>\"` attribute so the Playwright spec
   can target chips without coupling to the visible label.
 
-  Per rf2-9hc8 the strip lives directly above the canvas/workspace pane
-  inside `<main>`."
+  The strip lives directly above the canvas/workspace pane inside
+  `<main>`."
   [variant-id]
   (when variant-id
     ;; Hydrate from localStorage on first render of this variant's
@@ -191,10 +188,9 @@
 
 ;; ---- placeholder panes ---------------------------------------------------
 ;;
-;; rf2-rodx (Docs) is implemented in `re-frame.story.ui.docs`; rf2-qmjo
-;; (Tests) is implemented in `re-frame.story.ui.test-mode.view` (split
-;; per rf2-8n2fz into pure/state/view). Both
-;; placeholders have been removed — the shell routes the `:docs` /
-;; `:test` cases directly at the dedicated panes. The `:placeholder`
-;; style entry below stays in the styles map in case a future pane
-;; needs an empty-state shape, but no placeholder fn is registered.
+;; Docs is implemented in `re-frame.story.ui.docs`; Tests in
+;; `re-frame.story.ui.test-mode.view` (pure/state/view). The shell routes
+;; the `:docs` / `:test` cases directly at these dedicated panes. The
+;; `:placeholder` style entry below stays in the styles map in case a
+;; future pane needs an empty-state shape, but no placeholder fn is
+;; registered.

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -1,7 +1,6 @@
 (ns re-frame.story.ui.multi-substrate
   "Multi-substrate side-by-side rendering. Per `002-Runtime.md` §Substrate hooks
-  + `005-SOTA-Features.md` §Multi-substrate side-by-side rendering
-  + Stage 6 (rf2-zhwd). Phase-2 §5.1 #5.
+  + `005-SOTA-Features.md` §Multi-substrate side-by-side rendering.
 
   When a variant declares `:substrates #{:reagent :uix :helix}` the
   canvas renders the variant against each substrate side-by-side. Per
@@ -148,7 +147,7 @@
 (defn render-view
   "Render `view-id` under `substrate` with `eff-args`, via the registered
   substrate render fn — the clean reusable seam the `render-variant`
-  host-render hook (rf2-5x1wt.24) consumes. Returns the substrate's render
+  host-render hook consumes. Returns the substrate's render
   result (a hiccup vector for `:reagent`); a missing substrate yields an
   inline diagnostic hiccup rather than throwing, so the render verb's
   caller always sees *something*. `(fn [variant-id view-id args] …)` is the
@@ -159,18 +158,15 @@
     [:div {:style {:color (:text-secondary colors/tokens) :font-style "italic"}}
      (str "substrate :" (name substrate) " is not registered")]))
 
-;; ---- shared decorate-and-render seam (rf2-hzhmv / rf2-ba86n.8) -----------
+;; ---- shared decorate-and-render seam -----------------------------------
 ;;
 ;; The canvas single-pane path AND the `render-variant` host hook
 ;; (`re-frame.story.canonical/render-host-scope`) paint the SAME variant
 ;; through the SAME decorate-and-render seam, so a decorated variant looks
-;; identical on the live canvas and through `render-variant`. Before this
-;; consolidation only the canvas applied the variant's `:hiccup` decorators
-;; — the host hook rendered the BARE view (rf2-hzhmv), diverging from the
-;; canvas for any decorated variant. The decorator REFS both consume are the
-;; compiled plan's already-merged `[:world :decorators]` (the single merge
-;; authority, rf2-g74i9 / spec/017 §305-306), so the registered + inline
-;; paths agree too.
+;; identical on the live canvas and through `render-variant`. The decorator
+;; REFS both consume are the compiled plan's already-merged
+;; `[:world :decorators]` (the single merge authority, spec/017 §305-306),
+;; so the registered + inline paths agree too.
 
 (def ^:private decorator-error-styles
   {:wrap   {:background (:danger-bg colors/tokens)
@@ -195,8 +191,7 @@
   map every `:wrap` fn receives as `[body effective-args]`.
 
   The ONE decorate primitive both the canvas single-pane path and the
-  `render-variant` host hook call, so the two agree on the decorated tree
-  (rf2-hzhmv / rf2-ba86n.8)."
+  `render-variant` host hook call, so the two agree on the decorated tree."
   [view-hiccup hiccup-decorators effective-args]
   (try
     (decorators/apply-hiccup-decorators hiccup-decorators view-hiccup effective-args)
@@ -215,9 +210,9 @@
   "Render `view-id` under `substrate` with `eff-args` (via `render-view`),
   then wrap the result with the variant's `:hiccup` decorators resolved from
   `decorator-refs` (the compiled plan's `[:world :decorators]`). This is the
-  single decorate-and-render seam (rf2-hzhmv / rf2-ba86n.8): the
-  `render-variant` host hook calls it so a render-variant render of a
-  decorated variant paints the SAME tree the live canvas paints.
+  single decorate-and-render seam: the `render-variant` host hook calls it so
+  a render-variant render of a decorated variant paints the SAME tree the
+  live canvas paints.
 
   `decorator-refs` is a vector of `[decorator-id & args]` refs (raw refs, as
   the plan carries them); only the `:hiccup`-kind decorators wrap the view —
@@ -306,7 +301,7 @@
   Each cell renders inside a Reagent error boundary so a throw in one
   substrate's render doesn't take down its neighbours (`002-Runtime.md` §Substrate hooks).
 
-  Note (rf2-77nuq): per-substrate decorator stacks (`002-Runtime.md` §Decorator composition order)
+  Note: per-substrate decorator stacks (`002-Runtime.md` §Decorator composition order)
   are not yet threaded through here — `safe-render-cell` renders the
   raw view-id under each substrate. When that work lands, resolve the
   decorator pack here and thread it into each cell's render."
@@ -322,14 +317,12 @@
                        variant-id
                        {:active-modes   (:active-modes shell)
                         :cell-overrides (get-in shell [:cell-overrides variant-id])})]
-    ;; rf2-lbutp — the multi-substrate grid is the canvas's labelled
-    ;; landmark when a variant declares ≥2 substrates. `role="group"`
-    ;; + `aria-label` exposes the substrate-comparison surface as a
-    ;; group of cells; each cell is a `role="region"` with the
-    ;; substrate name as its accessible label (set in
-    ;; `safe-render-cell` below). The audit (#16) flagged the
-    ;; surface as zero-ARIA — the cells now read as labelled regions
-    ;; in landmark navigation.
+    ;; The multi-substrate grid is the canvas's labelled landmark when a
+    ;; variant declares ≥2 substrates. `role="group"` + `aria-label`
+    ;; exposes the substrate-comparison surface as a group of cells; each
+    ;; cell is a `role="region"` with the substrate name as its accessible
+    ;; label (set in `safe-render-cell` below), so the cells read as
+    ;; labelled regions in landmark navigation.
     [:div {:style       (:grid styles)
            :role        "group"
            :aria-label  (str "Multi-substrate render — "

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -1,15 +1,14 @@
 (ns re-frame.story.ui.open-in-editor
   "The 'Open in editor' affordance — a small chip / button that opens
-  the editor at a source-coord's file:line. Per rf2-evgf5 + Spec 005-
-  SOTA-Features.md §'Open in editor' per variant.
+  the editor at a source-coord's file:line. Per Spec 005-SOTA-Features.md
+  §'Open in editor' per variant.
 
   Mirrors `day8.re-frame2-xray.open-in-editor` — same shape, same
-  click-time gate, same launcher seam. Per rf2-r2un8: the two surfaces
-  were drifting; Xray's structure (resolve-uri helper + dispatch-based
-  path + install! registration) is the canonical shape both tools
-  consume now. Story keeps its existing public chip API
+  click-time gate, same launcher seam. Xray's structure (resolve-uri
+  helper + dispatch-based path + install! registration) is the canonical
+  shape both tools consume. Story exposes the public chip API
   (`open-chip` / `open-chip-for-variant` / `open-source-coord!`) but
-  delegates URI resolution to `resolve-uri` and adds a parallel
+  delegates URI resolution to `resolve-uri` and carries a parallel
   dispatch path (`:rf.story/open-in-editor` reg-event) so a panel
   that doesn't render the chip directly can still hand off a
   source-coord through re-frame.
@@ -27,18 +26,17 @@
   the user has to close manually. `Location.assign(...)` triggers the
   same OS dispatch without leaving an orphaned window.
 
-  ## Why `.assign` rather than `(set! .-location)` (rf2-muvs8)
+  ## Why `.assign` rather than `(set! .-location)`
 
   The two should be semantically equivalent — the property setter on
   `window.location` calls `Location.assign` internally per the HTML
-  spec. In practice some Chromium builds on Windows have been observed
-  to silently no-op the property assignment for non-http(s) schemes
-  while honouring the explicit `.assign` call from the same click
-  handler. `.assign` is the more reliable seam; `(set! ...)` was the
-  original implementation and the bug it caused (silent click on
-  Windows + VSCode) is what rf2-muvs8 fixed.
+  spec. In practice some Chromium builds on Windows silently no-op the
+  property assignment for non-http(s) schemes while honouring the
+  explicit `.assign` call from the same click handler. `.assign` is the
+  reliable seam (the `(set! ...)` form produces a silent click on
+  Windows + VSCode).
 
-  ## Diagnostic logging (rf2-muvs8)
+  ## Diagnostic logging
 
   `open!` emits a single-line `console.log` of the URI before each
   navigation. The log is the lowest-friction observability seam for
@@ -57,23 +55,23 @@
   The chip render-fn returns nil when `source-coord` lacks `:file` —
   the macro layer didn't capture a usable file path (the
   `\"NO_SOURCE_PATH\"` sentinel under CLJS without a form-meta
-  fallback, per rf2-mdjp). The UI hides the chip entirely so the user
-  doesn't click a no-op.
+  fallback). The UI hides the chip entirely so the user doesn't click a
+  no-op.
 
-  ## Scheme-rejection denylist (rf2-vwcsq, rf2-ox357n)
+  ## Scheme-rejection denylist
 
   `editor-uri/editor-uri` rejects `javascript:` / `data:` / `vbscript:`
-  for `{:custom ...}` templates at build time (per rf2-vwcsq) — the
-  spec-mandated scheme-rejection list (Security.md / Tool-Pair.md
-  §Editor URI scheme allowlist): everything other than the three
-  known-bad schemes passes through. The click-time `open!` seam below
-  re-applies the same cheap denylist (`editor-uri/forbidden-scheme?`)
-  because the `:rf.editor/open` reg-fx accepts a pre-resolved
-  `{:uri ...}` arg that bypasses `editor-uri`'s build-time gating —
-  the denylist must fire at every handoff. Per rf2-ox357n the prior
-  positive allowlist was removed: it failed CLOSED on any uncatalogued
-  editor scheme (a silent dead button), the exact friction the spec
-  forbids. Unknown custom non-dangerous schemes now pass through.
+  for `{:custom ...}` templates at build time — the spec-mandated
+  scheme-rejection list (Security.md / Tool-Pair.md §Editor URI scheme
+  allowlist): everything other than the three known-bad schemes passes
+  through. The click-time `open!` seam below re-applies the same cheap
+  denylist (`editor-uri/forbidden-scheme?`) because the
+  `:rf.editor/open` reg-fx accepts a pre-resolved `{:uri ...}` arg that
+  bypasses `editor-uri`'s build-time gating — the denylist must fire at
+  every handoff. There is no positive allowlist (it would fail CLOSED on
+  any uncatalogued editor scheme — a silent dead button — the exact
+  friction the spec forbids): unknown custom non-dangerous schemes pass
+  through.
 
   ## Bundle isolation
 

--- a/tools/story/src/re_frame/story/ui/promotion.cljc
+++ b/tools/story/src/re_frame/story/ui/promotion.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story.ui.promotion
   "Generated-failure promotion UX — turn a captured run ARTIFACT into a
-  curated, named Story variant (rf2-ba86n.13, spec/021 §3).
+  curated, named Story variant (spec/021 §3).
 
   ## What this surface is — and is NOT
 
@@ -40,7 +40,7 @@
   carries none of that until the author promotes it). The sidebar surfaces
   the store as a BOUNDED, collapsed 'Captured artifacts' affordance
   (`re-frame.story.ui.sidebar`) — opening an artifact drives the promotion
-  dialog WITHOUT adding a permanent nav row (respects ba86n.4's sidebar
+  dialog WITHOUT adding a permanent nav row (respects the sidebar
   bounding; spec/018 §10).
 
   ## Pure / CLJS split
@@ -293,8 +293,7 @@
      flow. `:promoted-id` holds the registered id after a successful promote
      (it gates the green confirmation) — it lives on the dialog state, NOT a
      component-local ratom, so `open!`/`close!` reset it as part of the
-     lifecycle and a freshly-opened artifact always reads as un-promoted
-     (rf2-lc0cp)."
+     lifecycle and a freshly-opened artifact always reads as un-promoted."
      {:open?       false
       :artifact-id nil
       :draft       nil
@@ -337,7 +336,7 @@
              now   (.now js/Date)]
          ;; Full reset (incl. `:promoted-id nil`) — a freshly-opened artifact
          ;; ALWAYS reads as un-promoted; no stale confirmation from a prior
-         ;; artifact's promote leaks across (rf2-lc0cp).
+         ;; artifact's promote leaks across.
          (reset! dialog-atom
                  {:open?       true
                   :artifact-id artifact-id
@@ -355,7 +354,7 @@
      "Record `promoted-id` as the registered variant id after a successful
      promote — gates the green confirmation. Stored on the dialog state (not
      a component-local ratom) so the next `open!`/`close!` clears it as part
-     of the lifecycle (rf2-lc0cp)."
+     of the lifecycle."
      [promoted-id]
      (swap! dialog-atom assoc :promoted-id promoted-id)
      nil))
@@ -592,7 +591,7 @@
      ;; promote-confirmation gate reads `:promoted-id` from `dialog-atom` — NOT
      ;; a component-local ratom — so `open!`/`close!` reset it as part of the
      ;; lifecycle and a freshly-opened artifact never inherits a prior promote's
-     ;; stale confirmation (rf2-lc0cp).
+     ;; stale confirmation.
      (fn []
        (let [dialog @dialog-atom]
          (when (:open? dialog)
@@ -622,7 +621,7 @@
                     :placeholder-input ":story.your-story/regression-042"
                     :on-edit-id        set-draft-id!
                     :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
-                    ;; rf2-ba86n.13 — the PRIMARY action drives the
+                    ;; The PRIMARY action drives the
                     ;; substrate's `promote-run-artifact!` register path
                     ;; (review-dialog renders it as the accent button left
                     ;; of 'copy'). Disabled until the draft carries a

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.story.ui.recorder
   "Test Codegen UI surface — toolbar REC chip + recording overlay.
 
-  Per bead rf2-5fc15. Wires the pure recorder
+  Wires the pure recorder
   (`re-frame.story.recorder`) to:
 
   - The chrome-level toolbar — a REC chip lives at the right of the
@@ -189,8 +189,8 @@
                  :display      "flex"
                  :align-items  "center"
                  :gap          "8px"}
-   ;; Modal styling for the save-as-variant dialog moved to
-   ;; `re-frame.story.review-dialog` (rf2-7jpky); only the chip /
+   ;; Modal styling for the save-as-variant dialog lives in
+   ;; `re-frame.story.review-dialog`; only the chip /
    ;; overlay / picker styles remain here.
    :btn-row     {:display "flex"
                  :gap "8px"
@@ -214,7 +214,7 @@
    :hint        {:color (:text-tertiary colors/tokens)
                  :font-style "italic"
                  :font-size (:micro typography/type-scale)}
-   ;; Mid-recording assertion picker (rf2-39u9e)
+   ;; Mid-recording assertion picker
    :assert-btn  {:padding "3px 9px"
                  :background (:accent-amber colors/tokens)
                  :color "white"
@@ -304,7 +304,7 @@
 ;; id in `:source-id` and the captured `:events` snapshot in
 ;; `:context` (with a top-level `:events` mirror for ergonomics).
 ;;
-;; **Snapshot at open time** (rf2-8x9nb): the captured events ride on
+;; **Snapshot at open time**: the captured events ride on
 ;; the dialog state itself — NOT read live off the recorder atom — so
 ;; clicking REC again to start a fresh recording (which resets the
 ;; recorder atom) cannot mutate the in-flight dialog's snippet. The
@@ -322,7 +322,7 @@
 (defn- open-dialog!
   "Open the save-as-variant dialog against `source-variant-id` with
   the captured `events` snapshot. `now-ms` defaults to the current
-  wall-clock; tests pass an explicit stamp. Per rf2-d5u89 the
+  wall-clock; tests pass an explicit stamp. The
   captured `:entries` are snapshotted alongside `:events` so the
   export dialog drives the `:script`-body translator with the rich
   DOM-event + timing record."
@@ -370,7 +370,7 @@
                      (cond
                        (and (not rec?) target)
                        (do
-                         ;; rf2-d5u89: re-attach DOM-capture listeners to
+                         ;; Re-attach DOM-capture listeners to
                          ;; the current canvas root. The shell's mount-
                          ;; time install handles the common case, but mode
                          ;; switches (Docs / Test → Canvas) re-mount the
@@ -382,7 +382,7 @@
                        rec?
                        (let [_     (recorder-dom/flush-type-buffer!)
                              {:keys [variant-id events entries]} (recorder/stop-recording!)]
-                         ;; rf2-nkjkj: open the dialog when EITHER stream
+                         ;; Open the dialog when EITHER stream
                          ;; captured something — a recording of canvas
                          ;; clicks/types only lands in :entries, never
                          ;; :events, so gating on :events alone would
@@ -414,7 +414,7 @@
         (str "  " (count (:events rec)))])]))
 
 ;; ---------------------------------------------------------------------------
-;; Mid-recording assertion picker (rf2-39u9e)
+;; Mid-recording assertion picker
 ;;
 ;; The recording overlay carries a `+ assert` button next to `stop`.
 ;; Click → `ui-picker` flips `:open?` true and the modal renders.
@@ -438,7 +438,7 @@
            :assertion    nil      ; the picked id, or nil while on phase 1
            :field-text   {}       ; field-key → raw input string
            :error        nil
-           :active-index 0}))     ; roving-focus cursor for phase-1 vocab list (rf2-07m13)
+           :active-index 0}))     ; roving-focus cursor for phase-1 vocab list
 
 (defn- open-picker! []
   (reset! ui-picker {:open? true :assertion nil :field-text {} :error nil :active-index 0}))
@@ -521,7 +521,7 @@
   "story-recorder-picker-title")
 
 (defn- vocab-key-handler
-  "Phase-1 keyboard handler for the assertion-vocabulary list (rf2-07m13).
+  "Phase-1 keyboard handler for the assertion-vocabulary list.
 
   - ArrowDown / ArrowUp move the active cursor one row.
   - Home / End jump to the first / last row.
@@ -556,11 +556,11 @@
   shell can mount it alongside the recorder overlay (and so tests can
   introspect the hiccup).
 
-  rf2-p1ai7: ARIA role=dialog + aria-modal + aria-labelledby on the
+  ARIA role=dialog + aria-modal + aria-labelledby on the
   picker panel; focus-trap wrapper handles Tab cycle, Escape, and
   return-focus.
 
-  rf2-07m13: phase-1 vocabulary list implements the WAI-ARIA APG
+  The phase-1 vocabulary list implements the WAI-ARIA APG
   menu pattern — role=menu on the container, role=menuitem on each
   row, roving tabindex with ArrowUp/ArrowDown/Home/End/Enter handling."
   []
@@ -680,7 +680,7 @@
                  :on-click  (fn [_] (insert!))}
                 "insert"]]]))]]])))
 
-;; rf2-d5u89: Reagent-mirror of the DOM-capture enabled flag so the
+;; Reagent-mirror of the DOM-capture enabled flag so the
 ;; overlay chip re-renders when the user toggles capture. The flag
 ;; lives in the dom-capture ns; here we just mirror it.
 
@@ -695,7 +695,7 @@
   "Fixed-position banner that floats at the top-right of the shell
   while a recording is in flight. Surfaces the target variant + the
   running event count + a `+ assert` button for mid-recording
-  assertion insertion (rf2-39u9e). Per rf2-d5u89 the overlay also
+  assertion insertion. The overlay also
   exposes a `DOM` toggle for opting in/out of DOM-event capture."
   []
   (let [{:keys [recording? variant-id events]} @ui-state
@@ -734,12 +734,12 @@
         {:style    (:btn-muted styles)
          :data-test "story-recorder-stop"
          :on-click (fn [_]
-                     ;; rf2-d5u89: drain pending typed-input buffer
+                     ;; Drain pending typed-input buffer
                      ;; before sealing the recording so the final
                      ;; :dom/type entry lands in the script.
                      (recorder-dom/flush-type-buffer!)
                      (let [{:keys [variant-id events entries]} (recorder/stop-recording!)]
-                       ;; rf2-nkjkj: open on EITHER stream — a DOM-only
+                       ;; Open on EITHER stream — a DOM-only
                        ;; recording lands only in :entries.
                        (when (or (seq events) (seq entries))
                          (open-dialog! variant-id events))))}
@@ -757,17 +757,17 @@
   The user edits the variant id inline; the snippet re-generates on
   every keystroke. Discard / close drop the captured recording.
 
-  ## Single source of truth — `:entries` (rf2-nkjkj)
+  ## Single source of truth — `:entries`
 
   The snippet is rendered from the recorder's RICH `:entries` snapshot
   via the `recording->script-body` translator, NOT the bare `:events`
   vector. `:entries` is the only stream that carries DOM interactions
   (`:dom/click` / `:dom/type` / `:dom/submit`, captured off the canvas
   root by `recorder.dom-capture`) — `:events` holds dispatched events
-  ONLY. Rendering the primary dialog off `:events` (the historical
-  `gen-play-snippet` path) SILENTLY DROPPED every recorded click /
-  type / submit, producing an incomplete, non-reproducing variant with
-  a misleading count. Consuming `:entries` here means a recording that
+  ONLY. The primary dialog renders off `:entries` rather than `:events`
+  because `:events` carries no recorded click / type / submit, so a
+  `:events`-only snippet would be an incomplete, non-reproducing
+  variant with a misleading count. Consuming `:entries` here means a recording that
   captured canvas clicks codegens `[:click ...]` / `[:type ...]` /
   `[:wait ...]` steps in the primary save flow, and the displayed count
   reflects the full rich recording.
@@ -778,7 +778,7 @@
 
   Reads `:entries` + `:source-id` from the dialog state itself — the
   snapshot was taken at `open-dialog!` time so a subsequent
-  `start-recording!` cannot mutate the visible snippet (rf2-8x9nb)."
+  `start-recording!` cannot mutate the visible snippet."
   []
   (let [dialog                                  @ui-dialog
         {:keys [events entries source-id]}      dialog]
@@ -812,7 +812,7 @@
            :on-edit-id        set-draft-id!
            :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
            :on-discard        (fn [] (recorder/clear!) (close-dialog!))
-           ;; rf2-x9zsr — open the export dialog with the captured
+           ;; Open the export dialog with the captured
            ;; snapshot for the auto-run / auto-assert affordances. We
            ;; DON'T close the parent dialog; the export dialog stacks on
            ;; top via a higher z-index.

--- a/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
@@ -1,13 +1,12 @@
 (ns re-frame.story.ui.recorder-export-dialog
-  "Recorder → :script export dialog UI (rf2-x9zsr).
+  "Recorder → :script export dialog UI.
 
-  The recorder's existing save-as-variant dialog
+  The recorder's save-as-variant dialog
   (`re-frame.story.ui.recorder/save-dialog`) emits the simple play body
   — each captured event vector wrapped as a `[:dispatch-sync
-  <event-vec>]` step (rf2-0wrud). The rich play DSL landed in rf2-8i2a9;
-  this dialog is its twin — same recording, different output shape. Per
-  rf2-7mj4z both emit the PUBLIC `:script` authoring slot (spec/017
-  §Public vocabulary), not the transitional `:play-script` spelling:
+  <event-vec>]` step. This dialog is its twin — same recording, using
+  the rich play DSL for a different output shape. Both emit the PUBLIC
+  `:script` authoring slot (spec/017 §Public vocabulary):
 
       (story/reg-variant :story.your/recorded
         {:extends :story.your/source
@@ -62,7 +61,7 @@
 ;; Dialog state — a single Reagent ratom carrying the dialog's
 ;; configuration. The dialog opens off the existing recorder save-
 ;; dialog, so it snapshots the *recorded* events + variant-id when
-;; opened (mirrors the rf2-8x9nb guard on the parent dialog — a
+;; opened (mirrors the snapshot guard on the parent dialog — a
 ;; subsequent start-recording! cannot mutate the in-flight export).
 ;; ---------------------------------------------------------------------------
 
@@ -72,7 +71,7 @@
   {:open?               false
    :source-id           nil   ; the recorded variant-id (rides into :extends)
    :events              []    ; captured events snapshot (legacy)
-   :entries             []    ; rich :entries snapshot (rf2-d5u89)
+   :entries             []    ; rich :entries snapshot
    :variant-id          nil   ; the new variant id (user-editable)
    :name                ""    ; optional :name field on the play-script
    :auto-assert?        true
@@ -91,7 +90,7 @@
 
     :source-id        — the recorded variant-id (rides into `:extends`).
     :events           — captured events snapshot (legacy bare-vectors).
-    :entries          — rich :entries snapshot (rf2-d5u89). When
+    :entries          — rich :entries snapshot. When
                         non-empty, the translator consumes this in
                         preference to `:events` so DOM-events + per-
                         event timestamps flow through to the script.
@@ -135,7 +134,7 @@
 (defn- build-export-from-dialog
   [{:keys [events entries source-id variant-id name auto-assert? final-db]}]
   ;; Prefer the rich :entries snapshot when it carries anything —
-  ;; that's where DOM-events + per-event timestamps live (rf2-d5u89).
+  ;; that's where DOM-events + per-event timestamps live.
   ;; Fall back to the legacy :events vector for back-compat.
   (let [src (if (seq entries) entries events)]
     (export-events/build-export
@@ -301,7 +300,7 @@
       (let [{:keys [spec rendered]} (build-export-from-dialog state)
             {:keys [name source-id variant-id auto-assert?
                     replay-status replay-failure-msg]} state]
-        ;; rf2-p1ai7: focus-trap wrapper — Escape closes, Tab cycles,
+        ;; Focus-trap wrapper — Escape closes, Tab cycles,
         ;; focus moves into the dialog on mount, focus returns to the
         ;; trigger on close. The dialog hiccup is passed eagerly so
         ;; tests can string-traverse the full tree without invoking
@@ -404,7 +403,7 @@
 (defn open-from-recorder-dialog!
   "Open the export dialog using the recorder save-dialog's captured
   snapshot. Reads the live frame db at click time so the auto-assert
-  option can derive assertions from real data. Per rf2-d5u89 the
+  option can derive assertions from real data. The
   caller threads the recorder's `:entries` (rich DOM-event + timing
   record) alongside `:events` so the translator emits `:click` /
   `:type` / `:wait` steps when DOM-events were captured."

--- a/tools/story/src/re_frame/story/ui/save_variant.cljs
+++ b/tools/story/src/re_frame/story/ui/save_variant.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.story.ui.save-variant
-  "Save-current-canvas-state-as-new-variant UI — the SB9 'Save' affordance
-  (rf2-one3t). The pure machinery lives in
+  "Save-current-canvas-state-as-new-variant UI — the SB9 'Save' affordance.
+  The pure machinery lives in
   `re-frame.story.save-variant`; this ns wires the Reagent ratom, the
   controls-panel button, and the modal dialog around it.
 
@@ -48,14 +48,13 @@
 
 (defn- open-dialog!
   "Open the dialog against `source-variant-id` with the captured
-  `args-snapshot`. `now-ms` seeds the default id. `violations` (rf2-
-  lancu) is the vector returned by
+  `args-snapshot`. `now-ms` seeds the default id. `violations` is the vector returned by
   `schema-validation/args-violations` against the live component
   schema — used by the dialog to render a non-blocking 'Args do not
   match the variant's Spec 010 schema' hint when non-empty. May be
   nil/empty (no schema registered, or all args conform).
 
-  `slices` (rf2-ba86n.6) is the eight-slice capture report from
+  `slices` is the eight-slice capture report from
   `save-variant/capture-slices` — the dialog renders its honesty-floor
   warnings (which slices are captured-as-declared / not-yet-projectable)
   so a saved variant is honest about what it does and does NOT capture.
@@ -156,7 +155,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- violations-hint
-  "Render the rf2-lancu non-blocking violations note. Stripe and list
+  "Render the non-blocking violations note. Stripe and list
   of violating keys, so the user catches a drifted-args paste before
   it lands in source. nil when no violations."
   [violations]
@@ -185,7 +184,7 @@
               (pr-str (:value v)))])]]))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-ba86n.6 — the eight-slice capture report.
+;; The eight-slice capture report.
 ;;
 ;; spec/019 §3 requires the save flow to be HONEST about which canvas
 ;; slices it can represent losslessly and which it cannot: "if the
@@ -206,7 +205,7 @@
    :not-wired            {:background "#332a2a" :color "#d09f9f" :border "#704040"}})
 
 (defn slice-report
-  "Render the non-blocking eight-slice capture report (rf2-ba86n.6). Lists
+  "Render the non-blocking eight-slice capture report. Lists
   every slice that is NOT a clean live projection — `:captured-as-declared`
   (carried forward via `:extends`) and `:not-wired` (not yet projectable)
   — with its honest note. Returns nil when every slice projects cleanly
@@ -257,12 +256,12 @@
   edits the new variant id; copy-to-clipboard surfaces the form for the
   user to paste into source.
 
-  rf2-lancu: when the captured snapshot violates the variant's Spec 010
+  When the captured snapshot violates the variant's Spec 010
   schema, a non-blocking hint renders above the snippet listing the
   violating keys. Non-blocking — the user can still paste; the snippet
   carries the violating args as captured (paste at your own risk).
 
-  rf2-ba86n.6: the eight-slice capture report renders below the snippet,
+  The eight-slice capture report renders below the snippet,
   warning which slices are captured-as-declared (carried via `:extends`)
   and which are not yet projectable — the honesty floor for a saved
   variant (spec/019 §3).

--- a/tools/story/src/re_frame/story/ui/schema_form.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_form.cljc
@@ -1,12 +1,12 @@
 (ns re-frame.story.ui.schema-form
-  "Schema-generated input forms for view-state values (rf2-xon7j).
+  "Schema-generated input forms for view-state values.
 
   ## What it is
 
   When a `:sub-overrides` target sub declares an output `:schema`, the
   designer should fill in a TYPED FORM (text / number / checkbox / select
   / flat fieldset) rather than hand-write the override's raw EDN. A schema
-  good enough to VALIDATE an override (the rf2-7pgiz `:where :sub-override`
+  good enough to VALIDATE an override (the `:where :sub-override`
   seam — core validates a HIT against the sub's declared `:schema`) is good
   enough to GENERATE its input. This namespace is the pure projection that
   turns a registered schema into a flat field-shape, builds default values,

--- a/tools/story/src/re_frame/story/ui/schema_validation.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_validation.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story.ui.schema-validation
   "Schema-validation panel — live Spec 010 boundary-failure surface per
-  variant. Per Story SOTA audit F-N / rf2-dvue.
+  variant.
 
   ## What it is
 
@@ -40,7 +40,7 @@
   `:extends`-inherited / `:compose`-d `:component` resolves) and reads the
   schema the compiler wrote to `[:world :view-args-schema]`, resolved
   first-match `[:rf/props :schema]` off the component view's `:view`
-  metadata (rf2-din8u / rf2-p5ivc (b)). The controls panel derives its
+  metadata. The controls panel derives its
   argtypes from the SAME slot, so validation and controls share one
   source.
 
@@ -110,15 +110,15 @@
     - `:failing-id` / `:event-id` / `:sub-id` / `:cofx-id` / `:fx-id`
                  — the registration/boundary id whose schema validation
                  failed (the registered event / sub / cofx / fx / app-db
-                 root). `:spec` is dead post-M-54 — this surface speaks
-                 the schema vocabulary (`reg-*` `:schema` metadata).
+                 root). This surface speaks the schema vocabulary
+                 (`reg-*` `:schema` metadata).
     - `:received` — the actual value that failed (event vector / value /
                     coeffect map / slice).
     - `:explain` — the validator's explanation (Malli explain map on
                    the CLJS reference; other shapes on other ports).
     - `:path` (when present, for app-db failures) — the failing leaf
                 path (registered root + Malli explainer's value-
-                navigation suffix per rf2-oh4se). The registration
+                navigation suffix). The registration
                 anchor itself rides on `:registered-path` when tooling
                 needs it.
     - `:frame` — the frame id the failure fired in.
@@ -302,7 +302,7 @@
 
      This is the SAME slot the controls panel derives argtypes from
      (`re-frame.story.ui.controls/resolve-argtypes`), so validation and
-     controls share one source (rf2-din8u / rf2-vnedo). Routing through the
+     controls share one source. Routing through the
      compiled plan also resolves an `:extends`-inherited / `:compose`-d
      `:component` that the previous bare-body read (`(:component vb)` /
      `(:component sb)`) missed.
@@ -441,7 +441,7 @@
 
 #?(:cljs
    (defn panel
-     "The schema-validation panel. Per rf2-dvue Form-2 — the inner
+     "The schema-validation panel. Form-2 — the inner
      render fn derefs the trace buffer so Reagent's reaction
      tracking sees every change.
 
@@ -533,8 +533,7 @@
 
 #?(:cljs
    (def ^:const panel-id
-     "Story-panel id for the schema-validation panel. Per Story SOTA
-     audit F-N / rf2-dvue."
+     "Story-panel id for the schema-validation panel."
      :rf.story.panel/schema-validation))
 
 #?(:cljs
@@ -561,7 +560,6 @@
        ;; annotation the annotator needs a hiccup DOM root to attach
        ;; `data-rf2-source-coord` to; a bare `[panel variant-id]` root
        ;; silences Story / Xray Inspect Mode for this panel.
-       ;; (rf2-iwny7)
        (rf/reg-view* panel-render-id (fn [variant-id] [:div [panel variant-id]]))
        (story-registrar/reg-story-panel*
          panel-id

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -1,9 +1,9 @@
 (ns re-frame.story.ui.state
   "Shell-local state — pure data + helpers (`.cljc`) plus the CLJS-only
-  reactive ratom bag. Per Stage 4 (rf2-ekai) the UI shell carries its
-  own selection / filter / mode state independently of the Story
-  registrar (the registrar is the source of truth for *what's
-  registered*; this ns is the source of truth for *what's selected*).
+  reactive ratom bag. The UI shell carries its own selection / filter /
+  mode state independently of the Story registrar (the registrar is the
+  source of truth for *what's registered*; this ns is the source of
+  truth for *what's selected*).
 
   ## Public surface
 
@@ -15,12 +15,12 @@
   - `set-cell-override`  — set a single arg override at a path
                            `[arg-key & sub-path]`; the nested-path
                            form backs the nested-schema controls
-                           walker (rf2-agshe). The `-scalar` wrapper
+                           walker. The `-scalar` wrapper
                            handles the bare top-level arg-key case.
   - `clear-cell-overrides` — drop all overrides for the focused variant.
   - `clear-cell-override`  — drop one top-level arg-key's override,
                              reverting that arg to its saved value (the
-                             controls panel's per-arg reset, rf2-ba86n.5).
+                             controls panel's per-arg reset).
   - `filter-variants`    — pure fn: given a set of variant bodies + the
                            shell state, return the visible subset.
   - `group-variants-by-story` — pure fn: build the sidebar tree.
@@ -47,7 +47,7 @@
 ;; ---- pure data: the default shape ----------------------------------------
 
 (def default-shell-state
-  "The initial shell state. Stage 4 keeps the shape small and additive.
+  "The initial shell state. The shape is small and additive.
 
   - `:selected-variant`  — variant id under focus, or nil.
   - `:selected-workspace` — workspace id under focus, or nil.
@@ -65,15 +65,13 @@
   - `:pinned-snapshots`  — {variant-id → [{:label ... :epoch-id ...}]}.
   - `:panel-visibility`  — {panel-id → boolean}. Determines whether a
                            registered :story-panel renders in the chrome.
-                           Stage 4 ships a vanilla set of panels
-                           (controls + dispatch-console); Stage 6
-                           registers more via reg-story-panel.
-                           Per rf2-sgdd3 the trace / scrubber / actions
-                           panels were retired in favour of Xray
-                           mounted in the RHS by default.
+                           Ships a vanilla set of panels (controls +
+                           dispatch-console); more register via
+                           reg-story-panel. Xray mounts in the RHS by
+                           default.
   - `:active-mode-tab`   — {variant-id → :dev | :docs | :test}. Per-variant
                            mode-tab selection for the render-shell's top
-                           Canvas | Docs | Tests switcher (rf2-9hc8).
+                           Canvas | Docs | Tests switcher.
                            Unspecified → :dev (canvas). Persisted in
                            localStorage under `re-frame.story/active-
                            mode-tab/<variant-id>`.
@@ -81,7 +79,7 @@
                            rail widths, hydrated from localStorage by the
                            CLJS shell. The defaults keep the canvas usable.
   - `:tests` — sub-map grouping every chrome-test-widget slot under
-               one root (rf2-uefbk). Holds:
+               one root. Holds:
 
       `:runs`           — {variant-id → run-state}. Per-variant test-run
                           record fed both by the `:test` mode pane's
@@ -93,14 +91,13 @@
                              :fail     — last run: ≥1 assertion failed
                           plus pass/fail/skip/total counts and timing.
                           Powers both the chrome widget's aggregate
-                          summary and the sidebar's per-variant dots
-                          (rf2-q0irb).
+                          summary and the sidebar's per-variant dots.
       `:watch-mode?`    — boolean. When true the chrome test widget's
                           eye-icon toggle is on and the shell auto-
                           re-runs testable variants whose snapshot
-                          identity drifted since the last observation
-                          (rf2-z1h0f). Default false — explicit re-run
-                          is the v1 contract; watch-mode is opt-in.
+                          identity drifted since the last observation.
+                          Default false — explicit re-run is the v1
+                          contract; watch-mode is opt-in.
       `:content-hashes` — {variant-id → hex-hash} the last-observed
                           snapshot-identity content hash per testable
                           variant. The watch-mode detector compares the
@@ -110,21 +107,20 @@
                           off (the detector seeds it on toggle-on)."
   {:selected-variant    nil
    :selected-workspace  nil
-   ;; rf2-8j7wg (audit C-4) — `:selected-story` carries a parent-story
-   ;; id when the user clicks a story HEADER in the sidebar (i.e. the
-   ;; `reg-story` node rather than one of its `reg-variant` children).
-   ;; The render shell routes this to a rollup docs page that
-   ;; aggregates every variant's docs section under the story. Mutually
-   ;; exclusive with `:selected-variant` + `:selected-workspace` at the
-   ;; transition level — `select-story` clears both, mirroring the
-   ;; existing variant ↔ workspace exclusion.
+   ;; `:selected-story` carries a parent-story id when the user clicks a
+   ;; story HEADER in the sidebar (i.e. the `reg-story` node rather than
+   ;; one of its `reg-variant` children). The render shell routes this to
+   ;; a rollup docs page that aggregates every variant's docs section
+   ;; under the story. Mutually exclusive with `:selected-variant` +
+   ;; `:selected-workspace` at the transition level — `select-story`
+   ;; clears both, mirroring the variant ↔ workspace exclusion.
    :selected-story      nil
    :tag-filter          #{}
    :active-modes        []
    :cell-overrides      {}
-   ;; rf2-c8kfy: stable monotonic ids for repeater rows so React keys
-   ;; survive mid-list deletes (no focus / cursor leakage onto the
-   ;; surviving rows). Counter allocates fresh ids; the row-ids map
+   ;; stable monotonic ids for repeater rows so React keys survive
+   ;; mid-list deletes (no focus / cursor leakage onto the surviving
+   ;; rows). Counter allocates fresh ids; the row-ids map
    ;; carries `{[variant-id path] → [id0 id1 ...]}` in lockstep with
    ;; the entries vector at `:cell-overrides`.
    :rf.story/repeater-id-counter 0
@@ -133,7 +129,7 @@
    :hot-reload-tick     0
    :fingerprints        {}
    :pinned-snapshots    {}
-   ;; rf2-q9kv5 — `:dispatch-console` slot. Default is nil (not false)
+   ;; `:dispatch-console` slot. Default is nil (not false)
    ;; so the per-story `:dispatch-console?` body flag is the effective
    ;; default. The shell's right-panel checks the per-story flag first
    ;; and falls back to FALSE when nothing is declared (opt-in default;
@@ -144,14 +140,14 @@
    :tests               {:runs           {}
                          :watch-mode?    false
                          :content-hashes {}}
-   ;; rf2-zll4h: chrome-wide toolbar selections for the viewport +
+   ;; chrome-wide toolbar selections for the viewport +
    ;; background switchers. nil means "use neutral default" — the
    ;; switcher resolves to `:full` / `:light` respectively. A per-story
    ;; `:viewport` / `:background` override on the story / variant body
    ;; takes precedence over the chrome-wide selection at resolve time.
    :viewport            nil
    :background          nil
-   ;; rf2-p3i0t / rf2-g8l8x / rf2-pucku — per-panel chrome visibility
+   ;; per-panel chrome visibility
    ;; toggled by muscle-memory hotkeys (`f` full-screen, `s` sidebar,
    ;; `a` RHS, `t` toolbar) and the `?embed=1` URL flag. Defaults: every
    ;; pane visible; full-screen + embed are opt-in.
@@ -160,16 +156,16 @@
                          :rhs?         true
                          :toolbar?     true
                          :embed?       false}
-   ;; rf2-ba86n.19 — lazy Xray-diff mounting (spec/018 §10). When true the
+   ;; lazy Xray-diff mounting (spec/018 §10). When true the
    ;; RHS Xray embed is COLLAPSED: the panel-host is not rendered, so no
    ;; `mount-<panel>!` fires and the panel's expensive diff compute (app-db
    ;; structural diff, epoch timeline) is deferred. Defaults false
    ;; (expanded) so the out-of-the-box RHS paints the panel; collapsing
-   ;; releases the Xray React root via the existing microtask path
-   ;; (rf2-4l7t2). The chip-row's disclosure toggle flips this slot.
+   ;; releases the Xray React root via the existing microtask path.
+   ;; The chip-row's disclosure toggle flips this slot.
    :xray-embed-collapsed? false})
 
-;; ---- pure transitions (extracted to state.transitions, rf2-gcpon) -------
+;; ---- pure transitions (extracted to state.transitions) ------------------
 
 (def select-variant            state.transitions/select-variant)
 (def select-workspace          state.transitions/select-workspace)
@@ -192,13 +188,13 @@
 (def pin-snapshot              state.transitions/pin-snapshot)
 (def toggle-panel              state.transitions/toggle-panel)
 
-;; ---- Xray-embed collapse re-exports (rf2-ba86n.19) ----------------------
+;; ---- Xray-embed collapse re-exports -------------------------------------
 
 (def xray-embed-collapsed?       state.transitions/xray-embed-collapsed?)
 (def toggle-xray-embed-collapsed state.transitions/toggle-xray-embed-collapsed)
 (def set-xray-embed-collapsed    state.transitions/set-xray-embed-collapsed)
 
-;; ---- chrome visibility re-exports (rf2-p3i0t / rf2-g8l8x / rf2-pucku) ---
+;; ---- chrome visibility re-exports ---------------------------------------
 
 (def chrome-visibility-defaults state.transitions/chrome-visibility-defaults)
 (def chrome-visibility         state.transitions/chrome-visibility)
@@ -206,7 +202,7 @@
 (def set-chrome-visibility     state.transitions/set-chrome-visibility)
 (def chrome-pane-visible?      state.transitions/chrome-pane-visible?)
 
-;; ---- mode-tab (rf2-9hc8) re-exports --------------------------------------
+;; ---- mode-tab re-exports -------------------------------------------------
 
 (def mode-tabs                 state.transitions/mode-tabs)
 (def mode-tab-labels           state.transitions/mode-tab-labels)
@@ -215,7 +211,7 @@
 (def active-mode-tab           state.transitions/active-mode-tab)
 (def set-active-mode-tab       state.transitions/set-active-mode-tab)
 
-;; ---- pure derivations (extracted to state.filters, rf2-gcpon) -----------
+;; ---- pure derivations (extracted to state.filters) ----------------------
 
 (def group-tags-by-axis           state.filters/group-tags-by-axis)
 (def axis-display-order           state.filters/axis-display-order)
@@ -225,12 +221,11 @@
 (def filter-variants              state.filters/filter-variants)
 (def group-variants-by-story      state.filters/group-variants-by-story)
 
-;; rf2-ee38b.3: the `state/parent-story-id` re-export was dropped — it
-;; had no internal src caller (sidebar / filters call
-;; `pred/parent-story-id` directly). The canonical helper lives in
-;; `re-frame.story.predicates`.
+;; The canonical `parent-story-id` helper lives in
+;; `re-frame.story.predicates`; sidebar / filters call
+;; `pred/parent-story-id` directly.
 
-;; ---- registry snapshot (extracted to state.snapshot, rf2-gcpon) ---------
+;; ---- registry snapshot (extracted to state.snapshot) --------------------
 
 (def registry-snapshot
   "Re-export of `re-frame.story.ui.state.snapshot/registry-snapshot`."
@@ -271,13 +266,12 @@
   (when config/enabled?
     (apply swap! shell-state-atom f args)))
 
-;; ---- test-runs + watch-mode (extracted to state.tests, rf2-gcpon) -------
+;; ---- test-runs + watch-mode (extracted to state.tests) ------------------
 ;;
-;; The cross-variant test-run aggregation surface (rf2-q0irb) and the
-;; watch-mode helpers (rf2-z1h0f) live in `re-frame.story.ui.state.tests`
-;; — split out per rf2-gcpon to honor the rf2-zkca8 leaf-size ceiling.
-;; Re-exported here so consumer requires of `re-frame.story.ui.state`
-;; keep working unchanged.
+;; The cross-variant test-run aggregation surface and the watch-mode
+;; helpers live in `re-frame.story.ui.state.tests`, split out to honor the
+;; leaf-size ceiling. Re-exported here so consumer requires of
+;; `re-frame.story.ui.state` keep working unchanged.
 
 (def test-run-statuses           state.tests/test-run-statuses)
 (def mark-test-running           state.tests/mark-test-running)

--- a/tools/story/src/re_frame/story/ui/state/filters.cljc
+++ b/tools/story/src/re_frame/story/ui/state/filters.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.story.ui.state.filters
   "Pure data → data helpers for the sidebar's faceted tag-filter UI and
   story-grouped variant listing. Split from
-  `re-frame.story.ui.state` per rf2-gcpon (leaf-size ceiling rf2-zkca8).
+  `re-frame.story.ui.state` to honor the leaf-size ceiling.
 
   ## What lives here
 
@@ -13,7 +13,7 @@
   - `filter-variants`           — apply the predicate over a variant map.
   - `group-variants-by-story`   — build the sidebar tree.
 
-  The faceted-filter contract (rf2-7ncf9 SB9 parity): AND across axes,
+  The faceted-filter contract (Storybook SB9 parity): AND across axes,
   OR within an axis. Documented per-fn below."
   (:require [re-frame.story.predicates :as pred]))
 
@@ -25,8 +25,8 @@
   `:re-frame.story.registrar/no-axis` (the same sentinel
   `registrar/tag->axis` returns for un-axis-grouped tags).
 
-  rf2-7ncf9 — faceted tag-filter UI. The sidebar's filter row walks
-  this result to render one labelled chip row per axis."
+  Faceted tag-filter UI: the sidebar's filter row walks this result to
+  render one labelled chip row per axis."
   [tags tag->axis]
   (->> tags
        (reduce (fn [acc t]
@@ -69,7 +69,7 @@
   sentinel `registrar/tag->axis` returns for un-axis-grouped tags. The
   faceted-filter predicate (`variant-tag-match?`) consumes the result.
 
-  Faceted-filter semantics (rf2-7ncf9, SB9 parity): AND across axes,
+  Faceted-filter semantics (Storybook SB9 parity): AND across axes,
   OR within an axis. Partitioning is the first half — the predicate
   enforces the AND-across rule by requiring every per-axis subset to
   intersect the variant's `:tags`."
@@ -83,7 +83,7 @@
 (defn variant-tag-match?
   "True iff `variant-body`'s `:tags` set satisfies the `tag-filter`.
 
-  Faceted filter semantics (rf2-7ncf9 SB9 parity):
+  Faceted filter semantics (Storybook SB9 parity):
 
   - **OR within an axis** — if the filter activates `:status/alpha`
     AND `:status/beta`, a variant tagged with either passes that
@@ -94,16 +94,14 @@
   - Tags without an `:axis` slot form a synthetic
     `:re-frame.story.registrar/no-axis` pseudo-axis with the same
     OR-within rule.
-  - Empty filter → every variant passes (Stage-4 behaviour preserved).
+  - Empty filter → every variant passes.
 
-  The pure 2-arity (without `tag->axis`) keeps the legacy OR-only
-  semantics so existing callers that don't have an axis-index handy
-  (tests, downstream tools) keep working. The 3-arity is the
-  facet-aware form the sidebar uses.
+  The pure 2-arity (without `tag->axis`) keeps the OR-only semantics so
+  callers that don't have an axis-index handy (tests, downstream tools)
+  work; the 3-arity is the facet-aware form the sidebar uses.
 
-  Stage 4 ignores the `:!`-prefix removal syntax — that's resolved at
-  registration time in `re-frame.story.registrar` via
-  `validate-tag-membership!`."
+  The `:!`-prefix removal syntax is resolved at registration time in
+  `re-frame.story.registrar` via `validate-tag-membership!`, not here."
   ([variant-body tag-filter]
    (or (empty? tag-filter)
        (let [tset (or (:tags variant-body) #{})]
@@ -122,12 +120,11 @@
   "Return the subset of `id->body` whose `:tags` match the filter.
   Pure data → data; JVM-testable.
 
-  The 2-arity preserves legacy OR-across-tags semantics. The 3-arity
-  takes a `tag->axis` map (see `registrar/tag->axis-index`) and
-  applies the faceted AND-across / OR-within rule (rf2-7ncf9). The
-  sidebar calls the 3-arity with a registrar-derived axis-index; the
-  legacy 2-arity stays for the bare-data callers that don't carry
-  registrar context."
+  The 2-arity uses OR-across-tags semantics. The 3-arity takes a
+  `tag->axis` map (see `registrar/tag->axis-index`) and applies the
+  faceted AND-across / OR-within rule. The sidebar calls the 3-arity
+  with a registrar-derived axis-index; the 2-arity serves the bare-data
+  callers that don't carry registrar context."
   ([id->body tag-filter]
    (into {}
          (filter (fn [[_ body]] (variant-tag-match? body tag-filter)))

--- a/tools/story/src/re_frame/story/ui/state/snapshot.cljc
+++ b/tools/story/src/re_frame/story/ui/state/snapshot.cljc
@@ -1,14 +1,14 @@
 (ns re-frame.story.ui.state.snapshot
   "Registry-snapshot leaf — single-call helper that builds a map of
   every Story-side artefact kind in one walk. Split from
-  `re-frame.story.ui.state` per rf2-gcpon.
+  `re-frame.story.ui.state`.
 
   The shell takes a fresh snapshot of the Story registrar on every
   render: variants / stories / workspaces / modes / decorators /
   panels / tags are what's currently registered, and the sidebar /
   control panel / workspace panes consume the snapshot. Lives in its
   own leaf so future memoisation (e.g. cache keyed on the registrar
-  mutation-tick rf2-zrswb / rf2-c5nwl) is local."
+  mutation-tick) is local."
   (:require [re-frame.story.registrar :as registrar]))
 
 (defn registry-snapshot

--- a/tools/story/src/re_frame/story/ui/state/tests.cljc
+++ b/tools/story/src/re_frame/story/ui/state/tests.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.story.ui.state.tests
   "Pure test-run aggregation + watch-mode helpers for the shell state
-  map. Split from `re-frame.story.ui.state` per rf2-gcpon (leaf-size
-  ceiling rf2-zkca8 — the parent ns was 718L).
+  map. Split from `re-frame.story.ui.state` to honor the leaf-size
+  ceiling.
 
   ## What lives here
 
@@ -31,7 +31,7 @@
   public defs so existing consumer requires (`re-frame.story.ui.state`)
   keep working.")
 
-;; ---- test-runs (rf2-q0irb) -----------------------------------------------
+;; ---- test-runs -----------------------------------------------------------
 ;;
 ;; Cross-variant aggregation surface: each variant's last `run-variant`
 ;; outcome is folded into `[:tests :runs]`. The chrome-level test
@@ -48,9 +48,8 @@
 ;; surfaces.
 
 (def test-run-statuses
-  "Canonical run-state ids, in render order (rf2-5x1wt.19 adds
-  `:cannot-run` — the unified result's distinct THIRD status, spec/017
-  §`:cannot-run`).
+  "Canonical run-state ids, in render order. `:cannot-run` is the
+  unified result's distinct THIRD status (spec/017 §`:cannot-run`).
 
   - `:pass`        last run: every assertion passed (and at least one assertion).
   - `:fail`        last run: ≥1 assertion failed.
@@ -66,9 +65,9 @@
   (assoc-in state [:tests :runs variant-id] {:status :running}))
 
 (defn- record-status
-  "The unified verdict for ONE assertion record (rf2-5x1wt.19): the
-  record's own `:status` when it is one of the four verdicts (the
-  unified shape), else derived from the outcome fields. Pure data →
+  "The unified verdict for ONE assertion record: the record's own
+  `:status` when it is one of the four verdicts (the unified shape),
+  else derived from the outcome fields. Pure data →
   data — a local mirror so this leaf needs no require into
   `re-frame.story.result` (which would loop through the runtime via
   `result` → `runtime`).
@@ -80,9 +79,8 @@
   - an explicit `:status` that is one of the four verdicts wins;
   - `:cannot-run?` / `:skipped?` truthy → `:cannot-run`;
   - `:exception` / `:error` truthy → `:error` (a thrown handler / fx /
-    step — rf2-fslmh: this branch was missing, so a derived record
-    carrying `:exception`/`:error` but no explicit `:status` was mis-
-    counted as `:pass`, a false-green);
+    step — a derived record carrying `:exception`/`:error` but no
+    explicit `:status` must count as `:error`, not a false-green `:pass`);
   - `:passed?` true → `:pass`; `:passed?` false → `:fail`;
   - otherwise `:pass` (a non-assertion / vacuous record does not fail
     the run — the /spec/007-Stories.md §Story-as-test duality).
@@ -111,9 +109,9 @@
        :skipped     <n>
        :all-passed? <bool>}
 
-  rf2-5x1wt.19 — buckets by each record's unified `:status` (spec/017
-  §Run result), so a `:cannot-run` assertion (a runner refusal — the
-  distinct THIRD status) is counted distinctly and NOT folded into
+  Buckets by each record's unified `:status` (spec/017 §Run result), so
+  a `:cannot-run` assertion (a runner refusal — the distinct THIRD
+  status) is counted distinctly and NOT folded into
   `:failed`. `:skipped` is the alias count kept for the legacy
   `:rf.assert/skipped` id (re-frame2's runtime doesn't emit it, but the
   slot stays open). `:all-passed?` is true iff `:total > 0 AND :failed = 0
@@ -146,8 +144,8 @@
 
   `summary` is the map returned by `aggregate-summary` —
   `{:total :passed :failed :cannot-run :skipped :all-passed?}` — extended
-  with optional `:ran-at-ms` / `:elapsed-ms` and (rf2-5x1wt.19) the run's
-  unified `:status` (so the sidebar dot reflects the run-level verdict,
+  with optional `:ran-at-ms` / `:elapsed-ms` and the run's unified
+  `:status` (so the sidebar dot reflects the run-level verdict,
   including a tape-floor `:fail` or a `:cannot-run` refusal that the
   assertion counts alone might miss).
 
@@ -202,8 +200,8 @@
        :all-green? <bool — total > 0 AND failed = 0 AND cannot-run = 0
                           AND running = 0 AND pending = 0>}
 
-  rf2-5x1wt.19 — `:cannot-run` (the unified distinct THIRD status) is
-  counted distinctly; a refusal is NOT green. Pure data → data; the JVM
+  `:cannot-run` (the unified distinct THIRD status) is counted
+  distinctly; a refusal is NOT green. Pure data → data; the JVM
   corpus exercises it against a fixture map without booting Reagent.
   `all-green?` mirrors `aggregate-summary`'s `:all-passed?` — true only
   when every variant has a recorded green run; a sea of `:pending` reads
@@ -235,11 +233,10 @@
 
 (defn- play-surface-has-steps?
   "True iff `body` declares a non-empty play surface — EITHER a
-  `:play-script` (map `:script` or bare-vector form, per rf2-0wrud) OR a
-  non-empty `:plays` vector (rf2-tl7zk multi-play). rf2-ee38b.3: the
-  `:plays` arm was added so a `:plays`-only variant counts as testable
-  in the chrome widget + sidebar dots, matching `ci-runner/has-any-play?`
-  and `test-mode.pure/variant-has-tests?`."
+  `:play-script` (map `:script` or bare-vector form) OR a non-empty
+  `:plays` vector (multi-play). A `:plays`-only variant counts as
+  testable in the chrome widget + sidebar dots, matching
+  `ci-runner/has-any-play?` and `test-mode.pure/variant-has-tests?`."
   [body]
   (let [script (:play-script body)
         plays  (:plays body)]
@@ -256,8 +253,8 @@
   order. The chrome widget + sidebar dots key off this seq.
 
   Variants are testable iff (a) their `:tags` contains `:test`, AND
-  (b) they declare a non-empty play surface (`:play-script` OR `:plays`
-  — rf2-ee38b.3). The second filter prunes variants tagged `:test` but
+  (b) they declare a non-empty play surface (`:play-script` OR `:plays`).
+  The second filter prunes variants tagged `:test` but
   without any assertions to run — those contribute neither to the
   headline counts nor to the 'Run all' iteration. Pure data → data;
   JVM-testable. `id->body` is the `{variant-id → body}` map from
@@ -271,7 +268,7 @@
        sort
        vec))
 
-;; ---- watch mode (rf2-z1h0f) ---------------------------------------------
+;; ---- watch mode ----------------------------------------------------------
 ;;
 ;; Storybook 9 ships a Vitest-addon watch-mode toggle (eye icon) that
 ;; re-runs the changed stories on file save. Story's parity surface is

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story.ui.state.transitions
   "Pure shell-state transition fns (data → data). Split from
-  `re-frame.story.ui.state` per rf2-gcpon (leaf-size ceiling rf2-zkca8).
+  `re-frame.story.ui.state` to honor the leaf-size ceiling.
 
   ## What lives here
 
@@ -18,7 +18,7 @@
 (defn select-variant
   "Set the focused variant id (or nil to deselect). Clears
   `:selected-story` — variant focus is mutually exclusive with the
-  story-rollup view (rf2-8j7wg)."
+  story-rollup view."
   [state variant-id]
   (-> state
       (assoc :selected-variant variant-id)
@@ -27,7 +27,7 @@
 (defn select-workspace
   "Set the focused workspace id (or nil to deselect). Clears
   `:selected-story` — workspace focus and the story-rollup view are
-  mutually exclusive shell modes (rf2-8j7wg)."
+  mutually exclusive shell modes."
   [state workspace-id]
   (-> state
       (assoc :selected-workspace workspace-id)
@@ -36,8 +36,7 @@
 (defn select-story
   "Set the focused parent-story id (or nil to deselect). Mutually
   exclusive with `:selected-variant` + `:selected-workspace` — clicking
-  a story HEADER swaps the main pane to the rollup docs view per
-  rf2-8j7wg (audit C-4)."
+  a story HEADER swaps the main pane to the rollup docs view."
   [state story-id]
   (-> state
       (assoc :selected-story story-id)
@@ -134,7 +133,7 @@
   "Set a single arg override for `variant-id`. `path` is a vector
   `[arg-key & sub-path]` — the first element is the top-level arg-key,
   the remaining elements address into the nested value via `assoc-in`
-  semantics. Used by the nested Malli walker per rf2-agshe.
+  semantics. Used by the nested Malli walker.
 
   An empty path is a no-op (caller error; the state is returned
   unchanged). For top-level scalar overrides use `set-cell-override-
@@ -153,7 +152,7 @@
 
 (defn clear-cell-overrides
   "Drop every override for `variant-id`. Also drops any repeater row-id
-  bookkeeping under the same variant (rf2-c8kfy) so the next render
+  bookkeeping under the same variant so the next render
   re-syncs from scratch against the resolved entry count.
 
   Row-id storage is keyed on `[variant-id path]` tuples (one entry per
@@ -175,10 +174,10 @@
   "Drop the override for a single top-level `arg-key` under `variant-id`,
   reverting that one arg to its saved (declared) value while leaving
   every other override intact. Backs the controls panel's per-arg
-  'reset' affordance (rf2-ba86n.5).
+  'reset' affordance.
 
   Also drops any repeater row-id bookkeeping anchored on a path whose
-  head is `arg-key` (rf2-c8kfy) so a reset collection re-syncs its row
+  head is `arg-key` so a reset collection re-syncs its row
   ids from scratch against the reverted entry count. Other args' row
   ids are untouched. When the last override for the variant is cleared
   the empty `:cell-overrides` entry is pruned so callers reading
@@ -202,27 +201,24 @@
                         m)
                   m)))))
 
-;; ---- repeater stable row-ids (rf2-c8kfy) ---------------------------------
+;; ---- repeater stable row-ids ---------------------------------------------
 ;;
 ;; The controls-panel `repeater-widget` (vector / set) renders one DOM row
-;; per entry. Pre-fix it keyed rows positionally (`^{:key i}`), so a
-;; mid-list delete shifted every surviving row's key up by one. React's
-;; reconciler matched by key + component type and reused the DOM node at
-;; each position with the next entry's value — an input that had focus /
-;; selection at index i+1 displayed index i's value with the SAME focus
+;; per entry, keyed on a stable monotonic id rather than the positional
+;; index. Position-keyed rows leak focus / selection on a mid-list delete:
+;; React's reconciler matches by key + component type and reuses the DOM
+;; node at each position with the next entry's value, so an input that had
+;; focus at index i+1 would display index i's value with the SAME focus
 ;; state. For `:set`-kind repeaters `vector-coerce` re-sorts on every
-;; render, so editing any entry shuffled keys against values and the
-;; bug fired on every keystroke. Same focus-leak class as rf2-kgn0c
-;; (workspace cells) / rf2-z4fza (xray trace ribbon) / rf2-c56hr
-;; (story workspace cell re-init).
+;; render, so editing any entry would shuffle keys against values on every
+;; keystroke.
 ;;
-;; The fix carries a parallel vector of monotonically-allocated ids
-;; alongside the entries vector, keyed by `[variant-id path]`. The
-;; renderer keys each row on `(str "r:" id)`; add appends a fresh id,
-;; delete drops the id at position i in lockstep with the entry. The
-;; counter is a single int held on the shell-state — pure data → data,
-;; JVM-testable. The ids are render-internal and never persisted to a
-;; variant or args slot.
+;; A parallel vector of monotonically-allocated ids rides alongside the
+;; entries vector, keyed by `[variant-id path]`. The renderer keys each row
+;; on `(str "r:" id)`; add appends a fresh id, delete drops the id at
+;; position i in lockstep with the entry. The counter is a single int held
+;; on the shell-state — pure data → data, JVM-testable. The ids are
+;; render-internal and never persisted to a variant or args slot.
 
 (defn- next-repeater-id
   "Allocate the next monotonic repeater row id and return
@@ -315,7 +311,7 @@
   [state panel-id]
   (update-in state [:panel-visibility panel-id] not))
 
-;; ---- Xray-embed collapse (rf2-ba86n.19) ---------------------------------
+;; ---- Xray-embed collapse -------------------------------------------------
 ;;
 ;; Lazy Xray-diff mounting (spec/018 §10): the RHS Xray embed defers its
 ;; panel MOUNT — and therefore the expensive diff compute the panel runs
@@ -323,8 +319,8 @@
 ;; The slot defaults to expanded (false) so the out-of-the-box RHS still
 ;; paints the panel; the user can collapse the band to halt compute when
 ;; they're not inspecting. Collapsing unmounts the panel-host component,
-;; which releases the Xray React root via the existing microtask path
-;; (rf2-4l7t2) — no duplicate teardown lives here.
+;; which releases the Xray React root via the existing microtask path —
+;; no duplicate teardown lives here.
 
 (defn xray-embed-collapsed?
   "Whether the RHS Xray embed is collapsed (panel mount + diff compute
@@ -344,18 +340,18 @@
   [state value]
   (assoc state :xray-embed-collapsed? (boolean value)))
 
-;; ---- chrome visibility (rf2-p3i0t / rf2-g8l8x / rf2-pucku) --------------
+;; ---- chrome visibility ---------------------------------------------------
 
 (def chrome-visibility-defaults
   "Canonical default shape for the `:chrome-visibility` slot. Used by
   state hydration + tests so a missing slot reads the same as a
   full-defaults map.
 
-  - `:full-screen?` is the `f`-key toggle (rf2-p3i0t): true → hide
-    sidebar + RHS + toolbar; canvas fills the viewport.
+  - `:full-screen?` is the `f`-key toggle: true → hide sidebar + RHS +
+    toolbar; canvas fills the viewport.
   - `:sidebar?` / `:rhs?` / `:toolbar?` are per-panel toggles
-    (`s` / `a` / `t` keys, rf2-g8l8x). Each defaults to true.
-  - `:embed?` is hydrated from `?embed=1` (rf2-pucku). When true the
+    (`s` / `a` / `t` keys). Each defaults to true.
+  - `:embed?` is hydrated from `?embed=1`. When true the
     shell renders canvas-only — overrides every individual pane toggle.
     Stateless / non-persisted (embeds are stateless by intent)."
   {:full-screen? false
@@ -390,9 +386,9 @@
 
 ;; ---- effective per-pane visibility derivations --------------------------
 ;;
-;; Embed-mode (rf2-pucku) wins absolutely: every chrome pane hides.
-;; Full-screen (rf2-p3i0t) hides every chrome pane but leaves canvas +
-;; in-canvas affordances. Per-pane toggles (rf2-g8l8x) win when neither
+;; Embed-mode wins absolutely: every chrome pane hides.
+;; Full-screen hides every chrome pane but leaves canvas +
+;; in-canvas affordances. Per-pane toggles win when neither
 ;; absolute mode is on.
 
 (defn chrome-pane-visible?
@@ -418,14 +414,14 @@
       (nil? slot-key)   true
       :else             (boolean (get v slot-key true)))))
 
-;; ---- mode-tab (rf2-9hc8) -------------------------------------------------
+;; ---- mode-tab ------------------------------------------------------------
 
 (def mode-tabs
   "Ordered vector of canonical render-shell mode tabs. Stable id order
   drives the chip strip's left-to-right layout. `:dev` is the canvas
   view (rendered by `re-frame.story.ui.canvas`), `:docs` is the
-  read-only AutoDocs-equivalent (rf2-rodx), `:test` is the
-  in-canvas aggregated pass/fail view (rf2-qmjo)."
+  read-only AutoDocs-equivalent, `:test` is the in-canvas aggregated
+  pass/fail view."
   [:dev :docs :test])
 
 (def mode-tab-labels
@@ -436,8 +432,7 @@
 
 (def default-mode-tab
   "Default mode-tab when no per-variant selection is recorded. `:dev`
-  preserves Story v1's existing behaviour — the variant renders in the
-  canvas as soon as it's selected."
+  renders the variant in the canvas as soon as it's selected."
   :dev)
 
 (defn valid-mode-tab?

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -1,9 +1,9 @@
 (ns re-frame.story.ui.test-mode.pure
-  "Pure data → data helpers for the `:test` mode pane (rf2-qmjo + spec/009).
+  "Pure data → data helpers for the `:test` mode pane (spec/009).
 
-  Split out of the legacy `re-frame.story.ui.test-mode` monolith per
-  rf2-8n2fz so the JVM test corpus can cover the pane's data shaping
-  without booting Reagent or the runtime. Companion namespaces:
+  Sits beside the CLJS pane so the JVM test corpus can cover the pane's
+  data shaping without booting Reagent or the runtime. Companion
+  namespaces:
 
   - `re-frame.story.ui.test-mode.state` — CLJS local-state atom + the
     `begin-run!` / `store-result!` / `select-step!` / `toggle-expanded!` /
@@ -23,9 +23,8 @@
 ;; `assertion-event?` lives canonically in `re-frame.story.predicates`
 ;; (a pure leaf ns the rest of Story consumes without cycle risk).
 ;; Aliased here so internal call sites stay textually identical.
-;;
-;; rf2-ee38b.3: the `parent-story-id` re-export was DROPPED — its sole
-;; caller (`test-mode.view`) now calls `pred/parent-story-id` directly.
+;; `parent-story-id` is not re-exported here — its sole caller
+;; (`test-mode.view`) calls `pred/parent-story-id` directly.
 
 (def ^:private assertion-event? pred/assertion-event?)
 
@@ -34,7 +33,7 @@
 ;; The four verdicts every assertion record / check / run carries
 ;; (`re-frame.story.result/statuses`). Mirrored here as a local set so the
 ;; pure helpers can recognise a stamped `:status` without a require into
-;; `re-frame.story.result` (which loops through the runtime). rf2-ba86n.11.
+;; `re-frame.story.result` (which loops through the runtime).
 
 (def statuses
   "The unified run / check / assertion verdicts (spec/017 §Run result)."
@@ -57,7 +56,7 @@
         :else            false))))
 
 (defn- has-plays?
-  "True iff `vb` carries a non-empty `:plays` vector (rf2-tl7zk multi-play)."
+  "True iff `vb` carries a non-empty `:plays` vector (multi-play)."
   [vb]
   (let [plays (:plays vb)]
     (boolean (and (vector? plays) (seq plays)))))
@@ -67,12 +66,9 @@
   `:play-script` OR a non-empty `:plays` vector. Used by the pane to
   gate between the run-and-render path and the empty-state placeholder.
 
-  Per rf2-0wrud (2026-05-20) `:play-script` is the canonical phase-4
-  slot; rf2-tl7zk added the multi-play `:plays` slot. rf2-ee38b.3: this
-  predicate now recognises BOTH (it previously checked only
-  `:play-script`, so a `:plays`-only variant rendered the
-  'no tests registered' empty-state even though the runner + CI runner
-  see its runnable plays — matching `ci-runner/has-any-play?`).
+  `:play-script` is the canonical phase-4 slot; `:plays` is the
+  multi-play slot. This predicate recognises BOTH, so a `:plays`-only
+  variant counts as testable — matching `ci-runner/has-any-play?`.
 
   Pure data → data; JVM-testable."
   [variant-id]
@@ -82,10 +78,9 @@
 
 ;; ---- pure: aggregate-summary --------------------------------------------
 ;;
-;; `aggregate-summary` lives in `re-frame.story.ui.state` (rf2-khmon) so
-;; the sidebar / chrome-level test widget can call one canonical fold
-;; without a require cycle. test-mode consumers call `state/aggregate-
-;; summary` directly.
+;; `aggregate-summary` lives in `re-frame.story.ui.state` so the sidebar /
+;; chrome-level test widget can call one canonical fold without a require
+;; cycle. test-mode consumers call `state/aggregate-summary` directly.
 
 ;; ---- pure: assertion-row ------------------------------------------------
 
@@ -115,18 +110,16 @@
   the renderer decides whether to surface it (only failing rows
   expand by default). Pure data → data; JVM-testable.
 
-  rf2-ba86n.11 — the unified run-result (`re-frame.story.result`) stamps a
-  `:status` on every assertion record (`:pass` / `:fail` / `:error` /
-  `:cannot-run`). This helper now PREFERS that stamped `:status` (the
-  unified shape, spec/017 §Run result) and only derives from `:passed?`
-  for a record minted by a status-unaware path. The legacy
-  `:passed?`-only read is the fallback, not the primary — completing the
-  Test-mode migration off the split lifecycle/assertions reading
-  (tools/story/spec/021 §1).
+  The unified run-result (`re-frame.story.result`) stamps a `:status` on
+  every assertion record (`:pass` / `:fail` / `:error` / `:cannot-run`).
+  This helper PREFERS that stamped `:status` (the unified shape, spec/017
+  §Run result) and only derives from `:passed?` for a record minted by a
+  status-unaware path — the `:passed?`-only read is the fallback, not the
+  primary (tools/story/spec/021 §1).
 
   `:row-key` is the stable identity the view uses to thread :expanded
-  state across re-runs (rf2-tistm): keying on positional index opened
-  the wrong row when a re-run reordered or inserted assertions. The
+  state across re-runs: keying on positional index would open the wrong
+  row when a re-run reordered or inserted assertions. The
   label string is the densest stable id available — it carries the
   assertion id + payload shape together — and is JVM-testable so the
   pure helpers can pin the contract.
@@ -142,8 +135,8 @@
         aid      (:assertion rec)
         status   (cond
                    (= :rf.assert/skipped aid)          :skip
-                   ;; rf2-ba86n.11 — the unified `:status` wins; the
-                   ;; :passed?-only derivation is the legacy fallback.
+                   ;; The unified `:status` wins; the :passed?-only
+                   ;; derivation is the fallback.
                    (contains? statuses st)             st
                    (:cannot-run? rec)                  :cannot-run
                    (or (:error rec) (:exception rec))  :error
@@ -151,7 +144,7 @@
                    ;; A record carrying neither a stamped :status nor a
                    ;; truthy :passed? reads :fail — the conservative
                    ;; view-side default (a missing pass signal can't be
-                   ;; rendered green). Matches the legacy contract.
+                   ;; rendered green).
                    :else                               :fail)
         payload  (or (:payload rec) [])
         label    (let [p (pretty-payload payload)]
@@ -211,7 +204,7 @@
               (pad (.getMinutes d)) ":"
               (pad (.getSeconds d)))))))
 
-;; ---- pure: play-step scrubber data (rf2-lc36w) --------------------------
+;; ---- pure: play-step scrubber data --------------------------------------
 ;;
 ;; Each play event derived from the variant body's `:play-script` is
 ;; dispatched as a
@@ -323,16 +316,14 @@
       :else                 (mapv :epoch-id (subvec hv (- (count hv) n))))))
 
 ;; ===========================================================================
-;; UNIFIED RUN-RESULT PROJECTION  (rf2-ba86n.11, tools/story/spec/021 §1)
+;; UNIFIED RUN-RESULT PROJECTION  (tools/story/spec/021 §1)
 ;; ===========================================================================
 ;;
 ;; The `:test` pane consumes the ONE unified run-result `run-variant` /
-;; `reset-variant` now return (the `re-frame.story.result/run-result`
-;; shape merged with the legacy lifecycle slots — runtime.cljc
-;; `record-result-map`). These helpers project that result into the
-;; per-section render data the view renders, COMPLETING the migration off
-;; the legacy split `:lifecycle` / `:assertions` reading (spec/021 §1
-;; supersedes 009's result-reading contract):
+;; `reset-variant` return (the `re-frame.story.result/run-result` shape
+;; merged with the lifecycle slots — runtime.cljc `record-result-map`).
+;; These helpers project that result into the per-section render data the
+;; view renders (spec/021 §1 carries the result-reading contract):
 ;;
 ;;   - `run-status`         — the top-level verdict, including the distinct
 ;;                            `:cannot-run` THIRD state + a `:pending`
@@ -361,7 +352,7 @@
   - no result / nothing recorded  → `:pending`
   - explicit unified `:status`    → that verdict (`:pass` / `:fail` /
                                      `:error` / `:cannot-run`)
-  - else (legacy host) derive from the assertion summary:
+  - else (count-only host) derive from the assertion summary:
       zero assertions             → `:pending`  (ran, no signal)
       any fail/error              → `:fail`
       any cannot-run              → `:cannot-run`
@@ -427,7 +418,7 @@
   expectations match a selector with N violations, only M of the N read
   `:consumed?` (the remaining N−M are the agreement-floor failure cause).
   Marking by mere selector-SET membership would falsely mark ALL N consumed
-  and so DISAGREE with the floor (rf2-5mrnwx) — the multiset count comes
+  and so DISAGREE with the floor — the multiset count comes
   from the run's `:rf.assert/schema-error :pass` records, one per
   matched expectation, each carrying the consumed violation's selector as
   `:actual` (`re-frame.story.result/schema-error-record`).
@@ -435,9 +426,8 @@
   The caller-supplied `:consumed-selectors` escape hatch (selectors
   pre-excused outside the matcher, with NO `:pass` record) still excuses
   EVERY same-selector violation — set-keyed, matching the floor's treatment
-  of that input. A legacy / partial result that predates the
-  `:consumed-selectors` slot falls back to the same `:pass`-record
-  derivation (multiset).
+  of that input. A partial result without the `:consumed-selectors` slot
+  falls back to the same `:pass`-record derivation (multiset).
 
       [{:selector   <selector>
         :where      <surface>
@@ -467,8 +457,8 @@
         ;; The caller-supplied escape-hatch selectors: in `:consumed-selectors`
         ;; but with NO matching `:pass` record (pre-excused outside the
         ;; matcher). These excuse EVERY same-selector violation (set-keyed,
-        ;; mirroring the floor). When the slot is absent (legacy result) there
-        ;; is no escape hatch — the `:pass`-record multiset is authoritative.
+        ;; mirroring the floor). When the slot is absent there is no escape
+        ;; hatch — the `:pass`-record multiset is authoritative.
         escape-hatch   (into #{}
                              (remove consumed-freqs)
                              (when (contains? result :consumed-selectors)
@@ -540,10 +530,10 @@
                (seq (:narrative result)))))
 
 ;; ===========================================================================
-;; VISUAL + A11Y CHECK RESULTS  (rf2-ba86n.15, tools/story/spec/021 §4)
+;; VISUAL + A11Y CHECK RESULTS  (tools/story/spec/021 §4)
 ;; ===========================================================================
 ;;
-;; The run path (post-#2484) evaluates the browser-tier oracle family —
+;; The run path evaluates the browser-tier oracle family —
 ;; `:rf.assert/a11y-structural` (the `:hiccup` structural-a11y check),
 ;; `:rf.assert/a11y` (the axe-style browser check), and
 ;; `:rf.assert/visual-snapshot` (the `:pixels` screenshot check) — through
@@ -595,7 +585,7 @@
   `:locus` is the offending element's hiccup tag (the structural check works
   over the rendered hiccup TREE, so the tag is the locus the `:hiccup` tier
   can prove). The structural tier has NO real source coordinate to thread
-  (rf2-ffu8t): the `:hiccup-structure` runner walks an in-memory hiccup tree,
+  the `:hiccup-structure` runner walks an in-memory hiccup tree,
   not a DOM, so there is no CSS selector and no file/line coord to recover —
   the tree carries none. Honesty over fabrication: the §4 source-link MUST is
   met by the axe `:browser` tier (`axe-a11y-findings`, which recovers a real
@@ -627,7 +617,7 @@
   `:locus` is the SOURCE LINK the §4 MUST requires (\"a11y findings with
   selector/source/context links\"). The axe `:browser` tier carries a real
   selector (recovered from the violation's `:nodes` → `:target` by
-  `browser/axe-finding`, rf2-ffu8t), so `:locus` is that selector — the
+  `browser/axe-finding`), so `:locus` is that selector — the
   result UI links it to the offending DOM element. When a violation carried
   no node target (rare — e.g. a page-level rule) `:locus` falls back to the
   rule id so the finding still reads. Empty when no violation. Pure data →

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -1,23 +1,22 @@
 (ns re-frame.story.ui.test-mode.state
-  "CLJS-side local state for the `:test` mode pane (rf2-qmjo + spec/009).
+  "CLJS-side local state for the `:test` mode pane (spec/009).
 
-  Split out of the legacy `re-frame.story.ui.test-mode` monolith per
-  rf2-8n2fz. The pane keeps its own ratom — one map keyed by variant-id.
+  The pane keeps its own ratom — one map keyed by variant-id.
   Each entry carries:
 
       {:result          <unified-run-result-map>
        :ran-at-ms       <epoch-ms>
        :running?        <bool>
        :expanded        #{<row-key>}      ; expanded assertion rows
-       :expanded-checks #{<check-id>}     ; expanded check groups (rf2-ba86n.11)
-       :failed-only?    <bool>            ; failed-only filter (rf2-ba86n.11)
+       :expanded-checks #{<check-id>}     ; expanded check groups
+       :failed-only?    <bool>            ; failed-only filter
        :play-events     <vector>          ; flat event-vec list derived from :play-script
        :epoch-ids       <vector>          ; trailing epoch-id slice
        :selected-step   <int|nil>}
 
-  rf2-ba86n.11 — `:result` is the ONE unified run-result the runtime now
-  returns (`re-frame.story.result/run-result` merged with the legacy
-  lifecycle slots): a top-level `:status`, `:checks`, `:schema-violations`,
+  `:result` is the ONE unified run-result the runtime returns
+  (`re-frame.story.result/run-result` merged with the lifecycle slots):
+  a top-level `:status`, `:checks`, `:schema-violations`,
   `:cannot-run` refusals, `:runner` / `:required-runner`, plus the
   `:assertions` records each stamped with their own `:status`. The pane
   reads it through `re-frame.story.ui.test-mode.pure`'s projection helpers.
@@ -26,7 +25,7 @@
   result in on resolve.
 
   `:play-events`, `:epoch-ids` + `:selected-step` are the step-through
-  scrubber slots (rf2-lc36w). `:selected-step` is the slider position
+  scrubber slots. `:selected-step` is the slider position
   (a slot index into `:epoch-ids`); `nil` means 'no scrub in flight'
   — the canvas shows the post-play app-db, the same value the user
   sees on a fresh run. A non-nil selection has called `restore-epoch`
@@ -60,7 +59,7 @@
   "Mark the variant's slot as running. Returns nothing. Stamps the
   shell-state `[:tests :runs]` slot too so the chrome-level test widget
   and the sidebar's per-variant dot read `:running` while the run
-  is in flight (rf2-q0irb)."
+  is in flight."
   [variant-id]
   (swap! results-atom assoc-in [variant-id :running?] true)
   (state/swap-state! state/mark-test-running variant-id))
@@ -72,20 +71,18 @@
   starts collapsed.
 
   Captures the play-events vector + the trailing epoch-id slice
-  against the same atom so the step-through scrubber (rf2-lc36w)
-  has a stable read-surface that doesn't drift on a later
-  unrelated dispatch.
+  against the same atom so the step-through scrubber has a stable
+  read-surface that doesn't drift on a later unrelated dispatch.
 
   Folds the run's aggregate into the shell-state `[:tests :runs]` slot
   too — the chrome-level test widget + sidebar dots read off that
-  slot (rf2-q0irb)."
+  slot."
   [variant-id result]
   (let [now          (interop/now-ms)
-        ;; Per rf2-0wrud `:play-script` is the canonical AND ONLY
-        ;; phase-4 slot. `play/variant-play-events` extracts a flat
-        ;; event-vec list (one per `:dispatch`/`:dispatch-sync` step)
-        ;; — the same shape the legacy `:play` slot carried, so the
-        ;; scrubber's slot-shape stays stable.
+        ;; `:play-script` is the canonical phase-4 slot.
+        ;; `play/variant-play-events` extracts a flat event-vec list
+        ;; (one per `:dispatch`/`:dispatch-sync` step), the shape the
+        ;; scrubber's slot expects.
         play-events  (play/variant-play-events variant-id)
         history      (rf/epoch-history variant-id)
         epoch-ids    (pure/epoch-id-slice history (count play-events))]
@@ -100,10 +97,10 @@
     (let [summary (-> (state/aggregate-summary (:assertions result))
                       (assoc :ran-at-ms  now
                              :elapsed-ms (:elapsed-ms result)
-                             ;; rf2-5x1wt.19 — thread the unified run-level
-                             ;; `:status` so the sidebar dot reflects a
-                             ;; tape-floor `:fail` / `:cannot-run` refusal
-                             ;; the assertion counts alone might miss.
+                             ;; thread the unified run-level `:status` so
+                             ;; the sidebar dot reflects a tape-floor
+                             ;; `:fail` / `:cannot-run` refusal the
+                             ;; assertion counts alone might miss.
                              :status     (:status result)))]
       (state/swap-state! state/record-test-run variant-id summary))))
 
@@ -117,7 +114,7 @@
   (we restore against the last epoch-id in the slice, which is the
   play-sequence's terminal state).
 
-  No-ops while the slot's `:running?` is true (rf2-tistm). A
+  No-ops while the slot's `:running?` is true. A
   scrubber-tick during an in-flight `reset-variant` would race
   `store-result!`: the restore would land against the frame being
   reset, the new `:epoch-ids` would overwrite the slice, and
@@ -147,8 +144,8 @@
 (defn toggle-expanded!
   "Toggle the expand state of an assertion row, keyed by stable
   identity (`row-key`, derived from `assertion-row :label`) rather
-  than positional index (rf2-tistm). A re-run that reorders or
-  inserts assertions would otherwise open the wrong row."
+  than positional index. A re-run that reorders or inserts assertions
+  would otherwise open the wrong row."
   [variant-id row-key]
   (swap! results-atom update-in [variant-id :expanded]
          (fn [s] (let [s (or s #{})]
@@ -157,8 +154,8 @@
                      (conj s row-key))))))
 
 (defn toggle-check!
-  "Toggle the expand state of a check group, keyed by check id
-  (rf2-ba86n.11). Mirrors `toggle-expanded!` for the per-test rows."
+  "Toggle the expand state of a check group, keyed by check id.
+  Mirrors `toggle-expanded!` for the per-test rows."
   [variant-id check-id]
   (swap! results-atom update-in [variant-id :expanded-checks]
          (fn [s] (let [s (or s #{})]
@@ -168,8 +165,8 @@
 
 (defn set-failed-only!
   "Set the failed-only filter flag for `variant-id`'s slot
-  (rf2-ba86n.11, spec/021 §1 — failed-only filtering). `on?` truthy
-  hides passing rows; falsey shows every row."
+  (spec/021 §1 — failed-only filtering). `on?` truthy hides passing
+  rows; falsey shows every row."
   [variant-id on?]
   (swap! results-atom assoc-in [variant-id :failed-only?] (boolean on?)))
 
@@ -178,11 +175,10 @@
   swap the result into local state when it resolves. No-ops if
   the slot already carries `:running?`.
 
-  Per rf2-zq6sn the variant's run threads its OWN cell-overrides
-  entry from shell state — same lookup the canvas / sidebar /
-  share-url paths perform — so the test pane re-runs against the
-  same effective-args the user has been editing in the controls
-  panel."
+  The variant's run threads its OWN cell-overrides entry from shell
+  state — same lookup the canvas / sidebar / share-url paths perform —
+  so the test pane re-runs against the same effective-args the user has
+  been editing in the controls panel."
   [variant-id]
   (let [shell @state/shell-state-atom
         opts  {:active-modes   (:active-modes shell)
@@ -196,7 +192,7 @@
                         ;; UI button comes back to "Re-run". Drop
                         ;; the shell-state running stamp too — the
                         ;; widget/dot should not stay yellow on a
-                        ;; rejection (rf2-q0irb).
+                        ;; rejection.
                         (swap! results-atom assoc-in
                                [variant-id :running?] false)
                         (state/swap-state! state/clear-test-run variant-id)

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_pure.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.story.ui.test-mode.stepper-pure
-  "Pure data → data helpers for the play step-debugger (rf2-ulw5m + spec/009
+  "Pure data → data helpers for the play step-debugger (spec/009
   §Play step-debugger).
 
   The step-debugger gives the `:test` mode pane Storybook's
@@ -19,9 +19,9 @@
             [re-frame.story.play.runner :as runner]
             [re-frame.story.ui.test-mode.pure :as test-mode-pure]))
 
-;; ---- step-outcome (rf2-ee38b.3 — full-script step list) ------------------
+;; ---- step-outcome (full-script step list) -------------------------------
 ;;
-;; The step-debugger now walks the FULL coerced :play-script (every step
+;; The step-debugger walks the FULL coerced :play-script (every step
 ;; type), driving each through the rich-DSL executor. Each step that has
 ;; run carries a result record (`runner/step-pass` / `step-fail` /
 ;; `step-skip` / `step-exception`); steps not yet reached carry no result.
@@ -55,7 +55,7 @@
 
   A step at `index < (count results)` has run and takes its outcome from
   `(nth results index)`; a step at or beyond the results length has not
-  run yet and renders neutral (`:event`). rf2-ee38b.3."
+  run yet and renders neutral (`:event`)."
   [steps results]
   (let [recs (vec (or results []))]
     (vec

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.story.ui.test-mode.stepper-state
-  "CLJS-side local state for the play step-debugger (rf2-ulw5m + spec/009
+  "CLJS-side local state for the play step-debugger (spec/009
   §Play step-debugger).
 
   The step-debugger is the Storybook Interactions-panel equivalent for
@@ -18,7 +18,7 @@
        :total          <int>          ; count of play-script STEPS in this run
        :play-steps     <vector>       ; immutable snapshot of the FULL coerced
                                       ;   :play-script step vector (every step
-                                      ;   type — rf2-ee38b.3; derived via
+                                      ;   type; derived via
                                       ;   re-frame.story.play/variant-play-steps)
        :statuses       <vector>       ; `stepper-pure/enrich-statuses` rows
        :breakpoints    #{<int>}       ; step indices that pause auto-play
@@ -74,10 +74,10 @@
   "Pure: re-derive the enriched step list from a slot. Called after every
   mutator that moves the cursor / changes breakpoints / records a step.
 
-  rf2-ee38b.3: the rows now cover the FULL coerced step vector (every
-  step type), and each row's outcome comes from the per-step result the
-  rich-DSL executor recorded into `play/stepper-state` — not from the
-  dispatch-only `:rf.story/assertions` projection (which never saw
+  The rows cover the FULL coerced step vector (every step type), and
+  each row's outcome comes from the per-step result the rich-DSL
+  executor recorded into `play/stepper-state` — not from the
+  dispatch-only `:rf.story/assertions` projection (which does not see
   rich-DSL `:assert-db` / `:assert-dom` / `:wait` / `:click` / `:type`
   steps)."
   [slot]
@@ -118,10 +118,10 @@
   ;; documented initial state.
   (-> (runtime/reset-variant variant-id)
       (.then  (fn [_]
-                ;; rf2-ee38b.3: the stepper walks the FULL coerced
-                ;; :play-script (every step type), not just the dispatch-
-                ;; bearing events. `play/variant-play-steps` returns the
-                ;; complete step vector and `play/begin-stepper!` seeds the
+                ;; The stepper walks the FULL coerced :play-script
+                ;; (every step type), not just the dispatch-bearing
+                ;; events. `play/variant-play-steps` returns the complete
+                ;; step vector and `play/begin-stepper!` seeds the
                 ;; substrate from the same source.
                 (let [play-steps (play/variant-play-steps variant-id)
                       total      (count play-steps)]
@@ -203,10 +203,10 @@
             seed  (first stack)]
         (when seed
           (rf/restore-epoch! variant-id seed))
-        ;; rf2-luzky — the assertions side-table is gone; restoring the
-        ;; pre-play epoch above already rewinds `[:rf.story/assertions]`
-        ;; (it lives in the frame's app-db), so a fresh forward run starts
-        ;; clean without an explicit accumulator reset.
+        ;; Restoring the pre-play epoch above already rewinds
+        ;; `[:rf.story/assertions]` (it lives in the frame's app-db), so a
+        ;; fresh forward run starts clean without an explicit accumulator
+        ;; reset.
         ;; Reset the substrate's run cursor (every step back to pending)
         ;; so the rewound stepper re-runs the whole script cleanly.
         (play/stepper-rewind! variant-id)

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_styles.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.story.ui.test-mode.stepper-styles
-  "Style map for the play step-debugger (rf2-ulw5m + spec/009 §Play
-  step-debugger). Pure data; no Reagent dependency. Matches the rest of
-  the test pane chrome (rf2-2uwv palette)."
+  "Style map for the play step-debugger (spec/009 §Play step-debugger).
+  Pure data; no Reagent dependency. Matches the rest of the test pane
+  chrome palette."
   (:require [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
 

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_view.cljs
@@ -1,13 +1,11 @@
 (ns re-frame.story.ui.test-mode.stepper-view
-  "Play step-debugger UI for the `:test` mode pane (rf2-ulw5m + spec/009
+  "Play step-debugger UI for the `:test` mode pane (spec/009
   §Play step-debugger).
 
   Storybook's Interactions panel ships a step / pause / rewind /
   breakpoint UI over the variant's `play()` sequence; this is Story's
-  parity surface. The runtime substrate (`re-frame.story.play`) was
-  already in place — only the UI was missing. Closing this gap is the
-  highest-leverage Storybook-parity win in the Phase-2 SOTA refinement
-  (see `ai/findings/2026-05-17-story-vs-storybook-deep-dive.md` §8 R1).
+  parity surface. The runtime substrate lives in `re-frame.story.play`;
+  this namespace is the UI over it.
 
   ## Surface
 

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -1,14 +1,12 @@
 (ns re-frame.story.ui.test-mode.view
   "The `:test` mode pane — in-canvas aggregated test-runner view.
-  Per rf2-qmjo + spec/009, migrated to the unified run-result UX per
-  tools/story/spec/021-Story-UI-Test-And-Evidence.md §1 (rf2-ba86n.11).
+  Per spec/009, presents the unified run-result UX per
+  tools/story/spec/021-Story-UI-Test-And-Evidence.md §1.
 
-  Replaces the `mode-tabs/tests-placeholder` stub that landed with the
-  mode-tabs primitive (rf2-9hc8). The pane runs the variant's `:script`
-  sequence via `run-variant`, consumes the ONE unified run-result the
-  runtime returns (`re-frame.story.result/run-result` merged with the
-  legacy lifecycle slots), and renders the result/proof surface inside the
-  canvas:
+  The pane runs the variant's `:script` sequence via `run-variant`,
+  consumes the ONE unified run-result the runtime returns
+  (`re-frame.story.result/run-result` merged with the lifecycle slots),
+  and renders the result/proof surface inside the canvas:
 
       ┌──────────────────────────────────────────────────────┐
       │  Header — variant id · parent story · Re-run button   │
@@ -34,10 +32,10 @@
       │  Evidence — result→spine link (graceful pending)      │
       └──────────────────────────────────────────────────────┘
 
-  ## Migration (rf2-ba86n.11, spec/021 §1 supersedes 009 result-reading)
+  ## Result reading (spec/021 §1)
 
-  The pane no longer derives status from a split `:lifecycle` /
-  `:assertions` reading. It reads the unified run-level `:status`, the
+  The pane reads status from the unified run-result, not a split
+  `:lifecycle` / `:assertions` reading. It reads the unified run-level `:status`, the
   `:checks` groups, the `:schema-violations` evidence, and the
   `:cannot-run` refusal rows through the pure projection helpers in
   `re-frame.story.ui.test-mode.pure` (`run-status` / `check-rows` /
@@ -55,7 +53,7 @@
   but not the variant's authoring shape. Switching from `:test` back
   to `:dev` restores the canvas exactly as the user left it.
 
-  ## Split (rf2-8n2fz)
+  ## Layout
 
   This namespace owns styles, the per-section renderers
   (`header` / `summary-section` / `scrubber-section` / `rows-section` /
@@ -66,7 +64,7 @@
     helpers (`variant-has-tests?`, `assertion-row`, `play-step-statuses`,
     `epoch-id-slice`, `format-elapsed-ms`, `format-timestamp-ms`). The
     `aggregate-summary` fold lives in `re-frame.story.ui.state` so the
-    sidebar / chrome-level test widget can share it (rf2-khmon).
+    sidebar / chrome-level test widget can share it.
   - `re-frame.story.ui.test-mode.state` — CLJS-only `results-atom` +
     the `begin-run!` / `store-result!` / `select-step!` /
     `toggle-expanded!` / `run-variant-pane!` mutators.
@@ -129,9 +127,9 @@
        (when (number? elapsed)
          [:span {:data-test "story-test-elapsed"}
           (pure/format-elapsed-ms elapsed)])]]
-     ;; rf2-ba86n.11 — runner selected vs required (spec/021 §1). The
-     ;; unified result threads `:runner` / `:required-runner` verbatim;
-     ;; render an honest "—" when the host did not stamp them.
+     ;; runner selected vs required (spec/021 §1). The unified result
+     ;; threads `:runner` / `:required-runner` verbatim; render an honest
+     ;; "—" when the host did not stamp them.
      (when result
        (let [runner   (:runner result)
              required (:required-runner result)]
@@ -159,8 +157,8 @@
       (let [summary (shell-state/aggregate-summary (:assertions result))
             {:keys [passed failed cannot-run total]} summary
             cannot-run (or cannot-run 0)
-            ;; rf2-ba86n.11 — the unified run-level verdict (spec/021 §1),
-            ;; via the pure projection. A tape-floor `:fail` / `:cannot-run`
+            ;; the unified run-level verdict (spec/021 §1), via the pure
+            ;; projection. A tape-floor `:fail` / `:cannot-run`
             ;; refusal / `:error` surfaces even when assertion counts alone
             ;; would read green.
             status     (pure/run-status result summary)
@@ -190,7 +188,7 @@
            "  "
            [:span {:style (:count-fail styles)} (str "✗ " failed " failed")]
            "  "
-           ;; rf2-5x1wt.19 — the distinct THIRD status, rendered (spec/017
+           ;; the distinct THIRD status, rendered (spec/017
            ;; §`:cannot-run` — Story UI MUST render `:cannot-run` distinctly).
            [:span {:style (:count-skip styles)} (str "⊘ " cannot-run " cannot-run")]]]]))))
 
@@ -212,7 +210,7 @@
   (get pred/assertion-glyph status "·"))
 
 (defn- scrubber-section
-  "Step-through scrubber (rf2-lc36w). One tick per play event with
+  "Step-through scrubber. One tick per play event with
   pass/fail/event/skip status colouring. Click a tick (or drag the
   slider below) to restore the variant's app-db to that step's
   epoch — the canvas re-renders against it.
@@ -336,7 +334,7 @@
      [:div {:style (:detail-source styles)}
       (str "at " (:file source)
            (when (:line source) (str ":" (:line source))))
-      ;; rf2-evgf5: per-assertion 'Open in editor' chip — surfaces the
+      ;; per-assertion 'Open in editor' chip — surfaces the
       ;; assertion's source-coord (the play-step site, captured by the
       ;; assertion's record builder per spec/004).
       (open-in-editor/open-chip source :test-detail)])])
@@ -364,14 +362,14 @@
      [:th {:style (:th styles)} "assertion"]
      [:th {:style (:th styles)} "detail"]]]
    [:tbody
-    ;; rf2-tistm — :expanded is keyed by the row's stable identity
+    ;; :expanded is keyed by the row's stable identity
     ;; (:row-key from assertion-row, the rendered label string) rather
     ;; than positional index. A re-run that reorders or inserts
     ;; assertions would otherwise open the wrong row.
     (for [[i row] (map-indexed vector rows)]
       (let [rk    (:row-key row)
             open? (contains? expanded rk)
-            ;; rf2-ba86n.11 — :error / :cannot-run disclose detail too.
+            ;; :error / :cannot-run disclose detail too.
             bad?  (#{:fail :error :cannot-run} (:status row))]
         ^{:key (str rk "#" i)}
         [:tr {:data-test      "story-test-row"
@@ -564,7 +562,7 @@
             "no retained evidence for this run"])]))))
 
 (defn- promotion-section
-  "Generated-failure promotion entry point (rf2-ba86n.13, spec/021 §3).
+  "Generated-failure promotion entry point (spec/021 §3).
   DISTINCT from save-current-state (spec/019 §3): the source here is the
   CAPTURED RUN ARTIFACT this run produced, not the live canvas args. The
   button captures the current run as an artifact (a replay back-link when
@@ -670,7 +668,7 @@
                       :aria-label "Variant tests"}
             [header variant-id]
             [summary-section variant-id]
-            ;; rf2-ba86n.11 — the unified run-result surfaces (spec/021 §1):
+            ;; the unified run-result surfaces (spec/021 §1):
             ;; checks grouped by id, the per-test assertions (terminal +
             ;; script-checkpoint, with the failed-only filter), schema
             ;; violations (consumed + unconsumed), and cannot-run refusals.
@@ -680,7 +678,7 @@
             [rows-section variant-id]
             [schema-section variant-id]
             [cannot-run-section variant-id]
-            ;; rf2-ba86n.15 — visual + a11y check RESULTS (spec/021 §4).
+            ;; visual + a11y check RESULTS (spec/021 §4).
             ;; Reads the browser-tier oracle records (structural-a11y /
             ;; axe-a11y / visual-snapshot) off the SAME unified `:assertions`
             ;; slot and presents them readably (violations as a
@@ -688,10 +686,10 @@
             ;; rather than as the raw `:actual` EDN blob the generic
             ;; assertions table would show.
             [visual-a11y-view/visual-a11y-section variant-id]
-            ;; rf2-ba86n.11 — result → evidence-spine link (spec/021 §2),
+            ;; result → evidence-spine link (spec/021 §2),
             ;; a graceful "evidence pending" until the spine display lands.
             [evidence-section variant-id]
-            ;; rf2-ba86n.13 — generated-failure promotion entry point
+            ;; generated-failure promotion entry point
             ;; (spec/021 §3). Captures THIS run as an artifact and opens the
             ;; promotion dialog. Distinct from save-current-state.
             [promotion-section variant-id]]))})))

--- a/tools/story/src/re_frame/story/view_args.cljc
+++ b/tools/story/src/re_frame/story/view_args.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.story.view-args
-  "The ONE shared view-args-schema resolver (rf2-din8u phase-1, ratifying
-  the rf2-p5ivc (b) ruling + closing rf2-ayu6n / rf2-vnedo).
+  "The ONE shared view-args-schema resolver.
 
   ## The invariant this enforces
 
@@ -16,24 +15,19 @@
   This matters because `:component` (the view whose schema we resolve) can
   be `:extends`-inherited or `:compose`-d in. The plan compiler resolves
   `:component` through the parent chain (`ctx`); a consumer that reads
-  `(:component variant-body)` off the bare side-table body misses an
-  inherited / composed component and silently resolves no schema. The
-  three pre-ruling resolvers each diverged here (plan.cljc read off the
-  resolved `view-meta` first-match `[:rf/props :spec :schema]`;
-  schema_validation read `[(:schema vb) (:schema sb) (:spec view-meta)
-  (:schema view-meta)]` off four bare slots; controls read `[:schema]`
-  only) — none agreed, and all but the plan's copy read the bare body.
-  This ns is the consolidation.
+  `(:component variant-body)` off the bare side-table body would miss an
+  inherited / composed component and silently resolve no schema. Routing
+  every consumer through this single resolver keeps them in agreement and
+  reading the resolved component, not the bare body.
 
   ## Key resolution (the canonical first-match order)
 
   The first-match key picker (`malli-schema/view-args-schema` over
   `[:rf/props :schema]`) lives in the pure leaf `re-frame.story.malli-
   schema`, shared with the plan compiler (which uses it to write
-  `[:world :view-args-schema]`). Per the rf2-p5ivc (b) ruling: `:rf/props`
-  (canonical) wins over `:schema` (the post-M-54 alternative location); no
-  composition; `:spec` is dead post-M-54 and dropped. See that ns + the
-  migration §M-54 record.
+  `[:world :view-args-schema]`). `:rf/props` (canonical) wins over
+  `:schema` (the alternative location); there is no composition and no
+  `:spec` slot. See that ns + the migration §M-54 record.
 
   ## Memoization
 

--- a/tools/story/src/re_frame/story/xray_preset.cljc
+++ b/tools/story/src/re_frame/story/xray_preset.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.story.xray-preset
-  "Per-story Xray preset (rf2-q9kv5).
+  "Per-story Xray preset.
 
   A story (or variant) body may carry a `:xray` slot that
   pre-configures the Xray shell when it mounts inside the rendered
@@ -9,21 +9,18 @@
   ## Schema (see `re-frame.story.schemas/XrayPreset`)
 
       {:xray {:open?    true                 ; auto-open the shell
-               :panel    :trace               ; pre-select panel (rf2-gbz39
-                                              ; removed :issues with the
-                                              ; Xray Issues tab, Option (c))
+               :panel    :trace               ; pre-select panel
                :filters  {:out [:my/noise]    ; filter pre-population
                           :in  []}
                :focus    {:event-pos 5}}}     ; pre-focus a cascade pos
 
   Every slot is optional. A missing `:xray` slot is the v0 behaviour
   (no auto-mount, no tab focus). Xray's mount surface is resolved at
-  compile time via a direct `:require` (rf2-ibpwr, mirroring rf2-senbl
-  for `mount-fn-for`); the optional filters API (rf2-ak4ms in flight)
-  is still runtime feature-detected via the `resolve-fn` lookup. When
-  Xray's mount ns is somehow not bound, the preset no-ops silently;
-  when filters is not present, only the filters step is skipped (with
-  a console.warn breadcrumb so authors notice).
+  compile time via a direct `:require` (mirroring `mount-fn-for`); the
+  optional filters API is runtime feature-detected via the `resolve-fn`
+  lookup. When Xray's mount ns is somehow not bound, the preset no-ops
+  silently; when filters is not present, only the filters step is
+  skipped (with a console.warn breadcrumb so authors notice).
 
   ## Where it runs
 
@@ -48,21 +45,20 @@
             [re-frame.story.registrar  :as registrar]
             #?(:cljs [re-frame.core           :as rf])
             #?(:cljs [re-frame.story.config   :as config])
-            ;; rf2-ibpwr: direct :require for compile-time symbol
-            ;; resolution of `day8.re-frame2-xray.mount/open!`. The
-            ;; pre-rf2-ibpwr `xray-available?` used a `find-ns-obj` +
-            ;; `aget` walk to feature-detect Xray, which returned a
+            ;; Direct :require for compile-time symbol resolution
+            ;; of `day8.re-frame2-xray.mount/open!`. `xray-available?`
+            ;; checks the bound symbol rather than a runtime
+            ;; `find-ns-obj` + `aget` walk, which returns a
             ;; false-negative in node-test (shadow-cljs's namespace
             ;; organisation does not guarantee top-level def'd fns are
             ;; surfaced as parent-namespace JS properties — the same
-            ;; bug class as the pre-rf2-senbl `mount-fn-for` walk).
+            ;; bug class the `mount-fn-for` walk would hit).
             ;; Xray is on the same shadow-cljs :source-paths as Story
             ;; (see `implementation/shadow-cljs.edn`), so the require
             ;; is a compile-time resolution; bundle-isolation still
             ;; holds because the gate only forbids `implementation/`
             ;; → `tools/` requires, not `tools/story` → `tools/xray`
-            ;; (the inverse is explicitly fine — see rf2-senbl PR
-            ;; comment for the dep-arrow analysis).
+            ;; (the inverse is explicitly fine).
             #?(:cljs [day8.re-frame2-xray.mount :as xray-mount])))
 
 ;; ---- pure: preset resolution ---------------------------------------------
@@ -127,13 +123,12 @@
      compile-time-resolved `xray-mount/open!` symbol is bound to a
      value at runtime.
 
-     rf2-ibpwr: this previously used a runtime `find-ns-obj` + `aget`
-     walk to feature-detect Xray, which returned a false-negative under
-     node-test (same bug class as the pre-rf2-senbl `mount-fn-for`
-     walk). The fix mirrors rf2-senbl's `mount-fn-for`: a direct
-     `:require` of `day8.re-frame2-xray.mount` at the top of this ns
-     means the symbol is resolved at compile time; the runtime call
-     just dereferences the bound value. Xray is on Story's shadow-cljs
+     The symbol is resolved at compile time via a direct `:require`
+     of `day8.re-frame2-xray.mount` at the top of this ns (mirroring
+     `mount-fn-for`); the runtime call just dereferences the bound
+     value. A runtime `find-ns-obj` + `aget` feature-detect walk
+     returns a false-negative under node-test (same bug class the
+     `mount-fn-for` walk would hit). Xray is on Story's shadow-cljs
      `:source-paths` so the require always resolves; the `some?` guard
      is belt-and-braces against a degenerate build that somehow shipped
      without Xray's mount ns. When false the preset no-ops silently."
@@ -150,9 +145,9 @@
 
 #?(:cljs
    (defn filters-available?
-     "True iff the Xray filters API (rf2-ak4ms, in flight) exposes a
-     `configure!` fn. Feature-detect — when false the `:filters` step
-     of the preset is skipped with a `console.warn`."
+     "True iff the Xray filters API exposes a `configure!` fn.
+     Feature-detect — when false the `:filters` step of the preset is
+     skipped with a `console.warn`."
      []
      (some? (resolve-fn 'day8.re-frame2-xray.filters.config/configure!))))
 
@@ -177,19 +172,18 @@
    (defn apply-open!
      "Drive the Xray shell open via `xray-mount/open!`. The symbol
      resolves at compile time via the direct `:require` at the top of
-     this ns (rf2-ibpwr — replaces the pre-fix `find-ns-obj` walk that
-     false-negatived under node-test).
+     this ns (a `find-ns-obj` walk would false-negative under
+     node-test).
 
-     Public composition seam: callers that need the legacy whole-shell
-     open compose `(do (wire-cross-host!) (apply-open!))` directly (see
-     the no-shim note below)."
+     Public composition seam: callers that need a whole-shell open
+     compose `(do (wire-cross-host!) (apply-open!))` directly."
      []
      (when xray-mount/open!
        (safe-call! "open!" xray-mount/open!))))
 
-;; ---- :project-root bridge (rf2-r1uod) ------------------------------------
+;; ---- :project-root bridge -----------------------------------------------
 ;;
-;; Symmetric to shop's rf2-6jyf6 (#1493): the source-coord chips in
+;; The source-coord chips in
 ;; Xray-as-RHS need `xray-config/project-root` set, but Story testbeds
 ;; configure only the Story side via
 ;; `story/configure! {:rf.story/project-root ...}`. Instead of asking
@@ -199,8 +193,8 @@
 ;;
 ;; Single source of truth: the host sets `:rf.story/project-root` once
 ;; via `story/configure!`; the bridge propagates the value into Xray's
-;; slot so both Story's own 'Open' chips (rf2-zfy1e) and Xray-as-RHS's
-;; chips (rf2-5m5n2) resolve coords against the same on-disk root.
+;; slot so both Story's own 'Open' chips and Xray-as-RHS's chips
+;; resolve coords against the same on-disk root.
 ;;
 ;; Fires from two seams:
 ;;   1. `story/configure!` after `set-project-root!` lands — the common
@@ -232,12 +226,12 @@
      (when (and config/enabled? (xray-config-available?))
        (when-let [root (config/get-project-root)]
          (when-let [configure! (resolve-fn 'day8.re-frame2-xray.config/configure!)]
-           ;; rf2-xea9u — Xray's configure! keys live under :rf.xray/*
-           ;; per the :rf.<tool>/* convention.
+           ;; Xray's configure! keys live under :rf.xray/* per the
+           ;; :rf.<tool>/* convention.
            (safe-call! "config/configure!" configure! {:rf.xray/project-root root})
            root)))))
 
-;; ---- :rf.xray/keybinding-enabled? bridge (rf2-q7who.1) -----------------
+;; ---- :rf.xray/keybinding-enabled? bridge --------------------------------
 ;;
 ;; Xray standalone attaches a window-level capture-phase `keydown`
 ;; listener that handles `Ctrl+Shift+C` (shell toggle), `Cmd/Ctrl+K`
@@ -247,8 +241,8 @@
 ;; binding would never fire because Xray's handler calls
 ;; `stopPropagation()` on every key it consumes.
 ;;
-;; The fix: when Story drives Xray as RHS (the always-on RHS panel,
-;; rf2-sgdd3), set `:rf.xray/keybinding-enabled? false` on Xray's
+;; When Story drives Xray as RHS (the always-on RHS panel), set
+;; `:rf.xray/keybinding-enabled? false` on Xray's
 ;; config slot so Xray's `keybinding/attach!` short-circuits. Story's
 ;; Cmd/Ctrl+K reaches its own command palette; Xray is still
 ;; mountable / dispatchable / inspectable via every other surface
@@ -260,9 +254,8 @@
 ;; Xray (no Story) is unaffected — only Story-driven mounts disable
 ;; the listener.
 ;;
-;; Per rf2-4eyik (the sibling bead that shipped the config slot) +
-;; rf2-xea9u (the :rf.xray/* configure! rename): "Hosts MUST set
-;; this BEFORE the Xray preload runs". Setting it from
+;; Hosts MUST set this slot (`:rf.xray/*` per the configure!
+;; convention) BEFORE the Xray preload runs. Setting it from
 ;; `wire-cross-host!` means the slot lands at variant-selection time,
 ;; after the preload's `keybinding/attach!` has already fired with the
 ;; default `true`. The Xray-side bead is the slot owner; preload-time
@@ -282,23 +275,20 @@
 
      Called by `wire-cross-host!` so Story-driven Xray-as-RHS mounts
      never have Xray swallow the host's global keybindings (typically
-     `Cmd/Ctrl+K` for Story's command palette). Per rf2-q7who.1
-     (rf2-4eyik sibling on the Xray side) + rf2-xea9u (:rf.xray/*
-     configure! rename). Idempotent — writing `false` over an existing
-     `false` is a plain reset!.
+     `Cmd/Ctrl+K` for Story's command palette). Idempotent — writing
+     `false` over an existing `false` is a plain reset!.
 
      Sequencing: `disable-keybinding!` flips the slot (intent
-     declaration); rf2-ycrt2's `detach-keybinding!` removes the
-     listener Xray's preload already installed under the default-true
-     posture (runtime mechanism). Both fire from `wire-cross-host!`
-     in that order."
+     declaration); `detach-keybinding!` removes the listener Xray's
+     preload already installed under the default-true posture (runtime
+     mechanism). Both fire from `wire-cross-host!` in that order."
      []
      (when (and config/enabled? (xray-config-available?))
        (when-let [configure! (resolve-fn 'day8.re-frame2-xray.config/configure!)]
          (safe-call! "config/configure!" configure! {:rf.xray/keybinding-enabled? false})
          true))))
 
-;; ---- keybinding/detach! bridge (rf2-ycrt2 — rf2-q7who.1 follow-on) -------
+;; ---- keybinding/detach! bridge ------------------------------------------
 ;;
 ;; `disable-keybinding!` above flips Xray's `:rf.xray/keybinding-enabled?`
 ;; slot to `false`, but that slot is only read at attach time (by
@@ -309,7 +299,7 @@
 ;; continues swallowing Story's `Cmd/Ctrl+K` despite the intent
 ;; declaration.
 ;;
-;; The fix (option (b) per rf2-ycrt2 operator decision): Xray exposes
+;; Xray exposes
 ;; a public `detach!` fn (idempotent, safe to call without prior
 ;; `attach!`). Story drives it after `disable-keybinding!` so the
 ;; intent-declaration is matched by a runtime removal. Slot remains the
@@ -331,8 +321,6 @@
      Called by `wire-cross-host!` AFTER `disable-keybinding!` flipped
      the slot — the slot declares intent, `detach!` removes the
      listener Xray's preload installed under the default-true posture.
-     The runtime gap rf2-q7who.1 declared but did not close — rf2-ycrt2
-     closes it.
 
      Idempotent — `keybinding/detach!` is a no-op when nothing is
      attached, so this bridge is safe on the rare edge where Xray's
@@ -348,7 +336,7 @@
 
 #?(:cljs
    (defn wire-cross-host!
-     "rf2-v1ach: bridge Story's configuration into Xray's config
+     "Bridge Story's configuration into Xray's config
      slots without mounting the full shell. Fires the three
      cross-host bridges (project-root + keybinding disable + listener
      detach) so the popout escape hatch + Xray's source-coord chips
@@ -364,15 +352,13 @@
        (disable-keybinding!)
        (detach-keybinding!))))
 
-;; rf2-ee38b.3: the DEPRECATED `ensure-xray-mounted!` whole-shell-open
-;; shim was REMOVED (no production caller; the per-panel embed
-;; `re-frame.story.ui.xray-embed` owns its mount via the
-;; `panels/mount-<panel>!` contract). Cross-host configuration bridges
-;; (project-root + keybinding disable + listener detach) are driven by
-;; `wire-cross-host!` above; a caller that genuinely needs the legacy
+;; The per-panel embed `re-frame.story.ui.xray-embed` owns its mount
+;; via the `panels/mount-<panel>!` contract. Cross-host configuration
+;; bridges (project-root + keybinding disable + listener detach) are
+;; driven by `wire-cross-host!` above; a caller that genuinely needs a
 ;; whole-shell open composes `(do (wire-cross-host!) (apply-open!))`
 ;; directly — there is no shim. Matches the project's no-back-compat
-;; posture (the spec carve-out in 003-Render-Shell.md was removed too).
+;; posture.
 
 #?(:cljs
    (defn- apply-panel!
@@ -387,8 +373,7 @@
 #?(:cljs
    (defn- apply-filters!
      "Configure Xray filters via the optional filters API. Skipped with
-     a warn breadcrumb when filters is not yet on the classpath
-     (rf2-ak4ms in flight)."
+     a warn breadcrumb when filters is not on the classpath."
      [filters]
      (cond
        (not (map? filters))
@@ -455,8 +440,8 @@
      who edits `:xray` and hot-reloads sees the change without
      remount.
 
-     rf2-v1ach: the RHS chip-row's user-override is shell-wide and
-     sticky across variant changes — `xray-embed/effective-panel`
+     The RHS chip-row's user-override is shell-wide and sticky across
+     variant changes — `xray-embed/effective-panel`
      prefers the user click when set, falling back to
      `resolve-panel` otherwise. Authors who want a different
      default per story declare it on the variant body

--- a/tools/story/testbeds/counter_with_stories/core.cljs
+++ b/tools/story/testbeds/counter_with_stories/core.cljs
@@ -30,10 +30,9 @@
             ;; sequence below.
             [counter-with-stories.elision-demo :as elision]
             [counter-with-stories.stories]
-            ;; Shared Story-host helper (rf2-tq26t / rf2-uv7sn): owns the
-            ;; live-app↔Story-shell hash router + React-root handle, and
-            ;; (rf2-77wqzi) the open-in-editor project-root config via the
-            ;; `:source-subdir` opt.
+            ;; Shared Story-host helper: owns the live-app↔Story-shell
+            ;; hash router + React-root handle, and the open-in-editor
+            ;; project-root config via the `:source-subdir` opt.
             [re-frame.testbed.story-host :as story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -50,7 +49,7 @@
    [views/counter-card {:label "Count"}]
    [elision/elision-card]])
 
-;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from absence,
+;; EP-0002: the runtime never synthesises a frame from absence,
 ;; so the live-app surface must render under an explicit frame scope. The
 ;; Story shell side (`#/stories`) allocates its own per-variant frames; this
 ;; wrapper scopes only the live-app `#/` surface to the testbed's
@@ -62,7 +61,7 @@
 ;; -- Routing between app and story shell ----------------------------------
 ;;
 ;; The live-app↔Story-shell hash router + React-root host handle live in
-;; the shared `re-frame.testbed.story-host` helper (rf2-tq26t / rf2-uv7sn);
+;; the shared `re-frame.testbed.story-host` helper;
 ;; `run` hands it `counter-app` as the live-app surface. The helper tears
 ;; one React root down before mounting the other on the same `#app` node.
 
@@ -77,16 +76,15 @@
   ;; No explicit `(story/install-canonical-vocabulary!)` call — the
   ;; first `reg-*` in `counter-with-stories.stories` (loaded via
   ;; :require above) auto-installs the canonical vocabulary on demand
-  ;; per rf2-p1ydc + spec/001 §Boot. The explicit call is legacy
-  ;; (rf2-y8gag — audit D-2) and removed from every canonical testbed.
+  ;; per spec/001 §Boot. Canonical testbeds carry no explicit boot call.
   ;; Configure the global args layer (Layer 1 of the args-precedence
   ;; chain; see `002-Runtime.md` §Args resolution precedence). The stories layer their own args on
   ;; top via reg-story / reg-variant. The open-in-editor project-root is
-  ;; now host-owned via the `:source-subdir` opt on
-  ;; `mount-with-hash-routing!` below (rf2-77wqzi), so this call carries
+  ;; host-owned via the `:source-subdir` opt on
+  ;; `mount-with-hash-routing!` below, so this call carries
   ;; only the global-args layer.
   (story/configure! {:rf.story/global-args {:locale :en}})
-  ;; EP-0002 (rf2-9o48ih): `init!` installs the adapter only — register the
+  ;; EP-0002: `init!` installs the adapter only — register the
   ;; testbed's `:rf/default` app frame explicitly, then run the frame-local
   ;; boot work (seed dispatch + elision listener install) inside its scope.
   ;; The live-app render is frame-scoped via `live-app-root` (the
@@ -96,7 +94,7 @@
   ;; EP-0015 §8: durable app-db size/sensitivity classification is FRAME-owned
   ;; — declared here as `:large {:app-db …}` so the `:user/avatar-pdf` slot
   ;; elides to the `:rf.size/large-elided` marker at wire egress. (Schemas
-  ;; describe shape only; they no longer carry app-db egress markers.)
+  ;; describe shape only; app-db egress markers are frame-owned.)
   (rf/reg-frame :rf/default
     {:large {:app-db [[:user/avatar-pdf]]}})
   (rf/with-frame :rf/default
@@ -108,17 +106,16 @@
     ;; handler and the `:rf.size/large-elided` marker for the `:large?`
     ;; schema slot without needing the trace surface or Xray attached.
     (elision/install-listener!))
-  ;; rf2-3qcxk — install the CI-as-test global hook the Playwright
+  ;; Install the CI-as-test global hook the Playwright
   ;; play-script runner reads. Inert until the runner polls it; safe
   ;; to install unconditionally because the function body is gated
   ;; on Story being enabled (the ns itself is Story-tooling).
   (story-ci/install-ci-hooks!)
   ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
   ;; `#/stories` lands on the shell without a manual click-through. The
-  ;; `:source-subdir` opt (rf2-77wqzi) hands the host this testbed's
+  ;; `:source-subdir` opt hands the host this testbed's
   ;; tool-relative source subdir; the host resolves the on-disk
   ;; open-in-editor project-root (build-env define or `?checkout-root=`
   ;; override, cross-platform) and calls `story/configure!` itself — which
-  ;; also bridges the root into Xray's slot. Replaces the former inline
-  ;; `resolve-source-root` + `story/configure! :rf.story/project-root`.
+  ;; also bridges the root into Xray's slot.
   (story-host/mount-with-hash-routing! live-app-root {:source-subdir "tools/story/testbeds"}))

--- a/tools/story/testbeds/counter_with_stories/elision_demo.cljs
+++ b/tools/story/testbeds/counter_with_stories/elision_demo.cljs
@@ -102,14 +102,13 @@
 ;; may be `nil` (when the user hasn't uploaded yet), so the schema permits
 ;; nil via `:maybe`.
 ;;
-;; EP-0002 (rf2-5q7um6): `reg-app-schema` is context-required frame-local —
+;; EP-0002: `reg-app-schema` is context-required frame-local —
 ;; a bare ns-load call under no scope raises `:rf.error/no-frame-context`
 ;; (boot-time namespace loading is NOT a reason to synthesise `:rf/default`,
 ;; per Spec 002 §Frame target resolution). This demo's app runs in the
 ;; `:rf/default` frame (see `core/run`), so name it explicitly here via
 ;; `with-frame` — the registration carries a frame stamp even though it
-;; lands at module-load before `init!`. (The broader testbed migration to a
-;; root provider is owned by the Story/tools bead rf2-bd4div.)
+;; lands at module-load before `init!`.
 (with-frame :rf/default
   (rf/reg-app-schema [:user/avatar-pdf]
                      {:schema [:maybe :string]}))

--- a/tools/story/testbeds/counter_with_stories/elision_demo_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/elision_demo_cljs_test.cljs
@@ -63,13 +63,13 @@
   ;; demo namespace's ns-load `reg-app-schema` call ran once at module load;
   ;; the preceding `(clear!)` step wiped it. Re-stamping it here keeps the
   ;; schema present for shape validation.
-  ;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local;
+  ;; EP-0002: reg-app-schema is context-required frame-local;
   ;; pass the target frame explicitly (the *override*) rather than relying on
   ;; an ambient default.
   (rf/reg-app-schema [:user/avatar-pdf]
                      {:schema [:maybe :string]
                       :frame :rf/default})
-  ;; EP-0015 §8 (rf2-d2r3um): durable app-db egress classification is
+  ;; EP-0015 §8: durable app-db egress classification is
   ;; FRAME-owned. Install the `[:user/avatar-pdf]` large declaration
   ;; (index-free :rf/path) onto :rf/default's elision registry via the
   ;; frame-classification seam so `elide-wire-value` finds a declared-large
@@ -85,8 +85,8 @@
   (reset! frame/frames {})
   (event-emit/clear-event-listeners!))
 
-;; EP-0002 (rf2-bd4div): these tests exercise the ambient dispatch /
-;; app-db-read paths, which now require a carried frame stamp. A function
+;; EP-0002: these tests exercise the ambient dispatch /
+;; app-db-read paths, which require a carried frame stamp. A function
 ;; fixture pins `:rf/default` (registered in `before!` via
 ;; `ensure-default-frame!`) as the established scope for the whole test
 ;; body via `with-frame` — the demo app runs in the ordinary `:rf/default`

--- a/tools/story/testbeds/counter_with_stories/events.cljs
+++ b/tools/story/testbeds/counter_with_stories/events.cljs
@@ -23,7 +23,7 @@
 ;; preserve any app-db keys the variant seeded earlier (a conventional
 ;; reducer shape). The Story runtime's per-frame lifecycle machine snapshot
 ;; lives at `[:rf.runtime/machines :snapshots ...]` in the frame's
-;; runtime-db partition (EP-0001 rf2-vzld77 — durable runtime-db state, not
+;; runtime-db partition (EP-0001 — durable runtime-db state, not
 ;; app-db), so a `:db` (app-db) effect can never touch it.
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} [_ initial-count]]

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -23,7 +23,7 @@
   - `reg-story-panel` — `:Panel.counter-with-stories/notes` (a small
                         project-custom panel in the right pane), and
                         `:Panel.counter-with-stories/broken-render`
-                        (rf2-76wo5 testbed — :render points at an
+                        (a testbed panel whose :render points at an
                         unregistered view to exercise the panel-host's
                         broken-render fallback branch).
   - `reg-story`       — four parent stories. The exemplary
@@ -35,8 +35,8 @@
                         `:story.counter-play-script`).
   - `reg-variant`     — an exemplary core of five `:story.counter`
                         variants exercising every authoring shape (four
-                        canonical + the events-only loader-body shape
-                        folded in per rf2-9jfo1.2), PLUS the deliberate
+                        canonical + the events-only loader-body shape),
+                        PLUS the deliberate
                         diagnostics / matrix / CI-runner fixtures under
                         the sibling parents below.
   - `reg-workspace`   — five workspaces (`:grid`, `:variants-grid`,
@@ -83,8 +83,8 @@
 ;;
 ;; The seven canonical Story tags (:dev :docs :test :screenshot
 ;; :experimental :internal :agent) auto-install on the first `reg-*`
-;; call below per rf2-p1ydc — no explicit boot step needed (rf2-y8gag
-;; — audit D-2). `reg-tag` / `reg-mode` / `reg-decorator` etc. all
+;; call below — no explicit boot step needed. `reg-tag` /
+;; `reg-mode` / `reg-decorator` etc. all
 ;; trigger the same idempotent installer chain via the registrar's
 ;; `maybe-auto-install!` hook.
 ;; ---------------------------------------------------------------------------
@@ -94,7 +94,7 @@
   Idempotent. The trailing top-level call fires this at namespace
   load; the test fixture calls it again after a clear-all! per test.
   The canonical vocabulary auto-installs on the first `reg-*` call —
-  no explicit boot step required (rf2-p1ydc + rf2-y8gag)."
+  no explicit boot step required."
   []
   ;; -------------------------------------------------------------------------
   ;; reg-tag — register the project's custom tag
@@ -109,7 +109,7 @@
     {:doc "Tag applied to the variant that ships as the example's
           canonical screenshot — the one the README points at."})
 
-  ;; rf2-7ncf9 — faceted tag taxonomy (SB9 parity). Tags carrying an
+  ;; Faceted tag taxonomy (SB9 parity). Tags carrying an
   ;; `:axis` slot group into per-axis chip rows in the sidebar filter.
   ;; The filter applies AND across axes + OR within an axis. The
   ;; preferred shape is the namespaced keyword (`:status/stable`,
@@ -216,7 +216,7 @@
      :for       #{:story.counter}})
 
   ;; -------------------------------------------------------------------------
-  ;; rf2-76wo5 — broken-render testbed panel
+  ;; Broken-render testbed panel
   ;;
   ;; A panel pointing at an :render view id that is NEVER registered.
   ;; Exercises the panel-host's broken-render fallback branch in
@@ -291,7 +291,7 @@
   ;;
   ;; reg-variant — the five `:story.counter` variants. Four exercise
   ;; distinct authoring shapes; the fifth is the events-only loader-body
-  ;; shape (rf2-9jfo1.2). This block plus the all-states / auto-grid
+  ;; shape. This block plus the all-states / auto-grid
   ;; workspaces is what a consumer reads to learn the authoring surface.
   ;; Everything below the GATE-FIXTURE banner is diagnostics machinery.
   ;; ===========================================================================
@@ -318,7 +318,7 @@
      :script [[:assert-db [:count] 7]
               [:assert [:rf.assert/sub-equals [:count-doubled] 14]]
               [:assert [:rf.assert/sub-equals [:count-parity]  :odd]]]
-     ;; rf2-7ncf9 — faceted tags alongside the existing canonical seven.
+     ;; Faceted tags alongside the existing canonical seven.
      ;; The sidebar groups these into per-axis chip rows.
      :tags   #{:dev :docs :test :counter-with-stories/canonical
                :status/stable :role/dev :team/counter :feature/counter}
@@ -332,8 +332,8 @@
     {:doc    "Counter after three increments from zero, driven from
              the :script so :rf.assert/dispatched? observes them."
      :setup [[:counter/initialise 0]]
-     ;; rf2-yn825: the play-runner's :rf.assert/* bridge now surfaces
-     ;; assertion failures that the buggy runner used to swallow. The
+     ;; The play-runner's :rf.assert/* bridge surfaces assertion
+     ;; failures up through the runner. The
      ;; path-equals [:count] 3 check passes under plain-atom (CLJS unit
      ;; test) but Playwright shows a different count (Reagent + StrictMode
      ;; — see reg_variant_e2e_cljs_test.cljs:18). The canonical count-3
@@ -348,16 +348,13 @@
      :substrates #{:reagent}
      :decorators [[:counter-with-stories/log-decorator "variant-level"]]})
 
-  ;; Variant 3b — canonical events-only loader-body shape (rf2-9jfo1.2 —
-  ;; folded in from the retired `tools/story/testbeds/xray_rhs_smoke/`
-  ;; testbed). Per rf2-043cm a variant is *events-only* when its body
-  ;; declares no `:loaders` AND no `:loaders-complete-when` AND its
-  ;; resolved decorator stack carries no `:frame-setup` decorators.
-  ;; Such variants take the lifecycle fast-path `:pre-mount → :ready`
-  ;; on mount (skipping `:mounting`/`:loading`) so the canvas's loading
-  ;; skeleton (rf2-0s4p1) never engages for variants that have nothing
-  ;; to wait for. PR #1574 surfaced the regression where the skeleton
-  ;; stalled indefinitely against this body shape.
+  ;; Variant 3b — canonical events-only loader-body shape. A variant is
+  ;; *events-only* when its body declares no `:loaders` AND no
+  ;; `:loaders-complete-when` AND its resolved decorator stack carries no
+  ;; `:frame-setup` decorators. Such variants take the lifecycle fast-path
+  ;; `:pre-mount → :ready` on mount (skipping `:mounting`/`:loading`) so
+  ;; the canvas's loading skeleton never engages for variants that have
+  ;; nothing to wait for.
   ;;
   ;; Pinned by `tools/story/test/re_frame/story_runtime_cljs_test.cljs`
   ;; (`cljs-events-only-fast-path-to-ready` + `cljs-events-only-
@@ -603,8 +600,8 @@
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  ;; rf2-0uo4e — failing-fx-stub-miss testbed variant. Source-side follow-on
-  ;; from rf2-6hauy. The :script declares :rf.assert/effect-emitted against
+  ;; Failing-fx-stub-miss testbed variant. The :script declares
+  ;; :rf.assert/effect-emitted against
   ;; :never-stubbed WITHOUT a corresponding force-fx-stub decorator
   ;; covering the id — the play-runner never observes the fx, so the
   ;; assertion fails with the canonical reason:
@@ -630,7 +627,7 @@
      :substrates #{:reagent}})
 
   ;; -------------------------------------------------------------------------
-  ;; :script CI fixtures (rf2-3qcxk — CI-as-test)
+  ;; :script CI fixtures (CI-as-test)
   ;;
   ;; The CI runner at `examples/scripts/serve-and-run-story-play-scripts.cjs`
   ;; discovers every registered variant whose body carries a non-empty
@@ -686,7 +683,7 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  ;; rf2-inbad fn-direct :pred fixture — verifies the advanced-CLJS-safe
+  ;; fn-direct :pred fixture — verifies the advanced-CLJS-safe
   ;; authoring path for `:assert-db :pred` (a fn reference handed in
   ;; directly instead of a symbol). The fixture pairs an in-line
   ;; anonymous predicate with a top-level clojure.core predicate so both
@@ -706,7 +703,7 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  ;; rf2-e0kof DOM-step fixtures — live-browser coverage of the rich-DSL
+  ;; DOM-step fixtures — live-browser coverage of the rich-DSL
   ;; `:click` / `:type` / `:assert-dom` steps. The pure-step + JVM
   ;; coverage in tools/story/test/re_frame/story/play/ exercises the
   ;; parser + the JVM no-DOM branches; this fixture closes the gap by
@@ -773,7 +770,7 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  ;; rf2-tl7zk multi-play fixture — three named plays on one variant.
+  ;; Multi-play fixture — three named plays on one variant.
   ;; The first play (happy-path) auto-runs on mount per the per-position
   ;; default; the other two run on demand (manual trigger via the
   ;; toolbar dropdown OR the CI runner's `runPlay` hook). One play

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -137,21 +137,21 @@
                    :story.counter-matrix/recorder-redaction
                    :story.counter-matrix/a11y-known-good
                    :story.counter-matrix/a11y-known-bad
-                   ;; rf2-0uo4e — failing-fx-stub-miss testbed (parent story
+                   ;; failing-fx-stub-miss testbed (parent story
                    ;; :story.counter-matrix).
                    :story.counter-matrix/failing-fx-stub-miss]]
         (is (contains? vs vid) (str vid " registered")))
       (is (= 14 (count vs))))))
 
-;; ---- recorder-redaction variant is self-contained (rf2-k924v) -----------
+;; ---- recorder-redaction variant is self-contained ----------------------
 ;;
 ;; This test ns requires `counter-with-stories.events` + `.stories`
 ;; (which itself requires events + views) — but NOT
 ;; `counter-with-stories.elision-demo`. The recorder-redaction-card
 ;; dispatches `:counter/sign-in`, a `:sensitive?` handler owned by the
-;; counter events slice. If the card still depended on elision-demo's
-;; `:auth/sign-in` (the pre-rf2-k924v coupling) this handler-meta probe
-;; would come back nil, because nothing here boots elision-demo.
+;; counter events slice. The card depends only on the counter events
+;; slice, not on elision-demo's `:auth/sign-in`, so this handler-meta
+;; probe resolves without booting elision-demo.
 
 (deftest recorder-redaction-sensitive-handler-registered-self-contained
   (testing "the `:counter/sign-in` handler the recorder-redaction-card

--- a/tools/story/testbeds/counter_with_stories/story_static.cljs
+++ b/tools/story/testbeds/counter_with_stories/story_static.cljs
@@ -40,7 +40,7 @@
   ;; No explicit `(story/install-canonical-vocabulary!)` call — the
   ;; `:require [counter-with-stories.stories]` above already loaded the
   ;; stories ns, whose first `reg-*` call auto-installed the canonical
-  ;; vocabulary per rf2-p1ydc (audit D-2 / rf2-y8gag).
+  ;; vocabulary.
   ;; Story global configuration — pinned defaults a published docs site
   ;; can ship with. Locale defaults to :en.
   ;;
@@ -59,16 +59,14 @@
   (story/configure! {:rf.story/global-args {:locale :en}})
   ;; NO shell-level `(rf/dispatch-sync [:counter/initialise 5])` here.
   ;; A bare global dispatch carries no frame context, and per EP-0002 the
-  ;; runtime never synthesises a `:rf/default` frame — so the router throws
-  ;; `:rf.error/no-frame-context` at `build-envelope`, which under `:advanced`
-  ;; minified to the `jj` pageerror that aborted the mount and left the shell
-  ;; unrendered (rf2-oki92v). The seed was also redundant: every counter
-  ;; variant renders inside its OWN isolated variant frame and seeds its
-  ;; `:count` slot via that variant's `:setup [[:counter/initialise N]]`
-  ;; (stories.cljs). There is no shell-level live-counter view to seed — this
-  ;; entry mounts only the Story shell — so the dispatch had no legitimate
-  ;; target. Frames are isolated contexts; the static shell holds no app-db
-  ;; of its own to seed.
+  ;; runtime never synthesises a `:rf/default` frame — so the router would
+  ;; throw `:rf.error/no-frame-context` at `build-envelope`. The seed would
+  ;; also be redundant: every counter variant renders inside its OWN isolated
+  ;; variant frame and seeds its `:count` slot via that variant's
+  ;; `:setup [[:counter/initialise N]]` (stories.cljs). There is no
+  ;; shell-level live-counter view to seed — this entry mounts only the Story
+  ;; shell — so the dispatch has no legitimate target. Frames are isolated
+  ;; contexts; the static shell holds no app-db of its own to seed.
   ;; Mount the Story shell directly onto `#app`. No hash routing — this
   ;; ns is the static-export entry only, the SPA lives in core.cljs.
   (story/mount-shell! (js/document.getElementById "app")))

--- a/tools/story/testbeds/counter_with_stories/views.cljs
+++ b/tools/story/testbeds/counter_with_stories/views.cljs
@@ -156,7 +156,7 @@
              :data-test "a11y-known-bad-action"}
     "Unlabelled image above"]])
 
-;; ---- counter-with-input — DOM-step play-script fixture (rf2-e0kof) -----
+;; ---- counter-with-input — DOM-step play-script fixture ----------------
 ;;
 ;; A minimal counter variant whose user surface exposes the three DOM
 ;; affordances the rich-DSL `:click` / `:type` / `:assert-dom` steps

--- a/tools/story/testbeds/login_form/core.cljs
+++ b/tools/story/testbeds/login_form/core.cljs
@@ -1,5 +1,5 @@
 (ns login-form.core
-  "Login-form testbed entry (rf2-0sg12).
+  "Login-form testbed entry.
 
   URL-hash-routed between two surfaces:
 
@@ -20,10 +20,9 @@
             [login-form.subs]
             [login-form.views :as views]
             [login-form.stories]
-            ;; Shared Story-host helper (rf2-tq26t / rf2-uv7sn): owns the
-            ;; live-app↔Story-shell hash router + React-root handle, and
-            ;; (rf2-77wqzi) the open-in-editor project-root config via the
-            ;; `:source-subdir` opt.
+            ;; Shared Story-host helper: owns the live-app↔Story-shell
+            ;; hash router + React-root handle, and the open-in-editor
+            ;; project-root config via the `:source-subdir` opt.
             [re-frame.testbed.story-host :as story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -55,7 +54,7 @@
     " five side-by-side, switch to Test mode and watch the assertions"
     " flip green."]])
 
-;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from absence,
+;; EP-0002: the runtime never synthesises a frame from absence,
 ;; so the live-app surface must render under an explicit frame scope. The
 ;; Story shell side (`#/stories`) allocates its own per-variant frames; this
 ;; wrapper scopes only the live-app `#/` surface to the testbed's `:rf/default`
@@ -70,8 +69,8 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The live-app↔Story-shell hash router + React-root host handle live in the
-;; shared `re-frame.testbed.story-host` helper (rf2-tq26t / rf2-uv7sn); `run`
-;; hands it `login-app` as the live-app surface.
+;; shared `re-frame.testbed.story-host` helper; `run` hands it `login-app`
+;; as the live-app surface.
 
 (defn ^:export run []
   ;; Story owns this page's full-width browser-test canvas. When the
@@ -83,8 +82,7 @@
   (rf/init! reagent-adapter/adapter)
   ;; No explicit `(story/install-canonical-vocabulary!)` — the first
   ;; `reg-*` in `login-form.stories` (loaded via the :require above)
-  ;; auto-installs the canonical vocabulary per rf2-p1ydc (audit D-2
-  ;; / rf2-y8gag).
+  ;; auto-installs the canonical vocabulary.
   ;; The live page wires `:rf.http/managed` to a demo override so
   ;; submit / retry have something to do. Story variants don't see
   ;; this — they allocate their own frames and the `force-fx-stub`
@@ -98,7 +96,7 @@
   ;; Without this, the live page's state-pill renders "state: "
   ;; (nil) until the user submits.
   ;;
-  ;; EP-0002 (rf2-9o48ih): `init!` installs the adapter only and a
+  ;; EP-0002: `init!` installs the adapter only and a
   ;; frameless `dispatch-sync` raises `:rf.error/no-frame-context`.
   ;; Run the seed dispatch inside the testbed's `:rf/default` frame
   ;; scope — symmetric to counter-with-stories' migrated boot.
@@ -108,10 +106,9 @@
   ;; root is frame-scoped via `live-app-root` (the
   ;; `frame-provider-existing` wrapper — scope-only into the already-
   ;; registered `:rf/default` frame).
-  ;; The `:source-subdir` opt (rf2-77wqzi) hands the host this testbed's
+  ;; The `:source-subdir` opt hands the host this testbed's
   ;; tool-relative source subdir; the host resolves the on-disk
   ;; open-in-editor project-root (build-env define or `?checkout-root=`
   ;; override, cross-platform) and calls `story/configure!` itself — which
-  ;; also bridges the root into Xray's slot. Replaces the former inline
-  ;; `resolve-source-root` + `story/configure!`.
+  ;; also bridges the root into Xray's slot.
   (story-host/mount-with-hash-routing! live-app-root {:source-subdir "tools/story/testbeds"}))

--- a/tools/story/testbeds/login_form/events.cljs
+++ b/tools/story/testbeds/login_form/events.cljs
@@ -1,5 +1,5 @@
 (ns login-form.events
-  "Login-form testbed events (rf2-0sg12) — five-state login flow.
+  "Login-form testbed events — five-state login flow.
 
   The Story tutorial's index page opens with a five-state login-form
   scenario (`docs/story/index.md:13-26`) and never delivers code for
@@ -19,8 +19,8 @@
   bodies are data; they reference these event-ids in their `:setup`
   slot. Story's per-variant frame isolation (Spec 002) means each variant
   gets its own fresh `[:rf.runtime/machines :snapshots :login/flow]` slot in
-  its runtime-db partition (EP-0001 rf2-vzld77 — machine snapshots are
-  durable runtime-db state, not app-db).
+  its runtime-db partition (EP-0001 — machine snapshots are durable
+  runtime-db state).
 
   Per Spec 014 §Testing the stub layer: `:rf.http/managed` is the
   fx-id the machine emits; the Story variants override that id via
@@ -35,10 +35,10 @@
             ;; the login flow's request fx would throw
             ;; :rf.error/no-such-fx.
             [re-frame.http.managed]
-            ;; rf2-cdmle — this testbed resolves
+            ;; This testbed resolves
             ;; :rf.http/managed-canned-success/failure via registrar lookup.
-            ;; Per the gate change, the canned-stub fx ids register from
-            ;; re-frame.http.test-support, NOT re-frame.http.managed.
+            ;; The canned-stub fx ids register from
+            ;; re-frame.http.test-support, not re-frame.http.managed.
             [re-frame.http.test-support]
             [re-frame.registrar :as registrar]))
 

--- a/tools/story/testbeds/login_form/stories.cljs
+++ b/tools/story/testbeds/login_form/stories.cljs
@@ -1,5 +1,5 @@
 (ns login-form.stories
-  "Story variants for the login-form testbed (rf2-0sg12).
+  "Story variants for the login-form testbed.
 
   Promotes the five-state login-form scenario from the Story
   tutorial's index page (`docs/story/index.md:13-26`) to runnable
@@ -19,15 +19,15 @@
   through MCP, the recorder, the visual-regression service).
 
   Every variant pins its terminal state with `:rf.assert/state-is
-  :login/flow ...`, the runtime-db-aware machine checkpoint. EP-0001
-  (rf2-vzld77) moved machine snapshots into the frame's runtime-db
-  partition; per rf2-ib5acl the play-runner's `:rf.assert/sub-equals`
-  / `:rf.assert/path-equals` evaluate against app-db, so a machine
-  projection isn't observable through them. The machine-snapshot `:data`
-  values (`:error` / `:attempts` / `:email`) are therefore verified in
-  the testbed's CLJS unit test (`stories_cljs_test.cljs`), which can read
-  the variant frame's runtime-db directly. The variant `:script` slots
-  still exercise the play-runner shapes that ARE supported post-migration:
+  :login/flow ...`, the runtime-db-aware machine checkpoint. Machine
+  snapshots live in the frame's runtime-db partition (EP-0001); the
+  play-runner's `:rf.assert/sub-equals` / `:rf.assert/path-equals`
+  evaluate against app-db, so a machine projection isn't observable
+  through them. The machine-snapshot `:data` values (`:error` /
+  `:attempts` / `:email`) are therefore verified in the testbed's CLJS
+  unit test (`stories_cljs_test.cljs`), which can read the variant
+  frame's runtime-db directly. The variant `:script` slots exercise the
+  play-runner shapes that ARE supported:
 
     :state-is        — every variant (`:rf.assert/state-is :login/flow ...`)
     :effect-emitted  — :submitting (the :rf.http/managed fx fired)
@@ -46,8 +46,7 @@
   "Register the login-form testbed's Story artefacts. Idempotent.
   Fired once at namespace load; the test fixture re-fires after a
   clear-all! per test. The canonical vocabulary auto-installs on the
-  first `reg-*` call below per rf2-p1ydc — no explicit boot step
-  required (audit D-2 / rf2-y8gag)."
+  first `reg-*` call below — no explicit boot step required."
   []
   ;; -------------------------------------------------------------------------
   ;; Project tag — the screenshot pinned to the tutorial.
@@ -116,9 +115,9 @@
              dispatching `:dismiss` here, and do NOT copy 'dispatch any
              event to bootstrap' as an idiom."
      :setup [[:login/flow [:login/dismiss]]]
-     ;; EP-0001 (rf2-vzld77 / rf2-ib5acl): the machine snapshot lives in
-     ;; the frame's runtime-db partition, so the state checkpoint reads it
-     ;; via `:rf.assert/state-is` (which evaluates against runtime-db) —
+     ;; EP-0001: the machine snapshot lives in the frame's runtime-db
+     ;; partition, so the state checkpoint reads it via
+     ;; `:rf.assert/state-is` (which evaluates against runtime-db) —
      ;; NOT a raw `:assert-db` path-equals, which only sees app-db.
      :script [[:assert [:rf.assert/state-is :login/flow :idle]]]
      :tags   #{:dev :docs :test}
@@ -172,14 +171,13 @@
                             {:failure {:status  401
                                        :message "Invalid credentials."}}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     ;; EP-0001 (rf2-vzld77 / rf2-ib5acl): the machine snapshot lives in
-     ;; the frame's runtime-db partition, so the state checkpoint reads it
-     ;; via `:rf.assert/state-is` (which evaluates against runtime-db).
+     ;; EP-0001: the machine snapshot lives in the frame's runtime-db
+     ;; partition, so the state checkpoint reads it via
+     ;; `:rf.assert/state-is` (which evaluates against runtime-db).
      ;; The error-message text in the snapshot's `:data` slot is verified
      ;; in the testbed's CLJS unit test (`stories_cljs_test.cljs`): the
      ;; play-runner's `:rf.assert/sub-equals` evaluates subs against app-db
-     ;; only, so a runtime-db machine projection isn't observable through it
-     ;; (see rf2-ib5acl notes — the play-runner gap is tracked separately).
+     ;; only, so a runtime-db machine projection isn't observable through it.
      :script [[:assert [:rf.assert/state-is :login/flow :error]]]
      :tags   #{:dev :docs :test}
      :substrates #{:reagent}})
@@ -205,8 +203,8 @@
               [:login/flow [:login/retry
                             {:email "ada@example.com" :password "correct-horse"}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     ;; EP-0001 (rf2-vzld77 / rf2-ib5acl): the attempt counter lives in the
-     ;; runtime-db snapshot's `:data`; the state checkpoint reads the
+     ;; EP-0001: the attempt counter lives in the runtime-db snapshot's
+     ;; `:data`; the state checkpoint reads the
      ;; snapshot via `:rf.assert/state-is`. The attempt-count value is
      ;; verified in the testbed's CLJS unit test (`stories_cljs_test.cljs`)
      ;; — the play-runner's `:rf.assert/sub-equals` only sees app-db, so a
@@ -236,8 +234,8 @@
                             {:value {:user  {:email "ada@example.com"}
                                      :token "story-token"}}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     ;; EP-0001 (rf2-vzld77 / rf2-ib5acl): the welcome-banner email lives
-     ;; in the runtime-db snapshot's `:data`; the state checkpoint reads
+     ;; EP-0001: the welcome-banner email lives in the runtime-db
+     ;; snapshot's `:data`; the state checkpoint reads
      ;; the snapshot via `:rf.assert/state-is`. The email value is verified
      ;; in the testbed's CLJS unit test (`stories_cljs_test.cljs`) — the
      ;; play-runner's `:rf.assert/sub-equals` only sees app-db, so a

--- a/tools/story/testbeds/login_form/stories_cljs_test.cljs
+++ b/tools/story/testbeds/login_form/stories_cljs_test.cljs
@@ -1,33 +1,29 @@
 (ns login-form.stories-cljs-test
-  "Regression guard for the login-form testbed's machine-snapshot reads
-  (rf2-ib5acl).
+  "Regression guard for the login-form testbed's machine-snapshot reads.
 
-  EP-0001 (rf2-vzld77) moved machine snapshots out of the retired app-db
-  `:rf/runtime` root and into the frame's runtime-db partition at
-  `[:rf.runtime/machines :snapshots <machine-id>]`. The login-form
-  testbed's four projection subs (`:login/state` `:login/error`
-  `:login/attempts` `:login/email`) and three `:script` checkpoints used
-  to reach into the dead app-db path — they compiled fine but resolved
-  empty at runtime, and NO CLJS gate caught it (the testbed had no unit
-  test; its variants run only via the browser story runner).
+  Machine snapshots live in the frame's runtime-db partition at
+  `[:rf.runtime/machines :snapshots <machine-id>]` (EP-0001). The
+  login-form testbed's four projection subs (`:login/state` `:login/error`
+  `:login/attempts` `:login/email`) and three `:script` checkpoints read
+  the snapshot through that partition.
 
   This test runs each variant through `story/run-variant` under the
   top-level `node-test` build (`npm run test:cljs`) and then, against the
   variant frame's live `frame-state-value` (which carries the runtime-db
-  partition), computes each migrated projection sub via `rf/compute-sub`
-  and asserts it resolves the live snapshot value — NOT nil from the dead
-  app-db path. `compute-sub` resolves a `:rf/machine`-derived sub against
-  the frame-state value's `:rf.db/runtime` partition (EP-0001), so this is
-  the faithful runtime-db read the views perform reactively. If a future
-  change reverts the subs to the dead app-db path, these assertions go red
-  and the CLJS gate fails loudly.
+  partition), computes each projection sub via `rf/compute-sub` and asserts
+  it resolves the live snapshot value. `compute-sub` resolves a
+  `:rf/machine`-derived sub against the frame-state value's
+  `:rf.db/runtime` partition (EP-0001), so this is the faithful runtime-db
+  read the views perform reactively. If a projection sub stops reading the
+  runtime-db partition, these assertions go red and the CLJS gate fails
+  loudly.
 
   Why compute-sub here rather than a `:rf.assert/sub-equals` `:script`
   checkpoint: the play-runner's `:sub-equals` evaluator computes subs
   against app-db ONLY, so a runtime-db machine projection reads nil through
-  it (tracked separately as a play-runner gap). The variant `:script`s pin
-  state with `:rf.assert/state-is` (runtime-db-aware); this CLJS test owns
-  the `:data`-slice (`:error` / `:attempts` / `:email`) verification.
+  it. The variant `:script`s pin state with `:rf.assert/state-is`
+  (runtime-db-aware); this CLJS test owns the `:data`-slice
+  (`:error` / `:attempts` / `:email`) verification.
 
   The variant stories ns is required at the top — loading it fires the
   `reg-*` macros — so the side-table + the four projection subs are

--- a/tools/story/testbeds/login_form/subs.cljs
+++ b/tools/story/testbeds/login_form/subs.cljs
@@ -1,22 +1,21 @@
 (ns login-form.subs
-  "Login-form testbed subs (rf2-0sg12).
+  "Login-form testbed subs.
 
   Four named subs project out the convenient pieces of the machine's
   current snapshot; the view also uses two `rf/machine-has-tag?` framework
   subs for `:auth/busy` and `:auth/authenticated`. Per Spec 005 §State
-  tags the tag queries replace the boolean-discriminator subs the
-  pre-machines style would have used (`:submitting?` /
-  `:authenticated?`).
+  tags, the tag queries express the busy/authenticated discriminators
+  declaratively.
 
-  EP-0001 (rf2-vzld77 / rf2-ib5acl): machine snapshots are durable
-  framework state and live in the frame's RUNTIME-DB partition at
-  `[:rf.runtime/machines :snapshots <machine-id>]`, NOT the retired
-  app-db `:rf/runtime` root. App code reads a machine's snapshot through
-  the framework `:rf/machine` sub (`(rf/subscribe [:rf/machine :login/flow])`)
-  rather than reaching into the runtime-db partition by raw path;
-  the framework sub reads the right partition for us. Each projection sub
-  below is a layer-2 sub deriving off `:rf/machine` via the `:<-` chain —
-  it re-computes only when the snapshot's relevant slice changes."
+  EP-0001: machine snapshots are durable framework state and live in the
+  frame's RUNTIME-DB partition at
+  `[:rf.runtime/machines :snapshots <machine-id>]`. App code reads a
+  machine's snapshot through the framework `:rf/machine` sub
+  (`(rf/subscribe [:rf/machine :login/flow])`) rather than reaching into
+  the runtime-db partition by raw path; the framework sub reads the right
+  partition for us. Each projection sub below is a layer-2 sub deriving
+  off `:rf/machine` via the `:<-` chain — it re-computes only when the
+  snapshot's relevant slice changes."
   (:require [re-frame.core :as rf]))
 
 (rf/reg-sub :login/state

--- a/tools/story/testbeds/login_form/views.cljs
+++ b/tools/story/testbeds/login_form/views.cljs
@@ -1,5 +1,5 @@
 (ns login-form.views
-  "Login-form testbed views (rf2-0sg12).
+  "Login-form testbed views.
 
   Two registered views — `login-form` (the form proper) and
   `login-card` (the framed container that swaps banner / form

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-template.hooks
-  "deps-new hooks for day8/re-frame2-template (rf2-dolpf §2.2-2.4).
+  "deps-new hooks for day8/re-frame2-template.
 
    `template.edn` declares this ns's `data-fn`, `template-fn`, and
    `post-process-fn`. deps-new invokes them in that order:
@@ -11,7 +11,7 @@
                             (e.g. dotfile renames deps-new can't do
                             natively).
 
-   Current scope (§2.2-2.4, rf2-c2770):
+   Current scope (003-DepsNew-Rebuild-Plan.md §2.2-2.4):
 
      - Substrates: Reagent / UIx / Helix (full matrix).
      - Flags: `:include-story?` (Reagent-only in v1; UIx + Helix variants
@@ -38,12 +38,12 @@
    `package.json` is the exception. Its sole per-flag delta — the
    `description` parenthetical naming the Story playground — is small
    enough to carry as the `{{story-tag}}` subst var, so a single
-   `_shared/package.json` source serves both paths (rf2-sqqxj). No
+   `_shared/package.json` source serves both paths. No
    second `package_with_story.json` source exists.
 
    The steady-state shape (see tools/template/spec/003-DepsNew-Rebuild-Plan.md
    §1) is the same matrix; additional flags (`:css`, `:include-ssr?`)
-   slot in here once their upstream gates clear (rf2-gthro, rf2-0m5ea)."
+   slot in here once their upstream gates clear."
   (:require [clojure.set :as set]
             [clojure.string :as string]))
 
@@ -76,8 +76,8 @@
   — anything else is a registration error and we throw with a clear
   message naming the valid set.
 
-  Tightened from the earlier kw/string/symbol forgiving-input posture
-  to the SOTA pre-alpha contract (rf2-h0imw / rf2-c8tmc Finding #3)."
+  The contract is keyword-only: string and symbol inputs are rejected
+  rather than coerced, matching the SOTA pre-alpha fail-closed posture."
   [raw]
   (let [substrate-kw (cond
                        (nil? raw)     :reagent
@@ -113,12 +113,12 @@
 ;; (the project-name derivations + run metadata) with whatever top-level
 ;; k/v args the caller passed. We accept exactly two template-specific
 ;; flags today (`:substrate`, `:include-story?`); the `:css` / `:include-ssr?`
-;; flags are reserved-but-unimplemented (gated on rf2-gthro / rf2-0m5ea).
+;; flags are reserved-but-unimplemented (gated on their upstream verification).
 ;;
 ;; The substrate posture already fails closed on bad values; this gate
 ;; extends that strictness to the *key set* so a flag typo
 ;; (`:include-story`) or a documented-future flag (`:css :tailwind`) can't
-;; fail open into a misleading vanilla scaffold (rf2-qck7t7 Finding #1).
+;; fail open into a misleading vanilla scaffold.
 ;;
 ;; HOW WE DISTINGUISH HARNESS KEYS FROM TEMPLATE KEYS: deps-new's
 ;; `preprocess-options` (org.corfield.new.impl) populates a fixed, known
@@ -285,7 +285,7 @@
   [data]
   ;; Fail closed on reserved + unknown arguments BEFORE any coercion, so a
   ;; flag typo or a documented-future flag never produces a misleading
-  ;; vanilla scaffold (rf2-qck7t7 Finding #1).
+  ;; vanilla scaffold.
   (gate-arg-keys! data)
   (let [substrate       (coerce-substrate (:substrate data))
         include-story?  (coerce-include-story? (:include-story? data))]
@@ -318,7 +318,7 @@
        ;; package.json `description` suffix — the single per-flag delta
        ;; between the default and with-Story descriptions. Emitting it as
        ;; a subst var lets one `_shared/package.json` source serve both
-       ;; paths (rf2-sqqxj — collapsed the byte-identical second file).
+       ;; paths from a single file.
        :story-tag           (if include-story? ", with Story playground" "")
        :namespace           (str top-ns "." main-ns)
        :nested-dirs         (str top-file "/" main-file)
@@ -329,7 +329,7 @@
        ;; shadow-cljs / react pins) by
        ;; `test/day8/re_frame2_template/version_lockstep_test.clj`. Bumping
        ;; them here in isolation will fail that test. The §3 release pipeline
-       ;; (rf2-dolpf) updates all four in lockstep.
+       ;; updates all four in lockstep.
        :rf2-version         "0.0.1.alpha"
        :shadow-version      "3.4.10"
        :react-version       "19.2.0"})))
@@ -424,7 +424,7 @@
         ;; per-flag variation is its `description` parenthetical, carried
         ;; by the `{{story-tag}}` subst var (see data-fn), so a single
         ;; `_shared/package.json` source serves both the default and the
-        ;; with-Story path (rf2-sqqxj).
+        ;; with-Story path.
         ;; Shared transforms — renames only. `:only` skips the bulk
         ;; copy of `_shared/*`, so source files that don't appear in
         ;; the file-map below DO NOT emit. Add explicit entries if

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -1,7 +1,5 @@
 (ns day8.re-frame2-template.emitted-test-run-test
-  "Behavioural test for the template's emitted unit-test scaffold
-   (rf2-ir6a0; deps-new port for rf2-c2770, closing the deeper-fidelity
-   half of rf2-owbpr).
+  "Behavioural test for the template's emitted unit-test scaffold.
 
    Sibling test files cover two cheap signals:
 
@@ -48,7 +46,7 @@
    and exits — preserves green on local fast-loop runs without
    pretending the smoke ran.
 
-   ## The MANUAL setup-skill scaffold fixture (rf2-ae98go)
+   ## The MANUAL setup-skill scaffold fixture
 
    The four substrate variants above materialise the GENERATOR template.
    The setup skill (`skills/re-frame2-setup/`) teaches a SECOND,
@@ -74,10 +72,10 @@
 
    This is a SEMANTIC-DRIFT NET — it proves the skill's own snippets
    compile against the in-repo monorepo source, NOT that a published
-   coordinate resolves. Per rf2-ae98go's ruling the per-PR
-   published-coordinate buildability gate stays DEFERRED to publication;
-   this fixture is the interim real-compile cover, riding the same
-   `RF2_TEMPLATE_RUN_EMITTED_TESTS` gate as the template variants above."
+   coordinate resolves. The per-PR published-coordinate buildability gate
+   stays DEFERRED to publication; this fixture is the interim real-compile
+   cover, riding the same `RF2_TEMPLATE_RUN_EMITTED_TESTS` gate as the
+   template variants above."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [clojure.edn :as edn]
@@ -86,17 +84,17 @@
             [day8.re-frame2-template.test-support
              :refer [tmp-dir delete-recursively run-template! repo-root]])
   ;; java.nio types used directly by `link-node-modules!` below. The
-  ;; tmp-dir / delete-recursively helpers that needed Path / LinkOption /
-  ;; FileVisitOption moved to the shared test-support ns (rf2-5v619).
+  ;; tmp-dir / delete-recursively helpers that need Path / LinkOption /
+  ;; FileVisitOption live in the shared test-support ns.
   (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]))
 
 ;; --- Helpers ---------------------------------------------------------------
 ;;
 ;; tmp-dir / delete-recursively / template-resource-dir / run-template! /
-;; repo-root live in the shared `test-support` ns (rf2-5v619, D1). The
-;; shared `run-template!` takes an optional 4th `include-story?` arg, so
-;; the with-story behavioural tier below reuses it directly.
+;; repo-root live in the shared `test-support` ns. The shared
+;; `run-template!` takes an optional 4th `include-story?` arg, so the
+;; with-story behavioural tier below reuses it directly.
 
 ;; --- Gating ----------------------------------------------------------------
 
@@ -268,8 +266,7 @@
   compile classpath; a broken UIx or Helix `core.cljs` (a wrong
   react-dom interop call, an adapter API rename, a view that won't
   compile) would otherwise ship green from shape + static-parse alone
-  and surface only when a user runs `npx shadow-cljs watch app`
-  (rf2-ee38b.23 / correctness L1).
+  and surface only when a user runs `npx shadow-cljs watch app`.
 
   When `include-story?` is true the generated project is the with-story
   scaffold (`core_with_stories.cljs`, `deps_with_story.edn` with the
@@ -278,9 +275,9 @@
   / `stories.cljs` / re-frame.story, so a broken with-story compile
   (re-frame.story API drift, a malformed deps_with_story.edn, a
   stories.cljs that won't load) fails here too rather than shipping
-  green (rf2-5v619, G1).
+  green.
 
-  ## :advanced release build (rf2-jdj17.2)
+  ## :advanced release build
 
   When the optional `release?` opt is true, the variant ALSO runs
   `clojure -M:shadow release app` — a `:advanced`/Closure-optimised
@@ -368,7 +365,7 @@
                    (is (re-find #"0 failures, 0 errors" out)
                        (str "expected '0 failures, 0 errors' line in output. Got:\n" out))))))
 
-           ;; --- :advanced release build (rf2-jdj17.2) -----------------------
+           ;; --- :advanced release build -------------------------------------
            ;; No other gate compiles the generated app under :advanced —
            ;; every other template compile is dev :none. Run
            ;; `clojure -M:shadow release app` so an :advanced-only failure
@@ -419,8 +416,8 @@
                                 "'day8.re_frame2_xray.preload' in "
                                 "resources/public/js/main.js — the "
                                 "cut-from-release invariant is broken."))
-                       ;; rf2-ek857f F2 — events.cljs registers the
-                       ;; default error-sink trace listener behind
+                       ;; events.cljs registers the default error-sink
+                       ;; trace listener behind
                        ;; `(when ^boolean goog.DEBUG ...)`, so Closure
                        ;; must DCE both the listener closure AND its
                        ;; substituted "[acme.my-app]" console marker out
@@ -459,7 +456,7 @@
 ;; --- Tests -----------------------------------------------------------------
 
 (deftest reagent-emitted-tests-run-test
-  ;; rf2-jdj17.2 — the Reagent default variant also runs the :advanced
+  ;; The Reagent default variant also runs the :advanced
   ;; release build (`release? true`). The `:app` module + `^:export init`
   ;; shape is substrate-invariant, so the default Reagent variant is the
   ;; canonical place to assert the release path compiles green and the
@@ -499,7 +496,7 @@
             (compile-and-run-emitted-test! :helix))))))
 
 (deftest reagent-with-story-emitted-tests-run-test
-  ;; G1 (rf2-5v619) — the only tier that actually shadow-compiles +
+  ;; The only tier that actually shadow-compiles +
   ;; node-runs the `:include-story? true` scaffold. Reagent-only because
   ;; with-story is Reagent-only in v1 (hooks.clj data-fn guard). Same
   ;; events_test.cljs as the default path runs; the value here is that
@@ -508,7 +505,7 @@
   ;; `stories.cljs` are all on the compile classpath — a broken
   ;; with-story compile fails the build before `node` ever runs.
   ;;
-  ;; rf2-jdj17.2 — the with-story variant ALSO runs the :advanced release
+  ;; The with-story variant ALSO runs the :advanced release
   ;; build (`release? true`). This is where the Story `:closure-define`
   ;; elision risk lives: core_with_stories.cljs documents the
   ;; `:closure-defines {re-frame.story.config/enabled? false}` elision,
@@ -533,7 +530,7 @@
             (compile-and-run-emitted-test! :reagent true {:release? true}))))))
 
 ;; ===========================================================================
-;; MANUAL setup-skill scaffold fixture (rf2-ae98go)
+;; MANUAL setup-skill scaffold fixture
 ;; ===========================================================================
 ;;
 ;; A second materialise+compile fixture that proves the `re-frame2-setup`
@@ -738,7 +735,7 @@
         (delete-recursively tmp)))))
 
 (deftest setup-skill-scaffold-compiles-test
-  ;; rf2-ae98go — the interim real-compile cover for the MANUAL setup-skill
+  ;; The interim real-compile cover for the MANUAL setup-skill
   ;; scaffold (the per-PR published-coordinate buildability gate stays
   ;; deferred to publication). Semantic-drift net: proves the skill's own
   ;; fenced snippets compile against the monorepo source, NOT that a

--- a/tools/template/test/day8/re_frame2_template/release_gate_test.clj
+++ b/tools/template/test/day8/re_frame2_template/release_gate_test.clj
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-template.release-gate-test
-  "Workflow-sanity coverage for `.github/workflows/template-release.yml`
-   (rf2-ek857f F1).
+  "Workflow-sanity coverage for `.github/workflows/template-release.yml`.
 
    The tag-triggered template release runs a pre-release test gate
    (`test-template`) before cutting a GitHub Release. The gate is only
@@ -14,13 +13,13 @@
      2. a populated `implementation/node_modules` (`npm ci` in
         `implementation`) so the emitted bundle's React imports resolve.
 
-   Before rf2-ek857f the release job ran a plain `clojure -M:test` with
-   neither — so a `template-v…` tag could publish a scaffold that fails
-   to compile / run / release, even though the PR + nightly template
-   gates (test.yml / expensive-tests.yml) would have caught it.
+   A plain `clojure -M:test` with neither would let a `template-v…` tag
+   publish a scaffold that fails to compile / run / release, even though
+   the PR + nightly template gates (test.yml / expensive-tests.yml) would
+   have caught it.
 
    These tests pin the release gate's shape so it cannot silently
-   regress back to a fast-loop-only run. They read the workflow YAML as
+   regress to a fast-loop-only run. They read the workflow YAML as
    text (no YAML parser dependency — the assertions are on stable
    substrings, mirroring how the sibling shape/static-parse tests assert
    on emitted source). They run in the default `clojure -M:test` (no

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-template.template-emission-test
-  "Static-parse tests for the template's emitted cljs scaffold (rf2-owbpr,
-   rf2-c2770 port to deps-new).
+  "Static-parse tests for the template's emitted cljs scaffold.
 
    The sibling `template_test.clj` verifies the generated file *shape*:
    names, deps.edn coords, shadow-cljs.edn wiring. It does NOT verify
@@ -27,9 +26,9 @@
      3. Repeats step 2 for `events.cljs`, `subs.cljs`, and `views.cljs`
         — same drift hazard, no extra harness cost.
 
-   The deeper-fidelity option (option (a) in the bead — run shadow-cljs
-   on the generated app) is left for after alpha publish; until then,
-   static parse catches the most likely regression."
+   The deeper-fidelity option (run shadow-cljs on the generated app) is
+   left for after alpha publish; until then, static parse catches the
+   most likely regression."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [clojure.string :as string]
@@ -42,7 +41,7 @@
 ;; --- Helpers ---------------------------------------------------------------
 ;;
 ;; tmp-dir / delete-recursively / template-resource-dir / run-template! /
-;; repo-root live in the shared `test-support` ns (rf2-5v619, D1).
+;; repo-root live in the shared `test-support` ns.
 
 ;; --- Static-parse machinery ----------------------------------------------
 
@@ -81,11 +80,11 @@
   requires (no `:as`) still count as 'required' for the purpose of the
   load-order assertion below.
 
-  Both `:require` and `:require-macros` are walked (rf2-3uqbd.2): the
-  Reagent scaffold brings `reg-view` in via `:require-macros [re-frame.core
-  :refer [reg-view]]` and calls it bare, so a `:require`-only parse left
-  that central macro invisible to the surface-drift audit. `:refer`-ed
-  symbols from either clause now feed the bare-symbol audit below."
+  Both `:require` and `:require-macros` are walked: the Reagent scaffold
+  brings `reg-view` in via `:require-macros [re-frame.core :refer
+  [reg-view]]` and calls it bare, so walking `:require-macros` too keeps
+  that central macro visible to the surface-drift audit. `:refer`-ed
+  symbols from either clause feed the bare-symbol audit below."
   [ns-form]
   (let [clauses    (drop 2 ns-form) ;; skip `ns` + ns-sym
         require?   #(and (sequential? %)
@@ -132,10 +131,9 @@
 
 (defn- collect-bare-symbols
   "Walk `forms` and collect every unqualified symbol (no namespace
-  component). Returns a set. Used (rf2-3uqbd.2) to detect bare,
-  `:refer`-ed framework symbols — e.g. the Reagent scaffold's
-  `(reg-view …)` calls, which are unqualified and therefore invisible to
-  `collect-qualified-symbols`."
+  component). Returns a set. Used to detect bare, `:refer`-ed framework
+  symbols — e.g. the Reagent scaffold's `(reg-view …)` calls, which are
+  unqualified and therefore invisible to `collect-qualified-symbols`."
   [forms]
   (let [acc (volatile! #{})]
     (walk/postwalk
@@ -208,32 +206,30 @@
   ;; (`^:private`, `^:no-doc`, `^{...}`, `^TypeHint`) between the
   ;; defining form and the symbol name.
   ;;
-  ;; Compiled once at ns-load — the previous shape rebuilt the
-  ;; java.util.regex.Pattern per call (×N framework files × N
-  ;; references × 3 substrates = thousands of compiles per suite run).
+  ;; Compiled once at ns-load — the audit loop scans each framework file
+  ;; many times (×N framework files × N references × 3 substrates =
+  ;; thousands of scans per suite run), so the pattern is built once.
   ;; The `^{...}` metadata-map alternative tolerates ONE level of brace
   ;; nesting (`\{(?:[^{}]++|\{[^{}]*+\})*+\}`) so a `def` whose docstring
   ;; embeds a literal map — e.g. `frame-provider`'s `Usage: [rf/frame-provider
-  ;; {:frame :todo} …]` — is still detected. The earlier `\{[^}]*\}` stopped
-  ;; at the FIRST inner `}`, so such a def's symbol was missed and any
-  ;; template reference to it tripped the audit (rf2-9o48ih: the EP-0002
-  ;; carried-frame scaffold references `rf/frame-provider`, the first
-  ;; template surface whose framework def carries an embedded-brace
-  ;; docstring).
+  ;; {:frame :todo} …]` — is still detected. A naive `\{[^}]*\}` would stop
+  ;; at the FIRST inner `}`, missing such a def's symbol so that any
+  ;; template reference to it would trip the audit (the carried-frame
+  ;; scaffold references `rf/frame-provider`, whose framework def carries
+  ;; an embedded-brace docstring).
   ;;
-  ;; POSSESSIVE quantifiers (rf2-uzne0p). The nested `(?:…|…)*` shape is a
-  ;; classic catastrophic-backtracking hazard: on a large source file
-  ;; (`re-frame.core/core.cljc`, ~3.1K lines) the greedy form recurses deep
-  ;; enough to throw `StackOverflowError` once any audited emitted file
+  ;; POSSESSIVE quantifiers. The nested `(?:…|…)*` shape is a classic
+  ;; catastrophic-backtracking hazard: on a large source file
+  ;; (`re-frame.core/core.cljc`, ~3.1K lines) a greedy form can recurse deep
+  ;; enough to throw `StackOverflowError` when an audited emitted file
   ;; references a `re-frame.core` symbol whose scan pushes the call stack a
-  ;; little further (the strict-mint-policy scaffold added a `rf/reg-frame`
-  ;; reference to events_test.cljs, tipping it over). Making the inner
-  ;; alternation (`[^{}]++` / `[^{}]*+`) and the outer meta-clause repetition
-  ;; (`*+`) POSSESSIVE means the engine never backtracks into already-matched
-  ;; metadata — the match is linear and stack-flat, with identical match
-  ;; semantics (the language matched is unchanged; only the backtracking is
-  ;; removed). `def`/`defn` names are `\s+`-terminated, so a possessive
-  ;; meta-clause never over-consumes the symbol it must capture.
+  ;; little further. Making the inner alternation (`[^{}]++` / `[^{}]*+`) and
+  ;; the outer meta-clause repetition (`*+`) POSSESSIVE means the engine
+  ;; never backtracks into already-matched metadata — the match is linear
+  ;; and stack-flat, with identical match semantics (the language matched is
+  ;; unchanged; only the backtracking is removed). `def`/`defn` names are
+  ;; `\s+`-terminated, so a possessive meta-clause never over-consumes the
+  ;; symbol it must capture.
   (let [meta-clause "(?:\\^(?:\\w[\\w/.:?<>=*+!\\-]*|\\{(?:[^{}]++|\\{[^{}]*+\\})*+\\})\\s+)*+"
         sym-char    "[a-zA-Z*+!?<>=$%_\\-][\\w*+!?<>=$%\\-]*"]
     (re-pattern
@@ -321,7 +317,7 @@
                      substrate ") uses alias " alias-sym
                      " but no matching :as is declared in the ns form"))))))))
 
-;; --- Strict EP-0017 cofx mint policy guard (rf2-uzne0p) --------------------
+;; --- Strict EP-0017 cofx mint policy guard ---------------------------------
 ;;
 ;; EP-0017's strict-test posture: a generated app that later adds a
 ;; generator-backed recordable coeffect must not be able to write a green
@@ -332,8 +328,8 @@
 ;; sets `:rf.cofx/mint-policy :strict`) or an explicit
 ;; `:rf.cofx/mint-policy :strict`. This guard reads the emitted file and
 ;; fails if the strict posture is dropped, or if the supply-data /
-;; explicit-live testing idiom is no longer documented for the user. It also
-;; locks out the retired EP-0017/EP-0018 vocabulary (`:rf.world/inputs`,
+;; explicit-live testing idiom is not documented for the user. It also
+;; locks out non-EP-0017/EP-0018 vocabulary (`:rf.world/inputs`,
 ;; grouped/nested cofx, `inject-cofx`).
 
 (defn- assert-events-test-strict-mint-policy!
@@ -368,7 +364,7 @@
                  "`:rf.cofx/mint-policy :explicit-live` opt-out — the per-call "
                  "escape a test uses when it INTENTIONALLY accepts "
                  "nondeterministic generation."))
-        ;; (4) No legacy EP-0017/EP-0018 vocabulary leaks into the scaffold.
+        ;; (4) No non-EP-0017/EP-0018 vocabulary leaks into the scaffold.
         (doseq [[re what]
                 [[#":rf\.world/inputs" ":rf.world/inputs (retired — declare :rf.cofx/requires)"]
                  [#"inject-cofx"        "inject-cofx (removed — declare :rf.cofx/requires)"]]]
@@ -409,7 +405,7 @@
 
     1. `<alias>/<sym>` qualified references whose alias resolves to a
        `re-frame.*` ns (e.g. `rf/dispatch`).
-    2. Bare, `:refer`-ed framework symbols (rf2-3uqbd.2) whose source ns
+    2. Bare, `:refer`-ed framework symbols whose source ns
        is `re-frame.*` (e.g. the Reagent scaffold's `(reg-view …)`,
        brought in via `:require-macros [re-frame.core :refer [reg-view]]`
        and called unqualified). Without this, a rename of `reg-view`
@@ -458,11 +454,10 @@
         (audit-framework-symbol! substrate file root target-ns sym
                                  "refers (bare)")))))
 
-;; --- scratch.cljs with-frame shape audit (rf2-ah0gi / rf2-twoc5) -----------
+;; --- scratch.cljs with-frame shape audit -----------------------------------
 ;;
 ;; The emitted dev/scratch.cljs is the user's REPL on-ramp. The two
-;; frame-scope macros are non-overlapping (per rf2-twoc5, Mike-approved
-;; 2026-05-28):
+;; frame-scope macros are non-overlapping:
 ;;
 ;;   `with-frame`     — pin form: first arg MUST be a keyword (or
 ;;                      keyword-resolving symbol). Vector arg is a
@@ -491,8 +486,8 @@
        (= "with-new-frame" (name (first form)))))
 
 (defn- valid-with-frame-first-arg?
-  "Pin form: keyword or symbol (resolves to keyword). Vector is the
-  compile-time error rf2-twoc5 added."
+  "Pin form: keyword or symbol (resolves to keyword). A vector arg is a
+  compile-time error."
   [arg]
   (or (keyword? arg) (symbol? arg)))
 
@@ -548,7 +543,7 @@
                    "keyword argument is a compile-time error; use "
                    "`with-frame` to pin to an existing frame-id.")))))))
 
-;; --- scratch.cljs frame-context audit (rf2-f37lul) -------------------------
+;; --- scratch.cljs frame-context audit --------------------------------------
 ;;
 ;; EP-0002 removed the implicit `:rf/default` floor: a frame-scoped call
 ;; (`dispatch` / `dispatch-sync` / `subscribe`) evaluated with no
@@ -659,8 +654,8 @@
     @acc))
 
 (defn- assert-scratch-frame-context!
-  "Reject any frameless frame-scoped REPL call in the emitted scratch.cljs
-  (rf2-f37lul). Complements the first-arg shape audit above."
+  "Reject any frameless frame-scoped REPL call in the emitted scratch.cljs.
+  Complements the first-arg shape audit above."
   [substrate ^java.io.File root]
   (let [scratch (io/file root "dev/scratch.cljs")]
     (is (.isFile scratch)
@@ -678,7 +673,7 @@
                "dispatch / dispatch-sync, or the 2-arity "
                "(subscribe <frame-id> [query]) form for subscribe.")))))
 
-;; --- Xray layout-host contract audit (rf2-29zmf) ---------------------------
+;; --- Xray layout-host contract audit ---------------------------------------
 ;;
 ;; The scaffold ships an Xray layout host in the emitted
 ;; `resources/public/index.html` (`<aside data-rf-xray-host>`) and sizes
@@ -698,8 +693,8 @@
 ;;
 ;; This audit reads the *generated* HTML/CSS (not the template resource
 ;; directly) so it also catches a future templating step that mangles
-;; the host. It fails on the stale `flex: 0 0 420px` / left-column shape
-;; the scaffold shipped before rf2-29zmf.
+;; the host. It fails on a stale `flex: 0 0 420px` / left-column shape,
+;; which is not the right-side host contract.
 
 (defn- assert-xray-host-contract!
   [substrate ^java.io.File root]
@@ -771,16 +766,15 @@
                  "collapse so release builds (no Xray preload) don't ship "
                  "a blank gutter."))))))
 
-;; --- Stale Xray-layout-wording scan (rf2-qck7t7 Finding #2) ----------------
+;; --- Stale Xray-layout-wording scan ----------------------------------------
 ;;
 ;; `assert-xray-host-contract!` above pins the RUNTIME shape (DOM order +
 ;; resize CSS var) for index.html / app.css only. The prose in the other
-;; emitted text files (deps.edn / shadow-cljs.edn comments) escaped that
-;; net: they kept describing the host as a "left layout column" / "left
-;; column" long after the runtime moved to the right-side layout-host
-;; contract. This guard scans EVERY emitted text file for the stale
-;; left-side wording so a future prose regression can't ship green while
-;; the narrow runtime tests stay happy.
+;; emitted text files (deps.edn / shadow-cljs.edn comments) sits outside
+;; that net: a "left layout column" / "left column" description there would
+;; contradict the right-side layout-host contract. This guard scans EVERY
+;; emitted text file for the stale left-side wording so a prose regression
+;; can't ship green while the narrow runtime tests stay happy.
 
 (def ^:private stale-xray-wording-re
   #"(?i)left[- ]?(layout )?column")
@@ -831,19 +825,19 @@
       (finally
         (delete-recursively tmp)))))
 
-;; --- Normative spec-prose Xray-host drift guard (rf2-7s8ou3) ----------------
+;; --- Normative spec-prose Xray-host drift guard ----------------------------
 ;;
 ;; `assert-xray-host-contract!` pins the RUNTIME shape of the EMITTED
 ;; index.html / app.css, and `assert-no-stale-xray-wording!` scans the
 ;; EMITTED text tree. But the template's OWN normative capability doc —
 ;; `tools/template/spec/002-Generated-Shape.md` §Xray devtools — is not an
-;; emitted artefact, so it escaped both nets. It shipped a stale contract
-;; long after the runtime moved to the right-side host: a `[data-rf-xray-host]`
-;; `<aside>` "inside a .rf2-app-shell with .rf2-xray-host fixed at 420px and
-;; #app taking the remaining width". That left the user-facing scaffold spec
-;; describing a layout the scaffold no longer emits, while the emitted-file
-;; tests stayed green. This guard scans the spec prose directly so the stale
-;; 420px / left-side wording cannot be reintroduced into the normative doc.
+;; emitted artefact, so it sits outside both nets. A stale contract there —
+;; a `[data-rf-xray-host]` `<aside>` "inside a .rf2-app-shell with
+;; .rf2-xray-host fixed at 420px and #app taking the remaining width" —
+;; would leave the user-facing scaffold spec describing a layout the
+;; scaffold does not emit, while the emitted-file tests stay green. This
+;; guard scans the spec prose directly so the stale 420px / left-side
+;; wording cannot be reintroduced into the normative doc.
 ;;
 ;; The doc must match the published right-side host contract
 ;; (tools/xray/spec/011-Launch-Modes.md §Layout host contract), which the
@@ -863,9 +857,9 @@
         (subs doc start end)))))
 
 (deftest spec-002-xray-host-prose-current-test
-  ;; rf2-7s8ou3 — normative scaffold-contract doc must describe the
-  ;; CURRENT right-side Xray layout host, not the stale fixed-420px /
-  ;; left-column shape the scaffold shipped before rf2-29zmf.
+  ;; The normative scaffold-contract doc must describe the CURRENT
+  ;; right-side Xray layout host, not a stale fixed-420px / left-column
+  ;; shape.
   (testing "002-Generated-Shape.md §Xray devtools matches the emitted right-side host contract"
     (let [doc-file (io/file (repo-root)
                             "tools/template/spec/002-Generated-Shape.md")]
@@ -926,7 +920,7 @@
   (testing "Helix-substrate emission has well-formed ns requires and no surface drift"
     (run-for-substrate! :helix)))
 
-;; --- :include-story? (rf2-t009p) -----------------------------------------
+;; --- :include-story? -----------------------------------------------------
 ;;
 ;; The with-stories core variant and the emitted stories.cljs both
 ;; pull on `re-frame.story` — the same drift hazard as the rest of the

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -1,5 +1,6 @@
 (ns day8.re-frame2-template.template-test
-  "JVM tests for the deps-new template body (rf2-c2770, rf2-dolpf §2.2-2.4).
+  "JVM tests for the deps-new template body (003-DepsNew-Rebuild-Plan.md
+   §2.2-2.4).
 
    Strategy:
 
@@ -17,9 +18,7 @@
             day8/re-frame2-story coord
           - true on non-Reagent substrates throws with a clear message
 
-   Mirrors the surface checks that previously lived in the clj-new test
-   suite at `test/clj/new/re_frame2_test.clj` (removed in rf2-40vmd /
-   §2.5 along with the clj-new template body)."
+   Covers the same generated-surface checks across the substrate matrix."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [clojure.string :as string]
@@ -30,8 +29,7 @@
 ;; --- Test helpers ----------------------------------------------------------
 ;;
 ;; tmp-dir / delete-recursively / template-resource-dir / run-template! /
-;; read-edn / file-exists? live in the shared `test-support` ns
-;; (rf2-5v619, D1; read-edn + file-exists? lifted in rf2-ee38b.23).
+;; read-edn / file-exists? live in the shared `test-support` ns.
 
 ;; --- The expected per-substrate shape ------------------------------------
 
@@ -41,14 +39,14 @@
    "package.json"
    "README.md"
    ".gitignore"
-   ;; Dev ergonomics bundle (rf2-r2jqo).
+   ;; Dev ergonomics bundle.
    ".editorconfig"
    ".clj-kondo/config.edn"
-   ;; Formatter config (rf2-5ecqj).
+   ;; Formatter config.
    ".cljfmt.edn"
-   ;; Git pre-commit hook config (rf2-s8xee).
+   ;; Git pre-commit hook config.
    "lefthook.yml"
-   ;; Baseline CI workflow (rf2-k2z79).
+   ;; Baseline CI workflow.
    ".github/workflows/ci.yml"
    "dev/user.clj"
    "dev/scratch.cljs"
@@ -94,7 +92,7 @@
           ;; The literal pin VALUE is owned by version_lockstep_test.clj
           ;; (reads repo-root VERSION on disk); asserting a hard-coded
           ;; "0.0.1.alpha" here would duplicate it and false-fail the
-          ;; moment VERSION bumps (rf2-5v619, D3). Present-check only.
+          ;; moment VERSION bumps. Present-check only.
           (is (some? (get-in deps [:deps 'day8/re-frame2 :mvn/version]))
               "core coord carries an :mvn/version pin"))
 
@@ -111,30 +109,30 @@
               "shadow-cljs.edn :source-paths includes \"test\" so the emitted test file is discoverable")
           (is (= :node-test (:target tst))
               "shadow-cljs :test build targets :node-test")
-          ;; Xray preload (rf2-y9zqc).
+          ;; Xray preload.
           (is (some #{'day8.re-frame2-xray.preload}
                     (get-in app [:devtools :preloads]))
               "shadow-cljs :app :devtools/preloads wires Xray"))
 
-        ;; -- Xray coord in deps.edn (rf2-y9zqc) --
+        ;; -- Xray coord in deps.edn --
         (let [deps (read-edn (io/file root "deps.edn"))]
           (is (contains? (:deps deps) 'day8/re-frame2-xray)
               "deps.edn references day8/re-frame2-xray")
-          ;; Pin value owned by version_lockstep_test.clj (rf2-5v619, D3).
+          ;; Pin value owned by version_lockstep_test.clj.
           (is (some? (get-in deps [:deps 'day8/re-frame2-xray :mvn/version]))
               "Xray coord carries an :mvn/version pin"))
 
-        ;; -- Schemas coord in deps.edn (rf2-48mij) --
+        ;; -- Schemas coord in deps.edn --
         (let [deps (read-edn (io/file root "deps.edn"))]
           (is (contains? (:deps deps) 'day8/re-frame2-schemas)
               "deps.edn references day8/re-frame2-schemas (best-practice
                whole-app-db schema needs the artefact on the classpath
                for CLJS validation to fire)")
-          ;; Pin value owned by version_lockstep_test.clj (rf2-5v619, D3).
+          ;; Pin value owned by version_lockstep_test.clj.
           (is (some? (get-in deps [:deps 'day8/re-frame2-schemas :mvn/version]))
               "schemas coord carries an :mvn/version pin"))
 
-        ;; -- Best-practice surface in events.cljs + schema.cljs (rf2-48mij) --
+        ;; -- Best-practice surface in events.cljs + schema.cljs --
         (let [events-text (slurp (io/file root "src/acme/my_app/events.cljs"))
               schema-text (slurp (io/file root "src/acme/my_app/schema.cljs"))
               core-text   (slurp (io/file root "src/acme/my_app/core.cljs"))]
@@ -162,12 +160,12 @@
               "schema.cljs registers a whole-app-db schema")
           (is (.contains schema-text "CounterDb")
               "schema.cljs ships the CounterDb Malli schema")
-          ;; -- Emitted source must not teach the retired positional
-          ;;    reg-app-schema grammar (rf2-wvh95f F2 :schema-in-metadata).
+          ;; -- Emitted source must not teach the positional
+          ;;    reg-app-schema grammar (schema-in-metadata).
           ;; The schema lives in the metadata map's :schema key; a bare
-          ;; positional schema now throws :rf.error/bad-app-schema-metadata.
-          ;; Scan emitted source comments too — events.cljs's schema-load
-          ;; comment previously cited the stale (reg-app-schema [] CounterDb).
+          ;; positional schema throws :rf.error/bad-app-schema-metadata.
+          ;; Scan emitted source comments too, so events.cljs's schema-load
+          ;; comment cannot cite the stale (reg-app-schema [] CounterDb).
           (is (not (.contains events-text "(reg-app-schema [] CounterDb)"))
               "events.cljs must NOT cite the retired positional
                (reg-app-schema [] CounterDb) form in a comment — the
@@ -182,7 +180,7 @@
                (rf/reg-app-schema [] {:schema CounterDb})")
 
           ;; -- EP-0011: HTTP exemplar names the uniform reply envelope
-          ;;    lowering + the compat-sugar distinction (rf2-rzsxrk) --
+          ;;    lowering + the compat-sugar distinction --
           ;; The exemplar must say the (:rf/reply msg)/{:kind …} payload is
           ;; managed-HTTP public compatibility SUGAR that lowers onto the
           ;; framework-wide uniform reply envelope, and must name the
@@ -205,13 +203,12 @@
               "events.cljs HTTP exemplar names the canonical :completed-at
                reply fact (EP-0011 — rf2-rzsxrk)")
 
-          ;; -- EP-0015: events.cljs decode-body classification guidance
-          ;;    (rf2-7i66d0) --
+          ;; -- EP-0015: events.cljs decode-body classification guidance --
           ;; The :decode :auto exemplar must say it is the simple
           ;; non-sensitive case and point real bodies at a :decode SCHEMA
           ;; with :sensitive? / :large? props + the unschematized
-          ;; fail-closed posture, so the scaffold cannot drift back to the
-          ;; pre-EP-0015 "decode :auto is the whole story" framing.
+          ;; fail-closed posture, so the scaffold cannot drift to a
+          ;; "decode :auto is the whole story" framing.
           (is (.contains events-text ":sensitive?")
               "events.cljs decode note names per-slot :sensitive? schema
                props for sensitive HTTP response bodies (EP-0015 — rf2-7i66d0)")
@@ -220,7 +217,7 @@
                whole-sensitive / fail-closed (EP-0015 — rf2-7i66d0)")
 
           ;; -- EP-0015: frame-owned classification pointer at the reg-frame
-          ;;    site + schema-is-shape-not-egress note (rf2-7i66d0) --
+          ;;    site + schema-is-shape-not-egress note --
           ;; core.cljs must point the user at frame-owned egress
           ;; classification where it registers :rf/default, and schema.cljs
           ;; must state that schemas validate shape, NOT durable app-db
@@ -250,12 +247,12 @@
             :helix   (is (.contains views-text "defnc")
                          "Helix views.cljs uses defnc")))
 
-        ;; -- Per-substrate README badge (rf2-sufwn) --
+        ;; -- Per-substrate README badge --
         ;;
-        ;; The badge LINE varies by substrate, so it stays in the
+        ;; The badge LINE varies by substrate, so it lives in the
         ;; per-substrate shape test. The substrate-INVARIANT README/CI/
-        ;; security text moved to `root-content-test` below — it comes
-        ;; from `root/` and was needlessly re-run 3× (rf2-5v619, L3).
+        ;; security text lives in `root-content-test` below — it comes
+        ;; from `root/`, so it is asserted once rather than per substrate.
         (let [readme-text (slurp (io/file root "README.md"))]
           (is (.contains readme-text
                          (case substrate
@@ -276,7 +273,7 @@
     (let [tmp (tmp-dir "rf2-template-root-content-")]
       (try
         (let [root (run-template! tmp "acme/my-app" :reagent)]
-          ;; -- README best-practice + naming sections (rf2-48mij) --
+          ;; -- README best-practice + naming sections --
           (let [readme-text (slurp (io/file root "README.md"))]
             (is (.contains readme-text "Best practices baked into the scaffold")
                 "README has a Best practices section")
@@ -291,12 +288,12 @@
             (is (.contains readme-text "spec/Conventions.md")
                 "README links to spec/Conventions.md for the normative catalogue"))
 
-          ;; -- README Hot reload — accurate reg-* cleanup claim (rf2-n70mno) --
+          ;; -- README Hot reload — accurate reg-* cleanup claim --
           ;; The runtime registry only adds / same-id-replaces on reload; a
           ;; deleted or renamed reg-* form's old (kind, id) is NOT pruned by
           ;; a plain shadow-cljs reload — it lingers until a browser/dev-
-          ;; process refresh. The README previously over-promised that a
-          ;; rename/remove "drops the old registration". Reject the stale
+          ;; process refresh. The README must not over-promise that a
+          ;; rename/remove "drops the old registration". Reject that
           ;; phrase and positively require the explicit-refresh recovery.
           ;; Scope the assertions to the Hot reload section.
           (let [readme-text (slurp (io/file root "README.md"))
@@ -324,7 +321,7 @@
                  browser/dev-process refresh rebuilds the registry from
                  an empty slate (rf2-n70mno)"))
 
-          ;; -- README EP-0015 privacy/egress classification (rf2-7i66d0) --
+          ;; -- README EP-0015 privacy/egress classification --
           ;; The README must carry a concise privacy/egress section that
           ;; distinguishes app-db schemas (shape) from frame-owned durable
           ;; classification (:sensitive / :large on reg-frame), and shows
@@ -354,7 +351,7 @@
                 "README privacy section links Spec 015 for the normative
                  classification model (EP-0015 — rf2-7i66d0)"))
 
-          ;; -- README EP-0011 HTTP reply-envelope lowering (rf2-rzsxrk) --
+          ;; -- README EP-0011 HTTP reply-envelope lowering --
           ;; The README HTTP section must name the lowering: the {:kind …}
           ;; payload is managed-HTTP compatibility sugar over the uniform
           ;; reply envelope, mapping HTTP outcomes onto canonical :status
@@ -389,14 +386,14 @@
                 "README HTTP section names :decode-schema :sensitive? props
                  for sensitive response bodies (EP-0015 — rf2-7i66d0)"))
 
-          ;; -- README substrate-invariant badges (rf2-sufwn) --
+          ;; -- README substrate-invariant badges --
           (let [readme-text (slurp (io/file root "README.md"))]
             (is (.contains readme-text "img.shields.io/badge/built")
                 "README ships a 'built with re-frame2' badge")
             (is (.contains readme-text "License-MIT")
                 "README ships a License badge"))
 
-          ;; -- README hot-reload contract accuracy (rf2-8n4s71 #2) --
+          ;; -- README hot-reload contract accuracy --
           ;; The generated README MUST describe the ACTUAL rf/init!
           ;; contract (implementation/core/src/re_frame/core.cljc init!;
           ;; pinned by implementation/core/test/re_frame/boot_test.clj):
@@ -406,13 +403,12 @@
           ;; init! docstring). The scaffold's core/init registers the frame
           ;; explicitly via (rf/reg-frame :rf/default {}) after init!. A
           ;; second init! call does NOT re-install the adapter, snapshot the
-          ;; registrar, or reset app-db. The earlier README overstated this
+          ;; registrar, or reset app-db. The README must NOT overstate this
           ;; ("each call to init! snapshots the registrar, re-installs the
-          ;; adapter, and resets the frame's app-db") AND wrongly claimed
-          ;; init! "ensures the :rf/default frame exists" (rf2-frex1l) —
-          ;; both teach a false mental model. The reset boundary is the
-          ;; starter's explicit dispatch-sync [:counter/initialise] in
-          ;; core.cljs, not init!.
+          ;; adapter, and resets the frame's app-db") NOR claim init!
+          ;; "ensures the :rf/default frame exists" — both teach a false
+          ;; mental model. The reset boundary is the starter's explicit
+          ;; dispatch-sync [:counter/initialise] in core.cljs, not init!.
           (let [readme-text (slurp (io/file root "README.md"))
                 ;; Scope the false-claim greps to the Hot reload section
                 ;; (from its heading to the next ## heading) so an honest
@@ -443,7 +439,7 @@
                 "README Hot reload section must NOT claim rf/init! resets
                  app-db by itself — the explicit dispatch-sync
                  [:counter/initialise] is the reset boundary (rf2-8n4s71 #2)")
-            ;; -- README init!/:rf/default contract (rf2-frex1l) --
+            ;; -- README init!/:rf/default contract --
             ;; init! does NOT create :rf/default (EP-0002); the scaffold's
             ;; core/init registers it explicitly via reg-frame. core.cljc
             ;; init! docstring + the emitted core.cljs pin this.
@@ -457,7 +453,7 @@
                  :rf/default frame and that reg-frame registers it explicitly
                  (EP-0002; rf2-frex1l)"))
 
-          ;; -- README schema registration is frame-scoped (rf2-frex1l) --
+          ;; -- README schema registration is frame-scoped --
           ;; reg-app-schema is frame-local (EP-0002); a frameless ns-load
           ;; call raises :rf.error/no-frame-context (schemas/storage.cljc
           ;; reg-app-schema). The emitted schema.cljs wraps it in
@@ -484,13 +480,13 @@
                  a register-schema! fn called under (with-frame :rf/default …)
                  (mirrors the emitted schema.cljs / core.cljs; rf2-frex1l)"))
 
-          ;; -- README Xray host wording — right-side, not left (rf2-8n4s71 #3) --
+          ;; -- README Xray host wording — right-side, not left --
           ;; The emitted index.html orders <main id="app"> BEFORE
           ;; <aside data-rf-xray-host> and app.css documents/implements a
           ;; RIGHT-side host (pinned by the Xray layout-host audit in
           ;; template_emission_test.clj; matches
-          ;; tools/xray/spec/011-Launch-Modes.md). The README must agree
-          ;; — it previously said "left layout column", contradicting the
+          ;; tools/xray/spec/011-Launch-Modes.md). The README must agree:
+          ;; a "left layout column" description would contradict the
           ;; emitted layout + the Xray spec.
           (let [readme-text (slurp (io/file root "README.md"))]
             (is (not (.contains readme-text "left layout column"))
@@ -502,7 +498,7 @@
                  (matches the emitted index.html/app.css + Xray spec —
                  rf2-8n4s71 #3)"))
 
-          ;; -- Baseline CI workflow (rf2-k2z79) --
+          ;; -- Baseline CI workflow --
           (let [ci-text (slurp (io/file root ".github/workflows/ci.yml"))]
             (is (.contains ci-text "name: ci")
                 ".github/workflows/ci.yml declares the ci workflow")
@@ -527,8 +523,7 @@
             ;; `${{ … }}` expressions untouched because no subst key
             ;; matches the spaced inner token. Pin that invariant so a
             ;; future data key collision or substitution-engine change
-            ;; that corrupts the workflow expressions is caught here
-            ;; (rf2-ee38b.23 / correctness P3).
+            ;; that corrupts the workflow expressions is caught here.
             (is (.contains ci-text "${{ runner.os }}")
                 "ci.yml's GitHub `${{ runner.os }}` expression survives
                  substitution verbatim (not eaten by deps-new {{key}}
@@ -537,14 +532,14 @@
                 "ci.yml's GitHub `${{ hashFiles(...) }}` expression
                  survives substitution verbatim"))
 
-          ;; -- Security baseline (rf2-sh3l8; CSP-runtime parity rf2-l4prz) --
+          ;; -- Security baseline (CSP-runtime parity) --
           (let [index-text  (slurp (io/file root "resources/public/index.html"))
                 ;; The actual CSP policy is the `content="…"` attribute of
                 ;; the CSP meta tag — NOT the surrounding HTML comment
                 ;; (which legitimately discusses directives like
                 ;; frame-ancestors). Pull just the policy string so the
                 ;; directive assertions below test the live policy, not
-                ;; documentation prose (rf2-l4prz).
+                ;; documentation prose.
                 csp-policy  (some-> (re-find #"http-equiv=\"Content-Security-Policy\"\s+content=\"([^\"]*)\""
                                              index-text)
                                     second)
@@ -560,7 +555,7 @@
             (is (.contains index-text "data-rf-xray-host")
                 "index.html provides Xray's default true-inline layout host")
 
-            ;; rf2-l4prz Finding 2 — the dev meta CSP MUST permit inline
+            ;; The dev meta CSP MUST permit inline
             ;; styles: the generated views use inline :style props and the
             ;; default-on Xray surface injects <style> blocks + inline
             ;; styles. A strict `style-src 'self'` would emit CSP
@@ -572,13 +567,12 @@
                  views + default-on Xray both rely on them — rf2-l4prz
                  Finding 2)")
 
-            ;; rf2-l4prz Finding 3 — `frame-ancestors` delivered via a
-            ;; <meta> tag is IGNORED by browsers; only a response header
-            ;; honours it. Asserting it on the meta tag (as the old test
-            ;; did) was a false anti-clickjacking pass. The CSP POLICY must
-            ;; NOT carry frame-ancestors; the anti-clickjacking contract
-            ;; lives in the README's response-header snippets, asserted
-            ;; below. (The HTML comment may mention it — we test the
+            ;; `frame-ancestors` delivered via a <meta> tag is IGNORED by
+            ;; browsers; only a response header honours it. Asserting it on
+            ;; the meta tag would be a false anti-clickjacking pass. The CSP
+            ;; POLICY must NOT carry frame-ancestors; the anti-clickjacking
+            ;; contract lives in the README's response-header snippets,
+            ;; asserted below. (The HTML comment may mention it — we test the
             ;; policy string, not the file.)
             (is (not (.contains csp-policy "frame-ancestors"))
                 "index.html meta CSP policy does NOT carry frame-ancestors —
@@ -623,7 +617,7 @@
   (testing ":substrate :helix produces the expected tree"
     (assert-shape! :helix)))
 
-;; --- Name derivation (rf2-ynjts.22) --------------------------------------
+;; --- Name derivation -----------------------------------------------------
 ;;
 ;; Every other test in this suite scaffolds `acme/my-app` — a project
 ;; name with a single-segment group (no dots) and a single-dash artifact.
@@ -725,8 +719,8 @@
             coercion replaces the earlier forgiving-input posture)."
     (let [tmp (tmp-dir "rf2-template-non-kw-")]
       (try
-        ;; String form — previously coerced silently to :reagent;
-        ;; now rejected so registration errors surface immediately.
+        ;; String form — rejected so registration errors surface
+        ;; immediately rather than being coerced silently to :reagent.
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #":rf\.error/template-substrate-must-be-keyword"
                               (run-template! tmp "acme/my-app" "reagent"))
@@ -744,7 +738,7 @@
         (finally
           (delete-recursively tmp))))))
 
-;; --- :include-story? flag (rf2-t009p / rf2-dolpf §2.4) -------------------
+;; --- :include-story? flag (003-DepsNew-Rebuild-Plan.md §2.4) -------------
 
 (deftest default-path-emits-no-story-files-test
   (testing "default path (no :include-story?) does not emit stories.cljs
@@ -804,13 +798,11 @@
                 pkg-txt (slurp (io/file root "package.json"))]
             (is (contains? (:deps deps) 'day8/re-frame2-story)
                 "deps.edn references day8/re-frame2-story")
-            ;; Pin value owned by version_lockstep_test.clj (rf2-5v619, D3).
+            ;; Pin value owned by version_lockstep_test.clj.
             (is (some? (get-in deps [:deps 'day8/re-frame2-story :mvn/version]))
                 "story coord carries an :mvn/version pin")
-            ;; rf2-ymnfx Issue B retired the Share popover (and the
-            ;; vendored qrcode-generator npm dep that backed its local
-            ;; QR encoder); the with-Story template no longer declares
-            ;; any Story-specific npm dependency.
+            ;; The with-Story template declares no Story-specific npm
+            ;; dependency — there is no vendored qrcode-generator dep.
             (is (not (.contains pkg-txt "\"qrcode-generator\""))
                 "package.json does NOT declare qrcode-generator (Share
                  popover + QR encoder retired in rf2-ymnfx Issue B)"))
@@ -825,7 +817,7 @@
             (is (.contains core-text "acme.my-app.stories")
                 "with-stories core.cljs requires the stories ns so its
                  reg-* calls fire at boot")
-            ;; rf2-l4prz Finding 4 — `init` runs on every hot-reload, and
+            ;; `init` runs on every hot-reload, and
             ;; the hashchange listener's closure identity changes per
             ;; rebuild. Without a defonce-held listener + removeEventListener
             ;; before re-adding, reloads accumulate stale listeners (each
@@ -865,9 +857,9 @@
         (finally
           (delete-recursively tmp))))))
 
-;; --- with-Story release elision: config ⇆ docs agreement (rf2-l4prz) -----
+;; --- with-Story release elision: config ⇆ docs agreement -----------------
 ;;
-;; Finding 1: the with-Story core docstring + the generated README must
+;; The with-Story core docstring + the generated README must
 ;; NOT claim that `npx shadow-cljs release app` elides Story
 ;; automatically / for free. It does NOT — `re-frame.story.config/enabled?`
 ;; defaults true and the emitted shadow-cljs.edn sets no `:release`
@@ -882,9 +874,9 @@
 ;;       docs would need to flip to "automatic" and this test reminds us);
 ;;   (b) the with-Story core docstring + README both carry the exact
 ;;       opt-in closure-define string AND flag it as opt-in;
-;;   (c) neither doc carries the retired false-automatic claims
+;;   (c) neither doc carries a false-automatic claim
 ;;       ("inherits that elision automatically" / "costs nothing in
-;;       production") that asserted free release elision.
+;;       production") that would promise free release elision.
 
 (deftest with-story-release-elision-docs-config-agree-test
   (testing "with-Story scaffold: the release-elision docs (core docstring
@@ -926,11 +918,11 @@
                 (str label " marks Story release elision as OPT-IN "
                      "(not automatic) (rf2-l4prz Finding 1)")))
 
-          ;; (c) The retired false-automatic claims must be gone from both
-          ;;     docs — these asserted free/automatic release elision.
+          ;; (c) The false-automatic claims must be absent from both
+          ;;     docs — they would assert free/automatic release elision.
           ;;     `inherits that elision automatically` (whitespace-folded)
-          ;;     and `costs nothing in production` were the two phrases
-          ;;     that promised a free/automatic release elision.
+          ;;     and `costs nothing in production` are the two phrases
+          ;;     that would promise a free/automatic release elision.
           (doseq [[label text] [["with-Story core.cljs" core-text]
                                 ["README" readme]]]
             (let [folded (clojure.string/replace text #"\s+" " ")]
@@ -944,7 +936,7 @@
         (finally
           (delete-recursively tmp))))))
 
-;; --- package.json one-source byte-exact contract (rf2-sqqxj) -------------
+;; --- package.json one-source byte-exact contract -------------------------
 ;;
 ;; The template emits package.json from a SINGLE `_shared/package.json`
 ;; source whose `description` parenthetical rides the `{{story-tag}}`
@@ -1067,7 +1059,7 @@
         (finally
           (delete-recursively tmp))))))
 
-;; --- argument-key gate (rf2-qck7t7 Finding #1) ----------------------------
+;; --- argument-key gate ----------------------------------------------------
 ;;
 ;; The substrate posture fails closed on bad VALUES; these tests pin the
 ;; complementary strictness on the KEY set. Reserved-but-unimplemented

--- a/tools/template/test/day8/re_frame2_template/test_support.clj
+++ b/tools/template/test/day8/re_frame2_template/test_support.clj
@@ -1,22 +1,17 @@
 (ns day8.re-frame2-template.test-support
-  "Shared harness for the tools/template JVM test suite (rf2-5v619, D1).
+  "Shared harness for the tools/template JVM test suite.
 
    The four sibling test files
    (`template_test.clj` / `template_emission_test.clj` /
-   `emitted_test_run_test.clj` / `version_lockstep_test.clj`) each used
-   to carry their own copies of `tmp-dir` / `delete-recursively` /
-   `template-resource-dir` / `run-template!` / `repo-root` — ~250 lines
-   of duplicated, stateless harness with three slightly-different
-   `repo-root` impls that drifted independently. These are pure
-   functions with no top-level mutable state, so the earlier
-   'kept-independent-to-avoid-state-sharing' rationale didn't hold;
-   they belong in one place.
+   `emitted_test_run_test.clj` / `version_lockstep_test.clj`) all draw
+   `tmp-dir` / `delete-recursively` / `template-resource-dir` /
+   `run-template!` / `repo-root` from here. These are pure functions with
+   no top-level mutable state, so a single shared copy is the right home.
 
-   `repo-root` is unified to a single walk-up that anchors on
-   `implementation/core/src/re_frame` (the strongest, deepest marker
-   the old impls used). The version-lockstep test previously anchored
-   on `implementation/package.json`; both files live under the same
-   repo root, so the deeper marker subsumes it."
+   `repo-root` is a single walk-up that anchors on
+   `implementation/core/src/re_frame` — the strongest, deepest repo
+   marker. `implementation/package.json` lives under the same repo root,
+   so this deeper marker subsumes it for every caller."
   (:require [clojure.java.io :as io]
             [clojure.edn :as edn]
             [clojure.string :as string]
@@ -28,9 +23,8 @@
 ;; --- emitted-file readers --------------------------------------------------
 ;;
 ;; `read-edn` / `file-exists?` are tiny one-liners that every test which
-;; walks an emitted project re-implements. Homed here (rf2-ee38b.23,
-;; clarity P3) so the next "read the emitted deps.edn" call doesn't
-;; re-inline `slurp` + `read-string`.
+;; walks an emitted project needs. Homed here so the next "read the
+;; emitted deps.edn" call doesn't re-inline `slurp` + `read-string`.
 
 (defn read-edn
   "Parse `f` (a `java.io.File`) as a single EDN value."
@@ -120,7 +114,7 @@
   `clojure -X:test` invocation must also work — so we walk up from
   `user.dir` until we find a directory with a
   `implementation/core/src/re_frame` child (the deepest, most
-  unambiguous repo marker the old per-file impls used)."
+  unambiguous repo marker)."
   []
   (loop [d (io/file (System/getProperty "user.dir"))]
     (cond
@@ -177,9 +171,9 @@
   "Like `run-template!`, but merges `extra-opts` straight onto the
   deps-new opts map — so a test can pass arbitrary template arguments
   (reserved flags, typo keys, …) that the positional `run-template!`
-  arity can't express. Used by the argument-gate negative tests
-  (rf2-qck7t7): they assert reserved / unknown keys fail closed before
-  any scaffold is emitted."
+  arity can't express. Used by the argument-gate negative tests: they
+  assert reserved / unknown keys fail closed before any scaffold is
+  emitted."
   [tmp project-name extra-opts]
   (let [dir-str   (.toString ^Path tmp)
         dir-name  (-> project-name name (string/replace #"^.*?/" ""))

--- a/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
+++ b/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
@@ -1,7 +1,5 @@
 (ns day8.re-frame2-template.version-lockstep-test
-  "Pin-lockstep guard for the template's inline version literals
-  (rf2-0kcsu; deps-new port for rf2-c2770; substrate + clojure(script)
-  pins added rf2-jdj17.3).
+  "Pin-lockstep guard for the template's inline version literals.
 
   Principle P5 (tools/template/spec/Principles.md) declares that the
   template's pin literals are bumped in lockstep with their external
@@ -12,20 +10,19 @@
     - `:shadow-version` ↔ `implementation/package.json` shadow-cljs
     - `:react-version`  ↔ `implementation/package.json` react (and react-dom)
 
-  rf2-jdj17.3 — the substrate-lib + clojure(script) pins are now guarded
-  too (they were latent-only before: the emitted-app smoke compiles
-  against the TEMPLATE's own pin, never the impl tree's, so a drift was
-  invisible to every gate):
+  The substrate-lib + clojure(script) pins are guarded too. They need an
+  explicit guard because the emitted-app smoke compiles against the
+  TEMPLATE's own pin, never the impl tree's, so a drift between them would
+  otherwise be invisible to every gate:
 
     - reagent/reagent          ↔ `implementation/core/deps.edn` :deps
     - com.pitch/uix.core       ↔ `implementation/adapters/uix/deps.edn` :deps
     - com.pitch/uix.dom        ↔ `implementation/adapters/uix/deps.edn`
                                   :test alias :extra-deps (the shipped
-                                  uix adapter does NOT require uix.dom —
-                                  rf2-sl7ml — so the impl pin lives in
-                                  the test/testbed classpath; the
-                                  template's :app needs it for its DOM
-                                  mount)
+                                  uix adapter does NOT require uix.dom, so
+                                  the impl pin lives in the test/testbed
+                                  classpath; the template's :app needs it
+                                  for its DOM mount)
     - lilactown/helix          ↔ `implementation/adapters/helix/deps.edn` :deps
     - org.clojure/clojure      ↔ `implementation/core/deps.edn` :deps
     - org.clojure/clojurescript ↔ `implementation/core/deps.edn` :deps
@@ -43,11 +40,10 @@
   `:devDependencies` (first hit wins) so the guard doesn't false-fail
   if the impl tree ever relocates a pin between the two sections.
 
-  History (rf2-8v20r): the template literal `:react-version` drifted to
-  `18.3.1` while `implementation/package.json` had moved to `19.2.0`.
-  Doctrine was right; the literal silently drifted with no automated
-  check. This test reads both sources of truth on disk and asserts the
-  entry-fn literals match, so the next bump can't drift silently.
+  Without an automated check a template literal such as `:react-version`
+  can silently drift away from `implementation/package.json`. This test
+  reads both sources of truth on disk and asserts the entry-fn literals
+  match, so a bump on one side can't drift silently from the other.
 
   The test runs free (JVM, no shadow), under the standard
   `clojure -M:test` invocation."
@@ -61,7 +57,7 @@
 ;; --- Helpers ---------------------------------------------------------------
 ;;
 ;; repo-root / run-template! / tmp-dir / delete-recursively live in the
-;; shared `test-support` ns (rf2-5v619, D1). repo-root anchors on
+;; shared `test-support` ns. repo-root anchors on
 ;; `implementation/core/src/re_frame` — the same repo root that holds
 ;; VERSION + implementation/package.json read below.
 
@@ -96,8 +92,7 @@
   shadow-cljs sit in `:devDependencies` (it is a test target, not a
   shipped lib), but if any of them ever moves to `:dependencies` the
   guard keeps working rather than false-failing the template suite for
-  a reason unrelated to the template (rf2-ee38b.23 / completeness +
-  correctness P3).
+  a reason unrelated to the template.
 
   We deliberately use a simple regex parse rather than dragging in a
   JSON library — the template test artefact has no JSON dep today, and
@@ -164,10 +159,8 @@
 ;;
 ;; Emission uses the shared `run-template!` (test-support) — the
 ;; pin literals are substrate-invariant, so the Reagent default path
-;; recovers them. (Previously a local `emit-reagent!` re-implemented
-;; the same `org.corfield.new/create` opts map; folded into the shared
-;; helper per rf2-jkake.22, keeping the rf2-5v619 D1 'one harness'
-;; posture.)
+;; recovers them. One harness drives every emission rather than a
+;; per-test re-implementation of the `org.corfield.new/create` opts map.
 
 (defn- extract-pin
   "Pull `\"pkg\": \"value\"` out of the emitted package.json text.
@@ -242,7 +235,7 @@
         (finally
           (delete-recursively tmp))))))
 
-;; --- substrate + clojure(script) lockstep (rf2-jdj17.3) -----------------
+;; --- substrate + clojure(script) lockstep --------------------------------
 ;;
 ;; The emitted deps.edn is valid EDN, so we read the pin straight off the
 ;; parsed map rather than regexing the text. `emit-deps-pin` generates
@@ -276,8 +269,8 @@
         (finally (delete-recursively tmp))))
 
     ;; com.pitch/uix.core — impl source of truth is adapters/uix/deps.edn :deps.
-    ;; com.pitch/uix.dom — the shipped uix adapter does NOT require uix.dom
-    ;; (rf2-sl7ml), so the impl pin lives in the :test alias's :extra-deps;
+    ;; com.pitch/uix.dom — the shipped uix adapter does NOT require uix.dom,
+    ;; so the impl pin lives in the :test alias's :extra-deps;
     ;; the template's :app build needs it for the DOM mount, so the template
     ;; pins it in :deps. Both must ride the same impl pin.
     (let [impl-uix-core (read-impl-deps-pin "implementation/adapters/uix/deps.edn"

--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -1,7 +1,6 @@
 (ns re-frame.testbed.config
   "Shared testbed-config helper — derives the on-disk source-root the
-  Xray / Story testbeds hand to their 'open in editor' resolvers
-  (rf2-5dphw).
+  Xray / Story testbeds hand to their 'open in editor' resolvers.
 
   ## Two roots, named for what they are
 
@@ -16,24 +15,23 @@
     the *output* `resolve-source-root` returns — the root the editor-URI
     composer prepends to a classpath-relative `:file` slot.
 
-  Keeping the two names distinct removes the overload that an earlier
-  `project-root`-everywhere vocabulary forced on the reader (input and
-  output both spelled 'root').
+  Keeping the two names distinct keeps input and output from both being
+  spelled 'root', which would overload the reader.
 
   ## Why this exists
 
   Xray and Story turn a source-coord (`standard_epochs/core.cljs:42`) into an
-  editor URI by prepending an on-disk *source root*. SHIPPED code reads
+  editor URI by prepending an on-disk *source root*. Shipped code reads
   that root from host config (`xray-config/configure!` /
-  `story/configure!`); there is no baked default. But the dev testbeds
-  that drive Xray / Story have to PASS a root to `configure!`, and they
-  previously each hardcoded the author's absolute Windows checkout
-  (`C:/Users/me/code/my-app/tools/xray/testbeds`) as that value —
-  six copies of one machine-specific string. On any other clone, any
-  other directory, and every Mac/Linux maintainer, 'open in editor'
-  resolved to a path that does not exist.
+  `story/configure!`); there is no baked default. The dev testbeds that
+  drive Xray / Story have to PASS a root to `configure!`, and that root
+  cannot be a hardcoded absolute checkout (e.g.
+  `C:/Users/me/code/my-app/tools/xray/testbeds`): on any other clone, any
+  other directory, and every Mac/Linux maintainer, such a literal resolves
+  'open in editor' to a path that does not exist. This helper derives the
+  root cross-platform from the build environment instead.
 
-  ## The fix (cross-platform, build-env derived)
+  ## How the root is derived (cross-platform, build-env derived)
 
   `checkout-root` is a `goog-define`d string, default `\"\"`. The dev launcher
   (`implementation/scripts/dev-testbed.cjs`, wired as the `dev` npm
@@ -47,13 +45,13 @@
 
   `resolve-source-root` then joins that checkout root with the
   tool-relative testbed subdir (`\"tools/xray/testbeds\"` /  `\"tools/story/testbeds\"`)
-  the caller passes. A `?checkout-root=<checkout>` query string still wins
+  the caller passes. A `?checkout-root=<checkout>` query string wins
   as the per-session escape hatch (CI, a reader on a different machine, a
   testbed served from a copied bundle) — it names the same thing as the
   build-time root (a CHECKOUT root) and has the subdir appended the same
   way, so the composed editor URI reaches the tool source root
   (`<checkout>/tools/xray/testbeds`) the classpath-relative source coords
-  resolve against (rf2-w4yw9q). When neither the override nor the
+  resolve against. When neither the override nor the
   build-time root is present, this returns `nil` and the testbed simply
   configures no root — 'open in editor' degrades to a no-op rather than a
   broken link, exactly the graceful-absence behaviour
@@ -98,7 +96,7 @@
   non-blank — or nil when the param is absent, blank, or the search string
   itself is blank/nil.
 
-  Decoding semantics (rf2-xdsat.1): a literal `+` in the value is preserved
+  Decoding semantics: a literal `+` in the value is preserved
   VERBATIM, NOT decoded to a space. The override names an on-disk checkout
   root, so a checkout at e.g. `/home/dev/re-frame2+wip` must round-trip
   through `?checkout-root=/home/dev/re-frame2+wip` with the `+` intact. We
@@ -164,9 +162,9 @@
   `%5C`-decoded Windows override root, e.g.
   `C:\\Users\\me\\code\\re-frame2\\`) becomes `/` — so a Windows
   `?checkout-root=` value joins exactly like a POSIX one rather than
-  yielding a `\\/` boundary (`C:\\...\\/tools/xray/testbeds`) that relied
-  on downstream tolerant path normalisation. `root` then has any single
-  trailing slash stripped (so `/repo/` + `sub` never yields `/repo//sub`);
+  yielding a `\\/` boundary (`C:\\...\\/tools/xray/testbeds`) that would
+  depend on downstream tolerant path normalisation. `root` then has any
+  single trailing slash stripped (so `/repo/` + `sub` never yields `/repo//sub`);
   `subdir` is trimmed and any leading slash(es) removed (so callers may
   pass it with or without a leading slash). A blank / nil / slash-only
   `subdir` collapses to the normalised root verbatim.
@@ -177,10 +175,9 @@
   blank relative path), so it is the only case where `normalized-root`
   ends in `/`. We therefore add the boundary separator only when the
   root does not already supply one, so `\"/\"` + `\"tools/xray/testbeds\"`
-  yields `/tools/xray/testbeds` (exactly one separator) rather than the
-  `//tools/xray/testbeds` the unconditional `(str root \"/\" subdir)`
-  produced — honouring the single-separator contract for every root,
-  POSIX filesystem-root included (rf2-fzgcii)."
+  yields `/tools/xray/testbeds` (exactly one separator) rather than
+  `//tools/xray/testbeds` — honouring the single-separator contract for
+  every root, POSIX filesystem-root included."
   [root subdir]
   (let [normalized-root   (-> root str/trim to-forward-slashes strip-trailing-slash)
         normalized-subdir (-> (or subdir "")
@@ -208,7 +205,7 @@
   relative to the testbed source root `<checkout>/tools/xray/testbeds`).
   The result must therefore reach down to that source root, or the composed
   editor URI misses the tool source-root segment and points at a nonexistent
-  file (rf2-w4yw9q). The override and the build-time define mean the
+  file. The override and the build-time define mean the
   same thing — a checkout root — so they share one join.
 
   Resolution order:

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -1,5 +1,5 @@
 (ns re-frame.testbed.open-in-editor-server
-  "Dev-server 'open in editor' endpoint (Option B, rf2-wn3bh).
+  "Dev-server 'open in editor' endpoint (Option B).
 
   The JS-ecosystem standard for jump-to-source is a dev-server endpoint:
   Vite's `/__open-in-editor`, react-dev-utils' `launchEditorEndpoint`,
@@ -26,14 +26,14 @@
 
   ## Why server-side beats the editor:// URI scheme
 
-  The historic open-in-editor path (still kept as the fallback — see
+  The editor:// open-in-editor path (kept as the fallback — see
   `day8.re-frame2-xray.open-in-editor` / `re-frame.story.ui.open-in-editor`)
   builds an `editor://file/<abs-path>:<line>:<column>` URI and hands it to
   `window.location`. That works zero-config for the common local-build
-  case (rf2-wvsxg bakes the absolute path in at macro-expansion time), but
-  it has two residual gaps Option B closes:
+  case (`absolutise-file` bakes the absolute path in at macro-expansion
+  time), but it has two residual gaps Option B closes:
 
-    1. `absolutise-file` (rf2-wvsxg) can only absolutise coords whose
+    1. `absolutise-file` can only absolutise coords whose
        sources are classpath `file:` resources — sources consumed as JARs
        / in-jar / unusual classpaths leave a RELATIVE `:file` that needs a
        manual `:project-root`. This endpoint resolves the relative file
@@ -60,7 +60,7 @@
   and passes the resolved `<abs-path>:<line>:<column>` string plus an
   optional editor-command hint. `launch-editor` parses the `:line:column`
   suffix itself and builds the per-editor argument shape (it handles every
-  OS + editor, superseding the per-editor `editor://` scheme table). The
+  OS + editor, so no per-editor `editor://` scheme table is needed). The
   editor hint maps the configured editor keyword (`:vscode`/`:cursor`/…)
   to the editor's launch command; when no hint is given launch-editor
   auto-detects the running editor (and honours `$LAUNCH_EDITOR`)."
@@ -106,7 +106,7 @@
   (when (and (string? editor) (not (str/blank? editor)))
     (get editor-command-by-keyword (str/lower-case (str/trim editor)))))
 
-;; ---- runtime :file resolution (mirrors absolutise-file, rf2-wvsxg) -------
+;; ---- runtime :file resolution (mirrors absolutise-file) ------------------
 ;;
 ;; The server runs on the dev JVM with the full shadow-cljs classpath, so
 ;; a classpath-relative `:file` (the common macro-captured shape — e.g.
@@ -280,8 +280,8 @@
 ;;      a `http://localhost:8042` Origin and passes. (A same-origin POST may
 ;;      omit Origin entirely, which is allowed once 1 + 2 hold.)
 ;;
-;; CORS is then reflected to the validated loopback Origin only — never the
-;; old `*` wildcard.
+;; CORS is then reflected to the validated loopback Origin only — never a
+;; `*` wildcard.
 
 (defn ^:private loopback-host?
   "True when `host` (a `Host`-header value, optionally `name:port`, or the
@@ -353,8 +353,8 @@
 (defn ^:private allow-origin
   "The `access-control-allow-origin` value to reflect: the request's own
   Origin when it is a validated loopback origin (so a legitimate cross-PORT
-  dev request gets a usable CORS header), else `\"null\"` (deny). Never the
-  old `*` wildcard."
+  dev request gets a usable CORS header), else `\"null\"` (deny). Never a
+  `*` wildcard."
   [{:keys [headers]}]
   (let [origin (get-header headers "origin")]
     (if (and origin (loopback-host? (origin-host origin)))

--- a/tools/testbed-support/src/re_frame/testbed/story_host.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/story_host.cljs
@@ -1,7 +1,6 @@
 (ns re-frame.testbed.story-host
   "Shared Story-host helper — the live-app ↔ Story-shell hash-toggle host
-  harness the Story showcase testbeds copied verbatim (rf2-tq26t /
-  rf2-uv7sn).
+  harness the Story showcase testbeds share.
 
   ## Why this exists
 
@@ -22,17 +21,15 @@
   `ensure-app-root!` / `tear-down-app-root!` / `mount-app!` /
   `mount-stories!`, and the `hashchange` listener — is pure React-DOM-root
   juggling, identical across every testbed but for the live-app root view
-  (the frame subtree above).
-  Five copies (`counter_with_stories`, `login_form`, the `login` and
-  `nine_states` examples, plus the template scaffolding) invited drift:
-  they already diverged in their `run` boot specifics (CI hooks, elision
-  listener, `:fx-overrides`) while carrying byte-identical host blocks.
+  (the frame subtree above). Centralising it here keeps each testbed's `run`
+  free to carry only its own boot specifics (CI hooks, elision listener,
+  `:fx-overrides`) without re-stating the host block.
 
   ## What it owns
 
   This namespace owns the React-root handle and the hash router ONLY — the
-  documented mount-handle exception to the app-db+events+subs rule
-  (rf2-5sjbg). Both the React-root atom and the installed-`hashchange`-listener
+  documented mount-handle exception to the app-db+events+subs rule. Both the
+  React-root atom and the installed-`hashchange`-listener
   handle are `defonce` atoms here, so a testbed's hot-reload re-`run` reuses
   the one root and replaces the one listener rather than leaking a fresh root
   or STACKING a duplicate listener per reload (the explicit store/remove
@@ -48,21 +45,20 @@
   so consuming testbeds need no build-wiring change. Bundle-isolation holds:
   nothing under `implementation/` `:require`s it (it lives under tools/).
 
-  ## The open-in-editor project-root (rf2-77wqzi)
+  ## The open-in-editor project-root
 
   Story stamps each registered source-coord with a CLASSPATH-RELATIVE
   `:file` slot (e.g. `login/stories.cljs`); the 'open in editor' chip
   prepends an on-disk *project-root* to turn it into a real editor URI
   (`re-frame.story.config/set-project-root!`). That root is per-build
   (it differs per clone), so it cannot be baked in — the host must hand
-  it to `story/configure!` at boot. Leaving that call inline in every
-  consuming `run` invited exactly the omission rf2-77wqzi found: the
-  two `examples/reagent` Story showcases mounted the shell fine but
-  never configured a root, so their Story source links resolved against
-  a nil root and OS editor handlers could not open the file (a false
-  green — the shell loads, the chip shows, the link is dead).
+  it to `story/configure!` at boot. Carrying that call inline in every
+  consuming `run` makes it easy to mount the shell while silently
+  forgetting the root: the shell loads and the chip shows, but the source
+  links resolve against a nil root and OS editor handlers cannot open the
+  file (a false green — the link is dead).
 
-  To make that impossible to forget, the project-root config is now a
+  To make that impossible to forget, the project-root config is a
   HOST responsibility: a consumer declares its tool-relative source
   subdir via the `:source-subdir` opt and `mount-with-hash-routing!`
   resolves the root (through the shared `re-frame.testbed.config`
@@ -88,8 +84,7 @@
 ;; before mounting the other so React owns the target node exclusively.
 ;;
 ;; `defonce` so a testbed's hot-reload re-`run` reuses the same root rather
-;; than leaking a fresh one per reload (the contract every per-file copy
-;; encoded).
+;; than leaking a fresh one per reload.
 
 (defonce ^:private app-root (atom nil))
 
@@ -141,15 +136,14 @@
       (mount-stories!)
       (mount-app!))))
 
-;; -- Open-in-editor project-root (rf2-77wqzi) ------------------------------
+;; -- Open-in-editor project-root -------------------------------------------
 ;;
 ;; A consumer declares its tool-relative source subdir (e.g.
 ;; `"examples/reagent"` or `"tools/story/testbeds"`) and the host resolves
 ;; the on-disk root through the shared cross-platform mechanism and hands it
 ;; to `story/configure!`. Centralising it here means a Story-host consumer
 ;; can no longer mount the shell while silently forgetting the project-root
-;; config — the omission rf2-77wqzi found in the two `examples/reagent`
-;; showcases. A blank subdir, or a checkout where neither the build-time
+;; config. A blank subdir, or a checkout where neither the build-time
 ;; define nor a `?checkout-root=` override is present, resolves to nil and
 ;; configures no root (graceful no-op, matching `set-project-root!`).
 
@@ -212,7 +206,7 @@
     `?checkout-root=` override, cross-platform) and calls `story/configure!`
     with `:rf.story/project-root` — which also bridges the root into Xray's
     slot. This is the ONE host-owned contract for Story-host project-root
-    config (rf2-77wqzi): declare the subdir and the host wires the rest, so
+    config: declare the subdir and the host wires the rest, so
     a consumer can no longer mount the shell while silently forgetting it.
     Omit the opt (or pass a 1-arity call) when the consumer configures
     `story/configure!` itself.

--- a/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.testbed.config-cljs-test
-  "Focused unit tests for `re-frame.testbed.config` (rf2-ynjts.23).
+  "Focused unit tests for `re-frame.testbed.config`.
 
   ## What this pins
 
@@ -20,13 +20,12 @@
     5. Blank `checkout-root` → `nil` (the graceful-no-op contract that
        `set-checkout-root!` already encodes for blank input).
 
-  Before this file the only coverage was indirect: the consuming
-  testbeds compile through `config.cljs` under `npm run
+  The consuming testbeds compile through `config.cljs` under `npm run
   test:xray-feature-gate`, but each calls `resolve-source-root` with
-  ONE fixed subdir and no query override, so the normalisation branches
-  above were never asserted. A behaviour-preserving refactor of the
-  join/strip logic could have silently regressed cross-platform path
-  construction.
+  ONE fixed subdir and no query override, so those checks never assert the
+  normalisation branches above. A behaviour-preserving refactor of the
+  join/strip logic could silently regress cross-platform path
+  construction, so this suite pins each branch directly.
 
   ## Where this lives
 
@@ -36,19 +35,19 @@
   `:ns-regexp \"cljs-test$\"`) discovers this suite there. The runtime
   helper source path (`tools/testbed-support/src`) carries the helper
   namespaces only, keeping the same source/test separation the rest of
-  the repo uses (rf2-d0631h). Nothing under `src/` `:require`s this test,
+  the repo uses. Nothing under `src/` `:require`s this test,
   so it is on the classpath only for the `:node-test` build that finds it
   by the `cljs-test$` ns regexp and never reaches a release bundle.
 
   ## How the `?checkout-root=` override (tier 1) is pinned here
 
   Tier 1 of the resolution order — the `?checkout-root=<path>` query
-  string winning over everything — used to have NO executable coverage:
-  the override read `js/window.location.search` directly, and there is no
-  `js/window` under `:node-test`, so the branch silently degraded to nil
-  and the cross-machine escape hatch could regress unnoticed (rf2-6bq0o).
+  string winning over everything — is browser-bound: the override reads
+  `js/window.location.search` directly, and there is no `js/window` under
+  `:node-test`, so a naive test would silently degrade to nil and the
+  cross-machine escape hatch could regress unnoticed.
 
-  `config.cljs` now isolates the single genuinely browser-bound step —
+  `config.cljs` isolates the single genuinely browser-bound step —
   reading `location.search` off the live document — behind the thin
   `query-param` adapter, and delegates the actual parse/decode/trim/
   non-blank contract to the PURE `query-param-from-search`, which takes a
@@ -79,8 +78,8 @@
 ;; slice's unit suite can pin the end-to-end composed path (no `//`, the
 ;; tool source-root segment present) without reaching into the Xray
 ;; editor-uri resolver. Defined here at the top so every composition test
-;; below — the rf2-w4yw9q override form, the rf2-d01s6s Windows form, and
-;; the rf2-fzgcii lone-`"/"`-root edge — can use it.
+;; below — the override form, the Windows form, and the lone-`"/"`-root
+;; edge — can use it.
 
 (defn- composed-editor-path
   "Mirror the open-in-editor prepend: resolved-root + \"/\" + the
@@ -130,7 +129,7 @@
 
 ;; ---- private helper: to-forward-slashes --------------------------------
 ;;
-;; The canonicalisation step (rf2-d01s6s): a Windows path with `\`
+;; The canonicalisation step: a Windows path with `\`
 ;; separators reduces to the same `/`-separated form a POSIX path already
 ;; has, matching the launcher's build-env normalisation and the
 ;; separator-agnostic editor-URI composer.
@@ -230,13 +229,13 @@
     (with-redefs [config/checkout-root "   "]
       (is (nil? (config/resolve-source-root "tools/xray/testbeds"))))))
 
-;; ---- resolve-source-root: the lone POSIX filesystem root "/" (rf2-fzgcii)
+;; ---- resolve-source-root: the lone POSIX filesystem root "/" ------------
 ;;
 ;; `strip-trailing-slash` DELIBERATELY preserves a lone `"/"` (the count > 1
 ;; guard) so a Unix filesystem root is not destroyed into a blank relative
 ;; path. That is the one normalised root that still ends in a separator — so
-;; the join must NOT then prepend a SECOND `/`. The pre-fix
-;; `(str normalized-root "/" subdir)` unconditionally did, yielding
+;; the join must NOT then prepend a SECOND `/`: an unconditional
+;; `(str normalized-root "/" subdir)` would yield
 ;; `//tools/xray/testbeds` for `root = "/"`, breaking the docstring's
 ;; single-separator promise. These tests pin the edge through the FULL
 ;; `resolve-source-root` surface for BOTH root tiers (build-time define and
@@ -310,9 +309,9 @@
 ;; off-browser by handing the pure parser literal `location.search`
 ;; strings — the same code path the browser adapter runs, no `js/window`
 ;; fakery. The parser splits the query string manually and decodes with
-;; `js/decodeURIComponent` (rf2-xdsat.1) so a LITERAL `+` survives verbatim
+;; `js/decodeURIComponent` so a LITERAL `+` survives verbatim
 ;; rather than being form-urlencoded-decoded to a space (the silent
-;; path-corruption seam that `js/URLSearchParams` introduced).
+;; path-corruption seam `js/URLSearchParams` would introduce).
 
 (deftest query-param-from-search-reads-the-named-param
   (testing "the named param's value is returned, trimmed + non-blank"
@@ -447,7 +446,7 @@
       (is (nil? (config/resolve-source-root "tools/xray/testbeds"))
           "no override AND no checkout-root → nil (graceful no-op)"))))
 
-;; ---- composed editor path: the documented override form (rf2-w4yw9q) ---
+;; ---- composed editor path: the documented override form ----------------
 ;;
 ;; The whole point of the resolved root is that the open-in-editor
 ;; resolver prepends it to a CLASSPATH-RELATIVE source coord (the
@@ -506,13 +505,13 @@
       (is (= "/home/dev/re-frame2+wip/tools/xray/testbeds/standard_epochs/core.cljs"
              via-override)))))
 
-;; ---- Windows override normalisation (rf2-d01s6s) -----------------------
+;; ---- Windows override normalisation ------------------------------------
 ;;
 ;; A Windows reader pasting `?checkout-root=C:\Users\me\code\re-frame2\`
 ;; (raw `\` separators, with or without a trailing `\`) — or its
 ;; %5C-encoded transport form — must resolve to a CLEAN, single-separator,
 ;; forward-slash path, NOT the `C:\...\/tools/xray/testbeds` boundary
-;; duplication that relied on downstream tolerant path normalisation. Both
+;; duplication that would rely on downstream tolerant path normalisation. Both
 ;; root tiers go through the SAME canonicalising join, so this holds for
 ;; the build-time `checkout-root` tier as well as the query override.
 

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -8,11 +8,11 @@
 
   The load-bearing regression: a classpath checkout path containing a
   literal `+` (e.g. `C:/code/re-frame2+wip`) must survive `:file`
-  resolution verbatim. The historic code decoded the `file:` resource URL
-  with `URLDecoder`, which is a FORM-body decoder that maps `+` → space,
-  so such a path resolved to a nonexistent `re-frame2 wip` dir and the
-  endpoint launched the editor at the wrong place. `file-url->path` now
-  decodes via `URI`, which leaves a literal `+` intact while still
+  resolution verbatim. Decoding the `file:` resource URL with `URLDecoder`
+  is wrong here — it is a FORM-body decoder that maps `+` → space,
+  so such a path would resolve to a nonexistent `re-frame2 wip` dir and the
+  endpoint would launch the editor at the wrong place. `file-url->path`
+  decodes via `URI` instead, which leaves a literal `+` intact while still
   decoding `%20` / `%2B`."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]

--- a/tools/testbed-support/test/re_frame/testbed/story_host_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/story_host_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.testbed.story-host-cljs-test
-  "Focused unit tests for `re-frame.testbed.story-host` (rf2-liive).
+  "Focused unit tests for `re-frame.testbed.story-host`.
 
   ## What this pins
 
@@ -13,18 +13,18 @@
   repeatedly tearing down/remounting the Story shell on the same `#app` node
   (lost shell state, leaked shell listeners/polls, React `createRoot` churn).
 
-  ## Why the OLD code was unsound (the bug these tests lock out)
+  ## The unsound pattern these tests lock out
 
-  The previous implementation installed the top-level `on-hash-change!`
-  `defn` as the listener and relied on the browser to no-op a *repeat*
-  `addEventListener` of the same fn reference. But a CLJS hot-reload
-  recompiles the namespace, rebinding the `on-hash-change!` `defn` to a
-  FRESH function object. So the post-reload re-`run` passed a DIFFERENT
-  reference — the browser did not dedupe, and a second listener stacked.
-  The documented \"idempotent across hot-reload\" contract was therefore
-  false for every Story showcase that consumes the helper.
+  Installing the top-level `on-hash-change!` `defn` as the listener and
+  relying on the browser to no-op a *repeat* `addEventListener` of the same
+  fn reference is unsound: a CLJS hot-reload recompiles the namespace,
+  rebinding the `on-hash-change!` `defn` to a FRESH function object. So the
+  post-reload re-`run` passes a DIFFERENT reference — the browser does not
+  dedupe, and a second listener stacks, making the \"idempotent across
+  hot-reload\" contract false for every Story showcase that consumes the
+  helper.
 
-  The fix mirrors the adjacent React-root store/remove discipline
+  The host instead mirrors the adjacent React-root store/remove discipline
   (`app-root` / `tear-down-app-root!`): the installed listener handle is
   stashed in the `defonce` `hash-listener*` atom and explicitly REMOVED
   before the next one is installed.
@@ -53,8 +53,8 @@
 ;; Holds a `hashchange`-listener registry (a JS Set of installed fns) plus a
 ;; mutable `location.hash`. `addEventListener` / `removeEventListener` mutate
 ;; that set with reference identity — the exact semantics the browser uses and
-;; the exact thing the fix depends on. We count ACTIVE listeners by the set's
-;; size, so a stacked duplicate (the bug) shows up as size 2.
+;; the exact thing the remove-then-add discipline depends on. We count ACTIVE
+;; listeners by the set's size, so a stacked duplicate shows up as size 2.
 ;; ---------------------------------------------------------------------------
 
 (defn- make-fake-window
@@ -84,7 +84,7 @@
 ;; `:node-test` target a bare-`window` `set!` is a strict-mode write to an
 ;; undeclared global and throws `ReferenceError`, whereas `goog.global` is a
 ;; real object we may add a property to — the same `goog.global` slot the
-;; xray keybinding tests stub `js/document` through (rf2-higwg). Reads of
+;; xray keybinding tests stub `js/document` through. Reads of
 ;; `js/window` inside `story-host` then see the fake.
 (def ^:private real-window (when (exists? js/window) js/window))
 
@@ -201,16 +201,16 @@
            single active listener, not an N-deep stack"))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-77wqzi — the host owns Story-host open-in-editor project-root config.
+;; The host owns Story-host open-in-editor project-root config.
 ;;
 ;; Story stamps each registered source-coord with a CLASSPATH-RELATIVE
 ;; `:file` slot (e.g. `login/stories.cljs`); the open-in-editor chip
-;; prepends an on-disk project-root to build a real editor URI. The two
-;; `examples/reagent` Story showcases previously mounted the shell fine but
-;; NEVER configured a root, so their Story source links resolved against a
-;; nil root and OS editor handlers could not open the file (a false green).
+;; prepends an on-disk project-root to build a real editor URI. A consumer
+;; that mounts the shell without configuring a root leaves its Story source
+;; links resolving against a nil root, so OS editor handlers cannot open the
+;; file (a false green).
 ;;
-;; The fix moved project-root config onto the host: a consumer declares its
+;; The host owns project-root config: a consumer declares its
 ;; tool-relative source subdir via the `:source-subdir` opt and
 ;; `mount-with-hash-routing!` resolves the on-disk root (through the shared
 ;; `re-frame.testbed.config` build-env / `?checkout-root=` mechanism) and

--- a/tools/testbed-support/test/re_frame/testbed/story_host_dom_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/story_host_dom_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.testbed.story-host-dom-cljs-test
-  "Browser-level handoff test for `re-frame.testbed.story-host` (rf2-fzgcii).
+  "Browser-level handoff test for `re-frame.testbed.story-host`.
 
   ## Why this exists (the gap the node suite cannot close)
 
@@ -22,8 +22,8 @@
   `rdc/create-root` on that same node — otherwise React 19 emits the
   \"You are calling ReactDOMClient.createRoot() on a container that has
   already been passed to createRoot() before\" warning, and roots leak.
-  rf2-fq1yg was exactly that class of bug (passing the DOM node, not the
-  root handle, to `unmount` — a silent no-op that left the shell root alive).
+  A subtle way to violate it is passing the DOM node, not the root handle,
+  to `unmount` — a silent no-op that leaves the shell root alive.
   Only a test that drives the REAL handoff on a REAL node can lock it out.
 
   ## What this test does

--- a/tools/xray/design-reference/xray_devtools_reference.cljs
+++ b/tools/xray/design-reference/xray_devtools_reference.cljs
@@ -1,5 +1,5 @@
 (ns xray.devtools
-  "Xray DevTools — authoritative SURFACE reference (rf2-xawwb).
+  "Xray DevTools — authoritative SURFACE reference.
 
   This file is a self-contained, loadable Reagent render of the
   AUTHORITATIVE Xray surface design produced by Figma Make. It is a
@@ -10,38 +10,36 @@
   exists so a human (or agent) can see the TARGET LOOK at a glance and
   diff the live chrome against it.
 
-  ## rf2-xawwb — the Figma-Make surface deltas recorded here
+  ## The Figma-Make surface, as rendered here
 
   1. **Chrome ribbon → DARK.** The top chrome ribbon paints the dark
      `--devtools-chrome-ribbon-bg` band with white
      `--devtools-chrome-ribbon-text` ink in BOTH themes. Label reads
-     `Event History` (was `Events`). The filter affordance is a `+ filter`
-     TEXT button. A sun/moon THEME TOGGLE flips light ⇄ dark.
+     `Event History`. The filter affordance is a `+ filter` TEXT button.
+     A sun/moon THEME TOGGLE flips light ⇄ dark.
   2. **Dark tabs ribbon.** The tab strip is a dark band carrying
      ROUNDED-TOP tab buttons (`border-radius 4px 4px 0 0`; active = light
      `--devtools-chrome-ribbon-tab-active` fill, inactive = translucent),
      prefixed with a `↳ for selected event` contextual label. The first
-     tab is `Handler` (was `Event`).
-  3. **Events ribbon reorg.** LEFT → RIGHT: a `↳ filters:` label + an
+     tab is `Handler`.
+  3. **Events ribbon layout.** LEFT → RIGHT: a `↳ filters:` label + an
      add-filter `+` button; the green/red filter pills (each with a
      vertical divider before the `✕`); then the `N events filtered out`
      count pushed to the RIGHT end.
   4. **Event-list column order:** `event id` FIRST, then `source`,
      `timestamp`, `duration`.
   5. **Handler panel** numbered lifecycle pipeline is 6 steps in operational
-     order (rf2-ynnre, B+): 1 DISPATCH, 2 COEFFECTS, 3 EVENT HANDLER,
-     4 FLOWS, 5 APP-DB CHANGES, 6 FX. FLOWS sits BETWEEN EVENT HANDLER and
+     order: 1 DISPATCH, 2 COEFFECTS, 3 EVENT HANDLER, 4 FLOWS,
+     5 APP-DB CHANGES, 6 FX. FLOWS sits BETWEEN EVENT HANDLER and
      APP-DB CHANGES so the panel's section rhythm tracks the operational
      order (handler returns pending `:db` → flows reshape → atomic commit
-     → fx). Supersedes the earlier Figma-A order (HANDLER → APP-DB
-     CHANGES → FLOWS → FX), per Mike's 2026-05-25 B+ decision on
-     rf2-5t9h0.
+     → fx).
 
-  ## What this reference DELIBERATELY keeps richer than the Figma stub
+  ## What this reference keeps richer than the Figma stub
 
-  The Figma export stubs the `app-db` panel. This reference RETAINS the
-  earlier richer `app-db-panel` section (APP STATE / MACHINE / ROUTE
-  cards) rather than the stub — the live App-db panel is the contractual
+  The Figma export stubs the `app-db` panel. This reference carries the
+  richer `app-db-panel` section (APP STATE / MACHINE / ROUTE cards)
+  rather than the stub — the live App-db panel is the contractual
   surface and the reference documents its shape.
 
   ## What this reference DELIBERATELY diverges from the Figma authority
@@ -51,16 +49,16 @@
     at `rgba(255,255,255,0.2)`; both this mirror and the live shell
     (`tools/xray/src/day8/re_frame2_xray/shell.cljs`) use 0.12 instead.
     The quieter inactive fill lets the active tab POP in the rhythm
-    of the dark tabs ribbon; 0.2 made the inactive tabs read as
+    of the dark tabs ribbon; 0.2 makes the inactive tabs read as
     competing siblings rather than backgrounded options. This is a
     deliberate, contractual divergence from the authority — codified
-    here (rf2-2kw7f) so a future audit doesn't re-raise it as drift.
+    here so a future audit doesn't raise it as drift.
 
   ## Out of scope (WIP)
 
-  The Machine panel design is a work-in-progress (Mike). This reference
-  carries NO Machine-panel design — the Machine TAB exists in the tab
-  bar (one label) but its body is a placeholder here."
+  The Machine panel design is a work-in-progress. This reference carries
+  NO Machine-panel design — the Machine TAB exists in the tab bar (one
+  label) but its body is a placeholder here."
   (:require [reagent.core :as r]
             [reagent.dom :as rdom]))
 
@@ -80,7 +78,7 @@
 
   /* Developer tool colors */
   --devtools-chrome-bg: #f5f5f5;
-  /* rf2-xawwb — dark chrome ribbon band (DARK even under the light theme) */
+  /* dark chrome ribbon band (DARK even under the light theme) */
   --devtools-chrome-ribbon-bg: #2a2a2a;
   --devtools-chrome-ribbon-text: #ffffff;
   --devtools-chrome-ribbon-text-muted: #b0b0b0;
@@ -190,7 +188,7 @@
    [:line {:x1 "10" :y1 "14" :x2 "21" :y2 "3"}]])
 
 ;; ============================================================================
-;; Chrome Ribbon Component (rf2-xawwb — DARK band + Event History + theme toggle)
+;; Chrome Ribbon Component (DARK band + Event History + theme toggle)
 ;; ============================================================================
 
 (defn chrome-ribbon [is-dark toggle-theme]
@@ -217,7 +215,7 @@
                          :align-items "center" :justify-content "center"}}
         [icon]])]
 
-    ;; rf2-xawwb — `+ filter` TEXT button (replaces the prior plus-icon).
+    ;; `+ filter` TEXT button.
     [:button {:class "devtools-caption"
               :style {:height "21px" :padding "0 8px" :border-radius "4px"
                       :border "1px solid var(--devtools-chrome-ribbon-text-muted)"
@@ -243,8 +241,8 @@
      [:span "Dynamic"]
      [chevron-down]]
 
-    ;; rf2-xawwb — sun/moon THEME TOGGLE. In the live shell this flips the
-    ;; existing `:theme` setting (toggling `rf-xray-theme-light/dark` on
+    ;; sun/moon THEME TOGGLE. In the live shell this flips the
+    ;; `:theme` setting (toggling `rf-xray-theme-light/dark` on
     ;; the shell + <html> root); here it toggles the local `dark` class so
     ;; the reference previews both palettes.
     [:button {:style {:padding "8px" :border-radius "4px" :background "transparent"
@@ -264,7 +262,7 @@
      [x-icon]]]])
 
 ;; ============================================================================
-;; Events Ribbon Component (rf2-xawwb — filters: label + add(+) left, count right)
+;; Events Ribbon Component (filters: label + add(+) left, count right)
 ;; ============================================================================
 
 (defn filter-pill [label tone]
@@ -273,7 +271,7 @@
                  :border-radius "4px" :border (str "1px solid " tone)
                  :height "21px" :color tone}}
    [:span {:style {:padding "0 8px"}} label]
-   ;; rf2-xawwb — VERTICAL DIVIDER before the ✕.
+   ;; VERTICAL DIVIDER before the ✕.
    [:div {:style {:width "1px" :height "13px" :background tone}}]
    [:button {:style {:width "21px" :height "21px" :border "none" :background "transparent"
                      :color "inherit" :cursor "pointer" :display "flex"
@@ -311,12 +309,12 @@
     "12 events filtered out"]])
 
 ;; ============================================================================
-;; Event List Component (rf2-xawwb — event-id FIRST, then source)
+;; Event List Component (event-id FIRST, then source)
 ;; ============================================================================
 
 (defn event-list []
   (let [height (r/atom 144)
-        ;; rf2-xawwb — column order is event-id FIRST, then source.
+        ;; column order is event-id FIRST, then source.
         mock-events [{:event-id ":title/flow"  :source "fx"     :timestamp "12:30:05.123" :duration "1.2 ms"}
                      {:event-id ":counter-inc" :source "view"   :timestamp "12:30:06.456" :duration "0.4 ms" :active? true}
                      {:event-id ":poll/tick"   :source "timer"  :timestamp "12:30:07.001" :duration "0.2 ms"}
@@ -349,14 +347,14 @@
                       :height "4px" :cursor "ns-resize" :background "transparent"}}]])))
 
 ;; ============================================================================
-;; Tabs Ribbon Component (rf2-xawwb — DARK band, rounded-top tabs, Handler tab)
+;; Tabs Ribbon Component (DARK band, rounded-top tabs, Handler tab)
 ;; ============================================================================
 
 (defn tab-button [active-tab tab-id label]
   (let [is-active (= @active-tab tab-id)]
-    ;; rf2-2kw7f — inactive fill is rgba(...,0.12), NOT the Figma
-    ;; authority's 0.2. Deliberate; see the docstring (§What this
-    ;; reference DELIBERATELY diverges from the Figma authority).
+    ;; inactive fill is rgba(...,0.12), NOT the Figma authority's 0.2.
+    ;; Deliberate; see the docstring (§What this reference DELIBERATELY
+    ;; diverges from the Figma authority).
     [:button {:class "devtools-body"
               :style {:padding "3px 16px" :border-radius "4px 4px 0 0" :border "none"
                       :background (if is-active "var(--devtools-chrome-ribbon-tab-active)" "rgba(255,255,255,0.12)")
@@ -370,15 +368,15 @@
                  :border-bottom "1px solid var(--devtools-border)"
                  :background "var(--devtools-chrome-ribbon-bg)"}}
 
-   ;; rf2-xawwb — `↳ for selected event` contextual label.
+   ;; `↳ for selected event` contextual label.
    [:span {:class "devtools-caption" :style {:color "var(--devtools-chrome-ribbon-text-muted)"
                                              :margin-right "13px" :display "flex"
                                              :align-items "center" :gap "8px" :align-self "center"}}
     [corner-down-right]
     "for selected event"]
 
-   ;; rf2-xawwb — first tab is `Handler` (was `Event`). Machine TAB stays
-   ;; (one label); its panel body design is WIP and out of scope here.
+   ;; first tab is `Handler`. Machine TAB carries one label; its panel
+   ;; body design is WIP and out of scope here.
    [tab-button active-tab :handler "Handler"]
    [tab-button active-tab :app-db "app-db"]
    [tab-button active-tab :views "Views"]
@@ -388,7 +386,7 @@
    [tab-button active-tab :issues "Issues"]])
 
 ;; ============================================================================
-;; Handler Panel Component (rf2-ynnre B+ — 6-step operational order:
+;; Handler Panel Component (6-step operational order:
 ;; DISPATCH / COEFFECTS / EVENT HANDLER / FLOWS / APP-DB CHANGES / FX)
 ;; ============================================================================
 
@@ -463,9 +461,9 @@
         "  (" [:span {:class "syntax-keyword"} "fn"] " [{:keys [db]} _]\n"
         "    {" [:span {:class "syntax-keyword"} ":db"] " (" [:span {:class "syntax-keyword"} "update"] " db " [:span {:class "syntax-keyword"} ":counter"] " inc)}))"]]]
 
-     ;; 4. FLOWS (rf2-ynnre — step 4, between EVENT HANDLER and APP-DB
-     ;; CHANGES, matching operational order). Shows the flow(s) that
-     ;; recomputed + their db contribution.
+     ;; 4. FLOWS (step 4, between EVENT HANDLER and APP-DB CHANGES,
+     ;; matching operational order). Shows the flow(s) that recomputed
+     ;; + their db contribution.
      [:section {:style {:position "relative"}}
       [step-circle 4]
       [step-label "FLOWS"]
@@ -482,9 +480,9 @@
          [:span "[:totals :sum]"]
          [:span {:style {:color "var(--devtools-success)"}} "42"]]]]]
 
-     ;; 5. APP-DB CHANGES (rf2-ynnre — step 5, after FLOWS, matching
-     ;; operational order). Carries the `committed diff` caption to
-     ;; clarify it's the post-flow t4 observable.
+     ;; 5. APP-DB CHANGES (step 5, after FLOWS, matching operational
+     ;; order). Carries the `committed diff` caption to clarify it's the
+     ;; post-flow t4 observable.
      [:section {:style {:position "relative"}}
       [step-circle 5]
       [step-label "APP-DB CHANGES"]
@@ -503,7 +501,7 @@
         [:span {:style {:color "var(--devtools-text-muted)"}} "[:last-updated]"]
         [:span {:style {:color "var(--devtools-success)"}} "#inst \"2026-05-23T12:30:05\""]]]]
 
-     ;; 6. FX (rf2-ynnre — carries the post-commit · irreversible caption)
+     ;; 6. FX (carries the post-commit · irreversible caption)
      [:section {:style {:position "relative"}}
       [step-circle 6]
       [step-label "FX"]

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -1,11 +1,10 @@
 (ns day8.re-frame2-xray.config
   "Compile-time and runtime configuration for Xray.
 
-  Phase 1 held a single config concern: the 'Open in editor'
-  preference (rf2-evgf5). Xray now also exposes the default inline
-  layout-host selector, default auto-open switch (rf2-eehov), and the
-  ribbon filter pill seed + persistence key (rf2-ak4ms). Future phases
-  extend this with theme defaults, buffer depth, etc.
+  Holds Xray's config concerns: the 'Open in editor' preference, the
+  default inline layout-host selector, the default auto-open switch, and
+  the ribbon filter pill seed + persistence key. Future phases extend
+  this with theme defaults, buffer depth, etc.
 
   ## Why a separate config ns
 
@@ -47,7 +46,7 @@
 (def default-layout-host-selector
   "[data-rf-xray-host]")
 
-;; ---- Inline-host resize contract (rf2-um813) ----------------------------
+;; ---- Inline-host resize contract ----------------------------------------
 ;;
 ;; The host page owns sizing for `[data-rf-xray-host]` (per
 ;; spec/011-Launch-Modes.md §Layout host contract). To let developers
@@ -81,13 +80,13 @@
 
 (def default-layout-host-width
   "Default value Xray recommends for `--rf-xray-inline-width` when the
-  host does not override it. Bumped from 420px → 560px per rf2-9ovfb
-  (Pitch8 field feedback: event vectors with map payloads wrap awkwardly
-  at 420px; 560px reads much better for the Event Detail panel)."
+  host does not override it. 560px: event vectors with map payloads
+  wrap awkwardly at narrower widths; 560px reads well for the Event
+  Detail panel."
   "560px")
 
 (def default-panel-width-px
-  "Default panel width in pixels (rf2-x8h9y). Mirrors
+  "Default panel width in pixels. Mirrors
   `default-layout-host-width` (`\"560px\"`) without the unit so the
   numeric Settings slot, the resize handle's drag math, and the
   double-click reset can compose against one source of truth. The
@@ -99,52 +98,47 @@
   560)
 
 (def min-panel-width-px
-  "Lower clamp for the resize handle (rf2-x8h9y). 320px matches the
+  "Lower clamp for the resize handle. 320px matches the
   inline-host snippet's `min-width: 320px` floor — below this the
   L1 ribbon clusters start to wrap and the chrome becomes unusable."
   320)
 
 (def max-panel-width-fraction
   "Upper clamp for the resize handle expressed as a fraction of the
-  viewport width (rf2-x8h9y). 0.9 leaves a 10% sliver for the host
+  viewport width. 0.9 leaves a 10% sliver for the host
   app so the user always has a visual anchor back to their content;
   full-viewport coverage is the dedicated `:fullscreen` panel-position
   rather than a side-effect of dragging the handle off the left edge."
   0.9)
 
-;; ---- L2 event-list vertical resize (rf2-t2dsh) ---------------------------
+;; ---- L2 event-list vertical resize --------------------------------------
 ;;
 ;; The seam between the L2 event list and the L3 tab bar is a draggable
 ;; row-resize affordance. The height value persists through the same
 ;; Settings round-trip as the panel-width; floor + ceiling clamp so the
 ;; list cannot collapse below two rows + chrome (the documented L2 min)
-;; and cannot expand so far that the L4 detail panel disappears.
-;;
-;; The earlier browser-native `:resize \"vertical\"` corner-grip was
-;; retired in rf2-t2dsh: it carried no persistence, no keyboard
-;; affordance, and a tiny corner hit-target. The seam matches the
-;; left-edge panel-width handle's interaction model so all resize
-;; surfaces share one mental model (drag the seam, double-click to
+;; and cannot expand so far that the L4 detail panel disappears. The seam
+;; matches the left-edge panel-width handle's interaction model so all
+;; resize surfaces share one mental model (drag the seam, double-click to
 ;; reset, keyboard arrows for fine step).
 
 (def default-events-list-height-px
-  "Default L2 event-list height in pixels (rf2-t2dsh). 200px == 8 rows
-  × 22px + 7 × 2px gap + 8px outer padding, matching the rf2-htik0
-  Bug 2 tightened rhythm. The drag handle on the L2/L3 seam writes the
-  live value back through `:rf.xray/set-events-list-height-px`, which
-  clamps + persists + writes the inline `height` style on the next
-  paint."
+  "Default L2 event-list height in pixels. 200px == 8 rows × 22px +
+  7 × 2px gap + 8px outer padding, matching the tightened row rhythm.
+  The drag handle on the L2/L3 seam writes the live value back through
+  `:rf.xray/set-events-list-height-px`, which clamps + persists + writes
+  the inline `height` style on the next paint."
   200)
 
 (def min-events-list-height-px
-  "Lower clamp for the L2/L3 seam drag handle (rf2-t2dsh). 48px ==
-  2 rows + chrome, matching the previously documented `min-height`
-  ceiling that kept the list operable when dragged tight."
+  "Lower clamp for the L2/L3 seam drag handle. 48px == 2 rows + chrome,
+  the `min-height` floor that keeps the list operable when dragged
+  tight."
   48)
 
 (def max-events-list-height-fraction
   "Upper clamp for the L2/L3 seam drag handle expressed as a fraction
-  of the viewport height (rf2-t2dsh). 0.7 leaves a 30% sliver for the
+  of the viewport height. 0.7 leaves a 30% sliver for the
   L1 chrome + L3 tab bar + L4 detail panel — full-viewport L2 isn't a
   documented mode; clamping prevents the user dragging the seam below
   the bottom of the viewport, which would orphan the L3/L4 surfaces."
@@ -163,7 +157,7 @@
 
 (defn clamp-events-list-height-px
   "Pure helper: clamp `px` to the seam handle's [min, viewport×0.7]
-  range (rf2-t2dsh). Pass `viewport-height-px` explicitly so the helper
+  range. Pass `viewport-height-px` explicitly so the helper
   stays CLJC-pure and JVM-testable (no implicit `window.innerHeight`
   reach). Non-numeric input falls back to `default-events-list-height-px`
   so a malformed persisted payload never leaves the list at an
@@ -180,8 +174,7 @@
 (def default-accent-css-var
   "Name of the CSS custom property carrying Xray's accent colour (the
   GitHub blue `#539bf5` from `theme/tokens.cljc` / `spec/007-UX-IA.md`
-  §Colour system / `:accent` — the single Figma accent per
-  rf2-ad7zx.13). Published per rf2-9ovfb so:
+  §Colour system / `:accent` — the single Figma accent). Published so:
 
     - Host application stylesheets can colour their own dev chrome
       to match Xray (e.g. a resize-handle inset shadow, a dock-
@@ -209,38 +202,36 @@
 (def default-accent
   "Default value Xray publishes for `--rf-xray-accent` — the single
   Figma accent from `theme/tokens.cljc` (`:accent`, GitHub blue
-  `#539bf5` per rf2-ad7zx.13). Resolved through the canonical
-  `dark-palette` map so the accent hex has exactly one source of truth
-  (rf2-5kfxe.4). Matches the accent catalogued in `spec/007-UX-IA.md`
-  §Colour system.
+  `#539bf5`). Resolved through the canonical `dark-palette` map so the
+  accent hex has exactly one source of truth. Matches the accent
+  catalogued in `spec/007-UX-IA.md` §Colour system.
 
   Reads `dark-palette` (the literal hex map) rather than `tokens`
-  because `tokens` exposes CSS-variable strings (`var(--rf-xray-…)`)
-  post rf2-on4cm; this constant is the VALUE that gets published
-  INTO the CSS variable, not a reference to it. The Dynamic/Static
-  mode no longer flips the accent colour (rf2-ad7zx.13), so the single
-  `:accent` token is the host-published default."
+  because `tokens` exposes CSS-variable strings (`var(--rf-xray-…)`);
+  this constant is the VALUE that gets published INTO the CSS variable,
+  not a reference to it. The single `:accent` token is the
+  host-published default across both Dynamic and Static mode."
   (:accent tokens/dark-palette))
 
 (def default-layout-host-snippet
   ;; DOM order is `<main>` first, host `<aside>` second — flex flow
   ;; lays the aside on the right of the app column (per spec/011-
-  ;; Launch-Modes.md §Layout host contract, rf2-e07yk). CSS uses
+  ;; Launch-Modes.md §Layout host contract). CSS uses
   ;; `var(--rf-xray-inline-width, 560px)` so a host that pastes the
   ;; snippet verbatim gets:
-  ;;   - default geometry (560px flex-basis per rf2-9ovfb, 320px floor)
+  ;;   - default geometry (560px flex-basis, 320px floor)
   ;;   - a single one-line override path:
   ;;       :root { --rf-xray-inline-width: 720px; }
   ;;   - a user-draggable resize handle auto-injected by Xray
-  ;;     (per rf2-70u8q + spec/007-UX-IA.md §Resize affordance) — the
-  ;;     consumer no longer wires `resize: horizontal` / `overflow:
-  ;;     auto`; Xray mounts its own handle as soon as the shell
-  ;;     renders. Consumers that prefer the browser-native handle
-  ;;     opt out by setting `resize: horizontal` on the host (yield-
-  ;;     to-consumer detection per spec/007 §Yield-to-consumer).
+  ;;     (per spec/007-UX-IA.md §Resize affordance) — the consumer
+  ;;     need not wire `resize: horizontal` / `overflow: auto`; Xray
+  ;;     mounts its own handle as soon as the shell renders. Consumers
+  ;;     that prefer the browser-native handle opt out by setting
+  ;;     `resize: horizontal` on the host (yield-to-consumer detection
+  ;;     per spec/007 §Yield-to-consumer).
   ;;   - app content to the left stays in normal flex flow
   ;;     (no overlay, no body padding).
-  ;;   - `--rf-xray-accent` published on `:root` (rf2-9ovfb) so
+  ;;   - `--rf-xray-accent` published on `:root` so
   ;;     host stylesheets can colour their own dev chrome (resize
   ;;     handles, dock separators, story chips) to match Xray
   ;;     without forking the hex. Override on `:root` for a tinted
@@ -310,7 +301,7 @@
   []
   @auto-open?)
 
-;; ---- *keybinding-enabled?* (rf2-4eyik — embed-host opt-out for the
+;; ---- *keybinding-enabled?* (embed-host opt-out for the
 ;; global keydown listener) ------------------------------------------------
 ;;
 ;; Xray attaches a window-level capture-phase `keydown` listener
@@ -324,8 +315,7 @@
 ;; routinely register their own `Cmd/Ctrl+K` palette + their own
 ;; bindings. With Xray's listener attached at the capture phase the
 ;; host's own bindings never fire — the embed silently swallows
-;; keystrokes that belong to the host (rf2-q7who Thread A, observed
-;; via rf2-drprn).
+;; keystrokes that belong to the host.
 ;;
 ;; The flag is the host's surrender switch: set it to `false` BEFORE
 ;; the Xray preload runs (typically inside the host's boot sequence
@@ -345,8 +335,7 @@
          standalone Xray shell needs its Ctrl+Shift+C / Cmd-K / spine
          bindings). Set to `false` by embed hosts (Story RHS, third-
          party tool surfaces) whose own keybindings collide with
-         Xray's — `attach!` short-circuits to a no-op. Per rf2-4eyik
-         (rf2-q7who Thread A)."}
+         Xray's — `attach!` short-circuits to a no-op."}
   keybinding-enabled?
   (atom true))
 
@@ -362,8 +351,7 @@
 
 (defn keybinding-attach-enabled?
   "Return true when `keybinding/attach!` should install the global
-  keydown listener. Read by `keybinding/attach!` at attach time. Per
-  rf2-4eyik (rf2-q7who Thread A)."
+  keydown listener. Read by `keybinding/attach!` at attach time."
   []
   @keybinding-enabled?)
 
@@ -376,7 +364,7 @@
   editor
   (atom :vscode))
 
-;; ---- editor-explicitly-set? (rf2-4s08ov — open-in-editor DX hint) -------
+;; ---- editor-explicitly-set? (open-in-editor DX hint) --------------------
 ;;
 ;; The `editor` atom defaults to `:vscode`, so a host that NEVER calls
 ;; `set-editor!` / `(configure! {:rf.xray/editor …})` is indistinguishable
@@ -385,10 +373,9 @@
 ;; default scheme, but if VS Code is not the developer's editor the OS
 ;; has no handler and the click is a SILENT no-op (the URI resolves
 ;; fine — `Location.assign` fires — but nothing happens because no OS
-;; protocol handler is registered; JS cannot observe that failure). Per
-;; rf2-ffijtp the fix was documented; rf2-4s08ov surfaces an actionable
-;; "pick an editor in Settings" hint at click-time instead of the
-;; silent no-op.
+;; protocol handler is registered; JS cannot observe that failure).
+;; Xray surfaces an actionable "pick an editor in Settings" hint at
+;; click-time instead of the silent no-op.
 ;;
 ;; This flag records whether the host EXPLICITLY chose an editor.
 ;; `set-editor!` sets it true on any non-nil call (the host has signalled
@@ -403,7 +390,7 @@
          framework default the host never confirmed. Set `true` by
          `set-editor!` on any non-nil call. Read by `editor-configured?`
          to decide whether the open-in-editor click should hint to
-         pick an editor in Settings (rf2-4s08ov)."}
+         pick an editor in Settings."}
   editor-explicitly-set?
   (atom false))
 
@@ -422,10 +409,10 @@
                                    `{line}` / `{column}` placeholders.
     - `nil`               — reset to `:vscode` default.
 
-  Per rf2-4s08ov a non-nil call flips `editor-explicitly-set?` to true
-  (the host has confirmed an editor — even `:vscode` explicitly counts);
-  a nil reset clears the flag back to the unconfigured state so the
-  open-in-editor DX hint re-arms.
+  A non-nil call flips `editor-explicitly-set?` to true (the host has
+  confirmed an editor — even `:vscode` explicitly counts); a nil reset
+  clears the flag back to the unconfigured state so the open-in-editor
+  DX hint re-arms.
 
   Returns nothing."
   [e]
@@ -438,7 +425,7 @@
   `set-editor!` (or `xray-config/configure! {:rf.xray/editor …}`)
   pushed into the atom at boot. Settings popup's editor-override
   picker reads this to render the 'Project default: <name>' hint
-  next to the Reset button (per rf2-dudqz).
+  next to the Reset button.
 
   This is NOT the value `get-editor` returns when an end-user override
   is in play — it is the BASE the override sits on top of."
@@ -447,7 +434,7 @@
 
 (def ^:private valid-editor-override-keywords
   "Enumerated keyword overrides accepted by `valid-editor-override?`.
-  Mirror of `set-editor!`'s accepted shape (rf2-dudqz). Adding a new
+  Mirror of `set-editor!`'s accepted shape. Adding a new
   editor here requires a matching `defmethod` in
   `re-frame.source-coords.editor-uri/editor-uri`."
   #{:vscode :cursor :windsurf :zed :idea})
@@ -461,10 +448,10 @@
     - A `{:custom <string>}` map (any non-empty string).
 
   Returns false for every other shape — corrupted localStorage
-  payloads, hand-edits, legacy values from earlier experimental
-  shapes. The read-side `get-editor` filters through this predicate
-  (rf2-a1tv6) so a corrupted slot degrades to the host default rather
-  than passing a malformed value through to the URI builder."
+  payloads, hand-edits, malformed values. The read-side `get-editor`
+  filters through this predicate so a corrupted slot degrades to the
+  host default rather than passing a malformed value through to the URI
+  builder."
   [v]
   (or (nil? v)
       (contains? valid-editor-override-keywords v)
@@ -476,7 +463,7 @@
   "Return the editor preference Xray's 'Open in editor' affordance
   should target.
 
-  Three-tier resolution (per rf2-dudqz):
+  Three-tier resolution:
 
     1. **End-user override** — the `[:general :editor-override]`
        settings slot. Settable via the Settings popup → General tab
@@ -484,10 +471,9 @@
        localStorage like every other operator preference. Wins when
        non-nil so a mixed-editor teammate can flip their machine to
        a different editor without touching the host app's boot config.
-       rf2-a1tv6 — the slot is filtered through
-       `valid-editor-override?` on read; malformed payloads (a
-       corrupted localStorage write, a hand-edit, a stale
-       experimental shape) degrade to the host default instead of
+       The slot is filtered through `valid-editor-override?` on read;
+       malformed payloads (a corrupted localStorage write, a hand-edit,
+       a non-conforming shape) degrade to the host default instead of
        reaching the URI builder. A rejection emits a `tap>` so tests
        + operators can observe the corruption.
     2. **Host default** — the `editor` atom set by
@@ -510,7 +496,7 @@
     (or override @editor)))
 
 (defn editor-configured?
-  "True iff an editor has been EFFECTIVELY configured (rf2-4s08ov) —
+  "True iff an editor has been EFFECTIVELY configured —
   i.e. either the host explicitly set `:rf.xray/editor`
   (`editor-explicitly-set?`) OR a valid non-nil operator override sits
   in the `[:general :editor-override]` settings slot.
@@ -533,10 +519,10 @@
         override (when (valid-editor-override? raw) raw)]
     (boolean (or @editor-explicitly-set? (some? override)))))
 
-;; ---- *project-root* (rf2-5m5n2 — 'Open in editor' path prefix) ----------
+;; ---- *project-root* ('Open in editor' path prefix) ----------------------
 ;;
-;; Per rf2-zfy1e (Story) / rf2-5m5n2 (Xray): source-coords stamped at
-;; registration time are classpath-relative (the form-meta `:file` slot,
+;; Source-coords stamped at registration time are classpath-relative
+;; (the form-meta `:file` slot,
 ;; e.g. `"panel_gallery/event_detail_stories.cljs"`). Editor URI handlers
 ;; (`vscode://file/<path>...`, `cursor://...`, `idea://...`, etc.) resolve
 ;; `<path>` against the filesystem; a relative path fails with "Path does
@@ -547,8 +533,8 @@
 ;; The host application sets this once at boot via
 ;; `(xray-config/configure! {:rf.xray/project-root "C:/Users/me/code/my-app/src"})`.
 ;; Default is nil — when unset, the source-coord file ships verbatim and
-;; the Open chip behaves exactly as it did pre-rf2-5m5n2 (useful for hosts
-;; whose source-paths are already absolute, and for tests).
+;; the Open chip ships the path unprefixed (useful for hosts whose
+;; source-paths are already absolute, and for tests).
 ;;
 ;; Xray's project-root is **independent** of Story's. Hosts that run
 ;; both tools may want different roots (e.g. an app-source root for
@@ -582,24 +568,22 @@
   []
   @project-root)
 
-;; ---- *egress-profile* (rf2-h40lt2 — EP-0015 per-(tool,frame) reveal grain) -
+;; ---- *egress-profile* (EP-0015 per-(tool,frame) reveal grain) -----------
 ;;
 ;; EP-0015 issue 7 / Spec 015 §Cross-tool visibility grain: on-box
 ;; visibility is per `(tool, frame)` — there is NO single process-global
 ;; `show-sensitive?` user toggle. Local tools default to
 ;; `:rf.egress/local-redacted` (suppress sensitive display); raw requires
-;; an explicit trusted-local opt-in (`:rf.egress/local-raw`). The
-;; predecessor process-global `:rf.privacy/show-sensitive?` boolean
-;; (rf2-azls9) is RETIRED and folded onto this named-boundary model —
-;; matching the Story migration (rf2-3t26eh) and the per-(tool,frame)
-;; `local_render.cljc` seam already shipped in this tool.
+;; an explicit trusted-local opt-in (`:rf.egress/local-raw`). This
+;; named-boundary model matches the per-(tool,frame) `local_render.cljc`
+;; seam shipped in this tool.
 ;;
 ;; This atom holds Xray's local-render egress PROFILE. Xray is a
 ;; framework-published trace consumer (its preload listener + the
 ;; trace-collector snapshot feed every panel), so every value-bearing slot
 ;; it surfaces on a dev surface ships under this profile. The "is a
-;; `:sensitive?` event visible?" decision is no longer a hand-held boolean:
-;; it derives from the profile's `:rf.size/include-sensitive?` resolution
+;; `:sensitive?` event visible?" decision derives from the profile's
+;; `:rf.size/include-sensitive?` resolution
 ;; via the framework projection table (`projection/profile-size-opts`), the
 ;; SAME table `project-egress` consumes — one source of truth, no
 ;; re-implemented redaction policy.
@@ -644,15 +628,14 @@
          `:sensitive?` redact/pass decision derives from this profile's
          `:rf.size/include-sensitive?` resolution via the framework
          projection table, the same table `project-egress` consumes (one
-         source of truth). Per EP-0015 (rf2-h40lt2), folding the retired
-         process-global `:rf.privacy/show-sensitive?` boolean (rf2-azls9)
-         onto the per-(tool,frame) frame-owned model."}
+         source of truth). Per EP-0015, on-box visibility is the
+         per-(tool,frame) frame-owned model."}
   egress-profile
   (atom default-egress-profile))
 
-;; ---- toggle-off callbacks (rf2-lqmje — retroactive scrub) ----------------
+;; ---- toggle-off callbacks (retroactive scrub) ---------------------------
 ;;
-;; Per Spec 009 §Privacy §Retroactive-scrub (rf2-lqmje), NARROWING the
+;; Per Spec 009 §Privacy §Retroactive-scrub, NARROWING the
 ;; egress profile from a sensitive-revealing boundary
 ;; (`:rf.egress/local-raw`) back to the redacting default MUST clear the
 ;; trace buffer — the reveal is NOT a one-way trapdoor. The collector only
@@ -729,14 +712,14 @@
   (boolean (:rf.size/include-sensitive? (projection/profile-size-opts profile))))
 
 (defn set-egress-profile!
-  "Replace Xray's local-render `:rf.egress/*` profile (EP-0015, rf2-h40lt2).
+  "Replace Xray's local-render `:rf.egress/*` profile (EP-0015).
   Xray's `configure!` calls this via `:rf.xray/egress-profile`. `nil`
   resets to the default (`:rf.egress/local-redacted` — fail-closed,
   sensitive display suppressed). An unknown profile keyword is rejected by
   `configure!` before reaching here; defence-in-depth, a non-member value
   coerces to the fail-closed default.
 
-  Per rf2-lqmje (Spec 009 §Privacy §Retroactive-scrub): when the call
+  Per Spec 009 §Privacy §Retroactive-scrub: when the call
   NARROWS the profile from a sensitive-revealing boundary
   (`:rf.egress/local-raw`) back to a redacting one, the trace buffer is
   cleared by invoking every registered `toggle-off-callbacks` entry. The
@@ -787,9 +770,8 @@
 
 (defn include-sensitive?
   "True iff Xray's current local-render profile reveals sensitive values
-  (i.e. resolves to `:rf.size/include-sensitive? true`). The successor to
-  the retired `get-show-sensitive` boolean read — the trace collector
-  consults this (via `suppress-sensitive?`) to decide whether a
+  (i.e. resolves to `:rf.size/include-sensitive? true`). The trace
+  collector consults this (via `suppress-sensitive?`) to decide whether a
   `:sensitive?` event is shown or redacted. Fail-closed by default."
   []
   (profile-includes-sensitive? @egress-profile))
@@ -797,17 +779,16 @@
 (defn sensitive-event?
   "True iff the trace event `ev` carries `:sensitive? true` at the top
   level. Thin alias over the framework-published `re-frame.privacy/sensitive?`
-  predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn
-  / rf2-iwqu9, every consumer of `:sensitive?` (Xray, Story,
-  story-mcp, re-frame2-pair-mcp) composes against ONE framework
-  primitive rather than reimplementing the five-token check. Per Spec
-  009 §Privacy."
+  predicate (re-exported as `re-frame.core/sensitive?`) — every consumer
+  of `:sensitive?` (Xray, Story, story-mcp, re-frame2-pair-mcp) composes
+  against ONE framework primitive rather than reimplementing the
+  five-token check. Per Spec 009 §Privacy."
   [ev]
   (privacy/sensitive? ev))
 
 (defn suppress-sensitive?
   "Should this trace event be suppressed by Xray's trace collector under
-  the current local-render egress profile (EP-0015, rf2-h40lt2)?
+  the current local-render egress profile (EP-0015)?
 
   Returns `true` iff (a) the event is `:sensitive? true` AND (b) the
   current profile does NOT reveal sensitive values (`include-sensitive?`
@@ -819,7 +800,7 @@
   (and (sensitive-event? ev)
        (not (include-sensitive?))))
 
-;; ---- *suppressed-counters* (rf2-azls9 — UI redaction indicator) ----------
+;; ---- *suppressed-counters* (UI redaction indicator) ---------------------
 ;;
 ;; The shell's bottom rail renders a `[● REDACTED N]` hint when sensitive
 ;; events were suppressed. The hint tells the user "you're seeing fewer
@@ -865,8 +846,8 @@
   (CLJC tests assert it directly); the dispatch is the reactive
   surface for CLJS.
 
-  Per rf2-1barg / rf2-nesy9: the dispatch targets the production Xray
-  shell frame via the named `defaults/default-frame-id` Var (NOT a bare
+  The dispatch targets the production Xray shell frame via the named
+  `defaults/default-frame-id` Var (NOT a bare
   `{:frame :rf/xray}` literal). This is a trace-collector infra seam,
   not a per-instance render affordance — `note-suppressed!` is called
   by the trace bus, which has no surrounding render/event frame, and
@@ -923,7 +904,7 @@
           (rf/dispatch [:rf.xray/reset-suppressed-counters frame-id]))))
    nil))
 
-;; ---- settings popup defaults + persistence (rf2-9poxq) ------------------
+;; ---- settings popup defaults + persistence ------------------------------
 ;;
 ;; The Settings popup modal (`settings/popup.cljs`) reads + writes a
 ;; settings map carrying user preferences for general / theme knobs.
@@ -940,13 +921,13 @@
 ;; subscription contract) folds onto `get-in` / `assoc-in` over the
 ;; same shape.
 ;;
-;; ## Locked decisions (rf2-9poxq R3, rf2-jh9ws)
+;; ## Locked decisions
 ;;
 ;; - auto-open-on-error default OFF (the user is in their app, not
 ;;   asking for Xray to interrupt them)
 ;; - panel-position default `:right-rail` (matches the existing
 ;;   `:rf.xray/layout-host-selector` inline-host posture)
-;; - theme default `:light` (rf2-3f2di — the authoritative reference
+;; - theme default `:light` (the authoritative reference
 ;;   `tools/xray/design-reference/xray_devtools_reference.cljs` renders
 ;;   light by default; Xray boots onto the same default. Both palettes
 ;;   exist in `theme/tokens.cljc` and the user can flip to dark.)
@@ -955,15 +936,15 @@
 ;;   subsequent inline-style reads via the published CSS custom
 ;;   property `--rf-xray-text-size`).
 ;;
-;; ## Migration (rf2-jh9ws)
+;; ## Unknown-section tolerance
 ;;
-;; Settings persisted with `:telemetry` key from prior sessions
-;; should NOT break. `load-settings-from-storage!` deep-merges over
-;; `default-settings` per-known-section, so any legacy `:telemetry`
-;; key in the persisted payload is silently dropped (the merge target
-;; no longer carries the slot). Same for `update-setting!` —
+;; A persisted payload carrying an unknown top-level section MUST NOT
+;; break. `load-settings-from-storage!` deep-merges over
+;; `default-settings` per-known-section, so any unknown top-level key in
+;; the persisted payload is silently dropped (the merge target only
+;; carries known slots). Same for `update-setting!` —
 ;; `valid-section-key?` rejects unknown `[section key]` paths so a
-;; rogue `[:telemetry :opt-in?]` write is a no-op + a tap>.
+;; write to an unknown section is a no-op + a tap>.
 
 (def settings-storage-key
   "localStorage key the settings round-trip uses. Versioned so a future
@@ -977,8 +958,7 @@
   against. See the comment block above for the rationale on each
   default.
 
-  ## :diff section (rf2-i39w2 — hiccup-diff micro-engine, Phase 3 of
-  rf2-abts7)
+  ## :diff section (hiccup-diff micro-engine)
 
   `:highlight-fn-ref-changes?` — opt-in toggle for the hiccup-diff
   engine's fn-ref classification (`ai/findings/2026-05-18-difftastic-
@@ -988,41 +968,38 @@
   `true` when diagnosing memoization issues — child re-renders because
   the parent passes a new fn every time.
 
-  ## :general additions (rf2-ttnst — Settings popup v1 expansion)
+  ## :general additions (Settings popup v1)
 
   - `:density` (#{:cosy :compact}, default `:cosy`) — vertical-rhythm
-    knob applied to Views detail rows + App-db diff rows. Per Mike's
-    2026-05-19 walkthrough the Comfy tier is dropped; only two
-    densities ship in v1. Consumers read `:rf.xray/density` and
-    branch padding/line-height. Runtime plumbing into individual
-    panels lands incrementally.
+    knob applied to Views detail rows + App-db diff rows. Two densities
+    ship in v1. Consumers read `:rf.xray/density` and branch
+    padding/line-height. Runtime plumbing into individual panels lands
+    incrementally.
   - `:show-tool-frames?` (boolean, default `false`) — when true the
     L1 frame picker dropdown reveals tool frames (`:rf/xray`,
     `:rf/pair2`). OFF by default per spec/007-UX-IA.md §Frame-
     observation isolation invariant I1.
   - `:long-keyword-threshold` (integer, default 24) — character count
     above which a fully-qualified keyword is elided in compact list
-    cells. Per spec/007-UX-IA.md §Long-keyword treatment; was
-    previously a fixed constant.
+    cells. Per spec/007-UX-IA.md §Long-keyword treatment.
   - `:show-unchanged-subs?` (boolean, default `false`) — always-expand
     pin for the Reactive panel's 'unchanged subs' disclosure (per
-    spec/021 §3.4 · rf2-wyvf2). OFF by default: unchanged subs are
+    spec/021 §3.4). OFF by default: unchanged subs are
     coverage signal, not signal-of-the-moment, so the panel hides
     them behind a footer disclosure that operator can flip per-
     cascade. Flip ON to always expand the disclosure inline.
 
   - `:show-ungrouped?` (boolean, default `false`) — opt-in surface
-    for the `:ungrouped` pseudo-cascade bucket (per rf2-r9lyy / Mike
-    2026-05-19 closure of rf2-q60yf). OFF by default: the L2 event
-    list filters `:ungrouped` (registry-time emits, frame lifecycle
-    outside a drain, `:rf.ssr/hydration-mismatch`, REPL evals) per
-    rf2-639lc — silent-by-default. Flip ON to reveal those events
+    for the `:ungrouped` pseudo-cascade bucket. OFF by default: the L2
+    event list filters `:ungrouped` (registry-time emits, frame
+    lifecycle outside a drain, `:rf.ssr/hydration-mismatch`, REPL
+    evals) — silent-by-default. Flip ON to reveal those events
     in L2 with a muted visual treatment; clicking the row focuses
     the bucket so downstream panels populate. Useful when debugging
     SSR / REPL / registry-time flows.
 
   - `:epoch-history` (integer, default 50) — depth of the per-frame
-    epoch ring buffer (per rf2-3zyyx / spec/021 §10.7, §13). Maps 1:1
+    epoch ring buffer (per spec/021 §10.7, §13). Maps 1:1
     to `(rf/configure! {:epoch-history {:depth N}})` — Xray's settings
     write through to that runtime knob via `apply-epoch-history!` so
     the live substrate ring resizes immediately on change AND the
@@ -1033,7 +1010,7 @@
     values save memory in long sessions, higher values retain more
     time-travel coverage.
 
-  ## :buffer section (rf2-ttnst — Settings popup v1 expansion)
+  ## :buffer section (Settings popup v1)
 
   Buffer-depth tunables surfaced in the Buffer tab.
 
@@ -1042,41 +1019,39 @@
     `re-frame.trace.tooling/default-cascades-retained`. Writes through
     to the runtime ring via `(rf/configure! {:trace-buffer
     {:cascades-retained N}})` — `apply-cascades-retained!` resizes the
-    live ring and `apply-all!` replays the persisted value on boot
-    (rf2-5u03ig). Renamed from `:trace-buffer/keep` per the rf2-3g9nw
-    D1=a ruling: the unit changed from events (1000) to cascades (50)
-    when Xray's separate ring was retired in favour of the framework's
-    per-frame cascade-keyed rings.
+    live ring and `apply-all!` replays the persisted value on boot.
+    The unit is cascades (50), retained in the framework's per-frame
+    cascade-keyed rings.
 
-  ## `:event-list-col-widths` (rf2-6ni62 — resizable event-list columns)
+  ## `:event-list-col-widths` (resizable event-list columns)
 
   Per-column pixel widths for the L2 event list's three user-resizable
   columns. The leading `event-id` column stays `flex: 1 1 auto` and
   absorbs any remaining width; the trailing three carry explicit widths
   the user drags via divider handles between cells. Persisted through
   the same settings round-trip so widths survive reload. Floors live in
-  `event-list-col-min-widths`; defaults match the pre-resize fixed
-  widths so a fresh install reads identically to the pre-feature shell.
+  `event-list-col-min-widths`; defaults give a fresh install a sensible
+  starting layout.
 
   Header + every row read these widths via the same
   `:rf.xray/event-list-col-widths` sub so the two surfaces never drift
   out of column alignment."
   {:general   {:text-size              13              ; px — slider range 10–18
-               :panel-position         :right-rail     ; :right-rail | :fullscreen (rf2-czcg5 dropped :popout — pop-out launches from the chrome ⛶ button)
-               :panel-width-px         default-panel-width-px ; rf2-x8h9y resize handle
-               :events-list-height-px  default-events-list-height-px ; rf2-t2dsh L2/L3 seam handle
+               :panel-position         :right-rail     ; :right-rail | :fullscreen (pop-out launches from the chrome ⛶ button)
+               :panel-width-px         default-panel-width-px ; resize handle
+               :events-list-height-px  default-events-list-height-px ; L2/L3 seam handle
                :auto-open-on-error?    false
                :density                :cosy           ; #{:cosy :compact}
                :show-tool-frames?      false
-               :show-unchanged-subs?   false           ; rf2-wyvf2 Reactive-panel disclosure pin
-               :show-ungrouped?        false           ; rf2-r9lyy opt-in pseudo-cascade surface
-               :epoch-history          50              ; rf2-3zyyx per-frame epoch ring depth
+               :show-unchanged-subs?   false           ; Reactive-panel disclosure pin
+               :show-ungrouped?        false           ; opt-in pseudo-cascade surface
+               :epoch-history          50              ; per-frame epoch ring depth
                :long-keyword-threshold 24
-               ;; rf2-ybjkx — user-side override of the OS-level
+               ;; User-side override of the OS-level
                ;; `prefers-reduced-motion: reduce` media query. Three
                ;; values:
-               ;;   :os      — defer to the OS pref (the historic
-               ;;              behaviour; CSS media query alone)
+               ;;   :os      — defer to the OS pref (CSS media query
+               ;;              alone)
                ;;   :always  — force reduced motion regardless of OS
                ;;   :never   — force full motion regardless of OS
                ;; Drives the `rf-xray-motion-override-{always,never}`
@@ -1084,7 +1059,7 @@
                ;; reads to override the media-query-derived
                ;; `--rf-xray-motion-scale`.
                :reduced-motion-override :os
-               ;; rf2-846h2 — user-side opt-in for the system-colors
+               ;; User-side opt-in for the system-colors
                ;; (Windows HCM) rendering path even when the OS HCM is
                ;; OFF. Default `false`. When `true`, the shell root +
                ;; `<html>` carry `data-rf-force-colors="active"`; the
@@ -1095,17 +1070,16 @@
                ;; chrome on demand. Additive to the OS detection —
                ;; both paths produce the same painted chrome.
                :use-system-colors?      false
-               ;; rf2-6ni62 — L2 event-list user-resizable column
-               ;; widths in pixels. Keys match the three resizable
-               ;; columns (`event-id` is flex). Defaults mirror the
-               ;; pre-resize fixed widths so a fresh install lays out
-               ;; identically. The drag-handle dispatch path clamps to
-               ;; `event-list-col-min-widths` before the write so the
+               ;; L2 event-list user-resizable column widths in pixels.
+               ;; Keys match the three resizable columns (`event-id` is
+               ;; flex). Defaults give a fresh install a sensible
+               ;; starting layout. The drag-handle dispatch path clamps
+               ;; to `event-list-col-min-widths` before the write so the
                ;; persisted payload is always in-range.
                :event-list-col-widths   {:source    52
                                          :timestamp 76
                                          :duration  60}
-               ;; rf2-dudqz — end-user editor override for Xray's
+               ;; End-user editor override for Xray's
                ;; 'Open in editor' click-to-source links. Mixed-editor
                ;; teams: the host app sets `:rf.xray/editor` once at
                ;; boot via `xray-config/configure!`, but individual
@@ -1125,7 +1099,7 @@
                ;; client-side; it never mutates the host's atom and
                ;; never reaches other browsers / tabs / users.
                :editor-override         nil}
-   :theme     :light                                 ; :light | :dark (rf2-3f2di — light default per the authority reference)
+   :theme     :light                                 ; :light | :dark (light default per the authority reference)
    :diff      {:highlight-fn-ref-changes? false}
    :buffer    {:cascades-retained 50}})
 
@@ -1148,10 +1122,9 @@
     over the default's, so unknown nested keys in `src` survive but
     a section absent from `src` keeps its full default.
   - `:theme` — a flat keyword, not a nested map; take the src's value
-    or fall back to the default (rf2-jh9ws).
-  Any unknown TOP-LEVEL section in `src` (e.g. a legacy `:telemetry`
-  key) falls on the floor — the reconstruction only knows the sections
-  enumerated here."
+    or fall back to the default.
+  Any unknown TOP-LEVEL section in `src` falls on the floor — the
+  reconstruction only knows the sections enumerated here."
   [src]
   (-> default-settings
       (update :general merge (:general src))
@@ -1161,7 +1134,7 @@
 
 (defn clamp-panel-width-px
   "Pure helper: clamp `px` to the resize handle's [min, viewport×0.9]
-  range (rf2-x8h9y). Pass `viewport-width-px` explicitly so the helper
+  range. Pass `viewport-width-px` explicitly so the helper
   stays CLJC-pure and JVM-testable (no implicit `window.innerWidth`
   reach). Non-numeric input falls back to `default-panel-width-px` so
   a malformed persisted payload never leaves the panel at an unusable
@@ -1174,13 +1147,13 @@
           ceil   (max floor max-px)]
       (long (-> px (max floor) (min ceil))))))
 
-;; ---- L2 event-list column widths (rf2-6ni62) -----------------------------
+;; ---- L2 event-list column widths ----------------------------------------
 ;;
 ;; The L2 event list carries four columns — `event-id` (flex), `source`,
 ;; `timestamp`, `duration`. The trailing three are user-resizable via
-;; drag handles BETWEEN columns. Defaults below mirror the pre-resize
-;; fixed widths so a fresh install lays out exactly as it did before the
-;; feature. Floors keep any column from collapsing to nothing — sized
+;; drag handles BETWEEN columns. Defaults below give a fresh install a
+;; sensible starting layout. Floors keep any column from collapsing to
+;; nothing — sized
 ;; from the lowercase column-label width (per-column floor, not a single
 ;; 60px blanket) so the header `source` / `timestamp` / `duration`
 ;; lowercase labels always read.
@@ -1190,15 +1163,13 @@
 ;; returns a fully-resolved map every consumer can read against. The
 ;; drag-handle dispatch path clamps to the floor BEFORE the write, so
 ;; the persisted payload is always in-range; `resolve-event-list-col-
-;; widths` is defence-in-depth for legacy payloads that pre-date the
-;; clamp.
+;; widths` is defence-in-depth for any out-of-range persisted payload.
 
 (def event-list-col-default-widths
   "Default per-column widths in pixels for the L2 event list's three
   user-resizable columns. Keys match the column ids (`event-id` is
-  flex; never sized). Values mirror the pre-resize fixed widths
-  (rf2-pjjwh + rf2-3f2di + rf2-lnod7) so a fresh install lays out
-  identically to the pre-feature shell."
+  flex; never sized). Values give a fresh install a sensible starting
+  layout."
   {:source    52
    :timestamp 76
    :duration  60})
@@ -1373,11 +1344,10 @@
      payload) degrade silently to the defaults the atom already holds.
      Called from the preload's side-effect block on CLJS startup.
 
-     Per rf2-jh9ws: legacy `:telemetry` keys (from sessions prior to
-     the Telemetry section's removal) are silently dropped — the
-     per-section merge below only knows about known slots, so any
-     unknown top-level key in the persisted payload falls on the
-     floor without throwing."
+     Unknown top-level keys in the persisted payload are silently
+     dropped — the per-section merge below only knows about known
+     slots, so any unknown top-level key falls on the floor without
+     throwing."
      []
      (try
        (when-let [raw (storage-get settings-storage-key)]
@@ -1427,7 +1397,7 @@
        (catch :default _ nil)))
   nil)
 
-;; ---- *filter-pills* (rf2-ak4ms — ribbon filter seeds + storage key) -----
+;; ---- *filter-pills* (ribbon filter seeds + storage key) -----------------
 ;;
 ;; Per `tools/xray/spec/018-Event-Spine.md` §7 ribbon pills persist
 ;; via localStorage per host-app under a Xray-namespaced key. Two
@@ -1450,8 +1420,8 @@
 
 (def default-filters
   "Default ribbon filter set Xray ships with — empty, per spec/018 §7
-  'Empty defaults' / rf2-ak4ms: first-session honesty beats first-
-  session quietness. Shipping a default `:mouse-move` filter would
+  'Empty defaults': first-session honesty beats first-session
+  quietness. Shipping a default `:mouse-move` filter would
   silently hide events the user didn't know they were emitting."
   {:in [] :out []})
 
@@ -1503,18 +1473,18 @@
 
 (defn configure!
   "Top-level Xray configuration. Every key lives under the
-  `:rf.xray/*` reserved namespace (per rf2-xea9u — re-frame2 tools'
-  `configure!` surfaces own their own reserved sub-namespace beneath
-  the framework `:rf/*` root; `:rf.<tool>/*` is the canonical
-  convention for ALL re-frame2 tool boot-time config). The on-box
-  reveal grain is per-tool (EP-0015 issue 7): Xray's egress profile
-  lives under `:rf.xray/egress-profile`, Story's under
-  `:rf.story/egress-profile` — there is NO single cross-tool toggle.
+  `:rf.xray/*` reserved namespace (re-frame2 tools' `configure!`
+  surfaces own their own reserved sub-namespace beneath the framework
+  `:rf/*` root; `:rf.<tool>/*` is the canonical convention for ALL
+  re-frame2 tool boot-time config). The on-box reveal grain is per-tool
+  (EP-0015 issue 7): Xray's egress profile lives under
+  `:rf.xray/egress-profile`, Story's under `:rf.story/egress-profile` —
+  there is NO single cross-tool toggle.
 
-  Keys group by TOPICAL prefix in their local name (the
-  key-naming axis per rf2-dz35f / audit-of-audits #16): editor /
-  layout-host / launch / keybinding / static-mode / settings /
-  filters / render / trace / logging. New keys MUST join an existing
+  Keys group by TOPICAL prefix in their local name (the key-naming
+  axis): editor / layout-host / launch / keybinding / static-mode /
+  settings / filters / render / trace / logging. New keys MUST join an
+  existing
   cluster prefix when the dial belongs to an established topic;
   mint a new prefix only when the knob opens a new axis. The full
   navigation map — every cluster, every v1 key, every vision key —
@@ -1522,11 +1492,10 @@
 
   Accepts:
 
-    `{:rf.xray/editor <kw>}` — Xray's 'Open in editor' preference
-       (rf2-evgf5).
+    `{:rf.xray/editor <kw>}` — Xray's 'Open in editor' preference.
     `{:rf.xray/project-root <string>}` — on-disk root prepended to
        the source-coord's classpath-relative `:file` slot before the
-       editor URI ships (rf2-5m5n2). Default `nil`. Nil / blank
+       editor URI ships. Default `nil`. Nil / blank
        clears the slot; an absent key leaves the current value
        untouched. Hosts whose source-paths are already absolute can
        leave this unset.
@@ -1545,10 +1514,9 @@
        listener. Embed hosts (Story mounts Xray as RHS) set `false`
        so their own global keybindings — typically `Cmd/Ctrl+K` for
        the host's command palette — are not swallowed by Xray's
-       capture-phase listener. Per rf2-4eyik (rf2-q7who Thread A).
-       MUST be set BEFORE the Xray preload runs.
+       capture-phase listener. MUST be set BEFORE the Xray preload runs.
     `{:rf.xray/egress-profile <kw>}` — Xray's on-box dev-UI egress
-       profile (EP-0015 issue 7, rf2-h40lt2). One of the closed
+       profile (EP-0015 issue 7). One of the closed
        `:rf.egress/*` enum (`re-frame.projection/profiles`); for the
        on-box dev surface the relevant pair is `:rf.egress/local-redacted`
        (the fail-closed default — suppress `:sensitive? true` display; the
@@ -1556,14 +1524,13 @@
        `:rf.egress/local-raw` (the trusted-local operator opt-in — reveal
        sensitive AND large values verbatim on your own machine). An unknown
        profile raises `:rf.error/unknown-egress-profile`. `nil` resets to
-       the default. This REPLACES the retired process-global
-       `:rf.privacy/show-sensitive?` boolean (rf2-azls9): EP-0015 §Cross-tool
-       visibility grain rules on-box visibility per `(tool, frame)`, with NO
-       single process-global user toggle. Revealing is an explicit operator
-       act flipping THIS tool's grain to `:rf.egress/local-raw`, not a
-       future-event switch shared across every tool.
+       the default. EP-0015 §Cross-tool visibility grain rules on-box
+       visibility per `(tool, frame)`, with NO single process-global user
+       toggle. Revealing is an explicit operator act flipping THIS tool's
+       grain to `:rf.egress/local-raw`, not a future-event switch shared
+       across every tool.
     `{:rf.xray/settings <map>}` — bulk-replace the Settings popup
-       state map (rf2-9poxq). Shape mirrors `default-settings`. The
+       state map. Shape mirrors `default-settings`. The
        popup's event surface (`:rf.xray/settings-update`) is the
        normal per-knob write path; this key is the bulk-set escape
        hatch (e.g. host wants to ship its own default theme).
@@ -1571,8 +1538,8 @@
        seed pill set the registry hydrates `:active-filters` with on
        FIRST install (when localStorage is empty). Default `nil` per
        spec/018 §7 'Empty defaults' — first-session honesty beats
-       first-session quietness (rf2-ak4ms). Story testbeds use this
-       to inject a known starting point for reproducibility.
+       first-session quietness. Story testbeds use this to inject a
+       known starting point for reproducibility.
     `{:rf.xray/filters-storage-key <string>}` — localStorage key
        the filter persistence layer reads / writes. Default
        `\"re-frame2.xray.filters.v1\"`. Hosts that run multiple
@@ -1593,10 +1560,9 @@
   Unknown keys are silently ignored (forward-compat: future Xray
   releases will grow keys; older hosts passing newer keys MUST NOT
   break, and newer hosts passing older-Xray-unaware keys MUST NOT
-  break). Pre-alpha posture: the rename to `:rf.xray/*` per
-  rf2-xea9u is a hard cut — the legacy bare / dotted spellings
-  (`:editor`, `:auto-open?`, `:launch/auto-open?`, etc.) are NOT
-  accepted. Returns nothing."
+  break). Every config key is `:rf.xray/*`-namespaced; bare / dotted
+  spellings (`:editor`, `:auto-open?`, `:launch/auto-open?`, etc.) are
+  NOT accepted. Returns nothing."
   [{editor-opt          :rf.xray/editor
     project-root-opt    :rf.xray/project-root
     settings-opt        :rf.xray/settings
@@ -1607,14 +1573,14 @@
     filters-opt         :rf.xray/filters
     filters-key-opt     :rf.xray/filters-storage-key
     :as opts}]
-  ;; rf2-eilutf — gate on key PRESENCE, not value `some?`. `set-editor!`
-  ;; already treats `nil` as the reset-to-default + clear-the-explicit-
-  ;; flag case (the per-key setter's documented contract); gating on
-  ;; `some?` here made the bulk `configure!` surface NON-equivalent to
-  ;; `set-editor!` — `(configure! {:rf.xray/editor nil})` silently
-  ;; no-op'd, leaving `editor-configured?` stuck true after a host tried
-  ;; to reset. Mirror every other key below (all `contains?`-gated) so an
-  ;; explicit `nil` resets and an ABSENT key leaves the atom untouched.
+  ;; Gate on key PRESENCE, not value `some?`. `set-editor!` treats `nil`
+  ;; as the reset-to-default + clear-the-explicit-flag case (the per-key
+  ;; setter's documented contract); gating on `some?` here would make the
+  ;; bulk `configure!` surface NON-equivalent to `set-editor!` —
+  ;; `(configure! {:rf.xray/editor nil})` would silently no-op, leaving
+  ;; `editor-configured?` stuck true after a host tried to reset. Every
+  ;; key below is `contains?`-gated so an explicit `nil` resets and an
+  ;; ABSENT key leaves the atom untouched.
   (when (contains? opts :rf.xray/editor)
     (set-editor! editor-opt))
   (when (contains? opts :rf.xray/project-root)
@@ -1625,10 +1591,10 @@
     (set-auto-open! auto-open-opt))
   (when (contains? opts :rf.xray/keybinding-enabled?)
     (set-keybinding-enabled! keybinding-opt))
-  ;; rf2-h40lt2 — the EP-0015 per-(tool,frame) egress profile replaces the
-  ;; retired process-global `:rf.privacy/show-sensitive?` boolean. Reject an
-  ;; unknown profile loudly (`:rf.error/unknown-egress-profile`) — the enum
-  ;; is closed — rather than silently coercing to the default, so a typo'd
+  ;; The EP-0015 per-(tool,frame) egress profile governs on-box reveal
+  ;; grain. Reject an unknown profile loudly
+  ;; (`:rf.error/unknown-egress-profile`) — the enum is closed —
+  ;; rather than silently coercing to the default, so a typo'd
   ;; reveal request surfaces instead of leaving the operator on the
   ;; fail-closed default thinking they opted in.
   (when (contains? opts :rf.xray/egress-profile)
@@ -1643,17 +1609,16 @@
   ;; NB: `settings-opt` is the destructured bulk-config map; the
   ;; in-namespace defonce atom is reached via the fully-qualified
   ;; symbol (`day8.re-frame2-xray.config/settings`) to disambiguate.
-  ;; rf2-jh9ws: legacy `:telemetry` keys in the bulk-config map are
-  ;; silently dropped — the per-section merge here only knows about
-  ;; known slots.
+  ;; Unknown sections in the bulk-config map are silently dropped — the
+  ;; per-section merge here only knows about known slots.
   (when (contains? opts :rf.xray/settings)
     (when (map? settings-opt)
       (reset! day8.re-frame2-xray.config/settings
               (merge-known-sections settings-opt))
       #?(:cljs (write-storage!))))
-  ;; Filter seed + storage key (rf2-ak4ms). Storage key sets BEFORE
-  ;; seed so a host that overrides both in one call gets the seed
-  ;; persisted under the right key.
+  ;; Filter seed + storage key. Storage key sets BEFORE seed so a host
+  ;; that overrides both in one call gets the seed persisted under the
+  ;; right key.
   (when (contains? opts :rf.xray/filters-storage-key)
     (set-filters-storage-key! filters-key-opt))
   (when (contains? opts :rf.xray/filters)
@@ -1664,8 +1629,8 @@
 
 (defn editor-uri
   "Build an 'Open in editor' URI for `source-coord` using Xray's
-  configured editor + configured project-root (rf2-5m5n2). Thin
-  wrapper around `re-frame.source-coords.editor-uri/editor-uri` that
+  configured editor + configured project-root. Thin wrapper around
+  `re-frame.source-coords.editor-uri/editor-uri` that
   reads the current preference from the atom AND threads the
   configured project-root through the helper's 3-arg form. Returns a
   string URI, or nil when the source-coord has no `:file`."

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -8,7 +8,7 @@
   `init!` / `open!` / `open-overlay!` / `close!` / `toggle!` /
   `popout!` / `status` /
   `target-frame` + `set-target-frame!` / `focus!` (the host-facing
-  Story→Xray focus entry point, rf2-crtmq) / `load-theme` — plus the
+  Story→Xray focus entry point) / `load-theme` — plus the
   four highest-traffic boot-time config knobs exposed by `config.cljc`
   (`configure!` / `set-editor!` / `set-auto-open!` /
   `set-egress-profile!`).
@@ -54,14 +54,14 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.focus :as focus]
-            ;; rf2-5w06uu — require the INERT install-helper ns, NOT the
+            ;; Require the INERT install-helper ns, NOT the
             ;; side-effecting `day8.re-frame2-xray.preload`. Loading
             ;; `preload` runs its top-level boot block (settings load,
             ;; handler/collector registration, browser globals,
-            ;; keybinding attach, auto-open) — so requiring this facade
-            ;; to reach the MANUAL `init!`/`configure!` API used to fire
+            ;; keybinding attach, auto-open); requiring this facade to
+            ;; reach the MANUAL `init!`/`configure!` API must NOT fire
             ;; full preload behaviour before the host's `configure!`
-            ;; could win. `install` is load-inert; the side-effects fire
+            ;; can win. `install` is load-inert; the side-effects fire
             ;; only when `init!` (below) calls them.
             [day8.re-frame2-xray.install :as install]
             [day8.re-frame2-xray.keybinding :as keybinding]
@@ -93,7 +93,7 @@
   mount/open!)
 
 (def open-overlay!
-  "Debug/fallback launch path: mount Xray as the legacy fixed overlay
+  "Debug/fallback launch path: mount Xray as a fixed overlay
   under `document.body`. Not the default developer experience."
   mount/open-overlay!)
 
@@ -132,15 +132,13 @@
        :density      :compact           ;; / :cosy   (settings persist)
        :buffer-depths {:epoch 50}}      ;; per-frame ring depth
 
-  EP-0002 (rf2-bd4div) — the inspected-host opt is `:target-frame`,
-  distinct from Xray's OWN frame (`:own-frame`, the `:rf/xray` shell
-  frame where the chrome's app-db lives — a fixed singleton, not a
-  per-call opt). The legacy `:default-frame` key is RETIRED (pre-alpha,
-  no shim): it conflated the two roles and read like the ambient
-  `:rf/default` fallback this EP removes. Omitting `:target-frame` leaves
-  the inspected target UNSELECTED — the frame picker (or the mount-time
-  discovery policy) selects one; Xray does NOT default the target to
-  `:rf/default` (Spec 002 §Frame target resolution — the carried invariant).
+  EP-0002 — the inspected-host opt is `:target-frame`, distinct from
+  Xray's OWN frame (`:own-frame`, the `:rf/xray` shell frame where the
+  chrome's app-db lives — a fixed singleton, not a per-call opt).
+  Omitting `:target-frame` leaves the inspected target UNSELECTED — the
+  frame picker (or the mount-time discovery policy) selects one; Xray
+  does NOT default the target to `:rf/default` (Spec 002 §Frame target
+  resolution).
 
   Wires the five foundation side-effects (registry, trace-cb, epoch-cb,
   browser-API exports, keybinding listener), then threads each supplied
@@ -158,11 +156,9 @@
   - `:buffer-depths` — accepts `{:epoch <n>}`; writes `:general
     :epoch-history` and drives the substrate's per-frame ring
     (`:depth` + `:trace-events-keep` to the same n) so trace is
-    retained for every retained epoch. The `:trace` axis from prior
-    spec drafts is folded into this single knob per the rf2-3g9nw D1=a
-    ruling + Mike pair-debug 2026-05-27 (one operator knob, atomic
-    relationship). Passing `:trace` is silently dropped pending a
-    second-axis separation if one re-emerges.
+    retained for every retained epoch. Trace retention is folded into
+    this single knob (one operator knob, atomic relationship). Passing
+    a separate `:trace` axis is silently dropped.
 
   Unknown opt keys are silently ignored (forward-compat): a future
   release adds keys here without breaking older callers, and a host
@@ -175,21 +171,20 @@
    (registry/register-xray-handlers!)
    (install/register-trace-collector!)
    (install/register-epoch-collector!)
-   ;; rf2-xxo3zz — install the browser-API exports on
+   ;; Install the browser-API exports on
    ;; `window.day8.re_frame2_xray.*` (same call the preload's boot
    ;; block makes). The palette pop-out fx + the Settings panel-position
    ;; effect late-bind their mount calls through these exports to break
    ;; the `mount → shell → palette/settings → mount` require cycle (see
-   ;; palette/events §mount-popout! + settings/effects §late-bind). Until
-   ;; this call landed, manual `init!` registered every handler but left
-   ;; the exports uninstalled, so those late-bound actions (palette
-   ;; Ctrl+Enter pop-out, Settings panel-position → fullscreen / back-to-
-   ;; inline, fullscreen, right-rail) silently no-op'd under the manual
-   ;; install path while the preload path worked. Idempotent: re-exports
+   ;; palette/events §mount-popout! + settings/effects §late-bind). The
+   ;; manual `init!` path must install the exports so those late-bound
+   ;; actions (palette Ctrl+Enter pop-out, Settings panel-position →
+   ;; fullscreen / back-to-inline, fullscreen, right-rail) fire under it
+   ;; just as they do under the preload path. Idempotent: re-exports
    ;; the same fn values.
    (install/install-browser-api-exports!)
    (keybinding/attach!)
-   ;; EP-0002 (rf2-bd4div) — select the explicit inspected TARGET frame in
+   ;; EP-0002 — select the explicit inspected TARGET frame in
    ;; Xray's OWN (`:rf/xray`) frame. Absent → leave unselected (the picker
    ;; / mount discovery policy chooses); never a `:rf/default` fallback.
    (when target-frame
@@ -214,7 +209,7 @@
   scrubber / app-db / machine-inspector panels are observing — or
   **`nil` when UNSELECTED**.
 
-  EP-0002 (rf2-bd4div) — the inspected target starts UNSELECTED and is
+  EP-0002 — the inspected target starts UNSELECTED and is
   selected by host config (`init! {:target-frame …}` / `set-target-
   frame!`), the frame picker, or the mount-time discovery policy. It is
   NOT defaulted to `:rf/default`: `:rf/default` is an ordinary id, never
@@ -226,9 +221,7 @@
 
   Named parallel to the underlying `:rf.xray/target-frame` sub +
   `:rf.xray/set-target-frame` event (and the `set-target-frame!`
-  setter below) so the facade name matches runtime reality. Prior to
-  rf2-kmhvg the fn was `active-frame` — the rename eliminates the
-  `active` / `target` split."
+  setter below) so the facade name matches runtime reality."
   []
   (rf/with-frame :rf/xray
     (rf/subscribe-once [:rf.xray/target-frame])))
@@ -239,10 +232,9 @@
   `:rf.xray/target-frame` sub and every dependent panel re-fire on the
   standard reactive path.
 
-  EP-0002 (rf2-bd4div) — `nil` resets the target to UNSELECTED (the
-  panels render their no-frame-selected state and the picker prompts a
-  choice). It no longer resets THROUGH a synthesised `:rf/default`:
-  the inspected target is never absence-repaired to the ordinary
+  EP-0002 — `nil` resets the target to UNSELECTED (the panels render
+  their no-frame-selected state and the picker prompts a choice). The
+  inspected target is never absence-repaired to the ordinary
   `:rf/default` id (Spec 002 §Frame target resolution).
 
   Returns nothing."
@@ -251,7 +243,7 @@
     (rf/dispatch [:rf.xray/set-target-frame frame-id]))
   nil)
 
-;; ---- Story → Xray focus (rf2-crtmq) -------------------------------------
+;; ---- Story → Xray focus -------------------------------------------------
 ;;
 ;; The host-facing focus entry point: a host (Story) sends a small,
 ;; data-shaped focus command from a narrative beat / failed assertion /
@@ -266,7 +258,7 @@
   "Focus an embedded Xray surface from a host (Story) beat / assertion /
   inspect command. See `day8.re-frame2-xray.focus/focus!` for the full
   command shape + ownership contract. The host-facing channel for
-  StoryUI focus links (rf2-crtmq)."
+  StoryUI focus links."
   focus/focus!)
 
 (def valid-focus-panels
@@ -275,11 +267,9 @@
   :machines :routing :resources :derivation-graph :module-view}`. A host
   validates a panel selector against this set before sending a focus
   command (the host-friendly alias `:routes` normalises to `:routing`).
-  The Issues tab was removed per rf2-gbz39 (Option (c)), so `:issues` is
-  no longer focusable. This MIRRORS the live L4 tab registry
-  (`panel-registry/tab-ids-for-mode :dynamic`) — rf2-1sddi6 / rf2-7ed9ms
-  aligned the set to the shipped inventory. See
-  `day8.re-frame2-xray.focus/valid-panels`."
+  This MIRRORS the live L4 tab registry
+  (`panel-registry/tab-ids-for-mode :dynamic`) — the set tracks the
+  shipped inventory. See `day8.re-frame2-xray.focus/valid-panels`."
   focus/valid-panels)
 
 ;; ---- runtime theme override ---------------------------------------------
@@ -307,10 +297,9 @@
 
 (def configure!
   "Top-level Xray configuration. Every key lives under the
-  `:rf.xray/*` reserved namespace (per rf2-xea9u — the `:rf.<tool>/*`
-  convention for re-frame2 tools' boot-time config). The on-box reveal
-  grain is per-tool (EP-0015 issue 7): there is NO single cross-tool
-  toggle.
+  `:rf.xray/*` reserved namespace (the `:rf.<tool>/*` convention for
+  re-frame2 tools' boot-time config). The on-box reveal grain is
+  per-tool (EP-0015 issue 7): there is NO single cross-tool toggle.
 
     `{:rf.xray/editor <kw>}`                — 'Open in editor' preference.
     `{:rf.xray/layout-host-selector <css>}` — true-inline layout host selector.
@@ -338,10 +327,9 @@
 
 (def set-egress-profile!
   "Replace Xray's on-box dev-UI `:rf.egress/*` profile (EP-0015
-  per-(tool,frame) reveal grain, rf2-h40lt2). `:rf.egress/local-redacted`
+  per-(tool,frame) reveal grain). `:rf.egress/local-redacted`
   (default) suppresses `:sensitive? true` display in Xray's trace
   collector; `:rf.egress/local-raw` is the trusted-local operator opt-in
   that reveals sensitive AND large values verbatim. `nil` resets to the
-  default. Replaces the retired process-global `set-show-sensitive!`
-  (`:rf.privacy/show-sensitive?`)."
+  default."
   config/set-egress-profile!)

--- a/tools/xray/src/day8/re_frame2_xray/defaults.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/defaults.cljs
@@ -1,9 +1,9 @@
 (ns day8.re-frame2-xray.defaults
   "Shared defaults for Xray's registrar surface.
 
-  Extracted so per-panel `install!` fns (the panel-owned blocks
-  migrated out of `registry.cljs` per rf2-d4xda) can read these Vars
-  without depending on `registry.cljs` — `registry.cljs` requires the
+  The dependency-free seam the per-panel `install!` fns (the
+  panel-owned registrar blocks) read these Vars through without
+  depending on `registry.cljs` — `registry.cljs` requires the
   panel namespaces to call their `install!` fns, so a panel→registry
   edge would form a cycle. This ns is the dependency-free seam.
 
@@ -12,11 +12,11 @@
   source of truth, same external surface.")
 
 (def default-frame-id
-  "Production singleton frame-id for the Xray SHELL itself (rf2-lnluk).
+  "Production singleton frame-id for the Xray SHELL itself.
   Distinct from `default-target-frame` (the OBSERVED host frame): this
   is the frame the shell's OWN app-db lives in — selected tab, focused
   epoch, theme, modal open-state. The single permitted bare `:rf/xray`
-  literal in the render-tree per the rf2-1w07r EPIC; every other
+  literal in the render-tree; every other
   affordance resolves its frame from React-context or a captured
   dispatcher rather than this literal.
 
@@ -31,12 +31,12 @@
   "The default OBSERVED-target state when no host frame has been
   selected: **`nil` = UNSELECTED**.
 
-  EP-0002 (rf2-bd4div) — Xray distinguishes its OWN frame (`default-
-  frame-id`, `:rf/xray`, where the shell's chrome state lives) from the
+  EP-0002 — Xray distinguishes its OWN frame (`default-frame-id`,
+  `:rf/xray`, where the shell's chrome state lives) from the
   inspected TARGET frame (the host app frame the scrubber / app-db /
   machine-inspector panels observe). The target frame is NOT defaulted to
-  `:rf/default`: under the carried invariant `:rf/default` is an ordinary
-  id, never an absence-repair fallback (Spec 002 §Frame target resolution).
+  `:rf/default`: `:rf/default` is an ordinary id, never an
+  absence-repair fallback (Spec 002 §Frame target resolution).
   The target frame starts UNSELECTED and becomes selected only by:
 
     - host config (`init! {:target-frame …}` / `set-target-frame!`),
@@ -49,7 +49,7 @@
   `:rf.xray/target-frame` sub reports `nil` and the panels render their
   unselected-target state (the frame picker prompts a choice) rather than
   reading a synthesised `:rf/default`. `set-target-frame! nil` resets to
-  this UNSELECTED state — it no longer resets THROUGH `:rf/default`.
+  this UNSELECTED state.
 
   Read via the `:rf.xray/target-frame` sub or written via the
   `:rf.xray/set-target-frame` event; panels that need the host db read

--- a/tools/xray/src/day8/re_frame2_xray/drop_in.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/drop_in.cljc
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.drop-in
-  "Drop-in mode for non-re-frame2 hosts (rf2-1o9cq, v1.1).
+  "Drop-in mode for non-re-frame2 hosts (v1.1).
 
   Xray's primary integration is as a dev-tool inside a re-frame2 app:
   the host's `re-frame.trace/emit!` calls fan trace events out to
@@ -88,8 +88,7 @@
   drop-in's pushes through Closure DCE. Hosts MAY call `attach!`
   unconditionally; in production it is a silent no-op.
 
-  Pre-alpha posture: no back-compat shims, no legacy spellings. The
-  API is a single arity-1 `attach!` taking an options map. Future
+  The API is a single arity-1 `attach!` taking an options map. Future
   modes (binary trace decoders, transit-over-websocket, etc.) add
   keys here additively."
   (:require [re-frame.interop :as interop]
@@ -168,8 +167,8 @@
   Xray-internal events carry `:frame :rf/xray`; host events cannot —
   so the filter is structurally a pass-through on this code path.
   Drop-in events carry no `:frame` so the trace collector routes them
-  to the frameless secondary ring (per the rf2-3g9nw D2=a ruling), the
-  same place the framework's frameless emits land.
+  to the frameless secondary ring, the same place the framework's
+  frameless emits land.
 
   Returns nothing. No-op when `event` is not a map (see
   `valid-event?`) or when the build is production (the `collect-

--- a/tools/xray/src/day8/re_frame2_xray/filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.filters
-  "Facade for Xray's IN/OUT auto-filter subsystem (rf2-ak4ms).
+  "Facade for Xray's IN/OUT auto-filter subsystem.
 
   Per the canonical Xray panel-facade pattern (mirrored from
   `palette.cljs`): the facade owns the `reg-view` Modal wrapper for
@@ -33,14 +33,14 @@
             [day8.re-frame2-xray.filters.typed-predicates :as typed]
             [day8.re-frame2-xray.spine-filters :as spine-filters]))
 
-;; ---- L2 visible-row predicate (rf2-jvghz) -------------------------------
+;; ---- L2 visible-row predicate -------------------------------------------
 ;;
 ;; Mirrors `shell/l2-cascade-visible?` — kept local so the
 ;; `:rf.xray/hidden-by-filters` sub below can count over the SAME
 ;; visible-row set the L2 list renders without a shell ↔ filters require
 ;; cycle (the shell already requires this ns transitively). The
 ;; `:ungrouped` bucket carries `:dispatch-id :ungrouped`; it only renders
-;; in L2 when the rf2-r9lyy power-user opt-in is on, so it is excluded
+;; in L2 when the power-user opt-in is on, so it is excluded
 ;; from the hidden-count's visible set by default — keeping N consistent
 ;; with the rows the user sees.
 
@@ -54,11 +54,11 @@
 
 (rf/reg-view Modal
   "The edit popup. Renders only when `:rf.xray/edit-popup-open?` is
-  true; closed-state is a single subscribe + a `when`. Per rf2-in6l2
+  true; closed-state is a single subscribe + a `when`.
   `reg-view`-registered so the body's subscribes route through the
   React-context tier to `:rf/xray`.
 
-  rf2-nesy9 — threads the reg-view-injected frame-aware `dispatch`
+  Threads the reg-view-injected frame-aware `dispatch`
   into `popup-view` so deferred `:on-*` handlers land on the
   surrounding instance frame, not a `{:frame :rf/xray}` literal."
   []
@@ -69,7 +69,7 @@
 
 (defn hydrate!
   "Drive the localStorage / seed / empty hydration order per spec/018
-  §7 + rf2-ak4ms:
+  §7:
 
     1. localStorage value (the user's last-session pill set);
     2. host-supplied seed via `(xray-config/configure! {:rf.xray/filters …})`
@@ -120,7 +120,7 @@
 (defn- append-typed-pill
   "Append a typed pill to `mode`'s bucket; no-op when an equivalent
   pill already exists. Used by the `:rf.xray/filter-by-*` typed-add
-  events (rf2-piye4) — the right-click affordances on the Machines /
+  events — the right-click affordances on the Machines /
   managed-fx panels dispatch through this so a double-add collapses
   to one pill rather than piling duplicates."
   [db mode pill]
@@ -146,7 +146,7 @@
               `:rf.xray/delete-edit-popup`,
               `:rf.xray/hide-event-type`,
               `:rf.xray/hydrate-filters`,
-              + rf2-piye4 typed-add events:
+              + typed-add events:
               `:rf.xray/filter-by-machine`,
               `:rf.xray/filter-by-http-correlation`,
               `:rf.xray/filter-by-fx`.
@@ -156,7 +156,7 @@
     - Side-effect: hydrate `:active-filters` from localStorage at
       first install via a no-history dispatch.
 
-  Called from `registry/register-xray-handlers!` after the legacy
+  Called from `registry/register-xray-handlers!` after the
   `:rf.xray/active-filters` slot is registered (so the sub-graph
   resolves in declaration order)."
   []
@@ -171,7 +171,7 @@
   ;; reads `:rf.xray/filtered-cascades`; raw `:rf.xray/cascades`
   ;; stays available for unfiltered totals.
   ;;
-  ;; Per spec/018 §3 Frame dropdown + rf2-oziyr: the frame picker is
+  ;; Per spec/018 §3 Frame dropdown: the frame picker is
   ;; ALSO a data-layer filter. The picker's selection lives on the
   ;; spine's `:focus :frame` slot (written by `:rf.xray/set-frame`);
   ;; we read the raw slot here (not the composed `:rf.xray/focus` sub)
@@ -180,25 +180,24 @@
   ;; app, picker has not been touched, OR a single-frame app whose
   ;; picker collapses to a flat label).
   ;; Pill matching routes through the typed-predicate dispatcher
-  ;; (rf2-piye4) so each pill's `:kind` selects the per-kind cascade
-  ;; matcher (`:event-id-pattern` delegates to the existing event-id
+  ;; so each pill's `:kind` selects the per-kind cascade
+  ;; matcher (`:event-id-pattern` delegates to the event-id
   ;; matcher; `:machine` / `:http-correlation` / `:fx` walk the
-  ;; cascade's trace-events for the matching tag). Pre-typed pills
+  ;; cascade's trace-events for the matching tag). Pills
   ;; persisted under `{:pattern <kw-or-str>}` hydrate as
-  ;; `:event-id-pattern` via `canonicalise-pill` — no migration step
-  ;; needed.
-  ;; rf2-ikuwt — the muted-event-ids set rides at the END of the
+  ;; `:event-id-pattern` via `canonicalise-pill`.
+  ;; The muted-event-ids set rides at the END of the
   ;; filter chain so right-click → 'Mute :event-id' strips the row
   ;; from L2 regardless of any IN-pill state. (An IN pill says 'keep
   ;; only these'; mute says 'never these'. Composition is OUT-like
   ;; semantically, but the mute set is a separate slot so it persists
   ;; independently of the pill set and the unmute manager has a clean
   ;; surface to enumerate.)
-  ;; rf2-4vp5j Workstream C — the frame scope reads the dedicated
+  ;; The frame scope reads the dedicated
   ;; `:rf.xray/view-scope-frame` slot (a single defaulted VIEW SCOPE),
   ;; NOT the spine's `[:focus :frame]` (which epoch auto-alignment + the
-  ;; focus-step walk also write — reading it here silently re-scoped the
-  ;; list to whatever epoch the user stepped onto). The frame is applied
+  ;; focus-step walk also write — reading it there would silently re-scope
+  ;; the list to whatever epoch the user stepped onto). The frame is applied
   ;; as a view scope FIRST, then the pill chain + mutes (the actual
   ;; filters) compose on top.
   ;;
@@ -222,20 +221,20 @@
           (typed/filter-cascades filters)
           (spine-filters/filter-cascades muted))))
 
-  ;; rf2-jvghz defect #1 + rf2-4vp5j Workstream C — the 'N events hidden
-  ;; by filters' message model. Composes the raw + filtered cascade lists
-  ;; and the active filter state into the pure `hidden/summary` record
-  ;; the events ribbon renders against. Counts over the L2 visible-row
-  ;; set (`l2-visible?`) so N matches the rows the user sees.
+  ;; The 'N events hidden by filters' message model. Composes the raw +
+  ;; filtered cascade lists and the active filter state into the pure
+  ;; `hidden/summary` record the events ribbon renders against. Counts
+  ;; over the L2 visible-row set (`l2-visible?`) so N matches the rows
+  ;; the user sees.
   ;;
-  ;; FRAME IS A VIEW SCOPE, NOT A FILTER (rf2-4vp5j Workstream C): the
-  ;; count BASELINE is computed WITHIN the selected frame — `raw` is
-  ;; first scoped to the view-scope frame, then pills/mutes are measured
-  ;; against that scope. This means switching frames NEVER inflates
-  ;; "hidden" (previously `raw` counted across all frames, so picking a
-  ;; frame made every other frame's events look "hidden by filters").
-  ;; The summary carries no `:frame` cause; only pill/mute suppression
-  ;; is the cause and the count.
+  ;; FRAME IS A VIEW SCOPE, NOT A FILTER: the count BASELINE is computed
+  ;; WITHIN the selected frame — `raw` is first scoped to the view-scope
+  ;; frame, then pills/mutes are measured against that scope. This means
+  ;; switching frames NEVER inflates "hidden" — each frame's events count
+  ;; only against their own frame's baseline, so picking a frame never
+  ;; makes another frame's events look "hidden by filters". The summary
+  ;; carries no `:frame` cause; only pill/mute suppression is the cause
+  ;; and the count.
   (rf/reg-sub :rf.xray/hidden-by-filters
     :<- [:rf.xray/cascades]
     :<- [:rf.xray/filtered-cascades]
@@ -372,7 +371,7 @@
              :fx [[:rf.xray.filters/persist (get next-db :active-filters)]]})
           {:db (close-popup db)}))))
 
-  ;; ---- clear-all (rf2-jvghz + rf2-4vp5j) ------------------------------
+  ;; ---- clear-all ------------------------------------------------------
   ;;
   ;; One-click reset behind the events ribbon's `Clear Filters` button.
   ;; Resets every suppressing FILTER so the filtered list snaps back to
@@ -382,10 +381,8 @@
   ;;   2. muted event-ids     → `:rf.xray/clear-muted-event-ids` (+ its
   ;;      own persist fx)
   ;;
-  ;; Per rf2-4vp5j Workstream C the FRAME is a view SCOPE, not a filter —
-  ;; Clear Filters must NOT change the frame. The previous
-  ;; `[:dispatch [:rf.xray/select-frame nil]]` was removed; the picker's
-  ;; selection survives a Clear Filters.
+  ;; The FRAME is a view SCOPE, not a filter — Clear Filters must NOT
+  ;; change the frame; the picker's selection survives a Clear Filters.
   ;;
   ;; Pills are reset inline (this handler already owns the
   ;; `:active-filters` slot + persist fx); the mute reset routes through
@@ -419,7 +416,7 @@
                    (-> (edit-popup/pill->draft pill)
                        (assoc :mode :out)))))}))
 
-  ;; ---- typed-predicate add events (rf2-piye4) -------------------------
+  ;; ---- typed-predicate add events -------------------------------------
   ;;
   ;; Right-click affordances on the Machines / managed-fx panels fire
   ;; these events to append a typed-predicate IN pill directly — no
@@ -462,7 +459,7 @@
       {:db (assoc db :active-filters
                 (or filters {:in [] :out []}))}))
 
-  ;; NO hydrate on install (rf2-swclw). The IN/OUT pills are a TRANSIENT
+  ;; NO hydrate on install. The IN/OUT pills are a TRANSIENT
   ;; exploration filter — they reset to unfiltered on every page load so
   ;; a fresh session never silently carries a stale filter. The slot
   ;; starts at its registry default `{:in [] :out []}` and

--- a/tools/xray/src/day8/re_frame2_xray/filters/edit_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/edit_popup.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.filters.edit-popup
-  "Edit popup for IN/OUT filter pills (rf2-ak4ms).
+  "Edit popup for IN/OUT filter pills.
 
   Per `tools/xray/spec/018-Event-Spine.md` §7 'Click-pill → edit
   popup' the popup is a modal overlay with (Add-filter copy shown;
@@ -53,10 +53,10 @@
 
 ;; ---- styles --------------------------------------------------------------
 ;;
-;; Backdrop honours `:rf.xray/modal-positioning` (rf2-om6fa). `:fixed`
+;; Backdrop honours `:rf.xray/modal-positioning`. `:fixed`
 ;; (production default) keeps the full-viewport overlay with max-int
 ;; z-index (one above the palette so an edit popup opened over an
-;; open palette wins focus — palette is z 2147483646 per rf2-wm7z4).
+;; open palette wins focus — palette is z 2147483646).
 ;; `:absolute` (Story testbeds) confines the backdrop to the shell
 ;; cell and drops the z-index to a sane in-cell layer.
 
@@ -214,7 +214,7 @@
   "The popup body. Caller (`filters/Modal`) gates the mount on
   `:rf.xray/edit-popup-open?`.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher injected by the
+  `dispatch` is the frame-aware dispatcher injected by the
   `filters/Modal` `reg-view` body — every deferred handler routes
   through it so the edit lands on the surrounding instance frame, not
   a `{:frame :rf/xray}` literal."
@@ -231,7 +231,7 @@
         ;; Apply is enabled when the pattern is non-blank.
         can-apply?  (let [p (:pattern draft)]
                       (and (string? p) (seq (clojure.string/trim p))))]
-    ;; rf2-7oxvd — shared backdrop + dialog scaffold. Keeps this popup's
+    ;; Shared backdrop + dialog scaffold. Keeps this popup's
     ;; own `backdrop-style` / `dialog-style` and its `tab-index "-1"`
     ;; dialog root. It carries NO backdrop/dialog keydown handler — Esc
     ;; is handled inside the pattern input's own `:on-key-down` (the

--- a/tools/xray/src/day8/re_frame2_xray/filters/hidden.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/filters/hidden.cljc
@@ -1,22 +1,20 @@
 (ns day8.re-frame2-xray.filters.hidden
   "Pure derivation for the events-ribbon 'N events hidden by filters'
-  message (rf2-jvghz, defect #1; frame-decoupled per rf2-4vp5j).
+  message.
 
   ## Why
 
-  After the epoch-per-event merges, Xray's L2 event list could look
-  broken on reload: persisted filters (a `:machine` IN-pill under
-  `re-frame2.xray.filters.v1`) survived in localStorage and silently
-  suppressed cascade rows with NO visible indicator. The L2 list reads
-  `:rf.xray/filtered-cascades` (filtered) while the raw stream lives on
-  `:rf.xray/cascades`; when filters suppressed rows the list was
-  indistinguishable from a broken tool.
+  The L2 event list reads `:rf.xray/filtered-cascades` (filtered) while
+  the raw stream lives on `:rf.xray/cascades`. When filters suppress
+  rows — for example a persisted `:machine` IN-pill from
+  `re-frame2.xray.filters.v1` in localStorage — the indicator makes the
+  suppression visible so the list never reads as a broken tool.
 
   This ns is the pure data primitive behind the affordance: given the
   raw + filtered visible-cascade counts and the active filter state,
   it answers 'is anything hidden, how many, and what is the cause?'.
 
-  ## Frame is a view SCOPE, not a filter (rf2-4vp5j Workstream C)
+  ## Frame is a view SCOPE, not a filter
 
   The picker-selected frame is a single, defaulted VIEW SCOPE — it is
   NOT part of the filter chain conceptually. It is therefore NEVER
@@ -70,7 +68,7 @@
   cascade); the count is what gates the message's render, this predicate
   is what 'Clear Filters' acts on.
 
-  Per rf2-4vp5j the frame is a view SCOPE, not a filter — it is NOT part
+  The frame is a view SCOPE, not a filter — it is NOT part
   of this predicate, so a frame selection alone never shows the events-
   ribbon action cluster and Clear Filters never resets the frame."
   [{:keys [filters muted]}]
@@ -119,7 +117,7 @@
        :pills           [{…} …]   ; IN/OUT pill summaries
        :muted-count     <int>}    ; muted event-ids
 
-  `state` is `{:filters {:in [] :out []} :muted #{}}`. Per rf2-4vp5j the
+  `state` is `{:filters {:in [] :out []} :muted #{}}`. The
   frame is a view scope, NOT a filter — it is excluded from this model
   entirely (no `:frame` key, never a cause, never counted as hidden)."
   [raw-visible-count filtered-visible-count state]

--- a/tools/xray/src/day8/re_frame2_xray/filters/matcher.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/filters/matcher.cljc
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.filters.matcher
-  "Pattern matching for Xray's IN/OUT filter pills (rf2-ak4ms).
+  "Pattern matching for Xray's IN/OUT filter pills.
 
   Per `tools/xray/spec/018-Event-Spine.md` §7 the filter system runs
   at the DATA layer (`:rf.xray/filtered-cascades` sub) — every consumer
@@ -170,7 +170,7 @@
   [cascades filters]
   (filterv #(keep-cascade? % filters) cascades))
 
-;; ---- frame-picker filter (rf2-oziyr) -------------------------------------
+;; ---- frame-picker filter ------------------------------------------------
 
 (defn keep-cascade-for-frame?
   "True iff `cascade`'s `:frame` matches the picker-selected
@@ -192,15 +192,15 @@
 (defn filter-cascades-by-frame
   "Restrict `cascades` to those whose `:frame` matches `picker-frame`.
   nil `picker-frame` returns `cascades` unchanged. Pure — no I/O, no
-  atoms read. Per spec/018 §3 Frame dropdown + rf2-oziyr."
+  atoms read. Per spec/018 §3 Frame dropdown."
   [cascades picker-frame]
   (if (nil? picker-frame)
     cascades
     (filterv #(keep-cascade-for-frame? % picker-frame) cascades)))
 
 (defn keep-cascade-for-view-scope?
-  "True iff `cascade` is in the picker-selected VIEW SCOPE `scope-frame`
-  (rf2-4vp5j). Like `keep-cascade-for-frame?` but the FRAMELESS
+  "True iff `cascade` is in the picker-selected VIEW SCOPE `scope-frame`.
+  Like `keep-cascade-for-frame?` but the FRAMELESS
   `:ungrouped` pseudo-cascade (nil `:frame` — registry-time emits /
   lifecycle outside a drain) is frame-AGNOSTIC and always survives the
   scope: it has no frame to match, and whether it RENDERS is gated
@@ -216,7 +216,7 @@
 
 (defn filter-cascades-by-view-scope
   "Restrict `cascades` to the picker-selected VIEW SCOPE `scope-frame`,
-  preserving frameless `:ungrouped` pseudo-cascades (rf2-4vp5j). nil
+  preserving frameless `:ungrouped` pseudo-cascades. nil
   `scope-frame` returns `cascades` unchanged. Pure — no I/O, no atoms
   read. The L2 list + hidden-count baseline read THIS (not the strict
   `filter-cascades-by-frame`) so a defaulted view scope never drops the

--- a/tools/xray/src/day8/re_frame2_xray/filters/persistence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/persistence.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.filters.persistence
-  "localStorage round-trip for Xray's IN/OUT filter pills (rf2-ak4ms).
+  "localStorage round-trip for Xray's IN/OUT filter pills.
 
   Per `tools/xray/spec/018-Event-Spine.md` §7 Filter persistence:
   ribbon pills persist via localStorage per host-app under a Xray-
@@ -8,8 +8,8 @@
 
   ## Default is empty
 
-  Per Mike's call (rf2-ak4ms / 10x-config R5 / spec/018 §7 'Empty
-  defaults'): first-session honesty beats first-session quietness. No
+  Per spec/018 §7 'Empty defaults': first-session honesty beats
+  first-session quietness. No
   events are filtered out by default — the user surfaces the noise
   themselves with explicit filters. Shipping a default `:mouse-move`
   filter would silently hide events the user didn't know they were
@@ -75,7 +75,7 @@
 
 ;; ---- localStorage helpers ------------------------------------------------
 ;; Raw browser access + the no-op-when-unavailable / swallow-throws
-;; posture live in the shared `local-storage` seam (rf2-jkake.24). The
+;; posture live in the shared `local-storage` seam. The
 ;; key is resolved per call through `get-storage-key` so a runtime
 ;; `configure!` re-key takes effect immediately.
 

--- a/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
@@ -1,28 +1,20 @@
 (ns day8.re-frame2-xray.filters.pills
-  "Top-ribbon IN/OUT filter pills for Xray (rf2-ak4ms).
+  "Top-ribbon IN/OUT filter pills for Xray.
 
   Per `tools/xray/spec/018-Event-Spine.md` §3 + §7 the ribbon carries
-  a filter cluster — IN pills (green-bordered `+`) + OUT pills (red-
-  bordered `×`) per the authoritative reference events-ribbon
-  (rf2-3f2di A6). Clicking any pill opens the rich edit popup (see
+  a filter cluster — IN pills (green-bordered) + OUT pills (red-
+  bordered) per the authoritative reference events-ribbon.
+  Clicking any pill opens the rich edit popup (see
   `filters/edit_popup.cljs`); clicking `×` on a pill removes it without
   round-tripping through the popup. The `[ + ]` add-pill opens the popup
   empty + defaulted to IN.
 
-  ## rf2-3f2di A5 — two-bar split
+  ## Two-bar split
 
   The committed pills (`pills-view`) live on bar-2 (the events ribbon);
   the add(+) affordance (`add-pill`) is mounted separately on bar-1 (the
   chrome ribbon) beside the `Filters:` label, matching the reference
   chrome-ribbon / events-ribbon split.
-
-  ## Replaces #1397's window.prompt stub
-
-  PR #1397 shipped the 4-layer chrome with a `js/window.prompt` stub
-  inside `shell.cljs`'s `ribbon-filter-pills`. This ns is the proper
-  UI. The shell's `ribbon-filter-pills` delegates here so the only
-  surviving consumer of the prompt stub is the `(throw …)` line in
-  the test that asserts the stub is gone.
 
   ## Pills hover tooltip
 
@@ -41,7 +33,7 @@
 
   ## Pure hiccup
 
-  Same posture as the rest of Xray's view code (rf2-tijr): pure
+  Same posture as the rest of Xray's view code: pure
   hiccup, no per-substrate switches. Mount is via `reg-view` from the
   caller (`shell.cljs`'s `ribbon-filter-pills`)."
   (:require [day8.re-frame2-xray.filters.typed-predicates :as typed]
@@ -50,26 +42,25 @@
 
 ;; ---- one pill ------------------------------------------------------------
 
-;; rf2-t2xba — the per-mode `+` / `×` LEADING glyph used to prefix the
-;; pill body has been retired. The Figma authority shows pills as
+;; The Figma authority shows pills as
 ;; `[text label] [trailing × delete button]` only — the include/exclude
 ;; signal is carried by the BORDER COLOUR (green = include, red = exclude,
-;; resolved by `pill-tone` below), not by a leading glyph. The trailing
-;; remove button is also rendered as `×` (distinct role: it's the
+;; resolved by `pill-tone` below), with no leading glyph. The trailing
+;; remove button is rendered as `×` (distinct role: it's the
 ;; click-target that removes the pill, scoped to the remove `<button>`
 ;; with its own aria-label).
 
 (defn- pill-tone [mode]
-  ;; rf2-3f2di A6 — green-bordered include (`:in`) pills, red-bordered
+  ;; Green-bordered include (`:in`) pills, red-bordered
   ;; exclude (`:out`) pills, per the authoritative reference events-ribbon
   ;; (`border: 1px solid var(--devtools-success)` for include,
-  ;; `--devtools-error` for exclude). Supersedes the prior magenta OUT
-  ;; tone; `:success`/`:error` are the reference's green/red tokens.
+  ;; `--devtools-error` for exclude). `:success`/`:error` are the
+  ;; reference's green/red tokens.
   (case mode :in (:success tokens) :out (:error tokens)))
 
 (defn- pill-kind
   "Read the pill's `:kind` slot, canonicalising via the typed-
-  predicate ns so legacy `{:pattern …}` pills surface as
+  predicate ns so bare `{:pattern …}` pills surface as
   `:event-id-pattern`."
   [pill]
   (:kind (typed/canonicalise-pill pill)))
@@ -92,25 +83,25 @@
   the pill directly (no popup round-trip for the common 'just delete
   it' case).
 
-  ## Typed-predicate kinds (rf2-piye4)
+  ## Typed-predicate kinds
 
-  Per Mike's rf2-drcyb closure, v1 ships three typed-predicate
+  v1 ships three typed-predicate
   kinds — `:machine`, `:http-correlation`, `:fx` — whose params are
   fully determined by the right-click source row. These pills are
   NOT editable in v1 (the popup is keyword-pattern-only); the body
   is non-clickable for typed pills and the user removes via the
-  `×` button. The legacy `:event-id-pattern` kind (back-compat for
-  pre-rf2-piye4 persisted shape) keeps its click-to-edit body.
+  `×` button. The `:event-id-pattern` kind (the bare
+  `{:pattern …}` shape) keeps its click-to-edit body.
 
   Props:
     `:mode`    `:in` | `:out`
     `:pill`    the pill record — either `{:pattern <kw-or-str>}`
-               (legacy keyword-pattern) or `{:kind <kw> :params {…}}`
+               (keyword-pattern) or `{:kind <kw> :params {…}}`
                (typed predicate)
     `:idx`     position in the mode bucket (drives the testid + the
                remove-filter event payload)
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
+  `dispatch` is the frame-aware dispatcher captured by the
   caller's `reg-view` body so the edit / remove clicks land on the
   surrounding instance frame, not a `{:frame :rf/xray}` literal."
   [dispatch {:keys [mode pill idx]}]
@@ -121,7 +112,7 @@
         body-text   (pill-display pill)]
     [:span {:data-testid testid
             :data-pill-kind (name kind)
-            ;; rf2-3f2di A6 — reference events-ribbon pill shape:
+            ;; Reference events-ribbon pill shape:
             ;; `border-radius 4px`, `border 1px solid <tone>` (green for
             ;; include, red for exclude), transparent bg, tone-coloured
             ;; text + an `x` to remove.
@@ -150,9 +141,8 @@
                          :font-family mono-stack
                          :font-size   (:caption type-scale)
                          :white-space "nowrap"}}
-        ;; rf2-t2xba — body is label + trailing pencil only. The leading
-        ;; `+` / `×` mode glyph was retired (the border colour already
-        ;; carries the include/exclude signal).
+        ;; Body is label + trailing pencil only — no leading mode glyph
+        ;; (the border colour carries the include/exclude signal).
         (str body-text " ")
         ;; Pencil glyph per spec/018 §7 'Pill visual contract' —
         ;; visual cue that the pill body is the click-to-edit target.
@@ -167,10 +157,10 @@
                        :font-family mono-stack
                        :font-size   (:caption type-scale)
                        :white-space "nowrap"}}
-        ;; rf2-t2xba — body is label only; the leading mode glyph was
-        ;; retired (border colour carries the include/exclude signal).
+        ;; Body is label only — no leading mode glyph (border colour
+        ;; carries the include/exclude signal).
         body-text])
-     ;; rf2-xawwb — a VERTICAL DIVIDER sits before the `✕` (Figma-Make
+     ;; A VERTICAL DIVIDER sits before the `✕` (Figma-Make
      ;; surface): a 1px tone-coloured rule separating the pill body from
      ;; the remove affordance. The remove button keeps its own border-left
      ;; as the divider so it round-trips through the same tone; the explicit
@@ -199,13 +189,13 @@
   "The `[ + ]` add-filter affordance — opens the edit popup empty +
   defaulted to IN per spec/018 §7 'Trailing +'.
 
-  rf2-3f2di A5 — promoted to the bar-1 chrome ribbon (beside the
+  Mounted on the bar-1 chrome ribbon (beside the
   `Filters:` label) per the authoritative reference chrome-ribbon, which
   carries the add(+) on bar-1 while the committed pills live on bar-2
   (the events ribbon). Public so the shell mounts it directly in the
   chrome ribbon's left cluster.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
+  `dispatch` is the frame-aware dispatcher captured by the
   caller's `reg-view` body."
   [dispatch]
   [:button {:data-testid "rf-xray-filter-add"
@@ -233,17 +223,16 @@
    "[ + ]"])
 
 (defn chrome-add-filter-button
-  "rf2-xawwb — the chrome-ribbon `+ filter` TEXT button (Figma-Make
-  surface). Replaces the prior `Filters:` label + plus-icon affordance
-  on bar-1 with a single outlined text button. Opens the SAME edit
+  "The chrome-ribbon `+ filter` TEXT button (Figma-Make
+  surface). A single outlined text button on bar-1. Opens the SAME edit
   popup as `add-pill` (`:rf.xray/open-edit-popup {:source :add :mode
-  :in}`) — only the surface changes; the add behaviour is retained.
+  :in}`).
 
   Outlined on the dark chrome band: a muted `chrome-ribbon-text-muted`
   border + ink so it reads as a secondary chrome affordance against the
   near-black ribbon.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
+  `dispatch` is the frame-aware dispatcher captured by the
   caller's `reg-view` body."
   [dispatch]
   [:button {:data-testid "rf-xray-filter-add"
@@ -265,14 +254,14 @@
    "+ filter"])
 
 (defn events-add-filter-button
-  "rf2-xawwb — the events-ribbon add-filter `+` ICON button (Figma-Make
+  "The events-ribbon add-filter `+` ICON button (Figma-Make
   surface). Sits after the `filters:` contextual label on bar-2, before
-  the committed pills. Opens the SAME edit popup as `add-pill`; the add
-  behaviour is retained. A square bordered `+` icon-button on the light
+  the committed pills. Opens the SAME edit popup as `add-pill`. A
+  square bordered `+` icon-button on the light
   data canvas (the events ribbon stays on `bg-2`, not the dark chrome
   band).
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
+  `dispatch` is the frame-aware dispatcher captured by the
   caller's `reg-view` body."
   [dispatch]
   [:button {:data-testid "rf-xray-filter-add-events"
@@ -313,18 +302,18 @@
 
 (defn pills-view
   "The committed filter pills cluster — green-bordered IN pills, then
-  red-bordered OUT pills (rf2-3f2di A6). Reads `:rf.xray/active-filters`
+  red-bordered OUT pills. Reads `:rf.xray/active-filters`
   via the caller; the caller is expected to be inside a `reg-view` so
   subscribes resolve to `:rf/xray`.
 
-  rf2-3f2di A5 — the add(+) affordance is NO LONGER part of this
+  The add(+) affordance is not part of this
   cluster: per the authoritative reference the committed pills live on
   bar-2 (the events ribbon) while the add(+) sits on bar-1 (the chrome
   ribbon, beside the `Filters:` label). The shell mounts `add-pill`
   directly in the chrome ribbon's left cluster and `pills-view` in the
   events ribbon.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
+  `dispatch` is the frame-aware dispatcher captured by the
   caller's `reg-view` body, threaded to each `pill`."
   [dispatch {:keys [filters]}]
   [:div {:data-testid "rf-xray-ribbon-filters"

--- a/tools/xray/src/day8/re_frame2_xray/filters/typed_predicates.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/filters/typed_predicates.cljc
@@ -1,10 +1,10 @@
 (ns day8.re-frame2-xray.filters.typed-predicates
-  "Typed-predicate filter kinds for Xray pills (rf2-piye4).
+  "Typed-predicate filter kinds for Xray pills.
 
   ## Why typed predicates
 
-  Spec/018 §7 pills shipped as `{:pattern <kw-or-str>}` records keyed
-  off the cascade's `event-id` only. Surface-aware filters — 'show
+  A bare `{:pattern <kw-or-str>}` pill keys off the cascade's
+  `event-id` only. Surface-aware filters — 'show
   every cascade that touched THIS machine' / 'show every cascade in
   THIS HTTP exchange' / 'show every cascade triggering THIS fx kind'
   — need to walk the cascade's trace-events, not just its event-id.
@@ -15,14 +15,13 @@
 
   Each kind has a matcher in `cascade-matches-by-kind?` that consults
   the cascade's data shape — event-id-pattern delegates to the
-  existing event-id matcher (`matcher.cljc`), the other three walk the
+  event-id matcher (`matcher.cljc`), the other three walk the
   cascade's trace-event buckets for the expected `:tags` slot.
 
-  ## v1 kinds (per Mike's rf2-drcyb closure)
+  ## v1 kinds
 
-  - `:event-id-pattern` — back-compat with rf2-ak4ms's
-    `{:pattern <kw-or-str>}` shape. Delegates to the existing
-    pattern matcher.
+  - `:event-id-pattern` — the `{:pattern <kw-or-str>}` shape.
+    Delegates to the event-id pattern matcher.
   - `:machine` — match cascades whose trace-events include a
     `:tags :machine-id` equal to `<params :machine-id>`. The right-
     click affordance on the Machines panel rows fires
@@ -36,25 +35,23 @@
     `<params :fx-id>`. The right-click affordance on managed-fx
     records' surface badge fires `:rf.xray/filter-by-fx`.
 
-  ## Deferred kinds (Mike's rf2-piye4 scoping)
+  ## Deferred kinds
 
   - `:source-coord` — defer to v1.1; niche.
   - `:interceptor` — defer to v1.1; niche.
-  - `:descendant-of` — MOOT (Causality dropped this session).
 
-  ## Back-compat
+  ## Bare-pattern pills
 
-  Pills stored under the legacy `{:pattern <kw-or-str>}` shape (every
-  pill written before this bead) hydrate as `:event-id-pattern` via
-  `canonicalise-pill`. The persistence load path is unchanged; the
-  matcher folds the missing `:kind` slot into the canonical kind on
-  the way through. New typed pills written by the right-click
-  affordances persist with the explicit `:kind` so re-load round-trips
-  cleanly.
+  Pills stored under the bare `{:pattern <kw-or-str>}` shape
+  hydrate as `:event-id-pattern` via
+  `canonicalise-pill`. The matcher folds the missing `:kind` slot into
+  the canonical kind on the way through. Typed pills written by the
+  right-click affordances persist with the explicit `:kind` so re-load
+  round-trips cleanly.
 
-  ## Composition (spec/018 §7 unchanged)
+  ## Composition (spec/018 §7)
 
-  IN/OUT pill composition stays:
+  IN/OUT pill composition is:
 
       keep = (no-IN-pills OR matches-IN) AND NOT (matches-OUT)
 
@@ -63,13 +60,13 @@
   Mixing typed + keyword pills in the same bucket is supported and
   exercised by tests.
 
-  ## Causal-parent matching under epoch-per-event (rf2-a1eld)
+  ## Causal-parent matching under epoch-per-event
 
   Under epoch-per-event each dequeued event — including `:fx :dispatch`
   children and machine-internal transitions — is its OWN cascade. A
   `:machine` / `:http-correlation` / `:fx` IN pill matching only the
   cascade carrying its tag would lose the link to the PARENT event that
-  spawned the transition (now a sibling cascade). The projection
+  spawned the transition (a sibling cascade). The projection
   surfaces the causal-parent link once as `:parent-dispatch-id`; a
   directly-matching cascade pulls in its whole SPAWNING LINEAGE — every
   causal ancestor walked UP that link to the root user event — so a
@@ -95,8 +92,8 @@
   - If `:kind` is already present, return verbatim (with `:params`
     defaulted to `{}`).
   - If `:pattern` is present and `:kind` is absent, infer
-    `:event-id-pattern` and migrate `:pattern` into `:params`. This is
-    the back-compat path for pills persisted under the rf2-ak4ms shape.
+    `:event-id-pattern` and lift `:pattern` into `:params`. This is
+    the path for pills persisted under the bare `{:pattern …}` shape.
   - Otherwise return the pill verbatim (the matcher will treat it as
     `:never` — guards a malformed pill from matching everything)."
   [pill]
@@ -170,10 +167,10 @@
   false)
 
 (defmethod cascade-matches-by-kind? :event-id-pattern
-  ;; Delegate to the existing event-id pattern matcher. The pill's
-  ;; `:params :pattern` is the same `kw-or-str` shape the legacy
+  ;; Delegate to the event-id pattern matcher. The pill's
+  ;; `:params :pattern` is the same `kw-or-str` shape the event-id
   ;; matcher consumes; we surface it under params for typed pills and
-  ;; fall back to the top-level `:pattern` for legacy shape.
+  ;; fall back to the top-level `:pattern` for the bare-pattern shape.
   [cascade pill]
   (let [canonical (canonicalise-pill pill)
         pattern   (get-in canonical [:params :pattern])
@@ -227,7 +224,7 @@
 
 (defn cascade-matches-pill?
   "True iff the typed pill matches the cascade. Single entrypoint —
-  routes through `canonicalise-pill` so legacy `{:pattern ...}` shape
+  routes through `canonicalise-pill` so the bare `{:pattern ...}` shape
   and explicit `{:kind ...}` shape land at the same matcher."
   [cascade pill]
   (cascade-matches-by-kind? cascade (canonicalise-pill pill)))
@@ -240,7 +237,7 @@
     (when (seq pills)
       (some #(cascade-matches-pill? cascade %) pills))))
 
-;; ---- causal-parent walk (rf2-a1eld) -------------------------------------
+;; ---- causal-parent walk -------------------------------------------------
 ;;
 ;; Under epoch-per-event each dequeued event — including `:fx :dispatch`
 ;; children and machine-internal transitions — is its OWN cascade
@@ -248,7 +245,7 @@
 ;; `:rf.trace/dispatch-id`). A `:machine` / `:http` / `:fx` typed pill
 ;; matching ONLY the cascade carrying its tag therefore loses the link
 ;; to the PARENT event that spawned the transition (the spawning event
-;; lives in a sibling cascade now). 'Filter to this machine' must
+;; lives in a sibling cascade). 'Filter to this machine' must
 ;; surface the spawning event's cascade too, not just the machine's
 ;; bare epoch.
 ;;
@@ -296,7 +293,7 @@
                (conj acc c))))))
 
 (defn in-kept-id-set
-  "Compute the set of `:dispatch-id`s kept by the IN pills (rf2-a1eld).
+  "Compute the set of `:dispatch-id`s kept by the IN pills.
   A cascade that DIRECTLY matches any IN pill pulls in its whole
   spawning lineage — itself plus every causal ancestor (walked via
   `index`). The union is what surfaces the spawning event's cascade
@@ -326,13 +323,13 @@
 
   `in-kept-ids` is the precomputed set from `in-kept-id-set` — the
   dispatch-ids kept by the IN pills, INCLUDING the spawning ancestors
-  of every directly-matching cascade (rf2-a1eld). nil `in-kept-ids`
+  of every directly-matching cascade. nil `in-kept-ids`
   means no IN filter is active (keep every cascade subject to OUT). The
   OUT test stays cascade-local — a hide pill suppresses only the
   cascade carrying its tag, never its ancestors (so hiding a child's fx
   does not silently drop the originating user event).
 
-  Pure data; JVM-runnable. The legacy single-cascade arity falls back
+  Pure data; JVM-runnable. The single-cascade arity falls back
   to direct (ancestor-free) IN matching for callers without the full
   cascade set."
   ([cascade {:keys [in out]}]
@@ -354,7 +351,7 @@
 
   Builds a `{dispatch-id → cascade}` index once, computes the IN-kept
   id set (each directly-matching cascade pulls in its spawning
-  ancestors, rf2-a1eld), then keeps cascades whose id is in that set
+  ancestors), then keeps cascades whose id is in that set
   and which no OUT pill suppresses — so a typed pill on a child
   transition cascade also keeps the spawning event's cascade under
   epoch-per-event."

--- a/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.palette.events
-  "Events for the Xray command palette (rf2-wm7z4).
+  "Events for the Xray command palette.
 
   Every event is registered under `:rf.xray/palette-*` so the
   `:rf.xray/*` collision contract (registry.cljs) holds. The events
@@ -94,7 +94,7 @@
       (assoc :palette-query "")
       (reset-cursor)))
 
-;; ---- rf2-ybjkx — recents ------------------------------------------------
+;; ---- recents ------------------------------------------------------------
 
 (defn- record-recent
   "Pure reducer. Update `db`'s `:palette-recents` slot to put
@@ -106,7 +106,7 @@
     (assoc db :palette-recents
               (recents/record (get db :palette-recents []) command-id))))
 
-;; ---- rf2-ybjkx — snapshot app-db ---------------------------------------
+;; ---- snapshot app-db ----------------------------------------------------
 ;;
 ;; Snapshot the focused frame's app-db onto the JS console as a single
 ;; `console.log(value)` call. Side effect; never blocks. Reads the
@@ -118,7 +118,7 @@
 ;; can reject (insecure context, no permission); we swallow the throw
 ;; so the console log lands either way.
 ;;
-;; ## Off-box egress (rf2-mxzgg / rf2-6fgob)
+;; ## Off-box egress
 ;;
 ;; The JS console AND the system clipboard are both OFF-BOX egress
 ;; sinks (Tool-Pair §Privacy egress, Security.md §Off-box egress):
@@ -129,7 +129,7 @@
 ;;
 ;; We therefore route the captured value through the runtime's single
 ;; named safe-egress fn `runtime/egress-value` — the SAME fail-closed
-;; projection the `get-app-db` accessor uses (post rf2-a96xq). On the
+;; projection the `get-app-db` accessor uses. On the
 ;; bare (no-opt) call the off-box defaults are baked in: sensitive
 ;; slots ⇒ `:rf/redacted`, large slots ⇒ `:rf.size/large-elided`. The
 ;; whole-db read has no `:path` (the value IS the walked root), so the
@@ -160,11 +160,11 @@
   defaults — sensitive ⇒ `:rf/redacted`, large ⇒ `:rf.size/large-
   elided`), pinned to the FOCUSED frame so that frame's own schema
   declarations govern the redaction, so neither off-box sink ever
-  receives the raw db (rf2-mxzgg). No-op when neither console nor
+  receives the raw db. No-op when neither console nor
   clipboard is present (test runtimes). Returns nil."
   [target-frame]
   (try
-    ;; EP-0002 (rf2-bd4div) — the snapshot targets the SELECTED inspected
+    ;; EP-0002 — the snapshot targets the SELECTED inspected
     ;; frame. When unselected (`target-frame` nil) this is a no-op: a
     ;; whole-db egress to console/clipboard is a read of a specific host
     ;; frame, never a synthesised `:rf/default` (Spec 002 §Frame target
@@ -197,7 +197,7 @@
     (catch :default _ nil))
   nil)
 
-;; ---- rf2-ybjkx — theme cycle -------------------------------------------
+;; ---- theme cycle --------------------------------------------------------
 
 (defn- next-theme
   "Pure helper. Cycle `:dark → :light → :dark`. Anything unknown lands
@@ -208,7 +208,7 @@
     :light :dark
     :dark))
 
-;; ---- rf2-ybjkx — reduced-motion cycle ----------------------------------
+;; ---- reduced-motion cycle -----------------------------------------------
 
 (defn- next-motion-override
   "Pure helper. Cycle `:os → :always → :never → :os`. Unknown lands on
@@ -232,9 +232,9 @@
 
   (rf/reg-fx :rf.xray.palette.fx/popout popout-fx!)
 
-  ;; rf2-ybjkx — snapshot app-db fx. Side-effect handler; reads the
+  ;; Snapshot app-db fx. Side-effect handler; reads the
   ;; focused frame's db, routes it through `runtime/egress-value` (the
-  ;; fail-closed off-box safe-egress projection, rf2-mxzgg) and ships
+  ;; fail-closed off-box safe-egress projection) and ships
   ;; the REDACTED/size-elided payload to the JS console + clipboard —
   ;; both off-box sinks. Late-bound through the framework's
   ;; `frame/frame` registry so a nil-frame ctx is a silent no-op rather
@@ -243,7 +243,7 @@
     (fn [_ctx {:keys [target-frame]}]
       (snapshot-app-db! target-frame)))
 
-  ;; rf2-ybjkx — recents persistence fx. The pure reducer writes the
+  ;; Recents persistence fx. The pure reducer writes the
   ;; vector into app-db; this fx mirrors the same vector into
   ;; localStorage so a reload surfaces the user's recents. Best-effort
   ;; — `recents/save!` swallows quota / availability failures.
@@ -253,7 +253,7 @@
 
   ;; ---- open / close / toggle --------------------------------------------
   ;;
-  ;; rf2-ybjkx — on open we ensure the `:palette-recents` slot is
+  ;; On open we ensure the `:palette-recents` slot is
   ;; seeded from localStorage. Open is rare (user-driven keystroke)
   ;; so the load cost is negligible; lazy-seed means we don't have to
   ;; thread a preload hook through every test that drives the registry.
@@ -320,7 +320,7 @@
   (rf/reg-event :rf.xray/palette-invoke
     (fn [{:keys [db]} [_ item popout?]]
       (let [[verb & args]    (:action item)
-            ;; rf2-ybjkx — record recents for `:command` source items
+            ;; Record recents for `:command` source items
             ;; only. Panels / frames / handlers / settings already
             ;; have their own recency surface (the recent-event source
             ;; and the user's session memory); the palette's recents
@@ -333,7 +333,7 @@
             ;; item invokes normally so the user never gets surprised
             ;; with a no-op.
             popout-now?      (and popout? (sources/popoutable? item))
-            ;; rf2-ybjkx — persist the recents vector on every command
+            ;; Persist the recents vector on every command
             ;; invoke so the next session surfaces the user's history.
             ;; Pure recents reads (no command invoked) skip this.
             base-fx          (cond-> []
@@ -345,16 +345,13 @@
         (case verb
           :palette/select-panel
           ;; Panel ids in `palette-panels` are the 6 L3 tab ids per
-          ;; spec/018 §5 (rf2-qy0nu trimmed the 14-id legacy list;
-          ;; rf2-gbz39 removed the Issues tab — 7→6).
-          ;; Dispatch into `:rf.xray/select-tab` so the visible tab
-          ;; flips; the legacy `:rf.xray/select-panel` slot is no
-          ;; longer read by the 4-layer shell.
+          ;; spec/018 §5. Dispatch into `:rf.xray/select-tab` so the
+          ;; visible tab flips — the slot the 4-layer shell reads.
           {:db close-db
            :fx (conj base-fx [:dispatch [:rf.xray/select-tab (first args)]])}
 
           :palette/select-static-tab
-          ;; rf2-ybjkx — Static-mode L3 tab jump. Routes through
+          ;; Static-mode L3 tab jump. Routes through
           ;; `:rf.xray.static/select-tab` (the Static-scoped tab slot
           ;; that the static shell's tab-bar reads). The palette
           ;; filter prevents Static jumps from surfacing while the
@@ -363,28 +360,25 @@
            :fx (conj base-fx [:dispatch [:rf.xray.static/select-tab (first args)]])}
 
           :palette/select-event
-          ;; Route to the Epoch tab with the event pre-selected. Post
-          ;; rf2-5gl5r the Event/Handler tab was retired (Epoch panel
-          ;; supersedes it); `:rf.xray/selected-event-id` is the
-          ;; selected-event slot the surviving panels read.
+          ;; Route to the Epoch tab with the event pre-selected. The
+          ;; Epoch panel is the canonical "what happened in this epoch"
+          ;; surface; `:rf.xray/selected-event-id` is the selected-event
+          ;; slot the panels read.
           {:db (assoc close-db
                       :selected-tab :epoch
                       :selected-event-id (first args))
            :fx base-fx}
 
           :palette/select-frame
-          ;; rf2-ybjkx — drive the frame-picker selection event so
-          ;; the user's choice flows through every per-frame composite
-          ;; (App-DB Diff, Views, Routing). The pre-bead behaviour
-          ;; just stamped `:selected-target-frame` into Xray's app-db
-          ;; with no plumb-through.
+          ;; Drive the frame-picker selection event so the user's
+          ;; choice flows through every per-frame composite (App-DB
+          ;; Diff, Views, Routing).
           ;;
-          ;; Per rf2-iwwou this dispatches the canonical `:rf.xray/
-          ;; select-frame` event-fx (NOT the spine's `:rf.xray/set-
-          ;; frame` primitive directly) — every persistence /
-          ;; instrumentation layer attached to the frame-switcher
-          ;; contract lives behind the one event surface, so the
-          ;; palette + the L1 ribbon picker + headless tests all
+          ;; Dispatches the canonical `:rf.xray/select-frame` event-fx
+          ;; (NOT the spine's `:rf.xray/set-frame` primitive directly) —
+          ;; every persistence / instrumentation layer attached to the
+          ;; frame-switcher contract lives behind the one event surface,
+          ;; so the palette + the L1 ribbon picker + headless tests all
           ;; share the same write path.
           {:db close-db
            :fx (conj base-fx [:dispatch [:rf.xray/select-frame (first args)]])}
@@ -393,10 +387,9 @@
           ;; Phase 1: route to a Xray-side store of the inspected
           ;; handler choice. The handler-detail panel is itself a
           ;; follow-on bead — for now the store is enough so the
-          ;; palette completes its part of the contract.
-          ;; (Post rf2-5gl5r the canonical "what happened in this
-          ;; epoch" tab is `:epoch`; the prior `:selected-tab :event`
-          ;; routing pointed at the retired Event/Handler panel.)
+          ;; palette completes its part of the contract. The canonical
+          ;; "what happened in this epoch" tab is `:epoch`, so the
+          ;; selection lands there.
           (let [[kind id] args]
             {:db (assoc close-db
                         :selected-tab :epoch
@@ -412,7 +405,7 @@
 
           :palette/clear-trace-buffer
           (do
-            ;; rf2-43koh — the framework's per-frame rings + Xray's
+            ;; The framework's per-frame rings + Xray's
             ;; frameless secondary ring + Xray's mirrored
             ;; `:trace-buffer` slot all drop together via
             ;; `trace-collector/retroactive-scrub!` (the same path
@@ -425,7 +418,7 @@
              :fx base-fx})
 
           :palette/clear-epoch-history
-          ;; rf2-ybjkx — drop Xray's epoch ring. The slot lives in
+          ;; Drop Xray's epoch ring. The slot lives in
           ;; Xray's app-db at `:epoch-history`; clearing it lets the
           ;; user start a fresh session without restarting the host
           ;; app. App-DB Diff + Views read off this slot so the next
@@ -438,9 +431,9 @@
            :fx (conj base-fx [:dispatch [:rf.xray/reset-suppressed-counters]])}
 
           :palette/snapshot-app-db
-          ;; rf2-ybjkx — Snapshot the SELECTED inspected frame's app-db
+          ;; Snapshot the SELECTED inspected frame's app-db
           ;; onto the console + clipboard. The target is the slot the L1
-          ;; frame-picker writes (`:target-frame`). EP-0002 (rf2-bd4div) —
+          ;; frame-picker writes (`:target-frame`). EP-0002 —
           ;; pass the slot value THROUGH (nil = unselected); the
           ;; `snapshot-app-db!` fx no-ops when unselected rather than
           ;; snapshotting a synthesised `:rf/default`.
@@ -451,7 +444,7 @@
                        (get db-with-recent :target-frame)}])}
 
           :palette/toggle-theme
-          ;; rf2-ybjkx — flip the Settings popup's theme slot via the
+          ;; Flip the Settings popup's theme slot via the
           ;; existing settings-update event. Routes through the same
           ;; reducer that the popup's radio uses so the popup's
           ;; reactive sub re-fires + the localStorage round-trip
@@ -467,7 +460,7 @@
                        (next-theme (config/get-setting :theme nil))]])}
 
           :palette/cycle-reduced-motion
-          ;; rf2-ybjkx — cycle the user-side reduced-motion override
+          ;; Cycle the user-side reduced-motion override
           ;; (:os → :always → :never → :os). Routes through the
           ;; settings-update event so the apply-fn + persist path are
           ;; the canonical ones — no parallel state.
@@ -480,7 +473,7 @@
                          (config/get-setting :general :reduced-motion-override))]])}
 
           :palette/jump-to-settings
-          ;; rf2-ybjkx — open the Settings popup. Routes through the
+          ;; Open the Settings popup. Routes through the
           ;; existing `:rf.xray/settings-open` event so the popup's
           ;; open path is the canonical one (lifts the atom snapshot
           ;; into app-db, defaults the active-tab to `:general`).
@@ -488,7 +481,7 @@
            :fx (conj base-fx [:dispatch [:rf.xray/settings-open]])}
 
           :palette/toggle-mode
-          ;; rf2-ybjkx — flip Dynamic ↔ Static. Routes through the
+          ;; Flip Dynamic ↔ Static. Routes through the
           ;; existing `:rf.xray/toggle-mode` event (also bound to
           ;; Cmd/Ctrl+Shift+M). Single source of truth for the
           ;; mode-flip + persistence side-effect.

--- a/tools/xray/src/day8/re_frame2_xray/palette/fuzzy.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/palette/fuzzy.cljc
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-xray.palette.fuzzy
-  "Fuzzy subsequence scorer for the Xray command palette
-  (rf2-wm7z4).
+  "Fuzzy subsequence scorer for the Xray command palette.
 
   Pure data; JVM-runnable so tests cover the scorer outside any
   browser dep. The algorithm follows the sublime-fuzzy / fzf-lite
@@ -11,8 +10,7 @@
 
   ## Why we ship our own scorer
 
-  Verified-redundant (rf2-wm7z4 worker dispatch): there is no
-  existing fuzzy implementation under `tools/xray/` or
+  There is no existing fuzzy implementation under `tools/xray/` or
   `implementation/core/`. Bringing in an npm dep would breach the
   bundle-isolation contract for the dev surface and pull a runtime
   dependency that production builds can't elide cleanly. ~60 lines
@@ -34,11 +32,11 @@
     `event-detail` with a run on `ev` and `det`).
   - Prefix bonus: +12 when the very first char matches at index 0.
   - Gap penalty: -1 per unmatched candidate char that sits AFTER the
-    first match (rf2-pwxhj). Leading non-matches — before the first
+    first match. Leading non-matches — before the first
     matched char — are free; every unmatched char once matching has
     begun is penalised, including the char immediately after a match
-    and gaps anchored at candidate index 0 (a prefix-anchored match no
-    longer earns a free pass on its internal gaps). Note that a query
+    and gaps anchored at candidate index 0 (a prefix-anchored match
+    earns no free pass on its internal gaps). Note that a query
     is only a match when EVERY query char is consumed, so the final
     matched char is at-or-before the last penalised gap only when the
     candidate carries trailing chars after the full query is satisfied;
@@ -161,16 +159,13 @@
                        ci
                        (or first-match ci)
                        (conj! indices ci)))
-              ;; Gap penalty (rf2-pwxhj): -1 per UNMATCHED candidate
-              ;; char that sits AFTER the first match. The condition is
-              ;; `(>= last-match-idx 0)` — a match has occurred — NOT
-              ;; `(pos? last-match-idx)`. The prior `(pos? ...)` test let
-              ;; a prefix-anchored match (first match at candidate index
-              ;; 0 → last-match-idx 0) escape every internal-gap penalty,
-              ;; and the now-deleted `gap-since-match?` latch (set one
-              ;; iteration too late) let the FIRST unmatched char after
-              ;; any match escape too. Penalising every post-match
-              ;; unmatched char uniformly closes both off-by-ones; leading
+              ;; Gap penalty: -1 per UNMATCHED candidate char that sits
+              ;; AFTER the first match. The condition is
+              ;; `(>= last-match-idx 0)` — a match has occurred —
+              ;; so every post-match unmatched char is penalised
+              ;; uniformly, including a prefix-anchored match's internal
+              ;; gaps (first match at candidate index 0 → last-match-idx
+              ;; 0) and the char immediately after a match. Leading
               ;; gaps (before the first match) stay free because
               ;; last-match-idx is still its -2 sentinel.
               (recur (inc ci)

--- a/tools/xray/src/day8/re_frame2_xray/palette/recents.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/recents.cljs
@@ -1,11 +1,11 @@
 (ns day8.re-frame2-xray.palette.recents
   "localStorage round-trip for the Xray command palette's
-  last-used-commands list (rf2-ybjkx).
+  last-used-commands list.
 
-  Per the bead's acceptance contract: the palette persists the top-3
-  recently-invoked commands to localStorage so a reload surfaces the
-  user's recent verbs first. The open-state itself is transient and
-  NEVER persisted — only the recents list.
+  The palette persists the top-3 recently-invoked commands to
+  localStorage so a reload surfaces the user's recent verbs first.
+  The open-state itself is transient and NEVER persisted — only the
+  recents list.
 
   ## Shape
 
@@ -14,8 +14,8 @@
       ;; localStorage value
       \"[:rf.xray.cmd/toggle-theme :rf.xray.cmd/jump-tab-event ...]\"
 
-  Most-recent-first order. The list is capped at 3 entries (per the
-  bead — top-3 recent). `record!` dedups on identity so re-invoking
+  Most-recent-first order. The list is capped at 3 entries (top-3
+  recent). `record!` dedups on identity so re-invoking
   the same command bubbles it back to position 0 without growing the
   list.
 
@@ -50,8 +50,7 @@
   3)
 
 ;; ---- localStorage helpers -----------------------------------------------
-;; Raw browser access lives in the shared `local-storage` seam
-;; (rf2-jkake.24).
+;; Raw browser access lives in the shared `local-storage` seam.
 
 (defn- read-raw
   []

--- a/tools/xray/src/day8/re_frame2_xray/palette/sources.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/palette/sources.cljc
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-xray.palette.sources
-  "Pure-data palette source aggregator for the Xray command palette
-  (rf2-wm7z4).
+  "Pure-data palette source aggregator for the Xray command palette.
 
   Builds the indexed surface the fuzzy scorer ranks against. The fn
   takes a single `inputs` map — the caller (sub layer in
@@ -81,9 +80,9 @@
   `:rf/xray` via the wrapping events fn (palette events resolve
   `[:panel id]` into `[:rf.xray/select-tab id]`).
 
-  Per rf2-ybjkx each row carries `:modes #{:dynamic}` so the mode
-  filter excludes Dynamic tab jumps when the palette opens in Static
-  mode. Static-mode tab jumps are produced by `static-tab-items`."
+  Each row carries `:modes #{:dynamic}` so the mode filter excludes
+  Dynamic tab jumps when the palette opens in Static mode. Static-mode
+  tab jumps are produced by `static-tab-items`."
   [panel-entries]
   (mapv
     (fn [{:keys [id label]}]
@@ -205,23 +204,21 @@
 
 ;; ---- per-source mode visibility ----------------------------------------
 ;;
-;; rf2-ybjkx — mode-aware command surface. Each command carries a
-;; `:modes` set declaring which Xray modes (`:dynamic` / `:static`)
-;; surface it. Commands meaningful in both modes (theme toggle,
-;; reduced-motion, jump-to-settings, toggle-mode) carry `#{:dynamic
-;; :static}`. Commands that only make sense in one mode (spine clear,
-;; Dynamic L4 jumps; Static sub-tab jumps) carry the appropriate
-;; single-mode set.
+;; Mode-aware command surface. Each command carries a `:modes` set
+;; declaring which Xray modes (`:dynamic` / `:static`) surface it.
+;; Commands meaningful in both modes (theme toggle, reduced-motion,
+;; jump-to-settings, toggle-mode) carry `#{:dynamic :static}`. Commands
+;; that only make sense in one mode (spine clear, Dynamic L4 jumps;
+;; Static sub-tab jumps) carry the appropriate single-mode set.
 ;;
 ;; The aggregator filters by `:modes` membership when `:mode` is
-;; non-nil in the inputs map; nil mode preserves the pre-bead
-;; behaviour (every command surfaced).
+;; non-nil in the inputs map; nil mode keeps every command surfaced.
 
 (defn command-items
   "Xray command verbs. Each carries a stable id + an action dispatch
   (the events ns owns the actual side-effect fns; the aggregator just
   describes the choices) + a `:modes` set declaring mode visibility
-  per rf2-ybjkx (see §per-source mode visibility above).
+  (see §per-source mode visibility above).
 
   ## Dynamic-only verbs
 
@@ -236,7 +233,7 @@
   Routes / Schemas / Flows / Interceptors). Static has no spine so the
   Dynamic tab jumps don't apply.
 
-  ## Mode-agnostic verbs (rf2-ybjkx)
+  ## Mode-agnostic verbs
 
   - `:toggle-theme`            — Dark ↔ Light cycle of the theme class.
   - `:cycle-reduced-motion`    — `:os → :always → :never → :os`.
@@ -283,7 +280,7 @@
     :action [:palette/open-popout]
     :modes  #{:dynamic :static}
     :popout? false}
-   ;; rf2-ybjkx — Snapshot the focused frame's app-db onto the JS
+   ;; Snapshot the focused frame's app-db onto the JS
    ;; console for clipboard capture / share with a teammate.
    {:source :command
     :id     :snapshot-app-db
@@ -294,9 +291,8 @@
     :action [:palette/snapshot-app-db]
     :modes  #{:dynamic :static}
     :popout? false}
-   ;; rf2-ybjkx — Theme toggle. The popup's radio is still the
-   ;; canonical UI; the palette is the keyboard-first ergonomic
-   ;; shortcut.
+   ;; Theme toggle. The popup's radio is the canonical UI; the
+   ;; palette is the keyboard-first ergonomic shortcut.
    {:source :command
     :id     :toggle-theme
     :label  "Toggle theme (dark ↔ light)"
@@ -306,7 +302,7 @@
     :action [:palette/toggle-theme]
     :modes  #{:dynamic :static}
     :popout? false}
-   ;; rf2-ybjkx — Reduced-motion cycle. Three states: `:os` (OS pref
+   ;; Reduced-motion cycle. Three states: `:os` (OS pref
    ;; alone), `:always` (force reduce), `:never` (force full). Cycles
    ;; through them so a single command covers every transition.
    {:source :command
@@ -318,7 +314,7 @@
     :action [:palette/cycle-reduced-motion]
     :modes  #{:dynamic :static}
     :popout? false}
-   ;; rf2-ybjkx — Jump to settings. Equivalent to the `,` / `s`
+   ;; Jump to settings. Equivalent to the `,` / `s`
    ;; bare-key shortcut but available from the palette so the user
    ;; can fuzzy-find the gesture without leaving the keyboard.
    {:source :command
@@ -330,7 +326,7 @@
     :action [:palette/jump-to-settings]
     :modes  #{:dynamic :static}
     :popout? false}
-   ;; rf2-ybjkx — Toggle Dynamic ↔ Static. Chord parity with
+   ;; Toggle Dynamic ↔ Static. Chord parity with
    ;; `Cmd/Ctrl-Shift-M` (see `keybinding.cljs`). Surfaced in BOTH
    ;; modes — the user can flip in either direction from the palette.
    {:source :command
@@ -353,7 +349,7 @@
     :popout? false}])
 
 (defn static-tab-items
-  "Static-mode sub-tab jumps (rf2-ybjkx). Five entries mirroring the
+  "Static-mode sub-tab jumps. Five entries mirroring the
   `static/shell.cljs/tabs` inventory: Machines / Routes / Schemas /
   Flows / Interceptors. Each carries `:modes #{:static}` so the aggregator
   filters them out when the palette opens in Dynamic mode."
@@ -373,7 +369,7 @@
 
 ;; ---- aggregator ----------------------------------------------------------
 
-;; ---- recents boosts (rf2-ybjkx) -----------------------------------------
+;; ---- recents boosts -----------------------------------------------------
 
 (def recents-boost-max
   "Max boost applied to the most-recently-used command. Decays linearly
@@ -406,9 +402,8 @@
 
 (defn- in-mode?
   "Mode predicate. `:modes` membership filter — nil mode keeps every
-  item (pre-bead behaviour), a non-nil mode keeps only items whose
-  `:modes` set contains it. Items missing `:modes` default to both
-  modes (the legacy contract — every item used to be visible always)."
+  item, a non-nil mode keeps only items whose `:modes` set contains it.
+  Items missing `:modes` default to both modes (visible always)."
   [mode item]
   (if (nil? mode)
     true
@@ -425,28 +420,28 @@
   Inputs map shape:
 
     {:panels        [{:id kw :label str} ...]    ; Dynamic L3 tabs
-     :static-tabs   [{:id kw :label str} ...]    ; Static L3 tabs (rf2-ybjkx)
+     :static-tabs   [{:id kw :label str} ...]    ; Static L3 tabs
      :trace-buffer  [trace ...]
      :frame-ids     (keyword?)
      :handlers      [{:id :kind :doc :file :line} ...]
-     :mode          :dynamic | :static | nil     ; filter (rf2-ybjkx)
-     :recents       [command-id ...]             ; recents boost (rf2-ybjkx)
+     :mode          :dynamic | :static | nil     ; mode filter
+     :recents       [command-id ...]             ; recents boost
     }
 
   Missing keys default to empty inputs of that kind — partial drives
   (e.g. recency-rank dragons without a populated buffer) are
   tolerable for the empty-state surface.
 
-  ## Mode-aware filter (rf2-ybjkx)
+  ## Mode-aware filter
 
   Items declare a `:modes` set; the aggregator drops items whose set
-  doesn't contain `:mode`. nil `:mode` preserves the pre-bead contract
-  (every item surfaced). The filter is applied AFTER source assembly
+  doesn't contain `:mode`. nil `:mode` keeps every item surfaced. The
+  filter is applied AFTER source assembly
   but BEFORE dedup so an item with the same `[:source :id]` in both
   modes can still surface — but no source emits the same id under
   both modes today.
 
-  ## Recents boost (rf2-ybjkx)
+  ## Recents boost
 
   Items whose `:source = :command` AND whose `:id` is in `:recents`
   receive an extra position-decayed boost added to their static

--- a/tools/xray/src/day8/re_frame2_xray/palette/subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/subs.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.palette.subs
-  "Subscriptions for the Xray command palette (rf2-wm7z4).
+  "Subscriptions for the Xray command palette.
 
   ## Sub tree
 
@@ -23,14 +23,14 @@
   in source-item count). Acceptable because the modal is closed
   most of the time; when open the user is actively typing.
 
-  ## Sidebar items reference
+  ## Panel inventory
 
-  The panel list is the same one the sidebar renders (shell.cljs).
-  Importing the shell's `sidebar-items` directly would create a
-  shell→palette→shell cycle once we wire `Modal` into the shell;
-  instead the palette holds its own canonical list and the shell
-  reads from it. The list is small (~16 entries) and the
-  duplication cost is negligible compared to the cycle-break."
+  The palette reads its Dynamic + Static panel inventory directly
+  from the internal L4 tab registry (`panel-registry`), which has no
+  shell / palette dependencies — `palette-subs → panel-registry` is a
+  one-way edge. Adding a tab is a single `panel-registry/reg-l4-tab!`
+  call in the panel's `install!`; the palette's source aggregator
+  picks it up via `palette-panels` / `palette-static-tabs`."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.host-registry :as host-registry]
             [day8.re-frame2-xray.palette.sources :as sources]
@@ -38,15 +38,12 @@
 
 ;; ---- canonical panel list ------------------------------------------------
 ;;
-;; Per rf2-2moh1 the palette reads its Dynamic + Static panel inventory
-;; directly from the internal L4 tab registry. Adding a tab means a
-;; single `panel-registry/reg-l4-tab!` call in the panel's `install!`;
-;; the palette's source aggregator picks it up via the helpers below.
-;;
-;; The previous cycle-break rationale (avoiding `palette → shell →
-;; palette` by duplicating the tab list) is moot because the registry
-;; has no shell / palette dependencies — `palette-subs → panel-registry`
-;; is a one-way edge.
+;; The palette reads its Dynamic + Static panel inventory directly from
+;; the internal L4 tab registry. Adding a tab means a single
+;; `panel-registry/reg-l4-tab!` call in the panel's `install!`; the
+;; palette's source aggregator picks it up via the helpers below. The
+;; registry has no shell / palette dependencies — `palette-subs →
+;; panel-registry` is a one-way edge.
 
 (defn palette-panels
   "Dynamic-mode tab entries in the shape the palette source-aggregator
@@ -111,7 +108,7 @@
     (fn [db _query]
       (max 0 (or (get db :palette-cursor) 0))))
 
-  ;; rf2-ybjkx — last-used commands. Vector of command keyword ids
+  ;; Last-used commands. Vector of command keyword ids
   ;; (most-recent first; capped at `recents/max-recents`). The slot is
   ;; seeded from localStorage on first palette-open (see events.cljs
   ;; `:rf.xray/palette-open`) and bumped on every `:command`
@@ -122,9 +119,9 @@
 
   ;; Layer-2 — aggregates the searchable corpus. Depends on
   ;; `:rf.xray/trace-buffer` (recent events) + `:rf.xray/mode`
-  ;; (rf2-ybjkx mode filter) + `:rf.xray/palette-recents` (rf2-ybjkx
-  ;; recents boost). The registrar / frame snapshot lookups happen
-  ;; inside the body and ride the same recompute cadence.
+  ;; (mode filter) + `:rf.xray/palette-recents` (recents boost). The
+  ;; registrar / frame snapshot lookups happen inside the body and
+  ;; ride the same recompute cadence.
   (rf/reg-sub :rf.xray/palette-index
     :<- [:rf.xray/trace-buffer]
     :<- [:rf.xray/mode]

--- a/tools/xray/src/day8/re_frame2_xray/palette/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/view.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.palette.view
-  "View for the Xray command palette (rf2-wm7z4).
+  "View for the Xray command palette.
 
   Per `tools/xray/spec/007-UX-IA.md` §Command palette:
   - 560px centred modal
@@ -11,13 +11,12 @@
   `palette.cljs` wraps it in `reg-view` so its subscribes route to
   the surrounding `:rf/xray` frame via React context.
 
-  ## Modal layer (rf2-7oxvd)
+  ## Modal layer
 
-  Phase 1 layers the palette over the Xray shell's `shell-view`
+  The palette layers over the Xray shell's `shell-view`
   (mounted there so subscribes resolve through the shell's frame
   provider). The backdrop + dialog scaffold is the shared
-  `theme/modal-chrome` contract — the eighth and last Xray modal to
-  adopt it. The palette supplies its own `backdrop-style` /
+  `theme/modal-chrome` contract. The palette supplies its own `backdrop-style` /
   `dialog-style`, the `:label \"Command palette\"` accessible name, the
   `data-rf-xray-mode` marker (via `:dialog-extra`) and the
   click-outside dismiss (`:on-dismiss`); `modal-chrome` owns the
@@ -36,10 +35,10 @@
   not need to drop modifier hands. Because the input owns Esc, the
   palette passes NO chrome keydown handler (the edit-popup pattern).
 
-  ## Focus trap + the combobox cursor (rf2-7oxvd)
+  ## Focus trap + the combobox cursor
 
-  Adopting `modal-chrome` brings the `a11y/dialog-ref` focus trap the
-  palette previously lacked. The trap intercepts only `Tab` /
+  `modal-chrome` provides the `a11y/dialog-ref` focus trap. The trap
+  intercepts only `Tab` /
   `Shift+Tab`; the palette's sole real focusable is the search input
   (the result `<li>`s carry no tabindex — the cursor is a VIRTUAL
   selection tracked via `aria-activedescendant`, focus never leaves the
@@ -48,7 +47,7 @@
   `:auto-focus` — it skips focus-on-open when a descendant already
   holds focus — so there is no double-focus on mount.
 
-  ## Why every deferred dispatch captures the surrounding frame (rf2-w8lxg / rf2-r0o63 / rf2-nesy9)
+  ## Why every deferred dispatch captures the surrounding frame
 
   Subscribes resolve through the React-context tier at RENDER time —
   React's `_currentValue` for the `frame-context` is set to the
@@ -66,15 +65,13 @@
   slots untouched. Symptom: palette appears frozen — arrow keys,
   Enter, click on a row, ESC, backdrop click all no-op.
 
-  An EARLIER fix pinned each deferred handler to a `{:frame :rf/xray}`
-  literal — correct for the singleton shell but entrenching the
-  one-frame lock (rf2-1w07r). The current contract (rf2-r0o63 /
-  rf2-nesy9) captures the SURROUNDING instance frame instead:
+  So each deferred handler captures the SURROUNDING instance frame:
   `palette.cljs`'s `Modal` `reg-view` body has a frame-aware `dispatch`
   injected by the macro and threads it into `palette-view`, which fans
   it out to every row + key handler. Each deferred handler calls that
   captured `dispatch` (never the global `rf/dispatch`, never a
-  literal), so N isolated instances each route to their own frame."
+  `{:frame :rf/xray}` literal), so N isolated instances each route to
+  their own frame."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.palette.sources :as sources]
             [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
@@ -83,7 +80,7 @@
 
 ;; ---- per-source visual style --------------------------------------------
 
-;; Per-source categorical legend (rf2-ad7zx.13). `:command` is the
+;; Per-source categorical legend. `:command` is the
 ;; primary action category → the single `:accent` (GitHub blue);
 ;; `:panel` keeps a fixed cool blue (`:info`) so it stays a distinct
 ;; category against the command accent. yellow/green/magenta are
@@ -222,13 +219,13 @@
   "DOM `id` of the palette result list. Stable per-modal (only one
   palette mounts at a time), so the input's `aria-controls` +
   `aria-activedescendant` references resolve without per-render id
-  churn. rf2-tt7ax."
+  churn."
   "rf-xray-palette-listbox")
 
 (defn- row-id
   "DOM `id` of result row `idx` — referenced by the input's
   `aria-activedescendant` so screen readers track the cursor highlight
-  as the user arrows up/down. rf2-tt7ax."
+  as the user arrows up/down."
   [idx]
   (str "rf-xray-palette-option-" idx))
 
@@ -263,7 +260,7 @@
 ;; ---- key handling -------------------------------------------------------
 
 (defn- handle-input-keydown
-  ;; EP-0002 (rf2-bd4div) — a deferred key handler fires at CLICK time,
+  ;; EP-0002 — a deferred key handler fires at CLICK time,
   ;; after render has committed and the frame context has unwound, so it
   ;; carries NO ambient frame stamp. It must therefore not `rf/subscribe`
   ;; the cursor itself (that ambient read raises `:rf.error/no-frame-context`
@@ -303,7 +300,7 @@
   the mount on `:rf.xray/palette-open?` — this fn assumes it's open
   and always renders.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher injected by the
+  `dispatch` is the frame-aware dispatcher injected by the
   `palette/Modal` `reg-view` body — threaded into every row + key
   handler so deferred handlers land on the surrounding instance frame,
   not a `{:frame :rf/xray}` literal."
@@ -311,12 +308,12 @@
   (let [query   (or @(rf/subscribe [:rf.xray/palette-query]) "")
         results @(rf/subscribe [:rf.xray/palette-results])
         cursor  @(rf/subscribe [:rf.xray/palette-cursor])]
-    ;; rf2-7oxvd — shared backdrop + dialog scaffold. The palette keeps
+    ;; Shared backdrop + dialog scaffold. The palette keeps
     ;; its own `backdrop-style` / `dialog-style` and its `:auto-focus`
     ;; input owning Esc (handled in `handle-input-keydown`, exactly the
     ;; edit-popup pattern), so it passes NO chrome keydown handler.
     ;; `modal-chrome` owns the click-outside dismiss, the
-    ;; `a11y/dialog-attrs` (rf2-tt7ax role/aria-modal + the `:label`
+    ;; `a11y/dialog-attrs` (role/aria-modal + the `:label`
     ;; accessible name — no visible title bar) and the `a11y/dialog-ref`
     ;; focus trap. The trap intercepts only Tab/Shift+Tab; the palette's
     ;; sole focusable is the input (rows drive the combobox cursor via
@@ -344,7 +341,7 @@
                 :auto-focus   true
                 :value        query
                 :placeholder  "Search panels, events, frames, commands…"
-                ;; rf2-tt7ax — combobox/listbox wiring: `aria-label`
+                ;; Combobox/listbox wiring: `aria-label`
                 ;; names the input (no visible <label>); `aria-controls`
                 ;; + `aria-activedescendant` point at the listbox + the
                 ;; active row id so screen readers track the highlight

--- a/tools/xray/src/day8/re_frame2_xray/panel_enum.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panel_enum.cljc
@@ -1,12 +1,12 @@
 (ns day8.re-frame2-xray.panel-enum
   "SINGLE SOURCE OF TRUTH for the Xray panel enumeration — the set of
-  independently-mountable Xray panel surfaces (rf2-rapnr; absorbs the
-  guard-half of rf2-7b1z4; follow-on to the rf2-3nbl5.2 API-governance
-  keystone).
+  independently-mountable Xray panel surfaces. This is the
+  API-governance keystone that also carries the guard half of the
+  reconciliation.
 
   ## The problem this closes
 
-  \"The set of Xray panels\" had THREE projections that could silently
+  \"The set of Xray panels\" has THREE projections that could silently
   drift apart:
 
     1. THE MOUNT FACADE — the `mount-<panel>!` fn family in
@@ -16,14 +16,11 @@
        `tools/xray/spec/008-Embedding-Contract.md`.
     3. THE API MANIFEST — the `:cljs-only` rows for
        `day8.re-frame2-xray.panels` in `spec/api-manifest-metadata.edn`
-       (rf2-jhn46) that the CLJS enumeration probe (rf2-2mtte)
-       runtime-verifies.
+       that the CLJS enumeration probe runtime-verifies.
 
-  Before this ns, adding / removing / renaming a panel meant editing
-  each projection by hand and HOPING they stayed aligned — exactly the
-  drift class the keystone exists to kill. (A live example the guard
-  caught: `007-UX-IA.md` named `mount-views!`, a fn that no longer
-  exists, while omitting `mount-event-spine!`, a fn that does.)
+  Without a single source, adding / removing / renaming a panel means
+  editing each projection by hand and HOPING they stay aligned — exactly
+  the drift class the keystone exists to kill.
 
   ## The single source
 
@@ -38,11 +35,11 @@
     - The Xray API spec — the same guard reconciles the `mount-*!`
       names parsed out of `007-UX-IA.md` + `008-Embedding-Contract.md`
       against this set (bidirectional → RED on drift).
-    - The api-manifest `:cljs-only` rows — the rf2-2mtte CLJS probe +
-      the rf2-gkp0t `xray_spec_check` already reconcile the manifest's
-      `panels` rows against the live vars; because the live vars are
-      themselves guarded against this enum, the manifest inherits enum
-      coherence transitively.
+    - The api-manifest `:cljs-only` rows — the CLJS enumeration probe +
+      the `xray_spec_check` reconcile the manifest's `panels` rows
+      against the live vars; because the live vars are themselves
+      guarded against this enum, the manifest inherits enum coherence
+      transitively.
 
   A DRIFT between any projection and this source goes RED in CI.
 

--- a/tools/xray/src/day8/re_frame2_xray/panel_registry.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panel_registry.cljc
@@ -1,18 +1,16 @@
 (ns day8.re-frame2-xray.panel-registry
-  "Internal L4-tab registry — `reg-l4-tab!` (rf2-2moh1).
+  "Internal L4-tab registry — `reg-l4-tab!`.
 
   ## The seam
 
-  Before this ns, `shell.cljs` carried a hard-coded vector of the
-  Dynamic tabs + a parallel case-switch in `detail-panel`; `static/
-  shell.cljs` carried the same shape for the 6 Static tabs. Adding a
-  tab (e.g. promoting Routing to its own L3 lens per rf2-nrbs9)
-  required editing two files in lock-step — modify-shell coupling.
+  The Dynamic and Static tab inventories are declared per-panel rather
+  than as hard-coded vectors in `shell.cljs` / `static/shell.cljs`,
+  avoiding the modify-shell coupling that a centralised tab list and a
+  parallel `detail-panel` case-switch would impose.
 
-  Per the audit finding `ai/findings/2026-05-20-tools-xray-api-review.md`
-  Finding #3: each panel's existing `(defn install! [] ...)` already
-  owns its subs / events / fxs. Threading the tab metadata through the
-  same install! call closes the loop — adding a tab now means:
+  Each panel's `(defn install! [] ...)` already owns its subs / events
+  / fxs. Threading the tab metadata through the same install! call
+  closes the loop — adding a tab means:
 
     (defn install! []
       ...subs / events / fxs...

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -1,15 +1,15 @@
 (ns day8.re-frame2-xray.panels
-  "Per-panel mount surface — rf2-crhr8. **Internal-but-stable**, NOT a
-  v1.0 host-facing embed contract (rf2-jw2ny).
+  "Per-panel mount surface. **Internal-but-stable**, NOT a v1.0
+  host-facing embed contract.
 
   Every Xray panel is independently mountable: a host can mount one
   panel in isolation without the surrounding 4-layer shell, without
   sibling panels, and without any shell-owned chrome state. This
   surface is the load-bearing seam the 4-layer shell composes through
   and that the test suite mounts panels through; it also lets Xray be
-  embedded inside Story, inside the Scittle playground (rf2-i8mv
-  option-c progressive disclosure), inside custom debugging
-  configurations, and inside the docs / guide / examples surface.
+  embedded inside Story, inside the Scittle playground (option-c
+  progressive disclosure), inside custom debugging configurations, and
+  inside the docs / guide / examples surface.
 
   **Status: internal-but-stable, not a host-facing v1.0 embed
   contract.** The mount fns are stable (the shell + tests depend on
@@ -21,7 +21,7 @@
   contract. This matches the status stated in
   `008-Embedding-Contract.md`, `tools/xray/spec/API.md`, and
   `007-UX-IA.md` §Mountable panel contract — one honest status across
-  every reference (rf2-jw2ny reconcile).
+  every reference.
 
   ## The surface
 
@@ -36,7 +36,7 @@
       (mount-routing!          mount-point opts) → unmount-fn
       (mount-resources!        mount-point opts) → unmount-fn
 
-      ;; Spine surface — the L2 event list in isolation (rf2-9k43e).
+      ;; Spine surface — the L2 event list in isolation.
       ;; The SAME `shell/event-list` reg-view the full 4-layer shell
       ;; composes at L2; mounted standalone it is the compact,
       ;; clickable recent-events navigator. Clicking a row dispatches
@@ -58,7 +58,7 @@
 
       (mount-shell! mount-point opts) → unmount-fn
 
-  ## Single-source panel enumeration (rf2-rapnr)
+  ## Single-source panel enumeration
 
   The SET of mountable panels — the `mount-<panel>!` family above —
   is enumerated ONCE in `day8.re-frame2-xray.panel-enum/panel-enum`
@@ -97,7 +97,7 @@
   render) to one place so every panel inherits the same contract by
   construction. Adding a new panel = add a new `mount-<panel>!` line.
 
-  ## Per-panel inputs (the coupling-map audit, rf2-crhr8 §1)
+  ## Per-panel inputs
 
   Every panel reads its data via subscribes — no sibling-render
   assumptions, no shell-owned local state. The subs (registered by
@@ -106,9 +106,9 @@
   | Panel | Reads | Writes (via dispatch) |
   |---|---|---|
   | **epoch-panel** | `:rf.xray/focus` · `:rf.xray/epoch-history` (via `panels.shared.focus-resolver`) | `:rf.xray.epoch/toggle-row-expand` · `:rf.xray.epoch/set-subs-filter-mode` |
-  | **app-db (current-state inspector)** | `:rf.xray/app-db-state` (current-state section model over the observed frame's live app-db, sectioned by reserved `:rf/*` area — rf2-okvit) | `:rf.xray/open-segment-inspector` |
+  | **app-db (current-state inspector)** | `:rf.xray/app-db-state` (current-state section model over the observed frame's live app-db, sectioned by reserved `:rf/*` area) | `:rf.xray/open-segment-inspector` |
   | **reactive-panel** | `:rf.xray/reactive-data` (composite over focused cascade's `:trace-events`) | `:rf.xray/reactive-toggle-unchanged` |
-  | **trace** | `:rf.xray/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events` into a flat list of rows, each with a stage column + colour-coded left edge, spec/023 · rf2-aqusw) | `:rf.xray/toggle-trace-row-expand` · `:rf.xray/open-in-editor` |
+  | **trace** | `:rf.xray/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events` into a flat list of rows, each with a stage column + colour-coded left edge, spec/023) | `:rf.xray/toggle-trace-row-expand` · `:rf.xray/open-in-editor` |
   | **machine-inspector** | `:rf.xray/machine-chart-data` · `:rf.xray/active-timers-for-focused-machine` · `:rf.xray/machine-scrubber-position` | scrubber events · `:rf.xray/focus-cascade` |
   | **routing** | `:rf.xray/registered-routes` · `:rf.xray/current-route-slice` · `:rf.xray/routing-tab-data` | route-simulation events |
   | **resources** | `:rf.xray/resources-tab-data` (composite over `:rf.xray/registered-resources` · `:rf.xray/resource-entries` · `:rf.xray/resource-work-ledger` · the route registry · the trace buffer) | (read-only — no dispatch; observing pins no resource) |
@@ -170,7 +170,7 @@
   multiple panel mounts collapse to one registration pass.
 
   Routes through `mount/ensure-xray-frame!` so the frame is not just
-  registered but ALSO seeded via the first-mount hook table (rf2-y1saa)
+  registered but ALSO seeded via the first-mount hook table
   — `::seed-trace-and-target-frame`, `::hydrate-filters`,
   `::hydrate-spine-filters`, `::hydrate-static-mode`,
   `::auto-open-watcher`. A direct `(rf/reg-frame :rf/xray {})` here
@@ -226,12 +226,11 @@
 ;; below; the chrome (registration, frame wiring, substrate delegation)
 ;; lives in `render-panel!` exactly once.
 ;;
-;; (rf2-5gl5r — `mount-event-detail!` removed alongside the retired
-;; Event/Handler panel; the Epoch panel supersedes it as the canonical
-;; "what happened in this epoch" mount target.)
+;; The Epoch panel is the canonical "what happened in this epoch"
+;; mount target.
 
 (defn mount-epoch-panel!
-  "Mount Xray's Epoch tab in isolation at `mount-point` (rf2-sc3r1).
+  "Mount Xray's Epoch tab in isolation at `mount-point`.
   Renders the numbered cascade — the focused epoch's complete
   computational timeline (DISPATCH → COEFFECTS → HANDLER → FLOW →
   FX → SUBSCRIPTIONS → VIEWS) with conditional rendering per the
@@ -246,7 +245,7 @@
   ([mount-point opts] (render-panel! app-db-diff/Panel mount-point opts)))
 
 (defn mount-reactive-panel!
-  "Mount Xray's Reactive tab in isolation at `mount-point` (rf2-wyvf2).
+  "Mount Xray's Reactive tab in isolation at `mount-point`.
   Renders the canonical sub-cascade + view-re-render visualisation
   per spec/021 §3."
   ([mount-point]      (mount-reactive-panel! mount-point nil))
@@ -284,14 +283,14 @@
   ([mount-point opts] (render-panel! resources/Panel mount-point opts)))
 
 (defn mount-event-spine!
-  "Mount Xray's L2 event spine in isolation at `mount-point` (rf2-9k43e).
+  "Mount Xray's L2 event spine in isolation at `mount-point`.
 
   Renders the SAME `shell/event-list` reg-view the full 4-layer shell
   composes at L2 — the recent-events timeline (single-line rows,
   latest-on-bottom) that IS the canonical scrubber. This is NOT a
   parallel spine: it reuses the full-shell component verbatim, so the
-  embedded spine inherits the row anatomy, the issue-row wash
-  (rf2-b8guz), the relative-time chips, virtualisation, filters, and —
+  embedded spine inherits the row anatomy, the issue-row wash, the
+  relative-time chips, virtualisation, filters, and —
   critically — the row-click → `:rf.xray/focus-cascade` write that
   drives the single-axis spine sub `:rf.xray/focus` (spec/018 §4 + §6).
 
@@ -311,12 +310,11 @@
   ([mount-point]      (mount-event-spine! mount-point nil))
   ([mount-point opts] (render-panel! shell/event-list mount-point opts)))
 
-;; (rf2-gbz39 — `mount-issues-ribbon!` removed alongside the retired
-;; Issues tab. Mike RULED Option (c): the dedicated Issues tab + its
-;; aggregate panel are gone; issues surface inline in the Epoch panel,
-;; via the L2 event-row pink-wash, and via the always-on issues ribbon
-;; signal — the `:rf.xray/issues-ribbon` composite (now registered in
-;; `registry.cljs`) survives as the auto-open-on-error signal source.)
+;; There is no dedicated Issues tab or aggregate panel. Issues surface
+;; inline in the Epoch panel, via the L2 event-row pink-wash, and via
+;; the always-on issues ribbon signal — the `:rf.xray/issues-ribbon`
+;; composite (registered in `registry.cljs`) is the auto-open-on-error
+;; signal source.
 
 (defn mount-segment-inspector!
   "Mount the App-DB segment-inspector popup in isolation at
@@ -345,9 +343,8 @@
   reads `:rf.xray/managed-fx-for-focused-event` and renders the
   records list. `managed-fx-template/records-list` is a pure fn over
   a records vector; this reg-view ties it to the focused cascade's
-  managed-fx sub so consumers get the same content the (retired)
-  Event/Handler panel embedded inline; rf2-5gl5r kept the sub but
-  dropped the inline-embed host.
+  managed-fx sub so consumers get the per-cascade managed-fx content
+  inline.
 
   Exposing this as a reg-view (rather than a plain fn) follows the
   Conventions.md panel-facade contract — every mount target
@@ -355,9 +352,9 @@
   frame-provider per Spec 006 §706."
   []
   (let [records @(rf/subscribe [:rf.xray/managed-fx-for-focused-event])]
-    ;; rf2-nesy9 — thread the reg-view-injected frame-aware dispatch so
-    ;; the panel's context-menu / focus affordances land on the
-    ;; surrounding instance frame, not a `{:frame :rf/xray}` literal.
+    ;; Thread the reg-view-injected frame-aware dispatch so the panel's
+    ;; context-menu / focus affordances land on the surrounding instance
+    ;; frame, not a `{:frame :rf/xray}` literal.
     (managed-fx/records-list dispatch records)))
 
 (defn mount-managed-fx!

--- a/tools/xray/src/day8/re_frame2_xray/preload.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/preload.cljs
@@ -1,7 +1,7 @@
 (ns day8.re-frame2-xray.preload
   "Xray preload — the entry point shadow-cljs's `:devtools/preloads`
   pulls. This namespace is the canonical install path for Xray per
-  rf2-n6x4q + tools/xray/spec/000-Vision.md §Headline experiences.
+  tools/xray/spec/000-Vision.md §Headline experiences.
 
   ## What loading this ns does
 
@@ -45,7 +45,7 @@
   production builds via shadow-cljs's `:dev`-only `:devtools` block."
   (:require [re-frame.interop :as interop]
             ;; Pull `re-frame.epoch` into the dev classpath via the
-            ;; Xray preload (rf2-1barg). The Xray Time Travel panel
+            ;; Xray preload. The Xray Time Travel panel
             ;; reads epoch records via `rf/epoch-history` +
             ;; `rf/register-epoch-listener!`; those wrappers late-bind into
             ;; `re-frame.epoch`'s seed table. When the host example
@@ -62,21 +62,20 @@
             ;; bundles by the `:devtools/preloads` shadow-cljs gate.
             [re-frame.epoch]
             [day8.re-frame2-xray.config :as config]
-            ;; rf2-5w06uu — the inert, callable install helpers
-            ;; (trace/epoch collector registration + browser-API
-            ;; exports) live in `day8.re-frame2-xray.install`, a
-            ;; namespace whose LOAD performs no side-effects. The
-            ;; preload's side-effecting boot block below calls them;
-            ;; the manual facade (`core`) requires `install` directly
-            ;; so requiring the facade no longer drags in this
-            ;; preload's load-time side-effects.
+            ;; The inert, callable install helpers (trace/epoch
+            ;; collector registration + browser-API exports) live in
+            ;; `day8.re-frame2-xray.install`, a namespace whose LOAD
+            ;; performs no side-effects. The preload's side-effecting
+            ;; boot block below calls them; the manual facade (`core`)
+            ;; requires `install` directly, so requiring the facade
+            ;; does not drag in this preload's load-time side-effects.
             [day8.re-frame2-xray.install :as install]
             [day8.re-frame2-xray.keybinding :as keybinding]
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.effects :as settings-effects]
-            ;; rf2-8xzoe.4 (F-4) — pull the Xray-runtime accessor
-            ;; namespace into the preload classpath. The `:require` is the
+            ;; Pull the Xray-runtime accessor namespace into the
+            ;; preload classpath. The `:require` is the
             ;; load: `day8.re-frame2-xray.runtime` installs its
             ;; `js/globalThis.__day8_re_frame2_xray_runtime` sentinel as
             ;; a top-level side effect (gated on `interop/debug-enabled?`).
@@ -86,13 +85,13 @@
             ;; entry is required on the consumer side.
             [day8.re-frame2-xray.runtime]))
 
-;; ---- install-helper re-exports (rf2-5w06uu) ------------------------------
+;; ---- install-helper re-exports -------------------------------------------
 ;;
-;; The callable install primitives now live in
+;; The callable install primitives live in
 ;; `day8.re-frame2-xray.install` (an inert-on-load ns). Re-export them
-;; here as `def`-aliases so the established `preload/<helper>` call
-;; sites — the Xray test corpus, `test_support/reset-all!`, embed-host
-;; tooling — keep resolving against the same fn values. Identity holds:
+;; here as `def`-aliases so `preload/<helper>` call sites — the Xray
+;; test corpus, `test_support/reset-all!`, embed-host tooling — resolve
+;; against the same fn values. Identity holds:
 ;; `(= install/register-trace-collector! preload/register-trace-collector!)`.
 
 (def register-trace-collector!
@@ -127,7 +126,7 @@
 ;; tree-shaking).
 
 (when interop/debug-enabled?
-  ;; Settings persistence (rf2-9poxq) — load BEFORE registry install
+  ;; Settings persistence — load BEFORE registry install
   ;; so the first sub read from the popup's events lands on the
   ;; persisted values, not on the defaults.
   (config/load-settings-from-storage!)
@@ -141,16 +140,15 @@
   ;; on a missing root; the events handler re-applies on every
   ;; subsequent update.
   (settings-effects/apply-all!)
-  ;; Auto-open-on-error watcher (rf2-9poxq) — NOT installed here.
+  ;; Auto-open-on-error watcher — NOT installed here.
   ;; The watcher subscribes to `:rf.xray/issues-ribbon`, a sub that
   ;; reads from `:rf/xray`'s app-db; but `:rf/xray` is
   ;; lazy-registered by `mount/ensure-xray-frame!` on first open
-  ;; (see mount.cljs §Why here, not at preload time). Eagerly
-  ;; subscribing here returned nil and `(add-watch nil ...)` threw
+  ;; (see mount.cljs §Why here, not at preload time). Subscribing
+  ;; here would return nil, and `(add-watch nil ...)` throws
   ;; `No protocol method IWatchable.-add-watch defined for type
-  ;; null` in test runtimes that never opened Xray (Story
-  ;; testbeds). The install is now driven from two correctness-
-  ;; safe hooks:
+  ;; null` in test runtimes that never open Xray (Story testbeds).
+  ;; The install is driven from two correctness-safe hooks:
   ;;   1. `mount/ensure-xray-frame!` — when Xray first opens, if
   ;;      the persisted setting is on, install (covers the user's
   ;;      `:auto-open-on-error? true` round-trip across reloads).

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -26,7 +26,7 @@
   the panel-selection slot, the shared cascades projection, and the
   three suppression-counter handlers) plus the orchestration call
   into each per-panel `install!`. Per-panel registrations live in the
-  panel's own ns under `(defn install! [] ...)` (rf2-d4xda) so each
+  panel's own ns under `(defn install! [] ...)` so each
   panel owns its subs / events / fxs colocated with the view that
   reads them. Sub-registration order is purely cosmetic — re-frame
   resolves `:<-` chains lazily at subscribe time, not register time."
@@ -36,11 +36,9 @@
             ;; top-level `reg-sub` / `reg-event` calls land in
             ;; the registrar at orchestrator-load time. The widget
             ;; owns `:rf.xray.edn-inspector/*` events/subs and is the
-            ;; SINGLE source of truth for browse + diff + mini
-            ;; (rf2-q3dzw phase 5; legacy `edn-inspector.render` +
-            ;; `theme.data-inspector` ns'es are deleted).
+            ;; SINGLE source of truth for browse + diff + mini.
             [day8.re-frame2-xray.views.edn-inspector]
-            ;; rf2-l4625 — popup overlay infra. `install!` registers
+            ;; Popup overlay infra. `install!` registers
             ;; the stack/entries subs + open/close/close-top/close-all
             ;; events at orchestrator-load time. The stack VIEW mount
             ;; lives in `shell.cljs`; per-panel "open in popup"
@@ -50,7 +48,7 @@
             ;; `:rf/xray` frame.
             [day8.re-frame2-xray.views.edn-inspector-popup
              :as edn-inspector-popup]
-            ;; rf2-uji72 — shared draggable-column-resize affordance.
+            ;; Shared draggable-column-resize affordance.
             ;; `install!` registers the `:rf.xray.column-widths/*`
             ;; events + sub that drive the per-table grid template.
             [day8.re-frame2-xray.views.resizable-table :as resizable-table]
@@ -89,14 +87,13 @@
             [day8.re-frame2-xray.panels.reactive-panel :as reactive-panel]
             [day8.re-frame2-xray.panels.trace :as trace]))
 
-;; ---- defaults (re-exported for back-compat callers) ---------------------
+;; ---- defaults (re-exported) ---------------------------------------------
 ;;
 ;; The Var itself lives in `day8.re-frame2-xray.defaults` so the
 ;; per-panel `install!` fns can read it without forming a
-;; registry→panel→registry cycle. Re-exported here so the existing
-;; test surface keeps reading `registry/default-target-frame` — same
-;; source of truth. (`default-panel-id` was dropped with rf2-qy0nu —
-;; the legacy `:rf.xray/selected-panel` slot is no longer read.)
+;; registry→panel→registry cycle. Re-exported here so the test surface
+;; reads `registry/default-target-frame` against the same source of
+;; truth.
 
 (def default-target-frame defaults/default-target-frame)
 
@@ -119,7 +116,7 @@
 
     ;; Xray's trace-buffer sub returns a flat snapshot of every
     ;; registered frame's per-frame trace ring + the small frameless
-    ;; secondary ring (per rf2-43koh + the rf2-3g9nw D2=a ruling).
+    ;; secondary ring.
     ;; The slot lives in Xray's app-db at `:trace-buffer` and is
     ;; populated by `trace-collector/refresh-trace-rings!` — a
     ;; microtask-coalesced snapshot from the framework's per-frame
@@ -144,11 +141,11 @@
 
     ;; Total count of :sensitive? trace events the collector has
     ;; suppressed under the current local-render egress profile
-    ;; (`:rf.xray/egress-profile`; rf2-h40lt2). The shell's bottom-rail renders a `[● REDACTED N]`
+    ;; (`:rf.xray/egress-profile`). The shell's bottom-rail renders a `[● REDACTED N]`
     ;; hint when this is positive so the user sees why the buffer is
     ;; shorter than the runtime's actual emit count.
     ;;
-    ;; Per rf2-0vxdn the counter lives in Xray's app-db at
+    ;; The counter lives in Xray's app-db at
     ;; `:suppressed-counters` ({frame-id → count}); `config/note-
     ;; suppressed!` dispatches `:rf.xray/note-sensitive-suppressed`
     ;; in CLJS, so the sub fires on the standard app-db-write
@@ -163,27 +160,25 @@
       (fn [db _query]
         (reduce + 0 (vals (get db :suppressed-counters {})))))
 
-    ;; ---- 4-layer chrome — selected tab (rf2-xy4yb / spec/018) ----
+    ;; ---- 4-layer chrome — selected tab (spec/018) ----
     ;;
     ;; The L3 tab bar reads `:rf.xray/selected-tab` to pick which
     ;; projection of the focused event the L4 detail panel renders.
-    ;; Default is `:epoch` post rf2-5gl5r — the Epoch panel is the
-    ;; canonical "what happened in this epoch" surface and registers
-    ;; at `:order -1` (leftmost). Previously defaulted to `:event`
-    ;; while the Handler/Event panel co-existed; that panel was
-    ;; retired and the Epoch panel supersedes it.
+    ;; Default is `:epoch` — the Epoch panel is the canonical "what
+    ;; happened in this epoch" surface and registers at `:order -1`
+    ;; (leftmost).
     (rf/reg-sub :rf.xray/selected-tab
       (fn [db _query]
         (get db :selected-tab :epoch)))
 
-    ;; ---- Machine tab fit-on-entry signal (rf2-6tw7t) ----
+    ;; ---- Machine tab fit-on-entry signal ----
     ;;
     ;; A monotonic counter bumped by `:rf.xray/select-tab :machines` and
     ;; `:rf.xray.static/select-tab :machines`. The Machine panel (Dynamic
     ;; `machine_inspector` + Static `static.machines` topology) reads it
     ;; and forwards the value as `MachineChart`'s `:fit-signal` so a
     ;; CHANGE re-fits the topology to view on panel-entry / tab-
-    ;; activation. The layout-key auto-fit (rf2-set3x) deliberately
+    ;; activation. The layout-key auto-fit deliberately
     ;; preserves manual zoom/pan across non-layout re-renders, leaving a
     ;; re-entered chart at its stale (possibly off-screen) viewport; this
     ;; signal is the orthogonal entry-fit escape hatch. Defaults to 0 so
@@ -193,7 +188,7 @@
       (fn [db _query]
         (get db :machine-tab-activations 0)))
 
-    ;; ---- Modal positioning (rf2-om6fa) ----
+    ;; ---- Modal positioning ----
     ;;
     ;; Every Xray modal (Settings popup, auto-filter edit popup,
     ;; Share modal, Cancellation cascade popover) defaults to
@@ -219,7 +214,7 @@
       (fn [{:keys [db]} [_ positioning]]
         {:db (assoc db :modal-positioning (or positioning :fixed))}))
 
-    ;; ---- Panel width (rf2-x8h9y horizontal resize handle) -------
+    ;; ---- Panel width (horizontal resize handle) -------
     ;;
     ;; The shell's left-edge resize handle drags the panel width.
     ;; `:rf.xray/panel-width-px` reads from the settings map (the
@@ -273,7 +268,7 @@
         {:fx [[:dispatch [:rf.xray/set-panel-width-px
                           config/default-panel-width-px]]]}))
 
-    ;; ---- L2 event-list height (rf2-t2dsh seam resize handle) -----
+    ;; ---- L2 event-list height (seam resize handle) -----
     ;;
     ;; The L2/L3 seam carries a row-resize drag handle that drives the
     ;; events-list height. Mirrors the panel-width-px shape above:
@@ -288,11 +283,9 @@
     ;;     emits one dispatch per pixel of motion; trace-buffering them
     ;;     would flood the bus with shape no panel consumes.
     ;;
-    ;; Per rf2-t2dsh the prior browser-native `:resize \"vertical\"`
-    ;; corner-grip on the L2 list was RETIRED — it carried no
-    ;; persistence, no keyboard affordance, and a tiny corner hit-
-    ;; target. The seam matches the panel-width handle's interaction
-    ;; model so all resize surfaces share one mental model.
+    ;; The seam matches the panel-width handle's interaction model so
+    ;; all resize surfaces share one mental model — a full-width
+    ;; click-area with persistence and a keyboard affordance.
     (rf/reg-sub :rf.xray/events-list-height-px
       (fn [db _query]
         (or (get-in db [:settings :general :events-list-height-px])
@@ -321,7 +314,7 @@
         {:fx [[:dispatch [:rf.xray/set-events-list-height-px
                           config/default-events-list-height-px]]]}))
 
-    ;; ---- L2 event-list resizable column widths (rf2-6ni62) -------
+    ;; ---- L2 event-list resizable column widths -------
     ;;
     ;; The L2 event-list carries four columns — `event-id` (flex),
     ;; `source`, `timestamp`, `duration`. The trailing three are
@@ -331,7 +324,7 @@
     ;; reload through `config/update-setting!` → localStorage.
     ;;
     ;; The sub resolves the persisted map over the defaults (defence-
-    ;; in-depth: a legacy / malformed payload yields a clamped, fully-
+    ;; in-depth: a stale / malformed payload yields a clamped, fully-
     ;; shaped map every consumer can read against). Header and rows
     ;; both read from the SAME sub so the two surfaces never drift
     ;; out of column alignment — the alignment guarantee.
@@ -372,13 +365,13 @@
         (when-let [default-px (get config/event-list-col-default-widths col-id)]
           {:fx [[:dispatch [:rf.xray/set-event-list-col-width col-id default-px]]]})))
 
-    ;; ---- 4-layer chrome — active filter pills (rf2-xy4yb / spec/018 §7) ----
+    ;; ---- 4-layer chrome — active filter pills (spec/018 §7) ----
     ;;
     ;; The ribbon's filter cluster reads `:rf.xray/active-filters` —
     ;; shape `{:in [{:pattern <str>}] :out [{:pattern <str>}]}` (pills
     ;; are keyed off event-id only; typed-predicate kinds add a
     ;; `{:kind … :params …}` shape via right-click affordances). The
-    ;; `:rf.xray/filtered-cascades` sub (rf2-ak4ms, installed via
+    ;; `:rf.xray/filtered-cascades` sub (installed via
     ;; `filters/install!` further down) composes against this slot to
     ;; produce the filtered cascade list every consumer reads.
     ;;
@@ -400,13 +393,13 @@
     ;; stays correct (and idle composites still don't pay for the
     ;; projection).
     ;;
-    ;; Per rf2-g1pt8 the projection ALSO hard-filters Xray-internal
-    ;; cascades (any cascade whose event-id is in the `rf.xray`
-    ;; namespace) at this single point so every downstream consumer
+    ;; The projection ALSO hard-filters Xray-internal cascades (any
+    ;; cascade whose event-id is in the `rf.xray` namespace) at this
+    ;; single point so every downstream consumer
     ;; — `:rf.xray/filtered-cascades`, the L2 event list, the spine,
-    ;; the Trace / Issues / Event / Views tabs — inherits the filter
+    ;; the Trace / Views tabs — inherits the filter
     ;; automatically. The ingest-side `self-noise/xray-internal-event?`
-    ;; guard (rf2-xs8vu) catches self-emitted sub-reads + view-renders
+    ;; guard catches self-emitted sub-reads + view-renders
     ;; inside Xray's frame scope, but `:rf.xray/*` events dispatched
     ;; WITHOUT a `{:frame :rf/xray}` option (palette quick-actions,
     ;; headless helpers) land on the host frame and slip past the
@@ -418,35 +411,24 @@
       (fn [buffer _query]
         (self-noise/filtered-cascades buffer)))
 
-    ;; ---- Focused-cascade composite (rf2-5gl5r — relocated from the
-    ;; retired event-detail panel) -----------------------------------
+    ;; ---- Focused-cascade composite -------------------------------
     ;;
     ;; `:rf.xray/focused-cascade-detail` produces the focused-cascade
     ;; record alongside the cascade vector + the effective dispatch-id/
     ;; frame so multiple consumers can read "the cascade the spine is
-    ;; pointing at" in one shot. The original home was
-    ;; `panels/event_detail.cljs`'s `install!`; when the Event/Handler
-    ;; panel was retired (Epoch panel supersedes it — rf2-5gl5r) the
-    ;; composite stayed valuable to the per-cascade managed-fx surface
-    ;; and the existing test corpus, so it lives here as a cross-panel
-    ;; primitive next to `:rf.xray/cascades` it composes against.
-    ;; (rf2-nugvv removed the share modal that previously also consumed
-    ;; it via `:rf.xray/cascade-export`.)
-    ;;
-    ;; rf2-7ed9ms — renamed from the retired-panel name
-    ;; `:rf.xray/event-detail` to the BEHAVIOUR name
-    ;; `:rf.xray/focused-cascade-detail`. The composite now means
-    ;; "the focused cascade's detail record", not "the Event Detail
-    ;; panel's data" (that panel is gone), so the live sub no longer
-    ;; carries retired-panel vocabulary in an active API surface.
+    ;; pointing at" in one shot. It is a cross-panel primitive (the
+    ;; per-cascade managed-fx surface + the test corpus read it), so it
+    ;; lives here next to `:rf.xray/cascades` it composes against. The
+    ;; name describes its behaviour: "the focused cascade's detail
+    ;; record".
     ;;
     ;; Reads the EFFECTIVE focused dispatch-id off the spine sub
     ;; (`:rf.xray/focus`); spine auto-advances to head in `:live` mode,
-    ;; so the consumers never pin to a stale id. Per rf2-639lc Bug 1:
-    ;; if the spine landed on `:ungrouped` (the projection's catch-all
-    ;; bucket for registry-time emits / frame lifecycle outside a
-    ;; drain), fall back to the most recent ROUTED cascade so the
-    ;; default-focus never lands on the projection's internal bucket.
+    ;; so the consumers never pin to a stale id. If the spine lands on
+    ;; `:ungrouped` (the projection's catch-all bucket for registry-time
+    ;; emits / frame lifecycle outside a drain), fall back to the most
+    ;; recent ROUTED cascade so the default-focus never lands on the
+    ;; projection's internal bucket.
     (rf/reg-sub :rf.xray/focused-cascade-detail
       :<- [:rf.xray/cascades]
       :<- [:rf.xray/focus]
@@ -477,19 +459,18 @@
            :selected-dispatch-frame selected-frame
            :selected-cascade        by-id})))
 
-    ;; ---- Spine shim — focus by dispatch-id (rf2-adve5, relocated
-    ;; rf2-5gl5r) ----------------------------------------------------
+    ;; ---- Spine shim — focus by dispatch-id ------------------------
     ;;
-    ;; `:rf.xray/select-dispatch-id` is the legacy entry point used by
-    ;; machine-inspector / trace / cancellation-cascade
+    ;; `:rf.xray/select-dispatch-id` is the by-dispatch-id entry point
+    ;; used by machine-inspector / trace / cancellation-cascade
     ;; / mcp-server / the cross-site event-status-colour e2e harness.
     ;; It writes through the spine via the same reducer the spec-018
-    ;; `:rf.xray/focus-cascade` event uses. Relocated from the retired
-    ;; event-detail panel — multi-panel consumer, lives here.
+    ;; `:rf.xray/focus-cascade` event uses. A multi-panel consumer, so
+    ;; it lives here.
     ;;
-    ;; rf2-o1c3r — re-key `:epoch-history` onto the selected cascade's
+    ;; Re-keys `:epoch-history` onto the selected cascade's
     ;; frame BEFORE resolving its settling epoch, exactly as the sibling
-    ;; `:rf.xray/focus-cascade` handler does (rf2-q8hvw). With the picker
+    ;; `:rf.xray/focus-cascade` handler does. With the picker
     ;; untouched the `:epoch-history` slot is keyed on the boot head
     ;; frame, so selecting a dispatch-id in a NON-head frame would
     ;; otherwise resolve its epoch against the wrong frame's ring →
@@ -506,9 +487,8 @@
           (spine/focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))}))
 
     ;; Programmatic clear of the focused cascade. Resets the spine
-    ;; focus back to LIVE (head-tracking) per the rf2-s0s5x Phase A
-    ;; semantics. Relocated from event_detail.cljs alongside the
-    ;; select event above (rf2-5gl5r).
+    ;; focus back to LIVE (head-tracking) per the Phase A semantics.
+    ;; A multi-panel consumer alongside the select event above.
     (rf/reg-event :rf.xray/clear-selected-dispatch-id
       (fn [{:keys [db]} _event]
         {:db (update db :focus (fnil assoc {})
@@ -517,21 +497,19 @@
                 :mode        :live
                 :previewing? false)}))
 
-    ;; ---- L2 relative-time anchor (rf2-vbbq0 / rf2-0s2at) ----------
+    ;; ---- L2 relative-time anchor ----------------------------------
     ;;
     ;; Every L2 row carries a small right-aligned chip showing how long
     ;; ago the cascade was dispatched ("5s" / "2m" / "1h" / "3d"). The
     ;; anchor — the "now" each row's relative-time computes against —
-    ;; flips on EVENT ARRIVAL, not on a wall-clock tick (rf2-0s2at).
+    ;; flips on EVENT ARRIVAL, not on a wall-clock tick.
     ;;
-    ;; Mike's design call (2026-05-19, watching the parallel-frames
-    ;; testbed live): a per-second `setInterval` re-rendered the L2
-    ;; list every second, producing constant flicker for negligible
-    ;; semantic gain. Relative time is meaningful BETWEEN events, not
-    ;; between seconds — so the anchor is the dispatched-time of the
-    ;; most recent cascade. When a new event arrives the anchor flips,
-    ;; older rows recompute (a row that was "3s" now reads "8s"); in
-    ;; between events the list is frozen.
+    ;; Relative time is meaningful BETWEEN events, not between seconds —
+    ;; so the anchor is the dispatched-time of the most recent cascade,
+    ;; which avoids the per-second flicker a wall-clock `setInterval`
+    ;; would produce for negligible semantic gain. When a new event
+    ;; arrives the anchor flips, older rows recompute (a row that was
+    ;; "3s" now reads "8s"); in between events the list is frozen.
     ;;
     ;; The sub composes off `:rf.xray/cascades` so it inherits the
     ;; Xray-internal filter (cascade-internal ticks never become the
@@ -547,18 +525,17 @@
           (when (seq times)
             (apply max times)))))
 
-    ;; ---- 4-layer chrome events (rf2-xy4yb / spec/018) -------------
+    ;; ---- 4-layer chrome events (spec/018) -------------------------
 
-    ;; L3 tab bar — flip the active tab. Six valid ids post rf2-gbz39
-    ;; (Issues tab removed; Option (c) — issues now surface inline in
-    ;; the Epoch + the L2 event-row pink-wash + the auto-open-on-error
-    ;; signal; rf2-5gl5r had retired the Event/Handler tab; Epoch
-    ;; supersedes):
+    ;; L3 tab bar — flip the active tab. Six valid ids:
     ;; :epoch :app-db :views :trace :machines :routing
-    ;; (rf2-2moh1 registry-driven; new tab requires only a reg-l4-tab! call).
+    ;; Registry-driven; a new tab requires only a reg-l4-tab! call.
+    ;; Issues surface inline in the Epoch panel, via the L2 event-row
+    ;; pink-wash, and via the auto-open-on-error signal — there is no
+    ;; dedicated Issues tab.
     (rf/reg-event :rf.xray/select-tab
       (fn [{:keys [db]} [_ tab-id]]
-        ;; rf2-6tw7t — activating the Machine tab bumps a monotonic
+        ;; Activating the Machine tab bumps a monotonic
         ;; fit-signal counter so the Machine panel's topology re-fits to
         ;; view on entry (xyflow's one-shot `:fitView` + the layout-key
         ;; auto-fit both leave a re-entered chart at its stale pan/zoom).
@@ -572,28 +549,26 @@
           (= tab-id :machines)
           (update :machine-tab-activations (fnil inc 0)))}))
 
-    ;; ---- Issues feed composite (rf2-gbz39) ------------------------
+    ;; ---- Issues feed composite ------------------------------------
     ;;
     ;; `:rf.xray/issues-ribbon` projects the focused epoch's
     ;; `:trace-events` into the issue subset (errors + warnings +
-    ;; advisories per Spec 009 §Error event catalogue). Mike RULED
-    ;; Option (c) — the dedicated Issues TAB + its aggregate panel were
-    ;; removed (the session-wide triage list was consciously dropped).
-    ;; Issues now surface inline in the Epoch panel, via the L2
-    ;; event-row pink-wash, and via the always-on issues ribbon signal
-    ;; (the auto-open-on-error watcher). This composite SURVIVES the
-    ;; tab removal because it remains the canonical projection the
+    ;; advisories per Spec 009 §Error event catalogue). Issues surface
+    ;; inline in the Epoch panel, via the L2 event-row pink-wash, and
+    ;; via the always-on issues ribbon signal (the auto-open-on-error
+    ;; watcher); there is no dedicated Issues tab or session-wide
+    ;; triage list. This composite is the canonical projection the
     ;; auto-open watcher reads (settings/effects.cljs/
     ;; install-auto-open-watcher!) — the cross-epoch "something is
-    ;; wrong" signal Mike kept under (c). The pure-data projection lives
-    ;; in `issues_ribbon_helpers.cljc` (also feeding the L2 pink-wash
+    ;; wrong" signal. The pure-data projection lives in
+    ;; `issues_ribbon_helpers.cljc` (also feeding the L2 pink-wash
     ;; predicate via `panels/l2-timeline/cascade-has-issue?`), so the
     ;; algebra runs under the JVM test target.
     ;;
     ;; Per spec/021 §1.2 the projection is focused-epoch-scoped — it
     ;; joins `:rf.xray/focus`'s `:epoch-id` against the per-frame
     ;; `:rf.xray/epoch-history`, classifies focus status (no-focus /
-    ;; focused / evicted; rf2-h0120 head-fallback), looks up the epoch
+    ;; focused / evicted; head-fallback), looks up the epoch
     ;; record, and threads it through `project-feed`.
     (rf/reg-sub :rf.xray/issues-ribbon
       :<- [:rf.xray/focus]
@@ -606,7 +581,7 @@
                                                                epoch-history)]
           (issues-helpers/project-feed record focus-status))))
 
-    ;; ---- Static-mode chrome (rf2-o5f5f.1) -------------------------
+    ;; ---- Static-mode chrome ---------------------------------------
     ;;
     ;; Xray exposes TWO modes per `tools/xray/spec/007-UX-IA.md`
     ;; §Static mode: Dynamic (event-coupled spine) and Static
@@ -658,7 +633,7 @@
     (rf/reg-event :rf.xray.static/select-tab
       (fn [{:keys [db]} [_ tab-id]]
         {:db (if (contains? (static-shell/tab-ids) tab-id)
-          ;; rf2-6tw7t — Static shares the same `:machines` tab id +
+          ;; Static shares the same `:machines` tab id +
           ;; `machine-canvas/Chart`, so activating it bumps the same
           ;; fit-signal counter the Dynamic select-tab does. The Static
           ;; topology view forwards it as `:fit-signal` too.
@@ -679,7 +654,7 @@
     ;; edit popup in `filters/save-edit-popup` composes against the
     ;; same slot but threads through the popup's draft. Both surfaces
     ;; share the `:rf.xray.filters/persist` fx so every mutation
-    ;; round-trips to localStorage in one place (rf2-ak4ms).
+    ;; round-trips to localStorage in one place.
     (rf/reg-event :rf.xray/add-filter
       (fn [{:keys [db]} [_ mode pill]]
         (let [next-db (update-in db [:active-filters mode] (fnil conj []) pill)]
@@ -697,42 +672,38 @@
           {:db next-db
            :fx [[:rf.xray.filters/persist (get next-db :active-filters)]]})))
 
-    ;; Ribbon right-icon events. Per rf2-czcg5 the second-window UX has
-    ;; landed, so the chrome now carries a VISIBLE `⛶` pop-out button
-    ;; (shell.cljs `ribbon-right-icons`) that dispatches
+    ;; Ribbon right-icon events. The chrome carries a VISIBLE `⛶`
+    ;; pop-out button (shell.cljs `ribbon-right-icons`) that dispatches
     ;; `:rf.xray/popout-shell`. The event fires the DOM-side
     ;; `:rf.xray.fx/popout-shell` effect (mount/install-fx!) which calls
     ;; `mount/popout!` — the event/fx bridge keeps shell.cljs free of a
     ;; direct mount require (mirrors the close-shell bridge below). The
-    ;; programmatic `(xray/popout!)` API remains the secondary path.
+    ;; programmatic `(xray/popout!)` API is the secondary path.
     (rf/reg-event :rf.xray/open-settings
       (fn [{:keys [db]} _event]
-        ;; Settings popup lands behind rf2-pending-settings-modal.
         {:db (assoc db :settings-open? true)}))
 
     (rf/reg-event :rf.xray/popout-shell
       (fn [_cofx _event]
-        ;; rf2-czcg5 — open the second-window pop-out via the DOM-side
-        ;; effect. No db change: the pop-out is a sibling mount surface,
-        ;; not a reactive flag.
+        ;; Open the second-window pop-out via the DOM-side effect. No db
+        ;; change: the pop-out is a sibling mount surface, not a
+        ;; reactive flag.
         {:fx [[:rf.xray.fx/popout-shell]]}))
 
     (rf/reg-event :rf.xray/close-shell
       (fn [{:keys [db]} _event]
-        ;; Close intent (rf2-fq491). Two outcomes, kept in lock-step:
+        ;; Close intent. Two outcomes, kept in lock-step:
         ;;   :db  — set the reactive `:close-requested?` flag so the
         ;;          round-trip is observable/testable.
         ;;   :fx  — `:rf.xray.fx/hide-shell` performs the actual DOM
         ;;          hide via `mount/close!` (the same CSS-only toggle the
         ;;          Ctrl+Shift+C keybinding drives through `mount/toggle!`).
-        ;; Previously this only set the flag and nothing consumed it, so
-        ;; the `✕` button was a no-op.
         {:db (assoc db :close-requested? true)
          :fx [[:rf.xray.fx/hide-shell]]}))
 
     ;; Install the DOM-side `:rf.xray.fx/hide-shell` effect that the
     ;; `:rf.xray/close-shell` event above fires. Idempotent — re-frame's
-    ;; registrar replaces in place (rf2-fq491).
+    ;; registrar replaces in place.
     (mount/install-fx!)
 
     ;; ---- trace-buffer mirror events -------------------------------
@@ -740,7 +711,7 @@
     ;; The reactive surface for the layer-1 `:rf.xray/trace-buffer`
     ;; sub is Xray's `:rf/xray` app-db `:trace-buffer` slot. Two
     ;; events drive that slot, both flagged `:rf.trace/no-emit? true`
-    ;; (rf2-qsjda) so the mirror dispatch does not re-enter the trace
+    ;; so the mirror dispatch does not re-enter the trace
     ;; fan-out and loop:
     ;;
     ;;   `:rf.xray/sync-trace-buffer` — wholesale overwrite with a
@@ -748,8 +719,8 @@
     ;;     per-frame ring + the frameless secondary ring. Dispatched
     ;;     by `trace-collector/refresh-trace-rings!` (production
     ;;     microtask-coalesced via `request-mirror-sync!`; tests call
-    ;;     `refresh-trace-rings!` directly per the rf2-3g9nw D3=b
-    ;;     ruling). Also seeds the slot at first mount.
+    ;;     `refresh-trace-rings!` directly for a deterministic sync
+    ;;     entrypoint). Also seeds the slot at first mount.
     ;;
     ;;   `:rf.xray/clear-trace-buffer` — drop the slot entirely.
     ;;     Dispatched by `trace-collector/retroactive-scrub!` when the
@@ -759,7 +730,7 @@
 
     ;; Clear the mirrored slot in lockstep with the framework's
     ;; per-frame rings + Xray's frameless secondary ring (dispatched
-    ;; from `trace-collector/retroactive-scrub!`). Per rf2-qsjda the
+    ;; from `trace-collector/retroactive-scrub!`). The
     ;; `:rf.trace/no-emit?` flag avoids re-entering the trace fan-out.
     (rf/reg-event :rf.xray/clear-trace-buffer
       {:rf.trace/no-emit? true}
@@ -771,14 +742,14 @@
     ;; app-db with whatever the framework's per-frame rings + Xray's
     ;; frameless secondary ring have accumulated before the shell was
     ;; opened, and from `trace-collector/refresh-trace-rings!` /
-    ;; `request-mirror-sync!` on every microtask. Per rf2-qsjda
+    ;; `request-mirror-sync!` on every microtask.
     ;; `:rf.trace/no-emit? true` for the same loop-avoidance reason.
     (rf/reg-event :rf.xray/sync-trace-buffer
       {:rf.trace/no-emit? true}
       (fn [{:keys [db]} [_ buffer]]
         {:db (assoc db :trace-buffer (vec buffer))}))
 
-    ;; Bump the per-frame suppressed-events counter (rf2-0vxdn).
+    ;; Bump the per-frame suppressed-events counter.
     ;; Dispatched from `trace-collector/collect-trace!` (CLJS) under
     ;; `:rf/xray` whenever the privacy gate drops a `:sensitive? true`
     ;; trace event. `frame-id` is the event's `:tags :frame` (the host
@@ -786,30 +757,30 @@
     ;; the bottom-rail `[● REDACTED N]` indicator via the
     ;; `:rf.xray/suppressed-sensitive-count` sub — fully reactive.
     ;;
-    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` opts the handler out of
+    ;; `:rf.trace/no-emit? true` opts the handler out of
     ;; framework trace emission. Without this, the dispatch fired by
     ;; `trace-collector/collect-trace!` would itself emit
     ;; `:rf.event/dispatched` etc. back through the trace-cb fan-out,
     ;; the collector would see
     ;; its own self-emit, and the cascade would loop until
-    ;; `drain-depth-default` terminated it. The framework now
+    ;; `drain-depth-default` terminated it. The framework
     ;; short-circuits emission at the `emit!` / `emit-error!` /
-    ;; `emit-dispatched-trace!` gates — the predecessor Xray-side
-    ;; `self-emitted?` guard (rf2-nk01x) is obsolete.
+    ;; `emit-dispatched-trace!` gates so no Xray-side `self-emitted?`
+    ;; guard is needed.
     (rf/reg-event :rf.xray/note-sensitive-suppressed
       {:rf.trace/no-emit? true}
       (fn [{:keys [db]} [_ frame-id]]
         {:db (update-in db [:suppressed-counters (or frame-id :global)]
                    (fnil inc 0))}))
 
-    ;; Reset the suppressed-events counter (rf2-0vxdn). With no arg,
+    ;; Reset the suppressed-events counter. With no arg,
     ;; clears every bucket; with a `frame-id`, drops just that bucket.
     ;; Dispatched from `trace-collector/retroactive-scrub!` (CLJS) —
     ;; clearing the trace ring buffer also drops the REDACTED
     ;; indicator state (the "you missed N events" overhang disappears
     ;; alongside the events that produced it).
     ;;
-    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
+    ;; `:rf.trace/no-emit? true` (see
     ;; `:rf.xray/note-sensitive-suppressed` above for the rationale).
     (rf/reg-event :rf.xray/reset-suppressed-counters
       {:rf.trace/no-emit? true}
@@ -828,12 +799,11 @@
     ;; The open-in-editor install is cross-panel — its
     ;; `:rf.xray/open-in-editor` event-fx + `:rf.editor/open` fx are
     ;; dispatched from trace, mcp-server, and the
-    ;; hydration debugger (rf2-g5q8d). Installed alongside the
+    ;; hydration debugger. Installed alongside the
     ;; per-panel installs so the registration order matches the
     ;; per-panel pattern.
 
-    ;; Cross-cutting epoch primitives (rf2-qy0nu — extracted from the
-    ;; deleted Time Travel panel). MUST install before app-db-diff +
+    ;; Cross-cutting epoch primitives. MUST install before app-db-diff +
     ;; views + machine-inspector — their composites :<- onto
     ;; `:rf.xray/epoch-history` / `:rf.xray/target-frame` (and pivot on
     ;; the spine focus epoch via `:rf.xray/focus-epoch-id`). Registration
@@ -841,7 +811,7 @@
     ;; dependency read is clearer.
     (epoch/install!)
     (open-in-editor/install!)
-    ;; rf2-4s08ov — open-in-editor 'pick an editor in Settings' hint
+    ;; Open-in-editor 'pick an editor in Settings' hint
     ;; toast. Installs before settings-popup since its
     ;; `:rf.xray/editor-hint-open-settings` event dispatches
     ;; `:rf.xray/settings-open` (registered by settings-popup), but the
@@ -850,18 +820,18 @@
     (editor-hint/install!)
     (palette/install!)
     (settings-popup/install!)
-    ;; rf2-l4625 — edn-inspector popup overlay (subs + events). The
+    ;; Edn-inspector popup overlay (subs + events). The
     ;; stack view is mounted in `shell.cljs` alongside the other modal
     ;; mounts; per-panel "open in popup" affordances pass through
     ;; `[ei/edn-inspector value {:popup-affordance? true …}]` and
     ;; dispatch the `:rf.xray.edn-inspector-popup/open` event registered
     ;; here.
     (edn-inspector-popup/install!)
-    ;; rf2-uji72 — shared draggable column-resize state for Xray
+    ;; Shared draggable column-resize state for Xray
     ;; tables. Registers :rf.xray.column-widths/{for-table,resize-pair,
     ;; reset,hydrate} + the :rf.xray.column-widths/persist fx.
     ;;
-    ;; rf2-xzg1y — column-widths now persist to localStorage under
+    ;; Column-widths persist to localStorage under
     ;; `re-frame2.xray.column-widths.v1`. `install!` wires the fx +
     ;; events; `hydrate!` runs here (preload-time, before the frame is
     ;; registered, so it's a guarded no-op) AND from `mount.cljs`'s
@@ -878,7 +848,7 @@
     ;; idempotency sentinel above prevents the hydrate-dispatch from
     ;; firing twice on shadow-cljs `:after-load`.
     (filters/install!)
-    ;; Per-event-id mute filter (rf2-ikuwt). Installs the
+    ;; Per-event-id mute filter. Installs the
     ;; `:rf.xray/muted-event-ids` slot + the mute / unmute / clear
     ;; events + the localStorage persistence fx + the unmute manager
     ;; modal open / close state. Installs AFTER `filters/install!` so
@@ -889,23 +859,23 @@
     ;; from `filtered-cascades` → `spine-filtered-cascades` so the
     ;; mute strip rides atop the existing IN/OUT pill filter).
     (spine-filters/install!)
-    ;; Spine MUST install before event-detail / time-travel — their
-    ;; legacy selection events shim writes through the spine slot,
+    ;; Spine MUST install before the cross-panel selection shims —
+    ;; the by-dispatch-id selection events write through the spine slot,
     ;; and the slot's reducer helpers live in spine.cljs.
     (spine/install!)
-    ;; Frame-switcher slot (rf2-iwwou) — hardened L1 frame-switcher
+    ;; Frame-switcher slot — hardened L1 frame-switcher
     ;; contract. MUST install AFTER `spine/install!` so the canonical
     ;; `:rf.xray/select-frame` event-fx's `[:dispatch [:rf.xray/set-
     ;; frame ...]]` resolves at install time. Registers the
     ;; `:rf.xray/current-frame` + `:rf.xray/available-frames` subs,
     ;; the `:rf.xray/select-frame` event-fx, and the `:rf.xray.frame-
     ;; switcher/persist` localStorage write fx. Does NOT restore the pin
-    ;; on init (rf2-swclw) — the frame pin is a transient filter, reset
+    ;; on init — the frame pin is a transient filter, reset
     ;; to unpinned on every page load by mount.cljs's
     ;; `::reset-transient-filters` hook.
     (frame-switcher/install!)
     (app-db-diff/install!)
-    ;; App-DB segment-inspector popup (rf2-e9tb0) — opens when any
+    ;; App-DB segment-inspector popup — opens when any
     ;; path-segment in the App-DB Diff breadcrumb is clicked. Installs
     ;; after `app-db-diff` so the segment-inspector's
     ;; `:rf.xray/segment-inspector-value` sub can chain off
@@ -913,25 +883,24 @@
     ;; Registration order is cosmetic — re-frame resolves `:<-` lazily;
     ;; the top-down dependency reading is the rationale.
     (app-db-segment-inspector/install!)
-    ;; Cancellation-cascade visualiser (rf2-59e7k) — installs the
+    ;; Cancellation-cascade visualiser — installs the
     ;; subs + events for the Machines tab side-panel + the trace-row
     ;; popover. The view-side `reg-view`s are picked up at ns-load.
     ;; Order: registers AFTER spine + cascades (composes against
     ;; `:rf.xray/focus` + `:rf.xray/trace-buffer`); registry order is
     ;; cosmetic since re-frame resolves `:<-` chains lazily.
     (cancellation-cascade/install!)
-    ;; Epoch panel (rf2-sc3r1) — the canonical "what happened in this
+    ;; Epoch panel — the canonical "what happened in this
     ;; epoch" surface; numbered cascade of every pipeline step. Reads
     ;; the spine's `:rf.xray/focus` + `:rf.xray/epoch-history`,
     ;; projects the focused record's `:trace-events` into ordered
-    ;; step rows. Registers at order -1 (leftmost). The retired
-    ;; Event/Handler panel (rf2-5gl5r) used to install here; its
-    ;; surviving cross-panel primitives — `:rf.xray/focused-cascade-detail`,
+    ;; step rows. Registers at order -1 (leftmost). The cross-panel
+    ;; primitives it consumes — `:rf.xray/focused-cascade-detail`,
     ;; `:rf.xray/select-dispatch-id`, `:rf.xray/clear-selected-
-    ;; dispatch-id` — were relocated to the cross-panel block above.
+    ;; dispatch-id` — live in the cross-panel block above.
     (epoch-panel/install!)
     (machine-inspector/install!)
-    ;; Static Machines sub-tab (rf2-o5f5f.2) — browses every registered
+    ;; Static Machines sub-tab — browses every registered
     ;; machine + Topology + JUMP-to-Dynamic + Cascade-dimmed surfaces.
     ;; Installs AFTER `machine-inspector/install!` so the static-machines
     ;; sub graph can :<- onto the existing `:rf.xray/registered-machines`,
@@ -940,14 +909,13 @@
     ;; cosmetic (re-frame resolves `:<-` chains lazily); the top-down
     ;; dependency read is clearer.
     (static-machines-panel/install!)
-    ;; Managed-fx wire-boundary diff template (rf2-uyp86) — installs the
+    ;; Managed-fx wire-boundary diff template — installs the
     ;; `:rf.xray/managed-fx-for-focused-event` sub + the
-    ;; `:rf.xray/focus-event` cross-link event. Originally embedded inline
-    ;; under the (now-retired) Event panel's six-domino cascade
-    ;; (rf2-5gl5r); the public `mount-managed-fx!` aggregator entry on
-    ;; `panels.cljs` is the remaining surface. No L3 tab.
+    ;; `:rf.xray/focus-event` cross-link event. The public
+    ;; `mount-managed-fx!` aggregator entry on `panels.cljs` is its
+    ;; mount surface. No L3 tab.
     (managed-fx-subs/install!)
-    ;; Routing tab (rf2-nrbs9, narrowed per rf2-o5f5f.3) — Dynamic L3
+    ;; Routing tab — Dynamic L3
     ;; tab carrying the focused-event lens (FROM/TO chips when the
     ;; focused event triggered navigation). Installs the registered-
     ;; routes / current-route-slice / routing-tab-data subs +
@@ -967,7 +935,7 @@
     ;; resources artefact (Xray does not :require it; bundle isolation).
     ;; Read-only: no `:rf.resource/*` dispatch (observing pins nothing).
     (resources/install!)
-    ;; Derivation-Graph tab (EP-0014 prop-3, rf2-9ett2d) — Dynamic L3 tab:
+    ;; Derivation-Graph tab (EP-0014 prop-3) — Dynamic L3 tab:
     ;; the UNIFIED derivation/process graph composed by
     ;; `re-frame.derivation.graph` across the five algebra-view families.
     ;; Xray is the EP's NAMED FIRST CONSUMER of the structured graph
@@ -979,13 +947,13 @@
     ;; redaction is `derivation-graph-helpers/redact-graph-for-egress`.
     ;; Read-only: assembling the graph pins nothing, dispatches nothing.
     (derivation-graph/install!)
-    ;; Module-view tab (rf2-32siq3.12) — Dynamic L4 tab: the EP-0023
+    ;; Module-view tab — Dynamic L4 tab: the EP-0023
     ;; `image -> frame -> event stream` public model — every live image-loaded
     ;; frame as an execution context carrying its resolved image's [kind id]
     ;; descriptors. Read-only: enumerating live frames + reading sealed
     ;; generations pins nothing, dispatches nothing.
     (module-view/install!)
-    ;; Static Routes panel (rf2-o5f5f.3) — Static-surface browse +
+    ;; Static Routes panel — Static-surface browse +
     ;; Simulate-URL + per-row inline expand + hermetic Simulate-
     ;; navigation preview. Installs the UI-state slots under
     ;; `:rf.xray.static.routes/*` + the `:rf.xray.static.routes/
@@ -993,7 +961,7 @@
     ;; registered above) — order is cosmetic since re-frame resolves
     ;; `:<-` chains lazily.
     (static-routes-panel/install!)
-    ;; Static Schemas sub-tab (rf2-o5f5f.4) — browse every registered
+    ;; Static Schemas sub-tab — browse every registered
     ;; Malli schema across app-db slots + events + subs. Reads the
     ;; public `re-frame.schemas` façade (`rf/frame-ids` +
     ;; `app-schemas` + `app-schema-meta-at`) + `(rf/registrations
@@ -1001,7 +969,7 @@
     ;; chip dispatches `:rf.xray/open-in-editor` (open-in-editor
     ;; installed above).
     (static-schemas-panel/install!)
-    ;; Static Flows sub-tab (rf2-uhsqb) — browse every flow registered
+    ;; Static Flows sub-tab — browse every flow registered
     ;; via `re-frame.flows/reg-flow`. Reads the public
     ;; `(rf/registrations :flow)` surface, regrouping the flat
     ;; `{flow-id meta}` shape by each entry's stamped `:frame`. Flows
@@ -1010,24 +978,17 @@
     (static-flows-panel/install!)
     (reactive-panel/install!)
     (trace/install!)
-    ;; (rf2-4v67l — Mike-direction) The Xray Chrome A11y dogfood panel
-    ;; was removed in favour of Story's already-shipped chrome-a11y
-    ;; panel (rf2-18t6p · `tools/story/src/re_frame/story/ui/
-    ;; chrome_a11y.cljs`) + Story's variant a11y scanner (rf2-qgms1 ·
-    ;; `tools/story/src/re_frame/story/ui/a11y.cljs`). A11y dogfooding
-    ;; is Story's domain; a duplicate Xray panel was noise that flagged
-    ;; the Xray events-list as a problem.
-    ;; (rf2-b2fif — Mike-direction) The Static Events + Views sub-tabs
-    ;; were removed — info is in the source code, the tabs were not
-    ;; pulling their weight. Remaining Static sub-tabs: Flows ·
-    ;; Interceptors · Routes · Schemas (+ the densest Machines tab as
-    ;; the landing target).
-    ;; Static Interceptors sub-tab (rf2-o5f5f.6) — pure-browse lens
+    ;; A11y dogfooding is Story's domain — Story ships the chrome-a11y
+    ;; panel (`tools/story/src/re_frame/story/ui/chrome_a11y.cljs`) +
+    ;; the variant a11y scanner (`tools/story/src/re_frame/story/ui/
+    ;; a11y.cljs`), so Xray carries no a11y panel of its own.
+    ;; Static sub-tabs: Flows · Interceptors · Routes · Schemas (+ the
+    ;; densest Machines tab as the landing target).
+    ;; Static Interceptors sub-tab — pure-browse lens
     ;; over every interceptor surfaced through the registered event
     ;; chains. Collapses by `:id` so each interceptor appears once
     ;; with a chain-count. No simulate — interceptors are composition
-    ;; primitives; simulate fires through the handler-level simulate
-    ;; in the Events sub-tab.
+    ;; primitives, not independently simulable.
     (static-interceptors-panel/install!))
   nil)
 

--- a/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
@@ -1,7 +1,7 @@
 (ns day8.re-frame2-xray.settings.editor-hint
-  "Open-in-editor 'pick an editor in Settings' hint toast (rf2-4s08ov).
+  "Open-in-editor 'pick an editor in Settings' hint toast.
 
-  ## The problem (rf2-ffijtp finding)
+  ## The problem
 
   Xray's 'Open in editor' chip resolves a source-coord to an editor
   URI (`vscode://…` by default) and fires `Location.assign`. When the
@@ -13,9 +13,8 @@
   nothing happens. JS cannot observe the OS-level handler miss, so the
   developer gets no feedback at all.
 
-  rf2-ffijtp documented the fix (host apps must set `:rf.xray/editor`);
-  rf2-4s08ov surfaces it at click-time so the chip itself guides the
-  developer.
+  The fix is for host apps to set `:rf.xray/editor`; this toast
+  surfaces that at click-time so the chip itself guides the developer.
 
   ## The hint
 
@@ -26,9 +25,10 @@
   appears in the bottom-right of the shell with a one-line note and an
   'Open Settings' button that lands the operator on the General tab's
   editor picker. Once an editor IS configured (host or operator), the
-  click resolves and navigates exactly as before — the hint never fires.
+  click resolves and navigates to the configured editor — the hint
+  never fires.
 
-  Conservative by design (per the bead): a small, non-intrusive
+  Conservative by design: a small, non-intrusive
   bottom-corner toast, NOT a redesign of Settings and NOT a modal that
   blocks the chrome. It is dismissable (✕) and self-dismisses the moment
   the operator opens Settings.
@@ -126,11 +126,11 @@
 
 (defn toast-view
   "Hiccup for the open editor-hint toast. The caller (`Toast`) gates
-  the mount on `:rf.xray/editor-hint-open?`. `dispatch` (rf2-nesy9) is
+  the mount on `:rf.xray/editor-hint-open?`. `dispatch` is
   the frame-aware dispatcher injected by the `reg-view` body so the
   deferred `:on-click` handlers land on the surrounding instance frame."
   [dispatch]
-  ;; rf2-wpvy6f — the PRIMARY, reachable Esc-dismissal path is the
+  ;; The PRIMARY, reachable Esc-dismissal path is the
   ;; shell-level global keydown listener (`keybinding/handle-keydown`),
   ;; which dismisses the hint whenever it is open regardless of where
   ;; focus sits. This toast is a non-modal `role=status` surface and
@@ -183,10 +183,10 @@
   `:rf.xray/editor-hint-open?` is true; closed-state is a single
   subscribe + a `when` — cheap.
 
-  Per rf2-in6l2 `reg-view`-registered so the body's subscribes route
-  through the React-context tier to `:rf/xray`. rf2-nesy9 — the
-  reg-view-injected `dispatch` is threaded into `toast-view` so the
-  deferred `:on-click` handlers land on the surrounding instance frame."
+  `reg-view`-registered so the body's subscribes route through the
+  React-context tier to `:rf/xray`. The reg-view-injected `dispatch`
+  is threaded into `toast-view` so the deferred `:on-click` handlers
+  land on the surrounding instance frame."
   []
   (when @(rf/subscribe [:rf.xray/editor-hint-open?])
     (toast-view dispatch)))

--- a/tools/xray/src/day8/re_frame2_xray/settings/popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/popup.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.settings.popup
-  "Settings popup modal facade (rf2-9poxq).
+  "Settings popup modal facade.
 
   Per `tools/xray/spec/018-Event-Spine.md` §9 Settings popup the
   modal is a transient overlay rather than a sidebar panel: open,
@@ -8,7 +8,7 @@
   `:rf.xray/settings-open?` is false; closed-state cost is one
   subscribe + a `when`.
 
-  ## Sections (rf2-9poxq + rf2-jh9ws + rf2-ttnst + rf2-ou3pn + rf2-wknb3)
+  ## Sections
 
   Four inner tabs:
   General | Keybindings | Buffer | Diff. The top tab strip drives
@@ -17,31 +17,18 @@
   dialog's `on-key-down`, gated against the editable-target case so
   numeric inputs are not interrupted.
 
-  The Theme tab was retired (rf2-ou3pn) — the ribbon's sun/moon icon
-  is now the canonical light/dark affordance. The `:use-system-colors?`
-  HCM-override checkbox moved to General → Power user.
+  Light/dark is driven by the ribbon's sun/moon icon (the canonical
+  affordance). The `:use-system-colors?` HCM-override checkbox lives
+  under General → Power user.
 
-  The Filters tab was retired (rf2-wknb3) — full filter management
-  lives in the top-ribbon pill strip (`filters/pills.cljs`), the
-  per-pill edit popup (`filters/edit_popup.cljs`), and the mute
-  manager modal (rf2-ikuwt). The settings tab's only widget was a
-  dead-chrome 'Open auto-filter UI' button dispatching an
-  unregistered event.
+  Filter management lives in the top-ribbon pill strip
+  (`filters/pills.cljs`), the per-pill edit popup
+  (`filters/edit_popup.cljs`), and the mute manager modal.
 
-  Keybindings (rf2-ttnst) v1 is READ-ONLY — a chord catalogue plus
-  the master `:rf.xray/keybinding-enabled?` toggle. Rebind UI is the
-  v1.1 follow-on. Buffer (rf2-ttnst) carries the depth tunables plus
-  a destructive `Clear buffer now` affordance with a nested confirm
-  modal.
-
-  Dropped vs. the earlier spec catalogue (per Mike 2026-05-19
-  §0ter.4 walkthrough): Actions tab + factory-reset BIG RED BUTTON,
-  density Comfy tier, per-tab default expansion knob, accent
-  user swap, sub-output diff layout toggle, section-grouping
-  threshold, Popout as its own tab. The Telemetry tab was removed
-  earlier (rf2-jh9ws) — Xray ships no telemetry endpoint and the
-  v1 toggle was a broken affordance; per the text audit (rf2-yn86j)
-  the chrome must not pretend.
+  Keybindings is READ-ONLY — a chord catalogue plus the master
+  `:rf.xray/keybinding-enabled?` toggle. Buffer carries the depth
+  tunables plus a destructive `Clear buffer now` affordance with a
+  nested confirm modal.
 
   ## Modal layer
 
@@ -69,13 +56,13 @@
   `:rf.xray/settings-open?` is true; closed-state is a single
   subscribe + a `when` — cheap.
 
-  Per rf2-in6l2 `reg-view`-registered so the body's subscribes
-  route through the React-context tier to `:rf/xray`.
+  `reg-view`-registered so the body's subscribes route through the
+  React-context tier to `:rf/xray`.
 
-  rf2-nesy9 — the reg-view-injected `dispatch` (the frame-aware
-  dispatcher captured at render time) is threaded into `popup-view`
-  so every deferred `:on-*` handler in the popup tree lands on the
-  surrounding instance frame, not a `{:frame :rf/xray}` literal."
+  The reg-view-injected `dispatch` (the frame-aware dispatcher
+  captured at render time) is threaded into `popup-view` so every
+  deferred `:on-*` handler in the popup tree lands on the surrounding
+  instance frame, not a `{:frame :rf/xray}` literal."
   []
   (when @(rf/subscribe [:rf.xray/settings-open?])
     (view/popup-view dispatch)))

--- a/tools/xray/src/day8/re_frame2_xray/settings/subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/subs.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.settings.subs
-  "Subscriptions for the Xray Settings popup modal (rf2-9poxq).
+  "Subscriptions for the Xray Settings popup modal.
 
   ## Sub tree
 
@@ -31,7 +31,7 @@
     (fn [db _query]
       (or (get db :settings-active-tab) :general)))
 
-  ;; rf2-ttnst — Buffer tab nested clear-confirm modal open state.
+  ;; Buffer tab nested clear-confirm modal open state.
   (rf/reg-sub :rf.xray/settings-clear-confirm-open?
     (fn [db _query]
       (boolean (get db :settings-clear-confirm-open? false))))
@@ -53,7 +53,7 @@
     (fn [db _query]
       (or (get db :settings) (config/get-settings))))
 
-  ;; rf2-i39w2 Phase 3 — convenience sub for the diff opts map the
+  ;; Convenience sub for the diff opts map the
   ;; hiccup-diff engine consumes via `classify-prop`. Reads the
   ;; `:diff` slot of the settings map (in app-db when seeded, the
   ;; atom otherwise) and reshapes to the engine's opts vocabulary.
@@ -67,7 +67,7 @@
         {:highlight-fn-ref-changes? (boolean
                                       (:highlight-fn-ref-changes? diff))})))
 
-  ;; rf2-dudqz — host editor default (the `editor` atom set by
+  ;; Host editor default (the `editor` atom set by
   ;; `set-editor!` / `(xray-config/configure! {:rf.xray/editor …})`).
   ;; Read by the Settings popup's editor-override picker so the
   ;; "Project default: <name>" hint shows what flipping back to the
@@ -78,11 +78,12 @@
     (fn [_db _query]
       (config/get-host-editor-default)))
 
-  ;; rf2-ttnst — convenience sub for the density knob. Reads
+  ;; Convenience sub for the density knob. Reads
   ;; `:general :density` (`:cosy` or `:compact`). Views detail rows
   ;; + App-db diff rows branch padding/line-height off this value.
-  ;; The Comfy tier is intentionally absent (Mike 2026-05-19); a
-  ;; persisted `:comfy` (from a prior schema) is treated as `:cosy`.
+  ;; The density tiers are exactly `:cosy` and `:compact`; any
+  ;; unrecognised value (e.g. a persisted `:comfy`) is treated as
+  ;; `:cosy`.
   (rf/reg-sub :rf.xray/density
     (fn [db _query]
       (let [d (or (get-in db [:settings :general :density])

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.static.flows.panel
-  "Top-level Flows sub-tab for Xray's Static surface (rf2-uhsqb).
+  "Top-level Flows sub-tab for Xray's Static surface.
 
   ## Browse-all verb
 
@@ -80,10 +80,10 @@
 
   An entry whose `:frame` slot is absent (defensive — every flow
   registration stamps `:frame`) buckets under the distinct
-  `:rf.xray/no-frame-stamp` sentinel. EP-0002 (rf2-bd4div) — a missing
-  frame stamp is NOT bucketed under `:rf/default` (now an ordinary id
-  that a real flow may legitimately register in): conflating the two
-  would mis-attribute a stamp-less registration to a real frame's group.
+  `:rf.xray/no-frame-stamp` sentinel. Per EP-0002, a missing frame
+  stamp is NOT bucketed under `:rf/default` (an ordinary id that a real
+  flow may legitimately register in): conflating the two would
+  mis-attribute a stamp-less registration to a real frame's group.
   Pure data — JVM-runnable."
   [registrations]
   (reduce-kv
@@ -152,8 +152,8 @@
 
 (defn- header
   []
-  ;; rf2-6xezz — Mike-direction 2026-05-21: panel-name heading scrubbed.
-  ;; The L4 tab strip is the panel-name source-of-truth.
+  ;; The header carries no panel-name heading — the L4 tab strip is the
+  ;; panel-name source-of-truth.
   [:div {:data-testid "rf-xray-static-flows-header"
          :style       {:padding "4px 16px"}}])
 
@@ -161,10 +161,10 @@
 
 (defn- search-box
   [query total filtered?]
-  ;; rf2-nesy9 — render-time frame capture so the deferred search input
-  ;; dispatches into the surrounding instance frame (rendered inside the
-  ;; flows Panel reg-view), not a `:rf/xray` literal. rf2-1keg3 — the
-  ;; flex-row markup lives in the shared `search-box` component.
+  ;; Render-time frame capture so the deferred search input dispatches
+  ;; into the surrounding instance frame (rendered inside the flows Panel
+  ;; reg-view), not a `:rf/xray` literal. The flex-row markup lives in
+  ;; the shared `search-box` component.
   (let [frame (rf/current-frame-id)]
     [search-box/search-box
      {:testid-prefix   "rf-xray-static-flows"
@@ -180,11 +180,11 @@
 
 (defn- flow-row
   [{:keys [flow-id frame inputs output-path doc] :as _row}]
-  ;; rf2-mq8wk — list semantics. Flow rows are non-interactive (no
-  ;; row-level dispatch), so `role=listitem` is the right shape — they
-  ;; are catalogue entries, not buttons. The interactive Static surface
-  ;; that earns keyboard activation is the Routes list (whose rows
-  ;; toggle an expand surface — see static/routes/browse_list.cljs).
+  ;; List semantics. Flow rows are non-interactive (no row-level
+  ;; dispatch), so `role=listitem` is the right shape — they are
+  ;; catalogue entries, not buttons. The interactive Static surface that
+  ;; earns keyboard activation is the Routes list (whose rows toggle an
+  ;; expand surface — see static/routes/browse_list.cljs).
   [:li {:data-testid (str "rf-xray-static-flows-row-"
                           (subs (pr-str flow-id) 1))
         :role        "listitem"
@@ -209,14 +209,14 @@
             :style {:color     (:text-tertiary tokens)
                     :font-size "10px"}}
      (pr-str frame)]]
-   ;; rf2-2kwhw — input + output path values render through the shared
-   ;; cljs-devtools EDN widget (spec 007:119 — "all values rendered via
-   ;; the cljs-devtools-shaped renderer") rather than raw `pr-str` +
+   ;; Input + output path values render through the shared cljs-devtools
+   ;; EDN widget (spec 007:119 — "all values rendered via the
+   ;; cljs-devtools-shaped renderer") rather than raw `pr-str` +
    ;; `[:code]`. `edn/inspect` is the canonical L4 renderer (same call
    ;; the App-DB segment-inspector uses); each value gets a stable
    ;; per-flow `node-key` so the widget's per-node expand state + copy
-   ;; affordance (rf2-f026h) ride the same way they do in the App-DB /
-   ;; Trace / Event surfaces.
+   ;; affordance ride the same way they do in the App-DB / Trace / Event
+   ;; surfaces.
    (let [flow-key (subs (pr-str flow-id) 1)]
      [:div {:style {:margin-left  "12px"
                     :color        (:text-secondary tokens)
@@ -252,8 +252,7 @@
   composite + the search-query slot and composes the header + search +
   flat list.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
+  `reg-view`-registered so subscribes resolve to `:rf/xray`."
   []
   (let [data @(rf/subscribe [:rf.xray.static.flows/tab-data])
         {:keys [silent? flows total filtered? query]} data]
@@ -293,7 +292,7 @@
 ;;
 ;; The raw value the production data sub reads. Shared with the
 ;; test-override seam (`install-test-overrides!` below) so the override
-;; branch lives in ONE place (the seam), not duplicated (rf2-e8330v).
+;; branch lives in ONE place (the seam), not duplicated.
 
 (defn- registered-flows-value
   "The registered flows regrouped into the per-frame
@@ -346,7 +345,7 @@
   ;; The test-only override seam (`:rf.xray.static.flows/set-registered-
   ;; flows-override-for-test` + the `*-override` sub) is NOT installed
   ;; here — production registration carries no `-for-test` ids. Tests opt
-  ;; into it via `install-test-overrides!` (rf2-e8330v / xxo3zz F3).
+  ;; into it via `install-test-overrides!`.
 
   ;; ---- production data sub ---------------------------------------------
 
@@ -377,17 +376,15 @@
     (fn [[registry-snapshot observed-frame query] _query]
       (project-data registry-snapshot observed-frame query)))
 
-  ;; rf2-2moh1 — register the Static Flows tab with the internal L4
-  ;; tab registry. Contiguous order: machines 0 · routes 1 · schemas 2
-  ;; · flows 3 · interceptors 4 (the standalone :views / :events tabs
-  ;; rf2-b2fif removed previously left orders 3 + 5 as gaps).
-  ;; rf2-l1ru8 — mnemonic is "f" (first-letter-of-label, the Static-mode
-  ;; convention: Machines→m, Routes→r, Interceptors→i). "f" is free in the
-  ;; Static mnemonic set (Schemas uses "c" because "s" is the Settings
-  ;; key; Flows has no such collision), and the Static shell's own
-  ;; canonical IA listing (`static/shell.cljs` "Flows (f)") documents "f"
-  ;; as the intended binding. The prior "l" was an off-convention impl
-  ;; value that disagreed with both the shell docstring and the skill.
+  ;; Register the Static Flows tab with the internal L4 tab registry.
+  ;; Contiguous order: machines 0 · routes 1 · schemas 2 · flows 3 ·
+  ;; interceptors 4.
+  ;; Mnemonic is "f" (first-letter-of-label, the Static-mode convention:
+  ;; Machines→m, Routes→r, Interceptors→i). "f" is free in the Static
+  ;; mnemonic set (Schemas uses "c" because "s" is the Settings key;
+  ;; Flows has no such collision), and the Static shell's own canonical
+  ;; IA listing (`static/shell.cljs` "Flows (f)") documents "f" as the
+  ;; intended binding.
   (panel-registry/reg-l4-tab!
     {:id    :flows
      :label "Flows"
@@ -398,7 +395,7 @@
 
   nil)
 
-;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+;; ---- test-only override seam --------------------------------------------
 
 (defn install-test-overrides!
   "Install the Static Flows panel's test-only override seam — the

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.static.interceptors.panel
-  "Top-level Interceptors sub-tab for Xray's Static surface (rf2-o5f5f.6).
+  "Top-level Interceptors sub-tab for Xray's Static surface.
 
   ## Pure-browse verb
 
@@ -10,7 +10,7 @@
 
     - an INLINE interceptor VALUE — a map carrying `:id`, optional
       `:before`/`:after` fns, and the framework `:rf/default?` marker for
-      auto-wrappers (rf2-twt7m); the additive-window legacy shape.
+      auto-wrappers.
     - a REFERENCE into the `:interceptor` registrar — a bare keyword id
       (`:my/logging`) or a parameterized `[id arg]` 2-vector
       (`[:rf.interceptor/path [:cart]]`). The runtime resolves refs to
@@ -100,8 +100,8 @@
   nil); inline values do not call it."
   [entry resolve-ref-fn]
   (cond
-    ;; INLINE interceptor value — the additive-window legacy shape. Checked
-    ;; FIRST: an inline value is a map, never a keyword or [id arg] vector.
+    ;; INLINE interceptor value — a map. Checked FIRST: an inline value
+    ;; is a map, never a keyword or [id arg] vector.
     (icpt-reg/interceptor-value? entry)
     {:id       (or (:id entry) ::unnamed)
      :ref?     false
@@ -210,7 +210,7 @@
 
 (defn- header
   []
-  ;; rf2-6xezz — Mike-direction 2026-05-21: panel-name heading scrubbed.
+  ;; Spacer only — the panel carries no name heading.
   [:div {:data-testid "rf-xray-static-interceptors-header"
          :style       {:padding "4px 16px"}}])
 
@@ -218,9 +218,9 @@
 
 (defn- search-box
   [query total filtered?]
-  ;; rf2-nesy9 — render-time frame capture (rendered inside the
-  ;; interceptors Panel reg-view), not a `:rf/xray` literal. rf2-1keg3 —
-  ;; the flex-row markup lives in the shared `search-box` component.
+  ;; Render-time frame capture (rendered inside the interceptors Panel
+  ;; reg-view), not a `:rf/xray` literal. The flex-row markup lives in
+  ;; the shared `search-box` component.
   (let [frame (rf/current-frame-id)]
     [search-box/search-box
      {:testid-prefix   "rf-xray-static-interceptors"
@@ -242,9 +242,9 @@
         row-id  (if (and (> (count id-text) 0) (= \: (first id-text)))
                   (subs id-text 1)
                   id-text)]
-    ;; rf2-mq8wk — list semantics. Interceptor rows are non-interactive
-    ;; catalogue entries (no row-level dispatch), so `role=listitem` is
-    ;; the right shape rather than `role=button`.
+    ;; List semantics. Interceptor rows are non-interactive catalogue
+    ;; entries (no row-level dispatch), so `role=listitem` is the right
+    ;; shape rather than `role=button`.
     [:li {:data-testid (str "rf-xray-static-interceptors-row-" row-id)
           :role        "listitem"
           :style       {:display       "block"
@@ -337,8 +337,7 @@
   "Static Interceptors panel root view. Subscribes to the
   interceptors composite + search slot.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
+  `reg-view`-registered so subscribes resolve to `:rf/xray`."
   []
   (let [data @(rf/subscribe [:rf.xray.static.interceptors/tab-data])
         {:keys [silent? interceptors total filtered? query]} data]
@@ -378,7 +377,7 @@
 ;;
 ;; The raw value the production data sub reads. Shared with the
 ;; test-override seam (`install-test-overrides!` below) so the override
-;; branch lives in ONE place (the seam), not duplicated (rf2-e8330v).
+;; branch lives in ONE place (the seam), not duplicated.
 
 (defn- registry-value
   "The event-chain registry off the HOST app's `:event` registrar — each entry
@@ -426,7 +425,7 @@
   ;; The test-only override seam (`:rf.xray.static.interceptors/set-
   ;; registry-override-for-test` + the `*-override` sub) is NOT installed
   ;; here — production registration carries no `-for-test` ids. Tests opt
-  ;; into it via `install-test-overrides!` (rf2-e8330v / xxo3zz F3).
+  ;; into it via `install-test-overrides!`.
 
   ;; ---- production data sub ---------------------------------------------
 
@@ -443,7 +442,7 @@
     (fn [[registrations-map query] _query]
       (project-data registrations-map query)))
 
-  ;; rf2-2moh1 — register the Static Interceptors tab. Contiguous order:
+  ;; Register the Static Interceptors tab. Contiguous order:
   ;; machines 0 · routes 1 · schemas 2 · flows 3 · interceptors 4.
   (panel-registry/reg-l4-tab!
     {:id    :interceptors
@@ -455,7 +454,7 @@
 
   nil)
 
-;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+;; ---- test-only override seam --------------------------------------------
 
 (defn install-test-overrides!
   "Install the Static Interceptors panel's test-only override seam — the

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-xray.static.machines.browse-list
-  "Browse-all list — L4-left pane of the Static Machines sub-tab
-  (rf2-o5f5f.2).
+  "Browse-all list — L4-left pane of the Static Machines sub-tab.
 
   ## What it renders
 
@@ -9,8 +8,7 @@
 
     - selection glyph (◉ active / ○ inactive — same vocabulary as
       the Static tab-bar's `tab-button`)
-    - machine-id in mono accent-violet (per the bead's §Browse-all
-      list)
+    - machine-id in mono accent-violet
     - source-coord chip (renders the file:line label; jump-to-source
       via `:rf.xray/open-in-editor`)
     - state-count chip (mono · tertiary)
@@ -35,20 +33,20 @@
   "Top-of-list search input. Incremental filtering — every keystroke
   dispatches `:rf.xray.static.machines/set-search`. Esc clears.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher threaded from the
+  `dispatch` is the frame-aware dispatcher threaded from the
   `browse-list` reg-view (a plain fn invoked as a Reagent component
   renders in its own cycle, so it cannot recover the frame itself).
 
   `query` is the current search string, threaded from the `browse-list`
-  reg-view's own subscribe (rf2-wxu4l3) — this helper is a plain fn
-  invoked as a Reagent component, so it renders in its OWN cycle and
-  CANNOT recover the `:rf/xray` frame to `rf/subscribe` itself (Spec 004
-  §Plain Reagent fns do not pick up the surrounding frame; a bare
-  `subscribe` here throws `:rf.error/no-frame-context` and crashes the
-  whole Static surface). The reg-view body already derefs the same
+  reg-view's own subscribe — this helper is a plain fn invoked as a
+  Reagent component, so it renders in its OWN cycle and CANNOT recover
+  the `:rf/xray` frame to `rf/subscribe` itself (Spec 004 §Plain Reagent
+  fns do not pick up the surrounding frame; a bare `subscribe` here
+  throws `:rf.error/no-frame-context` and crashes the whole Static
+  surface). The reg-view body already derefs the same
   `:rf.xray.static.machines/search` sub — pass that value down.
-  rf2-1keg3 — the markup lives in the shared `search-box` component's
-  `:pane` variant."
+  The markup lives in the shared `search-box` component's `:pane`
+  variant."
   [dispatch query]
   [search-box/search-box
    {:variant          :pane
@@ -68,8 +66,8 @@
   describing.
 
   `sort-key` is the current sort axis, threaded from the `browse-list`
-  reg-view's own subscribe (rf2-wxu4l3) — this helper is a plain fn
-  invoked as a Reagent component, so it renders in its OWN cycle and
+  reg-view's own subscribe — this helper is a plain fn invoked as a
+  Reagent component, so it renders in its OWN cycle and
   CANNOT recover the `:rf/xray` frame to `rf/subscribe` itself (Spec 004
   §Plain Reagent fns do not pick up the surrounding frame; a bare
   `subscribe` here throws `:rf.error/no-frame-context` and crashes the
@@ -99,7 +97,7 @@
 
 (defn- source-coord-chip
   "Render the source-coord chip for a row. Degrades to nil when the
-  coord is missing (silent — rf2-g3ghh)."
+  coord is missing (silent)."
   [source-coord]
   (when (some? source-coord)
     [:span {:data-testid "rf-xray-static-machines-row-source-coord"
@@ -127,7 +125,7 @@
 (defn- pip-cluster
   "Live-instance pip cluster per `helpers/pip-render-plan`. Renders
   filled cyan dots up to the cap, then a textual `>N live` form
-  beyond. Silent for zero (per rf2-g3ghh)."
+  beyond. Silent for zero."
   [live-count]
   (let [{:keys [kind count]} (h/pip-render-plan live-count)]
     (case kind
@@ -163,7 +161,7 @@
   tab with this machine selected — same handler the right-pane
   Instances pill uses (centralised in `instances_jump`).
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher threaded from the
+  `dispatch` is the frame-aware dispatcher threaded from the
   `browse-list` reg-view (via `row`)."
   [dispatch machine-id]
    [:button
@@ -189,7 +187,7 @@
 ;; ---- one row ------------------------------------------------------------
 
 (defn- row
-  "Render one browse-list row. `dispatch` (rf2-nesy9) is threaded from
+  "Render one browse-list row. `dispatch` is threaded from
   the `browse-list` reg-view."
   [dispatch {:keys [machine-id state-count live-count source-coord] :as r} active?]
   (let [glyph (if active? "◉" "○")]
@@ -270,14 +268,14 @@
 
 (rf/reg-view browse-list
   "L4-left pane of the Static Machines sub-tab — search + sort +
-  scrollable rows. Per rf2-in6l2 `reg-view`-registered so subscribes
-  resolve to `:rf/xray`."
+  scrollable rows. `reg-view`-registered so subscribes resolve to
+  `:rf/xray`."
   []
   (let [{:keys [rows total visible selected-id]}
         @(rf/subscribe [:rf.xray.static.machines/data])
         query    @(rf/subscribe [:rf.xray.static.machines/search])
-        ;; rf2-wxu4l3 — deref the sort axis HERE (in the reg-view body, where
-        ;; the `:rf/xray` frame is in context) and thread it into the plain-fn
+        ;; Deref the sort axis HERE (in the reg-view body, where the
+        ;; `:rf/xray` frame is in context) and thread it into the plain-fn
         ;; `sort-button` helper, which renders in its own cycle and cannot
         ;; recover the frame to subscribe itself.
         sort-key @(rf/subscribe [:rf.xray.static.machines/sort-key])]

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/cascade_dimmed.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/cascade_dimmed.cljs
@@ -1,18 +1,17 @@
 (ns day8.re-frame2-xray.static.machines.cascade-dimmed
-  "Cascade pill — DIMMED in the Static surface (rf2-o5f5f.2).
+  "Cascade pill — DIMMED in the Static surface.
 
-  Per the bead's §Cascade mode + findings Q7: the Cancellation Cascade
-  is a Dynamic-only surface (it composes against the trace ring buffer
-  which is event-coupled — there is no spine in Static mode). The pill
-  is rendered in the strip for muscle-memory consistency with the
-  Dynamic sub-strip (same DOM, same letter mnemonic), but it's GREYED
-  and the click is a no-op. A tooltip surfaces the why."
+  The Cancellation Cascade is a Dynamic-only surface (it composes
+  against the trace ring buffer which is event-coupled — there is no
+  spine in Static mode). The pill is rendered in the strip for
+  muscle-memory consistency with the Dynamic sub-strip (same DOM, same
+  letter mnemonic), but it's GREYED and the click is a no-op. A tooltip
+  surfaces the why."
   (:require [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack type-scale]]))
 
 (def tooltip-text
-  "Per the bead — surfaced as the pill's `title` AND its
-  `aria-disabled` description."
+  "Surfaced as the pill's `title` AND its `aria-disabled` description."
   "Cancellation cascade is a Dynamic-only surface. Switch to Dynamic mode to view.")
 
 (defn pill

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
@@ -1,33 +1,32 @@
 (ns day8.re-frame2-xray.static.machines.definition-detail
   "Right pane of the Static Machines sub-tab — header + 4-mode sub-strip
-  + per-mode body (rf2-o5f5f.2).
+  + per-mode body.
 
   ## Header
 
-  Per the bead's §Definition detail header:
+  The header reads:
 
       <machine-id> · <source-coord ↗> · <N> states · <M> live (→ Dynamic)
 
   ## 4-mode sub-strip
 
-  Per the bead's §4-mode sub-strip:
+  The sub-strip exposes:
 
       [Topology][Sim][Instances][Cascade]
 
   Topology is the default; Sim renders the hermetic 'what-if'
-  simulator (rf2-r4nao rehost — engine originally rf2-v869p);
-  Instances is a JUMP to the Dynamic Machines tab (`instances_jump`);
+  simulator; Instances is a JUMP to the Dynamic Machines tab
+  (`instances_jump`);
   Cascade is GREYED with a 'Dynamic-only' tooltip. Mnemonics
-  `t`/`s`/`i`/`c` are surfaced in each pill's `title` — the keybinding
-  wiring is follow-on per the bead.
+  `t`/`s`/`i`/`c` are surfaced in each pill's `title`. TODO: wire the
+  keybindings that act on those mnemonics.
 
   ## Per-mode body
 
   Topology mounts the `chart/svg` SVG renderer (no live highlight —
-  Static is event-INDEPENDENT). Sim mounts the rehosted Sim rail
-  (rf2-r4nao). Instances doesn't render a body (the click is the
-  surface). Cascade doesn't render a body either (the pill itself is
-  the surface).
+  Static is event-INDEPENDENT). Sim mounts the Sim rail. Instances
+  doesn't render a body (the click is the surface). Cascade doesn't
+  render a body either (the pill itself is the surface).
 
   ## Empty state (no machine selected)
 
@@ -50,8 +49,8 @@
 ;; ---- header -------------------------------------------------------------
 
 (defn- header
-  "Render the definition-detail header per the bead's §Definition
-  detail header. Sticks at the top of the right pane."
+  "Render the definition-detail header. Sticks at the top of the right
+  pane."
   [{:keys [machine-id source-coord state-count live-count]}]
   [:header {:data-testid "rf-xray-static-machines-detail-header"
             :data-machine-id (str machine-id)
@@ -63,10 +62,9 @@
                     :border-bottom (str "1px solid " (:border-subtle tokens))
                     :font-family   sans-stack
                     :font-size     (:body type-scale)}}
-   ;; Per rf2-rb6js / rf2-6xezz — definition-detail title renders at
-   ;; body type-scale (not `:display`) so the focused machine-id chip
-   ;; reads as in-panel chrome rather than a top-level heading. The
-   ;; testid is preserved so existing tests still locate the element.
+   ;; Definition-detail title renders at body type-scale (not
+   ;; `:display`) so the focused machine-id chip reads as in-panel
+   ;; chrome rather than a top-level heading.
    [:div {:data-testid "rf-xray-static-machines-detail-title"
           :style (merge {:margin    0
                          :font-size (:body type-scale)
@@ -127,13 +125,12 @@
    "Topology"])
 
 (defn- sub-strip
-  "Render the 4-mode pill row. Per the bead's §4-mode sub-strip — the
-  strip is the same DOM as the Dynamic sub-strip (muscle-memory
-  consistency), but Cascade is dimmed + Sim is a placeholder.
+  "Render the 4-mode pill row. The strip is the same DOM as the Dynamic
+  sub-strip (muscle-memory consistency), but Cascade is dimmed.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher threaded from the
-  `detail` reg-view (a plain fn invoked as a Reagent component renders
-  in its own cycle, so it cannot recover the frame itself)."
+  `dispatch` is the frame-aware dispatcher threaded from the `detail`
+  reg-view (a plain fn invoked as a Reagent component renders in its own
+  cycle, so it cannot recover the frame itself)."
   [dispatch {:keys [machine-id sub-mode live-count]}]
   (let [set-mode! (fn [mode]
                     (dispatch
@@ -161,13 +158,13 @@
 (defn- body
   "Dispatch to the per-mode body renderer. Topology + Sim render a
   body; Instances + Cascade do not (Instances is a JUMP affordance,
-  Cascade is dimmed). `dispatch` (rf2-nesy9) is threaded from `detail`.
+  Cascade is dimmed). `dispatch` is threaded from `detail`.
 
-  rf2-jholrb — the Sim sub-mode's plain-fn subtree (`sim/body` →
-  `SimChart` / `SimRail`) cannot recover the `:rf/xray` frame to
-  subscribe (Spec 004), so its sub values (`sim-values`) are derefed in
-  the `detail` reg-view and threaded down through here (mirrors the
-  rf2-wxu4l3 browse-list fix)."
+  The Sim sub-mode's plain-fn subtree (`sim/body` → `SimChart` /
+  `SimRail`) cannot recover the `:rf/xray` frame to subscribe (Spec
+  004), so its sub values (`sim-values`) are derefed in the `detail`
+  reg-view and threaded down through here (mirroring the browse-list
+  pattern)."
   [dispatch {:keys [sub-mode machine-id definition source-coord fit-signal
                     sim-values]}]
   (case sub-mode
@@ -223,25 +220,24 @@
     - `:rf.xray.static.machines/sub-mode` for the per-machine sub-
       mode (defaults to :topology)
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
+  `reg-view`-registered so subscribes resolve to `:rf/xray`."
   []
   (let [{:keys [rows selected-id]}
         @(rf/subscribe [:rf.xray.static.machines/data])
         row (some #(when (= selected-id (:machine-id %)) %) rows)
         definitions @(rf/subscribe [:rf.xray/machine-definitions])
         sub-mode @(rf/subscribe [:rf.xray.static.machines/sub-mode selected-id])
-        ;; rf2-6tw7t — fit-on-entry nonce (bumped by `:rf.xray.static/
-        ;; select-tab :machines`). Threaded down to the Topology body's
+        ;; Fit-on-entry nonce (bumped by `:rf.xray.static/select-tab
+        ;; :machines`). Threaded down to the Topology body's
         ;; `machine-canvas/Chart` `:fit-signal` so entering the Static
         ;; Machines tab re-frames the topology to view.
         fit-signal @(rf/subscribe [:rf.xray/machine-tab-fit-signal])
-        ;; rf2-jholrb — the Sim sub-mode's plain-fn subtree (`sim/body` →
+        ;; The Sim sub-mode's plain-fn subtree (`sim/body` →
         ;; `SimChart` / `SimRail`) renders in its OWN React cycle and so
         ;; cannot recover the `:rf/xray` frame to `rf/subscribe` itself
         ;; (Spec 004). Deref the sim sub family HERE (in this reg-view,
         ;; where the frame IS in context) and thread the values down —
-        ;; mirroring the rf2-wxu4l3 browse-list fix. Only derefed on the
+        ;; mirroring the browse-list pattern. Only derefed on the
         ;; `:sim` sub-mode so the Topology/Instances/Cascade modes don't
         ;; subscribe to sim state. The subs short-circuit to nil when sim
         ;; isn't active for the selected machine, so this is cheap.

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/helpers.cljc
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.static.machines.helpers
-  "Pure-data helpers for the Static Machines sub-tab (rf2-o5f5f.2).
+  "Pure-data helpers for the Static Machines sub-tab.
 
   ## Why a separate `.cljc` ns
 
@@ -11,8 +11,8 @@
 
   ## What this projects
 
-  Per the bead (rf2-o5f5f.2) the browse-all list enumerates
-  `(rf/machines)` and renders one row per registered machine. Each row
+  The browse-all list enumerates `(rf/machines)` and renders one row
+  per registered machine. Each row
   carries enough data for the L4-left list AND the L4-right header to
   render without recomputing: machine-id, state-count, live-instance
   count, and the lifted source-coord (when present in the registered
@@ -20,7 +20,7 @@
 
   ## Sort axes
 
-  Three sort axes per the bead's §Browse-all list:
+  Three sort axes:
 
     - `:name`   — alphabetical by `(name machine-id)`; default.
     - `:states` — by state-count DESC.
@@ -31,15 +31,13 @@
   ## Sub-modes (the 4-mode sub-strip)
 
   Four pills: `:topology` (default) · `:sim` · `:instances` · `:cascade`.
-  Per bead's §4-mode sub-strip the Sim cell is a placeholder until
-  sibling rf2-r4nao lands the real Sim view; the Cascade pill is
-  rendered but greyed (Dynamic-only surface)."
+  The Cascade pill is rendered but greyed (Dynamic-only surface)."
   (:require [clojure.string :as str]))
 
 ;; ---- sub-mode taxonomy --------------------------------------------------
 
 (def sub-modes
-  "Four sub-modes per the bead's §4-mode sub-strip."
+  "The four sub-modes of the sub-strip."
   [:topology :sim :instances :cascade])
 
 (def sub-mode-ids
@@ -65,10 +63,9 @@
     :else        default-sub-mode))
 
 (def sub-mode-mnemonics
-  "Per-sub-mode keyboard mnemonic letter. The keybinding wiring is
-  follow-on (per the bead's §Mnemonics deferral); this map carries the
-  pure-data half so the click affordance can surface the letter in its
-  `title`."
+  "Per-sub-mode keyboard mnemonic letter. This map carries the pure-data
+  half so the click affordance can surface the letter in its `title`.
+  TODO: wire up the keybindings that act on these mnemonics."
   {:topology  "t"
    :sim       "s"
    :instances "i"
@@ -114,9 +111,8 @@
   — the chip degrades gracefully (no chip rather than a broken link).
   Pure data — JVM-runnable.
 
-  Tolerates the alternate `:source` slot some legacy registrars used —
-  same lenient policy `open_in_editor.cljs/coerce-coord` applies on
-  the dispatch surface."
+  Also accepts the alternate `:source` slot — the same lenient policy
+  `open_in_editor.cljs/coerce-coord` applies on the dispatch surface."
   [definition]
   (when (map? definition)
     (or (get definition :source-coord)
@@ -154,20 +150,18 @@
 
 (defn- state-count
   "Count of EVERY rendered state in the machine's definition — the same
-  total the Static Machines topology renderer paints (rf2-6nx8y).
+  total the Static Machines topology renderer paints.
 
   Two definition shapes (Spec 005 §Definition shape):
 
     - Compound machine — a `{:initial :states}` map. Counts every state
       across all nesting levels: top-level states PLUS every compound
-      state's recursively-nested substates. Reading only the top-level
-      `:states` keys (the pre-rf2-6nx8y body) under-counted the deep
-      machines Xray exists to inspect.
+      state's recursively-nested substates, so the deep machines Xray
+      exists to inspect are counted in full.
 
     - Parallel machine — `{:type :parallel :regions {...}}`. Sums each
-      region's own state count (recursively). The pre-rf2-6nx8y body
-      read `(:states definition)`, which is absent on a parallel root, so
-      every parallel machine displayed `0 states`.
+      region's own state count (recursively); a parallel root has no
+      top-level `:states`, so the count walks the regions instead.
 
   Mirrors the node count `panels.machines.topology/parse-definition`
   emits for the same definition, so the browse-list chip, the detail
@@ -189,16 +183,14 @@
     (count-state-map (:states definition))))
 
 (defn- live-instance-count
-  "Number of times the machine-id appears in the snapshots map. v1
-  reads ONE frame's snapshots (the panel's target-frame); per the
-  bead's §Browse-all list the cross-frame sum is the eventual surface
-  but the reactive cross-frame walker is a follow-on bead. With one
-  frame, the count is either 0 (uninitialised) or 1 (initialised) —
-  the pip cluster degrades cleanly to a single dot in the common case.
+  "Number of times the machine-id appears in the snapshots map. Reads
+  ONE frame's snapshots (the panel's target-frame). With one frame, the
+  count is either 0 (uninitialised) or 1 (initialised) — the pip cluster
+  degrades cleanly to a single dot in the common case. TODO: sum across
+  frames once a reactive cross-frame walker exists.
 
-  Pure-data here so the v1 single-frame OR a future multi-frame
-  caller can feed the same projection without changing the row
-  shape."
+  Pure-data here so a single-frame OR a future multi-frame caller can
+  feed the same projection without changing the row shape."
   [snapshots machine-id]
   (let [snap (get snapshots machine-id)]
     (if (some? snap) 1 0)))
@@ -240,7 +232,7 @@
 (defn search-text
   "Concatenate the searchable surface for a row into one lowercase
   string. Covers the machine-id's name AND namespace AND the source
-  coord's file path — per the bead's §Browse-all list. Pure data."
+  coord's file path. Pure data."
   [{:keys [machine-id source-coord]}]
   (let [name-s (when (keyword? machine-id) (name machine-id))
         ns-s   (when (keyword? machine-id) (namespace machine-id))
@@ -265,8 +257,8 @@
   (str machine-id))
 
 (defn apply-sort
-  "Sort rows by `sort-key` per the bead's §Browse-all list. Ties break
-  on name for deterministic output. Pure data."
+  "Sort rows by `sort-key`. Ties break on name for deterministic output.
+  Pure data."
   [rows sort-key]
   (let [k (normalise-sort-key sort-key)]
     (case k
@@ -308,9 +300,8 @@
 ;; ---- live-instance pip cluster ------------------------------------------
 
 (def pip-cap
-  "Maximum number of pips rendered in a row's pip cluster per the
-  bead's §Browse-all list. Anything beyond renders as a `>{cap} N live`
-  textual count."
+  "Maximum number of pips rendered in a row's pip cluster. Anything
+  beyond renders as a `>{cap} N live` textual count."
   12)
 
 (defn pip-render-plan
@@ -319,7 +310,7 @@
   Returns one of:
     {:kind :pips :count <int>}    — render N filled dots (N ≤ pip-cap)
     {:kind :count :count <int>}   — render textual `>{cap} N live`
-    {:kind :none}                 — no live instances (silent — rf2-g3ghh)
+    {:kind :none}                 — no live instances (silent)
 
   Pure data."
   [live-count]

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/instances_jump.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/instances_jump.cljs
@@ -1,16 +1,14 @@
 (ns day8.re-frame2-xray.static.machines.instances-jump
   "Instances-mode JUMP — clicking the Instances pill (or the per-row
   `→ Dynamic` chip in the browse-list) switches Xray to Dynamic mode,
-  opens the Dynamic Machines tab, and selects this machine
-  (rf2-o5f5f.2).
+  opens the Dynamic Machines tab, and selects this machine.
 
   ## Why this lives in its own ns
 
   The browse-list rows AND the right-pane sub-strip both dispatch the
   same JUMP; centralising the dispatcher means the two surfaces never
-  drift. Per the bead's §Instances mode the JUMP is a Static-side
-  affordance that hands off to the Dynamic-side Machines tab via the
-  existing events:
+  drift. The JUMP is a Static-side affordance that hands off to the
+  Dynamic-side Machines tab via the existing events:
 
     `:rf.xray/set-mode :dynamic`        — flip mode pill back
     `:rf.xray/select-tab :machines`     — surface the Dynamic Machines tab
@@ -21,9 +19,8 @@
   Dynamic panel's responsibility — the static-side JUMP just lands the
   selection; the post-collapse Dynamic Machines panel runs event-driven
   off the focused event, so the selected-machine-id slot drives the
-  Sim engine + the jump/focus landing today (per `panels/machine_inspector.
-  cljs/select-machine-id`; the share-URL surface that previously also
-  consumed the slot was removed in rf2-nugvv)."
+  Sim engine + the jump/focus landing (per `panels/machine_inspector.
+  cljs/select-machine-id`)."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.theme.tokens
@@ -31,7 +28,7 @@
 
 (defn dispatch-jump-via
   "Dispatch the three events that telegraph the JUMP through the
-  caller-supplied frame-aware `dispatch-fn` (rf2-nesy9). The chip /
+  caller-supplied frame-aware `dispatch-fn`. The chip /
   pill render inside the `browse-list` / `definition-detail` reg-views
   and thread that reg-view's injected `dispatch` in here, so the three
   events land on the SURROUNDING instance frame — not a `:rf/xray`
@@ -71,10 +68,10 @@
   count badge (when `live-count > 0`) so the user reads how many live
   instances the JUMP will land in.
 
-  Per the bead's §Instances mode the Static surface stays static —
-  this pill is a JUMP affordance, not a mode the right pane renders.
+  The Static surface stays static — this pill is a JUMP affordance,
+  not a mode the right pane renders.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher threaded from the
+  `dispatch` is the frame-aware dispatcher threaded from the
   caller's reg-view so the JUMP lands on the surrounding instance
   frame (a plain fn invoked as a Reagent component cannot recover the
   frame itself)."

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -1,10 +1,9 @@
 (ns day8.re-frame2-xray.static.machines.panel
-  "Top-level Machines sub-tab for Xray's Static surface (rf2-o5f5f.2).
+  "Top-level Machines sub-tab for Xray's Static surface.
 
   ## Shape
 
-  Master-detail layout. Per the bead's §Browse-all list / §Definition
-  detail header:
+  Master-detail layout (browse-all list · definition detail header):
 
       ┌──────────────────────┬────────────────────────────────────┐
       │ L4-left (~280px)     │  L4-right (fills)                  │
@@ -26,7 +25,7 @@
     `:rf.xray.static.machines/selected-id` — user's selection (raw slot)
     `:rf.xray.static.machines/sub-mode-by-id` — per-machine sub-mode map
     `:rf.xray.static.machines/sub-mode`    — effective sub-mode for a machine
-    `:rf.xray.static.machines/sim-by-machine`         — sim slots map (rf2-r4nao)
+    `:rf.xray.static.machines/sim-by-machine`         — sim slots map
     `:rf.xray.static.machines/sim-state`              — sim slot for selected machine
     `:rf.xray.static.machines/sim-active?`            — sim on for selected machine?
     `:rf.xray.static.machines/sim-available-transitions` — picker source
@@ -76,8 +75,7 @@
   with a browse-all list on the left and the per-machine definition
   detail on the right.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
+  `reg-view`-registered so subscribes resolve to `:rf/xray`."
   []
   [:div {:data-testid "rf-xray-static-machines-panel"
          :style {:display          "flex"
@@ -142,7 +140,7 @@
   ;; machine-snapshots subs registered by panels.machine-inspector
   ;; (install order is purely cosmetic — re-frame resolves :<- lazily).
   ;; The `:rf.xray/machine-snapshots-override` test-seam composes on top
-  ;; of the live snapshots in `install-test-overrides!` (rf2-e8330v) —
+  ;; of the live snapshots in `install-test-overrides!` —
   ;; production registration carries no override branch.
   (rf/reg-sub :rf.xray.static.machines/rows
     :<- [:rf.xray/registered-machines]
@@ -237,15 +235,13 @@
   (install-subs!)
   (install-events!)
   (persistence/install-fx!)
-  ;; Sim sub-mode engine (rf2-r4nao rehost; originally rf2-v869p
-  ;; Phase 2). Installs the `:rf.xray.static.machines/sim-*` event +
-  ;; sub family the Sim rail consumes.
+  ;; Sim sub-mode engine. Installs the `:rf.xray.static.machines/sim-*`
+  ;; event + sub family the Sim rail consumes.
   (sim/install!)
   ;; Hydrate from localStorage. The persistence ns guards storage
   ;; availability internally so the JVM test path is a no-op.
   (persistence/hydrate!)
-  ;; rf2-2moh1 — register the Static Machines tab with the internal L4
-  ;; tab registry.
+  ;; Register the Static Machines tab with the internal L4 tab registry.
   (panel-registry/reg-l4-tab!
     {:id    :machines
      :label "Machines"
@@ -255,7 +251,7 @@
      :panel panel})
   nil)
 
-;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+;; ---- test-only override seam --------------------------------------------
 
 (defn install-test-overrides!
   "Re-register the Static Machines browse-list subs to layer the

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/persistence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/persistence.cljs
@@ -1,6 +1,6 @@
 (ns day8.re-frame2-xray.static.machines.persistence
   "localStorage round-trip for the Static Machines sub-tab's selection
-  + per-machine sub-mode (rf2-o5f5f.2).
+  + per-machine sub-mode.
 
   Two slots ride localStorage so the user's choices survive reloads:
 
@@ -21,9 +21,8 @@
   Sub-mode is per-machine, so the map has to ride a single slot keyed
   by machine-id. EDN is the same serialiser the filter slot uses
   (`re-frame2.xray.filters.v1`); modes are an enum so versioning
-  feels overkill, but the bead's posture for per-machine persistence
-  is that the map will grow new keys as new sub-modes land. EDN is
-  fine.
+  feels overkill, but the map grows new keys as new sub-modes land,
+  and EDN handles that cleanly.
 
   ## Production posture
 
@@ -51,8 +50,8 @@
   "xray.static.machines.sub-mode-by-id")
 
 ;; ---- localStorage helpers -----------------------------------------------
-;; Raw browser access lives in the shared `local-storage` seam
-;; (rf2-jkake.24); both slots are key-parameterised here.
+;; Raw browser access lives in the shared `local-storage` seam;
+;; both slots are key-parameterised here.
 
 ;; ---- selection round-trip -----------------------------------------------
 
@@ -139,9 +138,9 @@
   goes through the standard queue and is replayed against the new
   frame on the first dispatch-cycle."
   []
-  ;; rf2-nesy9 — init-time hydration targets the production Xray shell
-  ;; frame via the named `defaults/default-frame-id` Var (production-
-  ;; singleton seam), not a `{:frame :rf/xray}` literal.
+  ;; Init-time hydration targets the production Xray shell frame via the
+  ;; named `defaults/default-frame-id` Var (production-singleton seam),
+  ;; not a `{:frame :rf/xray}` literal.
   (rf/dispatch [:rf.xray.static.machines/hydrate
                 {:selected-id    (load-selected-id)
                  :sub-mode-by-id (load-sub-mode-by-id)}]

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
@@ -1,14 +1,10 @@
 (ns day8.re-frame2-xray.static.machines.sim
-  "Static Machines Sim sub-mode (rf2-r4nao rehost; engine originally
-  rf2-v869p, Phase 2, parent rf2-2tkza).
+  "Static Machines Sim sub-mode.
 
-  ## Rehost (rf2-r4nao)
-
-  Rehosted from `panels/machine_inspector_sim.cljs` when the Dynamic
-  Machine Inspector collapsed (rf2-y9xmf). The engine + UI algebra is
-  unchanged; only the ns + the mount point + the event/sub namespacing
-  moved. Sim now lives ONLY on the Static surface — it is event-
-  INDEPENDENT (a hermetic 'what-if' simulator) by design.
+  Sim lives ONLY on the Static surface — it is event-INDEPENDENT (a
+  hermetic 'what-if' simulator) by design. This ns is the thin CLJS
+  wrapper that wires the pure-data helpers to the reactive substrate;
+  all logic lives in `sim_helpers.cljc`.
 
   ## Surface
 
@@ -39,7 +35,7 @@
     - **Exit** disposes the per-machine sim slot and flips the strip's
       sub-mode back to `:topology`.
 
-  ## On-chart simulation (rf2-u422r, epic rf2-nrrtb)
+  ## On-chart simulation
 
   Stately's signature is simulating ON the chart. The Sim body is a
   two-pane split: `SimChart` (the topology chart bound to this engine)
@@ -56,16 +52,15 @@
 
     - The `body` view — the per-machine Sim panel mounted as the
       `:sim` sub-mode body in the Static Machines panel.
-    - `SimChart` — the on-chart simulation surface (rf2-u422r).
+    - `SimChart` — the on-chart simulation surface.
     - `SimRail` — the side controls/diagnostics column.
     - The `pill` affordance — the `Sim` pill in the 4-mode sub-strip.
     - The `:rf.xray.static.machines/sim-*` events:
       `sim-start`, `sim-step`, `sim-reset`, `sim-stop`,
-      `sim-chart-edge-clicked` (rf2-u422r on-chart step), plus
+      `sim-chart-edge-clicked` (on-chart step), plus
       `sim-set-pending-event` / `sim-set-pending-data`.
     - The `:rf.xray.static.machines/sim-*` sub family, incl.
-      `sim-current-state` / `sim-last-transition` (rf2-u422r chart
-      binding).
+      `sim-current-state` / `sim-last-transition` (chart binding).
 
   ## Helper algebra
 
@@ -173,15 +168,15 @@
       (when sim
         (sim-h/event-id-suggestions (:definition sim)))))
 
-  ;; rf2-u422r — the sim's current snapshot state, for the on-chart
-  ;; active-state highlight (amber via the chart's `:sim?` palette).
+  ;; The sim's current snapshot state, for the on-chart active-state
+  ;; highlight (amber via the chart's `:sim?` palette).
   (rf/reg-sub :rf.xray.static.machines/sim-current-state
     :<- [:rf.xray.static.machines/sim-state]
     (fn [sim _query]
       (sim-h/current-sim-state sim)))
 
-  ;; rf2-u422r — the most-recent transition `{:from :to :event}`, feeding
-  ;; the chart's focused-event lens so the taken edge animates after each
+  ;; The most-recent transition `{:from :to :event}`, feeding the
+  ;; chart's focused-event lens so the taken edge animates after each
   ;; on-chart (or step-button) step. nil before the first step.
   (rf/reg-sub :rf.xray.static.machines/sim-last-transition
     :<- [:rf.xray.static.machines/sim-state]
@@ -226,7 +221,7 @@
     (fn [{:keys [db]} [_ {:keys [machine-id event]}]]
       {:db (step-and-store db machine-id event)}))
 
-  ;; rf2-u422r — on-chart edge click → step. The chart's clickable edge
+  ;; On-chart edge click → step. The chart's clickable edge
   ;; hands us the raw fireable event-id; coerce it to a step event vector
   ;; and fold it through the SAME engine path as the step-button (no new
   ;; transition logic — `step-and-store` runs `step-sim` +
@@ -259,11 +254,9 @@
 ;; ---- pill (4-mode sub-strip) -------------------------------------------
 
 (defn pill
-  "Render the Sim pill in the 4-mode sub-strip. Mirrors the placeholder
-  pill's shape (`testid` + active/inactive styling) — the visual
-  contract for the strip is unchanged from rf2-o5f5f.2 + the rf2-r4nao
-  placeholder; only the body the pill flips to is now the real Sim
-  surface."
+  "Render the Sim pill in the 4-mode sub-strip. Shares the strip's
+  visual contract (`testid` + active/inactive styling); the pill flips
+  the panel body to the Sim surface."
   [{:keys [active? on-click]}]
   [:button
    {:data-testid    "rf-xray-static-machines-pill-sim"
@@ -426,9 +419,9 @@
                              :event event-v}])))))
     :style       {:background (:yellow tokens)
                   :border "none"
-                  ;; rf2-5kfxe.4 — dark text on yellow uses :bg-1
-                  ;; (between bg-0 and bg-2; AA-grade on the yellow
-                  ;; accent without competing with primary text).
+                  ;; Dark text on yellow uses :bg-1 (between bg-0 and
+                  ;; bg-2; AA-grade on the yellow accent without
+                  ;; competing with primary text).
                   :color (:bg-1 tokens)
                   :padding "6px 14px"
                   :border-radius "4px"
@@ -538,7 +531,7 @@
            ;; `get-react-key` only reads `:key` meta from vectors (see
            ;; reagent2.impl.template). `available-transition-row`
            ;; always returns a `[:li …]` vector, so apply the key
-           ;; directly via `with-meta`. (rf2-ppzid)
+           ;; directly via `with-meta`.
            (for [t transitions]
              (with-meta
                (available-transition-row dispatch machine-id pending-event t)
@@ -606,25 +599,25 @@
            ;; `get-react-key` only reads `:key` meta from vectors (see
            ;; reagent2.impl.template). `audit-trail-row` always returns
            ;; a `[:li …]` vector, so apply the key directly via
-           ;; `with-meta`. (rf2-ppzid)
+           ;; `with-meta`.
            (for [[idx row] (map-indexed vector trail)]
              (with-meta (audit-trail-row idx row) {:key idx}))))])
 
 (defn SimRail
   "The Sim sub-mode's content rail — banner + current state + event
   picker + Step / Reset / Exit + available transitions + audit trail.
-  Pure hiccup (per Xray's rf2-tijr convention).
+  Pure hiccup (per Xray convention).
 
   Returns nil when sim is not active for the currently-selected
   machine (the caller is expected to dispatch `:sim-start` BEFORE
   rendering when the body mounts; this guard keeps the rail safe
   during the auto-start microtask gap).
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher threaded from
-  `body` — fanned out to every control helper.
+  `dispatch` is the frame-aware dispatcher threaded from `body` —
+  fanned out to every control helper.
 
-  `sim` / `transitions` / `suggestions` (rf2-jholrb) are the derefed sub
-  values threaded down from the `detail` reg-view (`definition_detail`),
+  `sim` / `transitions` / `suggestions` are the derefed sub values
+  threaded down from the `detail` reg-view (`definition_detail`),
   via `body`. SimRail is a plain fn invoked as a Reagent component, so it
   renders in its OWN cycle and CANNOT recover the surrounding `:rf/xray`
   frame to `rf/subscribe` itself (Spec 004 §Plain Reagent fns do not pick
@@ -659,12 +652,12 @@
        (available-transitions-list dispatch machine-id (:pending-event sim) transitions)
        (audit-trail (:audit-trail sim))])))
 
-;; ---- on-chart simulation surface (rf2-u422r) ---------------------------
+;; ---- on-chart simulation surface ---------------------------------------
 
 (defn SimChart
   "The on-chart simulation surface — the topology chart bound to the
-  hermetic sim engine (rf2-u422r, epic rf2-nrrtb). Stately's signature
-  is simulating ON the chart; this is the binding seam that delivers it.
+  hermetic sim engine. Stately's signature is simulating ON the chart;
+  this is the binding seam that delivers it.
 
   Reuses the EXISTING engine end-to-end — no new transition logic:
 
@@ -674,7 +667,7 @@
       AMBER (distinct from the live cyan highlight on the Dynamic
       surface).
     - **Context band** — the machine's STATIC context shape (keys +
-      type captions, rf2-eao0s0) drives the chart's `:context-band`
+      type captions) drives the chart's `:context-band`
       so the root Context band renders here too (the Dynamic + Static
       Topology charts already pass it). Shape + declared-over-inferred
       provenance come from the shared `topology-view/static-context-
@@ -695,11 +688,11 @@
   Returns nil when sim is inactive (the auto-start gap) so the host's
   `when sim` guard keeps the render safe.
 
-  Pure hiccup (Xray rf2-tijr convention). `dispatch` (rf2-nesy9) is the
-  frame-aware dispatcher threaded from `body`.
+  Pure hiccup (Xray convention). `dispatch` is the frame-aware
+  dispatcher threaded from `body`.
 
-  `current` / `last-trans` (rf2-jholrb) are the derefed sub values
-  threaded down from the `detail` reg-view (`definition_detail`), via
+  `current` / `last-trans` are the derefed sub values threaded down
+  from the `detail` reg-view (`definition_detail`), via
   `body`. SimChart is a plain fn invoked as a Reagent component, so it
   renders in its OWN cycle and CANNOT recover the surrounding `:rf/xray`
   frame to `rf/subscribe` itself (Spec 004; a bare `subscribe` here
@@ -720,7 +713,7 @@
     {:definition             definition
      :machine-id             machine-id
      :current-state          current
-     ;; rf2-eao0s0 — surface the STATIC context shape so the root
+     ;; Surface the STATIC context shape so the root
      ;; Context band renders on the Static Sim chart too (the Dynamic
      ;; topology + focused-event + Static Topology charts already do).
      ;; Shape + provenance come from the shared machines-viz-backed
@@ -758,7 +751,7 @@
   `dispatch-sync`) so the render itself stays pure; the subsequent
   reactive cycle re-mounts with sim-state populated.
 
-  ## On-chart layout (rf2-u422r)
+  ## On-chart layout
 
   The sim body is a two-pane split: the interactive `SimChart` is the
   PRIMARY surface (left/main) — the user clicks transition edges on the
@@ -769,7 +762,7 @@
   audit trail. The chart and rail read the SAME sim-state, so clicking
   an edge and clicking a Step button are interchangeable.
 
-  ## Frame recovery (rf2-jholrb)
+  ## Frame recovery
 
   `body` is mounted by `definition_detail/body` as a plain-fn Reagent
   component, so it renders in its OWN cycle and CANNOT recover the
@@ -780,7 +773,7 @@
   the `detail` reg-view (where the frame IS in context) and threaded down
   through `definition_detail/body` to here, then fanned out to `SimChart`
   / `SimRail` (themselves plain-fn components). This mirrors the
-  rf2-wxu4l3 browse-list fix exactly."
+  browse-list frame-recovery pattern exactly."
   [dispatch {:keys [machine-id definition sim transitions suggestions
                     current last-trans]}]
   ;; Side-effecting auto-start, then the render. The `defn` body is an
@@ -789,7 +782,7 @@
   (when (and (some? machine-id)
              (some? definition)
              (nil? sim))
-    ;; rf2-nesy9 — auto-start dispatches through the threaded
+    ;; Auto-start dispatches through the threaded
     ;; frame-aware `dispatch` (sim/body is invoked as a Reagent
     ;; component, so render-time frame recovery is unavailable).
     (dispatch [:rf.xray.static.machines/sim-start
@@ -821,7 +814,7 @@
      " — Sim cannot clone what isn't there."]
 
     ;; Sim-state has landed (or the auto-start dispatch just queued).
-    ;; rf2-u422r — two-pane split: the on-chart sim surface is primary,
+    ;; Two-pane split: the on-chart sim surface is primary,
     ;; the rail is the side detail/controls column. Both guard the
     ;; auto-start gap (`SimChart` returns its wrapper unconditionally
     ;; but the chart degrades on a nil definition; `SimRail`'s `when

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim_helpers.cljc
@@ -1,13 +1,7 @@
 (ns day8.re-frame2-xray.static.machines.sim-helpers
-  "Pure-data helpers for Xray's Static Machines Sim sub-mode (rf2-r4nao
-  rehost; engine originally rf2-v869p Phase 2, parent rf2-2tkza).
+  "Pure-data helpers for Xray's Static Machines Sim sub-mode.
 
-  ## Rehost (rf2-r4nao)
-
-  Rehosted from `panels/machine_inspector_sim_helpers.cljc` when the
-  Dynamic Machine Inspector collapsed (rf2-y9xmf). The pure-data algebra
-  is unchanged — only the ns name + the consuming UI surface moved.
-  Sim is now exclusively a Static-surface sub-mode (event-INDEPENDENT
+  Sim is exclusively a Static-surface sub-mode (event-INDEPENDENT
   'what-if' simulator).
 
   ## Why a separate `.cljc` ns
@@ -29,7 +23,7 @@
       flips the chart from live-highlight to sim-highlight (amber).
     - The sim **clones** the registered machine definition into Xray
       state; production registry is untouched.
-    - A user picks an event from an autocomplete-style picker (v1: a
+    - A user picks an event from an autocomplete-style picker (a
       text input + dropdown of declared events for the current state)
       and clicks Step.
     - The runtime calls `rf/machine-transition` (the public late-bind
@@ -69,7 +63,7 @@
        machines artefact ns directly (Xray has no compile-time dep
        on `re-frame.machines.result`).
     8. `last-transition` / `current-sim-state` / `edge-click->event`
-       — rf2-u422r on-chart binding algebra: the focused-edge lens
+       — on-chart binding algebra: the focused-edge lens
        inputs + active-state highlight + edge-click → step-event
        coercion that bind the topology chart to the sim engine."
   (:require [clojure.string :as str]
@@ -150,9 +144,9 @@
   transition declared on the snapshot's current state node. The picker
   surfaces these as the user's step options.
 
-  v1 scope: only direct `:on` transitions on the leaf state. `:always` /
-  `:after` / parent-state inheritance are deferred to a follow-on bead
-  (the engine handles them at step time; the picker only surfaces what
+  Surfaces only direct `:on` transitions on the leaf state. `:always` /
+  `:after` / parent-state inheritance are not listed in the picker (the
+  engine still handles them at step time; the picker only surfaces what
   the user can fire interactively from the leaf).
 
   Returns `[]` when the definition / snapshot is nil, or the current
@@ -180,13 +174,13 @@
       {:state <keyword-or-vector>  ;; the declared :initial leaf
        :data  <map>}               ;; the declared :data initial map
 
-  Phase 2 keeps the initial-state cascade simple (the `:initial` slot
+  The initial-state cascade stays simple (the `:initial` slot is
   shallow-read) — the runtime's own `apply-initial-entry-cascade` would
-  fire `:entry` actions, which sim deliberately skips at v1 (we want a
-  pure, hermetic step machine the user drives). The first user-fired
-  event runs `rf/machine-transition` which DOES execute entry / exit /
-  action cascades — so action evaluation kicks in from step 1 onwards,
-  not from initial bootstrap.
+  fire `:entry` actions, which sim deliberately skips at bootstrap (we
+  want a pure, hermetic step machine the user drives). The first
+  user-fired event runs `rf/machine-transition` which DOES execute
+  entry / exit / action cascades — so action evaluation kicks in from
+  step 1 onwards, not from initial bootstrap.
 
   Returns nil when `definition` is nil or has no `:initial`."
   [definition]
@@ -359,9 +353,9 @@
       :else
       (record-error sim-state event nil "engine returned a non-Result value"))))
 
-;; ---- on-chart binding helpers (rf2-u422r) -------------------------------
+;; ---- on-chart binding helpers -------------------------------------------
 ;;
-;; The on-chart simulator (rf2-u422r, epic rf2-nrrtb) renders the sim ON
+;; The on-chart simulator renders the sim ON
 ;; the topology chart: the active state highlights amber, the taken
 ;; transition's edge animates, and clicking an outgoing event edge sends
 ;; that event into the SAME hermetic engine the step-button drives. These

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
@@ -1,13 +1,12 @@
 (ns day8.re-frame2-xray.static.machines.topology
-  "Topology mode renderer — Static-read view of a machine's state graph
-  (rf2-o5f5f.2; rf2-md9oz upgrade to interactive Chart adapter).
+  "Topology mode renderer — Static-read view of a machine's state graph.
 
   ## What it renders
 
   The Static Topology body embeds `machine-canvas/Chart` — the SAME
-  MachineChart surface the Dynamic Machines panel renders (rf2-gpzb4
-  xyflow migration). So the Static and Dynamic surfaces are the same
-  chart; pan / zoom / fit are driven by the mouse + xyflow's own
+  MachineChart surface the Dynamic Machines panel renders. So the
+  Static and Dynamic surfaces are the same chart; pan / zoom / fit are
+  driven by the mouse + xyflow's own
   on-canvas controls (drag to pan, wheel / pinch to zoom, the controls
   buttons to fit), NOT by Xray-owned keyboard shortcuts. There are NO
   implemented keyboard shortcuts (`+` / `-`, arrows, `f`, `0`) on either
@@ -30,7 +29,7 @@
   Dynamic do NOT hand a saved pan / zoom between each other. Each
   surface's viewport lives inside its own xyflow instance for the
   mount's lifetime. Fit-on-entry is the one piece Xray drives: entering
-  the Static Machines tab bumps a `:fit-signal` nonce (rf2-6tw7t) that
+  the Static Machines tab bumps a `:fit-signal` nonce that
   re-frames the topology (xyflow's one-shot `:fitView` + the layout-key
   auto-fit both leave a re-entered chart stale), so the chart opens
   framed to its content. After that, pan / zoom is the user's via the
@@ -48,13 +47,11 @@
 
   ## Definition-stale post-reload
 
-  Per the bead's §Topology mode + findings §3.3 the chart should
-  surface a 'definition reloaded' chip after a hot-reload changes
-  the machine spec while the user is looking at it. v1 ships the
-  scaffold without the reload-detection wiring — the chip will land
-  with a follow-on bead. The chart re-renders on every spec change
-  (the `machine-definitions` sub fires on framework hot-reload), so
-  the data shown is always live."
+  The chart re-renders on every spec change (the `machine-definitions`
+  sub fires on framework hot-reload), so the data shown is always live.
+  TODO: surface a 'definition reloaded' chip after a hot-reload changes
+  the machine spec while the user is looking at it (the reload-detection
+  wiring is not yet in place)."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
@@ -79,34 +76,30 @@
   "Render the interactive MachineChart canvas for `definition`. NO
   highlight + NO after-rings — Static Topology is a static-read.
 
-  rf2-md9oz — delegates to `machine-canvas/Chart` (the same MachineChart
-  surface the Dynamic Machines panel renders) so the user gets mouse /
+  Delegates to `machine-canvas/Chart` (the same MachineChart surface
+  the Dynamic Machines panel renders) so the user gets mouse /
   controls-driven xyflow zoom / pan / fit on the Static surface too (no
   Xray-owned keyboard shortcuts — viewport gestures are xyflow's). The
   static-flavoured opts are:
 
     :show-after-rings?      false  — no focused-event lens on static.
     :testid                        — overrides the inner SVG testid
-                                     so the existing static-panel
-                                     tests still match.
+                                     so the static-panel tests match.
 
-  rf2-eao0s0 — forward the STATIC context shape (keys + type captions)
-  into the chart so the root Context band renders on the Static
-  Topology surface too. The Dynamic topology + focused-event charts
-  already pass this; the Static charts had been mounting only
-  definition / machine-id, so the root Context chrome was missing.
+  Forwards the STATIC context shape (keys + type captions) into the
+  chart so the root Context band renders on the Static Topology
+  surface, matching the Dynamic topology + focused-event charts.
   Derived via the SHARED `topology-view/static-context-shape` /
   `static-context-inferred?` helpers (which delegate to machines-viz
   `context-shape`) — no duplicate derivation. nil shape → the chart
   hides the panel; the declared-over-inferred provenance gates the
   `inferred from :data` badge."
   [dispatch {:keys [definition machine-id fit-signal]}]
-  ;; rf2-gpzb4 (2026-05-21 xyflow migration) — ELK is now driven
-  ;; internally by xyflow inside `mv-chart/MachineChart`; the
-  ;; host-side layout-or-fallback dance is gone.
-  ;; rf2-nesy9 — `dispatch` is threaded from `body` (the Static Machines
-  ;; detail subtree is invoked as Reagent components, so render-time
-  ;; frame recovery is unavailable).
+  ;; ELK is driven internally by xyflow inside `mv-chart/MachineChart`;
+  ;; the host does no layout itself.
+  ;; `dispatch` is threaded from `body` (the Static Machines detail
+  ;; subtree is invoked as Reagent components, so render-time frame
+  ;; recovery is unavailable).
   (let [engine "xyflow+elkjs"]
     [:div {:data-testid    "rf-xray-static-machines-topology-chart"
            :data-machine-id (str machine-id)
@@ -122,15 +115,15 @@
      [machine-canvas/Chart
       {:definition             definition
        :machine-id             machine-id
-       ;; rf2-eao0s0 — surface the STATIC context shape so the root
-       ;; Context band renders without a live snapshot (the Dynamic
-       ;; topology + focused-event charts already do this). Shape +
-       ;; provenance come from the shared machines-viz-backed helpers.
+       ;; Surface the STATIC context shape so the root Context band
+       ;; renders without a live snapshot (matching the Dynamic
+       ;; topology + focused-event charts). Shape + provenance come
+       ;; from the shared machines-viz-backed helpers.
        :context-band           (topology-view/static-context-shape definition)
        :context-band-inferred? (topology-view/static-context-inferred? definition)
        :show-after-rings?      false
-       ;; rf2-6tw7t — fit-on-entry nonce so entering the Static Machines
-       ;; tab re-frames the topology (xyflow's one-shot `:fitView` +
+       ;; Fit-on-entry nonce so entering the Static Machines tab
+       ;; re-frames the topology (xyflow's one-shot `:fitView` +
        ;; the layout-key auto-fit both leave a re-entered chart stale).
        :fit-signal             fit-signal
        :inner-testid           "rf-xray-static-machines-topology-svg"
@@ -142,11 +135,9 @@
 ;; ---- chart toolbar (open in popout) -------------------------------------
 
 (defn- popout-affordance
-  "Per the bead — 'Open chart in popout' affordance. v1 scaffolds the
-  affordance against the existing `:rf.xray.static.machines/open-
-  chart-popout` event (registered by the panel install). Popout
-  geometry lands in a follow-on bead (sibling of the second-window
-  rf2-u3qm1 work)."
+  "'Open chart in popout' affordance. Wired to the
+  `:rf.xray.static.machines/open-chart-popout` event (registered by
+  the panel install). TODO: popout window geometry."
   [dispatch machine-id]
    [:button
    {:data-testid "rf-xray-static-machines-topology-popout"
@@ -194,14 +185,13 @@
   "Render Topology mode for `machine-id`. `definition` is the
   registrar's spec map; `source-coord` is its lifted coord (or nil).
 
-  The embedded `machine-canvas/Chart` (rf2-md9oz) wraps the
-  machines-viz xyflow `MachineChart` (rf2-gpzb4), which manages
-  zoom / pan / fit internally — the body function itself is still
-  pure hiccup.
+  The embedded `machine-canvas/Chart` wraps the machines-viz xyflow
+  `MachineChart`, which manages zoom / pan / fit internally — the body
+  function itself is still pure hiccup.
 
-  `dispatch` (rf2-nesy9) is threaded from `definition_detail/body` so
-  the chart's state-click + the toolbar's pop-out land on the
-  surrounding instance frame."
+  `dispatch` is threaded from `definition_detail/body` so the chart's
+  state-click + the toolbar's pop-out land on the surrounding instance
+  frame."
   [dispatch {:keys [machine-id definition source-coord fit-signal] :as args}]
   (cond
     (nil? definition)

--- a/tools/xray/src/day8/re_frame2_xray/static/mode_pill.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/mode_pill.cljs
@@ -1,6 +1,6 @@
 (ns day8.re-frame2-xray.static.mode-pill
   "Ribbon-left mode control — a compact single-select dropdown toggling
-  Dynamic ↔ Static (rf2-o5f5f.1, reshaped by rf2-4vp5j).
+  Dynamic ↔ Static.
 
   ## Purpose
 
@@ -20,26 +20,24 @@
   `keybinding.cljs`) fires the same `:rf.xray/toggle-mode` event so the
   chord and the dropdown are wired to the same handler.
 
-  ## Why a dropdown, not the old two-button pill (rf2-4vp5j)
+  ## Why a dropdown
 
-  Mode is an OCCASIONAL-use control — most sessions never flip it. The
-  earlier 160px two-segment radio pill was too dominant for that
-  cadence, anchoring the eye at chrome-left where the Frame picker now
-  belongs. The reshape collapses it to a compact `<select>` that shares
-  the frame picker's weight (`bg-2` fill, `border-default` hairline,
-  4px radius). Post rf2-ad7zx.13 the Figma export carries a single
-  `:accent` (GitHub blue) — the ribbon stripe no longer changes colour
-  by mode; the `<select>`'s `data-active-mode` attribute + active option
-  carry the mode state, and the Dynamic/Static MODE remains functional
-  (it drives motion/pulse), it just no longer drives accent colour.
+  Mode is an OCCASIONAL-use control — most sessions never flip it, so a
+  compact `<select>` is the right weight: understated and undominant at
+  chrome-left where the Frame picker also lives. It shares the frame
+  picker's weight (`bg-2` fill, `border-default` hairline, 4px radius).
+  The theme carries a single `:accent` (GitHub blue); the ribbon stripe
+  does not change colour by mode. The `<select>`'s `data-active-mode`
+  attribute + active option carry the mode state, and the
+  Dynamic/Static MODE drives motion/pulse rather than accent colour.
 
   ## Why a single registered view
 
   `(rf/reg-view mode-pill …)` is the canonical Xray shape: subscribes
   inside the component body resolve to `:rf/xray` via React-context
-  (rf2-in6l2 / Spec 004 §Plain Reagent fns do not pick up the
-  surrounding frame). The `<select>` is native so keyboard + screen-
-  reader navigation work out of the box.
+  (Spec 004 §Plain Reagent fns do not pick up the surrounding frame).
+  The `<select>` is native so keyboard + screen-reader navigation work
+  out of the box.
 
   ## Production posture
 
@@ -72,8 +70,8 @@
 ;; ---- view ---------------------------------------------------------------
 
 (rf/reg-view mode-pill
-  "Chrome-ribbon mode dropdown (rf2-o5f5f.1 / rf2-4vp5j) — a compact
-  single-select `<select>` toggling Dynamic ↔ Static. Shares the frame
+  "Chrome-ribbon mode dropdown — a compact single-select `<select>`
+  toggling Dynamic ↔ Static. Shares the frame
   picker's control style (`bg-2`, `border-default`, 4px radius) so the
   two chrome-left selectors read as one stratum. The mode SIGNAL is the
   ribbon's left-edge accent stripe, not this control — the dropdown is
@@ -97,8 +95,8 @@
                              (let [v    (.. e -target -value)
                                    mode (keyword v)]
                                (when (not= mode active-mode)
-                                 ;; rf2-nesy9 — reg-view-injected
-                                 ;; frame-aware dispatch.
+                                 ;; reg-view-injected frame-aware
+                                 ;; dispatch.
                                  (dispatch [:rf.xray/set-mode mode]))))
               :style       {:background    (:bg-2 tokens)
                             :color         (:text-primary tokens)

--- a/tools/xray/src/day8/re_frame2_xray/static/persistence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/persistence.cljs
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-xray.static.persistence
-  "localStorage round-trip for Xray's Dynamic ↔ Static mode selection
-  (rf2-o5f5f.1).
+  "localStorage round-trip for Xray's Dynamic ↔ Static mode selection.
 
   Per `tools/xray/spec/007-UX-IA.md` §Static mode + the findings doc
   `ai/findings/2026-05-19-xray-explorer-mode.md`: Xray exposes TWO
@@ -83,7 +82,7 @@
 
 ;; ---- localStorage helpers -----------------------------------------------
 ;; Raw browser access + the no-op-when-unavailable / swallow-throws
-;; posture live in the shared `local-storage` seam (rf2-jkake.24).
+;; posture live in the shared `local-storage` seam.
 
 (defn read-raw
   "Read the raw string Xray wrote under `storage-key`. Returns nil

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
@@ -1,8 +1,8 @@
 (ns day8.re-frame2-xray.static.routes.browse-list
   "Flat list + search + per-row inline expand for the Static Routes
-  tab (rf2-o5f5f.3).
+  tab.
 
-  ## Shape (post-rf2-lq0ef + Static reshape)
+  ## Shape
 
   Routes are flat (no tree). Sort: `:path` ascending default. Search
   is substring across route-id + path + doc — shared with the Dynamic
@@ -63,10 +63,10 @@
   `routing-helpers/filter-rows`. State on
   `:rf.xray.static.routes/query`.
 
-  rf2-nesy9 — `dispatch` threaded from the routes `Panel` reg-view (via
-  `render`), not a render-time capture (this whole subtree is invoked as
-  a Reagent component and cannot recover the frame). rf2-1keg3 — the
-  flex-row markup lives in the shared `search-box` component."
+  `dispatch` is threaded from the routes `Panel` reg-view (via
+  `render`), not a render-time capture — this whole subtree is invoked as
+  a Reagent component and cannot recover the frame. The flex-row markup
+  lives in the shared `search-box` component."
   [dispatch query total-routes filtered?]
   [search-box/search-box
    {:testid-prefix   "rf-xray-static-routes"
@@ -82,7 +82,7 @@
 (defn- route-row
   "One row in the flat catalogue. No marker chip, no `:here` glyph —
   Static is event-INDEPENDENT. Clicking the row toggles the expand
-  surface. `dispatch` (rf2-nesy9) is threaded from the routes `Panel`
+  surface. `dispatch` is threaded from the routes `Panel`
   reg-view down into the expand surface's jump / sim-nav affordances."
   [dispatch
    {:keys [route-id path doc parent has-on-match? has-can-leave? tags meta]
@@ -102,7 +102,7 @@
                                        "2px solid transparent")
                       :border-radius "2px"
                       :line-height   "20px"}}
-   ;; rf2-mq8wk — keyboard a11y. The route row's clickable body toggles
+   ;; Keyboard a11y. The route row's clickable body toggles
    ;; the inline expand surface, so it carries the L2 event-row recipe
    ;; (shell.cljs:1068 `role=button` + `tab-index=0` + `aria-label` +
    ;; Enter/Space activation). `aria-expanded` mirrors the open state so
@@ -175,7 +175,7 @@
   [dispatch
    {:keys [silent? routes total-routes filtered? query] :as _data}
    {:keys [expanded sim-open routes-map]}]
-  ;; rf2-nesy9 — `dispatch` is the frame-aware dispatcher threaded from
+  ;; `dispatch` is the frame-aware dispatcher threaded from
   ;; the routes `Panel` reg-view (render is invoked as a Reagent
   ;; component, so it cannot recover the frame itself).
   (cond

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
@@ -1,7 +1,7 @@
 (ns day8.re-frame2-xray.static.routes.panel
-  "Top-level Routes tab on Xray's Static surface (rf2-o5f5f.3).
+  "Top-level Routes tab on Xray's Static surface.
 
-  ## Two verbs, two homes (Mike's decision, 2026-05-19)
+  ## Two verbs, two homes
 
   Routes appears in BOTH Dynamic AND Static surfaces with different
   verbs. **Static gets BROWSE** — flat catalogue + Simulate-URL + per-
@@ -69,7 +69,7 @@
 
 (defn- header
   []
-  ;; rf2-6xezz — Mike-direction 2026-05-21: panel-name heading scrubbed.
+  ;; No panel-name heading — the Static surface chrome already names the tab.
   [:div {:data-testid "rf-xray-static-routes-header"
          :style       {:padding "4px 16px"}}])
 
@@ -80,8 +80,7 @@
   composite + UI-state slots and composes the header + Simulate-URL
   surface + browse list.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
+  `reg-view`-registered so subscribes resolve to `:rf/xray`."
   []
   (let [data       @(rf/subscribe [:rf.xray.static.routes/tab-data])
         expanded   @(rf/subscribe [:rf.xray.static.routes/expanded])
@@ -199,8 +198,7 @@
     (fn [[routes-map query sim-url] _query]
       (h/project-static-data routes-map query sim-url)))
 
-  ;; rf2-2moh1 — register the Static Routes tab with the internal L4
-  ;; tab registry.
+  ;; Register the Static Routes tab with the internal L4 tab registry.
   (panel-registry/reg-l4-tab!
     {:id    :routes
      :label "Routes"

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/row_expand.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/row_expand.cljs
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-xray.static.routes.row-expand
-  "Per-row inline expand renderer for the Static Routes flat list
-  (rf2-o5f5f.3).
+  "Per-row inline expand renderer for the Static Routes flat list.
 
   ## Shape
 
@@ -28,7 +27,7 @@
   Source-coord rendering reuses Xray's `open-in-editor` chip
   rendering when the registrar meta carries the optional
   `:rf.route/registered-at` slot. Absent → no chip (silent-by-
-  default per rf2-g3ghh / rf2-yn86j)."
+  default)."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.static.routes.simulate-nav :as sim-nav]
             [day8.re-frame2-xray.theme.tokens
@@ -47,12 +46,11 @@
 
 (defn- value-block
   "Render an EDN value through the shared cljs-devtools EDN widget
-  (rf2-2kwhw — spec 007:119 'all values rendered via the cljs-devtools-
-  shaped renderer'). Replaces the prior raw-`pr-str` `[:pre]` block so
-  the schema / meta values gain expand/collapse, syntax-colouring
-  parity, and the per-node copy host (rf2-f026h). The `testid` wrapper
-  is preserved so existing per-block selectors still resolve; the
-  `node-key` is stable per block so expand state survives reloads."
+  (spec 007:119 'all values rendered via the cljs-devtools-shaped
+  renderer'). Schema / meta values gain expand/collapse, syntax-colouring
+  parity, and a per-node copy host. The `testid` wrapper lets per-block
+  selectors resolve; the `node-key` is stable per block so expand state
+  survives reloads."
   [testid node-key value]
   [:div {:data-testid testid
          :style       {:margin        "0"
@@ -103,7 +101,7 @@
   §4.4 — fires the cross-link event the registry installs so the
   user lands on the Dynamic Routing lens scoped to this route.
 
-  `dispatch` (rf2-nesy9) is threaded from the routes `Panel` reg-view
+  `dispatch` is threaded from the routes `Panel` reg-view
   (this button is invoked as a Reagent component and cannot recover the
   frame itself)."
   [dispatch route-id]
@@ -206,7 +204,7 @@
                                 (subs (pr-str route-id) 1))
               :style       {:margin "4px 0"}}
         (section-label "Matched keys")
-        ;; rf2-2kwhw — matched-keys vector through the shared widget's
+        ;; Matched-keys vector through the shared widget's
         ;; inline current-state renderer (cljs-devtools one-liner).
         [:div {:style {:font-family mono-stack
                        :font-size   "11px"

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_nav.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_nav.cljs
@@ -1,19 +1,18 @@
 (ns day8.re-frame2-xray.static.routes.simulate-nav
   "Hermetic 'Simulate navigation' preview for Xray's Static Routes
-  tab (rf2-o5f5f.3).
+  tab.
 
   ## Purpose
 
-  Per the parent epic decision (option (a): two-verbs-two-homes) and
-  the findings doc §4.3 option (a): the per-row 'Simulate navigation'
-  button is HERMETIC — NO real dispatch into the host app, NO fx, NO
-  runtime-db / app-db mutation. It surfaces a preview of what would land:
+  The per-row 'Simulate navigation' button is HERMETIC — NO real
+  dispatch into the host app, NO fx, NO runtime-db / app-db mutation.
+  It surfaces a preview of what would land:
 
     - matched params (derived from the row's pattern + the optional
       URL from the row's simulate-URL input);
     - the registered `:on-match` event vector;
     - the expected runtime-db route slice
-      (`[:rf.runtime/routing :current ...]`, EP-0001 rf2-vzld77 — the
+      (`[:rf.runtime/routing :current ...]`, EP-0001 — the
       framework-owned route slice lives in runtime-db, not app-db) shape.
 
   The hermetic posture is the spec point — Xray is a lens, not a

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_url.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_url.cljs
@@ -1,17 +1,14 @@
 (ns day8.re-frame2-xray.static.routes.simulate-url
-  "Simulate-URL header surface for Xray's Static Routes tab
-  (rf2-o5f5f.3).
+  "Simulate-URL header surface for Xray's Static Routes tab.
 
   ## Purpose
 
-  Promoted from `panels/routing.cljs` per the two-verbs-two-homes
-  decision (Mike, 2026-05-19): the URL → route resolver is a Static
-  surface verb (browse), not a Dynamic cascade lens. Paste a URL,
-  see every route that matches plus its 6-rule `:rf.route/rank`
-  tuple; the winner is the first row by rank-descending (mirrors
-  `match-url`).
+  The URL → route resolver is a Static surface verb (browse), not a
+  Dynamic cascade lens. Paste a URL, see every route that matches plus
+  its 6-rule `:rf.route/rank` tuple; the winner is the first row by
+  rank-descending (mirrors `match-url`).
 
-  The implementation reuses the existing
+  The implementation reuses the
   `panels.routing-helpers/simulate-url` pure helper — the 6-rule
   rank cascade lives there, JVM-portable. This ns is the view +
   dispatch layer only.
@@ -35,7 +32,7 @@
   "Render a single rank tuple as compact mono text. The 6-tuple is
   `[static catch-all? total -splat -optional -reg-index]` per
   `parse-pattern` (the catch-all discriminator precedes total-length
-  so the bare `/*` is demoted below all concrete routes — rf2-1ugs5u);
+  so the bare `/*` is demoted below all concrete routes);
   surface it verbatim — the lens is about exposing the cascade, not
   interpreting it."
   [rank]
@@ -87,7 +84,7 @@
   value; `sim-result` is the projection from
   `routing-helpers/simulate-url` (nil when input is blank)."
   [dispatch sim-url sim-result]
-  ;; rf2-nesy9 — `dispatch` threaded from the routes `Panel` reg-view.
+  ;; `dispatch` threaded from the routes `Panel` reg-view.
   [:div {:data-testid "rf-xray-static-routes-sim"
          :style       {:padding       "10px 16px"
                        :border-top    (str "1px solid " (:border-subtle tokens))

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.static.schemas.panel
-  "Top-level Schemas sub-tab for Xray's Static surface (rf2-o5f5f.4).
+  "Top-level Schemas sub-tab for Xray's Static surface.
 
   ## Browse-all verb
 
@@ -40,8 +40,8 @@
 
   Each row carries a source-coord chip (when the registered metadata
   surfaces `:file` / `:line`). Click dispatches
-  `:rf.xray/open-in-editor` per the rf2-evgf5 / rf2-g5q8d wiring —
-  same affordance the Trace + Issues panels use.
+  `:rf.xray/open-in-editor` — the same affordance the Trace + Issues
+  panels use.
 
   ## State slots (all under `:rf.xray.static.schemas/*`)
 
@@ -87,7 +87,7 @@
 (defn project-app-schema-rows
   "Flatten `{frame-id {path schema-meta}}` into row maps.
   `schema-meta` carries `:schema`, `:doc`, plus `:file`/`:line`/`:ns`
-  source-coord slots (Malli EDN + the rf2-5m5n2 source-coord stamp)."
+  source-coord slots (Malli EDN + the source-coord stamp)."
   [schemas-by-frame]
   (->> schemas-by-frame
        (mapcat (fn [[frame-id by-path]]
@@ -162,7 +162,8 @@
 
 (defn- header
   []
-  ;; rf2-6xezz — Mike-direction 2026-05-21: panel-name heading scrubbed.
+  ;; The header carries no panel-name heading — the L4 tab strip is the
+  ;; panel-name source-of-truth.
   [:div {:data-testid "rf-xray-static-schemas-header"
          :style       {:padding "4px 16px"}}])
 
@@ -170,9 +171,9 @@
 
 (defn- search-box
   [query total filtered?]
-  ;; rf2-nesy9 — render-time frame capture (rendered inside the schemas
-  ;; Panel reg-view), not a `:rf/xray` literal. rf2-1keg3 — the flex-row
-  ;; markup lives in the shared `search-box` component.
+  ;; Render-time frame capture (rendered inside the schemas Panel
+  ;; reg-view), not a `:rf/xray` literal. The flex-row markup lives in
+  ;; the shared `search-box` component.
   (let [frame (rf/current-frame-id)]
     [search-box/search-box
      {:testid-prefix   "rf-xray-static-schemas"
@@ -216,10 +217,10 @@
   [{:keys [kind id frame schema doc source-coord] :as _row}]
   (let [id-text (pr-str id)
         row-id  (str (name kind) "-" id-text)]
-    ;; rf2-mq8wk — list semantics. Schema rows are non-interactive
-    ;; catalogue entries (the only row-level affordance is the
-    ;; `open-chip` jump-to-source, which is itself focusable), so
-    ;; `role=listitem` is the correct shape rather than `role=button`.
+    ;; List semantics. Schema rows are non-interactive catalogue entries
+    ;; (the only row-level affordance is the `open-chip` jump-to-source,
+    ;; which is itself focusable), so `role=listitem` is the correct
+    ;; shape rather than `role=button`.
     [:li {:data-testid (str "rf-xray-static-schemas-row-" row-id)
           :role        "listitem"
           :style       {:display       "block"
@@ -246,13 +247,13 @@
          (pr-str frame)])
       (when (and source-coord (:file source-coord))
         [open-in-editor/open-chip source-coord])]
-     ;; rf2-2kwhw — the Malli schema EDN renders through the shared
-     ;; cljs-devtools EDN widget (spec 007:119 — "all values rendered
-     ;; via the cljs-devtools-shaped renderer") rather than raw
-     ;; `pr-str` + `[:code]`, so it gains expand/collapse, syntax-
-     ;; colouring parity, and the per-node copy host (rf2-f026h). The
-     ;; `node-key` is stable per (kind,id) so expand state survives
-     ;; reloads and doesn't collide across rows.
+     ;; The Malli schema EDN renders through the shared cljs-devtools EDN
+     ;; widget (spec 007:119 — "all values rendered via the
+     ;; cljs-devtools-shaped renderer") rather than raw `pr-str` +
+     ;; `[:code]`, so it gains expand/collapse, syntax-colouring parity,
+     ;; and the per-node copy host. The `node-key` is stable per
+     ;; (kind,id) so expand state survives reloads and doesn't collide
+     ;; across rows.
      [:div {:data-testid (str "rf-xray-static-schemas-schema-" row-id)
             :style {:margin-left "20px"
                     :margin-top  "2px"
@@ -276,8 +277,7 @@
   "Static Schemas panel root view. Subscribes to the schemas composite
   + the search-query slot and composes the header + search + flat list.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
+  `reg-view`-registered so subscribes resolve to `:rf/xray`."
   []
   (let [data @(rf/subscribe [:rf.xray.static.schemas/tab-data])
         {:keys [silent? schemas total filtered? query]} data]
@@ -351,7 +351,7 @@
 ;;
 ;; The raw value the production data sub reads. Shared with the
 ;; test-override seam (`install-test-overrides!` below) so the override
-;; branch lives in ONE place (the seam), not duplicated (rf2-e8330v).
+;; branch lives in ONE place (the seam), not duplicated.
 
 (defn- registry-value
   "The three input registries assembled from public surfaces: app-db
@@ -414,7 +414,7 @@
   ;; The test-only override seam (`:rf.xray.static.schemas/set-registry-
   ;; override-for-test` + the `*-override` sub) is NOT installed here —
   ;; production registration carries no `-for-test` ids. Tests opt into
-  ;; it via `install-test-overrides!` (rf2-e8330v / xxo3zz F3).
+  ;; it via `install-test-overrides!`.
 
   ;; ---- production data sub ---------------------------------------------
 
@@ -445,8 +445,7 @@
     (fn [[{:keys [schemas-by-frame events subs]} observed-frame query] _query]
       (project-data schemas-by-frame events subs observed-frame query)))
 
-  ;; rf2-2moh1 — register the Static Schemas tab with the internal L4
-  ;; tab registry.
+  ;; Register the Static Schemas tab with the internal L4 tab registry.
   (panel-registry/reg-l4-tab!
     {:id    :schemas
      :label "Schemas"
@@ -457,7 +456,7 @@
 
   nil)
 
-;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+;; ---- test-only override seam --------------------------------------------
 
 (defn install-test-overrides!
   "Install the Static Schemas panel's test-only override seam — the

--- a/tools/xray/src/day8/re_frame2_xray/static/shared/search_box.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shared/search_box.cljs
@@ -1,15 +1,14 @@
 (ns day8.re-frame2-xray.static.shared.search-box
   "Shared search-box + substring `filter-rows` algebra for the Static
-  surface's flat-catalogue sub-tabs (rf2-1keg3).
+  surface's flat-catalogue sub-tabs.
 
-  ## Why this exists (rf2-nesy9 dedup follow-on, Cluster 1 + 2)
+  ## What it provides
 
   Five Static sub-tabs each grow a flat searchable catalogue — Flows,
   Interceptors, Schemas, Routes (the browse list), and Machines (the
-  browse list). Before this ns they each carried a private
-  `defn- search-box` that re-implemented the same skeleton: an
-  `<input>` dispatching a `set-query` event on every keystroke, wrapped
-  in a header row. Two layout variants existed:
+  browse list). They all render their search affordance through this one
+  component: an `<input>` dispatching a `set-query` event on every
+  keystroke, wrapped in a header row. Two layout variants are offered:
 
     - the `:catalogue` variant (Flows / Interceptors / Schemas /
       Routes) — a flex row with a `Search` label and a right-aligned
@@ -21,12 +20,11 @@
       `aria-label`, with no count chip (Machines surfaces its count in a
       separate toolbar).
 
-  Folding the five into one component drops each call-site from ~40 LoC
-  to ~6 and makes a UX change to the search affordance a one-file edit.
-  The two variants keep each call-site's exact rendered markup — this is
-  a pure refactor, zero visual change.
+  A single component keeps every call-site at ~6 LoC and makes a UX
+  change to the search affordance a one-file edit. Each variant renders
+  its call-site's exact markup.
 
-  ## Frame-correctness (rf2-1w07r EPIC / rf2-nesy9)
+  ## Frame-correctness
 
   The input's keystroke dispatch is an OUT-OF-RENDER affordance: it
   fires after render unwinds, when the ambient frame is gone, so a bare

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -1,10 +1,9 @@
 (ns day8.re-frame2-xray.static.shell
-  "Xray's Static surface — 3-layer chrome (rf2-o5f5f.1).
+  "Xray's Static surface — 3-layer chrome.
 
   ## Static = Xray-in-a-quieter-key
 
-  Per the parent epic rf2-o5f5f architectural lock + the audit at
-  rf2-zhrwo: Static shares Dynamic's full design language — Inter +
+  Static shares Dynamic's full design language — Inter +
   JetBrains Mono, the complete `theme/tokens.cljc` palette, the 4px
   spacing grid, Lucide-style ASCII glyphs, the 56px ribbon, the 40px
   tab-bar. Differentiation is temperature, not vocabulary.
@@ -56,8 +55,8 @@
 
   ## Tab inventory (5 sub-tabs)
 
-  The Static surface mounts five sub-tabs. Each sibling bead installs
-  its own panel into the L4 tab registry (rf2-2moh1):
+  The Static surface mounts five sub-tabs. Each panel installs
+  its own entry into the L4 tab registry:
 
       Machines (m, default) · Routes (r) · Schemas (c) · Flows (f) ·
       Interceptors (i)
@@ -67,12 +66,10 @@
   Machines instance inspector, `m` in Static opens the Machines
   registry browse).
 
-  rf2-b2fif removed the standalone Static Views + Events sub-tabs —
-  the info those sub-tabs surfaced is already in the source code; the
-  tabs were not pulling their weight.
+  Static has no standalone Views or Events sub-tabs — the information
+  those would surface already lives in the source code.
 
-  Tab-mnemonic mode-scoping lives in `static/keybinding.cljs`
-  follow-on — Phase 1 ships only the click path.
+  Tab-mnemonic mode-scoping lives in `static/keybinding.cljs`.
 
   ## Frame isolation
 
@@ -80,8 +77,8 @@
   in `[rf/frame-provider-existing {:frame :rf/xray}]`; every subscribe +
   dispatch inside the shell resolves to `:rf/xray`. Every subscribing
   region is `reg-view`-registered so its rendered component carries
-  `:contextType frame-context` (rf2-in6l2 + Spec 004 §Plain Reagent
-  fns do not pick up the surrounding frame).
+  `:contextType frame-context` (Spec 004 §Plain Reagent fns do not
+  pick up the surrounding frame).
 
   ## Mode-signal mechanism (4 stacked signals)
 
@@ -92,10 +89,9 @@
        lives at ribbon-left in BOTH modes (it's the toggle, not the
        indicator).
     2. **2-px left-edge ribbon stripe** — the single `:accent` (GitHub
-       blue) in both modes (rf2-ad7zx.13: the Figma export carries one
-       accent, no per-mode colour swap). Owned by both shells via the
-       explicit `mode-stripe-colour` arg passed into the ribbon's outer
-       div.
+       blue) in both modes (the Figma export carries one accent, no
+       per-mode colour swap). Owned by both shells via the explicit
+       `mode-stripe-colour` arg passed into the ribbon's outer div.
     3. **Motion dampening** — Dynamic ships the LIVE pulse + machine-
        active pulse + 180ms tab fade. Static drops the continuous
        pulses entirely; the 180ms tab fade collapses to 0ms (instant)
@@ -103,34 +99,34 @@
     4. **Chrome silhouette** — Dynamic is 4-layer; Static is 3-layer
        (no L2 / no spine). The shape itself is a signal.
 
-  ## Sibling beads filling the tab inventory
+  ## Tab panels
 
-  Each sibling bead owned its sub-tab panel:
+  Each sub-tab is backed by its own panel:
 
-    - rf2-o5f5f.2 — Machines registry browse + Topology
-    - rf2-o5f5f.3 — Routes registry browse + Simulate-URL
-    - rf2-o5f5f.4 — Schemas registry browse + sample data
-    - rf2-uhsqb   — Flows registry browse
-    - rf2-o5f5f.6 — Interceptors lens"
+    - Machines     — registry browse + Topology
+    - Routes       — registry browse + Simulate-URL
+    - Schemas      — registry browse + sample data
+    - Flows        — registry browse
+    - Interceptors — lens"
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.mode-pill :as mode-pill]
-            ;; Static panel views (Machines / Routes / Schemas / Views /
-            ;; Flows) are pulled in via the L4 tab registry — each
-            ;; panel's `install!` registers `{:panel <view-fn>}` with
-            ;; `panel-registry/reg-l4-tab!` (rf2-2moh1) and
-            ;; `detail-panel` reaches the entry through
-            ;; `panel-registry/tab-by-id :static`. The shell no longer
-            ;; requires those panel nses directly.
+            ;; Static panel views (Machines / Routes / Schemas /
+            ;; Flows / Interceptors) are pulled in via the L4 tab
+            ;; registry — each panel's `install!` registers
+            ;; `{:panel <view-fn>}` with `panel-registry/reg-l4-tab!`
+            ;; and `detail-panel` reaches the entry through
+            ;; `panel-registry/tab-by-id :static`. The shell does not
+            ;; require those panel nses directly.
             [day8.re-frame2-xray.theme.tokens
              :as t
              :refer [tokens type-scale layout sans-stack]]))
 
 ;; ---- tab inventory ------------------------------------------------------
 ;;
-;; Per rf2-2moh1 the Static-mode L3 tab inventory now lives in the
-;; internal `panel-registry`. Each Static panel's `install!` registers
+;; The Static-mode L3 tab inventory lives in the internal
+;; `panel-registry`. Each Static panel's `install!` registers
 ;; its own tab metadata (`{:modes #{:static} :order ...}`); the
 ;; helpers below read the registry so external callers (registry.cljs
 ;; for `:rf.xray.static/select-tab`'s contains? guard, tests asserting
@@ -146,10 +142,8 @@
   Static surface; opening Static on a fresh slate should land on the
   highest-value tab) — see `default-tab` below.
 
-  Per rf2-2moh1 this changed shape from a literal `def` vector to a
-  zero-arg `defn` reading the registry. Callers must invoke
-  `(static-shell/tabs)` not bare `static-shell/tabs` — `:no-back-
-  compat` pre-alpha posture."
+  A zero-arg `defn` reading the registry. Callers must invoke
+  `(static-shell/tabs)` not bare `static-shell/tabs`."
   []
   (panel-registry/tabs-for-mode :static))
 
@@ -172,28 +166,28 @@
 (def dynamic-stripe-token
   "Token-key for the Dynamic mode's 2-px left-edge ribbon stripe per
   the parent-epic mode-signal mechanism (signal #2). Held as a token
-  KEY (not the resolved hex) so per-theme palette switching (rf2-
-  5kfxe.6 light theme) flows through naturally.
+  KEY (not the resolved hex) so per-theme palette switching (light
+  theme) flows through naturally.
 
-  Post rf2-ad7zx.13 the Figma export carries a SINGLE accent (GitHub
-  blue), so the stripe paints `:accent` in BOTH modes — there is no
-  per-mode accent colour swap. The Dynamic/Static MODE stays functional
-  (it drives motion/pulse), it just no longer drives stripe colour."
+  The Figma export carries a SINGLE accent (GitHub blue), so the
+  stripe paints `:accent` in BOTH modes — there is no per-mode accent
+  colour swap. The Dynamic/Static MODE drives motion/pulse, not stripe
+  colour."
   :accent)
 
 (def static-stripe-token
   "Token-key for the Static mode's 2-px left-edge ribbon stripe per
-  the parent-epic mode-signal mechanism (signal #2). Post rf2-ad7zx.13
-  this is the single `:accent` (GitHub blue) — same as Dynamic; the
-  Figma export has no per-mode accent colour swap."
+  the parent-epic mode-signal mechanism (signal #2). The single
+  `:accent` (GitHub blue) — same as Dynamic; the Figma export has no
+  per-mode accent colour swap."
   :accent)
 
 (defn stripe-token-for-mode
   "Pure helper. Returns the token KEY (`:accent`) the L1 ribbon should
-  paint as its 2-px left-edge stripe for the given mode. Post
-  rf2-ad7zx.13 both modes resolve to the single `:accent` (the Figma
-  export's one blue accent). JVM-portable so the test corpus can cover
-  the round-trip without a CLJS runtime."
+  paint as its 2-px left-edge stripe for the given mode. Both modes
+  resolve to the single `:accent` (the Figma export's one blue
+  accent). JVM-portable so the test corpus can cover the round-trip
+  without a CLJS runtime."
   [mode]
   (case mode
     :static  static-stripe-token
@@ -215,7 +209,7 @@
   the Static shell stays self-contained and we don't form a cycle by
   reaching back into the Dynamic ns.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
+  `dispatch` is the frame-aware dispatcher captured by the
   `ribbon` reg-view body so the settings / close clicks land on the
   surrounding instance frame, not a `{:frame :rf/xray}` literal."
   [dispatch]
@@ -241,12 +235,12 @@
       "✕"]]))
 
 (rf/reg-view ribbon
-  "L1 ribbon — 56px chrome, Static-flavoured. Per parent-epic rf2-
-  o5f5f mode-signal mechanism the ribbon paints a 2-px left-edge
-  stripe in CYAN (Static) vs VIOLET (Dynamic). Mode pill sits at
-  ribbon-left; the L1 frame-switcher sits between mode-pill and the
-  right-icons cluster; right-icons (Settings · Close) sit at ribbon-
-  right.
+  "L1 ribbon — 56px chrome, Static-flavoured. Per the parent-epic
+  mode-signal mechanism the ribbon paints a 2-px left-edge stripe in
+  the single `:accent` (GitHub blue), same in both modes. Mode pill
+  sits at ribbon-left; the L1 frame-switcher sits between mode-pill and
+  the right-icons cluster; right-icons (Settings · Close) sit at
+  ribbon-right.
 
   The frame picker is MODE-INDEPENDENT — Static is also frame-scoped
   (registrations — events · subs · machines · routes · schemas · flows
@@ -258,8 +252,7 @@
   Static — those clusters are spine-coupled and have no meaning in an
   event-independent surface.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
+  `reg-view`-registered so subscribes resolve to `:rf/xray`."
   [_props]
   [:div {:data-testid "rf-xray-static-ribbon"
          :style {:display          "flex"
@@ -274,7 +267,7 @@
                  :font-family      sans-stack
                  :font-size        (:body type-scale)}}
    ;; LEFT cluster — scope selectors (Frame + Dynamic/Static), mirroring
-   ;; the Dynamic chrome ribbon's left cluster (rf2-4vp5j). The frame
+   ;; the Dynamic chrome ribbon's left cluster. The frame
    ;; picker is mode-INDEPENDENT — same contract as Dynamic's ribbon
    ;; (`shell.cljs/ribbon`): reads `:rf.xray/current-frame` +
    ;; `:rf.xray/available-frames`, writes via `:rf.xray/select-frame`.
@@ -293,20 +286,20 @@
 (defn- tab-button
   "One Static tab. Same `●` / `○` glyph language as the Dynamic
   `tab-button` (`shell.cljs/tab-button`) — design language is shared
-  per the rf2-zhrwo audit's 'Xray-in-a-quieter-key' framing.
+  under the 'Xray-in-a-quieter-key' framing.
 
-  Per the canonical chrome ARIA pattern (rf2-lvf8t / rf2-q7who Thread
-  B), the tab carries `role='tab'` + `aria-selected` so assistive
-  tech reads it as a tab, not a generic button."
+  Per the canonical chrome ARIA pattern, the tab carries `role='tab'` +
+  `aria-selected` so assistive tech reads it as a tab, not a generic
+  button."
   [dispatch {:keys [id label mnem active?]}]
-  ;; rf2-nesy9 — `dispatch` is the frame-bound `dispatch` injected by
+  ;; `dispatch` is the frame-bound `dispatch` injected by
   ;; the `tab-bar` reg-view body and threaded in here (a plain fn
   ;; invoked as a Reagent component renders in its OWN cycle, so
   ;; `current-frame-id` would fall through to :rf/default — threading the
   ;; injected `dispatch` is the reliable path).
   (let [glyph    (if active? "◉" "○")
         color    (if active? (:text-primary tokens) (:text-secondary tokens))
-        ;; rf2-plajx — mirror the Dynamic tab-button pattern: stable
+        ;; Mirror the Dynamic tab-button pattern: stable
         ;; tab-id + matching tabpanel id so the L4 panel's
         ;; `aria-labelledby` resolves.
         tab-id   (str "rf-xray-static-tab-button-" (name id))
@@ -332,7 +325,7 @@
                       :font-size     (:body type-scale)
                       :font-weight   (if active? 600 400)
                       :white-space   "nowrap"}}
-     ;; rf2-vxpq1 — `aria-hidden` on decorative ●/○ glyph.
+     ;; `aria-hidden` on decorative ●/○ glyph.
      [:span {:aria-hidden "true"
              :style {:color (if active?
                               (:accent tokens)
@@ -347,8 +340,7 @@
   Static-scoped (`:rf.xray.static/selected-tab`) so flipping modes
   doesn't clobber the Dynamic tab choice and vice-versa.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
+  `reg-view`-registered so subscribes resolve to `:rf/xray`."
   []
   (let [selected @(rf/subscribe [:rf.xray.static/selected-tab])]
     [:div {:data-testid "rf-xray-static-tab-bar"
@@ -362,39 +354,37 @@
                    :background    (:bg-1 tokens)
                    :border-top    (str "1px solid " (:border-subtle tokens))
                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
-     ;; rf2-2moh1 — iterate the registry's static-mode entries.
+     ;; iterate the registry's static-mode entries.
      (for [{:keys [id] :as tab} (tabs)]
        ^{:key id}
        [tab-button dispatch (assoc tab :active? (= id selected))])]))
 
 ;; ---- L4 detail panel ----------------------------------------------------
 ;;
-;; rf2-o5f5f roll-out complete (rf2-sdqsla): all five Static sub-tabs ship
-;; a real panel, so the unfilled-tab `placeholder-card` scaffold was
-;; removed. `detail-panel` always mounts the selected tab's `:panel` view;
-;; an unknown `:selected-tab` falls through to the unknown-tab stub.
+;; All five Static sub-tabs ship a real panel. `detail-panel` always
+;; mounts the selected tab's `:panel` view; an unknown `:selected-tab`
+;; falls through to the unknown-tab stub.
 
 (rf/reg-view detail-panel
-  "L4 detail panel — registry-driven mount (rf2-2moh1).
+  "L4 detail panel — registry-driven mount.
 
   Each Static panel's `install!` registers its tab entry via
   `panel-registry/reg-l4-tab!` with `:modes #{:static}` + a `:panel`
   view fn. The Static-mode L4 tabs are:
 
-    :machines     → `static.machines.panel/panel`         (rf2-o5f5f.2)
-    :routes       → `static.routes.panel/Panel`           (rf2-o5f5f.3)
-    :schemas      → `static.schemas.panel/Panel`          (rf2-o5f5f.4)
-    :flows        → `static.flows.panel/Panel`            (rf2-uhsqb)
-    :interceptors → `static.interceptors.panel/Panel`     (rf2-o5f5f.6)
+    :machines     → `static.machines.panel/panel`
+    :routes       → `static.routes.panel/Panel`
+    :schemas      → `static.schemas.panel/Panel`
+    :flows        → `static.flows.panel/Panel`
+    :interceptors → `static.interceptors.panel/Panel`
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
+  `reg-view`-registered so subscribes resolve to `:rf/xray`."
   []
   (let [selected (or @(rf/subscribe [:rf.xray.static/selected-tab])
                      default-tab)
         tab      (panel-registry/tab-by-id :static selected)]
     [:div {:data-testid (str "rf-xray-static-detail-panel-" (name selected))
-           ;; rf2-plajx — Static L4 closes the tab/tabpanel loop.
+           ;; Static L4 closes the tab/tabpanel loop.
            ;; Pairs with the per-tab `id` set by `tab-button` so
            ;; assistive tech reads the panel as "labelled by <tab
            ;; name>". Same shape as the Dynamic detail-panel.
@@ -423,8 +413,7 @@
   frame-provider + global-styles install + modal mounts; this surface
   just renders the chrome that swaps in when Static mode is active.
 
-  Per rf2-in6l2 `reg-view`-registered for parity with every other
-  shell region."
+  `reg-view`-registered for parity with every other shell region."
   []
   [:div {:data-testid "rf-xray-static-surface"
          :data-rf-xray-mode "static"

--- a/tools/xray/src/day8/re_frame2_xray/theme/a11y.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/a11y.cljs
@@ -1,18 +1,15 @@
 (ns day8.re-frame2-xray.theme.a11y
-  "Shared accessibility helpers (rf2-7389r).
+  "Shared accessibility helpers.
 
   Xray ships six modal surfaces (Settings, Share, Spine-filter mute
   manager, Filter edit-popup, Cancellation-cascade popover, App-DB
-  segment-inspector popover). The P2 a11y audit (`ai/findings/2026-
-  05-20-xray-story-a11y-audit.md` Finding #3) flagged that none of
-  them carry the WAI-ARIA modal contract end-to-end — `role=\"dialog\"`
-  + `aria-modal=\"true\"` + an accessible name + focus capture on
-  open.
+  segment-inspector popover). Each carries the WAI-ARIA modal contract
+  end-to-end — `role=\"dialog\"` + `aria-modal=\"true\"` + an accessible
+  name + focus capture on open.
 
-  Rather than copy the contract into every modal (drift risk — the
-  audit observed exactly this drift already, with each modal sliding
-  away from a coherent ARIA story), this ns extracts the small bits
-  the six call sites share.
+  Rather than copy that contract into every modal (drift risk — each
+  modal would slide away from a coherent ARIA story), this ns is the
+  single source of truth the six call sites share.
 
   ## What lives here
 

--- a/tools/xray/src/day8/re_frame2_xray/theme/modal_chrome.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/modal_chrome.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.theme.modal-chrome
-  "Shared modal-chrome scaffold (rf2-7oxvd).
+  "Shared modal-chrome scaffold.
 
   ALL EIGHT of Xray's modal surfaces — Settings, Filter edit-popup,
   Share, Mute manager, App-DB segment-inspector, EDN-inspector popup,
@@ -12,7 +12,7 @@
   and the SAME boring-but-load-bearing wiring on each:
 
     * the `data-rf-xray-modal-positioning` attribute derived from the
-      `:rf.xray/modal-positioning` opt (rf2-om6fa);
+      `:rf.xray/modal-positioning` opt;
     * a click-to-dismiss `:on-click` on the backdrop + a
       `(.stopPropagation %)` `:on-click` on the dialog so clicks on
       the dialog body don't bubble out and close it;
@@ -21,7 +21,7 @@
       `a11y/dialog-ref` focus-trap callback (focus-on-open, Tab-trap,
       restore-on-close).
 
-  ## Design — slots, not flags (rf2-7oxvd, Option C)
+  ## Design — slots, not flags
 
   This ns extracts ONLY that genuinely-identical scaffold. Everything
   that varies between modals stays a value the caller SUPPLIES — never
@@ -44,10 +44,10 @@
       `:dialog-extra` (merged last so the caller can override anything,
       including the testid).
 
-  ## The palette is a caller too (rf2-7oxvd, Option A)
+  ## The palette is a caller too
 
-  The command palette (`palette/view`) was the eighth and last modal
-  to adopt this scaffold. Its apparent divergences all land cleanly on
+  The command palette (`palette/view`) renders through this scaffold.
+  Its apparent divergences all land cleanly on
   the existing slots — no per-palette flag, no new slot:
 
     * always-`:fixed` (no `:rf.xray/modal-positioning` subscribe) → it
@@ -58,24 +58,22 @@
     * its hand-rolled combobox/listbox ARIA stays in the `children`
       (the dialog-level role/aria-modal/accessible-name comes from
       `a11y/dialog-attrs` via `:label`, exactly the contract its
-      `palette/aria-cljs-test` already asserts).
+      `palette/aria-cljs-test` asserts).
 
-  Adopting the chrome ALSO gives the palette the `a11y/dialog-ref`
-  focus trap it previously lacked — a strict a11y improvement. The
-  trap intercepts only Tab/Shift+Tab, and the palette's sole focusable
-  is the input (rows drive a virtual `aria-activedescendant` cursor,
-  not real focus), so Tab wraps to the input and the arrow-key
-  navigation is untouched. (Earlier partial passes left the palette
-  out under the C-stance; Mike ruled Option A — full consolidation.)
+  The chrome gives the palette the `a11y/dialog-ref`
+  focus trap. The trap intercepts only Tab/Shift+Tab, and the palette's
+  sole focusable is the input (rows drive a virtual
+  `aria-activedescendant` cursor, not real focus), so Tab wraps to the
+  input and the arrow-key navigation is untouched.
 
   ## Tab-index
 
   `dialog-ref`'s focus-on-open fallback focuses the dialog ROOT when
   the dialog has no focusable child, which requires the root to carry a
   `tab-index`. Modals supply their own value (`\"-1\"` for the
-  text-style modals, `0` for the popovers that were tab-index 0
-  pre-rf2-7389r) via `:dialog-tab-index`; the backdrop's optional
-  `:backdrop-tab-index` mirrors the popovers' existing `-1` root."
+  text-style modals, `0` for the popovers) via `:dialog-tab-index`; the
+  backdrop's optional `:backdrop-tab-index` mirrors the popovers' `-1`
+  root."
   (:require [day8.re-frame2-xray.theme.a11y :as a11y]))
 
 (defn modal-chrome

--- a/tools/xray/src/day8/re_frame2_xray/theme/perf_tier.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/perf_tier.cljc
@@ -2,42 +2,27 @@
   "Shared perf-tier classification — the canonical duration→tier→colour
   ladder per `tools/xray/spec/007-UX-IA.md` §Colour system §Perf scale.
 
-  ## Why this lives in `theme/` (rf2-6ja23)
+  ## Why this lives in `theme/`
 
   Inspired by Vue DevTools 3's colour-coded lifecycle hook durations
   (green ≤10ms / yellow >10ms / red >30ms). Spec/007-UX-IA.md
   §'Colour system' defines four tiers — `:fast` / `:medium` / `:slow`
   / `:blocking` (<16 / 16-50 / 50-100 / >100ms, where 100ms is the
   INP-blocking threshold). Every node carrying a measurable duration
-  should surface the tier-coloured dot the same way: same hex, same
+  surfaces the tier-coloured dot the same way: same hex, same
   glyph shape, same label string.
 
-  Originally the tier helpers were buried in
-  `panels/performance_helpers.cljc` and used only by the Performance
-  panel. The audit bead rf2-6ja23 found that:
-
-    - `event_detail` already surfaces `:duration-ms` on the handler row
-      (as raw EDN text — no tier dot).
-    - Every other panel that will eventually show per-node durations
-      (`subscriptions` sub-run timings, `effects` fx-handler timings,
-      `machine_inspector` guard-eval timings, `time_travel` cascade
-      span) is blocked on the trace stream carrying per-event
-      `:duration-ms`. Spec 009 L38: 'no separate start/end pair,
-      no :duration, no duration-ms tag'.
-
-  Hoisting the helpers to `theme/perf_tier.cljc` makes them
+  The classification ladder is design-system grade — one source of
+  truth, spec-anchored, JVM-portable — so it lives in `theme/` and is
   discoverable from anywhere in `panels/` without a cross-panel
-  require chain. The Performance panel re-exports from here (no
-  behaviour change) so existing call-sites keep working.
+  require chain. The Performance panel re-exports from here.
 
-  ## Audit ledger — panels that DO / DO NOT yet show tier dots
-
-  Last reviewed 2026-05-14 against the Phase 5 panel set.
+  ## Panel ledger — surfaces that DO / DO NOT yet show tier dots
 
     Panel                Surface that should carry the tier-dot   Status
     -----                --------------------------------------   ------
     performance          cascade-row, breakdown-bar, tier-chip    LIVE
-    event_detail         handler-row :duration-ms slot            LIVE (rf2-6ja23)
+    event_detail         handler-row :duration-ms slot            LIVE
     subscriptions        per-sub :duration-ms (run timings)       blocked on trace-stream
     effects              per-fx :duration-ms (handler timings)    blocked on trace-stream
     machine_inspector    guard-eval :duration-ms                  blocked on trace-stream
@@ -50,10 +35,6 @@
   this by computing `(max :time) - (min :time)` across cascade
   slices, which is a cheap proxy at the cascade level but doesn't
   attribute per-handler / per-sub.
-
-  Hoisting to `theme/` is the audit's structural finding: the
-  classification ladder is design-system grade (one source of truth,
-  spec-anchored, JVM-portable), not panel-local.
 
   ## Pure data, JVM-portable
 
@@ -107,7 +88,7 @@
 (defn tier-colour
   "Hex swatch per perf tier. Resolves the semantic token keyword
   (`tier->token`) through the canonical `theme/tokens` map so the
-  palette has exactly one source of truth (rf2-5kfxe.4). Falls back
+  palette has exactly one source of truth. Falls back
   to `:text-tertiary` for unknown tiers."
   [tier]
   (get tokens/tokens

--- a/tools/xray/src/day8/re_frame2_xray/theme/section.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/section.cljc
@@ -1,19 +1,18 @@
 (ns day8.re-frame2-xray.theme.section
-  "Shared stacked-section primitive (rf2-pie8q).
+  "Shared stacked-section primitive.
 
   Xray panels use a uniform rhythm of stacked sections — small upper-
   cased header (`▼ SECTION TITLE`) followed by a body, separated from
   the next section by a 1px dotted horizontal rule. The visual contract
-  is documented in `tools/xray/spec/007-UX-IA.md` and was reinvented
-  twice — once in `panels/managed_fx_template/section` (rf2-uyp86) and
-  again in `panels/event_detail/section` (rf2-zh2qc PR #1480). Both
-  invented identical typography (sans-stack, 11px, weight 600, letter-
-  spacing 0.6px, uppercase, `:text-secondary`) and identical body
-  styling (mono-stack, 12px, `:text-primary`, 6px/0/0/18px padding).
+  is documented in `tools/xray/spec/007-UX-IA.md`: the header is
+  typeset sans-stack, 11px, weight 600, letter-spacing 0.6px,
+  uppercase, `:text-secondary`; the body is mono-stack, 12px,
+  `:text-primary`, 6px/0/0/18px padding.
 
-  Hoisting the shape here gives the two consumers a single source of
-  truth so a future rhythm tweak (a tighter letter-spacing, say, or a
-  swap of the dotted rule for a solid one) lands in one place.
+  This is the single source of truth for the shape — both
+  `panels/managed_fx_template/section` and `panels/event_detail/section`
+  render through it, so a rhythm tweak (a tighter letter-spacing, say,
+  or a swap of the dotted rule for a solid one) lands in one place.
 
   ## Shape
 
@@ -52,8 +51,8 @@
 
     - No interactivity. Click-to-toggle wiring is the caller's
       responsibility — the primitive only renders the visual state the
-      caller passes via `:expanded?`. (Per the bead: 'sans tone-key,
-      with collapse glyph'.)
+      caller passes via `:expanded?` (sans tone-key, with the collapse
+      glyph).
     - No body-shape opinions. The body argument is opaque hiccup.
     - No section-stacking helper. Callers compose by listing sections
       inline; the dotted bottom border draws the rhythm."

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1,6 +1,6 @@
 (ns day8.re-frame2-xray.views.edn-inspector
   "Xray's first-class edn-inspector widget — roll-your-own CLJS-value
-  renderer (rf2-oqa60 phase 1).
+  renderer.
 
   ## What this is
 
@@ -11,20 +11,16 @@
   token variables so light + dark themes resolve at paint time
   without a re-render.
 
-  ## What replaces what
+  ## What this widget owns
 
-  - `views/edn-widget` — superseded for current-state browse
-    (phase 1 wires the App-DB panel here directly; phases 2-5 migrate
-    the remaining call sites).
-  - `theme/data-inspector` — sentinels (`:rf/redacted`,
-    `:rf.size/large-elided`) become first-class types INSIDE this
-    widget; the chrome wrapper goes away (D3=a per rf2-sndui).
-  - `edn-inspector/render` — diff renderer subsumed (phase 5; D5=a per
-    rf2-sndui). The diff path is now an opt-in mode on this same
-    widget — pass `:before` to render with gutter glyphs +
-    `← was <prior>` annotations.
-  - `binaryage/cljs-devtools` dep — dropped from the project; this
-    widget renders CLJS values natively from CLJS itself (rf2-oqa60).
+  - Current-state browse for every call site (the App-DB panel and the
+    rest mount this widget directly).
+  - Sentinels (`:rf/redacted`, `:rf.size/large-elided`) as first-class
+    types — chip chrome rendered inline, no separate wrapper.
+  - Diff rendering as an opt-in mode on the same widget — pass `:before`
+    to render with gutter glyphs + `← was <prior>` annotations.
+  - Native CLJS-value rendering, classified from CLJS itself with no
+    external devtools dependency.
 
   ## Public API
 
@@ -40,7 +36,7 @@
 
   - `:panel-id`     (optional, default `:rf.xray.edn-inspector/anon`)
                     distinguishes per-panel expansion state.
-  - `:site-id`      (optional, rf2-pvsxs) — when supplied, becomes the
+  - `:site-id`      (optional) — when supplied, becomes the
                     second component of the per-node expansion key
                     INSTEAD of the auto-generated mount-id. Lets the
                     same logical call site survive a panel-leave-and-
@@ -48,20 +44,18 @@
                     a stable site-id does not). Omit to keep the per-
                     call-site isolation default (two `[edn-inspector]`
                     mounts side-by-side stay independent).
-  - `:default-expanded-depth` (optional, default 8) — rf2-kbdk8: now an
-                    EXPAND CEILING rather than a trigger. The widget
-                    NEVER auto-expands past this depth — deeper nodes
-                    render as a `▸ {…N keys}` collapsed summary unless
-                    the operator clicks. Under the width-aware
-                    heuristic shallow nodes inline whenever their full
-                    `pr-str` fits the measured column; the depth ceiling
-                    only protects against pathological wide-and-deep
-                    auto-expansion when measurements are unavailable.
-                    Default raised from 2 → 8 to reflect the new
-                    semantic; tests that explicitly pass
-                    `:default-expanded-depth 2` (or any number) get the
-                    legacy depth-driven behaviour unchanged when no
-                    width measurement has arrived.
+  - `:default-expanded-depth` (optional, default 8) — an EXPAND
+                    CEILING. The widget NEVER auto-expands past this
+                    depth — deeper nodes render as a `▸ {…N keys}`
+                    collapsed summary unless the operator clicks. Under
+                    the width-aware heuristic shallow nodes inline
+                    whenever their full `pr-str` fits the measured
+                    column; the depth ceiling only protects against
+                    pathological wide-and-deep auto-expansion when
+                    measurements are unavailable. When no width
+                    measurement has arrived the depth-driven path runs:
+                    any explicit value (e.g.
+                    `:default-expanded-depth 2`) drives that fallback.
   - `:max-inline-width` (optional, default 60) — character budget for
                     the COLLAPSED-PREVIEW one-liner (`▸ {:a 1, :b 2,
                     …}` style); leaves the width-aware inline decision
@@ -82,7 +76,7 @@
                     expand heuristic. With no `:before` (and no
                     `:added?`) the same renderer shows `value` plainly —
                     no annotations, no rail, no chip.
-  - `:added?` (optional, default false) — rf2-kp7bw FIRST-RUN signal: a
+  - `:added?` (optional, default false) — FIRST-RUN signal: a
                     value that just came into existence (a sub's first
                     cache entry, an app-db key that just appeared) with
                     no prior value to diff against. Synthesises the
@@ -90,25 +84,22 @@
                     whole tree classifies as `:added` (green wash + `+`
                     chrome over every descendant). An explicit `:before`
                     always wins; empty containers still read `:added`.
-  - `:popup-affordance?` (optional, default false) — rf2-l4625; when
-                    true the widget renders a top-right ↗ icon button
-                    (rf2-7sdja — was ⊕; ↗ reads as 'open in new pane')
-                    that dispatches
+  - `:popup-affordance?` (optional, default false) — when true the
+                    widget renders a top-right ↗ icon button (reads as
+                    'open in new pane') that dispatches
                     `[:rf.xray.edn-inspector-popup/open mount-id payload]`
                     through the captured frame-aware dispatcher so the
                     popup-open write lands on the surrounding instance
-                    frame (rf2-r0o63 — supersedes the rf2-7sdja
-                    `:rf/xray` literal pin; N shells stay isolated). The
-                    popup-mount-id is derived from this widget's own mount-
-                    id, so re-clicking raises the existing popup rather
-                    than spawning a duplicate. Opt-in per call-site;
-                    panels enable the affordance where the inline
-                    widget is genuinely cramped (machine snapshots,
-                    sub values, trace payloads). App-DB does NOT use
-                    the affordance (rf2-7sdja — App-DB has plenty of
-                    horizontal room; the popup would be unnecessary
-                    affordance noise).
-  - `:card?`         (optional, default false) — rf2-63ie5; when true
+                    frame (N shells stay isolated). The popup-mount-id
+                    is derived from this widget's own mount-id, so
+                    re-clicking raises the existing popup rather than
+                    spawning a duplicate. Opt-in per call-site; panels
+                    enable the affordance where the inline widget is
+                    genuinely cramped (machine snapshots, sub values,
+                    trace payloads). App-DB does NOT use the affordance
+                    — it has plenty of horizontal room, so the popup
+                    would be unnecessary affordance noise.
+  - `:card?`         (optional, default false) — when true
                     the widget's outer container carries the inspector-
                     card chrome (background `:bg-1`, 1px `:border-
                     default` border, `8px` radius, `8px 10px` padding,
@@ -122,11 +113,11 @@
                     panels with multiple top-level inspector mounts
                     (App-DB's TOP + per-`:rf/*` sections; Handler's
                     side-by-side event-detail mounts) opt in.
-  - `:header`        (optional, default nil) — rf2-okq7p; opt-in
+  - `:header`        (optional, default nil) — opt-in
                     three-shade card chrome (outer `<section>` →
                     `<header>` ribbon → body sleeve), modelled on the
                     Machine panel's `focused-event-section`. `nil`
-                    renders inline as today. A string renders a
+                    renders inline. A string renders a
                     plain-label ribbon. Hiccup renders whatever the
                     consumer composes (label + code chip + per-
                     inspector affordances). The widget treats the
@@ -150,16 +141,14 @@
                     its own surface chrome, so `:card?` is usually
                     redundant when `:header` is present).
 
-  - `:zoomable?`     (optional, default false) — rf2-h71e0; gesture
-                    reworked rf2-zl4rs. When true every non-root
-                    container becomes a zoom-in TARGET: double-click
-                    (or Enter while the node is keyboard-focused)
-                    re-roots the inspector onto that node. There is no
-                    longer a `⊙` glyph button — the gesture lives on
-                    the container itself, which carries `tab-index 0` +
-                    an `aria-label` so the keyboard + screen-reader
-                    affordance the glyph button used to provide is
-                    preserved. The gesture dispatches
+  - `:zoomable?`     (optional, default false) — when true every
+                    non-root container becomes a zoom-in TARGET:
+                    double-click (or Enter while the node is keyboard-
+                    focused) re-roots the inspector onto that node. The
+                    gesture lives on the container itself, which carries
+                    `tab-index 0` + an `aria-label` so the keyboard +
+                    screen-reader affordance is available. The gesture
+                    dispatches
                     `[:rf.xray.edn-inspector/zoom-to panel-id mount-id
                     absolute-path]`, which stores the absolute path
                     under `:rf.xray.edn-inspector/zoom` keyed by
@@ -169,9 +158,9 @@
                     root (each segment clickable for one-tap zoom-up).
                     Esc (when the widget has focus AND a zoom is
                     active) pops one level off the zoom stack.
-                    Zoom applies in the SINGLE full+diff renderer
-                    (rf2-e28r3 / rf2-zl4rs): the re-root walks `value`
-                    always and `before` too when a pre-image is present,
+                    Zoom applies in the SINGLE full+diff renderer: the
+                    re-root walks `value` always and `before` too when a
+                    pre-image is present,
                     so the diff rail / chip / inline annotations paint
                     relative to the zoomed subtree. A zoom into a wholly
                     `:added` subtree re-roots both halves so the whole
@@ -182,10 +171,10 @@
                     pass a stable `:site-id` to survive a panel-leave-
                     and-return round-trip.
 
-  Drop the `:render-id` arg from the old facade — mount-id is now
-  auto-generated internally per D4=a (rf2-sndui).
+  There is no `:render-id` arg — the mount-id is auto-generated
+  internally.
 
-  ## Per-call-site isolation (rf2-sndui D4=a · rf2-pvsxs opt-out)
+  ## Per-call-site isolation
 
   Each `[edn-inspector …]` mount auto-assigns a UUID `mount-id` on
   first render (captured in a form-2 outer `let`). Two mounts side-
@@ -236,67 +225,64 @@
   | record           | `:info`            | `#user.Rec{` `}`         |
   | js object        | `:text-tertiary`   | `#object[` `]`           |
 
-  Per rf2-79ojx the per-type tokens were renamed + the palette retuned
-  to an editor-syntax-highlight scheme (One Dark / One Light). Five
-  scalar types now span four hue families: keyword magenta, string
-  green, number orange, boolean gold, nil grey."
+  The per-type tokens follow an editor-syntax-highlight scheme (One
+  Dark / One Light). Five scalar types span four hue families: keyword
+  magenta, string green, number orange, boolean gold, nil grey."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
-            ;; rf2-l42sg7 — expansion-state registration extracted to its
-            ;; own namespace (the `expansion-slot` key, its reg-sub, the
+            ;; Expansion-state registration lives in its own namespace
+            ;; (the `expansion-slot` key, its reg-sub, the
             ;; toggle/set/reset events, `expansion-key`, `resolve-expanded?`).
-            ;; Re-exported below so existing call sites + tests keep
-            ;; resolving against this widget namespace unchanged.
+            ;; Re-exported below so call sites + tests resolve against
+            ;; this widget namespace.
             [day8.re-frame2-xray.views.edn-inspector-state :as state]
             [day8.re-frame2-xray.views.edn-inspector-protocol :as ddp]
-            ;; rf2-n2jig — Editscript-backed diff projection engine.
-            ;; Replaces the home-grown leaf-walker classifier that
-            ;; used to live at lines 533-664 of this file. The
-            ;; engine produces `{:path-ops :container-ops :flat-rows
+            ;; Editscript-backed diff projection engine. Produces
+            ;; `{:path-ops :container-ops :flat-rows
             ;; :wholly-changed-roots :shift-suffix :vector-removals}`
             ;; — the renderer chrome below consumes it via
             ;; `engine/op-at`, `engine/wholly-changed-ancestor`,
             ;; `engine/shifted-was-index`, etc.
             [day8.re-frame2-xray.diff.engine :as engine]
-            ;; rf2-x16b1 — load default IXrayEdnInspector formatters
-            ;; for uuid + inst. Requiring for side-effect (extend-type).
-            ;; Consumers that extend the same types win — `extend-type`
-            ;; installs the most-recently-loaded impl.
+            ;; Load default IXrayEdnInspector formatters for uuid + inst.
+            ;; Requiring for side-effect (extend-type). Consumers that
+            ;; extend the same types win — `extend-type` installs the
+            ;; most-recently-loaded impl.
             [day8.re-frame2-xray.views.edn-inspector-default-formatters]))
 
 ;; =========================================================================
-;; expansion state — extracted to `views/edn-inspector-state` (rf2-l42sg7).
+;; expansion state — lives in `views/edn-inspector-state`.
 ;; The slot key, its reg-sub, the toggle/set/reset events, `expansion-key`,
-;; and `resolve-expanded?` now live there (it registers the same global
-;; event/sub ids). Re-exported here so call sites + tests keep resolving
-;; `edn-inspector/{expansion-slot,expansion-key,resolve-expanded?}`
-;; unchanged. The state ns lives in :rf.xray.edn-inspector/expansion under
-;; the SURROUNDING instance frame (the shell's frame-id; `:rf/xray` for the
-;; production singleton) — per-frame so N shells keep independent expansion.
+;; and `resolve-expanded?` live there (it registers the global
+;; event/sub ids). Re-exported here so call sites + tests resolve
+;; `edn-inspector/{expansion-slot,expansion-key,resolve-expanded?}`.
+;; The slot is :rf.xray.edn-inspector/expansion under the SURROUNDING
+;; instance frame (the shell's frame-id; `:rf/xray` for the production
+;; singleton) — per-frame so N shells keep independent expansion.
 ;; =========================================================================
 
 (def expansion-slot
-  "Re-export of `edn-inspector-state/expansion-slot` (rf2-l42sg7) — the
-  app-db slot holding the per-node expansion overrides. Public so the
-  consuming panel's reset affordance can clear it."
+  "Re-export of `edn-inspector-state/expansion-slot` — the app-db slot
+  holding the per-node expansion overrides. Public so the consuming
+  panel's reset affordance can clear it."
   state/expansion-slot)
 
 (def expansion-key
-  "Re-export of `edn-inspector-state/expansion-key` (rf2-l42sg7) — composes
-  the per-node expansion key. Pure data, JVM-portable."
+  "Re-export of `edn-inspector-state/expansion-key` — composes the
+  per-node expansion key. Pure data, JVM-portable."
   state/expansion-key)
 
 (def resolve-expanded?
-  "Re-export of `edn-inspector-state/resolve-expanded?` (rf2-l42sg7) — pure
+  "Re-export of `edn-inspector-state/resolve-expanded?` — pure
   projection returning whether THIS node renders expanded; the operator's
   sticky override (if present) wins."
   state/resolve-expanded?)
 
 ;; =========================================================================
 ;; available-width capture — per-mount measurement for the width-aware
-;; expansion heuristic (rf2-kbdk8)
+;; expansion heuristic
 ;; =========================================================================
 ;;
 ;; The widget measures its container's `clientWidth` via a `:ref` callback
@@ -311,7 +297,7 @@
 ;;
 ;; When no measurement is yet present (first render before the ref fires,
 ;; or a programmatic test render that doesn't mount), the widget falls
-;; back to the legacy strict inline-fit gate — the heuristic improvement
+;; back to the strict inline-fit gate — the heuristic improvement
 ;; is additive and graceful.
 
 (def widths-slot
@@ -337,20 +323,19 @@
       db)}))
 
 ;; =========================================================================
-;; zoom-into-node + breadcrumb navigation (rf2-h71e0; gesture reworked rf2-zl4rs)
+;; zoom-into-node + breadcrumb navigation
 ;; =========================================================================
 ;;
 ;; Zoom turns the inspector into a focused window onto an arbitrary subtree.
 ;; Operator double-clicks any container (or presses Enter while it is
-;; keyboard-focused, rf2-zl4rs); that node becomes the root of the displayed
-;; tree. There is no separate `⊙` glyph button — the gesture lives on the
-;; container itself. A breadcrumb trail at the top shows the path from the
-;; original root; clicking any segment zooms back to that level. Esc zooms
-;; out one level.
+;; keyboard-focused); that node becomes the root of the displayed
+;; tree. The gesture lives on the container itself. A breadcrumb trail at
+;; the top shows the path from the original root; clicking any segment
+;; zooms back to that level. Esc zooms out one level.
 ;;
 ;; State shape mirrors `expansion-slot` — keyed by `[panel-id site-or-
 ;; mount-id]` so two side-by-side mounts zoom independently and a stable
-;; `:site-id` (rf2-pvsxs) preserves the zoomed view across a panel-
+;; `:site-id` preserves the zoomed view across a panel-
 ;; leave-and-return round-trip:
 ;;
 ;;   {[:rf.xray/app-db [:rf.xray/app-db "top"]] [:cart :items]
@@ -516,24 +501,17 @@
 ;; diff mode — projection-aware chrome
 ;; =========================================================================
 ;;
-;; rf2-n2jig — Editscript-backed projection engine replaces the home-
-;; grown classifier wholesale (no shim, no transitional double-engine
-;; state). The 10 pre-existing fns (`diff-op` / `children-descendant?` /
-;; `op->gutter-glyph` / `op->gutter-tone-key` / `op->row-wash-key` /
-;; `op->row-stripe-key` / `gutter-colour` / `row-wash-bg` /
-;; `row-stripe-colour` / `container-op`) were retired here in favour of
-;; `day8.re-frame2-xray.diff.engine`'s pre-computed projection
-;; (`engine/project`) + the path-keyed lookup helpers (`engine/op-at`,
-;; `engine/wholly-changed-ancestor`, `engine/shifted-was-index`,
-;; `engine/type-change?`, `engine/redaction-side`,
-;; `engine/change-count-at`).
+;; Diff classification flows through `day8.re-frame2-xray.diff.engine`'s
+;; pre-computed projection (`engine/project`) + the path-keyed lookup
+;; helpers (`engine/op-at`, `engine/wholly-changed-ancestor`,
+;; `engine/shifted-was-index`, `engine/type-change?`,
+;; `engine/redaction-side`, `engine/change-count-at`).
 ;;
-;; The legacy `::missing` sentinel is re-exported below for compatibility
-;; with the existing diff-aware container-iteration logic
-;; (`children-of-pair`, `diff-pair-count`) — those walkers thread
-;; `::missing` to represent slots that exist on one side of the diff
-;; only. The CLASSIFIER side of that interaction (which op to attach to
-;; the leaf) now flows through the engine's projection map.
+;; The `::missing` sentinel is re-exported below for the diff-aware
+;; container-iteration logic (`children-of-pair`, `diff-pair-count`) —
+;; those walkers thread `::missing` to represent slots that exist on one
+;; side of the diff only. The CLASSIFIER side of that interaction (which
+;; op to attach to the leaf) flows through the engine's projection map.
 
 (def missing-sentinel
   "Marker for a `:before` / `:after` slot that does not exist in its
@@ -543,7 +521,7 @@
   edn-inspector tests can assert the walker triples against the exact
   sentinel value — distinct from `engine/missing-sentinel`
   (`:day8.re-frame2-xray.diff.engine/missing`), which is the CLASSIFIER
-  side's marker per rf2-n2jig. Never collides with a real `nil` slot."
+  side's marker. Never collides with a real `nil` slot."
   ::missing)
 
 ;; ---- per-op token tables ------------------------------------------------
@@ -602,7 +580,7 @@
     :modified (:diff-modified-stripe tokens)
     nil))
 
-;; ---- gutter-row hoisted style maps (rf2-7cddi) ---------------------------
+;; ---- gutter-row hoisted style maps --------------------------------------
 ;;
 ;; `gutter-row` fires once per change-bearing leaf in a diff render — a
 ;; 30-changed-leaf render allocates 90 fresh map literals at the call site without
@@ -639,7 +617,7 @@
 
 (defn- gutter-row
   "Wrap `body` with the diff row chrome: gutter glyph + low-opacity
-  row-background wash + 2px left-edge stripe (rf2-awqts).
+  row-background wash + 2px left-edge stripe.
 
   ## What lives on what channel
 
@@ -664,20 +642,18 @@
   descendant) gets the gutter glyph but NO wash + NO stripe — the
   changed descendants below carry the colour-coded signal.
 
-  ## rf2-1bra5 — inline-flex, not flex
+  ## inline-flex, not flex
 
-  Switched from `display: flex` (block-level) to `inline-flex` so a
-  diff'd scalar leaf composes inline with its preceding key inside a
-  map-row grid. Pre-fix the block-level `<div>` forced the leaf onto
-  its own line (the per-row flex container couldn't keep the key+value
-  on one line — `flex-wrap: wrap` pushed the wide block-div below the
-  key, producing the `:show-parity?` / `:threshold` two-line rows Mike
-  measured at ~28.79px against the inline ~17.79px sibling rows).
+  Uses `display: inline-flex` so a diff'd scalar leaf composes inline
+  with its preceding key inside a map-row grid. A block-level `<div>`
+  would force the leaf onto its own line (the per-row flex container
+  can't keep key+value on one line — `flex-wrap: wrap` pushes a wide
+  block-div below the key, producing two-line rows).
 
   Returns an `[:span ...]` (display: inline-flex) so it nests inside a
   grid cell without breaking the row.
 
-  ## rf2-n2jig — R5-tinted suppression
+  ## R5-tinted suppression
 
   The optional `chrome-opts` map carries R5-tinted overrides:
 
@@ -689,7 +665,7 @@
     op is `:same` or `:same-shifted` (so descendants of a wholly-
     new subtree still read as green).
 
-  ## rf2-zpeyv — slot-vs-value anchoring
+  ## slot-vs-value anchoring
 
   - `:suppress-wash?` — paint NO wash on this gutter-row. Used when
     the slot-anchored chrome paints the wash on the WHOLE ROW (key +
@@ -715,7 +691,7 @@
          glyph-colour  (if suppress-glyph?
                          (:text-tertiary tokens)
                          (op-gutter-colour op))]
-     ;; rf2-7cddi — hoisted style bases (see `gutter-row-*-style` defs above):
+     ;; Hoisted style bases (see `gutter-row-*-style` defs above):
      ;; the static skeletons are ns-top defs; only the dynamic per-op
      ;; overlays (`:border-left` colour + optional `:background` wash on
      ;; the outer; `:color` on the glyph) are computed per render.
@@ -874,12 +850,11 @@
                          :margin-left "4px"}}
           (str "· " bytes " bytes")])])
     :sentinel-large
-    ;; rf2-ndb13 — body keys per Spec 015 §Wire elision:
+    ;; Body keys per Spec 015 §Wire elision:
     ;; `:path :bytes :type :reason :hint :handle`. `:type` is the
     ;; original-value type tag (`:map :vector :string …`); `:hint`
     ;; carries the schema-author's docstring; `:handle` is the
-    ;; structured fetch handle for a future drill-in affordance
-    ;; (deferred — see rf2-ndb13 "Out of scope").
+    ;; structured fetch handle for a future drill-in affordance.
     (let [{:keys [bytes type hint]} (val (first v))]
       [:span {:data-rf-type "rf-size-large-elided"
               :data-testid  "rf-xray-edn-inspector-large"
@@ -928,7 +903,7 @@
 
 (defn inline-separator
   "Inter-element separator STRING for an inline / collapsed render of a
-  collection of `kind`, matching canonical EDN print spacing (rf2-7hqwe):
+  collection of `kind`, matching canonical EDN print spacing:
 
   - maps / records — `\", \"` between consecutive key/value PAIRS, e.g.
     `{:a 1, :b 2}` (the space WITHIN a pair is supplied separately by the
@@ -947,9 +922,8 @@
   "The inter-element separator rendered as a `:text-tertiary` hiccup span
   for inline collection renders. Shared by the two inline-fit render
   paths — `render-inline-recursive` (width-aware recursive) and
-  `render-container`'s legacy inline-fit branch — which previously built
-  this same span twice. The separator STRING comes from `inline-separator`
-  (canonical EDN spacing per kind)."
+  `render-container`'s strict inline-fit branch. The separator STRING
+  comes from `inline-separator` (canonical EDN spacing per kind)."
   [kind]
   [:span {:style (token-style :text-tertiary)} (inline-separator kind)])
 
@@ -1073,9 +1047,9 @@
 ;; =========================================================================
 
 (declare render-node)
-;; rf2-n2jig — `render-leaf-with-diff` uses `mini` for R7 type-change
-;; suffix rendering; `mini` is defined later in the file (it's the
-;; public 1-arg inline render). Forward declare so the compiler resolves.
+;; `render-leaf-with-diff` uses `mini` for R7 type-change suffix
+;; rendering; `mini` is defined later in the file (it's the public 1-arg
+;; inline render). Forward declare so the compiler resolves.
 (declare mini)
 
 (defn- children-of
@@ -1113,8 +1087,9 @@
   collection of the SAME family — `#{:a}→#{}`, `{:k :v}→{}`, `[x]→[]`,
   `(x)→()` — with the KEY INTACT (the slot still exists in AFTER).
 
-  This is the render-side discriminator for rf2-0c6a3. The engine's R5
-  `mark-wholly-changed` legitimately promotes such an emptied set / map
+  This is the render-side discriminator for an emptied collection. The
+  engine's R5 `mark-wholly-changed` legitimately promotes such an
+  emptied set / map
   KEY to `:removed` (the opposite side is empty, so there is no surviving
   member to anchor a member-level diff at the container path — see
   `engine/mark-wholly-changed`). But an emptied collection is NOT a
@@ -1149,7 +1124,7 @@
   "Diff-aware children walk — return a seq of `[child-key after-value
   before-value]` triples covering the UNION of `before` + `after` so
   removed children (present in BEFORE, absent from AFTER) are visible
-  to the diff renderer (rf2-zuh1e).
+  to the diff renderer.
 
   Slots that don't exist in their side carry `::missing` (the same
   `missing-sentinel` `diff-op` consumes), so the recursive renderer
@@ -1163,7 +1138,7 @@
     carry stable order across boundaries anyway (array-map vs hash-
     map crossover, `dissoc` rehashing); appended-at-end is simple,
     predictable, and reads as 'the post-image, then a deletions
-    section' in the rendered tree (rf2-zuh1e decision).
+    section' in the rendered tree.
   - **Vector / list / seq** — index-align up to the longer side's
     count; trailing BEFORE-only positions render as `:removed`.
   - **Set** — UNION of members, sorted by `pr-str` for stable render
@@ -1256,14 +1231,14 @@
   through removed element gets a React `:key` distinct from the surviving
   element now occupying that integer slot. The removal's op is forced
   `:removed` by its `::missing` after-value (`render-leaf-with-diff`'s
-  structural override, rf2-8pfkk), so this synthetic segment is never
+  structural override), so this synthetic segment is never
   consulted for a projection op lookup — it exists purely for key + testid
   uniqueness."
   :rf.xray.edn-inspector/removed)
 
 (defn sequential-diff-children
-  "Projection-aware children walk for a vector / list / seq in diff mode
-  (rf2-vu42n). Returns a seq of `[child-key after-value before-value]`
+  "Projection-aware children walk for a vector / list / seq in diff mode.
+  Returns a seq of `[child-key after-value before-value]`
   triples — the SAME shape `children-of-pair` returns — but built by
   CONSUMING the engine's `:vector-removals` + `:same-shifted` projection
   rather than index-aligning the raw before/after vectors.
@@ -1284,7 +1259,7 @@
     / `:same-shifted` / `:modified`). Their `before` slot carries the
     element's PRIOR value (recovered via the survivor's before-index) —
     NOT `::missing`, because `render-leaf-with-diff` treats a `::missing`
-    before slot as a structural `:added` (rf2-8pfkk), which would override
+    before slot as a structural `:added`, which would override
     the projection and paint a surviving element green.
   - Purely-added elements come from the AFTER vector at their AFTER index
     with a `::missing` before slot (correctly forcing `:added`).
@@ -1411,22 +1386,19 @@
                   (try (pr-str k) (catch :default _ (str k)))]))
 
 ;; =========================================================================
-;; width-aware expansion heuristic (rf2-kbdk8)
+;; width-aware expansion heuristic
 ;; =========================================================================
 ;;
-;; The closed-renderer's auto-expansion was depth-driven — any container
-;; within `default-expanded-depth` opened automatically regardless of how
-;; trivially its inline form would fit the available column width. Result:
-;; short values rendered as 8-9 row trees that consumed ~9× the vertical
-;; real-estate of their inline equivalents.
+;; The heuristic renders inline FIRST when the value's estimated inline
+;; width fits the available column (with a small safety margin); it falls
+;; back to tree-expand only when the inline form would overflow. This
+;; keeps short values from rendering as multi-row trees that consume far
+;; more vertical real-estate than their inline equivalents.
 ;;
-;; The new heuristic flips the test: render inline FIRST when the value's
-;; estimated inline width fits the available column (with a small safety
-;; margin); only fall back to tree-expand when the inline form would
-;; overflow. `default-expanded-depth` is repurposed as a CEILING — never
-;; auto-expand past depth N even when the inline form overflows; show a
-;; collapsed-summary instead. The operator's sticky override and diff-
-;; mode's force-open-over-changed-descendant rule still win.
+;; `default-expanded-depth` is a CEILING — never auto-expand past depth N
+;; even when the inline form overflows; show a collapsed-summary instead.
+;; The operator's sticky override and diff-mode's
+;; force-open-over-changed-descendant rule still win.
 ;;
 ;; Width is estimated by `(* char-count mono-char-width-px)` — JetBrains
 ;; Mono / Source Code Pro at the inspector's 12px size carries an
@@ -1436,11 +1408,10 @@
 ;; cause horizontal overflow).
 ;;
 ;; A `safety-margin-px` of 16px guards against edge-case wrap (a few extra
-;; pixels for the closing bracket, gutter, scroll-bar reserve). Tested live
-;; against the Handler panel dispatch-section mount (rf2-kbdk8 bead body):
-;; the 81-char `[:ws/connection [:rf.machine.timer/after-elapsed 2501
-;; [:active :authenticating]]]` value at ~570px estimate fits trivially in
-;; the 966px column and now renders inline at one row (was 148px / 8-9 rows).
+;; pixels for the closing bracket, gutter, scroll-bar reserve). For
+;; example, the 81-char `[:ws/connection [:rf.machine.timer/after-elapsed
+;; 2501 [:active :authenticating]]]` value at ~570px estimate fits
+;; trivially in a 966px column and renders inline at one row.
 
 (def mono-char-width-px
   "Monospace M-advance in CSS pixels at the inspector's 12px font size.

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
@@ -1,6 +1,5 @@
 (ns day8.re-frame2-xray.views.edn-inspector-popup
-  "Data-display popup overlay infra — phase 6 of rf2-oqa60 (D6=a per
-  rf2-sndui).
+  "Data-display popup overlay infra.
 
   ## What this is
 
@@ -8,7 +7,7 @@
   a CLJS value at depth via the first-class edn-inspector widget
   (`views.edn-inspector`). Anchor scope is Xray-internal only — the
   popup overlays the Xray DOM; it never anchors to the debugged
-  application's DOM (locked per D6=a).
+  application's DOM.
 
   ## Public API
 
@@ -35,7 +34,7 @@
   Two-arg overload matches `[edn-inspector value opts]` (D2=a) so the
   popup's call shape is the same as the widget it wraps.
 
-  ## Per-mount UUID (D8=a per rf2-sndui)
+  ## Per-mount UUID
 
   Each `[edn-inspector-popup …]` mount allocates a fresh UUID
   `mount-id` on first render via the form-2 outer fn. The `mount-id`:
@@ -65,16 +64,15 @@
     `[panel-id mount-id path]`, so the popup's contents survive
     unmount/remount when the same id is reused).
 
-  ## Why this lives in NEW files only
+  ## Why this is its own namespace
 
-  The umbrella widget at `views.edn-inspector.cljs` is phase 1's
-  surface and just landed in #2143. Phase 6's overlay infra is an
-  additive surface — a wrapper component + its own state slot — so
-  the phase-1 file stays untouched and the popup's lifecycle is
-  self-contained. The shell wires the `edn-inspector-popup-stack`
-  view into its overlay container in a follow-on bead; the install!
-  fn here makes the registrations idempotent so that wire-up is a
-  one-call addition.
+  The umbrella widget at `views.edn-inspector.cljs` owns value
+  rendering. This overlay infra is a separate surface — a wrapper
+  component + its own state slot — so the widget file stays focused
+  and the popup's lifecycle is self-contained. The shell wires the
+  `edn-inspector-popup-stack` view into its overlay container; the
+  `install!` fn here makes the registrations idempotent so that
+  wire-up is a one-call addition.
 
   ## Z-index
 
@@ -312,9 +310,9 @@
 ;; =========================================================================
 
 (defn- gen-mount-id
-  "Generate a stable per-mount UUID (D8=a per rf2-sndui). Public so
-  programmatic callers (a context-menu handler that wants to open a
-  popup at a known id) can mint a matching id ahead of time."
+  "Generate a stable per-mount UUID. Public so programmatic callers
+  (a context-menu handler that wants to open a popup at a known id)
+  can mint a matching id ahead of time."
   []
   (str (random-uuid)))
 
@@ -331,9 +329,9 @@
   `opts` may carry `:on-close` (0-arg fn). When present the caller
   owns the close lifecycle and the default rf-dispatch is skipped.
 
-  `frame` (rf2-nesy9) is the surrounding instance frame captured by
-  `popup-chrome` at render time so the close dispatch lands on it, not
-  a `{:frame :rf/xray}` literal. Defaults to `(rf/current-frame-id)` for
+  `frame` is the surrounding instance frame captured by `popup-chrome`
+  at render time so the close dispatch lands on it, not a
+  `{:frame :rf/xray}` literal. Defaults to `(rf/current-frame-id)` for
   the test seam / direct callers."
   ([mount-id opts] (close-fn mount-id opts (rf/current-frame-id)))
   ([mount-id {:keys [on-close]} frame]
@@ -349,9 +347,9 @@
   `:close mount-id` so the layered-popups contract holds — if the
   user opens A, then B over A, Esc closes B and leaves A standing.
 
-  `frame` (rf2-nesy9) is the surrounding instance frame captured by
-  `popup-chrome` at render time. Defaults to `(rf/current-frame-id)` for
-  the test seam."
+  `frame` is the surrounding instance frame captured by `popup-chrome`
+  at render time. Defaults to `(rf/current-frame-id)` for the test
+  seam."
   ([^js e] (handle-keydown e (rf/current-frame-id)))
   ([^js e frame]
    (when (= "Escape" (.-key e))
@@ -398,8 +396,8 @@
                 default-expanded-depth 2
                 max-inline-width 60
                 max-depth 16}} opts
-        ;; rf2-nesy9 — capture the surrounding instance frame at render
-        ;; time so the deferred close handlers dispatch into it, not a
+        ;; Capture the surrounding instance frame at render time so the
+        ;; deferred close handlers dispatch into it, not a
         ;; `:rf/xray` literal. popup-chrome renders inside the panels'
         ;; reg-views (and the stack reg-view), so current-frame-id resolves
         ;; through the React-context tier here.
@@ -410,9 +408,9 @@
         ;; The shared backdrop owns z-index for position 0; dialogs
         ;; ride on top of their own backdrop tier.
         dialog-z      (z-index-for (inc (or stack-pos 0)))]
-    ;; rf2-7oxvd — shared backdrop + dialog scaffold. This popup keeps
-    ;; its own (public) `backdrop-style` / `dialog-style`, its
-    ;; stack-position z-index OVERRIDE (folded onto the backdrop style),
+    ;; Shared backdrop + dialog scaffold. This popup keeps its own
+    ;; (public) `backdrop-style` / `dialog-style`, its stack-position
+    ;; z-index OVERRIDE (folded onto the backdrop style),
     ;; its `data-rf-mount-id` markers (via the `:*-extra` slots), the
     ;; backdrop -1 / dialog 0 tab-index split and the Esc-closes-top
     ;; `keydown` on both. `modal-chrome` owns the positioning attribute,
@@ -465,16 +463,15 @@
 (defn edn-inspector-popup
   "Floating popup overlay that wraps `[ei/edn-inspector value opts]`.
   Form-2 Reagent component: the outer fn allocates a stable
-  `mount-id` (UUID, D8=a per rf2-sndui) in closure; the inner fn
-  reads the popup's stack position from app-db (so multiple popups
+  `mount-id` (UUID) in closure; the inner fn reads the popup's
+  stack position from app-db (so multiple popups
   layer in z-index order) and renders the chrome.
 
-  Per D6=a the popup is **Xray-internal** — the backdrop spans the
-  Xray shell only (or the Story cell when `:rf.xray/modal-positioning`
-  resolves to `:absolute`); it never anchors to the debugged
-  application's DOM.
+  The popup is **Xray-internal** — the backdrop spans the Xray shell
+  only (or the Story cell when `:rf.xray/modal-positioning` resolves
+  to `:absolute`); it never anchors to the debugged application's DOM.
 
-  Per D8=a the auto-generated UUID on mount lives until unmount; two
+  The auto-generated UUID on mount lives until unmount; two
   side-by-side `[edn-inspector-popup …]` mounts get independent
   expansion state.
 
@@ -526,14 +523,14 @@
   **inline** opens (a panel that wants to control the popup
   imperatively from its own view tree).
 
-  Per rf2-1yif8 `reg-view`-registered (was a plain Reagent `defn`
-  prior, which silently routed `subscribe` / `dispatch` to
-  `:rf/default` when mounted under a non-default frame — the exact
-  class of bug `:rf.warning/plain-fn-under-non-default-frame-once`
-  was added to catch). The view-id is auto-derived from the symbol
-  per the canonical reg-view convention; the surrounding shell mounts
-  this stack under `:rf/xray`, so all its `subscribe` calls now
-  resolve through the React-context tier to the surrounding frame."
+  `reg-view`-registered so its `subscribe` / `dispatch` calls resolve
+  against the frame it is mounted under rather than silently routing
+  to `:rf/default` (the class of bug
+  `:rf.warning/plain-fn-under-non-default-frame-once` catches). The
+  view-id is auto-derived from the symbol per the canonical reg-view
+  convention; the surrounding shell mounts this stack under `:rf/xray`,
+  so all its `subscribe` calls resolve through the React-context tier
+  to the surrounding frame."
   []
   (let [stack   @(rf/subscribe [stack-slot])
         entries @(rf/subscribe [entries-slot])

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_protocol.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_protocol.cljs
@@ -1,13 +1,12 @@
 (ns day8.re-frame2-xray.views.edn-inspector-protocol
-  "Custom-formatters protocol for the Xray edn-inspector widget
-  (rf2-oqa60 phase 7 · rf2-0qrcr · D7=a per rf2-sndui ruling).
+  "Custom-formatters protocol for the Xray edn-inspector widget.
 
   ## Why this exists
 
-  Phase 1 (rf2-oqa60) shipped a *closed* renderer — it classifies
-  every built-in CLJS shape natively (maps, vectors, sets, records,
-  map-entries, sentinels, scalars). That covers the universe of
-  shapes Xray itself produces. Consuming applications, however, may
+  The widget is a *closed* renderer — it classifies every built-in
+  CLJS shape natively (maps, vectors, sets, records, map-entries,
+  sentinels, scalars). That covers the universe of shapes Xray itself
+  produces. Consuming applications, however, may
   carry **domain types** (typed records, custom deftypes, opaque
   wrappers around external library objects) that the closed renderer
   has no better fallback for than `pr-str`.
@@ -60,10 +59,10 @@
   ## Boundary
 
   The protocol is the ONLY public extension seam in the edn-inspector
-  widget. Per the locked B.9 / rf2-sndui interaction model the
-  widget itself ships exactly one path-click interaction; consumers
-  do NOT extend interactions through this protocol — only the
-  visual rendering of values.
+  widget. Per the B.9 interaction model the widget itself ships
+  exactly one path-click interaction; consumers do NOT extend
+  interactions through this protocol — only the visual rendering of
+  values.
 
   ## Spec
 

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_state.cljs
@@ -1,26 +1,19 @@
 (ns day8.re-frame2-xray.views.edn-inspector-state
-  "Expansion-state registration for the edn-inspector widget (rf2-l42sg7).
+  "Expansion-state registration for the edn-inspector widget.
 
-  Extracted from `views/edn-inspector` as the first cohesive-slice carve-
-  out of that over-large namespace (rf2-xxo3zz F5). This namespace owns
-  ONE concern: the per-node expansion overrides the widget stores in
-  re-frame app-db — the `expansion-slot` key, its `reg-sub`, the
-  `toggle-node` / `set-node` / `reset-expansion` events, the pure
-  `expansion-key` composer, and the `resolve-expanded?` projection.
+  This namespace owns ONE concern: the per-node expansion overrides the
+  widget stores in re-frame app-db — the `expansion-slot` key, its
+  `reg-sub`, the `toggle-node` / `set-node` / `reset-expansion` events,
+  the pure `expansion-key` composer, and the `resolve-expanded?`
+  projection.
 
-  The split is behaviour-preserving: the same global event/sub ids
-  register here, and `views/edn-inspector` re-exports the public vars
-  (`expansion-slot`, `expansion-key`, `resolve-expanded?`) so existing
-  call sites and tests keep resolving against the widget namespace
-  unchanged.
+  `views/edn-inspector` re-exports the public vars (`expansion-slot`,
+  `expansion-key`, `resolve-expanded?`) so call sites and tests can
+  resolve them against the widget namespace.
 
-  Why a separate namespace: the widget's expansion state is a self-
-  contained app-db slice with no dependency on the renderer (no tokens,
-  no hiccup). Isolating it shrinks the renderer namespace and gives the
-  expansion machinery its own reviewable, testable home — the sibling
-  `widths` (width-aware heuristic) and `zoom` (focus navigation) view-
-  state groups remain in `views/edn-inspector` for now; this pass takes
-  one clean slice only."
+  The expansion state is a self-contained app-db slice with no
+  dependency on the renderer (no tokens, no hiccup), so it lives apart
+  from the renderer namespace with its own reviewable, testable home."
   (:require [re-frame.core :as rf]))
 
 ;; =========================================================================
@@ -31,11 +24,7 @@
 
 (def expansion-slot
   "App-db slot holding the per-node expansion overrides. Public so
-  the consuming panel's reset affordance can clear it.
-
-  Distinct from the legacy `:rf.xray/edn-inspector-expansion` slot
-  used by `edn-inspector/render` — keeping them separate lets the old
-  engine and the new widget coexist during the phased rollout."
+  the consuming panel's reset affordance can clear it."
   :rf.xray.edn-inspector/expansion)
 
 (defn expansion-key
@@ -48,7 +37,7 @@
 
 (rf/reg-event :rf.xray.edn-inspector/toggle-node
   (fn [{:keys [db]} [_ panel-id mount-id path rendered-expanded?]]
-    ;; rf2-y59tb — first click MUST invert the currently-visible state.
+    ;; First click MUST invert the currently-visible state.
     ;;
     ;; The widget renders `default-expanded` paths (top-level nodes,
     ;; depth ≤ `default-expanded-depth`) open BEFORE the user clicks,
@@ -57,7 +46,7 @@
     ;; emit the same state the user already sees — a silent no-op on
     ;; the first click.
     ;;
-    ;; The dispatch payload now carries `rendered-expanded?` — the
+    ;; The dispatch payload carries `rendered-expanded?` — the
     ;; value `resolve-expanded?` returned for this path on the last
     ;; render (i.e. what the user currently sees). When no override
     ;; is stored the reducer flips from that visible state; when an

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
@@ -10,20 +10,13 @@
   operator learns one expand/collapse + diff interaction and applies
   it everywhere.
 
-  ## One engine, one facade (post-rf2-q3dzw)
+  ## One engine, one facade
 
   The WHOLE value-rendering contract lives in `views.edn-inspector`
-  as one renderer. This facade is a thin delegate that the legacy
-  `edn/*` call sites still reach through; new call sites should use
+  as one renderer — browse, diff, mini and sentinel chrome all in the
+  same widget. This facade is a thin delegate that the `edn/*` call
+  sites reach through; new call sites should use
   `[edn-inspector value opts]` directly.
-
-  Previous shape (pre-rf2-oqa60) composed two engines:
-  `edn-inspector.render` (diff-aware tree walker) and
-  `cljs-devtools-render` (binaryage/cljs-devtools-backed formatters).
-  Phase 1 (rf2-oqa60) shipped the roll-your-own browse path; phase 5
-  (rf2-q3dzw) subsumed the diff engine into the same widget and
-  deleted the legacy `edn-inspector.render` + `theme.data-inspector`
-  ns'es.
 
   ## Public API
 
@@ -44,20 +37,17 @@
              :refer [tokens mono-stack]]
             ;; The first-class edn-inspector widget owns the WHOLE
             ;; contract — browse, diff, mini, sentinel chrome — as a
-            ;; single source of truth (phase 5 / rf2-q3dzw,
-            ;; D5=a per rf2-sndui).
+            ;; single source of truth.
             [day8.re-frame2-xray.views.edn-inspector :as ei]
             [zprint.core :as zprint]))
 
-;; ---- subscription bridge — superseded by the new edn-inspector widget ----
+;; ---- expansion-state ownership ------------------------------------------
 ;;
-;; Pre-rf2-oqa60 this section glued the cljs-devtools walker to the
-;; shared expansion slot. With the phase 1 cut-over the new widget at
-;; `views.edn-inspector` owns its own `:rf.xray.edn-inspector/expansion`
-;; slot + toggle/reset events; the facade delegates and the cljs-
-;; devtools-render adapter is deleted.
+;; The widget at `views.edn-inspector` owns its own
+;; `:rf.xray.edn-inspector/expansion` slot + toggle/reset events; this
+;; facade simply delegates to it.
 
-;; ---- universal copy-to-clipboard affordance (rf2-f026h) ------------------
+;; ---- universal copy-to-clipboard affordance -----------------------------
 ;;
 ;; re-frame-10x makes every value copyable. Rather than thread a copy
 ;; button into each panel, the affordance rides on the WIDGET ROOT so
@@ -70,15 +60,14 @@
 ;; by `app-db-diff-events/install!` (always called from
 ;; `registry.cljs`), so the dispatch resolves on every surface.
 ;;
-;; rf2-nesy9 — the affordance captures the SURROUNDING frame at render
-;; time via `(rf/current-frame-id)` and dispatches into it on click. The
+;; The affordance captures the SURROUNDING frame at render time via
+;; `(rf/current-frame-id)` and dispatches into it on click. The
 ;; click-handler fires after React pops the frame context, so the
 ;; render-time capture is what keeps the dispatch on the right instance
 ;; frame (N parallel shells stay isolated). The widget root threads
 ;; everywhere through plain fns, so a render-time `current-frame-id`
 ;; capture is cleaner than plumbing a `dispatch-fn` through the whole
-;; inspect/browse/diff/mini tree — and replaces the prior
-;; `{:frame :rf/xray}` singleton literal.
+;; inspect/browse/diff/mini tree.
 
 (defn copy-affordance
   "A hover-revealed `⎘` copy button that copies `value` to the
@@ -89,8 +78,8 @@
   click-to-copy mark spec 007:668 uses for the namespace-fade keyword
   copy."
   [value testid]
-  ;; rf2-nesy9 — capture the surrounding instance frame at RENDER time
-  ;; so the deferred copy click dispatches back to it (not a `:rf/xray`
+  ;; Capture the surrounding instance frame at RENDER time so the
+  ;; deferred copy click dispatches back to it (not a `:rf/xray`
   ;; literal). The widget renders inside the panels' `reg-view`s, so
   ;; `current-frame-id` resolves through the React-context tier here.
   (let [frame (rf/current-frame-id)]
@@ -124,35 +113,27 @@
 
 ;; ---- panel-facing facade — inspect / inspect-inline ----------------------
 ;;
-;; Per Mike-direction rf2-9wsdy ("one widget, many call sites") every
-;; panel-side EDN render flows through this namespace. Per rf2-oqa60
-;; phase 1 the facade delegates to the first-class `views.edn-inspector`
-;; widget — the same engine handles every type (scalars, collections,
-;; sentinels) so this thin wrapper no longer needs sentinel-routing
-;; branches. Phases 2-4 migrate call sites to call `ei/edn-inspector`
-;; directly; this facade is the bridge through that transition.
+;; "One widget, many call sites" — every panel-side EDN render flows
+;; through this namespace. The facade delegates to the first-class
+;; `views.edn-inspector` widget — the same engine handles every type
+;; (scalars, collections, sentinels) so this thin wrapper needs no
+;; sentinel-routing branches. Call sites may also call `ei/edn-inspector`
+;; directly.
 
 (defn inspect
   "Sentinel-aware current-state rendering for one value — the canonical
   L4 detail-panel renderer. Routes through the first-class
-  edn-inspector widget (rf2-oqa60 phase 1) which classifies every type
-  natively, including the spec/015 sentinels (`:rf/redacted` and
-  `:rf.size/large-elided`) as first-class chip chrome (D3=a per
-  rf2-sndui).
-
-  Phase 1 delegates the legacy facade to the new widget so existing
-  call sites compile unchanged; phases 2-4 migrate each surface
-  (Trace, Sub, Machine) to call `edn-inspector/edn-inspector` directly.
+  edn-inspector widget, which classifies every type natively,
+  including the spec/015 sentinels (`:rf/redacted` and
+  `:rf.size/large-elided`) as first-class chip chrome.
 
   Single-arg form picks a default panel-id; two-arg / three-arg forms
   accept a node-key string (passed through as a stable per-mount
-  qualifier) and an opts map. The `:copy?` key from the old facade is
-  accepted but ignored — copy chrome is deferred to a follow-on bead
-  (the popup phase, D6=a).
+  qualifier) and an opts map. The `:copy?` key is accepted but ignored
+  — copy chrome rides on the widget root instead.
 
-  Diff rendering also routes through the new widget (an opt-in
-  `:before` mode on `ei/edn-inspector`) after phase 5 (rf2-q3dzw,
-  D5=a per rf2-sndui)."
+  Diff rendering also routes through the widget (an opt-in `:before`
+  mode on `ei/edn-inspector`)."
   ([v] (inspect v "root" nil))
   ([v node-key] (inspect v node-key nil))
   ([v node-key _opts]
@@ -162,9 +143,9 @@
 
 (defn inspect-inline
   "Compact one-line current-state rendering for hover tooltips / list
-  cells. Folds sentinel routing in (D2=a per rf2-sndui) — sentinels
-  render their chip chrome via the new widget's `mini` overload; all
-  other values render as a colour-coded one-liner."
+  cells. Folds sentinel routing in — sentinels render their chip
+  chrome via the widget's `mini` overload; all other values render as
+  a colour-coded one-liner."
   [v]
   (ei/mini v))
 
@@ -181,36 +162,33 @@
 ;;      registration (everything on one line, weird indentation,
 ;;      mid-expression breaks) becomes canonical-looking before
 ;;      rendering. zprint is dev-only — bundle-isolated from production
-;;      via the `:devtools/preloads` gate (rf2-6snc8). On a zprint
+;;      via the `:devtools/preloads` gate. On a zprint
 ;;      failure (parse error / unsupported reader macro) `format-source`
 ;;      falls through to the original source string so a bad input
 ;;      never strands the widget.
 ;;
 ;;   2. **In-bundle Clojure-mode tokenizer** — `tokenize-clojure` is a
 ;;      lightweight ~140-LoC source-text lexer that emits per-token
-;;      colour classifications mapped onto the theme tokens. Per the
-;;      rf2-93jp0 palette split, keywords paint on `:syntax-keyword`
+;;      colour classifications mapped onto the theme tokens. The palette
+;;      splits so keywords paint on `:syntax-keyword`
 ;;      (red family), strings on `:syntax-string` (blue family),
 ;;      numbers on `:syntax-number` (cool-blue), and builtins on
 ;;      `:accent` (chrome blue, macro-call emphasis) — each visually
 ;;      distinct, both light and dark, mirroring the Figma authority's
-;;      `.syntax-*` CSS classes. The bracketed phrase in the rf2-6snc8
-;;      acceptance ("highlight.js … or an embeddable Clojure-mode
-;;      subset") explicitly authorises this subset — and keeping the
-;;      highlighter in-bundle avoids the cost of a JS-side highlight.js
+;;      `.syntax-*` CSS classes. Keeping the highlighter in-bundle as a
+;;      Clojure-mode subset avoids the cost of a JS-side highlight.js
 ;;      dep on the dev classpath.
 
 (defn unescape-source-newlines
   "Turn the two-character escaped-newline sequence `\\n` (backslash + n)
   inside a captured Clojure source string back into a REAL newline so a
   multi-line `:doc` (or any multi-line string literal) renders across
-  lines, matching how it was written in source (rf2-iosnp). Pure fn;
-  testable.
+  lines, matching how it was written in source. Pure fn; testable.
 
   ## Why this is needed
 
   The substrate captures handler source via `(pr-str whole-form)`
-  (`re-frame.core-reg-macros/with-form-source-form`, rf2-xgfuy). Clojure's
+  (`re-frame.core-reg-macros/with-form-source-form`). Clojure's
   printer escapes newlines inside string literals, so a source-level
 
       {:doc \"line one
@@ -258,9 +236,9 @@
   capped at 72 columns so the rendered block fits inside the Event
   panel's narrow handler-source slot without horizontal scroll.
 
-  rf2-iosnp — after zprint (or the fall-through on a parse failure) the
-  result is run through [[unescape-source-newlines]] so an embedded
-  multi-line `:doc` renders its real line breaks instead of a literal
+  After zprint (or the fall-through on a parse failure) the result is
+  run through [[unescape-source-newlines]] so an embedded multi-line
+  `:doc` renders its real line breaks instead of a literal
   backslash-n on one over-wide line. zprint preserves string-literal
   contents verbatim, so the `\\n` escape survives the round-trip and is
   unescaped here as the final step."
@@ -275,10 +253,10 @@
 (defn highlight-clojure-token
   "Per-token colour resolution for the in-bundle Clojure syntax
   highlighter (source-text rendering only; CLJS-value rendering goes
-  through `cljs-devtools-render`). Pure data → token-keyword for the
+  through the edn-inspector widget). Pure data → token-keyword for the
   token-type classification. Public for unit tests.
 
-  ## Palette (rf2-93jp0)
+  ## Palette
 
   Each token type maps to a dedicated `:syntax-*` token from
   `theme/tokens.cljc` so the rendered hues match the Figma authority's
@@ -287,7 +265,7 @@
   resolve to DIFFERENT hues — keyword on `:syntax-keyword` (red family,
   per Figma), builtin on `:accent` (the chrome blue, reading as
   macro-call emphasis) — so a `:foo` keyword and a `reg-event`
-  builtin no longer paint identically against a real editor.
+  builtin paint distinctly against a real editor.
 
   The fallthrough is `:text-primary`, matching a real editor where
   plain symbols carry no special colour."
@@ -308,12 +286,11 @@
   #{"def" "defn" "defn-" "defmacro" "let" "if" "when" "when-not"
     "cond" "case" "do" "loop" "recur" "fn" "fn*" "reify"
     "deftype" "defrecord" "ns" "require" "reg-event"
-    ;; EP-0018 collapsed the three public event registrars onto `reg-event`
-    ;; (above); calling a retired name is now a hard error. The retired
-    ;; spellings nonetheless stay in the highlighter set because the
-    ;; source-text highlighter renders whatever source the substrate captured
-    ;; — including legacy `reg-event-db` / `-fx` / `-ctx` call sites in a v1
-    ;; or pre-migration app under inspection.
+    ;; The source-text highlighter renders whatever source the substrate
+    ;; captured — including `reg-event-db` / `-fx` / `-ctx` call sites in a
+    ;; v1 app under inspection — so those spellings stay in the highlighter
+    ;; set even though re-frame2's own event registrar is the single
+    ;; `reg-event` (EP-0018).
     "reg-event-db" "reg-event-fx" "reg-event-ctx" "reg-sub" "reg-fx" "reg-view"
     "reg-flow" "reg-machine" "dispatch" "dispatch-sync" "subscribe"
     "assoc" "assoc-in" "update" "update-in" "get" "get-in"
@@ -434,7 +411,7 @@
                      ;; flex ancestor (the Event-panel pipeline is a flex
                      ;; column) past the panel edge — the first line is then
                      ;; clipped left under the step-rail gutter and later
-                     ;; lines run off the right (rf2-l7ha9). The `min-width:0`
+                     ;; lines run off the right. The `min-width:0`
                      ;; companion lives on the flex-item ancestors so this
                      ;; `overflow-x:auto` can actually engage.
                      :max-width   "100%"

--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -82,8 +82,8 @@
 
   ## Test-free + self-contained
 
-  Per rf2-8cevm this testbed carries no spec.cjs; the edn-inspector's
-  regression coverage lives in the engine + renderer unit tests
+  This testbed carries no spec.cjs; the edn-inspector's regression
+  coverage lives in the engine + renderer unit tests
   (`diff/engine_cljs_test`, `views/edn_inspector_cljs_test`) + the
   `panel_gallery` Story gallery (gated by the Xray feature-matrix gate) +
   the substrate contract tests. This deck is the manual LIVE driver of the
@@ -565,10 +565,10 @@
   ;; surfaces resolves its classpath-relative `:file` to an on-disk URI.
   (xray-config/configure! {:rf.xray/project-root (resolve-source-root)})
   (rf/init! reagent-adapter/adapter)
-  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
-  ;; absence — register the single, plain host frame, scope the boot
-  ;; dispatch, and wrap the render in a `frame-provider-existing` (the
-  ;; frame is already created by `reg-frame`; carried invariant).
+  ;; EP-0002: the runtime never synthesises a frame from absence —
+  ;; register the single, plain host frame, scope the boot dispatch, and
+  ;; wrap the render in a `frame-provider-existing` (the frame is already
+  ;; created by `reg-frame`; carried invariant).
   (rf/reg-frame host-frame {})
   (rf/with-frame host-frame
     (rf/dispatch-sync [:edn-inspector/reset]))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -10,30 +10,24 @@ const {
   readTraceEventsAsEdn,
 } = require('../../../../testbeds/spec-helpers.cjs');
 
-// Post rf2-xy4yb (4-layer chrome refactor): the legacy 15-panel
-// sidebar + bottom rail is dead. The L3 tab bar exposes the 9 LIVE
-// Dynamic tabs: epoch / app-db / views / trace / machines / routing /
-// resources / derivation-graph / module-view
-// (spec/018 §5 §The 9 tabs; spec/007-UX-IA.md §L3 — post rf2-5gl5r the
-// Event/Handler tab was retired in favour of the Epoch panel; post
-// rf2-gbz39 the Issues tab was removed per Mike's Option (c) ruling —
-// issues surface inline in the Epoch panel + the L2 event-row pink-wash
-// + the always-on issues ribbon signal). The sweep walks EVERY shipped
-// Dynamic tab (rf2-1sddi6 F3 — Graph + Modules were previously omitted)
-// and asserts a real panel root, never the unknown-tab stub. Panels
-// without a tab no longer have a UI handoff and are dropped from
-// the shell-sweep scenario.
+// The 4-layer chrome's L3 tab bar exposes the 9 LIVE Dynamic tabs:
+// epoch / app-db / views / trace / machines / routing / resources /
+// derivation-graph / module-view (spec/018 §5 §The 9 tabs;
+// spec/007-UX-IA.md §L3). The Epoch panel is the canonical
+// "what happened in this epoch" surface; issues surface inline in the
+// Epoch panel + the L2 event-row pink-wash + the always-on issues
+// ribbon signal. The sweep walks EVERY shipped Dynamic tab and asserts
+// a real panel root, never the unknown-tab stub. Only panels with a tab
+// have a UI handoff, so the shell-sweep scenario covers exactly those.
 const PANEL_HANDOFFS = [
   ['epoch', 'rf-xray-epoch-panel'],
   ['app-db', 'rf-xray-app-db-diff'],
-  // The :views tab routes to the full Views panel per spec/012-Views.md
-  // (rf2-21ob3 replaced the legacy Subscriptions panel). The Views
-  // panel renders its canonical `rf-xray-reactive` root testid.
+  // The :views tab routes to the full Views panel per spec/012-Views.md.
+  // The Views panel renders its canonical `rf-xray-reactive` root testid.
   ['views', 'rf-xray-reactive'],
   ['trace', 'rf-xray-trace'],
   ['machines', 'rf-xray-machine-inspector'],
-  // The :routing tab (promoted under rf2-nrbs9 + reshaped under
-  // rf2-lq0ef) is the focused-event navigation lens. Its root view
+  // The :routing tab is the focused-event navigation lens. Its root view
   // renders the `rf-xray-routing` testid (panels/routing.cljs).
   ['routing', 'rf-xray-routing'],
   // The :resources tab (Spec 016 §Xray and AI tooling) is the
@@ -42,21 +36,19 @@ const PANEL_HANDOFFS = [
   // testbed no resources are registered, so the panel renders its
   // silent-by-default state under the same `rf-xray-resources` root.
   ['resources', 'rf-xray-resources'],
-  // The :derivation-graph tab (EP-0014 prop-3, rf2-9ett2d) — the unified
+  // The :derivation-graph tab (EP-0014 prop-3) — the unified
   // derivation/process graph. L4-only registry tab. Its root view always
   // renders the `rf-xray-derivation-graph` testid (panels/derivation_
   // graph.cljs); on the counter testbed it renders the silent state under
   // the same root.
   ['derivation-graph', 'rf-xray-derivation-graph'],
-  // The :module-view tab (EP-0013, rf2-wtg9z4) — the (realm, frame)
-  // address space + demand-trigger surface. L4-only registry tab. Its
-  // root view always renders the `rf-xray-module-view` testid
-  // (panels/module_view.cljs).
+  // The :module-view tab (EP-0013) — the (realm, frame) address space +
+  // demand-trigger surface. L4-only registry tab. Its root view always
+  // renders the `rf-xray-module-view` testid (panels/module_view.cljs).
   ['module-view', 'rf-xray-module-view'],
-  // rf2-gbz39 — the Issues tab was removed (Mike RULED Option (c));
-  // issues surface inline in the Epoch panel + the L2 event-row pink-
-  // wash + the always-on issues ribbon signal (the auto-open-on-error
-  // watcher). There is no dedicated Issues tab to enumerate here.
+  // There is no dedicated Issues tab to enumerate here; issues surface
+  // inline in the Epoch panel + the L2 event-row pink-wash + the
+  // always-on issues ribbon signal (the auto-open-on-error watcher).
 ];
 
 const STAGED_SURFACES = [
@@ -66,35 +58,12 @@ const STAGED_SURFACES = [
     html: ['examples', 'reagent', 'counter', 'index.html'],
     servedPath: 'counter',
   },
-  // ---- retired with the perf_counter testbed (rf2-6cq3u) --------------
-  //
-  // The `examples/counter-perf` surface staged + served the
-  // perf-instrumented counter from `tools/xray/testbeds/perf_counter/
-  // index.html`, but NO scenario navigated to `/counter-perf/` — it was
-  // a dead staged surface that compiled + served a bundle nothing hit.
-  // The three load scenarios the bead tracked ride independent
-  // surfaces: '20-event large value elision load' on
-  // `/testbeds/large-dispatcher/`, and the '1000-event trace row-budget'
-  // + '20-event launch-mode shared runtime' re-checks on `/counter/`.
-  // Deleting the perf_counter testbed therefore drops this surface with
-  // zero scenario impact. The migrated User-Timing-emission assertions
-  // live nightly as pure CLJS at `implementation/core/test/re_frame/
-  // performance_emit_nightly_test.cljs` (Wave 4, rf2-e3j8l).
   {
     build: 'testbeds/deliberate-throw',
     bundleDir: ['out', 'testbeds', 'deliberate-throw'],
     html: ['testbeds', 'deliberate_throw', 'index.html'],
     servedPath: 'testbeds/deliberate-throw',
   },
-  // ---- retired with the migrated scenario (rf2-w1mnq / rf2-fxnszc) -----
-  //
-  // The `testbeds/schema-violation` surface had been a no-op SKIP since
-  // #1745 and its schema-recovery assertions moved to CLJS unit
-  // (`tools/xray/test/.../panels/epoch/projection_cljs_test.cljc`, landed
-  // #1753). No live SCENARIOS entry navigated to `/testbeds/schema-
-  // violation/`, so staging it only paid a dead compile + serve. The
-  // testbed source remains under `testbeds/schema_violation/` as a manual-
-  // inspection target.
   {
     build: 'testbeds/http-toggle',
     bundleDir: ['out', 'testbeds', 'http-toggle'],
@@ -119,27 +88,6 @@ const STAGED_SURFACES = [
     html: ['testbeds', 'deep_machine', 'index.html'],
     servedPath: 'testbeds/deep-machine',
   },
-  // ---- retired with the dropped panels (rf2-xy4yb / rf2-fxnszc) -------
-  //
-  // `testbeds/long-flow-w-failure` (Flows panel) and `testbeds/drain-depth-
-  // trigger` (Performance panel) staged surfaces drove scenarios that were
-  // retired when the 4-layer chrome refactor (rf2-xy4yb) dropped both
-  // panels — there is no UI handoff left to assert. No live SCENARIOS
-  // entry navigates to either served path, so both were dead staged
-  // surfaces paying a compile + serve for nothing. The flow-failure trace
-  // evidence stays covered by the `deterministic exceptions` scenario; the
-  // `:halted-depth` epoch record stays observable via the substrate's
-  // host-side epoch-history probe. The testbed sources remain under
-  // `testbeds/{long_flow_w_failure,drain_depth_trigger}/`.
-  // ---- retired with the converted scenario (rf2-rviu8) ----------------
-  //
-  // The `testbeds/non-trivial-app-db` build was driven by the
-  // 'non-trivial app-db diff substrate' scenario. That scenario is
-  // now covered by `non_trivial_app_db_e2e_cljs_test.cljs` (data-
-  // level, no browser), so the staged surface is no longer needed.
-  // Removing it saves the bundle compile + serve setup. The testbed
-  // source remains under `testbeds/non_trivial_app_db/` for any
-  // future re-introduction.
   {
     build: 'testbeds/large-dispatcher',
     bundleDir: ['out', 'testbeds', 'large-dispatcher'],
@@ -152,29 +100,21 @@ const STAGED_SURFACES = [
     html: ['testbeds', 'ssr_hydration_mismatch', 'index.html'],
     servedPath: 'testbeds/ssr-hydration-mismatch',
   },
-  // ---- retired: never wired to a live scenario (rf2-fxnszc) -----------
-  //
-  // The `testbeds/ssr-multi-frame` surface was staged but no SCENARIOS
-  // entry ever navigated to `/testbeds/ssr-multi-frame/` — a dead staged
-  // surface that compiled + served a bundle nothing hit. The SSR
-  // multi-frame isolation invariant is covered as pure JVM coverage at
-  // `implementation/ssr/test/re_frame/ssr_multi_frame_isolation_test.clj`.
-  // The testbed source remains under `testbeds/ssr_multi_frame/`.
-  // rf2-azfct — panel-gallery testbed staged for the theme-token CSS-
-  // variable resolution probe. The gallery embeds bare Xray widgets
-  // without mounting the Xray shell, so its boot path must call
-  // `global-styles/install!` explicitly (rf2-pqulr). The probe asserts
-  // that contract from a real browser; without `install!` every
-  // `var(--rf-xray-*)` reference would resolve to its CSS fallback
-  // default and panels would paint unstyled.
+  // The panel-gallery testbed is staged for the theme-token CSS-variable
+  // resolution probe. The gallery embeds bare Xray widgets without
+  // mounting the Xray shell, so its boot path must call
+  // `global-styles/install!` explicitly. The probe asserts that contract
+  // from a real browser; without `install!` every `var(--rf-xray-*)`
+  // reference would resolve to its CSS fallback default and panels would
+  // paint unstyled.
   {
     build: 'testbeds/panel-gallery',
     bundleDir: ['out', 'testbeds', 'panel-gallery'],
     html: ['tools', 'xray', 'testbeds', 'panel_gallery', 'index.html'],
     servedPath: 'testbeds/panel-gallery',
   },
-  // rf2-5crg4 — routes-epochs deck (the ROUTING step-up tester). A
-  // single-frame numbered-button ladder over the real `reg-route` +
+  // The routes-epochs deck (the ROUTING step-up tester). A single-frame
+  // numbered-button ladder over the real `reg-route` +
   // `:rf.route/navigate` surface, driving the Xray Routing panel
   // (`rf-xray-routing`). Served from the deck's own hand-written
   // index.html (source dir first, like the 8032 :dev-http entry); the
@@ -185,11 +125,11 @@ const STAGED_SURFACES = [
     html: ['tools', 'xray', 'testbeds', 'routes_epochs', 'index.html'],
     servedPath: 'testbeds/routes-epochs',
   },
-  // rf2-w06op + rf2-kipb5 — machine-epochs deck (the STATE-MACHINE tester),
-  // converted to the shared queued-step runner (`runner.core`). A single-frame
-  // step matrix over the real `reg-machine` + machine-event-routing surface,
-  // driving the Xray Machine Inspector (`rf-xray-machine-inspector`). Served
-  // from the deck's own hand-written index.html (source dir first, like the
+  // The machine-epochs deck (the STATE-MACHINE tester), built on the
+  // shared queued-step runner (`runner.core`). A single-frame step matrix
+  // over the real `reg-machine` + machine-event-routing surface, driving
+  // the Xray Machine Inspector (`rf-xray-machine-inspector`). Served from
+  // the deck's own hand-written index.html (source dir first, like the
   // 8033 :dev-http entry); the compiled main.js falls through to
   // out/examples/machine-epochs.
   {
@@ -211,43 +151,37 @@ async function openXray(page) {
   await expectVisible(page.locator('[data-testid="rf-xray-shell"]'), 5000);
 }
 
-// Post rf2-xy4yb: the L3 tab bar replaces the legacy sidebar. Tabs
-// expose `data-testid="rf-xray-tab-<id>"` for the 9 LIVE Dynamic panels
-// (epoch / app-db / views / trace / machines / routing / resources /
-// derivation-graph / module-view — spec/018 §5 §The 9 tabs; rf2-5gl5r
-// retired the Event/Handler tab in favour of the Epoch panel; rf2-gbz39
-// removed the Issues tab per Mike's Option (c) ruling; Resources added
-// per Spec 016 §Xray and AI tooling; Graph + Modules per EP-0014 /
-// EP-0013, swept since rf2-1sddi6 F3).
+// The L3 tab bar's tabs expose `data-testid="rf-xray-tab-<id>"` for the
+// 9 LIVE Dynamic panels (epoch / app-db / views / trace / machines /
+// routing / resources / derivation-graph / module-view — spec/018 §5
+// §The 9 tabs; Resources per Spec 016 §Xray and AI tooling; Graph +
+// Modules per EP-0014 / EP-0013).
 async function clickTab(page, id, canvasTestId) {
   await page.locator(`[data-testid="rf-xray-tab-${id}"]`).click();
   await expectVisible(page.locator(`[data-testid="${canvasTestId}"]`), 5000);
 }
 
-// Legacy panel ids → new L3 tab ids. Panels removed by the 4-layer
-// refactor (time-travel, causality, subs, fx, flows, routes,
-// performance, schemas, hydration, mcp-server) and the rf2-y0z5b
-// causality-surface drop have no UI handoff — callers that target
-// them must be updated separately. rf2-5gl5r: `event-detail` and
-// `event` legacy ids both route to the Epoch panel's `:epoch` tab
-// (the canonical "what happened in this epoch" surface).
+// Panel-id vocabulary → L3 tab ids. Only the panels listed here have a
+// UI handoff in the 4-layer chrome; a caller targeting any other panel-id
+// gets an explicit throw (handled in `clickSidebar`). Both `event-detail`
+// and `event` route to the Epoch panel's `:epoch` tab — the canonical
+// "what happened in this epoch" surface.
 const LEGACY_PANEL_TO_TAB = {
   'event-detail': 'epoch',
   'event':        'epoch',
   'app-db':       'app-db',
   'trace':        'trace',
   'machines':     'machines',
-  // rf2-gbz39 — the Issues tab was removed (Mike RULED Option (c));
-  // there is no `issues` tab handoff. Issues surface inline in the
+  // There is no `issues` tab handoff. Issues surface inline in the
   // Epoch panel + the L2 event-row pink-wash + the always-on issues
   // ribbon signal.
 };
 
-// Back-compat wrapper used by scenarios still pointing at the old
-// panel-id vocabulary (multi-frame, large-dispatcher, etc.). Maps to
-// a tab when possible; throws explicitly when a caller targets a
-// panel the new chrome no longer exposes so the test surfaces the
-// real gap instead of timing out on a missing testid.
+// Wrapper used by scenarios that address panels by their panel-id
+// vocabulary (multi-frame, large-dispatcher, etc.). Maps to a tab when
+// one exists; throws explicitly when a caller targets a panel the chrome
+// does not expose so the test surfaces the real gap instead of timing
+// out on a missing testid.
 async function clickSidebar(page, id, canvasTestId) {
   const tabId = LEGACY_PANEL_TO_TAB[id];
   if (!tabId) {
@@ -325,19 +259,19 @@ async function clickSourceCoordChip(page, { panel, sourceIncludes = [] }) {
     const root = document.getElementById('rf-xray-root');
     const selectors = {
       trace: '[data-testid^="rf-xray-trace-row-"] button[data-testid$="-source-coord"]',
-      // rf2-gbz39 — the `issues` panel selector was dropped with the
-      // removed Issues tab; source-coord bridge coverage rides the
-      // Trace panel's chips (the same exception traces carry coords).
+      // There is no `issues` panel selector; source-coord bridge coverage
+      // rides the Trace panel's chips (the same exception traces carry
+      // the coords).
       hydration: '[data-testid="rf-xray-hydration-source-coord"] button',
     };
     if (!root) return { clicked: false, reason: 'Xray root missing', candidates: [] };
     const selector = selectors[targetPanel] || 'button[data-testid*="source"]';
     const buttons = Array.from(root.querySelectorAll(selector));
-    // rf2-ad7zx.9 — the Issues panel's source affordance is now an `↗`
-    // icon (per the Figma design); the `file:line` coord rides the
-    // button's `title` attribute, not its text. Prefer `title` when it
-    // carries the coord (icon affordances), falling back to textContent
-    // for the trace / hydration chips that still render the coord inline.
+    // An icon source affordance (the `↗` icon, per the Figma design)
+    // carries its `file:line` coord on the button's `title` attribute
+    // rather than its text. Prefer `title` when it carries the coord
+    // (icon affordances), falling back to textContent for the trace /
+    // hydration chips that render the coord inline.
     const coordOf = (button) => {
       const title = (button.getAttribute('title') || '').trim();
       const text = (button.textContent || '').trim();
@@ -375,14 +309,14 @@ async function assertSourceCoordBridge(page, state, ctx, opts) {
   const beforeUrl = page.url();
   const requestStart = ctx && ctx.browserState ? ctx.browserState.requestFailures.length : 0;
 
-  // rf2-4s08ov — explicitly configure an editor before clicking the
-  // chip. The counter surface (this scenario's host) wires only the
-  // bare preload and never sets `:rf.xray/editor`, so by default the
-  // click would now surface the 'pick an editor in Settings' DX hint
-  // (the intended behaviour for an unconfigured host) instead of
-  // firing the `vscode://` navigation this scenario asserts. Setting
-  // `:vscode` explicitly models a properly-wired host and exercises
-  // the click → `Location.assign` bridge the scenario is about.
+  // Explicitly configure an editor before clicking the chip. The counter
+  // surface (this scenario's host) wires only the bare preload and never
+  // sets `:rf.xray/editor`, so by default the click surfaces the 'pick an
+  // editor in Settings' DX hint (the intended behaviour for an
+  // unconfigured host) instead of firing the `vscode://` navigation this
+  // scenario asserts. Setting `:vscode` explicitly models a properly-
+  // wired host and exercises the click → `Location.assign` bridge the
+  // scenario is about.
   await page.evaluate(() => {
     const cfg = window.day8 && window.day8.re_frame2_xray &&
                 window.day8.re_frame2_xray.config;
@@ -401,16 +335,12 @@ async function assertSourceCoordBridge(page, state, ctx, opts) {
     });
   }
 
-  // Per rf2-xs8vu: the chip-click handler dispatches
-  // `:rf.xray/open-in-editor` under the `:rf/xray` frame, which then
-  // fires `:rf.editor/open` as an fx (also `:rf/xray`-framed). The
-  // trace-bus ingest filter (`xray-internal-event?`) correctly drops
-  // those self-emitted events before they reach Xray's buffer — they
-  // are Xray machinery, not host activity. The bridge round-trip
-  // therefore CANNOT be verified by reading Xray's trace feed
-  // (pre-rf2-xs8vu the test exploited the absence of that filter as
-  // a convenient probe; it was incidental observability, not the
-  // bridge's contract).
+  // The chip-click handler dispatches `:rf.xray/open-in-editor` under the
+  // `:rf/xray` frame, which then fires `:rf.editor/open` as an fx (also
+  // `:rf/xray`-framed). The trace-bus ingest filter (`xray-internal-
+  // event?`) correctly drops those self-emitted events before they reach
+  // Xray's buffer — they are Xray machinery, not host activity. The bridge
+  // round-trip therefore CANNOT be verified by reading Xray's trace feed.
   //
   // The contract is: clicking a chip writes `window.location.href`
   // to the resolved `vscode://...` URI (via `open-in-editor/open!`).
@@ -686,15 +616,13 @@ async function setXrayTargetFrame(page, frame) {
  * (`frame`, `eventId`) pair (an `:rf.event/dispatched` record) and
  * dispatch `:rf.xray/focus-cascade` to focus that cascade.
  *
- * Replaces the old `clickTraceRowByFrame` helper: post rf2-ycoct the
- * Trace DOM is cascade-scoped and only renders rows for the currently
- * focused cascade, so scanning trace rows to "find and click" a
- * sibling cascade no longer works. The bus buffer is the canonical,
- * unscoped source of (frame, event) → dispatch-id, and `:rf.xray/
- * focus-cascade` is the same spine event the L2 event-row click
- * dispatches — picking a cascade through this helper exercises the
- * same focus → projection wiring without depending on the cascade-
- * scoped Trace surface.
+ * The Trace DOM is cascade-scoped and only renders rows for the currently
+ * focused cascade, so scanning trace rows to "find and click" a sibling
+ * cascade does not work. The bus buffer is the canonical, unscoped source
+ * of (frame, event) → dispatch-id, and `:rf.xray/focus-cascade` is the
+ * same spine event the L2 event-row click dispatches — picking a cascade
+ * through this helper exercises the same focus → projection wiring without
+ * depending on the cascade-scoped Trace surface.
  */
 async function focusCascadeByFrameEvent(page, { frame, eventId }) {
   const result = await page.evaluate(({ targetFrame, targetEventId }) => {
@@ -797,12 +725,11 @@ async function focusCascadeByFrameEvent(page, { frame, eventId }) {
   return result;
 }
 
-// rf2-r6d6u: the trace header's 'X / Y in view' denominator is now
-// cascade-scoped (Y = in-scope, pre-user-filter count), so it is NO
-// LONGER a proxy for the whole ring's depth. The buffer-cap invariant
-// ('still capped at 1000') is read straight from the trace bus — the
-// canonical source of truth for ring depth, independent of which
-// cascade the spine has in focus.
+// The trace header's 'X / Y in view' denominator is cascade-scoped
+// (Y = in-scope, pre-user-filter count), so it is not a proxy for the
+// whole ring's depth. The buffer-cap invariant ('still capped at 1000')
+// is read straight from the trace bus — the canonical source of truth
+// for ring depth, independent of which cascade the spine has in focus.
 async function readTraceBufferDepth(page) {
   return page.evaluate(() => {
     const cljs = window.cljs && window.cljs.core;
@@ -830,10 +757,10 @@ async function pushSyntheticTraceEvents(page, count) {
         busKeys: bus ? Object.keys(bus).sort().slice(0, 60) : [],
       };
     }
-    // Post-rf2-43koh — bump the secondary ring's depth so the test can
-    // assert against a 1000-event budget without coupling the new
-    // default to a perf-test invariant. The default
-    // `default-frameless-ring-depth` (100) is what production hosts see.
+    // Bump the secondary ring's depth so the test can assert against a
+    // 1000-event budget without coupling the production default to a
+    // perf-test invariant. The default `default-frameless-ring-depth`
+    // (100) is what production hosts see.
     if (typeof bus.set_frameless_ring_depth_BANG_ === 'function') {
       bus.set_frameless_ring_depth_BANG_(eventCount);
     }
@@ -849,17 +776,17 @@ async function pushSyntheticTraceEvents(page, count) {
         ? cljs.keyword.call(null, trimmed)
         : cljs.keyword(trimmed);
     }
-    // Post rf2-ycoct: the Trace tab is cascade-scoped — it only
-    // renders rows belonging to the spine's focused cascade. To stress
-    // the per-cascade 200-row DOM budget we push every synthetic event
-    // under a SINGLE shared :dispatch-id so the buffer holds one
-    // focusable cascade containing all `eventCount` rows; LIVE mode
-    // auto-snaps focus to that head cascade and the trace ribbon ends
-    // up trying to render all 1000 — which the DOM budget then caps at
-    // 200 with the overflow indicator. (The earlier shape allocated a
-    // distinct :dispatch-id per event, producing 1000 single-row
-    // cascades; under cascade-scoping only the head cascade — a single
-    // row — would render, missing the budget assertion entirely.)
+    // The Trace tab is cascade-scoped — it only renders rows belonging to
+    // the spine's focused cascade. To stress the per-cascade 200-row DOM
+    // budget we push every synthetic event under a SINGLE shared
+    // :dispatch-id so the buffer holds one focusable cascade containing
+    // all `eventCount` rows; LIVE mode auto-snaps focus to that head
+    // cascade and the trace ribbon ends up trying to render all 1000 —
+    // which the DOM budget then caps at 200 with the overflow indicator.
+    // (Allocating a distinct :dispatch-id per event would instead produce
+    // 1000 single-row cascades, and under cascade-scoping only the head
+    // cascade — a single row — would render, missing the budget assertion
+    // entirely.)
     const sharedDispatchId = 500000;
     const now = Date.now();
     for (let i = 0; i < eventCount; i += 1) {
@@ -938,10 +865,9 @@ async function readLaunchModeProjection(page) {
         ? Array.from(root.querySelectorAll('[data-testid^="rf-xray-sidebar-item-"]'))
           .find((el) => (el.textContent || '').includes('◉'))
         : null;
-      // rf2-5gl5r — `rf-xray-event-detail-cascade` is gone with the
-      // retired Event/Handler panel. The Epoch panel is the canonical
-      // focused-cascade surface; its DISPATCH step is the rendering
-      // proxy for "a cascade is in focus and its data is rendered".
+      // The Epoch panel is the canonical focused-cascade surface; its
+      // DISPATCH step is the rendering proxy for "a cascade is in focus
+      // and its data is rendered".
       const epochPanel = root && root.querySelector('[data-testid="rf-xray-epoch-panel"]');
       const dispatchStep = root && root.querySelector('[data-testid="rf-xray-epoch-step-dispatch"]');
       return {
@@ -959,9 +885,9 @@ async function readLaunchModeProjection(page) {
         selectedDispatchId: null,
         selectedFrame: null,
         cascadeText: text(root, '[data-testid="rf-xray-epoch-panel"]'),
-        // Post rf2-5gl5r `cascadeRows` semantics shift: 1 when the
-        // Epoch panel rendered a DISPATCH step (focus has a cascade),
-        // 0 when not (empty-state / no-focus / epoch-evicted).
+        // `cascadeRows`: 1 when the Epoch panel rendered a DISPATCH step
+        // (focus has a cascade), 0 when not (empty-state / no-focus /
+        // epoch-evicted).
         cascadeRows: dispatchStep ? 1 : 0,
         traceRows: count(root, '[data-testid^="rf-xray-trace-row-"]'),
         epochPanelPresent: Boolean(epochPanel),
@@ -1040,9 +966,8 @@ async function runShellFeatureSweep(page) {
   await openXray(page);
 
   // Sweep every L3 tab. Each tab click must surface its panel canvas
-  // (per spec/018 §5). The 4-layer chrome dropped the legacy
-  // time-travel / routes / schemas / mcp-server panels — they no
-  // longer have a tab and are not part of this sweep.
+  // (per spec/018 §5). Only the panels with a tab take part in this
+  // sweep; panels without a tab have no UI handoff to assert.
   for (const [id, canvas] of PANEL_HANDOFFS) {
     await clickTab(page, id, canvas);
   }
@@ -1052,11 +977,10 @@ async function runShellFeatureSweep(page) {
   await clickHostButtonByLabel(page, '-');
 
   await clickTab(page, 'epoch', 'rf-xray-epoch-panel');
-  // Post rf2-5gl5r the Epoch panel supersedes the retired Event/Handler
-  // panel. Per rf2-639lc the panel default-focuses the head cascade
-  // on mount; the panel renders the numbered cascade steps directly
-  // (e.g. `rf-xray-epoch-step-dispatch`). Asserts non-empty via the
-  // presence of at least one step row.
+  // The Epoch panel is the canonical "what happened in this epoch"
+  // surface. It default-focuses the head cascade on mount and renders the
+  // numbered cascade steps directly (e.g. `rf-xray-epoch-step-dispatch`).
+  // Asserts non-empty via the presence of at least one step row.
   await waitForValue(
     () => page.locator('[data-testid="rf-xray-epoch-step-dispatch"]').count(),
     (count) => count > 0,
@@ -1064,15 +988,13 @@ async function runShellFeatureSweep(page) {
   );
 
   await clickTab(page, 'trace', 'rf-xray-trace');
-  // rf2-td380: the Trace panel is epoch-scoped — after the host
-  // dispatches above, LIVE auto-snap focuses the head epoch whose
-  // `:trace-events` populate the ribbon. Assert non-empty via the
-  // rendered rows (the 'X / Y in view' counts header is gone, rf2-o6yqq).
+  // The Trace panel is epoch-scoped — after the host dispatches above,
+  // LIVE auto-snap focuses the head epoch whose `:trace-events` populate
+  // the ribbon. Assert non-empty via the rendered rows (there is no
+  // 'X / Y in view' counts header).
   //
-  // rf2-jnxfj — rows are now `:div`s wrapped by the shared
-  // `rt/resizable-table` view (formerly `:li`s in a `:ul`). The
-  // data-testid contract `rf-xray-trace-row-<id>` is unchanged; only
-  // the container tag-name moved.
+  // Rows are `:div`s wrapped by the shared `rt/resizable-table` view. The
+  // data-testid contract `rf-xray-trace-row-<id>` identifies each row.
   await waitForValue(
     () => page.locator('[data-testid^="rf-xray-trace-row-"]').count(),
     (count) => count > 0,
@@ -1086,10 +1008,10 @@ async function runSourceCoordinatesAndLaunchModes(page, state, ctx) {
   await clearTrace(page);
   await clickHostButtonByLabel(page, '+');
   await waitForTraceMatch(page, /counter\/core\.cljs/, 'counter source-coordinate trace');
-  // rf2-td380 + rf2-gkczt: the Trace panel is epoch-scoped with no chip
-  // filter. After the host dispatch the spine auto-snaps focus to the
-  // head epoch (LIVE), whose `:trace-events` carry the source-coord
-  // rows — no filter step needed; every row's source-coord chip renders.
+  // The Trace panel is epoch-scoped with no chip filter. After the host
+  // dispatch the spine auto-snaps focus to the head epoch (LIVE), whose
+  // `:trace-events` carry the source-coord rows — no filter step needed;
+  // every row's source-coord chip renders.
   await waitForValue(
     () => page.locator('[data-testid^="rf-xray-trace-row-"] button[data-testid$="-source-coord"]').count(),
     (count) => count > 0,
@@ -1117,12 +1039,10 @@ async function runExceptionSchemaHttp(page, state, ctx) {
     ['machine exception', /machine-action-exception|deliberate-throw \/ machine action/],
   ]);
 
-  // rf2-gbz39 — the dedicated Issues tab was removed (Mike RULED
-  // Option (c)). Exceptions now surface INLINE in the Epoch panel as
-  // the "Exception Thrown" block (rf2-ahhgn / rf2-wnvid). Verify the
-  // inline surfacing, then run the source-coord bridge against the
-  // Trace panel's source-coord chips (the same exception traces carry
-  // the coords) since the Issues feed no longer exists.
+  // Exceptions surface INLINE in the Epoch panel as the "Exception
+  // Thrown" block. Verify the inline surfacing, then run the source-coord
+  // bridge against the Trace panel's source-coord chips (the same
+  // exception traces carry the coords).
   await clickTab(page, 'epoch', 'rf-xray-epoch-panel');
   await expectVisible(page.locator('[data-testid="rf-xray-epoch-panel"]'), 5000);
   const exceptionEpochText = ((await page.locator('[data-testid="rf-xray-epoch-panel"]').textContent()) || '').toLowerCase();
@@ -1132,18 +1052,18 @@ async function runExceptionSchemaHttp(page, state, ctx) {
     });
   }
 
-  // rf2-s6oqd + rf2-oqi0c — focus the handler-throw epoch (Button A,
-  // `::throw-in-handler`: throws before returning a `:db`) and assert the
-  // exception-chrome fixes hold on the live cascade:
-  //   (s6oqd)  NO spurious "Rolled back" recovery chip — nothing committed
-  //            or rolled back here (and the post-commit/flow throws in this
-  //            deck likewise never roll back the committed `:db`).
-  //   (oqi0c-b) NO category-reason boilerplate headline element on any
-  //            exception card (the position + "Exception Thrown" heading
-  //            carry the attribution).
-  //   (oqi0c-a) the HANDLER step does NOT render the redundant
-  //            "— no :db (handler threw)" line — the inline card is the
-  //            signal, so the `:db` sub-section is omitted on a throw.
+  // Focus the handler-throw epoch (Button A, `::throw-in-handler`: throws
+  // before returning a `:db`) and assert the exception-chrome contract
+  // holds on the live cascade:
+  //   (1) NO spurious "Rolled back" recovery chip — nothing committed or
+  //       rolled back here (and the post-commit/flow throws in this deck
+  //       likewise never roll back the committed `:db`).
+  //   (2) NO category-reason boilerplate headline element on any exception
+  //       card (the position + "Exception Thrown" heading carry the
+  //       attribution).
+  //   (3) the HANDLER step does NOT render the redundant
+  //       "— no :db (handler threw)" line — the inline card is the signal,
+  //       so the `:db` sub-section is omitted on a throw.
   await focusCascadeByFrameEvent(page, {
     frame: ':rf/default',
     eventId: ':deliberate-throw.core/throw-in-handler',
@@ -1155,7 +1075,7 @@ async function runExceptionSchemaHttp(page, state, ctx) {
     (count) => count > 0,
     { timeoutMs: 5000, description: 'oqi0c — handler exception card present' },
   );
-  // (s6oqd) no rollback happened → NO "Rolled back" recovery chip anywhere
+  // (1) no rollback happened → NO "Rolled back" recovery chip anywhere
   const handlerEpochRecoveryChips = await page
     .locator('[data-testid="rf-xray-epoch-panel"] [data-testid$="-recovery"]')
     .count();
@@ -1169,7 +1089,7 @@ async function runExceptionSchemaHttp(page, state, ctx) {
       chipText,
     });
   }
-  // (oqi0c-b) the category-reason boilerplate headline is dropped
+  // (2) no category-reason boilerplate headline is rendered
   const handlerEpochHeadlines = await page
     .locator('[data-testid="rf-xray-epoch-panel"] [data-testid$="-headline"]')
     .count();
@@ -1178,7 +1098,7 @@ async function runExceptionSchemaHttp(page, state, ctx) {
       headlineCount: handlerEpochHeadlines,
     });
   }
-  // (oqi0c-a) the HANDLER step omits the "— no :db (handler threw)" line
+  // (3) the HANDLER step omits the "— no :db (handler threw)" line
   const handlerThrewNoDbLine = await page
     .locator('[data-testid="rf-xray-epoch-handler-db-no-write"]')
     .count();
@@ -1223,15 +1143,14 @@ async function runHttpToggle(page) {
     await waitForTraceMatch(page, new RegExp(outcome.replace('.', '\\.')), `${outcome} trace`);
   }
 
-  // Post rf2-xy4yb: the dedicated Effects (fx) panel was dropped.
-  // Post rf2-5gl5r the Epoch panel is the canonical "what happened
-  // in this epoch" surface. Per rf2-639lc the panel default-focuses
-  // the head (most-recent) cascade on mount — opening the tab after
-  // the last `:go` dispatch surfaces its full numbered cascade.
-  // Assert the rendered panel carries the EFFECT HANDLERS step (rf2-kt6js;
-  // the `:rf.fx/handled` emits for the dispatched `:go` event are
-  // projected into the step's `:fx` sub-step). The step header reads
-  // "EFFECT HANDLERS" and the `:fx` sub-header reads ":fx".
+  // The Epoch panel is the canonical "what happened in this epoch"
+  // surface and folds fx/effects in as inline steps of its numbered
+  // cascade. It default-focuses the head (most-recent) cascade on mount —
+  // opening the tab after the last `:go` dispatch surfaces its full
+  // numbered cascade. Assert the rendered panel carries the EFFECT
+  // HANDLERS step (the `:rf.fx/handled` emits for the dispatched `:go`
+  // event are projected into the step's `:fx` sub-step). The step header
+  // reads "EFFECT HANDLERS" and the `:fx` sub-header reads ":fx".
   await clickTab(page, 'epoch', 'rf-xray-epoch-panel');
   await expectVisible(page.locator('[data-testid="rf-xray-epoch-panel"]'), 5000);
   const epochText = ((await page.locator('[data-testid="rf-xray-epoch-panel"]').textContent()) || '').toLowerCase();
@@ -1240,10 +1159,6 @@ async function runHttpToggle(page) {
       epochText: epochText.slice(0, 800),
     });
   }
-  // rf2-gbz39 — the Issues tab was removed (Mike RULED Option (c)).
-  // The fx outcomes for this scenario surface inline in the Epoch
-  // panel's EFFECT HANDLERS step (asserted above); there is no dedicated
-  // Issues tab to hand off to anymore.
 }
 
 async function runMultiFrame(page, state) {
@@ -1304,21 +1219,19 @@ async function runMultiFrame(page, state) {
     (count) => count > 0,
     { timeoutMs: 5000, description: 'multi-frame trace rows' },
   );
-  // Post rf2-ycoct: the Trace tab is cascade-scoped — it only renders
-  // rows belonging to the spine's focused cascade. LIVE mode auto-
-  // snaps focus to the head cascade (the most recent dispatch), so
-  // unless the :counter/b :multi-frame.core/inc cascade happens to be
-  // the head the Trace DOM never contains that row. The old test
-  // scanned `[data-testid^="rf-xray-trace-row-"]` for it directly
-  // and failed under cascade-scoping.
+  // The Trace tab is cascade-scoped — it only renders rows belonging to
+  // the spine's focused cascade. LIVE mode auto-snaps focus to the head
+  // cascade (the most recent dispatch), so unless the :counter/b
+  // :multi-frame.core/inc cascade happens to be the head the Trace DOM
+  // does not contain that row.
   //
   // The test's intent — exercise the cascade-focus → event-detail
-  // wiring for a chosen :counter/b cascade — is preserved by focusing
-  // the cascade explicitly via the spine event `:rf.xray/focus-
-  // cascade` (the same event the L2 event-row click dispatches) and
-  // then asserting the event-detail projection. We look up the
-  // dispatch-id by walking the bus buffer for the (frame, event-id)
-  // pair, which is independent of the cascade-scoped Trace DOM.
+  // wiring for a chosen :counter/b cascade — is met by focusing the
+  // cascade explicitly via the spine event `:rf.xray/focus-cascade`
+  // (the same event the L2 event-row click dispatches) and then asserting
+  // the event-detail projection. We look up the dispatch-id by walking
+  // the bus buffer for the (frame, event-id) pair, which is independent
+  // of the cascade-scoped Trace DOM.
   //
   // The L2 event list is frame-scoped: in a multi-frame app the
   // operator first picks the frame they want to inspect (the L1
@@ -1339,10 +1252,9 @@ async function runMultiFrame(page, state) {
     eventId: ':multi-frame.core/inc',
   });
   state.multiFrame.selectedTraceRow = selected;
-  // Post rf2-5gl5r the Epoch panel supersedes the retired Event/
-  // Handler panel; the selected-cascade projection lives on the
-  // Epoch DISPATCH step. Assert the panel text carries the event-id
-  // of the focused multi-frame cascade.
+  // The selected-cascade projection lives on the Epoch panel's DISPATCH
+  // step. Assert the panel text carries the event-id of the focused
+  // multi-frame cascade.
   await clickTab(page, 'epoch', 'rf-xray-epoch-panel');
   const eventDetailProjection = await waitForValue(
     () => page.evaluate(() => {
@@ -1368,12 +1280,9 @@ async function runMultiFrame(page, state) {
       expectedEvent: ':multi-frame.core/inc',
     });
   }
-  // Post rf2-xy4yb: the dedicated Causality and Time-Travel panels
-  // were dropped (Causality fully removed in rf2-y0z5b). Per
-  // spec/018 §5 + §6 Time Travel folds into the Event tab + RETRO
-  // scrubbing on the L2 event list. This scenario covers multi-
-  // frame isolation through the trace + event-tab cascade evidence
-  // above; the dedicated time-travel handoff steps are retired.
+  // This scenario covers multi-frame isolation through the trace +
+  // Epoch-tab cascade evidence above. Time Travel is part of the Epoch
+  // tab + RETRO scrubbing on the L2 event list (spec/018 §5 + §6).
 }
 
 async function runDeepMachine(page, state) {
@@ -1389,8 +1298,8 @@ async function runDeepMachine(page, state) {
   await clickSidebar(page, 'machines', 'rf-xray-machine-inspector');
   await expectVisible(page.locator('[data-testid="rf-xray-machine-inspector"]'), 5000);
 
-  // rf2-bz72m — drive the chart-render path through the existing
-  // test-only event surface (`:rf.xray/set-epoch-history-for-test` +
+  // Drive the chart-render path through the test-only event surface
+  // (`:rf.xray/set-epoch-history-for-test` +
   // `:rf.xray/set-focus-epoch-id-for-test`, both registered by
   // `panels/machine_inspector.cljs` §595 and not gated behind
   // `interop/debug-enabled?`).
@@ -1410,7 +1319,7 @@ async function runDeepMachine(page, state) {
   // empty in production today. (A future framework fix is tracked
   // separately — orthogonal to the shim-survival probe.)
   //
-  // The shim-survival probe this bead actually wants — the
+  // This scenario's shim-survival probe — the
   // chart/{svg,layout,elk_layout} re-export chain — only fires when
   // the focused epoch's cascade window carries at least one
   // `:rf.machine/transition` row whose `:machine-id` resolves to a
@@ -1489,13 +1398,11 @@ async function runDeepMachine(page, state) {
   state.deepMachine = state.deepMachine || {};
   state.deepMachine.chartInjection = chartInjection;
 
-  // rf2-bz72m / rf2-gpzb4 — assert the machines-viz xyflow chart
-  // actually renders. The chart was migrated to `@xyflow/react` on
-  // 2026-05-21 (Mike override of the 2026-05-19 ELK+SVG lock); the
-  // canvas is no longer a raw `<svg>` but an xyflow `<div
+  // Assert the machines-viz xyflow chart actually renders. The chart is
+  // built on `@xyflow/react`; the canvas is an xyflow `<div
   // class="react-flow">` containing per-node child `<div>`s. The
-  // assertion now counts (1) the chart wrapper testid, (2) the
-  // xyflow root class, and (3) at least one rendered state node
+  // assertion counts (1) the chart wrapper testid, (2) the xyflow root
+  // class, and (3) at least one rendered state node
   // (`[data-testid^="rf-mv-chart-node-"]`) — non-zero proves elk.js
   // laid out + xyflow rendered + the machines-viz custom node
   // components resolved through the shim chain.
@@ -1652,14 +1559,11 @@ async function runLargeDispatcher(page, state) {
   const traceEvents = await readTrace(page);
   await clickSidebar(page, 'app-db', 'rf-xray-app-db-diff');
   await expectVisible(page.locator('[data-testid="rf-xray-app-db-diff"]'), 5000);
-  // rf2-ndb13 — large markers render as first-class chip chrome inside
-  // the edn-inspector (the predicate previously mis-matched `:rf/large`
-  // and the marker fell through to ordinary map rendering, surfacing
-  // the `:rf.size/large-elided` keyword as plain text). With the
-  // predicate now keyed off the spec/015 marker, the chip appears under
-  // `[data-testid="rf-xray-edn-inspector-large"]`. Assert chip presence
-  // and absence of the raw payload — the two together cover "elision
-  // marker surfaced" and "raw value never leaks".
+  // Large markers render as first-class chip chrome inside the
+  // edn-inspector. The predicate is keyed off the spec/015 marker, so the
+  // chip appears under `[data-testid="rf-xray-edn-inspector-large"]`.
+  // Assert chip presence and absence of the raw payload — the two together
+  // cover "elision marker surfaced" and "raw value never leaks".
   const largeChips = page.locator(
     '[data-testid="rf-xray-app-db-diff"] [data-testid="rf-xray-edn-inspector-large"]',
   );
@@ -1678,9 +1582,9 @@ async function runLargeDispatcher(page, state) {
       appDbText: appDbText.slice(0, 1200),
     });
   }
-  // rf2-8pfkk — the edn-inspector's internal `::missing` absence
-  // sentinel (`:day8.re-frame2-xray.views.edn-inspector/missing`) must
-  // NEVER reach the rendered App-DB Diff. A removed slot renders as a
+  // The edn-inspector's internal `::missing` absence sentinel
+  // (`:day8.re-frame2-xray.views.edn-inspector/missing`) must NEVER reach
+  // the rendered App-DB Diff. A removed slot renders as a
   // struck-through ghost, not a literal sentinel keyword. The
   // per-rendering removed-to-empty + deleted-ancestor cases are pinned
   // exhaustively in the CLJS unit tests (`edn_inspector_cljs_test.cljs`
@@ -1708,21 +1612,18 @@ async function runLargeDispatcher(page, state) {
 async function runHydration(page) {
   // ---- (1) verify-hydration! emitted the structured trace ------------
   //
-  // Post rf2-xy4yb: the dedicated Hydration debugger panel was
-  // dropped. Post rf2-gbz39 (Mike RULED Option (c)) the Issues tab was
-  // ALSO removed; hydration mismatches surface as `:rf.ssr/*` rows
-  // (category-prefix "rf.ssr") via the L2 event-row signal + the
-  // always-on issues ribbon (auto-open-on-error) rather than a tab.
+  // Hydration mismatches surface as `:rf.ssr/*` rows (category-prefix
+  // "rf.ssr") via the L2 event-row signal + the always-on issues ribbon
+  // (auto-open-on-error).
   //
   // `:rf.ssr/hydration-mismatch` is emitted by `verify-hydration!`
   // OUTSIDE any event-handler context (see testbed `core.cljs:188`).
   // The framework's epoch capture (`re-frame.epoch.capture/capture-
   // event!`) drops out-of-cascade orphan emits — an error with no
-  // in-flight cascade AND no `:dispatch-id` (rf2-avvwm) — so the
-  // mismatch trace never lands in any `:rf/epoch-record`'s
-  // `:trace-events`. Surfacing orphaned out-of-cascade errors is a
-  // deliberately separate concern (the L2 timeline's per-row signal,
-  // not a per-epoch panel).
+  // in-flight cascade AND no `:dispatch-id` — so the mismatch trace
+  // never lands in any `:rf/epoch-record`'s `:trace-events`. Surfacing
+  // orphaned out-of-cascade errors is a deliberately separate concern
+  // (the L2 timeline's per-row signal, not a per-epoch panel).
   //
   // What this scenario verifies end-to-end:
   //
@@ -1730,16 +1631,15 @@ async function runHydration(page) {
   //     payload — proves `verify-hydration!` reached `emit-error!`)
   //   - the Xray shell opens cleanly under cascade (focused-epoch)
   //     scope without crashing — proving the focused-epoch projection
-  //     + head-fallback (rf2-h0120) resolve to a real epoch record.
+  //     + head-fallback resolve to a real epoch record.
   const mismatchBanner = page.locator('[data-testid="mismatch-banner"]');
   await expectVisible(mismatchBanner, 10000);
   await expectVisible(page.locator('[data-testid="mismatch-server-hash"]'), 5000);
 
-  // ---- (2) Xray shell opens cleanly under cascade scope (rf2-gbz39) ---
-  // The dedicated Issues tab was removed under Option (c). Verify the
-  // shell mounts cleanly and the default Epoch panel renders its
-  // focused-epoch projection without crashing (the head-fallback,
-  // rf2-h0120, resolves to a real epoch record).
+  // ---- (2) Xray shell opens cleanly under cascade scope --------------
+  // Verify the shell mounts cleanly and the default Epoch panel renders
+  // its focused-epoch projection without crashing (the head-fallback
+  // resolves to a real epoch record).
   await openXray(page);
   await clickTab(page, 'epoch', 'rf-xray-epoch-panel');
   await expectVisible(page.locator('[data-testid="rf-xray-epoch-panel"]'), 5000);
@@ -1752,16 +1652,15 @@ async function runTraceBudgetSaturation(page, state) {
   await clearTrace(page);
   const start = Date.now();
   const pushed = await pushSyntheticTraceEvents(page, 1000);
-  // rf2-r6d6u + rf2-td380 (+ rf2-43koh): the saturation invariant is a
-  // RING property. Post-rf2-43koh Xray's secondary frameless ring caps
-  // at `default-frameless-ring-depth` (100 events) by default; the
-  // synthetic-events helper bumps the depth to the pushed count via
-  // `set-frameless-ring-depth!` so this perf test can assert against a
-  // 1000-event budget independent of the production default. Frame-
-  // bound events ride the framework's per-frame rings (cascade-keyed,
-  // capped at `:cascades-retained` per frame). The Trace PANEL stays
-  // epoch-scoped (rf2-td380) — it renders the focused epoch record's
-  // `:trace-events`, NOT the global bus.
+  // The saturation invariant is a RING property. Xray's secondary
+  // frameless ring caps at `default-frameless-ring-depth` (100 events) by
+  // default; the synthetic-events helper bumps the depth to the pushed
+  // count via `set-frameless-ring-depth!` so this perf test can assert
+  // against a 1000-event budget independent of the production default.
+  // Frame-bound events ride the framework's per-frame rings (cascade-
+  // keyed, capped at `:cascades-retained` per frame). The Trace PANEL is
+  // epoch-scoped — it renders the focused epoch record's `:trace-events`,
+  // NOT the global bus.
   const expectedDepth = 1000;
   const saturatedDepth = await waitForValue(
     () => readTraceBufferDepth(page),
@@ -1800,8 +1699,8 @@ async function runTraceBudgetSaturation(page, state) {
 async function runLaunchModesTwentyEventLoad(page, state) {
   await expectHostCounterEquals(page, 5, 10000);
   await openXray(page);
-  // rf2-5gl5r — `event-detail` → `epoch` tab; the Epoch panel's
-  // root testid is `rf-xray-epoch-panel`.
+  // `event-detail` routes to the `epoch` tab; the Epoch panel's root
+  // testid is `rf-xray-epoch-panel`.
   await clickSidebar(page, 'event-detail', 'rf-xray-epoch-panel');
 
   const launch = await page.evaluate(() => {
@@ -1894,13 +1793,12 @@ async function runLaunchModesTwentyEventLoad(page, state) {
   }
 }
 
-// rf2-qd5r6 — ex-Tier-2 L-10 deepening of the Config (Spec 015) surface.
-// The lightweight chrome smokes already cover inline auto-mount + the
-// Ctrl+Shift+C toggle + the editor/project-root config round-trip
-// (Tier-1 §1 / §8 / §10c equivalents). What was not previously pinned
-// is the `configure!` multi-key map + partial-update semantics: a
-// single call carrying five keys round-trips every key; a second call
-// carrying only one key leaves the other four slots untouched.
+// Deepened coverage of the Config (Spec 015) surface. The lightweight
+// chrome smokes cover inline auto-mount + the Ctrl+Shift+C toggle + the
+// editor/project-root config round-trip. This scenario pins the
+// `configure!` multi-key map + partial-update semantics: a single call
+// carrying five keys round-trips every key; a second call carrying only
+// one key leaves the other four slots untouched.
 async function runConfigurePartialUpdate(page, state) {
   await expectHostCounterEquals(page, 5, 10000);
   await openXray(page);
@@ -1913,9 +1811,8 @@ async function runConfigurePartialUpdate(page, state) {
     if (typeof cfg.configure_BANG_ !== 'function') {
       return { ok: false, reason: 'configure_BANG_ missing' };
     }
-    // Two-arg keyword constructor: kw(ns, n) → :ns/n. Required for the
-    // rf2-xea9u rename: every configure! key now lives under :rf.xray/*
-    // or :rf.privacy/* (cross-tool privacy).
+    // Two-arg keyword constructor: kw(ns, n) → :ns/n. Every configure!
+    // key lives under :rf.xray/* or :rf.privacy/* (cross-tool privacy).
     const kw = (ns, n) => (cljs.keyword.call
       ? cljs.keyword.call(null, ns, n)
       : cljs.keyword(ns, n));
@@ -1996,7 +1893,7 @@ async function runConfigurePartialUpdate(page, state) {
 
     // Restore pre-state. Narrowing the egress profile :rf.egress/local-raw
     // → redacting default triggers the trace-bus retroactive scrub per
-    // Spec 009 §Privacy (rf2-lqmje); that's expected and not visible here.
+    // Spec 009 §Privacy; that's expected and not visible here.
     cfg.set_editor_BANG_(preEditor);
     cfg.set_project_root_BANG_(preProjectRoot);
     cfg.set_layout_host_selector_BANG_(preLayoutHost);
@@ -2017,18 +1914,15 @@ async function runConfigurePartialUpdate(page, state) {
   state.configureProbe = { ok: true };
 }
 
-// rf2-n39g2 — Static-mode browser scenario.
+// Static-mode browser scenario.
 //
-// Static mode shipped under #1565 + #1568 + #1569 (rf2-o5f5f.1 / .2 / .3).
-// Per rf2-8l3uk the `:rf.xray/static-mode?` feature gate was removed —
-// Static mode is unconditionally available. Before this scenario the
-// feature-matrix carried zero browser coverage for the highest-user-
-// visible Xray surface to land in the recent cluster. This scenario:
+// Static mode is unconditionally available (no feature gate). This
+// scenario:
 //
-//   1. Asserts the Dynamic baseline — mode dropdown present with
-//      `dynamic` selected (rf2-4vp5j reshaped the two-button pill into a
-//      compact `<select>`; `data-active-mode`/`value` carry the state),
-//      L2 spine event-list visible (4-layer chrome).
+//   1. Asserts the Dynamic baseline — the mode control is a compact
+//      `<select>` dropdown present with `dynamic` selected
+//      (`data-active-mode`/`value` carry the state), L2 spine event-list
+//      visible (4-layer chrome).
 //   2. Fires Ctrl+Shift+M (the cross-platform chord per
 //      `keybinding.cljs/mode-toggle-key?` — Cmd-Shift-M on macOS,
 //      Ctrl-Shift-M elsewhere; Playwright drives Ctrl as the headless
@@ -2036,16 +1930,12 @@ async function runConfigurePartialUpdate(page, state) {
 //      dropdown reads `static`, the Static surface mounts
 //      (`rf-xray-static-surface` with `data-rf-xray-mode="static"`),
 //      the L2 spine disappears (3-layer silhouette — chrome-silhouette
-//      mode-signal #4), the Machines sub-tab is selected by default
-//      (rf2-o5f5f.1 §tabs), and each shipped sub-tab (Routes / Schemas
-//      / Views / Flows) mounts its real panel root testid while
-//      `:events` (rf2-o5f5f.6 — last remaining placeholder) still
-//      renders a placeholder card naming the sibling bead.
+//      mode-signal #4), the Machines sub-tab is selected by default,
+//      and each shipped sub-tab (Routes / Schemas / Flows /
+//      Interceptors) mounts its real panel root testid.
 //   3. Selects `Dynamic` in the dropdown; mode flips back; L2 spine
 //      returns (proves the dropdown is the canonical toggle path too —
 //      not just the chord).
-//   4. Reloads the page; asserts localStorage `xray.mode` round-
-//      trips the last-set mode (Dynamic here, per the flip-back step).
 async function runStaticModeChromeAndChord(page, state) {
   // ---- (0) baseline — clear the persisted mode slot -----------------
   await page.goto(page.url(), { waitUntil: 'load' });
@@ -2062,10 +1952,9 @@ async function runStaticModeChromeAndChord(page, state) {
   await openXray(page);
 
   // ---- (1) Dynamic baseline -----------------------------------------
-  // Per rf2-8l3uk the mode control is always rendered (the Static-mode
-  // feature gate was removed). Per rf2-4vp5j it is a compact `<select>`
-  // dropdown; `data-active-mode` + `value` carry the active mode.
-  // Dynamic must be selected by default.
+  // The mode control is always rendered (Static mode is unconditionally
+  // available). It is a compact `<select>` dropdown; `data-active-mode` +
+  // `value` carry the active mode. Dynamic must be selected by default.
   await expectVisible(
     page.locator('[data-testid="rf-xray-mode-pill"]'),
     5000,
@@ -2120,8 +2009,8 @@ async function runStaticModeChromeAndChord(page, state) {
         '[data-testid="rf-xray-static-tab-machines"]',
       );
       // L4 detail panel — when Machines is the default tab the live
-      // panel mounts (rf2-o5f5f.2); the static-detail-panel-* root
-      // remains a stable testid hook regardless of which tab is selected.
+      // panel mounts; the static-detail-panel-* root is a stable testid
+      // hook regardless of which tab is selected.
       const detailPanel = document.querySelector(
         '[data-testid="rf-xray-static-detail-panel-machines"]',
       );
@@ -2152,15 +2041,11 @@ async function runStaticModeChromeAndChord(page, state) {
 
   // ---- (2a) Walk the Static sub-tabs --------------------------------
   // Tab inventory (per `static/shell.cljs/static-tabs`):
-  //   :machines     (.2 — default, mounted above)
-  //   :routes       (.3 — shipped #1568)
-  //   :schemas      (.4 — shipped #1636 / rf2-o5f5f.4)
-  //   :flows        (rf2-uhsqb — shipped #1636)
-  //   :interceptors (.6 — shipped)
-  //
-  // rf2-b2fif dropped the Static Views + Events sub-tabs — the info
-  // those tabs surfaced is already in the source code; the tabs were
-  // not pulling their weight.
+  //   :machines     (default, mounted above)
+  //   :routes
+  //   :schemas
+  //   :flows
+  //   :interceptors
   //
   // For each shipped panel we click its tab and wait for the panel's
   // canonical root `data-testid` (e.g. `rf-xray-static-schemas`) —
@@ -2202,9 +2087,9 @@ async function runStaticModeChromeAndChord(page, state) {
     shippedSubTabRoots[tabId] = observed;
   }
 
-  // Per rf2-o5f5f.6 all Static sub-tabs are now panelled — no
-  // placeholder cards remain. Keep the empty inventory + texts map so
-  // the downstream scenario snapshot shape stays stable.
+  // All Static sub-tabs are panelled — there are no placeholder cards.
+  // Keep the empty texts map so the downstream scenario snapshot shape
+  // stays stable.
   const placeholderTexts = {};
   // Restore the Machines tab so subsequent steps see the default L4.
   await page.locator('[data-testid="rf-xray-static-tab-machines"]').click();
@@ -2214,8 +2099,8 @@ async function runStaticModeChromeAndChord(page, state) {
   );
 
   // ---- (3) Select Dynamic in the dropdown — Static → Dynamic --------
-  // rf2-4vp5j — the mode control is a `<select>`; flipping back is a
-  // selectOption (the canonical toggle path, not just the chord).
+  // The mode control is a `<select>`; flipping back is a selectOption
+  // (the canonical toggle path, not just the chord).
   await page.locator('[data-testid="rf-xray-mode-pill"]').selectOption('dynamic');
   const afterClickBack = await waitForValue(
     () => page.evaluate(() => {
@@ -2243,11 +2128,6 @@ async function runStaticModeChromeAndChord(page, state) {
     { timeoutMs: 5000, description: 'Dynamic restored after selecting Dynamic in the dropdown' },
   );
 
-  // Per rf2-8l3uk Static mode is unconditionally available — no feature
-  // flag re-opt-in to exercise. The earlier reload/persistence cycle
-  // checked a localStorage round-trip that survived the gate removal
-  // only via a dangling `reoptIn` reference (rf2-rat6r); the branch is
-  // dead code and removed here.
   state.staticMode = {
     dynamicBaseline,
     afterChord,
@@ -2257,13 +2137,11 @@ async function runStaticModeChromeAndChord(page, state) {
   };
 }
 
-// rf2-z5zip — Cmd-K command palette browser scenario.
+// Cmd-K command palette browser scenario.
 //
-// The palette shipped under #1572 (rf2-ybjkx) — 6 new verbs, mode-
-// aware command index, recents slot, reduced-motion override. The
-// pre-bead suite carried helper-level unit gates only (no end-to-end
-// browser proof that the chord-bind → view-mount → dispatch route
-// land together). This scenario:
+// The palette offers verbs, a mode-aware command index, a recents slot,
+// and a reduced-motion override. This scenario gives end-to-end browser
+// proof that the chord-bind → view-mount → dispatch route land together:
 //
 //   1. Opens Xray, clears the recents slot (so the test starts from
 //      a known empty-recents state), then presses Ctrl+K.
@@ -2487,23 +2365,20 @@ async function runPaletteOpenExecute(page, state) {
   };
 }
 
-// rf2-azfct — Mike-authorised 2026-05-28 (explicit exception to the
-// "default Causa/Story tests to CLJS" rule because real-browser CSS-
-// variable resolution is the signal under test; the CLJS render-tree
-// tests pin the inline-style → `var(--rf-xray-*)` contract at the
-// hiccup layer but cannot prove the browser actually substitutes a
-// hex at paint time).
+// A deliberate exception to the "default Causa/Story tests to CLJS" rule:
+// real-browser CSS-variable resolution is the signal under test. The CLJS
+// render-tree tests pin the inline-style → `var(--rf-xray-*)` contract at
+// the hiccup layer but cannot prove the browser actually substitutes a
+// hex at paint time.
 //
-// rf2-pqulr (the P1 this gate catches): panel-gallery's boot path
-// missing `global-styles/install!` left every `var(--rf-xray-*)`
-// reference resolving to its CSS fallback default, painting every
-// variant unstyled. Without an automated gate the regression went
-// undetected for some time.
+// The regression class this gate guards against: a boot path that misses
+// `global-styles/install!` leaves every `var(--rf-xray-*)` reference
+// resolving to its CSS fallback default, painting every variant unstyled.
 //
-// The probe is minimal — one variant load + one token assertion per
-// the bead's acceptance. The Story shell is left at its default
-// landing (no variant click) because `:root` CSS custom properties
-// are global; the only thing under test is "did boot install them?".
+// The probe is minimal — one variant load + one token assertion. The
+// Story shell is left at its default landing (no variant click) because
+// `:root` CSS custom properties are global; the only thing under test is
+// "did boot install them?".
 async function runPanelGalleryThemeTokens(page, state) {
   // 1. Visit the gallery at /#/stories so the Story shell mounts.
   //    The gallery's boot calls `global-styles/install!` from
@@ -2561,8 +2436,8 @@ async function runPanelGalleryThemeTokens(page, state) {
   }
 }
 
-// rf2-5crg4 — routes-epochs routing step-up deck. Walks the deck's
-// numbered ladder top-to-bottom and asserts the Xray Routing panel
+// The routes-epochs routing step-up deck. Walks the deck's numbered
+// ladder top-to-bottom and asserts the Xray Routing panel
 // (`rf-xray-routing`) lights up across its three sections — CURRENT
 // ROUTE, NAVIGATION THIS EPOCH, and the nested ROUTE TABLE — plus the
 // blocked-navigation outcome. The deck owns its routes/events/subs and
@@ -2576,21 +2451,17 @@ async function runPanelGalleryThemeTokens(page, state) {
 
 // Drive a deck ladder rung by its (1-based) rung number.
 //
-// rf2-3xakq — the deck was converted to the shared queued-step runner
-// (`runner.core`). It no longer mounts a bespoke `routes-epochs-rung-<n>`
-// button per rung; instead the runner renders one step row per step, and
-// each row's index is a RANDOM-ACCESS RUN-THIS-STEP button
-// (`routes-epochs-step-<n>-run`, n = 0-based step index). The runner's
-// per-step run affordance is exactly the random-access addressing this
-// scenario needs — it drives rungs OUT OF ORDER (#3, #1, #4, #5, #7, #10,
-// #11), asserting the Routing panel after each, which the runner's
-// sequential cursor alone could not provide.
+// The deck rides the shared queued-step runner (`runner.core`): the
+// runner renders one step row per step, and each row's index is a
+// RANDOM-ACCESS RUN-THIS-STEP button (`routes-epochs-step-<n>-run`,
+// n = 0-based step index). That per-step run affordance is exactly the
+// random-access addressing this scenario needs — it drives rungs OUT OF
+// ORDER (#3, #1, #4, #5, #7, #10, #11), asserting the Routing panel after
+// each.
 //
-// The scenario keeps the historical 1-based rung vocabulary (rung 1 = the
-// first step) and maps it onto the 0-based runner step index here, so every
-// call site below reads unchanged. The step ORDER is identical to the old
-// ladder (same events, same routing features); only the driving affordance
-// moved to the runner.
+// The scenario uses a 1-based rung vocabulary (rung 1 = the first step)
+// and maps it onto the 0-based runner step index here, so every call site
+// below reads in rung terms.
 async function clickRung(page, n) {
   await clickTestId(page, `routes-epochs-step-${n - 1}-run`);
 }
@@ -2768,17 +2639,15 @@ async function runRoutesEpochs(page, state) {
       snap.currentId && snap.currentId.includes('routes-epochs/settings'),
     { timeoutMs: 10000, description: '#11 try-leave → guard blocked, CURRENT ROUTE stays :settings' },
   );
-  // rf2-wxu4l3 — the `afterBlocked` wait above resolves IMMEDIATELY because
-  // CURRENT ROUTE was already on :settings from rung #10, so a bare read of
-  // the pending-nav slot here races the #11 block cascade's runtime-db
+  // The `afterBlocked` wait above resolves IMMEDIATELY because CURRENT
+  // ROUTE was already on :settings from rung #10, so a bare read of the
+  // pending-nav slot here would race the #11 block cascade's runtime-db
   // commit (the slice-stayed-put invariant proves nothing changed, but the
   // commit that WRITES `:rf/pending-navigation` lands a tick later). Poll
-  // until the slot fills. The probe also reads the CORRECT location: per
-  // EP-0001 (rf2-vzld77) the pending-nav slot is durable routing RUNTIME-DB
-  // state at `[:rf.runtime/routing :pending-navigation]` — read via the
-  // public `re-frame.core/runtime-db-value` seam, NOT app-db (the former
-  // `app-db-value` probe at `[:rf/runtime :routing ...]` read the stale
-  // pre-EP-0001 partition + key and always saw nil). The deck strip
+  // until the slot fills. The probe reads the canonical location: per
+  // EP-0001 the pending-nav slot is durable routing RUNTIME-DB state at
+  // `[:rf.runtime/routing :pending-navigation]` — read via the public
+  // `re-frame.core/runtime-db-value` seam, NOT app-db. The deck strip
   // (`:rf/pending-navigation` runtime-sub) is the secondary cross-check.
   const pendingProbe = await waitForValue(
     () => page.evaluate(() => {
@@ -2833,10 +2702,10 @@ async function runRoutesEpochs(page, state) {
   };
 }
 
-// rf2-w06op + rf2-kipb5 — machine-epochs state-machine deck, converted to the
-// shared queued-step runner (`runner.core`). Walks the deck's step matrix
-// top-to-bottom (via the runner's per-step RUN-THIS-STEP buttons) and asserts
-// each step's machine feature landed, then opens the Xray Machine Inspector
+// The machine-epochs state-machine deck, built on the shared queued-step
+// runner (`runner.core`). Walks the deck's step matrix top-to-bottom (via
+// the runner's per-step RUN-THIS-STEP buttons) and asserts each step's
+// machine feature landed, then opens the Xray Machine Inspector
 // (`rf-xray-machine-inspector`) and confirms the panel mounts on the focused
 // machine event. The final handoff re-drives a few steps OUT OF ORDER (the
 // fresh-transition / unhandled-no-op / boot-entry-throw contrast) — the random-
@@ -2844,14 +2713,14 @@ async function runRoutesEpochs(page, state) {
 //
 // What this scenario can / cannot assert:
 // —————————————————————————————————————————————————————————————
-// rf2-q3lfm — the deck OWNS all 8 machine domains and drives each through the
-// REAL `reg-machine` + machine-event-routing surface, but each domain now
-// runs in its OWN frame (`:machine/<track>`). Every step's machine FEATURE
+// The deck OWNS all 8 machine domains and drives each through the REAL
+// `reg-machine` + machine-event-routing surface, with each domain running
+// in its OWN frame (`:machine/<track>`). Every step's machine FEATURE
 // (plain transition · entry/exit data delta · guard pass vs fail ·
 // parallel-region broadcast · ignored event · microstep · timer · spawn ·
 // deep-compound LCA · history) is genuinely exercised and is observable in
-// THAT track's frame app-db machine snapshot, read directly via the public
-// `re-frame.core/app-db-value` accessor (`readTrackSnapshots`, scoped to
+// THAT track's frame machine snapshot, read directly via the public
+// `re-frame.core/runtime-db-value` accessor (`readTrackSnapshots`, scoped to
 // `:machine/<track>`). We assert those per-frame snapshot facts — they are
 // the robust, non-flaky proof each machine feature fired in its own frame.
 //
@@ -2863,19 +2732,19 @@ async function runRoutesEpochs(page, state) {
 // (see `runDeepMachine` above, lines re: machine-transition + `:frame`),
 // a real host-app `:rf.machine/transition` carries no `:frame` tag and so
 // is not captured into an epoch's `:trace-events`, leaving the focused-
-// event transitions sub empty in production today. `deep_machine` owns the
-// chart-render shim-survival probe via test-only injection events; this
-// deck's job is the real-machine-feature step-up surface, asserted through
-// the substrate snapshot + the panel handoff.
+// event transitions sub empty. `deep_machine` owns the chart-render
+// shim-survival probe via test-only injection events; this deck's job is
+// the real-machine-feature step-up surface, asserted through the substrate
+// snapshot + the panel handoff.
 
-// rf2-q3lfm — the deck was reworked into a MULTI-MACHINE, FRAME-ISOLATED
-// stepper. Each machine domain now lives in its OWN frame (`:machine/<id>`)
-// and the left rail is a PICKER: selecting a track
-// (`machine-epochs-track-<id>`) shows its step path AND re-points Xray at
-// that machine's frame. The per-track step rows are still RANDOM-ACCESS
-// RUN-THIS-STEP buttons (`machine-epochs-step-<n>-run`, n = 0-based index
-// WITHIN the selected track's path), so this scenario first selects a track,
-// then drives that track's steps by their per-track index.
+// The deck is a MULTI-MACHINE, FRAME-ISOLATED stepper. Each machine domain
+// lives in its OWN frame (`:machine/<id>`) and the left rail is a PICKER:
+// selecting a track (`machine-epochs-track-<id>`) shows its step path AND
+// re-points Xray at that machine's frame. The per-track step rows are
+// RANDOM-ACCESS RUN-THIS-STEP buttons (`machine-epochs-step-<n>-run`,
+// n = 0-based index WITHIN the selected track's path), so this scenario
+// first selects a track, then drives that track's steps by their per-track
+// index.
 //
 // Select a track by its id (`:door` -> `machine-epochs-track-door`). The
 // select boots the track's machine(s) into its frame (boot-on-select) and
@@ -2899,21 +2768,16 @@ async function restartMachineTrack(page) {
 }
 
 // Read one machine's snapshot directly from its OWN `:machine/<track>` frame
-// RUNTIME-DB (rf2-q3lfm — per-machine frame isolation; snapshots no longer
-// live in `:rf/default`). Reconstructs the same `state … · tags …` text the
-// old `:rf/default` strip produced, scoped to the given track's frame, so the
-// per-machine assertions below read robustly. Returns `{ mounted, ... }`.
+// RUNTIME-DB (per-machine frame isolation; each track's snapshots live in
+// its own frame). Builds a `state … · tags …` text scoped to the given
+// track's frame, so the per-machine assertions below read robustly. Returns
+// `{ mounted, ... }`.
 //
-// rf2-wxu4l3 — machine snapshots are durable framework RUNTIME-DB state per
-// EP-0001 (rf2-vzld77; re-frame.machines.paths/snapshot-path): they live at
+// Machine snapshots are durable framework RUNTIME-DB state per EP-0001
+// (re-frame.machines.paths/snapshot-path): they live at
 // `[:rf.runtime/machines :snapshots <machine-id>]` in the runtime-db
 // PARTITION, read via the public `re-frame.core/runtime-db-value` seam — NOT
-// in app-db. The former `app-db-value` read at `[:rf/runtime :machines
-// :snapshots …]` looked at the stale pre-EP-0001 partition + key spelling and
-// always saw nil, so every track snapshot read back as `nil` (the door track
-// "booted to nil" symptom). The boot itself is correct (the door frame's
-// epoch ring shows :machine-epochs/boot-door → :door/main and runtime-db
-// carries `{:state :locked …}`); only this read seam was stale.
+// in app-db.
 //
 // `trackId` is the track name (e.g. 'door', 'media'); the frame id is
 // `:machine/<trackId>`. `machineIds` is the set of machine-ids the track
@@ -2979,12 +2843,8 @@ async function waitForTrackSnapshot(page, trackId, machineIds, pred, description
   );
 }
 
-// (rf2-q3lfm — the old single-`:rf/default` `readMachineStrip` is gone; the
-// per-machine-frame `readTrackSnapshots` above is the snapshot reader now,
-// since each machine's snapshot lives in its own `:machine/<track>` frame.)
-
 async function runMachineEpochs(page, state) {
-  // rf2-q3lfm — the MULTI-MACHINE, FRAME-ISOLATED stepper. Each machine
+  // The MULTI-MACHINE, FRAME-ISOLATED stepper. Each machine
   // domain runs in its OWN frame (`:machine/<track>`); the left rail is a
   // PICKER that, on select, boots the track's machine(s) (boot-on-select) AND
   // re-points Xray at that frame. We SELECT a track, then drive its per-track
@@ -3070,8 +2930,8 @@ async function runMachineEpochs(page, state) {
     'door#6 audit -> root :on fallthrough -> :locked',
   );
 
-  // ===== Cross-frame flip acceptance (rf2-q3lfm de-risk) =================
-  // The linchpin of the redesign: switch A -> B -> back to A and confirm each
+  // ===== Cross-frame flip acceptance ===================================
+  // The linchpin of the design: switch A -> B -> back to A and confirm each
   // machine's frame snapshot is ISOLATED. Pick traffic, drive it, return to
   // door and confirm DOOR's ring/state is intact (:locked, NOT touched by the
   // traffic steps) — the proof the two frames never interleave.
@@ -3097,7 +2957,8 @@ async function runMachineEpochs(page, state) {
 
   // Switch BACK to door: its frame's snapshot must be UNTOUCHED by the
   // traffic steps (door is still :locked from its last step) — frame
-  // isolation, the core lens of rf2-q3lfm. Re-selecting resumes door's ring.
+  // isolation, the core lens of this scenario. Re-selecting resumes door's
+  // ring.
   await selectMachineTrack(page, 'door');
   const doorAfterReturn = await waitForTrackSnapshot(
     page, 'door', [':door/main'],
@@ -3243,7 +3104,7 @@ async function runMachineEpochs(page, state) {
   await clickMachineStep(page, 1); // shallow restore
   await clickMachineStep(page, 2); // deep restore
 
-  // ===== Modal (MULTI-EVENT transition — events-as-nodes, rf2-vilpfa) ====
+  // ===== Modal (MULTI-EVENT transition — events-as-nodes) ===============
   // ONE edge (:open ──► :closed) reached on THREE distinct events
   // (cancel/submit/escape). Drive all three (re-opening between) and confirm
   // each lands :closed; the submit branch also runs :save (:saved? true). The
@@ -3282,7 +3143,7 @@ async function runMachineEpochs(page, state) {
     'modal#5 escape -> :closed (multi-event fan-in #3 — all 3 events land :closed)',
   );
 
-  // ===== Gate (MULTI-BRANCH GUARDED fork — guard-fork, rf2-vilpfa) ========
+  // ===== Gate (MULTI-BRANCH GUARDED fork — guard-fork) ==================
   // :gate/check forks from :idle by a guarded candidate vector (high?→:high,
   // low?→:low, else→:rejected); :gate/set arms :level first. Drive all three
   // guard branches; the fork's guard-predicate render is asserted in the CLJS
@@ -3326,11 +3187,11 @@ async function runMachineEpochs(page, state) {
   // ===== Xray Machine Inspector handoff + the throw/no-op contrast ======
   await openXray(page);
 
-  // rf2-q3lfm — the FUSE track throws on BOOT (boot-on-select): its initial
-  // :entry action :blow-fuse throws when the fuse frame is created on select.
-  // So the SOLE machine-action-exception trigger is now SELECTING fuse (not a
-  // late "rung 19"). Before selecting fuse, NO machine-action-exception may
-  // have fired from any other track's boot-on-select.
+  // The FUSE track throws on BOOT (boot-on-select): its initial :entry
+  // action :blow-fuse throws when the fuse frame is created on select. So
+  // the SOLE machine-action-exception trigger is SELECTING fuse. Before
+  // selecting fuse, NO machine-action-exception may have fired from any
+  // other track's boot-on-select.
   {
     const bootTrace = await readTrace(page);
     const bootThrow = bootTrace.filter((e) =>
@@ -3397,22 +3258,17 @@ const SCENARIOS = [
   {
     name: 'feature matrix shell and panel handoff',
     url: '/counter/',
-    // rf2-wa3oo: PR-smoke tier. The 6-tab handoff over the counter
-    // surface is the highest-signal Xray scenario — it boots the shell,
-    // walks every surviving L3 tab, and proves the chrome wiring. Kept
-    // on the PR critical path; the rest of the matrix runs nightly.
+    // PR-smoke tier. The tab handoff over the counter surface is the
+    // highest-signal Xray scenario — it boots the shell, walks every L3
+    // tab, and proves the chrome wiring. Kept on the PR critical path;
+    // the rest of the matrix runs nightly.
     smoke: true,
     panels: PANEL_HANDOFFS.map(([id]) => id),
-    // Post rf2-xy4yb + rf2-y0z5b + rf2-5gl5r: coverage narrowed to the
-    // surviving L3 tabs (Event/Handler retired in favour of the Epoch
-    // panel). Post rf2-gbz39 (Option (c)) the Issues tab was removed —
-    // 6 surviving tabs; issues surface inline in the Epoch panel + the
-    // L2 event-row pink-wash + the always-on issues ribbon signal.
-    // Removed surfaces (Time Travel, Causality Graph, Subscriptions,
-    // Routes, Schemas, Hydration, Performance, Flows, Effects, MCP
-    // Server) lost their UI handoff with the 4-layer chrome refactor
-    // and are covered (where still functionally present) by their
-    // dedicated substrate scenarios.
+    // Coverage spans the L3 tabs that have a UI handoff. Issues surface
+    // inline in the Epoch panel + the L2 event-row pink-wash + the
+    // always-on issues ribbon signal. Surfaces without a tab (e.g. Time
+    // Travel, Hydration, Effects) are covered, where still functionally
+    // present, by their dedicated substrate scenarios.
     coveredRows: [
       'Epoch Panel',
       'App-DB Diff',
@@ -3437,35 +3293,22 @@ const SCENARIOS = [
   {
     name: 'deterministic exceptions and inline/trace surfacing',
     url: '/testbeds/deliberate-throw/',
-    // rf2-wa3oo: PR-smoke tier. The exception → inline-Epoch/Trace
-    // surfacing path is the second-highest-signal slice (it proves the
-    // error lens wires up end-to-end against a real thrown handler).
-    // Counter + deliberate-throw are the only two surfaces the smoke
-    // compiles. (rf2-gbz39 — the Issues tab was removed under Option
-    // (c); exceptions now surface inline in the Epoch panel + via the
-    // Trace panel source-coord chips.)
+    // PR-smoke tier. The exception → inline-Epoch/Trace surfacing path is
+    // the second-highest-signal slice (it proves the error lens wires up
+    // end-to-end against a real thrown handler). Counter + deliberate-
+    // throw are the only two surfaces the smoke compiles. Exceptions
+    // surface inline in the Epoch panel + via the Trace panel source-coord
+    // chips.
     smoke: true,
     panels: ['epoch', 'trace'],
     coveredRows: ['Epoch Panel', 'Trace', 'Effects', 'Flows', 'Machines', 'Open in Editor / Source Coordinates'],
     run: runExceptionSchemaHttp,
   },
-  // Schema-violation coverage migrated to CLJS unit (rf2-w1mnq, landed
-  // #1753). The browser scenario had been a no-op SKIP since #1745 — its
-  // schema-recovery assertions never ran. Authoritative coverage now lives
-  // in tools/xray/test/.../panels/epoch/projection_cljs_test.cljc: all four
-  // `:where` surfaces (:app-db, :event, :cofx, :fx-args), the `:app-db`
-  // rollback, and the inline SIDE EFFECTS-step synthesis. The Epoch-Panel
-  // matrix row remains covered by other live scenarios (deterministic
-  // exceptions, managed http, multi-frame, hydration mismatch). The
-  // /testbeds/schema-violation/ build remains as a manual-inspection target.
   {
     name: 'managed http and effects rows',
     url: '/testbeds/http-toggle/',
-    // Post rf2-xy4yb: the Effects panel was dropped — fx/effects rows
-    // are now inline steps inside the Epoch panel's numbered cascade.
-    // Performance panel is gone too (Mike's call: use Chrome DevTools
-    // Performance). rf2-5gl5r: `event` panel renamed to `epoch`.
-    // rf2-gbz39: the Issues tab was removed (Option (c)) — fx outcomes
+    // fx/effects rows are inline steps inside the Epoch panel's numbered
+    // cascade; the Epoch tab is where this scenario reads them. fx outcomes
     // surface inline in the Epoch panel's EFFECT HANDLERS step.
     panels: ['epoch', 'trace'],
     coveredRows: ['Epoch Panel', 'Trace'],
@@ -3474,19 +3317,16 @@ const SCENARIOS = [
   {
     name: 'multi-frame isolation substrate',
     url: '/testbeds/multi-frame/',
-    // Post rf2-xy4yb + rf2-y0z5b: Causality Graph and Time Travel
-    // panels were dropped. Multi-frame isolation is now exercised
-    // via the Trace and Epoch tabs (cascade per frame). rf2-5gl5r:
-    // `event` panel renamed to `epoch`.
+    // Multi-frame isolation is exercised via the Trace and Epoch tabs
+    // (one cascade per frame).
     panels: ['trace', 'epoch'],
     coveredRows: ['Trace', 'Epoch Panel'],
     run: runMultiFrame,
   },
   {
-    // rf2-bz72m — deepened to assert the machines-viz chart SVG
-    // actually renders (not just the inspector mount). Catches a
-    // broken `chart/{svg,layout,elk_layout}` re-export shim after the
-    // #1570 / rf2-o9arp machines-viz extraction.
+    // Asserts the machines-viz chart actually renders (not just the
+    // inspector mount). Catches a broken `chart/{svg,layout,elk_layout}`
+    // re-export shim across the machines-viz package boundary.
     name: 'deep machine inspector substrate',
     url: '/testbeds/deep-machine/',
     panels: ['machines'],
@@ -3494,10 +3334,8 @@ const SCENARIOS = [
     run: runDeepMachine,
   },
   {
-    // rf2-n39g2 — Static mode (rf2-o5f5f.1 / .2 / .3) browser
-    // coverage: chord + pill + 3-layer chrome silhouette.
-    // (Persistence round-trip dropped by rf2-rat6r — rf2-8l3uk made
-    // Static mode unconditional so the reload cycle is dead code.)
+    // Static mode browser coverage: chord + mode dropdown + 3-layer
+    // chrome silhouette.
     name: 'static mode chrome and chord',
     url: '/counter/',
     panels: [],
@@ -3508,15 +3346,15 @@ const SCENARIOS = [
     run: runStaticModeChromeAndChord,
   },
   {
-    // rf2-z5zip — Cmd-K command palette (rf2-ybjkx) browser coverage:
-    // chord opens, fuzzy narrows, Enter executes a verb (theme flip),
-    // recents persist + lead on re-open, Esc closes without dispatch.
+    // Cmd-K command palette browser coverage: chord opens, fuzzy narrows,
+    // Enter executes a verb (theme flip), recents persist + lead on
+    // re-open, Esc closes without dispatch.
     name: 'command palette chord, fuzzy filter, execute verb, and recents round-trip',
     url: '/counter/',
-    // rf2-wa3oo: PR-smoke tier. Reuses the already-staged counter
-    // surface (no extra compile), and exercises the Cmd-K interaction
-    // path — the highest-signal "key interactions" coverage the audit
-    // asked the smoke to keep. Adds no surface to the compile set.
+    // PR-smoke tier. Reuses the already-staged counter surface (no extra
+    // compile), and exercises the Cmd-K interaction path — the highest-
+    // signal "key interactions" coverage. Adds no surface to the compile
+    // set.
     smoke: true,
     panels: [],
     coveredRows: [
@@ -3526,22 +3364,20 @@ const SCENARIOS = [
     run: runPaletteOpenExecute,
   },
   {
-    // rf2-azfct — theme-token CSS-variable resolution probe.
-    // Mike-authorised 2026-05-28 (explicit exception to the
-    // "default Causa/Story tests to CLJS" rule — real-browser
-    // CSS-variable resolution is the signal under test, CLJS
-    // unit tests can't reach it). Gates against the rf2-pqulr
-    // regression class: a boot path that embeds bare Xray widgets
-    // without calling `global-styles/install!` leaves every
-    // `var(--rf-xray-*)` reference resolving to its CSS fallback
-    // default, painting every variant unstyled.
+    // Theme-token CSS-variable resolution probe. A deliberate exception
+    // to the "default Causa/Story tests to CLJS" rule — real-browser
+    // CSS-variable resolution is the signal under test, which CLJS unit
+    // tests can't reach. Guards against the regression class where a boot
+    // path that embeds bare Xray widgets without calling
+    // `global-styles/install!` leaves every `var(--rf-xray-*)` reference
+    // resolving to its CSS fallback default, painting every variant
+    // unstyled.
     //
-    // PR-smoke tier — the panel-gallery surface is unique to this
-    // probe (no other smoke scenario uses it), but the regression
-    // class is severe (P1) and the probe is fast (~one page load
-    // + one DOM read). The compile + serve overhead is the cost
-    // of buying pre-merge coverage of a class of bugs that went
-    // undetected for some time when caught only by live observation.
+    // PR-smoke tier — the panel-gallery surface is unique to this probe
+    // (no other smoke scenario uses it), but the regression class is
+    // severe (P1) and the probe is fast (~one page load + one DOM read).
+    // The compile + serve overhead buys pre-merge coverage of a class of
+    // bugs otherwise only caught by live observation.
     name: 'panel-gallery theme-token CSS-variable resolution on :root (rf2-azfct)',
     url: '/testbeds/panel-gallery/#/stories',
     smoke: true,
@@ -3552,13 +3388,13 @@ const SCENARIOS = [
     run: runPanelGalleryThemeTokens,
   },
   {
-    // rf2-5crg4 — routes-epochs routing step-up deck. Drives the real
-    // `reg-route` + `:rf.route/navigate` surface and asserts the Xray
-    // Routing panel across CURRENT ROUTE (id + params + nested tree
-    // highlight), NAVIGATION THIS EPOCH (──► TO + outcome:
-    // transitioned / not-found / blocked), and the ROUTE TABLE
-    // (nested-row indent under the parent). Real Routing-panel coverage
-    // for the deck the `Routes` matrix row names.
+    // The routes-epochs routing step-up deck. Drives the real `reg-route`
+    // + `:rf.route/navigate` surface and asserts the Xray Routing panel
+    // across CURRENT ROUTE (id + params + nested tree highlight),
+    // NAVIGATION THIS EPOCH (──► TO + outcome: transitioned / not-found /
+    // blocked), and the ROUTE TABLE (nested-row indent under the parent).
+    // Real Routing-panel coverage for the deck the `Routes` matrix row
+    // names.
     name: 'routes-epochs routing ladder (current route, nav-this-epoch, nested table, blocked)',
     url: '/testbeds/routes-epochs/',
     panels: ['routing'],
@@ -3566,11 +3402,11 @@ const SCENARIOS = [
     run: runRoutesEpochs,
   },
   {
-    // rf2-w06op + rf2-g27vv + rf2-kipb5 + rf2-q3lfm — machine-epochs
-    // assertion-backed render harness, reworked into the MULTI-MACHINE,
-    // FRAME-ISOLATED stepper. Each machine domain runs in its OWN frame
-    // (`:machine/<track>`); the left rail is a PICKER that, on select, boots
-    // the track's machine(s) (boot-on-select) AND re-points Xray
+    // The machine-epochs assertion-backed render harness — a
+    // MULTI-MACHINE, FRAME-ISOLATED stepper. Each machine domain runs in
+    // its OWN frame (`:machine/<track>`); the left rail is a PICKER that,
+    // on select, boots the track's machine(s) (boot-on-select) AND
+    // re-points Xray
     // (`:rf.xray/select-frame`) at that frame. The scenario SELECTS each track
     // then drives its per-track step rows, asserting each step's machine
     // FEATURE off THAT track's frame snapshot: door (plain · entry/exit ·
@@ -3582,9 +3418,9 @@ const SCENARIOS = [
     // reject + live shallow/deep restore — the restore-cascade render is
     // asserted in the CLJS harness), modal (MULTI-EVENT transition: one edge
     // :open ──► :closed reached on THREE events — the events-as-nodes
-    // divergence, rf2-vilpfa), gate (MULTI-BRANCH GUARDED fork: :gate/check
-    // forks by guard high?/low?/else → :high/:low/:rejected — the guard-fork
-    // divergence, rf2-vilpfa). It also proves the per-machine frame
+    // divergence), gate (MULTI-BRANCH GUARDED fork: :gate/check forks by
+    // guard high?/low?/else → :high/:low/:rejected — the guard-fork
+    // divergence). It also proves the per-machine frame
     // ISOLATION with a cross-frame flip (door -> traffic -> back to door:
     // each frame's snapshot stays intact, never interleaved) + a Restart
     // (frame reset + re-arc from boot). Then opens the Xray Machine Inspector
@@ -3602,29 +3438,6 @@ const SCENARIOS = [
     coveredRows: ['Machines'],
     run: runMachineEpochs,
   },
-  // ---- retired by rf2-xy4yb (4-layer chrome refactor) -------------------
-  //
-  // 'long flow failure substrate' (Flows panel) and 'drain-depth load
-  // failure substrate' (Performance panel) were retired when the 4-layer
-  // chrome refactor dropped both panels — Flows folds into the Views tab
-  // as derived state (spec/018 §5) and Performance is replaced by Chrome
-  // DevTools' Performance tab (Mike's call). With no UI handoff to assert,
-  // their runners + staged surfaces were removed (rf2-fxnszc). Surviving
-  // flow-failure trace evidence is covered by `deterministic exceptions
-  // and inline/trace surfacing`; the `:halted-depth` epoch record stays
-  // observable via the substrate's host-side epoch-history probe.
-  //
-  // ---- converted to multi-frame e2e CLJS (rf2-rviu8) --------------------
-  //
-  // 'non-trivial app-db diff substrate' — the Playwright scenario
-  // only asserted the App-DB Diff panel mounted after a six-click
-  // sequence of deep-tree mutations. The data invariants (spine focus
-  // advances, target-frame-db reflects each mutation, epoch history
-  // grows by 6) are now covered at <50ms per assertion by
-  // `tools/xray/test/day8/re_frame2_xray/panels_e2e/
-  // non_trivial_app_db_e2e_cljs_test.cljs`. Per Mike's 2026-05-19
-  // multi-frame-e2e finding, removing this scenario cuts ~30s of
-  // browser gate runtime with zero coverage loss.
   {
     name: '20-event large value elision load',
     url: '/testbeds/large-dispatcher/',
@@ -3636,38 +3449,20 @@ const SCENARIOS = [
   {
     name: 'hydration mismatch debugger',
     url: '/testbeds/ssr-hydration-mismatch/',
-    // Post rf2-xy4yb: the dedicated Hydration debugger panel was
-    // dropped. Post rf2-gbz39 (Option (c)) the Issues tab was ALSO
-    // removed; hydration mismatches surface via the L2 event-row signal
-    // + the always-on issues ribbon. The scenario now verifies the
-    // Xray shell + Epoch panel mount cleanly under cascade scope.
+    // Hydration mismatches surface via the L2 event-row signal + the
+    // always-on issues ribbon. The scenario verifies the Xray shell +
+    // Epoch panel mount cleanly under cascade scope.
     panels: ['epoch'],
     coveredRows: ['Epoch Panel'],
     run: runHydration,
   },
-  // ---- converted to multi-frame e2e CLJS (rf2-rviu8) --------------------
-  //
-  // '20-event feature/load re-check' — the Playwright scenario drove
-  // 20 host counter +/- clicks and asserted the trace count grew +
-  // the focused cascade rendered (originally on the Event Detail
-  // panel; rf2-5gl5r migrated the surface to the Epoch panel). Both
-  // are data invariants the multi-frame e2e harness covers at ~5ms
-  // per dispatch (vs ~200ms per click in browser):
-  // `tools/xray/test/day8/re_frame2_xray/panels_e2e/
-  // twenty_event_load_e2e_cljs_test.cljs` walks the same 20-event
-  // sequence, asserts cascades grow, focus auto-follows the head
-  // (rf2-70tkv class), epoch history records every dispatch, and
-  // target-frame-db reflects the net counter value. Estimated CI
-  // saving: ~45s (full 20-click sequence + panel handoff).
   {
     name: '1000-event trace row-budget plus 20-dispatch re-check',
     url: '/counter/',
     panels: ['trace'],
     load: true,
-    // Post rf2-y0z5b: 'Performance' coveredRow was dropped (the
-    // Performance panel was retired per Mike's call — Chrome DevTools
-    // Performance tab is the canonical surface). Trace + Shell/Elision
-    // remain.
+    // Covers the Trace + Shell/Elision rows. Performance profiling is the
+    // job of Chrome DevTools' Performance tab, not an Xray panel.
     coveredRows: [
       'Trace',
       'Shell, Keybinding, Config, Preload, Settings, and Production Elision',
@@ -3686,16 +3481,6 @@ const SCENARIOS = [
     ],
     run: runLaunchModesTwentyEventLoad,
   },
-  // ---- converted to multi-frame e2e CLJS (rf2-rviu8) --------------------
-  //
-  // 'configure! multi-key map and partial-update semantics' (was
-  // rf2-qd5r6). The Playwright scenario went into a browser solely
-  // to call `window.day8.re_frame2_xray.config.configure_BANG_` and
-  // assert atom-state round-trips. Pure CLJS — no DOM involvement.
-  // Converted to direct fn-call coverage in
-  // `tools/xray/test/day8/re_frame2_xray/panels_e2e/
-  // configure_multi_key_e2e_cljs_test.cljs`. Estimated CI saving:
-  // ~10s (browser context teardown alone).
 ];
 
 module.exports = {

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -1,6 +1,6 @@
 (ns machine-epochs.core
   "MACHINE-EPOCHS testbed — the MULTI-MACHINE, FRAME-ISOLATED state-machine
-  stepper (rf2-q3lfm). It is the STATE-MACHINE consumer of the shared
+  stepper. It is the STATE-MACHINE consumer of the shared
   queued-step RUNNER (`runner.core`) re-expressed as a multi-track picker:
   each machine domain lives in its OWN frame and owns its OWN Xray epoch
   ring, and the picker re-points Xray (`:rf.xray/select-frame`) at the
@@ -8,15 +8,13 @@
   cascade, the time-travel scrubber, the App-db panel, the Machine
   Inspector) shows ONLY that machine's isolated arc.
 
-  ## The lens (rf2-q3lfm)
+  ## The lens
 
   THE VALUE is seeing the Xray progression for EACH machine IN ISOLATION.
-  All 8 machine domains used to dispatch into ONE frame (`:rf/default`), so
-  they shared ONE epoch ring — a machine's progression was scattered through
-  a global timeline interleaved with seven others (worst in the
-  switch-and-return flow). One frame per machine fixes that at the root:
-  switching switches WHICH isolated arc Xray shows — no interleaving, ever,
-  including across switch-and-return.
+  One frame per machine keeps every domain's arc clean: a machine's
+  progression is its OWN epoch ring, never scattered through a global
+  timeline interleaved with the others. Switching switches WHICH isolated
+  arc Xray shows — no interleaving, ever, including across switch-and-return.
 
   ## Two layers of frame
 
@@ -45,32 +43,30 @@
     (`rf/reset-frame!` = destroy + re-`reg-frame` with the same `:on-create`,
     so the ring clears and re-arcs from boot) and clears the track cursor.
 
-  ## Boot-on-select (the smaller call, applied — rf2-q3lfm)
+  ## Boot-on-select
 
   Selecting a track boots its machine(s) so the FIRST observed epoch is the
   machine's START cascade — directly answering 'choose a machine and see it
   start'. Consequence: selecting the FUSE track boots `:armed`, whose
   `:entry` action THROWS, so selecting fuse shows the exception card
-  immediately (arguably the point of the fuse track). We keep that — the
-  throw is the headline of the fuse arc.
+  immediately (the point of the fuse track) — the throw is the headline of
+  the fuse arc.
 
-  With boot-on-select, entering a track produces the START epoch
-  automatically as the ring's FIRST entry, so we DROPPED the explicit
-  'start machine' step rows: every track's first observed epoch is its
-  START badge for free (the door step-0 START-badge demo is preserved for
-  all tracks).
+  Entering a track produces the START epoch automatically as the ring's
+  FIRST entry, so there is no explicit 'start machine' step row: every
+  track's first observed epoch is its START badge for free (the door step-0
+  START-badge demo applies to all tracks).
 
   ## Tracks (code data — the single source of truth)
 
-  A `tracks` vector replaces the old flat `steps`. Each track is
+  A `tracks` vector is the single source of truth. Each track is
   `{:id :label :blurb :machines #{machine-ids} :path [{:label :event :watch}
   …]}`. `:machines` is a SET so the media track can own TWO machine-ids
   (`:media/shallow` + `:media/deep`) in one observed domain; `:on-create`
-  boots every machine in the set. The cross-machine fan-out steps of the old
-  deck were DROPPED (Mike ruling 5): every track drives exactly its own
-  domain.
+  boots every machine in the set. Every track drives exactly its own
+  domain — there are no cross-machine fan-out steps.
 
-  ## Localized runner (rf2-q3lfm)
+  ## Localized runner
 
   The shared `runner.core` is consumed by six decks and stays UNTOUCHED. The
   multi-track + frame-per-machine machinery is machine-epochs-LOCAL (this
@@ -79,7 +75,7 @@
   UX is specific to this deck (the only multi-machine one), so localizing
   contains blast radius (YAGNI: generalize only if a second deck needs it).
 
-  ## Idiomatic re-frame2 (rf2-5sjbg)
+  ## Idiomatic re-frame2
 
   app-db + events + subs ONLY — no Reagent atoms threaded through views, no
   frame-ids as view args. The picker rail, the step panel, the cursor, and
@@ -95,8 +91,8 @@
   No `spec.cjs` lives here. Regression coverage lives in the Xray test
   surface: the CLJS unit test
   `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test`
-  (drives the substrate directly, decoupled from this view — unchanged by
-  this redesign) + the feature-matrix gate
+  (drives the substrate directly, decoupled from this view) + the
+  feature-matrix gate
   (`tools/xray/testbeds/feature_matrix/scenarios.cjs` — the
   `machine-epochs machine ladder` scenario, which selects each track then
   drives its per-step RUN buttons + reads the per-machine frame's snapshot).
@@ -170,9 +166,9 @@
 ;; MACHINE EVENTS — the per-track path drivers (one event per path step)
 ;; ============================================================================
 ;;
-;; These are the SAME machine features the old flat deck drove; only the
-;; cross-machine fan-out steps were dropped. A step's `:event` is dispatched
-;; INTO the track's machine frame, so a multi-dispatch helper (e.g.
+;; Each event drives one clean machine feature within its own track. A
+;; step's `:event` is dispatched INTO the track's machine frame, so a
+;; multi-dispatch helper (e.g.
 ;; `:machine-epochs/reopen-then-block`) fans out within that one frame's
 ;; cascade — its child `:dispatch`es inherit the frame from the handler's
 ;; envelope (Spec 002 §Cascade propagation).
@@ -212,7 +208,7 @@
 
 ;; drive the spawned :session/login child to its :final? state. The child's
 ;; deterministic spawn-id is resolved through `machine-paths/spawned-path`.
-;; FAIL LOUD ON A MISS (rf2-4i0ac): an `assert` surfaces a missing slot as a
+;; FAIL LOUD ON A MISS: an `assert` surfaces a missing slot as a
 ;; loud failure at the call site rather than a silent no-op.
 (rf/reg-event :machine-epochs/finish-login
   {:doc "Resolve the spawned :session/login child via the machines artefact's
@@ -220,15 +216,13 @@
          to its :final? state. The child fires :on-done (reporting the token to
          the parent) and auto-destroys. Asserts the child id is present — a
          missing spawn slot fails loud rather than silently no-opping."}
-  ;; EP-0001 (rf2-vzld77 / rf2-wxu4l3): the machines runtime — `:snapshots`
-  ;; AND the parent→child `:spawned` join-state map — is durable framework
-  ;; RUNTIME-DB state at `[:rf.runtime/machines …]`, NOT app-db. Read the
-  ;; spawned child id off the `:rf.db/runtime` coeffect every event handler
-  ;; receives (the canonical idiom — mirrors the routing `:on-match` loader
-  ;; reading the route slice off `:rf.db/runtime`). The former app-db read
-  ;; resolved nil (app-db never holds `:spawned`), so the assert no-op'd /
-  ;; the child was never driven to :final, and the parent's :on-done never
-  ;; stamped :session-token.
+  ;; EP-0001: the machines runtime — `:snapshots` AND the parent→child
+  ;; `:spawned` join-state map — is durable framework RUNTIME-DB state at
+  ;; `[:rf.runtime/machines …]`, NOT app-db. Read the spawned child id off
+  ;; the `:rf.db/runtime` coeffect every event handler receives (the
+  ;; canonical idiom — mirrors the routing `:on-match` loader reading the
+  ;; route slice off `:rf.db/runtime`). app-db never holds `:spawned`, so a
+  ;; read against app-db would resolve nil and the assert would fail loud.
   (fn handler-finish-login [{:keys [db] rt :rf.db/runtime} _ev]
     (let [child-id (get-in rt (machine-paths/spawned-path :session/flow [:authenticating]))]
       (assert child-id
@@ -265,7 +259,7 @@
   (fn handler-probe-history [{:keys [db]} _ev]
     {:db (assoc db :machine-epochs/history-rejected? (machines/history-rejected?))}))
 
-;; the HISTORY restore dance (rf2-mle6e.5). To make the RESTORE the focal
+;; the HISTORY restore dance. To make the RESTORE the focal
 ;; cascade, the step first POSITIONS the player deep (`:insert` → `:seek`)
 ;; and EJECTS it (recording :player's last config into :rf/history), then
 ;; fires the final `:insert` — the restore whose cascade carries the
@@ -308,7 +302,7 @@
 ;; (RESTART) re-runs the SAME `:on-create`, so a restart re-arcs from boot.
 ;;
 ;; `[id [:rf.machine/start]]` is the eager kick (xstate `createActor().start()`):
-;; per F‴ (rf2-gl588) it runs the initial-entry cascade then STOPS — a PURE
+;; per F‴ it runs the initial-entry cascade then STOPS — a PURE
 ;; init-kick, never re-fed into the transition step.
 
 (defn- boot-machines-fx
@@ -344,7 +338,7 @@
   {:doc "Boot the fuse machine — its initial state :armed declares an :entry
          action :blow-fuse that THROWS, so booting fuse raises a real
          :rf.error/machine-action-exception immediately. The exception card +
-         pink-wash is the headline of the fuse arc (boot-on-select, rf2-q3lfm)."}
+         pink-wash is the headline of the fuse arc (boot-on-select)."}
   (fn [_ _] {:fx (boot-machines-fx [:fuse/box])}))
 
 (rf/reg-event :machine-epochs/boot-hvac
@@ -355,19 +349,19 @@
 (rf/reg-event :machine-epochs/boot-media
   {:doc "Boot BOTH media machines (:media/deep + :media/shallow) into the one
          media frame — the media track owns two machine-ids in one observed
-         domain (rf2-q3lfm). Both start at :tray."}
+         domain. Both start at :tray."}
   (fn [_ _] {:fx (boot-machines-fx [:media/deep :media/shallow])}))
 
 (rf/reg-event :machine-epochs/boot-modal
   {:doc "Boot the modal machine to :closed — the multi-event-transition machine
          whose :open ──► :closed edge is reached on THREE distinct events
-         (the events-as-nodes divergence, rf2-vilpfa)."}
+         (the events-as-nodes divergence)."}
   (fn [_ _] {:fx (boot-machines-fx [:modal/main])}))
 
 (rf/reg-event :machine-epochs/boot-gate
   {:doc "Boot the gate machine to :idle — the multi-branch guarded-fork machine
          whose :gate/check forks by guard (:high / :low / :rejected) from :idle
-         (the guard-fork divergence, rf2-vilpfa)."}
+         (the guard-fork divergence)."}
   (fn [_ _] {:fx (boot-machines-fx [:gate/main])}))
 
 ;; ============================================================================
@@ -381,16 +375,14 @@
 ;; - `:boot` is the frame's `:on-create` event — runs in the machine frame so
 ;;   the START cascade is the ring's first observed epoch (boot-on-select).
 ;; - `:path` is the ordered step list. Each step's `:event` is dispatched INTO
-;;   the track's machine frame. The explicit 'start machine' rows of the old
-;;   deck were DROPPED — boot-on-select produces the START epoch for free.
+;;   the track's machine frame. There is no explicit 'start machine' row —
+;;   boot-on-select produces the START epoch for free.
 ;;
-;; The first 8 domains are the same clean machine features the old flat deck
-;; drove; the cross-machine fan-out steps ('Reset door + tick traffic' and the
-;; multi-machine no-op) were DROPPED (Mike ruling 5). Two later domains —
-;; :modal (multi-event transition) + :gate (multi-branch guarded fork) — were
-;; ADDED (rf2-vilpfa) to cover the two xstate-render-divergence cases the
-;; original 8 miss: events-as-nodes (one edge reached on N events) and the
-;; guard-fork (one :check forking by guarded candidate).
+;; Each track drives exactly its own domain — there are no cross-machine
+;; fan-out steps. The :modal (multi-event transition) + :gate (multi-branch
+;; guarded fork) domains cover the two xstate-render-divergence cases:
+;; events-as-nodes (one edge reached on N events) and the guard-fork (one
+;; :check forking by guarded candidate).
 
 (def tracks
   [{:id       :door
@@ -949,7 +941,7 @@
 (defn ^:export run []
   (xray-config/configure! {:rf.xray/project-root (resolve-source-root)})
   (rf/init! reagent-adapter/adapter)
-  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; EP-0002: the runtime never synthesises a frame from
   ;; absence — register the SHELL frame explicitly and scope the boot
   ;; dispatches to it. The per-track machine frames are reg-frame'd inside
   ;; the `:machine-epochs/select` handler (a real cascade — `*handler-scope*`

--- a/tools/xray/testbeds/machine_epochs/machines.cljs
+++ b/tools/xray/testbeds/machine_epochs/machines.cljs
@@ -1,12 +1,12 @@
 (ns machine-epochs.machines
-  "The MACHINE SPECS for the machine-epochs render harness (rf2-g27vv),
+  "The MACHINE SPECS for the machine-epochs render harness,
   split out of `machine-epochs.core` so the ASSERTION harness
   (`day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test`) can
   register the IDENTICAL specs without pulling in the deck's Reagent mount.
 
   This makes 'what the operator sees in the deck' and 'what the test drives'
-  literally the SAME values — a drift between them is impossible (the bead's
-  single-source-of-truth requirement for the machine half of the matrix).
+  literally the SAME values — a drift between them is impossible. These specs
+  are the single source of truth for the machine half of the matrix.
 
   ## Cascade order is read off the structured `:cascade`
 
@@ -18,7 +18,7 @@
   here do only their real data mutation (`:opened-count`, `:score`, the
   spawned token, …); state-only transitions carry no action at all.
 
-  ## Test surface, not tutorial (feedback_testbeds_are_test_surfaces)
+  ## Test surface, not tutorial
 
   No deliberate bugs, no teaching layers. Every machine is a clean,
   believable domain exercising real features. The throwing `:fuse/box`
@@ -111,7 +111,7 @@
 ;; stay CONSTANT across every state. So the union `:tags` set is a SINGLE-
 ;; member swap each tick — the snapshot diff must render that as a member-
 ;; level :added / :removed (the joining + leaving vehicle tag), NOT a whole-
-;; key set replacement (gap 7 / rf2-l0us2). A single-member swap is the case
+;; key set replacement. A single-member swap is the case
 ;; the member-level set-diff renders today; keeping the constant members
 ;; off the churn proves the diff isolates exactly the member that moved.
 
@@ -250,25 +250,20 @@
 ;; MACHINE 6 — :fuse/box  (THROW-ON-BOOT: initial `:entry` action THROWS)
 ;; ============================================================================
 ;;
-;; A machine-action exception ON BOOT — the F‴ (rf2-gl588) re-vehicle. The
-;; initial state `:armed` declares an `:entry` action `:blow-fuse` that THROWS,
-;; so the initial-entry cascade itself raises a REAL
+;; A machine-action exception ON BOOT, modelled on F‴. The initial state
+;; `:armed` declares an `:entry` action `:blow-fuse` that THROWS, so the
+;; initial-entry cascade itself raises a REAL
 ;; `:rf.error/machine-action-exception`. This fires on ANY boot — an eager
 ;; `[:fuse/box [:rf.machine/start]]` kick OR the first real event lazily
 ;; booting the machine — because under F‴ `maybe-boot` is the single birth
-;; site that runs the cascade in both paths.
+;; site that runs the cascade in both paths. The start marker is a PURE
+;; init-kick (init then STOP — it never reaches the transition step); the
+;; throw lives on a real `:entry` action, demonstrating "exception on boot".
 ;;
-;; Pre-F‴ this coverage rode the double-duty wart: an eager start marker was
-;; re-processed as a normal trigger, hit `:armed`'s `:*` wildcard, and threw.
-;; F‴ makes the start marker a PURE init-kick (init then STOP — it never
-;; reaches the transition step), so that path is gone; the throw moves to a
-;; real `:entry` action, demonstrating "exception on boot" on the F‴ model.
-;;
-;; The CONTRAST with the door's benign unhandled-no-op still validates that
+;; The CONTRAST with the door's benign unhandled-no-op validates that
 ;; Xray's pink-wash / `issue-event?` predicate distinguishes a thrown action
 ;; (error, pink, EXCEPTION card, cascade-summary :outcome :error) from a
-;; benign no-op (NOT pink) — the foil is now a throwing BIRTH rather than a
-;; throwing wildcard.
+;; benign no-op (NOT pink) — the foil here is a throwing BIRTH.
 
 (defmachine fuse-machine
   {:initial :armed
@@ -333,7 +328,7 @@
       :on
       {:tags  #{:fan/on}
        ;; :nudge is an EXTERNAL self-transition (:target :same-state +
-       ;; :reenter? true forces a real exit→entry of :on — rf2-eicq0 v5 flip);
+       ;; :reenter? true forces a real exit→entry of :on — the xstate v5 rule);
        ;; :tweak is an INTERNAL self-transition (omit :target) — action-only,
        ;; no exit/entry. :tweak-fan must do real work (bump :tweaks) so the
        ;; internal transition stays a genuine transition, not a no-op.
@@ -349,7 +344,7 @@
 ;; MACHINE 8 — :media/deep + :media/shallow  (HISTORY: shallow + deep restore)
 ;; ============================================================================
 ;;
-;; gap 8 — first-class history states (rf2-mle6e). A media-player compound
+;; First-class history states. A media-player compound
 ;; `:player` owns a `:type :history` pseudo-state `:hist`. From `:stopped`,
 ;; `:play` targets `[:player :hist]` → re-entry RESTORES the recorded (or
 ;; default) configuration beneath `:player`. The cascade carries the
@@ -424,7 +419,7 @@
 ;; MACHINE 9 — :modal/main  (MULTI-EVENT transition — the events-as-nodes case)
 ;; ============================================================================
 ;;
-;; THE events-as-nodes divergence (rf2-vilpfa). One target, `:closed`, reached
+;; THE events-as-nodes divergence. One target, `:closed`, reached
 ;; from `:open` on THREE distinct events (`:modal/cancel`, `:modal/submit` [+a
 ;; `:save` action], `:modal/escape`). xstate v5 STACKS the three event labels
 ;; on ONE edge `:open ──► :closed`; re-frame2's events-as-nodes render draws
@@ -453,7 +448,7 @@
 ;; MACHINE 10 — :gate/main  (MULTI-BRANCH GUARDED fork — the guard-fork case)
 ;; ============================================================================
 ;;
-;; THE guard-fork divergence (rf2-vilpfa). `:gate/check` FORKS from `:idle` by
+;; THE guard-fork divergence. `:gate/check` FORKS from `:idle` by
 ;; a guarded candidate VECTOR: first guard-pass wins — `:gate-high?` → `:high`,
 ;; `:gate-low?` → `:low`, else the unguarded fallback `{:target :rejected}`.
 ;; `:gate/set` arms `:level` first (an internal `:action`-only transition,
@@ -488,9 +483,9 @@
 ;; HISTORY PLACEMENT probe — the misplaced-history rejection (rung #24).
 ;; ----------------------------------------------------------------------------
 ;;
-;; History is first-class (rf2-mle6e) but a `:type :history` pseudo-state MUST
+;; History is first-class, but a `:type :history` pseudo-state MUST
 ;; have an owning compound — a machine ROOT cannot be one. This probe confirms
-;; the placement constraint still fires (NOT the old not-in-v1 deferral).
+;; the placement constraint fires.
 
 (def history-machine-spec
   "A ROOT `:type :history` machine — rejected for PLACEMENT (a pseudo-state
@@ -505,7 +500,7 @@
 (defn history-rejected?
   "Attempt to register `history-machine-spec` (a ROOT `:type :history`) and
   return true iff it is REJECTED with `:rf.error/machine-history-misplaced`
-  (the placement constraint — history is first-class per rf2-mle6e, but a
+  (the placement constraint — history is first-class, but a
   pseudo-state must have an owning compound). Returns false if it
   unexpectedly registered, or rethrows a non-history error. The harness
   asserts this directly via `reg-machine` too."

--- a/tools/xray/testbeds/managed_http/core.cljs
+++ b/tools/xray/testbeds/managed_http/core.cljs
@@ -497,10 +497,10 @@
 (defn ^:export run []
   (xray-config/configure! {:rf.xray/project-root (resolve-source-root)})
   (rf/init! reagent-adapter/adapter)
-  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
-  ;; absence — establish the host frame explicitly, run the boot dispatch
-  ;; under its scope, and wrap the render in a `frame-provider-existing`
-  ;; (scope-only — the host frame is already `reg-frame`'d) so in-tree
+  ;; EP-0002: the runtime never synthesises a frame from absence —
+  ;; establish the host frame explicitly, run the boot dispatch under its
+  ;; scope, and wrap the render in a `frame-provider-existing` (scope-only
+  ;; — the host frame is already `reg-frame`'d) so in-tree
   ;; dispatch/subscribe resolve to it (the carried invariant).
   (rf/reg-frame host-frame {})
   (rf/with-frame host-frame

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -1,14 +1,13 @@
 (ns panel-gallery.core
-  "Boot for the Xray panel gallery testbed (rf2-durls — redone against
-  the de-singletoned shell + the four-bucket Story authoring model;
-  supersedes the rf2-sszlr boot).
+  "Boot for the Xray panel gallery testbed, built against the
+  per-frame shell + the four-bucket Story authoring model.
 
   ## What this testbed is
 
-  A visual gallery of the six original L4 tab panels (Epoch · App-db ·
+  A visual gallery of the six core L4 tab panels (Epoch · App-db ·
   Reactive · Trace · Machines · Routing) plus the full 4-layer Xray
   chrome, framed exactly like Storybook frames UI components. Issues is
-  NOT a tab (rf2-gbz39 — Option (c)): issue surfacing folds INLINE into
+  NOT a tab: issue surfacing folds INLINE into
   the Epoch panel + the L2 event-row pink-wash + the always-on issues
   ribbon signal, so there is no standalone Issues panel to gallery.
   Scroll the workspace; see what each panel looks like under varying
@@ -16,10 +15,10 @@
   the surface a developer (Mike first) reaches for when asking 'what
   does this look like under load X?'.
 
-  ## Intentional gallery exclusions (rf2-1sddi6 F3)
+  ## Intentional gallery exclusions
 
-  The three cohesive-sub-domain / runtime-structure tabs added after
-  this gallery's original six — **Resources** (`:resources`, EP-0016),
+  Three cohesive-sub-domain / runtime-structure tabs beyond the six
+  core lenses — **Resources** (`:resources`, EP-0016),
   **Graph** (`:derivation-graph`, EP-0014), and **Modules**
   (`:module-view`, EP-0013) — are deliberately NOT galleried here. They
   are visual *design* surfaces whose shipped-surface + focusability
@@ -43,19 +42,18 @@
 
   Per `tools/xray/spec/018-Event-Spine.md` the chrome is four stacked
   layers — top ribbon + event list + tab bar + detail panel — with
-  nine L4 tabs replacing the legacy sidebar's 16+ panels (Issues folded
-  inline per rf2-gbz39; this gallery covers the six core lenses and
-  intentionally excludes Resources / Graph / Modules — see the
-  exclusions note above). Time Travel is folded into the spine.
+  nine L4 tabs (Issues folded inline; this gallery covers the six core
+  lenses and intentionally excludes Resources / Graph / Modules — see
+  the exclusions note above). Time Travel is folded into the spine.
 
-  ## Per-variant frame isolation (de-singletoned shell — rf2-1w07r)
+  ## Per-variant frame isolation
 
   Every gallery variant renders inside the Story canvas's per-variant
   `frame-provider`, so each cell is its own isolated re-frame frame
   (its own app-db, sub-cache, router). The per-tab galleries seed that
   frame directly with canonical Xray events (e.g. `:rf.xray/sync-epoch-
   history`). The chrome / settings / filters galleries mount the FULL
-  shell — `shell/shell-view` now takes a `:frame-id` opt, and the
+  shell — `shell/shell-view` takes a `:frame-id` opt, and the
   `chrome-shell` wrapper threads `(rf/current-frame-id)` (the variant
   frame) into it, so the shell's own app-db also lives in the variant
   frame. N chrome cells therefore stay fully isolated in one grid; the
@@ -97,7 +95,7 @@
   (:require [re-frame.core :as rf]
             [re-frame.story :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; rf2-2c5xb — Xray's `configure!` to seed `:project-root`
+            ;; Xray's `configure!` seeds `:project-root`
             ;; so the source-coord chips on registered handlers /
             ;; views / machines resolve their classpath-relative
             ;; `:file` slot to an absolute on-disk URI. Without this
@@ -105,7 +103,7 @@
             ;; classpath-relative path (`panel_gallery/foo.cljs`) to
             ;; the OS scheme handler, which rejects it.
             ;;
-            ;; rf2-ymnfx (Issue A) — Story's parallel slot
+            ;; Story's parallel slot
             ;; (`:rf.story/project-root`) is seeded via
             ;; `story/configure!` below so the Story variant-toolbar
             ;; 'Open' button (which reads `re-frame.story.config/
@@ -118,7 +116,7 @@
             ;; re-seed of Xray is a no-op via `reset!`).
             [day8.re-frame2-xray.config :as xray-config]
             [day8.re-frame2-xray.registry :as xray-registry]
-            ;; rf2-pqulr — Xray's `:root` CSS-variable installer. Required
+            ;; Xray's `:root` CSS-variable installer. Required
             ;; here because the panel-gallery embeds bare Xray widgets
             ;; without mounting the Xray shell; the shell normally calls
             ;; `global-styles/install!` from its `shell-view` reg-view body.
@@ -129,45 +127,42 @@
             [day8.re-frame2-xray.theme.global-styles :as global-styles]
             [panel-gallery.panel-views :as panel-views]
             ;; Side-effecting story registrations — namespaces fire
-            ;; their `register-all!` at namespace load.
-            ;; (rf2-5gl5r — `gallery-event` removed alongside the
-            ;; retired Event/Handler panel; the Epoch gallery is the
-            ;; canonical surface.)
+            ;; their `register-all!` at namespace load. The Epoch gallery
+            ;; is the canonical event/handler surface.
             [panel-gallery.gallery-app-db]
             [panel-gallery.gallery-epoch]
             [panel-gallery.gallery-views]
             [panel-gallery.gallery-trace]
             [panel-gallery.gallery-machines]
             [panel-gallery.gallery-routing]
-            ;; (rf2-gbz39 — `gallery-issues` removed alongside the
-            ;; Issues tab; Option (c) folds issue surfacing into the
-            ;; Epoch panel + L2 event-row pink-wash + the always-on
-            ;; issues ribbon signal — no standalone Issues panel to
-            ;; gallery. Chrome-under-issue-load coverage lives in
-            ;; `gallery-chrome` `:story.xray.chrome/issue-load`.)
+            ;; Issue surfacing folds into the Epoch panel + L2 event-row
+            ;; pink-wash + the always-on issues ribbon signal, so there
+            ;; is no standalone Issues panel to gallery. Chrome-under-
+            ;; issue-load coverage lives in `gallery-chrome`
+            ;; `:story.xray.chrome/issue-load`.
             [panel-gallery.gallery-chrome]
-            ;; Chrome follow-on galleries — rf2-mpn8m settings popup,
-            ;; rf2-kbrkx auto-filter pill / edit-popup.
+            ;; Chrome follow-on galleries — settings popup,
+            ;; auto-filter pill / edit-popup.
             [panel-gallery.gallery-settings]
             [panel-gallery.gallery-filters]
-            ;; Widget galleries — rf2-hp4ow edn-inspector isolation
+            ;; Widget galleries — edn-inspector isolation
             ;; coverage. The widget is exercised indirectly by every
             ;; L4 panel that mounts it; this gallery gives it a
             ;; dedicated harness with one variant per input shape /
             ;; opts combination.
             [panel-gallery.gallery-edn-inspector]
-            ;; rf2-n2jig — mode-3 diff grammar Story set (R1-R8 +
+            ;; Mode-3 diff grammar Story set (R1-R8 +
             ;; combination + edge + theme/density). Shares the
             ;; `:panel-gallery.edn-inspector/fixture` slot + Panel
             ;; mount with the edn-inspector gallery above; the
             ;; variants pass `:full-with-diff? true` to opt into
             ;; the mode-3 chrome (R3 chip + R4 rail).
             [panel-gallery.gallery-diff-mode-3]
-            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; Shared testbed-config helper: derives the
             ;; open-in-editor project-root from the build env.
             [re-frame.testbed.config :as testbed-config]
-            ;; Shared live-app↔Story-shell hash-router host (rf2-tq26t /
-            ;; rf2-uv7sn). rf2-x31vn — panel-gallery adopts the helper so
+            ;; Shared live-app↔Story-shell hash-router host. The
+            ;; panel-gallery uses this helper so
             ;; its `hashchange` listener is installed via the helper's
             ;; remove-then-add `defonce` handle discipline rather than a
             ;; bare per-`run` `addEventListener` (which stacks a duplicate
@@ -213,7 +208,7 @@
 ;; ============================================================================
 
 ;; ----------------------------------------------------------------------------
-;; Project-root resolution (rf2-2c5xb)
+;; Project-root resolution
 ;; ----------------------------------------------------------------------------
 ;;
 ;; Source-coord `:file` slots captured at registration time are classpath-
@@ -224,7 +219,7 @@
 ;; to prepend — without it, the URI ships the bare relative path and the
 ;; OS-side editor handler rejects it ("Path does not exist").
 ;;
-;; Per the rf2-5m5n2 contract Xray exposes `:rf.xray/project-root`. The
+;; Xray exposes `:rf.xray/project-root`. The
 ;; panel-gallery boots with its known on-disk repo position by default; a
 ;; `?checkout-root=<path>` query string overrides for cross-machine portability
 ;; (mirroring the `standard_epochs` testbed's resolver).
@@ -239,7 +234,7 @@
 ;; its precedence over the build-time repo-root) is pinned by
 ;; `re-frame.testbed.config-cljs-test` in tools/testbed-support.
 
-;; rf2-5dphw — open-in-editor project-root derived from the build
+;; Open-in-editor project-root derived from the build
 ;; environment (the build-time `re-frame.testbed.config/checkout-root`
 ;; goog-define joined with this testbed's tool-relative subdir), not a
 ;; hardcoded personal path. `?checkout-root=<path>` still overrides per
@@ -256,21 +251,21 @@
 ;; -- Routing between landing and Story shell ------------------------------
 ;;
 ;; The live-app↔Story-shell hash router + React-root host handle live in the
-;; shared `re-frame.testbed.story-host` helper (rf2-tq26t / rf2-uv7sn); `run`
+;; shared `re-frame.testbed.story-host` helper; `run`
 ;; hands it `landing-view` as the live-app surface. The helper tears one React
 ;; root down before mounting the other on the same `#app` node, and installs
 ;; its `hashchange` listener via a `defonce` remove-then-add handle so a CLJS
-;; hot-reload re-`run` never stacks a duplicate (rf2-x31vn).
+;; hot-reload re-`run` never stacks a duplicate.
 
 (defn ^:export run []
-  ;; rf2-2c5xb — seed `:rf.xray/project-root` BEFORE the Xray handlers
+  ;; Seed `:rf.xray/project-root` BEFORE the Xray handlers
   ;; register so the first chip render reads the configured root. The
   ;; resolver reads only the configured atom; the URI build is independent
   ;; of `window.location`, so the panel-gallery's source links resolve to
   ;; the same on-disk paths regardless of which port shadow-cljs serves
   ;; the testbed from.
   (xray-config/configure! {:rf.xray/project-root (resolve-source-root)})
-  ;; rf2-ymnfx (Issue A) — seed `:rf.story/project-root` for the SAME
+  ;; Seed `:rf.story/project-root` for the SAME
   ;; on-disk root so the Story shell's variant-toolbar 'Open' button
   ;; (re-frame.story.ui.open-in-editor/open-chip) ships an absolute
   ;; path. Story's own atom is independent of Xray's; without this
@@ -289,11 +284,11 @@
   ;; Xray instance for the duration of the variant render — the per-tab
   ;; galleries seed it directly, and the chrome / settings / filters
   ;; galleries thread that same variant frame into `shell-view`'s
-  ;; `:frame-id` opt (de-singletoned shell, rf2-1w07r). No `:rf/xray`
+  ;; `:frame-id` opt (per-frame shell). No `:rf/xray`
   ;; literal, no testbed-local seed event — the variant's `:setup`
   ;; dispatches the canonical Xray events into its own frame.
   (xray-registry/register-xray-handlers!)
-  ;; rf2-pqulr — install Xray theme CSS variables on :root so
+  ;; Install Xray theme CSS variables on :root so
   ;; embedded widgets paint with the themed palette rather than
   ;; browser defaults. Shell normally calls this from shell-view;
   ;; the gallery bypasses the shell so we call directly.
@@ -314,7 +309,6 @@
   ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
   ;; `#/stories` lands on the shell — and so the `hashchange` listener is
   ;; installed via the helper's remove-then-add `defonce` handle rather than a
-  ;; bare per-`run` `addEventListener` that stacks duplicates across hot-reload
-  ;; (rf2-x31vn). The helper renders `[landing-view]` for any non-`#/stories`
-  ;; hash, matching the prior `mount-landing!`.
+  ;; bare per-`run` `addEventListener` that stacks duplicates across hot-reload.
+  ;; The helper renders `[landing-view]` for any non-`#/stories` hash.
   (story-host/mount-with-hash-routing! landing-view))

--- a/tools/xray/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures.cljs
@@ -1,5 +1,5 @@
 (ns panel-gallery.fixtures
-  "Pure fixture builders for the Xray panel gallery (rf2-1o7mp).
+  "Pure fixture builders for the Xray panel gallery.
 
   Story variants seed state by firing REAL Xray init events
   (`:rf.xray/sync-trace-buffer`, `:rf.xray/select-dispatch-id`)
@@ -23,11 +23,9 @@
                    :rf.view/render-key  [<view-id> <args>] ;; on :view
                    :frame       <frame-id>}}
 
-  The mirror of this shape (the `cascade-evs` helper template) lived
-  in the panel-detail panel's test corpus alongside the panel itself;
-  rf2-5gl5r retired the Event/Handler panel and its tests. The gallery
-  retains the template so any future panel projection change has one
-  shared fixture surface to drive variant seeds.
+  The `cascade-evs` helper template is the gallery's single shared
+  fixture surface, so any future panel projection change has one place
+  to drive variant seeds from.
 
   Builders return plain vectors; the variant `:events` slot wraps each
   in `[:rf.xray/sync-trace-buffer <buffer>]` for the seed dispatch.")
@@ -40,9 +38,8 @@
 ;; cascades surface a panel's `:frame` annotation in its cascade list.
 
 (defn cascade-evs
-  "Synthesize the eight trace events for a single cascade. Mirrors the
-  template used by the retired event-detail unit tests (rf2-5gl5r);
-  retained here as the canonical gallery seed.
+  "Synthesize the eight trace events for a single cascade. The canonical
+  gallery seed template.
 
   Returns a vector of trace-event maps shaped per
   `re-frame.trace.projection/group-cascades`."
@@ -392,10 +389,10 @@
        (mapcat identity)
        vec))
 
-;; ---- event-lens variants (rf2-zh2qc) -----------------------------------
+;; ---- event-lens variants -----------------------------------------------
 ;;
-;; Builders that exercise the redesigned Event lens's 6-section layout
-;; under realistic combinations of substrate keys (rf2-twt7m): the
+;; Builders that exercise the Event lens's 6-section layout
+;; under realistic combinations of substrate keys: the
 ;; dispatch-site coord on :rf.event/dispatched, the :fx + :db-present?
 ;; tags on :rf.fx/do-fx, and (in tests) the :rf/default? flag on
 ;; framework-auto-wrapped interceptors.
@@ -434,12 +431,12 @@
   (event-lens-simple-buffer))
 
 (defn event-lens-with-coeffects-buffer
-  "Event lens fixture exercising the COEFFECTS section (rf2-jhhqt,
-  rf2-9dk9y). Stamps two user-injected coeffects (`:now` +
+  "Event lens fixture exercising the COEFFECTS section. Stamps two
+  user-injected coeffects (`:now` +
   `:local-storage`) onto the `:rf.event/run-end` trace's
   `:tags :rf.event/coeffects` slot — the substrate filter has already
   excluded the framework defaults (`:db` `:event` `:frame` `:source`
-  `:trace-id`). Per rf2-9dk9y the stamp lives on `:run-end`, not
+  `:trace-id`). The stamp lives on `:run-end`, not
   `:do-fx`, because do-fx never fires for handlers that return only
   `:db` and no `:fx`."
   []
@@ -500,8 +497,8 @@
 (defn event-lens-handler-threw-buffer
   "Event lens fixture — handler threw mid-run. §5 + §6 should be
   ABSENT; the cascade-outcome glyph is ✗ red and the failure surfaces
-  inline (rf2-gbz39 — Issues is no longer a tab; issues fold into the
-  Epoch panel + the L2 pink-wash + the ribbon signal)."
+  inline — issues fold into the Epoch panel + the L2 pink-wash + the
+  ribbon signal."
   []
   (let [dispatch-id 300
         id-base     300
@@ -521,8 +518,8 @@
 (defn event-lens-hydration-completed-buffer
   "Event lens fixture — a :rf.ssr/hydrated completion event. Renders
   the SSR✓ outcome-line badge plus the hydration-outcome row inside
-  §5. With :mismatches 0 there's no issue cross-reference (rf2-gbz39 —
-  issues surface inline, not via a tab)."
+  §5. With :mismatches 0 there's no issue cross-reference (issues
+  surface inline)."
   []
   (let [dispatch-id 400
         id-base     400
@@ -542,7 +539,7 @@
 (defn event-lens-hydration-mismatch-buffer
   "Event lens fixture — hydration completed WITH mismatches. The
   hydration-outcome row carries the inline issue cross-reference
-  (rf2-gbz39 — issues surface inline, not via a dedicated tab)."
+  (issues surface inline)."
   []
   (let [dispatch-id 401
         id-base     410

--- a/tools/xray/testbeds/panel_gallery/fixtures_app_db.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_app_db.cljs
@@ -1,6 +1,5 @@
 (ns panel-gallery.fixtures-app-db
-  "Pure fixture builders for the Xray App-db tab gallery
-  (rf2-sszlr — rebuild for new 6-tab Xray shape).
+  "Pure fixture builders for the Xray App-db tab gallery.
 
   The app-db-diff panel reads these slots from the Xray frame:
 
@@ -13,12 +12,7 @@
   The atomic `:rf.xray/app-db-current+diff` sub resolves the focused
   epoch's `:value` (`:db-after`) + `:before` (`:db-before`), and
   `:rf.xray/app-db-state` projects that into the current-state section
-  model the facade view renders. (rf2-p53m2 — the former composite
-  `:rf.xray/app-db-diff` had no production view consumer and was pruned.)
-
-  rf2-e9tb0 — `:pinned-slices-store` and `:pinned-slices` were
-  dropped when the pinned-watches strip was superseded by the
-  segment-inspector popup.
+  model the facade view renders.
 
   ## Why seed via `:rf.xray/sync-epoch-history`
 
@@ -68,8 +62,7 @@
 
 (defn empty-buffer
   "No epochs — panel renders the `[empty]` state with the
-  reserved-keys scaffolding only (rf2-e9tb0 dropped the pinned-watches
-  strip)."
+  reserved-keys scaffolding only."
   []
   [])
 
@@ -241,9 +234,8 @@
 
 ;; ---- tab-specific buffer builders --------------------------------------
 ;;
-;; Per the rf2-sszlr per-tab gallery spec the App-db tab needs richer
-;; variant coverage: tiny app-db, large app-db, sensitive paths, large
-;; sentinels, watched-keys diff highlighting.
+;; The App-db tab carries richer variant coverage: tiny app-db, large
+;; app-db, sensitive paths, large sentinels, watched-keys diff highlighting.
 
 (defn tiny-app-db-buffer
   "Single epoch whose db-after is a deliberately tiny three-key map.
@@ -284,8 +276,7 @@
   "Single epoch where multiple app-db paths carry `:rf/redacted`
   markers — across `:auth`, `:user/profile`, `:billing`. The panel's
   slice renderer surfaces each marker verbatim per Spec 009 §Privacy
-  + the new spec/015-Data-Classification opt-in path marks
-  (rf2-vw7f5)."
+  + the spec/015-Data-Classification opt-in path marks."
   []
   [(epoch-record
      {:epoch-id 22

--- a/tools/xray/testbeds/panel_gallery/fixtures_diff_mode_3.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_diff_mode_3.cljs
@@ -1,6 +1,5 @@
 (ns panel-gallery.fixtures-diff-mode-3
-  "Fixture builders for the **mode-3 diff grammar** Story set
-  (rf2-n2jig).
+  "Fixture builders for the **mode-3 diff grammar** Story set.
 
   Mode-3 is the third lens of the HANDLER `:db` toggle: the full data
   tree WITH inline diff annotations (gutter glyphs, row washes, R3

--- a/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_edn_inspector.cljs
@@ -1,6 +1,6 @@
 (ns panel-gallery.fixtures-edn-inspector
   "Pure fixture builders for the edn-inspector widget gallery
-  (rf2-hp4ow — widget-isolation coverage).
+  (widget-isolation coverage).
 
   The edn-inspector widget (`day8.re-frame2-xray.views.edn-inspector`)
   is exercised indirectly by every L4 panel that mounts it — App-DB,
@@ -41,7 +41,7 @@
     (`edn-inspector-default-formatters`) render compact headers +
     full bodies.
   - **Diff mode** — before/after pairs that surface `:added`,
-    `:modified`, `:removed`, and `:same` rows via the rf2-zuh1e
+    `:modified`, `:removed`, and `:same` rows via the
     `children-of-pair` walk.
   - **Opts demos** — one variant per individual opt
     (`:zoomable?`, `:popup-affordance?`, `:card?` + `:header`,
@@ -116,7 +116,7 @@
 (defn map-nested
   "Six-level nested map. Exercises the depth ceiling — at depth ≥ 8
   the widget renders `▸ {…N keys}` summaries; ancestors up to that
-  depth open by default under the rf2-kbdk8 width-aware heuristic."
+  depth open by default under the width-aware heuristic."
   []
   {:value {:tenant {:acme {:department {:engineering {:team {:platform
                                                               {:project :xray
@@ -185,7 +185,7 @@
 
 (defn uuid-instance
   "Single random UUID. The default formatter renders a compact
-  `#uuid \"…<last-8>\"` header (rf2-x16b1)."
+  `#uuid \"…<last-8>\"` header."
   []
   {:value (random-uuid)})
 
@@ -193,7 +193,7 @@
   "Mixed insts spanning the formatter's relative-time bucketing —
   recent, hours-ago, days-ago, ISO-fallback. The default formatter
   picks the bucket based on `(.getTime (js/Date.))` at render
-  time (rf2-x16b1)."
+  time."
   []
   {:value (let [now      (.getTime (js/Date.))
                 ms-per-h (* 60 60 1000)

--- a/tools/xray/testbeds/panel_gallery/fixtures_machines.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_machines.cljs
@@ -1,6 +1,5 @@
 (ns panel-gallery.fixtures-machines
-  "Pure fixture builders for the Xray Machines tab gallery
-  (rf2-sszlr — rebuild for new 6-tab Xray shape).
+  "Pure fixture builders for the Xray Machines tab gallery.
 
   The Machines panel reads from `:rf.xray/machine-inspector-data`, a
   composite over `:rf.xray/registered-machines`,

--- a/tools/xray/testbeds/panel_gallery/fixtures_routing.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_routing.cljs
@@ -1,6 +1,5 @@
 (ns panel-gallery.fixtures-routing
-  "Pure fixture builders for the Xray Routes tab gallery (rf2-nrbs9,
-  reshaped per rf2-lq0ef).
+  "Pure fixture builders for the Xray Routes tab gallery.
 
   The Routes panel reads:
 
@@ -105,7 +104,7 @@
 (defn- deactivated-trace
   "The runtime's `:rf.route/deactivated` lifecycle emit for the PRIOR
   route on a cross-route nav. Its `:tags :route-id` is the FROM — the
-  panel reads FROM off this emit, not the live slice (rf2-m9rx6)."
+  panel reads FROM off this emit, not the live slice."
   [id dispatch-id route-id]
   {:id        id
    :op-type   :rf.event
@@ -118,7 +117,7 @@
 
   The 4-arity threads a `from-route`: the runtime emits
   `:rf.route/deactivated` for the prior route on a cross-route nav, and
-  the panel derives FROM from that emit (NOT the live slice, rf2-m9rx6),
+  the panel derives FROM from that emit (NOT the live slice),
   so the FROM ◆ glyph requires the deactivated trace to be present."
   ([dispatch-id to-route nav-token]
    [(event-dispatched-trace 1 dispatch-id [:rf.route/navigate to-route])

--- a/tools/xray/testbeds/panel_gallery/fixtures_trace.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_trace.cljs
@@ -1,20 +1,19 @@
 (ns panel-gallery.fixtures-trace
-  "Pure fixture builders for the Xray Trace tab gallery (rf2-sszlr —
-  rebuild for new 6-tab Xray shape; epoch-scoped rewire rf2-ofoqu).
+  "Pure fixture builders for the Xray Trace tab gallery.
 
-  ## Epoch-scoped feed (rf2-td380 / rf2-ofoqu)
+  ## Epoch-scoped feed
 
-  After PR #1958 (rf2-td380 / rf2-o6yqq / rf2-gkczt) the Trace panel
-  is a lens on the spine's FOCUSED EPOCH, not the global trace bus.
-  Its sub `:rf.xray/trace-feed` joins:
+  The Trace panel is a lens on the spine's FOCUSED EPOCH, not the
+  global trace bus. Its sub `:rf.xray/trace-feed` joins:
 
     - `:rf.xray/focus`          — carries `:epoch-id`
     - `:rf.xray/epoch-history`  — the per-frame ring of `:rf/epoch-record`
                                    maps (the framework's settling records)
 
   and renders the focused epoch's `:trace-events` slice (the complete
-  domino trail for one settling). It NO LONGER reads the trace bus /
-  `:trace-buffer`, so seeding the bus produces an empty panel.
+  domino trail for one settling). It reads the focused epoch's slice,
+  not the trace bus / `:trace-buffer` — seeding the bus produces an
+  empty panel.
 
   Each variant therefore seeds via `:rf.xray/sync-epoch-history` — the
   canonical seed event (`epoch.cljs`) that `assoc`s the history vector
@@ -27,8 +26,8 @@
 
   No variant pins `:rf.xray/focus`. With no trace bus seeded there are
   no cascades, so `compose-focus` leaves the focus `:epoch-id` nil; the
-  shared `panels.shared.focus-resolver` then applies its head-fallback
-  (rf2-h0120): nil focus + non-empty history → `:focused`, resolving to
+  shared `panels.shared.focus-resolver` then applies its head-fallback:
+  nil focus + non-empty history → `:focused`, resolving to
   the HEAD record `(peek epoch-history)`. `:rf.xray/epoch-history` is
   oldest-first, so the variant's representative epoch is placed LAST in
   the history vector and is what the panel renders. Multi-op variants
@@ -75,10 +74,10 @@
                      :reason                <string>
                      ...}}
 
-  The flat Trace panel (rf2-aqusw) projects each raw event into a row
+  The flat Trace panel projects each raw event into a row
   carrying `Δt · stage · area-badge · what-happened · target/detail ·
   duration` via `trace_helpers/project-feed-from-epoch`. There is no
-  chip-filtering UI (the focused epoch IS the scope, rf2-gkczt) — the
+  chip-filtering UI (the focused epoch IS the scope) — the
   fixtures keep the event shape minimal but exercise the full op-family
   vocabulary so the STAGE column + colour-coded left edge (resolved
   through the Epoch panel's `panels.epoch.badge` taxonomy) light up
@@ -203,12 +202,12 @@
 (defn hundred-events-buffer
   "One hundred events spanning all four op-types, three frames, three
   origins, four sources. A mid-density epoch — the flat list renders
-  every row (no row cap, rf2-aqusw)."
+  every row (no row cap)."
   []
   (n-events 100))
 
 (defn thousand-events-buffer
-  "One thousand events — a deep epoch. The flat list (rf2-aqusw)
+  "One thousand events — a deep epoch. The flat list
   renders the whole epoch's trace in fire order; exercises the panel +
   the shared resizable-table under a large row count."
   []
@@ -216,7 +215,7 @@
 
 (defn filtered-active-buffer
   "A buffer mixing two op-types (events + fx). The flat panel renders
-  every row (no chip-filtering post-rf2-gkczt — the focused epoch IS
+  every row (no chip-filtering — the focused epoch IS
   the scope); used by the mixed-op-types variant."
   []
   (vec
@@ -357,7 +356,7 @@
             :source :ui :origin :app :frame :rf/default :dispatch-id 100
             :render-key [:cart/badge nil]})])))
 
-;; ---- epoch-record + history builders (rf2-ofoqu) -------------------------
+;; ---- epoch-record + history builders ------------------------------------
 ;;
 ;; The Trace panel reads the FOCUSED EPOCH's `:trace-events`, resolved
 ;; via the shared focus-resolver over `:rf.xray/epoch-history`. These
@@ -406,7 +405,7 @@
 
 (defn medium-trace-history
   "One epoch carrying a 100-row domino trail. A mid-density epoch —
-  the flat list renders every row (no row cap, rf2-aqusw)."
+  the flat list renders every row (no row cap)."
   []
   (single-epoch-history
     {:epoch-id 3 :event [:dashboard/recompute-all]
@@ -443,7 +442,7 @@
 
 (defn mixed-op-types-history
   "One epoch whose trail mixes event + fx op-types (no chip-filtering
-  post-rf2-gkczt — the feed renders every row)."
+  — the feed renders every row)."
   []
   (single-epoch-history
     {:epoch-id 8 :event [:cart/add :apple]

--- a/tools/xray/testbeds/routes_epochs/core.cljs
+++ b/tools/xray/testbeds/routes_epochs/core.cljs
@@ -86,8 +86,8 @@
 
   ## Test-free + self-contained
 
-  Per rf2-8cevm this testbed carries no spec.cjs; regression coverage
-  lives in the substrate contract tests + the Xray feature-matrix gate
+  This testbed carries no spec.cjs; regression coverage lives in the
+  substrate contract tests + the Xray feature-matrix gate
   (`tools/xray/testbeds/feature_matrix/scenarios.cjs` — the
   `routes-epochs routing ladder` scenario, which drives the ladder via the
   runner's per-step RUN-THIS-STEP buttons). The routes / events / subs /
@@ -248,10 +248,9 @@
          from the route slice and writes `:profile` into app-db (the
          transition runs :loading → :idle around this loader).
 
-         EP-0001 (rf2-vzld77 / rf2-tj6w9l): the route slice is durable
-         routing RUNTIME-DB state at `[:rf.runtime/routing :current]`, no
-         longer in app-db `:rf/runtime`. An event handler reads it off the
-         `:rf.db/runtime` coeffect every event handler receives — the
+         EP-0001: the route slice is durable routing RUNTIME-DB state at
+         `[:rf.runtime/routing :current]`. An event handler reads it off
+         the `:rf.db/runtime` coeffect every event handler receives — the
          canonical `:on-match` loader idiom (mirrors the realworld
          example's `:profile/load`)."}
   (fn handler-load-profile [{:keys [db] rt :rf.db/runtime} _ev]
@@ -465,9 +464,9 @@
   ;; right project-root on its first paint of any chip.
   (xray-config/configure! {:rf.xray/project-root (resolve-source-root)})
   (rf/init! reagent-adapter/adapter)
-  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
-  ;; absence — establish the host frame explicitly. URL ownership is now an
-  ;; explicit declaration, so opt the host frame in via `{:url-bound? true}`
+  ;; EP-0002: the runtime never synthesises a frame from absence —
+  ;; establish the host frame explicitly. URL ownership is an explicit
+  ;; declaration, so opt the host frame in via `{:url-bound? true}`
   ;; (otherwise `:rf.nav/push-url` no-ops and history-driven steps stall).
   (rf/reg-frame host-frame {:url-bound? true})
   ;; Seed app-db and pull the current URL into the route slice (what a

--- a/tools/xray/testbeds/runner/core.cljs
+++ b/tools/xray/testbeds/runner/core.cljs
@@ -119,11 +119,11 @@
 ;; ============================================================================
 ;;
 ;; The one place the runner reaches into Xray, through the same host-facing
-;; focus channel Story uses. Restores the focus-pinning the rf2-5sjbg rewrite
-;; deleted, re-expressed for the app-db `:step` driver: a per-host-frame
-;; epoch listener fires AFTER each settle and focuses the just-settled CHILD
-;; epoch (not the `[:run-step]` parent), so a Step press leaves Xray showing
-;; the step's real result. No Reagent atom, no timer.
+;; focus channel Story uses. Pins the focus to 'the just-dispatched render'
+;; for the app-db `:step` driver: a per-host-frame epoch listener fires
+;; AFTER each settle and focuses the just-settled CHILD epoch (not the
+;; `[:run-step]` parent), so a Step press leaves Xray showing the step's
+;; real result. No Reagent atom, no timer.
 
 (defn focus-epoch!
   "Focus epoch `epoch-id` on `host-frame` in the embedded Xray surface,
@@ -229,7 +229,7 @@
           (assert event (str "runner step " n " has no :event"))
           {:db (assoc db :step n)
            ;; A 2-element `:fx :dispatch` entry — `[fx-id args]` per the
-           ;; `:fx` per-entry arity contract (rf2-18kwf / rf2-n6d3m). The
+           ;; `:fx` per-entry arity contract. The
            ;; child dispatch INHERITS `host-frame` from this handler's own
            ;; envelope (the views dispatch `[run-step-event n] {:frame
            ;; host-frame}`, so the handler runs in host-frame and

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -41,10 +41,9 @@
 
   Pick ANY ONE Xray panel — Epoch, App-db, Views, or Trace — (or the
   inline issue surfacing — Epoch issue blocks · L2 event-row wash · the
-  issues ribbon signal; the standalone Issues tab was removed per
-  rf2-gbz39) and step through top to bottom: that panel is COMPLETELY
-  exercised. The step set is chosen for per-panel coverage completeness,
-  not one-lens-per-step.
+  issues ribbon signal) and step through top to bottom: that panel is
+  COMPLETELY exercised. The step set is chosen for per-panel coverage
+  completeness, not one-lens-per-step.
 
   ## Per-panel coverage map
 
@@ -91,11 +90,11 @@
 
   ## Test-free + self-contained
 
-  Per rf2-8cevm this testbed carries no spec.cjs; regression coverage
-  lives in the substrate contract tests + the Xray feature-matrix gate.
-  The events / subs / views below are OWNED here — this deck does NOT
-  reuse the shared `testdeck.*` modules (whose coupling to the two-frame
-  + routing surfaces is what made the step-deck inflexible)."
+  This testbed carries no spec.cjs; regression coverage lives in the
+  substrate contract tests + the Xray feature-matrix gate. The events /
+  subs / views below are OWNED here — this deck does NOT reuse the shared
+  `testdeck.*` modules, keeping it decoupled from the two-frame + routing
+  surfaces."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Flows artefact — load-time hook so `reg-flow` resolves
@@ -175,13 +174,12 @@
 ;; writes an int there; the post-handler app-db validation (Spec 010
 ;; §Validation order) rejects it and rolls the :db effect back, while the
 ;; schema-violation issue surfaces inline — the Epoch panel's issue block,
-;; the L2 event-row wash, and the issues ribbon signal (the standalone
-;; Issues tab was removed per rf2-gbz39).
+;; the L2 event-row wash, and the issues ribbon signal.
 
 (def AuthSlice [:map [:token :string]])
-;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This testbed's deck
-;; hosts on :rf/default (see `host-frame` below), so name it explicitly.
+;; EP-0002: reg-app-schema is context-required frame-local; a bare ns-load
+;; call raises :rf.error/no-frame-context. This testbed's deck hosts on
+;; :rf/default (see `host-frame` below), so name it explicitly.
 (with-frame :rf/default
   (rf/reg-app-schema [:auth] {:schema AuthSlice}))
 
@@ -293,8 +291,8 @@
 ;; changed. Button #5 bumps `:base`; App-db shows `:derived` recompute
 ;; and Trace shows the flow run.
 
-;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local; name the
-;; :rf/default host frame explicitly for this ns-load registration.
+;; EP-0002: reg-flow is context-required frame-local; name the :rf/default
+;; host frame explicitly for this ns-load registration.
 (with-frame :rf/default
   (rf/reg-flow
     {:id          :standard-epochs/derived
@@ -832,10 +830,10 @@
   ;; standalone wrapper (header + the parameterised `root`) on the
   ;; host-frame with the `standard-epochs` testid prefix and the deck's
   ;; run-step event. The runner cursor lives in app-db `:step`.
-  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
-  ;; absence — register the host frame, scope the boot dispatch, and wrap
-  ;; the render in a `frame-provider-existing` (scope-only — the host
-  ;; frame is already `reg-frame`'d; the carried invariant).
+  ;; EP-0002: the runtime never synthesises a frame from absence —
+  ;; register the host frame, scope the boot dispatch, and wrap the render
+  ;; in a `frame-provider-existing` (scope-only — the host frame is
+  ;; already `reg-frame`'d; the carried invariant).
   (rf/reg-frame host-frame {})
   (rf/with-frame host-frame
     (rf/dispatch-sync [:standard-epochs/reset]))

--- a/tools/xray/testbeds/two_frame_isolation/core.cljs
+++ b/tools/xray/testbeds/two_frame_isolation/core.cljs
@@ -89,11 +89,10 @@
   buttons in the standard-epochs ladder are FEATURES being exercised —
   they light up Xray's Issues surface legitimately, per frame.
 
-  Per rf2-8cevm this testbed carries no spec.cjs; regression coverage for
-  multi-frame isolation lives in the substrate contract tests
-  (`npm run test:cljs`) + the Xray feature-matrix gate's `multi-frame
-  isolation substrate` scenario (on the framework `testbeds/multi_frame`
-  surface)."
+  This testbed carries no spec.cjs; regression coverage for multi-frame
+  isolation lives in the substrate contract tests (`npm run test:cljs`)
+  + the Xray feature-matrix gate's `multi-frame isolation substrate`
+  scenario (on the framework `testbeds/multi_frame` surface)."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Requiring `standard-epochs.core` installs every handler /


### PR DESCRIPTION
De-historicize comments/docstrings per rf2-2db7z1. Recovered after the worker's parent + the recovery agent were killed by an API rate-limit; commits were already made in-worktree, pushed by the mayor. Behaviour-neutral (comment/docstring only).