### PR TITLE
docs(impl): de-historicize comments/docstrings — reactive cluster (rf2-3mgiok)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -8,7 +8,7 @@
   LAST (after the handler and the rest of the `:after` chain, which
   reshapes the `:db` effect) — transforming the handler's pending `:db`
   effect, in topological order over their static dependency graph
-  (per Spec 013 §Drain integration; rf2-u0zz5).
+  (per Spec 013 §Drain integration).
 
   Flows are deliberately a NICHE convenience — not a sub replacement,
   not a new dataflow paradigm. Use a sub if the value is consumed by
@@ -31,32 +31,30 @@
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]
-            ;; EP-0014 slice-3 (rf2-s8w3nw): the JVM-only require of the
-            ;; flows tooling sibling that backs the `flow-algebra-view`
-            ;; alias at the foot of this ns. CLJS deliberately OMITS this
-            ;; require so a CLJS app that loads the flows artefact but never
-            ;; attaches a tool DCEs the tooling body wholesale — the facade
-            ;; never reaches it. JVM has no bundle to protect; the alias
-            ;; gives JVM tools / conformance fixtures the ergonomic
-            ;; `re-frame.flows/flow-algebra-view` shape. Mirrors the
-            ;; `re-frame.subs` → `re-frame.subs.tooling` JVM-only require
-            ;; (rf2-bmzq0 / rf2-gge6mf slice-2).
+            ;; JVM-only require of the flows tooling sibling that backs the
+            ;; `flow-algebra-view` alias at the foot of this ns. CLJS
+            ;; deliberately OMITS this require so a CLJS app that loads the
+            ;; flows artefact but never attaches a tool DCEs the tooling body
+            ;; wholesale — the facade never reaches it. JVM has no bundle to
+            ;; protect; the alias gives JVM tools / conformance fixtures the
+            ;; ergonomic `re-frame.flows/flow-algebra-view` shape. Mirrors the
+            ;; `re-frame.subs` → `re-frame.subs.tooling` JVM-only require.
             #?@(:clj [[re-frame.flows.tooling :as flows-tooling]])))
 
 ;; ---- public-surface re-exports -------------------------------------------
 ;;
-;; Per rf2-4gvb4 — the registry atoms are private. External consumers
-;; (test fixtures, conformance harnesses, cross-artefact integration tests)
-;; reach the registry shape through the read accessors
-;; (`flows-snapshot` / `last-inputs-snapshot`) and the existing reset fns
+;; The registry atoms are private. External consumers (test fixtures,
+;; conformance harnesses, cross-artefact integration tests) reach the
+;; registry shape through the read accessors
+;; (`flows-snapshot` / `last-inputs-snapshot`) and the reset fns
 ;; (`reset-flows!` / `reset-last-inputs!`). The facade re-exports both
 ;; pairs.
 ;;
-;; EP-0015: `last-inputs-snapshot` returns the RAW cached input values
-;; (owner-local app-db / runtime-db slices, possibly sensitive / large). It
-;; is an internal / test / rollback seam — `^:no-doc`, NOT an egress
-;; boundary. The raw dirty-check cache is never shipped off-box; tools and
-;; direct reads that cross a trust boundary read the ELIDED trace path
+;; `last-inputs-snapshot` returns the RAW cached input values (owner-local
+;; app-db / runtime-db slices, possibly sensitive / large). It is an
+;; internal / test / rollback seam — `^:no-doc`, NOT an egress boundary. The
+;; raw dirty-check cache is never shipped off-box; tools and direct reads
+;; that cross a trust boundary read the ELIDED trace path
 ;; (`:rf.flow/computed` / `:rf.flow/failed`, which ride `elide-inputs`).
 
 (def flows-snapshot       registry/flows-snapshot)
@@ -67,17 +65,17 @@
 (def reset-flows!       registry/reset-flows!)
 (def reset-last-inputs! registry/reset-last-inputs!)
 
-;; EP-0014 slice-3 (rf2-s8w3nw): the derivation/process algebra view of
-;; registered flows. JVM-runnable (the flow registry is partition-agnostic
-;; registration metadata), so a JVM convenience alias lets tools /
-;; conformance fixtures reach it as `re-frame.flows/flow-algebra-view`
-;; without naming the sibling. The body lives in `re-frame.flows.tooling`
-;; so a CLJS app that loads the flows artefact but attaches no tool DCEs it
-;; (the CLJS facade never `:require`s the tooling sibling — the require
-;; above is `#?@(:clj ...)`-gated). CLJS consumers (Xray + conformance)
-;; call `re-frame.flows.tooling/flow-algebra-view` directly. No
-;; `re-frame.core` facade export (EP-0014 issue-1 disposition). Mirrors the
-;; `re-frame.subs/sub-algebra-view` JVM alias (slice-2).
+;; The derivation/process algebra view of registered flows. JVM-runnable
+;; (the flow registry is partition-agnostic registration metadata), so a JVM
+;; convenience alias lets tools / conformance fixtures reach it as
+;; `re-frame.flows/flow-algebra-view` without naming the sibling. The body
+;; lives in `re-frame.flows.tooling` so a CLJS app that loads the flows
+;; artefact but attaches no tool DCEs it (the CLJS facade never `:require`s
+;; the tooling sibling — the require above is `#?@(:clj ...)`-gated). CLJS
+;; consumers (Xray + conformance) call
+;; `re-frame.flows.tooling/flow-algebra-view` directly. There is no
+;; `re-frame.core` facade export. Mirrors the
+;; `re-frame.subs/sub-algebra-view` JVM alias.
 #?(:clj
    (def flow-algebra-view flows-tooling/flow-algebra-view))
 
@@ -88,24 +86,23 @@
 ;; the pending `:db` effect before install and before :fx (per Spec 013
 ;; §Drain integration).
 
-;; ---- partition-qualified input resolution (EP-0001 §535-551, rf2-4eisfr) --
+;; ---- partition-qualified input resolution (EP-0001 §535-551) ------------
 ;;
-;; Mike RULED (b) 2026-06-09: flows read runtime-db via EXPLICIT partition-
-;; qualified inputs — this IS EP-0001 normative text (§535-551), not a fresh
-;; design call. The binary syntax (mayor refinement (i) — NO redundant
+;; Flows read runtime-db via EXPLICIT partition-qualified inputs (EP-0001
+;; normative text, §535-551). The binary syntax (no redundant
 ;; `[:rf.db/app …]` explicit-app form):
 ;;
 ;;   bare path            → app-db    e.g. [:user :first]
 ;;   [:rf.db/runtime …]   → runtime-db e.g. [:rf.db/runtime :rf.runtime/routing :current :route-id]
 ;;
-;; ANY flow may read runtime-db this way (mayor refinement (ii) — user flows
-;; AND framework flows); only the WRITE side is reserved (flow outputs land
-;; in app-db only — see `evaluate-flow!`'s `assoc-in db (:output-path flow)`). The
-;; resolver reads the SETTLED post-transition / post-macrostep PENDING frame-
-;; state the flow transform was handed (app-db = the pending `:db` effect /
-;; current app-db; runtime-db = the pending `:rf.db/runtime` effect / current
-;; runtime-db) — so a runtime-only event (e.g. a pure `:rf.route/transitioned`
-;; with no app-db change) still presents the changed route value here.
+;; ANY flow — user or framework — may read runtime-db this way; only the
+;; WRITE side is reserved (flow outputs land in app-db only — see
+;; `evaluate-flow!`'s `assoc-in db (:output-path flow)`). The resolver reads
+;; the SETTLED post-transition / post-macrostep PENDING frame-state the flow
+;; transform was handed (app-db = the pending `:db` effect / current app-db;
+;; runtime-db = the pending `:rf.db/runtime` effect / current runtime-db) —
+;; so a runtime-only event (e.g. a pure `:rf.route/transitioned` with no
+;; app-db change) still presents the changed route value here.
 ;;
 ;; A qualified runtime input never creates a spurious topo dependency edge:
 ;; `topo/depends-on?` compares a flow's `:inputs` against another flow's
@@ -118,10 +115,10 @@
 ;; app-db partition was value-identical.
 
 ;; The partition-syntax primitives (`runtime-partition-key` / `runtime-input?`
-;; / the strip via `input-resolve-path`) live ONCE in `re-frame.flows.registry`
-;; (rf2-4vreu8): `registry` is required by both this facade and
-;; `re-frame.flows.tooling` and requires neither back (no cycle), so it is the
-;; natural shared home for the rule all three consumers key on.
+;; / the strip via `input-resolve-path`) live ONCE in `re-frame.flows.registry`:
+;; `registry` is required by both this facade and `re-frame.flows.tooling`
+;; and requires neither back (no cycle), so it is the natural shared home for
+;; the rule all three consumers key on.
 
 (defn- resolve-input
   "Resolve one flow `:inputs` path against the pending frame-state's two
@@ -137,7 +134,7 @@
   "Read a flow's `:inputs` against the pending frame-state — `db` is the
   pending app-db partition, `runtime-db` the pending runtime-db partition.
   Bare paths read app-db; `[:rf.db/runtime …]` paths read runtime-db
-  (EP-0001 §535-551, rf2-4eisfr)."
+  (EP-0001 §535-551)."
   [db runtime-db flow]
   (mapv (fn [path] (resolve-input db runtime-db path)) (:inputs flow)))
 

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -147,23 +147,22 @@
   bus is the wire boundary on both paths, so a flow reading a large or
   sensitive input must not surface it raw on either.
 
-  rf2-p44r3u: the `:path` opt seeds which declaration `elide-wire-value`
-  matches the value against, so it MUST be the DECLARATION-COORDINATE path,
-  not the raw `:inputs` path. For a runtime-db-qualified input
-  `[:rf.db/runtime …rest]` (rf2-4eisfr) the value is read from runtime-db at
-  `…rest` and the elision registry keys its declaration at that STRIPPED
-  `…rest` path (the registry is partition-blind — `add-marks` / schema store
-  bare path vectors). Seeding the walk with the raw `[:rf.db/runtime …]`
-  path therefore never matched the declaration and surfaced the input value
-  RAW even though the same slot's derived output was correctly redacted. We
-  normalize each input path through the SAME `registry/input-resolve-path`
-  the flow-output propagation path already uses (`input-overlaps-declaration?`),
-  so success and failure trace input values elide against the stripped
-  runtime declaration path. A bare app-db input is unchanged by the
-  resolver, so this is a no-op for the common (app-db) case.
+  The `:path` opt seeds which declaration `elide-wire-value` matches the
+  value against, so it MUST be the DECLARATION-COORDINATE path, not the raw
+  `:inputs` path. For a runtime-db-qualified input `[:rf.db/runtime …rest]` the
+  value is read from runtime-db at `…rest` and the elision registry keys its
+  declaration at that STRIPPED `…rest` path (the registry is partition-blind —
+  `add-marks` / schema store bare path vectors). Seeding the walk with the raw
+  `[:rf.db/runtime …]` path would never match the declaration and would
+  surface the input value RAW even though the same slot's derived output is
+  correctly redacted. We normalize each input path through the SAME
+  `registry/input-resolve-path` the flow-output propagation path uses
+  (`input-overlaps-declaration?`), so success and failure trace input values
+  elide against the stripped runtime declaration path. A bare app-db input is
+  unchanged by the resolver, so this is a no-op for the common (app-db) case.
 
   Callers gate this behind their own outer `interop/debug-enabled?` so the
-  walk is DCE'd in CLJS production (rf2-drr4z); this fn does not re-gate."
+  walk is DCE'd in CLJS production; this fn does not re-gate."
   [frame-id flow input-values]
   (mapv (fn [input-path v]
           (elision/elide-wire-value
@@ -174,9 +173,8 @@
 (defn- validate-output!
   "Dev-only validation of a flow's computed `:derive`-output value against its
   optional `:schema` (Spec 013 §The registration shape — \"Malli schema
-  for the output value (dynamic-host validation in dev)\"). Per
-  rf2-ee38b.9 this is what makes the `:schema` flow-map key load-bearing
-  rather than inert metadata.
+  for the output value (dynamic-host validation in dev)\"). This is what
+  makes the `:schema` flow-map key load-bearing rather than inert metadata.
 
   Routes through the schemas artefact's `:schemas/validate-with-registered-fn`
   / `:schemas/explain-with-registered-fn` late-bind seam — the SAME seam
@@ -209,18 +207,15 @@
       (when-not (validate schema new-output)
         (let [explain     (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
               explanation (when explain (explain schema new-output))
-              ;; rf2-o69h5 — the SHARED schema-aware redaction seam. When the
-              ;; flow's output schema marks any slot `:sensitive?` this scrubs
-              ;; the value-bearing slots (`:value` / `:explain` /
+              ;; The SHARED schema-aware redaction seam. When the flow's output
+              ;; schema marks any slot `:sensitive?` this scrubs the
+              ;; value-bearing slots (`:value` / `:explain` /
               ;; `:explain-humanized`) to `:rf/redacted` and stamps
-              ;; `:sensitive? true`. Closes the a5kzs#1 class on `:where
-              ;; :flow-output`: the prior code path-elided `:value` (handling
-              ;; `:large?` / per-path sensitive declarations) but left
-              ;; `:explain` carrying the failing value verbatim under Malli's
-              ;; path-shaped output — a re-leak for a `:sensitive?`-marked
-              ;; output schema. The `:value` elision-walk stays the BASE
+              ;; `:sensitive? true`. The `:value` elision-walk is the BASE
               ;; (`:large?` handling, per-path declarations); the seam scrubs
-              ;; the rest when the schema declares sensitivity.
+              ;; the rest — including `:explain`, which would otherwise carry
+              ;; the failing value verbatim under Malli's path-shaped output —
+              ;; when the schema declares sensitivity.
               redact      (late-bind/get-fn-cached :schemas/redact-validation-tags)
               tags        {:category   :rf.error/schema-validation-failure
                            :where      :flow-output
@@ -255,7 +250,7 @@
   exception re-throws after the `:rf.flow/failed` trace fires.
 
   Failed-flow contract (Spec 013 §Failure semantics — atomicity
-  contract, Mike 2026-05-24): the failing flow's own output is NOT
+  contract): the failing flow's own output is NOT
   written (the throw happened during `:derive`; there is no usable
   new-output). This fn re-throws an ex-info carrying `:rf.flow/failed-id`
   so the router can attribute the cascade-level
@@ -273,15 +268,15 @@
   install. Invoked once per registered flow per event.
   Trace payload construction sits inside an `interop/debug-enabled?`
   outer gate so the elision walker (`elide-wire-value`) is not invoked
-  in CLJS production builds (per Spec 009 §Production builds, rf2-drr4z
-  perf slice). Future editors: keep the gate OUTERMOST on each emit
+  in CLJS production builds (per Spec 009 §Production builds). Future
+  editors: keep the gate OUTERMOST on each emit
   site and keep wire-value walks INSIDE it — Closure DCE folds the
   whole branch under `:advanced` + `goog.DEBUG=false`."
   [frame-id db runtime-db flow]
   (let [flow-id    (:id flow)
         new-inputs (read-inputs db runtime-db flow)
-        ;; Per rf2-94ol5 dirty-check storage is PER-FRAME: read this
-        ;; flow's last-seen inputs from THIS frame's own `last-inputs`
+        ;; Dirty-check storage is PER-FRAME: read this flow's last-seen
+        ;; inputs from THIS frame's own `last-inputs`
         ;; container. Per-frame dirty-check windows stay independent by
         ;; construction — the read can't observe a sibling frame's row.
         old-inputs (registry/get-frame-flow-last-inputs frame-id flow-id)]
@@ -293,8 +288,8 @@
         ;; didn't fire at all". Outer `debug-enabled?` gate elides the
         ;; tag-map construction in prod.
         (when interop/debug-enabled?
-          ;; `:input-paths-unchanged` (rf2-931pm) names every input db-path
-          ;; whose value was `=` to the previous run — the cascade DAG
+          ;; `:input-paths-unchanged` names every input db-path whose value
+          ;; was `=` to the previous run — the cascade DAG
           ;; consumer reads this to render the "considered, no recompute"
           ;; branch dimmed. For a value-equal skip every input is by
           ;; definition unchanged; we ship the full input-path vector.
@@ -305,8 +300,8 @@
                         :frame                  frame-id}))
         [db false])
       (try
-        ;; rf2-hhh92: wall-clock the flow's `:derive` recompute (dev-only)
-        ;; so `:rf.flow/computed` carries `:elapsed-ms` — the per-op
+        ;; Wall-clock the flow's `:derive` recompute (dev-only) so
+        ;; `:rf.flow/computed` carries `:elapsed-ms` — the per-op
         ;; duration the Trace panel's DURATION column reads. The `now-ms`
         ;; brackets ride `interop/debug-enabled?` (nil t0 in prod) so
         ;; Closure DCEs them under :advanced + `goog.DEBUG=false`.
@@ -314,32 +309,30 @@
               new-output (apply (:derive flow) new-inputs)
               flow-elapsed-ms (when interop/debug-enabled?
                                 (- (interop/now-ms) t0))
-              ;; Per rf2-qlzh4: capture the pre-write value at the
-              ;; flow's `:output-path` BEFORE we assoc-in the new output.
-              ;; This becomes the `:before` slot on the
-              ;; `:rf.flow/computed` trace below — consumers (Xray
-              ;; Event Detail, re-frame-10x flow panel) no longer
-              ;; need to walk the epoch's `:db-before` snapshot to
-              ;; render "wrote [:cart :total] 47.50 -> 52.50". The
-              ;; read happens against `db` (the loop accumulator that
-              ;; includes prior flows' writes in this drain), so a
-              ;; flow that reads (via `:inputs`) a slot an UPSTREAM
-              ;; flow wrote sees that upstream write — the correct
-              ;; cascade-local semantics. The `:before` at the flow's
-              ;; OWN `:output-path`, however, can only ever reflect the
-              ;; handler's / pre-existing value, NEVER another flow's
-              ;; write: the rf2-um6d9/#3086 invariant
-              ;; (`detect-output-path-overlap!`, wired into `reg-flow`)
-              ;; rejects any two same-frame flows whose output `:output-path`s
-              ;; stand in a prefix relationship, so no upstream flow can
-              ;; have written this flow's `:output-path` earlier in the drain
-              ;; (per Spec 013 §Disjoint output paths). Gated to dev-only
-              ;; so the read is DCE'd under `:advanced` + `goog.DEBUG=false`.
+              ;; Capture the pre-write value at the flow's `:output-path`
+              ;; BEFORE we assoc-in the new output.
+              ;; This becomes the `:before` slot on the `:rf.flow/computed`
+              ;; trace below, so consumers (Xray Event Detail, re-frame-10x
+              ;; flow panel) can render "wrote [:cart :total] 47.50 -> 52.50"
+              ;; without walking the epoch's `:db-before` snapshot. The read
+              ;; happens against `db` (the loop accumulator that includes prior
+              ;; flows' writes in this drain), so a flow that reads (via
+              ;; `:inputs`) a slot an UPSTREAM flow wrote sees that upstream
+              ;; write — the correct cascade-local semantics. The `:before` at
+              ;; the flow's OWN `:output-path`, however, can only ever reflect
+              ;; the handler's / pre-existing value, NEVER another flow's
+              ;; write: the disjoint-output-path invariant
+              ;; (`detect-output-path-overlap!`, wired into `reg-flow`) rejects
+              ;; any two same-frame flows whose output `:output-path`s stand in
+              ;; a prefix relationship, so no upstream flow can have written
+              ;; this flow's `:output-path` earlier in the drain (per Spec 013
+              ;; §Disjoint output paths). Gated to dev-only so the read is DCE'd
+              ;; under `:advanced` + `goog.DEBUG=false`.
               old-output (when interop/debug-enabled?
                            (get-in db (:output-path flow)))
               new-db     (assoc-in db (:output-path flow) new-output)]
           ;; Advance the dirty-check row in THIS frame's own `last-inputs`
-          ;; container (rf2-94ol5) — frame-local, can't touch a sibling.
+          ;; container — frame-local, can't touch a sibling.
           (registry/set-frame-flow-last-inputs! frame-id flow-id new-inputs)
           ;; Per Spec 009 §:op-type vocabulary: `:rf.flow/computed`
           ;; records a successful recompute. The dirty-check is
@@ -350,12 +343,11 @@
           ;; `:before`) ride through `elision/elide-wire-value` per
           ;; Spec 009 §Size elision in traces — the walker is the
           ;; single normative emission site for `:rf.size/large-
-          ;; elided` (and the `:rf/redacted` privacy sentinel).
-          ;; Without this the flow trace bypassed the elision
-          ;; contract that every other wire-emitting surface honours;
-          ;; a flow reading or producing a large or sensitive value
-          ;; would surface raw on the trace bus. Off-box defaults
-          ;; match `event-emit` / `error-emit`.
+          ;; elided` (and the `:rf/redacted` privacy sentinel) — so a
+          ;; flow reading or producing a large or sensitive value never
+          ;; surfaces raw on the trace bus, honouring the same elision
+          ;; contract every other wire-emitting surface does. Off-box
+          ;; defaults match `event-emit` / `error-emit`.
           ;;
           ;; The `:path` opt on each walker call names where in the
           ;; slice's root the wrapped value lives — `:result` and
@@ -366,9 +358,8 @@
           ;; frame-declared large slots.
           ;;
           ;; Outer `interop/debug-enabled?` gate keeps the elision
-          ;; walker out of CLJS prod builds (rf2-drr4z) — Closure
-          ;; constant-folds the whole branch under `:advanced` +
-          ;; `goog.DEBUG=false`.
+          ;; walker out of CLJS prod builds — Closure constant-folds the
+          ;; whole branch under `:advanced` + `goog.DEBUG=false`.
           (when interop/debug-enabled?
             (trace/emit! :flow :rf.flow/computed
                          {:flow-id      flow-id
@@ -382,8 +373,8 @@
                           :path         (:output-path flow)
                           :elapsed-ms   flow-elapsed-ms
                           :frame        frame-id})
-            ;; Per rf2-ee38b.9 — dev-only output-schema validation. Runs
-            ;; AFTER the `:rf.flow/computed` emit so the computed value is
+            ;; Dev-only output-schema validation. Runs AFTER the
+            ;; `:rf.flow/computed` emit so the computed value is
             ;; already on the trace stream when a violation surfaces;
             ;; observational (the write at `new-db` stands). Sits inside
             ;; this outer `debug-enabled?` gate so the whole surface DCEs
@@ -409,17 +400,17 @@
           ;; success path — the value that triggered the throw may itself
           ;; be a large or sensitive blob, and the trace bus is the wire
           ;; boundary. Outer debug-enabled? gate elides the walk in CLJS
-          ;; prod (rf2-drr4z).
-          ;; rf2-iqh5yf: emit a STRUCTURED, EDN-safe exception summary —
+          ;; prod.
+          ;; Emit a STRUCTURED, EDN-safe exception summary —
           ;; `:exception-message` (the plain message string) + `:exception-data`
           ;; (the ex-info ex-data map, or nil) — NEVER the raw Throwable. A bare
           ;; Throwable is not EDN-serializable and the central trace projection
           ;; switch (`re-frame.marks/project-trace-event`) has no branch for a
-          ;; bare `:ex` slot, so before this fix the raw object reached trace
-          ;; delivery, epoch capture, and tooling listeners unprojected — and a
-          ;; flow `:derive` throwing `ex-info` with app secrets in `ex-data`
-          ;; (or an interpolated message) leaked them off-box. The summary
-          ;; shape matches every other `:rf.error/*` category in the Spec 009
+          ;; bare `:ex` slot, so a raw object would reach trace delivery, epoch
+          ;; capture, and tooling listeners unprojected — and a flow `:derive`
+          ;; throwing `ex-info` with app secrets in `ex-data` (or an
+          ;; interpolated message) would leak them off-box. The summary shape
+          ;; matches every other `:rf.error/*` category in the Spec 009
           ;; catalogue (`:exception-message`; machine adds `:exception-data`);
           ;; `project-trace-event` redacts the `:exception-data` slot
           ;; fail-closed when the flow's frame declares any sensitivity (the
@@ -434,8 +425,8 @@
                           :exception-data    (ex-data e)
                           :inputs            (elide-inputs frame-id flow new-inputs)
                           :frame             frame-id}))
-          ;; Per rf2-je5p8: wrap the throw in an ex-info carrying the
-          ;; flow-attribution slot `:rf.flow/failed-id`.
+          ;; Wrap the throw in an ex-info carrying the flow-attribution slot
+          ;; `:rf.flow/failed-id`.
           ;; The router's `flows-after-interceptor` catch stashes the
           ;; throw under `:rf/flow-error`, then `emit-flow-eval-exception!`
           ;; reads `:rf.flow/failed-id` off the ex-data and stamps
@@ -452,20 +443,15 @@
           ;; the cascade-level error preserves the same attribution at the
           ;; substrate boundary.
           ;;
-          ;; rf2-cjr635: route through the canonical thrown-error builder
+          ;; Route through the canonical thrown-error builder
           ;; (`error/throw-error!`, Spec 009 §The thrown-error shape) like
           ;; every OTHER flows throw (`topo.cljc` cycle / overlap,
-          ;; `registry.cljc` frame-not-live). The hand-rolled re-throw
-          ;; carried ONLY `:rf.flow/failed-id` — no `:rf.error/id`, no
-          ;; `:where`, no `:recovery` — so a tool reading
-          ;; `(:rf.error/id (ex-data e))` got nil (a Machine-readable-errors
-          ;; violation), and its `(or <native-msg> ":rf.error/…")` message
-          ;; form dodged `check_thrown_error_messages.py` so it could
-          ;; silently regress to the bare-keyword shape. The builder DERIVES
-          ;; the human message from `:reason` + the `[:rf.error/<id>]` token
-          ;; and stamps the canonical `{:rf.error/id :where :recovery
-          ;; :reason}` ex-data. The flow-attribution slot rides in `:extra`;
-          ;; the original exception rides in `:extra :cause` for stack-trace
+          ;; `registry.cljc` frame-not-live). The builder DERIVES the human
+          ;; message from `:reason` + the `[:rf.error/<id>]` token and stamps
+          ;; the canonical `{:rf.error/id :where :recovery :reason}` ex-data,
+          ;; so a tool reading `(:rf.error/id (ex-data e))` gets the machine
+          ;; discriminator. The flow-attribution slot rides in `:extra`; the
+          ;; original exception rides in `:extra :cause` for stack-trace
           ;; introspection (the router surfaces the rethrown ex-info ITSELF
           ;; as the `:exception` slot of `:rf.error/flow-eval-exception`).
           (error/throw-error!
@@ -482,18 +468,18 @@
                         :cause             e}}))))))
 
 (defn run-flows-on-db
-  "Per Spec 013 §Drain integration (rf2-u0zz5) + EP-0001 §535-551
-  (rf2-4eisfr): walk THIS FRAME'S registered flows in topological order over
-  the pending frame-state, dirty-check each one, recompute and assoc-in the
-  result into a transformed APP-DB. Returns the flow-augmented APP-DB value.
+  "Per Spec 013 §Drain integration + EP-0001 §535-551: walk THIS FRAME'S
+  registered flows in topological order over the pending frame-state,
+  dirty-check each one, recompute and assoc-in the result into a transformed
+  APP-DB. Returns the flow-augmented APP-DB value.
 
   Signature `[frame-id db runtime-db]` — the full pending frame-state. `db`
   is the pending app-db partition; `runtime-db` the pending runtime-db
   partition (pass `nil` to resolve only bare app-db inputs). The router's
   flows-after-interceptor always supplies both partitions.
 
-  EP-0001 §535-551 (Mike RULED (b) 2026-06-09): a flow reads app-db by
-  default (bare `:inputs` paths) and runtime-db only through EXPLICIT
+  EP-0001 §535-551: a flow reads app-db by default (bare `:inputs` paths) and
+  runtime-db only through EXPLICIT
   partition-qualified inputs `[:rf.db/runtime …]` (binary syntax — there is
   NO redundant `[:rf.db/app …]` form). ANY flow — user or framework — may
   read runtime-db this way; only the WRITE side is reserved. Flow outputs
@@ -520,8 +506,8 @@
   here, leaving sibling frames' flows untouched.
 
   Failed-flow contract (Spec 013 §Failure semantics — atomicity
-  contract, Mike 2026-05-24): a flow throw is a PRE-INSTALL throw, so it
-  aborts the WHOLE event. There is NO partial commit — the pending `:db`
+  contract): a flow throw is a PRE-INSTALL throw, so it aborts the WHOLE
+  event. There is NO partial commit — the pending `:db`
   effect (the handler's write plus any prior successful flows' writes) is
   DISCARDED by the router's `flows-after-interceptor` catch, so app-db is
   left UNCHANGED. This fn therefore does NOT carry a partial-db on the
@@ -541,8 +527,8 @@
   preserved on the re-thrown ex-info so the router can attribute the
   cascade-level error to the failing flow.
 
-  Per rf2-94ol5 the snapshot / restore is scoped to the DRAINING frame's
-  OWN `last-inputs` container — `frame-id`'s atom, not a global. A sibling
+  The snapshot / restore is scoped to the DRAINING frame's OWN
+  `last-inputs` container — `frame-id`'s atom, not a global. A sibling
   frame draining concurrently on another JVM thread holds a different atom,
   so this rollback cannot clobber its just-advanced dirty-check rows. The
   per-frame-independence invariant (Spec 002 rule 1 / Spec 013
@@ -556,34 +542,34 @@
             ;; flow throw can roll back the frame's own advances — the event
             ;; aborts, so prior flows' `last-inputs` advances must NOT
             ;; survive (their outputs were never installed). Scoped to
-            ;; `frame-id` (rf2-94ol5) so a concurrently-draining sibling
-            ;; frame is structurally untouched. Restored in the catch below.
+            ;; `frame-id` so a concurrently-draining sibling frame is
+            ;; structurally untouched. Restored in the catch below.
             last-inputs-before (registry/frame-last-inputs-snapshot frame-id)
-            ;; rf2-gdzv6o: snapshot the frame's flow output-declaration elision
-            ;; slots BEFORE the refresh below mutates them. The refresh writes
+            ;; Snapshot the frame's flow output-declaration elision slots
+            ;; BEFORE the refresh below mutates them. The refresh writes
             ;; runtime-db IMMEDIATELY (`swap-elision-slot!`), but a flow throw
             ;; is a PRE-INSTALL throw that aborts the WHOLE event — so the
             ;; refresh's runtime-db write must be rolled back too, or app-db
             ;; rolls back while runtime-db elision declarations survive,
             ;; violating the all-or-nothing two-partition contract (Spec
             ;; 013:284,288 — a pre-install flow throw leaves BOTH partitions
-            ;; unchanged). Frame-scoped (rf2-94ol5); restored in the catch.
+            ;; unchanged). Frame-scoped; restored in the catch.
             decls-before       (registry/flow-output-declarations-snapshot frame-id)
-            ;; rf2-z980k8: DRAIN (read-and-clear) this frame's pending abandoned
-            ;; output paths — recorded by an IN-DRAIN same-frame `reg-flow`
-            ;; `:output-path` move (a direct app-db write would be clobbered by the
-            ;; deferred commit). `abandoned-before` is the snapshot the catch /
-            ;; post-commit rollback re-records (the move re-attempts next drain
-            ;; if the event aborts); `abandoned-paths` is the SAME set, consumed
-            ;; here exactly once. They are dissoc'd from the pending `:db` below,
-            ;; BEFORE the flow walk, so the vacate rides the value the deferred
-            ;; commit publishes (the handler's returned `:db` cannot resurrect
-            ;; the old path) and the new flow's recompute lands on a clean slot.
-            ;; Frame-scoped (rf2-94ol5).
+            ;; DRAIN (read-and-clear) this frame's pending abandoned output
+            ;; paths — recorded by an IN-DRAIN same-frame `reg-flow`
+            ;; `:output-path` move (a direct app-db write would be clobbered by
+            ;; the deferred commit). `abandoned-before` is the snapshot the
+            ;; catch / post-commit rollback re-records (the move re-attempts
+            ;; next drain if the event aborts); `abandoned-paths` is the SAME
+            ;; set, consumed here exactly once. They are dissoc'd from the
+            ;; pending `:db` below, BEFORE the flow walk, so the vacate rides
+            ;; the value the deferred commit publishes (the handler's returned
+            ;; `:db` cannot resurrect the old path) and the new flow's
+            ;; recompute lands on a clean slot. Frame-scoped.
             abandoned-before   (registry/abandoned-output-paths-snapshot frame-id)
             abandoned-paths    (registry/drain-abandoned-output-paths! frame-id)]
-        ;; rf2-ihfz9o: refresh each flow's output data-classification
-        ;; declarations BEFORE the flow walk so a propagated (input-
+        ;; Refresh each flow's output data-classification declarations
+        ;; BEFORE the flow walk so a propagated (input-
         ;; inherited) sensitive mark is in the frame's elision registry
         ;; when the t2 `:rf.event/db-pending-post-flow` trace and the
         ;; `:rf.flow/computed` `:result` slot project (Spec 015:568).
@@ -605,8 +591,8 @@
         ;; touches ONLY the runtime-db elision registry, never app-db,
         ;; so it cannot perturb the cascade value or app-db subs.
         ;;
-        ;; rf2-gdzv6o: this write is INSIDE the `try` so the catch arm can
-        ;; roll it back. It is staged-before-walk for the trace/projection
+        ;; This write is INSIDE the `try` so the catch arm can roll it back.
+        ;; It is staged-before-walk for the trace/projection
         ;; reasons above, but a downstream flow throw must unwind it — the
         ;; refresh is part of the event's two-partition transaction, not a
         ;; commit-before-the-walk side effect.
@@ -625,8 +611,8 @@
           ;; (the per-flow `:rf.flow/skip` / `:rf.flow/computed` traces carry
           ;; the dirty/clean signal tools actually read).
           (loop [remaining ordered
-                 ;; rf2-z980k8: vacate the IN-DRAIN abandoned output paths from
-                 ;; the pending `:db` FIRST — before any flow computes — so the
+                 ;; Vacate the IN-DRAIN abandoned output paths from the pending
+                 ;; `:db` FIRST — before any flow computes — so the
                  ;; old path is gone from the value the deferred commit
                  ;; publishes (the handler's returned `:db` carried it, but this
                  ;; transform is applied to that SAME value, so it cannot
@@ -644,24 +630,23 @@
             ;; Atomicity contract: discard ALL flow side-effects of this
             ;; aborted drain. The pending `:db` effect is dropped by the
             ;; router; here we restore THIS frame's pre-drain `last-inputs`
-            ;; (its own container only — rf2-94ol5) so every flow on this
-            ;; frame re-attempts next drain while sibling frames are
-            ;; untouched. rf2-gdzv6o: ALSO restore the frame's flow output-
-            ;; declaration elision slots — the pre-walk
+            ;; (its own container only) so every flow on this frame re-attempts
+            ;; next drain while sibling frames are untouched. ALSO restore the
+            ;; frame's flow output-declaration elision slots — the pre-walk
             ;; `refresh-flow-output-declarations!` wrote runtime-db directly,
             ;; and a pre-install flow throw must leave runtime-db (not just
             ;; app-db) EXACTLY unchanged (Spec 013:284,288). Both restores are
-            ;; frame-scoped (rf2-94ol5): sibling frames untouched. The throw
+            ;; frame-scoped: sibling frames untouched. The throw
             ;; (carrying `:rf.flow/failed-id` from `evaluate-flow!`) propagates
             ;; unchanged for router attribution.
             (registry/reset-frame-last-inputs-to! frame-id last-inputs-before)
             (registry/restore-flow-output-declarations! frame-id decls-before)
-            ;; rf2-z980k8: re-record the IN-DRAIN abandoned output paths drained
-            ;; above. A flow throw aborts the event — the pending `:db` (which
-            ;; carried the vacated state) is discarded — so the path move must
-            ;; re-attempt next drain rather than be silently lost. Frame-scoped
-            ;; (rf2-94ol5). The post-COMMIT rollback mirror lives in
-            ;; `commit-frame-effects!` via `:flows/restore-abandoned-paths!`.
+            ;; Re-record the IN-DRAIN abandoned output paths drained above. A
+            ;; flow throw aborts the event — the pending `:db` (which carried
+            ;; the vacated state) is discarded — so the path move must
+            ;; re-attempt next drain rather than be silently lost. Frame-scoped.
+            ;; The post-COMMIT rollback mirror lives in `commit-frame-effects!`
+            ;; via `:flows/restore-abandoned-paths!`.
             (registry/restore-abandoned-output-paths! frame-id abandoned-before)
             (throw e)))))))
 
@@ -685,43 +670,43 @@
 (late-bind/set-fn! :flows/run-flows-on-db    run-flows-on-db)
 (late-bind/set-fn! :flows/reset-last-inputs! reset-last-inputs!)
 (late-bind/set-fn! :flows/reset-flows!       reset-flows!)
-;; Per rf2-4wqu6 finding 1 — the dirty-check-rollback pair the router uses
-;; to keep this frame's `last-inputs` bookkeeping aligned with the DURABLE
-;; app-db across a POST-commit schema/machine-data rollback. The flow
-;; transform runs inside the chain and eagerly advances `last-inputs` for
-;; each computed flow; but the rollback decision lands AFTER the chain, in
-;; `commit-db-effect!`, OUTSIDE `run-flows-on-db`'s own throw-path
-;; snapshot/restore. Without these hooks a rolled-back commit restores
-;; app-db to `db-before` but leaves the advanced `last-inputs` rows, so the
-;; next clean drain sees `=`-equal inputs, SKIPS the flow, and the flow
-;; output never re-materialises — a deterministic dev/test failure path can
-;; permanently suppress a flow. The router snapshots the draining frame's
-;; rows BEFORE the flow transform and, on a rollback, restores them — the
-;; exact mirror of the in-`run-flows-on-db` throw-path rollback, just at the
-;; post-commit boundary the flows artefact cannot see. Both delegate to the
-;; SAME frame-scoped registry primitives the throw path uses (rf2-94ol5):
-;; structurally incapable of touching a sibling frame's container.
+;; The dirty-check-rollback pair the router uses to keep this frame's
+;; `last-inputs` bookkeeping aligned with the DURABLE app-db across a
+;; POST-commit schema/machine-data rollback. The flow transform runs inside
+;; the chain and eagerly advances `last-inputs` for each computed flow; but
+;; the rollback decision lands AFTER the chain, in `commit-db-effect!`,
+;; OUTSIDE `run-flows-on-db`'s own throw-path snapshot/restore. Without these
+;; hooks a rolled-back commit restores app-db to `db-before` but leaves the
+;; advanced `last-inputs` rows, so the next clean drain sees `=`-equal inputs,
+;; SKIPS the flow, and the flow output never re-materialises — a deterministic
+;; dev/test failure path could permanently suppress a flow. The router
+;; snapshots the draining frame's rows BEFORE the flow transform and, on a
+;; rollback, restores them — the exact mirror of the in-`run-flows-on-db`
+;; throw-path rollback, just at the post-commit boundary the flows artefact
+;; cannot see. Both delegate to the SAME frame-scoped registry primitives the
+;; throw path uses: structurally incapable of touching a sibling frame's
+;; container.
 (late-bind/set-fn! :flows/snapshot-last-inputs registry/frame-last-inputs-snapshot)
 (late-bind/set-fn! :flows/restore-last-inputs!  registry/reset-frame-last-inputs-to!)
-;; rf2-z980k8 — the abandoned-output-paths rollback pair, the exact mirror of
-;; the `last-inputs` pair above but for the IN-DRAIN `reg-flow` `:output-path`-move
-;; vacate. `run-flows-on-db` DRAINS (read-and-clears) the pending abandoned
-;; paths and dissocs them from the pending `:db`; its OWN throw arm re-records
-;; them. But a POST-commit schema / machine-data rollback lands AFTER the
-;; chain, in `commit-frame-effects!`, OUTSIDE `run-flows-on-db` — and discards
-;; the pending `:db` (which carried the vacated state). Without these hooks the
-;; abandoned path would be drained-and-cleared yet never durably vacated, so
-;; the move is silently lost. The router snapshots the pending set BEFORE the
-;; flow transform and, on a rollback, re-records it — the same boundary the
-;; `last-inputs` mirror covers. Frame-scoped (rf2-94ol5).
+;; The abandoned-output-paths rollback pair, the exact mirror of the
+;; `last-inputs` pair above but for the IN-DRAIN `reg-flow`
+;; `:output-path`-move vacate. `run-flows-on-db` DRAINS (read-and-clears) the
+;; pending abandoned paths and dissocs them from the pending `:db`; its OWN
+;; throw arm re-records them. But a POST-commit schema / machine-data rollback
+;; lands AFTER the chain, in `commit-frame-effects!`, OUTSIDE
+;; `run-flows-on-db` — and discards the pending `:db` (which carried the
+;; vacated state). Without these hooks the abandoned path would be
+;; drained-and-cleared yet never durably vacated, so the move is silently
+;; lost. The router snapshots the pending set BEFORE the flow transform and,
+;; on a rollback, re-records it — the same boundary the `last-inputs` mirror
+;; covers. Frame-scoped.
 (late-bind/set-fn! :flows/snapshot-abandoned-paths registry/abandoned-output-paths-snapshot)
 (late-bind/set-fn! :flows/restore-abandoned-paths!  registry/restore-abandoned-output-paths!)
-;; Per rf2-wbtjn — frame-destroy teardown hook (symmetric with the
-;; machines `:machines/teardown-on-frame-destroy!` hook landed by
-;; rf2-vsigt). `frame/destroy-frame!` invokes this hook so per-frame
-;; flow-registry entries, the matching `last-inputs` rows, and any
-;; `:flow` registrar slots whose last owning frame was destroyed all
-;; clear in one step. Without the hook a long-running SSR JVM (per-
-;; request frame churn) leaks flow state indefinitely.
+;; Frame-destroy teardown hook (symmetric with the machines
+;; `:machines/teardown-on-frame-destroy!` hook). `frame/destroy-frame!`
+;; invokes this hook so per-frame flow-registry entries, the matching
+;; `last-inputs` rows, and any `:flow` registrar slots whose last owning frame
+;; was destroyed all clear in one step. Without the hook a long-running SSR
+;; JVM (per-request frame churn) would leak flow state indefinitely.
 (late-bind/set-fn! :flows/teardown-on-frame-destroy!
                    registry/teardown-on-frame-destroy!)

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -809,8 +809,8 @@
            on the frame.
 
   `:rf.egress/output-sensitivity :rf.egress/public` is the DECLASSIFY claim
-  (EP-0015 issue 9; replaces the rejected `:sensitive? false` spelling): it
-  suppresses BOTH the whole-output force-mark and the propagated mark (per-path
+  (Spec 015): it suppresses BOTH the whole-output force-mark and the
+  propagated mark (per-path
   `:sensitive` entries, being explicit author intent on sub-slots, still
   apply). It cannot unmark a schema-/add-marks-sourced declaration on the same
   path — those entries are never `:source :flow`, so they survive the
@@ -835,13 +835,13 @@
   `reg` (pure). Drops THIS flow's prior `:source :flow` entries first (so a
   re-registration / mark-mutation refresh replaces cleanly), then overlays
   the freshly-resolved absolute declarations. The sensitive set is EXPLICIT
-  ∪ PROPAGATED (input-inherited, fail-closed) per Spec 015:313 + the
-  rf2-ihfz9o ruling; the large set is EXPLICIT-ONLY (:large is not auto-
-  propagated — the asymmetry settled in this PR). Resolving the propagation
-  against the CARRY (this-flow-dropped) registry means a flow never inherits
-  from its own prior mark (idempotence + no self-loop), and — because the
-  caller folds flows in topo order — a flow reading an upstream flow's `:output-path`
-  resolves against the upstream's already-folded propagated mark."
+  ∪ PROPAGATED (input-inherited, fail-closed) per Spec 015:313; the large set
+  is EXPLICIT-ONLY (:large is not auto-propagated — see the asymmetry note on
+  the classification block above). Resolving the propagation against the CARRY
+  (this-flow-dropped) registry means a flow never inherits from its own prior
+  mark (idempotence + no self-loop), and — because the caller folds flows in
+  topo order — a flow reading an upstream flow's `:output-path` resolves
+  against the upstream's already-folded propagated mark."
   [reg flow]
   (let [flow-id        (:id flow)
         [_ explicit-l] (explicit-flow-output-mark-paths flow)
@@ -869,7 +869,7 @@
   "Re-derive EVERY flow's `:source :flow` output declarations for `frame-id`,
   walking the frame's flows in TOPOLOGICAL (dependency) order so a flow that
   reads an upstream flow's `:output-path` inherits the upstream's just-refreshed
-  propagated mark (rf2-ihfz9o). Frame-scoped. Called at the START of
+  propagated mark. Frame-scoped. Called at the START of
   `re-frame.flows/run-flows-on-db` (before any flow computes, so the refreshed
   declaration is in the registry when the t2 `:rf.event/db-pending-post-flow`
   trace and the `:rf.flow/computed` `:result` slot project — Spec 015:568) —
@@ -917,7 +917,7 @@
                       reg
                       ordered))))))))
 
-;; ---- flow output-declaration snapshot / rollback (rf2-gdzv6o) -------------
+;; ---- flow output-declaration snapshot / rollback -------------------------
 ;;
 ;; `refresh-flow-output-declarations!` writes the frame's runtime-db elision
 ;; registry IMMEDIATELY (via `swap-elision-slot!`), BEFORE the flow walk in
@@ -932,16 +932,16 @@
 ;; These two helpers let the drain snapshot the frame's flow output-declaration
 ;; slots BEFORE the refresh and restore them EXACTLY on a throw — the precise
 ;; mirror of the `frame-last-inputs-snapshot` / `reset-frame-last-inputs-to!`
-;; pair this same walk already uses for the dirty-check rollback. Frame-scoped:
-;; both name `frame-id` and touch only that frame's runtime-db elision slot, so
-;; a concurrently-draining sibling frame is structurally untouched (rf2-94ol5).
+;; pair this same walk uses for the dirty-check rollback. Frame-scoped: both
+;; name `frame-id` and touch only that frame's runtime-db elision slot, so a
+;; concurrently-draining sibling frame is structurally untouched.
 
 (defn ^:no-doc flow-output-declarations-snapshot
   "Snapshot `frame-id`'s flow-touchable elision declaration sub-maps — the
   two slots `refresh-flow-output-declarations!` (and `fold-flow-declarations`)
   ever mutate: `:sensitive-declarations` and `:declarations`. Returned as a
   plain map suitable for `restore-flow-output-declarations!`. The drain-start
-  snapshot for the rf2-gdzv6o throw-path rollback."
+  snapshot for the throw-path rollback."
   [frame-id]
   {:sensitive-declarations (elision/sensitive-declarations frame-id)
    :declarations           (elision/declarations frame-id)})
@@ -952,7 +952,7 @@
   refresh that landed before an aborted flow walk. Writes the two declaration
   sub-maps back EXACTLY through `swap-elision-slot!` (pruning an emptied slot
   the same way `fold-flow-declarations` does), leaving any other elision-slot
-  keys the refresh never touches unchanged. Frame-scoped (rf2-94ol5)."
+  keys the refresh never touches unchanged. Frame-scoped."
   [frame-id prior]
   (let [prior-s (:sensitive-declarations prior)
         prior-l (:declarations prior)]
@@ -996,7 +996,7 @@
 
 ;; ---- registration --------------------------------------------------------
 
-;; `reg-flow`'s same-frame `:output-path`-change branch (rf2-73pi1) vacates the
+;; `reg-flow`'s same-frame `:output-path`-change branch vacates the
 ;; OLD output path via `vacate-output-path!`, which is defined alongside
 ;; `clear-flow` further down (both share the app-db dissoc semantics).
 ;; Forward-declare it so the registration path can reference it without
@@ -1029,25 +1029,26 @@
                         {:where    'rf/reg-flow
                          :event-id (:id flow)}))
          flow-id  (:id flow)]
-     ;; rf2-zbxvqj: reject registration against a NON-LIVE frame BEFORE any
-     ;; state mutates. `frame/frame` returns nil when the frame record is
-     ;; absent (never registered, or `destroy-frame!`'s step-6 dissoc ran) OR
+     ;; Reject registration against a NON-LIVE frame BEFORE any state mutates.
+     ;; `frame/frame` returns nil when the frame record is absent (never
+     ;; registered, or `destroy-frame!`'s step-6 dissoc ran) OR
      ;; present-but-`:destroyed?` (post-step-3, pre-step-6). Either way the
      ;; frame is non-live and must not acquire flow state.
      ;;
-     ;; The bug: `call-serialized-with-drain!` runs its thunk DIRECTLY for an
+     ;; `call-serialized-with-drain!` runs its thunk DIRECTLY for an
      ;; absent/destroyed frame (frame.cljc §call-serialized-with-drain!), so
-     ;; without this guard the registration below unconditionally installed a
+     ;; without this guard the registration below would install a
      ;; `flows[frame-id flow-id]` row, an elision declaration, and a `:flow`
-     ;; registrar slot stamped with the dead `frame-id`. A later `reg-frame`
-     ;; reusing that id then inherited the resurrected flow — breaking the
-     ;; frame-destroy isolation contract (Spec 013 §destroy-frame! releases
-     ;; every per-frame flow slot / last-inputs row / dead registrar entry).
+     ;; registrar slot stamped with the dead `frame-id` — and a later
+     ;; `reg-frame` reusing that id would inherit the resurrected flow,
+     ;; breaking the frame-destroy isolation contract (Spec 013 §destroy-frame!
+     ;; releases every per-frame flow slot / last-inputs row / dead registrar
+     ;; entry).
      ;;
-     ;; Pre-alpha contract (acceptance): REJECT with a stable structured
-     ;; error category rather than create dormant state for a typo'd or
-     ;; destroyed frame id. `clear-flow` keeps its permissive absent-frame
-     ;; no-op (teardown must be idempotent); only this MUTATING path rejects.
+     ;; So REJECT with a stable structured error category rather than create
+     ;; dormant state for a typo'd or destroyed frame id. `clear-flow` keeps
+     ;; its permissive absent-frame no-op (teardown must be idempotent); only
+     ;; this MUTATING path rejects.
      (when (nil? (frame/frame frame-id))
        (error/throw-error!
          :rf.error/flow-frame-not-live
@@ -1061,63 +1062,51 @@
          {:recovery :fix-registration
           :extra    {:frame frame-id
                      :flow  flow}}))
-     ;; ATOMIC check-and-insert (rf2-qxwib). The cycle check and the
-     ;; commit are ONE `swap!` update fn over `@flows`: it reads the
-     ;; frame's CURRENTLY-COMMITTED flow-map, runs topo-sort on the
-     ;; prospective map, and — only if that passes — returns the map
-     ;; with the new flow assoc'd in. `swap!` re-invokes the update fn
-     ;; (re-reading committed state, re-running the cycle check) whenever
-     ;; a concurrent writer wins the compare-and-set, so a cycle can
-     ;; NEVER be admitted by interleaving.
+     ;; ATOMIC check-and-insert. The cycle check and the commit are ONE
+     ;; `swap!` update fn over `@flows`: it reads the frame's
+     ;; CURRENTLY-COMMITTED flow-map, runs topo-sort on the prospective map,
+     ;; and — only if that passes — returns the map with the new flow assoc'd
+     ;; in. `swap!` re-invokes the update fn (re-reading committed state,
+     ;; re-running the cycle check) whenever a concurrent writer wins the
+     ;; compare-and-set, so a cycle can NEVER be admitted by interleaving:
+     ;; two threads reg-flow'ing on the same frame two flows that together
+     ;; form a cycle (T1: A reads B's path; T2: B reads A's path) cannot each
+     ;; pass against the OTHER's not-yet-committed flow and then both commit.
+     ;; The validation lives inside the update fn, so it re-runs against the
+     ;; winning CAS's view.
      ;;
-     ;; Pre-fix (rf2-7csri-era) this was check-THEN-act: it read
-     ;; `@flows` once, built a prospective map, ran topo-sort, then
-     ;; committed in a SEPARATE `swap!`. Two threads reg-flow'ing on the
-     ;; same frame two flows that together form a cycle (T1: A reads B's
-     ;; path; T2: B reads A's path) could each pass the check against the
-     ;; OTHER's not-yet-committed flow (neither sees it), then both
-     ;; commit — leaving a cyclic registry that throws on every drain.
-     ;; Folding the validation into the update fn closes that TOCTOU.
+     ;; The single-threaded path runs exactly one topo-sort: `swap!` invokes
+     ;; the update fn once with no contention. Only contended same-frame
+     ;; registration pays the retry (re-running the cheap Kahn sort over a
+     ;; handful of nodes), and only then to preserve correctness.
      ;;
-     ;; Single-threaded path is unchanged in cost: `swap!` invokes the
-     ;; update fn exactly once with no contention, so this runs the same
-     ;; single topo-sort the prior code did. Only contended same-frame
-     ;; registration pays the retry (re-running the cheap Kahn sort over
-     ;; a handful of nodes), and only then to preserve correctness.
-     ;;
-     ;; The cycle-check throw propagates OUT of `swap!`, so on rejection
-     ;; the atom is left untouched and the prior registration survives —
-     ;; preserving the rf2-7csri "a rejected REPLACEMENT does not vacate
-     ;; the slot the prior entry shares" guarantee, now atomically.
+     ;; The cycle-check throw propagates OUT of `swap!`, so on rejection the
+     ;; atom is left untouched and the prior registration survives — a
+     ;; rejected REPLACEMENT does not vacate the slot the prior entry shares.
      ;;
      ;; `prior-on-frame` captures THIS frame's currently-committed flow
      ;; entry for `flow-id`, recorded from inside the update fn so it
      ;; reflects the state the WINNING CAS observed (a contended retry
      ;; re-records against the re-read map; the last invocation — the one
      ;; whose return value commits — leaves the authoritative value). It
-     ;; drives two decisions below: (rf2-mb9vq) per-frame first-vs-
-     ;; replacement for the `:rf.flow/registered` trace, and (rf2-73pi1)
-     ;; the same-frame `:output-path`-change vacate. `nil` ⇒ first-time
-     ;; registration of `flow-id` on THIS frame (even if a SIBLING frame
-     ;; already holds the global registrar slot).
+     ;; drives two decisions below: per-frame first-vs-replacement for the
+     ;; `:rf.flow/registered` trace, and the same-frame `:output-path`-change
+     ;; vacate. `nil` ⇒ first-time registration of `flow-id` on THIS frame
+     ;; (even if a SIBLING frame already holds the global registrar slot).
      (let [prior-on-frame (volatile! nil)]
-       ;; rf2-2woz9 finding 2: a same-frame `reg-flow` REPLACEMENT publishes
-       ;; the new flow into `flows` (visible to a drain) in the `swap!`
-       ;; below, but the stale-`last-inputs` invalidation only fires later
-       ;; via `registrar/register!` → `invalidate-flow-on-replace!`. Pre-fix,
-       ;; a drain that started in that window saw the NEW flow with the OLD
-       ;; input cache and skipped recompute on `=`-equal inputs, so the first
-       ;; post-replacement drain kept stale output (violating Spec 013's
-       ;; re-registration contract that the new flow re-evaluates on the next
-       ;; event regardless of input equality). Serializing publish →
-       ;; path-vacate → invalidation against the frame drain (`:drain-lock`)
-       ;; makes them one indivisible step: no drain can observe the new flow
-       ;; before its stale dirty-check row is dropped. The atomic check-and-
-       ;; insert `swap!` (rf2-qxwib) is preserved verbatim INSIDE the
-       ;; serialized region — its TOCTOU cycle guarantee is unchanged; we
-       ;; only add the outer drain-exclusion. Reentrant: a mid-drain
-       ;; `:rf.fx/reg-flow` runs directly inside the single-drainer window
-       ;; (see `frame/call-serialized-with-drain!`).
+       ;; A same-frame `reg-flow` REPLACEMENT publishes the new flow into
+       ;; `flows` (visible to a drain) in the `swap!` below, while the
+       ;; stale-`last-inputs` invalidation fires via `registrar/register!` →
+       ;; `invalidate-flow-on-replace!`. Serializing publish → path-vacate →
+       ;; invalidation against the frame drain (`:drain-lock`) makes them one
+       ;; indivisible step: no drain can observe the new flow before its stale
+       ;; dirty-check row is dropped, so the new flow re-evaluates on the next
+       ;; event regardless of input equality (Spec 013's re-registration
+       ;; contract). The atomic check-and-insert `swap!` runs INSIDE the
+       ;; serialized region — its TOCTOU cycle guarantee composes with the
+       ;; outer drain-exclusion. Reentrant: a mid-drain `:rf.fx/reg-flow` runs
+       ;; directly inside the single-drainer window (see
+       ;; `frame/call-serialized-with-drain!`).
        (frame/call-serialized-with-drain!
          frame-id
          (fn []
@@ -1128,11 +1117,11 @@
                       (let [prospective (assoc prior-frame flow-id flow)]
                         ;; Two registration-time rejections, both run on the
                         ;; PROSPECTIVE map inside this update fn so they share
-                        ;; the cycle check's atomicity (rf2-qxwib): a throw
-                        ;; propagates out of `swap!`, the CAS never fires, and
-                        ;; the prior registration survives untouched.
+                        ;; the cycle check's atomicity: a throw propagates out
+                        ;; of `swap!`, the CAS never fires, and the prior
+                        ;; registration survives untouched.
                         ;;
-                        ;; 1. Throws :rf.error/flow-path-overlap (rf2-um6d9) if
+                        ;; 1. Throws :rf.error/flow-path-overlap if
                         ;;    the new flow's output :path overlaps an already-
                         ;;    registered sibling's :path (one a prefix of the
                         ;;    other). The topo dependency rule compares :path vs
@@ -1149,17 +1138,17 @@
                         (topo/detect-output-path-overlap! prospective)
                         (topo/topo-sort prospective)
                         (assoc m frame-id prospective)))))
-           ;; rf2-73pi1 finding 2: a same-frame re-registration that MOVES the
-           ;; output to a new `:output-path` must vacate the OLD path from this
-           ;; frame's app-db — otherwise the previous definition's last write
-           ;; lingers and downstream reads see stale derived state at the
-           ;; abandoned slot. Only fires on a real same-frame replacement
-           ;; (`prior-on-frame` non-nil) whose `:output-path` actually changed; the
-           ;; commit above already installed the new definition, so the new
-           ;; path recomputes on the next drain. First-time registration and
-           ;; same-path hot-reload leave app-db untouched.
+           ;; A same-frame re-registration that MOVES the output to a new
+           ;; `:output-path` must vacate the OLD path from this frame's app-db —
+           ;; otherwise the previous definition's last write lingers and
+           ;; downstream reads see stale derived state at the abandoned slot.
+           ;; Only fires on a real same-frame replacement (`prior-on-frame`
+           ;; non-nil) whose `:output-path` actually changed; the commit above
+           ;; already installed the new definition, so the new path recomputes
+           ;; on the next drain. First-time registration and same-path
+           ;; hot-reload leave app-db untouched.
            ;;
-           ;; rf2-z980k8: the vacate is routed by call shape.
+           ;; The vacate is routed by call shape:
            ;;  - OUT of a drain (a top-level / `:rf.fx`-post-commit lifecycle
            ;;    call): write app-db DIRECTLY — there is no pending commit to
            ;;    clobber it and the change is durable immediately.
@@ -1180,15 +1169,15 @@
                  (if (frame/in-drain? frame-id)
                    (record-abandoned-output-path! frame-id old-path)
                    (vacate-output-path! frame-id old-path)))))
-           ;; Spec 015 §7 / rf2-ouemt + rf2-ihfz9o: install this flow's output
-           ;; data-classification marks (EXPLICIT ∪ PROPAGATED-from-inputs)
-           ;; into the frame's app-db elision registry, rooted at `(:path
-           ;; flow)`. `write-flow-output-marks!` drops THIS flow's prior
+           ;; Spec 015 §7: install this flow's output data-classification marks
+           ;; (EXPLICIT ∪ PROPAGATED-from-inputs) into the frame's app-db
+           ;; elision registry, rooted at `(:path flow)`.
+           ;; `write-flow-output-marks!` drops THIS flow's prior
            ;; `:source :flow` entries first, so a re-registration that changed
-           ;; `:output-path` or the mark set replaces cleanly (covering the old-path
-           ;; declarations the value-vacate above does not touch). Inside the
-           ;; serialized region so a concurrent drain's `elide-wire-value` read
-           ;; cannot observe a half-updated registry.
+           ;; `:output-path` or the mark set replaces cleanly (covering the
+           ;; old-path declarations the value-vacate above does not touch).
+           ;; Inside the serialized region so a concurrent drain's
+           ;; `elide-wire-value` read cannot observe a half-updated registry.
            ;;
            ;; Gate: skip the registry write only for a FIRST registration that
            ;; (a) declares no classification key AND (b) inherits nothing —
@@ -1201,7 +1190,7 @@
            ;; add-marks-THEN-reg-flow ordering) writes its propagated mark
            ;; eagerly so an observer reading the registry right after reg-flow
            ;; sees it (the drain refresh would otherwise install it only on the
-           ;; first event). rf2-ihfz9o.
+           ;; first event).
            (when (or (flow-declares-marks? flow)
                      (some? @prior-on-frame)
                      (input-overlaps-declaration?
@@ -1209,55 +1198,47 @@
              (write-flow-output-marks! frame-id flow))
            ;; Cycle check + commit done atomically above. The :flow registrar
            ;; slot keys on flow-id only; stamp :frame into the metadata so
-           ;; introspection
-           ;; / hot-reload hooks can read the owning frame. `register!`
-           ;; returns `{:was previous :now metadata}` — `:was` is nil on
-           ;; first-time registration, non-nil on hot-reload re-registration.
-           ;; Per rf2-v5ttb: stamp `:handler-fn` so the registrar's
+           ;; introspection / hot-reload hooks can read the owning frame.
+           ;; `register!` returns `{:was previous :now metadata}` — `:was` is
+           ;; nil on first-time registration, non-nil on hot-reload
+           ;; re-registration.
+           ;;
+           ;; Stamp `:handler-fn` (= `:derive`) so the registrar's
            ;; `:different-fn?` calculation (registrar.cljc) can tell a real
            ;; body change from an idempotent reload. The registrar reads
-           ;; `:handler-fn` uniformly across kinds; events / subs / fx all
-           ;; populate it at their registration sites, but flows historically
-           ;; stored the body under `:derive` only — so `(not= nil nil)` was
-           ;; the answer for every flow re-registration and `:different-fn?`
-           ;; was always `false` (re-frame-10x's flow panel / Xray / re-frame2-pair
-           ;; missed every real body swap). The `:derive` slot is preserved
-           ;; for the flow-eval site that reads it; the additional
-           ;; `:handler-fn` stamp aligns the cross-kind hot-reload trace
-           ;; surface Spec 001 standardises.
+           ;; `:handler-fn` uniformly across kinds (events / subs / fx all
+           ;; populate it at their registration sites); flows carry the body
+           ;; under both `:derive` (read by the flow-eval site) and
+           ;; `:handler-fn` (the cross-kind hot-reload trace surface Spec 001
+           ;; standardises), so a tool reading `op-type :flow` sees a real body
+           ;; swap.
            ;;
-           ;; This `register!` is what fires the `invalidate-flow-on-replace!`
-           ;; replacement hook (:759) that drops the stale `last-inputs` row —
-           ;; keeping it INSIDE the serialized region is the fix for finding
-           ;; 2 (the publish above and this invalidation are now indivisible
-           ;; to a concurrent drain).
+           ;; This `register!` fires the `invalidate-flow-on-replace!`
+           ;; replacement hook that drops the stale `last-inputs` row — keeping
+           ;; it INSIDE the serialized region makes the publish above and this
+           ;; invalidation indivisible to a concurrent drain.
            (registrar/register!
              :flow flow-id
              (source-coords/merge-coords
                (assoc flow
                       :frame      frame-id
                       :handler-fn (:derive flow))))))
-       ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires
-       ;; on FIRST-TIME registration AGAINST THIS FRAME. Pre-rf2-mb9vq
-       ;; this gated on the GLOBAL registrar `:was` (flow-id-scoped, not
-       ;; frame-scoped), so registering the same flow-id against a SECOND
-       ;; frame — an INDEPENDENT first-time registration per Spec 013
-       ;; §Frame-scoping line 102 — was misclassified as a replacement and
-       ;; the trace was suppressed: a per-frame flow inventory built from
-       ;; `op-type :flow` missed the second frame's flow even though
-       ;; `flows-snapshot` showed it. Gate on the PER-FRAME prior slot
-       ;; (`prior-on-frame`) instead: a genuine same-frame re-registration
-       ;; (`prior-on-frame` non-nil) still suppresses — its hot-reload
-       ;; signal rides `:rf.registry/handler-replaced` (emitted by
-       ;; `registrar/register!` per Spec 001 §Hot-reload trace surface) —
-       ;; while a same-id/different-frame FIRST registration emits
-       ;; `:rf.flow/registered` with the correct `:frame` tag.
+       ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires on
+       ;; FIRST-TIME registration AGAINST THIS FRAME. The gate keys on the
+       ;; PER-FRAME prior slot (`prior-on-frame`), so registering the same
+       ;; flow-id against a SECOND frame — an INDEPENDENT first-time
+       ;; registration per Spec 013 §Frame-scoping line 102 — emits
+       ;; `:rf.flow/registered` with the correct `:frame` tag. A genuine
+       ;; same-frame re-registration (`prior-on-frame` non-nil) suppresses the
+       ;; `:rf.flow/registered` emit — its hot-reload signal rides
+       ;; `:rf.registry/handler-replaced` (emitted by `registrar/register!`
+       ;; per Spec 001 §Hot-reload trace surface) instead.
        ;;
        ;; The outer `debug-enabled?` gate matches the hot-path emits in
        ;; flows.cljc (per Spec 009 §Production builds, "keep the gate
        ;; OUTERMOST"); reg-flow is a cold path so the cost is negligible,
        ;; but the gate keeps the tag-map literal out of CLJS prod and the
-       ;; convention uniform across every flow emit site (rf2-ee38b.9).
+       ;; convention uniform across every flow emit site.
        (when (and interop/debug-enabled? (nil? @prior-on-frame))
          (trace/emit! :flow :rf.flow/registered
                       {:flow-id flow-id
@@ -1266,9 +1247,9 @@
                        :frame   frame-id})))
      ;; Spec 015 §7. Flows — the output data-classification marks are
      ;; installed FRAME-AWARE into the app-db elision registry via
-     ;; `write-flow-output-marks!` inside the serialized region above
-     ;; (rf2-ouemt). We deliberately do NOT also stash them in the global
-     ;; `re-frame.marks` per-(kind, id) table: that table is keyed by
+     ;; `write-flow-output-marks!` inside the serialized region above. They
+     ;; are deliberately NOT also stashed in the global `re-frame.marks`
+     ;; per-(kind, id) table: that table is keyed by
      ;; flow-id ALONE, but Spec 013 lets the SAME flow-id carry DIFFERENT
      ;; definitions (hence different marks) per frame, so a frame-blind
      ;; `{flow-id marks}` entry is the wrong shape for flows. The
@@ -1279,7 +1260,7 @@
 
 (defn- dissoc-in-safe
   "Like `dissoc-in` over `(butlast path) → (last path)` but robust against
-  the two unmaterialised-output failure modes flagged by audit rf2-q25os:
+  the two unmaterialised-output failure modes:
 
   - **Unmaterialised parent.** When a flow with `:path [:step-2 :result]`
     is cleared BEFORE its first drain, the parent slot `:step-2` may not
@@ -1299,15 +1280,14 @@
         leaf        (last path)
         parent      (get-in db parent-path ::missing)]
     (cond
-      ;; Parent was never materialised — leave db as-is. Per audit
-      ;; rf2-q25os Repro 1: registering a nested-path flow then clearing
-      ;; before any drain would write `{<parent> nil}` otherwise.
+      ;; Parent was never materialised — leave db as-is. Registering a
+      ;; nested-path flow then clearing before any drain would write
+      ;; `{<parent> nil}` otherwise.
       (or (= ::missing parent) (nil? parent)) db
       ;; Parent is non-map (scalar / vector / set) — there's no
-      ;; meaningful "dissoc this leaf" on a non-map intermediate. Per
-      ;; audit rf2-q25os Repro 2: throwing ClassCastException for a
-      ;; cleanup operation is poor manners; leave the value untouched
-      ;; (it's not OUR flow's output anyway).
+      ;; meaningful "dissoc this leaf" on a non-map intermediate. Throwing
+      ;; ClassCastException for a cleanup operation is poor manners; leave
+      ;; the value untouched (it's not OUR flow's output anyway).
       (not (map? parent)) db
       :else (update-in db parent-path dissoc leaf))))
 
@@ -1315,17 +1295,16 @@
   "Pure `db → db` removal of a flow output `:output-path`'s LEAF — the value
   transform shared by `vacate-output-path!` (which writes the result to the
   live app-db) and `run-flows-on-db`'s in-drain pending-`:db` vacate
-  (rf2-z980k8, which dissocs abandoned paths from the PENDING value the
-  deferred commit publishes). Returns `db` unchanged (often `identical?`)
-  when the dissoc is a no-op (missing key, unmaterialised parent, non-map
-  intermediate).
+  (which dissocs abandoned paths from the PENDING value the deferred commit
+  publishes). Returns `db` unchanged (often `identical?`) when the dissoc is a
+  no-op (missing key, unmaterialised parent, non-map intermediate).
 
-  `validate-flow` guarantees `:output-path` is a non-empty vector at registration,
-  so a `:output-path` read back out of the registry always carries one. rf2-aqt7:
-  a single-element vector `[:k]` is dissoc'd directly (`(update-in db []
-  dissoc :k)` would write `{... nil nil}`); a `(>= 2)` path routes through
-  `dissoc-in-safe` (unmaterialised-parent / non-map-intermediate safe, per
-  audit rf2-q25os)."
+  `validate-flow` guarantees `:output-path` is a non-empty vector at
+  registration, so a `:output-path` read back out of the registry always
+  carries one. A single-element vector `[:k]` is dissoc'd directly
+  (`(update-in db [] dissoc :k)` would write `{... nil nil}`); a `(>= 2)` path
+  routes through `dissoc-in-safe` (unmaterialised-parent / non-map-intermediate
+  safe)."
   [db path]
   (if (= 1 (count path))
     (dissoc db (first path))
@@ -1333,59 +1312,58 @@
 
 (defn- vacate-output-path!
   "Dissoc a flow's output `:output-path` from `frame-id`'s app-db (only that
-  frame's container). Shared by `clear-flow` (full deregistration) and
-  the same-frame `:output-path`-change branch of `reg-flow` (rf2-73pi1 finding
-  2 — moving a flow's output to a new path must vacate the OLD path so
-  downstream reads don't see stale derived state at the abandoned slot).
+  frame's container). Shared by `clear-flow` (full deregistration) and the
+  same-frame `:output-path`-change branch of `reg-flow` (moving a flow's
+  output to a new path must vacate the OLD path so downstream reads don't see
+  stale derived state at the abandoned slot).
 
   `validate-flow` guarantees `:output-path` is a non-empty vector at
   registration (rejects non-vector and empty via :rf.error/flow-bad-path),
   so a `:output-path` read back out of the registry always carries one — no
   non-vector / empty-path arms are reachable here.
 
-  rf2-aqt7: when :path is a single-element vector [:k], (butlast [:k])
-  is () and (update-in db [] dissoc :k) does NOT dissoc — Clojure's
-  update-in on the empty path falls into (assoc {} nil (apply f val
-  args)), producing {... nil nil}. Special-case length 1 so the leaf
-  is dissoc'd directly. The (>= 2) branch routes through
-  `dissoc-in-safe` which handles the unmaterialised-parent / non-map-
-  intermediate cases without writing nil parents or throwing (per audit
-  rf2-q25os).
+  When :path is a single-element vector [:k], (butlast [:k]) is () and
+  (update-in db [] dissoc :k) does NOT dissoc — Clojure's update-in on the
+  empty path falls into (assoc {} nil (apply f val args)), producing
+  {... nil nil}. So length 1 is special-cased to dissoc the leaf directly. The
+  (>= 2) branch routes through `dissoc-in-safe`, which handles the
+  unmaterialised-parent / non-map-intermediate cases without writing nil
+  parents or throwing.
 
-  Per rf2-2vpac: skips the write when the dissoc branch was a no-op
-  (missing key, or `dissoc-in-safe` returning `db` literally on
-  unmaterialised-parent / non-map-intermediate). Otherwise we trigger
-  reactive sub-cache invalidation for a no-op write — cheap-but-needless
-  walk of the sub graph (`identical?` is O(1)). No-op when the frame has
-  no app-db container.
+  Skips the write when the dissoc branch was a no-op (missing key, or
+  `dissoc-in-safe` returning `db` literally on unmaterialised-parent /
+  non-map-intermediate) — otherwise a no-op write triggers reactive sub-cache
+  invalidation, a cheap-but-needless walk of the sub graph (`identical?` is
+  O(1)). No-op when the frame has no app-db container.
 
-  EP-0001 (rf2-adwcv6): writes the app-db PARTITION of the one physical
-  frame-state container via `frame/swap-frame-db!` — `app-db-container` is
-  now a READ-ONLY projection. Flow OUTPUTS are app-db values (Mike ruling
-  #12), so vacating one is an app-db write. The `identical?` no-op skip is
-  preserved by computing `new-db` first and only swapping when it changed."
+  Writes the app-db PARTITION of the one physical frame-state container via
+  `frame/swap-frame-db!` (`app-db-container` is a READ-ONLY projection). Flow
+  OUTPUTS are app-db values, so vacating one is an app-db write. The
+  `identical?` no-op skip is preserved by computing `new-db` first and only
+  swapping when it changed."
   [frame-id path]
   (when-let [db (frame/frame-app-db-value frame-id)]
     (let [new-db (vacate-path-in-db db path)]
       (when-not (identical? new-db db)
         (frame/swap-frame-db! frame-id (constantly new-db))))))
 
-;; ---- registrar-slot owner maintenance (rf2-73pi1) ------------------------
+;; ---- registrar-slot owner maintenance ------------------------------------
 ;;
 ;; The `:flow` registrar slot is keyed by flow-id alone and carries the
 ;; MOST-RECENTLY-REGISTERED frame's flow-map with `:frame` stamped in
 ;; (Spec 013 §Frame-scoping line 105). On clear / destroy of the frame
-;; whose metadata currently occupies the slot, that metadata becomes
-;; STALE: it points at a frame that no longer owns the id. Runtime
-;; evaluation is unaffected (the per-frame `flows` registry is the source
-;; of truth), but registrar-backed tooling / hot-reload goes stale — the
-;; next surviving-frame re-registration computes `:different-fn?` against
-;; the dead frame's `:handler-fn`, and a Xray flow panel reading the slot
-;; attributes the flow to a destroyed frame.
+;; whose metadata currently occupies the slot, that metadata would become
+;; STALE: it would point at a frame that no longer owns the id. Runtime
+;; evaluation is unaffected either way (the per-frame `flows` registry is the
+;; source of truth), but registrar-backed tooling / hot-reload reads the slot —
+;; the next surviving-frame re-registration computes `:different-fn?` against
+;; the slot's `:handler-fn`, and a Xray flow panel reading the slot attributes
+;; the flow to its `:frame`. So the slot is realigned to a live owner whenever
+;; its current writer is cleared / destroyed.
 
 (defn- realign-registrar-owner!
   "After `flow-id` was removed from `cleared-frame-id`, keep the shared
-  `:flow` registrar slot pointing at an actually-live owner (rf2-73pi1).
+  `:flow` registrar slot pointing at an actually-live owner.
 
   - When NO surviving frame in `flows-map` holds `flow-id`, unregister
     the slot (the cleared/destroyed frame was the last owner).
@@ -1427,13 +1405,13 @@
   raises `:rf.error/no-frame-context` rather than clearing against
   `:rf/default`.
 
-  Per audit rf2-q25os: the nested-path dissoc is robust against the
-  output path never having been materialised (no spurious nil parent
-  created) and against a non-map intermediate (no ClassCastException
-  thrown) — see `dissoc-in-safe` / `vacate-output-path!` above.
+  The nested-path dissoc is robust against the output path never having
+  been materialised (no spurious nil parent created) and against a non-map
+  intermediate (no ClassCastException thrown) — see `dissoc-in-safe` /
+  `vacate-output-path!` above.
 
-  Vacation contract (rf2-ee38b.9): clearing a flow with `:path
-  [:wizard :result]` removes the LEAF (`:result`) only. If `:result`
+  Vacation contract: clearing a flow with `:path [:wizard :result]` removes
+  the LEAF (`:result`) only. If `:result`
   was the sole key under `:wizard`, an empty parent map `{:wizard {}}`
   remains — this is deliberate, not a leak. The flow's *value* is
   fully gone (the spec's \"vacate the slot\" requirement); pruning empty
@@ -1452,28 +1430,23 @@
                         :clear-flow
                         {:where    'rf/clear-flow
                          :event-id id}))
-         ;; rf2-4wqu6 finding 2: the flow lookup + `:output-path` capture MUST
-         ;; happen INSIDE the drain-lock, not before it. Pre-fix this
-         ;; read the flow and captured `path` ahead of
-         ;; `call-serialized-with-drain!`; on the JVM a competing same-frame
-         ;; same-id `reg-flow` replacement could win the lock after that
-         ;; stale read, install a NEW `:output-path`, a drain could materialise the
-         ;; replacement's new output, and this clear-flow would then run
-         ;; under the lock using the OLD path — vacating a now-empty old
-         ;; path (a no-op) while removing the live registry row and leaving
-         ;; the replacement's new output stale in app-db (violating Spec
-         ;; 013's clear-flow cleanup contract). It would also emit a
-         ;; misleading `:rf.flow/cleared` for the old path.
+         ;; The flow lookup + `:output-path` capture happen INSIDE the
+         ;; drain-lock, not before it. On the JVM a competing same-frame
+         ;; same-id `reg-flow` replacement could otherwise win the lock after
+         ;; a stale read, install a NEW `:output-path`, a drain could
+         ;; materialise the replacement's new output, and this clear-flow
+         ;; would run under the lock using the OLD path — vacating a now-empty
+         ;; old path (a no-op) while removing the live registry row and
+         ;; leaving the replacement's new output stale in app-db (violating
+         ;; Spec 013's clear-flow cleanup contract), and emitting a misleading
+         ;; `:rf.flow/cleared` for the old path.
          ;;
-         ;; The fix folds the lookup, path capture, app-db vacate, registry
-         ;; removal, dirty-row drop, and registrar realignment into ONE
-         ;; serialized operation over the SAME live flow definition. The
-         ;; thunk returns the path it actually cleared (or nil when no flow
-         ;; was registered under the lock) so the `:rf.flow/cleared` emit
-         ;; below fires only on a real clear, with the path captured under
-         ;; the lock. (rf2-2woz9 finding 1: serializing the mutation against
-         ;; the drain already made the vacate→deregister sequence atomic;
-         ;; this extends that atomicity to the lookup the sequence reads.)
+         ;; So the lookup, path capture, app-db vacate, registry removal,
+         ;; dirty-row drop, and registrar realignment fold into ONE serialized
+         ;; operation over the SAME live flow definition. The thunk returns the
+         ;; path it actually cleared (or nil when no flow was registered under
+         ;; the lock) so the `:rf.flow/cleared` emit below fires only on a real
+         ;; clear, with the path captured under the lock.
          ;; Reentrant: a mid-drain `:rf.fx/clear-flow` runs directly inside
          ;; the single-drainer window (see `frame/call-serialized-with-drain!`).
          cleared-path
@@ -1483,17 +1456,15 @@
              (when-let [flow (get-in @flows [frame-id id])]
                (let [path (:output-path flow)]
                  (vacate-output-path! frame-id path)
-                 ;; Spec 015 §7 / rf2-ouemt: drop this flow's output data-
-                 ;; classification declarations from the frame's app-db elision
-                 ;; registry so a deregistered flow leaves no orphaned redaction
-                 ;; behind. Schema- / add-marks-sourced entries survive.
+                 ;; Spec 015 §7: drop this flow's output data-classification
+                 ;; declarations from the frame's app-db elision registry so a
+                 ;; deregistered flow leaves no orphaned redaction behind.
+                 ;; Schema- / add-marks-sourced entries survive.
                  (clear-flow-output-marks! frame-id id)
                  ;; Drop the flow from `frame-id`'s per-frame slot; when that was
                  ;; the LAST flow on the frame, prune the now-empty `frame-id` key
-                 ;; entirely rather than leave a `{frame-id {}}` husk (rf2-4bbaw).
-                 ;; The husk was harmless (bounded by frame count, tolerated by the
-                 ;; concurrency-stress invariant) but a naive `flows-snapshot`
-                 ;; consumer would iterate the empty entry; pruning keeps the
+                 ;; entirely rather than leave a `{frame-id {}}` husk a naive
+                 ;; `flows-snapshot` consumer would iterate. Pruning keeps the
                  ;; registry exactly symmetric with `teardown-on-frame-destroy!`'s
                  ;; `(swap! flows dissoc frame-id)`.
                  (swap! flows (fn [m]
@@ -1501,30 +1472,27 @@
                                   (cond-> m'
                                     (empty? (get m' frame-id)) (dissoc frame-id)))))
                  ;; Drop the cleared flow's dirty-check row from THIS frame's own
-                 ;; `last-inputs` container (rf2-94ol5). Frame-local — a sibling
-                 ;; frame registering the same id keeps its own row untouched.
+                 ;; `last-inputs` container. Frame-local — a sibling frame
+                 ;; registering the same id keeps its own row untouched.
                  (drop-frame-flow-row! frame-id id)
                  ;; Keep the shared `:flow` registrar slot aligned with a live
-                 ;; owner (rf2-73pi1): unregister when this was the LAST frame
-                 ;; holding the id, or re-point the slot to a surviving owner
-                 ;; when the cleared frame was the slot's current (now-stale)
-                 ;; metadata writer. Pre-fix this only unregistered on
-                 ;; last-owner-release, leaving the slot pointing at the cleared
-                 ;; frame whenever a sibling still held the id.
+                 ;; owner: unregister when this was the LAST frame holding the
+                 ;; id, or re-point the slot to a surviving owner when the
+                 ;; cleared frame was the slot's current (now-stale) metadata
+                 ;; writer.
                  (realign-registrar-owner! @flows id frame-id)
                  path))))]
      ;; Per Spec 009 §:op-type vocabulary: :rf.flow/cleared fires after
      ;; clear-flow has removed the flow from the per-frame registry
      ;; and dissoc-in'd its output path. Tools observe this to drop
      ;; their per-flow display state. Only emit when a flow was ACTUALLY
-     ;; cleared (rf2-4wqu6 finding 2 — a no-op clear-flow for an unregistered
-     ;; id, or one that lost the race to a competing lifecycle op, emits
-     ;; nothing), carrying the path captured under the lock. The outer
-     ;; `debug-enabled?` gate matches the hot-path emits in flows.cljc (per
-     ;; Spec 009 §Production builds, "keep the gate OUTERMOST"); clear-flow is
-     ;; a cold path so the cost is negligible, but the gate keeps the
-     ;; tag-map literal out of CLJS prod and the convention uniform
-     ;; across every flow emit site (rf2-ee38b.9).
+     ;; cleared (a no-op clear-flow for an unregistered id, or one that lost
+     ;; the race to a competing lifecycle op, emits nothing), carrying the
+     ;; path captured under the lock. The outer `debug-enabled?` gate matches
+     ;; the hot-path emits in flows.cljc (per Spec 009 §Production builds,
+     ;; "keep the gate OUTERMOST"); clear-flow is a cold path so the cost is
+     ;; negligible, but the gate keeps the tag-map literal out of CLJS prod and
+     ;; the convention uniform across every flow emit site.
      (when (and cleared-path interop/debug-enabled?)
        (trace/emit! :flow :rf.flow/cleared
                     {:flow-id id
@@ -1534,14 +1502,12 @@
 
 ;; ---- frame-destroy teardown ---------------------------------------------
 ;;
-;; Per rf2-wbtjn — symmetric with the machines `:teardown-on-frame-destroy!`
-;; hook (rf2-vsigt). On `destroy-frame!`, the flows registered against the
-;; destroyed frame, the per-frame `last-inputs` rows, AND any `:flow`
-;; registrar entries whose last owning frame was the destroyed one MUST
-;; clear — otherwise SSR-style per-request frame churn / pair-tool
-;; time-travel / `make-frame` ephemeral usage leak flow definitions and
-;; cached input vectors indefinitely (audit
-;; `ai/findings/flows-security-audit-2026-05-15.md` F1).
+;; Symmetric with the machines `:teardown-on-frame-destroy!` hook. On
+;; `destroy-frame!`, the flows registered against the destroyed frame, the
+;; per-frame `last-inputs` rows, AND any `:flow` registrar entries whose last
+;; owning frame was the destroyed one MUST clear — otherwise SSR-style
+;; per-request frame churn / pair-tool time-travel / `make-frame` ephemeral
+;; usage would leak flow definitions and cached input vectors indefinitely.
 
 (defn teardown-on-frame-destroy!
   "Drop every per-frame entry the flows artefact holds against `frame-id`:
@@ -1550,35 +1516,34 @@
       registrar prune in step 4).
    2. Dissoc `frame-id` from the per-frame flow registry.
    3. Dissoc the destroyed frame's `last-inputs` container from the
-      per-frame `frame-last-inputs` registry — one step (rf2-94ol5),
-      since per-frame storage holds the destroyed frame's rows in its
-      own inner atom and removing the frame-keyed slot drops them all.
+      per-frame `frame-last-inputs` registry — one step, since per-frame
+      storage holds the destroyed frame's rows in its own inner atom and
+      removing the frame-keyed slot drops them all.
    4. For each flow-id the destroyed frame owned, keep the `:flow`
-      registrar slot aligned with a live owner (rf2-73pi1): unregister
-      the slot when no surviving frame still registers the id, or
-      re-point it to a surviving owner when the destroyed frame was the
-      slot's current (now-stale) metadata writer. The `:frame` stamped
-      onto the registrar entry was the destroyed frame whenever it was
-      the most-recent registrant — leaving that metadata pointing at the
-      dead frame staled registrar-backed tooling / hot-reload.
+      registrar slot aligned with a live owner: unregister the slot when
+      no surviving frame still registers the id, or re-point it to a
+      surviving owner when the destroyed frame was the slot's current
+      (now-stale) metadata writer. The `:frame` stamped onto the registrar
+      entry is the destroyed frame whenever it was the most-recent
+      registrant — leaving that metadata pointing at the dead frame would
+      stale registrar-backed tooling / hot-reload.
 
-   NO explicit flow-output elision-mark scrub (rf2-yt5bbl). Unlike
-   `clear-flow` — which removes ONE flow's `:source :flow` declarations
-   while its frame lives on (hence its `clear-flow-output-marks!` call) —
-   frame-destroy drops the WHOLE frame. The elision registry lives in the
-   frame's runtime-db partition at `[:rf.runtime/elision]`
-   (`re-frame.elision` §registry-of), INSIDE the one physical
-   `:frame-state` container held under the frame record; `destroy-frame!`
-   step 6 (`frame.cljc` §dissoc-frame!) `(swap! frames dissoc id)` drops
-   that whole record — container, runtime-db, and every `:source :flow`
-   declaration — so the marks are gone with the frame and a per-flow scrub
-   here would be redundant work over about-to-be-GC'd state. The
-   teardown hook runs BEFORE step 6 (`frame.cljc:1711` then `:1757`), but
-   that ordering is moot: nothing observes the (still-live) elision slot
-   between the hook and the dissoc, and a reused frame-id gets a FRESH
-   empty container (`frame.cljc` §new-frame-record), so a destroyed/reused
-   frame can never observe a prior incarnation's stale flow-sourced
-   declaration. Pinned by
+   NO explicit flow-output elision-mark scrub. Unlike `clear-flow` — which
+   removes ONE flow's `:source :flow` declarations while its frame lives on
+   (hence its `clear-flow-output-marks!` call) — frame-destroy drops the
+   WHOLE frame. The elision registry lives in the frame's runtime-db
+   partition at `[:rf.runtime/elision]` (`re-frame.elision` §registry-of),
+   INSIDE the one physical `:frame-state` container held under the frame
+   record; `destroy-frame!` step 6 (`frame.cljc` §dissoc-frame!)
+   `(swap! frames dissoc id)` drops that whole record — container,
+   runtime-db, and every `:source :flow` declaration — so the marks are gone
+   with the frame and a per-flow scrub here would be redundant work over
+   about-to-be-GC'd state. The teardown hook runs BEFORE step 6, but that
+   ordering is moot: nothing observes the (still-live) elision slot between
+   the hook and the dissoc, and a reused frame-id gets a FRESH empty
+   container (`frame.cljc` §new-frame-record), so a destroyed/reused frame
+   can never observe a prior incarnation's stale flow-sourced declaration.
+   Pinned by
    `flows_destroy_frame_teardown_test` §destroy-frame-drops-flow-output-marks.
 
    Idempotent against a frame the registry never recorded (a frame
@@ -1591,19 +1556,19 @@
     (let [owned-flow-ids (keys (get @flows frame-id))]
       (swap! flows dissoc frame-id)
       ;; Drop the destroyed frame's entire `last-inputs` container in one
-      ;; step (rf2-94ol5) — per-frame storage means the destroyed frame's
-      ;; rows ARE its inner atom, so removing the frame-keyed slot drops
-      ;; every row at once and cannot touch any sibling frame's container.
+      ;; step — per-frame storage means the destroyed frame's rows ARE its
+      ;; inner atom, so removing the frame-keyed slot drops every row at once
+      ;; and cannot touch any sibling frame's container.
       (swap! frame-last-inputs dissoc frame-id)
-      ;; rf2-z980k8: drop the destroyed frame's pending abandoned-output-paths
-      ;; container too (same per-frame storage idiom). The frame is gone, so
-      ;; any recorded-but-undrained path move is moot.
+      ;; Drop the destroyed frame's pending abandoned-output-paths container
+      ;; too (same per-frame storage idiom). The frame is gone, so any
+      ;; recorded-but-undrained path move is moot.
       (swap! frame-abandoned-output-paths dissoc frame-id)
-      ;; Registrar realignment (rf2-73pi1): for each flow-id the destroyed
-      ;; frame owned, either unregister the `:flow` slot (no surviving
-      ;; owner) or re-point it to a surviving owner when the destroyed
-      ;; frame was the slot's stale metadata writer — the shared
-      ;; `realign-registrar-owner!` helper `clear-flow` also uses.
+      ;; Registrar realignment: for each flow-id the destroyed frame owned,
+      ;; either unregister the `:flow` slot (no surviving owner) or re-point it
+      ;; to a surviving owner when the destroyed frame was the slot's stale
+      ;; metadata writer — the shared `realign-registrar-owner!` helper
+      ;; `clear-flow` also uses.
       (let [remaining @flows]
         (doseq [flow-id owned-flow-ids]
           (realign-registrar-owner! remaining flow-id frame-id)))))
@@ -1620,18 +1585,16 @@
 (defn- invalidate-flow-on-replace!
   [{:keys [kind id now]}]
   (when (= kind :flow)
-    ;; Per rf2-jfpf3: Spec 013 §Re-registration scopes the invalidation
-    ;; to `[frame-id flow-id]`, NOT every frame holding the flow id.
-    ;; Pre-fix, a re-registration on frame `:left` wiped
-    ;; `last-inputs[id]` entirely — `:right`'s row for the same id
-    ;; recomputed unnecessarily on its next drain, weakening frame
-    ;; isolation and wasting work under multi-frame setups (per-tenant
-    ;; SSR, pair-tool replays). The registrar replacement-hook payload
-    ;; carries `:now` (the new metadata) with `:frame` stamped at
-    ;; `reg-flow`-time; read the frame from there and drop only that
-    ;; frame's row from its own `last-inputs` container (rf2-94ol5 —
-    ;; per-frame storage makes the sibling-frame untouched guarantee
-    ;; structural rather than reliant on careful keying).
+    ;; Spec 013 §Re-registration scopes the invalidation to
+    ;; `[frame-id flow-id]`, NOT every frame holding the flow id — a
+    ;; re-registration on frame `:left` must not force `:right`'s row for the
+    ;; same id to recompute on its next drain (which would weaken frame
+    ;; isolation and waste work under multi-frame setups: per-tenant SSR,
+    ;; pair-tool replays). The registrar replacement-hook payload carries
+    ;; `:now` (the new metadata) with `:frame` stamped at `reg-flow`-time;
+    ;; read the frame from there and drop only that frame's row from its own
+    ;; `last-inputs` container — per-frame storage makes the sibling-frame
+    ;; untouched guarantee structural rather than reliant on careful keying.
     (let [frame-id (:frame now)]
       (drop-frame-flow-row! frame-id id))))
 
@@ -1645,38 +1608,34 @@
 
 (defn reset-last-inputs!
   "Test-only: clear ALL per-frame dirty-check `last-inputs` containers
-  (rf2-94ol5 — drops the whole `frame-last-inputs` registry, discarding
-  every frame's inner atom). The flows reset-runtime fixture uses this to
-  drop stale per-flow state between tests so re-registration does not
-  silently no-op when new-inputs =-equal a stale entry from a sibling test.
-  Per rf2-tfw3 (the fourth per-feature split): this is published through
-  the late-bind hook table so `re-frame.test-support`'s reset-runtime
-  fixture can call it without statically requiring `re-frame.flows`."
+  (drops the whole `frame-last-inputs` registry, discarding every frame's
+  inner atom). The flows reset-runtime fixture uses this to drop stale
+  per-flow state between tests so re-registration does not silently no-op
+  when new-inputs =-equal a stale entry from a sibling test. Published
+  through the late-bind hook table so `re-frame.test-support`'s
+  reset-runtime fixture can call it without statically requiring
+  `re-frame.flows`."
   []
   (reset! frame-last-inputs {})
   nil)
 
 (defn reset-flows!
   "Test-only: clear the per-frame flow registry AND the paired
-  dirty-check `last-inputs` map. Per rf2-tfw3 — exposed via the
-  late-bind hook table so `re-frame.test-support` can reset state
-  without a static require on this namespace.
+  dirty-check `last-inputs` map. Exposed via the late-bind hook table so
+  `re-frame.test-support` can reset state without a static require on this
+  namespace.
 
-  Per rf2-mb65w: resets BOTH atoms in lockstep. Pre-fix, the function
-  cleared only `flows` and left `last-inputs` standing. A test fixture
-  / re-frame2-pair / Xray harness calling `reset-flows!` standalone (the
-  function's name suggests \"reset all flow state\") then re-registered
-  the same flow-id would silently no-op the first evaluation when
-  new-inputs `=`-equalled a leftover entry. The two-atom reset is the
-  single sound invariant — anything calling `reset-flows!` wants flow
-  state cleared, and `last-inputs` is downstream cache for the same
-  registry. Per rf2-94ol5 the dirty-check reset now drops every
-  per-frame `last-inputs` container (the `frame-last-inputs` registry).
+  Resets BOTH atoms in lockstep: a test fixture / re-frame2-pair / Xray
+  harness calling `reset-flows!` standalone wants ALL flow state cleared, and
+  `last-inputs` is downstream cache for the same registry — leaving it
+  standing would silently no-op the first evaluation after a re-registration
+  when new-inputs `=`-equal a leftover entry. The dirty-check reset drops
+  every per-frame `last-inputs` container (the `frame-last-inputs` registry).
 
-  rf2-z980k8: ALSO drops every per-frame pending abandoned-output-paths
-  container — a `reset-flows!` caller wants ALL flow-derived per-frame state
-  cleared, and a leftover undrained path move from a sibling test must not
-  leak into the next."
+  ALSO drops every per-frame pending abandoned-output-paths container — a
+  `reset-flows!` caller wants ALL flow-derived per-frame state cleared, and a
+  leftover undrained path move from a sibling test must not leak into the
+  next."
   []
   (reset! flows {})
   (reset! frame-last-inputs {})

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -9,31 +9,24 @@
   undo / time-travel semantics belong to one frame's history. The
   registry shape is `{frame-id {flow-id flow-map}}`.
 
-  Dirty-check storage is PER-FRAME by construction (rf2-94ol5). Each
-  frame owns its own `last-inputs` container (`atom {flow-id inputs}`),
-  held in the `frame-last-inputs` registry keyed by frame-id. A frame's
-  drain reads and writes ONLY its own atom; the failed-flow rollback
-  snapshots and restores ONLY the draining frame's atom. Cross-frame
-  interference during a concurrent drain is therefore impossible by
-  construction — a frame can no more touch a sibling's dirty-check rows
-  than it can touch a sibling's app-db. (The prior single global atom
-  keyed `{flow-id {frame-id inputs}}` made the wholesale-snapshot
-  rollback over-broad: on a throw it reverted EVERY frame's rows, which
-  on the JVM could clobber a concurrently-draining sibling's just-
-  advanced rows. Mike ruled the structural per-frame-atom fix B over the
-  minimal per-frame-slice scoping A — 2026-06-01.)
+  Dirty-check storage is PER-FRAME by construction. Each frame owns its
+  own `last-inputs` container (`atom {flow-id inputs}`), held in the
+  `frame-last-inputs` registry keyed by frame-id. A frame's drain reads
+  and writes ONLY its own atom; the failed-flow rollback snapshots and
+  restores ONLY the draining frame's atom. Cross-frame interference during
+  a concurrent drain is therefore impossible by construction — a frame can
+  no more touch a sibling's dirty-check rows than it can touch a sibling's
+  app-db.
 
-  Per rf2-mnu8z this is the second leg of the flows split. The façade
-  (`re-frame.flows`) re-exports the public surface — `reg-flow`,
-  `clear-flow`, `reset-flows!`, `reset-last-inputs!`, plus the
-  rf2-4gvb4 read accessors `flows-snapshot` / `last-inputs-snapshot`.
-  The underlying atoms themselves are PRIVATE to this artefact: external
-  consumers (production code, the late-bind directory, test fixtures
-  across artefacts) reach the registry state through the accessor seam
-  rather than dereferencing the atom Vars directly. `last-inputs-snapshot`
-  re-aggregates the per-frame atoms back into the canonical
-  `{flow-id {frame-id inputs}}` observation shape so its public contract
-  is unchanged across the storage restructure."
+  The façade (`re-frame.flows`) re-exports the public surface — `reg-flow`,
+  `clear-flow`, `reset-flows!`, `reset-last-inputs!`, plus the read
+  accessors `flows-snapshot` / `last-inputs-snapshot`. The underlying atoms
+  themselves are PRIVATE to this artefact: external consumers (production
+  code, the late-bind directory, test fixtures across artefacts) reach the
+  registry state through the accessor seam rather than dereferencing the
+  atom Vars directly. `last-inputs-snapshot` re-aggregates the per-frame
+  atoms back into the canonical `{flow-id {frame-id inputs}}` observation
+  shape."
   (:require [re-frame.elision :as elision]
             [re-frame.error :as error]
             [re-frame.flows.topo :as topo]
@@ -47,15 +40,14 @@
 
 ;; ---- state ---------------------------------------------------------------
 ;;
-;; Per rf2-4gvb4 — the atoms below are PRIVATE to this artefact. External
-;; consumers reach the registry state through the public read accessors
-;; (`flows-snapshot` / `last-inputs-snapshot`) and the reset fns
-;; (`reset-flows!` / `reset-last-inputs!`) — the facade re-exports them at
-;; `re-frame.flows`. The atoms themselves are NOT a public surface; treating
-;; them as one couples consumers to the internal shape (the per-frame
-;; container restructure below would otherwise force every test fixture to
-;; follow). The accessor seam keeps the flexibility on the framework side
-;; while giving tests the read-and-reset affordances they actually need.
+;; The atoms below are PRIVATE to this artefact. External consumers reach the
+;; registry state through the public read accessors (`flows-snapshot` /
+;; `last-inputs-snapshot`) and the reset fns (`reset-flows!` /
+;; `reset-last-inputs!`) — the facade re-exports them at `re-frame.flows`. The
+;; atoms themselves are NOT a public surface; treating them as one couples
+;; consumers to the internal shape. The accessor seam keeps the flexibility on
+;; the framework side while giving tests the read-and-reset affordances they
+;; actually need.
 
 (defonce
   ^{:doc     "frame-id → flow-id → flow-map. Per-frame so undo / time-travel
@@ -64,24 +56,17 @@
   flows
   (atom {}))
 
-;; Per rf2-94ol5 — PER-FRAME dirty-check storage. `frame-last-inputs` is a
-;; registry mapping `frame-id → (atom {flow-id last-seen-input-vec})`: each
-;; frame owns its OWN inner atom of dirty-check rows, mirroring how every
-;; other per-frame runtime cell (app-db container, router queue, sub-cache,
-;; drain-lock — see `re-frame.frame/new-frame-record`) is held independently
-;; per frame.
+;; PER-FRAME dirty-check storage. `frame-last-inputs` is a registry mapping
+;; `frame-id → (atom {flow-id last-seen-input-vec})`: each frame owns its OWN
+;; inner atom of dirty-check rows, mirroring how every other per-frame runtime
+;; cell (app-db container, router queue, sub-cache, drain-lock — see
+;; `re-frame.frame/new-frame-record`) is held independently per frame.
 ;;
-;; This is the structural fix (Mike ruled B 2026-06-01): a frame's drain
-;; reads / writes ONLY `(get @frame-last-inputs frame-id)`, and the failed-
-;; flow rollback in `re-frame.flows/run-flows-on-db` snapshots / restores
-;; ONLY that one atom. A frame can no more clobber a sibling's dirty-check
-;; rows than it can clobber a sibling's app-db — cross-frame interference is
-;; impossible BY CONSTRUCTION, not merely avoided. The prior single global
-;; atom keyed `{flow-id {frame-id inputs}}` made the wholesale-snapshot
-;; rollback over-broad: on a throw it `reset!`-reverted EVERY frame's rows,
-;; so on the JVM a concurrently-draining sibling's just-advanced rows were
-;; clobbered (spurious recompute + sub-invalidation storm; violated the
-;; documented per-frame-independence invariant).
+;; A frame's drain reads / writes ONLY `(get @frame-last-inputs frame-id)`, and
+;; the failed-flow rollback in `re-frame.flows/run-flows-on-db` snapshots /
+;; restores ONLY that one atom. A frame can no more clobber a sibling's
+;; dirty-check rows than it can clobber a sibling's app-db — cross-frame
+;; interference is impossible BY CONSTRUCTION, not merely avoided.
 ;;
 ;; The outer `frame-last-inputs` atom is mutated only on frame-slot
 ;; lifecycle (first touch creates the inner atom; teardown / reset removes
@@ -90,9 +75,9 @@
 ;; reader / writer never contend on the outer registry.
 (defonce
   ^{:doc     "frame-id → (atom {flow-id last-seen-input-vec}). Per-frame
-              dirty-check containers (rf2-94ol5). Each frame's inner atom is
-              read / written only by that frame's drain; the failed-flow
-              rollback restores only the draining frame's own atom."
+              dirty-check containers. Each frame's inner atom is read /
+              written only by that frame's drain; the failed-flow rollback
+              restores only the draining frame's own atom."
     :private true}
   frame-last-inputs
   (atom {}))
@@ -114,7 +99,7 @@
                       (assoc m frame-id (atom {})))))
            frame-id)))
 
-;; ---- public read accessors (rf2-4gvb4) -----------------------------------
+;; ---- public read accessors -----------------------------------------------
 ;;
 ;; `flows-snapshot` and `last-inputs-snapshot` are the public seam external
 ;; consumers (test fixtures, conformance harnesses, the cross-artefact
@@ -131,14 +116,13 @@
 
 (defn ^:no-doc last-inputs-snapshot
   "Return the dirty-check value re-aggregated to the canonical observation
-  shape `{flow-id {frame-id inputs}}`. Reads every per-frame container
-  (rf2-94ol5 storage) and inverts the `{frame-id {flow-id inputs}}` layout
-  back to `flow-id`-outer so the public contract is unchanged across the
-  per-frame restructure. Empty per-frame containers contribute nothing, so
-  a frame whose dirty-check rows all cleared leaves no key behind.
-  Snapshot — observers MUST NOT mutate (the underlying atoms are private).
+  shape `{flow-id {frame-id inputs}}`. Reads every per-frame container and
+  inverts the `{frame-id {flow-id inputs}}` layout back to `flow-id`-outer.
+  Empty per-frame containers contribute nothing, so a frame whose dirty-check
+  rows all cleared leaves no key behind. Snapshot — observers MUST NOT mutate
+  (the underlying atoms are private).
 
-  RAW — NOT an egress boundary (EP-0015). The cached input vectors are the
+  RAW — NOT an egress boundary (Spec 015). The cached input vectors are the
   OWNER-LOCAL app-db / runtime-db values just read for the dirty check, so
   they can be sensitive or large. This accessor returns them verbatim and is
   for INTERNAL / TEST / ROLLBACK use only (the failed-flow rollback snapshot,
@@ -158,7 +142,7 @@
     {}
     @frame-last-inputs))
 
-;; ---- intra-artefact-only mutation helpers (rf2-4gvb4 / rf2-94ol5) --------
+;; ---- intra-artefact-only mutation helpers --------------------------------
 ;;
 ;; `re-frame.flows` (the facade evaluation path) reads / advances the
 ;; draining frame's `last-inputs` on every successful flow recompute and
@@ -198,11 +182,11 @@
   `re-frame.flows/run-flows-on-db`'s catch arm to roll back the draining
   frame's — and ONLY the draining frame's — dirty-check bookkeeping when a
   flow throws mid-cascade. A concurrently-draining sibling's container is a
-  different atom and is untouched (rf2-94ol5)."
+  different atom and is untouched."
   [frame-id prior]
   (reset! (ensure-frame-last-inputs-atom! frame-id) prior))
 
-;; ---- pending abandoned output paths (rf2-z980k8) -------------------------
+;; ---- pending abandoned output paths --------------------------------------
 ;;
 ;; A same-frame `reg-flow` REPLACEMENT that MOVES the output to a new
 ;; `:output-path` must vacate the OLD path from the frame's app-db (Spec 013
@@ -211,27 +195,26 @@
 ;; (below) does that with a DIRECT app-db write, which is correct for an
 ;; OUT-of-drain call.
 ;;
-;; But when `reg-flow` runs IN-drain — reentrantly from inside an event
-;; handler or a `:rf.fx/reg-flow` effect — the direct write is CLOBBERED. The
-;; drain runs flows over the PENDING `:db` (the handler's returned value,
-;; which still carries the old path) and the router's single deferred commit
-;; PUBLISHES that pending value AFTER the reentrant `reg-flow` returned —
-;; overwriting the direct vacate and RESURRECTING the old output (rf2-z980k8).
-;;
-;; The fix: when in-drain, record the abandoned path here instead of writing
-;; app-db directly. `re-frame.flows/run-flows-on-db` drains this set at the
-;; START of the pending-`:db` transform (before the flow walk) and dissocs
-;; each path from the PENDING db — so the vacate participates in the SAME
-;; value the deferred commit publishes and the handler's returned `:db`
-;; cannot resurrect the old path. Per-frame (rf2-94ol5 idiom): each frame
-;; owns its own inner atom; a sibling frame draining concurrently on another
-;; thread holds a different atom and is structurally untouched.
+;; When `reg-flow` runs IN-drain — reentrantly from inside an event handler or
+;; a `:rf.fx/reg-flow` effect — a direct write would be CLOBBERED: the drain
+;; runs flows over the PENDING `:db` (the handler's returned value, which still
+;; carries the old path) and the router's single deferred commit PUBLISHES that
+;; pending value AFTER the reentrant `reg-flow` returns, overwriting the direct
+;; vacate and RESURRECTING the old output. So in-drain, record the abandoned
+;; path here instead of writing app-db directly.
+;; `re-frame.flows/run-flows-on-db` drains this set at the START of the
+;; pending-`:db` transform (before the flow walk) and dissocs each path from
+;; the PENDING db — so the vacate participates in the SAME value the deferred
+;; commit publishes and the handler's returned `:db` cannot resurrect the old
+;; path. Per-frame: each frame owns its own inner atom; a sibling frame
+;; draining concurrently on another thread holds a different atom and is
+;; structurally untouched.
 
 (defonce
   ^{:doc     "frame-id → (atom #{abandoned-output-path ...}). Per-frame set
               of OLD output paths recorded by an IN-DRAIN same-frame
-              `reg-flow` `:output-path` move, pending vacate by the current drain's
-              `run-flows-on-db` pending-`:db` transform (rf2-z980k8)."
+              `reg-flow` `:output-path` move, pending vacate by the current
+              drain's `run-flows-on-db` pending-`:db` transform."
     :private true}
   frame-abandoned-output-paths
   (atom {}))
@@ -252,9 +235,9 @@
 
 (defn ^:no-doc record-abandoned-output-path!
   "Record `path` as a pending abandoned output path for `frame-id` — to be
-  vacated from the pending `:db` by the current drain's `run-flows-on-db`
-  (rf2-z980k8). Called by `reg-flow`'s in-drain `:output-path`-move branch
-  instead of the direct app-db write the OUT-of-drain branch uses. Frame-local."
+  vacated from the pending `:db` by the current drain's `run-flows-on-db`.
+  Called by `reg-flow`'s in-drain `:output-path`-move branch instead of the
+  direct app-db write the OUT-of-drain branch uses. Frame-local."
   [frame-id path]
   (swap! (ensure-frame-abandoned-paths-atom! frame-id) conj path))
 
@@ -269,8 +252,8 @@
 
 (defn ^:no-doc drain-abandoned-output-paths!
   "Atomically read-and-clear `frame-id`'s pending abandoned output paths,
-  returning the set that was pending (rf2-z980k8). The current drain's
-  `run-flows-on-db` consumes these once — dissocing each from the pending
+  returning the set that was pending. The current drain's `run-flows-on-db`
+  consumes these once — dissocing each from the pending
   `:db` BEFORE the flow walk — and a throw / post-commit rollback re-records
   them via `restore-abandoned-output-paths!` so the move re-attempts cleanly
   next drain. Frame-local: returns an empty set when the frame has no
@@ -287,26 +270,25 @@
   (`run-flows-on-db`'s catch arm) or a POST-commit schema / machine-data
   validation rolls the event back — the pending `:db` (carrying the vacated
   state) was discarded, so the abandoned paths must re-attempt next drain.
-  Frame-local (rf2-94ol5): a concurrently-draining sibling's container is a
+  Frame-local: a concurrently-draining sibling's container is a
   different atom and is untouched."
   [frame-id prior]
   (reset! (ensure-frame-abandoned-paths-atom! frame-id) (set prior)))
 
-;; ---- last-inputs row maintenance (rf2-94ol5) -----------------------------
+;; ---- last-inputs row maintenance -----------------------------------------
 ;;
 ;; With per-frame `last-inputs` containers, dropping one flow's dirty-check
 ;; row for a frame is a plain `dissoc` on that frame's own inner atom — no
 ;; two-level-map walk, and structurally incapable of touching a sibling
 ;; frame's container. The clear-flow / frame-destroy / hot-reload-invalidate
 ;; paths share this one helper so the "drop this flow's row for this frame"
-;; invariant lives in exactly one place. (The prior `prune-frame-row`
-;; maintained the global `{flow-id {frame-id v}}` map's inner-map emptiness;
-;; per-frame storage makes the dissoc unconditional and frame-local.)
+;; invariant lives in exactly one place. Per-frame storage makes the dissoc
+;; unconditional and frame-local.
 
 (defn- drop-frame-flow-row!
   "Drop `flow-id`'s dirty-check row from `frame-id`'s `last-inputs`
   container. No-op when the frame has no container. Frame-local by
-  construction (rf2-94ol5)."
+  construction."
   [frame-id flow-id]
   (when-let [a (get @frame-last-inputs frame-id)]
     (swap! a dissoc flow-id)))
@@ -331,49 +313,49 @@
 ;;
 ;; Per Spec 013 §Flow shape: `:inputs` is a vector of app-db paths,
 ;; `:output-path` is an app-db path. A path is a non-empty vector of scalar
-;; map keys. The prior validator only enforced `vector?` on each, so three
-;; classes of malformed input slipped through (per audit rf2-o3hok findings
-;; Q5 / TE4):
+;; map keys. The validator enforces this fully up front rather than letting a
+;; malformed shape boom later in the topo / evaluator stack. Three
+;; representative malformations it catches:
 ;;
-;;   - `:inputs [:foo :bar]` (vector of bare keywords) — passed; then
-;;     topo's `prefix?` threw on `(count :foo)`.
-;;   - `:inputs [[:foo] :bar]` (mixed) — same path, same delayed boom.
-;;   - `:output-path []` — passed; `(prefix? [] anything)` is true, so the
-;;     empty-path flow silently became a depends-on prerequisite of EVERY
-;;     other flow in the frame (per Spec 013 §Dependency rule).
+;;   - `:inputs [:foo :bar]` (vector of bare keywords) — topo's `prefix?`
+;;     would otherwise throw on `(count :foo)`.
+;;   - `:inputs [[:foo] :bar]` (mixed) — same problem one entry along.
+;;   - `:output-path []` — `(prefix? [] anything)` is true, so an empty-path
+;;     flow would silently become a depends-on prerequisite of EVERY other
+;;     flow in the frame (per Spec 013 §Dependency rule).
 ;;
-;; The tightened validator rejects each malformation up front with a stable
-;; error id and ex-data that names the offending entries / elements so
-;; callers don't have to chase the failure into the topo / evaluator stack.
+;; Each malformation is rejected with a stable error id and ex-data that names
+;; the offending entries / elements so callers don't have to chase the failure
+;; into the topo / evaluator stack.
 ;;
 ;; The OPTIONAL output data-classification keys (`:sensitive` / `:large` /
 ;; `:rf.egress/output-sensitivity` / `:large?`, Spec 015 §Derived sensitivity)
-;; are validated in the same table (rf2-cgk0wb): previously they were
-;; FAIL-OPEN — a malformed declaration (`:sensitive [:token]`, `:large "blob"`,
-;; a typo'd enum value) registered cleanly but installed no redaction, the
-;; worst failure for a safety feature. The boolean `:sensitive?` declassify
-;; spelling is now REJECTED (EP-0015 issue 9; Spec 015:425).
+;; are validated in the same table. They are validated FAIL-CLOSED: a malformed
+;; declaration (`:sensitive [:token]`, `:large "blob"`, a typo'd enum value) is
+;; rejected rather than silently installing no redaction — the worst failure
+;; for a safety feature. The boolean `:sensitive?` declassify spelling is
+;; REJECTED; derived-output sensitivity is declared with
+;; `:rf.egress/output-sensitivity` (Spec 015:425).
 
 (defn- valid-path-element?
-  "True iff `x` is admissible as a flow path segment — the SHARED EP-0012
+  "True iff `x` is admissible as a flow path segment — the SHARED
   concrete-segment domain (`re-frame.path/segment?`, Conventions §Segment
-  domain), no longer a flows-private enumeration (rf2-t3cfil). The shared
-  domain is a keyword / string / symbol / boolean / integer / UUID / instant
-  / nil; composites (vectors / maps / sets / seqs) and host handles are
-  rejected. Collections are never the right value for a `get-in` path step
-  and almost always indicate a caller bug (e.g. passing a bare keyword where
-  a vector-of-paths was expected, then wrapping it one level too many).
+  domain). The shared domain is a keyword / string / symbol / boolean /
+  integer / UUID / instant / nil; composites (vectors / maps / sets / seqs)
+  and host handles are rejected. Collections are never the right value for a
+  `get-in` path step and almost always indicate a caller bug (e.g. passing a
+  bare keyword where a vector-of-paths was expected, then wrapping it one
+  level too many).
 
-  Flows DELEGATE the membership question to the shared policy rather than
-  re-deriving it: per the EP-0012 disposition-1 graduation note, a subsystem
-  narrows from the shared upper bound but never re-enumerates it. This widens
-  the prior flows enumeration (keyword / string / integer / symbol / boolean)
-  to also admit UUID, instant, and nil segments — all valid associative keys
-  the shared `:rf/path` algebra already focuses through. The flows-SPECIFIC
-  restriction (a `:output-path` / `:inputs` path must be NON-EMPTY — an empty path is
-  a root-output footgun that makes the flow a depends-on prerequisite of every
-  other flow, Spec 013 §Dependency rule) is layered ON TOP in `valid-path?`
-  below, NOT folded into the shared segment domain."
+  Flows DELEGATE the membership question to the shared `:rf/path` policy
+  rather than re-deriving it: a subsystem narrows from the shared upper bound
+  but never re-enumerates it. The shared domain admits UUID, instant, and nil
+  segments alongside keyword / string / integer / symbol / boolean — all valid
+  associative keys the algebra already focuses through. The flows-SPECIFIC
+  restriction (a `:output-path` / `:inputs` path must be NON-EMPTY — an empty
+  path is a root-output footgun that makes the flow a depends-on prerequisite
+  of every other flow, Spec 013 §Dependency rule) is layered ON TOP in
+  `valid-path?` below, NOT folded into the shared segment domain."
   [x]
   (path/segment? x))
 
@@ -381,8 +363,8 @@
   "A flow `:inputs` path or the flow `:output-path` is a NON-EMPTY vector of
   valid path segments. The non-emptiness is the flows-specific root-output
   policy (Spec 013 §Dependency rule — an empty path overlaps every path); the
-  per-element domain is the shared EP-0012 segment policy (`valid-path-element?`
-  → `re-frame.path/segment?`, rf2-t3cfil)."
+  per-element domain is the shared segment policy (`valid-path-element?`
+  → `re-frame.path/segment?`)."
   [x]
   (and (vector? x) (seq x) (every? valid-path-element? x)))
 
@@ -433,8 +415,8 @@
 ;; discriminator, a `:reason` diagnostic, and optional `:extras` that
 ;; build per-clause ex-data slots (`:bad-entries` / `:bad-elements`).
 ;; `validate-flow` walks this vector and throws on the first failing
-;; predicate — matching the original `cond` evaluation order so existing
-;; tests pinning rejection ids see no shift.
+;; predicate, so the rules are ordered most-fundamental-first (a flow with a
+;; broken required shape reports that before any classification-key clause).
 ;;
 ;; Data-driven so the rules are introspectable (a test or the spec can
 ;; read the table) and adding a clause is a single conj.
@@ -443,19 +425,17 @@
     :error-kw :rf.error/flow-missing-id
     :reason   ":id is required (flow registration must name an id)"}
 
-   ;; rf2-ihfz9o issue 2: a PRESENT `:id` must be a keyword. Spec-Schemas
-   ;; §FlowMeta requires `[:id :keyword]` and Spec 013 §The registration
-   ;; shape describes flow ids as namespaced feature identifiers; the
-   ;; public examples are all keywords, and the `:flow-id` slot is emitted
-   ;; unchanged into `:rf.flow/*` trace + error payloads (re-frame.flows
-   ;; :274/:315), so a string / number / map id violates the public
-   ;; schema contract and leaks an arbitrary id shape downstream. Rejecting
-   ;; at the API boundary (pre-alpha — resolve here, not by normalising in
-   ;; every consumer) is the masterpiece choice. Distinct from the
-   ;; absent-id case above (`flow-missing-id` fires first on nil); this
-   ;; rule fires only when an id is present but the wrong type — a fifth
-   ;; member of the `:rf.error/flow-bad-*` family alongside bad-inputs /
-   ;; bad-output / bad-path.
+   ;; A PRESENT `:id` must be a keyword. Spec-Schemas §FlowMeta requires
+   ;; `[:id :keyword]` and Spec 013 §The registration shape describes flow ids
+   ;; as namespaced feature identifiers; the public examples are all keywords,
+   ;; and the `:flow-id` slot is emitted unchanged into `:rf.flow/*` trace +
+   ;; error payloads, so a string / number / map id violates the public schema
+   ;; contract and would leak an arbitrary id shape downstream. Rejecting at
+   ;; the API boundary — resolving here, not by normalising in every consumer —
+   ;; is the masterpiece choice. Distinct from the absent-id case above
+   ;; (`flow-missing-id` fires first on nil); this rule fires only when an id
+   ;; is present but the wrong type — a member of the `:rf.error/flow-bad-*`
+   ;; family alongside bad-inputs / bad-output / bad-path.
    {:pred     (fn [flow] (keyword? (:id flow)))
     :error-kw :rf.error/flow-bad-id
     :reason   ":id must be a keyword (flow ids are namespaced feature identifiers; the public FlowMeta schema requires :keyword and the :flow-id trace/error slot carries it unchanged)"}
@@ -465,12 +445,10 @@
     :reason   ":inputs must be a vector of paths"}
 
    ;; One clause for both "entry isn't a vector" and "entry isn't a valid
-   ;; path" — `valid-path?` already requires `vector?`, so the older
-   ;; two-arm split (the prior code carried a separate `(every? vector?
-   ;; ...)` check) was strictly subsumed by this one. The single rejection
-   ;; message names what the entry must be; the `:bad-entries` slot points
-   ;; at the offending values so callers can fix them without a stack-trace
-   ;; dig.
+   ;; path" — `valid-path?` already requires `vector?`, so this single check
+   ;; subsumes both. The rejection message names what the entry must be; the
+   ;; `:bad-entries` slot points at the offending values so callers can fix
+   ;; them without a stack-trace dig.
    {:pred     (fn [flow] (every? valid-path? (:inputs flow)))
     :error-kw :rf.error/flow-bad-inputs
     :reason   ":inputs entries must each be a non-empty vector of path segments (the shared EP-0012 segment domain: keyword / string / symbol / boolean / integer / UUID / instant / nil)"
@@ -493,23 +471,19 @@
     :reason   ":output-path elements must each be a path segment (the shared EP-0012 segment domain: keyword / string / symbol / boolean / integer / UUID / instant / nil)"
     :extras   (fn [flow] {:bad-elements (vec (remove valid-path-element? (:output-path flow)))})}
 
-   ;; rf2-cgk0wb issue 2: the OPTIONAL output data-classification keys
-   ;; (`:sensitive` / `:large` per-path vectors; `:sensitive?` / `:large?`
-   ;; whole-output booleans) were FAIL-OPEN. `explicit-flow-output-mark-paths`
-   ;; silently `(filter vector?)`-dropped malformed `:sensitive` / `:large`
-   ;; entries and only honoured a LITERAL `true` for `:sensitive?` / `:large?`,
-   ;; so a typo (`:sensitive [:token]`, `:large "blob"`, `:sensitive? :yes`,
-   ;; `:large? 1`) registered with a normal return value and NO diagnostic
-   ;; while the intended redaction / large-elision silently never happened.
-   ;; That is the worst failure mode for a SAFETY feature: the author believes
-   ;; a slot is protected and it is not. Reject at the API boundary instead —
-   ;; same fail-FAST posture the core flow-path validation already takes, and
-   ;; the same `:rf.error/flow-bad-*` family. These rules fire AFTER the core
-   ;; `:id` / `:inputs` / `:derive` / `:output-path` rules (a flow with a broken
-   ;; required shape reports that first), but BEFORE any registry / app-db /
-   ;; elision-declaration state mutates (validate-flow is the first call in
-   ;; `reg-flow`, before `frame-id` / the `swap!`), so a rejected registration
-   ;; installs NO flow row and NO elision declaration.
+   ;; The OPTIONAL output data-classification keys (`:sensitive` / `:large`
+   ;; per-path vectors; `:large?` whole-output boolean) are validated FAIL-FAST.
+   ;; A typo (`:sensitive [:token]`, `:large "blob"`, `:large? 1`) is rejected
+   ;; at the API boundary rather than silently installing no redaction /
+   ;; large-elision — the worst failure mode for a SAFETY feature is the author
+   ;; believing a slot is protected when it is not. Same fail-FAST posture as
+   ;; the core flow-path validation, and the same `:rf.error/flow-bad-*`
+   ;; family. These rules fire AFTER the core `:id` / `:inputs` / `:derive` /
+   ;; `:output-path` rules (a flow with a broken required shape reports that
+   ;; first), but BEFORE any registry / app-db / elision-declaration state
+   ;; mutates (validate-flow is the first call in `reg-flow`, before `frame-id`
+   ;; / the `swap!`), so a rejected registration installs NO flow row and NO
+   ;; elision declaration.
    ;;
    ;; Vector-of-subpaths rules: `:sensitive` / `:large`, when PRESENT, must be
    ;; a vector whose every entry is a valid output subpath — a vector of
@@ -544,13 +518,13 @@
     :extras   (fn [flow] {:bad-key     :large
                           :bad-entries (vec (remove valid-output-subpath? (:large flow)))})}
 
-   ;; Derived-output sensitivity (EP-0015 issue 9): a flow declares its
-   ;; output's sensitivity with the closed `:rf.egress/output-sensitivity`
-   ;; enum (`:rf.egress/inherit` default | `:rf.egress/sensitive` force |
-   ;; `:rf.egress/public` declassify) — NOT the rejected boolean `:sensitive?`
-   ;; overload (Spec 015:425). REJECT a `:sensitive?` key with a recovery
-   ;; hint naming the enum; an unknown enum value is fail-closed (a typo is a
-   ;; loud error, never a silent permissive inherit).
+   ;; Derived-output sensitivity (Spec 015): a flow declares its output's
+   ;; sensitivity with the closed `:rf.egress/output-sensitivity` enum
+   ;; (`:rf.egress/inherit` default | `:rf.egress/sensitive` force |
+   ;; `:rf.egress/public` declassify). A boolean `:sensitive?` key is REJECTED
+   ;; with a recovery hint naming the enum (Spec 015:425); an unknown enum
+   ;; value is fail-closed (a typo is a loud error, never a silent permissive
+   ;; inherit).
    {:pred     (fn [flow] (not (contains? flow :sensitive?)))
     :error-kw :rf.error/flow-bad-marks
     :reason   (str "the boolean :sensitive? declassify/force spelling is rejected on a "
@@ -587,25 +561,23 @@
             (throw (flow-error error-kw reason flow (when extras (extras flow))))))
         validation-rules))
 
-;; ---- Spec 015 §7 flow-output data classification (rf2-ouemt / rf2-ihfz9o) --
+;; ---- Spec 015 §7 flow-output data classification -------------------------
 ;;
 ;; A `reg-flow` registration may carry data-classification keys describing
 ;; the SENSITIVITY / SIZE of the flow's OWN OUTPUT value:
 ;;
 ;;   :rf.egress/output-sensitivity — the closed derived-output declassification
-;;        enum (EP-0015 issue 9): :rf.egress/inherit (default) | :rf.egress/sensitive
+;;        enum: :rf.egress/inherit (default) | :rf.egress/sensitive
 ;;        (force the whole output sensitive) | :rf.egress/public (declassify)
 ;;   :large?     true   — the whole output is large
 ;;   :sensitive  [paths]— per-output-path sensitive sub-slots ([[]] = whole)
 ;;   :large      [paths]— per-output-path large sub-slots ([[]] = whole)
 ;;
-;; PLUS — per Spec 015:313 and the rf2-ihfz9o ruling (Mike (a) PROPAGATE,
-;; 2026-06-09) — a flow OUTPUT inherits the data-classification of its
-;; INPUT paths. A flow reading a sensitive app-db (or runtime-db-qualified,
-;; rf2-4eisfr) input emits a sensitive output unless the author explicitly
-;; declassifies with `:rf.egress/output-sensitivity :rf.egress/public` (the
-;; rejected `:sensitive? false` spelling is gone — Spec 015:425). This is the
-;; same propagation/override grammar subscriptions already implement
+;; PLUS — per Spec 015:313 — a flow OUTPUT inherits the data-classification of
+;; its INPUT paths. A flow reading a sensitive app-db (or runtime-db-qualified)
+;; input emits a sensitive output unless the author explicitly declassifies
+;; with `:rf.egress/output-sensitivity :rf.egress/public` (Spec 015:425). This
+;; is the same propagation/override grammar subscriptions implement
 ;; (`marks/resolve-sub-output-marks`) — flows just need their OWN trigger
 ;; because a flow does not recompute on a mark-only change (subs re-resolve on
 ;; every compute pass). Propagation is FAIL-CLOSED: an over-redacted derived
@@ -615,13 +587,12 @@
 ;; mask / aggregate) declassify with `:rf.egress/output-sensitivity
 ;; :rf.egress/public` (015's :computed/hashed-token).
 ;;
-;; :large is ASYMMETRIC and is NOT auto-propagated (Mike's lean, rf2-ihfz9o
-;; OPEN PRECISION, settled here in impl): :sensitive is TRANSITIVE (derived-
-;; from-sensitive is sensitive), but a flow usually SHRINKS a large input
-;; (count / summary / first-N), so :large-by-default would over-elide the
-;; common case and force `:large? false` everywhere. The consequence
-;; asymmetry confirms it — under-redact-sensitive is a LEAK; mis-:large is
-;; mild either way. So :large marks come ONLY from explicit flow declarations
+;; :large is ASYMMETRIC and is NOT auto-propagated: :sensitive is TRANSITIVE
+;; (derived-from-sensitive is sensitive), but a flow usually SHRINKS a large
+;; input (count / summary / first-N), so :large-by-default would over-elide the
+;; common case and force `:large? false` everywhere. The consequence asymmetry
+;; confirms it — under-redact-sensitive is a LEAK; mis-:large is mild either
+;; way. So :large marks come ONLY from explicit flow declarations
 ;; (`:large? true` / `:large [paths]`); :sensitive marks come from explicit
 ;; declarations UNION propagated input marks.
 ;;
@@ -652,11 +623,11 @@
 ;;     elide the app-db destination slot through the SAME registry, so the
 ;;     db-diff / pending-db / view egress paths redact it too.
 ;;
-;; THE PROPAGATION TRIGGER (rf2-ihfz9o IMPLEMENTATION SHAPE): the input-path
-;; marks a flow inherits arrive on the frame's elision registry AFTER the
-;; flow registers (`add-marks` / `set-marks` / schema population / an upstream
-;; flow's propagated mark). A flow does NOT recompute on a mark-only change,
-;; so it needs a MARK-MUTATION-aware refresh. We resolve at TWO points,
+;; THE PROPAGATION TRIGGER: the input-path marks a flow inherits arrive on the
+;; frame's elision registry AFTER the flow registers (`add-marks` /
+;; `set-marks` / schema population / an upstream flow's propagated mark). A
+;; flow does NOT recompute on a mark-only change, so it needs a
+;; MARK-MUTATION-aware refresh. We resolve at TWO points,
 ;; FRAME-SCOPED and TOPO-ORDERED:
 ;;   1. at `reg-flow` time (initial install — covers add-marks-then-reg-flow),
 ;;   2. at the START of every `run-flows-on-db` drain, walking the frame's
@@ -706,13 +677,13 @@
     [(vec (concat whole-sens per-sens))
      (vec (concat whole-lg   per-large))]))
 
-;; ---- partition-qualified input primitives (EP-0001 §535-551, rf2-4eisfr) --
+;; ---- partition-qualified input primitives (EP-0001 §535-551) -------------
 ;;
 ;; The ONE home for the binary `:inputs`-path partition syntax shared across
-;; the flows artefact (rf2-4vreu8 dedupe): a bare leading path element resolves
-;; against app-db; a leading `:rf.db/runtime` opts the input into the runtime-db
-;; partition and is stripped before the path is used. Three consumers ride
-;; these primitives so the rule lives once:
+;; the flows artefact: a bare leading path element resolves against app-db; a
+;; leading `:rf.db/runtime` opts the input into the runtime-db partition and is
+;; stripped before the path is used. Three consumers ride these primitives so
+;; the rule lives once:
 ;;   - `re-frame.flows/resolve-input` — reads the input VALUE against the
 ;;     pending app-db / runtime-db partitions (strips for the runtime read);
 ;;   - `re-frame.flows/elide-inputs` + `input-overlaps-declaration?` below —
@@ -727,14 +698,14 @@
   flow input into the runtime-db partition (`:rf.db/runtime`). Bare paths (any
   other leading element) resolve against app-db. The single const all three
   flow-artefact consumers (resolver / elision / algebra projection) key on so
-  the rule, the resolver, and the doc stay in lockstep (rf2-4vreu8)."
+  the rule, the resolver, and the doc stay in lockstep."
   :rf.db/runtime)
 
 (defn ^:no-doc runtime-input?
   "True iff `path` is a partition-qualified runtime-db input — a vector whose
   FIRST element is `runtime-partition-key` (`:rf.db/runtime`). Everything else
-  is a bare app-db path (binary syntax — rf2-4eisfr refinement (i): there is no
-  third `[:rf.db/app …]` explicit-app form)."
+  is a bare app-db path (binary syntax — there is no third `[:rf.db/app …]`
+  explicit-app form)."
   [path]
   (= runtime-partition-key (first path)))
 
@@ -743,27 +714,24 @@
   path the elision registry is keyed by (plain path vectors, partition-
   blind — `add-marks` / schema / a flow's own propagated mark all store
   bare path vectors). A bare input is an app-db path verbatim; a runtime-
-  db-qualified input `[:rf.db/runtime …rest]` (rf2-4eisfr) drops the
-  partition key so its `…rest` matches a declaration on that runtime-db
-  slot (e.g. a sensitive route param / machine-data slot declared via
-  `add-marks`). Partition-aware by construction — the SAME machinery, one
-  pass, per the rf2-ihfz9o COMPOSE-WITH-rf2-4eisfr note.
+  db-qualified input `[:rf.db/runtime …rest]` drops the partition key so its
+  `…rest` matches a declaration on that runtime-db slot (e.g. a sensitive
+  route param / machine-data slot declared via `add-marks`). Partition-aware
+  by construction — the SAME machinery, one pass.
 
-  This is the SHARED strip-partition primitive (rf2-4vreu8): a runtime input
-  drops its leading `runtime-partition-key`; a bare input is returned verbatim
-  (as a vector). `re-frame.flows/resolve-input` uses it for the runtime-db
-  value read and `re-frame.flows.tooling/declared-input` for the algebra
+  This is the SHARED strip-partition primitive: a runtime input drops its
+  leading `runtime-partition-key`; a bare input is returned verbatim (as a
+  vector). `re-frame.flows/resolve-input` uses it for the runtime-db value
+  read and `re-frame.flows.tooling/declared-input` for the algebra
   `[:runtime …rest]` / `[:db …]` lowering, so all partition stripping routes
   through this one fn.
 
-  NOT private (rf2-p44r3u): `re-frame.flows/elide-inputs` reuses this SAME
-  normalization when seeding `elision/elide-wire-value`'s `:path` opt for a
-  flow's per-input trace value, so the `:rf.flow/computed` `:input-values`
-  and `:rf.flow/failed` `:inputs` slots elide a runtime-qualified input
-  against the STRIPPED declaration path — closing the input-value leak
-  where the registry keyed the sensitive declaration at the stripped path
-  but the trace seed carried the raw `[:rf.db/runtime …]` path and never
-  matched it."
+  Public so `re-frame.flows/elide-inputs` can reuse this SAME normalization
+  when seeding `elision/elide-wire-value`'s `:path` opt for a flow's per-input
+  trace value, so the `:rf.flow/computed` `:input-values` and
+  `:rf.flow/failed` `:inputs` slots elide a runtime-qualified input against
+  the STRIPPED declaration path — matching how the registry keys the sensitive
+  declaration at the stripped path."
   [input-path]
   (if (runtime-input? input-path)
     (subvec (vec input-path) 1)

--- a/implementation/flows/src/re_frame/flows/tooling.cljc
+++ b/implementation/flows/src/re_frame/flows/tooling.cljc
@@ -1,11 +1,10 @@
 (ns re-frame.flows.tooling
-  "Flows tooling sibling of `re-frame.flows` — carries the EP-0014 slice-3
+  "Flows tooling sibling of `re-frame.flows` — carries the
   derivation/process algebra view of registered flows (`flow-algebra-view`)
   that pair tools (Xray, re-frame2-pair-mcp) and the conformance fixtures
   query, but no production application code reads.
 
-  Mirrors the rf2-bmzq0 `re-frame.subs.tooling` split (and the rf2-qwm0a
-  `re-frame.trace.tooling` split before it):
+  Mirrors the `re-frame.subs.tooling` / `re-frame.trace.tooling` split:
     - CLJS consumers needing the surface call
       `re-frame.flows.tooling/<name>` directly. Apps that load the flows
       artefact but never attach a tool DCE the body wholesale (the sibling
@@ -19,22 +18,20 @@
       explicit sentinel at the foot of this ns additionally proves no
       stray `:require` ever pulled the body in.
 
-  READ-ONLY over the registry. Per the EP-0013 D1-impl in-flight work
-  (rf2-pnf7t5 / gkddyq) this ns touches NEITHER the core registrar
-  write-path NOR the flow registration signatures — exactly as slice-2's
-  subs.tooling read the sub registry without touching the registrar. It
-  reads the per-frame flow registry through the existing public accessor
-  `re-frame.flows.registry/flows-snapshot` (the rf2-4gvb4 read seam).
+  READ-ONLY over the registry: this ns touches NEITHER the core registrar
+  write-path NOR the flow registration signatures, reading the per-frame flow
+  registry through the public accessor
+  `re-frame.flows.registry/flows-snapshot`.
 
-  Per [Derivations.md](../../../../../../spec/Derivations.md) (graduated
-  from EP-0014) and the projected Malli shapes in [Spec-Schemas
+  Per [Derivations.md](../../../../../../spec/Derivations.md) and the
+  projected Malli shapes in [Spec-Schemas
   §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
   (:require [re-frame.flows.registry :as registry]
             [re-frame.registrar :as registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- algebra views (EP-0014 slice-3) -------------------------------------
+;; ---- algebra views -------------------------------------------------------
 ;;
 ;; Per [Derivations.md] §Worked equivalence — the flow is the canonical
 ;; `:app-db` / `:after-event` / `:frame` MATERIALIZED member of the
@@ -48,12 +45,9 @@
 ;;
 ;; This is the *registrar-derived* slice (Derivations §The EP-0013
 ;; relocation seam): the algebra view is assembled from the flow-map
-;; metadata at the surface that registered it, NOT (yet) from an EP-0013
-;; app value. It feeds the later internal graph-inspection helper (EP-0014
-;; bead-plan item 7); slice-3 ships NO public accessor — these functions
-;; live in the bundle-isolated tooling sibling, consumed by Xray + the
-;; conformance fixtures (the two named first consumers). No
-;; `re-frame.core` facade export (EP-0014 issue-1 disposition).
+;; metadata at the surface that registered it. These functions live in the
+;; bundle-isolated tooling sibling, consumed by Xray + the conformance
+;; fixtures; there is no `re-frame.core` facade export.
 ;;
 ;; The five fixed classifications for EVERY flow node (Derivations §Worked
 ;; equivalence — the flow column):
@@ -80,8 +74,8 @@
 
   Routes the partition test and the key strip through the SHARED
   `registry/runtime-input?` / `registry/input-resolve-path` primitives
-  (rf2-4vreu8) so the projection, the value resolver, and the elision
-  declaration-path resolver all key on the one home for the rule."
+  so the projection, the value resolver, and the elision declaration-path
+  resolver all key on the one home for the rule."
   [path]
   (if (registry/runtime-input? path)
     [:runtime (registry/input-resolve-path path)]
@@ -100,8 +94,7 @@
   on `frame-id`, or `nil` when none apply. The per-frame `flows` registry
   stores the raw flow-map WITHOUT source coords — `reg-flow` runs the flow
   through `source-coords/merge-coords` only when stamping the `:flow`
-  registrar slot. So coords are read (READ-only — slice-2's subs.tooling
-  read sub metadata from the registrar the same way) from that slot.
+  registrar slot. So coords are read (READ-only) from that slot.
 
   The `:flow` registrar slot is keyed by flow-id ALONE and holds the
   MOST-RECENTLY-REGISTERED frame's metadata (Spec 013 §Frame-scoping), so it
@@ -165,12 +158,11 @@
 
 (defn flow-algebra-view
   "Return the STATIC derivation/process algebra view of every registered
-  flow (EP-0014 slice-3; [Derivations.md], [Spec-Schemas
-  §`:rf/derivation-node`]).
+  flow ([Derivations.md], [Spec-Schemas §`:rf/derivation-node`]).
 
   Pure data over the per-frame flow registry — read through the public
-  `re-frame.flows.registry/flows-snapshot` seam (rf2-4gvb4), never touching
-  the registrar write-path or the flow registration signatures. The algebra
+  `re-frame.flows.registry/flows-snapshot` seam, never touching the registrar
+  write-path or the flow registration signatures. The algebra
   view companion to `flows-snapshot`: where `flows-snapshot` returns the raw
   `{frame-id {flow-id flow-map}}` registry, this lowers every flow into the
   normalized `:rf/derivation-node` shape the derivation/process algebra
@@ -213,10 +205,9 @@
   single frame (`{}` when the frame has no flows). JVM-runnable — the flow
   registry is partition-agnostic registration metadata.
 
-  Slice-3 ships NO public accessor (EP-0014 issue-1 disposition): this lives
-  in the bundle-isolated tooling sibling and is consumed by Xray + the
-  conformance fixtures; the public name is deferred until a third consumer
-  needs it. There is no `re-frame.core/flow-algebra-view` facade export."
+  Lives in the bundle-isolated tooling sibling and is consumed by Xray + the
+  conformance fixtures. There is no `re-frame.core/flow-algebra-view` facade
+  export."
   ([]
    (let [snapshot (registry/flows-snapshot)]
      (reduce-kv
@@ -239,9 +230,9 @@
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;
-;; Per rf2-bmzq0 / rf2-qwm0a (the subs.tooling + trace.tooling split
-;; pattern): `implementation/scripts/check-bundle-isolation.cjs` greps the
-;; counter bundle for this exact string. The string lives ONLY in this
+;; Per the subs.tooling + trace.tooling split pattern:
+;; `implementation/scripts/check-bundle-isolation.cjs` greps the counter
+;; bundle for this exact string. The string lives ONLY in this
 ;; file's source body — no other namespace, no docstring, no test fixture
 ;; references it — so its presence in the production counter bundle proves
 ;; the tooling sibling's body got pulled in (most likely via a stray

--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -5,12 +5,11 @@
   trace emission — every call decides the evaluation order of one
   frame's flows from the static `:inputs` / `:output-path` declarations alone.
 
-  Per rf2-mnu8z this is the first leg of the flows split — pulled out
-  of the original monolith so the algorithm is unit-testable in
-  isolation. The registry calls `topo-sort` up-front on a prospective
-  flow map to spot cycles before mutating state (rf2-7csri); the
-  outermost-`:after` walker (`re-frame.flows/run-flows-on-db`) calls it
-  on every drain to fix evaluation order.
+  The algorithm lives here in isolation so it is unit-testable on its
+  own. The registry calls `topo-sort` up-front on a prospective flow map
+  to spot cycles before mutating state; the outermost-`:after` walker
+  (`re-frame.flows/run-flows-on-db`) calls it on every drain to fix
+  evaluation order.
 
   Per Spec 013 §Topological sort the rule is: flow B depends on flow
   A iff A's `:output-path` and any of B's `:inputs` share a path prefix in
@@ -28,13 +27,11 @@
   order is undefined and they would race for the shared slot under
   last-write-wins. That is an authoring footgun, not a valid topology,
   so it is rejected at registration with `:rf.error/flow-path-overlap`."
-  ;; rf2-t3cfil (EP-0012 tier-2 flows consumer sweep): the prefix / overlap
-  ;; relations are the SHARED `:rf/path` algebra (`re-frame.path`,
-  ;; Conventions §The :rf/path algebra), not a flows-private dialect. Per the
-  ;; EP-0012 disposition-1 graduation note, "subsystems MUST NOT keep private
-  ;; ad hoc overlap / prefix logic once they cite these helpers — there is no
-  ;; tool-only path semantics." Flows is exactly such a consumer (the
-  ;; algebra's ns-doc names "flows" as a use site), so topo depends on
+  ;; The prefix / overlap relations are the SHARED `:rf/path` algebra
+  ;; (`re-frame.path`, Conventions §The :rf/path algebra), not a flows-private
+  ;; dialect: subsystems MUST NOT keep private ad hoc overlap / prefix logic —
+  ;; there is no tool-only path semantics. Flows is exactly such a consumer
+  ;; (the algebra's ns-doc names "flows" as a use site), so topo depends on
   ;; `re-frame.path` rather than re-deriving `prefix?` / a bespoke overlap
   ;; test. `re-frame.path` lives in core, which this artefact already depends
   ;; on, so this drags no new dependency onto the classpath and the module
@@ -45,7 +42,7 @@
 (defn depends-on?
   "Per Spec 013 §Topological sort: B depends on A iff A's :output-path and any
   of B's :inputs share a path prefix in either direction. The prefix
-  relation is the shared `re-frame.path/prefix?` (rf2-t3cfil)."
+  relation is the shared `re-frame.path/prefix?`."
   [b-flow a-flow]
   (let [a-path (:output-path a-flow)]
     (boolean
@@ -63,11 +60,10 @@
   `[:x :y]` lands inside `[:x]`'s value), but `[:x :y]` and `[:x :z]` are
   disjoint (siblings — neither is a prefix of the other).
 
-  This is the shared `re-frame.path/overlap?` relation (rf2-t3cfil) — the
-  SAME prefix-in-either-direction test every path-shaped subsystem inherits,
-  no longer a flows-private predicate. `re-frame.path/overlap?` normalizes
-  its inputs; flow paths are already validated vectors, so the behaviour is
-  identical."
+  This is the shared `re-frame.path/overlap?` relation — the SAME
+  prefix-in-either-direction test every path-shaped subsystem inherits.
+  `re-frame.path/overlap?` normalizes its inputs; flow paths are already
+  validated vectors, so the behaviour is identical."
   [a-path b-path]
   (path/overlap? a-path b-path))
 
@@ -82,7 +78,7 @@
   flow count — a handful of nodes at v1, same order as the graph build),
   short-circuited by `(some ...)`. The reported pair is canonically
   ordered by `(juxt hash str)` so the report is GENUINELY stable across
-  runs (rf2-tx1ub): `hash` alone leaves the order undefined on a hash
+  runs: `hash` alone leaves the order undefined on a hash
   collision (distinct ids, equal hash) — `sort-by` is stable and would
   fall back to map-iteration order there, a non-contract across JVM runs.
   The `str` tie-break makes the lo/hi assignment depend only on the ids'
@@ -217,11 +213,10 @@
   Tools (e.g. Xray) render this directly as the offending chain.
 
   Note: callers re-run this on every drain via
-  `re-frame.flows/run-flows-on-db`. A memo was trialled and removed (rf2-cd00):
-  the per-frame flow map is tiny (Kahn over a handful of nodes) and a
-  memo keyed on the flow map needs explicit invalidation on every
-  reg-flow / clear-flow anyway. The unmemoised call is the cheapest
-  correct option."
+  `re-frame.flows/run-flows-on-db`, unmemoised. The per-frame flow map is
+  tiny (Kahn over a handful of nodes) and a memo keyed on the flow map
+  would need explicit invalidation on every reg-flow / clear-flow anyway.
+  The unmemoised call is the cheapest correct option."
   [flow-map]
   (let [ids (vec (keys flow-map))]
     ;; 0/1 flows have no edges — order is trivial; skip the O(n²) graph
@@ -267,11 +262,11 @@
               ;; so the shape is inlined rather than reaching for
               ;; `registry.cljc`'s `flow-error` helper.
               ;;
-              ;; `:recovery :fix-registration` (rf2-ee38b.9) — a cycle is
-              ;; the same class of error as the sibling `validate-flow`
-              ;; rejections: detected at `reg-flow` time on a PROSPECTIVE
-              ;; map BEFORE any state mutates (rf2-7csri), so the prior
-              ;; registration survives and the caller fixes their
+              ;; `:recovery :fix-registration` — a cycle is the same class
+              ;; of error as the sibling `validate-flow` rejections:
+              ;; detected at `reg-flow` time on a PROSPECTIVE map BEFORE any
+              ;; state mutates, so the prior registration survives and the
+              ;; caller fixes their
               ;; `:inputs` / `:output-path` and retries. Stamping `:no-recovery`
               ;; would make an `:on-error` policy or tool that branches on
               ;; `:recovery` to decide "is this user-fixable?" treat a

--- a/implementation/flows/test/re_frame/flow_algebra_view_test.clj
+++ b/implementation/flows/test/re_frame/flow_algebra_view_test.clj
@@ -125,8 +125,8 @@
 
 (deftest runtime-qualified-input-lowers-to-a-runtime-read
   (testing "a [:rf.db/runtime …] input lowers to a [:runtime …rest] declared input"
-    ;; EP-0001 §535-551 (rf2-4eisfr): any flow may READ runtime-db via an
-    ;; explicit partition-qualified input; only the write side is reserved.
+    ;; EP-0001 §535-551: any flow may READ runtime-db via an explicit
+    ;; partition-qualified input; only the write side is reserved.
     (rf/reg-flow {:id     :route/derived
                   :inputs [[:rf.db/runtime :rf.runtime/routing :current :route-id]
                            [:local :seed]]

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -63,9 +63,9 @@
        Per-thread cycle-detection probe: each thread, mid-stress, does
        a `try`/`catch` `reg-flow` of a flow whose registration would
        close a two-flow cycle. The detector MUST throw
-       `:rf.error/flow-cycle` under contention; pre-fix any race in
-       topo-sort's snapshot read could miss the prospective edge and
-       silently admit the cycle. The probe is deterministic — every
+       `:rf.error/flow-cycle` under contention; a race in topo-sort's
+       snapshot read that missed the prospective edge would silently
+       admit the cycle. The probe is deterministic — every
        attempt MUST be detected — so the shared atomic counter for
        cycle hits MUST equal exactly `n-threads` (each thread did one
        probe).
@@ -106,8 +106,8 @@
 ;; state. The flows ns keeps a private `last-inputs` atom for
 ;; dirty-checking (per Spec 013 §Dirty-check semantics); we reset it
 ;; via `flows/reset-flows!` (which clears BOTH `flows` and
-;; `last-inputs` in lockstep per rf2-mb65w) so cross-test state cannot
-;; leak in either direction.
+;; `last-inputs` in lockstep) so cross-test state cannot leak in either
+;; direction.
 
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -118,27 +118,25 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
+  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
+  ;; ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (binding [frame/*current-frame* :rf/default]
     (test-fn)))
 
 (use-fixtures :each reset-runtime)
 
-;; Per-thread iteration count. Kept at the rf2-ynk7 / rf2-35rgj /
-;; rf2-1gpx8 standard 5000 so CI stays under ~60s wall-clock with the
-;; default thread count. Operators dial up via the env override; CI
-;; dials down by lowering it (e.g. `RF2_ZTW5P_STRESS_ITERS=500` for a
-;; smoke-test pass).
+;; Per-thread iteration count. The standard 5000 keeps CI under ~60s
+;; wall-clock with the default thread count. Operators dial up via the
+;; env override; CI dials down by lowering it (e.g.
+;; `RF2_ZTW5P_STRESS_ITERS=500` for a smoke-test pass).
 (def ^:private stress-iters
   (or (some-> (System/getenv "RF2_ZTW5P_STRESS_ITERS") Long/parseLong)
       5000))
 
-;; Eight parallel threads — matches rf2-ynk7's `concurrent-dispatch-stress`
-;; (`n-submitters 8`) and the rf2-1gpx8 thread count. Higher contention
-;; than the typical 4-core CI box; the per-frame partitioning means
+;; Eight parallel threads — higher contention than the typical 4-core CI
+;; box; the per-frame partitioning means
 ;; we're not over-saturating any one drain-lock, we're driving N
 ;; independent reg/eval/clear cycles in parallel and asserting the
 ;; flow-id allocator + registrar lookup + per-frame registry write
@@ -148,11 +146,9 @@
 ;; ---- the stress test ------------------------------------------------------
 
 (deftest ^:stress flow-reg-eval-clear-stress
-  ;; rf2-ztw5p — mirrors rf2-1gpx8's pattern for the flows surface.
-  ;;
-  ;; The two pinned counter invariants are the same as rf2-35rgj /
-  ;; rf2-1gpx8: every dispatched event ran exactly once (no drops) and
-  ;; every transition / `:derive` invocation fired exactly once per
+  ;; The two pinned counter invariants: every dispatched event ran exactly
+  ;; once (no drops) and every transition / `:derive` invocation fired
+  ;; exactly once per
   ;; dispatch (no doubles). Two distinct counter views (per-thread
   ;; atom + global AtomicLong) detect them independently — divergence
   ;; between the two would indicate the per-thread observation lost
@@ -267,8 +263,7 @@
                           ;; Clear the cycle-probe registration so
                           ;; the leak invariant can pass. (`:cyc-b`
                           ;; never registered because the cycle
-                          ;; throw rolled it back per
-                          ;; rf2-7csri/rf2-cdh9h.)
+                          ;; throw rolled it back.)
                           (flows/clear-flow cyc-a {:frame frame-id})
                           ;; Clear the main flow so the leak
                           ;; invariant can pass.
@@ -284,9 +279,9 @@
         ;; Bounded join — if a cycle ever hangs (e.g. a clear-flow
         ;; that doesn't fire under contention), we want a visible
         ;; failure rather than a stuck CI run. 120s gives ample
-        ;; headroom for 8 × 5000 cycles on a slow box; pre-fix races
-        ;; that drop events would surface as either a counter
-        ;; mismatch OR a future hanging at a downstream dispatch.
+        ;; headroom for 8 × 5000 cycles on a slow box; a race that
+        ;; dropped events would surface as either a counter mismatch
+        ;; OR a future hanging at a downstream dispatch.
         (doseq [f futures]
           (let [v (deref f 120000 ::timeout)]
             (is (not= ::timeout v)
@@ -337,9 +332,9 @@
         ;;     must be gone for every per-thread flow id (the LAST frame
         ;;     holding it released the id per Spec 013 §Frame-scoping).
         ;;
-        ;; rf2-4bbaw: each per-thread frame had ALL its flows cleared, so
-        ;; clearing the last one prunes the frame-id key entirely — the
-        ;; slot is strictly `nil`, never a `{frame-id {}}` empty husk.
+        ;; Each per-thread frame had ALL its flows cleared, so clearing the
+        ;; last one prunes the frame-id key entirely — the slot is strictly
+        ;; `nil`, never a `{frame-id {}}` empty husk.
         (let [flows-snapshot       (flows/flows-snapshot)
               last-inputs-snapshot (flows/last-inputs-snapshot)]
           (doseq [{:keys [frame-id flow-id cyc-a cyc-b]} per-thread]

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -1,11 +1,10 @@
 (ns re-frame.flows-concurrency-stress-test
-  "Per rf2-ztw5p — JVM concurrency stress coverage for the flows
-  surface (`reg-flow` / `clear-flow` / dirty-check / topo / failed-flow).
-  Mirrors the rf2-1gpx8 (machine actor) and rf2-35rgj (router) stress
-  patterns: many threads running independent per-frame cycles in
-  lockstep, asserting **no event dropped** and **no double-action**
-  invariants on counters that the deterministic single-shot suite
-  cannot detect.
+  "JVM concurrency stress coverage for the flows surface
+  (`reg-flow` / `clear-flow` / dirty-check / topo / failed-flow).
+  Mirrors the machine-actor and router stress patterns: many threads
+  running independent per-frame cycles in lockstep, asserting **no event
+  dropped** and **no double-action** invariants on counters that the
+  deterministic single-shot suite cannot detect.
 
   The deterministic flow tests in `flows_test.clj` cover correctness
   single-shot; this namespace pins the surface under parallel

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -143,10 +143,9 @@
   (flows/reset-flows!)
   (schemas/clear-schemas-by-frame!)
   (flows/reset-last-inputs!)
-  ;; Per rf2-bacs4: the error-emit listener registry is a `defonce` atom
-  ;; that survives test re-runs. Clear before each test so a listener
-  ;; registered by one fixture (per rf2-gmrks `:error-emit-records`
-  ;; matcher) doesn't leak into the next.
+  ;; The error-emit listener registry is a `defonce` atom that survives test
+  ;; re-runs. Clear before each test so a listener registered by one fixture
+  ;; (the `:error-emit-records` matcher) doesn't leak into the next.
   (error-emit/clear-error-listeners!)
   (rf/init! plain-atom/adapter)
   ;; Framework events / fx are registered at namespace-load time in
@@ -157,9 +156,9 @@
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.flows :reload)
-  ;; EP-0002 (rf2-5q7um6): the conformance corpus registers flows and
-  ;; dispatches ambiently against :rf/default; reg-flow + dispatch are now
-  ;; context-required (no :rf/default floor). Register :rf/default as an
+  ;; EP-0002: the conformance corpus registers flows and dispatches ambiently
+  ;; against :rf/default; reg-flow + dispatch are context-required (no
+  ;; :rf/default floor). Register :rf/default as an
   ;; ordinary frame here so the scope is available — but do NOT pin
   ;; `*current-frame*` around the whole body: `run-fixture`'s `reg-frame`
   ;; must run with no in-flight scope so its `:on-create` cascade fires
@@ -259,9 +258,8 @@
   surface. Mirrors core's runner shape."
   []
   {:read-db!  (fn [frame-id] (frame/frame-app-db-value frame-id))
-   ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via swap-frame-db! —
-   ;; app-db-container is now a read-only projection over the one physical
-   ;; frame-state container.
+   ;; EP-0001: write the app-db PARTITION via swap-frame-db! — app-db-container
+   ;; is a read-only projection over the one physical frame-state container.
    :write-db! (fn [frame-id new-db]
                 (frame/swap-frame-db! frame-id (constantly new-db)))
    :dispatch! (fn [event frame-id] (rf/dispatch event {:frame frame-id}))})
@@ -357,12 +355,12 @@
                               (fn [ev] (swap! traces conj ev)))
     traces))
 
-;; ---- error-emit capture (rf2-gmrks) -------------------------------------
+;; ---- error-emit capture --------------------------------------------------
 ;;
 ;; Per Spec 013 §Failure semantics rule 4 + §Resolved decisions
-;; §`:rf.error/flow-eval-exception` rides the always-on error substrate
-;; (rf2-0q0du): flow-eval failures fire on the always-on production
-;; error-emit substrate, which survives CLJS `:advanced` +
+;; §`:rf.error/flow-eval-exception` rides the always-on error substrate:
+;; flow-eval failures fire on the always-on production error-emit substrate,
+;; which survives CLJS `:advanced` +
 ;; `goog.DEBUG=false` elision. The `flow-eval-exception.edn` fixture's
 ;; `:error-emit-records` matcher asserts the listener captured a record
 ;; of the expected shape — the host-agnostic data-shape equivalent of
@@ -523,7 +521,7 @@
     (let [fid          (:fixture/id fixture)
           traces       (collect-traces fid)
           ;; Always register an error-emit listener so the
-          ;; `:error-emit-records` matcher (rf2-gmrks) has a captured
+          ;; `:error-emit-records` matcher has a captured
           ;; stream to assert against. Listeners with no expectations
           ;; cost nothing — the registry is cleared in `reset-runtime`
           ;; between fixtures.
@@ -541,29 +539,28 @@
           ;; seam is bypassed. Single-frame fixtures keep the original
           ;; shape (`:fixture/frame-config` configures `:rf/default`).
           ;;
-          ;; Order (rf2-wbtjn): event / sub / fx handlers must be
-          ;; registered BEFORE `reg-frame` fires the `:on-create`
-          ;; cascade — `:on-create` dispatches the fixture's seed event,
-          ;; which needs its handler resolved. Flow registration MUST
-          ;; come AFTER `reg-frame`: the destroy-frame! teardown hook
-          ;; (the symmetric leak fix this bead lands) clears any flows
-          ;; registered against the frame being destroyed, so
-          ;; registering them before the destroy would wipe them.
+          ;; Order: event / sub / fx handlers must be registered BEFORE
+          ;; `reg-frame` fires the `:on-create` cascade — `:on-create`
+          ;; dispatches the fixture's seed event, which needs its handler
+          ;; resolved. Flow registration MUST come AFTER `reg-frame`: the
+          ;; destroy-frame! teardown hook clears any flows registered against
+          ;; the frame being destroyed, so registering them before the destroy
+          ;; would wipe them.
           _            (rf/destroy-frame! :rf/default)
           _            (realise-event-sub-fx-handlers fixture)
           ;; reg-frame runs with NO in-flight scope so its `:on-create`
           ;; cascade fires SYNCHRONOUSLY (Spec 002 §reg-frame from inside a
           ;; handler async-queues on-create when `*current-frame*` is bound;
-          ;; EP-0002 / rf2-5q7um6). The carried-invariant scope is pinned
-          ;; AFTER reg-frame, around `realise-flows!` + the dispatch loop.
+          ;; EP-0002). The carried-invariant scope is pinned AFTER reg-frame,
+          ;; around `realise-flows!` + the dispatch loop.
           _            (if (seq frames-spec)
                          (doseq [f frames-spec]
                            (rf/reg-frame (:id f) (dissoc f :id)))
                          (rf/reg-frame :rf/default frame-config))
           dispatches   (or (:fixture/dispatches fixture) [])]
-      ;; EP-0002 (rf2-5q7um6): reg-flow + bare single-frame dispatches are
-      ;; context-required frame-local. Pin :rf/default as the established
-      ;; scope for the no-explicit-frame calls below. Multi-frame fixtures
+      ;; EP-0002: reg-flow + bare single-frame dispatches are context-required
+      ;; frame-local. Pin :rf/default as the established scope for the
+      ;; no-explicit-frame calls below. Multi-frame fixtures
       ;; pass explicit `{:frame …}` envelopes (the override), which win over
       ;; this ambient binding.
       (binding [frame/*current-frame* :rf/default]
@@ -573,8 +570,8 @@
       ;;   - an envelope map `{:event [...] :frame <id> ...}` (multi-frame,
       ;;     mirrors core's runner per
       ;;     spec/conformance/fixtures/frame-multi-instance.edn)
-      ;;   - a teardown step `{:destroy-frame <frame-id>}` (rf2-gmrks /
-      ;;     Spec 013 §Frame-destroy teardown). The runner calls
+      ;;   - a teardown step `{:destroy-frame <frame-id>}`
+      ;;     (Spec 013 §Frame-destroy teardown). The runner calls
       ;;     `frame/destroy-frame!` on the named frame; subsequent
       ;;     dispatch / matcher checks see the post-teardown state.
       (doseq [ev dispatches]
@@ -623,7 +620,7 @@
             ;; `:trace-absent` — a vector of trace patterns that MUST NOT
             ;; appear anywhere in the captured stream (no op-type filter).
             ;; Powers the atomicity-contract assertion that a flow throw
-            ;; emits NO `:rf.event/db-changed` (rf2-u0zz5).
+            ;; emits NO `:rf.event/db-changed`.
             forbidden-emits  (:trace-absent expect)
             absent-failures  (when forbidden-emits
                                (check-trace-absent @traces forbidden-emits))
@@ -647,7 +644,7 @@
                                      (for [[fid _] expected-after]
                                        [fid (flow-registry-ids fid)]))
                                :else (flow-registry-ids))
-            ;; `:flow-last-inputs-after` (rf2-gmrks) — `{flow-id
+            ;; `:flow-last-inputs-after` — `{flow-id
             ;; #{frame-ids}}` strict match. Per Spec 013 §Frame-destroy
             ;; teardown: after `destroy-frame!`, the destroyed frame's
             ;; row in every `last-inputs[flow-id]` MUST be dropped; the
@@ -658,7 +655,7 @@
                                (into {}
                                      (for [[flow-id _] expected-li]
                                        [flow-id (last-inputs-frame-set flow-id)])))
-            ;; `:registrar-flow-slots-after` (rf2-gmrks) — strict set
+            ;; `:registrar-flow-slots-after` — strict set
             ;; match of `:flow` registrar ids that survive the fixture's
             ;; teardown. Per Spec 013 §Frame-destroy teardown: the slot
             ;; drops iff no surviving frame still owns the id.
@@ -667,14 +664,13 @@
                                (into #{}
                                      (filter registrar-has-flow?
                                              expected-slots)))
-            ;; `:error-emit-records` (rf2-gmrks) — order-preserving
-            ;; subset match against the captured always-on error-emit
-            ;; substrate stream. Per Spec 013 §Failure semantics rule 4
-            ;; + Resolved decisions §`:rf.error/flow-eval-exception`
-            ;; rides the always-on error substrate (rf2-0q0du): the
-            ;; substrate fires under CLJS `:advanced` + `goog.DEBUG=false`
-            ;; — this matcher is the host-agnostic data-shape equivalent
-            ;; of the JVM-side prod-elision proof.
+            ;; `:error-emit-records` — order-preserving subset match against
+            ;; the captured always-on error-emit substrate stream. Per Spec 013
+            ;; §Failure semantics rule 4 + Resolved decisions
+            ;; §`:rf.error/flow-eval-exception` rides the always-on error
+            ;; substrate: the substrate fires under CLJS `:advanced` +
+            ;; `goog.DEBUG=false` — this matcher is the host-agnostic data-shape
+            ;; equivalent of the JVM-side prod-elision proof.
             expected-err     (:error-emit-records expect)
             err-failures     (when expected-err
                                (check-trace-stream @err-records expected-err))]
@@ -733,7 +729,7 @@
             ;; A flow fixture that will not parse, declares a spec-version
             ;; this runner does not claim, or declares a capability outside
             ;; the claim is NOT a benign skip — this runner is the reference
-            ;; gate for every `flow-*.edn` fixture (rf2-lrf1se). Record it as
+            ;; gate for every `flow-*.edn` fixture. Record it as
             ;; a FAILURE so `(is (zero? failed))` catches it; the fix is to
             ;; fix the fixture or extend `claimed-*` + implement the matcher
             ;; (a reviewed edit to this file), never to let it skip.
@@ -763,10 +759,10 @@
     (let [all     @results
           passed  (filter :passed? all)
           failed  (remove :passed? all)]
-      ;; Silent-on-success (rf2-try1x): summary prints only on failure.
-      ;; No skip bucket (rf2-lrf1se): a flow fixture this runner cannot run —
-      ;; load error, unclaimed spec-version, out-of-claim capability — is a
-      ;; FAILURE, not a non-blocking skip.
+      ;; Silent-on-success: the summary prints only on failure.
+      ;; No skip bucket: a flow fixture this runner cannot run — load error,
+      ;; unclaimed spec-version, out-of-claim capability — is a FAILURE, not a
+      ;; non-blocking skip.
       (when (seq failed)
         (println)
         (println "Flows conformance corpus (flow-*.edn fixtures):")

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -1,34 +1,19 @@
 (ns re-frame.flows-conformance-test
-  "Per rf2-4559c (audit rf2-o3hok §TE7). Drives every
-  `spec/conformance/fixtures/flow-*.edn` fixture through the live flows
-  runtime — `reg-flow`, `clear-flow`, the `:rf.fx/reg-flow` /
+  "Drives every `spec/conformance/fixtures/flow-*.edn` fixture through the
+  live flows runtime — `reg-flow`, `clear-flow`, the `:rf.fx/reg-flow` /
   `:rf.fx/clear-flow` runtime fxs, the per-frame flow registry, the
   topological sort, the dirty-check `last-inputs` map, the
   outermost-`:after` `run-flows-on-db` walker, and the `:rf.flow/*`
-  trace vocabulary — and
-  asserts the conformance-corpus's recorded outcome against what the
-  artefact actually produces.
+  trace vocabulary — and asserts the conformance-corpus's recorded outcome
+  against what the artefact actually produces.
 
-  This is the flows artefact's own conformance gate. Pre-rf2-4559c the
-  flow fixtures rode the CORE artefact's `re-frame.conformance-test`
-  (the pattern rf2-d0wem set for machines and rf2-i3qc0 set for ssr;
-  analogous gap for flows). Two drawbacks:
-
-    1. Several flow-specific assertion channels — `:expect-trace-stream`,
-       `:flow-recompute-counts`, `:flow-graph-topology`,
-       `:flow-registry-after` — that the corpus documents under
-       `spec/conformance/README.md` §Fixture lifecycle were not exercised
-       by the core runner. Fixtures asserting only through those channels
-       passed silently because the matcher was absent.
-    2. The gate ran at the wrong artefact. A flows-touching PR could
-       break a fixture and only surface at core's gate — at which
-       point the failure has to be triaged across two artefacts.
-
-  This namespace closes both gaps. It runs at the flows artefact's
-  gate (so a flow regression fails the flows CI step), and it
-  implements the flow-specific matchers (so the corpus's lifecycle /
-  topology / dirty-check / hot-reload / trace contracts are checked
-  against the live runtime).
+  This is the flows artefact's own conformance gate. It runs at the flows
+  artefact's gate (so a flow regression fails the flows CI step, not core's),
+  and it implements the flow-specific assertion channels — `:expect-trace-stream`,
+  `:flow-recompute-counts`, `:flow-graph-topology`, `:flow-registry-after`
+  (documented under `spec/conformance/README.md` §Fixture lifecycle) — so the
+  corpus's lifecycle / topology / dirty-check / hot-reload / trace contracts
+  are checked against the live runtime.
 
   ## What this runner does
 
@@ -98,8 +83,8 @@
   silently skipped — a silent skip would let a new flow fixture's
   contract go entirely unchecked while the gate stayed green.
 
-  Concretely (rf2-lrf1se): out-of-claim / unclaimed-spec-version flow
-  fixtures are recorded as FAILURES (not non-blocking skips), so the
+  Concretely: out-of-claim / unclaimed-spec-version flow fixtures are
+  recorded as FAILURES (not non-blocking skips), so the
   suite's `(is (zero? failed))` assertion catches them. The fix is to
   extend `claimed-capabilities` (and implement the matcher) — a reviewed
   edit to this file — never to let the fixture skip. There is no

--- a/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
+++ b/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
@@ -1,16 +1,13 @@
 (ns re-frame.flows-destroy-frame-teardown-test
-  "Per rf2-wbtjn — `destroy-frame!` must clean up the per-frame flow
-  state (registry slot, `last-inputs` rows, owning-frame registrar
-  entries). Symmetric with the machines `:machines/teardown-on-frame-destroy!`
-  hook (rf2-vsigt).
+  "`destroy-frame!` cleans up the per-frame flow state (registry slot,
+  `last-inputs` rows, owning-frame registrar entries). Symmetric with the
+  machines `:machines/teardown-on-frame-destroy!` hook.
 
-  Pre-rf2-wbtjn the implementation tore down sub-cache, machine
-  cascade, SSR side-channels, schemas and epoch state on
-  `destroy-frame!` but left flows untouched — `flows[frame-id]`,
-  `last-inputs[flow-id][frame-id]` and any `:flow` registrar slots
-  whose last owning frame was destroyed all retained references.
-  Memory leak class: long-running SSR JVM (per-request frame churn),
-  pair-tool time-travel, `make-frame` ephemeral usage.
+  Without this teardown, `flows[frame-id]`, `last-inputs[flow-id][frame-id]`
+  and any `:flow` registrar slots whose last owning frame was destroyed would
+  retain references — a memory leak class for the long-running SSR JVM
+  (per-request frame churn), pair-tool time-travel, and `make-frame` ephemeral
+  usage.
 
   These JVM-side tests run on the plain-atom substrate against the
   late-bound `:flows/teardown-on-frame-destroy!` hook the flows
@@ -40,9 +37,9 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
+  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
+  ;; ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (binding [frame/*current-frame* :rf/default]
     (test-fn)))
@@ -160,7 +157,7 @@
         "registrar slot survives because frame B still registers :shared")))
 
 ;; ---- registrar slot re-points to a LIVE owner when the slot's current ----
-;;      (last-registered) frame is destroyed (rf2-73pi1 finding 1).
+;;      (last-registered) frame is destroyed.
 
 (deftest destroy-frame-of-registrar-owner-repoints-to-surviving-frame
   (testing "Per rf2-73pi1: destroying the frame whose metadata currently
@@ -246,7 +243,7 @@
     (is (nil? (registrar/lookup :flow :area))
         "the new frame has no inherited :flow registrar slot")))
 
-;; ---- rf2-yt5bbl: flow-output elision marks ride the frame-record drop -----
+;; ---- flow-output elision marks ride the frame-record drop ----------------
 ;;
 ;; `clear-flow` scrubs ONE flow's `:source :flow` elision declarations via
 ;; `clear-flow-output-marks!` while its frame lives on. Frame-destroy does NOT
@@ -322,14 +319,14 @@
     (is (not (contains? (elision/sensitive-declarations :fc/scratch) [:auth :token]))
         "specifically: the first incarnation's [:auth :token] mark did not survive")))
 
-;; ---- rf2-zbxvqj: reg-flow must not resurrect stale flows on a dead frame --
+;; ---- reg-flow must not resurrect stale flows on a dead frame -------------
 ;;
-;; Pre-fix, `reg-flow` against an absent/destroyed frame ran the registration
-;; thunk DIRECTLY (call-serialized-with-drain! runs the thunk in-line for a
-;; non-live frame), installing a `flows` row, an elision declaration, and a
-;; `:flow` registrar slot stamped with the dead frame-id. A later `reg-frame`
-;; reusing that id then inherited the resurrected flow. The fix rejects the
-;; registration BEFORE any state mutates.
+;; `reg-flow` against an absent/destroyed frame is rejected BEFORE any state
+;; mutates. `call-serialized-with-drain!` runs the registration thunk in-line
+;; for a non-live frame, so without the guard the registration would install a
+;; `flows` row, an elision declaration, and a `:flow` registrar slot stamped
+;; with the dead frame-id — and a later `reg-frame` reusing that id would
+;; inherit the resurrected flow.
 
 (deftest reg-flow-against-destroyed-frame-rejects-and-mutates-nothing
   (testing "Per rf2-zbxvqj: reg-flow on a DESTROYED frame throws a stable

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -1,48 +1,46 @@
 (ns re-frame.flows-lifecycle-drain-race-test
-  "Per rf2-2woz9 — JVM regression coverage for the two flow-lifecycle vs
-  drain interleaving races.
+  "JVM regression coverage for the two flow-lifecycle vs drain interleaving
+  races.
 
-  Both bugs are window races between a flow LIFECYCLE op (`clear-flow` /
-  `reg-flow` replacement) and a concurrent EVENT DRAIN on the SAME frame.
-  Pre-fix, the lifecycle op's multi-step registry+app-db mutation was not
-  serialized against the frame's `:drain-lock`, so a drain could interleave
-  between steps and observe a half-applied change:
+  Both surfaces are window races between a flow LIFECYCLE op (`clear-flow` /
+  `reg-flow` replacement) and a concurrent EVENT DRAIN on the SAME frame. The
+  lifecycle op runs its multi-step registry+app-db mutation under
+  `frame/call-serialized-with-drain!`, which takes the frame's `:drain-lock`
+  (the single-drainer serialization primitive) so the mutation is atomic
+  w.r.t. any concurrent drain — a drain can NEVER observe a half-applied
+  lifecycle change. Without that serialization a drain could interleave
+  between steps:
 
-    FINDING 1 (clear-flow stale output). `clear-flow` vacated the output
-    `:output-path` BEFORE removing the flow from the per-frame registry. A
-    same-frame drain that started in that window saw the STILL-registered
-    flow, recomputed it, and re-committed the output `clear-flow` had just
-    vacated. `clear-flow` then removed the registry / last-inputs rows but
-    NEVER vacated again — so a cleared flow left stale derived state in
-    app-db (violating Spec 013's clear-flow cleanup contract).
+    SURFACE 1 (clear-flow stale output). `clear-flow` vacates the output
+    `:output-path` then removes the flow from the per-frame registry. A
+    same-frame drain interleaving between those two steps would see the
+    STILL-registered flow, recompute it, and re-commit the output `clear-flow`
+    had just vacated — leaving stale derived state in app-db (violating Spec
+    013's clear-flow cleanup contract). Serialization makes that window
+    unreachable.
 
-    FINDING 2 (re-registration skips recompute). A same-frame `reg-flow`
-    REPLACEMENT published the new flow into `flows` (visible to a drain) in
-    the `swap!`, but the stale-`last-inputs` invalidation only fired later
-    via `registrar/register!` → `invalidate-flow-on-replace!`. A drain that
-    started after the new flow was visible but before `last-inputs` was
-    dropped saw the new flow with the OLD input cache and skipped recompute
-    on `=`-equal inputs — so the first post-replacement drain KEPT the stale
-    output (violating Spec 013's re-registration contract that the new flow
-    re-evaluates on the next event regardless of input equality).
+    SURFACE 2 (re-registration skips recompute). A same-frame `reg-flow`
+    REPLACEMENT publishes the new flow into `flows` (visible to a drain) in
+    the `swap!`, and the stale-`last-inputs` invalidation fires via
+    `registrar/register!` → `invalidate-flow-on-replace!`. A drain
+    interleaving after the new flow was visible but before `last-inputs` was
+    dropped would see the new flow with the OLD input cache and skip recompute
+    on `=`-equal inputs, keeping the stale output (violating Spec 013's
+    re-registration contract that the new flow re-evaluates on the next event
+    regardless of input equality). Serializing the whole publish→invalidate
+    sequence makes that window unreachable too.
 
-  THE FIX (rf2-2woz9): both lifecycle ops now run their registry+app-db
-  mutation under `frame/call-serialized-with-drain!`, which takes the
-  frame's `:drain-lock` (the existing single-drainer serialization
-  primitive) so the mutation is atomic w.r.t. any concurrent drain. A drain
-  can therefore NEVER observe a half-applied lifecycle change. (Reentrant:
-  a mid-drain `:rf.fx/clear-flow` / `:rf.fx/reg-flow` runs directly inside
-  the single-drainer window rather than self-deadlocking on the lock.)
+  (Reentrant: a mid-drain `:rf.fx/clear-flow` / `:rf.fx/reg-flow` runs
+  directly inside the single-drainer window rather than self-deadlocking on
+  the lock.)
 
   TEST STRATEGY. Each test reproduces the dangerous interleaving
-  DETERMINISTICALLY by pausing the lifecycle op at the exact pre-fix gap
-  (via `with-redefs` of a private fn the op calls mid-region — NO production
-  test-seam) while a DIFFERENT thread attempts the racing dispatch. With the
-  fix the lifecycle op holds the drain-lock across the pause, so the racing
-  dispatch BLOCKS on the lock until the op fully completes; the post-
-  condition the bead pins (clean app-db / fresh recompute) then holds. A
-  pre-fix build would let the paused-window dispatch run and leave the
-  stale state — the asserts would fail.
+  DETERMINISTICALLY by pausing the lifecycle op mid-region (via `with-redefs`
+  of a private fn the op calls — NO production test-seam) while a DIFFERENT
+  thread attempts the racing dispatch. The lifecycle op holds the drain-lock
+  across the pause, so the racing dispatch BLOCKS on the lock until the op
+  fully completes; the post-condition (clean app-db / fresh recompute) then
+  holds.
 
   CLJS is single-threaded; this race is JVM-only by construction."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -67,9 +65,9 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
+  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
+  ;; ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (binding [frame/*current-frame* :rf/default]
     (test-fn)))
@@ -82,22 +80,22 @@
            "racing thread that never reached the rendezvous")))
 
 ;; ---------------------------------------------------------------------------
-;; Finding 1 — clear-flow must not leave stale output when a drain races the
+;; Surface 1 — clear-flow must not leave stale output when a drain races the
 ;; vacate→deregister window.
 ;; ---------------------------------------------------------------------------
 
 (deftest clear-flow-output-stays-vacated-when-a-drain-races-the-window
-  ;; rf2-2woz9 finding 1. Pause `clear-flow` AFTER it has vacated the output
-  ;; path (the pre-fix gap), launch an input-changing dispatch on another
-  ;; thread, then resume `clear-flow` and assert that after it returns the
-  ;; registry / last-inputs rows are gone AND the output path is absent.
+  ;; Pause `clear-flow` AFTER it has vacated the output path, launch an
+  ;; input-changing dispatch on another thread, then resume `clear-flow` and
+  ;; assert that after it returns the registry / last-inputs rows are gone AND
+  ;; the output path is absent.
   ;;
   ;; The pause is injected by redefining the private `vacate-output-path!`
   ;; so it does its real work, signals "vacated", then blocks on a release
-  ;; latch — leaving `clear-flow` parked exactly in the pre-fix window while
-  ;; still HOLDING the drain-lock (the fix). The racing dispatch on thread B
-  ;; therefore cannot acquire the lock and run until `clear-flow` completes;
-  ;; it observes no flow and never re-commits the vacated output.
+  ;; latch — leaving `clear-flow` parked in the window while still HOLDING the
+  ;; drain-lock. The racing dispatch on thread B therefore cannot acquire the
+  ;; lock and run until `clear-flow` completes; it observes no flow and never
+  ;; re-commits the vacated output.
   (testing "a same-frame dispatch racing the vacate window cannot re-commit cleared output"
     (let [;; `vacate-output-path!` is private to the registry ns; reach it
           ;; through the var-quote reader (privacy gates bare-symbol
@@ -123,9 +121,9 @@
       (alter-var-root vacate-var
                       (constantly
                         (fn [frame-id path]
-                          ;; Real work first (the pre-fix order: vacate, THEN
-                          ;; the registry removal clear-flow does next), then
-                          ;; park in the window with the drain-lock held.
+                          ;; Real work first (vacate, THEN the registry removal
+                          ;; clear-flow does next), then park in the window
+                          ;; with the drain-lock held.
                           (orig-vacate frame-id path)
                           (.countDown vacated)
                           (await! release "clear-flow release"))))
@@ -134,11 +132,11 @@
               (future
                 (flows/clear-flow :doubled {:frame :rf/default}))
               ;; Thread B: once clear-flow has vacated (and is parked under
-              ;; the drain-lock), fire an input-changing event. Pre-fix this
-              ;; would slip into the window, recompute the still-registered
-              ;; flow, and re-commit :out. Post-fix it spin-CAS-waits on the
-              ;; drain-lock until clear-flow finishes, then drains against an
-              ;; empty flow registry and leaves :out absent.
+              ;; the drain-lock), fire an input-changing event. It
+              ;; spin-CAS-waits on the drain-lock until clear-flow finishes,
+              ;; then drains against an empty flow registry and leaves :out
+              ;; absent (without serialization it would slip into the window,
+              ;; recompute the still-registered flow, and re-commit :out).
               racer
               (future
                 (await! vacated "vacate")
@@ -146,14 +144,13 @@
                 (.countDown raced))]
           ;; Give the racer a real chance to RUN its dispatch inside the
           ;; vacate window before releasing clear-flow. Bounded wait, not a
-          ;; hard rendezvous: under the FIX the racer BLOCKS on the
-          ;; drain-lock (held by the parked clear-flow), so `raced` never
-          ;; trips here and we fall through after the timeout to release
-          ;; clear-flow — the racer then drains against an empty registry. A
-          ;; PRE-FIX build lets the racer complete its drain (and re-commit
-          ;; :out) within the window, tripping `raced` fast; the final
-          ;; assert below then catches the stale output. Either way we must
-          ;; not hang.
+          ;; hard rendezvous: the racer BLOCKS on the drain-lock (held by the
+          ;; parked clear-flow), so `raced` never trips here and we fall
+          ;; through after the timeout to release clear-flow — the racer then
+          ;; drains against an empty registry. (If the window were observable,
+          ;; the racer would complete its drain and re-commit :out, tripping
+          ;; `raced` fast, and the final assert below would catch the stale
+          ;; output.) Either way we must not hang.
           (await! vacated "vacate (main)")
           (.await raced 3 TimeUnit/SECONDS)
           (.countDown release)
@@ -177,24 +174,23 @@
           "the :flow registrar slot was vacated (last owner released the id)"))))
 
 ;; ---------------------------------------------------------------------------
-;; Finding 2 — a re-registration must re-evaluate on the next drain even when
+;; Surface 2 — a re-registration must re-evaluate on the next drain even when
 ;; a drain races the publish→invalidate window.
 ;; ---------------------------------------------------------------------------
 
 (deftest re-registration-recomputes-when-a-drain-races-the-invalidate-window
-  ;; rf2-2woz9 finding 2. Pause the `reg-flow` REPLACEMENT after it has
-  ;; published the new flow into `flows` but BEFORE `registrar/register!`
-  ;; fires the `invalidate-flow-on-replace!` hook that drops the stale
-  ;; `last-inputs` row (the pre-fix gap), dispatch an UNRELATED event on
-  ;; another thread, then resume and assert the first post-replacement drain
-  ;; materialises the NEW output.
+  ;; Pause the `reg-flow` REPLACEMENT after it has published the new flow into
+  ;; `flows` but BEFORE `registrar/register!` fires the
+  ;; `invalidate-flow-on-replace!` hook that drops the stale `last-inputs`
+  ;; row, dispatch an UNRELATED event on another thread, then resume and
+  ;; assert the first post-replacement drain materialises the NEW output.
   ;;
   ;; The pause is injected by redefining `registrar/register!` to signal
   ;; "published" then block on a release latch on the `:flow` kind only — so
-  ;; reg-flow parks in the window while still HOLDING the drain-lock (the
-  ;; fix). The racing dispatch on thread B cannot acquire the lock and run
-  ;; until reg-flow completes its invalidation; the drain then sees the new
-  ;; flow with a DROPPED last-inputs row and recomputes regardless of input
+  ;; reg-flow parks in the window while still HOLDING the drain-lock. The
+  ;; racing dispatch on thread B cannot acquire the lock and run until
+  ;; reg-flow completes its invalidation; the drain then sees the new flow
+  ;; with a DROPPED last-inputs row and recomputes regardless of input
   ;; equality.
   (testing "an unrelated dispatch racing the invalidate window still gets a fresh recompute"
     (let [orig-register registrar/register!
@@ -218,8 +214,8 @@
                         (do
                           ;; The new flow is ALREADY published into `flows`
                           ;; by reg-flow's swap! before this call; parking
-                          ;; here reproduces the pre-fix publish→invalidate
-                          ;; gap. Signal, block, THEN run the real register!
+                          ;; here opens the publish→invalidate window.
+                          ;; Signal, block, THEN run the real register!
                           ;; (which fires invalidate-flow-on-replace!).
                           (.countDown published)
                           (await! release "reg-flow release")
@@ -236,22 +232,22 @@
                              {:frame :rf/default}))
               ;; Thread B: once the new flow is published (but invalidation
               ;; not yet applied), dispatch an UNRELATED event. Its inputs
-              ;; ([:n]) are =-equal to the previous run, so pre-fix the drain
-              ;; would skip recompute and KEEP :out = 10. Post-fix it
-              ;; spin-CAS-waits on the drain-lock until reg-flow drops the
-              ;; stale last-inputs row, then recomputes :out = 500.
+              ;; ([:n]) are =-equal to the previous run; it spin-CAS-waits on
+              ;; the drain-lock until reg-flow drops the stale last-inputs row,
+              ;; then recomputes :out = 500. (Without serialization the drain
+              ;; would skip recompute on =-equal inputs and KEEP :out = 10.)
               racer
               (future
                 (await! published "publish")
                 (rf/dispatch-sync [:unrelated] {:frame :rf/default})
                 (.countDown raced))]
-          ;; Bounded wait (not a hard rendezvous): under the FIX the racer
-          ;; BLOCKS on the drain-lock held by the parked reg-flow, so `raced`
-          ;; never trips and we fall through to release after the timeout — a
-          ;; PRE-FIX build lets the racer drain within the publish→invalidate
-          ;; window (skipping recompute on =-equal inputs, keeping :out = 10),
-          ;; tripping `raced` fast. The final assert then catches the stale
-          ;; output. Either way we must not hang.
+          ;; Bounded wait (not a hard rendezvous): the racer BLOCKS on the
+          ;; drain-lock held by the parked reg-flow, so `raced` never trips and
+          ;; we fall through to release after the timeout. (If the window were
+          ;; observable, the racer would drain within it — skipping recompute
+          ;; on =-equal inputs, keeping :out = 10 — tripping `raced` fast, and
+          ;; the final assert would catch the stale output.) Either way we must
+          ;; not hang.
           (await! published "publish (main)")
           (.await raced 3 TimeUnit/SECONDS)
           (.countDown release)
@@ -274,18 +270,15 @@
           "the unrelated event's own write also landed"))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-4wqu6 finding 2 — clear-flow's flow lookup + `:output-path` capture must
-;; happen UNDER the drain-lock, not before it. A stale PRE-LOCK read can race
-;; a same-id same-frame `reg-flow` replacement that moves the output to a new
-;; `:output-path`, leaving clear-flow vacating the OLD (now-empty) path while the
-;; replacement's NEW path stays materialised after the flow is removed from
-;; the registry — a stale-derived-state leak (violating Spec 013's clear-flow
-;; cleanup contract) plus a misleading `:rf.flow/cleared` for the old path.
-;;
-;; This is DISTINCT from rf2-2woz9: that fix serialized clear-flow's
-;; vacate→deregister MUTATION against the drain, but left the lookup + path
-;; capture OUTSIDE the lock. rf2-4wqu6 finding 2 folds the lookup into the
-;; serialized region so the whole op runs over the SAME live flow definition.
+;; clear-flow's flow lookup + `:output-path` capture happen UNDER the
+;; drain-lock, not before it — folded into the serialized region so the whole
+;; op runs over the SAME live flow definition. A stale PRE-LOCK read could
+;; otherwise race a same-id same-frame `reg-flow` replacement that moves the
+;; output to a new `:output-path`, leaving clear-flow vacating the OLD
+;; (now-empty) path while the replacement's NEW path stays materialised after
+;; the flow is removed from the registry — a stale-derived-state leak
+;; (violating Spec 013's clear-flow cleanup contract) plus a misleading
+;; `:rf.flow/cleared` for the old path.
 ;; ---------------------------------------------------------------------------
 
 (deftest clear-flow-lookup-happens-under-the-lock-vs-a-racing-path-change-replacement
@@ -304,11 +297,10 @@
   ;; MATERIALISES :out-b. The drain completes, releases the lock, and B's
   ;; serialized region finally runs.
   ;;
-  ;;   PRE-FIX: B vacates the stale pre-lock `[:out-a]` (a no-op — already
-  ;;            empty) and removes the registry row, leaving the
-  ;;            replacement's materialised `[:out-b]` STALE in app-db.
-  ;;   POST-FIX: B reads the LIVE flow UNDER the lock — `[:out-b]` — and
-  ;;            vacates THAT, so no stale derived state remains.
+  ;;   B reads the LIVE flow UNDER the lock — `[:out-b]` — and vacates THAT,
+  ;;   so no stale derived state remains. (A stale pre-lock read would vacate
+  ;;   the already-empty `[:out-a]` and leave the replacement's materialised
+  ;;   `[:out-b]` STALE in app-db.)
   (testing "clear-flow vacates the replacement's NEW path, not the stale pre-lock OLD path"
     (let [in-handler (CountDownLatch. 1) ;; drain parked in handler, OLD flow live
           release    (CountDownLatch. 1)] ;; resume the handler → swap + materialise
@@ -327,16 +319,15 @@
       ;; reg-flow runs reentrantly inside the single-drainer window; the
       ;; drain's flow transform then materialises :out-b = 100 × :n = 500.
       ;;
-      ;; rf2-z980k8: the handler returns its db UNCHANGED — a PLAIN
-      ;; replacement, NO `(dissoc db :out-a)` workaround. The IN-DRAIN
-      ;; `reg-flow` `:output-path` move now records :out-a as a pending abandoned
-      ;; path; the drain's flow transform dissocs it from the pending `:db`
-      ;; BEFORE the deferred commit publishes that value, so the old-path
-      ;; value cannot be resurrected by the handler's returned db. The fact
-      ;; that the `:out-a absent` assertion below still holds with a plain
-      ;; handler is the load-bearing regression proof for the bug. (Pre-fix
-      ;; the only way to keep :out-a gone was the manual dissoc — the
-      ;; reentrant DIRECT vacate write was clobbered by this deferred commit.)
+      ;; The handler returns its db UNCHANGED — a PLAIN replacement, NO
+      ;; `(dissoc db :out-a)` workaround. The IN-DRAIN `reg-flow`
+      ;; `:output-path` move records :out-a as a pending abandoned path; the
+      ;; drain's flow transform dissocs it from the pending `:db` BEFORE the
+      ;; deferred commit publishes that value, so the old-path value cannot be
+      ;; resurrected by the handler's returned db. The `:out-a absent`
+      ;; assertion below holding with a plain handler is the load-bearing
+      ;; regression proof — a reentrant DIRECT vacate write would be clobbered
+      ;; by this deferred commit.
       (rf/reg-event :replace-scaled
                        (fn [{:keys [db]} _]
                          (.countDown in-handler)
@@ -353,9 +344,9 @@
             replacer (future (rf/dispatch-sync [:replace-scaled] {:frame :rf/default}))]
         ;; Wait until A's drain is parked in the handler.
         (await! in-handler "in-handler (main)")
-        ;; Thread B: clear :scaled. Pre-fix its pre-lock read captures the
-        ;; OLD `[:out-a]` now (A hasn't swapped yet); in BOTH versions it
-        ;; then blocks on the drain-lock A's drain holds.
+        ;; Thread B: clear :scaled. A pre-lock read would capture the OLD
+        ;; `[:out-a]` now (A hasn't swapped yet); B then blocks on the
+        ;; drain-lock A's drain holds.
         (let [clearer (future (flows/clear-flow :scaled {:frame :rf/default}))]
           ;; B must NOT complete while A holds the lock — it's blocked on the
           ;; drain-lock (bounded wait; B's pre-lock read, if any, is a few
@@ -378,9 +369,10 @@
           "last-inputs row gone")
       (is (nil? (registrar/lookup :flow :scaled))
           "the :flow registrar slot was vacated (last owner released)")
-      ;; THE FINDING-2 ASSERT: clear-flow vacated the REPLACEMENT's live path
-      ;; (:out-b), not the stale pre-lock :out-a. Pre-fix :out-b would linger
-      ;; (500) after the flow was removed from the registry.
+      ;; THE LOAD-BEARING ASSERT: clear-flow vacated the REPLACEMENT's live
+      ;; path (:out-b), not the stale pre-lock :out-a. A stale pre-lock read
+      ;; would leave :out-b lingering (500) after the flow was removed from
+      ;; the registry.
       (is (not (contains? (rf/app-db-value :rf/default) :out-b))
           (str ":out-b ABSENT — clear-flow read the LIVE flow under the lock "
                "and vacated the replacement's new path. Pre-fix it vacated the "
@@ -390,28 +382,29 @@
           ":out-a also absent (the replacement vacated it on the path change)"))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-z980k8 — an IN-DRAIN same-frame `reg-flow` `:output-path` move must NOT
-;; resurrect the OLD output through the deferred `:db` commit.
+;; An IN-DRAIN same-frame `reg-flow` `:output-path` move must NOT resurrect
+;; the OLD output through the deferred `:db` commit.
 ;; ---------------------------------------------------------------------------
 
 (deftest reg-flow-path-move-in-drain-does-not-resurrect-old-output
-  ;; THE behavioral bug (rf2-z980k8). A same-frame `reg-flow` REPLACEMENT
-  ;; that MOVES the output `:output-path` from [:out-a] to [:out-b], issued from
-  ;; INSIDE an event handler (reentrantly, mid-drain), must vacate [:out-a].
+  ;; A same-frame `reg-flow` REPLACEMENT that MOVES the output `:output-path`
+  ;; from [:out-a] to [:out-b], issued from INSIDE an event handler
+  ;; (reentrantly, mid-drain), must vacate [:out-a].
   ;;
-  ;; Pre-fix the `:output-path`-move vacate was a DIRECT app-db write made during the
-  ;; reentrant `reg-flow`. But the router runs flows over the PENDING `:db`
-  ;; (the handler's returned value, which still carries :out-a) and PUBLISHES
-  ;; that pending value via its single DEFERRED commit AFTER the handler
-  ;; returned — overwriting the direct vacate and RESURRECTING :out-a. The
-  ;; handler here returns its db UNCHANGED (no manual `(dissoc db :out-a)`),
-  ;; so the only thing that can keep :out-a gone is the framework making the
-  ;; vacate participate in the pending-`:db` transform the commit publishes.
+  ;; The router runs flows over the PENDING `:db` (the handler's returned
+  ;; value, which still carries :out-a) and PUBLISHES that pending value via
+  ;; its single DEFERRED commit AFTER the handler returns. A DIRECT app-db
+  ;; vacate write during the reentrant `reg-flow` would therefore be
+  ;; overwritten by that deferred commit, RESURRECTING :out-a — so the
+  ;; framework makes the vacate participate in the pending-`:db` transform the
+  ;; commit publishes. The handler here returns its db UNCHANGED (no manual
+  ;; `(dissoc db :out-a)`), so the framework vacate is the only thing keeping
+  ;; :out-a gone.
   ;;
-  ;; Single-threaded — no race, no latch: the resurrection is deterministic on
-  ;; the drain thread (the reentrant write then the deferred commit on the
-  ;; same thread). This is the load-bearing regression: PRE-FIX :out-a = 10
-  ;; survives; POST-FIX :out-a is absent and :out-b = 500 is present.
+  ;; Single-threaded — no race, no latch: the path is deterministic on the
+  ;; drain thread (the reentrant write then the deferred commit on the same
+  ;; thread). The load-bearing post-condition: :out-a is absent and
+  ;; :out-b = 500 is present.
   (testing "in-drain reg-flow :output-path move vacates the old path through the deferred commit"
     (rf/reg-event :seed (fn [_ _] {:db {:n 5}}))
     ;; OLD flow: :out-a = 2 × :n.
@@ -447,11 +440,10 @@
           "the live registry points :scaled at its new path [:out-b]"))))
 
 (deftest reg-flow-path-move-out-of-drain-vacates-directly
-  ;; The OUT-of-drain branch is unchanged by rf2-z980k8: a top-level (not
-  ;; reentrant) `reg-flow` `:output-path` move vacates the old path with a DIRECT
-  ;; app-db write — there is no pending deferred commit to clobber it. Pins
-  ;; that the call-shape split (`frame/in-drain?`) did not regress the
-  ;; existing direct-vacate path (rf2-73pi1).
+  ;; The OUT-of-drain branch: a top-level (not reentrant) `reg-flow`
+  ;; `:output-path` move vacates the old path with a DIRECT app-db write —
+  ;; there is no pending deferred commit to clobber it. Pins that the
+  ;; call-shape split (`frame/in-drain?`) keeps the direct-vacate path intact.
   (testing "out-of-drain reg-flow :output-path move vacates the old path immediately"
     (rf/reg-event :seed (fn [_ _] {:db {:n 5}}))
     (rf/reg-flow {:id     :scaled

--- a/implementation/flows/test/re_frame/flows_output_marks_test.clj
+++ b/implementation/flows/test/re_frame/flows_output_marks_test.clj
@@ -1,44 +1,38 @@
 (ns re-frame.flows-output-marks-test
-  "JVM coverage for Spec 015 §7 (Flows) data-classification on `reg-flow`
-  (rf2-ouemt — senior-review finding; rf2-ihfz9o — input→output PROPAGATION).
+  "JVM coverage for Spec 015 §7 (Flows) data-classification on `reg-flow`,
+  including input→output PROPAGATION.
 
   A `reg-flow` registration may carry output data-classification keys
   (`:rf.egress/output-sensitivity` derived-output sensitivity enum + `:large?`
-  whole-output size, `:sensitive` / `:large` per-output-path). Pre-fix these
-  were stashed in the frame-blind global
-  `re-frame.marks` `{flow-id marks}` table whose only reader (`flow-marks`)
-  was never wired into the central trace projection switch — so the contract
-  was silently inert: a `{:sensitive [[:secret]]}` or `{:rf.egress/output-sensitivity :rf.egress/sensitive}`
-  flow emitted its raw `:result` on `:rf.flow/computed` AND wrote the raw
-  value to its app-db destination slot (visible to App-DB-Diff / pending-db
-  egress / view render-arg egress).
+  whole-output size, `:sensitive` / `:large` per-output-path). Flow output
+  marks are FIRST-CLASS through the SAME per-frame app-db elision registry the
+  schema-first wire walker (`elision/elide-wire-value`) reads: `reg-flow`
+  translates the output-rooted marks into absolute declarations rooted at
+  `(:output-path flow)` and installs them frame-aware. ONE walker then redacts
+  BOTH the flow trace `:result` / `:before` slots AND the app-db destination
+  slot — so a `{:sensitive [[:secret]]}` or
+  `{:rf.egress/output-sensitivity :rf.egress/sensitive}` flow never egresses
+  its raw value on `:rf.flow/computed` or its app-db destination slot (visible
+  to App-DB-Diff / pending-db egress / view render-arg egress).
 
-  The fix (rf2-ouemt) makes flow output marks FIRST-CLASS through the SAME
-  per-frame app-db elision registry the schema-first wire walker
-  (`elision/elide-wire-value`) already reads: `reg-flow` translates the
-  output-rooted marks into absolute declarations rooted at `(:output-path flow)`
-  and installs them frame-aware. ONE walker then redacts BOTH the flow
-  trace `:result` / `:before` slots AND the app-db destination slot.
+  A flow OUTPUT INHERITS the data-classification of its INPUT paths
+  (Spec 015:313 + the 015:568 conformance fixture): a flow reading a SENSITIVE
+  app-db (or runtime-db-qualified) input emits a sensitive output BY DEFAULT
+  (fail-closed — taint by default, declassify explicitly) unless the author
+  opts out with `:rf.egress/output-sensitivity :rf.egress/public`. `:large` is
+  asymmetric and is NOT auto-propagated (a flow usually shrinks a large
+  input). `:rf.egress/output-sensitivity :rf.egress/public` is a REAL
+  declassify — it suppresses the propagated mark.
 
-  rf2-ihfz9o (Mike RULED (a) PROPAGATE, 2026-06-09) closes the privacy gap
-  the prior impl carried: a flow OUTPUT now INHERITS the data-classification
-  of its INPUT paths (Spec 015:313 + the 015:568 conformance fixture). A flow
-  reading a SENSITIVE app-db (or runtime-db-qualified, rf2-4eisfr) input
-  emits a sensitive output BY DEFAULT (fail-closed — taint by default,
-  declassify explicitly) unless the author opts out with `:rf.egress/output-sensitivity :rf.egress/public`.
-  `:large` is asymmetric and is NOT auto-propagated (a flow usually shrinks a
-  large input). `:rf.egress/output-sensitivity :rf.egress/public` is now a REAL declassify — it suppresses
-  the propagated mark (previously a no-op).
-
-  These tests pin the acceptance cases the bead enumerates:
+  These tests pin the acceptance cases:
     1. per-path flow output redaction (`:sensitive` / `:large` sub-paths);
     2. whole-output `:rf.egress/output-sensitivity :rf.egress/sensitive`;
     3. `:large` whole-output markers;
     4. `:rf.egress/output-sensitivity :rf.egress/public` declassify (the explicit opt-out);
     5. same-flow-id multi-frame registrations with DIFFERENT marks (frame
-       isolation — the frame-blind table would conflate them);
+       isolation — a frame-blind table would conflate them);
     6. lifecycle (clear-flow / path-change drop & move declarations);
-    7. PROPAGATION (rf2-ihfz9o) — default sensitive inheritance, explicit
+    7. PROPAGATION — default sensitive inheritance, explicit
        `:rf.egress/output-sensitivity :rf.egress/sensitive` over a sensitive input, explicit `:rf.egress/output-sensitivity :rf.egress/public`
        declassify of a sensitive input, per-output-path coexisting with
        propagation, BOTH `:sensitive` AND `:large` axes, runtime-db-qualified
@@ -49,9 +43,9 @@
             [re-frame.elision :as elision]
             [re-frame.error-emit :as error-emit]
             [re-frame.frame :as frame]
-            ;; EP-0015 (rf2-mngp4o): `add-marks` / `set-marks` are no longer
-            ;; on the `re-frame.core` façade; these tests drive the internal
-            ;; `re-frame.marks` helpers directly.
+            ;; `add-marks` / `set-marks` are not on the `re-frame.core`
+            ;; façade; these tests drive the internal `re-frame.marks` helpers
+            ;; directly.
             [re-frame.marks :as marks]
             [re-frame.privacy :as privacy]
             [re-frame.registrar :as registrar]
@@ -72,9 +66,9 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
+  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
+  ;; ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (let [captured (atom [])]
     (binding [*captured*           captured
@@ -190,8 +184,8 @@
         ;; the marker rides `:reason :flow`. That uniformity is the point —
         ;; one walker, one marker shape; the `:reason` records provenance
         ;; (`:flow` here, `:frame` for frame-owned `:large {:app-db …}`,
-        ;; `:marks` for marks-sourced). Per EP-0015 §8 schemas no longer
-        ;; feed this registry, so `:schema` is no longer a `:reason`.
+        ;; `:marks` for marks-sourced). Per Spec 015 §8 schemas do not feed
+        ;; this registry, so `:schema` is not a `:reason`.
         (is (= :flow (:reason marker))
             "marker rides the walker's :reason :flow stamp (reg-flow-sourced)")))))
 
@@ -268,9 +262,9 @@
 ;; 5. Same-flow-id multi-frame registrations with DIFFERENT marks
 ;;
 ;; Spec 013 lets the SAME flow-id carry different definitions — hence
-;; different marks — in different frames. The frame-blind `{flow-id marks}`
-;; table the old code used would conflate them (last-writer-wins). The
-;; frame-aware elision-registry install keeps them isolated by construction.
+;; different marks — in different frames. A frame-blind `{flow-id marks}`
+;; table would conflate them (last-writer-wins); the frame-aware
+;; elision-registry install keeps them isolated by construction.
 ;; ---------------------------------------------------------------------------
 
 (deftest same-flow-id-different-frames-different-marks-isolated
@@ -395,20 +389,19 @@
         ":b's stale declaration is cleared — re-registration replaces in full")))
 
 ;; ===========================================================================
-;; 8. PROPAGATION (rf2-ihfz9o — Mike RULED (a) PROPAGATE)
+;; 8. PROPAGATION
 ;;
 ;; A flow OUTPUT inherits the data-classification of its INPUT paths
 ;; (Spec 015:313 + the 015:568 conformance fixture). The cases below pin the
-;; bead's enumerated propagation coverage:
+;; propagation coverage:
 ;;   - default inheritance (no explicit key on the flow);
 ;;   - explicit `:rf.egress/output-sensitivity :rf.egress/sensitive` over a sensitive input (force-mark holds);
 ;;   - explicit `:rf.egress/output-sensitivity :rf.egress/public` declassify of a sensitive input (the
-;;     opt-out actively SUPPRESSES the propagated mark — previously a no-op);
+;;     opt-out actively SUPPRESSES the propagated mark);
 ;;   - per-output-path marks coexisting with whole-output propagation;
 ;;   - both `:sensitive` AND `:large` axes (the asymmetry: :sensitive
 ;;     propagates, :large does NOT);
-;;   - runtime-db-qualified `[:rf.db/runtime …]` inputs (compose with
-;;     rf2-4eisfr — partition-aware);
+;;   - runtime-db-qualified `[:rf.db/runtime …]` inputs (partition-aware);
 ;;   - flow→flow DAG propagation (a flow reading an upstream flow's :output-path);
 ;;   - the t2 `:rf.event/db-pending-post-flow` redaction (Spec 015:568).
 ;; ===========================================================================
@@ -610,19 +603,18 @@
         "the output derived from a sensitive runtime-db slot is redacted")))
 
 (deftest runtime-db-qualified-input-value-is-elided-on-computed-trace
-  ;; rf2-p44r3u — the INPUT-VALUE leg of the runtime-qualified path. The
+  ;; The INPUT-VALUE leg of the runtime-qualified path. The
   ;; `propagation-runtime-db-qualified-input` test above proves the derived
   ;; OUTPUT is redacted; this proves the INPUT VALUE the flow read does not
-  ;; egress raw on the `:rf.flow/computed` `:input-values` slot. Pre-fix,
-  ;; `elide-inputs` seeded `elide-wire-value` with the DECLARED input path
-  ;; `[:rf.db/runtime :rf.runtime/routing :current :token]`, but the sensitive
-  ;; declaration is keyed at the STRIPPED runtime-db path
-  ;; `[:rf.runtime/routing :current :token]` (the registry is partition-blind),
-  ;; so the seed path never matched the declaration and the raw "RT-SECRET"
-  ;; rode the input-values slot. The fix normalizes the runtime-qualified
-  ;; input path (strip the partition key) before the elision walk, reusing the
-  ;; SAME registry normalization (`input-resolve-path`) the propagation path
-  ;; already uses.
+  ;; egress raw on the `:rf.flow/computed` `:input-values` slot. `elide-inputs`
+  ;; normalizes the runtime-qualified input path (strip the partition key)
+  ;; before the elision walk — reusing the SAME registry normalization
+  ;; (`input-resolve-path`) the propagation path uses — so the elision seed
+  ;; path matches the sensitive declaration, which is keyed at the STRIPPED
+  ;; runtime-db path `[:rf.runtime/routing :current :token]` (the registry is
+  ;; partition-blind). Without that strip the seed path
+  ;; `[:rf.db/runtime :rf.runtime/routing :current :token]` would never match
+  ;; the declaration and the raw "RT-SECRET" would ride the input-values slot.
   (testing "a sensitive runtime-db-qualified input value is elided (not raw)
             on the `:rf.flow/computed` `:input-values` slot"
     (reg-fw-runtime-handler! :seed-rt
@@ -647,11 +639,11 @@
            raw [:rf.db/runtime …] seed path) — the raw token never egresses"))))
 
 (deftest runtime-db-qualified-input-value-is-elided-on-failed-trace
-  ;; rf2-p44r3u — the SAME normalization must apply on the FAILURE path. A
-  ;; flow reading a sensitive runtime-db-qualified input whose `:derive`
-  ;; THROWS must not leak the raw input value on the `:rf.flow/failed`
-  ;; `:inputs` slot either (the trace bus is the wire boundary on both the
-  ;; success and the failure paths — `elide-inputs` is shared).
+  ;; The SAME normalization applies on the FAILURE path. A flow reading a
+  ;; sensitive runtime-db-qualified input whose `:derive` THROWS must not leak
+  ;; the raw input value on the `:rf.flow/failed` `:inputs` slot either (the
+  ;; trace bus is the wire boundary on both the success and the failure
+  ;; paths — `elide-inputs` is shared).
   (testing "a sensitive runtime-db-qualified input value is elided (not raw)
             on the `:rf.flow/failed` `:inputs` slot"
     (reg-fw-runtime-handler! :seed-rt
@@ -672,17 +664,17 @@
            path's :inputs slot — the raw token never egresses"))))
 
 (deftest runtime-db-whole-value-effect-preserves-flow-elision-declarations
-  ;; rf2-gom797 — a durable `:rf.db/runtime` whole-value effect must NOT clobber
-  ;; the elision declaration registry that lives in the SAME runtime-db
-  ;; partition at `[:rf.runtime/elision …]`. Pre-fix, `commit-frame-transition!`
-  ;; installed the effect's whole-value runtime-db verbatim, dropping every
-  ;; reserved `:rf.runtime/*` subsystem child (incl. `:rf.runtime/elision`) the
-  ;; effect did not itself carry — so a framework-authority event that seeded
-  ;; `:rf.runtime/routing` left the frame with NO flow-sourced elision
-  ;; declarations after commit, even though they were correctly read pre-commit
-  ;; (the existing `propagation-runtime-db-qualified-input` only asserts the
-  ;; SAME-event redaction, which reads the pre-commit registry). This regression
-  ;; pins POST-COMMIT declaration survival.
+  ;; A durable `:rf.db/runtime` whole-value effect must NOT clobber the
+  ;; elision declaration registry that lives in the SAME runtime-db partition
+  ;; at `[:rf.runtime/elision …]`. `commit-frame-transition!` preserves every
+  ;; reserved `:rf.runtime/*` subsystem child (incl. `:rf.runtime/elision`)
+  ;; the effect did not itself carry — so a framework-authority event that
+  ;; seeds `:rf.runtime/routing` leaves the frame's flow-sourced elision
+  ;; declarations intact after commit. (`propagation-runtime-db-qualified-input`
+  ;; only asserts the SAME-event redaction, which reads the pre-commit
+  ;; registry; this test pins POST-COMMIT declaration survival — installing
+  ;; the effect's whole-value runtime-db verbatim would drop the reserved
+  ;; children.)
   (testing "a durable `:rf.db/runtime` whole-value commit preserves the
             flow-sourced elision declarations (the registry is a reserved
             `:rf.runtime/elision` sibling, not application runtime-db)"
@@ -704,8 +696,8 @@
         "the propagated flow output declaration is present before dispatch")
     (reset! *captured* [])
     (rf/dispatch-sync [:seed-rt])
-    ;; POST-COMMIT — the bug: a whole-value :rf.db/runtime commit must NOT have
-    ;; wiped the elision registry. Both declarations must survive.
+    ;; POST-COMMIT: a whole-value :rf.db/runtime commit must NOT wipe the
+    ;; elision registry. Both declarations must survive.
     (is (contains? (sensitive-decls :rf/default) [:rf.runtime/routing :current :token])
         "the directly-marked runtime-db input declaration SURVIVES the durable runtime-db commit")
     (is (contains? (sensitive-decls :rf/default) [:derived :route-token])
@@ -720,16 +712,16 @@
         "the :rf.runtime/elision subsystem child coexists with :rf.runtime/routing post-commit")))
 
 (deftest drain-time-propagated-mark-survives-same-event-runtime-effect
-  ;; rf2-upx16k — the PRIVACY FAIL-OPEN the gom797 test above misses.
+  ;; The drain-time propagated-mark survival path that
+  ;; `runtime-db-whole-value-effect-preserves-flow-elision-declarations`
+  ;; does not cover.
   ;;
-  ;; gom797 (`runtime-db-whole-value-effect-preserves-flow-elision-declarations`)
-  ;; marks the input BEFORE dispatch, so the propagated output declaration is
-  ;; already in the LIVE registry — and, crucially, also in the chain-start
-  ;; `runtime-before` snapshot the router captured by reference. Reconciling the
-  ;; runtime effect against THAT snapshot still carries the declaration forward,
-  ;; so the bug stays hidden.
+  ;; That test marks the input BEFORE dispatch, so the propagated output
+  ;; declaration is already in the LIVE registry — and also in the chain-start
+  ;; `runtime-before` snapshot the router captured by reference. Reconciling
+  ;; the runtime effect against THAT snapshot carries the declaration forward.
   ;;
-  ;; This test exercises the missed path: the propagated output mark
+  ;; This test exercises the distinct path: the propagated output mark
   ;; MATERIALISES ONLY AT THE DRAIN-TIME TOPO REFRESH (the input is marked AFTER
   ;; reg-flow, so it is absent at reg-flow time — the
   ;; `propagation-fires-when-mark-added-AFTER-reg-flow` scenario). The refresh
@@ -737,15 +729,15 @@
   ;; `[:rf.runtime/elision]` slot DURING the `:after` chain — AFTER the router
   ;; captured `runtime-before` (the pre-handler coeffect, injected by reference
   ;; at chain start, whose elision slot is PRE-refresh). When the SAME event's
-  ;; handler ALSO returns a `:rf.db/runtime` effect SILENT about elision,
-  ;; reconciling against the stale `runtime-before` carries the PRE-refresh
-  ;; (mark-less) registry forward and the commit OVERWRITES the just-written
-  ;; `[:derived]` declaration — so the flow-derived sensitive output egresses
-  ;; RAW on the same event's db egress (and would stay raw until the next drain
-  ;; re-propagates). The fix reconciles against the LIVE runtime-db read at
-  ;; commit, so the freshly-propagated mark survives. Framework-authority
-  ;; handlers return runtime effects routinely (routing / machines), so this is
-  ;; not exotic.
+  ;; handler ALSO returns a `:rf.db/runtime` effect SILENT about elision, the
+  ;; commit reconciles against the LIVE runtime-db read at commit (not the
+  ;; stale chain-start `runtime-before` snapshot), so the freshly-propagated
+  ;; `[:derived]` declaration survives and the flow-derived sensitive output
+  ;; does NOT egress raw on the same event's db egress. (Reconciling against
+  ;; the PRE-refresh, mark-less `runtime-before` snapshot would carry the
+  ;; mark-less registry forward and overwrite the just-written declaration.)
+  ;; Framework-authority handlers return runtime effects routinely (routing /
+  ;; machines), so this is not exotic.
   (testing "a flow output mark freshly propagated at the drain-time refresh
             SURVIVES a same-event `:rf.db/runtime` effect commit — the derived
             slot does NOT egress raw (privacy mark is not overwritten by the
@@ -783,17 +775,17 @@
         "the framework-authority runtime-db effect committed durably")
     (is (some? (get (frame/frame-runtime-db-value :rf/default) :rf.runtime/elision))
         "the :rf.runtime/elision subsystem child coexists with :rf.runtime/routing post-commit")
-    ;; THE LOAD-BEARING PRIVACY ASSERTION (the channel the bug leaks on):
-    ;; egress the COMMITTED app-db through the wire-walker, which reads the
-    ;; COMMITTED runtime-db `[:rf.runtime/elision]` registry (`registry-of` →
-    ;; the live container). This is the db-diff / view / sub egress channel.
-    ;; Pre-fix the commit overwrote the freshly-propagated [:derived] mark
-    ;; (reconciled against the stale chain-start runtime-before snapshot), so
-    ;; the derived slot egressed RAW here. Post-fix the mark survives the
-    ;; commit, so the slot redacts. (The t2/computed-result trace assertions
-    ;; below project DURING the chain against the post-refresh LIVE registry, so
-    ;; they redact in BOTH the buggy and fixed cases — they do NOT distinguish
-    ;; the bug; this committed-registry egress is the one that does.)
+    ;; THE LOAD-BEARING PRIVACY ASSERTION (the channel most exposed to the
+    ;; leak): egress the COMMITTED app-db through the wire-walker, which reads
+    ;; the COMMITTED runtime-db `[:rf.runtime/elision]` registry (`registry-of`
+    ;; → the live container). This is the db-diff / view / sub egress channel.
+    ;; The mark survives the commit, so the derived slot redacts here; a commit
+    ;; that overwrote the freshly-propagated [:derived] mark (reconciling
+    ;; against the stale chain-start runtime-before snapshot) would egress it
+    ;; RAW. (The t2/computed-result trace assertions below project DURING the
+    ;; chain against the post-refresh LIVE registry, so they redact regardless
+    ;; — they do NOT distinguish this case; this committed-registry egress is
+    ;; the one that does.)
     (let [committed-db (frame/frame-app-db-value :rf/default)
           egressed     (binding [frame/*current-frame* :rf/default]
                          (elision/elide-wire-value committed-db {:frame :rf/default}))]
@@ -893,21 +885,17 @@
         "the output rides raw after declassification of the input")))
 
 ;; ---------------------------------------------------------------------------
-;; 8. Malformed classification metadata is rejected FAIL-CLOSED (rf2-cgk0wb)
+;; 8. Malformed classification metadata is rejected FAIL-CLOSED
 ;;
-;; Pre-fix, the OPTIONAL output data-classification keys fail-OPEN:
-;;   - `explicit-flow-output-mark-paths` silently `(filter vector?)`-dropped
-;;     malformed `:sensitive` / `:large` entries (`:sensitive [:token]`,
-;;     `:large "blob"`), and
-;;   - only a LITERAL `true` was honoured for `:sensitive?` / `:large?`, so a
-;;     present-but-malformed `:sensitive? :yes` / `:large? 1` behaved as ABSENT.
-;; A privacy/size declaration typo therefore registered with a normal return
-;; value and NO diagnostic, while the intended redaction NEVER happened — the
-;; worst failure mode for a safety feature. `validate-flow` now rejects each
-;; malformation at the API boundary with the `:rf.error/flow-bad-marks`
-;; discriminator BEFORE any registry / app-db / elision-declaration state
-;; mutates. These tests pin the rejection id + the canonical thrown-error
-;; shape, and prove NO flow row and NO elision declaration is installed.
+;; The OPTIONAL output data-classification keys are validated FAIL-CLOSED: a
+;; privacy/size declaration typo (`:sensitive [:token]` instead of
+;; `[[:token]]`, `:large "blob"`, `:large? 1`) is rejected rather than
+;; silently registering with no redaction installed — the worst failure mode
+;; for a safety feature. `validate-flow` rejects each malformation at the API
+;; boundary with the `:rf.error/flow-bad-marks` discriminator BEFORE any
+;; registry / app-db / elision-declaration state mutates. These tests pin the
+;; rejection id + the canonical thrown-error shape, and prove NO flow row and
+;; NO elision declaration is installed.
 ;; ---------------------------------------------------------------------------
 
 (defn- flow-row?
@@ -934,7 +922,7 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-bad-marks (:rf.error/id data))
           ":rf.error/id carries the bad-marks discriminator")
-      ;; rf2-vvixub — message is the human :reason sentence + the trailing
+      ;; The message is the human :reason sentence + the trailing
       ;; [:rf.error/<id>] token; assert the token substring, not equality.
       (is (re-find #"\[:rf\.error/flow-bad-marks\]" (ex-message ex))
           "message carries the [:rf.error/flow-bad-marks] token")

--- a/implementation/flows/test/re_frame/flows_path_cljs_test.cljc
+++ b/implementation/flows/test/re_frame/flows_path_cljs_test.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.flows-path-cljs-test
-  "rf2-du585y — CLJS-host coverage for flow :output-path / overlap semantics
+  "CLJS-host coverage for flow :output-path / overlap semantics
   (EP-0012 §The :rf/path algebra).
 
   The flow path validation (`valid-path?` → `re-frame.path/segment?`) and the

--- a/implementation/flows/test/re_frame/flows_path_overlap_test.clj
+++ b/implementation/flows/test/re_frame/flows_path_overlap_test.clj
@@ -1,23 +1,19 @@
 (ns re-frame.flows-path-overlap-test
-  "Per rf2-um6d9 — overlapping output `:output-path`s between sibling flows are
-  rejected at registration.
+  "Overlapping output `:output-path`s between sibling flows are rejected at
+  registration.
 
-  THE FINDING (senior-dev review rf2-y7lm8): the topo dependency rule
-  (`topo/depends-on?`, Spec 013 §Topological sort) compares ONLY flow A's
-  `:output-path` against flow B's `:inputs` — never `:output-path` vs `:output-path`. So two
-  flows in the SAME frame whose OUTPUT `:output-path`s overlap (one a prefix of
-  the other, identical included) but whose `:inputs` are disjoint from
-  each other's outputs get NO dependency edge. Both are 'ready' at
-  topo-sort start; their relative evaluation order falls out of
-  `(keys flow-map)` map-iteration order — a non-contract — so the shared
-  app-db slot is written last-write-wins, non-deterministically, with no
-  detection and no warning.
-
-  THE FIX: detect-and-reject at `reg-flow`, symmetric with the existing
-  cycle check and inside the same atomic `swap!` — two registered flows on
-  the same frame with overlapping output `:output-path`s is an error
-  (`:rf.error/flow-path-overlap`). See `topo/detect-output-path-overlap!`
-  and the registry `reg-flow` update fn.
+  The topo dependency rule (`topo/depends-on?`, Spec 013 §Topological sort)
+  compares ONLY flow A's `:output-path` against flow B's `:inputs` — never
+  `:output-path` vs `:output-path`. So two flows in the SAME frame whose OUTPUT
+  `:output-path`s overlap (one a prefix of the other, identical included) but
+  whose `:inputs` are disjoint from each other's outputs would get NO
+  dependency edge: both 'ready' at topo-sort start, their relative evaluation
+  order falling out of `(keys flow-map)` map-iteration order — a non-contract —
+  so the shared app-db slot would be written last-write-wins,
+  non-deterministically. So `reg-flow` detect-and-rejects such a pair,
+  symmetric with the cycle check and inside the same atomic `swap!`
+  (`:rf.error/flow-path-overlap`). See `topo/detect-output-path-overlap!` and
+  the registry `reg-flow` update fn.
 
   This file pins both ends:
     - the pure `topo` helpers (`output-paths-overlap?` /
@@ -26,11 +22,10 @@
       registration, the prior registration survives, and DISJOINT
       sibling outputs (the common, valid case) still register cleanly.
 
-  TERMINATION NOTE (rf2-um6d9 redo): `detect-output-path-overlap!` scans
-  the upper triangle of the frame's flow pairs via `(some ... (for ...))`
-  — terminating by construction. The disjoint-map and disjoint-sibling
-  tests below are the explicit regression guard: pre-fix the scan looped
-  forever on any frame with ≥2 disjoint flows, hanging the whole JVM suite."
+  TERMINATION NOTE: `detect-output-path-overlap!` scans the upper triangle of
+  the frame's flow pairs via `(some ... (for ...))` — terminating by
+  construction. The disjoint-map and disjoint-sibling tests below are the
+  explicit guard that the scan terminates on any frame with ≥2 disjoint flows."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
@@ -52,8 +47,8 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
+  ;; under no scope raises :rf.error/no-frame-context. Pin
   ;; :rf/default (an ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (binding [frame/*current-frame* :rf/default]
@@ -101,9 +96,8 @@
 
 (deftest detect-output-path-overlap!-passes-disjoint-map
   (testing "a frame map of pairwise-disjoint output paths passes (returns the map unchanged) — and TERMINATES"
-    ;; REGRESSION GUARD (rf2-um6d9 redo): pre-fix the scan looped forever on
-    ;; a ≥2-flow disjoint map; this assertion only completes if the scan
-    ;; terminates.
+    ;; TERMINATION GUARD: the scan must terminate on a ≥2-flow disjoint map;
+    ;; this assertion only completes if it does.
     (let [flow-map {:a {:id :a :inputs [[:w]] :derive identity :output-path [:x :a]}
                     :b {:id :b :inputs [[:h]] :derive identity :output-path [:x :b]}
                     :c {:id :c :inputs [[:q]] :derive identity :output-path [:y]}}]
@@ -164,15 +158,15 @@
           "repeated detection yields an identical :overlap (deterministic ordering)"))))
 
 (deftest detect-output-path-overlap!-pair-ordering-invariant-to-iteration-order
-  ;; rf2-tx1ub — the reported :overlap pair must be GENUINELY deterministic
-  ;; across runs, not merely run-stable. The prior `sort-by hash` tie-break
-  ;; left the lo/hi assignment undefined on a hash collision: `sort-by` is
-  ;; stable and would fall back to the INPUT (map-iteration) order, which is
-  ;; not a cross-run contract for Clojure hash-maps. The `(juxt hash str)`
-  ;; tie-break makes the result depend only on the ids' VALUES, so feeding
-  ;; the same logical pair in opposite iteration orders MUST yield the same
-  ;; reported pair. Insertion-ordered array-maps below stand in for the two
-  ;; possible cross-run iteration orders.
+  ;; The reported :overlap pair must be GENUINELY deterministic across runs,
+  ;; not merely run-stable. A bare `sort-by hash` tie-break would leave the
+  ;; lo/hi assignment undefined on a hash collision: `sort-by` is stable and
+  ;; would fall back to the INPUT (map-iteration) order, which is not a
+  ;; cross-run contract for Clojure hash-maps. The `(juxt hash str)` tie-break
+  ;; makes the result depend only on the ids' VALUES, so feeding the same
+  ;; logical pair in opposite iteration orders MUST yield the same reported
+  ;; pair. Insertion-ordered array-maps below stand in for the two possible
+  ;; cross-run iteration orders.
   (testing "the reported pair is invariant to flow-map iteration order"
     (let [flow-a {:id :a :inputs [[:w]] :derive identity :output-path [:x]}
           flow-b {:id :b :inputs [[:h]] :derive identity :output-path [:x]}
@@ -214,12 +208,11 @@
 
 (deftest reg-flow-rejects-overlapping-output-paths-with-disjoint-inputs
   (testing "rf2-um6d9 — two same-frame flows whose OUTPUT :paths overlap but whose INPUTS are disjoint are rejected at registration"
-    ;; This is the exact silent-footgun shape: A reads [:src-a] writes
-    ;; [:dest]; B reads [:src-b] writes [:dest]. Inputs are disjoint
-    ;; (neither reads the other's output) so the topo dependency rule
-    ;; produces NO edge — pre-fix both were 'ready' and the shared slot
-    ;; [:dest] was written in undefined order. Post-fix the second
-    ;; registration is rejected.
+    ;; The silent-footgun shape: A reads [:src-a] writes [:dest]; B reads
+    ;; [:src-b] writes [:dest]. Inputs are disjoint (neither reads the other's
+    ;; output) so the topo dependency rule produces NO edge — both would be
+    ;; 'ready' and the shared slot [:dest] would be written in undefined order.
+    ;; So the second registration is rejected.
     (rf/reg-flow {:id :a :inputs [[:src-a]] :derive identity :output-path [:dest]})
     (let [thrown (try
                    (rf/reg-flow {:id :b :inputs [[:src-b]] :derive identity :output-path [:dest]})
@@ -240,8 +233,8 @@
 
 (deftest reg-flow-allows-disjoint-sibling-output-paths
   (testing "rf2-um6d9 — flows writing to DISJOINT sibling paths under a shared parent register cleanly (the common valid case is unaffected) — and TERMINATES"
-    ;; REGRESSION GUARD (rf2-um6d9 redo): the integrated equivalent of the
-    ;; disjoint-map test — pre-fix this reg-flow call hung the suite.
+    ;; TERMINATION GUARD: the integrated equivalent of the disjoint-map test —
+    ;; this reg-flow call must complete, not hang the suite.
     (rf/reg-flow {:id :w :inputs [[:in-w]] :derive identity :output-path [:rect :w]})
     (rf/reg-flow {:id :h :inputs [[:in-h]] :derive identity :output-path [:rect :h]})
     (let [committed (get (flows/flows-snapshot) :rf/default)]

--- a/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
+++ b/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
@@ -1,35 +1,26 @@
 (ns re-frame.flows-per-frame-last-inputs-test
-  "Per rf2-94ol5 — the failed-flow rollback in `run-flows-on-db` must be
-  scoped to the DRAINING frame's own `last-inputs` container and MUST NOT
-  clobber a concurrently-draining sibling frame's dirty-check rows.
+  "The failed-flow rollback in `run-flows-on-db` is scoped to the DRAINING
+  frame's own `last-inputs` container and MUST NOT clobber a
+  concurrently-draining sibling frame's dirty-check rows.
 
-  THE BUG (pre-fix). `last-inputs` was a single global atom shaped
-  `{flow-id {frame-id inputs}}`. `run-flows-on-db` snapshotted the WHOLE
-  atom (all frames' rows) at drain start and, on a flow throw, `reset!`-
-  restored the whole thing. Correct for the draining frame, but over-broad:
-  it reverted EVERY frame's rows. Drain-locks are PER-FRAME (no global
-  cross-frame serialization — Spec 002 rule 1 + the flows concurrency
-  stress test rely on frames draining in parallel on different JVM
-  threads), so:
+  Each frame owns its OWN `last-inputs` container (`atom {flow-id inputs}`),
+  held in the flows registry's `frame-last-inputs` map keyed by frame-id. The
+  rollback snapshots / restores ONLY the draining frame's atom — a sibling's
+  container is a different atom and is structurally untouchable. Cross-frame
+  interference is impossible BY CONSTRUCTION, not merely avoided.
 
-    1. Frame A drain (thread 1) snapshots the global atom (B's row = V1).
-    2. Frame B drain (thread 2) advances B's row to V2 and commits.
-    3. Frame A's flow throws → reset! reverts the global atom → B's row
-       reverts to V1.
-
-  Consequence: B's app-db is correctly committed but its dirty-check row
-  is stale (V1). On B's NEXT drain with the SAME inputs (V2), `(= V2 V1)`
-  is false → the flow recomputes the same value, re-emits
-  `:rf.flow/computed`, produces a no-op `:db` write → spurious
-  `:rf.event/db-changed` + reactive sub invalidation. A frame-isolation
-  contract violation (Spec 002 §Rules rule 1 / Spec 013 §Frame-scoping).
-
-  THE FIX (Mike ruled B, 2026-06-01). Each frame owns its OWN `last-inputs`
-  container (`atom {flow-id inputs}`), held in the flows registry's
-  `frame-last-inputs` map keyed by frame-id. The rollback snapshots /
-  restores ONLY the draining frame's atom — a sibling's container is a
-  different atom and is structurally untouchable. Cross-frame interference
-  is impossible BY CONSTRUCTION, not merely avoided.
+  Why this matters under concurrency: drain-locks are PER-FRAME (no global
+  cross-frame serialization — Spec 002 rule 1 + the flows concurrency stress
+  test rely on frames draining in parallel on different JVM threads). A
+  rollback that reverted EVERY frame's rows would be wrong: while frame A's
+  drain is between snapshot and throw, frame B could advance and commit its
+  own row on another thread, and A's restore would revert B's just-advanced
+  row. B's app-db would be correctly committed but its dirty-check row stale —
+  so B's next drain with the SAME inputs would see `(= V2 V1)` false, recompute
+  the same value, re-emit `:rf.flow/computed`, produce a no-op `:db` write, and
+  trigger a spurious `:rf.event/db-changed` + reactive sub invalidation: a
+  frame-isolation contract violation (Spec 002 §Rules rule 1 / Spec 013
+  §Frame-scoping). Per-frame containers make that scenario unreachable.
 
   CLJS is single-threaded; the concurrency surface is JVM-only by design.
   This namespace is JVM-only (`.clj`)."
@@ -73,11 +64,11 @@
 ;; 1. Deterministic unit-level repro — the rollback must touch ONLY the
 ;;    draining frame's container (no thread interleaving needed).
 ;;
-;; This is the bead's "easiest unit-level repro": seed frame B's row to V2
-;; directly (simulating B's just-committed advance), then drive frame A's
-;; throwing-flow drain via the late-bound `run-flows-on-db`. A's drain-start
-;; snapshot predates nothing of B's — B lives in its own atom. Assert B's
-;; row is NOT reverted. Pre-fix the global `reset!` would have clobbered it.
+;; The easiest unit-level repro of the isolation invariant: seed frame B's
+;; row to V2 directly (simulating B's just-committed advance), then drive
+;; frame A's throwing-flow drain via the late-bound `run-flows-on-db`. A's
+;; drain-start snapshot touches nothing of B's — B lives in its own atom.
+;; Assert B's row is NOT reverted; a global rollback would clobber it.
 ;; ---------------------------------------------------------------------------
 
 (deftest rollback-does-not-clobber-sibling-frame-row-deterministic
@@ -151,7 +142,7 @@
           ":B never advanced (it threw)"))))
 
 ;; ---------------------------------------------------------------------------
-;; 3. JVM concurrency stress — the gap that hid the bug.
+;; 3. JVM concurrency stress — the interleaving the isolation guards.
 ;;
 ;; Frame A repeatedly drains a flow that ALWAYS throws; frame B repeatedly
 ;; drains a SUCCESSFUL flow whose inputs are STABLE after the first drain.
@@ -161,11 +152,11 @@
 ;; Invariant: B's flow `:derive` fires EXACTLY ONCE across all of B's
 ;; drains. The first drain recomputes (input changed from absent → [7]);
 ;; every subsequent drain has IDENTICAL inputs ([7] each time) so the
-;; dirty-check MUST skip. Pre-fix, frame A's concurrent throwing-drain
-;; would `reset!` the global atom and clobber B's just-advanced row, so
-;; B's next same-input drain would spuriously recompute — driving the
-;; `:derive` count above 1. With per-frame containers B's row is in its
-;; own atom and A's rollback can't reach it, so the count stays at 1.
+;; dirty-check MUST skip. A global-atom rollback would let frame A's
+;; concurrent throwing-drain clobber B's just-advanced row, so B's next
+;; same-input drain would spuriously recompute — driving the `:derive` count
+;; above 1. With per-frame containers B's row is in its own atom and A's
+;; rollback can't reach it, so the count stays at 1.
 ;;
 ;; A secondary invariant pins the consequence chain: B emits exactly ONE
 ;; `:rf.flow/computed` trace (the first, genuine recompute) — never a
@@ -245,8 +236,8 @@
 
           (trace/unregister-listener! ::b-computed-watch)
 
-          ;; THE INVARIANT: B's :derive fired exactly once. Pre-fix, A's
-          ;; concurrent rollback clobbering B's row would push this above 1.
+          ;; THE INVARIANT: B's :derive fired exactly once. A concurrent
+          ;; rollback clobbering B's row would push this above 1.
           (is (= 1 (.get b-output-calls))
               (str "B's flow :derive must fire EXACTLY once (the genuine "
                    "first recompute); every later same-input drain must "

--- a/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
+++ b/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
@@ -51,7 +51,7 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; EP-0002: reg-flow is context-required frame-local — an
   ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
   ;; :rf/default (an ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)

--- a/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
+++ b/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
@@ -1,37 +1,25 @@
 (ns re-frame.flows-reg-flow-toctou-test
-  "Per rf2-qxwib — JVM regression coverage for the reg-flow
-  check-and-insert TOCTOU.
+  "JVM regression coverage for the reg-flow check-and-insert atomicity.
 
-  THE BUG (pre-fix): `reg-flow`'s cycle detection was check-THEN-act.
-  It read `@flows` once, built a PROSPECTIVE flow-map, ran
-  `topo/topo-sort` on it, and — in a SEPARATE step — committed via
-  `swap!`. Two threads registering on the SAME frame two flows that
-  together form a dependency cycle (T1 registers A whose `:inputs` read
-  B's `:output-path`; T2 registers B whose `:inputs` read A's `:output-path`) could
-  interleave so that BOTH read the frame's pre-cycle state, BOTH pass
-  their individual prospective check (neither sees the other's
-  not-yet-committed flow), and BOTH commit — leaving a CYCLIC registry.
-  Drain-time topo-sort then throws `:rf.error/flow-cycle` on every drain
-  of that frame, defeating the Spec 013 §Cycle detection promise that a
-  cycle is caught AT REGISTRATION.
-
-  THE FIX: fold the cycle check INTO the `swap!` update fn so the
-  read-validate-commit is one atomic compare-and-set. The update fn
-  reads the committed frame-map, runs topo-sort on the prospective map,
-  and only returns the assoc'd map if that passes. `swap!` re-invokes
-  the update fn (re-reading committed state, re-validating) on
-  contention, so once ONE of the racing pair commits, the OTHER's retry
-  sees the committed edge and its topo-sort throws — exactly one of the
-  pair is admitted, and the committed registry is NEVER cyclic.
+  `reg-flow`'s cycle check and commit are ONE atomic compare-and-set: the
+  `swap!` update fn reads the committed frame-map, runs `topo/topo-sort` on
+  the prospective map, and only returns the assoc'd map if that passes.
+  `swap!` re-invokes the update fn (re-reading committed state, re-validating)
+  on contention, so two threads registering on the SAME frame two flows that
+  together form a dependency cycle (T1 registers A whose `:inputs` read B's
+  `:output-path`; T2 registers B whose `:inputs` read A's `:output-path`)
+  cannot both commit: once ONE of the racing pair commits, the OTHER's retry
+  sees the committed edge and its topo-sort throws. Exactly one of the pair is
+  admitted, and the committed registry is NEVER cyclic — upholding the Spec
+  013 §Cycle detection promise that a cycle is caught AT REGISTRATION (a
+  cyclic registry would otherwise throw `:rf.error/flow-cycle` on every drain).
 
   CLJS is single-threaded; this race is JVM-only by construction. The
-  rf2-ztw5p concurrency-stress test deliberately partitions by frame
-  (each thread owns its own frame, and runs its own cyc-a/cyc-b probe
-  sequentially within that frame), so the SAME-frame interleaving this
-  bug needs is out of its scope by design. This namespace targets it
-  directly: two threads, ONE shared frame, the cycle-forming pair
-  registered in lockstep, asserting the committed registry never holds
-  an admitted cycle.
+  concurrency-stress test partitions by frame (each thread owns its own frame),
+  so the SAME-frame interleaving is out of its scope by design. This namespace
+  targets it directly: two threads, ONE shared frame, the cycle-forming pair
+  registered in lockstep, asserting the committed registry never holds an
+  admitted cycle.
 
   Many rounds under a `CyclicBarrier` release maximise the interleaving
   window; round count is env-overridable via
@@ -59,9 +47,9 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
+  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
+  ;; ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (binding [frame/*current-frame* :rf/default]
     (test-fn)))
@@ -69,16 +57,16 @@
 (use-fixtures :each reset-runtime)
 
 ;; Round count. Each round opens a fresh interleaving window on the
-;; shared frame; the pre-fix race needs only ONE round where both
-;; threads read the pre-cycle state before either commits, so a few
-;; thousand rounds surface it reliably across box/JVM scheduling. CI
-;; can dial down via the env override for a smoke pass.
+;; shared frame; the race needs only ONE round where both threads read
+;; the pre-cycle state before either commits, so a few thousand rounds
+;; surface it reliably across box/JVM scheduling. CI can dial down via
+;; the env override for a smoke pass.
 (def ^:private rounds
   (or (some-> (System/getenv "RF2_QXWIB_TOCTOU_ROUNDS") Long/parseLong)
       4000))
 
 (deftest concurrent-same-frame-reg-flow-cannot-admit-a-cycle
-  ;; rf2-qxwib — the atomic check-and-insert regression.
+  ;; The atomic check-and-insert guarantee.
   ;;
   ;; Per round, on ONE shared frame, two threads simultaneously register
   ;; the two halves of a cycle-forming pair:
@@ -90,14 +78,12 @@
   ;; per-round flow-ids are namespaced by round so a stale registrar /
   ;; flows entry from a prior round cannot mask the race.
   ;;
-  ;; INVARIANT (the one that catches the bug): after each round, the
-  ;; frame's COMMITTED flow-map — read via `flows/flows-snapshot` —
-  ;; must NOT be cyclic. We assert this by running `topo/topo-sort` on
-  ;; the committed map: it must not throw. Pre-fix, a round that
-  ;; interleaved the check-then-act admitted BOTH flows, so the
-  ;; committed map was cyclic and this topo-sort throws — the test
-  ;; fails. Post-fix the atomic swap admits at most one of the pair, so
-  ;; the committed map is always acyclic.
+  ;; INVARIANT (the load-bearing one): after each round, the frame's
+  ;; COMMITTED flow-map — read via `flows/flows-snapshot` — must NOT be
+  ;; cyclic. We assert this by running `topo/topo-sort` on the committed
+  ;; map: it must not throw. The atomic swap admits at most one of the
+  ;; pair, so the committed map is always acyclic; a round that admitted
+  ;; both halves would leave a cyclic map and this topo-sort would throw.
   ;;
   ;; SECONDARY INVARIANT: EXACTLY one of the two registrations must be
   ;; REJECTED with `:rf.error/flow-cycle` (the loser of the CAS race, or

--- a/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
+++ b/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
@@ -1,33 +1,27 @@
 (ns re-frame.flows-rollback-dirty-check-test
-  "Per rf2-4wqu6 finding 1 — a POST-commit app-db schema rollback MUST roll
-  the flow dirty-check (`last-inputs`) bookkeeping back in lock-step with
-  app-db.
+  "A POST-commit app-db schema rollback rolls the flow dirty-check
+  (`last-inputs`) bookkeeping back in lock-step with app-db.
 
-  THE BUG. The flow transform runs as the router's OUTERMOST `:after`
-  interceptor: the moment a flow recomputes it advances THIS frame's
-  `last-inputs` row and folds the output into the chain's PENDING `:db`
-  effect. Whether that pending `:db` becomes DURABLE, however, is decided
-  AFTER the chain returns, in `commit-db-effect!`: a post-commit
-  schema / machine-data validation failure rolls app-db back to the
-  pre-handler value. `run-flows-on-db`'s OWN throw-path snapshot/restore
-  cannot cover that — the rollback lands OUTSIDE it.
+  The flow transform runs as the router's OUTERMOST `:after` interceptor: the
+  moment a flow recomputes it advances THIS frame's `last-inputs` row and
+  folds the output into the chain's PENDING `:db` effect. Whether that pending
+  `:db` becomes DURABLE, however, is decided AFTER the chain returns, in
+  `commit-db-effect!`: a post-commit schema / machine-data validation failure
+  rolls app-db back to the pre-handler value. `run-flows-on-db`'s OWN
+  throw-path snapshot/restore does not cover that — the rollback lands OUTSIDE
+  it. If the advanced `last-inputs` row survived such a rollback, the
+  dirty-check would believe the flow up-to-date even though app-db was restored
+  (the flow output gone): the next clean drain would see `=`-equal inputs, SKIP
+  the flow, and the output would never re-materialise.
 
-  Pre-fix the advanced `last-inputs` row SURVIVED the rollback. So even
-  though app-db was restored (the flow output gone), the dirty-check
-  believed the flow was up-to-date: the next clean drain saw `=`-equal
-  inputs, SKIPPED the flow, and the output NEVER re-materialised. A
-  deterministic dev/test failure path (a validator that rejects once and
-  then passes) could permanently suppress a flow until an input changed,
-  the flow re-registered, or fixtures reset the runtime.
-
-  THE FIX (rf2-4wqu6 finding 1). `flows-after-interceptor` snapshots the
-  draining frame's `last-inputs` rows BEFORE the flow transform advances
-  them (via the new `:flows/snapshot-last-inputs` hook) and stashes the
-  snapshot on the ctx. `commit-db-effect!`'s rollback arm restores it (via
-  `:flows/restore-last-inputs!`) the instant it rolls app-db back — the
-  exact mirror of the throw-path rollback, at the post-commit boundary the
-  flows artefact cannot reach. Frame-scoped (rf2-94ol5): a sibling frame's
-  container is a different atom and is untouched.
+  So `flows-after-interceptor` snapshots the draining frame's `last-inputs`
+  rows BEFORE the flow transform advances them (via the
+  `:flows/snapshot-last-inputs` hook) and stashes the snapshot on the ctx.
+  `commit-db-effect!`'s rollback arm restores it (via
+  `:flows/restore-last-inputs!`) the instant it rolls app-db back — the exact
+  mirror of the throw-path rollback, at the post-commit boundary the flows
+  artefact cannot reach. Frame-scoped: a sibling frame's container is a
+  different atom and is untouched.
 
   The validator seam is the pluggable predicate seam the rest of Spec 010
   uses (`set-schema-fns!`) so the test exercises the exact production
@@ -56,10 +50,9 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow / reg-app-schema are context-required
-  ;; frame-local — an ambient call under no scope raises
-  ;; :rf.error/no-frame-context. Pin :rf/default (an ordinary frame) as the
-  ;; established scope for the body.
+  ;; EP-0002: reg-flow / reg-app-schema are context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (try
     (binding [frame/*current-frame* :rf/default]
@@ -129,9 +122,9 @@
           "app-db rolled back to {:n 1} — the rejected :out write was discarded")
       (is (not (contains? (rf/app-db-value :rf/default) :out))
           ":out absent after the rollback")
-      ;; THE LOAD-BEARING FINDING-1 ASSERT: the flow's dirty-check row was
-      ;; rolled back in lock-step. Pre-fix it stayed advanced to [1], so the
-      ;; flow looked up-to-date despite its output never reaching app-db.
+      ;; THE LOAD-BEARING ASSERT: the flow's dirty-check row was rolled back
+      ;; in lock-step. A surviving advanced row would leave the flow looking
+      ;; up-to-date despite its output never reaching app-db.
       (is (not (contains? (flows/last-inputs-snapshot) :double))
           (str "flow :double's last-inputs row was rolled back with app-db "
                "(pre-fix it stayed advanced to {:double {:rf/default [1]}}, "
@@ -139,9 +132,9 @@
                (pr-str (flows/last-inputs-snapshot))))
 
       ;; Flip the validator to accept, then drive a CLEAN drain whose event
-      ;; does NOT change :n (the flow's only input). Pre-fix this no-op drain
-      ;; would skip the flow on =-equal inputs and :out would NEVER appear.
-      ;; Post-fix the rolled-back dirty-check forces a recompute.
+      ;; does NOT change :n (the flow's only input). The rolled-back
+      ;; dirty-check forces a recompute; a surviving advanced row would skip
+      ;; the flow on =-equal inputs and :out would never appear.
       (reset! reject-out? false)
       (rf/dispatch-sync [:touch-other])
 

--- a/implementation/flows/test/re_frame/flows_schema_validation_test.clj
+++ b/implementation/flows/test/re_frame/flows_schema_validation_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.flows-schema-validation-test
-  "JVM coverage for Spec 013 §Flow output validation (rf2-ee38b.9).
+  "JVM coverage for Spec 013 §Flow output validation.
 
   Pins the `:schema` flow-map key as load-bearing: a flow's computed
   `:derive` value is validated against its optional `:schema` on every

--- a/implementation/flows/test/re_frame/flows_schema_validation_test.clj
+++ b/implementation/flows/test/re_frame/flows_schema_validation_test.clj
@@ -51,10 +51,9 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow / reg-app-schema are context-required
-  ;; frame-local — an ambient call under no scope raises
-  ;; :rf.error/no-frame-context. Pin :rf/default (an ordinary frame) as the
-  ;; established scope for the body.
+  ;; EP-0002: reg-flow / reg-app-schema are context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (let [captured (atom [])]
     (binding [*captured*           captured
@@ -131,7 +130,7 @@
         (is (= :area        (:rf.flow/id tags))    ":rf.flow/id names the failing flow")
         (is (= :area        (:failing-id tags))    ":failing-id mirrors the flow id")
         (is (= [:rect :area] (:path tags))         ":path is the flow's output path")
-        ;; rf2-u9bjgr (EP-0015 fail-closed) — the flow's `:schema` here is a
+        ;; EP-0015 fail-closed — the flow's `:schema` here is a
         ;; PREDICATE FN (`(fn [v] ...)`), which is OPAQUE to the pure-data
         ;; walker (`walker/schema-opaque?`: non-vector, non-keyword). The
         ;; shared redaction seam (`:schemas/redact-validation-tags`) the

--- a/implementation/flows/test/re_frame/flows_t2_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_t2_trace_test.clj
@@ -41,9 +41,9 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
+  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
+  ;; ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (binding [frame/*current-frame* :rf/default]
     (test-fn)))

--- a/implementation/flows/test/re_frame/flows_t2_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_t2_trace_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.flows-t2-trace-test
-  "Per rf2-ta0y7: the framework stamps `:rf.event/db-pending-post-flow`
+  "The framework stamps `:rf.event/db-pending-post-flow`
   (t2) when one or more flows transformed the pending `:db` between
   the handler's return and the deferred commit. The flows artefact is
   loaded here so the `:flows/run-flows-on-db` late-bind hook is wired

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -51,13 +51,13 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): `reg-flow` / `clear-flow` are context-required
-  ;; frame-local — an ambient call under NO established scope now raises
-  ;; `:rf.error/no-frame-context` (there is no `:rf/default` floor). `init!`
-  ;; no longer creates `:rf/default`; register it as an ordinary frame and
-  ;; pin `*current-frame*` so the ambient `reg-flow` / `dispatch-sync` calls
-  ;; in the bodies below carry a scope stamp. Fixture-level equivalent of
-  ;; wrapping each body in `(rf/with-frame :rf/default …)`.
+  ;; EP-0002: `reg-flow` / `clear-flow` are context-required frame-local — an
+  ;; ambient call under NO established scope raises `:rf.error/no-frame-context`
+  ;; (there is no `:rf/default` floor; `init!` does not create `:rf/default`).
+  ;; Register it as an ordinary frame and pin `*current-frame*` so the ambient
+  ;; `reg-flow` / `dispatch-sync` calls in the bodies below carry a scope
+  ;; stamp. Fixture-level equivalent of wrapping each body in
+  ;; `(rf/with-frame :rf/default …)`.
   (frame/ensure-default-frame!)
   (binding [frame/*current-frame* :rf/default]
     (test-fn)))
@@ -81,9 +81,9 @@
 
 (deftest clear-flow-removes-from-registry-and-vacates-output-slot
   (testing "clear-flow removes the flow and dissoc-in's its output path"
-    ;; rf2-aqt7: clear-flow's update-in path math is off-by-one for
-    ;; single-element :output-path vectors. Use a two-element :output-path here so
-    ;; the working branch (>= 2 elements) is exercised.
+    ;; clear-flow's update-in path math takes a different branch for
+    ;; single-element :output-path vectors. Use a two-element :output-path here
+    ;; so the (>= 2 elements) branch is exercised.
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:rect {:w 3 :h 4}}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:rect :w] [:rect :h]]
@@ -101,12 +101,11 @@
     (flows/clear-flow :no-such-flow)))
 
 (deftest clear-flow-prunes-empty-frame-slot-from-registry
-  ;; rf2-4bbaw: clearing the LAST flow on a frame must dissoc the frame-id
-  ;; key from the per-frame `@flows` registry entirely, not leave a
-  ;; `{frame-id {}}` husk. (Distinct from the leaf-only app-db vacation
-  ;; husk covered by the next deftest — this is about the registry map,
-  ;; not app-db.) Symmetric with `teardown-on-frame-destroy!`'s
-  ;; `(swap! flows dissoc frame-id)`.
+  ;; Clearing the LAST flow on a frame dissocs the frame-id key from the
+  ;; per-frame `@flows` registry entirely, not leaving a `{frame-id {}}` husk.
+  ;; (Distinct from the leaf-only app-db vacation husk covered by the next
+  ;; deftest — this is about the registry map, not app-db.) Symmetric with
+  ;; `teardown-on-frame-destroy!`'s `(swap! flows dissoc frame-id)`.
   (testing "clearing the sole flow on a frame removes the frame-id key from flows-snapshot"
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
@@ -119,13 +118,13 @@
         "the frame-id key is GONE from @flows — no {frame-id {}} husk remains")))
 
 (deftest clear-flow-vacates-leaf-only-leaving-empty-parent-husk
-  ;; rf2-ee38b.9: clear-flow's vacation contract is LEAF-ONLY. When the
-  ;; cleared flow's leaf was the sole key under its parent, an empty
-  ;; parent map remains — deliberate, not a leak. Pruning empty ancestor
-  ;; maps would risk deleting unrelated sibling slots that happen to be
-  ;; empty, so the leaf-only behaviour is the correct contract. The
-  ;; flow's *value* is fully gone (the spec's "vacate the slot"
-  ;; requirement); only the structural empty-map parent persists.
+  ;; clear-flow's vacation contract is LEAF-ONLY. When the cleared flow's leaf
+  ;; was the sole key under its parent, an empty parent map remains —
+  ;; deliberate, not a leak. Pruning empty ancestor maps would risk deleting
+  ;; unrelated sibling slots that happen to be empty, so the leaf-only
+  ;; behaviour is the correct contract. The flow's *value* is fully gone (the
+  ;; spec's "vacate the slot" requirement); only the structural empty-map
+  ;; parent persists.
   (testing "clearing a flow whose leaf is the sole key under its parent leaves an empty parent map"
     (rf/reg-event :seed-wizard (fn [{:keys [db]} _] {:db {:wizard {}}}))
     (rf/reg-flow {:id     :wizard/result
@@ -148,13 +147,13 @@
           "only the empty husk (plus unrelated sibling :seed) remains under the parent"))))
 
 (deftest clear-flow-nested-path-before-first-compute-does-not-write-nil-parent
-  ;; Regression for rf2-q25os Repro 1. When a flow with a nested `:output-path`
-  ;; (e.g. `[:step-2 :result]`) is cleared BEFORE any drain has run the
-  ;; flow's output, the parent slot `:step-2` doesn't exist in app-db.
-  ;; Pre-fix, the naïve `(update-in cur [:step-2] dissoc :result)`
-  ;; returned `(dissoc nil :result) ⇒ nil`, producing `{:step-2 nil}` — a
-  ;; spurious nil parent. The robust path (`dissoc-in-safe`) leaves
-  ;; app-db unchanged when the parent was never materialised.
+  ;; When a flow with a nested `:output-path` (e.g. `[:step-2 :result]`) is
+  ;; cleared BEFORE any drain has run the flow's output, the parent slot
+  ;; `:step-2` doesn't exist in app-db. A naïve
+  ;; `(update-in cur [:step-2] dissoc :result)` would return
+  ;; `(dissoc nil :result) ⇒ nil`, producing `{:step-2 nil}` — a spurious nil
+  ;; parent. The robust path (`dissoc-in-safe`) leaves app-db unchanged when
+  ;; the parent was never materialised.
   (testing "clear-flow on nested-path flow before first compute leaves app-db unchanged"
     (rf/reg-flow {:id     :pending
                   :inputs [[:n]]
@@ -169,12 +168,11 @@
             "no spurious `:step-2 nil` parent was created")))))
 
 (deftest clear-flow-noop-dissoc-does-not-rewrite-the-container
-  ;; Regression for rf2-2vpac. `clear-flow` skips `replace-container!`
-  ;; when the dissoc branch was a no-op (the slot was never materialised
-  ;; / already absent). Without the guard, clearing an absent slot would
-  ;; install a value-equal-but-fresh db reference and trigger a needless
-  ;; O(n) reactive sub-graph invalidation walk — costly during teardown,
-  ;; where clearing absent slots is common.
+  ;; `clear-flow` skips `replace-container!` when the dissoc branch was a no-op
+  ;; (the slot was never materialised / already absent). Without that guard,
+  ;; clearing an absent slot would install a value-equal-but-fresh db reference
+  ;; and trigger a needless O(n) reactive sub-graph invalidation walk — costly
+  ;; during teardown, where clearing absent slots is common.
   ;;
   ;; The value-equality test above (`...before-first-compute...`) proves
   ;; the db VALUE is unchanged; this test proves the db REFERENCE is
@@ -234,19 +232,18 @@
             "and the leaf is gone from the installed value")))))
 
 (deftest clear-flow-non-map-intermediate-is-noop
-  ;; Regression for rf2-q25os Repro 2. When an intermediate path step
-  ;; holds a non-map value (e.g. someone wrote a scalar at `:step-2`
-  ;; before the flow's output ever materialised), pre-fix
-  ;; `(update-in cur [:step-2] dissoc :result)` called `(dissoc 1 :result)`
-  ;; and threw `ClassCastException`. The robust path treats this as a
-  ;; no-op — the flow's `:output-path` never materialised, so there's nothing
-  ;; to clear.
+  ;; When an intermediate path step holds a non-map value (e.g. someone wrote
+  ;; a scalar at `:step-2` before the flow's output ever materialised), a
+  ;; naïve `(update-in cur [:step-2] dissoc :result)` would call
+  ;; `(dissoc 1 :result)` and throw `ClassCastException`. The robust path
+  ;; treats this as a no-op — the flow's `:output-path` never materialised, so
+  ;; there's nothing to clear.
   (testing "clear-flow on a flow whose intermediate path step holds a scalar is a no-op (no throw)"
     ;; Seed a scalar at the parent slot. NO flow is active during this
     ;; drain — a flow whose `:output-path` is `[:step-2 :result]` would
     ;; `assoc-in` over the scalar (which throws on the JVM) and, per the
-    ;; atomicity contract (rf2-u0zz5), abort the whole drain. The scalar-
-    ;; intermediate case is about `clear-flow` robustness, not flow
+    ;; atomicity contract, abort the whole drain. The scalar-intermediate
+    ;; case is about `clear-flow` robustness, not flow
     ;; evaluation, so we register the flow AFTER seeding and never drain
     ;; it — its `:output-path` stays un-materialised, which is exactly the
     ;; non-map-intermediate case `clear-flow` must treat as a no-op.
@@ -269,9 +266,10 @@
 
 (deftest clear-flow-handles-single-element-path
   (testing "rf2-aqt7: clear-flow with a single-element :output-path dissocs the top-level key"
-    ;; The repro from rf2-aqt7: a flow whose :output-path is a one-element vector
-    ;; [:area]. Before the fix, clear-flow's (update-in cur [] dissoc :area)
-    ;; left :area in app-db (and silently introduced an {nil nil} entry).
+    ;; A flow whose :output-path is a one-element vector [:area]. A naïve
+    ;; (update-in cur [] dissoc :area) would leave :area in app-db (and
+    ;; silently introduce an {nil nil} entry); the length-1 special-case
+    ;; dissocs the top-level key directly.
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
@@ -324,7 +322,7 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-missing-id (:rf.error/id data))
           ":rf.error/id carries the missing-id discriminator")
-      ;; rf2-vvixub — message is the human :reason sentence + the trailing
+      ;; The message is the human :reason sentence + the trailing
       ;; [:rf.error/<id>] token; assert the token substring, not equality.
       (is (re-find #"\[:rf\.error/flow-missing-id\]" (ex-message ex))
           "message carries the [:rf.error/flow-missing-id] token")
@@ -338,21 +336,21 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-bad-output (:rf.error/id data))
           ":rf.error/id carries the bad-output discriminator")
-      ;; rf2-vvixub — assert the [:rf.error/<id>] token substring, not equality.
+      ;; Assert the [:rf.error/<id>] token substring, not equality.
       (is (re-find #"\[:rf\.error/flow-bad-output\]" (ex-message ex))
           "message carries the [:rf.error/flow-bad-output] token")
       (is (= 'rf/reg-flow (:where data))     ":where names the user-facing surface")
       (is (= :fix-registration (:recovery data)) ":recovery names the disposition"))))
 
 (deftest reg-flow-id-must-be-a-keyword
-  ;; rf2-ihfz9o issue 2: the public FlowMeta schema requires `[:id :keyword]`
-  ;; (Spec-Schemas §FlowMeta) and the `:flow-id` slot is emitted unchanged into
-  ;; `:rf.flow/*` trace + error payloads, so a non-keyword id leaks an
-  ;; arbitrary shape downstream. `reg-flow` rejects a present-but-non-keyword
-  ;; id at the API boundary with the dedicated `:rf.error/flow-bad-id`
-  ;; discriminator (a fifth member of the `:rf.error/flow-bad-*` family).
-  ;; nil/absent stays `:rf.error/flow-missing-id` (the absent-id case fires
-  ;; first); a keyword id passes.
+  ;; The public FlowMeta schema requires `[:id :keyword]` (Spec-Schemas
+  ;; §FlowMeta) and the `:flow-id` slot is emitted unchanged into `:rf.flow/*`
+  ;; trace + error payloads, so a non-keyword id would leak an arbitrary shape
+  ;; downstream. `reg-flow` rejects a present-but-non-keyword id at the API
+  ;; boundary with the dedicated `:rf.error/flow-bad-id` discriminator (a
+  ;; member of the `:rf.error/flow-bad-*` family). nil/absent is
+  ;; `:rf.error/flow-missing-id` (the absent-id case fires first); a keyword
+  ;; id passes.
   (testing "a nil :id throws :rf.error/flow-missing-id (absent), NOT flow-bad-id"
     (let [ex (try (rf/reg-flow {:id nil :inputs [[:n]] :derive identity :output-path [:x]})
                   (catch Throwable t t))]
@@ -365,7 +363,7 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-bad-id (:rf.error/id data))
           ":rf.error/id carries the bad-id discriminator")
-      ;; rf2-vvixub — assert the [:rf.error/<id>] token substring, not equality.
+      ;; Assert the [:rf.error/<id>] token substring, not equality.
       (is (re-find #"\[:rf\.error/flow-bad-id\]" (ex-message ex))
           "message carries the [:rf.error/flow-bad-id] token")
       (is (= 'rf/reg-flow (:where data))         ":where names the user-facing surface")
@@ -388,27 +386,27 @@
         "a keyword id registers cleanly and reg-flow returns the id")))
 
 ;; ---------------------------------------------------------------------------
-;; 1b. validate-flow well-formedness (rf2-gnl7q)
+;; 1b. validate-flow well-formedness
 ;;
-;; Per audit rf2-o3hok findings Q5 / TE4 — the prior `validate-flow` only
-;; checked `(vector? (:inputs flow))` and `(vector? (:output-path flow))`, so:
+;; `validate-flow` fully checks `:inputs` and `:output-path` shape up front
+;; rather than letting a malformed value boom deep in topo-sort. Without the
+;; full check:
 ;;
 ;;   - `:inputs [:foo :bar]` (vector of bare keywords, NOT vector-of-paths)
-;;     passed validation and then threw deep inside topo-sort's `prefix?`
-;;     when it called `(count :foo)`.
-;;   - `:inputs [[:foo] :bar]` (mixed) likewise passed, then exploded on
+;;     would pass and then throw inside topo-sort's `prefix?` on `(count :foo)`.
+;;   - `:inputs [[:foo] :bar]` (mixed) would likewise pass, then explode on
 ;;     the bare-keyword entry.
-;;   - `:output-path []` passed; `(prefix? [] anything)` returns true, silently
-;;     making the empty-path flow a depends-on prerequisite of EVERY other
-;;     flow in the frame.
+;;   - `:output-path []` would pass; `(prefix? [] anything)` returns true,
+;;     silently making the empty-path flow a depends-on prerequisite of EVERY
+;;     other flow in the frame.
 ;;
-;; These tests pin the tightened contract: each malformation is rejected
-;; up front with a stable error id (`:rf.error/flow-bad-inputs` or
-;; `:rf.error/flow-bad-path`) and ex-data that names the offending entries
-;; so callers can fix their flow map without a stack-trace scavenger hunt.
+;; These tests pin the contract: each malformation is rejected up front with a
+;; stable error id (`:rf.error/flow-bad-inputs` or `:rf.error/flow-bad-path`)
+;; and ex-data that names the offending entries so callers can fix their flow
+;; map without a stack-trace scavenger hunt.
 
-;; rf2-vvixub — branch on the canonical :rf.error/id discriminator, never
-;; on the (now human-sentence) message string.
+;; Branch on the canonical :rf.error/id discriminator, never on the
+;; (human-sentence) message string.
 (defn- flow-bad-inputs? [^Throwable t]
   (= :rf.error/flow-bad-inputs (:rf.error/id (ex-data t))))
 
@@ -429,7 +427,7 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-bad-inputs (:rf.error/id data))
           ":rf.error/id slot carries the discriminator keyword")
-      ;; rf2-vvixub — assert the [:rf.error/<id>] token substring, not equality.
+      ;; Assert the [:rf.error/<id>] token substring, not equality.
       (is (re-find #"\[:rf\.error/flow-bad-inputs\]" (ex-message ex))
           "message carries the [:rf.error/flow-bad-inputs] token")
       (is (nil? (:error data))
@@ -451,8 +449,8 @@
 
 (deftest reg-flow-rejects-bare-keyword-inputs
   (testing ":inputs [:foo :bar] is rejected (vector of bare keywords, not vector-of-paths)"
-    ;; Pre-fix this would pass validate-flow and then throw with
-    ;; (count :foo) somewhere deep in topo's prefix?.
+    ;; Without the up-front check this would pass validate-flow and then throw
+    ;; with (count :foo) somewhere deep in topo's prefix?.
     (let [ex (try
                (rf/reg-flow {:id     :bad
                              :inputs [:foo :bar]
@@ -505,9 +503,9 @@
 
 (deftest reg-flow-rejects-empty-path
   (testing ":output-path [] is rejected (would make this flow a prerequisite of every other flow)"
-    ;; Pre-fix: (prefix? [] anything) returns true, so an empty-path flow
-    ;; becomes depends-on for every other flow in the frame. Per Spec 013
-    ;; §Dependency rule this is never what the caller means.
+    ;; (prefix? [] anything) returns true, so an empty-path flow would become
+    ;; depends-on for every other flow in the frame. Per Spec 013 §Dependency
+    ;; rule this is never what the caller means, so it is rejected.
     (let [ex (try
                (rf/reg-flow {:id     :bad
                              :inputs [[:n]]
@@ -539,14 +537,13 @@
             (keyword / string / integer / symbol / boolean — and, after the
             rf2-t3cfil widening to re-frame.path/segment?, UUID / instant /
             nil too)"
-    ;; rf2-t3cfil: flow `valid-path-element?` delegates to the shared
-    ;; `re-frame.path/segment?` rather than a flows-private scalar
-    ;; enumeration, so a flow path may focus through any concrete EDN
-    ;; identity segment the `:rf/path` algebra already supports — including a
-    ;; UUID-keyed map (`{:by-id {#uuid "…" …}}`), an instant key, and the nil
-    ;; key. Each round-trips through reg-flow without throwing; tighter (and
-    ;; now shared) validation must not regress the common scalar case nor the
-    ;; newly-admitted ones.
+    ;; Flow `valid-path-element?` delegates to the shared
+    ;; `re-frame.path/segment?` rather than a flows-private scalar enumeration,
+    ;; so a flow path may focus through any concrete EDN identity segment the
+    ;; `:rf/path` algebra supports — including a UUID-keyed map
+    ;; (`{:by-id {#uuid "…" …}}`), an instant key, and the nil key. Each
+    ;; round-trips through reg-flow without throwing; the shared validation
+    ;; admits the common scalar case alongside these.
     (doseq [[label elt] [[:kw      :kw]
                          [:string  "str"]
                          [:int     42]
@@ -586,13 +583,11 @@
         "cycle-detection rolls back the partial registration of :b")))
 
 (deftest reg-flow-cycle-error-carries-ordered-cycle-path
-  ;; Regression for rf2-sny6o. The cycle-error ex-data contract
-  ;; (per Spec 013 §Cycle detection / Spec 009 §Error contract) is:
-  ;; `:cycle` is an ordered vector of flow ids with a closing repeat
-  ;; — e.g. `[:a :b :a]` for the cycle :a → :b → :a. Pre-fix the impl
-  ;; threw `(vec (keys @remaining))` (an unordered subset of stuck
-  ;; nodes) which was useless for tooling rendering the offending
-  ;; chain. This test pins the resolved shape.
+  ;; The cycle-error ex-data contract (per Spec 013 §Cycle detection /
+  ;; Spec 009 §Error contract): `:cycle` is an ordered vector of flow ids with
+  ;; a closing repeat — e.g. `[:a :b :a]` for the cycle :a → :b → :a. (An
+  ;; unordered subset of stuck nodes would be useless for tooling rendering
+  ;; the offending chain.) This test pins the ordered-closing-repeat shape.
   (testing "two-flow cycle: :cycle is [start ... start], length 3"
     (rf/reg-flow {:id :a :inputs [[:b]] :derive identity :output-path [:a]})
     (let [ex (try
@@ -609,8 +604,8 @@
       (is (= #{:a :b} (set cycle))
           ":cycle names both offending flow ids")
       ;; Spec 013 example: {:cycle [:a :b :a]}. Either :a or :b may
-      ;; legally be the starting node (impl picks deterministically
-      ;; via sort-by hash; spec leaves the starting node
+      ;; legally be the starting node (the impl picks deterministically
+      ;; via sort-by hash; the spec leaves the starting node
       ;; implementation-defined) — assert one of the two valid
       ;; closures.
       (is (contains? #{[:a :b :a] [:b :a :b]} cycle)
@@ -637,15 +632,13 @@
           "all three offending ids appear in the path"))))
 
 (deftest reg-flow-replacement-that-introduces-cycle-preserves-prior-registration
-  ;; Regression for rf2-7csri (bug) / rf2-cdh9h (this test). Pinned per
-  ;; audit rf2-o3hok finding Exec#2 (TE2). The bug: `reg-flow`'s former
-  ;; rollback path wrote the new entry FIRST then ran cycle detection;
-  ;; on a cyclic re-registration the rollback dissoc'd by id, which
-  ;; DELETED the prior registration as well as the just-written one. A
-  ;; hot-reload that accidentally introduced a cycle therefore silently
-  ;; vacated the previously-working flow. The fix (rf2-7csri) runs cycle
-  ;; detection on a PROSPECTIVE flow-map BEFORE mutating; on failure
-  ;; nothing is written and the prior registration stays intact.
+  ;; `reg-flow` runs cycle detection on a PROSPECTIVE flow-map BEFORE
+  ;; mutating; on failure nothing is written and the prior registration stays
+  ;; intact. A rollback path that wrote the new entry FIRST and then dissoc'd
+  ;; by id on a detected cycle would DELETE the prior registration as well as
+  ;; the just-written one — so a hot-reload that accidentally introduced a
+  ;; cycle would silently vacate the previously-working flow. This test pins
+  ;; that the prior registration survives.
   (testing "a cyclic reg-flow REPLACEMENT must not silently delete the prior registration"
     ;; Set up a non-cyclic two-flow graph where REPLACING :b is what
     ;; closes the cycle. Cannot use a self-cycle on :b (topo-sort skips
@@ -901,8 +894,8 @@
         ":rf.fx/clear-flow dissoc-in'd the output path")))
 
 (deftest fx-reg-flow-mid-event-lag-and-followup-dispatch-workaround
-  ;; rf2-1smwp — pin the LEAST-OBVIOUS flow behaviour as an explicit
-  ;; contract: a flow registered mid-event via `:rf.fx/reg-flow` does NOT
+  ;; Pin the LEAST-OBVIOUS flow behaviour as an explicit contract: a flow
+  ;; registered mid-event via `:rf.fx/reg-flow` does NOT
   ;; compute on THAT event's drain (the `:fx` walk runs after the flow
   ;; transform — Spec 013 §Sequencing / §Drain integration), and the
   ;; documented workaround (a follow-up no-op `:dispatch` from the SAME
@@ -957,11 +950,11 @@
     (is (nil? (registrar/lookup :flow :two)))))
 
 (deftest reset-flows-clears-both-flows-and-last-inputs
-  ;; Per rf2-mb65w. `reset-flows!` must reset BOTH the flow registry
-  ;; AND the dirty-check `last-inputs` map. Pre-fix it cleared only
-  ;; `flows`; a fixture / harness calling `reset-flows!` standalone
-  ;; then re-registering the same flow-id would silently no-op the
-  ;; first evaluation when new-inputs =-equalled a leftover entry.
+  ;; `reset-flows!` resets BOTH the flow registry AND the dirty-check
+  ;; `last-inputs` map. Clearing only `flows` would let a fixture / harness
+  ;; calling `reset-flows!` standalone then re-registering the same flow-id
+  ;; silently no-op the first evaluation when new-inputs =-equal a leftover
+  ;; entry.
   (testing "reset-flows! drops both flow registry AND last-inputs in lockstep"
     (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 5}}))
     (rf/reg-flow {:id     :double
@@ -980,11 +973,11 @@
         "last-inputs is ALSO empty after reset-flows! (rf2-mb65w)")))
 
 (deftest reset-flows-allows-re-registration-without-stale-skip
-  ;; The footgun: re-register the same flow id with the same inputs
-  ;; after a `reset-flows!`. Pre-fix, the stale `last-inputs` entry
+  ;; The footgun guard: re-register the same flow id with the same inputs
+  ;; after a `reset-flows!`. A stale `last-inputs` entry surviving the reset
   ;; would =-equal new inputs and the first drain would silently emit
-  ;; `:rf.flow/skip` instead of `:rf.flow/computed` — the new body
-  ;; never ran.
+  ;; `:rf.flow/skip` instead of `:rf.flow/computed` — the new body never
+  ;; running.
   (testing "after reset-flows! the re-registered flow re-evaluates on next drain"
     (let [calls (atom 0)]
       (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 5}}))
@@ -1021,11 +1014,8 @@
 ;; ---------------------------------------------------------------------------
 ;; 7. clear-flow :frame opt routing — multi-frame registrar-slot retention
 ;;
-;; Per audit rf2-0b2eh §TC-2 / rf2-otbub. The cross-artefact
-;; `smoke_test.clj` exercises frame-scoped flow REGISTRATION end-to-end,
-;; but the flows artefact's own test alias did not pin `clear-flow`'s
-;; `:frame` opt routing — three branches in registry.cljc went unverified
-;; here:
+;; This deftest pins `clear-flow`'s `:frame` opt routing within the flows
+;; artefact's own test alias — three branches in registry.cljc:
 ;;
 ;; 1. Frame opt routing: `(clear-flow :foo {:frame :left})` removes the
 ;;    flow from `:left`'s per-frame map only; sibling frame `:right`'s
@@ -1090,9 +1080,8 @@
     ;; Branch 4: the cleared flow truly stops firing. Re-seed both
     ;; frames and confirm :left's slot stays absent (no flow to run)
     ;; while :right's still-registered :compute recomputes off the new
-    ;; input. Folded in from the former `flows-are-frame-scoped` test
-    ;; (rf2-zqar3) — the dissoc-only assertion above does not prove the
-    ;; flow stopped firing on subsequent drains.
+    ;; input. The dissoc-only assertion above does not prove the flow stopped
+    ;; firing on subsequent drains; this does.
     (rf/dispatch-sync [:seed 7] {:frame :left})
     (rf/dispatch-sync [:seed 7] {:frame :right})
     (is (not (contains? (rf/app-db-value :left) :result))
@@ -1118,16 +1107,15 @@
 ;; ---------------------------------------------------------------------------
 ;; 8. `_hot-reload-hook` defonce-idempotency on namespace reload
 ;;
-;; Per audit rf2-0b2eh §TC-3 / rf2-5ay09. The flows registry installs a
-;; registrar replacement-hook (`invalidate-flow-on-replace!`) once at
-;; namespace load via `(defonce ^:private _hot-reload-hook
-;; (registrar/add-replacement-hook! ...))`. If the `defonce` protection
-;; ever regressed to a plain `def`, every namespace reload would push a
-;; duplicate hook into `re-frame.registrar/replacement-hooks` — every
-;; subsequent flow re-registration would invalidate `last-inputs` twice
-;; (functionally harmless because `dissoc` is idempotent, but a silent
-;; bookkeeping leak that would compound across many hot-reload cycles in
-;; long dev sessions).
+;; The flows registry installs a registrar replacement-hook
+;; (`invalidate-flow-on-replace!`) once at namespace load via
+;; `(defonce ^:private _hot-reload-hook
+;; (registrar/add-replacement-hook! ...))`. A plain `def` would push a
+;; duplicate hook into `re-frame.registrar/replacement-hooks` on every
+;; namespace reload — and every subsequent flow re-registration would
+;; invalidate `last-inputs` twice (functionally harmless because `dissoc` is
+;; idempotent, but a silent bookkeeping leak that would compound across many
+;; hot-reload cycles in long dev sessions).
 ;;
 ;; Pin the idempotency: `(require 're-frame.flows.registry :reload)`
 ;; MUST NOT push a duplicate hook.
@@ -1145,20 +1133,17 @@
 ;; ---------------------------------------------------------------------------
 ;; 9. Frame-scoping coverage lives in `clear-flow-routes-via-frame-opt`
 ;; above (registration routing, app-db dissoc, registrar-slot retention,
-;; AND the post-clear re-drain check). The former `flows-are-frame-scoped`
-;; smoke (relocated from core/smoke_test.clj per rf2-zqar3) duplicated that
-;; setup near-verbatim; its only unique assertion — the re-drain-after-clear
-;; check — has been folded into the artefact-native test, so it is dropped.
+;; AND the post-clear re-drain check).
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
-;; 9a. invalidate-flow-on-replace! is frame-scoped (rf2-jfpf3 regression)
+;; 9a. invalidate-flow-on-replace! is frame-scoped
 ;;
-;; Spec 013 §Re-registration scopes the invalidation to
-;; `[frame-id flow-id]`. Pre-fix, the replacement hook wiped every
-;; frame's row under the flow id. A re-registration on frame `:left`
-;; cleared `:right`'s last-inputs row too, causing unnecessary
-;; recompute on `:right`'s next drain and weakening frame isolation.
+;; Spec 013 §Re-registration scopes the invalidation to `[frame-id flow-id]`.
+;; A replacement hook that wiped every frame's row under the flow id would
+;; have a re-registration on frame `:left` clear `:right`'s last-inputs row
+;; too, causing unnecessary recompute on `:right`'s next drain and weakening
+;; frame isolation.
 ;; ---------------------------------------------------------------------------
 
 (deftest hot-reload-on-one-frame-does-not-invalidate-sibling-frames-last-inputs
@@ -1200,17 +1185,16 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 9b. :flow registrar slot carries last-registered frame's metadata
-;;     (Spec 013 §Frame-scoping line 105) — rf2-twi6k.
+;;     (Spec 013 §Frame-scoping line 105).
 ;;
 ;; Spec 013 §Frame-scoping line 105 states: "the registrar slot carries
 ;; the most-recently-registered frame's flow-map with `:frame frame-id`
 ;; stamped into the metadata". The destroy-frame teardown tests
 ;; (flows_destroy_frame_teardown_test.clj) exercise registrar prune
-;; behaviour, but the "last-registration-wins" invariant for the
-;; metadata's `:frame` slot was never pinned. A regression that flipped
-;; the registrar-write order (e.g. only-stamping-on-first-registration)
-;; would silently break Xray / re-frame-10x's per-flow frame
-;; attribution.
+;; behaviour; this pins the "last-registration-wins" invariant for the
+;; metadata's `:frame` slot. A registrar-write order that only stamped on
+;; first registration would silently break Xray / re-frame-10x's per-flow
+;; frame attribution.
 ;; ---------------------------------------------------------------------------
 
 (deftest registrar-slot-carries-last-registered-frame-metadata
@@ -1241,16 +1225,15 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 9b-i. Registrar slot re-points to a LIVE owner when the slot's current
-;;       (last-registered) frame is cleared / destroyed (rf2-73pi1 finding 1).
+;;       (last-registered) frame is cleared / destroyed.
 ;;
 ;; The `:flow` registrar slot carries the most-recently-registered frame's
-;; metadata (Spec 013 §Frame-scoping line 105). Pre-fix, clearing /
-;; destroying THAT frame while a sibling still held the id left the slot
-;; pointing at the dead frame: registrar-backed tooling / hot-reload went
-;; stale, and the next surviving-frame re-registration computed
-;; `:different-fn?` against the dead frame's stale `:handler-fn` /
-;; metadata. The fix re-points the slot to a surviving owner (or
-;; unregisters when none survive).
+;; metadata (Spec 013 §Frame-scoping line 105). When THAT frame is cleared /
+;; destroyed while a sibling still holds the id, the slot re-points to a
+;; surviving owner (or unregisters when none survive). Leaving it pointing at
+;; the dead frame would stale registrar-backed tooling / hot-reload, and the
+;; next surviving-frame re-registration would compute `:different-fn?` against
+;; the dead frame's stale `:handler-fn` / metadata.
 ;; ---------------------------------------------------------------------------
 
 (deftest clear-flow-of-registrar-owner-repoints-to-surviving-frame
@@ -1319,13 +1302,13 @@
         "registrar slot unregistered — no surviving frame holds :solo")))
 
 ;; ---------------------------------------------------------------------------
-;; 9b-ii. Same-frame re-registration with a CHANGED :output-path vacates the old
-;;        output path from app-db (rf2-73pi1 finding 2).
+;; 9b-ii. Same-frame re-registration with a CHANGED :output-path vacates the
+;;        old output path from app-db.
 ;;
 ;; Re-registering an existing flow-id on the SAME frame with a DIFFERENT
-;; :output-path moves the flow's output. Pre-fix, the previous output path stayed
-;; materialised in app-db — downstream reads saw stale derived state at the
-;; abandoned slot. The fix vacates the old path on same-frame :output-path change.
+;; :output-path moves the flow's output and vacates the old path. Leaving the
+;; previous output path materialised in app-db would let downstream reads see
+;; stale derived state at the abandoned slot.
 ;; ---------------------------------------------------------------------------
 
 (deftest same-frame-reregister-changed-path-vacates-old-path
@@ -1375,27 +1358,21 @@
 ;;
 ;; Two layered contracts converge here:
 ;;
-;;   (1) rf2-v5ttb — `:handler-fn` must be stamped on the flow registry
-;;       metadata so the registrar's `:different-fn?` calculation
-;;       actually compares the flow body across re-registrations.
-;;       Pre-fix the registrar compared `(:handler-fn previous)` to
-;;       `(:handler-fn metadata)` but the flows registration site stored
-;;       the body under `:derive` only — both reads were nil and
-;;       `:different-fn?` was always `false`. `reg-flow` now stamps
-;;       `:handler-fn` alongside `:derive` so the cross-kind registrar
-;;       trace surface (Spec 001) works for flows too.
+;;   (1) `:handler-fn` is stamped on the flow registry metadata so the
+;;       registrar's `:different-fn?` calculation compares the flow body
+;;       across re-registrations. `reg-flow` stamps `:handler-fn` alongside
+;;       `:derive`, so the cross-kind registrar trace surface (Spec 001) works
+;;       for flows too. (Storing the body only under `:derive` would leave both
+;;       `:handler-fn` reads nil and `:different-fn?` always `false`.)
 ;;
-;;   (2) rf2-g1b2m — Spec 009 B4 ruling, hot-reload dedup by shape
-;;       (#2135 spec landing, #2139 impl). The registrar consults the
-;;       trace.tooling dedup-by-shape table on every emit: identical
-;;       shape on re-register emits ZERO `:rf.registry/handler-replaced`
-;;       events; a real body change emits exactly one. This supersedes
-;;       the rf2-v5ttb-era "every re-registration emits one" assertion
-;;       for identity reloads.
+;;   (2) Spec 009 B4 hot-reload dedup by shape. The registrar consults the
+;;       trace.tooling dedup-by-shape table on every emit: identical shape on
+;;       re-register emits ZERO `:rf.registry/handler-replaced` events; a real
+;;       body change emits exactly one.
 ;;
 ;; Together: identity reload → 0 emits (B4 dedup-suppressed); real
-;; `:derive` body swap → 1 emit with `:different-fn? true` (rf2-v5ttb
-;; stamping makes the comparison meaningful).
+;; `:derive` body swap → 1 emit with `:different-fn? true` (the `:handler-fn`
+;; stamp makes the comparison meaningful).
 ;; ---------------------------------------------------------------------------
 
 (deftest flow-hot-reload-different-fn?-reflects-real-body-swap
@@ -1415,8 +1392,8 @@
           ;; (a) Real body swap — different `:handler-fn` identity, so
           ;; the B4 dedup table sees a shape change and allows the emit.
           ;; Exactly one `:rf.registry/handler-replaced` fires with
-          ;; `:different-fn? true` (rf2-v5ttb made the comparison
-          ;; meaningful by stamping `:handler-fn` on the flow metadata).
+          ;; `:different-fn? true` (the `:handler-fn` stamp on the flow
+          ;; metadata makes the comparison meaningful).
           (rf/reg-flow {:id     :double
                         :inputs [[:n]]
                         :derive (fn [n] (* 100 n))
@@ -1427,10 +1404,8 @@
               ":different-fn? true on real body change (rf2-v5ttb fix)")
           ;; (b) Idempotent reload — re-register with the SAME fn
           ;; identity as the previous registration. The B4 dedup table
-          ;; (rf2-g1b2m) has already recorded that shape, so the re-emit
-          ;; is suppressed: ZERO `:rf.registry/handler-replaced` events.
-          ;; This supersedes the prior rf2-v5ttb-era assertion of "one
-          ;; emit with `:different-fn? false`" for the idempotent case.
+          ;; has already recorded that shape, so the re-emit is suppressed:
+          ;; ZERO `:rf.registry/handler-replaced` events.
           (reset! captured [])
           (let [body-v2 (fn [n] (* 3 n))]
             (rf/reg-flow {:id     :double
@@ -1477,12 +1452,11 @@
         "after re-registration the flow body re-evaluates on the next drain")))
 
 ;; ---------------------------------------------------------------------------
-;; 10. New ordering: flows transform the pending `:db` effect as the
-;;     OUTERMOST `:after` — after the rest of the `:after` chain reshapes
-;;     the db, and BEFORE the `:db` install + BEFORE `:fx` (rf2-u0zz5,
-;;     Spec 013 §Drain integration).
+;; 10. Ordering: flows transform the pending `:db` effect as the OUTERMOST
+;;     `:after` — after the rest of the `:after` chain reshapes the db, and
+;;     BEFORE the `:db` install + BEFORE `:fx` (Spec 013 §Drain integration).
 ;;
-;; These pin the observable consequences of the relocation:
+;; These pin the observable consequences of that ordering:
 ;;   (a) `:fx` sees the flow-derived app-db (preserved guarantee);
 ;;   (b) the reactive cascade (subs) sees the flow-derived db;
 ;;   (c) flows run BEFORE the `:db` install (the value installed already

--- a/implementation/flows/test/re_frame/flows_topo_test.clj
+++ b/implementation/flows/test/re_frame/flows_topo_test.clj
@@ -18,7 +18,7 @@
             [re-frame.flows.topo :as topo]))
 
 ;; ---------------------------------------------------------------------------
-;; extract-cycle-path defensive throw (rf2-oozsq)
+;; extract-cycle-path defensive throw
 ;;
 ;; Construct a graph + remaining-set whose entries violate Kahn's stuck-
 ;; node invariant: a stuck node whose graph entry has no edges into the
@@ -111,8 +111,7 @@
             "ex-data carries exactly the canonical slots + :cycle (no extras, no missing)")))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-m05md — depends-on? direct function-boundary tests
-;; (follow-on from rf2-q1z1u F4)
+;; depends-on? direct function-boundary tests
 ;;
 ;; `depends-on?` is the load-bearing helper that `topo-sort` consumes
 ;; when building the dependency graph (each flow's set of dep ids is

--- a/implementation/flows/test/re_frame/flows_topo_test.clj
+++ b/implementation/flows/test/re_frame/flows_topo_test.clj
@@ -3,8 +3,8 @@
   algorithm-level invariants that the registration / drain tests
   exercise only indirectly.
 
-  Per rf2-oozsq: pin the defensive throw in `extract-cycle-path` (the
-  closing-repeat cycle-path extractor). The branch is unreachable by
+  Pins the defensive throw in `extract-cycle-path` (the closing-repeat
+  cycle-path extractor). The branch is unreachable by
   construction — by Kahn's algorithm every stuck node has at least one
   stuck dep, so the next-dep lookup never returns nil — but the throw
   is load-bearing defence: a closing-repeat vector built from a dead

--- a/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
+++ b/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.flows-trace-emit-elision-prod-test
-  "Per Spec 009 §Production builds (bead rf2-xxd6z) — RUNTIME prod-elision
-  contract for the `re-frame.flows` trace surface. Companion to the
+  "Per Spec 009 §Production builds — RUNTIME prod-elision contract for the
+  `re-frame.flows` trace surface. Companion to the
   string-grep sentinel sweep in `scripts/check-elision.cjs`: the grep
   catches keyword-literal survival in the bundle blob; this file pins
   the BEHAVIOUR — under `:advanced` + `goog.DEBUG=false`, a registered

--- a/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
+++ b/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
@@ -48,7 +48,7 @@
             ;; the prod test must prove the validation surface elides even
             ;; when the seam is wired, not merely when it is absent.
             [re-frame.schemas :as schemas]
-            ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
+            ;; The listener surface lives in `re-frame.trace.tooling`.
             [re-frame.trace.tooling :as trace-tooling]))
 
 (use-fixtures :each

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -33,16 +33,16 @@
   (flows/reset-flows!)
   (schemas/clear-schemas-by-frame!)
   (flows/reset-last-inputs!)
-  ;; Per rf2-bacs4: the error-emit listener registry is a `defonce`
-  ;; atom that survives test re-runs. Clear before each test so a
-  ;; listener registered by one test doesn't leak into the next.
+  ;; The error-emit listener registry is a `defonce` atom that survives test
+  ;; re-runs. Clear before each test so a listener registered by one test
+  ;; doesn't leak into the next.
   (error-emit/clear-error-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
-  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
-  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  ;; EP-0002: reg-flow is context-required frame-local — an ambient call
+  ;; under no scope raises :rf.error/no-frame-context. Pin :rf/default (an
+  ;; ordinary frame) as the established scope for the body.
   (frame/ensure-default-frame!)
   (let [captured (atom [])]
     (binding [*captured*           captured
@@ -66,17 +66,16 @@
   [op]
   (filterv #(= op (:operation %)) @*captured*))
 
-;; EP-0015 §8 (rf2-d2r3um): durable app-db egress classification is
-;; frame-owned (`reg-frame` `:sensitive` / `:large {:app-db …}`, installed
-;; by `re-frame.frame-classification` under `:source :frame`); schema-
-;; attached `{:sensitive? true}` / `{:large? true}` slot props no longer
-;; feed the frame elision registry the walker reads. These helpers seed the
-;; classification via the frame-owned path — the successor to the removed
-;; schema→elision population — preserving each test's real intent.
+;; EP-0015 §8: durable app-db egress classification is frame-owned
+;; (`reg-frame` `:sensitive` / `:large {:app-db …}`, installed by
+;; `re-frame.frame-classification` under `:source :frame`). Schema-attached
+;; `{:sensitive? true}` / `{:large? true}` slot props do not feed the frame
+;; elision registry the walker reads. These helpers seed the classification
+;; via the frame-owned path.
 
 (defn- install-large!
   "Seed the frame's large app-db classification (frame-owned, `:source
-  :frame`). Marker `:reason` for these paths is now `:frame`."
+  :frame`). Marker `:reason` for these paths is `:frame`."
   [frame-id & paths]
   (frame-class/install! frame-id
     (frame-class/validate+extract frame-id
@@ -248,19 +247,18 @@
           (is (= 12            (:result tags))           ":result is the computed value")
           (is (= [:rect :area] (:path tags)))
           (is (= :rf/default   (:frame tags)))
-          ;; Per rf2-qlzh4: :before carries the value at :output-path
-          ;; immediately BEFORE this flow's write. On the first
-          ;; compute the slot has never been written, so :before is
-          ;; nil. The KEY must be present so consumers can rely on
-          ;; uniform shape (rather than discriminating between
+          ;; :before carries the value at :output-path immediately BEFORE
+          ;; this flow's write. On the first compute the slot has never been
+          ;; written, so :before is nil. The KEY is always present so consumers
+          ;; can rely on uniform shape (rather than discriminating between
           ;; absent-key and explicit-nil).
           (is (contains? tags :before)
               ":before key present on every :rf.flow/computed trace")
           (is (nil? (:before tags))
               "first compute — :output-path has never been written; :before is nil")
-          ;; rf2-hhh92: per-op DURATION — the flow :derive recompute's
-          ;; wall-clock, dev-only, so the Trace panel's DURATION column
-          ;; reads it off :rf.flow/computed.
+          ;; Per-op DURATION — the flow :derive recompute's wall-clock,
+          ;; dev-only, so the Trace panel's DURATION column reads it off
+          ;; :rf.flow/computed.
           (is (contains? tags :elapsed-ms)
               ":elapsed-ms present on every :rf.flow/computed trace")
           (is (number? (:elapsed-ms tags))
@@ -269,7 +267,7 @@
               ":elapsed-ms is non-negative"))))))
 
 ;; ---------------------------------------------------------------------------
-;; 2b. :before slot tracks the pre-write value across drains (rf2-qlzh4)
+;; 2b. :before slot tracks the pre-write value across drains
 ;;
 ;; Per Spec 013 §Flow tracing: `:rf.flow/computed` carries `:before`
 ;; — the value at the flow's `:output-path` immediately before this drain's
@@ -405,8 +403,8 @@
         (is (= :inputs-value-equal (:reason tags))
             ":reason names the suppression cause (rf2-719e value-equal recompute suppression)")
         (is (= :rf/default         (:frame tags)))
-        ;; Per rf2-931pm: `:input-paths-unchanged` names every input
-        ;; db-path whose value was `=` to the previous run — the cascade
+        ;; `:input-paths-unchanged` names every input db-path whose value was
+        ;; `=` to the previous run — the cascade
         ;; DAG consumer reads this to render the "considered, no recompute"
         ;; branch dimmed. For a value-equal skip every input is by
         ;; definition unchanged, so the tag carries the FULL input-path
@@ -504,8 +502,8 @@
           ":rf.flow/failed fires once on the first drain (initial evaluation throws)")
       (let [tags (:tags (first evs))]
         (is (= :boom (:flow-id tags)))
-        ;; rf2-iqh5yf: the raw Throwable `:ex` slot is GONE — replaced by a
-        ;; structured, EDN-safe exception summary (`:exception-message` plain
+        ;; No raw Throwable `:ex` slot — the failure carries a structured,
+        ;; EDN-safe exception summary instead (`:exception-message` plain
         ;; string + `:exception-data` ex-data map). No raw Throwable rides the
         ;; trace bus / epoch capture / tooling listeners by default.
         (is (not (contains? tags :ex))
@@ -525,18 +523,16 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 5b. :rf.error/flow-eval-exception routes through the always-on
-;;     error-emit substrate (rf2-hrt5c — security audit follow-up).
+;;     error-emit substrate.
 ;;
-;; Pre-fix, `run-flows!` caught flow throws and called
-;; `trace/emit-error!` ONLY. In CLJS production builds, that path is
-;; DCE'd by `goog.DEBUG=false` — flow failures became silent to
-;; corpus-wide error listeners (Sentry / Honeybadger / Rollbar
-;; shippers registered via `register-error-listener!`). The
-;; handler-exception path (`emit-handler-exception!`) had ALREADY been
-;; routed through the always-on substrate; flow-eval was asymmetric.
-;; This test pins the symmetric routing: a flow-eval throw must surface
-;; on the listener registry record in JVM dev AND survive prod elision
-;; in CLJS.
+;; A flow-eval throw routes through the always-on error-emit substrate, not
+;; just `trace/emit-error!` — which is DCE'd by `goog.DEBUG=false` in CLJS
+;; production builds, where it would leave flow failures silent to corpus-wide
+;; error listeners (Sentry / Honeybadger / Rollbar shippers registered via
+;; `register-error-listener!`). This matches the handler-exception path
+;; (`emit-handler-exception!`). This test pins the routing: a flow-eval throw
+;; surfaces on the listener registry record in JVM dev AND survives prod
+;; elision in CLJS.
 ;; ---------------------------------------------------------------------------
 
 (deftest flow-eval-exception-routes-through-error-emit-substrate
@@ -584,16 +580,13 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 5b'. The flow-eval boundary re-throw carries the CANONICAL thrown-error
-;;      shape (rf2-cjr635).
+;;      shape.
 ;;
-;; Pre-fix, `evaluate-flow!`'s catch re-threw a hand-rolled ex-info carrying
-;; ONLY `:rf.flow/failed-id` — NO `:rf.error/id`, no `:where`, no
-;; `:recovery` — and a `(or <native-msg> ":rf.error/flow-eval-exception")`
-;; message form that DODGED `check_thrown_error_messages.py` (it is not a
-;; bare-literal first arg) so it could silently regress to the keyword-only
-;; shape. A tool reading `(:rf.error/id (ex-data e))` got nil (a Machine-
-;; readable-errors violation). The fix routes through `error/throw-error!`
-;; like every other flows throw. The router surfaces the rethrown ex-info
+;; `evaluate-flow!`'s catch re-throws through `error/throw-error!` like every
+;; other flows throw, so the rethrown ex-info carries the full canonical shape
+;; (`:rf.error/id` / `:where` / `:recovery` / a human message bearing the
+;; greppability token) — a tool reading `(:rf.error/id (ex-data e))` gets the
+;; machine discriminator, not nil. The router surfaces the rethrown ex-info
 ;; ITSELF as the `:exception` slot of the cascade-level
 ;; `:rf.error/flow-eval-exception` record, so we inspect its ex-data there.
 ;; ---------------------------------------------------------------------------
@@ -630,26 +623,20 @@
         ;; Spec 009 §The thrown-error shape rule 4: trailing greppability token.
         (is (re-find #"\[:rf\.error/flow-eval-exception\]" (ex-message thrown))
             "the derived message carries the [:rf.error/<id>] token")
-        ;; And it is NOT the retired keyword-only message shape.
+        ;; And it is a human sentence, not the bare keyword.
         (is (not= ":rf.error/flow-eval-exception" (ex-message thrown))
             "message is a human sentence, not the bare keyword")))))
 
 ;; ---------------------------------------------------------------------------
-;; 5c. :rf.fx/reg-flow cycle detection routes through error-emit (rf2-eb4lp)
+;; 5c. :rf.fx/reg-flow cycle detection routes through error-emit
 ;;
-;; Pre-fix, a cycle introduced through `:rf.fx/reg-flow` from a handler's
-;; `:fx` raised `:rf.error/flow-cycle` synchronously inside the reserved-
-;; fx body, the throw bubbled uncaught up the drain stack, and the drain
-;; emergency-release re-threw. The typed `:rf.error/flow-cycle` ex-data
-;; (carrying the `:cycle` closing-repeat vector tools render) never
-;; reached the error-emit substrate. In CLJS production the runtime
-;; cycle was silently lost.
-;;
-;; Post-fix: `handle-one-fx`'s reserved-fx branch catches
-;; `:rf.error/flow-cycle` and routes through `error-emit/dispatch-on-
-;; error!` with the `:cycle` ex-data preserved, plus the dev-side trace
-;; emit. Mirrors the rf2-hrt5c handler-exception and rf2-fslx0 flow-eval
-;; routings.
+;; A cycle introduced through `:rf.fx/reg-flow` from a handler's `:fx` raises
+;; `:rf.error/flow-cycle`; `handle-one-fx`'s reserved-fx branch catches it and
+;; routes through `error-emit/dispatch-on-error!` with the `:cycle` ex-data
+;; (the closing-repeat vector tools render) preserved, plus the dev-side trace
+;; emit. This mirrors the handler-exception and flow-eval routings, so the
+;; runtime cycle reaches corpus-wide error listeners even in CLJS production
+;; (where a dev-only trace emit would be DCE'd).
 ;; ---------------------------------------------------------------------------
 
 (deftest fx-reg-flow-cycle-routes-through-error-emit-substrate
@@ -745,16 +732,16 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 7. Wire-bearing flow trace payloads ride through `elide-wire-value`
-;;    (rf2-vkqkk — pins Spec 009 §Size elision in traces / §Privacy contract
-;;    for the flow trace surface).
+;;    (Spec 009 §Size elision in traces / §Privacy contract for the flow
+;;    trace surface).
 ;;
 ;; `:rf.flow/computed` carries `:input-values` and `:result`; `:rf.flow/failed`
 ;; carries `:inputs`. Per Spec 009 the wire-bearing payload of every tracer
-;; surface MUST pass through the elision walker (the single normative emission
-;; site for `:rf.size/large-elided` and `:rf/redacted`). Pre-fix, the flow
-;; tracer bypassed the walker — a flow reading or producing a large value
-;; surfaced raw on the trace bus while sibling tracers (event-emit, error-
-;; emit, dispatch trace) honoured the contract. These tests pin the routing.
+;; surface passes through the elision walker (the single normative emission
+;; site for `:rf.size/large-elided` and `:rf/redacted`), so a flow reading or
+;; producing a large value is elided on the trace bus exactly as the sibling
+;; tracers (event-emit, error-emit, dispatch trace) do. These tests pin the
+;; routing.
 ;; ---------------------------------------------------------------------------
 
 (deftest computed-trace-elides-large-result
@@ -763,10 +750,9 @@
     ;; contract a `:db` return replaces ONLY the app-db partition, so the
     ;; frame-installed elision registry — which lives in the runtime-db
     ;; partition at `[:rf.runtime/elision]` — survives untouched for the
-    ;; flow's evaluate-time registry read. (Pre-migration the registry sat
-    ;; in app-db under `:rf/runtime`, where a replacing handler WOULD have
-    ;; clobbered it; that footgun is structurally gone — see
-    ;; `re-frame.events/reject-legacy-runtime-root!`.)
+    ;; flow's evaluate-time registry read. A replacing handler cannot reach
+    ;; the runtime-db partition (see
+    ;; `re-frame.events/reject-legacy-runtime-root!`).
     (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 1}}))
     (rf/reg-flow {:id     :payload
                   :inputs [[:n]]
@@ -923,14 +909,14 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 7c-bis. Failed-flow rolls back the output-declaration refresh — two-
-;; partition atomicity (rf2-gdzv6o).
+;; partition atomicity.
 ;;
 ;; `run-flows-on-db` refreshes each flow's `:source :flow` output elision
-;; declarations BEFORE the flow walk (rf2-ihfz9o), writing the frame's
-;; runtime-db elision registry IMMEDIATELY via `swap-elision-slot!`. A flow
-;; throw is a PRE-INSTALL throw: the event aborts wholesale, app-db rolls
-;; back and the dirty-check rolls back — but pre-fix the refresh's runtime-db
-;; write SURVIVED, leaving the elision declarations ahead of the committed
+;; declarations BEFORE the flow walk, writing the frame's runtime-db elision
+;; registry IMMEDIATELY via `swap-elision-slot!`. A flow throw is a
+;; PRE-INSTALL throw: the event aborts wholesale, app-db rolls back, the
+;; dirty-check rolls back, AND the refresh's runtime-db write rolls back too —
+;; otherwise the elision declarations would be left ahead of the committed
 ;; (rolled-back) frame state. Spec 013:284,288 requires a pre-install flow
 ;; throw to leave BOTH partitions unchanged. This deftest pins that the
 ;; runtime-db elision declarations are EXACTLY unchanged after a throw, in
@@ -1087,10 +1073,10 @@
 ;; analytics — would escape) AND the handler's own `:db` write must NOT
 ;; land (no partial commit).
 ;;
-;; Per rf2-u0zz5: the flow transform is the outermost `:after`; on a
-;; throw it `dissoc`-es the pending `:db` effect and stashes
-;; `:rf/flow-error` on the context, so the install is a no-op and
-;; `commit-and-flow!` skips `run-fx-effects!`.
+;; The flow transform is the outermost `:after`; on a throw it
+;; `dissoc`-es the pending `:db` effect and stashes `:rf/flow-error` on the
+;; context, so the install is a no-op and `commit-and-flow!` skips
+;; `run-fx-effects!`.
 ;; ---------------------------------------------------------------------------
 
 (deftest fx-does-not-run-after-flow-throws
@@ -1104,8 +1090,8 @@
                           :fx [[:dispatch [:after-throw]]]}))
       ;; Register a flow that throws. The flow runs as the outermost
       ;; :after — after the handler, BEFORE :db install and BEFORE :fx
-      ;; walks (rf2-u0zz5); a throw aborts the event, so :after-throw
-      ;; must NOT dispatch and the handler's :db must NOT install.
+      ;; walks; a throw aborts the event, so :after-throw must NOT dispatch
+      ;; and the handler's :db must NOT install.
       (rf/reg-flow {:id     :boom
                     :inputs [[:n]]
                     :derive (fn [_] (throw (ex-info "boom" {:why :test})))
@@ -1166,7 +1152,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 7e. An fx throw does NOT wind back app-db — the POST-commit boundary
-;;     (atomicity contract, Mike 2026-05-24; rf2-q1sbo).
+;;     (atomicity contract).
 ;;
 ;; `:fx` is the ONLY post-install stage. By the time it walks, the
 ;; deferred (flow-augmented) `:db` has ALREADY committed: an fx throw
@@ -1174,9 +1160,7 @@
 ;; (HTTP, navigation, dispatch) may already have fired and are
 ;; irreversible, so unwinding the db would desync state from the world.
 ;; This is the mirror of `fx-does-not-run-after-flow-throws` (a PRE-commit
-;; throw aborts wholesale): a POST-commit throw leaves everything
-;; committed. Previously this was covered only by a machine-proxy test;
-;; this pins the flow-specific case directly.
+;; throw aborts wholesale): a POST-commit throw leaves everything committed.
 ;; ---------------------------------------------------------------------------
 
 (deftest fx-throw-does-not-wind-back-handler-db-or-flow-output
@@ -1212,7 +1196,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 7f. No spurious `:rf.event/db-changed` on a no-write event — the
-;;     deferred-install contract (rf2-q1sbo).
+;;     deferred-install contract.
 ;;
 ;; A `reg-event` handler that returns NO `:db` (only `:fx`), whose
 ;; flows' inputs are all unchanged (so every flow SKIPS), produces no
@@ -1313,8 +1297,7 @@
 ;; level of every `:rf.flow/*` trace event when the in-scope handler's
 ;; cascade is sensitive — "the flow itself does not declare `:sensitive?`
 ;; directly; the marker rides the cascade." Sensitivity is frame-
-;; classification-derived (EP-0015 §8, rf2-d2r3um — the successor to the
-;; schema-derived overlap of rf2-hjs2d): a handler scoped (`rf/path`) over a
+;; classification-derived (EP-0015 §8): a handler scoped (`rf/path`) over a
 ;; frame-owned `:sensitive {:app-db …}` slot makes the router bind
 ;; `:rf/sensitive? true` into the handler scope. Flows run inside that scope
 ;; (`commit-and-flow!` sits inside `run-handler-cascade!`'s
@@ -1372,11 +1355,10 @@
           ":rf.flow/failed carries the top-level `:sensitive? true` stamp too"))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-iqh5yf — `:rf.flow/failed` must NOT deliver a raw Throwable, and a
-;; sensitive flow's exception ex-data must be redacted before the trace
-;; crosses the bus / epoch capture / tooling listeners. The throwing flow's
-;; ex-data carries a secret; assert it is redacted while flow-id / frame
-;; attribution is preserved.
+;; `:rf.flow/failed` must NOT deliver a raw Throwable, and a sensitive flow's
+;; exception ex-data must be redacted before the trace crosses the bus / epoch
+;; capture / tooling listeners. The throwing flow's ex-data carries a secret;
+;; assert it is redacted while flow-id / frame attribution is preserved.
 ;; ---------------------------------------------------------------------------
 
 (deftest flow-failed-emits-structured-summary-not-raw-throwable
@@ -1535,8 +1517,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 8b. Strict trace-stream ordering on a flow throw — atomicity contract
-;;     (Spec 013 §Failure semantics / §Trace stream ordering on a flow
-;;     throw; rf2-u0zz5, Mike 2026-05-24).
+;;     (Spec 013 §Failure semantics / §Trace stream ordering on a flow throw).
 ;;
 ;; A flow throw is a PRE-INSTALL throw: the event aborts. The router
 ;; DISCARDS the pending `:db` effect, so NO `:rf.event/db-changed` is
@@ -1604,8 +1585,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 8c. Strict trace-stream ordering on the CLEAN (success) path — pins the
-;;     Spec 009 §Canonical per-event trace sequence diagram against the impl
-;;     (rf2-q1sbo follow-up to rf2-u0zz5, Mike 2026-05-24).
+;;     Spec 009 §Canonical per-event trace sequence diagram against the impl.
 ;;
 ;; The load-bearing fact the 009 diagram encodes: `:rf.event/run-end` is a
 ;; CASCADE-TAIL trace — the router emits it in `emit-cascade-trailers!`
@@ -1615,9 +1595,8 @@
 ;;   :rf.flow/computed → :rf.event/db-changed → :rf.fx/handled
 ;;     → :rf.fx/do-fx (terminating fx-walk marker) → :rf.event/run-end (LAST)
 ;;
-;; Pre-rf2-u0zz5 the diagram had `:rf.event/run-end` BEFORE
-;; `:rf.event/db-changed`; this test conformance-checks the corrected
-;; ordering so the diagram can't silently drift back.
+;; This test conformance-checks that ordering so the diagram can't silently
+;; drift.
 ;; ---------------------------------------------------------------------------
 
 (deftest clean-path-trace-stream-run-end-fires-last

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -8,8 +8,8 @@
   directly so a regression surfaces as a plain unit-test failure rather
   than only through the data-driven gate.
 
-  Per rf2-2s1o: `:flow` op-type and `:rf.flow/*` operation vocabulary
-  added for re-frame-10x v2's flow panel."
+  The `:flow` op-type and `:rf.flow/*` operation vocabulary back
+  re-frame-10x v2's flow panel."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -41,12 +41,11 @@
       (finally
         (late-bind/set-fn! hook-key original)))))
 
-;; rf2-wad2fl (front-porch shrink): `clear-flow` was demoted off the
-;; `re-frame.core` façade — it is reached through `re-frame.flows/clear-flow`
-;; now, so the façade artefact-missing contract no longer applies to it. The
-;; `reg-flow` registration MACRO remains on the façade (source-coord capture);
-;; its missing-artefact contract is tested below, alongside the
-;; framework-internal hook no-op contracts.
+;; `clear-flow` is not on the `re-frame.core` façade — it is reached through
+;; `re-frame.flows/clear-flow`, so the façade artefact-missing contract does
+;; not apply to it. The `reg-flow` registration MACRO is on the façade
+;; (source-coord capture); its missing-artefact contract is tested below,
+;; alongside the framework-internal hook no-op contracts.
 
 (deftest reg-flow-raises-when-flows-artefact-missing
   (testing "rf/reg-flow (macro) raises :rf.error/flows-artefact-missing when the :flows/reg-flow hook is nil"
@@ -63,26 +62,26 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "reg-flow throws when the flows artefact is absent")
-          ;; rf2-vvixub — the message is the human :reason sentence + the
-          ;; trailing [:rf.error/<id>] greppability token (Spec 009 §The
-          ;; thrown-error shape). Assert the token substring + the canonical
-          ;; :rf.error/id discriminator, NOT exact keyword-equality.
+          ;; The message is the human :reason sentence + the trailing
+          ;; [:rf.error/<id>] greppability token (Spec 009 §The thrown-error
+          ;; shape). Assert the token substring + the canonical :rf.error/id
+          ;; discriminator, NOT exact keyword-equality.
           (is (re-find #"\[:rf\.error/flows-artefact-missing\]" (.getMessage thrown))
               "the message carries the [:rf.error/flows-artefact-missing] token")
           (let [data (ex-data thrown)]
             (is (= :rf.error/flows-artefact-missing (:rf.error/id data))
                 "ex-data carries the canonical :rf.error/id discriminator")
-            ;; Per rf2-hoiu the throw lives in `re-frame.core-flows/reg-flow`
-            ;; — the sibling-namespace fn-form delegate the macro routes
-            ;; through. Per rf2-j8icl the `:where` symbol is namespace-
-            ;; qualified to the user-facing surface (`rf/reg-flow`).
+            ;; The throw lives in `re-frame.core-flows/reg-flow` — the
+            ;; sibling-namespace fn-form delegate the macro routes through. The
+            ;; `:where` symbol is namespace-qualified to the user-facing
+            ;; surface (`rf/reg-flow`).
             (is (= 'rf/reg-flow (:where data))
                 "ex-data carries :where = 'rf/reg-flow")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))
 
 ;; ---------------------------------------------------------------------------
-;; Framework-internal hooks (rf2-g9t87)
+;; Framework-internal hooks
 ;;
 ;; The four hooks below are framework-internal: their consumers are
 ;; `re-frame.router/flows-after-interceptor` (outermost `:after` flow
@@ -110,8 +109,8 @@
     (with-hook-as-nil :flows/run-flows-on-db
       (fn []
         (rf/init! plain-atom/adapter)
-        ;; EP-0002 (rf2-5q7um6): `init!` no longer creates `:rf/default`,
-        ;; and a bare `dispatch-sync` under no established scope raises
+        ;; EP-0002: `init!` does not create `:rf/default`, and a bare
+        ;; `dispatch-sync` under no established scope raises
         ;; `:rf.error/no-frame-context`. Register `:rf/default` and pin it
         ;; as the established scope so this absent-flows-artefact drain test
         ;; carries a frame stamp (the carried invariant).

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -1,13 +1,12 @@
 (ns re-frame.late-bind-missing-test
-  "Per rf2-5b6x — assert the documented missing-artefact error contract for
-  the flows artefact's `re-frame.core` re-exports.
+  "Assert the documented missing-artefact error contract for the flows
+  artefact's `re-frame.core` re-exports.
 
   Each per-feature split (schemas / machines / routing / flows / http /
   ssr) raises a documented `:rf.error/<artefact>-artefact-missing`
   ex-info when a consumer calls a re-exported surface but the artefact
-  is absent from the classpath. The contract was previously only
-  documented in prose; this test pins the runtime behaviour against
-  regression.
+  is absent from the classpath. This test pins that runtime behaviour
+  against regression.
 
   Strategy: the flows artefact IS on the classpath here (the test ns
   requires `re-frame.flows`, which fires the late-bind hook
@@ -16,8 +15,8 @@
   assertion, then restore it in `finally`. Identical mechanism as the
   test would use on CLJS.
 
-  Per Spec 002 §The late-bind seam, rf2-tfw3 (flows split), and the
-  prose at the call sites in `re-frame.core`."
+  Per Spec 002 §The late-bind seam and the prose at the call sites in
+  `re-frame.core`."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]


### PR DESCRIPTION
Applies the LENS from parent rf2-2db7z1 to the reactive cluster: strip history-narration from code comments + docstrings (bead-ids, "Pre-fix / the prior / formerly / no longer / Mike RULED / EP-00NN renamed-added-removed" framing, migration narration), describing the CURRENT contract as-if-always and generously. Preserves the narrow exceptions: external/spec anchors (Spec 0XX §…, EP-0XXX §…, XState, RFCs) stay; genuine teaching of the current design stays; non-meta uses of "prior/previous" stay (e.g. "the prior registration survives" in a concurrency narrative). Behaviour-neutral — comments/docstrings only.

## Scope delivered

**`implementation/flows/` — COMPLETE** (all 26 files: 4 source + 22 test):
- Source: `flows.cljc`, `flows/registry.cljc`, `flows/topo.cljc`, `flows/tooling.cljc`
- Tests: all `*_test.clj` / `*_test.cljc` / `*_test.cljs` under `flows/test/re_frame/`

Strictly limited to `;;` comments and docstrings. Runtime-value strings (`is`/`testing` labels, `:reason` error-message strings, the `bundle-isolation-sentinel` literal `rf.flows.tooling/sentinel:rf2-...:do-not-rename`) are deliberately left untouched — they are behaviour, and tests / the bundle-isolation grep depend on them. `deps.edn` is out of scope (`.edn`, not code).

## Remaining (not in this PR)

`implementation/resources/` (~22 src + ~40 test) and `implementation/epoch/` (~6 src + ~16 test) still carry the history-narration the lens targets (~1800 `rf2-`-bearing lines, many in-scope comments/docstrings). They were not reached in this session. Recommend a follow-up worker (or splitting rf2-3mgiok into flows-done + resources + epoch). The flows/ surface is independent and complete on its own.

## Quality gates

- `npm run test:cljs` — **skipped locally** (no `implementation/node_modules`; npm install not run). Relying on CI as the merge gate.
- Reader-parse sanity check (`clojure` `read` with `:read-cond :allow`) — **PASS** on every edited file.
- `clj-kondo --lint implementation/flows/src` — **0 errors**, 1 pre-existing warning (unused `bundle-isolation-sentinel`, by design).
- `clj-kondo --lint implementation/flows/test` — **0 errors** (80 pre-existing test-style warnings, unrelated to comment edits).
- Behaviour-neutral: comments/docstrings only; no code/string/test-assertion changes.

Parent: rf2-2db7z1