### PR TITLE
refactor(core): extract shared re-frame.derivation.node from 5 per-feature tooling nses (rf2-2mkflj)

### DIFF
--- a/implementation/core/src/re_frame/derivation/node.cljc
+++ b/implementation/core/src/re_frame/derivation/node.cljc
@@ -1,0 +1,118 @@
+(ns re-frame.derivation.node
+  "Internal LEAF helper for the five algebra-view tooling siblings (subs /
+  flows / routing / machines / resources) — the two scaffold shapes those
+  siblings each lower their registrar metadata into:
+
+    - the `:source` source-coordinate projection (Derivations §Errors and
+      diagnostics) — `(source-coords meta)` / `(attach-source node meta)`;
+    - the fixed-classification `node-base` spine (Derivations §The node
+      shape) — `(node-base id output classification)`.
+
+  Before rf2-2mkflj these two shapes were copy-pasted verbatim across the
+  five per-feature `tooling.cljc` siblings: the same four-line
+  `{:ns :file :line}` → `:source` `cond->` block lived in each, and the
+  seven-key classification spine was a helper ONCE in `subs.tooling` but
+  hand-inlined in the other four. A change to the `:source` shape (or a new
+  spine key) had to be propagated by hand to five places, with no gate to
+  catch the drift. This ns is the single place each now lives; the five
+  siblings `:require` it.
+
+  SCOPE — this is a LEAF. It carries ONLY the family-agnostic scaffold (the
+  source-coord projection + the classification spine that EVERY algebra node
+  shares). It deliberately does NOT unify the per-feature `node-for` /
+  `declared-inputs` bodies: those are genuinely domain-specific (a schema
+  AST vs a state tree vs app-db paths vs route-transition triggers), and a
+  single generic algebra-view there would be harmful over-abstraction. Each
+  sibling keeps its own domain mapping and decorates the shared spine with
+  its own keys (`:refinement` / `:source-form` / `:inputs` / `:owner` /
+  `:authority` / `:selectors` / `:commands` / `:spawns?` …) after calling
+  `node-base`.
+
+  REQUIRE GRAPH — this leaf lives in `core` (sibling to
+  `re-frame.derivation.graph`) and depends on NOTHING feature-specific (it
+  reads only the registrar-shaped metadata maps the siblings already hold).
+  The four optional siblings (flows / routing / machines / resources) ALL
+  already depend on core, so requiring this introduces no new
+  artefact-to-artefact edge — exactly the play already used for
+  `resources → ssr` (rf2-366u0g) and `trace → projection` (rf2-ih437c).
+
+  BUNDLE ISOLATION — this is pure data construction (no `ex-info`, no trace
+  string, no side effect) reached ONLY by the dev-only tooling siblings,
+  which are themselves DCE'd from production builds. It therefore needs no
+  bundle-isolation sentinel of its own: with no production-reachable caller,
+  `:advanced` + `goog.DEBUG=false` drop these bodies wholesale.
+
+  Per [spec/Derivations.md] §The node shape + §Errors and diagnostics and
+  the projected Malli shapes in [Spec-Schemas §`:rf/derivation-node`].")
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; Shape A — the source-coordinate projection.
+;;
+;; The registrar stamps `:ns` / `:file` / `:line` source coordinates onto a
+;; registration's metadata (Spec 001 §Source-coordinate capture). Every
+;; algebra-view sibling projects whichever of those three are present into a
+;; single `:source` map (Derivations §Errors and diagnostics). The coords are
+;; READ-only off the metadata the sibling already holds; nothing executable is
+;; ever serialized.
+;; ---------------------------------------------------------------------------
+
+(defn source-coords
+  "The `:source` map (Derivations §Errors and diagnostics) projected from a
+  registration's metadata `meta`: whichever of `:ns` / `:file` / `:line` are
+  present, in that fixed key order. Returns the (possibly empty) coord map —
+  callers that gate on presence test `(seq …)`.
+
+  This is the byte-identical four-line `cond->` block the five tooling
+  siblings each carried verbatim before rf2-2mkflj. Flows reuses THIS leaf
+  inside its frame-match gate (a different-frame same-id flow must not inherit
+  the wrong source location), so the projection is exposed separately from
+  `attach-source`."
+  [meta]
+  (cond-> {}
+    (contains? meta :ns)   (assoc :ns   (:ns   meta))
+    (contains? meta :file) (assoc :file (:file meta))
+    (contains? meta :line) (assoc :line (:line meta))))
+
+(defn attach-source
+  "Attach the projected `:source` coords (`source-coords`) to `node` when any
+  are present — the extract-and-attach idiom shared by the subs / routing /
+  machines / resources siblings (flows attaches a frame-matched coord map of
+  its own, built from `source-coords`). Returns `node` unchanged when the
+  metadata carries no coords."
+  [node meta]
+  (let [source (source-coords meta)]
+    (cond-> node
+      (seq source) (assoc :source source))))
+
+;; ---------------------------------------------------------------------------
+;; Shape C — the fixed-classification `node-base` spine.
+;;
+;; Every algebra node shares the same seven-key classification spine
+;; (Derivations §The node shape): its fact `:id`, its `:output` address, and
+;; the five classification facts `{:kind :storage :evaluation :lifecycle
+;; :materialized?}`. Each family supplies its own values for those five (a sub
+;; is an ephemeral on-demand `:derivation`; a route is a runtime-db on-route
+;; `:process`; …) and then decorates the spine with its domain-specific keys.
+;; ---------------------------------------------------------------------------
+
+(defn node-base
+  "The fixed seven-key classification spine every algebra node shares
+  (Derivations §The node shape): `:id` (the node's canonical fact identity —
+  Derivations §Fact identity), `:output` (its output address), and the five
+  classification facts carried in `classification`
+  (`:kind` / `:storage` / `:evaluation` / `:lifecycle` / `:materialized?`).
+
+  Returns `{:id id :kind … :output output :storage … :evaluation …
+  :lifecycle … :materialized? …}`. Callers `assoc` / `cond->` their
+  domain-specific keys (`:refinement` / `:source-form` / `:inputs` /
+  `:owner` / …) onto the result."
+  [id output {:keys [kind storage evaluation lifecycle materialized?]}]
+  {:id            id
+   :kind          kind
+   :output        output
+   :storage       storage
+   :evaluation    evaluation
+   :lifecycle     lifecycle
+   :materialized? materialized?})

--- a/implementation/core/src/re_frame/subs/tooling.cljc
+++ b/implementation/core/src/re_frame/subs/tooling.cljc
@@ -24,7 +24,8 @@
   §Subscription topology vs subscription tracking."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
-            [re-frame.interop :as interop]))
+            [re-frame.interop :as interop]
+            [re-frame.derivation.node :as node]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -270,33 +271,32 @@
   (Derivations §The node shape): a `:derivation` whose ephemeral output is
   evaluated on-demand and owned by its subscription-cache entry. `id` is the
   node's canonical fact identity (Derivations §Fact identity) — the sub id
-  for a static node, the concrete query vector for a live cache entry."
+  for a static node, the concrete query vector for a live cache entry.
+
+  The seven-key spine itself lives in the shared `re-frame.derivation.node`
+  leaf (rf2-2mkflj); this thin wrapper supplies the subscription family's
+  fixed classification."
   [id output]
-  {:id            id
-   :kind          :derivation
-   :output        output
-   :storage       :ephemeral
-   :evaluation    :on-demand
-   :lifecycle     :subscription-cache-entry
-   :materialized? false})
+  (node/node-base id output
+                  {:kind          :derivation
+                   :storage       :ephemeral
+                   :evaluation    :on-demand
+                   :lifecycle     :subscription-cache-entry
+                   :materialized? false}))
 
 (defn- with-source-coords
   "Attach the registrar's source-coordinate / schema / doc metadata to a
   node when present — the `:source` map (Derivations §Errors and
-  diagnostics) and the `:schema` fact. Functions stay opaque tokens; we
-  never serialize the executable body."
+  diagnostics, via the shared `re-frame.derivation.node` leaf) and the
+  `:schema` fact. Functions stay opaque tokens; we never serialize the
+  executable body."
   [node meta]
-  (let [source (cond-> {}
-                 (contains? meta :ns)   (assoc :ns   (:ns   meta))
-                 (contains? meta :file) (assoc :file (:file meta))
-                 (contains? meta :line) (assoc :line (:line meta)))]
-    (cond-> node
-      (seq source)             (assoc :source source)
-      (contains? meta :schema) (assoc :schema (:schema meta))
-      (contains? meta :doc)    (assoc :doc (:doc meta))
-      ;; The body fn is an opaque token — surfaced under :derive so a tool
-      ;; can show the function source/identity without it being serialized.
-      (contains? meta :handler-fn) (assoc :derive (:handler-fn meta)))))
+  (cond-> (node/attach-source node meta)
+    (contains? meta :schema) (assoc :schema (:schema meta))
+    (contains? meta :doc)    (assoc :doc (:doc meta))
+    ;; The body fn is an opaque token — surfaced under :derive so a tool
+    ;; can show the function source/identity without it being serialized.
+    (contains? meta :handler-fn) (assoc :derive (:handler-fn meta))))
 
 (defn- static-node-for
   "Build the static algebra view for one registered sub from its registrar

--- a/implementation/flows/src/re_frame/flows/tooling.cljc
+++ b/implementation/flows/src/re_frame/flows/tooling.cljc
@@ -26,7 +26,8 @@
   Per [Derivations.md](../../../../../../spec/Derivations.md) and the
   projected Malli shapes in [Spec-Schemas
   §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
-  (:require [re-frame.flows.registry :as registry]
+  (:require [re-frame.derivation.node :as node]
+            [re-frame.flows.registry :as registry]
             [re-frame.registrar :as registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -106,10 +107,7 @@
   [frame-id flow-id]
   (let [slot (registrar/lookup :flow flow-id)]
     (when (= frame-id (:frame slot))
-      (let [source (cond-> {}
-                     (contains? slot :ns)   (assoc :ns   (:ns   slot))
-                     (contains? slot :file) (assoc :file (:file slot))
-                     (contains? slot :line) (assoc :line (:line slot)))]
+      (let [source (node/source-coords slot)]
         (when (seq source) source)))))
 
 (defn- with-metadata
@@ -144,16 +142,15 @@
   coords / schema / doc."
   [frame-id flow]
   (let [flow-id (:id flow)]
-    (-> {:id            flow-id
-         :kind          :derivation
-         :source-form   {:kind :reg-flow :id flow-id}
-         :inputs        (declared-inputs flow)
-         :output        [:db (vec (:output-path flow))]
-         :storage       :app-db
-         :evaluation    :after-event
-         :lifecycle     :frame
-         :owner         [:frame frame-id]
-         :materialized? true}
+    (-> (node/node-base flow-id [:db (vec (:output-path flow))]
+                        {:kind          :derivation
+                         :storage       :app-db
+                         :evaluation    :after-event
+                         :lifecycle     :frame
+                         :materialized? true})
+        (assoc :source-form {:kind :reg-flow :id flow-id}
+               :inputs      (declared-inputs flow)
+               :owner       [:frame frame-id])
         (with-metadata frame-id flow))))
 
 (defn flow-algebra-view

--- a/implementation/machines/src/re_frame/machines/tooling.cljc
+++ b/implementation/machines/src/re_frame/machines/tooling.cljc
@@ -40,7 +40,8 @@
   Per [Derivations.md](../../../../../../spec/Derivations.md) §Machines expose
   algebra views and the projected Malli shapes in
   [Spec-Schemas §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.derivation.node :as node]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.machines.lifecycle-fx.resolver :as resolver]
             [re-frame.machines.paths :as paths]
@@ -206,14 +207,9 @@
   user-supplied spec keys. Functions stay opaque — a machine's transition
   logic is its `:states` / `:actions` / `:guards`, never serialized here."
   [node machine meta]
-  (let [source (cond-> {}
-                 (contains? meta :ns)   (assoc :ns   (:ns   meta))
-                 (contains? meta :file) (assoc :file (:file meta))
-                 (contains? meta :line) (assoc :line (:line meta)))]
-    (cond-> node
-      (seq source)                    (assoc :source source)
-      (contains? machine :doc)        (assoc :doc (:doc machine))
-      (contains? machine :data-schema) (assoc :schema (:data-schema machine)))))
+  (cond-> (node/attach-source node meta)
+    (contains? machine :doc)         (assoc :doc (:doc machine))
+    (contains? machine :data-schema) (assoc :schema (:data-schema machine))))
 
 (defn- node-for
   "Build the derivation/process algebra view of one machine spec (Derivations
@@ -231,18 +227,17 @@
   declared `[:event …]` triggers), `:output` (the runtime-db snapshot path),
   `:source-form`, `:spawns?` flag, and source coords / schema / doc."
   [id source-id machine meta]
-  (-> {:id            id
-       :kind          :process
-       :refinement    :machine-process
-       :source-form   {:kind :reg-machine :id source-id}
-       :inputs        (declared-event-inputs machine)
-       :output        [:runtime (paths/snapshot-path id)]
-       :storage       :runtime-db
-       :evaluation    (evaluation-policy machine)
-       :lifecycle     :machine-instance
-       :owner         [:machine id]
-       :materialized? true
-       :spawns?       (declares-spawn? machine)}
+  (-> (node/node-base id [:runtime (paths/snapshot-path id)]
+                      {:kind          :process
+                       :storage       :runtime-db
+                       :evaluation    (evaluation-policy machine)
+                       :lifecycle     :machine-instance
+                       :materialized? true})
+      (assoc :refinement  :machine-process
+             :source-form {:kind :reg-machine :id source-id}
+             :inputs      (declared-event-inputs machine)
+             :owner       [:machine id]
+             :spawns?     (declares-spawn? machine))
       (with-metadata machine meta)))
 
 (defn machine-algebra-view

--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -36,7 +36,8 @@
   Per [Derivations.md](../../../../../../spec/Derivations.md) §Resources
   expose process nodes (graduated from EP-0014) and the projected Malli
   shapes in [Spec-Schemas §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.derivation.node :as node]
+            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.scope-registry :as scope-registry]
@@ -234,15 +235,10 @@
   fn is the resource's whole-value process driver, surfaced under `:derive`
   as an opaque token (never serialized)."
   [node spec slot]
-  (let [source (cond-> {}
-                 (contains? slot :ns)   (assoc :ns   (:ns   slot))
-                 (contains? slot :file) (assoc :file (:file slot))
-                 (contains? slot :line) (assoc :line (:line slot)))]
-    (cond-> node
-      (seq source)                  (assoc :source source)
-      (contains? spec :data-schema) (assoc :schema (:data-schema spec))
-      (some? (:doc spec))           (assoc :doc (:doc spec))
-      (contains? spec :request)     (assoc :derive (:request spec)))))
+  (cond-> (node/attach-source node slot)
+    (contains? spec :data-schema) (assoc :schema (:data-schema spec))
+    (some? (:doc spec))           (assoc :doc (:doc spec))
+    (contains? spec :request)     (assoc :derive (:request spec))))
 
 (defn- static-node-for
   "Build the STATIC derivation/process algebra view of one resource from its
@@ -263,19 +259,18 @@
   [resource-id spec slot]
   (let [transport-id (or (:transport spec) transport/default-transport)
         resolver     (scope-resolver-enrichment spec)]
-    (-> {:id            resource-id
-         :kind          resource-superkind
-         :refinement    resource-refined-kind
-         :source-form   {:kind :reg-resource :id resource-id}
-         :inputs        (declared-inputs spec)
-         :output        [:runtime [state/resources-key :entries]]
-         :storage       resource-storage
-         :authority     (authority-for transport-id)
-         :evaluation    resource-evaluation
-         :lifecycle     resource-lifecycle
-         :selectors     resource-selectors
-         :commands      (resource-commands transport-id)
-         :materialized? true}
+    (-> (node/node-base resource-id [:runtime [state/resources-key :entries]]
+                        {:kind          resource-superkind
+                         :storage       resource-storage
+                         :evaluation    resource-evaluation
+                         :lifecycle     resource-lifecycle
+                         :materialized? true})
+        (assoc :refinement  resource-refined-kind
+               :source-form {:kind :reg-resource :id resource-id}
+               :inputs      (declared-inputs spec)
+               :authority   (authority-for transport-id)
+               :selectors   resource-selectors
+               :commands    (resource-commands transport-id))
         (cond-> (some? resolver) (assoc :scope-resolver resolver))
         (with-metadata spec slot))))
 

--- a/implementation/routing/src/re_frame/routing/tooling.cljc
+++ b/implementation/routing/src/re_frame/routing/tooling.cljc
@@ -34,7 +34,8 @@
   from EP-0014; §Routes expose algebra views) and the projected Malli
   shapes in [Spec-Schemas §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
   (:require [re-frame.registrar :as registrar]
-            [re-frame.frame :as frame]))
+            [re-frame.frame :as frame]
+            [re-frame.derivation.node :as node]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -161,17 +162,13 @@
 
 (defn- with-source-coords
   "Attach the registrar's source-coordinate / doc metadata to a route node
-  when present — the `:source` map (Derivations §Errors and diagnostics) and
-  the `:doc`. Source coords are auto-captured by `reg-route` via
-  `re-frame.source-coords/merge-coords` (Spec 001 §Source-coordinate capture)."
+  when present — the `:source` map (Derivations §Errors and diagnostics, via
+  the shared `re-frame.derivation.node` leaf) and the `:doc`. Source coords
+  are auto-captured by `reg-route` via `re-frame.source-coords/merge-coords`
+  (Spec 001 §Source-coordinate capture)."
   [node route-meta]
-  (let [source (cond-> {}
-                 (contains? route-meta :ns)   (assoc :ns   (:ns   route-meta))
-                 (contains? route-meta :file) (assoc :file (:file route-meta))
-                 (contains? route-meta :line) (assoc :line (:line route-meta)))]
-    (cond-> node
-      (seq source)                 (assoc :source source)
-      (contains? route-meta :doc)  (assoc :doc (:doc route-meta)))))
+  (cond-> (node/attach-source node route-meta)
+    (contains? route-meta :doc) (assoc :doc (:doc route-meta))))
 
 (defn- node-for
   "Build the derivation/process algebra view of one registered route from its
@@ -194,16 +191,15 @@
   the `:source-form`, the route-owned resource activation `:resource-edges`
   (when declared), and source coords / doc."
   [route-id route-meta]
-  (-> {:id            :rf/route
-       :kind          :process
-       :refinement    :route-fact
-       :source-form   {:kind :reg-route :id route-id}
-       :inputs        route-transition-inputs
-       :output        route-output
-       :storage       :runtime-db
-       :evaluation    :on-route
-       :lifecycle     :frame
-       :materialized? true}
+  (-> (node/node-base :rf/route route-output
+                      {:kind          :process
+                       :storage       :runtime-db
+                       :evaluation    :on-route
+                       :lifecycle     :frame
+                       :materialized? true})
+      (assoc :refinement  :route-fact
+             :source-form {:kind :reg-route :id route-id}
+             :inputs      route-transition-inputs)
       (cond-> (seq (:resources route-meta))
         (assoc :resource-edges (resource-activation-edges route-meta)))
       (with-source-coords route-meta)))


### PR DESCRIPTION
Pure behaviour-neutral concept-unification refactor for **rf2-2mkflj**.

## What

The source-coordinate `:source` projection (**Shape A**) and the fixed-classification `node-base` spine (**Shape C**) were copy-pasted across the five algebra-view tooling siblings — `subs` / `routing` / `machines` / `flows` / `resources`. The four-line `{:ns :file :line}` → `:source` `cond->` block lived verbatim in each, and the seven-key spine was a helper *once* in `subs.tooling` but hand-inlined in the other four. A change to the `:source` shape or a new spine key had to be hand-propagated to five places with no gate to catch the drift.

Extracted a single leaf helper **`re-frame.derivation.node`** (new file, sibling to `re-frame.derivation.graph` in core) exposing:

- `source-coords` / `attach-source` — Shape A (the `:source` coord projection; `attach-source` does extract+attach, `source-coords` is the extract-only leaf flows reuses inside its frame-match gate)
- `node-base [id output classification]` — Shape C (the seven-key `{:id :kind :output :storage :evaluation :lifecycle :materialized?}` spine)

All five tooling siblings now `:require` it. Each keeps its own domain `node-for` / `declared-inputs` mapping and decorates the shared spine with its family-specific keys (`:refinement` / `:source-form` / `:inputs` / `:owner` / `:authority` / `:selectors` / `:commands` / `:spawns?`).

## Scope bounds honoured (per the bead)

- **Did NOT** unify the per-feature `node-for` / `declared-inputs` bodies (genuinely domain-specific — schema AST vs state tree vs app-db paths vs route triggers).
- **Left `trace/tooling.cljc` out** entirely (stateful listener/ring surface, shares no scaffold).
- **Left `sub-topology`'s flat top-level coord block untouched** — it flattens coords into the topology entry (different shape from the `:source`-nested algebra node), and the bead did not list it.

## Require graph

Clean — no new coupling. The leaf lives in core and depends on **nothing** (no `:require` form at all; reads only registrar-shaped metadata maps). The four optional siblings already depend on core (`day8/re-frame2 {:local/root "../core"}`), so requiring it adds no artefact-to-artefact edge. No `deps.edn` change required.

## Behaviour-neutral verification

The emitted node maps are **value-identical** before/after (same keys, same values; only array-map insertion order shifts, which is irrelevant to Clojure map equality). Every algebra-view test compares by `=` / `select-keys` / `set (keys …)` — all order-independent — and there are no `pr-str`/EDN-snapshot golden comparisons of node maps.

## Quality gates

| Gate | Result |
|------|--------|
| `npm run test:cljs` | ✅ 7914 tests / 36446 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` (feature-matrix, exercises tooling node shapes) | ✅ 15 scenarios, 0 failures, 13 matrix rows, 10 surfaces compiled 0 warnings |
| subs algebra-view (`core` JVM) | ✅ 14 tests / 46 assertions |
| routing algebra-view (JVM) | ✅ 15 tests / 50 assertions |
| machines algebra-view (JVM) | ✅ 18 tests / 51 assertions |
| flows algebra-view (JVM) | ✅ 11 tests / 35 assertions |
| core derivation-graph (JVM) | ✅ 18 tests / 71 assertions |
| resources algebra-view (CLJS) | ✅ covered under `test:cljs` |

CI is the merge gate.