### PR TITLE
fix(core): preserve flow elision marks on post-commit rollback (rf2-qzs1y9)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1280,10 +1280,35 @@
             ;; cascade too. Then emit the rollback change traces so subs /
             ;; listeners see the restored state. The schema-failure error
             ;; trace already fired between the forward and rollback commits.
-            (let [rb-changed (frame/replace-frame-state!
+            ;;
+            ;; Privacy fail-safe (forward/rollback symmetry, rf2-qzs1y9): the
+            ;; forward commit above reconciles the runtime-db effect against the
+            ;; LIVE runtime-db so flow-written elision marks ([:rf.runtime/elision])
+            ;; propagated during the `:after` drain SURVIVE the commit. The
+            ;; rollback target `runtime-before` is the chain-start snapshot
+            ;; captured by reference BEFORE the drain ran, so it predates those
+            ;; marks. Restoring it verbatim would silently DISCARD the
+            ;; flow-written elision declarations — the very marks the forward
+            ;; path takes care to preserve — and a flow-derived sensitive path
+            ;; would egress RAW until the next successful drain re-propagated.
+            ;; The elision registry is CROSS-CUTTING durable subsystem state
+            ;; written OUT-OF-BAND (`reg-flow` / `add-marks` / frame-
+            ;; classification), NOT part of the transactional handler effect the
+            ;; schema rejected — so it must NOT be unwound with the rejected db.
+            ;; Carry the LIVE registry (the freshest flow-propagated marks, as
+            ;; preserved by the forward reconcile and still resident on the
+            ;; container) forward onto the restored `runtime-before`, mirroring
+            ;; the forward path. A stale declaration for a path the rolled-back
+            ;; db no longer contains is harmless (it redacts nothing); dropping a
+            ;; live one risks raw egress — fail safe toward redaction.
+            (let [live-elision (get (frame/frame-runtime-db-value frame)
+                                    :rf.runtime/elision)
+                  runtime-restore (elision/write-elision-slot runtime-before
+                                                              live-elision)
+                  rb-changed (frame/replace-frame-state!
                                frame
                                {frame/app-partition-key     db-before
-                                frame/runtime-partition-key runtime-before})]
+                                frame/runtime-partition-key runtime-restore})]
               ;; Roll back the flow dirty-check
               ;; (`last-inputs`) bookkeeping in lock-step with the app-db
               ;; (frame-scoped). No-op when no flow ran or the

--- a/implementation/core/test/re_frame/partitioned_commit_test.clj
+++ b/implementation/core/test/re_frame/partitioned_commit_test.clj
@@ -28,9 +28,16 @@
        post-commit-best-effort fx asymmetry (Mike-ruled, unchanged)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.elision :as elision]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
+            [re-frame.marks :as marks]
             [re-frame.registrar :as registrar]
+            ;; Load the schemas artefact so the
+            ;; `:schemas/validate-app-schema!` late-bind hook is published —
+            ;; the post-commit schema-rollback tests below guard on it and are
+            ;; otherwise skipped when this ns runs in isolation (`-n`).
+            [re-frame.schemas]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]
@@ -377,3 +384,56 @@
           "app-db rolled back to the pre-handler value")
       (is (= {:rf.runtime/machines {:m :pre}} (rf/runtime-db-value :pc/rb))
           "runtime-db ALSO rolled back — the whole transition unwinds coherently"))))
+
+;; rf2-qzs1y9 — forward/rollback symmetry for flow-written elision marks.
+;;
+;; The forward commit reconciles the runtime-db effect against the LIVE
+;; runtime-db so an elision mark a flow's `:after`-chain drain wrote into
+;; `[:rf.runtime/elision]` (AFTER the chain-start `runtime-before` snapshot was
+;; captured by reference) SURVIVES the commit. The post-commit schema-validation
+;; ROLLBACK must mirror that care: it restores the pre-handler `runtime-before`,
+;; which predates the in-drain mark — restoring it verbatim would silently
+;; DISCARD the flow-written elision declaration, and a flow-derived sensitive
+;; path would egress RAW until the next successful drain re-propagated. We model
+;; the flow's in-drain `refresh-flow-output-declarations!` write with `add-marks`
+;; from an `:after` interceptor — both reach the SAME `[:rf.runtime/elision]`
+;; slot via `elision/swap-elision-slot!`, the exact out-of-band write the
+;; forward-path comment names, running in-chain after `runtime-before` is fixed.
+(deftest schema-rollback-preserves-flow-written-elision-marks
+  (testing "a post-commit schema rollback PRESERVES an elision mark written
+            out-of-band during the :after chain (the mark the forward path
+            preserves) — forward/rollback symmetry (rf2-qzs1y9)"
+    (when (late-bind/get-fn :schemas/validate-app-schema!)
+      (rf/reg-frame :pc/rb-elision {:doc "rb-elision"})
+      ;; seed a coherent pre-handler frame-state with NO elision registry — the
+      ;; mark must be born DURING the chain, so it is absent from `runtime-before`.
+      (rf/replace-frame-state! :pc/rb-elision {:rf.db/app {:n 0}
+                                               :rf.db/runtime {}})
+      (is (= {} (elision/sensitive-declarations :pc/rb-elision))
+          "precondition: no flow-written sensitive declaration before dispatch")
+      ;; app schema demanding :n stay a non-negative int — the bad handler
+      ;; violates it, forcing the post-commit rollback.
+      (rf/with-frame :pc/rb-elision
+        (rf/reg-app-schema [] {:schema [:map [:n [:int {:min 0}]]]}))
+      ;; An :after interceptor that writes a sensitive elision mark into the LIVE
+      ;; runtime-db — the stand-in for a flow drain propagating an output-
+      ;; sensitivity mark mid-chain. It runs after `runtime-before` was captured,
+      ;; so the mark exists ONLY in the live runtime-db, never in the snapshot.
+      (rf/reg-interceptor* :pc/flow-mark-writer
+        {:after (fn [ctx]
+                  (marks/add-marks :pc/rb-elision {[:secret] :sensitive})
+                  ctx)})
+      (rf/reg-event :pc/bad-elision
+        {:doc "schema-violating handler that triggers the rollback"
+         :interceptors [:pc/flow-mark-writer]}
+        (fn [_ _]
+          {:db {:n -5}}))                                ;; violates the schema → rollback
+      (rf/dispatch-sync [:pc/bad-elision] {:frame :pc/rb-elision})
+      (is (= {:n 0} (rf/app-db-value :pc/rb-elision))
+          "app-db rolled back to the pre-handler value (the schema rejection held)")
+      ;; THE REGRESSION: before the fix the rollback restored `runtime-before`
+      ;; verbatim and this mark was gone, so `[:secret]` would egress RAW.
+      (is (= {[:secret] {:source :marks}}
+             (elision/sensitive-declarations :pc/rb-elision))
+          "the flow-written elision mark SURVIVES the rollback — the rollback
+           mirrors the forward path's privacy fail-safe (rf2-qzs1y9)"))))


### PR DESCRIPTION
## What

Closes the forward/rollback asymmetry for flow-written elision marks in `commit-frame-effects!` (`implementation/core/src/re_frame/router.cljc`).

The **forward** commit deliberately reconciles a `:rf.db/runtime` effect against the **LIVE** runtime-db so an elision mark a flow's `:after`-chain drain wrote into `[:rf.runtime/elision]` survives the commit (a long comment explains exactly this — the mark is written *after* the chain-start `runtime-before` snapshot is captured by reference).

The post-commit schema-validation **rollback** restored `runtime-before` **verbatim** — the chain-start snapshot, which predates the in-drain mark. So an elision declaration a flow wrote during the `:after` chain was silently discarded on rollback: the very mark the forward path takes care to preserve. After such a rollback a flow-derived sensitive path could egress **RAW** until the next successful drain re-propagated the mark.

## Fix

The elision registry is **cross-cutting durable subsystem state** written out-of-band (`reg-flow` / `add-marks` / frame-classification), **not** part of the transactional handler effect the schema rejected — so it must not be unwound with the rejected db. The rollback now carries the freshest **live** `[:rf.runtime/elision]` registry forward onto the restored `runtime-before` via `elision/write-elision-slot`, mirroring the forward reconcile. Privacy fail-safe toward redaction: a stale declaration for a path the rolled-back db no longer contains is harmless (it redacts nothing); dropping a live one risks raw egress.

Single rollback site; `run-post-commit-validation!` funnels both app-db-schema and machine-data validation failures through it, so both cases are covered.

## Regression test

`schema-rollback-preserves-flow-written-elision-marks` in `partitioned_commit_test.clj` writes a sensitive elision mark out-of-band from an `:after` interceptor (same `[:rf.runtime/elision]` slot via `elision/swap-elision-slot!` that a flow drain uses), forces a post-commit schema rollback, and asserts the mark **survives**.

- **Before fix:** FAILS — post-rollback `sensitive-declarations` = `{}` (mark discarded), confirmed via diagnostics.
- **After fix:** PASSES.

Also adds `[re-frame.schemas]` to the test ns require so the `:schemas/validate-app-schema!` late-bind hook is published when the namespace runs in isolation (`-n`) — without it the existing `schema-rollback-unwinds-both-partitions` test was silently skipped too.

## Quality gates

- `clojure -M:test -n re-frame.partitioned-commit-test` (JVM): **18 tests / 53 assertions, 0 failures, 0 errors** (was 1 failure with the fix reverted — proving the regression test hits the real path).
- `npm run test:cljs` (compile + node-runtime suite): **7905 tests / 36422 assertions, 0 failures, 0 errors**.
- Touched only `router.cljc` + `partitioned_commit_test.clj`.

CI is the merge gate.