### PR TITLE
fix(core): clear trace-disabled-frames on frame destroy (rf2-zcl055)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2052,6 +2052,18 @@
         ;; still flows through the live stream cleanly. Routed via
         ;; late-bind so production CLJS bundles (no trace.tooling) no-op.
         (safe-call-hook! :trace.tooling/release-frame-ring! id)
+        ;; rf2-zcl055: release the destroyed frame's trace-emission gate
+        ;; flag — the teardown counterpart to `reg-frame`'s
+        ;; `trace/set-frame-no-emit!`. A tool / inspector frame registered
+        ;; with `:rf.trace/frame-no-emit? true` (e.g. `:rf/xray`) otherwise
+        ;; leaves a permanent entry in trace.cljc's process-global
+        ;; `trace-disabled-frames` set (the ring IS freed above; the flag
+        ;; was not — a teardown asymmetry). Called directly (not via a
+        ;; tooling hook) because `trace.cljc` is always loaded — the set +
+        ;; predicate live on the core trace surface, same as the `reg-frame`
+        ;; registration call. Idempotent no-op for application frames (the
+        ;; common case, where the id was never added).
+        (trace/clear-frame-no-emit-for! id)
         ;; EP-0024: there is ONE `frames` registry, and `dissoc-frame!` below IS
         ;; the forget. The frame's resolved generation rides the record's
         ;; `:generation` slot, so dropping the record drops it too — no separate

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -223,6 +223,20 @@
   (reset! trace-disabled-frames #{})
   nil)
 
+(defn clear-frame-no-emit-for!
+  "Remove `frame-id` from the trace-disabled set. Per-frame teardown
+  counterpart to `set-frame-no-emit!` — routed into `destroy-frame!`
+  alongside the per-frame trace-ring release so a destroyed tool /
+  inspector frame (e.g. `:rf/xray`) does not leave a permanent entry in
+  this process-global atom (rf2-zcl055). `clear-frame-no-emit!` resets
+  the WHOLE set; this removes one id. Idempotent — a no-op when the id is
+  absent (the common application-frame case). Equivalent to
+  `(set-frame-no-emit! frame-id false)`; named for symmetry with the
+  destroy-time call site."
+  [frame-id]
+  (swap! trace-disabled-frames disj frame-id)
+  nil)
+
 (defn- tagged-frame-trace-disabled?
   "True when `tags` carries a `:frame` that is registered trace-disabled.
   The empty-set common case (no tool frame mounted) short-circuits

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -617,6 +617,29 @@
     (is (= [] (rf/trace-buffer :tool/inspector))
         "tool-frame's ring stays empty")))
 
+(deftest destroy-clears-trace-disabled-flag
+  ;; rf2-zcl055: `reg-frame` adds a `:rf.trace/frame-no-emit? true` frame to
+  ;; the process-global trace-disabled set; `destroy-frame!` must remove it
+  ;; (the teardown counterpart to `set-frame-no-emit!`, symmetric with the
+  ;; per-frame trace-ring release). Without the fix the destroyed frame's id
+  ;; lingers permanently in `trace/trace-disabled-frames` — a process-global
+  ;; id leak (one keyword per destroyed-and-never-re-registered tool frame).
+  (testing "a destroyed trace-disabled frame leaves no entry in the trace-disabled set"
+    (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
+    (is (trace/frame-trace-disabled? :tool/inspector)
+        "reg-frame marked the tool frame trace-disabled")
+    (frame/destroy-frame! :tool/inspector)
+    (is (not (trace/frame-trace-disabled? :tool/inspector))
+        "destroy-frame! removed the frame id from trace-disabled-frames (no process-global leak)"))
+  (testing "destroying one tool frame does not disturb another's trace-disabled flag"
+    (rf/reg-frame :tool/a {:rf.trace/frame-no-emit? true})
+    (rf/reg-frame :tool/b {:rf.trace/frame-no-emit? true})
+    (frame/destroy-frame! :tool/a)
+    (is (not (trace/frame-trace-disabled? :tool/a))
+        "destroyed frame's flag is cleared")
+    (is (trace/frame-trace-disabled? :tool/b)
+        "the surviving tool frame's flag is untouched")))
+
 ;; ---- 6. B4 hot-reload dedup-by-shape ------------------------------------
 
 (deftest hot-reload-unchanged-handler-emits-zero-traces


### PR DESCRIPTION
## Summary

`reg-frame` marks a `:rf.trace/frame-no-emit? true` tool/inspector frame (e.g. `:rf/xray`) in trace.cljc's process-global `trace-disabled-frames` set via `trace/set-frame-no-emit!`, but `destroy-frame!` only released the per-frame trace **ring** — it never removed the id from the **set**. A destroyed-and-never-re-registered tool frame therefore leaked one keyword per id permanently in the process-global atom.

It's a minor, dev-only, debug-gated leak (re-registration under the same id self-heals), but it's a real teardown **asymmetry**: the ring IS freed on destroy, the trace-disabled flag was not.

## Root cause

`destroy-frame!` (frame.cljc) fired `:trace.tooling/release-frame-ring!` but had no counterpart for the `trace/set-frame-no-emit!` call made at `reg-frame` time. The existing `clear-frame-no-emit!` resets the *whole* set, which is wrong for per-frame destroy.

## Fix

- **trace.cljc**: add `clear-frame-no-emit-for!` — a per-frame removal (`disj`), the teardown counterpart to `set-frame-no-emit!`. Idempotent; equivalent to `(set-frame-no-emit! id false)`, named for the destroy-time call site.
- **frame.cljc**: route `(trace/clear-frame-no-emit-for! id)` into `destroy-frame!` directly alongside the trace-ring release. Direct `trace/` call (not a tooling hook) mirrors how `reg-frame` sets the flag — `trace.cljc` is always loaded, the set + predicate live on the core trace surface.

## Quality gates

| Gate | Result |
|------|--------|
| Regression test `destroy-clears-trace-disabled-flag` (JVM, `trace_buffer_test.clj`) | **FAILS before fix** (2 failures — id lingers), **PASSES after** (1 test / 4 assertions) |
| `re-frame.trace-buffer-test` full namespace (JVM) | 48 tests / 119 assertions, 0 failures, 0 errors |
| `re-frame.frame-lifecycle-test` (JVM — destroy-path adjacent) | 34 tests / 169 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (node CLJS gate) | Skipped locally — `node_modules` absent; relying on CI |

Scope: trace.cljc + frame.cljc + the test file only (+49 lines). Bead rf2-zcl055.