### PR TITLE
test(core): make 3 load-order-coupled JVM tests self-sufficient (rf2-55j4s3)

### DIFF
--- a/implementation/core/test/re_frame/late_bind_drift_test.clj
+++ b/implementation/core/test/re_frame/late_bind_drift_test.clj
@@ -37,10 +37,36 @@
 
 (def ^:private repo-implementation-root
   "Absolute path to the `implementation/` directory at the repo root.
-  Resolved relative to this file's classpath location: tests run from
-  `implementation/core/`, so `..` reaches `implementation/`."
-  (-> (io/file "..")
-      .getCanonicalFile))
+
+  Anchored to a CLASSPATH RESOURCE, not the working directory (rf2-55j4s3).
+  The earlier `(io/file \"..\")` form assumed the JVM cwd was
+  `implementation/core/` so that `..` reached `implementation/`. That holds
+  for the canonical per-artefact gate (`clojure -M:test` run from
+  `implementation/core/`, which is what CI runs) but SILENTLY MIS-SCOPES the
+  scan under the combined `implementation/deps.edn :test` alias: run from
+  `implementation/`, `..` resolves to the REPO ROOT, so the source walk picks
+  up `set-fn!` sites under `tools/` (e.g. `:subs/resolve-sub-override` in
+  `tools/story/`) that the core directory legitimately does not document —
+  the scan then reports phantom orphans.
+
+  Resolving from `(io/resource \"re_frame/late_bind/directory.cljc\")` — the
+  on-disk location of the core source that DECLARES the directory under test —
+  pins the root to `implementation/` regardless of cwd or which alias loaded
+  the namespace. The five parents walk
+  `directory.cljc → late_bind → re_frame → src → core → implementation`."
+  (let [res (io/resource "re_frame/late_bind/directory.cljc")]
+    (assert res
+            (str "late-bind-drift-test cannot locate "
+                 "re_frame/late_bind/directory.cljc on the classpath — the "
+                 "core src dir must be on the test classpath for the drift "
+                 "scan to anchor its implementation root."))
+    (-> (io/file res)            ; .../core/src/re_frame/late_bind/directory.cljc
+        .getParentFile           ; .../core/src/re_frame/late_bind
+        .getParentFile           ; .../core/src/re_frame
+        .getParentFile           ; .../core/src
+        .getParentFile           ; .../core
+        .getParentFile           ; .../implementation
+        .getCanonicalFile)))
 
 (defn- source-files
   "Every `.clj`, `.cljc`, `.cljs` file under `implementation/<art>/src/`.

--- a/implementation/core/test/re_frame/reg_view_test.clj
+++ b/implementation/core/test/re_frame/reg_view_test.clj
@@ -263,15 +263,42 @@
 ;; in `reg-view`'s expansion — that is the canonical view-registration
 ;; surface.
 
+(defn- reagent-slim-classifier-present?
+  "True iff `reagent2.impl.component/classify-form-body` is resolvable on the
+  CURRENT classpath — the exact precondition `expand-reg-view` keys its
+  compile-time fold on (`requiring-resolve` of the same symbol). Mirrors the
+  macro's own probe so this test reasons about the same classpath fact the
+  macro does."
+  []
+  (boolean
+    (when-let [v (try (requiring-resolve
+                        'reagent2.impl.component/classify-form-body)
+                      (catch Exception _ nil))]
+      (bound? v))))
+
 (deftest reg-view-fold-graceful-without-reagent-slim
-  (testing "expand-reg-view emits a usable form-tag-free expansion when
-            reagent2.impl.component is absent from the classpath"
-    ;; The core test classpath does NOT include reagent-slim, so
-    ;; expand-reg-view's requiring-resolve returns nil and the
-    ;; expansion stamps no :reagent2/form meta.
-    (rf/reg-view fold-no-rs [n] [:p n])
-    (let [slot-meta (registrar/lookup :view
-                      :re-frame.reg-view-test/fold-no-rs)]
-      (is (some? slot-meta) "the view is registered")
-      (is (nil? (:reagent2/form slot-meta))
-          "no form tag stamped — UIx/Helix-only build path"))))
+  ;; This test pins the classpath-sensitive fold contract of `expand-reg-view`
+  ;; (rf2-yfbx). It is conditioned on a CLASSPATH PRECONDITION rather than
+  ;; assuming one (rf2-55j4s3): the canonical per-artefact core gate has
+  ;; reagent-slim ABSENT, but the combined `implementation/deps.edn` `:test`
+  ;; alias puts `day8/reagent-slim` on the classpath — under which the
+  ;; macro DOES (and must) stamp the form tag, so a blanket
+  ;; `(nil? (:reagent2/form ...))` assertion fired a phantom failure. We
+  ;; branch on the live precondition so the test asserts the correct half of
+  ;; the contract under EITHER classpath, losing no coverage: absence ⇒
+  ;; no tag stamped; presence ⇒ a tag stamped.
+  (rf/reg-view fold-no-rs [n] [:p n])
+  (let [slot-meta (registrar/lookup :view
+                    :re-frame.reg-view-test/fold-no-rs)]
+    (is (some? slot-meta) "the view is registered")
+    (if (reagent-slim-classifier-present?)
+      (testing "reagent-slim ON classpath — expand-reg-view folds the form
+                shape into the slot meta (combined-alias / reagent-slim build)"
+        (is (some? (:reagent2/form slot-meta))
+            "form tag stamped when reagent2.impl.component is resolvable"))
+      (testing "reagent-slim ABSENT — expand-reg-view emits a form-tag-free
+                expansion (core / UIx / Helix-only build path)"
+        ;; expand-reg-view's requiring-resolve returns nil, so the
+        ;; expansion stamps no :reagent2/form meta.
+        (is (nil? (:reagent2/form slot-meta))
+            "no form tag stamped — UIx/Helix-only build path")))))

--- a/implementation/core/test/re_frame/trace_listener_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_test.clj
@@ -28,7 +28,8 @@
   JVM-only by intent; the listener API is platform-agnostic.
 
   Per bead rf2-h5by."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -254,7 +255,21 @@
     ;; combined with the `:elision-probe` build (Spec 009 §Production-elision
     ;; verification) that exercises the surface in production, this protects
     ;; the elision contract.
-    (let [src (slurp "src/re_frame/trace.cljc")]
+    ;;
+    ;; Source is read via the CLASSPATH RESOURCE, not a cwd-relative path
+    ;; (rf2-55j4s3). The earlier `(slurp "src/re_frame/trace.cljc")` assumed
+    ;; the JVM cwd was `implementation/core/` (the canonical per-artefact
+    ;; gate, which CI runs); under the combined `implementation/deps.edn`
+    ;; `:test` alias the cwd is `implementation/` and the file lives at
+    ;; `core/src/...`, so the relative slurp threw FileNotFoundException.
+    ;; `io/resource` finds `re_frame/trace.cljc` on the classpath regardless
+    ;; of cwd.
+    (let [res (io/resource "re_frame/trace.cljc")
+          _   (assert res
+                      (str "emit-rides-debug-flag cannot locate "
+                           "re_frame/trace.cljc on the classpath — the core "
+                           "src dir must be on the test classpath."))
+          src (slurp res)]
       (is (re-find #"\(defn-? emit![\s\S]*?interop/debug-enabled\?" src)
           "emit! body is gated on interop/debug-enabled?")
       (is (re-find #"\(defn-? emit-error![\s\S]*?interop/debug-enabled\?" src)


### PR DESCRIPTION
## Summary

Three core JVM tests (`every-published-key-has-a-directory-entry`, `reg-view-fold-graceful-without-reagent-slim`, `emit-rides-debug-flag`) passed under the canonical per-artefact gate but failed in local single-namespace runs under the combined `implementation/deps.edn` `:test` alias. CI runs each artefact's `:test` alias separately from the artefact dir — so CI stayed green while ad-hoc combined-alias runs surfaced "phantom" failures (flagged by the wfy2kq worker on PR #4839).

Diagnosis: **not real main breakage** — cwd- and classpath-sensitivity in the three tests. They are now self-sufficient and pass under both compositions, with no weakened assertions and no production source touched.

## Root cause + fix, per test

- **`every-published-key-has-a-directory-entry`** (late-bind drift): `repo-implementation-root` used `(io/file "..")` relative to cwd. From `implementation/core/` (CI's cwd) `..` correctly reaches `implementation/`; from `implementation/` (combined-alias cwd) it resolves to the **repo root**, so the source-scan scooped up `set-fn!` sites under `tools/` (e.g. `:subs/resolve-sub-override` in `tools/story/`) as phantom orphans. **Fix:** anchor the scan root to `(io/resource "re_frame/late_bind/directory.cljc")` — the on-disk location of the core ns under test — cwd-independent.

- **`emit-rides-debug-flag`**: read source via cwd-relative `(slurp "src/re_frame/trace.cljc")`, which threw `FileNotFoundException` from `implementation/`. **Fix:** read via `(io/resource "re_frame/trace.cljc")`.

- **`reg-view-fold-graceful-without-reagent-slim`**: a classpath-precondition test — it asserts the *absence-graceful* fold path (reagent-slim NOT on classpath ⇒ no `:reagent2/form` meta). The combined alias puts `day8/reagent-slim` on the classpath, under which the macro DOES (and must) stamp the tag, so the blanket `(nil? …)` assertion fired a false failure. **Fix:** branch on the live precondition (`requiring-resolve` of `reagent2.impl.component/classify-form-body`, the same probe the macro uses) and assert the correct half of the contract under either classpath — absence ⇒ no tag, presence ⇒ tag present. Coverage gained, not weakened (the combined-alias run now actively exercises the fold-fired branch).

## Quality gates

- Isolation (`clojure -M:test -n <ns>` from `implementation/core`): all 3 green.
- Full core sweep (`clojure -M:test` from `implementation/core`): **1710 tests, 7357 assertions, 0 failures, 0 errors** (identical totals to clean baseline — no test dropped).
- Combined-alias repro (`clojure -M:test -d core/test -n …` from `implementation/`, reagent-slim on classpath): was 2 failures + 1 error, now **0 failures**.
- Full combined-alias `core/test` sweep from `implementation/`: **1713 tests, 0 failures**.
- clj-kondo on the 3 files: clean (1 pre-existing unused-binding warning in an untouched test, not introduced here).

No production source changed; only the 3 named test namespaces (+ a `clojure.java.io` require).