### PR TITLE
fix(core): retain :dispatch-later timer handles for frame-destroy cancellation (rf2-uxz52g)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2042,6 +2042,20 @@
         ;; destroyed frame in each host cache. No-op when re-frame.resources
         ;; is absent (the artefact is optional).
         (safe-call-hook! :resources/on-frame-destroyed! id)
+        ;; Cancel + drop the destroyed frame's still-pending
+        ;; `:dispatch-later` host timers (rf2-uxz52g). Each arms a host-clock
+        ;; timer whose thunk dispatches the deferred event into THIS frame;
+        ;; left armed across destroy it fires a dead-on-arrival dispatch into
+        ;; a torn-down frame, and its armed handle + captured closure leak
+        ;; until the delay elapses (unbounded under frame churn in long-running
+        ;; SSR / test processes). The handles live in a host-side side table
+        ;; in `re-frame.fx` (NOT runtime-db — off the epoch/SSR egress wire),
+        ;; mirroring the resources / machines timer tables; this hook releases
+        ;; the frame's slice. Reached via late-bind because `re-frame.fx`
+        ;; static-requires nothing of `re-frame.frame` (a back-require would
+        ;; invert the load order); the hook is bound at boot since fx ships in
+        ;; every canonical build.
+        (safe-call-hook! :fx/on-frame-destroyed! id)
         ;; The shipped subsystems tear down via the named ordered hooks above.
         (emit-frame-destroyed-trace! id)
         ;; Per Spec 009 §Per-frame trace rings:

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -183,6 +183,110 @@
   (or (-> frame-record :config :platform)
       (interop/active-platform)))
 
+;; ---- :dispatch-later host-timer side table (rf2-uxz52g) -------------------
+;;
+;; `:dispatch-later` arms a host-clock timer (`interop/set-timeout!`) whose
+;; thunk dispatches the deferred event into its frame. The host handle must
+;; be RETAINED so `destroy-frame!` can cancel a still-pending timer for a
+;; frame that is torn down before it fires — otherwise the armed timer + its
+;; captured closure leak until it fires, and the deferred dispatch is
+;; dead-on-arrival anyway (it lands in a destroyed frame, where `dispatch!`
+;; recovers it as a `:rf.error/frame-destroyed` diagnostic). Under frame
+;; churn (long-running SSR / test processes) that is unbounded retention.
+;;
+;; This MIRRORS the resources stale / GC / poll timer side table
+;; (`re-frame.resources.timers/timer-table`) and the machines `:after`
+;; timer table: a module-level transient host cache keyed by frame, holding
+;; ONLY the opaque non-serializable host handle, NEVER runtime-db, never on
+;; the SSR / hydration / epoch wire, cleared per-frame on frame destroy. A
+;; fired timer drops its OWN entry before dispatching, so the table holds
+;; exactly the set of still-pending timers.
+
+(defonce ^:private dispatch-later-counter
+  ;; Monotonic counter minting a unique id per armed `:dispatch-later` so
+  ;; two timers in the same frame (same or different events) never collide
+  ;; on a side-table slot. The id is opaque bookkeeping — it never escapes
+  ;; this ns.
+  (atom 0))
+
+(defonce
+  ^{:private true
+    :doc "Host-side side table of pending `:dispatch-later` timer handles,
+   keyed by `[frame-id timer-id]` → an opaque host handle from
+   `re-frame.interop/set-timeout!`. Transient host state (NOT runtime-db),
+   so an epoch restore cannot rewind / recycle it and it never rides the
+   SSR / hydration / epoch wire. A fired timer drops its own entry;
+   `release-frame!` cancels + drops every still-pending timer for a
+   destroyed frame (frame/destroy-frame! via the `:fx/on-frame-destroyed!`
+   late-bind hook). Mirrors `re-frame.resources.timers/timer-table`."}
+  dispatch-later-timers
+  (atom {}))
+
+(defn- arm-dispatch-later!
+  "Arm a `:dispatch-later` host timer that dispatches `event` with `opts`
+  after `ms`, RETAINING its handle in `dispatch-later-timers` under
+  `[frame-id timer-id]` so `release-frame!` can cancel it on frame destroy.
+  The timer thunk drops its OWN slot BEFORE dispatching, so the table tracks
+  exactly the pending set (a fired timer leaves no residue). Returns nil."
+  [frame-id ms event opts]
+  (let [timer-id (swap! dispatch-later-counter inc)
+        k        [frame-id timer-id]
+        handle   (interop/set-timeout!
+                   (fn []
+                     ;; Drop our own slot first — the timer has fired, so its
+                     ;; handle is spent; a later `release-frame!` must not try
+                     ;; to cancel a fired handle, and the table must not retain
+                     ;; a fired timer.
+                     (swap! dispatch-later-timers dissoc k)
+                     ;; Sticky hook (rf2-f72pd) — the timer callback fires per
+                     ;; scheduled :dispatch-later. When the frame was destroyed
+                     ;; before the timer fired, this slot was already cancelled
+                     ;; + dropped by `release-frame!`, so this thunk never runs;
+                     ;; on the live path `dispatch!` enqueues into the frame.
+                     (when-let [dispatch! (late-bind/get-fn-cached :router/dispatch!)]
+                       (dispatch! event opts)))
+                   ms)]
+    (swap! dispatch-later-timers assoc k handle)
+    nil))
+
+(defn release-frame!
+  "Cancel + drop EVERY still-pending `:dispatch-later` timer for a destroyed
+  `frame-id` (rf2-uxz52g). Invoked from `frame/destroy-frame!` via the
+  `:fx/on-frame-destroyed!` late-bind hook so a timer armed before destroy
+  never fires a dead-on-arrival dispatch into the torn-down frame, and its
+  armed host handle + captured closure are released promptly rather than
+  leaking until the delay elapses. Idempotent — a frame with no pending
+  timers is a no-op. Returns nil."
+  [frame-id]
+  (doseq [[[fid _tid :as k] handle] @dispatch-later-timers]
+    (when (= fid frame-id)
+      (interop/clear-timeout! handle)
+      (swap! dispatch-later-timers dissoc k)))
+  nil)
+
+(defn reset-dispatch-later-timers!
+  "Cancel + drop EVERY frame's pending `:dispatch-later` timers (test
+  isolation, rf2-uxz52g). Published via `:fx/reset-dispatch-later-timers!`
+  so the shared CLJS `make-reset-runtime-fixture` reset-hooks table clears it
+  per test — host-side transient state the runtime / frames reset does not
+  touch, so without this a stale armed timer from a sibling test could fire
+  mid-next-test. Returns nil."
+  []
+  (doseq [[_ handle] @dispatch-later-timers]
+    (interop/clear-timeout! handle))
+  (reset! dispatch-later-timers {})
+  nil)
+
+;; Publish the frame-destroy cleanup + test-isolation reset through the
+;; late-bind registry (mirroring `:resources/on-frame-destroyed!` /
+;; `:machines/reset-timers!`). `re-frame.frame/destroy-frame!` cannot
+;; static-require this ns (fx requires nothing of frame, and a back-require
+;; would invert the load order), so the hook is the seam. Bound once at
+;; ns-load — `re-frame.fx` ships in every canonical build (core.cljc
+;; side-effect-requires it), so the hook is always present.
+(late-bind/set-fn! :fx/on-frame-destroyed!           release-frame!)
+(late-bind/set-fn! :fx/reset-dispatch-later-timers!  reset-dispatch-later-timers!)
+
 ;; ---- do-fx ----------------------------------------------------------------
 
 (declare dispatch-fx-handler)
@@ -415,18 +519,20 @@
    ;; (carrying the same `:source-detail {:ms <ms>}`) when the parent
    ;; envelope is machine-internal, matching the `:dispatch` fx
    ;; handler's machine-action discriminator above.
+   ;;
+   ;; Per rf2-uxz52g: the armed host handle is RETAINED in the
+   ;; `dispatch-later-timers` side table (keyed by frame) so
+   ;; `destroy-frame!` can cancel a still-pending timer for a frame torn
+   ;; down before it fires (a fired timer drops its own slot). Without the
+   ;; retain, the armed timer + its captured closure leak until the delay
+   ;; elapses, and the deferred dispatch is dead-on-arrival in the
+   ;; destroyed frame.
    (fn [frame-id parent-envelope {:keys [ms event]}]
      (let [machine? (:rf.machine/internal? parent-envelope)
            opts (assoc (child-dispatch-opts frame-id parent-envelope)
                        :source        (if machine? :machine-action :fx-dispatch-later)
                        :source-detail {:ms ms})]
-       (interop/set-timeout!
-         (fn []
-           ;; Sticky hook (rf2-f72pd) — same as above; the timer
-           ;; callback fires per scheduled :dispatch-later.
-           (when-let [dispatch! (late-bind/get-fn-cached :router/dispatch!)]
-             (dispatch! event opts)))
-         ms)))
+       (arm-dispatch-later! frame-id ms event opts)))
 
    ;; Per Spec 013 — flows are frame-scoped. The flow registers against
    ;; the dispatching frame.

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -137,6 +137,22 @@
     :design-bead "rf2-x3m8c"
     :description "Dispose every cached subscription in a destroyed frame's sub-cache, emitting one `:rf.sub/dispose` per slot with `:rf.sub/reason :frame-destroy`. Invoked by `frame/destroy-frame!` via late-bind so `re-frame.frame` carries no static dep on `re-frame.subs.cache` (which requires `frame`)."}
 
+   ;; ---- re-frame.fx (:dispatch-later host-timer side table) -----------------
+   ;; Core (NOT an optional artefact): `re-frame.fx` is side-effect-required at
+   ;; boot, so these hooks are bound in every canonical build. Reached via
+   ;; late-bind because `re-frame.frame/destroy-frame!` (and the test-support
+   ;; reset fixture) cannot static-require `re-frame.fx` — fx requires nothing
+   ;; of frame, and a back-require would invert the load order — exactly the
+   ;; `:subs.cache/dispose-all-for-frame-destroy!` cycle-break above.
+   {:key         :fx/on-frame-destroyed!
+    :producer-ns 're-frame.fx
+    :design-bead "rf2-uxz52g"
+    :description "Cancel + drop the destroyed frame's still-pending `:dispatch-later` host timers (re-frame.fx/dispatch-later-timers, keyed by [frame-id timer-id] → host handle). Each `:dispatch-later` arms a host-clock timer whose thunk dispatches the deferred event into the frame; left armed across destroy it fires a dead-on-arrival dispatch into a torn-down frame and its armed handle + captured closure leak until the delay elapses (unbounded under frame churn). Host-side transient state (NOT runtime-db, off the epoch/SSR egress wire), mirroring the resources / machines timer tables. Invoked by `frame/destroy-frame!` by key."}
+   {:key         :fx/reset-dispatch-later-timers!
+    :producer-ns 're-frame.fx
+    :design-bead "rf2-uxz52g"
+    :description "Test-isolation reset: cancel + drop EVERY frame's pending `:dispatch-later` host timers (re-frame.fx/dispatch-later-timers). Host-side transient state the runtime / frames reset does not touch; the shared CLJS make-reset-runtime-fixture reset-hooks table fires it per test so a stale armed timer from a sibling test can't fire mid-next-test (mirrors :machines/reset-timers!)."}
+
    ;; ===========================================================================
    ;; GROUP 2 — CROSS-ARTEFACT
    ;;

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -229,6 +229,15 @@
     :machines/reset-timers!          — cancel in-flight `:after` wall-clock
                                        timers so a stale timer from a
                                        sibling test can't survive.
+    :fx/reset-dispatch-later-timers! — cancel every frame's pending
+                                       `:dispatch-later` host timers
+                                       (rf2-uxz52g) so a stale armed timer
+                                       from a sibling test can't fire mid-
+                                       next-test. Host-side transient state
+                                       the `frames` reset above does not
+                                       touch (mirrors `:machines/reset-
+                                       timers!`); always bound (re-frame.fx
+                                       ships in core).
     :machines/reset-spawn-order!     — drop the per-frame spawn-order
                                        channel (rf2-vsigt) so a stale
                                        entry from a sibling test can't
@@ -297,6 +306,7 @@
    {:hook :flows/reset-last-inputs!        :phase :pre-dispose}
    {:hook :schemas/clear-by-frame!         :phase :pre-dispose}
    {:hook :machines/reset-timers!          :phase :post-dispose}
+   {:hook :fx/reset-dispatch-later-timers! :phase :post-dispose}
    {:hook :machines/reset-spawn-order!     :phase :post-dispose}
    {:hook :routing/reset-counters!         :phase :post-dispose}
    {:hook :routing/reset-nav-counters!     :phase :post-dispose}

--- a/implementation/core/test/re_frame/dispatch_later_frame_destroy_test.clj
+++ b/implementation/core/test/re_frame/dispatch_later_frame_destroy_test.clj
@@ -1,0 +1,159 @@
+(ns re-frame.dispatch-later-frame-destroy-test
+  "Regression: a `:dispatch-later` timer armed for a frame that is destroyed
+  before the timer fires must be CANCELLED by `destroy-frame!` (rf2-uxz52g).
+
+  FINDING (code review, worker-max session 2026-06-20): the `:dispatch-later`
+  reserved-fx body armed a host-clock timer via `interop/set-timeout!` but did
+  NOT retain the host handle anywhere, so `destroy-frame!` could not cancel a
+  still-pending `:dispatch-later` timer. A frame torn down before its timer
+  fired leaked the armed timer + its captured closure until the delay elapsed,
+  and the deferred dispatch was dead-on-arrival — it landed in a destroyed
+  frame, surfacing `:rf.error/frame-destroyed` on the always-on axis (the
+  drain recovers, but the timer fired needlessly and held resources).
+
+  FIX (rf2-uxz52g): `:dispatch-later` retains each armed handle in a host-side
+  side table keyed by frame (`re-frame.fx/dispatch-later-timers`), mirroring
+  the resources stale/GC/poll timer table; `destroy-frame!` cancels + drops the
+  frame's slice via the `:fx/on-frame-destroyed!` late-bind hook.
+
+  Two legs, both fail before the fix / pass after:
+
+    (white-box) the armed handle is retained under the frame's key, then the
+                key is gone after `destroy-frame!` (the table is cancelled +
+                cleared for that frame).
+    (behavioural) the deferred event NEVER dispatches into the destroyed frame
+                  — no `:rf.error/frame-destroyed` is surfaced and the target
+                  handler never runs, even after waiting well past the delay.
+                  Before the fix the timer fired into the dead frame and
+                  emitted `:rf.error/frame-destroyed`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.schemas :as schemas]
+            [re-frame.registrar :as registrar]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (schemas/clear-schemas-by-frame!)
+  (error-emit/clear-error-listeners!)
+  ;; Cancel + drop any pending :dispatch-later host timer so a sibling test
+  ;; cannot leak one into this run (the same reset the fixture reset-hooks
+  ;; table fires in the CLJS path).
+  (fx/reset-dispatch-later-timers!)
+  (rf/init! plain-atom/adapter)
+  (rf/reg-frame :rf/default {})
+  (test-fn)
+  (fx/reset-dispatch-later-timers!))
+
+(use-fixtures :each reset-runtime)
+
+(def ^:private test-frame :rf2-uxz52g/worker)
+
+(defn- timers-for-frame
+  "White-box read of the pending `:dispatch-later` host timers retained for
+  `frame-id` (the private `re-frame.fx/dispatch-later-timers` side table is
+  keyed by `[frame-id timer-id]`)."
+  [frame-id]
+  (->> @@(resolve 're-frame.fx/dispatch-later-timers)
+       (filter (fn [[[fid _tid] _handle]] (= fid frame-id)))))
+
+;; ===========================================================================
+;; (white-box) the armed handle is retained, then cancelled + dropped on
+;; frame destroy.
+;; ===========================================================================
+
+(deftest dispatch-later-handle-retained-then-cancelled-on-destroy
+  (testing "an armed :dispatch-later handle is retained under the frame's key
+            and removed by destroy-frame! (rf2-uxz52g)"
+    (rf/reg-frame test-frame {:doc "rf2-uxz52g destroy-cancellation frame"})
+    (rf/reg-event :rf2-uxz52g/target (fn [{:keys [db]} _] {:db db}))
+    (rf/reg-event :rf2-uxz52g/arm-later
+      ;; A long delay so the timer never fires on its own during the test —
+      ;; the only ways its slot leaves the table are (a) destroy-frame!
+      ;; cancellation (the fix) or (b) the timer firing (which we never wait
+      ;; for here).
+      (fn [_ _] {:fx [[:dispatch-later {:ms 600000 :event [:rf2-uxz52g/target]}]]}))
+
+    (rf/dispatch-sync [:rf2-uxz52g/arm-later] {:frame test-frame})
+
+    (is (= 1 (count (timers-for-frame test-frame)))
+        "the armed :dispatch-later host handle is RETAINED in the side table
+         keyed by the arming frame (before the fix nothing was retained)")
+
+    (rf/destroy-frame! test-frame)
+
+    (is (zero? (count (timers-for-frame test-frame)))
+        "destroy-frame! cancelled + dropped the frame's pending :dispatch-later
+         timer (before the fix the handle was never retained, so it could not
+         be cancelled — the timer stayed armed until the delay elapsed)")))
+
+;; ===========================================================================
+;; (behavioural) the deferred event never dispatches into the destroyed frame.
+;; ===========================================================================
+
+(deftest dispatch-later-does-not-fire-into-destroyed-frame
+  (testing "a :dispatch-later scheduled then destroyed before it fires NEVER
+            dispatches into the dead frame — no :rf.error/frame-destroyed, and
+            the target handler never runs (rf2-uxz52g)"
+    (let [target-ran (atom 0)
+          errors     (atom [])]
+      (rf/register-listener! :errors ::recorder (fn [record] (swap! errors conj record)))
+      (rf/reg-frame test-frame {:doc "rf2-uxz52g behavioural frame"})
+      (rf/reg-event :rf2-uxz52g/target
+        ;; Records into an EXTERNAL atom (not frame-db) so a would-be dead
+        ;; dispatch is observable independent of the destroyed-frame recovery.
+        (fn [{:keys [db]} _] (swap! target-ran inc) {:db db}))
+      (rf/reg-event :rf2-uxz52g/arm-short
+        ;; A short delay: long enough to arm + destroy first, short enough to
+        ;; fire well within the test's wait window IF it is not cancelled.
+        (fn [_ _] {:fx [[:dispatch-later {:ms 40 :event [:rf2-uxz52g/target]}]]}))
+
+      (rf/dispatch-sync [:rf2-uxz52g/arm-short] {:frame test-frame})
+      ;; Destroy the frame BEFORE the 40ms timer can fire.
+      (rf/destroy-frame! test-frame)
+
+      ;; Wait well past the delay (and past any async drain) so a leaked timer
+      ;; would have fired by now.
+      (Thread/sleep 300)
+
+      (rf/unregister-listener! :errors ::recorder)
+
+      (is (zero? @target-ran)
+          "the deferred target handler never ran — the timer was cancelled on
+           destroy, so it never dispatched into the dead frame")
+      (is (empty? (filter #(= :rf.error/frame-destroyed (:error %)) @errors))
+          "no :rf.error/frame-destroyed surfaced — the cancelled timer never
+           enqueued a dead-on-arrival dispatch into the destroyed frame (before
+           the fix the timer fired and the dead dispatch emitted this error)"))))
+
+;; ===========================================================================
+;; A live frame's :dispatch-later still fires normally — the fix must not
+;; perturb the ordinary (non-destroyed) path.
+;; ===========================================================================
+
+(deftest dispatch-later-still-fires-for-a-live-frame
+  (testing "a :dispatch-later for a frame that stays alive still dispatches its
+            event, and the fired timer leaves no residue in the side table"
+    (let [target-ran (atom 0)]
+      (rf/reg-frame test-frame {:doc "rf2-uxz52g live-path frame"})
+      (rf/reg-event :rf2-uxz52g/target
+        (fn [{:keys [db]} _] (swap! target-ran inc) {:db db}))
+      (rf/reg-event :rf2-uxz52g/arm-short
+        (fn [_ _] {:fx [[:dispatch-later {:ms 20 :event [:rf2-uxz52g/target]}]]}))
+
+      (rf/dispatch-sync [:rf2-uxz52g/arm-short] {:frame test-frame})
+      ;; Do NOT destroy — let the timer fire and the deferred event drain.
+      (Thread/sleep 300)
+
+      (is (= 1 @target-ran)
+          "the live frame's :dispatch-later fired and the deferred target ran")
+      (is (zero? (count (timers-for-frame test-frame)))
+          "a fired timer drops its own side-table slot — no leak on the live
+           path either")
+      (rf/destroy-frame! test-frame))))


### PR DESCRIPTION
## Summary

The `:dispatch-later` reserved-fx body armed a host-clock timer via `interop/set-timeout!` but did **not retain the host handle** anywhere, so `destroy-frame!` could not cancel a still-pending `:dispatch-later` timer (fx.cljc, the `:dispatch-later` reserved body). A frame torn down before its timer fired leaked the armed timer + its captured closure until the delay elapsed, and the deferred dispatch was dead-on-arrival — it landed in a destroyed frame, surfacing `:rf.error/frame-destroyed` on the always-on axis. Under frame churn (long-running SSR / test processes) that is unbounded resource retention.

## Fix

- `:dispatch-later` retains each armed handle in a host-side side table keyed by `[frame-id timer-id]` (`re-frame.fx/dispatch-later-timers`), **mirroring** the resources stale/GC/poll timer table (`re-frame.resources.timers/timer-table`) and the machines `:after` table — transient host state, never runtime-db, off the epoch/SSR egress wire. A fired timer drops its **own** slot before dispatching, so the table tracks exactly the pending set.
- `destroy-frame!` cancels + drops the frame's slice via the new `:fx/on-frame-destroyed!` late-bind hook. Reached via late-bind because `re-frame.frame` cannot static-require `re-frame.fx` (a back-require inverts load order) — the same cycle-break posture as `:subs.cache/dispose-all-for-frame-destroy!`.
- Test isolation rides a new `:fx/reset-dispatch-later-timers!` row in the shared `make-reset-runtime-fixture` reset-hooks table (mirrors `:machines/reset-timers!`).
- Both new keys are inventoried in `late-bind/directory.cljc` (the drift test gate passes).

## Files

- `implementation/core/src/re_frame/fx.cljc` — side table + `arm-dispatch-later!` / `release-frame!` / `reset-dispatch-later-timers!` + `set-fn!` publishes; `:dispatch-later` body now retains.
- `implementation/core/src/re_frame/frame.cljc` — `destroy-frame!` calls `(safe-call-hook! :fx/on-frame-destroyed! id)`.
- `implementation/core/src/re_frame/late_bind/directory.cljc` — two new hook directory entries.
- `implementation/core/src/re_frame/test_support.cljc` — reset-hook row + rationale.
- `implementation/core/test/re_frame/dispatch_later_frame_destroy_test.clj` — regression test (new).

## Regression test (fails before / passes after)

- **white-box** — the armed handle is retained under the frame's key, then gone after `destroy-frame!` (cancelled + cleared).
- **behavioural** — a `:dispatch-later` destroyed before it fires never dispatches into the dead frame: no `:rf.error/frame-destroyed`, target handler never runs after waiting past the delay.
- **live-path guard** — an undestroyed frame's `:dispatch-later` still fires and leaves no side-table residue.

Verified the test fails before the fix (white-box: nothing retained, `0` vs `1`; behavioural: dead timer fired + emitted `:rf.error/frame-destroyed`) and passes after, by temporarily reverting the source changes and re-running.

## Quality gates

- `clojure -M:test -n re-frame.dispatch-later-frame-destroy-test` — 3 tests / 6 assertions, **0 failures** (and confirmed failing on pre-fix source).
- `clojure -M:test -n re-frame.late-bind-drift-test` — green (validates the new `set-fn!` calls against the directory).
- `clojure -M:test -n re-frame.fx-test -n re-frame.frame-lifecycle-test -n re-frame.frame-destroy-composed-test` — 84 tests / 437 assertions, **0 failures**.
- `npm run test:cljs` — **skipped locally** (`node_modules` absent in a fresh worktree; `npm install` not run). Relying on CI as the merge gate. The touched source is plain CLJC over `interop/set-timeout!` / `clear-timeout!` (present on both runtimes); the JVM regression test exercises the same code path.
