### PR TITLE
fix(machines): reap guard-suppressed :after timer registry entry, prevent spent re-arm (rf2-8cndln)

### DIFF
--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -258,6 +258,50 @@
                  (dissoc m frame-id)
                  (assoc m frame-id inner)))))))
 
+(defn- reap-fired-entry!
+  "Reap a one-shot `:after` entry whose host-clock timer has just FIRED —
+  release its sub-reaction watcher + subscription registration and drop the
+  inner-table slot. Distinct from `cancel-after-timer-entry!`: a fired timer
+  was NOT cancelled (the host clock ran to completion), so this emits NO
+  `:rf.machine.timer/cancelled` trace — the fired/stale-after trace already
+  records the synthetic event's fate. This is the host-clock counterpart of
+  the cancellation paths: it exists so the COMMON case where a fire is
+  guard-suppressed (the synthetic event is discarded, the state does NOT
+  exit, so no `:on-exit` cancel ever runs) does not strand the entry — a leak
+  of the add-watch + held subscription ref-count, and — worse — a live
+  watcher that would re-arm a fresh timer for a one-shot that already
+  fired-and-was-discarded the next time the sub-vec delay's value changes.
+  Per XState v5 semantics a delayed transition's timer fires once per arming;
+  a guard-rejected fire does NOT re-schedule.
+
+  EPOCH-GUARDED. The reap runs only when the slot still holds THIS fire's
+  entry — same `:epoch` as the one the timer was armed at. A real-transition
+  fire exits the state, runs `:on-exit` cancel, and re-entry installs a FRESH
+  entry under the same key at a strictly-greater per-decl-path epoch; the
+  guard refuses to clobber that successor (and refuses to double-reap an
+  already-cancelled slot). Returns nil.
+
+  `vec`-snapshots nothing — a single `get-in` + a compare-and-dissoc swap that
+  re-reads the epoch inside the swap fn so a concurrent re-arm between the
+  read and the swap is not clobbered on the JVM target."
+  [frame-id k fired-epoch]
+  (when-let [entry (get-in @after-timers [frame-id k])]
+    (when (= fired-epoch (:epoch entry))
+      (release-entry-resources! frame-id entry (:delay k))
+      (swap! after-timers
+             (fn [m]
+               ;; Re-read the entry inside the swap: only dissoc when the slot
+               ;; STILL carries this fire's epoch, so a concurrent re-arm that
+               ;; landed a fresh entry between the outer read and this swap is
+               ;; preserved rather than dropped.
+               (if (= fired-epoch (:epoch (get-in m [frame-id k])))
+                 (let [inner (dissoc (get m frame-id) k)]
+                   (if (empty? inner)
+                     (dissoc m frame-id)
+                     (assoc m frame-id inner)))
+                 m)))))
+  nil)
+
 (defn- on-sub-changed!
   "Watch callback invoked when a subscription-vector delay's value
   changes. Per Spec 005 §Dynamic delay re-resolution: cancel the prior
@@ -403,7 +447,24 @@
                       (dispatch! [parent-id [:rf.machine.timer/after-elapsed
                                               delay-key epoch (vec invoke-id)]]
                                  {:frame              frame-id
-                                  :source             :after-timer})))
+                                  :source             :after-timer}))
+                    ;; A one-shot `:after` timer fires exactly once per arming
+                    ;; (XState v5 §delayed transitions). Reap THIS fire's entry
+                    ;; — release the sub-reaction watcher + held subscription
+                    ;; ref-count and drop the slot — epoch-guarded so a
+                    ;; real-transition exit's re-armed successor (fresh entry,
+                    ;; strictly-greater epoch) is not clobbered. Without this,
+                    ;; a GUARD-SUPPRESSED fire (state does not exit, so no
+                    ;; `:on-exit` cancel runs) would strand the entry AND let a
+                    ;; later sub-vec value change re-arm a spent one-shot via
+                    ;; `on-sub-changed!`. The reap is silent — a fired timer
+                    ;; was not cancelled, so no `:cancelled` trace is emitted.
+                    ;; Runs AFTER the dispatch returns: in dispatch-sync the
+                    ;; transition (and its `:on-exit` cancel, if any) has
+                    ;; already executed, so the epoch guard sees the settled
+                    ;; slot; in async dispatch the guard still distinguishes
+                    ;; this entry from any future re-arm by epoch.
+                    (reap-fired-entry! frame-id k epoch))
                   resolved-ms)
                 watch-key (when (= :sub delay-source)
                             [::after-watch frame-id parent-id invoke-id delay-key])]

--- a/implementation/machines/test/re_frame/after_fire_reap_test.cljc
+++ b/implementation/machines/test/re_frame/after_fire_reap_test.cljc
@@ -1,0 +1,164 @@
+(ns re-frame.after-fire-reap-test
+  "rf2-8cndln — a guard-suppressed `:after` timer fire must REAP its own
+  registry entry at fire time, not leak it.
+
+  Background. `machines.timer/schedule-after-timer!` arms a host-clock timer
+  whose fire thunk dispatches the synthetic
+  `[:rf.machine.timer/after-elapsed …]` event. Entries in the per-frame
+  `after-timers` table were previously reaped ONLY by a CANCELLATION path —
+  state exit (`:on-exit`), actor destroy, frame destroy, sub re-resolution.
+  Nothing reaped an entry whose timer actually FIRED.
+
+  That is invisible for a fire that drives a real transition: the state
+  exits, `after-cancel-fx` runs, and the entry is cleared as `:on-exit`. But a
+  GUARD-SUPPRESSED fire (the elapsed event is discarded, the state does NOT
+  exit) runs no cancel — so the entry is stranded:
+
+    (a) a live `add-watch` on the dynamic-delay reaction plus a held
+        subscription ref-count leak for as long as the machine stays in the
+        state; and — worse —
+    (b) if that sub value later changes, the still-installed watcher's
+        `on-sub-changed!` RE-ARMS a brand-new timer for a one-shot that
+        already fired-and-was-discarded.
+
+  XState v5 semantics: a delayed (`after`) transition's timer fires ONCE per
+  arming; a guard-rejected delayed transition does NOT re-schedule. The fix
+  reaps the firing entry (host handle + remove-watch + unsubscribe) at fire
+  time, epoch-guarded so a concurrent re-entry's fresh entry (strictly-greater
+  per-decl-path epoch) is not clobbered.
+
+  These tests exercise the REAL fire path — the host-clock thunk
+  `machines.timer` installs — rather than dispatching the synthetic
+  `:after-elapsed` event directly (which bypasses the `after-timers` registry
+  entirely, the reason the bug was invisible to the rest of the suite). The
+  host clock + the dynamic-delay subscription reaction are both controlled via
+  `with-redefs`, after the pattern already used by the sub-vec :after exception
+  tests in `after_test.clj`, so the test is deterministic on BOTH the JVM and
+  CLJS runtimes (plain-atom JVM reactions are recompute-on-deref, so a real db
+  mutation would never fire a reaction watch — a plain controllable atom stands
+  in for the reaction so `add-watch` / `remove-watch` and a `reset!`-driven
+  change are synchronous on both platforms)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            ;; Loading `re-frame.machines` installs the machines-artefact
+            ;; late-bind hooks (`reg-machine`, `reset-timers!`) the test relies
+            ;; on; under a single-ns test run nothing else pulls it in.
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.timer :as timer]
+            [re-frame.subs :as subs]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- default-inner
+  "The `:rf/default` frame's inner timer table (the `{inner-key entry}`
+  map), or `{}` when the frame holds no live `:after` timers."
+  []
+  (get @timer/after-timers :rf/default {}))
+
+(deftest guard-suppressed-sub-delay-fire-reaps-entry-and-does-not-rearm
+  ;; A sub-vec `:after` delay whose transition is guard-suppressed. The host
+  ;; clock fires; the synthetic elapsed event is discarded by the false guard;
+  ;; the state does NOT exit. The firing entry MUST be reaped at fire time
+  ;; (no leak), and the now-spent one-shot MUST NOT re-arm when the dynamic
+  ;; delay's value later changes.
+  (testing "rf2-8cndln — a guard-suppressed sub-delay :after fire reaps its
+            registry entry (no leak) and the spent one-shot does not re-arm"
+    (let [;; A plain atom stands in for the dynamic-delay subscription
+          ;; reaction: `add-watch` / `remove-watch` and a `reset!`-driven
+          ;; change are synchronous on both JVM and CLJS, unlike the
+          ;; recompute-on-deref plain-atom reaction (which never pushes a
+          ;; watch on a db change).
+          delay-reaction (atom 5000)
+          ;; Count every host-clock arm and keep the latest fire thunk.
+          arm-count      (atom 0)
+          last-thunk     (atom nil)
+          m {:initial :idle
+             :data    {}
+             ;; Guard always false → the timer's elapsed event is discarded,
+             ;; the state does NOT exit, so no `:on-exit` cancel ever runs —
+             ;; the exact path that previously stranded the entry.
+             :guards  {:never? (fn [_] false)}
+             :states  {:idle    {:on {:go :running}}
+                       :running {:after {[:t/dyn-delay]
+                                         {:guard :never? :target :done}}}
+                       :done    {}}}]
+      (rf/reg-sub :t/dyn-delay (fn [_db _] @delay-reaction))
+      (rf/reg-machine :reap/sub m)
+      (with-redefs [;; Resolve the sub-vec delay to our controllable reaction
+                    ;; (both the schedule path and the re-arm path read it).
+                    subs/subscribe   (fn
+                                       ([_query-v] delay-reaction)
+                                       ([_frame-id _query-v] delay-reaction))
+                    subs/unsubscribe (fn ([_] nil) ([_ _] nil))
+                    ;; Capture the host-clock thunk instead of arming a real
+                    ;; wall-clock timer; return an opaque sentinel handle.
+                    interop/schedule-after! (fn [thunk _ms]
+                                              (swap! arm-count inc)
+                                              (reset! last-thunk thunk)
+                                              ::handle)]
+        (rf/dispatch-sync [:reap/sub [:go]])
+        (is (= :running (mtest/machine-state :reap/sub))
+            "entered the :after-bearing state")
+        (is (= 1 (count (default-inner)))
+            "precondition: the sub-delay :after timer registered one entry")
+        (is (= 1 @arm-count) "precondition: armed exactly once on entry")
+        (is (some? @last-thunk)
+            "precondition: the host-clock thunk was captured")
+
+        ;; Fire the host clock. The thunk dispatches the synthetic
+        ;; :after-elapsed event (async via :router/dispatch!) and then reaps
+        ;; this fire's entry. The false guard means the state stays :running
+        ;; and the per-decl-path epoch is unchanged, so the epoch-guarded
+        ;; reap drops the entry.
+        (@last-thunk)
+
+        ;; (a) NO LEAK — the firing entry is reaped.
+        (is (= :running (mtest/machine-state :reap/sub))
+            "guard-suppressed fire did not transition the state")
+        (is (empty? (default-inner))
+            "(a) the guard-suppressed fire REAPED its registry entry — no leak")
+
+        ;; (b) NO RE-ARM — change the dynamic delay's value. Before the fix
+        ;; the watcher is still installed, so `on-sub-changed!` re-arms a
+        ;; fresh timer for the spent one-shot; after the fix the watcher is
+        ;; gone, so the change is inert.
+        (reset! delay-reaction 9999)
+        (is (empty? (default-inner))
+            "(b) the spent one-shot did NOT re-arm on a later sub-value change
+                 (XState v5: a fired delayed transition does not re-schedule)")
+        (is (= 1 @arm-count)
+            "no fresh host-clock timer was armed after the spent fire"))))
+
+  (testing "control — a sub-value change BEFORE the fire DOES re-arm
+            (the watcher is genuinely live until the fire reaps it, so the
+            no-re-arm assertion above is meaningful, not vacuous)"
+    (let [delay-reaction (atom 5000)
+          arm-count      (atom 0)
+          m {:initial :idle
+             :data    {}
+             :guards  {:never? (fn [_] false)}
+             :states  {:idle    {:on {:go :running}}
+                       :running {:after {[:t/dyn-delay2]
+                                         {:guard :never? :target :done}}}
+                       :done    {}}}]
+      (rf/reg-sub :t/dyn-delay2 (fn [_db _] @delay-reaction))
+      (rf/reg-machine :reap/sub2 m)
+      (with-redefs [subs/subscribe   (fn
+                                       ([_query-v] delay-reaction)
+                                       ([_frame-id _query-v] delay-reaction))
+                    subs/unsubscribe (fn ([_] nil) ([_ _] nil))
+                    interop/schedule-after! (fn [_thunk _ms]
+                                              (swap! arm-count inc)
+                                              ::handle)]
+        (rf/dispatch-sync [:reap/sub2 [:go]])
+        (is (= 1 @arm-count) "armed once on entry")
+        (is (= 1 (count (default-inner))) "one live entry")
+        ;; Change the delay BEFORE any fire — the live watcher re-resolves.
+        (reset! delay-reaction 7000)
+        (is (= 2 @arm-count) "sub-value change re-armed the live (un-fired) timer")
+        (is (= 1 (count (default-inner)))
+            "still exactly one entry after the cancel-and-reschedule")))))


### PR DESCRIPTION
## Summary

A one-shot `:after` timer's host-clock fire thunk (`machines/timer.cljc`) dispatched the synthetic `:rf.machine.timer/after-elapsed` event but **never reaped its own `after-timers` registry entry**. Entries were reaped ONLY by the cancellation paths — state exit (`:on-exit`), actor destroy, frame destroy, sub re-resolution.

A **guard-suppressed** fire runs no cancel (the elapsed event is discarded, the state does NOT exit), so a `:sub-vector` `:after` delay stranded:
- **(a)** a live `add-watch` on the dynamic-delay reaction plus a held subscription ref-count — a leak for as long as the machine stays in the state; and — worse —
- **(b)** if that sub value later changed, the still-installed watcher's `on-sub-changed!` **re-armed a brand-new timer** for a one-shot that already fired-and-was-discarded.

This was invisible to the suite because the existing JVM tests dispatch the synthetic elapsed event directly, bypassing the `timer.cljc` registry entirely.

## Fix

Reap the firing entry (host handle + remove-watch + unsubscribe) **at fire time**, **epoch-guarded** so a concurrent re-entry's fresh entry (same key, strictly-greater per-decl-path epoch) is not clobbered. The reap is **silent** — a fired timer was not cancelled, so no `:rf.machine.timer/cancelled` trace is emitted (the `:fired` / `:stale-after` trace already records the synthetic event's fate). Literal- and fn-form delays are reaped too (their nil watcher/reaction slots are tolerated).

## XState v5 conformance

Aligns with XState v5 delayed-transition semantics: a delayed (`after`) transition's timer fires **once per arming**; a guard-rejected delayed transition does **not** re-schedule. Pre-fix, a guard-rejected sub-vec `:after` would re-schedule on the next sub change — a divergence this corrects.

## Quality gates

- `cd implementation/machines && clojure -M:test` (machines JVM, JVM-runnable without node_modules): **781 tests, 2556 assertions, 0 failures, 0 errors** (includes the existing `:after` / timer / cancellation tests + the new regression).
- New regression `re-frame.after-fire-reap-test` (`.cljc`): exercises the **real** host-clock thunk (controllable host clock + dynamic-delay reaction via `with-redefs`, matching the sub-vec `:after` exception tests). Asserts (a) the entry is reaped (no leak) and (b) the spent one-shot does not re-arm on a later sub-value change. A control case proves the watcher is genuinely live until the fire reaps it (the no-re-arm assertion is not vacuous). **Fails before the fix (5 failures), passes after.**
- `npm run test:cljs` (CLJS node-test): **skipped locally** — fresh worktree has no `node_modules`; relying on CI. The new test is `.cljc` so it runs under the CLJS node-test gate in CI as well.