### PR TITLE
docs(impl): de-historicize comments/docstrings — core/machines/boundaries/nav-render (rf2-hhaw6u, rf2-hsi2uv, rf2-ci131b, rf2-oj93up)

### DIFF
--- a/implementation/core/deps.edn
+++ b/implementation/core/deps.edn
@@ -1,51 +1,42 @@
-;; day8/re-frame2 — core artefact (rf2-0hxm).
+;; day8/re-frame2 — core artefact.
 ;;
 ;; Per Spec 006 §Adapter shipping convention: adapters ship as separate
 ;; Maven artefacts; this is the core (registry, drain, fx, trace) and
-;; excludes substrate-specific code. Per rf2-zha9 the adapters live under
-;; implementation/adapters/<name>/ (renamed from substrates/ per rf2-0imy);
-;; the Reagent adapter is in implementation/adapters/reagent/. Per rf2-p7va
-;; (the first per-feature split per rf2-5vjj Strategy B) the Spec 010
-;; schema-attachment surface
-;; lives in implementation/schemas/ (`day8/re-frame2-schemas`); per
-;; rf2-xbtj (the second per-feature split) the Spec 005 state-machine
-;; surface lives in implementation/machines/ (`day8/re-frame2-machines`);
-;; per rf2-k682 (the third per-feature split) the Spec 012 routing
-;; surface lives in implementation/routing/ (`day8/re-frame2-routing`);
-;; per rf2-tfw3 (the fourth per-feature split) the Spec 013 flows
-;; surface lives in implementation/flows/ (`day8/re-frame2-flows`);
-;; per rf2-5kpd (the fifth per-feature split) the Spec 014 managed-HTTP
-;; surface lives in implementation/http/ (`day8/re-frame2-http`); per
-;; rf2-uo7v (the sixth per-feature split) the Spec 011 SSR surface
-;; lives in implementation/ssr/ (`day8/re-frame2-ssr`); per rf2-lt4e
-;; (the seventh and final per-feature split) the Tool-Pair epoch
-;; surface lives in implementation/epoch/ (`day8/re-frame2-epoch`).
+;; excludes substrate-specific code. The adapters live under
+;; implementation/adapters/<name>/; the Reagent adapter is in
+;; implementation/adapters/reagent/. The Spec 010 schema-attachment surface
+;; lives in implementation/schemas/ (`day8/re-frame2-schemas`); the Spec 005
+;; state-machine surface lives in implementation/machines/
+;; (`day8/re-frame2-machines`); the Spec 012 routing surface lives in
+;; implementation/routing/ (`day8/re-frame2-routing`); the Spec 013 flows
+;; surface lives in implementation/flows/ (`day8/re-frame2-flows`); the
+;; Spec 014 managed-HTTP surface lives in implementation/http/
+;; (`day8/re-frame2-http`); the Spec 011 SSR surface lives in
+;; implementation/ssr/ (`day8/re-frame2-ssr`); the Tool-Pair epoch surface
+;; lives in implementation/epoch/ (`day8/re-frame2-epoch`).
 ;;
 ;; Reagent appears as a dependency here because re-frame.views (CLJS-only
-;; reg-view) is currently Reagent-coupled per Spec 006 §CLJS reference
-;; scope. Per the rf2-0hxm decision, that coupling is preserved at the
-;; views.cljs layer; the *substrate* adapter ns (re-frame.adapter.reagent)
-;; lives in the Reagent artefact. The full substrate-config plumbing
-;; unification is deferred to rf2-3yij (UIx adapter).
+;; reg-view) is Reagent-coupled per Spec 006 §CLJS reference scope. That
+;; coupling lives at the views.cljs layer; the *substrate* adapter ns
+;; (re-frame.adapter.reagent) lives in the Reagent artefact.
 ;;
-;; metosin/malli is intentionally NOT a dep of this artefact: per
-;; rf2-p7va the schemas artefact owns the Malli relationship. The
-;; runtime resolves of `malli.core/validate` in `re-frame.epoch` and
-;; `re-frame.http.managed` are intentional best-effort `(resolve ...)`
-;; calls that no-op when Malli is absent — apps that opt into managed
-;; HTTP decode-schemas or epoch-restore schema validation pull in the
-;; schemas artefact (which carries Malli) alongside core.
+;; metosin/malli is intentionally NOT a dep of this artefact: the schemas
+;; artefact owns the Malli relationship. The runtime resolves of
+;; `malli.core/validate` in `re-frame.epoch` and `re-frame.http.managed`
+;; are intentional best-effort `(resolve ...)` calls that no-op when Malli
+;; is absent — apps that opt into managed HTTP decode-schemas or
+;; epoch-restore schema validation pull in the schemas artefact (which
+;; carries Malli) alongside core.
 {:paths ["src"]
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
          org.clojure/clojurescript {:mvn/version "1.12.145"}
          reagent/reagent           {:mvn/version "2.0.1"}}
 
  :aliases
- {;; The core artefact's tests historically exercised schema-aware,
-  ;; machine-aware, routing-aware AND flow-aware paths (every
-  ;; reset-runtime fixture rolled the per-frame schema registry, the
-  ;; machines wall-clock-timer table (rf2-gr8q replaced the per-process
-  ;; spawn-counter atom with in-snapshot allocation), the route-
+ {;; The core artefact's tests exercise schema-aware, machine-aware,
+  ;; routing-aware AND flow-aware paths (every reset-runtime fixture
+  ;; rolls the per-frame schema registry, the machines wall-clock-timer
+  ;; table (whose spawn ids are allocated in-snapshot), the route-
   ;; registration counter, and the per-frame
   ;; flow registry; many test files require re-frame.schemas to set up
   ;; their data shapes; smoke_test.clj / pattern_smoke_test.clj /
@@ -66,13 +57,9 @@
   ;; epoch-history / restore-epoch! / register-epoch-listener! / unregister-epoch-listener!
   ;; / clear-history! / clear-epoch-listeners! surface so the production-elision
   ;; build asserts every gated branch in the namespace).
-  ;; Per rf2-p7va those tests stay in core/test/ and pull schemas in as
-  ;; a test-only dep; per rf2-xbtj they pull machines in the same way;
-  ;; per rf2-k682 they pull routing in the same way; per rf2-tfw3 they
-  ;; pull flows in the same way; per rf2-5kpd they pull http in the same
-  ;; way; per rf2-uo7v they pull ssr in the same way; per rf2-lt4e they
-  ;; pull epoch in the same way. The core artefact's test classpath
-  ;; therefore includes schemas (with Malli), machines, routing, flows,
+  ;; Those tests stay in core/test/ and pull schemas, machines, routing,
+  ;; flows, http, ssr, and epoch in as test-only deps. The core artefact's
+  ;; test classpath therefore includes schemas (with Malli), machines, routing, flows,
   ;; http, ssr, and epoch while the published library jar carries none
   ;; of them. Keeps the per-test coverage intact without smuggling any
   ;; feature into the production classpath. See
@@ -81,18 +68,16 @@
   ;; implementation/http/deps.edn, implementation/ssr/deps.edn, and
   ;; implementation/epoch/deps.edn.
   :test {:extra-paths ["test" "../../examples/reagent"
-                       ;; rf2-cd2zo — the ssr / ssr_streaming /
+                       ;; The ssr / ssr_streaming /
                        ;; state_machine_walkthrough examples' headless test
-                       ;; fns were folded INTO re-frame.examples-test (this
-                       ;; artefact's test/ tree) as inline deftest bodies,
-                       ;; retiring the sibling examples/.../test/ source
-                       ;; dirs. examples_test.clj now requires only the
+                       ;; fns live IN re-frame.examples-test (this
+                       ;; artefact's test/ tree) as inline deftest bodies.
+                       ;; examples_test.clj requires only the
                        ;; example *source* nses (`ssr.core`,
                        ;; `ssr-streaming.core`, `state-machine-walkthrough.core`),
                        ;; which the bare `../../examples/reagent` root above
                        ;; carries — so no examples/.../test source path is
-                       ;; needed and the example tree is test-free
-                       ;; (rf2-8cevm).
+                       ;; needed and the example tree is test-free.
                        ]
          :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                        day8/re-frame2-machines   {:local/root "../machines"}
@@ -101,18 +86,18 @@
                        day8/re-frame2-http       {:local/root "../http"}
                        day8/re-frame2-ssr        {:local/root "../ssr"}
                        day8/re-frame2-epoch      {:local/root "../epoch"}
-                       ;; rf2-p10npe — the optional Resources artefact
+                       ;; The optional Resources artefact
                        ;; (Spec 016). Pulled in as a TEST-ONLY dep so the
                        ;; JVM core test build can require re-frame.resources
                        ;; (conformance_test.clj) and populate the
                        ;; `:resources` feature probe that features-cljs-test
                        ;; asserts; the published core jar carries none of it.
                        day8/re-frame2-resources  {:local/root "../resources"}
-                       ;; rf2-try1x — silent-on-success reporter.
+                       ;; Silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         ;; rf2-bv2qqm — the default PR/local gate (incl. the fast-PR
+         ;; The default PR/local gate (incl. the fast-PR
          ;; spine `scripts/test-fast-pr.sh`, which runs this artefact)
          ;; EXCLUDES the heavy `^:stress` namespace
          ;; (`concurrency_stress_test`, three 5000-iter × 8-thread
@@ -123,7 +108,7 @@
          ;; `scripts/test-rigorous-local.sh`.
          :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
 
-  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
+  ;; Nightly/rigorous slow-test gate. INCLUDES ONLY the
   ;; `^:slow` / `^:stress` tests (the union the default `:test` alias
   ;; excludes), so `:test` + `:slow-test` together cover every test once.
   :slow-test
@@ -141,8 +126,8 @@
                  {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
-  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow:
-  ;; the release workflow runs `clojure -M:clein deploy` from this
+  ;; Clojars deploy. The release workflow runs `clojure -M:clein deploy`
+  ;; from this
   ;; artefact's directory, which builds pom + jar and pushes to Clojars
   ;; using CLOJARS_USERNAME / CLOJARS_PASSWORD env vars.
   :clein {:extra-deps {io.github.noahtheduke/clein
@@ -152,8 +137,7 @@
 
   ;; Build descriptor consumed by clein. Per-artefact: this builds the
   ;; `day8/re-frame2` core artefact. The Reagent adapter has its own
-  ;; build descriptor in implementation/adapters/reagent/deps.edn
-  ;; (per rf2-zha9 / rf2-0imy).
+  ;; build descriptor in implementation/adapters/reagent/deps.edn.
   ;;
   ;; :version is a relative path to the repo-root VERSION file — single
   ;; source of truth for both artefacts. Mike updates VERSION in the

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -9,20 +9,19 @@
   (Schemas Describe Shape, Not Public Egress Policy): schemas describe
   shape and validation, NOT durable app-db egress policy — a
   `reg-app-schema` `{:sensitive? true}` / `{:large? true}` slot prop is
-  **no longer** a second route into this registry. Schema `:sensitive?`
-  still drives schema-validation-failure-trace redaction (the schema's own
+  not a route into this registry. Schema `:sensitive?`
+  drives schema-validation-failure-trace redaction (the schema's own
   egress product — `re-frame.schemas`), and machine `:data-schema` per-slot
-  props still classify machine `:data` (EP-0005, unchanged). There are no
+  props classify machine `:data` (EP-0005). There are no
   imperative large-path APIs.
 
-  EP-0001 (rf2-vzld77): the elision declaration registry is DURABLE,
+  EP-0001: the elision declaration registry is DURABLE,
   serializable framework state (it must survive epoch-restore / SSR-
   hydration so an off-box projection redacts consistently), so it lives in
-  the frame's **runtime-db** partition at `[:rf.runtime/elision …]` — NOT in
-  app-db (where it briefly sat under the retired `:rf/runtime` root). Per
-  Conventions §Reserved runtime-db keys. Reads come off the runtime-db
-  projection; writes go through `frame/swap-runtime-db!` (the runtime-db
-  partition write surface)."
+  the frame's **runtime-db** partition at `[:rf.runtime/elision …]`, not in
+  app-db. Per Conventions §Reserved runtime-db keys. Reads come off the
+  runtime-db projection; writes go through `frame/swap-runtime-db!` (the
+  runtime-db partition write surface)."
   (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -96,9 +95,9 @@
   `add-marks` / `set-marks` — can share a single source of truth
   for the prune logic. Not part of the public API.
 
-  EP-0001 (rf2-vzld77): operates on the runtime-db partition value (the
+  EP-0001: operates on the runtime-db partition value (the
   elision registry is durable framework state — Conventions §Reserved
-  runtime-db keys), no longer on the app-db `:rf/runtime` root."
+  runtime-db keys)."
   [runtime-db new-reg]
   (cond
     (seq new-reg)
@@ -115,7 +114,7 @@
 
 (defn ^:no-doc reconcile-runtime-db-effect
   "Reconcile the durable elision registry across a whole-value
-  `:rf.db/runtime` partition commit (rf2-gom797).
+  `:rf.db/runtime` partition commit.
 
   A framework-authority event may return a `:rf.db/runtime` effect whose
   value WHOLE-VALUE-REPLACES the runtime-db partition (Spec 002 §A runtime
@@ -170,10 +169,9 @@
   truth for the read-transform-write skeleton. Not part of the
   public API.
 
-  EP-0001 (rf2-vzld77): writes through `frame/swap-runtime-db!` (the
+  EP-0001: writes through `frame/swap-runtime-db!` (the
   runtime-db partition of the one physical frame-state container) — the
-  elision registry is durable framework state and lives in runtime-db, not
-  in the retired app-db `:rf/runtime` root."
+  elision registry is durable framework state and lives in runtime-db."
   [frame-id f]
   (frame/swap-runtime-db! frame-id
                           (fn [old-runtime-db]
@@ -209,17 +207,14 @@
   ([frame-id]
    (or (get (registry-of frame-id) :sensitive-declarations) {})))
 
-;; EP-0015 §8 (rf2-d2r3um): the schema-attached `{:sensitive? true}` /
-;; `{:large? true}` slot props are NO LONGER a route into this app-db
+;; EP-0015 §8: the schema-attached `{:sensitive? true}` /
+;; `{:large? true}` slot props are NOT a route into this app-db
 ;; egress registry. Durable app-db classification is frame-owned —
 ;; `re-frame.frame-classification/install!` writes `:source :frame`
-;; declarations at `reg-frame` time. The former
-;; `populate-{elision,sensitive}-from-schemas!` / `populate-from-schemas!`
-;; functions (which walked `reg-app-schema` slot props into `:source
-;; :schema` declarations) are removed: schemas describe shape, not durable
-;; app-db egress policy. Schema `:sensitive?` still drives
+;; declarations at `reg-frame` time. Schemas describe shape, not durable
+;; app-db egress policy. Schema `:sensitive?` drives
 ;; schema-validation-failure-trace redaction (`re-frame.schemas`), and
-;; machine `:data-schema` props still classify machine `:data` (EP-0005) —
+;; machine `:data-schema` props classify machine `:data` (EP-0005) —
 ;; both consult the schema directly, not this registry.
 
 (defn clear-warning-cache!
@@ -231,7 +226,7 @@
   "Return a byte-count for a value's printed representation. Used by the
   `:rf.size/large-elided` marker payload. `^:no-doc` public so
   `re-frame.marks` reuses it rather than re-inlining the same `pr-str`
-  byte-count a second time (rf2-ih437c)."
+  byte-count a second time."
   [v]
   #?(:clj  (count (.getBytes ^String (pr-str v) "UTF-8"))
      :cljs (count (pr-str v))))
@@ -239,7 +234,7 @@
 (defn ^:no-doc value-type
   "Coarse value-type tag for the `:rf.size/large-elided` marker payload.
   `^:no-doc` public so `re-frame.marks` reuses it rather than re-inlining
-  the same closed `cond` a second time (rf2-ih437c)."
+  the same closed `cond` a second time."
   [v]
   (cond
     (map? v)    :map
@@ -269,15 +264,15 @@
   "Build the `:rf.size/large-elided` marker map for value `v` at `path`.
   `^:no-doc` public so `re-frame.marks/large-marker` builds the marker
   here (with `{:reason :marks}`) rather than re-inlining the shape a
-  second time (rf2-ih437c)."
+  second time."
   [v path {:keys [hint as-of-epoch include-digests? reason]}]
   (let [body (cond-> {:path   (vec path)
                       :bytes  (pr-str-bytes v)
                       :type   (value-type v)
-                      ;; EP-0015 §8 (rf2-d2r3um): the declaration source is
-                      ;; now frame-owned (`:source :frame`), not schema —
-                      ;; carry that provenance in `:reason` (defaults to
-                      ;; `:frame` when the decl omits an explicit source).
+                      ;; EP-0015 §8: the declaration source is
+                      ;; frame-owned (`:source :frame`) — carry that
+                      ;; provenance in `:reason` (defaults to `:frame`
+                      ;; when the decl omits an explicit source).
                       :reason (or reason :frame)
                       :hint   hint
                       :handle (handle-of (vec path) as-of-epoch)}
@@ -289,7 +284,7 @@
   matched `large-decl` (its `:hint` / `:source`) and the walk `ctx` (its
   `:as-of-epoch` / `:include-digests?`). Single source for the BYTE-IDENTICAL
   4-key option map the path-based walker (`walk`) and the value-match large
-  collector (`collect-large-markers!`) each pass to `->marker` (rf2-4p0bxp).
+  collector (`collect-large-markers!`) each pass to `->marker`.
   Both call sites carry the same `:as-of-epoch` / `:include-digests?` keys on
   their respective `ctx`, so the marker is identical whichever arm emits it."
   [large-decl ctx]
@@ -311,7 +306,7 @@
                       :hint     "Add this path to the frame's `:large {:app-db [...]}` classification (EP-0015)."
                       :recovery :no-recovery})))))
 
-;; ---- collection-coordinate declaration matching (rf2-wm9kp) ---------------
+;; ---- collection-coordinate declaration matching --------------------------
 ;;
 ;; Schema-derived declarations are INDEX-FREE: the schema walker descends
 ;; positional/keyed containers (`:vector` / `:sequential` / `:set` /
@@ -397,7 +392,7 @@
   segment). Both are retained only when they remain a prefix of some
   declared path (`decl-prefixes`), bounding the set.
 
-  POSITION-PRECISE skip (rf2-wm9kp follow-up): the `:map-of`-key
+  POSITION-PRECISE skip: the `:map-of`-key
   interpretation — keeping `c` unchanged so the key is treated as a
   collection coordinate — is only legitimate for a candidate that has
   ALREADY consumed at least one declared segment (`(seq c)`). A non-empty
@@ -478,7 +473,7 @@
   integer index, forking decl-paths via fork-index-paths' micro-shape that
   otherwise recurs across the path-based walker (`walk-indexed` / `walk-seq`)
   and the large-value collector (`collect-large-markers!`'s vector / seq
-  branches) (rf2-zp0g04). `reduce` iterates a vector in index order, so the
+  branches). `reduce` iterates a vector in index order, so the
   vector and seq cases share one traversal; the volatile index reproduces the
   per-element `(conj path i)` exactly. The caller owns `acc`'s identity
   (transient vector for the walkers, transient `[raw marker]` accumulator for
@@ -520,9 +515,8 @@
   "Walk a POSITIONAL container `coll` (a vector OR a seq), reproducing each
   element at its integer-indexed path `(conj path i)` and forking the
   candidate decl-paths through the index. Both the vector (`:vector`) and seq
-  (`:sequential`) walk arms share this body (rf2-zp0g04): each yields a
-  persistent vector of walked elements (a seq normalises to a vector here, as
-  the prior `walk-seq` did)."
+  (`:sequential`) walk arms share this body: each yields a persistent vector
+  of walked elements (a seq normalises to a vector here)."
   [coll path decl-paths ctx]
   (let [decl-prefixes (:decl-prefixes ctx)]
     (persistent!
@@ -554,7 +548,7 @@
         ;; length of the prior marker, not the original payload. Mirrors
         ;; the sensitive-case idempotence (the `:rf/redacted` scalar
         ;; sentinel is non-matchable so the walker descends into nothing
-        ;; on a re-projection pass). Per rf2-fq8ep.
+        ;; on a re-projection pass).
         v
         (->marker v path (marker-opts large-decl ctx)))
 
@@ -604,8 +598,8 @@
                    :large              large
                    :sensitive          sensitive
                    ;; Prefix set of every declared path — bounds the forked
-                   ;; candidate decl-path set as the walker descends maps
-                   ;; (rf2-wm9kp). Empty when nothing is declared ⇒ the fork
+                   ;; candidate decl-path set as the walker descends maps.
+                   ;; Empty when nothing is declared ⇒ the fork
                    ;; prunes to {} immediately and the walker is identity.
                    :decl-prefixes      (decl-prefix-set {:large large :sensitive sensitive})
                    :include-large?     (true? (:rf.size/include-large? opts))
@@ -623,10 +617,10 @@
   "Walk `v` and substitute the frame's declared sensitive or large paths for
   wire egress (the durable declarations live in `[:rf.runtime/elision …]`,
   installed frame-owned by `re-frame.frame-classification` under
-  `:source :frame` — EP-0015 §8; the schema→app-db-egress route is gone).
-  Sensitive wins over large when both declarations match.
+  `:source :frame` — EP-0015 §8). Sensitive wins over large when both
+  declarations match.
 
-  EP-0002 (rf2-gjq3ow) — the wire-egress frame resolves from the CARRIED
+  EP-0002 — the wire-egress frame resolves from the CARRIED
   stamp: the explicit `:frame` opt (*override*) wins, else the in-effect
   carried-invariant scope (`frame/resolve-current-frame` — a `with-frame`
   binding or an enclosing frame-provider). There is NO `:rf/default` floor:
@@ -636,14 +630,14 @@
 
   A resolved frame-id is not enough — it must RESOLVE to a live frame.
   An explicit `:frame` opt (or a stale carried scope) may name a frame that
-  was never registered or has since been destroyed. EP-0015 issue 1
-  (rf2-t55hxg.18): an unresolvable frame's per-frame elision registry is
-  unreachable (`registry-of` returns nil), so feeding it through the policy
-  walk produced an EMPTY-policy identity transform — shipping every value
-  verbatim under NO policy, the exact silent leak this contract abolishes.
-  An unknown / destroyed frame therefore FAILS CLOSED here too, identically
-  to the frameless case: it is validated against the live registry
-  (`frame/frame`) before being treated as policy-bearing. Spec 015
+  was never registered or has since been destroyed. EP-0015 issue 1: an
+  unresolvable frame's per-frame elision registry is unreachable
+  (`registry-of` returns nil), so feeding it through the policy walk would
+  be an EMPTY-policy identity transform — shipping every value verbatim under
+  NO policy, a silent leak. An unknown / destroyed frame therefore FAILS
+  CLOSED here too, identically to the frameless case: it is validated against
+  the live registry (`frame/frame`) before being treated as policy-bearing.
+  Spec 015
   §Direct reads and fail-closed frame resolution: an unresolved frame must
   fail closed — it must not fall through to a permissive walk, and never
   synthesizes `:rf/default`.
@@ -664,7 +658,7 @@
          ;; LIVE frame. `frame/frame` returns nil for an unknown /
          ;; never-registered / destroyed id, so an explicit `:frame` opt or
          ;; a stale carried scope that names a dead frame is treated exactly
-         ;; like the frameless case below (fail closed). rf2-t55hxg.18.
+         ;; like the frameless case below (fail closed).
          live-frame? (and (some? frame-id) (some? (frame/frame frame-id)))]
      (cond
        ;; Known + LIVE carried frame ⇒ apply that frame's elision policy.
@@ -690,7 +684,7 @@
   (and (map? v) (contains? v :rf.size/large-elided)))
 
 ;; ---------------------------------------------------------------------------
-;; Derived-tree VALUE-based redaction (EP-0015 issue 2, rf2-i783h0).
+;; Derived-tree VALUE-based redaction (EP-0015 issue 2).
 ;;
 ;; `elide-wire-value` redacts a value by its frame-declared `:sensitive`
 ;; app-db PATH. But a DERIVED tree — rendered hiccup, a resolved
@@ -706,9 +700,9 @@
 ;; the same `:rf/redacted` sentinel `elide-wire-value` emits. This is the
 ;; value-based DUAL of the path-based walker above — it belongs in the same
 ;; ns so the two arms of "redact app-db-sensitive values at egress" share one
-;; home (the elision registry, the sentinel, the indexing convention). It
-;; centralizes the engine Story-MCP / re-frame2-pair-mcp previously each
-;; carried privately (the SECOND place EP-0015 egress semantics could drift).
+;; home (the elision registry, the sentinel, the indexing convention). It is
+;; the single engine Story-MCP / re-frame2-pair-mcp share for value-based
+;; redaction, so EP-0015 egress semantics live in one place.
 ;;
 ;; ## Non-unique-secret guard
 ;;
@@ -840,7 +834,7 @@
   "The set of values sitting at `frame-id`'s declared-`:sensitive?` app-db
   paths, read out of the RAW `source-db` — the candidate secrets, with NO
   wire-disclosure guard applied. The fail-SAFE base set for value-matching a
-  derived tree (EP-0015 issue 2, rf2-i783h0).
+  derived tree (EP-0015 issue 2).
 
   Reads the SAME frame-owned `:sensitive` `:app-db` declarations
   (`sensitive-declarations`) the path-based walker reads — installed by
@@ -877,7 +871,7 @@
   disclosed on the wire (the non-unique-secret guard). Use this to
   value-redact a DERIVED tree where the same sensitive value reappears at a
   non-app-db position the path-based `elide-wire-value` walker can't reach
-  (EP-0015 issue 2, rf2-i783h0).
+  (EP-0015 issue 2).
 
   Candidates come from `collect-sensitive-values` (the unguarded base set).
   The non-unique-secret guard then subtracts any candidate that ALSO appears,
@@ -915,7 +909,7 @@
 
 (defn- redact-matching-tree
   "The single derived-tree value-match walker, parameterized by the egress
-  AXIS via `replace-fn` (rf2-jevy26). Walks `tree`; at each node `replace-fn`
+  AXIS via `replace-fn`. Walks `tree`; at each node `replace-fn`
   returns either the AXIS replacement (a matched node is substituted wholesale
   and NOT descended) or the `no-match` sentinel (descend structurally).
   Recurses maps/vectors/sets/seqs (map KEYS too — a secret/large value used as
@@ -962,9 +956,8 @@
   "Value-redact a DERIVED `tree` (rendered hiccup, a resolved `:effective-args`
   map, a snapshot body, a plan-resolved value slot) against the live values
   at `frame-id`'s declared-`:sensitive?` app-db paths, before wire egress
-  (EP-0015 issue 2, rf2-i783h0). The single framework home for the
-  value-match-redaction primitive Story-MCP / re-frame2-pair-mcp previously
-  each carried privately.
+  (EP-0015 issue 2). The single framework home for the
+  value-match-redaction primitive Story-MCP / re-frame2-pair-mcp share.
 
   Collects the secret set from `source-db` (the raw db the derived tree was
   produced from) via `sensitive-value-set` — including the non-unique-secret
@@ -994,7 +987,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Large-value value-match — the DUAL of the sensitive engine for the :large
-;; egress axis (rf2-9o5ixx, EP-0015: sensitive + large are PEER egress axes).
+;; egress axis (EP-0015: sensitive + large are PEER egress axes).
 ;;
 ;; `elide-wire-value` elides a declared-`:large` slot to a `:rf.size/large-
 ;; elided` marker by PATH. But the same large blob can be re-keyed into a
@@ -1051,7 +1044,7 @@
 
       ;; Positional container (vector OR seq): descend each element at its
       ;; integer-indexed path, forking decl-paths through the index — the
-      ;; shared `reduce-indexed-forks` micro-shape (rf2-zp0g04).
+      ;; shared `reduce-indexed-forks` micro-shape.
       (or (vector? node) (seq? node))
       (reduce-indexed-forks
         node decl-paths (:decl-prefixes ctx)
@@ -1066,7 +1059,7 @@
 
 (defn large-value-marker-map
   "The `{large-value marker}` map for `frame-id`'s declared-`:large` app-db
-  paths, read out of the RAW `source-db` (rf2-9o5ixx). Each key is the whole
+  paths, read out of the RAW `source-db`. Each key is the whole
   blob value sitting at a declared-large path; each value is the
   `:rf.size/large-elided` marker `elide-wire-value` would have emitted for it
   (same `:path` / `:bytes` / `:handle` / digest under `wire-opts`).
@@ -1095,7 +1088,7 @@
 
 (defn redact-matching-large-values
   "Walk `tree`, substituting any leaf `=` to a key of `marker-map` with that
-  key's `:rf.size/large-elided` marker (rf2-9o5ixx). The large-axis dual of
+  key's `:rf.size/large-elided` marker. The large-axis dual of
   `redact-matching-values`. Recurses maps/vectors/sets/seqs; map KEYS are
   walked too. Returns `tree` unchanged when `marker-map` is empty.
 
@@ -1111,7 +1104,7 @@
 
 (defn redact-derived-large-values
   "Value-elide a DERIVED `tree` against the live values at `frame-id`'s
-  declared-`:large` app-db paths, before wire egress (rf2-9o5ixx). The
+  declared-`:large` app-db paths, before wire egress. The
   large-axis dual of `redact-derived-values`: collects the
   `{large-value marker}` map from `source-db` via `large-value-marker-map`
   (under the egress floor `wire-opts`), then substitutes any matching leaf in
@@ -1130,29 +1123,28 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Composed multi-slot derived-tree egress — the SINGLE public assembling
-;; helper (rf2-leggev Option B2, rf2-j7qbhm).
+;; helper.
 ;;
-;; The sensitive + large value-match arms above are the disassembled GEARS of
-;; one operation: "redact a frame's app-db-sensitive / -large values out of a
+;; The sensitive + large value-match arms above are the GEARS of one
+;; operation: "redact a frame's app-db-sensitive / -large values out of a
 ;; derived tree (or a set of derived value slots) before off-box egress". The
 ;; one assembling consumer — Story-MCP's `scrub-rendered` (single tree, both
 ;; axes) and `scrub-explain-values` (one collection pass over many value
-;; slots) — previously reached the gears piecemeal through the `re-frame.core`
-;; façade. Spec 015 names the BOUNDARY / OPERATION, not the gearbox, so the
-;; gears no longer crowd the façade: this one helper subsumes them, and the
-;; low-level arms stay in this namespace for the rare bespoke caller.
+;; slots) — names the BOUNDARY / OPERATION via this helper. Spec 015 names the
+;; BOUNDARY / OPERATION, not the gearbox: this one helper subsumes the gears,
+;; and the low-level arms stay in this namespace for the rare bespoke caller.
 ;;
-;; The one-pass property the gears were carved to provide is preserved: the
-;; sensitive candidate set AND the large marker-map are each collected ONCE
-;; from `source-db`, then substituted across EVERY slot. Sensitive runs FIRST
-;; (it wins — the large collector already skips sensitive-declared nodes), and
-;; the large pass sees only the sensitive-survived slots.
+;; One-pass: the sensitive candidate set AND the large marker-map are each
+;; collected ONCE from `source-db`, then substituted across EVERY slot.
+;; Sensitive runs FIRST (it wins — the large collector already skips
+;; sensitive-declared nodes), and the large pass sees only the
+;; sensitive-survived slots.
 ;; ---------------------------------------------------------------------------
 
 (defn redact-derived-slots
   "Redact a frame's app-db-sensitive / -large values out of one or more
   DERIVED value slots before off-box egress — the SINGLE composed multi-slot
-  egress helper (rf2-leggev Option B2). The value-based DUAL of the path-based
+  egress helper. The value-based DUAL of the path-based
   `elide-wire-value`, assembled so a consumer names the BOUNDARY (\"scrub these
   derived slots for `frame-id`'s egress\") instead of hand-wiring the
   sensitive / large value-match gears.
@@ -1179,7 +1171,7 @@
        `:rf.size/large-elided` marker.
 
   Both collections are done a SINGLE time and reused across every slot — the
-  one-pass property the low-level gears were carved to expose.
+  one-pass property the low-level gears expose.
 
   `wire-opts` is the `elide-wire-value` egress floor the path-based `:app-db`
   slot ships under (e.g. an off-box-tool profile's `:rf.size/*` opt-set);
@@ -1239,7 +1231,7 @@
               m
               slot-keys))))
 
-;; EP-0015 §8 (rf2-d2r3um): no `:elision/populate-from-schemas!` hook —
-;; schemas no longer feed the app-db egress registry (frame policy owns it).
+;; EP-0015 §8: there is no `:elision/populate-from-schemas!` hook — frame
+;; policy owns the app-db egress registry; schemas describe shape only.
 (late-bind/set-fn! :elision/sensitive-declarations sensitive-declarations)
 (late-bind/set-fn! :elision/clear-warning-cache! clear-warning-cache!)

--- a/implementation/core/src/re_frame/emit.cljc
+++ b/implementation/core/src/re_frame/emit.cljc
@@ -11,10 +11,9 @@
       failure for off-box exception shippers.
 
   Survives `:advanced` + `goog.DEBUG=false`. Parallel to (not a
-  fallback for) the dev-only `re-frame.trace` surface. Per rf2-ic1sv:
-  consolidated naming · dev/prod axis encoded in the namespace
-  (`re-frame.trace/*` = dev-only / DCE'd; `re-frame.emit/*` = always-
-  on / survives prod).
+  fallback for) the dev-only `re-frame.trace` surface. The dev/prod
+  axis is encoded in the namespace (`re-frame.trace/*` = dev-only /
+  DCE'd; `re-frame.emit/*` = always-on / survives prod).
 
   Public surface:
 

--- a/implementation/core/src/re_frame/error.cljc
+++ b/implementation/core/src/re_frame/error.cljc
@@ -8,8 +8,8 @@
   site in the runtime routes through them so the human message and the
   `:rf.error/id` machine discriminator cannot drift: the builder DERIVES
   the message from `:reason` + the `[:rf.error/<id>]` greppability token
-  and sets the canonical ex-data shape. Keyword-only messages become
-  structurally impossible by construction (rf2-vvixub).
+  and sets the canonical ex-data shape. Keyword-only messages are
+  structurally impossible by construction.
 
   `type-of-value` renders a short type tag in the `:reason` string of
   a `:rf.error/schema-validation-failure` trace event; consumed by
@@ -27,7 +27,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- the canonical thrown-error builder (rf2-vvixub) ----------------------
+;; ---- the canonical thrown-error builder ----------------------------------
 ;;
 ;; Spec 009 §The thrown-error shape rules the human-message contract:
 ;;
@@ -39,15 +39,15 @@
 ;;   3. The message is stable in MEANING, not bytes — tests MUST NOT
 ;;      exact-equal it.
 ;;   4. The message carries a trailing `[:rf.error/<id>]` token for
-;;      log/CI greppability, preserving the only thing the old
-;;      "category-from-message-alone" property bought.
+;;      log/CI greppability, so a log line or raw stack trace still
+;;      pivots to a stable category from the message alone.
 ;;   5. `:reason` IS that required human sentence; there is no separate
 ;;      `:rf.error/message` slot (it would duplicate `:reason`).
 ;;
 ;; The builder derives the message FROM `:reason` + the token, so the
 ;; message and `:rf.error/id` cannot drift, and a keyword-only message is
-;; impossible to emit. Today's hand-rolled `(ex-info (str error-kw) …)`
-;; sites — which made the keyword the WHOLE message — route through here.
+;; impossible to emit. Every framework `(throw (ex-info …))` site routes
+;; through here.
 
 (defn id-token
   "The trailing greppability token for a thrown-error `:rf.error/id` —
@@ -92,7 +92,7 @@
 
 (defn thrown-ex-info
   "Build the canonical thrown-error `ex-info` (Spec 009 §The thrown-error
-  shape, rf2-vvixub). The SINGLE chokepoint every framework
+  shape). The SINGLE chokepoint every framework
   `(throw (ex-info …))` site routes through.
 
   Args:
@@ -126,33 +126,32 @@
 
 (defn throw-error!
   "Build (via `thrown-ex-info`) and `throw` the canonical thrown-error
-  `ex-info` in one call (Spec 009 §The thrown-error shape, rf2-vvixub).
+  `ex-info` in one call (Spec 009 §The thrown-error shape).
   Same args as `thrown-ex-info`. Never returns normally."
   ([error-id where-sym reason] (throw-error! error-id where-sym reason nil))
   ([error-id where-sym reason opts]
    (throw (thrown-ex-info error-id where-sym reason opts))))
 
-;; ---- nil-safe thrown-value message extractor (rf2-vzrxp3) -----------------
+;; ---- nil-safe thrown-value message extractor -----------------------------
 ;;
 ;; The runtime catches thrown values at ~7 sites (the router pipeline
 ;; exception, the cofx supplier throw, the fx-handler throw, the reactive /
 ;; compute sub throws, the interceptor-registry arg-resolve throw) and stamps
-;; the host message into the `:exception-message` trace / error-record slot via
-;; a RAW `#?(:clj (.getMessage e) :cljs (.-message e))`. That is unsafe in CLJS:
+;; the host message into the `:exception-message` trace / error-record slot.
+;; A raw `#?(:clj (.getMessage e) :cljs (.-message e))` is unsafe in CLJS:
 ;; ANY value is legally throwable, and a thrown NON-Error value (a keyword, a
 ;; map, a string — `(throw :boom)` / `(throw {:k 1})`) has no `.-message`
-;; property, so `(.-message e)` is `nil` and `:exception-message` silently
-;; becomes nil. The off-box shipper then sees an error with no message at all.
+;; property, so `(.-message e)` reads `nil` and `:exception-message` silently
+;; becomes nil — the off-box shipper then sees an error with no message at all.
 ;;
-;; `error.cljc` already centralises message BUILDING (the thrown-error
-;; builders above) but had no shared message EXTRACTOR. This is it: the ONE
-;; nil-safe `ex-message`-equivalent the catch sites route through, so a
-;; non-Error throwable degrades to a useful rendering instead of nil. Pure;
-;; runs only on the failure path.
+;; This is the ONE nil-safe `ex-message`-equivalent the catch sites route
+;; through, so a non-Error throwable degrades to a useful rendering instead of
+;; nil. (`error.cljc` centralises message BUILDING in the thrown-error builders
+;; above, and message EXTRACTION here.) Pure; runs only on the failure path.
 
 (defn ex-message-safe
-  "Nil-safe extractor for the human message of a CAUGHT thrown value `e`
-  (rf2-vzrxp3). Returns a string (or nil only when `e` itself is nil).
+  "Nil-safe extractor for the human message of a CAUGHT thrown value `e`.
+  Returns a string (or nil only when `e` itself is nil).
 
   - For a host exception (JVM `Throwable`, CLJS `js/Error` / `ExceptionInfo`)
     returns its message — `(.getMessage e)` on the JVM, `(ex-message e)` /
@@ -164,10 +163,10 @@
     render to a recognisable token; a map / collection renders structurally.
   - Returns nil ONLY for a nil `e` (there is genuinely no message).
 
-  The reason the raw `(.-message e)` was unsafe on CLJS: the property is
-  absent on a plain value, so it reads `nil` with no error — the worst
-  failure mode for a diagnostic. This degrades loudly-but-safely instead.
-  Pure; hot-path safe (runs only on the catch path)."
+  A raw `(.-message e)` is unsafe on CLJS because the property is absent on
+  a plain value, so it reads `nil` with no error — the worst failure mode for
+  a diagnostic. This degrades loudly-but-safely instead. Pure; hot-path safe
+  (runs only on the catch path)."
   [e]
   (cond
     (nil? e) nil
@@ -178,37 +177,33 @@
     ;; the value so the diagnostic carries SOMETHING rather than nil.
     (str e)))
 
-;; ---- shared removed-API thrower: inline interceptor (rf2-8au0w6) -----------
+;; ---- shared removed-API thrower: inline interceptor -----------------------
 ;;
-;; The retired-name "throwing stub" pattern (a removed public API survives as
-;; a `^:no-doc` var that throws a LOUD, actionable `:rf.error/<x>-removed`
-;; naming the replacement) was hand-rolled per surface. The per-surface DATA
-;; TABLES (`events/removed-reg-event-names`, `std-interceptors/removed-std-
-;; interceptor-values`, rf2-ne2uk8) already collapse each surface's rows to one
-;; literal vector — but the THROW MECHANICS were still re-rolled per file, and
-;; the `inline-interceptor-removed` thrower was LITERAL copy-paste across two
-;; namespaces (`events` + `interceptor-registry`). The helper below is the ONE
-;; shared definition both inline-interceptor rejection sites delegate to, so the
-;; throw mechanics live once. Behaviour is byte-identical: each caller passes
-;; its exact `where` / `reason` / `extra`, so the thrown ex-info shape is
-;; unchanged. (The always-on FAN-OUT removed-stub variant — the EP-0017
-;; `inject-cofx` + EP-0018 reg-event removals — shares `cofx/raise-removed!`
-;; instead, because that fan-out needs `late-bind` + `trace`, both of which
-;; require `error`; housing it here would close a load cycle.)
+;; The "throwing stub" pattern (a removed public API survives as a `^:no-doc`
+;; var that throws a LOUD, actionable `:rf.error/<x>-removed` naming the
+;; replacement) is described per surface in DATA TABLES
+;; (`events/removed-reg-event-names`, `std-interceptors/removed-std-
+;; interceptor-values`) that collapse each surface's rows to one literal
+;; vector. The helper below is the ONE shared definition both inline-interceptor
+;; rejection sites delegate to, so the throw mechanics live once: each caller
+;; passes its exact `where` / `reason` / `extra`, so the thrown ex-info shape
+;; is the caller's own. (The always-on FAN-OUT removed-stub variant — the
+;; `inject-cofx` + reg-event removals — shares `cofx/raise-removed!` instead,
+;; because that fan-out needs `late-bind` + `trace`, both of which require
+;; `error`; housing it here would close a load cycle.)
 
 (defn throw-inline-interceptor-removed!
-  "Throw the EP-0022 reference-only-flip hard error
-  `:rf.error/inline-interceptor-removed` (rf2-0adhqs.9) for an INLINE
-  interceptor value found where a chain expects a REFERENCE. The ONE
+  "Throw the hard error `:rf.error/inline-interceptor-removed` for an INLINE
+  interceptor value found where a chain expects a REFERENCE (interceptor chains
+  are reference-only, EP-0022 §Event and frame chain grammar). The ONE
   definition both rejection sites delegate to — the registration-time site
   (`re-frame.events/validate-meta-interceptors!`, `:where 'rf/reg-event`) and
   the chain-assembly site (`re-frame.interceptor-registry/resolve-chain`,
   `:where 'rf/resolve-chain`). Each passes its own `where` symbol, fully
   composed `reason` sentence, and `extra` ex-data map, so the thrown shape is
-  exactly what each site threw before the dedup; only the throw mechanics are
-  shared. The migration path the message names: register the interceptor with
-  `reg-interceptor` and reference it by id (a bare keyword or an `[id arg]`
-  2-vector). Never returns normally."
+  the caller's own; only the throw mechanics are shared. The fix the message
+  names: register the interceptor with `reg-interceptor` and reference it by id
+  (a bare keyword or an `[id arg]` 2-vector). Never returns normally."
   [where reason extra]
   (throw-error!
     :rf.error/inline-interceptor-removed
@@ -228,8 +223,8 @@
   `re-frame.events`'s `legacy-runtime-root-ex-data`) — so the two surfaces
   carry an IDENTICAL map. Those sites cannot route the BUILD through
   `thrown-ex-info` without forking the shared payload; this helper lets them
-  keep the one payload and still emit the human message instead of the bare
-  `(str (:rf.error/id data))` keyword the message position used to carry.
+  keep the one payload and still emit the human message in the message
+  position rather than a bare `(str (:rf.error/id data))` keyword.
 
   `data` MUST carry `:rf.error/id` and SHOULD carry `:reason`; the message is
   `(human-message (:rf.error/id data) (:reason data))`. ex-data is `data`
@@ -238,12 +233,11 @@
   (ex-info (human-message (:rf.error/id data) (:reason data)) data))
 
 (defn keyword-only-message?
-  "Conformance predicate (rf2-vvixub): true when `message` is a bare
-  stringified `:rf.error/…` keyword — i.e. the OLD keyword-only message
-  shape the new contract forbids. A conformant framework message LEADS
-  with a human sentence and only carries the keyword inside the trailing
-  `[:rf.error/<id>]` token, so a conformant message is never `(str
-  some-keyword)` on its own.
+  "Conformance predicate: true when `message` is a bare stringified
+  `:rf.error/…` keyword — the keyword-only message shape the contract
+  forbids. A conformant framework message LEADS with a human sentence and
+  only carries the keyword inside the trailing `[:rf.error/<id>]` token, so a
+  conformant message is never `(str some-keyword)` on its own.
 
   Used by the thrown-error conformance test to reject any framework throw
   that regresses to a keyword-only human message."
@@ -253,7 +247,7 @@
          (re-matches #":rf\.error/[A-Za-z0-9*+!_.?\-]+" message))))
 
 (defn message-has-id-token?
-  "Conformance predicate (rf2-vvixub): true when `message` contains the
+  "Conformance predicate: true when `message` contains the
   trailing `[:rf.error/<id>]` greppability token (Spec 009 §The
   thrown-error shape, rule 4). The conformance test asserts every
   framework thrown message carries the token so a log/CI grep still
@@ -263,7 +257,7 @@
     (and (string? message)
          (re-find #"\[:rf\.error/[A-Za-z0-9*+!_.?\-]+\]" message))))
 
-;; ---- EP-0015-safe diagnostic value summary (rf2-uwqale) -------------------
+;; ---- EP-0015-safe diagnostic value summary -------------------------------
 ;;
 ;; Spec 015 §Data-Classification rules that raw application values MUST NOT
 ;; be baked into framework exception messages or ex-data: once a value is
@@ -271,10 +265,10 @@
 ;; by browser consoles, error boundaries, host logs, SSR/static-export
 ;; error handlers, and production observability BEFORE the record projector
 ;; (`project-egress`) can classify the original paths — path-based
-;; projection cannot recover a value that no longer sits at a path. The fix
-;; the EP names is: adapter/diagnostic surfaces carry a SUMMARY of the
-;; offending value (shape / type / count / keys / bounded head), never the
-;; value itself. `diag-value-summary` is that summary primitive.
+;; projection cannot recover a value that no longer sits at a path. So
+;; adapter/diagnostic surfaces carry a SUMMARY of the offending value
+;; (shape / type / count / keys / bounded head), never the value itself.
+;; `diag-value-summary` is that summary primitive.
 ;;
 ;; It is intentionally tiny and self-contained (no `elide-wire-value` /
 ;; `project-egress` dependency) because the surfaces that need it include
@@ -306,7 +300,7 @@
 
 (defn diag-value-summary
   "EP-0015-safe SUMMARY of a value for a framework diagnostic message or
-  ex-data slot (Spec 015 §Data-Classification, rf2-uwqale). Returns a
+  ex-data slot (Spec 015 §Data-Classification). Returns a
   small data map describing the value's SHAPE — never the value itself —
   so the diagnostic survives off-box capture without leaking app-owned
   sensitive/large content.

--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -19,26 +19,23 @@
           :time         <millis>
           :exception    <ex>
           :elapsed-ms   <int>
-          :source-coord {:ns :file :line}  ;; rf2-3un2g; absent if
-                                           ;; the failing handler was
-                                           ;; registered programmatically
+          :source-coord {:ns :file :line}  ;; absent if the failing
+                                           ;; handler was registered
+                                           ;; programmatically
                                            ;; (no macro capture)
           }
 
     For off-box observability shippers (Sentry, Honeybadger,
-    Rollbar). Per rf2-3un2g the `:source-coord` slot rides the
-    always-on parallel `error-coords-by-id` registry so it survives
-    CLJS `:advanced` + `goog.DEBUG=false` builds where public
-    registry-meta has been stripped of coord-keys.
+    Rollbar). The `:source-coord` slot rides the always-on parallel
+    `error-coords-by-id` registry so it survives CLJS `:advanced` +
+    `goog.DEBUG=false` builds where public registry-meta carries no
+    coord-keys.
 
   Observability is the only concern here — there is no app-steering
   recovery policy. Recovery is framework-owned: the per-category typed
   defaults (frame-destroyed recovers + emits, sub-exception returns nil,
-  handler-exception fails loud without crashing the app). The per-frame
-  `:on-error` recovery policy was REMOVED (rf2-hiqtk8, superseding the
-  rf2-2hvga axis-2 / recovery-policy-eligible column): recovery is not a
-  framework app-policy concern, and the policy's return value was never
-  read or applied — a documented-but-fictional contract.
+  handler-exception fails loud without crashing the app). Recovery is
+  not a framework app-policy concern.
 
   A LISTENER throw is silently dropped (a sibling-isolation concern, not
   a framework error). Each listener invocation is try/catch wrapped.
@@ -47,11 +44,10 @@
   belt-and-braces gate alongside an explicit config flag. The substrate
   proper carries no gate.
 
-  NOTE: handler-meta `:sensitive?` is no longer consulted here.
-  Sensitive data marking is path-based per the upcoming data-
-  classification mechanism (separate spec doc; in progress) — the
-  per-path elision wire-walker is the load-bearing redaction surface
-  on this path."
+  Sensitive data marking is path-based per the data-classification
+  mechanism (separate spec doc); handler-meta `:sensitive?` is not
+  consulted here. The per-path elision wire-walker is the load-bearing
+  redaction surface on this path."
   (:require [re-frame.elision        :as elision]
             [re-frame.emit-substrate :as emit]
             [re-frame.late-bind      :as late-bind]
@@ -74,8 +70,7 @@
 (def register-error-listener!
   "Register a listener `f` under `id`. Re-registering the same id
   replaces. `f` receives a single error-record map (see ns docstring
-  §Record shape); its return value is ignored. Returns `id`. Per
-  rf2-bacs4."
+  §Record shape); its return value is ignored. Returns `id`."
   (:register registry))
 
 (def unregister-error-listener!
@@ -87,7 +82,7 @@
   code should never call this. Returns nil."
   (:clear registry))
 
-;; ---- kind-aware source-coord lookup (rf2-bxud9v) --------------------------
+;; ---- kind-aware source-coord lookup --------------------------------------
 ;;
 ;; The always-on `error-coords-by-id` parallel registry is keyed by
 ;; `[registry-kind id]` — the SAME `kind` the public reg-* macro path
@@ -112,11 +107,11 @@
 
 (def ^:private sub-error-categories
   "Categories whose `:event-id` slot carries a SUB id — their source
-  coords live under `[:sub sub-id]` in the always-on registry. Per
-  rf2-bxud9v: `dispatch-on-error!` looked these up under `[:event …]`
-  (the hardcoded default), so the always-on production error records
-  for the parametric input-fn failures (and the reactive sub-exception)
-  omitted the failing sub's `:source-coord`."
+  coords live under `[:sub sub-id]` in the always-on registry, so
+  `dispatch-on-error!` resolves them there rather than under the
+  `[:event …]` default. Covers the parametric input-fn failures and
+  the reactive sub-exception, so the always-on production error records
+  carry the failing sub's `:source-coord`."
   #{:rf.error/sub-input-fn-exception
     :rf.error/sub-input-fn-bad-return
     :rf.error/sub-exception
@@ -125,7 +120,7 @@
 (defn- error-source-coord
   "Resolve the `{:ns :file :line}` source-coord for the failing `id` of an
   `error-kw` category, pivoting on the registry kind the `id` was
-  registered with (rf2-bxud9v). Returns nil when no coords were captured
+  registered with. Returns nil when no coords were captured
   (programmatic registration that bypassed the macro path, or an id that
   was never registered) — the caller `cond->`s the slot in, so nil means
   the `:source-coord` slot is ABSENT from the record rather than nil.
@@ -164,9 +159,7 @@
   machine-unresolved-guard — stay dev-trace-only and do NOT call
   this fn; that is correct, not a gap.)
 
-  There is no app-steering recovery policy: the per-frame `:on-error`
-  recovery policy was REMOVED (rf2-hiqtk8, superseding the rf2-2hvga
-  axis-2 / recovery-policy-eligible column). Recovery is framework-owned
+  There is no app-steering recovery policy. Recovery is framework-owned
   (the per-category typed defaults); observability is this listener.
 
   Builds the tight error-record ONCE, runs
@@ -184,10 +177,10 @@
   app-db slice. Sensitive-data redaction on this path is path-based:
   the per-frame `:rf.runtime/elision` registry's `:sensitive-
   declarations` drive the wire-walker's per-slot substitutions.
-  Handler-meta `:sensitive?` is no longer consulted (path-marked
-  classification is the v2 mechanism; separate spec doc; in progress).
+  Handler-meta `:sensitive?` is not consulted; path-marked
+  classification is the mechanism (separate spec doc).
 
-  ## Component attribution (rf2-n4x74b)
+  ## Component attribution
 
   `attrs` is an OPTIONAL trailing map carrying the component-attributed
   slots `{:failing-id <kw> :reason <string>}`. For the categories whose
@@ -212,7 +205,7 @@
   ([error-kw event event-id frame-id exception elapsed-ms time]
    (dispatch-on-error! error-kw event event-id frame-id exception elapsed-ms time nil))
   ([error-kw event event-id frame-id exception elapsed-ms time attrs]
-  (let [;; Per rf2-3un2g §Always-on error-coord registry: source-coords
+  (let [;; Always-on error-coord registry: source-coords
         ;; for the failing handler/sub ride the always-on parallel
         ;; registry (NOT the public registry-meta — which is stripped of
         ;; coord-keys under CLJS `:advanced + goog.DEBUG=false`). The
@@ -221,7 +214,7 @@
         ;; programmatic registrations that bypassed the macro path —
         ;; that's fine; the slot is absent from the record rather than nil.
         ;;
-        ;; Per rf2-bxud9v the lookup is KIND-AWARE: the registry is keyed
+        ;; The lookup is KIND-AWARE: the registry is keyed
         ;; by `[registry-kind id]`, so a sub-id (`:rf.error/sub-*`
         ;; categories) must resolve under `[:sub …]`, not the hardcoded
         ;; `[:event …]`. See [[error-source-coord]] / [[sub-error-categories]].
@@ -230,7 +223,7 @@
         ;; via the per-frame `:rf.runtime/elision` registry get their
         ;; per-path substitutions.
         elided-event (elision/elide-wire-value event {:frame frame-id})
-        ;; rf2-n4x74b: lift the component-attributed slots into the always-on
+        ;; Lift the component-attributed slots into the always-on
         ;; record so an off-box shipper sees WHICH interceptor / cofx failed in
         ;; production (the `:event-id` slot carries the EVENT id for these
         ;; categories; the failing component id would otherwise ride only the
@@ -251,7 +244,7 @@
                        (some? reason)     (assoc :reason reason))]
     ;; Corpus-wide listeners fan out (the ADVANCED integration registry).
     ((:fan-out registry) record)
-    ;; EP-0015 §9 (rf2-t55hxg.7): the frame-owned observability sink route —
+    ;; EP-0015 §9: the frame-owned observability sink route —
     ;; the NORMAL production error-observation surface (Spec 015 §Frame-owned
     ;; observability sink policy). Parallel to the corpus-wide listener
     ;; fan-out above: routes the error record to THIS frame's declared
@@ -269,26 +262,23 @@
                     time nil))
    nil)))
 
-;; ---- the two-channel fan-out helper (rf2-c4oycd) --------------------------
+;; ---- the two-channel fan-out helper ---------------------------------------
 ;;
 ;; EVERY production-reachable runtime `:rf.error/*` site fans the SAME category
 ;; out along BOTH error channels in lock-step: the always-on
 ;; `dispatch-on-error!` listener registry (axis 1 — production-survivable; the
 ;; off-box-shipper / SSR-projector source of truth) AND the dev-only
 ;; `trace/emit-error!` surface (axis 2 — DCE'd under CLJS `:advanced` +
-;; `goog.DEBUG=false`). Before this helper that two-step was open-coded at ~12
-;; emit sites across `subs` / `subs.memo` / `cofx` / `router.diagnostics`
-;; (reaching `dispatch-on-error!` through the `:error-emit/dispatch-on-error`
-;; late-bind hook) plus 4 bespoke `router` wrappers (which static-require this
-;; ns and call `dispatch-on-error!` directly) and `fx`'s `emit-fx-error!`. The
-;; shape never varied — same positional record + the category-specific dev-trace
-;; `tags` map — so `emit-fx-error!` had already factored it locally (the proof
-;; the abstraction was wanted, just not shared). This is the ONE shared helper
-;; those sites collapse onto.
+;; `goog.DEBUG=false`). This is the ONE shared helper those sites use: the
+;; ~12 emit sites across `subs` / `subs.memo` / `cofx` / `router.diagnostics`
+;; (reaching it through the `:error-emit/emit-error-both` late-bind hook), the
+;; 4 `router` wrappers (which static-require this ns), and `fx`'s
+;; `emit-fx-error!` — all the same positional record + the category-specific
+;; dev-trace `tags` map.
 
 (defn emit-error-both!
   "Fan a runtime `:rf.error/*` `category` out through BOTH error channels in one
-  call (rf2-c4oycd): the always-on corpus-wide [[dispatch-on-error!]] listener
+  call: the always-on corpus-wide [[dispatch-on-error!]] listener
   registry (axis 1 — production-survivable; survives CLJS `:advanced` +
   `goog.DEBUG=false`, the off-box-shipper + SSR-error-projector source of truth)
   AND the dev-only `re-frame.trace/emit-error!` surface (axis 2 — DCE'd in CLJS
@@ -301,18 +291,18 @@
   [[dispatch-on-error!]] — `event` is elided by the wire-walker there, `time` is
   the emit instant in millis, `elapsed-ms` is `0` at the non-timed invalid-op
   sites and the measured duration at the router's timed pipeline/flow paths).
-  `trace-tags` is the category-specific dev-trace tag map — passed UNCHANGED to
-  `trace/emit-error!`, so dev-trace consumers see exactly the shape they did
-  before (the map is still built at the call site and threaded here).
+  `trace-tags` is the category-specific dev-trace tag map — built at the call
+  site and passed UNCHANGED to `trace/emit-error!`, so dev-trace consumers see
+  exactly that shape.
 
-  Per rf2-n4x74b the COMPONENT-ATTRIBUTED slots `:failing-id` / `:reason` are
+  The COMPONENT-ATTRIBUTED slots `:failing-id` / `:reason` are
   ALSO lifted out of `trace-tags` onto the always-on record (axis 1) — but ONLY
   when the `:failing-id` is present AND DISTINCT from `:event-id`. That is the
   case exactly for the categories whose failing component is not the dispatched
   event: a user interceptor (`:rf.error/interceptor-exception`) or a coeffect
   supplier (`:rf.error/coeffect-exception`), where `:event-id` carries the EVENT
-  id and the interceptor / cofx id rode only the DCE'd dev-trace tags. For
-  handler-exception and the sub-* categories the failing id already EQUALS
+  id and the interceptor / cofx id would otherwise ride only the DCE'd dev-trace
+  tags. For handler-exception and the sub-* categories the failing id already EQUALS
   `:event-id`, so nothing extra is stamped and the tight record is unchanged.
   The off-box shipper now learns WHICH interceptor / cofx failed in production.
 
@@ -322,7 +312,7 @@
   load cycle through `elision` → `frame`)."
   [category event event-id frame exception elapsed-ms time trace-tags]
   ;; Axis 1 — always-on corpus-wide listener (+ EP-0015 frame-owned sink).
-  ;; rf2-n4x74b: lift the component-attributed `:failing-id` / `:reason` from
+  ;; Lift the component-attributed `:failing-id` / `:reason` from
   ;; the trace-tags onto the always-on record when the failing component is
   ;; DISTINCT from the dispatched event (interceptor / cofx categories). The
   ;; distinct-from-event-id guard keeps the record tight for the categories
@@ -348,9 +338,9 @@
 ;; flow categories — failures of a DISPATCHED EVENT or a SUBSCRIBE.
 ;;
 ;; But not every always-on `:rf.error/*` is an event failure. The
-;; frame-teardown report (rf2-ini4wr) was the FIRST non-event always-on
-;; record — a destroy-time fact with a `:hook-failures` vector, no event, no
-;; `:event-id`. The EP-0008 SSR promotion (rf2-hhutya) adds six more:
+;; frame-teardown report is a non-event always-on record — a destroy-time
+;; fact with a `:hook-failures` vector, no event, no `:event-id`. The EP-0008
+;; SSR promotion adds six more:
 ;; render-time / writer-phase / head-resolution / projector-fallback /
 ;; hydration-parse failures, each carrying its OWN flat category keys
 ;; (`:exception` / `:phase` / `:reason` / `:projector-id` / …) and either a
@@ -359,8 +349,8 @@
 ;; precedent — a frameless always-on record IS supported).
 ;;
 ;; `dispatch-error-record!` is the GENERAL always-on emit these share: it
-;; takes a PRE-BUILT union record and fans it out unchanged. The union shape
-;; (settled jointly with the teardown report, NOT a second ad-hoc shape):
+;; takes a PRE-BUILT union record and fans it out unchanged. The one union
+;; shape every non-event always-on record uses:
 ;;
 ;;     {:error <kw>          ;; the :rf.error/* category (REQUIRED)
 ;;      :frame <id-or-nil>   ;; the owning frame, or nil (frameless)
@@ -410,18 +400,15 @@
   ;; exception / stack), NOT privacy-gated like the dev trace; the caller is
   ;; contracted to keep identifiers tight and carry no raw app-db slice.
   ((:fan-out registry) record)
-  ;; EP-0015 §9 / Spec 015 §Frame-owned observability sink policy
-  ;; (rf2-ntv9i9.1): the frame-owned `:observability :errors` sink route — the
+  ;; EP-0015 §9 / Spec 015 §Frame-owned observability sink policy:
+  ;; the frame-owned `:observability :errors` sink route — the
   ;; NORMAL production error-observation surface. Parallel to the corpus-wide
   ;; fan-out above, exactly as the event-centric `dispatch-on-error!` routes to
   ;; `route-error!`: a NON-EVENT union record carrying a resolvable `:frame`
   ;; ALSO routes to that frame's declared error sinks, PROJECTED under the
   ;; frame's classification + the sink's egress profile (the flat category
   ;; slots ride `:tags` → redacted; `:exception` drops under
-  ;; `:rf.egress/public-error`). Before this, the teardown report + the EP-0008
-  ;; SSR promotions reached ONLY the low-level listener registry and bypassed
-  ;; the frame-sink model — leaving the flagship teardown report invisible to
-  ;; the normal Datadog/Sentry sink story. Late-bound (the static
+  ;; `:rf.egress/public-error`). Late-bound (the static
   ;; `error-emit` → `observability` → `projection` → `elision` require would
   ;; re-enter this ns's own require graph); the hook is nil (no-op) until
   ;; `re-frame.observability` loads. Fail-closed + sibling-isolated inside
@@ -479,9 +466,7 @@
   (when (seq hook-failures)
     ;; The bounded report is itself a non-event union record — fan it out
     ;; through the shared general helper so the teardown report and the
-    ;; EP-0008 SSR promotions ride ONE fan-out path / ONE record shape, not
-    ;; two ad-hoc ones (rf2-hhutya / rf2-ini4wr — settle one union shape
-    ;; jointly).
+    ;; EP-0008 SSR promotions ride ONE fan-out path / ONE record shape.
     (dispatch-error-record!
       {:error          :rf.error/frame-teardown-failed
        :frame          frame-id
@@ -497,30 +482,28 @@
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
-;; `router.cljc` already statically `:require`s this namespace (per
-;; rf2-hqbeh; the substrate is a foundational always-on surface
-;; alongside the router itself), so a late-bind hook isn't strictly
-;; needed here. We publish one anyway for symmetry with rf2-rirbq's
+;; `router.cljc` statically `:require`s this namespace (the substrate is a
+;; foundational always-on surface alongside the router itself), so a late-bind
+;; hook isn't strictly needed here. We publish one anyway for symmetry with the
 ;; `:event-emit/dispatch-on-event` hook and to keep the substrate
 ;; addressable from other artefacts that may want to fire error
 ;; records without static-requiring this ns.
 
 (late-bind/set-fn! :error-emit/dispatch-on-error dispatch-on-error!)
 
-;; The shared two-channel fan-out (rf2-c4oycd). `fx` / `subs` / `subs.memo` /
+;; The shared two-channel fan-out. `fx` / `subs` / `subs.memo` /
 ;; `cofx` / `router.diagnostics` reach it through this hook — they cannot
-;; static-require this ns (the `error-emit` → `elision` → `frame` load cycle),
-;; exactly as they reached `dispatch-on-error!` through its hook before.
+;; static-require this ns (the `error-emit` → `elision` → `frame` load cycle).
 (late-bind/set-fn! :error-emit/emit-error-both emit-error-both!)
 
 ;; The frame-teardown report fires from `frame/destroy-frame!`'s finally-
 ;; shaped flush. `frame` MUST reach it via late-bind: a static
 ;; `re-frame.frame` → `re-frame.error-emit` require closes a load cycle
-;; (`error-emit` → `elision` → `frame`). Per EP-0008 / rf2-ini4wr.
+;; (`error-emit` → `elision` → `frame`). Per EP-0008.
 (late-bind/set-fn! :error-emit/dispatch-frame-teardown-report
                    dispatch-frame-teardown-report!)
 
-;; The general non-event always-on record helper (rf2-hhutya). The EP-0008
+;; The general non-event always-on record helper. The EP-0008
 ;; SSR error-emit promotions (`:rf.error/ssr-render-failed`,
 ;; `:rf.error/ssr-streaming-writer-failed`, `:rf.error/malformed-hydration-
 ;; payload` — incl. the pre-frame FRAMELESS parse path, `:rf.error/ssr-head-
@@ -534,13 +517,12 @@
 ;; published through late-bind so `frame.cljc` can install a TRANSIENT
 ;; always-on error listener around the `:on-destroy` dispatch without a
 ;; static require (the same `error-emit` → `elision` → `frame` load cycle).
-;; This is the production-survivable replacement for the dev-only
-;; `:trace.tooling/register-listener!` capture the common `:on-destroy`-throw
-;; path used before EP-0008 / rf2-87f7fb: the router fans the handler throw
-;; out as `:rf.error/handler-exception` on THIS always-on axis, so a
-;; transient listener here observes it under `goog.DEBUG=false` where the
-;; dev trace is DCE'd. Survives `:advanced` + `goog.DEBUG=false` — these are
-;; the same surfaces `rf/register-error-listener!` exports, just addressable
-;; from a non-requiring artefact.
+;; This is the production-survivable capture for the common `:on-destroy`-throw
+;; path: the router fans the handler throw out as
+;; `:rf.error/handler-exception` on THIS always-on axis, so a transient
+;; listener here observes it under `goog.DEBUG=false` where the dev trace is
+;; DCE'd. Survives `:advanced` + `goog.DEBUG=false` — these are the same
+;; surfaces `rf/register-error-listener!` exports, just addressable from a
+;; non-requiring artefact.
 (late-bind/set-fn! :error-emit/register-error-listener!   register-error-listener!)
 (late-bind/set-fn! :error-emit/unregister-error-listener! unregister-error-listener!)

--- a/implementation/core/src/re_frame/event_emit.cljc
+++ b/implementation/core/src/re_frame/event_emit.cljc
@@ -38,9 +38,9 @@
   drops the record entirely — framework-internal bookkeeping handlers
   (Xray, Story) are not user-domain observable signal.
 
-  NOTE: handler-meta `:sensitive?` is no longer consulted here.
-  Sensitive data marking is path-based per the upcoming data-
-  classification mechanism (separate spec doc; in progress)."
+  Sensitive data marking is path-based per the data-classification
+  mechanism (separate spec doc); handler-meta `:sensitive?` is not
+  consulted here."
   (:require [re-frame.elision       :as elision]
             [re-frame.emit-substrate :as emit]
             [re-frame.late-bind     :as late-bind]
@@ -63,8 +63,7 @@
 (def register-event-listener!
   "Register a listener `f` under `id`. Re-registering the same id
   replaces. `f` receives a single event-record map (see ns docstring
-  §Record shape); its return value is ignored. Returns `id`. Per
-  rf2-rirbq."
+  §Record shape); its return value is ignored. Returns `id`."
   (:register registry))
 
 (def unregister-event-listener!
@@ -85,7 +84,7 @@
 
   Short-circuits to a no-op when the registry is empty (one deref +
   empty-map check). Otherwise looks up the event's handler-meta and
-  drops the record when `:rf.trace/no-emit?` (rf2-qsjda) is set.
+  drops the record when `:rf.trace/no-emit?` is set.
   Surviving records run through `re-frame.elision/elide-wire-value`
   ONCE with off-box defaults (large → `:rf.size/large-elided`;
   sensitive paths → `:rf/redacted`), then fan out through the emit-
@@ -114,7 +113,6 @@
 ;;
 ;; `router.cljc` invokes `dispatch-on-event!` once per processed event.
 ;; The router looks the fn up through the late-bind hook table at call
-;; time rather than `:require`ing this namespace directly. Per
-;; rf2-rirbq.
+;; time rather than `:require`ing this namespace directly.
 
 (late-bind/set-fn! :event-emit/dispatch-on-event dispatch-on-event!)

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -3,13 +3,12 @@
   §Registry model.
 
   The ONE public event form is `reg-event` — pure (cofx, event) → a closed
-  effects map (EP-0018, ruled 2026-06-14; final removal flip rf2-xhfxcs.14).
-  Coeffects in, a closed effects map out.
+  effects map (EP-0018). Coeffects in, a closed effects map out.
 
-  EP-0018 collapsed the historical three-form family to one. `reg-event-db` /
+  `reg-event` is the single event-registration form. `reg-event-db` /
   `reg-event-fx` are REMOVED and public `reg-event-ctx` is demoted to a
   framework-internal `context -> context` primitive; calling any of the
-  retired public names is a hard error naming the replacement (the
+  removed public names is a hard error naming the replacement (the
   facade-exported throwing stubs `re-frame.events/reg-event-db` /
   `reg-event-fx` / `reg-event-ctx` raise
   `:rf.error/reg-event-db-removed` / `-fx-removed` / `-ctx-removed`, per
@@ -17,29 +16,26 @@
   is expressed with interceptors authored via the public `reg-interceptor`
   form and referenced by id from a `reg-event` registration's
   `:interceptors` chain (`->interceptor` is the internal lowering
-  constructor post-EP-0022, not the application authoring form).
+  constructor, not the application authoring form).
 
   All event registrations register under registry kind `:event` and share the
   ONE handler-wrapping interceptor `:rf/event-handler` (`:rf/default? true`);
-  the historical `:event/kind` sub-tag and the per-kind `:rf/db-handler` /
-  `:rf/fx-handler` / `:rf/ctx-handler` ids are gone (EP-0018 §5). The runtime
+  there is no `:event/kind` sub-tag and no per-kind `:rf/db-handler` /
+  `:rf/fx-handler` / `:rf/ctx-handler` ids (EP-0018 §5). The runtime
   treats every event uniformly during drain.
 
   Per Spec 015 §1. Event handlers — the registration meta-map accepts
   optional `:sensitive [paths]` and `:large [paths]` keys that index
   into the dispatched event vector's arg-map (the second element).
   The marks are DERIVED from the registrar meta at `re-frame.marks/marks-for`
-  read time (rf2-ehexnw); reg-event only VALIDATES them fail-loud via
+  read time; reg-event only VALIDATES them fail-loud via
   `re-frame.marks/validate-marks!` — an ALWAYS-ON registration-time validator
-  reached by DIRECT REQUIRE (rf2-58bq1r). `re-frame.marks` is core-owned, lives
-  in the SAME artefact as events/fx/subs, and is already pinned into every
+  reached by DIRECT REQUIRE. `re-frame.marks` is core-owned, lives
+  in the SAME artefact as events/fx/subs, and is pinned into every
   production bundle (it is side-effect-required by `re-frame.core`); the
-  validator fail-louds in prod as well as dev. The former `:marks/validate-marks!`
-  late-bind hop bought nothing for THIS key — it was not a DCE seam (marks is in
-  the bundle regardless), not optional-artefact decoupling (marks is never
-  absent), and the require is cycle-free (marks' transitive closure touches none
-  of events/fx/cofx/subs). The dev-gated marks PROJECTION hooks stay late-bound
-  (eq7m0x). No imperative stash."
+  validator fail-louds in prod as well as dev. The direct require is
+  cycle-free (marks' transitive closure touches none of events/fx/cofx/subs).
+  The dev-gated marks PROJECTION hooks stay late-bound. No imperative stash."
   (:require [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
@@ -53,19 +49,15 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- metadata-map `:interceptors` — the superset middle slot (rf2-bpmszk) -
+;; ---- metadata-map `:interceptors` — the superset middle slot -------------
 ;;
 ;; The `reg-event` metadata-map carries a RESERVED `:interceptors` key,
 ;; making the map the ONE superset middle-slot shape:
 ;; `{:doc … :schema … :sensitive … :interceptors [i1 i2]}`.
-;; The historical positional interceptor VECTOR form (`[i1 i2]`) is retired:
-;; put the chain under `:interceptors` in the metadata map.
+;; The interceptor chain goes under `:interceptors` in the metadata map.
 ;;
-;; This SUPERSEDES the former rf2-bbea warning
-;; (`:rf.warning/interceptors-in-metadata-map`): `:interceptors` inside the
-;; metadata-map is now the documented home, not a typo. The Circle-Drawer
-;; footgun rf2-w3vn flagged (a silently-dropped chain) is structurally gone —
-;; the chain is now honoured, not dropped.
+;; `:interceptors` inside the metadata-map is the documented home for the
+;; chain, and the chain is honoured.
 ;;
 ;; The malformed-value guard below keeps the superset honest: a non-vector
 ;; `:interceptors` value, or a vector carrying a non-map (non-interceptor)
@@ -75,10 +67,10 @@
 
 (defn- interceptor-entry?
   "True when `x` is a valid `:interceptors` chain entry. REFERENCE-ONLY under
-  EP-0022 (the flip, rf2-0adhqs.9): an entry MUST be an interceptor REFERENCE —
+  EP-0022: an entry MUST be an interceptor REFERENCE —
   a bare keyword id or an `[id arg]` 2-vector. Refs resolve to their registered
   values at chain assembly. An INLINE interceptor value (a map carrying `:id` /
-  `:before` / `:after`, an `->interceptor` result, a value-Var) is no longer a
+  `:before` / `:after`, an `->interceptor` result, a value-Var) is not a
   valid entry — register it with `reg-interceptor` and reference it by id. A
   non-ref entry is rejected at registration by `validate-meta-interceptors!`
   (an inline value gets the `:rf.error/inline-interceptor-removed`-aimed
@@ -106,14 +98,13 @@
 (defn- throw-inline-interceptor-removed!
   "Raise `:rf.error/inline-interceptor-removed` (ex-info) at registration when a
   metadata-map `:interceptors` chain carries an INLINE interceptor value. Per
-  EP-0022 §Event and frame chain grammar (the reference-only flip,
-  rf2-0adhqs.9): chains carry REFERENCES only. The earliest, clearest fail
-  point for a stale inline value (an `->interceptor` result, a `(path …)` /
-  `(redact-interceptor …)` value, a value-Var) — a typo dies at `reg-event`,
-  not at first dispatch. Mirrors the dispatch-time
+  EP-0022 §Event and frame chain grammar: chains carry REFERENCES only. The
+  earliest, clearest fail point for a stale inline value (an `->interceptor`
+  result, a `(path …)` / `(redact-interceptor …)` value, a value-Var) — a typo
+  dies at `reg-event`, not at first dispatch. Mirrors the dispatch-time
   `interceptor-registry/resolve-chain` rejection with the same error id —
   both delegate to the ONE shared `error/throw-inline-interceptor-removed!`
-  (rf2-8au0w6) passing this site's `:where 'rf/reg-event`, reason, and ex-data."
+  passing this site's `:where 'rf/reg-event`, reason, and ex-data."
   [reg-fn-name id value offending]
   (error/throw-inline-interceptor-removed!
     'rf/reg-event
@@ -135,12 +126,12 @@
   keyword id or an `[id arg]` 2-vector — per `interceptor-entry?`). A no-op
   (returns `value`) for a well-shaped vector.
 
-  Reference-only since EP-0022 (the flip, rf2-0adhqs.9):
+  Reference-only (EP-0022):
     - a non-vector value raises `:rf.error/reg-event-bad-interceptors`;
     - an INLINE interceptor value entry (a map carrying `:before` / `:after` /
       `:id`, an `->interceptor` result, a value-Var) raises the dedicated
       `:rf.error/inline-interceptor-removed` — the loud, actionable signal that
-      chains are now reference-only (vs. the generic bad-interceptors message);
+      chains are reference-only (vs. the generic bad-interceptors message);
     - any OTHER non-ref entry (a string, number, …) raises the generic
       `:rf.error/reg-event-bad-interceptors`."
   [reg-fn-name id value]
@@ -153,8 +144,8 @@
            "references (e.g. `{:interceptors [:auth/required [:rf.interceptor/path [:cart]]]}`)."))
 
     (not (every? interceptor-entry? value))
-    ;; Discriminate a stale INLINE value (the EP-0022 reference-only flip's
-    ;; headline footgun) from any other malformed entry, so the developer gets
+    ;; Discriminate a stale INLINE value (the headline reference-only
+    ;; footgun) from any other malformed entry, so the developer gets
     ;; the actionable "register + reference by id" message rather than a generic
     ;; bad-interceptors tell.
     (if-let [inline (some (fn [e]
@@ -178,7 +169,7 @@
   interceptor. A reference to an absent id throws
   `:rf.error/unregistered-interceptor` at registration so typos die before
   dispatch. Only refs are checked here; the appended framework handler-wrapper
-  (the one inline value a chain carries since the reference-only flip) is
+  (the one inline value a chain carries) is
   skipped — any other inline value has already been rejected by
   `validate-meta-interceptors!`. Resolution is deferred to chain assembly (the
   router) so hot-reloaded descriptors are picked up on the next dispatch."
@@ -192,14 +183,13 @@
       (icpt-reg/resolve-ref entry)))
   chain)
 
-;; ---- validate-at-boundary-interceptor registration-time validation (rf2-iftj4) -----------------
+;; ---- validate-at-boundary-interceptor registration-time validation -------
 ;;
 ;; The `:rf.schema/at-boundary` interceptor (per Spec 010 §Production builds)
-;; is structurally meaningless without a `:schema` to validate against. Per
-;; rf2-ycqtv finding #8 (Mike-pick option (b)), the registrar hard-rejects
-;; any handler that attaches the interceptor without `:schema` metadata,
-;; throwing `:rf.error/at-boundary-missing-schema` at reg time so the
-;; developer learns immediately, regardless of dev/prod gate.
+;; is structurally meaningless without a `:schema` to validate against. The
+;; registrar hard-rejects any handler that attaches the interceptor without
+;; `:schema` metadata, throwing `:rf.error/at-boundary-missing-schema` at reg
+;; time so the developer learns immediately, regardless of dev/prod gate.
 ;;
 ;; Detection is by interceptor `:id` (`:rf.schema/at-boundary`), not by var
 ;; equality — keeps `events` decoupled from `re-frame.spec` (which depends
@@ -208,22 +198,21 @@
 (defn- at-boundary-entry?
   "Truthy when a single RAW chain entry attaches the `:rf.schema/at-boundary`
   interceptor by REFERENCE — the bare keyword `:rf.schema/at-boundary` (the
-  only legal chain form since the EP-0022 reference-only flip, rf2-0adhqs.9;
-  the chain stores refs UNRESOLVED, so the bare keyword reaches here).
+  only legal chain form, EP-0022; the chain stores refs UNRESOLVED, so the
+  bare keyword reaches here).
 
   The `[:rf.schema/at-boundary arg]` 2-vector form is NOT detected here: it is
   unreachable for this missing-schema check. `:rf.schema/at-boundary` is a
   STATIC interceptor (no `:factory`), so an `[:rf.schema/at-boundary arg]`
   chain ref is rejected at `validate-refs-registered!` with
   `:rf.error/interceptor-factory-arity` BEFORE
-  `reject-at-boundary-without-schema!` (which calls this predicate) ever runs
-  (rf2-48ypb6.1, rf2-wjr8ow). The `[id arg]` shape is therefore simply an
-  unregistered-factory-shape misuse and fails loud on its own.
+  `reject-at-boundary-without-schema!` (which calls this predicate) ever runs.
+  The `[id arg]` shape is therefore simply an unregistered-factory-shape
+  misuse and fails loud on its own.
 
-  The former INLINE-VALUE migration form — the `validate-at-boundary-interceptor`
-  Var dropped directly into the chain — is no longer accepted (chains are
-  reference-only; `validate-meta-interceptors!` rejects it
-  `:rf.error/inline-interceptor-removed` before this runs). Detects by id
+  Chains are reference-only, so an inline `:rf.schema/at-boundary` value is
+  rejected by `validate-meta-interceptors!` with
+  `:rf.error/inline-interceptor-removed` before this runs. Detects by id
   keyword so the check stays cycle-free against `re-frame.spec`."
   [icpt]
   ;; By-ref: bare keyword.
@@ -232,7 +221,7 @@
 (defn- attaches-validate-at-boundary-interceptor?
   "Truthy when the effective user interceptor chain attaches the
   `:rf.schema/at-boundary` interceptor by REF (`[:rf.schema/at-boundary]`, the
-  only legal chain form since the EP-0022 reference-only flip). See
+  only legal chain form, EP-0022). See
   `at-boundary-entry?`. Detects by id so the check stays cycle-free against
   `re-frame.spec`."
   [interceptors]
@@ -243,7 +232,7 @@
   "Raise `:rf.error/at-boundary-missing-schema` (ex-info) when the
   metadata-map `:interceptors` chain includes `:rf.schema/at-boundary`
   but the metadata-map carries no `:schema`. Per Spec 010 §Production
-  builds + rf2-iftj4: the boundary interceptor is structurally
+  builds: the boundary interceptor is structurally
   meaningless without a `:schema`, so the registrar rejects the call
   at registration time rather than waiting until first dispatch.
 
@@ -278,12 +267,11 @@
 ;; (:dispatch, :dispatch-later, :dispatch-n, :http, etc.) must move into :fx
 ;; as [[fx-id args] ...] entries.
 ;;
-;; EP-0001 (rf2-bvwoi4): the partition split widened the closed set from
-;; #{:db :fx} to #{:db :rf.db/runtime :fx} (per Spec-Schemas §:rf/effect-map +
-;; Spec 002 §Write authority). `:db` is the app-db partition (still targets
-;; app-db); `:rf.db/runtime` is the runtime-db partition — the one new
-;; state-bearing top-level key, reserved BY CONVENTION for framework-authority
-;; writers (NOT a security boundary). `:rf.db/runtime` is NOT a shape error
+;; EP-0001: the closed set is #{:db :rf.db/runtime :fx} (per Spec-Schemas
+;; §:rf/effect-map + Spec 002 §Write authority). `:db` is the app-db partition;
+;; `:rf.db/runtime` is the runtime-db partition — a state-bearing top-level
+;; key, reserved BY CONVENTION for framework-authority writers (NOT a security
+;; boundary). `:rf.db/runtime` is NOT a shape error
 ;; here — a non-framework handler emitting it is surfaced by the
 ;; `:rf.warning/app-handler-runtime-effect` dev diagnostic (in
 ;; `commit-fx-effects`), not dropped. All OTHER unknown top-level keys remain
@@ -298,7 +286,7 @@
   "The closed set of top-level effect-map keys a `reg-event` handler may
   return. Per Spec-Schemas §:rf/effect-map — `:db` (app-db partition),
   `:rf.db/runtime` (runtime-db partition, framework-authority by convention,
-  EP-0001 rf2-bvwoi4), and `:fx` (everything else). Widening this set is a
+  EP-0001), and `:fx` (everything else). Widening this set is a
   Spec change; any other top-level key is a shape error."
   #{:db :rf.db/runtime :fx})
 
@@ -308,7 +296,7 @@
   effect-map is closed at the top level (`#{:db :rf.db/runtime :fx}`).
   Returns the list of offending keys (which the caller drops).
 
-  Hot-path short-circuit (rf2-4ymm0 EV4): the well-shaped case is the
+  Hot-path short-circuit: the well-shaped case is the
   overwhelming majority — handlers return `{}`, `{:db ...}`, `{:fx ...}`,
   or `{:db ... :fx ...}`. Allocating an `offending` vector per dispatch
   for the every-key-walks-the-closed-set check is wasted work. Pre-check
@@ -335,20 +323,19 @@
                               :recovery          :logged-and-skipped})))
       offending)))
 
-;; ---- :fx VALUE-shape policing (rf2-24zly) ---------------------------------
+;; ---- :fx VALUE-shape policing --------------------------------------------
 ;;
-;; `police-effect-map-shape!` above polices the top-level KEYS only. The
-;; one shape it does NOT check is the :fx VALUE: per Spec-Schemas §:rf/effect-map
-;; the :fx value is `[:vector [:tuple :keyword :any]]` — a sequential of
-;; [fx-id args] pairs. A handler that returns a non-sequential :fx value
-;; (e.g. `{:fx :oops}` or `{:fx {:dispatch [...]}}` — a plausible
-;; forgot-the-outer-vector typo) used to escape policing entirely: the value
-;; was assoc'd straight into the effects map, and `fx/do-fx`'s
-;; `(doseq [pair fx-vec] ...)` then threw an uncaught host exception
-;; ("Don't know how to create ISeq from: …"). Because :fx runs AFTER the :db
-;; commit, that throw escaped `process-event!` into the drain's emergency
-;; release: app-db left mutated, no structured trace, no `:on-error` fire,
-;; downstream queued events abandoned.
+;; `police-effect-map-shape!` above polices the top-level KEYS only. This
+;; checks the one shape it does NOT: the :fx VALUE. Per Spec-Schemas
+;; §:rf/effect-map the :fx value is `[:vector [:tuple :keyword :any]]` — a
+;; sequential of [fx-id args] pairs. A handler that returns a non-sequential
+;; :fx value (e.g. `{:fx :oops}` or `{:fx {:dispatch [...]}}` — a plausible
+;; forgot-the-outer-vector typo) is caught here. Without this check the value
+;; would be assoc'd straight into the effects map, and `fx/do-fx`'s
+;; `(doseq [pair fx-vec] ...)` would throw an uncaught host exception
+;; ("Don't know how to create ISeq from: …") AFTER the :db commit — escaping
+;; `process-event!` into the drain's emergency release with app-db mutated, no
+;; structured trace, no `:on-error` fire, downstream queued events abandoned.
 ;;
 ;; We close the gap symmetric with M-8: a non-sequential (and non-nil) :fx
 ;; value emits :rf.error/effect-map-shape (recovery :logged-and-skipped) and
@@ -383,7 +370,7 @@
                             :recovery          :logged-and-skipped})
         false))))
 
-;; ---- final-effects boundary policing (rf2-u1kdvg) -------------------------
+;; ---- final-effects boundary policing -------------------------------------
 ;;
 ;; `commit-fx-effects` (below) polices the effect-map shape + the whole-`:fx`
 ;; value for a `reg-event` HANDLER RETURN — at the moment the handler-wrapping
@@ -419,7 +406,7 @@
 
   This is the boundary gate covering effects that bypass the
   `commit-fx-effects` per-handler-return checks — an `:after`-interceptor
-  mutation (rf2-u1kdvg). `nil` / a non-map effects value (no effects
+  mutation. `nil` / a non-map effects value (no effects
   produced) passes through untouched.
 
   Hot-path short-circuit: when the effects map is already well-shaped (the
@@ -438,10 +425,9 @@
 
 ;; ---- handler-as-interceptor wrapper ---------------------------------------
 ;;
-;; EP-0018 (rf2-xhfxcs.14): the historical db/fx/ctx triple collapsed to ONE
-;; event form, so the handler-wrapping interceptor is ONE shape too. Its
-;; `:before`:
-;;   1. honours :rf/skip-handler? (Spec 010 §Validation order, rf2-7leq/jwm4),
+;; EP-0018: there is ONE event form, so the handler-wrapping interceptor is
+;; ONE shape too. Its `:before`:
+;;   1. honours :rf/skip-handler? (Spec 010 §Validation order),
 ;;   2. invokes the user handler with the coeffects map + the event vector
 ;;      (`(fn [coeffects event] effect-map)`),
 ;;   3. projects the returned closed effects map into the context via
@@ -449,15 +435,15 @@
 ;;      policing).
 ;; The interceptor stamps the single id `:rf/event-handler` and carries
 ;; `:rf/default? true` so tools filter the framework auto-wrapper without an
-;; id allowlist. (The former per-kind `:rf/db-handler` / `:rf/fx-handler` /
-;; `:rf/ctx-handler` ids + the `:event/kind` sub-tag are gone.)
+;; id allowlist. There are no per-kind handler ids and no `:event/kind`
+;; sub-tag.
 
 (defn- police-runtime-effect-authority!
-  "EP-0001 (rf2-bvwoi4): when `effects` carries a `:rf.db/runtime` effect AND
+  "EP-0001: when `effects` carries a `:rf.db/runtime` effect AND
   the running handler does NOT have framework-write authority, emit the
   `:rf.warning/app-handler-runtime-effect` dev diagnostic. `:rf.db/runtime`
-  is reserved BY CONVENTION for framework / runtime-extension code (Mike
-  ruling #4) — NOT a security boundary: the effect is STILL applied (recovery
+  is reserved BY CONVENTION for framework / runtime-extension code — NOT a
+  security boundary: the effect is STILL applied (recovery
   `:warned`); the diagnostic names the runtime-db ownership rule rather than
   enforcing a capability or silently dropping the effect.
 
@@ -489,35 +475,31 @@
                          "code should reach subsystem state through public framework "
                          "subscriptions and effects, and write application data via `:db`.")}))))
 
-;; ---- legacy :rf/runtime root — HARD ERROR (EP-0001 rf2-tfepxu) -------------
+;; ---- legacy :rf/runtime root — HARD ERROR (EP-0001) -----------------------
 ;;
 ;; Per Conventions §The legacy `:rf/runtime` root — hard error in final form
-;; (decision #8) + 009 §Error event catalogue: the former single reserved
-;; app-db root `:rf/runtime` is RETIRED. Framework durable state now lives in
-;; the runtime-db partition (`:rf.db/runtime`), addressed by `:rf.runtime/*`
-;; children. A stray `:rf/runtime` root surviving at the TOP of app-db —
-;; whether written by user code or carried over from v1-shaped code — is a
-;; HARD ERROR (`:rf.error/legacy-runtime-root`) in the final form (pre-alpha:
-;; no long-lived migration alias; the temporary migration WARNING is removed
-;; now that all in-repo consumers are on runtime-db).
+;; + 009 §Error event catalogue: the `:rf/runtime` app-db root key is reserved
+;; and rejected. Framework durable state lives in the runtime-db partition
+;; (`:rf.db/runtime`), addressed by `:rf.runtime/*` children. A stray
+;; `:rf/runtime` root at the TOP of app-db is a HARD ERROR
+;; (`:rf.error/legacy-runtime-root`); there is no migration alias.
 ;;
-;; This supersedes the retired `:rf.warning/runtime-state-dropped` containment
-;; diagnostic: under the two-partition contract an ordinary `:db` return
-;; replaces ONLY app-db and CANNOT touch runtime-db (the clobber footgun is
-;; structurally gone), so the only remaining way `:rf/runtime` reaches app-db
-;; is a handler that EXPLICITLY writes it — which this guard rejects loudly.
+;; Under the two-partition contract an ordinary `:db` return replaces ONLY
+;; app-db and CANNOT touch runtime-db (the clobber footgun is structurally
+;; absent), so the only way `:rf/runtime` reaches app-db is a handler that
+;; EXPLICITLY writes it — which this guard rejects loudly.
 
 (def ^:private legacy-runtime-root-key
-  "The retired app-db root key. Framework durable state moved to the
-  runtime-db partition; a stray `:rf/runtime` at the top of app-db is the
-  legacy-shaped write this guard rejects."
+  "The reserved app-db root key this guard rejects. Framework durable state
+  lives in the runtime-db partition; a stray `:rf/runtime` at the top of
+  app-db is the legacy-shaped write this guard rejects."
   :rf/runtime)
 
 (defn legacy-runtime-root?
-  "True iff `app-db` carries the retired `:rf/runtime` root key at its top
-  level (per Conventions §The legacy `:rf/runtime` root + decision #8). The
+  "True iff `app-db` carries the reserved `:rf/runtime` root key at its top
+  level (per Conventions §The legacy `:rf/runtime` root). The
   pure detector both `reject-legacy-runtime-root!` (the in-chain throw) and
-  the router's final-effects boundary (rf2-u1kdvg, the in-band abort) share
+  the router's final-effects boundary (the in-band abort) share
   so the rejection rule has a single definition. Cheap on the hot path — a
   single `contains?` over the top-level keys."
   [app-db]
@@ -527,7 +509,7 @@
   "The shared `:rf.error/legacy-runtime-root` ex-data / error-trace tag map
   for the offending `event`. Used both by `reject-legacy-runtime-root!`
   (carried on the thrown ex-info) and by the router's final-effects
-  boundary emit (rf2-u1kdvg) so the two rejection sites surface an identical
+  boundary emit so the two rejection sites surface an identical
   payload."
   [event]
   (let [event-id (when (vector? event) (first event))]
@@ -548,11 +530,11 @@
 
 (defn reject-legacy-runtime-root!
   "Throw `:rf.error/legacy-runtime-root` (ex-info) when `app-db` carries the
-  retired `:rf/runtime` root key at its top level. Per Conventions §The
-  legacy `:rf/runtime` root + decision #8: a HARD ERROR in the final form —
-  framework runtime state lives in the runtime-db partition now, never under
-  an app-db `:rf/runtime` root. A no-op (returns `app-db`) for any value that
-  does not carry the legacy key, so it is cheap on the hot path.
+  reserved `:rf/runtime` root key at its top level. Per Conventions §The
+  legacy `:rf/runtime` root: a HARD ERROR — framework runtime state lives in
+  the runtime-db partition, never under an app-db `:rf/runtime` root. A no-op
+  (returns `app-db`) for any value that does not carry the key, so it is cheap
+  on the hot path.
 
   Always-on (NOT dev-gated): a legacy-shaped write is a structural contract
   violation that must surface in every build, not a dev-only advisory.
@@ -561,7 +543,7 @@
   `:before`, so a handler-RETURN legacy root is captured by the interceptor
   machinery and surfaced as `:rf.error/handler-exception`). The symmetric
   FINAL-effects boundary check — covering a legacy root inserted by an
-  `:after` interceptor AFTER this ran — lives in the router (rf2-u1kdvg) and
+  `:after` interceptor AFTER this ran — lives in the router and
   emits in-band rather than throwing, so the drain is not aborted."
   [app-db event]
   (when (legacy-runtime-root? app-db)
@@ -571,25 +553,24 @@
 (defn- commit-fx-effects
   "fx-kind commit: enforce the closed effect-map (M-8 + EP-0001) and assoc
   :db / :rf.db/runtime / :fx into the context. Bad-return / nil-return policy
-  lives here too — `nil` is the documented legal no-op (rf2-k3bj); any
+  lives here too — `nil` is the documented legal no-op; any
   non-map return emits :rf.error/effect-handler-bad-return with :no-recovery
   and the dispatch becomes a no-op.
 
   Two shape checks run before commit: `police-effect-map-shape!` rejects
   top-level keys outside `#{:db :rf.db/runtime :fx}` (M-8 + EP-0001), and
-  `fx-value-ok?` rejects a non-sequential `:fx` value (rf2-24zly) — both emit
+  `fx-value-ok?` rejects a non-sequential `:fx` value — both emit
   :rf.error/effect-map-shape (:logged-and-skipped) and DROP the offending
   slot, so a malformed effect map never reaches `fx/do-fx` to throw a raw
   host exception after the :db commit.
 
-  EP-0001 (rf2-bvwoi4): `:db` targets the app-db partition; `:rf.db/runtime`
+  EP-0001: `:db` targets the app-db partition; `:rf.db/runtime`
   targets the runtime-db partition (reserved by convention — a non-framework
   handler emitting it fires `:rf.warning/app-handler-runtime-effect` via
   `police-runtime-effect-authority!`, but the effect is still committed). The
-  `:rf.db/runtime` effect is assoc'd into the context here; the actual
-  PARTITIONED commit (scoping `:db` to app-db, installing the runtime-db /
-  full-frame write as one atomic frame-state transition) lands in rf2-adwcv6
-  (bead 5)."
+  `:rf.db/runtime` effect is assoc'd into the context here; the partitioned
+  commit (scoping `:db` to app-db, installing the runtime-db / full-frame
+  write as one atomic frame-state transition) happens downstream."
   [ctx event effects]
   (cond
     (nil? effects) ctx                       ;; documented legal no-op
@@ -608,9 +589,9 @@
       (police-runtime-effect-authority! ctx event effects)
       (cond-> ctx
         (contains? effects :db) (interceptor/assoc-effect :db (:db effects))
-        ;; runtime-db partition effect (EP-0001 rf2-bvwoi4). Carried through the
-        ;; context here; the partitioned/atomic commit path lands in rf2-adwcv6
-        ;; (bead 5). Reserved-by-convention — the authority diagnostic above has
+        ;; runtime-db partition effect (EP-0001). Carried through the
+        ;; context here; the partitioned/atomic commit path runs downstream.
+        ;; Reserved-by-convention — the authority diagnostic above has
         ;; already fired for a non-framework writer; the effect is applied either way.
         (contains? effects :rf.db/runtime) (interceptor/assoc-effect :rf.db/runtime (:rf.db/runtime effects))
         (and (contains? effects :fx)
@@ -618,16 +599,15 @@
 
 (def event-handler-interceptor-id
   "The single `:id` the framework stamps on the handler-wrapping interceptor
-  (the terminal `:before` that invokes the user event handler). One id since
-  EP-0018 collapsed the db/fx/ctx triple to one form — a captured
-  `:rf/interceptor-error` whose `:id` is this is the EVENT HANDLER itself
-  throwing (vs. a user interceptor). A stable framework-owned contract."
+  (the terminal `:before` that invokes the user event handler). There is ONE
+  such id (EP-0018) — a captured `:rf/interceptor-error` whose `:id` is this
+  is the EVENT HANDLER itself throwing (vs. a user interceptor). A stable
+  framework-owned contract."
   :rf/event-handler)
 
 (defn- wrap-event-handler
   "Wrap `handler-fn` into the ONE event-handler interceptor whose :before
-  runs the handler (EP-0018 — the historical per-kind db/fx/ctx wrappers
-  collapsed to this single shape).
+  runs the handler (EP-0018 — one wrapper shape for every event).
 
   The :before:
     (a) honours :rf/skip-handler? (Spec 010 steps 1-2 recovery — schema
@@ -638,7 +618,7 @@
     (d) commits the returned closed effects map via `commit-fx-effects`.
 
   The interceptor stamps `:rf/event-handler` and carries `:rf/default? true`
-  (rf2-twt7m Change 3) so tools (Xray, Story, the Event lens) can filter the
+  so tools (Xray, Story, the Event lens) can filter the
   framework's auto-wrapper without a hardcoded id allowlist. Self-describing:
   the meta lives on the interceptor map itself."
   [handler-fn]
@@ -652,7 +632,7 @@
         (let [event   (interceptor/get-coeffect ctx :event)
               new-ctx (commit-fx-effects ctx event
                                          (handler-fn (interceptor/get-coeffect ctx) event))]
-          ;; EP-0001 (rf2-tfepxu, decision #8): a `:db` effect carrying the
+          ;; EP-0001: a `:db` effect carrying the
           ;; retired `:rf/runtime` app-db root is a HARD ERROR — reject it at
           ;; the single post-commit chokepoint. No-op (cheap) when the legacy
           ;; key is absent.
@@ -666,7 +646,7 @@
   `:interceptors` vector carrying the `:rf/event-handler` wrapping
   interceptor at its tail.
 
-  Per rf2-a2sn1 — the single source of truth for the handler-meta shape,
+  The single source of truth for the handler-meta shape,
   shared by `register-event!` (the registration path) AND the machines
   lazy-actor-handler resolver (which materialises a spawned actor's
   handler-meta on demand from its app-db snapshot rather than from a
@@ -689,7 +669,7 @@
   handler may legitimately return a `:rf.db/runtime` effect without
   tripping the `:rf.warning/app-handler-runtime-effect` dev diagnostic.
 
-  EP-0001 (rf2-3939ig) — the GENERAL minting mechanism. A registration
+  EP-0001 — the GENERAL minting mechanism. A registration
   site mints authority by stamping the reserved `:rf/framework-authority?
   true` registration-meta key (see Conventions §Reserved registration
   meta). Spec 002 §Write authority names machines, routing, elision, and
@@ -705,7 +685,7 @@
   predicate folds the implication in, keeping the machine contract
   unchanged.
 
-  Reserved BY CONVENTION (Mike ruling #4), not a capability gate: the
+  Reserved BY CONVENTION, not a capability gate: the
   effect is applied either way; the flag only governs the dev diagnostic."
   [meta]
   (boolean (or (:rf/framework-authority? meta)
@@ -716,10 +696,9 @@
 ;; `:rf.cofx/requires` is a standard registration-metadata key (Spec 001 middle
 ;; slot) on `reg-event` declaring the handler's consumed coeffect ids. The
 ;; runtime delivers EXACTLY the declared facts, flat, into the handler's
-;; coeffects map (declared-only delivery — Spec 002 §Satisfaction). Since
-;; EP-0018 collapsed to the one coeffects-in form, `:rf.cofx/requires` is
-;; uniformly available to every event (the EP-0017 hole — a db handler that
-;; structurally could not take delivery — is closed). The parsing / shape
+;; coeffects map (declared-only delivery — Spec 002 §Satisfaction). Every
+;; event takes the one coeffects-in form, so `:rf.cofx/requires` is uniformly
+;; available to every event. The parsing / shape
 ;; validation / duplicate-id check lives in `re-frame.cofx/parse-requires`; the
 ;; parsed entries are stored on the registration under
 ;; `:rf.cofx/requires-parsed` for the satisfaction step
@@ -729,20 +708,18 @@
 
 ;; ---- registration ---------------------------------------------------------
 
-;; ---- bare-interceptor detection (rf2-3ut12) -------------------------------
+;; ---- bare-interceptor detection ------------------------------------------
 ;;
 ;; The `reg-event` interceptor chain lives under metadata `:interceptors`
 ;; and MUST be a VECTOR (per Spec 001 §Allowed forms of the middle slot).
 ;; A BARE interceptor —
 ;; `(reg-event id mw/some-interceptor handler)` rather than
-;; `(reg-event id {:interceptors [mw/some-interceptor]} handler)` — used to be SILENTLY
-;; dropped: an interceptor built by `->interceptor` / `->interceptor*` is a
-;; *map* (`{:id … :before … :after …}`), so `normalise-args`' two-arg branch
-;; read it as the metadata-map, the chain never reached the registrar, and
-;; the interceptor never ran — no error, no warning (field-confirmed via the
-;; rf8 migration). This is the same silent-drop class as
-;; `:rf.warning/runtime-state-dropped` (p806o), the fail-closed work (gro94),
-;; and the M-8 silent no-op (cxo1h).
+;; `(reg-event id {:interceptors [mw/some-interceptor]} handler)` — is a
+;; recognised-but-unhonourable input: an interceptor built by `->interceptor` /
+;; `->interceptor*` is a *map* (`{:id … :before … :after …}`), so without this
+;; detection `normalise-args`' two-arg branch would read it as the
+;; metadata-map, the chain would never reach the registrar, and the
+;; interceptor would never run — a silent drop.
 ;;
 ;; Per Conventions §No silent swallow — recognised input MUST signal: a
 ;; bare interceptor is a recognised-but-unhonourable input, and the cascade
@@ -795,7 +772,7 @@
   Per Spec 001 §Allowed forms of the middle slot. Returns
   `[metadata handler]`.
 
-  Loud-fails on a BARE interceptor (rf2-3ut12): an interceptor map handed
+  Loud-fails on a BARE interceptor: an interceptor map handed
   where a metadata-map was expected is rejected with
   `:rf.error/reg-event-bare-interceptor` rather than silently dropped — the
   two-arg branch catches `(reg-event id bare-icpt handler)` (a map with
@@ -826,15 +803,15 @@
 
 (defn- merge-form-source
   "Merge `*pending-form-source*` into `m` under `:rf.handler/source`
-  (Spec 009 §`:rf.handler/source`, Xray Spec 021 §11.2 B.7 stretch,
-  rf2-xgfuy). User-supplied `:rf.handler/source` overrides the auto-
+  (Spec 009 §`:rf.handler/source`, Xray Spec 021 §11.2 B.7 stretch).
+  User-supplied `:rf.handler/source` overrides the auto-
   captured value (mirrors `source-coords/merge-coords` semantics — so
   tooling that synthesises registrations from another source can stamp
   the original form-source). Returns `m` unchanged when no source is
   pending (programmatic / REPL registrations that bypass the macro
   path).
 
-  Per rf2-xgfuy §Production elision: the whole body is gated on
+  Production elision: the whole body is gated on
   `interop/debug-enabled?`. Under `:advanced` + `goog.DEBUG=false`
   Closure constant-folds the gate to `false` and DCEs the entire merge
   — both the literal `:rf.handler/source` keyword's reachability from
@@ -858,7 +835,7 @@
   The metadata-map carries a reserved `:interceptors` key. A non-vector /
   non-interceptor value raises `:rf.error/reg-event-bad-interceptors`.
 
-  RETAIN-vs-STRIP decision (one line, per the bead): the raw `:interceptors`
+  RETAIN-vs-STRIP: the raw `:interceptors`
   key is STRIPPED from the stored metadata. The registrar entry already stores
   the EFFECTIVE chain (user interceptors + the framework wrapper) under
   `:interceptors`; retaining the raw user value under the same key would collide
@@ -876,7 +853,7 @@
       ;; REFERENCE resolves at registration (typos die before dispatch), but
       ;; store the chain UNRESOLVED — the router resolves refs at chain
       ;; assembly so a hot-reloaded interceptor descriptor is picked up on the
-      ;; next dispatch (EP-0022, rf2-0adhqs.2).
+      ;; next dispatch (EP-0022).
       (validate-refs-registered! meta-interceptors)
       [(dissoc meta :interceptors) meta-interceptors])))
 
@@ -886,13 +863,13 @@
   Steps:
     1. parse the variadic tail into [metadata handler];
     2. resolve the interceptor chain from metadata `:interceptors` via
-       `resolve-interceptors` (rf2-bpmszk): validates the map value and strips
+       `resolve-interceptors`: validates the map value and strips
        the raw key from the stored meta;
     3. wrap the user handler into the `:rf/event-handler` interceptor via
        `wrap-event-handler`;
     4. register under `:event` with `:handler-fn` retained for tooling
        introspection and `:rf.handler/source` carrying the macro-captured
-       form-source string when present (Spec 009, rf2-xgfuy);
+       form-source string when present (Spec 009);
     5. return the event id. Path-D schema-first privacy has no
        user-facing redaction interceptor to police at registration time.
 
@@ -901,7 +878,7 @@
   (let [[raw-meta handler-fn] (normalise-args reg-fn-name args)
         [meta interceptors] (resolve-interceptors reg-fn-name id raw-meta)
         wrapped (wrap-event-handler handler-fn)]
-    ;; Per Spec 010 §Production builds + rf2-iftj4: reject the
+    ;; Per Spec 010 §Production builds: reject the
     ;; registration when `:rf.schema/at-boundary` is attached but no
     ;; `:schema` is declared on the metadata-map. The boundary
     ;; interceptor is structurally meaningless without a schema, so
@@ -913,20 +890,19 @@
     ;; entry vector the satisfaction step consumes (`cofx/deliver-declared-cofx`,
     ;; via `assemble-initial-ctx`), raising `:rf.error/cofx-request-invalid` /
     ;; `:rf.error/cofx-name-collision` on a malformed / duplicate declaration.
-    ;; EP-0018: `:rf.cofx/requires` is uniformly available (the former
-    ;; db-handler exception is gone — the one form is coeffects-in).
+    ;; EP-0018: `:rf.cofx/requires` is uniformly available — the one form is
+    ;; coeffects-in.
     ;; Per Spec 015 §1. Event handlers: VALIDATE any declared `:sensitive` /
-    ;; `:large` marks fail-loud BEFORE the registrar write (rf2-ehexnw); the
-    ;; marks themselves are DERIVED from the registrar meta at `marks-for` read
-    ;; time, no imperative stash. DIRECT REQUIRE (rf2-58bq1r): `marks` is
-    ;; core-owned, same-artefact, already pinned into the prod bundle, and
-    ;; always-on, so the former `:marks/validate-marks!` late-bind hop bought
-    ;; nothing here (no DCE seam, no optional-artefact decoupling) and the require
-    ;; is cycle-free. Runs for MACHINE registrations too: a machine's author
-    ;; marks ride its `:event` reg meta (via `reg-machine` opts); `marks-for
-    ;; :event <id>` returns those registrar-derived author marks (EP-0025
-    ;; rf2-398kql removed the machine `:data-schema`→marks union — frame-declared
-    ;; paths are now the sole app-db classification mechanism).
+    ;; `:large` marks fail-loud BEFORE the registrar write; the marks
+    ;; themselves are DERIVED from the registrar meta at `marks-for` read
+    ;; time, no imperative stash. DIRECT REQUIRE: `marks` is core-owned,
+    ;; same-artefact, pinned into the prod bundle, and always-on, so the
+    ;; require needs no late-bind hop (no DCE seam, no optional-artefact
+    ;; decoupling) and is cycle-free. Runs for MACHINE registrations too: a
+    ;; machine's author marks ride its `:event` reg meta (via `reg-machine`
+    ;; opts); `marks-for :event <id>` returns those registrar-derived author
+    ;; marks (EP-0025 — frame-declared paths are the sole app-db classification
+    ;; mechanism).
     (marks/validate-marks! :event meta)
     (let [requires-parsed (cofx/parse-requires id (:rf.cofx/requires meta))]
       (registrar/register! :event id
@@ -939,8 +915,8 @@
 
 (defn reg-event
   "Register a `(fn [coeffects event-vec] effect-map)` event handler under
-  `id` — the ONE public event-registration form (EP-0018, ruled
-  2026-06-14). Coeffects in, a closed effects map out.
+  `id` — the ONE public event-registration form (EP-0018). Coeffects in, a
+  closed effects map out.
 
   The handler is **pure** — it receives a coeffect map (carrying `:db`,
   `:event`, plus exactly the facts it declared via `:rf.cofx/requires`,
@@ -978,13 +954,12 @@
 
   Coeffects are declared via `:rf.cofx/requires` on the metadata map (the
   value arrives FLAT in the cofx map under its id) — uniformly available
-  to every event (the EP-0017 hole closed by EP-0018). `inject-cofx` is
-  removed (EP-0017). The historical positional interceptor vector middle
-  slot is removed; put the chain under metadata `:interceptors`.
+  to every event. `inject-cofx` is not available. Put the interceptor chain
+  under metadata `:interceptors`.
 
   Returns `id`. Returning `nil` from the handler is a documented no-op.
 
-  Full-context work that a `(fn [context] context)` handler once expressed
+  Full-context work that a `(fn [context] context)` handler expresses
   is done with a registered interceptor (authored with `reg-interceptor`,
   the public `context -> context` form) referenced by id from a `reg-event`
   registration's `:interceptors` chain.
@@ -1039,7 +1014,7 @@
   call to a removed public event registrar `reg-fn-name` (a string like
   \"reg-event-db\"), naming `replacement` and showing `fix` (the actionable
   conversion). The `inject-cofx` removed-stub twin: composes the EP-0018
-  reason then delegates to the ONE shared `cofx/raise-removed!` (rf2-8au0w6),
+  reason then delegates to the ONE shared `cofx/raise-removed!`,
   which surfaces on the always-on error-emit listener (production-survivable)
   AND the dev trace bus, then throws the ex-info carrying the same
   `:rf.error/id` — the offending `id` rides the trace + ex-data under `:id`."
@@ -1048,7 +1023,7 @@
                     "Use `" replacement "` instead — " fix)]
     (cofx/raise-removed! error-kw where reason id :id)))
 
-;; ---- data-driven removed event-registration names (rf2-ne2uk8) ------------
+;; ---- data-driven removed event-registration names ------------------------
 ;;
 ;; The three retired public event registrars are described ONCE in the data
 ;; table below, not as three near-identical bespoke stubs. Each row carries the
@@ -1068,7 +1043,7 @@
 
 (def ^:private removed-reg-event-names
   "The EP-0018 retired public event-registration names, one row each — the
-  single audit surface for the removed event registrars (rf2-ne2uk8). A row is
+  single audit surface for the removed event registrars. A row is
   `{:sym :error-kw :where :replacement :fix}`:
     - `:sym`         the bare var symbol exported `^:no-doc` from this ns and
                      aliased onto the `re-frame.core` facade;
@@ -1163,7 +1138,7 @@
   ([] (registrar/clear-kind! :event))
   ([id] (registrar/unregister! :event id)))
 
-;; ---- EP-0023 inline-registration lowering (rf2-ffc6s0) --------------------
+;; ---- EP-0023 inline-registration lowering --------------------------------
 ;;
 ;; An image's inline `:registrations` `:reg-event` entry carries the raw
 ;; handler fn under `:impl` (image lowering is the pure `re-frame.image`
@@ -1191,9 +1166,9 @@
   satisfaction step (`router/assemble-initial-ctx`) reads the TOP-LEVEL
   `:rf.cofx/requires-parsed` slot to deliver the declared coeffects, so an
   inline image-loaded event MUST carry it or its declared facts are silently
-  dropped (rf2-khi7xr — a fail-open drop, violating EP-0017 §5 uniform
-  declared-only delivery and the EP-0023 §Image Fragments \"both paths lower to
-  the same runtime descriptor shape\" contract). A malformed / duplicate
+  dropped (a fail-open drop, violating EP-0017 §5 uniform declared-only
+  delivery and the EP-0023 §Image Fragments \"both paths lower to the same
+  runtime descriptor shape\" contract). A malformed / duplicate
   declaration fails loud at lowering (`:rf.error/cofx-request-invalid` /
   `:rf.error/cofx-name-collision`), mirroring registration.
 

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -10,7 +10,7 @@
 
   Reserved frame ids:
     :rf/default              — an ORDINARY frame id (per Spec 002 §`:rf/default`
-                              is an ordinary id, EP-0002). It carries NO
+                              is an ordinary id). It carries NO
                               framework privilege: the runtime never creates
                               it, never infers it from a missing stamp, and
                               never uses it as a resolution floor. A small
@@ -48,11 +48,11 @@
 ;;   :config      the metadata that reg-frame was given
 ;;
 ;; Per Spec 002 §One physical container, two projection reactions + Spec 006
-;; §Frame-state container and partition projections (EP-0001 decision #3):
+;; §Frame-state container and partition projections:
 ;; the frame holds ONE physical frame-state container; app-db and runtime-db
 ;; are PROJECTION REACTIONS over it. Partition-aware sub-cache invalidation
-;; falls out of `make-derived-value`'s memoised `=`-equality — NO dirty flags
-;; (decision #7): a runtime-only commit recomputes the app-db projection,
+;; falls out of `make-derived-value`'s memoised `=`-equality — NO dirty flags:
+;; a runtime-only commit recomputes the app-db projection,
 ;; finds `:rf.db/app` `=`, and does not propagate to app subs; an app-only
 ;; commit is symmetric.
 ;;
@@ -72,37 +72,36 @@
   "Reserved frame-state key naming the runtime-db partition (`:rf.db/runtime`)."
   :rf.db/runtime)
 
-;; ---- EP-0023 runnable frame OBJECT marker + target normalization ----------
+;; ---- runnable frame OBJECT marker + target normalization ------------------
 ;;
-;; EP-0023 collapse slice 1 (rf2-32siq3.32): `re-frame.live-frame/make-frame`
-;; returns a SINGLE runnable image-loaded frame OBJECT — a map carrying the
-;; resolved image generation AND a reference (`:rf.frame/runnable-id`) to the
-;; backing EP-0013 runnable RECORD this ns owns in `frames`. The object IS the
-;; public live frame; its runnable interior (app-db / runtime-db / queue /
-;; sub-cache / lifecycle) is the record reached by the runnable-id (EP-0023
-;; §Frame — "the live frame object owns app-db, runtime-db, event queue and
-;; drain state, subscription cache, ... a reference to the resolved image
-;; generation it is running").
+;; `re-frame.live-frame/make-frame` returns a SINGLE runnable image-loaded
+;; frame OBJECT — a map carrying the resolved image generation AND a reference
+;; (`:rf.frame/runnable-id`) to the backing runnable RECORD this ns owns in
+;; `frames`. The object IS the public live frame; its runnable interior
+;; (app-db / runtime-db / queue / sub-cache / lifecycle) is the record reached
+;; by the runnable-id (EP-0023 §Frame — "the live frame object owns app-db,
+;; runtime-db, event queue and drain state, subscription cache, ... a reference
+;; to the resolved image generation it is running").
 ;;
 ;; The PUBLIC target a dispatch / subscribe / destroy / app-db read addresses is
 ;; a frame — usually a frame id KEYWORD (the public routing address), sometimes
 ;; a frame VALUE the lifecycle APIs return (EP-0024 Operation target grammar —
 ;; "the API teaches one routing address: the frame id"; internal normalization
-;; still accepts a frame value for tests/tools). Every runnable subsystem
+;; also accepts a frame value for tests/tools). Every runnable subsystem
 ;; resolves per-frame state through a frame-id ADDRESS keyed into `frames` (the
 ;; ONE registry — the universal chokepoint: the router queue/drain,
 ;; `commit-frame-transition!`, the sub-cache, cofx, elision, …). So a frame
 ;; VALUE target is normalized to its id at the public entry, and every
-;; bare-`frame-id`-keyed operation downstream stays byte-identical.
+;; bare-`frame-id`-keyed operation downstream is identical.
 ;;
-;; EP-0024 (rf2-tu2vr7) — the frame VALUE is the live lifecycle token
-;; `make-frame` returns. Its representation is NOT an app-facing data contract:
-;; it carries the `:rf.frame/object` marker (so a value target is discriminated
-;; structurally from a keyword id) and `:rf.frame/runnable-id` (= the frame id
-;; its record is keyed by in the one `frames` registry). The resolved image
-;; generation is NOT embedded on the value — it lives on the record (the
-;; `:generation` slot), read by id. `frame-value->id` is the single public
-;; accessor from a frame value to its id (Open Issue #2 — representation hidden).
+;; The frame VALUE is the live lifecycle token `make-frame` returns. Its
+;; representation is NOT an app-facing data contract: it carries the
+;; `:rf.frame/object` marker (so a value target is discriminated structurally
+;; from a keyword id) and `:rf.frame/runnable-id` (= the frame id its record is
+;; keyed by in the one `frames` registry). The resolved image generation is NOT
+;; embedded on the value — it lives on the record (the `:generation` slot), read
+;; by id. `frame-value->id` is the single public accessor from a frame value to
+;; its id (EP-0024 Open Issue #2 — representation hidden).
 
 (def ^:const object-marker
   "Reserved frame-value marker key. A `true` value at this key on a map means
@@ -114,7 +113,7 @@
 
 (def ^:const runnable-id-key
   "Reserved key on a frame VALUE naming the frame id its record is keyed by in
-  the one `frames` registry (EP-0024, rf2-tu2vr7). For an `:id`-bearing value
+  the one `frames` registry (EP-0024). For an `:id`-bearing value
   this equals the public `:rf.frame/id`; for a no-id (direct) value it is a
   process-unique `:rf.frame/<gensym>` so the value is still runnable (its record
   is addressable) while bypassing the PUBLIC frame-id space (EP-0024 — direct
@@ -142,8 +141,8 @@
 
 (defn frame-target->id
   "Normalize a public frame TARGET — a frame-id KEYWORD or a frame VALUE — to the
-  frame id its record is keyed by in the one `frames` registry (EP-0024,
-  rf2-tu2vr7). A frame VALUE (carrying `:rf.frame/object true`) yields its
+  frame id its record is keyed by in the one `frames` registry (EP-0024). A
+  frame VALUE (carrying `:rf.frame/object true`) yields its
   `:rf.frame/runnable-id`; any other target (a keyword id, or a nil / malformed
   value) is returned UNCHANGED — so every keyword-target caller is
   byte-identical. The internal normalization seam dispatch / subscribe / destroy
@@ -164,17 +163,17 @@
 (defonce
   ^{:doc "Map of frame-id → frame-record. Per-process (one global frame
   registry), keyed by the bare frame-id keyword. A frame is addressed by its
-  process-local id; there is no realm coordinate (EP-0023, rf2-upgtq4)."}
+  process-local id."}
   frames
   (atom {}))
 
-;; ---- frame address — the bare frame-id (EP-0023, rf2-upgtq4) ----------------
+;; ---- frame address — the bare frame-id ------------------------------------
 ;;
 ;; A frame is addressed by its process-local frame-id keyword. The registry key
 ;; is the bare id — no realm coordinate threads the lookup, the `swap! frames
 ;; assoc`, or any tool's `@frames` read.
 
-;; ---- destroy-in-flight guard (rf2-r1ciy) ---------------------------------
+;; ---- destroy-in-flight guard ---------------------------------------------
 ;;
 ;; Tracks frame-ids whose `destroy-frame!` call is currently mid-flight so
 ;; a re-entrant `(destroy-frame! id)` from inside the same id's
@@ -187,17 +186,17 @@
 (defonce ^:private destroying-frames
   (atom #{}))
 
-;; EP-0008 (rf2-ntv9i9.1): monotonic counter for the per-destroy UNIQUE
-;; transient `:on-destroy`-throw capture listener key. `fire-on-destroy-event!`
-;; installs a listener on the always-on error-emit registry for the duration of
-;; the `:on-destroy` dispatch; the registry keys by id (assoc/dissoc). A
-;; CONSTANT key (the former `::on-destroy-throw-watch`) let an OVERLAPPING /
-;; NESTED destroy — a Spec 002 (rf2-r1ciy) supported shape: an `:on-destroy`
-;; handler destroying a DIFFERENT frame — REPLACE the outer destroy's listener
-;; under the same key, then DROP it on the inner's finally, so the outer's
-;; `:rf.error/handler-exception` was never captured and its dedicated
-;; `:rf.error/on-destroy-handler-exception` discriminator was silently dropped.
-;; A fresh per-invocation key gives each (possibly nested) destroy its own
+;; Monotonic counter for the per-destroy UNIQUE transient `:on-destroy`-throw
+;; capture listener key. `fire-on-destroy-event!` installs a listener on the
+;; always-on error-emit registry for the duration of the `:on-destroy`
+;; dispatch; the registry keys by id (assoc/dissoc). The listener key MUST be
+;; UNIQUE per invocation: an OVERLAPPING / NESTED destroy — a Spec 002
+;; supported shape: an `:on-destroy` handler destroying a DIFFERENT frame —
+;; would otherwise REPLACE the outer destroy's listener under a shared key,
+;; then DROP it on the inner's finally, so the outer's
+;; `:rf.error/handler-exception` is never captured and its dedicated
+;; `:rf.error/on-destroy-handler-exception` discriminator is silently lost. A
+;; fresh per-invocation key gives each (possibly nested) destroy its own
 ;; listener — no clobber, no cross-removal. `defonce` so a hot reload does not
 ;; rewind the counter mid-flight.
 (defonce ^:private on-destroy-watch-counter
@@ -253,11 +252,10 @@
   []
   *current-frame*)
 
-;; Per Spec 009 §Per-frame trace rings (rf2-g1b2m / rf2-8uwce): publish
-;; the in-flight frame-id through `late-bind` so the trace tooling
-;; sibling can route emit-site trace events to their owning frame's
-;; ring. Returns nil when no cascade is in flight (frameless emits).
-;; The hook is sticky (rf2-f72pd) and read on every push-to-ring!.
+;; Per Spec 009 §Per-frame trace rings: publish the in-flight frame-id through
+;; `late-bind` so the trace tooling sibling can route emit-site trace events to
+;; their owning frame's ring. Returns nil when no cascade is in flight
+;; (frameless emits). The hook is sticky and read on every push-to-ring!.
 (late-bind/set-fn! :frame/current-frame-id (fn [] *current-frame*))
 
 (defn resolve-current-frame
@@ -275,19 +273,18 @@
   the React-context tier is LIVE — adapters publish their React-context-
   aware impl through the hook at ns-load time. That impl returns nil when
   neither the dynamic var nor an enclosing Provider names a frame (the
-  Provider default is now the no-provider sentinel, NOT `:rf/default`, per
-  Spec 002 §`:rf/default` is an ordinary id + the EP-0002 React-context
-  bead). When the hook is unbound (no adapter loaded yet, or JVM build)
+  Provider default is the no-provider sentinel, per Spec 002 §`:rf/default`
+  is an ordinary id). When the hook is unbound (no adapter loaded yet, or JVM build)
   the result is `current-frame` — the dynamic-var tier alone; the React-
   context tier silently no-ops to nil.
 
   This is the canonical scope reader — `subs/subscribe`,
   `router/dispatch*`'s frame computation, and `core/current-frame-id`
-  delegate here so the React-context tier is single-sourced (rf2-jj8xf).
+  delegate here so the React-context tier is single-sourced.
   Public frame-scoped operations that must have a frame call
   `require-current-frame!`, which is built on this reader."
   []
-  ;; Sticky hook (rf2-f72pd) — `:adapter/current-frame` is published
+  ;; Sticky hook — `:adapter/current-frame` is published
   ;; once per loaded React-shaped adapter at ns-load time and routed
   ;; via `current-adapter`; it fires on every ambient resolution
   ;; (every ambient dispatch and every ambient subscribe).
@@ -395,7 +392,7 @@
 
 ;; ---- :rf.error/bad-frame-provider-arg — a bad explicit target -------------
 ;;
-;; Distinct from `:rf.error/no-frame-context` (rf2-9kpigo). A public
+;; Distinct from `:rf.error/no-frame-context`. A public
 ;; `frame-provider` whose `:frame` is non-nil but NOT a keyword has carried
 ;; an explicit-but-malformed target — `{:frame "app"}`, `{:frame 7}`,
 ;; `{:frame ['x]}`. Frame ids are keywords (Spec 002 §Frame identity is a
@@ -409,8 +406,8 @@
 ;;
 ;; Without this, the lower-level reader's `coerce-context-value` would
 ;; stringify-coerce a `{:frame "app"}` prop back into `:app` and silently
-;; route descendants to a registered `:app` frame — the bug rf2-9kpigo
-;; describes. Validating at the public provider entry points stops the bad
+;; route descendants to a registered `:app` frame. Validating at the public
+;; provider entry points stops the bad
 ;; value from ever reaching React Context. The raw-hiccup compatibility
 ;; coercion at the reader boundary is intentionally preserved (the public
 ;; surfaces never write a non-keyword value, so prop-stringified keywords
@@ -448,9 +445,9 @@
   payload)
 
 (defn require-keyword-frame-provider-arg!
-  "Validate a public `frame-provider`'s `:frame` arg (rf2-9kpigo). Returns
+  "Validate a public `frame-provider`'s `:frame` arg. Returns
   `frame-kw` unchanged when it is a keyword. A nil value routes to the
-  existing `:rf.error/no-frame-context` path (absence — the provider
+  `:rf.error/no-frame-context` path (absence — the provider
   establishes no usable scope). A non-nil non-keyword value emits + throws
   the distinct `:rf.error/bad-frame-provider-arg` so the bad explicit
   target fails loudly at the provider rather than being silently coerced to
@@ -458,7 +455,7 @@
 
   `where` (sym/kw) names the validating call site for the payload. The nil
   branch threads `where` + a `:supply-frame` recovery into the
-  no-frame-context payload, matching each provider surface's prior nil
+  no-frame-context payload, matching each provider surface's nil
   handling."
   [frame-kw where]
   (cond
@@ -536,13 +533,11 @@
 
 (defn frame
   "Return the frame record for `id` (a frame-id keyword), or nil if not
-  registered or destroyed. The registry is keyed by the bare frame-id
-  (rf2-upgtq4 — the realm-addressing dimension was collapsed; the realm
-  substrate is single-default-only).
+  registered or destroyed. The registry is keyed by the bare frame-id.
 
   2-level lookup written as keyword-invoke (`(-> f :lifecycle :destroyed?)`)
   rather than `(get-in f [:lifecycle :destroyed?])` — `get-in` allocates
-  a path vector per call (rf2-mqv4m), and `frame` runs on every dispatch
+  a path vector per call, and `frame` runs on every dispatch
   / subscribe through `current-frame` resolution."
   [id]
   (when-let [f (get @frames id)]
@@ -566,8 +561,7 @@
   intended seam explicit and avoid suggesting general
   destroyed-vs-never-registered discrimination.
 
-  Keyed by the bare frame-id (rf2-upgtq4 — the realm-addressing dimension was
-  collapsed)."
+  Keyed by the bare frame-id."
   [id]
   (if-let [f (get @frames id)]
     (true? (-> f :lifecycle :destroyed?))
@@ -581,9 +575,9 @@
   "Resolve the ADDRESS key for `frame-id` — the key a per-frame SIDE-CHANNEL
   (SSR request / response / error-trace / head snapshot, …) keys its entries by.
   This is the bare `frame-id` keyword: a frame is addressed by its process-local
-  id, with no realm coordinate. Retained as the named seam the SSR side-channels
-  share so their keying stays single-sourced (a re-introduced address scheme
-  would change this one fn). INTERNAL."
+  id. The named seam the SSR side-channels share so their keying stays
+  single-sourced (any change to the address scheme is confined to this one fn).
+  INTERNAL."
   [frame-id]
   frame-id)
 
@@ -612,7 +606,7 @@
   registered, non-destroyed frame. The shared front of both `frame-ids`
   arities (the 1-arity composes a prefix filter after it). The frame-id is
   read from the record's own `:id` slot (which equals the map key, the bare
-  frame-id, since rf2-upgtq4 collapsed the realm-addressing dimension)."
+  frame-id)."
   (comp (remove (fn [[_ f]] (-> f :lifecycle :destroyed?)))
         (map (fn [[_ f]] (:id f)))))
 
@@ -631,9 +625,8 @@
 
   Per Spec 002 §The public registrar query API.
 
-  The `frames` registry is keyed by the bare frame-id (rf2-upgtq4 — the realm-
-  addressing dimension was collapsed); the frame-id is read from each record's
-  own `:id` slot."
+  The `frames` registry is keyed by the bare frame-id; the frame-id is read from
+  each record's own `:id` slot."
   ([]
    (into #{} live-frame-id-xf @frames))
   ([ns-prefix]
@@ -659,34 +652,31 @@
 (defn image-loaded-frame-ids
   "Return the set of PUBLIC frame ids whose record currently carries a resolved
   image GENERATION — the image-loaded frames the hot-reload reprojection path
-  enumerates (EP-0024, rf2-tu2vr7). The derived read that replaced the dissolved
-  second live-frame registry's `live-frame-ids`: an image-loaded frame is now
-  just a `frames`-registry record with a non-nil `:generation` slot, so this is
-  a filter over the ONE registry, not a separate index.
+  enumerates (EP-0024). An image-loaded frame is a `frames`-registry record with
+  a non-nil `:generation` slot, so this is a filter over the ONE registry, not a
+  separate index.
 
   EXCLUDES no-id (direct) frames — a frame created with no `:id` is keyed by a
-  private `:rf.frame/<gensym>` id; like the dissolved registry's `live-frame-ids`
-  (which kept only `:rf.frame/id`-bearing entries), this enumeration drops the
-  reserved `:rf.frame/` namespace so the reprojection / enumeration path never
-  touches a harness-local frame the spec says its owner reloads explicitly
-  (EP-0023 §Frame — direct frames bypass auto-reprojection). Excludes destroyed
-  frames."
+  private `:rf.frame/<gensym>` id; this enumeration keeps only PUBLIC ids and
+  drops the reserved `:rf.frame/` namespace so the reprojection / enumeration
+  path never touches a harness-local frame the spec says its owner reloads
+  explicitly (EP-0023 §Frame — direct frames bypass auto-reprojection). Excludes
+  destroyed frames."
   []
   (into #{}
         (comp (filter (fn [[_ f]] (image-loaded-frame-record? f)))
               (map (fn [[_ f]] (:id f))))
         @frames))
 
-;; ---- the internal value-read frame resolver seam (EP-0024, rf2-az1ct6) ----
+;; ---- the internal value-read frame resolver seam --------------------------
 ;;
 ;; The value-read helpers below all share one shape: resolve the frame record
 ;; for an id (the bare-id lookup + the destroyed? guard via `frame`),
 ;; take ONE slot off it, and — for the *-value readers — deref that slot's
-;; container through the substrate adapter. rf2-az1ct6 factors that repeated
-;; "resolve record → take slot (→ read container)" mechanics into ONE internal
-;; seam so the readers do not each re-implement it. No public grammar changes:
-;; `frame` is still the record resolver, the per-slot accessors keep their
-;; names + nil-on-unknown/destroyed contract; only the duplication is removed.
+;; container through the substrate adapter. That repeated "resolve record → take
+;; slot (→ read container)" mechanics is factored into ONE internal seam so the
+;; readers do not each re-implement it. `frame` is the record resolver, the
+;; per-slot accessors carry their names + nil-on-unknown/destroyed contract.
 
 (defn frame-slot
   "Return slot `k` of the frame record for frame ADDRESS `id`, or nil when the
@@ -702,7 +692,7 @@
   substrate container (via `frame-slot`) and deref it through the adapter, or
   nil when the frame is unknown/destroyed (or the slot is absent). The shared
   read mechanics the `*-value` readers (`frame-app-db-value` /
-  `frame-runtime-db-value` / `frame-state-value`) funnel through (rf2-az1ct6).
+  `frame-runtime-db-value` / `frame-state-value`) funnel through.
   INTERNAL."
   [id k]
   (when-let [container (frame-slot id k)]
@@ -721,8 +711,8 @@
   (frame-slot id :generation))
 
 (defn frame-capabilities
-  "Return the host capability map frame `id` was created with (EP-0024,
-  rf2-tu2vr7), or nil when the frame supplied none / is unknown. Stored on the
+  "Return the host capability map frame `id` was created with (EP-0024), or nil
+  when the frame supplied none / is unknown. Stored on the
   record's `:config` under the reserved `:rf.frame/capabilities` key by
   `make-frame` so `reload-images!` / reprojection can re-check capabilities by id
   without a second registry holding them. Pure."
@@ -731,7 +721,7 @@
 
 (defn frame-adapter
   "Return the active-substrate adapter binding frame `id` was created with
-  (EP-0024, rf2-tu2vr7), or nil when the frame supplied none / is unknown.
+  (EP-0024), or nil when the frame supplied none / is unknown.
   Stored on the record's `:config` under the reserved `:rf.frame/adapter` key by
   `make-frame` so tooling (Xray's image/frame view) can read it by id. Pure."
   [id]
@@ -741,8 +731,8 @@
   "Swap the resolved image GENERATION on frame `id`'s record IN PLACE,
   preserving every other (state-bearing) slot by identity — the in-place
   generation swap `re-frame.live-frame`'s `make-frame` / `reload-images!` /
-  reprojection write through (EP-0024, rf2-tu2vr7). A no-op for an unknown frame
-  (the registry is keyed by the bare frame-id, rf2-upgtq4). Returns nil.
+  reprojection write through (EP-0024). A no-op for an unknown frame
+  (the registry is keyed by the bare frame-id). Returns nil.
   INTERNAL — the one mutator of the `:generation` slot."
   [id generation]
   (swap! frames (fn [m]
@@ -818,25 +808,23 @@
   [id]
   (frame-slot-value id :app-db))
 
-;; ---- EP-0001 two-partition readers (rf2-q4i9ko / rf2-adwcv6) --------------
+;; ---- EP-0001 two-partition readers ----------------------------------------
 ;;
 ;; Per Spec 002 §The two-partition frame contract a frame owns two durable
 ;; partitions — user `app-db` and framework `runtime-db` — projected as a
 ;; coherent `frame-state` value `{:rf.db/app … :rf.db/runtime …}`.
 ;;
-;; rf2-q4i9ko (bead 3) introduced the read SURFACE; rf2-adwcv6 (bead 5, this
-;; one) makes the physical one-container frame-state + projection reactions
-;; real, so `frame-runtime-db-value` now reads the live runtime-db partition.
+;; The physical one-container frame-state + projection reactions back these
+;; readers, so `frame-runtime-db-value` reads the live runtime-db partition.
 
 (defn frame-runtime-db-value
   "Read the current runtime-db partition value for a frame — the
   framework-owned subsystem state. Returns `nil` for an unknown / destroyed
   frame.
 
-  rf2-adwcv6 (bead 5): reads the real `:rf.db/runtime` partition off the one
-  physical frame-state container (via the runtime-db projection). A fresh
-  frame's runtime-db starts `{}`. Per Spec 002 §The two-partition frame
-  contract."
+  Reads the `:rf.db/runtime` partition off the one physical frame-state
+  container (via the runtime-db projection). A fresh frame's runtime-db starts
+  `{}`. Per Spec 002 §The two-partition frame contract."
   [id]
   (frame-slot-value id :runtime-db))
 
@@ -845,14 +833,13 @@
   `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`. Returns `nil` for an
   unknown / destroyed frame.
 
-  rf2-adwcv6 (bead 5): reads the one physical frame-state container directly
-  (a single deref) rather than composing two reads, so the returned value is
-  the exact coherent snapshot the commit installed. Per Spec 002 §The
-  two-partition frame contract."
+  Reads the one physical frame-state container directly (a single deref) rather
+  than composing two reads, so the returned value is the exact coherent snapshot
+  the commit installed. Per Spec 002 §The two-partition frame contract."
   [id]
   (frame-slot-value id :frame-state))
 
-;; ---- EP-0001 partition commit + write helpers (rf2-adwcv6) ----------------
+;; ---- EP-0001 partition commit + write helpers -----------------------------
 ;;
 ;; The frame-state container is the ONE physical write target. Every durable
 ;; state write — the router's per-event commit, the privileged runtime
@@ -910,7 +897,7 @@
       ;; ONE atomic frame-state install — both partitions in one write, per
       ;; Spec 006 §Commit boundary.
       ;;
-      ;; identical?-noop short-circuit (rf2-ekq28v): when the next frame-state
+      ;; identical?-noop short-circuit: when the next frame-state
       ;; would carry forward each partition's CURRENT OBJECT unchanged
       ;; (`identical?`, not merely `=`), the install is a genuine no-op — the
       ;; common `(if cond (assoc db …) db)` else-arm returns the same object —
@@ -992,12 +979,12 @@
   surface; the read / partition-commit dance belongs here, not at every
   fx-handler call site.
 
-  EP-0001 (rf2-adwcv6): now writes the app-db partition of the physical
-  frame-state container (was a direct `replace-container!` on the old app-db
-  store). Framework durable state — machines, routing, elision, SSR — no
-  longer rides under app-db; those writers use the runtime-db sibling
-  `swap-runtime-db!` to mutate the `:rf.db/runtime` partition (`:rf.runtime/*`
-  children). This surface mutates only the app-db partition."
+  Writes the app-db partition of the physical frame-state container. Framework
+  durable state — machines, routing, elision, SSR — rides under runtime-db, not
+  app-db; those writers use the runtime-db sibling `swap-runtime-db!` to mutate
+  the `:rf.db/runtime` partition (`:rf.runtime/*` children). This surface
+  mutates only the app-db partition (per Spec 002 §The two-partition frame
+  contract)."
   [id f & args]
   (swap-partition! id app-partition-key f args))
 
@@ -1019,13 +1006,13 @@
   [id f & args]
   (swap-partition! id runtime-partition-key f args))
 
-;; ---- lifecycle-vs-drain serialization (rf2-2woz9) -------------------------
+;; ---- lifecycle-vs-drain serialization -------------------------------------
 ;;
 ;; Some per-frame registry mutations must be ATOMIC with respect to that
 ;; frame's event drain — they read-modify-write shared registry state AND
 ;; app-db, and a concurrent drain that interleaves between the steps can
 ;; observe a half-applied lifecycle change. The flows artefact has two such
-;; ops (rf2-2woz9):
+;; ops:
 ;;
 ;;   - `clear-flow` vacates the output path THEN removes the flow from the
 ;;     registry. A drain that starts in that window still sees the flow,
@@ -1078,7 +1065,7 @@
   `:rf.fx/reg-flow` effect mid-cascade). Public wrapper over the same
   `:in-drain?` thread marker `call-serialized-with-drain!` reads.
 
-  rf2-z980k8: `reg-flow`'s same-frame `:path`-change vacate must DEFER to the
+  `reg-flow`'s same-frame `:path`-change vacate must DEFER to the
   drain's pending-`:db` transform when in-drain (a direct app-db write made
   here is clobbered by the deferred commit that publishes the handler's
   returned `:db`), but may vacate directly when OUT of a drain (no pending
@@ -1091,7 +1078,7 @@
 
 (defn call-serialized-with-drain!
   "Run thunk `f` serialized against `frame-id`'s event drain, returning its
-  value (rf2-2woz9). Used by per-frame registry mutations that must not
+  value. Used by per-frame registry mutations that must not
   interleave with a concurrent `run-flows-on-db` pass.
 
   - Frame absent (unregistered / destroyed): nothing can be draining it, so
@@ -1122,7 +1109,7 @@
 ;;
 ;; A :preset key in metadata expands at registration time into a fixed
 ;; bundle of metadata keys. User-supplied keys win on conflict.
-;; Per Spec 002 §Frame presets, the v1 closed list is:
+;; Per Spec 002 §Frame presets, the closed list is:
 ;;   :default :test :story :ssr-server
 
 (defn- preset-expansion [preset]
@@ -1133,7 +1120,7 @@
   ;;                  (Spec 014); explicit :drain-depth 100 (matches the
   ;;                  framework default — surfaced so tooling can read the
   ;;                  bound off frame-meta without consulting the global default);
-  ;;                  :rf.cofx/mint-policy :strict (EP-0017 slice-B.8 — a
+  ;;                  :rf.cofx/mint-policy :strict (per EP-0017 §6 — a
   ;;                  declared-absent generator-backed recordable fact is
   ;;                  missing-required rather than freshly minted, so a test's
   ;;                  path of least resistance is supply-the-fact, not a silent
@@ -1150,7 +1137,7 @@
   ;;   :ssr-server -> :platform :server (gates fx via reg-fx :platforms).
   ;; User-supplied keys win on conflict; see expand-preset.
   ;;
-  ;; rf2-cdmle — the :test / :story redirect targets
+  ;; The :test / :story redirect targets
   ;; `:rf.http/managed-canned-success`, which registers from the test-
   ;; support namespace `re-frame.http.test-support`. Apps that use these
   ;; presets must `:require [re-frame.http.test-support]` (alongside
@@ -1161,7 +1148,7 @@
     :default    {}
     :test       {:fx-overrides        {:rf.http/managed :rf.http/managed-canned-success}
                  :drain-depth         100
-                 ;; EP-0017 §6 / slice-B.8 (rf2-5spzo7): the :test preset
+                 ;; Per EP-0017 §6: the :test preset
                  ;; defaults the cofx MINT POLICY to :strict — a declared-absent
                  ;; generator-backed recordable fact under a test frame is
                  ;; `:rf.error/missing-required-cofx`, never a freshly-minted
@@ -1200,7 +1187,7 @@
   ;; §One physical container, two projection reactions; EP-0001 decision #3).
   ;; A fresh frame starts with an empty app-db (Spec 002 §Frames always start
   ;; with app-db = {}) and an empty runtime-db.
-  (let [;; EP-0024 (rf2-tu2vr7): `make-frame` threads the resolved generation +
+  (let [;; EP-0024: `make-frame` threads the resolved generation +
         ;; the `:initial-db` seed through the config under reserved keys so they
         ;; are installed on the record BEFORE `reg-frame` fires `:on-create` —
         ;; an `:on-create` cascade then resolves through the frame's OWN image
@@ -1211,7 +1198,7 @@
                       {app-partition-key     (if (some? seeded-app-db) seeded-app-db {})
                        runtime-partition-key {}})]
    {:id          id
-    ;; EP-0024 (rf2-tu2vr7) — the resolved IMAGE GENERATION slot. ONE unified
+    ;; EP-0024 — the resolved IMAGE GENERATION slot. ONE unified
     ;; frame value owns its resolved generation directly on the single
     ;; `frames`-registry record (Term: Frame value — "owns … resolved image
     ;; generation"); there is no second live-frame registry holding it. nil for
@@ -1266,11 +1253,9 @@
     runtime state (app-db, sub-cache, queue) is preserved; only the
     metadata/config is replaced. Hot-reload Just Works."
   [id metadata]
-  (let [;; The registry is keyed by the bare frame-id (rf2-upgtq4 — the
-        ;; realm-addressing dimension was collapsed; the realm substrate is
-        ;; single-default-only).
+  (let [;; The registry is keyed by the bare frame-id.
         config (source-coords/merge-coords (expand-preset metadata))
-        ;; EP-0015 §3 (rf2-ueg1tn): validate the frame-owned classification
+        ;; EP-0015 §3: validate the frame-owned classification
         ;; keys (`:sensitive` / `:large` / `:observability`) EARLY — pure,
         ;; container-independent, fail-loud. A malformed path / unknown
         ;; classification key / non-string carrier name throws here, BEFORE
@@ -1292,7 +1277,7 @@
           (when-let [install! (late-bind/get-fn :frame-classification/install!)]
             (install! id classification)))]
     (registrar/register! :frame id config)
-    ;; Frame-level trace-emission gate (rf2-2qaqh): a frame registered
+    ;; Frame-level trace-emission gate: a frame registered
     ;; with `:rf.trace/frame-no-emit? true` is a tool / inspector frame
     ;; (e.g. Xray's `:rf/xray`) whose own reactive substrate must NOT
     ;; flood the shared trace ring it inspects. The flag is the frame-
@@ -1301,7 +1286,7 @@
     ;; registration and re-registration so a hot-reload can flip it
     ;; either way; `trace.cljc` owns the canonical set + predicate.
     (trace/set-frame-no-emit! id (true? (:rf.trace/frame-no-emit? config)))
-    ;; Per Spec 009 §Retention contract (rf2-g1b2m / rf2-8uwce): apply
+    ;; Per Spec 009 §Retention contract: apply
     ;; the per-frame `:rf.trace/cascades-retained` override at
     ;; registration time. Honoured on BOTH first registration and re-
     ;; registration so a hot-reload can flip it either way. When the
@@ -1319,7 +1304,7 @@
         (nil? existing)
         (let [f (new-frame-record id config)]
           (swap! frames assoc id f)
-          ;; EP-0015 §3 (rf2-ueg1tn): install the frame-owned app-db
+          ;; EP-0015 §3: install the frame-owned app-db
           ;; classification into the durable elision registry NOW — the
           ;; container exists, and this MUST land before `:on-create` runs
           ;; (a `:rf/path` declared sensitive must be redacted in any trace
@@ -1343,26 +1328,23 @@
           ;; The signal for "inside a handler" is `trace/*handler-scope*`
           ;; being bound — the router binds it (via
           ;; `with-dispatch-id+call-site`) for the duration of a handler's
-          ;; execution and ONLY then. EP-0002 (rf2-9o48ih): the prior
-          ;; signal was `*current-frame*`, but under the carried invariant
-          ;; a test harness (or any caller) may establish an AMBIENT
-          ;; `with-frame` scope for its bare dispatches — binding
-          ;; `*current-frame*` WITHOUT any cascade in flight. That made a
-          ;; genuine TOP-LEVEL `reg-frame`/`make-frame` (no handler running)
-          ;; look mid-cascade and wrongly async-queue its `:on-create`, so
-          ;; the post-creation state was never observable synchronously.
-          ;; `*handler-scope*` is bound by the router's per-handler frame
-          ;; ONLY — it is set during real cascade processing and is nil
-          ;; under a bare ambient scope — so it distinguishes
-          ;; "created mid-cascade" (async) from "top-level boot under an
-          ;; ambient scope" (synchronous) precisely. Both lifecycle
-          ;; contract tests still hold: a child frame reg'd from inside a
-          ;; handler async-queues (handler-scope bound); a top-level
-          ;; reg-frame runs `:on-create` synchronously (handler-scope nil).
-          ;; Per rf2-hxj0d: stamp the frame-init dispatch with
-          ;; `:source :frame-init` so the Epoch panel's DISPATCH step
-          ;; renders "from frame-init" instead of being mislabelled
-          ;; via the previous `:ui` default. Additionally, capture the
+          ;; execution and ONLY then. Under the carried invariant a test
+          ;; harness (or any caller) may establish an AMBIENT `with-frame`
+          ;; scope for its bare dispatches — binding `*current-frame*`
+          ;; WITHOUT any cascade in flight — so `*current-frame*` cannot be
+          ;; the discriminator: a genuine TOP-LEVEL `reg-frame`/`make-frame`
+          ;; (no handler running) would look mid-cascade and wrongly
+          ;; async-queue its `:on-create`, leaving the post-creation state
+          ;; unobservable synchronously. `*handler-scope*` is bound by the
+          ;; router's per-handler frame ONLY — it is set during real cascade
+          ;; processing and is nil under a bare ambient scope — so it
+          ;; distinguishes "created mid-cascade" (async) from "top-level boot
+          ;; under an ambient scope" (synchronous) precisely. Both lifecycle
+          ;; contracts hold: a child frame reg'd from inside a handler
+          ;; async-queues (handler-scope bound); a top-level reg-frame runs
+          ;; `:on-create` synchronously (handler-scope nil).
+          ;; Stamp the frame-init dispatch with `:source :frame-init` so the
+          ;; Epoch panel's DISPATCH step renders "from frame-init". Additionally, capture the
           ;; `reg-frame` call-site coord as `:rf.trace/call-site` so
           ;; the click-to-source affordance jumps to the
           ;; `(rf/reg-frame :foo {:on-create [...]})` line. The macro
@@ -1374,17 +1356,17 @@
           ;; `interop/debug-enabled?` so production CLJS builds DCE
           ;; the call-site read.
           ;;
-          ;; rf2-inkdqh: the gate MUST be the OUTERMOST form (the canonical
+          ;; The gate MUST be the OUTERMOST form (the canonical
           ;; `(if interop/debug-enabled? <stamped> <plain>)` shape per Spec
           ;; 009 §Production builds), NOT an `(and interop/debug-enabled?
           ;; ...)` test in a `cond->` step. A `cond->` test-position gate
           ;; leaves the `:rf.trace/call-site` keyword literal reachable in
           ;; the assoc form — Closure does not constant-fold it away under
-          ;; `:advanced` + `goog.DEBUG=false`, so the keyword survived into
-          ;; production bundles (caught by the elision-probe once the frame-
-          ;; registration path was rooted — see
-          ;; `re-frame.elision-probe/touch-teardown!`). Splitting the gate
-          ;; to the outermost `if` lets DCE prove the whole dev arm dead.
+          ;; `:advanced` + `goog.DEBUG=false`, so the keyword leaks into
+          ;; production bundles (the elision-probe catches it via the rooted
+          ;; frame-registration path — see
+          ;; `re-frame.elision-probe/touch-teardown!`). The outermost `if`
+          ;; lets DCE prove the whole dev arm dead.
           (when-let [on-create (:on-create config)]
             (let [init-opts (if interop/debug-enabled?
                               (cond-> {:frame  id
@@ -1413,7 +1395,7 @@
         ;; Re-registration: surgical update of replaceable slots only.
         ;; Per Spec 002 §Re-registration — surgical update.
         :else
-        (let [;; EP-0024 (rf2-tu2vr7): idempotent replacement — re-`make-frame`
+        (let [;; EP-0024: idempotent replacement — re-`make-frame`
               ;; threads the freshly-resolved generation under the reserved
               ;; `:rf.frame/generation` config key. Refresh the `:generation`
               ;; slot from it (a re-make WITH new `:images` swaps the running
@@ -1427,41 +1409,39 @@
               stored-config (dissoc config :rf.frame/generation :rf.frame/initial-db)]
           (swap! frames update id
                  assoc :config stored-config :generation (get config :rf.frame/generation))
-          ;; EP-0015 §3 (rf2-ueg1tn): re-registration REPLACES frame-owned
+          ;; EP-0015 §3: re-registration REPLACES frame-owned
           ;; classification — the declaration IS the frame's policy (no
           ;; additive merge). `install!` drops the prior `:source :frame`
           ;; elision entries and overlays the new ones; schema- and
           ;; marks-sourced declarations survive. A re-registration that
           ;; DROPS its classification clears the prior frame-sourced entries
           ;; (absent-key clears, per Spec 002 §Re-registration). Runtime
-          ;; state (app-db, sub-cache, queue) is preserved as ever.
+          ;; state (app-db, sub-cache, queue) is preserved.
           (install-classification!)
           (trace/emit! :rf.frame :rf.frame/re-registered
                        {:frame id :config stored-config})
           id)))))
 
 (defn make-anon-frame-record!
-  "INTERNAL anonymous-instance creation (EP-0024, rf2-tu2vr7): generate a
+  "INTERNAL anonymous-instance creation (EP-0024): generate a
   gensym'd id under `:rf.frame/`, register a configured record under it, and
   return the gensym'd id. This is NOT a public constructor — the ONE public
   constructor is `re-frame.live-frame/make-frame` (`rf/make-frame`), which
   accepts both image-selection AND record-config opts and returns the frame
-  VALUE. This id-returning record helper survives as the internal no-`:id`
+  VALUE. This id-returning record helper is the internal no-`:id`
   configured-record path the unified constructor and the test/SSR harnesses build
   on. Per Spec 002 §Per-instance frames.
 
-  rf2-ji3tvy — RENAMED from the bare `make-frame` so the internal record helper
-  no longer COLLIDES by short name with the public `re-frame.live-frame/make-frame`
-  (the frame-VALUE constructor): a reader who saw `frame/make-anon-frame-record!` could not tell
-  from the call which one ran. The `-record!` suffix names exactly what it
-  returns — an anonymous gensym-keyed RECORD's id, not a frame value."
+  The `-record!` suffix names exactly what it returns — an anonymous gensym-keyed
+  RECORD's id, not a frame value — so it never reads as the public
+  `re-frame.live-frame/make-frame` (the frame-VALUE constructor) at a call site."
   [config]
   (let [id (keyword "rf.frame" (str (gensym "")))]
     (reg-frame id config)
     id))
 
 (defn make-frame-value
-  "Build a live frame VALUE for frame id `runnable-id` (EP-0024, rf2-tu2vr7) —
+  "Build a live frame VALUE for frame id `runnable-id` (EP-0024) —
   the lifecycle token `make-frame` returns. INTERNAL: the value carries the
   `:rf.frame/object` marker, its `:rf.frame/runnable-id` (= the id its record is
   keyed by), and the public `:rf.frame/id` + the creation inputs
@@ -1488,7 +1468,7 @@
 ;; Frame id of the in-flight `destroy-frame!`, bound for the duration of
 ;; the teardown so `safe-call-hook!` can stamp `:frame` on a hook-failure
 ;; diagnostic regardless of the hook's arg shape (the cache-reset hooks
-;; take no frame arg). Per rf2-x3m8c.
+;; take no frame arg).
 (def ^:dynamic *destroying-frame-id* nil)
 
 ;; Per-destroy accumulator of cleanup-hook failures, bound to a fresh atom
@@ -1503,7 +1483,7 @@
 ;; the entries collected so far are already in the atom and the `finally`
 ;; boundary still flushes them (EP-0008 R1 / Spec 009 §Emit-safety —
 ;; finally-shaped flush). nil outside a destroy (defensive — `safe-call-hook!`
-;; only conj's when bound). Per rf2-ini4wr.
+;; only conj's when bound).
 (def ^:dynamic *teardown-hook-failures* nil)
 
 ;; Pre-cascade frame-state snapshot of the in-flight dequeued event, bound by
@@ -1512,15 +1492,15 @@
 ;; INSIDE that binding, so `destroy-frame!` can recover the whole frame-state
 ;; (both partitions) held BEFORE the in-flight event's cascade began — the
 ;; `:frame-state-before` slot the `:halted-destroy` epoch record carries per
-;; Spec-Schemas §`:rf/epoch-record` §Outcomes (rf2-9neiq). EP-0001
-;; (rf2-3aizt1, decision #2): the canonical snapshot unit is the whole
-;; frame-state; the epoch derives `:db-before` from its app-db projection.
+;; Spec-Schemas §`:rf/epoch-record` §Outcomes. The canonical snapshot unit is
+;; the whole frame-state; the epoch derives `:db-before` from its app-db
+;; projection.
 ;; nil outside a drain (an out-of-cascade `destroy-frame!` — hot-reload,
 ;; `reset-frame!`, REPL — commits no `:halted-destroy` record, so the slot
 ;; is moot there).
 (def ^:dynamic *cascade-frame-state-before* nil)
 
-;; rf2-bh56rc: the in-flight dequeued event's causal `:rf/time-ms` (the
+;; The in-flight dequeued event's causal `:rf/time-ms` (the
 ;; `:rf.cofx` `:rf/time-ms` stamped on its envelope at the causal
 ;; boundary), bound by the router around `process-event!` alongside
 ;; `*cascade-frame-state-before*`. A handler that calls `destroy-frame!`
@@ -1538,7 +1518,7 @@
   failure is NOT silent. On a throw we do TWO things, on two distinct
   Spec 009 observability channels:
 
-    1. ALWAYS-ON axis (EP-0008 R1, rf2-ini4wr) — conj the failure entry
+    1. ALWAYS-ON axis (EP-0008 R1) — conj the failure entry
        (`{:hook <key> :exception <ex> :where :safe-call-hook!}`) onto the
        per-destroy `*teardown-hook-failures*` accumulator. `destroy-frame!`
        flushes the accumulated entries as ONE bounded
@@ -1550,7 +1530,7 @@
        which-hooks-failed-together correlation (Spec 009 §Channel-
        promotion catalogue rows).
 
-    2. DIAGNOSTIC channel (EP-0008 R2, rf2-x3m8c) — emit the per-hook
+    2. DIAGNOSTIC channel (EP-0008 R2) — emit the per-hook
        `:rf.warning/teardown-hook-exception` trace at its CAUSAL position
        carrying the hook key, the in-flight frame id (`*destroying-frame-
        id*`), and the exception, so a leaked optional-artefact cleanup
@@ -1583,19 +1563,19 @@
 (defn- emit-on-destroy-handler-exception!
   "Surface `:rf.error/on-destroy-handler-exception` through BOTH the
   ALWAYS-ON error-emit axis (production-survivable) AND the dev-only trace
-  surface. Per EP-0008 (rf2-7b9r4l): the dedicated `:on-destroy`-throw
+  surface. Per EP-0008: the dedicated `:on-destroy`-throw
   category is the DISCRIMINABLE teardown signal — an operator on a
   `goog.DEBUG=false` host must be able to tell 'this throw happened during
   destroy' from a generic `:rf.error/handler-exception`. The router's
   `:rf.error/handler-exception` is the production source of record for the
-  *handler throw*, but the discriminator (it was an `:on-destroy`) was
-  previously LOST under elision (the dedicated category rode only the DCE'd
-  `trace/emit-error!`). It now rides the always-on axis too.
+  *handler throw*; the discriminator (it was an `:on-destroy`) rides the
+  always-on axis too so it survives elision rather than riding only the DCE'd
+  `trace/emit-error!`.
 
-  This is also the ONLY always-on coverage for the rf2-bxud9v defence-in-
-  depth re-throw branch (`dispatch-sync!` itself faulting): that path never
-  produced a router `:rf.error/handler-exception`, so before this promotion
-  it had ZERO production observability.
+  This is also the ONLY always-on coverage for the defence-in-depth re-throw
+  branch (`dispatch-sync!` itself faulting): that path never produces a router
+  `:rf.error/handler-exception`, so the always-on emission here is its only
+  production observability.
 
   `frame` cannot static-require `re-frame.error-emit` (the always-on error
   substrate sits above frame in the load order — a static require closes a
@@ -1628,7 +1608,7 @@
 (defn- fire-on-destroy-event!
   "Run the user-supplied `:on-destroy` event synchronously, then continue
   teardown regardless of outcome. Per Spec 002 §Destroy — `:on-destroy`
-  handler throw semantics (rf2-r1ciy decision b): a throw from the user's
+  handler throw semantics: a throw from the user's
   handler MUST NOT abort teardown. Emit `:rf.error/on-destroy-handler-exception`
   through the always-on error-emit axis AND the dev trace
   (`emit-on-destroy-handler-exception!`) and continue — every downstream
@@ -1641,18 +1621,17 @@
   surface the throw as the dedicated `:rf.error/on-destroy-handler-
   exception` category (Mike's decision), we install a TRANSIENT listener
   on the ALWAYS-ON error-emit axis for the duration of the dispatch under a
-  UNIQUE per-destroy key (rf2-ntv9i9.1 — a constant key let a nested /
-  overlapping destroy clobber the outer's listener and drop its dedicated
-  record): any `:rf.error/handler-exception` record whose `:frame` matches us
-  is captured and re-emitted under the new category. The always-on axis is
-  the one surface the router's handler-exception fan-out ALSO rides
+  UNIQUE per-destroy key (a constant key would let a nested / overlapping
+  destroy clobber the outer's listener and drop its dedicated record): any
+  `:rf.error/handler-exception` record whose `:frame` matches us is captured
+  and re-emitted under the dedicated category. The always-on axis is the one
+  surface the router's handler-exception fan-out ALSO rides
   (`re-frame.router/emit-pipeline-exception!` → `error-emit/dispatch-on-
-  error!`), so this capture survives `:advanced` + `goog.DEBUG=false`
-  where the dev trace is DCE'd (rf2-87f7fb — the pre-EP-0008 capture
-  observed the dev-only `trace.tooling` listener registry, which no-ops
-  in production, so the dedicated discriminator did NOT survive prod for
-  the common path despite the Spec 009 catalogue promising it does). We
-  reach the registry through the `:error-emit/register-error-listener!` /
+  error!`), so this capture survives `:advanced` + `goog.DEBUG=false` where the
+  dev trace is DCE'd — observing the dev-only `trace.tooling` listener registry
+  (which no-ops in production) instead would not survive prod despite the Spec
+  009 catalogue promising it does. We reach the registry through the
+  `:error-emit/register-error-listener!` /
   `:error-emit/unregister-error-listener!` late-bind hooks because a
   static `re-frame.frame` → `re-frame.error-emit` require closes the
   `error-emit` → `elision` → `frame` load cycle (the same reason the
@@ -1661,8 +1640,8 @@
   We ALSO wrap the dispatch itself in try/catch as a defence-in-depth: if
   `dispatch-sync!` ever re-throws (e.g. a fault inside the dispatch
   infrastructure itself, not the user handler), we catch it here — and
-  per EP-0008 (rf2-7b9r4l) the dedicated category now rides the always-on
-  axis so this defence-in-depth branch (which never produced a router
+  per EP-0008 the dedicated category rides the always-on axis so this
+  defence-in-depth branch (which never produces a router
   `:rf.error/handler-exception`) is observable in production. The two
   paths are mutually exclusive (a router-converted handler throw never
   re-throws out of `dispatch-sync!`; an infra fault re-throws and never
@@ -1687,9 +1666,9 @@
             ;; guard keeps the install defensive regardless.
             register     (late-bind/get-fn :error-emit/register-error-listener!)
             remove-cb    (late-bind/get-fn :error-emit/unregister-error-listener!)
-            ;; rf2-ntv9i9.1: a UNIQUE per-destroy listener key — NOT a constant.
+            ;; A UNIQUE per-destroy listener key — NOT a constant.
             ;; A nested / overlapping destroy (an `:on-destroy` that destroys a
-            ;; different frame, Spec 002 rf2-r1ciy) would otherwise clobber the
+            ;; different frame, Spec 002) would otherwise clobber the
             ;; outer destroy's listener under a shared key and drop the outer's
             ;; dedicated `:on-destroy-handler-exception`. A fresh key per call
             ;; gives each extent its own listener.
@@ -1710,9 +1689,9 @@
               ;; Defence-in-depth: dispatch-sync! normally swallows
               ;; handler throws, but if the dispatch infrastructure
               ;; itself fails we still emit the dedicated category. This
-              ;; branch never produced a router :rf.error/handler-exception,
+              ;; branch never produces a router :rf.error/handler-exception,
               ;; so the always-on emission here is its ONLY production
-              ;; observability (EP-0008, rf2-7b9r4l).
+              ;; observability (EP-0008).
               (reset! infra-fault? true)
               (emit-on-destroy-handler-exception! id on-destroy ex nil)))
           (finally
@@ -1722,8 +1701,8 @@
         ;; `:rf.error/handler-exception` record, re-emit under the
         ;; dedicated :on-destroy category so consumers can discriminate
         ;; teardown failures from regular handler throws. Rides the
-        ;; always-on axis (EP-0008, rf2-7b9r4l) so the discriminable
-        ;; teardown signal survives `goog.DEBUG=false` (rf2-87f7fb). The
+        ;; always-on axis (EP-0008) so the discriminable
+        ;; teardown signal survives `goog.DEBUG=false`. The
         ;; `infra-fault?` guard keeps the single-record contract explicit
         ;; — the defence-in-depth arm above already emitted in that case.
         (when (and (not @infra-fault?) @captured)
@@ -1737,7 +1716,7 @@
 (defn- notify-machine-destruction!
   "Frame-destroy machine-cascade entry-point.
 
-  Per rf2-vsigt — Spec 005 §Cross-Spec Interactions §1: when the
+  Per Spec 005 §Cross-Spec Interactions §1: when the
   machines artefact is loaded, delegate the full cascade
   (reverse-creation walk, per-machine `:exit` cascade, HTTP abort,
   unified teardown projection, system-id release, handler unregister)
@@ -1745,8 +1724,8 @@
   hook is published by `re-frame.machines` so core never statically
   requires the optional machines artefact.
 
-  Fallback (no machines artefact on the classpath): preserve the
-  legacy minimal behaviour — fire the `:http/abort-on-actor-destroy`
+  Fallback (no machines artefact on the classpath): the minimal contract —
+  fire the `:http/abort-on-actor-destroy`
   hook per snapshot key and emit `:rf.machine.lifecycle/destroyed`
   with `:reason :parent-frame-destroyed`. Without the machines
   artefact there are no live `:exit` cascades to run, no actor
@@ -1755,7 +1734,7 @@
   (if-let [teardown! (late-bind/get-fn :machines/teardown-on-frame-destroy!)]
     (teardown! id)
     ;; Fallback path — minimal contract when the machines artefact is absent.
-    ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
+    ;; EP-0001: machine snapshots are durable runtime-db state.
     (let [container  (runtime-db-container id)
           rt         (when container (adapter/read-container container))
           machines   (get-in rt [:rf.runtime/machines :snapshots])
@@ -1766,7 +1745,7 @@
                (catch #?(:clj Throwable :cljs :default) _ nil)))
         (trace/emit! :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed
                      {:frame      id
-                      ;; rf2-ws5thu — the reaped actor's live INSTANCE address;
+                      ;; The reaped actor's live INSTANCE address;
                       ;; `:machine-id` is reserved for the registered TYPE. Must
                       ;; match the machines-artefact orchestrator emit
                       ;; (`lifecycle-fx/frame-destroy/emit-lifecycle-destroyed!`)
@@ -1777,21 +1756,20 @@
                       :reason     :parent-frame-destroyed})))))
 
 (defn- mark-frame-destroyed!
-  ;; The `frames` registry is keyed by the bare frame-id (rf2-upgtq4 — the
-  ;; realm-addressing dimension was collapsed), so flip `:destroyed?` on that
-  ;; record.
+  ;; The `frames` registry is keyed by the bare frame-id, so flip `:destroyed?`
+  ;; on that record.
   [id]
   (swap! frames update id assoc-in [:lifecycle :destroyed?] true))
 
 (defn- tear-down-sub-cache!
   "Dispose every cached subscription reaction for the destroyed frame.
 
-  Per rf2-x3m8c: route through the sub-cache-owned
+  Route through the sub-cache-owned
   `:subs.cache/dispose-all-for-frame-destroy!` hook so each eviction
   emits a `:rf.sub/dispose` trace (reason `:frame-destroy`) — frame
   teardown is a real eviction class and MUST appear in the sub-cache
   lifecycle stream like `unsubscribe` / hot-reload / `clear-sub-cache!`
-  do (the bypass that disposed reactions directly was invisible to
+  do (disposing reactions directly would be invisible to
   tooling). `subs.cache` requires `frame` (this ns), so the call is
   late-bound to keep the dependency one-directional. The fallback
   (hook unbound — only reachable if `re-frame.subs.cache` was never
@@ -1811,7 +1789,7 @@
 (defn- tear-down-partition-projections!
   "Dispose the two partition projection reactions (`:app-db` /
   `:runtime-db`) that `make-derived-value` layered over the physical
-  frame-state container (rf2-adwcv6). Each projection holds a watch on the
+  frame-state container. Each projection holds a watch on the
   physical container (on the React-hook / plain-atom spine) or a Reagent
   reaction; left undisposed across a `destroy-frame!`, those watches /
   reactions leak in long-lived processes (test bundles, SSR per-request
@@ -1830,24 +1808,23 @@
                {:frame id}))
 
 (defn- dissoc-frame!
-  ;; The frame record is keyed by the bare frame-id (rf2-upgtq4 — the realm-
-  ;; addressing dimension was collapsed); removing it is a plain dissoc.
+  ;; The frame record is keyed by the bare frame-id; removing it is a plain
+  ;; dissoc.
   [id]
   (swap! frames dissoc id))
 
 (defn- unregister-frame!
-  ;; The `:frame` registrar slot lives in the process-global registrar (the
-  ;; realm substrate is single-default-only and the realm-addressing dimension
-  ;; was collapsed, rf2-upgtq4), so the unregister is a plain registrar call.
+  ;; The `:frame` registrar slot lives in the process-global registrar, so the
+  ;; unregister is a plain registrar call.
   [id]
   (registrar/unregister! :frame id))
 
 (defn- notify-epoch-listeners!
   "Fire the epoch destroy hook, threading the two frame-state snapshots the
   `:halted-destroy` epoch record carries per Spec-Schemas §`:rf/epoch-record`
-  §Outcomes (rf2-9neiq). EP-0001 (rf2-3aizt1, decision #2): the canonical
-  snapshot unit is the whole frame-state (both partitions); the epoch surface
-  derives the `:db-before` / `:db-after` app-db projections from them.
+  §Outcomes. The canonical snapshot unit is the whole frame-state (both
+  partitions); the epoch surface derives the `:db-before` / `:db-after` app-db
+  projections from them.
 
     `fs-before` — the pre-cascade snapshot (frame-state before the in-flight
                   event's cascade began), recovered from the router-bound
@@ -1861,10 +1838,10 @@
 
   Both snapshots are captured BEFORE the frame is removed and passed
   explicitly so the epoch surface (which fires AFTER `dissoc-frame!`,
-  step 6) does not have to read a container that is already gone — the
-  root cause of the prior nil-`:db-before` / nil-`:db-after` records.
+  step 6) does not have to read a container that is already gone — reading it
+  there would yield nil-`:db-before` / nil-`:db-after` records.
 
-  `committed-at` (rf2-bh56rc) is the destroying event's causal `:rf/time-ms`
+  `committed-at` is the destroying event's causal `:rf/time-ms`
   (the router-bound `*cascade-time-ms*`), threaded so the `:halted-destroy`
   record's `:committed-at` is replayable per EP-0010 §Time rather than an
   ambient host-clock read. nil outside a drain (the moot out-of-cascade
@@ -1880,7 +1857,7 @@
     2. notify-machine-destruction!  — per Spec 005 §Cross-Spec Interactions §1:
                                       delegates to the machines artefact's
                                       `:machines/teardown-on-frame-destroy!`
-                                      hook (rf2-vsigt). That walks each
+                                      hook. That walks each
                                       active machine in reverse-creation
                                       order: runs the `:exit` cascade
                                       against a live container, applies
@@ -1900,7 +1877,7 @@
                                       frame-destroy!` hook, so each
                                       eviction emits `:rf.sub/dispose`
                                       with `:rf.sub/reason
-                                      :frame-destroy` (rf2-x3m8c).
+                                      :frame-destroy`.
     *. cleanup hooks (best-effort, no-op when artefact absent):
          :elision/clear-warning-cache!      — reset schema-first elision
                                               warning cache.
@@ -1910,23 +1887,20 @@
                                               artefact's frame-scoped
                                               `:after` timer table.
          :schemas/on-frame-destroyed!       — drop schemas registered
-                                              against this frame
-                                              (rf2-wkxng / rf2-6m0se).
+                                              against this frame.
          :flows/teardown-on-frame-destroy!  — drop flows + last-inputs
                                               rows + dead `:flow`
-                                              registrar slots
-                                              (rf2-wbtjn).
+                                              registrar slots.
          :routing/on-frame-destroyed!       — release the frame's
                                               host-side transient routing
-                                              caches — scroll positions
-                                              (rf2-1hncp2) + nav-token /
-                                              pending-nav counters
-                                              (rf2-oosjmh).
+                                              caches — scroll positions +
+                                              nav-token / pending-nav
+                                              counters.
          :resources/on-frame-destroyed!     — release the frame's
                                               host-side transient resource
                                               caches — work-ledger host
                                               handles + generation
-                                              high-water mark (rf2-afpdkn).
+                                              high-water mark.
     5. emit-frame-destroyed-trace!  — emit :frame/destroyed AFTER the
                                       machine cascade.
     6. dissoc-frame!                — remove from the `frames` atom.
@@ -1942,14 +1916,12 @@
                                       epoch record carries real
                                       :frame-state-before / :frame-state-after
                                       (and their :db-* app-db projections) per
-                                      Spec-Schemas §:rf/epoch-record §Outcomes
-                                      (rf2-9neiq / rf2-3aizt1) — not the prior
-                                      nil/nil.
+                                      Spec-Schemas §:rf/epoch-record §Outcomes.
 
   Subsequent dispatch / subscribe against a destroyed frame raises
   :rf.error/frame-destroyed.
 
-  Re-entrancy (rf2-r1ciy): if `destroy-frame!` is called for `id` while
+  Re-entrancy: if `destroy-frame!` is called for `id` while
   an outer `destroy-frame!` for the same `id` is still on the stack
   (e.g. the user's `:on-destroy` handler itself calls `destroy-frame!`,
   or a machine `:exit` cascade does so), the re-entrant call is a
@@ -1961,24 +1933,22 @@
   circuits at the outer `when-let`); the in-flight guard closes the
   RE-ENTRANT window before `mark-frame-destroyed!` flips the flag.
 
-  EP-0024 (rf2-tu2vr7): the target may be a frame-id KEYWORD or a frame VALUE
+  EP-0024: the target may be a frame-id KEYWORD or a frame VALUE
   (`rf/make-frame`'s return token). A value is normalized to its id via
   `frame-target->id` so the whole recipe keys the ONE registry's record
-  unchanged; `dissoc-frame!` IS the forget (the resolved generation rode the
-  record, dropped with it — no second registry, no `:live-frame/forget!` hook)."
+  unchanged; `dissoc-frame!` IS the forget (the resolved generation rides the
+  record, dropped with it — one registry, no separate forget hook)."
   [target]
-  ;; EP-0024 (rf2-tu2vr7): accept a frame VALUE or a frame-id keyword. Normalize
-  ;; a value to its id so every keyed teardown step below targets the record; a
-  ;; keyword passes through unchanged.
+  ;; Accept a frame VALUE or a frame-id keyword. Normalize a value to its id so
+  ;; every keyed teardown step below targets the record; a keyword passes
+  ;; through unchanged.
   (let [id (frame-target->id target)]
   ;; Re-entrancy guard: short-circuit if we're already destroying this id.
-  ;; Silent no-op (idempotent destroy is already a no-op pattern; no new
-  ;; trace event needed per rf2-r1ciy decision).
-  ;; The registry is keyed by the bare frame-id (rf2-upgtq4 — the realm-
-  ;; addressing dimension was collapsed; the realm substrate is single-default-
-  ;; only), so every keyed teardown step (the in-flight guard,
-  ;; `mark-frame-destroyed!`, `dissoc-frame!`, the registrar unregister) targets
-  ;; the frame-id-keyed record directly — no realm binding to thread.
+  ;; Silent no-op (idempotent destroy is a no-op pattern; no new trace event
+  ;; needed).
+  ;; The registry is keyed by the bare frame-id, so every keyed teardown step
+  ;; (the in-flight guard, `mark-frame-destroyed!`, `dissoc-frame!`, the
+  ;; registrar unregister) targets the frame-id-keyed record directly.
   (when-let [f (frame id)]
       (when-not (contains? @destroying-frames id)
       (swap! destroying-frames conj id)
@@ -1988,19 +1958,18 @@
       ;; the container is gone entirely. Reading it here yields the state
       ;; the partial cascade left the frame in at the moment destroy was
       ;; requested — the `:frame-state-after` slot the `:halted-destroy`
-      ;; epoch record carries (rf2-9neiq). The pre-cascade
-      ;; `:frame-state-before` rides the router-bound
-      ;; `*cascade-frame-state-before*` dynamic var (nil outside a drain).
-      ;; Both are passed to `notify-epoch-listeners!` (step 8). EP-0001
-      ;; (rf2-3aizt1, decision #2): the whole frame-state, both partitions.
+      ;; epoch record carries. The pre-cascade `:frame-state-before` rides the
+      ;; router-bound `*cascade-frame-state-before*` dynamic var (nil outside a
+      ;; drain). Both are passed to `notify-epoch-listeners!` (step 8): the
+      ;; whole frame-state, both partitions.
       (let [cascade-fs-before *cascade-frame-state-before*
-            ;; rf2-bh56rc: the destroying event's causal `:time-ms`, bound by
+            ;; The destroying event's causal `:time-ms`, bound by
             ;; the router alongside `*cascade-frame-state-before*`. Threaded to
             ;; the epoch hook so the `:halted-destroy` record's `:committed-at`
             ;; is replayable (per EP-0010 §Time). nil outside a drain.
             cascade-time-ms   *cascade-time-ms*
             fs-at-destroy     (frame-state-value id)
-            ;; EP-0008 R1 (rf2-ini4wr): per-destroy accumulator for
+            ;; EP-0008 R1: per-destroy accumulator for
             ;; cleanup-hook failures. `safe-call-hook!` conj's an entry per
             ;; failed hook; the finally-shaped flush below ships them as ONE
             ;; always-on `:rf.error/frame-teardown-failed` report. Held in a
@@ -2015,7 +1984,7 @@
         (notify-machine-destruction! id)
         (mark-frame-destroyed! id)
         (tear-down-sub-cache! id f)
-        ;; Dispose the app-db / runtime-db projection reactions (rf2-adwcv6)
+        ;; Dispose the app-db / runtime-db projection reactions
         ;; AFTER the sub-cache (the sub-cache's layer-1 reactions watch the
         ;; app-db projection; disposing the projection first would orphan
         ;; their source watch). The projections watch the physical
@@ -2024,33 +1993,31 @@
         (safe-call-hook! :elision/clear-warning-cache!)
         (safe-call-hook! :ssr/on-frame-destroyed id)
         (safe-call-hook! :machines/on-frame-destroyed! id)
-        ;; Per rf2-wkxng / rf2-6m0se: drop every schema registered against
+        ;; Drop every schema registered against
         ;; the destroyed frame so a re-registered frame starts with a
         ;; clean schema slate. Without this hook, orphan app-db schemas
         ;; from a prior `reg-frame` cycle persist and re-fire under the
         ;; rollback contract — manifesting as spurious rollbacks against
         ;; paths the new frame's :on-create never wrote. No-op when
-        ;; re-frame.schemas is absent (the artefact is optional per
-        ;; rf2-p7va).
+        ;; re-frame.schemas is absent (the artefact is optional).
         (safe-call-hook! :schemas/on-frame-destroyed! id)
-        ;; Per rf2-wbtjn: drop every flow registered against the destroyed
+        ;; Drop every flow registered against the destroyed
         ;; frame plus its cached `last-inputs` rows, and prune the
         ;; `:flow` registrar slot when the destroyed frame was the last
-        ;; owner. Symmetric with the machines teardown hook above
-        ;; (rf2-vsigt). Without this hook a long-running SSR JVM with
+        ;; owner. Symmetric with the machines teardown hook above.
+        ;; Without this hook a long-running SSR JVM with
         ;; per-request frame churn grows the flow registry unboundedly.
-        ;; This hook does NOT scrub the frame's flow-output elision marks
-        ;; (rf2-yt5bbl): those live in the runtime-db partition INSIDE the
+        ;; This hook does NOT scrub the frame's flow-output elision marks:
+        ;; those live in the runtime-db partition INSIDE the
         ;; `:frame-state` container, which `dissoc-frame!` (step 6 below)
         ;; drops wholesale with the frame record — a per-flow scrub here
         ;; would be redundant work over about-to-be-GC'd state, and a reused
         ;; frame-id gets a fresh empty container so no stale flow-sourced
         ;; declaration survives the cycle (see the flows
         ;; `teardown-on-frame-destroy!` docstring).
-        ;; No-op when re-frame.flows is absent (the artefact is optional
-        ;; per rf2-tfw3).
+        ;; No-op when re-frame.flows is absent (the artefact is optional).
         (safe-call-hook! :flows/teardown-on-frame-destroy! id)
-        ;; rf2-1hncp2 + rf2-oosjmh: release the destroyed frame's host-side
+        ;; Release the destroyed frame's host-side
         ;; transient routing caches — scroll positions
         ;; (re-frame.routing.scroll) AND the nav-token / pending-nav counter
         ;; high-water marks (re-frame.routing.nav-counters). Neither is
@@ -2061,7 +2028,7 @@
         ;; one entry per destroyed frame in each cache. No-op when
         ;; re-frame.routing is absent (the artefact is optional).
         (safe-call-hook! :routing/on-frame-destroyed! id)
-        ;; rf2-afpdkn: release the destroyed frame's host-side transient
+        ;; Release the destroyed frame's host-side transient
         ;; RESOURCE caches — the work-ledger host handles
         ;; (re-frame.resources.work-ledger/handle-table, the AbortControllers
         ;; / timer handles keyed by [frame-id work-id]) AND the resource
@@ -2073,14 +2040,11 @@
         ;; ride the dropped frame value. Without this hook a long-running
         ;; multi-frame / per-request-frame process leaks one entry per
         ;; destroyed frame in each host cache. No-op when re-frame.resources
-        ;; is absent (the artefact is optional, post-v1).
+        ;; is absent (the artefact is optional).
         (safe-call-hook! :resources/on-frame-destroyed! id)
-        ;; rf2-f8ztaj: the realm-owned host-transient inventory hatch was
-        ;; REMOVED (no production subsystem ever registered a descriptor; the
-        ;; shipped subsystems tear down via the named ordered hooks above). The
-        ;; per-frame inventory walk that used to run here is gone with it.
+        ;; The shipped subsystems tear down via the named ordered hooks above.
         (emit-frame-destroyed-trace! id)
-        ;; Per Spec 009 §Per-frame trace rings (rf2-g1b2m / rf2-8uwce):
+        ;; Per Spec 009 §Per-frame trace rings:
         ;; release the destroyed frame's cascade-keyed ring so no
         ;; residual trace events leak across the frame lifecycle. Fired
         ;; AFTER `:rf.frame/destroyed` emits so the destroyed trace
@@ -2088,18 +2052,16 @@
         ;; still flows through the live stream cleanly. Routed via
         ;; late-bind so production CLJS bundles (no trace.tooling) no-op.
         (safe-call-hook! :trace.tooling/release-frame-ring! id)
-        ;; EP-0024 (rf2-tu2vr7): the live-frame collapse removed the second
-        ;; PUBLIC live-frame registry — there is ONE `frames` registry, and
-        ;; `dissoc-frame!` below IS the forget. The frame's resolved generation
-        ;; rode the record's `:generation` slot, so dropping the record drops it
-        ;; too; the former `:live-frame/forget!` teardown hook (whose only job
-        ;; was keeping the second registry coherent) is dissolved.
+        ;; EP-0024: there is ONE `frames` registry, and `dissoc-frame!` below IS
+        ;; the forget. The frame's resolved generation rides the record's
+        ;; `:generation` slot, so dropping the record drops it too — no separate
+        ;; forget hook is needed.
         (dissoc-frame! id)
         (unregister-frame! id)
         (notify-epoch-listeners! id cascade-fs-before fs-at-destroy cascade-time-ms)
         nil
         (finally
-          ;; EP-0008 R1 (rf2-ini4wr) — FINALLY-shaped flush of the always-on
+          ;; EP-0008 R1 — FINALLY-shaped flush of the always-on
           ;; teardown report. If any cleanup hook threw (entries accumulated
           ;; in `hook-failures`), ship ONE bounded
           ;; `:rf.error/frame-teardown-failed` record carrying the
@@ -2127,10 +2089,8 @@
 
 (defn reset-frame!
   "destroy-frame! followed by reg-frame with the same config. Per Spec 002
-  §reset-frame! — full replace, opt-in. The realm-addressing dimension was
-  collapsed (rf2-upgtq4 — the realm substrate is single-default-only), so the
-  destroy + re-register target the frame-id-keyed record directly with no realm
-  binding to thread."
+  §reset-frame! — full replace, opt-in. The destroy + re-register target the
+  frame-id-keyed record directly."
   [id]
   (when-let [f (frame id)]
     (let [config (:config f)]
@@ -2139,21 +2099,19 @@
 
 ;; ---- :rf/default — TEST-ONLY fixture helper -------------------------------
 ;;
-;; Per Spec 002 §`:rf/default` is an ordinary id (EP-0002): `:rf/default`
+;; Per Spec 002 §`:rf/default` is an ordinary id: `:rf/default`
 ;; is NOT created by `init!`, is NOT the React-context default, is NOT a
 ;; lookup tier, and is NOT inferred from a missing stamp. The runtime never
-;; synthesises it. `init!` no longer calls this.
+;; synthesises it.
 ;;
-;; This helper survives ONLY as a convenience for TEST FIXTURES that pin
+;; This helper is a convenience for TEST FIXTURES that pin
 ;; `*current-frame*` to `:rf/default` and dispatch ambiently — the standard
 ;; `re-frame.test-support/make-reset-runtime-fixture` and the per-suite
 ;; reset-runtime fixtures across the adapter / SSR test trees call it to
 ;; establish a known default scope. It is a TEST PATH, not a runtime path:
-;; no production / SSR code reaches it, and the chain's later call-site
-;; beads (EP-0002 §3+) migrate real ambient call sites to carry an explicit
-;; frame. Kept (rather than deleted) because removing it would break those
-;; out-of-scope test fixtures wholesale; the name + this banner make the
-;; test-only intent unambiguous.
+;; no production / SSR code reaches it (real ambient call sites carry an
+;; explicit frame). The name + this banner make the test-only intent
+;; unambiguous.
 
 (defn ensure-default-frame!
   "TEST-ONLY fixture helper. Register the ordinary `:rf/default` frame if
@@ -2161,7 +2119,7 @@
   `:rf/default` and dispatches ambiently has a frame to land on.
 
   NOT a runtime path — `init!` does NOT call this (per Spec 002
-  §`:rf/default` is an ordinary id, EP-0002: the runtime never synthesises
+  §`:rf/default` is an ordinary id: the runtime never synthesises
   a default frame). Application / SSR boot code that wants a default-named
   app frame registers it explicitly via `(rf/reg-frame :rf/default {…})`."
   []

--- a/implementation/core/src/re_frame/frame_classification.cljc
+++ b/implementation/core/src/re_frame/frame_classification.cljc
@@ -24,7 +24,7 @@
 
          :on-create [:app/init]})
 
-  ## What this slice owns (EP-0015 bead-plan item 3)
+  ## What this namespace owns
 
   This namespace is the frame metadata **schema + registry** for the three
   classification keys. It is the validation + install seam `reg-frame`
@@ -35,11 +35,10 @@
     registry (`[:rf.runtime/elision :sensitive-declarations]` /
     `[:rf.runtime/elision :declarations]`, Conventions §Reserved runtime-db
     keys) under `:source :frame` — the canonical durable app-db egress
-    route post-EP-0015 §8 (the `reg-app-schema` schema→app-db-egress route
-    is GONE; schemas describe shape, not durable app-db egress policy). The
-    only other source that can live in this registry is the demoted
+    route (per EP-0015 §8: schemas describe shape, not durable app-db egress
+    policy). The only other source that can live in this registry is the
     imperative-mark route (`:source :marks` — internal / test /
-    generated-code only, no longer public). A path declared by ANY source
+    generated-code only). A path declared by ANY source
     is classified: the sources union at lookup time. Re-registering a frame
     REPLACES the `:source :frame` entries (the declaration IS the frame's
     policy); any `:source :marks` entries survive untouched.
@@ -53,13 +52,13 @@
     the config; the `http-carriers` resolver (this ns) lowers them to
     lower-cased extension sets the HTTP privacy redactor unions onto the
     immutable built-in carrier denylist at trace-emit time, reached via the
-    `:frame-classification/http-carriers` late-bind hook (EP-0015 HTTP
-    slice, bead-plan item 8 — rf2-ppkh3v).
+    `:frame-classification/http-carriers` late-bind hook (EP-0015 §3, HTTP
+    carriers).
 
     `:headers` is vector-only — the header denylist is immutable (a
     default-off header would be a real leak). `:query-params` additionally
-    accepts a `{:include [..] :except [..]}` policy map (rf2-4wqxq8):
-    `:include` extends the defaults (as the legacy vector form does), and
+    accepts a `{:include [..] :except [..]}` policy map:
+    `:include` extends the defaults (as the plain vector form does), and
     `:except` SUBTRACTS denylisted names from the built-in defaults for
     THIS frame's own dev trace — effective policy `(defaults − except) ∪
     include`. All redaction is debug-gated trace surface (elided in
@@ -72,8 +71,7 @@
     sink policy, likewise retained on the frame's `:config`. This slice
     validates its shape (each entry a map naming a `:sink` keyword);
     ROUTING production records through the declared sinks — the EP-0015 §9
-    central claim — is now LIVE in `re-frame.observability` (bead-plan
-    item 7, rf2-t55hxg.7): the router fires
+    central claim — lives in `re-frame.observability`: the router fires
     `:observability/route-handled-event` once per processed event and
     `error-emit/dispatch-on-error!` fires `:observability/route-error` per
     `:rf.error/*` site, each projecting the record through `project-egress`
@@ -149,7 +147,7 @@
 ;; values. A well-formed declaration is a VECTOR of paths; each path is a
 ;; sequential collection of CONCRETE EDN segments (the empty path `[]` is
 ;; legal — it marks the whole app-db). `rf.path/normalize-concrete` is the
-;; EP-0012 VALIDATED concrete boundary (rf2-w9x5fv item 2): it canonicalises
+;; EP-0012 VALIDATED concrete boundary: it canonicalises
 ;; a sequential path to a vector AND fails closed with `:rf.error/bad-path`
 ;; on a non-sequential path OR any segment outside the concrete EDN domain
 ;; (an opaque host object, a function, a template-parameter segment). We
@@ -240,8 +238,8 @@
   denylist is immutable (no `:except` subtraction; a default-off header
   would be a real leak).
 
-  `:query-params` (rf2-4wqxq8) accepts EITHER:
-   - a vector of carrier-name strings — the legacy include-only form, OR
+  `:query-params` accepts EITHER:
+   - a vector of carrier-name strings — the include-only form, OR
    - a map `{:include [..] :except [..]}` — `:include` extends the defaults,
      `:except` subtracts from the built-in defaults for this frame's own dev
      trace. Both keys are optional; each (when present) is a vector of
@@ -253,7 +251,7 @@
   (cond
     (nil? names) nil
 
-    ;; rf2-4wqxq8 — query-params may carry a {:include :except} policy map.
+    ;; query-params may carry a {:include :except} policy map.
     (and (= :query-params carrier-key) (map? names))
     (do
       (doseq [k (keys names)]
@@ -354,7 +352,7 @@
              (str ":observability " stream " entries must carry a :sink "
                   "keyword id")
              {:bad-key [:observability stream :sink] :bad-entry entry})))
-  ;; rf2-t55hxg.13 — `:rf.egress/profile`, when present, must name a member
+  ;; `:rf.egress/profile`, when present, must name a member
   ;; of the closed EP-0015 §10 profile enum (`re-frame.projection/profiles`).
   ;; `projection.cljc`'s `resolve-elision-opts` already throws on an unknown
   ;; profile at egress time, but that is far downstream of registration — a
@@ -465,16 +463,16 @@
 ;;
 ;; Frame-owned app-db classification installs into `[:rf.runtime/elision …]`
 ;; tagged `:source :frame`. Re-registration REPLACES only the `:source :frame`
-;; entries; any `:source :marks` entries (the demoted imperative-mark route —
+;; entries; any `:source :marks` entries (the imperative-mark route —
 ;; `re-frame.marks`, internal / test only) survive untouched, and the sources
-;; union at lookup time. The schema→app-db-egress route is GONE (EP-0015 §8 —
-;; no `:source :schema` installer feeds this registry; schemas describe shape,
-;; not durable app-db egress policy). This mirrors how `re-frame.marks/set-marks`
-;; replaces only its own `:source :marks` entries.
+;; union at lookup time. No `:source :schema` installer feeds this registry
+;; (per EP-0015 §8: schemas describe shape, not durable app-db egress policy).
+;; This mirrors how `re-frame.marks/set-marks` replaces only its own
+;; `:source :marks` entries.
 
 (defn- without-frame-sourced
   "Drop `:source :frame` entries from a `{path decl}` declaration map,
-  preserving any other-sourced entries (the demoted `:source :marks` route).
+  preserving any other-sourced entries (the `:source :marks` route).
   Returns `{}` for nil."
   [decls]
   (reduce-kv (fn [acc p decl]
@@ -543,8 +541,8 @@
       {:headers      #{<lower-cased header name>...}
        :query-params <query-param policy>}
 
-  where the `:query-params` policy is (rf2-4wqxq8):
-   - a `#{<lower-cased name>...}` SET for the legacy include-only vector form
+  where the `:query-params` policy is:
+   - a `#{<lower-cased name>...}` SET for the include-only vector form
      (`:query-params [\"shop_token\"]`) — names EXTEND the built-in defaults; OR
    - a `{:include #{..} :except #{..}}` MAP for the `{:include [..] :except [..]}`
      form — `:include` extends the defaults, `:except` subtracts from them for
@@ -577,7 +575,7 @@
                          (cond-> {}
                            inc (assoc :include inc)
                            exc (assoc :except exc))))
-                     ;; legacy include-only vector → plain extension set
+                     ;; include-only vector → plain extension set
                      (->set raw-qs))]
             (when (or hs qs)
               (cond-> {}

--- a/implementation/core/src/re_frame/identity.cljc
+++ b/implementation/core/src/re_frame/identity.cljc
@@ -1,8 +1,8 @@
 (ns re-frame.identity
-  "Internal canonical-EDN-identity algebra (EP-0012, ACCEPTED ruling
-  rf2-s7xshi). The normative contract lives in [`spec/Conventions.md`
-  §Canonical EDN identity]; this namespace is the reference
-  implementation of the `CEDN-1` encoding.
+  "Internal canonical-EDN-identity algebra (EP-0012). The normative
+  contract lives in [`spec/Conventions.md` §Canonical EDN identity];
+  this namespace is the reference implementation of the `CEDN-1`
+  encoding.
 
   ## Status — INTERNAL (EP-0012 disposition 1)
 
@@ -95,7 +95,7 @@
   "True iff `n` is an integer inside the CEDN-1 portable safe-integer range
   `[-9007199254740991, 9007199254740991]` (the ECMAScript safe-integer
   range). This is the SHARED predicate the CEDN-1 encoder and the `:rf/path`
-  concrete-segment domain both key off (rf2-ujmc3u): the shared path
+  concrete-segment domain both key off: the shared path
   vocabulary MUST NOT be wider than canonical EDN identity, so an integer
   that cannot be portably compared / printed / routed / digested is not a
   valid concrete path segment either. `re-frame.path/segment?` composes this
@@ -203,7 +203,7 @@
   ;; instant are distinct JVM map keys (`=` does not equate them) yet render
   ;; the identical `t:<utc>` token. Emitting both would produce a structurally
   ;; ambiguous identity; instead we reject the whole identity closed
-  ;; (rf2-w9x5fv item 3) rather than silently serialize colliding key tokens.
+  ;; rather than silently serialize colliding key tokens.
   (let [entries (->> m
                      (map (fn [[k v]] [(encode k) (encode v)]))
                      (sort-by first))
@@ -243,7 +243,7 @@
     (map? x)            (encode-map x)
     ;; `seq?` subsumes `list?` (every list is a seq; lazy seqs are seq? but
     ;; not list?) and both encode identically, so one `seq?` branch covers
-    ;; the whole list-kind (fe3a9q: the prior `list?` branch was dead).
+    ;; the whole list-kind.
     (seq? x)            (str "l(" (encode-elements x) ")")
     :else               (reject! x :unsupported-host-value)))
 
@@ -270,8 +270,7 @@
   canonicalization (\"Duplicate canonical keys are invalid and MUST be
   rejected before the value becomes a cache key, route identity, or work
   id\") this rejects the whole identity closed — the same fail-closed rule
-  `canonical-bytes` enforces, so the two surfaces never diverge (rf2-w9x5fv
-  item 3)."
+  `canonical-bytes` enforces, so the two surfaces never diverge."
   [m]
   (let [out (reduce-kv (fn [acc k v]
                          (let [ck (canonical k)]
@@ -292,7 +291,7 @@
   canonical value. Instants normalize to a single representation
   (millisecond-precision UTC), so `canonical` and `canonical-bytes` share ONE
   canonical form — a value stored via `canonical` and a value compared via
-  `canonical-bytes` can never disagree (rf2-w9x5fv item 3). Fails closed with
+  `canonical-bytes` can never disagree. Fails closed with
   `:rf.error/non-edn-identity` for any out-of-domain value — the validation
   walk runs eagerly so a host handle buried anywhere in the structure is
   rejected, never host-stringified — and for a map carrying DUPLICATE
@@ -314,7 +313,7 @@
     ;; moment are NOT `=`, so preserving the host object would give two
     ;; unequal canonical values for one identity fact. Normalize both to the
     ;; single CEDN-1 UTC text so `canonical` and `canonical-bytes` agree on a
-    ;; single canonical form (rf2-w9x5fv item 3).
+    ;; single canonical form.
     (instant-value? value) (instant->utc-millis-string value)
     (symbol? value)    value
     (integer? value)   (if (and (not (bad-number? value)) (safe-integer? value))
@@ -324,7 +323,7 @@
     (vector? value)    (mapv canonical value)
     (set? value)       (into #{} (map canonical) value)
     (map? value)       (canonical-map value)
-    ;; `seq?` subsumes `list?` (fe3a9q) — one branch covers list-kind.
+    ;; `seq?` subsumes `list?` — one branch covers list-kind.
     (seq? value)       (apply list (map canonical value))
     :else              (reject! value :unsupported-host-value)))
 

--- a/implementation/core/src/re_frame/image.cljc
+++ b/implementation/core/src/re_frame/image.cljc
@@ -7,7 +7,7 @@
   > stream. It answers one question: which registrations are visible to this
   > frame?
 
-  This namespace is the FOUNDATION slice of the EP-0023 wave (rf2-32siq3.3):
+  This namespace is the FOUNDATION slice of the EP-0023 wave:
   the constructor (`image`), the normalized image value, the exact `:include-ns`
   glob grammar, inline `:registrations` lowering, and the PURE selector that
   given a collection of descriptors — each carrying its source-code provenance
@@ -36,18 +36,18 @@
       inline descriptors), with zero-match `:include-ns` patterns failing loud
       (EP-0023 §Namespace-Selected Images \"Zero matches are fail-loud\").
 
-  DEFERRED to sibling slices (NOT touched here):
+  OWNED by sibling slices (NOT here):
 
     * the provenance-preserving registration SOURCE STORE keyed by
       `[kind id provenance-namespace]` (slice .2) — the live store that
-      PRODUCES the descriptors this selector consumes. This slice tests the
-      selector against SYNTHETIC descriptor collections so the two slices can
-      land in parallel; the live wiring is slice .4 (assembly).
+      PRODUCES the descriptors this selector consumes. This selector works
+      against any descriptor collection carrying `:rf.provenance/ns`; the live
+      wiring is slice .4 (assembly).
     * image ASSEMBLY into a sealed `[kind id]` generation, collision
       validation, framework-standard registrations, replacement winners
       (`:replace` / `:replace-standard`), capability checks, and resolved-
-      generation caching (later wave beads).
-    * `make-frame` / `reload-images!` frame loading (later wave beads).
+      generation caching.
+    * `make-frame` / `reload-images!` frame loading.
 
   ## The selector contract (input shape from the source store)
 
@@ -389,14 +389,14 @@
 
   `:replace` / `:replace-standard` are the EP-0023 §Image Patching And Overrides
   declared-winner maps (`{[kind id] winner-source-coordinate}`). They are BARE
-  structural slots (the EP-0017 v5 line, per Conventions §`:rf.image/*`) carried
+  structural slots (per Conventions §`:rf.image/*`) carried
   through UNINTERPRETED here — the image value is inert data; the assembly slice
-  (rf2-32siq3.4) reads them to resolve collisions. The constructor validates the
+  reads them to resolve collisions. The constructor validates the
   STRUCTURAL shape of each entry (`validate-replacement-map!`): the map and each
   key/value, so a malformed key or winner coordinate fails loud at `rf/image`
   with an actionable diagnostic rather than reaching assembly's collision checks
   as a generic `nth not supported` destructuring error or a misleading
-  no-collision report (rf2-32siq3.20). The SEMANTIC winner-coordinate validation
+  no-collision report. The SEMANTIC winner-coordinate validation
   AGAINST the actual selected collisions (does this key really collide? does the
   coordinate name exactly one selected descriptor?) stays the assembly slice's
   fail-loud job."
@@ -433,7 +433,7 @@
 
 (defn- validate-replacement-map!
   "Fail-loud STRUCTURAL validation of a `:replace` / `:replace-standard` map at
-  the image boundary (rf2-32siq3.20). `map-key` is `:replace` or
+  the image boundary. `map-key` is `:replace` or
   `:replace-standard` (named in diagnostics); `m` the declared-winner map;
   `image-id` the containing image's id (when known). Pure.
 
@@ -443,10 +443,11 @@
   `{:standard true}`). A malformed key (non-vector, wrong arity, or an
   unsupported kind) or a malformed winner coordinate throws
   `:rf.error/invalid-image` with an actionable diagnostic BEFORE assembly's
-  `check-replacement-keys-collide!` destructures the key — so a keyword key no
-  longer surfaces as `nth not supported`, and a typo'd coordinate no longer
-  masquerades as a stale winner. The SEMANTIC checks (real collision? winner
-  names exactly one selected descriptor?) remain the assembly slice's job."
+  `check-replacement-keys-collide!` destructures the key — so a keyword key
+  surfaces as a clear diagnostic rather than `nth not supported`, and a typo'd
+  coordinate is caught here rather than masquerading downstream as a stale
+  winner. The SEMANTIC checks (real collision? winner names exactly one
+  selected descriptor?) remain the assembly slice's job."
   [image-id map-key m]
   (doseq [[k winner] m]
     (when-not (and (vector? k) (= 2 (count k)))
@@ -584,7 +585,7 @@
                  "winner source coordinate — got " (pr-str m) ".")
             {:recovery :use-a-replacement-winner-map
              :extra    {:image id :bad-key k :received m}}))
-        ;; Structural validation of each entry (rf2-32siq3.20): the [kind id]
+        ;; Structural validation of each entry: the [kind id]
         ;; key and the winner source coordinate, fail-loud before assembly.
         (validate-replacement-map! id k m)))
     (cond-> {:rf.image/include-ns include-ns

--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.image-assembly
   "EP-0023 §Image Validation / §Image Patching And Overrides / §Image
-  Composition — the ASSEMBLY slice (rf2-32siq3.4): resolve one or more image
+  Composition — the ASSEMBLY slice: resolve one or more image
   values into a SEALED, VALIDATED image generation and fail loud before a frame
   can run it.
 
@@ -42,7 +42,7 @@
       6. seal the result into an immutable [kind id] resolver;
       7. give the frame that sealed generation (frame loading is slice .7).
 
-  ## The DEFAULT image (rf2-32siq3.24)
+  ## The DEFAULT image
 
   The DEFAULT image (EP-0023 §Default Image Semantics) is the implicit selector
   over the WHOLE default source store: `reg-*` mutates the source store, and the
@@ -93,10 +93,10 @@
   ## The .5 / .6 seams (documented boundary)
 
   This slice builds the validation STRUCTURE and fails loud on every condition
-  the EP names for assembly. One seam (.6) is left for a sibling slice to deepen;
-  the .5 replacement policy is now LANDED here:
+  the EP names for assembly. The .5 replacement policy lives here; one seam
+  (.6) is left for a sibling slice to deepen:
 
-    * SLICE .5 (replacement policy — LANDED) — owns the EXACT `:replace` /
+    * SLICE .5 (replacement policy) — owns the EXACT `:replace` /
       `:replace-standard` winner policy: a replacement declares the survivor of
       a REAL collision and is never a silent order override. The three fail-loud
       legs (EP-0023 §Image Validation / §Image Patching And Overrides):
@@ -113,9 +113,9 @@
           proves the invariant is preserved ([[standard-replaceable?]] +
           `resolve-collision` → `:rf.error/image-standard-replacement-forbidden`).
       The seam fns [[resolve-replacement-winner]] / [[standard-replaceable?]]
-      remain the future plug points for richer winner-source matching and the
+      are the plug points for richer winner-source matching and the
       conformance-profile proof that would lift the invariant-coupled lock; the
-      detection STRUCTURE (`.4`'s undeclared-collision fail-loud) is unchanged.
+      undeclared-collision fail-loud detection STRUCTURE sits alongside them.
 
     * SLICE .6 (capability checks) — owns the DEEP capability-map checking
       against the frame's host `:capabilities`. This slice already collects the
@@ -159,9 +159,9 @@
 ;; ship standard registrations (e.g. the `:rf.interceptor/path` standard from
 ;; EP-0022, the `:rf.nav/*` standards from routing) can contribute their
 ;; descriptors at load without this core ns static-requiring them. Assembly
-;; reads the current set. The first version ships an EMPTY standard set — the
-;; structure + policy keys are in place; the specific standard descriptors are
-;; contributed by their owning artefacts in later wave work.
+;; reads the current set. The standard set starts EMPTY — the structure +
+;; policy keys are in place; each owning artefact contributes its standard
+;; descriptors at load via `register-standard!`.
 
 (defonce ^{:doc "Framework-standard descriptors, keyed `[kind id]` → descriptor.
   Each descriptor carries `:standard true` and the `:rf.standard/*` policy keys.
@@ -362,20 +362,20 @@
                     (image/select-descriptors image descriptors))))
         images))
 
-;; ---- inline-registration lowering (EP-0023 §Image Fragments, rf2-ffc6s0) ---
+;; ---- inline-registration lowering (EP-0023 §Image Fragments) ---------------
 ;;
 ;; An inline `:registrations` entry lowers (in the pure `re-frame.image` slice)
 ;; to a descriptor carrying its raw fn BODY under `:impl` — inert data with NO
 ;; runnable slots. A registered descriptor, by contrast, carries the RUNNABLE
 ;; shape `register!` stored (`:handler-fn` + the per-kind discriminators: an
 ;; event's `:interceptors` wrapper chain, a sub's `:input-kind` / `:input-signals`).
-;; So a generation built from inline `:registrations` resolved the descriptor
-;; but ran NOTHING — the cascade reads `registrar/handler` (`:handler-fn`) and
-;; an event needs `:interceptors`, neither of which an `:impl`-only descriptor
-;; carries (rf2-ffc6s0). EP-0023 §Image Fragments is explicit: "Both paths
-;; should lower to the same runtime descriptor shape."
+;; The cascade reads `registrar/handler` (`:handler-fn`) and an event needs
+;; `:interceptors`, neither of which an `:impl`-only descriptor carries, so an
+;; inline descriptor must be lowered to the runnable shape before a generation
+;; runs it. EP-0023 §Image Fragments is explicit: "Both paths should lower to
+;; the same runtime descriptor shape."
 ;;
-;; This step closes that gap: for each SELECTED descriptor that is inline
+;; This step does that lowering: for each SELECTED descriptor that is inline
 ;; (`:rf.provenance/inline`) and carries a real fn body (`:impl`), call the
 ;; kind's late-bound lowering (`:image/lower-inline-<kind>`, published by
 ;; `re-frame.events` / `.subs` / `.fx` / `.cofx`) with the inline `:metadata` +
@@ -395,7 +395,7 @@
 
 (defn lower-inline-descriptor
   "Lower ONE selected descriptor into its runnable shape when it is an inline
-  descriptor carrying a real fn body (EP-0023 §Image Fragments, rf2-ffc6s0).
+  descriptor carrying a real fn body (EP-0023 §Image Fragments).
   An inline descriptor (`:rf.provenance/inline`) with an `:impl` fn is merged
   with the runnable slots its kind's late-bound lowering produces (the same
   slots `register!` stores for a `reg-*` of that kind) — preserving `:impl`,
@@ -418,7 +418,7 @@
 (defn lower-inline-descriptors
   "Map `lower-inline-descriptor` over `descriptors` — lowering every selected
   inline descriptor with a real fn body into its runnable shape before
-  validation + sealing (EP-0023 §Image Fragments, rf2-ffc6s0). Registered /
+  validation + sealing (EP-0023 §Image Fragments). Registered /
   standard / metadata-only descriptors pass through untouched. Order
   preserved (it never decides a collision winner downstream)."
   [descriptors]
@@ -984,7 +984,7 @@
   `descriptors` is the candidate pool. This is the function the cache wraps —
   it has no cache awareness, so every cache MISS computes one full generation
   here (the SSR re-seal the cache exists to avoid). Throws on every fail-loud
-  condition exactly as before (a throwing input is NOT cached)."
+  condition (a throwing input is NOT cached)."
   [images descriptors]
   (let [;; A representative image id for diagnostics (the first that carries
         ;; one); collision/winner errors also name exact coordinates.
@@ -993,8 +993,8 @@
         ;; runnable shape (`:handler-fn` + per-kind runtime slots) so the
         ;; sealed resolver's inline entries route through dispatch / subscribe
         ;; identically to a `:include-ns`-selected registered descriptor
-        ;; (EP-0023 §Image Fragments — "the same runtime descriptor shape",
-        ;; rf2-ffc6s0). Registered / standard / metadata-only entries are
+        ;; (EP-0023 §Image Fragments — "the same runtime descriptor shape").
+        ;; Registered / standard / metadata-only entries are
         ;; unchanged; `:impl` + provenance are preserved for collision /
         ;; replacement / dedupe (all unchanged downstream).
         selected (lower-inline-descriptors (select-for-images images descriptors))
@@ -1021,7 +1021,7 @@
 
 ;; ===========================================================================
 ;; Resolved-generation cache (EP-0023 §Image — "The reference implementation
-;; MUST cache resolved generations") + rf2-3sjdmi (cache-key correctness)
+;; MUST cache resolved generations") + cache-key correctness
 ;; ===========================================================================
 ;;
 ;; Resolved generations are IMMUTABLE and may be physically shared across many
@@ -1052,7 +1052,7 @@
 ;;   * `:replace` / `:replace-standard` — the declared replacement maps.
 ;;
 ;; So the image vector IS the "normalized :images + inline fingerprints +
-;; replacement maps" portion of the key. This is the rf2-3sjdmi correctness
+;; replacement maps" portion of the key. This is the correctness
 ;; point: the key is built from the image INPUTS, NOT from `:rf.gen/resolver`
 ;; alone — two compositions differing ONLY in `:replace` carry different image
 ;; values, so they occupy different cache slots and can never cache-collide on
@@ -1068,7 +1068,7 @@
 ;;     `*source-store*` vs the process-default) can each sit at the same
 ;;     generation integer over DIFFERENT descriptor pools. The store identity
 ;;     disambiguates them so a sealed generation assembled from one store is
-;;     never handed back for another (rf2-1x2zuc). ANY reg-*/forget-*/clear on
+;;     never handed back for another. ANY reg-*/forget-*/clear on
 ;;     the active store bumps its generation leg.
 ;;   * the framework-standard generation: `standard-generation` — ANY
 ;;     register-standard!/clear bumps it.
@@ -1118,7 +1118,7 @@
       atom (identity, so distinct stores never alias) paired with its monotonic
       per-store generation (so a mutation re-seals). The identity is REQUIRED
       because the generation is keyed per store: two distinct stores at the
-      same generation integer would otherwise collide (rf2-1x2zuc);
+      same generation integer would otherwise collide;
     * explicit-pool arity — the explicit descriptor pool VALUE itself (distinct
       pools are distinct values, so distinct keys without a separate identity).
 
@@ -1133,7 +1133,7 @@
   "Look the normalized `images` up in the resolved-generation cache under
   `[images pool-leg (standard-generation)]` (the live-store `pool-leg` is the
   `[store-identity store-generation]` pair, so distinct stores at the same
-  generation never alias — rf2-1x2zuc); on a MISS compute the sealed
+  generation never alias); on a MISS compute the sealed
   generation via `assemble*` (against `descriptors`), cache it, and return it.
   A cache HIT returns the SAME sealed object — this is the SSR no-re-seal
   guarantee. A throwing `assemble*` (a fail-loud validation) is NOT cached: the
@@ -1189,14 +1189,14 @@
   object without re-running selection + validation + sealing. This is the SSR
   fast path. ANY change to a selected, standard, inline, or replacement input
   bumps a key leg and forces a re-seal; two compositions differing only in
-  `:replace` never cache-collide (rf2-3sjdmi).
+  `:replace` never cache-collide.
 
   Two arities:
     (assemble images)            — select against the live source store; the
                                    key's pool leg is the live source-store
                                    IDENTITY + its generation (the identity stops
                                    two distinct stores at the same generation
-                                   from aliasing — rf2-1x2zuc).
+                                   from aliasing).
     (assemble images descriptors)— select against an explicit descriptor pool
                                    (tests / harnesses / a pre-snapshotted
                                    store); the key's pool leg is the descriptor
@@ -1238,7 +1238,7 @@
        ;; The pool leg pairs the active store IDENTITY with its generation: the
        ;; generation is keyed per store, so the identity is what stops two
        ;; distinct stores at the same generation from aliasing one sealed
-       ;; generation (rf2-1x2zuc).
+       ;; generation.
        (assemble-cached images
                         (source-store-descriptors)
                         [(source-store/store-identity)
@@ -1256,7 +1256,7 @@
 (defn assemble-default
   "Resolve the DEFAULT image — the implicit selector over the WHOLE registration
   source store + the framework standards — into a SEALED, VALIDATED image
-  generation (EP-0023 §Default Image Semantics / Bead Plan item 6). The default
+  generation (EP-0023 §Default Image Semantics). The default
   path projects ALL default-source `reg-*` descriptors into the default image
   generation, FAILING LOUD if that projection contains same-kind same-id
   collisions.
@@ -1281,7 +1281,7 @@
                                    generation is cached, invalidated the instant
                                    any `reg-*` / `forget-*` / `clear-*` bumps it,
                                    and never aliased across two distinct stores
-                                   at the same generation (rf2-1x2zuc; EP-0023
+                                   at the same generation (EP-0023
                                    §Image — the default generation is cached
                                    keyed on the source-store generation).
     (assemble-default descriptors)— select against an explicit descriptor pool
@@ -1296,7 +1296,7 @@
   ([]
    ;; Live-store default: pair the active store identity with its generation so
    ;; the default generation of two distinct stores at the same generation never
-   ;; aliases (rf2-1x2zuc).
+   ;; aliases.
    (assemble-cached [default-image]
                     (source-store-descriptors)
                     [(source-store/store-identity)

--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -10,8 +10,8 @@
   Built via the `->interceptor` macro (`re-frame.core`, captures the
   definition-site `:source-coord` for jump-to-source per Spec 001) or
   the `->interceptor*` fn (this ns; HoF / programmatic, no coord
-  capture). A captured `:source-coord` rides the error-record (per
-  rf2-siheh) so tooling can jump to the throwing interceptor's source.
+  capture). A captured `:source-coord` rides the error-record so
+  tooling can jump to the throwing interceptor's source.
 
   The 'context' is a map with :coeffects (inputs) and :effects (outputs).
   The chain runs :before in order, then the handler, then :after in
@@ -138,14 +138,11 @@
   `classify-pipeline-exception` reads `:id` to attribute the throw to the
   event handler (a handler-wrapping `:id`) or a user interceptor.
 
-  EP-0017 removed `inject-cofx` — the only mechanism that stamped
-  `:rf/cofx-id` on an interceptor — and moved coeffect-supplier-throw
-  handling to context assembly (`re-frame.cofx`, BEFORE the chain runs).
-  No interceptor carries `:rf/cofx-id` anymore, so the old conditional
-  copy of it onto this record was permanently dead and has been removed
-  (rf2-oky3gt).
+  No interceptor carries `:rf/cofx-id`: coeffect delivery happens during
+  context assembly (`re-frame.cofx`, BEFORE the chain runs), so a
+  coeffect-supplier throw is handled there rather than on this record.
 
-  Per rf2-siheh the record carries the throwing interceptor's
+  The record carries the throwing interceptor's
   `:source-coord` when one was captured (the `->interceptor` macro
   stamps it from `(meta &form)`). The router threads it onto the
   `:rf.error/interceptor-exception` trace so the Xray Epoch INTERCEPTOR
@@ -219,7 +216,7 @@
   portable. Returns nil when the `:after` was a no-op (returned the
   context unchanged) so the caller can skip stashing the row entirely
   — the Xray AFTER INTERCEPTORS section renders nothing for no-op
-  interceptors. Per rf2-9dk9y."
+  interceptors."
   [before after]
   (let [slots (reduce (fn [acc seg]
                         (if-let [d (segment-delta (get before seg)
@@ -234,21 +231,19 @@
   "True iff `x` is a framework-installed scaffolding interceptor VALUE —
   the framework's own appended handler-wrapper, stamped `:rf/default?
   true` (see `re-frame.events/register-event!`). Two callers share this
-  one predicate (rf2-ih437c):
+  one predicate:
 
     - `invoke-after` (this ns) skips its ctx-delta capture for these —
       they are framework machinery, not user-meaningful interceptors on
       the Xray AFTER INTERCEPTORS surface.
     - `re-frame.interceptor-registry/resolve-chain` lets this ONE inline
-      value pass through a chain untouched (the reference-only flip,
-      rf2-0adhqs.9, rejects every other inline value). `interceptor-
-      registry` already `:require`s this ns, so it calls here rather than
-      keeping a second copy.
+      value pass through a chain untouched (chains are reference-only and
+      reject every other inline value). `interceptor-registry` already
+      `:require`s this ns, so it calls here rather than keeping a second
+      copy.
 
-  EP-0017 removed `inject-cofx`; no interceptor carries `:rf/cofx-id`
-  anymore (coeffect delivery moved to context assembly), so the old
-  `:rf/cofx-id` skip-clause was permanently dead and has been removed
-  (rf2-oky3gt) — the predicate is the `:rf/default?` check alone.
+  No interceptor carries `:rf/cofx-id` (coeffect delivery happens during
+  context assembly), so the predicate is the `:rf/default?` check alone.
 
   The `(map? x)` guard makes the predicate total over a chain entry of
   ANY shape (the registry calls it on raw chain entries that may be
@@ -259,7 +254,7 @@
 
 (defn- invoke-after [context interceptor]
   (if-let [f (:after interceptor)]
-    (let [;; Dev-only ctx-delta capture per rf2-9dk9y. The snapshot ride
+    (let [;; Dev-only ctx-delta capture. The snapshot ride
           ;; the same `interop/debug-enabled?` gate as the trace surface
           ;; so production CLJS bundles DCE the capture. Framework
           ;; defaults (`:rf/default?`) are skipped — they are not

--- a/implementation/core/src/re_frame/interceptor_registry.cljc
+++ b/implementation/core/src/re_frame/interceptor_registry.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.interceptor-registry
   "Registered interceptors — the `:interceptor` registrar kind and the
-  by-reference chain resolution (EP-0022; reference-only since rf2-0adhqs.9).
+  by-reference chain resolution (EP-0022; chains are reference-only).
 
   Per [Spec 001 §Interceptors](../../../spec/001-Registration.md) and
   [Spec 002 §Registered interceptors and the chain grammar](../../../spec/002-Frames.md):
@@ -32,18 +32,17 @@
     static descriptor; an `[id arg]` vector resolves a `:factory` and builds
     for the arg.
 
-  - `resolve-chain` — the chain-assembly seam (EP-0022 reference-only flip,
-    rf2-0adhqs.9). Walk an event/frame `:interceptors` chain and resolve every
-    REFERENCE to its registered interceptor value. A stale INLINE interceptor
+  - `resolve-chain` — the chain-assembly seam (EP-0022 reference-only
+    grammar). Walk an event/frame `:interceptors` chain and resolve every
+    REFERENCE to its registered interceptor value. An INLINE interceptor
     value (a map carrying `:before` / `:after` / `:id`, a `->interceptor` call
     result, a value-Var) in a chain position fails LOUD with
     `:rf.error/inline-interceptor-removed` — chains are reference-only. The ONE
     inline value that flows through is the framework's own appended handler-
     wrapper (`:rf/default? true`), which is framework machinery, not an
-    application-authored chain entry. (The additive window where refs and
-    inline values coexisted is closed — mirrors EP-0018 B-add→Z.)
+    application-authored chain entry.
 
-  ## Realm-awareness (rf2-a15n62)
+  ## Realm-awareness
 
   Resolution goes through `registrar/lookup`, which reads the active
   registrar (`registrar/*registrar*` when an explicit-realm seating is in
@@ -178,10 +177,9 @@
   An interceptor value is legal ONLY at the `reg-interceptor` REGISTRATION
   boundary (the authoring input) and as the framework's own appended handler-
   wrapper. In an event/frame `:interceptors` CHAIN an application-authored
-  interceptor value is `:rf.error/inline-interceptor-removed` (EP-0022
-  reference-only flip, rf2-0adhqs.9) — chains carry references only. This
-  predicate is the shape detector both the registration boundary and the
-  chain's stale-inline rejection share."
+  interceptor value is `:rf.error/inline-interceptor-removed` (EP-0022:
+  chains carry references only). This predicate is the shape detector both
+  the registration boundary and the chain's inline rejection share."
   [x]
   (and (map? x)
        (or (contains? x :before)
@@ -192,11 +190,10 @@
 ;; predicate) is the ONE inline interceptor value `resolve-chain` lets pass
 ;; through a chain untouched: it is framework machinery (the terminal
 ;; `:before` that invokes the user handler), not an application-authored
-;; chain entry, so the reference-only flip (rf2-0adhqs.9) does not reject
-;; it. The predicate lives in `re-frame.interceptor` (already required here)
-;; and is shared with that ns's `invoke-after` ctx-delta-capture gate —
-;; one copy, not two (rf2-ih437c). Call it as
-;; `interceptor/framework-default-interceptor?`.
+;; chain entry, so the reference-only grammar does not reject it. The
+;; predicate lives in `re-frame.interceptor` (already required here) and is
+;; shared with that ns's `invoke-after` ctx-delta-capture gate — one copy,
+;; not two. Call it as `interceptor/framework-default-interceptor?`.
 
 (defn interceptor-ref?
   "True when `x` is an interceptor REFERENCE (Spec 002 §Interceptor
@@ -320,17 +317,16 @@
 (defn- throw-inline-interceptor-removed!
   "Raise `:rf.error/inline-interceptor-removed` (ex-info) for an INLINE
   interceptor value found in a chain position. Per EP-0022 §Event and frame
-  chain grammar (the reference-only flip, rf2-0adhqs.9): event/frame
-  `:interceptors` chains carry REFERENCES only — a bare keyword id or an
-  `[id arg]` 2-vector. An inline interceptor map / value / Var (an
-  `->interceptor` result, a `(path …)` value, a `(redact-interceptor …)`
-  value, a locally-bound interceptor symbol) is no longer accepted; it must be
-  registered with `reg-interceptor` and referenced by id. Loud-fail at chain
-  assembly rather than a silent no-op (Conventions §No silent swallow).
-  Delegates to the ONE shared `error/throw-inline-interceptor-removed!`
-  (rf2-8au0w6) passing this site's `:where 'rf/resolve-chain`, reason, and
-  ex-data — the registration-time twin (`re-frame.events`) shares the same
-  thrower."
+  chain grammar: event/frame `:interceptors` chains carry REFERENCES only —
+  a bare keyword id or an `[id arg]` 2-vector. An inline interceptor map /
+  value / Var (an `->interceptor` result, a `(path …)` value, a
+  `(redact-interceptor …)` value, a locally-bound interceptor symbol) is not
+  accepted; it must be registered with `reg-interceptor` and referenced by
+  id. Loud-fail at chain assembly rather than a silent no-op (Conventions §No
+  silent swallow). Delegates to the ONE shared
+  `error/throw-inline-interceptor-removed!` passing this site's
+  `:where 'rf/resolve-chain`, reason, and ex-data — the registration-time
+  twin (`re-frame.events`) shares the same thrower."
   [entry]
   (error/throw-inline-interceptor-removed!
     'rf/resolve-chain
@@ -372,7 +368,7 @@
                     (throw-factory-arity!
                       ref id
                       (str "the `:factory` for interceptor `" id "` threw while building "
-                           ;; rf2-vzrxp3: nil-safe (a thrown non-Error value has no message).
+                           ;; nil-safe (a thrown non-Error value has no message).
                            "for arg `" (pr-str arg) "`: " (error/ex-message-safe e) ".")))))]
     (cond
       ;; Factory returned an executable interceptor value (a map with
@@ -430,8 +426,8 @@
 
 (defn resolve-chain
   "Resolve an event/frame `:interceptors` chain entry-by-entry into executable
-  interceptor values. REFERENCE-ONLY (EP-0022 flip, rf2-0adhqs.9): a REFERENCE
-  (keyword / `[id arg]`) resolves to its registered interceptor value. A stale
+  interceptor values. REFERENCE-ONLY (EP-0022): a REFERENCE
+  (keyword / `[id arg]`) resolves to its registered interceptor value. An
   INLINE interceptor value (a map carrying `:before` / `:after` / `:id`, an
   `->interceptor` result, a value-Var) in a chain position fails LOUD with
   `:rf.error/inline-interceptor-removed` — chains are reference-only. A
@@ -467,8 +463,8 @@
               ;; true`) — framework machinery, not an authored chain entry;
               ;; passes through untouched (the reference-only carve-out).
               (interceptor/framework-default-interceptor? entry) entry
-              ;; A stale INLINE interceptor value — reference-only flip rejects
-              ;; it LOUD (EP-0022, rf2-0adhqs.9): register it + reference by id.
+              ;; An INLINE interceptor value — the reference-only grammar
+              ;; rejects it LOUD (EP-0022): register it + reference by id.
               (interceptor-value? entry) (throw-inline-interceptor-removed! entry)
               :else (throw-invalid-ref! entry)))
           chain)))
@@ -479,7 +475,7 @@
   (rejected `:rf.error/inline-interceptor-removed`). A hot-path predicate the
   resolution seams use to skip the walk when a chain is nothing but the
   framework's appended handler-wrapper (the common all-default shape — an event
-  with no authored chain). Reference-only since EP-0022 (rf2-0adhqs.9): a
+  with no authored chain). Reference-only (EP-0022): a
   chain carrying ONLY the framework default needs no resolution; the moment it
   carries a ref OR a stale inline value, `resolve-chain` must walk it (to
   resolve the ref, or to reject the inline value loudly)."

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.late-bind
   "Hook registry for cross-namespace and cross-artefact forward
   references. Producing ns calls `set-fn!` (single key) or `set-fns!`
-  (map of entries, rf2-rtk2e) at load time; consumer calls `get-fn` at
+  (map of entries) at load time; consumer calls `get-fn` at
   call time. Identical behaviour on JVM and CLJS.
 
   Carries two flavours of forward reference:
@@ -17,7 +17,7 @@
   `re-frame.late-bind.directory` — one CLJC entry per hook key. The
   drift test `implementation/core/test/re_frame/late_bind_drift_test.clj`
   asserts the directory matches the in-tree publications, walking both
-  the per-key `set-fn!` form and the rf2-rtk2e map-form `set-fns!`
+  the per-key `set-fn!` form and the map-form `set-fns!`
   block."
   (:require [re-frame.error :as error]))
 
@@ -31,7 +31,7 @@
   hooks
   (atom {}))
 
-;; ---- sticky resolution cache (rf2-f72pd) ----------------------------------
+;; ---- sticky resolution cache ----------------------------------------------
 ;;
 ;; `get-fn-cached` is a sticky variant of `get-fn` for hooks that are
 ;; published once at boot and never withdrawn in production
@@ -50,10 +50,9 @@
 ;; Invariant: `set-fn!` and `chain-fn!` invalidate the slot for the key
 ;; they re-publish. Production registers each hook once at boot and
 ;; never again — cache hits 100%. Dev hot-reload of an artefact
-;; re-registers — the next cached lookup re-resolves through `hooks`,
-;; identical to today's behaviour. The pattern mirrors
-;; `re-frame.registrar/emit!-cache` (which memoised `:trace/emit!`
-;; under the same logic before this generalised mechanism existed).
+;; re-registers — the next cached lookup re-resolves through `hooks`.
+;; The pattern mirrors `re-frame.registrar/emit!-cache`, which memoises
+;; `:trace/emit!` under the same logic.
 
 (defonce ^:private fn-cache
   ;; hook-key → resolved-fn. Distinct from `hooks` so the cache slot
@@ -87,7 +86,7 @@
   nil)
 
 (defn set-fns!
-  "Register every `hook-key → fn` entry in `m` in one call (rf2-rtk2e).
+  "Register every `hook-key → fn` entry in `m` in one call.
 
   Equivalent to calling `set-fn!` once per entry, but reads as a single
   publication of an artefact's late-bind contract rather than a column
@@ -114,7 +113,7 @@
   (get @hooks hook-key))
 
 (defn get-fn-cached
-  "Sticky variant of `get-fn` (rf2-f72pd) — memoises the resolved fn
+  "Sticky variant of `get-fn` — memoises the resolved fn
   for `hook-key` so subsequent calls read a per-key atom slot rather
   than re-deref'ing the global `hooks` map.
 
@@ -127,8 +126,8 @@
   Use at hot-path call sites — every dispatch reads
   `:schemas/validate-event!`, `:schemas/validate-app-schema!`,
   `:flows/run-flows-on-db`, `:epoch/settle!`, `:epoch/capture-event`,
-  `:event-emit/dispatch-on-event`, `:router/dispatch!` — so a
-  100-event cascade resolved each ~100 times before this cache."
+  `:event-emit/dispatch-on-event`, `:router/dispatch!` — where a
+  100-event cascade would otherwise resolve each key ~100 times."
   [hook-key]
   (or (get @fn-cache hook-key)
       (when-let [resolved (get @hooks hook-key)]
@@ -158,10 +157,10 @@
         (when previous (apply previous args))
         nil))))
 
-;; ---- warn-once clear-fn governance registry (rf2-z79p8) -------------------
+;; ---- warn-once clear-fn governance registry ------------------------------
 ;;
 ;; Every process-wide `defonce` warn-once cache in the adapter / views
-;; family (`warned-non-dom-roots`, the rf2-9hoos `seen-render-keys` set,
+;; family (`warned-non-dom-roots`, the `seen-render-keys` set,
 ;; the slim hiccup interpreter's `warned-keyword-prop` cache, and the
 ;; React-hook spine's per-adapter source-coord cache) must be wiped by the
 ;; standard `make-reset-runtime-fixture` between tests — otherwise a sibling
@@ -169,23 +168,19 @@
 ;; warning. The mechanism is the chained `:adapter/clear-warn-once-caches!`
 ;; late-bind hook the fixture fires.
 ;;
-;; This defect class bit four times before the chokepoint landed: rf2-4edk
-;; (the original source-coord cache), rf2-9hoos (seen-render-keys), rf2-qy6cl
-;; (the slim keyword-prop cache), and rf2-z79p8 (a since-retired plain-fn
-;; pairs cache — its warning is gone per EP-0002, removed in rf2-k4xous).
-;; Each fix was the SAME one-liner: chain the clear-fn. The pattern was
-;; fragile because there was no single chokepoint and nothing asserted the
-;; set of `defonce` warn-once caches equals the set of clears in the chain —
-;; a cache could be added with a bare `defonce` + a standalone clear-fn and
-;; silently escape the fixture.
+;; This defect class is fragile to wire by hand: chaining the clear-fn is a
+;; one-liner, but with no single chokepoint nothing asserts the set of
+;; `defonce` warn-once caches equals the set of clears in the chain — a cache
+;; could be added with a bare `defonce` + a standalone clear-fn and silently
+;; escape the fixture.
 ;;
 ;; `register-warn-once-clear-fn!` is that chokepoint: it both (a) chains
 ;; the clear-fn into `:adapter/clear-warn-once-caches!` and (b) records
 ;; the cache in this governance registry with `:arm` / `:armed?` probes.
 ;; The governance assertion (warn_once_clear_governance test) enumerates
 ;; the registry, arms every cache, fires the chain once, and asserts each
-;; cache is empty afterwards — so a future 5th cache that registers but
-;; forgets the chain (or escapes the chokepoint entirely) trips the gate.
+;; cache is empty afterwards — so a cache that registers but forgets the
+;; chain (or escapes the chokepoint entirely) trips the gate.
 
 (defonce
   ^{:doc "Vector of governance entries for the adapter/views warn-once
@@ -193,7 +188,7 @@
    `:adapter/clear-warn-once-caches!` fixture hook. Populated at ns-load
    by `register-warn-once-clear-fn!`. Each entry is
    `{:label keyword, :clear-fn fn, :arm fn, :armed? fn}`. Consumed only by
-   the warn-once-clear governance assertion (rf2-z79p8); production never
+   the warn-once-clear governance assertion; production never
    reads it. The registry is the authoritative enumeration of the cache
    class — the assertion proves every member is actually cleared by the
    single canonical chain."}
@@ -201,7 +196,7 @@
   (atom []))
 
 (defn register-warn-once-clear-fn!
-  "Canonical chokepoint (rf2-z79p8) for wiring a process-wide warn-once
+  "Canonical chokepoint for wiring a process-wide warn-once
   `defonce` cache into the chained `:adapter/clear-warn-once-caches!`
   fixture-reset hook. Call this — never a bare `chain-fn!` on that key —
   so the cache is BOTH chained AND enrolled in the governance registry

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -16,7 +16,7 @@
     {:key          fully-qualified late-bind hook key (keyword, REQUIRED)
      :producer-ns  symbol naming the namespace that publishes the key
                    (REQUIRED — may be a vector when an adapter routing
-                   chain has multiple publishers, see rf2-0d35)
+                   chain has multiple publishers)
      :design-bead  decision-bead id that introduced or shaped the key
                    (string, optional)
      :description  one-line summary of what the hook does
@@ -39,7 +39,7 @@
 (def hooks
   "Vector of hook-directory entries — see the ns docstring for shape.
 
-  Ordering: grouped into four primary purposes (rf2-j0jxk), and within
+  Ordering: grouped into four primary purposes, and within
   each purpose by namespace prefix so additions land near their siblings:
 
     1. CYCLE-BREAKING  — leaf namespaces (router, subs) calling into
@@ -57,7 +57,7 @@
        `require-fn!`). Also covers the always-on observability surface
        (`:event-emit/*`, `:error-emit/*`) — production-survivor seams
        that fire on every dispatch. NOTE the `marks` rows are NOT an
-       absent-optional-artefact case (rf2-eq7m0x): `re-frame.marks`
+       absent-optional-artefact case: `re-frame.marks`
        ships IN core and is side-effect-required at boot (core.cljc),
        so the hooks are bound in every canonical build — the
        indirection is the production-DCE/elision seam (the dev-only
@@ -96,7 +96,7 @@
    ;; misses in production.
    ;; ===========================================================================
 
-   ;; ---- re-frame.router (rf2-d4sf foundational dispatch seam) ----------------
+   ;; ---- re-frame.router (foundational dispatch seam) ------------------------
    {:key         :router/dispatch!
     :producer-ns 're-frame.router
     :description "Enqueue an event for processing by the drain loop."}
@@ -104,7 +104,7 @@
     :producer-ns 're-frame.router
     :description "Process an event synchronously, bypassing the drain queue."}
 
-   ;; ---- EP-0023 inline-registration lowering (rf2-ffc6s0) -------------------
+   ;; ---- EP-0023 inline-registration lowering -------------------------------
    ;; `re-frame.image-assembly` lowers an image's inline `:registrations` fn
    ;; bodies (`:impl`) into the runnable descriptor shape per kind so they route
    ;; through dispatch identically to a `:include-ns`-selected registration
@@ -150,7 +150,7 @@
    ;; dispatch and ship in their own namespaces.
    ;;
    ;; EXCEPTION — the `:marks/*` rows are NOT an absent-optional-artefact
-   ;; case (rf2-eq7m0x). `re-frame.marks` ships IN core and is side-
+   ;; case. `re-frame.marks` ships IN core and is side-
    ;; effect-required at boot (core.cljc), so the hooks are bound in
    ;; every canonical build — `marks` is NEVER absent. For the DEV-GATED
    ;; projection hooks the late-bind hop is the production-DCE/elision
@@ -158,18 +158,16 @@
    ;; `interop/debug-enabled?` and is gated at the trace/emit! call sites,
    ;; so the hop keeps the lookup off the always-on registration path. The
    ;; always-on `:marks/redact-event-by-registration` prod redactor is
-   ;; reached through the SAME indirection. NOTE (rf2-58bq1r): the
-   ;; `:marks/validate-marks!` row is GONE — being always-on AND
-   ;; same-artefact AND already bundled, the seam rationale never applied to
-   ;; it, so reg-event / reg-fx / reg-cofx / reg-sub call
-   ;; `re-frame.marks/validate-marks!` by DIRECT REQUIRE. See the per-key
-   ;; notes below.
+   ;; reached through the SAME indirection. `re-frame.marks/validate-marks!`
+   ;; is always-on, same-artefact, and already bundled, so the seam rationale
+   ;; does not apply to it: reg-event / reg-fx / reg-cofx / reg-sub call it by
+   ;; DIRECT REQUIRE. See the per-key notes below.
    ;; ===========================================================================
 
    ;; ---- re-frame.elision (frame-owned app-db egress registry) ---------------
-   ;; EP-0015 §8 (rf2-d2r3um): no `:elision/populate-from-schemas!` seam —
-   ;; schemas no longer feed the app-db egress registry. Durable app-db
-   ;; classification is frame-owned (`re-frame.frame-classification`).
+   ;; EP-0015 §8: durable app-db classification is frame-owned
+   ;; (`re-frame.frame-classification`) — the app-db egress registry is fed by
+   ;; the frame, not by schemas.
    {:key         :elision/sensitive-declarations
     :producer-ns 're-frame.elision
     :design-bead "rf2-w3n5u"
@@ -179,8 +177,8 @@
     :design-bead "rf2-w3n5u"
     :description "Reset the once-per-(frame,path) :rf.warning/large-value-unschema'd cache."}
 
-   ;; ---- re-frame.marks (rf2-vw7f5 Spec 015 data classification) -------------
-   ;; NOT an optional-artefact decoupling (rf2-eq7m0x): `re-frame.marks` ships IN
+   ;; ---- re-frame.marks (Spec 015 data classification) ----------------------
+   ;; NOT an optional-artefact decoupling: `re-frame.marks` ships IN
    ;; core and is boot side-effect-required (core.cljc), so these hooks are bound
    ;; in every canonical build. For the DEV-GATED projection hooks the indirection
    ;; is the production-DCE/elision SEAM — their emit-time surface rides
@@ -191,32 +189,24 @@
    ;;   :marks/clear-marks!, :marks/clear-sub-output-marks!.
    ;; ALWAYS-ON production survivor still reached through the indirection:
    ;;   :marks/redact-event-by-registration (the production egress redactor).
-   ;; NOTE (rf2-58bq1r): the `:marks/validate-marks!` hook row is GONE. It was the
-   ;; ONE always-on, NON-dev-gated marks key, so the DCE-seam rationale never
-   ;; applied to it: `re-frame.marks` lives in the SAME artefact as its only
-   ;; callers (events / fx / cofx / subs) and is already pinned into every
-   ;; production bundle, the validator fail-louds in prod, and the require is
-   ;; cycle-free (marks' transitive closure touches none of events/fx/cofx/subs).
-   ;; A before/after `:advanced` + goog.DEBUG=false bundle diff confirmed marks
-   ;; present and the dev-only sentinels still elided either way — the hop bought
-   ;; no decoupling and no elision win, so reg-event / reg-fx / reg-cofx / reg-sub
-   ;; now call `re-frame.marks/validate-marks!` by DIRECT REQUIRE.
-   ;; NOTE (rf2-gjp7t6): the `:marks/add-marks` / `:marks/set-marks` hook rows
-   ;; are GONE. EP-0015 §3 (rf2-mngp4o) removed the public imperative façade
-   ;; exports; the hooks themselves had ZERO consumers and were kept only for
-   ;; directory-contract symmetry — dead weight. The underlying `add-marks` /
-   ;; `set-marks` fns survive as test / conformance-only helpers reached by
-   ;; DIRECT REQUIRE (the marks tests + the conformance corpus harness), never
-   ;; through a late-bind hook.
+   ;; `re-frame.marks/validate-marks!` is reached by DIRECT REQUIRE rather than
+   ;; a late-bind hook: it is the ONE always-on, NON-dev-gated marks surface, so
+   ;; the DCE-seam rationale does not apply. `re-frame.marks` lives in the SAME
+   ;; artefact as its callers (events / fx / cofx / subs), is pinned into every
+   ;; production bundle, fail-louds in prod, and the require is cycle-free
+   ;; (marks' transitive closure touches none of events/fx/cofx/subs).
+   ;; `add-marks` / `set-marks` are likewise DIRECT-REQUIRE test /
+   ;; conformance-only helpers (the marks tests + the conformance corpus
+   ;; harness), with no late-bind hook and no public imperative façade export
+   ;; (EP-0015 §3 keeps the imperative surface out of the public API).
    {:key         :marks/marks-for
     :producer-ns 're-frame.marks
     :design-bead "rf2-w46fpt"
     :description "Read the mark declaration for a (kind, id), or nil — DERIVED at read time from registrar/handler-meta (rf2-ehexnw), no side-table, uniformly for every kind. EP-0025 (rf2-398kql): the prior :event-kind machine :data-schema→marks union is GONE — schema-field classification is killed in favour of frame-declared paths. Hook retained for the directory contract; re-frame.machines (snapshot / SSR trace egress) now calls `re-frame.marks/marks-for` by direct require, not through this late-bind hook."}
-   ;; NOTE: the :marks/declare-machine-schema-marks! / :marks/clear-machine-schema-marks!
-   ;; hooks are GONE (EP-0025, rf2-398kql). They published the writers of the
-   ;; deleted schema-sourced machine-id->schema-marks table — the machine
-   ;; :data-schema→marks redaction bridge (EP-0005). Frame-declared :sensitive /
-   ;; :large {:app-db …} paths are now the sole app-db classification mechanism.
+   ;; NOTE (EP-0025): frame-declared :sensitive / :large {:app-db …} paths are
+   ;; the sole app-db classification mechanism. There is no schema-sourced
+   ;; machine-id->schema-marks table and no :data-schema→marks redaction bridge,
+   ;; so marks carries no machine-schema-marks writer hooks.
    {:key         :marks/project-trace-event
     :producer-ns 're-frame.marks
     :design-bead "rf2-vw7f5"
@@ -267,9 +257,9 @@
    ;; ---- re-frame.flows -------------------------------------------------------
    ;; Both the public `rf/reg-flow` / `rf/clear-flow` surfaces AND the
    ;; `:rf.fx/reg-flow` / `:rf.fx/clear-flow` runtime fxs route through
-   ;; the same two hooks (rf2-7ppmo). The api-shape `(arg opts)` already
-   ;; carries the `:frame` opt the fx-side path needs, so a separate
-   ;; `*-fx!` hook pair was dead indirection.
+   ;; the same two hooks. The api-shape `(arg opts)` carries the `:frame`
+   ;; opt the fx-side path needs, so no separate `*-fx!` hook pair is
+   ;; required.
    {:key         :flows/reg-flow
     :producer-ns 're-frame.flows
     :description "Register a flow definition with the runtime (public-API + :rf.fx/reg-flow)."}
@@ -307,7 +297,7 @@
     :design-bead "rf2-wbtjn"
     :description "Drop the destroyed frame's per-frame flow registry slot, its `last-inputs` rows, and any `:flow` registrar entries whose last owning frame was destroyed. Invoked by `frame/destroy-frame!` symmetric with the machines teardown hook (rf2-vsigt) — without this hook a long-running SSR JVM with per-request frame churn grows the flow registry unboundedly."}
 
-   ;; ---- re-frame.schemas (rf2-p7va boundary; rf2-r2uh / rf2-froe / rf2-t0hq) -
+   ;; ---- re-frame.schemas -----------------------------------------------------
    {:key         :schemas/validate-event!
     :producer-ns 're-frame.schemas
     :description "Validate an event vector against the registered event schema."}
@@ -405,7 +395,7 @@
     :design-bead "rf2-kj51z"
     :description "Walk a Malli EDN form at a base-path; return paths whose props carry :sensitive? true. Consumed by re-frame.elision."}
 
-   ;; ---- re-frame.machines (rf2-xbtj / rf2-8bp3) ------------------------------
+   ;; ---- re-frame.machines ----------------------------------------------------
    {:key         :machines/reg-machine
     :producer-ns 're-frame.machines
     :design-bead "rf2-8bp3"
@@ -486,7 +476,7 @@
     :design-bead "rf2-jm2u63"
     :description "SSR hydration projector for the durable `:rf.runtime/machines` slice `(fn [runtime-db frame-id]) -> machines-slice`. `re-frame.ssr.payload-policy/project-runtime-db` consults it so each machine snapshot's `:data` is redacted/elided per the owning machine's `:data-schema` `:sensitive?` / `:large?` classification under `:rf.egress/ssr-hydration` (the same `marks/marks-for :event <actor-id>` marks the trace-egress chokepoint uses, via `marks/redact-with-paths` then `project-egress`) BEFORE it rides the hydration wire — closing the raw-classified-machine-data hydration leak (EP-0015 §6/§8). Mirrors the resources `:ssr/extend-runtime-db-projection` model; absent the machines artefact the slice rides unchanged."}
 
-   ;; ---- re-frame.routing (rf2-k682) -----------------------------------------
+   ;; ---- re-frame.routing -----------------------------------------------------
    {:key         :routing/reg-route
     :producer-ns 're-frame.routing
     :description "Register a route pattern and handler."}
@@ -530,7 +520,7 @@
     :design-bead "rf2-1hncp2"
     :description "Release the destroyed frame's host-side transient routing caches — the scroll-position cache (re-frame.routing.scroll/scroll-positions-cache, rf2-1hncp2) AND the nav-token / pending-nav counter high-water marks (re-frame.routing.nav-counters/nav-counters-cache, rf2-oosjmh). Neither is runtime-db state — they live in module-level atoms (host-derived, ephemeral, off the epoch/SSR egress wire; the counters host-side specifically so an epoch restore cannot rewind + recycle a token), so they need explicit per-frame teardown like the other transient caches. Invoked by frame/destroy-frame! symmetric with the ssr / machines / flows / schemas teardown hooks; no-op when re-frame.routing is absent (the artefact is optional)."}
 
-   ;; ---- re-frame.resources (rf2-p10npe — EP-0003 slice 2) -------------------
+   ;; ---- re-frame.resources (EP-0003 slice 2) -------------------------------
    ;; The optional Resources artefact (Spec 016) publishes its public-API
    ;; surface here so re-frame.core reaches it without a static :require.
    ;; The routing / SSR integrations are published as cross-feature
@@ -556,7 +546,7 @@
     :producer-ns 're-frame.resources
     :design-bead "rf2-p10npe"
     :description "Return resource introspection for a frame target — registered resources + the live per-frame resource-instance table. Per Spec 016 §Introspection."}
-   ;; ---- mutations (rf2-dwme29 — EP-0003 §Mutations, first public-beta gate) -
+   ;; ---- mutations (EP-0003 §Mutations, first public-beta gate) -------------
    ;; The causal-write counterpart of the resource registration surface.
    {:key         :resources/reg-mutation
     :producer-ns 're-frame.resources
@@ -578,7 +568,7 @@
     :producer-ns 're-frame.resources
     :design-bead "rf2-dwme29"
     :description "Return mutation introspection for a frame target — registered mutation ids + the live per-frame mutation-instance table (keyed by instance id). Per EP-0003 §Mutations."}
-   ;; ---- named resource-scope resolvers (rf2-hls77w — EP-0016 D3 slice 2) ----
+   ;; ---- named resource-scope resolvers (EP-0016 D3 slice 2) ----------------
    ;; The third resources kind: pure named db-derived scope resolvers.
    {:key         :resources/reg-resource-scope
     :producer-ns 're-frame.resources
@@ -649,11 +639,11 @@
     :design-bead "rf2-obi8rr"
     :description "Cross-feature LATE-BOUND epoch-restore trace COMMIT hook (Spec 016 §Restore and replay / §Xray and AI tooling) — the post-install half of :resources/reconcile-on-restore. The reconcile runs BEFORE the atomic replace-frame-state! install and defers its success rows (:rf.resource/restored + :rf.resource/owner-released), riding the trace intents back as metadata; epoch perform-restore! consults this hook with the reconciled runtime-db ONLY on the install-success branch so those success rows fire exactly once the restore truly installed — never for a destroyed-frame install (the rf2-s93722 post-liveness teardown race) that returns nil and writes nothing. Resources is the first consumer; consulted by re-frame.epoch.tool-pair/commit-resources-restore-traces! inside perform-restore!. No-op when no resources artefact is loaded, when the frame-state carries no runtime-db partition, or when the runtime-db carries no deferred intents (a resource-free restore)."}
 
-   ;; ---- re-frame.http.managed (rf2-5kpd / rf2-6y3q / rf2-wvkn / rf2-ijm7) ----
-   ;; The stub-family hook publishes from `re-frame.http.test-support`
-   ;; per rf2-lwmgw — single discoverable home for HTTP test surfaces.
-   ;; The raw install/uninstall pair has no façade wrapper (rf2-ntwwyt), so it
-   ;; carries no late-bind hook — tests call it directly via the home namespace.
+   ;; ---- re-frame.http.managed -----------------------------------------------
+   ;; The stub-family hook publishes from `re-frame.http.test-support` — the
+   ;; single discoverable home for HTTP test surfaces. The raw install/uninstall
+   ;; pair has no façade wrapper, so it carries no late-bind hook — tests call
+   ;; it directly via the home namespace.
    {:key         :http/with-managed-request-stubs*
     :producer-ns 're-frame.http.test-support
     :description "Function form of the with-managed-request-stubs macro."}
@@ -689,7 +679,7 @@
     :design-bead "rf2-ijm7"
     :description "Register the machine-shape wrapper for managed HTTP requests."}
 
-   ;; ---- re-frame.ssr (rf2-uo7v) ---------------------------------------------
+   ;; ---- re-frame.ssr ---------------------------------------------------------
    {:key         :ssr/render-tree-hash
     :producer-ns 're-frame.ssr
     :description "Compute the stable hash of a rendered tree (SSR cache key)."}
@@ -707,7 +697,7 @@
     :design-bead "rf2-fcj33"
     :description "Clear the SSR side-channel atoms (pending-error-traces, request-slots, response-slots) for a destroyed frame, per Spec 011 §Per-request frame teardown contract. The response-slots entry joined under rf2-jbcmt when the `:rf/response` accumulator moved off `app-db` to plug a hydration-payload leak + per-fx full-app-db swap. Also invokes `:ssr/head-on-frame-destroyed` (if registered) so the head ns can release per-frame snapshot bookkeeping (rf2-4dra9)."}
 
-   ;; ---- re-frame.ssr.head (rf2-4dra9 — head/meta contract) ------------------
+   ;; ---- re-frame.ssr.head (head/meta contract) -----------------------------
    {:key         :ssr/reg-head
     :producer-ns 're-frame.ssr.head
     :design-bead "rf2-4dra9"
@@ -733,12 +723,9 @@
     :design-bead "rf2-4dra9"
     :description "Clear the per-frame head-snapshot entry on destroy. `re-frame.ssr/on-frame-destroyed!` invokes this hook by key after clearing its own side-channel atoms."}
 
-   ;; ---- re-frame.ssr.streaming (rf2-ojakd / rf2-olb64 — chunked SSR) ---------
+   ;; ---- re-frame.ssr.streaming (chunked SSR) -------------------------------
    ;; Three keys host adapters (e.g. ssr-ring/streaming) call to drive
-   ;; the chunked-rendering pipeline. The drift scan picked these up
-   ;; only after the rf2-qwm0a regex fix added `.` to the namespace
-   ;; character class — they were always published but the original
-   ;; regex `[a-zA-Z0-9!?*+\-]+` excluded the `.` in `ssr.streaming/`.
+   ;; the chunked-rendering pipeline.
    {:key         :ssr.streaming/render-shell!
     :producer-ns 're-frame.ssr.streaming
     :design-bead "rf2-ojakd"
@@ -752,7 +739,7 @@
     :design-bead "rf2-ojakd"
     :description "Build the final hydration payload after every streaming chunk has been emitted."}
 
-   ;; ---- re-frame.epoch (rf2-lt4e Tool-Pair surface) -------------------------
+   ;; ---- re-frame.epoch (Tool-Pair surface) ---------------------------------
    {:key         :epoch/settle!
     :producer-ns 're-frame.epoch
     :design-bead "rf2-nj6p7"
@@ -831,13 +818,13 @@
     :design-bead "rf2-mrsck"
     :description "Convenience wrapper returning (mapv projected-record (epoch-history frame-id))."}
 
-   ;; ---- re-frame.event-emit (rf2-rirbq — always-on event observability) -----
+   ;; ---- re-frame.event-emit (always-on event observability) ----------------
    {:key         :event-emit/dispatch-on-event
     :producer-ns 're-frame.event-emit
     :design-bead "rf2-rirbq"
     :description "Always-on per-event fan-out for production observability (Datadog / Honeycomb / Sentry). Survives `:advanced` + `goog.DEBUG=false`; parallel to (not a fallback for) the dev-only trace surface. Router invokes once per processed event after the cascade settles."}
 
-   ;; ---- re-frame.error-emit (rf2-bacs4 — always-on error observability) -----
+   ;; ---- re-frame.error-emit (always-on error observability) ----------------
    {:key         :error-emit/dispatch-on-error
     :producer-ns 're-frame.error-emit
     :design-bead "rf2-bacs4"
@@ -863,7 +850,7 @@
     :design-bead "rf2-87f7fb"
     :description "Drop a listener registered through `:error-emit/register-error-listener!`. Paired with it in `frame/fire-on-destroy-event!`'s finally-shaped teardown of the transient `:on-destroy`-throw capture listener (rf2-87f7fb), so the listener never leaks past the dispatch. Survives `:advanced` + `goog.DEBUG=false`."}
 
-   ;; ---- re-frame.observability (rf2-t55hxg.7 — EP-0015 §9 frame sink routing) -
+   ;; ---- re-frame.observability (EP-0015 §9 frame sink routing) --------------
    {:key         :observability/route-handled-event
     :producer-ns 're-frame.observability
     :design-bead "rf2-t55hxg.7"
@@ -890,7 +877,7 @@
    ;; ns-load auto-wires every adapter's slot.
    ;; ===========================================================================
 
-   ;; ---- re-frame.adapter.reagent (rf2-0hxm) ---------------------------------
+   ;; ---- re-frame.adapter.reagent --------------------------------------------
    {:key         :reagent/set-hiccup-emitter!
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim
@@ -901,7 +888,7 @@
     :design-bead "rf2-4z7bp"
     :description "Install the substrate-specific hiccup emitter for SSR. Chained — every loaded React-shaped adapter contributes its own install step so a single SSR ns-load auto-wires every adapter's render-to-string slot."}
 
-   ;; ---- re-frame.views (CLJS, rf2-4edk warn-once chain) ---------------------
+   ;; ---- re-frame.views (CLJS, warn-once chain) ------------------------------
    {:key         :views/reading-render-key
     :producer-ns 're-frame.views
     :design-bead "rf2-vh1k3"
@@ -915,7 +902,7 @@
     :design-bead "rf2-te71r"
     :description "Emit :rf.view/unmounted for a view instance's teardown. Consumed by the shared React-hook spine (make-wrap-view) so UIx/Helix views emit on unmount via a React.useEffect cleanup, restoring parity with the Reagent family's phase-A (rf2-9hoos) reaction-dispose unmount hook. Reaching the emit through late-bind keeps the spine free of a static require on the CLJS-only views ns; both sides gate on interop/debug-enabled?."}
 
-   ;; ---- :adapter/* — chained / routed across every CLJS adapter (rf2-0d35) --
+   ;; ---- :adapter/* — chained / routed across every CLJS adapter -------------
    {:key         :adapter/clear-warn-once-caches!
     :producer-ns '[re-frame.views.warn-once
                    re-frame.views
@@ -1018,8 +1005,8 @@
     :producer-ns 're-frame.trace
     :description "Emit a trace error event (registrar replace-warning seam)."}
 
-   ;; ---- re-frame.trace.tooling (rf2-qwm0a — dev-tooling buffer + listener
-   ;; surface split off for production DCE; trace.cljc reaches the buffer
+   ;; ---- re-frame.trace.tooling (dev-tooling buffer + listener surface,
+   ;; separate from trace.cljc for production DCE; trace.cljc reaches the buffer
    ;; push + listener fan-out through this single hook). The public
    ;; surface fns (`register-listener!` / `unregister-listener!` /
    ;; `clear-listeners!` / `trace-buffer` / `clear-trace-buffer!` /
@@ -1047,10 +1034,10 @@
     :design-bead "rf2-r1ciy"
     :description "Drop a dev-trace listener. Sibling of `:trace.tooling/register-listener!` — same rf2-r1ciy seam; same direct-call consumers (tests / tools / SSR)."}
 
-   ;; ---- re-frame.trace.tooling — per-frame trace rings (rf2-g1b2m / rf2-8uwce) ----
+   ;; ---- re-frame.trace.tooling — per-frame trace rings ----------------------
    ;;
-   ;; The four hooks below carry the per-frame ring + B4 dedup machinery
-   ;; introduced by rf2-g1b2m / rf2-8uwce. They're consulted from
+   ;; The four hooks below carry the per-frame ring + B4 dedup machinery.
+   ;; They're consulted from
    ;; `re-frame.frame/reg-frame` + `destroy-frame!` (lifecycle) and
    ;; `re-frame.registrar/register!` / `unregister!` / `clear-kind!`
    ;; (B4 dedup). All routed via late-bind so production CLJS bundles
@@ -1077,7 +1064,7 @@
     :design-bead "rf2-g1b2m"
     :description "Read the currently-bound frame id from `re-frame.frame/*current-frame*`. Consulted by `re-frame.trace.tooling/push-to-ring!` as the routing fallback when the trace event itself does not carry a `:frame` tag (e.g. sub recompute / view render emits inside an in-flight cascade)."}
 
-   ;; ---- re-frame.trace.cascade (rf2-931pm — focused-event-only cascade-DAG aggregator) ----
+   ;; ---- re-frame.trace.cascade (focused-event-only cascade-DAG aggregator) ----
    ;;
    ;; The three hooks let `re-frame.epoch/settle!` reach the aggregator
    ;; (`:trace.cascade/capture-for-epoch!`) without requiring the
@@ -1103,7 +1090,7 @@
     :design-bead "rf2-931pm"
     :description "Restore the no-op default focus predicate (no epoch focused). Withdraw counterpart of `:trace.cascade/set-focus-predicate!`; same no-Xray-consumer status — only the core `trace_cascade_captured_test` calls `re-frame.trace.cascade/clear-focus-predicate!` directly."}
 
-   ;; NOTE (rf2-7pgiz): `:subs/resolve-sub-override` — the SUBSTITUTIVE
+   ;; NOTE: `:subs/resolve-sub-override` — the SUBSTITUTIVE
    ;; dev-only sub-override seam consulted by `re-frame.subs/subscribe`
    ;; inside its `interop/debug-enabled?` gate — is PUBLISHED from the
    ;; Story side (`re-frame.story.sub-overrides`, under `tools/`), NOT

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.live-frame
-  "EP-0023 image-loading + EP-0024 (rf2-tu2vr7) the unified frame collapse: the
+  "EP-0023 image-loading + EP-0024 unified frame model: the
   ONE public `rf/make-frame` constructor over the ONE `re-frame.frame/frames`
   registry. `make-frame` accepts `:images` (always a vector) — resolving those
   image values into ONE sealed image generation (via

--- a/implementation/core/src/re_frame/observability.cljc
+++ b/implementation/core/src/re_frame/observability.cljc
@@ -34,7 +34,7 @@
     `error-emit/dispatch-error-record!` calls [[route-error-record!]] for
     the EP-0008 NON-EVENT union records (the frame-teardown report, the
     promoted SSR categories) — BOTH ALONGSIDE the always-on error-emit
-    listener fan-out (rf2-ntv9i9.1).
+    listener fan-out.
 
   This is the THIRD of the three observation streams (Spec 015 §The three
   observation streams) — the bounded, projected, frame-`:observability`-
@@ -256,22 +256,21 @@
         (route-stream! frame-id record entries))))
   nil)
 
-;; ---- non-event union record route (EP-0008, rf2-ntv9i9.1) -----------------
+;; ---- non-event union record route (EP-0008) -------------------------------
 ;;
 ;; `route-error!` (above) is the EVENT-centric route: its positional signature
 ;; `[error-kw event event-id frame-id exception elapsed-ms time correlation]`
 ;; builds an `:rf.observe/error` record from a dispatched-event / subscribe
-;; failure. But the EP-0008 NON-EVENT always-on records — the frame-teardown
+;; failure. The EP-0008 NON-EVENT always-on records — the frame-teardown
 ;; report (`:hook-failures`) and the promoted SSR categories (`:phase` /
 ;; `:reason` / `:projector-id` / …) — do NOT fit that positional shape: they
 ;; are pre-built union records with flat category-specific slots and no
-;; `:event` / `:event-id`. Before rf2-ntv9i9.1 these reached ONLY the
-;; corpus-wide `register-error-listener!` registry (the advanced integration
-;; API) and BYPASSED the frame-owned `:observability :errors` sinks — yet Spec
-;; 015 §Frame-owned observability sink policy says EVERY production-reachable
-;; `:rf.error/*` site routes to the frame sinks ALONGSIDE the listener fan-out.
-;; That left the NORMAL production sink model (the Datadog/Sentry story) blind
-;; to EP-0008's flagship teardown report. `route-error-record!` closes the gap.
+;; `:event` / `:event-id`. `route-error-record!` is their route to the
+;; frame-owned `:observability :errors` sinks, so that — per Spec 015
+;; §Frame-owned observability sink policy — EVERY production-reachable
+;; `:rf.error/*` site reaches the frame sinks ALONGSIDE the corpus-wide
+;; `register-error-listener!` fan-out, keeping the production sink model (the
+;; Datadog/Sentry story) fed with EP-0008's teardown report.
 
 (def ^:private error-record-summary-keys
   "Slots of a non-event union error record that map onto the canonical

--- a/implementation/core/src/re_frame/path.cljc
+++ b/implementation/core/src/re_frame/path.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.path
   "Internal path algebra for `:rf/path` — the shared lightweight-optics
-  vocabulary every path-shaped re-frame2 fact inherits (EP-0012,
-  ACCEPTED ruling rf2-s7xshi). The normative contract lives in
+  vocabulary every path-shaped re-frame2 fact inherits (EP-0012). The
+  normative contract lives in
   [`spec/Conventions.md` §The `:rf/path` algebra]; this namespace is the
   reference implementation.
 
@@ -85,7 +85,7 @@
   normalize to a vector (Conventions §Path shape).
 
   The root path is the EXPLICIT empty vector `[]`; a nil path FAILS CLOSED
-  with `:rf.error/bad-path` (EP-0012 fail-closed boundary, rf2-w9x5fv). An
+  with `:rf.error/bad-path` (EP-0012 fail-closed boundary). An
   omitted path is NOT silently the whole value: a caller that legitimately
   has no path handles that absence BEFORE normalization (e.g. an `or`-default
   to `[]` at its own boundary, where targeting the root is the deliberate
@@ -126,13 +126,13 @@
   validation: `normalize-concrete` THROWS on a bad segment; `segment?`
   answers the same membership question without throwing, for a consumer
   that builds its own diagnostic (e.g. flows' `reg-flow` validator names
-  the offending entries under `:bad-elements` — rf2-t3cfil). A subsystem
+  the offending entries under `:bad-elements`). A subsystem
   that needs a NARROWER domain composes its own predicate ON TOP of this
   one (e.g. `(and (segment? x) (not (nil? x)))`), so the shared upper bound
   stays the single definition and no consumer re-enumerates the host-type
   discrimination.
 
-  rf2-ujmc3u: an INTEGER segment must be inside the CEDN-1 safe-integer
+  An INTEGER segment must be inside the CEDN-1 safe-integer
   range — the shared path vocabulary MUST NOT be wider than canonical EDN
   identity, or a consumer keying off `segment?` could admit an integer
   (`9007199254740992`) that cannot be portably compared, printed, routed,
@@ -157,7 +157,7 @@
   "Normalize a path to the canonical vector form AND validate that every
   segment is a concrete EDN identity value (Conventions §Segment domain).
 
-  This is the VALIDATED concrete boundary (EP-0012 rf2-w9x5fv item 2):
+  This is the VALIDATED concrete boundary (EP-0012 item 2):
   `normalize` coerces container shape only; `normalize-concrete` additionally
   fails closed with `:rf.error/bad-path` on any segment outside the concrete
   domain — an opaque host object, a function, a template-parameter segment
@@ -388,12 +388,12 @@
   `instantiate` is a CONCRETE-path PRODUCER: its result is meant to be fed
   to `get` / `put` / `over` as a runtime path, so it routes the substituted
   result through `normalize-concrete` — the SAME validated boundary frame
-  classification and resource scope use (rf2-w9x5fv). A binding whose VALUE
+  classification and resource scope use. A binding whose VALUE
   is outside the concrete-segment domain — a function, host object, or a
   composite (vector / map / set), including a literal `[:rf.path/param …]`
   data form — FAILS CLOSED with `:rf.error/bad-path` rather than silently
-  smuggling a non-portable segment into a path presented as concrete
-  (rf2-ehkut7). A present-`nil` binding is a legal concrete segment and
+  smuggling a non-portable segment into a path presented as concrete.
+  A present-`nil` binding is a legal concrete segment and
   passes (the missing-binding case is the fail-closed
   `:rf.error/missing-path-param` above)."
   [path-or-decl bindings]

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -10,9 +10,10 @@
   property of the data VALUE at a path, not of the handler that touched it.
 
   EP-0015 §8: schemas describe shape, not durable app-db egress policy — a
-  `reg-app-schema` `{:sensitive? true}` slot prop is no longer a route into
-  this registry. (Schema `:sensitive?` still drives schema-validation-
-  failure-trace redaction in `re-frame.schemas`, a separate egress product.)
+  `reg-app-schema` `{:sensitive? true}` slot prop is not a route into this
+  registry, which is fed solely by frame-owned classification. (Schema
+  `:sensitive?` drives schema-validation-failure-trace redaction in
+  `re-frame.schemas`, a separate egress product.)
 
   The helpers here are the path-overlap arm of that scheme — they redact
   event-payload paths whose path-scoped handler slice overlaps a
@@ -50,7 +51,7 @@
 
 (defn- sensitive-declarations
   [frame-id]
-  ;; rf2-ivr38u — HOT PATH (every dispatch, via `schema-redaction-paths`
+  ;; HOT PATH (every dispatch, via `schema-redaction-paths`
   ;; in the router's `prepare-handler-ctx`). The
   ;; `:elision/sensitive-declarations` hook is published ONCE at boot
   ;; (`re-frame.elision`, bottom of file) and never withdrawn in
@@ -84,10 +85,9 @@
 
   The overlap is computed against the frame's sensitive-declarations
   registry (frame-owned `:sensitive {:app-db …}` classification, EP-0015
-  §3 / §8) — NOT against schema-attached `{:sensitive? true}` slot props,
-  which no longer feed this registry. The fn name is retained for callers.
+  §3 / §8), the single source of truth for app-db sensitivity.
 
-  rf2-ivr38u — DOMINANT-PATH SKIP: when the frame declares ZERO sensitive
+  DOMINANT-PATH SKIP: when the frame declares ZERO sensitive
   app-db paths (the common case) there is no overlap to compute, so the
   `handler-db-paths` chain walk + `mapcat` are bypassed entirely."
   [frame-id interceptors]
@@ -103,16 +103,15 @@
       (empty? path)
       redacted-sentinel
 
-      ;; rf2-agpv2.4 — the parent must be ASSOCIATIVE for `assoc-in` to
-      ;; descend into it, not merely non-nil. A `(some? …)` guard let a
-      ;; non-nil scalar parent through (e.g. payload `{:auth "tok"}` with
-      ;; redact path `[:auth :password]`): `assoc-in` then recurses into
-      ;; the string and throws ("cannot assoc onto a String"). That throw
-      ;; lands inside a `:before` interceptor and aborts the whole event
-      ;; (classified `:rf.error/interceptor-exception`, no `:db` commit, no
-      ;; `:fx`) — a redaction that silently drops the event. `associative?`
-      ;; treats a non-associative parent as a no-op, matching the
-      ;; missing-leaf no-op posture below.
+      ;; The parent must be ASSOCIATIVE for `assoc-in` to descend into it,
+      ;; not merely non-nil. A non-nil scalar parent (e.g. payload
+      ;; `{:auth "tok"}` with redact path `[:auth :password]`) would make
+      ;; `assoc-in` recurse into the string and throw ("cannot assoc onto a
+      ;; String"); that throw lands inside a `:before` interceptor and aborts
+      ;; the whole event (classified `:rf.error/interceptor-exception`, no
+      ;; `:db` commit, no `:fx`) — a redaction that silently drops the event.
+      ;; `associative?` treats a non-associative parent as a no-op, matching
+      ;; the missing-leaf no-op posture below.
       (associative? (get-in payload (butlast path)))
       (assoc-in payload path redacted-sentinel)
 
@@ -179,17 +178,16 @@
   event vector's payload map with the `:rf/redacted` sentinel before the
   handler body runs.
 
-  REMOVED FROM THE PUBLIC API (EP-0015 §7, rf2-mngp4o). A positional
-  \"redact for the trace but not the handler\" interceptor made privacy
+  NOT part of the public API (EP-0015 §7). A positional
+  \"redact for the trace but not the handler\" interceptor would make privacy
   depend on interceptor placement rather than on the owner of the payload
-  shape; registration-owned `:sensitive` payload classification +
-  centralized `project-egress` at egress boundaries replace it. This fn
-  remains as internal router plumbing (the router still recognises a
-  resolved `redact-interceptor`-shaped value — `:id :rf/redact-interceptor`
-  — in a handler's chain), but it is no longer published from the
-  `re-frame.core` façade. Since EP-0022 (chains are reference-only) it can
-  only reach a chain via `reg-interceptor` + a by-id reference, never as an
-  inline value.
+  shape; privacy instead rests on registration-owned `:sensitive` payload
+  classification + centralized `project-egress` at egress boundaries. This
+  fn is internal router plumbing (the router recognises a resolved
+  `redact-interceptor`-shaped value — `:id :rf/redact-interceptor` — in a
+  handler's chain) and is not published from the `re-frame.core` façade.
+  Per EP-0022 (chains are reference-only) it can only reach a chain via
+  `reg-interceptor` + a by-id reference, never as an inline value.
 
   The handler itself receives the UNREDACTED payload via the regular
   `:event` coeffect slot; the redaction is for the trace surface only
@@ -213,7 +211,7 @@
       handler invocation on the trace surface inside the cascade. The
       record carries the already-scrubbed trace events into the fn.
 
-  Internal usage (no longer a public `rf/` surface; reference-only since
+  Internal usage (not a public `rf/` surface; reference-only per
   EP-0022 — register the built value, reference it by id):
 
       (rf/reg-interceptor :auth/redact-login
@@ -264,7 +262,7 @@
         interceptors))
 
 (defn collect-redaction-paths
-  "Single-pass fusion (rf2-ivr38u / rf2-tgea2z companion) of
+  "Single-pass fusion of
   `schema-redaction-paths` + `user-redaction-paths` over the SAME
   resolved interceptor chain — read together by the router's
   `prepare-handler-ctx` on every dispatch.
@@ -278,9 +276,9 @@
   to calling `schema-redaction-paths` and `user-redaction-paths`
   separately. The schema-path overlap is only computed when the frame
   declares ≥1 sensitive app-db path (the dominant no-classification path
-  skips the overlap `mapcat` entirely); the single chain walk still
+  skips the overlap `mapcat` entirely); the single chain walk
   collects `:path` slices unconditionally so the overlap, when needed,
-  sees the same db-paths the two-walk form did."
+  sees the same db-paths it would under two separate walks."
   [frame-id interceptors]
   (let [sensitive-paths (keys (sensitive-declarations frame-id))
         {:keys [db-paths user-paths]}

--- a/implementation/core/src/re_frame/projection.cljc
+++ b/implementation/core/src/re_frame/projection.cljc
@@ -37,9 +37,7 @@
   override WINS — `profile-opts` is the floor, the caller's opts the
   overlay).
 
-  The six ruled profiles (EP-0015 issue 3, renamed for axis consistency —
-  `local-redacted` / `local-raw` replacing the EP's earlier
-  on-box-hidden-sensitive / trusted-local-raw spellings):
+  The six ruled profiles (EP-0015 issue 3):
 
   | Profile | Default behaviour |
   |---|---|
@@ -61,7 +59,7 @@
   borrow another frame's policy — `project-egress` inherits that fail-closed
   posture, it does NOT synthesise `:rf/default`.
 
-  ## Event-shaped slots carry REGISTRATION-owned marks (EP-0015 / rf2-qe6v1u)
+  ## Event-shaped slots carry REGISTRATION-owned marks (EP-0015)
 
   An `:rf.observe/*` record's `:event` slot is the raw dispatched vector — a
   REGISTRATION-OWNED transient payload (EP-0015): a handler registered with
@@ -223,7 +221,7 @@
 (defn- redact-event-by-registration
   "Apply the event handler's REGISTRATION-OWNED `:sensitive` / `:large` marks
   to an event-shaped slot value (a `[event-id arg-map …]` vector) via the
-  always-on `:marks/redact-event-by-registration` hook (EP-0015 / rf2-qe6v1u).
+  always-on `:marks/redact-event-by-registration` hook (EP-0015).
   A no-op (returns `event` unchanged) when the hook is unbound (the marks ns has
   not loaded) or the handler declared no marks. This is the EVENT-owner pass
   that precedes the FRAME-policy `walk-slot`: event args are registration-owned
@@ -235,7 +233,7 @@
 
 (defn- project-event-slot
   "Project an event-shaped slot: the event registration's marks FIRST (the
-  EVENT owner — EP-0015 / rf2-qe6v1u), then the frame-policy size/sensitive
+  EVENT owner — EP-0015), then the frame-policy size/sensitive
   walk. A sentinel the registration pass writes is inert under the subsequent
   walk."
   [event elision-opts]
@@ -272,7 +270,7 @@
     (if (and (contains? record :event)
              (include-event-args? elision-opts))
       ;; Trusted-local opt-in: keep `:event`, PROJECTED (never raw) — the event
-      ;; registration's marks FIRST (EP-0015 / rf2-qe6v1u), then frame policy.
+      ;; registration's marks FIRST (EP-0015), then frame policy.
       (assoc base :event (project-event-slot (:event record) elision-opts))
       ;; Off-box default: the `:event` args slot is omitted entirely.
       base)))
@@ -301,7 +299,7 @@
   [record opts elision-opts]
   (let [base (select-keys record error-summary-keys)
         ;; Tree-shaped slots → walker. The `:event` slot is REGISTRATION-owned
-        ;; (EP-0015 / rf2-qe6v1u): apply the event handler's marks before the
+        ;; (EP-0015): apply the event handler's marks before the
         ;; frame-policy walk. `:tags` is frame-policy-only (it is the generic
         ;; non-event tree-lift from `route-error-record!`).
         with-tree (reduce
@@ -376,7 +374,7 @@
   (the override wins). An unknown `:rf.egress/profile` throws
   `:rf.error/unknown-egress-profile` — the enum is closed.
 
-  Frame resolution (EP-0015 / rf2-vkblw4): an `:rf.observe/*` record is
+  Frame resolution (EP-0015): an `:rf.observe/*` record is
   FRAME-BEARING — it carries its OWNING frame under a top-level `:frame`
   slot (the §`project-egress` example record carries `:frame :app/main`
   with opts supplying only `:rf.egress/profile`). That owning frame is the
@@ -384,11 +382,11 @@
   when `opts` does NOT supply `:frame` it is SEEDED from the record's
   top-level `:frame`. An explicit `:frame` opt still WINS (override
   semantics — it is the caller's deliberate reclassification), and a
-  kindless / frameless input seeds nothing. Without this seed the
-  documented record-owned-frame call shape silently dropped the record's
-  frame and walked every tree slot under the AMBIENT (or no) frame — which
-  over-redacted off-box slots and, under a sensitive opt-in profile,
-  shipped values raw that the record's frame would have governed.
+  kindless / frameless input seeds nothing. This seed is what lets the
+  record-owned-frame call shape walk every tree slot under the record's
+  OWN frame: without it those slots would fall to the AMBIENT (or no)
+  frame, over-redacting off-box slots and, under a sensitive opt-in
+  profile, shipping raw values the record's frame would have governed.
 
   Fail-closed (EP-0002 / Spec 015 §Direct reads): a tree-shaped slot is
   projected only when the frame is KNOWN — the explicit `:frame` opt, the
@@ -404,7 +402,7 @@
    ;; The record is frame-bearing: seed `:frame` from its owning `:frame`
    ;; slot when opts omits one (an explicit `:frame` opt WINS). A kindless
    ;; / frameless input adds nothing, so the fail-closed posture below is
-   ;; preserved when no frame is known from any source. rf2-vkblw4.
+   ;; preserved when no frame is known from any source.
    (let [opts         (let [record-frame (and (map? record-or-value)
                                               (:frame record-or-value))]
                         (if (and record-frame (not (:frame opts)))

--- a/implementation/core/src/re_frame/recordable.cljc
+++ b/implementation/core/src/re_frame/recordable.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.recordable
-  "Internal DATA-ONLY recordable-value predicate (EP-0017 erratum rf2-rmroo4).
+  "Internal DATA-ONLY recordable-value predicate (EP-0017 erratum).
 
   ## Purpose — \"can this value be recorded and read back as ordinary data?\"
 
@@ -65,8 +65,7 @@
   it as a non-recordable host handle so the failure surfaces AT THE SOURCE
   coeffect (via `explain-non-recordable`) rather than far away at replay /
   Xray / SSR / epoch-export time. Authors who genuinely need to record an
-  instant convert to `java.util.Date` (`Date/from`) at the boundary
-  (rf2-3az1vn P2)."
+  instant convert to `java.util.Date` (`Date/from`) at the boundary."
   [x]
   #?(:clj  (instance? Date x)
      :cljs (instance? js/Date x)))

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -8,10 +8,10 @@
     :event :sub :fx :cofx :interceptor :view :frame :route :head
     :error-projector :flow :resource
 
-  Machine guards and actions are NOT a registrar kind (rf2-ftrcv,
-  supersedes rf2-ypu5i / rf2-npvsx). Per Spec 005 the machine spec's
-  `:guards` / `:actions` maps are the single source of truth — the
-  runtime resolves them through the machine spec, never the registrar.
+  Machine guards and actions are NOT a registrar kind. Per Spec 005 the
+  machine spec's `:guards` / `:actions` maps are the single source of
+  truth — the runtime resolves them through the machine spec, never the
+  registrar.
   Their dev-only fn-source handler-meta surface (`(rf/handler-meta
   :machine-guard [machine-id guard-id])`, consumed by Xray's
   focused-transition lens + re-frame-pair source-jump) is DERIVED on
@@ -22,7 +22,7 @@
   per Spec 009 §Production builds (the macro emits no `:source-*` slots
   under `goog.DEBUG=false`, so the derivation returns nil).
 
-  App-db schemas are NOT a registrar kind (rf2-cq1ak). `reg-app-schema`
+  App-db schemas are NOT a registrar kind. `reg-app-schema`
   writes only to the schemas artefact's own per-frame side-table
   (`schemas/schemas-by-frame`), which is the single source of truth.
   Tools introspecting app-db schemas go through `schemas/app-schemas`
@@ -36,7 +36,7 @@
   metadata map allocation all disappear from `:advanced` production
   bundles where `goog.DEBUG` is `false`.
 
-  ## Pure-documentation metadata elision (rf2-9wwkcm)
+  ## Pure-documentation metadata elision
 
   Per Spec 001 §Production elision contract, a registration-metadata key
   is **elidable** in production iff it has ZERO production runtime use AND
@@ -75,29 +75,29 @@
 (def kinds
   "The closed set of registry kinds for v1. Adding a new kind is a Spec change.
 
-  Machine guards/actions are NOT registrar kinds (rf2-ftrcv, supersedes
-  rf2-ypu5i / rf2-npvsx) — the runtime resolves them through the machine
-  spec's `:guards` / `:actions` maps, and their dev-only fn-source
-  handler-meta is DERIVED from the machine's `:event` registration spec
-  (see `re-frame.core-machines/machine-handler-meta`), not stored here.
+  Machine guards/actions are NOT registrar kinds — the runtime resolves
+  them through the machine spec's `:guards` / `:actions` maps, and their
+  dev-only fn-source handler-meta is DERIVED from the machine's `:event`
+  registration spec (see `re-frame.core-machines/machine-handler-meta`),
+  not stored here.
 
-  App-db schemas (rf2-cq1ak) are NOT a registrar kind — they live in the
-  schemas artefact's per-frame side-table (`schemas/schemas-by-frame`).
+  App-db schemas are NOT a registrar kind — they live in the schemas
+  artefact's per-frame side-table (`schemas/schemas-by-frame`).
   Introspect via `schemas/app-schemas` / `schemas/app-schema-meta-at`.
 
-  `:resource` (rf2-p10npe, Spec 016 §Registration) is the resources
+  `:resource` (Spec 016 §Registration) is the resources
   artefact's registrar kind — `reg-resource` registers a resource spec
   under it. Deliberately `:resource`, NOT `:query` (which would collide
   with route query-params + prior-art names). Reserved whether or not the
   Resources artefact ships.
 
-  `:mutation` (rf2-dwme29, Spec 016 §Deferred slices / EP-0003 §Mutations,
+  `:mutation` (Spec 016 §Deferred slices / EP-0003 §Mutations,
   the first public-beta gate) is the resources artefact's mutation
   registrar kind — `reg-mutation` registers a mutation spec under it (the
   causal-write counterpart of `:resource`). Reserved whether or not the
   Resources artefact ships.
 
-  `:resource-scope` (rf2-hls77w, Spec 016 §Named resource-scope resolvers /
+  `:resource-scope` (Spec 016 §Named resource-scope resolvers /
   EP-0016 D3) is the resources artefact's THIRD kind — `reg-resource-scope`
   registers a pure named scope resolver under it (the one scope-resolution
   currency reused by resource registration, route resources, ensure /
@@ -105,7 +105,7 @@
   distinct kind, not folded into `:resource`. Reserved whether or not the
   Resources artefact ships.
 
-  `:interceptor` (rf2-0adhqs.2, Spec 001 §Interceptors / EP-0022) is the
+  `:interceptor` (Spec 001 §Interceptors / EP-0022) is the
   registered-interceptor registrar kind — `reg-interceptor` stores an
   interceptor DESCRIPTOR (`{:before}` / `{:after}` / `{:before :after}` /
   `{:factory}`) under it, keyed by a qualified keyword id. Event/frame
@@ -139,8 +139,8 @@
 ;; `*registrar*` is a rebindable seam an alternate-registrar seating could bind
 ;; to redirect the `reg-*` lowering path to a different `(kind, id) → metadata`
 ;; table without re-plumbing an argument through `re-frame.events` / `.subs` /
-;; `.fx` / `.cofx`. No live caller binds it today (the EP-0013 install seating
-;; path was removed); outside any binding it is nil and the default path holds.
+;; `.fx` / `.cofx`. No live caller binds it; outside any binding it is nil and
+;; the default path holds.
 (def ^:dynamic *registrar*
   "The active registrar atom, or nil for the process-default
   `kind->id->metadata`. A rebindable seam; no live caller binds it (nil ⇒ the
@@ -157,9 +157,9 @@
   (or *registrar* kind->id->metadata))
 
 ;; ---- the active resolved image GENERATION (EP-0023 §Frame-derived live
-;;      registration resolution, rf2-32siq3.9) --------------------------------
+;;      registration resolution) ------------------------------------------------
 ;;
-;; EP-0023 restates the a15n62 invariant in image/frame terms:
+;; EP-0023 states the resolution invariant in image/frame terms:
 ;;
 ;;     target frame -> resolved image generation -> registration resolution
 ;;
@@ -176,11 +176,11 @@
 ;; subscribe / fx / cofx / view / resource lookup is in flight against an
 ;; EP-0023 frame object), `lookup` / `handler` / `registrations` / `ids`
 ;; resolve through the generation's resolver FIRST instead of the registrar
-;; atom. When nil — the absence-is-default path, EVERY existing caller (the
-;; EP-0013 realm-routed dispatch and the single-realm default path alike) — the
-;; reads target `active-registrar`'s atom exactly as before, byte-identical.
-;; This var is consulted with ONE nil check on the read hot path; the dominant
-;; production path leaves it unbound and pays a single `nil?` branch.
+;; atom. When nil — the absence-is-default path, taken by EVERY caller that is
+;; not resolving against a frame object (the realm-routed dispatch and the
+;; single-realm default path alike) — the reads target `active-registrar`'s
+;; atom. This var is consulted with ONE nil check on the read hot path; the
+;; dominant production path leaves it unbound and pays a single `nil?` branch.
 ;;
 ;; PERF / coherence: like `*registrar*`, the binding is established ONCE per
 ;; cascade / subscribe-build by `re-frame.live-frame/call-with-frame-resolution`
@@ -200,8 +200,8 @@
   subscribe / fx / cofx / view / resource resolution targeting an EP-0023 frame
   OBJECT, so `(kind, id)` lookups resolve through the frame's OWN image
   generation rather than the global/default registrar (EP-0023 §Frame-derived
-  live registration resolution, rf2-32siq3.9). nil ⇒ the absence-is-default
-  registrar-atom path — byte-identical for every existing caller."
+  live registration resolution). nil ⇒ the absence-is-default
+  registrar-atom path, taken by every caller not resolving against a frame."
   nil)
 
 (defn- generation-resolver
@@ -248,7 +248,7 @@
   ;; first-time registration). Registered by namespaces that need to
   ;; validate cross-id invariants at registration time (e.g. routing's
   ;; `:url-bound?` "only one frame owns the URL" rule per Spec 012
-  ;; §Multi-frame routing — rf2-w50qm). Fires AFTER the slot is written
+  ;; §Multi-frame routing). Fires AFTER the slot is written
   ;; so the hook can inspect the final registry state.
   (atom []))
 
@@ -269,7 +269,7 @@
 ;; `:trace/emit!` (re-frame.trace depends on re-frame.registrar, so
 ;; `:require` would cycle). `:trace/emit!` is published once at
 ;; re-frame.trace load and never withdrawn, so the resolution is sticky
-;; — `late-bind/get-fn-cached` memoises it (rf2-f72pd).
+;; — `late-bind/get-fn-cached` memoises it.
 ;;
 ;; Each call site keeps its OUTERMOST `(when interop/debug-enabled? ...)`
 ;; gate. That gate is the load-bearing condition Closure constant-folds
@@ -281,9 +281,8 @@
 
 (defn- emit!
   "Invoke `:trace/emit!` with the `:rf.registry` op-type, memoising the
-  late-bind resolution through `late-bind/get-fn-cached` (rf2-f72pd —
-  this fn previously held its own per-key `emit!-cache` atom; that
-  pattern is now generalised in `re-frame.late-bind`). Callers MUST
+  late-bind resolution through `late-bind/get-fn-cached` (the shared
+  memoisation pattern lives in `re-frame.late-bind`). Callers MUST
   wrap invocations in `(when interop/debug-enabled? ...)` so Closure
   DCE elides the call and its literal args under `:advanced +
   goog.DEBUG=false`."
@@ -293,7 +292,7 @@
 
 (defn- dedup-allow?
   "Consult the B4 hot-reload dedup-by-shape table (per Spec 009
-  §Hot-reload dedup — re-emits suppressed by shape, rf2-g1b2m). Returns
+  §Hot-reload dedup — re-emits suppressed by shape). Returns
   true if the emit should proceed; false if the prior emit for this
   `(kind, id)` already carried an identical shape (so this re-emit
   carries no new signal).
@@ -411,12 +410,12 @@
   hot reload; a different ns for the same `(kind, id)` is the
   image-isolation collision case).
 
-  Comparing fn IDENTITY (the prior implementation) mis-detected: a
-  same-file save-and-re-eval yields a FRESH fn instance, so identity
-  always differs and the warning fired on every hot reload — exactly the
-  false positive the spec says MUST be silent. Comparing provenance
-  instead, the same source site re-evaluates to the same `(ns, file,
-  line)` and is correctly silent.
+  Provenance is the right basis, NOT fn identity: a same-file
+  save-and-re-eval yields a FRESH fn instance, so an identity comparison
+  always differs and would fire the warning on every hot reload — exactly
+  the false positive the spec says MUST be silent. Comparing provenance,
+  the same source site re-evaluates to the same `(ns, file, line)` and is
+  correctly silent.
 
   Absent provenance on EITHER side (a programmatic / REPL `register!`
   that bypassed the macro path — no coords captured) is NOT a collision:
@@ -462,7 +461,7 @@
                          (source-coords new-meta) (assoc :source-coords
                                                          (source-coords new-meta))))))))
 
-;; ---- pure-documentation metadata elision (rf2-9wwkcm) ----------------------
+;; ---- pure-documentation metadata elision ----------------------------------
 
 (def pure-documentation-keys
   "The registration-metadata keys that are PURE documentation — zero
@@ -489,7 +488,7 @@
   "Drop the pure-documentation keys (`pure-documentation-keys`) from a
   registration `metadata` map in production builds (`interop/debug-enabled?`
   false). Returns `metadata` unchanged in dev. Per Spec 001 §Production
-  elision contract (rf2-9wwkcm).
+  elision contract.
 
   The `interop/debug-enabled?` gate is the OUTERMOST form so Closure
   constant-folds it under `:advanced` + `goog.DEBUG=false`: the dev arm
@@ -520,7 +519,7 @@
   devtools refresh their view from this event). The trace's `:tags`
   carry `:different-fn?` so tooling can branch idempotent reloads from
   real fn-identity changes without re-emitting through a separate
-  surface — `(rf2-6w7zn)`."
+  surface."
   [kind id metadata]
   (when-not (valid-kind? kind)
     (error/throw-error!
@@ -530,7 +529,7 @@
       {:recovery :fix-registration
        :extra    {:kind kind
                   :id   id}}))
-  ;; Always-on error-coord parallel registry (rf2-3un2g §Production
+  ;; Always-on error-coord parallel registry (§Production
   ;; elision). When a public reg-* macro is on the stack `*pending-coords*`
   ;; carries the captured coord-map (slim in CLJS prod — no `:column`).
   ;; The error-emit substrate looks coords up via
@@ -542,7 +541,7 @@
   ;; itself guards against nil.
   (when-let [pc source-coords/*pending-coords*]
     (source-coords/remember-error-coords! kind id pc))
-  ;; Pure-documentation metadata elision (rf2-9wwkcm). Under `:advanced` +
+  ;; Pure-documentation metadata elision. Under `:advanced` +
   ;; `goog.DEBUG=false` strip the pure-documentation keys (`:doc`) BEFORE the
   ;; metadata is stored, so `(rf/handler-meta kind id)` carries no `:doc` in
   ;; production — consistent with source-coords already being absent there
@@ -557,7 +556,7 @@
         reg      (active-registrar)
         previous (-> @reg (get kind) (get id))]
     (swap! reg assoc-in [kind id] metadata)
-    ;; EP-0023 provenance-preserving source store (rf2-32siq3.2). In addition
+    ;; EP-0023 provenance-preserving source store. In addition
     ;; to the resolver-map write above (the unchanged default-image runtime
     ;; path), record the descriptor in the source store keyed by
     ;; [kind id provenance-namespace]. Cross-namespace duplicate `(kind, id)`
@@ -581,11 +580,11 @@
           (try (f {:kind kind :id id :was previous :now metadata
                    :different-fn? different?})
                (catch #?(:clj Throwable :cljs :default) _ nil)))
-        ;; Per Spec 001 §Hot-reload trace surface (rf2-6w7zn): emit
+        ;; Per Spec 001 §Hot-reload trace surface: emit
         ;; `:rf.registry/handler-replaced` on EVERY re-registration —
         ;; not only when the handler-fn changes. Kinds like `:frame`
-        ;; replace the slot without rotating `:handler-fn`, so a
-        ;; `different?`-gated emit dropped legitimate re-registration
+        ;; replace the slot without rotating `:handler-fn`, so gating the
+        ;; emit on `different?` would drop legitimate re-registration
         ;; events on the floor. The `:different-fn?` tag is preserved
         ;; for tools that want to suppress idempotent-reload noise on
         ;; their side.
@@ -595,7 +594,7 @@
         ;; branch (per Spec 009 §Production builds).
         ;;
         ;; Per Spec 009 §Hot-reload dedup — re-emits suppressed by shape
-        ;; (B4 ruling, rf2-g1b2m): consult the dedup table. Identical
+        ;; (B4 ruling): consult the dedup table. Identical
         ;; shape on re-register (a hot-reload that didn't actually
         ;; change the handler) emits ZERO `:rf.registry/handler-replaced`
         ;; trace events; a real edit emits exactly one.
@@ -604,32 +603,32 @@
             (emit! :rf.registry/handler-replaced
                    {:kind kind :id id :different-fn? different?}))
           ;; Per Spec 001 §Re-registration of a different function —
-          ;; collision warning (rf2-45kaz). Decoupled from the
-          ;; handler-replaced dedup gate (rf2-3az1vn P2): the collision
-          ;; warning detects a CROSS-SOURCE id clash by PROVENANCE
-          ;; (different `(ns, file, line)`), not by handler-fn shape, and
-          ;; carries its OWN per-(kind, id) suppression (`collision-warned`).
-          ;; Nesting it inside the `dedup-allow?` (handler-replaced) gate
-          ;; meant a kind with no rotating `:handler-fn` — `:frame`,
-          ;; `:route`, `:head` — could be deduped-away by shape and so a
-          ;; GENUINE cross-source clash for those kinds never warned. Call
-          ;; it independently (still under `interop/debug-enabled?` for
-          ;; production elision); `collision?` keeps a same-source hot-reload
-          ;; re-eval silent, and the warn-once cache keeps the dev stream
-          ;; readable across reload churn.
+          ;; collision warning. Decoupled from the handler-replaced dedup
+          ;; gate: the collision warning detects a CROSS-SOURCE id clash by
+          ;; PROVENANCE (different `(ns, file, line)`), not by handler-fn
+          ;; shape, and carries its OWN per-(kind, id) suppression
+          ;; (`collision-warned`). It must run independently of the
+          ;; `dedup-allow?` (handler-replaced) gate: a kind with no rotating
+          ;; `:handler-fn` — `:frame`, `:route`, `:head` — can be deduped-away
+          ;; by shape, so nesting the collision check inside that gate would
+          ;; let a GENUINE cross-source clash for those kinds go unwarned.
+          ;; Called here independently (still under `interop/debug-enabled?`
+          ;; for production elision); `collision?` keeps a same-source
+          ;; hot-reload re-eval silent, and the warn-once cache keeps the dev
+          ;; stream readable across reload churn.
           (maybe-emit-collision! kind id previous metadata)))
       ;; First-time registration — emit handler-registered per Spec 009
       ;; §:op-type vocabulary. Hot-reload tools (10x, re-frame-pair) use
       ;; this to track when fresh ids appear in the registry. The B4
       ;; dedup table is also consulted here so the FIRST emit per
       ;; (kind, id) records the baseline shape for subsequent re-emit
-      ;; suppression (rf2-g1b2m). A first registration always allows
+      ;; suppression. A first registration always allows
       ;; (no prior entry to compare against).
       :else
       (when interop/debug-enabled?
         (when (dedup-allow? :rf.registry/handler-registered kind id metadata)
           (emit! :rf.registry/handler-registered {:kind kind :id id}))))
-    ;; Per Spec 001 §`:doc` is dev-warned when absent (rf2-45kaz). Fires
+    ;; Per Spec 001 §`:doc` is dev-warned when absent. Fires
     ;; on every reg-* call whose final metadata-map carries no usable
     ;; `:doc`, once per (kind, id) within the runtime process. Production
     ;; elides via the outer `interop/debug-enabled?` gate (Spec 009
@@ -639,7 +638,7 @@
     ;; without `:doc` does NOT re-fire the warning.
     (when interop/debug-enabled?
       (maybe-emit-missing-doc! kind id metadata))
-    ;; Always-on registration hooks (rf2-w50qm): fire on BOTH first-time
+    ;; Always-on registration hooks: fire on BOTH first-time
     ;; and re-registration so cross-id invariants (e.g. routing's
     ;; `:url-bound?` exclusivity per Spec 012 §Multi-frame routing) can
     ;; be validated at the moment of any registration. Hooks run isolated
@@ -666,7 +665,7 @@
     ;; fires on explicit removal so hot-reload tools can update their
     ;; views. Only emit when something was actually present.
     ;;
-    ;; Per Spec 009 §Hot-reload dedup (B4 ruling, rf2-g1b2m): a clear
+    ;; Per Spec 009 §Hot-reload dedup (B4 ruling): a clear
     ;; of an id the dedup table thinks is already absent (a double-
     ;; clear) is suppressed. The first clear records the `::cleared`
     ;; sentinel; subsequent re-clears emit nothing.
@@ -694,13 +693,13 @@
     ;; `(swap! (active-source-store) dissoc kind)` here would NOT bump the
     ;; generation, leaving the resolved-image-generation cache (keyed on the
     ;; source-store generation) to HIT and return a stale generation that still
-    ;; resolves the just-cleared `(kind, id)`s (rf2-32siq3.34).
+    ;; resolves the just-cleared `(kind, id)`s.
     (source-store/clear-kind! kind)
     (swap! missing-doc-warned clear-kind)
     (swap! collision-warned   clear-kind)
     ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
     ;; fires for each id so consumers see consistent registry transitions.
-    ;; B4 dedup (rf2-g1b2m): a clear-of-a-cleared id is suppressed; the
+    ;; B4 dedup: a clear-of-a-cleared id is suppressed; the
     ;; first clear records the `::cleared` sentinel.
     (when interop/debug-enabled?
       (when (seq previous-ids)
@@ -718,7 +717,7 @@
   this, a test that re-registers an already-warned (kind, id) pair
   would silently miss the warning under suppression.
 
-  Per Spec 009 §Hot-reload dedup (B4 ruling, rf2-g1b2m): also clears
+  Per Spec 009 §Hot-reload dedup (B4 ruling): also clears
   the dev-only `:rf.registry/*` dedup-by-shape table via the
   trace.tooling sibling's clearance hook — a test fixture targeting
   the registry must start each case from a clean dedup slate so the
@@ -732,7 +731,7 @@
   ;; namespace-string pool) in lockstep with the process-default resolver map,
   ;; so a test fixture starts each case from a clean state on both surfaces.
   (source-store/clear-all!)
-  ;; Also clear the always-on error-coord parallel registry (rf2-3un2g)
+  ;; Also clear the always-on error-coord parallel registry
   ;; so test cases start from a clean state on both surfaces.
   (source-coords/forget-error-coords!)
   ;; Clear the B4 dedup table when the trace.tooling sibling is loaded.
@@ -749,7 +748,7 @@
 (defn lookup
   "Return the metadata map registered for (kind, id), or nil.
 
-  EP-0023 §Frame-derived live registration resolution (rf2-32siq3.9): when an
+  EP-0023 §Frame-derived live registration resolution: when an
   EP-0023 frame OBJECT's image generation is in scope (`*generation*` bound by
   `re-frame.live-frame/call-with-frame-resolution`), the `(kind, id)` resolves
   through the FRAME'S OWN generation resolver — so two frames running different
@@ -757,12 +756,13 @@
   generation's resolver is keyed `[kind id]`; the descriptor is the same
   registration-metadata shape `register!` stores (the source store records it
   verbatim), so the return value is byte-shape-identical to the registrar path.
-  When `*generation*` is unbound — the absence-is-default path, EVERY existing
-  caller (single-realm + the a15n62 realm-routed dispatch) — resolution targets
-  the `active-registrar` atom exactly as before, one `nil?` branch on the read.
+  When `*generation*` is unbound — the absence-is-default path, taken by every
+  caller not resolving against a frame object (single-realm + the realm-routed
+  dispatch) — resolution targets the `active-registrar` atom, one `nil?` branch
+  on the read.
 
   Uses paired `get` calls rather than `(get-in ... [kind id])` — `get-in`
-  allocates a path vector per call (rf2-mqv4m), and `lookup` runs per
+  allocates a path vector per call, and `lookup` runs per
   dispatch (event handler), per fx (handler), and per sub (handler)."
   [kind id]
   (if-let [resolver (generation-resolver)]
@@ -800,12 +800,12 @@
   custom slots (id-by-keyword filtering composes via the caller's own
   `filter` over the result map's keys when needed).
 
-  EP-0023 (rf2-32siq3.9): when a frame generation is in scope (`*generation*`
-  bound), the `{id metadata}` map is PROJECTED from the generation's resolver
-  for `kind` — only the ids the frame's OWN image carries, so a generation-
-  scoped query (a per-frame fx walk, a view-id resolution) sees the frame's
-  registration universe, not the global registrar's. Unbound ⇒ the registrar
-  atom path, byte-identical."
+  EP-0023 §Frame-derived live registration resolution: when a frame generation
+  is in scope (`*generation*` bound), the `{id metadata}` map is PROJECTED from
+  the generation's resolver for `kind` — only the ids the frame's OWN image
+  carries, so a generation-scoped query (a per-frame fx walk, a view-id
+  resolution) sees the frame's registration universe, not the global
+  registrar's. Unbound ⇒ the registrar atom path."
   ([kind]
    (if-let [resolver (generation-resolver)]
      (kind-registrations-from-resolver resolver kind)

--- a/implementation/core/src/re_frame/reply.cljc
+++ b/implementation/core/src/re_frame/reply.cljc
@@ -133,22 +133,20 @@
        (seq event)
        (keyword? (first event))))
 
-;; ---- the canonical thrown-error shape for reply failures (rf2-tqlwzr) ------
+;; ---- the canonical thrown-error shape for reply failures -------------------
 ;;
-;; Reply throws historically carried a reply-specific `:rf.error/kind`
-;; discriminator and a human message but no canonical `:rf.error/id` — so a
-;; tool classifying thrown errors by Spec 009's `:rf.error/id` could not handle
-;; reply failures uniformly with every other framework throw. `reply-error`
-;; routes every reply throw through the central builder
-;; (`re-frame.error/thrown-ex-info`, Spec 009 §The thrown-error shape): the
-;; canonical `:rf.error/id` is the `:rf.error/reply-*` keyword (the SOLE Spec
-;; 009 machine discriminator — `:rf.error/`-namespaced so the framework's grep
-;; token / conformance machinery handles it like every other throw), the human
-;; sentence rides `:reason` and leads the derived message (+ the
-;; `[:rf.error/<id>]` token), and the reply-specific `:rf.reply/*` category is
-;; PRESERVED in `:rf.error/kind` for callers that already branch on it. The
-;; `:rf.error/id` ↔ `:rf.error/kind` pair stays in lockstep by construction.
-;; `:where` names the user-facing surface (`:rf/reply-to`).
+;; Every reply throw carries a canonical `:rf.error/id` so a tool classifying
+;; thrown errors by Spec 009's `:rf.error/id` handles reply failures uniformly
+;; with every other framework throw. `reply-error` routes every reply throw
+;; through the central builder (`re-frame.error/thrown-ex-info`, Spec 009 §The
+;; thrown-error shape): the canonical `:rf.error/id` is the `:rf.error/reply-*`
+;; keyword (the SOLE Spec 009 machine discriminator — `:rf.error/`-namespaced
+;; so the framework's grep token / conformance machinery handles it like every
+;; other throw), the human sentence rides `:reason` and leads the derived
+;; message (+ the `[:rf.error/<id>]` token), and the reply-specific
+;; `:rf.reply/*` category rides `:rf.error/kind` for callers that branch on it.
+;; The `:rf.error/id` ↔ `:rf.error/kind` pair stays in lockstep by
+;; construction. `:where` names the user-facing surface (`:rf/reply-to`).
 
 (defn- reply-category->error-id
   "Map a reply-specific `:rf.reply/<suffix>` category to its canonical
@@ -160,7 +158,7 @@
   (keyword "rf.error" (str "reply-" (name category))))
 
 (defn- reply-error
-  "Build the canonical reply thrown-error `ex-info` (rf2-tqlwzr). `category`
+  "Build the canonical reply thrown-error `ex-info`. `category`
   is the `:rf.reply/*` discriminator: it lands in `:rf.error/kind` (the
   preserved reply-specific slot), and its `:rf.error/reply-*` projection lands
   in `:rf.error/id` (the canonical Spec 009 slot). `reason` is the human
@@ -607,7 +605,7 @@
   otherwise from the reply map's own carried `:rf.frame/id` stamp. A reply
   carrying its frame identity SELF-SUMMARIZES by default: a caller need not
   thread the identity back through `opts` just to apply the right egress
-  policy (rf2-wjo28z). Explicit `:frame` still wins (an inspector may target
+  policy. Explicit `:frame` still wins (an inspector may target
   a different policy frame), and resolution still fails closed — if neither
   an explicit `:frame` nor a carried `:rf.frame/id` names a LIVE frame, the
   wire slots redact to the `:rf/redacted` sentinel rather than ship under no
@@ -686,7 +684,7 @@
                 `:work/status :suppressed`, and a `:value` in `extra` is
                 STRIPPED (a stale reply MUST NOT carry `:value` — see
                 `validate-reply`). So threading a natural success/error reply
-                as `extra` cannot produce a non-stale outcome (rf2-waawic).
+                as `extra` cannot produce a non-stale outcome.
 
   Returns:
     {:deliver? <bool>           ;; false ⇒ DO NOT dispatch the app target
@@ -718,7 +716,7 @@
                               :stale/reason   reason
                               :stale/authorised? authorised?})))
          opt-in?  (and wants? authorised?)
-         ;; rf2-waawic — `suppress` is THE correctness boundary, so "stale
+         ;; `suppress` is THE correctness boundary, so "stale
          ;; wins over the natural completion status" (Managed-Effects
          ;; §Status taxonomy) MUST be structurally impossible for a caller
          ;; to violate. Merge `extra` FIRST (its identity facts — `:work/id`,

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -40,8 +40,8 @@
 ;; is the in-flight event's :dispatch-id.
 ;;
 ;; The in-flight dispatch's id is tracked through
-;; `re-frame.trace/*handler-scope*`'s `:dispatch-id` slot (per rf2-g6ih4 —
-;; the scope-bundle Var lives in `trace` so `trace/emit!` can read it and
+;; `re-frame.trace/*handler-scope*`'s `:dispatch-id` slot (the scope-bundle
+;; Var lives in `trace` so `trace/emit!` can read it and
 ;; stamp every trace event emitted inside the cascade with the cascade-
 ;; wide id). `process-event!` binds the scope around the inner
 ;; `process-event*`; child dispatches read it both to populate
@@ -60,7 +60,7 @@
 (defn- next-dispatch-id []
   (swap! dispatch-counter inc))
 
-;; ---- lexical-scope fx-override binding (rf2-5uwl) -------------------------
+;; ---- lexical-scope fx-override binding -------------------------
 ;;
 ;; Per the `rf/with-fx-overrides` macro (declared in re-frame.core) tests
 ;; bind this Var to a `{fx-id -> override}` map for the macro body's
@@ -76,15 +76,14 @@
 ;; key (the per-frame tier).
 (def ^:dynamic *fx-overrides* nil)
 
-;; ---- EP-0017 recordable-coeffect stamping (rf2-s9ss0t / rf2-alc1lf) --------
+;; ---- EP-0017 recordable-coeffect stamping --------
 ;;
 ;; The CAUSAL BOUNDARY: `build-envelope` ensures every dispatch carries an
 ;; `:rf.cofx` map bearing `:rf/time-ms` — the one host-clock read whose value
-;; durable writes may fold (Spec 002 §Recordable coeffects, EP-0010). EP-0017
-;; (slice-A.2) RETIRED the EP-0010 envelope field `:rf.world/inputs`, renaming
-;; it to the flat `:rf.cofx` map (one fact per owner-qualified key, no grouping
-;; sub-maps) and the framework time fact from the nested `:time-ms` to the flat
-;; `:rf/time-ms`.
+;; durable writes may fold (Spec 002 §Recordable coeffects, EP-0010). The
+;; recordable-coeffect envelope field is the flat `:rf.cofx` map (one fact per
+;; owner-qualified key, no grouping sub-maps); the framework time fact is the
+;; flat `:rf/time-ms`.
 ;; This is the ONLY place the clock is read for the causal token; it is NOT
 ;; re-read inside the handler, flow transform, resource reducer, work-ledger
 ;; writer, or commit.
@@ -97,7 +96,7 @@
 ;;     owner-qualified fact slots ride through). The router fills ONLY the
 ;;     framework-required `:rf/time-ms` when absent, never overwriting a
 ;;     supplied one (EP-0010 §Restore, Replay, And Hydration).
-;;   - `:rf/time-ms` is WALL-CLOCK EPOCH ms (rf2-n1rh0f / EP-0010 §Time), read
+;;   - `:rf/time-ms` is WALL-CLOCK EPOCH ms (EP-0010 §Time), read
 ;;     from `interop/epoch-now-ms` (`js/Date.now()` / `System/currentTimeMillis`)
 ;;     — NOT `interop/now-ms` (CLJS `performance.now()` is origin-relative, so a
 ;;     durable timestamp folded from it would be incomparable with `js/Date`-
@@ -147,13 +146,11 @@
                         :after-timer :fx-dispatch :fx-dispatch-later
                         :http :router :ssr-hydration :test :tool
                         :websocket :repl :unknown :other`.
-                        Default `:unknown` per rf2-hxj0d
-                        (changed from `:ui` to avoid false
-                        attribution of unstamped dispatches as
-                        UI-driven). UI handler call-sites stamp
-                        `:source :ui` explicitly; substrate-internal
-                        dispatch sites stamp the matching specific
-                        value per rf2-ejtpd + rf2-c3990 + rf2-1ve9h:
+                        Default `:unknown` — an unstamped dispatch is
+                        not attributed as UI-driven. UI handler
+                        call-sites stamp `:source :ui` explicitly;
+                        substrate-internal dispatch sites stamp the
+                        matching specific value:
                           - machine `:after` timer       → :after-timer
                           - machine `:always` microstep  → :always (on the
                             per-microstep trace; `:always` does not
@@ -161,7 +158,7 @@
                           - machine spawn fx             → :machine-spawn
                           - `:dispatch`(-later) fx from a
                             machine handler              → :machine-action
-                            (rf2-c3990 — the actor-message path)
+                            (the actor-message path)
                           - `:dispatch` fx               → :fx-dispatch
                           - `:dispatch-later` fx         → :fx-dispatch-later
                           - routing-internal dispatch    → :router
@@ -170,14 +167,10 @@
                           - test-harness fixture          → :test
                           - tool / story / REPL          → :tool / :repl
                           - app websocket adapter         → :websocket (opt-in)
-                        Per rf2-c3990 the prior broad `:fx` /
-                        `:machine` / `:dispatch-later` / `:timer`
-                        aliases are dropped — every dispatch site
-                        stamps the specific kind. Per rf2-1ve9h
-                        (Mike-approved Option A, 2026-05-28) the
-                        prior parallel `:rf/dispatch-origin` axis was
-                        collapsed into `:source` — `:source` is now
-                        the single closed-enum functional-origin axis.
+                        Every dispatch site stamps the specific kind;
+                        there are no broad `:fx` / `:machine` /
+                        `:dispatch-later` / `:timer` aliases. `:source`
+                        is the single closed-enum functional-origin axis.
     :origin             actor identity tag (:app default; :pair, :story,
                         :test, ... per Spec 002 §Dispatch origin tagging).
                         Open-vocabulary; distinct from :source which is
@@ -201,14 +194,14 @@
     :parent-dispatch-id the in-flight dispatch's id when this dispatch is
                         emitted from inside another event's processing
     :call-site          compile-time-captured invocation coord stamped by
-                        the `dispatch` / `dispatch-sync` macro (rf2-ts1a).
+                        the `dispatch` / `dispatch-sync` macro.
                         nil for the fn-form path (`dispatch*` etc.) and
                         under `goog.DEBUG=false` advanced builds."
   [event opts]
   (let [dispatch-id        (when interop/debug-enabled? (next-dispatch-id))
         parent-dispatch-id (when interop/debug-enabled?
                              (some-> trace/*handler-scope* :dispatch-id))
-        ;; Per rf2-ts1a: read the macro-stamped `:rf.trace/call-site`
+        ;; Read the macro-stamped `:rf.trace/call-site`
         ;; only when interop/debug-enabled?. Wrap the read itself in
         ;; the gate so the closure compiler can DCE the keyword
         ;; reference under `:advanced` + `goog.DEBUG=false`. Without
@@ -218,7 +211,7 @@
         ;; referenced syntactically.
         call-site          (when interop/debug-enabled?
                              (:rf.trace/call-site opts))
-        ;; EP-0010 disposition 5 (rf2-lj39cn): the RETIRED `:dispatched-at`
+        ;; EP-0010 disposition 5: the RETIRED `:dispatched-at`
         ;; dispatch opt gets the STANDARD RETIREMENT TREATMENT — a HARD
         ;; ERROR naming the replacement, NOT the generic warn-on-unknown-opt
         ;; below. Checked FIRST — BEFORE the cofx clock stamp below —
@@ -230,7 +223,7 @@
         ;; is a correctness contract that must fire in production too — see
         ;; `reject-retired-dispatch-opts!`.
         _                  (diag/reject-retired-dispatch-opts! opts event)
-        ;; EP-0010 (rf2-47lgee / rf2-nftz2s): VALIDATE a caller-supplied
+        ;; EP-0010: VALIDATE a caller-supplied
         ;; `:rf.cofx` at the PUBLIC dispatch boundary BEFORE the clock
         ;; stamp below — a supplied value must be nil-or-map and a supplied
         ;; `:rf/time-ms` must be an integer (Spec 002 §Recordable coeffects +
@@ -243,14 +236,14 @@
         ;; read ordering as the retirement check above. See
         ;; `diag/validate-cofx!`.
         _                  (diag/validate-cofx! opts event)
-        ;; EP-0017 §Dispatch Envelope Stamping (rf2-s9ss0t / rf2-alc1lf): the
+        ;; EP-0017 §Dispatch Envelope Stamping: the
         ;; CAUSAL BOUNDARY — ensure `:rf.cofx` carries `:rf/time-ms`, the one
         ;; host-clock read durable writes fold. `ensure-cofx` owns the
         ;; preserve-supplied / fill-missing-`:rf/time-ms` shape contract (see the
         ;; section comment on the helper above). Stamped AFTER the retirement +
         ;; validation checks so an invalid dispatch never reads the clock.
         cofx               (ensure-cofx (:rf.cofx opts))
-        ;; Per rf2-jbzhj: surface unrecognised opts keys (typically a typo'd
+        ;; Surface unrecognised opts keys (typically a typo'd
         ;; opt like `:fram` for `:frame`) rather than silently swallowing
         ;; them. Emitted HERE — BEFORE the frame resolution below — so a
         ;; `:fram` typo still gets its specific, actionable warning even
@@ -289,7 +282,7 @@
         ;; spelling into the error payload's `:event-id` slot when known,
         ;; so a frameless top-level dispatch's error is attributed to the
         ;; event it was carrying.
-        ;; EP-0023 (rf2-32siq3.32): the explicit `:frame` opt may be a frame-id
+        ;; EP-0023: the explicit `:frame` opt may be a frame-id
         ;; KEYWORD or a live frame OBJECT (`rf/make-frame`'s return value —
         ;; `(rf/dispatch-sync frame [...])`). Normalize an object to its
         ;; runnable-id ADDRESS via `frame/frame-target->id` so the envelope
@@ -307,7 +300,7 @@
                                    :dispatch
                                    {:where    're-frame.router/build-envelope
                                     :event-id (first event)})))
-        ;; Per rf2-j20a7 / Spec 005 §Level 4: a dispatch emitted from a
+        ;; Per Spec 005 §Level 4: a dispatch emitted from a
         ;; machine's own processing (its `:action` / `:entry` / `:exit` /
         ;; transition handling, via `:fx [[:dispatch …]]` or an inter-
         ;; machine dispatch) is a machine-internal continuation. The
@@ -321,7 +314,7 @@
         ;; ordering guarantee — NOT a trace concern — so the flag is
         ;; carried unconditionally (never gated on interop/debug-enabled?).
         machine-internal?  (true? (:rf.machine/internal? opts))
-        ;; EP-0017 §6 / slice-B.8 (rf2-5spzo7): the per-call cofx MINT POLICY
+        ;; EP-0017 §6 / slice-B.8: the per-call cofx MINT POLICY
         ;; — the most-specific binding point. A Tool-Pair replay supplies
         ;; `:strict` (so an incomplete record fails loudly rather than minting
         ;; a fresh value); a nondeterminism-declaring test supplies
@@ -334,17 +327,16 @@
         mint-policy        (:rf.cofx/mint-policy opts)]
     (cond-> {:event                  event
              :frame                  frame
-             ;; Per rf2-5uwl: merge the lexical-scope `*fx-overrides*`
+             ;; Merge the lexical-scope `*fx-overrides*`
              ;; (bound by `rf/with-fx-overrides`) under the per-call opt so
              ;; the per-call opt wins on key collision. The per-frame
              ;; tier is still merged later inside `apply-overrides`.
              :fx-overrides           (merge *fx-overrides* (:fx-overrides opts {}))
              :interceptor-overrides  (:interceptor-overrides opts {})
              :trace-id               (:trace-id opts)
-             ;; Per rf2-hxj0d: default `:source` is `:unknown` —
-             ;; previously defaulted to `:ui`, which silently
-             ;; misattributed every unstamped dispatch (frame-init,
-             ;; internal continuations, REPL eval) as UI-driven. UI
+             ;; Default `:source` is `:unknown` so an unstamped
+             ;; dispatch (frame-init, internal continuations, REPL
+             ;; eval) is never misattributed as UI-driven. UI
              ;; handler call-sites stamp `:source :ui` explicitly; the
              ;; `:on-create` frame-init dispatch (frame.cljc) stamps
              ;; `:source :frame-init`; fx-emit dispatches (fx.cljc)
@@ -352,7 +344,7 @@
              ;; their own kind. `:unknown` surfaces "we lost track"
              ;; rather than fabricating an origin.
              :source                 (:source opts :unknown)
-             ;; Per rf2-5qp4g: per-source-kind detail riding alongside
+             ;; Per-source-kind detail riding alongside
              ;; the closed-set `:source` value. Optional; only stamped
              ;; by substrate dispatch sites that carry kind-specific
              ;; payload (e.g. `:dispatch-later` fx stamps `{:ms <ms>}`
@@ -363,13 +355,13 @@
              ;; `emit-dispatched-trace`).
              :source-detail          (:source-detail opts)
              :origin                 (:origin opts :app)
-             ;; EP-0017 (rf2-s9ss0t / rf2-alc1lf): the flat recordable-coeffect
+             ;; EP-0017: the flat recordable-coeffect
              ;; map, stamped unconditionally (durable causal data, not a
              ;; diagnostic — see the `cofx` binding above). Always carries
              ;; `:rf/time-ms`; caller-supplied additional owner-qualified facts
              ;; ride through preserved.
              :rf.cofx                cofx}
-      ;; Per rf2-ts1a: the macro form of `dispatch` / `dispatch-sync`
+      ;; The macro form of `dispatch` / `dispatch-sync`
       ;; stamps an `:rf.trace/call-site` on the opts map. The read in
       ;; `call-site` above is gated on interop/debug-enabled? so this
       ;; branch and its keyword literal DCE under :advanced +
@@ -378,10 +370,10 @@
       call-site          (assoc :call-site         call-site)
       dispatch-id        (assoc :dispatch-id        dispatch-id)
       parent-dispatch-id (assoc :parent-dispatch-id parent-dispatch-id)
-      ;; Per rf2-j20a7: carry the machine-internal continuation flag onto
+      ;; Carry the machine-internal continuation flag onto
       ;; the envelope so `dispatch!` can front-of-queue insert it.
       machine-internal?  (assoc :rf.machine/internal? true)
-      ;; EP-0017 §6 / slice-B.8 (rf2-5spzo7): carry the per-call cofx mint
+      ;; EP-0017 §6 / slice-B.8: carry the per-call cofx mint
       ;; policy onto the envelope only when supplied, so `assemble-initial-ctx`
       ;; reads it (per-call wins over the frame config). Absent ⇒ the key is
       ;; omitted and the frame-config / `:live` fallback applies.
@@ -391,7 +383,7 @@
   (registrar/lookup :event event-id))
 
 (defn- resolve-unhandled
-  "Per rf2-a2sn1 — the pluggable unresolved-handler resolver seam.
+  "The pluggable unresolved-handler resolver seam.
 
   When `resolve-handler` finds no registrar entry for `event-id`,
   `process-event*` consults this before erroring. It is the late-bound
@@ -428,11 +420,9 @@
 ;; Cross-frame dispatch-sync warnings + the no-handler error path live
 ;; in `re-frame.router.diagnostics`. Every one of those fns runs on a
 ;; cold/error path or sits behind `interop/debug-enabled?`, so the
-;; cross-ns indirection adds no measurable cost. (The async-callback
-;; fallthrough-to-default warning family was RETIRED in EP-0002 — a bare
-;; dispatch under no scope now fails loudly with `:rf.error/no-frame-
-;; context` at envelope-build time rather than silently sliding to
-;; `:rf/default` and warning.)
+;; cross-ns indirection adds no measurable cost. (There is no `:rf/default`
+;; floor — a bare dispatch under no scope fails loudly with
+;; `:rf.error/no-frame-context` at envelope-build time.)
 
 (def ^:private empty-fx-overrides
   "Shared sentinel returned by `apply-overrides` on the no-override hot
@@ -498,11 +488,11 @@
 
 (defn- override-replacement
   "Resolve an `:interceptor-overrides` replacement VALUE to an executable
-  interceptor (or nil to remove). Per EP-0022 §`:interceptor-overrides` (the
-  reference-only flip, rf2-0adhqs.9): public override replacements are a `nil`
+  interceptor (or nil to remove). Per EP-0022 §`:interceptor-overrides`:
+  public override replacements are a `nil`
   (remove) or an interceptor REFERENCE (keyword / `[id arg]`, resolved through
-  the registrar). Value-valued overrides are retired — an inline interceptor
-  value (or any non-ref non-nil) is `:rf.error/interceptor-override-invalid`,
+  the registrar). A value-valued override — an inline interceptor
+  value (or any non-ref non-nil) — is `:rf.error/interceptor-override-invalid`,
   keeping the override map serializable + inspectable across story / SSR / test
   / tool surfaces."
   [k replacement]
@@ -578,7 +568,7 @@
 
 (defn- override-summary
   "Build the dev-only `:rf.interceptor/override-summary` trace tag (Spec 009
-  §`:tags` interceptor family, rf2-9vx0jk). Summarises which authored
+  §`:tags` interceptor family). Summarises which authored
   interceptor references an `:interceptor-overrides` map (merged per-frame +
   per-call, per-call winning) actually acted on for THIS dispatch, by walking
   the PRE-override `resolved-chain` (whose entries still carry their authored
@@ -626,7 +616,7 @@
       (assoc matched :count (count (:matched matched))))))
 
 (defn- validate-event!
-  "Per Spec 010 §Validation order step 1 (rf2-jwm4): validate the
+  "Per Spec 010 §Validation order step 1: validate the
   dispatched event vector against the handler's :schema BEFORE the
   handler's interceptor chain runs. Failures emit
   :rf.error/schema-validation-failure with :where :event and skip the
@@ -636,7 +626,7 @@
   skipped. Defaults to true when the schemas namespace hasn't been
   loaded.
 
-  Body gated on `interop/debug-enabled?` (rf2-gaqwr). Spec 010
+  Body gated on `interop/debug-enabled?`. Spec 010
   validate-*! is a dev-only validator surface — per
   `re-frame.schemas.validate` §Production builds, every dev-time
   `validate-*!` body sits inside its own `(if interop/debug-enabled?
@@ -649,17 +639,17 @@
   the `:schemas/validate-event!` keyword's interned slot to a
   constant `true` on the hot path.
 
-  Per rf2-lo28u: `frame` is threaded so the `:where :event` failure
+  `frame` is threaded so the `:where :event` failure
   trace carries a `:frame` tag and is captured into the in-flight
   cascade's epoch `:trace-events` by `epoch.capture/capture-event!`
   (which drops any trace whose tags lack `:frame`). Without it the
-  violation fired on the global trace stream but never landed in the
-  epoch record — so the Xray Issues / Schema-timeline lens showed
-  nothing for an event-args schema failure, while the `:where :app-db`
-  path (which always tags `:frame`) surfaced correctly."
+  violation would fire on the global trace stream but never land in the
+  epoch record, so the Xray Issues / Schema-timeline lens would show
+  nothing for an event-args schema failure (the `:where :app-db`
+  path always tags `:frame`)."
   [event-id event handler-meta frame]
   (if interop/debug-enabled?
-    ;; Sticky hook (rf2-f72pd) — `:schemas/validate-event!` is published
+    ;; Sticky hook — `:schemas/validate-event!` is published
     ;; once at re-frame.schemas load and never withdrawn in dev; fires
     ;; per-dispatch.
     (if-let [validate! (late-bind/get-fn-cached :schemas/validate-event!)]
@@ -673,7 +663,7 @@
   keys (:source :trace-id) are surfaced as cofx entries so handler bodies
   can read them. Per Spec 002 §Routing — the dispatch envelope.
 
-  EP-0001 (rf2-bvwoi4) — the event context threads BOTH durable partitions
+  EP-0001 — the event context threads BOTH durable partitions
   plus the frame id (per Spec 002 §Event context threads both partitions):
 
     :db            the app-db partition value (the inherited bare key — KEEPS
@@ -685,7 +675,7 @@
                    the frame id, distinct from the public `:frame` opt.
 
   The runtime-db partition is a real frame-state slot (the one-container
-  frame-state, rf2-adwcv6): `frame-runtime-db-value` reads the live runtime-db
+  frame-state): `frame-runtime-db-value` reads the live runtime-db
   projection — `{}` for a fresh frame, the populated partition once a
   subsystem (machines / routing / elision / ssr) has written to it — and that
   value is injected by reference as the `:rf.db/runtime` coeffect.
@@ -693,7 +683,7 @@
   `:rf/framework-authority?` is a NON-coeffect context flag (not visible to
   handler bodies) recording whether THIS handler has framework-write
   authority over the reserved `:rf.db/runtime` partition. Per the GENERAL
-  minting mechanism (EP-0001 rf2-3939ig), it is true for any handler whose
+  minting mechanism (EP-0001), it is true for any handler whose
   registration meta carries the reserved `:rf/framework-authority? true`
   key — stamped by the framework registrars Spec 002 §Write authority names
   (machines, routing; elision / ssr write through privileged frame-state
@@ -717,7 +707,7 @@
         ;; `events/register-event!`). nil / empty for the overwhelming majority
         ;; of handlers (no declarations) — the delivery step is then a no-op.
         requires    (:rf.cofx/requires-parsed handler-meta)
-        ;; EP-0017 §6 / slice-B.8 (rf2-5spzo7) / rf2-n0myjq: the EFFECTIVE cofx
+        ;; EP-0017 §6 / slice-B.8: the EFFECTIVE cofx
         ;; mint policy for this dispatch, resolved ONCE here (per-call envelope
         ;; opt ▸ frame config ▸ `:live`). The event path consumes it inline at
         ;; the `(seq requires)` branch below; it is ALSO stamped onto `base-cofx`
@@ -737,7 +727,7 @@
                              :event           event
                              :rf.db/runtime   runtime-db
                              :rf.frame/id     frame
-                             ;; EP-0017 (rf2-s9ss0t / rf2-alc1lf): the flat
+                             ;; EP-0017: the flat
                              ;; recordable-coeffect map (the envelope's
                              ;; canonical complete record) is a framework
                              ;; coeffect alongside `:db` / `:event` /
@@ -748,7 +738,7 @@
                              ;; Filtered out of the user-cofx trace projection
                              ;; by `fx/framework-coeffect-keys`.
                              :rf.cofx         (:rf.cofx envelope)
-                             ;; rf2-n0myjq — the resolved effective mint policy,
+                             ;; The resolved effective mint policy,
                              ;; a framework coeffect for the machine ensure path.
                              :rf.cofx/mint-policy mint-policy}
                       (:source envelope)   (assoc :source (:source envelope))
@@ -757,7 +747,7 @@
     ;; facts come from the token's `:rf.cofx` (validated against `:schema`);
     ;; ambient facts run their suppliers now; a declared-absent GENERATOR-BACKED
     ;; recordable fact is GENERATED at processing-start (slice B.7) UNDER THE
-    ;; RESOLVED MINT POLICY (slice B.8, rf2-5spzo7 — per-call opt ▸ frame config
+    ;; RESOLVED MINT POLICY (slice B.8 — per-call opt ▸ frame config
     ;; ▸ `:live`; `:strict` does NOT generate and surfaces missing-required) and
     ;; written back into the record; a
     ;; declared-absent PROVIDED fact is `:rf.error/missing-required-cofx`; an
@@ -774,7 +764,7 @@
     ;; EP-0017 §4). With no generators on the path the record is unchanged.
     (let [{:keys [coeffects rf/skip-handler?] :as delivered}
           (if (seq requires)
-            ;; EP-0017 §6 / slice-B.8 (rf2-5spzo7): the effective cofx MINT
+            ;; EP-0017 §6 / slice-B.8: the effective cofx MINT
             ;; POLICY for this dispatch (most-specific-wins — per-call opt ▸
             ;; frame config ▸ `:live`) was resolved ONCE above as `mint-policy`
             ;; and is reused here. The policy gates ONLY the declared-absent
@@ -813,7 +803,7 @@
 
 (defn- classify-pipeline-exception
   "Classify a captured `:rf/interceptor-error` into the true failing
-  component (per rf2-mszrz). Returns
+  component. Returns
   `{:operation <:rf.error/*> :failing-id <kw> :reason <string>}` — the
   category and attribution the exception emit fans out under. The chain
   runner records `{:phase :id}`; this fn reads that captured identity
@@ -828,19 +818,18 @@
       `handler-wrapping-interceptor-ids`) → `:rf.error/handler-exception`,
       `:failing-id` = the event id.
 
-  Coeffect-supplier throws do NOT reach here: EP-0017 moved coeffect
-  delivery to context assembly (BEFORE the interceptor chain runs), so a
+  Coeffect-supplier throws do NOT reach here: coeffect delivery runs at
+  context assembly (BEFORE the interceptor chain runs), so a
   supplier throw is captured and emitted as `:rf.error/coeffect-exception`
-  by `re-frame.cofx/emit-coeffect-exception!` directly. The retired
-  `inject-cofx` was the only mechanism that stamped `:rf/cofx-id` on an
-  interceptor; with it gone, the old `:rf/cofx-id`-keyed branch here was
-  permanently unreachable dead code (rf2-oky3gt) and has been removed.
+  by `re-frame.cofx/emit-coeffect-exception!` directly. No interceptor
+  carries a `:rf/cofx-id`, so this classifier only ever discriminates
+  user-interceptor throws from the event handler itself.
 
-  Mirrors the existing distinct-by-component precedent the runtime
-  already follows for `:rf.error/flow-eval-exception` (flow transform)
-  and `:rf.error/fx-handler-exception` (post-commit fx walk) — the
-  `:before` chain was the one site that conflated handler-vs-interceptor
-  into `handler-exception`."
+  Mirrors the distinct-by-component precedent the runtime
+  follows for `:rf.error/flow-eval-exception` (flow transform)
+  and `:rf.error/fx-handler-exception` (post-commit fx walk): each `:before`-
+  chain throw is attributed to its own failing component, not blanket-
+  attributed to the event handler."
   [error event-id]
   (let [id (:id error)]
     (cond
@@ -858,8 +847,8 @@
 (defn- elapsed-ms-from
   "The integer `:elapsed-ms` for an error / event-emit record: `end-ms`
   minus `start-ms`, floored at 0 and rounded to a long. Owns the
-  cross-platform rounding contract in ONE place (per rf2-bacs4 / rf2-rirbq
-  §Record shape — `:elapsed-ms` is an integer): `interop/now-ms` is a long on
+  cross-platform rounding contract in ONE place (§Record shape —
+  `:elapsed-ms` is an integer): `interop/now-ms` is a long on
   the JVM (`System/currentTimeMillis`) but a float on CLJS
   (`js/performance.now()` carries sub-millisecond precision), so the value is
   rounded once at the substrate boundary so the record's contract holds on
@@ -872,11 +861,11 @@
 (defn- emit-pipeline-exception!
   "Surface an interceptor-chain exception as the trace event for its TRUE
   failing component AND fan it out through the always-on error-emit
-  listener substrate (per rf2-bacs4). The chain captures the exception
+  listener substrate. The chain captures the exception
   into `:rf/interceptor-error` rather than re-throwing (the drain must
   not abort); this helper translates that into both delivery channels.
 
-  Per rf2-mszrz the category + `:failing-id` are derived from the
+  The category + `:failing-id` are derived from the
   captured component identity via `classify-pipeline-exception` — a
   coeffect-injection throw emits `:rf.error/coeffect-exception` attributed
   to the cofx id, a user-interceptor throw emits
@@ -892,7 +881,7 @@
   slot, the router-installed redaction interceptor stores the scrubbed
   event form under `:rf/redacted-event`; this helper surfaces it.
 
-  Per rf2-bacs4: a corpus-wide listener registry runs for off-box
+  A corpus-wide listener registry runs for off-box
   observability shippers (Sentry / Honeybadger / Rollbar) and MUST fire
   even when the trace surface is compile-time elided in CLJS production
   builds. We build the tight error-record up-front, hand it to
@@ -905,7 +894,7 @@
   listeners."
   [error event-id event frame ctx start-ms]
   (let [exception  (:exception error)
-        ;; rf2-vzrxp3: nil-safe extractor — a thrown non-Error value (legal in
+        ;; nil-safe extractor — a thrown non-Error value (legal in
         ;; CLJS) has no `.-message`, so a raw read would silently nil the slot.
         msg        (error/ex-message-safe exception)
         emit-event (privacy/redacted-event-from-ctx ctx)
@@ -914,7 +903,7 @@
         {:keys [operation failing-id reason]}
         (classify-pipeline-exception error event-id)
         handler-throw? (= operation :rf.error/handler-exception)
-        ;; rf2-siheh — the throwing user interceptor's definition-site
+        ;; The throwing user interceptor's definition-site
         ;; coord (captured by the `->interceptor` macro and carried on
         ;; the interceptor map → error-record). Threaded onto the
         ;; `:rf.error/interceptor-exception` trace so the Xray Epoch
@@ -935,12 +924,12 @@
                      ;; `:handler-id` is only meaningful when the EVENT
                      ;; handler itself threw — a coeffect / interceptor
                      ;; failure has no handler-id to carry (the handler
-                     ;; never ran). Stamping the event-id regardless
-                     ;; (the pre-rf2-mszrz behaviour) mis-fed consumers.
+                     ;; never ran), so stamping the event-id regardless
+                     ;; would mis-feed consumers.
                      handler-throw? (assoc :handler-id event-id)
                      icpt-coord     (assoc :source-coord icpt-coord))]
-    ;; Fan out along BOTH channels (rf2-c4oycd shared helper). Axis 1 — the
-    ;; always-on corpus-wide listener (rf2-bacs4): every fn registered through
+    ;; Fan out along BOTH channels (shared helper). Axis 1 — the
+    ;; always-on corpus-wide listener: every fn registered through
     ;; `rf/register-error-listener!` receives the tight error-record so
     ;; production builds with the trace surface elided still observe the error.
     ;; Trigger-handler / dispatch-id enrichment is dev-only and rides the trace
@@ -949,7 +938,7 @@
       operation emit-event event-id frame exception elapsed-ms end-ms tags)))
 
 (defn- run-post-commit-validation!
-  "Per Spec 010 §Per-step recovery row 4 (rf2-wkxng / rf2-6m0se): validate
+  "Per Spec 010 §Per-step recovery row 4: validate
   app-db against registered schemas after each commit. Returns the
   validator's boolean conjunction — true when every registered schema
   for the frame conformed (or the schemas artefact isn't loaded / no
@@ -964,14 +953,14 @@
   registered against THIS dispatch's frame only — sibling frames'
   schemas don't fire here.
 
-  Per rf2-jbbp7 / Spec 010 §Per-step recovery row 7: AND-conjoins the
+  Per Spec 010 §Per-step recovery row 7: AND-conjoins the
   app-db validator with `:machines/validate-machine-data!` (the
   `:where :machine-data` boundary). The machine walker iterates
   `[:rf.runtime/machines :snapshots]` in the new RUNTIME-DB value (EP-0001
-  rf2-vzld77 — machine snapshots are durable runtime-db state) and validates
+  — machine snapshots are durable runtime-db state) and validates
   each snapshot's `:data` against the registered machine's `:data-schema`.
 
-  EP-0001 (rf2-vzld77): each validator runs against its OWN partition's new
+  EP-0001: each validator runs against its OWN partition's new
   value — app-db schema validation on `db-after`, machine-data validation on
   `runtime-db-after` — and only when that partition was actually written this
   commit (`app-effect?` / `rt-effect?`). The conjunction means a `false` from
@@ -986,23 +975,22 @@
   actual app-db state from the rest of the cascade. Real schema
   failures route through the in-band false return.
 
-  Per rf2-ss06u.3 the swallowed throw is NO LONGER SILENT: the catch
+  The swallowed throw is never silent: the catch
   emits a `:rf.error/malformed-schema` trace before coercing to `true`,
-  so a thrown validator is always observable (the prior bare `(catch …
-  true)` installed an unvalidated commit with NO trace — a fail-OPEN
-  bypass of the same class as the rf2-sk0ql path leak). A MALFORMED
-  REGISTERED SCHEMA (childless `[:vector]`, unknown op) no longer reaches
-  this catch at all — `validate-app-schema!` now isolates that throw
-  per-entry (rf2-ss06u.3), surfaces its own `:rf.error/malformed-schema`
+  so a thrown validator is always observable (coercing to `true` without a
+  trace would install an unvalidated commit — a fail-OPEN bypass). A
+  MALFORMED REGISTERED SCHEMA (childless `[:vector]`, unknown op) does not
+  reach this catch at all — `validate-app-schema!` isolates that throw
+  per-entry, surfaces its own `:rf.error/malformed-schema`
   trace, fails CLOSED (in-band `false` → rollback), and keeps validating
-  the frame's sibling schemas. So a throw THAT STILL REACHES THIS CATCH
+  the frame's sibling schemas. So a throw THAT REACHES THIS CATCH
   is the validator/late-bind machinery itself failing wholesale — the
   trace makes that visible without masking app-db from the rest of the
   cascade."
   [db-after runtime-db-after app-effect? rt-effect? event-id frame]
   (let [emit-swallow!
-        ;; Surface a swallowed validator throw so it is never invisible
-        ;; (rf2-ss06u.3). DCE-gated inside `trace/emit-error!`.
+        ;; Surface a swallowed validator throw so it is never invisible.
+        ;; DCE-gated inside `trace/emit-error!`.
         (fn [where ex]
           (trace/emit-error!
             :rf.error/malformed-schema
@@ -1016,12 +1004,11 @@
                      :recovery  :no-recovery}
               event-id (assoc :failing-id event-id))))
         run-partition-validator!
-        ;; The per-partition validator arm template (rf2-6zfzxy). Runs the
+        ;; The per-partition validator arm template. Runs the
         ;; late-bound `hook-key` validator against the partition's new value
         ;; ONLY when `effect?` (that partition was written this commit) AND the
         ;; hook is installed; otherwise → true (an absent validator / unwritten
-        ;; partition is a pass). Resolves the hook ONCE (the prior arms called
-        ;; `get-fn-cached` twice — in the `and` then re-fetched in the `let`).
+        ;; partition is a pass). Resolves the hook ONCE.
         ;; nil-coerce: a nil return is success (don't roll back) so a host
         ;; returning nil on a clean validate keeps working. A host-thrown
         ;; validator is caught, surfaced via `emit-swallow!`, and treated as
@@ -1041,12 +1028,12 @@
             true))
         ;; App-db schema validation runs only when a `:db` effect produced a
         ;; new app-db (app schemas validate app-db only — Mike ruling #11).
-        ;; Sticky hook (rf2-f72pd) — fires per-dispatch.
+        ;; Sticky hook — fires per-dispatch.
         app-ok?
         (run-partition-validator! app-effect? :schemas/validate-app-schema!
                                   db-after :app-db)
-        ;; Per rf2-jbbp7 — the machine-data boundary (Spec 005 §Schema
-        ;; validation). EP-0001 (rf2-vzld77): machine snapshots are durable
+        ;; The machine-data boundary (Spec 005 §Schema
+        ;; validation). EP-0001: machine snapshots are durable
         ;; runtime-db state, so this validates the new RUNTIME-DB value and
         ;; runs only when a `:rf.db/runtime` effect landed this commit. The
         ;; hook is absent when the machines artefact isn't on the classpath;
@@ -1102,7 +1089,7 @@
                   phase (assoc :rf.trace/phase phase)))))
 
 (defn- commit-frame-effects!
-  "Install the partitioned frame transition atomically (EP-0001 rf2-adwcv6,
+  "Install the partitioned frame transition atomically (EP-0001,
   Spec 002 §Drain-loop pseudocode §commit + §An ordinary :db return replaces
   only app-db). A cascade may produce:
 
@@ -1123,8 +1110,8 @@
   Returns true when the commit is durable (no partition effect, or app-db
   schema conformed); false when post-commit app-db schema validation
   rejected the new state and the frame-state has been **rolled back** to the
-  pre-handler value (per Spec 010 §Per-step recovery row 4 / rf2-wkxng /
-  rf2-6m0se). App-db schema validation is APP-DB-ONLY (app schemas validate
+  pre-handler value (per Spec 010 §Per-step recovery row 4). App-db schema
+  validation is APP-DB-ONLY (app schemas validate
   the app partition, Mike ruling #11); a rejection unwinds the WHOLE
   transition (both partitions) so the frame is left coherently at its
   pre-handler state.
@@ -1132,7 +1119,7 @@
   Change traces (per Spec 009 §Canonical per-event trace sequence):
     - `:rf.event/db-changed` — APP-DB-ONLY (Mike ruling #6): fires only when
       the app-db partition changed; NEVER for a runtime-only commit;
-    - `:rf.event/db-noop` (rf2-ekq28v) — APP-DB-ONLY: fires when a `:db`
+    - `:rf.event/db-noop` — APP-DB-ONLY: fires when a `:db`
       effect was present but app-db did NOT change (the handler returned an
       unchanged db; the `identical?`-noop fast-path in
       `commit-frame-transition!` skipped the write, or a distinct-but-`=`
@@ -1145,13 +1132,13 @@
   `#{:app-db}`); an unchanged-db `:db` commit emits db-noop (and no
   frame-state-changed for the app-db partition).
 
-  nil-coercion (rf2-ekq28v): a `:db nil` effect is coerced to `{}` HERE —
+  nil-coercion: a `:db nil` effect is coerced to `{}` HERE —
   at the `:db` effect → `:rf.db/app` partition mapping, before the commit —
   so the partition layer never sees a nil app-db (app-db is always a map).
   The coercion emits a dev-mode `:rf.warning/db-nil-coerced` diagnostic for
   accidental-wipe visibility; a deliberate clear (`{:db {}}`) does not.
 
-  Per Spec 013 §Drain integration (rf2-u0zz5): `(:db effects)` here is the
+  Per Spec 013 §Drain integration: `(:db effects)` here is the
   FLOW-AUGMENTED app-db value — the OUTERMOST flows-after-interceptor has
   already rewritten the pending `:db` effect by the time the chain returns.
   So `:event/db-changed` reflects the flow-derived db and fires AFTER
@@ -1168,7 +1155,7 @@
   Schema-derived redaction is reflected in the change traces' `:tags :event`
   slot via `privacy/redacted-event-from-ctx`.
 
-  Per rf2-4wqu6 finding 1: on rollback the flow dirty-check (`last-inputs`)
+  On rollback the flow dirty-check (`last-inputs`)
   bookkeeping is rolled back in lock-step (the flow transform advanced each
   computed flow's row inside the chain; restoring app-db without restoring
   those rows would leave the dirty-check believing the flows are
@@ -1178,11 +1165,11 @@
   [effects event-id event frame ctx db-before runtime-before]
   (let [app-effect?  (contains? effects :db)
         rt-effect?   (contains? effects :rf.db/runtime)
-        ;; nil-coercion (rf2-ekq28v): app-db is ALWAYS a map, never nil. A
+        ;; nil-coercion: app-db is ALWAYS a map, never nil. A
         ;; `:db nil` effect is coerced to `{}` HERE — at the `:db` effect →
         ;; `:rf.db/app` partition mapping, BEFORE `commit-frame-transition!` —
-        ;; so the partition layer never sees a nil app-db. This removes the v1
-        ;; nil-footgun (a db handler returning nil wiping app-db to nil)
+        ;; so the partition layer never sees a nil app-db. This rules out a
+        ;; db handler returning nil wiping app-db to nil
         ;; structurally, at the commit boundary. A `:db nil` return is more
         ;; often a BUG (a handler accidentally computed nil) than a deliberate
         ;; clear, so the coercion emits a dev-mode `:rf.warning/db-nil-coerced`
@@ -1205,7 +1192,7 @@
                          "diagnostic).")}))
     (if (or app-effect? rt-effect?)
       (let [emit-event (privacy/redacted-event-from-ctx ctx)
-            ;; rf2-gom797: a whole-value `:rf.db/runtime` effect REPLACES the
+            ;; A whole-value `:rf.db/runtime` effect REPLACES the
             ;; runtime-db partition (decision #5), but the elision declaration
             ;; registry at `[:rf.runtime/elision]` is a CROSS-CUTTING durable
             ;; subsystem child written OUT-OF-BAND by `reg-flow` / `add-marks` /
@@ -1218,7 +1205,7 @@
             ;; survives unless the effect speaks about it explicitly (a
             ;; full-frame install / deliberate clear is honoured verbatim).
             ;;
-            ;; rf2-upx16k (privacy fail-open): reconcile against the LIVE
+            ;; Privacy fail-open: reconcile against the LIVE
             ;; runtime-db read AT COMMIT, NOT the chain-start `runtime-before`
             ;; snapshot. The flow drain's `refresh-flow-output-declarations!`
             ;; writes propagated output-sensitivity marks straight into the
@@ -1257,7 +1244,7 @@
         ;; partition actually changed. A runtime-only commit never fires it.
         (when app-changed?
           (emit-db-event! :rf.event/db-changed event-id emit-event frame))
-        ;; db-noop (rf2-ekq28v): a `:db` effect that left app-db UNCHANGED — the
+        ;; db-noop: a `:db` effect that left app-db UNCHANGED — the
         ;; handler returned an unchanged db (the `identical?`-noop fast-path in
         ;; `commit-frame-transition!` skipped the write, OR a distinct-but-`=`
         ;; value collapsed to no change). The forward commit is a genuine
@@ -1270,7 +1257,7 @@
           (emit-db-event! :rf.event/db-noop event-id emit-event frame))
         ;; Partition-tagged frame-state-changed — when EITHER partition changed.
         (emit-frame-state-changed! event-id emit-event frame changed)
-        ;; Post-commit validation runs per-partition (EP-0001 rf2-vzld77):
+        ;; Post-commit validation runs per-partition (EP-0001):
         ;; app-db schema validation on the new app-db (only when a `:db` effect
         ;; landed — app schemas validate app-db only, Mike ruling #11) AND the
         ;; machine-data `:where :machine-data` boundary on the new runtime-db
@@ -1279,13 +1266,12 @@
         ;; WHOLE transition.
         (if (run-post-commit-validation! new-db new-runtime-db
                                          app-effect? rt-effect? event-id frame)
-          ;; EP-0001 (rf2-vzld77): framework runtime subsystems no longer live
-          ;; in app-db under `:rf/runtime` — they are in the runtime-db
-          ;; partition — so the `{:db fresh-map}` footgun (rf2-p806o: a fresh
-          ;; `:db` map dropping co-located `:rf/runtime`) is structurally gone
+          ;; EP-0001: framework runtime subsystems live in the runtime-db
+          ;; partition, not in app-db under `:rf/runtime` — so a fresh
+          ;; `{:db fresh-map}` cannot drop co-located runtime state
           ;; (Conventions §The clobber footgun is eliminated structurally). The
-          ;; legacy `:rf/runtime` app-db key becomes a hard error in bead 9
-          ;; (rf2-tfepxu); no per-commit detector is needed here.
+          ;; `:rf/runtime` app-db key is a hard error elsewhere; no per-commit
+          ;; detector is needed here.
           true
           (do
             ;; Roll back the WHOLE transition (both partitions) to the
@@ -1298,14 +1284,14 @@
                                frame
                                {frame/app-partition-key     db-before
                                 frame/runtime-partition-key runtime-before})]
-              ;; Per rf2-4wqu6 finding 1: roll back the flow dirty-check
+              ;; Roll back the flow dirty-check
               ;; (`last-inputs`) bookkeeping in lock-step with the app-db
-              ;; (frame-scoped, rf2-94ol5). No-op when no flow ran or the
+              ;; (frame-scoped). No-op when no flow ran or the
               ;; flows artefact never loaded.
               (when (contains? ctx :rf/flow-last-inputs-before)
                 (when-let [restore-li (late-bind/get-fn-cached :flows/restore-last-inputs!)]
                   (restore-li frame (:rf/flow-last-inputs-before ctx))))
-              ;; rf2-z980k8: re-record the IN-DRAIN abandoned output paths the
+              ;; Re-record the IN-DRAIN abandoned output paths the
               ;; flow transform drained-and-cleared. The pending `:db` (which
               ;; carried the vacated state) was just discarded by the rollback,
               ;; so the `:path` move must re-attempt next drain rather than be
@@ -1321,7 +1307,7 @@
       true)))
 
 (def ^:private flows-after-interceptor
-  "Per Spec 013 §Drain integration (rf2-u0zz5): the framework-owned
+  "Per Spec 013 §Drain integration: the framework-owned
   OUTERMOST `:after` interceptor that runs the flow transform. The router
   PREPENDS it to the dispatch-time `full-chain` (NOT the registered
   handler-meta chain — see `prepare-handler-ctx`), so it is the first
@@ -1344,8 +1330,8 @@
   When the flows artefact is absent (`:flows/run-flows-on-db` hook nil)
   the `:after` is a single nil-check no-op.
 
-  Failure (Spec 013 §Failure semantics — atomicity contract, Mike
-  2026-05-24): a flow throw is a PRE-INSTALL throw, so it aborts the whole
+  Failure (Spec 013 §Failure semantics — atomicity contract): a flow throw
+  is a PRE-INSTALL throw, so it aborts the whole
   event exactly like a handler / interceptor-`:after` throw. The `:after`
   catches the ex-info, DISCARDS the pending `:db` effect (`dissoc`-ing it
   from `(:effects ctx)`) so the single deferred install installs NOTHING —
@@ -1363,7 +1349,7 @@
   allocation). The dispatching frame is read from the context coeffects
   (`assemble-initial-ctx` stamps `:frame`).
 
-  Per rf2-ta0y7 (Mike 2026-05-25): this interceptor is also the emit
+  This interceptor is also the emit
   point for the t1 / t2 pending-`:db` snapshot pair on the trace
   stream. The handler returned its `:db` effect; the rest of the
   `:after` chain reshaped it (e.g. `path`-interceptor splice) and the
@@ -1379,11 +1365,11 @@
                                             commit (the value flows
                                             reshaped, when they did).
 
-  Mike's ruling stores the full value plain — same posture as
+  The full value is stored plain — same posture as
   `:rf.event/fx` on `:rf.fx/do-fx`. Persistent data structures make
   the cost a pointer per emit (structural sharing with app-db); no
   copy, no diff, no DEBUG conditional. `day8/de-dupe` at the pair-mcp
-  wire boundary (rf2-obpa9) collapses the repeated subtrees on
+  wire boundary collapses the repeated subtrees on
   egress. The Xray Handler panel reads t1 to render the returned
   `:db` value under EVENT HANDLER and (t1, t2) together to render
   the t1→t2 reshape under FLOWS — the framework does NOT precompute
@@ -1412,7 +1398,7 @@
       (let [frame       (:rf.frame/id (:coeffects ctx))
             effects     (:effects ctx)
             has-db?     (contains? effects :db)
-            ;; EP-0001 §535-551 (rf2-4eisfr): a runtime-db write also lands as
+            ;; EP-0001 §535-551: a runtime-db write also lands as
             ;; a pending `:rf.db/runtime` effect (e.g. a pure
             ;; `:rf.route/transitioned` returns `{:rf.db/runtime …}` and NO
             ;; `:db`). The flow transform must observe the SETTLED pending
@@ -1438,7 +1424,7 @@
                                  (if has-runtime-effect?
                                    (:rf.db/runtime effects)
                                    (frame/frame-runtime-db-value frame)))
-            ;; Per rf2-ta0y7: stamp `:rf.event/v` + `:rf.trace/event-id`
+            ;; Stamp `:rf.event/v` + `:rf.trace/event-id`
             ;; on the t1 / t2 trace events so they carry the same
             ;; per-event attribution every other `:op-type :rf.event`
             ;; emit carries (parity with `:rf.event/run-start` /
@@ -1463,7 +1449,7 @@
                         :rf.event/db       pending-db}))
         (if run-on-db
           (try
-            (let [;; Per rf2-4wqu6 finding 1: snapshot THIS frame's
+            (let [;; Snapshot THIS frame's
                   ;; dirty-check (`last-inputs`) rows BEFORE the flow transform
                   ;; advances them. The transform eagerly advances a flow's row
                   ;; the moment it recomputes, folding the output into the
@@ -1479,7 +1465,7 @@
                   ;; can permanently suppress a flow). We stash the pre-drain
                   ;; snapshot on the ctx; `commit-db-effect!` restores it iff it
                   ;; rolls back — the exact mirror of the throw-path rollback,
-                  ;; at the post-commit boundary. Frame-scoped (rf2-94ol5): the
+                  ;; at the post-commit boundary. Frame-scoped: the
                   ;; snapshot is `frame`'s own container, structurally unable to
                   ;; touch a sibling frame draining on another thread. The
                   ;; snapshot is a persistent map (pointer-sized to stash); the
@@ -1487,7 +1473,7 @@
                   ;; which case there are no rows and nothing to restore.
                   snapshot-li (late-bind/get-fn-cached :flows/snapshot-last-inputs)
                   li-before   (when snapshot-li (snapshot-li frame))
-                  ;; rf2-z980k8: snapshot the frame's pending abandoned-output-
+                  ;; Snapshot the frame's pending abandoned-output-
                   ;; paths BEFORE the transform (it DRAINS/clears them and
                   ;; dissocs them from the pending `:db`). On a POST-commit
                   ;; rollback `commit-frame-effects!` re-records this snapshot —
@@ -1495,7 +1481,7 @@
                   ;; the boundary `run-flows-on-db`'s own throw arm cannot see.
                   snapshot-ap (late-bind/get-fn-cached :flows/snapshot-abandoned-paths)
                   ap-before   (when snapshot-ap (snapshot-ap frame))
-                  ;; EP-0001 §535-551 (rf2-4eisfr): hand the flow transform
+                  ;; EP-0001 §535-551: hand the flow transform
                   ;; BOTH partitions of the pending frame-state. Bare `:inputs`
                   ;; resolve against `pending-db` (app-db); `[:rf.db/runtime …]`
                   ;; inputs resolve against `pending-runtime-db`. The returned
@@ -1507,8 +1493,8 @@
               ;; t1→t2 reshape. The dirty-check below is the same
               ;; identical-by-reference guard the effect-publish below
               ;; uses; t2 fires on the same condition that a `:db`
-              ;; effect survives to `commit-db-effect!`. Per
-              ;; rf2-ta0y7 t2 may fire even when the handler returned
+              ;; effect survives to `commit-db-effect!`. t2 may fire
+              ;; even when the handler returned
               ;; no `:db` (flows synthesised one from app-db); resolve
               ;; the attribution-event lazily so the no-handler-`:db`
               ;; case still carries it.
@@ -1526,22 +1512,22 @@
               ;; effect (which would force an app-db install + db-changed
               ;; trace on an event that wrote nothing). When we DO publish a
               ;; `:db`, stash the pre-drain dirty-check snapshot + the
-              ;; restorer fn (rf2-4wqu6 finding 1) so `commit-db-effect!` can
+              ;; restorer fn so `commit-db-effect!` can
               ;; roll `last-inputs` back in lock-step with an app-db rollback.
               ;; A no-flow / no-write event publishes no `:db`, hits no
               ;; commit/rollback boundary, and needs no snapshot.
               (if (or has-db? (not (identical? new-db pending-db)))
                 (cond-> (interceptor/assoc-effect ctx :db new-db)
                   snapshot-li (assoc :rf/flow-last-inputs-before li-before)
-                  ;; rf2-z980k8: stash the pre-drain abandoned-paths snapshot so
+                  ;; Stash the pre-drain abandoned-paths snapshot so
                   ;; a post-commit rollback can re-record the drained-but-not-
                   ;; durably-vacated path moves. Only when a `:db` is published
                   ;; (a no-`:db` event hits no commit/rollback boundary).
                   snapshot-ap (assoc :rf/flow-abandoned-paths-before ap-before))
                 ctx))
             (catch #?(:clj Throwable :cljs :default) e
-              ;; Atomicity contract (Spec 013 §Failure semantics, Mike
-              ;; 2026-05-24): a flow throw is a PRE-INSTALL throw, so it
+              ;; Atomicity contract (Spec 013 §Failure semantics): a flow
+              ;; throw is a PRE-INSTALL throw, so it
               ;; aborts the whole event. DISCARD any pending `:db` effect
               ;; (the handler's and any prior flows' writes) so the single
               ;; deferred install installs NOTHING — app-db stays unchanged,
@@ -1567,12 +1553,11 @@
 (defn- emit-flow-eval-exception!
   "Surface a flow-eval throw (stashed by `flows-after-interceptor` under
   `:rf/flow-error`) as `:rf.error/flow-eval-exception` through BOTH the
-  dev-only trace surface AND the always-on error-emit substrate (per
-  rf2-hrt5c — the security-audit fix). Per Spec 013 §Failure semantics
-  rule 3 the caller skips `:fx` after this fires; the drain continues
-  with the NEXT event.
+  dev-only trace surface AND the always-on error-emit substrate. Per
+  Spec 013 §Failure semantics rule 3 the caller skips `:fx` after this
+  fires; the drain continues with the NEXT event.
 
-  Per rf2-hrt5c: `trace/emit-error!` is gated by `interop/debug-enabled?`
+  `trace/emit-error!` is gated by `interop/debug-enabled?`
   and DCEs under `:advanced` + `goog.DEBUG=false` — so the always-on
   listener path is what survives prod elision and reaches off-box
   monitors. Mirrors the pipeline-exception path
@@ -1580,10 +1565,9 @@
   [e event event-id frame start-ms]
   (let [end-ms     (interop/now-ms)
         elapsed-ms (elapsed-ms-from start-ms end-ms)]
-    ;; Fan out along BOTH channels (rf2-c4oycd shared helper). Axis 1 — the
-    ;; always-on corpus-wide listener (rf2-bacs4) fires in CLJS production where
-    ;; the trace surface (axis 2) is compile-time elided. Same payload shape as
-    ;; before — existing trace consumers are unaffected.
+    ;; Fan out along BOTH channels (shared helper). Axis 1 — the
+    ;; always-on corpus-wide listener fires in CLJS production where
+    ;; the trace surface (axis 2) is compile-time elided.
     (error-emit/emit-error-both!
       :rf.error/flow-eval-exception
       event event-id frame e elapsed-ms end-ms
@@ -1592,7 +1576,7 @@
 (defn- emit-legacy-runtime-root!
   "Surface `:rf.error/legacy-runtime-root` through BOTH the always-on
   error-emit substrate AND the dev-only trace surface — the FINAL-effects
-  boundary counterpart (rf2-u1kdvg) of the in-chain
+  boundary counterpart of the in-chain
   `events/reject-legacy-runtime-root!` throw.
 
   Why a SEPARATE in-band emit rather than re-throwing: the in-chain guard
@@ -1603,18 +1587,18 @@
   AFTER that guard has run, in the FINAL effects map the router consumes.
   Detecting it here and THROWING would escape `process-event!` into
   `drain-emergency-release!` — which re-throws, abandoning the rest of the
-  drained queue (the very queue-abandonment footgun the bead closes). So
+  drained queue. So
   we emit in-band and abort THIS event only (`:error`
   outcome, NO commit, NO `:fx`), preserving the no-partial-commit promise
   while keeping the drain alive.
 
-  Always-on per rf2-bacs4: the corpus-wide listener observes the
+  Always-on: the corpus-wide listener observes the
   rejection in production where the trace surface DCEs."
   [event event-id frame start-ms]
   (let [end-ms     (interop/now-ms)
         elapsed-ms (elapsed-ms-from start-ms end-ms)
         tags       (events/legacy-runtime-root-ex-data event)]
-    ;; Fan out along BOTH channels (rf2-c4oycd shared helper). Axis 1 — the
+    ;; Fan out along BOTH channels (shared helper). Axis 1 — the
     ;; always-on listener (survives prod elision); axis 2 — the dev trace (DCE'd
     ;; under `:advanced` + `goog.DEBUG=false`). No exception object: this is an
     ;; invalid-write rejection, not a host throw.

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -1,16 +1,13 @@
 (ns re-frame.router.diagnostics
   "Dev-only diagnostics for the router: cross-frame dispatch-sync warnings
-  (rf2-fp97) and the no-handler error path. Extracted from
-  `re-frame.router` per rf2-0ytl4 Phase-2 seam R-B.
+  and the no-handler error path. A sibling of `re-frame.router`, holding
+  the warning / error fns that the router facade reaches into.
 
-  The async-callback fallthrough-to-default warning family
-  (`:rf.warning/dispatch-from-async-callback-fell-through-to-default`,
-  rf2-o8m0) was RETIRED in EP-0002 (rf2-9wa0lf): there is no longer a
-  `:rf/default` floor for a bare dispatch to slide onto, so the warning's
-  precondition can never arise. A dispatch under no established scope now
-  fails loudly at envelope-build time with `:rf.error/no-frame-context`
-  (emitted from `re-frame.frame/require-current-frame!`), replacing the
-  dev-only warning with an always-on, production-survivable error.
+  There is no `:rf/default` floor for a bare dispatch to slide onto: a
+  dispatch under no established scope fails loudly at envelope-build time
+  with `:rf.error/no-frame-context` (emitted from
+  `re-frame.frame/require-current-frame!`) — an always-on,
+  production-survivable error.
 
   Every fn here either runs on a cold/error path or sits behind
   `interop/debug-enabled?` — production builds (`:advanced` +
@@ -36,11 +33,10 @@
   `{:frame …}` override, an established scope, or a captured stamp) — a
   frameless bare dispatch never gets this far: it raised
   `:rf.error/no-frame-context` at envelope-build time (EP-0002 §Dispatch
-  And Router; the async-callback fallthrough warning that used to fire
-  ahead of this error is retired).
+  And Router).
 
-  Per rf2-2hvga (= B / widen): the `:rf.error/no-such-handler` category
-  ALSO fans out through the always-on error-emit listener (surface #4) so
+  The `:rf.error/no-such-handler` category ALSO fans out through the
+  always-on error-emit listener (surface #4) so
   it survives `:advanced` + `goog.DEBUG=false` and reaches off-box
   observability shippers — a dispatch to a never-registered handler is a
   production-meaningful runtime error. Recovery is the runtime's built-in
@@ -53,7 +49,7 @@
   The dev `trace/emit-error!` below stays dev-only (it DCEs under
   `goog.DEBUG=false`); the always-on listener fan-out is what survives."
   [event-id event frame]
-  ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the always-on
+  ;; Both channels via the shared helper: axis 1 the always-on
   ;; listener (survives prod elision), axis 2 the dev trace (DCEs under
   ;; `:advanced` + `goog.DEBUG=false`). No exception — invalid op; `elapsed-ms 0`.
   ;; Reached via the `:error-emit/emit-error-both` hook (this diagnostics ns
@@ -75,7 +71,7 @@
        :recovery          :replaced-with-default})))
 
 (defn other-frame-mid-drain
-  "Per rf2-fp97 — Spec 002 §dispatch-sync cross-frame note. Return the
+  "Per Spec 002 §dispatch-sync cross-frame note. Return the
   frame-id of any registered, non-destroyed frame OTHER than `target-id`
   whose router currently shows `:in-sync-drain?` or `:in-drain?` true.
   Returns nil when no such frame exists.
@@ -101,11 +97,11 @@
         (frame/frame-ids)))
 
 (def ^:const known-dispatch-opts
-  "Per rf2-jbzhj — the closed set of keys `build-envelope` reads off the
+  "The closed set of keys `build-envelope` reads off the
   `dispatch` / `dispatch-sync` opts map (and therefore the only keys that
   affect dispatch behaviour). Every other key is silently swallowed, so a
   typo'd opt (`:fram` for `:frame`, `:src` for `:source`) changes nothing
-  and gives no signal — the no-silent-swallow principle (rf2-3nbl5.1)
+  and gives no signal — the no-silent-swallow principle
   forbids that quietness. `emit-unknown-dispatch-opts-warning!` warns on
   any opts key outside this set.
 
@@ -119,15 +115,13 @@
     :origin                 actor identity tag
     :rf.cofx                EP-0017 flat recordable-coeffect map
                             (caller-supplied `:rf/time-ms` + owner-qualified
-                            facts; the router fills `:rf/time-ms` when absent —
-                            rf2-s9ss0t / rf2-alc1lf)
+                            facts; the router fills `:rf/time-ms` when absent)
     :rf.cofx/mint-policy    EP-0017 §6 / slice-B.8 per-call cofx mint policy
                             (`:live` / `:strict` / `:explicit-live`); the
                             most-specific binding point — a Tool-Pair replay
                             supplies `:strict`, a nondeterminism-declaring test
                             supplies `:explicit-live`. Absent ⇒ the frame
                             config's policy, else the router's `:live` default
-                            (rf2-5spzo7)
     :rf.trace/call-site     macro-stamped invocation coord (dev-only)
     :rf.machine/internal?   machine-internal continuation flag (front-queue)"
   #{:frame :fx-overrides :interceptor-overrides :trace-id :source
@@ -138,14 +132,13 @@
   "Throw `:rf.error/dispatched-at-retired` when a `dispatch` /
   `dispatch-sync` opts map carries the RETIRED `:dispatched-at` key.
 
-  EP-0010 disposition 5 / rider b retired `:dispatched-at` under the
-  STANDARD RETIREMENT TREATMENT (EP-0007 one-name-per-fact rule 2): a hard
-  error NAMING the replacement, never a silent alias and never a soft
-  warn-on-unknown-opt. Two spellings of \"when was this dispatched\" violate
-  one-name-per-fact, so a caller still passing `:dispatched-at` must be told
-  the canonical replacement, not left to a generic unknown-opt warning that
-  merely lists the known set (which would let the soft path become the
-  de-facto spelling — the cg7llv deterrent precedent).
+  `:dispatched-at` is retired under the STANDARD RETIREMENT TREATMENT
+  (EP-0007 one-name-per-fact rule 2): a hard error NAMING the replacement,
+  never a silent alias and never a soft warn-on-unknown-opt. Two spellings
+  of \"when was this dispatched\" violate one-name-per-fact, so a caller
+  still passing `:dispatched-at` must be told the canonical replacement, not
+  left to a generic unknown-opt warning that merely lists the known set
+  (which would let the soft path become the de-facto spelling).
 
   The durable causal-time fact is `(:rf/time-ms (:rf.cofx envelope))`
   — stamped by the framework at the dispatch causal boundary, NOT supplied
@@ -163,12 +156,13 @@
 
   Per Spec 002 §`:dispatched-at` is retired + EP-0010 disposition 5.
 
-  EP-0017 (rf2-oa2dun): the `:rf.world/inputs` dispatch opt is RENAMED to
-  `:rf.cofx` (no alias, no coexistence window — EP-0007 rule 2). Supplying the
-  retired key gets the SAME standard retirement treatment — a hard error
-  `:rf.error/world-inputs-renamed` naming `:rf.cofx` — checked alongside
-  `:dispatched-at` here so it fires before the clock stamp / frame resolution.
-  Always-on (a correctness contract; fires in production too)."
+  The flat recordable-coeffect map is supplied under `:rf.cofx`; there is
+  no `:rf.world/inputs` dispatch opt (no alias, no coexistence window —
+  EP-0007 rule 2). Supplying `:rf.world/inputs` gets the SAME standard
+  retirement treatment — a hard error `:rf.error/world-inputs-renamed`
+  naming `:rf.cofx` — checked alongside `:dispatched-at` here so it fires
+  before the clock stamp / frame resolution. Always-on (a correctness
+  contract; fires in production too)."
   [opts event]
   (when (contains? opts :rf.world/inputs)
     (error/throw-error!
@@ -209,8 +203,8 @@
                :replacement '(:rf/time-ms (:rf.cofx envelope))}})))
 
 (defn- validate-supplied-cofx-values!
-  "ALWAYS-ON structural-EDN check of a SUPPLIED `:rf.cofx` map's values
-  (rf2-rmroo4 slice A; production-hardened rf2-q34j26). Every value other than
+  "ALWAYS-ON structural-EDN check of a SUPPLIED `:rf.cofx` map's values.
+  Every value other than
   the framework's `:rf/time-ms` fact rides the durable causal record, so each
   MUST be recordable EDN data (EP-0017:386). The first non-recordable value
   throws `:rf.error/cofx-value-invalid` (reason `:non-edn-recordable-value`).
@@ -227,7 +221,7 @@
   complementary always-on per-supplier contract; this is the structural
   always-EDN floor that fires even when no `:schema` was declared.
 
-  The `:supplied` arm of the shared `value-check/check-edn-value!` (rf2-6zfzxy)
+  The `:supplied` arm of the shared `value-check/check-edn-value!`
   — its generated-value twin (slice B) lives at the generator write-back site
   (`re-frame.cofx`). The always-on listener carries the triggering `event` (the
   supplied path runs at the dispatch boundary, before any frame is owned)."
@@ -244,10 +238,9 @@
 
 (defn validate-cofx!
   "Throw `:rf.error/invalid-cofx` when a caller-supplied `:rf.cofx` is
-  structurally malformed at the PUBLIC dispatch boundary (rf2-47lgee /
-  rf2-nftz2s / rf2-alc1lf).
+  structurally malformed at the PUBLIC dispatch boundary.
 
-  EP-0017 makes `:rf.cofx` the durable causal token (the flat
+  `:rf.cofx` is the durable causal token (the flat
   recordable-coeffect map): its `:rf/time-ms` is the one host-clock fact
   durable writes fold (Spec 002 §Recordable coeffects), and replay / restore
   / SSR-hydration feed it verbatim. So a malformed token is not a harmless
@@ -257,7 +250,7 @@
   already validates its own wire shape, but that does NOT protect ordinary
   public `dispatch` / `dispatch-sync`; a single central validator at the
   dispatch boundary is simpler to reason about than relying on every caller /
-  tool to validate (rf2-nftz2s §1).
+  tool to validate.
 
   The contract MIRRORS the `:rf.cofx` schema (Spec-Schemas.md §:rf.cofx):
 
@@ -267,8 +260,8 @@
       framework's lone provided-on-the-envelope fact).
 
   Other facts (app-owned, subsystem-qualified) pass the cheap MAP-SHAPE gate
-  here, then — ALWAYS-ON (rf2-rmroo4 slice A; production-hardened rf2-q34j26 per
-  EP-0017 Open Issue 9 — structural EDN always, hard error in production too) —
+  here, then — ALWAYS-ON (per EP-0017 Open Issue 9 — structural EDN always,
+  hard error in production too) —
   each value is walked by `validate-supplied-cofx-values!` to confirm it is
   recordable EDN data (EP-0017:386): a host handle (DOM node, Promise, function,
   atom, Date, JS / Java object) supplied as a recordable coeffect throws
@@ -326,7 +319,7 @@
           {:extra {:event-id   (first event)
                    :event      event
                    :rf/time-ms (:rf/time-ms supplied)}}))
-      ;; rf2-rmroo4 slice A / rf2-q34j26 — structural-EDN-ALWAYS check of the
+      ;; Structural-EDN-ALWAYS check of the
       ;; SUPPLIED values, AFTER the map-shape + `:rf/time-ms` shape checks above
       ;; and BEFORE the per-supplier `:schema` validation (cofx.cljc,
       ;; satisfaction step). ALWAYS-ON (EP-0017 Open Issue 9 — production hard
@@ -346,14 +339,14 @@
     (seq (remove known-dispatch-opts (keys opts)))))
 
 (defn emit-unknown-dispatch-opts-warning!
-  "Per rf2-jbzhj: emit `:rf.warning/unknown-dispatch-opt` when a
+  "Emit `:rf.warning/unknown-dispatch-opt` when a
   `dispatch` / `dispatch-sync` opts map carries one or more keys outside
   the recognised `known-dispatch-opts` set. The runtime reads only the
   known keys in `build-envelope`; an unrecognised key (almost always a
   typo — `:fram` instead of `:frame`) is otherwise silently swallowed and
   changes nothing, producing wrong behaviour with no signal. Pre-alpha
   posture: surface it loudly rather than ship a quiet footgun (aligns with
-  the committed no-silent-swallow principle, rf2-3nbl5.1).
+  the no-silent-swallow principle).
 
   One warning per dispatch call carrying unknown keys: the message names
   every bad key and the full known set so the fix is obvious. The dispatch
@@ -363,7 +356,7 @@
   Body gated on `interop/debug-enabled?` so the whole surface — the
   warning keyword's interned slot, the reason-string allocation, the
   `unknown-dispatch-opts` walk — DCEs wholesale under `:advanced` +
-  `goog.DEBUG=false` (rf2-gaqwr). The caller in `build-envelope` reads the
+  `goog.DEBUG=false`. The caller in `build-envelope` reads the
   unknown-key seq inside the same gate so production never walks the opts."
   [unknown event]
   (when interop/debug-enabled?
@@ -389,14 +382,14 @@
                     :recovery     :no-recovery}))))
 
 (defn emit-cross-frame-warning!
-  "Per rf2-fp97: emit `:rf.warning/cross-frame-dispatch-sync-during-drain`
+  "Emit `:rf.warning/cross-frame-dispatch-sync-during-drain`
   when `dispatch-sync!` lands on frame `target-id` while a different
   frame (`other-id`) is mid-drain. The caller frame is read from
   `frame/*current-frame*`; when unbound (no frame context — e.g. a
   process-level REPL caller threading the dispatch through some unusual
   path) the field is `:rf/none`.
 
-  Per Mike's 2026-05-13 Option B decision: warn, do not refuse.
+  The cross-frame case is intentional but surprising: warn, do not refuse.
   Continues with the dispatch."
   [target-id other-id event]
   (let [caller-id (or frame/*current-frame* :rf/none)

--- a/implementation/core/src/re_frame/router_transducer.cljc
+++ b/implementation/core/src/re_frame/router_transducer.cljc
@@ -1,8 +1,8 @@
 (ns re-frame.router-transducer
-  "Phase-1 reference scaffold for the v1.1 transducer-shaped router design
-  (rf2-cl8me). Non-normative: this namespace is NOT wired into the live
-  runtime. It exists so the design in spec/Design-TransducerRouter.md is
-  exercisable from the REPL and pinned by a CLJS/CLJ unit-test surface.
+  "Reference scaffold for the transducer-shaped router design. Non-normative:
+  this namespace is NOT wired into the live runtime. It exists so the design
+  in spec/Design-TransducerRouter.md is exercisable from the REPL and pinned
+  by a CLJS/CLJ unit-test surface.
 
   The design intent:
    - `frame-transducer-factory` returns a transducer that maps dispatch

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -19,7 +19,7 @@
   if their reader's value changed by =, layer-2+ subs cascade
   topologically.
 
-  Disposal is **synchronous on derefer-count → 0** (rf2-cmfln, per
+  Disposal is **synchronous on derefer-count → 0** (per
   Spec 006 §Reference counting and disposal). When the last subscriber
   drops (`unsubscribe` drives the 1 → 0 transition), the cache entry is
   evicted IN-TICK: the reaction is disposed, the on-dispose callback
@@ -45,14 +45,13 @@
             [re-frame.subs.memo :as subs-memo]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]
-            ;; JVM autoload (rf2-bmzq0): the tooling sibling has zero
-            ;; artefact cost on JVM and we keep the legacy
-            ;; `re-frame.subs/<name>` shape working for JVM test
-            ;; fixtures via the alias block at the bottom of the
-            ;; file. CLJS deliberately omits this require so the
-            ;; tooling sibling stays out of production bundles. The
-            ;; reciprocal — `subs.tooling` requires `subs` to drive
-            ;; the alias chain — is avoided because subs.tooling
+            ;; JVM autoload: the tooling sibling has zero
+            ;; artefact cost on JVM and the `re-frame.subs/<name>`
+            ;; shape works for JVM test fixtures via the alias block
+            ;; at the bottom of the file. CLJS deliberately omits this
+            ;; require so the tooling sibling stays out of production
+            ;; bundles. The reciprocal — `subs.tooling` requires `subs`
+            ;; to drive the alias chain — is avoided because subs.tooling
             ;; only needs `registrar` / `frame` / `interop` and a
             ;; cyclic require would break the JVM autoload.
             #?@(:clj [[re-frame.subs.tooling :as subs-tooling]])))
@@ -164,9 +163,8 @@
               (vec remaining))))))
 
 (defn reg-sub
-  "Register a subscription under `id`. The only sub-registration form
-  in v2 — `reg-sub-raw` is dropped (per Spec 002 §Subscriptions
-  composing).
+  "Register a subscription under `id`. The sole sub-registration form
+  (per Spec 002 §Subscriptions composing).
 
   Four shapes — one per input-producer kind (Spec 006 §Subscription
   input producers):
@@ -237,20 +235,18 @@
                    (throw e)))
         {:keys [meta handler-fn input-kind input-signals input-fn]} parsed]
     ;; Per Spec 015 §Derived sensitivity — VALIDATE declarations fail-loud
-    ;; BEFORE the registrar write (rf2-ehexnw):
+    ;; BEFORE the registrar write:
     ;;   :sensitive / :large — per-output-path marks
     ;;   :rf.egress/output-sensitivity — the derived-output declassification
-    ;;     enum (:rf.egress/inherit | :rf.egress/sensitive | :rf.egress/public,
-    ;;     EP-0015 issue 9; the rejected :sensitive? overload throws here for
-    ;;     the :sub kind)
+    ;;     enum (:rf.egress/inherit | :rf.egress/sensitive | :rf.egress/public;
+    ;;     the :sensitive? overload throws here for the :sub kind)
     ;;   :large? — whole-output size override
     ;; The marks themselves are DERIVED from the registrar meta at `marks-for`
     ;; read time (no imperative stash). The propagation table
     ;; (`re-frame.marks/mark-sub-output!`) is updated on each sub-cache compute
-    ;; pass — see `compute-and-cache!`. DIRECT REQUIRE (rf2-58bq1r): the
-    ;; always-on, same-artefact `validate-marks!` is called directly, not through
-    ;; the former `:marks/validate-marks!` late-bind hop (a vestigial indirection
-    ;; for this key — no DCE seam, no decoupling, cycle-free).
+    ;; pass — see `compute-and-cache!`. The always-on, same-artefact
+    ;; `validate-marks!` is called directly (no late-bind hop): no DCE seam
+    ;; needed, no decoupling, cycle-free.
     (marks/validate-marks! :sub meta)
     (registrar/register! :sub id
       (cond-> (assoc (source-coords/merge-coords meta)
@@ -274,11 +270,11 @@
   reads ONE frame-state container directly (no `:<-` / `input-fn` producer,
   so `:input-signals` is empty `[]`).
 
-  rf2-ehexnw — VALIDATE marks fail-loud BEFORE the registrar write; marks are
+  VALIDATE marks fail-loud BEFORE the registrar write; marks are
   DERIVED from the registrar meta at read time, no imperative stash. Emits the
-  Spec 009 §`:rf.sub/create` materialisation trace. Returns `id`. DIRECT REQUIRE
-  (rf2-58bq1r): always-on, same-artefact validator called directly, not via the
-  former `:marks/validate-marks!` late-bind hop."
+  Spec 009 §`:rf.sub/create` materialisation trace. Returns `id`. The
+  always-on, same-artefact validator is called directly, not via a
+  late-bind hop."
   [id meta handler-fn input-kind]
   (marks/validate-marks! :sub meta)
   (registrar/register! :sub id
@@ -295,7 +291,7 @@
 (defn reg-runtime-sub
   "Register a FRAMEWORK subscription whose single layer-1-shaped signal
   source is the frame's **runtime-db** projection rather than app-db
-  (EP-0001 rf2-vzld77; Spec 002 §Subscriptions read the partition they
+  (Spec 002 §Subscriptions read the partition they
   belong to). The handler shape is identical to a layer-1 `reg-sub`
   computation fn — `(fn [runtime-db query-v] …)` — but the `db`-position
   argument is the runtime-db partition value, so framework subsystem subs
@@ -314,8 +310,8 @@
 (defn reg-frame-state-sub
   "Register a FRAMEWORK subscription whose single layer-1-shaped signal
   source is the frame's WHOLE frame-state container — BOTH partitions
-  `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}` (EP-0016 D3 slice 3,
-  rf2-616xa6). The handler shape is identical to a layer-1 `reg-sub`
+  `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`. The handler shape
+  is identical to a layer-1 `reg-sub`
   computation fn — `(fn [frame-state query-v] …)` — but the `db`-position
   argument is the FULL frame-state value, so the body can read durable
   runtime-db state AND derive over app-db in one coherent snapshot.
@@ -425,36 +421,34 @@
   `:rf.error/sub-input-fn-bad-return` ex-info from `normalize-sub-inputs`
   (the input-fn returned a bad shape). Call sites catch both, discriminate
   them, and route through the loud emission path with the right `:where`.
-  Legacy registrations (pre-`:input-kind`, theoretical) fall back to the
-  `:input-signals` list."
+  A registration without an `:input-kind` discriminator (defensive
+  fallback) resolves its `:input-signals` list as the literal inputs."
   [sub-meta query-v]
   (case (:input-kind sub-meta)
     :db          []
     :runtime-db  []
-    ;; EP-0016 D3 slice 3: a `:frame-state` sub is a single-source reader
-    ;; over the WHOLE frame-state value (both partitions); no input producer.
+    ;; A `:frame-state` sub is a single-source reader over the WHOLE
+    ;; frame-state value (both partitions); no input producer.
     :frame-state []
     :static     (vec (:input-signals sub-meta))
     :parametric (:queries (normalize-sub-inputs ((:input-fn sub-meta) query-v)))
-    ;; Fallback for any registration that predates the discriminator —
-    ;; treat its `:input-signals` as the literal input list (the prior
-    ;; behaviour). Defensive; all `reg-sub` paths now stamp `:input-kind`.
+    ;; Defensive fallback for a registration with no `:input-kind`
+    ;; discriminator — treat its `:input-signals` as the literal input
+    ;; list. Every `reg-sub` path stamps `:input-kind`.
     (vec (:input-signals sub-meta))))
 
-;; ---- single-source (layer-1-shaped) input-kinds (rf2-6zfzxy) --------------
+;; ---- single-source (layer-1-shaped) input-kinds ---------------------------
 ;;
 ;; `:db` / `:runtime-db` / `:frame-state` are the layer-1-SHAPED single-source
 ;; reader kinds: each reads ONE frame-state container directly (no `:<-` /
 ;; `input-fn` producer, so `produce-input-queries` returns `[]` for all three),
 ;; and each runs the same fixed-arity-1 memoised body — only the container the
-;; reaction watches differs. That membership was re-derived three ways (the
-;; reactive `(or layer-1? runtime-db? frame-state?)` flag union + the
-;; `compute-sub` `#{:db :runtime-db :frame-state}` inline set + the reactive
-;; `inputs` cond's three explicit container branches). The set + container map
-;; below are the single source those collapse onto.
+;; reaction watches differs. The set + container map below are the single
+;; source of this membership, consulted by the reactive build and the
+;; `compute-sub` path alike.
 
 (def ^:private single-source-input-kinds
-  "The layer-1-shaped single-source reader kinds (EP-0001 / EP-0016 D3): each
+  "The layer-1-shaped single-source reader kinds: each
   reads ONE frame-state container directly via the same fixed-arity-1 body."
   #{:db :runtime-db :frame-state})
 
@@ -463,7 +457,7 @@
   The reactive build watches the resolved container as the reaction's lone
   signal source: `:db` the app-db projection, `:runtime-db` the runtime-db
   projection, `:frame-state` the WHOLE frame-state value (both partitions, so
-  the body re-runs on a change to EITHER — EP-0016 D3 slice 3, rf2-616xa6)."
+  the body re-runs on a change to EITHER)."
   {:db          frame/app-db-container
    :runtime-db  frame/runtime-db-container
    :frame-state frame/frame-state-container})
@@ -477,8 +471,7 @@
   query-v)
 
 ;; Ref-counting, synchronous disposal, hot-reload invalidation, and
-;; `clear-sub-cache!` live in `re-frame.subs.cache` — extracted per
-;; rf2-0ytl4 Phase-2 seam S-A (fold-in of seam S-E). The public surface
+;; `clear-sub-cache!` live in `re-frame.subs.cache`. The public surface
 ;; (`clear-sub-cache!`) is reached through `re-frame.core`'s defalias
 ;; pointing at `re-frame.subs.cache/*` directly (no facade re-export).
 
@@ -487,12 +480,11 @@
 ;; The memo wrappers (`make-layer-1-memoised-body`,
 ;; `make-layer-n-single-input-memoised-body`, `make-layer-n-memoised-body`) and
 ;; the trace/perf/validate/recover bracket (`validate-and-trace`,
-;; `maybe-validate-sub!`) live in `re-frame.subs.memo` — extracted
-;; per rf2-0ytl4 Phase-2 seam S-B. Per-recompute hot path is the closure
-;; body (in-process); only the per-miss constructor call from
-;; `compute-and-cache!` below crosses the ns boundary.
+;; `maybe-validate-sub!`) live in `re-frame.subs.memo`. Per-recompute hot
+;; path is the closure body (in-process); only the per-miss constructor
+;; call from `compute-and-cache!` below crosses the ns boundary.
 
-;; ---- parametric input-fn error emission (rf2-7brl74) ----------------------
+;; ---- parametric input-fn error emission -----------------------------------
 ;;
 ;; Per Spec 009 §Error catalogue: `:rf.error/sub-input-fn-exception` (the
 ;; `input-fn` threw while materializing a node) and
@@ -516,9 +508,9 @@
   [error-kw query-id query-v frame-id e where]
   (let [data        (ex-data e)
         bad-return? (= :rf.error/sub-input-fn-bad-return error-kw)
-        ;; rf2-vzrxp3: nil-safe extractor (a thrown non-Error value has no message).
+        ;; nil-safe extractor (a thrown non-Error value has no message).
         msg         (error/ex-message-safe e)]
-    ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the always-on
+    ;; Both channels via the shared helper: axis 1 the always-on
     ;; listener (survives prod elision), axis 2 the dev trace (DCEs under
     ;; `:advanced` + `goog.DEBUG=false`). For the bad-return case there is no
     ;; genuine exception to ship (the throw is just our tagged carrier), so the
@@ -557,23 +549,22 @@
 
 (defn- produce-input-queries-or-emit!
   "Run [[produce-input-queries]] inside the shared try/produce/catch/
-  discriminate-bad-return wrapper both the reactive cache path and the
-  `compute-sub` path used identically (rf2-6zfzxy). Returns `[input-qs
+  discriminate-bad-return wrapper that both the reactive cache path and the
+  `compute-sub` path use identically. Returns `[input-qs
   input-error?]`: `[(produce-input-queries sub-meta query-v) false]` on
   success, or — when the parametric `input-fn` throws OR returns a bad shape
   (the tagged `:rf.error/sub-input-fn-bad-return` ex-info from
   `normalize-sub-inputs`) — emits LOUDLY via [[emit-sub-input-fn-error!]] and
   returns `[recovery-qs true]`. The exception is discriminated into
   `:rf.error/sub-input-fn-bad-return` vs `:rf.error/sub-input-fn-exception` by
-  its `:rf.error/id`, exactly as both call sites did.
+  its `:rf.error/id`.
 
   `where` (`:reactive` / `:compute-sub`) tags the emission site; `frame-id` is
   the reactive path's owning frame (nil on the pure `compute-sub` path).
   `recovery-qs` is the input-qs the caller wants on failure (`[]` reactive / nil
   compute-sub — both yield `(count …) 0`, and the `input-error?` flag
-  short-circuits every downstream use, so the choice is cosmetic; preserved per
-  call site to keep the collapse byte-identical). Layer-1 / `:static` never
-  throw here — only the parametric `input-fn` can."
+  short-circuits every downstream use, so the choice is cosmetic). Layer-1 /
+  `:static` never throw here — only the parametric `input-fn` can."
   [sub-meta query-v query-id frame-id where recovery-qs]
   (try
     [(produce-input-queries sub-meta query-v) false]
@@ -598,13 +589,12 @@
 
     - `make-layer-1-memoised-body` / `make-layer-n-single-input-memoised-body` /
       `make-layer-n-memoised-body` — Spec 006 §No-op via value
-      equality (rf2-719e). Wraps the user's body in a `=`-skipping
+      equality. Wraps the user's body in a `=`-skipping
       memo. The layer-1 form is fixed-arity-1 and compares the db
       scalar directly (avoids per-recompute varargs-seq allocation).
       Layer-2 with a single `:<-` input gets the same fixed-arity-1
-      treatment (rf2-0y2bp — the dominant layer-2 shape per
-      rf2-v1nu0). Layer-2+ with ≥2 inputs keeps the vec-of-inputs
-      varargs shape.
+      treatment (the dominant layer-2 shape). Layer-2+ with ≥2 inputs
+      uses the vec-of-inputs varargs shape.
     - `validate-and-trace`  — Spec 009 :sub/run trace emit, perf bracket,
       Spec 010 step 6 validation, error contract
       (`:replaced-with-default` on throw).
@@ -626,11 +616,10 @@
                         ;; carries the full query-vector that failed to resolve
                         ;; and `:resolved-inputs` is empty — the miss is detected
                         ;; on `sub-meta` lookup, before any `:<-` input is
-                        ;; resolved. (rf2-agpv2.3 — aligns the emit tag-shape to
-                        ;; Spec 009; recovery is unchanged: nil-yielding reaction,
-                        ;; not cached.)
+                        ;; resolved. The emit tag-shape follows Spec 009;
+                        ;; recovery is a nil-yielding reaction, not cached.
                         ;;
-                        ;; Per rf2-2hvga (= B / widen): fan out through the
+                        ;; Fan out through the
                         ;; always-on error-emit listener (surface #4) so a
                         ;; subscribe to a never-registered sub survives
                         ;; `:advanced` + `goog.DEBUG=false` and reaches off-box
@@ -638,9 +627,9 @@
                         ;; An invalid op whose recovery is the built-in
                         ;; `:replaced-with-default`. The `:frame`-stampable
                         ;; record carries `frame-id` + the attempted `query-v`
-                        ;; for 7d30s + shipper attribution.
+                        ;; for frame + shipper attribution.
                         ;;
-                        ;; Both channels via the shared helper (rf2-c4oycd):
+                        ;; Both channels via the shared helper:
                         ;; axis 1 the always-on listener (survives prod elision),
                         ;; axis 2 the dev trace (DCEs under `:advanced` +
                         ;; `goog.DEBUG=false`). No exception — invalid op;
@@ -670,12 +659,11 @@
         ;; resolve + the not-cached symmetric-input-release guard below.
         ;; `:runtime-db` / `:frame-state` are the OTHER single-source kinds (the
         ;; `single-source-input-kinds` set drives the shared memoised-body +
-        ;; container-lookup decisions); EP-0001 (rf2-vzld77) made `:runtime-db`
-        ;; a layer-1-shaped framework reader over the frame's runtime-db
-        ;; projection, and EP-0016 D3 slice 3 (rf2-616xa6) made `:frame-state`
-        ;; a single-source reader over the WHOLE frame-state value (both
-        ;; partitions, so the body re-runs on EITHER an app-db or a runtime-db
-        ;; change).
+        ;; container-lookup decisions). `:runtime-db` is a layer-1-shaped
+        ;; framework reader over the frame's runtime-db projection, and
+        ;; `:frame-state` is a single-source reader over the WHOLE frame-state
+        ;; value (both partitions, so the body re-runs on EITHER an app-db or a
+        ;; runtime-db change).
         layer-1?      (= :db input-kind)
         ;; The single-source container resolver for this kind (`:db` → app-db,
         ;; `:runtime-db` → runtime-db, `:frame-state` → whole frame-state), or
@@ -705,10 +693,9 @@
         ;; production yields an empty `input-qs` and a constant-nil body.
         ;; Single-source readers (`:db` / `:runtime-db` / `:frame-state`) watch
         ;; ONE resolved container; the `single-source-container-for` lookup
-        ;; (rf2-6zfzxy) picks the app-db / runtime-db / whole-frame-state
-        ;; container — the `:frame-state` container propagates on a change to
-        ;; EITHER partition (EP-0016 D3 slice 3). Layer-2+ subscribes each
-        ;; realized input.
+        ;; picks the app-db / runtime-db / whole-frame-state container — the
+        ;; `:frame-state` container propagates on a change to EITHER partition.
+        ;; Layer-2+ subscribes each realized input.
         inputs        (cond
                         container-fn [(container-fn frame-id)]
                         input-error? []
@@ -736,8 +723,8 @@
 
                         ;; PARAMETRIC subs (any realized input count,
                         ;; including 1) deliver a VECTOR of input values to
-                        ;; the computation fn — `(fn [[a b] q] ...)` — per the
-                        ;; EP §Single input contract. Route through the
+                        ;; the computation fn — `(fn [[a b] q] ...)` — per
+                        ;; Spec 006 §Single input contract. Route through the
                         ;; varargs layer-n wrapper with `vector-inputs? true`
                         ;; so even a single realized parametric input is
                         ;; delivered as `[value]`, NOT the bare-value `:<-`
@@ -746,9 +733,9 @@
                         (subs-memo/make-layer-n-memoised-body
                           body-fn query-id query-v frame-id input-qs sub-meta true)
 
-                        ;; Static `:<-` with a single input — dominant shape
-                        ;; per rf2-v1nu0; specialise to fixed-arity-1 for
-                        ;; parity with layer-1 (rf2-0y2bp). Delivers the bare
+                        ;; Static `:<-` with a single input — the dominant
+                        ;; shape; specialise to fixed-arity-1 for
+                        ;; parity with layer-1. Delivers the bare
                         ;; value (the v1 `:<-` single-input convention).
                         (= 1 (count input-qs))
                         (subs-memo/make-layer-n-single-input-memoised-body
@@ -782,8 +769,8 @@
           (when-let [mark! (late-bind/get-fn :marks/mark-sub-output!)]
             (let [[s? l?] (resolve frame-id query-id input-signals layer-1?)]
               (mark! frame-id query-id s? l?))))))
-    ;; Skip caching the no-such-sub miss — see the rf2-l9u5 note in the
-    ;; docstring. The reaction is built so callers that hold a reference
+    ;; Skip caching the no-such-sub miss — see the docstring's
+    ;; unknown-sub note. The reaction is built so callers that hold a reference
     ;; deref to nil (per Spec 009 §Error contract recovery
     ;; :replaced-with-default), but the cache slot stays empty so a later
     ;; registration is observed by the next subscribe.
@@ -807,7 +794,7 @@
                          (if (identical? reaction (get-in m [k :reaction]))
                            (dissoc m k)
                            m))))))
-    ;; rf2-agpv2.2 — symmetric input release on the not-cached path.
+    ;; Symmetric input release on the not-cached path.
     ;; A layer-2+ build already subscribed each `:<-` input above (bumping
     ;; their ref-counts), but the dispose-wiring that releases them lives
     ;; ONLY inside the `(when (and cache sub-meta) …)` branch. If the frame
@@ -829,7 +816,7 @@
              (catch #?(:clj Throwable :cljs :default) _ nil))))
     reaction))
 
-;; ---- the sub-override subscribe seam (rf2-7pgiz; CLJS, dev-only) ----------
+;; ---- the sub-override subscribe seam (CLJS, dev-only) --------------------
 ;;
 ;; See the block comment inside `subscribe` for the full rationale. These
 ;; two helpers are CLJS-only and consulted ONLY inside the
@@ -842,7 +829,7 @@
 
 #?(:cljs
    (defn- maybe-validate-sub-override!
-     "FOLD-IN (rf2-7pgiz). When a `:sub-overrides` HIT targets a sub that
+     "When a `:sub-overrides` HIT targets a sub that
      declares an output `:schema`, validate the pinned `value` against it
      the SAME way Spec 010 §step 6 validates a `:sub-return` — through the
      registered validator reached via the `:schemas/validate-with-registered-fn`
@@ -860,7 +847,7 @@
      the registered validator so a substituted (non-Malli) validator
      covers this surface identically to `:sub-return`.
 
-     `frame-id` (rf2-7d30s) is the subscribing frame — stamped onto the
+     `frame-id` is the subscribing frame — stamped onto the
      failure trace so `re-frame.epoch.capture/capture-event!` (which
      buffers only frame-tagged traces) attributes the override-validation
      failure to that frame's epoch, mirroring `:sub-return`'s `:frame`
@@ -879,15 +866,15 @@
                    explain (when-let [exp (late-bind/get-fn-cached
                                             :schemas/explain-with-registered-fn)]
                              (try (exp schema value) (catch :default _ nil)))
-                   ;; rf2-o69h5 — route the value-bearing slots (`:value` /
+                   ;; Route the value-bearing slots (`:value` /
                    ;; `:received` / `:explain` / `:rf.sub/query-v`) through the
                    ;; SHARED schema-aware redaction seam so a `:sub-override`
                    ;; on a `:sensitive?`-marked sub schema scrubs identically
                    ;; to the regular `:sub-return` path (which redacts via
                    ;; `validate-sub!`). This override path bypasses
-                   ;; `validate-sub!`, so without the seam it leaked the
-                   ;; failing value verbatim — the a5kzs#1 class on the
-                   ;; `:sub-override` surface.
+                   ;; `validate-sub!`, so the seam is what keeps the failing
+                   ;; value from leaking verbatim on the `:sub-override`
+                   ;; surface.
                    redact  (late-bind/get-fn-cached :schemas/redact-validation-tags)
                    tags    (cond-> {:where          :sub-override
                                     :rf.sub/id      sub-id
@@ -912,12 +899,12 @@
 #?(:cljs
    (defn- resolve-sub-override
      "Consult the `:subs/resolve-sub-override` late-bind hook for an
-     exact-query-vector `:sub-overrides` HIT (rf2-7pgiz). The hook (Story-
+     exact-query-vector `:sub-overrides` HIT. The hook (Story-
      published) reads the closest enclosing override-context Provider and
      returns `[value]` on a hit (a one-element vector so a nil-valued
      override is honoured) or nil on a miss / unbound.
 
-     On a HIT, schema-validate the pinned value (the FOLD-IN — see
+     On a HIT, schema-validate the pinned value (see
      `maybe-validate-sub-override!`) and return a CONSTANT reaction
      `(adapter/make-derived-value [] (constantly v))` — no inputs, never
      recomputes, never cached, never touches app-db / `compute-sub`. On a
@@ -939,14 +926,14 @@
   build-and-cache on miss; reuse on hit. The 1-arity ambient form
   resolves the active frame through the carried-invariant scope/hold
   chain via `frame/require-current-frame!` (EP-0002): a `with-frame` /
-  frame-provider scope (the `:adapter/current-frame` late-bind hook,
-  rf2-d4sf) or a captured `*current-frame*` stamp. There is NO
+  frame-provider scope (the `:adapter/current-frame` late-bind hook)
+  or a captured `*current-frame*` stamp. There is NO
   `:rf/default` floor — a subscribe issued under no established scope
   raises `:rf.error/no-frame-context` rather than silently reading the
   wrong frame. Pass the 2-arity `(subscribe frame-id query-v)` to read a
   named frame from outside any scope (async callbacks, tools, tests, SSR).
 
-  Per Spec 006 §Plain-fn-under-non-default-frame warning (rf2-d3k3):
+  Per Spec 006 §Plain-fn-under-non-default-frame warning:
   the 1-arity form runs the plain-fn detection check — if the
   surrounding React-context Provider names a non-default frame and the
   rendering component is NOT reg-view-wrapped (so its subscribe call
@@ -957,14 +944,14 @@
   `goog.DEBUG=false`) elides via `interop/debug-enabled?`.
 
   The 2-arity `(subscribe frame-id query-v)` form **deliberately
-  skips** the plain-fn detection check (rf2-r0zf2). Supplying an
+  skips** the plain-fn detection check. Supplying an
   explicit `frame-id` IS the opt-out — the caller has told the runtime
   exactly which frame to target, so a fall-through-to-`:rf/default`
   diagnostic doesn't apply. Use the 2-arity form from a plain
   Reagent fn body when you want to subscribe against a known frame
   without triggering the warning surface.
 
-  Per Spec 006 §The sub-override subscribe seam (rf2-7pgiz, CLJS /
+  Per Spec 006 §The sub-override subscribe seam (CLJS /
   dev-only): when a Story render wraps the variant view in the
   override-context Provider, an exact-query-vector `:sub-overrides` HIT
   short-circuits build-and-cache and returns a constant reaction holding
@@ -999,7 +986,7 @@
                  :event-id (first query-v)})
               query-v))
   ([frame-id query-v]
-   ;; EP-0023 (rf2-32siq3.32): the 2-arity target may be a frame-id KEYWORD or a
+   ;; The 2-arity target may be a frame-id KEYWORD or a
    ;; live frame OBJECT (`(rf/subscribe frame query-v)` — `rf/make-frame`'s
    ;; return value). Normalize an object to its runnable-id ADDRESS so the
    ;; sub-cache lookup (`(frame/frame frame-id)`),
@@ -1010,7 +997,7 @@
    ;; image, byte-identical to the keyword form. Mirrors the dispatch-side
    ;; normalization in `re-frame.router/build-envelope`.
    (let [frame-id (frame/frame-target->id frame-id)]
-   ;; rf2-9hoos (CLJS, dev-only): record the view→sub edge — push this
+   ;; (CLJS, dev-only): record the view→sub edge — push this
    ;; query-v into the in-flight render's deref sink so `:rf.view/rendered`
    ;; can carry the view's OWN read-set (`:deref-subs`). No-op outside a
    ;; view render (the sink is unbound) and on the JVM. Routed through
@@ -1022,7 +1009,7 @@
       (when interop/debug-enabled?
         (when-let [record! (late-bind/get-fn :views/record-view-deref!)]
           (record! query-v))))
-   ;; rf2-7pgiz (CLJS, dev-only): the SUBSTITUTIVE override seam. Story's
+   ;; (CLJS, dev-only): the SUBSTITUTIVE override seam. Story's
    ;; lowest-fidelity ladder rung (`:sub-overrides`) pins a view into an
    ;; `:error`/`:loading`/`:empty` state by naming subscription
    ;; query-vectors and the values they should surface — no events, no
@@ -1042,7 +1029,7 @@
    ;; sub through `compute-sub` against the real app-db) still cannot be
    ;; satisfied by an override — the load-bearing honesty boundary.
    ;;
-   ;; FOLD-IN (rf2-7pgiz): an override that violates the sub's own
+   ;; An override that violates the sub's own
    ;; declared output `:schema` is exactly the "pin a state the real
    ;; derivation could never produce" anti-pattern, so we schema-validate
    ;; the pinned value the SAME way Spec 010 §step 6 validates a
@@ -1062,15 +1049,15 @@
    ;; nil to fall through to the normal build-and-cache path. On the JVM
    ;; and in production it is always nil (the gate / reader DCE / no-op).
    ;;
-   ;; EP-0023 (rf2-uejnt3): route the BUILD path through the target frame's
+   ;; Route the BUILD path through the target frame's
    ;; resolved IMAGE generation when `frame-id` names an image-loaded frame, so
    ;; `registrar/lookup :sub` (and the layer-2+ input `subscribe` calls inside
    ;; `compute-and-cache!`) resolve the sub handler through the frame's OWN
-   ;; image (rf2-32siq3.9's seam, invoked at the live subscribe entry). Two
-   ;; frames running DIFFERENT images thus build the same sub-id against their
-   ;; own image's descriptor. A target naming no image-loaded frame (a
+   ;; image (the image-resolution seam, invoked at the live subscribe entry).
+   ;; Two frames running DIFFERENT images thus build the same sub-id against
+   ;; their own image's descriptor. A target naming no image-loaded frame (a
    ;; single-realm default frame) derives no generation, so this binds nothing
-   ;; and the build resolves through the registrar atom exactly as before
+   ;; and the build resolves through the registrar atom directly
    ;; (absence-is-default). DERIVED from the carried target (EP-0002).
    (live-frame/call-with-frame-resolution
      (live-frame/frame-resolution-target frame-id)
@@ -1082,8 +1069,8 @@
      (let [frame-record (frame/frame frame-id)]
        (cond
          ;; Missing or destroyed frame: emit + return nil rather than
-         ;; deref-ing nil and exploding. Per rf2-2hvga (= B + recover-but-
-         ;; emit): subscribe RECOVERS (returns nil) AND emits a
+         ;; deref-ing nil and exploding. Subscribe RECOVERS (returns nil)
+         ;; AND emits a
          ;; production-survivable `:rf.error/frame-destroyed` through the
          ;; always-on error-emit listener (surface #4) so a subscribe
          ;; during a teardown / hot-reload race recovers safely while a
@@ -1092,10 +1079,10 @@
          ;; `:error-emit/dispatch-on-error` late-bind hook (subs cannot
          ;; static-require `re-frame.error-emit` — load cycle). The
          ;; `:frame`-stampable record carries `frame-id` + the attempted
-         ;; `query-v` (as `:event`) for 7d30s + shipper attribution.
+         ;; `query-v` (as `:event`) for frame + shipper attribution.
          (nil? frame-record)
          (do
-           ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the
+           ;; Both channels via the shared helper: axis 1 the
            ;; always-on listener (survives prod elision), axis 2 the dev trace
            ;; (DCEs under `:advanced` + `goog.DEBUG=false`). No exception —
            ;; invalid op; `elapsed-ms 0`. Reached via the
@@ -1144,7 +1131,7 @@
                (if (identical? reaction (get-in new [k :reaction]))
                  reaction
                  (compute-and-cache! frame-id query-v)))
-             (compute-and-cache! frame-id query-v))))))))))) ;; close fn + call-with-frame-resolution (rf2-uejnt3) + normalize-target let (rf2-32siq3.32)
+             (compute-and-cache! frame-id query-v))))))))))) ;; close fn + call-with-frame-resolution + normalize-target let
 
 (defn subscribe-once
   "One-shot read of a sub's current value. Subscribes, derefs, then
@@ -1158,7 +1145,7 @@
   `:rf.cofx/requires` (EP-0017) so the read is part of the cofx contract
   rather than a side-effect inside the handler body.
 
-  Per rf2-cmfln (Spec 006 §Reference counting and disposal): the
+  Per Spec 006 §Reference counting and disposal: the
   teardown `unsubscribe` runs synchronously on the 1 → 0 transition,
   so the one-shot read's whole lifetime — subscribe, deref, dispose —
   completes in the calling tick. Concurrent reactive subscribers keep
@@ -1186,8 +1173,8 @@
 
 (defn- frame-state-value?
   "True when `v` is a frame-state projection map carrying at least one
-  partition key (`:rf.db/app` / `:rf.db/runtime`). EP-0001 (rf2-vzld77):
-  `compute-sub` accepts EITHER a bare app-db map (the historical form) or a
+  partition key (`:rf.db/app` / `:rf.db/runtime`).
+  `compute-sub` accepts EITHER a bare app-db map or a
   full frame-state value, so a single call can resolve both `:db` and
   `:runtime-db` subs in one dependency graph against the coherent snapshot."
   [v]
@@ -1208,8 +1195,8 @@
   (if (frame-state-value? supplied)
     (case input-kind
       :runtime-db (get supplied :rf.db/runtime)
-      ;; EP-0016 D3 slice 3: a `:frame-state` sub's body wants the WHOLE
-      ;; frame-state value (both partitions) — pass it through unextracted.
+      ;; A `:frame-state` sub's body wants the WHOLE frame-state value
+      ;; (both partitions) — pass it through unextracted.
       :frame-state supplied
       (get supplied :rf.db/app))
     supplied))

--- a/implementation/core/src/re_frame/subs/cache.cljc
+++ b/implementation/core/src/re_frame/subs/cache.cljc
@@ -1,8 +1,6 @@
 (ns re-frame.subs.cache
   "Sub-cache state, ref-counting, synchronous disposal, hot-reload
-  invalidation, and the test-fixture cache clear. Extracted from
-  `re-frame.subs` per rf2-0ytl4 Phase-2 seam S-A (fold-in of seam S-E
-  for the registrar-replacement hook).
+  invalidation, and the test-fixture cache clear.
 
   Per Spec 006 §Subscription cache and §Reference counting and disposal.
   This ns owns the per-frame `:sub-cache` shape:
@@ -13,7 +11,7 @@
   via deref. Disposal is wired on the reaction (interop/add-on-dispose!),
   not an entry-level callback slot.
 
-  Disposal is **synchronous on derefer-count → 0** (rf2-cmfln, per
+  Disposal is **synchronous on derefer-count → 0** (per
   Spec 006 §Reference counting and disposal). When the last subscriber
   drops (`unsubscribe!` drives the 1 → 0 transition), the cache entry is
   evicted IN-TICK — the reaction is disposed, the on-dispose callback
@@ -24,7 +22,7 @@
 
   The shared-component-thrash scenario (a component unmounts and the
   same subscription remounts in the same tick) re-builds the slot on the
-  new mount; this is acceptable per the rf2-cmfln design — the
+  new mount; this is acceptable by design — the
   recomputed value is `=` to the disposed one, so the post-mount render
   observes no value change, and the cache-miss path's cost is dominated
   by `compute-and-cache!`'s reaction construction (one allocation, no
@@ -42,7 +40,7 @@
   if it stays trivial. Keeping the constant chokepoint co-located with
   `subscribe` preserves the hot-path lookup.
 
-  Per rf2-mrnur (Spec 009 §:op-type vocabulary §`:rf.sub/dispose`): every
+  Per Spec 009 §:op-type vocabulary §`:rf.sub/dispose`: every
   eviction site emits a `:rf.sub/dispose` trace event so consumers can
   observe the sub-cache lifecycle's terminal half — created / run / skip
   / **dispose**. The reason axis discriminates the eviction path:
@@ -51,7 +49,7 @@
   teardown), `:frame-destroy` (the frame's cache was torn down by
   `destroy-frame!` — routed in via the
   `:subs.cache/dispose-all-for-frame-destroy!` late-bind hook so
-  `frame.cljc` carries no static dep on this ns; rf2-x3m8c).
+  `frame.cljc` carries no static dep on this ns).
   Cache-key shape is the query-vector itself
   (`re-frame.subs/cache-key` is identity), so the emit derives
   `:rf.sub/id` and `:rf.sub/query-v` directly from `k`. The emits ride
@@ -66,7 +64,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- dispose trace emit (rf2-mrnur) ---------------------------------------
+;; ---- dispose trace emit ---------------------------------------------------
 ;;
 ;; Per Spec 009 §:op-type vocabulary §`:rf.sub/dispose` — every cache
 ;; eviction site funnels through this helper so the emit tag-shape is
@@ -99,13 +97,13 @@
   (`interop/dispose!`) inside the swap-fn could fire 2+ times under
   concurrent invalidate + dispose race.
 
-  Per rf2-mrnur: emits `:rf.sub/dispose` with `:rf.sub/reason
+  Emits `:rf.sub/dispose` with `:rf.sub/reason
   :no-more-derefers` after the CAS commits, for the call that actually
   drove the eviction (read off the `old` / `new` snapshot diff — the
   same single-fire discipline that gates `interop/dispose!`). `frame-id`
-  rides on the emit's `:frame` tag; the 2-arity form is preserved for
-  legacy call sites that don't carry a frame-id (the emit fires with
-  `:frame nil` and tools fall back to `:rf.sub/id` for grouping)."
+  rides on the emit's `:frame` tag; the 2-arity form serves call sites
+  that don't carry a frame-id (the emit fires with `:frame nil` and
+  tools fall back to `:rf.sub/id` for grouping)."
   ([cache k] (dispose-entry-now! cache k nil))
   ([cache k frame-id]
    (let [[old new] (swap-vals! cache
@@ -120,7 +118,7 @@
      ;; replace! or clear-sub-cache!) that won the CAS race would
      ;; have left the slot absent in `old` too, so we don't double-dispose.
      (when (and (contains? old k) (not (contains? new k)))
-       ;; rf2-mrnur — emit the dispose trace before tearing down the
+       ;; Emit the dispose trace before tearing down the
        ;; reaction. Single-fire (gated on the same CAS-winner check as
        ;; `interop/dispose!`) so we never double-emit under contention.
        (emit-dispose! frame-id k :no-more-derefers)
@@ -134,8 +132,7 @@
   ref-count reaches 0, dispose the entry **synchronously** — evict the
   cache slot, run the reaction's on-dispose callback (which releases
   input refs symmetrically), and emit `:rf.sub/dispose` with reason
-  `:no-more-derefers`. Per Spec 006 §Reference counting and disposal
-  (rf2-cmfln).
+  `:no-more-derefers`. Per Spec 006 §Reference counting and disposal.
 
   No grace-period: the 1 → 0 transition disposes in-tick. A resubscribe
   arriving AFTER `unsubscribe!` returns is treated as a fresh cache miss
@@ -147,11 +144,11 @@
   Called from the public `re-frame.subs/unsubscribe` after `cache-key`
   + `cache` resolution; the facade fn holds the public API shape.
 
-  Per rf2-mrnur: `frame-id` is threaded through to `dispose-entry-now!`
+  `frame-id` is threaded through to `dispose-entry-now!`
   so the `:rf.sub/dispose` trace emit at the actual eviction site
-  carries the right `:frame` tag. The 2-arity form is preserved for
-  legacy callers that don't carry a frame-id; the emit falls back to
-  `:frame nil` on that path."
+  carries the right `:frame` tag. The 2-arity form serves callers that
+  don't carry a frame-id; the emit falls back to `:frame nil` on that
+  path."
   ([cache k] (unsubscribe! cache k nil))
   ([cache k frame-id]
    (let [;; The swap-fn body is pure — it returns only the new cache
@@ -243,7 +240,7 @@
               ;; swap saw them, so the diff names ONLY the keys we own.
               evicted-keys (filterv #(not (contains? new %))
                                     (keys old))]
-          ;; rf2-mrnur — emit dispose per evicted key BEFORE running the
+          ;; Emit dispose per evicted key BEFORE running the
           ;; per-reaction `interop/dispose!` teardown. The reason
           ;; `:hot-reload` discriminates this path from sync 1 → 0 fires
           ;; (`:no-more-derefers`) and explicit `clear-sub-cache!`
@@ -280,7 +277,7 @@
   ([frame-id]
    (when-let [cache (:sub-cache (frame/frame frame-id))]
      (doseq [[k entry] @cache]
-       ;; rf2-mrnur — emit dispose per evicted key BEFORE the per-
+       ;; Emit dispose per evicted key BEFORE the per-
        ;; reaction `interop/dispose!`. Reason `:cache-clear`
        ;; discriminates the explicit-teardown path from sync 1 → 0
        ;; fires (`:no-more-derefers`) and hot-reload re-registration
@@ -305,7 +302,7 @@
   static dependency on the CLJS-only spine. Per Spec 006 §Lifetime
   contract — frame disposal §Adapter symmetry: the adapter's
   `dispose-adapter!` disposes every frame's sub-cache as part of process
-  teardown (rf2-ghfkkk).
+  teardown.
 
   Best-effort, per-frame: a throwing per-entry dispose does NOT abort the
   rest of the walk — every other cached entry in the same frame AND every
@@ -318,7 +315,7 @@
     (clear-sub-cache! frame-id))
   nil)
 
-;; ---- frame-destroy eviction (rf2-x3m8c) ----------------------------------
+;; ---- frame-destroy eviction ----------------------------------------------
 ;;
 ;; `re-frame.frame/destroy-frame!` tears the destroyed frame's sub-cache
 ;; down as one of its ordered steps. It MUST funnel through this helper

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -1,9 +1,8 @@
 (ns re-frame.subs.memo
   "Memo wrappers + the trace/perf/validate/recover bracket that brackets
-  a user sub body. Extracted from `re-frame.subs` per rf2-0ytl4 Phase-2
-  seam S-B — pure cohesion split, public surface unchanged.
+  a user sub body.
 
-  Per Spec 006 §No-op via value equality (rf2-719e). Reagent's auto-run
+  Per Spec 006 §No-op via value equality. Reagent's auto-run
   reaction unconditionally invokes the compute fn on any source-watch
   fire, then dedups *downstream notification* by `=`. That's one level
   too late for the spec — the body fn itself must NOT re-run when the
@@ -22,14 +21,13 @@
   allocation in the artefact.
 
   Layer-2 with a single `:<-` input gets the same fixed-arity-1
-  treatment (rf2-0y2bp). The adapter's `make-derived-value` already
-  specialises its recompute closure to `(compute-fn @s0)` for the
-  1-source case (rf2-v1nu0) — but the layer-N memo wrapper was
-  varargs (`(fn [& in-vals])`), which forces a one-element ArraySeq
-  allocation on every recompute. The dominant layer-2 shape is
-  1-input, so we mirror the layer-1 specialisation here: fixed-arity-1
-  wrapper, direct scalar compare against the last-seen input value.
-  The ≥2-input path keeps the original varargs shape.
+  treatment. The adapter's `make-derived-value` specialises its
+  recompute closure to `(compute-fn @s0)` for the 1-source case, and the
+  memo wrapper mirrors the layer-1 specialisation: a fixed-arity-1
+  wrapper with a direct scalar compare against the last-seen input value,
+  avoiding the one-element ArraySeq allocation a varargs
+  (`(fn [& in-vals])`) form would force on every recompute. The dominant
+  layer-2 shape is 1-input. The ≥2-input path uses the varargs shape.
 
   Per-recompute hot path is the closure body (in-process) — unaffected
   by the ns boundary. Per-miss constructor call (from
@@ -46,11 +44,12 @@
 
 ;; ---- recompute attribution sentinel + cause-sub resolution ---------------
 ;;
-;; Per rf2-l1jz8 — the `:sub/run` trace carries value-change + cascade
+;; The `:sub/run` trace carries value-change + cascade
 ;; attribution so Xray's Reactive panel can populate its "SUBS WHOSE
 ;; VALUE CHANGED" and "SUBS THAT CASCADED" sections. The memo wrapper
 ;; already holds the prior computed value and prior input value(s) in its
-;; volatile cells (it must, to dedup `=`-equal recomputes per rf2-719e),
+;; volatile cells (it must, to dedup `=`-equal recomputes per Spec 006
+;; §No-op via value equality),
 ;; so the attribution is computed from data already on hand — no extra
 ;; cache read, no second `=` walk on the hot recompute path beyond the one
 ;; the memo wrapper already performed.
@@ -88,7 +87,7 @@
             (recur (inc i))))))))
 
 (defn maybe-validate-sub!
-  "Per Spec 010 §Validation order step 6 (rf2-wcam) — after a sub
+  "Per Spec 010 §Validation order step 6 — after a sub
   recomputes, validate its return value against any :schema on the sub
   meta. On failure, emit :rf.error/schema-validation-failure and
   return nil per :replaced-with-default recovery; otherwise return
@@ -98,14 +97,14 @@
   stays free of a hard re-frame.schemas dep (avoids load-order
   surprises).
 
-  rf2-9cm27 — `frame-id` (the reaction's frame) is passed through to
+  `frame-id` (the reaction's frame) is passed through to
   `validate-sub!` so the `:where :sub-return` failure trace carries
   `:frame` and lands in the per-frame epoch `:trace-events` (epoch
   capture buffers only frame-tagged traces). Mirrors the `:where
   :app-db` / `:where :event` traces."
   [value query-v sub-id sub-meta frame-id]
   (if (and sub-meta (:schema sub-meta))
-    ;; Sticky hook (rf2-f72pd) — fires per-sub recompute.
+    ;; Sticky hook — fires per-sub recompute.
     (if-let [validate (late-bind/get-fn-cached :schemas/validate-sub!)]
       (if (try (validate sub-id query-v value sub-meta frame-id)
                (catch #?(:clj Throwable :cljs :default) _ true))
@@ -124,26 +123,26 @@
 
   Concerns folded in here, in order:
 
-  1. Spec 009 §Performance instrumentation (rf2-du3i) — bracket the
+  1. Spec 009 §Performance instrumentation — bracket the
      body call in performance marks so prod builds with the perf flag
      enabled produce a `rf:sub:<sub-id>` measure entry. Default-off;
      under `:advanced` + `re-frame.performance/enabled?=false` the
      bracket DCEs.
-  2. Spec 010 §Validation order step 6 (rf2-wcam) — validate the body's
+  2. Spec 010 §Validation order step 6 — validate the body's
      return value against the sub's `:schema` meta. Failures emit
      :rf.error/schema-validation-failure and yield nil (recovery
      :replaced-with-default).
   3. Spec 009 §:op-type vocabulary — emit :sub/run for the recompute.
      The memo-hit path does NOT emit (per Spec 006 §No-op via value
      equality). The emit fires AFTER (1)+(2) so the trace can carry the
-     COMPUTED value and value-change / cascade attribution (rf2-l1jz8 —
-     see §Recompute attribution below). It MUST stay inside
+     COMPUTED value and value-change / cascade attribution (see
+     §Recompute attribution below). It MUST stay inside
      `with-handler-scope` so the sub's source-coord rides the tag.
   4. Spec 009 §Error contract — `try/catch` around (1)+(2)+(3). On
      exception emit :rf.error/sub-exception and yield nil (recovery
      :replaced-with-default).
 
-  ## Recompute attribution (rf2-l1jz8, dev-only)
+  ## Recompute attribution (dev-only)
 
   When `interop/debug-enabled?` the `:sub/run` tag carries:
 
@@ -158,7 +157,7 @@
                        `false` on every subsequent recompute. Disambiguates
                        a value-change row from a freshly-created sub row
                        so consumers (Xray's SUBSCRIPTIONS leaf-scalar
-                       renderer per rf2-fyd8u) can pick `← was X` vs
+                       renderer) can pick `← was X` vs
                        `:added` chrome without inferring from
                        `:prev-value nil`. Not wire-sensitive. Per
                        Spec 009 §`:rf.sub/run`.
@@ -175,7 +174,7 @@
                        reactive input. Sourced from the in-flight
                        cascade buffer via the `:epoch/cascade-cause`
                        late-bind hook — same source the views path uses
-                       for `:rf.view/cause-event-id` (rf2-25zo2 / rf2-okz1u).
+                       for `:rf.view/cause-event-id`.
                        OMITTED (key absent, not nil) when the sub runs
                        outside any cascade (a post-settle reactive flush
                        against no live drain) or when the epoch artefact
@@ -227,17 +226,17 @@
   ;; (`:sub/run` success, `:rf.error/sub-exception` / schema-validation /
   ;; transitive sub-miss errors). The emit MUST sit inside the scope.
   ;;
-  ;; `vector-inputs?` (rf2-7brl74): when true, the body ALWAYS receives the
+  ;; `vector-inputs?`: when true, the body ALWAYS receives the
   ;; resolved inputs as a VECTOR (in producer order) — the contract for a
   ;; PARAMETRIC `input-fn` sub, whose computation fn destructures `[[a] q]`
-  ;; even for a single input (Spec 006 §Subscription input producers; EP
-  ;; §Single input). When false (the static `:<-` path) the existing v1
+  ;; even for a single input (Spec 006 §Subscription input producers
+  ;; §Single input). When false (the static `:<-` path) the v1
   ;; convention holds: a single `:<-` input is delivered as the bare value,
   ;; ≥2 inputs as a vector. The layer-1 / single-`:<-` wrappers pass false.
   (trace/with-handler-scope
     (trace/handler-scope-from-meta :sub query-id sub-meta)
     (try
-      ;; rf2-hhh92: wall-clock the sub body (dev-only) so `:rf.sub/run`
+      ;; Wall-clock the sub body (dev-only) so `:rf.sub/run`
       ;; carries `:rf.sub/elapsed-ms` — the per-op duration the Trace
       ;; panel's DURATION column reads. The `now-ms` brackets ride
       ;; `interop/debug-enabled?` (nil t0 in prod), so Closure DCEs them
@@ -265,7 +264,7 @@
             elapsed-ms (when interop/debug-enabled? (- (interop/now-ms) t0))
             validated (maybe-validate-sub! computed query-v query-id sub-meta frame-id)]
         ;; Emit AFTER compute+validate so the trace carries the computed
-        ;; value + attribution (rf2-l1jz8). The base tag is unconditional
+        ;; value + attribution. The base tag is unconditional
         ;; (op-type vocabulary parity with the prod path); the attribution
         ;; slots ride the dev gate so Closure DCEs the enriched tag map
         ;; under :advanced. `:prev-value` / `:value` are emitted RAW —
@@ -276,7 +275,7 @@
         (if interop/debug-enabled?
           (let [cascade?  (boolean (seq input-signals))
                 cause-sub (changed-cause-sub prev-in-vals in-vals input-signals)
-                ;; rf2-vh1k3 — the render-key of the view whose render is
+                ;; The render-key of the view whose render is
                 ;; deref-ing this reaction (nil outside a view render). The
                 ;; epoch back-fill reads this off the target epoch's
                 ;; `:sub-runs` so a late-arriving render is attributed to
@@ -287,10 +286,10 @@
                 reader-rk (when-let [f (late-bind/get-fn-cached
                                          :views/reading-render-key)]
                             (f))
-                ;; rf2-okz1u — `:rf.sub/cause-event-id` names the
+                ;; `:rf.sub/cause-event-id` names the
                 ;; dispatching cascade whose handler-body invalidated
                 ;; this sub's reactive input. Same source the views path
-                ;; uses for `:rf.view/cause-event-id` (rf2-25zo2): the
+                ;; uses for `:rf.view/cause-event-id`: the
                 ;; in-flight cascade buffer published by re-frame.epoch
                 ;; under the `:epoch/cascade-cause` late-bind hook. The
                 ;; hook walks the frame's per-cascade buffer and returns
@@ -320,15 +319,14 @@
                                                            prev-value)
                                   :rf.sub/value          validated
                                   :rf.sub/cascade?       cascade?
-                                  ;; rf2-e3acps — the REALIZED input
+                                  ;; The REALIZED input
                                   ;; query-vectors for this concrete cache
                                   ;; entry (the literal `:<-` list for
                                   ;; `:static`, the `(input-fn query-v)`
                                   ;; result for `:parametric`, `[]` for
                                   ;; layer-1). `input-signals` is the
                                   ;; per-entry realized edge set (Spec 006
-                                  ;; §Subscription input producers; the EP
-                                  ;; §Tooling live/cache view). Lets the
+                                  ;; §Subscription input producers). Lets the
                                   ;; Xray live-cascade view render REALIZED
                                   ;; parametric edges without fabricating
                                   ;; un-materialized ones. Query-vectors,
@@ -348,13 +346,13 @@
                         :frame          frame-id}))
         validated)
       (catch #?(:clj Throwable :cljs :default) e
-        (let [msg    (error/ex-message-safe e) ; rf2-vzrxp3: nil-safe
+        (let [msg    (error/ex-message-safe e) ; nil-safe (a thrown non-Error value has no message)
               reason (str "Subscription `" query-id
                           "` threw while computing: "
                           msg ". Returning nil.")
               ;; Shared `:tags` body — consumed by BOTH the always-on
               ;; error-emit policy-event (below) and the dev-only trace.
-              ;; rf2-7d30s — frame-attribute the sub-exception (the reactive
+              ;; Frame-attribute the sub-exception (the reactive
               ;; sub-run knows its `frame-id`, used by the success emit
               ;; above). Without `:frame` the error is dropped by
               ;; `re-frame.epoch.capture/capture-event!` (frame-tagged only)
@@ -369,7 +367,7 @@
                       :exception-message msg
                       :reason            reason
                       :recovery          :replaced-with-default}]
-          ;; rf2-vvwmi — route the reactive `:rf.error/sub-exception`
+          ;; Route the reactive `:rf.error/sub-exception`
           ;; through the ALWAYS-ON `error-emit/dispatch-on-error!`
           ;; substrate (mirroring router.cljc's handler-exception and
           ;; fx.cljc's reserved-fx typed-throw paths) so it survives
@@ -385,7 +383,7 @@
           ;; leaks `:exception` / message; that detail rides the trace +
           ;; off-box listener record only (Spec 011 §Internal trace
           ;; events are not leaked). A reactive sub has no triggering
-          ;; event vector, but per rf2-bxud9v the failing sub's `query-v`
+          ;; event vector, but the failing sub's `query-v`
           ;; / `query-id` ride `:event` / `:event-id` (mirroring the
           ;; sub-input-fn path) so the kind-aware error-emit lookup
           ;; resolves the sub's `:source-coord` under `[:sub query-id]`
@@ -399,11 +397,11 @@
           ;; status source of truth.
           ;;
           ;; `:rf.error/sub-exception` recovery is the framework's built-in
-          ;; 'return nil' — there is no app-steering recovery policy
-          ;; (rf2-hiqtk8). The SSR fail-closed posture (rf2-vvwmi) rides the
+          ;; 'return nil' — there is no app-steering recovery policy.
+          ;; The SSR fail-closed posture rides the
           ;; always-on listener record the `error-emit-projection-listener`
           ;; buffers — which preserves the SSR 500 projection.
-          ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the
+          ;; Both channels via the shared helper: axis 1 the
           ;; always-on listener (survives prod elision), axis 2 the dev trace —
           ;; preserved for the trace surface + retain-N buffer + dev-side
           ;; projection (carries the same rich internal detail; DCEs under
@@ -423,21 +421,21 @@
               tags)))
         nil))))
 
-;; ---- the shared memo-hit `:rf.sub/skip` emit (rf2-6zfzxy) -----------------
+;; ---- the shared memo-hit `:rf.sub/skip` emit -----------------------------
 ;;
 ;; All three memo wrappers below emit a byte-identical `:rf.sub/skip` trace on a
-;; memo hit (input value-equal to last-seen, the user body does NOT re-run,
-;; rf2-719e) so tools can show the "considered, no recompute" branch of the
-;; reactive cascade DAG (rf2-931pm). The ONLY thing that varied was
+;; memo hit (input value-equal to last-seen, the user body does NOT re-run)
+;; so tools can show the "considered, no recompute" branch of the
+;; reactive cascade DAG. The only thing that varies is
 ;; `:rf.sub/input-paths-unchanged` (`[]` for layer-1 which has no upstream sub
 ;; inputs; `(vec input-signals)` for the layer-n forms). The skip-emit BODY is
-;; deduped here; the three wrappers stay separate (their per-recompute hot
-;; closures are perf-justified — fixed-arity-1 vs single-input vs varargs — and
-;; only the cold skip-emit body was the clone).
+;; deduped here; the three wrappers stay separate — their per-recompute hot
+;; closures are perf-justified (fixed-arity-1 vs single-input vs varargs) and
+;; only the cold skip-emit body is shared.
 
 (defn- emit-sub-skip!
   "Emit the memo-hit `:rf.sub/skip` trace for a sub that was reactively
-  considered but did NOT recompute (input value-equal, rf2-719e / rf2-931pm).
+  considered but did NOT recompute (input value-equal).
   `input-paths-unchanged` is the inputs-stable set (`[]` for layer-1, the
   realized `:<-` query-vectors for layer-n). Outer `interop/debug-enabled?`
   gate elides the tag-map construction + emit in CLJS production (Closure DCE
@@ -474,21 +472,21 @@
       (when body-fn
         (if (= @last-db db)
           ;; Memo hit — input value-equal to last-seen, the user body
-          ;; does NOT re-run (rf2-719e). Emit `:rf.sub/skip` so tools
+          ;; does NOT re-run. Emit `:rf.sub/skip` so tools
           ;; can show the "considered, no recompute" branch of the
-          ;; reactive cascade DAG (rf2-931pm). Layer-1 has no upstream
+          ;; reactive cascade DAG. Layer-1 has no upstream
           ;; sub inputs, so `:input-paths-unchanged` is `[]`.
           (do
             (emit-sub-skip! query-id query-v frame-id sub-meta [])
             @last-result)
           ;; Capture the prior cells BEFORE the recompute so the
-          ;; `:sub/run` attribution (rf2-l1jz8) can report value-change
+          ;; `:sub/run` attribution can report value-change
           ;; against the last computed value. Layer-1 has no upstream
           ;; sub inputs, so `input-signals` is `[]` and `prev-in-vals`
           ;; is irrelevant to cause-sub resolution (a layer-1 recompute
           ;; is driven by an app-db path change, never a sub cascade).
           ;;
-          ;; rf2-fyd8u — pass `unset` for `prev-value` on the run that
+          ;; Pass `unset` for `prev-value` on the run that
           ;; allocated the cache slot (the input cell `last-db` is still
           ;; the `::unset` sentinel here — pre-vreset). `last-result`
           ;; starts at `nil` (not `::unset`) so it cannot serve as the
@@ -507,7 +505,7 @@
 
 (defn make-layer-n-single-input-memoised-body
   "Specialised memo wrapper for layer-2 subs with a single `:<-` input
-  (the dominant layer-2 shape — see rf2-v1nu0 perf-sweep finding).
+  (the dominant layer-2 shape).
   Fixed-arity-1 — avoids the varargs-seq allocation that a
   `(fn [& in-vals])` form would force on every reaction recompute, and
   compares the upstream value to the last-seen scalar (no seq-vs-seq
@@ -523,7 +521,7 @@
   `validate-and-trace` receives `in-vals` as a singleton list — the
   same shape the varargs wrapper would have produced for arity-1 —
   preserving the `(body-fn (first in-vals) query-v)` invocation path
-  inside the validate/trace bracket (rf2-0y2bp)."
+  inside the validate/trace bracket."
   [body-fn query-id query-v frame-id input-signals sub-meta]
   (let [last-v0     (volatile! ::unset)
         last-result (volatile! nil)]
@@ -531,7 +529,7 @@
       (when body-fn
         (if (= @last-v0 v0)
           ;; Memo hit — see `make-layer-1-memoised-body` for the
-          ;; `:rf.sub/skip` rationale (rf2-931pm). `:input-paths-unchanged`
+          ;; `:rf.sub/skip` rationale. `:input-paths-unchanged`
           ;; carries the upstream sub query-vector(s) whose values were
           ;; stable; layer-2+ subs name their inputs by `[query-id args]`
           ;; rather than db-paths.
@@ -539,13 +537,13 @@
             (emit-sub-skip! query-id query-v frame-id sub-meta (vec input-signals))
             @last-result)
           ;; Capture prior cells BEFORE the recompute for the `:sub/run`
-          ;; attribution (rf2-l1jz8). `prev-in-vals` is the last-seen
+          ;; attribution. `prev-in-vals` is the last-seen
           ;; single input value in singleton-list shape (matching the
           ;; `(list v0)` `in-vals` form) so `changed-cause-sub` can diff
           ;; it positionally against `input-signals`; the `::unset`
           ;; sentinel on first recompute leaves `:cause-sub` nil.
           ;;
-          ;; rf2-fyd8u — pass `unset` for `prev-value` on the run that
+          ;; Pass `unset` for `prev-value` on the run that
           ;; allocated the cache slot (the input cell `last-v0` is still
           ;; the `::unset` sentinel here). `last-result` is `nil` then
           ;; too but keying on `last-v0` keeps the discriminator well-
@@ -573,16 +571,16 @@
   Returns a `(fn [& in-vals])`. When `body-fn` is nil the wrapper
   yields nil on every call without touching the memo cells.
 
-  `vector-inputs?` (rf2-7brl74, optional — defaults false): forwarded to
+  `vector-inputs?` (optional — defaults false): forwarded to
   `validate-and-trace`. True for a parametric `input-fn` sub so the body
   always receives a VECTOR of input values (producer order) even at one
-  input — the EP §Single input contract (`(fn [[a] q] ...)`). False (or
-  omitted) for a static `:<-` multi-input sub so the existing v1
+  input — the Spec 006 §Single input contract (`(fn [[a] q] ...)`). False
+  (or omitted) for a static `:<-` multi-input sub so the v1
   convention holds.
 
   See `make-layer-1-memoised-body` for the layer-1 specialisation and
   `make-layer-n-single-input-memoised-body` for the static single-`:<-`
-  specialisation (rf2-0y2bp)."
+  specialisation."
   ([body-fn query-id query-v frame-id input-signals sub-meta]
    (make-layer-n-memoised-body
      body-fn query-id query-v frame-id input-signals sub-meta false))
@@ -593,7 +591,7 @@
       (when body-fn
         (if (= @last-in-vals in-vals)
           ;; Memo hit — see `make-layer-1-memoised-body` for the
-          ;; `:rf.sub/skip` rationale (rf2-931pm). `:input-paths-unchanged`
+          ;; `:rf.sub/skip` rationale. `:input-paths-unchanged`
           ;; carries every upstream `:<-` query-vector whose value was
           ;; stable (the varargs path has ≥2 inputs and the memo
           ;; compare is whole-seq `=`, so every input was stable).
@@ -601,12 +599,12 @@
             (emit-sub-skip! query-id query-v frame-id sub-meta (vec input-signals))
             @last-result)
           ;; Capture prior cells BEFORE the recompute for the `:sub/run`
-          ;; attribution (rf2-l1jz8). `prev-in-vals` is the last-seen
+          ;; attribution. `prev-in-vals` is the last-seen
           ;; input-value seq (parallel to `input-signals`), which
           ;; `changed-cause-sub` diffs positionally to name the upstream
           ;; sub that cascaded. `::unset` on first recompute → nil cause.
           ;;
-          ;; rf2-fyd8u — pass `unset` for `prev-value` on the run that
+          ;; Pass `unset` for `prev-value` on the run that
           ;; allocated the cache slot (the input cell `last-in-vals` is
           ;; still the `::unset` sentinel here). Keying on `last-in-vals`
           ;; rather than `last-result` so a sub whose first cached value

--- a/implementation/core/src/re_frame/subs/tooling.cljc
+++ b/implementation/core/src/re_frame/subs/tooling.cljc
@@ -4,20 +4,19 @@
   tools (Xray, re-frame2-pair-mcp, re-frame-10x) query but no production
   application code reads.
 
-  Per rf2-bmzq0 (audit rf2-53tcf §Part 4 P2): keeping these fns in
-  `re-frame.subs` paid for their bodies in every CLJS bundle that
-  loaded the subs ns, even though no production code path reaches
-  them. Splitting them off lets `:advanced` + `goog.DEBUG=false` DCE
-  the bodies wholesale (the sibling ns is loaded only when a test
-  fixture, tool, or dev preload requires it).
+  These fns live here, not in `re-frame.subs`, so that `:advanced` +
+  `goog.DEBUG=false` DCE their bodies wholesale: no production code path
+  reaches them, and this sibling ns is loaded only when a test fixture,
+  tool, or dev preload requires it. A production counter bundle never
+  loads this ns.
 
-  Mirrors the rf2-qwm0a `re-frame.trace.tooling` split:
+  Surface shape, mirroring the `re-frame.trace.tooling` split:
     - CLJS consumers needing the surface call
       `re-frame.subs.tooling/<name>` directly. Production counter
       bundles never load this ns and DCE the bodies wholesale.
-    - JVM consumers keep the legacy `re-frame.subs/<name>` /
-      `rf/sub-topology` / `rf/sub-cache` shape via the convenience
-      aliases in `re-frame.subs` and `re-frame.core` (gated under
+    - JVM consumers reach the same fns via the `re-frame.subs/<name>` /
+      `rf/sub-topology` / `rf/sub-cache` convenience aliases in
+      `re-frame.subs` and `re-frame.core` (gated under
       `#?(:clj ...)`). JVM has no bundle to protect; the aliases
       cost nothing.
 
@@ -100,9 +99,9 @@
               ;; (args preserved); `:parametric` reports the `:parametric`
               ;; sentinel (the realized edge set is per-concrete-query-v
               ;; runtime state, not statically enumerable); `:db` and
-              ;; `:runtime-db` (single-source layer-1-shaped readers — EP-0001
-              ;; rf2-vzld77, the latter reading the runtime-db projection) and
-              ;; any legacy registration without a discriminator report `[]`.
+              ;; `:runtime-db` (single-source layer-1-shaped readers — the
+              ;; latter reading the runtime-db projection) and any
+              ;; registration without a discriminator report `[]`.
               inputs     (case input-kind
                            :parametric :parametric
                            :static     (vec (:input-signals meta))
@@ -182,10 +181,10 @@
      :clj
      nil))
 
-;; ---- algebra views (EP-0014 slice-2) -------------------------------------
+;; ---- algebra views -------------------------------------------------------
 ;;
-;; Per [Derivations.md] (graduated from EP-0014) and the projected Malli
-;; shapes in [Spec-Schemas §`:rf/derivation-node`]. Every subscription —
+;; Per [Derivations.md] and the projected Malli shapes in
+;; [Spec-Schemas §`:rf/derivation-node`]. Every subscription —
 ;; `reg-sub` (layer-1 `:db`, static `:<-`, parametric input-fn),
 ;; `reg-runtime-sub`, `reg-frame-state-sub`, and each live sub-cache entry —
 ;; is an instance of the derivation/process algebra: a `:derivation`
@@ -193,13 +192,11 @@
 ;; is an ephemeral fact, evaluated on-demand, owned by its
 ;; subscription-cache entry.
 ;;
-;; This is the *registrar-derived* slice (Derivations §The EP-0013
-;; relocation seam): the algebra view is assembled from registration
-;; metadata at the surface that registers each source form, NOT (yet) from
-;; an EP-0013 app value. It feeds the later internal graph-inspection helper
-;; (EP-0014 bead-plan item 7); slice-2 ships NO public accessor — these
-;; functions live in the bundle-isolated tooling sibling, consumed by Xray
-;; and conformance fixtures.
+;; This is the *registrar-derived* view: it is assembled from registration
+;; metadata at the surface that registers each source form, not from a
+;; durable app value. It feeds the internal graph-inspection helper. These
+;; functions ship NO public accessor — they live in the bundle-isolated
+;; tooling sibling, consumed by Xray and conformance fixtures.
 ;;
 ;; The five fixed classifications for EVERY subscription node (the worked
 ;; equivalence in Derivations §Worked equivalence — subscriptions are the
@@ -320,8 +317,7 @@
 
 (defn sub-algebra-view
   "Return the STATIC derivation/process algebra view of every registered
-  subscription (EP-0014 slice-2; [Derivations.md], [Spec-Schemas
-  §`:rf/derivation-node`]).
+  subscription ([Derivations.md], [Spec-Schemas §`:rf/derivation-node`]).
 
   Pure data over the registrar — no app-db, no per-frame cache, no reactive
   runtime. The algebra-view companion to `sub-topology`: where `sub-topology`
@@ -359,10 +355,9 @@
   one-arity form returns the single node for `sub-id`, or `nil` if it is not
   registered. JVM-runnable — the registration metadata is partition-agnostic.
 
-  Slice-2 ships NO public accessor (EP-0014 issue-1 disposition): this lives
-  in the bundle-isolated tooling sibling and is consumed by Xray + the
-  conformance fixtures; the public name is deferred until a third consumer
-  needs it."
+  Ships NO public accessor: this lives in the bundle-isolated tooling
+  sibling and is consumed by Xray + the conformance fixtures; the public
+  name is deferred until a third consumer needs it."
   ([]
    (let [subs-meta (registrar/registrations :sub)]
      (reduce-kv
@@ -376,8 +371,8 @@
 
 (defn sub-cache-algebra-view
   "Return the LIVE derivation/process algebra view of a frame's sub-cache —
-  one `:rf/derivation-node` per concrete cached entry (EP-0014 slice-2;
-  [Derivations.md] §Static and live graphs).
+  one `:rf/derivation-node` per concrete cached entry ([Derivations.md]
+  §Static and live graphs).
 
   The live counterpart to `sub-algebra-view`: where the static view reports
   the `:parametric` marker for an input-fn sub, the live view reports the
@@ -450,7 +445,7 @@
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;
-;; Per rf2-bmzq0: `implementation/scripts/check-bundle-isolation.cjs`
+;; `implementation/scripts/check-bundle-isolation.cjs`
 ;; greps the counter bundle for this exact string. The string lives
 ;; ONLY in this file's source body — no other namespace, no docstring,
 ;; no test fixture references it — so its presence in the production

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -20,8 +20,7 @@
       on entry and [:rf.machine/destroy actor-id] on exit; deterministic
       actor ids via the in-snapshot :rf/spawn-counter (declarative) / the
       frame's runtime-db [:rf.runtime/machines :spawn-counter <machine-id>]
-      slot (hand-emitted) — no process-global state (rf2-gr8q / rf2-owvvr;
-      the body comment below + spawn.cljc both note the global atom is gone).
+      slot (hand-emitted) — no process-global state.
     - Declarative :spawn-all — spawn-and-join sugar over N parallel
       :spawn's plus a join condition (:all / :any / {:n N} / {:fn pred}).
     - The :raise reserved fx-id (machine-internal pre-commit dispatch).
@@ -65,16 +64,15 @@
             [re-frame.machines.timer :as timer]
             [re-frame.registrar :as registrar]
             [re-frame.subs :as subs]
-            ;; EP-0014 slice-6 (rf2-2axssk): the JVM-only require of the
-            ;; machines tooling sibling that backs the `machine-algebra-view` /
-            ;; `machine-instance-algebra-view` / `machine-selector?` aliases at
-            ;; the foot of this ns. CLJS deliberately OMITS this require so a
-            ;; CLJS app that loads the machines artefact but never attaches a
-            ;; tool DCEs the tooling body wholesale — the facade never reaches
-            ;; it. JVM has no bundle to protect; the aliases give JVM tools /
-            ;; conformance fixtures the ergonomic `re-frame.machines/<name>`
-            ;; shape. Mirrors the `re-frame.flows` → `re-frame.flows.tooling`
-            ;; JVM-only require (rf2-s8w3nw slice-3).
+            ;; The JVM-only require of the machines tooling sibling that backs
+            ;; the `machine-algebra-view` / `machine-instance-algebra-view` /
+            ;; `machine-selector?` aliases at the foot of this ns. CLJS
+            ;; deliberately OMITS this require so a CLJS app that loads the
+            ;; machines artefact but never attaches a tool DCEs the tooling body
+            ;; wholesale — the facade never reaches it. JVM has no bundle to
+            ;; protect; the aliases give JVM tools / conformance fixtures the
+            ;; ergonomic `re-frame.machines/<name>` shape. Mirrors the
+            ;; `re-frame.flows` → `re-frame.flows.tooling` JVM-only require.
             #?@(:clj [[re-frame.machines.tooling :as machines-tooling]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -84,35 +82,34 @@
 ;; These `def`s make the sub-namespace fns reachable as
 ;; `re-frame.machines/<name>` so consumers (the `re-frame.core` late-bind
 ;; bridge, the conformance corpus, the test fixtures, examples that
-;; `:require [re-frame.machines :as machines]`) see the same surface
-;; they did pre-split.
+;; `:require [re-frame.machines :as machines]`) all see one surface.
 
 ;; Declarative-`:spawn` spawns allocate ids inside the parent
 ;; snapshot's `:rf/spawn-counter` slot via
 ;; `re-frame.machines.transition/allocate-spawned-id`; hand-emitted
 ;; spawn fxs allocate from the frame's app-db slot at
 ;; `[:rf.runtime/machines :spawn-counter <machine-id>]` inside the
-;; spawn-fx db-swap (per rf2-owvvr — the single-reserved-root contract).
+;; spawn-fx db-swap (the single-reserved-root contract).
 ;; `machine-transition` is a pure function — no module-level mutable
 ;; state, deterministic from its (machine snapshot event) arguments.
 
 (def reg-machine*           registration/reg-machine*)
 (def make-machine-handler registration/make-machine-handler)
-;; Per rf2-jbbp7 — boundary-validation surface for the `:data-schema` key
-;; on `reg-machine` (Spec 005 §Schema validation, Spec 010 §Per-step
-;; recovery row 7). The post-commit walker validates every snapshot's
-;; `:data` against its registered machine's `:data-schema`; the spawn-time
-;; sibling validates a spawned actor's initial `:data` before install.
+;; Boundary-validation surface for the `:data-schema` key on `reg-machine`
+;; (Spec 005 §Schema validation, Spec 010 §Per-step recovery row 7). The
+;; post-commit walker validates every snapshot's `:data` against its
+;; registered machine's `:data-schema`; the spawn-time sibling validates a
+;; spawned actor's initial `:data` before install.
 (def validate-machine-data! data-validation/validate-machine-data!)
 (def validate-spawn-data!   data-validation/validate-spawn-data!)
-;; rf2-wrrvs7 — the `:rf.machine/update-snapshot` escape-hatch sibling
-;; validates the would-be-merged snapshot's `:data` BEFORE the fx writes
-;; it, closing the boundary bypass on the escape hatch.
+;; The `:rf.machine/update-snapshot` escape-hatch sibling validates the
+;; would-be-merged snapshot's `:data` BEFORE the fx writes it, so the
+;; `:data-schema` boundary covers the escape hatch too.
 (def validate-update-snapshot-data! data-validation/validate-update-snapshot-data!)
-;; The pure registration-time validator (Spec 005 §registration validators,
-;; rf2-f9tu). Re-exported so the conformance corpus's `:reg-machine` Mode-B
-;; call op can pin the registration-error taxonomy (Spec 009 §thrown-error
-;; shape) directly against the leaf fn — no registrar/substrate fixture.
+;; The pure registration-time validator (Spec 005 §registration validators).
+;; Re-exported so the conformance corpus's `:reg-machine` Mode-B call op can
+;; pin the registration-error taxonomy (Spec 009 §thrown-error shape)
+;; directly against the leaf fn — no registrar/substrate fixture.
 (def validate-machine!      validation/validate-machine!)
 (def spawn-fx               spawn/spawn-fx)
 (def spawn-all-init-fx      spawn/spawn-all-init-fx)
@@ -155,13 +152,12 @@
   "Look up the spawned-machine id currently bound to `system-id` in the
   active frame's `[:rf.runtime/machines :system-ids]` reverse index, or nil.
 
-  EP-0002 carried invariant: the 1-arity ambient form resolves the frame
-  through the scope/hold chain via `frame/require-current-frame!` — a
-  lookup issued under no established scope raises
-  `:rf.error/no-frame-context` rather than reading an invented default's
-  reverse index. Pass the 2-arity `(machine-by-system-id system-id
-  frame-id)` to look up a named frame from outside any scope (async
-  callbacks / tools / cross-frame lookups).
+  The 1-arity ambient form resolves the frame through the scope/hold chain
+  via `frame/require-current-frame!` — a lookup issued under no established
+  scope raises `:rf.error/no-frame-context` rather than reading an invented
+  default's reverse index. Pass the 2-arity `(machine-by-system-id
+  system-id frame-id)` to look up a named frame from outside any scope
+  (async callbacks / tools / cross-frame lookups).
 
   Per Spec 005 §Named addressing via :system-id + Spec 002 §Resolver
   surface."
@@ -172,26 +168,25 @@
        :machine-by-system-id
        {:where 're-frame.machines/machine-by-system-id})))
   ([system-id frame-id]
-   ;; EP-0001 (rf2-vzld77): the system-ids reverse index is durable
-   ;; machine runtime-db state — read it off the runtime-db partition.
+   ;; The system-ids reverse index is durable machine runtime-db state —
+   ;; read it off the runtime-db partition.
    (get-in (frame/frame-runtime-db-value frame-id) (paths/system-id-path system-id))))
 
-;; ---- derivation/process algebra views (EP-0014 slice-6) -------------------
+;; ---- derivation/process algebra views -------------------------------------
 ;;
-;; EP-0014 slice-6 (rf2-2axssk): the derivation/process algebra view of
-;; registered machines (`machine-algebra-view`), their live instances /
-;; spawned actors (`machine-instance-algebra-view`), and the machine-selector
-;; recognizer (`machine-selector?`). A machine is the canonical `:process`
-;; member of the algebra (a derivation WITH state, lifecycle, and commands over
-;; time); its snapshot materializes into runtime-db, evaluated `:on-transition`.
+;; The derivation/process algebra view of registered machines
+;; (`machine-algebra-view`), their live instances / spawned actors
+;; (`machine-instance-algebra-view`), and the machine-selector recognizer
+;; (`machine-selector?`). A machine is the canonical `:process` member of the
+;; algebra (a derivation WITH state, lifecycle, and commands over time); its
+;; snapshot materializes into runtime-db, evaluated `:on-transition`.
 ;;
 ;; JVM convenience aliases: the bodies live in `re-frame.machines.tooling` so a
 ;; CLJS app that loads the machines artefact but attaches no tool DCEs them (the
 ;; CLJS facade never `:require`s the tooling sibling — the require above is
 ;; `#?@(:clj ...)`-gated). CLJS consumers (Xray + conformance) call
-;; `re-frame.machines.tooling/<name>` directly. No `re-frame.core` facade export
-;; (EP-0014 issue-1 disposition). Mirrors the `re-frame.flows/flow-algebra-view`
-;; JVM alias (slice-3).
+;; `re-frame.machines.tooling/<name>` directly. No `re-frame.core` facade
+;; export. Mirrors the `re-frame.flows/flow-algebra-view` JVM alias.
 #?(:clj
    (do
      (def machine-algebra-view          machines-tooling/machine-algebra-view)
@@ -225,12 +220,10 @@
   `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`,
   with a no-op fall-through when the system-id is unbound.
 
-  Demoted off the `re-frame.core` facade (rf2-gkt25a / rf2-80mmlf — exactly
-  one in-repo caller, a negative-path test): the CANONICAL action-side
-  messaging surface is the reserved `[:rf.machine/dispatch-to-system
-  [system-id event]]` fx tuple (see `dispatch-to-system-fx`); this direct-
-  call FN is the redundant call-site twin, retained here as an
-  implementation-tier helper rather than an app-facing front-porch API.
+  An implementation-tier helper, not an app-facing front-porch API: the
+  CANONICAL action-side messaging surface is the reserved
+  `[:rf.machine/dispatch-to-system [system-id event]]` fx tuple (see
+  `dispatch-to-system-fx`); this direct-call FN is the call-site twin.
   Per Spec 005 §Cross-machine messaging by name."
   ([system-id event]
    (when-let [machine-id (machine-by-system-id system-id)]
@@ -248,9 +241,9 @@
   system-id is unbound (symmetric with the `dispatch-to-system` FN's
   no-op fall-through). Per Spec 005 §Cross-machine messaging by name."
   [{frame-id :frame} [system-id event]]
-  ;; EP-0002 carried invariant — the cascade envelope frame is the
-  ;; fx-context `:frame`; a nil stamp is an invariant failure
-  ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+  ;; The cascade envelope frame is the fx-context `:frame`; a nil stamp is
+  ;; an invariant failure (`:rf.error/no-frame-context`), never a
+  ;; synthesised `:rf/default`.
   (let [frame-id (frame/require-frame-stamp!
                    frame-id :rf.machine/dispatch-to-system
                    {:where 'rf.machine/dispatch-to-system :event-id system-id})]
@@ -334,59 +327,54 @@
 ;; re-installs the subs after `registrar/clear-all!`. `:reload` is
 ;; shallow — a sub registered inside the sub-namespace wouldn't re-fire.
 
-;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state, so
-;; the framework machine subs read the frame's RUNTIME-DB projection
-;; (`reg-runtime-sub`) — the `db`-position arg is the runtime-db value (Spec
-;; 002 §Subscriptions read the partition they belong to).
+;; Machine snapshots are durable runtime-db state, so the framework machine
+;; subs read the frame's RUNTIME-DB projection (`reg-runtime-sub`) — the
+;; `db`-position arg is the runtime-db value (Spec 002 §Subscriptions read
+;; the partition they belong to).
 (subs/reg-runtime-sub :rf/machine
   {:doc "Subscribe to a machine's current snapshot `{:state <kw> :data <map> :tags <set>}`. Returns nil for an unknown or not-yet-initialised machine. Per Spec 005 §Subscribing to machines via sub-machine."}
   (fn [runtime-db [_ machine-id]]
     (get-in runtime-db (paths/snapshot-path machine-id))))
 
-;; Per Spec 005 §State tags (rf2-ee0d / Nine States Stage 1): the
-;; `:rf/machine-has-tag?` framework sub returns `true` iff the named
-;; machine's current snapshot's `:tags` set contains the queried tag.
-;; A machine that hasn't been initialised yet (no snapshot at
-;; `[:rf.runtime/machines :snapshots <id>]`) returns `false`.
+;; Per Spec 005 §State tags: the `:rf/machine-has-tag?` framework sub
+;; returns `true` iff the named machine's current snapshot's `:tags` set
+;; contains the queried tag. A machine that hasn't been initialised yet (no
+;; snapshot at `[:rf.runtime/machines :snapshots <id>]`) returns `false`.
 ;;
 ;; Derived sub — reads the snapshot via `get-in` rather than chaining
 ;; off `:rf/machine` — so a view that only cares about whether a specific
 ;; tag is present re-renders only when the containment-bit flips.
 (subs/reg-runtime-sub :rf/machine-has-tag?
-  {:doc "Subscribe to a machine's `:fsm/tags` containment-bit for `tag`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). Per Spec 005 §State tags (rf2-ee0d / Nine States Stage 1)."}
+  {:doc "Subscribe to a machine's `:fsm/tags` containment-bit for `tag`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). Per Spec 005 §State tags."}
   (fn [runtime-db [_ machine-id tag]]
     (contains? (get-in runtime-db (paths/snapshot-path machine-id :tags)) tag)))
 
-;; ---- spawned-actor ownership (rf2-ma0wvq) ---------------------------------
+;; ---- spawned-actor ownership ----------------------------------------------
 ;;
 ;; Per Spec 014 §Abort on actor destroy: a managed `:rf.http/managed`
 ;; request "belongs to" a spawned actor when its originating event-id is
-;; that actor's address. The http artefact USED to decide this itself by
-;; re-stating `paths/spawned-path` and structurally walking the registry —
-;; a hidden dependency on this artefact's private runtime-db shape. The
-;; ownership decision is now MACHINES-OWNED and published through the
-;; `:machines/owning-actor-id` hook (rf2-ma0wvq), so the structural read
-;; lives next to the runtime-db shape it depends on. http reaches it via
-;; `late-bind/get-fn` and falls back to nil when machines is absent.
+;; that actor's address. The ownership decision is MACHINES-OWNED and
+;; published through the `:machines/owning-actor-id` hook, so the structural
+;; read lives next to the runtime-db shape it depends on. http reaches it
+;; via `late-bind/get-fn` and falls back to nil when machines is absent.
 ;;
-;; SET SEMANTICS (rf2-n877mb, step 2 of rf2-ma0wvq): the owning set is
-;; SNAPSHOT MEMBERSHIP — `event-id` owns a request iff a SPAWNED actor's
-;; snapshot lives at `[:rf.runtime/machines :snapshots <event-id>]`, where
-;; "spawned" is the durable `:rf/machine-type`-at-root discriminator
-;; `install-spawn!` stamps on EVERY spawned actor (declarative `:spawn` /
-;; `:spawn-all` AND imperative `[:rf.machine/spawn ...]`), and a
-;; singleton's snapshot never carries. This WIDENS the step-1 set (which
-;; read the `:spawned` registry — declarative spawns only) to imperatively-
-;; spawned actors. Imperative spawns install a snapshot WITHOUT a `:spawned`
-;; registry slot (the slot is gated on the declarative-desugar
+;; SET SEMANTICS: the owning set is SNAPSHOT MEMBERSHIP — `event-id` owns a
+;; request iff a SPAWNED actor's snapshot lives at
+;; `[:rf.runtime/machines :snapshots <event-id>]`, where "spawned" is the
+;; durable `:rf/machine-type`-at-root discriminator `install-spawn!` stamps
+;; on EVERY spawned actor (declarative `:spawn` / `:spawn-all` AND
+;; imperative `[:rf.machine/spawn ...]`), and a singleton's snapshot never
+;; carries it. Snapshot membership covers imperatively-spawned actors as
+;; well as declarative ones: imperative spawns install a snapshot WITHOUT a
+;; `:spawned` registry slot (the slot is gated on the declarative-desugar
 ;; `:rf/parent-id` + `:rf/invoke-id`, per `lifecycle-fx.spawn/spawn-fx`'s
-;; `track?`), so the registry read structurally MISSED them and their
-;; managed HTTP was never aborted on destroy. The destroy side already
-;; fired `:http/abort-on-actor-destroy` for imperative destroys (via
+;; `track?`), so keying on the snapshot rather than the registry catches
+;; them and their managed HTTP is aborted on destroy. The destroy side
+;; fires `:http/abort-on-actor-destroy` for imperative destroys (via
 ;; `lifecycle-fx.finalize` / `lifecycle-fx.frame-destroy`, which key on the
-;; SAME `:rf/machine-type` marker); only this RECORDING side excluded them.
-;; This is the SAME discriminator `frame-destroy/spawned-snapshot?` uses,
-;; so recording and teardown agree on exactly which ids are actors.
+;; SAME `:rf/machine-type` marker); the recording side keys on the SAME
+;; discriminator `frame-destroy/spawned-snapshot?` uses, so recording and
+;; teardown agree on exactly which ids are actors.
 
 (defn owning-actor-id
   "Resolve the spawned-actor-id that OWNS `event-id` in `frame-id`, or nil.
@@ -398,21 +386,19 @@
   event handler, or from a singleton machine whose snapshot carries no
   `:rf/machine-type` marker).
 
-  Published as the `:machines/owning-actor-id` late-bind hook (rf2-ma0wvq)
-  so the http artefact can ask machines \"who owns this request's
-  originating event?\" without statically `:require`ing this artefact or
-  re-stating its private runtime-db shape. When machines is absent the
-  hook is unregistered and http's caller falls back to nil.
+  Published as the `:machines/owning-actor-id` late-bind hook so the http
+  artefact can ask machines \"who owns this request's originating event?\"
+  without statically `:require`ing this artefact or re-stating its private
+  runtime-db shape. When machines is absent the hook is unregistered and
+  http's caller falls back to nil.
 
-  Set semantics (rf2-n877mb, step 2): SNAPSHOT MEMBERSHIP via the durable
-  `:rf/machine-type`-at-root discriminator — declarative `:spawn` /
-  `:spawn-all` AND imperative `[:rf.machine/spawn ...]` actors, since
-  `install-spawn!` stamps that marker on every spawned actor's snapshot
-  and a singleton's snapshot never carries it. This is the SAME
-  discriminator the destroy side (`frame-destroy/spawned-snapshot?`) keys
-  on, so recording and teardown classify ids identically (see the section
-  comment above for why step 1's `:spawned`-registry read missed imperative
-  spawns).
+  Set semantics: SNAPSHOT MEMBERSHIP via the durable `:rf/machine-type`-at-
+  root discriminator — declarative `:spawn` / `:spawn-all` AND imperative
+  `[:rf.machine/spawn ...]` actors, since `install-spawn!` stamps that
+  marker on every spawned actor's snapshot and a singleton's snapshot never
+  carries it. This is the SAME discriminator the destroy side
+  (`frame-destroy/spawned-snapshot?`) keys on, so recording and teardown
+  classify ids identically (see the section comment above).
 
   PERF: `frame/frame-runtime-db-value` is a substrate `deref` returning the
   persistent runtime-db map BY REFERENCE (no copy, no scan), so the lookup
@@ -428,7 +414,7 @@
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
-;; Per rf2-xbtj the machines surface ships in
+;; The machines surface ships in
 ;; `day8/re-frame2-machines`. `re-frame.core` and `re-frame.test-support`
 ;; MUST NOT `:require [re-frame.machines]` — the artefact is optional, and
 ;; a static require would force every consumer of the core artefact to
@@ -458,11 +444,11 @@
 ;; Late-bound so core never statically requires the machines artefact.
 (late-bind/set-fn! :machines/on-frame-destroyed!
                    (fn [frame-id] (timer/cancel-all-timers! frame-id)))
-;; rf2-u5kmf8 — epoch-restore host-transient quiesce. The epoch restore
-;; boundary (`perform-restore!`) installs the captured durable frame-state
-;; WHOLESALE, but the in-flight `:after` host-clock timers the unwound epochs
-;; armed are NOT frame-state — the pure per-path epoch invariant stale-drops a
-;; fired timer, but its wall-clock handle would still fire unless released. This
+;; Epoch-restore host-transient quiesce. The epoch restore boundary
+;; (`perform-restore!`) installs the captured durable frame-state WHOLESALE,
+;; but the in-flight `:after` host-clock timers the unwound epochs armed are
+;; NOT frame-state — the pure per-path epoch invariant stale-drops a fired
+;; timer, but its wall-clock handle would still fire unless released. This
 ;; hook releases the restored frame's orphaned timer handles eagerly (one
 ;; `:rf.machine.timer/cancelled :reason :on-restore` per entry), so a restore
 ;; carries no leaked timers from the discarded epochs (Managed-Effects §restore:
@@ -470,13 +456,13 @@
 ;; statically require the machines artefact.
 (late-bind/set-fn! :machines/on-frame-restored!
                    (fn [frame-id] (timer/cancel-frame-timers-on-restore! frame-id)))
-;; Per rf2-vsigt — frame-destroy machine-cascade hook. `frame/destroy-frame!`
-;; calls this hook BEFORE the sub-cache / adapter teardown so each active
-;; machine's `:exit` cascade runs against a live container in reverse-
-;; creation order per Spec 005 §Cross-Spec Interactions §1.
+;; Frame-destroy machine-cascade hook. `frame/destroy-frame!` calls this
+;; hook BEFORE the sub-cache / adapter teardown so each active machine's
+;; `:exit` cascade runs against a live container in reverse-creation order
+;; per Spec 005 §Cross-Spec Interactions §1.
 (late-bind/set-fn! :machines/teardown-on-frame-destroy!
                    frame-destroy/teardown-on-frame-destroy!)
-;; Per rf2-vsigt — test-isolation hook fired by
+;; Test-isolation hook fired by
 ;; `re-frame.test-support/make-reset-runtime-fixture`. Drops the per-frame
 ;; spawn-order vectors so a stale entry from a sibling test cannot
 ;; contaminate a frame-destroy walk in the next test.
@@ -484,8 +470,8 @@
                    spawn-order/reset-all!)
 (late-bind/set-fn! :machines/spawn-fx               spawn-fx)
 (late-bind/set-fn! :machines/destroy-machine-fx     destroy-machine-fx)
-;; Per rf2-a2sn1 — the lazy actor-handler resolver. Core's dispatch
-;; consults this hook on `:rf.error/no-such-handler` BEFORE erroring:
+;; The lazy actor-handler resolver. Core's dispatch consults this hook on
+;; `:rf.error/no-such-handler` BEFORE erroring:
 ;; given an unresolved event-id (a spawned actor-id with no per-instance
 ;; registration), the resolver materialises the actor's handler-meta from
 ;; its (revertible) app-db snapshot, so `restore-epoch!` reverts actor
@@ -498,8 +484,8 @@
 (late-bind/set-fn! :machines/resolve-actor-handler-meta
                    registration/resolve-actor-handler-meta)
 (late-bind/set-fn! :machines/actor-resolvable?      resolver/resolvable?)
-;; Per rf2-rlt3sv — the epoch restore version-drift precondition resolves a
-;; SPAWNED actor's CURRENT definition the same way dispatch does: from the
+;; The epoch restore version-drift precondition resolves a SPAWNED actor's
+;; CURRENT definition the same way dispatch does: from the
 ;; snapshot's `:rf/machine-type` (a registered TYPE keyword resolved through
 ;; the registrar, or an inline `:definition` spec map carried verbatim).
 ;; `machine-version-mismatch` reads the resolved spec's
@@ -508,43 +494,41 @@
 ;; accepting an incompatible older snapshot (the snapshot key is an instance id,
 ;; not a registered handler, so the singleton registrar probe never matched it).
 (late-bind/set-fn! :machines/spec-from-snapshot     resolver/spec-from-snapshot)
-;; Per rf2-jbbp7 — the post-commit walker the router AND-conjoins with
+;; The post-commit walker the router AND-conjoins with
 ;; `validate-app-schema!` to gate the `:db` commit on the
 ;; `:where :machine-data` boundary (Spec 005 §Schema validation, Spec
 ;; 010 §Per-step recovery row 7).
 (late-bind/set-fn! :machines/validate-machine-data! validate-machine-data!)
-;; Per rf2-jm2u63 — the SSR hydration projector for durable machine snapshots.
+;; The SSR hydration projector for durable machine snapshots.
 ;; `re-frame.ssr.payload-policy/project-runtime-db` consults this hook to project
 ;; the `:rf.runtime/machines` slice so each snapshot's `:data` is redacted /
 ;; elided per the FRAME's declared `:sensitive` / `:large {:app-db …}` paths
-;; (EP-0015) under `:rf.egress/ssr-hydration` BEFORE it rides the wire — closing
-;; the raw-classified-machine-data hydration leak. (EP-0025, rf2-398kql: the
-;; prior machine `:data-schema`→marks classification layer is removed —
-;; frame-owned classification is the sole app-db mechanism.)
+;; under `:rf.egress/ssr-hydration` BEFORE it rides the wire — keeping
+;; classified machine data out of the hydration payload. Frame-owned
+;; classification is the sole app-db mechanism.
 ;; Late-bound so SSR never statically requires the machines artefact.
 (late-bind/set-fn! :machines/project-ssr-runtime-db
                    machines-ssr/project-ssr-runtime-db)
-;; Per rf2-ma0wvq — spawned-actor ownership resolver. The http artefact
-;; consults this to classify whether a managed request's originating
-;; event-id belongs to a spawned actor (so an actor-destroy cascade can
-;; abort it). Machines OWNS the registry shape, so the structural walk
-;; lives here; http reaches it via late-bind and falls back to nil when
-;; machines is absent (apps without state machines pay nothing). See the
-;; `owning-actor-id` docstring for the set semantics (rf2-n877mb step 2:
-;; snapshot `:rf/machine-type` membership — declarative AND imperative
-;; spawns).
+;; Spawned-actor ownership resolver. The http artefact consults this to
+;; classify whether a managed request's originating event-id belongs to a
+;; spawned actor (so an actor-destroy cascade can abort it). Machines OWNS
+;; the registry shape, so the structural walk lives here; http reaches it
+;; via late-bind and falls back to nil when machines is absent (apps without
+;; state machines pay nothing). See the `owning-actor-id` docstring for the
+;; set semantics (snapshot `:rf/machine-type` membership — declarative AND
+;; imperative spawns).
 (late-bind/set-fn! :machines/owning-actor-id        owning-actor-id)
 (late-bind/set-fn! :machines/spawn-all-init-fx      spawn-all-init-fx)
 (late-bind/set-fn! :machines/after-schedule-fx      after-schedule-fx)
 (late-bind/set-fn! :machines/after-cancel-fx        after-cancel-fx)
 (late-bind/set-fn! :machines/update-snapshot-fx     update-snapshot/update-snapshot-fx)
 
-;; rf2-ijm7 — load-order resilience for the `:rf.http/managed` machine-shape
-;; wrapper. The wrapper is registered by re-frame.http.managed via the
-;; `:machines/reg-machine` hook published above; but if http-managed loaded
+;; Load-order resilience for the `:rf.http/managed` machine-shape wrapper.
+;; The wrapper is registered by re-frame.http.managed via the
+;; `:machines/reg-machine` hook published above; but if http-managed loads
 ;; BEFORE this namespace (the load-order is determined by the consuming app's
 ;; require graph, not by either artefact), the wrapper's bottom-of-ns call
-;; found a nil hook and skipped its registration. We close that race by
+;; finds a nil hook and skips its registration. We close that race by
 ;; re-invoking the http artefact's `:http/register-managed-machine!` hook
 ;; from here — if http-managed is on the classpath the hook is set and the
 ;; wrapper registers now; if it isn't, the hook is nil and this is a no-op.

--- a/implementation/machines/src/re_frame/machines/cofx_attach.cljc
+++ b/implementation/machines/src/re_frame/machines/cofx_attach.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.machines.cofx-attach
   "Machine consumer-attachment for recordable coeffects. Per Spec 005
   §Consumer attachment — declaring requirements on named entries + EP-0017
-  slice-B.9 (rf2-mjmxgb).
+  slice-B.9.
 
   ## What this namespace does
 
@@ -387,11 +387,11 @@
   COMPOUND machine's snapshot state resolves within. This is a plain
   `(:states machine)` read; it does NOT handle the parallel-region case.
 
-  rf2-ny0yrz CL2: the per-region union for a PARALLEL machine lives in
-  `ensure-set-for` (it iterates each region's body via `region-machine`
-  and unions each region's own scope, plus the parallel root's own
-  transition surfaces) — NOT here. `scope-for` is called only on the
-  flat/compound path (and the root-level surfaces inside `ensure-set-for`)."
+  The per-region union for a PARALLEL machine lives in `ensure-set-for` (it
+  iterates each region's body via `region-machine` and unions each region's
+  own scope, plus the parallel root's own transition surfaces) — NOT here.
+  `scope-for` is called only on the flat/compound path (and the root-level
+  surfaces inside `ensure-set-for`)."
   [machine]
   (:states machine))
 
@@ -427,14 +427,14 @@
 ;; `[:rf.machine/done <completed-node-path>]`; the completed node's `:on-done`
 ;; transition (a SEPARATE slot from `:on`) is the candidate the runtime selects
 ;; (`transition/pick-done-transition`), so the ensure-set for a raised done
-;; event MUST add that `:on-done` guard/action diet (rf2-xsdn5h — the enclosing
+;; event MUST add that `:on-done` guard/action diet (the enclosing
 ;; `:on {:rf.machine/done …}` escape hatch IS already covered by the `:on` walk
 ;; since the event-id matches an `:on` key, but the `:on-done` slot is not).
 (def ^:private done-event-id :rf.machine/done)
 
 (defn- on-done-diet-for-event
   "Add (into `add!`) the `:on-done` guard/action diets of the completed node a
-  raised done event targets (rf2-xsdn5h). `event` is `[:rf.machine/done
+  raised done event targets. `event` is `[:rf.machine/done
   <node-path>]`; `<node-path>` (the 2nd element) is the absolute path of the
   compound (or parallel-region) node whose `:final?` child completed. The node's
   `:on-done` value is one-or-more candidate maps (mirroring
@@ -469,9 +469,9 @@
 
   When `event` is a raised compound/parallel done signal
   (`[:rf.machine/done <node-path>]`), the completed node's `:on-done` guard/
-  action diets join the set too (rf2-xsdn5h) — the `:on` walk covers the
-  enclosing `:on {:rf.machine/done …}` escape hatch, but the `:on-done` slot is
-  a separate candidate the runtime selects.
+  action diets join the set too — the `:on` walk covers the enclosing
+  `:on {:rf.machine/done …}` escape hatch, but the `:on-done` slot is a
+  separate candidate the runtime selects.
 
   `by-entry` is the registration index's `:by-entry` map. Returns a vector of
   parsed-requires entries (deduped by id, declaration-order-insensitive — the
@@ -486,8 +486,8 @@
                        (vswap! seen-ids conj id)
                        (vswap! acc conj e))))
         add-always! (fn [tgt] (add! (always-diet-for-state by-entry states tgt)))
-        ;; rf2-knxbok — accumulate a lifecycle (`:entry`/`:exit`) slot's named-
-        ;; action diet along a path into a transient, then add! it deduped.
+        ;; Accumulate a lifecycle (`:entry`/`:exit`) slot's named-action diet
+        ;; along a path into a transient, then add! it deduped.
         add-lifecycle! (fn [scope p slot]
                          (let [diet (transient [])]
                            (lifecycle-diet-along-path by-entry scope p slot diet)
@@ -510,9 +510,9 @@
                 cand  (candidate-maps (get on k))]
           (add! (entry-diet by-entry :guards  (:guard cand)))
           (add! (entry-diet by-entry :actions (:action cand)))
-          ;; rf2-knxbok — (c) the exit→action→entry cascade a fired candidate
-          ;; runs also executes the active-state `:exit` actions and the
-          ;; target-state `:entry` actions (a named `:actions` ref carrying
+          ;; (c) the exit→action→entry cascade a fired candidate runs also
+          ;; executes the active-state `:exit` actions and the target-state
+          ;; `:entry` actions (a named `:actions` ref carrying
           ;; `:rf.cofx/requires` is the only legal lifecycle consumer). Add the
           ;; TARGET state's `:entry` diet — and the `:entry` diet of every node
           ;; entered descending the target's `:initial` chain, since entering a
@@ -522,8 +522,8 @@
             (add-lifecycle! states (initial-descent-path states tgt) :entry)
             ;; (b) :always closure reachable from this candidate's target.
             (add! (always-diet-for-state by-entry states tgt))))))
-    ;; rf2-knxbok — (c, exit) any fired candidate exits some suffix of the
-    ;; active state path; over-approximate soundly by ensuring the `:exit` diet
+    ;; (c, exit) any fired candidate exits some suffix of the active state
+    ;; path; over-approximate soundly by ensuring the `:exit` diet
     ;; of every active node leaf→root (an un-fired exit is a harmless no-op —
     ;; generated facts are written back idempotently). Candidate-independent, so
     ;; added once.
@@ -533,7 +533,7 @@
     ;; microstep, or after a guard-blocked / unhandled event) reachable
     ;; without any :on transition firing.
     (add! (always-diet-for-state by-entry states path))
-    ;; rf2-xsdn5h — (d) a raised compound/parallel done signal
+    ;; (d) a raised compound/parallel done signal
     ;; (`[:rf.machine/done <node-path>]`) selects the completed node's `:on-done`
     ;; transition (a separate slot from `:on`); add its guard/action diet + the
     ;; `:always` closure reachable from its target so an `:on-done` callback's
@@ -582,9 +582,9 @@
   unions each region's scope; this adds the root's OWN transition surfaces,
   which the runtime evaluates separately (`transition/root-on-match` /
   `transition/root-after-match`) as the ancestor fallback (Spec 005 §Root
-  parallel `:on` / §Root-level `:after`). Without this a coeffect declared by
-  a root `:on` / root `:after` guard/action — live transition surfaces — is
-  never ensured before selection (rf2-bu106a).
+  parallel `:on` / §Root-level `:after`). A coeffect declared by a root
+  `:on` / root `:after` guard/action — live transition surfaces — is thereby
+  ensured before selection.
 
   Two surfaces, mirroring the two runtime root resolvers:
 
@@ -643,7 +643,7 @@
   path resolves within its own `:states` body), since the broadcast routes
   the event to every region, PLUS the parallel ROOT's own `:on` / `:after`
   candidates (the ancestor fallback the runtime evaluates separately via
-  `transition/root-on-match` / `root-after-match` — rf2-bu106a). The set is
+  `transition/root-on-match` / `root-after-match`). The set is
   deduped by id across regions and the root."
   [machine snapshot event]
   (let [{:keys [by-entry]} (get machine ensure-index-key)
@@ -654,8 +654,7 @@
         (if (and (map? state) (map? (:regions machine)) (seq (:regions machine)))
           ;; parallel — union each region's scope PLUS the parallel ROOT's own
           ;; `:on` / `:after` (the ancestor fallback the runtime evaluates
-          ;; separately — `root-on-match` / `root-after-match`), deduped by id
-          ;; (rf2-bu106a).
+          ;; separately — `root-on-match` / `root-after-match`), deduped by id.
           (let [acc      (volatile! [])
                 seen-ids (volatile! #{})
                 add!     (fn [diet]
@@ -697,13 +696,13 @@
 
 (defn bootstrap-ensure-set-for
   "Compute the consumer-attachment ENSURE-SET for `machine`'s BIRTH (initial-
-  entry) macrostep (rf2-knxbok). The bootstrap cascade
+  entry) macrostep. The bootstrap cascade
   (`parallel/apply-initial-entry-cascade`, run inside `maybe-boot` BEFORE the
   dispatch-time `ensure-ctx-cofx`) fires the initial-state descent's `:entry`
   actions, then the birth-time `:always` settle. A named `:actions` ref on an
   `:entry` slot (or reached by a birth `:always`) carrying `:rf.cofx/requires`
   must therefore have its facts ensured BEFORE `maybe-boot` runs — otherwise it
-  reads an unensured token (the bootstrap hole this closes).
+  reads an unensured token.
 
   Returns the deduped union of: the `:entry` diet of every node entered on the
   initial-descent path, PLUS the `:always` closure reachable from the initial
@@ -748,8 +747,8 @@
   the dispatch-time (`ensure-cofx`) and birth-time (`bootstrap-ensure-cofx`)
   ensure steps.
 
-  `mint-policy` (EP-0017 §6, rf2-n0myjq) gates the declared-absent generator-
-  backed branch — `:strict` (replay / the `:test` preset) refuses to mint and
+  `mint-policy` (EP-0017 §6) gates the declared-absent generator-backed
+  branch — `:strict` (replay / the `:test` preset) refuses to mint and
   surfaces `:rf.error/missing-required-cofx`, `:live` / `:explicit-live`
   generate. The 6-arity of `deliver-declared-cofx` is the policy-aware surface
   the EVENT path uses; threading the resolved policy here gives the machine
@@ -777,8 +776,8 @@
   spread (machine callbacks read the WHOLE record off `:rf.cofx`, never a flat
   delivery): we keep only the augmented record.
 
-  `mint-policy` (EP-0017 §6, rf2-n0myjq) is the EFFECTIVE policy the caller
-  resolved (per-call dispatch opt ▸ frame config ▸ `:live`), threaded into
+  `mint-policy` (EP-0017 §6) is the EFFECTIVE policy the caller resolved
+  (per-call dispatch opt ▸ frame config ▸ `:live`), threaded into
   `deliver-declared-cofx`'s 6-arity so the machine ensure path mints under the
   SAME semantics as the event path: replay / `:test` (`:strict`) refuse to mint
   a declared-absent generator-backed fact (surfacing missing-required), `:live`
@@ -797,11 +796,11 @@
 
 (defn bootstrap-ensure-cofx
   "Ensure the BIRTH (initial-entry) ensure-set onto the in-flight `:rf.cofx`
-  record `recorded` BEFORE `maybe-boot` runs the bootstrap cascade (rf2-knxbok).
+  record `recorded` BEFORE `maybe-boot` runs the bootstrap cascade.
   Same satisfaction surface / write-back / error semantics as `ensure-cofx`,
   but the ensure-set is `bootstrap-ensure-set-for` (the initial-descent `:entry`
-  diet + the birth `:always` closure). `mint-policy` (rf2-n0myjq) is the
-  effective resolved policy, threaded identically to `ensure-cofx`. A no-op
+  diet + the birth `:always` closure). `mint-policy` is the effective
+  resolved policy, threaded identically to `ensure-cofx`. A no-op
   (returns `recorded`) when the bootstrap ensure-set is empty."
   ([machine recorded frame-id failing-id]
    (bootstrap-ensure-cofx machine recorded frame-id failing-id

--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.machines.data-validation
-  "Machine `:data` schema validation at the `:where :machine-data` boundary
-  (rf2-jbbp7).
+  "Machine `:data` schema validation at the `:where :machine-data` boundary.
 
   Per Spec 005 §Schema validation: a machine spec may declare a
   top-level `:data-schema` key whose value validates the machine's `:data`
@@ -46,18 +45,17 @@
 ;; return makes the caller SKIP the install, so there is nothing to roll
 ;; back (`:rollback? false`). `:spawn` is the spawn-install pre-check;
 ;; `:update-snapshot` is the snapshot-level escape-hatch pre-write check
-;; (rf2-wrrvs7) — the fx merges the patch onto the live snapshot, so the
-;; validator runs against the would-be-merged snapshot and the fx skips
-;; the `swap-runtime-db!` write on failure. `:macrostep` / `:bootstrap`
+;; — the fx merges the patch onto the live snapshot, so the validator runs
+;; against the would-be-merged snapshot and the fx skips the
+;; `swap-runtime-db!` write on failure. `:macrostep` / `:bootstrap`
 ;; validate the ALREADY-committed snapshot, so a `false` rolls the
 ;; cascade back (`:rollback? true`).
 (def ^:private pre-commit-phases #{:spawn :update-snapshot})
 
 (defn- emit-failure!
-  "Emit `:rf.error/schema-validation-failure` with `:where :machine-data`
-  per the bead's trace-event shape. `phase` is one of `:macrostep` /
-  `:spawn` / `:bootstrap` / `:update-snapshot` — surfaces the lifecycle
-  position to operators.
+  "Emit `:rf.error/schema-validation-failure` with `:where :machine-data`.
+  `phase` is one of `:macrostep` / `:spawn` / `:bootstrap` /
+  `:update-snapshot` — surfaces the lifecycle position to operators.
 
   The trace tag carries:
     :where           :machine-data
@@ -73,18 +71,18 @@
     :recovery        :no-recovery
     :reason          one-sentence diagnostic
 
-  Per Spec 009 / Spec 010 the emit reuses the existing
-  `:rf.error/schema-validation-failure` op; the new `:where` value is
-  the only schema-side extension.
+  Per Spec 009 / Spec 010 the emit reuses the
+  `:rf.error/schema-validation-failure` op; the `:where :machine-data`
+  value is the schema-side extension.
 
-  Per rf2-o69h5 the value-bearing slots (`:value` / `:received` /
-  `:explain`) are routed through the SHARED schema-aware redaction seam
+  The value-bearing slots (`:value` / `:received` / `:explain`) are routed
+  through the SHARED schema-aware redaction seam
   (`:schemas/redact-validation-tags`) BEFORE emit — the same redactor the
   dev-time `validate-*!` hot path and the production boundary interceptor
   use. A machine `:data` schema that marks any slot `:sensitive?` (e.g. an
   auth token in machine data) therefore scrubs those slots to `:rf/redacted`
-  and stamps `:sensitive? true`, closing the a5kzs#1 class on this surface.
-  The hook is unbound only when the schemas artefact is absent — but this
+  and stamps `:sensitive? true`, keeping classified slots out of the error
+  trace. The hook is unbound only when the schemas artefact is absent — but this
   fn is only reached when a schema is registered (validation ran), and the
   schemas artefact owns the validator that ran it, so the hook is bound
   whenever a failure can fire; the `(or redact ...)` fallthrough is
@@ -126,9 +124,9 @@
       router will restore the pre-handler db on a false return).
     - `:phase :spawn` → rollback? false (the snapshot has not yet
       installed; the spawn-fx caller skips the install on false).
-    - `:phase :update-snapshot` → rollback? false (rf2-wrrvs7 — the
-      escape-hatch fx validates the would-be-merged snapshot and skips
-      the `swap-runtime-db!` write on false; nothing was committed)."
+    - `:phase :update-snapshot` → rollback? false (the escape-hatch fx
+      validates the would-be-merged snapshot and skips the
+      `swap-runtime-db!` write on false; nothing was committed)."
   [machine-id snapshot schema phase]
   (if-let [validate-fn (late-bind/get-fn-cached
                          :schemas/validate-with-registered-fn)]
@@ -146,7 +144,7 @@
   resolves through the registered event handler (`:machines/machine-meta`);
   a SPAWNED actor has NO per-instance handler — its TYPE rides the snapshot's
   `:rf/machine-type` reserved slot, so it resolves through
-  `:machines/spec-from-snapshot` (rf2-a2sn1). Returns the schema or nil
+  `:machines/spec-from-snapshot`. Returns the schema or nil
   (no schema / unresolvable spec).
 
   Both resolvers are consumed through the late-bind table to keep this
@@ -170,17 +168,17 @@
   schema / no validator); false on first failure with the per-snapshot trace
   already emitted.
 
-  rf2-2t9xn3: schema resolution goes through `resolve-data-schema`, which
-  resolves a SINGLETON via `machine-meta` AND falls back to the snapshot's
+  Schema resolution goes through `resolve-data-schema`, which resolves a
+  SINGLETON via `machine-meta` AND falls back to the snapshot's
   `:rf/machine-type` (`:machines/spec-from-snapshot`) for a SPAWNED actor.
-  A spawned actor has no per-instance registration, so a `machine-meta`-only
-  lookup returned nil for it and its `:data` was never validated at the
-  macrostep boundary — a schema-violating action committed without rollback
+  A spawned actor has no per-instance registration, so the snapshot fallback
+  is what validates its `:data` at the macrostep boundary — without it a
+  schema-violating action on a spawned actor would commit without rollback
   (the spawn-time `validate-spawn-data!` only catches the INITIAL data).
 
-  EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state, so
-  this validator runs against the new RUNTIME-DB value (the `:rf.db/runtime`
-  effect a machine macrostep commit produces) — NOT app-db. The router calls
+  Machine snapshots are durable runtime-db state, so this validator runs
+  against the new RUNTIME-DB value (the `:rf.db/runtime` effect a machine
+  macrostep commit produces) — NOT app-db. The router calls
   it after the partitioned commit whenever a runtime-db effect landed; on
   `false` the router rolls back the WHOLE transition (same mechanism as the
   `:where :app-db` rollback).
@@ -194,8 +192,8 @@
   ;; `validate-app-schema!` so the late-bind hook the router consumes can
   ;; be invoked uniformly.
   (if interop/debug-enabled?
-    ;; Per the validate-app-schema! pattern (rf2-wkxng): validate EVERY
-    ;; snapshot (no short-circuit) so each failing machine surfaces its
+    ;; Per the validate-app-schema! pattern: validate EVERY snapshot (no
+    ;; short-circuit) so each failing machine surfaces its
     ;; own trace (consumers see the full set), AND-conjoining the per-
     ;; snapshot conform decision so the router decides rollback
     ;; deterministically. A snapshot whose machine declares no `:data-schema`
@@ -234,18 +232,17 @@
     true))
 
 (defn validate-update-snapshot-data!
-  "rf2-wrrvs7 — sibling validator for the `:rf.machine/update-snapshot`
-  escape-hatch fx. Validates the WOULD-BE-MERGED `snapshot`'s `:data`
-  against the actor's resolved `:data-schema` BEFORE the fx writes the
-  patch into runtime-db. Returns true on conform / no schema / no validator
-  (the fx proceeds with the write); false on failure (the fx SKIPS the
-  write so the invalid `:data` never installs).
+  "Sibling validator for the `:rf.machine/update-snapshot` escape-hatch fx.
+  Validates the WOULD-BE-MERGED `snapshot`'s `:data` against the actor's
+  resolved `:data-schema` BEFORE the fx writes the patch into runtime-db.
+  Returns true on conform / no schema / no validator (the fx proceeds with
+  the write); false on failure (the fx SKIPS the write so the invalid
+  `:data` never installs).
 
   Spec 005 §Snapshot-level escape hatch: user error/status state lives
   under `:data` *where `:data-schema` validation covers it* — so an
   escape-hatch `:data` patch is NOT exempt from the `:where :machine-data`
-  boundary. The prior code merged the patch directly via `swap-runtime-db!`
-  and bypassed this boundary, letting an invalid `:data` stick.
+  boundary; this validator gates the escape-hatch merge.
 
   This is a PRE-WRITE rejection (nothing committed → nothing to roll back):
   the failure emits `:where :machine-data :phase :update-snapshot

--- a/implementation/machines/src/re_frame/machines/grammar.cljc
+++ b/implementation/machines/src/re_frame/machines/grammar.cljc
@@ -14,19 +14,14 @@
     2. **the runtime engine** (`transition` / `parallel`) resolves the
        same targets against the same tree at dispatch time.
 
-  Before this namespace existed those two layers each owned a private
-  copy of the `:states`-tree descent and the transition-value form
-  grammar. The validation `candidate-targets` docstring even said it
-  *mirrors* `transition/normalise-candidates` — the semantic contract
-  was duplicated by convention rather than by construction, so every
-  grammar addition or XState-parity refinement had to update multiple
-  private implementations in lockstep, with the standing risk that
-  registration accepts a shape the runtime drives differently (or
-  rejects one the runtime would handle).
-
-  Naming the descent + form grammar once, here, makes both layers
-  consume ONE source of truth. This is the sibling of
-  `re-frame.machines.path-walk` (the deepest-wins leaf→root walk): both
+  Naming the descent + form grammar once, here, makes both layers consume
+  ONE source of truth rather than each owning a private copy of the
+  `:states`-tree descent and the transition-value form grammar. A single
+  home means a grammar addition or XState-parity refinement updates one
+  implementation, with no risk that registration accepts a shape the
+  runtime drives differently (or rejects one the runtime would handle).
+  This is the sibling of `re-frame.machines.path-walk` (the deepest-wins
+  leaf→root walk): both
   are leaf namespaces (no require on `transition` / `validation` /
   `parallel`) so either layer can require them without a load cycle.
 
@@ -116,8 +111,8 @@
 
   Note `:vec-target` matches any vector that is NOT the non-empty
   all-maps candidate form — including the empty vector, which both
-  callers historically treat as a (non-resolving) absolute-path target
-  rather than a distinct malformed form."
+  callers treat as a (non-resolving) absolute-path target rather than a
+  distinct malformed form."
   [v]
   (cond
     (nil? v)        :nil

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -9,7 +9,7 @@
   frame's runtime-db, and (if the actor was system-id-bound) clears the
   `[:rf.runtime/machines :system-ids]` reverse index entry.
 
-  Per rf2-t07u (Option A revised), `args` can be either:
+  `args` can be either:
     - a keyword `actor-id` — the IMPERATIVE form: an action emits
       `[:rf.machine/destroy actor-id]` directly with the actor id it
       holds. This is first-class current API — re-frame2's spelling of
@@ -20,12 +20,11 @@
       id from `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` in the frame's
       runtime-db.
 
-  Both forms are canonical and current (pre-alpha, no compatibility
-  shims): the keyword form is the imperative entry-point, the map form
-  is what the `:spawn` desugaring emits on state exit. They are not a
-  new-vs-old pair.
+  Both forms are canonical: the keyword form is the imperative
+  entry-point, the map form is what the `:spawn` desugaring emits on state
+  exit. They are parallel entry-points, not a paired alternative.
 
-  Per rf2-6vmw, the map form may also carry `:rf/spawn-all true` —
+  The map form may also carry `:rf/spawn-all true` —
   the declarative-`:spawn-all` exit-cascade form. The slot at
   `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` holds a join-state map whose
   `:children` sub-map has every spawned child id. The handler iterates
@@ -48,9 +47,9 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn- actor-live?
-  "Per rf2-lbjnz — the silent-idempotent liveness probe, shared by the
+  "The silent-idempotent liveness probe, shared by the
   keyword/tracked `destroy-single!` path and the per-actor
-  `destroy-single-actor!` path (rf2-ndfjo). An actor with a resolved
+  `destroy-single-actor!` path. An actor with a resolved
   `actor-id` is live iff ANY of the following survive:
 
     - **Handler still registered** at `actor-id` in the event
@@ -70,8 +69,8 @@
   A truly-already-destroyed actor has all three gone — the unified
   teardown projection + `registrar/unregister!` + `spawn-order/forget!`
   run atomically per `destroy-single-actor!` / `destroy-single!` /
-  `finalize-machine`. See [Spec 005 §Destroy is silent-idempotent
-  (rf2-lbjnz)] for the normative paragraph.
+  `finalize-machine`. See Spec 005 §Destroy is silent-idempotent
+  for the normative paragraph.
 
   The tracked-slot signal `destroy-single!` additionally consults is
   resolved-actor-id agnostic and so stays local to that call site."
@@ -93,34 +92,32 @@
   Ordered steps (Spec 005 §Declarative `:spawn` §Composition with explicit
   `:entry` / `:exit`; §Cancellation cascade D6-D8):
 
-    1. (rf2-nahfm) run the active configuration's `:exit` cascade BEFORE
+    1. run the active configuration's `:exit` cascade BEFORE
        any teardown work — fires `:exit`-emitted fx via do-fx and writes
        any `:data` updates back to the (about-to-be-dissoc'd) snapshot;
-    2. (rf2-wvkn) abort in-flight `:rf.http/managed` requests;
-    3. (EP-0025, rf2-398kql) — the prior per-instance `:data-schema`-marks
-       clear (rf2-egvm4t) is REMOVED; the schema→marks bridge it matched is
-       gone (schema-field classification killed), so there is no marks-table
-       residue to drop;
-    4. (rf2-82a0u) cancel armed `:after` timers, one
+    2. abort in-flight `:rf.http/managed` requests;
+    3. a machine's `:data-schema` is validation-only and produces no
+       per-instance marks table, so there is no marks-table residue to drop;
+    4. cancel armed `:after` timers, one
        `:rf.machine.timer/cancelled :reason :on-destroy` trace per timer;
     5. apply the unified teardown projection (`teardown/teardown-actor`),
        capturing the released `:system-id` via a side channel so we keep a
        single runtime-db read + single write (machine snapshots are durable
-       runtime-db state, rf2-vzld77). `teardown-args` selects the slots the
+       runtime-db state). `teardown-args` selects the slots the
        projection prunes (`{:actor-id …}` for the per-actor form; the
        tracked map adds `:parent-id` / `:invoke-id`);
     6. emit `:rf.machine/destroyed` via the optional `emit-destroyed!-fn`
        (called with the released sid) — `destroy-single!` emits here so the
-       trace lands after `:exit` (rf2-iilco); `destroy-single-actor!`'s
+       trace lands after `:exit`; `destroy-single-actor!`'s
        callers own the emit, so they pass nil;
-    7. (rf2-vsigt) forget the actor from the per-frame spawn-order channel
+    7. forget the actor from the per-frame spawn-order channel
        REGARDLESS of whether the runtime-db swap landed — by the time
        frame-destroy runs the container may already be nil but the
        spawn-order entry still needs clearing;
     8. when the swap landed, emit `:rf.machine/system-id-released` and
        unregister the live event handler (last, so an in-flight trace emit
        against the actor still resolves before the slot disappears);
-    9. (rf2-xw5t0y) release the actor's resource leases — fire
+    9. release the actor's resource leases — fire
        `:rf.resource/release-owner` for owner `[:machine actor-id]` (Spec 016
        §Release authority is per owner kind, 016:290) so a resource the actor
        `ensure`d under its machine-owner key does not leak the lease (keep
@@ -134,10 +131,9 @@
   [frame-id actor-id teardown-args emit-destroyed!-fn]
   (exit-cascade/run-child-exit! frame-id actor-id)
   (finalize/abort-actor-in-flight-http! actor-id)
-  ;; EP-0025 (rf2-398kql): the per-instance `:data-schema`-marks clear (step 3,
-  ;; rf2-egvm4t) is GONE — the spawn-time schema→marks bridge it cleaned up after
-  ;; is removed (schema-field classification killed). No marks-table residue to
-  ;; drop here.
+  ;; Step 3: a machine's `:data-schema` is validation-only and produces no
+  ;; per-instance marks table, so there is no marks-table residue to drop
+  ;; here.
   (timer/cancel-actor-timers! frame-id actor-id)
   ;; `teardown-actor` returns [new-runtime-db released-sid]; `swap-runtime-db!`
   ;; expects a fn returning the new runtime-db only, so capture the sid via a
@@ -155,7 +151,7 @@
     (when db-swapped?
       (traces/emit-system-id-released! frame-id @sid actor-id)
       (registrar/unregister! :event actor-id))
-    ;; (9) rf2-xw5t0y — release the actor's resource leases once it is gone, so
+    ;; (9) release the actor's resource leases once it is gone, so
     ;; a `[:machine actor-id]`-owned resource does not outlive the actor and
     ;; keep refetching/polling. Fired regardless of `db-swapped?`: a re-destroy
     ;; whose teardown projection no-op'd may still have a live owner-pinned
@@ -169,12 +165,12 @@
 
 (defn destroy-single-actor!
   "Destroy a single spawned actor against the frame's container: run
-  the active configuration's `:exit` cascade (rf2-nahfm), apply the
+  the active configuration's `:exit` cascade, apply the
   unified teardown projection (per
   `re-frame.machines.lifecycle-fx.teardown`), abort in-flight
-  `:rf.http/managed` requests (rf2-wvkn), emit the
+  `:rf.http/managed` requests, emit the
   `:system-id-released` trace, unregister the live event handler, and
-  forget the actor from the per-frame spawn-order channel (rf2-vsigt).
+  forget the actor from the per-frame spawn-order channel.
   The ordered teardown pipeline is shared with `destroy-single!` via
   `teardown-live-actor!`.
 
@@ -187,30 +183,29 @@
   teardown clears the snapshot, so `:exit`-time side effects (HTTP
   requests, logs, dispatches) execute against the live snapshot.
 
-  Per rf2-ndfjo — silent-idempotent guard: an already-destroyed actor
+  Silent-idempotent guard: an already-destroyed actor
   (all liveness signals gone) is a no-op. Returns `true` iff the actor
-  was live and torn down this call, and `nil` (the `when`'s falsey value;
-  rf2-ny0yrz CL4 — narrowed from the earlier `false` wording) for the
-  silent no-op — so callers (notably `destroy-spawn-all-children!`) can
-  gate their `:rf.machine/destroyed` emit on the truthy live-and-torn-down
+  was live and torn down this call, and `nil` (the `when`'s falsey value)
+  for the silent no-op — so callers (notably `destroy-spawn-all-children!`)
+  can gate their `:rf.machine/destroyed` emit on the truthy live-and-torn-down
   return, preventing a double-destroyed trace for join-cancelled survivors
   the resolution cascade already tore down. Mirrors the `live?` gate
-  `destroy-single!` carries (rf2-lbjnz)."
+  `destroy-single!` carries."
   [frame-id actor-id]
   (when (actor-live? frame-id actor-id (frame/frame-runtime-db-value frame-id))
     ;; This site does NOT emit `:rf.machine/destroyed` — its callers
     ;; (`destroy-spawn-all-children!`, the frame-destroy walker) own that
     ;; emit, gating it on this fn's truthy return so each actor's destroyed
-    ;; trace fires exactly once (rf2-ndfjo). So no emit-destroyed callback.
+    ;; trace fires exactly once. So no emit-destroyed callback.
     (teardown-live-actor! frame-id actor-id {:actor-id actor-id} nil)
-    ;; rf2-ndfjo — signal to callers (`destroy-spawn-all-children!`) that
+    ;; Signal to callers (`destroy-spawn-all-children!`) that
     ;; this actor was live and torn down this call, so they emit
     ;; `:rf.machine/destroyed` exactly once. The `when` returns nil for
     ;; an already-destroyed actor (silent no-op).
     true))
 
 (defn- destroy-spawn-all-children!
-  "Per rf2-6vmw — the declarative-`:spawn-all` exit-cascade form.
+  "The declarative-`:spawn-all` exit-cascade form.
   Resolves the children map from `[:rf.runtime/machines :spawned parent-id invoke-id]`,
   tears each child down via `destroy-single-actor!`, then clears the
   join-state slot via the unified teardown projection (slot-prune only:
@@ -220,22 +215,22 @@
                            (paths/spawned-path parent-id invoke-id))
         children   (when (map? join-state) (:children join-state))]
     (doseq [[child-id spawned-id] children]
-      ;; (rf2-iilco) `destroy-single-actor!` runs the child's `:exit`
+      ;; `destroy-single-actor!` runs the child's `:exit`
       ;; cascade before teardown; we fire `:rf.machine/destroyed` AFTER it
       ;; so the trace lands after `:exit` — the same exit-then-destroyed
       ;; ordering `destroy-single!` and `finalize-machine` use.
       ;;
-      ;; rf2-ndfjo — silent-idempotent destroy contract (rf2-lbjnz):
+      ;; Silent-idempotent destroy contract:
       ;; `:cancel-on-decision?` join resolution (join.cljc/build-resolution-fx)
       ;; already tore down surviving children via the guarded
       ;; `destroy-single!` keyword form (one `:destroyed` each) BEFORE the
       ;; parent's exit cascade re-reads the still-uncleared join-state here.
-      ;; `destroy-single-actor!` now returns falsey for those
+      ;; `destroy-single-actor!` returns falsey for those
       ;; already-destroyed survivors (its liveness guard short-circuits), so
       ;; gating the emit on its return value keeps each survivor's
       ;; `:rf.machine/destroyed` to EXACTLY ONE — no phantom double-destroy.
       ;;
-      ;; rf2-gn80 D6 — `:reason :explicit` discriminates "the parent cascade
+      ;; D6 — `:reason :explicit` discriminates "the parent cascade
       ;; tore the child down" from `:rf.machine/finished` (the auto-destroy
       ;; on `:final?`). Per-child fires omit `:system-id` (the join-state's
       ;; children aren't system-id-bound through the parent's slot).
@@ -254,15 +249,15 @@
     nil))
 
 (defn- destroy-single!
-  "Per rf2-t07u — the keyword (imperative) form and the single-
+  "The keyword (imperative) form and the single-
   `:spawn` (tracked map) form of `:rf.machine/destroy`. Resolves the
   actor-id (keyword direct OR via the `[:rf.runtime/machines :spawned ...]` slot), emits
   the `:rf.machine/destroyed` trace, then applies the unified teardown
   projection.
 
-  Per rf2-lbjnz (Mike decision a, aligned with XState convention) —
-  destroying an **already-destroyed** actor is a **silent idempotent
-  no-op**. The actor's lifecycle has one observable transition
+  Aligned with XState convention, destroying an **already-destroyed** actor
+  is a **silent idempotent no-op**. The actor's lifecycle has one observable
+  transition
   (Active → Stopped); subsequent destroy attempts emit NO
   `:rf.machine/destroyed` trace, perform NO teardown, and raise NO
   error.
@@ -302,8 +297,7 @@
   teardown projection + `registrar/unregister!` + `spawn-order/forget!`
   run atomically per `destroy-single-actor!` and `finalize-machine`.
 
-  See [Spec 005 §Destroy is silent-idempotent (rf2-lbjnz)] for the
-  normative paragraph."
+  See Spec 005 §Destroy is silent-idempotent for the normative paragraph."
   [frame-id args]
   (let [tracked?  (map? args)
         parent-id (when tracked? (:rf/parent-id args))
@@ -312,20 +306,20 @@
         slot-id   (when (and tracked? old-db)
                     (get-in old-db (paths/spawned-path parent-id invoke-id)))
         actor-id  (if tracked? slot-id args)
-        ;; rf2-lbjnz — silent-idempotent guard. `live?` is true iff ANY
+        ;; Silent-idempotent guard. `live?` is true iff ANY
         ;; liveness signal survives. The first three (handler registered /
         ;; snapshot present / spawn-order entry) are the resolved-actor-id
         ;; signals shared with `destroy-single-actor!` via `actor-live?`
-        ;; (rf2-ndfjo extracted them so both destroy paths apply the
-        ;; identical probe). The tracked-slot signal is local to this site —
-        ;; belt-and-braces for the declarative-`:spawn` tracked-map form.
-        ;; See docstring for what each signal covers.
+        ;; (both destroy paths apply the identical probe). The tracked-slot
+        ;; signal is local to this site — belt-and-braces for the
+        ;; declarative-`:spawn` tracked-map form. See docstring for what each
+        ;; signal covers.
         live?     (or (actor-live? frame-id actor-id old-db)
                       (and tracked? (some? slot-id)))]
     (when live?
       ;; Shared ordered teardown pipeline (see `teardown-live-actor!`). The
-      ;; `:exit` cascade runs BEFORE the `:rf.machine/destroyed` trace
-      ;; (rf2-iilco): per Spec 005 §Declarative `:spawn` §Composition with
+      ;; `:exit` cascade runs BEFORE the `:rf.machine/destroyed` trace:
+      ;; per Spec 005 §Declarative `:spawn` §Composition with
       ;; explicit `:entry` / `:exit` (005:2138) the `:exit` action reads the
       ;; actor's final snapshot before the auto-destroy clears it, so a
       ;; consumer observing the db between `:exit` and `:rf.machine/destroyed`
@@ -335,7 +329,7 @@
       (teardown-live-actor!
         frame-id actor-id
         {:actor-id actor-id :parent-id parent-id :invoke-id invoke-id}
-        ;; rf2-gn80 D6 — `:reason :explicit` discriminates "an action / fx
+        ;; D6 — `:reason :explicit` discriminates "an action / fx
         ;; tore the actor down" from `:rf.machine/finished` (the auto-destroy
         ;; on `:final?`). Always stamp `:system-id` (nil when not bound) per
         ;; the destroyed-trace-shape contract for the `destroy-single!` site.

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
@@ -21,9 +21,9 @@
   per-region reduce). This file is the side-effect wrapper that:
     1. resolves the actor's snapshot from the frame's runtime-db,
     2. resolves the actor's machine spec — a spawned actor's TYPE rides
-       its snapshot under `:rf/machine-type` (per rf2-a2sn1, spawned
-       actors carry no per-instance registrar entry); a singleton's spec
-       comes from its registered handler,
+       its snapshot under `:rf/machine-type` (spawned actors carry no
+       per-instance registrar entry); a singleton's spec comes from its
+       registered handler,
     3. runs the pure cascade,
     4. writes the post-cascade snapshot back to runtime-db so any caller
        reading the snapshot AFTER `:exit` (e.g. `finalize-machine`'s
@@ -53,7 +53,7 @@
 (defn- resolve-machine-spec
   "Resolve `actor-id`'s machine spec for the `:exit` cascade. Prefer the
   `snapshot`'s `:rf/machine-type` TYPE reference (the home for spawned
-  actors, which carry no per-instance registrar entry per rf2-a2sn1);
+  actors, which carry no per-instance registrar entry);
   fall back to a registered handler under `actor-id` itself (the
   singleton case — a `reg-machine`'d machine reaching `:final?`). Returns
   nil when neither resolves — the actor was already torn down, or the
@@ -100,7 +100,7 @@
               ;; `:exit` and teardown see the `:exit`-time `:data`
               ;; writes; the production-runtime cost is one extra
               ;; swap-runtime-db! per destroy. Machine snapshots are
-              ;; durable runtime-db state (rf2-vzld77).
+              ;; durable runtime-db state.
               (when (not= snapshot new-snap)
                 (frame/swap-runtime-db! frame-id
                                         (fn [rt] (assoc-in rt (paths/snapshot-path actor-id) new-snap))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -27,7 +27,7 @@
   unregistered.
 
   This namespace also owns `abort-actor-in-flight-http!` — the late-bind
-  hook into the http-managed artefact (rf2-wvkn) — the single home for
+  hook into the http-managed artefact — the single home for
   the abort contract every destroy trigger shares: the finalize cascade,
   the spawn-destroy teardowns (`lifecycle-fx.destroy`), and the
   frame-destroy singleton-straggler pass (`lifecycle-fx.frame-destroy`).
@@ -52,7 +52,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- in-flight HTTP abort cascade (rf2-wvkn) ------------------------------
+;; ---- in-flight HTTP abort cascade -----------------------------------------
 ;;
 ;; Per Spec 005 §Cancellation cascade — in-flight `:rf.http/managed`
 ;; aborts: when a spawned state-machine actor is destroyed, every
@@ -73,28 +73,26 @@
            (catch #?(:clj Throwable :cljs :default) _ nil))))
   nil)
 
-;; ---- per-instance :data-schema marks cleanup: REMOVED (EP-0025, rf2-398kql)
+;; ---- per-instance :data-schema marks cleanup -------------------------------
 ;;
-;; `clear-actor-schema-marks!` (rf2-egvm4t) is GONE. It fired
-;; `:marks/clear-machine-schema-marks!` to drop a destroyed spawned actor's
-;; per-instance `:data-schema`→marks entry (recorded at spawn time by the
-;; rf2-fm1cpl bridge). With schema-field classification killed in favour of
-;; frame-declared paths as the sole app-db mechanism, the spawn-time bridge and
-;; its schema-sourced marks table are both removed, so there is nothing to
-;; clear here — a destroyed actor leaves no schema-marks residue by construction.
+;; A machine's `:data-schema` is validation-only; it does not produce a
+;; per-instance marks table. There is therefore no schema-marks entry to
+;; clear at destroy — a destroyed actor leaves no schema-marks residue by
+;; construction. A spawned actor's `:data` redaction (if any) rides the
+;; frame's declared paths, the sole app-db redaction mechanism.
 
 ;; ---- final-state resolution -----------------------------------------------
 
-;; Per Spec 005 §Final states §The done-state signal (rf2-bnjb3): the
-;; `all-regions-final?` predicate now lives in `re-frame.machines.parallel`
+;; Per Spec 005 §Final states §The done-state signal: the
+;; `all-regions-final?` predicate lives in `re-frame.machines.parallel`
 ;; (shared by the parallel macrostep's done-signal / `:on-done` firing and
-;; this whole-machine finalize path). Re-exported here so existing callers
-;; (and the conformance corpus) keep the `finalize/all-regions-final?`
+;; this whole-machine finalize path). Re-exported here so callers
+;; (and the conformance corpus) reach it at the `finalize/all-regions-final?`
 ;; address. `finalize` requires `parallel`, never the reverse — no cycle.
 (def all-regions-final? parallel/all-regions-final?)
 
 (defn- region-final-leaf-nodes
-  "Per Spec 005 §Final states + §Parallel regions (rf2-g13nm2 C2): resolve
+  "Per Spec 005 §Final states + §Parallel regions: resolve
   every region's active final leaf-node from the post-transition `state`
   map (a `{region-name region-state}` map). Returns an ordered seq of
   `[region-name leaf-node]` in the state-map's iteration order — the basis
@@ -107,16 +105,14 @@
        state))
 
 (defn- parallel-output-key
-  "Per Spec 005 §Final states (rf2-g13nm2 C2): resolve a finishing PARALLEL
+  "Per Spec 005 §Final states: resolve a finishing PARALLEL
   machine's `:output-key` by scanning EVERY region's final leaf — not just
   the first region's. Returns the first (state-map order) region leaf that
   declares an `:output-key`, or nil when no region designates output.
 
-  The pre-fix code read `:output-key` from `(first state)` only, so a
-  machine declaring `:output-key` on a NON-FIRST region silently reported
-  `result = nil`. Scanning all region leaves makes `:output-key` work on
-  ANY region (the spec never restricted it to the first), and a genuine
-  CONFLICT — two regions declaring DIFFERENT `:output-key`s — emits
+  `:output-key` works on ANY region (the spec never restricted it to the
+  first). A genuine CONFLICT — two regions declaring DIFFERENT
+  `:output-key`s — emits
   `:rf.error/machine-parallel-output-key-conflict` and deterministically
   keeps the first-region declaration (last-region-loses would be just as
   arbitrary; first-in-state-order is the stable, documented tiebreak)."
@@ -141,19 +137,11 @@
     (some (fn [[_ node]] (:output-key node)) declared)))
 
 (defn- parallel-error-leaf-node
-  "Per Spec 005 §Final states §`:on-error` + §Parallel regions (rf2-encnvn):
+  "Per Spec 005 §Final states §`:on-error` + §Parallel regions:
   classify a finishing PARALLEL machine's terminal as ERROR by scanning
   EVERY region's final leaf — not just the first region's. Returns the
   first (state-map order) region final leaf that declares `:error? true`,
   or nil when no region's terminal is an error final.
-
-  The pre-fix code read `:error?` from `(first state)` only — the SAME
-  first-region blind spot the `:output-key` scan (`parallel-output-key`)
-  already fixed for output. So a parallel child whose FIRST region reached
-  a plain final but a NON-FIRST region reached `{:final? true :error? true}`
-  was all-regions-final and torn down, yet classified as a SUCCESS finish:
-  the spawning parent's `:spawn :on-error` was skipped, `:on-done` could run
-  instead, and `:rf.machine/done` carried `:error? false` / `:status :ok`.
 
   Spec 005 §3061 says a parallel machine finishes when EVERY region's active
   leaf is `:final?` and never restricts the error terminal to the first
@@ -170,7 +158,7 @@
   "Walk `parent-spec`'s state tree to the node at `invoke-id` (the
   absolute prefix-path stamped at spawn time) and return that node's
   `:spawn` map. For a parallel-region parent, the first element of
-  `invoke-id` is the region name (per rf2-l67o); strip and descend
+  `invoke-id` is the region name; strip and descend
   into that region's body. Returns nil if the path doesn't resolve
   or the node doesn't declare `:spawn`."
   [parent-spec invoke-id]
@@ -186,9 +174,9 @@
 ;; ---- the orchestrator ------------------------------------------------------
 
 (defn finalize-machine
-  "Per Spec 005 §Final states (rf2-gn80): orchestrate the `:on-done` +
+  "Per Spec 005 §Final states: orchestrate the `:on-done` +
   auto-destroy cascade. Returns `{:rf.db/runtime new-runtime-db :fx fx}` —
-  the snapshot teardown is a durable runtime-db write (EP-0001 rf2-vzld77),
+  the snapshot teardown is a durable runtime-db write (EP-0001),
   returned under the framework-authority `:rf.db/runtime` partition, NOT
   `:db` (see the return at `finalize-machine!`'s tail). It is the handler's
   return value when the post-transition snapshot has finished (its active
@@ -205,13 +193,13 @@
     frame-id       — the frame the actor runs in
     runtime-db     — the runtime-db partition value AT the time the handler
                      was invoked (machine snapshots are durable runtime-db
-                     state — EP-0001 rf2-vzld77); returned under `:rf.db/runtime`
+                     state — EP-0001); returned under `:rf.db/runtime`
     next-snapshot  — the post-transition snapshot (the caller already
                      determined it is final by recomputing from `:state`)
     _inner-event   — the event that caused the finish (for diagnostics)
     extra-fx       — the fx vector from the transition (passed through)"
   [machine machine-id frame-id runtime-db next-snapshot _inner-event extra-fx]
-  ;; (rf2-nahfm) Run the actor's active configuration `:exit` cascade
+  ;; Run the actor's active configuration `:exit` cascade
   ;; FIRST so the final state's `:exit` actions fire from the auto-
   ;; destroy teardown (Spec 005 §Final states §Composition with
   ;; `:entry` / `:exit`). The cascade is pure — it returns a new
@@ -229,16 +217,14 @@
         next-snapshot (if exit-ok? (result/snap exit-result) next-snapshot)
         exit-fx       (if exit-ok? (vec (result/fx exit-result)) [])
         runtime-db    (if exit-ok?
-                        ;; rf2-ny0yrz CL4 — narrowed: project the post-`:exit`
-                        ;; CHILD snapshot back into runtime-db so any reader of
-                        ;; the runtime-db between here and the teardown dissoc
-                        ;; observes the final state's `:exit`-time `:data`
-                        ;; writes on the FINISHING child. (The child's
-                        ;; `result` is computed directly from `next-snapshot`
-                        ;; below, NOT re-read from runtime-db, and `:on-done`
-                        ;; reads the PARENT's `:data` — the earlier comment's
-                        ;; "`:on-done` reading the child" example was
-                        ;; inaccurate; the projection's purpose is runtime-db
+                        ;; Project the post-`:exit` CHILD snapshot back into
+                        ;; runtime-db so any reader of the runtime-db between
+                        ;; here and the teardown dissoc observes the final
+                        ;; state's `:exit`-time `:data` writes on the FINISHING
+                        ;; child. (The child's `result` is computed directly
+                        ;; from `next-snapshot` below, NOT re-read from
+                        ;; runtime-db, and `:on-done` reads the PARENT's
+                        ;; `:data`; the projection's purpose is runtime-db
                         ;; consistency for the finalize cascade's own reads.)
                         (assoc-in runtime-db (paths/snapshot-path machine-id) next-snapshot)
                         runtime-db)
@@ -250,38 +236,36 @@
                           machine-id frame-id (result/info exit-result)))]
   (let [child-data (:data next-snapshot)
         parallel?  (parallel/parallel? machine)
-        ;; (rf2-encnvn) Resolve the ERROR-classifying leaf. For a PARALLEL
+        ;; Resolve the ERROR-classifying leaf. For a PARALLEL
         ;; machine, scan EVERY region's final leaf — a parallel finish is an
         ;; ERROR when ANY region's reached final declares `:error? true`, not
         ;; only the first region's (Spec 005 §3060-§3061; XState v5 parallel
-        ;; error-final semantics). The pre-fix code read `:error?` from
-        ;; `(first state)` only — the same first-region blind spot the
-        ;; `:output-key` scan (C2) already fixed for output. For a flat
-        ;; machine the single leaf IS the error-classifying leaf.
+        ;; error-final semantics). For a flat machine the single leaf IS the
+        ;; error-classifying leaf.
         error-node  (if parallel?
                       (parallel-error-leaf-node machine (:state next-snapshot))
                       (transition/node-at machine
                                           (transition/state-path (:state next-snapshot))))
         error-leaf? (true? (:error? error-node))
-        ;; Per rf2-g13nm2 C2: a PARALLEL machine's `:output-key` may live on
-        ;; ANY region's terminal leaf, not just the first. Scan all regions
-        ;; (error on conflict); a flat machine reads its single leaf. When the
-        ;; finish is an ERROR, the error payload's `:output-key` is sourced
-        ;; from the ERROR region's leaf so the right error `:data` slot routes
-        ;; to `:on-error` (rf2-encnvn).
+        ;; A PARALLEL machine's `:output-key` may live on ANY region's
+        ;; terminal leaf, not just the first. Scan all regions (error on
+        ;; conflict); a flat machine reads its single leaf. When the finish is
+        ;; an ERROR, the error payload's `:output-key` is sourced from the
+        ;; ERROR region's leaf so the right error `:data` slot routes to
+        ;; `:on-error`.
         output-key  (cond
                       (and parallel? error-leaf?) (:output-key error-node)
                       parallel?                   (parallel-output-key machine (:state next-snapshot) frame-id machine-id)
                       :else                       (:output-key error-node))
         result      (when output-key (get child-data output-key))
-        ;; Per Spec 005 §Final states §`:on-error` (rf2-5hlsh; XState v5 invoke
+        ;; Per Spec 005 §Final states §`:on-error` (XState v5 invoke
         ;; `onError`): a `:final?` leaf MAY also declare `:error? true` — a
         ;; designated ERROR terminal. When a `:spawn`-spawned child finishes
         ;; via an error leaf AND its spawning parent declares `:spawn :on-error`,
         ;; the runtime routes the failure to a PARENT TRANSITION (control flow,
         ;; not just observability) instead of the `:data`-only `:on-done`
         ;; callback. A plain `:final?` leaf keeps firing `:on-done`. `error-leaf?`
-        ;; is computed above (cross-region scan for parallel — rf2-encnvn).
+        ;; is computed above (cross-region scan for parallel).
         parent-id   (:rf/parent-id child-data)
         invoke-id   (:rf/invoke-id child-data)
         ;; Per EP-0011 §Machine Completion / Managed-Effects §The uniform
@@ -296,7 +280,7 @@
         ;; routes the raw failure payload to the parent transition. This is
         ;; internal lowering only — the reply map is what the trace stream,
         ;; ledger, and future work-correlation read uniformly (m-reply).
-        ;; (rf2-6mfkp3) Thread the CAUSAL completion timestamp into the
+        ;; Thread the CAUSAL completion timestamp into the
         ;; reply so `:completed-at` carries the one host-clock read the
         ;; router captured for the finishing event — NOT an ambient
         ;; `(.now)`. Per spec/Managed-Effects.md §155/§231 a machine
@@ -317,10 +301,10 @@
                       (some? completed-at) (assoc :completed-at completed-at))
         ;; (1) Find parent's `:on-done` / `:on-error`, if this is a `:spawn`-
         ;; spawned actor. The parent's spec carries the `:spawn` map at
-        ;; `invoke-id`. Per rf2-a2sn1 — resolve the parent's spec from the
-        ;; registrar (a singleton parent) OR, for a NESTED spawn whose
-        ;; parent is itself a spawned actor (no per-instance registration),
-        ;; from the parent's own snapshot `:rf/machine-type`.
+        ;; `invoke-id`. Resolve the parent's spec from the registrar (a
+        ;; singleton parent) OR, for a NESTED spawn whose parent is itself a
+        ;; spawned actor (no per-instance registration), from the parent's own
+        ;; snapshot `:rf/machine-type`.
         parent-path (paths/snapshot-path parent-id)
         parent-snap (when parent-id (get-in runtime-db parent-path))
         parent-reg  (when parent-id (registrar/lookup :event parent-id))
@@ -341,15 +325,14 @@
                          parent-id
                          (some? (:on-error spawn-spec)))
         ;; Per EP-0011 §Machine Completion / Managed-Effects §Stale
-        ;; suppression (rf2-lohbfg): the one reachable machine-supersession
+        ;; suppression: the one reachable machine-supersession
         ;; case is a `:spawn`-spawned child reaching `:final?` AFTER its
         ;; spawning parent was already DESTROYED. The completion is then
         ;; STALE — its `:on-done` / `:on-error` routing has no live parent to
         ;; drive, so per §Stale suppression the app target MUST NOT run and
         ;; the completion is recorded `:status :stale` / `:work/status
-        ;; :suppressed` via the shared substrate (rather than silently
-        ;; reducing `:on-done` to identity, which emitted only an `:ok`
-        ;; reply + no stale vocabulary).
+        ;; :suppressed` via the shared substrate, carrying the full stale
+        ;; vocabulary rather than a bare `:ok` reply.
         ;;
         ;; LIVENESS is the gate (not `on-done-fn` resolvability): when the
         ;; parent was destroyed BOTH its snapshot AND — for a singleton
@@ -397,7 +380,7 @@
         ;; `:correlation`) route through the shared elision walker via
         ;; `m-reply/trace-reply`.
         ;;
-        ;; (rf2-lohbfg) A STALE late completion (parent destroyed before the
+        ;; A STALE late completion (parent destroyed before the
         ;; child finished) additionally rides `:rf.reply/stale-reason`
         ;; (`:rf.machine/actor-not-live`) and `:rf.reply/correlation` (the
         ;; carried/current generation gate) — the parity counterpart of the
@@ -409,7 +392,7 @@
                        (m-reply/stale-spawn-trace reply {:frame frame-id})
                        (m-reply/trace-reply reply {:frame frame-id}))
         _ (trace/emit! :rf.machine :rf.machine/done
-                       ;; rf2-ws5thu — `:actor-id` is the finishing actor's
+                       ;; `:actor-id` is the finishing actor's
                        ;; live INSTANCE address (singleton: its registration
                        ;; id; spawned: the `<type>#<n>` / fixed instance id).
                        ;; `:machine-id` is reserved for the registered TYPE.
@@ -419,19 +402,19 @@
                                 :error?     error-leaf?
                                 :frame      frame-id
                                 ;; reply-envelope vocabulary (Managed-Effects §9)
-                                ;; rf2-niarhz — the CANONICAL `:work/id` joins
+                                ;; The CANONICAL `:work/id` joins
                                 ;; this spawned-actor completion into Xray's
                                 ;; uniform work/reply rows + stale-race
                                 ;; grouping, which key on bare `:work/id`. The
-                                ;; `:rf.reply/work-id` spelling is retained for
-                                ;; back-compat readers, but the canonical key
-                                ;; is what tooling groups by.
+                                ;; `:rf.reply/work-id` spelling is carried
+                                ;; alongside for readers that key on it; the
+                                ;; canonical key is what tooling groups by.
                                 :work/id              (:work/id done-summary)
                                 :work/kind            (:work/kind done-summary)
                                 :rf.reply/status      (:status done-summary)
                                 :rf.reply/work-id     (:work/id done-summary)
                                 :rf.reply/work-status (:work/status done-summary)}
-                         ;; (rf2-6mfkp3) the causal completion timestamp — the
+                         ;; the causal completion timestamp — the
                          ;; router's `:rf.cofx` `:rf/time-ms` threaded
                          ;; into the reply (Managed-Effects §155/§231: a
                          ;; completion affecting durable state carries causal
@@ -440,7 +423,7 @@
                          (some? (:completed-at done-summary))
                          (assoc :rf.reply/completed-at (:completed-at done-summary)
                                 :completed-at          (:completed-at done-summary))
-                         ;; stale-suppression vocabulary (rf2-lohbfg) — carried
+                         ;; stale-suppression vocabulary — carried
                          ;; ADDITIVELY only for a stale late completion, joined
                          ;; to `:work/id` via the shared `:rf.reply/*` facts.
                          stale-spawn? (assoc :rf.reply/stale-reason (:stale/reason done-summary)
@@ -449,13 +432,13 @@
         ;; snapshot lives at [:rf.runtime/machines :snapshots <parent-id>]; we read it,
         ;; pass the unified context-map (`{:data :result}`) to
         ;; `:on-done`, and write the new `:data` back. Per Spec 005
-        ;; §Final states / rf2-grw4i / rf2-v0rrr the callback receives
+        ;; §Final states the callback receives
         ;; one context-map arg and returns the new `:data` map. An ERROR
         ;; leaf routing to `:on-error` SKIPS `:on-done` — the two spawn hooks
         ;; are mutually exclusive per finish (error-leaf → transition,
         ;; success-leaf → `:data` callback).
         ;;
-        ;; (rf2-lohbfg) When the parent was destroyed before the child
+        ;; When the parent was destroyed before the child
         ;; finished (`stale-spawn?` — no live `parent-snap`), the completion
         ;; is STALE: per Managed-Effects §Stale suppression the app target
         ;; (the `:on-done` callback) MUST NOT run, and there is nothing to
@@ -493,7 +476,7 @@
               (assoc-in runtime-db (conj parent-path :data) new-parent-data)
               runtime-db))
           runtime-db)
-        ;; (4) Apply the unified teardown projection (per rf2-lha2t):
+        ;; (4) Apply the unified teardown projection:
         ;; dissoc the child's snapshot, release any `:system-id`
         ;; reverse-index entry (D8 — after on-done ran), and clear the
         ;; parent's `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot with
@@ -516,16 +499,16 @@
                                    :invoke-id invoke-id
                                    :reason    :rf.machine/finished})]
     ;; (6) Synchronous side effects: abort in-flight HTTP, cancel
-    ;; armed `:after` timers (rf2-82a0u — `:reason :on-destroy`), emit
+    ;; armed `:after` timers (`:reason :on-destroy`), emit
     ;; system-id-released trace (when applicable), unregister handler.
     (abort-actor-in-flight-http! machine-id)
     (timer/cancel-actor-timers! frame-id machine-id)
-    ;; EP-0025 (rf2-398kql): the per-instance `:data-schema`-marks clear
-    ;; (rf2-egvm4t) is REMOVED — the spawn-time schema→marks bridge it matched
-    ;; is gone (schema-field classification killed). No marks residue to drop.
+    ;; A machine's `:data-schema` is validation-only and produces no
+    ;; per-instance marks table, so there is no schema-marks residue to drop
+    ;; at this seam.
     (traces/emit-system-id-released! frame-id released-sid machine-id)
     (registrar/unregister! :event machine-id)
-    ;; (7) Per Spec 005 §Final states §`:on-error` (rf2-5hlsh): when the child
+    ;; (7) Per Spec 005 §Final states §`:on-error`: when the child
     ;; finished via an ERROR leaf AND the spawning parent declares
     ;; `:spawn :on-error`, dispatch the synthetic reserved failure event into
     ;; the parent. It resolves natively through the parent's macrostep
@@ -548,15 +531,15 @@
     ;; internal vocabulary, not what the parent transition sees.
     (when on-error?
       (spawn-error/dispatch-spawn-error! frame-id parent-id invoke-id result))
-    ;; Machine snapshots are durable runtime-db state (EP-0001 rf2-vzld77):
+    ;; Machine snapshots are durable runtime-db state (EP-0001):
     ;; the finalize teardown is a runtime-db write, returned under
     ;; `:rf.db/runtime` (the framework-authority partition effect), NOT `:db`.
     {:rf.db/runtime db-after-destroy
-     ;; rf2-nahfm — append the destroy-time `:exit` cascade's fx to
+     ;; Append the destroy-time `:exit` cascade's fx to
      ;; the transition's fx vector so any `:exit`-emitted dispatches /
      ;; HTTP / etc. fire as part of the same epoch.
      ;;
-     ;; rf2-xw5t0y — also append the resource-lease release for this actor's
+     ;; Also append the resource-lease release for this actor's
      ;; `[:machine machine-id]` owner so the `:final?`-state auto-destroy
      ;; releases its leases too (the explicit-destroy / spawn-cascade /
      ;; frame-destroy paths release via `teardown-live-actor!`; finalize is the

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -11,7 +11,7 @@
        enforced by `:rf.machine/destroy` — leaf-to-root exit, side
        effects fire against the live snapshot).
     3. Abort that actor's in-flight `:rf.http/managed` requests
-       (preserves the rf2-wvkn `:http/abort-on-actor-destroy` contract
+       (the `:http/abort-on-actor-destroy` contract holds
        across every destroy trigger including frame destroy).
     4. Apply the unified app-db teardown projection — dissoc
        `[:rf.runtime/machines :snapshots <id>]`, release `[:rf.runtime/machines :system-ids <sid>]` when the
@@ -40,7 +40,7 @@
   runtime-db — the walker covers them as a stragglers pass after the
   recorded vector drains.
 
-  Per rf2-apfait — restore/hydration/full-runtime-db-replacement repopulate
+  Restore/hydration/full-runtime-db-replacement repopulate
   durable runtime-db snapshots WITHOUT repopulating the process-side
   spawn-order atom (the atom is transient bookkeeping, not durable state per
   Spec 002 §Durable vs transient). A restored SPAWNED actor's snapshot
@@ -48,8 +48,8 @@
   SINGLETON snapshot never carries it — actor_liveness_test:213). The
   straggler pass therefore SPLITS on that durable discriminator: spawned
   stragglers run the FULL `destroy/destroy-single-actor!` teardown (handler
-  unregister, schema-mark clear, system-id release, timer cancel, snapshot
-  dissoc) in reverse-creation order DERIVED from the durable actor-id (the
+  unregister, system-id release, timer cancel, snapshot dissoc) in
+  reverse-creation order DERIVED from the durable actor-id (the
   `#<n>` suffix), not the singleton straggler path that skips all of that.
   True singletons keep the exit-cascade-only straggler path."
   (:require [clojure.string :as str]
@@ -69,14 +69,14 @@
   RUNTIME-DB (a map of actor-id → snapshot), or an empty map. Read at the
   start of the walk so we have a stable view of which actors were live; the
   walk itself swaps the container and these reads are not re-evaluated.
-  EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state."
+  EP-0001: machine snapshots are durable runtime-db state."
   [frame-id]
   (let [container (frame/runtime-db-container frame-id)
         rt        (when container (adapter/read-container container))]
     (or (get-in rt (paths/snapshot-path)) {})))
 
 (defn- spawned-snapshot?
-  "Per rf2-apfait — true iff `snapshot` is a SPAWNED actor's snapshot, not
+  "True iff `snapshot` is a SPAWNED actor's snapshot, not
   a singleton's. The durable, app-db-derived discriminator is the presence
   of `:rf/machine-type` at the snapshot root: `install-spawn!` stamps it on
   every spawned actor (keyword TYPE or inline `:definition`), and a
@@ -89,7 +89,7 @@
   (some? (:rf/machine-type snapshot)))
 
 (defn- creation-rank
-  "Per rf2-apfait — derive a best-effort creation-order rank for a restored
+  "Derive a best-effort creation-order rank for a restored
   spawned `actor-id` whose process-side spawn-order entry was lost across
   restore/hydration. Spawned ids are allocated as `<type>#<n>` with a
   monotonic per-type counter (`allocate-actor-id-in-runtime-db`), so the
@@ -101,8 +101,7 @@
 
   Ordering the spawned-straggler walk by DESCENDING rank reconstructs the
   newest-first exit order Spec 005 §Cross-Spec Interactions §1 requires,
-  derived purely from durable runtime-db (per the bead's acceptance
-  criterion)."
+  derived purely from durable runtime-db."
   [actor-id]
   (let [s (name actor-id)
         i (str/last-index-of s "#")]
@@ -132,7 +131,7 @@
   [frame-id actor-id snapshot]
   (trace/emit! :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed
                {:frame      frame-id
-                ;; rf2-ws5thu — the reaped actor's live INSTANCE address;
+                ;; The reaped actor's live INSTANCE address;
                 ;; `:machine-id` is reserved for the registered TYPE.
                 :actor-id   actor-id
                 :last-state (:state snapshot)
@@ -150,13 +149,11 @@
   The HTTP-abort fires the shared `:http/abort-on-actor-destroy`
   late-bind hook via `finalize/abort-actor-in-flight-http!` — the same
   best-effort, idempotent helper the spawn-destroy + final-state
-  teardowns use, so the rf2-wvkn contract has one home.
+  teardowns use, so the abort contract has one home.
 
-  EP-0025 (rf2-398kql): this path formerly noted it deliberately did NOT clear
-  `:data-schema` marks (rf2-egvm4t). The whole machine `:data-schema`→marks
-  bridge is now removed (schema-field classification killed in favour of
-  frame-declared paths), so there are no schema marks for any teardown path —
-  singleton or spawned — to clear or preserve."
+  A machine's `:data-schema` is validation-only; it does not produce a
+  per-instance marks table. There are therefore no schema marks for any
+  teardown path — singleton or spawned — to clear or preserve."
   [frame-id actor-id]
   (exit-cascade/run-child-exit! frame-id actor-id)
   (finalize/abort-actor-in-flight-http! actor-id)
@@ -166,14 +163,14 @@
   "Run the full machine-cascade teardown for `frame-id`. Idempotent
   against double-invocation, fail-soft against missing artefacts.
 
-  Per rf2-vsigt + rf2-apfait the orchestration is:
+  The orchestration is:
    1. Snapshot `[:rf.runtime/machines :snapshots]` once.
    2. Build the disposal order in three segments:
       a. Recorded spawn-order reversed (newest first) — the live-process
          spawned actors, walked in true reverse-creation order.
       b. SPAWNED stragglers — snapshots that carry `:rf/machine-type` but
          are absent from the (transient) spawn-order atom. This is the
-         restore / hydration / `replace-runtime-db!` case (rf2-apfait):
+         restore / hydration / `replace-runtime-db!` case:
          durable runtime-db carries the snapshot, the transient atom does
          not. Walked newest-first by `creation-rank` derived from the
          durable `<type>#<n>` actor-id, so reverse-creation order is
@@ -188,7 +185,7 @@
          cascade D6.
       b. Spawned actors (recorded OR restored straggler): run the full
          single-actor destroy — exit-cascade → http-abort →
-         schema-mark clear → timer cancel → unified teardown projection →
+         timer cancel → unified teardown projection →
          system-id-release trace → handler-unregister → spawn-order forget.
       c. Singletons (registered via `reg-machine`, snapshot present but no
          `:rf/machine-type`): run the `:exit` cascade + HTTP abort, but
@@ -209,7 +206,7 @@
           ;; payloads, restored runtime-db, and test fixtures that seed
           ;; snapshots directly.
           stragglers   (remove recorded-set (keys snapshots))
-          ;; rf2-apfait — partition stragglers on the durable
+          ;; Partition stragglers on the durable
           ;; `:rf/machine-type` discriminator. Spawned stragglers (restore
           ;; / hydration / replace-runtime-db! repopulated the durable
           ;; snapshot but not the transient spawn-order atom) MUST get the
@@ -231,10 +228,9 @@
         (try (destroy/destroy-single-actor! frame-id actor-id)
              (catch #?(:clj Throwable :cljs :default) _ nil)))
       ;; (b') Restored spawned stragglers: SAME full destroy, newest-first
-      ;; by durable creation rank. rf2-apfait — before this fix these
-      ;; flowed through the singleton straggler path and skipped handler
-      ;; unregister / schema-mark clear / system-id release / timer cancel
-      ;; / snapshot dissoc.
+      ;; by durable creation rank. These get the complete spawned teardown
+      ;; (handler unregister / system-id release / timer cancel / snapshot
+      ;; dissoc), not the exit-only singleton straggler path.
       (doseq [actor-id spawned-stragglers']
         (let [snapshot (get snapshots actor-id)]
           (emit-lifecycle-destroyed! frame-id actor-id snapshot))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -13,7 +13,7 @@
    3. Verifies `<child-id>` (event[1]) is one of the parent's spawned
       children. Forged / unknown ids are rejected with the
       `:rf.error/machine-spawn-all-bad-child-id` error trace and a
-      no-op fx (the join state is NOT mutated). See rf2-ns8ut.
+      no-op fx (the join state is NOT mutated).
    4. Adds `<child-id>` to `:done` or `:failed`.
    5. If `:resolved?` is already true, the event is silently dropped
       (post-resolution late-completion).
@@ -63,18 +63,19 @@
   `{:invoke-id <prefix-path> :spec <invoke-all-spec> :kind :done|:failed}`
   matches (empty when none).
 
-  Per Spec 005 §Parallel regions (rf2-l67o): for parallel-region machines,
-  iterates each region's active state-tree (prefixing the region name onto the
+  Per Spec 005 §Parallel regions: for parallel-region machines, iterates
+  each region's active state-tree (prefixing the region name onto the
   resolved `:invoke-id`, matching the per-region scoping
   `prefix-region-invoke-id` applies on the entry-side). A flat machine has at
   most one active match.
 
-  Per rf2-w84jv: returns ALL matches (not the first via `some`) so the
-  interceptor can disambiguate by join-state child-id OWNERSHIP. Two active
-  parallel regions may legitimately reuse the SAME generic `:on-child-done`
-  event id (e.g. `:done`, `:asset/loaded`); the first-match-wins `some`
-  mis-routed a later region's child completion to the first region's join,
-  flagged it as a forged child-id, and hung the correct region's join."
+  Returns ALL matches (not just the first) so the interceptor can
+  disambiguate by join-state child-id OWNERSHIP. Two active parallel regions
+  may legitimately reuse the SAME generic `:on-child-done` event id (e.g.
+  `:done`, `:asset/loaded`); returning every match lets the interceptor
+  route a child completion to the region whose join actually owns the
+  child-id, rather than first-match-wins mis-routing it to another region's
+  join."
   [machine snapshot inner-event-id]
   (cond
     (parallel/parallel? machine)
@@ -122,8 +123,8 @@
       :else false)))
 
 (defn- join-unsatisfiable?
-  "Per rf2-ny0yrz C5: decide whether `spec`'s join condition can NEVER be
-  met by the remaining undecided children, given `join-state`'s current
+  "Decide whether `spec`'s join condition can NEVER be met by the remaining
+  undecided children, given `join-state`'s current
   `:done` / `:failed` folds. The footgun this guards: a `{:n N}` / `{:fn}`
   (or `:any` / `:all`) join with NO `:on-any-failed` silently hangs FOREVER
   once enough children have FAILED that the success condition is
@@ -207,8 +208,8 @@
      :join-event-kw    join-event-kw}))
 
 (defn- decisive-child-reply-facts
-  "rf2-d63qtp — build the reply-envelope facts for the DECISIVE child
-  completion that drove a `:spawn-all` join resolution, ready to ride
+  "Build the reply-envelope facts for the DECISIVE child completion that
+  drove a `:spawn-all` join resolution, ready to ride
   ADDITIVELY on the resolution trace (Managed-Effects §Tracing /
   §Status taxonomy). The decisive child's completion IS the managed-async
   completion that resolved the join, so it lowers through the shared
@@ -246,14 +247,14 @@
   "Fire the post-resolution observability traces in order: any-failed,
   all-completed, or some-completed.
 
-  Per rf2-ko8jb the `:frame` tag is REQUIRED for epoch-capture admission
+  The `:frame` tag is REQUIRED for epoch-capture admission
   (`re-frame.epoch.capture/capture-event!` silently drops events whose
   tags lack `:frame`). The caller threads `frame-id` (resolved from
   `(:rf/frame machine)` at the interceptor's entry) so the join
   resolution traces reach the cascade's `:trace-events` slot.
 
-  rf2-d63qtp — the DECISIVE child completion that drove the resolution
-  lowers through the shared `join-child-reply`; its reply-envelope facts
+  The DECISIVE child completion that drove the resolution lowers through
+  the shared `join-child-reply`; its reply-envelope facts
   (`:work/id`, `:rf.reply/status`, `:rf.reply/work-status`, the causal
   `:completed-at`) ride ADDITIVELY on the resolution trace, so the
   join-resolving child completion classifies the same way the
@@ -303,7 +304,7 @@
 
       [<parent-id> [<resolution-event> <decisive-child-id> & <child-extra>]]
 
-  Per rf2-ko8jb the `:frame` tag is REQUIRED for epoch-capture admission
+  The `:frame` tag is REQUIRED for epoch-capture admission
   (`re-frame.epoch.capture/capture-event!` silently drops events whose
   tags lack `:frame`). The caller threads `frame-id` (resolved from
   `(:rf/frame machine)` at the interceptor's entry) so the per-survivor
@@ -320,10 +321,10 @@
                                    (remove (fn [[cid _]]
                                              (contains? completed-ids cid))))]
             (doseq [[cid spawned-id] survivors]
-              ;; rf2-sfunt8 — a join-survivor cancellation closes the
-              ;; survivor's actor work attempt the reply-envelope way: a
-              ;; `:status :cancelled` reply (cancellation as DATA, Managed-
-              ;; Effects §Cancellation). The reply-envelope facts (`:work/id`
+              ;; A join-survivor cancellation closes the survivor's actor
+              ;; work attempt the reply-envelope way: a `:status :cancelled`
+              ;; reply (cancellation as DATA, Managed-Effects §Cancellation).
+              ;; The reply-envelope facts (`:work/id`
               ;; keyed on the survivor's spawned instance, `:rf.reply/status
               ;; :cancelled`, `:cancel/reason :on-join-resolution`) ride
               ;; ADDITIVELY so the survivor cancellation joins the same
@@ -367,7 +368,7 @@
     (vec (concat (or cancel-fx []) (or dispatch-fx [])))))
 
 (defn intercept-spawn-all-event
-  "Per Spec 005 §Child completion protocol (rf2-6vmw). When the parent's
+  "Per Spec 005 §Child completion protocol. When the parent's
   handler receives an event whose inner event-id matches the active
   `:spawn-all`-bearing state's `:on-child-done` / `:on-child-error`,
   the runtime updates the join state and (on resolution) cancels surviving
@@ -376,38 +377,35 @@
 
   Returns nil (NOT a child-event for any active `:spawn-all`) or a
   re-frame effect map with `:rf.db/runtime` (updated runtime-db — the join
-  state is durable machine runtime-db state, EP-0001 rf2-vzld77) and `:fx`
+  state is durable machine runtime-db state) and `:fx`
   (per-sibling destroys + the join-event dispatch). `runtime-db` is the
   frame's runtime-db partition value (the `:rf.db/runtime` coeffect)."
   [machine runtime-db _path snapshot parent-id inner-event]
   (let [inner-id (first inner-event)
         child-id (second inner-event)
         matches  (find-active-spawn-alls machine snapshot inner-id)
-        ;; Per rf2-w84jv: when more than one active spawn-all matches the
-        ;; event id (two parallel regions reusing the SAME `:on-child-done`),
-        ;; route to the join whose LIVE join-state `:children` OWNS the
-        ;; arriving child-id — ownership, not declaration order, decides. The
-        ;; first-match `some` mis-routed a later region's completion to the
-        ;; first region's join, flagged it as forged, and hung the correct
-        ;; region. The owning match is preferred; if none owns the child
-        ;; (genuinely forged), fall back to the first match so the
-        ;; bad-child-id error trace still fires against a real join.
+        ;; When more than one active spawn-all matches the event id (two
+        ;; parallel regions reusing the SAME `:on-child-done`), route to the
+        ;; join whose LIVE join-state `:children` OWNS the arriving child-id —
+        ;; ownership, not declaration order, decides. The owning match is
+        ;; preferred; if none owns the child (genuinely forged), fall back to
+        ;; the first match so the bad-child-id error trace still fires against
+        ;; a real join.
         owns?    (fn [{invoke-id :invoke-id}]
                    (let [js (get-in runtime-db (paths/spawned-path parent-id invoke-id))]
                      (and (map? js) (contains? (:children js) child-id))))
         match    (or (some #(when (owns? %) %) matches)
                      (first matches))
-        ;; Per rf2-ko8jb: resolve the live frame from the runtime-stamped
-        ;; machine (registration.cljc/prepare-machine-ctx assoc'd
-        ;; `:rf/frame` before handing the machine to the interceptor).
-        ;; Threaded into `emit-resolution-traces!` / `build-resolution-fx`
-        ;; AND used inline for the late-completion + bad-child-id error
-        ;; traces — all of these are dropped by epoch-capture without
-        ;; `:frame`.
+        ;; Resolve the live frame from the runtime-stamped machine
+        ;; (registration.cljc/prepare-machine-ctx assoc'd `:rf/frame` before
+        ;; handing the machine to the interceptor). Threaded into
+        ;; `emit-resolution-traces!` / `build-resolution-fx` AND used inline
+        ;; for the late-completion + bad-child-id error traces — all of these
+        ;; are dropped by epoch-capture without `:frame`.
         frame-id (:rf/frame machine)
-        ;; rf2-d63qtp — the CAUSAL completion timestamp of the child's
-        ;; finishing dispatch (the router-stamped `:rf/time-ms` off the
-        ;; machine def's `:rf.cofx`, threaded by prepare-machine-ctx). Rides
+        ;; The CAUSAL completion timestamp of the child's finishing dispatch
+        ;; (the router-stamped `:rf/time-ms` off the machine def's
+        ;; `:rf.cofx`, threaded by prepare-machine-ctx). Rides
         ;; the reply-envelope join-child / late-completion facts the same way
         ;; the single-`:spawn` `:rf.machine/done` reply carries it
         ;; (Managed-Effects §Causal completion metadata). nil for a pure-fn /
@@ -438,9 +436,9 @@
           ;; Already resolved: ignore late-completion. Trace once for
           ;; observability so tools can correlate.
           ;;
-          ;; rf2-d63qtp — the post-resolution late completion is a STALE
-          ;; suppression the reply-envelope way (Managed-Effects §Stale
-          ;; suppression): the join is latched `:resolved?`, so the late
+          ;; The post-resolution late completion is a STALE suppression the
+          ;; reply-envelope way (Managed-Effects §Stale suppression): the
+          ;; join is latched `:resolved?`, so the late
           ;; child fold MUST NOT mutate it (no app effect) — exactly the
           ;; §Stale suppression contract. Build the canonical
           ;; `stale-join-child-reply` (`:status :stale` / `:work/status
@@ -489,7 +487,7 @@
           ;; collapsing the join early. Gate it: emit a structured error
           ;; trace and short-circuit with a no-op fx (do NOT mutate the
           ;; join state). Per Spec 005 §Spawn-and-join and the machines
-          ;; security-audit finding F1 (rf2-ns8ut / rf2-s9tf8).
+          ;; security-audit finding F1.
           (not (contains? (:children join-state) child-id))
           (do (trace/emit-error! :rf.error/machine-spawn-all-bad-child-id
                                  {:actor-id parent-id
@@ -509,7 +507,7 @@
                               :failed (update join-state :failed (fnil conj #{}) child-id))
                 resolution   (compute-resolution spec join-state' kind)
                 join-state'' (assoc join-state' :resolved? (:resolved? resolution))]
-            ;; rf2-ny0yrz C5 — surface a join that just became UNSATISFIABLE.
+            ;; Surface a join that just became UNSATISFIABLE.
             ;; When a child FAILS and the spec has no `:on-any-failed`, the
             ;; failure folds into `:failed` without resolving; once enough
             ;; children have failed that the success condition is unreachable

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -2,7 +2,7 @@
   "Registration boundary: handler factory + `reg-machine*`.
 
   `make-machine-handler` is the `reg-event` handler factory beneath the
-  `reg-machine` macro (EP-0018 one-event surface — a single
+  `reg-machine` macro (one-event surface — a single
   `(cofx, event) -> effects-map-or-nil` handler, no `reg-event-fx` /
   `reg-event-db` split); `reg-machine*` is the plain-fn surface used by
   the late-bind table and by REPL workflows. The factory decomposes
@@ -12,7 +12,7 @@
       `re-frame.machines.lifecycle-fx.validation`: parallel shape,
       `:spawn-all` shape, dropped `:timeout-ms` slots, guard/action
       ref resolution, final-state shape).
-    - `parallel/build-initial-snapshot` (rf2-fgqs4) — initial-state
+    - `parallel/build-initial-snapshot` — initial-state
       cascade, `:data` / `:meta` / `:rf/spawn-counter` seeding, tag union
       stamping (lazily, on first event). Single source of truth shared
       with the spawn path.
@@ -40,7 +40,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- single-registration-home flag (rf2-genufr) ---------------------------
+;; ---- single-registration-home flag ----------------------------------------
 ;;
 ;; A machine that carries a `:data-schema` MUST flow through the single
 ;; registration home so the `:rf/machine?` / `:rf/machine` registration-
@@ -49,7 +49,7 @@
 ;; schema validates NOTHING.
 ;;
 ;; `register-machine-event!` below is the SINGLE HOME that stamps it (it is the
-;; body of `reg-machine*` AND the new event-`:schema` arity). The bare
+;; body of `reg-machine*` AND the event-`:schema` arity). The bare
 ;; `(reg-event id meta (make-machine-handler spec))` direct path does NOT stamp
 ;; it — which is exactly how a `:data-schema` could go silently inert. So
 ;; `make-machine-handler` FAILS LOUD when it is handed a `:data-schema`-bearing
@@ -61,10 +61,10 @@
 ;; so the bare direct path stays legal for it (the Story testbed / schema-free
 ;; examples rely on it).
 ;;
-;; EP-0025 (rf2-398kql): the home formerly ran a SECOND `:data-schema` side-
-;; effect — `register-data-schema-marks!`, the schema→marks redaction bridge.
-;; That bridge is REMOVED (schema-field classification killed in favour of
-;; frame-declared paths), so the home now runs only the validation-stamp.
+;; The home runs exactly one `:data-schema` side-effect: the validation-stamp.
+;; A machine's `:data-schema` is VALIDATION-ONLY — per-slot props do not
+;; classify durable `:data` for snapshot egress. Frame-declared `:sensitive` /
+;; `:large {:app-db …}` paths are the sole app-db data-classification mechanism.
 (def ^:dynamic *in-registration-home?*
   "True while `make-machine-handler` is invoked from a registration site that
   ALSO stamps the `:rf/machine?` / `:rf/machine` meta (the single home, or the
@@ -73,20 +73,19 @@
   — fail loud (the schema would validate nothing)."
   false)
 
-;; The reserved creation marker `:rf.machine/start` (renamed from
-;; `:rf.machine/bootstrap` — rf2-gl588, pre-alpha no shim) is defined once in
+;; The reserved creation marker is `:rf.machine/start`. It is defined once in
 ;; the leaf engine namespace as `transition/start-marker` so the handler here
 ;; and the cascade in `parallel` share one source of truth without a require
-;; cycle. Per F‴ it is a PURE init-kick: `maybe-boot` runs the initial-entry
+;; cycle. It is a PURE init-kick: `maybe-boot` runs the initial-entry
 ;; cascade, then the handler STOPS — the marker is NEVER fed into `run-step`
 ;; as a trigger (no `before == after` self-transition, no `:*`-wildcard throw).
 
-;; Per rf2-fgqs4 the initial-snapshot builder lives in `parallel.cljc` as
+;; The initial-snapshot builder lives in `parallel.cljc` as
 ;; `build-initial-snapshot` — single source of truth for both the
 ;; singleton-registration path (here) and the spawn path
-;; (`lifecycle-fx.spawn/install-spawn!`). The two used to drift: the spawn
-;; path silently omitted `:rf/spawn-counter` and `:meta`. See
-;; `parallel/build-initial-snapshot` for the canonical 6-step shape.
+;; (`lifecycle-fx.spawn/install-spawn!`), so both seed `:rf/spawn-counter` and
+;; `:meta` identically. See `parallel/build-initial-snapshot` for the canonical
+;; 6-step shape.
 
 ;; ---- handler factory ------------------------------------------------------
 
@@ -114,24 +113,24 @@
   "Emit `:rf.error/machine-action-exception` for a `result/fail` Result's
   `::result/info` map. Returns `{}` so the handler short-circuits.
 
-  Per rf2-zsm03 (privacy — AI/MCP egress + logs threat model): the
+  Privacy (AI/MCP egress + logs threat model): the
   `:event` slot is redacted by the marks projection's `project-event-tags`
   and `:before`/`:after`/`:snapshot` by `project-machine-tags`, but the
   `:exception-data` slot below carries the thrown action's `ex-data` — the
   developer's arbitrary exception payload, which could embed the same app
   secrets the machine's `:data` marks gate. That slot is path-elided at the
-  trace egress chokepoint by `re-frame.marks/project-machine-error-tags`
-  (a NEW projection clause): when the machine declares ANY `:sensitive`
+  trace egress chokepoint by `re-frame.marks/project-machine-error-tags`:
+  when the machine declares ANY `:sensitive`
   mark the whole `:exception-data` slot scrubs to `:rf/redacted` before the
   trace crosses the bus / epoch-capture / AI-MCP boundary or a log sink —
-  the same egress seam (the marks projection) the rf2-o69h5 class sweep
-  routed the core validation-failure class through. The redaction lives at
+  the same egress seam (the marks projection) the core validation-failure
+  class routes through. The redaction lives at
   the chokepoint (not here) so it covers EVERY consumer of the trace
   uniformly and stays the single place the `:sensitive` decision is made.
 
-  Per Spec 005 §Final states §`:on-error` (rf2-5hlsh; XState v5 invoke
-  `onError`): an uncaught child action exception is the SECOND `:on-error`
-  trigger (the control-flow case — formerly observability-only). When the
+  Per Spec 005 §Final states §`:on-error` (XState v5 invoke
+  `onError`): an uncaught child action exception is a control-flow `:on-error`
+  trigger in addition to the observability trace. When the
   THROWING actor is a `:spawn`-spawned child whose spawning parent declares
   `:spawn :on-error`, route the failure to the parent's declarative
   `:on-error` transition via `spawn-error/dispatch-spawn-error!` — additive to
@@ -140,7 +139,7 @@
   `:data` was stamped with `:rf/parent-id` / `:rf/invoke-id` at spawn time);
   the exception envelope rides as the parent transition's `:event` payload so
   a guard / action can branch on it. Singletons (no parent) and parents that
-  declare no `:on-error` route nowhere — the trace IS the signal, unchanged."
+  declare no `:on-error` route nowhere — the trace IS the signal."
   [ctx event reason info]
   (let [{:keys [machine-id frame-id runtime-db snapshot]} ctx
         ex         (:exception info)
@@ -149,7 +148,7 @@
         ex-data    (when ex (ex-data ex))
         action-ref (:action-ref info)]
     (trace/emit-error! :rf.error/machine-action-exception
-                       ;; rf2-yyvtk5 — the throwing action ran in a LIVE
+                       ;; The throwing action ran in a LIVE
                        ;; actor's transition; `machine-id` here is the
                        ;; event-handler key (the running INSTANCE address —
                        ;; a singleton's registration id, or a spawned
@@ -170,7 +169,7 @@
                         :exception-data    ex-data
                         :reason            reason
                         :recovery          :no-recovery})
-    ;; (rf2-5hlsh) — additive control-flow routing. Read the spawning
+    ;; Additive control-flow routing. Read the spawning
     ;; parent / invoke-id off the child's stamped `:data`; if the parent
     ;; declares `:spawn :on-error`, dispatch the failure into it. The error
     ;; payload carries the exception envelope so the parent transition's
@@ -182,7 +181,7 @@
         (spawn-error/dispatch-spawn-error!
           frame-id parent-id invoke-id
           {:rf.error/id       :rf.error/machine-action-exception
-           ;; rf2-yyvtk5 — the failing child is a LIVE actor INSTANCE.
+           ;; The failing child is a LIVE actor INSTANCE.
            :actor-id          machine-id
            :action-id         action-ref
            :event             event
@@ -196,7 +195,7 @@
   (atomic rollback — no snapshot write reaches runtime-db) per Spec 005
   §Bounded depth / §Final states §`:on-error`.
 
-  rf2-y3jv8q — a bounded-depth abort (`:always` / `:raise` depth limit
+  A bounded-depth abort (`:always` / `:raise` depth limit
   tripped on a runaway cycle, the XState-v5-throws case) is a DISTINCT
   failure from a thrown action: the engine already emitted the precise
   `:rf.error/machine-{always,raise}-depth-exceeded` category at the abort
@@ -214,7 +213,7 @@
     {}
     (trace-action-failure! ctx event reason (result/info r))))
 
-;; ---- 4-step pipeline (rf2-2zzyg) ------------------------------------------
+;; ---- 4-step pipeline ------------------------------------------------------
 ;;
 ;; The handler-fn returned by `make-machine-handler` decomposes into four
 ;; named pure-fn steps, each ≤ 30 LoC, that read onto Spec 005 §Drain
@@ -237,7 +236,7 @@
 ;; branch in `make-machine-handler` itself — it must short-circuit before
 ;; boot / step / commit run.
 
-;; ---- snapshot/definition compatibility (rf2-fasdp) ------------------------
+;; ---- snapshot/definition compatibility ------------------------------------
 ;;
 ;; Per Spec 005 §Snapshot shape stability invariants 3 & 4:
 ;;
@@ -256,13 +255,11 @@
 ;; with the snapshot — restoring an incompatible snapshot means
 ;; restarting the machine, not patching it.
 ;;
-;; Per rf2-fasdp this closes the audit-confirmed drift: the prior code
-;; only distinguished "no snapshot" from "snapshot present", without
-;; verifying the snapshot's state still exists in the (possibly
-;; hot-reloaded) definition or that the version stamps agree. Both
-;; failures previously kept driving the incompatible snapshot through
-;; the transition engine, where they surfaced as cryptic downstream
-;; errors instead of the spec's named warnings + fallback behaviour.
+;; The reconciler verifies the snapshot's state still exists in the (possibly
+;; hot-reloaded) definition AND that the version stamps agree before driving
+;; it through the transition engine — so a vanished state or a version bump
+;; surfaces as the spec's named warning + fallback behaviour rather than a
+;; cryptic downstream error from an incompatible snapshot.
 
 (defn- state-resolves?
   "True iff the snapshot's `:state` (flat keyword / compound vector
@@ -275,10 +272,9 @@
   For PARALLEL machines this requires EXACTLY the declared region key set
   (no missing region, no extra/stale region) AND every region's path to
   resolve to a real non-history leaf — `parallel/parallel-state-valid?`
-  (bz0ox.2 / x4s9t.2). The prior check validated only the regions PRESENT in
-  the snapshot, so a partial map like `{:left :done}` for a 2-region machine
-  validated, then silently ran a partial configuration that could vacuously
-  fire root `:on-done` / auto-destroy.
+  (bz0ox.2 / x4s9t.2). A partial map like `{:left :done}` for a 2-region
+  machine fails to resolve, so it can never run a partial configuration that
+  vacuously fires root `:on-done` / auto-destroy.
 
   For FLAT / COMPOUND machines the path must resolve to a real, OCCUPIABLE
   leaf — `transition/state-occupiable?` rejects both a missing state AND a
@@ -333,8 +329,7 @@
 (defn- reconcile-snapshot
   "Apply the Spec 005 §Snapshot shape stability invariants 3 & 4 at
   handler-entry. Returns the (possibly replaced) snapshot — the caller
-  uses it as the basis for `needs-bootstrap?` / the transition. Per
-  rf2-fasdp.
+  uses it as the basis for `needs-bootstrap?` / the transition.
 
   Version check runs FIRST (an explicit version bump is a stronger
   signal than an opportunistic state-vanished detection — if the
@@ -355,15 +350,15 @@
     :else existing-snap))
 
 (defn- prepare-machine-ctx
-  "Step 1 of 4 (rf2-2zzyg). Stamp the live frame / platform / parent-id
+  "Step 1 of 4. Stamp the live frame / platform / parent-id
   onto the machine def, look up the existing snapshot at
   `[:rf.runtime/machines :snapshots <machine-id>]` in the **runtime-db**
-  partition (machine snapshots are durable runtime-db state — EP-0001
-  rf2-vzld77), decide `needs-bootstrap?`, route the inner event. Returns a
+  partition (machine snapshots are durable runtime-db state),
+  decide `needs-bootstrap?`, route the inner event. Returns a
   `ctx` map the remaining three steps read. `runtime-db` is the
   `:rf.db/runtime` coeffect the router injected by reference.
 
-  Per rf2-0z73: detect 'first event for this machine' so the initial
+  Detect 'first event for this machine' so the initial
   state's `:entry` actions fire as part of bringing the machine to life.
   Two flavours:
     - Singleton path: `(get-in runtime-db path)` is `nil` — the snapshot is
@@ -373,7 +368,7 @@
       `:rf/bootstrap-pending? true` so the actor's first dispatch sees
       the marker and runs the cascade before processing the event.
 
-  Per rf2-fasdp: when an existing snapshot is found, run the Spec 005
+  When an existing snapshot is found, run the Spec 005
   §Snapshot shape stability invariants 3 & 4 reconciler before
   threading it onward — a hot-reload that dropped a state, or a
   `:rf/snapshot-version` bump, replaces the snapshot with a fresh
@@ -382,7 +377,7 @@
   `:rf.error/machine-state-not-in-definition` or
   `:rf.error/machine-snapshot-version-mismatch` event.
 
-  Per EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): the event handler's causal
+  The event handler's causal
   recordable-coeffect token (`cofx` — the router's `:rf.cofx` coeffect, Spec
   002 §Event Context And Coeffects) is stamped onto the machine def under
   `:rf/cofx` alongside `:rf/frame` / `:rf/platform` / `:rf/parent-id`,
@@ -396,7 +391,7 @@
   (conformance corpus) are unaffected."
   [db runtime-db frame cofx mint-policy event machine base-initial]
   (let [machine-id    (first event)
-        ;; EP-0002 — `frame` is the cascade-threaded envelope frame the
+        ;; `frame` is the cascade-threaded envelope frame the
         ;; calling machine handler already asserted via
         ;; `require-frame-stamp!`; no `:rf/default` repair here.
         frame-id      frame
@@ -405,13 +400,12 @@
                                      :rf/frame     frame-id
                                      :rf/platform  platform
                                      :rf/parent-id machine-id)
-                        ;; EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): thread
-                        ;; the causal recordable-coeffect token onto the machine
-                        ;; def so `callback-ctx` exposes it as `:rf.cofx`. Stamp
-                        ;; only when present so the absent-token path stays clean
-                        ;; for pure-fn callers.
+                        ;; Thread the causal recordable-coeffect token onto the
+                        ;; machine def so `callback-ctx` exposes it as `:rf.cofx`.
+                        ;; Stamp only when present so the absent-token path stays
+                        ;; clean for pure-fn callers.
                         (some? cofx) (assoc :rf/cofx cofx)
-                        ;; rf2-n0myjq — thread the resolved effective cofx MINT
+                        ;; Thread the resolved effective cofx MINT
                         ;; POLICY (per-call opt ▸ frame config ▸ `:live`, the
                         ;; router stamped it as the `:rf.cofx/mint-policy`
                         ;; framework coeffect) onto the machine def under the
@@ -420,8 +414,8 @@
                         ;; replay/`:test` machine refuses to mint a declared-
                         ;; absent generator-backed guard/action fact (surfacing
                         ;; missing-required) instead of always defaulting to
-                        ;; `:live`; the in-engine raised-event ensure (rf2-xsdn5h)
-                        ;; reads the SAME stamped policy. Stamped only alongside a
+                        ;; `:live`; the in-engine raised-event ensure reads the
+                        ;; SAME stamped policy. Stamped only alongside a
                         ;; threaded token so pure-fn callers stay untouched.
                         (some? cofx) (assoc :rf/cofx-mint-policy
                                             (or mint-policy cofx/default-mint-policy)))
@@ -443,7 +437,7 @@
      :snapshot         snapshot
      ;; `:existing-snap?` records whether the handler found a snapshot
      ;; ALREADY in runtime-db at entry. It distinguishes the two FRESH
-     ;; flavours for the `:rf.machine/started` `:cause` (rf2-gl588):
+     ;; flavours for the `:rf.machine/started` `:cause`:
      ;;   - nil snapshot  → singleton (`:explicit` / `:lazy`, by trigger);
      ;;   - present + `:rf/bootstrap-pending?` → spawn-pre-seeded (`:spawned`).
      :existing-snap?   (some? existing-snap)
@@ -453,7 +447,7 @@
 
 (defn- start-cause
   "Compute the `:rf.machine.start/cause` enum for a `maybe-boot` that ran
-  the initial-entry cascade (rf2-gl588). Three-way, per Mike 2026-06-03:
+  the initial-entry cascade. Three-way:
 
     - `:spawned`  — the handler found a snapshot ALREADY in runtime-db (the
                     spawn fx pre-seeded it + stamped `:rf/bootstrap-pending?`);
@@ -465,7 +459,7 @@
                     a REAL first event — init folded into that event's epoch.
                     The `:lazy` cause flags that something dispatched to the
                     machine before it was explicitly started (an ordering
-                    smell the Xray `[START]` badge surfaces — rf2-it4vt)."
+                    smell the Xray `[START]` badge surfaces)."
   [ctx]
   (cond
     (:existing-snap? ctx)                                  :spawned
@@ -473,7 +467,7 @@
     :else                                                  :lazy))
 
 (defn- ensure-bootstrap-cofx
-  "Per EP-0017 slice-B.9 (rf2-knxbok) — the BIRTH-time consumer-attachment
+  "The BIRTH-time consumer-attachment
   ensure step, run BEFORE `maybe-boot`. The bootstrap cascade
   (`apply-initial-entry-cascade`, inside `maybe-boot`) fires the initial-state
   descent's `:entry` actions and the birth `:always` settle, so a named `:entry`
@@ -492,7 +486,7 @@
     (if-not (and (:needs-bootstrap? ctx) (contains? machine :rf/cofx))
       ctx
       (let [recorded  (:rf/cofx machine)
-            ;; rf2-n0myjq — ensure under the resolved effective mint policy the
+            ;; Ensure under the resolved effective mint policy the
             ;; router stamped (`:rf/cofx-mint-policy`), so a `:strict` replay /
             ;; `:test` birth refuses to mint a declared-absent generator-backed
             ;; `:entry` / birth-`:always` fact (surfacing missing-required).
@@ -504,21 +498,20 @@
           (assoc ctx :machine (assoc machine :rf/cofx augmented)))))))
 
 (defn- maybe-boot
-  "Step 2 of 4 (rf2-2zzyg). If `ctx` is bootstrap-pending, run
+  "Step 2 of 4. If `ctx` is bootstrap-pending, run
   `apply-initial-entry-cascade` once before processing the user event.
   Bootstrap fx flow OUT of the handler ahead of any fx the user event
   produces — entry happens-before user-event handling. Returns a Result
   whose `::snap` has `:rf/bootstrap-pending?` cleared on success.
 
-  Per rf2-0z73 the bootstrap cascade fires the initial state's `:entry`
-  actions; per the Result ADT (rf2-aa2rw) a `:fail` short-circuits the
-  rest of the pipeline.
+  The bootstrap cascade fires the initial state's `:entry`
+  actions; a Result `:fail` short-circuits the rest of the pipeline.
 
-  Per rf2-gl588 this is the machine's SINGLE birth site — it runs in both
+  This is the machine's SINGLE birth site — it runs in both
   axis-A paths (eager `:rf.machine/start` kick AND lazy first-real-event).
   So whenever the cascade succeeds it emits ONE `:rf.machine/started`
   trace carrying `{:machine-id :frame-id :state :data :cause}` — the
-  signal Xray renders as the `[START]` badge (rf2-it4vt) in BOTH paths
+  signal Xray renders as the `[START]` badge in BOTH paths
   automatically. The trace is emitted only on success (a thrown `:entry`
   action short-circuits to `:fail` → `trace-action-failure!` instead).
   Restoration paths (SSR / `restore-epoch!` / `replace-app-db`) install a
@@ -537,7 +530,7 @@
                           :state      (:state booted)
                           :data       (:data booted)
                           :cause      (start-cause ctx)})
-            ;; Per rf2-n9f4z: preserve the bootstrap-entry `::cascade` so
+            ;; Preserve the bootstrap-entry `::cascade` so
             ;; `commit-or-finalize` can prepend the initial-descent `:entry`
             ;; steps when bootstrap and the user event land in the same call.
             (result/with-cascade
@@ -546,7 +539,7 @@
     (result/ok (:snapshot ctx) [])))
 
 (defn- run-step
-  "Step 3 of 4 (rf2-2zzyg). Run the pure macrostep against the post-boot
+  "Step 3 of 4. Run the pure macrostep against the post-boot
   snapshot + the routed inner event. Returns the Result from
   `parallel/machine-transition` — caller inspects `result/fail?` /
   `result/ok?` and projects accordingly."
@@ -554,7 +547,7 @@
   (parallel/machine-transition (:machine ctx) post-boot-snap (:inner-event ctx)))
 
 (defn- ensure-ctx-cofx
-  "Per EP-0017 slice-B.9 (rf2-mjmxgb) — the dispatch-time consumer-attachment
+  "The dispatch-time consumer-attachment
   ensure step, run between `maybe-boot` and `run-step`. Computes the derived
   per-(state × event-type) ensure-set for the POST-BOOT snapshot's active
   state + the routed inner event (`cofx-attach/ensure-set-for`, incl. the
@@ -567,11 +560,11 @@
   was threaded (`:rf/cofx` absent — pure-fn / no-router callers), or when the
   ensure-set is empty — `ctx` is returned unchanged in all three.
 
-  Ensuring runs under the default `:live` mint policy (the router default);
-  the `:strict` binding points for replay / the `:test` preset are slice-B.8's
-  surface. A provided fact absent from the record is `:rf.error/missing-
-  required-cofx`; a schema-invalid value is `:rf.error/cofx-value-invalid`
-  (both production hard errors, propagated by `deliver-declared-cofx`)."
+  Ensuring runs under the resolved effective mint policy the router stamped
+  (`:rf/cofx-mint-policy`). A provided fact absent from the record is
+  `:rf.error/missing-required-cofx`; a schema-invalid value is
+  `:rf.error/cofx-value-invalid` (both production hard errors, propagated by
+  `deliver-declared-cofx`)."
   [ctx post-boot-snap]
   (let [machine (:machine ctx)]
     ;; Only run when a causal token was threaded (the normal dispatch path
@@ -580,7 +573,7 @@
     (if-not (contains? machine :rf/cofx)
       ctx
       (let [recorded  (:rf/cofx machine)
-            ;; rf2-n0myjq — ensure under the resolved effective mint policy the
+            ;; Ensure under the resolved effective mint policy the
             ;; router stamped (`:rf/cofx-mint-policy`); `:strict` replay / `:test`
             ;; refuses to mint a declared-absent generator-backed guard/action
             ;; fact (surfacing missing-required) rather than defaulting `:live`.
@@ -593,12 +586,12 @@
           (assoc ctx :machine (assoc machine :rf/cofx augmented)))))))
 
 (defn- commit-or-finalize
-  "Step 4 of 4 (rf2-2zzyg). Emit `:rf.machine/transition` (and optional
+  "Step 4 of 4. Emit `:rf.machine/transition` (and optional
   `:rf.machine/snapshot-updated`) traces, build the new app-db, and
   route to `finalize-machine` if the post-transition snapshot is on a
   final leaf / all regions final.
 
-  Per Spec 005 §Final states (rf2-gn80): the finality flag is recomputed
+  Per Spec 005 §Final states: the finality flag is recomputed
   at the lifecycle-handler boundary against the post-transition
   snapshot. For single / compound machines, look up the leaf node and
   check `:final?`. For parallel-region machines, the parent is `:final?`
@@ -609,7 +602,7 @@
     (let [{:keys [machine machine-id frame-id runtime-db path snapshot inner-event]} ctx
           boot-fx   (result/fx boot-result)
           merged-fx (vec (concat boot-fx fx))
-          ;; Per rf2-n9f4z: when this handler call both bootstrapped the
+          ;; When this handler call both bootstrapped the
           ;; machine AND processed a user event, the `:before`/`:after`
           ;; slots span both — so the cascade prepends the bootstrap entry
           ;; cascade (the initial-descent `:entry` steps) ahead of the
@@ -617,12 +610,12 @@
           ;; A no-bootstrap call's `boot-result` carries an empty cascade.
           cascade   (into (vec (result/cascade boot-result))
                           (result/cascade step-result))
-          ;; Per rf2-coozg: a genuine no-op macrostep emits NO
+          ;; A genuine no-op macrostep emits NO
           ;; `:rf.machine/transition`. An unhandled / guard-blocked event
           ;; already signals the benign `:rf.machine.event/unhandled-no-op`
           ;; (the engine's `:else` branch + the parallel aggregate); a
           ;; redundant `[:rf.machine/start]` on an already-booted machine
-          ;; is the reserved-`:rf/*` carve-out (rf2-t4582) that emits
+          ;; is the reserved-`:rf/*` carve-out that emits
           ;; nothing at all. In BOTH cases the macrostep changed
           ;; nothing — `:before` == `:after`, the combined (boot + step)
           ;; cascade is empty, and zero `:always` microsteps ran — so a
@@ -630,11 +623,9 @@
           ;; `:cascade []`) adds no information and CONTRADICTS the no-op
           ;; signal (it borrows external-self-transition `{X}→{X}`
           ;; vocabulary that implies the `:exit`/`:entry` firing that did
-          ;; NOT happen — rf2-e6q97). Suppressing it makes the no-op
+          ;; NOT happen). Suppressing it makes the no-op
           ;; SINGLE-signalled + consistent across unhandled / blocked /
-          ;; redundant-bootstrap, and lets the Xray projection's
-          ;; `drop-spurious-no-op-transition` band-aid wither (nothing to
-          ;; drop once the row is never emitted).
+          ;; redundant-bootstrap.
           ;;
           ;; The legitimate FIRST bootstrap (`:initial-entry`) is NOT a
           ;; no-op: it installs the initial state via a non-empty
@@ -645,8 +636,8 @@
           no-op?    (and (= snapshot next-snapshot)
                          (empty? cascade)
                          (zero? (result/microsteps step-result)))
-          ;; Per Spec 005 §Final states §Embedded vs top-level (rf2-bnjb3 /
-          ;; rf2-zlmz7) — the D7 reconciliation. Whole-machine finality (route
+          ;; Per Spec 005 §Final states §Embedded vs top-level — the D7
+          ;; reconciliation. Whole-machine finality (route
           ;; to `finalize-machine`: singleton auto-destroy / spawning parent's
           ;; `:spawn :on-done`) is gated on:
           ;;   - flat / compound: a `:final?` leaf that is a DIRECT CHILD of
@@ -663,18 +654,18 @@
           ;;     the one that fired it. Gating on `(nil? :on-done)` (not on the
           ;;     per-macrostep `parallel-done-handled?` edge flag) keeps a
           ;;     resting all-final machine alive on every subsequent no-op event
-          ;;     too — `:on-done` fires once on entry (h3wca.1 edge guard) yet
+          ;;     too — `:on-done` fires once on entry (the edge guard) yet
           ;;     the machine must not tear down on the later resting macrosteps
           ;;     where the flag is (correctly) absent.
           finished? (or (and (not (parallel/parallel? machine))
                              (transition/top-level-final? machine (:state next-snapshot)))
                         (and (finalize/all-regions-final? machine (:state next-snapshot))
                              (nil? (:on-done machine))))
-          ;; Machine snapshots are durable runtime-db state (rf2-vzld77):
+          ;; Machine snapshots are durable runtime-db state:
           ;; write the new snapshot into the runtime-db partition value;
           ;; the handler returns it under `:rf.db/runtime`, NOT `:db`.
           new-runtime-db (assoc-in runtime-db path next-snapshot)]
-      ;; Per rf2-hwuki: `:frame` tag is REQUIRED for epoch-capture
+      ;; The `:frame` tag is REQUIRED for epoch-capture
       ;; admission (`re-frame.epoch.capture/capture-event!` silently
       ;; drops trace events whose tags lack `:frame`). Without this
       ;; tag the headline machine-transition trace never reaches the
@@ -686,22 +677,21 @@
       ;; The per-microstep `:rf.machine.microstep/transition` stream is
       ;; emitted inside the engine; this is the macrostep-level rollup.
       ;;
-      ;; Per rf2-n9f4z the trace ALSO carries `:cascade` — the structured,
+      ;; The trace ALSO carries `:cascade` — the structured,
       ;; ordered step vector explaining HOW the transition reached its
       ;; after-state: exit (deepest-first) → transition `:action` @ LCA →
       ;; entry (shallowest-first + initial-descent), each step with its
       ;; `:kind` / `:state` / `:region` / `:action` / `:data-delta`, plus a
       ;; `:microstep` step (carrying nested `:steps`) per `:always`
-      ;; iteration, with per-region structure for parallel machines. This
-      ;; replaces the need for app-level `:data :trail` workarounds and is
-      ;; the contract Xray's epoch panel renders (rf2-52u5n). It rides under
+      ;; iteration, with per-region structure for parallel machines. This is
+      ;; the contract Xray's epoch panel renders. It rides under
       ;; the same handler-scope `:sensitive?` stamp as `:before` / `:after`
       ;; (per Spec 005 §Privacy), so a sensitive machine's cascade
       ;; `:data-delta`s are scrubbed at egress alongside the snapshot slots.
       (when-not no-op?
         (trace/emit! :rf.machine :rf.machine/transition
                      {:frame      frame-id
-                      ;; rf2-ws5thu — the LIVE actor instance address (the
+                      ;; The LIVE actor instance address (the
                       ;; event-handler key: a singleton's registration id, or
                       ;; a spawned actor's `<type>#<n>` / fixed instance id).
                       ;; Reserved `:machine-id` names the registered TYPE only.
@@ -732,22 +722,22 @@
   registration's event-id, derived at handler-call time from the
   dispatched event vector's first element.
 
-  Per rf2-f9tu the body is decomposed into:
+  The body is decomposed into:
     - `validation/validate-machine!` — every registration-time check.
     - `parallel/build-initial-snapshot` — initial-state cascade, `:data` /
       `:meta` seeding, `:rf/spawn-counter` seeding, tag union stamping
-      (rf2-fgqs4 unified this with the spawn path).
+      (unified with the spawn path).
     - the returned handler fn — frame stamping, intercept-spawn-all-
       event branch (in `lifecycle-fx.join`), bootstrap-pending detection
       + initial-entry cascade, machine-transition dispatch, action-failure
       projection, finalize delegation (in `lifecycle-fx.finalize`).
 
-  Per rf2-2zzyg the returned handler fn is further decomposed into a
+  The returned handler fn is further decomposed into a
   four-step pipeline — `prepare-machine-ctx` → `maybe-boot` →
   `run-step` → `commit-or-finalize` — with the intercept-spawn-all-
   event short-circuit branching off after step 1."
   [machine]
-  ;; Per EP-0017 slice-B.9 (rf2-mjmxgb) — consumer attachment. Run FIRST so
+  ;; Consumer attachment. Run FIRST so
   ;; the inline-fn restriction (`:rf.error/machine-cofx-requires-inline`) and
   ;; the named-entry `:rf.cofx/requires` parse (`:rf.error/cofx-request-invalid`
   ;; / `-name-collision`) surface as their OWN precise categories before
@@ -757,7 +747,7 @@
   ;; `:rf/cofx-ensure-index` for the dispatch-time `ensure-ctx-cofx` to read.
   (let [machine (cofx-attach/index-ensure-sets machine)]
   (validation/validate-machine! machine)
-  ;; Per rf2-genufr — fail-loud guard. A `:data-schema`-bearing spec MUST be
+  ;; Fail-loud guard. A `:data-schema`-bearing spec MUST be
   ;; registered through the single home (`reg-machine` / `reg-machine*` / the
   ;; event-`:schema` arity), which is the ONLY place the `:rf/machine?` /
   ;; `:rf/machine` registration-metadata stamp runs — the `:where :machine-data`
@@ -767,9 +757,9 @@
   ;; `:data-schema` reached here outside the home would be silently inert.
   ;; Surface it at the moment of construction rather than letting it no-op. A
   ;; schema-LESS spec is unaffected — the bare direct path stays legal for it.
-  ;; (EP-0025, rf2-398kql: the schema→marks redaction half of this guard's
-  ;; rationale is gone — schema props no longer classify `:data` for egress —
-  ;; but the validation-stamp half still requires the home, so the guard stays.)
+  ;; The guard secures the validation-stamp: it ensures a `:data-schema` reaches
+  ;; the home that stamps the meta the validator resolves through. (`:data-schema`
+  ;; props do not classify `:data` for egress — schema is validation-only.)
   (when (and (:data-schema machine)
              (not *in-registration-home?*))
     (error/throw-error!
@@ -787,17 +777,17 @@
            "(reg-machine* id {:schema EventSchema} machine).")
       {:recovery :use-reg-machine
        :extra    {:data-schema (:data-schema machine)}}))
-  ;; Per rf2-f9tu — `build-initial-snapshot` runs lazily INSIDE the
+  ;; `build-initial-snapshot` runs lazily INSIDE the
   ;; returned handler, not at registration time. The initial-state
   ;; computation reaches through `:initial` / `:states` / `:regions`;
   ;; running it at registration time would force every registered spec
   ;; (including the stub child machines the conformance corpus declares
   ;; without `:initial` for `:spawn` targets, and any spec whose
   ;; `:initial` derives from a fn-form computed at dispatch time) to
-  ;; satisfy the snapshot shape at reg-machine call time. The original
-  ;; (pre-split) implementation deferred this work; preserve that.
+  ;; satisfy the snapshot shape at reg-machine call time. Deferring the work
+  ;; to the handler keeps registration tolerant of such specs.
   ;;
-  ;; `machine` already carries the EP-0017 slice-B.9 consumer-attachment index
+  ;; `machine` already carries the consumer-attachment index
   ;; (`:rf/cofx-ensure-index`, stamped above by `cofx-attach/index-ensure-sets`
   ;; ahead of `validate-machine!`), so the handler closure captures it and
   ;; `prepare-machine-ctx` threads it onto the machine def — the dispatch-time
@@ -807,7 +797,7 @@
                               machine {:bootstrap-pending? false}))]
     (fn [{:keys [db] frame :rf.frame/id rt :rf.db/runtime
           cofx :rf.cofx mint-policy :rf.cofx/mint-policy :as _cofx} event]
-      ;; EP-0002 carried invariant: a machine handler is invoked inside an
+      ;; A machine handler is invoked inside an
       ;; event cascade, so the cofx ALWAYS carries the frame stamp under
       ;; `:rf.frame/id` (the HELD stamp). A nil stamp is an invariant
       ;; failure — surface `:rf.error/no-frame-context`, never repair to a
@@ -822,7 +812,7 @@
                    {:machine-id (first event)
                     :event      event
                     :frame      frame})
-      ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db
+      ;; Machine snapshots are durable runtime-db
       ;; state. The handler reads the snapshot from the `:rf.db/runtime`
       ;; coeffect (a fresh frame's runtime-db is `nil` until first write —
       ;; default it to `{}` so the snapshot lookup / install paths see a map)
@@ -836,7 +826,7 @@
                           (:machine-id ctx) (:inner-event ctx))]
         (if intercepted
           intercepted
-          ;; Per EP-0017 slice-B.9 (rf2-knxbok) — ensure the BIRTH initial-entry
+          ;; Ensure the BIRTH initial-entry
           ;; ensure-set onto the in-flight `:rf.cofx` record BEFORE `maybe-boot`
           ;; runs the bootstrap cascade (which fires the initial-state `:entry`
           ;; actions). The augmented `ctx` flows into both `maybe-boot` and the
@@ -845,7 +835,7 @@
           (let [ctx         (ensure-bootstrap-cofx ctx)
                 boot-result (maybe-boot ctx)]
             (if (result/fail? boot-result)
-              ;; rf2-y3jv8q — route both a thrown initial-entry action AND a
+              ;; Route both a thrown initial-entry action AND a
               ;; birth-time bounded-depth abort (a born-state `:always` / raise
               ;; runaway) through the shared failure handler: a depth-abort
               ;; skips the misleading action-exception re-emit (its precise
@@ -854,31 +844,30 @@
                                     "Machine initial-entry action threw."
                                     boot-result)
               (result/with-ok [post-boot-snap boot-fx] boot-result
-                ;; Per rf2-gl588 — PURE init-kick (the Job-B cut-point,
-                ;; sub-decision (b)): when the routed inner event IS the
+                ;; PURE init-kick: when the routed inner event IS the
                 ;; reserved `:rf.machine/start` marker, `maybe-boot` has
                 ;; already run the INITIAL MACROSTEP — the initial-entry
-                ;; cascade AND the birth-time `:always` + raise settle
-                ;; (rf2-505ic), via `parallel/apply-initial-entry-cascade`
+                ;; cascade AND the birth-time `:always` + raise settle,
+                ;; via `parallel/apply-initial-entry-cascade`
                 ;; — and emitted `:rf.machine/started`. STOP here — never
                 ;; feed the synthetic marker into `run-step` as a trigger.
-                ;; This removes the misleading `before == after` self-
-                ;; transition for quiet states and the `:*`-wildcard throw
-                ;; for `:fuse/box`-shaped initial states; the marker now
+                ;; This avoids a misleading `before == after` self-
+                ;; transition for quiet states and a `:*`-wildcard throw
+                ;; for `:fuse/box`-shaped initial states; the marker
                 ;; means exactly "create + run the initial macrostep," like
                 ;; `xstate.init`. (`commit-or-finalize` is bypassed: a pure
                 ;; start emits no `:rf.machine/transition`;
                 ;; `:rf.machine/started` is the sole birth signal.)
                 ;;
-                ;; Per rf2-505ic the birth `:always` settle CAN now land
+                ;; The birth `:always` settle CAN land
                 ;; the machine on a final leaf at start (an initial leaf
                 ;; whose `:always` targets a final state) — XState v5 treats
                 ;; such an actor as done immediately. So recompute finality
                 ;; from the settled snapshot (mirroring `commit-or-finalize`)
                 ;; and route to `finalize-machine` when finished, so the
                 ;; `:on-done` + auto-destroy cascade fires on eager start
-                ;; just as it would on the lazy path. Per rf2-bnjb3 / rf2-zlmz7
-                ;; the embedded-vs-top-level reconciliation applies here too:
+                ;; just as it would on the lazy path. The
+                ;; embedded-vs-top-level reconciliation applies here too:
                 ;; only a TOP-LEVEL final (flat/compound) or an all-regions-
                 ;; final parallel that declares NO root `:on-done` tears the
                 ;; actor down; a parallel root WITH `:on-done` rests in the
@@ -899,7 +888,7 @@
                                                  (vec boot-fx))
                       {:rf.db/runtime (assoc-in runtime-db (:path ctx) post-boot-snap)
                        :fx            (vec boot-fx)}))
-                  ;; Per EP-0017 slice-B.9 (rf2-mjmxgb) — ensure the derived
+                  ;; Ensure the derived
                   ;; per-(state × event-type) cofx ensure-set onto the
                   ;; in-flight `:rf.cofx` record BEFORE transition selection
                   ;; (`run-step`) runs. A guard-consumed fact MUST be present
@@ -915,73 +904,67 @@
                   (let [ctx (ensure-ctx-cofx ctx post-boot-snap)
                         step-result (run-step ctx post-boot-snap)]
                     (if (result/fail? step-result)
-                      ;; rf2-y3jv8q — route both a thrown transition action AND
+                      ;; Route both a thrown transition action AND
                       ;; a bounded-depth abort (the runaway `:always` / `:raise`
                       ;; cycle, XState-v5-throws case) through the shared
                       ;; failure handler. A depth-abort surfaces as a FAILED
                       ;; macrostep (atomic rollback, the precise depth-exceeded
-                      ;; category already emitted in-engine) rather than the
-                      ;; pre-fix silent no-op that swallowed the event.
+                      ;; category already emitted in-engine), so a runaway
+                      ;; settle never silently swallows the event as a no-op.
                       (handle-step-failure! ctx (:inner-event ctx)
                                             "Machine action threw."
                                             step-result)
-                      ;; Per rf2-n9f4z: pass the full `boot-result` (fx +
+                      ;; Pass the full `boot-result` (fx +
                       ;; bootstrap-entry cascade), not just `boot-fx`, so a
                       ;; same-call bootstrap's entry cascade prepends the
                       ;; event-driven cascade on the `:rf.machine/transition`
                       ;; trace.
                       (commit-or-finalize ctx step-result boot-result)))))))))))))
 
-;; ---- :data-schema redaction bridge: REMOVED (EP-0025, rf2-398kql) ---------
+;; ---- :data-schema is validation-only --------------------------------------
 ;;
-;; A machine's `:data-schema` (the renamed `:schema` key — rf2-rcim4m) is a
-;; Malli EDN form that VALIDATES the machine's `:data` slot. That validation is
-;; UNTOUCHED. What is gone is the EP-0005 schema→MARKS redaction bridge
-;; (`register-data-schema-marks!`, rf2-w46fpt / rf2-qpibk0): it extracted each
-;; `:sensitive?` / `:large?` per-`:data`-slot prop from the `:data-schema`,
-;; rooted it under `[:data …]`, and recorded it in core's schema-sourced
-;; marks side-table so `project-machine-tags` / the SSR projector would redact
-;; the marked snapshot slot at egress.
+;; A machine's `:data-schema` is a Malli EDN form that VALIDATES the machine's
+;; `:data` slot. It is a validation contract only — its per-slot
+;; `:sensitive?` / `:large?` props do NOT classify the machine's durable
+;; `:data` for trace / SSR egress.
 ;;
-;; EP-0025 makes frame-declared `:sensitive` / `:large {:app-db …}` paths
-;; (`reg-frame`, EP-0015) the SOLE app-db data-classification mechanism and
-;; KILLS the schema-field classification axis. A machine that needs a durable
-;; `:data` slot redacted at egress now declares it on the frame (the snapshot
-;; lives in the frame's runtime-db partition); the `:data-schema` is for
-;; validation only. The spawn-time / restore-time per-instance bridge and the
-;; destroy-time clear (rf2-fm1cpl / rf2-egvm4t) are removed with it.
+;; App-db data-classification has a single mechanism: frame-declared
+;; `:sensitive` / `:large {:app-db …}` paths (`reg-frame`). A machine that
+;; needs a durable `:data` slot redacted at egress declares it on the frame
+;; (the snapshot lives in the frame's runtime-db partition); the `:data-schema`
+;; is for validation only.
 
-;; ---- the single registration home (rf2-genufr) ----------------------------
+;; ---- the single registration home -----------------------------------------
 
 (defn- register-machine-event!
-  "THE single home for registering a machine as an event handler. Per
-  rf2-genufr it stamps the `:rf/machine?` / `:rf/machine` registration metadata
+  "THE single home for registering a machine as an event handler. It
+  stamps the `:rf/machine?` / `:rf/machine` registration metadata
   so the `:where :machine-data` post-commit walker resolves the `:data-schema`
   through `(machine-meta id)` (without the stamp the schema validates nothing).
 
-  `reg-machine*` (both arities) routes through here, so the bare
-  `(reg-event id meta (make-machine-handler spec))` direct path — which does
-  not stamp the meta and so would leave a `:data-schema` inert — is no longer
-  needed (and `make-machine-handler` fails loud when handed a `:data-schema`-
-  bearing spec outside this home; see its guard).
+  `reg-machine*` (both arities) routes through here. The bare
+  `(reg-event id meta (make-machine-handler spec))` direct path does
+  not stamp the meta and so would leave a `:data-schema` inert, so
+  `make-machine-handler` fails loud when handed a `:data-schema`-bearing spec
+  outside this home (see its guard) — a schema-bearing machine MUST flow
+  through the home.
 
-  `opts` is an optional registration-metadata map (rf2-wgmipl). Its `:schema`
+  `opts` is an optional registration-metadata map. Its `:schema`
   key (when present) is the `:where :event` boundary validator for the
   dispatched OUTER event vector — the machine + event-vector-schema shape.
   Other opts keys ride onto the metadata verbatim. The framework-owned
   `:rf/machine?` / `:rf/machine` keys are stamped here and MUST NOT appear in
   `opts`.
 
-  EP-0025 (rf2-398kql): the home formerly ran a SECOND `:data-schema` side-
-  effect — `register-data-schema-marks!`, the schema→marks redaction bridge.
-  That bridge is REMOVED; schema-field classification is killed in favour of
-  frame-declared `:sensitive` / `:large {:app-db …}` paths as the sole app-db
-  mechanism. The home now runs only the validation-stamp."
+  The home runs exactly one `:data-schema` side-effect: the validation-stamp.
+  The `:data-schema` is validation-only — its per-slot props do not classify
+  durable `:data` for egress (frame-declared `:sensitive` / `:large {:app-db …}`
+  paths are the sole app-db mechanism)."
   [machine-id machine opts]
-  ;; rf2-t65lqt — the MIDDLE `opts` slot (rf2-wvh95f F2) must be a map BEFORE
+  ;; The MIDDLE `opts` slot must be a map BEFORE
   ;; any `contains?`/`assoc` runs against it. The 2-arity passes `nil` (the
   ;; no-opts path) which normalises to `{}` below; a 3-arity caller that hands
-  ;; a non-nil, non-map opts (the slip after the F2 grammar change) would
+  ;; a non-nil, non-map opts would
   ;; otherwise leak a raw host `IllegalArgumentException` ("Key must be
   ;; integer") from the reserved-key `contains?` instead of a public
   ;; diagnostic. Mirrors reg-route's `invalid-route-metadata` non-map guard +
@@ -1010,7 +993,7 @@
       {:recovery :drop-reserved-keys
        :extra    {:machine-id machine-id
                   :opts       opts}}))
-   ;; Per rf2-s83iu: install a per-machine region-machine cache before
+   ;; Install a per-machine region-machine cache before
    ;; the machine value is threaded through the handler closure and
    ;; published to the registrar. Re-registration replaces the machine
    ;; map and its attached cache atom, so no separate invalidation step
@@ -1027,13 +1010,12 @@
                           :rf/machine? true
                           :rf/machine  machine)]
     (events/reg-event machine-id meta handler-fn)
-    ;; EP-0025 (rf2-398kql): the `:data-schema`→marks redaction bridge is GONE.
-    ;; The `:data-schema` still VALIDATES `:data` (via the `:where :machine-data`
-    ;; post-commit walker, resolved through the `:rf/machine` meta stamped above),
-    ;; but its per-slot `:sensitive?` / `:large?` props no longer classify the
-    ;; machine's durable `:data` for trace / SSR egress — frame-declared
-    ;; `:sensitive` / `:large {:app-db …}` paths are the sole app-db mechanism.
-    ;; Per EP-0017 slice-B.9 (rf2-mjmxgb) — the dev-only consumer-attachment
+    ;; The `:data-schema` VALIDATES `:data` (via the `:where :machine-data`
+    ;; post-commit walker, resolved through the `:rf/machine` meta stamped above);
+    ;; its per-slot props do not classify the machine's durable `:data` for
+    ;; trace / SSR egress — frame-declared `:sensitive` / `:large {:app-db …}`
+    ;; paths are the sole app-db mechanism.
+    ;; The dev-only consumer-attachment
     ;; lints (consume-without-declaring + ambient-durable). Run here in the
     ;; home (with the machine-id known) over a locally-indexed copy so the
     ;; lints read the parsed diets without altering the stored `:rf/machine`
@@ -1045,7 +1027,7 @@
                   :initial    (:initial machine)})
     machine-id)))
 
-;; ---- reg-machine* — plain-fn surface (rf2-8bp3) ---------------------------
+;; ---- reg-machine* — plain-fn surface --------------------------------------
 
 (defn reg-machine*
   "Plain-fn surface beneath the `reg-machine` macro. Registers a machine
@@ -1055,8 +1037,8 @@
   Per Spec 005 §reg-machine vs reg-machine*: the macro `reg-machine`
   walks the literal spec form at expansion time and co-locates per-element
   source onto each `:guards` / `:actions` entry plus a reference-site
-  `:source-coords` onto each `:states`-tree map node (rf2-npvsx /
-  rf2-vqja2). This fn assumes no such walking — it accepts whatever spec
+  `:source-coords` onto each `:states`-tree map node. This fn assumes no such
+  walking — it accepts whatever spec
   map the caller has already constructed. Use this fn for runtime
   registration with computed ids, fixture-synthesised specs, or REPL
   workflows.
@@ -1072,7 +1054,7 @@
   (set by the `reg-machine` macro) is merged into the registration
   metadata via the `reg-event` defn's `merge-coords` call.
 
-  ## Grammar — the metadata-map is the MIDDLE slot (rf2-wvh95f F2)
+  ## Grammar — the metadata-map is the MIDDLE slot
 
   The 3-arity is `(reg-machine* machine-id opts machine)` — the optional
   `opts` registration-metadata map sits in the canonical Spec 001 MIDDLE
@@ -1093,7 +1075,7 @@
 (defn handler-meta-for
   "Build the registrar-shaped handler-meta map for a machine `spec`
   WITHOUT registering it — the surface the lazy-actor-handler resolver
-  (rf2-a2sn1) drives a spawned actor's cascade through. Equivalent in
+  drives a spawned actor's cascade through. Equivalent in
   shape to what `reg-machine*` installs under the machine-id, but
   materialised on demand from the actor's (revertible) runtime-db snapshot
   rather than held in a per-instance registrar entry.
@@ -1109,11 +1091,10 @@
   of the type."
   [spec]
   (let [machine    (parallel/install-region-cache spec)
-        ;; rf2-genufr — this materialisation seam stamps the `:rf/machine?` /
+        ;; This materialisation seam stamps the `:rf/machine?` /
         ;; `:rf/machine` meta below, so it is a legitimate `make-machine-handler`
         ;; home for a `:data-schema`-bearing spec — bind the flag so the
-        ;; fail-loud guard passes. (EP-0025, rf2-398kql: the per-instance
-        ;; schema→marks bridge its caller once re-ran is gone.)
+        ;; fail-loud guard passes.
         handler-fn (binding [*in-registration-home?* true]
                      (make-machine-handler machine))]
     (events/event-handler-meta {:rf/machine? true :rf/machine machine}
@@ -1129,7 +1110,7 @@
   map the router can drive the cascade with — or nil to let core surface
   the genuine `:rf.error/no-such-handler`.
 
-  Resolution is purely runtime-db-derived (rf2-a2sn1): read the actor's live
+  Resolution is purely runtime-db-derived: read the actor's live
   snapshot from the frame's runtime-db, resolve its TYPE spec via
   `resolver/spec-from-snapshot`, and materialise the handler-meta from
   the spec. No live snapshot (or no resolvable type) → nil: the actor
@@ -1145,18 +1126,15 @@
   per-instance handler is — by design — never registered), so the allocation
   is bounded by actual spawned-actor traffic, not by every dispatch.
 
-  EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state, so
+  Machine snapshots are durable runtime-db state, so
   the live snapshot is read off the frame's runtime-db partition.
 
-  EP-0025 (rf2-398kql): this seam formerly ALSO re-ran the per-instance
-  `:data-schema`→marks bridge (rf2-egvm4t) to rehydrate a restored / replayed
-  actor's schema-derived snapshot-egress marks. That bridge is REMOVED —
-  schema-field classification is killed in favour of frame-declared paths — so
-  there are no per-instance schema marks to rehydrate here; the seam now only
-  materialises the handler-meta from the restored snapshot's spec."
+  Schema-egress classification is frame-declared, not per-instance, so this
+  seam has no per-instance schema marks to rehydrate; it materialises the
+  handler-meta from the restored snapshot's spec only."
   [event frame-id]
   (let [actor-id   (first event)
-        ;; EP-0002 — `frame-id` is the cascade-threaded envelope frame the
+        ;; `frame-id` is the cascade-threaded envelope frame the
         ;; router's no-handler diagnostics pass in; read its runtime-db
         ;; directly, no `:rf/default` repair. (A nil frame-id yields nil
         ;; runtime-db → the genuine `:no-such-handler`, never a read against

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machines.lifecycle-fx.resolver
-  "Spawned-actor SPEC resolution from runtime-db (rf2-a2sn1) — the leaf helper
+  "Spawned-actor SPEC resolution from runtime-db — the leaf helper
   beneath the lazy actor-handler resolver.
 
   Per Spec 005 §Spawning §Liveness is derived from runtime-db: a spawned
@@ -7,13 +7,13 @@
   runtime-db write (install the snapshot + the spawn-registry slot); destroy
   is a pure runtime-db remove. An actor's liveness IS exactly the presence
   of its snapshot at `[:rf.runtime/machines :snapshots <actor-id>]` in
-  the frame's value — so `restore-epoch!` (which since EP-0001 reverts the
-  WHOLE frame-state, both the app-db AND runtime-db partitions, via
+  the frame's value — so `restore-epoch!` (which reverts the WHOLE
+  frame-state, both the app-db AND runtime-db partitions, via
   `replace-frame-state!` against the epoch's `:frame-state-after`) reverts
-  liveness perfectly, with ZERO registrar drift. This closes the
-  Goal-2 revertibility leak: rewinding past a spawn no longer leaves an
-  orphaned handler, and rewinding past a destroy re-materialises a
-  working handler from the restored snapshot.
+  liveness perfectly, with ZERO registrar drift. Revertibility holds
+  exactly: rewinding past a spawn leaves no orphaned handler, and rewinding
+  past a destroy re-materialises a working handler from the restored
+  snapshot.
 
   The actor's TYPE rides the snapshot under the reserved root key
   `:rf/machine-type` (per Spec 005 §Reserved snapshot-internal keys):
@@ -81,8 +81,8 @@
 
     (or (spec-from-registry id) (spec-from-snapshot snapshot)).
 
-  Per rf2-a2sn1 the two legs are mutually exclusive for any one id — a
-  registered singleton has a registrar entry but no `:rf/machine-type` on
+  The two legs are mutually exclusive for any one id — a registered
+  singleton has a registrar entry but no `:rf/machine-type` on
   its snapshot, while a spawned actor carries no per-instance registrar
   entry but stamps `:rf/machine-type` on its snapshot — so the `or` order
   is behaviourally irrelevant and either leg resolves at most one spec.

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/resource_release.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/resource_release.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machines.lifecycle-fx.resource-release
-  "Machine→resource lease release on actor destroy (rf2-xw5t0y).
+  "Machine→resource lease release on actor destroy.
 
   Per Spec 016 §Release authority is per owner kind (016:290):
 
@@ -15,13 +15,12 @@
   actor — the SAME id the actor's `ensure` carries as `:owner [:machine
   actor-id]`, so releasing it drops exactly the destroyed actor's leases.
 
-  THE LEAK this closes (rf2-xw5t0y, from the rf2-na0j8r conceptual audit): the
-  machine teardown NEVER released the actor's resource leases. A machine that
-  `ensure`d a resource under its `[:machine actor-id]` owner and was then
-  destroyed LEAKED the lease — the entry stayed owner-pinned and kept
-  refetching / polling forever. The spec leaned on \"machine liveness is a pure
-  function of frame-state\" as if release were automatic, but resource liveness
-  is a SEPARATE durable owner-set, not derived from machine state.
+  Machine teardown releases the actor's resource leases. A machine that
+  `ensure`d a resource under its `[:machine actor-id]` owner releases that
+  lease on destroy, so the entry is not left owner-pinned refetching /
+  polling forever. Resource liveness is a SEPARATE durable owner-set, not
+  derived from machine state, so the release must be fired explicitly rather
+  than relying on \"machine liveness is a pure function of frame-state\".
 
   ## Decoupling + the no-resources guard
 

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -4,7 +4,7 @@
 
   `apply-transition-once` emits `[:rf.machine/spawn args]` into the fx
   vector whenever entry cascades cross a `:spawn`-bearing state. Per
-  Spec 005 §Spawning + rf2-a2sn1, a spawned actor's liveness is
+  Spec 005 §Spawning, a spawned actor's liveness is
   APP-DB-ONLY: `spawn-fx` seeds the actor's initial snapshot at
   `[:rf.runtime/machines :snapshots <spawned-id>]` in the spawning
   frame's app-db, stamping the revertible TYPE reference at
@@ -18,7 +18,7 @@
   revertibility invariant). Frame isolation follows from the snapshot
   living inside the spawning frame's app-db.
 
-  Per rf2-6vmw `spawn-all-init-fx` also lives here — the runtime
+  `spawn-all-init-fx` also lives here — the runtime
   emits `[:rf.machine/spawn-all-init args]` alongside per-child
   `:rf.machine/spawn` fxs on entry to a `:spawn-all`-bearing state to
   seed the join state at `[:rf.runtime/machines :spawned <parent> <invoke-id>]`."
@@ -37,7 +37,7 @@
 
 ;; `spawn-fx` (the fx handler / fail-closed gate) delegates the accepted-spawn
 ;; body to `spawn-fx*`, defined below it — forward-declared so the gate can
-;; reference it (rf2-ywv74m).
+;; reference it.
 (declare spawn-fx*)
 
 ;; ---- id allocation --------------------------------------------------------
@@ -45,9 +45,8 @@
 (defn- pre-allocated-actor-id
   "Resolve the pre-allocated actor id carried on the spawn args. Per Spec
   005 §Declarative :spawn Spec-spec keys: `:fixed-actor-id` is an explicit
-  actor-address literal (per-state singleton; rf2-0ggtr5 — was the
-  overloaded `:spawn-id`); `:rf/spawned-id` is stamped by the transition
-  reducer (rf2-gr8q — allocated from the parent snapshot's
+  actor-address literal (per-state singleton); `:rf/spawned-id` is stamped
+  by the transition reducer (allocated from the parent snapshot's
   `:rf/spawn-counter`). Returns nil for hand-emitted
   `[:rf.machine/spawn args]` fxs that bypass the transition reducer —
   the caller (`spawn-fx`) allocates such ids from the frame's app-db
@@ -58,14 +57,13 @@
       (:rf/spawned-id args)))
 
 (defn- allocate-actor-id-in-runtime-db
-  "Hand-emitted-spawn fallback allocator (rf2-gr8q). When the spawn args
+  "Hand-emitted-spawn fallback allocator. When the spawn args
   carry no pre-allocated id (no `:fixed-actor-id`, no `:rf/spawned-id`), this
   fn bumps the frame's runtime-db counter at
   `[:rf.runtime/machines :spawn-counter <machine-id>]` and returns
-  `[new-runtime-db spawned-id]`. Per rf2-gr8q the global `spawn-counter`
-  atom is gone; the allocator lives where the side-effect belongs —
-  inside the fx-handler's runtime-db swap — so the pure transition layer
-  stays effect-free. Per EP-0001 rf2-vzld77 the counter sits under the
+  `[new-runtime-db spawned-id]`. The allocator lives where the side-effect
+  belongs — inside the fx-handler's runtime-db swap — so the pure transition
+  layer stays effect-free. The counter sits under the
   `:rf.runtime/machines` sub-container of the durable runtime-db partition
   alongside `:snapshots`, `:system-ids`, `:spawned` (Conventions §Reserved
   runtime-db keys)."
@@ -82,7 +80,7 @@
   Returns the spec map or nil if neither resolves. Per Spec 005
   §Spawn-spec keys.
 
-  Per rf2-ywv74m a nil return from a `:machine-id`-bearing spawn means the
+  A nil return from a `:machine-id`-bearing spawn means the
   named TYPE is UNREGISTERED — the fail-closed reject path (see
   `unregistered-spawn-type?` / `reject-unregistered-spawn!`). An inline
   `:definition` always resolves to itself."
@@ -94,13 +92,13 @@
       machine-id  (resolver/spec-from-registry machine-id))))
 
 (defn- unregistered-spawn-type?
-  "Per rf2-ywv74m (Mike ruling, 2026-06-15): a `:spawn` / `:spawn-all`
-  per-child whose `:machine-id` names an UNREGISTERED machine TYPE — and
-  which carries no inline `:definition` — is REJECTED fail-closed. True iff
-  the args name a `:machine-id`, carry no `:definition`, and no registered
-  machine spec resolves for that id (the implicit \"spec-less spawn\" path,
-  now REMOVED as a supported lifecycle). A `:definition` spawn never trips
-  this (the spec IS the args)."
+  "A `:spawn` / `:spawn-all` per-child whose `:machine-id` names an
+  UNREGISTERED machine TYPE — and which carries no inline `:definition` — is
+  REJECTED fail-closed. True iff the args name a `:machine-id`, carry no
+  `:definition`, and no registered machine spec resolves for that id. There
+  is no implicit \"spec-less spawn\" lifecycle: a `:machine-id` that resolves
+  to no registered spec is rejected rather than materialising an actor. A
+  `:definition` spawn never trips this (the spec IS the args)."
   [args]
   (boolean
     (and (:machine-id args)
@@ -108,11 +106,12 @@
          (nil? (resolve-spawn-machine args)))))
 
 (defn- reject-unregistered-spawn!
-  "Per rf2-ywv74m — emit the always-on `:rf.error/machine-spawn-unregistered-type`
-  and reject the spawn. The implicit \"spec-less spawn\" path (a `:machine-id`
-  that resolves to no registered spec) is REMOVED: a rejected spawn installs
-  NO snapshot, NO slot, NO system-id binding, allocates NO spawned-id, records
-  NO spawn-order entry, fires NO trace, and dispatches NO `:start`.
+  "Emit the always-on `:rf.error/machine-spawn-unregistered-type` and reject
+  the spawn. A `:machine-id` that resolves to no registered spec is rejected
+  outright (there is no implicit \"spec-less spawn\" lifecycle): a rejected
+  spawn installs NO snapshot, NO slot, NO system-id binding, allocates NO
+  spawned-id, records NO spawn-order entry, fires NO trace, and dispatches
+  NO `:start`.
 
   ALWAYS-ON (EP-0008 non-event union-record axis, surface #4): the reject is a
   production-reachable fail-closed boundary fact — an off-box shipper on a
@@ -124,12 +123,11 @@
   `:rf.error/write-after-destroy` / `:rf.error/on-destroy-handler-exception`
   carry.
 
-  Privacy (rf2-ywv74m correctness call-out): the record carries STRUCTURAL
-  context ONLY — `:machine-id`, `:frame`, `:reason`, `:recovery`. The full
-  spawn `args` are NEVER carried: `:start` payloads / `:data` may hold
-  application data (auth tokens, PII), and this record is production-surviving
-  and NOT privacy-gated. `:reason` names the id and the fix without echoing
-  any value-bearing slot."
+  Privacy: the record carries STRUCTURAL context ONLY — `:machine-id`,
+  `:frame`, `:reason`, `:recovery`. The full spawn `args` are NEVER carried:
+  `:start` payloads / `:data` may hold application data (auth tokens, PII),
+  and this record is production-surviving and NOT privacy-gated. `:reason`
+  names the id and the fix without echoing any value-bearing slot."
   [frame-id machine-id]
   (let [reason (error/human-message
                  :rf.error/machine-spawn-unregistered-type
@@ -158,23 +156,22 @@
     nil))
 
 (defn- machine-type-ref
-  "Per rf2-a2sn1 — the revertible TYPE reference stamped onto a spawned
-  actor's snapshot root under `:rf/machine-type`, so the lazy resolver
-  (`lifecycle-fx.resolver`) can re-materialise the actor's handler purely
-  from app-db. A `:machine-id` spawn stores the registered TYPE keyword
-  (the type outlives every instance — registered like a singleton). An
-  inline `:definition` spawn stores the spec map verbatim (there is no
-  registered type; the snapshot is the only source of truth, and it is
-  fully revertible). Per rf2-ywv74m a spawn always names exactly one of the
-  two — an unregistered `:machine-id` is rejected fail-closed BEFORE this is
-  reached (see `reject-unregistered-spawn!`), so this never returns nil on
-  the accepted path."
+  "The revertible TYPE reference stamped onto a spawned actor's snapshot root
+  under `:rf/machine-type`, so the lazy resolver (`lifecycle-fx.resolver`)
+  can re-materialise the actor's handler purely from app-db. A `:machine-id`
+  spawn stores the registered TYPE keyword (the type outlives every
+  instance — registered like a singleton). An inline `:definition` spawn
+  stores the spec map verbatim (there is no registered type; the snapshot is
+  the only source of truth, and it is fully revertible). A spawn always names
+  exactly one of the two — an unregistered `:machine-id` is rejected
+  fail-closed BEFORE this is reached (see `reject-unregistered-spawn!`), so
+  this never returns nil on the accepted path."
   [args]
   (or (:machine-id args)
       (:definition args)))
 
 (defn- stamp-framework-data
-  "Per rf2-ijm7: stamp framework-reserved keys into the spawned actor's
+  "Stamp framework-reserved keys into the spawned actor's
   initial `:data` so the actor knows its own address (`:rf/self-id`)
   and, for declarative-`:spawn` spawns, its parent's address +
   invoke-id."
@@ -192,10 +189,10 @@
 ;; (`lifecycle-fx.registration/make-machine-handler`); the shared builder
 ;; seeds `:rf/spawn-counter` and `:meta` consistently across both paths.
 ;; The spawn path passes `:bootstrap-pending? true` because the actor's
-;; first dispatch must fire the initial-entry cascade (rf2-0z73).
+;; first dispatch must fire the initial-entry cascade.
 
 (defn- spawn-rejected?
-  "Per rf2-jbbp7 + rf2-f3kp7: decide whether a spawn must be rejected by
+  "Decide whether a spawn must be rejected by
   schema validation BEFORE any registration or install side effect runs.
   When the spawning machine's spec carries a `:data-schema`, the freshly-built
   `initial-snap`'s `:data` is validated against it. A failure emits
@@ -214,18 +211,18 @@
 
 (defn- install-spawn!
   "Atomically install the spawned actor's `initial-snap` (with its
-  revertible `:rf/machine-type` TYPE reference stamped at the root — per
-  rf2-a2sn1), system-id binding, and runtime-owned spawn registry slot
+  revertible `:rf/machine-type` TYPE reference stamped at the root),
+  system-id binding, and runtime-owned spawn registry slot
   into the frame's app-db. Returns `:ok`. Emits the collision and
   system-id-bound traces when applicable.
 
-  Per rf2-a2sn1 there is NO per-instance handler registration — the
+  There is NO per-instance handler registration — the
   actor's liveness IS the presence of this snapshot in the (revertible)
   frame value, and the snapshot's `:rf/machine-type` lets the lazy
   resolver re-materialise the handler on dispatch. Spawn is therefore a
   pure app-db write.
 
-  Per rf2-f3kp7 schema-rejection is decided by the caller (`spawn-fx`)
+  Schema-rejection is decided by the caller (`spawn-fx`)
   via `spawn-rejected?` BEFORE this fn runs, so by the time
   `install-spawn!` is reached the spawn is known-accepted and
   `initial-snap` (built once by the caller) is threaded in rather than
@@ -236,16 +233,16 @@
   merge is applied on top of `rt-after-alloc` so the caller's counter bump
   survives. Under Spec 002's single-drainer invariant the discarded
   re-read is value-equal to the snapshot the caller already had. Machine
-  snapshots are durable runtime-db state (EP-0001 rf2-vzld77)."
+  snapshots are durable runtime-db state (EP-0001)."
   [frame-id rt-after-alloc spec spawned-id initial-snap
    {:keys [system-id parent-id invoke-id track? type-ref]}]
   (let [existing (when system-id (get-in rt-after-alloc (paths/system-id-path system-id)))
-        ;; Per rf2-a2sn1 — stamp the revertible TYPE reference onto the
-        ;; snapshot root so the lazy resolver can re-materialise the
-        ;; handler from app-db alone. Per rf2-ywv74m the spawn is known-
-        ;; accepted by the time `install-spawn!` runs (an unregistered
-        ;; `:machine-id` was rejected fail-closed upstream), so `spec` is
-        ;; always present; the `spec`/`type-ref` guards are belt-and-braces.
+        ;; Stamp the revertible TYPE reference onto the snapshot root so the
+        ;; lazy resolver can re-materialise the handler from app-db alone. The
+        ;; spawn is known-accepted by the time `install-spawn!` runs (an
+        ;; unregistered `:machine-id` was rejected fail-closed upstream), so
+        ;; `spec` is always present; the `spec`/`type-ref` guards are
+        ;; belt-and-braces.
         initial-snap (cond-> initial-snap
                        (and spec type-ref) (assoc :rf/machine-type type-ref))]
     (when (and system-id existing (not= existing spawned-id))
@@ -270,9 +267,9 @@
       (trace/emit! :rf.machine :rf.machine/system-id-bound
                    {:frame      frame-id
                     :system-id  system-id
-                    ;; rf2-ws5thu — the live actor INSTANCE address (the
-                    ;; spawned id), not the registered TYPE; `:machine-id`
-                    ;; is reserved for the type.
+                    ;; The live actor INSTANCE address (the spawned id), not
+                    ;; the registered TYPE; `:machine-id` is reserved for the
+                    ;; type.
                     :actor-id   spawned-id}))
     :ok))
 
@@ -282,17 +279,17 @@
   "fx handler for `:rf.machine/spawn`. Per Spec 005 §Spawning, the spawned
   actor's snapshot lives at `[:rf.runtime/machines :snapshots
   <spawned-id>]` in the spawning frame's app-db, and its liveness IS that
-  snapshot's presence in the (revertible) frame value — per rf2-a2sn1
-  there is NO per-instance event-handler registration.
+  snapshot's presence in the (revertible) frame value — there is NO
+  per-instance event-handler registration.
 
   Lifecycle wired here:
-   0. **Fail-closed gate (rf2-ywv74m).** If `:machine-id` names an
+   0. **Fail-closed gate.** If `:machine-id` names an
       UNREGISTERED machine TYPE and the spawn carries no inline
       `:definition`, REJECT the spawn: emit the always-on
       `:rf.error/machine-spawn-unregistered-type` and return without
       installing anything — no snapshot, no slot, no system-id, no
       spawned-id allocation, no spawn-order record, no trace, no `:start`
-      dispatch. The implicit \"spec-less spawn\" path is REMOVED.
+      dispatch. There is no implicit \"spec-less spawn\" lifecycle.
    1. Resolve the spawn's machine spec (`:machine-id` from the registrar
       OR an inline `:definition`).
    2. Initialise the actor's snapshot at `[:rf.runtime/machines
@@ -301,7 +298,7 @@
       TYPE reference at `:rf/machine-type` (the `:machine-id` keyword, or
       the inline `:definition` map) so the lazy resolver
       (`lifecycle-fx.resolver`) can re-materialise the actor's handler
-      from app-db alone. Per rf2-ijm7 the runtime stamps `:rf/self-id`
+      from app-db alone. The runtime stamps `:rf/self-id`
       (the spawned actor's own address) and, when applicable,
       `:rf/parent-id` + `:rf/invoke-id` into the actor's initial `:data`.
       Re-spawn under the same id replaces — last-write-wins.
@@ -309,20 +306,20 @@
       `[:rf.runtime/machines :system-ids]` reverse index. Collisions emit
       `:rf.error/system-id-collision` and rebind (last-write-wins).
    4. If `:rf/parent-id` + `:rf/invoke-id` present (declarative `:spawn`
-      desugar — rf2-t07u Option A revised), bind the spawned id at
+      desugar), bind the spawned id at
       `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]`.
    5. If `:start` event-vector present, dispatch
-      `[<spawned-id> <start>]`. When `:start` is absent (per rf2-ijm7),
+      `[<spawned-id> <start>]`. When `:start` is absent,
       the runtime dispatches a synthetic `[<spawned-id>
       [:rf.machine.spawn/spawned]]` so generic child machines may declare a
       leaf-level `:on :rf.machine.spawn/spawned :target ...` transition.
       The first dispatch lazy-resolves the just-installed snapshot into a
       live handler (no registration step).
 
-  Per rf2-a2sn1 — eliminating the per-instance registration is what
-  closes the Goal-2 revertibility leak: spawn writes only app-db, destroy
-  removes only app-db, so `restore-epoch!` (app-db-only) reverts an
-  actor's liveness perfectly with ZERO registrar drift."
+  Eliminating the per-instance registration is what closes the Goal-2
+  revertibility leak: spawn writes only app-db, destroy removes only app-db,
+  so `restore-epoch!` (app-db-only) reverts an actor's liveness perfectly
+  with ZERO registrar drift."
   [{frame-id :frame} args]
   (let [;; EP-0002 carried invariant: `:rf.machine/spawn` runs inside an
         ;; event cascade, so the fx context ALWAYS carries the envelope
@@ -332,28 +329,28 @@
         frame-id   (frame/require-frame-stamp!
                      frame-id :rf.machine/spawn
                      {:where 'rf.machine/spawn :event-id (:system-id args)})]
-    ;; Step 0 (rf2-ywv74m) — fail-closed gate. An unregistered `:machine-id`
+    ;; Step 0 — fail-closed gate. An unregistered `:machine-id`
     ;; (no inline `:definition`) is REJECTED here, BEFORE any id allocation,
     ;; spec resolution, snapshot/slot/system-id install, spawn-order record,
     ;; trace, or `:start` dispatch. The reject emits the always-on
     ;; `:rf.error/machine-spawn-unregistered-type` and returns nil — the
-    ;; strongest atomicity (the implicit spec-less spawn path is removed, so
-    ;; there is no half-installed bookkeeping the next op could trip over).
+    ;; strongest atomicity (there is no spec-less spawn path, so there is no
+    ;; half-installed bookkeeping the next op could trip over).
     (if (unregistered-spawn-type? args)
       (reject-unregistered-spawn! frame-id (:machine-id args))
       (spawn-fx* frame-id args))))
 
 (defn- spawn-fx*
   "The accepted-spawn body of `spawn-fx` — runs only after the
-  `unregistered-spawn-type?` fail-closed gate (rf2-ywv74m) has let the spawn
+  `unregistered-spawn-type?` fail-closed gate has let the spawn
   through. `frame-id` is the resolved (non-nil-stamped) frame; `args` the
   spawn args. Returns the allocated `spawned-id`."
   [frame-id args]
-  (let [;; Per rf2-gr8q: prefer the pre-allocated id (declarative :spawn
+  (let [;; Prefer the pre-allocated id (declarative :spawn
         ;; routes through the transition reducer which bumps the parent
         ;; snapshot's `:rf/spawn-counter`). Hand-emitted spawn fxs carry
         ;; no pre-allocated id; the frame's runtime-db spawn-counter slot
-        ;; at `[:rf.runtime/machines :spawn-counter]` (rf2-owvvr) serves
+        ;; at `[:rf.runtime/machines :spawn-counter]` serves
         ;; as the fallback allocator, bumped inside the same db-swap as
         ;; the snapshot install / registry bind below.
         pre-id     (pre-allocated-actor-id args)
@@ -361,13 +358,13 @@
         spec'      (if (and spec (contains? args :data))
                      (assoc spec :data (:data args))
                      spec)
-        ;; Per rf2-a2sn1 — the revertible TYPE reference the lazy
-        ;; resolver reads back off the installed snapshot.
+        ;; The revertible TYPE reference the lazy resolver reads back off
+        ;; the installed snapshot.
         type-ref   (machine-type-ref args)
         system-id  (:system-id args)
-        ;; Per rf2-t07u (Option A revised): the runtime tracks each
-        ;; declarative-:spawn spawn at [:rf.runtime/machines :spawned <parent-id>
-        ;; <invoke-id>] — populated only when the spawn carries both.
+        ;; The runtime tracks each declarative-:spawn spawn at
+        ;; [:rf.runtime/machines :spawned <parent-id> <invoke-id>] —
+        ;; populated only when the spawn carries both.
         parent-id  (:rf/parent-id args)
         invoke-id  (:rf/invoke-id args)
         track?     (and parent-id invoke-id)
@@ -379,7 +376,7 @@
         ;; newer) runtime-db at write time — for the JVM atom container the
         ;; read is consistent because `frame/swap-runtime-db!` is the only
         ;; writer during fx drain (Spec 002 §Single drainer per frame).
-        ;; Machine snapshots are durable runtime-db state (rf2-vzld77).
+        ;; Machine snapshots are durable runtime-db state.
         old-rt     (frame/frame-runtime-db-value frame-id)
         machine-id-for-alloc (or (:id-prefix args) (:machine-id args))
         [rt-after-alloc spawned-id]
@@ -395,38 +392,36 @@
         initial-snap (when spec''
                        (parallel/build-initial-snapshot
                          spec'' {:bootstrap-pending? true}))
-        ;; Per rf2-f3kp7: decide schema rejection BEFORE the trace and the
+        ;; Decide schema rejection BEFORE the trace and the
         ;; install. Gating both on `(not rejected?)` makes a rejected spawn
         ;; FULLY atomic — it installs no snapshot, records no spawn-order
         ;; entry, dispatches no `:start`, and announces no
         ;; `:rf.machine.spawn/spawned` (only the
         ;; `:rf.error/schema-validation-failure :phase :spawn` that
-        ;; `validate-spawn-data!` already emitted). Per rf2-a2sn1 there is
-        ;; no longer any per-instance handler registration to gate — a
-        ;; rejected spawn simply writes nothing to app-db, so no liveness
-        ;; exists for the rejected actor (the strongest form of atomicity:
-        ;; an actor's liveness IS its snapshot, and the snapshot was never
-        ;; installed).
+        ;; `validate-spawn-data!` already emitted). There is no per-instance
+        ;; handler registration to gate — a rejected spawn simply writes
+        ;; nothing to app-db, so no liveness exists for the rejected actor
+        ;; (the strongest form of atomicity: an actor's liveness IS its
+        ;; snapshot, and the snapshot was never installed).
         rejected?  (spawn-rejected? spec'' spawned-id initial-snap)]
-    ;; (rf2-g13nm2 C3) Gate the ENTIRE accepted-spawn cascade — the
+    ;; Gate the ENTIRE accepted-spawn cascade — the
     ;; `:rf.machine.spawn/spawned` trace, the snapshot/system-id/spawn-slot
     ;; install, AND the `:start` (or synthetic) dispatch — on BOTH the spawn
     ;; being accepted (`not rejected?`) AND the frame being LIVE (`old-rt`).
     ;; When the frame was destroyed / never existed, `old-rt` is nil and
     ;; `spawned-id` is nil (the `:else` allocator branch above): firing the
     ;; spawned trace and dispatching `[nil <start>]` for an actor that was
-    ;; NEVER installed is an atomicity violation (a phantom spawn signal +
-    ;; a dispatch into the void). The pre-fix code gated only the install on
-    ;; `old-rt`, leaving the trace + dispatch to fire regardless. Now a
-    ;; destroyed-frame spawn is a clean no-op — no trace, no install, no
-    ;; dispatch — symmetric with the schema-reject path's atomicity.
+    ;; NEVER installed would be an atomicity violation (a phantom spawn
+    ;; signal + a dispatch into the void). A destroyed-frame spawn is a clean
+    ;; no-op — no trace, no install, no dispatch — symmetric with the
+    ;; schema-reject path's atomicity.
     (when (and (not rejected?) old-rt)
       (trace/emit! :rf.machine :rf.machine.spawn/spawned
                    {:frame      frame-id
                     ;; `:machine-id` is the spec-time registered TYPE (xor
                     ;; an inline `:definition`); `:spawned-id` is the live
-                    ;; instance address; `:invoke-id` (rf2-0ggtr5 — was
-                    ;; `:spawn-id`) is the declarative invocation path.
+                    ;; instance address; `:invoke-id` is the declarative
+                    ;; invocation path.
                     :machine-id (:machine-id args)
                     :spawned-id spawned-id
                     :id-prefix  (:id-prefix args)
@@ -435,7 +430,7 @@
                     :system-id  system-id
                     :parent-id  parent-id
                     :invoke-id  invoke-id})
-      ;; Per rf2-a2sn1 — NO per-instance handler registration. The actor's
+      ;; NO per-instance handler registration. The actor's
       ;; liveness IS its snapshot's presence in the (revertible) frame
       ;; value; the snapshot's `:rf/machine-type` (stamped by
       ;; `install-spawn!`) lets the lazy resolver re-materialise the
@@ -454,20 +449,17 @@
                          :invoke-id invoke-id
                          :track?    track?
                          :type-ref  type-ref})
-        ;; EP-0025 (rf2-398kql): the per-instance `:data-schema`→marks bridge
-        ;; (rf2-fm1cpl) is REMOVED. It re-keyed the spawned type's schema-derived
-        ;; `:sensitive?` / `:large?` `[:data …]` marks under the INSTANCE id so a
-        ;; `:rf.machine/transition` trace carrying `:actor-id` = the instance id
-        ;; would redact the marked `:data` slot. With schema-field classification
-        ;; killed in favour of frame-declared paths as the sole app-db mechanism,
-        ;; there is no per-instance schema-marks table to populate; a spawned
-        ;; actor's `:data` redaction (if any) rides the FRAME's declared paths.
-        ;; Per rf2-vsigt — record the spawned actor in the frame's
-        ;; spawn-order channel so frame-destroy can walk in reverse-
-        ;; creation order per Spec 005 §Cross-Spec Interactions §1.
+        ;; A machine's `:data-schema` is validation-only: it does not produce
+        ;; a per-instance marks table, so there is no schema-marks table to
+        ;; populate at spawn. A spawned actor's `:data` redaction (if any)
+        ;; rides the FRAME's declared paths, the sole app-db redaction
+        ;; mechanism.
+        ;; Record the spawned actor in the frame's spawn-order channel so
+        ;; frame-destroy can walk in reverse-creation order per Spec 005
+        ;; §Cross-Spec Interactions §1.
         (spawn-order/record! frame-id spawned-id)
-        ;; Per rf2-qpuk4 — the REGISTRAR-substrate "instance appeared"
-        ;; observation, the symmetric partner of
+        ;; The REGISTRAR-substrate "instance appeared" observation, the
+        ;; symmetric partner of
         ;; `:rf.machine.lifecycle/created` (handler registered) and
         ;; `:rf.machine.lifecycle/destroyed` (handler/snapshot reaped).
         ;; The fx-substrate emit above (`:rf.machine.spawn/spawned`) says
@@ -483,29 +475,24 @@
                      {:frame      frame-id
                       ;; `:machine-id` = spec-time registered TYPE;
                       ;; `:spawned-id` = live instance address;
-                      ;; `:invoke-id` (rf2-0ggtr5) = declarative invocation path.
+                      ;; `:invoke-id` = declarative invocation path.
                       :machine-id (:machine-id args)
                       :spawned-id spawned-id
                       :invoke-id  invoke-id
                       :system-id  system-id
                       :parent-id  parent-id
                       :state      (:state initial-snap)}))
-      ;; (6) Fire the :start event into the new actor. Per rf2-ijm7,
-      ;; spawns that don't supply :start receive a synthetic
-      ;; [:rf.machine.spawn/spawned] so generic child machines can declare their
-      ;; first transition out of an :initial state at spec-write time.
+      ;; (6) Fire the :start event into the new actor. Spawns that don't
+      ;; supply :start receive a synthetic [:rf.machine.spawn/spawned] so
+      ;; generic child machines can declare their first transition out of an
+      ;; :initial state at spec-write time.
       (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-        ;; Per rf2-ejtpd + rf2-1ve9h: stamp `:source :machine-spawn`
-        ;; on the actor-bootstrap dispatch so the Epoch panel's
-        ;; DISPATCH step labels it "from machine spawn" rather than
-        ;; `:unknown` (rf2-hxj0d residual default) or `:fx-dispatch`
-        ;; (which would be the value if the spawn fx routed through
-        ;; `:dispatch`), and Xray's L2 timeline can prefix the row +
-        ;; per-source filter pills can discriminate actor-bootstrap
-        ;; cascades. Per rf2-1ve9h (Mike-approved Option A,
-        ;; 2026-05-28) the prior parallel `:rf/dispatch-origin
-        ;; :internal` axis was collapsed into `:source` —
-        ;; `:machine-spawn` is now the single functional-origin
+        ;; Stamp `:source :machine-spawn` on the actor-bootstrap dispatch so
+        ;; the Epoch panel's DISPATCH step labels it "from machine spawn"
+        ;; rather than `:unknown` or `:fx-dispatch` (which would be the value
+        ;; if the spawn fx routed through `:dispatch`), and Xray's L2 timeline
+        ;; can prefix the row + per-source filter pills can discriminate
+        ;; actor-bootstrap cascades. `:source` is the single functional-origin
         ;; discriminator (closed-enum per Spec-Schemas
         ;; §`:rf/dispatch-envelope`).
         (let [start (:start args)
@@ -519,7 +506,7 @@
 ;; ---- :rf.machine/spawn-all-init -------------------------------------------
 
 (defn spawn-all-init-fx
-  "fx handler for `:rf.machine/spawn-all-init` (rf2-6vmw). Per Spec 005
+  "fx handler for `:rf.machine/spawn-all-init`. Per Spec 005
   §Spawn-and-join via `:spawn-all`, on entry to a `:spawn-all`-bearing
   state the runtime emits this fx (alongside per-child `:rf.machine/spawn`
   fxs) to seed the join state at `[:rf.runtime/machines :spawned <parent> <invoke-id>]` in
@@ -535,8 +522,7 @@
   parent's `make-machine-handler` boundary and are intercepted by
   `intercept-spawn-all-event` (in `lifecycle-fx.join`).
 
-  Per rf2-ywv74m (the `:spawn-all` join-hang correctness fix): this fx
-  fires FIRST in the entry `:fx` vector — BEFORE the per-child
+  This fx fires FIRST in the entry `:fx` vector — BEFORE the per-child
   `:rf.machine/spawn` fxs. If ANY child in the set names an UNREGISTERED
   machine TYPE (no inline `:definition`), the join is REJECTED here: NO
   join-state is seeded. A never-running spec-less child would otherwise
@@ -559,9 +545,9 @@
         invoke-id  (:rf/invoke-id args)
         join-state (:join-state args)
         children   (:children join-state)
-        ;; Per rf2-ywv74m — the original child invoke-specs (carry
-        ;; `:machine-id` / `:definition`) ride the seeded join-state's
-        ;; `:spec`. Detect any unregistered child TYPE up front.
+        ;; The original child invoke-specs (carry `:machine-id` /
+        ;; `:definition`) ride the seeded join-state's `:spec`. Detect any
+        ;; unregistered child TYPE up front.
         unregistered (->> (get-in join-state [:spec :children])
                           (filterv unregistered-spawn-type?))]
     (if (seq unregistered)
@@ -573,12 +559,12 @@
             (reject-unregistered-spawn! frame-id (:machine-id child)))
           nil)
       (do
-        ;; Machine spawn-registry state is durable runtime-db state (rf2-vzld77).
+        ;; Machine spawn-registry state is durable runtime-db state.
         (frame/swap-runtime-db! frame-id assoc-in
                                 (paths/spawned-path parent-id invoke-id) join-state)
         (trace/emit! :rf.machine :rf.machine.spawn-all/started
-                     {;; rf2-ws5thu — the parent's live actor INSTANCE address;
-                      ;; rf2-0ggtr5 — `:invoke-id` is the declarative invocation path.
+                     {;; The parent's live actor INSTANCE address;
+                      ;; `:invoke-id` is the declarative invocation path.
                       :actor-id   parent-id
                       :invoke-id  invoke-id
                       :child-ids  (set (keys children))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.machines.lifecycle-fx.spawn-error
   "Spawn `:on-error` routing — the child-failure → parent-transition wiring
-  (rf2-5hlsh; XState v5 `invoke onError`).
+  (XState v5 `invoke onError`).
 
   Per Spec 005 §Final states §`:on-error`, when a `:spawn`-spawned child
   FAILS, the runtime routes the failure to the spawning parent's
@@ -44,9 +44,9 @@
 
 (defn- resolve-parent-spec
   "Resolve the spawning parent's machine spec from `parent-id` against `db`.
-  Per rf2-a2sn1 — a singleton parent has a registrar entry; a NESTED spawn
-  whose parent is itself a spawned actor (no per-instance registration) is
-  resolved from its own snapshot's `:rf/machine-type`. Mirrors the resolution
+  A singleton parent has a registrar entry; a NESTED spawn whose parent is
+  itself a spawned actor (no per-instance registration) is resolved from its
+  own snapshot's `:rf/machine-type`. Mirrors the resolution
   `finalize-machine` does for `:on-done`."
   [db parent-id]
   (when parent-id
@@ -58,7 +58,7 @@
   "Walk `parent-spec`'s state tree to the `:spawn`-bearing node at `invoke-id`
   (the absolute prefix-path stamped at spawn time) and return its `:spawn`
   map. For a parallel-region parent the first element of `invoke-id` is the
-  region name (per rf2-l67o); strip and descend into that region's body.
+  region name; strip and descend into that region's body.
   Returns nil if the path doesn't resolve or the node declares no `:spawn`.
   (Same resolution as `finalize/find-spawn-spec-at` — duplicated here so this
   leaf namespace stays independent of `finalize`, which depends on it.)"
@@ -90,7 +90,7 @@
   "Dispatch the reserved parent-failure event
   `[<parent-id> [:rf.machine.spawn/error <invoke-id> <error>]]` into the
   spawning parent so its macrostep fires the declarative `:spawn :on-error`
-  transition (rf2-5hlsh). `error` is the failure payload that rides on the
+  transition. `error` is the failure payload that rides on the
   parent transition's `:event` (the child's `:output-key` slot for the
   error-leaf trigger, or the exception envelope for the action-exception
   trigger). No-op when the `:router/dispatch!` hook is absent (pure-fn /

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
@@ -61,8 +61,7 @@
                   spawn-slot prune)
     :parent-id  — the spawning actor's id (declarative form only)
     :invoke-id  — the absolute invocation prefix-path the runtime stamped
-                  on the child at spawn time (rf2-0ggtr5 — was `:spawn-id`;
-                  declarative form only)
+                  on the child at spawn time (declarative form only)
 
   When `:parent-id` and `:invoke-id` are both supplied, the
   `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot is

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
@@ -5,16 +5,14 @@
   `:rf.machine/system-id-released` ARE the contract surface that tools
   (Xray, story-mcp, re-frame-10x) key on for the actor-destroy signal.
   Independent emission sites = independent chances to drift in the
-  argument-map keys; rf2-ur63f / round-2 audit Trace-r2-3 consolidates
-  the three `:rf.machine/destroyed` sites and the two
-  `:rf.machine/system-id-released` sites into a single home so a key
-  rename is one-edit-touches-all.
+  argument-map keys; the three `:rf.machine/destroyed` sites and the two
+  `:rf.machine/system-id-released` sites emit through this single home so a
+  key rename is one-edit-touches-all.
 
   This namespace is the natural home (rather than `teardown.cljc`)
-  because `teardown.cljc` is the unified pure app-db projection
-  (rf2-lha2t) — it deliberately emits NO traces so the projection stays
-  a value→value function. These helpers ARE side effects, so they live
-  separately."
+  because `teardown.cljc` is the unified pure app-db projection — it
+  deliberately emits NO traces so the projection stays a value→value
+  function. These helpers ARE side effects, so they live separately."
   (:require [re-frame.machines.reply :as m-reply]
             [re-frame.trace :as trace]))
 
@@ -23,13 +21,13 @@
 (defn emit-destroyed!
   "Fire `:rf.machine/destroyed` against the canonical argument map.
 
-  Per the rf2-vgkdt destroyed-trace-shape contract (assertion test in
+  Per the destroyed-trace-shape contract (assertion test in
   `re-frame.destroyed-trace-shape-test`), the permitted site-provided
   keys are `#{:frame :actor-id :system-id :parent-id :invoke-id
   :child-id :reason}`. `:actor-id` is the destroyed actor's live INSTANCE
-  address (rf2-ws5thu — reserving `:machine-id` for the registered TYPE);
-  `:invoke-id` (rf2-0ggtr5 — was `:spawn-id`) is the declarative
-  invocation path. Callers pass only the slots their site populates —
+  address (`:machine-id` is reserved for the registered TYPE);
+  `:invoke-id` is the declarative invocation path. Callers pass only the
+  slots their site populates —
   `nil` values are stamped through, matching pre-consolidation behaviour
   (e.g. `destroy-single!` always stamps `:system-id`, even when nil;
   `destroy-spawn-all-children!` per-child fires omit `:system-id` by NOT
@@ -38,9 +36,9 @@
   `reason` is the discriminator — `:explicit` for direct-destroy
   cascades, `:rf.machine/finished` for final-state auto-destroy.
 
-  rf2-sfunt8 — an `:explicit` destroy is a CANCELLATION of an in-progress
-  actor work attempt (the actor was torn down before reaching a `:final?`
-  leaf), so it closes the work attempt the reply-envelope way: a
+  An `:explicit` destroy is a CANCELLATION of an in-progress actor work
+  attempt (the actor was torn down before reaching a `:final?` leaf), so
+  it closes the work attempt the reply-envelope way: a
   `:status :cancelled` reply (cancellation as DATA, not the absence of a
   reply — Managed-Effects §Cancellation; EP-0011 §Cancellation). The
   reply-envelope facts (`:work/id` keyed on the destroyed actor instance,
@@ -90,7 +88,7 @@
     (trace/emit! :rf.machine :rf.machine/system-id-released
                  {:frame      frame-id
                   :system-id  sid
-                  ;; rf2-ws5thu — the released actor's live INSTANCE address;
+                  ;; the released actor's live INSTANCE address;
                   ;; `:machine-id` is reserved for the registered TYPE.
                   :actor-id   actor-id})))
 

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
@@ -44,9 +44,9 @@
   (destroyed / not-yet-materialised) or when `:rf/machine-id` is absent.
   Per Spec 005 §Snapshot-level escape hatch.
 
-  Validation scope (rf2-ny0yrz CL1): the merged candidate's `:data` IS
-  validated against the actor's `:data-schema` (rf2-wrrvs7, below). A
-  `:state` / `:meta` patch is NOT occupiability-checked — the escape hatch
+  Validation scope: the merged candidate's `:data` IS validated against the
+  actor's `:data-schema` (below). A `:state` / `:meta` patch is NOT
+  occupiability-checked — the escape hatch
   trusts the caller to supply a `:state` that resolves to a real, occupiable
   state-node of the machine's definition. A `:state` patch naming a non-
   existent / non-occupiable node writes a snapshot the next transition will
@@ -57,9 +57,9 @@
   low-frequency \"I need to touch `:state` + something else atomically\"
   primitive, not a guarded `:on`-transition."
   [{frame-id :frame} args]
-  (let [;; EP-0002 carried invariant — the cascade envelope frame is the
-        ;; fx-context `:frame`; a nil stamp is an invariant failure
-        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+  (let [;; The cascade envelope frame is the fx-context `:frame`; a nil
+        ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
+        ;; never a synthesised `:rf/default`.
         frame-id   (frame/require-frame-stamp!
                      frame-id :rf.machine/update-snapshot
                      {:where 'rf.machine/update-snapshot
@@ -71,10 +71,10 @@
       ;; (Spec 005:463). Canonical id / tags per Spec 009 §Error event
       ;; catalogue.
       ;;
-      ;; rf2-x9haxl — align the addressed-id tag shape with the action-effect
-      ;; path (`transition/enforce-db-disallow`) and Spec 009 §`:rf.machine/*`
-      ;; (rf2-yyvtk5): the offending write ran against a LIVE actor INSTANCE, so
-      ;; it rides under `:actor-id` — `:rf.machine/update-snapshot` carries the
+      ;; The addressed-id tag shape aligns with the action-effect path
+      ;; (`transition/enforce-db-disallow`) and Spec 009 §`:rf.machine/*`:
+      ;; the offending write ran against a LIVE actor INSTANCE, so it rides
+      ;; under `:actor-id` — `:rf.machine/update-snapshot` carries the
       ;; actor id under `:rf/machine-id`, which IS the running instance address
       ;; (a singleton's registration id, or a spawned actor's `<type>#<n>` /
       ;; fixed id). `:offending-value` (the whole app-db the patch wrongly
@@ -89,11 +89,11 @@
                             :recovery        :logged-and-skipped}))
       (let [clean-patch (select-keys patch permitted-patch-keys)]
         (when (seq clean-patch)
-          ;; Machine snapshots are durable runtime-db state (rf2-vzld77):
-          ;; the escape-hatch patch is a runtime-db partition write.
+          ;; Machine snapshots are durable runtime-db state: the
+          ;; escape-hatch patch is a runtime-db partition write.
           ;;
-          ;; rf2-wrrvs7 — the escape-hatch `:data` patch is NOT exempt
-          ;; from the `:where :machine-data` boundary. Spec 005 §Snapshot-
+          ;; The escape-hatch `:data` patch is NOT exempt from the
+          ;; `:where :machine-data` boundary. Spec 005 §Snapshot-
           ;; level escape hatch says user error/status state lives under
           ;; `:data` *where `:data-schema` validation covers it*. The fx
           ;; runs on the single drainer (Spec 002), so read-then-write is

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -8,19 +8,18 @@
   macro, the registrar, Xray) inspect the `ex-data`. The validators
   in this namespace are:
 
-    - `validate-history!` — `:type :history` pseudo-state shape
-      (rf2-mle6e.3): placement, closed key-set, one-per-compound,
+    - `validate-history!` — `:type :history` pseudo-state shape:
+      placement, closed key-set, one-per-compound,
       `:default-target` resolution.
-    - `validate-parallel!` — `:type :parallel` shape (rf2-l67o).
+    - `validate-parallel!` — `:type :parallel` shape.
     - `validate-spawn!` — single `:spawn` `:machine-id` xor
-      `:definition` (rf2-vyjq3m).
-    - `validate-spawn-all!` — `:spawn-all` shape (rf2-6vmw).
-    - `validate-no-spawn-timeout-ms!` — rejects the dropped
-      `:timeout-ms` / `:on-timeout` slots on `:spawn` / `:spawn-all`
-      (rf2-3y3y).
-    - `validate-final-state!` — `:final?` shape (rf2-gn80).
+      `:definition`.
+    - `validate-spawn-all!` — `:spawn-all` shape.
+    - `validate-no-spawn-timeout-ms!` — rejects the unsupported
+      `:timeout-ms` / `:on-timeout` slots on `:spawn` / `:spawn-all`.
+    - `validate-final-state!` — `:final?` shape.
     - `validate-machine!` — top-level dispatch + guard/action ref
-      resolution (rf2-oz9t).
+      resolution.
 
   `walk-state-nodes` yields `[state-key state-node]` pairs for every
   node under `:states`, recursing through `:states` maps; used by the
@@ -59,7 +58,7 @@
                          {:recovery :fix-registration :extra extras})))
 
 (defn- ref-resolves?
-  "Mirror of the runtime resolver `transition/chase-ref` (rf2-ylpnn): a
+  "Mirror of the runtime resolver `transition/chase-ref`: a
   `:guards` / `:actions` keyword reference resolves iff chasing the
   keyword-indirection chain through `registry` terminates at a fn (a bare
   fn registry value, or the co-located `{:fn <fn> ...}` entry map). A
@@ -76,8 +75,7 @@
    - hits a keyword with no `registry` entry → unresolved (false);
    - re-visits a keyword (a CYCLE) → unresolved (false) — the runtime
      `chase-ref` returns nil on a cycle, treating it as unresolved, so a
-     cyclic indirection is now rejected at registration rather than
-     throwing the same unresolved error at runtime."
+     cyclic indirection is rejected at registration rather than at runtime."
   [registry ref]
   (loop [r ref seen #{}]
     (cond
@@ -90,9 +88,10 @@
       :else                  false)))
 
 (defn- validate-no-spawn-timeout-ms!
-  "Per rf2-3y3y / Spec 005 §Wall-clock timeouts on :spawn — use parent
-  state's `:after`, the pre-release `:timeout-ms` / `:on-timeout` slots
-  on `:spawn` and `:spawn-all` are DROPPED."
+  "Per Spec 005 §Wall-clock timeouts on :spawn — `:timeout-ms` /
+  `:on-timeout` on `:spawn` / `:spawn-all` are rejected: registration throws
+  `:rf.error/spawn-timeout-ms-removed`. Express a wall-clock spawn timeout
+  via the parent state's `:after` slot instead."
   [state-key state-node]
   (doseq [[slot-key spec]
           [[:spawn     (:spawn state-node)]
@@ -115,17 +114,16 @@
                     :migration  "migration/from-re-frame-v1/README.md §M-44"})))))))
 
 (defn- spawn-id-xor-definition-error
-  "The XOR check shared by single `:spawn` and each `:spawn-all` child
-  (rf2-vyjq3m): a spawn-spec must declare EXACTLY ONE of `:machine-id` /
+  "The XOR check shared by single `:spawn` and each `:spawn-all` child:
+  a spawn-spec must declare EXACTLY ONE of `:machine-id` /
   `:definition`. Returns a `:reason` string when the spec violates the XOR
   (neither key, or both keys), or nil when exactly one is present. Per Spec
   005 §`:spawn` (the spec-table key cell \"exactly one of these\") +
-  Spec-Schemas §`:rf/state-node` — making \"exactly one of `:machine-id` or
-  `:definition`\" a registration-time constraint (previously only the
-  neither-`:spawn-all`-child case was rejected; single `:spawn` and the
-  both-set case both slipped through, so a both-set spec could initialise a
-  child from the inline `:definition` while stamping `:rf/machine-type` from
-  the registered `:machine-id` — a lazy-resolution / restore type mismatch)."
+  Spec-Schemas §`:rf/state-node` — \"exactly one of `:machine-id` or
+  `:definition`\" is a registration-time constraint. (A both-set spec would
+  otherwise initialise a child from the inline `:definition` while stamping
+  `:rf/machine-type` from the registered `:machine-id` — a lazy-resolution /
+  restore type mismatch.)"
   [spec]
   (let [has-id?  (contains? spec :machine-id)
         has-def? (contains? spec :definition)]
@@ -137,7 +135,7 @@
       :else nil)))
 
 (defn- validate-spawn-all!
-  "Per Spec 005 §Spawn-and-join via `:spawn-all` (rf2-6vmw): walk the
+  "Per Spec 005 §Spawn-and-join via `:spawn-all`: walk the
   state tree at registration time and reject malformed `:spawn-all`
   declarations.
 
@@ -176,11 +174,10 @@
                      "each child spawn-spec must declare an :id keyword"
                      {:state state-key
                       :child c})))
-          ;; rf2-vyjq3m: a child spawn-spec must declare EXACTLY ONE of
-          ;; `:machine-id` / `:definition` (XOR) — previously only the
-          ;; NEITHER case was rejected; a child carrying BOTH keys slipped
-          ;; through `(or :machine-id :definition)` and could materialise a
-          ;; different machine type on restore than the one that spawned it.
+          ;; A child spawn-spec must declare EXACTLY ONE of
+          ;; `:machine-id` / `:definition` (XOR). A child carrying BOTH keys
+          ;; would otherwise materialise a different machine type on restore
+          ;; than the one that spawned it.
           (when-let [reason (spawn-id-xor-definition-error c)]
             (throw (validation-error
                      :rf.error/machine-spawn-all-bad-shape
@@ -228,7 +225,7 @@
                     :join join})))))))
 
 (defn- validate-parallel!
-  "Per Spec 005 §Parallel regions (rf2-l67o / Stage 2) and Spec-Schemas
+  "Per Spec 005 §Parallel regions and Spec-Schemas
   §`:rf/transition-table` §`:type :parallel` constraint: when a root
   state-node declares `:type :parallel`, validate the shape at
   registration time.
@@ -242,23 +239,23 @@
       state-tree declares `:type :parallel`; nested parallel regions
       aren't supported in v1.
     - `:rf.error/machine-parallel-on-done-target` — the parallel root's
-      `:on-done` declares an in-machine `:target` in ANY value form
-      (rf2-bnjb3 / rf2-6srk5): a bare-keyword target, a vector-path target,
+      `:on-done` declares an in-machine `:target` in ANY value form:
+      a bare-keyword target, a vector-path target,
       a map with `:target`, or a candidate vector containing a target map.
       A root-only `:type :parallel` machine has no sibling flat state to
       land a target on; the parallel `:on-done` runs its `:action` + emits
       `:fx` (the \"then continue\" is a dispatch/raise in that fx), never an
-      in-machine transition target. (Before rf2-6srk5 only the map / vector-
-      of-maps forms were rejected, so bare-keyword and vector-path targets
-      slipped through to a silent runtime stall.)
+      in-machine transition target. Every target-bearing value form is
+      rejected (an accepted target would silently stall the all-final
+      configuration).
     - `:rf.error/machine-parallel-root-on-bad-target` — a root parallel `:on`
-      transition's `:target` is NOT region-qualified (rf2-tsq6g). The root
+      transition's `:target` is NOT region-qualified. The root
       `:on` is the ancestor fallback; a `:target` must name one or more
       regions — `[<region> & <in-region-path>]` (single) or
       `[[<region> …] [<region> …]]` (multiple). A bare keyword / a head that
       is not a declared region is rejected (the root has no flat sibling state
       to land a non-region-qualified target on).
-    Per rf2-wox0vd a `:type :parallel` ROOT MAY now declare `:after` — it is
+    A `:type :parallel` ROOT MAY declare `:after` — it is
     ROOT-OWNED (scheduled at machine birth, alive for the whole machine,
     stale-gated by the root's own per-path epoch). Its `:target` reuses the
     EXACT region-qualified grammar root `:on` targets use, so a non-region-
@@ -273,22 +270,23 @@
       (throw (validation-error
                :rf.error/machine-parallel-bad-shape
                ":type :parallel requires a non-empty :regions map")))
-    ;; Per rf2-bnjb3 / rf2-6srk5: the parallel root's `:on-done` must not carry
-    ;; an in-machine `:target` in ANY form (root-only parallel has no flat
-    ;; sibling to land on). Normalise EVERY value-form `:on-done` admits —
-    ;; mirroring `transition/normalise-candidates` (the runtime grammar the
+    ;; The parallel root's `:on-done` must not carry an in-machine `:target`
+    ;; in ANY form (root-only parallel has no flat sibling to land on).
+    ;; Normalise EVERY value-form `:on-done` admits — mirroring
+    ;; `transition/normalise-candidates` (the runtime grammar the
     ;; parallel-root `apply-on-done-action` resolves through) — to its
     ;; candidate map(s), then reject if any candidate declares `:target`.
     ;;
-    ;; The pre-rf2-6srk5 check only normalised the MAP and vector-of-maps forms,
-    ;; so a bare-keyword target (`:on-done :next`) and a vector-path target
-    ;; (`:on-done [:next]`) slipped past validation, then normalised at runtime
-    ;; to a `:target`-only / action-less candidate that `apply-on-done-action`
-    ;; selected, ran no action for, marked the done signal handled (suppressing
-    ;; auto-destroy), and moved nowhere — a SILENT STALL in the all-final
-    ;; configuration. Per the loud-failure posture, every target-bearing form
-    ;; must be rejected loudly at registration. Action / fx-only `:on-done`
-    ;; (no `:target`) stays accepted.
+    ;; This covers every target-bearing form: a bare-keyword target
+    ;; (`:on-done :next`), a vector-path target (`:on-done [:next]`), a map
+    ;; with `:target`, and a candidate vector containing a target map. An
+    ;; accepted target would normalise at runtime to a `:target`-only /
+    ;; action-less candidate that `apply-on-done-action` selects, runs no
+    ;; action for, marks the done signal handled (suppressing auto-destroy),
+    ;; and moves nowhere — a SILENT STALL in the all-final configuration. Per
+    ;; the loud-failure posture, every target-bearing form is rejected loudly
+    ;; at registration. Action / fx-only `:on-done` (no `:target`) stays
+    ;; accepted.
     (when (contains? machine :on-done)
       (let [on-done (:on-done machine)
             ;; Mirror transition/normalise-candidates: keyword → {:target kw};
@@ -315,22 +313,22 @@
                         "dispatch to a coordinator). Per Spec 005 §Final states "
                         "§The done-state signal.")
                    {:on-done on-done})))))
-    ;; Per rf2-tsq6g: every root parallel `:on` transition's `:target` (if
-    ;; present) MUST be region-qualified — the root ancestor fallback has no
-    ;; flat sibling state to land a bare-keyword / non-region target on. A
-    ;; target is either a single region-qualified path `[<region> &
-    ;; <in-region-path>]` (a vector whose head is a declared region) OR
-    ;; multiple such paths `[[<region> …] [<region> …]]` (a vector of
-    ;; vectors). A targetless / action-only transition is fine (no target to
-    ;; check). The check normalises each `:on` entry to its candidate map(s)
-    ;; and validates each candidate's `:target`.
+    ;; Every root parallel `:on` transition's `:target` (if present) MUST be
+    ;; region-qualified — the root ancestor fallback has no flat sibling state
+    ;; to land a bare-keyword / non-region target on. A target is either a
+    ;; single region-qualified path `[<region> & <in-region-path>]` (a vector
+    ;; whose head is a declared region) OR multiple such paths
+    ;; `[[<region> …] [<region> …]]` (a vector of vectors). A targetless /
+    ;; action-only transition is fine (no target to check). The check
+    ;; normalises each `:on` entry to its candidate map(s) and validates each
+    ;; candidate's `:target`.
     ;;
-    ;; Per rf2-wox0vd the SAME region-qualified target grammar governs a
-    ;; root-owned `:after` transition (the timer-driven analog of the root
-    ;; `:on` ancestor fallback), so a non-region-qualified root `:after`
-    ;; target is rejected with the SAME `:rf.error/machine-parallel-root-on-
-    ;; bad-target` keyword. `candidates-of` is the shared `:on` / `:after`
-    ;; value-form normaliser (mirroring `transition/normalise-candidates`).
+    ;; The SAME region-qualified target grammar governs a root-owned `:after`
+    ;; transition (the timer-driven analog of the root `:on` ancestor
+    ;; fallback), so a non-region-qualified root `:after` target is rejected
+    ;; with the SAME `:rf.error/machine-parallel-root-on-bad-target` keyword.
+    ;; `candidates-of` is the shared `:on` / `:after` value-form normaliser
+    ;; (mirroring `transition/normalise-candidates`).
     (let [region-names (set (keys (:regions machine)))
           declared?    (fn [t] (contains? region-names t))
           bad-target!  (fn [slot target]
@@ -418,7 +416,7 @@
   recursing through `:states` maps. Used by the registration-time
   validators.
 
-  Per Spec 005 §Parallel regions (rf2-l67o / Stage 2): for parallel-region
+  Per Spec 005 §Parallel regions: for parallel-region
   machines, walks the state nodes under every region's `:states`. Region-
   name keywords are NOT yielded as state keys (they're region identifiers,
   not states)."
@@ -439,11 +437,10 @@
       (walk [] (:states machine)))))
 
 ;; Per Spec 005 §History states (`:type :history` — shallow / deep /
-;; default-target) §Pseudo-state constraints (rf2-mle6e.1, PR #2863): the
-;; v1 CLJS reference claims `:fsm/history`, so a `:type :history` node is
-;; FIRST-CLASS grammar — no longer rejected. `make-machine-handler`
-;; validates the pseudo-state's shape at registration (the same layer that
-;; rejects malformed compound states):
+;; default-target) §Pseudo-state constraints: the v1 CLJS reference claims
+;; `:fsm/history`, so a `:type :history` node is FIRST-CLASS grammar.
+;; `make-machine-handler` validates the pseudo-state's shape at registration
+;; (the same layer that rejects malformed compound states):
 ;;
 ;;   - a `:type :history` node MUST be declared inside a compound state's
 ;;     `:states` (it has an owning compound whose configuration it
@@ -459,14 +456,14 @@
 ;;     direct child of the owning compound (keyword form) or an absolute
 ;;     path the definition declares (vector form).
 ;;
-;; The legacy `:history` state-node KEY form (`{:a {:history {...}}}`) and
+;; The `:history` state-node KEY form (`{:a {:history {...}}}`) and
 ;; a root / region `:type :history` are NOT part of the grammar — they are
 ;; misplaced-history registration errors (`:rf.error/machine-history-
 ;; misplaced`), the named error every other malformed-placement case uses.
 ;; Per Spec 009 §Error contract the recovery is `:no-recovery` (registration
 ;; is rejected). The precise error-id catalogue for history-grammar
-;; violations is owned by Spec 009 (mle6e.2); these ids conform to that
-;; family's `:rf.error/machine-history-*` naming.
+;; violations is owned by Spec 009; these ids conform to that family's
+;; `:rf.error/machine-history-*` naming.
 
 (def ^:private history-pseudo-keys
   "The closed key-set a `:type :history` pseudo-state may carry. Anything
@@ -622,8 +619,7 @@
   compound), the closed key-set, at-most-one-per-compound, and
   `:default-target` resolution.
 
-  Replaces the withdrawn `:rf.error/machine-grammar-not-in-v1` deferral
-  (rf2-mle6e.1, PR #2863): history is now claimed (`:fsm/history`). A
+  History is first-class grammar (`:fsm/history`). A
   `:type :history` node at the machine root, or directly on a region body
   with no enclosing compound, is `:rf.error/machine-history-misplaced`."
   [machine]
@@ -651,7 +647,7 @@
     (validate-history-scope! :rf/root (:states machine))))
 
 (defn- validate-final-state!
-  "Per Spec 005 §Final states (rf2-gn80) §`:final?` constraints:
+  "Per Spec 005 §Final states §`:final?` constraints:
 
    - A `:final?` state MUST NOT be compound (no `:states`, no `:initial`).
    - A `:final?` state MUST NOT declare `:on`, `:always`, `:after`,
@@ -659,7 +655,7 @@
      transitions out. `:entry` and `:exit` ARE permitted.
    - A non-final state declaring `:output-key` is a registration error
      (`:rf.error/machine-output-key-without-final`).
-   - Per Spec 005 §`:on-error` (rf2-5hlsh): a `:final?` leaf MAY declare
+   - Per Spec 005 §`:on-error`: a `:final?` leaf MAY declare
      `:error? true` — a designated ERROR terminal (re-frame2's spelling of
      XState v5's error final). A child finishing via an error leaf routes to
      the spawning parent's `:spawn :on-error` transition instead of
@@ -695,8 +691,8 @@
              {:state      state-key
               :output-key (:output-key state-node)}))
 
-    ;; Non-final state declaring :error? — error per rf2-5hlsh (symmetric
-    ;; with :output-key). `:error?` designates an error TERMINAL; it is
+    ;; Non-final state declaring :error? — error (symmetric with
+    ;; :output-key). `:error?` designates an error TERMINAL; it is
     ;; meaningless on a non-final state.
     (contains? state-node :error?)
     (throw (validation-error
@@ -707,14 +703,13 @@
               :error? (:error? state-node)}))))
 
 (defn- validate-spawn!
-  "Per Spec 005 §`:spawn` + Spec-Schemas §`:rf/state-node` (rf2-vyjq3m): a
+  "Per Spec 005 §`:spawn` + Spec-Schemas §`:rf/state-node`: a
   single `:spawn`-bearing state node's spawn-spec must declare EXACTLY ONE of
   `:machine-id` / `:definition`. Rejects both-set and neither-set at
-  registration with `:rf.error/machine-spawn-bad-shape` (fail-closed) — the
-  contract promised registration-time rejection but `validate-machine!`
-  previously had NO single-`:spawn` XOR check, so a malformed spec deferred to
-  a late actor-id allocation failure (neither) or a silent type mismatch on
-  restore (both). `:spawn-all` children are checked by `validate-spawn-all!`
+  registration with `:rf.error/machine-spawn-bad-shape` (fail-closed) —
+  without this gate a malformed spec would defer to a late actor-id
+  allocation failure (neither) or a silent type mismatch on restore (both).
+  `:spawn-all` children are checked by `validate-spawn-all!`
   (the `:spawn` / `:spawn-all` mutual exclusion means at most one runs here).
   Absent `:spawn` is fine."
   [state-key state-node]
@@ -728,7 +723,7 @@
                   :spawn spawn}))))))
 
 (defn- validate-spawn-on-error!
-  "Per Spec 005 §Final states §`:on-error` (rf2-5hlsh): a `:spawn`-bearing
+  "Per Spec 005 §Final states §`:on-error`: a `:spawn`-bearing
   state's `:spawn :on-error` is an `:on`-shaped transition spec — a keyword
   target, a vector-path target, a single transition map `{:target :guard
   :actions}`, or a guarded candidate vector. Reject a malformed `:on-error`
@@ -793,7 +788,7 @@
   "True iff an `:always` entry's `:target` resolves to its own declaring
   state at `path` (a self-loop). The `:same-state` sentinel is an explicit
   external self-target (it re-enters the declaring state — see Spec 005
-  §Self-transitions, rf2-46ban), so it is always a self-loop. A keyword
+  §Self-transitions), so it is always a self-loop. A keyword
   target names a sibling at the declaring level — it self-targets when it
   equals the declaring state's own key (the last element of `path`). A
   vector target is an absolute path — it self-targets when it equals `path`.
@@ -893,7 +888,7 @@
       (let [scope (:states machine)]
         (walk scope [] scope)))))
 
-;; ---- transition target shape + resolution (rf2-w84jv) ---------------------
+;; ---- transition target shape + resolution ---------------------------------
 ;;
 ;; Per Spec 005 (005:441 "the snapshot's :state slot is already validated at
 ;; registration time — a transition targeting an unknown state fails
@@ -903,24 +898,22 @@
 ;; declaring state's parent compound), a non-empty vector path (absolute from
 ;; the region/machine root), or the `:same-state` self-target sentinel.
 ;; Anything else is malformed; a keyword / vector that does not resolve to a
-;; real node is an unresolved target. Before rf2-w84jv the validator checked
-;; only `:guard` / `:action` refs, so `{:target 42}` registered and threw
-;; `:rf.error/machine-bad-state-form` later at dispatch, and `{:target
-;; [:missing]}` registered and committed an invalid snapshot — false-green
-;; registration + brittle runtime failures. This block closes the gap loudly,
-;; aligned with XState v5 (which rejects unresolvable targets at machine
-;; creation). The parallel ROOT's own region-qualified `:on` / `:on-done`
-;; targets have DIFFERENT (region-qualified) semantics and are validated by
-;; `validate-parallel!`; this block walks only per-region / flat state nodes.
+;; real node is an unresolved target. Both are rejected loudly at
+;; registration: `{:target 42}` is a malformed shape, `{:target [:missing]}`
+;; is unresolved. This is aligned with XState v5 (which rejects unresolvable
+;; targets at machine creation). The parallel ROOT's own region-qualified
+;; `:on` / `:on-done` targets have DIFFERENT (region-qualified) semantics and
+;; are validated by `validate-parallel!`; this block walks only per-region /
+;; flat state nodes.
 
 (def ^:private candidate-targets
   "Normalise a transition slot's value (an `:on` entry, an `:after` entry,
   an `:on-done`, a `:spawn :on-error`) to the seq of `:target`s it declares,
   each tagged with `:present?`. The shared `grammar/candidate-targets`,
   built on the SAME `grammar/transition-value-form` recogniser the runtime
-  normaliser (`transition/normalise-candidates`) uses — so this is no
-  longer a hand-kept mirror but the one grammar layer by construction. The
-  `:present?` marker distinguishes \"`:target` key absent\" (internal
+  normaliser (`transition/normalise-candidates`) uses — so registration and
+  the runtime share one grammar layer by construction. The `:present?` marker
+  distinguishes \"`:target` key absent\" (internal
   transition — always fine) from \"`:target` present but malformed\" (e.g.
   `{:target nil}`)."
   grammar/candidate-targets)
@@ -995,7 +988,7 @@
               :target target}))))
 
 (defn- valid-after-delay-key?
-  "Per rf2-apfait + Spec-Schemas §`:rf/state-node` `:after` (1699-1705):
+  "Per Spec-Schemas §`:rf/state-node` `:after` (1699-1705):
   an `:after` map KEY (the delay) is well-formed iff it is one of the
   three closed forms:
 
@@ -1019,7 +1012,7 @@
         (fn? delay-key))))
 
 (defn- validate-after-delays!
-  "Per rf2-apfait — reject any `:after` map KEY that is not a positive
+  "Reject any `:after` map KEY that is not a positive
   integer, a non-empty subscription vector, or a function, at
   registration. Walks every transition-bearing node: each state node
   (`walk-state-nodes`), every region root + the parallel root, and the
@@ -1062,7 +1055,7 @@
       (check-key! :rf/root delay-key))))
 
 (defn- validate-transition-targets!
-  "Per Spec 005 (005:441) + Spec-Schemas §TransitionTarget (rf2-w84jv):
+  "Per Spec 005 (005:441) + Spec-Schemas §TransitionTarget:
   reject malformed-shape and unresolved transition `:target`s at registration
   for every transition-bearing slot of every per-region / flat state node —
   `:on`, `:after`, `:always`, a compound's `:on-done`, and a `:spawn`-bearing
@@ -1072,9 +1065,9 @@
 
   Catches `{:target 42}` (malformed → `:rf.error/machine-bad-target`) and
   `{:target [:missing]}` (unresolved → `:rf.error/machine-unresolved-target`)
-  at registration rather than at the triggering dispatch (where the former
-  threw `:rf.error/machine-bad-state-form` and the latter committed an invalid
-  snapshot)."
+  at registration rather than at the triggering dispatch (where a malformed
+  target would otherwise throw `:rf.error/machine-bad-state-form` and an
+  unresolved one would commit an invalid snapshot)."
   [machine]
   (doseq [[scope path node] (walk-state-nodes-with-scope machine)]
     (let [state-key (peek path)
@@ -1094,35 +1087,35 @@
         (check! :spawn/on-error oe)))))
 
 (defn validate-machine!
-  "Run every registration-time check the machine grammar requires (rf2-f9tu).
+  "Run every registration-time check the machine grammar requires.
   Composed at the top of `make-machine-handler` so the registered handler
   fn's body is exclusively about request processing.
 
-  Per Spec 005 §History states §Pseudo-state constraints (rf2-mle6e.3):
+  Per Spec 005 §History states §Pseudo-state constraints:
   every `:type :history` pseudo-state — placement (must have an owning
   compound), the closed `:type` / `:deep?` / `:default-target` key-set,
   at-most-one-per-compound, and `:default-target` resolution. Throws
   `:rf.error/machine-history-misplaced` / `-extra-keys` / `-duplicate` /
   `-bad-default-target`.
 
-  Per Spec 005 §Parallel regions (rf2-l67o / Stage 2): `:type :parallel`
+  Per Spec 005 §Parallel regions: `:type :parallel`
   shape — `:regions` non-empty, mutually exclusive with `:initial` /
   `:states`, no nested parallel.
 
-  Per Spec 005 §Spawn-and-join via `:spawn-all` (rf2-6vmw): every
+  Per Spec 005 §Spawn-and-join via `:spawn-all`: every
   `:spawn-all`-bearing state node — shape, no duplicate `:id`s, required
   join-event keys per `:join` form, mutually exclusive with `:spawn`.
 
-  Per Spec 005 §`:spawn` + Spec-Schemas §`:rf/state-node` (rf2-vyjq3m):
+  Per Spec 005 §`:spawn` + Spec-Schemas §`:rf/state-node`:
   every single `:spawn`-bearing state node — and every `:spawn-all` child —
   must declare EXACTLY ONE of `:machine-id` / `:definition` (XOR). Throws
   `:rf.error/machine-spawn-bad-shape` (single `:spawn`) /
   `:rf.error/machine-spawn-all-bad-shape` (child) on both-set or neither-set.
 
-  Per rf2-3y3y: every `:spawn` / `:spawn-all` rejects the dropped
+  Every `:spawn` / `:spawn-all` rejects the unsupported
   `:timeout-ms` / `:on-timeout` slot (use parent `:after`).
 
-  Per rf2-oz9t: every `:on` / `:always` / `:entry` / `:exit` slot's guard
+  Every `:on` / `:always` / `:entry` / `:exit` slot's guard
   and action keyword refs must resolve against the machine's `:guards` /
   `:actions` maps. Throws `:rf.error/machine-unresolved-guard` /
   `:rf.error/machine-unresolved-action` on dangling refs.
@@ -1135,14 +1128,14 @@
   that targets its own declaring state is rejected. Throws
   `:rf.error/machine-always-self-loop`.
 
-  Per Spec 005 (005:441) + Spec-Schemas §TransitionTarget (rf2-w84jv):
+  Per Spec 005 (005:441) + Spec-Schemas §TransitionTarget:
   every transition slot's `:target` (`:on` / `:after` / `:always` /
   compound `:on-done` / `:spawn :on-error`) must be a well-formed,
   resolvable target. Throws `:rf.error/machine-bad-target` (malformed
   shape) / `:rf.error/machine-unresolved-target` (keyword / vector that
   names no declared state).
 
-  Per rf2-apfait + Spec-Schemas §`:rf/state-node` `:after`: every `:after`
+  Per Spec-Schemas §`:rf/state-node` `:after`: every `:after`
   map KEY (the delay) must be a positive integer, a non-empty subscription
   vector, or a function. Throws `:rf.error/machine-bad-after-delay` for a
   static key that is none of those (`-1`, `0`, `\"soon\"`, `nil`, `[]`) —
@@ -1162,9 +1155,9 @@
   ;; resolve vector `:target`s, so it drives off the path-aware walker.
   (doseq [[path n] (walk-state-nodes-with-path machine)]
     (validate-always-self-loop! path (peek path) n))
-  ;; rf2-w84jv: every transition slot's `:target` shape + resolution.
+  ;; Every transition slot's `:target` shape + resolution.
   (validate-transition-targets! machine)
-  ;; rf2-apfait: every `:after` delay KEY must be a positive integer, a
+  ;; Every `:after` delay KEY must be a positive integer, a
   ;; non-empty subscription vector, or a function — gated at registration
   ;; rather than degrading to an fx-time :rf.warning/no-clock-configured.
   (validate-after-delays! machine)
@@ -1173,7 +1166,7 @@
   ;; a placeholder; real misuse traces at handler-call time fill it in.
   (let [guards-map  (:guards machine)
         actions-map (:actions machine)
-        ;; Follow the FULL chase-ref chain (rf2-ylpnn), not just the first
+        ;; Follow the FULL chase-ref chain, not just the first
         ;; key — a multi-hop keyword indirection (`{:a :b}` → `:b`) whose
         ;; terminal hop is missing, or a cyclic indirection, is rejected
         ;; here at registration rather than throwing the same unresolved
@@ -1209,8 +1202,8 @@
       ;; Per Spec 005 §Delayed `:after` (005:1334 "exactly as for `:on`"):
       ;; `:after` entries may carry `:guard` / `:action` refs (e.g.
       ;; `{1000 {:target :timeout :guard :no-progress?}}`). A dangling
-      ;; `:after` ref previously slipped past registration and only threw
-      ;; at runtime when the timer fired — fail fast here instead.
+      ;; `:after` ref is failed fast here at registration rather than at
+      ;; runtime when the timer fires.
       (doseq [[_ t] (:after state-node)]
         (check-transition! t s))
       ;; `:always` admits a single entry map OR a vector of entry maps;
@@ -1221,12 +1214,12 @@
       (doseq [t (always-entries state-node)]
         (check-guard!  (:guard t)  s)
         (check-action! (:action t) s))
-      ;; Per Spec 005 §Final states §The done-state signal (rf2-bnjb3 /
-      ;; rf2-zlmz7): an `:on-done` on a compound node is an `:on`-shaped
-      ;; transition (fired when the compound reaches a `:final?` child); its
-      ;; guard / action refs must resolve at registration like any other slot.
+      ;; Per Spec 005 §Final states §The done-state signal: an `:on-done` on
+      ;; a compound node is an `:on`-shaped transition (fired when the
+      ;; compound reaches a `:final?` child); its guard / action refs must
+      ;; resolve at registration like any other slot.
       (check-transition! (:on-done state-node) s)
-      ;; Per Spec 005 §Final states §`:on-error` (rf2-5hlsh): a `:spawn`-bearing
+      ;; Per Spec 005 §Final states §`:on-error`: a `:spawn`-bearing
       ;; state's `:spawn :on-error` is an `:on`-shaped transition fired when a
       ;; spawned child fails; its guard / action refs resolve at registration
       ;; like `:on-done`. (Shape is checked separately by `validate-spawn-on-error!`.)
@@ -1234,24 +1227,20 @@
       (check-action! (:entry state-node) s)
       (check-action! (:exit  state-node) s))
     ;; Per Spec 005 §Transition resolution: the machine root's own `:on`
-    ;; fallback (now consulted at runtime per the root-`:on` fix) carries
-    ;; `:guard` / `:action` refs that must resolve at registration too —
-    ;; previously `walk-state-nodes` only descended `:states`, so a
-    ;; dangling root-`:on` / root-`:after` ref escaped validation
-    ;; entirely. `walk-state-nodes` yields the nodes INSIDE each region's
-    ;; `:states` but not the region body itself, so a parallel machine's
-    ;; per-region root `:on` / `:after` (which IS consulted at runtime via
-    ;; the region's own `machine-transition-single` root fallback) is
-    ;; validated here too.
+    ;; fallback (consulted at runtime) carries `:guard` / `:action` refs that
+    ;; must resolve at registration too. `walk-state-nodes` yields the nodes
+    ;; INSIDE each region's `:states` but not the region body itself, so a
+    ;; parallel machine's per-region root `:on` / `:after` (which IS consulted
+    ;; at runtime via the region's own `machine-transition-single` root
+    ;; fallback) is validated here too.
     ;;
-    ;; Per rf2-tsq6g: the PARALLEL ROOT's OWN `:on` (the ancestor fallback,
-    ;; now consulted at runtime when no region handles the event) carries
-    ;; `:guard` / `:action` refs that must resolve here too — previously the
-    ;; root-parallel transition path was skipped, so a bad ref there did not
-    ;; surface. The parent parallel root is therefore added to `roots`. (The
-    ;; root-parallel transition target SHAPE — region-qualified — is validated
-    ;; by `validate-parallel!`; this block validates only the guard/action
-    ;; refs, like every other transition slot.)
+    ;; The PARALLEL ROOT's OWN `:on` (the ancestor fallback, consulted at
+    ;; runtime when no region handles the event) carries `:guard` / `:action`
+    ;; refs that must resolve here too, so the parent parallel root is added
+    ;; to `roots`. (The root-parallel transition target SHAPE —
+    ;; region-qualified — is validated by `validate-parallel!`; this block
+    ;; validates only the guard/action refs, like every other transition
+    ;; slot.)
     (let [roots (if (parallel/parallel? machine)
                   (cons machine (vals (:regions machine)))
                   [machine])]
@@ -1261,7 +1250,7 @@
       (doseq [root roots
               [_ t] (:after root)]
         (check-transition! t :rf/root)))
-    ;; Per rf2-bnjb3: the PARALLEL ROOT's own `:on-done` (fired when all
+    ;; The PARALLEL ROOT's own `:on-done` (fired when all
     ;; regions reach final) carries `:guard` / `:action` refs that must
     ;; resolve at registration. (`walk-state-nodes` yields per-region nodes,
     ;; not the parallel root itself, so this is validated explicitly.)

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.machines.parallel
-  "Parallel-region machines. Per Spec 005 §Parallel regions (rf2-l67o /
-  Stage 2).
+  "Parallel-region machines. Per Spec 005 §Parallel regions.
 
   A machine declaring `:type :parallel` carries a `:regions` map of
   region-name → state-tree (each region a full state-node body with its
@@ -27,7 +26,7 @@
   (single vs parallel) so the transition engine doesn't need to know
   the parallel layer exists.
 
-  `:raise` semantics (rf2-yi7ts / rf2-nr434 — XState v5 / SCXML gold
+  `:raise` semantics (XState v5 / SCXML gold
   standard). A flat / compound machine drains its own `:raise` queue FIFO
   inside `re-frame.machines.transition`. A PARALLEL machine owns the
   macrostep's single internal-event queue HERE: each region DEFERS its
@@ -35,7 +34,7 @@
   leaves `:raise` fx un-drained — `transition/drain-to-fixed-point` in
   `defer?` mode), and `parallel-machine-transition` re-broadcasts each
   surfaced raise across EVERY region, FIFO, until the queue settles — then
-  commits once. Each re-broadcast is its own microstep: per rf2-42mml it
+  commits once. Each re-broadcast is its own microstep: it
   re-selects against the config as of THAT microstep's start (a FRESH
   frozen `:all-state` / `:tags` view, reflecting prior-microstep region
   moves) while the in-flight `:data` flows through.
@@ -89,8 +88,8 @@
                 state)))))
 
 (defn all-regions-final?
-  "Per Spec 005 §Parallel regions + §Final states §The done-state signal
-  (rf2-bnjb3): a parallel-region machine has reached its done configuration
+  "Per Spec 005 §Parallel regions + §Final states §The done-state signal:
+  a parallel-region machine has reached its done configuration
   only when the snapshot is a VALID parallel configuration (every declared
   region present + occupiable — `parallel-state-valid?`) AND EVERY region's
   active leaf is `:final?`. Walk each region's body + active path and check
@@ -131,13 +130,13 @@
         (assoc :rf/parent-id      (:rf/parent-id parent-machine))
         (assoc :rf/platform       (:rf/platform parent-machine))
         (assoc :rf/frame          (:rf/frame parent-machine))
-        ;; EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): the causal
+        ;; The causal
         ;; recordable-coeffect token is transition-local, NOT registration-time
         ;; data — `prepare-machine-ctx` stamps `:rf/cofx` per dispatch. The cache
         ;; is populated at registration time, so we must NOT bake a value (or even
         ;; the key) in here: a stale `:rf/cofx` cached from the priming dispatch
-        ;; would otherwise leak into a later transition whose parent carries none
-        ;; (rf2-gqr4vs). `region-spec-overlaid` is the single choke-point that
+        ;; would otherwise leak into a later transition whose parent carries none.
+        ;; `region-spec-overlaid` is the single choke-point that
         ;; overlays the LIVE `:rf/cofx` onto the cached spec — present iff the
         ;; current parent carries it, dissoc'd otherwise — so the absent path
         ;; leaves no stale slot for `callback-ctx`'s presence check to read.
@@ -153,7 +152,7 @@
   fxs the region emits carry the parent's identity (the region name is
   prepended onto the `:rf/invoke-id` separately).
 
-  Per round-2 P-r2-1 (rf2-s83iu): region-specs are registration-time
+  Region-specs are registration-time
   data, not transition-time data. The result is memoised in metadata
   on `parent-machine` itself — re-registration replaces the entire
   machine map, so the old cache becomes garbage automatically and no
@@ -185,9 +184,7 @@
   [region-body]
   (let [decl      (:initial region-body)
         ;; `region-body` already carries `:states` — `initial-cascade`
-        ;; reads it through `node-at`, so pass it directly (the prior
-        ;; `(assoc region-body :states (:states region-body))` re-assoc'd
-        ;; `:states` with the value it already held — a no-op layer).
+        ;; reads it through `node-at`, so pass it directly.
         full-path (transition/initial-cascade region-body (transition/state-path decl))]
     (transition/denormalise-state full-path decl)))
 
@@ -210,12 +207,12 @@
   (let [tags (if (parallel? machine)
                (compute-tags-parallel machine (:state snapshot))
                (transition/compute-tags machine (:state snapshot)))]
-    ;; Per rf2 clarity dedup: the empty→dissoc / else→assoc elision lives
+    ;; The empty→dissoc / else→assoc elision lives
     ;; once in `transition/stamp-tags`; both tag-commit fns delegate to it.
     (transition/stamp-tags snapshot tags)))
 
 (defn build-initial-snapshot
-  "Build the freshly-derived initial snapshot for `machine` (rf2-fgqs4).
+  "Build the freshly-derived initial snapshot for `machine`.
   The single source of truth used by both the singleton-registration path
   (`lifecycle-fx.registration/make-machine-handler`) and the spawn path
   (`lifecycle-fx.spawn/install-spawn!`). Steps:
@@ -225,7 +222,7 @@
       machines, the root `:initial` cascade denormalised to a leaf path.
       Per Spec 005 §Initial-state cascading and §Parallel regions.
    2. Seed `:data` — `(:data machine)` or `{}`.
-   3. Seed `:rf/spawn-counter {}` — per rf2-gr8q the in-snapshot
+   3. Seed `:rf/spawn-counter {}` — the in-snapshot
       allocator MUST be present on live snapshots so
       `:entry`-declared `:spawn`s allocate ids through the contract path
       (not `allocate-spawned-id`'s defensive `(fnil inc 0)` backstop).
@@ -234,9 +231,9 @@
       same `:meta` the spec declares. Spawned actors that declare `:meta`
       MUST carry it through to the snapshot.
    5. Stamp the initial tag union via `commit-tags-parallel` — per Spec
-      005 §State tags (rf2-ee0d) / §Tags compose across regions
-      (rf2-l67o); the slot is elided when the union is empty.
-   6. Optionally stamp `:rf/bootstrap-pending? true` (per rf2-0z73) when
+      005 §State tags / §Tags compose across regions;
+      the slot is elided when the union is empty.
+   6. Optionally stamp `:rf/bootstrap-pending? true` when
       `bootstrap-pending?` is truthy — the spawn path needs this so the
       actor's first dispatch fires the initial-entry cascade. The
       singleton-registration path stamps the marker lazily inside
@@ -262,8 +259,8 @@
 (defn- prefix-region-invoke-id
   "Per Spec 005 §Per-region `:spawn` / `:after` / `:always` scoping:
   spawn / destroy / after-schedule / after-cancel fxs emitted by a region
-  carry an `:rf/invoke-id` (rf2-0ggtr5 — the declarative invocation path;
-  was `:rf/spawn-id`) that's the in-region prefix-path. To keep the
+  carry an `:rf/invoke-id` (the declarative invocation path) that's the
+  in-region prefix-path. To keep the
   runtime-owned `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot unique
   per-region (and per-region `:after` epoch tracking distinct from sibling
   regions), prepend the region name onto the `:rf/invoke-id`."
@@ -275,7 +272,7 @@
 
       :else fx)))
 
-;; ---- initial-state entry cascade (rf2-0z73) -------------------------------
+;; ---- initial-state entry cascade ------------------------------------------
 ;;
 ;; Per Spec 005 §Initial cascading and §Entry/exit cascading along the
 ;; LCA, every state's `:entry` action fires when its state is entered.
@@ -295,7 +292,7 @@
   a `result/ok` Result carrying the post-cascade snapshot + fx, or a
   `result/fail` Result if any `:entry` action threw.
 
-  Per rf2-82a0u: every initial-entry cascade action carries `:phase
+  Every initial-entry cascade action carries `:phase
   :initial-entry` on its `:rf.machine/action-ran` emit so the Handler
   section's LIFECYCLE rendering distinguishes the bootstrap entry
   burst from a later `:on`-driven entry-cascade."
@@ -312,7 +309,7 @@
        :decl-path []}
       :initial-entry)))
 
-;; ---- parallel-region broadcast invariant (rf2-vqubp) ----------------------
+;; ---- parallel-region broadcast invariant ----------------------------------
 ;;
 ;; Per Spec 005 §Parallel regions, every reducer that broadcasts ONE
 ;; per-region computation across a parallel-region machine MUST:
@@ -321,7 +318,7 @@
 ;;     key order when the spec has been mutated post-registration),
 ;;   - thread shared `:data` sequentially through regions so a later
 ;;     region's step sees earlier regions' writes,
-;;   - thread the in-snapshot `:rf/spawn-counter` (rf2-gr8q) so any
+;;   - thread the in-snapshot `:rf/spawn-counter` so any
 ;;     declarative `:spawn` fired in a region bumps the SAME shared
 ;;     counter,
 ;;   - run each region as a synthetic single-machine spec via
@@ -345,11 +342,11 @@
   `parent-machine` threaded into a broadcast DOES carry the current values, so
   overlay them here so region pure logic (`build-after-fx`'s server-skip gate,
   trace `:frame` attribution, declarative-`:spawn` parent attribution) always
-  runs against the live runtime context (rf2-z522n / rf2-r09fc).
+  runs against the live runtime context.
   `(:id parent-machine)` is the defensive `:rf/parent-id` fallback for pure-fn
   callers. The single overlay choke-point shared by the broadcast invariant
   (`reduce-regions`) and the root-parallel `:on` region-target apply
-  (`apply-root-parallel-transition` — rf2-tsq6g)."
+  (`apply-root-parallel-transition`)."
   [parent-machine rn]
   (let [parent-id (or (:rf/parent-id parent-machine) (:id parent-machine))]
     (cond-> (region-machine parent-machine rn)
@@ -359,14 +356,12 @@
       ;; runtime) and must replace any stale cached value.
       true (assoc :rf/platform (:rf/platform parent-machine)
                   :rf/frame    (:rf/frame parent-machine))
-      ;; EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): overlay the live causal
+      ;; Overlay the live causal
       ;; recordable-coeffect token so a region guard / action reads the CURRENT
       ;; dispatch's `:rf.cofx`. `:rf/cofx` is transition-local — `callback-ctx`
       ;; keys off its PRESENCE — so the overlay must MATCH the live parent
-      ;; exactly: assoc when the parent carries it, DISSOC otherwise. A bare
-      ;; `(contains? parent-machine ...)`-gated assoc left a stale slot intact
-      ;; when the live parent carried none, leaking a cached coeffect into a
-      ;; later transition (rf2-gqr4vs). Dissoc on the absent path guarantees the
+      ;; exactly: assoc when the parent carries it, DISSOC otherwise. Dissoc on
+      ;; the absent path guarantees the
       ;; cached spec can never surface a coeffect the current caller did not
       ;; carry — even if the cache faulted in under a coeffect-carrying parent.
       (contains? parent-machine :rf/cofx)
@@ -375,10 +370,10 @@
       (not (contains? parent-machine :rf/cofx))
       (dissoc :rf/cofx)
 
-      ;; rf2-n0myjq — overlay the live effective cofx MINT POLICY the same way
+      ;; Overlay the live effective cofx MINT POLICY the same way
       ;; as `:rf/cofx` (match the parent's presence exactly: assoc when carried,
       ;; dissoc otherwise) so a region's in-engine raised-event ensure
-      ;; (rf2-xsdn5h) mints under the SAME `:strict` / `:live` policy the parent
+      ;; mints under the SAME `:strict` / `:live` policy the parent
       ;; dispatch resolved, never a stale cached one.
       (contains? parent-machine :rf/cofx-mint-policy)
       (assoc :rf/cofx-mint-policy (:rf/cofx-mint-policy parent-machine))
@@ -416,7 +411,7 @@
         ordered     (filterv #(contains? state-map %)
                              (or (vec (keys (:regions parent-machine)))
                                  (vec (keys state-map))))
-        ;; rf2-42mml — FROZEN pre-broadcast cross-region snapshot. The
+        ;; FROZEN pre-broadcast cross-region snapshot. The
         ;; `:all-state` / `:tags` a region's guard OR action reads are computed
         ;; ONCE here, from the pre-event `state-map`, and threaded UNCHANGED
         ;; into every region's step ctx — NOT rebuilt per region from the
@@ -431,7 +426,7 @@
         ;; after it) — exact XState v5 / SCXML parity (a parallel macrostep
         ;; selects against the pre-event configuration/context, then applies).
         ;;
-        ;; Per the rf2-42mml sharpening, the FROZEN view is threaded into the
+        ;; The FROZEN view is threaded into the
         ;; ACTION ctx too (not only guards): statechart atomicity — the
         ;; configuration changes atomically old->new, there is no intermediate
         ;; configuration some transitions observe and others do not; only
@@ -440,11 +435,10 @@
         ;; microstep loop, so the region's internal cascade also reads the
         ;; frozen view.)
         ;;
-        ;; This REVERSES rf2-46ly6's "evolving-snapshot" READ-TIMING but KEEPS
-        ;; 46ly6's CAPABILITY intact: a region guard / action still reads a
+        ;; A region guard / action reads a
         ;; sibling's state via `:all-state` (precise) and `:tags` (coarse
-        ;; stateIn substitute). Only the snapshot those keys resolve against
-        ;; flips (frozen pre-event, not evolving same-event). Same-event
+        ;; stateIn substitute), and those keys resolve against the frozen
+        ;; pre-event view. Same-event
         ;; cross-region coordination retimes to the NEXT microstep via the
         ;; statechart-idiomatic path (a region `:raise`s / writes `:data`; the
         ;; FIFO re-broadcast re-selects against the now-updated config — a
@@ -456,7 +450,7 @@
            cur-data     (:data snapshot)
            cur-counter  (:rf/spawn-counter snapshot)
            ;; Per Spec 005 §Composition with parallel regions — per-region
-           ;; history (rf2-mle6e.3): thread the shared `:rf/history` map
+           ;; history: thread the shared `:rf/history` map
            ;; through regions like `:data`. The slot's keys are REGION-
            ;; QUALIFIED (head = region name), so per-region recordings never
            ;; collide — a later region only writes its own qualified keys
@@ -481,19 +475,19 @@
           ;; aggregate handled flag (true iff at least one region resolved
           ;; the event) so `parallel-machine-transition` warns exactly once
           ;; only when EVERY region declined. Per §Trace events the
-          ;; macrostep `:microsteps` count is the sum across regions. Per
-          ;; rf2-n9f4z the structured `::cascade` is the per-region step
+          ;; macrostep `:microsteps` count is the sum across regions. The
+          ;; structured `::cascade` is the per-region step
           ;; sequences concatenated in declaration order — each step
           ;; already carries `:region` (stamped by the single-machine
           ;; engine from the synthetic region-spec's `:rf/region`), so the
           ;; flat concatenation stays per-region addressable for the
-          ;; consumer (rf2-52u5n).
+          ;; consumer.
           (-> (result/ok (commit-tags-parallel parent-machine merged) acc-fx)
               (result/with-handled any-handled?)
               (result/with-microsteps micro-total)
               (result/with-cascade cascade)))
         (let [rn          (first pending)
-              ;; Per rf2-r09fc: stamp the REAL parent machine-id onto the
+              ;; Stamp the REAL parent machine-id onto the
               ;; synthetic region-spec so any declarative `:spawn` / `:after`
               ;; the region fires keys its
               ;; `[:rf.runtime/machines :spawned <parent> <invoke-id>]` slot
@@ -525,11 +519,11 @@
               ;; `bootstrap-step`) funnel through, so region pure logic
               ;; (`build-after-fx`'s server-skip gate, trace `:frame`
               ;; attribution) always runs against the LIVE runtime context —
-              ;; never the cached snapshot (rf2-z522n / rf2-r09fc).
+              ;; never the cached snapshot.
               region-spec (region-spec-overlaid parent-machine rn)
               region-snap (cond-> {:state (get state-map rn)
                                    :data  cur-data
-                                   ;; Per rf2-46ly6 / rf2-69d1n: thread the
+                                   ;; Thread the
                                    ;; cross-region coordination context into
                                    ;; every region's guard/action ctx — the
                                    ;; XState v5 `stateIn` / SCXML `In()`
@@ -539,9 +533,9 @@
                                    ;; active-state map (the PRECISE sibling-
                                    ;; state read); `:tags` is the MACHINE-WIDE
                                    ;; tag union across every region (the coarse
-                                   ;; tag-as-stateIn substitute — rf2-69d1n).
+                                   ;; tag-as-stateIn substitute).
                                    ;;
-                                   ;; rf2-42mml: both resolve against the
+                                   ;; Both resolve against the
                                    ;; FROZEN pre-broadcast snapshot (`state-map`
                                    ;; → `frozen-all-state` / `frozen-tags`,
                                    ;; computed ONCE above), NOT the evolving
@@ -572,7 +566,7 @@
                             ;; Seed the region snapshot with the shared
                             ;; (region-qualified) `:rf/history` so a restore
                             ;; reads the prior recording and a record writes
-                            ;; the region's own key (rf2-mle6e.3).
+                            ;; the region's own key.
                             (some? cur-history)
                             (assoc :rf/history cur-history))
               step-result (step-fn region-spec region-snap)]
@@ -582,12 +576,11 @@
                   region-micro    (result/microsteps step-result)
                   region-cascade  (result/cascade step-result)]
               (result/with-ok [reg-snap reg-fx] step-result
-                ;; Per rf2-3h1pf: accumulate fx via `into` so the region
+                ;; Accumulate fx via `into` so the region
                 ;; loop doesn't rebuild the accumulator as a fresh vector
-                ;; on every region step (the old shape was
-                ;; `(vec (concat acc-fx prefixed-fx))` — O(N²·M) copying
-                ;; for N regions × M fx; `into` uses a transient
-                ;; internally — O(N·M) amortised). The prefix-fn is
+                ;; on every region step: `into` uses a transient
+                ;; internally — O(N·M) amortised for N regions × M fx. The
+                ;; prefix-fn is
                 ;; folded into the transducer position so we don't
                 ;; materialise the intermediate `prefixed-fx` vector.
                 (recur (rest pending)
@@ -595,7 +588,7 @@
                        (:rf/spawn-counter reg-snap)
                        ;; Carry forward this region's `:rf/history` writes
                        ;; (region-qualified keys) so later regions + the
-                       ;; merge see them (rf2-mle6e.3).
+                       ;; merge see them.
                        (:rf/history reg-snap)
                        (assoc new-states rn (:state reg-snap))
                        (into acc-fx
@@ -619,11 +612,11 @@
   compound machines, runs `bootstrap-step` directly — the broadcast
   invariant doesn't apply.
 
-  Per rf2-505ic the `:always` fixed-point + raise drain that settles the
+  The `:always` fixed-point + raise drain that settles the
   initial macrostep is a SEPARATE phase — `apply-initial-entry-cascade`
   composes this entry cascade with `settle-birth`.
 
-  Per Spec 005 §Root parallel `:after` (rf2-wox0vd): a `:type :parallel` root
+  Per Spec 005 §Root parallel `:after`: a `:type :parallel` root
   declaring `:after` is ROOT-OWNED — its timers are scheduled HERE, at machine
   birth (when the parallel root is entered), folded onto the per-region entry
   cascade's Result. `reduce-regions` walks each REGION's `:after`; the root's
@@ -648,7 +641,7 @@
 
 (declare machine-transition)
 
-;; ---- parallel macrostep internal-event queue (rf2-yi7ts) ------------------
+;; ---- parallel macrostep internal-event queue ------------------------------
 ;;
 ;; XState v5 / SCXML gold standard: `raise` enqueues on the machine's ONE
 ;; internal event queue; the macrostep pops the front and broadcasts that
@@ -698,7 +691,7 @@
                   (fn [region-spec region-snap]
                     (machine-transition region-spec region-snap event))))
 
-;; ---- root parallel `:on` — the ancestor fallback (rf2-tsq6g) --------------
+;; ---- root parallel `:on` — the ancestor fallback --------------------------
 ;;
 ;; XState v5 / SCXML gold standard: a transition declared on a `<parallel>`
 ;; node is the ANCESTOR FALLBACK for its regions — deepest-wins with parent
@@ -723,23 +716,20 @@
 ;;      targets `[[<region> …] [<region> …]]` (the XState `target ['.a.x',
 ;;      '.b.y']` analog).
 ;;
-;; Before this, a user-written root-level `:on` on a `:type :parallel` machine
-;; was NEITHER validated NOR executed — silently DROPPED (the broadcast only
-;; reached the synthetic region machines). rf2-tsq6g kills the silent-drop and
-;; honours the ancestor fallback.
+;; A user-written root-level `:on` on a `:type :parallel` machine is validated
+;; and executed as the ancestor fallback: when no region handles the event, the
+;; broadcast falls through to the root `:on`.
 ;;
-;; rf2-42mml COORDINATION: the root transition's GUARD is resolved against the
+;; COORDINATION: the root transition's GUARD is resolved against the
 ;; FROZEN pre-event `snapshot` (the value `parallel-machine-transition` was
 ;; called with) — NOT an evolving per-region snapshot — so root-parallel guard
-;; selection is already aligned to the two-phase frozen-selection model
-;; rf2-42mml installs for region guards. (rf2-42mml rebases on this merge and
-;; freezes the REGION-guard snapshot too; the root resolver here is already
-;; frozen-correct.)
+;; selection is aligned to the same two-phase frozen-selection model the
+;; region guards use.
 
 (defn- normalise-root-targets
   "Normalise a root parallel transition's `:target` into a vector of
   region-qualified absolute targets `[[<region> & <in-region-path>] …]`. Per
-  the grammar (rf2-tsq6g):
+  the grammar:
     - nil / absent  → `[]` (targetless / action-only).
     - a vector of KEYWORDS (`[:a :two]`) → ONE region-qualified target
       (head = region name, rest = the in-region path). Wrapped to `[[:a :two]]`.
@@ -808,7 +798,7 @@
 
 (defn- apply-root-parallel-transition
   "Apply the parallel machine ROOT's selected `:on` transition as the
-  ancestor fallback (rf2-tsq6g): run the root `:action` ONCE against the
+  ancestor fallback: run the root `:action` ONCE against the
   shared `:data`, then atomically apply each region-qualified `:target` to
   its named region (leaving untargeted regions unchanged), and re-stamp the
   tag union. `transition` is the transition map `root-on-match` selected.
@@ -859,8 +849,7 @@
   Result. Shared by the parallel event MACROSTEP (`parallel-machine-
   transition`, seed = the external event's first broadcast) and the
   parallel BIRTH settle (`settle-birth`, seed = the post-initial-cascade
-  per-region `:always` settle) — rf2-505ic factored this out so birth
-  reuses the identical queue drain rather than duplicating it.
+  per-region `:always` settle) — both reuse the identical queue drain.
 
   `acc-fx` accumulates only the real (non-`:raise`) fx; `acc-micro` /
   `acc-cascade` roll up the totals across every (re-)broadcast.
@@ -884,7 +873,7 @@
       (result/with-ok [snap0 fx0] first-r
         (let [[raises0 real0] (split-raises fx0)
               external-handled? (result/handled? first-r)]
-          ;; rf2-xsdn5h — `m` is the live parent machine threaded through the
+          ;; `m` is the live parent machine threaded through the
           ;; re-broadcast loop. Each dequeued raise's `ensure-raised-cofx`
           ;; re-stamps it with an augmented `:rf/cofx` so the raised event's
           ;; region guards/actions read the ensured / generated facts (overlaid
@@ -916,8 +905,8 @@
                 ;; `transition/unhandled-event-no-op?` so reserved-`:rf/*`
                 ;; framework lifecycle traffic — the synthetic bootstrap,
                 ;; the spawn kick-off, the stories-runtime pings — is NOT
-                ;; classified as an unknown-user-event no-op (rf2-ugdas /
-                ;; rf2-t4582). On the BIRTH path `event` is `nil`, so the
+                ;; classified as an unknown-user-event no-op. On the BIRTH
+                ;; path `event` is `nil`, so the
                 ;; `unhandled-event-no-op?` gate is never reached — birth
                 ;; never emits the no-op. Mirrors the flat-machine emission
                 ;; in `transition/machine-transition-single`.
@@ -925,7 +914,7 @@
                            (some? event)
                            (transition/unhandled-event-no-op? event))
                   (trace/emit! :rf.machine :rf.machine.event/unhandled-no-op
-                               ;; rf2-yyvtk5 — a LIVE actor (every region
+                               ;; A LIVE actor (every region
                                ;; declined) received the unknown event; address
                                ;; it by `:actor-id`, not `:machine-id` (the
                                ;; registered TYPE). Mirrors the flat emission.
@@ -935,14 +924,14 @@
                                 :frame      (:rf/frame machine)}))
                 result)
 
-              ;; `>=` boundary parity with the flat drain (rf2-r26e2): the
+              ;; `>=` boundary parity with the flat drain: the
               ;; loop re-broadcasts internal events at depths 0..limit-1
               ;; then aborts at `depth == limit`. Atomic rollback — the
               ;; WHOLE macrostep is discarded; no partial snapshot / fx
               ;; survives (Spec 005 §Drain semantics: bounded depth halts
               ;; with the snapshot uncommitted, `:no-recovery`).
               (>= depth raise-limit)
-              ;; rf2-y3jv8q — a tripped re-broadcast `:raise` depth limit is a
+              ;; A tripped re-broadcast `:raise` depth limit is a
               ;; FAILED macrostep, not a benign no-op (parity with the flat
               ;; drain in `transition/drain-to-fixed-point`). Emit the precise
               ;; category, then return a `result/fail` carrying the
@@ -950,7 +939,7 @@
               ;; routes through the handler's failure path (atomic rollback
               ;; preserved — no snapshot write reaches runtime-db) instead of
               ;; surfacing as a silent no-op that swallows the triggering event.
-              (let [info {;; rf2-yyvtk5 — the aborting actor is a LIVE INSTANCE;
+              (let [info {;; The aborting actor is a LIVE INSTANCE;
                           ;; address it by `:actor-id` (mirrors the flat drain),
                           ;; not `:machine-id` (the registered TYPE).
                           :error-id   :rf.error/machine-raise-depth-exceeded
@@ -964,7 +953,7 @@
 
               :else
               (let [ev   (first pending)
-                    ;; rf2-xsdn5h — ensure THIS raised event's declared cofx
+                    ;; Ensure THIS raised event's declared cofx
                     ;; onto the parent BEFORE re-broadcasting it across the
                     ;; regions. `ensure-set-for` unions every region's scope (and
                     ;; the parallel root's own `:on` / `:after`), so a region
@@ -981,7 +970,7 @@
                     (let [[new-raises real-fx] (split-raises fx2)]
                       (recur snap2
                              m'
-                             ;; FIFO (rf2-nr434): drop the just-processed
+                             ;; FIFO: drop the just-processed
                              ;; front, APPEND this broadcast's own raises to
                              ;; the BACK — behind the still-pending queue.
                              (into (vec (rest pending)) new-raises)
@@ -990,7 +979,7 @@
                              (+ acc-micro (result/microsteps step))
                              (into acc-casc (result/cascade step))))))))))))))
 
-;; ---- parallel done-state / `:on-done` signal (rf2-bnjb3) ------------------
+;; ---- parallel done-state / `:on-done` signal ------------------------------
 ;;
 ;; Per Spec 005 §Final states §The done-state signal: when EVERY region of a
 ;; parallel machine reaches a `:final?` leaf, the parallel state is DONE —
@@ -1020,7 +1009,7 @@
 ;; signal — distinct hooks, distinct purposes.
 
 (defn fire-parallel-on-done
-  "Per Spec 005 §Final states §The done-state signal (rf2-bnjb3): if the
+  "Per Spec 005 §Final states §The done-state signal: if the
   parallel `machine`'s settled `result` snapshot has NEWLY reached its
   all-regions-final done configuration this macrostep AND the parallel root
   declares `:on-done`, run that `:on-done` transition's `:action` against
@@ -1039,10 +1028,11 @@
   all-final config — i.e. the after-snapshot is all-final AND the
   before-snapshot was NOT. On the BIRTH path it is always `true` (birth is the
   single macrostep that enters the initial configuration; a machine born
-  all-final crosses the edge at birth). Without this guard the `:on-done`
-  `:action` + `:fx` re-fired on every no-op event the regions decline while
-  resting all-final — a coordinator's continuation re-dispatched repeatedly,
-  any `:data` accumulation drifting upward."
+  all-final crosses the edge at birth). The guard ensures the `:on-done`
+  `:action` + `:fx` fire once and do NOT re-fire on every no-op event the
+  regions decline while resting all-final — so a coordinator's continuation
+  is dispatched exactly once and `:data` does not accumulate on resting
+  macrosteps."
   [machine result newly-reached?]
   (if (result/fail? result)
     result
@@ -1073,11 +1063,11 @@
 (declare settle-region-birth)
 
 (defn- root-fallback-seed
-  "Per Spec 005 §Transition broadcast §Root parallel `:on` (rf2-tsq6g): when
+  "Per Spec 005 §Transition broadcast §Root parallel `:on`: when
   NO region handled `event` (the first broadcast `first-r` is not handled),
   consult the parallel ROOT's own `:on` as the ancestor fallback. The root
-  transition is resolved against the FROZEN pre-event `snapshot` (rf2-42mml
-  frozen-selection coordination — the root guard sees the pre-event config),
+  transition is resolved against the FROZEN pre-event `snapshot`
+  (frozen-selection coordination — the root guard sees the pre-event config),
   and only for a genuine UNKNOWN USER event (`unhandled-event-no-op?` —
   reserved `:rf/*` framework lifecycle traffic is NOT a candidate; its
   done / error / timer routing already runs through the region resolvers).
@@ -1122,7 +1112,7 @@
       first-r)))
 
 (defn- root-after-seed
-  "Per Spec 005 §Root parallel `:after` (rf2-wox0vd): resolve a parallel-ROOT
+  "Per Spec 005 §Root parallel `:after`: resolve a parallel-ROOT
   `:after` firing — the synthetic `[:rf.machine.timer/after-elapsed delay-key
   epoch []]` event whose decl-path is the empty root path (NOT region-name
   prefixed). The root `:after` is the timer-driven analog of the root `:on`
@@ -1148,7 +1138,7 @@
   (let [match (transition/root-after-match machine event snapshot)]
     ;; Trace the firing / staleness / guard-suppression BEFORE applying, so
     ;; listeners observe events in occurrence order (single-machine parity).
-    ;; rf2-hawtjr — thread the causal completion timestamp (the firing
+    ;; Thread the causal completion timestamp (the firing
     ;; dispatch's router-stamped `:rf/time-ms` off `:rf.cofx`) so the
     ;; parallel-root `:after` completion carries `:completed-at` like the
     ;; single-machine path.
@@ -1181,7 +1171,7 @@
   return the merged result. Returns a `result/ok` Result on success or a
   `result/fail` Result if any region's action threw.
 
-  Per Spec 005 §Transition broadcast §Root parallel `:on` (rf2-tsq6g): when
+  Per Spec 005 §Transition broadcast §Root parallel `:on`: when
   NO region selects a transition for the event, the parallel ROOT's own `:on`
   is consulted as the ANCESTOR FALLBACK (deepest-wins with parent fallthrough
   — the parallel analog of the flat / compound machine-root `:on` fallback).
@@ -1191,9 +1181,9 @@
   more region-qualified targets, leaving untargeted regions unchanged; the
   moved regions then settle their `:always` + raises through the same parent
   internal-event queue. The root transition's GUARD is selected against the
-  frozen pre-event snapshot (rf2-42mml coordination).
+  frozen pre-event snapshot (frozen-selection coordination).
 
-  Per Spec 005 §Transition broadcast (rf2-42mml — select-then-apply): each
+  Per Spec 005 §Transition broadcast (select-then-apply): each
   region's enabled transition is SELECTED against ONE frozen pre-broadcast
   snapshot (its own deepest-wins lookup, reading siblings via the frozen
   `:all-state` / `:tags`), then the selected transitions are APPLIED in
@@ -1203,17 +1193,17 @@
   selected. The `:data` slot is the one value that flows — each region's
   actions see the prior region's `:data` writes in declaration order; the
   cross-region `:all-state` / `:tags` a guard OR action reads stay frozen
-  (statechart atomicity). Per rf2-vqubp the broadcast invariant lives in
+  (statechart atomicity). The broadcast invariant lives in
   `reduce-regions`.
 
-  Per Spec 005 §Parallel-region `:raise` broadcast (rf2-yi7ts — XState v5
+  Per Spec 005 §Parallel-region `:raise` broadcast (XState v5
   parity): a `:raise` emitted by ANY region is NOT region-local. It enters
   this macrostep's internal-event queue and is re-broadcast across EVERY
   region — exactly what an equivalent self-`[:dispatch [<self-id> …]]` would
   broadcast, but pre-commit and inside the one macrostep. Each re-broadcast
-  is its own microstep (rf2-42mml): it re-selects against the config as of
+  is its own microstep: it re-selects against the config as of
   that microstep's start (a fresh frozen `:all-state` / `:tags` view that
-  reflects prior-microstep region moves) while the in-flight `:data` flows. Raises are drained FIFO (rf2-nr434): a raise
+  reflects prior-microstep region moves) while the in-flight `:data` flows. Raises are drained FIFO: a raise
   surfaced earlier is re-broadcast before one surfaced later, and a raise
   emitted *while handling* a re-broadcast goes to the BACK of the queue.
   The whole macrostep — external event + every re-broadcast internal event
@@ -1226,13 +1216,13 @@
   For the synthetic `[:rf.machine.timer/after-elapsed ...]` event,
   delivery is region-scoped — the broadcast routes to the bearing region
   only, identified by the region-name prefix on the in-flight timer's
-  `:rf/invoke-id`. The exception is a ROOT-OWNED `:after` (rf2-wox0vd),
+  `:rf/invoke-id`. The exception is a ROOT-OWNED `:after`,
   whose carried decl-path is the empty root path `[]` (no region prefix):
   `root-after-elapsed?` detects it and routes it to `root-after-seed` (the
   timer-driven analog of the root `:on` ancestor fallback) instead of
   broadcasting it to the regions."
   [machine snapshot event]
-  (let [;; rf2-wox0vd — a parallel-ROOT `:after` timer (`[]` decl-path) is
+  (let [;; A parallel-ROOT `:after` timer (`[]` decl-path) is
         ;; root-owned, not region-scoped: resolve it through the root `:on`
         ;; apply path rather than broadcasting it to the regions (which key off
         ;; a region-name-prefixed decl-path and would all decline it).
@@ -1240,12 +1230,13 @@
         first-r       (if root-after?
                         (root-after-seed machine snapshot event)
                         (broadcast-once machine snapshot event))
-        ;; rf2-tsq6g — root parallel `:on` ancestor fallback. When no region
+        ;; Root parallel `:on` ancestor fallback. When no region
         ;; handled the event, consult the root `:on`; if it fires, its result
         ;; (handled, region targets moved) BECOMES the macrostep seed and is
         ;; settled through the same parent queue (so a moved region's `:always`
         ;; / `:raise` continue the macrostep). When no region handled AND the
-        ;; root declines, `seed` == `first-r` and the existing no-op path runs.
+        ;; root declines, `seed` == `first-r` and the all-regions-declined
+        ;; no-op path runs.
         ;; A root-`:after` firing already IS the root-owned seed, so the `:on`
         ;; fallback is skipped (the `:after` reserved-namespace event is not an
         ;; unhandled user event `root-fallback-seed` would consult `:on` for).
@@ -1253,7 +1244,7 @@
                         first-r
                         (root-fallback-seed machine snapshot event first-r))
         settled       (drain-parent-queue machine snapshot event seed)
-        ;; h3wca.1 — false→true EDGE guard. `:on-done` fires ONCE, on the
+        ;; false→true EDGE guard. `:on-done` fires ONCE, on the
         ;; macrostep that CROSSES into the all-regions-final done config
         ;; (XState v5 `onDone` / SCXML `done.state.<id>`), NOT on every later
         ;; event delivered while resting there. A no-op event to an already-
@@ -1263,7 +1254,7 @@
         newly-final?  (and (not was-final?)
                            (not (result/fail? settled))
                            (all-regions-final? machine (:state (result/snap settled))))]
-    ;; Per Spec 005 §Final states §The done-state signal (rf2-bnjb3): when this
+    ;; Per Spec 005 §Final states §The done-state signal: when this
     ;; macrostep NEWLY makes every region final and the parallel root declares
     ;; `:on-done`, fire it (run its action + emit its fx) WITHOUT auto-
     ;; destroying — the transitionable parallel completion signal. No
@@ -1289,22 +1280,21 @@
    3-5. Settle in the unified SCXML microstep loop — after the taken
       transition PREFER enabled :always (eventless) transitions and only
       dequeue the next raised internal event (FIFO) once :always is
-      quiescent; commit at the fixed point (rf2-uv8os ordering, rf2-nr434
-      FIFO).
+      quiescent; commit at the fixed point.
 
   Bounded by :raise-depth-limit and :always-depth-limit (both default 16).
   Parallel-region machines (`:type :parallel`) are dispatched into
   `parallel-machine-transition`, where the event is broadcast across
-  regions per Spec 005 §Parallel regions (rf2-l67o) and region-emitted
-  raises re-broadcast through the parent macrostep's internal-event queue
-  (rf2-yi7ts). Flat / compound machines drop straight into the
+  regions per Spec 005 §Parallel regions and region-emitted
+  raises re-broadcast through the parent macrostep's internal-event queue.
+  Flat / compound machines drop straight into the
   single-machine engine in `re-frame.machines.transition`."
   [machine snapshot event]
   (if (parallel? machine)
     (parallel-machine-transition machine snapshot event)
     (transition/machine-transition-single machine snapshot event)))
 
-;; ---- birth-time `:always` + raise settle (rf2-505ic) ----------------------
+;; ---- birth-time `:always` + raise settle ----------------------------------
 ;;
 ;; XState v5 / SCXML gold standard: the INITIAL macrostep is initial-entry
 ;; + the eventless (`always`) drain. `createActor(m).start()` evaluates
@@ -1334,8 +1324,8 @@
 
 (defn- settle-birth
   "Run the birth-time settle — raise drain + `:always` fixed-point loop —
-  against the POST-initial-cascade Result, BEFORE the machine is committed
-  (rf2-505ic). The shared settling tail of the macrostep, reused so a
+  against the POST-initial-cascade Result, BEFORE the machine is committed.
+  The shared settling tail of the macrostep, reused so a
   transient initial leaf whose `:always` guard already holds is settled
   past — unobserved — on start, exactly as XState v5 / SCXML do.
 
@@ -1391,7 +1381,7 @@
                                (result/cascade always-r))
                              (result/microsteps always-r))
                            (result/handled? always-r))))]
-        ;; Per rf2-bnjb3: a parallel machine BORN all-regions-final (each
+        ;; A parallel machine BORN all-regions-final (each
         ;; region's initial+`:always` settles onto a `:final?` leaf) fires the
         ;; parallel root's `:on-done` on birth too — same transitionable signal
         ;; as the event-driven macrostep (XState v5 treats such an actor as done
@@ -1414,7 +1404,7 @@
         false))))
 
 (defn apply-initial-entry-cascade
-  "The machine's INITIAL MACROSTEP (rf2-505ic — XState v5 / SCXML parity):
+  "The machine's INITIAL MACROSTEP (XState v5 / SCXML parity):
   the initial-entry cascade THEN the eventless (`:always`) + raise settle,
   composed and returned as ONE Result. The single birth site for BOTH
   paths (eager `[:rf.machine/start]` and lazy first-event); the lifecycle
@@ -1442,7 +1432,7 @@
   A no-`:always`, no-`:raise` machine settles in zero microsteps —
   `settle-birth` finds no matching `:always`, drains no raises, and returns
   the post-cascade snapshot + the entry fx verbatim with the tag union
-  re-stamped (identical to the pre-rf2-505ic birth)."
+  re-stamped."
   [machine initial-snapshot]
   (let [entry-r (run-initial-cascade machine initial-snapshot)]
     (if (result/fail? entry-r)
@@ -1455,7 +1445,7 @@
             ;; the initial-`:entry` raises drained internally (bz0ox.1).
             ;; Cascade: entry cascade ++ the `:always` microstep cascade.
             ;; `::microsteps` rides from the settle (the entry cascade ran no
-            ;; `:always`). Per rf2-bnjb3 the settle's `parallel-done-handled?`
+            ;; `:always`). The settle's `parallel-done-handled?`
             ;; flag (set when a parallel machine born all-final fired its root
             ;; `:on-done`) rides through so the birth finalize gate sees it.
             (cond-> (-> (result/ok settled-snap (vec settle-fx))
@@ -1465,7 +1455,7 @@
                         (result/with-microsteps (result/microsteps settle-r)))
               (result/parallel-done-handled? settle-r) (result/with-parallel-done))))))))
 
-;; ---- destroy-time exit cascade (rf2-nahfm) --------------------------------
+;; ---- destroy-time exit cascade --------------------------------------------
 ;;
 ;; Per Spec 005 §Final states §Composition with `:entry` / `:exit` and
 ;; §Declarative `:spawn` §Composition: the active configuration's

--- a/implementation/machines/src/re_frame/machines/path_walk.cljc
+++ b/implementation/machines/src/re_frame/machines/path_walk.cljc
@@ -12,16 +12,14 @@
 
   Spec 005 spells this rule out for `:on`, for `:always`, for `:after`,
   and for `:spawn-all` join-event interception — four surfaces, one
-  rule. Before this namespace existed, the rule was implemented four
-  times across two files as the same `(loop [i (dec (count path))] ...
-  (recur (dec i)))` shape, each picker re-deriving the boundary
-  arithmetic and the prefix-construction by hand.
-
-  Naming the rule once, in one place, lets the pickers read as their
-  own intent: 'pick the deepest `:on` match', 'pick the deepest
-  `:always` whose guard passes', etc., delegating the walk mechanics
-  to `walk-path-leaf-to-root`. New pickers (e.g. per-state error
-  handlers, if ever added) inherit the rule for free.
+  rule. Naming the rule once, in one place, keeps the four pickers from
+  each re-deriving the same `(loop [i (dec (count path))] ... (recur
+  (dec i)))` boundary arithmetic and prefix-construction by hand, and
+  lets each picker read as its own intent: 'pick the deepest `:on`
+  match', 'pick the deepest `:always` whose guard passes', etc.,
+  delegating the walk mechanics to `walk-path-leaf-to-root`. New pickers
+  (e.g. per-state error handlers, if ever added) inherit the rule for
+  free.
 
   ## Surface
 
@@ -48,11 +46,10 @@
 
   ## Trace hook (future)
 
-  Per the rf2-tjhhp note: this primitive paves the way for a
-  `pick-trace` instrumentation that Xray wants — 'the runtime checked
-  these states in this order before settling on the deepest match'.
-  When that lands, the trace will hang off this single fn rather than
-  fan out across four pickers.
+  This primitive paves the way for a `pick-trace` instrumentation that
+  Xray wants — 'the runtime checked these states in this order before
+  settling on the deepest match'. When that lands, the trace will hang
+  off this single fn rather than fan out across four pickers.
 
   ## Why not also root→leaf?
 
@@ -74,10 +71,10 @@
   slot is `nil` and descent stops; remaining slots are absent. The
   return vector's `count` ≤ `(count path)`.
 
-  Per rf2-3h1pf the walk is done ONCE root→leaf to feed the leaf→root
-  iteration in `walk-path-leaf-to-root` — the old shape re-descended
-  from the root at every level (O(depth²) per picker call). One pass
-  + a small vector of resolved nodes turns it into O(depth)."
+  The walk is done ONCE root→leaf to feed the leaf→root iteration in
+  `walk-path-leaf-to-root` — re-descending from the root at every level
+  would be O(depth²) per picker call; one pass + a small vector of
+  resolved nodes keeps it O(depth)."
   [tree path]
   (loop [m       (:states tree)
          remain  path
@@ -107,18 +104,17 @@
   at that prefix; when the prefix doesn't resolve (defensive), the
   predicate is skipped and the walk continues toward the root.
 
-  Per rf2-ogsrx the inclusive-prefix is taken via `subvec` (zero-copy
-  slice) rather than `(vec (take (inc i) path))` (lazy-seq + realise +
-  copy). On a depth-D path × P pickers per macrostep the walk now
-  allocates D×P subvec references rather than D×P fresh vectors.
+  The inclusive-prefix is taken via `subvec` (zero-copy slice) rather
+  than `(vec (take (inc i) path))` (lazy-seq + realise + copy). On a
+  depth-D path × P pickers per macrostep the walk allocates D×P subvec
+  references rather than D×P fresh vectors.
 
-  Per rf2-3h1pf the descent through `tree`'s `:states` is done ONCE
-  root→leaf via `resolve-path-nodes`, then iterated in reverse — the
-  old shape called `node-at*` at every level, re-descending from the
-  root each time, giving O(depth²) per picker call. The single-pass
-  shape is O(depth). Four pickers (`:on`, `:always`, `:after`,
-  `:spawn-all` join) all run this primitive on the same active path
-  per macrostep, so the depth² → depth win compounds on every event.
+  The descent through `tree`'s `:states` is done ONCE root→leaf via
+  `resolve-path-nodes`, then iterated in reverse — descending from the
+  root at every level would give O(depth²) per picker call; the
+  single-pass shape is O(depth). Four pickers (`:on`, `:always`,
+  `:after`, `:spawn-all` join) all run this primitive on the same active
+  path per macrostep, so the depth² → depth win compounds on every event.
   The `path` argument is coerced to a vector once at the top so
   callers may pass any seqable; downstream callers receiving the
   prefix may rely on the vector contract (predicates often

--- a/implementation/machines/src/re_frame/machines/paths.cljc
+++ b/implementation/machines/src/re_frame/machines/paths.cljc
@@ -3,9 +3,8 @@
 
   The machines runtime keeps four sibling maps under the reserved
   `:rf.runtime/machines` child of each frame's **runtime-db** partition
-  (EP-0001 rf2-vzld77; Conventions §Reserved runtime-db keys — machine
-  snapshots are durable framework state, so they live in runtime-db, NOT
-  in the retired app-db `:rf/runtime` root):
+  (Conventions §Reserved runtime-db keys — machine snapshots are durable
+  framework state, so they live in the runtime-db partition):
 
     - `:snapshots`     — actor-id → snapshot `{:state :data :tags …}`
     - `:system-ids`    — system-id → actor-id reverse index

--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -58,7 +58,7 @@
   (which calls `re-frame.elision/elide-wire-value`) — never a
   family-private elider (Managed-Effects §Tracing).
 
-  ## Why there is no `target-obsolete?` gate here (rf2-wwfn7q)
+  ## Why there is no `target-obsolete?` gate here
 
   HTTP carries an `actor-destroy-target-obsolete?` predicate
   (`re-frame.http.reply`) that lowers a destroyed-actor reply to `:stale`/
@@ -122,8 +122,8 @@
                          :cljs (.lastIndexOf nm "#")))]
       (if (and i (nat-int? i) (pos? i))
         (let [suffix (subs nm (inc i))
-              ;; (rf2-ny0yrz C4) The CLJS branch must REJECT a non-fully-
-              ;; numeric suffix BEFORE `js/parseInt`: `js/parseInt "3abc" 10`
+              ;; The CLJS branch must REJECT a non-fully-numeric suffix
+              ;; BEFORE `js/parseInt`: `js/parseInt "3abc" 10`
               ;; leniently returns 3, whereas CLJ `Long/parseLong "3abc"`
               ;; THROWS → falls through to generation 1. A `:fixed-actor-id`
               ;; carrying a `#` followed by a malformed suffix would otherwise
@@ -163,9 +163,8 @@
   `:actor-id` is the finishing actor's live INSTANCE address; the
   `:invoke-id` is the declarative spawn invocation-path (the absolute
   prefix-path of the `:spawn`-bearing parent state) — the two are
-  distinct identity facts (rf2-0ggtr5 / rf2-ws5thu). Optional facts are
-  omitted when absent rather than nil-filled (Managed-Effects §The
-  reply map)."
+  distinct identity facts. Optional facts are omitted when absent rather
+  than nil-filled (Managed-Effects §The reply map)."
   [{:keys [actor-id parent-id work-bearing-path frame completed-at]}]
   (cond-> {:work/id   (spawn-work-id actor-id work-bearing-path)
            :work/kind :machine}
@@ -265,17 +264,17 @@
 ;; `:spawn-all` join-child completion (Managed-Effects §The reply map /
 ;; §Status taxonomy / §Stale suppression; EP-0011 §Machine Completion).
 ;;
-;; rf2-d63qtp — single `:spawn` finality lowers through `success-reply` /
+;; Single `:spawn` finality lowers through `success-reply` /
 ;; `error-reply` / `stale-spawn-reply`; the `:spawn-all` join-child
 ;; completion (a child dispatching `[parent [:on-child-done child-id …]]` /
-;; `:on-child-error` into the parent's join) previously folded into join
-;; state + emitted join traces with NO canonical reply map, `:work/id`, or
-;; `:rf.reply/*` facts. These helpers give the join-child path the SAME
-;; uniform reply vocabulary the single-`:spawn` path already carries — the
-;; PUBLIC join protocol (the parent dispatch, the resolution events, the
-;; cancel-on-decision cascade) is unchanged; this is INTERNAL trace-stream
-;; lowering only, so a join child's done / failed / late completion
-;; classifies the same way HTTP / resources / single-`:spawn` do.
+;; `:on-child-error` into the parent's join) folds into join state and
+;; carries the SAME uniform reply vocabulary the single-`:spawn` path
+;; carries — a canonical reply map, `:work/id`, and `:rf.reply/*` facts.
+;; The PUBLIC join protocol (the parent dispatch, the resolution events,
+;; the cancel-on-decision cascade) is independent of these helpers; this is
+;; INTERNAL trace-stream lowering only, so a join child's done / failed /
+;; late completion classifies the same way HTTP / resources /
+;; single-`:spawn` do.
 ;;
 ;; A join child's work-id reuses the machine head keyed on the child's
 ;; SPAWNED instance id (the `<type>#<n>` actor address in the join-state
@@ -380,9 +379,8 @@
   EDN-serializable. `decl-path` nil (the node was exited — no live
   counterpart) yields `[:rf.work/timer nil epoch]`, a valid distinct id.
 
-  rf2-niarhz — without this the machine `:after` timer completions
-  (`:rf.machine.timer/fired` / `:rf.machine.timer/stale-after`) carried the
-  reply STATUS / work-status but NO `:work/id`, so they could not join into
+  The machine `:after` timer completions (`:rf.machine.timer/fired` /
+  `:rf.machine.timer/stale-after`) carry this `:work/id` so they join into
   the uniform work/reply rows that every other managed async family
   correlates by (Managed-Effects §Tracing — \"one `:work/id`\")."
   [actor-id decl-path epoch]
@@ -419,22 +417,22 @@
   `:work/status :suppressed`, and the carried/current epoch facts under
   `:correlation`.
 
-  rf2-niarhz — the reply now carries the canonical `:work/id`
+  The reply carries the canonical `:work/id`
   `[:rf.work/timer <decl-path> <scheduled-epoch>]` (the timer's attempt
   identity — see `timer-work-id`), so a stale `:after` completion joins into
   the uniform work/reply rows by the same key HTTP / resources / routing use.
 
-  rf2-hawtjr — the reply now also threads the CAUSAL completion timestamp
-  (`:completed-at`) when the timer-firing dispatch supplied one. The
-  synthetic `:after`-elapsed dispatch is a causal token carrying the
-  router-stamped `:rf/time-ms` (EP-0010 / the fresh fire-time read); a
-  stale `:after` completion can mutate machine snapshot data is not the
-  case here (the transition is suppressed), but Managed-Effects §Causal
-  completion metadata / §Tracing want completion time to ride the reply
-  wherever the firing token has it, so the suppressed-timer trace can be
-  correlated in real time with the firing dispatch. Omitted (not
-  nil-filled) when absent — an unscripted / no-cofx fire path carries no
-  `:completed-at` (Managed-Effects §The reply map).
+  The reply also threads the CAUSAL completion timestamp (`:completed-at`)
+  when the timer-firing dispatch supplied one. The synthetic
+  `:after`-elapsed dispatch is a causal token carrying the router-stamped
+  `:rf/time-ms` (EP-0010 / the fresh fire-time read); a stale `:after`
+  completion does not mutate machine snapshot data (the transition is
+  suppressed), but Managed-Effects §Causal completion metadata / §Tracing
+  want completion time to ride the reply wherever the firing token has it,
+  so the suppressed-timer trace can be correlated in real time with the
+  firing dispatch. Omitted (not nil-filled) when absent — an unscripted /
+  no-cofx fire path carries no `:completed-at` (Managed-Effects §The reply
+  map).
 
   `ctx` keys: `:actor-id` (optional — the timer's owning actor INSTANCE),
   `:state`, `:delay`, `:decl-path`, `:scheduled-epoch`, `:current-epoch`,
@@ -458,7 +456,7 @@
 (defn after-fired-reply
   "Build the canonical reply for a machine `:after` timer that FIRED (live —
   its declaring path is still active and its carried epoch equals the node's
-  current per-path epoch). rf2-niarhz — a fired `:after` timer is a CLOSED
+  current per-path epoch). A fired `:after` timer is a CLOSED
   `:after` completion: `:status :ok` / `:work/status :completed`, carrying the
   canonical `:work/id` `[:rf.work/timer <decl-path> <epoch>]` and
   `:work/kind :timer` so its `:rf.machine.timer/fired` trace joins the uniform
@@ -476,10 +474,10 @@
   `:work/status` inside the closed `work-statuses` vocabulary. Pass
   `:guard-suppressed? true` for that case.
 
-  rf2-hawtjr — the reply now also threads the CAUSAL completion timestamp
-  (`:completed-at`) when the timer-firing dispatch supplied one. The
-  synthetic `:after`-elapsed dispatch is a causal token carrying the
-  router-stamped `:rf/time-ms` (EP-0010 / the fresh fire-time read), and a
+  The reply also threads the CAUSAL completion timestamp (`:completed-at`)
+  when the timer-firing dispatch supplied one. The synthetic
+  `:after`-elapsed dispatch is a causal token carrying the router-stamped
+  `:rf/time-ms` (EP-0010 / the fresh fire-time read), and a
   fired `:after` timer's transition can mutate machine snapshot `:data`
   (its `:action`), so per Managed-Effects §Causal completion metadata the
   completion time MUST ride the reply when it affects durable state. The
@@ -517,21 +515,20 @@
 ;; §Cancellation: "Cancellation is represented as data, not as the absence
 ;; of a reply").
 ;;
-;; rf2-sfunt8 — machine cancellation terminal paths (timer cancel on state
-;; exit / destroy / supersede / frame-destroy; actor destroy;
-;; `:spawn-all` join-survivor cancel) previously completed by ABSENCE of a
-;; reply — their traces carried reason / state / epoch but no canonical
-;; `:work/id`, `:rf.reply/status :cancelled`, `:rf.reply/work-status`, or
-;; `:cancel/reason`. A cancelled timer / actor could therefore have a
-;; scheduled / spawned START but no terminal EP-0011 reply row. These
-;; helpers close the work attempt the reply-envelope way: cancellation as
-;; DATA. The validated `:status :cancelled` shape requires BOTH
+;; Machine cancellation terminal paths (timer cancel on state exit /
+;; destroy / supersede / frame-destroy; actor destroy; `:spawn-all`
+;; join-survivor cancel) complete the work attempt the reply-envelope way:
+;; cancellation as DATA. Each carries the canonical `:work/id`,
+;; `:rf.reply/status :cancelled`, `:rf.reply/work-status`, and
+;; `:cancel/reason`, so a cancelled timer / actor's terminal EP-0011 reply
+;; row joins the same uniform work/reply row its scheduled / spawned START
+;; opened. The validated `:status :cancelled` shape requires BOTH
 ;; `:cancel/reason` AND `:cancelled? true` (cancellation is a positive
 ;; fact), and `:work/status :cancelled` (the closed work-status vocab).
 ;; ---------------------------------------------------------------------------
 
 (def timer-cancel-reasons
-  "The closed `:rf.machine.timer/cancelled` `:reason` set (rf2-82a0u) —
+  "The closed `:rf.machine.timer/cancelled` `:reason` set —
   the cancel-reason taxonomy a cancelled-timer reply's `:cancel/reason`
   carries: `:on-exit` (state exit), `:on-destroy` (actor destroy),
   `:on-resolution` (subscription-delay re-resolution), `:on-supersede`

--- a/implementation/machines/src/re_frame/machines/result.cljc
+++ b/implementation/machines/src/re_frame/machines/result.cljc
@@ -1,18 +1,12 @@
 (ns re-frame.machines.result
-  "One result type for the machine-transition engine. Per rf2-aa2rw / rf2-ra1he §P0 #2.
+  "One result type for the machine-transition engine.
 
   The engine's pure surface (`apply-transition-once`, `machine-transition-
   single`, `parallel-machine-transition`, `apply-initial-entry-cascade`,
   and the public `machine-transition`) returns a Result map — either an
   `:ok` with the post-transition snapshot + emitted fx, or a `:fail`
-  carrying diagnostic info about the action / `:data`-fn that threw.
-
-  Pre-refactor this concept was spelled three different ways across the
-  engine — `[::action-failed info]` vector sentinel, a
-  `{:rf.machine/action-failure ...}` map shape inside `run-action`, and a
-  `[:ok | :fail]` mini-ADT inside `materialise-data`. Six call-sites
-  spelled the same `(if (and (vector? r) (= ::action-failed (first r))) ...)`
-  disambiguation guard. This namespace replaces all three with one shape.
+  carrying diagnostic info about the action / `:data`-fn that threw. One
+  shape is the engine's single success/failure result type.
 
   ## Shape
 
@@ -85,7 +79,7 @@
   the transition-level context (`:decl-path`, `:transition`,
   `:state-path`) before re-raising.
 
-  rf2-ny0yrz CL3: guarded with `(if (fail? r) … r)`, symmetric with the
+  Guarded with `(if (fail? r) … r)`, symmetric with the
   `with-handled` / `with-microsteps` / `with-cascade` siblings (which
   pass a non-`:ok` Result through unchanged). A non-`:fail` Result returns
   unchanged — `fail-with` only enriches an actual failure's `::info`, never
@@ -98,23 +92,16 @@
 
 (defn depth-abort
   "Build a `:fail` Result for a bounded-depth abort (`:always-depth-limit`
-  / `:raise-depth-limit` tripped mid-macrostep) — per rf2-y3jv8q.
+  / `:raise-depth-limit` tripped mid-macrostep).
 
   A runaway eventless / raise cycle (e.g. `a →:always b →:always a`) is NOT
-  a benign no-op: XState v5 THROWS on such a cycle. The pre-fix engine
-  returned `(ok rollback-snapshot [])` from the abort, which the lifecycle
-  boundary (`commit-or-finalize`) saw as `next == snapshot` ⇒ a no-op,
-  emitting NO `:rf.machine/transition` trace and routing NO error to the
-  handler return — the runaway was indistinguishable from a guard-blocked
-  no-op and the triggering user event was silently swallowed (only an
-  out-of-band `emit-error!` recorded it).
-
-  Returning a `:fail` instead routes the abort through the SAME failure
-  path an action exception takes (`trace-action-failure!` short-circuits the
-  handler to `{}`), so the macrostep surfaces as a FAILED macrostep — no
-  snapshot write reaches runtime-db, preserving the atomic rollback Spec
-  005 §Bounded depth requires (the pre-event snapshot stays committed),
-  while the event is no longer silently consumed.
+  a benign no-op: XState v5 THROWS on such a cycle. A depth abort returns a
+  `:fail` Result, which routes through the SAME failure path an action
+  exception takes (`trace-action-failure!` short-circuits the handler to
+  `{}`), so the macrostep surfaces as a FAILED macrostep — no snapshot
+  write reaches runtime-db, preserving the atomic rollback Spec 005
+  §Bounded depth requires (the pre-event snapshot stays committed), and the
+  triggering user event is not silently consumed.
 
   The `::info` map carries `::depth-abort? true` so the handler routing
   recognises this is a depth-abort — NOT a thrown action — and SKIPS the
@@ -130,7 +117,7 @@
   "True iff `r` is a `:fail` Result produced by a bounded-depth abort
   (`depth-abort`) — distinguishes a `:always` / `:raise` depth-limit trip
   from a thrown-action `:fail`, so the handler routing skips the generic
-  action-exception trace for the depth case (rf2-y3jv8q). A non-`:fail`
+  action-exception trace for the depth case. A non-`:fail`
   Result (or a thrown-action `:fail`) returns false."
   [r]
   (and (fail? r) (true? (get-in r [::info ::depth-abort?]))))
@@ -161,7 +148,7 @@
   a parallel-region machine reports whether its inbound event resolved to
   a transition so the parent can emit the benign
   `:rf.machine.event/unhandled-no-op` trace exactly once when EVERY region
-  declines (rf2-ugdas — xstate-v5 parity; not an error). The flag is internal to the
+  declines (xstate-v5 parity; not an error). The flag is internal to the
   machines engine — `:fail` Results and non-region callers ignore it; the
   key is namespaced so it never collides with snapshot / fx slots."
   [r handled?]
@@ -192,12 +179,12 @@
 
 (defn with-cascade
   "Stamp the optional `::cascade` step-vector onto an `:ok` Result. Per
-  Spec 005 §Transition cascade instrumentation (rf2-n9f4z): the ordered
+  Spec 005 §Transition cascade instrumentation: the ordered
   exit → action → entry (+ initial-descent) + `:always`-microstep step
   sequence the macrostep ran, so the lifecycle handler can carry it as
   the `:cascade` field on the outer `:rf.machine/transition` trace. This
   is the structured explanation of HOW the transition reached its
-  after-state — the contract Xray's epoch panel renders (rf2-52u5n).
+  after-state — the contract Xray's epoch panel renders.
 
   Internal to the machines engine; the key is namespaced so it never
   collides with snapshot / fx slots. `:fail` Results pass through
@@ -215,7 +202,7 @@
 
 (defn with-parallel-done
   "Stamp the `::parallel-done-handled?` flag onto an `:ok` Result. Per Spec
-  005 §Final states §The done-state signal (rf2-bnjb3): when a parallel
+  005 §Final states §The done-state signal: when a parallel
   machine reaches all-regions-final AND its root declared `:on-done`, the
   parallel layer fires that `:on-done` (run action + emit fx) and marks the
   Result so the lifecycle boundary (`commit-or-finalize`) does NOT auto-

--- a/implementation/machines/src/re_frame/machines/spawn_order.cljc
+++ b/implementation/machines/src/re_frame/machines/spawn_order.cljc
@@ -18,9 +18,7 @@
   pure runtime bookkeeping, has no observer contract, and never
   participates in revertibility (destroyed actors stay destroyed). The
   same pattern is used for the `:after` timer table in
-  `re-frame.machines.timer/after-timers`.
-
-  Per rf2-vsigt — the frame-destroy machine-cascade fix.")
+  `re-frame.machines.timer/after-timers`.")
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/implementation/machines/src/re_frame/machines/ssr.cljc
+++ b/implementation/machines/src/re_frame/machines/ssr.cljc
@@ -3,18 +3,18 @@
   Per Spec 011 §The hydration payload (`:rf/runtime-db`) + Spec 015
   §State machines.
 
-  ## The leak this closes (rf2-jm2u63)
+  ## The classification boundary this enforces
 
   Machine snapshots are durable runtime-db state living at
   `[:rf.runtime/machines :snapshots <actor-id>]`, each carrying a
   `{:state :data :tags …}` body. The SSR hydration payload's
   `:rf/runtime-db` slice ships `:rf.runtime/machines` so the client
-  re-materialises actors. But `re-frame.ssr.payload-policy/project-runtime-db`
-  previously copied `:rf.runtime/machines` WHOLESALE — so a snapshot whose
-  frame classifies a `:data` path `:sensitive` / `:large` shipped that field
-  RAW in the hydration blob, exactly the leak frame-owned classification exists
-  to prevent. Unlike resources (which has `:ssr/extend-runtime-db-projection`),
-  machines had no SSR projection hook.
+  re-materialises actors. `re-frame.ssr.payload-policy/project-runtime-db`
+  consults this hook so a snapshot whose frame classifies a `:data` path
+  `:sensitive` / `:large` has that field redacted / elided in the
+  hydration blob — frame-owned classification governs machine `:data`
+  egress. Like resources (which has `:ssr/extend-runtime-db-projection`),
+  machines provides this SSR projection hook.
 
   ## What this does
 
@@ -26,14 +26,10 @@
   the wire. The projection uses SHARED frame-independent primitives — NEVER a
   family-private elider.
 
-  EP-0025 (rf2-398kql): the machine `:data-schema`→marks redaction layer is
-  GONE. Durable machine `:data` was once classified by the machine's
-  `:data-schema` `:sensitive?` / `:large?` per-slot props (EP-0005 schema→marks
-  bridge); that schema-field classification axis is killed. Machine `:data`
-  egress classification is now FRAME-OWNED, like every other app-db /
-  runtime-db path — declared on `reg-frame` `:sensitive` / `:large {:app-db …}`
-  (EP-0015), the sole app-db classification mechanism. (The `:data-schema` still
-  VALIDATES `:data`; it just no longer classifies it for egress.)
+  Machine `:data` egress classification is FRAME-OWNED, like every other
+  app-db / runtime-db path — declared on `reg-frame` `:sensitive` /
+  `:large {:app-db …}`, the sole app-db classification mechanism. The
+  `:data-schema` VALIDATES `:data`; it does not classify it for egress.
 
   Snapshots whose frame classifies no matching `:data` path ride VERBATIM — the
   projection is precise, not a blanket scrub. The sibling registry slots
@@ -60,17 +56,17 @@
   snapshot classification governs the projection (nil ⇒ no frame walk ⇒ `:data`
   rides verbatim).
 
-  EP-0025 (rf2-398kql): machine `:data` egress classification is FRAME-OWNED.
-  A frame classifies a durable machine `:data` slot by declaring the absolute
-  runtime-db path `[:rf.runtime/machines :snapshots <actor-id> :data …]` via
-  `reg-frame` `:sensitive` / `:large {:app-db …}` (EP-0015, the sole app-db
-  mechanism). `re-frame.marks/frame-snapshot-marks` re-roots those declarations
+  Machine `:data` egress classification is FRAME-OWNED. A frame classifies
+  a durable machine `:data` slot by declaring the absolute runtime-db path
+  `[:rf.runtime/machines :snapshots <actor-id> :data …]` via `reg-frame`
+  `:sensitive` / `:large {:app-db …}` (the sole app-db mechanism).
+  `re-frame.marks/frame-snapshot-marks` re-roots those declarations
   snapshot-relative (`[:data …]`); here we strip the leading `:data` segment to
   index into the snapshot's bare `:data` map and redact via the SHARED frame-
   independent `re-frame.marks/redact-with-paths` walker — `:sensitive` slots to
   `:rf/redacted`, `:large` to the `:rf.size/large-elided` marker (sensitive
-  wins). The prior OWNER-schema layer — the machine `:data-schema` `:sensitive?`
-  / `:large?` per-slot marks — is REMOVED with the schema→marks bridge.
+  wins). Snapshot egress does not consult per-slot `:sensitive?` / `:large?`
+  schema marks; frame-owned classification is the sole mechanism.
 
   The snapshot's NON-`:data` slots (`:state`, `:tags`, `:rf/machine-type`, the
   reserved spawn-counter slot, …) are durable structural facts the client needs
@@ -98,8 +94,8 @@
   hydration `:rf/runtime-db` payload (the body behind the
   `:machines/project-ssr-runtime-db` late-bind hook). Returns the
   `:rf.runtime/machines` value with every snapshot's `:data` projected per its
-  machine's `:data-schema` classification (`project-snapshot-data`); or
-  `runtime-db`'s `:rf.runtime/machines` value unchanged when it carries no
+  frame-owned `:sensitive` / `:large` classification (`project-snapshot-data`);
+  or `runtime-db`'s `:rf.runtime/machines` value unchanged when it carries no
   snapshots.
 
   `frame-id` is the SSR request frame (nil ⇒ owner marks only — see

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.machines.timer
   "Wall-clock `:after` timer scheduling. Per Spec 005 §Delayed `:after`
-  transitions and rf2-3y3y.
+  transitions.
 
   On entry to an `:after`-bearing state node, the pure transition engine
   (`re-frame.machines.transition`) emits one `:rf.machine/after-schedule`
@@ -24,10 +24,10 @@
   through the standard cascade.
 
   A frame-scoped timer table tracks live handles so cancellation (state
-  exit) and subscription-driven re-resolution can clear them. Per
-  rf2-ysa94 the table is partitioned per frame (`{<frame-id> {<inner-key>
-  <entry>}}`), so concurrent frames in the same process — the common
-  test-fixture and SSR-load shape — observe disjoint timer state. The
+  exit) and subscription-driven re-resolution can clear them. The table is
+  partitioned per frame (`{<frame-id> {<inner-key> <entry>}}`), so
+  concurrent frames in the same process — the common test-fixture and
+  SSR-load shape — observe disjoint timer state. The
   epoch mechanism backstops correctness; explicit cancellation via
   `:rf.machine/after-cancel` is an optimisation that promptly releases
   the host-clock handle.
@@ -47,17 +47,16 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defonce after-timers
-  ;; Per Spec 005 §Delayed `:after` transitions and rf2-3y3y and the rf2-ysa94
-  ;; frame-scoping refactor: runtime-owned timer-handle table for in-flight
-  ;; :after timers, partitioned per frame.
+  ;; Per Spec 005 §Delayed `:after` transitions: runtime-owned timer-handle
+  ;; table for in-flight :after timers, partitioned per frame.
   ;;
   ;; Outer shape: {<frame-id> {<inner-key> <entry>}}.
   ;; Inner key:   {:parent <parent-id> :spawn <invoke-id-vec>
   ;;               :delay <delay-key>} — multiple delays per :after map
   ;;              have their own slot, and parallel-region machines
   ;;              partition further on the region-prefixed invoke-id.
-  ;;              Per rf2-gwznv the key is a map rather than a positional
-  ;;              tuple — readers no longer have to remember slot order.
+  ;;              The key is a map rather than a positional tuple — the map
+  ;;              form lets readers ignore slot order.
   ;; Entry value:
   ;;   {:handle <opaque host-clock handle>
   ;;    :reaction <subscription reaction or nil>
@@ -67,9 +66,8 @@
   ;;    :state <state-keyword>
   ;;    :delay-source <:literal | :sub | :fn>}
   ;;
-  ;; Frame-scoping the outer key (rf2-ysa94) was the last process-global
-  ;; piece of state in the machines artefact (per the rf2-ra1he audit, §TM4).
-  ;; Two consequences:
+  ;; Frame-scoping the outer key keeps the timer table out of process-global
+  ;; state. Two consequences:
   ;;   (1) Two frames running concurrently see strictly disjoint inner
   ;;       tables — no cross-frame contamination of timer handles, no
   ;;       chance that one frame's `reset-timers!` clobbers another's
@@ -88,13 +86,11 @@
   "Inner-table key — frame-id is the OUTER key into `after-timers` and
   is intentionally absent from this map.
 
-  Per rf2-gwznv the key is a `{:parent ... :spawn ... :delay ...}`
-  map rather than a positional tuple — readers no longer have to
-  remember slot order, and the scan in `after-cancel-fx` reads
-  `(:parent k)` / `(:spawn k)` rather than `(nth k 0)` / `(nth k 1)`.
-  The key is opaque to callers (used only as a `get-in` index into
-  `after-timers`'s inner map); the change is invisible outside this
-  file."
+  The key is a `{:parent ... :spawn ... :delay ...}` map rather than a
+  positional tuple — the map form lets readers ignore slot order, and the
+  scan in `after-cancel-fx` reads `(:parent k)` / `(:spawn k)` rather than
+  `(nth k 0)` / `(nth k 1)`. The key is opaque to callers (used only as a
+  `get-in` index into `after-timers`'s inner map)."
   [parent-id invoke-id delay-key]
   {:parent parent-id
    :spawn (vec invoke-id)
@@ -121,16 +117,13 @@
     [delay-key nil]
 
     (fn? delay-key)
-    ;; Per rf2-c1tnr the fn-form `:after` resolution used to silently
-    ;; swallow throws — a fn that NPE'd surfaced as
-    ;; `:rf.warning/no-clock-configured` downstream with no signal that
-    ;; the fn itself blew up. Now we emit `:rf.error/machine-after-fn-
-    ;; threw` on the exception path; the fn still falls through to no-
-    ;; clock-configured for recovery, but the exception is observable.
+    ;; A throwing fn-form `:after` emits `:rf.error/machine-after-fn-threw`
+    ;; on the exception path; the fn falls through to no-clock-configured
+    ;; for recovery, but the exception is observable rather than silently
+    ;; swallowed.
     ;;
-    ;; Per rf2-grw4i / rf2-v0rrr: the `:after` delay-fn receives the
-    ;; unified context-map `{:snapshot ...}` and returns a positive-int
-    ;; ms delay.
+    ;; The `:after` delay-fn receives the unified context-map
+    ;; `{:snapshot ...}` and returns a positive-int ms delay.
     (let [v (try (delay-key {:snapshot snapshot})
                  (catch #?(:clj Throwable :cljs :default) e
                    (trace/emit-error! :rf.error/machine-after-fn-threw
@@ -147,9 +140,8 @@
           v        (when reaction
                      (try @reaction
                           (catch #?(:clj Throwable :cljs :default) e
-                            ;; rf2-1b6uh5 — canonical subscription identity:
-                            ;; `:rf.sub/id` (+ `:rf.sub/query-v` for the full
-                            ;; vector), not the bare `:sub-id`.
+                            ;; Canonical subscription identity: `:rf.sub/id`
+                            ;; (+ `:rf.sub/query-v` for the full vector).
                             (trace/emit-error! :rf.error/machine-after-sub-threw
                                                {:exception      e
                                                 :rf.sub/id      (first delay-key)
@@ -171,9 +163,9 @@
   outer atom. Tolerates partial-state entries (the watcher / reaction
   slots are nil for literal- and fn-form delays)."
   [frame-id entry delay-key]
-  ;; Shared best-effort host-clock cancel (rf2-7x2lky) — swallows throws and
-  ;; no-ops a nil handle, tolerating the partial-state entries (literal- /
-  ;; fn-form delays whose watcher / reaction slots are nil).
+  ;; Shared best-effort host-clock cancel — swallows throws and no-ops a nil
+  ;; handle, tolerating the partial-state entries (literal- / fn-form delays
+  ;; whose watcher / reaction slots are nil).
   (managed-timer/cancel! (:handle entry))
   (when (and (:reaction entry) (:sub-watcher-key entry))
     (try (remove-watch (:reaction entry) (:sub-watcher-key entry))
@@ -184,38 +176,36 @@
 
 (defn- emit-cancelled!
   "Emit the unified `:rf.machine.timer/cancelled` trace for one
-  cancellation site. Per rf2-82a0u: every cancellation path — state
-  exit, machine destroy, subscription re-resolution, in-place
-  supersede, frame destroy — flows through this single emit so
-  consumers can pair scheduled→fired→cancelled by
-  `(actor-id, state, epoch)` and branch on `:reason` from the
-  closed set `:on-exit / :on-destroy / :on-resolution / :on-supersede
-  / :on-frame-destroy`.
+  cancellation site. Every cancellation path — state exit, machine
+  destroy, subscription re-resolution, in-place supersede, frame
+  destroy — flows through this single emit so consumers can pair
+  scheduled→fired→cancelled by `(actor-id, state, epoch)` and branch on
+  `:reason` from the closed set `:on-exit / :on-destroy / :on-resolution
+  / :on-supersede / :on-frame-destroy`.
 
   Payload shape mirrors `:rf.machine.timer/scheduled` for arm-fire-
   cancel pairing — same `:actor-id` / `:state` / `:delay` / `:epoch`
-  / `:frame` slots — plus the `:reason` discriminator. Per rf2-1b6uh5
-  the dynamic-delay subscription identity rides under the canonical
-  `:rf.sub/id` (the sub-id) plus `:rf.sub/query-v` (the full
-  subscription vector) when the cancelled timer was a sub-vec delay
-  (`:delay-source :sub`) — the same spelling the rest of the framework
-  uses for a subscription trace identity, not the bare `:sub-id`.
-  `:delay` reads the entry's `:resolved-ms` so the cancelled trace
+  / `:frame` slots — plus the `:reason` discriminator. The dynamic-delay
+  subscription identity rides under the canonical `:rf.sub/id` (the
+  sub-id) plus `:rf.sub/query-v` (the full subscription vector) when the
+  cancelled timer was a sub-vec delay (`:delay-source :sub`) — the same
+  spelling the rest of the framework uses for a subscription trace
+  identity. `:delay` reads the entry's `:resolved-ms` so the cancelled trace
   reports the wall-clock window the timer actually held, not the
   unresolved delay-key."
   [frame-id k entry reason]
   (let [delay-key    (:delay k)
         delay-source (:delay-source entry)
         sub-vec      (when (vector? delay-key) delay-key)
-        ;; rf2-sfunt8 — close the timer work attempt the reply-envelope way:
-        ;; a cancelled `:after` timer is `:status :cancelled` DATA, not the
-        ;; absence of a reply (Managed-Effects §Cancellation). The canonical
-        ;; `:work/id` matches the fired / stale reply's so the cancelled
-        ;; completion joins the same uniform work/reply row the timer's
-        ;; scheduling started; `:cancel/reason` carries the closed
-        ;; `timer-cancel-reasons` discriminator. The reply facts ride
-        ;; ADDITIVELY — the public trace shape (`:actor-id` / `:state` /
-        ;; `:delay` / `:epoch` / `:reason` / sub identity) is preserved.
+        ;; Close the timer work attempt the reply-envelope way: a cancelled
+        ;; `:after` timer is `:status :cancelled` DATA, not the absence of a
+        ;; reply (Managed-Effects §Cancellation). The canonical `:work/id`
+        ;; matches the fired / stale reply's so the cancelled completion
+        ;; joins the same uniform work/reply row the timer's scheduling
+        ;; started; `:cancel/reason` carries the closed `timer-cancel-reasons`
+        ;; discriminator. The reply facts ride ADDITIVELY — the public trace
+        ;; shape (`:actor-id` / `:state` / `:delay` / `:epoch` / `:reason` /
+        ;; sub identity) is preserved.
         cancel-reply (m-reply/cancelled-timer-reply
                        {:actor-id  (:parent k)
                         :state     (:state entry)
@@ -226,7 +216,7 @@
                         :reason    reason})
         summary      (m-reply/trace-reply cancel-reply {:frame frame-id})]
     (trace/emit! :rf.machine :rf.machine.timer/cancelled
-                 (cond-> {;; rf2-ws5thu — the timer's owning actor INSTANCE;
+                 (cond-> {;; the timer's owning actor INSTANCE;
                           ;; `:machine-id` is reserved for the registered TYPE.
                           :actor-id   (:parent k)
                           :state      (:state entry)
@@ -250,8 +240,8 @@
 (defn- cancel-after-timer-entry!
   "Cancel and clear a single :after timer-table entry under `frame-id`,
   emitting one `:rf.machine.timer/cancelled` trace stamped with
-  `reason` (closed set per rf2-82a0u: `:on-exit / :on-destroy /
-  :on-resolution / :on-supersede / :on-frame-destroy`). Idempotent —
+  `reason` (closed set: `:on-exit / :on-destroy / :on-resolution /
+  :on-supersede / :on-frame-destroy`). Idempotent —
   a second call against the same `[frame-id k]` is a no-op (the entry
   is gone so no trace fires)."
   [frame-id k reason]
@@ -271,9 +261,9 @@
 (defn- on-sub-changed!
   "Watch callback invoked when a subscription-vector delay's value
   changes. Per Spec 005 §Dynamic delay re-resolution: cancel the prior
-  in-flight timer, emit `:rf.machine.timer/cancelled` (per rf2-82a0u
-  the unified cancellation event with `:reason :on-resolution`), and
-  reschedule a fresh timer at the new resolution time. Epoch is
+  in-flight timer, emit `:rf.machine.timer/cancelled` (the unified
+  cancellation event with `:reason :on-resolution`), and reschedule a
+  fresh timer at the new resolution time. Epoch is
   unchanged (the snapshot's :state hasn't moved); we read it back from
   the live snapshot at reschedule-time so a concurrent state change is
   caught by the epoch invariant when the new timer fires."
@@ -281,11 +271,11 @@
   (when-not (= old-v new-v)
     (let [k (after-timer-key parent-id invoke-id delay-key)]
       (cancel-after-timer-entry! frame-id k :on-resolution)
-      ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
+      ;; Machine snapshots are durable runtime-db state.
       (when-let [rt (frame/frame-runtime-db-value frame-id)]
         (let [snap (get-in rt (paths/snapshot-path parent-id))
-              ;; Per Spec 005 §Per-region :after scoping (rf2-l67o): for
-              ;; parallel-region machines the snapshot's :state is a map
+              ;; Per Spec 005 §Per-region :after scoping: for parallel-region
+              ;; machines the snapshot's :state is a map
               ;; of region-name → that region's state, and the invoke-id
               ;; is `[<region-name> <state...>]` (prefix-region-invoke-id).
               ;; Resolve the active path inside the bearing region; the
@@ -323,11 +313,11 @@
   subscription-change watcher.
 
   Idempotent against the timer-table key — cancels any prior entry
-  before installing the new one. Per rf2-82a0u the leading cancel
-  emits a `:rf.machine.timer/cancelled` trace with `:reason
-  :on-supersede` — the only path that hits this branch with a live
-  prior entry is `cancel-and-reschedule` (initial schedule against an
-  empty slot is a no-op cancel)."
+  before installing the new one. The leading cancel emits a
+  `:rf.machine.timer/cancelled` trace with `:reason :on-supersede` —
+  the only path that hits this branch with a live prior entry is
+  `cancel-and-reschedule` (initial schedule against an empty slot is a
+  no-op cancel)."
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
    {:keys [emit-scheduled-trace?]}]
   (let [delay-source (transition/classify-delay-source delay-key)
@@ -345,23 +335,22 @@
               (not (pos? resolved-ms)))
           ;; Bad delay resolution — emit advisory and skip.
           ;;
-          ;; Per rf2-fva6c.1: `resolve-delay-ms` for a subscription-vector
-          ;; delay calls `subs/subscribe` (bumping the sub-cache ref-count)
-          ;; BEFORE we know whether the resolved value is usable. The bad-
-          ;; delay branch short-circuits and stores nothing in
-          ;; `after-timers`, so no future `cancel-after-timer-entry!` will
-          ;; ever run `release-entry-resources!` to drop the ref. Pair the
-          ;; subscribe with an `unsubscribe` here so every exit path
-          ;; balances the ref-count. Per Spec 006 §Reference counting and
-          ;; disposal.
+          ;; `resolve-delay-ms` for a subscription-vector delay calls
+          ;; `subs/subscribe` (bumping the sub-cache ref-count) BEFORE we
+          ;; know whether the resolved value is usable. The bad-delay branch
+          ;; short-circuits and stores nothing in `after-timers`, so no
+          ;; future `cancel-after-timer-entry!` will ever run
+          ;; `release-entry-resources!` to drop the ref. Pair the subscribe
+          ;; with an `unsubscribe` here so every exit path balances the
+          ;; ref-count. Per Spec 006 §Reference counting and disposal.
           (do
             (when (and reaction (vector? delay-key))
               (try (subs/unsubscribe frame-id delay-key)
                    (catch #?(:clj Throwable :cljs :default) _ nil)))
             (trace/emit! :warning :rf.warning/no-clock-configured
-                         ;; rf2-yyvtk5 — the timer's owning actor is a LIVE
-                         ;; INSTANCE; address it by `:actor-id`, not
-                         ;; `:machine-id` (reserved for the registered TYPE).
+                         ;; the timer's owning actor is a LIVE INSTANCE;
+                         ;; address it by `:actor-id`, not `:machine-id`
+                         ;; (reserved for the registered TYPE).
                          {:actor-id     parent-id
                           :state        state
                           :delay-key    delay-key
@@ -372,24 +361,23 @@
           :else
           (let [_ (when emit-scheduled-trace?
                     (trace/emit! :rf.machine :rf.machine.timer/scheduled
-                                 (cond-> {;; rf2-ws5thu — the timer's owning
-                                          ;; actor INSTANCE; `:machine-id` is
-                                          ;; reserved for the registered TYPE.
+                                 (cond-> {;; the timer's owning actor INSTANCE;
+                                          ;; `:machine-id` is reserved for the
+                                          ;; registered TYPE.
                                           :actor-id     parent-id
                                           :state        state
                                           :delay        resolved-ms
                                           :delay-source delay-source
                                           :epoch        epoch
                                           :frame        frame-id}
-                                   ;; rf2-1b6uh5 — canonical subscription
-                                   ;; identity: `:rf.sub/id` + `:rf.sub/query-v`,
-                                   ;; not the bare `:sub-id`.
+                                   ;; canonical subscription identity:
+                                   ;; `:rf.sub/id` + `:rf.sub/query-v`.
                                    (= :sub delay-source)
                                    (assoc :rf.sub/id      (first delay-key)
                                           :rf.sub/query-v (vec delay-key)))))
                 handle
-                ;; Shared positive-delay-guarded arm (rf2-7x2lky) — the
-                ;; host-clock arm step both timer artefacts share. `resolved-ms`
+                ;; Shared positive-delay-guarded arm — the host-clock arm
+                ;; step both timer artefacts share. `resolved-ms`
                 ;; is already known-positive here (the non-positive case was
                 ;; handled by the prior `cond` branch with the
                 ;; `:no-clock-configured` advisory), so the guard is a no-op
@@ -398,18 +386,12 @@
                 (managed-timer/arm!
                   (fn []
                     (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-                      ;; Per rf2-ejtpd + rf2-1ve9h: stamp `:source
-                      ;; :after-timer` on the timer-fired dispatch so
-                      ;; the Epoch panel's DISPATCH step labels it
-                      ;; "from :after timer" rather than the
-                      ;; `:unknown` residual default (rf2-hxj0d), and
-                      ;; Xray's L2 timeline can prefix the row + per-
-                      ;; source filter pills can discriminate timer-
-                      ;; fired cascades. Per rf2-1ve9h (Mike-approved
-                      ;; Option A, 2026-05-28) the prior parallel
-                      ;; `:rf/dispatch-origin :timer` axis was
-                      ;; collapsed into `:source` — `:after-timer` is
-                      ;; now the single functional-origin discriminator
+                      ;; Stamp `:source :after-timer` on the timer-fired
+                      ;; dispatch so the Epoch panel's DISPATCH step labels
+                      ;; it "from :after timer", and Xray's L2 timeline can
+                      ;; prefix the row + per-source filter pills can
+                      ;; discriminate timer-fired cascades. `:after-timer`
+                      ;; is the single functional-origin discriminator
                       ;; (closed-enum per Spec-Schemas
                       ;; §`:rf/dispatch-envelope`).
                       ;; Per Spec 005 §Hierarchy interaction: carry the
@@ -426,20 +408,19 @@
                 watch-key (when (= :sub delay-source)
                             [::after-watch frame-id parent-id invoke-id delay-key])]
             (when (and reaction watch-key)
-              ;; Per rf2-c1tnr — surface `add-watch` exceptions rather
-              ;; than silently dropping them; the sub-changed re-resolution
-              ;; watcher won't fire if `add-watch` failed, so the author
-              ;; needs a signal that the dynamic-delay subscription is
-              ;; not actually wired up.
+              ;; Surface `add-watch` exceptions rather than silently
+              ;; dropping them; the sub-changed re-resolution watcher won't
+              ;; fire if `add-watch` failed, so the author needs a signal
+              ;; that the dynamic-delay subscription is not actually wired
+              ;; up.
               (try
                 (add-watch reaction watch-key
                            (fn [_ _ old-v new-v]
                              (on-sub-changed! frame-id parent-id invoke-id
                                               delay-key state old-v new-v)))
                 (catch #?(:clj Throwable :cljs :default) e
-                  ;; rf2-yyvtk5 — owning actor INSTANCE under `:actor-id`.
-                  ;; rf2-1b6uh5 — canonical subscription identity
-                  ;; (`:rf.sub/id` + `:rf.sub/query-v`), not the bare `:sub-id`.
+                  ;; Owning actor INSTANCE under `:actor-id`; canonical
+                  ;; subscription identity (`:rf.sub/id` + `:rf.sub/query-v`).
                   (trace/emit-error! :rf.error/machine-after-watch-failed
                                      {:exception      e
                                       :actor-id       parent-id
@@ -459,8 +440,8 @@
 
 (defn after-schedule-fx
   "fx handler for `:rf.machine/after-schedule`. Per Spec 005 §Delayed
-  `:after` transitions and rf2-3y3y, on entry to an :after-bearing state
-  node the runtime emits one of these per :after entry. The handler
+  `:after` transitions, on entry to an :after-bearing state node the
+  runtime emits one of these per :after entry. The handler
   resolves the delay (literal pos-int? / subscription vector / fn),
   schedules a real wall-clock timer via `interop/schedule-after!` (Spec
   005 §Clock abstraction), and (for
@@ -478,9 +459,9 @@
 
   No-op under `:platform :server` (per Spec 005 §SSR mode)."
   [{frame-id :frame} args]
-  (let [;; EP-0002 carried invariant — the cascade envelope frame is the
-        ;; fx-context `:frame`; a nil stamp is an invariant failure
-        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+  (let [;; The cascade envelope frame is the fx-context `:frame`; a nil
+        ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
+        ;; never a synthesised `:rf/default`.
         frame-id   (frame/require-frame-stamp!
                      frame-id :rf.machine/after-schedule
                      {:where 'rf.machine/after-schedule
@@ -491,7 +472,7 @@
         delay-key  (:delay-key args)
         epoch      (:epoch args)
         server?    (boolean (:server? args))
-        ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
+        ;; Machine snapshots are durable runtime-db state.
         snapshot   (get-in (frame/frame-runtime-db-value frame-id)
                            (paths/snapshot-path parent-id))]
     ;; Initial state-entry scheduling — the :scheduled trace was already
@@ -508,29 +489,27 @@
     nil))
 
 (defn after-cancel-fx
-  "fx handler for `:rf.machine/after-cancel`. Per rf2-3y3y, emitted on
-  exit from an :after-bearing state node to release the host-clock timer
-  handles and any subscription watchers attached to the prior visit's
-  timers. The epoch-mismatch invariant backstops correctness if a timer
-  fires before this fx runs; this handler is the fast-path that prevents
-  zombie watchers and releases timer slots promptly.
+  "fx handler for `:rf.machine/after-cancel`. Emitted on exit from an
+  :after-bearing state node to release the host-clock timer handles and
+  any subscription watchers attached to the prior visit's timers. The
+  epoch-mismatch invariant backstops correctness if a timer fires before
+  this fx runs; this handler is the fast-path that prevents zombie
+  watchers and releases timer slots promptly.
 
-  Per rf2-82a0u each cancellation emits one
-  `:rf.machine.timer/cancelled` trace with `:reason :on-exit` so the
-  scheduled→fired→cancelled pairing in the Xray Handler section's
-  AFTER TIMERS sub-section can attribute the cancel to the state-exit
-  cause.
+  Each cancellation emits one `:rf.machine.timer/cancelled` trace with
+  `:reason :on-exit` so the scheduled→fired→cancelled pairing in the Xray
+  Handler section's AFTER TIMERS sub-section can attribute the cancel to
+  the state-exit cause.
 
-  Per rf2-ysa94 the scan is now bounded by the active frame's inner
-  table — siblings' timers in other frames are no longer walked. Per
-  rf2-gwznv the inner key is `{:parent ... :spawn ... :delay ...}`,
-  so the only cross-key axis we still iterate is `:delay` (one entry
-  per :after map entry on the bearing state node — typically 1-3
-  entries)."
+  The scan is bounded by the active frame's inner table — siblings'
+  timers in other frames are not walked. The inner key is
+  `{:parent ... :spawn ... :delay ...}`, so the only cross-key axis we
+  iterate is `:delay` (one entry per :after map entry on the bearing
+  state node — typically 1-3 entries)."
   [{frame-id :frame} args]
-  (let [;; EP-0002 carried invariant — the cascade envelope frame is the
-        ;; fx-context `:frame`; a nil stamp is an invariant failure
-        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+  (let [;; The cascade envelope frame is the fx-context `:frame`; a nil
+        ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
+        ;; never a synthesised `:rf/default`.
         frame-id  (frame/require-frame-stamp!
                     frame-id :rf.machine/after-cancel
                     {:where 'rf.machine/after-cancel
@@ -545,10 +524,10 @@
 
 (defn cancel-actor-timers!
   "Cancel every in-flight `:after` timer owned by `parent-id` under
-  `frame-id`. Per rf2-82a0u: emits one `:rf.machine.timer/cancelled`
-  trace per entry with `:reason :on-destroy`. Called from the machine-
-  destroy paths so trace consumers see the cancellation cause distinct
-  from state-exit / frame-destroy cancellations.
+  `frame-id`. Emits one `:rf.machine.timer/cancelled` trace per entry
+  with `:reason :on-destroy`. Called from the machine-destroy paths so
+  trace consumers see the cancellation cause distinct from state-exit /
+  frame-destroy cancellations.
 
   Pure side-effect — no return value. No-op when the actor has no
   in-flight timers. The transition engine's epoch invariant backstops
@@ -572,14 +551,13 @@
   stream observed by the next test.
 
   1-arity: just the given frame's timers (`frame/destroy-frame!` hook).
-  Per rf2-82a0u each cancelled timer emits one
-  `:rf.machine.timer/cancelled` trace with `:reason :on-frame-destroy`
-  so the Handler section's AFTER TIMERS sub-section can pair scheduled
-  → cancelled on frame teardown.
+  Each cancelled timer emits one `:rf.machine.timer/cancelled` trace with
+  `:reason :on-frame-destroy` so the Handler section's AFTER TIMERS
+  sub-section can pair scheduled → cancelled on frame teardown.
 
-  Per rf2-ysa94 the timer table is partitioned per frame; the 1-arity
-  variant releases the destroyed frame's host-clock handles and
-  subscription watchers without touching sibling frames' state."
+  The timer table is partitioned per frame; the 1-arity variant releases
+  the destroyed frame's host-clock handles and subscription watchers
+  without touching sibling frames' state."
   ([]
    (doseq [[frame-id inner] @after-timers
            [k entry] inner]
@@ -597,7 +575,7 @@
 (defn cancel-frame-timers-on-restore!
   "Cancel every in-flight `:after` timer the given `frame-id` currently holds,
   emitting one `:rf.machine.timer/cancelled` trace per entry with
-  `:reason :on-restore` (rf2-u5kmf8).
+  `:reason :on-restore`.
 
   Epoch restore installs the captured durable frame-state (the machine
   snapshots in runtime-db) WHOLESALE, so timer LIVENESS reverts atomically —

--- a/implementation/machines/src/re_frame/machines/tooling.cljc
+++ b/implementation/machines/src/re_frame/machines/tooling.cljc
@@ -1,14 +1,13 @@
 (ns re-frame.machines.tooling
-  "Machines tooling sibling of `re-frame.machines` — carries the EP-0014
-  slice-6 derivation/process algebra view of registered machines, their live
+  "Machines tooling sibling of `re-frame.machines` — carries the
+  derivation/process algebra view of registered machines, their live
   snapshots, and their spawned actors (`machine-algebra-view`,
   `machine-instance-algebra-view`, `machine-selector?`) that pair tools
   (Xray, re-frame2-pair-mcp) and the conformance fixtures query, but no
   production application code reads.
 
-  Mirrors the rf2-s8w3nw `re-frame.flows.tooling` split (and the rf2-bmzq0
-  `re-frame.subs.tooling` / rf2-qwm0a `re-frame.trace.tooling` splits before
-  it):
+  Mirrors the `re-frame.flows.tooling` split (and the
+  `re-frame.subs.tooling` / `re-frame.trace.tooling` splits):
     - CLJS consumers needing the surface call
       `re-frame.machines.tooling/<name>` directly. Apps that load the
       machines artefact but never attach a tool DCE the body wholesale (the
@@ -39,7 +38,7 @@
       actor's TYPE spec through `re-frame.machines.lifecycle-fx.resolver`.
 
   Per [Derivations.md](../../../../../../spec/Derivations.md) §Machines expose
-  algebra views (graduated from EP-0014) and the projected Malli shapes in
+  algebra views and the projected Malli shapes in
   [Spec-Schemas §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
   (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -49,7 +48,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- algebra views (EP-0014 slice-6) -------------------------------------
+;; ---- algebra views --------------------------------------------------------
 ;;
 ;; Per [Derivations.md] §Machines expose algebra views — a machine is the
 ;; canonical `:process` member of the derivation/process algebra (a derivation
@@ -62,24 +61,21 @@
 ;; its `:machine-instance` lifecycle.
 ;;
 ;; A machine SELECTOR — an ordinary `reg-sub` over `[:rf/machine …]` — is NOT
-;; a member surfaced here: per EP-0014 issue-4 (no second subscription system)
-;; selectors stay ORDINARY subscription `:derivation` nodes, classified by
-;; slice-2's `re-frame.subs.tooling/sub-algebra-view` like any other sub. This
+;; a member surfaced here: selectors are not a second subscription system,
+;; they stay ORDINARY subscription `:derivation` nodes, classified by
+;; `re-frame.subs.tooling/sub-algebra-view` like any other sub. This
 ;; ns provides only the `machine-selector?` recognizer so a graph tool can
 ;; label a subscription node that reads a machine snapshot with the
 ;; `:machine-selector` refinement + the `:selector` edge role — the machine
 ;; itself remains the stateful `:process`, the selector an ephemeral
 ;; `:derivation` over its materialized snapshot.
 ;;
-;; This is the *registrar-derived* slice (Derivations §The EP-0013 relocation
-;; seam): the machine-process node is assembled from the machine spec metadata
-;; at the surface that registered it, NOT (yet) from an EP-0013 app value. The
-;; live INSTANCE view additionally reads the frame's runtime-db snapshots. It
-;; feeds the later internal graph-inspection helper (EP-0014 bead-plan item 7);
-;; slice-6 ships NO public accessor — these functions live in the
-;; bundle-isolated tooling sibling, consumed by Xray + the conformance fixtures
-;; (the two named first consumers). No `re-frame.core` facade export (EP-0014
-;; issue-1 disposition).
+;; This is the *registrar-derived* slice (Derivations §The relocation seam):
+;; the machine-process node is assembled from the machine spec metadata at
+;; the surface that registered it. The live INSTANCE view additionally reads
+;; the frame's runtime-db snapshots. These functions live in the
+;; bundle-isolated tooling sibling, consumed by Xray + the conformance
+;; fixtures; no `re-frame.core` facade export.
 ;;
 ;; The fixed classifications for EVERY machine-process node (Derivations
 ;; §Machines expose algebra views — the machine column):
@@ -93,9 +89,9 @@
 ;; `:scheduled` / `:on-reply` when the spec declares timers / async commands),
 ;; and the OUTPUT snapshot path.
 ;;
-;; A machine consumes the slice-1 vocabulary verbatim — it does NOT redefine
-;; the `:rf/storage-class` / `:rf/evaluation-policy` / `:rf/lifecycle` enums or
-;; the `:rf/derivation-node` shape (those are owned by Spec-Schemas /
+;; A machine consumes the shared derivation vocabulary verbatim — it does NOT
+;; redefine the `:rf/storage-class` / `:rf/evaluation-policy` / `:rf/lifecycle`
+;; enums or the `:rf/derivation-node` shape (those are owned by Spec-Schemas /
 ;; Derivations).
 
 (def ^:private reserved-event-ns
@@ -251,7 +247,7 @@
 
 (defn machine-algebra-view
   "Return the STATIC derivation/process algebra view of every registered
-  machine (EP-0014 slice-6; [Derivations.md] §Machines expose algebra views,
+  machine ([Derivations.md] §Machines expose algebra views,
   [Spec-Schemas §`:rf/derivation-node`]).
 
   Pure data over the machine registry — read through the public
@@ -281,8 +277,8 @@
                      not declared inputs.
   - `:output`      — `[:runtime [:rf.runtime/machines :snapshots <id>]]` — the
                      machine MATERIALIZES its snapshot into the runtime-db
-                     partition (machine snapshots are durable runtime-db state
-                     — EP-0001 rf2-vzld77).
+                     partition (machine snapshots are durable runtime-db
+                     state).
   - `:storage`     — `:runtime-db`.
   - `:evaluation`  — the policy SET: always `:on-transition`; plus `:scheduled`
                      when the spec declares `:after` timers, plus `:on-reply`
@@ -303,14 +299,14 @@
   `nil` if it is not registered as a machine. JVM-runnable — the machine spec
   is partition-agnostic registration metadata.
 
-  Machine SELECTORS (subs over `[:rf/machine …]`) are NOT surfaced here: per
-  EP-0014 issue-4 they remain ordinary subscription `:derivation` nodes
+  Machine SELECTORS (subs over `[:rf/machine …]`) are NOT surfaced here: they
+  remain ordinary subscription `:derivation` nodes
   (`re-frame.subs.tooling/sub-algebra-view`); use `machine-selector?` to label
   one with the `:machine-selector` refinement.
 
-  Slice-6 ships NO public accessor (EP-0014 issue-1 disposition): this lives in
-  the bundle-isolated tooling sibling and is consumed by Xray + the conformance
-  fixtures; the public name is deferred until a third consumer needs it."
+  This ships NO public accessor: it lives in the bundle-isolated tooling
+  sibling and is consumed by Xray + the conformance fixtures; the public
+  name is deferred until a third consumer needs it."
   ([]
    (reduce
      (fn [acc machine-id]
@@ -329,7 +325,7 @@
 (defn machine-instance-algebra-view
   "Return the LIVE derivation/process algebra view of a frame's machine
   snapshots — one `:rf/derivation-node` per LIVE instance, singleton AND
-  spawned actor (EP-0014 slice-6; [Derivations.md] §Static and live graphs).
+  spawned actor ([Derivations.md] §Static and live graphs).
 
   The live counterpart to `machine-algebra-view`: where the static view
   reports one node per registered machine TYPE, the live view reports one node
@@ -337,7 +333,7 @@
   `[:rf.runtime/machines :snapshots <actor-id>]` in the frame's runtime-db —
   the realized machine instances the static graph cannot enumerate (a spawned
   actor has NO per-instance registration; its liveness IS the presence of its
-  snapshot — Spec 005 §Liveness is derived from runtime-db, rf2-a2sn1).
+  snapshot — Spec 005 §Liveness is derived from runtime-db).
 
   Per-instance node:
 
@@ -418,7 +414,7 @@
   "True iff the subscription registered under `sub-id` is a MACHINE SELECTOR —
   an ordinary `reg-sub` whose static `:<-` inputs include a `[:rf/machine …]`
   (or `[:rf/machine-has-tag? …]`) query vector (Derivations §Machine process
-  and selector; EP-0014 issue-4).
+  and selector).
 
   Machine selectors are NOT a second subscription system — they stay ORDINARY
   ephemeral `:derivation` subscription nodes (classified by
@@ -445,8 +441,8 @@
 
 (defn machine-selector-targets
   "The SET of machine ids the subscription registered under `sub-id` reads
-  as a machine selector (Derivations §Machine process and selector; EP-0014
-  issue-4). Where `machine-selector?` answers only the boolean \"is this a
+  as a machine selector (Derivations §Machine process and selector). Where
+  `machine-selector?` answers only the boolean \"is this a
   selector?\", this returns the actual TARGET machine ids — the second
   element of each accepted `[:rf/machine machine-id …]` /
   `[:rf/machine-has-tag? machine-id …]` static `:<-` input.
@@ -454,10 +450,10 @@
   A graph tool needs the target, not just the boolean: a machine selector
   draws a `:selector` edge from the SPECIFIC machine it reads, never from
   every registered machine. The boolean `machine-selector?` could only say
-  \"this sub is a selector\", forcing the graph composer to cross-product
-  every machine node against every selector — a false-edge bug in
-  multi-machine apps (rf2-4qmiij). This fn lets the composer draw the edge
-  from exactly the `[:machine target-id]` node(s) the selector names.
+  \"this sub is a selector\", which would force the graph composer to
+  cross-product every machine node against every selector — a false-edge in
+  multi-machine apps. This fn lets the composer draw the edge from exactly
+  the `[:machine target-id]` node(s) the selector names.
 
   Only the STATIC `:<-` form is mined: the machine-id MUST be a literal
   keyword in the static input vector. A `[:rf/machine-has-tag? machine-id
@@ -486,9 +482,9 @@
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;
-;; Per rf2-s8w3nw / rf2-bmzq0 / rf2-qwm0a (the flows / subs / trace tooling
-;; split pattern): `implementation/scripts/check-bundle-isolation.cjs` greps
-;; the counter bundle for this exact string. The string lives ONLY in this
+;; Following the flows / subs / trace tooling split pattern:
+;; `implementation/scripts/check-bundle-isolation.cjs` greps the counter
+;; bundle for this exact string. The string lives ONLY in this
 ;; file's source body — no other namespace, no docstring, no test fixture
 ;; references it — so its presence in the production counter bundle proves the
 ;; tooling sibling's body got pulled in (most likely via a stray `:require`

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -13,7 +13,7 @@
   post-transition snapshot + the emitted fx vector, including the
   `:rf.machine/spawn` allocator's id sequencing) depends ONLY on the
   arguments. There is no module-level mutable state and no `app-db` read
-  — per rf2-gr8q the declarative-`:spawn` spawn-id allocator lives
+  — the declarative-`:spawn` spawn-id allocator lives
   INSIDE the snapshot under `:rf/spawn-counter` (a per-machine-id integer
   map), so identical triples produce identical Results and the reducer
   threads the bumped counter through the returned snapshot. That is the
@@ -66,15 +66,15 @@
 
   Two roles, both `:entry`-only (it NEVER reaches an `:on` map):
     1. As an EAGER kick (`[:machine-id [:rf.machine/start]]`) it brings a
-       machine to life now rather than on its first real event. Per F‴
-       (rf2-gl588) it is a PURE init-kick — the lifecycle handler runs the
+       machine to life now rather than on its first real event. It is a
+       PURE init-kick — the lifecycle handler runs the
        initial-entry cascade then STOPS; the marker is never fed into the
        transition step as a trigger.
     2. As the placeholder `:event` value threaded through the initial-entry
        cascade so `:entry` actions reading `(fn [{:keys [event]}] …)` see a
        non-nil, reserved-namespace discriminator on the BIRTH call.
 
-  Renamed from `:rf.machine/bootstrap` (pre-alpha, no back-compat shim).
+  The reserved creation marker is `:rf.machine/start`.
   The canonical definition lives here in the leaf engine namespace so both
   `parallel` (the cascade) and `lifecycle-fx.registration` (the handler)
   reference one source of truth without a require cycle."
@@ -91,13 +91,13 @@
   here (above the resolution helpers) so `pick-transition` /
   `pick-done-transition` can special-case it. See §The done-state signal
   helpers (`compound-done-paths` / `done-raise-fx` / `apply-on-done-action`)
-  below for the full mechanism (rf2-bnjb3 / rf2-zlmz7)."
+  below for the full mechanism."
   :rf.machine/done)
 
 (def spawn-error-event-id
   "The reserved inner event-id dispatched into a PARENT machine when one of
   its `:spawn`-spawned children FAILS — re-frame2's spelling of XState v5
-  `invoke onError` (control flow, not just observability — rf2-5hlsh). Two
+  `invoke onError` (control flow, not just observability). Two
   triggers raise it (both fired from the child's finalize / action-exception
   path in `lifecycle-fx.finalize` / `lifecycle-fx.registration`):
 
@@ -123,7 +123,7 @@
   map until it hits a fn (or fails). Tolerates one level of indirection
   like {:short-name :registered-id} where :registered-id resolves to a fn.
 
-  Per rf2-npvsx every `:guards` / `:actions` / `:on-spawn-actions` entry
+  Every `:guards` / `:actions` / `:on-spawn-actions` entry
   is the co-located `{:fn <fn> ...}` map (the `:source-*` slots are
   dev-only). A registry VALUE may therefore be that entry map, a bare fn
   (programmatic `reg-machine*` with raw fns, or a `(constantly …)`
@@ -140,12 +140,12 @@
                                       nil)
       :else                         nil)))
 
-;; ---- the canonical thrown-error shape for transition failures (rf2-yl39ub) --
+;; ---- the canonical thrown-error shape for transition failures --------------
 ;;
-;; Runtime transition failures historically threw a bare-keyword `ex-info`
-;; with minimal data and no canonical `:rf.error/id` / `:where` / `:recovery` /
-;; `:reason`. `machine-error` routes every transition throw through the central
-;; builder (`re-frame.error/thrown-ex-info`, Spec 009 §The thrown-error shape):
+;; `machine-error` routes every transition throw through the central
+;; builder (`re-frame.error/thrown-ex-info`, Spec 009 §The thrown-error shape),
+;; so every transition failure carries a canonical `:rf.error/id` / `:where` /
+;; `:recovery` / `:reason`:
 ;; the human sentence rides `:reason` and leads the derived message (+ the
 ;; `[:rf.error/<id>]` token), `:where` names the machine grammar surface, and
 ;; the surface-specific context (machine id, offending slot + value, known
@@ -153,7 +153,7 @@
 ;; REGISTRATION shape errors, so the default recovery is `:fix-registration`.
 
 (defn- machine-error
-  "Build the canonical machine-transition thrown-error `ex-info` (rf2-yl39ub).
+  "Build the canonical machine-transition thrown-error `ex-info`.
   `category` is the `:rf.error/machine-*` discriminator (lands in
   `:rf.error/id`); `reason` is the human sentence; `extras` merge on top.
   `:recovery` defaults to `:fix-registration` (these are caller-fixable
@@ -221,7 +221,7 @@
 
 ;; ---- guard/action contract --------------------------------------------------
 ;;
-;; Per Spec 005 §Guards / §Actions (rf2-grw4i / rf2-v0rrr), the canonical
+;; Per Spec 005 §Guards / §Actions, the canonical
 ;; signature for every machine callback is a SINGLE context-map argument:
 ;;
 ;;   (fn [{:keys [data event state meta]}] ...)
@@ -248,7 +248,7 @@
 ;; makes meaningful keys explicit; the runtime delivers them in a single
 ;; map.
 ;;
-;; ---- cross-region guard/action context (rf2-46ly6 / rf2-69d1n) ------------
+;; ---- cross-region guard/action context ------------------------------------
 ;;
 ;; XState v5 / SCXML gold standard: a parallel region's guard can predicate
 ;; on a SIBLING region's active state via `stateIn(stateValue)` (XState v5
@@ -256,8 +256,8 @@
 ;; the canonical orthogonal-region coordination primitive — region A's
 ;; `:submit` guarded by "region B is in `:valid`".
 ;;
-;; re-frame2 expresses this WITHOUT a separate `stateIn` primitive (per
-;; rf2-69d1n — behavioural parity, not API mimicry). When `call-guard` /
+;; re-frame2 expresses this WITHOUT a separate `stateIn` primitive
+;; (behavioural parity, not API mimicry). When `call-guard` /
 ;; `call-action` run for a REGION of a parallel machine, the context map
 ;; gains two cross-region keys, threaded in by `parallel/reduce-regions`:
 ;;
@@ -283,16 +283,16 @@
 
 (defn- callback-ctx
   "Build the unified context-map handed to a `:guard` / `:action` / `:entry`
-  / `:exit` callback. Per Spec 005 §Guards / §Actions (rf2-grw4i /
-  rf2-v0rrr) the base shape is `{:data :event :state :meta}`.
-  Per rf2-46ly6 / rf2-69d1n, a parallel REGION's snapshot additionally
+  / `:exit` callback. Per Spec 005 §Guards / §Actions
+  the base shape is `{:data :event :state :meta}`.
+  A parallel REGION's snapshot additionally
   carries the machine-wide `:tags` union and the full `:all-state` region
   map (threaded by `parallel/reduce-regions`) — the cross-region
   coordination keys (XState v5 `stateIn` / SCXML `In()`). `:all-state` is
   the parallel-region marker: present iff this is a region snapshot, so
   flat / compound machines surface neither key and their ctx is unchanged.
 
-  Per EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): when the event handler's
+  When the event handler's
   causal recordable-coeffect token (the router's `:rf.cofx` coeffect — Spec
   002 §Event Context And Coeffects) has been threaded onto the machine def
   under `:rf/cofx` (stamped by `prepare-machine-ctx` alongside `:rf/frame` /
@@ -317,9 +317,8 @@
 (defn- call-guard
   "Invoke a resolved guard fn against a snapshot + event with the unified
   context-map contract — `(fn [{:keys [data event state meta]}] boolean)`.
-  Per Spec 005 §Guards (rf2-grw4i / rf2-v0rrr); a parallel region's guard
-  additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n), and —
-  per EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf) — the causal `:rf.cofx`
+  Per Spec 005 §Guards; a parallel region's guard
+  additionally receives `:tags` + `:all-state`, and the causal `:rf.cofx`
   token when the handler threaded it onto the machine def."
   [machine g snapshot event]
   (g (callback-ctx machine snapshot event)))
@@ -327,16 +326,15 @@
 (defn- call-action
   "Invoke a resolved action fn against a snapshot + event with the unified
   context-map contract — `(fn [{:keys [data event state meta]}] effects)`.
-  Per Spec 005 §Actions (rf2-grw4i / rf2-v0rrr); a parallel region's action
-  additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n), and —
-  per EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf) — the causal `:rf.cofx`
+  Per Spec 005 §Actions; a parallel region's action
+  additionally receives `:tags` + `:all-state`, and the causal `:rf.cofx`
   token when the handler threaded it onto the machine def."
   [machine f snapshot event]
   (f (callback-ctx machine snapshot event)))
 
 ;; ---- guard / action evaluation traces -------------------------------------
 ;;
-;; Per Spec 009 §Instrumentation and rf2-2nwfd: every user-declared guard
+;; Per Spec 009 §Instrumentation: every user-declared guard
 ;; evaluation emits `:rf.machine/guard-evaluated`; every user-declared
 ;; action invocation emits `:rf.machine/action-ran`. Both traces ride
 ;; through the standard trace bus, so `*handler-scope*` auto-stamps
@@ -357,13 +355,12 @@
   synthesised always-true — skip the trace (it is not a user-declared
   evaluation) and return true.
 
-  Per rf2-82a0u: when the guard fn throws, emit
+  When the guard fn throws, emit
   `:rf.machine/guard-evaluated` with `:outcome :threw` and the
   `:exception` slot, then treat the guard as failed (return `false`)
-  so the candidate-walk continues evaluating siblings — Spec 005
-  §Guards is silent on throw semantics; the engine's existing
-  implicit behaviour (let it propagate) hides the failure entirely
-  from the trace stream. Treating throw as `:fail` matches the
+  so the candidate-walk continues evaluating siblings. This surfaces the
+  failure on the trace stream rather than letting it propagate silently.
+  Treating throw as `:fail` matches the
   documented `:action`-threw convention (the action that throws emits
   one trace and the cascade halts; for guards the cascade should walk
   past the throwing candidate to the next one, which is the
@@ -373,26 +370,26 @@
   (if (nil? guard-ref)
     true
     (let [g          (resolve-guard machine guard-ref)
-          ;; rf2-yyvtk5 — a guard is evaluated against a LIVE actor's
+          ;; A guard is evaluated against a LIVE actor's
           ;; snapshot, so the addressed id is the running INSTANCE
           ;; (`:rf/parent-id` is the live actor address stamped by
           ;; `prepare-machine-ctx`; `:id` is the singleton's registration
           ;; id, which IS its live address). It rides under `:actor-id` —
           ;; `:machine-id` is reserved for the registered TYPE.
           actor-id   (or (:rf/parent-id machine) (:id machine))
-          ;; Per rf2-ko8jb: epoch-capture admission requires `:frame`.
+          ;; Epoch-capture admission requires `:frame`.
           ;; `(:rf/frame machine)` is stamped by `prepare-machine-ctx`
           ;; (registration.cljc) before the engine is invoked; nil-safe
           ;; for pure-function callers (conformance corpus, JVM fixtures).
           frame-id   (:rf/frame machine)
-          ;; rf2-tjm3u2 — the ACTIVE state the guard was evaluated against
+          ;; The ACTIVE state the guard was evaluated against
           ;; (the snapshot's `:state`: a keyword, a vector path, or — for a
           ;; parallel region's snapshot — a region value). Stamped on the
           ;; trace so a downstream consumer can disambiguate WHICH state's
           ;; edge a guard-block belongs to. Without it, two states that
           ;; declare the SAME event + SAME guard id are indistinguishable by
-          ;; `(event, guard)` alone, and a single guard failure paints BOTH
-          ;; edges (the bug). The guard runs during the active-configuration
+          ;; `(event, guard)` alone, and a single guard failure would paint BOTH
+          ;; edges. The guard runs during the active-configuration
           ;; resolution, so the active `:state` is the discriminator: the
           ;; consumer (`panels.machines.trace-state/extract-guard-blocked-
           ;; edge-ids`) matches only edges whose declaring `:from-path` is on
@@ -422,7 +419,7 @@
 
 ;; ---- spawn-id allocator (in-snapshot) -------------------------------------
 ;;
-;; Per Spec 005 §Declarative :spawn (sugar over spawn) and rf2-gr8q: on
+;; Per Spec 005 §Declarative :spawn (sugar over spawn): on
 ;; entry to a :spawn-bearing state the runtime emits a :rf.machine/spawn
 ;; fx and assigns the spawned actor a deterministic id of the form
 ;; `<machine-id>#<n>`. The counter lives inside the snapshot under the
@@ -433,8 +430,8 @@
 ;; the snapshot's counter via update-in and the bumped value is the
 ;; allocated id.
 ;;
-;; `build-initial-snapshot` (in re-frame.machines.parallel — unified per
-;; rf2-fgqs4 across the singleton-registration and spawn paths) stamps
+;; `build-initial-snapshot` (in re-frame.machines.parallel — unified
+;; across the singleton-registration and spawn paths) stamps
 ;; `{:rf/spawn-counter {}}` on every freshly-registered machine's
 ;; initial snapshot so the slot is always present for live runtime
 ;; spawns. Hand-built snapshots (the conformance fixtures) may omit the
@@ -451,7 +448,7 @@
   "Pure allocator. Given a snapshot and the spawned actor's machine-id,
   return `[snap' spawned-id]` where snap' carries the bumped counter at
   `[:rf/spawn-counter <machine-id>]` and spawned-id is
-  `<machine-id>#<bumped-n>`. Per rf2-gr8q the counter lives in-snapshot
+  `<machine-id>#<bumped-n>`. The counter lives in-snapshot
   so machine-transition is deterministic from its arguments."
   [snap machine-id]
   (let [snap' (update-in snap [:rf/spawn-counter machine-id] (fnil inc 0))
@@ -459,7 +456,7 @@
     [snap' (format-spawn-id machine-id n)]))
 
 (defn- bind-spawned-id-into-parent-data
-  "Per rf2-rc8wci — bind a declaratively-`:spawn`'d actor's assigned id into
+  "Bind a declaratively-`:spawn`'d actor's assigned id into
   the SPAWNING (parent) machine's own `:data`, at spawn-time, under the
   reserved per-invoke map `:rf/spawned`: `{:rf/spawned {<invoke-id> <spawned-id>}}`.
 
@@ -587,7 +584,7 @@
 
 ;; ---- :fsm/tags — active-configuration tag union ---------------------------
 ;;
-;; Per Spec 005 §State tags (rf2-ee0d / Nine States Stage 1). A state node
+;; Per Spec 005 §State tags. A state node
 ;; may declare `:tags <set-of-keywords>`. The runtime maintains a derived
 ;; `:tags` slot on the snapshot — the union of every currently-active
 ;; state's tag set.
@@ -652,7 +649,7 @@
   {:target s2 :action a}]`) resolves identically whether it is reached
   through an `:on` clause or an `:after` delay entry.
 
-  rf2-16gxd — the FORBIDDEN-TRANSITION value form. A nil VALUE (the key is
+  The FORBIDDEN-TRANSITION value form. A nil VALUE (the key is
   PRESENT in the table with value nil — `{:on {:logout nil}}`) normalises to
   a single unguarded INTERNAL candidate `[{}]`, exactly as the empty map
   `{:on {:logout {}}}` does. Both are enabled, targetless (internal) no-ops
@@ -679,7 +676,7 @@
   [v bad-value-id]
   (case (grammar/transition-value-form v)
     ;; A nil VALUE (the key is present with value nil) is the
-    ;; forbidden-transition / internal no-op form (rf2-16gxd) — unify
+    ;; forbidden-transition / internal no-op form — unify
     ;; with the empty-map single-candidate `[{}]`.
     :nil              [{}]
     :keyword          [{:target v}]
@@ -703,7 +700,7 @@
   only value-form the inline-source macro keys per-INDEX (single-map /
   keyword / vector-target forms are keyed at the bare slot path). Used to
   decide whether the selected candidate's index is meaningful for the
-  spec-path discriminator (rf2-lai1qv): for the index-free forms the
+  spec-path discriminator: for the index-free forms the
   carried `:candidate-idx` is nil so `cascade-row-source-key` emits the
   bare-slot shape that matches the macro's keying. Delegates to the
   shared `grammar/candidate-vector-form?` so the per-index decision and
@@ -712,7 +709,7 @@
   (grammar/candidate-vector-form? v))
 
 (defn- transition-slot
-  "Build the structured spec-path DISCRIMINATOR (rf2-lai1qv) carried on a
+  "Build the structured spec-path DISCRIMINATOR carried on a
   selected transition under `:rf/transition-slot`, so the Xray cascade
   rows can address the EXACT inline-source spec-path slot rather than
   reconstructing it from `source-state` / `event` / `phase` (which loses
@@ -742,7 +739,7 @@
      :root?         (empty? decl-path)}))
 
 (defn- finalize-on-transition-slot
-  "rf2-lai1qv — complete the PARTIAL `:on` `:rf/transition-slot`
+  "Complete the PARTIAL `:on` `:rf/transition-slot`
   `match-on-clause` stamped (slot / matched event-key / candidate-idx /
   raw-value, but no decl-path) by folding in the `decl-path` the pick
   site owns and running it through `transition-slot` (which computes
@@ -762,7 +759,7 @@
   0-based index of the first guard-passing candidate alongside the
   candidate map — or nil when none pass. The index is what the inline
   source lookup needs to address a multi-candidate `:on` / `:after` /
-  `:always` vector's exact spec-path slot (rf2-lai1qv); the bare
+  `:always` vector's exact spec-path slot; the bare
   `select-passing-candidate` wrapper drops it for callers that only need
   the candidate."
   [machine candidates snapshot event]
@@ -798,8 +795,8 @@
   stale on next firing.
 
   For flat / compound machines the map lives at `[:data :rf/after-epoch]`.
-  Per Spec 005 §Per-region `:always` / `:after` / `:spawn` scoping
-  (rf2-l67o / Stage 2): when `machine` is a region of a parallel-region
+  Per Spec 005 §Per-region `:always` / `:after` / `:spawn` scoping:
+  when `machine` is a region of a parallel-region
   parent (signalled by `:rf/region`), the map is region-scoped —
   `[:data :rf/after-epoch-by-region <region-name>]` — so a sibling
   region's transition doesn't invalidate this region's in-flight timers
@@ -839,10 +836,10 @@
   2202) the node's epoch AND its declaring path travel with EVERY timer:
   the synthetic event is the 4-element `[delay-key epoch decl-path]`
   shape the runtime always emits, so a `nil` `carried-decl-path` is a
-  malformed event (a hand-rolled / pre-decl-path dispatch). It resolves
-  to nil — no transition, the benign unhandled-no-op signal. There is no
-  legacy 3-element leaf→root fallback (rf2-wtw3rw): the decl-path is
-  contractual, not optional.
+  malformed event (a hand-rolled dispatch). It resolves
+  to nil — no transition, the benign unhandled-no-op signal. The decl-path
+  is contractual, not optional: the synthetic event always routes to its
+  scheduling node by the carried path.
 
   A timer is **live** iff its scheduling node is still on the active path
   (its `carried-decl-path` is a prefix of the current path) AND the
@@ -867,14 +864,14 @@
   [machine path event snapshot]
   (let [[_ delay-key carried-epoch raw-carried-decl-path] event
         region        (:rf/region machine)
-        ;; rf2-yyvtk5 — the timer's owning actor is a LIVE INSTANCE
+        ;; The timer's owning actor is a LIVE INSTANCE
         ;; (`:rf/parent-id` is the live actor address stamped by
         ;; `prepare-machine-ctx`; `:id` is a singleton's registration id,
         ;; which IS its live address). The match carries it under
         ;; `:actor-id` so `emit-pick-traces!` can stamp the
         ;; `:rf.machine.timer/fired` / `:rf.machine.timer/stale-after` rows
         ;; with the owning actor (spec/009 §machine `:after` timer
-        ;; lifecycle) — previously these rows carried `:actor-id nil`.
+        ;; lifecycle).
         actor-id      (or (:rf/parent-id machine) (:id machine))
         ;; Per Spec 005 §Per-region :after scoping: the runtime carries a
         ;; region-name-prefixed decl-path (`prefix-region-invoke-id`) for
@@ -905,7 +902,7 @@
           (let [cands     (normalise-candidates t :rf.error/machine-bad-after-spec)
                 [idx tspec] (select-passing-candidate-indexed machine cands snapshot event)]
             (if tspec
-              {;; rf2-lai1qv — stamp the `:after` spec-path discriminator
+              {;; Stamp the `:after` spec-path discriminator
                ;; (decl-path prefix + the delay-key + the matched candidate
                ;; index) so the Xray cascade row addresses the exact
                ;; `[:states … :after <delay>]` inline-source slot.
@@ -927,7 +924,7 @@
               {:guard-suppressed? true
                :actor-id          actor-id
                :state             (last prefix)
-               ;; rf2-ze13fg — carry the declaring path so `after-fired-reply`
+               ;; Carry the declaring path so `after-fired-reply`
                ;; (via `timer-work-id`) yields the canonical
                ;; `[:rf.work/timer [<actor> <decl-path>] epoch]` work-id. The
                ;; live (`resolve-hit`) and stale branches both set `:decl-path`;
@@ -961,7 +958,7 @@
           ;; Likewise when the node has been exited (no longer on the
           ;; active path) → stale.
           ;;
-          ;; Per EP-0011 §Timer Reply / Managed-Effects §Stale suppression,
+          ;; Per Managed-Effects §Stale suppression,
           ;; the declaring path + per-path epoch ARE the data-only
           ;; suppression gate. Carry `:decl-path` so the lifecycle's
           ;; `:rf.machine.timer/stale-after` trace can express the
@@ -975,17 +972,16 @@
            :scheduled-epoch carried-epoch
            :current-epoch   cur-epoch}))
 
-      ;; A malformed event with no carried decl-path (rf2-wtw3rw): the
+      ;; A malformed event with no carried decl-path: the
       ;; runtime always emits the 4-element `[delay-key epoch decl-path]`
       ;; shape (Spec 005 §Hierarchy interaction), so a nil decl-path can
-      ;; only be a hand-rolled / pre-decl-path dispatch. There is no
-      ;; legacy leaf→root fallback — resolve to nil (no transition, the
+      ;; only be a hand-rolled dispatch. Resolve to nil (no transition, the
       ;; benign unhandled-no-op).
       :else nil)))
 
 (defn ns-wildcard-key
   "Per Spec 005 §Wildcard transitions §Namespaced (partial) event
-  descriptors (rf2-z4t2v). The namespace-wildcard descriptor for an
+  descriptors. The namespace-wildcard descriptor for an
   event-id is its KEYWORD NAMESPACE paired with the `*` name — `:foo/bar`
   → `:foo/*`, `:mouse/down` → `:mouse/*`. This is re-frame2's spelling of
   XState v5's partial (prefix) event descriptor `mouse.*` (SCXML §3.12.1
@@ -1011,7 +1007,7 @@
   §Transition resolution / §Wildcard transitions — the per-level matching
   rule applied identically at every state-node and at the machine root.
 
-  rf2-z4t2v — three descriptor tiers, in PRIORITY order at each level:
+  Three descriptor tiers, in PRIORITY order at each level:
     1. EXACT `event-id` candidates;
     2. the NAMESPACE-WILDCARD `:ns/*` (`ns-wildcard-key` — `:mouse/*`
        catches any `:mouse/...` event; re-frame2's spelling of XState v5's
@@ -1019,7 +1015,7 @@
     3. the TOTAL `:*` wildcard.
   Most-specific wins: exact > namespace-wildcard > total.
 
-  rf2-icj9t — each tier is the LEAST-PRIORITY ENABLED transition relative
+  Each tier is the LEAST-PRIORITY ENABLED transition relative
   to the tiers above it, NOT a 'no more specific KEY exists' fallback. A
   tier is consulted whenever NO higher tier yielded an ENABLED candidate —
   the higher key is absent, OR every one of its guarded candidates returned
@@ -1033,7 +1029,7 @@
   a guard-failed transition is simply not selected, leaving lower-priority
   ones eligible).
 
-  rf2-e7yhv — when the returned match came from EITHER wildcard tier (the
+  When the returned match came from EITHER wildcard tier (the
   more specific tiers were absent or all guard-blocked, and a wildcard's
   candidate fired) the transition is stamped `:rf/via-wildcard? true`.
   This rides the `:transition` slot through `apply-transition-once` into a
@@ -1044,7 +1040,7 @@
   [machine node event-id event snapshot]
   (let [on            (:on node)
         select        (fn [k]
-                        ;; rf2-16gxd — gate on PRESENCE. An ABSENT key yields
+                        ;; Gate on PRESENCE. An ABSENT key yields
                         ;; no candidates (this tier is not enabled → fall
                         ;; through to the next tier, then to the parent). A
                         ;; PRESENT key normalises its value, where a nil value
@@ -1056,7 +1052,7 @@
                         ;; is the whole point of the forbidden idiom: absence ≠
                         ;; block.
                         ;;
-                        ;; rf2-lai1qv — on a hit, stamp the PARTIAL spec-path
+                        ;; On a hit, stamp the PARTIAL spec-path
                         ;; discriminator `:rf/transition-slot` (`:slot :on`, the
                         ;; MATCHED key `k`, the candidate index, and the raw
                         ;; value form). `decl-path` / `:root?` are filled by the
@@ -1081,7 +1077,7 @@
         ;; non-namespaced event-id; `ns-key` is nil and `select` is never
         ;; called). Tier 3 — total `:*`. Most-specific wins; each tier is
         ;; consulted only when the tiers above yielded no ENABLED candidate
-        ;; (absent key OR every guarded candidate guard-blocked) — rf2-icj9t.
+        ;; (absent key OR every guarded candidate guard-blocked).
         ns-key        (ns-wildcard-key event-id)]
     (if-let [exact-hit (select event-id)]
       exact-hit
@@ -1092,7 +1088,7 @@
 
 (defn root-on-match
   "Per Spec 005 §Transition broadcast §Root parallel `:on` — the ancestor
-  fallback (rf2-tsq6g): resolve the PARALLEL ROOT's own `:on` for `event`
+  fallback: resolve the PARALLEL ROOT's own `:on` for `event`
   against the frozen pre-event `snapshot`, most-specific-tier-first
   (exact → `:ns/*` → `:*`), via `match-on-clause` with the machine map itself
   as the matching node. Returns the matched transition map (carrying
@@ -1113,7 +1109,7 @@
   (match-on-clause machine machine (first event) event snapshot))
 
 (defn- pick-done-transition
-  "Per Spec 005 §Final states §The done-state signal (rf2-bnjb3 / rf2-zlmz7):
+  "Per Spec 005 §Final states §The done-state signal:
   resolve the synthetic completion event `[:rf.machine/done <node-path>]` —
   raised when the compound / parallel node at `<node-path>` reached its done
   configuration — to a transition. Two resolution arms, in priority order:
@@ -1134,8 +1130,8 @@
       `:event` (`(= <path> (second event))`) to disambiguate which node is
       done when several could raise it.
 
-  **Parallel-region scoping — by region IDENTITY, not state-name shape
-  (rf2-12ekv, superseding the rf2-m3arq shape-match).** A region-local
+  **Parallel-region scoping — by region IDENTITY, not state-name shape.**
+  A region-local
   compound's done signal is re-broadcast across EVERY sibling region by the
   parent internal-event queue (`parallel/drain-parent-queue` — the correct
   XState v5 / SCXML `:raise` rule), so the raised done reaches every region's
@@ -1144,19 +1140,15 @@
   even one whose compound shares the leading state-name (a common shape:
   per-region `:flow` sub-flows, `:loading`/`:loaded` axes).
 
-  The earlier rf2-m3arq gate compared two REGION-RELATIVE paths with
-  `prefix-of?` — a state-name SHAPE match, not a region-identity test — so it
-  leaked whenever the sibling shared the leading state-name, and it only guarded
-  arm 2 (arm 1 was ungated). The root-cause fix (rf2-12ekv) makes the done-raise
-  carry a REGION-NAME HEAD (`done-raise-fx` stamps `:rf/region` onto the raised
-  path — the same region-name-prefixing discipline `:after` / `:spawn`
-  `:on-error` already use). Here we strip that head and decline a FOREIGN
-  region's done by region NAME, mirroring `pick-after-transition`
+  The done-raise carries a REGION-NAME HEAD (`done-raise-fx` stamps
+  `:rf/region` onto the raised path — the same region-name-prefixing discipline
+  `:after` / `:spawn` `:on-error` use). Here we strip that head and decline a
+  FOREIGN region's done by region NAME, mirroring `pick-after-transition`
   (`decline-region?` = `(not= region (first carried-path))`) and
   `pick-spawn-error-transition`. The region-stripped path is then region-
   relative again for BOTH arms — arm 1 resolves the done node via the stripped
   `done-path`, arm 2 walks `:on` for the stripped event — so a sibling sharing
-  the path-SHAPE no longer matches: identity (the region-name head), not shape,
+  the path-SHAPE does not match: identity (the region-name head), not shape,
   decides. Flat / compound machines carry no `:rf/region` and the done-raise
   carries no head, so the strip / decline is inert — an unguarded
   `:on {:rf.machine/done …}` stays unambiguous (only the one machine raises into
@@ -1170,7 +1162,7 @@
   [machine path event snapshot]
   (let [[_ raw-done-path] event
         region        (:rf/region machine)
-        ;; rf2-12ekv — region-identity scoping. The done-raise carries a
+        ;; Region-identity scoping. The done-raise carries a
         ;; region-name HEAD when raised from a parallel region (`done-raise-fx`
         ;; stamps `:rf/region`). Within a region's resolution `machine` is the
         ;; region body (region-relative `node-at`) and `path` is in-region, so
@@ -1193,7 +1185,7 @@
                         (assoc (vec event) 1 done-path)
                         event)
         done-node     (when (vector? done-path) (node-at machine done-path))
-        ;; rf2-16gxd — gate on PRESENCE of `:on-done`. The forbidden-transition
+        ;; Gate on PRESENCE of `:on-done`. The forbidden-transition
         ;; nil→`[{}]` rule in `normalise-candidates` is for a PRESENT value;
         ;; an ABSENT `:on-done` must yield no candidates so resolution falls
         ;; through to the enclosing explicit `:on {:rf.machine/done …}` walk
@@ -1219,7 +1211,7 @@
 
 (defn- pick-spawn-error-transition
   "Per Spec 005 §Final states §`:on-error` — child-failure control flow
-  (rf2-5hlsh; XState v5 `invoke onError`): resolve the synthetic parent event
+  (XState v5 `invoke onError`): resolve the synthetic parent event
   `[:rf.machine.spawn/error <invoke-id> <error>]` — dispatched into the PARENT
   when one of its `:spawn`-spawned children failed — to a transition.
 
@@ -1257,21 +1249,19 @@
   [machine path event snapshot]
   (let [[_ raw-invoke-id] event
         region         (:rf/region machine)
-        ;; rf2-w84jv — region-identity scoping, symmetric with
-        ;; `pick-done-transition`'s `decline-region?` (rf2-12ekv). A `:spawn`
+        ;; Region-identity scoping, symmetric with
+        ;; `pick-done-transition`'s `decline-region?`. A `:spawn`
         ;; declared inside a parallel region carries a region-name-prefixed
         ;; invoke-id (`prefix-region-invoke-id`), so `(first raw-invoke-id)` is
         ;; the OWNING region's name. The spawn-error broadcast reaches every
         ;; region's resolver (`drain-parent-queue`), so a region whose name
-        ;; does NOT match the invoke-id head must decline OUTRIGHT — for BOTH
+        ;; does NOT match the invoke-id head declines OUTRIGHT — for BOTH
         ;; the `:spawn :on-error` arm and the explicit `:on
-        ;; {:rf.machine.spawn/error …}` escape-hatch arm. Before this gate the
-        ;; foreign region nilled `invoke-id` (correctly disabling arm 1) but
-        ;; still fell through to arm 2, letting a sibling region's explicit
-        ;; handler catch another region's child failure — violating
-        ;; XState v5 `invoke onError` region scoping. Mirrors the done-side
-        ;; identity test: a head naming a DIFFERENT region is not this
-        ;; region's spawn error.
+        ;; {:rf.machine.spawn/error …}` escape-hatch arm. This honours
+        ;; XState v5 `invoke onError` region scoping: a sibling region's
+        ;; explicit handler never catches another region's child failure.
+        ;; Mirrors the done-side identity test: a head naming a DIFFERENT
+        ;; region is not this region's spawn error.
         decline-region? (and region
                              (vector? raw-invoke-id)
                              (not= region (first raw-invoke-id)))
@@ -1330,7 +1320,7 @@
 
   Special-cases the synthetic :rf.machine.timer/after-elapsed event by
   delegating to pick-after-transition, and the synthetic
-  `[:rf.machine/done <node-path>]` completion event (rf2-bnjb3 / rf2-zlmz7)
+  `[:rf.machine/done <node-path>]` completion event
   by delegating to `pick-done-transition` (the done node's `:on-done`, then
   an enclosing explicit `:on {:rf.machine/done …}`)."
   [machine path event snapshot]
@@ -1364,7 +1354,7 @@
   §Transition resolution the no-op marks an UNKNOWN USER event a machine
   declined (xstate-v5 parity — ignored, never thrown).
 
-  Carve-out (rf2-t4582 — a conscious refinement of rf2-ugdas): the no-op
+  Carve-out: the no-op
   classifies an unknown USER / domain event, NOT framework lifecycle
   traffic. Per [Conventions.md §The single-root reserved set] the
   framework reserves the `:rf/*` root namespace for every framework-owned
@@ -1378,10 +1368,10 @@
      §Synthetic creation marker) is a placeholder threaded into the
      initial-entry actions so they carry an `:event` key — the start RAN
      the entry cascade and INSTALLED the state; it is the machine's BIRTH,
-     not a no-op. (Per F‴ / rf2-gl588 an eager `[:machine-id
-     [:rf.machine/start]]` kick is a PURE init that STOPS — it never
-     reaches this no-op site as a trigger; the rule subsumes the marker
-     only as the cascade-threaded `:event` placeholder.);
+     not a no-op. (An eager `[:machine-id [:rf.machine/start]]` kick is a
+     PURE init that STOPS — it never reaches this no-op site as a trigger;
+     the rule subsumes the marker only as the cascade-threaded `:event`
+     placeholder.);
    - the spawn kick-off `[:rf.machine.spawn/spawned]` (Spec 005 §spawn
      kick-off) is dispatched into every spawned actor so generic children
      may declare a first transition — an actor that declines it simply
@@ -1391,17 +1381,15 @@
      `:rf.story.lifecycle/events-complete` at a machine already resting in
      `:ready`) ride the same root.
 
-  This re-SEPARATES the spawn-kickoff exemption rf2-ugdas folded into the
-  general rule, and ALIGNS with xstate: xstate's own init (`xstate.init`)
+  This ALIGNS with xstate: xstate's own init (`xstate.init`)
   runs the initial-entry and is NOT reported as an unhandled event — only
   unknown user events are silently ignored. Distinguishing re-frame2's
-  bootstrap / spawn-kickoff makes us MORE like xstate, not a v5-parity
-  violation. SEVERITY is unchanged from rf2-ugdas (benign — nothing
-  throws); only the SEMANTIC classification is restored, so reserved-
-  `:rf/*` framework init does not read as an unknown-user-event no-op.
+  bootstrap / spawn-kickoff keeps us aligned with xstate. The classification
+  is benign — nothing throws; reserved-`:rf/*` framework init simply does not
+  read as an unknown-user-event no-op.
 
   (`:rf.machine.timer/after-elapsed` is special-cased in `pick-transition`
-  and `:rf.machine/start` is `:entry`-only — and, per F‴ (rf2-gl588), the
+  and `:rf.machine/start` is `:entry`-only — and the
   eager start kick STOPS after initial-entry without ever running the
   transition step — so neither reaches the no-op site as a trigger; both
   are reserved-namespace, so the rule subsumes them regardless.)
@@ -1423,7 +1411,7 @@
      parent so the state appears in both the exit and entry cascades — is
      `compute-cascade-paths`' job; here `:same-state` simply names the
      declaring state as the target. Per Spec 005 §Self-transitions +
-     Spec-Schemas TransitionTarget (rf2-46ban).
+     Spec-Schemas TransitionTarget.
    - keyword target → sibling at decl-path's level (replace last element).
      A keyword that names the declaring state's OWN key resolves to
      `decl-path` too, so it is the same external self-transition as
@@ -1433,9 +1421,8 @@
    - nil target (internal transition) → nil; the caller wraps the call
      in `some->>` so the nil short-circuits the initial-cascade descent.
 
-  Per rf2-adwxh the explicit `(nil? target) nil` arm is dropped — when
-  target is neither vector nor keyword, the `cond` falls through to
-  nil, which is the documented internal-transition contract."
+  When target is neither vector nor keyword, the `cond` falls through to
+  nil, which is the internal-transition contract."
   [decl-path target]
   (cond
     (= :same-state target) (vec decl-path)
@@ -1447,7 +1434,7 @@
 (defn- common-prefix-length [a b]
   (count (take-while true? (map = a b))))
 
-;; ---- history pseudo-states (rf2-mle6e.3) ----------------------------------
+;; ---- history pseudo-states ------------------------------------------------
 ;;
 ;; Per Spec 005 §History states (`:type :history` — shallow / deep /
 ;; default-target). A `:type :history` node under a compound's `:states` is
@@ -1456,8 +1443,8 @@
 ;;
 ;;   - RESTORES on re-entry — `compute-cascade-paths` swaps the pseudo-state
 ;;     target for the resolved leaf BEFORE the LCA geometry, so the standard
-;;     exit/action/entry cascade applies unchanged (46ban's external-self-
-;;     transition LCA fix is the precedent: resolve the real path first,
+;;     exit/action/entry cascade applies unchanged (the external-self-
+;;     transition LCA rule is the precedent: resolve the real path first,
 ;;     then let the geometry run on it);
 ;;   - RECORDS on exit — `apply-transition-once` writes the exited compound's
 ;;     last-active configuration into the snapshot `:rf/history` slot as part
@@ -1483,8 +1470,8 @@
   `:type :history` pseudo-state. Per Spec-Schemas §`:type :history`: a
   history node is TARGETABLE (a transition may aim at it) but is NEVER an
   occupied active state — a snapshot whose active leaf IS a history node is
-  malformed and must reset, not be driven through the engine (bz0ox.2 /
-  x4s9t.2). A malformed `:state` shape (`state-path` throws) is treated as
+  malformed and must reset, not be driven through the engine. A malformed
+  `:state` shape (`state-path` throws) is treated as
   not-occupiable so the caller's reset path covers shape-error AND
   missing-state AND occupied-history alike."
   [machine state]
@@ -1518,7 +1505,7 @@
 (defn- valid-leaf-path?
   "True iff `path` resolves to a real (non-history) state-node in the
   current definition. Used to detect a DANGLING recorded path after hot
-  reload (rf2-wgfv0): a recorded config referencing a removed substate."
+  reload: a recorded config referencing a removed substate."
   [machine path]
   (let [n (node-at machine path)]
     (and (some? n) (not (history-node? n)))))
@@ -1538,7 +1525,7 @@
      `:rf.machine.history/restored` `:restored-config` tag).
    - `:default` — no (valid) recording: the owning compound was never
      entered, or the recorded config is a DANGLING path a hot-reloaded
-     definition removed (rf2-wgfv0). Falls back to the pseudo-state's
+     definition removed. Falls back to the pseudo-state's
      `:default-target` (initial-cascaded), or — when absent — the owning
      compound's `:initial` cascade, exactly as a first-ever entry would.
      Additionally carries `:fallback` — `:default-target` when the
@@ -1622,8 +1609,8 @@
   compound must actually be left. A transition that merely moves between
   two children of `C` (LCA = C, so `C` SURVIVES as the LCCA) records
   NOTHING for `C` — `C` was never exited, so there is no last-active
-  configuration to remember (rf2-9eidiv: ruled ALIGN to the exit-set rule,
-  retiring the prior `<=` active-child-subtree-teardown trigger).
+  configuration to remember (the exit-set rule: history captures only when
+  the compound is actually left).
 
   Returns `[snapshot recorded]` where `recorded` is the seq of
   `{:compound-path :recorded-config :kind :prev-config}` maps (for the
@@ -1643,7 +1630,7 @@
     ;; EXIT SET — its node (index `depth - 1` along `src-path`) lies strictly
     ;; below the surviving LCA boundary: `lca-len < depth`. (A move BETWEEN
     ;; `C`'s children leaves `lca-len = depth`, so `C` survives as the LCCA
-    ;; and records nothing — the XState v5 / SCXML exit-set rule, rf2-9eidiv.)
+    ;; and records nothing — the XState v5 / SCXML exit-set rule.)
     (reduce
       (fn [[snap recs] depth]
         (let [compound-path (subvec src-path 0 depth)
@@ -1667,7 +1654,7 @@
       [snapshot []]
       (range 0 n))))
 
-;; ---- history trace events (rf2-mle6e.3; spec/009 contract: rf2-mle6e.2) ----
+;; ---- history trace events (spec/009 contract) -----------------------------
 ;;
 ;; Per Spec 005 §History states + Spec 009 §Trace events. The engine emits
 ;; observability traces under the machine-activity family `:rf.machine.
@@ -1689,7 +1676,7 @@
 ;;     deep leaf path / shallow child keyword), `:prev-config` (the value
 ;;     overwritten; ABSENT on the first-ever recording), `:frame`.
 ;;
-;; Shapes match spec/009 §History trace events EXACTLY (rf2-mle6e.2).
+;; Shapes match spec/009 §History trace events EXACTLY.
 
 (defn- emit-history-restored!
   "Per spec/009 §`:rf.machine.history/restored`. `source` is `:recorded` |
@@ -1700,7 +1687,7 @@
   value."
   [machine compound-path resolved-leaf source kind restored-config fallback]
   (trace/emit! :rf.machine :rf.machine.history/restored
-               ;; rf2-yyvtk5 — the actor whose live transition restored
+               ;; The actor whose live transition restored
                ;; history is a running INSTANCE; address it by `:actor-id`
                ;; (`:machine-id` is the registered TYPE).
                (cond-> {:actor-id      (or (:rf/parent-id machine) (:id machine))
@@ -1719,7 +1706,7 @@
   `:prev-config`."
   [machine recorded]
   (trace/emit! :rf.machine :rf.machine.history/recorded
-               ;; rf2-yyvtk5 — the actor whose live exit recorded history is
+               ;; The actor whose live exit recorded history is
                ;; a running INSTANCE; address it by `:actor-id`
                ;; (`:machine-id` is the registered TYPE).
                (merge {:actor-id (or (:rf/parent-id machine) (:id machine))
@@ -1739,20 +1726,20 @@
   `result/fail` Result (the action threw). Successful actions may return
   `nil` (treated as `{}`).
 
-  Per rf2-2nwfd: every user-declared action invocation emits
+  Every user-declared action invocation emits
   `:rf.machine/action-ran` with the action-ref, the canonical input
   `{:data :event}`, and an outcome — the action's return value on
   success (or `:ok` when the action returned nil), or
   `:rf.error/action-threw` on the exceptional path. The synthesised
   no-op for `nil` action-ref is not user-declared — skip the trace.
 
-  Per rf2-82a0u every emit also carries `:phase` from the closed set
+  Every emit also carries `:phase` from the closed set
   `:exit / :transition / :entry / :always / :after-action /
   :initial-entry / :destroy-exit` so the Xray Handler section's
   LIFECYCLE rendering can group rows by phase without spec-walking
   at render time.
 
-  Per rf2-lai1qv the optional `transition-slot` — the selected
+  The optional `transition-slot` — the selected
   transition's EXACT spec-path discriminator (`transition-slot`) — is
   stamped on the emit under `:transition-slot` when present (only the
   transition `:action` carries one; `:exit` / `:entry` boundary actions
@@ -1764,11 +1751,11 @@
   ([machine snap action-ref event phase transition-slot]
   (if action-ref
     (let [f         (resolve-action machine action-ref)
-          ;; rf2-yyvtk5 — an action runs against a LIVE actor's snapshot, so
+          ;; An action runs against a LIVE actor's snapshot, so
           ;; the addressed id is the running INSTANCE. It rides under
           ;; `:actor-id`; `:machine-id` is reserved for the registered TYPE.
           actor-id  (or (:rf/parent-id machine) (:id machine))
-          ;; Per rf2-ko8jb: epoch-capture admission requires `:frame`.
+          ;; Epoch-capture admission requires `:frame`.
           frame-id  (:rf/frame machine)
           base-tags (cond-> {:actor-id   actor-id
                              :action-id  action-ref
@@ -1796,8 +1783,8 @@
   map MUST NOT carry `:db`. This is the SINGLE enforcement choke-point so
   the invariant holds UNIFORMLY across every phase that runs an action —
   the cascade collector (`collect-actions`) and the parallel-root
-  `:on-done` path (`apply-on-done-action`) both funnel through here
-  (rf2-z522n). When `:db` is present, emit the structured error and return
+  `:on-done` path (`apply-on-done-action`) both funnel through here.
+  When `:db` is present, emit the structured error and return
   the effects map with `:db` STRIPPED — the remaining `:data` / `:fx`
   effects flow through. Canonical id / op-type / tags / recovery per Spec
   009 §Error event catalogue (Ownership.md:48):
@@ -1813,7 +1800,7 @@
   (if (and (map? r) (contains? r :db))
     (do
       (trace/emit-error! :rf.error/machine-action-wrote-db
-                         ;; rf2-yyvtk5 — the offending action ran against a
+                         ;; The offending action ran against a
                          ;; LIVE actor; address it by `:actor-id` (the
                          ;; running INSTANCE), not `:machine-id` (the TYPE).
                          {:actor-id        (or (:rf/parent-id machine)
@@ -1821,17 +1808,17 @@
                           :action-id       action-ref
                           :state-path      state-path
                           :offending-value (:db r)
-                          ;; Per rf2-ko8jb: epoch-capture admission requires `:frame`.
+                          ;; Epoch-capture admission requires `:frame`.
                           :frame           (:rf/frame machine)
                           :recovery        :logged-and-skipped})
       (dissoc r :db))
     r))
 
-;; ---- structured cascade steps (rf2-n9f4z) ---------------------------------
+;; ---- structured cascade steps ---------------------------------------------
 ;;
 ;; Per Spec 005 §Transition cascade instrumentation: each cascade phase the
 ;; engine runs is recorded as one self-describing STEP map so tooling
-;; (Xray's epoch panel — rf2-52u5n) can explain HOW a transition reached
+;; (Xray's epoch panel) can explain HOW a transition reached
 ;; its after-state without re-deriving the LCA geometry. A step carries:
 ;;
 ;;   {:kind   :exit | :action | :entry        ;; which cascade boundary
@@ -1850,7 +1837,7 @@
 ;;                                             ;;   291), matching the
 ;;                                             ;;   :rf.machine.history/restored
 ;;                                             ;;   event's :source; ABSENT on every
-;;                                             ;;   non-history step (rf2-mle6e.3)
+;;                                             ;;   non-history step
 ;;
 ;; The step vector is built in `compute-cascade-paths` (which owns the
 ;; ordered prefix paths + action refs) and the per-step `:data-delta` is
@@ -1879,14 +1866,14 @@
   throwing action produced — per Spec 005 §Errors, the cascade halts on
   the first throw and the snapshot does not commit.
 
-  Per rf2-82a0u + rf2-n9f4z each input `step` is a map
+  Each input `step` is a map
   `{:kind <structural> :phase <driver> :action <ref> :state <path>
     :region <name>}`:
    - `:kind` is the STRUCTURAL boundary recorded on the cascade step —
-     `:exit` / `:action` / `:entry` (the rf2-52u5n consumer contract); the
+     `:exit` / `:action` / `:entry` (the consumer contract); the
      destroy path passes `:exit`.
    - `:phase` is the DRIVER phase stamped on the `:rf.machine/action-ran`
-     emit (rf2-82a0u) — `:exit` / `:entry` for cascade boundaries, the
+     emit — `:exit` / `:entry` for cascade boundaries, the
      transition-phase (`:transition` / `:always` / `:after-action` /
      `:initial-entry`) for the action step, `:destroy-exit` for the
      destroy path. Defaults to `:kind` when absent.
@@ -1894,7 +1881,7 @@
      entered/exited WITHOUT an `:entry`/`:exit` action still shows in the
      cascade), but runs no action and contributes an empty `:data-delta`.
 
-  Per rf2-n9f4z the `:data-delta` of each step is computed against the
+  The `:data-delta` of each step is computed against the
   snapshot's `:data` immediately before the step's action ran, so the
   cascade explains the per-step `:data` contribution. The recorded step
   carries the STRUCTURAL fields only (`:kind` / `:state` / `:region` /
@@ -1930,8 +1917,7 @@
                           ;; Per Spec 005 §Hard-disallow `:db`: strip any `:db`
                           ;; write (emitting the structured error) through the
                           ;; shared enforcement choke-point, then thread the
-                          ;; cleaned effects map's `:data` / `:fx` forward
-                          ;; (rf2-z522n).
+                          ;; cleaned effects map's `:data` / `:fx` forward.
                           (let [r        (enforce-db-disallow machine r0 action (:state snap))
                                 new-data (cond-> before-data
                                            (contains? r :data) (merge (:data r)))
@@ -1950,7 +1936,7 @@
         [final-r cascade] acc]
     (result/with-cascade final-r cascade)))
 
-;; ---- apply-transition-once helpers (extracted per rf2-g1s1) ---------------
+;; ---- apply-transition-once helpers ----------------------------------------
 ;;
 ;; Each helper builds one fx-vector slice that flows out of apply-transition-
 ;; once. The slices compose in order (after-cancel, destroy, spawn, after-
@@ -1960,10 +1946,10 @@
 ;; what's stamped on them).
 
 (defn- materialise-data
-  "Resolve a :spawn spec's `:data` slot. Per Spec 005 §Declarative `:spawn`
-  and rf2-h131, `:data` admits a fn form `(fn [{:keys [snapshot event]}]
+  "Resolve a :spawn spec's `:data` slot. Per Spec 005 §Declarative `:spawn`,
+  `:data` admits a fn form `(fn [{:keys [snapshot event]}]
   data)` so the spawn's initial data can depend on the parent snapshot at
-  the moment of entry. Per rf2-grw4i / rf2-v0rrr the fn is invoked with
+  the moment of entry. The fn is invoked with
   the unified context-map shape. The fn runs against the post-action
   snapshot (any :action :data writes are visible). Returns
   `[::ok-data <materialised-data>]` on success, or a `result/fail` Result
@@ -1980,7 +1966,7 @@
 
 (defn- build-after-fx
   "Per Spec 005 §SSR mode and Cross-Spec-Interactions §4 (Machines × SSR):
-  `:after` is a no-op under `:platform :server`. Per rf2-3y3y: emit the
+  `:after` is a no-op under `:platform :server`. Emit the
   canonical `:rf.machine.timer/scheduled` (or /skipped-on-server) trace
   synchronously here AND emit `:rf.machine/after-schedule` fx; the fx
   handler resolves the delay (literal / sub-vec / fn) and installs the
@@ -1993,7 +1979,7 @@
   (when-not internal?
     (let [parent-id (or (:rf/parent-id machine) :rf/transition-pure)
           server?   (= :server (:rf/platform machine))
-          ;; Per rf2-ko8jb: epoch-capture admission requires `:frame`.
+          ;; Epoch-capture admission requires `:frame`.
           frame-id  (:rf/frame machine)]
       (vec
         (mapcat
@@ -2016,7 +2002,7 @@
                           ms-tag       delay-key]
                       (if server?
                         (trace/emit! :rf.machine :rf.machine.timer/skipped-on-server
-                                     (cond-> {;; rf2-ws5thu — owning actor INSTANCE
+                                     (cond-> {;; Owning actor INSTANCE.
                                               :actor-id     parent-id
                                               :state        leaf-state
                                               :delay        ms-tag
@@ -2025,20 +2011,20 @@
                                               :platform     :server
                                               :frame        frame-id
                                               :recovery     :skipped}
-                                       ;; rf2-1b6uh5 — canonical subscription
+                                       ;; Canonical subscription
                                        ;; identity, not the bare `:sub-id`.
                                        (= :sub delay-source)
                                        (assoc :rf.sub/id      (first delay-key)
                                               :rf.sub/query-v (vec delay-key))))
                         (trace/emit! :rf.machine :rf.machine.timer/scheduled
-                                     (cond-> {;; rf2-ws5thu — owning actor INSTANCE
+                                     (cond-> {;; Owning actor INSTANCE.
                                               :actor-id     parent-id
                                               :state        leaf-state
                                               :delay        ms-tag
                                               :delay-source delay-source
                                               :epoch        epoch
                                               :frame        frame-id}
-                                       ;; rf2-1b6uh5 — canonical subscription
+                                       ;; Canonical subscription
                                        ;; identity, not the bare `:sub-id`.
                                        (= :sub delay-source)
                                        (assoc :rf.sub/id      (first delay-key)
@@ -2054,7 +2040,7 @@
           entered-pairs)))))
 
 (defn- build-after-cancel-fx
-  "Per rf2-3y3y: when exiting an `:after`-bearing state node, emit
+  "When exiting an `:after`-bearing state node, emit
   `:rf.machine/after-cancel` fx so the runtime tears down any pending
   wall-clock timer (and watcher, for sub-vec delays). The epoch advance
   backstops correctness; explicit cancellation releases the timer handle
@@ -2068,7 +2054,7 @@
          {:rf/parent-id parent-id
           :rf/invoke-id (vec prefix)}]))))
 
-;; ---- root-level `:after` for parallel machines (rf2-wox0vd) ----------------
+;; ---- root-level `:after` for parallel machines ----------------------------
 ;;
 ;; XState v5 gold standard: `after` may be declared at ANY level, including a
 ;; `<parallel>` node. A parallel-ROOT `:after` is ROOT-OWNED — scheduled when
@@ -2088,7 +2074,7 @@
 ;; transition`).
 
 (defn root-after-match
-  "Per Spec 005 §Root parallel `:after` (rf2-wox0vd): resolve the synthetic
+  "Per Spec 005 §Root parallel `:after`: resolve the synthetic
   `[:rf.machine.timer/after-elapsed delay-key carried-epoch []]` event for a
   parallel ROOT's `:after` (decl-path `[]`). Returns the SAME shape
   `pick-after-transition` returns — `{:transition … :decl-path [] :delay
@@ -2137,7 +2123,7 @@
               {:guard-suppressed? true
                :actor-id          actor-id
                :state             :rf/parallel-root
-               ;; rf2-ze13fg — the parallel-ROOT timer's declaring path is the
+               ;; The parallel-ROOT timer's declaring path is the
                ;; empty path `[]` (the root `:after` lives on the machine map,
                ;; decl-path `[]`). Carry it so `after-fired-reply` builds the
                ;; canonical work-id `[:rf.work/timer [<actor>] epoch]` and the
@@ -2160,7 +2146,7 @@
 
 (defn root-after-elapsed?
   "True iff `event` is a synthetic `:after`-elapsed timer carrying the ROOT
-  decl-path `[]` (rf2-wox0vd) — a parallel-root-owned `:after` firing, as
+  decl-path `[]` — a parallel-root-owned `:after` firing, as
   opposed to a region-scoped timer (whose carried decl-path is region-name
   prefixed). Lets the parallel macrostep route a root timer to the root
   resolver instead of broadcasting it to the regions."
@@ -2170,13 +2156,12 @@
        (= [] (vec (nth event 3 nil)))))
 
 (defn- build-destroy-fx
-  "Per Spec 005 §Declarative `:spawn` and rf2-t07u
-  (Option A revised): nodes being EXITED with `:spawn` emit
+  "Per Spec 005 §Declarative `:spawn`: nodes being EXITED with `:spawn` emit
   `:rf.machine/destroy` carrying `{:rf/parent-id ... :rf/invoke-id ...}`
   so the destroy-machine fx handler resolves the live actor id from the
   runtime-owned `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot in runtime-db.
 
-  Per Spec 005 §Spawn-and-join via `:spawn-all` (rf2-6vmw): on exit, tear
+  Per Spec 005 §Spawn-and-join via `:spawn-all`: on exit, tear
   down EVERY child the parent spawned plus the join-state slot. The
   destroy-fx handler reads the map at `[:rf.runtime/machines :spawned <parent> <invoke-id>]`
   and iterates `:children` to destroy each, then clears the slot."
@@ -2207,9 +2192,9 @@
 
 (defn- allocate-one
   "Allocate one spawned-id from `spawn-spec`'s `:machine-id` (the registered
-  machine TYPE) against `snap`'s in-snapshot counter (rf2-gr8q). When
+  machine TYPE) against `snap`'s in-snapshot counter. When
   `spawn-spec` carries an explicit `:fixed-actor-id` literal (the explicit
-  actor-address input — per-state singleton; rf2-0ggtr5) the counter is NOT
+  actor-address input — per-state singleton) the counter is NOT
   bumped and that fixed address is used verbatim. Returns
   `[snap' spawned-id]`."
   [snap spawn-spec]
@@ -2219,9 +2204,9 @@
 
 (defn- apply-on-spawn
   "Run `spawn-spec`'s `:on-spawn` advisory callback against `snap`'s `:data`.
-  Per Spec 005 §Declarative `:spawn` (rf2-grw4i / rf2-v0rrr), the signature
+  Per Spec 005 §Declarative `:spawn`, the signature
   is `(fn [{:keys [data id]}] _)` — context-map input, advisory return
-  (any return value is DROPPED). Per rf2-t07u (Option A revised) the
+  (any return value is DROPPED). The
   runtime tracks the spawn-id at `[:rf.runtime/machines :spawned parent-id invoke-id]`;
   `:on-spawn` is purely observational — callers needing snapshot-level
   side effects emit `[:rf.machine/update-snapshot {:rf/machine-id <id>
@@ -2229,7 +2214,7 @@
   fx is registered in `re-frame.machines` and handled by
   `re-frame.machines.lifecycle-fx.update-snapshot`).
 
-  No-silent-swallow (rf2-dtth6): the snapshot is returned UNCHANGED — a
+  No-silent-swallow: the snapshot is returned UNCHANGED — a
   callback that returns a non-nil value (e.g. the canonical-looking
   `(assoc data :pending id)`) has that value silently dropped, which is the
   exact trap the advisory contract sets. Surface it: emit a dev-only
@@ -2239,7 +2224,7 @@
   free and adds no module-level mutable state — the engine stays a pure
   function of `[machine snapshot event]`.
 
-  Error contract (rf2-km4bn4): the `:on-spawn` callback is a machine
+  Error contract: the `:on-spawn` callback is a machine
   action like any other, so a THROW must route through the documented
   machine action exception contract — NOT escape as a generic
   `:rf.error/handler-exception`. Mirroring `run-action` / `materialise-data`,
@@ -2251,8 +2236,8 @@
   (`registration/trace-action-failure!`) then emits exactly one
   `:rf.error/machine-action-exception` and drops the accumulated effects —
   so a throwing observer never commits the parent/child snapshot or the
-  spawned registry slot. On SUCCESS the snapshot is returned UNCHANGED, as
-  before. (No `:rf.machine/action-ran` activity trace fires here on either
+  spawned registry slot. On SUCCESS the snapshot is returned UNCHANGED.
+  (No `:rf.machine/action-ran` activity trace fires here on either
   path: `:on-spawn` is an advisory observer, not a cascade action — adding
   it would introduce a novel `:phase` outside the documented closed set,
   Spec-Schemas.md §`action-ran`.)"
@@ -2265,7 +2250,7 @@
       (let [ret (f {:data (:data snap) :id spawned-id})]
         (when (some? ret)
           (trace/emit! :warning :rf.warning/on-spawn-return-ignored
-                       ;; rf2-yyvtk5 — the spawning parent is a LIVE actor
+                       ;; The spawning parent is a LIVE actor
                        ;; INSTANCE; address it by `:actor-id`. `:spawned-id`
                        ;; is the freshly-spawned child's instance address.
                        {:actor-id   (or (:rf/parent-id machine) (:id machine))
@@ -2284,7 +2269,7 @@
 (defn- spawn-one
   "Single-spawn primitive shared by `:spawn` and `:spawn-all` per-child.
   Materialises any `:data` fn-form against `mat-snap` + `event` (Spec 005
-  §Spec-spec keys / rf2-h131); on failure returns a `result/fail` Result
+  §Spec-spec keys); on failure returns a `result/fail` Result
   stamped with `failure-extra`. On success builds the spawn-args via
   `args-builder` (mode-specific wiring of `:rf/parent-id` /
   `:rf/invoke-id` / `:rf/spawn-all-id` keys) and returns a `result/ok`
@@ -2317,7 +2302,7 @@
   Returns `[snap-after acc-fx']` for the reducer, or a `reduced` wrapper
   around a `result/fail` Result on failure. The failure is stamped
   `:action-ref :rf.spawn/data-fn` + `:invoke-id` for a `:data`-fn throw,
-  or — per rf2-km4bn4 — `:action-ref :rf.spawn/on-spawn` + `:invoke-id`
+  or `:action-ref :rf.spawn/on-spawn` + `:invoke-id`
   (carried up from `apply-on-spawn`) for a throwing `:on-spawn` callback,
   so the lifecycle boundary routes BOTH through the machine action
   exception contract rather than letting an `:on-spawn` throw escape as a
@@ -2338,27 +2323,27 @@
     (if (result/fail? spawn-r)
       (reduced spawn-r)
       (let [spawn-fx (result/fx spawn-r)
-            ;; Per rf2-km4bn4: a throwing `:on-spawn` callback returns a
+            ;; A throwing `:on-spawn` callback returns a
             ;; `result/fail` (not a snapshot) — short-circuit the spawn
             ;; reducer so no parent/child snapshot or registry slot commits
             ;; and the accumulated fx is dropped at the lifecycle boundary.
             s'       (apply-on-spawn machine s-alloc spawn-spec id)]
         (if (result/fail? s')
           (reduced (result/fail-with s' {:invoke-id invoke-id}))
-          ;; Per rf2-rc8wci — bind the assigned actor id into the parent's
+          ;; Bind the assigned actor id into the parent's
           ;; own `:data` under `[:rf/spawned <invoke-id>]` (XState-context
           ;; parity). Threaded onto the parent snapshot AFTER the advisory
           ;; `:on-spawn` ran (the bind never depends on `:on-spawn`, which
-          ;; cannot carry the id back — its return is dropped, rf2-grw4i /
-          ;; rf2-v0rrr) so a later action can read the id and imperatively
+          ;; cannot carry the id back — its return is dropped) so a later
+          ;; action can read the id and imperatively
           ;; `[:rf.machine/destroy <id>]` with no external-atom side-channel.
           [(bind-spawned-id-into-parent-data s' invoke-id id)
            (into acc-fx spawn-fx)])))))
 
 (defn- handle-spawn-all-decl
   "Handle the `:spawn-all` branch of the spawn reducer in
-  `apply-transition-once`. Per Spec 005 §Spawn-and-join via `:spawn-all`
-  (rf2-6vmw), `:spawn-all` is spawn-and-join sugar over N parallel
+  `apply-transition-once`. Per Spec 005 §Spawn-and-join via `:spawn-all`,
+  `:spawn-all` is spawn-and-join sugar over N parallel
   `:spawn`'s plus a join condition. The implementation mirrors the
   concept:
 
@@ -2427,7 +2412,7 @@
     (if (result/fail? spawn-fxs-r)
       (reduced spawn-fxs-r)
       ;; (4) Thread :on-spawn advisory callbacks across siblings. Per
-      ;; rf2-km4bn4 a throwing child `:on-spawn` returns a `result/fail`
+      ;; A throwing child `:on-spawn` returns a `result/fail`
       ;; (not the threaded snapshot); short-circuit the sibling reduce on
       ;; the FIRST throw — stamping the failing `:child-id` + `:invoke-id`
       ;; onto the failure — so the reducer never terminates mid-spawn
@@ -2444,7 +2429,7 @@
                  children-with-ids)]
         (if (result/fail? s')
           (reduced s')
-          ;; Per rf2-rc8wci — bind the `:spawn-all`'s children id-map into the
+          ;; Bind the `:spawn-all`'s children id-map into the
           ;; parent's own `:data` under `[:rf/spawned <invoke-id>]` (the whole
           ;; `{<child-id> <spawned-id>}` map, mirroring the join-state's
           ;; `:children`), so an action can read it without an external atom.
@@ -2452,7 +2437,7 @@
            (-> acc-fx (conj init-fx) (into spawn-fxs-r))])))))
 
 (defn final-state-node?
-  "Per Spec 005 §Final states (rf2-gn80): true iff the state-node declares
+  "Per Spec 005 §Final states: true iff the state-node declares
   `:final? true`. The marker is a first-class state-spec key (D1) — NOT
   stashed under `:meta` — so authors and AI agents see it at the state
   level."
@@ -2460,7 +2445,7 @@
   (true? (:final? node)))
 
 (defn final-on-leaf?
-  "Per Spec 005 §Final states (rf2-gn80): true iff the state at the LEAF
+  "Per Spec 005 §Final states: true iff the state at the LEAF
   of `state` declares `:final? true`. Finality is a pure recompute from
   the post-transition `:state` — it is NOT stamped onto the snapshot
   (there is no `:rf/finished?` slot; per Spec 005 §Persistence posture the
@@ -2468,7 +2453,7 @@
   bookkeeping).
 
   This answers \"is the active leaf final?\" — NOT \"does the whole machine
-  finish?\". Per rf2-bnjb3 / rf2-zlmz7 (the done-state / `:on-done` signal)
+  finish?\". Per the done-state / `:on-done` signal
   the two questions diverge: a `:final?` leaf that is a DIRECT CHILD of the
   machine root is whole-machine finality (auto-destroy / spawning parent's
   `:on-done`); a `:final?` leaf EMBEDDED inside a compound signals only that
@@ -2487,7 +2472,7 @@
     (final-state-node? node)))
 
 (defn top-level-final?
-  "Per Spec 005 §Final states §Embedded vs top-level (rf2-bnjb3 / rf2-zlmz7):
+  "Per Spec 005 §Final states §Embedded vs top-level:
   true iff `state`'s active leaf is `:final?` AND it is a DIRECT CHILD of the
   machine root — i.e. a length-1 state path. This is the WHOLE-MACHINE
   finality the lifecycle-handler boundary gates auto-destroy / spawning-
@@ -2507,7 +2492,7 @@
     (and (= 1 (count path))
          (final-state-node? (node-at machine path)))))
 
-;; ---- done-state / :on-done completion signal (rf2-bnjb3 / rf2-zlmz7) -------
+;; ---- done-state / :on-done completion signal ------------------------------
 ;;
 ;; Per Spec 005 §Final states §The done-state signal. XState v5 `onDone` /
 ;; SCXML §3.7 `done.state.<id>`: when a COMPOUND state reaches a `<final>`
@@ -2518,9 +2503,9 @@
 ;; flow WHILE the machine keeps running — the canonical "do these sub-flows,
 ;; then continue" pattern.
 ;;
-;; re-frame2 ships this as a first-class transitionable signal (replacing the
-;; former `:raise`-from-the-final-leaf's-`:entry` substitute, which collided
-;; with the `:final?`-auto-destroys rule — the rf2-zlmz7 footgun):
+;; re-frame2 ships this as a first-class transitionable signal, distinct from
+;; the `:final?`-auto-destroys rule (an embedded compound's done does not tear
+;; the machine down — it signals completion the enclosing flow can act on):
 ;;
 ;;   - The reserved event-id is `:rf.machine/done`; the completed node's
 ;;     declaration PATH rides as the event's single arg —
@@ -2554,7 +2539,7 @@
          (final-state-node? (node-at machine child-path)))))
 
 (defn compound-done-paths
-  "Per Spec 005 §Final states §The done-state signal (rf2-zlmz7): given the
+  "Per Spec 005 §Final states §The done-state signal: given the
   POST-transition leaf path `leaf-path`, return the vector of EMBEDDED
   compound declaration-paths that are NEWLY done — each compound whose active
   direct child is a `:final?` leaf, EXCLUDING the machine root (a `:final?`
@@ -2596,12 +2581,12 @@
   macrostep's FIFO `:raise` queue (verbatim `:raise` fx, drained by the
   unified `drain-to-fixed-point` microstep loop / the parallel parent queue)
   so the enclosing `:on-done` transition fires in the SAME macrostep — after
-  the committing transition's `:always` has settled (rf2-uv8os). Returns `[]`
+  the committing transition's `:always` has settled. Returns `[]`
   when no
   compound is newly done (the common case — most transitions land on an
   ordinary leaf). `machine` is the flat / compound machine or a region body.
 
-  **Region-identity scoping (rf2-12ekv).** When `machine` is a parallel region
+  **Region-identity scoping.** When `machine` is a parallel region
   (`:rf/region` present), `compound-done-paths` returns a REGION-RELATIVE path
   (region-body `node-at`). The parent internal-event queue re-broadcasts the
   raise across EVERY sibling region (the correct XState v5 / SCXML `:raise`
@@ -2625,7 +2610,7 @@
           (compound-done-paths machine leaf-path))))
 
 (defn apply-on-done-action
-  "Per Spec 005 §Final states §The done-state signal (rf2-bnjb3): run a
+  "Per Spec 005 §Final states §The done-state signal: run a
   PARALLEL ROOT's `:on-done` transition's `:action` against `snap`'s `:data`,
   threading the standard `{:data :fx}` effects-map contract. The parallel
   root's `:on-done` carries no in-machine `:target` (root-only parallel has no
@@ -2640,7 +2625,7 @@
   `[:rf.machine/done []]` event so a 3-arity action introspecting `:event`
   sees the reserved done discriminator.
 
-  Per rf2-z522n the action runs under phase `:transition` — the parallel
+  The action runs under phase `:transition` — the parallel
   root's `:on-done` IS a transition (the XState v5 `onDone` is a transition;
   an EMBEDDED compound's `:on-done` already runs through
   `apply-transition-once` at phase `:transition` via `pick-done-transition`).
@@ -2666,7 +2651,7 @@
             (result/ok (assoc snap :data new-data) (vec (or (:fx r) [])))))))))
 
 (defn run-root-transition-action
-  "Per Spec 005 §Transition broadcast §Root parallel `:on` (rf2-tsq6g): run a
+  "Per Spec 005 §Transition broadcast §Root parallel `:on`: run a
   PARALLEL ROOT's selected `:on` transition's `:action` ONCE against the
   parallel `snap`'s shared `:data`, threading the standard `{:data :fx}`
   effects-map contract. Unlike the per-region apply, the root transition's
@@ -2685,7 +2670,7 @@
   merged, `:fx` collected), or a `result/fail` if the action threw. A
   targetless / action-less transition returns `(ok snap [])`."
   [machine snap transition event]
-  (let [;; rf2-lai1qv — the root `:on` lives OUTSIDE `:states` (decl-path
+  (let [;; The root `:on` lives OUTSIDE `:states` (decl-path
         ;; `[]`). `root-on-match` → `match-on-clause` stamped the partial
         ;; `:on` discriminator; finalize it with the empty decl-path so the
         ;; Xray cascade row addresses `[:on <event-key>]` (root-relative, no
@@ -2700,7 +2685,7 @@
                        (contains? r :data) (merge (:data r)))]
         (result/ok (assoc snap :data new-data) (vec (or (:fx r) [])))))))
 
-;; ---- destroy-time exit cascade (rf2-nahfm) --------------------------------
+;; ---- destroy-time exit cascade --------------------------------------------
 ;;
 ;; Per Spec 005 §Declarative `:spawn` §Composition with explicit `:entry`
 ;; / `:exit` and §Final states §Composition with `:entry` / `:exit`: when
@@ -2745,10 +2730,10 @@
         ;; Leaf→root: exit cascade reverses `nodes-along-path` (which
         ;; returns shallowest-first), matching `compute-cascade-paths`'s
         ;; `(map ... (reverse exited-pairs))` ordering.
-        ;; Per rf2-82a0u every action-ran emit carries `:phase`; destroy-
+        ;; Every action-ran emit carries `:phase`; destroy-
         ;; time exit cascades stamp `:destroy-exit` so the Xray Handler
         ;; section can attribute the action to the actor-teardown cause.
-        ;; Per rf2-n9f4z `collect-actions` walks cascade STEP maps. The
+        ;; `collect-actions` walks cascade STEP maps. The
         ;; destroy-time exit cascade records one `:exit` step per active
         ;; node carrying an `:exit` action (deepest-first), so an actor
         ;; teardown surfaces the same structured cascade shape as a
@@ -2763,7 +2748,7 @@
                                    ;; Structural `:kind :exit` (the cascade
                                    ;; step's shape); driver `:phase
                                    ;; :destroy-exit` (the `action-ran` emit
-                                   ;; phase, rf2-82a0u).
+                                   ;; phase).
                                    {:kind :exit :phase :destroy-exit
                                     :state (vec prefix) :region region
                                     :action (:exit n)})))
@@ -2774,7 +2759,7 @@
 ;;
 ;; Per Spec 005 §Entry/exit cascading along the LCA, one transition flows
 ;; through four named phases. Each phase is a pure helper; `apply-transition-
-;; once` composes them. The decomposition is per rf2-8sz7f / audit §T6.
+;; once` composes them.
 ;;
 ;;   compute-cascade-paths  — derive src/target paths, LCA, exit/entry/action
 ;;                            refs, the `[prefix node]` pair vectors, and
@@ -2798,9 +2783,9 @@
   "Phase 1 — derive the transition's geometry. Returns a map with:
     :src-path       — source state path (vector).
     :target-leaf    — initial-cascaded target path (nil for internal).
-    :internal?      — the EFFECTIVE internal flag (rf2-gt1pu): true iff the
+    :internal?      — the EFFECTIVE internal flag: true iff the
                       transition has NO `:target` (a targetless internal
-                      no-op). Per XState v5 (rf2-gt1pu) any EXPLICIT target —
+                      no-op). Per XState v5 any EXPLICIT target —
                       even self / ancestor / current-compound on the active
                       path — re-resolves the active descendants below the
                       target (children reset to `:initial`), so it is NOT a
@@ -2808,15 +2793,15 @@
                       `lca-len` for the four active-path geometries
                       (self/ancestor ± `:reenter?`, descendant ± `:reenter?`).
     :lca-len        — common-prefix length of src and target.
-    :cascade-steps  — per rf2-n9f4z, the vec of cascade STEP maps in
+    :cascade-steps  — the vec of cascade STEP maps in
                       execution order (`:exit` × N deepest-first → the
                       transition `:action` @ LCA → `:entry` × N
                       shallowest-first + initial-descent) — the input to
                       `collect-actions`. Each step is
                       `{:kind <phase> :state <path> :region <name-or-nil>
                         :action <ref-or-nil>}`; `:kind` doubles as the
-                      `action-ran` `:phase` (rf2-82a0u) AND the structured
-                      cascade step's kind (rf2-52u5n consumer contract).
+                      `action-ran` `:phase` AND the structured
+                      cascade step's kind (the consumer contract).
                       The caller (`apply-transition-once`) supplies the
                       transition-phase per cascade-driver (`:transition` /
                       `:always` / `:after-action` / `:initial-entry`); a
@@ -2840,7 +2825,7 @@
                       thus its live timer). Per Spec 005 §Hierarchy
                       interaction (the per-level tracking the normative
                       external contract requires).
-    :history-restore — per Spec 005 §Restoring (rf2-mle6e.3): present iff
+    :history-restore — per Spec 005 §Restoring: present iff
                       this transition resolved to a `:type :history`
                       pseudo-state — the spec/009 `:rf.machine.history/
                       restored` tag bag `{:compound-path :resolved-leaf
@@ -2853,7 +2838,7 @@
                       `:rf.machine.history/restored` trace from it."
   [machine snapshot transition transition-phase]
   (let [src-path      (state-path (:state snapshot))
-        ;; rf2-h16qii — the transition's DECLARATION path: the absolute path
+        ;; The transition's DECLARATION path: the absolute path
         ;; of the state node whose `:on` / `:always` / `:after` table this
         ;; transition was declared in. It anchors the LCA geometry below —
         ;; `target-path` resolves a keyword target as a SIBLING at this level
@@ -2867,10 +2852,7 @@
         ;; on the machine ROOT — `target-path` then resolves a keyword target
         ;; to a top-level sibling (`[target]`) and `:same-state` to the root,
         ;; which is the correct geometry for a root-declared targetless /
-        ;; self transition. The pre-fix default `(take 1 src-path)` GUESSED
-        ;; depth-1 (the first element of the active leaf's path) — wrong for a
-        ;; root-declared transition (its decl-path is `[]`, not `[<top>]`), so
-        ;; the LCA / exit / entry cascade diverged. (A transition declared
+        ;; self transition. (A transition declared
         ;; DEEPER than root without a stamped `:decl-path` is not a reachable
         ;; in-tree case; the root default is the principled, geometry-correct
         ;; choice for the only caller that hits it.)
@@ -2878,7 +2860,7 @@
         raw-target    (:target transition)
         ;; `targetless?` is the structural "no `:target` declared" predicate.
         ;; It is NOT the same as the effective `internal?` flag computed
-        ;; below: under the XState-v5 model (rf2-eicq0) a TARGETED transition
+        ;; below: under the XState-v5 model a TARGETED transition
         ;; whose target lands on the ACTIVE PATH (self or proper ancestor) is
         ;; ALSO internal by default — it only becomes external when the
         ;; transition opts in with `:reenter? true`. So `internal?` = no
@@ -2903,8 +2885,9 @@
         ;; recorded (or default / dangling-fallback) leaf BEFORE the LCA
         ;; geometry. The resolved leaf is what the entry cascade enters and
         ;; what the snapshot's `:state` records — the pseudo-state is never a
-        ;; configuration member (the 46ban precedent: resolve the real path,
-        ;; then run the standard geometry on it). `:history-restore` rides
+        ;; configuration member (the external-self-transition precedent:
+        ;; resolve the real path, then run the standard geometry on it).
+        ;; `:history-restore` rides
         ;; the result so `apply-transition-once` can emit the
         ;; `:rf.machine.history/restored` trace.
         hist-node     (when (and (not targetless?) target-base0)
@@ -2930,7 +2913,7 @@
         ;; declared target.
         target-base   (if history-restore (:resolved-leaf history-restore) target-base0)
         target-leaf   (some->> target-base (initial-cascade machine))
-        ;; ---- Exit-set boundary: the true LCCA (rf2-emz8l) ----------------
+        ;; ---- Exit-set boundary: the true LCCA ----------------------------
         ;; Per Spec 005 §Entry/exit cascading and SCXML §3.13: the exit set
         ;; of an EXTERNAL transition is bounded by the LEAST COMMON COMPOUND
         ;; ANCESTOR — the deepest compound state that is a PROPER ancestor of
@@ -2947,7 +2930,7 @@
         ;;
         ;;  (1) TARGET ON THE ACTIVE PATH — `target-base` is a prefix of
         ;;      `src-path` (the target is the source itself, OR a proper
-        ;;      ANCESTOR of the source). Per the XState-v5 model (rf2-eicq0)
+        ;;      ANCESTOR of the source). Per the XState-v5 model
         ;;      this is INTERNAL BY DEFAULT — the source neither exits nor
         ;;      re-enters; the transition's `:action` fires and the
         ;;      configuration is unchanged (same shape as a targetless
@@ -2964,7 +2947,7 @@
         ;;      flipped — see Spec 005 §Self-transitions). Without the pull-up
         ;;      a re-entering active-path target would have its plain
         ;;      common-prefix LCA equal the full target depth and the
-        ;;      transition would be a SILENT NO-OP (rf2-emz8l). `max 0` keeps
+        ;;      transition would be a SILENT NO-OP. `max 0` keeps
         ;;      a root-level target (`target-base == []`) sane: with
         ;;      `:reenter?` the whole machine exits + re-enters from the root.
         ;;
@@ -2991,7 +2974,7 @@
         ;; independent of the `:reenter?` opt-in. An explicit active-path
         ;; target is NEVER a configuration no-op — XState v5 RE-RESOLVES the
         ;; active descendants below the target (children reset to `:initial`)
-        ;; even without `:reenter?` (rf2-gt1pu). Only a TARGETLESS transition
+        ;; even without `:reenter?`. Only a TARGETLESS transition
         ;; preserves the configuration unchanged.
         target-on-active-path? (and (not targetless?)
                                     (= (count target-base)
@@ -3002,10 +2985,10 @@
         ;; compound D whose target T is a PROPER DESCENDANT of D re-enters the
         ;; targeted descendant T (and exits/re-enters the active descendants
         ;; between D and the resolved leaf), while D itself and the prefix
-        ;; above survive — UNLESS `:reenter?` forces D's own restart
-        ;; (rf2-127ff). Note T need NOT be on the active branch: D may target a
-        ;; DISJOINT descendant (e.g. a sibling of the active child) — exactly
-        ;; the rf2-127ff `:editor`→`[:editor :preview]` shape while `:draft` is
+        ;; above survive — UNLESS `:reenter?` forces D's own restart.
+        ;; Note T need NOT be on the active branch: D may target a
+        ;; DISJOINT descendant (e.g. a sibling of the active child) — the
+        ;; `:editor`→`[:editor :preview]` shape while `:draft` is
         ;; active. So this is gated on T-vs-D, NOT on `target-on-active-path?`.
         ;;
         ;; THREE structural conditions (all over ABSOLUTE paths):
@@ -3018,7 +3001,6 @@
         ;;       leaf→root walk that selected the transition guarantees it for a
         ;;       real `:on` match;
         ;;   (c) T is a PROPER DESCENDANT of D (D is a strict prefix of T).
-        ;; (rf2-gt1pu / rf2-127ff.)
         target-descendant-of-decl? (and (not targetless?)
                                         (pos? (count decl-path))
                                         (= (count decl-path)
@@ -3028,7 +3010,7 @@
                                            (common-prefix-length decl-path target-base)))
         ;; A HISTORY restore is an external re-entry BY NATURE — it resolves
         ;; the pseudo-state to a concrete config and re-enters the compound,
-        ;; recording the outgoing config on the way (rf2-mle6e). It must NOT
+        ;; recording the outgoing config on the way. It must NOT
         ;; be folded into the internal-default even when the resolved leaf
         ;; happens to coincide with the source (the never-entered fall-back to
         ;; the compound's `:initial` can land back on the current leaf). So a
@@ -3039,16 +3021,15 @@
         ;; (cascade-steps, `commit-snapshot` state preservation, after-fx /
         ;; after-cancel / destroy / done-raise / history-record). ONLY a
         ;; targetless transition is internal (true configuration no-op).
-        ;; XState v5 (rf2-gt1pu): any EXPLICIT target — even self / ancestor /
+        ;; XState v5: any EXPLICIT target — even self / ancestor /
         ;; current-compound on the active path — re-resolves the active
-        ;; descendants below the target, so it is NOT a no-op. (Pre-rf2-gt1pu
-        ;; this also folded a no-`:reenter?` active-path target into
-        ;; `internal?`, collapsing the middle "re-resolve descendants" case to
-        ;; a targetless no-op — the bug.)
+        ;; descendants below the target, so it is NOT a no-op. A no-`:reenter?`
+        ;; active-path target is the middle "re-resolve descendants" case, NOT
+        ;; a targetless no-op.
         internal?     targetless?
         ;; The exit/entry boundary (LCCA depth) — the count of the common
-        ;; prefix that SURVIVES (is neither exited nor entered). The geometries
-        ;; (rf2-gt1pu / rf2-127ff), all grounded in xstate@5.32.0, are
+        ;; prefix that SURVIVES (is neither exited nor entered). The geometries,
+        ;; all grounded in xstate@5.32.0, are
         ;; discriminated by the TARGET ↔ DECLARING-state (`decl-path`)
         ;; relationship, NOT by the active leaf:
         ;;
@@ -3063,7 +3044,7 @@
         ;;          e.g. declared on :parent, target [:parent :child] while at
         ;;          [:parent :child :a] → exit a + child, re-enter child/a;
         ;;          :parent not exited.
-        ;;      WITH `:reenter?` (rf2-127ff) — the DECLARING compound D exits +
+        ;;      WITH `:reenter?` — the DECLARING compound D exits +
         ;;        re-enters (run D's :exit/:entry, restart D's :after, re-spawn),
         ;;        then descends to the NAMED descendant T (NOT D's :initial —
         ;;        `target-leaf` already cascades from T).
@@ -3078,7 +3059,7 @@
         ;;        target-BASE so re-resolution is not a no-op).
         ;;          e.g. at [:process :step3], target :process → exit step3,
         ;;          re-enter :initial (step1); :process not exited.
-        ;;      WITH `:reenter?` (eicq0) — T is exited + re-entered (restart
+        ;;      WITH `:reenter?` — T is exited + re-entered (restart
         ;;        timers/spawns) then re-descends. boundary = (count target-base) - 1.
         ;;  • DISJOINT-subtree target (not a descendant of D, not on the active
         ;;    path) — the LCCA is the plain common-prefix node; `:reenter?` is a
@@ -3102,34 +3083,32 @@
                         (common-prefix-length src-path target-leaf))
         ;; Walk each path once; reuse the `[prefix node]` pair vectors
         ;; for both the cascade ref derivation AND the spawn/destroy fx
-        ;; emission downstream (per audit §T6 #2 — eliminate the double
-        ;; nodes-along-path call). `nodes-along-path` returns a vector, so
-        ;; `subvec` is one zero-copy slice — the prior `(vec (drop ...))`
-        ;; built a lazy seq, then realised it, then `vec`'d (three
-        ;; allocations). Per rf2-ijbg2.
+        ;; emission downstream (one `nodes-along-path` call serves both).
+        ;; `nodes-along-path` returns a vector, so `subvec` is one zero-copy
+        ;; slice rather than a realised-then-`vec`'d lazy seq.
         exited-pairs  (when-not internal?
                         (let [pairs (nodes-along-path machine src-path)]
                           (subvec pairs (min lca-len (count pairs)))))
         entered-pairs (when-not internal?
                         (let [pairs (nodes-along-path machine target-leaf)]
                           (subvec pairs (min lca-len (count pairs)))))
-        ;; Per rf2-82a0u: phase per cascade-slot per `transition-phase`.
-        ;; Bootstrap entries collapse to `:initial-entry` — the bead's
-        ;; closed set distinguishes "entry from the bootstrap cascade"
+        ;; Phase per cascade-slot per `transition-phase`.
+        ;; Bootstrap entries collapse to `:initial-entry` — the closed
+        ;; phase set distinguishes "entry from the bootstrap cascade"
         ;; from "entry from a regular `:on`-driven transition".
         entry-phase   (if (= :initial-entry transition-phase) :initial-entry :entry)
-        ;; Per rf2-n9f4z: the cascade STEP maps `collect-actions` walks —
+        ;; The cascade STEP maps `collect-actions` walks —
         ;; one per boundary, in exit (deepest-first) → action @ LCA → entry
         ;; (shallowest-first + initial-descent) order. Each carries the
         ;; state path it fires at + the region (for parallel machines) so
-        ;; tooling can render the structured cascade (rf2-52u5n) without
+        ;; tooling can render the structured cascade without
         ;; re-deriving the LCA geometry.
         ;;
         ;; Two ORTHOGONAL dimensions ride each step:
         ;;   :kind  — the STRUCTURAL boundary: `:exit` / `:action` / `:entry`
         ;;            (closed set; `:microstep` is appended by the `:always`
-        ;;            loop). This is the consumer (rf2-52u5n) contract.
-        ;;   :phase — the action-ran DRIVER phase (rf2-82a0u): `:exit` /
+        ;;            loop). This is the consumer contract.
+        ;;   :phase — the action-ran DRIVER phase: `:exit` /
         ;;            `:entry` for cascade boundaries, but the transition
         ;;            `:action` carries the caller-supplied `transition-phase`
         ;;            (`:transition` / `:always` / `:after-action` /
@@ -3152,7 +3131,7 @@
         action-steps  (when (:action transition)
                         [(cond-> {:kind :action :phase transition-phase :state (vec decl-path)
                                   :region region :action (:action transition)}
-                           ;; rf2-lai1qv — carry the selected transition's
+                           ;; Carry the selected transition's
                            ;; EXACT spec-path discriminator onto the action
                            ;; step so `run-action` can stamp it on the
                            ;; `:rf.machine/action-ran` trace; the Xray cascade
@@ -3195,7 +3174,7 @@
      :entered-pairs entered-pairs
      :cascade-steps cascade-steps
      :after-bump-paths after-bump-paths
-     ;; Per Spec 005 §Restoring (rf2-mle6e.3): present iff this transition
+     ;; Per Spec 005 §Restoring: present iff this transition
      ;; resolved to a history pseudo-state — the spec/009 `:rf.machine.
      ;; history/restored` tag bag `{:compound-path :resolved-leaf :source
      ;; :kind (+:restored-config|+:fallback)}`. `apply-transition-once`
@@ -3207,7 +3186,7 @@
   at LCA → `entry` shallowest-first) via `collect-actions`. Returns the
   Result from `collect-actions` — either `result/ok` with the post-cascade
   snapshot + accumulated fx (and the structured `::cascade` step vector
-  via `result/with-cascade` — rf2-n9f4z), or a `result/fail` carrying the
+  via `result/with-cascade`), or a `result/fail` carrying the
   throwing action's diagnostic map."
   [machine snapshot event cascade]
   (collect-actions machine snapshot event (:cascade-steps cascade)))
@@ -3228,7 +3207,7 @@
             bump-paths)))
 
 (defn schedule-root-after-fx
-  "Per Spec 005 §Root parallel `:after` (rf2-wox0vd): schedule a parallel
+  "Per Spec 005 §Root parallel `:after`: schedule a parallel
   ROOT's `:after` timers at machine birth. Bumps the root's per-path epoch
   (decl-path `[]`) on `snap-final` so a later machine-teardown / explicit
   epoch advance makes the in-flight timer stale, then emits the SAME
@@ -3265,11 +3244,11 @@
   interaction. Internal transitions preserve the input snapshot's
   `:state` unchanged."
   [machine snapshot snap-after cascade]
-  ;; Per rf2-adwxh: the `cond` has three arms — `internal?` (raw-target
+  ;; The `cond` has three arms — `internal?` (raw-target
   ;; is nil; preserve current state), vector target (use the cascade-
   ;; descended leaf as a vector), keyword target (collapse a single-
-  ;; element leaf to a keyword, else vectorise). A pre-rf2-adwxh `:else`
-  ;; arm was dead: `internal?` already covers the nil-raw-target case,
+  ;; element leaf to a keyword, else vectorise). No `:else` arm is needed:
+  ;; `internal?` already covers the nil-raw-target case,
   ;; and `:target` validation upstream rejects anything other than
   ;; keyword/vector/nil.
   (let [{:keys [internal? raw-target target-leaf after-bump-paths]} cascade
@@ -3334,19 +3313,19 @@
   the change becomes stale). A target leaf that declares :after schedules
   a fresh timer at the new epoch via a :rf.machine.timer/scheduled trace.
 
-  Per Spec 005 §Final states (rf2-gn80): the returned snapshot is NOT
+  Per Spec 005 §Final states: the returned snapshot is NOT
   tagged with `:rf/finished?` here — that flag is recomputed at the
   lifecycle-handler boundary so the pure-call surface (conformance corpus,
   JVM pure-fn tests) stays free of transient runtime metadata.
 
-  Per rf2-8sz7f / audit §T6 the body composes four named phases:
+  The body composes four named phases:
   `compute-cascade-paths` → `run-cascade` → `commit-snapshot` →
   `run-spawn-phase`. Each phase is a pure helper above.
 
   `transition` is the transition map with a synthetic :decl-path key
   recording where in the state-path tree the transition was declared.
 
-  Per rf2-82a0u `transition-phase` is the closed-set keyword stamped
+  `transition-phase` is the closed-set keyword stamped
   on the transition's `:action` `action-ran` emit — one of
   `:transition` (regular `:on` match), `:always` (eventless step),
   `:after-action` (timer-driven), `:initial-entry` (bootstrap cascade).
@@ -3364,15 +3343,15 @@
                                    :transition transition
                                    :state-path (:src-path cascade)})
       (result/with-ok [snap-after fx] cascade-r
-        (let [;; Per rf2-n9f4z: the structured cascade steps `collect-actions`
+        (let [;; The structured cascade steps `collect-actions`
               ;; recorded ride `cascade-r` via `::cascade`; re-stamp them onto
               ;; the final Result (the `result/ok` below builds a fresh Result
               ;; that would otherwise drop them) so `machine-transition-single`
               ;; can accumulate the macrostep's full step sequence.
               cascade-steps   (result/cascade cascade-r)
               snap-committed  (commit-snapshot machine snapshot snap-after cascade)
-              ;; Per Spec 005 §Recording — on compound-state exit
-              ;; (rf2-mle6e.3): as part of the exit-cascade commit, write
+              ;; Per Spec 005 §Recording — on compound-state exit:
+              ;; as part of the exit-cascade commit, write
               ;; each history-bearing exited compound's last-active config
               ;; into `:rf/history`, keyed by the (region-qualified)
               ;; declaration path. The active config recorded is the
@@ -3407,15 +3386,15 @@
                                        :transition transition
                                        :state-path (:src-path cascade)})
             (result/with-ok [snap-after-spawns spawn-fx] spawn-r
-              (let [;; Per Spec 005 §Final states §The done-state signal
-                    ;; (rf2-bnjb3 / rf2-zlmz7): if the committed configuration
+              (let [;; Per Spec 005 §Final states §The done-state signal:
+                    ;; if the committed configuration
                     ;; makes an EMBEDDED compound newly done (its active direct
                     ;; child is a `:final?` leaf), raise `[:rf.machine/done
                     ;; <compound-path>]` into the macrostep's FIFO `:raise`
                     ;; queue so the enclosing `:on-done` transition fires in
                     ;; the SAME macrostep (drained by the unified
                     ;; `drain-to-fixed-point` loop / the parallel parent
-                    ;; queue, after `:always` settles — rf2-uv8os). Only an
+                    ;; queue, after `:always` settles). Only an
                     ;; EXTERNAL transition
                     ;; (a new configuration was entered) can newly satisfy a
                     ;; compound's done condition — an internal transition keeps
@@ -3456,7 +3435,7 @@
                                  [i t]))
                              (map-indexed vector always))]
         (when hit
-          ;; rf2-lai1qv — stamp the `:always` spec-path discriminator
+          ;; Stamp the `:always` spec-path discriminator
           ;; (decl-path prefix + the matched candidate index for the
           ;; vector form; index-free for the single-map form, matching the
           ;; macro's bare-`:always` keying) so the Xray cascade row
@@ -3485,14 +3464,14 @@
   ;; Overridable per machine via `:raise-depth-limit`.
   ;;
   ;; Public (not `^:private`) so the parallel layer's parent-owned
-  ;; internal-event-queue drain (`parallel.cljc`, rf2-yi7ts) bounds its
+  ;; internal-event-queue drain (`parallel.cljc`) bounds its
   ;; re-broadcast loop on the SAME default, keeping one source of truth
   ;; for the limit rather than duplicating the magic 16.
   16)
 
 ;; Forward-declared so `drain-to-fixed-point` can call
 ;; `machine-transition-single` directly when it dequeues a raised internal
-;; event (the unified SCXML microstep loop, rf2-uv8os). The recursive
+;; event (the unified SCXML microstep loop). The recursive
 ;; `:raise` step is always against an already-resolved single (flat /
 ;; compound) machine context — for a parallel parent,
 ;; `parallel-machine-transition` (in `re-frame.machines.parallel`) owns the
@@ -3512,7 +3491,7 @@
   preserving source order. Used by `drain-to-fixed-point` to peel a deferred
   nested macrostep's surfaced raises (and an `:always` step's own raises) off
   its real (do-fx-bound) fx so the raises append to the BACK of the FIFO
-  queue while the real fx accumulate (rf2-nr434 FIFO, rf2-uv8os ordering)."
+  queue while the real fx accumulate (FIFO + SCXML microstep ordering)."
   [fx-vec]
   (reduce (fn [acc [fx-id :as entry]]
             (if (= :raise fx-id)
@@ -3530,13 +3509,13 @@
   match shape lights up more than one. No-op when `match` is nil or
   carries no relevant marker.
 
-  Per rf2-ko8jb the `:frame` tag is REQUIRED for epoch-capture
+  The `:frame` tag is REQUIRED for epoch-capture
   admission (`re-frame.epoch.capture/capture-event!` silently drops
   events whose tags lack `:frame`). The caller threads `frame-id`
   resolved from `(:rf/frame machine)` so timer-firing observability
   reaches the cascade's `:trace-events` slot.
 
-  rf2-hawtjr — the caller also threads `completed-at`, the CAUSAL
+  The caller also threads `completed-at`, the CAUSAL
   completion timestamp of the timer-firing dispatch (the router-stamped
   `:rf/time-ms` off `(get-in machine [:rf/cofx :rf/time-ms])` — the SAME
   fresh fire-time token the firing `:after` guard / action read, NOT an
@@ -3550,18 +3529,18 @@
   ([frame-id match completed-at]
   (when match
     (when (:stale? match)
-      ;; Per EP-0011 §Timer Reply / Managed-Effects §Stale suppression:
-      ;; the machine `:after` timer is the existing specialized stale-gated
-      ;; instance of the uniform reply envelope. Express the existing
-      ;; epoch-mismatch drop in the shared reply vocabulary — the declaring
-      ;; path + per-path epoch ARE the data-only suppression gate — and ride
-      ;; the reply-shaped facts (`:rf.reply/status :stale`,
-      ;; `:rf.reply/work-status :suppressed`, the carried/current gate)
+      ;; Per Managed-Effects §Stale suppression:
+      ;; the machine `:after` timer is a specialized stale-gated
+      ;; instance of the uniform reply envelope. The
+      ;; epoch-mismatch drop is expressed in the shared reply vocabulary — the
+      ;; declaring path + per-path epoch ARE the data-only suppression gate —
+      ;; and the reply-shaped facts (`:rf.reply/status :stale`,
+      ;; `:rf.reply/work-status :suppressed`, the carried/current gate) ride
       ;; ADDITIVELY on the trace, preserving its public shape (`:state` /
       ;; `:delay` / `:scheduled-epoch` / `:current-epoch` / `:recovery`)
-      ;; while the trace stream now classifies the drop the same way HTTP /
-      ;; resources / routing do (m-reply). The behaviour is unchanged: the
-      ;; timer's transition still does not fire.
+      ;; so the trace stream classifies the drop the same way HTTP /
+      ;; resources / routing do (m-reply). The timer's transition does not
+      ;; fire.
       (let [stale-reply (m-reply/after-stale-reply
                           {:actor-id        (:actor-id match)
                            :state           (:state match)
@@ -3574,7 +3553,7 @@
             summary     (m-reply/trace-reply stale-reply {:frame frame-id})]
         (trace/emit! :rf.machine :rf.machine.timer/stale-after
                      (cond->
-                     {;; rf2-yyvtk5 / rf2-ws5thu — the timer's owning actor
+                     {;; The timer's owning actor
                       ;; INSTANCE (spec/009 §`:rf.machine.timer/*`);
                       ;; `:machine-id` is reserved for the registered TYPE.
                       :actor-id           (:actor-id match)
@@ -3585,10 +3564,10 @@
                       :frame              frame-id
                       :recovery           :replaced-with-default
                       ;; reply-envelope vocabulary (Managed-Effects §9)
-                      ;; rf2-niarhz — `:work/id` (canonical) joins this stale
+                      ;; `:work/id` (canonical) joins this stale
                       ;; `:after` completion into the uniform work/reply rows
                       ;; the same way every other managed async family does;
-                      ;; `:rf.reply/work-id` retained for back-compat readers.
+                      ;; `:rf.reply/work-id` is the alias readers may also key on.
                       :work/id              (:work/id summary)
                       :work/kind            (:work/kind summary)
                       :rf.reply/status      (:status summary)
@@ -3596,7 +3575,7 @@
                       :rf.reply/work-status (:work/status summary)
                       :rf.reply/stale-reason (:stale/reason summary)
                       :rf.reply/correlation (:correlation summary)}
-                       ;; rf2-hawtjr — the CAUSAL completion timestamp of the
+                       ;; The CAUSAL completion timestamp of the
                        ;; firing dispatch (router-stamped `:rf/time-ms`), under
                        ;; both the canonical `:completed-at` and the reply-
                        ;; envelope `:rf.reply/completed-at` (mirroring the
@@ -3605,13 +3584,12 @@
                        (some? (:completed-at summary))
                        (assoc :completed-at          (:completed-at summary)
                               :rf.reply/completed-at (:completed-at summary))))))
-    ;; rf2-niarhz — a FIRED (live) `:after` timer is a CLOSED `:after`
+    ;; A FIRED (live) `:after` timer is a CLOSED `:after`
     ;; completion (`:status :ok` / `:work/status :completed`). Build the
     ;; canonical fired reply and stamp the reply-envelope facts (`:work/id`,
     ;; `:work/kind :timer`, status, work-status) onto the
     ;; `:rf.machine.timer/fired` trace so it joins the uniform work/reply rows
-    ;; (Managed-Effects §Tracing). Was previously a bespoke epoch trace with
-    ;; no reply vocabulary at all.
+    ;; (Managed-Effects §Tracing).
     (when (:guard-suppressed? match)
       (let [fired-reply (m-reply/after-fired-reply
                           {:actor-id          (:actor-id match)
@@ -3625,7 +3603,7 @@
             summary     (m-reply/trace-reply fired-reply {:frame frame-id})]
         (trace/emit! :rf.machine :rf.machine.timer/fired
                      (cond->
-                     {;; rf2-yyvtk5 / rf2-ws5thu — owning actor INSTANCE.
+                     {;; Owning actor INSTANCE.
                       :actor-id (:actor-id match)
                       :state  (:state match)
                       :delay  (:delay match)
@@ -3639,14 +3617,14 @@
                       :rf.reply/work-id     (:work/id summary)
                       :rf.reply/work-status (:work/status summary)
                       :rf.reply/correlation (:correlation summary)}
-                       ;; rf2-hawtjr — causal completion time (see stale branch).
+                       ;; Causal completion time (see stale branch).
                        (some? (:completed-at summary))
                        (assoc :completed-at          (:completed-at summary)
                               :rf.reply/completed-at (:completed-at summary))))))
     (when (and (not (:stale? match))
                (not (:guard-suppressed? match))
                (:delay match))
-      ;; rf2-wox0vd — a parallel-ROOT `:after` carries the empty decl-path
+      ;; A parallel-ROOT `:after` carries the empty decl-path
       ;; `[]`, so `(last decl-path)` is nil; mark the firing state with the
       ;; root sentinel `:rf/parallel-root` (matching the stale / guard-
       ;; suppressed branches' root marker) rather than emitting `:state nil`.
@@ -3663,7 +3641,7 @@
             summary     (m-reply/trace-reply fired-reply {:frame frame-id})]
         (trace/emit! :rf.machine :rf.machine.timer/fired
                      (cond->
-                     {;; rf2-yyvtk5 / rf2-ws5thu — owning actor INSTANCE.
+                     {;; Owning actor INSTANCE.
                       :actor-id (:actor-id match)
                       :state  fired-state
                       :delay  (:delay match)
@@ -3677,13 +3655,13 @@
                       :rf.reply/work-id     (:work/id summary)
                       :rf.reply/work-status (:work/status summary)
                       :rf.reply/correlation (:correlation summary)}
-                       ;; rf2-hawtjr — causal completion time (see stale branch).
+                       ;; Causal completion time (see stale branch).
                        (some? (:completed-at summary))
                        (assoc :completed-at          (:completed-at summary)
                               :rf.reply/completed-at (:completed-at summary)))))))))
 
 (defn ensure-raised-cofx
-  "Per EP-0017 / rf2-xsdn5h — re-run the consumer-attachment ensure step for a
+  "Re-run the consumer-attachment ensure step for a
   RAISED internal event `event` against the active `snap` BEFORE its transition
   is selected, returning the (possibly `:rf/cofx`-augmented) `machine`.
 
@@ -3701,7 +3679,7 @@
   `:rf.cofx/requires` that the external event's ensure-set never covered. Without
   re-ensuring here, a generator-backed recordable fact reads nil (instead of
   being minted or strict-missing), and a provided fact absent from the token
-  skips the required-cofx error — the rf2-xsdn5h hole.
+  would skip the required-cofx error. Re-ensuring here closes that gap.
 
   This is a no-op (returns `machine` unchanged) for the pure-fn engine callers
   (conformance corpus / SSR / JVM fixtures): they carry no `:rf/cofx`, so
@@ -3709,7 +3687,7 @@
   preserved, and the reduction stays a pure function of its arguments. When a
   router dispatch DID thread the token (`:rf/cofx` present), the ensure mints
   under the resolved effective mint policy stamped on the machine def
-  (`:rf/cofx-mint-policy` — rf2-n0myjq) — `:strict` replay / `:test` refuse to
+  (`:rf/cofx-mint-policy`) — `:strict` replay / `:test` refuse to
   mint and surface `:rf.error/missing-required-cofx`. The augmented record is
   written back onto the machine def so `callback-ctx` surfaces every ensured /
   generated fact to the raised event's guards / actions, and so a subsequent
@@ -3731,11 +3709,11 @@
 (defn drain-to-fixed-point
   "Shared settling tail of the single-machine macrostep — steps 3-5 of
   Spec 005 §Drain semantics §Level 3, factored out of
-  `machine-transition-single` (rf2-505ic) so the machine-BIRTH cascade
+  `machine-transition-single` so the machine-BIRTH cascade
   reuses the SAME `:always` + raise settle the event-driven macrostep uses,
   rather than duplicating it.
 
-  **XState v5 / SCXML microstep order (rf2-uv8os).** The macrostep is the
+  **XState v5 / SCXML microstep order.** The macrostep is the
   fixed point of ONE unified loop that, after every taken transition,
   PREFERS enabled `:always` (eventless) transitions and only dequeues the
   next raised internal event once `:always` is quiescent:
@@ -3745,11 +3723,8 @@
      NO eventless transition is enabled does the processor pop one internal
      event. XState v5 matches this — a transition that raises `R` while
      entering a state with an `:always` takes the `:always` FIRST, then
-     handles `R` in the post-`:always` state. (An earlier engine drained the
-     ENTIRE raise queue before checking `:always`; that was an unblessed
-     divergence — the spec's claim of XState/SCXML parity for it was false —
-     now aligned to v5.)
-   - **FIFO among raised events once dequeued (rf2-nr434).** A taken step's
+     handles `R` in the post-`:always` state.
+   - **FIFO among raised events once dequeued.** A taken step's
      own raises append to the BACK of the one internal-event queue, behind
      the still-pending siblings; the queue is drained breadth-first.
 
@@ -3762,8 +3737,7 @@
   loop; (3) otherwise quiescent — commit.
 
   3-5 of Spec 005 §Drain semantics §Level 3 thus interleave into this single
-  loop, replacing the old `drain-raise-queue → then `:always`-loop` two-phase
-  structure. The fixed point is stamped with the active-configuration tag
+  loop. The fixed point is stamped with the active-configuration tag
   union (`commit-tags`), `::microsteps` (the count of `:always` iterations),
   and `::cascade` (the structured step vector).
 
@@ -3775,7 +3749,7 @@
   step per eventless iteration.
 
   Atomic rollback on a tripped `:always-depth-limit` / `:raise-depth-limit`
-  (Spec 005 §Bounded depth) is enforced by the FAILURE SURFACE (rf2-y3jv8q):
+  (Spec 005 §Bounded depth) is enforced by the FAILURE SURFACE:
   the abort returns a `result/depth-abort` `:fail`, which threads NO snapshot
   / fx, and the lifecycle handler short-circuits to `{}` — so neither a
   partially-advanced snapshot nor accumulated fx reaches runtime-db, and the
@@ -3784,10 +3758,10 @@
   explicit rollback-target argument is threaded — the `:fail` carrying no
   payload IS the rollback.
 
-  `raise-depth` seeds the transitive `:raise` depth counter (rf2-b88nm);
+  `raise-depth` seeds the transitive `:raise` depth counter;
   `defer?` is the effective region-defer flag. When `defer?` is true (a
-  nested raise-handling call — `drain-raises`' role is now inlined here — or
-  a parallel region whose raises lift to the parent macrostep, rf2-yi7ts),
+  nested raise-handling call, or
+  a parallel region whose raises lift to the parent macrostep),
   the loop still settles `:always` locally but SURFACES the internal-event
   queue back un-drained as `:raise` fx for the queue-owner above to harvest.
   When `defer?` is false (the queue-owning flat / compound drain) the loop
@@ -3805,23 +3779,23 @@
         ;; (the seed of the FIFO internal-event queue) and its real
         ;; (do-fx-bound) fx. Per Spec 005 §Drain semantics the raises are
         ;; held in the queue and only handled AFTER the seed state's
-        ;; `:always` has settled (rf2-uv8os).
+        ;; `:always` has settled.
         (let [{seed-raises :raises seed-real :rest} (split-raise-fx fx-after-event)
-              ;; Per rf2-n9f4z: seed the macrostep cascade with the seeding
+              ;; Seed the macrostep cascade with the seeding
               ;; transition's (event-driven exit/action/entry, OR birth
               ;; initial-entry) steps; the `:always` loop appends one
               ;; `:microstep` step per eventless iteration (carrying that
               ;; microstep's own nested cascade). The accumulated vector is
               ;; the structured explanation the outer `:rf.machine/
-              ;; transition` trace carries (rf2-52u5n).
+              ;; transition` trace carries.
               base-cascade (result/cascade start-result)]
           ;; The unified SCXML microstep loop. `always-depth` counts the
           ;; `:always` iterations (→ `::microsteps`); `raise-depth` counts
           ;; internal events dequeued (→ `:raise-depth-limit`, seeded from the
-          ;; transitive inbound count per rf2-b88nm). `pending` is the FIFO
+          ;; transitive inbound count). `pending` is the FIFO
           ;; internal-event queue — `[:raise <event-vec>]` entries kept
           ;; verbatim. `visited` tracks state-paths for the depth-abort path.
-          ;; rf2-xsdn5h — `m` is the live machine def threaded through the loop.
+          ;; `m` is the live machine def threaded through the loop.
           ;; It starts as `machine` and is re-stamped with an augmented `:rf/cofx`
           ;; whenever a dequeued raise's `ensure-raised-cofx` mints / delivers a
           ;; fact, so a subsequent raise / `:always` re-presents the generated
@@ -3842,7 +3816,7 @@
                 ;; ---- (1) PREFER `:always` — settle eventless first --------
                 (some? always-m)
                 (if (>= always-depth always-limit)
-                  ;; rf2-y3jv8q — a tripped `:always` depth limit is a FAILED
+                  ;; A tripped `:always` depth limit is a FAILED
                   ;; macrostep, not a benign no-op. XState v5 THROWS on such a
                   ;; runaway eventless cycle. Emit the precise error category
                   ;; (the single trace for the trip) and return a `result/fail`
@@ -3850,12 +3824,11 @@
                   ;; the handler's failure path (`trace-action-failure!`
                   ;; short-circuits to `{}` — no snapshot write reaches
                   ;; runtime-db, so the rollback to the pre-event snapshot is
-                  ;; preserved). The pre-fix `(result/ok rollback-snapshot [])`
-                  ;; surfaced as `next == snapshot` ⇒ a no-op (no
-                  ;; `:rf.machine/transition`, no error to the return),
-                  ;; indistinguishable from a guard-blocked no-op and silently
-                  ;; swallowing the triggering event.
-                  (let [info {;; rf2-yyvtk5 — the aborting actor is a LIVE
+                  ;; preserved). Routing the trip through the failure surface
+                  ;; keeps it distinct from a guard-blocked no-op, so the
+                  ;; triggering event is surfaced as an error rather than
+                  ;; silently swallowed.
+                  (let [info {;; The aborting actor is a LIVE
                               ;; INSTANCE. Its address is `:rf/parent-id`
                               ;; (stamped by `prepare-machine-ctx`; the spec map
                               ;; forbids `:id`), or `:id` for a singleton (whose
@@ -3867,7 +3840,7 @@
                                               (:id m))
                               :depth      always-depth
                               :path       visited
-                              ;; Per rf2-ko8jb: epoch-capture admission requires
+                              ;; Epoch-capture admission requires
                               ;; `:frame`.
                               :frame      (:rf/frame m)
                               :recovery   :no-recovery}]
@@ -3875,7 +3848,7 @@
                     ;; Macrostep rolls back atomically — no cascade survives the
                     ;; abort; the `result/fail` carries no `::snap`/`::fx`.
                     (result/depth-abort info))
-                  ;; Per rf2-82a0u: `:always` microstep's transition `:action`
+                  ;; `:always` microstep's transition `:action`
                   ;; `action-ran` emit carries `:phase :always` so the Handler
                   ;; section can group eventless cascades distinctly from
                   ;; `:on`-driven transitions.
@@ -3890,7 +3863,7 @@
                         ;; carrying the from/to states and the 0-based
                         ;; microstep index, so visualisers/debuggers see the
                         ;; inner `:always` cascade the outer trace hides.
-                        ;; Per rf2-ejtpd: stamp `:source :always` so the
+                        ;; Stamp `:source :always` so the
                         ;; trigger-kind classifier is uniform with the
                         ;; dispatch-envelope vocabulary (Spec-Schemas
                         ;; §`:rf/dispatch-envelope`). `:always` microsteps
@@ -3898,7 +3871,7 @@
                         ;; macrostep); the trace is the surface where the
                         ;; closed-set value is observable.
                         (trace/emit! :rf.machine :rf.machine.microstep/transition
-                                     {;; rf2-yyvtk5 — a microstep belongs to a
+                                     {;; A microstep belongs to a
                                       ;; LIVE actor's macrostep; address it by
                                       ;; `:actor-id` (the running INSTANCE),
                                       ;; not `:machine-id` (the TYPE).
@@ -3908,10 +3881,10 @@
                                       :to              (:state snap2)
                                       :microstep-index always-depth
                                       :source          :always
-                                      ;; Per rf2-ko8jb: epoch-capture
+                                      ;; Epoch-capture
                                       ;; admission requires `:frame`.
                                       :frame           (:rf/frame m)})
-                        ;; Per rf2-n9f4z: append a `:microstep` cascade step
+                        ;; Append a `:microstep` cascade step
                         ;; carrying the microstep's own nested exit/action/entry
                         ;; `:steps` (from the eventless transition's
                         ;; `apply-transition-once` cascade) so the eventless
@@ -3923,7 +3896,7 @@
                                           :from            (:state snap)
                                           :to              (:state snap2)
                                           :steps           (result/cascade step-result)}
-                              ;; Per rf2-uv8os: an `:always` step's OWN raises
+                              ;; An `:always` step's OWN raises
                               ;; go to the BACK of the internal-event queue —
                               ;; NOT drained immediately. The loop re-checks
                               ;; `:always` first (SCXML prefers eventless), so
@@ -3943,7 +3916,7 @@
                 ;;
                 ;; The seed state (and every state reached since) has no
                 ;; enabled `:always`. Now — and only now — handle the FRONT
-                ;; raised internal event (FIFO, rf2-nr434). In `defer?` mode
+                ;; raised internal event (FIFO). In `defer?` mode
                 ;; we DON'T drain: the queue belongs to the parent macrostep
                 ;; (a nested raise-handling frame or a parallel region), so we
                 ;; surface the whole queue back as `:raise` fx and return.
@@ -3957,14 +3930,14 @@
                       (result/with-microsteps always-depth)
                       (result/with-cascade cascade))
                   (if (>= raise-depth raise-limit)
-                    ;; rf2-y3jv8q — a tripped `:raise` depth limit is a FAILED
+                    ;; A tripped `:raise` depth limit is a FAILED
                     ;; macrostep, not a benign no-op (mirrors the `:always`
                     ;; abort above). Emit the precise category, then return a
                     ;; `result/fail` carrying the `::depth-abort?` sentinel so
                     ;; the runaway raise cycle routes through the handler's
-                    ;; failure path and the triggering event is no longer
-                    ;; silently swallowed.
-                    (let [info {;; rf2-yyvtk5 — the aborting actor is a LIVE
+                    ;; failure path and the triggering event is surfaced as an
+                    ;; error rather than silently swallowed.
+                    (let [info {;; The aborting actor is a LIVE
                                 ;; INSTANCE; its address is `:rf/parent-id`
                                 ;; (stamped by `prepare-machine-ctx`; the spec
                                 ;; map forbids `:id`), or `:id` for a singleton.
@@ -3974,7 +3947,7 @@
                                 :actor-id   (or (:rf/parent-id m)
                                                 (:id m))
                                 :depth      raise-depth
-                                ;; Per rf2-ko8jb: epoch-capture admission
+                                ;; Epoch-capture admission
                                 ;; requires `:frame`.
                                 :frame      (:rf/frame m)
                                 :recovery   :no-recovery}]
@@ -3985,7 +3958,7 @@
                       (result/depth-abort info))
                     (let [[_ ev]       (first pending)
                           rest-pending (subvec pending 1)
-                          ;; rf2-xsdn5h — re-run the consumer-attachment ensure
+                          ;; Re-run the consumer-attachment ensure
                           ;; step for THIS raised event BEFORE its transition is
                           ;; selected. The external event's ensure-set (run once
                           ;; before the macrostep by `ensure-ctx-cofx`) never
@@ -4007,7 +3980,7 @@
                           ;; self-draining recursion would be depth-first). Pass
                           ;; `(inc raise-depth)` as the transitive seed so the
                           ;; nested call's depth bound continues from this
-                          ;; drain's count (rf2-b88nm).
+                          ;; drain's count.
                           step-result  (machine-transition-single
                                          m' snap ev (inc raise-depth) true)]
                       (if (result/fail? step-result)
@@ -4041,7 +4014,7 @@
                 ;; the outer handler's `:rf.machine/transition` trace carries
                 ;; the new tag set). `always-depth` is the count of `:always`
                 ;; microsteps taken — stamped via `::microsteps` (Spec 005
-                ;; §Trace events). Per rf2-n9f4z the `cascade` rides via
+                ;; §Trace events). The `cascade` rides via
                 ;; `::cascade`.
                 :else
                 (-> (result/ok (commit-tags m snap) fx)
@@ -4058,12 +4031,12 @@
    3-5. Settle the macrostep in the unified SCXML microstep loop — after the
       taken transition, PREFER enabled `:always` (eventless) transitions and
       only dequeue the next raised internal event (FIFO) once `:always` is
-      quiescent; commit at the fixed point (rf2-uv8os aligns this ordering to
+      quiescent; commit at the fixed point (this ordering matches
       XState v5 / SCXML — `:always` settles BEFORE the next raise is handled;
-      rf2-nr434 keeps raised events FIFO once dequeued).
+      raised events stay FIFO once dequeued).
 
   Steps 3-5 (the unified `:always`/raise settle + tag commit) live in the
-  shared `drain-to-fixed-point` (rf2-505ic) so machine BIRTH reuses the
+  shared `drain-to-fixed-point` so machine BIRTH reuses the
   identical settling tail — see `re-frame.machines.parallel`'s
   `settle-birth` / `apply-initial-entry-cascade`.
 
@@ -4081,12 +4054,12 @@
   faithful FIFO queue:
 
    - `drain-to-fixed-point` re-enters this fn with `defer-raises? true` when
-     it dequeues a raise (rf2-nr434), so the popped raise's OWN raises
+     it dequeues a raise, so the popped raise's OWN raises
      surface back un-drained and the queue-owning loop appends them to the
      BACK of its FIFO queue (true breadth-first; a self-draining recursion
      would be depth-first).
-   - A REGION of a parallel parent (`:rf/region` present) ALWAYS defers
-     (rf2-yi7ts): its raises belong to the PARENT macrostep's one
+   - A REGION of a parallel parent (`:rf/region` present) ALWAYS defers:
+     its raises belong to the PARENT macrostep's one
      internal-event queue, which re-broadcasts each across EVERY region
      against the full evolving snapshot (XState v5 / SCXML: `raise` targets
      the machine's single internal queue, never a per-region one).
@@ -4100,7 +4073,7 @@
   before reaching this call. The public entry passes 0; the queue-owning
   `drain-to-fixed-point` passes its running count so a self-chaining
   single-raise accumulates transitive depth against the SAME
-  `:raise-depth-limit` rather than resetting per nested call (rf2-b88nm).
+  `:raise-depth-limit` rather than resetting per nested call.
   It seeds the settle loop below so raises emitted anywhere in this
   macrostep continue counting from the inbound transitive depth."
   ([machine snapshot event]
@@ -4125,7 +4098,7 @@
                                        (not (:guard-suppressed? match))))
         ;; Trace timer firing / staleness / guard-suppression BEFORE
         ;; running the transition, so listeners see events in the order
-        ;; they occurred. rf2-hawtjr — thread the CAUSAL completion
+        ;; they occurred. Thread the CAUSAL completion
         ;; timestamp (the router-stamped `:rf/time-ms` off the firing
         ;; dispatch's `:rf.cofx`, the SAME fresh fire-time token the
         ;; timer-fired guard / action read) so a fired or stale `:after`
@@ -4144,7 +4117,7 @@
           (result/ok snapshot [])
 
           match
-          ;; Per rf2-82a0u: the transition's `:action` `action-ran` emit
+          ;; The transition's `:action` `action-ran` emit
           ;; carries `:phase :after-action` when the match came from a
           ;; firing `:after` timer (the synthetic `:rf.machine.timer/
           ;; after-elapsed` event), `:transition` otherwise.
@@ -4152,7 +4125,7 @@
             machine snapshot event
             (-> (:transition match)
                 (assoc :decl-path (:decl-path match))
-                ;; rf2-lai1qv — finalize the `:on` spec-path discriminator:
+                ;; Finalize the `:on` spec-path discriminator:
                 ;; `match-on-clause` stamped the PARTIAL `:rf/transition-slot`
                 ;; (slot / matched key / candidate-idx / raw value); the
                 ;; pick site owns the decl-path prefix (`[]` for a root /
@@ -4180,10 +4153,11 @@
             ;; Because the op-type is `:rf.machine` (not a severity
             ;; discriminator), the Xray issue-projection predicate does not
             ;; classify it as an issue — no pink wash, no ribbon entry, for
-            ;; free. (rf2-ugdas; retires `:rf.error/machine-unhandled-event`.)
+            ;; free. An unhandled user event is a benign no-op trace, never an
+            ;; error.
             ;;
-            ;; rf2-t4582 — reserved-`:rf/*` lifecycle carve-out (a conscious
-            ;; refinement of rf2-ugdas). The no-op classifies an unknown
+            ;; Reserved-`:rf/*` lifecycle carve-out. The no-op classifies an
+            ;; unknown
             ;; USER event; framework lifecycle traffic — the synthetic
             ;; creation marker `[:rf.machine/start]` (cascade-threaded
             ;; `:event` placeholder), the spawn kick-off
@@ -4204,21 +4178,21 @@
             (when (and (nil? (:rf/region machine))
                        (unhandled-event-no-op? event))
               (trace/emit! :rf.machine :rf.machine.event/unhandled-no-op
-                           {;; rf2-yyvtk5 — a LIVE actor received the unknown
+                           {;; A LIVE actor received the unknown
                             ;; event; address it by `:actor-id` (the running
                             ;; INSTANCE), not `:machine-id` (the TYPE).
                             :actor-id   (or (:rf/parent-id machine) (:id machine))
                             :event      event
                             :state      (:state snapshot)
-                            ;; Per rf2-ko8jb: epoch-capture admission
+                            ;; Epoch-capture admission
                             ;; requires `:frame`.
                             :frame      (:rf/frame machine)}))
             (result/ok snapshot [])))]
     ;; Steps 3-5: hand the post-event seed Result to the shared
     ;; `drain-to-fixed-point` — raise-drain FIFO, `:always` fixed-point
-    ;; loop, tag commit (rf2-505ic factored this out so machine birth
-    ;; reuses the identical settling tail). On a depth-abort the drain returns
-    ;; a `result/depth-abort` `:fail` (rf2-y3jv8q) — the whole macrostep
+    ;; loop, tag commit (this shared tail lets machine birth
+    ;; reuse the identical settling). On a depth-abort the drain returns
+    ;; a `result/depth-abort` `:fail` — the whole macrostep
     ;; unwinds via the failure surface (no snapshot threaded), leaving the
     ;; PRE-event `snapshot` committed. `handled?` rides the Result for the
     ;; parallel parent's all-regions-declined no-op aggregation.

--- a/implementation/machines/test/re_frame/actor_liveness_test.cljc
+++ b/implementation/machines/test/re_frame/actor_liveness_test.cljc
@@ -1,21 +1,16 @@
 (ns re-frame.actor-liveness-test
-  "Per rf2-a2sn1 — a dynamically-spawned machine actor's LIVENESS is
-  derived from its (revertible) runtime-db snapshot, NOT from a per-instance
-  registrar entry.
+  "A dynamically-spawned machine actor's LIVENESS is derived from its
+  (revertible) runtime-db snapshot, NOT from a per-instance registrar entry.
 
-  The design defect this pins the fix for: machine STATE lived in the frame
-  value (revertible) but a spawned actor's LIVENESS — its per-instance
-  event-handler registration — lived OUTSIDE the frame value, in the
-  registrar. `restore-epoch!` reverts the frame value, not the registrar, so
-  it could never revert the registration: rewinding past a spawn orphaned
-  the handler; rewinding past a destroy left the snapshot inspectable but the
-  handler gone → `:rf.error/no-such-handler`. The fix (Mike-ruled
-  LAZY-RESOLVER): spawn/destroy become PURE frame-value writes (install/remove
-  the snapshot + the spawn-registry slot in runtime-db, stamping the
-  revertible `:rf/machine-type`), and a dispatch to an unregistered actor-id
-  lazily resolves the actor's TYPE handler from its snapshot. Liveness ==
-  snapshot presence. Post-EP-0001 (rf2-vzld77) the snapshot is durable
-  runtime-db state, so liveness lives in the runtime-db partition.
+  Liveness == snapshot presence. Machine STATE lives in the frame value
+  (revertible), and a spawned actor's liveness lives in the same revertible
+  runtime-db partition rather than the registrar — so a `restore-epoch!`
+  that reverts the frame value reverts the actor's liveness with it.
+  Spawn/destroy are PURE frame-value writes (install/remove the snapshot +
+  the spawn-registry slot in runtime-db, stamping the revertible
+  `:rf/machine-type`), and a dispatch to an unregistered actor-id lazily
+  resolves the actor's TYPE handler from its snapshot. The snapshot is
+  durable runtime-db state, so liveness lives in the runtime-db partition.
 
   These JVM+CLJS unit tests pin the machines-side invariants WITHOUT the
   epoch artefact: spawn/destroy mutate ZERO registrar state, dispatch
@@ -43,8 +38,8 @@
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
 (defn- registrar-event-snapshot
@@ -59,11 +54,11 @@
   Used here so the machines unit test exercises the revertibility property
   without test-dep'ing the epoch artefact.
 
-  EP-0001 (rf2-vzld77): a spawned actor's LIVENESS is its snapshot's presence
-  in the **runtime-db** partition (machine snapshots are durable runtime-db
-  state), so reverting liveness means reverting runtime-db — written via
-  `frame/swap-runtime-db!`. (The full frame-state restore PROJECTIONS are
-  bead 7 — rf2-3aizt1; this helper installs just the runtime-db partition.)"
+  A spawned actor's LIVENESS is its snapshot's presence in the **runtime-db**
+  partition (machine snapshots are durable runtime-db state), so reverting
+  liveness means reverting runtime-db — written via `frame/swap-runtime-db!`.
+  This helper installs just the runtime-db partition (the full frame-state
+  restore PROJECTIONS live elsewhere)."
   [frame-id runtime-db]
   (frame/swap-runtime-db! frame-id (constantly runtime-db)))
 

--- a/implementation/machines/test/re_frame/actor_resource_lease_release_test.cljc
+++ b/implementation/machines/test/re_frame/actor_resource_lease_release_test.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.actor-resource-lease-release-test
-  "Per rf2-xw5t0y — machine-SIDE contract for releasing an actor's resource
-  leases on destroy (Spec 016 §Release authority is per owner kind, 016:290).
+  "Machine-SIDE contract for releasing an actor's resource leases on destroy
+  (Spec 016 §Release authority is per owner kind, 016:290).
 
   The cross-artefact integration (a real resource entry → released → no
   continued polling) is pinned in the resources artefact

--- a/implementation/machines/test/re_frame/after_delay_validation_test.clj
+++ b/implementation/machines/test/re_frame/after_delay_validation_test.clj
@@ -1,18 +1,16 @@
 (ns re-frame.after-delay-validation-test
-  "Per rf2-apfait (Finding 2) — `:after` delay KEYS are validated at
-  registration. The schema (Spec-Schemas §`:rf/state-node` `:after`,
-  1699-1705) constrains an `:after` map key to one of three closed forms:
-  a positive integer (literal ms), a non-empty subscription vector
-  (`[sub-id & args]`), or a function. Before this fix, an invalid STATIC
-  key (`-1`, `0`, `\"soon\"`, `nil`, `[]`) passed `validate-machine!` and
-  degraded to a runtime `:rf.warning/no-clock-configured` no-op at fx time
-  — delaying authoring feedback and letting tools/conformance treat an
-  invalid machine as valid.
+  "`:after` delay KEYS are validated at registration. The schema
+  (Spec-Schemas §`:rf/state-node` `:after`, 1699-1705) constrains an
+  `:after` map key to one of three closed forms: a positive integer
+  (literal ms), a non-empty subscription vector (`[sub-id & args]`), or a
+  function. An invalid STATIC key (`-1`, `0`, `\"soon\"`, `nil`, `[]`) is
+  rejected by `validate-machine!` with `:rf.error/machine-bad-after-delay`,
+  giving authoring-time feedback rather than letting tools/conformance treat
+  an invalid machine as valid.
 
-  `validate-machine!` now rejects such keys with
-  `:rf.error/machine-bad-after-delay`. DYNAMIC delays (a subscription
-  vector / fn that RESOLVES to an invalid ms at runtime) keep their
-  fx-time warning — only the static key shape is gated here (covered by
+  DYNAMIC delays (a subscription vector / fn that RESOLVES to an invalid ms
+  at runtime) keep their fx-time `:rf.warning/no-clock-configured` warning —
+  only the static key shape is gated here (covered by
   `re-frame.after-test`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.after-test
-  "Per Spec 005 §Delayed :after transitions and rf2-3y3y.
+  "Per Spec 005 §Delayed :after transitions.
 
   State-level :after timer semantics:
     - Flat map {<delay> <transition>} per state.
@@ -11,7 +11,7 @@
       the per-machine :rf/after-epoch counter.
     - No-invoke variant: a state with :after but no :spawn is a pure
       timed-transition state.
-    - :timeout-ms / :on-timeout on :spawn / :spawn-all is REMOVED;
+    - :timeout-ms / :on-timeout on :spawn / :spawn-all is rejected;
       registration throws :rf.error/spawn-timeout-ms-removed.
 
   These JVM tests dispatch the synthetic
@@ -31,8 +31,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; runtime-db / snapshot lookup via the shared machines test-support
-;; (rf2-3l8lqe finding #4).
+;; runtime-db / snapshot lookup via the shared machines test-support.
 (def ^:private frame-db mtest/runtime-db)
 (def ^:private snapshot mtest/snapshot)
 
@@ -135,7 +134,7 @@
 
 ;; ---- same-tick tie-break: first-fired advances epoch, slower drops stale --
 ;;
-;; rf2-3kvdb — xstate-parity STEP-ALGORITHM slice (determinism of
+;; xstate-parity STEP-ALGORITHM slice (determinism of
 ;; simultaneously-enabled transitions).
 ;;
 ;; XState v5 / SCXML §3.13 resolve simultaneously-enabled transitions by
@@ -152,8 +151,7 @@
 ;; same-tick timer's event then carries a now-stale epoch and drops
 ;; (:rf.machine.timer/stale-after). No double-transition.
 ;;
-;; This test PINS that contract (NO engine change — the behaviour already
-;; holds; we prove the deliberate non-guarantee externally). Two timers at
+;; This test PINS that deliberate non-guarantee externally. Two timers at
 ;; DIFFERENT delays (5000 + 30000) are scheduled at one entry (same epoch);
 ;; we capture that epoch, then dispatch BOTH synthetic events back-to-back
 ;; — the in-test analogue of two host callbacks landing in the same tick.
@@ -247,20 +245,17 @@
             "sibling :after timer continues and transitions on its own"))
       (rf/unregister-listener! :trace ::g))))
 
-;; ---- guarded candidate-vector :after (rf2-vvbdl) --------------------------
+;; ---- guarded candidate-vector :after --------------------------------------
 ;;
 ;; Per Spec 005 §Delayed :after transitions §Transition spec: the :after
 ;; value admits the SAME guarded candidate-vector form as an :on clause —
 ;; [{:guard g :target s} {:target s2 :action a}] — resolved first-guard-
-;; pass-wins. Pre-rf2-vvbdl pick-after-transition normalised only keyword /
-;; single-map values, so a guarded vector was passed whole into the single-
-;; guard resolver: the guard passed vacuously, the whole vector became the
-;; :transition, and the timer fired with NO transition + NO effects (the
-;; machine was silently stranded). This is the integration counterpart to
-;; the pure-engine sweep in re-frame.after-value-forms-test — driving the
-;; full runtime so the action's :data write and the cascade are exercised.
-;; The live repro was the step-deck :ws/connection machine stuck in
-;; [:active :authenticating].
+;; pass-wins. pick-after-transition normalises the guarded vector and
+;; resolves it through the candidate walk, so the firing timer fires the
+;; first guard-passing candidate's transition + effects. This is the
+;; integration counterpart to the pure-engine sweep in
+;; re-frame.after-value-forms-test — driving the full runtime so the
+;; action's :data write and the cascade are exercised.
 
 (deftest after-guarded-vector-first-pass-runtime
   (testing "guarded candidate-vector :after through the runtime — first guard
@@ -369,10 +364,9 @@
 ;; Per Spec 005 §Hierarchy interaction (the normative external contract at
 ;; 005:1638): "leaf-only sibling transitions inside the same parent MUST
 ;; NOT cause that parent's pending :after timer to fire as stale on its
-;; next match." A single per-machine epoch could not satisfy this — a
-;; child sibling transition that itself bumps the shared counter staled the
-;; still-active parent's in-flight timer. The per-decl-path epoch model
-;; bumps ONLY the exited/entered nodes, leaving the live parent untouched.
+;; next match." The per-decl-path epoch model satisfies this: it bumps ONLY
+;; the exited/entered nodes, leaving the live parent's in-flight timer
+;; untouched.
 
 (deftest after-parent-survives-child-sibling-transition
   (testing "a parent's :after stays live across a child-only sibling
@@ -481,8 +475,8 @@
   (testing "(fn [snap] ms) delay form: invoked once at state entry"
     (let [;; Per spec, fn delays use the ORIGINAL fn key for synthetic-event
           ;; lookup. This test exercises pick-after-transition's lookup
-          ;; with a fn delay-key. Per rf2-grw4i / rf2-v0rrr the delay-fn
-          ;; receives a single context-map arg `{:snapshot ...}`.
+          ;; with a fn delay-key. The delay-fn receives a single
+          ;; context-map arg `{:snapshot ...}`.
           delay-fn (fn [_ctx] 7000)
           m {:initial :idle
              :data    {}
@@ -509,8 +503,8 @@
           parent {:initial :idle
                   :data    {}
                   :on-spawn-actions
-                  ;; Advisory observation hook — returns nil (rf2-dtth6
-                  ;; warns on a non-nil dropped return).
+                  ;; Advisory observation hook — returns nil (a non-nil
+                  ;; dropped return would warn).
                   {:rec (fn [{:keys [id]}] (tap> [::spawned id]) nil)}
                   :states
                   {:idle {:on {:go :authenticating}}
@@ -535,17 +529,18 @@
         (is (nil? (get-in (frame-db) [:rf.runtime/machines :snapshots child-id]))
             "child machine destroyed via standard exit cascade")))))
 
-;; ---- fn-form :after exception observability (rf2-c1tnr) -------------------
+;; ---- fn-form :after exception observability -------------------------------
 
 (deftest after-fn-form-throw-surfaces-trace
   (testing "fn-form :after that throws emits :rf.error/machine-after-fn-threw"
-    ;; Pre-rf2-c1tnr the throw was silently caught and the resolution
-    ;; returned [nil nil], surfacing only as :rf.warning/no-clock-
-    ;; configured downstream with no signal that the fn itself blew up.
+    ;; A fn-form :after delay that throws surfaces the failure: the error
+    ;; arm emits :rf.error/machine-after-fn-threw and recovers to
+    ;; :rf.warning/no-clock-configured downstream, so the blown-up fn is
+    ;; observable rather than silently swallowed.
     (let [delay-fn (fn [_ctx]
                      (throw (ex-info "fn-form delay blew up" {:where :test})))]
-      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
-      ;; unregister in a `finally`, no hand-rolled register/try/finally.
+      ;; Shared `with-trace-capture` — guaranteed unregister in a `finally`,
+      ;; no hand-rolled register/try/finally.
       (mtest/with-trace-capture captured
         (rf/reg-machine :a/throws
                         {:initial :idle
@@ -569,23 +564,22 @@
             (is (= :no-clock-configured (:recovery first-err))
                 ":recovery hoisted to the envelope top-level")))))))
 
-;; ---- sub-cache ref-count balance on bad-delay early-return (rf2-fva6c.1) ---
+;; ---- sub-cache ref-count balance on bad-delay early-return ----------------
 
 (defn- default-sub-cache []
   @(:sub-cache (frame/frame :rf/default)))
 
 (deftest after-sub-vec-bad-delay-does-not-leak-subscription
-  ;; rf2-fva6c.1: `schedule-after-timer!` resolves a subscription-vector
-  ;; `:after` delay by calling `subs/subscribe`, which bumps the sub-cache
-  ;; ref-count BEFORE we know whether the resolved value is positive. When
-  ;; the resolved value is nil / 0 / negative, the bad-delay branch
-  ;; previously emitted :rf.warning/no-clock-configured and short-circuited
-  ;; — without unsubscribing. No entry was stored in `after-timers`, so no
-  ;; future cancellation path would ever drop the ref. Long-running CLJS
-  ;; processes with repeated bad delays accumulated sub-cache slots.
+  ;; `schedule-after-timer!` resolves a subscription-vector `:after` delay
+  ;; by calling `subs/subscribe`, which bumps the sub-cache ref-count BEFORE
+  ;; we know whether the resolved value is positive. When the resolved value
+  ;; is nil / 0 / negative, the bad-delay branch emits
+  ;; :rf.warning/no-clock-configured AND unsubscribes, so no sub-cache slot
+  ;; leaks even though no entry is stored in `after-timers` (the only
+  ;; cancellation path that would otherwise drop the ref).
   ;;
-  ;; Per rf2-cmfln sub-cache disposal is synchronous on derefer-count → 0,
-  ;; so we observe the cache state without timing.
+  ;; Sub-cache disposal is synchronous on derefer-count → 0, so we observe
+  ;; the cache state without timing.
   (testing "sub-vec :after delay resolving to 0 unsubscribes (no sub-cache leak)"
     (rf/reg-event :a/seed-bad (fn [{:keys [db]} _] {:db (assoc db :timeout-config 0)}))
     (rf/reg-sub :a/timeout-config-0 (fn [db _] (:timeout-config db)))
@@ -639,9 +633,7 @@
       (is (not (contains? (default-sub-cache) [:a/timeout-config-neg]))
           "sub-cache remains clean after 5 bad-delay schedules"))))
 
-;; ---- sub-vec :after exception observability arms (rf2-t4uo0) --------------
-;;
-;; Per rf2-q1z1u F1 (HIGH) — follow-on for rf2-c1tnr.
+;; ---- sub-vec :after exception observability arms --------------------------
 ;;
 ;; `timer.cljc` has three error-emit arms in :after-delay resolution:
 ;; - :rf.error/machine-after-fn-threw     (fn-form throw on `(delay-key snapshot)`)
@@ -649,11 +641,11 @@
 ;; - :rf.error/machine-after-watch-failed (add-watch throw)
 ;;
 ;; The fn-form arm is pinned above by `after-fn-form-throw-surfaces-trace`.
-;; The other two arms are the SAFETY NET against the silent-swallow
-;; class of bug rf2-c1tnr fixed: pre-rf2-c1tnr a deref-throw or an
-;; add-watch-throw was silently caught and the resolution returned
-;; [nil nil], surfacing only as `:rf.warning/no-clock-configured`
-;; downstream with no signal the underlying reactive surface blew up.
+;; The other two arms are the SAFETY NET against silently swallowing a
+;; deref-throw or an add-watch-throw: each surfaces the failure as its own
+;; error trace rather than returning [nil nil] and showing up only as
+;; `:rf.warning/no-clock-configured` downstream with no signal the
+;; underlying reactive surface blew up.
 ;;
 ;; These tests pin those two cousin arms at the trace-emit boundary —
 ;; mirroring the fn-form test's shape exactly so a regression that
@@ -663,10 +655,9 @@
   (testing "rf2-t4uo0 — sub-vec :after whose @reaction throws emits
             :rf.error/machine-after-sub-threw with :rf.sub/id +
             :exception slots and :recovery :no-clock-configured"
-    ;; Pre-rf2-c1tnr the deref throw was silently caught and the
-    ;; resolution returned [nil nil], surfacing only as
-    ;; :rf.warning/no-clock-configured. The error arm makes the
-    ;; underlying sub failure observable.
+    ;; A deref throw on the reaction surfaces the underlying sub failure
+    ;; through the error arm rather than returning [nil nil] and showing up
+    ;; only as :rf.warning/no-clock-configured.
     ;;
     ;; A USER-SPACE sub body throw is caught by `validate-and-trace`
     ;; in re-frame.subs.memo BEFORE it reaches the timer's `try
@@ -684,7 +675,7 @@
           throwing-reaction (reify clojure.lang.IDeref
                               (deref [_]
                                 (throw (ex-info throw-msg {:where :test}))))]
-      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4).
+      ;; Shared `with-trace-capture`.
       (mtest/with-trace-capture captured
         (rf/reg-sub :s/well-formed (fn [_db _] 1000))
         (rf/reg-machine
@@ -723,10 +714,10 @@
   (testing "rf2-t4uo0 — sub-vec :after where add-watch on the reaction
             throws emits :rf.error/machine-after-watch-failed with
             :rf.sub/id + :exception slots and :recovery :static-delay"
-    ;; Pre-rf2-c1tnr an add-watch throw was silently swallowed; the
-    ;; sub-changed re-resolution watcher would not fire (so dynamic
-    ;; delays would silently stop re-resolving) without any signal.
-    ;; This arm makes the failure observable.
+    ;; An add-watch throw is made observable: without the error arm the
+    ;; sub-changed re-resolution watcher would not fire (so dynamic delays
+    ;; would silently stop re-resolving) without any signal. This arm
+    ;; surfaces the failure.
     ;;
     ;; To trigger the arm reliably we shadow `clojure.core/add-watch`
     ;; over the schedule path. The shadow throws once for the
@@ -743,7 +734,7 @@
                            (throw (ex-info "add-watch blew up on after-watch"
                                            {:where :test :key key}))
                            (real-add target key f)))]
-      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4).
+      ;; Shared `with-trace-capture`.
       (mtest/with-trace-capture captured
         ;; A well-behaved sub returning a positive delay — subscribe
         ;; succeeds, deref returns 1000 (so the bad-delay branch

--- a/implementation/machines/test/re_frame/after_timer_completed_at_test.clj
+++ b/implementation/machines/test/re_frame/after_timer_completed_at_test.clj
@@ -1,23 +1,21 @@
 (ns re-frame.after-timer-completed-at-test
-  "rf2-hawtjr — the machine `:after` timer reply path carries the CAUSAL
-  `:completed-at` (EP-0011 §Timer Reply / Managed-Effects §Causal completion
-  metadata).
+  "The machine `:after` timer reply path carries the CAUSAL `:completed-at`
+  (EP-0011 §Timer Reply / Managed-Effects §Causal completion metadata).
 
-  The spawned-machine `:rf.machine/done` reply already threads the finishing
+  The spawned-machine `:rf.machine/done` reply threads the finishing
   dispatch's `:rf.cofx :rf/time-ms` into the reply + trace; the `:after`
-  timer reply path previously did NOT. The synthetic `:after`-elapsed
-  dispatch is itself a causal token carrying a fresh router-stamped
-  `:rf/time-ms` (the same fire-time token the firing guard / action read),
-  and a fired `:after` timer's transition can mutate machine snapshot
-  `:data` — so per Managed-Effects §Causal completion metadata the
-  completion time MUST ride the fired-timer reply, and §Tracing wants it on
-  the stale-timer suppression trace too.
+  timer reply path does the same. The synthetic `:after`-elapsed dispatch is
+  itself a causal token carrying a fresh router-stamped `:rf/time-ms` (the
+  same fire-time token the firing guard / action read), and a fired `:after`
+  timer's transition can mutate machine snapshot `:data` — so per
+  Managed-Effects §Causal completion metadata the completion time rides the
+  fired-timer reply, and §Tracing carries it on the stale-timer suppression
+  trace too.
 
-  These tests drive the REAL `interop/schedule-after!` fire boundary (the
-  rf2-hg39nf recipe) so the timer-fire dispatch is router-stamped with a
-  known fire-time clock value, then assert `:completed-at` /
-  `:rf.reply/completed-at` ride the `:rf.machine.timer/fired` and
-  `:rf.machine.timer/stale-after` traces."
+  These tests drive the REAL `interop/schedule-after!` fire boundary so the
+  timer-fire dispatch is router-stamped with a known fire-time clock value,
+  then assert `:completed-at` / `:rf.reply/completed-at` ride the
+  `:rf.machine.timer/fired` and `:rf.machine.timer/stale-after` traces."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]

--- a/implementation/machines/test/re_frame/after_value_forms_test.clj
+++ b/implementation/machines/test/re_frame/after_value_forms_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.after-value-forms-test
-  "Per rf2-vvbdl — exhaustive coverage of `:after` value-form resolution.
+  "Exhaustive coverage of `:after` value-form resolution.
 
   The `:after` table value at a delay-key admits the SAME value-form
   grammar as an `:on` clause (Spec 005 §Delayed `:after` transitions
@@ -18,14 +18,11 @@
     (h) hierarchical guarded `:after` (leaf vs parent epoch / staleness)
     (i) parallel-region-scoped guarded `:after` (region decl-path routing)
 
-  Pre-rf2-vvbdl `pick-after-transition` normalised the resolved `:after`
-  value with only `(if (keyword? t) {:target t} t)` — so a guarded
-  candidate-vector was passed WHOLE into the single-guard resolver. There
-  `(:guard <vector>)` is nil → the guard passed vacuously, `:transition`
-  became the entire vector, and downstream `(:target …)` / `(:action …)`
-  read nil: the timer fired with outcome :ok but applied NO transition and
-  NO effects (the machine was silently stranded). Cases (e), (f), (g) — the
-  candidate-vector forms — are the regressions that case fixes.
+  A guarded candidate-vector `:after` value resolves through the shared
+  candidate-walk: each candidate's guard is evaluated in order, the first
+  passing candidate's `:target` / `:action` drives the transition, and an
+  unguarded candidate acts as the fallback. Cases (e), (f), (g) — the
+  candidate-vector forms — pin this resolution against regression.
 
   These tests drive the PURE `machines/machine-transition` surface with the
   synthetic `[:rf.machine.timer/after-elapsed delay-key epoch decl-path]`
@@ -146,7 +143,7 @@
 
 ;; ---- (e) guarded vector, first guard passes -> first target ---------------
 ;;
-;; THE REGRESSION. Pre-fix this returned :loading unchanged (silent no-op).
+;; The candidate-vector form: the first passing guard's target fires.
 
 (deftest after-guarded-vector-first-guard-passes
   (testing "guarded candidate-vector :after: first guard passes → first target"

--- a/implementation/machines/test/re_frame/birth_always_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/birth_always_cljs_test.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.birth-always-cljs-test
-  "Per rf2-505ic (xstate-v5 / SCXML parity) — the machine's INITIAL
-  MACROSTEP is initial-entry + the eventless (`:always`) + raise settle.
+  "xstate-v5 / SCXML parity — the machine's INITIAL MACROSTEP is
+  initial-entry + the eventless (`:always`) + raise settle.
   After the initial-entry cascade builds the birth snapshot, the SAME
   raise-drain + `:always` fixed-point loop the event macrostep uses runs
   BEFORE the birth commit, so a transient initial leaf whose `:always`
@@ -50,7 +50,7 @@
 ;; PURE — birth eventless settle via `apply-initial-entry-cascade`
 ;; ===========================================================================
 ;;
-;; `apply-initial-entry-cascade` is the machine's single birth site; it now
+;; `apply-initial-entry-cascade` is the machine's single birth site; it
 ;; composes the initial-entry cascade with `settle-birth` (the raise-drain +
 ;; `:always` fixed-point). `boot` builds the freshly-synthesised initial
 ;; snapshot via `build-initial-snapshot` (the same source-of-truth the
@@ -85,16 +85,16 @@
   [fx]
   (boolean (some (fn [[fx-id]] (= :raise fx-id)) fx)))
 
-;; ---- bz0ox.1 — birth-time `:entry` `:raise` drains INSIDE the macrostep ----
+;; ---- birth-time `:entry` `:raise` drains INSIDE the macrostep -------------
 ;;
 ;; XState v5 / SCXML §3.13: the initial macrostep runs initial-entry THEN
 ;; the internal-event-queue drain. A `raise` emitted by an initial `:entry`
 ;; enters the machine's ONE internal queue and is consumed before quiescence
-;; — it never surfaces as an outbound (reserved) effect. Before the fix
-;; `settle-birth` seeded the drain with an EMPTY fx vector, so an initial
-;; `:entry`'s `[:raise ...]` was concatenated onto the OUTBOUND fx instead of
-;; draining: the birth snapshot stuck at the pre-raise leaf and a reserved
-;; `:raise` fx escaped to the global layer (→ `:rf.error/no-such-fx`).
+;; — it never surfaces as an outbound (reserved) effect. `settle-birth`
+;; seeds the drain with the initial-entry's own fx, so an initial `:entry`'s
+;; `[:raise ...]` drains INSIDE the birth macrostep: the birth snapshot
+;; settles to the raised-event target and no reserved `:raise` fx escapes to
+;; the global layer.
 
 (deftest pure-birth-entry-raise-drains-flat
   (testing "(bz0ox.1) a flat machine whose initial `:entry` raises `[:go]`
@@ -293,7 +293,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter substrate-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 

--- a/implementation/machines/test/re_frame/cancellation_reply_envelope_test.clj
+++ b/implementation/machines/test/re_frame/cancellation_reply_envelope_test.clj
@@ -1,15 +1,14 @@
 (ns re-frame.cancellation-reply-envelope-test
-  "rf2-sfunt8 — machine cancellation terminal paths close the work attempt
-  the reply-envelope way (EP-0011 §Cancellation / Managed-Effects
-  §Cancellation: \"Cancellation is represented as data, not as the absence
-  of a reply\").
+  "Machine cancellation terminal paths close the work attempt the
+  reply-envelope way (EP-0011 §Cancellation / Managed-Effects §Cancellation:
+  \"Cancellation is represented as data, not as the absence of a reply\").
 
-  Previously a cancelled `:after` timer, a destroyed actor, and a
-  `:spawn-all` join-survivor cancellation completed by ABSENCE of a reply —
-  their traces carried reason / state / epoch but no canonical `:work/id`,
-  `:rf.reply/status :cancelled`, `:rf.reply/work-status`, or `:cancel/reason`.
-  A cancelled timer / actor could therefore have a scheduled / spawned START
-  but no terminal EP-0011 reply row.
+  A cancelled `:after` timer, a destroyed actor, and a `:spawn-all`
+  join-survivor cancellation each carry a canonical terminal reply: their
+  traces carry reason / state / epoch ALONGSIDE a canonical `:work/id`,
+  `:rf.reply/status :cancelled`, `:rf.reply/work-status`, and `:cancel/reason`
+  — so a cancelled timer / actor closes its scheduled / spawned START with a
+  terminal EP-0011 reply row.
 
   These tests pin the reply-envelope facts on the three cancellation traces:
    1. `:rf.machine.timer/cancelled` (on state exit) →

--- a/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
+++ b/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
@@ -1,6 +1,5 @@
 (ns re-frame.cross-region-guard-ctx-test
-  "Per Spec 005 §Cross-region coordination — tags as `stateIn`
-  (rf2-46ly6 / rf2-69d1n).
+  "Per Spec 005 §Cross-region coordination — tags as `stateIn`.
 
   XState v5 / SCXML gold standard: a parallel region's guard can
   predicate on a SIBLING region's active state via `stateIn(stateValue)`
@@ -8,29 +7,27 @@
   B.1) — the canonical orthogonal-region coordination primitive.
 
   re-frame2 expresses this WITHOUT a separate `stateIn` primitive
-  (rf2-69d1n — behavioural parity, not API mimicry). `reduce-regions`
-  threads the machine-wide active-configuration `:tags` union and the
-  full `:all-state` region map into every region's guard/action ctx
-  (rf2-46ly6). A region guard then reads a sibling region's state via
-  either:
+  (behavioural parity, not API mimicry). `reduce-regions` threads the
+  machine-wide active-configuration `:tags` union and the full `:all-state`
+  region map into every region's guard/action ctx. A region guard then reads
+  a sibling region's state via either:
     - `(contains? (:tags ctx) :some/state-tag)` — the coarse tag query
       (the documented `stateIn` substitute);
     - `(= :valid (:form (:all-state ctx)))` — the precise sibling-state
       read.
 
-  Coverage (the bead's comprehensive test list):
+  Coverage:
     (a) a region guard reading `(:tags ctx)` sees a SIBLING region's
         state-tag and fires / blocks accordingly — the core cross-region
-        coordination case, impossible before rf2-46ly6.
+        coordination case.
     (b) the §State-tags-as-stateIn worked example from spec/005 actually
         works from a region guard.
-    (c) FROZEN selection (rf2-42mml) — a sibling's SAME-EVENT transition is
-        NOT visible to a later region's guard during selection; the guard
-        reads the frozen pre-event sibling config. (Read-TIMING flips from
-        rf2-46ly6's evolving; the read CAPABILITY is preserved. The
+    (c) FROZEN selection — a sibling's SAME-EVENT transition is NOT visible
+        to a later region's guard during selection; the guard reads the
+        frozen pre-event sibling config (aligns to XState v5 / SCXML). The
         dedicated frozen-selection / declaration-order-independence /
         next-microstep convergence fixtures live in
-        `frozen_region_select_test.clj`.)
+        `frozen_region_select_test.clj`.
     (d) region guards still see their OWN state correctly (regression).
     (e) non-parallel (flat / compound) guard ctx is UNAFFECTED — neither
         `:tags` nor `:all-state` appears (regression).
@@ -46,8 +43,8 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
 ;; ---- (a) region guard reads a sibling region's tag ------------------------

--- a/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
+++ b/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
@@ -1,10 +1,8 @@
 (ns re-frame.destroy-exit-cascade-test
-  "Per rf2-nahfm — every destroy path runs the child's active configuration
-  `:exit` cascade BEFORE teardown. Pre-rf2-nahfm the four destroy entry-
-  points each cleared the actor's snapshot WITHOUT firing the `:exit`
-  actions Spec 005 §Declarative `:spawn` §Composition with explicit
-  `:entry` / `:exit` and §Final states §Composition with `:entry` /
-  `:exit` promise.
+  "Every destroy path runs the child's active configuration `:exit` cascade
+  BEFORE teardown, per Spec 005 §Declarative `:spawn` §Composition with
+  explicit `:entry` / `:exit` and §Final states §Composition with `:entry` /
+  `:exit`.
 
   The four destroy paths exercised here:
     1. Explicit `[:rf.machine/destroy actor-id]` fx (keyword form)
@@ -53,7 +51,7 @@
                :states
                {:armed {:on {:fire {:action (fn [_] {:fx [[:rf.machine/destroy :ne/standalone]]})}}}}})]
       ;; Bring the standalone machine to life by dispatching ANY event
-      ;; (the first dispatch fires the bootstrap cascade per rf2-pexjc).
+      ;; (the first dispatch fires the bootstrap cascade).
       (rf/dispatch-sync [:ne/standalone [:rf.machine/noop]])
       (is (zero? @exit-fired) "no :exit yet — actor still alive")
       (rf/dispatch-sync [:ne/destroyer [:fire]])

--- a/implementation/machines/test/re_frame/destroy_silent_idempotent_test.cljc
+++ b/implementation/machines/test/re_frame/destroy_silent_idempotent_test.cljc
@@ -1,10 +1,9 @@
 (ns re-frame.destroy-silent-idempotent-test
-  "Per rf2-lbjnz (Mike decision a, aligned with XState convention).
+  "Destroy idempotence is a deliberate contract, aligned with the XState
+  convention.
 
-  Pins the destroy idempotence contract as **deliberate, not
-  accidental**. The actor lifecycle has exactly one observable
-  transition (Active → Stopped); subsequent destroy attempts are
-  silent no-ops:
+  The actor lifecycle has exactly one observable transition (Active →
+  Stopped); subsequent destroy attempts are silent no-ops:
 
     - NO second `:rf.machine/destroyed` trace fires,
     - NO error is raised,
@@ -12,18 +11,17 @@
       registrar is already cleared, the spawn-slot is already
       cleared).
 
-  The two regression scenarios pinned here:
+  The two scenarios pinned here:
 
     1. **Explicit destroy after auto-destroy** — an actor reaches
-       `:final?` and auto-destroys (rf2-gn80 D4); a subsequent
+       `:final?` and auto-destroys (D4); a subsequent
        `[:rf.machine/destroy <id>]` fx is a silent no-op.
 
     2. **Double-explicit destroy** — two destroy fxs in the same
        cascade (or two cascaded destroys in the same drain) collapse
        to one observable destroy + one trace.
 
-  The spec contract lives at [Spec 005 §Destroy is silent-idempotent
-  (rf2-lbjnz)](spec/005-StateMachines.md#destroy-is-silent-idempotent-rf2-lbjnz)
+  The spec contract lives at Spec 005 §Destroy is silent-idempotent,
   with a cross-link from §Final states D6.
 
   The file is named `*-test.cljc` so it's discovered by both
@@ -34,7 +32,7 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
    [re-frame.machines.test-support :as mtest]
-   ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`
+   ;; listener surface lives in `re-frame.trace.tooling`
    ;; (production-DCE split).
    [re-frame.trace.tooling :as trace-tooling]
    [re-frame.registrar :as registrar]
@@ -46,7 +44,7 @@
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
@@ -170,9 +168,9 @@
 
 ;; ---- Test 3: spawn-all join-cancelled survivor destroyed exactly once ------
 ;;
-;; rf2-ndfjo — the destroy-single-actor! / spawn-all exit-cascade path was
-;; unpinned. When a `:spawn-all` join resolves with `:cancel-on-decision?`
-;; true (the default), surviving children are torn down TWICE:
+;; When a `:spawn-all` join resolves with `:cancel-on-decision?` true (the
+;; default), each surviving child is torn down exactly once even though two
+;; destroy paths target it:
 ;;
 ;;   1. `build-resolution-fx` (join.cljc) emits `[:rf.machine/destroy
 ;;      <survivor>]` (keyword form → guarded `destroy-single!`) — one
@@ -180,14 +178,12 @@
 ;;   2. the parent then transitions OUT of the `:spawn-all` state; the
 ;;      exit cascade emits `[:rf.machine/destroy {:rf/spawn-all true ...}]`
 ;;      → `destroy-spawn-all-children!` re-reads the still-uncleared
-;;      join-state and (pre-fix) fired `destroy-single-actor!` +
-;;      `emit-destroyed!` UNCONDITIONALLY per child — a SECOND
-;;      `:rf.machine/destroyed` for the already-cancelled survivors.
+;;      join-state. Its per-child teardown carries the same liveness guard
+;;      `destroy-single!` does, so an already-cancelled survivor is a silent
+;;      no-op — no SECOND `:rf.machine/destroyed`.
 ;;
-;; This violated the silent-idempotent destroy contract (rf2-lbjnz): one
-;; observable Active→Stopped transition ⇒ exactly one `:rf.machine/destroyed`
-;; per actor. The fix gives `destroy-single-actor!` the same liveness guard
-;; `destroy-single!` carries and gates the cascade's emit on it.
+;; This upholds the silent-idempotent destroy contract: one observable
+;; Active→Stopped transition ⇒ exactly one `:rf.machine/destroyed` per actor.
 
 (defn- mk-cancel-child
   "Child that, on `:go`, transitions to `:done` and dispatches

--- a/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
@@ -1,22 +1,21 @@
 (ns re-frame.destroyed-exit-order-test
-  "Per rf2-iilco — the `:rf.machine/destroyed` trace fires AFTER the
-  child's active-configuration `:exit` cascade on EVERY destroy path.
+  "The `:rf.machine/destroyed` trace fires AFTER the child's
+  active-configuration `:exit` cascade on EVERY destroy path.
 
-  Before rf2-iilco the explicit / declarative-`:spawn` destroy
-  (`destroy-single!`) and the `:spawn-all` per-child teardown
-  (`destroy-spawn-all-children!`) emitted `:rf.machine/destroyed`
-  BEFORE running `run-child-exit!`, while the final-state auto-destroy
-  (`finalize-machine`) emitted it AFTER the cascade. A consumer keying
-  on `:rf.machine/destroyed` therefore saw the destroy signal at a
-  different point relative to the `:exit` side-effects depending on
-  which entry-point fired — a latent inconsistency for tools (Xray,
-  re-frame-10x, story-mcp) that key on the trace.
+  All three destroy entry-points emit `:rf.machine/destroyed` AFTER the
+  `:exit` cascade: the explicit / declarative-`:spawn` destroy
+  (`destroy-single!`), the `:spawn-all` per-child teardown
+  (`destroy-spawn-all-children!`), and the final-state auto-destroy
+  (`finalize-machine`). A consumer keying on `:rf.machine/destroyed`
+  therefore sees the destroy signal at a consistent point relative to the
+  `:exit` side-effects regardless of which entry-point fired — important
+  for tools (Xray, re-frame-10x, story-mcp) that key on the trace.
 
   Spec 005 §Declarative `:spawn` §Composition with explicit `:entry` /
   `:exit` (005:2138) pins the order: the `:exit` action reads the
   actor's final snapshot *before* the auto-destroy clears it, so a
   consumer observing the db between `:exit` and `:rf.machine/destroyed`
-  must see the live snapshot. That makes exit-then-destroyed the
+  sees the live snapshot. That makes exit-then-destroyed the
   spec-correct convention; this file pins it on all three paths.
 
   Mechanism: a shared ordered log captures both the `:exit` action's

--- a/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
@@ -1,7 +1,5 @@
 (ns re-frame.destroyed-trace-shape-test
-  "Per rf2-vgkdt and the rf2-2ukxv round-2 audit §TE-r2-3.
-
-  `:rf.machine/destroyed` is emitted at three distinct sites — each
+  "`:rf.machine/destroyed` is emitted at three distinct sites — each
   for a different destroy class:
 
     1. `destroy-spawn-all-children!` (lifecycle_fx/destroy.cljc):
@@ -48,13 +46,13 @@
 ;; `:tags` per Spec 009 §Cascade-id stamping; those keys are not part
 ;; of the per-site contract.
 ;;
-;; rf2-sfunt8 — an `:explicit` destroy closes the actor work attempt the
-;; reply-envelope way (a `:status :cancelled` reply — cancellation as DATA,
-;; Managed-Effects §Cancellation / EP-0011 §Cancellation). The cancelled
-;; reply facts ride ADDITIVELY on the destroyed trace, so they are part of
-;; the contract for the `:explicit` (cancellation) sites; a
-;; `:rf.machine/finished` destroy carries none of them (the actor already
-;; closed through `finalize-machine`'s `:rf.machine/done` reply).
+;; An `:explicit` destroy closes the actor work attempt the reply-envelope
+;; way (a `:status :cancelled` reply — cancellation as DATA, Managed-Effects
+;; §Cancellation / EP-0011 §Cancellation). The cancelled reply facts ride
+;; ADDITIVELY on the destroyed trace, so they are part of the contract for
+;; the `:explicit` (cancellation) sites; a `:rf.machine/finished` destroy
+;; carries none of them (the actor already closed through
+;; `finalize-machine`'s `:rf.machine/done` reply).
 (def ^:private reply-envelope-keys
   #{:work/id :work/kind :rf.reply/status :rf.reply/work-id
     :rf.reply/work-status :rf.reply/cancelled? :rf.reply/cancel-reason
@@ -78,7 +76,7 @@
 ;; is the destroyed-trace SHAPE probe — it returns a [capture-atom
 ;; unregister-fn] pair so a test can inspect the raw envelope key-set and
 ;; control exactly when it stops capturing (the scope-macro form cannot
-;; express the manual-stop). Per rf2-kjmtbq this site is left as raw by design.
+;; express the manual-stop). This site is left as raw by design.
 (defn- record!
   []
   (let [a  (atom [])
@@ -109,7 +107,7 @@
           (str label ": :reason discriminator is always emitted"))
       (is (#{:explicit :rf.machine/finished} (:reason tags))
           (str label ": :reason is one of :explicit / :rf.machine/finished"))
-      ;; rf2-sfunt8 — an :explicit destroy is a cancellation; it carries the
+      ;; An :explicit destroy is a cancellation; it carries the
       ;; reply-envelope cancellation facts. A :rf.machine/finished destroy is
       ;; NOT a cancellation (the actor closed through :rf.machine/done) — no
       ;; cancelled reply facts.

--- a/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.dispatch-to-system-fx-cljs-test
-  "Per rf2-xgj34 — regression for the `:rf.machine/dispatch-to-system` fx.
+  "Regression for the `:rf.machine/dispatch-to-system` fx.
 
   Spec 005 §Cross-machine messaging by name documents the action-side
   mechanism for a machine to send a message to its spawned child actor
@@ -9,12 +9,9 @@
   dropped, so the fx form — not a captured-id dispatch — is how an action
   reaches a NAMED child.)
 
-  The bug (rf2-xgj34): the machines artefact shipped only the
-  `dispatch-to-system` FN (`re-frame.core`), never the fx — so a machine
-  following the spec hit `:rf.error/no-such-fx`. The fix registers the fx
-  in `re-frame.machines`. The headline property here: a machine action
-  emits the fx and the spawned actor's snapshot shows the message landed —
-  i.e. the fx id is now handled and routes the dispatch.
+  The fx is registered in `re-frame.machines`. The headline property here:
+  a machine action emits the fx and the spawned actor's snapshot shows the
+  message landed — i.e. the fx id is handled and routes the dispatch.
 
   Args shape is the single 2-element pair `[<system-id> <event-vector>]`
   (the framework fx contract is a `[fx-id args]` pair; `do-fx` drops
@@ -46,7 +43,7 @@
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 

--- a/implementation/machines/test/re_frame/done_signal_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/done_signal_cljs_test.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.done-signal-cljs-test
-  "Per rf2-bnjb3 (parallel onDone) + rf2-zlmz7 (compound onDone). Verifies the
+  "Parallel onDone + compound onDone. Verifies the
   TRANSITIONABLE done-state / `:on-done` completion signal at the LIVE handler
   boundary (not just the pure engine — the SCXML-conformance corpus covers the
   pure surface). XState v5 `onDone` / SCXML §3.7 `done.state.<id>`.
@@ -11,10 +11,9 @@
   a TOP-LEVEL `:final?` leaf (direct child of the machine root) STILL
   auto-destroys (the actor-done case); an embedded final signals-not-destroys.
 
-  The former substitute (`:raise` from the final leaf's `:entry`, which
-  collided with `:final?`-auto-destroys — the rf2-zlmz7 footgun) is gone: you
-  mark the sub-flow's terminal leaf `:final?` and declare `:on-done` on the
-  enclosing compound, and the machine keeps running.
+  To advance a completed sub-flow you mark the sub-flow's terminal leaf
+  `:final?` and declare `:on-done` on the enclosing compound, and the machine
+  keeps running.
 
   Named `*-cljs-test.cljc` so both cognitect.test-runner (JVM) and shadow-cljs
   (CLJS) discover it — the engine + lifecycle are identical across runtimes."
@@ -37,8 +36,8 @@
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
 (defn- record-traces! [k]
@@ -50,7 +49,7 @@
   (filter #(= operation (:operation %)) @traces))
 
 ;; ===========================================================================
-;; rf2-zlmz7 — COMPOUND onDone (embedded :final? signals, does NOT destroy)
+;; COMPOUND onDone (embedded :final? signals, does NOT destroy)
 ;; ===========================================================================
 
 (deftest compound-done-advances-and-machine-survives
@@ -134,7 +133,7 @@
           "the whole-machine :rf.machine/done fired (actor finality)"))))
 
 ;; ===========================================================================
-;; rf2-bnjb3 — PARALLEL onDone (all-regions-final fires root :on-done)
+;; PARALLEL onDone (all-regions-final fires root :on-done)
 ;; ===========================================================================
 
 (deftest parallel-done-fires-root-on-done-and-survives
@@ -250,7 +249,7 @@
         "machine alive — :b still pending")))
 
 ;; ===========================================================================
-;; rf2-z522n — parallel-root :on-done honours the :db hard-disallow + phase
+;; parallel-root :on-done honours the :db hard-disallow + phase
 ;; ===========================================================================
 
 (deftest parallel-on-done-action-returning-db-emits-error-and-drops-db
@@ -276,7 +275,7 @@
             "exactly one wrote-db hard-disallow error from the parallel :on-done action")
         (is (= :complete (-> errs first :tags :action-id))
             "the diagnostic names the offending :on-done action")
-        ;; rf2-x9haxl — `:offending-value` (the whole app-db the :on-done action
+        ;; `:offending-value` (the whole app-db the :on-done action
         ;; wrongly returned) is summarized to `:rf/redacted` at the trace egress
         ;; chokepoint so it never leaks raw; `:action-id` still locates it.
         (is (= :rf/redacted (-> errs first :tags :offending-value))
@@ -356,12 +355,12 @@
              :on-done {:target :somewhere}
              :regions {:a {:initial :run :states {:run {} }}}})))))
 
-;; rf2-6srk5 — EVERY target-bearing :on-done value-form must be rejected
-;; LOUDLY at registration (not just the map form). Before the fix, a bare-
-;; keyword target and a vector-path target slipped past validation and then
-;; SILENTLY STALLED at runtime: apply-on-done-action normalised them to a
-;; target-only / action-less candidate, ran no action, marked the parallel
-;; done-signal handled (suppressing auto-destroy), and moved nowhere.
+;; EVERY target-bearing :on-done value-form is rejected LOUDLY at registration
+;; (not just the map form). A bare-keyword target and a vector-path target must
+;; not slip past validation: were one to reach runtime it would SILENTLY STALL —
+;; apply-on-done-action would normalise it to a target-only / action-less
+;; candidate, run no action, mark the parallel done-signal handled (suppressing
+;; auto-destroy), and move nowhere. Registration rejects them up front.
 (deftest parallel-on-done-bare-keyword-target-rejected
   (testing "rf2-6srk5: a parallel root's :on-done declaring a BARE-KEYWORD
             target (:on-done :next) is rejected at registration — it would

--- a/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
+++ b/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
@@ -1,23 +1,17 @@
 (ns re-frame.dropped-snapshot-diagnostic-test
   "Spec 005 / Conventions §The clobber footgun is eliminated structurally —
-  the `{:db fresh-map}` footgun is GONE under the two-partition frame
-  (EP-0001 rf2-vzld77).
+  the `{:db fresh-map}` footgun is structurally impossible under the
+  two-partition frame.
 
-  Pre-migration, machine snapshots sat under an `:rf/runtime` root INSIDE
-  app-db, so an event returning a from-scratch `:db` effect wholesale-replaced
-  app-db and silently dropped every live machine snapshot — the footgun the
-  `:rf.warning/runtime-state-dropped` diagnostic flagged. Under the
-  two-partition contract machine snapshots live in the **runtime-db**
-  partition at `[:rf.runtime/machines :snapshots <id>]`, and an ordinary `:db`
-  effect replaces ONLY app-db — runtime-db is a partition the handler never
-  holds. So a fresh-map `:db` return CANNOT touch a live machine snapshot:
-  the footgun is structurally impossible, not merely warned.
+  Machine snapshots live in the **runtime-db** partition at
+  `[:rf.runtime/machines :snapshots <id>]`, and an ordinary `:db` effect
+  replaces ONLY app-db — runtime-db is a partition the handler never holds.
+  So a fresh-map `:db` return CANNOT touch a live machine snapshot: the
+  footgun is structurally impossible, not merely warned.
 
   These machines-artefact integration tests prove that property end-to-end
   against a genuine registered machine: a from-scratch `:db` return leaves the
-  machine ALIVE and the snapshot intact. (The legacy `:rf/runtime`-root hard
-  error + the retirement of the now-vestigial `:rf.warning/runtime-state-dropped`
-  diagnostic are bead 9 — rf2-tfepxu.)
+  machine ALIVE and the snapshot intact.
 
   JVM-only by intent — the commit path is substrate-independent."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -39,9 +33,9 @@
   (reset! frame/frames {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
-  ;; machine fxs require a carried frame stamp. Register `:rf/default`
-  ;; explicitly and pin it as the established scope for the body.
+  ;; `init!` does not synthesise `:rf/default`, and machine fxs require a
+  ;; carried frame stamp. Register `:rf/default` explicitly and pin it as the
+  ;; established scope for the body.
   (frame/ensure-default-frame!)
   (require 're-frame.machines :reload)
   (machines/reset-timers!)
@@ -57,7 +51,7 @@
    :states  {:off {:on {:flip :on}}
              :on  {:on {:flip :off}}}})
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4).
+;; snapshot lookup via the shared machines test-support.
 (defn- live-snapshot?
   [machine-id]
   (some? (mtest/snapshot machine-id)))
@@ -65,8 +59,7 @@
 (defn- with-recorder
   "Register a recorder, run `body-fn`, return captured
   :rf.warning/runtime-state-dropped events. Routed through the shared
-  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
-  unregister in a `finally`."
+  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
   [body-fn]
   (mtest/with-trace-capture recorded
     (body-fn)
@@ -87,11 +80,10 @@
 (deftest fresh-db-return-cannot-drop-a-live-machine
   (testing "an event returning {:db fresh-map} leaves the live machine ALIVE — machine snapshots are runtime-db, an ordinary :db effect replaces ONLY app-db"
     (register-live-machine!)
-    ;; The former footgun: a handler (here a plain event, but the same shape a
-    ;; boot-machine action emits inside a cascade) rebuilds app-db from
-    ;; scratch. Pre-migration this dropped the `:rf/runtime` app-db root and
-    ;; with it the live :diag/m1 snapshot. Under the two-partition contract
-    ;; the snapshot lives in runtime-db, which `:db` never holds.
+    ;; A handler (here a plain event, but the same shape a boot-machine
+    ;; action emits inside a cascade) rebuilds app-db from scratch. Under the
+    ;; two-partition contract the live :diag/m1 snapshot lives in runtime-db,
+    ;; which `:db` never holds — so the from-scratch `:db` cannot drop it.
     (rf/reg-event :diag/reboot (fn [{:keys [db]} _] {:db {:fresh-app-state true}}))
     (let [warnings (with-recorder #(rf/dispatch-sync [:diag/reboot]))]
       (is (empty? warnings)

--- a/implementation/machines/test/re_frame/final_state_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_cljs_test.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.final-state-cljs-test
-  "Per rf2-gn80. Verifies the `:final?` / `:on-done` / `:output-key`
-  contract for state-machine final states. Ten locked decisions (D1-D10)
-  are exercised here under both JVM and CLJS runtimes.
+  "Verifies the `:final?` / `:on-done` / `:output-key` contract for
+  state-machine final states. Ten locked decisions (D1-D10) are exercised
+  here under both JVM and CLJS runtimes.
 
    D1 — `:final?` is a first-class key on the state node (NOT under
         `:meta`).
@@ -28,7 +28,7 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`
+   ;; The listener surface lives in `re-frame.trace.tooling`
    ;; (production-DCE split). On JVM the convenience aliases in
    ;; re-frame.core preserve the `rf/<name>` shape, but on CLJS the
    ;; tooling sibling must be referenced directly.
@@ -44,8 +44,8 @@
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
 (defn- traces-for
@@ -332,12 +332,11 @@
     (is (some? (registrar/lookup :event :rf2-gn80/par-partial))
         "machine handler is still live — :right hasn't reached :final? yet")))
 
-;; ---- (rf2-g13nm2 C2) :output-key on a NON-FIRST region's terminal leaf ----
+;; ---- (C2) :output-key on a NON-FIRST region's terminal leaf ----
 ;; A spawned parallel child whose :output-key lives on a region OTHER than the
-;; first (state-map order) must still report that slot back through the
-;; parent's :spawn :on-done. The pre-fix finalize read :output-key from
-;; `(first state)` only, so a non-first region's :output-key silently yielded
-;; result=nil.
+;; first (state-map order) still reports that slot back through the parent's
+;; :spawn :on-done — finalize scans every region's terminal leaf for the
+;; :output-key, not just the first.
 
 (deftest parallel-output-key-on-non-first-region-reported
   (testing "C2: a spawned parallel child reports :output-key from a NON-FIRST region"
@@ -345,8 +344,8 @@
       (rf/reg-machine :rf2-gn80/par-child
         {:type    :parallel
          ;; :alpha is the FIRST region and carries NO :output-key; :beta (a
-         ;; later region) is the one declaring :output-key. Pre-fix this read
-         ;; nil because finalize only inspected the first region's leaf.
+         ;; later region) is the one declaring :output-key — finalize must
+         ;; scan past the first region's leaf to find it.
          :regions {:alpha {:initial :run
                            :states  {:run  {:on {:fin :done}}
                                      :done {:final? true}}}
@@ -411,14 +410,14 @@
         (is (seq (traces-for traces :rf.error/machine-parallel-output-key-conflict))
             "a :rf.error/machine-parallel-output-key-conflict trace was emitted")))))
 
-;; ---- (rf2-encnvn) :error? final on a NON-FIRST region routes as ERROR ------
+;; ---- :error? final on a NON-FIRST region routes as ERROR ------
 ;; A spawned PARALLEL child whose FIRST region (state-map order) reaches a
 ;; plain final but a NON-FIRST region reaches `{:final? true :error? true}`
-;; must route to the spawning parent's `:spawn :on-error` (control flow) — NOT
-;; `:on-done` — and the `:rf.machine/done` trace must carry `:error? true`.
-;; The pre-fix finalize read `:error?` from `(first state)` only (the same
-;; first-region blind spot the C2 `:output-key` scan above already fixed), so
-;; a non-first-region error final was MIS-REPORTED as a successful finish.
+;; routes to the spawning parent's `:spawn :on-error` (control flow) — NOT
+;; `:on-done` — and the `:rf.machine/done` trace carries `:error? true`.
+;; Finalize scans every region's terminal leaf for `:error?` (the same
+;; all-regions scan the C2 `:output-key` case above relies on), so an error
+;; final in any region is classified as an error finish.
 
 (deftest parallel-error-final-on-non-first-region-routes-as-error
   (testing "rf2-encnvn: a spawned parallel child whose NON-FIRST region reaches an :error? final routes to :on-error, not :on-done"
@@ -427,8 +426,9 @@
       (rf/reg-machine :rf2-encnvn/par-err-child
         {:type    :parallel
          ;; :alpha is the FIRST region and reaches a PLAIN final (no :error?).
-         ;; :beta (a later region) is the one reaching the ERROR terminal.
-         ;; Pre-fix, finalize classified the finish off :alpha only → success.
+         ;; :beta (a later region) is the one reaching the ERROR terminal —
+         ;; finalize classifies the finish off every region, so :beta's
+         ;; error final wins.
          :regions {:alpha {:initial :run
                            :states  {:run  {:on {:fin :done}}
                                      :done {:final? true}}}

--- a/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
+++ b/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
@@ -1,8 +1,7 @@
 (ns re-frame.frame-destroy-cascade-test
-  "Per rf2-vsigt — frame destroy must run the machine `:exit` /
-  disposal cascade in reverse-creation order BEFORE sub-cache /
-  adapter teardown. Spec 005 §Cross-Spec Interactions §1 enumerates
-  the contract:
+  "Frame destroy runs the machine `:exit` / disposal cascade in
+  reverse-creation order BEFORE sub-cache / adapter teardown. Spec 005
+  §Cross-Spec Interactions §1 enumerates the contract:
 
     `(rf/destroy-frame! :auth)` is called while the frame holds active
     machine instances mid-flight. Each active machine runs its `:exit`
@@ -10,11 +9,10 @@
     disposes first). After every machine has settled, sub-cache
     disposes / substrate releases / `:frame/destroyed` traces.
 
-  Pre-rf2-vsigt the implementation aborted in-flight HTTP and emitted
-  `:rf.machine.lifecycle/destroyed` but did not run the `:exit`
-  actions, did not unregister the spawned-actor handlers, did not
-  clear the `[:rf.runtime/machines :system-ids]` reverse index, and did not enforce any
-  ordering.
+  The cascade runs the `:exit` actions, unregisters the spawned-actor
+  handlers, clears the `[:rf.runtime/machines :system-ids]` reverse index,
+  and enforces the reverse-creation ordering — alongside aborting in-flight
+  HTTP and emitting `:rf.machine.lifecycle/destroyed`.
 
   These JVM-side tests run on the plain-atom substrate against the
   late-bound `:machines/teardown-on-frame-destroy!` hook that the
@@ -180,8 +178,7 @@
       (rf/reg-machine :lt/child child)
       (rf/reg-machine :lt/boot boot)
       (rf/dispatch-sync [:lt/boot [:start]] {:frame :lt/auth})
-      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
-      ;; unregister in a `finally`.
+      ;; Shared `with-trace-capture` — guaranteed unregister in a `finally`.
       (mtest/with-trace-capture traces
         (rf/destroy-frame! :lt/auth)
         (let [destroyed (filter #(= :rf.machine.lifecycle/destroyed (:operation %))
@@ -266,17 +263,17 @@
       ;; Each frame has its own spawn-order vector.
       (is (= [:iso/child-a#1] (spawn-order/frame-order :iso/frame-a)))
       (is (= [:iso/child-b#1] (spawn-order/frame-order :iso/frame-b)))
-      ;; Per rf2-a2sn1 — a spawned actor carries NO per-instance registrar
-      ;; entry; its liveness IS its snapshot's presence in the frame's
-      ;; (revertible) app-db. Cross-frame isolation is therefore asserted
-      ;; on the snapshots, not the registrar.
+      ;; A spawned actor carries NO per-instance registrar entry; its
+      ;; liveness IS its snapshot's presence in the frame's (revertible)
+      ;; app-db. Cross-frame isolation is therefore asserted on the
+      ;; snapshots, not the registrar.
       (is (some? (get-in (rf/runtime-db-value :iso/frame-a)
                          [:rf.runtime/machines :snapshots :iso/child-a#1]))
           "frame A's spawned actor is live (snapshot present) before destroy")
       (is (some? (get-in (rf/runtime-db-value :iso/frame-b)
                          [:rf.runtime/machines :snapshots :iso/child-b#1]))
           "frame B's spawned actor is live (snapshot present) before destroy")
-      ;; Spawned actors never register a per-instance handler (rf2-a2sn1).
+      ;; Spawned actors never register a per-instance handler.
       (is (nil? (registrar/lookup :event :iso/child-a#1))
           "frame A's spawned actor has no per-instance registrar entry")
       (is (nil? (registrar/lookup :event :iso/child-b#1))
@@ -298,18 +295,17 @@
 
 ;; ---- restore / hydration: spawned snapshots absent from spawn-order ------
 ;;
-;; Per rf2-apfait — restore / SSR hydration / `replace-runtime-db!` /
-;; `restore-epoch!` repopulate the DURABLE runtime-db snapshots WITHOUT
-;; repopulating the PROCESS-SIDE (transient) `spawn-order` atom (Spec 002
-;; §Durable vs transient: the atom is runtime bookkeeping, not durable
-;; state). Before the fix, `destroy-frame!` saw such snapshots only via the
-;; straggler pass and routed them through `run-singleton-exit-cascade!`,
-;; which runs the `:exit` cascade + HTTP abort ONLY — it does NOT dissoc
-;; the snapshot, release the system-id reverse index, clear schema marks,
-;; cancel `:after` timers, or unregister a handler. A restored SPAWNED
-;; actor (snapshot carries `:rf/machine-type`) must instead flow through
-;; the FULL `destroy-single-actor!` teardown, in reverse-creation order
-;; derived from the durable `<type>#<n>` actor-id.
+;; Restore / SSR hydration / `replace-runtime-db!` / `restore-epoch!`
+;; repopulate the DURABLE runtime-db snapshots WITHOUT repopulating the
+;; PROCESS-SIDE (transient) `spawn-order` atom (Spec 002 §Durable vs
+;; transient: the atom is runtime bookkeeping, not durable state). A restored
+;; SPAWNED actor (snapshot carries `:rf/machine-type`) flows through the FULL
+;; `destroy-single-actor!` teardown — dissoc the snapshot, release the
+;; system-id reverse index, clear schema marks, cancel `:after` timers,
+;; unregister a handler — in reverse-creation order derived from the durable
+;; `<type>#<n>` actor-id. (The straggler `run-singleton-exit-cascade!` path
+;; runs the `:exit` cascade + HTTP abort only and is reserved for restored
+;; SINGLETON snapshots that carry no `:rf/machine-type`.)
 ;;
 ;; These tests model restore by spawning normally, then wiping ONLY the
 ;; transient spawn-order atom (`spawn-order/reset-all!`) while leaving the

--- a/implementation/machines/test/re_frame/frozen_region_select_test.clj
+++ b/implementation/machines/test/re_frame/frozen_region_select_test.clj
@@ -1,7 +1,6 @@
 (ns re-frame.frozen-region-select-test
   "Per Spec 005 §Transition broadcast (select-then-apply) + §Cross-region
-  coordination (rf2-42mml — XState v5 / SCXML parity, verified vs
-  xstate@5.32.0).
+  coordination (XState v5 / SCXML parity, verified vs xstate@5.32.0).
 
   XState v5 selects the enabled transition set for a parallel macrostep
   against the PRE-EVENT configuration / context, THEN runs the selected
@@ -11,12 +10,11 @@
   accumulating — the one value that flows). The cross-region `:all-state` /
   `:tags` a guard OR action reads are frozen (statechart atomicity).
 
-  This REVERSES rf2-46ly6's evolving READ-TIMING but KEEPS its CAPABILITY:
-  a region guard / action still reads a sibling's state via `:all-state`
-  (precise) / `:tags` (coarse). Only the snapshot those keys resolve
-  against flips (frozen pre-event, not evolving same-event).
+  A region guard / action reads a sibling's state via `:all-state`
+  (precise) / `:tags` (coarse), resolved against the frozen pre-event
+  snapshot — not an evolving same-event view.
 
-  Acceptance fixtures (the bead's list):
+  Acceptance fixtures:
     (1) `:data` write in region A is NOT visible to region B's same-event
         GUARD (B sees the frozen pre-event `:data`); B fires only on a
         later event / raised rebroadcast.
@@ -42,7 +40,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
@@ -261,9 +259,9 @@
     (let [ab (:state (snapshot :frozen/order-ab))
           ba (:state (snapshot :frozen/order-ba))]
       ;; Under FROZEN selection, b's guard sees frozen :a=:idle in BOTH
-      ;; orderings → b stays :idle in both. (Under the OLD evolving model,
-      ;; a-then-b would have leaked a=:done to b and opened it — the
-      ;; declaration-order-dependent footgun this fix removes.)
+      ;; orderings → b stays :idle in both. An evolving same-event model
+      ;; would leak a=:done to b for a-then-b and open it — the
+      ;; declaration-order-dependent footgun frozen selection avoids.
       (is (= {:a :done :b :idle} ab)
           "a-then-b: b saw frozen :a=:idle → b blocked")
       (is (= {:a :done :b :idle} ba)

--- a/implementation/machines/test/re_frame/grammar_parity_test.clj
+++ b/implementation/machines/test/re_frame/grammar_parity_test.clj
@@ -1,7 +1,7 @@
 (ns re-frame.grammar-parity-test
-  "Per rf2-3l8lqe finding #2 — registration validation and the runtime
-  transition engine must agree on the machine grammar BY CONSTRUCTION,
-  not by a hand-kept comment that one mirrors the other.
+  "Registration validation and the runtime transition engine must agree on
+  the machine grammar BY CONSTRUCTION, not by a hand-kept comment that one
+  mirrors the other.
 
   Both layers now consume `re-frame.machines.grammar` (the shared
   state-tree descent + transition-value-form recogniser):

--- a/implementation/machines/test/re_frame/guard_action_traces_test.clj
+++ b/implementation/machines/test/re_frame/guard_action_traces_test.clj
@@ -1,12 +1,12 @@
 (ns re-frame.guard-action-traces-test
-  "Per rf2-2nwfd: the machines substrate emits two cascade-discoverable
-  traces around every transition:
+  "The machines substrate emits two cascade-discoverable traces around every
+  transition:
 
     :rf.machine/guard-evaluated
       {:guard-id <kw-or-fn>
        :input    {:data <data> :event <event-vec>}
-       :state    <active-state>   ;; rf2-tjm3u2 — the active state the
-                                  ;; guard ran against (source disambiguation)
+       :state    <active-state>   ;; the active state the guard ran against
+                                  ;; (source disambiguation)
        :outcome  :pass | :fail}
 
     :rf.machine/action-ran
@@ -42,8 +42,7 @@
 (defn- record-traces!
   "Register a trace listener for the duration of `body-fn`, returning
   the captured trace vec. Routed through the shared
-  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
-  unregister in a `finally`."
+  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
   [body-fn]
   (mtest/with-trace-capture seen
     (body-fn)
@@ -75,7 +74,7 @@
             "input :data carries the snapshot's :data slot")
         (is (= [:go] (-> g :tags :input :event))
             "input :event carries the originating event vec")
-        ;; rf2-tjm3u2 — the active state the guard ran against is stamped
+        ;; the active state the guard ran against is stamped
         ;; so a consumer can disambiguate which state's edge a block
         ;; belongs to (two states reusing the same event + guard id).
         (is (= :idle (-> g :tags :state))
@@ -227,22 +226,15 @@
       (is (= cascade-id (-> a :tags :rf.trace/dispatch-id))
           "action-ran picks up the same cascade dispatch-id"))))
 
-;; ---- rf2-4yrr6 / rf2-gl588 — the throw-on-boot machine (machine-epochs
-;; :fuse/box) ------------------------------------------------------------------
+;; ---- the throw-on-boot machine (machine-epochs :fuse/box) ------------------
 ;;
 ;; The machine-epochs testbed's `:fuse/box` exercises a machine-action
-;; exception ON BOOT. Pre-F‴ it relied on the double-duty wart: an eager
-;; `[:rf.machine/bootstrap]` kick was re-processed as a normal trigger against
-;; the just-born `:armed`, which had no `:on` entry → fell to a `:*` wildcard
-;; whose `:blow-fuse` action threw. F‴ (rf2-gl588) makes the start marker a
-;; PURE init-kick that STOPS after initial-entry — it is NEVER re-fed into the
-;; transition step, so that `:*`-via-marker path no longer exists.
+;; exception ON BOOT. The start marker is a PURE init-kick that STOPS after
+;; initial-entry — it is NEVER re-fed into the transition step.
 ;;
-;; The throw is therefore RE-VEHICLED to a real initial-`:entry` action on
-;; `:armed`: now the throw fires inside the initial-entry cascade itself, on
-;; ANY boot (eager `:rf.machine/start` kick OR lazy first-real-event). This
-;; preserves the "exception on boot" coverage on the F‴ creation model. Three
-;; facts pin it:
+;; The throw is carried by a real initial-`:entry` action on `:armed`: it
+;; fires inside the initial-entry cascade itself, on ANY boot (eager
+;; `:rf.machine/start` kick OR lazy first-real-event). Three facts pin it:
 ;;
 ;;   1. An eager `[:fuse/box [:rf.machine/start]]` kick runs the initial-entry
 ;;      cascade, whose `:armed` `:entry` action `:blow-fuse` THROWS on boot.
@@ -254,8 +246,7 @@
 ;;      so only the throwing-entry shape trips the exception.
 
 (defn- fuse-machine-spec
-  "An `:armed`-at-birth machine whose initial `:entry` action throws — the
-  F‴ re-vehicle of the old `:*`-wildcard-on-boot throw."
+  "An `:armed`-at-birth machine whose initial `:entry` action throws on boot."
   []
   {:initial :armed
    :data    {}

--- a/implementation/machines/test/re_frame/initial_entry_test.clj
+++ b/implementation/machines/test/re_frame/initial_entry_test.clj
@@ -1,16 +1,14 @@
 (ns re-frame.initial-entry-test
-  "Per rf2-0z73. Verifies whether a machine's **initial-state `:entry`
-  actions** fire when the machine first comes into existence — both for
-  top-level singleton machines (registered via `reg-machine`) and for
-  spawned actors (via declarative `:spawn` or imperative
-  `[:rf.machine/spawn ...]`).
+  "Verifies that a machine's **initial-state `:entry` actions** fire when
+  the machine first comes into existence — both for top-level singleton
+  machines (registered via `reg-machine`) and for spawned actors (via
+  declarative `:spawn` or imperative `[:rf.machine/spawn ...]`).
 
-  Surfaced from rf2-yf97 (the websocket example) and the
-  `:rf.http/managed` machine-shape wrapper: both work around an apparent
-  gap by declaring `:on :rf.machine.spawn/spawned :action ...` on the initial
-  state instead of relying on the natural `:entry` slot. If `:entry`
-  doesn't fire on initial state, every Pattern doc and worked example
-  that assumes the canonical `:entry` shape is misleading.
+  The canonical `:entry` slot is the right place to run initial-state
+  actions; relying on `:on :rf.machine.spawn/spawned :action ...` on the
+  initial state is a workaround, not the natural shape. If `:entry` did not
+  fire on the initial state, every Pattern doc and worked example that
+  assumes the canonical `:entry` shape would be misleading.
 
   Three scenarios under test, mirroring the three ways a machine first
   comes into existence:
@@ -37,7 +35,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
@@ -129,7 +127,7 @@
                                   ;; :leaf's parent :mid), so the absolute
                                   ;; vector target [:outer :elsewhere] resolves
                                   ;; it; a bare keyword would resolve as a
-                                  ;; sibling of :leaf under :mid (rf2-w84jv).
+                                  ;; sibling of :leaf under :mid.
                                   {:leaf {:entry :enter-leaf
                                           :on    {:go [:outer :elsewhere]}}}}
                            :elsewhere {}}}}}]
@@ -138,7 +136,7 @@
       (is (= [:outer :mid :leaf] @calls)
           "every state in the initial cascade fired :entry shallowest-first, exactly once"))))
 
-;; ---- (4) initial :entry cascade error path (rf2-dd3b / PR #330 gap) -------
+;; ---- (4) initial :entry cascade error path -------------------------------
 ;;
 ;; Per Spec 005 §Errors and machines.cljc:2161/2174 — if an action in
 ;; the bootstrap cascade throws, the runtime:
@@ -147,9 +145,9 @@
 ;;   - DOES NOT commit the snapshot (no `:db` effect)
 ;;   - DOES NOT flow any fx the cascade accumulated
 ;;
-;; PR #330 added the cascade itself; the happy paths above cover it.
-;; rf2-dd3b adds the throw-path coverage so a regression that silently
-;; committed a partial cascade or swallowed the trace would be caught.
+;; The happy paths above cover the cascade; this section pins the throw-path
+;; coverage so a regression that silently committed a partial cascade or
+;; swallowed the trace would be caught.
 
 (deftest initial-entry-throw-halts-bootstrap-atomically
   (testing "a throw in initial :entry leaves the snapshot uncommitted and

--- a/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
+++ b/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
@@ -1,24 +1,20 @@
 (ns re-frame.initial-snapshot-unification-test
-  "Per rf2-fgqs4 — pinning tests for the unified `build-initial-snapshot`
-  helper in `re-frame.machines.parallel`. Pre-rf2-fgqs4 the spawn path
-  had its own `compute-initial-snapshot` that silently OMITTED two slots
-  the singleton-registration path stamped:
+  "Pinning tests for the unified `build-initial-snapshot` helper in
+  `re-frame.machines.parallel`. Both the singleton-registration path and
+  the spawn path build their initial snapshot through this one helper, so
+  both always stamp two slots:
 
-    - `:rf/spawn-counter {}` — the in-snapshot id allocator (rf2-gr8q).
-      A spawned actor whose `:entry` declares a `:spawn` would fall
-      onto `allocate-spawned-id`'s defensive `(fnil inc 0)` backstop
-      instead of the contract path of reading from a present slot.
+    - `:rf/spawn-counter {}` — the in-snapshot id allocator. A spawned
+      actor whose `:entry` declares a `:spawn` reads the next id from this
+      present slot via the contract path of `allocate-spawned-id` (the
+      defensive `(fnil inc 0)` backstop is never reached).
 
     - `:meta` — per Spec 005 §Snapshot shape, a spec's optional `:meta`
       propagates onto the snapshot so 3-arity ctx and downstream
-      version checks see the same `:meta` the spec declares. The spawn
-      path dropped it on the floor.
+      version checks see the same `:meta` the spec declares.
 
   These tests pin the unified behaviour at both ends: the helper itself
-  (unit-level) and the end-to-end spawn path (integration-level).
-
-  Pre-fix the integration tests below FAIL on the spawn path; post-fix
-  they PASS on both paths."
+  (unit-level) and the end-to-end spawn path (integration-level)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -36,9 +32,9 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
-  ;; machine fxs require a carried frame stamp. Register `:rf/default`
-  ;; explicitly and pin it as the established scope for the body.
+  ;; `init!` does not synthesise `:rf/default`, and machine fxs require a
+  ;; carried frame stamp. Register `:rf/default` explicitly and pin it as
+  ;; the established scope for the body.
   (frame/ensure-default-frame!)
   (require 're-frame.machines :reload)
   (machines/reset-timers!)
@@ -47,8 +43,8 @@
 
 (use-fixtures :each reset-runtime)
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
 ;; ---- (1) `parallel/build-initial-snapshot` unit contract -------------------
@@ -94,9 +90,8 @@
 ;; ---- (2) End-to-end spawn integration: :meta propagates --------------------
 ;;
 ;; A spawned actor whose spec declares `:meta` MUST carry that `:meta`
-;; on its initial snapshot at `[:rf.runtime/machines :snapshots <spawned-id>]`. Pre-rf2-fgqs4
-;; the spawn-path helper silently dropped `:meta`, so any
-;; `^:rf.machine/wants-ctx` action introspecting `:meta` saw nil.
+;; on its initial snapshot at `[:rf.runtime/machines :snapshots <spawned-id>]`,
+;; so any `^:rf.machine/wants-ctx` action introspecting `:meta` sees it.
 
 (deftest spawned-actor-snapshot-carries-meta
   (testing "a spawned actor whose spec declares :meta has it on its snapshot"
@@ -125,7 +120,6 @@
 ;; an `:entry`-declared `:spawn` on the actor's initial state goes
 ;; through the contract path of `allocate-spawned-id` (reading from a
 ;; present slot) rather than the defensive `(fnil inc 0)` backstop.
-;; Pre-rf2-fgqs4 the spawn-path snapshot lacked the slot entirely.
 
 (deftest spawned-actor-snapshot-carries-spawn-counter
   (testing "a spawned actor's snapshot carries :rf/spawn-counter (rf2-gr8q contract)"

--- a/implementation/machines/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/machines/test/re_frame/late_bind_missing_test.clj
@@ -1,13 +1,12 @@
 (ns re-frame.late-bind-missing-test
-  "Per rf2-5b6x — assert the documented missing-artefact error contract for
-  the machines artefact's `re-frame.core` re-exports.
+  "Assert the documented missing-artefact error contract for the machines
+  artefact's `re-frame.core` re-exports.
 
   Each per-feature split (schemas / machines / routing / flows / http /
   ssr) raises a documented `:rf.error/<artefact>-artefact-missing`
   ex-info when a consumer calls a re-exported surface but the artefact
-  is absent from the classpath. The contract was previously only
-  documented in prose; this test pins the runtime behaviour against
-  regression.
+  is absent from the classpath. This test pins that runtime behaviour
+  against regression.
 
   Strategy: the machines artefact IS on the classpath here (the test ns
   requires `re-frame.machines`, which fires the late-bind hook
@@ -16,19 +15,18 @@
   assertion, then restore it in `finally`. Identical mechanism as the
   test would use on CLJS.
 
-  Per Spec 002 §The late-bind seam, rf2-xbtj (machines split), and the
-  prose at the call sites in `re-frame.core`.
+  Per Spec 002 §The late-bind seam and the prose at the call sites in
+  `re-frame.core`.
 
-  Note (rf2-wad2fl — front-porch shrink): the ONLY machine surface that
-  remains on the `re-frame.core` façade is the `reg-machine` /
-  `defmachine` registration MACRO (source-coord capture; no owned-ns
-  macro form), so the façade missing-artefact contract is tested here for
-  `reg-machine` only. The fn surfaces (`reg-machine*`, `make-machine-
-  handler`, `machine-transition`) and the read-only query surfaces
-  (`machines`, `machine-meta`, `machine-by-system-id`) were demoted off
-  the façade — they are reached through `re-frame.machines` (the owned
-  namespace; requiring it means the artefact is present, so the façade
-  artefact-missing contract no longer applies to them)."
+  The ONLY machine surface on the `re-frame.core` façade is the
+  `reg-machine` / `defmachine` registration MACRO (source-coord capture;
+  no owned-ns macro form), so the façade missing-artefact contract is
+  tested here for `reg-machine` only. The fn surfaces (`reg-machine*`,
+  `make-machine-handler`, `machine-transition`) and the read-only query
+  surfaces (`machines`, `machine-meta`, `machine-by-system-id`) live on
+  `re-frame.machines` (the owned namespace; requiring it means the
+  artefact is present, so the façade artefact-missing contract does not
+  apply to them)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]
@@ -61,7 +59,7 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "reg-machine throws when the machines artefact is absent")
-          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; The message is the human :reason + trailing
           ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
           ;; not exact keyword-equality.
           (is (re-find #"\[:rf\.error/machines-artefact-missing\]" (.getMessage thrown))
@@ -69,11 +67,11 @@
           (is (= :rf.error/machines-artefact-missing (:rf.error/id (ex-data thrown)))
               "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
-            ;; Per rf2-hoiu the throw lives in
+            ;; The throw lives in
             ;; `re-frame.core-machines/reg-machine` — the sibling-namespace
-            ;; fn-form delegate the macro routes through. Per rf2-j8icl
-            ;; the `:where` symbol is namespace-qualified to the user-
-            ;; facing surface (`rf/reg-machine`).
+            ;; fn-form delegate the macro routes through. The `:where` symbol
+            ;; is namespace-qualified to the user-facing surface
+            ;; (`rf/reg-machine`).
             (is (= 'rf/reg-machine (:where data))
                 "ex-data carries :where = 'rf/reg-machine")
             (is (= :probe/macro-machine (:machine-id data))

--- a/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
+++ b/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
@@ -1,6 +1,5 @@
 (ns re-frame.lifecycle-composed-corners-test
-  "Per rf2-6txsp — compose rare machine timer / join / final / system-id
-  interleavings.
+  "Compose rare machine timer / join / final / system-id interleavings.
 
   Existing per-edge regression coverage (`timer_frame_scope_test`,
   `after_test`, `spawn_all_test`, `final_state_cljs_test`,
@@ -377,9 +376,9 @@
           "precondition: spawned actor snapshot is live"))
     (is (pos? (count (spawn-order/frame-order :corner.leak/scoped)))
         "precondition: spawn-order channel has entries")
-    ;; Per rf2-a2sn1 — a spawned actor carries NO per-instance registrar
-    ;; entry; its liveness is its snapshot's presence in app-db (asserted
-    ;; live above). The registrar precondition is therefore inverted.
+    ;; A spawned actor carries NO per-instance registrar entry; its
+    ;; liveness is its snapshot's presence in app-db (asserted live above).
+    ;; The registrar precondition is therefore inverted.
     (is (nil? (registrar/lookup :event :corner.leak/child#1))
         "precondition: spawned actor has no per-instance registrar entry (liveness lives in its app-db snapshot)")
 

--- a/implementation/machines/test/re_frame/machine_actor_concurrency_stress_test.clj
+++ b/implementation/machines/test/re_frame/machine_actor_concurrency_stress_test.clj
@@ -1,14 +1,14 @@
 (ns re-frame.machine-actor-concurrency-stress-test
-  "Per rf2-1gpx8 — JVM concurrency stress coverage for the machine actor
-  spawn/destroy/invoke lifecycle. Mirrors rf2-35rgj's router concurrency
+  "JVM concurrency stress coverage for the machine actor
+  spawn/destroy/invoke lifecycle. Mirrors the router concurrency
   stress pattern (`concurrency_stress_test.clj`) but targets the actor
   surface instead of the router.
 
   The deterministic machine-test suite covers correctness single-shot;
   this namespace pins the actor surface under parallel
   `(rf/dispatch [machine-id ...] {:frame F})` from many threads. The
-  invariants are the same as rf2-35rgj's: **no event dropped** and **no
-  double-action**.
+  invariants are the same as the router stress test's: **no event dropped**
+  and **no double-action**.
 
   The shape — per Spec 005 §Declarative `:spawn` + Spec 002 §Rules
   rule 1 (frames are independent state machines, their drain-locks don't
@@ -29,7 +29,7 @@
       one shared `worker-mid` would only bind the last closure.
         1. `(rf/dispatch-sync [driver-mid [:go]]   {:frame F})` —
            drives the parent into `:working`, which spawns the worker
-           via `:rf.machine/spawn` fx (rf2-t07u — runtime tracks the
+           via `:rf.machine/spawn` fx (the runtime tracks the
            spawned id at `[:rf.runtime/machines :spawned <driver-mid> [:working]]`).
         2. `(rf/dispatch-sync [<actor-id> [:tick]] {:frame F})` —
            dispatches a `:tick` event AT THE SPAWNED ACTOR. The
@@ -57,20 +57,19 @@
     3. **Clean destroy lifecycle.** Every frame's
        `[:rf.runtime/machines :snapshots]` slot MUST be empty at
        quiescence — every worker spawned was destroyed, no actor
-       leaked. Per rf2-t07u Option A revised the
-       `[:rf.runtime/machines :spawned ...]` slot is lazy-allocation
-       pruned and MUST be absent.
+       leaked. The `[:rf.runtime/machines :spawned ...]` slot is
+       lazy-allocation pruned and MUST be absent.
 
     4. **Spawn-counter monotonicity.** Each frame's parent-snapshot
        slot `[:rf.runtime/machines :snapshots <driver-mid> :rf/spawn-counter <worker-mid>]`
        MUST equal `iters` at the end — every iter allocated exactly
-       one fresh worker id from the parent's in-snapshot counter
-       (rf2-gr8q), never colliding, never skipping.
+       one fresh worker id from the parent's in-snapshot counter,
+       never colliding, never skipping.
 
   Threads start in lockstep via `CountDownLatch.countDown` — the same
-  shape rf2-35rgj scenario 2 uses to maximise contention. Per-thread
-  iters default to 5000 (rf2-ynk7 / rf2-35rgj standard); env-overridable
-  via `RF2_1GPX8_STRESS_ITERS`.
+  shape the router stress test's scenario 2 uses to maximise contention.
+  Per-thread iters default to 5000; env-overridable via
+  `RF2_1GPX8_STRESS_ITERS`.
 
   CLJS is single-threaded; the JVM is the only runtime where the actor
   spawn/destroy lifecycle CAN race across threads. This test is
@@ -94,15 +93,15 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; Per-thread iteration count. Kept at the rf2-ynk7 / rf2-35rgj standard
-;; 5000 so CI stays under ~60s wall-clock with the default thread count.
+;; Per-thread iteration count. Kept at the standard 5000 so CI stays under
+;; ~60s wall-clock with the default thread count.
 ;; Operators dial up via the env override; CI dials down by lowering it
 ;; (e.g. `RF2_1GPX8_STRESS_ITERS=500` for a smoke-test pass).
 (def ^:private stress-iters
   (or (some-> (System/getenv "RF2_1GPX8_STRESS_ITERS") Long/parseLong)
       5000))
 
-;; Eight parallel threads — matches rf2-ynk7's `concurrent-dispatch-stress`
+;; Eight parallel threads — matches the `concurrent-dispatch-stress`
 ;; (`n-submitters 8`). Higher contention than the typical 4-core CI box;
 ;; the per-frame partitioning means we're not over-saturating any one
 ;; drain-lock, we're driving N independent spawn/destroy cycles in
@@ -140,7 +139,7 @@
   entry to `:working` and destroys it on exit. Per Spec 005
   §Declarative `:spawn` the runtime tracks the spawned id at
   `[:rf.runtime/machines :spawned <driver-mid> [:working]]`; on exit back to `:idle` the
-  matched destroy fx fires automatically (rf2-t07u Option A revised)."
+  matched destroy fx fires automatically."
   [worker-mid]
   {:initial :idle
    :states  {:idle    {:on {:go :working}}
@@ -150,9 +149,9 @@
 ;; ---- the stress test ------------------------------------------------------
 
 (deftest ^:stress actor-spawn-dispatch-destroy-stress
-  ;; rf2-1gpx8 — mirrors rf2-35rgj's pattern for the machine actor surface.
+  ;; Mirrors the router stress test's pattern for the machine actor surface.
   ;;
-  ;; The two pinned invariants are the same as rf2-35rgj's: every
+  ;; The two pinned invariants are the same as the router stress test's: every
   ;; dispatched event ran exactly once (no drops) and every transition
   ;; fired exactly once per dispatch (no doubles). Two distinct counter
   ;; views (per-thread atom + global AtomicLong) detect them
@@ -201,9 +200,8 @@
                             (rf/dispatch-sync [driver-mid [:go]]
                                               {:frame frame-id})
                             ;; Resolve the spawned actor id from the
-                            ;; runtime-owned registry (rf2-t07u Option A
-                            ;; revised — the framework writes the slot
-                            ;; on every declarative-:spawn spawn).
+                            ;; runtime-owned registry (the framework writes
+                            ;; the slot on every declarative-:spawn spawn).
                             ;; Reading the frame's app-db is safe: frame
                             ;; state is independent (Spec 002 §Rules
                             ;; rule 1) and this thread holds the only
@@ -223,8 +221,8 @@
         ;; Bounded join — if the cycle ever hangs (e.g. a destroy fx
         ;; that doesn't fire under contention), we want a visible
         ;; failure rather than a stuck CI run. 120s gives ample
-        ;; headroom for 8 × 5000 cycles on a slow box; pre-fix races
-        ;; that drop events would surface as either a counter
+        ;; headroom for 8 × 5000 cycles on a slow box; a race
+        ;; that drops events surfaces as either a counter
         ;; mismatch OR a future hanging at a downstream dispatch.
         (doseq [f futures]
           (let [v (deref f 120000 ::timeout)]
@@ -279,15 +277,14 @@
                 (str "Frame " frame-id ": expected zero leaked worker "
                      "actor snapshots; got " (count worker-leaks)
                      " leaks: " (pr-str (mapv first worker-leaks))))
-            ;; Per rf2-t07u the empty `[:rf.runtime/machines :spawned]`
-            ;; slot is pruned to absent — all spawn-registry slots were
-            ;; cleared on destroy.
+            ;; The empty `[:rf.runtime/machines :spawned]` slot is pruned to
+            ;; absent — all spawn-registry slots were cleared on destroy.
             (is (not (contains? (get-in db [:rf.runtime/machines]) :spawned))
                 (str "Frame " frame-id ": [:rf.runtime/machines :spawned] "
                      "slot must be lazy-allocation pruned (every spawn "
                      "was matched by a destroy); got "
                      (pr-str (get-in db [:rf.runtime/machines :spawned]))))
-            ;; Per rf2-gr8q the declarative-:spawn allocator lives in
+            ;; The declarative-:spawn allocator lives in
             ;; the parent's snapshot at
             ;; `[:rf.runtime/machines :snapshots <driver-mid> :rf/spawn-counter <worker-mid>]`
             ;; — the spawn-counter bumps inside the transition reducer

--- a/implementation/machines/test/re_frame/machine_after_timer_fresh_causal_token_test.clj
+++ b/implementation/machines/test/re_frame/machine_after_timer_fresh_causal_token_test.clj
@@ -1,7 +1,5 @@
 (ns re-frame.machine-after-timer-fresh-causal-token-test
-  "Per EP-0010 §Dispatch Envelope Stamping + Spec 002 §The World-Input Rule
-  (rf2-hg39nf — the one previously-uncovered EP-0010 gap flagged by the
-  rf2-we6i51 coverage review).
+  "Per EP-0010 §Dispatch Envelope Stamping + Spec 002 §The World-Input Rule.
 
   THE CONTRACT. A machine `:after` timer fires a synthetic
   `[<parent-id> [:rf.machine.timer/after-elapsed ...]]` dispatch back into
@@ -31,7 +29,7 @@
   the `after-elapsed` dispatch opts) would pass every existing test. This
   test fails on exactly that regression.
 
-  THE RECIPE (rf2-hg39nf notes — adversarial clock separation).
+  THE RECIPE (adversarial clock separation).
     1. Stub `interop/schedule-after!` to CAPTURE the timer-callback thunk
        (rather than scheduling it on the host clock) so the test owns the
        fire boundary deterministically.

--- a/implementation/machines/test/re_frame/machine_after_timer_restore_quiesce_test.clj
+++ b/implementation/machines/test/re_frame/machine_after_timer_restore_quiesce_test.clj
@@ -1,6 +1,5 @@
 (ns re-frame.machine-after-timer-restore-quiesce-test
-  "rf2-u5kmf8 — epoch-restore host-transient quiesce for machine `:after`
-  timers.
+  "Epoch-restore host-transient quiesce for machine `:after` timers.
 
   Epoch restore installs the captured durable frame-state (the machine
   snapshots in runtime-db) WHOLESALE, so timer LIVENESS reverts atomically —
@@ -14,7 +13,7 @@
   `:machines/on-frame-restored!` late-bind hook the epoch restore boundary
   consults) is the restore counterpart of the `:on-frame-destroy` cleanup —
   it releases the restored frame's orphaned `:after` host handles eagerly and
-  emits one `:rf.machine.timer/cancelled` trace per entry with the new
+  emits one `:rf.machine.timer/cancelled` trace per entry with
   `:reason :on-restore` (Managed-Effects §restore: \"epoch restore MUST NOT
   revive host work\")."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]

--- a/implementation/machines/test/re_frame/machine_algebra_view_test.clj
+++ b/implementation/machines/test/re_frame/machine_algebra_view_test.clj
@@ -1,8 +1,7 @@
 (ns re-frame.machine-algebra-view-test
-  "Tests for the derivation/process algebra view of machines (EP-0014
-  slice-6, rf2-2axssk). Per [spec/Derivations.md] §Machines expose algebra
-  views (graduated from EP-0014) and the `:rf/derivation-node` shape in
-  [spec/Spec-Schemas.md].
+  "Tests for the derivation/process algebra view of machines. Per
+  [spec/Derivations.md] §Machines expose algebra views and the
+  `:rf/derivation-node` shape in [spec/Spec-Schemas.md].
 
   `re-frame.machines.tooling/machine-algebra-view` lowers every registered
   machine into the normalized algebra node every declared fact/process
@@ -15,7 +14,7 @@
   actor). `…/machine-selector?` recognizes a sub that reads a machine snapshot;
   `…/machine-selector-targets` extracts the SET of machine ids that selector
   reads (so a graph tool draws the `:selector` edge to the SPECIFIC machine,
-  never the cross product — rf2-4qmiij).
+  never the cross product).
 
   These tests pin the registrar-derived projection: the fixed classifications
   (`:kind` / `:storage` / `:lifecycle` / `:materialized?`), the declared
@@ -24,11 +23,11 @@
   output snapshot path, the `:owner` / `:spawns?`, the source-form metadata,
   and the live spawned-actor projection.
 
-  Slice-6 ships NO public accessor (EP-0014 issue-1 disposition): the views
-  live in the bundle-isolated `re-frame.machines.tooling` sibling, reached on
-  JVM through the `re-frame.machines/machine-*` convenience aliases, and
-  consumed by Xray + the conformance fixtures. There is no
-  `re-frame.core/machine-algebra-view` public facade export."
+  There is NO public accessor: the views live in the bundle-isolated
+  `re-frame.machines.tooling` sibling, reached on JVM through the
+  `re-frame.machines/machine-*` convenience aliases, and consumed by Xray +
+  the conformance fixtures. There is no `re-frame.core/machine-algebra-view`
+  public facade export."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
@@ -306,7 +305,7 @@
     (is (false? (mtooling/machine-selector? :plain/sub)))
     (is (false? (mtooling/machine-selector? :nope/missing)))))
 
-;; ---- machine-selector-targets extractor (rf2-4qmiij) ---------------------
+;; ---- machine-selector-targets extractor ----------------------------------
 
 (deftest machine-selector-targets-extractor
   (testing "extracts the target machine id from a [:rf/machine machine-id] selector"

--- a/implementation/machines/test/re_frame/machine_cascade_instrumentation_test.cljc
+++ b/implementation/machines/test/re_frame/machine_cascade_instrumentation_test.cljc
@@ -1,12 +1,11 @@
 (ns re-frame.machine-cascade-instrumentation-test
-  "Per rf2-n9f4z — the `:rf.machine/transition` trace carries a structured
-  `:cascade` field: the ordered exit / transition-action / entry steps (+
-  initial-descent + `:always` microsteps + per-region structure) that
-  explain HOW a transition reached its after-state, so tooling (Xray's
-  epoch panel — rf2-52u5n) can render the cascade rather than only
-  `{from}->{to} + {n} microstep(s)`.
+  "The `:rf.machine/transition` trace carries a structured `:cascade` field:
+  the ordered exit / transition-action / entry steps (+ initial-descent +
+  `:always` microsteps + per-region structure) that explain HOW a transition
+  reached its after-state, so tooling (Xray's epoch panel) can render the
+  cascade rather than only `{from}->{to} + {n} microstep(s)`.
 
-  The cascade step shape (the contract rf2-52u5n renders) is a vector of
+  The cascade step shape (the contract tooling renders) is a vector of
   self-describing step maps in execution order:
 
     {:kind   :exit | :action | :entry | :microstep
@@ -18,15 +17,10 @@
   `:microstep` steps add `:microstep-index` / `:from` / `:to` / `:steps`
   (the microstep's own nested exit/action/entry cascade).
 
-  RED before this bead: the only fields on `:rf.machine/transition` were
-  `{:machine-id :event :before :after :microsteps}` — `:cascade` was
-  absent, so tooling could not explain the entry/exit cascade.
-
   The HVAC fixture mirrors the live machine-epochs testbed
   (`:hvac/controller`) whose own `:data :trail` records the cascade order
   — that trail is the ORACLE these tests cross-check the emitted cascade
-  against (the trail exists only because the framework did not expose this;
-  this bead removes the need for it)."
+  against."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines.test-support :as mtest]
@@ -35,7 +29,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; Routed through the shared `mtest/with-trace-capture`
 ;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
   (mtest/with-trace-capture seen

--- a/implementation/machines/test/re_frame/machine_cofx_attach_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_attach_test.clj
@@ -1,7 +1,7 @@
 (ns re-frame.machine-cofx-attach-test
-  "Per EP-0017 slice-B.9 (rf2-mjmxgb) — machine consumer attachment.
+  "Machine consumer attachment.
 
-  Covers the three slice-B.9 pieces and their adversarial corners:
+  Covers the three pieces and their adversarial corners:
 
     1. INLINE-FN RESTRICTION — `:rf.cofx/requires` may live ONLY on a named
        `:guards` / `:actions` entry map. An inline declaration (on an `:on`
@@ -183,7 +183,7 @@
           "the ensure-set for [:go] at :idle includes the :always-closure
            fact reachable through the :pending target"))))
 
-;; ---- multi-hop :always chain (rf2-h9gwkx) ---------------------------------
+;; ---- multi-hop :always chain ---------------------------------------------
 ;;
 ;; The single-hop cases above reach an :always one hop from the candidate
 ;; target. The runtime, however, settles :always to a MULTI-HOP fixed point
@@ -191,9 +191,9 @@
 ;; runs ONCE before that macrostep (registration/ensure-ctx-cofx). A
 ;; :rf.cofx/requires declared on an :always guard/action reached at chain
 ;; depth >=2 (A --go--> B, B :always--> C, C :always {:guard g-requiring-cofx})
-;; must therefore be ensured up front; before rf2-h9gwkx the static closure
-;; chased only ONE :always hop, so the depth>=2 fact was silently un-ensured
-;; (the guard read nil with no missing-required throw — replay-nondeterminism).
+;; is ensured up front: the static closure chases the :always chain to a
+;; fixed point, so the depth>=2 fact is in the ensure-set (the guard reads
+;; the ensured value, never a silent nil) — preserving replay-determinism.
 
 (deftest ensure-set-for-follows-multi-hop-always-chain
   (testing "white-box: ensure-set-for chases :always targets to a FIXED POINT,
@@ -280,10 +280,9 @@
              (:rf.error/id (ex-data e)))
           "the depth>=2 :always-required provided fact, absent, throws
            missing-required (it WAS in the ensure-set) — not a silent nil")
-      ;; counter-check: before rf2-h9gwkx the depth>=2 fact was DROPPED from
-      ;; the ensure-set (one-hop closure), so this would have been an empty
-      ;; ensure-set → no-op → the guard later reads nil silently. Confirm the
-      ;; fact is now present in the derived set (the positive of the throw).
+      ;; counter-check: confirm the depth>=2 fact is present in the derived
+      ;; ensure-set (the positive of the throw) — the closure reaches it, so
+      ;; it is never dropped to a silent-nil read.
       (is (contains? (set (map :id (cofx-attach/ensure-set-for
                                      m {:state :a :data {}} [:go])))
                      :rf/time-ms)
@@ -385,16 +384,16 @@
           "the pure engine runs without a token and without an ensure error"))))
 
 ;; ===========================================================================
-;; PARALLEL ROOT :on / :after in the ensure-set (rf2-bu106a)
+;; PARALLEL ROOT :on / :after in the ensure-set
 ;; ===========================================================================
 ;;
-;; The parallel branch of `ensure-set-for` unioned each REGION's scope only —
-;; the parallel ROOT's own `:on` / `:after` (live ancestor-fallback transition
+;; The parallel branch of `ensure-set-for` unions each REGION's scope AND the
+;; parallel ROOT's own `:on` / `:after` (live ancestor-fallback transition
 ;; surfaces the runtime evaluates separately via `transition/root-on-match` /
-;; `root-after-match`) were dropped. A coeffect declared by a root `:on` /
-;; root `:after` guard/action was therefore never ensured before selection, so
-;; the guard/action silently read nil (or skipped the missing-required throw).
-;; These tests prove the root surfaces now contribute to the ensure-set.
+;; `root-after-match`). A coeffect declared by a root `:on` / root `:after`
+;; guard/action is therefore ensured before selection, so the guard/action
+;; reads the ensured value (or surfaces the missing-required throw).
+;; These tests prove the root surfaces contribute to the ensure-set.
 ;;
 ;; XState-v5 alignment: a transition (`on`) or delayed transition (`after`)
 ;; declared on a `<parallel>` node is a first-class ancestor fallback (Spec 005

--- a/implementation/machines/test/re_frame/machine_cofx_lifecycle_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_lifecycle_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.machine-cofx-lifecycle-test
-  "EP-0017 slice-B.9 — cofx ensure-set coverage for ENTRY / EXIT lifecycle
-  actions + the bootstrap/birth path (rf2-knxbok).
+  "Cofx ensure-set coverage for ENTRY / EXIT lifecycle actions + the
+  bootstrap/birth path.
 
   Spec 005's EP-0017 section says a `:guard` / `:action` / `:entry` / `:exit`
   callback that depends on host facts must read DECLARED recordable coeffects,
@@ -9,16 +9,14 @@
   referenced by keyword from an `:entry` / `:exit` slot, the ONLY legal way for
   a lifecycle boundary action to consume a recordable fact.
 
-  The dispatch-time ensure-set previously unioned only candidate transition
-  `:guard` / `:action` diets and the `:always` guard/action closure diets — it
-  NEVER added the `:actions` diet for the active-state `:exit` refs or the
-  target-state `:entry` refs the exit→action→entry cascade runs. And the
-  bootstrap initial-entry / birth `:entry` actions ran inside `maybe-boot`
-  BEFORE the ensure step was reached at all. So a named `:entry` / `:exit`
-  action declaring a generator-backed or provided recordable fact read nil / an
-  unensured token instead of getting the EP-0017 behaviour (generate-and-write-
-  back in live mode; missing-required in strict/replay) — a replay/determinism
-  hole.
+  The dispatch-time ensure-set unions the candidate transition `:guard` /
+  `:action` diets, the `:always` guard/action closure diets, AND the
+  `:actions` diet for the active-state `:exit` refs and the target-state
+  `:entry` refs the exit→action→entry cascade runs. The bootstrap
+  initial-entry / birth `:entry` actions are ensured before `maybe-boot`
+  runs the cascade. So a named `:entry` / `:exit` action declaring a
+  generator-backed or provided recordable fact gets the EP-0017 behaviour
+  (generate-and-write-back in live mode; missing-required in strict/replay).
 
   These tests pin BOTH the white-box ensure-set derivation (`ensure-set-for`)
   and the end-to-end live behaviour (the generated value lands in the action's

--- a/implementation/machines/test/re_frame/machine_cofx_mint_policy_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_mint_policy_test.clj
@@ -1,24 +1,25 @@
 (ns re-frame.machine-cofx-mint-policy-test
-  "Regression coverage for three EP-0017 machine cofx-correctness fixes:
+  "Coverage for two machine cofx-correctness contracts:
 
-    1. rf2-n0myjq — the machine consumer-attachment ensure path must mint
-       under the EFFECTIVE mint policy (per-call opt ▸ frame config ▸ `:live`),
-       not the hard-wired `:live` default. Under `:strict` (replay / the `:test`
-       preset) a declared-absent generator-backed guard/action fact is
-       `:rf.error/missing-required-cofx`, NEVER freshly minted; `:explicit-live`
-       opts back into generation.
+    1. The machine consumer-attachment ensure path mints under the
+       EFFECTIVE mint policy (per-call opt ▸ frame config ▸ `:live`). Under
+       `:strict` (replay / the `:test` preset) a declared-absent
+       generator-backed guard/action fact is
+       `:rf.error/missing-required-cofx`, NEVER freshly minted;
+       `:explicit-live` opts back into generation.
 
-    2. rf2-xsdn5h — a same-macrostep RAISED internal event (`[:raise <event>]`,
-       including synthetic compound / parallel `:on-done` signals) must have its
+    2. A same-macrostep RAISED internal event (`[:raise <event>]`,
+       including synthetic compound / parallel `:on-done` signals) has its
        selected transition's named guard/action `:rf.cofx/requires` ensured
        BEFORE selection, under the same mint policy. The external event's
-       ensure-set (run once before the macrostep) never covered a guard/action a
-       raise can reach, so without the in-engine re-ensure a generator-backed
-       fact read nil and a provided fact skipped the missing-required error.
+       ensure-set runs once before the macrostep and does not cover a
+       guard/action a raise can reach, so the engine re-ensures in-drain — a
+       generator-backed fact is minted and a provided-but-absent fact raises
+       missing-required rather than being read as nil.
 
   These drive the REAL dispatch path (`rf/dispatch-sync` through the live
-  machine handler + transition engine), so a red→green proves the actual failing
-  path, not a routed-around green."
+  machine handler + transition engine), so the test hits the actual path,
+  not a routed-around green."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
@@ -33,7 +34,7 @@
 (def ^:private SCRIPTED-TIME-MS 1234500000)
 
 ;; ===========================================================================
-;; rf2-n0myjq — the ensure path honours the effective mint policy
+;; the ensure path honours the effective mint policy
 ;; ===========================================================================
 
 (deftest strict-ensure-refuses-to-mint-guard-fact-throws
@@ -171,7 +172,7 @@
           "default :live minted the birth :entry fact"))))
 
 ;; ===========================================================================
-;; rf2-xsdn5h — raised-event transitions get their cofx ensured
+;; raised-event transitions get their cofx ensured
 ;; ===========================================================================
 
 (deftest raised-user-event-guard-fact-ensured
@@ -296,7 +297,7 @@
           "both regions advanced: :left on :go, :right on the ensured :inner"))))
 
 ;; ===========================================================================
-;; rf2-x9haxl — wrote-db `:offending-value` redacted at egress
+;; wrote-db `:offending-value` redacted at egress
 ;; ===========================================================================
 
 (deftest wrote-db-offending-value-redacted-at-egress

--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -1,22 +1,23 @@
 (ns re-frame.machine-data-schema-redaction-test
-  "EP-0025 (rf2-398kql) — machine `:data` trace-egress redaction via FRAME-
-  DECLARED classification (the frame-owned sole app-db mechanism).
+  "Machine `:data` trace-egress redaction via FRAME-DECLARED classification
+  (the frame-owned sole app-db mechanism).
 
-  Machine `:data` validation ships separately (rf2-jbbp7): a `:data-schema`
-  Malli form validates the machine's `:data` slot, and the validation-failure
-  trace routes its value slots through the schema-aware redactor — UNCHANGED by
-  EP-0025. What this file pins is *snapshot* egress: a machine `:data` slot is
-  redacted in the `:before` / `:after` / `:snapshot` / `:data` / `:input` /
-  `:cascade` slots of `:rf.machine/*` traces when the FRAME declares its
-  runtime-db snapshot path sensitive / large.
+  Machine `:data` validation ships separately: a `:data-schema` Malli form
+  validates the machine's `:data` slot, and the validation-failure trace
+  routes its value slots through the schema-aware redactor. What this file
+  pins is *snapshot* egress: a machine `:data` slot is redacted in the
+  `:before` / `:after` / `:snapshot` / `:data` / `:input` / `:cascade` slots
+  of `:rf.machine/*` traces when the FRAME declares its runtime-db snapshot
+  path sensitive / large.
 
-  EP-0025 REVERSES the EP-0005 schema→marks bridge: a `:sensitive?` / `:large?`
-  Malli prop on a `:data-schema` slot NO LONGER classifies durable `:data` for
-  egress. Instead the frame declares the machine snapshot's `:data` path via
-  `reg-frame` `:sensitive` / `:large {:app-db …}` (the absolute runtime-db path
+  Classification of durable `:data` for egress is frame-owned: the frame
+  declares the machine snapshot's `:data` path via `reg-frame`
+  `:sensitive` / `:large {:app-db …}` (the absolute runtime-db path
   `[:rf.runtime/machines :snapshots <actor-id> :data …]`); the trace egress
-  chokepoint re-roots that snapshot-relative (`marks/frame-snapshot-marks`) and
-  redacts the matching slot.
+  chokepoint re-roots that snapshot-relative (`marks/frame-snapshot-marks`)
+  and redacts the matching slot. A `:sensitive?` / `:large?` Malli prop on a
+  `:data-schema` slot is VALIDATION ONLY and does not classify durable
+  `:data` for egress.
 
   The contract under test:
 
@@ -27,12 +28,12 @@
    2. **Precision.** An undeclared sibling slot rides egress verbatim; a
       machine whose frame declares nothing rides every `:data` slot raw.
 
-   3. **Schema props do NOT classify (EP-0025 reversal).** A `:data-schema`
-      `:sensitive?` slot does NOT, by itself, redact durable `:data` at
-      snapshot egress — only the frame-declared path does.
+   3. **Schema props do NOT classify.** A `:data-schema` `:sensitive?` slot
+      does NOT, by itself, redact durable `:data` at snapshot egress — only
+      the frame-declared path does.
 
    4. **No top-level machine classification key.** A top-level `:sensitive` /
-      `:large` key on a `reg-machine` spec is ignored (rf2-0k5ubx)."
+      `:large` key on a `reg-machine` spec is ignored."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             ;; Loading the machines artefact publishes its late-bind hooks
@@ -41,7 +42,7 @@
             [re-frame.marks :as marks]
             [re-frame.machines.test-support :as mtest]
             ;; The schemas artefact + Malli adapter — `:data-schema` VALIDATION
-            ;; still runs; the props just no longer classify durable :data.
+            ;; runs; the props do not classify durable :data.
             [re-frame.schemas]
             [re-frame.schemas.malli]
             [re-frame.substrate.plain-atom :as plain-atom]))
@@ -54,9 +55,10 @@
 (def ^:private auth-id :rf.machine-redaction/auth)
 
 (def ^:private auth-schema
-  "A `:data-schema` — VALIDATION ONLY (EP-0025: per-slot props no longer
-  classify). It still carries `:sensitive?` / `:large?` props to PROVE they
-  do not classify durable `:data` at snapshot egress (test (3))."
+  "A `:data-schema` is VALIDATION ONLY: per-slot props do not classify durable
+  `:data` for snapshot egress; frame-declared paths are the sole egress
+  mechanism. It carries `:sensitive?` / `:large?` props to PROVE they do not
+  classify durable `:data` at snapshot egress (test (3))."
   [:map
    [:retries :int]
    [:token   {:sensitive? true} [:maybe :string]]
@@ -169,7 +171,7 @@
       (is (= :rf/redacted (get-in out [:tags :snapshot :data :token])))
       (is (not (.contains (pr-str out) "secret-jwt-snap"))))))
 
-;; ---- (2b) FULL machine :data slot coverage (rf2-20d6k2) -------------------
+;; ---- (2b) FULL machine :data slot coverage -------------------------------
 
 (deftest started-data-slot-redacted-in-egress
   (testing ":rf.machine/started carries the booted snapshot's :data MAP
@@ -285,7 +287,7 @@
       (is (= "not-secret" (get-in out [:tags :data :token]))
           "no frame declaration → :data slot verbatim"))))
 
-;; ---- (2c) :actor-id PREFERRED-branch coverage (rf2-sxmeqs) ----------------
+;; ---- (2c) :actor-id PREFERRED-branch coverage ----------------------------
 
 (deftest sensitive-slot-redacted-in-egress-actor-id
   (testing "an :actor-id-keyed transition (the PREFERRED lookup branch
@@ -318,8 +320,8 @@
           "redacted via the PREFERRED :actor-id (declared), not the :machine-id sibling")
       (is (not (.contains (pr-str out) "secret-jwt"))))))
 
-;; ---- (3) EP-0025 reversal: a :data-schema :sensitive? prop does NOT --------
-;;          classify durable :data at snapshot egress.
+;; ---- (3) a :data-schema :sensitive? prop does NOT classify durable :data --
+;;          at snapshot egress.
 
 (deftest schema-sensitive-prop-does-not-classify-durable-data
   (testing "EP-0025 reversal — a :data-schema :sensitive? / :large? slot prop
@@ -337,14 +339,13 @@
           "a :large? :data-schema slot does NOT elide without a frame declaration"))))
 
 ;; ---- (4) NEGATIVE: a top-level machine :sensitive / :large key is NOT a ----
-;;          classification route (rf2-0k5ubx 2026-06-09; EP-0025).
+;;          classification route.
 ;;
-;; A considered proposal to add TOP-LEVEL machine `:sensitive` / `:large` keys
-;; (the spelling frames DO take) was REJECTED — `reg-machine` carries no such
-;; key. Per EP-0025 machine :data classification belongs on the FRAME. The
-;; validator walks only the grammar keys, so a top-level key is IGNORED (not
-;; rejected), and it feeds NO classification — a token under such a spec rides
-;; RAW at snapshot egress unless the FRAME declares it.
+;; `reg-machine` carries no TOP-LEVEL `:sensitive` / `:large` key (the
+;; spelling frames DO take). Machine :data classification belongs on the
+;; FRAME. The validator walks only the grammar keys, so a top-level key is
+;; IGNORED (not rejected), and it feeds NO classification — a token under such
+;; a spec rides RAW at snapshot egress unless the FRAME declares it.
 
 (deftest top-level-machine-sensitive-key-is-not-honoured
   (testing "a TOP-LEVEL :sensitive / :large key on a reg-machine spec is NOT a

--- a/implementation/machines/test/re_frame/machine_decl_path_default_test.clj
+++ b/implementation/machines/test/re_frame/machine_decl_path_default_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.machine-decl-path-default-test
-  "Per rf2-h16qii — `compute-cascade-paths`' default `:decl-path` is ROOT
-  (`[]`), not a depth-1 guess.
+  "`compute-cascade-paths`' default `:decl-path` is ROOT (`[]`), not a
+  depth-1 guess.
 
   `compute-cascade-paths` (reached via the public `apply-transition-once`)
   reads `(:decl-path transition <default>)` — the absolute path of the state
@@ -10,15 +10,15 @@
   re-entered\") is GATED on a NON-EMPTY decl-path (`(pos? (count decl-path))`),
   which deliberately excludes the synthetic ROOT.
 
-  The pre-fix default was `(vec (take 1 src-path))` — the FIRST element of the
-  active leaf's path, i.e. it assumed the transition was declared at DEPTH 1.
   Every in-tree caller stamps `:decl-path` (via `pick-transition` then
   `machine-transition-single`'s `(assoc :decl-path …)`), so the default is
   reached only by a pure-fn / hand-built / future caller of the public
-  `apply-transition-once`. For such a caller a ROOT-declared transition
-  (decl-path `[]`) on a deep machine was mis-located at `[<top>]` — a NON-empty
-  path that WRONGLY tripped `target-descendant-of-decl?`, diverging the LCA
-  geometry (the wrong exit / entry set).
+  `apply-transition-once`. For such a caller the ROOT default keeps a
+  ROOT-declared transition (decl-path `[]`) on a deep machine correctly
+  located at root: a depth-1 default (`(vec (take 1 src-path))`, the first
+  element of the active leaf's path) would mis-locate it at `[<top>]` — a
+  NON-empty path that WRONGLY trips `target-descendant-of-decl?`, diverging
+  the LCA geometry (the wrong exit / entry set).
 
   This is a pure-engine geometry test — it calls `apply-transition-once`
   directly with a transition map carrying NO `:decl-path`, so it exercises the
@@ -60,10 +60,10 @@
     ;; false (empty decl-path), so lca-len = common-prefix = 1 → exit :q,
     ;; enter :r, :s. CORRECT.
     ;;
-    ;; With the pre-fix depth-1 default (decl-path [:p]):
+    ;; With a depth-1 default (decl-path [:p]):
     ;; `target-descendant-of-decl?` would be TRUE ([:p] is a prefix of both
     ;; src and target), forcing lca-len = (dec (count [:p :r :s])) = 2 →
-    ;; exit set EMPTY (:q not exited) and only :s entered. BROKEN: :q would
+    ;; exit set EMPTY (:q not exited) and only :s entered. WRONG: :q would
     ;; stay on the active path while the machine dives to :s.
     (let [snapshot {:state [:p :q] :data {:log []}}
           ;; NB: no :decl-path key — exercises the default.

--- a/implementation/machines/test/re_frame/machine_depth_abort_failure_test.clj
+++ b/implementation/machines/test/re_frame/machine_depth_abort_failure_test.clj
@@ -1,24 +1,17 @@
 (ns re-frame.machine-depth-abort-failure-test
-  "Per rf2-y3jv8q — a bounded-depth abort (`:always` / `:raise` depth limit
-  tripped on a runaway cycle) surfaces as a FAILED macrostep, NOT a silent
-  benign no-op.
+  "A bounded-depth abort (`:always` / `:raise` depth limit tripped on a
+  runaway cycle) surfaces as a FAILED macrostep, NOT a silent benign no-op.
+  A runaway `a →:always b →:always a` cycle must be DISTINGUISHABLE from a
+  guard-blocked no-op (XState v5 THROWS on such a cycle).
 
-  Before this bead the depth-abort returned `(result/ok rollback-snapshot
-  [])` from the drain. `commit-or-finalize` then saw `next == snapshot` and
-  classified the macrostep a no-op: no `:rf.machine/transition` trace, NO
-  error routed through the handler return — only an out-of-band
-  `emit-error!`. A runaway `a →:always b →:always a` cycle was thus
-  INDISTINGUISHABLE from a guard-blocked no-op, and the triggering user
-  event was silently swallowed. XState v5 THROWS on such a cycle.
-
-  The fix returns a `result/fail` carrying the `::result/depth-abort?`
+  The depth-abort returns a `result/fail` carrying the `::result/depth-abort?`
   sentinel; it routes through the SAME failure path a thrown action takes
   (the handler short-circuits to `{}` — no snapshot write reaches
   runtime-db, so the atomic rollback Spec 005 §Bounded depth requires is
   preserved). The precise `:rf.error/machine-{always,raise}-depth-exceeded`
   category is emitted once at the abort site (the single trace for the
   trip); the engine does NOT additionally emit the benign
-  `:rf.machine.event/unhandled-no-op` — so the runaway is now DISTINGUISHABLE
+  `:rf.machine.event/unhandled-no-op` — so the runaway is DISTINGUISHABLE
   from a guard-blocked no-op.
 
   JVM-only — the dynamic-var listener path is platform-agnostic."
@@ -74,10 +67,10 @@
             "the depth-exceeded trace is error-grade (a failed macrostep)")
         (is (= :no-recovery (:recovery tr))
             "the trip is :no-recovery"))
-      ;; The CORE of the bug: a runaway cycle must NOT masquerade as the
-      ;; benign no-op a guard-blocked / unhandled event emits. Before the fix
-      ;; the abort returned an OK rollback snapshot and the runaway was
-      ;; indistinguishable from a guard-blocked no-op.
+      ;; The CORE contract: a runaway cycle must NOT masquerade as the
+      ;; benign no-op a guard-blocked / unhandled event emits — the abort
+      ;; surfaces as a failed macrostep, distinguishable from a
+      ;; guard-blocked no-op.
       (is (= 0 (count no-ops))
           "a runaway cycle is NOT a benign no-op — no unhandled-no-op fires")
       ;; Atomic rollback (Spec 005 §Bounded depth): the macrostep failed, so

--- a/implementation/machines/test/re_frame/machine_finality_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_finality_purity_test.clj
@@ -1,24 +1,21 @@
 (ns re-frame.machine-finality-purity-test
-  "Per rf2-vf5cf §G1. Direct pure-engine (JVM) coverage for the three
-  finality predicates the lifecycle handler recomputes at the macrostep
-  boundary to decide whether to fire `:on-done` + auto-destroy:
+  "Direct pure-engine (JVM) coverage for the three finality predicates the
+  lifecycle handler recomputes at the macrostep boundary to decide whether
+  to fire `:on-done` + auto-destroy:
 
     - `transition/final-state-node?` — the per-node `:final? true` flag.
     - `transition/final-on-leaf?`    — the active LEAF of a snapshot is final.
     - `finalize/all-regions-final?`  — a parallel machine is final iff
       EVERY region's active leaf is final.
 
-  Pre-rf2-vf5cf a grep of the machines test tree returned ZERO direct
-  matches for these symbols — they were exercised only TRANSITIVELY via
-  integration dispatch in `final_state_cljs_test.cljc`. The riskiest of
-  the three is the parallel union (`all-regions-final?`,
+  The riskiest of the three is the parallel union (`all-regions-final?`,
   finalize.cljc:69): a partial-final parallel snapshot (some regions
   final, some not) finalising prematurely would surface only as a
   downstream dispatch symptom, not a clean predicate failure. These
   tests pin the predicates at the cheapest-and-most-precise layer — pure
   fns of their arguments, no frame, no dispatch loop, no app-db.
 
-  Per Spec 005 §Final states (rf2-gn80):
+  Per Spec 005 §Final states:
     - `:final?` is a first-class state-node key (D1), NOT stashed under
       `:meta`.
     - A parallel-region machine is `:final?` only when EVERY region's
@@ -44,7 +41,7 @@
         ":final? false is explicitly not final")
     (is (false? (transition/final-state-node? {:on {:go :other}}))
         "an ordinary transition-bearing node is not final")
-    ;; Per Spec 005 rf2-gn80 D1 the flag is a FIRST-CLASS key. A truthy-
+    ;; Per Spec 005 D1 the flag is a FIRST-CLASS key. A truthy-
     ;; but-not-true value (e.g. stashed under :meta, or a non-boolean) is
     ;; NOT final — the predicate is `(true? ...)`, not `(boolean ...)`.
     (is (false? (transition/final-state-node? {:meta {:final? true}}))
@@ -106,7 +103,7 @@
 ;; ---------------------------------------------------------------------------
 ;; all-regions-final? — parallel union (finalize.cljc:69)
 ;;
-;; THE riskiest predicate (rf2-vf5cf §G1): a partial-final parallel
+;; THE riskiest predicate: a partial-final parallel
 ;; snapshot must NOT finalise. The fn returns true ONLY when the machine
 ;; is :type :parallel, the snapshot :state is a region→leaf map, AND every
 ;; region's active leaf is :final?.
@@ -183,14 +180,14 @@
           "a nested NON-final region leaf prevents finalisation"))))
 
 ;; ---------------------------------------------------------------------------
-;; all-regions-final? — declared-region KEY PARITY (bz0ox.2 / x4s9t.2)
+;; all-regions-final? — declared-region KEY PARITY
 ;;
-;; A partial parallel snapshot must NEVER vacuously read as all-final. Before
-;; the fix, `all-regions-final?` iterated only the regions PRESENT in the
-;; state-map, so a map missing a declared region (e.g. `{:left :done}` for a
-;; 2-region machine) passed `every?` over the one present-and-final region —
-;; reading true and (downstream) firing root :on-done / auto-destroy with a
-;; whole region absent.
+;; A partial parallel snapshot must NEVER vacuously read as all-final.
+;; `all-regions-final?` requires EXACT declared-region key parity, so a map
+;; missing a declared region (e.g. `{:left :done}` for a 2-region machine)
+;; reads false rather than passing `every?` over the one present-and-final
+;; region — which would otherwise read true and (downstream) fire root
+;; :on-done / auto-destroy with a whole region absent.
 ;; ---------------------------------------------------------------------------
 
 (deftest all-regions-final?-missing-region-is-not-final

--- a/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
+++ b/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machine-front-of-queue-test
-  "Per rf2-j20a7 / Spec 005 §Level 4 — end-to-end coverage that a REAL
+  "Per Spec 005 §Level 4 — end-to-end coverage that a REAL
   machine's continuation dispatch (`:fx [[:dispatch …]]` emitted from an
   action) leap-frogs to the FRONT of the router queue, while an event
   that merely TARGETS a machine but originates externally stays FIFO.

--- a/implementation/machines/test/re_frame/machine_history_smoke_test.clj
+++ b/implementation/machines/test/re_frame/machine_history_smoke_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.machine-history-smoke-test
-  "Minimal smoke for the first-class history ENGINE (rf2-mle6e.3). Drives the
+  "Minimal smoke for the first-class history ENGINE. Drives the
   pure `machine-transition` primitive directly (no frame / app-db) to prove
   record-on-exit + restore-on-re-entry work for the shapes the spec pins:
 
@@ -8,25 +8,25 @@
     - DEEP record/restore — records and restores the full leaf path.
     - DEFAULT-TARGET on first entry — nothing recorded yet → `:default-target`
       (or the compound's `:initial` when absent).
-    - DANGLING recorded path after hot reload (rf2-wgfv0 engine half) — a
-      recorded config the (reloaded) definition removed falls back to the
-      default, never entering the dead path; benign (no `:rf.error/*`).
+    - DANGLING recorded path after hot reload — a recorded config the
+      (reloaded) definition no longer declares falls back to the default,
+      never entering the dead path; benign (no `:rf.error/*`).
     - PER-REGION parallel history — recorded keys are region-qualified;
       restoring one region leaves siblings untouched.
     - SNAPSHOT REVERTIBILITY — `:rf/history` rides `pr-str` / `read-string`
       (it lives inside the snapshot value, like `:rf/machine-type`).
 
   The COMPREHENSIVE history suite (unit matrix + conformance restore
-  fixtures + the W3C-adapted corpus) is rf2-mle6e.4's job — this is only the
+  fixtures + the W3C-adapted corpus) lives elsewhere — this is only the
   engine-author's proof that record/restore is wired end-to-end.
 
   TRACE SHAPE — the `:rf.machine.history/restored` + `:rf.machine.history/
-  recorded` emits MUST match spec/009 §History trace events EXACTLY (the
-  tag-key catalogue owned by rf2-mle6e.2). The `*-trace-shape` tests below
-  capture the emitted events via a `re-frame.trace` listener and assert the
-  precise tag bags (`:compound-path` / `:kind` / `:source` / `:fallback` /
-  `:restored-config` / `:recorded-config` / `:prev-config` / `:resolved-leaf`)
-  + the cascade-step `:source` stamping (spec/009 line 291)."
+  recorded` emits MUST match spec/009 §History trace events EXACTLY. The
+  `*-trace-shape` tests below capture the emitted events via a `re-frame.trace`
+  listener and assert the precise tag bags (`:compound-path` / `:kind` /
+  `:source` / `:fallback` / `:restored-config` / `:recorded-config` /
+  `:prev-config` / `:resolved-leaf`) + the cascade-step `:source` stamping
+  (spec/009 line 291)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
@@ -34,7 +34,7 @@
 
 ;; ---- trace capture (spec/009 shape proof) --------------------------------
 ;;
-;; Trace capture via the shared machines test-support (rf2-3l8lqe finding #4):
+;; Trace capture via the shared machines test-support:
 ;; the `:each` `trace-capture-fixture` feeds `mtest/*captured*` with guaranteed
 ;; unregister in a `finally`; `events-of` / `reset-captured!` read + clear it.
 
@@ -57,7 +57,7 @@
     (result/snap r)))
 
 ;; A media-player chart whose `:playing` COMPOUND owns a DEEP history
-;; pseudo-state. Per the XState v5 / SCXML exit-set rule (rf2-9eidiv), only
+;; pseudo-state. Per the XState v5 / SCXML exit-set rule, only
 ;; a compound that is GENUINELY EXITED records history — so the history
 ;; owner must be a compound the transition leaves. Here `:stop` exits the
 ;; whole `:playing` subtree to its sibling `:stopped`, recording `:playing`'s
@@ -229,8 +229,8 @@
 
 ;; ---- spec/009 trace-shape proofs -----------------------------------------
 ;;
-;; These pin the EXACT tag bags spec/009 §History trace events declares — the
-;; reconcile target (rf2-mle6e.2 contract). They assert presence AND absence
+;; These pin the EXACT tag bags spec/009 §History trace events declares.
+;; They assert presence AND absence
 ;; (e.g. `:restored-config` absent on `:source :default`, `:fallback` absent
 ;; on `:source :recorded`, `:prev-config` absent on the first-ever recording).
 
@@ -374,13 +374,13 @@
       (is (empty? (history-events :rf.machine.history/restored))
           "no restored event for a non-history transition"))))
 
-;; ---- exit-set boundary regression (rf2-9eidiv) ---------------------------
+;; ---- exit-set boundary regression ----------------------------------------
 ;;
 ;; The XState v5 / SCXML exit-set rule: a history-owning compound records
 ;; ONLY when it is itself EXITED. A pure WITHIN-compound sibling move — where
-;; the history owner SURVIVES as the LCCA — records NOTHING. This was the OLD
-;; `<=` trigger (active-child-subtree teardown); the strict `<` gate retires
-;; it. This regression locks the boundary so it never silently slips back.
+;; the history owner SURVIVES as the LCCA — records NOTHING. The strict `<`
+;; gate enforces this boundary. This regression locks it so it never silently
+;; slips.
 
 ;; `:player` itself owns deep history; `:swap` moves between its two children
 ;; (:playing ↔ :stopped). `:player` is the LCA of that move — it SURVIVES (is

--- a/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.machine-history-unit-cljs-test
-  "Comprehensive UNIT matrix for the first-class history ENGINE (rf2-mle6e.3,
-  merged). The COMPLEMENT of `machine_history_smoke_test` — the smoke proved
+  "Comprehensive UNIT matrix for the first-class history ENGINE. The
+  COMPLEMENT of `machine_history_smoke_test` — the smoke proves
   record/restore is wired end-to-end; this suite pins the corners the spec
   (005 §History states + 009 §History trace events) enumerates and that the
   smoke leaves uncovered:
@@ -17,8 +17,8 @@
     - DEFAULT-TARGET fallback (no recording) — both with `:default-target`
       declared AND with it absent (the compound's `:initial`).
     - `:initial`-fallback when neither a recording nor a `:default-target`.
-    - DANGLING recorded path after hot-reload (rf2-wgfv0) falls back, never
-      enters the dead path, no `:rf.error/*`.
+    - DANGLING recorded path after hot-reload falls back, never enters the
+      dead path, no `:rf.error/*`.
     - PER-REGION parallel history at STRUCTURALLY-IDENTICAL region paths —
       region-qualified keys never collide; restoring one region is isolated.
     - SNAPSHOT REVERT (Goal 2) — the `:rf/history` slot is part of the
@@ -49,7 +49,7 @@
    [re-frame.machines.test-support :as mtest]))
 
 ;; ===========================================================================
-;; Harness — pure engine + trace capture (shared, rf2-3l8lqe finding #4)
+;; Harness — pure engine + trace capture (shared)
 ;; ===========================================================================
 ;;
 ;; Trace capture (register + guaranteed unregister, CLJ/CLJS-compatible) is
@@ -90,7 +90,7 @@
 ;;
 ;; The contrast intentionally records `:playing` as `:player`'s SHALLOW direct
 ;; child, so the owning compound (`:player`) must be GENUINELY EXITED for the
-;; shallow recording to fire (the XState v5 / SCXML exit-set rule, rf2-9eidiv).
+;; shallow recording to fire (the XState v5 / SCXML exit-set rule).
 ;; This uses the external-sibling shape (mirroring SCXML test388 `:s0 -> :away`):
 ;; `:leave` exits the whole `:player` subtree to a top-level sibling `:away`;
 ;; `:resume` re-enters via `[:player :hist]`.
@@ -253,7 +253,7 @@
           "missing :deep? records the direct child (shallow)"))))
 
 ;; ===========================================================================
-;; §5. DANGLING recorded path after hot-reload (rf2-wgfv0)
+;; §5. DANGLING recorded path after hot-reload
 ;;
 ;; A recorded config the (hot-reloaded) definition no longer declares is
 ;; discarded on restore — the runtime falls back, never enters the dead path.
@@ -444,16 +444,15 @@
             ":recorded-config = the value written by this exit")))))
 
 ;; ===========================================================================
-;; §9. EXIT-SET BOUNDARY (rf2-9eidiv) — the surviving-LCCA owner records NOTHING
+;; §9. EXIT-SET BOUNDARY — the surviving-LCCA owner records NOTHING
 ;;
-;; The decisive regression for the XState v5 / SCXML alignment: a history-
-;; owning compound records ONLY when it is itself in the EXIT SET. A pure
-;; WITHIN-compound sibling move — where the owner SURVIVES as the LCCA — is
-;; the OLD `<=` (active-child-subtree-teardown) trigger that the strict `<`
-;; gate retires. These pin the new boundary on BOTH a flat single-machine
-;; chart AND a nested chart (where the surviving OUTER owner records nothing
-;; while a genuinely-exited INNER owner still does), so it can never silently
-;; slip back to `<=`.
+;; The decisive case for the XState v5 / SCXML alignment: a history-owning
+;; compound records ONLY when it is itself in the EXIT SET (the strict `<`
+;; gate). A pure WITHIN-compound sibling move — where the owner SURVIVES as
+;; the LCCA — records nothing. These pin the boundary on BOTH a flat
+;; single-machine chart AND a nested chart (where the surviving OUTER owner
+;; records nothing while a genuinely-exited INNER owner still does), so it can
+;; never silently slip to an active-child-subtree-teardown (`<=`) trigger.
 ;; ===========================================================================
 
 ;; `:player` owns deep history; `:swap` moves between its two children

--- a/implementation/machines/test/re_frame/machine_identity_naming_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_identity_naming_cljs_test.cljs
@@ -1,12 +1,10 @@
 (ns re-frame.machine-identity-naming-cljs-test
-  "Adversarial coverage for the machine-identity naming split
-  (rf2-0ggtr5 + rf2-ws5thu).
+  "Adversarial coverage for the machine-identity naming split.
 
-  Two formerly-overloaded names were split into three distinct identity
-  facts. These tests pin the distinctions so a future regression that
-  re-conflates them fails loudly:
+  Machine identity is carried as three distinct facts. These tests pin the
+  distinctions so a regression that re-conflates them fails loudly:
 
-   1. **TYPE vs live actor INSTANCE** (rf2-ws5thu). The live-actor lifecycle
+   1. **TYPE vs live actor INSTANCE**. The live-actor lifecycle
       traces (`:rf.machine/transition`, `:rf.machine/done`,
       `:rf.machine/system-id-bound` / `-released`, the `:rf.machine.timer/*`
       rows, `:rf.machine.lifecycle/destroyed`) carry the INSTANCE address
@@ -16,12 +14,11 @@
       `:rf.machine.lifecycle/created` spec-time-type rows). For a SPAWNED
       actor the two are provably different values (`<type>#<n>` ≠ `<type>`).
 
-   2. **Explicit actor-address INPUT vs declarative invocation PATH**
-      (rf2-0ggtr5). On one declarative `:spawn` the explicit-address input
-      key `:fixed-actor-id` (was `:spawn-id`) and the runtime-stamped
-      invocation-path key `:rf/invoke-id` (was `:rf/spawn-id`) are distinct
-      facts carrying distinct shapes (a bare keyword address vs a state-path
-      vector)."
+   2. **Explicit actor-address INPUT vs declarative invocation PATH**.
+      On one declarative `:spawn` the explicit-address input
+      key `:fixed-actor-id` and the runtime-stamped invocation-path key
+      `:rf/invoke-id` are distinct facts carrying distinct shapes (a bare
+      keyword address vs a state-path vector)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.trace.tooling :as trace-tooling]
@@ -135,7 +132,7 @@
                    :working
                    {:spawn {:machine-id     :idn3/child
                             ;; explicit actor-address INPUT — pins the id
-                            ;; instead of gensym (was the overloaded :spawn-id).
+                            ;; instead of gensym.
                             :fixed-actor-id :idn3/pinned}}}}]
       (rf/reg-machine :idn3/child child)
       (rf/reg-machine :idn3/parent parent)
@@ -158,7 +155,7 @@
             "the explicit-address identity and the invocation-path identity are NOT conflated")
         (is (keyword? (:rf/self-id child-data)))
         (is (vector?  (:rf/invoke-id child-data)))
-        ;; The retired overloaded keys MUST be absent.
+        ;; The overloaded `:rf/spawn-id` key is not a reserved key.
         (is (not (contains? child-data :rf/spawn-id))
             "the retired reserved key :rf/spawn-id is gone (now :rf/invoke-id)")))))
 

--- a/implementation/machines/test/re_frame/machine_identity_naming_pure_test.clj
+++ b/implementation/machines/test/re_frame/machine_identity_naming_pure_test.clj
@@ -1,22 +1,20 @@
 (ns re-frame.machine-identity-naming-pure-test
   "Adversarial JVM (pure-surface) coverage for the machine-identity naming
-  split (rf2-0ggtr5 + rf2-ws5thu). Exercises the pure `machine-transition`
-  reducer directly (no live frame) so the emitted spawn/destroy fx args are
-  the contract under test.
+  split. Exercises the pure `machine-transition` reducer directly (no live
+  frame) so the emitted spawn/destroy fx args are the contract under test.
 
-  Pins the two distinctions the split introduced:
+  Pins two identity distinctions:
 
-   1. **Explicit actor-address INPUT vs declarative invocation PATH**
-      (rf2-0ggtr5). On the InvokeSpec, `:fixed-actor-id` (the explicit
-      address, was `:spawn-id`) pins the spawned id; the runtime stamps the
-      invocation path under `:rf/invoke-id` (was `:rf/spawn-id`) on the
-      emitted `:rf.machine/spawn` / `:rf.machine/destroy` fx args. They are
-      distinct facts with distinct shapes (a bare keyword vs a state-path
-      vector).
+   1. **Explicit actor-address INPUT vs declarative invocation PATH**.
+      On the InvokeSpec, `:fixed-actor-id` (the explicit address) pins the
+      spawned id; the runtime stamps the invocation path under
+      `:rf/invoke-id` on the emitted `:rf.machine/spawn` /
+      `:rf.machine/destroy` fx args. They are distinct facts with distinct
+      shapes (a bare keyword vs a state-path vector).
 
-   2. **Registered TYPE vs spawned INSTANCE** (rf2-ws5thu). The InvokeSpec
-      `:machine-id` names the registered TYPE; the allocated `:rf/spawned-id`
-      is the live INSTANCE address (`<type>#<n>`) — never conflated."
+   2. **Registered TYPE vs spawned INSTANCE**. The InvokeSpec `:machine-id`
+      names the registered TYPE; the allocated `:rf/spawned-id` is the live
+      INSTANCE address (`<type>#<n>`) — never conflated."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]))
@@ -42,7 +40,7 @@
           "TYPE and INSTANCE are distinct values")
       (is (vector? (:rf/invoke-id args))
           "the invocation path is a vector — never a bare id keyword")
-      ;; The retired overloaded keys MUST be absent from the emitted args.
+      ;; The overloaded keys are not part of the emitted args.
       (is (not (contains? args :rf/spawn-id))
           "retired reserved arg :rf/spawn-id is gone (now :rf/invoke-id)")
       (is (not (contains? args :spawn-id))

--- a/implementation/machines/test/re_frame/machine_noop_signal_test.clj
+++ b/implementation/machines/test/re_frame/machine_noop_signal_test.clj
@@ -1,22 +1,16 @@
 (ns re-frame.machine-noop-signal-test
-  "Per rf2-coozg — a genuine machine no-op is signalled ONCE, consistently.
+  "A genuine machine no-op is signalled ONCE, consistently.
 
-  Before this bead the engine double-signalled an unhandled / guard-blocked
-  no-op: the `:else` branch of `machine-transition-single` (and the
-  parallel aggregate in `parallel-machine-transition`) emitted the benign
-  `:rf.machine.event/unhandled-no-op`, AND `commit-or-finalize`
-  UNCONDITIONALLY emitted a no-change `:rf.machine/transition` (before =
-  after, `:microsteps 0`, `:cascade []`). A redundant `[:rf.machine/start]`
-  on an already-booted machine emitted ONLY the bare no-change transition
-  (no `unhandled-no-op` — reserved-`:rf/*` lifecycle is carved out per
-  rf2-t4582). So a no-op was signalled two ways for unhandled/blocked
-  events, one way for redundant bootstrap — inconsistent + redundant.
+  `commit-or-finalize` suppresses the `:rf.machine/transition` emit when the
+  macrostep is a genuine no-op — `:before` == `:after` AND the combined
+  (boot + step) `:cascade` is empty AND zero `:microsteps`. So:
 
-  The fix: `commit-or-finalize` suppresses the `:rf.machine/transition`
-  emit when the macrostep is a genuine no-op — `:before` == `:after` AND
-  the combined (boot + step) `:cascade` is empty AND zero `:microsteps`.
-  The `unhandled-no-op` becomes the SOLE signal for an unhandled / blocked
-  event; a redundant bootstrap on an already-booted machine emits NOTHING.
+    - An unhandled / guard-blocked event emits exactly one benign
+      `:rf.machine.event/unhandled-no-op` and NO no-change
+      `:rf.machine/transition`.
+    - A redundant `[:rf.machine/start]` on an already-booted machine emits
+      NOTHING — reserved-`:rf/*` lifecycle is carved out of `unhandled-no-op`,
+      and the no-change transition is suppressed.
 
   The legitimate first bootstrap (`:initial-entry`) carries a non-empty
   initial-descent `:cascade`, so it is NEVER a no-op and its transition
@@ -38,7 +32,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; Routed through the shared `mtest/with-trace-capture`
 ;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
   (mtest/with-trace-capture seen
@@ -109,9 +103,9 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 3. Redundant bootstrap on an already-booted machine — emits NEITHER
-;;    signal (reserved-`:rf/*` lifecycle is exempt from unhandled-no-op per
-;;    rf2-t4582, and the no-change transition is now suppressed too). The
-;;    no-op is consistent: nothing fires for genuine non-events.
+;;    signal (reserved-`:rf/*` lifecycle is exempt from unhandled-no-op,
+;;    and the no-change transition is suppressed too). The no-op is
+;;    consistent: nothing fires for genuine non-events.
 ;; ---------------------------------------------------------------------------
 
 (deftest redundant-start-emits-no-no-op-signal
@@ -135,11 +129,11 @@
           "no second `:rf.machine/started` — the machine is already alive"))))
 
 ;; ---------------------------------------------------------------------------
-;; 4. The LEGITIMATE first start runs its `:initial-entry` cascade and, per
-;;    F‴ (rf2-gl588), signals the BIRTH with a `:rf.machine/started` trace —
-;;    NOT a `:rf.machine/transition`. The start marker is a PURE init-kick:
-;;    it STOPS after initial-entry, so no transition row is emitted (the old
-;;    `before == after` self-transition is gone). It is not an unhandled-no-op.
+;; 4. The LEGITIMATE first start runs its `:initial-entry` cascade and
+;;    signals the BIRTH with a `:rf.machine/started` trace — NOT a
+;;    `:rf.machine/transition`. The start marker is a PURE init-kick:
+;;    it STOPS after initial-entry, so no transition row is emitted (no
+;;    `before == after` self-transition). It is not an unhandled-no-op.
 ;; ---------------------------------------------------------------------------
 
 (deftest first-start-signals-birth-via-started-trace

--- a/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.machine-property-cljs-test
-  "Property / model-based test layer for the machines engine (rf2-dp1fi0).
+  "Property / model-based test layer for the machines engine.
 
   The machines suite is otherwise ENTIRELY example-based — pin-and-assert
   (one input → one expected snapshot), the 186-fixture SCXML conformance
@@ -424,7 +424,7 @@
 ;; `transition/compute-tags` — that is the SAME fn the engine's commit-tags
 ;; calls (`transition.cljc` `commit-tags` → `compute-tags`), so reusing it
 ;; only cross-checks the elision rule + state/tag consistency, never the
-;; union math itself (rf2-ln2ctp). Instead, walk the active-state ancestor
+;; union math itself. Instead, walk the active-state ancestor
 ;; chain HERE — descending the machine spec's `:states` map directly along
 ;; the state path and reading each node's declared `:tags` slot by hand — so
 ;; the expected union is derived by a genuinely independent method. The
@@ -474,7 +474,7 @@
   union for `machine` + `state` (the projection the engine must stamp), via
   a HAND-WRITTEN ancestor-chain walk over the machine spec — NOT via
   `transition/compute-tags` (which the engine itself uses, so reusing it
-  would be circular; rf2-ln2ctp). For parallel, union the independent walk
+  would be circular). For parallel, union the independent walk
   across every region; for flat/compound, walk the single path."
   [machine state]
   (if (map? state)
@@ -565,11 +565,10 @@
                         :actions shared-actions
                         :states  {:loop {:on {:e0 {:action :a/raise}}}}}
           ;; Both calls MUST return (not hang / SOE). The harness running to
-          ;; completion is the settle proof. Per rf2-y3jv8q an unbounded
-          ;; :always / :raise cycle now surfaces as a FAILED macrostep at the
-          ;; depth bound (XState v5 throws on such a runaway) — a `result/fail`
-          ;; carrying the `::depth-abort?` sentinel, NOT an :ok rollback no-op
-          ;; that masqueraded as a guard-blocked decline.
+          ;; completion is the settle proof. An unbounded :always / :raise
+          ;; cycle surfaces as a FAILED macrostep at the depth bound (XState
+          ;; v5 throws on such a runaway) — a `result/fail` carrying the
+          ;; `::depth-abort?` sentinel, NOT an :ok rollback no-op.
           r-always (machines/machine-transition
                      always-cycle (initial-snapshot always-cycle) [:noop])
           r-raise  (machines/machine-transition

--- a/implementation/machines/test/re_frame/machine_pure_error_contract_test.clj
+++ b/implementation/machines/test/re_frame/machine_pure_error_contract_test.clj
@@ -1,25 +1,23 @@
 (ns re-frame.machine-pure-error-contract-test
-  "Coverage & rigour pass (rf2-ynjts.10). Direct pure-engine (JVM)
-  coverage for the runtime error / resolution contracts that the
-  REGISTRATION-TIME validator (`validate-machine!`) does NOT cover —
-  because the pure-call surface (`re-frame.machines/machine-transition`,
-  the conformance corpus, JVM fixtures) reaches the engine WITHOUT
-  running `validate-machine!`. A grep of the machines test tree before
-  this file returned ZERO direct matches for these contracts:
+  "Direct pure-engine (JVM) coverage for the runtime error / resolution
+  contracts that the REGISTRATION-TIME validator (`validate-machine!`) does
+  NOT cover — because the pure-call surface
+  (`re-frame.machines/machine-transition`, the conformance corpus, JVM
+  fixtures) reaches the engine WITHOUT running `validate-machine!`:
 
-    - the BENIGN unhandled-event no-op (rf2-ugdas — xstate-v5 parity). An
-      unknown USER event is no longer an error: it emits the benign
+    - the BENIGN unhandled-event no-op (xstate-v5 parity). An unknown USER
+      event is NOT an error: it emits the benign
       `:rf.machine.event/unhandled-no-op` trace (op-type `:rf.machine`,
-      NOT `:error` / `:warning`) and leaves the snapshot unchanged.
-      rf2-t4582 refines this: reserved-`:rf/*` framework lifecycle traffic
-      (the synthetic creation marker `[:rf.machine/start]`, the spawn
-      kick-off `[:rf.machine.spawn/spawned]`, the stories-runtime
-      lifecycle pings) is NOT classified as an unknown-user-event no-op —
+      NOT `:error` / `:warning`) and leaves the snapshot unchanged; no
+      `:rf.error/machine-unhandled-event` advisory is emitted.
+      Reserved-`:rf/*` framework lifecycle traffic (the synthetic creation
+      marker `[:rf.machine/start]`, the spawn kick-off
+      `[:rf.machine.spawn/spawned]`, the stories-runtime lifecycle pings)
+      is NOT classified as an unknown-user-event no-op —
       `transition/unhandled-event-no-op?` gates the emit. Severity is
-      unchanged (benign, nothing throws); only the SEMANTIC carve-out is
-      restored, so the machine's BIRTH renders its `:initial-entry`
-      cascade rather than a no-op. Domain (non-`:rf/*`) events still emit
-      the benign no-op (the rf2-ugdas behaviour, preserved).
+      benign (nothing throws); the SEMANTIC carve-out means the machine's
+      BIRTH renders its `:initial-entry` cascade rather than a no-op.
+      Domain (non-`:rf/*`) events emit the benign no-op.
 
     - `:rf.error/machine-bad-state-form` — `state-path` throws on a
       `:state` that is neither keyword nor vector (transition.cljc:232).
@@ -57,24 +55,23 @@
             [re-frame.machines.transition :as transition]))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-ugdas + rf2-t4582 — the BENIGN unhandled-event no-op (xstate-v5
-;; parity) WITH the reserved-:rf/* lifecycle carve-out. Through the pure
-;; macrostep, an unknown USER event emits the benign
-;; `:rf.machine.event/unhandled-no-op` trace (op-type :rf.machine, NOT
-;; :error / :warning) and leaves the snapshot unchanged; NO
-;; :rf.error/machine-unhandled-event is ever emitted (the advisory is
-;; retired). A reserved-:rf/* framework lifecycle event (bootstrap, spawn
-;; kick-off, stories pings) does NOT emit the no-op — it is framework init,
-;; not an unknown user event. Pins the engine's actual emission decision
-;; (transition.cljc `unhandled-event-no-op?` + the emit-site gate).
+;; The BENIGN unhandled-event no-op (xstate-v5 parity) WITH the
+;; reserved-:rf/* lifecycle carve-out. Through the pure macrostep, an
+;; unknown USER event emits the benign `:rf.machine.event/unhandled-no-op`
+;; trace (op-type :rf.machine, NOT :error / :warning) and leaves the
+;; snapshot unchanged; an unknown USER event is NOT an error, so no
+;; :rf.error/machine-unhandled-event advisory is emitted. A reserved-:rf/*
+;; framework lifecycle event (bootstrap, spawn kick-off, stories pings) does
+;; NOT emit the no-op — it is framework init, not an unknown user event.
+;; Pins the engine's actual emission decision (transition.cljc
+;; `unhandled-event-no-op?` + the emit-site gate).
 ;; ---------------------------------------------------------------------------
 
 (defn- capture-events!
   "Drive a pure `machine-transition` while a tooling listener records every
   emitted trace event (full envelope). Returns the vector of events
   (deterministic — no wall-clock / random). Routed through the shared
-  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed unregister
-  in a `finally`."
+  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
   [definition snapshot event]
   (mtest/with-trace-capture seen
     (machines/machine-transition definition snapshot event)
@@ -156,13 +153,12 @@
         "the bare reserved root is exempt")))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-t4582 — the machine's BIRTH renders as :initial-entry, not a no-op.
-;; The start threads the synthetic `[:rf.machine/start]` event into the
-;; initial-entry cascade (Spec 005 §Synthetic creation marker). Because
-;; `:rf.machine/start` is reserved-:rf/*, the start NEVER trips the
-;; unhandled-no-op even when the initial state declares no `:on`; instead it
-;; runs the entry cascade and the entry action emits `:rf.machine/action-ran`
-;; with `:phase :initial-entry`.
+;; The machine's BIRTH renders as :initial-entry, not a no-op. The start
+;; threads the synthetic `[:rf.machine/start]` event into the initial-entry
+;; cascade (Spec 005 §Synthetic creation marker). Because `:rf.machine/start`
+;; is reserved-:rf/*, the start NEVER trips the unhandled-no-op even when the
+;; initial state declares no `:on`; instead it runs the entry cascade and the
+;; entry action emits `:rf.machine/action-ran` with `:phase :initial-entry`.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private boot-entry-spec
@@ -180,8 +176,7 @@
   (testing "the initial-entry cascade emits the :initial-entry-phase action-ran
    and installs the initial state — NOT an unhandled-no-op for
    [:rf.machine/start]"
-    ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
-    ;; unregister in a `finally`.
+    ;; Shared `with-trace-capture` — guaranteed unregister in a `finally`.
     (mtest/with-trace-capture seen
       (let [r    (parallel/apply-initial-entry-cascade
                    boot-entry-spec {:state :a :data {}})
@@ -322,11 +317,11 @@
           "ex-data carries the machine-id"))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-yl39ub — runtime transition throws carry the canonical Spec 009
-;; thrown-error shape: a human :reason sentence, a :where, a :recovery, and a
-;; message that LEADS with the sentence + TRAILS with the [:rf.error/<id>]
-;; token (never a bare keyword). Covers a malformed transition VALUE form (the
-;; `:other` arm of normalise-candidates) and the canonical-shape invariants.
+;; Runtime transition throws carry the canonical Spec 009 thrown-error
+;; shape: a human :reason sentence, a :where, a :recovery, and a message that
+;; LEADS with the sentence + TRAILS with the [:rf.error/<id>] token (never a
+;; bare keyword). Covers a malformed transition VALUE form (the `:other` arm
+;; of normalise-candidates) and the canonical-shape invariants.
 ;; ---------------------------------------------------------------------------
 
 (deftest malformed-transition-value-throws-bad-on-clause

--- a/implementation/machines/test/re_frame/machine_raise_cofx_replay_test.clj
+++ b/implementation/machines/test/re_frame/machine_raise_cofx_replay_test.clj
@@ -1,45 +1,38 @@
 (ns re-frame.machine-raise-cofx-replay-test
-  "Per rf2-08br0v / rf2-cheez6.1 — replay-determinism of a generator-backed
-  cofx fact MINTED by a same-macrostep RAISED event's guard/action.
+  "Replay-determinism of a generator-backed cofx fact MINTED by a
+  same-macrostep RAISED event's guard/action.
 
-  ## The investigation (rf2-08br0v — confirmed REAL)
+  ## The mechanism
 
-  `drain-to-fixed-point` re-runs `ensure-raised-cofx` per dequeued raise
-  (rf2-xsdn5h). Under `:live` it MINTS a fresh generator-backed recordable
-  fact mid-macrostep when a raise-selected guard's `:rf.cofx/requires` was NOT
-  in the external event's ensure-set. The minted value is written onto the
+  `drain-to-fixed-point` re-runs `ensure-raised-cofx` per dequeued raise.
+  Under `:live` it MINTS a fresh generator-backed recordable fact
+  mid-macrostep when a raise-selected guard's `:rf.cofx/requires` is NOT in
+  the external event's ensure-set. The minted value is written onto the
   engine-local machine def's `:rf/cofx` and threads forward IN the drain (so a
   later raise / `:always` re-presents it — in-drain consistency).
 
-  But pre-fix it did NOT flow back to the token the EPOCH captures. The epoch's
-  `:rf.cofx` replay token is captured at `:rf.event/run-start`
+  The epoch's `:rf.cofx` replay token is captured at `:rf.event/run-start`
   (`re-frame.epoch.capture/find-trigger-event` reads the run-start trace's
   `:rf.event/cofx`), which the router emits from `assemble-initial-ctx`'s
   coeffects BEFORE the handler runs. A state machine's outer event handler
   declares no `:rf.cofx/requires` (they live on guards/actions), so
   `assemble-initial-ctx` mints NOTHING for it — and the machine's own ensure
   steps (`ensure-ctx-cofx` pre-drain, `ensure-raised-cofx` in-drain) run INSIDE
-  the handler, AFTER run-start. So the run-start TRACE carried only the
+  the handler, AFTER run-start. So the run-start TRACE carries only the
   externally-supplied facts (e.g. `:rf/time-ms`), never the machine-minted ones.
 
-  Consequence (the divergence): a `:live` original run mints a fresh value and
-  a raise-selected guard decides on it; on `:strict` replay the token lacked
-  that fact, so `ensure-raised-cofx` (mint-policy-aware, rf2-n0myjq) REFUSED to
-  mint and surfaced `:rf.error/missing-required-cofx` — the replayed macrostep
-  failed where the original advanced. Replay was non-deterministic.
+  ## How replay stays deterministic
 
-  ## The structural fix (rf2-cheez6.1)
-
-  The fix lives in `re-frame.epoch.capture/find-trigger-event`: it merges the
-  cascade's `:rf.cofx/generated` mint traces (every actual recordable mint
-  emits one, carrying the marks-projected produced value) onto the run-start
-  replay token at epoch-ASSEMBLY time. The run-start TRACE itself is unchanged
-  — it remains the PRE-handler token — so this namespace's run-start-trace
-  assertion below still observes only `:rf/time-ms` (that is the trace's
-  contract; the augmentation is an epoch-read concern). The end-to-end
-  determinism proof against the assembled epoch record lives in the epoch
-  artefact (`re-frame.machine-minted-cofx-replay-token-test`), whose test
-  classpath carries epoch.
+  `re-frame.epoch.capture/find-trigger-event` merges the cascade's
+  `:rf.cofx/generated` mint traces (every actual recordable mint emits one,
+  carrying the marks-projected produced value) onto the run-start replay token
+  at epoch-ASSEMBLY time. The run-start TRACE itself remains the PRE-handler
+  token — so this namespace's run-start-trace assertion below observes only
+  `:rf/time-ms` (that is the trace's contract; the augmentation is an
+  epoch-read concern). The end-to-end determinism proof against the assembled
+  epoch record lives in the epoch artefact
+  (`re-frame.machine-minted-cofx-replay-token-test`), whose test classpath
+  carries epoch.
 
   ## What this namespace proves (machines surface, no epoch dep)
 
@@ -110,8 +103,8 @@
       ;; (2) The run-start TRACE is the PRE-handler token — only :rf/time-ms.
       ;; This is the trace's contract (the augmentation is an epoch-read
       ;; concern, see the epoch artefact's companion test), and it documents
-      ;; WHY the fix reconstructs the minted facts from the cascade's mint
-      ;; traces rather than from the run-start emit.
+      ;; WHY epoch assembly reconstructs the minted facts from the cascade's
+      ;; mint traces rather than from the run-start emit.
       (let [captured-cofx (:rf.event/cofx (:tags @run-start))]
         (is (some? @run-start) "a run-start trace was captured")
         (is (= {:rf/time-ms 111} captured-cofx)

--- a/implementation/machines/test/re_frame/machine_raise_fifo_test.clj
+++ b/implementation/machines/test/re_frame/machine_raise_fifo_test.clj
@@ -1,14 +1,13 @@
 (ns re-frame.machine-raise-fifo-test
-  "Per rf2-nr434 — `:raise` drains FIFO (XState v5 / SCXML internal-event
-  queue), NOT depth-first.
+  "`:raise` drains FIFO (XState v5 / SCXML internal-event queue), NOT
+  depth-first.
 
   XState v5 / SCXML gold standard: `raise` / `<raise>` enqueues on the
   machine's ONE internal event queue, drained breadth-first within the
   macrostep. A transition that raises `[B]` then `[C]`, where B's handler
   itself raises `[D]`, processes them `B, C, D` — D goes to the BACK of the
-  queue, BEHIND the still-pending sibling C. The engine previously prepended
-  the nested raise (`(concat fx2 rest-pending)` in `drain-raises`), giving a
-  depth-first `B, D, C`; that was an unblessed divergence, now aligned.
+  queue, BEHIND the still-pending sibling C (a depth-first drain would give
+  `B, D, C`).
 
   These are pure-engine tests — they call `machine-transition` directly and
   read processing order off the post-macrostep snapshot's `:data` log (the
@@ -149,13 +148,13 @@
                                         (get-in ev [:tags :rf/op-type-id]
                                                 (:op-type-id ev)))
                                 (swap! seen conj ev)))]
-        ;; rf2-y3jv8q — a depth-bound abort is now a FAILED macrostep, not an
-        ;; :ok rollback no-op (XState v5 throws on such a runaway). The pure
-        ;; surface returns a `result/fail` carrying the `::depth-abort?`
-        ;; sentinel; atomic rollback is still guaranteed — a `:fail` threads
-        ;; NO snapshot / fx, so nothing intermediate escapes the abort. (The
-        ;; lifecycle handler short-circuits to `{}`, leaving the pre-event
-        ;; snapshot committed in runtime-db.)
+        ;; A depth-bound abort is a FAILED macrostep, not an :ok rollback
+        ;; no-op (XState v5 throws on such a runaway). The pure surface
+        ;; returns a `result/fail` carrying the `::depth-abort?` sentinel;
+        ;; atomic rollback is guaranteed — a `:fail` threads NO snapshot / fx,
+        ;; so nothing intermediate escapes the abort. (The lifecycle handler
+        ;; short-circuits to `{}`, leaving the pre-event snapshot committed in
+        ;; runtime-db.)
         (let [r (machines/machine-transition spec {:state :idle :data {}} [:start])]
           (is (result/fail? r)
               "depth-exceeded returns a :fail (failed macrostep), not an :ok no-op")
@@ -166,17 +165,16 @@
           (is (nil? (result/fx r))
               "a :fail threads no fx — no accumulated side-effect leaks the abort"))))))
 
-;; ---- 6. depth-bound rollback is TRULY atomic (x4s9t.1) --------------------
+;; ---- 6. depth-bound rollback is TRULY atomic ------------------------------
 ;;
-;; The earlier rollback test fans out identical `[:noop]` self-loops that
+;; The plain rollback test (§5) fans out identical `[:noop]` self-loops that
 ;; neither mutate :data nor emit non-raise fx, so the partially-advanced
 ;; snapshot HAPPENS to equal the original even without a real rollback — it
-;; cannot distinguish the buggy `(result/ok snap accum)` from the correct
-;; `(result/ok rollback-snapshot [])`. These fixtures make every intermediate
-;; raise MUTATE state + :data AND emit a non-raise side-effect fx BEFORE the
-;; limit trips, so a non-atomic abort would commit a drifted snapshot and leak
-;; the accumulated effects. The contract: the WHOLE macrostep is discarded —
-;; original snapshot, empty fx.
+;; cannot distinguish a non-atomic abort from a true one. These fixtures make
+;; every intermediate raise MUTATE state + :data AND emit a non-raise
+;; side-effect fx BEFORE the limit trips, so a non-atomic abort would commit a
+;; drifted snapshot and leak the accumulated effects. The contract: the WHOLE
+;; macrostep is discarded — original snapshot, empty fx.
 
 (deftest depth-bound-rollback-discards-intermediate-mutations-and-fx
   (testing "(x4s9t.1) a :raise depth-limit abort rolls back the ENTIRE
@@ -200,10 +198,10 @@
                              :on {:to-a :a}}}}
           original {:state :idle :data {:n 0}}
           r        (machines/machine-transition spec original [:start])]
-      ;; rf2-y3jv8q — the abort is a FAILED macrostep. Atomic rollback is
-      ;; enforced by the `:fail` threading NO snapshot / fx: every intermediate
-      ;; :a/:b state, bumped :n, and accumulated :side-effect fx is discarded
-      ;; with the macrostep (there is nothing to commit on a `:fail`).
+      ;; The abort is a FAILED macrostep. Atomic rollback is enforced by the
+      ;; `:fail` threading NO snapshot / fx: every intermediate :a/:b state,
+      ;; bumped :n, and accumulated :side-effect fx is discarded with the
+      ;; macrostep (there is nothing to commit on a `:fail`).
       (is (result/fail? r)
           "depth-exceeded returns a :fail (failed macrostep), not an :ok no-op")
       (is (result/depth-abort? r)

--- a/implementation/machines/test/re_frame/machine_remediation_ee38b_test.clj
+++ b/implementation/machines/test/re_frame/machine_remediation_ee38b_test.clj
@@ -1,20 +1,17 @@
 (ns re-frame.machine-remediation-ee38b-test
-  "Remediation coverage for rf2-ee38b.5 (review sweep of implementation/
-  machines). Pins the behaviours the three-lens review found missing or
-  wrong:
+  "Pins these machines behaviours:
 
     - P1 root (top-level) `:on` fallback is consulted at runtime
       (Spec 005 §Transition resolution steps 6-7) — keyword + vector
       targets, `:*` wildcard, deepest-wins override, guard gating.
     - P2 the benign `:rf.machine.event/unhandled-no-op` is emitted when no
-      level matches an unknown USER event (rf2-ugdas — xstate-v5 parity;
-      op-type :rf.machine, NOT an error). The former
-      `:rf.error/machine-unhandled-event` advisory is retired. Per
-      rf2-t4582 reserved-`:rf/*` framework lifecycle traffic (bootstrap,
+      level matches an unknown USER event (xstate-v5 parity; op-type
+      :rf.machine, NOT an error). An unknown USER event is NOT an error: no
+      `:rf.error/machine-unhandled-event` advisory is emitted. Reserved-
+      `:rf/*` framework lifecycle traffic (bootstrap,
       `:rf.machine.spawn/spawned`, stories pings) does NOT emit the no-op —
-      it is framework init, not an unknown user event; the
-      reserved-namespace carve-out is restored (severity stays benign).
-      The case pinned below uses a DOMAIN event (`[:nope]`), so it still
+      it is framework init, not an unknown user event (severity stays
+      benign). The case pinned below uses a DOMAIN event (`[:nope]`), so it
       emits the no-op.
     - P2 `:always` microstep traces — per-microstep
       `:rf.machine.microstep/transition` + the outer
@@ -25,7 +22,7 @@
     - P3 history grammar placement validated at registration — a
       `:type :history` node MUST have an owning compound
       (`:rf.error/machine-history-misplaced`); a well-placed node validates
-      (history is first-class per rf2-mle6e, Spec 005 §History states).
+      (history is first-class — Spec 005 §History states).
     - P3 `:after` + root-`:on` guard/action ref validation at
       registration (Spec 005:1334)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -38,8 +35,8 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
-;; — guaranteed unregister in a `finally`.
+;; Routed through the shared `mtest/with-trace-capture` — guaranteed
+;; unregister in a `finally`.
 (defn- record-traces! [body-fn]
   (mtest/with-trace-capture seen
     (body-fn)
@@ -114,7 +111,7 @@
     (rf/dispatch-sync [:rem/root-guard [:go]])
     (is (= :a (snap-of :rem/root-guard)) "guard false → unhandled, no transition")))
 
-;; ---- P2: :rf.machine.event/unhandled-no-op (rf2-ugdas — xstate-v5) ----------
+;; ---- P2: :rf.machine.event/unhandled-no-op (xstate-v5 parity) ----------
 
 (deftest unhandled-event-emits-benign-no-op
   (testing "no level matches → benign :rf.machine.event/unhandled-no-op with
@@ -196,10 +193,10 @@
           ws  (ops evs :rf.error/machine-action-wrote-db)]
       (is (= 1 (count ws)) "exactly one wrote-db error")
       (is (= :bad (-> ws first :tags :action-id)))
-      ;; rf2-x9haxl — `:offending-value` (the whole app-db the action wrongly
-      ;; returned) is summarized to `:rf/redacted` at the trace egress
-      ;; chokepoint (`marks/project-machine-wrote-db-tags`) so it never leaks
-      ;; raw to listeners / epoch / MCP / logs. The `:action-id` locates the
+      ;; `:offending-value` (the whole app-db the action wrongly returned)
+      ;; is summarized to `:rf/redacted` at the trace egress chokepoint
+      ;; (`marks/project-machine-wrote-db-tags`) so it never leaks raw to
+      ;; listeners / epoch / MCP / logs. The `:action-id` locates the
       ;; offending action; the operator does not need the app-db contents.
       (is (= :rf/redacted (-> ws first :tags :offending-value))
           "the offending app-db value is redacted at egress (rf2-x9haxl)")
@@ -234,9 +231,8 @@
           ":db in the patch surfaces the hard-disallow error"))))
 
 ;; ---- P3: history grammar placement validated at registration ----------------
-;; History is first-class (rf2-mle6e); the registration validator now enforces
-;; the PLACEMENT constraint — a `:type :history` node MUST have an owning
-;; compound — rather than rejecting history wholesale.
+;; History is first-class; the registration validator enforces the PLACEMENT
+;; constraint — a `:type :history` node MUST have an owning compound.
 
 (deftest history-misplaced-rejected-at-registration
   (testing "a `:type :history` node with NO owning compound (machine root,

--- a/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
+++ b/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
@@ -1,7 +1,7 @@
 (ns re-frame.machine-reply-lowering-test
   "Conformance: the two machine async completions share the uniform
   reply-envelope status/trace vocabulary (EP-0011 §Machine Completion /
-  §Timer Reply; Managed-Effects §The uniform reply envelope, rf2-zqefg3.4).
+  §Timer Reply; Managed-Effects §The uniform reply envelope).
   INTERNAL LOWERING ONLY — the public statechart API (`:on-done` /
   `:on-error` / `:after` / actor-destroy) is preserved exactly.
 
@@ -89,12 +89,11 @@
               (is (= :stale (:rf.reply/status tags)))
               (is (= :suppressed (:rf.reply/work-status tags)))
               (is (= :rf.machine.timer/after-epoch-mismatch (:rf.reply/stale-reason tags)))
-              ;; rf2-niarhz — the canonical :work/id joins the uniform
-              ;; work/reply rows (the timer work-id keyed on the SCHEDULED
-              ;; epoch — the timer's attempt identity). Per rf2-yyvtk5 the
-              ;; pick-transition stale `match` now carries the owning actor
-              ;; INSTANCE under `:actor-id`, so the logical-id is
-              ;; `[<actor-id> & <decl-path>]` — the timer's full
+              ;; the canonical :work/id joins the uniform work/reply rows (the
+              ;; timer work-id keyed on the SCHEDULED epoch — the timer's
+              ;; attempt identity). The pick-transition stale `match` carries
+              ;; the owning actor INSTANCE under `:actor-id`, so the logical-id
+              ;; is `[<actor-id> & <decl-path>]` — the timer's full
               ;; actor-scoped identity, not the bare declaring path.
               (is (= [:rf.work/timer [:rl/after :loading] scheduled-epoch]
                      (:work/id tags))
@@ -171,9 +170,9 @@
             (is (= [:rf.work/machine :rl/child#1 [:working] 1]
                    (:rf.reply/work-id tags))
                 "canonical machine work-id (additive spelling)")
-            ;; rf2-niarhz — the CANONICAL :work/id is now stamped so Xray's
-            ;; uniform work/reply grouping (keys on bare :work/id) joins this
-            ;; spawned-actor completion.
+            ;; the CANONICAL :work/id is stamped so Xray's uniform work/reply
+            ;; grouping (keys on bare :work/id) joins this spawned-actor
+            ;; completion.
             (is (= [:rf.work/machine :rl/child#1 [:working] 1]
                    (:work/id tags))
                 "canonical :work/id join key on the done trace")
@@ -228,8 +227,8 @@
         (finally (trace/unregister-listener! ::done-err))))))
 
 ;; ===========================================================================
-;; (3) spawn-stale — parent destroyed BEFORE the child finishes (rf2-lohbfg /
-;;     rf2-tkisxm). The PRODUCTION path (not the pure builder): a child reaches
+;; (3) spawn-stale — parent destroyed BEFORE the child finishes.
+;;     The PRODUCTION path (not the pure builder): a child reaches
 ;;     its :final? leaf AFTER its spawning parent was already destroyed. The
 ;;     :on-done callback MUST NOT run (no live parent to mutate), the ledger /
 ;;     trace MUST classify the late completion :status :stale / :work/status
@@ -346,7 +345,7 @@
         "live parent: :on-done ran with the canonical reply's :value (not suppressed)")))
 
 ;; ===========================================================================
-;; (4) causal :completed-at threading (rf2-6mfkp3). A spawned machine
+;; (4) causal :completed-at threading. A spawned machine
 ;;     completion can mutate durable parent-machine data (:on-done writes
 ;;     the parent's :data). Per spec/Managed-Effects.md §155/§231 a
 ;;     completion that affects durable state MUST carry causal completion

--- a/implementation/machines/test/re_frame/machine_schema_arity_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_arity_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.machine-schema-arity-test
-  "rf2-genufr + rf2-wgmipl — the single registration home, the fail-loud
-  guard, and the public `reg-machine` event-vector `:schema` arity.
+  "The single registration home, the fail-loud guard, and the public
+  `reg-machine` event-vector `:schema` arity.
 
   Background. A machine carrying a `:data-schema` must flow through the single
   registration home so the `:rf/machine?` / `:rf/machine` registration-metadata
@@ -8,26 +8,22 @@
   `:data-schema` THROUGH `(machine-meta id)`, so without the stamp the schema
   validates nothing.
 
-  Before rf2-genufr, the direct `(reg-event id meta (make-machine-handler
-  spec))` path did not stamp it — the author had to hand-stamp the meta.
-  `make-machine-handler` is now the fail-loud guard: a `:data-schema`-bearing
-  spec reaching it outside the single registration home raises. The single home
-  (`reg-machine*` and its event-`:schema` arity) stamps the meta.
+  The single home (`reg-machine*` and its event-`:schema` arity) stamps the
+  meta. `make-machine-handler` is the fail-loud guard: a `:data-schema`-bearing
+  spec reaching it outside the single registration home raises.
 
-  EP-0025 (rf2-398kql): the home formerly ran a SECOND `:data-schema` side-
-  effect — `register-data-schema-marks!`, the schema→marks redaction bridge.
-  That bridge is REMOVED; durable machine `:data` egress classification is
-  frame-owned (`reg-frame` `:sensitive` / `:large {:app-db …}`). The privacy-
-  redaction tests that pinned the bridge are removed with it — the frame-owned
-  redaction surface is pinned by `machine-data-schema-redaction-test`.
+  A `:data-schema` is validation-only; it does not run a second
+  egress-classification side-effect. Durable machine `:data` egress
+  classification is frame-owned (`reg-frame` `:sensitive` / `:large {:app-db
+  …}`), and that frame-owned redaction surface is pinned by
+  `machine-data-schema-redaction-test`.
 
   Contract under test:
 
    1. **Auto-stamp / live validation via the event-:schema arity.** A machine
       registered via `(reg-machine* id {:schema EventSchema} machine)` — the
-      blessed replacement for the hand-stamped direct path; per rf2-wvh95f F2
-      the opts metadata map is the canonical MIDDLE slot — validates its
-      `:data-schema` (it was inert under the bare direct path).
+      opts metadata map is the canonical MIDDLE slot — validates its
+      `:data-schema`.
 
    2. **Event-vector :schema arity.** The `:schema` on the opts map validates
       the dispatched OUTER event vector at the `:where :event` boundary
@@ -35,7 +31,7 @@
       `:data-schema` validates the machine's `:data`. Both live together.
 
    3. **Fail-loud guard.** The bare `(reg-event id meta
-      (make-machine-handler spec))` path on a `:data-schema`-bearing spec now
+      (make-machine-handler spec))` path on a `:data-schema`-bearing spec
       RAISES `:rf.error/machine-schema-requires-reg-machine` rather than
       silently no-opping. A schema-LESS spec stays legal on the bare path."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -92,20 +88,20 @@
   ad-hoc inner sub-events (`[:noop]`, `[:auth.login/break]`) to exercise the
   registration-arity + redaction machinery, so the fixture must admit them. The
   login examples' SHIPPED schema is STRICTER (no `[:vector :any]` fallback) —
-  that corrected shape and its malformed-submit rejection are pinned separately
-  by `login-example-event-schema-rejects-malformed-submit` below (rf2-thhp91)."
+  that shape and its malformed-submit rejection are pinned separately
+  by `login-example-event-schema-rejects-malformed-submit` below."
   [:cat [:= :auth.login/flow]
    [:or
     [:cat [:= :auth.login/submit] Credentials]
     [:vector :any]]
    [:? :any]])
 
-;; The login examples' SHIPPED outer-event schema (rf2-thhp91). This is the
-;; corrected shape now registered on the :auth.login/flow machine in all three
-;; login examples (examples/reagent/login, examples/uix/login_uix,
-;; examples/helix/login_helix). Kept here as the executable spec of that shape
-;; so its malformed-submit rejection is a real regression gate (the examples
-;; tree is test-free, so the schema contract is pinned in the framework suite).
+;; The login examples' SHIPPED outer-event schema. This is the shape
+;; registered on the :auth.login/flow machine in all three login examples
+;; (examples/reagent/login, examples/uix/login_uix, examples/helix/login_helix).
+;; Kept here as the executable spec of that shape so its malformed-submit
+;; rejection is a real regression gate (the examples tree is test-free, so the
+;; schema contract is pinned in the framework suite).
 (def ^:private LoginExampleEvent
   [:cat [:= :auth.login/flow]
    [:or
@@ -139,7 +135,7 @@
                 :states      {:idle {:on {:auth.login/break {:target :idle :action :break}}}}}]
       (machines/reg-machine* flow-id {:schema AuthLoginEvent} spec)
       ;; The machine meta is stamped — machine-meta reads the spec + :data-schema
-      ;; back (the inert-schema bug: machine-meta returned nil on the old path).
+      ;; back (so the schema is live, not inert).
       (let [meta (machines/machine-meta flow-id)]
         (is (some? meta) "machine-meta is non-nil (meta WAS stamped)")
         (is (= AuthLoginData (:data-schema meta))
@@ -153,12 +149,9 @@
             "exactly one :where :machine-data trace fired — the schema is LIVE")
         (is (= flow-id (-> traces first :tags :machine-id)))))))
 
-;; NOTE (EP-0025, rf2-398kql): the two privacy-redaction tests that pinned the
-;; schema→marks bridge — `event-schema-arity-registers-redaction-marks` (a
-;; `:sensitive?` `:data-schema` slot is bridged into the marks table) and
-;; `event-schema-arity-sensitive-slot-redacted-at-egress` (it redacts at trace
-;; egress) — are REMOVED. The bridge is gone; durable machine `:data` egress
-;; classification is frame-owned, and the redaction surface is pinned by
+;; NOTE: a `:data-schema` is validation-only — it carries no schema→marks
+;; redaction bridge. Durable machine `:data` egress classification is
+;; frame-owned, and the redaction surface is pinned by
 ;; `re-frame.machine-data-schema-redaction-test` (frame-declared snapshot paths).
 
 ;; ---- (3) the event-vector :schema validates the outer vector ---------------
@@ -199,15 +192,13 @@
 
 ;; ---- (3b) the login examples' SHIPPED event schema rejects malformed submit -
 ;;
-;; Regression gate for rf2-thhp91: the login examples (reagent / uix / helix)
-;; previously registered `AuthLoginEvent` with a permissive `[:vector :any]`
-;; fallback that re-admitted a `:submit` whose Credentials failed, so a
-;; malformed submit (short password / bad email) passed the `:where :event`
-;; boundary and drove the transition + login HTTP effect. This pins the
-;; corrected `LoginExampleEvent` shape end-to-end: malformed submit is rejected
-;; at the boundary and does NOT transition; valid submit + the framework reply
-;; sub-events still pass. The examples tree is test-free, so this is where the
-;; shipped schema's contract is enforced.
+;; Regression gate for the login examples (reagent / uix / helix): the shipped
+;; `LoginExampleEvent` has no permissive `[:vector :any]` fallback, so a
+;; `:submit` whose Credentials fail is rejected at the `:where :event` boundary
+;; and does NOT transition + does NOT drive the login HTTP effect. This pins the
+;; shape end-to-end: malformed submit is rejected at the boundary; valid submit +
+;; the framework reply sub-events still pass. The examples tree is test-free, so
+;; this is where the shipped schema's contract is enforced.
 
 (deftest login-example-event-schema-rejects-malformed-submit
   (testing "the login examples' shipped LoginExampleEvent rejects a malformed
@@ -303,12 +294,12 @@
              (:rf.error/id (ex-data ex)))))))
 
 (deftest reg-machine-rejects-non-map-opts
-  ;; rf2-t65lqt — the 3-arity MIDDLE opts slot (rf2-wvh95f F2) must be a map
-  ;; BEFORE the reserved-key `contains?` / `assoc` runs. A non-map opts (vector
-  ;; / string / number) must surface the canonical :rf.error/invalid-machine-
-  ;; opts naming the machine, NOT a raw host IllegalArgumentException ("Key must
-  ;; be integer"). Mirrors reg-route's non-map metadata guard + the
-  ;; reg-resource / reg-mutation metadata-slot map gate.
+  ;; The 3-arity MIDDLE opts slot must be a map BEFORE the reserved-key
+  ;; `contains?` / `assoc` runs. A non-map opts (vector / string / number)
+  ;; must surface the canonical :rf.error/invalid-machine-opts naming the
+  ;; machine, NOT a raw host IllegalArgumentException ("Key must be integer").
+  ;; Mirrors reg-route's non-map metadata guard + the reg-resource /
+  ;; reg-mutation metadata-slot map gate.
   (testing "a vector opts slot is rejected with the canonical error id"
     (let [ex (try
                (machines/reg-machine* :rf.machine-arity/bad-vec

--- a/implementation/machines/test/re_frame/machine_schema_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.machine-schema-test
-  "Per rf2-jbbp7. Verifies the `:data-schema` key on `reg-machine` and the
-  new `:where :machine-data` validation boundary.
+  "Verifies the `:data-schema` key on `reg-machine` and the
+  `:where :machine-data` validation boundary.
 
   The contract under test:
 
@@ -27,8 +27,8 @@
       unaffected; the framework's existing behaviour is preserved.
 
    6. **Tag payload.** Failures carry `:machine-id`, `:phase`, `:value`,
-      `:explain`, `:rollback?`, `:recovery` so the Xray attachment bead
-      (rf2-xgeag) and other downstream consumers have the full surface.
+      `:explain`, `:rollback?`, `:recovery` so the Xray per-step attachment
+      and other downstream consumers have the full surface.
 
   Tests use Malli schemas (the framework default validator)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -36,9 +36,9 @@
             [re-frame.machines :as machines]
             [re-frame.registrar :as registrar]
             ;; The schemas artefact ships the registered-validator hot
-            ;; path the new `:where :machine-data` boundary routes
-            ;; through; the `.malli` adapter ns publishes Malli's
-            ;; validate/explain into the late-bind table.
+            ;; path the `:where :machine-data` boundary routes through;
+            ;; the `.malli` adapter ns publishes Malli's validate/explain
+            ;; into the late-bind table.
             [re-frame.machines.test-support :as mtest]
             [re-frame.schemas]
             [re-frame.schemas.malli]
@@ -50,8 +50,8 @@
 (defn- collect-traces!
   "Run `f` while collecting every `:rf.error/schema-validation-failure`
   trace event. Returns the captured trace events as a vector. Routed through
-  the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
-  unregister in a `finally`."
+  the shared `mtest/with-trace-capture` — guaranteed unregister in a
+  `finally`."
   [f]
   (mtest/with-trace-capture traces
     (f)
@@ -111,8 +111,8 @@
             "tag carries the offending :data value")
         (is (true? (:rollback? tag))
             "tag declares :rollback? true (commit was rolled back)")
-        ;; `:recovery` is hoisted onto the trace envelope (per rf2-twt7m),
-        ;; not inside `:tags` — mirrors the `:where :app-db` projection.
+        ;; `:recovery` is hoisted onto the trace envelope, not inside
+        ;; `:tags` — mirrors the `:where :app-db` projection.
         (is (= :no-recovery (:recovery trace-ev))
             "trace envelope declares :no-recovery (consistent with :where :app-db)")
         ;; Rollback restores pre-handler app-db.
@@ -123,7 +123,7 @@
                        [:rf.runtime/machines :snapshots :rf.machine-schema/macrostep]))
             "the machine's snapshot returns to its pre-handler value")))))
 
-;; ---- (2b) macrostep boundary on a SPAWNED actor (rf2-2t9xn3) -------------
+;; ---- (2b) macrostep boundary on a SPAWNED actor -------------
 
 (deftest spawned-actor-macrostep-violation-rolls-back-and-emits
   (testing "a SPAWNED actor (no per-instance handler) whose transition action
@@ -178,8 +178,9 @@
         (is (true? (:rollback? tag))
             "tag declares :rollback? true (commit must be rolled back)")
         ;; The whole point: the macrostep ROLLS BACK — the violating :data
-        ;; does not commit. Pre-fix, machine-meta returns nil for the spawned
-        ;; actor → validation is skipped → {:n 0} commits and no rollback fires.
+        ;; does not commit. The schema resolves off the snapshot's
+        ;; :rf/machine-type (not via machine-meta, which returns nil for a
+        ;; spawned actor), so the validation runs and the rollback fires.
         (is (= snap-before
                (get-in (rf/runtime-db-value :rf/default)
                        [:rf.runtime/machines :snapshots
@@ -259,10 +260,9 @@
         (is (nil? (get-in (rf/runtime-db-value :rf/default)
                           [:rf.runtime/machines :snapshots :rf.machine-schema/spawned]))
             "rejected spawn: snapshot is not in app-db")
-        ;; rf2-f3kp7 — atomic reject. The prior code called `reg-machine*`
-        ;; out of step with the install gate, leaking a registered event
-        ;; handler + a phantom `(rf/machines)` entry for the rejected actor.
-        ;; A schema-rejected spawn must register NOTHING.
+        ;; Atomic reject: a schema-rejected spawn registers NOTHING —
+        ;; no event handler, no `(rf/machines)` entry — the install gate
+        ;; and registration are in lockstep.
         (is (nil? (registrar/lookup :event :rf.machine-schema/spawned))
             "rejected spawn: NO event handler is registered (rf2-f3kp7)")
         (is (not (contains? (set (machines/machines)) :rf.machine-schema/spawned))
@@ -313,6 +313,6 @@
         (is (contains? tag :value)        ":value present (Xray reads the failing slot)")
         (is (contains? tag :explain)      ":explain present (Xray renders Malli explanation)")
         (is (contains? tag :rollback?)    ":rollback? present (Xray's blast-radius muting)")
-        ;; `:recovery` rides the trace envelope, not :tags (rf2-twt7m).
+        ;; `:recovery` rides the trace envelope, not :tags.
         (is (contains? trace-ev :recovery) ":recovery present on trace envelope")
         (is (string? (:reason tag))       ":reason is a human-readable string")))))

--- a/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
@@ -1,10 +1,10 @@
 (ns re-frame.machine-source-coord-cljs-test
-  "CLJS coverage for co-located per-element source stamping (rf2-npvsx +
-  rf2-vqja2, supersedes rf2-8bp3). Per Spec 005 §Source-coord stamping the
-  `reg-machine` macro walks the literal spec form at expansion time and
-  CO-LOCATES per-element source onto each guard / action / on-spawn-action
-  entry, and CO-LOCATES a reference-site `:source-coords` onto each MAP node
-  inside the `:states` tree (state-node / transition map) at its spec-path.
+  "CLJS coverage for co-located per-element source stamping. Per Spec 005
+  §Source-coord stamping the `reg-machine` macro walks the literal spec form
+  at expansion time and CO-LOCATES per-element source onto each guard /
+  action / on-spawn-action entry, and CO-LOCATES a reference-site
+  `:source-coords` onto each MAP node inside the `:states` tree (state-node /
+  transition map) at its spec-path.
 
   The CLJS counterpart of machine_source_coord_test.clj. Per the keyword-
   reference rule the macro captures:
@@ -160,7 +160,7 @@
     (is (some? (node-coords :rf2-8bp3/hier [:states :outer :states :inner :on :go]))
         "transition map inside hierarchical inner state co-locates its coord")))
 
-;; ---- inline-fn :source-code co-location (rf2-se70xj) ----------------------
+;; ---- inline-fn :source-code co-location -----------------------------------
 
 ;; Read the inline-fn `:source-code` string for an inline slot off the
 ;; enclosing `:states`-tree map node.

--- a/implementation/machines/test/re_frame/machine_source_coord_test.clj
+++ b/implementation/machines/test/re_frame/machine_source_coord_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.machine-source-coord-test
   "Per-element source-coord stamping for machine specs. Per Spec 005
-  §Source-coord stamping (rf2-npvsx + rf2-vqja2, supersedes rf2-8bp3) — the
+  §Source-coord stamping — the
   `reg-machine` macro walks the literal spec form at expansion time and
   CO-LOCATES per-element source onto each guard / action / on-spawn-action
   entry (`:guards {<id> {:fn .. :source-coords {...} :source-code \"..\"}}`),
@@ -18,7 +18,7 @@
   `:submit` transition map. Inline-fn / keyword slots (`:entry` / `:exit`
   / `:guard` / `:action` / `:on-spawn`) hold a value, not a map, so they
   carry no coord of their own; a tool reads the nearest enclosing map's
-  coord (per rf2-vqja2, mirroring the keyword-reference rule).
+  coord (mirroring the keyword-reference rule).
 
   This test runs on JVM only because the source-coord-walking macro is
   Clojure-side. CLJS tests in machine_source_coord_cljs_test.cljs cover
@@ -50,7 +50,7 @@
 
 ;; Helper: read a co-located reference-site `:source-coords` off the MAP
 ;; node (state-node / transition map) at `spec-path` inside the registered
-;; spec's `:states` tree (rf2-vqja2).
+;; spec's `:states` tree.
 (defn- node-coords [machine-id spec-path]
   (get-in (machines/machine-meta machine-id) (conj (vec spec-path) :source-coords)))
 
@@ -115,11 +115,11 @@
     (is (some? (element-coords :rf2-8bp3/on-spawn-defs :on-spawn-actions :capture-id))
         "the :capture-id on-spawn-action fn-form carries co-located :source-coords")))
 
-;; ---- inline-fn :source-code co-location (rf2-se70xj) ----------------------
+;; ---- inline-fn :source-code co-location ----------------------
 ;;
 ;; Inline `:entry` / `:exit` / `:guard` / `:action` fn LITERALS inside the
 ;; `:states` tree hold a fn VALUE, not a map, so they cannot carry a
-;; `:source-code` of their own (per rf2-vqja2 the same reason `:source-coords`
+;; `:source-code` of their own (the same reason `:source-coords`
 ;; lives on the enclosing node). The reg-machine macro co-locates each inline
 ;; fn's `pr-str` source onto the ENCLOSING `:states`-tree map node under a
 ;; `{<slot> <source-string>}` map keyed `:source-code` — so Xray's Epoch-panel
@@ -153,8 +153,8 @@
     (is (string? (get-in (machines/machine-meta :rf2-se70xj/inline-action)
                          [:guards :ok? :source-code]))
         "named guard carries :source-code (parity baseline)")
-    ;; The inline transition :action now carries :source-code on the
-    ;; enclosing transition map (the rf2-se70xj fix).
+    ;; The inline transition :action carries :source-code on the
+    ;; enclosing transition map.
     (let [src (inline-source :rf2-se70xj/inline-action [:states :idle :on :cancel] :action)]
       (is (string? src)
           "inline transition :action carries :source-code on the enclosing transition map")
@@ -455,7 +455,7 @@
            (machines/machine-meta :rf2-8bp3/plain))
         "spec round-trips verbatim")))
 
-;; ---- defmachine: value-registered per-element source capture (rf2-gwj8l) --
+;; ---- defmachine: value-registered per-element source capture --
 ;;
 ;; The common app shape is `(def m {…}) … (reg-machine :id m)`. `reg-machine`
 ;; sees only the `m` symbol at its call site, so its literal-walk captures
@@ -500,7 +500,7 @@
       (is (fn? (get-in meta [:guards :may-close?]))
           "plain (def) machine carries bare fns, not co-located entry maps")
       ;; No reference-site `:source-coords` co-located on any state-node
-      ;; (the macro saw only the symbol, so no literal walk; rf2-vqja2).
+      ;; (the macro saw only the symbol, so no literal walk).
       (is (not (contains? (get-in meta [:states :locked]) :source-coords)))
       (is (not (contains? (get-in meta [:states :open]) :source-coords)))
       (is (nil? (rf/handler-meta :machine-action [:rf2-gwj8l/plain-door :clear-hold])))

--- a/implementation/machines/test/re_frame/machine_spawn_trace_egress_test.clj
+++ b/implementation/machines/test/re_frame/machine_spawn_trace_egress_test.clj
@@ -1,21 +1,19 @@
 (ns re-frame.machine-spawn-trace-egress-test
-  "EP-0015 spawn-trace egress projection (rf2-0gdic7 / rf2-lft14p / rf2-mxboxi).
+  "Spawn-trace egress projection.
 
-  Three review findings against `implementation/machines`, all about RAW
-  child-owned payloads leaving through the parent / spawn trace surfaces even
-  though every other machine `:data` slot is projected at the egress chokepoint
-  (`re-frame.marks/project-trace-event`):
+  Three RAW child-owned payloads that could leave through the parent / spawn
+  trace surfaces are projected at the egress chokepoint
+  (`re-frame.marks/project-trace-event`), like every other machine `:data`
+  slot:
 
-   1. **`:start` payload (rf2-mxboxi).** The accepted spawn path emits
+   1. **`:start` payload.** The accepted spawn path emits
       `:rf.machine.spawn/spawned` carrying `:start (:start args)`. A child's
-      `:start` event can hold credentials / large payloads, yet
-      `project-machine-tags` projected only `:before`/`:after`/`:snapshot`/
-      `:data`/`:input`/`:cascade` — never `:start`. So the start payload
-      egressed raw (contrast `reject-unregistered-spawn!`, which deliberately
-      omits all spawn args for exactly this reason).
+      `:start` event can hold credentials / large payloads, so
+      `project-machine-tags` summarizes `:start` at egress (the same posture
+      `reject-unregistered-spawn!` takes by omitting all spawn args).
 
-   2/3. **synthetic `:on-error` payload (rf2-0gdic7 / rf2-lft14p).** When a
-      spawned child FAILS, the runtime dispatches the reserved event
+   2/3. **synthetic `:on-error` payload.** When a spawned child FAILS, the
+      runtime dispatches the reserved event
       `[:rf.machine.spawn/error <invoke-id> <error>]` into the parent. `<error>`
       is CHILD-owned: the child's raw `:output-key` result (error-leaf trigger)
       or an exception envelope including `:exception-data` (action-exception
@@ -23,15 +21,15 @@
       transition` carry that event vector under `:event`, and the parent's
       `:rf.machine/guard-evaluated` / `:rf.machine/action-ran` carry it under
       `:input :event`. The event-vector projection keys off the PARENT
-      event-id's marks (and `:rf.machine.spawn/error` is a reserved id with no
-      marks), and the payload sits at the THIRD vector position which the
-      arg-map redactor never touches — so the raw child error egressed raw.
+      event-id's marks (`:rf.machine.spawn/error` is a reserved id with no
+      marks), and the payload sits at the THIRD vector position, so the
+      projection summarizes the child error at egress.
 
-  The fix keeps RAW LOCAL parent control flow (the transition still reads the
-  raw error off `:event` via `(nth ev 2)`) but PROJECTS the synthetic on-error
-  payload + the `:start` payload at trace egress only. The posture is the same
+  Parent control flow stays RAW LOCAL (the transition reads the raw error off
+  `:event` via `(nth ev 2)`); the synthetic on-error payload + the `:start`
+  payload are PROJECTED at trace egress only. The posture is the same
   conservative fail-closed seam `project-machine-error-tags` uses: a
-  child-owned payload we cannot classify against the parent's marks is
+  child-owned payload that cannot be classified against the parent's marks is
   summarized to the `:rf/redacted` sentinel before it crosses the bus /
   epoch-capture / AI-MCP egress boundary."
   (:require [clojure.test :refer [deftest is testing]]
@@ -60,7 +58,7 @@
   []
   {:account "acct-99" :secret "secret-output-leaf"})
 
-;; ---- (mxboxi) :start payload on :rf.machine.spawn/spawned -----------------
+;; ---- :start payload on :rf.machine.spawn/spawned -------------------------
 
 (deftest spawned-start-payload-redacted-in-egress
   (testing "rf2-mxboxi — the :rf.machine.spawn/spawned trace's :start payload is
@@ -84,7 +82,7 @@
       (is (not (.contains (pr-str out) "hunter2"))
           "no raw :start password leaked"))))
 
-;; ---- (0gdic7 / lft14p) synthetic on-error payload at the parent -----------
+;; ---- synthetic on-error payload at the parent -----------------------------
 
 (defn- spawn-error-event [error]
   ;; the inner event the parent handler sees after the router strips parent-id

--- a/implementation/machines/test/re_frame/machine_spawn_unregistered_type_test.clj
+++ b/implementation/machines/test/re_frame/machine_spawn_unregistered_type_test.clj
@@ -1,14 +1,13 @@
 (ns re-frame.machine-spawn-unregistered-type-test
-  "rf2-ywv74m — fail-closed spawn of an UNREGISTERED machine TYPE.
+  "Fail-closed spawn of an UNREGISTERED machine TYPE.
 
-  Mike ruling (2026-06-15): a `:rf.machine/spawn` (or a `:spawn-all`
-  per-child) whose `:machine-id` names no registered machine TYPE — and
-  which carries no inline `:definition` — is REJECTED fail-closed and emits
-  the NEW always-on `:rf.error/machine-spawn-unregistered-type`. The
-  implicit \"spec-less spawn\" lifecycle is REMOVED: a rejected spawn
-  installs NO snapshot, NO slot, NO system-id, allocates NO spawned-id,
-  records NO spawn-order entry, fires NO `:rf.machine.spawn/spawned` trace,
-  and dispatches NO `:start`.
+  A `:rf.machine/spawn` (or a `:spawn-all` per-child) whose `:machine-id`
+  names no registered machine TYPE — and which carries no inline
+  `:definition` — is REJECTED fail-closed and emits the always-on
+  `:rf.error/machine-spawn-unregistered-type`. There is no implicit
+  spec-less spawn lifecycle: a rejected spawn installs NO snapshot, NO slot,
+  NO system-id, allocates NO spawned-id, records NO spawn-order entry, fires
+  NO `:rf.machine.spawn/spawned` trace, and dispatches NO `:start`.
 
   Pinned here (the bead's required contract):
 

--- a/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
+++ b/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
@@ -1,34 +1,32 @@
 (ns re-frame.machine-trace-frame-tag-sweep-test
-  "Per rf2-ko8jb: every `:rf.machine/*` and `:rf.error/machine-*` trace
-  event MUST carry the `:frame` tag so `re-frame.epoch.capture/capture-event!`
-  admits it into the cascade's `:trace-events` buffer. Without the tag
-  the trace is dropped silently — fans out to direct listeners but
-  never reaches the epoch-history slot the Xray Machine Inspector
-  reads from.
+  "Every `:rf.machine/*` and `:rf.error/machine-*` trace event MUST carry
+  the `:frame` tag so `re-frame.epoch.capture/capture-event!` admits it into
+  the cascade's `:trace-events` buffer. Without the tag the trace is dropped
+  silently — fans out to direct listeners but never reaches the
+  epoch-history slot the Xray Machine Inspector reads from.
 
   This test file is the sister to `re_frame.transition_frame_tag_test`
-  (rf2-hwuki, which locks `:rf.machine/transition` at registration.cljc).
-  rf2-ko8jb sweeps the remaining ~13 emit sites across:
+  (which locks `:rf.machine/transition` at registration.cljc) and sweeps the
+  remaining ~13 emit sites across:
 
     - finalize.cljc — :on-done callback throw (machine-action-exception)
     - join.cljc — invoke-all resolution traces (any-failed, all-completed,
       some-completed, cancelled-on-join-resolution, late-completion,
       bad-child-id)
     - timer.cljc — wall-clock fx-layer traces (no-clock-configured,
-      cancelled (rf2-82a0u — unified cancellation event with :reason
-      closed set), scheduled-from-watcher, after-fn-threw,
-      after-sub-threw, after-watch-failed)
+      cancelled (the unified cancellation event with its :reason closed
+      set), scheduled-from-watcher, after-fn-threw, after-sub-threw,
+      after-watch-failed)
     - transition.cljc — pure-engine traces (guard-evaluated, action-ran
       success+error, timer/scheduled, timer/skipped-on-server,
       timer/fired, timer/stale-after, raise-depth-exceeded,
       always-depth-exceeded)
 
-  The test rationale mirrors the rf2-hwuki test's: this lives in the
-  machines artefact (which doesn't depend on epoch) so the contract is
-  exercised even when the epoch artefact isn't on the test classpath.
-  A future regression that drops `:frame` from any of these sites fails
-  here first (clear cause) before the upstack epoch / Xray gates
-  notice the absent trace events."
+  The test rationale mirrors the sister test's: this lives in the machines
+  artefact (which doesn't depend on epoch) so the contract is exercised even
+  when the epoch artefact isn't on the test classpath. A future regression
+  that drops `:frame` from any of these sites fails here first (clear cause)
+  before the upstack epoch / Xray gates notice the absent trace events."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines.test-support :as mtest]
@@ -42,8 +40,7 @@
 (defn- record-traces!
   "Register a trace listener for the duration of `body-fn`, returning
   the captured trace vec. Routed through the shared
-  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed unregister
-  in a `finally`."
+  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
   [body-fn]
   (mtest/with-trace-capture seen
     (body-fn)

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -1,11 +1,11 @@
 (ns re-frame.machine-transition-purity-test
-  "Per rf2-gr8q. Locks in the contract that `machine-transition`'s
-  RETURNED VALUE is a deterministic function of its arguments —
-  identical (machine, snapshot, event) triples produce identical Result
-  values (snapshot + effects vector) INCLUDING the spawn-id sequencing
-  inside emitted `:rf.machine/spawn` fx maps.
+  "Locks in the contract that `machine-transition`'s RETURNED VALUE is a
+  deterministic function of its arguments — identical (machine, snapshot,
+  event) triples produce identical Result values (snapshot + effects vector)
+  INCLUDING the spawn-id sequencing inside emitted `:rf.machine/spawn` fx
+  maps.
 
-  ## What \"pure\" means here (rf2-3l8lqe finding #1)
+  ## What \"pure\" means here
 
   \"Pure\" is scoped to the REDUCTION: the Result depends only on the
   arguments, with no module-level mutable state and no `app-db` read. It
@@ -19,23 +19,13 @@
   the snapshot/fx value and never read back into the reduction. The
   determinism property below is therefore independent of whether any
   listener is registered — the test asserts the RETURNED Result, not the
-  absence of a trace side channel. (Decoupling trace into an
-  interpreter-owned sink is an open architectural ruling, not assumed
-  here.)
+  absence of a trace side channel.
 
-  Pre-rf2-gr8q the spawn-id allocator was a module-level
-  `(defonce spawn-counter (atom {}))` keyed on `[frame-id machine-id]`
-  in `re-frame.machines.transition`. The function's docstring promised
-  pure / deterministic but the allocator was a side effect: a second
-  identical call returned different spawn-ids (`:worker#2` vs the first
-  call's `:worker#1`). The conformance corpus only worked because the
-  per-fixture reset zeroed the atom between fixtures.
-
-  Post-rf2-gr8q the counter lives inside the snapshot at
+  The spawn-id allocator counter lives inside the snapshot at
   `:rf/spawn-counter` (a per-machine-id integer map); each spawn bumps
   the slot via `update-in` and the returned snapshot carries the bumped
-  value. The function is now deterministic from its arguments — the
-  property this test locks in.
+  value. The function is deterministic from its arguments — the property
+  this test locks in.
 
   Two flavours of the property:
 
@@ -79,11 +69,10 @@
           "two pure-call invocations from the same input produce the same next-snapshot")
       (is (= fx1 fx2)
           "two pure-call invocations from the same input produce the same effects vector")
-      ;; Per rf2-d0wem (informed by rf2-ra1he §TE1): assert only the
-      ;; load-bearing slots of the emitted spawn fx — the contract — and
-      ;; leave implementation-detail keys (`:id-prefix`, exact arg-map
-      ;; shape, the user-passed `:data` / `:start` echo) free to evolve
-      ;; without churning this test. The contract is:
+      ;; Assert only the load-bearing slots of the emitted spawn fx — the
+      ;; contract — and leave implementation-detail keys (`:id-prefix`, exact
+      ;; arg-map shape, the user-passed `:data` / `:start` echo) free to
+      ;; evolve without churning this test. The contract is:
       ;;   - the fx-id is `:rf.machine/spawn`
       ;;   - `:rf/spawned-id` is `:http/post#1` (allocator deterministic)
       ;;   - `:rf/parent-id` is `:rf/transition-pure` (sentinel for the
@@ -109,10 +98,10 @@
       ;; `get-in`.
       (is (= :authenticating (:state snap1))
           "snapshot's :state advances to :authenticating")
-      ;; Per rf2-rc8wci the pure transition now binds the spawned id into the
-      ;; parent's own `:data` under `[:rf/spawned <invoke-id>]` (XState-context
-      ;; parity) — part of the pure-fn result, deterministic from the inputs.
-      ;; No USER-domain `:data` key was written; only the reserved capture.
+      ;; The pure transition binds the spawned id into the parent's own
+      ;; `:data` under `[:rf/spawned <invoke-id>]` (XState-context parity) —
+      ;; part of the pure-fn result, deterministic from the inputs. No
+      ;; USER-domain `:data` key was written; only the reserved capture.
       (is (= {:rf/spawned {[:authenticating] :http/post#1}} (:data snap1))
           "the spawned id is captured into the parent's :data under :rf/spawned (XState-context parity)")
       (is (empty? (dissoc (:data snap1) :rf/spawned))
@@ -122,8 +111,8 @@
 
   (testing "different input snapshots allocate independently — no shared module-level counter"
     ;; Two separate input snapshots, each starting at counter 0, both
-    ;; allocate `:http/post#1`. Pre-rf2-gr8q the second would have
-    ;; produced `:http/post#2` because the atom carried over.
+    ;; allocate `:http/post#1` — the allocator counter lives in the
+    ;; snapshot, so the two calls never share state.
     (let [snap-a {:state :idle :data {:tag :a}}
           snap-b {:state :idle :data {:tag :b}}
           {fx-a ::result/fx} (machines/machine-transition auth-flow-spec snap-a [:submit])
@@ -149,10 +138,9 @@
 
 ;; ---- trace is an observability side channel, not part of the reduction ----
 ;;
-;; Per rf2-3l8lqe finding #1 (honest-purity contract): the reducer emits
-;; `trace/emit!` diagnostic events inline, but those emits are pure
-;; OBSERVABILITY — they never feed back into the returned Result. This
-;; test pins both halves of the contract the bead asks for: (a) the
+;; The honest-purity contract: the reducer emits `trace/emit!` diagnostic
+;; events inline, but those emits are pure OBSERVABILITY — they never feed
+;; back into the returned Result. This test pins both halves: (a) the
 ;; RETURNED transition value is identical whether or not a listener is
 ;; registered (the reduction is independent of the trace side channel),
 ;; and (b) the engine DID emit the expected trace data when a listener
@@ -208,7 +196,7 @@
       (is (= {:worker 3} (:rf/spawn-counter snap'))
           "three :worker children bumped the slot to 3"))))
 
-;; ---- Pure transition smoke (relocated from core/smoke_test.clj, rf2-zqar3) ----
+;; ---- Pure transition smoke ----
 ;;
 ;; These pin baseline machine-transition behaviours — flat transitions,
 ;; :always microsteps, and pre-commit :raise routing. Co-located with the
@@ -244,15 +232,14 @@
           {s ::result/snap} (machines/machine-transition m {:state :checking :data {:authed? true}} [:noop])]
       (is (= :authed (:state s))))))
 
-;; ---- depth-limit boundary parity (rf2-r26e2) ------------------------------
+;; ---- depth-limit boundary parity ------------------------------------------
 ;;
 ;; Per Spec 005 §Bounded depth (005:1276) the `:always` microstep loop and
 ;; the `:raise` drain share the same default (16) and the same intent: a
 ;; limit of N permits exactly N steps before the cascade aborts uncommitted.
-;; The `:always` loop bounds on `(>= depth limit)`; pre-rf2-r26e2 the
-;; `:raise` drain bounded on `(> depth limit)`, which silently permitted one
-;; extra recursion (N+1). These two tests pin the boundary to N on BOTH
-;; paths so the operators can never drift apart again.
+;; Both the `:always` loop and the `:raise` drain bound on `(>= depth limit)`,
+;; so a limit of N permits exactly N steps. These two tests pin the boundary
+;; to N on BOTH paths so the operators stay in lockstep.
 ;;
 ;; The boundary is a pure-engine property, observed here via the `:depth`
 ;; tag the depth-exceeded error trace carries: with the `>=` boundary the
@@ -263,8 +250,7 @@
   "Drive a pure `machine-transition` while a tooling listener records traces,
   returning the `:depth` tag of the first error trace whose `:operation`
   matches `error-op` (or nil if none fired). Routed through the shared
-  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed unregister
-  in a `finally`."
+  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
   [error-op definition snapshot event]
   (mtest/with-trace-capture seen
     (machines/machine-transition definition snapshot event)
@@ -301,8 +287,7 @@
     ;; the bound (same shape as raise-depth-exceeded-tag-carries-frame).
     ;; With :raise-depth-limit 4 and 6 raises in one batch the drain
     ;; processes raises at depths 0..3 then aborts at depth 4 — the SAME
-    ;; boundary the :always loop above hits at its limit. Pre-rf2-r26e2
-    ;; (`> depth limit`) the abort fired at depth 5 (N+1), one past parity.
+    ;; boundary the :always loop above hits at its limit (`>= depth limit`).
     (let [spec {:initial :idle
                 :data    {}
                 :raise-depth-limit 4
@@ -322,19 +307,17 @@
       (is (= 4 depth)
           ":raise aborts at depth == limit (4) — same boundary as :always (was 5 pre-fix)"))))
 
-;; ---- transitive self-chaining raise depth (rf2-b88nm) ---------------------
+;; ---- transitive self-chaining raise depth ---------------------------------
 ;;
 ;; The `raise-depth-boundary-matches-always-boundary` test above bounds
 ;; BREADTH — N raise siblings drained from a single `:fx` vector through
-;; one `drain-raises` queue. But a SELF-CHAINING single-raise (a state
-;; whose `:raise` re-targets a path that itself raises) recurses through
-;; nested `machine-transition-single` → `drain-raises` frames. Pre-fix
-;; each nested `drain-raises` restarted its depth counter at 0, so the
-;; transitive chain was UNBOUNDED: a runaway self-chain blew the JVM call
-;; stack (StackOverflowError) instead of firing the clean
-;; `:rf.error/machine-raise-depth-exceeded`. The fix threads the
-;; transitive raise-depth across the nested recursion so self-chaining
-;; raises accumulate against the same `:raise-depth-limit`.
+;; one `drain-raises` queue. A SELF-CHAINING single-raise (a state whose
+;; `:raise` re-targets a path that itself raises) recurses through nested
+;; `machine-transition-single` → `drain-raises` frames. The transitive
+;; raise-depth threads across the nested recursion so self-chaining raises
+;; accumulate against the same `:raise-depth-limit` — a runaway self-chain
+;; fires the clean `:rf.error/machine-raise-depth-exceeded` rather than
+;; blowing the JVM call stack.
 
 (deftest self-chaining-raise-bounded-transitively
   (testing "an infinitely self-chaining :raise hits :raise-depth-limit cleanly,

--- a/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.machine-transition-trigger-handler-test
-  "Per rf2-lf84g — `:rf.trace/trigger-handler` rides `:rf.machine/transition`.
+  "`:rf.trace/trigger-handler` rides `:rf.machine/transition`.
 
   Spec 009 §Trace correlation: every trace event emitted inside a
   handler's execution scope carries the in-scope handler's registration
@@ -11,12 +11,11 @@
   `*current-trigger-handler*`.
 
   Xray's machine-inspector wants 'jump to the action that just ran'
-  from a transition trace. With this widening, the registration coord
-  rides on every `:rf.machine/transition` event — tools render the
-  click-to-jump link from the same slot they already read on error
-  events.
+  from a transition trace. The registration coord rides on every
+  `:rf.machine/transition` event — tools render the click-to-jump link
+  from the same slot they read on error events.
 
-  Locked shape (per rf2-3nn8 / rf2-lf84g):
+  Locked shape:
 
     {:kind         :event           ;; machines register under :event kind
      :id           <machine-id>
@@ -31,8 +30,8 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
-;; — guaranteed unregister in a `finally`.
+;; Routed through the shared `mtest/with-trace-capture` — guaranteed
+;; unregister in a `finally`.
 (defn- record-traces
   [body-fn]
   (mtest/with-trace-capture seen

--- a/implementation/machines/test/re_frame/machine_world_inputs_ctx_test.clj
+++ b/implementation/machines/test/re_frame/machine_world_inputs_ctx_test.clj
@@ -1,6 +1,5 @@
 (ns re-frame.machine-world-inputs-ctx-test
-  "Per EP-0010 §The World-Input Rule + Spec 005 §Guards / §Actions
-  (rf2-g0m4p5).
+  "Per EP-0010 §The World-Input Rule + Spec 005 §Guards / §Actions.
 
   EP-0010 requires that durable machine decisions and snapshot writes
   depending on time / random / UUID-style host facts fold the CAUSAL
@@ -10,17 +9,12 @@
   the token is what makes the decision deterministic under restore /
   replay / SSR hydration: the SAME token replays the SAME decision.
 
-  Before this fix the machine transition path built the guard / action /
-  entry / exit callback ctx as `{:data :event :state :meta}` (+ the
-  parallel-region `:tags` / `:all-state`) — the causal token was injected
-  into event coeffects by the router but NOT exposed to machine callbacks,
-  so a durable machine guard / action had no causal way to read host facts
-  and fell back to ambient reads.
-
-  The fix threads the handler's `:rf.cofx` coeffect onto the
-  machine def (`prepare-machine-ctx`, alongside `:rf/frame` /
+  The machine transition path threads the handler's `:rf.cofx` coeffect
+  onto the machine def (`prepare-machine-ctx`, alongside `:rf/frame` /
   `:rf/platform` / `:rf/parent-id`, propagated to region specs) and
-  surfaces it on the callback ctx under the SAME `:rf.cofx` key.
+  surfaces it on the guard / action / entry / exit callback ctx under the
+  `:rf.cofx` key — so a durable machine guard / action reads host facts
+  causally rather than from an ambient clock.
 
   Coverage:
     (a) a flat-machine GUARD reads exactly the scripted `:time-ms` from

--- a/implementation/machines/test/re_frame/machines/test_support.cljc
+++ b/implementation/machines/test/re_frame/machines/test_support.cljc
@@ -1,17 +1,14 @@
 (ns re-frame.machines.test-support
   "Shared test-support helpers for the machines artefact's test suite.
-  Per rf2-3l8lqe finding #4.
 
-  Before this namespace existed, the machines tests hand-rolled the same
-  handful of fixtures and probes in dozens of small local copies: a
-  private `frame-db` (`rf/runtime-db-value`), a private `snapshot`
-  (`get-in db [:rf.runtime/machines :snapshots id]`) repeated ~30 times,
-  and a trace-capture register/unregister dance repeated ~15 times — each
-  copy a drift point when machine storage, frame handling, or trace
-  listener cleanup changes. A false green could hide where one copy was
-  updated and another still read the old shape.
+  This namespace is the suite's ONE home for the fixtures and probes the
+  machines tests share — a single `frame-db` (`rf/runtime-db-value`), a
+  single `snapshot` (`get-in db [:rf.runtime/machines :snapshots id]`), and a
+  single trace-capture register/unregister helper — so machine storage,
+  frame handling, and trace-listener cleanup have one place to track rather
+  than dozens of local copies that could drift out of sync.
 
-  This namespace gives the suite ONE home for:
+  It gives the suite ONE home for:
 
     - the **reset-runtime fixture** (re-exported from core's
       `re-frame.test-support`, so a test ns requires one support ns);

--- a/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
@@ -10,20 +10,18 @@
   Concerns covered:
     - `:after` schedules with current epoch on entry; fires on synthetic
       timer event with matching epoch; epoch advances on entry.
-    - Stale detection (rf2-7urp): real event beats timer; stale firing must
+    - Stale detection: real event beats timer; stale firing must
       not transition; `:rf.machine.timer/stale-after` trace emitted.
     - Multi-stage `:after` with guard suppression (sibling continues when
       one entry is guard-suppressed).
     - Subscription-vector dynamic delay (`:delay-source :sub` + `:rf.sub/id` + `:rf.sub/query-v`).
 
-  Per the bead: prefer dispatch-sync of the synthetic
-  `:rf.machine.timer/after-elapsed` event over wall-clock setTimeout waits,
-  so the test is deterministic under Node.
-
-  Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
+  Prefer dispatch-sync of the synthetic `:rf.machine.timer/after-elapsed`
+  event over wall-clock setTimeout waits, so the test is deterministic under
+  Node."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            ;; listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.machines.test-support :as mtest]))
@@ -32,7 +30,7 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path. Inline trace
 ;; captures below keep their raw trace.tooling register/unregister.
 (def ^:private snapshot mtest/snapshot)
@@ -107,7 +105,7 @@
       ;; detection: (a) the stale firing MUST NOT cause a transition, and
       ;; (b) the runtime emits :rf.machine.timer/stale-after as the
       ;; canonical signal so observers can distinguish "suppressed stale
-      ;; firing" from "no firing at all" (rf2-7urp).
+      ;; firing" from "no firing at all".
       (trace-tooling/register-listener! ::stale (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:http2/flow [:rf.machine.timer/after-elapsed 5000 1 [:loading]]])
       (trace-tooling/unregister-listener! ::stale)
@@ -115,8 +113,8 @@
           "stale timer must not fire its transition")
       (is (= 2 (get-in (snapshot :http2/flow) [:data :rf/after-epoch [:loading]]))
           "stale firing does not bump epoch")
-      ;; Per rf2-7urp: the stale-after trace must emit even though the
-      ;; current state (:ready) no longer carries an :after table.
+      ;; The stale-after trace must emit even though the current state
+      ;; (:ready) no longer carries an :after table.
       (is (some (fn [ev]
                   (and (= :rf.machine.timer/stale-after (:operation ev))
                        (= 5000 (:delay (:tags ev)))
@@ -171,15 +169,13 @@
             "sibling timer transitions on its own")
         (trace-tooling/unregister-listener! ::mg)))))
 
-;; ---- guarded candidate-vector :after (rf2-vvbdl) -------------------------
+;; ---- guarded candidate-vector :after -------------------------------------
 ;;
 ;; Per Spec 005 §Delayed :after transitions §Transition spec: the :after
 ;; value admits the SAME guarded candidate-vector form as an :on clause —
 ;; [{:guard g :target s} {:target s2 :action a}] — first-guard-pass-wins.
-;; Pre-rf2-vvbdl this silently no-op'd (the vector was passed whole into the
-;; single-guard resolver). The live repro was the step-deck :ws/connection
-;; machine stuck in [:active :authenticating]. This is the CLJS / reactive-
-;; substrate counterpart to the pure-engine sweep + JVM integration tests.
+;; This is the CLJS / reactive-substrate counterpart to the pure-engine sweep
+;; + JVM integration tests.
 
 (deftest machine-after-guarded-vector-cljs
   (testing "guarded candidate-vector :after under the reactive substrate —

--- a/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
@@ -5,12 +5,10 @@
   Mirrors the conformance fixtures
   ../spec/conformance/fixtures/always-single-microstep.edn (single guarded
   fire, atomic commit) and always-depth-exceeded.edn (cycle hits the bounded
-  depth limit).
-
-  Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
+  depth limit)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            ;; listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.machines.test-support :as mtest]))
@@ -19,7 +17,7 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path. Inline trace
 ;; captures below keep their raw trace.tooling register/unregister.
 (def ^:private snapshot mtest/snapshot)
@@ -75,7 +73,7 @@
   (testing ":always cycle hits depth limit — macrostep fails atomically (rf2-y3jv8q)"
     ;; Two states ping-pong via :always with always-true guards. The microstep
     ;; loop trips the depth limit; per Spec 005 §Bounded depth the macrostep
-    ;; FAILS atomically — XState v5 throws on such a runaway (rf2-y3jv8q). The
+    ;; FAILS atomically — XState v5 throws on such a runaway. The
     ;; abort routes through the failure path (the handler short-circuits to
     ;; `{}`), so no snapshot write reaches runtime-db and the already-committed
     ;; pre-event :start snapshot stays put. (Boot the machine FIRST so :start is

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -1,18 +1,15 @@
 (ns re-frame.machines-conformance-test
-  "Per rf2-d0wem (and rf2-ra1he §TE5). Drives every conformance-corpus
-  fixture whose `:fixture/calls` exercise `:machine-transition`
-  through `re-frame.machines/machine-transition` and `=`-checks the
-  result against the recorded `:expect-next-snapshot` /
+  "Drives every conformance-corpus fixture whose `:fixture/calls` exercise
+  `:machine-transition` through `re-frame.machines/machine-transition` and
+  `=`-checks the result against the recorded `:expect-next-snapshot` /
   `:expect-effects`.
 
   The conformance corpus at `spec/conformance/fixtures/*.edn` is the
-  normative behaviour description for `machine-transition`. Pre-rf2-d0wem
-  only the core artefact's `re-frame.conformance-test` ran the corpus.
-  This namespace wires the machine-related Mode B fixtures into the
-  machines artefact's own CI gate, so the spec-defined invariants run
-  on every machines-touching PR (and any machines refactor that breaks a
-  fixture surfaces at the machines artefact's gate rather than only
-  downstream at core's).
+  normative behaviour description for `machine-transition`. This namespace
+  wires the machine-related Mode B fixtures into the machines artefact's own
+  CI gate, so the spec-defined invariants run on every machines-touching PR
+  (and any machines refactor that breaks a fixture surfaces at the machines
+  artefact's gate rather than only downstream at core's).
 
   Scope:
     - Mode B fixtures only — `:fixture/calls` containing
@@ -107,10 +104,10 @@
 ;; out-of-scope for this runner and the fixture is reported as skipped.
 
 (def claimed-capabilities
-  "Capabilities the pure machine-transition primitive covers.
-  Per rf2-d0wem this is the FSM/actor capability surface; any fixture
-  declaring capabilities outside this set is reported as skipped (it
-  belongs to core's downstream runner, not this Mode B gate)."
+  "Capabilities the pure machine-transition primitive covers — the
+  FSM/actor capability surface. Any fixture declaring capabilities outside
+  this set is reported as skipped (it belongs to core's downstream runner,
+  not this Mode B gate)."
   #{:fsm/flat
     :fsm/hierarchical
     :fsm/parallel-regions
@@ -118,14 +115,13 @@
     :fsm/delayed-after
     :fsm/tags
     :fsm/final-states
-    ;; rf2-mle6e: first-class history pseudo-states (`:type :history` —
-    ;; shallow / deep / default-target). The pure `machine-transition`
-    ;; primitive records on exit + restores on re-entry against the
-    ;; in-snapshot `:rf/history` slot, so history fixtures run in this Mode B
-    ;; gate. The comprehensive record/restore corpus lands under mle6e.4.
+    ;; First-class history pseudo-states (`:type :history` — shallow / deep
+    ;; / default-target). The pure `machine-transition` primitive records on
+    ;; exit + restores on re-entry against the in-snapshot `:rf/history`
+    ;; slot, so history fixtures run in this Mode B gate.
     :fsm/history
-    ;; rf2-vf5cf: the registration-error taxonomy (Spec 009 thrown-error
-    ;; shape) — pinned by the `:reg-machine` Mode-B op against the pure
+    ;; The registration-error taxonomy (Spec 009 thrown-error shape) —
+    ;; pinned by the `:reg-machine` Mode-B op against the pure
     ;; `validate-machine!` validator.
     :fsm/registration-validation
     :actor/spawn-destroy
@@ -147,7 +143,7 @@
 
 (def claimed-spec-versions
   "Fixture spec versions this runner conforms against. Matches the core
-  runner's set (rf2-d0wem time)."
+  runner's set."
   #{"1.0"})
 
 (defn- runnable-capability-set?
@@ -177,8 +173,7 @@
 (defn- realise-machine-action
   "Build a `(fn [{:keys [data event]}])` from a DSL body. The fn returns
   `{:data <maybe-new-data> :fx <vec-of-fx>}` matching the action's
-  canonical return shape per Spec 005 §Actions (rf2-grw4i / rf2-v0rrr —
-  single context-map arg)."
+  canonical return shape per Spec 005 §Actions (single context-map arg)."
   [steps]
   (fn [{:keys [data event]}]
     (let [eval-value (requiring-resolve 're-frame.conformance/eval-value*)
@@ -203,8 +198,7 @@
 
 (defn- realise-machine-guard
   "Build a `(fn [{:keys [data event]}])` from a DSL body — returns a
-  boolean. Per Spec 005 §Guards (rf2-grw4i / rf2-v0rrr — single context-
-  map arg)."
+  boolean. Per Spec 005 §Guards (single context-map arg)."
   [steps]
   (fn [{:keys [data event]}]
     (let [eval-value (requiring-resolve 're-frame.conformance/eval-value*)
@@ -255,18 +249,17 @@
                         (catch Throwable e
                           {::result/snap nil
                            ::result/fx   [:error (.getMessage e)]}))
-        ;; rf2-y3jv8q — a bounded-depth abort (`:always` / `:raise` depth
-        ;; limit tripped on a runaway cycle) now returns a `result/fail`
-        ;; carrying the `::depth-abort?` sentinel, NOT an `:ok` rollback no-op
-        ;; (XState v5 throws on such a cycle; the silent-no-op masking it as a
-        ;; guard-blocked decline was the bug). The fixture's
-        ;; `:expect-next-snapshot` / `:expect-effects` capture the
-        ;; ATOMIC-ROLLBACK contract: the macrostep does not commit, so the
-        ;; externally-observable next-snapshot is the INPUT snapshot and the
-        ;; effects are empty (the lifecycle handler short-circuits to `{}`,
-        ;; leaving the pre-event snapshot committed). Project a depth-abort
-        ;; `:fail` onto that observable shape so the fixture asserts the same
-        ;; rollback fact under the corrected failure surface.
+        ;; A bounded-depth abort (`:always` / `:raise` depth limit tripped on
+        ;; a runaway cycle) returns a `result/fail` carrying the
+        ;; `::depth-abort?` sentinel, not an `:ok` rollback no-op (XState v5
+        ;; throws on such a cycle). The fixture's `:expect-next-snapshot` /
+        ;; `:expect-effects` capture the ATOMIC-ROLLBACK contract: the
+        ;; macrostep does not commit, so the externally-observable
+        ;; next-snapshot is the INPUT snapshot and the effects are empty (the
+        ;; lifecycle handler short-circuits to `{}`, leaving the pre-event
+        ;; snapshot committed). Project a depth-abort `:fail` onto that
+        ;; observable shape so the fixture asserts the rollback fact under the
+        ;; failure surface.
         depth-abort? (result/depth-abort? r)
         snap-out   (if depth-abort? (:snapshot call) (::result/snap r))
         fx-out     (if depth-abort? [] (::result/fx r))
@@ -374,7 +367,7 @@
           passed  (filter :passed? run)
           failed  (remove :passed? run)
           skipped (filter :skipped? all)]
-      ;; Silent-on-success (rf2-try1x): summary prints only on failure.
+      ;; Silent-on-success: summary prints only on failure.
       (when (seq failed)
         (println)
         (println "Machines conformance corpus (Mode B :machine-transition):")

--- a/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
@@ -1,7 +1,6 @@
 (ns re-frame.machines-forbidden-transition-cljs-test
   "Per Spec 005 §Transition resolution §Forbidden transitions + §Wildcard
-  transitions, and rf2-16gxd (Mike ruled 2026-06-04: DOCUMENT + nil-BLOCKS;
-  NO new sentinel).
+  transitions.
 
   The forbidden-transition idiom — re-frame2's spelling of XState v5's
   `on: {LOGOUT: undefined}` / an SCXML targetless internal
@@ -14,13 +13,12 @@
   Two unified spellings of the matching internal no-op:
     - `{:on {:logout {}}}`   — explicit empty transition map (always blocked);
     - `{:on {:logout nil}}`  — a PRESENT key with a nil value; nil is the
-      Clojure analogue of XState `undefined`, so rf2-16gxd makes it ALSO
-      block (it previously fell through to the parent — the nil-vs-{} trap).
+      Clojure analogue of XState `undefined`, so it ALSO blocks.
 
   The whole idiom turns on PRESENCE: a child with NO `:logout` key still
   INHERITS the parent's (absence ≠ block). And a forbidden block is an
   ENABLED internal candidate, so — unlike a GUARD-BLOCKED candidate, which
-  falls through to `:ns/*` / `:*` / the parent (rf2-icj9t) — it shadows
+  falls through to `:ns/*` / `:*` / the parent — it shadows
   every coarser descriptor AND every ancestor for that event.
 
   Exercised through `reg-machine` / `dispatch-sync` — the same runtime
@@ -34,8 +32,8 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
@@ -46,7 +44,7 @@
   snapshot is synthesised lazily on first dispatch)."
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
-    ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
+    ;; Machine snapshots are durable runtime-db state.
     (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots machine-id] snap)}))
@@ -80,7 +78,8 @@
           "the empty-map child entry matched + halted the walk — parent :logout NOT inherited; state unchanged"))))
 
 ;; ---------------------------------------------------------------------------
-;; (b) `{:on {:logout nil}}` ALSO blocks — THE FIX (was falling through)
+;; (b) `{:on {:logout nil}}` ALSO blocks (a present nil is the XState
+;;     `undefined` analogue)
 ;; ---------------------------------------------------------------------------
 
 (deftest nil-child-entry-also-blocks-parent-inherited-transition
@@ -94,8 +93,8 @@
              :on      {:logout [:unauthenticated]}
              :states
              ;; :modal opts OUT with a PRESENT nil value — the XState
-             ;; `LOGOUT: undefined` analogue. Pre-fix this fell through to
-             ;; the parent's :logout (the nil-vs-{} trap); post-fix it blocks.
+             ;; `LOGOUT: undefined` analogue. A present nil blocks the
+             ;; parent's :logout (it does not fall through).
              {:dashboard {:on {:open-modal :modal}}
               :modal     {:on {:logout nil             ;; FORBIDDEN — present nil
                                :close  :dashboard}}}}
@@ -207,7 +206,7 @@
 ;;     A forbidden block (enabled internal candidate) does NOT fall to a
 ;;     same-level wildcard, NOR to a parent wildcard — it is a deliberate
 ;;     consume-here. This is the OPPOSITE of a GUARD-BLOCKED exact, which
-;;     DOES fall through (rf2-icj9t). Test both halves so the distinction is
+;;     DOES fall through. Test both halves so the distinction is
 ;;     pinned.
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
@@ -11,11 +11,11 @@
     - Compound state: sibling-leaf transition fires only the leaf
       exit/entry (LCA cascade).
     - Deepest-wins: leaf overrides parent for the same event id.
-    - Wildcard precedence (rf2-fhb9): leaf `:*` shadows parent's explicit
+    - Wildcard precedence: leaf `:*` shadows parent's explicit
       handler at the same event; parent fallthrough still works when the
       leaf declares neither explicit nor `:*`.
 
-  Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
+  Counterpart to the non-hierarchical coverage in `machines_cljs_test.cljs`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -25,7 +25,7 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
@@ -36,7 +36,7 @@
   exercise a different leaf without rebuilding the whole machine)."
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
-    ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
+    ;; Machine snapshots are durable runtime-db state.
     (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots machine-id] snap)}))
@@ -70,13 +70,12 @@
                           :on    {:close :dashboard}}}}}}]
       (rf/reg-machine :auth/flow machine)
       ;; The runtime cascades the declared :initial through compound
-      ;; :initial chains on first-snapshot synthesis (rf2-m1tv), so the
-      ;; first event dispatches against the deepest leaf without us
-      ;; having to seed the snapshot manually. Per rf2-0z73, the
-      ;; initial-state cascade ALSO fires every state's :entry action
-      ;; on first-event bootstrap (shallowest-first along the initial
-      ;; chain) — so the log accumulates :enter-auth + :enter-dash
-      ;; BEFORE the sibling-leaf transition kicks in.
+      ;; :initial chains on first-snapshot synthesis, so the first event
+      ;; dispatches against the deepest leaf without us having to seed the
+      ;; snapshot manually. The initial-state cascade ALSO fires every
+      ;; state's :entry action on first-event bootstrap (shallowest-first
+      ;; along the initial chain) — so the log accumulates :enter-auth +
+      ;; :enter-dash BEFORE the sibling-leaf transition kicks in.
       (reset! log [])
       ;; Sibling-leaf transition. LCA is :authenticated; only the leaf
       ;; exit/entry hooks fire for the transition itself — the parent's
@@ -120,13 +119,12 @@
           "internal transition — snapshot unchanged")
       (is (= [:leaf] @log) "leaf's :help action fired; parent shadowed"))))
 
-;; ---- wildcard precedence in hierarchical machines (rf2-fhb9) -------------
+;; ---- wildcard precedence in hierarchical machines ------------------------
 ;; Per Spec 005 §Wildcard transitions and §Transition resolution: at each
 ;; level, explicit-event match beats `:*`; only if neither matches does the
 ;; runtime walk up to the parent. So a leaf's `:*` SHADOWS a parent's
 ;; explicit handler for the same event — wildcard wins at the deeper level
-;; before parent fallthrough kicks in. This is the divergence point that
-;; the §Wildcard transitions list at L213-218 used to muddle (rf2-fhb9).
+;; before parent fallthrough kicks in.
 (deftest machine-hierarchical-wildcard-precedence-cljs
   (testing "leaf :* shadows parent's explicit handler for the same event"
     (let [log (atom [])
@@ -181,13 +179,11 @@
           "no explicit anywhere — parent's :* fires"))))
 
 ;; ---- external (:reenter? true) vs internal self-transitions ---------------
-;; (rf2-46ban introduced external self-transitions; rf2-eicq0 FLIPPED the
-;; default to XState-v5 internal-default.)
 ;; Per Spec 005 §Self-transitions: a self/ancestor `:target` is INTERNAL BY
 ;; DEFAULT — the action fires, `:exit`/`:entry` do NOT, the configuration is
 ;; unchanged (XState-v5 semantics). The EXTERNAL self-transition — `:exit`
 ;; then the transition's `:action` then `:entry`, re-descending a compound's
-;; `:initial` chain — is now the opt-in `:reenter? true`. This ns exercises
+;; `:initial` chain — is the opt-in `:reenter? true`. This ns exercises
 ;; the live runtime; the pure-engine ordering is pinned in the SCXML
 ;; conformance corpus (`scxml-external-self-transition-*` /
 ;; `scxml-reenter-*`).
@@ -208,9 +204,9 @@
                    :on    {:refresh {:target :same-state :reenter? true :action :poke}}}}}]
       (rf/reg-machine :self/flat-same-state machine)
       ;; Prime: the first dispatch fires the bootstrap initial-cascade
-      ;; entry (per rf2-0z73). A benign unhandled event drives that
-      ;; bootstrap without touching :idle, so the reset below leaves only
-      ;; the self-transition's own exit/action/entry in the log.
+      ;; entry. A benign unhandled event drives that bootstrap without
+      ;; touching :idle, so the reset below leaves only the
+      ;; self-transition's own exit/action/entry in the log.
       (rf/dispatch-sync [:self/flat-same-state [:rf2-46ban/prime]])
       (reset! log [])
       (rf/dispatch-sync [:self/flat-same-state [:refresh]])
@@ -265,11 +261,10 @@
       (is (= [:poke] @log)
           "ONLY the action fired — no exit, no entry (internal semantics preserved)")))
 
-  ;; ---- rf2-eicq0: the v5 DEFAULT FLIP --------------------------------------
-  ;; A self/own-keyword `:target` WITHOUT `:reenter?` is now INTERNAL — the
-  ;; OLD external-default (rf2-46ban) is gone. This is the breaking regression
-  ;; guard: a `:target :same-state` with no `:reenter?` must NOT fire
-  ;; exit/entry.
+  ;; ---- the v5 internal-default --------------------------------------------
+  ;; A self/own-keyword `:target` WITHOUT `:reenter?` is INTERNAL. This is the
+  ;; regression guard: a `:target :same-state` with no `:reenter?` must NOT
+  ;; fire exit/entry.
   (testing "DEFAULT-INTERNAL self-transition (:target :same-state, NO
             :reenter?) — action ONLY, no exit/entry (XState-v5 flip, rf2-eicq0)"
     (let [log (atom [])
@@ -368,22 +363,19 @@
           "exit the active child :idle → action at the LCCA (:session) → re-enter :initial (:active); :session itself NOT exited/entered (no :reenter?)"))))
 
 ;; ---- external (:reenter? true) transition to a PROPER ANCESTOR -----------
-;; (LCCA ancestor-restart geometry — rf2-emz8l; default flipped by rf2-eicq0)
+;; (LCCA ancestor-restart geometry)
 ;;
 ;; Per Spec 005 §Entry/exit cascading along the LCCA + XState v5 / SCXML
 ;; §3.13: a `:reenter? true` transition from a descendant leaf to one of its
 ;; PROPER ANCESTORS A restarts A — A's active subtree (including A) exits, the
 ;; transition action fires at the LCCA (A's parent), then A re-enters and
-;; re-descends its `:initial` chain. Under the rf2-eicq0 v5 flip RE-ENTERING
-;; THE ANCESTOR ITSELF is OPT-IN; an ancestor target WITHOUT `:reenter?` does
-;; NOT exit/re-enter the ancestor BUT (rf2-gt1pu) still RE-RESOLVES its active
+;; re-descends its `:initial` chain. RE-ENTERING THE ANCESTOR ITSELF is
+;; OPT-IN (`:reenter? true`); an ancestor target WITHOUT `:reenter?` does
+;; NOT exit/re-enter the ancestor BUT still RE-RESOLVES its active
 ;; descendants (children reset to :initial) — it is not a no-op.
-;; Before rf2-emz8l the engine bounded the exit set by the longest common
-;; PREFIX of the source path and the initial-cascaded target leaf, so an
-;; ancestor target was a SILENT NO-OP. This ns exercises the LIVE runtime
-;; (`reg-machine` / `dispatch-sync`); the pure-engine geometry + ordering is
-;; pinned in the SCXML conformance corpus
-;; (`scxml-external-transition-to-proper-ancestor-*`).
+;; This ns exercises the LIVE runtime (`reg-machine` / `dispatch-sync`);
+;; the pure-engine geometry + ordering is pinned in the SCXML conformance
+;; corpus (`scxml-external-transition-to-proper-ancestor-*`).
 (deftest machine-ancestor-restart-cljs
   (testing ":reenter? true transition to a proper ANCESTOR restarts that
             ancestor — exit subtree (incl. ancestor) → action → re-enter
@@ -456,7 +448,7 @@
       (is (= [:exit-2 :exit-a :enter-a :enter-1] @log)
           "exit :two then :a → re-enter :a → re-init :one")))
 
-  ;; ---- rf2-gt1pu: ancestor target WITHOUT :reenter? RE-RESOLVES descendants -
+  ;; ---- ancestor target WITHOUT :reenter? RE-RESOLVES descendants -----------
   (testing "DEFAULT ancestor target (NO :reenter?) does NOT re-enter the
             ancestor itself, but RE-RESOLVES its active descendants — children
             reset to the ancestor's :initial. XState v5: 'an explicit target

--- a/implementation/machines/test/re_frame/machines_initial_cascade_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_initial_cascade_cljs_test.cljs
@@ -1,11 +1,9 @@
 (ns re-frame.machines-initial-cascade-cljs-test
-  "CLJS-side coverage for the initial-state cascade on first dispatch
-  (rf2-m1tv). Per Spec 005 §Initial-state cascading: when a machine is first
+  "CLJS-side coverage for the initial-state cascade on first dispatch.
+  Per Spec 005 §Initial-state cascading: when a machine is first
   instantiated and its declared `:initial` lands on a compound state, the
   runtime descends the `:initial` chain to a leaf path on snapshot synthesis.
-  Without this, the first event resolves against the wrong state-node level.
-
-  Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
+  Without this, the first event resolves against the wrong state-node level."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -15,7 +13,7 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 

--- a/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
@@ -1,17 +1,16 @@
 (ns re-frame.machines-ns-wildcard-cljs-test
   "Per Spec 005 §Wildcard transitions §Namespaced (partial) event
-  descriptors and rf2-z4t2v. CORRECTNESS coverage for the NAMESPACE-WILDCARD
-  event-descriptor tier (Mike ruled 2026-06-04: ADD `:ns/*`).
+  descriptors. CORRECTNESS coverage for the NAMESPACE-WILDCARD
+  event-descriptor tier `:ns/*`.
 
-  The ruled invariant: `:on` resolves THREE descriptor tiers most-specific
-  first — EXACT `:foo/bar` > NAMESPACE-WILDCARD `:foo/*` > TOTAL `:*` — at
-  each level, before walking to the parent. `:foo/*` is re-frame2's spelling
-  of XState v5's partial (prefix) event descriptor `mouse.*` (SCXML §3.12.1
+  The invariant: `:on` resolves THREE descriptor tiers most-specific first —
+  EXACT `:foo/bar` > NAMESPACE-WILDCARD `:foo/*` > TOTAL `:*` — at each
+  level, before walking to the parent. `:foo/*` is re-frame2's spelling of
+  XState v5's partial (prefix) event descriptor `mouse.*` (SCXML §3.12.1
   dot-prefix tokens): re-frame2 events are namespaced keywords, so the
   keyword namespace is the natural prefix tier. The `:ns/*` tier integrates
-  with the rf2-icj9t wildcard-fallthrough: a guard-blocked exact key falls
-  through to `:ns/*`, a guard-blocked `:ns/*` falls through to `:*`, then to
-  the parent.
+  with the wildcard-fallthrough: a guard-blocked exact key falls through to
+  `:ns/*`, a guard-blocked `:ns/*` falls through to `:*`, then to the parent.
 
   Exercised through `reg-machine` / `dispatch-sync` — the same runtime
   surface real apps use."
@@ -24,8 +23,8 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
@@ -35,7 +34,7 @@
   the whole machine."
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
-    ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
+    ;; Machine snapshots are durable runtime-db state.
     (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots machine-id] snap)}))
@@ -136,7 +135,7 @@
       (rf/reg-machine :z4t2v/blocked-exact->ns machine)
       (reset! log [])
       ;; Exact :mouse/down's guard returns false ⇒ not enabled ⇒ fall through
-      ;; to the same-level :mouse/* (rf2-icj9t fallthrough across tiers).
+      ;; to the same-level :mouse/* (fallthrough across tiers).
       (rf/dispatch-sync [:z4t2v/blocked-exact->ns [:mouse/down]])
       (is (= [:ns-any] @log)
           "guard-blocked exact :mouse/down fell through to :mouse/*")

--- a/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
@@ -1,9 +1,9 @@
 (ns re-frame.machines-on-error-cljs-test
-  "Per rf2-5hlsh — first-class `:spawn :on-error` (XState v5 invoke `onError`).
+  "First-class `:spawn :on-error` (XState v5 invoke `onError`).
 
   When a `:spawn`-spawned child FAILS, the runtime routes the failure to the
   spawning parent's `:spawn :on-error` TRANSITION (control flow — a declarative
-  parent state change), SYMMETRIC with the existing `:spawn :on-done` teardown
+  parent state change), SYMMETRIC with the `:spawn :on-done` teardown
   hook. Two triggers:
 
     (1) the child reaches a designated ERROR `:final?` leaf (`:error? true`) —
@@ -11,12 +11,11 @@
         transition's `:event`;
     (2) an uncaught child action exception
         (`:rf.error/machine-action-exception`) — the exception envelope rides
-        into the `:on-error` transition's `:event` (this was formerly
-        observability-only).
+        into the `:on-error` transition's `:event`.
 
-  `:on-error` is ADDITIVE: the trace emission (observability) and the explicit
-  dispatch-back-to-parent escape hatch both keep working; `:on-error` is the
-  declarative invoke-site control-flow form.
+  `:on-error` works alongside both observability surfaces: the trace emission
+  and the explicit dispatch-back-to-parent escape hatch both keep working;
+  `:on-error` is the declarative invoke-site control-flow form.
 
   Tests:
     (a) child reaches error `:final?` leaf → parent `:on-error :target` fires
@@ -29,14 +28,14 @@
         unchanged (regression);
     (f) malformed `:on-error` / `:error?`-without-`:final?` rejected at
         registration;
-    (g) parallel-PARENT region `:spawn` (rf2-r09fc) — a `:spawn` declared
+    (g) parallel-PARENT region `:spawn` — a `:spawn` declared
         inside a parallel REGION keys its `:spawned` slot under the REAL
         parent (not `:rf/transition-pure`), so BOTH the region's `:spawn
         :on-done` and `:spawn :on-error` resolve REGION-SCOPED end-to-end
         (error `:final?` leaf AND uncaught child-action exception), with the
         sibling region untouched.
     (h) parallel-region explicit `:on {:rf.machine.spawn/error …}` escape
-        hatch is REGION-scoped (rf2-w84jv) — a sibling region's explicit
+        hatch is REGION-scoped — a sibling region's explicit
         handler must NOT catch another region's child failure.
 
   Named `*-cljs-test.cljc` so it runs under both cognitect.test-runner (JVM)
@@ -59,8 +58,8 @@
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
 (defn- spawned-id-for
@@ -332,22 +331,21 @@
                                               :on-error {:target :errored}}}
                             :errored {:final? true :error? true}}})))))
 
-;; ---- (g) parallel-PARENT region :spawn :on-done / :on-error (rf2-r09fc) -----
+;; ---- (g) parallel-PARENT region :spawn :on-done / :on-error -----
 ;;
-;; Per rf2-r09fc — a declarative `:spawn` declared INSIDE a parallel REGION
-;; must key its `[:rf.runtime/machines :spawned <parent> <invoke-id>]` slot
-;; under the REAL parent machine-id (the parallel machine itself), NOT the
+;; A declarative `:spawn` declared INSIDE a parallel REGION keys its
+;; `[:rf.runtime/machines :spawned <parent> <invoke-id>]` slot under the REAL
+;; parent machine-id (the parallel machine itself), NOT the
 ;; `:rf/transition-pure` fallback. `parallel/reduce-regions` re-stamps the live
 ;; parent-id onto the synthetic region-spec, so both `:spawn :on-done` AND
-;; `:spawn :on-error` (rf2-5hlsh) resolve region-scoped end-to-end. The
+;; `:spawn :on-error` resolve region-scoped end-to-end. The
 ;; resolvers (`pick-spawn-done-transition` / `pick-spawn-error-transition`)
 ;; strip the region-name prefix off the invoke-id so the hook fires at the
 ;; region's own state level — exactly as `pick-after-transition` does.
 ;;
-;; The bead's quirk was that the region's child carried a bogus
-;; `:data :rf/parent-id` of `:rf/transition-pure`, so NEITHER hook could
-;; resolve the parent from the child's finalize. These tests assert the slot
-;; now keys under the real parent and both hooks fire region-scoped.
+;; The region's child carries its `:data :rf/parent-id` as the real parent so
+;; both hooks resolve the parent from the child's finalize. These tests assert
+;; the slot keys under the real parent and both hooks fire region-scoped.
 
 (deftest parallel-region-spawn-keys-slot-under-real-parent
   (testing "a :spawn declared inside a parallel region keys its :spawned slot under the REAL parent id (not :rf/transition-pure) and the child's :data :rf/parent-id is the real parent (rf2-r09fc)"
@@ -476,18 +474,17 @@
       (is (= :idle (get-in (snapshot :rf2-r09fc-g3/parent) [:state :other]))
           "the sibling :other region is untouched — :on-error is region-local"))))
 
-;; ---- (h) explicit :on {:rf.machine.spawn/error …} escape hatch is REGION-scoped (rf2-w84jv) ----
+;; ---- (h) explicit :on {:rf.machine.spawn/error …} escape hatch is REGION-scoped ----
 ;;
-;; Per rf2-w84jv — the spawn-error broadcast reaches EVERY region's resolver
+;; The spawn-error broadcast reaches EVERY region's resolver
 ;; (`drain-parent-queue`), so the explicit `:on {:rf.machine.spawn/error …}`
-;; escape-hatch arm of `pick-spawn-error-transition` must decline outright in a
+;; escape-hatch arm of `pick-spawn-error-transition` declines outright in a
 ;; FOREIGN region (a region whose name does not match the invoke-id head),
 ;; SYMMETRIC with the `:spawn :on-error` arm and with `pick-done-transition`'s
-;; region-identity `decline-region?` gate. Before the fix the foreign region
-;; nilled its invoke-id (correctly disabling the `:spawn :on-error` arm) but
-;; still fell through to the explicit-`:on` arm, letting a SIBLING region's
-;; explicit handler catch another region's child failure — violating XState v5
-;; `invoke onError` region scoping.
+;; region-identity `decline-region?` gate. A foreign region nils its invoke-id
+;; (disabling the `:spawn :on-error` arm) AND declines the explicit-`:on` arm,
+;; so a SIBLING region's explicit handler never catches another region's child
+;; failure — upholding XState v5 `invoke onError` region scoping.
 
 (deftest parallel-region-explicit-on-spawn-error-is-region-scoped
   (testing "an explicit :on {:rf.machine.spawn/error …} in a sibling region does NOT catch another region's child failure (rf2-w84jv)"
@@ -505,8 +502,8 @@
     ;; the event falls through to the explicit-`:on` walk). :loader's own
     ;; explicit `:on {:rf.machine.spawn/error :handled}` then catches it
     ;; in-region; the sibling :other declares a DECOY explicit handler that
-    ;; must NEVER fire — the failure belongs to :loader's region. Before the
-    ;; fix :other's decoy caught :loader's child failure (foreign-region leak).
+    ;; must NEVER fire — the failure belongs to :loader's region, and the
+    ;; explicit escape hatch is region-scoped.
     (rf/reg-machine :rf2-w84jv-h/parent
       {:type    :parallel
        :data    {}

--- a/implementation/machines/test/re_frame/machines_raise_chain_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_raise_chain_cljs_test.cljs
@@ -1,19 +1,17 @@
 (ns re-frame.machines-raise-chain-cljs-test
-  "CLJS-side coverage for the `:raise` chain (rf2-c0nt) under the Reagent
-  reactive substrate.
+  "CLJS-side coverage for the `:raise` chain under the Reagent reactive
+  substrate.
 
   Per Spec 005 §`:raise`: an `:action` may return `{:fx [[:raise <event-vec>]]}`
   to re-enter the same machine pre-commit. The handler in `drain-raises`
   recurses through `machine-transition`, so a chain of raises threads through
   multiple transitions before the macrostep commits.
 
-  Pre-fix `drain-raises` looked up `machine-transition` with `(resolve …)`.
-  The fix (rf2-c0nt) drops that indirection in favour of a direct call backed
-  by an explicit `(declare machine-transition)` forward reference. This test
-  pins regression coverage for the :raise-chain path on CLJS so that future
-  refactors of `drain-raises` cannot silently break the recursive entry point.
-
-  Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
+  `drain-raises` calls `machine-transition` directly, backed by an explicit
+  `(declare machine-transition)` forward reference. This test pins
+  regression coverage for the :raise-chain path on CLJS so that future
+  refactors of `drain-raises` cannot silently break the recursive entry
+  point."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -23,7 +21,7 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 

--- a/implementation/machines/test/re_frame/machines_reply_test.cljc
+++ b/implementation/machines/test/re_frame/machines_reply_test.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.machines-reply-test
   "Pure unit tests for `re-frame.machines.reply` — the machine family's
   slice of the uniform reply envelope (EP-0011 §Machine Completion /
-  §Timer Reply; Managed-Effects §The uniform reply envelope, rf2-zqefg3.4).
+  §Timer Reply; Managed-Effects §The uniform reply envelope).
 
   These exercise the PURE reply-shaping helpers directly: the
   `:rf.work/machine` work-id construction (generation parsed off the
@@ -37,13 +37,12 @@
       (is (= wid (m-reply/spawn-work-id :a/b#3 [:x])))
       (is (= wid (read-string (pr-str wid)))))))
 
-;; ---- (rf2-ny0yrz C4) cross-platform actor-generation determinism ----------
-;; CLJS `js/parseInt "3abc" 10` leniently yields 3, while CLJ
-;; `Long/parseLong "3abc"` THROWS → falls through to generation 1. A
-;; `:fixed-actor-id` carrying a `#` followed by a non-fully-numeric suffix
-;; therefore minted DIFFERENT work-ids per platform — a determinism break.
-;; The CLJS branch now tests `#"\d+"` (fully numeric) before parseInt so
-;; both platforms default a malformed suffix to generation 1.
+;; ---- cross-platform actor-generation determinism --------------------------
+;; A `:fixed-actor-id` carrying a `#` followed by a non-fully-numeric suffix
+;; defaults to generation 1 on BOTH platforms. CLJS `js/parseInt "3abc" 10`
+;; leniently yields 3 while CLJ `Long/parseLong "3abc"` THROWS, so the CLJS
+;; branch tests `#"\d+"` (fully numeric) before parseInt — both platforms
+;; agree on generation 1 for a malformed suffix (no determinism break).
 
 (deftest actor-generation-numeric-suffix
   (testing "a fully-numeric #n suffix parses to n on both platforms"
@@ -58,7 +57,8 @@
 (deftest actor-generation-malformed-suffix-is-one-cross-platform
   (testing "C4: a # followed by a NON-fully-numeric suffix is generation 1 on
             BOTH CLJ and CLJS (no lenient js/parseInt divergence)"
-    ;; partially-numeric: CLJS js/parseInt used to yield 3 here; CLJ threw → 1
+    ;; partially-numeric: a lenient CLJS js/parseInt would yield 3 here, CLJ
+    ;; would throw — the `#"\d+"` pre-check defaults both to 1
     (is (= 1 (m-reply/actor-generation :weird/actor#3abc))
         "partially-numeric suffix defaults to generation 1 on both platforms")
     ;; non-numeric suffix: NaN (CLJS) / throw (CLJ) — both already → 1
@@ -189,7 +189,7 @@
                :frame           :rf/default})]
       (is (= :stale (:status r)))
       (is (= :timer (:work/kind r)) "machine :after is a specialized timer instance")
-      ;; rf2-niarhz — the canonical :work/id joins the uniform work/reply rows;
+      ;; the canonical :work/id joins the uniform work/reply rows;
       ;; the SCHEDULED epoch (the timer's attempt identity) keys it.
       (is (= [:rf.work/timer [:a/multi :loading] 1] (:work/id r)))
       (is (= :suppressed (:work/status r)))
@@ -225,7 +225,7 @@
         (is (true? (-> r :correlation :guard-suppressed?)))
         (is (reply/valid-reply? r))))))
 
-;; ---- terminal cancellation replies (rf2-sfunt8) ---------------------------
+;; ---- terminal cancellation replies ----------------------------------------
 
 (deftest cancelled-timer-reply-is-canonical
   (testing "rf2-sfunt8 — a cancelled :after timer is :status :cancelled DATA"

--- a/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
@@ -12,24 +12,22 @@
     - `:spawn` spawns child on entry and destroys it on exit; the
       deterministic actor id is tracked in the runtime spawn-registry slot
       (the on-spawn callback is advisory — its return is dropped).
-    - `:spawn :data` fn-form materialised at spawn (rf2-h131): the spawned
+    - `:spawn :data` fn-form materialised at spawn: the spawned
       child receives the result map, not the fn; fn sees the post-action
       snapshot.
-    - State-level `:after` on a `:spawn`-bearing state (rf2-3y3y):
+    - State-level `:after` on a `:spawn`-bearing state:
       synthetic timer-elapsed cancels the child via the standard exit
       cascade and transitions the parent.
     - `:timeout-ms` on `:spawn` / `:spawn-all` is rejected at registration
-      with `:rf.error/spawn-timeout-ms-removed` (rf2-3y3y).
+      with `:rf.error/spawn-timeout-ms-removed`.
 
   The on-spawn callback fires inline during `apply-transition-once` (advisory
   — its return is dropped); the deterministic child id is read back from the
   runtime spawn-registry slot at
-  `[:rf.runtime/machines :spawned <parent> <invoke-id>]`.
-
-  Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
+  `[:rf.runtime/machines :spawned <parent> <invoke-id>]`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            ;; listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.machines.test-support :as mtest]))
@@ -38,8 +36,8 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path. The per-section
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path. The per-section
 ;; trace captures below keep their raw trace.tooling register/unregister: they
 ;; reset and re-scope the capture mid-test (interleaved with assertions), which
 ;; the scope-macro / :each-fixture forms cannot express.
@@ -51,12 +49,12 @@
           {:initial :idle
            :data    {:credentials {:user "alice" :pass "secret"}}
            :on-spawn-actions
-           ;; Per Spec 005 §Declarative :spawn (rf2-grw4i / rf2-v0rrr):
-           ;; on-spawn callback takes a single context-map. The callback is
-           ;; advisory — its return is DROPPED and the runtime tracks the
-           ;; spawned id at [:rf.runtime/machines :spawned <parent> <invoke-id>]
-           ;; regardless. Returns nil (observational; rf2-dtth6 warns on a
-           ;; non-nil dropped return).
+           ;; Per Spec 005 §Declarative :spawn: on-spawn callback takes a
+           ;; single context-map. The callback is advisory — its return is
+           ;; DROPPED and the runtime tracks the spawned id at
+           ;; [:rf.runtime/machines :spawned <parent> <invoke-id>]
+           ;; regardless. Returns nil (observational; a non-nil dropped
+           ;; return warns).
            {:auth/record-actor (fn [{:keys [id]}]
                                  (js/console.debug "spawned" id) nil)}
            :states
@@ -73,10 +71,9 @@
                      :auth/failed    :idle}}
 
             :authenticated {}}}
-          ;; rf2-ywv74m — the spawned child TYPE must be REGISTERED before it
-          ;; is spawned (the implicit "spec-less spawn" path is removed; an
-          ;; unregistered `:machine-id` now rejects fail-closed with
-          ;; `:rf.error/machine-spawn-unregistered-type`). Register a minimal
+          ;; The spawned child TYPE must be REGISTERED before it is spawned:
+          ;; an unregistered `:machine-id` rejects fail-closed with
+          ;; `:rf.error/machine-spawn-unregistered-type`. Register a minimal
           ;; `:http/post` child so the spawn is accepted — matching the JVM
           ;; `spawn_registry_test`'s `(reg-machine :http/post …)`.
           child  {:initial :running :data {} :states {:running {}}}
@@ -92,10 +89,9 @@
       (rf/dispatch-sync [:auth3/flow [:submit]])
       (let [s (snapshot :auth3/flow)]
         (is (= :authenticating (:state s)))
-        ;; Per rf2-grw4i / rf2-v0rrr `:on-spawn` is purely advisory —
-        ;; the runtime tracks the spawned id at [:rf.runtime/machines :spawned <parent>
-        ;; <invoke-id>] instead of relying on the user-supplied callback
-        ;; to write into `:data`.
+        ;; `:on-spawn` is purely advisory — the runtime tracks the spawned
+        ;; id at [:rf.runtime/machines :spawned <parent> <invoke-id>] instead
+        ;; of relying on the user-supplied callback to write into `:data`.
         (is (= :http/post#1
                (get-in (rf/runtime-db-value :rf/default)
                        [:rf.runtime/machines :spawned :auth3/flow [:authenticating]]))
@@ -117,7 +113,7 @@
                 @traces)
           "expected :rf.machine/destroyed trace targeting :http/post#1"))))
 
-;; ---- two-axis spawn observation (rf2-qpuk4) -----------------------------
+;; ---- two-axis spawn observation -----------------------------------------
 ;; A spawn emits TWO traces: the fx-substrate observation
 ;; `:rf.machine.spawn/spawned` (the spawn fx ran) AND the registrar-substrate
 ;; observation `:rf.machine.lifecycle/spawned` (the actor's snapshot landed in
@@ -155,7 +151,7 @@
                 @traces)
           "registrar-substrate axis: expected :rf.machine.lifecycle/spawned carrying :spawned-id + initial :state"))))
 
-;; ---- :spawn :data fn-form materialised at spawn (rf2-h131) --------------
+;; ---- :spawn :data fn-form materialised at spawn -------------------------
 ;; Per Spec 005 §Spec-spec keys (line 1503/1511): `:data` admits a function
 ;; form `(fn [snap ev] data)` so the spawned child's initial data can be
 ;; derived from the parent's post-action snapshot + the triggering event.
@@ -202,11 +198,11 @@
              (:url (:data (snapshot :h131b/worker#1))))
           "fn-form saw the :data writes the transition's :action made"))))
 
-;; ---- state-level :after on :spawn-bearing state (rf2-3y3y) --------------
+;; ---- state-level :after on :spawn-bearing state -------------------------
 ;; Per Spec 005 §Wall-clock timeouts on :spawn — use parent state's :after.
-;; The pre-rf2-3y3y :timeout-ms slot on :spawn / :spawn-all is dropped;
-;; wall-clock guards are expressed via :after on the :spawn-bearing state
-;; itself. When :after fires, the standard exit cascade tears down the
+;; Wall-clock guards on a spawn are expressed via :after on the
+;; :spawn-bearing state itself (:spawn / :spawn-all carry no :timeout-ms
+;; slot). When :after fires, the standard exit cascade tears down the
 ;; spawned child via :rf.machine/destroy.
 
 (deftest machine-after-on-invoke-cljs
@@ -217,7 +213,7 @@
           parent {:initial :idle
                   :data    {}
                   :on-spawn-actions
-                  ;; Advisory observation hook — returns nil (rf2-dtth6).
+                  ;; Advisory observation hook — returns nil.
                   {:record (fn [{:keys [id]}] (js/console.debug "spawned" id) nil)}
                   :states
                   {:idle {:on {:go :authenticating}}
@@ -256,7 +252,7 @@
             "child machine snapshot torn down by the standard exit cascade"))
       (trace-tooling/unregister-listener! ::ato))))
 
-;; ---- :timeout-ms on :spawn / :spawn-all is rejected (rf2-3y3y) ---------
+;; ---- :timeout-ms on :spawn / :spawn-all is rejected -------------------
 
 (deftest machine-spawn-timeout-ms-removed-cljs
   (testing ":timeout-ms on :spawn is rejected with :rf.error/spawn-timeout-ms-removed"

--- a/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.machines-system-id-cljs-test
-  "CLJS-side coverage for `:system-id` named-machine addressing (rf2-suue /
-  rf2-ecv4) under the Reagent reactive substrate.
+  "CLJS-side coverage for `:system-id` named-machine addressing under the
+  Reagent reactive substrate.
 
   Per Spec 005 §Named addressing via :system-id: a spawn whose args carry a
   `:system-id` keyword binds that name in the per-frame `[:rf.runtime/machines :system-ids]`
@@ -8,15 +8,13 @@
   destroy clears it; collisions emit `:rf.error/system-id-collision` and
   rebind (last-write-wins).
 
-  These tests exercise the bundled live-handler wiring (rf2-suue
-  precondition): the spawn registers the child as a real event handler,
-  so dispatch-by-system-id reaches a running actor.
-
-  Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
+  These tests exercise the bundled live-handler wiring: the spawn registers
+  the child as a real event handler, so dispatch-by-system-id reaches a
+  running actor."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
-            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            ;; listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.machines.test-support :as mtest]))
@@ -102,10 +100,9 @@
                                  [:rf.runtime/machines :snapshots spawned :data :msgs]))
             "dispatch via system-id lookup reached the live actor")
         ;; And the implementation-tier sugar fn no-ops when the system-id is
-        ;; unbound. rf2-gkt25a / rf2-80mmlf: `dispatch-to-system` is demoted
-        ;; off the `re-frame.core` facade and lives in `re-frame.machines`;
-        ;; the canonical action-side surface is the `:rf.machine/dispatch-to-system`
-        ;; fx tuple.
+        ;; unbound. `dispatch-to-system` lives in `re-frame.machines` (not the
+        ;; `re-frame.core` facade); the canonical action-side surface is the
+        ;; `:rf.machine/dispatch-to-system` fx tuple.
         (is (nil? (machines/dispatch-to-system :no-such-system [:notify "x"]))
             "dispatch-to-system on an unbound system-id returns nil"))))
 

--- a/implementation/machines/test/re_frame/machines_tags_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_tags_cljs_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.machines-tags-cljs-test
-  "CLJS-side coverage for `:fsm/tags` — state tags (rf2-ee0d Nine States
-  Stage 1) under the Reagent reactive substrate.
+  "CLJS-side coverage for `:fsm/tags` — state tags (Nine States Stage 1)
+  under the Reagent reactive substrate.
 
   Per Spec 005 §State tags: a state-node body may declare `:tags
   <set-of-keywords>`. The runtime maintains the union of every active
@@ -13,9 +13,7 @@
     - No-declaration machine: empty union elided from snapshot.
     - `:rf/machine-has-tag?` sub + `rf/machine-has-tag?` sugar; false for unknown
       machine.
-    - `:tags` reflects the post-`:always`-microstep state.
-
-  Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
+    - `:tags` reflects the post-`:always`-microstep state."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -25,7 +23,7 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 

--- a/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
@@ -1,10 +1,8 @@
 (ns re-frame.machines-wildcard-fallthrough-cljs-test
-  "Per Spec 005 §Transition resolution / §Wildcard transitions and
-  rf2-icj9t. CORRECTNESS coverage for the CROSS-KEY explicit→`:*`
-  fallthrough rule (Mike ruled 2026-06-04: A = FALLTHROUGH, an engine
-  change).
+  "Per Spec 005 §Transition resolution / §Wildcard transitions.
+  CORRECTNESS coverage for the CROSS-KEY explicit→`:*` fallthrough rule.
 
-  The ruled invariant: `:*` is the LEAST-PRIORITY ENABLED transition at
+  The invariant: `:*` is the LEAST-PRIORITY ENABLED transition at
   its level — NOT a 'no explicit KEY exists' fallback. A guard-blocked
   explicit `:on` entry must fall through to the same-level `:*`, and if no
   same-level wildcard is enabled, resolution walks to the parent (whose own
@@ -27,8 +25,8 @@
   (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
-;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+;; snapshot lookup via the shared machines test-support — no hardcoded
+;; `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
@@ -38,7 +36,7 @@
   the whole machine."
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
-    ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
+    ;; Machine snapshots are durable runtime-db state.
     (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots machine-id] snap)}))
@@ -64,10 +62,8 @@
       (rf/reg-machine :icj9t/same-level machine)
       (reset! log [])
       ;; :foo's explicit guard returns false ⇒ the explicit candidate is
-      ;; NOT enabled. Under the OLD behaviour the wildcard was consulted
-      ;; only when no explicit KEY existed, so :foo resolved to the no-op
-      ;; and :* never fired. Under the ruling the blocked explicit falls
-      ;; through to the same-level :* — :wildcard-action fires.
+      ;; NOT enabled. The blocked explicit falls through to the same-level
+      ;; :* — :wildcard-action fires.
       (rf/dispatch-sync [:icj9t/same-level [:foo]])
       (is (= [:wildcard] @log)
           "guard-blocked explicit :foo fell through to same-level :*")

--- a/implementation/machines/test/re_frame/nested_validation_test.clj
+++ b/implementation/machines/test/re_frame/nested_validation_test.clj
@@ -1,27 +1,15 @@
 (ns re-frame.nested-validation-test
-  "Per rf2-oz9t — verify-the-gap-first probe for the machine
-  registration-time validator's coverage of :guard / :action keyword
-  references in NESTED states and in non-`:on` slots
-  (`:always`, `:entry`, `:exit`).
+  "Coverage for the machine registration-time validator's handling of
+  :guard / :action keyword references in NESTED states and in non-`:on`
+  slots (`:always`, `:entry`, `:exit`).
 
-  Background: in `re-frame.machines`, `make-machine-handler`
-  validates keyword `:guard` / `:action` references via a manual
-  top-level `doseq` over `(:states machine)`, walking only `:on`
-  transitions. The sibling helper `walk-state-nodes` (used just above
-  for other registration-time validation) walks recursively but is NOT
-  reused for guard/action validation. Spec 005 implies the
-  registration-time validator should cover the full state tree and
-  every transition-bearing slot, not just top-level `:on`.
+  Per Spec 005, the registration-time validator covers the full state tree
+  and every transition-bearing slot, not just top-level `:on`. A keyword
+  `:guard` / `:action` reference that names no registered entry must fail
+  registration clearly rather than slipping through to manifest at runtime.
 
-  These tests pin the observable behaviour. If a misuse passes
-  registration silently and only manifests at runtime, the gap is real
-  and the validator needs to drive off the recursive walker. If the
-  registration throws clearly, the narrow pass is structurally
-  sufficient and a code comment should explain why.
-
-  Each test registers a machine that points at an unregistered
-  keyword from a single misuse site, isolated so the failure mode is
-  unambiguous."
+  Each test registers a machine that points at an unregistered keyword
+  from a single misuse site, isolated so the failure mode is unambiguous."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines.test-support :as mtest]
@@ -150,15 +138,12 @@
       (is (some? thrown)
           "nested :always :action misuse SHOULD throw at registration"))))
 
-;; ---- regression (rf2-zg579): single-map :always must be normalised ------
+;; ---- single-map :always must be normalised -------------------------------
 ;; The grammar admits `:always` as a single entry map OR a vector of entry
-;; maps. The guard/action ref-validation loop used to iterate `(:always
-;; state-node)` directly; for a single-map `:always` that yields the map's
-;; MapEntries, so `(:guard t)`/`(:action t)` no-op'd and a dangling ref
-;; slipped past fail-fast registration (surfacing only late, at runtime).
-;; The fix routes the loop through the in-file `always-entries` normaliser.
-;; The vector form (above) was already covered; these pin the single-map
-;; form so both shapes are guarded.
+;; maps. The guard/action ref-validation loop routes through the in-file
+;; `always-entries` normaliser, so a dangling ref in EITHER shape is caught
+;; at fail-fast registration. These pin the single-map form; the vector
+;; form is covered above — both shapes are guarded.
 
 (deftest top-level-always-single-map-guard-keyword-unresolved
   (testing "Top-level single-map :always with unregistered :guard keyword fails registration"
@@ -270,14 +255,13 @@
       (is (some? thrown)
           "nested-state :exit action misuse SHOULD throw at registration"))))
 
-;; ---- gap probe: parallel-region keyword refs (rf2-rp0y / PR #307 gap) ----
+;; ---- parallel-region keyword refs ----------------------------------------
 ;;
 ;; Per Spec 005 §Parallel regions and machines.cljc:1903-1990:
 ;; `walk-state-nodes` iterates parallel regions via the `(parallel?
 ;; machine)` branch, so the registration-time validator at lines
-;; 1977-1990 SHOULD catch keyword-ref typos inside any region.
-;; nested_validation_test covers flat + compound only; rf2-rp0y adds
-;; the parallel-region coverage.
+;; 1977-1990 catches keyword-ref typos inside any region. These cover the
+;; parallel-region cases alongside the flat + compound cases above.
 
 (deftest parallel-region-on-guard-keyword-unresolved
   (testing "Parallel region :on with unregistered :guard keyword fails registration"
@@ -386,12 +370,11 @@
       (is (some? thrown)
           ":always misuse inside a region SHOULD throw at registration"))))
 
-;; ---- :always self-loop forbidden at registration (rf2-hh1pi) -------------
+;; ---- :always self-loop forbidden at registration -------------------------
 ;;
 ;; Per Spec 005 §Self-loop forbidden at registration (005:1290-1301): a
 ;; state whose `:always` targets itself is rejected at construction time
-;; via `:rf.error/machine-always-self-loop`. Before rf2-hh1pi this was
-;; only caught LATE at runtime via the depth-exceeded backstop.
+;; via `:rf.error/machine-always-self-loop`.
 
 (deftest always-self-loop-keyword-target-rejected
   (testing "an :always entry whose keyword :target names its own state is rejected"
@@ -435,10 +418,10 @@
     ;; `scxml-eventless-settles-to-fixed-point` (the :more?/:bump counter
     ;; that settles :n 0→3). That corpus drives the PURE engine via `step`;
     ;; this case proves the same shape is also registration-legal via the
-    ;; full `reg-machine` validator (per the acdlp acceptance: the demo must
-    ;; register, not only step). A self-:target form of this counter would
-    ;; throw :rf.error/machine-always-self-loop — see the rejection tests
-    ;; above — so the targetless form is the only registration-legal one.
+    ;; full `reg-machine` validator. A self-:target form of this counter
+    ;; would throw :rf.error/machine-always-self-loop — see the rejection
+    ;; tests above — so the targetless form is the only registration-legal
+    ;; one.
     (let [m {:initial :a
              :data    {:n 0}
              :guards  {:more? (fn [{d :data}] (< (:n d) 3))}
@@ -494,7 +477,7 @@
       (is (some? thrown) "region :always self-loop SHOULD throw at registration")
       (is (= :rf.error/machine-always-self-loop (:rf.error/id (ex-data thrown)))))))
 
-;; ---- compound state missing :initial rejected (rf2-boryv) ----------------
+;; ---- compound state missing :initial rejected ----------------------------
 ;;
 ;; Per Spec 005 §Initial-state cascading (005:930): every compound
 ;; state-node MUST declare `:initial`. Without it the cascade has no
@@ -565,13 +548,13 @@
       (is (nil? thrown)
           "a well-shaped parallel machine should register without throwing"))))
 
-;; ---- multi-hop keyword-indirection in :guards / :actions (rf2-ylpnn) ------
+;; ---- multi-hop keyword-indirection in :guards / :actions -----------------
 ;; The runtime resolver `transition/chase-ref` tolerates keyword INDIRECTION:
 ;; a :guards / :actions entry value may itself be a keyword pointing at
-;; another entry. The registration validator must follow that SAME chain to
-;; its terminal fn — testing membership of only the FIRST key let a multi-hop
-;; chain whose terminal hop is missing pass registration and blow up only at
-;; runtime, defeating the fail-fast contract (Spec 005 §Registration).
+;; another entry. The registration validator follows that SAME chain to its
+;; terminal fn, so a multi-hop chain whose terminal hop is missing fails at
+;; registration rather than blowing up at runtime (Spec 005 §Registration,
+;; the fail-fast contract).
 
 (deftest multi-hop-guard-indirection-resolves-registers
   (testing "a :guard ref through TWO hops of keyword indirection to a fn
@@ -636,16 +619,15 @@
       (is (= :rf.error/machine-unresolved-guard (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-guard contract"))))
 
-;; ---- transition :target shape + resolution (rf2-w84jv) -------------------
+;; ---- transition :target shape + resolution -------------------------------
 ;;
 ;; Per Spec 005 (005:441 "a transition targeting an unknown state fails
 ;; registration") + Spec-Schemas §TransitionTarget ([:or :keyword [:vector
 ;; :keyword]]): every transition slot's `:target` must be a well-formed,
-;; resolvable target. Before rf2-w84jv only `:guard` / `:action` refs were
-;; validated, so a malformed `{:target 42}` registered and threw
-;; `:rf.error/machine-bad-state-form` later at the triggering dispatch, and a
-;; missing `{:target [:missing]}` registered and committed an invalid snapshot.
-;; XState v5 rejects unresolvable targets at machine creation; we align.
+;; resolvable target. A malformed `{:target 42}` and a missing
+;; `{:target [:missing]}` both fail registration rather than blowing up at
+;; the triggering dispatch or committing an invalid snapshot. XState v5
+;; rejects unresolvable targets at machine creation; we align.
 
 (deftest on-scalar-target-rejected-at-registration
   (testing "an :on transition whose :target is a non-keyword/non-vector scalar is rejected at registration (rf2-w84jv)"

--- a/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
+++ b/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
@@ -1,7 +1,7 @@
 (ns re-frame.parallel-raise-broadcast-test
-  "Per rf2-yi7ts — a `:raise` emitted inside a parallel REGION re-enters the
-  PARENT parallel macrostep and re-broadcasts to ALL regions against the
-  full evolving snapshot. It is NOT region-local.
+  "A `:raise` emitted inside a parallel REGION re-enters the PARENT parallel
+  macrostep and re-broadcasts to ALL regions against the full evolving
+  snapshot. It is NOT region-local.
 
   XState v5 / SCXML gold standard: `raise` enqueues on the machine's ONE
   internal event queue; the macrostep pops the front and broadcasts the
@@ -10,12 +10,10 @@
   reaches its SIBLINGS, a sibling's guard sees the raise's `:data` writes
   (evolving snapshot), and the originating region re-sees it too.
 
-  Before the fix the per-region drain (`machine-transition-single`'s local
-  `drain-raises` against the region-spec) delivered a region's raise to the
-  RAISING REGION ONLY — never broadcast. The fix: regions DEFER their raises
-  (`transition/drain-or-defer-raises`); `parallel/parallel-machine-transition`
-  owns the macrostep's internal-event queue and re-broadcasts each surfaced
-  raise across every region.
+  Regions DEFER their raises (`transition/drain-or-defer-raises`);
+  `parallel/parallel-machine-transition` owns the macrostep's
+  internal-event queue and re-broadcasts each surfaced raise across every
+  region.
 
   Pure-engine tests — call `machine-transition` directly and read the merged
   post-macrostep snapshot. Order is recorded in `:data :log` (shared `:data`
@@ -200,13 +198,13 @@
                    :states  {:z {:on {:go {:action :start}}}}}}}
           original {:state {:loop :run :idle :z} :data {:token :keep}}
           r        (machines/machine-transition spec original [:go])]
-      ;; rf2-y3jv8q — a parallel re-broadcast depth-bound abort is a FAILED
-      ;; macrostep, not an :ok rollback no-op (parity with the flat drain;
-      ;; XState v5 throws on the runaway). The `:fail` threads NO snapshot /
-      ;; fx, so the whole macrostep — both regions' states, the looping
-      ;; region's :data writes, and every accumulated fx — is discarded. The
-      ;; lifecycle handler short-circuits to `{}`, leaving the pre-event
-      ;; snapshot committed in runtime-db.
+      ;; A parallel re-broadcast depth-bound abort is a FAILED macrostep,
+      ;; not an :ok rollback no-op (parity with the flat drain; XState v5
+      ;; throws on the runaway). The `:fail` threads NO snapshot / fx, so the
+      ;; whole macrostep — both regions' states, the looping region's :data
+      ;; writes, and every accumulated fx — is discarded. The lifecycle
+      ;; handler short-circuits to `{}`, leaving the pre-event snapshot
+      ;; committed in runtime-db.
       (is (result/fail? r)
           "depth-exceeded yields a :fail (failed macrostep), not an :ok no-op")
       (is (result/depth-abort? r)

--- a/implementation/machines/test/re_frame/parallel_region_runtime_overlay_test.clj
+++ b/implementation/machines/test/re_frame/parallel_region_runtime_overlay_test.clj
@@ -1,31 +1,28 @@
 (ns re-frame.parallel-region-runtime-overlay-test
-  "Per rf2-z522n (finding 1). Regression for the STALE region frame/platform
-  bug.
+  "Region frame/platform runtime overlay.
 
   `re-frame.machines.parallel/region-machine` MEMOISES the synthetic
   single-machine spec for each region in metadata on the parent machine, at
   REGISTRATION time. The cached spec captures `:rf/platform` / `:rf/frame`
   from whatever the parent machine held when the cache was first populated —
   which can be the UNSTAMPED registration-time machine (before
-  `prepare-machine-ctx` stamps the live runtime values). On a later
-  transition, `reduce-regions` re-stamped only `:rf/parent-id` onto the
-  cached spec, so the region's pure logic ran with the STALE/missing
-  `:rf/platform` / `:rf/frame`.
+  `prepare-machine-ctx` stamps the live runtime values).
+
+  `reduce-regions` overlays the LIVE `:rf/platform` / `:rf/frame` (alongside
+  `:rf/parent-id`) from the parent machine onto the cached region spec before
+  EVERY region step, at the `reduce-regions` choke-point — so the region's
+  pure logic always runs with the live runtime values, never a stale/missing
+  cached `:rf/platform` / `:rf/frame`.
 
   Consequences this test guards:
-    - A parallel-region `:after` ran `build-after-fx` against the stale
-      `:rf/platform`. Under SSR (`:platform :server`) the region timer was
-      treated as a CLIENT timer (`:scheduled` + a host-clock
-      `:after-schedule` fx) instead of being skipped
-      (`:skipped-on-server`).
-    - Region timer/action traces carried the stale (missing) `:rf/frame`,
-      so epoch-capture / frame-isolation attribution dropped or
-      mis-attributed them.
+    - A parallel-region `:after` runs `build-after-fx` against the LIVE
+      `:rf/platform`. Under SSR (`:platform :server`) the region timer is
+      skipped (`:skipped-on-server`), not treated as a CLIENT timer
+      (`:scheduled` + a host-clock `:after-schedule` fx).
+    - Region timer/action traces carry the LIVE `:rf/frame`, so
+      epoch-capture / frame-isolation attribution is correct.
 
-  The fix overlays the LIVE `:rf/platform` / `:rf/frame` (alongside
-  `:rf/parent-id`) from the parent machine onto the cached region spec
-  before EVERY region step, at the `reduce-regions` choke-point. These
-  tests drive `parallel/machine-transition` directly (pure) with an
+  These tests drive `parallel/machine-transition` directly (pure) with an
   explicitly-stamped parent so the assertion does not depend on a live SSR
   frame."
   (:require [clojure.test :refer [deftest is testing]]
@@ -40,8 +37,8 @@
   "Register a trace listener for the duration of `body-fn`; return the
   captured trace vec. (`trace/emit!` delivers to listeners synchronously,
   so a PURE `machine-transition` call surfaces its traces here without a
-  dispatch cycle.) Routed through the shared `mtest/with-trace-capture`
-  (rf2-3l8lqe finding #4) — guaranteed unregister in a `finally`."
+  dispatch cycle.) Routed through the shared `mtest/with-trace-capture` —
+  guaranteed unregister in a `finally`."
   [body-fn]
   (mtest/with-trace-capture seen
     (body-fn)
@@ -150,7 +147,7 @@
         (is (empty? (of-op cli-tr :rf.machine.timer/skipped-on-server))
             "no stale server-skip leaked from the prior run")))))
 
-;; ---- rf2-gqr4vs: transition-local `:rf/cofx` must not survive the cache ----
+;; ---- transition-local `:rf/cofx` must not survive the cache ----------------
 
 ;; A parallel machine whose region action captures the causal `:rf.cofx`
 ;; coeffect threaded onto the action ctx. The `:capture` action records what it

--- a/implementation/machines/test/re_frame/parallel_root_on_test.clj
+++ b/implementation/machines/test/re_frame/parallel_root_on_test.clj
@@ -1,11 +1,11 @@
 (ns re-frame.parallel-root-on-test
-  "Per Spec 005 §Transition broadcast §Root parallel `:on` (rf2-tsq6g —
-  XState v5 / SCXML gold standard). The parallel ROOT's own `:on` is the
-  ANCESTOR FALLBACK for its regions: deepest-wins with parent fallthrough,
-  the parallel analog of the flat / compound machine-root `:on` fallback.
+  "Per Spec 005 §Transition broadcast §Root parallel `:on` (XState v5 / SCXML
+  gold standard). The parallel ROOT's own `:on` is the ANCESTOR FALLBACK for
+  its regions: deepest-wins with parent fallthrough, the parallel analog of
+  the flat / compound machine-root `:on` fallback.
 
-  Verified against xstate@5.32.0 (recorded in rf2-tsq6g). The selection
-  semantic is the load-bearing thing — atomic ancestor-fallback suppression:
+  Verified against xstate@5.32.0. The selection semantic is the load-bearing
+  thing — atomic ancestor-fallback suppression:
 
     - root `:on`, NO region handles the event  → the root transition fires,
       moving the targeted region(s).            GO  -> {a:two, b:two}
@@ -19,12 +19,12 @@
       whole root transition is suppressed and the untargeted sibling stays
       UNCHANGED.                                 RESET -> {a:special, b:unchanged}
 
-  Plus: the original BUG regression (root `:on` was accepted-and-ignored —
-  silently dropped), the multi-region target grammar, the root `:action`
-  running once, guard/action ref validation reaching the root-parallel
-  transition, the region-qualified target-shape validation, and (rf2-wox0vd)
-  the ROOT-LEVEL `:after` — root-owned, region-qualified targets, action/fx-
-  only timeouts, guard suppression, and cancel-on-exit via the root epoch.
+  Plus: the root `:on` fires (it is registered AND executed), the
+  multi-region target grammar, the root `:action` running once, guard/action
+  ref validation reaching the root-parallel transition, the region-qualified
+  target-shape validation, and the ROOT-LEVEL `:after` — root-owned,
+  region-qualified targets, action/fx-only timeouts, guard suppression, and
+  cancel-on-exit via the root epoch.
 
   These JVM tests pair with the conformance fixtures
   spec/conformance/fixtures/parallel-root-on-*.edn."
@@ -38,7 +38,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
@@ -54,10 +54,10 @@
                  :states  {:one {:on {:go :two}}
                            :two {}}}}})
 
-;; ---- 1. THE BUG: root :on was accepted-and-ignored (silent drop) ----------
+;; ---- 1. root :on fires on a :type :parallel machine -----------------------
 ;;
-;; This is the first-action proof in the bead: a root-level :on on a
-;; :type :parallel machine was NEITHER validated NOR executed. Now it FIRES.
+;; A root-level :on on a :type :parallel machine is both validated AND
+;; executed — it FIRES.
 
 (deftest root-on-no-longer-silently-dropped
   (testing "a root :on on :type :parallel is registered AND executed (was silently dropped)"
@@ -311,15 +311,14 @@
                            :b {:initial :one :states {:one {} :two {}}}}}))
         "region-qualified targets + resolvable refs pass")))
 
-;; ---- 13. ROOT-LEVEL :after on a parallel root (rf2-wox0vd — ALIGN) ---------
+;; ---- 13. ROOT-LEVEL :after on a parallel root -----------------------------
 ;;
 ;; XState v5 gold standard: `after` may be declared at any level, including a
 ;; <parallel> node. A parallel-ROOT `:after` is ROOT-OWNED — scheduled at
 ;; machine birth, alive for the whole machine, stale-gated by the root's OWN
 ;; per-path epoch (NOT bound to any region's lifecycle). It is the timer-driven
 ;; analog of the root `:on` ancestor fallback, reusing the exact region-
-;; qualified target grammar. (Replaces the pre-wox0vd loud rejection
-;; `:rf.error/machine-parallel-root-after-not-supported`.)
+;; qualified target grammar.
 
 (deftest root-after-registers-and-validates
   (testing "a :type :parallel root declaring :after now REGISTERS (was rejected loudly)"
@@ -429,12 +428,12 @@
       (is (= {:a :one :b :one} (:state snap))
           "guard false -> the root :after timer fires-and-discards; no region moved"))))
 
-;; ---- 15. ADVERSARIAL: root :after cancels-on-exit via epoch (rf2-wox0vd) ---
+;; ---- 15. ADVERSARIAL: root :after cancels-on-exit via epoch ----------------
 ;;
-;; The bead's required adversarial coverage: the root :after is ROOT-OWNED and
-;; stale-gated by the root's OWN per-path epoch. A timer carrying a STALE epoch
-;; (the root was torn down / its epoch advanced) DROPS — exactly the cancel-
-;; on-exit-via-epoch the per-state :after machinery uses, but at the root.
+;; Adversarial coverage: the root :after is ROOT-OWNED and stale-gated by the
+;; root's OWN per-path epoch. A timer carrying a STALE epoch (the root was torn
+;; down / its epoch advanced) DROPS — exactly the cancel-on-exit-via-epoch the
+;; per-state :after machinery uses, but at the root.
 
 (deftest root-after-stale-epoch-drops
   (testing "a root :after firing with a STALE epoch does NOT transition (cancel-on-exit)"
@@ -453,7 +452,7 @@
       (is (= {:a :one :b :one} (:state snap))
           "stale-epoch root :after dropped; no region moved (cancel-on-exit via epoch)"))))
 
-;; ---- 16. root :after end-to-end through registration + birth (rf2-wox0vd) --
+;; ---- 16. root :after end-to-end through registration + birth ---------------
 ;;
 ;; The live runtime path: registration runs the BIRTH cascade, which schedules
 ;; the root :after (seeds the root epoch at the flat `[]` slot AND emits the

--- a/implementation/machines/test/re_frame/parallel_test.clj
+++ b/implementation/machines/test/re_frame/parallel_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.parallel-test
-  "Per Spec 005 §Parallel regions and rf2-l67o (Nine States Stage 2).
+  "Per Spec 005 §Parallel regions (Nine States Stage 2).
 
   Parallel-region semantics covered:
     - A `:type :parallel` machine's initial snapshot has `:state` as a
@@ -38,7 +38,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 
@@ -306,7 +306,7 @@
       (is (some? (snapshot :par/storage))
           "snapshot synthesised at [:rf.runtime/machines :snapshots :par/storage]"))))
 
-;; ---- 13. region-machine memoization (rf2-s83iu) ---------------------------
+;; ---- 13. region-machine memoization ---------------------------------------
 
 (deftest region-machine-result-is-memoised-per-machine
   (testing "region-machine returns identical-equal results across repeat calls for the same parent-machine"

--- a/implementation/machines/test/re_frame/reduce_regions_test.clj
+++ b/implementation/machines/test/re_frame/reduce_regions_test.clj
@@ -1,12 +1,12 @@
 (ns re-frame.reduce-regions-test
   "Pure-fn unit test for `re-frame.machines.parallel/reduce-regions` —
-  the broadcast invariant for parallel-region machines (rf2-vqubp).
+  the broadcast invariant for parallel-region machines.
 
   Asserts the four threading properties the helper encodes:
    1. Regions iterate in declaration order (the order `:regions` was
       authored).
    2. A later region's step sees earlier regions' `:data` writes.
-   3. The shared `:rf/spawn-counter` (rf2-gr8q) threads in/out across
+   3. The shared `:rf/spawn-counter` threads in/out across
       regions — bumps in one region are visible to the next.
    4. Per-region fx is prefixed via `prefix-region-invoke-id` so the
       `[:rf.runtime/machines :spawned ...]` slot key stays unique per region.
@@ -24,8 +24,8 @@
             [re-frame.machines.result :as result]))
 
 (def ^:private reduce-regions
-  ;; Reach in to the private helper. Per rf2-vqubp this test isolates
-  ;; the broadcast invariant from the two production step-fns.
+  ;; Reach in to the private helper. This test isolates the broadcast
+  ;; invariant from the two production step-fns.
   #'parallel/reduce-regions)
 
 (defn- two-region-spec

--- a/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.scxml-conformance-cljs-test
-  "SCXML semantic-core conformance corpus for the re-frame2 machine engine
-  (rf2-rkkag).
+  "SCXML semantic-core conformance corpus for the re-frame2 machine engine.
 
   NOTE — the namespace is named `*-cljs-test` (file `*_cljs_test.cljc`) so
   it is discovered by BOTH the shadow-cljs `:node-test` build
@@ -14,14 +13,13 @@
 
   Spec 005 asserts xstate-v5 parity for the machine engine and Spec 005
   L1300 (and the worked examples throughout) ANCHOR that parity to the
-  xstate / SCXML / Harel state-chart semantics. Before this corpus the
-  re-frame2 machine test surface was strong per-feature (compound,
-  parallel, entry/exit ordering, `:always`, `:after`, guards, final/done,
-  wildcard, unhandled-no-op, transition resolution) but carried ZERO
-  references to the W3C SCXML conformance suite or to Harel's original
-  state-chart semantics. Parity was *asserted*, not *externally proven*.
+  xstate / SCXML / Harel state-chart semantics. This corpus proves that
+  parity externally against the W3C SCXML conformance suite and Harel's
+  original state-chart semantics — complementing the strong per-feature
+  surface (compound, parallel, entry/exit ordering, `:always`, `:after`,
+  guards, final/done, wildcard, unhandled-no-op, transition resolution).
 
-  This namespace closes that gap. Every test below maps a re-frame2
+  Every test below maps a re-frame2
   machine-engine behaviour onto the SCXML / Harel semantic rule it derives
   from, citing:
 
@@ -92,27 +90,24 @@
 
    3. **HISTORY pseudo-states** — SCXML `<history type=\"shallow|deep\">`
       (W3C SCXML §3.10, e.g. test 387, 388, 579, 580 history family).
-      re-frame2 ships FIRST-CLASS history (rf2-mle6e — the post-v1 deferral
-      is withdrawn): `{:type :history :deep? <bool> :default-target <t>}` is
-      a targetable pseudo-state under a compound's `:states`. NO LONGER an
-      exclusion — the §History section below now carries BOTH the
+      re-frame2 ships FIRST-CLASS history:
+      `{:type :history :deep? <bool> :default-target <t>}` is
+      a targetable pseudo-state under a compound's `:states`. History is
+      COVERED, not excluded — the §History section below carries BOTH the
       registration-time GRAMMAR-CONSTRAINT rejections (a `:type :history` node
       MUST have an owning compound — `:rf.error/machine-history-misplaced`)
       AND the RECORD/RESTORE behavioural corpus (the W3C 387/388/579/580
       family adapted to the re-frame2 grammar shape). The Mode-B
       `:machine-transition` fixture counterparts live at
       `spec/conformance/fixtures/scxml-history-test{387,388,579,580}-*.edn`
-      and `history-{shallow,deep,default-target,per-region,dangling}-*.edn`
-      (rf2-mle6e.4). This entry is retained in the EXCLUSIONS list only as a
-      historical marker — history is now COVERED, not excluded.
+      and `history-{shallow,deep,default-target,per-region,dangling}-*.edn`.
+      This entry is listed for completeness alongside the genuine exclusions
+      so the scope boundary stays auditable.
 
-  ## Divergences found
+  ## Divergences from the SCXML core
 
-  This corpus originally PINNED one semantic divergence from the SCXML
-  core: **external self-transition semantics were not implemented**
-  (resolved by rf2-46ban, which gave the engine SCXML external-default
-  self-transitions). rf2-eicq0 then ALIGNED THE DEFAULT to XState v5 (the
-  gold standard), which FLIPPED SCXML's default: a targeted self/ancestor
+  re-frame2 follows XState v5 (the gold standard) for self-transition
+  defaults, which FLIPS SCXML's default: a targeted self/ancestor
   transition is INTERNAL by default; the external restart is the opt-in
   `:reenter? true`. SCXML's `type=\"external\"` default is therefore a
   DELIBERATE DIVERGENCE re-frame2 does NOT follow — it follows v5. The
@@ -121,7 +116,7 @@
   exit/entry); the EXTERNAL cases carry `:reenter? true` and fire
   exit → action → entry, re-descending a compound's :initial chain. The
   SCXML default-external semantics are still EXERCISED (via `:reenter? true`)
-  but are no longer the re-frame2 default."
+  but are not the re-frame2 default."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
@@ -497,8 +492,8 @@
 ;; the node, or an ancestor `<transition event='done.state.id'>`) can TAKE it,
 ;; advancing the outer flow WHILE the machine keeps running. The signal is a
 ;; transitionable completion event, NOT (necessarily) a teardown. XState v5
-;; `onDone`. Spec 005 §Final states §The done-state signal (rf2-bnjb3 /
-;; rf2-zlmz7). These exercise the PURE engine: the done-raise fires through
+;; `onDone`. Spec 005 §Final states §The done-state signal. These exercise the
+;; PURE engine: the done-raise fires through
 ;; the FIFO `:raise` queue and the enclosing `:on-done` resolves in the SAME
 ;; macrostep — observable on the post-macrostep snapshot.
 ;; ===========================================================================
@@ -707,10 +702,10 @@
                                               :inner-done {:final? true}}}
                               :work-done {}}}
               ;; :other carries an UNGUARDED escape hatch on the SAME reserved
-              ;; event-id AND shares the leading state-name `:flow`. Before
-              ;; rf2-12ekv the re-broadcast of :work's region-relative done
-              ;; [:flow] would be CAUGHT here (shape match), leaking :other →
-              ;; :hijacked. It must stay put: :work's done is not :other's done.
+              ;; event-id AND shares the leading state-name `:flow`. A naive
+              ;; shape-match on the re-broadcast of :work's region-relative done
+              ;; [:flow] would be CAUGHT here, leaking :other → :hijacked.
+              ;; Region-name scoping keeps it put: :work's done is not :other's.
               :other {:initial :flow
                       :on {:rf.machine/done :hijacked}
                       :states {:flow {:initial :wait
@@ -756,8 +751,8 @@
               ;; :other ALSO has a compound named :flow on its active path —
               ;; SHARING the leading state-name — and an UNGUARDED escape hatch.
               ;; The bare region-relative done-path [:flow] is a prefix of
-              ;; :other's active path [:flow :wait], so the rf2-m3arq shape-match
-              ;; gate falsely passes and :other's hatch fires → :hijacked. It
+              ;; :other's active path [:flow :wait], so a naive shape-match gate
+              ;; would falsely pass and fire :other's hatch → :hijacked. It
               ;; must stay put: :work's done is not :other's done.
               :other {:initial :flow
                       :on {:rf.machine/done :hijacked}
@@ -1022,11 +1017,9 @@
           "no effects emitted for an unhandled event"))))
 
 ;; ===========================================================================
-;; §10. Self-transitions (internal default vs external opt-in — rf2-eicq0,
-;;      refined for descendant re-resolution by rf2-gt1pu)
+;; §10. Self-transitions (internal default vs external opt-in)
 ;;
-;; XState v5 is the gold standard. THREE cases the engine must distinguish
-;; (rf2-gt1pu — earlier rf2-eicq0 collapsed the middle case into the first):
+;; XState v5 is the gold standard. THREE cases the engine must distinguish:
 ;;
 ;;   (1) TARGETLESS — the action fires; NO onexit/onentry; the active
 ;;       configuration (including active descendants) is PRESERVED unchanged.
@@ -1046,20 +1039,13 @@
 ;; the inverted `reenter`). A targetless transition is internal in both
 ;; models.
 ;;
-;; HISTORY: rf2-46ban first gave the engine EXTERNAL self-transition
-;; semantics (`:target :same-state` → exit/entry); that was the v4/SCXML
-;; external-DEFAULT shape. rf2-eicq0 flipped the DEFAULT to v5 internal and
-;; introduced `:reenter? true` as the external handle. rf2-gt1pu then split
-;; the no-`:reenter?` case into (1) and (2): an EXPLICIT active-path target is
-;; not a configuration no-op — it re-resolves descendants.
-;;
 ;; The engine: `re-frame.machines.transition/target-path` resolves the
 ;; `:same-state` sentinel (and a `:target` naming the declaring state's own
 ;; keyword) to the declaring state's own path; `compute-cascade-paths` keeps
 ;; the LCCA at the TARGET's depth (case 2 — only descendants below the target
 ;; cross the cascade boundary) and pulls it UP to the target's parent (case 3)
 ;; ONLY when the transition carries `:reenter? true`. The effective
-;; `internal?` (true config no-op) flag is now reserved for TARGETLESS
+;; `internal?` (true config no-op) flag is reserved for TARGETLESS
 ;; transitions alone.
 ;; ===========================================================================
 
@@ -1138,7 +1124,7 @@
 
 ;; ===========================================================================
 ;; §10b. External (:reenter? true) transition to a PROPER ANCESTOR
-;;       (LCCA-restart geometry — rf2-emz8l; default flipped by rf2-eicq0)
+;;       (LCCA-restart geometry)
 ;;
 ;; A `:reenter? true` transition from a descendant leaf to one of its PROPER
 ;; ANCESTORS A restarts A: the LCCA of {source, A} is A's PARENT (A is a
@@ -1149,20 +1135,18 @@
 ;; external SELF-transition (§10) — a self-target is the degenerate case
 ;; where A is the source leaf itself.
 ;;
-;; Under the rf2-eicq0 v5 flip RE-ENTERING THE ANCESTOR ITSELF is OPT-IN: an
+;; Under the XState v5 model RE-ENTERING THE ANCESTOR ITSELF is OPT-IN: an
 ;; ancestor target WITHOUT `:reenter?` does NOT exit/re-enter the ancestor.
-;; BUT (rf2-gt1pu) it is NOT a no-op: the ancestor's ACTIVE DESCENDANTS are
+;; BUT it is NOT a no-op: the ancestor's ACTIVE DESCENDANTS are
 ;; re-resolved (children reset to the ancestor's :initial). See
 ;; `scxml-default-ancestor-target-re-resolves-descendants` below. XState v5
 ;; flipped the SCXML default; re-frame2 follows it.
 ;;
-;; BEFORE rf2-emz8l the engine bounded the exit set by the longest common
-;; PREFIX of the source path and the (initial-cascaded) target leaf. For an
-;; ancestor target whose `:initial` chain re-descends to the source, that
-;; LCP equals the full path → the exit AND entry sets were BOTH empty → a
-;; SILENT NO-OP. The fix computes the true LCCA against the target BASE
+;; The engine computes the true LCCA against the target BASE
 ;; (pre-initial-cascade): when the (`:reenter?`) target is a prefix of the
-;; active path, the LCCA is pulled up to the target's parent. Spec 005
+;; active path, the LCCA is pulled up to the target's parent — so an ancestor
+;; target whose `:initial` chain re-descends to the source still produces the
+;; full exit/re-enter cascade rather than collapsing to a no-op. Spec 005
 ;; §Entry/exit cascading along the LCCA.
 ;; ===========================================================================
 
@@ -1316,7 +1300,7 @@
 
 ;; ===========================================================================
 ;; §10c. Explicit targets on the active path RE-RESOLVE DESCENDANTS
-;;       (rf2-gt1pu — the middle case; rf2-127ff — parent-declared reenter
+;;       (the middle case; and parent-declared reenter
 ;;       to a specific descendant). XState v5 gold standard.
 ;;
 ;; The defining XState v5 rule (stately.ai/docs/transitions):
@@ -1327,8 +1311,7 @@
 ;; and "[reenter:true] will cause the state to re-enter when transitioning to
 ;; itself or descendent states."
 ;;
-;; Each case below is grounded in a xstate@5.32.0 runtime check recorded in
-;; rf2-gt1pu / rf2-127ff:
+;; Each case below is grounded in a xstate@5.32.0 runtime check:
 ;;   • process.step3 + parent-declared target "process" (no reenter)
 ;;        -> step3 exit, step1 entry; NO process exit/entry.
 ;;   • parent.child.a + parent-declared target [:parent :child] (no reenter)
@@ -1589,14 +1572,14 @@
 ;;
 ;; SCXML §3.10 `<history type="shallow|deep">` records and restores the
 ;; most recent active descendant of a compound/parallel state. re-frame2
-;; ships FIRST-CLASS history (rf2-mle6e — the post-v1 deferral is withdrawn):
+;; ships FIRST-CLASS history:
 ;; `{:type :history :deep? <bool> :default-target <t>}` under a compound's
 ;; `:states`. This section covers BOTH halves:
 ;;   §13a — the registration-time PLACEMENT / GRAMMAR-CONSTRAINT rejections the
 ;;          engine enforces (a `:type :history` node MUST have an owning
 ;;          compound; the closed key-set; one-per-compound).
 ;;   §13b — the RECORD/RESTORE behavioural corpus, the W3C 387/388/579/580
-;;          history family ADAPTED to the re-frame2 grammar shape (rf2-mle6e.4).
+;;          history family ADAPTED to the re-frame2 grammar shape.
 ;;          The Mode-B `:machine-transition` fixture counterparts live at
 ;;          `spec/conformance/fixtures/scxml-history-test*-*.edn` +
 ;;          `history-*-*.edn`; these in-corpus tests give the same coverage

--- a/implementation/machines/test/re_frame/scxml_irp_semantic_core_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_irp_semantic_core_cljs_test.cljc
@@ -1,37 +1,35 @@
 (ns re-frame.scxml-irp-semantic-core-cljs-test
-  "W3C SCXML IRP semantic-core conformance COMPLETION corpus (rf2-7wy0ke).
+  "W3C SCXML IRP semantic-core conformance corpus.
 
   ## What this namespace is
 
-  `scxml_conformance_cljs_test.cljc` (rf2-rkkag) established the
-  SCXML-anchored corpus and proved a SUBSET of the W3C SCXML IRP
+  The sibling `scxml_conformance_cljs_test.cljc` establishes the
+  SCXML-anchored corpus and proves a SUBSET of the W3C SCXML IRP
   (Implementation Report Plan, https://www.w3.org/Voice/2013/scxml-irp/)
   semantic-core families: the microstep/internal-queue (144), transition
   selection + cond ordering (153/155), entry/exit LCCA ordering (504/505),
   parallel broadcast (403/404), parallel done (570/580), eventless settle
   (372/388 family), history (387/388/579/580), and the default-initial
-  cascade (355/372). rf2-7wy0ke COMPLETES the semantic core: it AUDITS the
-  W3C IRP MANDATORY semantic-core test set against existing re-frame2
+  cascade (355/372). This namespace COMPLETES the semantic core: it AUDITS
+  the W3C IRP MANDATORY semantic-core test set against the re-frame2
   coverage (the `## W3C SCXML IRP SEMANTIC-CORE COVERAGE MATRIX` below) and
-  PORTS the NOT-COVERED ids as additive conformance cases here, each citing
-  its W3C test id + Spec 005 anchor + xstate@5.x verification, matching the
-  sibling file's citation discipline.
+  carries the NOT-COVERED ids as additive conformance cases here, each
+  citing its W3C test id + Spec 005 anchor + xstate@5.x verification,
+  matching the sibling file's citation discipline.
 
-  This is an ADDITIVE COMPLETION, not a rewrite. New cases live in their
-  OWN namespace (this file) so the sequenced sibling rf2-dp1fi0
-  (property/model-based machines-test layer) slots cleanly after on the same
-  surface. The cases drive the SAME pure engine surface
-  (`re-frame.machines/machine-transition` + the pure predicates + the
-  registration validator) so they are JVM- and CLJS-runnable from arguments
-  alone, dual-runtime via the `*-cljs-test` / `*_cljs_test.cljc` convention
-  (discovered by both `npm run test:cljs` and `clojure -M:test`).
+  These cases live in their OWN namespace (this file). They drive the SAME
+  pure engine surface (`re-frame.machines/machine-transition` + the pure
+  predicates + the registration validator) so they are JVM- and
+  CLJS-runnable from arguments alone, dual-runtime via the `*-cljs-test` /
+  `*_cljs_test.cljc` convention (discovered by both `npm run test:cljs` and
+  `clojure -M:test`).
 
-  XState v5 (xstate@5.32.0, the recorded gold standard — rf2-tsq6g) is the
-  reference for every behaviour; the W3C SCXML IRP semantic-core is the
-  canonical corpus. Where re-frame2 deliberately diverges from the raw SCXML
-  shape (substrate-constrained, or behavioural parity via different
-  expression), the case asserts the RE-FRAME2 behaviour and CITES the
-  documented divergence rather than the SCXML default.
+  XState v5 (xstate@5.32.0, the recorded gold standard) is the reference for
+  every behaviour; the W3C SCXML IRP semantic-core is the canonical corpus.
+  Where re-frame2 deliberately diverges from the raw SCXML shape
+  (substrate-constrained, or behavioural parity via different expression),
+  the case asserts the RE-FRAME2 behaviour and CITES the documented
+  divergence rather than the SCXML default.
 
   =========================================================================
   ## W3C SCXML IRP SEMANTIC-CORE COVERAGE MATRIX
@@ -42,7 +40,7 @@
   evaluation, no `<send>`/`<invoke>`/I-O-processor mechanics — both excluded
   by design, the same line xstate draws; see the sibling file's
   `## SCXML EXCLUSIONS`). Each row is COVERED (by an existing fixture or
-  deftest), NEW (ported here by rf2-7wy0ke), or OUT-OF-SCOPE-with-reason.
+  deftest), NEW (ported here), or OUT-OF-SCOPE-with-reason.
 
   Initial / default-entry:
     355  initial absent ⇒ first child in document order   COVERED
@@ -86,8 +84,8 @@
                                   scxml-irp-test396-exact-event-name-match.
     399  descriptor matching = exact OR token-prefix       NEW — re-frame2 spells the
                                   SCXML §3.12.1 dot-prefix token descriptor as the
-                                  keyword NAMESPACE-wildcard `:ns/*` (rf2-z4t2v); a
-                                  bare (non-namespaced) event has no token tier.
+                                  keyword NAMESPACE-wildcard `:ns/*`; a bare
+                                  (non-namespaced) event has no token tier.
                                   scxml-irp-test399-*.
 
   done / final / parallel-done:
@@ -110,10 +108,10 @@
     504  external transition exit set = LCCA descendants   COVERED (scxml-lca-cascade-*)
     505  internal transition (compound source): target's
          descendants in the exit set                       NEW — re-frame2 / xstate v5
-                                  FLIP the SCXML internal/external DEFAULT
-                                  (rf2-eicq0): an explicit on-path target is
-                                  INTERNAL by default (re-resolves descendants);
-                                  external restart is opt-in `:reenter? true`.
+                                  FLIP the SCXML internal/external DEFAULT:
+                                  an explicit on-path target is INTERNAL by
+                                  default (re-resolves descendants); external
+                                  restart is opt-in `:reenter? true`.
                                   scxml-irp-test505-internal-default-re-resolves-descendants.
     506  internal treated as external when not applicable  NEW — disjoint-subtree target
                                   is always external (exit/enter both leaves).
@@ -196,7 +194,7 @@
 ;; by exact name (396) OR by a token-prefix descriptor — `error` matches
 ;; `error.send.failed` (399). re-frame2 events are NAMESPACED KEYWORDS, so
 ;; the keyword namespace is the natural token-prefix tier: `:error/*` is
-;; re-frame2's spelling of SCXML's `error.*` partial descriptor (rf2-z4t2v).
+;; re-frame2's spelling of SCXML's `error.*` partial descriptor.
 ;; The three tiers resolve most-specific-first at each level: exact >
 ;; namespace-wildcard `:ns/*` > total `:*`. Spec 005 §Wildcard transitions
 ;; §Namespaced (partial) event descriptors. xstate v5 partial descriptor
@@ -287,19 +285,19 @@
 
 ;; ===========================================================================
 ;; §C. Internal vs external transition exit set — W3C IRP test505/506/533
-;;      (SCXML §3.13; re-frame2 / xstate v5 FLIP the default — rf2-eicq0)
+;;      (SCXML §3.13; re-frame2 / xstate v5 FLIP the default)
 ;;
 ;; SCXML §3.13 distinguishes `type="internal"` (target's descendants in the
 ;; exit set, source compound NOT exited) from `type="external"` (the source
 ;; compound is in the exit set). SCXML's DEFAULT is EXTERNAL. xstate v5
-;; FLIPPED the default — an explicit on-path target is INTERNAL by default
+;; FLIPS the default — an explicit on-path target is INTERNAL by default
 ;; (re-resolve descendants, do NOT re-enter the compound), and the external
-;; restart is the opt-in `reenter: true`. re-frame2 follows xstate v5
-;; (rf2-eicq0). These cases assert the v5 behaviour and CITE the divergence
-;; from SCXML's external-default; the SCXML external semantics are still
-;; EXERCISED via `:reenter? true` in the sibling §10/§10b/§10c. Verified
-;; against xstate@5.32.0 (rf2-gt1pu). Spec 005 §Self-transitions §The three
-;; explicit-target geometries.
+;; restart is the opt-in `reenter: true`. re-frame2 follows xstate v5.
+;; These cases assert the v5 behaviour and CITE the divergence from SCXML's
+;; external-default; the SCXML external semantics are still EXERCISED via
+;; `:reenter? true` in the sibling §10/§10b/§10c. Verified against
+;; xstate@5.32.0. Spec 005 §Self-transitions §The three explicit-target
+;; geometries.
 ;; ===========================================================================
 
 (deftest scxml-irp-test505-internal-default-re-resolves-descendants
@@ -453,7 +451,7 @@
 ;; leaf final?" and is true for BOTH — so it cannot prove the root-vs-embedded
 ;; rule on its own. test415 therefore asserts `top-level-final?`; the embedded
 ;; counter-case below pins the predicates apart. Spec 005 §Final states
-;; §Top-level vs embedded (rf2-bnjb3 / rf2-zlmz7).
+;; §Top-level vs embedded.
 ;; ===========================================================================
 
 (deftest scxml-irp-test415-top-level-final-is-machine-final

--- a/implementation/machines/test/re_frame/snapshot_compat_test.clj
+++ b/implementation/machines/test/re_frame/snapshot_compat_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.snapshot-compat-test
-  "Per rf2-fasdp / Spec 005 §Snapshot shape stability invariants 3 & 4.
+  "Per Spec 005 §Snapshot shape stability invariants 3 & 4.
 
   Verifies the handler-entry reconciler fires the right named
   `:rf.error/*` event AND resets the snapshot to a fresh initial-state
@@ -25,10 +25,10 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe
-;; finding #4). The bespoke `capture-error-traces` below stays local —
-;; it is an intentional manual-stop idiom (returns a `:stop!` thunk the
-;; call sites invoke explicitly) rather than a `finally`-scoped block.
+;; snapshot lookup via the shared machines test-support. The bespoke
+;; `capture-error-traces` below stays local — it is an intentional
+;; manual-stop idiom (returns a `:stop!` thunk the call sites invoke
+;; explicitly) rather than a `finally`-scoped block.
 (def ^:private snapshot mtest/snapshot)
 
 (defn- capture-error-traces []
@@ -86,16 +86,16 @@
           (is (= :next (:state snap))))
         (finally (stop!))))))
 
-;; ---- (3b) parallel region-key parity (bz0ox.2 / x4s9t.2) -----------------
+;; ---- (3b) parallel region-key parity -------------------------------------
 ;;
 ;; A parallel configuration is EVERY declared region active simultaneously.
 ;; A snapshot MISSING a declared region (corrupted/old restore, or a hot
 ;; reload that ADDED a region) or carrying an EXTRA/stale region (a hot
-;; reload that DROPPED a region) is malformed: validating only the regions
-;; PRESENT let a partial map like `{:left :done}` for a 2-region machine
-;; pass, then silently run a partial configuration that could vacuously fire
-;; root :on-done / auto-destroy. The reconciler must require EXACT declared-
-;; region key parity and reset through :rf.error/machine-state-not-in-definition.
+;; reload that DROPPED a region) is malformed. The reconciler requires EXACT
+;; declared-region key parity: a partial map like `{:left :done}` for a
+;; 2-region machine is rejected rather than silently running a partial
+;; configuration that could vacuously fire root :on-done / auto-destroy. A
+;; key-parity violation resets through :rf.error/machine-state-not-in-definition.
 
 (deftest parallel-missing-region-resets-to-initial
   (testing "a parallel snapshot MISSING a declared region resets to :initial and emits :rf.error/machine-state-not-in-definition (bz0ox.2 / x4s9t.2)"
@@ -111,7 +111,7 @@
       (try
         (rf/reg-machine :compat/par-missing spec)
         ;; Seed a partial snapshot missing :right — :left already final.
-        ;; Pre-fix this validated and (with :right absent) could vacuously
+        ;; Without strict key parity a snapshot missing :right could vacuously
         ;; read all-final and auto-destroy the machine with a region missing.
         (frame/swap-runtime-db! :rf/default
                               assoc-in
@@ -156,11 +156,11 @@
               "reset rebuilt exactly the declared regions at their initial leaves"))
         (finally (stop!))))))
 
-;; ---- (3c) occupied :history pseudo-state (bz0ox.2) -----------------------
+;; ---- (3c) occupied :history pseudo-state ---------------------------------
 ;;
 ;; A :type :history node is TARGETABLE but NEVER an occupied active state. A
 ;; snapshot whose active leaf IS a history node is malformed — node existence
-;; alone is not occupiability. The reconciler must reject it and reset.
+;; alone is not occupiability. The reconciler rejects it and resets.
 
 (deftest occupied-history-pseudo-state-resets-to-initial
   (testing "a flat/compound snapshot whose active leaf is a :type :history pseudo-state resets to :initial and emits :rf.error/machine-state-not-in-definition (bz0ox.2)"
@@ -175,7 +175,7 @@
       (try
         (rf/reg-machine :compat/hist spec)
         ;; Seed a snapshot occupying the history pseudo-state — node-at
-        ;; resolves it (pre-fix => validated), but it is never occupiable.
+        ;; resolves it, but it is never occupiable.
         (frame/swap-runtime-db! :rf/default
                               assoc-in
                               [:rf.runtime/machines :snapshots :compat/hist]

--- a/implementation/machines/test/re_frame/spawn_all_reply_envelope_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_reply_envelope_test.clj
@@ -1,12 +1,12 @@
 (ns re-frame.spawn-all-reply-envelope-test
-  "rf2-d63qtp — `:spawn-all` join-child completions lower through the
-  uniform reply envelope (EP-0011 §Machine Completion / Managed-Effects
-  §Status taxonomy / §Stale suppression / §Tracing).
+  "`:spawn-all` join-child completions lower through the uniform reply
+  envelope (EP-0011 §Machine Completion / Managed-Effects §Status taxonomy /
+  §Stale suppression / §Tracing).
 
-  Single `:spawn` finality already lowers through `re-frame.machines.reply`
-  and stamps `:work/id` + `:rf.reply/status` on `:rf.machine/done`. The
-  `:spawn-all` child completion previously folded into join state + emitted
-  resolution traces with NO canonical reply map. These tests pin that:
+  Single `:spawn` finality lowers through `re-frame.machines.reply` and stamps
+  `:work/id` + `:rf.reply/status` on `:rf.machine/done`. The `:spawn-all`
+  child completion folds into join state AND carries a canonical reply map.
+  These tests pin that:
 
    1. the DECISIVE child completion that drives a join resolution rides
       reply-envelope facts (`:work/id`, `:rf.reply/status :ok` / `:error`,

--- a/implementation/machines/test/re_frame/spawn_all_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_test.clj
@@ -1,7 +1,7 @@
 (ns re-frame.spawn-all-test
-  "Per rf2-6vmw and Spec 005 §Spawn-and-join via :spawn-all. Verifies
-  the first-class `:spawn-all` spawn-and-join surface that gives
-  parallel-region state-machines a single declarative shape.
+  "Per Spec 005 §Spawn-and-join via :spawn-all. Verifies the first-class
+  `:spawn-all` spawn-and-join surface that gives parallel-region
+  state-machines a single declarative shape.
 
   The test scenarios cover the four join-condition shapes
   (:all / :any / {:n N} / {:fn pred}) plus cancel-on-decision
@@ -26,7 +26,7 @@
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; runtime-db / snapshot lookup via the shared machines test-support
-;; (rf2-3l8lqe finding #4) — no hardcoded `[:rf.runtime/machines …]` path.
+;; — no hardcoded `[:rf.runtime/machines …]` path.
 (def ^:private frame-db mtest/runtime-db)
 (def ^:private snapshot mtest/snapshot)
 
@@ -250,11 +250,11 @@
         ;; :c was cancelled.
         (is (nil? (get-in (frame-db) [:rf.runtime/machines :snapshots (:c ids)])))))))
 
-;; ---- (rf2-ny0yrz C5) unsatisfiable join warning --------------------------
+;; ---- unsatisfiable join warning ------------------------------------------
 ;;
 ;; A {:n N} / {:fn} (or :all / :any) join with NO :on-any-failed silently
 ;; hangs forever once enough children fail that the success condition is
-;; unreachable. The runtime now emits a one-shot
+;; unreachable. The runtime emits a one-shot
 ;; :rf.warning/spawn-all-join-unsatisfiable on the fold that first makes the
 ;; join unsatisfiable.
 
@@ -411,9 +411,9 @@
                                              :join           {:n 3}
                                              :on-child-done  :done
                                              :on-child-error :failed}}}}))))
-  ;; rf2-vyjq3m: a :spawn-all child must declare EXACTLY ONE of :machine-id /
-  ;; :definition (XOR). Previously a child carrying BOTH slipped through
-  ;; `(or :machine-id :definition)`; now both-set is rejected too.
+  ;; A :spawn-all child must declare EXACTLY ONE of :machine-id /
+  ;; :definition (XOR): a child carrying BOTH is rejected, as is a child
+  ;; carrying NEITHER.
   (testing ":spawn-all child with BOTH :machine-id AND :definition — rejected (XOR)"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
@@ -441,15 +441,15 @@
                                              :on-all-complete [:done]}}}}))
         "an inline-definition :spawn-all child (no :machine-id) registers cleanly")))
 
-;; ---- single :spawn :machine-id xor :definition (rf2-vyjq3m) ---------------
+;; ---- single :spawn :machine-id xor :definition ---------------------------
 ;;
-;; `validate-machine!` previously had NO single-:spawn XOR check — a :spawn
-;; declaring BOTH :machine-id and :definition (ambiguous: inline init while
-;; :rf/machine-type stamps the registered id → type mismatch on restore) or
-;; NEITHER (nothing to instantiate → late actor-id allocation failure) slipped
-;; through registration. Now both fail-closed with :rf.error/machine-spawn-
-;; bad-shape. XState-v5 alignment: `invoke` takes exactly one source (a
-;; referenced/registered actor logic OR an inline one), never both/neither.
+;; `validate-machine!` enforces a single-:spawn XOR check at registration: a
+;; :spawn declaring BOTH :machine-id and :definition (ambiguous: inline init
+;; while :rf/machine-type stamps the registered id → type mismatch on
+;; restore) or NEITHER (nothing to instantiate → late actor-id allocation
+;; failure) fails-closed with :rf.error/machine-spawn-bad-shape. XState-v5
+;; alignment: `invoke` takes exactly one source (a referenced/registered
+;; actor logic OR an inline one), never both/neither.
 
 (deftest single-spawn-id-xor-definition-validated-at-registration
   (testing "a single :spawn declaring NEITHER :machine-id nor :definition — rejected"
@@ -502,7 +502,7 @@
                                      :done    {}}}))
         "an explicit :id-prefix alongside exactly-one source is fine")))
 
-;; ---- decisive-child payload forwarding (rf2-4aop8) -----------------------
+;; ---- decisive-child payload forwarding -----------------------------------
 
 (defn- mk-child-with-payload
   "Like mk-child but the terminal-state dispatch carries an extra payload
@@ -562,7 +562,7 @@
                (:join-event (:data snap)))
             "resolution event carries decisive child-id and forwarded payload")))))
 
-;; ---- late-completion safety net (rf2-1tt9q) -----------------------------
+;; ---- late-completion safety net ------------------------------------------
 ;;
 ;; intercept-spawn-all-event has a post-resolution branch (join.cljc:134-141)
 ;; that fires when a child-done event arrives AFTER the join already
@@ -626,7 +626,7 @@
         (finally
           (rf/unregister-listener! :trace ::late-cb))))))
 
-;; ---- forged child-id rejection (rf2-ns8ut) ------------------------------
+;; ---- forged child-id rejection -------------------------------------------
 ;;
 ;; intercept-spawn-all-event must verify the inbound `child-id` is one
 ;; of the parent's spawned children before mutating the join state.
@@ -844,15 +844,14 @@
         (is (= :ready (:state (snapshot :sup/gate-ok)))
             "legitimate :spawn-all resolution still fires :on-all-complete")))))
 
-;; ---- parallel regions reusing the SAME :on-child-done id (rf2-w84jv) -----
+;; ---- parallel regions reusing the SAME :on-child-done id -----------------
 ;;
 ;; Two active parallel regions may legitimately reuse a generic
 ;; `:on-child-done` event id (`:done`, `:asset/loaded`). `find-active-spawn-all`
-;; used `some`, returning the FIRST region whose active state matched — so a
-;; child completion from a LATER region was routed to the first region's join,
-;; failed its child-id OWNERSHIP check as forged, and the correct region's join
-;; never updated (it hung). The fix collects ALL active matches and routes by
-;; which join-state OWNS the arriving child-id.
+;; collects ALL active matches and routes each child completion by which
+;; join-state OWNS the arriving child-id, so a completion from one region is
+;; never misrouted to a sibling region's join (which would fail its child-id
+;; ownership check as forged and leave the correct region hung).
 
 (deftest parallel-regions-sharing-on-child-done-route-by-child-ownership
   (testing "two parallel regions reusing :on-child-done :done route each child completion to the region whose join OWNS it; no bad-child-id, neither region hangs (rf2-w84jv)"

--- a/implementation/machines/test/re_frame/spawn_data_fn_form_test.clj
+++ b/implementation/machines/test/re_frame/spawn_data_fn_form_test.clj
@@ -1,14 +1,12 @@
 (ns re-frame.spawn-data-fn-form-test
-  "Per rf2-h131 and Spec 005 §Declarative `:spawn`
+  "Per Spec 005 §Declarative `:spawn`
   §Spec-spec keys: `:data` admits a function form `(fn [snap ev] data)`
   so the spawned child's initial data can be derived from the parent's
   post-action snapshot + the triggering event.
 
   The four invariants under test:
 
-   1. **Literal-map `:data` (regression).** A literal map is passed
-      through verbatim — the back-compat path that pre-rf2-h131
-      already worked.
+   1. **Literal-map `:data`.** A literal map is passed through verbatim.
 
    2. **fn-form `:data` is materialised.** When `:data` is a fn, the
       runtime invokes `(data snap event)` and passes the resulting
@@ -33,11 +31,11 @@
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; runtime-db / snapshot lookup via the shared machines test-support
-;; (rf2-3l8lqe finding #4) — no hardcoded `[:rf.runtime/machines …]` path.
+;; — no hardcoded `[:rf.runtime/machines …]` path.
 (def ^:private snapshot mtest/snapshot)
 (def ^:private frame-db mtest/runtime-db)
 
-;; ---- (1) literal-map :data — back-compat regression -----------------------
+;; ---- (1) literal-map :data — passes through verbatim ----------------------
 
 (deftest literal-map-data-passes-through
   (testing "literal-map `:data` arrives at the spawned child verbatim"
@@ -79,7 +77,7 @@
             "the fn-form derived :url from the parent's :data.:endpoint")
         (is (= :post (:method child-data))
             "the fn-form-derived :method survived the spawn")
-        ;; Runtime stamps :rf/self-id etc. into :data per rf2-ijm7 — the
+        ;; Runtime stamps :rf/self-id etc. into :data — the
         ;; materialised map is the BASE the runtime then augments.
         (is (= :worker/proc#1 (:rf/self-id child-data))
             "the runtime stamped :rf/self-id over the materialised map")))))
@@ -141,8 +139,8 @@
                                                     (throw (ex-info "boom" {:why :test})))}}}}]
       (rf/reg-machine :worker/proc child)
       (rf/reg-machine :sup/throwing parent)
-      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
-      ;; unregister in a `finally`, no hand-rolled register/try/finally.
+      ;; Shared `with-trace-capture` — guaranteed unregister in a `finally`,
+      ;; no hand-rolled register/try/finally.
       (mtest/with-trace-capture traces
         (rf/dispatch-sync [:sup/throwing [:start]])
         ;; The cascade halted: no actor was spawned. Per Spec 005 §Errors,

--- a/implementation/machines/test/re_frame/spawn_destroyed_frame_atomicity_test.clj
+++ b/implementation/machines/test/re_frame/spawn_destroyed_frame_atomicity_test.clj
@@ -1,20 +1,18 @@
 (ns re-frame.spawn-destroyed-frame-atomicity-test
-  "Per rf2-g13nm2 C3 — destroyed-/unknown-frame spawn atomicity.
+  "Destroyed-/unknown-frame spawn atomicity.
 
   `spawn-fx*` (the accepted-spawn body of `:rf.machine/spawn`) reads the
   frame's runtime-db once as `old-rt`; for a DESTROYED or never-created
   frame that read is nil, and the fallback id-allocator yields a nil
-  `spawned-id` (the `:else` branch). The install of the snapshot /
-  system-id / spawn-slot is correctly gated on `(when old-rt …)` and so
-  skips for a dead frame — BUT pre-fix the `:rf.machine.spawn/spawned`
-  trace AND the `:start` (or synthetic) dispatch sat outside that gate
-  (under `(when-not rejected?)` only). A destroyed-frame spawn therefore
-  fired a phantom `spawned` trace and dispatched `[nil <start>]` into the
-  void for an actor that was NEVER installed — an atomicity violation.
+  `spawned-id` (the `:else` branch).
 
-  The fix gates the WHOLE accepted-spawn cascade (trace + install +
-  dispatch) on `(and (not rejected?) old-rt)`, so a dead-frame spawn is a
-  clean no-op: no trace, no install, no dispatch, nil returned."
+  The WHOLE accepted-spawn cascade — the `:rf.machine.spawn/spawned`
+  trace, the snapshot / system-id / spawn-slot install, and the `:start`
+  (or synthetic) dispatch — is gated on `(and (not rejected?) old-rt)`, so
+  a dead-frame spawn is a clean no-op: no trace, no install, no dispatch,
+  nil returned. This keeps the spawn atomic — there is never a phantom
+  `spawned` trace or a `[nil <start>]` dispatch for an actor that was not
+  installed."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]

--- a/implementation/machines/test/re_frame/spawn_on_spawn_throw_test.clj
+++ b/implementation/machines/test/re_frame/spawn_on_spawn_throw_test.clj
@@ -1,18 +1,18 @@
 (ns re-frame.spawn-on-spawn-throw-test
-  "Per rf2-km4bn4. A throwing `:on-spawn` advisory callback must route
-  through the documented machine action exception contract — exactly as a
-  throwing `:action` / `:data`-fn does (spawn_data_fn_form_test §4) — and
-  MUST NOT escape as a generic `:rf.error/handler-exception`.
+  "A throwing `:on-spawn` advisory callback routes through the documented
+  machine action exception contract — exactly as a throwing `:action` /
+  `:data`-fn does (spawn_data_fn_form_test §4) — and MUST NOT escape as a
+  generic `:rf.error/handler-exception`.
 
   `:on-spawn` is a machine action (resolved through `:on-spawn-actions`
-  with `:actions` fallback, Spec 005 §Declarative `:spawn`). Pre-fix the
-  callback was invoked raw (no try/catch, no Result conversion), so a
-  buggy observer aborted the whole event as an uncaught handler failure —
-  bypassing the machine-scoped `:rf.error/machine-action-exception`
-  diagnostic, the frame-tagged trace, and the atomic-rollback discipline.
+  with `:actions` fallback, Spec 005 §Declarative `:spawn`). The callback is
+  invoked inside the machine layer's try/catch with Result conversion, so a
+  throwing observer is caught and routed through the machine-scoped
+  `:rf.error/machine-action-exception` diagnostic, the frame-tagged trace,
+  and the atomic-rollback discipline — never aborting the whole event as an
+  uncaught handler failure.
 
-  The contract the fix establishes, verified here for BOTH single `:spawn`
-  and `:spawn-all`:
+  The contract, verified here for BOTH single `:spawn` and `:spawn-all`:
 
    1. A throwing `:on-spawn` emits EXACTLY ONE
       `:rf.error/machine-action-exception` (op-type `:error`) stamped with
@@ -34,7 +34,7 @@
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; runtime-db / snapshot lookup via the shared machines test-support
-;; (rf2-3l8lqe finding #4) — no hardcoded `[:rf.runtime/machines …]` path.
+;; — no hardcoded `[:rf.runtime/machines …]` path.
 (def ^:private snapshot mtest/snapshot)
 (def ^:private frame-db mtest/runtime-db)
 
@@ -59,8 +59,8 @@
 
 (defn- handler-exceptions
   "The generic `:rf.error/handler-exception` envelopes among `traces` —
-  the contract violation this fix closes (the throw must NOT reach the
-  core dispatch boundary)."
+  the throw must NOT reach the core dispatch boundary, so this is expected
+  to be empty."
   [traces]
   (filter #(= :rf.error/handler-exception (:operation %)) traces))
 

--- a/implementation/machines/test/re_frame/spawn_registry_test.clj
+++ b/implementation/machines/test/re_frame/spawn_registry_test.clj
@@ -1,10 +1,9 @@
 (ns re-frame.spawn-registry-test
-  "Per rf2-t07u (Option A revised). Verifies the runtime-tracked
-  declarative-`:spawn` spawn registry at `[:rf.runtime/machines :spawned <parent-id>
-  <invoke-id>]` — the slot the framework writes on every declarative
-  `:spawn` spawn so the matching destroy cascade can locate the
-  spawned id WITHOUT reading the user's `:data :pending` (the v1
-  pre-rf2-t07u magic).
+  "Verifies the runtime-tracked declarative-`:spawn` spawn registry at
+  `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` — the slot the
+  framework writes on every declarative `:spawn` spawn so the matching
+  destroy cascade can locate the spawned id WITHOUT reading the user's
+  `:data :pending`.
 
   The four invariants under test:
 
@@ -20,11 +19,11 @@
       pruned and the empty `[:rf.runtime/machines :spawned]` slot is
       dissoc'd entirely.
 
-   3. **Auth-flow scenario without `:data :pending` magic.** A spec
+   3. **Auth-flow scenario without `:data :pending` bookkeeping.** A spec
       whose `:on-spawn` does NOT record the id in any `:data` slot
       still has the spawned actor cleanly destroyed on state exit —
-      the runtime no longer reads `:data` to find the id. (Pre-rf2-t07u
-      this scenario silently leaked the actor.)
+      the runtime tracks the id internally rather than reading `:data`
+      to find it.
 
    4. **Multi-child independent tracking.** A parent that has two
       different `:spawn`-bearing states (different invoke-ids) tracks
@@ -45,7 +44,7 @@
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; runtime-db / snapshot lookup via the shared machines test-support
-;; (rf2-3l8lqe finding #4) — no hardcoded `[:rf.runtime/machines …]` path.
+;; — no hardcoded `[:rf.runtime/machines …]` path.
 (def ^:private snapshot mtest/snapshot)
 (def ^:private frame-db mtest/runtime-db)
 
@@ -53,10 +52,10 @@
 
 (deftest spawn-writes-runtime-registry-slot
   (testing "entering a :spawn-bearing state binds [:rf.runtime/machines :spawned <parent> <invoke-id>] to the spawned-id"
-    (let [;; Per rf2-grw4i / rf2-v0rrr the :on-spawn callback is purely
-          ;; advisory — its return value is ignored. We capture the id
-          ;; via a side-effect atom to verify the callback fires; the
-          ;; runtime tracks the id at [:rf.runtime/machines :spawned ...] regardless.
+    (let [;; The :on-spawn callback is purely advisory — its return value
+          ;; is ignored. We capture the id via a side-effect atom to verify
+          ;; the callback fires; the runtime tracks the id at
+          ;; [:rf.runtime/machines :spawned ...] regardless.
           observed (atom nil)
           child  {:initial :running
                   :data    {}
@@ -65,7 +64,7 @@
                   :on-spawn-actions
                   ;; Observational body — side-effect into an atom, returns
                   ;; nil (the advisory contract drops the return; returning
-                  ;; nil keeps the dev-warn quiet, rf2-dtth6).
+                  ;; nil keeps the dev-warn quiet).
                   {:record (fn [{:keys [id]}] (reset! observed id) nil)}
                   :states
                   {:idle      {:on {:start :working}}
@@ -121,11 +120,10 @@
 
 ;; ---- (3) auth-flow scenario WITHOUT user-side :on-spawn bookkeeping -------
 ;;
-;; The scenario the rf2-t07u DESIGN section calls out: a :spawn whose
-;; user-supplied :on-spawn doesn't write the id under any :data slot.
-;; Pre-rf2-t07u the runtime silently leaked the spawned actor on state-exit
-;; (it had no `:data :pending` to read). With Option A revised, the runtime
-;; tracks the id internally and the destroy cascade works correctly.
+;; A :spawn whose user-supplied :on-spawn doesn't write the id under any
+;; :data slot still has the spawned actor cleanly destroyed on state-exit:
+;; the runtime tracks the id internally, so the destroy cascade works
+;; correctly without any `:data :pending` to read.
 
 (deftest auth-flow-without-data-pending-magic
   (testing "a :spawn without any :on-spawn :data write still has the actor destroyed on state-exit"
@@ -148,10 +146,10 @@
             spawned-id (get-in db [:rf.runtime/machines :spawned :auth/main [:authenticating]])]
         (is (= :http/post#1 spawned-id))
         (is (some? (get-in db [:rf.runtime/machines :snapshots spawned-id])))
-        ;; Per rf2-rc8wci the runtime now binds the spawned id into the
-        ;; parent's `:data` under `[:rf/spawned <invoke-id>]` (XState-context
-        ;; parity) — so the user's domain `:data` keys are still untouched,
-        ;; but the reserved `:rf/spawned` capture is present.
+        ;; The runtime binds the spawned id into the parent's `:data` under
+        ;; `[:rf/spawned <invoke-id>]` (XState-context parity) — so the
+        ;; user's domain `:data` keys are untouched, but the reserved
+        ;; `:rf/spawned` capture is present.
         (is (= {:rf/spawned {[:authenticating] :http/post#1}}
                (get-in (snapshot :auth/main) [:data]))
             "user domain :data untouched; runtime stamps only the reserved :rf/spawned id capture")
@@ -204,7 +202,7 @@
         (is (not (contains? (get-in db [:rf.runtime/machines]) :spawned))
             "with both invokes torn down, the lazy-allocation slot is dissoc'd")))))
 
-;; ---- (rf2-rc8wci) spawned-id bound into the parent's own :data -----------
+;; ---- spawned-id bound into the parent's own :data -----------
 ;;
 ;; The declarative `:spawn` binds the assigned actor id into the SPAWNING
 ;; (parent) machine's own `:data` under the reserved per-invoke map
@@ -365,9 +363,9 @@
     (let [child  {:initial :running :data {} :states {:running {}}}
           ;; This test pins the keyword-form imperative destroy MECHANISM
           ;; in isolation, so it feeds the id via a test-local atom. NOTE:
-          ;; the atom is NOT the idiomatic way to obtain the id — per
-          ;; rf2-rc8wci the first-class path is to read it from the parent's
-          ;; own `:data` under `[:rf/spawned <invoke-id>]` (see
+          ;; the atom is NOT the idiomatic way to obtain the id — the
+          ;; first-class path is to read it from the parent's own `:data`
+          ;; under `[:rf/spawned <invoke-id>]` (see
           ;; `action-reads-parent-data-id-and-destroys-no-atom` above for
           ;; the no-atom round-trip). The atom here only isolates the
           ;; `[:rf.machine/destroy <id>]` keyword-arg shape under test.
@@ -380,7 +378,7 @@
                                 {:fx [[:rf.machine/destroy @recorded]]})}
                   :on-spawn-actions
                   ;; Sidechannel-atom capture — returns nil (advisory; the
-                  ;; runtime drops the return, rf2-dtth6).
+                  ;; runtime drops the return).
                   {:record (fn [{:keys [id]}] (reset! recorded id) nil)}
                   :states
                   {:idle    {:on {:start :working}}
@@ -403,12 +401,11 @@
 
 ;; ---- (5) spawned actor's snapshot carries :rf/spawn-counter + :meta -------
 ;;
-;; Per rf2-fgqs4 the unified build-initial-snapshot helper seeds
-;; :rf/spawn-counter {} and propagates :meta on every snapshot it
-;; builds — including spawned actors. Before rf2-fgqs4 the spawn path
-;; called a stripped-down builder that omitted both keys; the runtime
-;; then fell back to the defensive (fnil inc 0) backstop and the
-;; spawned child's :meta was dropped.
+;; The unified build-initial-snapshot helper seeds :rf/spawn-counter {} and
+;; propagates :meta on every snapshot it builds — including spawned actors.
+;; A spawned child's grandchild id therefore allocates from the child's own
+;; :rf/spawn-counter, and the child's spec-declared :meta flows through to
+;; its snapshot.
 
 (deftest spawned-actor-snapshot-carries-spawn-counter
   (testing "a spawned actor's initial snapshot has :rf/spawn-counter {}"
@@ -441,7 +438,7 @@
         (is (= {:foo :bar :version 7} (:meta snap))
             "spec-declared :meta is propagated to the spawned actor's snapshot")))))
 
-;; ---- (rf2-dtth6) dev-warn when :on-spawn returns a dropped value ---------
+;; ---- dev-warn when :on-spawn returns a dropped value ---------
 ;;
 ;; `:on-spawn` is advisory: its return is DROPPED. A callback that returns a
 ;; non-nil value (the canonical-looking `(assoc data :pending id)` trap) has
@@ -455,9 +452,8 @@
 (defn- capture-warn-ops!
   "Run `thunk` while a trace listener records every emitted `:operation`.
   Returns the vector of operations seen during the body. Routed through the
-  shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
-  unregister in a `finally` — then projects each envelope to its
-  `:operation`."
+  shared `mtest/with-trace-capture` — guaranteed unregister in a `finally`
+  — then projects each envelope to its `:operation`."
   [thunk]
   (mtest/with-trace-capture seen
     (thunk)

--- a/implementation/machines/test/re_frame/substrate_source_machine_test.clj
+++ b/implementation/machines/test/re_frame/substrate_source_machine_test.clj
@@ -1,8 +1,8 @@
 (ns re-frame.substrate-source-machine-test
-  "Per rf2-ejtpd — substrate-internal `:source` values stamped at the
-  machine-substrate dispatch sites. JVM coverage; the substrate stamp
-  paths are platform-agnostic `.cljc` so the assertions hold uniformly
-  across CLJS reagent / plain-atom / JVM hosts.
+  "Substrate-internal `:source` values stamped at the machine-substrate
+  dispatch sites. JVM coverage; the substrate stamp paths are
+  platform-agnostic `.cljc` so the assertions hold uniformly across CLJS
+  reagent / plain-atom / JVM hosts.
 
   | new `:source` value | stamped by                            | when                                                    |
   |---------------------|---------------------------------------|---------------------------------------------------------|
@@ -84,11 +84,9 @@
           (is (= [:after-source/flow [:rf.machine.timer/after-elapsed 1000 1 [:loading]]]
                  (get-in timer-ev [:tags :rf.event/v]))
               "the dispatched event vector carries the machine id + synthetic trigger")
-          ;; Per rf2-1ve9h the prior `:rf/dispatch-origin :timer` axis
-          ;; was collapsed into `:source` — `:after-timer` is now the
-          ;; single functional-origin discriminator (Mike-approved
-          ;; Option A, 2026-05-28). No separate `:rf/dispatch-origin`
-          ;; tag rides alongside.
+          ;; `:source` is the single functional-origin discriminator —
+          ;; `:after-timer` carries the axis. No separate
+          ;; `:rf/dispatch-origin` tag rides alongside.
           (is (nil? (get-in timer-ev [:tags :rf/dispatch-origin]))
               ":rf/dispatch-origin retired per rf2-1ve9h — `:source` carries the axis"))
         (finally (trace-tooling/unregister-listener! ::after-src))))))
@@ -143,7 +141,7 @@
 (deftest machine-spawn-synthetic-spawned-stamps-source-machine-spawn
   (testing "machine spawn fx stamps :source :machine-spawn on the synthetic [:rf.machine.spawn/spawned] event"
     ;; When the spawn args omit :start, the runtime dispatches
-    ;; [<child-id> [:rf.machine.spawn/spawned]] (rf2-ijm7) — same stamp path.
+    ;; [<child-id> [:rf.machine.spawn/spawned]] — same stamp path.
     (let [parent-machine
           {:initial :idle
            :data    {}
@@ -182,13 +180,13 @@
 
 (deftest machine-action-dispatch-stamps-source-machine-action
   (testing ":dispatch fx from a machine handler stamps :source :machine-action (rf2-c3990)"
-    ;; Per rf2-c3990: when the parent envelope carries
-    ;; `:rf.machine/internal? true` (the router stamps this on every
-    ;; machine-handler invocation), the `:dispatch` fx handler stamps
-    ;; the child envelope with `:source :machine-action` instead of the
-    ;; ordinary `:fx-dispatch` — the actor-message path. This lets
-    ;; tools distinguish machine-emitted continuations from plain
-    ;; `:dispatch` fx cascades in a non-machine handler.
+    ;; When the parent envelope carries `:rf.machine/internal? true` (the
+    ;; router stamps this on every machine-handler invocation), the
+    ;; `:dispatch` fx handler stamps the child envelope with
+    ;; `:source :machine-action` instead of the ordinary `:fx-dispatch` —
+    ;; the actor-message path. This lets tools distinguish machine-emitted
+    ;; continuations from plain `:dispatch` fx cascades in a non-machine
+    ;; handler.
     (let [parent-machine
           {:initial :idle
            :actions {:emit-action
@@ -221,8 +219,8 @@
   (testing ":dispatch fx from a NON-machine event handler retains :source :fx-dispatch (rf2-c3990)"
     ;; The :machine-action stamp is conditional on the parent envelope
     ;; carrying `:rf.machine/internal? true`. Ordinary event handlers
-    ;; that emit `:dispatch` keep the pre-rf2-c3990 `:fx-dispatch`
-    ;; stamp — this regression-guards the discriminator.
+    ;; that emit `:dispatch` keep the `:fx-dispatch` stamp — this
+    ;; regression-guards the discriminator.
     (let [seen (atom [])]
       (rf/reg-event :ordinary/parent
         (fn [_ctx _]

--- a/implementation/machines/test/re_frame/tags_test.clj
+++ b/implementation/machines/test/re_frame/tags_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.tags-test
-  "Per Spec 005 §State tags and rf2-ee0d (Nine States Stage 1).
+  "Per Spec 005 §State tags (Nine States Stage 1).
 
   State-tag semantics covered:
     - Flat machine: the snapshot's :tags is the active state's tag set.
@@ -16,8 +16,7 @@
 
   These JVM tests pair with the conformance fixtures
   spec/conformance/fixtures/tags-{flat,compound,empty,round-trip}.edn.
-  The CLJS surface is exercised by re-frame.machines-tags-cljs-test
-  (split out of the former monolithic re-frame.machines-cljs-test per rf2-3vps4)."
+  The CLJS surface is exercised by re-frame.machines-tags-cljs-test."
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
@@ -29,7 +28,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
 (def ^:private snapshot mtest/snapshot)
 

--- a/implementation/machines/test/re_frame/timer_frame_scope_test.clj
+++ b/implementation/machines/test/re_frame/timer_frame_scope_test.clj
@@ -1,25 +1,14 @@
 (ns re-frame.timer-frame-scope-test
-  "Per rf2-ysa94: regression test for the frame-scoping of
-  `re-frame.machines.timer/after-timers` — the last process-global atom
-  in the machines artefact prior to this refactor.
+  "Frame-scoping of `re-frame.machines.timer/after-timers`.
 
-  Pre-rf2-ysa94 the table was a single flat map keyed by
-  `[frame-id parent-id invoke-id delay-key]`. Two consequences (the
-  rf2-ra1he audit §TM4 motivation):
-
-    1. Frame isolation broken under concurrent fixture runs. A
-       `reset-timers!` call from one test fixture cleared sibling test
-       fixtures' entries via `(reset! after-timers {})`.
-
-    2. `after-cancel-fx` did a linear scan over the entire atom on every
-       state-exit-with-:after — O(timers-all-frames) instead of
-       O(timers-this-frame).
-
-  Post-rf2-ysa94 the table is `{<frame-id> {<inner-key> <entry>}}` and
-  the public API gains a 1-arity `reset-timers!` / `cancel-all-timers!`
-  for per-frame teardown. The destroy-frame! hook
-  `:machines/on-frame-destroyed!` releases a destroyed frame's timers
-  without disturbing siblings.
+  The table is `{<frame-id> {<inner-key> <entry>}}` — entries partition by
+  frame-id, so frame isolation holds under concurrent fixture runs (a
+  `reset-timers!` on one frame leaves siblings untouched) and
+  `after-cancel-fx` scans only the active frame's entries
+  (O(timers-this-frame), not O(timers-all-frames)). The public API offers a
+  1-arity `reset-timers!` / `cancel-all-timers!` for per-frame teardown, and
+  the destroy-frame! hook `:machines/on-frame-destroyed!` releases a
+  destroyed frame's timers without disturbing siblings.
 
   The assertions below exercise both the structural invariant (entries
   partition by frame-id) and the behaviour: two frames scheduling timers
@@ -75,12 +64,10 @@
           "the timer table partitions entries under the left frame")
       (is (contains? tt :iso/right)
           "the timer table partitions entries under the right frame")
-      ;; Inner keys (per rf2-gwznv): {:parent <parent-id> :spawn
-      ;; <invoke-id-vec> :delay <delay-key>}. Because the machine spec
-      ;; is identical the inner keys collide across frames —
-      ;; pre-rf2-ysa94 the keying included the frame-id; post-rf2-ysa94
-      ;; the frame-id is the OUTER key and the inner keys legitimately
-      ;; coincide.
+      ;; Inner keys are {:parent <parent-id> :spawn <invoke-id-vec>
+      ;; :delay <delay-key>}. Because the machine spec is identical the
+      ;; inner keys collide across frames — the frame-id is the OUTER
+      ;; key and the inner keys legitimately coincide.
       (let [left-inner-keys  (set (keys (get tt :iso/left)))
             right-inner-keys (set (keys (get tt :iso/right)))]
         (is (= left-inner-keys right-inner-keys)
@@ -134,7 +121,7 @@
     (is (= {} @timer/after-timers)
         "0-arity clears the whole table — the fixture-teardown shape")))
 
-;; ---- regression: after-cancel-fx no longer scans across frames -----------
+;; ---- regression: after-cancel-fx is scoped to the active frame -----------
 
 (deftest after-cancel-fx-scoped-to-active-frame
   (testing "exiting an :after-bearing state in one frame must not cancel sibling frames' timers"

--- a/implementation/machines/test/re_frame/trace_enhancements_rf2_82a0u_test.clj
+++ b/implementation/machines/test/re_frame/trace_enhancements_rf2_82a0u_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.trace-enhancements-rf2-82a0u-test
-  "Per rf2-82a0u: three additive trace enhancements feed the Xray epoch
-  panel's Handler section. This test file pins the new emit shapes:
+  "Three trace enhancements feed the Xray epoch panel's Handler section.
+  This test file pins their emit shapes:
 
     1. `:rf.machine/action-ran` carries `:phase` from the closed set
        `:exit / :transition / :entry / :always / :after-action /
@@ -25,7 +25,7 @@
 
 ;; ---- helpers ---------------------------------------------------------------
 
-;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; Routed through the shared `mtest/with-trace-capture`
 ;; — guaranteed unregister in a `finally`.
 (defn- record-traces!
   [body-fn]

--- a/implementation/machines/test/re_frame/transition_frame_tag_test.clj
+++ b/implementation/machines/test/re_frame/transition_frame_tag_test.clj
@@ -1,24 +1,20 @@
 (ns re-frame.transition-frame-tag-test
-  "Per rf2-hwuki: `:rf.machine/transition` MUST carry the `:frame` tag so
+  "`:rf.machine/transition` MUST carry the `:frame` tag so
   `re-frame.epoch.capture/capture-event!` admits it into the cascade's
   trace buffer.
 
-  Discovered by the Xray matrix P1 gaps worker (rf2-bz72m chart-render
-  scenario) while building a chart-render assertion: the framework
-  emitted `:rf.machine/transition` WITHOUT `:frame`, so the epoch
-  capture gate (`(when (and frame-id ...) (state/buffer-event! ...))`)
-  silently dropped the event. The trace fanned out to direct trace
-  listeners (so unit tests that registered a `register-listener!`
-  observed it) but never reached the epoch-history `:trace-events`
-  slot the Xray Machine Inspector reads from. The chart 'never
-  rendered' for real cascades; Xray's own unit tests sidestepped it
-  via a `:rf.xray/set-epoch-history-for-test` injection seam.
+  The epoch capture gate (`(when (and frame-id ...) (state/buffer-event!
+  ...))`) admits a trace event only when its tags carry `:frame`; an event
+  whose tags lack `:frame` is dropped from the epoch-history
+  `:trace-events` slot the Xray Machine Inspector reads from (though it
+  still fans out to direct trace listeners). So a `:rf.machine/transition`
+  must tag `:frame` for the Machine Inspector to see real cascades.
 
   This test lives in the machines artefact (which does not depend on
   epoch) so the site contract is exercised even when the epoch artefact
   isn't on the test classpath. The end-to-end harvested-record
   assertion lives upstack in the epoch / Xray gates — they read the
-  same `:tags :frame` slot we lock here, so a future regression that
+  same `:tags :frame` slot we lock here, so a regression that
   drops the tag fails at this site test first (clear cause)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]

--- a/implementation/machines/test/re_frame/transition_slot_spec_path_test.clj
+++ b/implementation/machines/test/re_frame/transition_slot_spec_path_test.clj
@@ -1,12 +1,11 @@
 (ns re-frame.transition-slot-spec-path-test
-  "rf2-lai1qv — the substrate stamps the selected transition's EXACT
-  spec-path DISCRIMINATOR (`:transition-slot`) on the
-  `:rf.machine/action-ran` trace so Xray's cascade rows can address the
-  precise inline-source slot (candidate index, `:after` delay-key,
-  root-vs-state) rather than reconstructing the path from
-  `source-state` / `event` / `phase` (which hardcoded candidate 0,
-  could not name the delay-key, and assumed a `:states` prefix for a
-  root `:on`).
+  "The substrate stamps the selected transition's EXACT spec-path
+  DISCRIMINATOR (`:transition-slot`) on the `:rf.machine/action-ran` trace
+  so Xray's cascade rows can address the precise inline-source slot
+  (candidate index, `:after` delay-key, root-vs-state) directly, rather
+  than reconstructing the path from `source-state` / `event` / `phase` —
+  a reconstruction that cannot pin the candidate index, name the delay-key,
+  or distinguish a root `:on` from a `:states`-prefixed one.
 
   These tests drive the four enumerated cases through the live runtime
   and pin the discriminator the trace carries. The Xray-side
@@ -23,7 +22,7 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; Routed through the shared `mtest/with-trace-capture`
 ;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
   (mtest/with-trace-capture seen

--- a/implementation/machines/test/re_frame/update_snapshot_schema_test.clj
+++ b/implementation/machines/test/re_frame/update_snapshot_schema_test.clj
@@ -1,11 +1,10 @@
 (ns re-frame.update-snapshot-schema-test
-  "rf2-wrrvs7 — the `:rf.machine/update-snapshot` escape hatch must NOT
-  bypass the `:where :machine-data` boundary. Spec 005 §Snapshot-level
-  escape hatch: user error/status state lives under `:data` *where
-  `:data-schema` validation covers it*. The fx validates the would-be-
-  merged snapshot's `:data` against the actor's `:data-schema` BEFORE
-  writing, and a violating patch is rejected — the invalid `:data` never
-  installs.
+  "The `:rf.machine/update-snapshot` escape hatch must NOT bypass the
+  `:where :machine-data` boundary. Spec 005 §Snapshot-level escape hatch:
+  user error/status state lives under `:data` *where `:data-schema`
+  validation covers it*. The fx validates the would-be-merged snapshot's
+  `:data` against the actor's `:data-schema` BEFORE writing, and a violating
+  patch is rejected — the invalid `:data` never installs.
 
   Contract under test:
 
@@ -22,9 +21,8 @@
       per-instance handler) is validated and rejected on violation.
    5. **Missing / destroyed actor.** A patch addressed to an actor with
       no snapshot is a no-op — no write, no trace.
-   6. **`:db` hard-disallow preserved.** A `:db` key still surfaces
-      `:rf.error/machine-action-wrote-db` and is dropped (regression
-      guard against the validation rewrite).
+   6. **`:db` hard-disallow.** A `:db` key surfaces
+      `:rf.error/machine-action-wrote-db` and is dropped.
 
   Uses Malli (the framework default validator)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]


### PR DESCRIPTION
De-historicize comments/docstrings per rf2-2db7z1. Recovered after the worker's parent + the recovery agent were killed by an API rate-limit; commits were already made in-worktree, pushed by the mayor. Behaviour-neutral (comment/docstring only).