### PR TITLE
test(conformance): floor corpus runners on non-empty fixture count (no silent-green) (rf2-3hamsq)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -1622,6 +1622,22 @@
           passed  (filter :passed? run)
           failed  (remove :passed? run)
           skipped (filter :skipped? all)]
+      ;; rf2-3hamsq — non-empty floor. This is the DEFAULT `npm run
+      ;; test:cljs` PR gate. The CLJS variant inlines fixtures at COMPILE
+      ;; time via the all-fixtures macro, so a wrong test-RUNTIME cwd
+      ;; can't empty it — but a build-time glob returning empty, or a
+      ;; capability-vocab rename that orphans every fixture, would still
+      ;; pass the lone (zero? (count failed)) vacuously. Assert that
+      ;; fixtures actually executed:
+      ;;   - (pos? (count run)) catches the fully-empty case;
+      ;;   - the expected-minimum (>= 150) catches partial mass-orphaning
+      ;;     (today's runnable count is 186 of 188; the corpus grows).
+      (is (pos? (count run))
+          "at least one claim-applicable CLJS conformance fixture must have executed")
+      (is (>= (count run) 150)
+          (str "CLJS conformance corpus runnable-fixture floor (>= 150): only "
+               (count run) " executed — a build-time glob fault or a "
+               "capability-vocab rename has orphaned the corpus."))
       ;; Silent-on-success (rf2-try1x): the corpus summary only prints
       ;; when there are failures. See the JVM mirror in
       ;; conformance_test.clj for the rationale.

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -1906,6 +1906,21 @@
           passed    (filter :passed? run)
           failed    (remove :passed? run)
           skipped   (filter :skipped? all)]
+      ;; rf2-3hamsq — non-empty floor. The lone (zero? (count failed))
+      ;; below passes GREEN over an empty / fully-skipped / orphaned
+      ;; corpus (wrong cwd, fixtures-dir rename, or a capability-vocab
+      ;; rename that orphans every fixture) — verifying NOTHING. Assert
+      ;; that fixtures actually executed:
+      ;;   - (pos? (count run)) catches the fully-empty case;
+      ;;   - the expected-minimum (>= 150) catches partial mass-orphaning
+      ;;     without pinning an exact count (today's runnable count is 186
+      ;;     of 188 total; the corpus grows over time).
+      (is (pos? (count run))
+          "at least one claim-applicable conformance fixture must have executed")
+      (is (>= (count run) 150)
+          (str "core conformance corpus runnable-fixture floor (>= 150): only "
+               (count run) " executed — a fixtures-dir/cwd fault or a "
+               "capability-vocab rename has orphaned the corpus."))
       ;; Silent-on-success (rf2-try1x): the corpus summary only prints
       ;; when there are failures. The `is` assertion below carries the
       ;; pass/fail signal; the stats and skip-list are diagnostic

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -744,6 +744,23 @@
     (let [all     @results
           passed  (filter :passed? all)
           failed  (remove :passed? all)]
+      ;; rf2-3hamsq — non-empty floor. This runner has no skip bucket:
+      ;; every discovered flow-*.edn fixture is runnable (an out-of-claim
+      ;; capability or unclaimed spec-version is a FAILURE, not a skip),
+      ;; so `all` IS the executed set. The lone (zero? (count failed))
+      ;; below passes GREEN over an empty / orphaned corpus (wrong cwd or
+      ;; a fixtures-dir rename emptying file-seq) — verifying NOTHING.
+      ;; Assert that fixtures actually executed:
+      ;;   - (pos? (count all)) catches the fully-empty case;
+      ;;   - the expected-minimum (>= 7) catches partial mass-orphaning
+      ;;     without pinning an exact count (today's count is 9 flow-*.edn
+      ;;     fixtures; the set grows).
+      (is (pos? (count all))
+          "at least one flow-*.edn fixture must have executed")
+      (is (>= (count all) 7)
+          (str "flows corpus fixture floor (>= 7): only "
+               (count all) " executed — a fixtures-dir/cwd fault has "
+               "orphaned the corpus."))
       ;; Silent-on-success: the summary prints only on failure.
       ;; No skip bucket: a flow fixture this runner cannot run — load error,
       ;; unclaimed spec-version, out-of-claim capability — is a FAILURE, not a

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -367,6 +367,21 @@
           passed  (filter :passed? run)
           failed  (remove :passed? run)
           skipped (filter :skipped? all)]
+      ;; rf2-3hamsq — non-empty floor. The lone (zero? (count failed))
+      ;; below passes GREEN over an empty / fully-skipped / orphaned
+      ;; corpus (wrong cwd, fixtures-dir rename, or a capability-vocab
+      ;; rename that orphans every Mode B fixture) — verifying NOTHING.
+      ;; Assert that fixtures actually executed:
+      ;;   - (pos? (count run)) catches the fully-empty case;
+      ;;   - the expected-minimum (>= 40) catches partial mass-orphaning
+      ;;     without pinning an exact count (today's runnable count is 61
+      ;;     :machine-transition / :reg-machine fixtures; the set grows).
+      (is (pos? (count run))
+          "at least one Mode B :machine-transition fixture must have executed")
+      (is (>= (count run) 40)
+          (str "machines corpus runnable-fixture floor (>= 40): only "
+               (count run) " executed — a fixtures-dir/cwd fault or a "
+               "capability-vocab rename has orphaned the corpus."))
       ;; Silent-on-success: summary prints only on failure.
       (when (seq failed)
         (println)

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -621,6 +621,21 @@
           passed  (filter :passed? run)
           failed  (remove :passed? run)
           skipped (filter :skipped? all)]
+      ;; rf2-3hamsq — non-empty floor. A lone (zero? (count failed))
+      ;; passes GREEN over an empty / fully-skipped / orphaned corpus
+      ;; (a wrong cwd, a fixtures-dir rename, or a capability-vocab
+      ;; rename that moves every fixture out of claim) — the gate then
+      ;; verifies NOTHING. Assert that fixtures actually executed:
+      ;;   - (pos? (count run)) catches the fully-empty case;
+      ;;   - the expected-minimum (>= 4) catches partial mass-orphaning
+      ;;     without pinning an exact count (today's runnable count is 5:
+      ;;     the four Spec 010 validation points + error-schema-failure).
+      (is (pos? (count run))
+          "at least one claim-runnable schemas conformance fixture must have executed")
+      (is (>= (count run) 4)
+          (str "schemas corpus runnable-fixture floor (>= 4): only "
+               (count run) " executed — a fixtures-dir/cwd fault or a "
+               "capability-vocab rename has orphaned the corpus."))
       ;; Silent-on-success (rf2-try1x): summary prints only on failure.
       (when (seq failed)
         (println)

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -789,6 +789,21 @@
           passed  (filter :passed? run)
           failed  (remove :passed? run)
           skipped (filter :skipped? all)]
+      ;; rf2-3hamsq — non-empty floor. The lone (zero? (count failed))
+      ;; below passes GREEN over an empty / fully-skipped / orphaned
+      ;; corpus (wrong cwd, fixtures-dir rename, or a capability-vocab
+      ;; rename that orphans every ssr-* fixture) — verifying NOTHING.
+      ;; Assert that fixtures actually executed:
+      ;;   - (pos? (count run)) catches the fully-empty case;
+      ;;   - the expected-minimum (>= 10) catches partial mass-orphaning
+      ;;     without pinning an exact count (today's runnable count is 14
+      ;;     ssr-*.edn fixtures; the set grows).
+      (is (pos? (count run))
+          "at least one claim-runnable ssr-*.edn fixture must have executed")
+      (is (>= (count run) 10)
+          (str "ssr corpus runnable-fixture floor (>= 10): only "
+               (count run) " executed — a fixtures-dir/cwd fault or a "
+               "capability-vocab rename has orphaned the corpus."))
       ;; Silent-on-success (rf2-try1x): summary prints only on failure.
       (when (seq failed)
         (println)


### PR DESCRIPTION
## What

All six fixture-corpus conformance runners asserted only `(is (zero? (count failed)))` with **no floor that any fixture actually ran**. An empty / fully-skipped / orphaned corpus — wrong cwd, a `spec/conformance/fixtures/` rename, or a capability-vocab rename that orphans every fixture — leaves `failed` empty, so `(zero? 0)` ⇒ GREEN having verified **nothing**. This is the rf2-lo28u "gate that doesn't gate" class, on the most load-bearing invariant (these corpora *are* the spec-validation mechanism, rf2-3xt7).

The trigger is current: the JVM runners discover fixtures via cwd-relative `(io/file "../../spec/conformance/fixtures")` + `file-seq` — a `file-seq` over a missing dir returns no `.isFile` members ⇒ empty fixture list ⇒ silent GREEN. Contrast the runners that already carry floors: `error_catalogue_channel_conformance_test.clj:471/476`, `derivation_algebra_conformance:342`, `event_model_conformance:396`, `epoch_mcp_egress_conformance:182/395`.

## Fix

Add a non-empty floor to **each** of the 6 runners (additions only, no production source / no fixture changes):
- `(is (pos? (count run)))` — catches the fully-empty case (the floor).
- `(is (>= (count run) <expected-min>))` — catches **partial** mass-orphaning (e.g. a capability-vocab rename moving most fixtures out of claim) without pinning an exact count, since the corpora grow (the ceiling). Floors are set "well below today's count," matching the existing-floor idiom.

| Runner | floor (`run`) | today's runnable / total |
|---|---|---|
| schemas `schemas_conformance_test.clj` | `>= 4` | 5 / 5 |
| core JVM `conformance_test.clj` | `>= 150` | 186 / 188 |
| core CLJS `conformance_corpus_cljs_test.cljs` (default `npm run test:cljs` PR gate) | `>= 150` | 186 / 188 |
| machines `machines_conformance_test.clj` | `>= 40` | 61 / 61 |
| ssr `ssr_conformance_test.clj` | `>= 10` | 14 / 14 |
| flows `flows_conformance_test.clj` | `>= 7` | 9 / 9 |

`flows` has no skip bucket (an out-of-claim capability is itself a failure), so its floor is on `all` — the executed set. The cwd-coupled `io/file` discovery was left as-is: the minimal/safe floor is the load-bearing fix here, and `io/resource` re-anchoring is a larger orthogonal change best done on its own.

## Empty-corpus RED proof (mandatory)

- **CLJS PR-gate runner** — temporarily stubbed `run` empty: both floor assertions FAILED (`pos?` and `>= 150`), `2 failures`, while the original `(zero? (count failed))` passed vacuously. Restored ⇒ GREEN.
- **schemas JVM runner** — temporarily pointed `fixtures-dir` at a missing dir (the real cwd/rename fault): both floors FAILED (`only 0 executed`), `2 failures, 0 errors`; the original assertion would have passed GREEN. Restored ⇒ GREEN.

## Quality gates

- `clojure -M:test` schemas — `Ran 1 tests, 3 assertions, 0 failures` (run=5)
- `clojure -M:test` machines — `0 failures` (run=61)
- `clojure -M:test` ssr — `0 failures` (run=14)
- `clojure -M:test` flows — `0 failures` (all=9)
- `clojure -M:test` core JVM `re-frame.conformance-test` — `Ran 2 tests, 8 assertions, 0 failures` (run=186/188)
- `npm run test:cljs` (full PR gate) — `Ran 7914 tests containing 36448 assertions. 0 failures, 0 errors.` (corpus run=186/188)

No skips. node_modules junctioned from the mayor checkout for the CLJS gate.

rf2-3hamsq