### PR TITLE
fix(core): route bypassing egress paths through project-egress choke-point + add conformance ratchet (rf2-7qbxbm, rf2-mrtis6)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -1613,6 +1613,48 @@
     (assoc tags :offending-value privacy/redacted-sentinel)
     tags))
 
+(defn- resource-failure-op?
+  "True for the resource / mutation FAILURE trace ops whose tags carry the
+  `:rf.http/*` failure ENVELOPE under `:error` / `:page-error` (rf2-7qbxbm) —
+  `:rf.resource/failed` (first-load), `:rf.resource/page-failed` (load-more,
+  the `:page-error` channel), and `:rf.mutation/failed`. Matched by op rather
+  than by raw slot-presence so an unrelated trace that happens to carry a
+  scalar `:error` keyword (a status enum, not an HTTP envelope) is NOT
+  swept up. Keyed conservatively to the three failure ops the resources
+  artefact emits the envelope from."
+  [operation]
+  (case operation
+    (:rf.resource/failed :rf.resource/page-failed :rf.mutation/failed) true
+    false))
+
+(defn- project-resource-error-tags
+  "Walk the resource/mutation FAILURE trace tag shape (rf2-7qbxbm). The
+  `:rf.resource/failed` / `:rf.mutation/failed` rows carry the `:rf.http/*`
+  reply's failure ENVELOPE under `:error`; the load-more `:rf.resource/page-
+  failed` row carries it under `:page-error`. That envelope holds the RAW
+  server response (`:body` / `:body-text` / `:detail`), which routinely echoes
+  the SUBMITTED FORM FIELDS + validation text quoting user values — app-owned
+  data the path-keyed app-db walker cannot resolve (it is the HTTP reply, not
+  an app-db slice) and the marks cond-> had NO clause for, so it passed through
+  this on-box dev-trace chokepoint verbatim. (This is the DCE'd on-box leg of
+  rf2-7qbxbm; the production-reachable off-box leg is closed in
+  `re-frame.resources.trace-egress`.)
+
+  The envelope is observability-only — the operator needs to know a resource /
+  mutation FAILED and its status (the sibling `:status-before` / `:status-
+  after` / `:resource/key` structural tags, left intact), not the raw response
+  body — so each present envelope slot is summarized to the `:rf/redacted`
+  sentinel UNCONDITIONALLY (the body is unschematized by construction — status
+  classification runs before decode — so it is whole-sensitive off-box, the
+  same EP-0015 disposition-5 fail-closed posture the HTTP body redaction takes;
+  a scalar / nil envelope slot is left alone). The runtime never reads these
+  slots back — they are trace-only — so the strip is egress-only and changes no
+  behaviour."
+  [tags]
+  (cond-> tags
+    (some? (:error tags))      (assoc :error      privacy/redacted-sentinel)
+    (some? (:page-error tags)) (assoc :page-error privacy/redacted-sentinel)))
+
 (defn- machine-op?
   [operation]
   (let [n (and (keyword? operation) (namespace operation))]
@@ -1818,7 +1860,23 @@
                       ;; reaching here carries `:offending-value` but none of the
                       ;; earlier slot shapes.
                       (and (map? tags) (contains? tags :offending-value))
-                      (project-machine-wrote-db-tags))]
+                      (project-machine-wrote-db-tags)
+
+                      ;; rf2-7qbxbm — the resource/mutation FAILURE traces
+                      ;; (`:rf.resource/failed` / `:rf.resource/page-failed` /
+                      ;; `:rf.mutation/failed`) carry the `:rf.http/*` reply
+                      ;; failure ENVELOPE (raw `:body` / `:body-text` / `:detail`
+                      ;; — echoing submitted form fields + validation text) under
+                      ;; `:error` / `:page-error`. The app-db path walker is blind
+                      ;; to it (it is the HTTP reply, not an app-db slice) and no
+                      ;; clause above matched, so it passed through this on-box
+                      ;; dev-trace chokepoint verbatim. Keyed on the failure op so
+                      ;; a scalar `:error` status keyword on an unrelated trace is
+                      ;; not swept up; summarizes the envelope slot(s) to
+                      ;; `:rf/redacted` (DCE'd in production — the off-box
+                      ;; production leg is closed in resources.trace-egress).
+                      (and (map? tags) (resource-failure-op? operation))
+                      (project-resource-error-tags))]
       (assoc event :tags tags'))))
 
 ;; ---- late-bind hook registration ----------------------------------------

--- a/implementation/core/test/re_frame/egress_chokepoint_conformance_test.clj
+++ b/implementation/core/test/re_frame/egress_chokepoint_conformance_test.clj
@@ -1,0 +1,321 @@
+(ns re-frame.egress-chokepoint-conformance-test
+  "rf2-mrtis6 — the conformance PIN that makes the egress-redaction
+  CHOKE-POINT real, not documentary, for the ALWAYS-ON (production-surviving)
+  union-record fan-out.
+
+  ## What this pins
+
+  Security.md §The privacy / classification surface is NORMATIVE:
+
+    > Projection is centralized at trust boundaries via `project-egress`
+    > (the record-level primitive) over `elide-wire-value` (the low-level
+    > walker) … per-tool reimplementation of the projection is prohibited.
+    > Sinks consume already-projected records only.
+
+  The choke-point ALREADY EXISTS — `re-frame.projection/project-egress`
+  (projection.cljc). The EP-0015 §9 frame-owned observability route
+  (`route-error!` / `route-error-record!`) already funnels error records
+  through it. The risk this ratchet governs is the cmxiss-shaped
+  `forgot the always-on half` bug family at the EGRESS boundary: a NEW site
+  that ships a payload-bearing always-on union record to the corpus-wide
+  `register-error-listener!` registry WITHOUT routing the untrusted slots
+  through `project-egress` first.
+
+  The two always-on union-record fan-out chokepoints are
+  `re-frame.error-emit/dispatch-error-record!` and
+  `…/dispatch-frame-teardown-report!` (error_emit.cljc). Their corpus-listener
+  leg (`((:fan-out registry) record)`) ships the record UNCHANGED — the
+  off-box-shipper (Sentry / Datadog) API, deliberately NOT privacy-gated for
+  the host `:exception` residual. Safety therefore rests on every CALLER
+  either (a) carrying ONLY structural identifiers / a host-exception residual,
+  or (b) routing the untrusted payload-bearing slots through `project-egress`
+  BEFORE the fan-out. There is otherwise ZERO framework enforcement.
+
+  ## The ratchet (modelled exactly on error_catalogue_channel_conformance_test)
+
+  SOURCE-SCAN every artefact `src/` tree (reusing `impl-src-roots` /
+  `non-test-source-files` from the error-catalogue test) for the namespaces
+  that CALL either chokepoint, and assert each calling namespace is EITHER:
+
+    - the `error-emit` chokepoint namespace ITSELF (it defines the fns and its
+      `dispatch-frame-teardown-report!` → `dispatch-error-record!` internal
+      call routes the frame leg through `route-error-record!` → `project-egress`
+      by construction); OR
+    - a namespace that ALSO references `project-egress` (it routes its
+      untrusted slots through the choke-point before the fan-out — the
+      ssr/hydrate.cljc B5 model); OR
+    - on the explicit `structural-only-allow-list` — a caller VETTED to carry
+      ONLY value-free structural slots (a fixed diagnostic `:reason` string, a
+      frame id, a DOM element id, a recovery enum), so its raw fan-out is safe.
+
+  A NEW caller that is none of these fails CI with a missing-routing
+  diagnostic — exactly how the error-catalogue test fails on a new
+  uncatalogued emit site. `allow-list-stays-honest` keeps the allow-list from
+  rotting: an entry that stops calling the chokepoint, or that starts routing
+  through `project-egress`, must be dropped in the same PR.
+
+  ## Scope boundary (NEEDS-MIKE ruling, recorded)
+
+  RECORD-LEVEL slots only. Per Security.md §Out-of-scope (\"the framework does
+  NOT walk exception messages or ex-data maps automatically\") this gate
+  asserts the always-on record carries no raw app-db / event slice AT THE
+  RECORD LEVEL; it treats a host `:exception` / its ex-data as an opaque host
+  residual (the existing posture — the taint-tracking non-goal). The
+  no-secrets-in-ex-data discipline stays a review/lint rule, NOT a structural
+  guarantee. The teardown report's `:hook-failures[].exception` ex-data and
+  the SSR `:exception` legs are therefore the documented exception residual,
+  not a ratchet failure.
+
+  CONSERVATIVE by design (same posture as the error-catalogue scan): the scan
+  reads the dominant direct idiom (a namespace that calls the chokepoint fn /
+  the published `:error-emit/dispatch-error-record` hook). It under-reports via
+  variable-arg indirection rather than false-positiving — acceptable for a
+  ratchet whose job is to catch NEW direct fan-out sites.
+
+  JVM-only (`.clj`, NOT `*-cljs-test`): it `slurp`s repo source files, which
+  only the JVM `clojure -M:test` runner can do."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Source roots + file enumeration (reused verbatim from
+;; error_catalogue_channel_conformance_test — the cmxiss enforcement precedent)
+;; ---------------------------------------------------------------------------
+
+(def ^:private impl-src-roots
+  "Every artefact's non-test source root, resolved from the JVM test CWD
+  (`implementation/core/` per rf2-0hxm → repo root is `../../`). Falls back to
+  the pre-split `../implementation/...` layout for a transitional REPL run from
+  `implementation/`. Only existing dirs are kept."
+  (let [bases ["../../implementation" "../implementation" "../.."]]
+    (->> bases
+         (mapcat (fn [base]
+                   (let [d (io/file base)]
+                     (when (.isDirectory d)
+                       (->> (.listFiles d)
+                            (filter #(.isDirectory %))
+                            (map #(io/file % "src")))))))
+         (filter #(.isDirectory %))
+         distinct
+         vec)))
+
+(def ^:private source-file-exts
+  #{".clj" ".cljc" ".cljs"})
+
+(defn- non-test-source-files
+  "Every `.clj` / `.cljc` / `.cljs` file under the artefact src roots. src roots
+  carry only production source; we guard with a `/test/` path check anyway."
+  []
+  (->> impl-src-roots
+       (mapcat (fn [root] (file-seq root)))
+       (filter #(.isFile %))
+       (filter (fn [f]
+                 (let [n (.getName f)]
+                   (some #(str/ends-with? n %) source-file-exts))))
+       (remove (fn [f]
+                 (let [p (str/replace (.getPath f) "\\" "/")]
+                   (or (str/includes? p "/test/")
+                       (str/ends-with? (.getName f) "_test.clj")
+                       (str/ends-with? (.getName f) "_test.cljc")
+                       (str/ends-with? (.getName f) "_test.cljs")))))))
+
+;; ---------------------------------------------------------------------------
+;; The always-on union-record fan-out chokepoints + the routing primitive
+;; ---------------------------------------------------------------------------
+
+(def ^:private chokepoint-call-re
+  "Matches a CALL to either always-on union-record fan-out chokepoint —
+  `dispatch-error-record!` or `dispatch-frame-teardown-report!`. The fn may be
+  ns-qualified (`error-emit/dispatch-error-record!`) or bare (a late-bound
+  local rebinding, as ssr/hydrate / ssr/boot / ssr-ring do:
+  `(when-let [dispatch-error-record! (late-bind/get-fn …)] (dispatch-error-
+  record! record))`). Anchored on `(` so a docstring/comment MENTION of the fn
+  name (no preceding paren) does NOT count as a call — only a genuine call form
+  pins a namespace as a caller."
+  #"\(\s*(?:[a-zA-Z0-9_.-]+/)?(dispatch-error-record!|dispatch-frame-teardown-report!)")
+
+(def ^:private chokepoint-def-ns
+  "The namespace that DEFINES the chokepoint fns — `re-frame.error-emit`. Its
+  own `dispatch-frame-teardown-report!` → `dispatch-error-record!` internal
+  call, and the fan-out itself, route the frame leg through
+  `route-error-record!` → `project-egress` by construction (EP-0015 §9). It is
+  the choke-point owner, not a bypassing caller."
+  're-frame.error-emit)
+
+(def ^:private routing-marker-re
+  "A namespace ROUTES through the choke-point when its source references
+  `project-egress` (directly, or via the `projection/project-egress` /
+  `re-frame.projection` alias). A caller that projects its untrusted
+  payload-bearing slots before the fan-out (the ssr/hydrate.cljc B5 model)
+  matches here and is NOT required on the structural-only allow-list."
+  #"project-egress")
+
+(def ^:private ns-decl-re
+  "Match a source file's leading `(ns <fully.qualified.name>` declaration and
+  capture the namespace symbol. A text scan rather than `read-string` because
+  `.cljc` files carry reader conditionals (`#?(:cljs …)`) that plain
+  `read-string` rejects (`Conditional read not allowed`). Anchored on `(ns` at
+  a line start (after optional leading whitespace) so a `(ns …)` MENTION inside
+  a docstring/comment does not win over the real declaration; `(?m)` makes `^`
+  match each line. The name class allows the `.`/`-`/digit chars a re-frame ns
+  uses."
+  #"(?m)^\s*\(ns\s+([a-zA-Z][a-zA-Z0-9_.*+!?<>=-]*)")
+
+(defn- ns-form-symbol
+  "Extract the namespace symbol from a source file's leading `(ns …)`
+  declaration via the text scan (reader-conditional-safe). Returns nil when no
+  `(ns …)` form is found."
+  [src]
+  (when-let [[_ ns-name] (re-find ns-decl-re src)]
+    (symbol ns-name)))
+
+(defn- chokepoint-caller-namespaces
+  "Scan every non-test source file and return a map
+  `{<ns-symbol> {:file <path> :routes? <bool>}}` for each namespace that CALLS
+  a fan-out chokepoint. `:routes?` is whether the same file references
+  `project-egress` (it routes its untrusted slots through the choke-point).
+  Pure text scan — no classpath load — so it sees every artefact regardless of
+  the test classpath."
+  []
+  (reduce
+    (fn [acc f]
+      (let [src (slurp f)]
+        (if (re-find chokepoint-call-re src)
+          (if-let [ns-sym (ns-form-symbol src)]
+            (assoc acc ns-sym
+                   {:file    (str/replace (.getPath f) "\\" "/")
+                    :routes? (boolean (re-find routing-marker-re src))})
+            acc)
+          acc)))
+    {}
+    (non-test-source-files)))
+
+;; ---------------------------------------------------------------------------
+;; The self-honest structural-only allow-list (rf2-mrtis6 census B1-B7)
+;; ---------------------------------------------------------------------------
+
+(def ^:private structural-only-allow-list
+  "Namespaces that CALL a fan-out chokepoint with a record VETTED to carry ONLY
+  value-free structural slots — so the raw corpus-leg fan-out is safe WITHOUT
+  routing the record through `project-egress`. Each entry is the census caller
+  (B-row) + the one-line reason its record is structural-only. A NEW caller not
+  on this list and not routing through `project-egress` fails the coverage test;
+  `allow-list-stays-honest` fails if a listed entry stops calling the chokepoint
+  or starts routing (forcing the co-edit).
+
+    - re-frame.ssr.boot (census B3) — `dispatch-malformed-hydration-frameless!`
+      ships a FRAMELESS (`:frame nil`) `:rf.error/malformed-hydration-payload`
+      record carrying `:where` (a quoted symbol), `:failing-id :rf/hydrate`,
+      `:element-id` (a DOM element id — a structural locator, not app data),
+      `:reason` (a framework-authored sentence), `:recovery :no-recovery`. No
+      slot lifts a value OUT of the untrusted payload — the parse FAILED, so
+      there is no parsed value to carry; only the structural fact that it failed.
+
+    - re-frame.ssr.error-projector (census B4) — `emit-always-on-error!` ships
+      the `:rf.error/sanitised-on-projection` FALLBACK record (the public
+      boundary fell back to the locked generic-500). Structural status fact;
+      carries no app value (the whole point of the fallback is that projection
+      failed, so the unprojected payload is NOT carried forward — re-entry guard,
+      RULED rf2-hhutya).
+
+    - re-frame.ssr.ring.lifecycle (census B6) — `emit-always-on-error!` ships
+      the ring-host lifecycle error record (`:rf.error/ssr-ring-error-view-
+      failed` and siblings): structural host-lifecycle facts + a host
+      `:exception` residual (the documented exception non-goal — Security.md
+      §Out-of-scope), no app-db / event slice.
+
+  NOTE the census B5 site `re-frame.ssr.hydrate` is DELIBERATELY ABSENT: it
+  lifts the untrusted `:payload-frame-id` out of the deserialised payload, so it
+  is NOT structural-only — it ROUTES through `project-egress` (the B5 fix) and
+  is governed by the routing arm, not this list. If it ever stopped routing it
+  would fail the coverage test, which is the point."
+  '#{re-frame.ssr.boot
+     re-frame.ssr.error-projector
+     re-frame.ssr.ring.lifecycle})
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(deftest source-scan-finds-the-chokepoint-callers
+  (testing "Sanity: the source scan reaches the artefact src trees and finds
+            the known always-on fan-out chokepoint callers. A zero / tiny
+            result means the src roots did not resolve from the test CWD (a
+            path-layout change) — fail loudly rather than vacuously passing the
+            coverage invariant below with an empty caller set."
+    (let [roots   impl-src-roots
+          callers (chokepoint-caller-namespaces)]
+      (is (seq roots)
+          "at least one artefact src root resolved from the JVM test CWD")
+      ;; The chokepoint definer + at least the SSR caller family must be found.
+      (is (contains? callers chokepoint-def-ns)
+          (str chokepoint-def-ns " (the chokepoint definer) is among the "
+               "scanned callers"))
+      (is (>= (count callers) 4)
+          (str "source scan found the known fan-out chokepoint callers "
+               "(>= 4 namespaces: the definer + the SSR family), not a broken "
+               "/ empty scan; found " (count callers) ": "
+               (pr-str (sort (keys callers)))))
+      ;; Anchor on the B5 routing site — proves the routing arm is live.
+      (is (get-in callers ['re-frame.ssr.hydrate :routes?])
+          "re-frame.ssr.hydrate (census B5) routes through project-egress"))))
+
+(deftest every-chokepoint-caller-routes-or-is-allow-listed
+  (testing "rf2-mrtis6 (the enforcement spine): every namespace that CALLS an
+            always-on union-record fan-out chokepoint
+            (`dispatch-error-record!` / `dispatch-frame-teardown-report!`)
+            either (a) IS the `error-emit` chokepoint definer (routes the frame
+            leg via route-error-record! → project-egress), (b) routes its
+            untrusted slots through `project-egress` in the same namespace, or
+            (c) is on the explicit `structural-only-allow-list` (a record vetted
+            value-free). A NEW caller that does none of these ships a
+            payload-bearing always-on record to corpus listeners UNREDACTED —
+            the egress-boundary analogue of the cmxiss `forgot the always-on
+            half` bug — and fails HERE with a missing-routing diagnostic."
+    (let [callers   (chokepoint-caller-namespaces)
+          unhandled (->> callers
+                         (remove (fn [[ns-sym {:keys [routes?]}]]
+                                   (or (= ns-sym chokepoint-def-ns)
+                                       routes?
+                                       (contains? structural-only-allow-list
+                                                  ns-sym))))
+                         (map (fn [[ns-sym info]] [ns-sym (:file info)]))
+                         (into {}))]
+      (is (empty? unhandled)
+          (str "always-on union-record fan-out callers that NEITHER route "
+               "their untrusted slots through `project-egress` NOR are on the "
+               "structural-only-allow-list (rf2-mrtis6 — they ship a "
+               "payload-bearing record to corpus listeners raw): "
+               (pr-str unhandled)
+               " — either route the untrusted slots through `project-egress` "
+               "before the fan-out (the ssr/hydrate B5 model), or, if the "
+               "record is VETTED value-free (structural ids + a host exception "
+               "residual only), add the namespace to structural-only-allow-list "
+               "with a one-line rationale.")))))
+
+(deftest allow-list-stays-honest
+  (testing "rf2-mrtis6: every namespace on the structural-only-allow-list must
+            STILL call a fan-out chokepoint AND must STILL NOT route through
+            `project-egress`. This keeps the allow-list from rotting: an entry
+            that stops calling the chokepoint (the caller was deleted /
+            refactored) must be dropped, and an entry that NOW routes through
+            `project-egress` (it graduated to projecting its slots) must ALSO be
+            dropped so the routing arm — not this list — governs it. Both
+            drifts fail here, forcing the co-edit."
+    (let [callers          (chokepoint-caller-namespaces)
+          no-longer-caller (set/difference structural-only-allow-list
+                                           (set (keys callers)))
+          now-routes       (->> structural-only-allow-list
+                                (filter (fn [ns-sym]
+                                          (get-in callers [ns-sym :routes?])))
+                                set)]
+      (is (empty? no-longer-caller)
+          (str "structural-only-allow-list entries that no longer call a "
+               "fan-out chokepoint (drop them, rf2-mrtis6): "
+               (pr-str (sort no-longer-caller))))
+      (is (empty? now-routes)
+          (str "structural-only-allow-list entries that NOW route through "
+               "`project-egress` (drop them so the routing arm governs them, "
+               "rf2-mrtis6): " (pr-str (sort now-routes)))))))

--- a/implementation/core/test/re_frame/marks_test.clj
+++ b/implementation/core/test/re_frame/marks_test.clj
@@ -830,3 +830,93 @@
   (rf/reg-event :evt {:sensitive [[:a]]} (fn [_ _] {}))
   (rf/reg-event :evt {:sensitive [[:b]]} (fn [_ _] {}))
   (is (= [[:b]] (:sensitive (marks/marks-for :event :evt)))))
+
+;; ---- rf2-7qbxbm: resource/mutation FAILURE :error / :page-error envelope ---
+;;
+;; The on-box (DCE'd-in-production) leg of rf2-7qbxbm. The
+;; `:rf.resource/failed` / `:rf.resource/page-failed` / `:rf.mutation/failed`
+;; traces carry the `:rf.http/*` failure ENVELOPE — the raw server response
+;; (`:body` / `:body-text` / `:detail`) echoing submitted form fields — under
+;; `:error` / `:page-error`. The marks cond-> had NO clause for it, so it
+;; passed through `project-trace-event` verbatim to on-box listeners /
+;; epoch capture. The new clause summarizes the envelope slot to `:rf/redacted`.
+
+(def ^:private http-failure-envelope
+  {:status    422
+   :body-text "{\"auth-token\":\"on-box-secret-PII\"}"
+   :detail    :rf.http/http-4xx})
+
+(defn- envelope-contains-secret? [v]
+  (boolean
+    (cond
+      (string? v) (.contains ^String v "on-box-secret")
+      (map? v)    (or (some envelope-contains-secret? (keys v))
+                      (some envelope-contains-secret? (vals v)))
+      (coll? v)   (some envelope-contains-secret? v)
+      :else       false)))
+
+(deftest resource-failed-error-envelope-redacted-on-box
+  (testing "rf2-7qbxbm (on-box leg): a :rf.resource/failed trace's :error HTTP
+            failure envelope is summarized to :rf/redacted; structural status
+            tags ride; no raw secret survives"
+    (let [projected (marks/project-trace-event
+                      {:operation :rf.resource/failed
+                       :op-type   :rf.event
+                       :tags      {:rf.frame/id    :rf/default
+                                   :frame          :rf/default
+                                   :status-before  :loading
+                                   :status-after   :error
+                                   :error          http-failure-envelope}})]
+      (is (= :rf/redacted (get-in projected [:tags :error]))
+          "the :error HTTP failure envelope is redacted on-box")
+      (is (= :loading (get-in projected [:tags :status-before]))
+          "the structural status-before tag rides verbatim")
+      (is (= :error (get-in projected [:tags :status-after]))
+          "the structural status-after tag rides verbatim")
+      (is (not (envelope-contains-secret? (:tags projected)))
+          "no raw response-body secret survives on the projected trace"))))
+
+(deftest resource-page-failed-page-error-envelope-redacted-on-box
+  (testing "rf2-7qbxbm (on-box leg): a :rf.resource/page-failed trace's
+            :page-error envelope (load-more third error channel) is redacted"
+    (let [projected (marks/project-trace-event
+                      {:operation :rf.resource/page-failed
+                       :op-type   :rf.event
+                       :tags      {:rf.frame/id :rf/default
+                                   :frame       :rf/default
+                                   :page-error  http-failure-envelope}})]
+      (is (= :rf/redacted (get-in projected [:tags :page-error]))
+          "the :page-error envelope is redacted on-box")
+      (is (not (envelope-contains-secret? (:tags projected)))
+          "no raw secret survives"))))
+
+(deftest mutation-failed-error-envelope-redacted-on-box
+  (testing "rf2-7qbxbm (on-box leg): a :rf.mutation/failed trace's :error
+            envelope is redacted; the mutation id structural tag rides"
+    (let [projected (marks/project-trace-event
+                      {:operation :rf.mutation/failed
+                       :op-type   :rf.event
+                       :tags      {:rf.frame/id :rf/default
+                                   :frame       :rf/default
+                                   :mutation    :m/save
+                                   :instance    7
+                                   :error       http-failure-envelope}})]
+      (is (= :rf/redacted (get-in projected [:tags :error]))
+          "the mutation failure envelope is redacted on-box")
+      (is (= :m/save (get-in projected [:tags :mutation]))
+          "the mutation id structural tag rides verbatim")
+      (is (not (envelope-contains-secret? (:tags projected)))
+          "no raw secret survives"))))
+
+(deftest unrelated-trace-with-scalar-error-keyword-untouched
+  (testing "rf2-7qbxbm guard: the resource-failure clause is keyed on the
+            FAILURE ops, so an UNRELATED trace carrying a scalar :error status
+            keyword (not an HTTP envelope) is NOT swept up — no over-redaction"
+    (let [projected (marks/project-trace-event
+                      {:operation :rf.resource/work-completed
+                       :op-type   :rf.event
+                       :tags      {:rf.frame/id :rf/default
+                                   :frame       :rf/default
+                                   :status      :error}})]
+      (is (= :error (get-in projected [:tags :status]))
+          "a scalar :error status on a non-failure op rides verbatim"))))

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -390,3 +390,115 @@
           tags       (:tags (first (:trace-events projected)))]
       (is (= cursor-secret (:page-param tags))
           "raw cursor rides with :include-sensitive?"))))
+
+;; ---------------------------------------------------------------------------
+;; (rf2-7qbxbm) :error / :page-error HTTP failure envelope — the raw server
+;; response body (echoing submitted form fields) MUST NOT egress off-box raw.
+;; ---------------------------------------------------------------------------
+
+(def ^:private http-error-envelope
+  "An `:rf.http/*` failure envelope as the resource/mutation FAILURE rows carry
+  it under `:error` / `:page-error` — the raw server response whose `:body-text`
+  echoes a submitted form field quoting a secret. This is the C2/D1 leak vector
+  rf2-7qbxbm names: it is NOT a scoped key, NOT a cursor, so it fell through the
+  projector's `:else` verbatim and reached the epoch/MCP off-box channel raw."
+  {:status    422
+   :body      {:errors {:auth-token (str "value '" secret "' is already taken")}}
+   :body-text (str "{\"auth-token\":\"" secret "\"}")
+   :detail    :rf.http/http-4xx})
+
+(deftest off-box-redacts-resource-failed-error-envelope
+  (testing "rf2-7qbxbm — a :rf.resource/failed first-load row's :error HTTP
+            failure envelope (raw response body echoing a submitted secret) is
+            tokenized off-box; the structural status tags survive; no raw secret
+            egresses"
+    (let [scoped-key (sk :rf.scope/global :secret/article {:auth-token secret})
+          record     (record-with
+                       [(event :rf.resource/failed
+                               {:rf.frame/id :test/rt :resource/key scoped-key
+                                :work/id [:rf.work/resource 1] :generation 1
+                                :status-before :loading :status-after :error
+                                :error http-error-envelope})])
+          projected  (epoch/projected-record record)
+          tags       (:tags (first (:trace-events projected)))]
+      (is (redacted-component? (:error tags))
+          "the HTTP failure envelope is tokenized off-box")
+      (is (true? (:sensitive? tags)) "the row is stamped :sensitive?")
+      (testing "the structural status attribution survives"
+        (is (= :loading (:status-before tags)))
+        (is (= :error (:status-after tags)))
+        (is (= :secret/article (second (:resource/key tags)))))
+      (testing "NO raw secret survives anywhere in the projected record"
+        (is (not (contains-secret? projected)))))))
+
+(deftest off-box-redacts-page-failed-page-error-envelope
+  (testing "rf2-7qbxbm — a :rf.resource/page-failed load-more row's :page-error
+            HTTP failure envelope is tokenized off-box (the third error channel)"
+    (let [scoped-key (sk :rf.scope/global :secret/article {:auth-token secret})
+          record     (record-with
+                       [(event :rf.resource/page-failed
+                               {:rf.frame/id :test/rt :resource/key scoped-key
+                                :work/id [:rf.work/resource 1] :generation 2
+                                :status-before :loaded :status-after :loaded
+                                :page-error http-error-envelope})])
+          projected  (epoch/projected-record record)
+          tags       (:tags (first (:trace-events projected)))]
+      (is (redacted-component? (:page-error tags))
+          "the load-more failure envelope is tokenized off-box")
+      (is (true? (:sensitive? tags)) "the row is stamped :sensitive?")
+      (testing "NO raw secret survives anywhere in the projected record"
+        (is (not (contains-secret? projected)))))))
+
+(deftest off-box-redacts-mutation-failed-error-envelope
+  (testing "rf2-7qbxbm — a :rf.mutation/failed settlement row's :error HTTP
+            failure envelope is tokenized off-box"
+    (let [record    (record-with
+                      [(event :rf.mutation/failed
+                              {:rf.frame/id :test/rt :instance 7 :mutation :m/save
+                               :work/id [:rf.work/mutation :m/save 7] :generation 1
+                               :error http-error-envelope})])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (redacted-component? (:error tags))
+          "the mutation failure envelope is tokenized off-box")
+      (is (true? (:sensitive? tags)) "the row is stamped :sensitive?")
+      (testing "the structural attribution survives"
+        (is (= :m/save (:mutation tags)))
+        (is (= 7 (:instance tags))))
+      (testing "NO raw secret survives anywhere in the projected record"
+        (is (not (contains-secret? projected)))))))
+
+(deftest off-box-fail-closed-on-unknown-map-slot
+  (testing "rf2-7qbxbm structural — the flipped fail-CLOSED :else: an UNKNOWN
+            map-shaped slot a future row might add WITHOUT a projector clause is
+            tokenized by default, so it cannot leak app data the way :error did.
+            Scalar structural facts on the SAME row still ride verbatim."
+    (let [scoped-key (sk :rf.scope/global :secret/article {:auth-token secret})
+          record     (record-with
+                       [(event :rf.resource/failed
+                               {:rf.frame/id :test/rt :resource/key scoped-key
+                                :generation 5 :cause :ensure
+                                ;; a hypothetical future map slot with NO clause
+                                :future-detail {:hidden (str secret "-future")}})])
+          projected  (epoch/projected-record record)
+          tags       (:tags (first (:trace-events projected)))]
+      (is (redacted-component? (:future-detail tags))
+          "an unknown MAP slot is tokenized by the fail-closed default")
+      (testing "scalar structural facts on the same row ride verbatim"
+        (is (= 5 (:generation tags)))
+        (is (= :ensure (:cause tags))))
+      (testing "NO raw future secret survives"
+        (is (not (contains-secret? projected)))))))
+
+(deftest trusted-local-include-sensitive-keeps-raw-error-envelope
+  (testing "rf2-7qbxbm — the trusted-local :include-sensitive? opt-in keeps the
+            raw HTTP failure envelope (the local-raw boundary — the off-box
+            redaction is the DEFAULT, not an unconditional strip)"
+    (let [record    (record-with
+                      [(event :rf.resource/failed
+                              {:rf.frame/id :test/rt :status-after :error
+                               :error http-error-envelope})])
+          projected (epoch/projected-record record {:include-sensitive? true})
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= http-error-envelope (:error tags))
+          "the raw envelope rides with :include-sensitive?"))))

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -130,7 +130,32 @@
   #{:resource/keys :matched :removed :keys :exempt :committed
     :patched :populated :invalidated
     :restored :conflicted :refetched
-    :restored-keys :conflicted-keys :refetched-keys :reconciliation-refetches})
+    :restored-keys :conflicted-keys :refetched-keys :reconciliation-refetches
+    ;; `:affected-keys` — the `:rf.mutation/succeeded` / `:rf.mutation/failed`
+    ;; settlement rows' union of populated/patched/removed/stale-marked scoped
+    ;; keys (Spec 016 §Mutation completion continuations). A vector of scoped
+    ;; keys exactly like `:matched` / `:removed`, so it is PER-KEY projected
+    ;; here (preserving a tool's per-key joins) rather than falling to the
+    ;; fail-closed default below as one coarse digest (rf2-7qbxbm).
+    :affected-keys})
+
+(def ^:private error-envelope-slot
+  "Tag slots that carry an HTTP FAILURE ENVELOPE — the `:rf.http/*` reply's
+  `{:status :body :body-text :detail …}` map (rf2-7qbxbm). The
+  `:rf.resource/failed` first-load row + the `:rf.mutation/failed` settlement
+  row stamp the envelope under `:error`; the `:rf.resource/page-failed`
+  load-more row stamps it under `:page-error`. The raw response body
+  (`:body` / `:body-text` / `:detail`) routinely echoes the SUBMITTED FORM
+  FIELDS and validation text quoting user values — app-owned data the generic
+  scoped-key vocabulary is structurally blind to (it is not a scoped key, not
+  a cursor), so it slipped through the `:else` verbatim and reached the
+  epoch / MCP off-box channel UNREDACTED. It is tokenized to a content-
+  addressed `{:rf/redacted <digest>}` via the SAME `redact-value` the cursor
+  uses (distinct envelopes stay distinct, so a tool's per-failure joins
+  survive; the raw body never rides). The status/category attribution is
+  preserved on the row's OTHER scalar tags (`:status-before` / `:status-after`
+  / `:rf.frame/id` / …) — only the body-bearing envelope is tokenized."
+  #{:error :page-error})
 
 (def ^:private cursor-slot
   "Tag slots that carry the load-more PAGINATION CURSOR as a FREE scalar tag
@@ -246,6 +271,49 @@
                   (if cursor-redacts?
                     (do (note! true) (assoc m k (ssr/redact-value v)))
                     (assoc m k v)))
+
+                ;; HTTP failure envelope (`:error` / `:page-error`): the raw
+                ;; `:rf.http/*` reply map (`:body` / `:body-text` / `:detail`)
+                ;; echoes submitted form fields + validation text — app-owned
+                ;; data the scoped-key vocabulary is blind to (rf2-7qbxbm). It
+                ;; is UNCONDITIONALLY tokenized off-box (content-addressed via
+                ;; `redact-value`, the same tokenizer the cursor uses) — the
+                ;; status/category attribution survives on the row's sibling
+                ;; scalar tags. Idempotent (an already-redacted token rides
+                ;; as-is). A nil / non-payload envelope rides verbatim.
+                (and (error-envelope-slot k) (some? v))
+                (if (redacted-token? v)
+                  (do (note! true) (assoc m k v))
+                  (do (note! true) (assoc m k (ssr/redact-value v))))
+
+                ;; FAIL-CLOSED default (rf2-7qbxbm): an UNKNOWN slot whose value
+                ;; is a MAP — the unambiguous payload shape (an HTTP envelope, an
+                ;; arbitrary app result/error map the scoped-key / cursor /
+                ;; envelope vocabulary above did not recognise) — is tokenized
+                ;; rather than passed through verbatim. This flips the former
+                ;; verbatim `:else` (which fell OPEN on any unrecognised slot) to
+                ;; fail CLOSED on map payloads, so a FUTURE map-bearing slot
+                ;; added to a resource/mutation row without a projector clause
+                ;; cannot leak the same way `:error` did. An already-projected
+                ;; (`{:rf/redacted …}`) map is itself a map, so it is guarded
+                ;; FIRST and rides as-is (idempotent — never re-digested).
+                ;;
+                ;; SCALARS and scalar-collections ride verbatim through the final
+                ;; `:else`: structural facts (keywords / numbers / booleans /
+                ;; short id strings — `:rf.frame/id`, `:cause`, `:decision`,
+                ;; `:generation`, `:work/id`, `:delay-ms`, `:status-before` /
+                ;; `:status-after`, counts) and app-defined TAG-keyword vectors
+                ;; (`:invalidated-tags`) are not app-data payloads, and
+                ;; tokenizing them would destroy attribution / a tool's joins
+                ;; with no security gain. The genuine app-data leak vectors are
+                ;; the scoped keys (handled above), the cursor (handled above),
+                ;; and the MAP-shaped HTTP envelope (handled here) — the
+                ;; conservative fail-closed scope the audit ruled.
+                (redacted-token? v)
+                (do (note! true) (assoc m k v))
+
+                (map? v)
+                (do (note! true) (assoc m k (ssr/redact-value v)))
 
                 :else (assoc m k v)))
             {}

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -157,6 +157,20 @@
   / `:rf.frame/id` / …) — only the body-bearing envelope is tokenized."
   #{:error :page-error})
 
+(def ^:private sibling-owned-slot
+  "Tag slots OWNED by the SIBLING `:rf.resource/scope-resolved` projector
+  (`re-frame.resources.scope-registry/project-scope-resolved-egress`), which the
+  epoch tool-pair runs BEFORE this family projector on the SAME row
+  (`omit-off-box-resource-scope-values` → `omit-off-box-resource-trace-keys`).
+  That projector already classifies these resolver-owned slots — redacting them
+  for a sensitive resolver, but leaving them VERBATIM for an explicitly
+  `:rf.egress/public` (declassified) resolver (rf2-84l82t, the enumerable
+  declassification surface). They must therefore PASS THROUGH this projector's
+  fail-closed map default unchanged — re-tokenizing a declassified `:input-
+  values` map here would undo the sibling's deliberate declassification
+  (rf2-7qbxbm)."
+  #{:input-values :scope})
+
 (def ^:private cursor-slot
   "Tag slots that carry the load-more PAGINATION CURSOR as a FREE scalar tag
   (not a scoped key): the `:rf.resource/load-more` row's `:page-param` (the
@@ -298,19 +312,27 @@
                 ;; (`{:rf/redacted …}`) map is itself a map, so it is guarded
                 ;; FIRST and rides as-is (idempotent — never re-digested).
                 ;;
-                ;; SCALARS and scalar-collections ride verbatim through the final
-                ;; `:else`: structural facts (keywords / numbers / booleans /
-                ;; short id strings — `:rf.frame/id`, `:cause`, `:decision`,
-                ;; `:generation`, `:work/id`, `:delay-ms`, `:status-before` /
-                ;; `:status-after`, counts) and app-defined TAG-keyword vectors
+                ;; SCALARS, scalar-collections, and SIBLING-OWNED slots ride
+                ;; verbatim through the final `:else`: structural facts
+                ;; (keywords / numbers / booleans / short id strings —
+                ;; `:rf.frame/id`, `:cause`, `:decision`, `:generation`,
+                ;; `:work/id`, `:delay-ms`, `:status-before` / `:status-after`,
+                ;; counts) and app-defined TAG-keyword vectors
                 ;; (`:invalidated-tags`) are not app-data payloads, and
                 ;; tokenizing them would destroy attribution / a tool's joins
-                ;; with no security gain. The genuine app-data leak vectors are
-                ;; the scoped keys (handled above), the cursor (handled above),
-                ;; and the MAP-shaped HTTP envelope (handled here) — the
-                ;; conservative fail-closed scope the audit ruled.
+                ;; with no security gain; the scope-resolved sibling projector's
+                ;; `:input-values` / `:scope` slots (`sibling-owned-slot`) were
+                ;; ALREADY classified upstream (and a `:rf.egress/public`
+                ;; resolver's ride VERBATIM by design), so re-tokenizing them
+                ;; here would undo that declassification. The genuine app-data
+                ;; leak vectors are the scoped keys (above), the cursor (above),
+                ;; and the MAP-shaped HTTP envelope (above) — the conservative
+                ;; fail-closed scope the audit ruled.
                 (redacted-token? v)
                 (do (note! true) (assoc m k v))
+
+                (sibling-owned-slot k)
+                (assoc m k v)
 
                 (map? v)
                 (do (note! true) (assoc m k (ssr/redact-value v)))

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -18,7 +18,8 @@
   the handler fns only.
 
   Per the rf2-gxgo7 split of re-frame.ssr."
-  (:require [re-frame.error :as error]
+  (:require [clojure.string :as str]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -169,16 +170,21 @@
   per-tool reimplementation prohibited; sinks consume already-projected
   records only) under the off-box-observability profile, seeded at the
   rejected `frame`, BEFORE the record fans out. A frame that declares the
-  `:rf/frame-id` path `:sensitive` redacts it; an unresolvable / FRAMELESS
-  frame fails CLOSED (the whole `extra` value redacts to `:rf/redacted`
-  rather than ride raw — EP-0002 / EP-0015 issue 1). The dev-trace axis
-  (DCE'd in production) keeps the raw `extra` for local Xray fidelity — the
-  leak is off-box, not the local trace. `:reason` is framework-AUTHORED
-  prose (the slice-shape / frame-id-mismatch sentences, interpolating a
-  value TYPE or the structural frame ids, never a raw app value), so it
-  rides as the framework's own diagnostic — it is NOT a deserialised payload
-  slot, and routing it would over-redact the operator's diagnostic with no
-  security gain (a frameless reject would lose the reason entirely)."
+  `:payload-frame-id` path `:sensitive` redacts it; an unresolvable /
+  FRAMELESS frame fails CLOSED (the whole `extra` value redacts to
+  `:rf/redacted` rather than ride raw — EP-0002 / EP-0015 issue 1). The
+  dev-trace axis (DCE'd in production) keeps the raw `extra` + raw `:reason`
+  for local Xray fidelity — the leak is off-box, not the local trace.
+
+  `:reason` is framework-AUTHORED prose, BUT the frame-id-mismatch sentence
+  INTERPOLATES the untrusted `:payload-frame-id` into its text (`'<value>'`),
+  so a corpus listener reading the always-on record's `:reason` would see the
+  raw value the structural `:payload-frame-id` slot just redacted. The off-box
+  record therefore SCRUBS the redacted value's rendering out of the reason
+  (replacing the raw `pr-str` occurrence with the `:rf/redacted` sentinel)
+  whenever the projection redacted that slot — so the value cannot leak via
+  the prose copy either. When the projection did NOT redact it (a frame that
+  does not declare the path sensitive), the reason rides as authored."
   ([error-id frame reason] (emit-rejected-hydration! error-id frame reason nil))
   ([error-id frame reason extra]
    (let [base {:where      'rf.ssr/hydrate
@@ -200,15 +206,30 @@
      ;; Fail-closed on an unresolvable / frameless frame (whole-value redact).
      (when-let [dispatch-error-record!
                 (late-bind/get-fn :error-emit/dispatch-error-record)]
-       (let [safe-extra (when (seq extra)
-                          (projection/project-egress
-                            extra
-                            {:frame             frame
-                             :rf.egress/profile :rf.egress/off-box-observability}))]
+       (let [safe-extra  (when (seq extra)
+                           (projection/project-egress
+                             extra
+                             {:frame             frame
+                              :rf.egress/profile :rf.egress/off-box-observability}))
+             ;; The reason prose interpolates the raw `:payload-frame-id` (via
+             ;; string concatenation: `'<value>'`). If the projection redacted
+             ;; that slot, scrub the raw value's rendering out of the reason so
+             ;; it does not leak via the prose copy. Matches the `str`-form the
+             ;; mismatch sentence interpolates (`'" payload-frame-id "'`).
+             raw-pfid    (:payload-frame-id extra)
+             redacted?   (and (contains? extra :payload-frame-id)
+                              (not= raw-pfid (:payload-frame-id safe-extra)))
+             safe-reason (if (and redacted? (string? reason) (some? raw-pfid))
+                           (str/replace reason
+                                        (str "'" raw-pfid "'")
+                                        (str ":rf/redacted"))
+                           reason)]
          (dispatch-error-record!
-           (merge {:error error-id
-                   :time  (interop/now-ms)}
-                  base safe-extra)))))))
+           (merge {:error  error-id
+                   :time   (interop/now-ms)}
+                  base
+                  {:reason safe-reason}
+                  safe-extra)))))))
 
 (defn hydrate-event-handler
   "Handler fn for the `:rf/hydrate` event. Replaces app-db with

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -22,6 +22,7 @@
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.projection :as projection]
             [re-frame.ssr.hash :as hash]
             [re-frame.trace :as trace]))
 
@@ -152,7 +153,32 @@
   (dev trace elided) must still see it (EP-0008 rf2-hhutya). `extra` is
   merged onto the always-on record (the frame-id guard carries
   `:target-frame` / `:payload-frame-id`, mirroring the boot helper's thrown
-  ex-data); the dev-trace tags carry it too so Xray sees the same shape."
+  ex-data); the dev-trace tags carry it too so Xray sees the same shape.
+
+  EGRESS CHOKE-POINT (rf2-7qbxbm / rf2-mrtis6 census B5): `extra` lifts
+  values OUT OF the DESERIALISED, UNTRUSTED hydration payload — the
+  frame-id-mismatch guard stamps `:payload-frame-id (:rf/frame-id payload)`,
+  a value the adversary-controllable wire put there. The always-on record
+  fans out to corpus listeners (Sentry / Datadog) raw `by contract`, so a
+  payload value placed in `extra` would egress off-box UNREDACTED — the
+  identical `forgot to route through the projector` gap the conformance
+  ratchet (rf2-mrtis6) governs, on the SSR no-bead leg the design census
+  surfaced. So the untrusted `extra` slots route THROUGH the centralized
+  record-level boundary primitive `re-frame.projection/project-egress` (over
+  the shared `elide-wire-value` walker — Security.md §The privacy surface:
+  per-tool reimplementation prohibited; sinks consume already-projected
+  records only) under the off-box-observability profile, seeded at the
+  rejected `frame`, BEFORE the record fans out. A frame that declares the
+  `:rf/frame-id` path `:sensitive` redacts it; an unresolvable / FRAMELESS
+  frame fails CLOSED (the whole `extra` value redacts to `:rf/redacted`
+  rather than ride raw — EP-0002 / EP-0015 issue 1). The dev-trace axis
+  (DCE'd in production) keeps the raw `extra` for local Xray fidelity — the
+  leak is off-box, not the local trace. `:reason` is framework-AUTHORED
+  prose (the slice-shape / frame-id-mismatch sentences, interpolating a
+  value TYPE or the structural frame ids, never a raw app value), so it
+  rides as the framework's own diagnostic — it is NOT a deserialised payload
+  slot, and routing it would over-redact the operator's diagnostic with no
+  security gain (a frameless reject would lose the reason entirely)."
   ([error-id frame reason] (emit-rejected-hydration! error-id frame reason nil))
   ([error-id frame reason extra]
    (let [base {:where      'rf.ssr/hydrate
@@ -167,12 +193,22 @@
      ;; UNGATED. Union record shape via the late-bind hook. (The PRE-FRAME
      ;; parse failure in `boot/read-server-payload` is the FRAMELESS sibling
      ;; of this same category.)
+     ;;
+     ;; The untrusted payload-derived `extra` slots route through
+     ;; `project-egress` (off-box-observability, frame-seeded) so a
+     ;; deserialised payload value never fans out to a corpus listener raw.
+     ;; Fail-closed on an unresolvable / frameless frame (whole-value redact).
      (when-let [dispatch-error-record!
                 (late-bind/get-fn :error-emit/dispatch-error-record)]
-       (dispatch-error-record!
-         (merge {:error error-id
-                 :time  (interop/now-ms)}
-                base extra))))))
+       (let [safe-extra (when (seq extra)
+                          (projection/project-egress
+                            extra
+                            {:frame             frame
+                             :rf.egress/profile :rf.egress/off-box-observability}))]
+         (dispatch-error-record!
+           (merge {:error error-id
+                   :time  (interop/now-ms)}
+                  base safe-extra)))))))
 
 (defn hydrate-event-handler
   "Handler fn for the `:rf/hydrate` event. Replaces app-db with

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -858,6 +858,67 @@
             (is (= :some/other-frame (-> mismatch :tags :payload-frame-id))
                 ":payload-frame-id is the payload's (server) frame stamp")))))))
 
+;; ===========================================================================
+;; rf2-7qbxbm / rf2-mrtis6 census B5 — the always-on corpus leg of the
+;; frame-id-mismatch rejection routes the UNTRUSTED deserialised
+;; :payload-frame-id through project-egress, so a frame that declares it
+;; sensitive does NOT ship it raw to off-box corpus listeners (Sentry /
+;; Datadog). The dev trace (DCE'd in production) keeps the raw value.
+;; ===========================================================================
+
+(deftest mismatch-always-on-record-redacts-sensitive-payload-frame-id
+  (testing "rf2-7qbxbm/B5: when the rejected frame declares the
+            :payload-frame-id path :sensitive, the ALWAYS-ON corpus record
+            (the production-surviving off-box-shipper leg) carries the value
+            REDACTED — it routes through project-egress — even though the dev
+            trace keeps it raw. The sensitive deserialised payload value never
+            fans out to a corpus listener raw."
+    (register-baseline-handlers!)
+    (let [;; the rejected client frame declares the untrusted payload slot
+          ;; :sensitive — so project-egress redacts it on the off-box leg.
+          client-frame (frame/make-anon-frame-record!
+                         {:doc       "B5 sensitive payload-frame-id client"
+                          :platform  :client
+                          :sensitive {:app-db [[:payload-frame-id]]}})
+          ;; the corpus-listener stand-in (the off-box shipper) records the
+          ;; ALWAYS-ON union record.
+          corpus       (atom [])
+          _            (rf/register-listener! :errors ::b5-corpus
+                         (fn [record] (swap! corpus conj record)))
+          payload      {:rf/frame-id    :secret/other-frame
+                        :rf/app-db      {:count 42}
+                        :rf/render-hash "deadbeef"}
+          dev-traces   (capture-traces!
+                         (fn []
+                           (rf/dispatch-sync [:rf/hydrate payload]
+                                             {:frame client-frame})))]
+      (try
+        (let [record   (first (filter #(= :rf.error/hydration-frame-id-mismatch
+                                          (:error %))
+                                      @corpus))
+              dev-trace (first (filter #(= :rf.error/hydration-frame-id-mismatch
+                                           (:operation %))
+                                       dev-traces))]
+          (is (some? record)
+              (str "the frame-id-mismatch fanned out on the ALWAYS-ON axis; "
+                   "saw: " (pr-str (mapv :error @corpus))))
+          (when record
+            (testing "the ALWAYS-ON corpus record redacts the untrusted payload value"
+              (is (= :rf/redacted (:payload-frame-id record))
+                  (str ":payload-frame-id is redacted on the always-on record "
+                       "(routed through project-egress); got "
+                       (pr-str (:payload-frame-id record))))
+              (is (not= :secret/other-frame (:payload-frame-id record))
+                  "the raw deserialised payload frame-id does NOT ride the corpus record")
+              (is (not (re-find #"secret/other-frame" (pr-str record)))
+                  "no raw :secret/other-frame value survives anywhere in the corpus record")))
+          (when dev-trace
+            (testing "the dev trace (DCE'd in production) keeps the raw value for local fidelity"
+              (is (= :secret/other-frame (-> dev-trace :tags :payload-frame-id))
+                  "the dev-trace tags carry the raw payload frame-id (the leak is off-box, not local)"))))
+        (finally
+          (rf/unregister-listener! :errors ::b5-corpus))))))
+
 (deftest direct-dispatch-matching-frame-id-hydrates-normally
   (testing "rf2-nv3mua: a direct dispatch whose :rf/frame-id MATCHES the
             dispatch target installs the slice normally (the validation is


### PR DESCRIPTION
Routes three egress paths that bypassed the existing `project-egress` / `redact-value` choke-point back through it, and adds a CI ratchet so a new forgetful site fails CI. The choke-point already exists and is Security.md-normative ("per-tool reimplementation prohibited; sinks consume already-projected records only"); this is enforcement + gap-closure, not new infrastructure. Per the audit's conservative defaults (`ai/findings/2026-06-20.egress-chokepoint-design.md`).

## What changed, per site

**rf2-mrtis6 (anchor) — source-scan conformance ratchet** (`egress_chokepoint_conformance_test.clj`): modelled exactly on `error_catalogue_channel_conformance_test.clj`. Scans every artefact `src/` for namespaces that call the always-on union-record fan-out chokepoints (`dispatch-error-record!` / `dispatch-frame-teardown-report!`) and asserts each either (a) is the `error-emit` definer, (b) routes its untrusted slots through `project-egress` in the same ns, or (c) is on a self-honest structural-only allow-list. A new bypassing caller fails CI; `allow-list-stays-honest` forces the co-edit. **RECORD-LEVEL slots only** — ex-data / host `:exception` stay an opaque residual per Security.md's taint-tracking non-goal.

**rf2-7qbxbm — HTTP error body / resource-mutation failure trace (C2/D1):**
- `resources/trace_egress.cljc` (D1, production-reachable off-box leg): `:rf.resource/failed` / `:rf.resource/page-failed` / `:rf.mutation/failed` rows carry the raw `:rf.http/*` failure envelope (`:body`/`:body-text`/`:detail`, echoing submitted form fields) under `:error`/`:page-error`. These fell through the projector's verbatim `:else` and reached epoch/MCP off-box raw. Now content-address-tokenized via the same `redact-value` the cursor uses. `:affected-keys` added to the per-key scoped-keys vocabulary (was leaking coarse via `:else`).
- `core/marks.cljc` (C2, DCE'd on-box dev-trace leg): added the resource-failure clause to `project-trace-event`'s `cond->` so the same envelope is summarized to `:rf/redacted` on-box.

**Fail-open `:else` → fail-CLOSED:** `trace_egress.cljc`'s verbatim `:else` now tokenizes unknown MAP-shaped slots by default (the unambiguous payload shape), so a future map payload added without a clause cannot leak the way `:error` did. Scalars / scalar-keyword vectors ride verbatim (attribution preserved); the scope-resolved sibling projector's `:input-values`/`:scope` are exempted (already classified upstream; a `:rf.egress/public` resolver's ride verbatim by design).

**ssr/hydrate.cljc (census B5, no prior bead):** `emit-rejected-hydration!` lifted the untrusted deserialized `:payload-frame-id` into the always-on error record, which fans out raw to corpus listeners. The untrusted payload-derived `extra` now routes through `project-egress` (off-box-observability, frame-seeded; fail-closed on a frameless/unresolvable frame), and the `:reason` prose's interpolated copy of that value is scrubbed when the projection redacted it.

> Note on marks: the structural fail-closed `:else` flip lives in `trace_egress.cljc` (a projector with a constrained slot vocabulary, where "unknown payload slot" is soundly definable). `marks/project-trace-event` is a multi-shape dev-trace projector where most unknown tags are legitimately structural, so a blanket redact would be unsound; it gets the explicit `:error`/`:page-error` clause + is governed by the mrtis6 ratchet for future egress-record sites.

## Regression tests (assert ACTUAL redaction — verified RED without the fix)
- `epoch_egress_resource_trace_test.clj`: `:error`/`:page-error` HTTP envelopes echoing a secret → tokenized off-box; `contains-secret?` false; structural status tags survive. Plus fail-closed-on-unknown-map and the `:include-sensitive?` local-raw opt-in. (RED without fix: 9 failures, the raw envelope egressed.)
- `marks_test.clj`: same envelope → `:rf/redacted` on-box; a scalar `:error` status keyword on a non-failure op is NOT swept up.
- `ssr_hydration_test.clj`: a frame declaring `:payload-frame-id` sensitive → the always-on corpus record redacts it (and scrubs the reason) while the dev trace keeps it raw. (RED without fix: 3 failures, raw `:secret/other-frame` egressed.)

## Quality gates
- `npm run test:cljs` — **7914 tests, 36446 assertions, 0 failures, 0 errors**
- core JVM (`clojure -M:test`) — **1719 tests, 0 failures** (incl. the new mrtis6 ratchet + marks regressions)
- epoch JVM — **376 tests, 0 failures** (incl. the new D1 trace-egress regressions)
- resources JVM — **608 tests, 0 failures**
- ssr JVM — **359 tests, 0 failures** (incl. the new B5 regression)
- mrtis6 ratchet: **GREEN**; now enforces that every `dispatch-error-record!`/`dispatch-frame-teardown-report!` caller routes through `project-egress` or is allow-listed structural-only.
- All suites re-run green after rebasing onto current `origin/main`. CI is the merge gate.

Note: built using the mayor's `implementation/node_modules` junctioned into the worktree (gitignored, not pushed) — flagged for the hygiene loop.

Does NOT touch `elision.cljc` or `redact-event` (rf2-5n2clp held decision; rf2-cd71m3 separate). Does NOT close beads.
