### PR TITLE
test(conformance): anchor corpus discovery to io/resource (cwd-independent) (rf2-ywrwkl)

### DIFF
--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -277,14 +277,40 @@
 ;; ---- fixture loader -------------------------------------------------------
 
 (def fixtures-dir
-  ;; The corpus lives under spec/conformance/fixtures at the repo root.
-  ;; Per rf2-0hxm the JVM tests run from implementation/core/, so the
-  ;; relative path is ../../spec/conformance/fixtures. Fall back to the
-  ;; pre-split layout for transitional REPLs running from
-  ;; implementation/ — whichever exists first wins.
-  (let [nested  (io/file "../../spec/conformance/fixtures")
-        legacy  (io/file "../spec/conformance/fixtures")]
-    (if (.exists nested) nested legacy)))
+  ;; The conformance corpus lives under spec/conformance/fixtures at the
+  ;; repo root.
+  ;;
+  ;; Anchored to a CLASSPATH RESOURCE, not the working directory
+  ;; (rf2-ywrwkl, the same fix rf2-55j4s3 applied to 3 sibling core tests).
+  ;; The earlier cwd-relative form ((io/file "../../spec/conformance/
+  ;; fixtures") with a "../spec/..." legacy fallback) assumed the JVM cwd
+  ;; was implementation/core/. That holds for the canonical per-artefact
+  ;; gate (clojure -M:test from implementation/core/, which CI runs) but
+  ;; SILENTLY MIS-SCOPES under the combined implementation/deps.edn :test
+  ;; alias: run from implementation/, "../../" resolves ABOVE the repo root,
+  ;; file-seq returns nothing, and the corpus discovers zero fixtures (the
+  ;; rf2-3hamsq floor turns that mis-discovery RED instead of silent-green).
+  ;;
+  ;; This test namespace's own source file is on the test classpath (the
+  ;; artefact's :test {:extra-paths ["test"]}), so resolving it via
+  ;; io/resource pins the anchor to the on-disk source location regardless
+  ;; of cwd or which alias loaded the namespace. Walking five parents
+  ;; (conformance_test.clj → re_frame → test → core → implementation → repo
+  ;; root) reaches the repo root, then we descend into
+  ;; spec/conformance/fixtures.
+  (let [res (io/resource "re_frame/conformance_test.clj")]
+    (assert res
+            (str "conformance-test cannot locate its own source on the "
+                 "classpath — the core test/ dir must be on the test "
+                 "classpath for fixture discovery to anchor."))
+    (-> (io/file res)        ; .../core/test/re_frame/conformance_test.clj
+        .getParentFile       ; .../core/test/re_frame
+        .getParentFile       ; .../core/test
+        .getParentFile       ; .../core
+        .getParentFile       ; .../implementation
+        .getParentFile       ; repo root
+        (io/file "spec" "conformance" "fixtures")
+        .getCanonicalFile)))
 
 (defn- load-fixture [file]
   (try

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -159,10 +159,40 @@
 ;; ---- fixture discovery ----------------------------------------------------
 
 (def fixtures-dir
-  "The corpus lives at the repo root under
-  `spec/conformance/fixtures/`. The flows artefact's tests run from
-  `implementation/flows/`, so the relative path is two-deep."
-  (io/file "../../spec/conformance/fixtures"))
+  "The conformance corpus lives at the repo root under
+  `spec/conformance/fixtures/`.
+
+  Anchored to a CLASSPATH RESOURCE, not the working directory (rf2-ywrwkl,
+  the same fix rf2-55j4s3 applied to 3 sibling core tests). The earlier
+  `(io/file \"../../spec/conformance/fixtures\")` form assumed the JVM cwd
+  was `implementation/flows/` so that `../../` reached the repo root. That
+  holds for the canonical per-artefact gate (`clojure -M:test` run from
+  `implementation/flows/`, which is what CI runs) but SILENTLY MIS-SCOPES
+  under the combined `implementation/deps.edn :test` alias: run from
+  `implementation/`, `../../` resolves ABOVE the repo root, `file-seq`
+  returns nothing, and the corpus discovers zero fixtures (the rf2-3hamsq
+  floor turns that mis-discovery RED instead of silent-green).
+
+  This test namespace's own source file is on the test classpath (the
+  artefact's `:test {:extra-paths [\"test\"]}`), so resolving it via
+  `io/resource` pins the anchor to the on-disk source location regardless
+  of cwd or which alias loaded the namespace. Walking five parents
+  (`flows_conformance_test.clj → re_frame → test → flows → implementation →
+  repo root`) reaches the repo root, then we descend into
+  `spec/conformance/fixtures`."
+  (let [res (io/resource "re_frame/flows_conformance_test.clj")]
+    (assert res
+            (str "flows-conformance-test cannot locate its own source on the "
+                 "classpath — the flows test/ dir must be on the test "
+                 "classpath for fixture discovery to anchor."))
+    (-> (io/file res)        ; .../flows/test/re_frame/flows_conformance_test.clj
+        .getParentFile       ; .../flows/test/re_frame
+        .getParentFile       ; .../flows/test
+        .getParentFile       ; .../flows
+        .getParentFile       ; .../implementation
+        .getParentFile       ; repo root
+        (io/file "spec" "conformance" "fixtures")
+        .getCanonicalFile)))
 
 (defn- load-fixture
   "Read one EDN fixture, applying the same `::name` rewrite the core

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -46,10 +46,40 @@
 ;; ---- fixture discovery ----------------------------------------------------
 
 (def fixtures-dir
-  "The corpus lives at `spec/conformance/fixtures/` at the repo root.
-  Tests run from `implementation/machines/`, so the relative path is
-  `../../spec/conformance/fixtures`."
-  (io/file "../../spec/conformance/fixtures"))
+  "The conformance corpus lives at `spec/conformance/fixtures/` at the
+  repo root.
+
+  Anchored to a CLASSPATH RESOURCE, not the working directory (rf2-ywrwkl,
+  the same fix rf2-55j4s3 applied to 3 sibling core tests). The earlier
+  `(io/file \"../../spec/conformance/fixtures\")` form assumed the JVM cwd
+  was `implementation/machines/` so that `../../` reached the repo root.
+  That holds for the canonical per-artefact gate (`clojure -M:test` run
+  from `implementation/machines/`, which is what CI runs) but SILENTLY
+  MIS-SCOPES under the combined `implementation/deps.edn :test` alias: run
+  from `implementation/`, `../../` resolves ABOVE the repo root, `file-seq`
+  returns nothing, and the corpus discovers zero fixtures (the rf2-3hamsq
+  floor turns that mis-discovery RED instead of silent-green).
+
+  This test namespace's own source file is on the test classpath (the
+  artefact's `:test {:extra-paths [\"test\"]}`), so resolving it via
+  `io/resource` pins the anchor to the on-disk source location regardless
+  of cwd or which alias loaded the namespace. Walking five parents
+  (`machines_conformance_test.clj → re_frame → test → machines →
+  implementation → repo root`) reaches the repo root, then we descend into
+  `spec/conformance/fixtures`."
+  (let [res (io/resource "re_frame/machines_conformance_test.clj")]
+    (assert res
+            (str "machines-conformance-test cannot locate its own source on "
+                 "the classpath — the machines test/ dir must be on the test "
+                 "classpath for fixture discovery to anchor."))
+    (-> (io/file res)        ; .../machines/test/re_frame/machines_conformance_test.clj
+        .getParentFile       ; .../machines/test/re_frame
+        .getParentFile       ; .../machines/test
+        .getParentFile       ; .../machines
+        .getParentFile       ; .../implementation
+        .getParentFile       ; repo root
+        (io/file "spec" "conformance" "fixtures")
+        .getCanonicalFile)))
 
 (defn- load-fixture [file]
   (try

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -105,10 +105,40 @@
 ;; ---- fixture discovery ----------------------------------------------------
 
 (def fixtures-dir
-  "The corpus lives at the repo root under
-  `spec/conformance/fixtures/`. The schemas artefact's tests run from
-  `implementation/schemas/`, so the relative path is two-deep."
-  (io/file "../../spec/conformance/fixtures"))
+  "The conformance corpus lives at the repo root under
+  `spec/conformance/fixtures/`.
+
+  Anchored to a CLASSPATH RESOURCE, not the working directory (rf2-ywrwkl,
+  the same fix rf2-55j4s3 applied to 3 sibling core tests). The earlier
+  `(io/file \"../../spec/conformance/fixtures\")` form assumed the JVM cwd
+  was `implementation/schemas/` so that `../../` reached the repo root. That
+  holds for the canonical per-artefact gate (`clojure -M:test` run from
+  `implementation/schemas/`, which is what CI runs) but SILENTLY MIS-SCOPES
+  under the combined `implementation/deps.edn :test` alias: run from
+  `implementation/`, `../../` resolves ABOVE the repo root, `file-seq`
+  returns nothing, and the corpus discovers zero fixtures (the rf2-3hamsq
+  floor turns that mis-discovery RED instead of silent-green).
+
+  This test namespace's own source file is on the test classpath (the
+  artefact's `:test {:extra-paths [\"test\"]}`), so resolving it via
+  `io/resource` pins the anchor to the on-disk source location regardless
+  of cwd or which alias loaded the namespace. Walking five parents
+  (`schemas_conformance_test.clj → re_frame → test → schemas →
+  implementation → repo root`) reaches the repo root, then we descend into
+  `spec/conformance/fixtures`."
+  (let [res (io/resource "re_frame/schemas_conformance_test.clj")]
+    (assert res
+            (str "schemas-conformance-test cannot locate its own source on "
+                 "the classpath — the schemas test/ dir must be on the test "
+                 "classpath for fixture discovery to anchor."))
+    (-> (io/file res)        ; .../schemas/test/re_frame/schemas_conformance_test.clj
+        .getParentFile       ; .../schemas/test/re_frame
+        .getParentFile       ; .../schemas/test
+        .getParentFile       ; .../schemas
+        .getParentFile       ; .../implementation
+        .getParentFile       ; repo root
+        (io/file "spec" "conformance" "fixtures")
+        .getCanonicalFile)))
 
 (defn- load-fixture
   "Read one EDN fixture. The corpus does not use auto-resolved keywords

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -114,10 +114,40 @@
 ;; ---- fixture discovery ----------------------------------------------------
 
 (def fixtures-dir
-  "The corpus lives at the repo root under
-  `spec/conformance/fixtures/`. The ssr artefact's tests run from
-  `implementation/ssr/`, so the relative path is two-deep."
-  (io/file "../../spec/conformance/fixtures"))
+  "The conformance corpus lives at the repo root under
+  `spec/conformance/fixtures/`.
+
+  Anchored to a CLASSPATH RESOURCE, not the working directory (rf2-ywrwkl,
+  the same fix rf2-55j4s3 applied to 3 sibling core tests). The earlier
+  `(io/file \"../../spec/conformance/fixtures\")` form assumed the JVM cwd
+  was `implementation/ssr/` so that `../../` reached the repo root. That
+  holds for the canonical per-artefact gate (`clojure -M:test` run from
+  `implementation/ssr/`, which is what CI runs) but SILENTLY MIS-SCOPES
+  under the combined `implementation/deps.edn :test` alias: run from
+  `implementation/`, `../../` resolves ABOVE the repo root, `file-seq`
+  returns nothing, and the corpus discovers zero fixtures (the rf2-3hamsq
+  floor turns that mis-discovery RED instead of silent-green).
+
+  This test namespace's own source file is on the test classpath (the
+  artefact's `:test {:extra-paths [\"test\"]}`), so resolving it via
+  `io/resource` pins the anchor to the on-disk source location regardless
+  of cwd or which alias loaded the namespace. Walking five parents
+  (`ssr_conformance_test.clj → re_frame → test → ssr → implementation →
+  repo root`) reaches the repo root, then we descend into
+  `spec/conformance/fixtures`."
+  (let [res (io/resource "re_frame/ssr_conformance_test.clj")]
+    (assert res
+            (str "ssr-conformance-test cannot locate its own source on the "
+                 "classpath — the ssr test/ dir must be on the test "
+                 "classpath for fixture discovery to anchor."))
+    (-> (io/file res)        ; .../ssr/test/re_frame/ssr_conformance_test.clj
+        .getParentFile       ; .../ssr/test/re_frame
+        .getParentFile       ; .../ssr/test
+        .getParentFile       ; .../ssr
+        .getParentFile       ; .../implementation
+        .getParentFile       ; repo root
+        (io/file "spec" "conformance" "fixtures")
+        .getCanonicalFile)))
 
 (defn- load-fixture
   "Read one EDN fixture, applying the same `::name` rewrite the JVM core


### PR DESCRIPTION
Follow-up to rf2-3hamsq (PR #4853). The 5 JVM conformance-corpus runners
discovered their repo-root fixtures (`spec/conformance/fixtures/`) via a
cwd-relative `(io/file "../../spec/conformance/fixtures")`. That holds under
the canonical per-artefact gate (`clojure -M:test` from
`implementation/<art>/`, which CI runs) but mis-scopes under the combined
`implementation/deps.edn :test` alias run from `implementation/` — `"../../"`
resolves *above* the repo root, `file-seq` finds nothing, the corpus
discovers zero fixtures. The rf2-3hamsq non-empty floor turns that
mis-discovery RED rather than silent-green; this re-anchor removes the cwd
trigger entirely (the same fix rf2-55j4s3 applied to 3 sibling core tests).

## What changed

Each runner's own test-ns source file is on its artefact test classpath
(`:test {:extra-paths ["test"]}`), so `(io/resource "re_frame/<runner>.clj")`
pins the anchor to the on-disk source location regardless of cwd. Walking
five parents (`<runner>.clj → re_frame → test → <art> → implementation →
repo root`) reaches the repo root, then we descend into
`spec/conformance/fixtures`.

Re-anchored: `schemas`, `core`, `machines`, `ssr`, `flows`
conformance runners. The rf2-3hamsq floors (`(pos? (count run))` +
per-runner expected-min) are preserved unchanged — they are the safety net
proving the re-anchor still discovers the SAME fixture set.

**Not changed:** the CLJS corpus runner
(`conformance_corpus_cljs_test.cljs`) — its `all-fixtures` macro inlines
fixtures at COMPILE time, so runtime discovery is already cwd-independent
(the bead scopes to the JVM `io/file`/`file-seq` runtime variants).

## Cwd-independence proof

Schemas conformance deftest, discovered fixtures + result, run from BOTH cwds:

| cwd | fixtures-dir resolved | EDN files | deftest |
|-----|----------------------|-----------|---------|
| `implementation/schemas/` (per-artefact) | `<repo>/spec/conformance/fixtures` | 188 | 3 pass, 0 fail |
| `implementation/` (combined alias — previously found 0) | `<repo>/spec/conformance/fixtures` | 188 | 3 pass, 0 fail |

Before this fix, from `implementation/` the old `io/file "../../..."` resolved
to `re-frame2-worktrees/spec/conformance/fixtures` (one level above the repo)
→ 0 EDN files → floor RED. All 5 runners' `fixtures-dir` now resolve
identically (188 EDN) from both cwds.

## Quality gates

- `clojure -M:test -n <conformance-ns>` per-artefact for all 5 runners — **PASS** (schemas/machines/ssr/flows 3 assertions; core 8 assertions; 0 fail/0 error)
- Schemas deftest run via direct eval from `implementation/schemas/` AND `implementation/` — **PASS** both, 188 EDN, floor green (cwd-independence proof above)
- `npm run test:cljs` — **PASS** (7914 tests, 36448 assertions, 0 failures, 0 errors) — confirms the untouched CLJS corpus floor stays green
- Runnable fixture counts unchanged from rf2-3hamsq baseline: schemas 5, core 186/188, machines 61, ssr 14, flows 9

Touched only the 5 JVM conformance runner test files — no production source, no fixtures moved, no deps/classpath changes. CI is the merge gate.