### PR TITLE
fix(core): epoch drain recovers cleanly when a thunk throws (no stranded dirty flags) (rf2-l3lelt)

### DIFF
--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -113,7 +113,23 @@
   drain requests (the running loop already observes newly-enqueued
   thunks). Each thunk recomputes its derived value and, on a `=`-change,
   notifies its watchers — which may enqueue downstream thunks that the
-  same loop then drains, preserving topological order."
+  same loop then drains, preserving topological order.
+
+  Per-thunk throw isolation (rf2-l3lelt). On the production sub graph a
+  flush thunk never throws: the spine compute-fn is
+  `subs.memo/validate-and-trace`, which brackets the user sub body in
+  `try/catch`, emits `:rf.error/sub-exception`, and recovers to nil. A
+  non-catching compute-fn (a RAW derived value built by tooling/tests)
+  can throw, though — and a throw propagating out of the bare drain loop
+  STRANDED every downstream thunk still queued behind it: the `finally`
+  retained them in `@queue`, but their `dirty?` flag stayed `true`, so
+  `mark-dirty!` (guarded by `(when-not @dirty? …)`) could never re-enqueue
+  them on a later source change — a latent stuck-dirty strand. Mirroring
+  `drain-after-render-queue!`, each thunk now runs inside its own
+  `try/catch` that swallows: one misbehaving thunk cannot strand the rest,
+  and the loop drains to completion (the throwing thunk's own `dirty?` was
+  already cleared by `flush!` before `recompute`, so it leaves no stuck
+  guard either)."
   [{:keys [flushing? queue queued] :as _scheduler}]
   (when-not @flushing?
     (vreset! flushing? true)
@@ -125,8 +141,10 @@
     ;; building a chain of nested subvec views per cascade step. The
     ;; cursor advances and the entry leaves `queued` BEFORE the thunk runs,
     ;; so a thunk that throws is already considered consumed (matching the
-    ;; old head-pop-before-call ordering); the `finally` then compacts
-    ;; `@queue` to exactly the not-yet-drained tail on every exit path.
+    ;; old head-pop-before-call ordering). A per-thunk `try/catch` (see the
+    ;; docstring) isolates a throwing thunk so the loop still drains the
+    ;; downstream tail to completion; the `finally` then releases the
+    ;; backing vector for the next epoch.
     (let [cursor (volatile! 0)]
       (try
         (loop []
@@ -134,18 +152,18 @@
             (let [thunk (nth @queue @cursor)]
               (vswap! queued disj thunk)
               (vswap! cursor inc)
-              (thunk))
+              ;; Per-thunk throw isolation (rf2-l3lelt): swallow so one
+              ;; throwing thunk cannot strand the not-yet-drained tail —
+              ;; mirrors `drain-after-render-queue!`'s per-callback guard.
+              (try (thunk) (catch :default _ nil)))
             (recur)))
         (finally
-          ;; Drop the drained prefix in ONE pass (a single fresh vector,
-          ;; not a per-step subvec chain): normally the tail is empty so
-          ;; this releases the backing vector for the next epoch; on a
-          ;; thunk throw it leaves the un-drained remainder, exactly as the
-          ;; incremental-subvec drain did.
-          (let [q @queue]
-            (vreset! queue (if (< @cursor (count q))
-                             (into [] (subvec q @cursor))
-                             [])))
+          ;; The loop now consumes `@queue` to empty on every
+          ;; non-re-entrant exit (per-thunk isolation means no throw escapes
+          ;; the loop), so the cursor reaches the end and this releases the
+          ;; backing vector for the next epoch. Re-entrant drains still
+          ;; short-circuit on `@flushing?` above and never reach here.
+          (vreset! queue [])
           (vreset! flushing? false))))))
 
 (defn- schedule-flush!

--- a/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
@@ -259,6 +259,89 @@
       (is (= 0 @body-runs)
           "the disposed reaction's flush did not recompute on drain"))))
 
+;; ---- throw mid-drain does NOT strand downstream thunks --------------------
+;; (rf2-l3lelt)
+
+(deftest throwing-thunk-mid-drain-does-not-strand-downstream
+  (testing "a derived value whose compute-fn THROWS during the epoch drain
+            must not strand the downstream thunks still queued behind it:
+            the throw is contained (it does not escape replace-container!),
+            the surviving sibling drains its flush in the SAME epoch, and —
+            critically — its dirty? guard is cleared so a LATER source change
+            can re-enqueue it (no stuck-dirty strand).
+
+            Wiring mirrors the real graph: both layer-1 values watch the root
+            and so both enqueue a flush thunk on the ONE shared scheduler per
+            replace-container!. The thrower is constructed FIRST, so its flush
+            thunk is drained FIRST — meaning the surviving sibling is the
+            still-queued downstream entry a bare (rethrowing) drain would
+            strand (its flush never running, its dirty? stuck true, never
+            re-markable by `mark-dirty!`'s `(when-not @dirty? …)` guard).
+            (rf2-l3lelt)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          boom?      (atom false)
+          ;; Thrower: reads :a, throws on demand. Constructed FIRST so its
+          ;; flush thunk enqueues (and drains) ahead of the survivor's.
+          thrower    (make-derived [root]
+                       (fn [db] (when @boom? (throw (js/Error. "boom")))
+                         (:a db)))
+          ;; Survivor: the downstream thunk a stranding drain would skip.
+          survivor   (make-derived [root] (fn [db] (:b db)))
+          notes      (atom [])]
+      ;; Lazy baselines (the sub-cache reads on subscribe).
+      (is (= 1 @thrower) "thrower baseline")
+      (is (= 10 @survivor) "survivor baseline")
+      (add-watch survivor :w (fn [_ _ prev nu] (swap! notes conj [prev nu])))
+      ;; Arm the throw, then ONE replace-container! queues BOTH flush thunks;
+      ;; the thrower's recompute throws mid-drain.
+      (reset! boom? true)
+      (is (nil? (replace! root {:a 99 :b 20}))
+          "the mid-drain throw is contained — replace-container! returns
+           normally (the per-thunk guard swallows; the throw does not escape
+           the drain)")
+      (is (= [[10 20]] @notes)
+          "the survivor's flush STILL ran in the same epoch — it was not
+           stranded behind the throwing thunk")
+      (is (= 20 @survivor) "survivor deref reflects the settled value")
+      ;; The load-bearing strand assertion: disarm the throw and change the
+      ;; survivor's slice AGAIN. With the bug its dirty? was stuck true (its
+      ;; flush never ran on the first write), so this second change could
+      ;; never re-enqueue it and the watcher would NOT fire. With the fix the
+      ;; survivor drained cleanly the first time, so it re-marks and notifies.
+      (reset! boom? false)
+      (reset! notes [])
+      (replace! root {:a 99 :b 30})
+      (is (= [[20 30]] @notes)
+          "a LATER source change re-enqueues + flushes the survivor — no
+           stuck-dirty strand (the surviving thunk's guard was cleared)"))))
+
+(deftest throwing-thunk-clears-its-own-dirty-guard
+  (testing "the THROWING derived value itself leaves no stuck-dirty guard:
+            flush! resets dirty? BEFORE recompute, so even though its
+            recompute threw, a later (non-throwing) source change re-enqueues
+            and flushes it normally. (rf2-l3lelt)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          boom?    (atom false)
+          thrower  (make-derived [root]
+                     (fn [db] (when @boom? (throw (js/Error. "boom")))
+                       (:a db)))
+          notes    (atom [])]
+      (is (= 1 @thrower) "baseline deref establishes prev-state")
+      (add-watch thrower :w (fn [_ _ prev nu] (swap! notes conj [prev nu])))
+      ;; First write throws mid-drain.
+      (reset! boom? true)
+      (is (nil? (replace! root {:a 2 :b 10}))
+          "the throw is contained")
+      (is (= [] @notes)
+          "the throwing flush did not notify (its recompute never returned)")
+      ;; Disarm; a fresh change must re-enqueue + flush the (formerly
+      ;; throwing) value — proving its dirty? guard was not left stuck true.
+      (reset! boom? false)
+      (replace! root {:a 3 :b 10})
+      (is (= [[1 3]] @notes)
+          "the value recovered: its dirty? guard was cleared by flush! before
+           the throw, so the next change re-marks + flushes it"))))
+
 ;; ---- direct source mutation outside an epoch ------------------------------
 
 (deftest layer-1-direct-source-write-still-flushes


### PR DESCRIPTION
Fixes the latent stuck-dirty strand in the substrate-spine epoch drain (rf2-l3lelt).

## Root cause

`drain-scheduler!` (implementation/core/src/re_frame/substrate/spine.cljs) ran each queued `flush!` thunk **bare**. On the production sub graph a flush thunk never throws — the compute-fn is `subs.memo/validate-and-trace`, which brackets the user sub body, emits `:rf.error/sub-exception`, and recovers to nil. But a **non-catching** compute-fn (a RAW derived value built by tooling/tests) can throw, and the throw propagated out of the drain loop and **stranded every downstream thunk still queued behind it**: the `finally` retained them in `@queue`, but their `dirty?` flag stayed `true`, so `mark-dirty!` (guarded by `(when-not @dirty? …)`) could never re-enqueue them on a later source change — the entry could only ever recover via a fresh `replace-container!` epoch.

## Fix

Wrap the per-thunk call in a `try/catch` that swallows, mirroring the established in-file convention in `drain-after-render-queue!` ("Per-fn throws are swallowed so one misbehaving callback cannot strand the rest"). No new error shape invented.

- One throwing thunk can no longer strand the downstream tail.
- The loop now drains the queue to completion on every non-re-entrant exit, so the `finally` unconditionally resets `@queue` to a fresh empty vector (releasing the backing array) — the old throw-time subvec-compaction branch is gone.
- The throwing thunk's own `dirty?` was already cleared by `flush!` *before* `recompute` (rf2-jgzica), so it leaves no stuck guard either.

Touches only `spine.cljs` + its glitch-free test.

## Recovery semantics chosen

Per-thunk isolation + swallow, aligned to `drain-after-render-queue!` (the single in-file drain-error precedent). A flush thunk is a framework scheduler primitive that does not throw on the real graph; an unexpected throw from a non-catching raw thunk is contained per-entry so the cascade still settles. The throw "surfaces" as a contained, non-propagating event: `replace-container!` returns normally and the rest of the epoch drains — rather than aborting the whole drain. Console shims were considered and rejected (principle-violating per prior ruling), and a typed `throw-error!` would re-introduce the very propagation the fix removes.

## Regression tests (fail before, pass after)

Two new tests in `spine_glitch_free_cljs_test.cljs`, driving the spine's epoch scheduler directly over plain source atoms sharing one scheduler:

- `throwing-thunk-mid-drain-does-not-strand-downstream` — thrower constructed first (drains first); asserts (a) `replace-container!` returns nil (throw contained, does not escape), (b) the surviving sibling's flush ran in the same epoch, and (c) a **later** source change re-enqueues + flushes the survivor (no stuck-dirty strand).
- `throwing-thunk-clears-its-own-dirty-guard` — the throwing value itself recovers on the next change (its `dirty?` was cleared by `flush!` before the throw).

Proven by reverting the fix: 2 failures + 2 errors (the `Error: boom` propagating out of `replace!` + the strand assertions). Restored: green.

## Quality gates

- `npm run test:cljs` (from `implementation/`): **7914 tests / 36444 assertions, 0 failures, 0 errors** with the fix. Reverting the drain change → 2 failures + 2 errors on exactly the two new tests; restored → green.

CI is the merge gate.