### PR TITLE
feat(ssr): EP-0025 repoint SSR egress onto project-egress classification registry (rf2-ux7983)

### DIFF
--- a/implementation/ssr-ring/test/re_frame/ssr/ring/app_db_egress_projection_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/app_db_egress_projection_test.clj
@@ -27,10 +27,19 @@
 
 (defn- reg-sensitive-frame! []
   ;; A server frame whose classification marks the nested :session :token path
-  ;; sensitive — the canonical durable app-db egress route (EP-0015 §3/§8).
+  ;; sensitive — the canonical durable app-db egress route. EP-0025 B4-ssr
+  ;; follow-on (rf2-ux7983): the path is classified through the post-purge
+  ;; mechanism — a B3 COMMIT-PLANE `:sensitive` effect the frame's init event
+  ;; returns alongside `:db` (EP-0025 §How it works / §Examples) — writing it
+  ;; into the per-frame `[:rf.runtime/elision]` registry the
+  ;; `:rf.egress/ssr-hydration` egress walk reads. Replaces the retired
+  ;; `reg-frame :sensitive {:app-db}` durable annotation (deleted by the
+  ;; EP-0025 B1b purge). Value-independent — classified at init, read at egress.
+  (rf/reg-event :rf.bt9kct/classify
+    (fn [_ _] {:sensitive [[:session :token]]}))
   (rf/reg-frame server-frame
-    {:platform  :server
-     :sensitive {:app-db [[:session :token]]}}))
+    {:platform       :server
+     :initial-events [[:rf.bt9kct/classify]]}))
 
 (def ^:private app-db
   "An app-db whose allowlisted :session key carries a frame-sensitive child

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -874,12 +874,21 @@
             trace keeps it raw. The sensitive deserialised payload value never
             fans out to a corpus listener raw."
     (register-baseline-handlers!)
+    ;; EP-0025 B4-ssr follow-on (rf2-ux7983): the rejected client frame declares
+    ;; the untrusted `:payload-frame-id` slot :sensitive through the post-purge
+    ;; mechanism — a B3 COMMIT-PLANE `:sensitive` effect the frame's init event
+    ;; returns alongside `:db` (EP-0025 §How it works / §Examples) — writing it
+    ;; into the per-frame `[:rf.runtime/elision]` registry. So project-egress
+    ;; redacts it on the off-box leg, replacing the retired
+    ;; `:sensitive {:app-db}` durable annotation (deleted by the B1b purge).
+    (rf/reg-event :rf.b5/classify
+      (fn [_ _] {:sensitive [[:payload-frame-id]]}))
     (let [;; the rejected client frame declares the untrusted payload slot
           ;; :sensitive — so project-egress redacts it on the off-box leg.
           client-frame (frame/make-anon-frame-record!
-                         {:doc       "B5 sensitive payload-frame-id client"
-                          :platform  :client
-                          :sensitive {:app-db [[:payload-frame-id]]}})
+                         {:doc            "B5 sensitive payload-frame-id client"
+                          :platform       :client
+                          :initial-events [[:rf.b5/classify]]})
           ;; the corpus-listener stand-in (the off-box shipper) records the
           ;; ALWAYS-ON union record.
           corpus       (atom [])

--- a/implementation/ssr/test/re_frame/ssr_machine_snapshot_projection_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_machine_snapshot_projection_test.clj
@@ -3,10 +3,11 @@
   `:data`.
 
   EP-0025 (rf2-398kql): durable machine `:data` egress classification is
-  FRAME-OWNED — the frame declares the machine snapshot's `:data` path sensitive
-  / large via `reg-frame` `:sensitive` / `:large {:app-db …}` (the absolute
-  runtime-db path `[:rf.runtime/machines :snapshots <actor-id> :data …]`, the
-  sole app-db mechanism). Hydration is a serialized-state egress boundary
+  FRAME-OWNED — the frame classifies the machine snapshot's `:data` path
+  sensitive / large by its absolute runtime-db path
+  `[:rf.runtime/machines :snapshots <actor-id> :data …]`, the sole app-db
+  mechanism (post-purge: a B3 commit-plane `:sensitive` / `:large` effect — see
+  the follow-on note below). Hydration is a serialized-state egress boundary
   projected under `:rf.egress/ssr-hydration`. The SSR `:rf/runtime-db` payload
   ships `:rf.runtime/machines` so the client re-materialises actors — but the
   prior `project-runtime-db` copied the machines slice WHOLESALE, so a snapshot
@@ -18,13 +19,22 @@
   `:data-schema` still VALIDATES `:data`) and a FRAME-declared classification of
   the snapshot `:data` path; the machines artefact is loaded so the late-bound
   `:machines/project-ssr-runtime-db` hook is bound. (EP-0025 removed the EP-0005
-  `:data-schema`→marks SSR-classification bridge; classification is frame-side.)"
+  `:data-schema`→marks SSR-classification bridge; classification is frame-side.)
+
+  EP-0025 B4-ssr follow-on (rf2-ux7983): the snapshot `:data` path is classified
+  through the post-purge mechanism — a B3 COMMIT-PLANE `:sensitive` / `:large`
+  effect returned by a `reg-event` handler alongside `:db` (EP-0025 §How it
+  works). It writes the absolute runtime-db snapshot path into the SAME per-frame
+  `[:rf.runtime/elision]` registry the `:rf.egress/ssr-hydration` egress walk
+  reads (tagged `:source :effect`, unioned at egress-lookup), so the SSR
+  projection redacts/elides it exactly as a `:source :frame` declaration would.
+  This replaces the retired imperative `marks/add-marks` API (deleted by the
+  EP-0025 B1b purge); the classification is read ONLY at egress, so it redacts
+  whatever value later occupies the path."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             ;; Loading machines publishes :machines/project-ssr-runtime-db.
             [re-frame.machines]
-            ;; marks/add-marks declares the frame-owned snapshot classification.
-            [re-frame.marks :as marks]
             [re-frame.schemas]
             [re-frame.schemas.malli]
             [re-frame.ssr.payload-policy :as payload-policy]
@@ -50,14 +60,34 @@
      :states      {:anon   {:on {:login :authed}}
                    :authed {}}}))
 
+;; Classify the snapshot `:data` token slot SENSITIVE and blob slot LARGE on the
+;; ambient `:rf/default` frame via a B3 COMMIT-PLANE classification effect
+;; (EP-0025 §How it works) — a `reg-event` handler returning `:sensitive` /
+;; `:large` alongside `:db`. The effect writes the absolute runtime-db snapshot
+;; path into the per-frame `[:rf.runtime/elision]` registry (tagged
+;; `:source :effect`), the SAME slot the `:rf.egress/ssr-hydration` egress walk
+;; reads — value-independent, read only at egress. This is the post-purge app-db
+;; classification mechanism (the imperative `marks/add-marks` API was retired by
+;; the EP-0025 B1b purge).
+
+(def ^:private classify-event :rf.ssr-machine/classify-snapshot)
+
+(defn- reg-classify-event! []
+  (rf/reg-event classify-event
+    (fn [_ _]
+      ;; No `:db` change — classification is value-independent; we mark the
+      ;; absolute runtime-db snapshot paths BEFORE the projection reads them.
+      {:sensitive [[:rf.runtime/machines :snapshots auth-id :data :token]]
+       :large     [[:rf.runtime/machines :snapshots auth-id :data :blob]]})))
+
 (defn- declare-frame-marks!
-  "Declare the machine snapshot's `:data` token slot SENSITIVE and blob slot
-  LARGE on the ambient `:rf/default` frame (the frame-owned classification, the
-  sole app-db mechanism) by its absolute runtime-db snapshot path."
+  "Classify the machine snapshot's `:data` token slot SENSITIVE and blob slot
+  LARGE on the ambient `:rf/default` frame by its absolute runtime-db snapshot
+  path, through a B3 commit-plane classification effect (the post-purge
+  frame-owned app-db mechanism)."
   []
-  (marks/add-marks :rf/default
-    {[:rf.runtime/machines :snapshots auth-id :data :token] :sensitive
-     [:rf.runtime/machines :snapshots auth-id :data :blob]  :large}))
+  (reg-classify-event!)
+  (rf/dispatch-sync [classify-event]))
 
 (defn- runtime-db-with-secret-snapshot
   "A runtime-db carrying ONE durable machine snapshot whose `:data` holds a

--- a/implementation/ssr/test/re_frame/ssr_streaming_hydration_egress_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_hydration_egress_test.clj
@@ -29,12 +29,22 @@
 
 (defn- reg-sensitive-server-frame!
   "Register a server frame whose classification marks [:session :token]
-  sensitive and seed its app-db with a sensitive child + public siblings."
+  sensitive and seed its app-db with a sensitive child + public siblings.
+
+  EP-0025 B4-ssr follow-on (rf2-ux7983): the durable `:session :token` app-db
+  path is classified through the post-purge mechanism — a B3 COMMIT-PLANE
+  `:sensitive` effect returned by the frame's init event alongside `:db`
+  (EP-0025 §How it works / §Examples). The effect writes the path into the
+  per-frame `[:rf.runtime/elision]` registry the `:rf.egress/ssr-hydration`
+  egress walk reads, replacing the retired `reg-frame :sensitive {:app-db}`
+  durable annotation (deleted by the EP-0025 B1b purge)."
   [db]
-  (rf/reg-event :rf.uc3cs4/seed (fn [{d :db} [_ v]] {:db v}))
+  (rf/reg-event :rf.uc3cs4/seed
+    (fn [_ [_ v]]
+      {:db        v
+       :sensitive [[:session :token]]}))
   (rf/reg-frame sframe
-    {:platform  :server
-     :sensitive {:app-db [[:session :token]]}
+    {:platform       :server
      :initial-events [[:rf.uc3cs4/seed db]]}))
 
 ;; ---- project-delta: allowlist + projection on the streaming delta ---------


### PR DESCRIPTION
## Summary

EP-0025 B4-ssr follow-on (rf2-ux7983). B4 (#4867) made `project-egress` read the per-frame classification registry as the single source and repointed story-mcp + re-frame2-pair off the value-match free fn `redact-derived-slots` onto the `:rf.observe/derived-tree` record kind; **SSR was DEFERRED** because rf2-7ae2to was rewriting the ssr-ring runtime in parallel (now merged, #4865). This PR repoints the SSR egress consumer onto the post-purge classification mechanism.

### Finding: the SSR egress SOURCE was already on `project-egress`

The SSR-mediated egress paths were already repointed onto `project-egress` in rf2-bt9kct / rf2-uc3cs4 (pre-B4), and are already aligned with the path-based **post-purge contract** (the B1b purge rf2-j3jlgu removes the value-match engine + the `project-egress` derived-tree delegation):

- hydration / streaming app-db slice → `payload-policy/project-app-db-egress` → `project-egress` under `:rf.egress/ssr-hydration` (allowlist-first, defense-in-depth);
- streaming per-subtree deltas → `streaming/project-delta` → same boundary;
- the `:rf/hydrate` rejection always-on record → `project-egress` (off-box-observability) in `hydrate/emit-rejected-hydration!`;
- SSR error-emit union records → core's `route-error-record!` → `project-egress`.

**None** of the SSR source uses the value-match `redact-derived-slots` engine the purge removes. So the SSR source needs no change — it reads the registry generically (frame- / marks- / effect-sourced declarations all unioned), agnostic to *how* a path was classified.

### What B4 deferred: the consumer tests' classification mechanism

The SSR egress **consumer tests** declared app-db classification via mechanisms the B1b purge **deletes**: the imperative `marks/add-marks` API and the `reg-frame :sensitive {:app-db}` durable annotation. Repointed onto the **surviving B3 commit-plane `:sensitive` / `:large` effect** (a `reg-event` handler returns it alongside `:db`; EP-0025 §How it works / §Examples), which writes the path into the **same** per-frame `[:rf.runtime/elision]` registry the `:rf.egress/ssr-hydration` egress walk reads:

| Test | Was | Now |
|---|---|---|
| `ssr/ssr_machine_snapshot_projection_test` | `marks/add-marks` | init-event commit-plane `:sensitive`/`:large` effect on the absolute runtime-db snapshot path |
| `ssr/ssr_streaming_hydration_egress_test` | `reg-frame :sensitive {:app-db}` | `:sensitive` effect in the frame's seed init-event |
| `ssr/ssr_hydration_test` (B5 always-on leg) | `make-anon-frame-record! :sensitive {:app-db}` | `:sensitive` effect via `:initial-events` |
| `ssr-ring/app_db_egress_projection_test` | `reg-frame :sensitive {:app-db}` | `:sensitive` effect via `:initial-events` |

Each test still asserts the SSR egress path redacts/elides the classified path — now proving redaction via a **B3 commit-plane effect** (the bead's acceptance criterion), through the SAME registry/path-based `project-egress` boundary B4's consumers use.

`projection.cljc` **NOT touched** (B4 + the purge own it — SSR calls it, does not change it).

### Out of scope (flagged for the purge / resources beads)

- `ssr/framework_zero_ownership_diagnostics_test.clj` directly tests `frame-classification/install!` (the very function purge item 4 deletes) — the purge owns that test's fate.
- `ssr-ring/resource_payload_projection_test.clj` uses `reg-frame :sensitive {:app-db}` but its premise is **resource derived-sensitivity inheritance** (`{:from-db}`), which the purge removes ("all sensitivity propagation") and which lives in `implementation/resources/` (out of ssr/ssr-ring scope). Repointing the annotation alone would not save it.

## Quality gates

- `implementation/ssr` JVM (`clojure -M:test`): **359 tests, 1448 assertions, 0 failures, 0 errors** — green.
- `implementation/ssr-ring` JVM (`clojure -M:test`): **157 tests, 724 assertions, 0 failures, 0 errors** — green.
- `npm run test:cljs` (node-runtime): **7962 tests, 36619 assertions, 0 failures, 0 errors** — green. (node_modules junctioned from the mayor tree for the run, then removed; mayor node_modules intact.)

CI is the merge gate.

Refs: rf2-ux7983
