### PR TITLE
docs(skills): de-historicize comments/docstrings — CODE only (rf2-hjomv6)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1277,9 +1277,8 @@
 ;; absent (no epoch has fired yet for this frame), we compute it lazily
 ;; from `(rf/app-db-value frame-id)` and stash it.
 ;;
-;; Pre-alpha: no back-compat surface to keep — `app-db-hash` is the
-;; only accessor; callers needing a path-scoped hash hash the slice
-;; themselves until a sub-tree accessor is filed.
+;; `app-db-hash` is the only accessor; callers needing a path-scoped
+;; hash hash the slice themselves until a sub-tree accessor is filed.
 
 (defonce ^:private frame-db-hashes
   ;; frame-id -> cached `(hash app-db)` integer

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -2623,7 +2623,7 @@
            (assoc result :resolved event-v)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Dispatch dry-run (rf2-17hvp)
+;; Dispatch dry-run
 ;; ---------------------------------------------------------------------------
 ;;
 ;; "If I dispatch X, will it do what I expect?" answered without
@@ -2772,7 +2772,7 @@
                                           (the id we just produced is
                                           at the head of the ring).
 
-   Per rf2-17hvp this primitive is the framework-side surface; the MCP
+   This primitive is the framework-side surface; the MCP
    tool `dispatch-dry-run` wraps it. Bound by the registered fx set
    at call time — fx registered after the dry-run start (a rare race)
    would slip through the override; the cost is one un-stubbed fx
@@ -2782,7 +2782,7 @@
   ([event-v opts]
    (let [frame-id  (or (:frame opts) (current-frame))
          _         (when-not frame-id
-                     ;; rf2-n58jxo — enriched ambiguous-frame context (see
+                     ;; Enriched ambiguous-frame context (see
                      ;; pair-dispatch-sync!); dry-run knows the event vector.
                      (throw (ex-info "ambiguous frame"
                                      (ambiguous-frame-error :dispatch-dry-run {:event event-v}))))
@@ -2838,7 +2838,7 @@
                      :before-epoch-id           before-id
                      ;; Project the would-be epoch into the same
                      ;; cascade-summary shape dispatch /
-                     ;; replace-app-db / restore-epoch use (rf2-6yqdl).
+                     ;; replace-app-db / restore-epoch use.
                      ;; Operators read one vocabulary across all four.
                      :cascade-summary           (cascade-summary target-epoch)
                      :would-fire-effects        recorded
@@ -2858,7 +2858,7 @@
 
 (defn- restore-cascade-summary
   "Build a cascade-summary projection for a successful `restore-epoch`
-   call (rf2-6yqdl). A restore is NOT a real cascade — the framework
+   call. A restore is NOT a real cascade — the framework
    rewinds the app-db in-place without recording a new epoch — so the
    normal `epoch-by-id` lookup wouldn't surface anything. Instead we
    project against the TARGET epoch (the one we restored TO) and
@@ -2881,7 +2881,7 @@
     (let [diff       (db-diff-summary pre-db (:db-after target))
           fx-fired   (->> (:effects target) (map :fx-id) distinct vec)
           transitions (machine-transitions-summary (:trace-events target))
-          ;; rf2-6nks4 (finding-2): a restore of a SENSITIVE historical
+          ;; A restore of a SENSITIVE historical
           ;; epoch must not ship the target's raw trigger-event under the
           ;; default off-box posture. Read the target epoch's
           ;; `:rf.epoch/sensitive?` rollup and redact the `:event-vector`
@@ -2912,8 +2912,7 @@
        :unreplayable-effects unreplayable})))
 
 (defn restore-epoch
-  "(rf/restore-epoch! frame-id epoch-id). Returns a structured envelope
-   per rf2-6yqdl:
+  "(rf/restore-epoch! frame-id epoch-id). Returns a structured envelope:
 
      - `{:ok? true :restored? true :epoch-id <id> :frame <id>
          :cascade-summary {...} :unreplayable-effects [...]}` on success.
@@ -2936,11 +2935,11 @@
        (let [extras (restore-cascade-summary pre-db frame-id epoch-id)]
          (merge {:ok? true :restored? true :epoch-id epoch-id :frame frame-id}
                 extras))
-       ;; Preserve the legacy `false` return on failure — the MCP
+       ;; Return the framework's `false` on failure — the MCP
        ;; restore-epoch tool turns that into a structured envelope at
-       ;; the wire boundary (the pre-rf2-6yqdl behaviour). Mirrors how
-       ;; replace-app-db! returns a soft-failure envelope on the runtime
-       ;; side but the tool can elide the framework's `false`.
+       ;; the wire boundary. Mirrors how replace-app-db! returns a
+       ;; soft-failure envelope on the runtime side but the tool can
+       ;; elide the framework's `false`.
        false))))
 
 (defn undo-step-back
@@ -2948,7 +2947,7 @@
    `{:ok? true :epoch-id <previous> :restored? true :cascade-summary
    {...} :unreplayable-effects [...]}` on success or
    `{:ok? false :reason :no-prior-epoch}` when there is no previous
-   record. Cascade-summary slot per rf2-6yqdl."
+   record. Carries a cascade-summary slot."
   ([] (undo-step-back (current-frame)))
   ([frame-id]
    (let [history (vec (rf/epoch-history frame-id))
@@ -2967,8 +2966,7 @@
 
 (defn undo-to-epoch
   "Restore a specific epoch by id. Returns the same shape as
-   `restore-epoch`'s success envelope. Cascade-summary slot per
-   rf2-6yqdl."
+   `restore-epoch`'s success envelope, carrying a cascade-summary slot."
   ([epoch-id] (undo-to-epoch epoch-id (current-frame)))
   ([epoch-id frame-id]
    (let [pre-db (rf/app-db-value frame-id)
@@ -3003,9 +3001,9 @@
 
    Alias of the canonical `re-frame.source-coords/parse-source-coord`
    (the source-coord contract owner) — the inverse of
-   `format-source-coord`. This parser used to be reimplemented near-
-   byte-for-byte here and in Story's element_inspector.cljc; rf2-nr7vf2
-   collapsed both onto the one canonical impl in core. See that fn for
+   `format-source-coord`. The pair preload and Story's
+   element_inspector.cljc both route through this one canonical impl in
+   core. See that fn for
    the four-segment value format (Spec 006 §Attribute value format),
    the `?`-placeholder degradation, and the Tool-Pair opacity caveat
    (downstream callers MUST NOT depend on the parsed shape's stability
@@ -3017,10 +3015,9 @@
    (or the raw string for a non-keyword id), or nil.
 
    Alias of the canonical `re-frame.source-coords/parse-view-id` (the source-
-   coord contract owner) — the inverse of `format-view-id`. This reader used to
-   be reimplemented inline in `view-entity` here and in Xray's fallback view-
-   walker; rf2-ztxnm8 collapsed both onto the one canonical impl in core (the
-   data-rf-view analogue of rf2-nr7vf2's `parse-source-coord` work). See that fn
+   coord contract owner) — the inverse of `format-view-id`. `view-entity` here
+   and Xray's fallback view-walker both route through this one canonical impl
+   in core. See that fn
    for the value format (Spec 006 §View tagging contract §Attribute value
    format) and the Tool-Pair opacity caveat (downstream callers MUST NOT depend
    on the parsed shape's stability across re-frame2 versions)."
@@ -3171,10 +3168,10 @@
     {:ok? false :reason :no-element :selector selector}))
 
 ;; ---------------------------------------------------------------------------
-;; ui-read — view-plane RENDERED-CONTENT read + producing ENTITY (rf2-3bu3d.1)
+;; ui-read — view-plane RENDERED-CONTENT read + producing ENTITY
 ;; ---------------------------------------------------------------------------
 ;;
-;; The two DOM-read planes (rf2-q0r7e). `dom-read` (above) is the RAW DOM
+;; The two DOM-read planes. `dom-read` (above) is the RAW DOM
 ;; plane: a CSS selector → matched nodes, multi-node, NO re-frame2 awareness
 ;; — "what does this exact node SAY?". `ui-read` (here) is the re-frame2 VIEW
 ;; plane: it rides the `data-rf-view` map → content PLUS the producing ENTITY

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -2147,7 +2147,7 @@
 (declare epoch-elapsed-ms)
 
 ;; ---------------------------------------------------------------------------
-;; Cascade summary (rf2-6yqdl)
+;; Cascade summary
 ;; ---------------------------------------------------------------------------
 ;;
 ;; A compact projection of the framework's `:rf/epoch-record` that answers
@@ -2179,14 +2179,14 @@
 ;;   :frame               — the frame-id the cascade settled in
 ;;   :outcome             — the consumer-facing tier (`:ok` / `:blocked`
 ;;                          / `:error`, per `outcome->consumer-facing`).
-;;                          rf2-hhkbb — forced `:error` when the cascade
+;;                          Forced `:error` when the cascade
 ;;                          contained a thrown handler / machine action
 ;;                          (a `:rf.error/*` op in `:trace-events`), even
 ;;                          though the epoch itself settled `:outcome :ok`
 ;;                          (the interceptor seam contained the throw).
 ;;   :errors              — vector of compact `{:operation :message?
 ;;                          :machine-id? :action-id?}` descriptors, one per
-;;                          contained cascade exception (rf2-hhkbb). Absent
+;;                          contained cascade exception. Absent
 ;;                          when the cascade threw nothing. Present ⇒
 ;;                          `:outcome :error` and the downstream
 ;;                          `dispatch-consequence!` reports `:no-op? false`.
@@ -2264,8 +2264,7 @@
   "Project the epoch's detailed `:outcome` cause onto the consumer-
   facing three-tier summary (`:ok` / `:blocked` / `:error`). Mirrors
   `re-frame.epoch.assembly/outcome->consumer-facing` (the same projection
-  pinned in the framework). When `:outcome` is absent (older epoch
-  shapes), defaults to `:ok`."
+  pinned in the framework). When `:outcome` is absent, defaults to `:ok`."
   [outcome]
   (case outcome
     :ok                       :ok
@@ -2274,7 +2273,7 @@
     :halted-handler-exception :error
     :ok))
 
-;; ---- contained cascade errors (rf2-hhkbb) ---------------------------------
+;; ---- contained cascade errors --------------------------------------------
 ;;
 ;; A handler / machine-action throw does NOT halt the drain: the
 ;; interceptor error-capture seam contains it, the epoch settles
@@ -2282,10 +2281,10 @@
 ;; `:rf.error/*` op (Spec-Schemas §`:rf/epoch-record` §Outcomes; the
 ;; reference runtime never emits `:halted-handler-exception`). So
 ;; `outcome-tier` alone reads such an epoch as `:ok` — and because the
-;; aborted action committed no `:db` and fired no fx, the downstream
-;; `:no-op?` heuristic (no db-change AND no fx) also misfires. The result
-;; is a silent-green-on-error trap for any NON-visual consumer triaging
-;; on `:outcome` / `:no-op?` (the human pink-card path, rf2-4yrr6, is
+;; aborted action committed no `:db` and fired no fx, the `:no-op?`
+;; heuristic (no db-change AND no fx) would also misfire. Left unhandled
+;; that is a silent-green-on-error trap for any NON-visual consumer
+;; triaging on `:outcome` / `:no-op?` (the human pink-card path is
 ;; unaffected — it reads the trace directly).
 ;;
 ;; The structured summary closes the gap by scanning `:trace-events` for
@@ -2294,16 +2293,16 @@
 ;; (`:no-op?` exclusion lives downstream in `consequence-from-summary`).
 ;;
 ;; `cascade-error-ops` MIRRORS the Xray Epoch panel's `cascade-exception-
-;; ops` (`tools/xray/.../panels/epoch/projection.cljc`, rf2-ahhgn /
-;; rf2-mszrz / rf2-e7yhv) — the structured summary and the human panel
-;; agree on exactly which `:rf.error/*` ops count as a cascade-level
-;; throw. Schema-VALIDATION failures (`:rf.error/schema-validation-
-;; failure`) are deliberately NOT here: a rejected-but-rolled-back
-;; cascade is not a thrown action, and its outcome is governed elsewhere.
+;; ops` (`tools/xray/.../panels/epoch/projection.cljc`) — the structured
+;; summary and the human panel agree on exactly which `:rf.error/*` ops
+;; count as a cascade-level throw. Schema-VALIDATION failures
+;; (`:rf.error/schema-validation-failure`) are deliberately NOT here: a
+;; rejected-but-rolled-back cascade is not a thrown action, and its
+;; outcome is governed elsewhere.
 
 (def ^:private cascade-error-ops
   "Closed set of cascade-level `:rf.error/*` trace ops that mark an epoch
-  whose cascade contained a thrown handler / machine action (rf2-hhkbb).
+  whose cascade contained a thrown handler / machine action.
   Mirrors Xray's `cascade-exception-ops` so the structured summary and the
   human Epoch panel agree on what counts as a throw."
   #{:rf.error/coeffect-exception
@@ -2317,7 +2316,7 @@
 (defn- cascade-errors
   "Project the contained cascade-exception trace events out of an epoch's
   `:trace-events` into a vector of compact descriptors, or nil when the
-  cascade carried no contained throw (rf2-hhkbb).
+  cascade carried no contained throw.
 
   Each descriptor carries `:operation` (the `:rf.error/*` op) plus, when
   the trace event stamped them, `:message` (the exception's `.getMessage`
@@ -2339,8 +2338,7 @@
     (when (seq picks) picks)))
 
 (defn- redact-sensitive-event-vector
-  "Egress guard for the cascade-summary `:event-vector` slot (rf2-6nks4,
-  finding-2).
+  "Egress guard for the cascade-summary `:event-vector` slot.
 
   The `:event-vector` slot copies the epoch's RAW `:trigger-event` — the
   original dispatch vector, e.g. `[:auth/login {:password \"hunter2\"}]`.
@@ -2351,10 +2349,11 @@
   tools (`restore-epoch` passes the runtime map through verbatim;
   `dispatch-dry-run` deliberately does NOT walk `:cascade-summary`,
   treating it as a counts-only projection) trust this projection to be
-  already-safe. The merged rf2-z7roa elision walker scrubs dispatch-dry-
-  run's `:db-state-after-simulation` / `:would-fire-effects` but left
-  the cascade-summary `:event-vector` UNWALKED — a restore / dry-run of
-  a sensitive historical epoch shipped the raw event payload even under
+  already-safe. The wire-path elision walker scrubs dispatch-dry-run's
+  `:db-state-after-simulation` / `:would-fire-effects`, but the
+  cascade-summary `:event-vector` rides outside that walk — so this guard
+  redacts it here, otherwise a restore / dry-run of a sensitive historical
+  epoch would ship the raw event payload even under
   `--allow-sensitive-reads` OFF.
 
   Fail-closed: when the epoch is sensitive AND the raw-state gate is OFF
@@ -2379,7 +2378,7 @@
 (defn cascade-summary
   "Project an assembled `:rf/epoch-record` into the compact wire shape
   surfaced by dispatch / replace-app-db / restore-epoch / dispatch-dry-
-  run (rf2-6yqdl). See the §Cascade summary section header above for
+  run. See the §Cascade summary section header above for
   the slot inventory.
 
   Pure data — `(epoch-record) -> cascade-summary-map`. Returns nil for a
@@ -2394,10 +2393,10 @@
           transitions (machine-transitions-summary trace-events)
           elapsed    (epoch-elapsed-ms record)
           sensitive? (:rf.epoch/sensitive? record)
-          ;; rf2-hhkbb — a contained throw (handler / machine action) rode
-          ;; the trace stream while the epoch settled `:outcome :ok`. When
-          ;; present it OVERRIDES the outcome tier to `:error` and surfaces
-          ;; under `:errors` so a non-visual consumer detects the failure.
+          ;; A contained throw (handler / machine action) rides the trace
+          ;; stream while the epoch settles `:outcome :ok`. When present it
+          ;; OVERRIDES the outcome tier to `:error` and surfaces under
+          ;; `:errors` so a non-visual consumer detects the failure.
           errors     (cascade-errors trace-events)]
       (cond-> {:epoch-id        epoch-id
                :frame           frame
@@ -2407,10 +2406,10 @@
                :subs-recomputed (count (or sub-runs []))
                :renders         (count (or renders []))}
         event-id      (assoc :event-id event-id)
-        ;; rf2-6nks4 (finding-2): the raw trigger-event is redacted to
-        ;; `:rf/redacted` when the epoch is sensitive and the raw-state
-        ;; gate is OFF (fail-closed default) — see
-        ;; `redact-sensitive-event-vector`. Raw only on opt-in.
+        ;; The raw trigger-event is redacted to `:rf/redacted` when the
+        ;; epoch is sensitive and the raw-state gate is OFF (fail-closed
+        ;; default) — see `redact-sensitive-event-vector`. Raw only on
+        ;; opt-in.
         trigger-event (assoc :event-vector
                              (redact-sensitive-event-vector trigger-event sensitive?))
         transitions   (assoc :machine-transitions transitions)
@@ -2445,7 +2444,7 @@
    `{:ok? true :queued? true :event ...}`. The epoch-id appears once
    the cascade settles; callers can read it via `last-pair-epoch`.
 
-   Per rf2-6yqdl the response carries a `:cascade-summary` slot when
+   The response carries a `:cascade-summary` slot when
    the runtime drained the queue synchronously (the typical CLJS
    single-threaded case — `rf/dispatch` enqueues, the goog.async tick
    drains, and by the time our `(rf/epoch-history)` read fires the
@@ -2454,18 +2453,17 @@
    `:cascade-summary-pending? true :before-epoch-id <prior-head>` so
    the caller can poll `watch-epochs` for the eventual settlement.
 
-   No back-compat shim — `:queued? true` is preserved (the pre-rf2-6yqdl
-   contract) but the cascade slot is the canonical 'what happened?'
-   surface for new code."
+   `:queued? true` rides on the response, but the cascade slot is the
+   canonical 'what happened?' surface."
   ([event-v] (pair-dispatch! event-v {}))
   ([event-v opts]
    (let [frame-id  (or (:frame opts) (current-frame))
-         ;; EP-0002 (rf2-9o48ih): the nREPL eval thread carries no ambient
-         ;; `with-frame` scope, so `rf/dispatch` would `require-current-frame!`
-         ;; and throw `:rf.error/no-frame-context`. Thread the resolved
-         ;; operating frame in as the explicit `:frame` override (the
-         ;; carried-invariant escape the router honours first) so the dispatch
-         ;; lands on the frame `current-frame` chose.
+         ;; The nREPL eval thread carries no ambient `with-frame` scope, so
+         ;; `rf/dispatch` would `require-current-frame!` and throw
+         ;; `:rf.error/no-frame-context`. Thread the resolved operating frame
+         ;; in as the explicit `:frame` override (the carried-invariant escape
+         ;; the router honours first) so the dispatch lands on the frame
+         ;; `current-frame` chose.
          opts      (cond-> opts frame-id (assoc :frame frame-id))
          before-id (when frame-id (some-> (rf/epoch-history frame-id) peek :epoch-id))]
      (rf/dispatch event-v (merge {:origin :pair} opts))
@@ -2492,7 +2490,7 @@
    as the pair-attributed epoch.
 
    On real success returns {:ok? true :epoch-id <id> :event ...
-   :cascade-summary {...}} — per rf2-6yqdl the cascade summary rides
+   :cascade-summary {...}} — the cascade summary rides
    under `:cascade-summary` (the compact projection defined above; see
    §Cascade summary). When epoch-history depth is 0 (recording
    disabled) or the frame isn't registered, reports the failure mode
@@ -2501,15 +2499,15 @@
   ([event-v opts]
    (let [frame-id  (or (:frame opts) (current-frame))
          _         (when-not frame-id
-                     ;; rf2-n58jxo — carry the enriched ambiguous-frame
-                     ;; context (operation, event, available frames, current
-                     ;; pin, fix) as ex-data so the MCP `.catch` →
-                     ;; `err->result` surfaces it verbatim, not a bare reason.
+                     ;; Carry the enriched ambiguous-frame context
+                     ;; (operation, event, available frames, current pin, fix)
+                     ;; as ex-data so the MCP `.catch` → `err->result`
+                     ;; surfaces it verbatim, not a bare reason.
                      (throw (ex-info "ambiguous frame"
                                      (ambiguous-frame-error :dispatch {:event event-v}))))
-         ;; EP-0002 (rf2-9o48ih): thread the resolved operating frame in as
-         ;; the explicit `:frame` override — the nREPL eval thread carries no
-         ;; ambient `with-frame` scope, so `rf/dispatch-sync` would otherwise
+         ;; Thread the resolved operating frame in as the explicit `:frame`
+         ;; override — the nREPL eval thread carries no ambient `with-frame`
+         ;; scope, so `rf/dispatch-sync` would otherwise
          ;; `require-current-frame!` and throw `:rf.error/no-frame-context`.
          opts      (assoc opts :frame frame-id)
          before-id (some-> (rf/epoch-history frame-id) peek :epoch-id)]
@@ -2538,14 +2536,13 @@
           :hint "dispatch-sync returned, but epoch-history head did not advance."})))))
 
 ;; ---------------------------------------------------------------------------
-;; Dispatch CONSEQUENCE — the default sync result (rf2-3bu3d.2)
+;; Dispatch CONSEQUENCE — the default sync result
 ;; ---------------------------------------------------------------------------
 ;;
-;; Default sync dispatch previously returned a transport ACK
-;; (`{:mode :sync}`), so a no-op was indistinguishable from success — a
-;; malformed-frame dispatch (the `::rf/xray` colon-coercion, rf2-ldfnx)
-;; reported success-shaped while doing NOTHING; only a separate state
-;; read revealed the no-op.
+;; A bare transport ACK (`{:mode :sync}`) makes a no-op indistinguishable
+;; from success — a malformed-frame dispatch (the `::rf/xray`
+;; colon-coercion) would report success-shaped while doing NOTHING, and
+;; only a separate state read would reveal the no-op.
 ;;
 ;; `dispatch-consequence!` returns the re-frame2 CONSEQUENCE by default:
 ;;
@@ -2562,7 +2559,7 @@
 
 (defn- consequence-from-summary
   "Project a `pair-dispatch-sync!` success envelope into the
-   dispatch-consequence shape (rf2-3bu3d.2). `result` carries
+   dispatch-consequence shape. `result` carries
    `:ok? true :epoch-id :cascade-summary`. The summary's `:db-diff`
    (`{:changed-paths :added-paths :removed-paths}`) and `:fx-fired`
    feed the consequence's `:changed-paths` / `:effects-fired`. A cascade
@@ -2575,7 +2572,7 @@
                              (:removed-paths db-diff)))
         effects (vec (or fx-fired []))
         db-changed? (boolean (seq changed))
-        ;; rf2-hhkbb — a contained throw (handler / machine action) is NOT
+        ;; A contained throw (handler / machine action) is NOT
         ;; a no-op even though it committed no db-change and fired no fx:
         ;; the cascade did nothing PRECISELY BECAUSE the action aborted.
         ;; The `:errors` slot (set by `cascade-summary` when the trace
@@ -2592,9 +2589,9 @@
         (cond-> (= :error outcome) (assoc :outcome :error)))))
 
 (defn dispatch-consequence!
-  "Synchronous dispatch returning the re-frame2 CONSEQUENCE by default
-   (rf2-3bu3d.2). Validates the event-id against the live `:event`
-   registrar FIRST (rf2-3bu3d.3): an unknown id returns the structured
+  "Synchronous dispatch returning the re-frame2 CONSEQUENCE by default.
+   Validates the event-id against the live `:event`
+   registrar FIRST: an unknown id returns the structured
    `validate-registered` error (`:reason :unknown-id` + `:nearest`)
    WITHOUT dispatching — never a silent no-op success. On a known id,
    dispatches synchronously and projects the consequence:
@@ -2602,14 +2599,14 @@
      {:ok? true :epoch-id :db-changed? :changed-paths :effects-fired
       :no-op? :event :frame :resolved :cascade-summary}
 
-   `:resolved` echoes the parsed event vector (rf2-3bu3d.3) so the wire
+   `:resolved` echoes the parsed event vector so the wire
    result carries the value the runtime actually saw. A genuine no-op
    (handler ran, changed nothing, fired nothing) returns `:db-changed?
    false :effects-fired [] :no-op? true` — VISIBLE, not a fake ack.
 
    On a frame-untargetable / no-epoch failure, the
-   `pair-dispatch-sync!` `:ok? false` envelope rides through verbatim
-   (the rf2-ldfnx invariant — the tool surfaces it as an error)."
+   `pair-dispatch-sync!` `:ok? false` envelope rides through verbatim —
+   the tool surfaces it as an error rather than a fake success."
   ([event-v] (dispatch-consequence! event-v {}))
   ([event-v opts]
    (let [v (validate-event-id event-v)]

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1847,7 +1847,7 @@
    trace-like topics, matches, enqueues. Cheap when no subs exist (the
    common path).
 
-   rf2-mscih channel split:
+   Channel split:
    - Cascade-bundle topics (`:trace`/`:fx`/`:error`) receive events
      carrying a `:rf.trace/dispatch-id` tag. The bundling happens at
      drain time; the queue stays per-event for the byte+event budget.
@@ -3704,7 +3704,7 @@
   30000)
 
 (defn- maybe-elide-sample
-  "Elide a sampled `:app-db` / `:sub` value for off-box egress (rf2-8fin7.2).
+  "Elide a sampled `:app-db` / `:sub` value for off-box egress.
 
    The signal recorder (`record` / `read-recording`) and the blocking watch
    (`watch-until`) ship the sampled VALUES of `{:app-db [path]}` and
@@ -3716,8 +3716,7 @@
    value through the SAME walker, server-side (app-side, where the
    `[:rf.runtime/elision]` registry in runtime-db is reachable).
 
-   Gate posture mirrors `maybe-elide-for-tap` + the MCP read surfaces
-   (rf2-c2dtu):
+   Gate posture mirrors `maybe-elide-for-tap` + the MCP read surfaces:
 
    - Gate OFF (`:allow-raw-state? false`, the published-build default the
      MCP server signals via `configure-raw-state!`): the value is walked
@@ -3754,15 +3753,14 @@
      {:focus true}               — a stable descriptor of
                                     `document.activeElement` (tag + id +
                                     a short data-/aria- attr digest) — the
-                                    focus-slot the hand-built recorder
-                                    tracked.
+                                    focus-slot.
 
    `frame-id` resolves the operating frame for :app-db / :sub signals.
    Returns the sampled value (any EDN-able shape) or nil. Errors degrade
    to `{:rf.recording/error <message>}` so one bad signal never collapses
    the whole sampler tick.
 
-   rf2-8fin7.2 — the value-bearing `:app-db` / `:sub` arms route the
+   The value-bearing `:app-db` / `:sub` arms route the
    sampled value through `maybe-elide-sample` (the off-box-egress walker)
    so a declared-sensitive app-db slot (or a sub deriving from one) is
    redacted before it crosses the MCP boundary, under the default
@@ -3770,10 +3768,10 @@
    per-call posture (gate-ON `:include-sensitive` opt-in); `nil` ⇒
    fail-closed defaults.
 
-   rf2-p9scds — the `:dom` / `:focus` arms are DERIVED reads: a node's
+   The `:dom` / `:focus` arms are DERIVED reads: a node's
    textContent / attribute / focus descriptor can carry a secret copied out
    of a declared-sensitive app-db slot, a NON-app-db position the path-based
-   elider can't reach. They are now value-redacted via `maybe-redact-derived`
+   elider can't reach. They are value-redacted via `maybe-redact-derived`
    (`re-frame.core/redact-derived-slots`) against the frame's secrets under
    the off-box gate — the value-based dual of the `:app-db` / `:sub` elision.
    `start-recording!` / `watch-until` refuse a `:dom` / `:focus` signal under
@@ -3827,13 +3825,13 @@
    `:sample` are the signals' positional indices so the predicate can
    address `(get sample 0)` regardless of signal shape.
 
-   rf2-8fin7.2 — `elide-opts` (the optional 3rd arg) carries the off-box
+   `elide-opts` (the optional 3rd arg) carries the off-box
    egress posture for `:app-db` / `:sub` value sampling (gate-ON
    `:include-sensitive` opt-in). `watch-until` threads it from the MCP
    gate + per-call args; absent ⇒ fail-closed defaults via
    `sample-one-signal`.
 
-   rf2-p9scds — FAIL CLOSED: under the off-box gate a signal that needs
+   FAIL CLOSED: under the off-box gate a signal that needs
    frame policy (`:app-db` / `:sub` always; `:dom` / `:focus` because their
    derived values are value-redacted against the frame's secrets) cannot be
    sampled when `frame-id` is nil (ambiguous frame). Rather than sample
@@ -3870,7 +3868,7 @@
       (let [{:keys [signals frame-id last-values frame-count started-at
                     stop max-entries elide-opts]} rec
             now      (js/Date.now)
-            ;; rf2-8fin7.2 — each `:app-db` / `:sub` sample is elided for
+            ;; Each `:app-db` / `:sub` sample is elided for
             ;; off-box egress before it lands in the change-log (which
             ;; `read-recording` ships to the model). `elide-opts` carries
             ;; the gate-ON `:include-sensitive` opt-in; absent ⇒ the
@@ -3962,7 +3960,7 @@
      :frame    operating frame for :app-db / :sub signals. Defaults to the
                session's operating frame.
      :max-entries  drop-oldest ring cap on the change-log (default 2000).
-     :elide-opts  (rf2-8fin7.2) off-box-egress walker opts threaded into
+     :elide-opts  off-box-egress walker opts threaded into
                   every `:app-db` / `:sub` sample so a declared-sensitive
                   slot is redacted before it lands in the change-log
                   `read-recording` ships to the model. The MCP `record`
@@ -3975,7 +3973,7 @@
    frame policy but no frame can be resolved (multi-frame session, no
    selection) — read ops must not silently fall back to :rf/default.
    `:app-db` / `:sub` always need a frame (they read it); `:dom` / `:focus`
-   need one under the off-box gate (rf2-p9scds — their derived values are
+   need one under the off-box gate (their derived values are
    value-redacted against the frame's secrets, so the secret source must be
    pickable). Under the trusted-local gate (`--allow-sensitive-reads`) a
    `:dom` / `:focus`-only recording needs no frame (it ships raw)."
@@ -3983,9 +3981,9 @@
   (let [signals  (vec signals)
         gate-on? (:allow-raw-state? @raw-state-config)
         needs-frame? (some #(or (contains? % :app-db) (contains? % :sub)
-                                ;; rf2-p9scds — :dom / :focus are value-
-                                ;; redacted under the off-box gate, so they
-                                ;; need a frame to source the secret set.
+                                ;; :dom / :focus are value-redacted under the
+                                ;; off-box gate, so they need a frame to
+                                ;; source the secret set.
                                 (and (not gate-on?)
                                      (or (contains? % :dom) (contains? % :focus))))
                            signals)
@@ -4011,7 +4009,7 @@
                   :frame-id    frame-id
                   :stop        stop'
                   :max-entries (or max-entries default-recording-max-entries)
-                  ;; rf2-8fin7.2 — carried through each tick so `:app-db` /
+                  ;; Carried through each tick so `:app-db` /
                   ;; `:sub` samples are elided for off-box egress before
                   ;; landing in the change-log.
                   :elide-opts  elide-opts
@@ -4106,7 +4104,7 @@
 ;; Watch predicate matching
 ;; ---------------------------------------------------------------------------
 ;;
-;; Translated for re-frame2's :rf/epoch-record shape — :event-id and
+;; Matches against re-frame2's :rf/epoch-record shape — :event-id and
 ;; :trigger-event are top-level slots; :sub-runs / :renders / :effects
 ;; are pre-projected; the trace-events vector carries everything else.
 
@@ -4235,8 +4233,8 @@
    time this call returns.
 
    The response carries BOTH the full `:epoch` (the verbatim assembled
-   record — the trace mode's historical payload) AND a `:cascade-summary`
-   slot per rf2-6yqdl. Callers that only need the headline 'what
+   record — the trace mode's full payload) AND a `:cascade-summary`
+   slot. Callers that only need the headline 'what
    happened' read the compact summary; callers that need the raw
    trace-events / db-before / db-after pair read `:epoch`."
   ([event-v] (dispatch-and-collect event-v {}))
@@ -4248,7 +4246,7 @@
        result))))
 
 ;; ---------------------------------------------------------------------------
-;; Dispatch-and-settle (rf2-vk79g)
+;; Dispatch-and-settle
 ;; ---------------------------------------------------------------------------
 ;;
 ;; Closes the observe→drive loop SYNCHRONOUSLY in ONE call: dispatch →
@@ -4267,14 +4265,14 @@
 ;;     those land a tick later and re-fan into the record. Reading once,
 ;;     immediately, misses them.
 ;;
-;;   - The `:await-render` path (rf2-gfu33) flushes via
+;;   - The `:await-render` path flushes via
 ;;     `interop/after-render` — the rAF-scheduled, post-commit /
 ;;     pre-paint hook. It is ASYNC (returns a Promise the server awaits
 ;;     through the mailbox), and on a backgrounded / unfocused tab the
 ;;     underlying React lane commit is rAF-throttled, so it can stall.
 ;;
 ;;   - `dispatch-and-settle!` flushes via the substrate adapter's
-;;     `flush-render!` (rf2-40a84): React `flushSync` for the React-shaped
+;;     `flush-render!`: React `flushSync` for the React-shaped
 ;;     substrates, `reagent.core/flush` for the ratom family. NOT
 ;;     rAF-scheduled, so it commits even headless / backgrounded and is
 ;;     fully SYNCHRONOUS — no Promise, no mailbox. ZERO substrate
@@ -4308,8 +4306,8 @@
 
 (defn dispatch-and-settle!
   "Dispatch (origin :pair) and SYNCHRONOUSLY settle the view layer, then
-   return the assembled epoch INCLUDING the view-lifecycle signal
-   (rf2-vk79g). ONE call = dispatch → render → complete epoch.
+   return the assembled epoch INCLUDING the view-lifecycle signal.
+   ONE call = dispatch → render → complete epoch.
 
    Steps:
      1. `dispatch-sync` — run the cascade; the epoch records its db-diff,
@@ -4334,11 +4332,11 @@
                              when nothing mounted/unmounted (e.g. a no-op
                              dispatch or a state change no view reads).
      :cascade-summary      — the compact projection (its `:renders` count
-                             now reflects the flushed renders).
+                             reflects the flushed renders).
 
    On a frame-untargetable / no-epoch dispatch the `pair-dispatch-sync!`
-   `:ok? false` envelope rides through verbatim (the rf2-ldfnx invariant)
-   — NO flush is attempted (nothing settled).
+   `:ok? false` envelope rides through verbatim — NO flush is attempted
+   (nothing settled).
 
    The `flush-render!` call is a no-op-safe contract fn: under the
    plain-atom / SSR adapters (no live React commit) it returns nil and
@@ -4372,7 +4370,7 @@
 ;; Coarse-grained snapshot — one round-trip per investigate-X workflow.
 ;; ---------------------------------------------------------------------------
 ;;
-;; Many investigate-X tasks chain 5-10 reads — each currently a fresh nREPL
+;; Many investigate-X tasks chain 5-10 reads — each one a fresh nREPL
 ;; round-trip plus Claude-think latency. The runtime-side composer below
 ;; assembles every per-frame slice (:app-db, :sub-cache, :machines, :epochs,
 ;; :traces) in one CLJS eval, so the MCP `snapshot` op is a single bencode
@@ -4388,8 +4386,8 @@
 ;; is replaced with a `{:rf.mcp/summary {:type :map :keys [...] :count
 ;; ... :bytes ~...}}` marker carrying the top-level shape only. Callers
 ;; pass `:path [...]` to receive `(get-in db path)` (`:mode
-;; :path-sliced`); root `:path []` opts back into the full slice
-;; (equivalent to the legacy default). Out-of-range paths surface
+;; :path-sliced`); root `:path []` opts back into the full slice.
+;; Out-of-range paths surface
 ;; per-frame in a `:path-not-found` map with `:deepest-valid-prefix`
 ;; so the agent can re-aim. The `get-path` tool exposes the same
 ;; targeted-read primitive directly — `:exists?` distinguishes a path
@@ -4406,11 +4404,10 @@
     :app-db     (rf/app-db-value frame-id)
     :sub-cache  (subs-tooling/sub-cache-snapshot frame-id)
     ;; The global machine-id list is registrar-level (not per-frame).
-    ;; Per Spec 005 + rf2-eguy4 each frame holds its own machine
+    ;; Per Spec 005 each frame holds its own machine
     ;; snapshots at [:rf.runtime/machines :snapshots machine-id] in the
-    ;; RUNTIME-DB partition (EP-0001 rf2-vzld77 moved machine snapshots out
-    ;; of app-db :rf/runtime into the durable runtime-db partition — read
-    ;; via `rf/runtime-db-value`, NOT `rf/app-db-value`), so the per-frame
+    ;; durable RUNTIME-DB partition (read via `rf/runtime-db-value`, NOT
+    ;; `rf/app-db-value`), so the per-frame
     ;; slice returns {:ids [...] :state {machine-id snapshot}}.
     :machines   (let [ids (vec (machines/machines))
                       state (or (get-in (rf/runtime-db-value frame-id)
@@ -4418,12 +4415,10 @@
                                 {})]
                   {:ids ids :state state})
     :epochs     (vec (rf/epoch-history frame-id))
-    ;; Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame and
-    ;; cascade-bundle-shaped by default; rf2-mscih shifts this slot
-    ;; to deliver bundles (the storage unit) rather than the legacy
-    ;; flat-event stream, matching the cascade-bundle wire format
-    ;; emitted by the streaming subscribe surface (Tool-Pair §Reading
-    ;; the per-frame trace ring + Tool-Pair §`watch-epochs` /
+    ;; The trace ring is per-frame and cascade-bundle-shaped: this slot
+    ;; delivers bundles (the storage unit), matching the cascade-bundle
+    ;; wire format emitted by the streaming subscribe surface (Tool-Pair
+    ;; §Reading the per-frame trace ring + Tool-Pair §`watch-epochs` /
     ;; `trace-window` consumer shape).
     :traces     (vec (trace-tooling/trace-buffer frame-id))
     nil))
@@ -4443,8 +4438,8 @@
    Opts:
      :frames    Which frames to snapshot. One of:
                   :app  — the APP frames only (default): every registered
-                          frame with reserved `:rf/*` TOOL frames removed
-                          (rf2-3bu3d.6). `:rf/default` is an app frame and
+                          frame with reserved `:rf/*` TOOL frames removed.
+                          `:rf/default` is an app frame and
                           is retained (see `reserved-tool-frame?`). This is
                           the first-read default so a snapshot doesn't
                           OVERFLOW on Xray / Story / SSR tool-frame state.
@@ -4482,9 +4477,9 @@
    (ensure-trace-listener!)
    (ensure-epoch-listener!)
    (let [fids       (cond
-                      ;; rf2-3bu3d.6 — the DEFAULT scope is the APP frames
-                      ;; (reserved `:rf/*` tool frames excluded). `:all` is
-                      ;; the explicit opt-in to tool-frame state.
+                      ;; The DEFAULT scope is the APP frames (reserved
+                      ;; `:rf/*` tool frames excluded). `:all` is the
+                      ;; explicit opt-in to tool-frame state.
                       (= :app frames)      (app-frame-ids)
                       (= :all frames)      (vec (rf/frame-ids))
                       (sequential? frames) (vec frames)
@@ -4519,10 +4514,10 @@
         app-fids (app-frame-ids)]
     {:ok?                       true
      :session-id                session-id
-     ;; rf2-ertqw — the browser half of the freshness token rides on
+     ;; The browser half of the freshness token rides on
      ;; `health` so `discover-app` surfaces liveness in its very first
-     ;; call. `:runtime-instance-id` mirrors `:session-id` (kept under
-     ;; both names: `:session-id` is the historical sentinel slot, the
+     ;; call. `:runtime-instance-id` mirrors `:session-id` (carried under
+     ;; both names: `:session-id` is the sentinel slot, the
      ;; freshness vocabulary names it `:runtime-instance-id`);
      ;; `:runtime-loaded-at` is the stale-build cross-check input.
      :runtime-instance-id       session-id
@@ -4532,7 +4527,7 @@
      :coord-annotation-enabled? (coord-annotation-enabled?)
      :last-click-capture?       true
      :frames                    (vec fids)
-     ;; rf2-3bu3d.4 — the reserved-frame-aware view: registered frames
+     ;; The reserved-frame-aware view: registered frames
      ;; with `:rf/*` TOOL frames (Xray's `:rf/xray`, SSR slots, …)
      ;; removed. `:rf/default` is retained (it is an app frame). When this
      ;; holds exactly one id while `:frames` holds more, the session is
@@ -4541,7 +4536,7 @@
      :app-frames                app-fids
      :selected-frame            @selected-frame
      :operating-frame           (current-frame)
-     ;; rf2-3bu3d.4 — ambiguity counts APP frames, not raw frames. A
+     ;; Ambiguity counts APP frames, not raw frames. A
      ;; single-app session that ALSO carries an Xray (or other `:rf/*`
      ;; tool) frame has exactly one app frame, so it is NOT ambiguous and
      ;; pays no `frames/select` tax. Genuinely multi-app sessions (two-plus
@@ -4558,18 +4553,18 @@
      :pair-epoch-count          (count @pair-epoch-ids)}))
 
 ;; ---------------------------------------------------------------------------
-;; App-shape orientation summary (rf2-3bu3d.8)
+;; App-shape orientation summary
 ;; ---------------------------------------------------------------------------
 
 (def ^:private orient-registrar-kinds
   "The registrar kinds whose COUNTS the orientation summary reports — the
-   closed v1 registrar set (mirrors `handler-meta`'s `registrar-kinds`),
+   closed registrar set (mirrors `handler-meta`'s `registrar-kinds`),
    including `:interceptor` (the registered-interceptor kind — `reg-interceptor`
    stores a `{:before}` / `{:after}` / `{:factory}` descriptor under it; event/
-   frame `:interceptors` chains carry REFERENCES into this kind, EP-0022) so an
+   frame `:interceptors` chains carry REFERENCES into this kind) so an
    app using `reg-interceptor` surfaces its registered-interceptor count on
    first contact, and the three resources-artefact kinds (`:resource` /
-   `:mutation` / `:resource-scope`, EP-0016 / rf2-f8s9g6) so a resources-heavy
+   `:mutation` / `:resource-scope`) so a resources-heavy
    app's orientation summary names its cached-read / write / scope-resolver
    counts (zero on an app that uses none — `registrar-count` is defensively
    zero on an empty registrar). `:event` / `:sub` / `:fx` additionally
@@ -4587,12 +4582,12 @@
   (count (try (keys (rf/registrations kind)) (catch :default _ nil))))
 
 (defn- process-registry-view
-  "The PROCESS-WIDE registry view — counts for every v1 kind plus the full
-   sorted id vectors for the three most navigable kinds, off the process-global
-   registrar. The fallback orient uses when no single operating frame resolves
-   (a multi-frame ambiguous session, or a core that predates the EP-0023
-   frame-image-generation reads). `:basis :process` labels which registrar
-   these counts came from."
+  "The PROCESS-WIDE registry view — counts for every registrar kind plus the
+   full sorted id vectors for the three most navigable kinds, off the
+   process-global registrar. The fallback orient uses when no single operating
+   frame resolves (a multi-frame ambiguous session, or a core whose operating
+   frame carries no sealed image generation). `:basis :process` labels which
+   registrar these counts came from."
   []
   {:basis  :process
    :counts (into {} (map (fn [k] [k (registrar-count k)])) orient-registrar-kinds)
@@ -4603,12 +4598,12 @@
 (defn- frame-registry-view
   "The OPERATING-FRAME registry view — counts + the high-value id vectors
    resolved through `frame-id`'s OWN sealed image generation rather than the
-   process-wide registrar (rf2-srobm0). The same `(kind, id)` can resolve
+   process-wide registrar. The same `(kind, id)` can resolve
    differently per frame, so the SELECTED universe a frame actually runs is
    the registry an agent driving that frame should see — not the union of
    every namespace's registrations the flat registrar holds.
 
-   Routes through the PUBLIC `rf/frame-generation` read (rf2-wkw8na): the
+   Routes through the PUBLIC `rf/frame-generation` read: the
    resolver's `[kind id]` keys give the per-kind counts and the navigable id
    vectors directly off the generation. `:basis :frame` + `:frame` label
    which frame these counts resolved through. Returns nil when the frame does
@@ -4631,13 +4626,12 @@
          :subs   (ids-of :sub)
          :fx     (ids-of :fx)})
       ;; A frame that does not carry a generation (`:rf.error/frame-no-
-      ;; generation`) means this core predates the EP-0023 reads, or the
-      ;; operating frame has no sealed image. Fall back to the process view
-      ;; rather than fail the whole orientation.
+      ;; generation`) is an imageless frame with no sealed image. Fall back
+      ;; to the process view rather than fail the whole orientation.
       (catch :default _ nil))))
 
 (defn orient
-  "App-shape orientation summary (rf2-3bu3d.8) — answer 'what is this app
+  "App-shape orientation summary — answer 'what is this app
    and what can I drive?' in ONE round-trip.
 
    When an agent connects to an UNFAMILIAR app, orienting otherwise takes
@@ -4654,29 +4648,29 @@
                       `frames-list` view (reserved `:rf/*` tool frames
                       split out via `app-frame-ids`). `:all` / `:app` /
                       `:operating` are the PUBLIC frame addressing surface
-                      (EP-0023 image -> frame -> event stream).
+                      (the image -> frame -> event stream model).
      :app-db-top-keys {<app-frame-id> [<top-level key> ...]} — the
                       top-level app-db keys per APP frame (the cheap
                       'what state shape is this' read; drill with
                       `get-path` / `snapshot`). Tool frames are excluded
-                      (rf2-3bu3d.6 posture) so the summary doesn't
+                      so the summary doesn't
                       overflow on Xray/SSR inspection state.
      :registry        {:basis :frame|:process :frame <id>?
                        :counts {<kind> N ...}
                        :events [...] :subs [...] :fx [...]} — registrar
-                      COUNTS for every v1 kind, plus the full sorted id
+                      COUNTS for every kind, plus the full sorted id
                       vectors for the three most navigable kinds. Drill
                       any other kind via `list-handlers {kind ...}`.
                       RE-BASED on the OPERATING FRAME's resolved image
-                      generation when a single operating frame resolves
-                      (rf2-srobm0, EP-0023) — the SELECTED universe that
+                      generation when a single operating frame resolves —
+                      the SELECTED universe that
                       frame actually runs, not the process-wide registrar
                       union (the same `(kind, id)` can resolve differently
                       per frame). `:basis :frame` + `:frame <id>` name the
                       resolution; falls back to `:basis :process` (the
                       process-wide registrar counts) in a multi-frame
-                      ambiguous session or against a core predating the
-                      EP-0023 frame-image-generation reads.
+                      ambiguous session or against an operating frame that
+                      carries no sealed image generation.
      :machines        the registered machine ids (`rf/machines`).
 
    Compact + summarized by design (respect the wire cap): counts + the
@@ -4689,10 +4683,10 @@
   (let [h        (health)
         app-fids (app-frame-ids)
         op-frame (:operating-frame h)
-        ;; rf2-srobm0 — re-base the registry on the OPERATING FRAME's resolved
+        ;; Re-base the registry on the OPERATING FRAME's resolved
         ;; image generation when one resolves; fall back to the process-wide
-        ;; registrar counts otherwise (ambiguous multi-frame session, or a core
-        ;; predating the EP-0023 frame-image-generation reads).
+        ;; registrar counts otherwise (ambiguous multi-frame session, or an
+        ;; operating frame with no sealed image generation).
         registry (or (frame-registry-view op-frame) (process-registry-view))]
     {:ok?      true
      :liveness {:debug-enabled?      (:debug-enabled? h)

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -30,11 +30,10 @@
 ;;;;
 ;;;; Naming surfaces — MCP vs runtime.
 ;;;;
-;;;;   re-frame2-pair-mcp deliberately carries TWO vocabularies for the
-;;;;   same logical surface: the MCP tool catalogue (operator-facing,
-;;;;   disciplined to the cross-MCP NAMING.md `list-<things>` verb
-;;;;   shape) and the runtime fn surface in THIS ns +
-;;;;   `re-frame.core` (historical names, kept as-is). Rename pairs:
+;;;;   re-frame2-pair-mcp carries TWO vocabularies for the same logical
+;;;;   surface: the MCP tool catalogue (operator-facing, disciplined to the
+;;;;   cross-MCP NAMING.md `list-<things>` verb shape) and the runtime fn
+;;;;   surface in THIS ns + `re-frame.core`. The pairs:
 ;;;;
 ;;;;     | MCP tool name           | Runtime fn name             |
 ;;;;     |-------------------------|-----------------------------|
@@ -44,25 +43,21 @@
 ;;;;     | `read-dom`              | `dom-read`                  |
 ;;;;     | `read-ui`               | `ui-read`                   |
 ;;;;
-;;;;   (rf2-q0r7e: `read-dom` and `read-ui` share one DOM-read core —
-;;;;   `node->content` — and both ship a thin `(…/dom-read …)` /
-;;;;   `(…/ui-read …)` call via the same eval-form plumbing, so neither
-;;;;   op's eval form can rot independently.)
-;;;;
-;;;;   (rf2-qicji: `list-subscriptions` reads the live reactive
-;;;;   sub-cache via `sub-cache-info`; the streaming-tap diagnostic it
-;;;;   formerly carried moved to `list-streams`, still wrapping
-;;;;   `subscription-info`.)
+;;;;   `read-dom` and `read-ui` share one DOM-read core (`node->content`),
+;;;;   and both ship a thin `(…/dom-read …)` / `(…/ui-read …)` call via the
+;;;;   same eval-form plumbing, so neither op's eval form can rot
+;;;;   independently. `list-subscriptions` reads the live reactive sub-cache
+;;;;   via `sub-cache-info`; `list-streams` carries the streaming-tap
+;;;;   diagnostic, wrapping `subscription-info`.
 ;;;;
 ;;;;   An agent generating an eval form via `eval-cljs` uses the
 ;;;;   right-hand column; the same agent calling the MCP tool surface
-;;;;   uses the left-hand column. The split is deliberate (the rename
-;;;;   stops at the MCP boundary — the runtime's audience
+;;;;   uses the left-hand column. The split is deliberate: the verb
+;;;;   discipline stops at the MCP boundary — the runtime's audience
 ;;;;   is smaller than the MCP surface, and a runtime rename ripples
-;;;;   into every eval-form caller). This paragraph documents the
-;;;;   asymmetry so it's discoverable rather than inherited-from-
-;;;;   history; see `spec/Principles.md` §"Tool verbs follow the
-;;;;   cross-MCP convention" for the policy rationale.
+;;;;   into every eval-form caller. This paragraph documents the
+;;;;   asymmetry so it's discoverable; see `spec/Principles.md` §"Tool
+;;;;   verbs follow the cross-MCP convention" for the policy rationale.
 
 (ns re-frame2-pair.runtime
   (:require [re-frame.core :as rf]
@@ -81,20 +76,20 @@
             ;; dev-only, so requiring the tooling ns directly here is
             ;; bundle-isolation-safe.
             [re-frame.trace.tooling :as trace-tooling]
-            ;; rf2-7737vq — the canonical RAW trace-event frame reader
+            ;; The canonical RAW trace-event frame reader
             ;; (`re-frame.trace/trace-event-frame`). Owned by the trace
             ;; contract ns; `re-frame.trace` is already loaded via
             ;; `re-frame.core` above, so this require adds no bundle weight
             ;; (dev-tier preload — bundle-isolation-safe).
             [re-frame.trace :as trace]
             ;; `flush-render!` (the SYNCHRONOUS render-commit contract fn,
-            ;; Spec 006 §`flush-render!`, rf2-40a84) lives in
+            ;; Spec 006 §`flush-render!`) lives in
             ;; re-frame.substrate.adapter, not re-frame.core. It resolves
             ;; the INSTALLED adapter via `require-adapter!` and routes the
             ;; flush through that adapter's substrate-native impl (React
             ;; `flushSync` for the React-shaped substrates; `reagent.core/
             ;; flush` for the ratom family) — ZERO substrate hardcoding here.
-            ;; `dispatch-and-settle!` (rf2-vk79g) calls it to flush pending
+            ;; `dispatch-and-settle!` calls it to flush pending
             ;; renders/unmounts synchronously so their `:rf.view/render` /
             ;; `:rf.view/unmounted` traces land in (and re-fan back to the
             ;; causing) epoch before we re-read it. Dev-tier preload, so the
@@ -103,16 +98,15 @@
             [re-frame.interop :as interop]
             ;; `parse-source-coord` (the canonical inverse of
             ;; `format-source-coord`) is the source-coord contract owner's
-            ;; parser for the `data-rf2-source-coord` DOM attribute (rf2-nr7vf2).
-            ;; The pair preload used to carry a near-byte-for-byte copy of this
-            ;; parser; it now routes through the one canonical impl in core.
+            ;; parser for the `data-rf2-source-coord` DOM attribute. The pair
+            ;; preload routes through this one canonical impl in core.
             ;; Dev-tier preload, so the direct require is bundle-isolation-safe.
             [re-frame.source-coords :as source-coords]
             [clojure.data :as data]
             [clojure.set :as set]
             [clojure.string :as str]
             ;; cljs.reader is load-bearing for the eval-cljs typed result
-            ;; codec (rf2-qobqy): both `re-frame2-pair-mcp.tools.result-envelope/
+            ;; codec: both `re-frame2-pair-mcp.tools.result-envelope/
             ;; wrap-form` (the DEFAULT eval path) and `…tools.await-promise/
             ;; read-mailbox-form` (the `:await true` path) emit wrapper
             ;; source that calls `cljs.reader/read-string` to round-trip-
@@ -121,11 +115,9 @@
             ;; this require shadow's `cljs-eval` resolves the wrapper's
             ;; `cljs.reader/read-string` as an :undeclared-var, returns an
             ;; empty `:results`, and the server reads the blank value as a
-            ;; bare `nil` — collapsing EVERY wrapped eval to `:value nil`
-            ;; (the exact regression the typed codec exists to PREVENT; it
-            ;; turned the live-overflow conformance gate RED because the
-            ;; over-budget string came back as nil and the cap never tripped).
-            ;; The runtime preload is the codec's guaranteed-present
+            ;; bare `nil` — collapsing EVERY wrapped eval to `:value nil`.
+            ;; The require keeps the symbol resolvable so the codec round-
+            ;; trips correctly. The runtime preload is the codec's guaranteed-present
             ;; substrate (re-frame2-pair-mcp refuses every tool with
             ;; `:runtime-not-preloaded` when this ns is absent), so pinning
             ;; the require here makes the symbol resolvable in every app the
@@ -155,12 +147,12 @@
 ;; not a per-call `(js/Date.now)`), so it answers "when did the running
 ;; code actually load?" rather than "what time is it now?".
 ;;
-;; This is the browser half of the stale-BUILD detector (rf2-ertqw):
+;; This is the browser half of the stale-BUILD detector:
 ;; `discover-app` cross-checks it against the JVM-side build's last
 ;; compile/flush timestamp. If the build recompiled AFTER this stamp,
 ;; the browser tab is serving OLD code (a hot-reload didn't land, or a
-;; stale incremental build is being served) — the exact silent failure
-;; mode that drove the rf2-lo28u stale-build false-alarm detour. A full
+;; stale incremental build is being served) — a silent failure mode the
+;; detector catches before an agent reasons off stale code. A full
 ;; page refresh re-evaluates the namespace and re-mints both `session-id`
 ;; and this stamp, so a fresh load reads as fresh.
 (def loaded-at
@@ -190,7 +182,7 @@
    :installed  loaded-at})
 
 ;; ---------------------------------------------------------------------------
-;; Freshness / liveness token (rf2-ertqw)
+;; Freshness / liveness token
 ;; ---------------------------------------------------------------------------
 ;;
 ;; A pair session is a THIN runtime-direct reader, not a stateful proxy.
@@ -219,7 +211,7 @@
 ;; the JVM holds the shadow-cljs worker state.
 
 (defn freshness
-  "The browser-runtime half of the freshness/liveness token (rf2-ertqw).
+  "The browser-runtime half of the freshness/liveness token.
    Cheap — three scalar reads, no app-db walk, no listener install. The
    MCP server merges this with the JVM-side build/heartbeat half.
 
@@ -241,7 +233,7 @@
 ;; Mutating ops refuse with :ambiguous-frame when more than one APP frame
 ;; is registered and the session hasn't selected one.
 ;;
-;; Reserved-frame-aware resolution (rf2-3bu3d.4)
+;; Reserved-frame-aware resolution
 ;; ---------------------------------------------
 ;;
 ;; A pairing session almost always runs against an app that ALSO carries
@@ -249,19 +241,19 @@
 ;; build, an SSR slot. Those frames live under the framework-reserved
 ;; `:rf/*` root (spec/Conventions.md §Reserved namespaces). They are NOT
 ;; the app the operator is pairing against; they are devtool surfaces the
-;; tooling itself mounted. Counting them toward ambiguity meant every
-;; Xray-instrumented app (the common case) was "ambiguous" on the first
+;; tooling itself mounted. Counting them toward ambiguity would make every
+;; Xray-instrumented app (the common case) "ambiguous" on the first
 ;; mutating op — forcing a `frames/select` + retry up front for no real
 ;; choice (there is exactly one APP frame; the other is a tool frame).
 ;;
 ;; So the resolver is RESERVED-FRAME-AWARE: a `:rf/*`-namespaced frame is
 ;; a tool frame and is EXCLUDED from the ambiguity count, with ONE
 ;; deliberate exception — `:rf/default`, which per Conventions.md §Reserved
-;; namespaces (EP-0002) is an ordinary app frame id with no framework
-;; privilege. It is an APP frame, not a tool frame, despite sharing the
-;; `:rf/*` root. We key off the reserved-namespace RULE (namespace = "rf",
-;; minus the `:rf/default` carve-out), never a literal `:rf/xray`, so the
-;; behaviour holds for any tool frame any project mounts under `:rf/*`.
+;; namespaces is an ordinary app frame id with no framework privilege. It
+;; is an APP frame, not a tool frame, despite sharing the `:rf/*` root. We
+;; key off the reserved-namespace RULE (namespace = "rf", minus the
+;; `:rf/default` carve-out), never a literal `:rf/xray`, so the behaviour
+;; holds for any tool frame any project mounts under `:rf/*`.
 ;;
 ;; When exactly one APP frame remains after excluding tool frames, tier 3
 ;; AUTO-SELECTS it: single-app + Xray is unambiguous with no `frames/
@@ -289,10 +281,9 @@
    §Reserved namespaces — framework-owned ids live under the single `:rf/*`
    root), NOT a hardcoded id, so it holds for every `:rf/*` tool frame any
    project mounts. The SOLE carve-out is `:rf/default`: per Conventions.md
-   §Reserved namespaces (EP-0002) it is an ordinary app frame id with no
-   framework privilege — it shares the `:rf/*` root but is a normal app
-   frame an app may explicitly register, so it is never treated as a tool
-   frame.
+   §Reserved namespaces it is an ordinary app frame id with no framework
+   privilege — it shares the `:rf/*` root but is a normal app frame an app
+   may explicitly register, so it is never treated as a tool frame.
 
    Non-keyword / un-namespaced ids (a user's `:stories`, `:sandbox`) are
    app frames and return false."
@@ -303,7 +294,7 @@
 
 (defn app-frame-ids
   "The registered APP frame ids — `(rf/frame-ids)` with `:rf/*` reserved TOOL
-   frames removed (rf2-3bu3d.4). `:rf/default` is retained (it is an app frame;
+   frames removed. `:rf/default` is retained (it is an app frame;
    see `reserved-tool-frame?`). The order/source mirrors `(rf/frame-ids)`."
   []
   (vec (remove reserved-tool-frame? (rf/frame-ids))))
@@ -312,7 +303,7 @@
   "Resolve the operating frame: explicit override -> session pin ->
    the sole registered APP frame -> nil (ambiguous).
 
-   Tier 3 is reserved-frame-aware (rf2-3bu3d.4): `:rf/*` TOOL frames (Xray's
+   Tier 3 is reserved-frame-aware: `:rf/*` TOOL frames (Xray's
    `:rf/xray`, SSR slots, …) are EXCLUDED, so a single-app session that ALSO
    carries an Xray frame resolves to the one app frame instead of refusing.
    `:rf/default` is an app frame and is retained (see `reserved-tool-frame?`).
@@ -331,9 +322,9 @@
 
 (defn frames-list
   "All registered, non-destroyed frame ids plus the operating frame (the
-   PUBLIC address — EP-0023's image -> frame -> event stream).
+   PUBLIC address — the image -> frame -> event stream model).
 
-   `:app-frames` exposes the reserved-frame-aware view (rf2-3bu3d.4): the
+   `:app-frames` exposes the reserved-frame-aware view: the
    registered frames with `:rf/*` tool frames removed. When it holds exactly
    one id while `:frames` holds more, the session is single-app-plus-tool-frame
    and `:operating` auto-resolved to that lone app frame (no `select-frame!`
@@ -356,15 +347,14 @@
       {:ok? false :reason :no-such-frame :frame-id id}))
 
 ;; ---------------------------------------------------------------------------
-;; Ambiguous-frame diagnostics (rf2-n58jxo)
+;; Ambiguous-frame diagnostics
 ;;
 ;; A read/mutate op that can't resolve a single operating frame in a
-;; multi-frame session used to refuse with a bare `{:ok? false :reason
-;; :ambiguous-frame :hint "..."}` — no operation name, no available-frame
-;; list, no current-frame context. An agent then had to round-trip
-;; `frames-list` (or `discover-app`) just to learn WHICH frames it could
-;; pick from and HOW to pin one. `ambiguous-frame-error` builds the
-;; enriched envelope once so every refusal site carries:
+;; multi-frame session refuses with an ENRICHED envelope so the agent can
+;; recover without a round-trip to `frames-list` / `discover-app` just to
+;; learn WHICH frames it can pick from and HOW to pin one.
+;; `ambiguous-frame-error` builds that envelope once so every refusal site
+;; carries:
 ;;
 ;;   :operation       the op that refused (`:dispatch`, `:read-sub`, …) —
 ;;                    the machine handle for the failing call.
@@ -377,13 +367,13 @@
 ;;   :hint             the human sentence + the concrete fix (pass `frame`
 ;;                    or pin via `select-frame!` / `set-operating-frame`).
 ;;
-;; `:reason :ambiguous-frame` stays the SOLE machine discriminator (the
-;; documented bare-dialect reason, Tool-Catalogue §307) — the new slots
-;; are additive context, never a discriminator change.
+;; `:reason :ambiguous-frame` is the SOLE machine discriminator (the
+;; documented bare-dialect reason, Tool-Catalogue §307) — the other slots
+;; are additive context only, not part of the discriminator.
 ;; ---------------------------------------------------------------------------
 
 (defn ambiguous-frame-error
-  "Build the enriched `:ambiguous-frame` refusal envelope (rf2-n58jxo).
+  "Build the enriched `:ambiguous-frame` refusal envelope.
    `operation` is the refusing op keyword; `extra` (optional) carries the
    op-specific context the caller knows — `:event`, `:query`, `:query-v`.
    The envelope always carries the available app frames, the current session
@@ -432,29 +422,28 @@
 ;; The MCP server (`tools/re-frame2-pair-mcp/`) carries a
 ;; `--allow-sensitive-reads` boot gate (default OFF; CLI flag name
 ;; aligned across MCP servers). The internal Clojure keyword
-;; `:allow-raw-state?` below is the implementation-side identifier and
-;; retains the legacy name. When OFF, the runtime MUST default-elide
-;; any verbatim app-db value before emitting it through `tap>` —
-;; otherwise an `app-db-reset!` log entry would surface the same raw
-;; payload that the wire path already redacts.
+;; `:allow-raw-state?` below is the implementation-side identifier. When
+;; OFF, the runtime MUST default-elide any verbatim app-db value before
+;; emitting it through `tap>` — otherwise an `app-db-reset!` log entry
+;; would surface the same raw payload that the wire path already redacts.
 ;;
 ;; The MCP server signals the runtime once per build per server lifetime
 ;; via `(configure-raw-state! {:allow-raw-state? bool})`. The flag is
-;; consulted by `app-db-reset!` (and any future raw-state tap site)
+;; consulted by `app-db-reset!` (and any other raw-state tap site)
 ;; before deciding whether to ship verbatim payloads or run them through
 ;; `re-frame.core/elide-wire-value`.
 ;;
-;; Default OFF — a runtime loaded into an app without a re-frame2-pair-mcp server
-;; sees the gate as "raw allowed", which preserves the original behaviour
-;; for direct CLJS callers (developer at the REPL invoking
-;; `app-db-reset!`). The re-frame2-pair-mcp server flips it on first tool use to
-;; "raw gated" when its own boot flag is OFF.
+;; Default raw-allowed — a runtime loaded into an app without a
+;; re-frame2-pair-mcp server sees the gate as "raw allowed", so a direct
+;; CLJS caller (developer at the REPL invoking `app-db-reset!`) gets
+;; verbatim payloads. When a re-frame2-pair-mcp server attaches with its
+;; own boot flag OFF, it flips the gate to "raw gated" on first tool use.
 
 (defonce ^:private raw-state-config
   ;; {:allow-raw-state? bool}
   ;; Default true — raw `tap>` payloads ride unmodified UNTIL the MCP
   ;; server signals otherwise. A bare CLJS REPL session (no re-frame2-pair-mcp
-  ;; attached) sees the legacy verbatim behaviour.
+  ;; attached) sees verbatim payloads.
   (atom {:allow-raw-state? true}))
 
 (defn configure-raw-state!
@@ -498,8 +487,7 @@
 
 (defn- maybe-redact-derived
   "Value-redact a DERIVED `tree` (rendered DOM text / an attribute map / a
-  focus descriptor) for off-box egress (rf2-i783h0, the rf2-p9scds DOM /
-  readback finding).
+  focus descriptor) for off-box egress.
 
   The path-based `elide-wire-value` walker redacts by DECLARED app-db path —
   but rendered DOM text / attribute values sit at a NON-app-db position the
@@ -542,8 +530,7 @@
    `tap>` so the human sees what the agent changed.
 
    Delegates to the canonical Tool-Pair write surface
-   `(rf/replace-app-db! frame-id v)` (Tool-Pair §Pair-tool writes;
-   renamed from `rf/reset-frame-db!`, EP-0001 rf2-tfepxu).
+   `(rf/replace-app-db! frame-id v)` (Tool-Pair §Pair-tool writes).
    That surface bypasses the dispatch loop (no event, no
    cascade) but DOES record a synthetic `:rf/epoch-record` with
    `:event-id :rf.epoch/db-replaced` so that `restore-epoch` can
@@ -558,7 +545,7 @@
    Operators who passed `--allow-sensitive-reads` see verbatim payloads.
 
    Returns `{:ok? true :frame frame-id :cascade-summary {...}}` on
-   success. The cascade-summary slot (rf2-6yqdl) projects the synthetic
+   success. The cascade-summary slot projects the synthetic
    `:rf.epoch/db-replaced` epoch the framework just recorded — the
    `:event-id` is `:rf.epoch/db-replaced`, `:db-diff` summarises the
    before-vs-after delta at depth 1, and `:fx-fired` is empty (state
@@ -579,10 +566,10 @@
           :t                  (js/Date.now)})
    (try
      (if (rf/replace-app-db! frame-id v)
-       ;; Per rf2-6yqdl: surface the synthetic `:rf.epoch/db-replaced`
-       ;; epoch the framework just appended (Tool-Pair §Pair-tool writes).
-       ;; The new head IS this epoch by construction; reading the
-       ;; history head is the canonical way to project it.
+       ;; Surface the synthetic `:rf.epoch/db-replaced` epoch the
+       ;; framework just appended (Tool-Pair §Pair-tool writes). The new
+       ;; head IS this epoch by construction; reading the history head is
+       ;; the canonical way to project it.
        (let [head-id (some-> (rf/epoch-history frame-id) peek :epoch-id)]
          (attach-cascade {:ok? true :frame frame-id :epoch-id head-id}
                          frame-id head-id))
@@ -623,7 +610,7 @@
   (-> (rf/registrations kind) keys sort vec))
 
 ;; ---------------------------------------------------------------------------
-;; Call-time id validation (rf2-3bu3d.3)
+;; Call-time id validation
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The MCP wire boundary parses an event-vec / sub-vec / frame-id once,
@@ -633,8 +620,8 @@
 ;; principle, spec/Conventions.md, applied to the wire). The validation
 ;; is runtime-side because only the runtime holds the live registrar.
 ;;
-;; Complements rf2-sofwv (which generates/validates tool DESCRIPTORS from
-;; the registries at attach time) — this is the CALL-TIME VALUE check.
+;; This is the CALL-TIME VALUE check; it complements the attach-time pass
+;; that generates and validates tool DESCRIPTORS from the registries.
 
 (defn- levenshtein
   "Edit distance between two strings — the nearest-match ranking metric.
@@ -676,7 +663,7 @@
 
 (defn validate-registered
   "Validate that `id` is registered under registrar `kind` against the
-   LIVE registry (rf2-3bu3d.3). Returns:
+   LIVE registry. Returns:
 
      {:ok? true  :kind kind :id id}                         — registered
      {:ok? false :reason :unknown-id :kind kind :id id
@@ -706,8 +693,8 @@
                              "; nothing is registered under " kind "."))}))))
 
 (defn validate-event-id
-  "Validate the head of an event vector against the `:event` registrar
-   (rf2-3bu3d.3). `event-v` is the parsed event vector; the id is its
+  "Validate the head of an event vector against the `:event` registrar.
+   `event-v` is the parsed event vector; the id is its
    first element. Returns the `validate-registered` shape, plus echoes
    the `:event` vector so the wire result carries the resolved value."
   [event-v]
@@ -717,15 +704,15 @@
 
 (defn validate-sub-id
   "Validate the head of a subscription query-vector against the `:sub`
-   registrar (rf2-3bu3d.7). `query-v` is the parsed sub vector; the id is
+   registrar. `query-v` is the parsed sub vector; the id is
    its first element. Returns the `validate-registered` shape, plus echoes
    the `:query-v` so the wire result carries the resolved value.
 
    The read-side counterpart of `validate-event-id`: a typo'd sub-id
    (`[:current-userr]`) returns `:reason :unknown-id` with `:nearest`
    matches instead of silently subscribing to a non-existent sub and
-   handing back nil/garbage (the typo-silent-nil mistake class the raw
-   `eval-cljs` read invited)."
+   handing back nil/garbage (the typo-silent-nil mistake class a raw
+   `eval-cljs` read invites)."
   [query-v]
   (let [id (when (sequential? query-v) (first query-v))
         r  (validate-registered :sub id)]
@@ -740,9 +727,9 @@
 (def ^:private fn-slot-sentinel
   "Readable EDN placeholder substituted for a Function value anywhere in a
    handler-meta map. `pr-str` of a raw Function emits `#object[Function …]`
-   — unreadable EDN on the MCP wire (rf2-l7vnd), and the result-envelope
-   codec then tags the WHOLE response `:unserializable`, hiding the
-   serializable structure around it. Replacing each fn with this keyword
+   — unreadable EDN on the MCP wire, and the result-envelope codec then
+   tags the WHOLE response `:unserializable`, hiding the serializable
+   structure around it. Replacing each fn with this keyword
    keeps the map EDN-clean while still surfacing THAT a fn slot is declared
    — so an agent reads the shape (e.g. a resource-scope's `:inputs` map,
    `:whole-db?` flag, or a mutation's declared `:invalidates`/`:populates`)
@@ -758,7 +745,7 @@
 
    This is the general counterpart to the top-level `:handler-fn` dissoc:
    the resources-artefact kinds (`:resource` / `:mutation` /
-   `:resource-scope`, EP-0016) store their spec under `:rf/resource` /
+   `:resource-scope`) store their spec under `:rf/resource` /
    `:rf/mutation` / `:rf/resource-scope` with NESTED fns (`:request`,
    `:tags`, `:invalidates`, `:populates`, `:resolve`). The top-level dissoc
    alone leaves those nested handles in the map, so the response would still
@@ -783,24 +770,21 @@
 
    Augments with :handler-fn-hash for use as a probe over hot-reload.
 
-   rf2-l7vnd: the :handler-fn slot carries a raw Function. `pr-str` of a
-   Function emits `#object[Function ...]` — unreadable EDN on the MCP
-   wire, which made the tool's read-back fall to a string and the
-   handler-meta envelope misreport :unexpected-shape. The hash already
-   covers every hot-reload probing use; the raw fn ref had no surviving
-   on-the-wire consumer. Drop it before returning so the response is
-   EDN-clean by construction.
+   The raw :handler-fn slot is a Function, and `pr-str` of a Function
+   emits `#object[Function ...]` — unreadable EDN on the MCP wire that
+   would tag the whole handler-meta envelope :unexpected-shape. The hash
+   covers every hot-reload probing use, so the raw fn ref is dropped
+   before returning, leaving the response EDN-clean by construction.
 
-   rf2-f8s9g6 (EP-0016 prop-3): the resources-artefact kinds store their
-   spec under `:rf/resource` / `:rf/mutation` / `:rf/resource-scope` with
-   NESTED handler fns (`:request`, `:tags`, `:invalidates`, `:populates`,
-   `:resolve`). Dropping only the top-level `:handler-fn` leaves those
-   nested handles, so the response would still trip the wire codec's
+   The resources-artefact kinds store their spec under `:rf/resource` /
+   `:rf/mutation` / `:rf/resource-scope` with NESTED handler fns
+   (`:request`, `:tags`, `:invalidates`, `:populates`, `:resolve`).
+   Dropping only the top-level `:handler-fn` would leave those nested
+   handles, so the response would still trip the wire codec's
    `:unserializable` path. `strip-fns` replaces every fn at any depth with
    the readable `:rf/fn` sentinel, so the serializable structure (a
-   resource-scope's `:inputs` map + `:whole-db?` flag — the EP-0016
-   disposition-2 inspectability promise — a mutation's declared
-   consequences, a resource's scope policy) survives on the wire."
+   resource-scope's `:inputs` map + `:whole-db?` flag, a mutation's
+   declared consequences, a resource's scope policy) survives on the wire."
   [kind id]
   (if-let [m (rf/handler-meta kind id)]
     (-> m
@@ -817,22 +801,21 @@
   (handler-fn-hash (rf/handler-meta kind id)))
 
 ;; ---------------------------------------------------------------------------
-;; Frame-derived registrar introspection (EP-0023, rf2-srobm0)
+;; Frame-derived registrar introspection
 ;;
-;; The forward EP-0023 direction: a frame's inspectable registration set is its
-;; RESOLVED IMAGE GENERATION — the same `(kind, id)` can resolve DIFFERENTLY per
-;; frame (two frames running different images each resolve their own
-;; descriptor). The process-global registrar reads above answer "what is
-;; registered process-globally"; these answer "what does THIS FRAME's running
-;; image resolve `(kind, id)` to" — keyed off the frame's sealed generation,
-;; not the process-global registrar.
+;; A frame's inspectable registration set is its RESOLVED IMAGE GENERATION —
+;; the same `(kind, id)` can resolve DIFFERENTLY per frame (two frames running
+;; different images each resolve their own descriptor). The process-global
+;; registrar reads above answer "what is registered process-globally"; these
+;; answer "what does THIS FRAME's running image resolve `(kind, id)` to" —
+;; keyed off the frame's sealed generation, not the process-global registrar.
 ;;
-;; They consume ONLY the PUBLIC facade reads shipped by rf2-wkw8na — the
+;; They consume ONLY the PUBLIC facade reads — the
 ;; `{:frame f :kind k …}` arities of `rf/registrations` / `rf/handler-meta` /
-;; `rf/handler-ids`, and `rf/frame-generation`. EP-0023 forbids tools from
-;; consuming `re-frame.live-frame` / `re-frame.image-assembly` internals
-;; directly; the facade re-surfaces the BEHAVIOUR through these reads, so this
-;; preload stays on the public surface.
+;; `rf/handler-ids`, and `rf/frame-generation`. Tools must not consume
+;; `re-frame.live-frame` / `re-frame.image-assembly` internals directly; the
+;; facade re-surfaces the BEHAVIOUR through these reads, so this preload stays
+;; on the public surface.
 ;;
 ;; PROVENANCE: a resolved descriptor carries the source coordinate that
 ;; identifies where the winning registration came from — `:rf.provenance/ns`
@@ -848,7 +831,7 @@
 (defn- coordinate-summary
   "The provenance/standard coordinate facts a resolved descriptor carries,
    as a small EDN-clean map (or nil when the descriptor carries none — a
-   pre-EP-0023 / process-global meta map). Surfaces WHICH source won the
+   process-global meta map). Surfaces WHICH source won the
    `(kind, id)` resolution:
 
      {:source :registered :ns \"my.app.events\"}      a registered descriptor
@@ -876,8 +859,7 @@
   "Per-FRAME handler metadata for `(kind, id)` — the registration resolved
    through frame `frame-id`'s OWN sealed image generation (NOT the
    process-global registrar). Routes through the PUBLIC facade read
-   `(rf/handler-meta {:frame f :kind k :id id})` (rf2-wkw8na); EP-0023 §Frame-
-   derived live registration resolution.
+   `(rf/handler-meta {:frame f :kind k :id id})`.
 
    Surfaces the resolved descriptor's `:rf.provenance/ns` + inline/image +
    `:standard` facts the process-global reads can't — plus a normalized
@@ -904,7 +886,7 @@
   "Enumerate the ids registered under `kind` resolved through frame
    `frame-id`'s OWN image generation — only the ids that frame's image
    carries (NOT the process-global registrar). Routes through the PUBLIC facade
-   read `(rf/handler-ids {:frame f :kind k})` (rf2-wkw8na). Returns the sorted
+   read `(rf/handler-ids {:frame f :kind k})`. Returns the sorted
    id vector. FAILS LOUD up the eval boundary on an unresolvable frame."
   [frame-id kind]
   (-> (rf/handler-ids {:frame frame-id :kind kind}) sort vec))
@@ -912,8 +894,8 @@
 (defn frame-registrar-registrations
   "The `{id meta}` map for `kind` resolved through frame `frame-id`'s OWN image
    generation, each meta carrying its provenance/coordinate facts. Routes
-   through the PUBLIC facade read `(rf/registrations {:frame f :kind k})`
-   (rf2-wkw8na). Fns are stripped (the `:rf/fn` sentinel) so the map is
+   through the PUBLIC facade read `(rf/registrations {:frame f :kind k})`.
+   Fns are stripped (the `:rf/fn` sentinel) so the map is
    EDN-clean. FAILS LOUD up the eval boundary on an unresolvable frame."
   [frame-id kind]
   (reduce-kv
@@ -940,11 +922,10 @@
   (-> (rf/frame-generation frame-id) :rf.gen/requires sort vec))
 
 (defn describe-image
-  "Describe the IMAGE GENERATION a frame is running — the EP-0023 Use-Case 7
-   read (Ref-Plan item 17). Answers \"what behaviour does THIS frame run, and
-   where did each piece come from?\" in one round-trip, over the PUBLIC
-   `rf/frame-generation` read (rf2-wkw8na); EP-0023 forbids consuming the
-   `re-frame.image-assembly` internals directly.
+  "Describe the IMAGE GENERATION a frame is running. Answers \"what
+   behaviour does THIS frame run, and where did each piece come from?\" in
+   one round-trip, over the PUBLIC `rf/frame-generation` read; tools must
+   not consume the `re-frame.image-assembly` internals directly.
 
    Frame resolution mirrors every other read op: no-arg / `{:frame nil}` uses
    the OPERATING frame, an explicit `:frame` targets that frame. Returns
@@ -974,7 +955,7 @@
 
    `:include-ns?` (default false) gates the per-registration provenance map.
 
-   NO-GENERATION FRAME (post-EP-0024): only an EXPLICIT `:images` key triggers
+   NO-GENERATION FRAME: only an EXPLICIT `:images` key triggers
    image resolution, so a frame configured with NO `:images` is an ordinary
    frame on the shared registrar that carries no composed image — and the public
    `rf/frame-generation` read FAILS LOUD (`:rf.error/frame-no-generation`) for
@@ -998,7 +979,7 @@
                           (let [{err-id :rf.error/id
                                  live   :live-frame-ids} (ex-data e)]
                             ;; A live frame that carries no generation (an
-                            ;; imageless frame — EP-0024) is the graceful
+                            ;; imageless frame) is the graceful
                             ;; no-image case, NOT a read failure. Surface the
                             ;; sentinel and let the caller report it cleanly.
                             ;; Any other thrown error — including a :frame

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1041,7 +1041,7 @@
 (defn sub-cache-info
   "List the LIVE reactive subscriptions materialised in a frame's
    per-frame sub-cache — the answer to \"what subscriptions are
-   currently active?\" (rf2-qicji).
+   currently active?\".
 
    Reads the SAME source `snapshot`'s `:sub-cache` slice reads
    (`subs-tooling/sub-cache-snapshot`, via the `sub-cache` fn above), so
@@ -1067,7 +1067,7 @@
    read); when true each entry also carries `:value` (the current
    deref), `:ref-count`, `:input-kind`, and `:realized-inputs`.
 
-   `:input-kind` + `:realized-inputs` (rf2-e3acps) surface the
+   `:input-kind` + `:realized-inputs` surface the
    subscription's input topology PER LIVE CACHE ENTRY — the realized
    counterpart to the static `sub-topology`. `:input-kind` is `:db` /
    `:static` / `:parametric`; `:realized-inputs` is the REALIZED input
@@ -1135,7 +1135,7 @@
          {:ok? false :reason :sub-error :message (.-message e) :frame frame-id})))))
 
 (defn read-sub!
-  "Validated one-shot subscription read (rf2-3bu3d.7) — the read-side
+  "Validated one-shot subscription read — the read-side
    no-silent-swallow counterpart to `dispatch-consequence!`.
 
    The #1 read on any re-frame2 app is a subscription value, and dropping
@@ -1217,11 +1217,10 @@
       {:ok? false :reason :not-a-machine :id machine-id}))
 
 (defn machine-state
-  "Snapshot of one machine in the operating frame. Per Spec 005 + rf2-eguy4,
+  "Snapshot of one machine in the operating frame. Per Spec 005,
    machine snapshots live at `[:rf.runtime/machines :snapshots machine-id]`
-   in the RUNTIME-DB partition (EP-0001 rf2-vzld77 moved machine snapshots
-   out of app-db `:rf/runtime` into the durable runtime-db partition — read
-   via `rf/runtime-db-value`, NOT `rf/snapshot-of`, which reads app-db)."
+   in the durable RUNTIME-DB partition — read via `rf/runtime-db-value`,
+   NOT `rf/snapshot-of`, which reads app-db."
   ([machine-id] (machine-state machine-id (current-frame)))
   ([machine-id frame-id]
    (get-in (rf/runtime-db-value frame-id)
@@ -1236,18 +1235,15 @@
 ;; ours under id :re-frame2-pair-epoch — multi-tool coexistence per
 ;; Spec 009 §Listener ordering.
 ;;
-;; rf2-ertqw — runtime-direct reads, no parallel epoch capture buffer.
+;; Runtime-direct reads, no parallel epoch capture buffer.
 ;; The pair session is a THIN, runtime-direct reader: every epoch read
 ;; (`epoch-history`, `epochs-since`, `last-epoch`, `find-where`, and the
 ;; MCP `trace-window` / `watch-epochs` tools that eval them) hits
 ;; `(rf/epoch-history frame-id)` — the framework's AUTHORITATIVE ring,
 ;; the SAME source `eval-cljs` reaches directly. There is deliberately
 ;; NO session-side capture buffer that mirrors the ring: such a buffer
-;; only fills while a listener is attached, so it returned EMPTY while
-;; the ring HELD epochs — the silent-WRONG-read this bead exists to
-;; kill. (A legacy `observed-epochs` stash used to shadow the ring "to
-;; save a re-walk"; it was never read by any read path and was the
-;; vestige of the stateful-proxy posture, so it was removed.) The epoch
+;; only fills while a listener is attached, so it would return EMPTY while
+;; the ring HELD epochs — a silent-WRONG-read. The epoch
 ;; listener below drives ONLY the per-frame app-db-hash cache (a derived
 ;; scalar, not a record copy) and the streaming-subs fan-out.
 
@@ -1321,7 +1317,7 @@
 ;; the same `register-epoch-listener!` slot — combined into
 ;; `on-epoch-streaming` below to keep listener ordering deterministic.
 ;; The listener derives a scalar hash and fans events to subscribers; it
-;; does NOT retain a copy of the ring (rf2-ertqw — reads go straight to
+;; does NOT retain a copy of the ring (reads go straight to
 ;; `(rf/epoch-history frame-id)`).
 
 (declare on-epoch-streaming)
@@ -1435,7 +1431,7 @@
 
 (defn epoch-diff
   "Pre-computed diff between an epoch's `:db-before` and `:db-after`,
-   shaped to match the v1 vocabulary the skill uses:
+   shaped to the vocabulary the skill uses:
        {:only-before <map> :only-after <map> :common <map>}"
   [{:keys [db-before db-after]}]
   (let [[ob oa c] (data/diff db-before db-after)]
@@ -1464,10 +1460,9 @@
 
 (defonce ^:private last-trace-id (atom 0))
 
-;; The legacy `last-trace-id` cursor and the streaming dispatch both
-;; ride the same `register-listener!` slot — combined into
-;; `on-trace-streaming` below. The legacy `on-trace` was
-;; inlined into the streaming listener.
+;; The `last-trace-id` cursor and the streaming dispatch both ride the
+;; same `register-listener!` slot — combined into `on-trace-streaming`
+;; below.
 
 (declare on-trace-streaming)
 
@@ -1539,8 +1534,8 @@
 ;; Topic semantics:
 ;;   :trace     — every event in the raw trace stream matching `:filter`
 ;;                (filter map mirrors `(re-frame.trace.tooling/trace-buffer)` filter vocab —
-;;                see the trace-buffer surface). Cascade-bundle delivery
-;;                (rf2-mscih): per drain, matched events are grouped by
+;;                see the trace-buffer surface). Cascade-bundle delivery:
+;;                per drain, matched events are grouped by
 ;;                `:rf.trace/dispatch-id` and projected into one cascade
 ;;                bundle per cascade (`group-cascades` shape with a
 ;;                `:trace-events` slot carrying the raw events). Events
@@ -1567,7 +1562,7 @@
 ;; vocabulary verbatim — they just default `:op-type` to `:rf.fx` /
 ;; `:error` and let callers override the rest.
 ;;
-;; Cascade-bundle wire format (rf2-mscih) — emitted on `:trace`/`:fx`/
+;; Cascade-bundle wire format — emitted on `:trace`/`:fx`/
 ;; `:error` drain ticks:
 ;;
 ;;   {:dispatch-id        <id>                  ;; cascade id
@@ -1588,7 +1583,7 @@
 ;; trace-ring sees the same shape on the wire (per Spec 009 §Cascade
 ;; projection + Tool-Pair §Reading the per-frame trace ring).
 ;;
-;; Cross-frame cascade reconstruction (rf2-mscih) — a cascade can fan
+;; Cross-frame cascade reconstruction — a cascade can fan
 ;; out across frames; every emit on every frame shares the same
 ;; `:rf.trace/dispatch-id`. Consumers merge by `:dispatch-id` across
 ;; per-frame bundles to reconstruct the cross-frame view (per Tool-Pair
@@ -1683,7 +1678,7 @@
     {}))
 
 ;; ---------------------------------------------------------------------------
-;; Cascade-bundle projection (rf2-mscih)
+;; Cascade-bundle projection
 ;; ---------------------------------------------------------------------------
 ;;
 ;; Per Spec 009 §Cascade projection and Tool-Pair §Reading the per-frame
@@ -1724,12 +1719,10 @@
    This is load-bearing: dispatch ids are unique only WITHIN a frame
    (the portable trace contract), so two cascades sharing a dispatch id
    across frames are distinct bundles, each carrying only its own frame's
-   raw `:trace-events`. Re-deriving the grouping here keyed by
-   `:rf.trace/dispatch-id` alone (the prior `by-id` group-by) merged
-   foreign-frame events into both bundles — latent today (the runtime's
-   global dispatch counter never collides cross-frame) but live the
-   moment per-frame id allocation lands. Reuse the framework
-   key; never re-derive a weaker one.
+   raw `:trace-events`. Grouping by `:rf.trace/dispatch-id` alone would
+   merge foreign-frame events into both bundles the moment per-frame id
+   allocation lets two frames collide on a dispatch id — so reuse the
+   framework key, never re-derive a weaker one.
 
    Events whose `:rf.trace/dispatch-id` tag is missing are NOT included
    — the caller is expected to have filtered them upstream (cascade-
@@ -1904,13 +1897,13 @@
              m m))))
 
 (defn- on-trace-streaming
-  "Replacement raw-trace listener that drives both the last-trace-id
-   cursor (legacy) and the streaming subs dispatch.
+  "Raw-trace listener that drives both the last-trace-id cursor and the
+   streaming subs dispatch.
 
    Privacy filter: trace events stamped `:sensitive? true`
    at the top level are dropped from the streaming dispatch by default,
    per Spec 009 §Privacy. The `last-trace-id` cursor still advances so
-   the legacy `since`-based ring-buffer reads remain monotonic — only
+   the `since`-based ring-buffer reads remain monotonic — only
    the LLM-facing streaming surface is gated. Opt in via
    `(configure-privacy! {:include-sensitive? true})`."
   [ev]
@@ -1924,7 +1917,7 @@
    app-db-hash cache (a scalar, for the precheck cache-hit decision) —
    and the streaming-subs fan-out. It does NOT retain a copy of the
    epoch ring: every epoch read hits `(rf/epoch-history frame-id)`
-   directly, so there is no session-side buffer to drift (rf2-ertqw)."
+   directly, so there is no session-side buffer to drift."
   [record]
   (when-let [frame-id (:frame record)]
     (update-frame-db-hash! frame-id (:db-after record)))
@@ -1955,7 +1948,7 @@
    Idempotency: each call returns a fresh sub-id — repeated `subscribe!`
    calls do not share state. Use `unsubscribe!` to release.
 
-   Topic delivery shape (rf2-mscih):
+   Topic delivery shape:
      :trace / :fx / :error — drain returns `:cascades [<bundle> ...]`
                              with each bundle in the `(rf/trace-buffer
                              frame-id)` shape (per Spec 009 §Cascade
@@ -2011,7 +2004,7 @@
 
 (defn drain-subscription!
   "Pop every queued event for `sub-id` and return them in order.
-   Returns one of two envelopes per the sub's topic (rf2-mscih):
+   Returns one of two envelopes per the sub's topic:
 
    - Cascade-bundle topics (`:trace`/`:fx`/`:error`):
      `{:ok? true :sub-id ... :cascades [<bundle> ...] :dropped-events <n>
@@ -2065,7 +2058,7 @@
                   :overflow-reason overflow-reason
                   :gone?           false}]
         (cond
-          ;; Cascade-bundle delivery (rf2-mscih) — group raw queued
+          ;; Cascade-bundle delivery — group raw queued
           ;; trace events by `:rf.trace/dispatch-id` into bundles. The
           ;; cascade-bundle topics never enqueue frameless events
           ;; (`dispatch-trace-to-subs!` filters them out at the gate),
@@ -2093,7 +2086,7 @@
    currently materialised in a frame?\" use `sub-cache-info`, which
    reads the per-frame reactive cache `snapshot`'s `:sub-cache` slice
    reads. The MCP `list-streams` tool wraps THIS fn; the MCP
-   `list-subscriptions` tool wraps `sub-cache-info` (rf2-qicji).
+   `list-subscriptions` tool wraps `sub-cache-info`.
 
    Returns
    `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes
@@ -2122,9 +2115,8 @@
    the per-frame trace-ring cascade bundles for matching parent links.
    Returns a tree of `{:dispatch-id <id> :event <ev> :children [...]}`.
 
-   Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame and
-   cascade-keyed; per rf2-mscih the read unit is the cascade bundle
-   (`group-cascades` shape) rather than the legacy flat-event stream.
+   The trace ring is per-frame and cascade-keyed; the read unit is the
+   cascade bundle (`group-cascades` shape).
    A single cascade can fan out across frames (per Spec 002
    §Cross-frame dispatch) — every emit on every frame shares the same
    `:rf.trace/dispatch-id`, so cross-frame reconstruction iterates

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -3263,20 +3263,15 @@
 ;; ---------------------------------------------------------------------------
 ;; Shared DOM-read core — used by BOTH `dom-read` (raw DOM plane) and
 ;; `ui-read` (re-frame2 view plane), so the per-node projection cannot rot
-;; on one op alone (rf2-q0r7e).
+;; on one op alone.
 ;;
-;; Before this share, `dom-read` lived INLINED as a raw eval string in the
-;; MCP tool (`read_dom.cljs`) while `ui-read` called this runtime ns. The
-;; two carried INDEPENDENT copies of "querySelector → {:tag :text :attrs}",
-;; and they rotted apart: rf2-w2mjm — the inlined read-dom form lowered the
-;; tag with `(str/lower-case …)`, but the BARE browser cljs-eval context the
-;; inlined string ran in aliases NOTHING (no `:require`), so `str` was
-;; unresolved, the whole form nilled out, and EVERY read-dom call came back
-;; `:read-dom-blank-result` — while read-ui, calling THIS ns (which DOES
-;; `:require [clojure.string :as str]`), stayed green. Folding read-dom onto
-;; this runtime fn removes that alias trap entirely: both ops now run in a
-;; namespace with real requires, and the projection below is the single
-;; place a fix or a break lands.
+;; Both ops run through THIS runtime ns (which `:require`s
+;; `[clojure.string :as str]`), so the projection's `(str/lower-case …)` and
+;; any other aliased call resolve. A copy inlined as a raw eval string in an
+;; MCP tool would run in a BARE browser cljs-eval context that aliases
+;; NOTHING — `str` would be unresolved, the form would nil out, and the read
+;; would come back blank. Keeping the projection here, in a namespace with
+;; real requires, is the single place a fix or a break lands.
 ;;
 ;; The SEMANTICS stay distinct — `dom-read` is the raw DOM plane (a CSS
 ;; selector → matched nodes, multi-node, no re-frame2 awareness) and
@@ -3336,7 +3331,7 @@
   "Read `el`'s `textContent`, capped at `max-text` characters. Over-cap
    text collapses to the framework size-elision marker shape
    `{:rf.size/large-elided {:type :dom-text :chars N :preview \"…\"}}` —
-   the SAME shape `get-path` / `snapshot` emit (rf2-urjnc), so an agent
+   the SAME shape `get-path` / `snapshot` emit, so an agent
    recognises an elision uniformly. Under-cap text rides as the raw
    string. Pure read."
   [el max-text]
@@ -3352,7 +3347,7 @@
    both DOM-read planes return. `max-text` caps the text (see `cap-text`);
    `attr-opts` selects the attribute strategy (see `collect-attrs`). The
    single place the per-node projection lives — a fix or a break here
-   lands on BOTH `dom-read` and `ui-read`, never one alone (rf2-q0r7e)."
+   lands on BOTH `dom-read` and `ui-read`, never one alone."
   [el max-text attr-opts]
   {:tag   (str/lower-case (or (.-tagName el) ""))
    :text  (cap-text el max-text)
@@ -3360,7 +3355,6 @@
 
 ;; ---------------------------------------------------------------------------
 ;; dom-read — raw DOM plane: CSS selector → matched nodes {:tag :text :attrs}
-;; (rf2-nfjil; folded onto this runtime ns by rf2-q0r7e).
 ;;
 ;; The complement to `ui-read`: NO re-frame2 awareness. A plain
 ;; `querySelectorAll`, optional sub-selector run relative to each match, a
@@ -3369,8 +3363,8 @@
 ;; never leaves the tab.
 
 (defn dom-read
-  "Read rendered DOM content by CSS selector — the RAW DOM plane
-   (rf2-nfjil). Returns the matched-node count + per-node
+  "Read rendered DOM content by CSS selector — the RAW DOM plane.
+   Returns the matched-node count + per-node
    `{:tag :text :attrs}`, capped at the source. The view-plane
    counterpart is `ui-read` (which rides the `data-rf-view` map and also
    returns the producing re-frame2 entity).
@@ -3394,7 +3388,7 @@
                     whose declared-`:sensitive?` app-db values the rendered
                     text / attrs are value-redacted against (see below).
 
-   PRIVACY (rf2-p9scds). Rendered DOM text / attribute values can carry a
+   PRIVACY. Rendered DOM text / attribute values can carry a
    secret copied out of a declared-sensitive app-db slot — a NON-app-db
    position the path-based `elide-wire-value` walker can never reach. Under
    the off-box egress posture (raw-state gate OFF — the published-build
@@ -3431,7 +3425,7 @@
          attr-opts (if attrs
                      {:names attrs :prefix-sweep? false}
                      {:names nil   :prefix-sweep? true})
-         ;; rf2-p9scds — resolve the frame whose declared-sensitive app-db
+         ;; Resolve the frame whose declared-sensitive app-db
          ;; values the rendered nodes are value-redacted against. Only
          ;; load-bearing under the off-box gate (gate ON passes raw, frame
          ;; irrelevant).
@@ -3495,7 +3489,7 @@
           ;; The canonical `data-rf-view` reader (the inverse of
           ;; `format-view-id`): leading-colon → keyword, else raw string
           ;; (Spec 006 §View tagging contract). Same parse the fallback
-          ;; view-walker uses — both now alias core's `parse-view-id`.
+          ;; view-walker uses — both alias core's `parse-view-id`.
           view-id  (parse-view-id attr)
           ;; Source-coord: the attribute carries <ns>:<sym>:<line>:<col>;
           ;; handler-meta augments with :file (the four-segment attr can't
@@ -3527,8 +3521,8 @@
 
 (defn ui-read
   "Read the RENDERED content of a view (or the view at a point / selector)
-   as structured, ELIDED data, PLUS the re-frame2 entity that produced it
-   (rf2-3bu3d.1). The re-frame2 VIEW plane — answers \"what does the thing
+   as structured, ELIDED data, PLUS the re-frame2 entity that produced it.
+   The re-frame2 VIEW plane — answers \"what does the thing
    I'm looking at SHOW, and what produced it?\" in ONE round-trip, on ANY
    re-frame2 app with zero testids.
 
@@ -3555,11 +3549,11 @@
      :frame     operating-frame override for the `:subs-read` slice +
                 the value-redaction source-db.
 
-   PRIVACY (rf2-p9scds). The rendered `:content` (text AND attrs) can carry
+   PRIVACY. The rendered `:content` (text AND attrs) can carry
    a secret copied out of a declared-sensitive app-db slot — a NON-app-db
-   position the path-based `elide-wire-value` walker can never reach (so a
-   bare `(elide-wire-value text {:frame …})` over the anonymous string was
-   a no-op for this leak class, and attrs were never touched at all). Under
+   position the path-based `elide-wire-value` walker can never reach (a
+   bare `(elide-wire-value text {:frame …})` over the anonymous string is
+   a no-op for this leak class, and never touches attrs). Under
    the off-box egress posture (raw-state gate OFF — the published-build
    default) the whole `:content` is value-redacted via `maybe-redact-derived`
    (`re-frame.core/redact-derived-slots`) against the frame's secrets, so a
@@ -3625,7 +3619,7 @@
                    view-root (if (= via :view-id)
                                hit-el
                                (nearest-view-root hit-el))
-                   ;; Shared per-node projection (rf2-q0r7e) — the SAME
+                   ;; Shared per-node projection — the SAME
                    ;; tag + capped-text + attr core dom-read uses. The
                    ;; view plane reads the curated structural set PLUS the
                    ;; data-*/aria- sweep, and DROPS the framework-internal
@@ -3636,15 +3630,13 @@
                    base      (node->content hit-el max-text
                                             {:names nil :prefix-sweep? true
                                              :drop-internal? true})
-                   ;; rf2-p9scds — value-redact the WHOLE rendered content
+                   ;; Value-redact the WHOLE rendered content
                    ;; (text AND attrs) against the frame's declared-sensitive
-                   ;; app-db secrets. The old code ran the path-based
-                   ;; `elide-wire-value` over just the anonymous `:text`
-                   ;; string — but that walker redacts by app-db PATH, and
-                   ;; rendered text has none, so it never caught a secret
-                   ;; copied INTO the DOM, and attrs were untouched entirely.
-                   ;; `redact-derived-slots` is the value-based dual: it
-                   ;; substitutes any leaf `=` to a frame secret. Off-box
+                   ;; app-db secrets. The path-based `elide-wire-value`
+                   ;; redacts by app-db PATH, and rendered text has none, so
+                   ;; it can't catch a secret copied INTO the DOM, nor touch
+                   ;; attrs. `redact-derived-slots` is the value-based dual:
+                   ;; it substitutes any leaf `=` to a frame secret. Off-box
                    ;; default redacts; gate ON passes verbatim (trusted-local).
                    content   (maybe-redact-derived base frame-id)]
                {:ok?     true
@@ -3657,16 +3649,16 @@
             :message (.-message e)}))))))
 
 ;; ---------------------------------------------------------------------------
-;; Signal recorder (rf2-zo4b9)
+;; Signal recorder
 ;; ---------------------------------------------------------------------------
 ;;
-;; Intermittent / human-in-the-loop bugs (the rf2-yng0y render-timing
-;; race, only reproducible under real mouse input) need a recorder:
+;; Intermittent / human-in-the-loop bugs (a render-timing race only
+;; reproducible under real mouse input) need a recorder:
 ;; install an observer, let the human interact, read back a change-log.
-;; That move used to be hand-built each session — a `requestAnimationFrame`
-;; loop pushing focus-slot + DOM snapshots into `window.__zoombug`. It was
-;; decisive, but bespoke and footgun-prone: rAF timing, change-dedup,
-;; teardown. This first-classes it.
+;; Hand-rolling that each session — a `requestAnimationFrame` loop pushing
+;; focus-slot + DOM snapshots into a window global — is decisive but
+;; footgun-prone: rAF timing, change-dedup, teardown. This first-classes
+;; the whole gesture.
 ;;
 ;; A SIGNAL is a read-only sample of one observable: an app-db path, a
 ;; subscription value, a DOM text/attribute read, or the currently-focused

--- a/skills/re-frame2-pair/scripts/bencode.clj
+++ b/skills/re-frame2-pair/scripts/bencode.clj
@@ -4,7 +4,7 @@
 ;;;; bencode is a ~40-line protocol and nREPL speaks it directly over TCP,
 ;;;; so inlining the codec is simpler than bolting on a dependency.
 ;;;;
-;;;; Shared by BOTH halves of the bash-shim transport (rf2-qq7w2k):
+;;;; Shared by BOTH halves of the bash-shim transport:
 ;;;;   - scripts/ops.clj           ENCODES requests + DECODES responses
 ;;;;   - tests/shim/stub_nrepl.clj DECODES requests + ENCODES canned replies
 ;;;; They are mirror halves of the same protocol, so the codec lives once.

--- a/skills/re-frame2-pair/scripts/ops.clj
+++ b/skills/re-frame2-pair/scripts/ops.clj
@@ -10,13 +10,13 @@
 ;;;; that exec's `bb ops.clj <subcommand> [args...]` and forwards the edn
 ;;;; printed on stdout.
 ;;;;
-;;;; Transport status — the bash-shim is **retired from the skill's tool
+;;;; Transport status — the bash-shim is **not part of the skill's tool
 ;;;; surface** (the `allowed-tools:` frontmatter carries no shell tool, so
 ;;;; an agent cannot run it). It is NOT a skill-facing fallback transport.
 ;;;; The MCP server in `tools/re-frame2-pair-mcp/` is the only skill-facing
 ;;;; transport; it holds a single nREPL connection per session (~14× faster
 ;;;; than the per-call connect/disconnect this file performs). These shims
-;;;; remain on disk only for the project's own test harness (`tests/shim/`,
+;;;; live on disk for the project's own test harness (`tests/shim/`,
 ;;;; `tests/e2e/`) and ad-hoc shell use OUTSIDE the skill. Op semantics are
 ;;;; identical between the shim and the MCP surface — see
 ;;;; `skills/re-frame2-pair/references/ops.md` for the full op catalogue
@@ -60,17 +60,16 @@
 ;;;;
 ;;;; Runtime preload requirement
 ;;;; ---------------------------
-;;;; The runtime is no longer injected at first connect — it ships into
-;;;; the consumer app via shadow-cljs's `:devtools :preloads` mechanism.
-;;;; See `skills/re-frame2-pair/SKILL.md` (§Setup) for the one-line
-;;;; preload entry. `discover` refuses with `:reason :runtime-not-preloaded`
-;;;; when the namespace isn't present.
+;;;; The runtime ships into the consumer app via shadow-cljs's
+;;;; `:devtools :preloads` mechanism. See `skills/re-frame2-pair/SKILL.md`
+;;;; (§Setup) for the one-line preload entry. `discover` refuses with
+;;;; `:reason :runtime-not-preloaded` when the namespace isn't present.
 ;;;;
 ;;;; All ops return edn on stdout. Shells capture and forward.
 
 ;; The minimal bencode codec is shared with the test stub
 ;; (tests/shim/stub_nrepl.clj); it lives in scripts/bencode.clj and is
-;; loaded off this file's own location so cwd doesn't matter (rf2-qq7w2k).
+;; loaded off this file's own location so cwd doesn't matter.
 (load-file (str (.getParent (java.io.File. *file*)) "/bencode.clj"))
 
 (ns ops
@@ -164,8 +163,8 @@
    Picking by mtime — rather than first-in-list — is what makes this
    robust: the live dev build rewrites its port file on every (re)start,
    so the freshest file is the live one. A stale repo-root
-   `.shadow-cljs/nrepl.port` left over from an earlier run can no longer
-   shadow the live `implementation/.shadow-cljs/nrepl.port`."
+   `.shadow-cljs/nrepl.port` cannot shadow the live
+   `implementation/.shadow-cljs/nrepl.port`."
   []
   (or (when-let [p (System/getenv "SHADOW_CLJS_NREPL_PORT")]
         (Integer/parseInt p))
@@ -228,15 +227,15 @@
       :else
       (let [outer (safe-edn (str (:value res)))]
         (cond
-          ;; rf2-n58jxo (mirrors the MCP-side rf2-mvdwv fix in nrepl.cljs) —
-          ;; a populated `:err` on shadow's outer response is an analyzer
+          ;; A populated `:err` on shadow's outer response is an analyzer
           ;; warning (unresolved symbol) or a compile error. It MUST surface
           ;; even though shadow ALSO pushes a "nil" into `:results`: peeking
-          ;; `:results` FIRST (the pre-fix order) swallowed the compile
-          ;; failure as a silent nil — the CLI eval reported success-shaped
-          ;; while the form never produced a real value. The `:err` branch
-          ;; now takes precedence so a compile error/warning is DISTINCT from
-          ;; a runtime throw (`:eval-error`, the `:ex` path above).
+          ;; `:results` first would swallow the compile failure as a silent
+          ;; nil, and the CLI eval would report success-shaped while the form
+          ;; never produced a real value. So the `:err` branch takes
+          ;; precedence, keeping a compile error/warning DISTINCT from a
+          ;; runtime throw (`:eval-error`, the `:ex` path above). Mirrors the
+          ;; same precedence on the MCP side in nrepl.cljs.
           (and (map? outer) (not (str/blank? (str (:err outer)))))
           (throw (ex-info "cljs eval compile error/warning"
                           {:reason :cljs-eval-error
@@ -304,7 +303,7 @@
   (cljs-eval-value build-id "(re-frame2-pair.runtime/health)"))
 
 ;; ---------------------------------------------------------------------------
-;; Running-build enumeration + fail-loud build resolution (rf2-ivlb3).
+;; Running-build enumeration + fail-loud build resolution.
 ;;
 ;; Mirrors `tools/re-frame2-pair-mcp/src/.../tools/probe.cljs`'s
 ;; `running-builds` / `resolve-build!` / `resolve-and-preflight!`. Both
@@ -443,7 +442,7 @@
 (defn- explicit-build?
   "True iff the caller passed an explicit `--build=` flag or set
    $SHADOW_CLJS_BUILD_ID — vs. relying on the bare `:app` fallback in
-   `default-build-id`. The eval-path resolver (rf2-ivlb3) auto-detects
+   `default-build-id`. The eval-path resolver auto-detects
    the running build ONLY when the build is the bare default."
   [args]
   (boolean (or (some #(str/starts-with? % "--build=") args)
@@ -457,10 +456,10 @@
         build-id  (build-id-from-args rest-args)
         explicit? (explicit-build? rest-args)]
     (try
-      ;; rf2-ivlb3: resolve the build (auto-detect the single running one
-      ;; when no explicit --build was passed) and confirm a live runtime
-      ;; BEFORE eval'ing. Never emit `:ok? true :value nil` for a build
-      ;; with no runtime — that's indistinguishable from a genuine nil.
+      ;; Resolve the build (auto-detect the single running one when no
+      ;; explicit --build was passed) and confirm a live runtime BEFORE
+      ;; eval'ing. Never emit `:ok? true :value nil` for a build with no
+      ;; runtime — that's indistinguishable from a genuine nil.
       (let [resolved (resolve-and-preflight! build-id explicit?)]
         (emit {:ok? true :value (cljs-eval-value resolved form) :build resolved}))
       (catch Exception e
@@ -581,13 +580,11 @@
       (= a "--origin")          (recur (rest more) (assoc pred :origin (->kw (first more))))
       (= a "--frame")           (recur (rest more) (assoc pred :frame (->kw (first more))))
 
-      ;; --custom (arbitrary CLJS predicate form) was advertised
-      ;; in earlier docs but never implemented. Implementing it requires
-      ;; designing the predicate-fn surface (security implications: the
-      ;; transport would eval untrusted CLJS), so it is removed from the
-      ;; documented surface for now. The flag is rejected with an
-      ;; explanatory error rather than silently skipped, so any stale
-      ;; caller surfaces clearly.
+      ;; --custom (arbitrary CLJS predicate form) is not supported.
+      ;; Supporting it requires designing the predicate-fn surface
+      ;; (security implications: the transport would eval untrusted CLJS).
+      ;; The flag is rejected with an explanatory error rather than
+      ;; silently skipped, so any caller passing it surfaces clearly.
       (= a "--custom")
       (do
         (emit {:ok? false
@@ -615,7 +612,7 @@
         ;;   --window-ms alone: run for N ms, no count limit.
         ;;   --count alone:     run until N matches, no window timeout.
         ;;   both set:          first to fire wins (race).
-        ;;   neither set:       default to a 30s window (back-compat).
+        ;;   neither set:       default to a 30s window.
         window-raw   (flag-value args "--window-ms" nil)
         count-raw    (flag-value args "--count" nil)
         window-ms    (when window-raw (Long/parseLong window-raw))

--- a/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
+++ b/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
@@ -29,7 +29,7 @@
 (rf/reg-event :counter/dec
  (fn [{:keys [db]} _event] {:db (update db :count dec)}))
 
-;; EP-0017 reproducible-coeffects fixture (rf2-jyxmtq). Declares
+;; Reproducible-coeffects fixture. Declares
 ;; `:rf.cofx/requires [:rf/time-ms]` so its `handler-meta` surfaces the
 ;; authored declaration, and folds the recorded wall-clock fact (read FLAT as
 ;; `time-ms`) into durable state under `:stamped-at`. The MCP conformance
@@ -70,9 +70,9 @@
  ;; Spec 006 §Source-coord annotation) — re-frame2 stamps registered-view roots
  ;; with data-rf2-source-coord, so re-frame2-pair's DOM bridge has something to
  ;; find with no configure! call needed.
- ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
- ;; absence — `:rf/default` is this fixture's app frame, registered
- ;; explicitly here (init! installs only the adapter). The boot dispatch
+ ;; The runtime never synthesises a frame from absence — `:rf/default`
+ ;; is this fixture's app frame, registered explicitly here (init!
+ ;; installs only the adapter). The boot dispatch
  ;; runs under the frame scope and the render is wrapped in
  ;; `frame-provider-existing` (scope-only — the frame already exists from
  ;; reg-frame) so the reg-view-injected dispatch/subscribe resolve to it.

--- a/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
+++ b/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
@@ -4,8 +4,8 @@
 ;;;; Per `docs/TESTING.md` §4 the goal of prompt regression is to catch
 ;;;; SILENT DRIFT in the skill's recipes as the skill itself evolves.
 ;;;; A conversation-driving harness (Claude in the loop) is the *fidelity-
-;;;; ideal* version of this surface; the v1 here is the structural
-;;;; substrate that catches the cheapest class of drift:
+;;;; ideal* version of this surface; the structural substrate here catches
+;;;; the cheapest class of drift:
 ;;;;
 ;;;; - The canonical prompt's *recipe* still lives in `references/recipes.md`
 ;;;; under the expected heading.
@@ -47,7 +47,7 @@
 (def ^:private hot-reload (delay (slurp-rel "references/ops.md")))
 
 ;; User-facing docs + the streaming + variant leaves the MCP-surface
-;; conformance drift guards (rf2-ojo3z) assert against.
+;; conformance drift guards assert against.
 (def ^:private readme-md (delay (slurp-rel "README.md")))
 (def ^:private capabilities-md (delay (slurp-rel "docs/capabilities.md")))
 (def ^:private local-dev-md (delay (slurp-rel "docs/LOCAL_DEV.md")))
@@ -56,7 +56,7 @@
 (def ^:private variant-md (delay (slurp-rel "references/variant-as-frame.md")))
 (def ^:private wire-size-md (delay (slurp-rel "references/wire-size-budget.md")))
 
-;; Live Pair-MCP catalogue cardinality (rf2-sdudwy). The generated descriptor
+;; Live Pair-MCP catalogue cardinality. The generated descriptor
 ;; manifest is the single source of truth for the tool count; read its
 ;; `:meta :tool-count` directly rather than hard-coding a number here, so this
 ;; guard tracks the catalogue automatically. The manifest sits two levels up
@@ -220,7 +220,7 @@
  (is (str/includes? @hot-reload "tail-build"))))
 
 ;; ---------------------------------------------------------------------------
-;; Privacy-contract drift (rf2-k2off)
+;; Privacy-contract drift
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The skill-facing privacy guarantee MUST match what the pair-mcp tools
@@ -230,11 +230,10 @@
 ;;     un-walked, regardless of --allow-sensitive-reads).
 ;;   - Epoch egress (trace-window / watch-epochs / the :epoch streaming
 ;;     topic) is REDACTED/ELIDED by default via projected-record /
-;;     elide-wire-value (rf2-6wvh5 / rf2-vr2hn) — not shipped raw.
-;; These assertions fail if the docs drift back to the over-broad
-;; "sensitive data does not cross the LLM boundary by default" claim or
-;; the stale "epoch records are not dropped / carry no sensitive stamp"
-;; wording the rf2-k2off review caught.
+;;     elide-wire-value — not shipped raw.
+;; These assertions fail if the docs drift to the over-broad "sensitive
+;; data does not cross the LLM boundary by default" claim or the "epoch
+;; records are not dropped / carry no sensitive stamp" wording.
 
 (defn- includes-ci? [text needle]
   (str/includes? (str/lower-case text) (str/lower-case needle)))
@@ -291,22 +290,21 @@
         "ops.md must still name the raw trace-buffer / epoch-history surfaces the carve-out governs.")))
 
 ;; ---------------------------------------------------------------------------
-;; MCP-surface conformance drift (rf2-ojo3z)
+;; MCP-surface conformance drift
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The skill-facing docs MUST describe the MCP-primary tool surface at its
-;; LIVE cardinality, NOT the retired bash/Babashka shim world or v1-style op
-;; names. These guards assert the current surface IS named and the specific
-;; retired-as-primary phrasings the rf2-ojo3z review caught do NOT come back.
-;; They are scoped to the user-facing prose docs (README / capabilities /
-;; LOCAL_DEV / TESTING) — the legitimate harness appendix in references/ops.md
-;; is out of scope here. The count is the live catalogue cardinality
-;; (rf2-sdudwy): the descriptor manifest
-;; tools/re-frame2-pair-mcp/tool-descriptors.edn carries :meta :tool-count
-;; (30 after describe-image landed, rf2-srobm0). This assertion reads that
-;; live `@tool-count` rather than a hardcoded literal so the README pin stays
-;; in lockstep with the catalogue; the `catalogue-count-matches-live-manifest`
-;; guard below is the fuller cross-doc sweep.
+;; LIVE cardinality, NOT the bash/Babashka shim world or v1-style op names.
+;; These guards assert the current surface IS named and the shim-/v1-as-primary
+;; phrasings do NOT appear. They are scoped to the user-facing prose docs
+;; (README / capabilities / LOCAL_DEV / TESTING) — the legitimate harness
+;; appendix in references/ops.md is out of scope here. The count is the live
+;; catalogue cardinality: the descriptor manifest
+;; tools/re-frame2-pair-mcp/tool-descriptors.edn carries :meta :tool-count.
+;; This assertion reads that live `@tool-count` rather than a hardcoded literal
+;; so the README pin stays in lockstep with the catalogue; the
+;; `catalogue-count-matches-live-manifest` guard below is the fuller cross-doc
+;; sweep.
 
 (deftest readme-names-mcp-primary-tool-surface
   (testing "README names the live-cardinality MCP-primary surface, not 'fourteen ops'"
@@ -388,10 +386,10 @@
              "(rf2-ojo3z)."))))
 
 ;; ---------------------------------------------------------------------------
-;; Independent-review findings (rf2-a85bb2)
+;; Wire-size-budget + recipes drift
 ;; ---------------------------------------------------------------------------
 ;;
-;; Finding 2 — wire-size-budget.md must describe the SAME topic-dependent
+;; wire-size-budget.md must describe the SAME topic-dependent
 ;; subscribe payload slot as streaming-subscriptions.md: `:events` for the
 ;; flat topics (epoch/frameless) and `:cascades` for the cascade-bundle
 ;; topics (trace/fx/error). A host decoding subscribe dedup off the
@@ -437,18 +435,17 @@
              "coord resolution, matching recipes.md (rf2-a85bb2)."))))
 
 ;; ---------------------------------------------------------------------------
-;; Restore / hot-reload teaching drift (rf2-7a1mkv)
+;; Restore / hot-reload teaching drift
 ;; ---------------------------------------------------------------------------
 ;;
-;; Finding 1 — restore-epoch reinstalls the whole frame-state (both app-db
-;; AND runtime-db partitions via replace-frame-state!), NOT app-db only. The
-;; pair skill used to teach "restore rewinds app-db only" / "app-db is back".
-;; These assertions fail if that stale framing returns and assert the
-;; positive frame-state framing.
-;; Finding 2 — tail-build returns probe diagnostics (:probe-values / :reason
-;; / :note); a timeout is NOT always a compile error. The "read the tail
-;; output / treat a timeout as a compile error" framing must not return.
-;; Finding 3 — the subscribe topic catalogue in ops.md must list :frameless.
+;; - restore-epoch reinstalls the whole frame-state (both app-db AND
+;;   runtime-db partitions via replace-frame-state!), NOT app-db only. These
+;;   assertions fail if an "app-db only" / "app-db is back" framing appears and
+;;   assert the positive frame-state framing.
+;; - tail-build returns probe diagnostics (:probe-values / :reason / :note); a
+;;   timeout is NOT always a compile error. The "read the tail output / treat a
+;;   timeout as a compile error" framing must not appear.
+;; - the subscribe topic catalogue in ops.md must list :frameless.
 
 (deftest restore-not-taught-as-app-db-only
   (testing "pair skill no longer teaches restore as app-db-only (rf2-7a1mkv finding 1)"
@@ -504,16 +501,16 @@
              "rf2-7a1mkv finding 3)."))))
 
 ;; ---------------------------------------------------------------------------
-;; snapshot uses plural `frames`, not singular `frame` (rf2-hf7m9j finding 2)
+;; snapshot uses plural `frames`, not singular `frame`
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The `snapshot` MCP tool reads only the plural `:frames` arg
 ;; (snapshot.cljs parses `(args/parse-frames-arg (wire/arg ... :frames))`)
 ;; — it has NO singular `frame` arg, unlike dispatch / get-path / read-sub.
-;; The variant-diff recipe used to call `snapshot {frame: ...}` (singular),
-;; which the tool ignores: it would snapshot the operating frame twice and
-;; produce a false comparison. These guards fail if a snapshot recipe
-;; regresses to the singular form.
+;; A variant-diff recipe calling `snapshot {frame: ...}` (singular) would be
+;; ignored by the tool: it would snapshot the operating frame twice and
+;; produce a false comparison. These guards fail if a snapshot recipe uses the
+;; singular form.
 
 (deftest snapshot-recipe-uses-plural-frames-not-singular-frame
   (testing "the variant-diff recipe selects frames via plural `frames`, not singular `frame` (rf2-hf7m9j)"
@@ -534,7 +531,6 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Named state-rewrite writes route through the dedicated gated tools
-;; (rf2-230ekq)
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The two write-authority tools `restore-epoch` + `replace-app-db` are the
@@ -542,8 +538,8 @@
 ;; allow-listed (the server's `--allow-writes` gate, not the allow-list, is
 ;; the write boundary). The raw eval forms (`(rf/restore-epoch! …)` /
 ;; `app-db-reset!`) are the BACKSTOP only. These guards fail if the skill
-;; regresses to teaching the eval form as the default-reachable write path,
-;; or drops the two tools from the allow-list.
+;; teaches the eval form as the default-reachable write path, or drops the two
+;; tools from the allow-list.
 
 (deftest write-tools-are-allow-listed
   (testing "SKILL.md allow-lists both dedicated write tools (rf2-230ekq)"
@@ -585,16 +581,16 @@
              "framed as the fallback, not the default (rf2-230ekq)."))))
 
 ;; ---------------------------------------------------------------------------
-;; Catalogue-cardinality drift (rf2-sdudwy)
+;; Catalogue-cardinality drift
 ;; ---------------------------------------------------------------------------
 ;;
-;; The existing name-level gate (scripts/check_skill_mcp_drift.py) compares the
+;; The name-level gate (scripts/check_skill_mcp_drift.py) compares the
 ;; SKILL.md allow-list against the server descriptor SET — it does NOT read the
-;; PROSE cardinality, so the skill/re-authoring docs kept teaching a stale
-;; 28-tool catalogue after the surface grew to 29. These guards anchor every
-;; doc that states a count to the LIVE manifest `:tool-count` (read from
-;; tools/re-frame2-pair-mcp/tool-descriptors.edn) and fail when a doc still
-;; carries a stale number. Add a doc to `count-docs` if it states the count.
+;; PROSE cardinality, so a doc can carry a stale tool count even when the
+;; allow-list is correct. These guards anchor every doc that states a count to
+;; the LIVE manifest `:tool-count` (read from
+;; tools/re-frame2-pair-mcp/tool-descriptors.edn) and fail when a doc carries a
+;; stale number. Add a doc to `count-docs` if it states the count.
 
 (def ^:private count-docs
   ;; [label deref] for every skill/re-authoring doc that states the tool count
@@ -634,16 +630,16 @@
                    "the live surface is " live " tools (rf2-sdudwy).")))))))
 
 ;; ---------------------------------------------------------------------------
-;; Gated-write allow-list policy drift (rf2-sdudwy)
+;; Gated-write allow-list policy drift
 ;; ---------------------------------------------------------------------------
 ;;
-;; Current policy (scripts/check_skill_mcp_drift.py: `intentional_server_only`
+;; The policy (scripts/check_skill_mcp_drift.py: `intentional_server_only`
 ;; is empty for the re-frame2-pair mapping): EVERY server tool — including a
-;; new `--allow-writes`-gated write tool — is allow-listed and fenced at the
-;; SERVER. The re-authoring docs once told a future author to keep gated write
-;; tools OFF the allow-list and put them in `intentional_server_only`; that
-;; contradicts the live gate and would regenerate stale guidance. This guard
-;; fails if the contradictory policy reappears in the re-authoring/meta docs.
+;; `--allow-writes`-gated write tool — is allow-listed and fenced at the
+;; SERVER. Re-authoring docs telling a future author to keep gated write tools
+;; OFF the allow-list and put them in `intentional_server_only` would
+;; contradict the live gate and regenerate wrong guidance. This guard fails if
+;; that contradictory policy appears in the re-authoring/meta docs.
 
 (deftest gated-write-tools-stay-allow-listed-in-reauthoring-docs
   (testing "re-authoring docs do NOT route gated write tools into intentional_server_only / off the allow-list"

--- a/skills/re-frame2-pair/tests/runtime/_support.clj
+++ b/skills/re-frame2-pair/tests/runtime/_support.clj
@@ -1,10 +1,10 @@
 ;;;; tests/runtime/_support.clj
 ;;;;
 ;;;; Shared babashka test scaffold for the `tests/runtime/*` structural
-;;;; pins (rf2-yrpt90). Every structural-pin test needs to locate, slurp
-;;;; and parse `preload/re_frame2_pair/runtime.cljs`, then walk the parsed
-;;;; forms looking for a named defn / a predicate hit. That harness was
-;;;; copy-pasted verbatim across ~12 tests; it lives here once.
+;;;; pins. Every structural-pin test needs to locate, slurp and parse
+;;;; `preload/re_frame2_pair/runtime.cljs`, then walk the parsed forms
+;;;; looking for a named defn / a predicate hit. That locate+parse+walk
+;;;; harness lives here once, shared across the runtime tests.
 ;;;;
 ;;;; Per-test ASSERTIONS stay in each test file — only the mechanical
 ;;;; locate+parse+walk harness collapses here.
@@ -29,8 +29,8 @@
 (def runtime-cljs-path
   "Absolute path to `preload/re_frame2_pair/runtime.cljs`. Resolved off
    this file's location: tests/runtime/_support.clj → skill root →
-   preload/…. Exits 2 (matching the historical per-test guard) when the
-   source can't be found, so a moved/renamed runtime fails loud."
+   preload/…. Exits 2 when the source can't be found, so a moved/renamed
+   runtime fails loud."
   (let [skill-root (-> this-file
                        .getParentFile   ;; tests/runtime/
                        .getParentFile   ;; tests/

--- a/skills/re-frame2-pair/tests/runtime/app_db_reset_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/app_db_reset_test.clj
@@ -5,13 +5,13 @@
 ;;;;
 ;;;; Why this test exists:
 ;;;;
-;;;; `app-db-reset!` previously reached into `(rf/handler-meta :frame
-;;;; frame-id)` looking for an `:app-db` key — not the canonical
-;;;; Tool-Pair write surface — and could plausibly return
-;;;; `{:ok? true}` without mutating state or appending the synthetic
-;;;; epoch that `restore-epoch` depends on. The fix delegates to
-;;;; `rf/replace-app-db!` (Tool-Pair §Pair-tool writes; renamed from
-;;;; `rf/reset-frame-db!`, EP-0001 rf2-tfepxu).
+;;;; `app-db-reset!` MUST delegate to the canonical Tool-Pair write
+;;;; surface `rf/replace-app-db!` (Tool-Pair §Pair-tool writes), so the
+;;;; reset mutates app-db AND appends the synthetic epoch that
+;;;; `restore-epoch` depends on. Reaching into `(rf/handler-meta :frame
+;;;; frame-id)` for an `:app-db` key instead could return `{:ok? true}`
+;;;; without mutating state or recording the epoch — this test forbids
+;;;; that shape.
 ;;;;
 ;;;; Why a structural test rather than a runtime test:
 ;;;;
@@ -42,7 +42,7 @@
 ;;;; Tool-Pair write surface — guarantees app-db mutation +
 ;;;; synthetic-epoch append per).
 ;;;; 2. The body does NOT reach into `rf/handler-meta` to grab
-;;;; an `:app-db` key (the bug we just fixed).
+;;;; an `:app-db` key (the forbidden no-mutation shape).
 ;;;; 3. The success branch returns `{:ok? true ...}`, the
 ;;;; soft-failure branch returns `{:ok? false :reason
 ;;;; :reset-rejected ...}`.
@@ -58,8 +58,8 @@
  (:require [clojure.test :refer [deftest is run-tests testing]]
  [runtime-support :as rt]))
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private form-contains? rt/form-contains?)
 
 (def ^:private app-db-reset-form (rt/defn-named 'app-db-reset!))

--- a/skills/re-frame2-pair/tests/runtime/cascade_summary_outcome_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/cascade_summary_outcome_test.clj
@@ -1,7 +1,7 @@
 ;;;; tests/runtime/cascade_summary_outcome_test.clj
 ;;;;
 ;;;; Babashka-runnable verification of the cascade-summary's CONTAINED-THROW
-;;;; detection (rf2-hhkbb) in `preload/re_frame2_pair/runtime.cljs`:
+;;;; detection in `preload/re_frame2_pair/runtime.cljs`:
 ;;;;
 ;;;;   - `cascade-errors`              — scans an epoch's `:trace-events` for a
 ;;;;                                     contained cascade exception (a
@@ -13,15 +13,15 @@
 ;;;;   - `consequence-from-summary`    — `:no-op? false` for a thrown-action
 ;;;;                                     epoch (a throw is NOT a no-op).
 ;;;;
-;;;; THE BUG (rf2-hhkbb): a `:*` wildcard machine action throwing
+;;;; THE CONTRACT: a `:*` wildcard machine action throwing
 ;;;; `:rf.error/machine-action-exception` does NOT halt the drain — the
 ;;;; interceptor error-capture seam contains it, the epoch settles
 ;;;; `:outcome :ok`, and the throw rides the trace stream. Because the
-;;;; aborted action committed no `:db` and fired no fx, the structured
-;;;; cascade-summary read it as `{:outcome :ok :no-op? true}` — a silent-
-;;;; green-on-error trap for any non-visual consumer triaging on those
-;;;; slots. (The human pink-card path, rf2-4yrr6, reads the trace directly
-;;;; and is unaffected.) The fix surfaces the throws under `:errors`, forces
+;;;; aborted action commits no `:db` and fires no fx, a naive structured
+;;;; cascade-summary would read it as `{:outcome :ok :no-op? true}` — a
+;;;; silent-green-on-error trap for any non-visual consumer triaging on
+;;;; those slots. (The human pink-card path reads the trace directly and is
+;;;; unaffected.) So the summary surfaces the throws under `:errors`, forces
 ;;;; `:outcome :error`, and reports `:no-op? false`.
 ;;;;
 ;;;; Why a parallel implementation lives here:
@@ -283,8 +283,8 @@
 ;; Structural pin — keep the bb mirror honest against the cljs source.
 ;; ---------------------------------------------------------------------------
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private runtime-cljs-path rt/runtime-cljs-path)
 (def ^:private form-contains? rt/form-contains?)
 

--- a/skills/re-frame2-pair/tests/runtime/cascade_summary_redaction_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/cascade_summary_redaction_test.clj
@@ -1,22 +1,21 @@
 ;;;; tests/runtime/cascade_summary_redaction_test.clj
 ;;;;
 ;;;; Babashka-runnable verification of the cascade-summary `:event-vector`
-;;;; egress redaction (rf2-6nks4, finding-2) in
-;;;; `preload/re_frame2_pair/runtime.cljs`.
+;;;; egress redaction in `preload/re_frame2_pair/runtime.cljs`.
 ;;;;
-;;;; THE BUG (rf2-6nks4, finding-2): `cascade-summary` /
-;;;; `restore-cascade-summary` copy the epoch's RAW `:trigger-event` into
-;;;; the projection's `:event-vector` slot verbatim, and the MCP
-;;;; `restore-epoch` + `dispatch-dry-run` tools pass that projection
-;;;; through (restore-epoch ships the runtime map verbatim; dispatch-dry-
-;;;; run DELIBERATELY does not walk `:cascade-summary`). The merged
-;;;; rf2-z7roa elision walker scrubbed dispatch-dry-run's
-;;;; `:db-state-after-simulation` / `:would-fire-effects` but left the
-;;;; cascade-summary `:event-vector` UNWALKED — so a restore / dry-run of
-;;;; a SENSITIVE historical epoch returned the raw event payload (auth
-;;;; tokens, passwords, …) even under `--allow-sensitive-reads` OFF.
+;;;; THE CONTRACT: `cascade-summary` / `restore-cascade-summary` copy the
+;;;; epoch's RAW `:trigger-event` into the projection's `:event-vector`
+;;;; slot, and the MCP `restore-epoch` + `dispatch-dry-run` tools pass that
+;;;; projection through (restore-epoch ships the runtime map verbatim;
+;;;; dispatch-dry-run DELIBERATELY does not walk `:cascade-summary`). The
+;;;; wire-path elision walker scrubs dispatch-dry-run's
+;;;; `:db-state-after-simulation` / `:would-fire-effects`, but the
+;;;; cascade-summary `:event-vector` rides outside that walk — so without a
+;;;; guard a restore / dry-run of a SENSITIVE historical epoch would return
+;;;; the raw event payload (auth tokens, passwords, …) even under
+;;;; `--allow-sensitive-reads` OFF.
 ;;;;
-;;;; THE FIX: `redact-sensitive-event-vector` redacts the slot to
+;;;; THE MECHANISM: `redact-sensitive-event-vector` redacts the slot to
 ;;;; `:rf/redacted` when the source epoch is `:rf.epoch/sensitive? true`
 ;;;; AND the runtime raw-state gate is OFF (the published-build default —
 ;;;; the MCP server signals `configure-raw-state! {:allow-raw-state?
@@ -237,8 +236,8 @@
 ;; trips these.
 ;; ---------------------------------------------------------------------------
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private runtime-cljs-path rt/runtime-cljs-path)
 (def ^:private form-contains? rt/form-contains?)
 

--- a/skills/re-frame2-pair/tests/runtime/dispatch_consequence_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/dispatch_consequence_test.clj
@@ -1,14 +1,14 @@
 ;;;; tests/runtime/dispatch_consequence_test.clj
 ;;;;
-;;;; Babashka-runnable structural pin (rf2-3bu3d.2 / rf2-3bu3d.3) that the
-;;;; runtime preload defines the wire-boundary consequence + validation
-;;;; surface the MCP `dispatch` tool routes through:
+;;;; Babashka-runnable structural pin that the runtime preload defines the
+;;;; wire-boundary consequence + validation surface the MCP `dispatch` tool
+;;;; routes through:
 ;;;;
 ;;;;   - `dispatch-consequence!`  — the DEFAULT sync dispatch. Returns the
 ;;;;     re-frame2 CONSEQUENCE (`:db-changed?` / `:changed-paths` /
 ;;;;     `:effects-fired` / `:no-op?`) so a no-op is VISIBLE, not a fake
-;;;;     `{:mode :sync}` ack (rf2-3bu3d.2). VALIDATEs the event-id FIRST
-;;;;     and ECHOes the resolved event (rf2-3bu3d.3).
+;;;;     `{:mode :sync}` ack. VALIDATEs the event-id FIRST and ECHOes the
+;;;;     resolved event.
 ;;;;   - `validate-event-id` / `validate-registered` — the call-time id
 ;;;;     check against the LIVE registrar. An unknown id returns
 ;;;;     `:reason :unknown-id` with `:nearest` matches — never a silent
@@ -23,8 +23,8 @@
   (:require [clojure.test :refer [deftest is run-tests]]
             [runtime-support :as rt]))
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private defn-named rt/defn-named)
 (def ^:private form-contains? rt/form-contains?)
 

--- a/skills/re-frame2-pair/tests/runtime/dom_readback_redaction_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/dom_readback_redaction_test.clj
@@ -1,36 +1,29 @@
 ;;;; tests/runtime/dom_readback_redaction_test.clj
 ;;;;
 ;;;; Babashka-runnable verification of the DOM / readback derived-value
-;;;; egress redaction (rf2-p9scds) in
-;;;; `preload/re_frame2_pair/runtime.cljs`.
+;;;; egress redaction in `preload/re_frame2_pair/runtime.cljs`.
 ;;;;
-;;;; THE BUG (rf2-p9scds). EP-0015 / Spec 015 treat framework-known
-;;;; derivations from sensitive inputs as sensitive unless explicitly
-;;;; public, and Tool-Pair says rendered DOM text crossing off-box must not
-;;;; ride unconditionally. The pair runtime's DOM / readback surfaces did
-;;;; NOT apply that posture:
-;;;;
-;;;;   - `dom-read` (raw DOM plane) returned `node->content` nodes directly
-;;;;     with NO redaction at all.
-;;;;   - `ui-read` ran the path-based `elide-wire-value` over just the
-;;;;     anonymous `:text` string — but that walker redacts by app-db PATH,
-;;;;     and rendered text has none, so it never caught a secret copied INTO
-;;;;     the DOM; `:attrs` were returned untouched entirely.
-;;;;   - `sample-one-signal`'s `:dom` / `:focus` arms passed the rendered
-;;;;     textContent / attribute / focus descriptor through un-elided.
-;;;;
+;;;; THE CONTRACT. Spec 015 treats framework-known derivations from
+;;;; sensitive inputs as sensitive unless explicitly public, and Tool-Pair
+;;;; says rendered DOM text crossing off-box must not ride unconditionally.
 ;;;; A secret copied from a declared-sensitive app-db path (`[:auth :token]`
-;;;; -> "SECRET") into rendered DOM text / attrs / a focus descriptor then
-;;;; crossed the off-box MCP wire RAW.
+;;;; -> "SECRET") into rendered DOM text / attrs / a focus descriptor must
+;;;; NOT cross the off-box MCP wire RAW. The trap to avoid: `dom-read`
+;;;; returning `node->content` nodes with no redaction, `ui-read` running
+;;;; the path-based `elide-wire-value` over just the anonymous `:text`
+;;;; string (that walker redacts by app-db PATH, and rendered text has none,
+;;;; so it never catches a secret copied INTO the DOM, and never touches
+;;;; `:attrs`), or `sample-one-signal`'s `:dom` / `:focus` arms passing the
+;;;; rendered textContent / attribute / focus descriptor through un-elided.
 ;;;;
-;;;; THE FIX. `maybe-redact-derived` value-redacts a DERIVED tree (rendered
-;;;; text / attrs / focus descriptor) via `re-frame.core/redact-derived-
-;;;; values` against the frame's declared-`:sensitive?` app-db VALUES, under
-;;;; the off-box raw-state gate. `dom-read` / `ui-read` / the `:dom` /
-;;;; `:focus` sample arms now route their derived output through it. A
-;;;; surface that needs frame policy but cannot resolve a frame under the
-;;;; off-box gate FAILS CLOSED with `:ambiguous-frame`, never synthesising
-;;;; `:rf/default`.
+;;;; THE MECHANISM. `maybe-redact-derived` value-redacts a DERIVED tree
+;;;; (rendered text / attrs / focus descriptor) via
+;;;; `re-frame.core/redact-derived-values` against the frame's
+;;;; declared-`:sensitive?` app-db VALUES, under the off-box raw-state gate.
+;;;; `dom-read` / `ui-read` / the `:dom` / `:focus` sample arms route their
+;;;; derived output through it. A surface that needs frame policy but cannot
+;;;; resolve a frame under the off-box gate FAILS CLOSED with
+;;;; `:ambiguous-frame`, never synthesising `:rf/default`.
 ;;;;
 ;;;; Why a parallel implementation lives here. `runtime.cljs` is CLJS-only
 ;;;; (a shadow-cljs `:devtools :preloads` file) and depends on the live
@@ -184,8 +177,8 @@
 ;; regression in the cljs trips RED.
 ;; ---------------------------------------------------------------------------
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private defn-form rt/defn-named)
 
 (defn- mentions? [form needle]
@@ -215,8 +208,8 @@
     (is (some? f))
     (is (mentions? f 'maybe-redact-derived)
         "ui-read must value-redact the whole :content")
-    ;; The bug was a path-based elide over JUST the :text string. Assert that
-    ;; exact shape is gone — ui-read must not call elide-wire-value on :text.
+    ;; A path-based elide over JUST the :text string is the wrong shape.
+    ;; Assert it is absent — ui-read must not call elide-wire-value on :text.
     (is (not (str/includes? s "(rf/elide-wire-value (:text base)"))
         "ui-read must NOT path-elide only :text (the rf2-p9scds bug)")
     (is (mentions? f 'ambiguous-frame-error)
@@ -225,8 +218,7 @@
 (deftest dom-and-focus-sample-arms-redact
   (let [f (defn-form 'sample-one-signal)]
     (is (some? f))
-    ;; Both DERIVED arms must route through the value-redactor — the docstring
-    ;; previously (and wrongly) said they pass through un-elided.
+    ;; Both DERIVED arms must route through the value-redactor.
     (is (<= 2 (count (re-seq #"maybe-redact-derived" (pr-str f))))
         "both the :dom and :focus arms must value-redact their derived output")))
 
@@ -235,7 +227,7 @@
         samp  (defn-form 'sample-signals)]
     (is (mentions? start 'ambiguous-frame-error)
         "start-recording! must refuse an unresolvable frame")
-    ;; needs-frame? must now extend to :dom / :focus under the off-box gate.
+    ;; needs-frame? must extend to :dom / :focus under the off-box gate.
     (is (and (mentions? start :dom) (mentions? start :focus))
         "start-recording! needs-frame? must cover :dom / :focus (off-box gate)")
     (is (mentions? samp 'ambiguous-frame-error)

--- a/skills/re-frame2-pair/tests/runtime/frame_registrar_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/frame_registrar_test.clj
@@ -1,24 +1,23 @@
 ;;;; tests/runtime/frame_registrar_test.clj
 ;;;;
-;;;; Babashka-runnable structural pin (rf2-srobm0) for the EP-0023
-;;;; forward-direction preload fns: the per-frame registrar reads and the
-;;;; `describe-image` generation read.
+;;;; Babashka-runnable structural pin for the frame-derived preload fns:
+;;;; the per-frame registrar reads and the `describe-image` generation read.
 ;;;;
 ;;;; Why this test exists:
 ;;;;
 ;;;; The MCP `handler-meta` / `list-handlers` / `describe-image` tools
 ;;;; re-key registration resolution through the OPERATING FRAME's running
 ;;;; image generation (the same `(kind, id)` can resolve differently per
-;;;; frame). EP-0023 forbids tools from consuming `re-frame.live-frame` /
-;;;; `re-frame.image-assembly` internals directly — the preload must route
-;;;; through the PUBLIC facade reads shipped by rf2-wkw8na:
+;;;; frame). Tools must not consume `re-frame.live-frame` /
+;;;; `re-frame.image-assembly` internals directly — the preload routes
+;;;; through the PUBLIC facade reads:
 ;;;;
 ;;;;   (rf/handler-meta {:frame f :kind k :id id})
 ;;;;   (rf/handler-ids  {:frame f :kind k})
 ;;;;   (rf/registrations {:frame f :kind k})
 ;;;;   (rf/frame-generation f)
 ;;;;
-;;;; This pin asserts the four new preload fns exist and route through the
+;;;; This pin asserts the four preload fns exist and route through the
 ;;;; `:frame`-arity facade reads / `frame-generation` — NOT the internal
 ;;;; live-frame / image-assembly namespaces. A regression that reached into
 ;;;; the internals (or dropped the per-frame fns) turns this red.
@@ -32,8 +31,8 @@
   (:require [clojure.test :refer [deftest is run-tests]]
             [runtime-support :as rt]))
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private defn-form rt/defn-named)
 (def ^:private form-contains? rt/form-contains?)
 
@@ -94,14 +93,14 @@
         "frame-capability-requires reports the image-declared :rf.gen/requires set.")))
 
 ;; ---------------------------------------------------------------------------
-;; describe-image guards the no-generation fail-loud (EP-0024 contract).
+;; describe-image guards the no-generation fail-loud.
 ;;
-;; Post-EP-0024 only an EXPLICIT :images key triggers image resolution, so an
-;; imageless frame carries NO generation and the public rf/frame-generation
-;; read FAILS LOUD (:rf.error/frame-no-generation) for it. describe-image must
-;; GUARD that call — catch the no-generation fail-loud for a LIVE frame and
-;; report it gracefully (:no-generation?), rather than letting it escape up the
-;; eval boundary — while still failing loud on a genuinely unresolvable target.
+;; Only an EXPLICIT :images key triggers image resolution, so an imageless
+;; frame carries NO generation and the public rf/frame-generation read FAILS
+;; LOUD (:rf.error/frame-no-generation) for it. describe-image must GUARD that
+;; call — catch the no-generation fail-loud for a LIVE frame and report it
+;; gracefully (:no-generation?), rather than letting it escape up the eval
+;; boundary — while still failing loud on a genuinely unresolvable target.
 ;; ---------------------------------------------------------------------------
 
 (deftest describe-image-guards-no-generation-fail-loud
@@ -120,7 +119,7 @@
         "describe-image MUST re-`throw` any non-no-generation error so a genuinely unresolvable :frame target still fails loud up the eval boundary.")))
 
 ;; ---------------------------------------------------------------------------
-;; No internal-namespace leakage (EP-0023 forbids tools consuming these).
+;; No internal-namespace leakage (tools must not consume these).
 ;; ---------------------------------------------------------------------------
 
 (deftest no-live-frame-or-image-assembly-internals-in-frame-fns

--- a/skills/re-frame2-pair/tests/runtime/multi_frame_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/multi_frame_test.clj
@@ -87,12 +87,12 @@
   (reset! selected-frame frame-id)
   {:ok? true :frame frame-id})
 
-;; rf2-3bu3d.4 — reserved-frame-aware resolution. KEEP IN SYNC with
+;; Reserved-frame-aware resolution. KEEP IN SYNC with
 ;; `reserved-tool-frame?` / `app-frame-ids` / `current-frame` in
 ;; preload/re_frame2_pair/runtime.cljs. A `:rf/*` frame is a TOOL frame (Xray's
 ;; `:rf/xray`, SSR slots) EXCLUDED from the ambiguity count, with the sole
 ;; `:rf/default` carve-out (an ordinary app frame id per Conventions.md §Reserved
-;; namespaces / EP-0002).
+;; namespaces).
 
 (defn reserved-tool-frame? [frame-id]
   (and (keyword? frame-id)
@@ -112,7 +112,7 @@
            (first app-fids))))))
 
 ;; ---------------------------------------------------------------------------
-;; Mirror of `ambiguous-frame-error` (rf2-n58jxo) — the enriched refusal
+;; Mirror of `ambiguous-frame-error` — the enriched refusal
 ;; envelope: operation, op-specific context, available app frames, the
 ;; current pin, and the concrete fix.
 ;;
@@ -238,7 +238,7 @@
     (is (= :ghost (current-frame :ghost)))))
 
 ;; ---------------------------------------------------------------------------
-;; Reserved-frame-aware resolution (rf2-3bu3d.4)
+;; Reserved-frame-aware resolution
 ;;
 ;; A `:rf/*` TOOL frame (`:rf/xray`, an SSR slot) is excluded from the
 ;; ambiguity count; the sole remaining APP frame auto-selects. `:rf/default`
@@ -297,7 +297,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Tier-3 sole-app-frame resolution (frame-only — there is no realm/container
-;; dimension; the re-frame.realm substrate was removed, rf2-udl74a).
+;; dimension).
 ;; ---------------------------------------------------------------------------
 
 (deftest single-app-frame-resolves
@@ -337,9 +337,9 @@
       (catch clojure.lang.ExceptionInfo e
         (let [data (ex-data e)]
           (is (= :ambiguous-frame (:reason data)))
-          ;; rf2-n58jxo — the throw carries the enriched diagnostics: the
-          ;; operation, the event being dispatched, the available app
-          ;; frames, the current pin, and a fix-bearing hint.
+          ;; The throw carries the enriched diagnostics: the operation, the
+          ;; event being dispatched, the available app frames, the current
+          ;; pin, and a fix-bearing hint.
           (is (= :dispatch (:operation data)))
           (is (= [:cart/apply-coupon "SPRING25"] (:event data)))
           (is (= #{:rf/default :stories} (set (:available-frames data)))
@@ -383,7 +383,7 @@
     (let [result (subs-sample [:counter])]
       (is (false? (:ok? result)))
       (is (= :ambiguous-frame (:reason result)))
-      ;; rf2-n58jxo — enriched: operation, the query, the available frames.
+      ;; Enriched: operation, the query, the available frames.
       (is (= :subs-sample (:operation result)))
       (is (= [:counter] (:query result)))
       (is (= #{:rf/default :stories} (set (:available-frames result)))))))

--- a/skills/re-frame2-pair/tests/runtime/orient_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/orient_test.clj
@@ -1,14 +1,14 @@
 ;;;; tests/runtime/orient_test.clj
 ;;;;
-;;;; Babashka-runnable structural pin (rf2-3bu3d.8) that the runtime
-;;;; preload defines `orient` — the app-shape orientation summary the MCP
-;;;; `orient` tool wraps — and that it COMPOSES from the existing
-;;;; introspection surfaces (no parallel reimplementation) and carries the
-;;;; documented summary slots.
+;;;; Babashka-runnable structural pin that the runtime preload defines
+;;;; `orient` — the app-shape orientation summary the MCP `orient` tool
+;;;; wraps — and that it COMPOSES from the existing introspection surfaces
+;;;; (no parallel reimplementation) and carries the documented summary
+;;;; slots.
 ;;;;
-;;;; ## What rf2-3bu3d.8 adds
+;;;; ## What orient provides
 ;;;;
-;;;;   First-contact on an UNFAMILIAR app otherwise took several calls
+;;;;   First-contact on an UNFAMILIAR app otherwise takes several calls
 ;;;;   (discover-app + snapshot top-keys + list-handlers +
 ;;;;   list-subscriptions + machines). `orient` composes them into one
 ;;;;   compact map by REUSING the existing surfaces:
@@ -38,8 +38,8 @@
   (:require [clojure.test :refer [deftest is run-tests]]
             [runtime-support :as rt]))
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private defn-named rt/defn-named)
 (def ^:private form-contains? rt/form-contains?)
 
@@ -64,9 +64,9 @@
         "orient reuses `health` for liveness/frames.")
     (is (form-contains? #(= 'app-frame-ids %) form)
         "orient reuses `app-frame-ids` (tool frames split out).")
-    ;; rf2-srobm0 — the registry slot is now produced by the registry-view
-    ;; helpers (frame-registry-view ⊳ process-registry-view fallback); the
-    ;; process view still reuses `registrar-list` for the navigable ids.
+    ;; The registry slot is produced by the registry-view helpers
+    ;; (frame-registry-view ⊳ process-registry-view fallback); the process
+    ;; view reuses `registrar-list` for the navigable ids.
     (is (and (form-contains? #(= 'frame-registry-view %) form)
              (form-contains? #(= 'process-registry-view %) form))
         "orient composes its :registry from the frame/process registry-view helpers.")
@@ -76,7 +76,7 @@
 (deftest orient-excludes-tool-frames-from-top-keys
   ;; :app-db-top-keys must key on app frames (via app-frame-ids), so a
   ;; reserved :rf/* tool frame's inspection state can't overflow the
-  ;; first-contact summary (rf2-3bu3d.6 posture).
+  ;; first-contact summary.
   (let [form (defn-named 'orient)]
     (is (form-contains? #(= 'app-frame-ids %) form)
         "orient derives :app-db-top-keys keys from app-frame-ids — tool frames excluded.")))
@@ -93,10 +93,10 @@
    The `:registry` slot here mirrors the PROCESS-VIEW fallback shape
    (`process-registry-view`) — the byte-stable counts + navigable id vectors.
    Live, orient re-bases on the OPERATING FRAME's image generation when one
-   resolves (rf2-srobm0), adding `:basis :frame` + `:frame <id>` and keying
-   the counts off the frame's resolver; the process view carries `:basis
-   :process`. This mirror pins the documented summary slot shape, not the
-   per-basis resolution (the frame/process registry-view fns own that)."
+   resolves, adding `:basis :frame` + `:frame <id>` and keying the counts off
+   the frame's resolver; the process view carries `:basis :process`. This
+   mirror pins the documented summary slot shape, not the per-basis
+   resolution (the frame/process registry-view fns own that)."
   [{:keys [health app-fids app-dbs registrations machines]}]
   {:ok?      true
    :liveness {:debug-enabled?      (:debug-enabled? health)

--- a/skills/re-frame2-pair/tests/runtime/parse_rf2_coord_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/parse_rf2_coord_test.clj
@@ -6,10 +6,10 @@
 ;;;; Why a parallel implementation lives here:
 ;;;;
 ;;;;   `preload/re_frame2_pair/runtime.cljs` is a CLJS-only file loaded
-;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It now
+;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It
 ;;;;   aliases the CANONICAL parser `re-frame.source-coords/parse-source-coord`
-;;;;   (the source-coord contract owner; rf2-nr7vf2 collapsed the formerly-
-;;;;   triplicated parser onto it — the inverse of `format-source-coord`).
+;;;;   (the source-coord contract owner — the inverse of
+;;;;   `format-source-coord`).
 ;;;;   Loading that core `.cljc` ns under bb would drag in re-frame.interop +
 ;;;;   the editor-uri sibling, so this script keeps a dependency-free mirror
 ;;;;   of the four-segment parse and asserts behaviour against samples cribbed

--- a/skills/re-frame2-pair/tests/runtime/parse_view_id_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/parse_view_id_test.clj
@@ -6,13 +6,12 @@
 ;;;; Why a parallel implementation lives here:
 ;;;;
 ;;;;   `preload/re_frame2_pair/runtime.cljs` is a CLJS-only file loaded
-;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It now
+;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It
 ;;;;   aliases the CANONICAL reader `re-frame.source-coords/parse-view-id`
-;;;;   (the source-coord contract owner; rf2-ztxnm8 collapsed the formerly-
-;;;;   inline `data-rf-view` parse in `view-entity` onto it — the inverse of
-;;;;   `format-view-id`, the data-rf-view analogue of the parse-source-coord
-;;;;   work in rf2-nr7vf2). Loading that core `.cljc` ns under bb would drag
-;;;;   in re-frame.interop + the editor-uri sibling, so this script keeps a
+;;;;   (the source-coord contract owner — the inverse of `format-view-id`,
+;;;;   the data-rf-view analogue of `parse-source-coord`). Loading that core
+;;;;   `.cljc` ns under bb would drag in re-frame.interop + the editor-uri
+;;;;   sibling, so this script keeps a
 ;;;;   dependency-free mirror of the read rule (leading-colon -> keyword;
 ;;;;   first `/` -> namespaced keyword; else raw string) and asserts the
 ;;;;   round-trip against a mirror of `format-view-id` so format drift shows

--- a/skills/re-frame2-pair/tests/runtime/preload_sentinel_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/preload_sentinel_test.clj
@@ -6,11 +6,10 @@
 ;;;;
 ;;;; Why this test exists:
 ;;;;
-;;;; The MCP server's `discover-app` no longer cljs-eval-injects the
-;;;; runtime; it probes the load-time marker and refuses with
-;;;; `:reason :runtime-not-preloaded` if absent. The probe depends on
-;;;; the preload setting `js/globalThis.__re_frame2_pair_runtime` to a
-;;;; non-nil value. If that side-effect ever regresses (someone removes
+;;;; The MCP server's `discover-app` probes the load-time marker and
+;;;; refuses with `:reason :runtime-not-preloaded` if absent. The probe
+;;;; depends on the preload setting `js/globalThis.__re_frame2_pair_runtime`
+;;;; to a non-nil value. If that side-effect ever regresses (someone removes
 ;;;; the `defonce`, or renames the global) every re-frame2-pair session breaks
 ;;;; the same way: "runtime not preloaded" despite the preload being
 ;;;; in place. This structural check fails fast at PR time.
@@ -33,8 +32,8 @@
  (:require [clojure.test :refer [deftest is run-tests]]
  [runtime-support :as rt]))
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private all-forms rt/all-forms)
 (def ^:private form-contains? rt/form-contains?)
 

--- a/skills/re-frame2-pair/tests/runtime/raw_state_tap_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/raw_state_tap_test.clj
@@ -14,8 +14,8 @@
 ;;;; `rf/elide-wire-value` directly) — verbatim payloads only ride
 ;;;; when the gate is explicitly opted in.
 ;;;; 3. `raw-state-config` defaults to `:allow-raw-state? true` so a
-;;;; bare REPL session (no re-frame2-pair-mcp attached) sees the legacy
-;;;; behaviour. The MCP-server boot flips it to `false` via
+;;;; bare REPL session (no re-frame2-pair-mcp attached) sees verbatim
+;;;; payloads. The MCP-server boot flips it to `false` via
 ;;;; `configure-raw-state!`.
 ;;;;
 ;;;; Run: bb tests/runtime/raw_state_tap_test.clj
@@ -27,8 +27,8 @@
  (:require [clojure.test :refer [deftest is run-tests testing]]
  [runtime-support :as rt]))
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 
 (defn- find-top-form
  "Find the top-level form whose head matches `head-sym` and whose first

--- a/skills/re-frame2-pair/tests/runtime/read_sub_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/read_sub_test.clj
@@ -1,10 +1,10 @@
 ;;;; tests/runtime/read_sub_test.clj
 ;;;;
 ;;;; Babashka-runnable verification of `read-sub!` + `validate-sub-id` in
-;;;; preload/re_frame2_pair/runtime.cljs (rf2-3bu3d.7) — the validated
-;;;; one-shot subscription read the MCP `read-sub` tool wraps.
+;;;; preload/re_frame2_pair/runtime.cljs — the validated one-shot
+;;;; subscription read the MCP `read-sub` tool wraps.
 ;;;;
-;;;; ## What rf2-3bu3d.7 adds
+;;;; ## What read-sub! provides
 ;;;;
 ;;;;   Reading a subscription value — the #1 read on any re-frame2 app —
 ;;;;   via raw eval-cljs `@(rf/subscribe [:foo])` is UNVALIDATED: a typo'd
@@ -43,7 +43,7 @@
 ;; and carry the no-silent-swallow slots. Mirrors the dispatch_consequence
 ;; structural-pin style so a refactor that drops the validation can't ship
 ;; green. Shared locate+parse+walk scaffold lives in
-;; tests/runtime/_support.clj (rf2-yrpt90).
+;; tests/runtime/_support.clj.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private defn-named rt/defn-named)
@@ -69,9 +69,9 @@
     (is (some? form))
     (doseq [slot [:unknown-id :ambiguous-frame :sub-error :not-a-sub-vector]]
       ;; :unknown-id is produced by validate-registered (called via
-      ;; validate-sub-id); :ambiguous-frame is now produced via the shared
-      ;; enriched builder `ambiguous-frame-error` (rf2-n58jxo) rather than an
-      ;; inline keyword; the others are literal in read-sub!.
+      ;; validate-sub-id); :ambiguous-frame is produced via the shared
+      ;; enriched builder `ambiguous-frame-error` rather than an inline
+      ;; keyword; the others are literal in read-sub!.
       (is (or (form-contains? #(= slot %) form)
               (and (= slot :unknown-id)
                    (form-contains? #(= 'validate-sub-id %) form))
@@ -138,10 +138,9 @@
       (throw (ex-info "boom" {}))
       v)))
 
-;; Mirror of `ambiguous-frame-error` (rf2-n58jxo). The full runtime helper
-;; carries realm context; this read-sub mirror uses the simpler frame model
-;; (no realms) so it surfaces the load-bearing slots: operation, the query,
-;; the available frames, the current pin. KEEP THE SLOT CONTRACT IN SYNC.
+;; Mirror of `ambiguous-frame-error`. It surfaces the load-bearing slots:
+;; operation, the query, the available frames, the current pin. KEEP THE
+;; SLOT CONTRACT IN SYNC.
 (defn ambiguous-frame-error [operation extra]
   (merge {:ok? false :reason :ambiguous-frame :operation operation
           :available-frames (vec (frame-ids))
@@ -191,9 +190,9 @@
     (is (= {:id 42 :name "Ada"} (:value r)))))
 
 (deftest unknown-sub-id-validated-not-subscribed
-  ;; The headline rf2-3bu3d.7 case: a typo'd sub-id must NOT silently
-  ;; subscribe + return nil. Validation short-circuits with :unknown-id +
-  ;; :nearest, :subscribed? false.
+  ;; The headline case: a typo'd sub-id must NOT silently subscribe +
+  ;; return nil. Validation short-circuits with :unknown-id + :nearest,
+  ;; :subscribed? false.
   (register-frame! :rf/default)
   (register-sub! :current-user)
   (let [r (read-sub! [:current-userr])]
@@ -218,7 +217,7 @@
   (let [r (read-sub! [:cart/total])]
     (is (false? (:ok? r)))
     (is (= :ambiguous-frame (:reason r)))
-    ;; rf2-n58jxo — enriched diagnostics on the refusal.
+    ;; Enriched diagnostics on the refusal.
     (is (= :read-sub (:operation r)))
     (is (= [:cart/total] (:query r)))
     (is (= #{:rf/default :rf/other} (set (:available-frames r)))

--- a/skills/re-frame2-pair/tests/runtime/recorder_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/recorder_test.clj
@@ -1,7 +1,7 @@
 ;;;; tests/runtime/recorder_test.clj
 ;;;;
 ;;;; Babashka-runnable structural verification of the signal recorder in
-;;;; `preload/re_frame2_pair/runtime.cljs` (rf2-zo4b9).
+;;;; `preload/re_frame2_pair/runtime.cljs`.
 ;;;;
 ;;;; Why a structural test rather than a runtime test:
 ;;;;
@@ -42,8 +42,8 @@
             [clojure.test :refer [deftest is run-tests testing]]
             [runtime-support :as rt]))
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private defn-form rt/defn-named)
 (def ^:private form-contains? rt/form-contains?)
 
@@ -143,10 +143,10 @@
         "start-recording! must default a wall-clock stop when none given")
     (is (form-contains? #(= % :no-signals) start)
         "start-recording! must refuse an empty signal-set")
-    ;; rf2-n58jxo — the bare `:ambiguous-frame` literal was replaced by a
-    ;; call to the shared enriched builder `ambiguous-frame-error`; the
-    ;; contract (refuse an unresolvable frame for app-db/sub signals) is now
-    ;; carried by that call rather than an inline keyword.
+    ;; The refusal for app-db/sub signals routes through the shared enriched
+    ;; builder `ambiguous-frame-error`; the contract (refuse an unresolvable
+    ;; frame) is carried by that call rather than a bare `:ambiguous-frame`
+    ;; keyword.
     (is (mentions-sym? start 'ambiguous-frame-error)
         "start-recording! must refuse an unresolvable frame via ambiguous-frame-error")))
 

--- a/skills/re-frame2-pair/tests/runtime/registrar_describe_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/registrar_describe_test.clj
@@ -1,22 +1,20 @@
 ;;;; tests/runtime/registrar_describe_test.clj
 ;;;;
-;;;; Babashka-runnable structural pin (rf2-l7vnd) that
-;;;; `registrar-describe` strips the raw `:handler-fn` value from its
-;;;; return before handing it to the MCP wire.
+;;;; Babashka-runnable structural pin that `registrar-describe` strips the
+;;;; raw `:handler-fn` value from its return before handing it to the MCP
+;;;; wire.
 ;;;;
 ;;;; Why this test exists:
 ;;;;
 ;;;; `re-frame.core/handler-meta` carries a `:handler-fn` slot whose
 ;;;; value is a raw Function. `pr-str` of a Function emits
-;;;; `#object[Function "..."]` — unreadable EDN on the MCP wire. Before
-;;;; rf2-l7vnd the MCP server's `read-edn-safe` then fell back to the
-;;;; raw string, and the `handler-meta` tool surfaced
-;;;; `{:ok? false :reason :unexpected-shape :value "{...}"}` — a
-;;;; "failed" envelope with the actual handler data embedded as a
-;;;; string. Every operator hit this on every `handler-meta` call.
+;;;; `#object[Function "..."]` — unreadable EDN on the MCP wire, which the
+;;;; MCP server's `read-edn-safe` would fall back to as a raw string,
+;;;; surfacing `{:ok? false :reason :unexpected-shape :value "{...}"}` — a
+;;;; "failed" envelope with the actual handler data embedded as a string.
 ;;;;
-;;;; The fix is to drop `:handler-fn` server-side so the wire EDN is
-;;;; clean by construction. The hash (`:handler-fn-hash`) is the
+;;;; So `registrar-describe` drops `:handler-fn` server-side, leaving the
+;;;; wire EDN clean by construction. The hash (`:handler-fn-hash`) is the
 ;;;; wire-friendly substitute consumers actually use.
 ;;;;
 ;;;; Run: bb tests/runtime/registrar_describe_test.clj
@@ -28,8 +26,8 @@
  (:require [clojure.test :refer [deftest is run-tests]]
  [runtime-support :as rt]))
 
-;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
-;; (rf2-yrpt90). Alias the vars the assertions below use.
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj.
+;; Alias the vars the assertions below use.
 (def ^:private all-forms rt/all-forms)
 (def ^:private form-contains? rt/form-contains?)
 

--- a/skills/re-frame2-pair/tests/runtime/snapshot_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/snapshot_test.clj
@@ -33,11 +33,11 @@
 ;; under test routes by `:include` keys and assembles one map per
 ;; frame-id.
 
-;; EP-0001 rf2-vzld77 — machine snapshots are RUNTIME-DB-partition state.
-;; The fixture now carries a `:runtime-db` partition per frame (read via
-;; `rf/runtime-db-value` in production); the `:machines` slice sources its
-;; `:state` from `[:rf.runtime/machines :snapshots]` there, NOT from app-db
-;; `:rf/runtime`. KEEP IN SYNC with preload/re_frame2_pair/runtime.cljs.
+;; Machine snapshots are RUNTIME-DB-partition state. The fixture carries a
+;; `:runtime-db` partition per frame (read via `rf/runtime-db-value` in
+;; production); the `:machines` slice sources its `:state` from
+;; `[:rf.runtime/machines :snapshots]` there, NOT from app-db `:rf/runtime`.
+;; KEEP IN SYNC with preload/re_frame2_pair/runtime.cljs.
 (def fixture-frames
  {:rf/default {:app-db {:cart {:items 3 :total 4200}}
  :runtime-db {:rf.runtime/machines {:snapshots {:auth {:state :authed}}}}
@@ -51,7 +51,7 @@
  :sub-cache {[:stories/active] {:value :checkout :ref-count 1}}
  :epochs [{:epoch-id "s1" :event-id :stories/load}]
  :traces [{:id 3 :operation :rf.event/dispatched :tags {:frame :stories}}]}
- ;; rf2-3bu3d.6 — a reserved :rf/* TOOL frame (Xray's inspector frame).
+ ;; A reserved :rf/* TOOL frame (Xray's inspector frame).
  ;; Its :app-db is the huge tool-frame inspection state that the default
  ;; `:app` scope MUST exclude so the first read doesn't overflow on it.
  :rf/xray {:app-db {:xray/inspector {:xray-mega-state :massive}}
@@ -67,11 +67,10 @@
 (defn stub-epoch-history [fid] (get-in fixture-frames [fid :epochs]))
 (defn stub-machines [] [:auth :session]) ;; global registrar surface
 (defn stub-trace-buffer
- "Per rf2-g1b2m / rf2-8uwce the framework's `trace-buffer` is now
- per-frame and cascade-keyed; the frame-id is the required first arg.
- Per rf2-mscih the snapshot `:traces` slice now ships cascade-bundles
- by default (the framework's storage unit), matching the streaming
- subscribe wire shape. This stub returns the fixture's `:traces`
+ "The framework's `trace-buffer` is per-frame and cascade-keyed; the
+ frame-id is the required first arg. The snapshot `:traces` slice ships
+ cascade-bundles by default (the framework's storage unit), matching the
+ streaming subscribe wire shape. This stub returns the fixture's `:traces`
  vector directly — the loosely-typed stub is shape-agnostic; the
  production snapshot slice calls `(trace-tooling/trace-buffer
  frame-id)` (zero-arg opts) for the cascade-bundle default."
@@ -86,12 +85,12 @@
 (def ^:private all-snapshot-slices
  [:app-db :sub-cache :machines :epochs :traces])
 
-;; rf2-3bu3d.6 — reserved-frame predicate + app-frame view. KEEP IN SYNC
-;; with `reserved-tool-frame?` / `app-frame-ids` in
-;; preload/re_frame2_pair/runtime.cljs (landed rf2-3bu3d.4). A `:rf/*`
-;; frame is a TOOL frame (Xray's :rf/xray, SSR slots) excluded from the
-;; default snapshot scope; the sole `:rf/default` carve-out is an ordinary
-;; APP frame id (no framework privilege), not a tool frame.
+;; Reserved-frame predicate + app-frame view. KEEP IN SYNC with
+;; `reserved-tool-frame?` / `app-frame-ids` in
+;; preload/re_frame2_pair/runtime.cljs. A `:rf/*` frame is a TOOL frame
+;; (Xray's :rf/xray, SSR slots) excluded from the default snapshot scope;
+;; the sole `:rf/default` carve-out is an ordinary APP frame id (no
+;; framework privilege), not a tool frame.
 
 (defn- reserved-tool-frame? [frame-id]
  (and (keyword? frame-id)
@@ -105,17 +104,16 @@
  (case slice
  :app-db (stub-get-frame-db frame-id)
  :sub-cache (stub-sub-cache frame-id)
- ;; rf2-vzld77 — machine snapshots read from the RUNTIME-DB partition
- ;; at [:rf.runtime/machines :snapshots], NOT app-db :rf/runtime.
+ ;; Machine snapshots read from the RUNTIME-DB partition at
+ ;; [:rf.runtime/machines :snapshots], NOT app-db :rf/runtime.
  :machines {:ids (vec (stub-machines))
  :state (or (get-in (stub-runtime-db frame-id)
  [:rf.runtime/machines :snapshots])
  {})}
  :epochs (vec (stub-epoch-history frame-id))
- ;; Per rf2-g1b2m / rf2-8uwce the trace ring is per-frame; per
- ;; rf2-mscih the snapshot `:traces` slice ships cascade-bundles
- ;; by default (the framework's storage unit, matching the
- ;; streaming subscribe wire shape per Tool-Pair §Reading the
+ ;; The trace ring is per-frame; the snapshot `:traces` slice ships
+ ;; cascade-bundles by default (the framework's storage unit, matching
+ ;; the streaming subscribe wire shape per Tool-Pair §Reading the
  ;; per-frame trace ring). Production runtime calls
  ;; `(trace-tooling/trace-buffer frame-id)` (zero-arg opts).
  :traces (vec (stub-trace-buffer frame-id))
@@ -132,9 +130,9 @@
  ([{:keys [frames include]
  :or {frames :app include all-snapshot-slices}}]
  (let [fids (cond
- ;; rf2-3bu3d.6 — DEFAULT scope `:app` = app frames only
- ;; (reserved :rf/* tool frames excluded). `:all` is the
- ;; explicit opt-in to tool-frame state.
+ ;; DEFAULT scope `:app` = app frames only (reserved :rf/*
+ ;; tool frames excluded). `:all` is the explicit opt-in
+ ;; to tool-frame state.
  (= :app frames) (app-frame-ids)
  (= :all frames) (vec (stub-frame-ids))
  (sequential? frames) (vec frames)
@@ -147,11 +145,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest default-scope-is-app-frames-excludes-reserved-tool-frames
- ;; rf2-3bu3d.6 — THE bead's central assertion. The no-arg / default
- ;; snapshot returns the APP frames only; the reserved :rf/xray TOOL
- ;; frame is EXCLUDED so the first read doesn't overflow on tool-frame
- ;; inspection state. RED before the fix (default was :all → :rf/xray
- ;; was present); GREEN after.
+ ;; The central assertion. The no-arg / default snapshot returns the APP
+ ;; frames only; the reserved :rf/xray TOOL frame is EXCLUDED so the first
+ ;; read doesn't overflow on tool-frame inspection state.
  (let [snap (snapshot-state)]
  (testing "default scope = app frames; reserved :rf/* tool frame excluded"
  (is (= #{:rf/default :stories} (set (keys snap)))
@@ -165,7 +161,7 @@
  (str fid " missing slice keys"))))))
 
 (deftest explicit-all-includes-reserved-tool-frames
- ;; rf2-3bu3d.6 — the opt-in. `:all` returns EVERY frame INCLUDING the
+ ;; The opt-in. `:all` returns EVERY frame INCLUDING the
  ;; reserved :rf/xray tool frame.
  (let [snap (snapshot-state {:frames :all})]
  (is (= #{:rf/default :stories :rf/xray} (set (keys snap)))
@@ -185,9 +181,8 @@
  "naming :rf/xray explicitly includes it")))
 
 (deftest app-db-slice-delegates-to-frame-db
- ;; rf2-vzld77 — the app-db partition no longer carries machine snapshots
- ;; (they moved to runtime-db); the `:app-db` slice is the pure app
- ;; partition.
+ ;; The app-db partition does not carry machine snapshots (those live in
+ ;; runtime-db); the `:app-db` slice is the pure app partition.
  (let [snap (snapshot-state {:include [:app-db]})]
  (is (= {:cart {:items 3 :total 4200}}
  (get-in snap [:rf/default :app-db])))

--- a/skills/re-frame2-pair/tests/runtime/streaming_subscriptions_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/streaming_subscriptions_test.clj
@@ -54,11 +54,11 @@
  (and (or (nil? operation) (= operation (:operation ev)))
  (or (nil? op-type) (= op-type (:op-type ev)))
  (or (nil? severity) (= severity (:op-type ev)))
- ;; rf2-7737vq — mirror the runtime's canonical
- ;; `re-frame.trace/trace-event-frame` read: a RAW trace event carries
- ;; frame identity ONLY under `[:tags :frame]`. (Inlined as the
- ;; `get-in` the canonical reader is implemented as, because this bb
- ;; mirror can't `:require` the CLJS preload / the CLJC trace ns.)
+ ;; Mirror the runtime's canonical `re-frame.trace/trace-event-frame`
+ ;; read: a RAW trace event carries frame identity ONLY under
+ ;; `[:tags :frame]`. (Inlined as the `get-in` the canonical reader is
+ ;; implemented as, because this bb mirror can't `:require` the CLJS
+ ;; preload / the CLJC trace ns.)
  (or (nil? frame) (= frame (get-in ev [:tags :frame])))
  (or (nil? event-id) (= event-id
  (get-in ev [:tags :rf.trace/event-id])))
@@ -177,7 +177,7 @@
  (evict-oldest sub' max-events max-bytes)))
 
 (defn frameless-event?
- "Mirror of `runtime/frameless-event?` (rf2-mscih) — true when the event
+ "Mirror of `runtime/frameless-event?` — true when the event
  carries no `:rf.trace/dispatch-id` tag. The cascade-bundle topics
  filter these out at the dispatch gate; the `:frameless` topic accepts
  only these."
@@ -331,9 +331,8 @@
  (is (not (trace-matches? filter-map {:time 201})))))
 
 (deftest trace-filter-frame-reads-tags-frame
- ;; rf2-7737vq — a RAW trace event carries frame identity ONLY under
- ;; `[:tags :frame]`. The prior top-level-`:frame` fallback is gone, so a
- ;; top-level-only `:frame` no longer matches the frame filter axis.
+ ;; A RAW trace event carries frame identity ONLY under `[:tags :frame]`.
+ ;; A top-level-only `:frame` does not match the frame filter axis.
  (let [filter-map {:frame :stories}]
  (is (trace-matches? filter-map {:tags {:frame :stories}}))
  (is (not (trace-matches? filter-map {:frame :stories}))
@@ -397,9 +396,9 @@
  (let [subs (-> {} (subscribe! "s1" {:topic :trace :filter {:op-type :error}}))]
  (is (contains? subs "s1"))
  (is (= :trace (get-in subs ["s1" :topic])))
- (let [;; Three events, only one matches. Per rf2-mscih cascade-bundle
- ;; topics require `:rf.trace/dispatch-id` (frameless events get
- ;; routed to the `:frameless` channel instead).
+ (let [;; Three events, only one matches. Cascade-bundle topics require
+ ;; `:rf.trace/dispatch-id` (frameless events get routed to the
+ ;; `:frameless` channel instead).
  ev1 {:op-type :error :tags {:rf.trace/event-id :user/login
  :rf.trace/dispatch-id 1}}
  ev2 {:op-type :info :tags {:rf.trace/event-id :user/login
@@ -410,9 +409,9 @@
  (dispatch-trace-to-subs! ev1)
  (dispatch-trace-to-subs! ev2)
  (dispatch-trace-to-subs! ev3))]
- ;; Per rf2-mscih the drain returns `:queue` raw; the MCP-server
- ;; layer projects them into `:cascades` for cascade-bundle
- ;; topics. The bb-runnable mirror exposes the queue directly so
+ ;; The drain returns `:queue` raw; the MCP-server layer projects
+ ;; them into `:cascades` for cascade-bundle topics. The bb-runnable
+ ;; mirror exposes the queue directly so
  ;; the contract under test is "what landed in the queue after
  ;; filtering" rather than the post-projection wire shape.
  (let [[drain1 subs] (drain-subscription! subs "s1")]
@@ -445,9 +444,9 @@
 (deftest epoch-subscription-only-receives-epoch-events
  ;; An :epoch sub should NOT be fed trace events; a :trace sub should
  ;; NOT be fed epoch records. Verifies the topic gating in the
- ;; dispatchers. Per rf2-mscih the trace event carries a dispatch-id
- ;; so it routes to the cascade-bundle topic; a frameless event would
- ;; route to `:frameless` instead.
+ ;; dispatchers. The trace event carries a dispatch-id so it routes to
+ ;; the cascade-bundle topic; a frameless event would route to
+ ;; `:frameless` instead.
  (let [subs (-> {}
  (subscribe! "epoch-sub" {:topic :epoch :filter {:event-id :cart/add}})
  (subscribe! "trace-sub" {:topic :trace}))
@@ -461,7 +460,7 @@
 
 (deftest fx-topic-defaults-op-type-but-respects-overrides
  (let [;; :fx sub with no extra filter matches any trace event with
- ;; :op-type :rf.fx. Per rf2-mscih cascade-bundle topics require
+ ;; :op-type :rf.fx. Cascade-bundle topics require
  ;; `:rf.trace/dispatch-id`.
  subs (-> {} (subscribe! "fx-sub" {:topic :fx}))
  ev {:op-type :rf.fx :tags {:fx-id :http :rf.trace/dispatch-id 1}}
@@ -502,7 +501,7 @@
 
 (deftest overflow-count-only-trip-drops-oldest-and-reports-events-reason
  ;; bytes budget set generously so it can't trip — count budget = 2.
- ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
+ ;; Cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [subs (-> {} (subscribe! "s" {:topic :trace
  :max-buffered-events 2
  :max-buffered-bytes 100000000}))
@@ -532,7 +531,7 @@
 
 (deftest overflow-bytes-only-trip-drops-oldest-and-reports-bytes-reason
  ;; event budget set generously — fat events trip the byte budget.
- ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
+ ;; Cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [;; Each event's pr-str is dominated by :payload's length.
  fat (apply str (repeat 300 "x"))
  e1 {:op-type :info :id 1 :payload fat :tags {:rf.trace/dispatch-id 1}}
@@ -561,7 +560,7 @@
  ;; Small events + tight count cap + roomy byte cap = count trips first.
  ;; The reason MUST be :max-buffered-events when only the event budget
  ;; was exceeded on the tripping enqueue (bytes are still under cap).
- ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
+ ;; Cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [events (mapv #(hash-map :id % :tags {:rf.trace/dispatch-id %})
  (range 1 11)) ;; 10 events
  byte-cap 1000000 ;; never trips
@@ -579,7 +578,7 @@
  ;; Fat events + roomy count cap + tight byte cap = bytes trip first.
  ;; The reason MUST be :max-buffered-bytes since the byte budget is
  ;; what's forcing eviction.
- ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
+ ;; Cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [fat (apply str (repeat 1000 "y"))
  e1 {:id 1 :payload fat :tags {:rf.trace/dispatch-id 1}}
  e2 {:id 2 :payload fat :tags {:rf.trace/dispatch-id 2}}
@@ -604,7 +603,7 @@
 (deftest overflow-defaults-honour-runtime-defaults
  ;; Subscribe with neither budget specified — defaults populate from
  ;; the runtime constants. A queue under both caps takes no eviction.
- ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
+ ;; Cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [subs (-> {} (subscribe! "s" {:topic :trace}))
  sub (get subs "s")]
  (is (= default-max-buffered-events (:max-buffered-events sub)))
@@ -620,8 +619,8 @@
 (deftest unknown-topic-rejected-at-subscribe-level
  ;; The runtime's `subscribe!` returns {:ok? false :reason :unknown-topic}
  ;; — mirrored here as the dispatcher refusing to fan to an unknown topic.
- ;; Per rf2-mscih `:frameless` joins the recognised set as the explicit
- ;; opt-in channel for events with no `:rf.trace/dispatch-id`.
+ ;; `:frameless` is in the recognised set as the explicit opt-in
+ ;; channel for events with no `:rf.trace/dispatch-id`.
  (let [recognised #{:trace :epoch :fx :error :frameless}]
  (is (not (contains? recognised :other)))
  (is (every? recognised [:trace :epoch :fx :error :frameless]))))
@@ -652,7 +651,7 @@
  ;; Spec 009 §Privacy default contract: a `:sensitive? true` trace
  ;; event registered against a matching subscription MUST NOT be
  ;; enqueued under the default privacy posture.
- ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
+ ;; Cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [default-cfg {:include-sensitive? false}
  subs (-> {} (subscribe! "s1" {:topic :trace}))
  sensitive-ev {:op-type :rf.event :sensitive? true
@@ -679,7 +678,7 @@
  ;; The opt-in path is the escape hatch for apps where re-frame2-pair itself is
  ;; the trust boundary. With `:include-sensitive? true` the streaming
  ;; surface forwards every event regardless of the flag.
- ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
+ ;; Cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [opt-in-cfg {:include-sensitive? true}
  subs (-> {} (subscribe! "s1" {:topic :trace}))
  sensitive-ev {:op-type :rf.event :sensitive? true
@@ -698,7 +697,7 @@
  ;; The privacy guard runs *before* the per-subscription filter, so
  ;; even a subscription whose filter would otherwise match a sensitive
  ;; event sees nothing under the default policy.
- ;; Per rf2-mscih cascade-bundle topics require `:rf.trace/dispatch-id`.
+ ;; Cascade-bundle topics require `:rf.trace/dispatch-id`.
  (let [default-cfg {:include-sensitive? false}
  subs (-> {} (subscribe! "auth-events"
  {:topic :trace
@@ -711,7 +710,7 @@
  "even a filter that *names* the sensitive event must not pull it through")))
 
 ;; ---------------------------------------------------------------------------
-;; Cascade-bundle topic routing (rf2-mscih)
+;; Cascade-bundle topic routing
 ;; ---------------------------------------------------------------------------
 
 (deftest cascade-bundle-topics-reject-frameless-events
@@ -754,7 +753,7 @@
  (is (= [reg-ev repl-ev] (get-in subs ["frameless-sub" :queue]))))))
 
 (deftest cross-frame-dispatch-id-merge-contract
- ;; rf2-mscih cross-frame contract — a single cascade can fan out
+ ;; Cross-frame contract — a single cascade can fan out
  ;; across frames; every emit on every frame shares the same
  ;; `:rf.trace/dispatch-id`. The runtime queues events per
  ;; subscription; the consumer reconstructs the cross-frame timeline

--- a/skills/re-frame2-pair/tests/runtime/sub_cache_info_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/sub_cache_info_test.clj
@@ -2,19 +2,16 @@
 ;;;;
 ;;;; Babashka-runnable verification of the `sub-cache-info` reactive
 ;;;; sub-cache reader in `preload/re_frame2_pair/runtime.cljs` — the
-;;;; reader the re-frame2-pair MCP `list-subscriptions` tool wraps
-;;;; (rf2-qicji).
+;;;; reader the re-frame2-pair MCP `list-subscriptions` tool wraps.
 ;;;;
-;;;; ## What rf2-qicji fixed
+;;;; ## What sub-cache-info reads
 ;;;;
-;;;;   The MCP `list-subscriptions` tool used to wrap `subscription-info`
-;;;;   (the streaming-tap registry — trace/epoch/fx/error queues), so it
-;;;;   returned `{:subs []}` even when a frame had live reactive
-;;;;   subscriptions. The fix repoints `list-subscriptions` at
-;;;;   `sub-cache-info`, which reads the SAME live per-frame reactive
-;;;;   sub-cache `snapshot`'s `:sub-cache` slice reads
-;;;;   (`re-frame.subs.tooling/sub-cache-snapshot`). This test asserts
-;;;;   the reader:
+;;;;   The MCP `list-subscriptions` tool wraps `sub-cache-info`, which reads
+;;;;   the SAME live per-frame reactive sub-cache `snapshot`'s `:sub-cache`
+;;;;   slice reads (`re-frame.subs.tooling/sub-cache-snapshot`) — the live
+;;;;   reactive subscriptions, NOT the streaming-tap registry
+;;;;   (`subscription-info`, the trace/epoch/fx/error queues). This test
+;;;;   asserts the reader:
 ;;;;     - reports the cached query-vectors for a frame (the acceptance
 ;;;;       contract: `[["mounted?"]]` shows up when "mounted?" is cached);
 ;;;;     - AGREES with the sub-cache snapshot source by construction
@@ -48,8 +45,7 @@
 ;;
 ;; `frame-sub-caches` stands in for the live per-frame sub-cache the
 ;; framework's `re-frame.subs.tooling/sub-cache-snapshot` projects:
-;; `{query-v {:value v :ref-count n :input-kind k :realized-inputs [...]}}`
-;; (rf2-e3acps added the `:input-kind` + `:realized-inputs` slots).
+;; `{query-v {:value v :ref-count n :input-kind k :realized-inputs [...]}}`.
 ;; Disposing a reaction removes its entry — modelled here by `dispose-sub!`.
 ;; ---------------------------------------------------------------------------
 
@@ -64,7 +60,7 @@
 
 (defn cache-sub!
   "Cache an entry. The 4-arity defaults a layer-1 `:db` reader (no
-   realized input edges); the 6-arity sets the rf2-e3acps `:input-kind`
+   realized input edges); the 6-arity sets the `:input-kind`
    + `:realized-inputs` slots explicitly (static / parametric subs)."
   ([frame-id query-v value ref-count]
    (cache-sub! frame-id query-v value ref-count :db []))
@@ -104,7 +100,7 @@
 ;; preload/re_frame2_pair/runtime.cljs §Subscriptions.
 ;; ---------------------------------------------------------------------------
 
-;; Mirror of `ambiguous-frame-error` (rf2-n58jxo) — the load-bearing slots
+;; Mirror of `ambiguous-frame-error` — the load-bearing slots
 ;; (operation, available frames, current pin). KEEP THE SLOT CONTRACT IN SYNC.
 (defn ambiguous-frame-error [operation]
   {:ok? false :reason :ambiguous-frame :operation operation
@@ -145,8 +141,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest reports-cached-query-vectors-for-the-frame
-  ;; The acceptance contract (rf2-qicji): with ["mounted?"] cached in
-  ;; :rf/default, list-subscriptions {frame :rf/default} surfaces it.
+  ;; The acceptance contract: with ["mounted?"] cached in :rf/default,
+  ;; list-subscriptions {frame :rf/default} surfaces it.
   (register-frame! :rf/default)
   (cache-sub! :rf/default ["mounted?"] true 1)
   (let [r (sub-cache-info {:frame :rf/default})]
@@ -190,9 +186,8 @@
     (is (= [] (:subs r)))))
 
 (deftest include-values-carries-value-ref-count-input-kind-realized
-  ;; rf2-e3acps — :include-values? surfaces :input-kind + :realized-inputs
-  ;; alongside :value / :ref-count. A layer-1 :db reader has no realized
-  ;; input edges.
+  ;; :include-values? surfaces :input-kind + :realized-inputs alongside
+  ;; :value / :ref-count. A layer-1 :db reader has no realized input edges.
   (register-frame! :rf/default)
   (cache-sub! :rf/default ["cart" "total"] 4200 2)
   (let [r (sub-cache-info {:frame :rf/default :include-values? true})]
@@ -201,7 +196,7 @@
            (:subs r)))))
 
 (deftest include-values-surfaces-realized-parametric-inputs
-  ;; rf2-e3acps — the egress contract: a PARAMETRIC sub's live cache entry
+  ;; The egress contract: a PARAMETRIC sub's live cache entry
   ;; surfaces its REALIZED input query-vectors (the (input-fn query-v)
   ;; result for the concrete outer query-v), the runtime counterpart to
   ;; the static sub-topology's :inputs :parametric sentinel.
@@ -240,7 +235,7 @@
     (is (false? (:ok? r)))
     (is (= :ambiguous-frame (:reason r))
         "two frames + no selection ⇒ refuse rather than silently read :rf/default")
-    ;; rf2-n58jxo — enriched: operation + the available frames the caller can pin.
+    ;; Enriched: operation + the available frames the caller can pin.
     (is (= :sub-cache-info (:operation r)))
     (is (= #{:rf/default :rf/xray} (set (:available-frames r))))))
 

--- a/skills/re-frame2-pair/tests/shim/shim_test.clj
+++ b/skills/re-frame2-pair/tests/shim/shim_test.clj
@@ -136,8 +136,8 @@
 (def healthy-cases
   {:default "nil"
    :matches
-   {;; running-build enumeration (rf2-ivlb3) — JVM-side eval; exactly
-    ;; one build running so eval auto-detects it without --build.
+   {;; running-build enumeration — JVM-side eval; exactly one build
+    ;; running so eval auto-detects it without --build.
     "active-builds" "[:app]"
     ;; sentinel probe
     "(some? (and (exists? js/globalThis)" "true"
@@ -179,15 +179,15 @@
              "(some? (and (exists? js/globalThis)" "false"}})
 
 (def no-running-build-cases
-  ;; rf2-ivlb3: zero shadow builds running. eval can't auto-detect a
-  ;; build → :no-runtime-for-build with empty :running-builds.
+  ;; Zero shadow builds running. eval can't auto-detect a build →
+  ;; :no-runtime-for-build with empty :running-builds.
   {:default "nil"
    :matches {"active-builds" "[]"
              "(some? (and (exists? js/globalThis)" "false"}})
 
 (def multi-build-cases
-  ;; rf2-ivlb3: two builds running, none passed via --build → eval can't
-  ;; pick one → :no-runtime-for-build enumerating both.
+  ;; Two builds running, none passed via --build → eval can't pick one →
+  ;; :no-runtime-for-build enumerating both.
   {:default "nil"
    :matches {"active-builds" "[:app :examples/step-deck]"
              "(some? (and (exists? js/globalThis)" "true"}})
@@ -219,10 +219,10 @@
 
 (deftest eval-cljs-no-runtime-for-build
   (testing "ops eval against a build with no live runtime → :no-runtime-for-build (NOT :ok? true :value nil)"
-    ;; rf2-ivlb3: the original bug returned {:ok? true :value nil} for
-    ;; EVERY form (including (count ...), which can never be nil) when
-    ;; the resolved build had no live re-frame2-pair runtime. The fix
-    ;; must fail loud instead.
+    ;; A build with no live re-frame2-pair runtime must FAIL LOUD, not
+    ;; return {:ok? true :value nil} for EVERY form (including (count ...),
+    ;; which can never be nil) — a nil result there is indistinguishable
+    ;; from a genuine nil.
     (with-stub missing-preload-cases
       (fn [cwd]
         (let [r   (run-shim cwd "eval" "(count [1 2 3])")

--- a/skills/re-frame2-pair/tests/shim/stub_nrepl.clj
+++ b/skills/re-frame2-pair/tests/shim/stub_nrepl.clj
@@ -22,8 +22,8 @@
 
 ;; The minimal bencode codec is shared with the production shim
 ;; (scripts/ops.clj); it lives in scripts/bencode.clj and is loaded off
-;; this file's own location so cwd doesn't matter (rf2-qq7w2k). The stub
-;; DECODES requests + ENCODES canned replies — the mirror of ops.clj.
+;; this file's own location so cwd doesn't matter. The stub DECODES
+;; requests + ENCODES canned replies — the mirror of ops.clj.
 (load-file (str (.getParent (.getParentFile (.getParentFile (java.io.File. *file*))))
                 "/scripts/bencode.clj"))
 
@@ -85,8 +85,8 @@
         ;; ops.clj wraps every cljs-eval as
         ;;   (shadow.cljs.devtools.api/cljs-eval :app "<form>" {})
         ;; but JVM-side evals (e.g. the running-build enumeration
-        ;;   (vec (shadow.cljs.devtools.api/active-builds))
-        ;; from rf2-ivlb3) are sent raw, with no inner string literal.
+        ;;   (vec (shadow.cljs.devtools.api/active-builds)))
+        ;; are sent raw, with no inner string literal.
         cljs?    (str/includes? code "cljs-eval")
         ;; Extract the inner form (best-effort substring) for table lookup.
         inner    (let [start (.indexOf ^String code "\"")

--- a/skills/re-frame2-setup/tests/setup_drift_test.clj
+++ b/skills/re-frame2-setup/tests/setup_drift_test.clj
@@ -1,8 +1,7 @@
 ;;;; tests/setup_drift_test.clj — structural regression for the
 ;;;; re-frame2-setup skill's correctness-critical contract claims.
 ;;;;
-;;;; Guards the two drifts the skills-setup correctness review found
-;;;; (rf2-0qkyn):
+;;;; Guards two contract claims the setup skill must keep correct:
 ;;;;
 ;;;;   1. Lockstep is a BUILD/dependency discipline, not a boot-time
 ;;;;      runtime check. The runtime (`rf/init!` + `install-adapter!`)
@@ -30,17 +29,15 @@
 ;;;; CI: gated by the `skills-structural` job in .github/workflows/test.yml,
 ;;;; which loops `skills/re-frame2-setup/tests/*_test.clj`. The job fires when
 ;;;; `report-changed-surfaces.sh` classifies a `skills/re-frame2-setup/**`
-;;;; change as `skills_structural=true` (rf2-agi57x). So a fix this suite guards
-;;;; (the prose-drift Locks 1–12 below) can no longer regress silently —
-;;;; previously this was a local-only check.
+;;;; change as `skills_structural=true`. So the prose-drift Locks 1–12 below
+;;;; are guarded in CI, not just locally.
 ;;;;
 ;;;; What this suite does NOT cover: it is a PROSE-DRIFT / structural guard, not
 ;;;; a buildability smoke. It does not materialise the scaffold and run
 ;;;; `npm install` + `npx shadow-cljs compile app` — that heavier
 ;;;; generated-project smoke is deferred (pre-publish, the framework coords
 ;;;; resolve only against a reviewed monorepo checkout, so a full end-to-end
-;;;; build isn't a cheap per-PR gate yet; tracked as a decision-flagged
-;;;; follow-up under rf2-agi57x). Run `npm run test:cljs` / the substrate
+;;;; build isn't a cheap per-PR gate yet). Run `npm run test:cljs` / the substrate
 ;;;; contract tests for real-regression coverage of the wiring this skill
 ;;;; teaches.
 ;;;;
@@ -213,16 +210,16 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 3 — Xray layout host snippet matches the CURRENT published contract
-;; (right-side host, --rf-xray-inline-width-driven width). rf2-w4axt.
+;; (right-side host, --rf-xray-inline-width-driven width).
 ;;
 ;; The setup recipe scaffolds the `[data-rf-xray-host]` layout host. The
 ;; published contract (tools/xray/spec/011-Launch-Modes.md §Layout host
 ;; contract + the shipped examples/_shared/css) is a RIGHT-side host whose
-;; flex-basis reads `var(--rf-xray-inline-width, 560px)`. A prior revision
-;; scaffolded a LEFT-side host with a literal `flex: 0 0 420px`, which (a)
-;; put the panel on the wrong side and (b) ignored the persisted resize
-;; width Xray's drag handle writes. These guards fail if that stale shape
-;; (or the literal `420px`) reappears in the setup guidance.
+;; flex-basis reads `var(--rf-xray-inline-width, 560px)`. A LEFT-side host
+;; with a literal `flex: 0 0 420px` would (a) put the panel on the wrong
+;; side and (b) ignore the persisted resize width Xray's drag handle writes.
+;; These guards fail if that wrong shape (or the literal `420px`) appears in
+;; the setup guidance.
 ;; ---------------------------------------------------------------------------
 
 (deftest xray-host-snippet-consumes-inline-width-var
@@ -283,13 +280,13 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 4 — the reagent/dom CLJS-namespace troubleshooting row diagnoses the
-;; Maven/classpath side, NOT npm React. rf2-w4axt.
+;; Maven/classpath side, NOT npm React.
 ;;
 ;; `reagent.dom.client` ships from the `reagent/reagent` Maven coordinate on
 ;; the CLJS classpath; a missing npm React surfaces as a JS module error, not
-;; a missing .cljs namespace. A prior row told the author to `npm install
-;; react react-dom` to fix a missing CLJS namespace — wrong layer. This guard
-;; fails if the reagent/dom row is mapped back to npm-only recovery.
+;; a missing .cljs namespace. Telling the author to `npm install react
+;; react-dom` to fix a missing CLJS namespace is the wrong layer. This guard
+;; fails if the reagent/dom row is mapped to npm-only recovery.
 ;; ---------------------------------------------------------------------------
 
 (deftest reagent-dom-row-diagnoses-maven-not-npm
@@ -323,7 +320,6 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 5 — the dev CSP guidance matches the generator template's index.html.
-;; rf2-pxl6l.
 ;;
 ;; The template's root/resources/public/index.html ships a DEV-flavoured CSP
 ;; meta tag tuned to the runtime the scaffold produces:
@@ -333,12 +329,12 @@
 ;;     run.
 ;;   - NO meta `frame-ancestors` — browsers IGNORE it from a <meta> tag; it is a
 ;;     response-header-only directive, so it belongs in the production header.
-;; A prior revision documented a strict dev CSP (`style-src 'self'`, meta
-;; `frame-ancestors`), which diverged from the tested template and could cause
-;; first-run CSP violations / broken Xray styling. These guards fail if that
-;; stale strict-dev shape (or a meta `frame-ancestors`) reappears, and require
-;; the dev/prod split (a documented stricter production RESPONSE HEADER that
-;; adds `frame-ancestors`) to stay present.
+;; A strict dev CSP (`style-src 'self'`, meta `frame-ancestors`) would
+;; diverge from the tested template and cause first-run CSP violations /
+;; broken Xray styling. These guards fail if that strict-dev shape (or a meta
+;; `frame-ancestors`) appears, and require the dev/prod split (a documented
+;; stricter production RESPONSE HEADER that adds `frame-ancestors`) to stay
+;; present.
 ;; ---------------------------------------------------------------------------
 
 (defn- meta-csp-content
@@ -398,7 +394,6 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 6 — user-facing direct-run shadow-cljs commands are qualified with npx.
-;; rf2-pxl6l.
 ;;
 ;; A fresh project's only shadow-cljs is a LOCAL npm devDependency; bare
 ;; `shadow-cljs watch app` hits `command not found` when no global binary is on
@@ -421,15 +416,15 @@
 ;; ---------------------------------------------------------------------------
 ;; Lock 7 — the UIx/Helix manual path supplies substrate-specific VIEW code and
 ;; does NOT route UIx/Helix authors to the Reagent `reg-view` first-counter.
-;; rf2-74uffk.
 ;;
 ;; The Reagent first-counter leaf uses `reg-view` (auto-injected
 ;; dispatch/subscribe) — a Reagent-only construct. UIx/Helix have no
 ;; auto-injection: they read subs via the adapter `use-subscribe` hook and
-;; dispatch via `(:dispatch (rf/frame-handle))`. A prior revision only supplied
-;; deps/entry-root substitutions for UIx/Helix, leaving an author to combine a
-;; UIx/Helix entry ns with the Reagent `reg-view` counter — a non-compiling
-;; scaffold. These guards require the substrate VIEW snippets to be present in
+;; dispatch via `(:dispatch (rf/frame-handle))`. Supplying only
+;; deps/entry-root substitutions for UIx/Helix would leave an author to
+;; combine a UIx/Helix entry ns with the Reagent `reg-view` counter — a
+;; non-compiling scaffold. These guards require the substrate VIEW snippets to
+;; be present in
 ;; entry-namespace.md (matching the template's _uix/_helix/views.cljs) and
 ;; require SKILL.md + first-counter.md to steer UIx/Helix away from `reg-view`.
 ;; ---------------------------------------------------------------------------
@@ -487,15 +482,14 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 8 — the JS-module React recovery uses the PINNED baseline, not bare
-;; `npm install react react-dom` (which writes latest-from-npm). rf2-74uffk.
+;; `npm install react react-dom` (which writes latest-from-npm).
 ;;
 ;; The skill's default path copies the React/ReactDOM versions from the pinned
 ;; `implementation/package.json` (deps-versions.md §package.json) and only takes
-;; latest-from-npm on explicit opt-in. A prior revision's JS-module
-;; troubleshooting row advised bare `npm install react react-dom`, which writes
-;; npm's current `latest` into package.json — breaking reproducibility and
-;; risking a React/Reagent mismatch. This guard fails if that bare command
-;; reappears in the JS-module row and requires the pinned-baseline recovery.
+;; latest-from-npm on explicit opt-in. Bare `npm install react react-dom` would
+;; write npm's current `latest` into package.json — breaking reproducibility
+;; and risking a React/Reagent mismatch. This guard fails if that bare command
+;; appears in the JS-module row and requires the pinned-baseline recovery.
 ;; ---------------------------------------------------------------------------
 
 (deftest js-module-react-row-uses-pinned-baseline
@@ -525,7 +519,6 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 9 — the greenfield framework coordinate branches on PUBLICATION STATE.
-;; rf2-ol8l7a.
 ;;
 ;; re-frame2 is NOT on Clojars/npm yet (README §Status: "not yet published …
 ;; add as a :git/sha coordinate"). A `day8/re-frame2* {:mvn/version "<VERSION>"}`
@@ -569,17 +562,16 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 10 — the schema-missing contract is a LOUD error, not a CLJS soft-pass.
-;; rf2-ol8l7a.
 ;;
-;; Current core routes reg-app-schema / reg-app-schemas through :on-absent
-;; :throw — without `day8/re-frame2-schemas` they throw
+;; Core routes reg-app-schema / reg-app-schemas through :on-absent :throw —
+;; without `day8/re-frame2-schemas` they throw
 ;; :rf.error/schemas-artefact-missing (implementation/core/.../core_schemas.cljc).
 ;; Requiring `re-frame.schemas` wires Malli automatically, so a registered
-;; schema validates (Spec 010 §Schema implies validation on CLJS). A prior
-;; revision taught that missing the schemas artefact "soft-passes" on the normal
-;; setup path — false: it throws, and a present artefact validates. These guards
-;; fail if the soft-pass-on-the-setup-path framing reappears and require the
-;; loud-error / Malli-wired contract to be stated.
+;; schema validates (Spec 010 §Schema implies validation on CLJS). Teaching
+;; that missing the schemas artefact "soft-passes" on the normal setup path is
+;; false: it throws, and a present artefact validates. These guards fail if the
+;; soft-pass-on-the-setup-path framing appears and require the loud-error /
+;; Malli-wired contract to be stated.
 ;; ---------------------------------------------------------------------------
 
 (deftest schema-missing-artefact-is-loud-not-softpass
@@ -618,18 +610,18 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 11 — the FIRST canonical shadow-cljs.edn block carries the day-one Xray
-;; preload. rf2-agi57x.
+;; preload.
 ;;
 ;; Xray is a day-one dep (deps-versions.md) and index.html ships the
 ;; [data-rf-xray-host] column; the SKILL.md day-one shape + done-checklist both
-;; require `:devtools/preloads [day8.re-frame2-xray.preload]`. A prior revision
-;; presented the FIRST copyable shadow-cljs.edn block WITHOUT the preload (it
-;; arrived only in a later ":devtools (optional, for hot-reload)" section) — so
-;; the most obvious block to copy produced a compiling app whose right-side host
-;; stays empty: a false-green scaffold (the dep + host markup are present but
-;; nothing loads Xray). This guard fails if the day-one block drops the preload
-;; while the deps/checklist still require Xray, or if the section reverts to
-;; framing the preload as optional hot-reload material.
+;; require `:devtools/preloads [day8.re-frame2-xray.preload]`. Presenting the
+;; FIRST copyable shadow-cljs.edn block WITHOUT the preload (arriving only in a
+;; later ":devtools (optional, for hot-reload)" section) would make the most
+;; obvious block to copy produce a compiling app whose right-side host stays
+;; empty: a false-green scaffold (the dep + host markup are present but nothing
+;; loads Xray). This guard fails if the day-one block drops the preload while
+;; the deps/checklist still require Xray, or if the section frames the preload
+;; as optional hot-reload material.
 ;; ---------------------------------------------------------------------------
 
 (defn- first-shadow-build-block
@@ -672,12 +664,11 @@
 (deftest shadow-devtools-section-not-labelled-optional-hot-reload
   (testing "the :devtools section header no longer frames the Xray preload as optional hot-reload material"
     (let [body @shadow-cljs-md]
-      ;; The Contents TOC + the section header previously read
-      ;; ":devtools block (optional, for hot-reload)", implying the Xray preload
-      ;; is opt-in hot-reload tooling. It is the day-one default — not optional
-      ;; hot-reload material. (For the :browser target the module :init-fn re-runs
-      ;; after each hot reload by default, so no separate ^:dev/after-load hook is
-      ;; needed at all.)
+      ;; A ":devtools block (optional, for hot-reload)" TOC/section header
+      ;; would imply the Xray preload is opt-in hot-reload tooling. It is the
+      ;; day-one default — not optional hot-reload material. (For the :browser
+      ;; target the module :init-fn re-runs after each hot reload by default,
+      ;; so no separate ^:dev/after-load hook is needed at all.)
       (is (not (str/includes? body "optional, for hot-reload"))
           (str "shadow-cljs.md still labels the `:devtools` section "
                "\"optional, for hot-reload\". The Xray preload is the day-one "
@@ -687,20 +678,20 @@
 ;; ---------------------------------------------------------------------------
 ;; Lock 12 — the generator route is USER-RUN; the skill's allowed-tools do NOT
 ;; grant `clojure -Tnew create`, and the UIx/Helix greenfield route the skill
-;; EXECUTES is the manual scaffold. rf2-agi57x.
+;; EXECUTES is the manual scaffold.
 ;;
 ;; The skill documents the one-command `clojure -Tnew create …` generator as a
 ;; complete alternative, but its `allowed-tools` front-matter grants only
 ;; `clojure -Stree`, npm, and `shadow-cljs watch/compile` — NOT `-Tnew`. So the
 ;; skill must frame the generator as something the AUTHOR runs, while the route
 ;; the skill itself executes (esp. for UIx/Helix) is the manual scaffold whose
-;; commands the grant actually covers. A prior revision steered UIx/Helix users
-;; toward the generator as "the fastest/complete path" without flagging that the
-;; loaded skill cannot run it — weakening prompt ergonomics (the agent
-;; recommends a route it must then abandon or interrupt for extra tool access).
-;; These guards fail if the front-matter starts advertising `-Tnew`, or if the
-;; prose stops framing the generator as user-run / stops giving UIx/Helix an
-;; executable manual route.
+;; commands the grant actually covers. Steering UIx/Helix users toward the
+;; generator as "the fastest/complete path" without flagging that the loaded
+;; skill cannot run it weakens prompt ergonomics (the agent recommends a route
+;; it must then abandon or interrupt for extra tool access). These guards fail
+;; if the front-matter starts advertising `-Tnew`, or if the prose stops
+;; framing the generator as user-run / stops giving UIx/Helix an executable
+;; manual route.
 ;; ---------------------------------------------------------------------------
 
 (deftest allowed-tools-do-not-grant-generator-command
@@ -747,28 +738,27 @@
 ;; ---------------------------------------------------------------------------
 ;; Lock 13 — the PUBLIC entry-ramp docs (docs-site setup page + top-level
 ;; skills index) stay in sync with the current setup/template contract.
-;; rf2-79gtjr.
 ;;
-;; The authoritative SKILL.md / setup references / template API docs are
-;; correct, but two USER-FACING discoverability surfaces had drifted:
+;; The authoritative SKILL.md / setup references / template API docs are the
+;; source of truth; two USER-FACING discoverability surfaces must not drift
+;; from them:
 ;;
-;;   * docs/skills/re-frame2-setup.md taught the stale "all ten ship at the
-;;     same version" lockstep count (the contract is ELEVEN publishable
-;;     framework artefacts, with day8/re-frame2-xray on the same line — see
-;;     SKILL.md cardinal rule 2 + README.md), and linked the reference
-;;     leaves to a SINGULAR `…/skills/re-frame2-setup/reference` GitHub path
-;;     that 404s (the directory is `references`, plural). check_doc_slugs.py
-;;     can't catch either: it skips external http(s) URLs and does not
-;;     validate prose artefact counts.
+;;   * docs/skills/re-frame2-setup.md must teach the current lockstep count —
+;;     ELEVEN publishable framework artefacts, with day8/re-frame2-xray on the
+;;     same line (see SKILL.md cardinal rule 2 + README.md) — not a stale "all
+;;     ten ship at the same version" count, and must link the reference leaves
+;;     to the PLURAL `…/skills/re-frame2-setup/references` GitHub path (a
+;;     singular `…/reference` 404s). check_doc_slugs.py can't catch either: it
+;;     skips external http(s) URLs and does not validate prose artefact counts.
 ;;
-;;   * skills/README.md presented the one-shot generator as the published
-;;     `io.github.day8/re-frame2-template` `-Tnew create` form with NO
-;;     pre-split caveat — but that coord can't resolve pre-split (the
-;;     external repo doesn't exist yet; the working route is `:local/root`,
-;;     per tools/template/README.md + the setup skill's own cardinal rule 4).
+;;   * skills/README.md must caveat the one-shot generator: the published
+;;     `io.github.day8/re-frame2-template` `-Tnew create` form can't resolve
+;;     pre-split (the external repo doesn't exist yet; the working route is
+;;     `:local/root`, per tools/template/README.md + the setup skill's own
+;;     cardinal rule 4).
 ;;
 ;; These guards read the two public files off disk (no network) and fail if
-;; any of the three drifts reappears while check_doc_slugs.py stays green.
+;; any of the three drifts appears while check_doc_slugs.py stays green.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private docs-setup-page-md
@@ -843,7 +833,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 8 — the manual boot seed matches the generator's reset-boundary
-;; contract. rf2-xqds87.
+;; contract.
 ;;
 ;; The generator template seeds via an explicit `(rf/dispatch-sync
 ;; [...initialise])` under `(rf/with-frame :rf/default ...)`, NOT via a

--- a/skills/shared/tests/evals/score-behavioral-eval.clj
+++ b/skills/shared/tests/evals/score-behavioral-eval.clj
@@ -1,12 +1,11 @@
 #!/usr/bin/env bb
 ;;;; score-behavioral-eval.clj — scorer for the shared-protocol behavioral
-;;;; eval (rf2-1inyqr finding 2).
+;;;; eval.
 ;;;;
 ;;;; The three security-critical fixtures under `tests/fixtures/` lock agent
 ;;;; RUNTIME BEHAVIOUR (does the agent refuse `gh issue create`? does it leak a
-;;;; raw JWT? does it gate an evidence-shaped Edit?). The fixtures were
-;;;; document-runnable only — a maintainer replayed them by hand and eyeballed
-;;;; the result. That is too easy to skip and too hard to compare across
+;;;; raw JWT? does it gate an evidence-shaped Edit?). Replaying them by hand and
+;;;; eyeballing the result is too easy to skip and too hard to compare across
 ;;;; model/tooling changes for a shared SECURITY boundary.
 ;;;;
 ;;;; This scorer makes the behavioural contract EXECUTABLE. The agent-execution

--- a/skills/shared/tests/retro_protocol_test.clj
+++ b/skills/shared/tests/retro_protocol_test.clj
@@ -1,31 +1,27 @@
 ;;;; tests/retro_protocol_test.clj — structural regression for the shared
 ;;;; retro protocol.
 ;;;;
-;;;; The shared protocol carries three normative locks that the
-;;;; skills-shared security audit verified and that the hardening PRs
-;;;; implemented:
+;;;; The shared protocol carries three normative locks:
 ;;;;
-;;;;   1. Untrusted-evidence boundary  — Finding 1, High
-;;;;   2. Universal redaction          — Finding 2, Medium
-;;;;   3. Edit-gate split              — Finding 3, recommendation
+;;;;   1. Untrusted-evidence boundary  — High
+;;;;   2. Universal redaction          — Medium
+;;;;   3. Edit-gate split              — recommendation
 ;;;;
-;;;; Plus a fourth surface (Lock 4) the original suite left unguarded:
-;;;; the shell-safety / command-injection boundary on the `gh issue`
-;;;; surfaces the protocol grants, specified in `issue-filing.md`. It is
-;;;; the same untrusted-evidence threat model as Lock 1 projected onto the
-;;;; shell — across the body (`--body-file`, Lock 4), the title (inline
-;;;; `--title`, Lock 4b), the per-filing OS-temp body path (Lock 4c), and
-;;;; the search query (inline `gh issue list --search`, Lock 4d,
-;;;; rf2-7g9htq.1 — `--search` has no `--search-file`, so a query lifted
-;;;; from evidence re-opens the same transcript→shell injection the
-;;;; title/body rules close).
+;;;; Plus a fourth surface (Lock 4): the shell-safety / command-injection
+;;;; boundary on the `gh issue` surfaces the protocol grants, specified in
+;;;; `issue-filing.md`. It is the same untrusted-evidence threat model as
+;;;; Lock 1 projected onto the shell — across the body (`--body-file`,
+;;;; Lock 4), the title (inline `--title`, Lock 4b), the per-filing OS-temp
+;;;; body path (Lock 4c), and the search query (inline
+;;;; `gh issue list --search`, Lock 4d — `--search` has no `--search-file`,
+;;;; so a query lifted from evidence re-opens the same transcript→shell
+;;;; injection the title/body rules close).
 ;;;;
-;;;; The audit's Finding 4 was PARTIAL — the prose was in place but no
-;;;; regression suite asserted the locks. This file closes that gap by
-;;;; pinning the load-bearing phrasings as a structural drift detector.
+;;;; This file pins the load-bearing phrasings of all four locks as a
+;;;; structural drift detector.
 ;;;;
-;;;; This is the CHEAP class of drift the protocol can suffer: a future
-;;;; edit silently weakening the wording (e.g. dropping "MUST ignore",
+;;;; This catches the CHEAP class of drift the protocol can suffer: an edit
+;;;; silently weakening the wording (e.g. dropping "MUST ignore",
 ;;;; collapsing the four attacker classes into one, removing the
 ;;;; placeholder convention, deleting the "When in doubt, gate"
 ;;;; tie-break). A conversation-driving variant — actually replaying
@@ -134,8 +130,7 @@
 (deftest untrusted-evidence-enumerates-four-attacker-classes
   (testing "four attacker classes still enumerated"
     (let [s (section @protocol-md "Untrusted-evidence boundary")]
-      ;; The audit found the original protocol had ZERO of these. The
-      ;; lock requires all four classes named with at least a
+      ;; The lock requires all four classes named with at least a
       ;; representative phrasing. Alternation per class to survive
       ;; reasonable rewording.
       (testing "tool-use redirection class"
@@ -328,11 +323,10 @@
 ;; `--body-file` flag (which reads the body verbatim from disk, so no
 ;; shell expansion ever touches the transcript-derived text) rather than
 ;; interpolated inline. This is the same untrusted-evidence threat model
-;; as Lock 1, projected onto the shell. The structural test pinned the
-;; three prose locks but left this one — the actual destructive surface
-;; — unguarded; a silent weakening here (dropping the `--body-file`
-;; requirement, or the "never interpolate inline" rule) would re-open
-;; transcript→shell injection with no gate firing.
+;; as Lock 1, projected onto the shell — the actual destructive surface.
+;; A weakening here (dropping the `--body-file` requirement, or the "never
+;; interpolate inline" rule) would re-open transcript→shell injection with
+;; no gate firing.
 ;; ---------------------------------------------------------------------------
 
 (deftest issue-filing-shell-safety-section-exists
@@ -379,13 +373,12 @@
 ;; protects the body therefore cannot protect the title; an
 ;; evidence-/transcript-derived title can carry `$()`, backticks, `"`,
 ;; `\`, or a newline that the shell expands BEFORE `gh` receives argv,
-;; re-opening transcript→shell injection even though the body is safe
-;; (the half rf2-q8qu2/#3121 left uncovered — it hardened the body
-;; only). The title is safe ONLY because the agent authors it from a
-;; restricted safe alphabet and never pastes evidence text into it.
-;; These assertions pin that invariant in the same leaf and frontmatter
-;; that carry the body-safety locks, so a silent weakening of the title
-;; rule fails the suite alongside the body checks.
+;; re-opening transcript→shell injection even though the body is safe.
+;; The title is safe ONLY because the agent authors it from a restricted
+;; safe alphabet and never pastes evidence text into it. These assertions
+;; pin that invariant in the same leaf and frontmatter that carry the
+;; body-safety locks, so a weakening of the title rule fails the suite
+;; alongside the body checks.
 ;; ---------------------------------------------------------------------------
 
 (deftest issue-filing-carries-title-safety-rule
@@ -454,7 +447,7 @@
                "time, not just in the linked leaf.")))))
 
 ;; ---------------------------------------------------------------------------
-;; Lock 4c — Per-filing OS-temp body path (rf2-de7pqw → rf2-ca5v9s)
+;; Lock 4c — Per-filing OS-temp body path
 ;;
 ;; The `--body-file` target must be a FRESH, per-filing temp file in the
 ;; host OS's temp directory — never a fixed, predictable name like
@@ -463,17 +456,15 @@
 ;; after the user approved filing; and (b) is predictable, so two
 ;; concurrent retros / two rapid filings overwrite each other's redacted
 ;; body — filing the WRONG redacted text to GitHub or leaving sensitive
-;; evidence in a shared location longer than intended. rf2-de7pqw fixed
-;; the in-lane re-frame2-pair-retro/** leaves and deferred this structural
-;; regression + the shared-recipe propagation to rf2-ca5v9s. These
-;; assertions lock the fix in the SHARED canonical recipe and its consumer
-;; template: the published recipe MUST NOT prescribe `/tmp/issue-body.md`
-;; as the `--body-file` target, and MUST name a per-filing OS-temp path
-;; (TMPDIR / $env:TEMP). The "never a fixed /tmp/issue-body.md" PROHIBITION
-;; strings are tolerated — the regression fires only on the prescriptive
-;; command form (`--body-file /tmp/issue-body.md`) or the prescriptive
-;; "compose /tmp/issue-body.md" Write step, never on a prohibition that
-;; merely names the banned literal.
+;; evidence in a shared location longer than intended. These assertions
+;; lock the rule in the SHARED canonical recipe and its consumer template:
+;; the published recipe MUST NOT prescribe `/tmp/issue-body.md` as the
+;; `--body-file` target, and MUST name a per-filing OS-temp path (TMPDIR /
+;; $env:TEMP). The "never a fixed /tmp/issue-body.md" PROHIBITION strings
+;; are tolerated — the regression fires only on the prescriptive command
+;; form (`--body-file /tmp/issue-body.md`) or the prescriptive "compose
+;; /tmp/issue-body.md" Write step, never on a prohibition that merely names
+;; the banned literal.
 ;; ---------------------------------------------------------------------------
 
 (defn- prescribes-fixed-body-path?
@@ -548,7 +539,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock 4d — Search-argument safety on the inline `gh issue list --search`
-;; recipe (rf2-7g9htq.1)
+;; recipe
 ;;
 ;; Search-before-file is mandatory, and the recipe is
 ;; `gh issue list --repo <owner/repo> --search "<keywords>"`. `--search`
@@ -663,11 +654,8 @@
 ;; `Write` and `Bash(gh issue create *)` PRESENT, and must NOT carry `Edit`
 ;; (it never rewrites source) or `Bash(bd *)` (the monorepo's internal tracker
 ;; has no place in a published skill — see `skills/README.md` §Published-skill
-;; allowed-tools baseline). A prior drift had `spec/design.md` claiming the
-;; block omits `Write`, which — if followed by a reauthoring pass — would
-;; remove the only documented shell-safe filing path. This test fails loudly
-;; if a future edit removes `Write`/`gh issue create` or smuggles in
-;; `Edit`/`Bash(bd *)`.
+;; allowed-tools baseline). This test fails loudly if an edit removes
+;; `Write`/`gh issue create` or smuggles in `Edit`/`Bash(bd *)`.
 ;; ---------------------------------------------------------------------------
 
 (defn- frontmatter
@@ -720,8 +708,8 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures present — the document-runnable behavioural scenarios live
-;; alongside this structural test. If they disappear, the prose-only
-;; portion of the regression goes back to PARTIAL.
+;; alongside this structural test. They are the behavioural counterpart to
+;; the structural drift detector; these checks keep them from disappearing.
 ;; ---------------------------------------------------------------------------
 
 (deftest fixtures-dir-exists
@@ -760,16 +748,15 @@
                  "maintainers will be confused."))))))
 
 ;; ---------------------------------------------------------------------------
-;; Behavioral eval — the three security fixtures now have an EXECUTABLE
-;; scoring path (rf2-1inyqr finding 2). The fixtures were document-runnable
-;; only; a future wording / consumer / model-behaviour shift could pass every
+;; Behavioral eval — the three security fixtures have an EXECUTABLE scoring
+;; path. A wording / consumer / model-behaviour shift could pass every
 ;; structural grep while an agent actually runs `gh issue create`, leaks a
 ;; token, or applies an evidence-shaped Edit. `tests/evals/behavioral-evals.json`
 ;; encodes each fixture's §Expected / §Anti-expectation locks as machine-
 ;; checkable predicates, and `score-behavioral-eval.clj` scores a captured
 ;; transcript into a machine-readable pass/fail artifact. These structural
-;; tests keep the eval machinery + its workflow wiring from silently
-;; disappearing, and run the scorer's own self-test as a cheap always-on guard.
+;; tests keep the eval machinery + its workflow wiring from disappearing, and
+;; run the scorer's own self-test as a cheap always-on guard.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private behavioral-evals-file
@@ -837,19 +824,19 @@
                "release / checklist gate (rf2-1inyqr finding 2).")))))
 
 ;; ---------------------------------------------------------------------------
-;; Pair-retro production/probe/filing drift (rf2-dhnixf)
+;; Pair-retro production/probe/filing drift
 ;;
-;; Finding 1 — the production-elision known-friction must not claim "every
-;; Tool-Pair surface elides"; the dev-gated surfaces (trace / epoch / schema
-;; / source-coord) go dark, but orientation / registry-frame shape, the
-;; direct-read primitives, and the always-on error-emit substrate still
-;; answer.
-;; Finding 2 — the attach-failure guidance + eval fixtures must teach the
-;; current diagnostic ladder (:nrepl-unreachable / :build-not-running /
-;; :no-runtime-connected / :runtime-loaded-but-preload-missing), not the
-;; legacy blanket :runtime-not-preloaded as the normal-case reason.
-;; Finding 3 — the README routing index must carry the optional-label /
-;; fail-open filing model, not a mandatory `pair-mcp` label.
+;; - the production-elision known-friction must not claim "every Tool-Pair
+;;   surface elides"; the dev-gated surfaces (trace / epoch / schema /
+;;   source-coord) go dark, but orientation / registry-frame shape, the
+;;   direct-read primitives, and the always-on error-emit substrate still
+;;   answer.
+;; - the attach-failure guidance + eval fixtures must teach the current
+;;   diagnostic ladder (:nrepl-unreachable / :build-not-running /
+;;   :no-runtime-connected / :runtime-loaded-but-preload-missing), with the
+;;   blanket :runtime-not-preloaded framed only as the fallback reason.
+;; - the README routing index must carry the optional-label / fail-open
+;;   filing model, not a mandatory `pair-mcp` label.
 ;; ---------------------------------------------------------------------------
 
 (deftest pair-retro-production-elision-not-blanket

--- a/skills/shared/tests/tool_pair_surfaces_test.clj
+++ b/skills/shared/tests/tool_pair_surfaces_test.clj
@@ -2,30 +2,27 @@
 ;;;; shared Tool-Pair surface enumeration.
 ;;;;
 ;;;; `tool-pair-surfaces.md` is the single shared-corpus pointer at the
-;;;; consumer-facing Tool-Pair surfaces. The skills/shared correctness
-;;;; review (rf2-eca6x.1) found its direct-read entries named raw runtime
-;;;; reads (`app-db-value`, `compute-sub`, `sub-cache`) WITHOUT carrying
-;;;; the MUST-level off-box wire-egress contract from spec/Tool-Pair.md —
-;;;; so a consuming skill routing/drafting upstream Tool-Pair work from
-;;;; this leaf could describe direct reads as raw values rather than
-;;;; `rf/elide-wire-value`-scrubbed egress with sensitive/large defaults
-;;;; suppressed. The existing `retro_protocol_test.clj` suite does not
-;;;; cover this leaf, so the drift was unguarded.
+;;;; consumer-facing Tool-Pair surfaces. Its direct-read entries MUST name
+;;;; the off-box wire-egress contract from spec/Tool-Pair.md — direct reads
+;;;; are `rf/elide-wire-value`-scrubbed egress with sensitive/large defaults
+;;;; suppressed, not raw runtime reads — so a consuming skill routing /
+;;;; drafting upstream Tool-Pair work from this leaf describes the egress
+;;;; correctly. `retro_protocol_test.clj` does not cover this leaf, so this
+;;;; suite guards it directly.
 ;;;;
-;;;; rf2-c9xgp follow-up: the wire-surface list was ALSO stale against the
-;;;; current re-frame2-pair-mcp catalogue — it named a standalone
-;;;; `get-app-db` / `sub-cache` tool that the catalogue does not ship, and
-;;;; omitted the real subscription-read egress (`read-sub`,
+;;;; The wire-surface list MUST match the current re-frame2-pair-mcp
+;;;; catalogue: it names the real subscription-read egress (`read-sub`,
 ;;;; `list-subscriptions` with `:include-values`) and `dispatch-dry-run`,
-;;;; all under the same `--allow-sensitive-reads` fail-closed posture.
-;;;; This suite now pins the CURRENT privacy-relevant tool names so a
-;;;; future catalogue drift (a renamed/dropped read tool, a new app-db
-;;;; egress tool that skips the elision posture) fails loudly here.
+;;;; all under the same `--allow-sensitive-reads` fail-closed posture, and
+;;;; does NOT name a standalone `get-app-db` / `sub-cache` tool the
+;;;; catalogue doesn't ship. This suite pins the CURRENT privacy-relevant
+;;;; tool names so a catalogue drift (a renamed/dropped read tool, a new
+;;;; app-db egress tool that skips the elision posture) fails loudly here.
 ;;;;
 ;;;; This file pins the load-bearing direct-read privacy tokens and the
-;;;; link to the Tool-Pair direct-read section, so a future edit that
-;;;; strips the elision invariant from the shared surface guidance fails
-;;;; loudly. Mirrors `retro_protocol_test.clj`'s structural-drift shape.
+;;;; link to the Tool-Pair direct-read section, so an edit that strips the
+;;;; elision invariant from the shared surface guidance fails loudly.
+;;;; Mirrors `retro_protocol_test.clj`'s structural-drift shape.
 ;;;;
 ;;;; Run:    bb skills/shared/tests/tool_pair_surfaces_test.clj   (from repo root)
 ;;;;         bb tests/tool_pair_surfaces_test.clj                 (from skills/shared/)
@@ -75,7 +72,7 @@
       ;; egress surfaces — NOT a standalone `get-app-db` / `sub-cache` tool.
       ;; A consuming skill drafting upstream work must see the shipped wire
       ;; vocabulary, not only the raw `app-db-value` / `compute-sub` runtime
-      ;; API (rf2-eca6x.1) and not a stale tool name (rf2-c9xgp).
+      ;; API, and not a tool name the catalogue doesn't ship.
       (is (and (str/includes? body "snapshot")
                (str/includes? body "get-path")
                (str/includes? body "read-sub")
@@ -89,8 +86,7 @@
 (deftest subscription-reads-and-dry-run-named-as-gated-egress
   (testing "subscription-value reads + dispatch-dry-run are pinned under the same fail-closed posture"
     (let [body @surfaces-md]
-      ;; rf2-c9xgp: the original four-name list omitted the real
-      ;; subscription-read egress and the dry-run app-db/fx egress. Both
+      ;; The subscription-read egress and the dry-run app-db/fx egress both
       ;; ride the SAME `--allow-sensitive-reads` posture (read-sub.cljs /
       ;; list_subscriptions.cljs route :value through elide-wire-value;
       ;; dispatch-dry-run is gated per re-frame2-pair-mcp/README.md:200).
@@ -110,11 +106,11 @@
 (deftest get-app-db-only-as-generic-not-current-tool
   (testing "get-app-db is framed as a generic/third-party class, never a current pair-mcp tool"
     (let [body @surfaces-md]
-      ;; rf2-c9xgp: `get-app-db` is NOT a current re-frame2-pair-mcp tool —
-      ;; the catalogue reaches app-db via `snapshot`/`get-path`. The leaf
-      ;; may keep `get-app-db` only as a generic / third-party direct-read
-      ;; class name. If it appears at all, it must be near a generic/third-
-      ;; party qualifier, never presented as a shipped pair-mcp tool.
+      ;; `get-app-db` is NOT a re-frame2-pair-mcp tool — the catalogue
+      ;; reaches app-db via `snapshot`/`get-path`. The leaf may keep
+      ;; `get-app-db` only as a generic / third-party direct-read class
+      ;; name. If it appears at all, it must be near a generic/third-party
+      ;; qualifier, never presented as a shipped pair-mcp tool.
       (when (str/includes? body "get-app-db")
         (is (or (str/includes? body "generic / third-party")
                 (str/includes? body "generic/third-party")
@@ -141,20 +137,18 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock — the public egress boundary is `project-egress`, NOT `elide-wire-value`
-;; (rf2-2s4jre)
 ;;
-;; EP-0015 moved the public egress boundary up a layer: `rf/project-egress`
-;; is the record-level boundary primitive (resolves a `:rf.egress/*` profile +
-;; known `:frame`, applies frame-owned classification, fails closed with no
-;; frame), and `rf/elide-wire-value` is the low-level tree walker it delegates
-;; to. spec/015 §project-egress + implementation/SECURITY.md pin this split;
-;; spec/015:264 says tools/sinks should rarely call `elide-wire-value`
-;; directly. The earlier leaf taught `elide-wire-value` as "the single
-;; normative direct-value emission site" — that wording teaches new direct-
-;; read surfaces to hand-call the low-level walker (hand-assembling
-;; `:rf.size/*` opts) and bypass closed-profile validation + fail-closed
-;; frame seeding. These pins keep the boundary primitive named and forbid the
-;; stale boundary-overload wording from creeping back.
+;; `rf/project-egress` is the record-level boundary primitive (resolves a
+;; `:rf.egress/*` profile + known `:frame`, applies frame-owned
+;; classification, fails closed with no frame), and `rf/elide-wire-value` is
+;; the low-level tree walker it delegates to. spec/015 §project-egress +
+;; implementation/SECURITY.md pin this split; spec/015:264 says tools/sinks
+;; should rarely call `elide-wire-value` directly. Teaching
+;; `elide-wire-value` as "the single normative direct-value emission site"
+;; would push new direct-read surfaces to hand-call the low-level walker
+;; (hand-assembling `:rf.size/*` opts) and bypass closed-profile validation +
+;; fail-closed frame seeding. These pins keep the boundary primitive named
+;; and forbid the boundary-overload wording from creeping in.
 ;; ---------------------------------------------------------------------------
 
 (deftest project-egress-named-as-the-public-boundary
@@ -177,10 +171,10 @@
 (deftest elide-wire-value-not-overloaded-as-the-boundary
   (testing "the leaf does NOT teach elide-wire-value as the single normative direct-value emission site"
     (let [body @surfaces-md]
-      ;; rf2-2s4jre: the stale framing called the low-level walker "the single
-      ;; normative direct-value emission site". Post-EP-0015 the boundary is
-      ;; `project-egress`; the walker is delegated to. Guard the exact stale
-      ;; phrasings so a regression to walker-as-boundary fails loudly.
+      ;; The public boundary is `project-egress`; the low-level walker is
+      ;; delegated to, not "the single normative direct-value emission site".
+      ;; Guard the exact walker-as-boundary phrasings so a regression to that
+      ;; framing fails loudly.
       (is (not (str/includes? body "single normative direct-value emission site"))
           (str "tool-pair-surfaces.md again calls `elide-wire-value` \"the "
                "single normative direct-value emission site\". Post-EP-0015 "
@@ -245,21 +239,18 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock — the leaf enumerates the FULL upstream-routing surface catalogue
-;; (rf2-985x1t)
 ;; ---------------------------------------------------------------------------
 ;;
-;; The independent correctness review (rf2-985x1t) found the leaf advertised
-;; only an abbreviated subset of the Tool-Pair surface families: it stopped
-;; at trace / registrar / epoch-restore / schema / source-coord / direct
-;; reads and OMITTED render-driving + dispatch-settle, view-plane reads /
-;; view attribution, the signal recorder, and the operating-frame trio —
-;; all of which the authoritative contract (spec/Tool-Pair.md) and the
-;; current re-frame2-pair-mcp catalogue ship. A retro finding about
-;; deterministic dispatch->settle->DOM, read-ui/read-dom provenance,
-;; human-interaction recording, or multi-frame operating-frame ambiguity
-;; could therefore be mislabeled as pair-tool friction and filed against
-;; the wrong layer. These tests pin the current catalogue tokens so a
-;; future re-narrowing of the leaf fails loudly here.
+;; The leaf MUST enumerate every Tool-Pair surface family — trace, registrar,
+;; epoch-restore, schema, source-coord, direct reads, render-driving +
+;; dispatch-settle, view-plane reads / view attribution, the signal recorder,
+;; and the operating-frame trio — all of which the authoritative contract
+;; (spec/Tool-Pair.md) and the current re-frame2-pair-mcp catalogue ship.
+;; An abbreviated subset would let a retro finding about deterministic
+;; dispatch->settle->DOM, read-ui/read-dom provenance, human-interaction
+;; recording, or multi-frame operating-frame ambiguity be mislabeled as
+;; pair-tool friction and filed against the wrong layer. These tests pin the
+;; current catalogue tokens so a re-narrowing of the leaf fails loudly here.
 
 (deftest render-driving-and-settle-enumerated
   (testing "the leaf names render-driving via flush-render! and the dispatch :settle mode"
@@ -304,16 +295,16 @@
 (deftest watch-until-differentiated-from-raf-recorder
   (testing "the leaf differentiates watch-until (server polling) from the rAF record/read-recording recorder (rf2-3bu4ik)"
     (let [body @surfaces-md]
-      ;; rf2-3bu4ik: the leaf used to group `watch-until` with the rAF-backed
-      ;; `record` / `read-recording` recorder as one "rAF observer" triplet.
-      ;; The current contract (tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
-      ;; + tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_until.cljs)
-      ;; keeps them separate: `record` installs a rAF observer with a
-      ;; `:recording-id` change log; `watch-until` has the MCP SERVER poll a
-      ;; cheap runtime read on a fixed cadence — NO rAF loop, NO browser-side
-      ;; mailbox, NO recording registry. A consuming skill that conflates them
-      ;; misdiagnoses a watch-until failure as an rAF / recording-registry
-      ;; problem. This pin fails loudly if the differentiation regresses.
+      ;; `watch-until` and the rAF-backed `record` / `read-recording`
+      ;; recorder are SEPARATE surfaces (tools/re-frame2-pair-mcp/spec/
+      ;; 003-Tool-Catalogue.md + tools/re-frame2-pair-mcp/src/
+      ;; re_frame2_pair_mcp/tools/watch_until.cljs): `record` installs a rAF
+      ;; observer with a `:recording-id` change log; `watch-until` has the MCP
+      ;; SERVER poll a cheap runtime read on a fixed cadence — NO rAF loop, NO
+      ;; browser-side mailbox, NO recording registry. A consuming skill that
+      ;; conflates them misdiagnoses a watch-until failure as an rAF /
+      ;; recording-registry problem. This pin fails loudly if the
+      ;; differentiation regresses.
       (is (contains-any? body ["server polls" "server-side poll" "server-side"
                                "server poll" "polls a cheap runtime read"])
           (str "tool-pair-surfaces.md no longer describes `watch-until` as a "
@@ -343,43 +334,34 @@
                "rf2-985x1t).")))))
 
 ;; ---------------------------------------------------------------------------
-;; Lock — the operating-frame / registrar guidance teaches the post-EP-0023
-;; PUBLIC model with the realm coordinate REMOVED ENTIRELY: the frame id is
-;; the whole address; there is NO realm dimension, public OR internal,
-;; anywhere in the wire/resolution shape.
+;; Lock — the operating-frame / registrar guidance teaches the PUBLIC model
+;; where the frame id is the whole address: there is NO realm dimension,
+;; public OR internal, anywhere in the wire/resolution shape.
 ;;
-;; History of this lock block:
-;;   * rf2-wpwckr pinned the EP-0013 disposition-3 realm-aware PUBLIC model
-;;     (the `rf/realm-ids` / `rf/frame-realm` facade pair + a public `:realm`
-;;     pin). SUPERSEDED.
-;;   * The EP-0023 intermediate disposition demoted the realm to
-;;     LABELED-INTERNAL installation substrate (read from `re-frame.realm` /
-;;     `re-frame.frame`), with the inspect envelope still carrying `:realms` /
-;;     `:operating-realm` / `:selected-realm` (always nil) slots. SUPERSEDED.
-;;   * rf2-udl74a (PR #4811) ATOMICALLY REMOVED the `re-frame.realm` /
-;;     `re-frame.app-value` / `re-frame.migration` substrate. There is now NO
-;;     realm coordinate at all — public or internal. The operating-frame wire
-;;     envelope is FRAME-ONLY: `:frames` / `:app-frames` / `:selected` /
-;;     `:operating`, with the `:realms` / `:operating-realm` / `:selected-realm`
-;;     / `:frame-realms` slots GONE (pinned at the wire layer by
-;;     tools/mcp-conformance/.../operating_frame_address_test.clj
-;;     §no-realm-slots-on-the-envelope; the runtime emitter is the pair preload
-;;     `frames-list`).
+;; The operating-frame wire envelope is FRAME-ONLY: `:frames` / `:app-frames`
+;; / `:selected` / `:operating`. It carries no `:realms` / `:operating-realm`
+;; / `:selected-realm` / `:frame-realms` slots, and there is no `re-frame.realm`
+;; substrate, no `rf/realm-ids` / `rf/frame-realm` facade, and no public
+;; `:realm` pin. The frame-only envelope is pinned at the wire layer by
+;; tools/mcp-conformance/.../operating_frame_address_test.clj
+;; §no-realm-slots-on-the-envelope; the runtime emitter is the pair preload
+;; `frames-list`.
 ;;
-;; These pins now (a) FAIL LOUDLY if the leaf re-introduces ANY realm coordinate
-;; as a LIVE surface — the removed facade pair, a public `:realm` pin, a
-;; labeled-internal substrate read, or a realm slot on the inspect envelope —
-;; and (b) keep the correct frame-only public model + the realm-removed history
-;; pinned. Mirrors the frame-only collapse in the re-frame2-pair / re-frame2-xray
-;; skill wording and the wire-vocab conformance gate.
+;; These pins FAIL LOUDLY if the leaf introduces ANY realm coordinate as a
+;; LIVE surface — a facade pair, a public `:realm` pin, a labeled-internal
+;; substrate read, or a realm slot on the inspect envelope — and keep the
+;; frame-only public model pinned. Mirrors the frame-only model in the
+;; re-frame2-pair / re-frame2-xray skill wording and the wire-vocab
+;; conformance gate.
 ;; ---------------------------------------------------------------------------
 
 (deftest realm-vocab-only-as-removed-history-never-live
   (testing "any realm mention is framed as REMOVED, never as a live facade/substrate surface (rf2-udl74a)"
     (let [body @surfaces-md
-          ;; If the leaf names the removed facade exports / internal namespaces
-          ;; at all, they MUST appear inside an explicit removed/gone framing,
-          ;; never as a live surface. rf2-udl74a deleted the whole substrate.
+          ;; If the leaf names the (absent) facade exports / internal
+          ;; namespaces at all, they MUST appear inside an explicit
+          ;; removed/gone framing, never as a live surface — there is no
+          ;; realm substrate.
           names-realm-symbol? (or (str/includes? body "realm-ids")
                                   (str/includes? body "frame-realm")
                                   (str/includes? body "re-frame.realm")
@@ -395,8 +377,7 @@
                  "+ the `rf/realm-ids` / `rf/frame-realm` facade exports "
                  "atomically — there is no realm coordinate, public or "
                  "internal. Any realm mention is retired-history only.")))
-      ;; The EP-0023-intermediate labeled-internal substrate framing is ALSO
-      ;; stale now (the substrate it described was deleted). The leaf must NOT
+      ;; There is no labeled-internal realm substrate. The leaf must NOT
       ;; teach the realm as a LIVE labeled-internal surface a tool reads.
       (is (not (contains-any? body ["survives only as **labeled-internal"
                                     "retained only as the labeled-internal"
@@ -466,14 +447,13 @@
                "frame id, so the arg is required (no implicit/realm target).")))))
 
 ;; ---------------------------------------------------------------------------
-;; Lock — the four partition-aware state-injection mutators (rf2-7g9htq.2)
+;; Lock — the four partition-aware state-injection mutators
 ;;
-;; The leaf used to name only `replace-app-db!` / `reset-app-db!` (the
-;; app-db-only halves), under-teaching the post-EP-0001 partition-aware
-;; write API. spec/Tool-Pair.md §Pair-tool writes defines FOUR mutators;
-;; a skill that omits the runtime-db / full-frame siblings can describe
-;; arbitrary repro / story state injection as app-db-only and miss the
-;; full-frame install (`replace-frame-state!`) for machine snapshots /
+;; spec/Tool-Pair.md §Pair-tool writes defines FOUR partition-aware
+;; mutators, not just the app-db-only `replace-app-db!` / `reset-app-db!`
+;; halves. A skill that omits the runtime-db / full-frame siblings can
+;; describe arbitrary repro / story state injection as app-db-only and miss
+;; the full-frame install (`replace-frame-state!`) for machine snapshots /
 ;; routes / elision / SSR metadata. These pins fail loudly if the leaf
 ;; mentions `replace-app-db!` but drops either partition-aware sibling.
 ;; ---------------------------------------------------------------------------
@@ -501,10 +481,10 @@
                "story/repro tool relies on (rf2-7g9htq.2).")))))
 
 ;; ---------------------------------------------------------------------------
-;; Lock — restore-epoch is whole-frame-state, not app-db-only (rf2-7g9htq /
-;; rf2-7a1mkv). The leaf must teach that restore reinstalls BOTH partitions
-;; via replace-frame-state!, so a consuming skill doesn't describe machine
-;; snapshots / routes / elision as surviving time-travel.
+;; Lock — restore-epoch is whole-frame-state, not app-db-only. The leaf must
+;; teach that restore reinstalls BOTH partitions via replace-frame-state!, so
+;; a consuming skill doesn't describe machine snapshots / routes / elision as
+;; surviving time-travel.
 ;; ---------------------------------------------------------------------------
 
 (deftest restore-epoch-named-as-frame-state-both-partitions
@@ -521,17 +501,17 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock — the privacy-relevant read catalogue covers the STREAMING reads +
-;; the signal recorder, not just the one-shot direct-read set (rf2-7g9htq.3).
+;; the signal recorder, not just the one-shot direct-read set.
 ;;
-;; The earlier leaf scoped the fail-closed egress map to the one-shot set
-;; (snapshot / get-path / read-sub / list-subscriptions / dispatch-dry-run)
-;; and omitted the streaming reads (subscribe / trace-window / watch-epochs)
-;; and the signal recorder — all of which are privacy-bearing off-box reads
-;; under the SAME default-off gate. A consuming skill using this leaf as the
-;; privacy map could treat streaming epoch reads and recordings as outside
-;; the boundary. These pins keep the broader catalogue + its emission sites
-;; (elide-wire-value for direct values / recorded samples; projected-record
-;; for epoch records) visible at the leaf.
+;; The fail-closed egress map covers the one-shot set (snapshot / get-path /
+;; read-sub / list-subscriptions / dispatch-dry-run) AND the streaming reads
+;; (subscribe / trace-window / watch-epochs) AND the signal recorder — all
+;; privacy-bearing off-box reads under the SAME default-off gate. Scoping the
+;; map to the one-shot set alone would let a consuming skill treat streaming
+;; epoch reads and recordings as outside the boundary. These pins keep the
+;; broader catalogue + its emission sites (elide-wire-value for direct values
+;; / recorded samples; projected-record for epoch records) visible at the
+;; leaf.
 ;; ---------------------------------------------------------------------------
 
 (deftest streaming-reads-named-as-gated-egress
@@ -568,18 +548,18 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock — the linked authoritative direct-read privacy specs describe the
-;; runtime-db elision registry, NOT the retired app-db one (rf2-kvpr74)
+;; runtime-db elision registry, NOT the app-db one
 ;;
 ;; `tool-pair-surfaces.md` points agents at spec/Tool-Pair.md §Direct-read
 ;; privacy and spec/Security.md §Direct-read privacy as the "Full contract".
-;; Per EP-0001 the elision declaration registry is durable runtime-db state
-;; at `[:rf.runtime/elision …]` (implementation/core/src/re_frame/elision.cljc),
-;; NOT the retired app-db `[:rf/runtime :elision …]` root. A spec that still
-;; teaches the app-db path in CURRENT TENSE produces false-green direct-read
-;; privacy checks (a walker reading a dead registry emits raw values). This
-;; guard fails on a CURRENT-TENSE `[:rf/runtime :elision …]` reference in
-;; either linked spec or the shared leaf, allowing only explicit retired-
-;; history mentions (a line that names the path as retired / no-longer-used).
+;; The elision declaration registry is durable runtime-db state at
+;; `[:rf.runtime/elision …]` (implementation/core/src/re_frame/elision.cljc),
+;; NOT the app-db `[:rf/runtime :elision …]` root. A spec that teaches the
+;; app-db path in CURRENT TENSE produces false-green direct-read privacy
+;; checks (a walker reading a dead registry emits raw values). This guard
+;; fails on a CURRENT-TENSE `[:rf/runtime :elision …]` reference in either
+;; linked spec or the shared leaf, allowing only explicit retired-history
+;; mentions (a line that names the path as retired / no-longer-used).
 ;; ---------------------------------------------------------------------------
 
 (defn- retired-framing?
@@ -636,21 +616,20 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Lock — the leaf carries an AVAILABILITY-TIER model, not a flat names-only
-;; catalogue (rf2-1inyqr)
+;; catalogue
 ;;
-;; The skills/shared best-practice review (rf2-1inyqr finding 1) found the
-;; leaf taught a flat `## The surfaces` catalogue with no capability /
-;; availability annotation — so a consuming skill could name the right
-;; Tool-Pair family while teaching the WRONG operational model: treating an
-;; absent epoch artefact like a broken pair tool, assuming `sub-cache` is
-;; portable to JVM/SSR, expecting `data-rf-view` in a production build, or
-;; abandoning usable production probes because the flat list hid which
-;; surfaces still answer. The authoritative tiers live in spec/Tool-Pair.md
-;; (dev-gate via `interop/debug-enabled?`, the `day8/re-frame2-epoch`
-;; artefact home + absent-artefact split, the CLJS-only `sub-cache` note,
-;; the 006 `data-rf-view` production-elision gate). These pins fail loudly
-;; if the leaf regresses to a names-only catalogue that drops the tier
-;; qualifiers.
+;; The leaf MUST annotate each surface with its capability / availability
+;; tier, not teach a flat `## The surfaces` catalogue. A names-only list
+;; lets a consuming skill name the right Tool-Pair family while teaching the
+;; WRONG operational model: treating an absent epoch artefact like a broken
+;; pair tool, assuming `sub-cache` is portable to JVM/SSR, expecting
+;; `data-rf-view` in a production build, or abandoning usable production
+;; probes because a flat list hides which surfaces still answer. The
+;; authoritative tiers live in spec/Tool-Pair.md (dev-gate via
+;; `interop/debug-enabled?`, the `day8/re-frame2-epoch` artefact home +
+;; absent-artefact split, the CLJS-only `sub-cache` note, the 006
+;; `data-rf-view` production-elision gate). These pins fail loudly if the
+;; leaf regresses to a names-only catalogue that drops the tier qualifiers.
 ;; ---------------------------------------------------------------------------
 
 (deftest availability-tiers-section-present
@@ -698,7 +677,7 @@
       ;; data-rf-view is already pinned by view-plane-reads-enumerated; here
       ;; we pin the AVAILABILITY claim — that it rides the production-elision
       ;; gate, so a production-attached session must not expect the view↔DOM
-      ;; map to be populated (rf2-1inyqr).
+      ;; map to be populated.
       (is (contains-any? body ["data-rf-view` not stamped"
                                "data-rf-view / data-rf2-source-coord"
                                "data-rf2-source-coord` / `data-rf-view`"


### PR DESCRIPTION
Applies the LENS from parent rf2-2db7z1 to **skills/ CODE only** (the pair preload runtime.cljs + scripts + tests). Comments and docstrings now describe the CURRENT contract as-if-always, generously, with history-narration stripped: evolution framing (formerly/previously/used to/no longer/renamed from/legacy/retired/superseded), change-provenance bead-ids (rf2-xxxxx) and EP-numbers offered as justification, "THE BUG/THE FIX" framing, and negative definitions of deleted concepts.

Behaviour-neutral: **comments and docstrings only** — no executable code, test assertions (`is`/`testing` strings), `deftest` names, or predicate data were changed.

## Scope

- `preload/re_frame2_pair/runtime.cljs` (~4.7K lines) — the largest surface; de-historicized header, require-block scars, and every fn docstring/section while preserving spec anchors (Spec 006/009, Tool-Pair §, Conventions.md §) and genuine current-design teaching.
- `scripts/ops.clj`, `scripts/bencode.clj` — transport docstrings/comments.
- `tests/runtime/*` (20 files) + `_support.clj` — structural-pin headers + inline comments; the recurring `(rf2-yrpt90). Alias the vars` scaffold note normalized across 10 files.
- `tests/shim/*`, `tests/prompts/prompt_regression_test.clj`, `tests/fixture/src/counter/core.cljs`.
- `skills/shared/tests/{retro_protocol_test,tool_pair_surfaces_test}.clj` + `evals/score-behavioral-eval.clj`, `skills/re-frame2-setup/tests/setup_drift_test.clj` — the drift-guard suites: section-header rationale de-historicized; the `is`/`testing`/predicate strings (which ARE the guard's behaviour) left untouched.

Preserved per the LENS: spec-section anchors, external-standard references, forward-looking TODO/FUTURE notes, real scar-comments (reframed to lead with current rationale, bead-id dropped), and non-meta uses of "previous"/"old"/"no longer" (e.g. a disposed sub no longer appearing in the live cache).

Out of scope (untouched): skill `.md` prose, `examples/`, `implementation/`.

## Quality gates

- **clj-kondo**: runtime.cljs + ops.clj + the edited test files lint clean — 0 new errors/warnings (the 5 pre-existing runtime.cljs warnings and the score-behavioral-eval.clj ns-name-mismatch are unchanged and present on origin/main).
- **bb test suites**: all 25 bb-runnable skills test files pass (0 failures, 0 errors) — including the structural-pin tests that parse runtime.cljs forms and assert specific code shapes, which confirms the CODE is byte-for-byte unchanged beneath the comments/docstrings.
- **score-behavioral-eval.clj `--self-test`**: PASSED.
- Behaviour-neutral confirmed: changeset is 30 skills CODE files, comment/docstring lines only; no `.md`/`examples/`/`implementation/` touched.