### PR TITLE
fix(api-manifest): classify re-frame.flows/flow-meta-at facade export (rf2-75wr5v)

### DIFF
--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -1048,6 +1048,12 @@
   ["re-frame.flows" "reg-flow"]              {:tier :implementation :owner "013" :status "v1"}
   ["re-frame.flows" "clear-flow"]            {:tier :implementation :owner "013" :status "v1"}
   ["re-frame.flows" "flows-snapshot"]        {:tier :tooling :owner "013" :status "v1"}
+  ;; The canonical per-frame flow introspection surface — the flows analogue of
+  ;; `re-frame.schemas/app-schema-meta-at` (rf2-en00bk, applying the rf2-0frdi
+  ;; precedent). Frame-divergent-per-id; the `(handler-meta :flow flow-id)`
+  ;; replacement. `:tooling` (pair-tools / 10x panels / source-coord tests),
+  ;; mirroring `app-schema-meta-at`'s classification.
+  ["re-frame.flows" "flow-meta-at"]          {:tier :tooling :owner "013" :status "v1"}
   ;; EP-0015: the raw `last-inputs-snapshot` is `^:no-doc` (internal / test /
   ;; rollback seam, NOT an egress boundary), so it stays off the public
   ;; manifest. Off-box reads ride the elided trace path, not a dedicated

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 485,
+ :var-count 486,
  :tier-vocab
  [:front-porch
   :advanced
@@ -216,6 +216,7 @@
   {:namespace "re-frame.epoch", :var "unregister-epoch-listener!", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "clear-flow", :tier :implementation, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "flow-algebra-view", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.flows", :var "flow-meta-at", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "flows-snapshot", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "reg-flow", :tier :implementation, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "reset-flows!", :tier :implementation, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
## Summary

Main is RED on the **Public-API manifest drift-check** gate (`lint.yml` → `api-manifest` job), blocking all PRs.

**Root cause:** PR #4857 (rf2-en00bk) added the public facade export `re-frame.flows/flow-meta-at` — the flows analogue of `re-frame.schemas/app-schema-meta-at` — but did not add its `:classification` sidecar entry to `spec/api-manifest-metadata.edn`. The drift-check is CI-only, so the gap slipped past merge and surfaced on Mike's PR #4859 (which doesn't touch flows).

**Fix (precedent-mirrored, mechanical):**
- Added the sidecar entry mirroring the `app-schema-meta-at` precedent:
  ```clojure
  ["re-frame.flows" "flow-meta-at"]  {:tier :tooling :owner "013" :status "v1"}
  ```
  (`:tooling` introspection, same shape as `app-schema-meta-at`'s `:tooling`; owner `013` = the Flows spec, mirroring schemas' `010`.)
- Regenerated `spec/api-manifest.edn` (var-count 485 → 486; the new `flow-meta-at` row carries `runtime-verified? true`).

`flow-meta-at` is genuinely public — `(defn flow-meta-at ...)` in `implementation/flows/src/re_frame/flows/registry.cljc`, re-exported via `(def flow-meta-at registry/flow-meta-at)` in `re_frame/flows.cljc` (no `^:private`/`^:no-doc`). It is the documented `app-schema-meta-at` analogue, so it is classified rather than made private.

Touches ONLY `spec/api-manifest-metadata.edn` + `spec/api-manifest.edn`. Independent of Mike's PR #4859.

## Quality gates

Ran locally from `implementation/scripts/api-manifest/` (JDK 21, Clojure CLI available):

- `clojure -M -m re-frame.api-manifest.gen --check` → **EXIT 0** (`OK: spec/api-manifest.edn in sync (486 public vars).`) — the exact failing CI command.
- `clojure -M -m re-frame.api-manifest.api-md-check` → **EXIT 0** (184 var-rows in sync).

CI is the authoritative merge gate.