### PR TITLE
fix(xray): Trace panel reads canonical per-area elapsed tags for durations (rf2-k7vtri, rf2-1y5o8t, rf2-hopyiq)

### DIFF
--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -98,8 +98,14 @@ Registration ops (`:rf.flow/registered`, `:rf.route/registered`, `:rf.fx/reg-flo
 ## §6 Duration / timing
 
 - Duration renders as a plain number in ms; `—` when no timing is available.
-- **Views** — sourced from `:rf.view/elapsed-ms` (available today).
-- **Subs · coeffects · fx · flows · handler** — require run-start/run-end timing on the trace events. This is a Spec-009 instrumentation dependency; until present, these ops render `—`. (Implementation should add the timing capture so the arc is fully profiled.)
+- Per-op timing is sourced from the **canonical per-area `:rf.<area>/elapsed-ms` tag** the substrate stamps on each op family's run-end / handled / rendered emit (dev builds):
+  - **Views** — `:rf.view/elapsed-ms` ([Spec 009](../../../spec/009-Instrumentation.md) §281, `re-frame.views`).
+  - **Fx** — `:rf.fx/elapsed-ms` (§241, `re-frame.fx`).
+  - **Coeffects** — `:rf.cofx/elapsed-ms` (§243, `re-frame.cofx`).
+  - **Subs** — `:rf.sub/elapsed-ms` (§251).
+  - **Handler** — `:rf.event/elapsed-ms` (`re-frame.router` emit-run-end).
+  - **Flows** — a bare `:elapsed-ms` tag (`re-frame.flows`).
+- `—` remains the correct render only in the genuine no-timing cases: point-in-time emits that carry no elapsed (e.g. `:rf.epoch/snapshotted`, `:rf.event/dispatched`), and **production builds** where the timing capture is DCE-stripped.
 
 ## §7 Errors & warnings
 
@@ -234,7 +240,7 @@ Type scale, spacing, density, iconography, base surfaces/borders MUST conform to
 
 ## Appendix A — Op-handling matrix (the "covers ALL trace" checklist)
 
-Every Spec-009 trace operation → its row. The **Stage** column is the Epoch pipeline step each op maps to (§3a — the flat panel's stage column + colour-coded edge). `dur?` = number once timing instrumentation lands (§6), else `—`. Errors/warnings collapse to one generic rule each; registration/boot ops are out of scope.
+Every Spec-009 trace operation → its row. The **Stage** column is the Epoch pipeline step each op maps to (§3a — the flat panel's stage column + colour-coded edge). `dur?` = a number sourced from the op family's per-area `:rf.<area>/elapsed-ms` tag in dev builds (§6), `—` for genuine point-in-time emits and production (DCE-stripped) builds. Errors/warnings collapse to one generic rule each; registration/boot ops are out of scope.
 
 | Operation | Stage (§3a) | Area | Row label | Target / detail | Dur |
 |---|---|---|---|---|---|

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
@@ -3,28 +3,32 @@
 
   ## What this panel shows (spec/023-Trace-Panel.md)
 
-  The Trace panel renders the COMPLETE TRACE ARC of a single epoch —
-  every trace operation the substrate emits during the epoch, in fire
-  order, organised by the epoch's phase shape. Its contract is
-  COMPLETENESS: every op-family in the Spec-009 vocabulary surfaces
-  (spec/023 §1). The structural projection here turns the focused
-  epoch's `:trace-events` into:
+  The Trace panel renders the COMPLETE TRACE of a single epoch — every
+  trace operation the substrate emits during the epoch, in strict fire
+  order (oldest-first). Its contract is COMPLETENESS: every op-family in
+  the Spec-009 vocabulary surfaces (spec/023 §1). Since rf2-aqusw the
+  panel is a SINGLE FLAT LIST — no envelope, no phase-band nesting, no
+  empty-band scaffolding. The 4-band hierarchy (EPOCH OPEN / DISPATCH /
+  EVENT HANDLING / EFFECTS-FX / REACTIVE RENDERING) was replaced because
+  it was hard to scan. The epoch-lifecycle ops (`:rf.epoch/*`) render as
+  ORDINARY rows in the flat list; `:rf.epoch/outcome` carries the
+  consumer-facing `:ok` / `:blocked` / `:error` summary.
 
-      ○ EPOCH OPEN  envelope row (epoch-lifecycle ops · :rf.epoch/*)
-      ▾ ① DISPATCH          (the event dispatched)
-      ▾ ② EVENT HANDLING    (coeffects → handler → flows → db-changed)
-      ▾ ③ EFFECTS / FX      (fx handlers · routing nav · machine timers)
-      ▾ ④ REACTIVE RENDERING (subscriptions → views)
-      ● EPOCH CLOSE outcome :ok/:blocked/:error
+  Each op renders as a row of SIX columns (spec/023 §3):
 
-  Each op renders as a row of five columns (spec/023 §3):
+      Δt · stage · area badge · what-happened · target/detail · duration
 
-      Δt · area badge · what-happened · target/detail · duration
+  The phase information the bands conveyed is recovered per-row by the
+  STAGE column + a colour-coded left edge — each row names the Epoch-panel
+  pipeline step it belongs to (spec/023 §3a).
 
   Errors and warnings are cross-cutting — they render INLINE at their
-  chronological point in whatever band they occurred (spec/023 §7),
-  emphasised so failures stand out. Empty phase bands render dimmed
-  with `(none)` so the 4-phase shape is always legible (spec/023 §13).
+  chronological point in the flat list (spec/023 §7), with the row's left
+  edge riding the severity colour so failures stand out.
+
+  NOTE: the band-projection helpers (`build-bands` etc.) below are
+  retained for cross-panel / test consumers, but the Trace panel no
+  longer renders bands — see the per-helper comments.
 
   ## Why a separate `.cljc` ns
 
@@ -712,13 +716,30 @@
   (get-in ev [:tags :rf.event/origin]))
 
 (defn duration-ms
-  "Per-op elapsed time, in ms, when the trace event reports it. Reads
-  `[:tags :elapsed-ms]` then a top-level `:elapsed-ms` fallback. Returns
-  nil otherwise — point-in-time emits carry no elapsed, so the duration
-  column renders `—` (spec/023 §6). Pure data → number-or-nil;
-  JVM-testable."
+  "Per-op elapsed time, in ms, when the trace event reports it.
+
+  The substrate stamps the CANONICAL per-area namespaced elapsed tag on
+  each op family's run-end / handled / rendered emit — `:rf.fx/elapsed-ms`
+  (re-frame.fx · spec/009 §241), `:rf.cofx/elapsed-ms` (re-frame.cofx ·
+  §243), `:rf.sub/elapsed-ms` (§251), `:rf.event/elapsed-ms`
+  (re-frame.router emit-run-end), `:rf.view/elapsed-ms` (re-frame.views ·
+  §281). Flows carry a bare `:elapsed-ms` tag (re-frame.flows). We read the
+  per-area tag by op family first, then the bare `:elapsed-ms` (flows + any
+  legacy projected emit-record carrying it top-level). This mirrors the
+  Epoch projection reader's canonical-tag fix (rf2-ipaza); reading only the
+  non-canonical `:elapsed-ms` silently rendered `—` for every fx/sub/view/
+  cofx/handler row against real substrate traces (rf2-k7vtri).
+
+  Returns nil otherwise — genuine point-in-time emits carry no elapsed, and
+  production DCE strips the timing capture, so the duration column renders
+  `—` (spec/023 §6). Pure data → number-or-nil; JVM-testable."
   [ev]
-  (let [e (or (get-in ev [:tags :elapsed-ms])
+  (let [e (or (get-in ev [:tags :rf.fx/elapsed-ms])
+              (get-in ev [:tags :rf.sub/elapsed-ms])
+              (get-in ev [:tags :rf.view/elapsed-ms])
+              (get-in ev [:tags :rf.cofx/elapsed-ms])
+              (get-in ev [:tags :rf.event/elapsed-ms])
+              (get-in ev [:tags :elapsed-ms])
               (:elapsed-ms ev))]
     (when (number? e) e)))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -29,6 +29,7 @@
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-xray.panels.epoch.badge :as epoch-badge]
             [day8.re-frame2-xray.panels.trace-helpers :as h]
+            [day8.re-frame2-xray.test-helpers.trace-event-builders :as teb]
             [day8.re-frame2-xray.theme.tokens :as tokens]))
 
 ;; ---- fixture builders ---------------------------------------------------
@@ -631,15 +632,28 @@
     (let [rows (h/with-rel-times [{:time 100} {:time 103}])]
       (is (= ["+0.0" "+3.0"] (mapv :rel-time rows))))))
 
-(deftest duration-ms-reads-elapsed
-  (testing "duration-ms pulls :elapsed-ms from tags"
-    (is (= 0.4 (h/duration-ms (ev {:id 1 :op-type :rf.view
-                                   :operation :rf.view/render
-                                   :tags {:elapsed-ms 0.4}})))))
+(deftest duration-ms-reads-canonical-per-area-elapsed-tags
+  ;; rf2-k7vtri — the substrate stamps the CANONICAL per-area namespaced
+  ;; elapsed tag (`:rf.fx/elapsed-ms`, `:rf.sub/elapsed-ms`, …), NOT a bare
+  ;; `:elapsed-ms`, on each op family's run-end / handled / rendered emit.
+  ;; Drive the canonical builders (the same shape `trace/emit!` stamps) so a
+  ;; reader that only read the non-canonical `:elapsed-ms` is caught: before
+  ;; the fix every one of these resolved to nil (the panel rendered `—`).
+  (testing "FX duration — :rf.fx/elapsed-ms (spec/009 §241)"
+    (is (= 12.0 (h/duration-ms (teb/fx-handled-ev :http/post {:url "/x"} 12.0)))))
+  (testing "SUB duration — :rf.sub/elapsed-ms (spec/009 §251)"
+    (is (= 0.7 (h/duration-ms (teb/sub-run-ev [:items] true nil [1 2 3] 0.7)))))
+  (testing "VIEW duration — :rf.view/elapsed-ms (spec/009 §281)"
+    (is (= 3.4 (h/duration-ms (teb/view-rendered-ev :app/root [[:items]] 3.4)))))
+  (testing "COEFFECT duration — :rf.cofx/elapsed-ms (spec/009 §243)"
+    (is (= 0.6 (h/duration-ms (teb/cofx-run-ev :session {:user-id 42} 0.6)))))
+  (testing "HANDLER duration — :rf.event/elapsed-ms (re-frame.router emit-run-end)"
+    (is (= 4.2 (h/duration-ms (teb/run-end-ev 4.2)))))
+  (testing "FLOW duration — bare :elapsed-ms tag (re-frame.flows)"
+    (is (= 0.9 (h/duration-ms (teb/flow-recomputed-ev :total [:total] 1 2 0.9)))))
   (testing "point-in-time emits carry no elapsed → nil (renders —)"
-    (is (nil? (h/duration-ms (ev {:id 1 :op-type :rf.sub
-                                  :operation :rf.sub/run
-                                  :tags {:rf.sub/id :x}}))))))
+    (is (nil? (h/duration-ms (teb/sub-run-ev [:items] true nil [1 2 3]))))
+    (is (nil? (h/duration-ms (teb/cofx-run-ev :session {:user-id 42}))))))
 
 (deftest format-duration-figma-form
   (is (= "0.4 ms" (h/format-duration 0.4)))


### PR DESCRIPTION
## Summary

Cluster fix on the Xray Trace-panel timing path (one PR — a `tools/xray` change updates `tools/xray/spec` in the same PR per the Xray-specs-kept-current rule).

**rf2-k7vtri (P2 bug — the fix):** the Trace panel DURATION column rendered `—` for every FX / sub / view / coeffect / handler row against real substrate traces. `trace_helpers/duration-ms` read only the non-canonical `[:tags :elapsed-ms]` + a top-level `:elapsed-ms`, but the substrate stamps the **canonical per-area namespaced** tags: `:rf.fx/elapsed-ms` · `:rf.sub/elapsed-ms` · `:rf.view/elapsed-ms` · `:rf.cofx/elapsed-ms` · `:rf.event/elapsed-ms`. Only flow rows (bare `:elapsed-ms`) read right. Same defect class as the already-merged Epoch-panel fix (rf2-ipaza). `duration-ms` now reads the per-area tag by op family first, then the bare `:elapsed-ms` fallback (flows + any legacy projected emit-record).

**rf2-1y5o8t (P3 spec-currency):** spec/023 §6 (+ the Appendix `dur?` note) rewritten — per-op durations are sourced from the per-area `:rf.<area>/elapsed-ms` tags now emitted in dev builds (spec/009 §241/243/251/281); the stale "Spec-009 dependency; until present render `—`" gap language is removed. `—` is kept only for genuine point-in-time emits and production (DCE-stripped) builds.

**rf2-hopyiq (P4 docstring-currency):** the `trace_helpers.cljc` ns docstring rewritten to the flat **six-column single-list** model (rf2-aqusw), replacing the retired 4-band / five-columns / envelope description; notes the band-projection helpers are retained for cross-panel / test consumers.

## Regression (CLJS unit, proven by revert)

Rewrote `duration-ms-reads-canonical-per-area-elapsed-tags` to drive the **canonical builders** (`fx-handled-ev` / `sub-run-ev` / `view-rendered-ev` / `cofx-run-ev` / `run-end-ev` / `flow-recomputed-ev`) — the same shape `trace/emit!` stamps — and assert a real duration renders for each op family. The prior test masked the bug with a hand-typed `{:elapsed-ms 0.4}` fixture.

- **Before the fix** (reverted `duration-ms` body): the 5 canonical-tag assertions FAIL (fx/sub/view/cofx/handler render `—`/nil); flow + nil cases still pass.
- **After the fix:** all pass.

## Quality gates

- `npm run test:cljs` — **PASS** (7914 tests, 36452 assertions, 0 failures, 0 errors). Includes the new regression test.
- `npm run test:xray-feature-gate` (exercises the Trace panel) — **PASS** (15 scenarios, 0 failures, 13 matrix rows).
- Revert-proof — **confirmed**: reverting the fix fails exactly the 5 canonical-tag assertions.
- `mkdocs build --strict` — **skipped locally** (mkdocs not installed). Note: `tools/xray/spec/023-Trace-Panel.md` is NOT in `mkdocs.yml` nav, so the docs gate does not ingest it; CI runs the strict build regardless.

Touches only `tools/xray/` (trace_helpers.cljc + its test + spec/023-Trace-Panel.md).