### PR TITLE
docs(impl): de-historicize comments/docstrings — resources + epoch (rf2-l1ydwz)

### DIFF
--- a/implementation/epoch/deps.edn
+++ b/implementation/epoch/deps.edn
@@ -29,10 +29,9 @@
 ;; Tool-Pair §Time-travel §Production elision) — production builds
 ;; (`:advanced` + `goog.DEBUG=false`) elide every recorded shape,
 ;; the projection walker, and the restore predicates whether or not
-;; the artefact is on the classpath. The split is therefore *also* a
-;; dev-time bundle-shape improvement: development builds that don't
-;; opt into the pair-tool surface no longer carry the namespace at
-;; all.
+;; the artefact is on the classpath. Keeping it a separate artefact is
+;; *also* a dev-time bundle-shape win: development builds that don't opt
+;; into the pair-tool surface carry none of the namespace at all.
 ;;
 ;; Consumers add this artefact alongside the core artefact:
 ;;

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -253,13 +253,13 @@
 
   Per EP-0015 §15 + open-issue 6 (RULED, hardened): the ring buffer and
   every `register-epoch-listener!` listener receive the RAW record.
-  Storage-side redaction was REMOVED — post-EP-0010 epoch records are
-  causal replay material, and mutating them at rest corrupts the replay
-  contract (not merely restore fidelity). The app-supplied `:redact-fn`
-  is now a PROJECTION-SIDE-ONLY advanced override, applied at the off-box
-  egress boundary inside `projected-record` (never at storage time). The
-  `:rf.epoch/sensitive?` rollup inside `build-record` still reflects raw
-  signals so off-box consumers can branch on it before projecting.
+  Epoch records are causal replay material (per EP-0010), and mutating
+  them at rest would corrupt the replay contract (not merely restore
+  fidelity), so storage is always raw. The app-supplied `:redact-fn` is a
+  PROJECTION-SIDE-ONLY advanced override, applied at the off-box egress
+  boundary inside `projected-record` (never at storage time). The
+  `:rf.epoch/sensitive?` rollup inside `build-record` reflects raw signals
+  so off-box consumers can branch on it before projecting.
 
   `committed-at` is the record's durable causal time — per EP-0010 §Time
   and Spec 002 §The World-Input Rule (rf2-bh56rc) the committing causal
@@ -525,11 +525,10 @@
 ;; repros. The runtime-db partition is never touched (Mike ruling #10 — a
 ;; db-shaped name never silently replaces runtime-db).
 ;;
-;; EP-0001 (rf2-tfepxu, bead 9): the surface formerly named `reset-frame-db!`
-;; is renamed to `replace-app-db!` (Mike ruling #10 + spec/API.md), with a
-;; new app-db-only sibling `reset-app-db!` that resets the app-db partition
-;; to `{}` while preserving live runtime-db — the app-db sibling of the
-;; whole-frame `reset-frame!`.
+;; `replace-app-db!` (per spec/API.md, Mike ruling #10) installs an
+;; arbitrary `app-db`; its app-db-only sibling `reset-app-db!` resets the
+;; app-db partition to `{}` while preserving live runtime-db — the app-db
+;; sibling of the whole-frame `reset-frame!`.
 ;;
 ;; The surface is dev-only — gated on `interop/debug-enabled?`, the same
 ;; gate as `restore-epoch!` / `register-epoch-listener!` / the rest of the
@@ -563,9 +562,9 @@
   PRIOR epoch rewinds past the injection.
 
   Per EP-0015 §15 + open-issue 6 (RULED): the synthetic record is stored
-  RAW — storage-side redaction was removed (the ring is causal replay
-  material); the `:redact-fn` advanced override runs projection-side only,
-  inside `projected-record`. Per rf2-qs6dl: stamps the synthetic epoch as
+  RAW (the ring is causal replay material); the `:redact-fn` advanced
+  override runs projection-side only, inside `projected-record`. Per
+  rf2-qs6dl: stamps the synthetic epoch as
   the frame's last-settled so post-settle re-renders attribute back to it
   rather than the next real cascade.
 
@@ -691,9 +690,9 @@
 
 (defn replace-app-db!
   "Replace `frame-id`'s `app-db` partition with `new-db`, bypassing the
-  dispatch loop. Per Tool-Pair §Pair-tool writes. Renamed from
-  `reset-frame-db!` (EP-0001 rf2-tfepxu, Mike ruling #10 — a db-shaped name
-  never silently replaces runtime-db).
+  dispatch loop. Per Tool-Pair §Pair-tool writes (Mike ruling #10 — a
+  db-shaped name never silently replaces runtime-db, so the runtime-db
+  partition is preserved unchanged).
 
   Records a synthetic `:rf/epoch-record` so `restore-epoch!` can rewind
   the previous state; emits `:rf.epoch/db-replaced` on success. The
@@ -904,7 +903,7 @@
       should pass this. An unknown profile is rejected against the closed
       enum.
 
-  The legacy unqualified `:include-*` keys are ADVANCED per-call overrides
+  The unqualified `:include-*` keys are ADVANCED per-call overrides
   composed OVER the selected profile (NOT the primary boundary selector) —
   `{:include-sensitive? :include-large? :include-runtime-db?
   :include-fx-args? :include-event-args?}`, all defaulting `false`.
@@ -982,10 +981,9 @@
    :epoch/record-sub-run!     listeners/record-sub-run!
    ;; rf2-59hx3: post-settle view-unmount back-fill — the teardown sibling
    ;; of the two above. A `:rf.view/unmounted` fires at React teardown time,
-   ;; after the cascade that removed the view settled; pre-fix it was
-   ;; silently dropped at the capture seam so the teardown left no signal.
-   ;; Back-fills it into the causing (most-recently-settled) epoch's
-   ;; `:trace-events`, where Xray's VIEWS step surfaces it.
+   ;; after the cascade that removed the view settled — too late for the
+   ;; capture seam. Back-fills it into the causing (most-recently-settled)
+   ;; epoch's `:trace-events`, where Xray's VIEWS step surfaces it.
    :epoch/record-unmount!     listeners/record-unmount!
    :epoch/on-frame-destroyed  listeners/on-frame-destroyed!
 
@@ -1003,9 +1001,9 @@
    :epoch/configure!                 configure!
    ;; rf2-yw1w1u: test-support config-isolation hook. `re-frame.test-
    ;; support`'s reset-hook table fires this to restore epoch config to
-   ;; the shipped default between tests, so test namespaces no longer
-   ;; reset the private `state/config` var directly. rf2-c0rv4v: points
-   ;; straight at the `state/reset-config!` seam (no facade wrapper).
+   ;; the shipped default between tests, keeping the private `state/config`
+   ;; var out of test namespaces. rf2-c0rv4v: points straight at the
+   ;; `state/reset-config!` seam (no facade wrapper).
    :epoch/reset-config!              state/reset-config!
    :epoch/clear-history!             clear-history!
    :epoch/clear-epoch-listeners!     clear-epoch-listeners!

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -125,9 +125,9 @@
 
   Per EP-0015 §15 (Epoch Redaction) + open-issue 6 disposition (RULED,
   hardened): `:redact-fn` is the PROJECTION-SIDE-ONLY advanced override.
-  Storage-side mutation was REMOVED — post-EP-0010 epoch records are
-  causal replay material; mutating them at rest corrupts the replay
-  contract. So this helper runs ONLY at the off-box egress boundary,
+  Epoch records are causal replay material (per EP-0010); mutating them at
+  rest would corrupt the replay contract, so storage stays raw. This
+  helper runs ONLY at the off-box egress boundary,
   inside `re-frame.epoch.tool-pair/projected-record`, AFTER the
   frame/profile `re-frame.projection/project-egress` projection. The ring
   buffer + every `register-epoch-listener!` listener deliver the RAW

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -115,13 +115,13 @@
 ;; render and a reactive sub-run it fires post-settle (no in-flight cascade
 ;; for its frame) and carries a `:frame` tag but NO `:rf.trace/dispatch-id`.
 ;;
-;; Pre-rf2-59hx3 it fell through to the orphan-drop branch below (no
-;; in-flight cascade AND no `:dispatch-id`) and was SILENTLY DROPPED — so a
-;; view unmount produced NO signal anywhere in the epoch record, and Xray's
-;; VIEWS-step `unmounted-views-rows` (which reads it off `:trace-events`)
-;; had nothing to surface. The teardown was an invisible absence.
+;; With no in-flight cascade AND no `:dispatch-id`, it would otherwise fall
+;; through the orphan-drop branch below and leave a view unmount with NO
+;; signal anywhere in the epoch record — so Xray's VIEWS-step
+;; `unmounted-views-rows` (which reads it off `:trace-events`) would have
+;; nothing to surface.
 ;;
-;; The fix attributes it through the SAME post-settle back-fill mechanism
+;; Instead it is attributed through the SAME post-settle back-fill mechanism
 ;; renders + sub-runs use (no parallel correlate-by-render-key path): it is
 ;; back-filled into the cascade that CAUSED the teardown — the frame's
 ;; most-recently-settled epoch — via the `:epoch/record-unmount!` hook. The
@@ -187,18 +187,18 @@
   no in-flight cascade is back-filled into the causing epoch via the
   `:epoch/record-sub-run!` hook (sibling of `:epoch/record-render!`). An
   in-flight sub-run (a handler that subscribes, an SSR render) belongs to
-  the in-flight cascade and is buffered as before.
+  the in-flight cascade and is buffered like any other in-flight emit.
 
   Per rf2-59hx3: the same post-settle timing applies to a view UNMOUNT
   (`:rf.view/unmounted`) — it fires at React teardown time, AFTER the
-  cascade that removed the view settled. Pre-fix it fell through to the
-  orphan-drop branch (no in-flight cascade + no `:dispatch-id`) and was
-  silently dropped, so a view teardown produced no signal. It is now
-  back-filled into the causing cascade (the most-recently-settled epoch)
-  via the `:epoch/record-unmount!` hook (sibling of the two above), where
-  it rides the epoch's `:trace-events` so Xray's VIEWS step can surface it.
-  An in-flight unmount (a synchronous teardown inside a drain) belongs to
-  that cascade and is buffered as before."
+  cascade that removed the view settled. With no in-flight cascade and no
+  `:dispatch-id` it would otherwise fall through the orphan-drop branch and
+  leave a view teardown with no signal, so it is back-filled into the
+  causing cascade (the most-recently-settled epoch) via the
+  `:epoch/record-unmount!` hook (sibling of the two above), where it rides
+  the epoch's `:trace-events` so Xray's VIEWS step can surface it. An
+  in-flight unmount (a synchronous teardown inside a drain) belongs to that
+  cascade and is buffered like any other in-flight emit."
   [event]
   (when interop/debug-enabled?
     (let [op       (:operation event)
@@ -247,8 +247,8 @@
           ;; A `:rf.view/unmounted` fires at React teardown time, AFTER the
           ;; cascade that removed the view settled, so it carries a `:frame`
           ;; tag but no `:dispatch-id` and arrives with an empty buffer.
-          ;; Pre-fix it hit the orphan-drop branch below and was silently
-          ;; dropped — the view teardown was an invisible absence. Back-fill
+          ;; Without this arm it would hit the orphan-drop branch below and
+          ;; leave the view teardown unrecorded. Back-fill
           ;; it into the causing cascade (the most-recently-settled epoch)
           ;; via `:epoch/record-unmount!` so it lands in that epoch's
           ;; `:trace-events`, where Xray's VIEWS-step `unmounted-views-rows`
@@ -273,12 +273,10 @@
           ;; listener fan-out (those run independently of this capture seam);
           ;; only the epoch-record capture buffer skips it.
           ;;
-          ;; Pre-rf2-avvwm such an orphan was buffered, then the NEXT
-          ;; dequeued event's harvest vacuumed it in as the first
-          ;; `:trace-events` entry (the per-event-epoch boundary from
-          ;; rf2-nj6p7 left it stranded; the post-settle render/sub-run
-          ;; branches above already gate on the same `in-flight-cascade?`
-          ;; signal — this is the third out-of-cascade emit class).
+          ;; This is the third out-of-cascade emit class: the post-settle
+          ;; render/sub-run branches above gate on the same
+          ;; `in-flight-cascade?` signal, and an orphan emit with no cascade
+          ;; in flight is left uncorrelated here.
           ;;
           ;; A `:dispatch-id`-bearing emit is ALWAYS buffered even when no
           ;; cascade is in flight for THIS frame at the instant of the emit:
@@ -417,9 +415,8 @@
 ;; post-settle back-fill in `re-frame.epoch.listeners` (which projects a
 ;; single late-arriving event into the same row shape). Keeping the row
 ;; literal in ONE place means a future field added to the `:sub/run` /
-;; `:view/render` projection lands on both surfaces automatically — the
-;; rf2-ee38b clarity review flagged the prior verbatim duplication as a
-;; lockstep maintenance hazard.
+;; `:view/render` projection lands on both surfaces automatically, avoiding
+;; a lockstep maintenance hazard across two duplicate row literals.
 
 (defn sub-run-row
   "Project a `:rf.sub/run` trace event into its structured `:sub-runs`
@@ -544,11 +541,11 @@
   `{:sub-runs <v> :renders <v> :effects <v>}` with each value a
   persistent vector built via transient accumulators.
 
-  Per rf2-ecu37 (audit rf2-fzrav §M1): the prior shape was three
-  independent `into []` transducer walks of the same buffer — for an
-  N-event cascade that's 3·N operation reads where N suffice. The
-  fused reducer mirrors `find-trigger-event`'s style (rf2-txrq9):
-  one traversal, multiple accumulators, single allocation budget.
+  Fusing the three projections into one reducer pass keeps the buffer walk
+  to N operation reads for an N-event cascade (three independent `into []`
+  transducer walks would cost 3·N). Mirrors `find-trigger-event`'s style
+  (rf2-txrq9): one traversal, multiple accumulators, single allocation
+  budget.
 
   Per-projection contracts preserved verbatim (no schema change):
 
@@ -678,16 +675,14 @@
   must NOT depend on `:trace-events` (which `:trace-events-keep` elides
   on older records and the post-settle reactive back-fill pads with
   nil-`:dispatch-id` events). Xray's `:rf.xray/focus` epoch-id
-  correlation walks this slot; pre-rf2-rly4a it walked `:trace-events`
-  tags, which returned nil whenever the focused cascade's epoch had its
-  raw stream elided — starving the epoch-scoped Views + Trace panels.
+  correlation walks this slot rather than `:trace-events` tags, which
+  return nil whenever the focused cascade's epoch has its raw stream
+  elided — that would starve the epoch-scoped Views + Trace panels.
 
-  Per rf2-txrq9: single-walk reduction over `events` — the original
-  two-pass `or`-of-`some` reordered both walks across the buffer
-  on the degenerate path. We accumulate the first `:event/run-start`,
-  the first fallback `:event-id`, AND (rf2-cheez6.1, below) the
-  cascade's mid-drain machine-minted generator facts in one traversal
-  and prefer the run-start.
+  Per rf2-txrq9: single-walk reduction over `events`. We accumulate the
+  first `:event/run-start`, the first fallback `:event-id`, AND
+  (rf2-cheez6.1, below) the cascade's mid-drain machine-minted generator
+  facts in one traversal and prefer the run-start.
 
   Per rf2-cheez6.1 / rf2-08br0v — augment the run-start's `:rf.cofx`
   replay token with generator facts MINTED MID-DRAIN. The run-start
@@ -699,10 +694,10 @@
   `ensure-raised-cofx` in-drain for a raise-selected guard), AFTER
   run-start was emitted, and are written onto the engine-local machine
   def — they never flow back to the ctx coeffects the run-start read.
-  So the pre-fix token carried only externally-supplied facts, and a
-  `:strict` replay (mint-policy-aware, rf2-n0myjq) of a machine decision
-  gated on such a fact diverged: the missing fact → missing-required
-  while the live run minted a value.
+  Without this merge the token would carry only externally-supplied facts,
+  and a `:strict` replay (mint-policy-aware, rf2-n0myjq) of a machine
+  decision gated on such a fact would diverge: the missing fact →
+  missing-required while the live run minted a value.
 
   Every actual recordable mint — pre-handler in `assemble-initial-ctx`
   AND mid-drain in the machine ensure steps — emits a dev-only
@@ -734,8 +729,8 @@
             (let [op   (:operation ev)
                   tags (:tags ev)]
               (cond
-                ;; run-start beats the fallback. We DO NOT short-circuit
-                ;; (the prior `reduced`): the cascade's `:rf.cofx/generated`
+                ;; run-start beats the fallback. We DO NOT short-circuit:
+                ;; the cascade's `:rf.cofx/generated`
                 ;; mint traces fire AFTER run-start, so the walk must
                 ;; continue to gather them (below). A second run-start for
                 ;; the same buffer is impossible (one per cascade), so the
@@ -777,11 +772,11 @@
                 ;; `:event/run-start` tag … absent when the cascade carried
                 ;; no dispatch-id (rejected dispatch / pre-run-start halt)"
                 ;; — the strictly-spec shape for a no-run-start cascade is
-                ;; ABSENT. The prior fallback could surface the dispatch-id
+                ;; ABSENT. Pinning `:dispatch-id` here would surface the id
                 ;; of an arbitrary non-run-start trace (e.g. an error trace
-                ;; from a rejected dispatch), which the run-start arm
-                ;; (rf2-rly4a) is the canonical source for. Only the
-                ;; run-start arm above pins `:dispatch-id`.
+                ;; from a rejected dispatch); the run-start arm (rf2-rly4a)
+                ;; is the canonical source for it, so only that arm above
+                ;; pins `:dispatch-id`.
                 (and (nil? (:fallback acc)) (some? (:rf.trace/event-id tags)))
                 (assoc acc :fallback {:event-id (:rf.trace/event-id tags)
                                       :event    (:rf.event/v tags)})

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -141,9 +141,9 @@
                          frame-id target render-key))
           ;; EP-0015 §15 + open-issue 6 (RULED, hardened): the back-fill
           ;; appends the RAW render event (to `:trace-events`) + the RAW
-          ;; projected row (to `:renders`). Storage-side redaction was
-          ;; REMOVED — the ring is causal replay material; the `:redact-fn`
-          ;; advanced override runs projection-side only, inside
+          ;; projected row (to `:renders`). The ring is causal replay
+          ;; material, so it stays raw; the `:redact-fn` advanced override
+          ;; runs projection-side only, inside
           ;; `projected-record`, so the off-box egress (Xray-MCP
           ;; `watch-epochs`, recorders) sees the redacted shape while the
           ;; ring + this listener fan-out deliver the raw record. No
@@ -201,12 +201,11 @@
   `useEffect`-cleanup time — AFTER the cascade that removed the view settled
   — so it cannot ride the in-flight cascade buffer (there is none).
 
-  Pre-rf2-59hx3 the unmount fell through `capture-event!`'s orphan-drop
-  branch (no in-flight cascade + no `:dispatch-id`) and was silently
-  dropped, so a view teardown produced NO signal in the epoch record and
-  Xray's VIEWS-step `unmounted-views-rows` — which reads `:rf.view/unmounted`
-  off `:trace-events` — had nothing to surface. The teardown was an
-  invisible absence.
+  With no in-flight cascade and no `:dispatch-id`, the unmount would
+  otherwise fall through `capture-event!`'s orphan-drop branch and leave
+  no signal in the epoch record — so Xray's VIEWS-step
+  `unmounted-views-rows`, which reads `:rf.view/unmounted` off
+  `:trace-events`, would have nothing to surface.
 
   This back-fills the unmount into the frame's most-recently-settled epoch
   (the cascade that drove the teardown). Unlike `record-render!` there is NO
@@ -281,7 +280,7 @@
        conforms the record to Spec-Schemas §`:rf/epoch-record` §Outcomes,
        which documents `:halted-destroy` as carrying the pre-cascade
        snapshot as `:frame-state-before` and the destroy-time/partial state
-       as `:frame-state-after` — NOT the prior nil / nil. The record is delivered
+       as `:frame-state-after`. The record is delivered
        to LISTENERS ONLY — it is NOT appended to the ring buffer, because
        step 3 drops the destroyed frame's ring and `(rf/epoch-history
        destroyed)` returns `[]` per the rf2-d656 read-empty contract.
@@ -334,8 +333,8 @@
     ;; mid-drain case. Per rf2-9neiq the `:db-before` / `:db-after`
     ;; slots carry the real pre-cascade + destroy-time snapshots
     ;; `destroy-frame!` threaded (captured before the container was
-    ;; torn down), so the record matches the documented contract rather
-    ;; than the prior nil / nil. The record is delivered to listeners
+    ;; torn down), so the record matches the documented contract. The
+    ;; record is delivered to listeners
     ;; only — the ring buffer gets dropped in step 3 (rf2-d656).
     ;; Mid-drain detection reuses the canonical
     ;; `capture/in-flight-cascade?` gate (the same predicate the
@@ -347,9 +346,9 @@
         ;; Per EP-0015 §15 + open-issue 6 (RULED, hardened): the
         ;; halted-destroy partial record is delivered RAW to listeners
         ;; (the same posture as the :ok / :halted-depth ring records).
-        ;; Storage-side redaction was REMOVED — epoch records are causal
-        ;; replay material; the `:redact-fn` advanced override runs
-        ;; projection-side only, inside `projected-record`. A listener
+        ;; Epoch records are causal replay material, so they stay raw; the
+        ;; `:redact-fn` advanced override runs projection-side only, inside
+        ;; `projected-record`. A listener
         ;; that forwards off-box projects at its egress boundary.
         (let [record (assembly/build-record frame-id fs-before fs-after buffered-events
                                             committed-at

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -205,11 +205,11 @@
   means 'keep every record's :trace-events'.
 
   HOT PATH: invoked from `append-record` on every drain settle (every
-  user-facing event). Pre-rf2-1e38x this rewrote the whole history
-  vector via `map-indexed`; under steady state only one record per
-  append actually transitions, so the O(n) walk was wasted work. The
-  steady-state invariant holds because every prior append already
-  elided its own just-crossed record; runtime reductions of `keep`
+  user-facing event). Under steady state only one record per append
+  actually transitions out of the keep-window, so touching just that
+  record (rather than walking the whole history vector) is all that is
+  needed. The steady-state invariant holds because every prior append
+  already elided its own just-crossed record; runtime reductions of `keep`
   via `(rf/configure! {:epoch-history ...})` will take full effect on
   subsequent appends rather than retroactively rewriting the buffer
   (pre-alpha posture)."
@@ -300,11 +300,11 @@
 ;; settled (Reagent batches re-renders onto a later tick — see
 ;; `re-frame.interop/after-render`). By commit time `settle!` has already
 ;; harvested the cascade buffer and committed the record, so the render
-;; emit lands in a now-empty buffer and — pre-rf2-qs6dl — was harvested
-;; by the NEXT cascade's settle, mis-attributing every render to cascade
-;; N+1 (the one-epoch lag the bead documents).
+;; emit lands in a now-empty buffer; left to the ordinary harvest it would
+;; be vacuumed by the NEXT cascade's settle and mis-attributed to cascade
+;; N+1 (a one-epoch lag).
 ;;
-;; The fix attributes the render to the cascade that CAUSED it: when a
+;; Instead the render is attributed to the cascade that CAUSED it: when a
 ;; render fires with no in-flight cascade for the frame, it is back-filled
 ;; into that frame's most-recently-settled epoch record (the cascade that
 ;; dirtied the view's inputs and scheduled the re-render). `last-settled-
@@ -560,16 +560,16 @@
       `:sub-runs` `deps`-only match (harmless — they predate the re-render).
 
     * keep = 0 (rf2-bhglx) — no record retains raw traces, so EVERY record is
-      matched via its structured `:sub-runs`. Pre-fix the scan broke at the
-      first trace-elided record (the NEWEST one under keep-0) and returned nil,
-      so a genuine value-changing sub-run sitting in the newest epoch's
-      `:sub-runs` was never seen and the render was mis-attributed to the
+      matched via its structured `:sub-runs`. The scan must NOT break at the
+      first trace-elided record (the NEWEST one under keep-0): a genuine
+      value-changing sub-run sitting in the newest epoch's `:sub-runs` must
+      still be seen, or the render would be mis-attributed to the
       mount/default epoch. Consulting `:sub-runs` lets the newest-first scan
       find it and short-circuit on the current epoch.
 
-  The earlier hard break at the elision boundary (rf2-3rg4j / rf2-b2c02) is
-  GONE: it assumed a trace-elided record can never match, which the structured
-  `:sub-runs` fallback makes false. Under keep-0 the scan is O(depth) to a
+  The scan never treats the elision boundary as a hard stop (rf2-3rg4j /
+  rf2-b2c02): a trace-elided record can still match via its structured
+  `:sub-runs` fallback. Under keep-0 the scan is O(depth) to a
   miss; that is the necessary cost of attribution when no trace window exists,
   and it still short-circuits on the first (newest) value-change for the common
   genuine-re-render case. One pass newest-first; short-circuits at the first
@@ -628,13 +628,13 @@
 ;; A `:view/render` (rf2-qs6dl) and a reactive `:sub/run` (rf2-wi900) both
 ;; fire at React COMMIT / DEREF time, which Reagent batches onto a later
 ;; tick AFTER the causing cascade settled. So each lands in the now-empty
-;; capture buffer post-settle and — pre-fix — was harvested by the NEXT
-;; cascade's settle, mis-attributing it to cascade N+1 (the one-epoch lag
-;; both beads document: a phantom render in the wrong cascade's
-;; `:renders`, a phantom sub-run + `:value-changed?` in the wrong
-;; cascade's `:sub-runs` / Xray Views subs table).
+;; capture buffer post-settle; left to the ordinary harvest it would be
+;; vacuumed by the NEXT cascade's settle and mis-attributed to cascade N+1
+;; (a one-epoch lag: a phantom render in the wrong cascade's `:renders`, a
+;; phantom sub-run + `:value-changed?` in the wrong cascade's `:sub-runs` /
+;; Xray Views subs table).
 ;;
-;; The fix back-fills the event into the cascade that CAUSED it (the
+;; Instead the event is back-filled into the cascade that CAUSED it (the
 ;; frame's most-recently-settled epoch — the cascade that dirtied the
 ;; view's / reaction's inputs and scheduled the re-render / recompute),
 ;; reusing the `last-settled-epoch` map. The render and sub-run paths are
@@ -942,9 +942,9 @@
       ;; (capture/capture-event! out-of-cascade branch) so in normal
       ;; operation none arrive. This seam is the defensive backstop: a
       ;; nil-dispatch-id orphan that slips past the upstream guard has no
-      ;; settle event to ever reclaim it, so retaining it (the pre-rf2-ee38b
-      ;; behaviour) left it in the buffer indefinitely — re-grouped into
-      ;; `theirs` and re-retained on every subsequent harvest. Discarding
+      ;; settle event to ever reclaim it, so retaining it would leave it in
+      ;; the buffer indefinitely — re-grouped into `theirs` and re-retained
+      ;; on every subsequent harvest. Discarding
       ;; it makes the harvest self-cleaning and removes reliance on the
       ;; upstream guard being perfect (rf2-ee38b §correctness). The
       ;; `event-dispatch-id = settling-id` predicate already guarantees an

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -668,14 +668,11 @@
       record; the projected row is appended when non-nil.
 
   Per EP-0015 §15 + open-issue 6 (RULED, hardened): the back-fill appends
-  the RAW delta. Storage-side redaction was REMOVED — the ring is causal
-  replay material; the `:redact-fn` advanced override runs projection-side
-  only (inside `projected-record`), so the off-box egress sees the
-  redacted shape while the ring keeps the exact raw delta. The whole-record
-  redaction dance the old storage-side hook required (the rf2-82pcg leak
-  the back-fill once needed to plug, the rf2-qhxz6 once-per-slot narrowing,
-  the rf2-7i872 redact-outside-swap fix) is GONE: with no per-back-fill
-  redact invocation there is no leak to close on the storage path and no
+  the RAW delta. The ring is causal replay material, so it stays raw; the
+  `:redact-fn` advanced override runs projection-side only (inside
+  `projected-record`), so the off-box egress sees the redacted shape while
+  the ring keeps the exact raw delta. Because no redaction runs on the
+  storage path, there is no per-back-fill leak to close and no
   non-idempotent-fn hazard inside the swap.
 
   rf2-c0rv4v: the splice is a single PURE `swap!` update fn. It invokes no

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -102,10 +102,9 @@
   two are soft-pass: we can't disprove validity, so we treat the db
   as valid.
 
-  Single walk over the schema set — callers that previously chained
-  `schema-validate-ok?` + `failing-paths-for` paid two walks where one
-  suffices. The validity question is `(empty? (failing-schema-paths
-  frame-id db))`."
+  Single walk over the schema set: the validity question is
+  `(empty? (failing-schema-paths frame-id db))`, so callers get both the
+  yes/no answer and the failing paths from one traversal."
   [frame-id db]
   (let [schemas  (registered-app-schemas frame-id)
         validate (malli-validate-fn)]
@@ -163,15 +162,14 @@
           spec-snapshot-version))
 
 ;; EP-0001 (rf2-vzld77 / rf2-3aizt1 / rf2-k4xe7u) — the machine snapshots
-;; and route slice are DURABLE runtime-db partition state. rf2-vzld77 moved
-;; them to the namespaced runtime-db root keys `:rf.runtime/machines` /
-;; `:rf.runtime/routing`; the restore-precondition readers below take the
+;; and route slice are DURABLE runtime-db partition state, addressed at the
+;; namespaced runtime-db root keys `:rf.runtime/machines` /
+;; `:rf.runtime/routing`. The restore-precondition readers below take the
 ;; runtime-db PARTITION value (`(:rf.db/runtime frame-state)`) and walk those
-;; namespaced paths. Pre-fix they read the retired app-db `[:rf/runtime …]`
-;; path off the epoch-recorded app-db (which is now empty → silently nil), so
-;; the missing-handler-machine + version-drift preconditions no longer fired
-;; (rf2-k4xe7u). The epoch now captures the whole frame-state (decision #2),
-;; so `check-restore-preconditions!` passes the runtime-db partition here.
+;; namespaced paths. The epoch captures the whole frame-state (decision #2),
+;; so `check-restore-preconditions!` passes the runtime-db partition here,
+;; against which the missing-handler-machine + version-drift preconditions
+;; fire.
 (def ^:private machine-snapshots-path
   "Path to the machine-snapshots map inside the runtime-db partition value."
   [:rf.runtime/machines :snapshots])
@@ -228,7 +226,7 @@
 
   `runtime-db` is the `:rf.db/runtime` partition of the epoch-recorded
   frame-state (EP-0001 rf2-3aizt1 / rf2-k4xe7u — machine snapshots + route
-  slice are runtime-db state, NOT the retired app-db `[:rf/runtime …]` path).
+  slice are runtime-db partition state).
 
   Per rf2-ocg1: machine lookup goes through the event registry, NOT
   the internal `:head` registrar kind. The latter is unrelated to
@@ -554,7 +552,7 @@
 ;;
 ;; Late-bound so epoch never statically depends on the optional Resources
 ;; artefact — absent the artefact the hook is nil and the runtime-db installs
-;; verbatim (the pre-rf2-7r5mc2 behaviour, correct for an app with no resources).
+;; verbatim, which is correct for an app with no resources.
 
 (defn reconcile-runtime-db-on-restore
   "Reconcile the runtime-db partition of a `frame-state` value about to be
@@ -950,10 +948,10 @@
 ;; of `project-egress`'s `:rf.observe/*` record kinds, so each tree slot is
 ;; handed to `project-egress` as a KINDLESS tree value (the direct-read
 ;; path), which delegates to `elide-wire-value` against the frame's
-;; classification. This replaces the prior ad-hoc `elide-wire-value` calls
-;; with the frame/profile projection primitive (EP-0015 bead-plan item 10).
+;; classification. Routing every slot through the frame/profile projection
+;; primitive (EP-0015 bead-plan item 10) keeps elision in one place.
 ;;
-;; Two slots are value-bearing in ways the original four-slot model missed:
+;; Two slots are value-bearing and need the same projection walk:
 ;;
 ;;   - The CANONICAL frame-state slots `:frame-state-before` /
 ;;     `:frame-state-after` (EP-0001 rf2-3aizt1 decision #2 + ruling #14):
@@ -1040,7 +1038,7 @@
   selects the boundary (default `:rf.egress/off-box-observability`); MCP /
   AI / tool consumers pass `:rf.egress/off-box-tool` to receive the
   structural marker indicators / counters the tool profile enables. The
-  selected profile is the floor; the legacy unqualified `:include-sensitive?`
+  selected profile is the floor; the unqualified `:include-sensitive?`
   / `:include-large?` opts default `false` (the off-box safe path) and, when
   a trusted-local caller opts them back in, compose on top as ADVANCED
   explicit `:rf.size/*` overrides (the override wins — see
@@ -1577,11 +1575,11 @@
   `:rf.event/v` trace tag (`capture/find-trigger-event`); they are NOT
   routed through the marks-projection chokepoint at emit time, NOR are they
   rooted at the frame's app-db, so the schema-path-keyed `elide-wire-value`
-  walker cannot prove any of them safe. (The prior projection routed this
-  slot through the generic `project-payload-slot`, which roots the walk at
-  the frame's app-db classification — so a secret carried positionally in
-  the event vector, e.g. `[:login \"topsecret\"]`, egressed RAW because no
-  app-db sensitive declaration matches the trigger-event path.)
+  walker cannot prove any of them safe. (Routing this slot through the
+  generic `project-payload-slot` would root the walk at the frame's app-db
+  classification — so a secret carried positionally in the event vector,
+  e.g. `[:login \"topsecret\"]`, would egress RAW because no app-db
+  sensitive declaration matches the trigger-event path.)
 
   A safe per-event projection cannot be proven, so off-box egress FAILS
   CLOSED (Spec 009 §Privacy / sensitive data in traces + Security.md
@@ -1679,7 +1677,7 @@
       tool) should pass. An unknown profile is rejected against the closed
       enum (a typo is a loud error, never a silent permissive walk).
 
-  The legacy unqualified `:include-*` keys are ADVANCED per-call overrides
+  The unqualified `:include-*` keys are ADVANCED per-call overrides
   composed OVER the selected profile (NOT the primary boundary selector):
 
       {:include-sensitive?  <bool>   ;; reveal app-db sensitive values

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -1285,11 +1285,11 @@
 ;;
 ;; The false-green guard at the projection boundary. The :rf.view/rendered op
 ;; stamps :rf.view/cause-event-id (views.cljs, rf2-1cc03) exactly as the
-;; :rf.sub/run op stamps :rf.sub/cause-event-id — but render-row formerly
-;; dropped it, so every projected render row keyed as nil and the Story
-;; causal/cascade :view surface silently measured 0 (an over-render could
-;; never be caught: a SILENT GREEN). This pins that the render row carries
-;; the cause end-to-end, mirroring the sub-row.
+;; :rf.sub/run op stamps :rf.sub/cause-event-id, and the render row must
+;; carry it through: if a projected render row keyed as nil, the Story
+;; causal/cascade :view surface would silently measure 0 and an over-render
+;; could never be caught (a SILENT GREEN). This pins that the render row
+;; carries the cause end-to-end, mirroring the sub-row.
 
 (deftest renders-projection-carries-cause-event-id
   (testing "rf2-9gquv — a :rf.view/rendered op carrying :rf.view/cause-event-id

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -534,15 +534,13 @@
 ;;
 ;; RAW back-fill under CAS contention. `back-fill-event!` mutates the single
 ;; global `histories` atom under `swap!`. Per EP-0015 §15 + open-issue 6
-;; (RULED, hardened) the back-fill stores the RAW delta — storage-side
-;; redaction was REMOVED (the ring is causal replay material; the
-;; `:redact-fn` advanced override runs projection-side only). The swap
-;; update fn (the pure splice inside `back-fill-event!`, rf2-c0rv4v) is
-;; therefore PURE — it invokes no injected
-;; fn, so a JVM CAS retry re-runs only the pure splice. The pre-removal
-;; redact-outside-swap dance (rf2-7i872) is gone by construction: there is
-;; no per-back-fill redact invocation, hence no double-invoke / duplicate-
-;; warning hazard.
+;; (RULED, hardened) the back-fill stores the RAW delta — the ring is causal
+;; replay material, so it stays raw; the `:redact-fn` advanced override runs
+;; projection-side only. The swap update fn (the pure splice inside
+;; `back-fill-event!`, rf2-c0rv4v) is therefore PURE — it invokes no injected
+;; fn, so a JVM CAS retry re-runs only the pure splice. With no per-back-fill
+;; redact invocation there is no double-invoke / duplicate-warning hazard
+;; inside the swap.
 ;;
 ;; This scenario drives N threads, each performing M post-settle sub-run
 ;; back-fills (`state/back-fill-sub-run!`) against its OWN frame's settled
@@ -601,9 +599,9 @@
                             (dotimes [i stress-iters]
                               (let [sid (keyword (str "s" i))]
                                 ;; Production post-settle path: the back-fill
-                                ;; stores the RAW delta — no redact arg (the
-                                ;; storage-side hook was removed; redaction is
-                                ;; projection-side, in `projected-record`).
+                                ;; stores the RAW delta — no redact arg
+                                ;; (redaction is projection-side, in
+                                ;; `projected-record`).
                                 (state/back-fill-sub-run!
                                   frame-id epoch-id
                                   (sub-run-event frame-id sid i)
@@ -640,12 +638,12 @@
 ;;
 ;; BACK-FILL vs INTERLEAVED EVICTION at ring cap. `back-fill-event!` fires at
 ;; React commit / deref / teardown time, OUTSIDE any drain, so a cascade
-;; `record!` for the SAME frame can interleave with it. Pre-fix the back-fill
-;; resolved the target record's ring index against ONE `@histories` deref, then
-;; read / spliced against later derefs; at ring CAP an interleaved append EVICTS
-;; the front record and shifts every index down by one, so the stale up-front
-;; index spliced the WRONG record. The fix re-derives the index from the SINGLE
-;; CAS-retried `@histories` value inside the one `swap!`.
+;; `record!` for the SAME frame can interleave with it. The back-fill must
+;; re-derive the target record's ring index from the SINGLE CAS-retried
+;; `@histories` value inside the one `swap!`: resolving the index against one
+;; deref and then splicing against a later deref would splice the WRONG record,
+;; because at ring CAP an interleaved append EVICTS the front record and shifts
+;; every index down by one.
 ;;
 ;; This scenario pins ONE frame at a small ring cap and runs two contending
 ;; thread groups against it:

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -140,8 +140,8 @@
 
 ;; ---- EP-0015 §15 / open-issue 6 :redact-fn surface JVM coverage ----------
 ;;
-;; Post-ruling the `:redact-fn` is the PROJECTION-SIDE advanced override —
-;; storage-side mutation was REMOVED. It is NEVER invoked by `settle!` /
+;; The `:redact-fn` is the PROJECTION-SIDE advanced override, never a
+;; storage-side mutation. It is NEVER invoked by `settle!` /
 ;; `replace-app-db!` / the back-fill (regardless of gate); it runs ONLY
 ;; inside `projected-record`, applied to the projected egress copy. The
 ;; ring is causal replay material, delivered raw.

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
@@ -227,8 +227,8 @@
 ;; Per Spec-Schemas §`:rf/epoch-record` and Security.md §Epoch privacy
 ;; posture: each assembled record carries an integer count of
 ;; frame-declared sensitive paths whose value differs between :db-before
-;; and :db-after. Computed inside `build-record` from the RAW dbs (now
-;; always raw — storage-side redaction was removed). Closes the
+;; and :db-after. Computed inside `build-record` from the RAW dbs (the
+;; stored record is always raw). Closes the
 ;; "redact-fn ⇒ empty diff but something changed" gap for projected egress.
 ;;
 ;; Coverage matrix:

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -165,7 +165,7 @@
           ":depth nil dropped; prior 9 survives"))))
 
 ;; ============================================================================
-;;  Invariant 1 — ring + listeners are RAW (storage-side redaction removed)
+;;  Invariant 1 — ring + listeners are RAW (no storage-side redaction)
 ;; ============================================================================
 
 (deftest invariant-1-ring-record-is-raw-even-with-redact-fn-installed
@@ -647,8 +647,8 @@
 ;;  "verify with a restore/replay test" instruction (rf2-t55hxg.9)
 ;; ============================================================================
 ;;
-;; Disposition 6 (epoch redaction) is IMPLEMENTED CORRECTLY — the storage-side
-;; `:redact-fn` mutation was removed, so the in-process ring carries the RAW
+;; Disposition 6 (epoch redaction) is IMPLEMENTED CORRECTLY — the `:redact-fn`
+;; never mutates storage, so the in-process ring carries the RAW
 ;; record (invariant 1, above) and the restore path reads that raw ring,
 ;; never the projected copy. The replay-faithful-under-redaction property
 ;; therefore holds BY CONSTRUCTION. But the disposition's explicit instruction

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -200,16 +200,16 @@
 ;; processing-start (re-frame.cofx/deliver-declared-cofx writes the generated
 ;; value back into the in-flight `:rf.cofx` record).
 ;;
-;; Before rf2-1xdotm the assembled `:rf/epoch-record` carried `:trigger-event`
-;; / `:event-id` / `:dispatch-id` but NO first-class `:rf.cofx` replay token,
-;; so a tool replaying from the record could not supply the exact facts the
-;; original run consumed: under strict replay it would miss the generated fact
-;; and fail with `:rf.error/missing-required-cofx`. These tests reproduce the
-;; gap with a generator-backed recordable cofx and pin the fix end-to-end —
-;; dispatch once with no supplied fact (generator mints it), assert the record
-;; carries the post-generation `:rf.cofx`, then replay the recorded event under
-;; `:strict` from that token and assert NO generator call occurs and the
-;; handler receives the recorded value.
+;; The assembled `:rf/epoch-record` carries `:trigger-event` / `:event-id` /
+;; `:dispatch-id` AND a first-class `:rf.cofx` replay token (rf2-1xdotm), so a
+;; tool replaying from the record can supply the exact facts the original run
+;; consumed. Without that token a strict replay would miss a generated fact
+;; and fail with `:rf.error/missing-required-cofx`. These tests pin the
+;; property end-to-end with a generator-backed recordable cofx — dispatch once
+;; with no supplied fact (generator mints it), assert the record carries the
+;; post-generation `:rf.cofx`, then replay the recorded event under `:strict`
+;; from that token and assert NO generator call occurs and the handler
+;; receives the recorded value.
 
 (deftest epoch-record-carries-post-generation-rf-cofx
   (testing "rf2-1xdotm — the assembled :rf/epoch-record exposes the complete
@@ -2324,15 +2324,15 @@
 ;;
 ;; `value-changed-epoch-for` (state.cljc) scans the ring newest-first for the
 ;; epoch that genuinely re-rendered a view, bounded so it only walks records
-;; that still carry `:trace-events` (the matchable set). rf2-3rg4j bounded it
-;; at `(- n keep)`. rf2-b2c02 R2: that index-derived bound is correct only in
-;; STEADY STATE — after a RUNTIME `:trace-events-keep` REDUCTION, elision is
-;; non-retroactive (`elide-just-crossed-trace-events`'s docstring), so records
-;; that were inside the OLD keep-window still carry `:trace-events` yet now sit
-;; BELOW `(- n new-keep)`. An index bound would skip those still-trace-bearing
-;; records and miss a genuine value-change, mis-attributing the render. The fix
-;; bounds the scan on the directly-observable elision state (break at the first
-;; record MISSING `:trace-events`) so it tracks reality under any reconfigure.
+;; that still carry `:trace-events` (the matchable set). The scan bounds on the
+;; directly-observable elision state (rf2-b2c02 R2): it breaks at the first
+;; record MISSING `:trace-events`, so it tracks reality under any reconfigure.
+;; An index bound at `(- n keep)` (rf2-3rg4j) is correct only in STEADY STATE:
+;; after a RUNTIME `:trace-events-keep` REDUCTION, elision is non-retroactive
+;; (`elide-just-crossed-trace-events`'s docstring), so records that were inside
+;; the OLD keep-window still carry `:trace-events` yet now sit BELOW
+;; `(- n new-keep)` — an index bound would skip those still-trace-bearing
+;; records and miss a genuine value-change, mis-attributing the render.
 ;;
 ;; rf2-yw1w1u — the two tests below KEEP direct private-var access
 ;; (`@#'state/histories`, `@#'state/config`, `@#'state/value-changed-epoch-for`)
@@ -2868,11 +2868,11 @@
 ;; (rf/configure! {:epoch-history {:depth 0}}) the ring buffer is DISABLED by
 ;; documented design (Tool-Pair §Time-travel — depth 0 retains no history;
 ;; consume via register-epoch-listener!), so the synthetic anchor can never land
-;; in the ring. Pre-fix: state/record! early-returned under its pos-depth guard,
-;; so NOTHING landed, yet perform-replace! returned true AND re-anchored
-;; last-settled-epoch (a PHANTOM anchor naming a non-ring epoch-id) — a tool/pair
-;; gesture believed it could rewind and could not (restore-epoch! of that id
-;; failed :rf.epoch/restore-unknown-epoch). Contract chosen: LOUD REJECT —
+;; in the ring (state/record! early-returns under its pos-depth guard). If
+;; perform-replace! nonetheless returned true and re-anchored last-settled-epoch
+;; (a PHANTOM anchor naming a non-ring epoch-id), a tool/pair gesture would
+;; believe it could rewind and could not (restore-epoch! of that id fails
+;; :rf.epoch/restore-unknown-epoch). The contract is therefore LOUD REJECT —
 ;; depth 0 means "history disabled", so force-appending the anchor would
 ;; contradict the spec; instead reject loudly via the in-artefact failure
 ;; channel (the analogue of the artefact-missing throw at core_epoch.cljc:111).
@@ -3016,10 +3016,10 @@
 ;; ---- replace-runtime-db! / replace-frame-state! (rf2-szbzei) ---------------
 ;;
 ;; Per Tool-Pair §Pair-tool writes the four partition-aware injection
-;; mutators are ALL epoch-backed dev/tooling writes. rf2-szbzei extends
-;; the epoch-backed write path (previously app-db-only) to the runtime-db
-;; and full-frame mutators. The invariants below mirror the app-db-pair
-;; tests above, proving the four contract points the bead enumerates:
+;; mutators are ALL epoch-backed dev/tooling writes — the app-db, runtime-db,
+;; and full-frame mutators all run through the one epoch-backed write path
+;; (rf2-szbzei). The invariants below mirror the app-db-pair tests above,
+;; proving the four contract points the bead enumerates:
 ;;
 ;;   1. A replace-runtime-db! / replace-frame-state! injection records a
 ;;      synthetic :rf.epoch/db-replaced epoch, and restore-epoch! of a PRIOR
@@ -3311,14 +3311,13 @@
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     ;; Out-of-drain emit: :rf.epoch/db-replaced fires with a :frame tag.
-    ;; Pre-fix, capture-event! would buffer it into capture-buffers[:test/main].
+    ;; capture-event! must NOT buffer it into capture-buffers[:test/main].
     (rf/replace-app-db! :test/main {:n 100})
 
-    ;; Cascade 2: a real event. Post-fix, its harvested record reflects
-    ;; only the :bump cascade. Pre-fix, the leaked :rf.epoch/db-replaced
-    ;; event would be the FIRST event in the buffer, and
-    ;; find-trigger-event's fallback arm would pick its :epoch-id over
-    ;; the real :bump event.
+    ;; Cascade 2: a real event. Its harvested record reflects only the :bump
+    ;; cascade. Were the :rf.epoch/db-replaced event leaked into the buffer it
+    ;; would be the FIRST event there, and find-trigger-event's fallback arm
+    ;; would pick its :epoch-id over the real :bump event.
     (rf/dispatch-sync [:bump] {:frame :test/main})
 
     (let [history    (rf/epoch-history :test/main)
@@ -3745,13 +3744,6 @@
         (is (= 1 (count silenced))
             "silencing fires for the observed frame")))))
 
-;; rf2-ee38b: the `clear-frame-history!` seam pin (rf2-jvrd) was removed
-;; alongside the dead `defn-` it existed solely to test — scoped clearing
-;; is not on the integration critical path (the fixture uses the unscoped
-;; `clear-history!`), and `state/drop-frame-history!` is already exercised
-;; directly by the destroy path. Pre-alpha posture favours deleting
-;; unreferenced API surface over preserving a self-justifying seam.
-
 ;; ---- rf2-ronz: on-frame-destroyed! direct unit pin ------------------------
 ;;
 ;; Per test-coverage-review-2026-05-12 P3-20. Currently reached only
@@ -3836,9 +3828,8 @@
 ;; buffer — treating it as belonging to that cascade. The
 ;; `find-trigger-event` fallback would pick its `:epoch-id` as the
 ;; trigger; `project-all` (rf2-ecu37) would silently include the
-;; leaked entries. The rf2-htf28 fix added the missing ops to the skip-set; pin
-;; the contract here so a future regression that drops them surfaces
-;; loudly.
+;; leaked entries. The skip-set carries these ops (rf2-htf28); this pins
+;; the contract so a future regression that drops them surfaces loudly.
 
 (deftest capture-buffer-does-not-cross-contaminate-from-replace-app-db
   (testing "an out-of-drain :rf.epoch/db-replaced emit from
@@ -3851,8 +3842,8 @@
     ;; 1. Drive one cascade — clean record lands.
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
-    ;; 2. replace-app-db! out-of-drain — emits :rf.epoch/db-replaced
-    ;;    which (pre-rf2-htf28) would buffer into capture-buffers.
+    ;; 2. replace-app-db! out-of-drain — emits :rf.epoch/db-replaced,
+    ;;    which must NOT buffer into capture-buffers.
     (is (true? (rf/replace-app-db! :test/main {:n 99})))
 
     ;; 3. Drive a second cascade for [:foo].
@@ -3953,15 +3944,12 @@
 ;; for a destroyed frame; devtools receive the record via the listener
 ;; fan-out, the documented introspection channel for the destroy halt).
 ;;
-;; rf2-9neiq corrected the FALSE-GREEN db assertions here: this test
-;; previously PINNED `nil` :db-before / :db-after, contradicting
-;; Spec-Schemas §:rf/epoch-record §Outcomes, which documents
-;; :halted-destroy as carrying the PRE-CASCADE snapshot as :db-before and
-;; the DESTROY-TIME state as :db-after. The prior nil/nil arose because
-;; `destroy-frame!` notified epoch AFTER the container was dissoc'd; the
-;; fix threads both snapshots (pre-cascade via frame/*cascade-db-before*,
-;; destroy-time via the container read at the top of destroy-frame!) into
-;; the destroy hook so the record now carries the real app-db state.
+;; Per Spec-Schemas §:rf/epoch-record §Outcomes, :halted-destroy carries the
+;; PRE-CASCADE snapshot as :db-before and the DESTROY-TIME state as :db-after
+;; (rf2-9neiq) — NOT nil/nil. `destroy-frame!` threads both snapshots
+;; (pre-cascade via frame/*cascade-db-before*, destroy-time via the container
+;; read at the top of destroy-frame!) into the destroy hook before the
+;; container is dissoc'd, so the record carries the real app-db state.
 
 (deftest live-halted-destroy-fires-partial-record-with-real-snapshots
   (testing "a mid-drain destroy-frame! fires exactly one :halted-destroy
@@ -4159,15 +4147,14 @@
 ;; ---- rf2-7kxxx: find-trigger-event must not synthesise [eid] when
 ;; ---- :event tag is absent on the fallback arm ----------------------------
 ;;
-;; Per audit r3 §F2: the fallback arm of `find-trigger-event` previously
-;; synthesised `[eid]` as `:event` when the buffered event carried an
-;; `:event-id` tag but no `:event` tag. That misrepresents an event that
-;; originally carried payload (e.g. `[:foo "bar" 42]`) as a payload-less
-;; event. Post-fix: the fallback returns `:event nil` when the tag is
-;; absent, and (per rf2-kl5p1) `build-record` then omits the
-;; `:trigger-event` slot entirely. No silent fabrication; consumers
-;; rendering 'what triggered this cascade' either see the real event
-;; vector or none at all.
+;; Per audit r3 §F2: the fallback arm of `find-trigger-event` returns
+;; `:event nil` when the buffered event carries an `:event-id` tag but no
+;; `:event` tag, and (per rf2-kl5p1) `build-record` then omits the
+;; `:trigger-event` slot entirely. Synthesising `[eid]` as `:event` would
+;; misrepresent an event that carried payload (e.g. `[:foo "bar" 42]`) as a
+;; payload-less event, so there is no such fabrication; consumers rendering
+;; 'what triggered this cascade' either see the real event vector or none at
+;; all.
 
 (deftest find-trigger-event-fallback-does-not-synthesise-event-vector
   (testing "find-trigger-event's fallback arm — :event-id tag present,
@@ -4223,11 +4210,11 @@
 ;; Per the correctness review (ai/findings/review/correctness--
 ;; implementation-epoch.md): the run-start arm (rf2-rly4a) reads
 ;; :dispatch-id from the canonical `:event/run-start` trace, which is
-;; correct. The fallback arm previously also surfaced the :dispatch-id of
-;; an arbitrary non-run-start trace (e.g. an error trace from a rejected
-;; dispatch). Spec-Schemas §`:rf/epoch-record` documents :dispatch-id as
+;; correct. Surfacing the :dispatch-id of an arbitrary non-run-start trace
+;; (e.g. an error trace from a rejected dispatch) on the fallback arm would
+;; be wrong: Spec-Schemas §`:rf/epoch-record` documents :dispatch-id as
 ;; pinned from the run-start tag and ABSENT for a no-run-start cascade —
-;; so the fallback arm must NOT pin a dispatch-id; only the run-start arm
+;; so the fallback arm does NOT pin a dispatch-id; only the run-start arm
 ;; does.
 
 (deftest find-trigger-event-fallback-omits-dispatch-id
@@ -4339,12 +4326,12 @@
 
 ;; ---- rf2-douii: configure! validates at the boundary ---------------------
 ;;
-;; Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: `configure!` previously
-;; accepted any value for `:depth` and `:trace-events-keep`. A nil or
-;; non-numeric value would survive configuration and explode later at
-;; `record!` time when `pos?` / `nat-int?` ran on the stored value. The
-;; validation now sanitises at the boundary — invalid values are silently
-;; dropped, the prior valid config survives.
+;; Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: `configure!` validates
+;; `:depth` and `:trace-events-keep` at the boundary — invalid values (nil,
+;; non-numeric) are silently dropped and the prior valid config survives.
+;; Without that boundary check a bad value would survive configuration and
+;; explode later at `record!` time when `pos?` / `nat-int?` ran on the stored
+;; value.
 
 (deftest configure-rejects-nil-depth
   (testing "(rf/configure! {:epoch-history {:depth nil}}) is a no-op; the
@@ -4878,15 +4865,13 @@
 ;; `frame/replace-*` write returns STILL slips through — the liveness check
 ;; said "live", yet the physical write lands against a now-destroyed frame and
 ;; the choke-point `commit-frame-transition!` returns `nil` (the nil-container
-;; guard). Pre-rf2-s93722 the four perform helpers IGNORED that return, so they
-;; emitted success telemetry, recorded + fanned out a synthetic epoch, and
-;; returned `true` for a write that never happened.
-;;
-;; The fix: capture the `frame/replace-*` return; `nil` is the destroyed-frame
-;; signal (a non-nil — possibly EMPTY — changed-key-set means the write
-;; landed, even a no-op), so surface the canonical `:rf.error/no-such-handler`
-;; (kind :frame) / `false` BEFORE any success telemetry, synthetic epoch, or
-;; listener fanout. Empty-set / no-op writes stay successful.
+;; guard). The four perform helpers (rf2-s93722) capture that return: `nil` is
+;; the destroyed-frame signal (a non-nil — possibly EMPTY — changed-key-set
+;; means the write landed, even a no-op), so they surface the canonical
+;; `:rf.error/no-such-handler` (kind :frame) / `false` BEFORE any success
+;; telemetry, synthetic epoch, or listener fanout. Ignoring the return would
+;; emit success telemetry and a fanned-out synthetic epoch for a write that
+;; never happened. Empty-set / no-op writes stay successful.
 ;;
 ;; The race is reproduced by redefining the boundary `frame/replace-*` write
 ;; to DESTROY the frame and then delegate to the real fn — so liveness has
@@ -5200,12 +5185,12 @@
 ;;
 ;; notify-listeners! iterates a listener SNAPSHOT, then per cb-id calls
 ;; record-observation! (writing the separate observed-frames-by-cb atom)
-;; BEFORE invoking the callback. If unregister-epoch-listener! removes a cb
-;; between the snapshot and the record-observation! call, the stale cb-id
-;; would (pre-rf2-7i872) be RE-INTRODUCED into observed-frames-by-cb and
-;; later receive a bogus :rf.epoch.cb/silenced-on-frame-destroy trace on
-;; frame destroy. The fix gates record-observation! on the cb-id still being
-;; a live listener at record time.
+;; BEFORE invoking the callback. record-observation! is gated (rf2-7i872) on
+;; the cb-id still being a live listener at record time: if
+;; unregister-epoch-listener! removes a cb between the snapshot and the
+;; record-observation! call, an ungated write would RE-INTRODUCE the stale
+;; cb-id into observed-frames-by-cb, which would later receive a bogus
+;; :rf.epoch.cb/silenced-on-frame-destroy trace on frame destroy.
 
 (deftest record-observation-skips-unregistered-cb-no-stale-bookkeeping
   (testing "rf2-7i872 — record-observation! against a cb that has been

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -389,9 +389,10 @@
 ;; `:rf/time-ms` via `:rf.cofx/requires` (rf2-abyycr / rf2-601ife). Their
 ;; handlers read the recorded allocation FLAT under `:coeffects
 ;; :rf.resource/generation-allocation` (`{:generation N :counter N}`) and the
-;; causal time FLAT under `:coeffects :rf/time-ms` — they no longer re-mint
-;; `(inc snapshot)` from an ambient read NOR reach through the whole `:rf.cofx`
-;; token for the time fact. The allocation is recorded on the token
+;; causal time FLAT under `:coeffects :rf/time-ms` — the generation comes
+;; from the recorded allocation rather than an ambient `(inc snapshot)`, and
+;; the time fact is read directly from the coeffects, not through the whole
+;; `:rf.cofx` token. The allocation is recorded on the token
 ;; (generator-backed recordable cofx) so replay reproduces an identical
 ;; generation; the host high-water advances via the
 ;; `:rf.resource/commit-generation` fx (`max`).

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -86,9 +86,8 @@
 ;; token's `:rf/time-ms` (rf2-dsyqmz); the terminal `:settled-at` + any patch /
 ;; populate `:loaded-at` is the reply token's completion time (`:completed-at`,
 ;; the reply event's causal `:rf/time-ms`, rf2-40dqi6 / rf2-r65m41). No ambient
-;; clock is read at a durable write site, so this ns no longer defines a
-;; `now-ms` helper (the remaining timer DELAYS are advisory host transients
-;; computed from the durable absolute timestamps).
+;; clock is read at a durable write site (the timer DELAYS are advisory host
+;; transients computed from the durable absolute timestamps).
 ;;
 ;; The pure stale / timer helpers a patched / populated entry reads
 ;; (`stale-at-for` / `positive-or-nil` / `server-frame?`) live in `state.cljc`

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -87,9 +87,8 @@
 ;; The WALL-clock epoch-ms read this slice uses — the server clock stamped on
 ;; `loaded-at` / `stale-at`, and the live clock the client compares restored
 ;; absolute timestamps against to surface skew — is the core
-;; `re-frame.interop/epoch-now-ms` (rf2-366u0g). It is byte-identical to the
-;; private `now-ms` this ns used to define (`System/currentTimeMillis` on the
-;; JVM, `js/Date.now` on CLJS) and is the canonical EP-0010 §Time wall-clock
+;; `re-frame.interop/epoch-now-ms` (rf2-366u0g — `System/currentTimeMillis`
+;; on the JVM, `js/Date.now` on CLJS), the canonical EP-0010 §Time wall-clock
 ;; surface — NOT the perf clock `interop/now-ms` (`performance.now()` on CLJS,
 ;; origin-relative, ~1e4), which is incomparable with `js/Date`-based freshness
 ;; checks. These resources are durable freshness / skew readers, so the wall

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -452,9 +452,8 @@
 ;;   3. a reserved bare-keyword scope wrapped in a vector (the canonical
 ;;      `:rf.scope/global` supplied as the singleton `[:rf.scope/global]`) is
 ;;      rejected fail-closed (rf2-bwwk6l) — the global scope IS the bare
-;;      keyword, and a wrapped spelling that silently collapsed to it was a
-;;      back-compat alias for historical prose, not a second spelling the
-;;      contract blesses.
+;;      keyword `:rf.scope/global`, and the wrapped spelling is not a second
+;;      spelling the contract blesses.
 
 (def reserved-scope-ns
   "The framework-reserved scope namespace (`:rf.scope/*`, per Conventions
@@ -491,10 +490,8 @@
   "Throw `:rf.error/resource-invalid-scope` when `scope` is a VECTOR whose
   head is a reserved bare-keyword concrete scope (`:rf.scope/global`) —
   i.e. the singleton `[:rf.scope/global]` spelling (rf2-bwwk6l). The global
-  scope IS the bare keyword `:rf.scope/global`; wrapping it in a vector was a
-  back-compat alias the implementation silently collapsed, kept only for
-  payloads copied from historical prose. Pre-alpha there is no alias: the
-  wrapped form fails closed and the diagnostic names the canonical bare
+  scope IS the bare keyword `:rf.scope/global`; the wrapped form is not an
+  alias for it — it fails closed and the diagnostic names the canonical bare
   spelling. A genuine scope TUPLE like `[:rf.scope/session {…}]` carries a
   payload after the namespaced tag and is untouched — only a reserved
   bare-keyword head with NO concrete payload (the historical alias shape) is

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -240,8 +240,8 @@
   in another.
 
   The 2-arity stamps the entry's own `:resource/key` — the scoped-key VECTOR
-  `[canonical-scope resource-id canonical-params]` (rf2-9e0tyq). Since the
-  `:entries` map is now keyed on the CEDN-1 byte `key-id` (a string), the
+  `[canonical-scope resource-id canonical-params]` (rf2-9e0tyq). Because the
+  `:entries` map is keyed on the CEDN-1 byte `key-id` (a string), the
   kind-preserving scoped-key vector is carried INSIDE the entry so every
   consumer that needs the `[scope rid params]` shape (the prior-sibling scan,
   the scope-mismatch heuristic, the clear-scope filter, the Xray live-node
@@ -263,16 +263,16 @@
 ;; canonicalization / domain validation to `identity/canonical` (rf2-wgutc2,
 ;; EP-0012 correctness review item 1).
 ;;
-;; This closes three divergences the prior resource-local canonicalizer
-;; carried against CEDN-1:
-;;   - it accepted broad `number?` values (floats, ratios, decimals,
-;;     out-of-safe-range integers) — CEDN-1 admits only portable integers in
-;;     the ECMAScript safe range, and rejects the rest fail-closed;
-;;   - it collapsed lists to vectors (`(sequential? x) (mapv …)`), erasing
-;;     the list-vs-vector EDN distinction CEDN-1 preserves (Conventions
-;;     §Sequences and sets: "Vectors and lists … are distinct EDN facts");
-;;   - it sorted map keys under a bespoke `total-edn-compare`, a second
-;;     ordering definition the shared CEDN-1 byte order subsumes.
+;; Delegating to the shared algebra means resource identities get exactly
+;; the CEDN-1 guarantees:
+;;   - only portable integers in the ECMAScript safe range are admitted as
+;;     numbers; floats, ratios, decimals, and out-of-safe-range integers
+;;     are rejected fail-closed;
+;;   - lists and vectors stay distinct EDN facts (Conventions §Sequences
+;;     and sets: "Vectors and lists … are distinct EDN facts"), never
+;;     collapsed together;
+;;   - map-key ordering is the one shared CEDN-1 byte order, with no
+;;     bespoke second ordering definition.
 ;;
 ;; `identity/canonical` also fails closed on DUPLICATE canonical map keys
 ;; (two distinct host keys whose CEDN-1 bytes collide), so a colliding cache
@@ -612,7 +612,7 @@
   here is pure overhead on a per-reaction path (rf2-rplgkw).
 
   The returned vector is the kind-PRESERVING canonical identity (a list value
-  stays a list, distinct from a vector — rf2-wgutc2). It is NO LONGER used
+  stays a list, distinct from a vector — rf2-wgutc2). It is NOT used
   directly as a Clojure map key: the `:entries` map, the reverse indexes, and
   the work-ledger map are keyed on its CEDN-1 byte `key-id` (`state/key-id`,
   rf2-9e0tyq) so the map-key comparison is EXACTLY the CEDN-1 byte identity
@@ -636,7 +636,7 @@
   first-loads with no placeholder). A pure selection — the projection pointer
   it returns never inserts data into the new entry.
 
-  rf2-9e0tyq: `entries` is now keyed on the CEDN-1 byte `key-id`, so the
+  rf2-9e0tyq: `entries` is keyed on the CEDN-1 byte `key-id`, so the
   scope/params comparison reads each candidate entry's stored `:resource/key`
   vector — NOT the map key (which is the opaque bytes string)."
   [entries new-key]

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -187,13 +187,13 @@
   the first such scope, or nil when no other scope for this resource is active.
 
   rf2-tluunj — visits ONLY entries that currently hold an active owner, via the
-  `owner-index` (`{<owner> #{<key-id> …}}`), instead of scanning the WHOLE
-  `:entries` map on every `:rf.resource/state` sub recompute. The heuristic
-  only ever fires on an ACTIVE entry (`entry-active?`), and an entry is active
-  IFF it is a member of some owner-index bucket, so the owner-index members are
-  exactly the candidate set — every entry the old full scan would have passed
-  the `entry-active?` test for, and no more. Resolving each member to its entry
-  via `entry-path-by-id` keeps the rest of the predicate identical. Pure."
+  `owner-index` (`{<owner> #{<key-id> …}}`), so a `:rf.resource/state` sub
+  recompute never scans the WHOLE `:entries` map. The heuristic only ever
+  fires on an ACTIVE entry (`entry-active?`), and an entry is active IFF it is
+  a member of some owner-index bucket, so the owner-index members are exactly
+  the candidate set — every entry that passes the `entry-active?` test, and no
+  more. Resolving each member to its entry via `entry-path-by-id` keeps the
+  rest of the predicate identical. Pure."
   [resources-subtree sub-key]
   (let [[sub-scope rid _params] sub-key
         entries     (:entries resources-subtree)

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -290,10 +290,10 @@
 ;; ---- derived freshness (Spec 016 §Status semantics) -----------------------
 ;;
 ;; The live clock the `:stale?` derivation compares `:stale-at` against is the
-;; core WALL-clock `re-frame.interop/epoch-now-ms` (rf2-366u0g) — byte-identical
-;; to the private `now-ms` this ns used to define (`System/currentTimeMillis`
-;; on the JVM, `js/Date.now` on CLJS), and the canonical EP-0010 §Time
-;; wall-clock surface. NOT the perf clock `interop/now-ms` (`performance.now()`
+;; core WALL-clock `re-frame.interop/epoch-now-ms` (rf2-366u0g —
+;; `System/currentTimeMillis` on the JVM, `js/Date.now` on CLJS), the
+;; canonical EP-0010 §Time wall-clock surface. NOT the perf clock
+;; `interop/now-ms` (`performance.now()`
 ;; on CLJS, origin-relative), which is incomparable with the `js/Date`-based
 ;; `:stale-at` timestamps. Freshness is computed from durable timestamps, not
 ;; from trusting a timer fired on time (Spec 016 §Stale and GC scheduling).

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -182,9 +182,8 @@
   summary. Terminal rows are pruned on the linked entry's next successful
   transition; a bounded per-resource-key tail is retained for Xray. Per
   Spec 016 §Ledger row retention and identity. The canonical set lives in
-  `re-frame.resources.state/terminal-work-statuses` (rf2-366u0g — no longer
-  re-typed here); re-bound under the ledger surface's own name so a ledger
-  consumer reads one home."
+  `re-frame.resources.state/terminal-work-statuses` (rf2-366u0g); re-bound
+  under the ledger surface's own name so a ledger consumer reads one home."
   state/terminal-work-statuses)
 
 (defn terminal?

--- a/implementation/resources/test/re_frame/resource_generation_recordable_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resource_generation_recordable_cljs_test.cljc
@@ -5,17 +5,18 @@
   the reply token as the stale-suppression correlation), so the minted VALUE
   must be RECORDABLE even though the host allocator stays transient.
 
-  ## The hole this proves-then-closes
+  ## The hazard this guards against
 
-  The generation used to be minted from the AMBIENT `:rf.resource/generation`
-  cofx — a host-cache read, never recorded, re-run on replay. On replay the
-  ambient read re-mints a DIFFERENT generation (the host allocator is at a
-  different high-water than it was at record time), so a recorded managed
-  reply that was ACCEPTED at record time (its generation matched the live
-  entry's) replays as STALE-SUPPRESSED (the re-minted generation no longer
-  matches), or vice versa — the recorded log and the replayed state diverge.
+  If the generation were minted from an AMBIENT `:rf.resource/generation`
+  cofx — a host-cache read, never recorded, re-run on replay — then on replay
+  the ambient read would re-mint a DIFFERENT generation (the host allocator
+  is at a different high-water than it was at record time), so a recorded
+  managed reply that was ACCEPTED at record time (its generation matched the
+  live entry's) would replay as STALE-SUPPRESSED (the re-minted generation no
+  longer matches), or vice versa — the recorded log and the replayed state
+  would diverge.
 
-  The fix makes `:rf.resource/generation-allocation` a GENERATOR-BACKED
+  Instead `:rf.resource/generation-allocation` is a GENERATOR-BACKED
   RECORDABLE cofx: the generator mints the next monotone allocation at
   processing-start and the runtime records the value on the causal token, so
   replay (supplying the recorded allocation) reproduces the IDENTICAL
@@ -28,15 +29,15 @@
      success reply (carrying generation 1) is ACCEPTED (the entry loads). The
      recorded `:rf.cofx/generated` trace op captures the allocation the
      runtime stamped onto the token: `{:generation 1 :counter 1}`.
-  2. REPLAY-CORRECT (the fix) — the host allocator is now at a DIFFERENT
-     high-water (10, as a fresh process / a different frame's work would
-     leave it); replay the SAME ensure SUPPLYING the recorded allocation on
-     the token. The handler reads generation 1 (the recorded value), NOT
+  2. REPLAY-CORRECT (determinism preserved) — the host allocator is now at a
+     DIFFERENT high-water (10, as a fresh process / a different frame's work
+     would leave it); replay the SAME ensure SUPPLYING the recorded allocation
+     on the token. The handler reads generation 1 (the recorded value), NOT
      `(inc 10)` = 11. The recorded reply (generation 1) is ACCEPTED again —
      the durable outcome equals the record.
-  3. REPLAY-DIVERGENT (the bug, shown as a control) — same allocator at 10,
+  3. REPLAY-DIVERGENT (the hazard, shown as a control) — same allocator at 10,
      but replay the ensure WITHOUT the recorded allocation, so the generator
-     re-mints generation 11 (the old ambient behaviour). The recorded reply
+     re-mints generation 11 (the un-recorded ambient path). The recorded reply
      (generation 1) is now STALE-SUPPRESSED — generation 1 no longer matches
      the live entry's generation 11 — so the entry never loads the reply
      value: the exact divergence the recordable allocation kills.

--- a/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
@@ -398,7 +398,7 @@
   ;; `rf/resolve-resource-scope` is advertised PURE (the logout/account-switch
   ;; idiom resolves the old scope from the cofx db). A pure read must not
   ;; mutate observability state, so it emits NO :rf.resource/scope-resolved
-  ;; row — pre-fix it routed through the traced resolver core.
+  ;; row — it does not route through the traced resolver core.
   (rf/dispatch-sync [:t/login "jake"])
   (testing "the helper still resolves the concrete scope correctly"
     (let [rows (record-scope-resolved!

--- a/implementation/resources/test/re_frame/resources_http_completed_at_clock_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_http_completed_at_clock_cljs_test.cljs
@@ -74,8 +74,8 @@
             `js/Date.now()` — and the entry read STALE the instant it loaded."
     (async done
       (rf/init! reagent-adapter/adapter)
-      ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
-      ;; and the managed-HTTP fxs require a carried frame stamp. Register
+      ;; EP-0002 (rf2-nn0jqa): `init!` does not synthesise a `:rf/default`
+      ;; frame, and the managed-HTTP fxs require a carried frame stamp. Register
       ;; `:rf/default` explicitly; the dispatch below carries `{:frame
       ;; :rf/default}` so the sync dispatch AND the async reply continuation
       ;; both target it.
@@ -107,8 +107,8 @@
                       "the live transport reply decoded + landed the data")
                   ;; The core regression assertion: freshness is checked
                   ;; against `js/Date.now` (the freshness readers' clock).
-                  ;; A just-loaded entry MUST NOT be stale. Pre-fix this is
-                  ;; TRUE (perf-clock :stale-at ≪ js/Date.now()).
+                  ;; A just-loaded entry MUST NOT be stale. A perf-clock
+                  ;; :stale-at (≪ js/Date.now()) would wrongly read as stale.
                   (is (false? (state/entry-stale? e now-epoch))
                       "a just-loaded resource is NOT stale against js/Date.now")
                   ;; :loaded-at must be a wall-clock epoch value (within a
@@ -120,7 +120,8 @@
                       ":loaded-at is a wall-clock epoch ms (within 10s of js/Date.now)")
                   ;; :stale-at = :loaded-at + window, and therefore lands in
                   ;; the FUTURE relative to js/Date.now() (the window has not
-                  ;; elapsed). Pre-fix :stale-at was already in the deep past.
+                  ;; elapsed). A perf-clock :stale-at would already be in the
+                  ;; deep past.
                   (is (= (+ loaded-at stale-after-ms) stale-at)
                       ":stale-at is :loaded-at + :stale-after-ms")
                   (is (> stale-at now-epoch)

--- a/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
@@ -621,8 +621,9 @@
 (deftest lone-vector-tag-matches-the-right-resource-end-to-end
   ;; The adversarial end-to-end: a mutation whose :invalidates returns a LONE
   ;; vector tag `[:article slug]` must invalidate the entry carrying that tag.
-  ;; Pre-fix, `(set raw)` made it `#{:article "w"}`, matching NOTHING — the
-  ;; ownerless article stayed fresh (a silent no-op the author never sees).
+  ;; Wrapping it with `(set raw)` would make it `#{:article "w"}`, matching
+  ;; NOTHING — the ownerless article would stay fresh (a silent no-op the
+  ;; author never sees). This pins the tag is treated as a single tag.
   (reg-article-resource!)
   (rf/reg-mutation :m/save
     {:scope :rf.scope/global

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -1706,9 +1706,10 @@
   ;; The adversarial phase-order pin: `:rf.mutation/replied` is emitted from
   ;; the settlement boundary AFTER `:rf.mutation/succeeded`, so its stream
   ;; position truthfully reflects phase 6 (continuation runs after cache
-  ;; consequences + instance settlement). Pre-fix it was emitted while BUILDING
-  ;; the dispatch effect (inside continuation-fx), so the row could appear
-  ;; BEFORE succeeded — misleading evidence of the phase order.
+  ;; consequences + instance settlement). Emitting it while BUILDING the
+  ;; dispatch effect (inside continuation-fx) would let the row appear BEFORE
+  ;; succeeded — misleading evidence of the phase order — which this pins
+  ;; against.
   (reg-capture-continuation!)
   (rf/reg-mutation :m/save (save-article-spec) save-article-request)
   (let [rows (record-mutation-traces!

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -753,10 +753,11 @@
 ;; start-new-work). Its basis MUST be the ensure token's causal
 ;; `(:time-ms (:rf.cofx cofx))`, NOT an ambient host-clock read — so a
 ;; replayed ensure under a LATER live clock takes the SAME branch the recorded
-;; `:time-ms` dictated. Pre-fix the gate read `(now-ms)` (= the live host
-;; clock, ~1.78e12 epoch-ms / `System/currentTimeMillis`), which dwarfs any
-;; scripted `:stale-at`, so a replay always re-read the live clock and could
-;; flip serve-cache → refetch, minting a DIVERGENT work-ledger row.
+;; `:time-ms` dictated. Reading `(now-ms)` instead (= the live host clock,
+;; ~1.78e12 epoch-ms / `System/currentTimeMillis`) would dwarf any scripted
+;; `:stale-at`, so a replay would re-read the live clock and could flip
+;; serve-cache → refetch, minting a DIVERGENT work-ledger row — which this
+;; pins against.
 (deftest fresh-skip-decision-reads-causal-time-ms-not-ambient-clock
   (rf/reg-resource :fsd/article (article-spec {:stale-after-ms 60000}) article-spec-request)
   (let [scoped-key  (state/scoped-resource-key :rf.scope/global :fsd/article {:slug "w"})


### PR DESCRIPTION
Remainder of rf2-3mgiok (flows/ already done + merged via PR #4845). Applies the LENS from parent rf2-2db7z1 to the `implementation/resources/` and `implementation/epoch/` surfaces: strip history-narration from comments + docstrings; describe the CURRENT contract as-if-always, generously; preserve the narrow exceptions (spec/EP/XState anchors, genuine current-design teaching, non-meta `prior`/`previous`/`no longer`, load-bearing literals).

## Scope

25 files across `implementation/epoch/` (src + test + deps.edn) and `implementation/resources/` (src + test). Comments and docstrings ONLY — fully behaviour-neutral.

**What was rewritten** (representative):
- "Storage-side redaction was REMOVED" → "the ring is causal replay material, so it stays raw" (epoch src + tests)
- "the surface formerly named `reset-frame-db!` is renamed to…" → states the current `replace-app-db!` / `reset-app-db!` contract
- "Pre-fix it fell through the orphan-drop branch…" → frames the hazard subjunctively as what the current back-fill prevents
- "the prior resource-local canonicalizer carried three divergences…" → states the three CEDN-1 guarantees positively
- "`entries` is now keyed on the CEDN-1 byte `key-id`" → drops the "now"
- "this ns no longer defines a `now-ms` helper" → states the durable-write-site clock contract positively
- negative definitions of deleted concepts (e.g. "NOT the retired app-db `[:rf/runtime …]` path") removed

**What was deliberately preserved** (narrow exceptions): domain vocabulary (`superseded` resource attempts/replies, runtime "no longer registered / entry is gone" conditions), spec/EP anchors (EP-0010/EP-0015/Spec 016/Tool-Pair), non-meta `prior`/`previous` (the prior loaded sibling key, a previously-installed redact-fn at runtime), and all `is`/`testing`/`deftest`/`:reason` runtime-value label strings (untouched). In `epoch/tool_pair.cljc`, all `throw`/`ex-info` expressions and messages were left untouched (krrv87 error-model territory).

## Quality gates

- **Reader-parse**: every edited `.clj`/`.cljc` parses clean (`read` with `:read-cond :allow`). `.cljs` files with `#js` literals validated via clj-kondo instead.
- **clj-kondo --lint**: 0 errors across all 25 edited files; 156 warnings, all pre-existing (unused bindings/namespaces, unrelated to comments — confirmed identical counts on origin/main base versions).
- **Behaviour-neutral verification**: branch diff (merge-base..HEAD) contains zero non-comment code-line changes (one removed blank line aside) and zero changes to any `is`/`testing`/`deftest`/`:reason` label string.
- **test:cljs**: skipped locally (node_modules absent in fresh worktree); relying on CI as the merge gate.

Per rf2-l1ydwz: bead left OPEN; PR URL appended to its notes.