### PR TITLE
fix(xray): repoint Flows panel introspection to flows/flow-meta-at after registrar :flow emptied (rf2-20359j)

### DIFF
--- a/tools/xray/deps.edn
+++ b/tools/xray/deps.edn
@@ -70,13 +70,17 @@
          day8/re-frame2-routing {:local/root "../../implementation/routing"}
 
          ;; Per rf2-uhsqb — `day8/re-frame2-flows` is a hard dep of
-         ;; Xray. The Static Flows sub-tab reads
-         ;; `re-frame.flows.registry/flows` at view-render time to
-         ;; project the registered-flows catalogue. Same posture as
-         ;; the routing dep above: most real hosts already pull the
-         ;; flows artefact, but the Static Flows sub-tab must work
-         ;; (rendering an empty catalogue when no flows are registered)
-         ;; even for hosts that haven't registered any flows yet.
+         ;; Xray. The Static Flows sub-tab reads the public
+         ;; `re-frame.flows/flows-snapshot` introspection surface (and
+         ;; the Epoch panel's flow-step source link reads
+         ;; `re-frame.flows/flow-meta-at`) to project the registered-flows
+         ;; catalogue — the per-frame flows atom is the sole store after
+         ;; rf2-en00bk (the registrar `:flow` slot is reserved-but-empty),
+         ;; repointed off it by rf2-20359j. Same posture as the routing
+         ;; dep above: most real hosts already pull the flows artefact, but
+         ;; the Static Flows sub-tab must work (rendering an empty
+         ;; catalogue when no flows are registered) even for hosts that
+         ;; haven't registered any flows yet.
          day8/re-frame2-flows {:local/root "../../implementation/flows"}
 
          ;; Per rf2-o5f5f.4 — `day8/re-frame2-schemas` is a hard dep

--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -375,7 +375,7 @@ Spec consumer: framework Spec 013 (registered-flow surface) + Spec 009
 
 | Sub | Returns |
 |---|---|
-| `:rf.xray/registered-flows` | `(rf/registrations :flow)` — process-global registry. Test override via `:registered-flows-override`. |
+| `:rf.xray/registered-flows` | `(re-frame.flows/flows-snapshot)` — the per-frame `{frame-id {flow-id flow-map}}` store (the SOLE store after framework rf2-en00bk; the registrar `:flow` slot is reserved-but-empty, so the former `(rf/registrations :flow)` read now returns `{}`). Test override via `:registered-flows-override`. |
 | `:rf.xray/flow-trace-events` | Trace-buffer's `:op-type :flow` slice. |
 | `:rf.xray/selected-flow-id` | Flow-id or `nil`. |
 | `:rf.xray/flows-data` | Composite — `{:rows :status-counts :total :selected-flow-id}`. |

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -800,8 +800,13 @@ sections that read top-to-bottom as the developer scans.
      `↳` glyph linking back to the upstream flow id)
    - `wrote <write-path>` + after-value (via `inspector/inspect`)
    - `read <input-path-1> <input-path-2> …` — input paths recovered
-     from the registry via `(rf/handler-meta :flow flow-id)` (the
-     per-firing trace does not carry input PATHS; rf2-qlzh4 polish
+     from the per-frame flows store via
+     `(re-frame.flows/flow-meta-at flow-id {:frame frame-id})` (the
+     `(rf/handler-meta :flow id)` replacement after framework rf2-en00bk
+     made the flows atom the sole store and emptied the registrar `:flow`
+     slot; the flow's frame rides the `:rf.flow/computed` trace's `:frame`
+     tag, and flows are frame-divergent-per-id so the read is frame-scoped).
+     The per-firing trace does not carry input PATHS; rf2-qlzh4 polish
      bead tracks adding `:before` to the trace payload for full self-
      containment). When the flow has been cleared mid-session the
      read line renders `input paths unavailable (flow may have been
@@ -865,7 +870,8 @@ sections that read top-to-bottom as the developer scans.
   default; no '(none)' placeholder).
 - **Flow cleared mid-session** — FLOWS section still renders the row
   (the firing happened); the read-paths line renders the absent
-  placeholder since `(rf/handler-meta :flow id)` returns nil.
+  placeholder since `(re-frame.flows/flow-meta-at flow-id {:frame frame-id})`
+  returns nil.
 - **Handler threw** — §6 + §7 + §8 are all absent (handler never
   returned, so the flow transform never ran, the db never committed,
   and the fx walk never started — every post-handler stage is omitted);

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -3659,10 +3659,15 @@ The accompanying view-layer chrome:
 
 - **Header** — `:FLOW` badge + flow-id button to the right of
   the badge. The button is clickable when
-  `(rf/handler-meta :flow <id>)` returns a coordinate (click-to-source
-  jumps through the shared `:rf.xray/open-in-editor` scheme denylist —
-  see §9.1.11); otherwise the id renders as a plain coloured span.
-  An external-link glyph trails the id when source-jump is wired.
+  `(re-frame.flows/flow-meta-at <id> {:frame <frame-id>})` returns a
+  coordinate (the `(rf/handler-meta :flow id)` replacement after framework
+  rf2-en00bk made the per-frame flows atom the sole store and emptied the
+  registrar `:flow` slot; the flow's frame rides the `:rf.flow/computed`
+  trace's `:frame` tag and flows are frame-divergent-per-id, so the lookup
+  is frame-scoped). Click-to-source jumps through the shared
+  `:rf.xray/open-in-editor` scheme denylist — see §9.1.11; otherwise the id
+  renders as a plain coloured span. An external-link glyph trails the id
+  when source-jump is wired.
 - **Body — the flow's OWN `:db` diff (rf2-4wywy / rf2-48oc4)** — a
   flow's contribution IS an app-db mutation: it writes `:output` into
   `:path` AFTER the handler returned. The body renders that

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1844,8 +1844,10 @@
 
 (defn flow-rows
   "Project flow-recompute events into rows. Each row carries
-  `:flow-id`, `:path` (the db path the flow wrote), and optional
-  before/after values. Empty vec when no flow fired this epoch.
+  `:flow-id`, `:frame` (the frame the flow fired in — flows are
+  frame-divergent-per-id per Spec 013, so the source-coord lookup needs
+  it), `:path` (the db path the flow wrote), and optional before/after
+  values. Empty vec when no flow fired this epoch.
 
   Per rf2-yhgk8 the substrate stamps the canonical
   `:rf.flow/computed` operation with BARE `:flow-id` / `:path` /
@@ -1860,6 +1862,7 @@
     (vec
       (for [ev evs]
         {:flow-id     (common/tag-of ev :flow-id)
+         :frame       (common/tag-of ev :frame)
          :path        (common/tag-of ev :path)
          :before      (common/tag-of ev :before)
          :after       (common/tag-of ev :result)
@@ -3949,10 +3952,11 @@
             ;; pair and the view falls back to the scalar before→after line.
             flow-db-pre  (effective-post-handler-db events db-before)
             flow-db-post (db-pending-t2 events)
-            flow-steps (mapv (fn [{:keys [flow-id path before after duration-ms]}]
+            flow-steps (mapv (fn [{:keys [flow-id frame path before after duration-ms]}]
                                (cond-> {:step    :flow
                                         :badge   :FLOW
                                         :flow-id flow-id
+                                        :frame   frame
                                         :path    path
                                         :before  before
                                         :after   after}

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -67,6 +67,7 @@
   helper composed into the numbered cascade by `pipeline-view`."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.flows :as flows]
             [re-frame.schemas :as schemas]
             [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
@@ -4251,10 +4252,19 @@
   Graceful fallback: when the projection carried no pre/post snapshots
   (a pre-rf2-ta0y7 runtime, or neither t1 nor t2 on the stream) the
   body falls back to the per-path `[path] before → after` scalar line."
-  [{:keys [flow-id path before after duration-ms step-number
+  [{:keys [flow-id frame path before after duration-ms step-number
            db-pre-flow db-post-flow errors]}]
-  (let [flow-meta  (when (keyword? flow-id)
-                     (try (rf/handler-meta :flow flow-id)
+  (let [;; rf2-20359j — flows are FRAME-DIVERGENT-per-id (Spec 013), so the
+        ;; source-coord lookup reads the per-frame `flows/flow-meta-at`
+        ;; (the `(handler-meta :flow id)` replacement after rf2-en00bk
+        ;; emptied the registrar `:flow` slot). The flow's OWN frame rides
+        ;; the `:rf.flow/computed` event's `:frame` tag (threaded through
+        ;; the projection's flow-step map), so we pass it as the EXPLICIT
+        ;; `:frame` override rather than resolving the carried scope — the
+        ;; latter would resolve Xray's OWN `:rf/xray` frame, not the host
+        ;; frame whose flow this is. nil frame degrades to no source link.
+        flow-meta  (when (and (keyword? flow-id) (keyword? frame))
+                     (try (flows/flow-meta-at flow-id {:frame frame})
                           (catch :default _ nil)))
         coord      (when (and flow-meta (string? (:file flow-meta)))
                      {:file (:file flow-meta) :line (:line flow-meta)})

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -22,15 +22,18 @@
   ## Data source
 
   Reads the registered flows through the public introspection surface
-  `(rf/registrations :flow)` (Tool-Pair.md §public APIs; spec/014
-  catalogues `:rf.xray/registered-flows` as `(rf/registrations :flow)`)
-  rather than reaching the private `re-frame.flows.registry/flows`
-  atom. The registrar slot keys on flow-id with `:frame` stamped per
-  entry (registry.cljc — `reg-flow` stamps `:frame` into the metadata),
-  so the sub groups the flat `{flow-id meta}` map by `:frame` back into
-  the `{frame-id {flow-id flow-map}}` shape the per-frame projection +
-  picker-scoping helpers consume. The view never reasons about the
-  registry's two-level shape directly.
+  `re-frame.flows/flows-snapshot` (Tool-Pair.md §public APIs; spec/014
+  catalogues `:rf.xray/registered-flows` as `flows/flows-snapshot`).
+  Since rf2-en00bk the per-frame `flows` atom is the SOLE store; the
+  registrar `:flow` kind is RESERVED-but-empty (no write), so the old
+  `(rf/registrations :flow)` read now returns `{}` (an empty catalogue).
+  `flows-snapshot` returns the whole-registry `{frame-id {flow-id
+  flow-map}}` value DIRECTLY — already in the per-frame shape the
+  projection + picker-scoping helpers consume, so no flat-to-grouped
+  regrouping is needed. The store is FRAME-DIVERGENT-per-id (Spec 013):
+  the same flow-id against two frames carries each frame's OWN definition,
+  which this panel surfaces per frame — a strict improvement over the old
+  frame-blind last-registration-wins registrar slot.
 
   Optional test override slot: `:rf.xray.static.flows/registered-
   flows-override` lets the CLJS test suite inject deterministic
@@ -47,7 +50,7 @@
   `[rf/frame-provider-existing {:frame :rf/xray}]` in `static/shell.cljs`."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [day8.re-frame2-xray.host-registry :as host-registry]
+            [re-frame.flows :as flows]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
@@ -71,27 +74,6 @@
   (if (nil? frame-id)
     registry-snapshot
     (select-keys registry-snapshot [frame-id])))
-
-(defn registrations->by-frame
-  "Group the flat `(rf/registrations :flow)` shape — `{flow-id meta}`
-  where each `meta` carries a `:frame` stamped at `reg-flow`-time — back
-  into the per-frame `{frame-id {flow-id flow-map}}` shape the
-  projection + picker-scoping helpers consume.
-
-  An entry whose `:frame` slot is absent (defensive — every flow
-  registration stamps `:frame`) buckets under the distinct
-  `:rf.xray/no-frame-stamp` sentinel. Per EP-0002, a missing frame
-  stamp is NOT bucketed under `:rf/default` (an ordinary id that a real
-  flow may legitimately register in): conflating the two would
-  mis-attribute a stamp-less registration to a real frame's group.
-  Pure data — JVM-runnable."
-  [registrations]
-  (reduce-kv
-    (fn [acc flow-id meta]
-      (let [frame-id (get meta :frame :rf.xray/no-frame-stamp)]
-        (assoc-in acc [frame-id flow-id] meta)))
-    {}
-    registrations))
 
 (defn project-rows
   "Flatten `{frame-id {flow-id flow-map}}` into a flat vector of rows,
@@ -295,18 +277,28 @@
 ;; branch lives in ONE place (the seam), not duplicated.
 
 (defn- registered-flows-value
-  "The registered flows regrouped into the per-frame
-  `{frame-id {flow-id flow-map}}` shape from the HOST app's `:flow` registrar.
+  "The registered flows in the per-frame `{frame-id {flow-id flow-map}}`
+  shape, read directly from the authoritative flows store via
+  `re-frame.flows/flows-snapshot`.
 
-  Read via `host-registry/registrations` (the generation-bypassing
-  host-registry form), NOT a bare `(rf/registrations :flow)`: this runs inside the
-  `:rf.xray.static.flows/registered-flows` sub COMPUTATION, and Xray seats in
-  its OWN image-loaded `:rf/xray` frame, so the sub build binds the registrar to
-  Xray's image generation — a bare read would resolve through Xray's OWN image
-  (no host `:flow` ids) and the panel would show an empty flow catalogue. See
-  `day8.re-frame2-xray.host-registry`."
+  Reads `flows/flows-snapshot` — the whole-registry `{frame-id {flow-id
+  flow-map}}` snapshot — NOT the registrar `:flow` slot. Since rf2-en00bk
+  the per-frame `flows` atom is the SOLE store; the registrar `:flow` kind
+  is RESERVED-but-empty (no write), so the old `(rf/registrations :flow)` /
+  `host-registry/registrations :flow` read now returns `{}` and the panel
+  rendered an empty catalogue. `flows-snapshot` deref's the process-global
+  `re-frame.flows.registry/flows` atom directly, so — unlike a registrar
+  read — it is generation-INDEPENDENT: it does not route through the
+  registrar resolver and is unaffected by Xray's sub build binding to its
+  OWN `:rf/xray` image generation. No regrouping is needed: the snapshot
+  is ALREADY in the per-frame `{frame-id {flow-id flow-map}}` shape the
+  projection + picker-scoping helpers consume, and is FRAME-DIVERGENT by
+  construction — the same flow-id registered against two frames carries
+  each frame's OWN `:inputs` / `:derive` / `:output-path`, a strict
+  improvement over the old frame-blind last-registration-wins registrar
+  slot (rf2-20359j)."
   []
-  (try (registrations->by-frame (host-registry/registrations :flow))
+  (try (flows/flows-snapshot)
        (catch :default _ {})))
 
 ;; ---- registrations -------------------------------------------------------
@@ -324,9 +316,8 @@
         — test-only override setter.
     - `:rf.xray.static.flows/registered-flows` — production data sub
                                                   reading the public
-                                                  `(rf/registrations
-                                                  :flow)` surface
-                                                  (or override).
+                                                  `flows/flows-snapshot`
+                                                  surface (or override).
     - `:rf.xray.static.flows/tab-data`         — view-facing composite."
   []
 
@@ -349,15 +340,16 @@
 
   ;; ---- production data sub ---------------------------------------------
 
-  ;; Read the registered flows through the public `(rf/registrations
-  ;; :flow)` introspection surface (Tool-Pair.md §public APIs) once per
-  ;; sub re-fire, then regroup the flat `{flow-id meta}` shape into the
-  ;; per-frame `{frame-id {flow-id flow-map}}` shape the projection +
-  ;; picker-scoping helpers consume. `:<-`-composing against
-  ;; `:rf.xray/trace-buffer` keeps the sub reactive against the same
-  ;; "something changed" pulse the other static-mode subs ride —
-  ;; without it, a fresh `reg-flow!` wouldn't surface until the next
-  ;; subscribe re-render.
+  ;; Read the registered flows through the public `flows/flows-snapshot`
+  ;; introspection surface (Tool-Pair.md §public APIs) once per sub
+  ;; re-fire. The snapshot is already in the per-frame `{frame-id
+  ;; {flow-id flow-map}}` shape the projection + picker-scoping helpers
+  ;; consume — no flat-to-grouped regroup needed (rf2-en00bk made the
+  ;; per-frame flows atom the sole store; the registrar `:flow` slot is
+  ;; reserved-but-empty). `:<-`-composing against `:rf.xray/trace-buffer`
+  ;; keeps the sub reactive against the same "something changed" pulse the
+  ;; other static-mode subs ride — without it, a fresh `reg-flow!`
+  ;; wouldn't surface until the next subscribe re-render.
   (rf/reg-sub :rf.xray.static.flows/registered-flows
     :<- [:rf.xray/trace-buffer]
     (fn [_buffer _query]

--- a/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
@@ -18,6 +18,13 @@
     5. **Search filter** — substring across flow-id + path + doc."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-20359j — load-time hook so `reg-flow` / `flows-snapshot`
+            ;; resolve. The Static Flows panel reads the PRODUCTION data
+            ;; source `flows/flows-snapshot` (the per-frame flows atom is the
+            ;; sole store after rf2-en00bk; the registrar `:flow` slot is
+            ;; reserved-but-empty), so the live-source regression below
+            ;; registers real flows through `rf/reg-flow`.
+            [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -323,3 +330,118 @@
                            tree "rf-xray-edn-inspector-")]
         (is (seq widget-nodes)
             "at least one edn-inspector widget container present")))))
+
+;; -------------------------------------------------------------------------
+;; (6) LIVE production data source regression (rf2-20359j)
+;; -------------------------------------------------------------------------
+;;
+;; Every test above injects fixtures through the test-only OVERRIDE seam
+;; (`set-registered-flows-override-for-test`), which is exactly why CI
+;; stayed green after rf2-en00bk silently emptied the panel's real data
+;; source: the override branch never touches the production read. This
+;; section exercises the genuine PRODUCTION path — the
+;; `:rf.xray.static.flows/registered-flows` sub's `registered-flows-value`
+;; → `re-frame.flows/flows-snapshot` read — against REAL `reg-flow`
+;; registrations, with NO override installed.
+;;
+;; rf2-en00bk made the per-frame `flows` atom the SOLE store and left the
+;; registrar `:flow` slot RESERVED-but-empty. Before this PR the panel read
+;; `(host-registry/registrations :flow)` (→ now `{}`), so the production
+;; data source returned an EMPTY catalogue against real flows; after the
+;; repoint it reads `flows/flows-snapshot` and surfaces them. Reverting the
+;; `registered-flows-value` body back to the registrar read fails the first
+;; assertion below (empty catalogue) while every override-based test above
+;; stays green — proving the gap this regression closes.
+
+(defn- production-setup-xray!
+  "Install the PRODUCTION Static Flows wiring (no override seam) plus the
+  two host frames the live-source flows register against."
+  []
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {})
+  (frame/reg-frame :flows-test/frame-a {:doc "host frame A"})
+  (frame/reg-frame :flows-test/frame-b {:doc "host frame B"}))
+
+(deftest live-source-reads-flows-snapshot-not-empty-registrar-slot
+  (testing "rf2-20359j — the PRODUCTION Static Flows data source reads
+            `flows/flows-snapshot` (the per-frame flows store) and surfaces
+            real `reg-flow` registrations. Pre-repoint it read the now-empty
+            registrar `:flow` slot and returned an empty catalogue (the panel
+            degraded silently); the override-based tests above could not see
+            this regression."
+    (production-setup-xray!)
+    ;; Register REAL flows against host frame A via the public facade.
+    (rf/reg-flow {:id          :user/full-name
+                  :inputs      [[:user :first] [:user :last]]
+                  :derive      (fn [first* last*] (str first* " " last*))
+                  :output-path [:derived :full-name]
+                  :doc         "concat first + last"}
+                 {:frame :flows-test/frame-a})
+    (rf/reg-flow {:id          :cart/total
+                  :inputs      [[:cart :items]]
+                  :derive      (fn [_] 0)
+                  :output-path [:cart :total]
+                  :doc         "sum of cart items"}
+                 {:frame :flows-test/frame-a})
+    ;; Read through the LIVE production sub — NOT the override seam — inside
+    ;; the :rf/xray frame the panel seats in. nil picker frame → list every
+    ;; frame's flows (see scope-to-frame), so the catalogue carries both.
+    (rf/with-frame :rf/xray
+      (let [snapshot @(rf/subscribe [:rf.xray.static.flows/registered-flows])]
+        (is (seq snapshot)
+            "production data source is NON-EMPTY against real flows (was {}
+             when reading the now-empty registrar :flow slot)")
+        (is (= #{:user/full-name :cart/total}
+               (set (keys (get snapshot :flows-test/frame-a))))
+            "frame A's two flows surface, keyed by frame in the per-frame shape"))
+      (let [data @(rf/subscribe [:rf.xray.static.flows/tab-data])]
+        (is (false? (:silent? data))
+            "tab-data is not silent — the panel renders rows, not the empty state")
+        (is (= 2 (:total data))
+            "both real flows reach the view-facing composite")))))
+
+(deftest live-source-surfaces-frame-divergent-definitions
+  (testing "rf2-20359j / Spec 013 — the SAME flow-id registered against two
+            frames carries each frame's OWN divergent definition in the
+            production data source. The old frame-blind registrar slot could
+            only ever show the last registrant; `flows/flows-snapshot` shows
+            both, and the panel scopes per frame."
+    (production-setup-xray!)
+    (let [derive-a (fn [first* last*] (str first* " " last*))
+          derive-b (fn [first* last*] (str last* ", " first*))]
+      ;; Same flow-id :user/full-name, two frames, DIVERGENT :derive +
+      ;; :output-path.
+      (rf/reg-flow {:id          :user/full-name
+                    :inputs      [[:user :first] [:user :last]]
+                    :derive      derive-a
+                    :output-path [:derived :natural]
+                    :doc         "first last"}
+                   {:frame :flows-test/frame-a})
+      (rf/reg-flow {:id          :user/full-name
+                    :inputs      [[:user :first] [:user :last]]
+                    :derive      derive-b
+                    :output-path [:derived :sortable]
+                    :doc         "last, first"}
+                   {:frame :flows-test/frame-b})
+      (rf/with-frame :rf/xray
+        (let [snapshot @(rf/subscribe [:rf.xray.static.flows/registered-flows])
+              entry-a  (get-in snapshot [:flows-test/frame-a :user/full-name])
+              entry-b  (get-in snapshot [:flows-test/frame-b :user/full-name])]
+          (is (some? entry-a) "frame A's entry present")
+          (is (some? entry-b) "frame B's entry present")
+          (is (= derive-a (:derive entry-a))
+              "frame A keeps its OWN :derive (not clobbered by frame B's later reg)")
+          (is (= derive-b (:derive entry-b))
+              "frame B keeps its OWN :derive")
+          (is (= [:derived :natural] (:output-path entry-a))
+              "frame A keeps its OWN :output-path")
+          (is (= [:derived :sortable] (:output-path entry-b))
+              "frame B keeps its OWN :output-path — divergent per frame")))
+      ;; Cross-check the introspection surface the Epoch panel's source link
+      ;; reads (`flow-meta-at` with an explicit :frame) agrees, frame-by-frame.
+      (is (= derive-a (:derive (flows/flow-meta-at :user/full-name
+                                                   {:frame :flows-test/frame-a})))
+          "flow-meta-at resolves frame A's divergent definition")
+      (is (= derive-b (:derive (flows/flow-meta-at :user/full-name
+                                                   {:frame :flows-test/frame-b})))
+          "flow-meta-at resolves frame B's divergent definition"))))


### PR DESCRIPTION
## What

Framework rf2-en00bk (PR #4857) made the per-frame `flows` atom the SOLE store and left the registrar `:flow` slot RESERVED-but-empty. Two Xray readers still consulted the old, now-empty registrar paths, so both surfaces degraded silently (try/catch-guarded — no crash, but non-functional; the override-based panel tests stayed green and masked it).

This PR repoints both readers onto the new frame-scoped flows introspection API that #4857 added.

### Readers repointed (from → to)

1. **Static Flows panel** (`static/flows/panel.cljs`) — `registered-flows-value`
   - from `(host-registry/registrations :flow)` → now `{}` → empty catalogue
   - to `re-frame.flows/flows-snapshot` — already the per-frame `{frame-id {flow-id flow-map}}` shape the projection + picker-scoping helpers consume (the now-dead `registrations->by-frame` regroup helper removed). Surfaces each frame's OWN definition — strictly better than the frame-blind last-registration-wins slot.

2. **Epoch panel flow-step source link** (`panels/epoch/view.cljs`) — `render-flow-step`
   - from `(rf/handler-meta :flow flow-id)` → now nil → no click-to-source
   - to `re-frame.flows/flow-meta-at` with an **explicit** `:frame` (the flow's own frame, threaded from the `:rf.flow/computed` trace's `:frame` tag through the projection's flow-step map). The carried scope would resolve Xray's own `:rf/xray` frame, not the host frame whose flow it is.

Both reads deref the process-global flows atom directly, so they are generation-independent — no host-registry generation-bypass needed.

### Regression (CLJS unit, per the Causa/Story convention)

Two new tests in the Static Flows panel suite exercise the **live production data source** (NOT the override seam) against real `reg-flow` registrations:
- `live-source-reads-flows-snapshot-not-empty-registrar-slot` — the production sub returns a non-empty catalogue; the panel is not silent.
- `live-source-surfaces-frame-divergent-definitions` — the same flow-id against two frames each surfaces its OWN `:derive` / `:output-path`; cross-checked against `flow-meta-at`.

Verified by temporary revert (data source → `{}`): 10 panel-source assertions go red while every override-based test stays green — proving the gap this closes.

### Spec currency

`tools/xray/spec/014-Registry-Catalogue.md`, `018-Event-Spine.md`, `021-Dynamic-Panel-Designs.md` prose repointed off `(rf/registrations :flow)` / `(rf/handler-meta :flow id)` onto `flows-snapshot` / `flow-meta-at`. `deps.edn` flows-dep comment updated.

Touch boundary: `tools/xray/` only.

## Quality gates

- `npm run test:cljs` — PASS (7918 tests, 36498 assertions, 0 failures; +2 new tests vs baseline 7916)
- `npm run test:xray-feature-gate` — PASS (15 scenarios, 0 failures, 13 matrix rows; exit 0)
- `mkdocs build --strict` — SKIPPED: `tools/xray/spec/` is not in the mkdocs nav, so the doc edits don't affect the docs build (CI runs it regardless).