### PR TITLE
docs(examples): de-historicize comments/docstrings (rf2-akhdqh)

### DIFF
--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -301,7 +301,7 @@
 ;;
 ;; The machine snapshot lives at [:rf.runtime/machines :snapshots :auth.login/flow] (per
 ;; Spec 005). These named subs project out the convenient pieces. The
-;; "in :submitting?" / "in :authed?" predicates moved to the
+;; "in :submitting?" / "in :authed?" predicates live as the
 ;; `:rf/machine-has-tag?` framework sub in views below (per Spec 005
 ;; §State tags).
 

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -56,15 +56,13 @@
 ;; SCHEMAS
 ;; ============================================================================
 
-;; EP-0025 (rf2-398kql): schema-attached `:sensitive?` / `:large?` field
-;; classification is REMOVED — frame-declared `:sensitive` / `:large {:app-db …}`
-;; paths (`reg-frame`, EP-0015) are the SOLE app-db classification mechanism.
-;; The password never lands in app-db (it rides the machine EVENT-arg schema and
-;; the HTTP body), so there is no app-db path to frame-declare; the prior
-;; `{:sensitive? true}` slot prop was a documentary no-op and is dropped. The
-;; managed-HTTP request below still carries `:sensitive? true` to scrub the
-;; password off the wire — a DIFFERENT axis (Spec 014 §Privacy, KEPT) and the
-;; working, observable redaction. Parity across reagent/login + uix.
+;; Frame-declared `:sensitive` / `:large {:app-db …}` paths (`reg-frame`)
+;; are the sole app-db classification mechanism. The password never lands
+;; in app-db (it rides the machine EVENT-arg schema and the HTTP body), so
+;; there is no app-db path to frame-declare. The managed-HTTP request below
+;; carries `:sensitive? true` to scrub the password off the wire — a
+;; different axis (Spec 014 §Privacy) and the working, observable
+;; redaction. Parity across reagent/login + uix.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -29,7 +29,7 @@
    does not re-copy the boot sequence — and passes a pre-mount hook that
    exercises the pure-CLJS SSR path the gate inspects; nothing about that
    fixture plumbing leaks into this namespace, and the two boot paths
-   cannot drift because there is only one (rf2-pe4u0g)."
+   cannot drift because there is only one."
   (:require [reagent2.dom.client                :as rdc]
             [re-frame.core                      :as rf]
             [re-frame.views]
@@ -83,13 +83,12 @@
 
 (defonce react-root (atom nil))
 
-;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the client render is wrapped in a `frame-provider` so
-;; every in-tree `dispatch`/`subscribe` resolves to the app frame. Matches
-;; the canonical mount in examples/reagent/counter/core.cljs.
+;; The runtime never synthesises a frame from absence — an app must
+;; establish its frame explicitly. `init!` installs the adapter (it does
+;; NOT create the frame), `reg-frame` registers the app frame, the boot
+;; dispatch runs under `with-frame`, and the client render is wrapped in a
+;; `frame-provider` so every in-tree `dispatch`/`subscribe` resolves to the
+;; app frame. Matches the canonical mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn boot!

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -32,10 +32,9 @@
       settle in one walk — right after the handler, before the db install.
    3. RUNTIME-TOGGLEABLE DERIVATION — the discount is a feature gate. The
       `:rf.fx/reg-flow` / `:rf.fx/clear-flow` fx register and clear the
-      `:cart/discount-rate` flow from a handler, mid-event. v1's
-      `on-changes` interceptor cannot do this (it is wired into specific
-      events at registration time); flows are runtime-registered and
-      runtime-clearable.
+      `:cart/discount-rate` flow from a handler, mid-event. Flows are
+      runtime-registered and runtime-clearable — the derivation can be
+      switched on or off as state changes, not fixed at registration time.
 
    Demonstrates:
    - `rf/reg-flow`                                  (Spec 013 §Registration shape)

--- a/examples/reagent/infinite_feed/core.cljs
+++ b/examples/reagent/infinite_feed/core.cljs
@@ -8,7 +8,7 @@
    accumulation driven by a CAUSAL `:rf.resource/load-more` event. There is no
    app-db list slice, no `:loading-more?` flag, no cursor threading, and no
    append reducer — the runtime owns all of it (that is the whole point of the
-   primitive; before EP-0021 an app hand-rolled every one of those by hand).
+   primitive: without it, an app hand-rolls every one of those by hand).
 
    It teaches, in one cohesive app, the four facts the primitive surfaces:
 

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -105,22 +105,17 @@
 ;; the form. Open by default; the regex/min-length checks describe the
 ;; shape the inner handler relies on.
 ;;
-;; EP-0025 — schema-attached `:sensitive?` / `:large?` field
-;; classification is REMOVED. Frame-declared `:sensitive` / `:large {:app-db …}`
-;; paths (`reg-frame`, EP-0015) are now the SOLE app-db data-classification
-;; mechanism. `Credentials` is the machine's EVENT-arg schema (it rides
-;; `AuthLoginEvent` via the machine's event `:schema`); the password is never
-;; written to durable app-db or the machine `:data` slot, so there is NO app-db
-;; path to frame-declare for it — and the prior `{:sensitive? true}` slot prop
-;; was already a documentary no-op (it classified the event-arg shape but never
-;; redacted the dispatched vector; see the pre-EP-0025 HONEST-SCOPE note in the
-;; git history). It is dropped here.
+;; Frame-declared `:sensitive` / `:large {:app-db …}` paths (`reg-frame`)
+;; are the sole app-db data-classification mechanism. `Credentials` is the
+;; machine's EVENT-arg schema (it rides `AuthLoginEvent` via the machine's
+;; event `:schema`); the password is never written to durable app-db or the
+;; machine `:data` slot, so there is no app-db path to frame-declare for it.
 ;;
 ;; The password's real off-box egress path is the HTTP request body — redacted
 ;; by the per-request `:sensitive? true` flag on the managed-HTTP call in
-;; `:issue-request` below (Spec 014 §Privacy, a DIFFERENT axis from app-db
-;; classification and explicitly KEPT). That carrier-level flag is the WORKING,
-;; observable redaction for this login flow.
+;; `:issue-request` below (Spec 014 §Privacy, a different axis from app-db
+;; classification). That carrier-level flag is the working, observable
+;; redaction for this login flow.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
@@ -395,11 +390,8 @@
 ;; machine spec. `reg-machine` is the blessed registration home — it stamps
 ;; the `:rf/machine?` / `:rf/machine` metadata that `(machine-meta
 ;; :auth.login/flow)` reads, so the `:where :machine-data` walker resolves the
-;; `:data-schema` and it VALIDATES. (EP-0025: the home no longer
-;; bridges the `:data-schema`'s `:sensitive?` / `:large?` slots into snapshot-
-;; egress redaction — schema-field classification is removed; durable machine
-;; `:data` egress classification is frame-owned, like every other app-db path.)
-;; The former hand-stamped `reg-event` + `make-machine-handler` composition is gone.
+;; `:data-schema` and it VALIDATES. Durable machine `:data` egress
+;; classification is frame-owned, like every other app-db path.
 (rf/reg-machine :auth.login/flow
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema AuthLoginEvent}

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -415,7 +415,7 @@
 
 ;; The machine snapshot lives at [:rf.runtime/machines :snapshots :auth.login/flow] (per
 ;; Spec 005). These named subs project out the convenient pieces. The
-;; "in :submitting?" and "in :authed?" predicates moved to the
+;; "in :submitting?" and "in :authed?" predicates live as the
 ;; `rf/machine-has-tag?` queries in views below (per Spec 005 §State tags).
 
 ;; EP-0001: machine snapshots are durable runtime-db state — read

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -221,10 +221,10 @@
                (`{:kind :success :value ...}` / `{:kind :failure
                :failure ...}`) reaches the inner `:auth.login/success` /
                `:auth.login/failure` sub-events via the explicit
-               `:on-success` / `:on-failure` form. Collapses the former
+               `:on-success` / `:on-failure` form. The
                schedule-reply → `:dispatch-later` → deliver-reply chain
-               into one `:after-ms` parameter (the delay is a parameter
-               of the same canned effect, not a new fx)."
+               is expressed as one `:after-ms` parameter (the delay is a
+               parameter of the same canned effect, not a new fx)."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -627,9 +627,9 @@
 ;;
 ;; The form and control panel use `(rf/machine-has-tag? :ui/nine-states
 ;; :mode/read-only)` to disable themselves when the :mode region is
-;; :done. The legacy variant queried `:ui.state/done?` for the same
-;; thing; tags are cleaner because the view doesn't need to know
-;; *which* state of which region carries the read-only intent.
+;; :done. Querying by tag is cleaner than querying a specific state
+;; (`:ui.state/done?`): the view doesn't need to know *which* state of
+;; which region carries the read-only intent.
 
 (reg-view ^{:doc "Form for adding a todo. Drives the form region (states 7 & 8)."}
           new-todo-form []

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -235,9 +235,9 @@
   ;; EP-0001: the route slice is durable routing runtime-db state.
   ;; `?page=` (1-indexed, durable on the route query) becomes the wire's
   ;; limit/offset window via `rh/paginate-path` (official RealWorld pagination).
-  ;; The active tag is now a `/tag/:tag` route PARAM (not `?tag=`).
-  ;; Read it off the route params + the page off the query. The WIRE stays
-  ;; `/articles?tag=…` — the frontend route shape changed, not the API.
+  ;; The active tag is a `/tag/:tag` route PARAM, read off the route params,
+  ;; with the page read off the query. The WIRE stays `/articles?tag=…` — the
+  ;; frontend route shape and the API query string are independent.
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [current   (get-in rt [:rf.runtime/routing :current])
           tag       (get-in current [:params :tag])

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -318,9 +318,9 @@
 
 ;; The `:tags/data` sub is defined in `realworld.tags`. The
 ;; popular-tags lifecycle is the :data-region machine variant of
-;; Pattern-RemoteData — the slice is gone, items are projected off
-;; the `:realworld/tags` machine's `:data`. The home view's sidebar
-;; below consumes `:tags/data` as before; only the source changed.
+;; Pattern-RemoteData — items are projected off the `:realworld/tags`
+;; machine's `:data`, with no separate app-db slice. The home view's
+;; sidebar below consumes `:tags/data`.
 
 ;; ---- render-priority + :articles.home/render selector ----
 ;;

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -130,12 +130,11 @@
 
 ;; `reg-machine` is the single registration home.
 ;; The auth machine carries a `:data-schema` (validating the snapshot's
-;; `:data` slot); registering it here (rather than the former hand-composed
-;; `reg-event` + `make-machine-handler`) stamps the `:rf/machine?` /
+;; `:data` slot); registering it here stamps the `:rf/machine?` /
 ;; `:rf/machine` metadata that makes the `:data-schema` LIVE (`(machine-meta
 ;; :auth/flow)` reads it, the `:where :machine-data` walker resolves it) AND
-;; bridges its redaction marks — both in one place. Under the old direct path
-;; the `:data-schema` was silently INERT (the exact bug). This
+;; bridges its redaction marks — both in one place. The metadata is what makes
+;; the `:data-schema` enforced rather than inert. This
 ;; machine validates only its `:data` (no outer event-vector `:schema`), so
 ;; the opts map carries just `:doc` + `:rf.http/decode-schemas`.
 (rf/reg-machine :auth/flow

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -240,8 +240,8 @@
           ;; A markdown body so the article-detail page exercises the
           ;; sanitized CommonMark renderer (realworld-shared.markdown/render —
           ;; render): headings, bold/italic, inline + fenced code, a safe
-          ;; link, lists, plus full-CommonMark shapes the old hand-rolled
-          ;; subset could not do (a table, a nested list). The renderer emits
+          ;; link, lists, plus full-CommonMark shapes a hand-rolled subset would
+          ;; miss (a table, a nested list). The renderer emits
           ;; hiccup (never raw HTML), so this is real markup while any injected
           ;; `<script>` / `javascript:` link in user content degrades to inert
           ;; escaped text.
@@ -413,8 +413,8 @@
                reply via `:dispatch-later` —
                observable in the tape, time-travel-safe, NOT raw
                `js/setTimeout`. The delay lets the `:loading` UI state be
-               observable; `:after-ms` collapses the former schedule-reply
-               → `:dispatch-later` → deliver-reply chain into one
+               observable; `:after-ms` expresses the schedule-reply
+               → `:dispatch-later` → deliver-reply chain as one
                parameter of the same canned effect."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
@@ -452,15 +452,14 @@
 ;; unauthenticated user has no token to send).
 ;;
 ;; SINGLE SOURCE OF TRUTH: this is the ONE place the Bearer
-;; header is written. `realworld.http/request` no longer reads the token —
-;; it just composes the request map. Centralising the read here keeps the
+;; header is written. `realworld.http/request` composes the request map and
+;; leaves the token to this interceptor. Centralising the read here keeps the
 ;; example carried-frame-correct: the interceptor reads from `(:frame ctx)`
 ;; (the frame the cascade actually runs under, EP-0002), so the
-;; header tracks a renamed / multi-frame mount rather than a hard-coded
-;; `:rf/default`. (An earlier revision wired the token in BOTH `rh/request`
-;; and here as a side-by-side teaching duality; the `rh/request`
-;; copy hard-coded `:rf/default` and bypassed the carried invariant, so it
-;; was dropped — one read site, the recommended production shape.)
+;; header tracks a non-default / multi-frame mount rather than a hard-coded
+;; `:rf/default`. One read site is the recommended production shape — wiring the
+;; token into `rh/request` as well would hard-code `:rf/default` and bypass the
+;; carried invariant.
 
 (defn- bearer-auth-interceptor [ctx]
   (let [token (some-> (rf/app-db-value (:frame ctx))

--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -197,8 +197,8 @@
 ;;
 ;; Tests, SSR hydration, and replay fixtures supply an exact `:rf/time-ms` via
 ;; the dispatch opts (`{:rf.cofx {:rf/time-ms 1781078400123}}`); live code lets
-;; the router stamp it. There is no app-side clock cofx — `inject-cofx` is
-;; removed (EP-0017); declared `:rf/time-ms` is the one home.
+;; the router stamp it. The app declares no clock cofx of its own — the
+;; framework-provided `:rf/time-ms` is the one home for wall-clock time (EP-0017).
 
 ;; ============================================================================
 ;; FAILURE PROJECTION

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -143,11 +143,11 @@
 ;;     `(second event)` is a URL string resolved to a route via
 ;;     `rf/match-url`.
 ;;
-;; An earlier sketch gated ONLY `:rf.route/navigate`, so the guard FAILED
-;; OPEN on the most common access path: a logged-out user who typed
-;; `/settings`, reloaded a protected page, or followed an anchor reached
-;; the route (and the on-match drain then fired a request the real
-;; Conduit backend would 401). Gating all three entry points closes that
+;; The guard MUST gate all three entry points, not just `:rf.route/navigate`:
+;; gating navigate alone would FAIL OPEN on the most common access path — a
+;; logged-out user who typed `/settings`, reloaded a protected page, or followed
+;; an anchor would reach the route (and the on-match drain would then fire a
+;; request the real Conduit backend would 401). Gating all three closes that
 ;; gap — `resolve-nav-target` normalises each event to an `{:id :params}`
 ;; target so ONE redirect path handles them all.
 ;;

--- a/examples/reagent/realworld/settings.cljs
+++ b/examples/reagent/realworld/settings.cljs
@@ -313,9 +313,9 @@
     (get-in snap [:data :submit-error])))
 
 (rf/reg-sub :settings/submitting?
-  {:doc "Tag-shaped read of the form's in-flight intent. Replaces the
-         slice-form `(= :submitting status)` comparison; views still
-         see a plain boolean."}
+  {:doc "Tag-shaped read of the form's in-flight intent — a tag query
+         standing in for a slice-form `(= :submitting status)` comparison;
+         views see a plain boolean."}
   :<- [:rf/machine-has-tag? :settings/form :settings/in-flight]
   (fn sub-settings-submitting? [in-flight? _]
     (boolean in-flight?)))

--- a/examples/reagent/realworld/ssr.cljc
+++ b/examples/reagent/realworld/ssr.cljc
@@ -74,7 +74,7 @@
    ;; EP-0002: the caller names the frame to hydrate explicitly —
    ;; no zero-arity `:rf/default` convenience. Under the carried invariant the
    ;; hydration target is a deliberate choice, not an inferred default; a
-   ;; renamed / multi-frame client must pass its own frame-id.
+   ;; non-default / multi-frame client must pass its own frame-id.
    (defn hydrate-client! [frame-id]
      (when-let [payload (read-server-payload)]
        (rf/dispatch-sync [:rf/hydrate payload] {:frame frame-id})

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -199,8 +199,8 @@
 ;; ============================================================================
 ;;
 ;; The view consumes the same names a slice-form reader would: `:tags/data`
-;; for the items, `:tags/error` for the error map. The `:loading?` /
-;; `:fetching?` booleans are gone — views ask the tag instead:
+;; for the items, `:tags/error` for the error map. There are no `:loading?` /
+;; `:fetching?` booleans — views ask the tag instead:
 ;;
 ;;     @(rf/machine-has-tag? :realworld/tags :tags/loading)     ;; truly empty + in-flight
 ;;     @(rf/machine-has-tag? :realworld/tags :tags/in-flight)   ;; any in-flight (loading OR fetching)

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -320,7 +320,7 @@
 
 (rf/reg-sub :home/selected-tag
   {:doc "The active tag, read from the `/tag/:tag` route's PATH params
-         (no longer a `?tag=` query)."}
+         (a route path param, not a `?tag=` query)."}
   :<- [:rf.route/params]
   (fn [params _] (:tag params)))
 

--- a/examples/reagent/realworld_resources/article_editor.cljs
+++ b/examples/reagent/realworld_resources/article_editor.cljs
@@ -2,9 +2,8 @@
   "Create / edit / delete an article — the RealWorld-on-resources editor.
 
    This is the form-heavy, flow-bearing page the focused `resources/` demo never
-   shows and the variant was previously missing: it is the resources-variant
-   port of the `:rf.http/managed` sibling's `realworld/article_editor.cljs`. It
-   exercises three things at once:
+   shows: the resources-variant counterpart of the `:rf.http/managed` sibling's
+   `realworld/article_editor.cljs`. It exercises three things at once:
 
    1. The WRITE is a MUTATION. `:realworld/save-article` POSTs `/articles`
       (create) or PUTs `/articles/:slug` (edit) and declares per-target scoped
@@ -449,10 +448,11 @@
   "The article-editor page. A Reagent Form-3 component: the inner render is the
    pure `editor-form-view`; the mount hook installs ONE off-render reaction that
    seeds the draft when an edit-mode article read settles with data. (The
-   save/delete SUCCESS continuation is no longer an off-render reaction — it is
-   the mutation's `:reply-to [:editor/replied]` target, EP-0016 D1. A reply-side
-   continuation only exists for the mutation write; the seed reaction watches a
-   RESOURCE read settle, which has no reply-to, so it stays a Form-3 reaction.)
+   save/delete SUCCESS continuation is the mutation's `:reply-to
+   [:editor/replied]` target, EP-0016 D1, not an off-render reaction. A
+   reply-side continuation only exists for the mutation write; the seed reaction
+   watches a RESOURCE read settle, which has no reply-to, so it stays a Form-3
+   reaction.)
    `rf/frame-handle` is captured here (during render, under the frame-provider),
    so the reaction's dispatch carries the frame; unmount disposes the reaction
    and releases the edit-mode article lease."

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -30,8 +30,7 @@
 
    For the `:rf.http/managed` counterpart (schema-driven decode, retry/abort,
    the classification order, optimistic rollback against managed HTTP), see the
-   sibling `examples/reagent/realworld/` — kept intact as the canonical Spec
-   014 demo."
+   sibling `examples/reagent/realworld/` — the canonical Spec 014 demo."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Managed HTTP — the single built-in resource/mutation transport.

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -1,7 +1,7 @@
 (ns realworld-resources.core
   "Entry point for the RealWorld-on-resources (Conduit) example — a sibling of
-   `examples/reagent/realworld/` that ports the read surface to EP-0003 (Spec
-   016) RESOURCES and the write surface to MUTATIONS, instead of hand-rolled
+   `examples/reagent/realworld/` that expresses the read surface as EP-0003 (Spec
+   016) RESOURCES and the write surface as MUTATIONS, rather than hand-rolled
    `:rf.http/managed` Pattern-RemoteData slices.
 
    Wires the app together:
@@ -24,9 +24,8 @@
      http.cljs       — the demo backend stub + failure projection
      views.cljs      — passive pages + the small UI event glue
 
-   STATUS. EP-0003 graduated accepted→final on 2026-06-11, so the
-   resources + mutations runtime is real and this example runs live. The
-   example tree is test-free; resource/mutation contract coverage
+   The resources + mutations runtime (EP-0003) backs this example, which runs
+   live. The example tree is test-free; resource/mutation contract coverage
    lives in `implementation/resources/test/` and the conformance fixtures.
 
    For the `:rf.http/managed` counterpart (schema-driven decode, retry/abort,
@@ -170,13 +169,13 @@
 ;;
 ;; CARRIED-FRAME-CORRECT (EP-0002): the token is read from
 ;; `(:frame ctx)` — the frame the cascade actually runs under — not a
-;; hard-coded `:rf/default`, so the header tracks a renamed / multi-frame
+;; hard-coded `:rf/default`, so the header tracks a non-default / multi-frame
 ;; mount. The interceptor returns ctx unchanged when no token is present, so
 ;; login / register / the public reads (logged-out) are unaffected.
 
 ;; Public (not `defn-`) so a headless fixture can wire it into a test frame
-;; and assert the decoration — the sibling's route guard takes the other route
-;; now: it is a `reg-interceptor` descriptor referenced BY ID
+;; and assert the decoration. The sibling's route guard takes the other route:
+;; it is a `reg-interceptor` descriptor referenced BY ID
 ;; (`:realworld-resources.routing/auth-guard`, EP-0022) rather than a var. The
 ;; example tree stays test-free; the visibility is the only concession.
 (defn bearer-auth-interceptor [ctx]

--- a/examples/reagent/realworld_resources/mutations.cljs
+++ b/examples/reagent/realworld_resources/mutations.cljs
@@ -1,8 +1,7 @@
 (ns realworld-resources.mutations
   "The MUTATION registry — every RealWorld write as a named, causal write to
    remote state that invalidates / patches / populates the cached resource
-   reads it affected (Spec 016 §Mutations, EP-0003 §Mutations — landed, first
-   public-beta gate).
+   reads it affected (Spec 016 §Mutations, EP-0003 §Mutations).
 
    This is the half the focused `examples/reagent/resources/` lifecycle demo
    does NOT show: the read→write→invalidate→refetch loop end-to-end in a full
@@ -26,7 +25,7 @@
    through the passive `[:rf.mutation/state {:instance …}]` sub
    (`{:pending? :success? :error? :settled? :result :error :optimistic?}`).
 
-   OPTIMISTIC ROLLBACK is LANDED (Spec 016 §Optimistic mutations, EP-0019). The
+   OPTIMISTIC ROLLBACK (Spec 016 §Optimistic mutations, EP-0019). The
    favorite / unfavorite writes below declare `:optimistic-tags` — the heart
    flips and the count moves on click, BEFORE the request is sent, across every
    cached read showing that article (the detail, every list, the session feed)

--- a/examples/reagent/realworld_resources/mutations.cljs
+++ b/examples/reagent/realworld_resources/mutations.cljs
@@ -13,7 +13,7 @@
      use (the runtime owns reply addressing — the app `:request` MUST NOT
      supply `:request-id` / `:on-success` / `:on-failure`);
    - declares `:invalidates` — the resource `:tags` the write makes stale on
-     success, fed straight into the landed `:rf.resource/invalidate-tags`
+     success, fed straight into `:rf.resource/invalidate-tags`
      (scoped, owner-aware: mounted-and-owned reads refetch, inactive ones go
      stale). The detail page and any list refetch with NO further wiring;
    - some also declare `:populates` — seeding the affected resource entry from

--- a/examples/reagent/realworld_resources/resources.cljs
+++ b/examples/reagent/realworld_resources/resources.cljs
@@ -3,9 +3,10 @@
    runtime-managed server-state read (Spec 016 §Public API / §Resource
    registration spec).
 
-   This is the half of the example that replaces the `:rf.http/managed`
-   sibling's hand-rolled Pattern-RemoteData slices (`{:status :data :error
-   :loaded-at :attempt}` per read). Here each read is `reg-resource`d once;
+   This is the half of the example that expresses as resources what the
+   `:rf.http/managed` sibling hand-rolls as Pattern-RemoteData slices
+   (`{:status :data :error :loaded-at :attempt}` per read). Here each read is
+   `reg-resource`d once;
    route entry / events CAUSE the fetch, and views read the runtime cache
    PASSIVELY through `[:rf.resource/*]` subs. No `:status` / `:loading?`
    app-db fields exist for these reads — the framework owns the lifecycle.

--- a/examples/reagent/realworld_resources/resources.cljs
+++ b/examples/reagent/realworld_resources/resources.cljs
@@ -23,9 +23,9 @@
    an inactive entry (no owner) is GC-eligible after its window. A fresh
    re-`ensure` is a cache-hit (no fetch, no dedupe) — `:rf.resource/cache-hit`.
 
-   STATUS. Resources is a POST-V1 optional artefact and the read-resource
-   runtime + mutations have LANDED (EP-0003, final on main 2026-06-11), so all
-   of this runs live. The example tree is test-free."
+   Resources is a POST-V1 optional artefact; the read-resource runtime +
+   mutations (EP-0003) back this example, so all of it runs live. The example
+   tree is test-free."
   (:require [clojure.string]
             [re-frame.core :as rf]
             ;; Managed HTTP ships in day8/re-frame2-http — the single built-in
@@ -255,9 +255,9 @@
 ;; the resource declares `:scope {:from-db :realworld/session}`: a derived-scope
 ;; REFERENCE the runtime resolves at every site against app-db.
 ;;
-;; This is the EP-0016 idiom that replaces the prior `:rf.scope/from-caller`
-;; hand-wiring (where the route ensured the feed from an event and every view
-;; threaded a `:session/scope` payload). Now:
+;; This is the EP-0016 idiom — naming the scope once, rather than `:rf.scope/
+;; from-caller` hand-wiring (a route ensuring the feed from an event and every
+;; view threading a `:session/scope` payload). The result:
 ;;   - a `[:rf.resource/state {:resource :realworld/feed :params {…}}]` sub
 ;;     resolves the scope ITSELF — no view passes a `:scope` payload — and
 ;;     re-keys reactively across login / logout (Spec 016 §A `{:from-db …}`

--- a/examples/reagent/realworld_resources/scope.cljs
+++ b/examples/reagent/realworld_resources/scope.cljs
@@ -20,17 +20,17 @@
 
    ## One named resolver, every site (the EP-0016 idiom)
 
-   Before EP-0016 this app hand-rolled the session/feed seam: the feed
-   resource declared `:rf.scope/from-caller`, the home route ensured it from an
-   event (a route `:scope` resolver couldn't see app-db), every view threaded a
-   `:session/scope` value onto its subscription payload, and a favourite toggle
-   needed an extra explicit session-scoped invalidation because a global-scope
-   mutation couldn't reach the session feed. Four hand-wired seams for one fact:
-   \"who is the current viewer?\"
+   The session/feed seam answers one fact — \"who is the current viewer?\" — and
+   a named resource-scope resolver states that fact ONCE rather than wiring it
+   by hand at every site. Hand-wiring would mean: the feed resource declaring
+   `:rf.scope/from-caller`, the home route ensuring it from an event (a route
+   `:scope` resolver can't see app-db), every view threading a `:session/scope`
+   value onto its subscription payload, and a favourite toggle needing an extra
+   explicit session-scoped invalidation because a global-scope mutation can't
+   reach the session feed — four hand-wired seams for one fact.
 
-   EP-0016 names that fact ONCE — `reg-resource-scope :realworld/session` with
-   declared db inputs — and every site references it as `{:from-db
-   :realworld/session}`:
+   `reg-resource-scope :realworld/session` with declared db inputs names that
+   fact once, and every site references it as `{:from-db :realworld/session}`:
 
    - the feed RESOURCE declares `:scope {:from-db :realworld/session}`
      (resources.cljs), so a subscription resolves the scope itself — no view

--- a/examples/reagent/realworld_resources/settings.cljs
+++ b/examples/reagent/realworld_resources/settings.cljs
@@ -25,14 +25,13 @@
    superseded reply never fires it (the mandatory stale-suppression boundary,
    inherited for free).
 
-   This is the idiom that replaced the variant's earlier off-render Form-3
-   `reagent.ratom/run!` settle reaction: before `:reply-to` existed, a mutation
-   had no reply-side hook and the only sanctioned way to react to settlement
-   was to mount a reaction watching `[:rf.mutation/state …]`. `:reply-to` is the
-   reply-side continuation the mutation surface was missing — a CAUSAL EVENT
+   `:reply-to` is the mutation's reply-side continuation — a CAUSAL EVENT
    TARGET (an ordinary event through the tape / interceptors / replay), not a
-   callback. The view is now a plain Form-1: a pure function of subs that never
-   dispatches out of band.
+   callback. It keeps the view a plain Form-1: a pure function of subs that
+   never dispatches out of band. The alternative — an off-render Form-3
+   `reagent.ratom/run!` reaction watching `[:rf.mutation/state …]` for
+   settlement — pulls a side-effecting reaction into the view; `:reply-to`
+   gives the same settle hook as a declarative, replayable event target.
 
    Compare the `:rf.http/managed` sibling (`examples/reagent/realworld/`): its
    settings submit gets the continuation via the request's `:on-success

--- a/examples/reagent/realworld_resources/views.cljs
+++ b/examples/reagent/realworld_resources/views.cljs
@@ -44,7 +44,7 @@
 ;; — it changes the URL and the declarative route plan does the rest. The
 ;; personalised feed is one of those route resources, scoped by the named
 ;; `{:from-db :realworld/session}` resolver (routing.cljs / resources.cljs) —
-;; so the home page no longer needs an `:on-match` event to ensure it by hand.
+;; so the home page needs no `:on-match` event to ensure it by hand.
 
 ;; ROUTE-SHAPE CONFORMANCE: the tag filter is the `/tag/:tag` PATH
 ;; route (`:realworld/home-tag`) — the active tag is a route PARAM, not a
@@ -127,9 +127,9 @@
 ;; The official Conduit article page carries contextual controls: a non-author
 ;; viewer follows/unfollows the AUTHOR; the author sees Edit (→ /editor/:slug)
 ;; and Delete. Logged-out viewers see neither. Both the follow continuation and
-;; the delete continuation are now call-site `:reply-to` targets (EP-0016 D1) —
-;; the mutation reply-side seam the variant previously had to emulate with
-;; Form-3 settle reactions on the article page.
+;; the delete continuation are call-site `:reply-to` targets (EP-0016 D1) —
+;; the mutation reply-side seam, declared at the call site rather than emulated
+;; with Form-3 settle reactions on the article page.
 
 (rf/reg-event :ui/follow-author
   {:doc "Follow / unfollow the article author from the detail page. Fires the
@@ -466,7 +466,7 @@
 
 (reg-view ^{:doc "The article-detail page — a pure function of subs that never
                   dispatches out of band. The two settle continuations the page
-                  needs are now the mutations' own `:reply-to` targets (EP-0016
+                  needs are the mutations' own `:reply-to` targets (EP-0016
                   D1): deleting fires `:ui/delete-article` → `:reply-to
                   [:ui/article-deleted]` (navigate home), and following the
                   author fires `:ui/follow-author` → `:reply-to

--- a/examples/reagent/realworld_shared/markdown.cljs
+++ b/examples/reagent/realworld_shared/markdown.cljs
@@ -3,14 +3,13 @@
    both realworld example apps (`realworld.*` and `realworld-resources.*`).
 
    The official RealWorld (Conduit) spec renders the article body as
-   CommonMark. This replaces the earlier hand-rolled markdown subset
-   with a real CommonMark library so the clone is faithful:
+   CommonMark. This uses a real CommonMark library so the clone is faithful:
    tables, nested lists, images, footnotes — the shapes a hand-rolled
-   subset could not cover — render correctly, and the parser is no longer
-   our maintenance/bug surface.
+   subset could not cover — render correctly, and the parser is not a
+   maintenance/bug surface of our own.
 
-   Library choice (Mike ruled 2026-06-11)
-   ---------------------------------------
+   Library choice
+   --------------
    `io.github.nextjournal/markdown`, used in HICCUP-EMITTING mode
    (`md/->hiccup`). In ClojureScript it tokenizes with `markdown-it` (a
    pure-JS CommonMark tokenizer — no DOM, runs in the browser AND in the

--- a/examples/reagent/resources/core.cljs
+++ b/examples/reagent/resources/core.cljs
@@ -1,7 +1,7 @@
 (ns resources.core
   "Worked example for [Spec 016 Resources](../../../spec/016-Resources.md)
    (the EP-0003 read-resource MVP). A small server-state app — an articles
-   list and an article detail — demonstrating the LANDED resource surface
+   list and an article detail — demonstrating the resource surface
    composed as proper re-frame2: app-db + events + subs, views passive,
    fetches caused.
 

--- a/examples/reagent/resources/core.cljs
+++ b/examples/reagent/resources/core.cljs
@@ -36,16 +36,15 @@
    (no refetch — `:rf.resource/cache-hit`); the manual Refresh forces a
    refetch regardless.
 
-   STATUS. Resources is a POST-V1 optional artefact and the read-resource
-   runtime has LANDED (EP-0003): `reg-resource`, the `:rf.resource/*` passive
+   Resources is a POST-V1 optional artefact. The read-resource runtime
+   (EP-0003) provides `reg-resource`, the `:rf.resource/*` passive
    subs, route `:resources` metadata, and the causal `:rf.resource/ensure` /
    `:rf.resource/refetch` / `:rf.resource/invalidate-tags` /
-   `:rf.resource/release-owner` event bodies are all real and operational.
-   This example covers the READ side only; mutations (`reg-mutation` /
-   `:rf.mutation/execute`) have also landed but live in the guide
-   (docs/guide/concepts/server-state.md §Writes invalidate by tag) and the migration walkthrough.
-   GraphQL is a deferred later phase. The example tree is test-free;
-   resource-contract coverage lives in
+   `:rf.resource/release-owner` event bodies. This example covers the READ
+   side only; mutations (`reg-mutation` / `:rf.mutation/execute`) are covered
+   in the guide (docs/guide/concepts/server-state.md §Writes invalidate by
+   tag) and the migration walkthrough. GraphQL is a deferred later phase. The
+   example tree is test-free; resource-contract coverage lives in
    `implementation/resources/test/` and the conformance fixtures."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
@@ -315,7 +314,7 @@
 ;; subs LAYERED over the passive `[:rf.resource/data …]` sub (Spec 016 §No
 ;; :select key), NOT a resource-local hook. The EP-0004 input-fn is a pure
 ;; `(fn [query-v])` returning a VECTOR OF QUERY VECTORS — never a deref'd
-;; subscribe (the v1 signal-fn idiom, which raises
+;; subscribe (a deref'd-subscribe input-fn raises
 ;; :rf.error/sub-input-fn-bad-return). The compute fn then receives the
 ;; resolved input values positionally: `[[articles] _]`.
 (rf/reg-sub :resources.app/first-slug

--- a/examples/reagent/resources_ssr/core.cljc
+++ b/examples/reagent/resources_ssr/core.cljc
@@ -24,10 +24,9 @@
      hydrated entry renders immediately and does NOT immediately re-fetch
      (stale / redacted / omitted entries refetch by the hydration plan).
 
-   LANDED BEHAVIOUR (EP-0003). The SSR blocking-drain, the
-   per-entry projection with redaction / omission / scoped-key privacy /
-   index omission, and the client hydration
-   reconcile + refetch plan are all RUNTIME-real. So this
+   The SSR blocking-drain, the per-entry projection with redaction /
+   omission / scoped-key privacy / index omission, and the client hydration
+   reconcile + refetch plan are all runtime behaviour (EP-0003). This
    example drives the actual server path: it DRAINS the blocking page
    resource before render (`ssr/drain-blocking-resources!`) and serializes
    only the ALLOWED runtime-db projection (`payload-policy/project-runtime-db`)
@@ -157,7 +156,7 @@
 ;; projection in `:rf/runtime-db`. The per-request frame is torn down in a
 ;; `finally` on every exit path (memory hygiene).
 ;;
-;; Two landed steps make this the canonical server path (EP-0003):
+;; Two steps make this the canonical server path (EP-0003):
 ;;
 ;;   1. `ssr/drain-blocking-resources!` settles the `[:ssr …]`-owned blocking
 ;;      ensure (or times it out into a structured first-load failure) BEFORE

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -32,8 +32,7 @@
 
 (def tick-ms
   "Wall-clock delay between successive timer ticks. Kebab-case per the
-   sibling `examples/reagent/long_running_work` convention; the
-   SCREAMING-CASE here was a v1 holdover."
+   sibling `examples/reagent/long_running_work` convention."
   100)
 
 ;; ============================================================================

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -138,11 +138,10 @@
     ;; than from a positional event arg.
     ;;
     ;; EP-0001: the framework route slice lives in the
-    ;; runtime-db partition at `[:rf.runtime/routing :current]`, NOT under a
-    ;; legacy app-db `:rf/runtime` root (which is now a hard error). This
-    ;; example's render never reads the route slice, so the vestigial
-    ;; pre-EP `:db` write is simply dropped — the server flow only needs to
-    ;; kick off the managed-HTTP article fetch.
+    ;; runtime-db partition at `[:rf.runtime/routing :current]`. This
+    ;; example's render never reads the route slice, so the `:db` write is
+    ;; simply dropped — the server flow only needs to kick off the
+    ;; managed-HTTP article fetch.
     {:db db
      :fx [[:rf.http/managed
            {:request    {:method :get :url "/api/articles"}

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -207,7 +207,7 @@
 ;; point onto that path (see re-frame.machines §framework-shipped subs);
 ;; the named subs below chain off it to project out the convenient
 ;; pieces. The "in :submitting?" / "in :authed?" / "in :locked-out?"
-;; predicates moved to the `rf/machine-has-tag?` queries in views.cljs
+;; predicates live as the `rf/machine-has-tag?` queries in views.cljs
 ;; (ch.12 §State tags) — discriminating on the machine's runtime-projected
 ;; `:tags` set decouples view code from individual state-keyword identity.
 

--- a/examples/reagent/todomvc/db.cljs
+++ b/examples/reagent/todomvc/db.cljs
@@ -1,8 +1,8 @@
 (ns todomvc.db
   (:require [re-frame.core :as rf]))
 
-;; The :showing slot is no longer in the default db — Spec 012's :route slice
-;; owns it now. The :showing sub (in subs.cljs) derives :all/:active/:completed
+;; The default db carries no `:showing` slot — Spec 012's :route slice owns
+;; that fact. The :showing sub (in subs.cljs) derives :all/:active/:completed
 ;; from :rf.route/id.
 (def default-db
   {:todos (sorted-map)})

--- a/examples/reagent/todomvc/views.cljs
+++ b/examples/reagent/todomvc/views.cljs
@@ -45,7 +45,7 @@
               (save)))})])))
 
 (defn todo-item [dispatch]
-  ;; editing? is local component state by design — matches v1 TodoMVC; not in app-db so it isn't persisted/inspected (TodoMVC tradeoff).
+  ;; editing? is local component state by design — matches the canonical TodoMVC; not in app-db so it isn't persisted/inspected (TodoMVC tradeoff).
   (let [editing? (reagent/atom false)]
     (fn [_dispatch {:keys [id title completed]}]
       [:li {:class (str/join " " (cond-> []

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -323,7 +323,7 @@
                  ;; :authenticating under :active — a bare keyword would
                  ;; resolve to [:active :failed] (which does not exist), so
                  ;; the absolute vector target [:failed] is required
-                 ;; (transition-target validation now rejects the bare keyword).
+                 ;; (transition-target validation rejects the bare keyword).
                  :ws/auth-failed {:target [:failed]
                                   :action :record-error}}}
 

--- a/examples/reagent/websocket/schema.cljs
+++ b/examples/reagent/websocket/schema.cljs
@@ -100,8 +100,8 @@
 ;; EP-0001: machine snapshots are runtime-db state, not app-db —
 ;; an `reg-app-schema` on a machine-snapshot path validates nothing (app
 ;; schemas validate the app-db partition only, Mike ruling #11). The
-;; machine's own `:data-schema` is the snapshot-validation surface, so the
-;; vestigial app-schema reg is removed.
+;; machine's own `:data-schema` is the snapshot-validation surface; no
+;; app-schema reg is wired on the snapshot path.
 ;;
 ;; EP-0002: reg-app-schema is context-required frame-local; a
 ;; bare ns-load call raises :rf.error/no-frame-context. This example runs in

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -32,15 +32,13 @@
 ;; SCHEMAS
 ;; ============================================================================
 
-;; EP-0025 (rf2-398kql): schema-attached `:sensitive?` / `:large?` field
-;; classification is REMOVED — frame-declared `:sensitive` / `:large {:app-db …}`
-;; paths (`reg-frame`, EP-0015) are the SOLE app-db classification mechanism.
-;; The password never lands in app-db (it rides the machine EVENT-arg schema and
-;; the HTTP body), so there is no app-db path to frame-declare; the prior
-;; `{:sensitive? true}` slot prop was a documentary no-op and is dropped. The
-;; managed-HTTP request below still carries `:sensitive? true` to scrub the
-;; password off the wire — a DIFFERENT axis (Spec 014 §Privacy, KEPT) and the
-;; working, observable redaction. Parity across reagent/login + helix.
+;; Frame-declared `:sensitive` / `:large {:app-db …}` paths (`reg-frame`)
+;; are the sole app-db classification mechanism. The password never lands
+;; in app-db (it rides the machine EVENT-arg schema and the HTTP body), so
+;; there is no app-db path to frame-declare. The managed-HTTP request below
+;; carries `:sensitive? true` to scrub the password off the wire — a
+;; different axis (Spec 014 §Privacy) and the working, observable
+;; redaction. Parity across reagent/login + helix.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -281,7 +281,7 @@
 ;;
 ;; The machine snapshot lives at [:rf.runtime/machines :snapshots :auth.login/flow] (per
 ;; Spec 005). These named subs project out the convenient pieces. The
-;; "in :submitting?" / "in :authed?" predicates moved to the
+;; "in :submitting?" / "in :authed?" predicates live as the
 ;; `:rf/machine-has-tag?` framework sub in views below (per Spec 005
 ;; §State tags).
 


### PR DESCRIPTION
Applies the de-historicization LENS (parent rf2-2db7z1) to the `examples/` surface: comments and docstrings now describe the CURRENT contract as-if-always, generously, instead of narrating the code's own change-history. Behaviour-neutral — comments/docstrings only.

## What changed

Across 32 of the 78 `examples/` clj* files, stripped history-narration while keeping (and where helpful, sharpening) the teaching:

- **Evolution framing about the code itself** — "ported to / replaces the earlier / moved to / is now / no longer / is gone / was a v1 holdover / former / kept intact". Rewritten to state the current shape positively (e.g. "expresses the read surface as resources" not "ports the read surface to"; "predicates live as the `machine-has-tag?` sub" not "predicates moved to").
- **Status/landing provenance** — "LANDED / has landed / graduated accepted→final on 2026-06-11 / first public-beta gate / real and operational". Replaced with plain statements of the runtime contract (e.g. "the resources + mutations runtime (EP-0003) backs this example").
- **Negative definitions of deleted concepts** — "the vestigial app-schema reg is removed / `inject-cofx` is removed / the slice is gone / the `:loading?` booleans are gone". Rewritten as positive statements of what IS (e.g. "views ask the tag rather than reading `:loading?` booleans").
- **Migration/foil narration** — "before EP-0016 this app hand-rolled… / the variant previously had to emulate… / an earlier sketch gated only navigate". Reframed as design rationale for the current shape (the alternative idiom and why this is better), not as this code's past.
- **Dated provenance** — dropped "(Mike ruled 2026-06-11)" and "rf2-xxxxx" tags where they justified the current shape.

Preserved the narrow exceptions per the LENS: EP-/Spec-section anchors that name the CURRENT contract (kept), the scar-comment rationale on the routing auth-guard (kept the WHY — failing open on the common access path — dropped the "earlier sketch" framing), and non-meta uses of "previous/no-longer/retired" that describe RUNTIME behaviour (a retired tick generation, a previously-loaded pagination page, a deleted article entry, a stale error value) — left untouched. Structure unchanged; testbeds stay idiomatic; no `*.spec.cjs` added.

## Quality gates

- `clj-kondo --lint` on all 32 changed files: **0 errors**, 5 warnings — all pre-existing style warnings (unused bindings/namespaces) confirmed present on origin/main, none introduced here.
- Verified every changed line lives inside a comment or docstring (diff scan) — fully behaviour-neutral.
- Adapter smokes (`npm run test:adapter-smokes`) **skipped locally** — fresh worktree has no `implementation/node_modules`; relying on CI as the merge gate.