### PR TITLE
fix(core): correct transient contract in secret-set wire walker (rf2-cd71m3)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -814,21 +814,22 @@
   elements are all walked, since a candidate aliased to ANY surviving wire
   position is disclosed."
   [acc! node candidates]
-  (when (contains? candidates node)
-    (conj! acc! node))
-  (cond
-    (map? node)
-    (reduce-kv (fn [a k v]
-                 (collect-wire-values! a k candidates)
-                 (collect-wire-values! a v candidates))
-               acc! node)
+  (let [acc! (cond-> acc!
+               (contains? candidates node) (conj! node))]
+    (cond
+      (map? node)
+      (reduce-kv (fn [a k v]
+                   (-> a
+                       (collect-wire-values! k candidates)
+                       (collect-wire-values! v candidates)))
+                 acc! node)
 
-    (coll? node)
-    (reduce (fn [a x] (collect-wire-values! a x candidates))
-            acc! node)
+      (coll? node)
+      (reduce (fn [a x] (collect-wire-values! a x candidates))
+              acc! node)
 
-    :else
-    acc!))
+      :else
+      acc!)))
 
 (defn collect-sensitive-values
   "The set of values sitting at `frame-id`'s declared-`:sensitive?` app-db

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -911,3 +911,75 @@
   (let [tree [:span "ordinary"]]
     (is (identical? tree (elision/redact-derived-slots tree nil nil :rf/default {}))
         "nil source-db + no extra source ⇒ tree returned unwalked")))
+
+;; ── rf2-cd71m3: transient-contract correctness in the wire walker ─────────
+;;
+;; `collect-wire-values!` walks the POST-elision db conj!ing every surviving
+;; value that aliases a candidate secret onto a transient set — the
+;; non-unique-secret guard that powers `sensitive-value-set`. It is correct
+;; TODAY only because `TransientHashSet/conj!` happens to return the SAME
+;; object, so discarding the return is harmless. The documented transient
+;; contract requires the RETURN value of every `conj!` (and every threaded
+;; recursive call) to be used; a refactor to a transient vector — or a host
+;; whose transient set reallocates — would silently drop candidates from the
+;; secret set, i.e. UNDER-redaction of secrets aliased onto the wire.
+
+(deftype ^:private ReallocAcc [coll]
+  ;; A transient-collection accumulator whose `conj!` returns a DISTINCT
+  ;; object every time (modelling a transient vector or a reallocating host
+  ;; set). Mutating in place and discarding the return loses the element —
+  ;; exactly the contract `collect-wire-values!` must honour.
+  clojure.lang.ITransientCollection
+  (conj [_ x] (ReallocAcc. (conj coll x)))
+  (persistent [_] (set coll)))
+
+(deftest collect-wire-values-honours-transient-return-contract
+  ;; Drive the private walker with a return-sensitive accumulator. If any
+  ;; `conj!` return — or the first recursive call in the map branch — is
+  ;; discarded, aliased candidates are LOST. The fixed walker threads every
+  ;; return, so all aliased candidates are collected.
+  ;;
+  ;; This test FAILS against the pre-fix walker (which discards the conj! and
+  ;; map-key recursive returns) and PASSES against the threaded walker.
+  (let [walk! (var-get #'elision/collect-wire-values!)
+        candidates #{"SECRET-K" "SECRET-V" "SECRET-IN-VEC" "SECRET-IN-SET"
+                     "SECRET-DEEP"}
+        ;; A candidate appears as a map KEY, a map VALUE, a vector element, a
+        ;; set member, and a deeply-nested value — every walk branch.
+        wire {"SECRET-K" 1
+              :v "SECRET-V"
+              :vec ["plain" "SECRET-IN-VEC"]
+              :set #{"benign" "SECRET-IN-SET"}
+              :deep {:a {:b ["SECRET-DEEP"]}}}
+        collected (persistent! (walk! (->ReallocAcc []) wire candidates))]
+    (is (= candidates collected)
+        "every aliased candidate is collected when the conj!/recursion return
+         is threaded — no candidate is silently dropped")))
+
+(deftest sensitive-value-set-collects-all-aliased-secrets-over-32
+  ;; Bead acceptance: a wire walk with >32 candidates still collects every
+  ;; aliased secret. Forward-regression guard against a future transient-type
+  ;; change that would make discarded returns lossy (see the contract test
+  ;; above for the fails-before/passes-after proof).
+  ;;
+  ;; 64 distinct scalar secrets are each declared sensitive via a literal-index
+  ;; `:rf/path` ([:secrets i]) AND ALSO aliased verbatim at a NON-sensitive
+  ;; surviving wire position (`:public`). `sensitive-value-set` = candidates
+  ;; MINUS those found on the wire; since every scalar candidate is public, a
+  ;; complete wire walk removes ALL of them, leaving the EMPTY guard set. A
+  ;; single dropped wire value would leave that secret in the returned set, so
+  ;; the empty result proves the walker collected every one of the 64.
+  (let [n       64
+        secrets (mapv #(str "SECRET-" %) (range n))
+        ;; Each element declared sensitive by literal index → scalar
+        ;; candidates only (no whole-collection candidate to confound the set).
+        paths   (mapv (fn [i] [:secrets i]) (range n))]
+    (install-class! paths [])
+    (let [;; Same values re-surfaced at a non-declared, non-redacted position.
+          public (mapv #(str "SECRET-" %) (range n))
+          db     {:secrets secrets :public public}
+          guard  (elision/sensitive-value-set db :rf/default {})]
+      (is (= n (count (set secrets))) "sanity: >32 distinct candidate secrets")
+      (is (= #{} guard)
+          "every one of the 64 aliased secrets is found on the wire and removed
+           from the guard set — none silently dropped by the walker"))))


### PR DESCRIPTION
## Summary

Fixes a transient-contract violation in `collect-wire-values!`
(`implementation/core/src/re_frame/elision.cljc`), the security-critical
secret-set wire walker that powers the non-unique-secret guard
(`sensitive-value-set`).

The walker discarded the return of `conj!` and relied on in-place transient
mutation; its map branch made two recursive calls and discarded the first's
return. This is correct **today** only because `TransientHashSet/conj!`
returns the same object in both Clojure and ClojureScript. A refactor to a
transient vector — or a host whose transient set reallocates — would silently
drop candidates from the secret set, i.e. **under-redaction** of secrets
aliased onto the wire.

The fix threads the accumulator throughout, mirroring the correct sibling
`collect-governed-values!`:
- `cond->` for the membership add, and
- `->` for the map branch's two recursive calls.

Perf-neutral: same walk, threaded accumulator. Scope is the value-layer fix
only (the bead's case E1); the broader egress choke-point work is a separate
held decision and is **not** touched here.

## Regression tests

Both added to `implementation/core/test/re_frame/elision_test.clj`:

1. **`collect-wire-values-honours-transient-return-contract`** — drives the
   private walker with a return-sensitive transient accumulator (`ReallocAcc`,
   whose `conj!` returns a distinct object, honouring the documented
   contract). **Fails before / passes after**: the pre-fix walker collects
   `#{}` (drops every aliased secret); the threaded walker collects all five,
   across map-key, map-value, vector, set, and deeply-nested wire positions.
2. **`sensitive-value-set-collects-all-aliased-secrets-over-32`** — the bead
   acceptance criterion: a >32-candidate (64 distinct secrets) wire walk
   through the real `sensitive-value-set`, asserting every aliased secret is
   found on the wire and removed from the guard set. Forward-regression guard.

Fails-before/passes-after was verified by reverting only the implementation
change and re-running (pre-fix: contract test fails collecting `#{}`).

## Quality gates

- `npm run test:cljs` (from `implementation/`): **7914 tests, 36446
  assertions, 0 failures, 0 errors**. node_modules junctioned from the mayor
  tree (worktree had none) — flag for the hygiene loop.
- Elision JVM suite (`clojure -M:test -n re-frame.elision-test`): 56 tests,
  125 assertions, 0 failures.

Closes nothing — bead `rf2-cd71m3` left open per dispatch; PR URL appended to
its notes.
