### PR TITLE
refactor(resources): parameterize the stale-suppress reply-handler trio into a shared ns (rf2-nnke18)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -66,6 +66,7 @@
             [re-frame.frame :as frame]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.reply :as rreply]
+            [re-frame.resources.reply-handlers :as reply-handlers]
             [re-frame.resources.route :as route]
             [re-frame.resources.scope-registry :as scope-registry]
             [re-frame.resources.state :as state]
@@ -1817,122 +1818,71 @@
 ;; generation before writing (Spec 016 §Transport — stale suppression is
 ;; the correctness boundary). User code MUST NOT dispatch them.
 
-(defn- entry-current-generation
-  "Read the LIVE counterpart generation for a stale-suppression gate: the
-  `:generation` of the entry currently occupying `resource-key` at
-  completion. nil when no entry occupies the slot (it was removed / GC'd /
-  cleared — no live counterpart, exactly the supersession the gate records).
-  This is the `:current` half of the carried-vs-current pair the canonical
-  stale reply carries; the `:carried` half is the generation stamped on the
-  reply token (`(:generation payload)`)."
-  [runtime-db resource-key]
-  (:generation (get-in runtime-db (state/entry-path resource-key))))
+;; The stale-suppression trio (the live-slot verifier, the stale-suppress
+;; reply builder, and the stale-suppressed trace emitter) is the SHARED
+;; substrate `re-frame.resources.reply-handlers` (rf2-nnke18) — byte-identical
+;; behaviour to the mutation family, parameterized by the three resource knobs
+;; below (the slot path-fn, the work-kind, and the stale-reason) plus the
+;; resource correlation-fn / trace-id / bespoke trace facts.
+
+(defn- entry-path-for-reply
+  "The resource family's durable-slot path-fn (`(payload) → db-path`): the
+  cache entry at the reply's `:resource/key`. Used by the shared
+  `reply-handlers` verifier + current-generation reader."
+  [{resource-key :resource/key}]
+  (state/entry-path resource-key))
+
+(defn- resource-correlation
+  "The resource family's stale-reply diagnostic correlation keys (beyond the
+  carried/current `:generation` pair): `:resource/key` + `:scope`, each
+  OMITTED when absent (Managed-Effects §The reply map)."
+  [{resource-key :resource/key :keys [scope]}]
+  (cond-> {}
+    (some? resource-key) (assoc :resource/key resource-key)
+    (some? scope)        (assoc :scope scope)))
+
+(def ^:private resource-stale-knobs
+  "The resource family's stale-suppress knobs for
+  `reply-handlers/stale-suppress-reply`: `:work-kind`, `:stale-reason`, and
+  the `:correlation-fn`."
+  {:work-kind      rreply/work-kind-resource
+   :stale-reason   :rf.resource/superseded
+   :correlation-fn resource-correlation})
 
 (defn- stale-suppress-reply
   "Build the canonical `:status :stale` reply outcome for a superseded /
-  vanished RESOURCE reply through the SHARED `re-frame.reply` substrate
-  (via `rreply/stale-reply`), so the resource family lowers its stale
-  outcome exactly as every other managed-async family does (Managed-Effects
-  §Stale suppression). The carried correlation is the reply token's
-  `:work/id` + `:generation`; the current correlation is the live entry's
-  `:generation` (nil when the slot is gone — no live counterpart). The
-  result rides `:rf.reply/status :stale` / `:rf.reply/work-status
-  :suppressed` / `:rf.reply/stale-reason` / the carried-vs-current
-  generation pair ADDITIVELY onto the existing `:rf.resource/stale-
-  suppressed` trace via `emit-resource-stale-suppressed!`.
-
-  Returns the `re-frame.reply/suppress` outcome map (`:deliver?` is false —
-  the app reply target MUST NOT run; `:reply` is the data-only `:status
-  :stale` reply; `:work/status :suppressed`). `extra` threads diagnostic
-  facts (e.g. `:outcome`) onto the stale reply."
-  [runtime-db resource-key {work-id :work/id :keys [generation scope] :as payload} extra]
-  (let [carried-gen (:generation payload)
-        current-gen (entry-current-generation runtime-db resource-key)]
-    (rreply/stale-reply
-      {:carried {:work/id work-id :generation carried-gen}
-       :current {:generation current-gen}
-       :extra   (merge {:work/id      work-id
-                        :work/kind    rreply/work-kind-resource
-                        :stale/reason :rf.resource/superseded
-                        :correlation  (cond-> {:generation {:carried carried-gen
-                                                             :current current-gen}}
-                                        (some? resource-key) (assoc :resource/key resource-key)
-                                        (some? scope)         (assoc :scope scope))}
-                       extra)})))
+  vanished RESOURCE reply through the SHARED `reply-handlers` substrate (which
+  lowers through `rreply/stale-reply`), so the resource family lowers its stale
+  outcome exactly as the mutation family + every other managed-async family
+  does (Managed-Effects §Stale suppression). `extra` threads diagnostic facts
+  (e.g. `:outcome`) onto the stale reply."
+  [runtime-db _resource-key payload extra]
+  (reply-handlers/stale-suppress-reply
+    runtime-db entry-path-for-reply payload resource-stale-knobs extra))
 
 (defn- emit-resource-stale-suppressed!
   "Emit the `:rf.resource/stale-suppressed` trace for a suppressed late
-  resource reply, carrying its bespoke facts (`:resource/key` / `:work/id` /
+  resource reply via the SHARED `reply-handlers/emit-stale-suppressed!`,
+  carrying the resource bespoke facts (`:resource/key` / `:work/id` /
   `:generation` / `:outcome`) PLUS the canonical reply-envelope vocabulary
-  ADDITIVELY (joined to `:work/id` via the shared `:rf.reply/*` facts):
-  `:rf.reply/status :stale`, `:rf.reply/work-status :suppressed`,
-  `:rf.reply/stale-reason`, `:rf.reply/work-id`, and `:rf.reply/correlation`
-  (the carried-vs-current generation gate) — the SAME additive shape the
-  machine `:rf.machine/done` and HTTP / probe stale paths ride (Managed-
-  Effects §Tracing / EP-0011). `stale` is the `stale-suppress-reply`
-  outcome; its trace summary routes wire slots through the shared elider via
-  `rreply/trace-reply`."
+  ADDITIVELY (Managed-Effects §Tracing / EP-0011 / rf2-waawic)."
   [frame-id resource-key work-id generation outcome stale]
-  (let [summary (rreply/trace-reply (:reply stale))]
-    (trace/emit! :rf.event :rf.resource/stale-suppressed
-                 {:rf.frame/id frame-id :resource/key resource-key
-                  :work/id work-id :generation generation :outcome outcome
-                  ;; reply-envelope vocabulary (Managed-Effects §9) — the
-                  ;; canonical :status :stale reply produced via the shared
-                  ;; substrate, recorded ADDITIVELY (the bespoke facts above
-                  ;; are preserved).
-                  :rf.reply/status      (:status summary)
-                  :rf.reply/work-status (:work/status summary)
-                  :rf.reply/work-id     (:work/id summary)
-                  :rf.reply/stale-reason (:stale/reason summary)
-                  :rf.reply/correlation (:correlation summary)
-                  ;; rf2-waawic — the SHARED carried/current stale-gate facts
-                  ;; `re-frame.reply/suppress` already computed on `(:trace
-                  ;; stale)`. Projecting them here lets the uniform
-                  ;; reply-envelope view read the stale gate without
-                  ;; resource-family-specific parsing (the `:rf.reply/
-                  ;; correlation` above is the reply's bespoke generation pair;
-                  ;; these are the shared substrate facts Xray's
-                  ;; reply-envelope panel reads at :518).
-                  :rf.reply/carried     (:rf.reply/carried (:trace stale))
-                  :rf.reply/current     (:rf.reply/current (:trace stale))})))
+  (reply-handlers/emit-stale-suppressed!
+    :rf.resource/stale-suppressed
+    {:rf.frame/id frame-id :resource/key resource-key
+     :work/id work-id :generation generation :outcome outcome}
+    stale))
 
 (defn- live-entry-for-reply
-  "Look the live entry up for an internal reply and verify it is still the
-  one the reply belongs to: the reply's stamped `:rf.frame/id` equals the
-  RECEIVING frame (`receiving-frame-id`), the entry exists, its
-  `:current-work` equals the reply's `:work/id`, AND its `:generation`
-  equals the reply's `:generation`. Returns the entry on a match, nil on a
-  cross-frame / stale / superseded / vanished reply (which MUST be suppressed
-  — Spec 016 §Cancellation is opportunistic; stale suppression is mandatory).
-
-  FRAME VERIFICATION (rf2-eu2ifi): the runtime stamps the qualified
-  `:rf.frame/id` into every reply payload at lowering; the reply handler runs
-  in the RECEIVING frame's cofx. A reply whose payload frame does not match
-  the receiving frame is REJECTED without touching this frame's entry or
-  ledger — a misrouted reply (a cross-frame request-id collision, or a reply
-  re-dispatched into the wrong frame) can never mutate the wrong frame's
-  cache. The frame stamp is checked FIRST (before the per-frame entry lookup)
-  so a cross-frame reply is rejected even when both frames happen to hold the
-  same scoped key at the same generation.
-
-  The work-id is the single intra-frame identity (it embeds the generation);
-  the generation check is belt-and-braces for a future transport that reuses
-  a work-id. A reply with no stamped frame (a direct-dispatch test payload
-  that omits `:rf.frame/id`) skips the frame check (nil never collides with a
-  concrete frame id) and is verified by work-id + generation alone — the
-  runtime-slice tests stay deterministic.
-
-  The verification work identity is `:work/id` (EP-0007 — the qualified
-  spelling the ledger row, the entry's `:current-work`, and the uniform
-  reply envelope share). One attempt, one work id, one name."
-  [runtime-db receiving-frame-id {work-id :work/id resource-key :resource/key :keys [generation] :as payload}]
-  (let [reply-frame (:rf.frame/id payload)]
-    (when (or (nil? reply-frame) (= reply-frame receiving-frame-id))
-      (when-let [entry (get-in runtime-db (state/entry-path resource-key))]
-        (when (and (= work-id (:current-work entry))
-                   (= generation (:generation entry)))
-          entry)))))
+  "Look the live entry up for an internal reply via the SHARED
+  `reply-handlers/live-slot-for-reply` (frame + work-id + generation
+  verification against the resource entry at the reply's `:resource/key`).
+  Returns the entry on a match, nil on a cross-frame / stale / superseded /
+  vanished reply (which MUST be suppressed — Spec 016 §Cancellation is
+  opportunistic; stale suppression is mandatory)."
+  [runtime-db receiving-frame-id payload]
+  (reply-handlers/live-slot-for-reply
+    runtime-db receiving-frame-id entry-path-for-reply payload))
 
 ;; ---- transport reply payload extraction → canonical reply map --------------
 ;;

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -68,6 +68,7 @@
             [re-frame.resources.mutation-runtime :as mstate]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.reply :as rreply]
+            [re-frame.resources.reply-handlers :as reply-handlers]
             [re-frame.resources.scope-registry :as scope-registry]
             [re-frame.resources.state :as state]
             [re-frame.resources.transport :as transport]
@@ -1469,116 +1470,73 @@
 ;; writing (stale suppression is the correctness boundary). User code MUST
 ;; NOT dispatch these.
 
+;; The stale-suppression trio (the live-slot verifier, the stale-suppress
+;; reply builder, and the stale-suppressed trace emitter) is the SHARED
+;; substrate `re-frame.resources.reply-handlers` (rf2-nnke18) — byte-identical
+;; behaviour to the resource family, parameterized by the three mutation knobs
+;; below (the slot path-fn, the work-kind, and the stale-reason) plus the
+;; mutation correlation-fn / trace-id / bespoke trace facts.
+
+(defn- instance-path-for-reply
+  "The mutation family's durable-slot path-fn (`(payload) → db-path`): the
+  mutation instance at the reply's `:instance-id`. Used by the shared
+  `reply-handlers` verifier + current-generation reader."
+  [{:keys [instance-id]}]
+  (mstate/instance-path instance-id))
+
+(defn- mutation-correlation
+  "The mutation family's stale-reply diagnostic correlation keys (beyond the
+  carried/current `:generation` pair): `:instance/id` + `:mutation/id` +
+  `:scope`, each OMITTED when absent (Managed-Effects §The reply map)."
+  [{:keys [instance-id mutation-id scope]}]
+  (cond-> {}
+    (some? instance-id) (assoc :instance/id instance-id)
+    (some? mutation-id) (assoc :mutation/id mutation-id)
+    (some? scope)       (assoc :scope scope)))
+
+(def ^:private mutation-stale-knobs
+  "The mutation family's stale-suppress knobs for
+  `reply-handlers/stale-suppress-reply`: `:work-kind`, `:stale-reason`, and
+  the `:correlation-fn`."
+  {:work-kind      rreply/work-kind-mutation
+   :stale-reason   :rf.mutation/superseded
+   :correlation-fn mutation-correlation})
+
 (defn- live-instance-for-reply
-  "Look the live mutation instance up for an internal reply and verify it is
-  still the one the reply belongs to: the reply's stamped `:rf.frame/id`
-  equals the RECEIVING frame (`receiving-frame-id`), the instance exists,
-  its `:current-work` equals the reply's `:work/id`, AND its `:generation`
-  equals the reply's `:generation`. Returns the instance on a match, nil on
-  a cross-frame / stale / superseded / cleared reply (which MUST be
-  suppressed). Mirrors the resource `live-entry-for-reply`.
-
-  FRAME VERIFICATION (rf2-jzh5gq, the mutation analogue of rf2-eu2ifi): the
-  managed-HTTP transport stamps the qualified `:rf.frame/id` into every
-  reply payload at lowering (`transport/http.cljc`); the reply handler runs
-  in the RECEIVING frame's cofx. A reply whose payload frame does not match
-  the receiving frame is REJECTED without touching this frame's instance or
-  ledger — with two frames using the same mutation instance / generation, a
-  misrouted reply can no longer settle the WRONG frame. The frame stamp is
-  checked FIRST (before the per-frame instance lookup), so a cross-frame
-  reply is rejected even when both frames happen to hold the same instance
-  at the same generation. A reply with no stamped frame (a direct-dispatch
-  test payload that omits `:rf.frame/id`) skips the frame check (nil never
-  collides with a concrete frame id) and is verified by work-id +
-  generation alone.
-
-  The verification work identity is `:work/id` (EP-0007 — one attempt, one
-  work id, one name)."
-  [runtime-db receiving-frame-id {work-id :work/id :keys [instance-id generation] :as payload}]
-  (let [reply-frame (:rf.frame/id payload)]
-    (when (or (nil? reply-frame) (= reply-frame receiving-frame-id))
-      (when-let [inst (get-in runtime-db (mstate/instance-path instance-id))]
-        (when (and (= work-id (:current-work inst))
-                   (= generation (:generation inst)))
-          inst)))))
-
-(defn- instance-current-generation
-  "Read the LIVE counterpart generation for a stale-suppression gate: the
-  `:generation` of the mutation instance currently occupying `instance-id`
-  at completion. nil when no instance occupies the slot (it was cleared —
-  no live counterpart, exactly the supersession the gate records). The
-  `:current` half of the carried-vs-current pair the canonical stale reply
-  carries; the `:carried` half is the generation stamped on the reply token
-  (`(:generation payload)`)."
-  [runtime-db instance-id]
-  (:generation (get-in runtime-db (mstate/instance-path instance-id))))
+  "Look the live mutation instance up for an internal reply via the SHARED
+  `reply-handlers/live-slot-for-reply` (frame + work-id + generation
+  verification against the mutation instance at the reply's `:instance-id`).
+  Returns the instance on a match, nil on a cross-frame / stale / superseded /
+  cleared reply (which MUST be suppressed). Mirrors the resource
+  `live-entry-for-reply` (the shared substrate is identical; only the slot
+  path-fn differs)."
+  [runtime-db receiving-frame-id payload]
+  (reply-handlers/live-slot-for-reply
+    runtime-db receiving-frame-id instance-path-for-reply payload))
 
 (defn- stale-suppress-reply
   "Build the canonical `:status :stale` reply outcome for a superseded /
-  cleared MUTATION reply through the SHARED `re-frame.reply` substrate (via
-  `rreply/stale-reply`), so the mutation family lowers its stale outcome
-  exactly as every other managed-async family does (Managed-Effects §Stale
-  suppression). The carried correlation is the reply token's `:work/id` +
-  `:generation`; the current correlation is the live instance's
-  `:generation` (nil when the slot is gone — no live counterpart). The
-  result rides `:rf.reply/status :stale` / `:rf.reply/work-status
-  :suppressed` / `:rf.reply/stale-reason` / the carried-vs-current
-  generation pair ADDITIVELY onto the existing `:rf.mutation/stale-
-  suppressed` trace via `emit-mutation-stale-suppressed!`.
-
-  Returns the `re-frame.reply/suppress` outcome map (`:deliver?` false — no
-  durable mutation write, no `:reply-to` continuation; `:reply` is the
-  data-only `:status :stale` reply; `:work/status :suppressed`). `extra`
-  threads diagnostic facts (e.g. `:outcome`) onto the stale reply."
-  [runtime-db {work-id :work/id :keys [instance-id generation scope mutation-id] :as payload} extra]
-  (let [carried-gen (:generation payload)
-        current-gen (instance-current-generation runtime-db instance-id)]
-    (rreply/stale-reply
-      {:carried {:work/id work-id :generation carried-gen}
-       :current {:generation current-gen}
-       :extra   (merge {:work/id      work-id
-                        :work/kind    rreply/work-kind-mutation
-                        :stale/reason :rf.mutation/superseded
-                        :correlation  (cond-> {:generation {:carried carried-gen
-                                                             :current current-gen}}
-                                        (some? instance-id)  (assoc :instance/id instance-id)
-                                        (some? mutation-id)  (assoc :mutation/id mutation-id)
-                                        (some? scope)         (assoc :scope scope))}
-                       extra)})))
+  cleared MUTATION reply through the SHARED `reply-handlers` substrate (which
+  lowers through `rreply/stale-reply`), so the mutation family lowers its stale
+  outcome exactly as the resource family + every other managed-async family
+  does (Managed-Effects §Stale suppression). `extra` threads diagnostic facts
+  (e.g. `:outcome`) onto the stale reply."
+  [runtime-db payload extra]
+  (reply-handlers/stale-suppress-reply
+    runtime-db instance-path-for-reply payload mutation-stale-knobs extra))
 
 (defn- emit-mutation-stale-suppressed!
   "Emit the `:rf.mutation/stale-suppressed` trace for a suppressed late
-  mutation reply, carrying its bespoke facts (`:instance` / `:work/id` /
+  mutation reply via the SHARED `reply-handlers/emit-stale-suppressed!`,
+  carrying the mutation bespoke facts (`:instance` / `:work/id` /
   `:generation` / `:outcome`) PLUS the canonical reply-envelope vocabulary
-  ADDITIVELY (joined to `:work/id` via the shared `:rf.reply/*` facts):
-  `:rf.reply/status :stale`, `:rf.reply/work-status :suppressed`,
-  `:rf.reply/stale-reason`, `:rf.reply/work-id`, and `:rf.reply/correlation`
-  (the carried-vs-current generation gate) — the SAME additive shape the
-  machine `:rf.machine/done` and the resource stale path ride (Managed-
-  Effects §Tracing / EP-0011). `stale` is the `stale-suppress-reply`
-  outcome; its trace summary routes wire slots through the shared elider via
-  `rreply/trace-reply`."
+  ADDITIVELY (Managed-Effects §Tracing / EP-0011 / rf2-waawic)."
   [frame-id instance-id work-id generation outcome stale]
-  (let [summary (rreply/trace-reply (:reply stale))]
-    (trace/emit! :rf.event :rf.mutation/stale-suppressed
-                 {:rf.frame/id frame-id :instance instance-id
-                  :work/id work-id :generation generation :outcome outcome
-                  ;; reply-envelope vocabulary (Managed-Effects §9) — the
-                  ;; canonical :status :stale reply produced via the shared
-                  ;; substrate, recorded ADDITIVELY (the bespoke facts above
-                  ;; are preserved).
-                  :rf.reply/status      (:status summary)
-                  :rf.reply/work-status (:work/status summary)
-                  :rf.reply/work-id     (:work/id summary)
-                  :rf.reply/stale-reason (:stale/reason summary)
-                  :rf.reply/correlation (:correlation summary)
-                  ;; rf2-waawic — the SHARED carried/current stale-gate facts
-                  ;; `re-frame.reply/suppress` already computed on `(:trace
-                  ;; stale)`, projected so the uniform reply-envelope view
-                  ;; reads the stale gate without mutation-family-specific
-                  ;; parsing (Xray's reply-envelope panel reads them at :518).
-                  :rf.reply/carried     (:rf.reply/carried (:trace stale))
-                  :rf.reply/current     (:rf.reply/current (:trace stale))})))
+  (reply-handlers/emit-stale-suppressed!
+    :rf.mutation/stale-suppressed
+    {:rf.frame/id frame-id :instance instance-id
+     :work/id work-id :generation generation :outcome outcome}
+    stale))
 
 ;; The managed-HTTP transport APPENDS its PUBLIC reply payload as the LAST
 ;; arg of the internal reply event (Spec 014 §Reply addressing), exactly as

--- a/implementation/resources/src/re_frame/resources/reply_handlers.cljc
+++ b/implementation/resources/src/re_frame/resources/reply_handlers.cljc
@@ -1,0 +1,203 @@
+(ns re-frame.resources.reply-handlers
+  "Spec 016 — the framework-INTERNAL reply-handler substrate SHARED by the
+  resource read path (`re-frame.resources.events`) and the mutation write
+  path (`re-frame.resources.mutation-events`).
+
+  ## What this namespace is
+
+  The layer ABOVE `re-frame.resources.reply` (the canonical reply-envelope
+  builder, `rreply`). Both the resource and mutation families verify a late
+  internal reply against the LIVE durable slot (frame + work-id + generation)
+  and, on a superseded / vanished / cross-frame reply, lower the SAME stale-
+  suppression outcome (`:status :stale` / `:work/status :suppressed`) and emit
+  the SAME additively-shaped stale-suppressed trace. That trio of behaviours —
+  the live-slot verifier, the stale-suppress reply builder, and the
+  stale-suppressed trace emitter — was copy-pasted between `events.cljc` and
+  `mutation_events.cljc`, differing ONLY in the durable slot they look up and a
+  handful of vocabulary knobs. This ns hoists them ONCE, parameterized by those
+  knobs (rf2-nnke18).
+
+  ## The three knobs each family passes
+
+  - **`path-fn`** — `(payload) → db-path` for the family's durable slot: the
+    resource entry (`state/entry-path` keyed on `:resource/key`) or the
+    mutation instance (`mstate/instance-path` keyed on `:instance-id`). Used
+    by `live-for-reply?` (the verifier reads `:current-work` + `:generation`
+    off the slot) and by `current-generation` (the `:current` half of the
+    carried-vs-current stale gate reads the slot's live `:generation`).
+  - **`work-kind`** — `rreply/work-kind-resource` | `rreply/work-kind-mutation`
+    (Managed-Effects §Work-id correlation).
+  - **`stale-reason`** — `:rf.resource/superseded` | `:rf.mutation/superseded`
+    (the family's `:stale/reason` on the suppressed reply).
+
+  …plus a `correlation-fn` (`(payload) → extra-correlation` — the family's
+  diagnostic correlation keys beyond the carried/current `:generation` pair:
+  `:resource/key` for a resource; `:instance/id` + `:mutation/id` for a
+  mutation; both add `:scope`) and, at emit time, the `trace-id`
+  (`:rf.resource/stale-suppressed` | `:rf.mutation/stale-suppressed`) plus the
+  family's `bespoke-facts` (`:resource/key …` | `:instance …`). These ride the
+  SAME mechanism — they are still per-family vocabulary, not behaviour.
+
+  Pure extraction (rf2-nnke18): the verification logic, the emitted stale
+  reply, the trace ids, and the carried-vs-current generation comparison are
+  byte-identical to the pre-extraction copies in both families.
+
+  ## Stale suppression is the correctness boundary
+
+  A late reply carrying a superseded work-id / generation MUST NEVER mutate a
+  newer (or another frame's) durable slot — Spec 016 §Cancellation is
+  opportunistic; stale suppression is mandatory. The verifier checks the
+  reply's stamped `:rf.frame/id` against the RECEIVING frame FIRST (a
+  cross-frame reply is rejected before the per-frame slot lookup), then the
+  slot's `:current-work` + `:generation` against the reply token. A reply with
+  no stamped frame (a direct-dispatch test payload) skips the frame check (nil
+  never collides with a concrete frame id) and is verified by work-id +
+  generation alone."
+  (:require [re-frame.resources.reply :as rreply]
+            [re-frame.trace :as trace]))
+
+;; ---------------------------------------------------------------------------
+;; (1) Live-slot verifier (Spec 016 §Transport — stale suppression).
+;; ---------------------------------------------------------------------------
+
+(defn live-slot-for-reply
+  "Look the live durable slot up for an internal reply and verify it is still
+  the one the reply belongs to: the reply's stamped `:rf.frame/id` equals the
+  RECEIVING frame (`receiving-frame-id`), the slot at `(path-fn payload)`
+  exists, its `:current-work` equals the reply's `:work/id`, AND its
+  `:generation` equals the reply's `:generation`. Returns the slot value on a
+  match, nil on a cross-frame / stale / superseded / vanished reply (which MUST
+  be suppressed).
+
+  FRAME VERIFICATION (rf2-eu2ifi / rf2-jzh5gq): the runtime stamps the
+  qualified `:rf.frame/id` into every reply payload at lowering; the reply
+  handler runs in the RECEIVING frame's cofx. A reply whose payload frame does
+  not match the receiving frame is REJECTED without touching this frame's slot
+  or ledger — a misrouted reply (a cross-frame request-id collision, or a reply
+  re-dispatched into the wrong frame) can never mutate the wrong frame's slot.
+  The frame stamp is checked FIRST (before the per-frame slot lookup) so a
+  cross-frame reply is rejected even when both frames happen to hold the same
+  slot at the same generation. A reply with no stamped frame (a direct-dispatch
+  test payload that omits `:rf.frame/id`) skips the frame check (nil never
+  collides with a concrete frame id) and is verified by work-id + generation
+  alone — the runtime-slice tests stay deterministic.
+
+  The verification work identity is `:work/id` (EP-0007 — the qualified
+  spelling the ledger row, the slot's `:current-work`, and the uniform reply
+  envelope share). One attempt, one work id, one name. The generation check is
+  belt-and-braces for a future transport that reuses a work-id.
+
+  `path-fn` is the family's slot path: `(payload) → db-path` (the resource
+  `state/entry-path`-by-`:resource/key`, or the mutation
+  `mstate/instance-path`-by-`:instance-id`)."
+  [runtime-db receiving-frame-id path-fn {work-id :work/id :keys [generation] :as payload}]
+  (let [reply-frame (:rf.frame/id payload)]
+    (when (or (nil? reply-frame) (= reply-frame receiving-frame-id))
+      (when-let [slot (get-in runtime-db (path-fn payload))]
+        (when (and (= work-id (:current-work slot))
+                   (= generation (:generation slot)))
+          slot)))))
+
+;; ---------------------------------------------------------------------------
+;; (2) Current-generation reader (the `:current` half of the stale gate).
+;; ---------------------------------------------------------------------------
+
+(defn current-generation
+  "Read the LIVE counterpart generation for a stale-suppression gate: the
+  `:generation` of the durable slot currently occupying `(path-fn payload)` at
+  completion. nil when no slot occupies it (it was removed / GC'd / cleared —
+  no live counterpart, exactly the supersession the gate records). This is the
+  `:current` half of the carried-vs-current pair the canonical stale reply
+  carries; the `:carried` half is the generation stamped on the reply token
+  (`(:generation payload)`)."
+  [runtime-db path-fn payload]
+  (:generation (get-in runtime-db (path-fn payload))))
+
+;; ---------------------------------------------------------------------------
+;; (3) Stale-suppress reply builder (lowers through the shared substrate).
+;; ---------------------------------------------------------------------------
+
+(defn stale-suppress-reply
+  "Build the canonical `:status :stale` reply outcome for a superseded /
+  vanished reply through the SHARED `re-frame.reply` substrate (via
+  `rreply/stale-reply`), so the family lowers its stale outcome exactly as
+  every other managed-async family does (Managed-Effects §Stale suppression).
+  The carried correlation is the reply token's `:work/id` + `:generation`; the
+  current correlation is the live slot's `:generation` (nil when the slot is
+  gone — no live counterpart). The result rides `:rf.reply/status :stale` /
+  `:rf.reply/work-status :suppressed` / `:rf.reply/stale-reason` / the
+  carried-vs-current generation pair ADDITIVELY onto the family's
+  `…/stale-suppressed` trace via `emit-stale-suppressed!`.
+
+  Returns the `re-frame.reply/suppress` outcome map (`:deliver?` is false — the
+  app reply target MUST NOT run; `:reply` is the data-only `:status :stale`
+  reply; `:work/status :suppressed`).
+
+  The three family knobs:
+  - `path-fn` reads the live slot's `:current` generation (see
+    `current-generation`);
+  - `work-kind` is `rreply/work-kind-resource` | `rreply/work-kind-mutation`;
+  - `stale-reason` is the family's `:stale/reason`.
+  `correlation-fn` is `(payload) → extra-correlation` (the family's diagnostic
+  correlation keys merged ONTO the carried/current `:generation` pair —
+  `:resource/key` / `:scope` for a resource; `:instance/id` / `:mutation/id` /
+  `:scope` for a mutation). `extra` threads diagnostic facts (e.g. `:outcome`)
+  onto the stale reply."
+  [runtime-db path-fn {work-id :work/id :as payload} {:keys [work-kind stale-reason correlation-fn]} extra]
+  (let [carried-gen (:generation payload)
+        current-gen (current-generation runtime-db path-fn payload)]
+    (rreply/stale-reply
+      {:carried {:work/id work-id :generation carried-gen}
+       :current {:generation current-gen}
+       :extra   (merge {:work/id      work-id
+                        :work/kind    work-kind
+                        :stale/reason stale-reason
+                        :correlation  (assoc (correlation-fn payload)
+                                             :generation {:carried carried-gen
+                                                          :current current-gen})}
+                       extra)})))
+
+;; ---------------------------------------------------------------------------
+;; (4) Stale-suppressed trace emitter (additive reply-envelope vocabulary).
+;; ---------------------------------------------------------------------------
+
+(defn emit-stale-suppressed!
+  "Emit the family's `…/stale-suppressed` trace (`trace-id`) for a suppressed
+  late reply, carrying its bespoke facts (`bespoke-facts` — `:resource/key` /
+  `:work/id` / `:generation` / `:outcome` for a resource; `:instance` /
+  `:work/id` / `:generation` / `:outcome` for a mutation) PLUS the canonical
+  reply-envelope vocabulary ADDITIVELY (joined to `:work/id` via the shared
+  `:rf.reply/*` facts): `:rf.reply/status :stale`, `:rf.reply/work-status
+  :suppressed`, `:rf.reply/stale-reason`, `:rf.reply/work-id`, and
+  `:rf.reply/correlation` (the carried-vs-current generation gate) — the SAME
+  additive shape the machine `:rf.machine/done` and HTTP / probe stale paths
+  ride (Managed-Effects §Tracing / EP-0011). `stale` is the
+  `stale-suppress-reply` outcome; its trace summary routes wire slots through
+  the shared elider via `rreply/trace-reply`.
+
+  `bespoke-facts` is the family's leading per-trace map (its caller-side
+  spelling of `:rf.frame/id` + the durable key + `:work/id` / `:generation` /
+  `:outcome`); the additive `:rf.reply/*` facts are MERGED on top."
+  [trace-id bespoke-facts stale]
+  (let [summary (rreply/trace-reply (:reply stale))]
+    (trace/emit! :rf.event trace-id
+                 (merge bespoke-facts
+                        {;; reply-envelope vocabulary (Managed-Effects §9) — the
+                         ;; canonical :status :stale reply produced via the
+                         ;; shared substrate, recorded ADDITIVELY (the bespoke
+                         ;; facts above are preserved).
+                         :rf.reply/status      (:status summary)
+                         :rf.reply/work-status (:work/status summary)
+                         :rf.reply/work-id     (:work/id summary)
+                         :rf.reply/stale-reason (:stale/reason summary)
+                         :rf.reply/correlation (:correlation summary)
+                         ;; rf2-waawic — the SHARED carried/current stale-gate
+                         ;; facts `re-frame.reply/suppress` already computed on
+                         ;; `(:trace stale)`. Projecting them here lets the
+                         ;; uniform reply-envelope view read the stale gate
+                         ;; without family-specific parsing (the
+                         ;; `:rf.reply/correlation` above is the reply's bespoke
+                         ;; generation pair; these are the shared substrate facts
+                         ;; Xray's reply-envelope panel reads).
+                         :rf.reply/carried     (:rf.reply/carried (:trace stale))
+                         :rf.reply/current     (:rf.reply/current (:trace stale))}))))


### PR DESCRIPTION
## What

Within the resources artefact, the resource read path (`events.cljc`) and the mutation write path (`mutation_events.cljc`) copy-pasted four near-twin framework-internal reply helpers:

| resource (`events.cljc`) | mutation (`mutation_events.cljc`) |
| --- | --- |
| `live-entry-for-reply` | `live-instance-for-reply` |
| `entry-current-generation` | `instance-current-generation` |
| `stale-suppress-reply` | `stale-suppress-reply` |
| `emit-resource-stale-suppressed!` | `emit-mutation-stale-suppressed!` |

They differed ONLY in the durable slot each looks up (resource entry vs mutation instance) and a handful of vocabulary knobs. This was the layer ABOVE the shared `re-frame.resources.reply` (`rreply`) envelope builder that had NOT been hoisted.

This PR extracts them ONCE into a new `re-frame.resources.reply-handlers` ns, parameterized. Both families bind their knobs in thin local wrappers and call the shared forms; the existing call sites are unchanged.

### The three knobs each family passes
1. **`path-fn`** — `(payload) → db-path` for the durable slot: resource `state/entry-path` (keyed on `:resource/key`) vs mutation `mstate/instance-path` (keyed on `:instance-id`). Drives both the live-slot verifier and the current-generation reader.
2. **`work-kind`** — `rreply/work-kind-resource` vs `rreply/work-kind-mutation`.
3. **`stale-reason`** — `:rf.resource/superseded` vs `:rf.mutation/superseded`.

(plus a `correlation-fn` for the family's diagnostic correlation keys — `:resource/key`/`:scope` vs `:instance/id`/`:mutation/id`/`:scope` — and, at emit time, the `trace-id` + `bespoke-facts`. These are still per-family vocabulary, not behaviour.)

## Behaviour-neutral

Pure extraction (rf2-nnke18): the verification logic, the emitted stale reply, the trace ids, and the carried-vs-current generation comparison are byte-identical for BOTH families before/after. The only difference each call site passes is its path-fn / work-kind / stale-reason. The new ns depends only on `rreply` (resources-internal) + `re-frame.trace` — no cross-artefact reach.

Proof: `resources_lifecycle_trace_ops_cljs_test/stale-suppressed-trace-carries-canonical-reply-envelope` (and the mutation twin) assert the FULL `:rf.resource/stale-suppressed` / `:rf.mutation/stale-suppressed` trace map incl. the `:rf.reply/correlation` carried/current generation pair + bespoke `:resource/key` / `:instance` facts — both green unchanged.

## Quality gates

- `resources` JVM suite (`clojure -M:test`): **608 tests, 6084 assertions, 0 failures, 0 errors** ✅
- `reply-conformance` JVM suite (`clojure -M:test`): **29 tests, 439 assertions, 0 failures, 0 errors** ✅
- `npm run test:cljs` (node-runtime, incl. reply-conformance corpus + stale-suppressed trace fixtures): **7914 tests, 36446 assertions, 0 failures, 0 errors** ✅

CI is the merge gate.

Closes-after-merge: rf2-nnke18 (bead left open; PR URL appended to notes per protocol).