### PR TITLE
fix(core): spine flush!-after-dispose + cross-adapter view-warn parity (rf2-jgzica, rf2-9ex1i9)

### DIFF
--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -393,11 +393,30 @@
                                (vreset! prev-state v))
                              v))
           flush!         (fn flush! []
+                           ;; Disposed-tombstone guard (rf2-jgzica). A
+                           ;; derived value's `mark-dirty!` enqueues this
+                           ;; thunk on the SHARED epoch scheduler; the drain
+                           ;; runs at epoch close. If the reaction is disposed
+                           ;; BETWEEN mark-dirty and the drain (a cascade where
+                           ;; a downstream unsubscribe drives a sibling
+                           ;; ref-count to 0 and disposes a reaction whose
+                           ;; flush is already queued), the queued thunk still
+                           ;; fires. `-dispose` clears `watchers`, so the
+                           ;; `notify` fan-out is already a no-op — but
+                           ;; `recompute` is the memo wrapper, so without this
+                           ;; guard it re-runs the user sub body and (in dev)
+                           ;; emits a spurious `:rf.sub/run`: the exact
+                           ;; redundant-recompute the epoch scheduler exists to
+                           ;; prevent (rf2-i21f5). The scheduler cannot dequeue
+                           ;; a single thunk, so the disposed reaction skips it
+                           ;; here instead. Also reset `dirty?` so a re-marked-
+                           ;; then-disposed entry leaves a clean guard.
                            (vreset! dirty? false)
-                           (let [new-derived  (recompute)
-                                 prev-derived @prev-state]
-                             (vreset! prev-state new-derived)
-                             (notify prev-derived new-derived)))
+                           (when-not @disposed?
+                             (let [new-derived  (recompute)
+                                   prev-derived @prev-state]
+                               (vreset! prev-state new-derived)
+                               (notify prev-derived new-derived))))
           mark-dirty!    (fn mark-dirty! []
                            (when-not @dirty?
                              (vreset! dirty? true)

--- a/implementation/core/src/re_frame/views/source_coord_annotation.cljs
+++ b/implementation/core/src/re_frame/views/source_coord_annotation.cljs
@@ -14,7 +14,9 @@
   site.
 
   Per Spec 006 §View tagging contract (rf2-01il5) the same wrapper also
-  stamps `data-rf-view=\"<ns>/<sym>\"` on the same root element — the
+  stamps `data-rf-view=\":rf.foo/bar\"` on the same root element — the
+  value is `(str id)` (a printed keyword, leading colon included; see the
+  shared `format-view-id`), NOT the colon-less `<ns>/<sym>` form. The
   fallback for the runtime view-hierarchy walker when the Fiber-reading
   primary path (Spec View-Hierarchy-Capture, rf2-mxkq7) is unavailable.
   Both attributes ride the same wrapper, the same hiccup walk, and the
@@ -148,11 +150,26 @@
                      :data-rf-view          view-attr}]
           (into [head attrs] (rest out)))))
 
-    ;; Non-DOM root (fn-component head, fragment, lazy-seq, nil). Skip
-    ;; with a one-shot warning. Pair tools fall back to :rf/id;
+    ;; Non-DOM root (fn-component head, fragment, lazy-seq, string, number,
+    ;; nil). Skip with a one-shot warning. Pair tools fall back to :rf/id;
     ;; view-walker falls back to the Fiber-walker primary path.
+    ;;
+    ;; Warn on ANY non-nil un-annotatable root (rf2-9ex1i9), not just
+    ;; vectors. A reg-view'd component returning a STRING (or number) is
+    ;; equally un-annotatable as a fn-headed vector — there is no root DOM
+    ;; element to stamp `data-rf2-source-coord` / `data-rf-view` onto. The
+    ;; React-hook walk (`re-frame.substrate.spine/inject-source-coord-attr`)
+    ;; already warns on any non-nil non-element output; this side formerly
+    ;; warned only on vectors, so a string-returning view was SILENT under
+    ;; Reagent but WARNED under UIx/Helix — an observable cross-adapter
+    ;; divergence on a pair-tool warning surface. Both walks now share the
+    ;; warn-on-any-non-nil-non-element predicate (the message TEXT was
+    ;; already shared via adapter/context to prevent drift; the TRIGGER
+    ;; condition is unified here). nil stays silent on both sides (a view
+    ;; legitimately renders nothing). The diagnostic head is the hiccup head
+    ;; for a vector, else the value itself.
     :else
     (do
-      (when (vector? out)
-        (warn-once/warn-non-dom-root! id (first out)))
+      (when (some? out)
+        (warn-once/warn-non-dom-root! id (if (vector? out) (first out) out)))
       out)))

--- a/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
@@ -30,6 +30,7 @@
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.disposable :as rf-disposable]
             [re-frame.substrate.spine :as spine]))
 
 ;; ---- harness --------------------------------------------------------------
@@ -192,6 +193,71 @@
           "layer-3 notified once with the value computed against the
            settled layer-2 — no spurious extra notification cascaded down")
       (is (= 2200 @l3)))))
+
+;; ---- dispose mid-cascade does NOT recompute the disposed reaction ---------
+;; (rf2-jgzica)
+
+(deftest disposed-layer-2-flush-mid-cascade-does-not-recompute
+  (testing "a layer-2 derived value disposed AFTER it is marked dirty but
+            BEFORE the scheduler drains its queued flush must NOT re-run its
+            compute-fn (the user sub body) — the queued thunk is already on
+            the shared epoch scheduler and cannot be dequeued, so flush!
+            itself must short-circuit on the disposed guard. Without the
+            guard the memo wrapper recomputes and (in dev) emits a spurious
+            :rf.sub/run for a reaction whose watchers are already cleared —
+            the redundant-recompute class the epoch scheduler exists to
+            prevent (rf2-i21f5). (rf2-jgzica)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1a    (make-derived [root] (fn [db] (:a db)))
+          l1b    (make-derived [root] (fn [db] (:b db)))
+          ;; Layer-2 over BOTH layer-1 inputs. Its compute-fn stands in for
+          ;; the user sub body; every invocation increments the counter just
+          ;; as a real body would emit :rf.sub/run.
+          body-runs (atom 0)
+          l2     (make-derived [l1a l1b]
+                   (fn [a b] (swap! body-runs inc) (+ a b)))]
+      ;; Establish the lazy baseline (the sub-cache reads on subscribe), then
+      ;; zero the counter so we only measure cascade-time body runs.
+      (is (= 11 @l2) "baseline: 1 + 10")
+      (reset! body-runs 0)
+      ;; Arm the mid-cascade dispose. During the epoch drain l1a's flush
+      ;; notifies first → l2 marks dirty and ENQUEUES its flush. l1b's flush
+      ;; runs next; this extra watcher on l1b fires during that notify —
+      ;; AFTER l2 is already queued but BEFORE l2's own flush drains — and
+      ;; disposes l2. The queued l2 flush then runs against a disposed
+      ;; reaction.
+      (add-watch l1b :dispose-l2 (fn [_ _ _ _] (rf-disposable/-dispose l2)))
+      ;; ONE app-db write changes BOTH inputs, so both l1a and l1b flush and
+      ;; the dispose lands between l2's mark-dirty and its queued flush.
+      (replace! root {:a 2 :b 20})
+      (is (= 0 @body-runs)
+          "the disposed layer-2 reaction's body did NOT re-run during the
+           drain — flush! short-circuited on @disposed? (no spurious
+           recompute / :rf.sub/run)"))))
+
+(deftest direct-dispose-then-flush-does-not-recompute
+  (testing "a focused variant with no cascade: a derived value is marked
+            dirty (its source changes inside an epoch), disposed while the
+            epoch is still open, and the queued flush must not recompute it.
+            Drives the dispose deterministically by nesting it inside the
+            same open epoch via a re-entrant replace! on an unrelated source
+            watch — keeping the queued l1 flush pending until the outer epoch
+            closes. (rf2-jgzica)"
+    (let [{:keys [make-derived replace! root scheduler]} (build-graph)
+          body-runs (atom 0)
+          l1     (make-derived [root]
+                   (fn [db] (swap! body-runs inc) (:a db)))]
+      (is (= 1 @l1) "baseline deref establishes prev-state")
+      (reset! body-runs 0)
+      ;; Open an epoch, mark l1 dirty (enqueues its flush), dispose l1 while
+      ;; the epoch is still open (queue not yet drained), then let the epoch
+      ;; close and drain. The queued l1 flush must skip the recompute.
+      (#'spine/with-epoch scheduler
+        (fn []
+          (reset! root {:a 99 :b 10})   ;; marks l1 dirty, enqueues flush
+          (rf-disposable/-dispose l1))) ;; dispose before the drain
+      (is (= 0 @body-runs)
+          "the disposed reaction's flush did not recompute on drain"))))
 
 ;; ---- direct source mutation outside an epoch ------------------------------
 

--- a/implementation/core/test/re_frame/views/source_coord_warn_parity_cljs_test.cljs
+++ b/implementation/core/test/re_frame/views/source_coord_warn_parity_cljs_test.cljs
@@ -1,0 +1,112 @@
+(ns re-frame.views.source-coord-warn-parity-cljs-test
+  "Cross-adapter parity for the non-DOM-root warning emitted by the two
+  source-coord annotation walks (rf2-9ex1i9):
+
+    * Reagent hiccup walk:
+      `re-frame.views.source-coord-annotation/inject-source-coord-attr`
+    * React-hook walk (UIx / Helix):
+      `re-frame.substrate.spine/inject-source-coord-attr`
+
+  THE BUG: the React-hook walk warned whenever its output was non-element
+  AND non-nil (so a registered view returning a STRING or NUMBER warned);
+  the Reagent hiccup walk warned ONLY when the output was a vector. A
+  string-returning view therefore emitted a one-shot non-DOM-root console
+  warning under UIx/Helix but was SILENT under Reagent — an observable
+  cross-adapter inconsistency on a pair-tool warning surface. The message
+  TEXT was already shared (adapter/context) so it could not drift; the
+  TRIGGER condition had drifted. The fix unifies both walks on the honest
+  warn-on-ANY-non-nil-non-element predicate (a string root is equally
+  un-annotatable on both substrates), and `nil` stays silent on both (a
+  view legitimately renders nothing).
+
+  These tests drive BOTH walks directly (no JSDOM, no adapter install) and
+  assert their warn behaviour is IDENTICAL for a matrix of un-annotatable
+  outputs. The Reagent walk routes its warning through the process-wide
+  `warn-once` cache + `js/console.warn`; the spine walk takes an injectable
+  `warn-fn`. We observe both via a `js/console.warn` stub so the assertion
+  is uniform across walks.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.spine :as spine]
+            [re-frame.views.source-coord-annotation :as sca]
+            [re-frame.views.warn-once :as warn-once]))
+
+;; ---- harness --------------------------------------------------------------
+
+(def ^:private orig-console-warn (when (exists? js/console) (.-warn js/console)))
+
+(defn console-warn-stub-fixture
+  "Stub `js/console.warn` to count calls so both walks' warnings are
+  observable uniformly, and clear the process-wide non-DOM-root warn-once
+  cache before AND after each test so a sibling test's first-encounter
+  warning can't swallow ours (and ours can't leak)."
+  [test-fn]
+  (warn-once/clear-warned-non-dom-roots!)
+  (let [calls (atom 0)]
+    (set! (.-warn js/console) (fn [& _] (swap! calls inc)))
+    ;; Stash the counter where the test bodies can read it.
+    (set! (.-rf2-warn-calls js/console) calls)
+    (try (test-fn)
+         (finally
+           (set! (.-warn js/console) orig-console-warn)
+           (warn-once/clear-warned-non-dom-roots!)))))
+
+(use-fixtures :each console-warn-stub-fixture)
+
+(defn- warn-count [] @(.-rf2-warn-calls js/console))
+
+;; Drive the Reagent hiccup walk for `out` under a fresh warn-once cache and
+;; return whether it warned (1) or stayed silent (0).
+(defn- reagent-warned? [out]
+  (warn-once/clear-warned-non-dom-roots!)
+  (let [before (warn-count)]
+    (sca/inject-source-coord-attr :rf.test/view "rf.test:view:1:1" out)
+    (- (warn-count) before)))
+
+;; Drive the React-hook (spine) walk for `out` and return whether it warned.
+;; The private fn takes an injectable warn-fn; we route it through the SAME
+;; warn-once helper the production wiring uses so the observable matches the
+;; Reagent path (one-shot per id, lands on the stubbed console.warn).
+(defn- spine-warned? [out]
+  (warn-once/clear-warned-non-dom-roots!)
+  (let [before  (warn-count)
+        warn-fn (fn [id type-tag] (warn-once/warn-non-dom-root! id type-tag))]
+    (#'spine/inject-source-coord-attr
+      warn-fn :rf.test/view "rf.test:view:1:1" ":rf.test/view" out)
+    (- (warn-count) before)))
+
+;; ---- parity matrix --------------------------------------------------------
+
+(deftest string-returning-view-warns-on-both-walks
+  (testing "a reg-view'd component returning a STRING root warns on BOTH
+            walks (rf2-9ex1i9 — formerly silent under Reagent, warned under
+            UIx/Helix)"
+    (is (= 1 (reagent-warned? "just a string"))
+        "Reagent hiccup walk warns on a string root")
+    (is (= 1 (spine-warned? "just a string"))
+        "React-hook spine walk warns on a string root")))
+
+(deftest number-returning-view-warns-on-both-walks
+  (testing "a NUMBER root is equally un-annotatable and warns on both walks"
+    (is (= 1 (reagent-warned? 42)) "Reagent walk warns on a number root")
+    (is (= 1 (spine-warned? 42))   "spine walk warns on a number root")))
+
+(deftest nil-returning-view-is-silent-on-both-walks
+  (testing "a view legitimately rendering NOTHING (nil) stays silent on
+            both walks — the warn predicate is non-NIL, not non-element"
+    (is (= 0 (reagent-warned? nil)) "Reagent walk silent on nil")
+    (is (= 0 (spine-warned? nil))   "spine walk silent on nil")))
+
+(deftest dom-tag-root-is-silent-on-reagent-walk
+  (testing "a real DOM-tag-rooted hiccup is annotated, not warned (Reagent
+            walk control case)"
+    (is (= 0 (reagent-warned? [:div "hi"]))
+        "Reagent walk does not warn on a :div root")))
+
+(deftest fn-headed-vector-warns-on-reagent-walk
+  (testing "a fn/component-headed vector still warns on the Reagent walk
+            (the case that ALWAYS warned — regression guard that unifying
+            the predicate did not drop the original trigger)"
+    (is (= 1 (reagent-warned? [(fn [] [:div]) "child"]))
+        "Reagent walk still warns on a fn-headed vector")))


### PR DESCRIPTION
Two related spine/view-walk bugs from the 2026-06-20 worker-max code-review deep sweep, clustered into one PR because both touch `substrate/spine.cljs` (avoiding a same-file conflict between two workers).

## rf2-jgzica — flush! re-runs the user sub body on a disposed derived value

A derived value's `mark-dirty!` enqueues `flush!` on the shared epoch scheduler; the drain runs at epoch close. If the reaction is disposed BETWEEN mark-dirty and the drain (a cascade where a downstream unsubscribe drives a sibling ref-count to 0 and disposes a reaction whose `flush!` is already queued), the queued thunk still ran. `-dispose` clears `watchers`, so the `notify` fan-out was already a no-op — but `recompute` is the memo wrapper, so it re-ran the user sub body and (in dev) emitted a spurious `:rf.sub/run`: the exact redundant-recompute class the epoch scheduler exists to prevent (rf2-i21f5). Bounded (the wrong value never reaches a subscriber), not an app-value correctness bug.

**Fix:** `flush!` early-returns when `@disposed?`. The scheduler cannot dequeue a single thunk, so the disposed reaction skips the recompute at drain time instead.

## rf2-9ex1i9 — string-returning view warns under UIx/Helix but not Reagent; stale docstring

The two source-coord annotation walks shared their warning MESSAGE text (adapter/context) but had drifted on the warning TRIGGER: the React-hook walk (UIx/Helix) warned on any non-element non-nil output, while the Reagent hiccup walk warned only on a vector output. So a reg-view'd component returning a STRING (or number) warned under UIx/Helix but was SILENT under Reagent — an observable cross-adapter inconsistency on a pair-tool warning surface.

**Fix:** unified the Reagent walk on the honest warn-on-any-non-nil-non-element predicate (a string root is equally un-annotatable on both substrates); `nil` stays silent on both. Also corrected a stale docstring: the `data-rf-view` value is `(str id)` => `:rf.foo/bar` (leading colon, per the shared `format-view-id` and Spec 006), not the colon-less `<ns>/<sym>` it claimed.

## Regression tests (each fails before its fix, passes after — verified)

- `spine_glitch_free_cljs_test.cljs`: `disposed-layer-2-flush-mid-cascade-does-not-recompute` (dispose a layer-2 sub mid-cascade while a sibling input changes) + `direct-dispose-then-flush-does-not-recompute` (focused dispose-while-epoch-open variant). Both assert the disposed reaction's compute-fn does NOT re-run on drain. **2/2 fail before the guard, pass after.**
- `source_coord_warn_parity_cljs_test.cljs` (new): drives BOTH walks directly and asserts identical warn behaviour across a matrix (string, number, nil, DOM-tag, fn-headed vector). The string + number cases **fail before the fix, pass after**; nil/DOM-tag/fn-headed control cases are green either way.

## Quality gates

Run locally in the worktree (node_modules junctioned from the main checkout):

- `shadow-cljs compile node-test` + `node out/node-test.js` (== `npm run test:cljs`): **PASS** — 7912 tests, 36434 assertions, 0 failures, 0 errors (spine is core).
- `npm run test:adapter-smokes` (Reagent / UIx / Helix browser smokes — cross-adapter surface for 9ex1i9): **PASS** — 3 specs, 0 failures.
- `npm run test:elision` (production elision probe — `data-rf2-source-coord` / `data-rf-view` are elision sentinels): **PASS** — 42/42 sentinels absent from production, 42/42 present in control.

CI is the merge gate.