### PR TITLE
fix(core): schema-rollback restores full app-db, not path slice (rf2-wfy2kq)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1911,10 +1911,13 @@
   Per Spec 010 §Per-step recovery row 4 (rf2-wkxng / rf2-6m0se): a
   post-commit `:db` schema-validation failure rolls the container
   back to the pre-handler value AND treats the dispatch as failed —
-  flows do NOT evaluate and `:fx` does NOT walk. The pre-handler db
-  is read from `(get-in final-ctx [:coeffects :db])` (assemble-
-  initial-ctx stamps it there). Downstream queued events still drain
-  per run-to-completion (handled by `drain-loop!`'s outer pass).
+  flows do NOT evaluate and `:fx` does NOT walk. The pre-handler db is
+  read from the cascade's pre-handler frame-state snapshot
+  (`frame/*cascade-frame-state-before*`'s app-db partition) — NOT from
+  `[:coeffects :db]`, which an `:rf.interceptor/path` handler focuses to
+  a slice (rf2-wfy2kq); see the `db-before` binding below. Downstream
+  queued events still drain per run-to-completion (handled by
+  `drain-loop!`'s outer pass).
 
   Per Spec 002 §Cascade propagation: `envelope` is threaded into
   `run-fx-effects!` so reserved-fx defmethods can propagate
@@ -1981,7 +1984,28 @@
         ;; `:rf.error/effect-map-shape` (`:logged-and-skipped`) for each.
         ;; Runs BEFORE any commit, preserving the no-partial-commit promise.
         effects        (events/police-final-effects! (:effects final-ctx) event)
-        db-before      (get-in final-ctx [:coeffects :db])
+        ;; Pre-handler app-db partition for the post-commit schema-rollback
+        ;; target (rf2-wfy2kq). MUST NOT be read from `[:coeffects :db]`: the
+        ;; `:rf.interceptor/path` std-interceptor's `:before` overwrites
+        ;; `[:coeffects :db]` with the FOCUSED slice and its `:after` only
+        ;; restores `[:effects :db]`, never the coeffect (std_interceptors
+        ;; §standard-path-interceptor). So under an idiomatic
+        ;; `[:rf.interceptor/path p]` handler, `(get-in final-ctx [:coeffects
+        ;; :db])` is the path SLICE, not the full app-db — and rolling back to
+        ;; it would install the slice as the WHOLE app-db, destroying every key
+        ;; outside `p` (data corruption on the recovery path). Source instead
+        ;; from the cascade's pre-handler frame-state snapshot
+        ;; (`frame/*cascade-frame-state-before*`, bound by `run-one-pass!`
+        ;; around the WHOLE cascade) — the canonical full pre-handler frame-
+        ;; state, whose app-db projection is `=` the un-focused coeffect by
+        ;; construction (both read the live container before the handler runs in
+        ;; `assemble-initial-ctx`) yet is immune to mid-chain path focusing.
+        ;; Fall back to the coeffect only when the var is unbound (no real
+        ;; cascade in flight — REPL / direct call; the rollback path cannot fire
+        ;; there since nothing commits out-of-cascade).
+        db-before      (if-let [fs-before frame/*cascade-frame-state-before*]
+                         (get fs-before frame/app-partition-key)
+                         (get-in final-ctx [:coeffects :db]))
         ;; Pre-handler runtime-db partition (EP-0001 rf2-adwcv6): the
         ;; `:rf.db/runtime` coeffect `assemble-initial-ctx` injected by
         ;; reference. Needed by `commit-frame-effects!` so an app-db schema

--- a/implementation/core/test/re_frame/partitioned_commit_test.clj
+++ b/implementation/core/test/re_frame/partitioned_commit_test.clj
@@ -437,3 +437,71 @@
              (elision/sensitive-declarations :pc/rb-elision))
           "the flow-written elision mark SURVIVES the rollback — the rollback
            mirrors the forward path's privacy fail-safe (rf2-qzs1y9)"))))
+
+;; rf2-wfy2kq (P1 DATA-CORRUPTION) — the post-commit schema rollback must
+;; restore the FULL prior app-db, not a path-focused SLICE.
+;;
+;; The mechanism the corruption rode on: a `[:rf.interceptor/path p]` handler's
+;; `:before` overwrites `[:coeffects :db]` with the FOCUSED slice (the handler
+;; sees only the slice), and its `:after` rewrites only `[:effects :db]` — it
+;; NEVER restores `[:coeffects :db]`. The old rollback read `db-before` from
+;; `(get-in final-ctx [:coeffects :db])`, so under an idiomatic path handler
+;; `db-before` was the SLICE. On a post-commit schema rejection the rollback
+;; then installed that slice as the WHOLE app-db, DESTROYING every key outside
+;; `p`. The existing rollback tests above don't catch it because they use no
+;; path interceptor, so `[:coeffects :db]` coincidentally equals the full db.
+;;
+;; This test exercises the REAL corruption path: a handler focused on `[:slice]`
+;; with sibling state (`:keep`) living OUTSIDE the path, a root-path app schema
+;; that rejects the spliced-back full db, and an assertion that the rollback
+;; restored the WHOLE prior app-db — `:keep` MUST survive.
+;;
+;; Before the fix (`db-before` from `[:coeffects :db]`):
+;;   rollback installs `{:n 0}` (the slice) as the whole app-db → `:keep` gone.
+;; After the fix (`db-before` from `frame/*cascade-frame-state-before*`'s app
+;; partition):
+;;   rollback installs `{:keep :must-survive :slice {:n 0}}` (the full db).
+(deftest schema-rollback-restores-full-app-db-not-path-slice
+  (testing "a post-commit schema rollback under a [:rf.interceptor/path …]
+            handler restores the FULL prior app-db, NOT the path slice — every
+            key outside the focused path survives (rf2-wfy2kq)"
+    (when (late-bind/get-fn :schemas/validate-app-schema!)
+      (rf/reg-frame :pc/rb-path {:doc "rb-path"})
+      ;; Seed a coherent pre-handler app-db with state BOTH inside AND OUTSIDE
+      ;; the path the handler will focus. `:keep` is the canary — it lives
+      ;; outside `[:slice]`, so a slice-as-whole-db rollback would destroy it.
+      (rf/replace-frame-state! :pc/rb-path
+                               {:rf.db/app    {:keep  :must-survive
+                                               :slice {:n 0}}
+                                :rf.db/runtime {:rf.runtime/machines {:m :pre}}})
+      ;; Root-path app schema: demands :keep stay present AND :slice.n a
+      ;; non-negative int. The path handler's bad write makes :slice.n -5; the
+      ;; path :after splices that back into the FULL db, so the schema (which
+      ;; validates the full committed app-db) rejects it → post-commit rollback.
+      (rf/with-frame :pc/rb-path
+        (rf/reg-app-schema [] {:schema [:map
+                                        [:keep  :keyword]
+                                        [:slice [:map [:n [:int {:min 0}]]]]]}))
+      ;; A PATH-FOCUSED handler: it sees ONLY `{:n 0}` (the [:slice] slice) and
+      ;; returns `{:n -5}`. This is the idiomatic interceptor that triggers the
+      ;; corruption — its `:before` overwrites [:coeffects :db] with the slice.
+      (rf/reg-event :pc/path-bad
+        {:doc          "path-focused schema-violating handler → rollback"
+         :interceptors [[:rf.interceptor/path [:slice]]]}
+        (fn [{:keys [db]} _]
+          ;; precondition (inside the chain): the handler sees the SLICE only.
+          (is (= {:n 0} db)
+              "the path handler is focused on the [:slice] sub-db")
+          {:db {:n -5}}))                                ;; violates the schema
+      (rf/dispatch-sync [:pc/path-bad] {:frame :pc/rb-path})
+      ;; THE REGRESSION ASSERTION: the rollback restored the FULL prior app-db,
+      ;; not the path slice. Before the fix this was `{:n 0}` (the slice clobbered
+      ;; the whole partition) and `:keep` was destroyed.
+      (is (= {:keep :must-survive :slice {:n 0}}
+             (rf/app-db-value :pc/rb-path))
+          "the FULL prior app-db is restored on rollback — sibling state outside
+           the focused path SURVIVES (NOT corrupted to the path slice)")
+      (is (= :must-survive (:keep (rf/app-db-value :pc/rb-path)))
+          "the out-of-path canary key SURVIVED the schema-rollback")
+      (is (= {:rf.runtime/machines {:m :pre}} (rf/runtime-db-value :pc/rb-path))
+          "runtime-db ALSO rolled back coherently — the whole transition unwinds"))))


### PR DESCRIPTION
## Summary

**P1 data-corruption fix.** On the post-commit schema-validation **rollback** path, `commit-and-flow!` (router.cljc) sourced the rollback target `db-before` from `(get-in final-ctx [:coeffects :db])`. Under an idiomatic `[:rf.interceptor/path p]` handler that coeffect is the **focused slice**, not the full app-db — the path interceptor's `:before` overwrites `[:coeffects :db]` with the slice (std_interceptors.cljc) and its `:after` only restores `[:effects :db]`, never the coeffect. So on a schema rejection the rollback installed the **slice as the whole app-db**, destroying every key outside `p`.

The existing rollback tests never caught it: they use no path interceptor, so `[:coeffects :db]` coincidentally equalled the full db.

## Fix

Source `db-before` from the cascade's pre-handler frame-state snapshot — `frame/*cascade-frame-state-before*`'s app-db partition (bound by `run-one-pass!` around the whole cascade). That is the canonical **full** pre-handler app-db, `=` the un-focused coeffect by construction (both read the live container before the handler runs in `assemble-initial-ctx`) yet **immune to mid-chain path focusing**. Falls back to the coeffect only when the var is unbound (no real cascade — REPL / direct call; the rollback path cannot fire there since nothing commits out-of-cascade).

Builds on the rf2-qzs1y9 forward/rollback symmetry work (already in base) — does **not** revert it. `runtime-before` was already safe (nothing focuses runtime coeffects); this is the pure-`:db` asymmetry.

Scope: `router.cljc` + the partitioned-commit test only.

## Regression test

`schema-rollback-restores-full-app-db-not-path-slice` (partitioned_commit_test.clj) drives the **real** corruption path: a `[:rf.interceptor/path [:slice]]` handler with sibling state `:keep` living outside the path, forced through a post-commit schema rollback, asserting the **full** prior app-db is restored.

- **Before the fix** (proved by temporarily reverting `db-before` to `[:coeffects :db]`): app-db rolled back to `{:n 0}` — the slice clobbered the whole partition, canary `:keep` destroyed (`nil`). Test FAILS.
- **After the fix**: app-db = `{:keep :must-survive :slice {:n 0}}` — full prior app-db restored. Test PASSES.

Only this one test flipped on the revert; the 18 other partitioned-commit tests (incl. the qzs1y9 elision-rollback) stayed green — confirming the qzs1y9 work is intact.

## Quality gates

- `clojure -M:test -d core/test -n re-frame.partitioned-commit-test` (JVM) — **green** (19 tests / 57 assertions, 0 failures, 0 errors).
- `npm run test:cljs` (CLJS node, full suite, the canonical merge gate) — **green** (7905 tests / 36422 assertions, 0 failures, 0 errors). `npm install` run first (node_modules was absent).
- Full `core/test` JVM sweep: 1704 tests, the only non-green items are **3 pre-existing failures unrelated to this change** (`every-published-key-has-a-directory-entry` late-bind drift, `reg-view-fold-graceful-without-reagent-slim`, `emit-rides-debug-flag`) — verified failing identically on a clean `origin/main` worktree; none touch the rollback / `db-before` path.

Closes-with-PR: rf2-wfy2kq (bead left open per worker protocol; PR URL appended to notes).