### PR TITLE
fix(testbeds+adapters): EP-0027 complete :on-create fleet migration (rf2-7u1wwn)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -134,8 +134,8 @@
   throws rather than synthesising `:rf/default` (Spec 002 §Frame target
   resolution). A non-nil but non-keyword `:frame` emits the distinct
   `:rf.error/bad-frame-provider-arg` and throws (rf2-9kpigo). A
-  frame-CONSTRUCTION / lifecycle opt (`:id` / `:images` / `:initial-db` /
-  `:on-create` / …) is a MISUSE: the owned-frame core emits + throws
+  frame-CONSTRUCTION / lifecycle opt (`:id` / `:images` / `:initial-events`
+  / …) is a MISUSE: the owned-frame core emits + throws
   `:rf.error/frame-provider-existing-lifecycle-opt` pointing the caller at
   the OWNED `frame-provider`, because a scope-only provider neither creates
   nor owns a frame.

--- a/implementation/adapters/reagent-slim/DESIGN-RATIONALE.md
+++ b/implementation/adapters/reagent-slim/DESIGN-RATIONALE.md
@@ -60,7 +60,7 @@ Massive. Every dropped surface drops source code, transitively-required modules,
 
 ### Re-frame2-fit impact
 
-Several of the dropped surfaces have direct re-frame2 idiomatic replacements that are usually better. `cursor` collapses into a layer-2 sub. `with-let`'s setup-and-teardown maps onto `:on-create`/`:on-destroy` events on a registered view. `track` is what subs are. `next-tick` overlaps re-frame2's own scheduling primitives. Apps using these surfaces are not stranded — they migrate to re-frame2 idiom and usually end up with cleaner code.
+Several of the dropped surfaces have direct re-frame2 idiomatic replacements that are usually better. `cursor` collapses into a layer-2 sub. `with-let`'s setup-and-teardown maps onto `:initial-events` / `:on-destroy` events on a registered view. `track` is what subs are. `next-tick` overlaps re-frame2's own scheduling primitives. Apps using these surfaces are not stranded — they migrate to re-frame2 idiom and usually end up with cleaner code.
 
 ### Migration note
 

--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -172,7 +172,7 @@ re-frame2's reactive substrate already gates render at the subscription level
 component is re-rendering too often, the diagnosis is usually "your sub is
 firing too often," not "this component needs a manual gate."
 
-### `:get-initial-state` → outer-fn Form-2 closure, or `:on-create` event
+### `:get-initial-state` → outer-fn Form-2 closure, or `:initial-events`
 
 `getInitialState` (a Reagent shim over React's pre-hooks pattern) returned the
 initial value of `this`'s state atom. Two replacements:
@@ -184,11 +184,11 @@ initial value of `this`'s state atom. Two replacements:
     (fn render [_]
       [:button {:on-click #(swap! count inc)} @count])))
 
-;; :on-create on the surrounding frame — for app-state init
-(rf/reg-frame :feature/counter {:on-create [:counter/initialise]})
+;; :initial-events on the surrounding frame — for app-state init
+(rf/reg-frame :feature/counter {:initial-events [[:counter/initialise]]})
 ```
 
-The frame `:on-create` path is preferred when the state belongs to app-db (the
+The frame `:initial-events` path is preferred when the state belongs to app-db (the
 event is named, registered, queryable, and visible in the trace stream). The
 Form-2 closure path is appropriate when the state is genuinely view-local
 (component instance lifetime, never read elsewhere).
@@ -458,7 +458,7 @@ Form-3 is the right tool for **imperative DOM library integration**. For
 everything else, prefer the re-frame2 idioms — they are simpler, named,
 and visible in the trace stream.
 
-### Use frame `:on-create` / `:on-destroy`, not Form-3, for app-state side effects
+### Use frame `:initial-events` / `:on-destroy`, not Form-3, for app-state side effects
 
 If a "mount-time" effect updates app-db (load data, register a listener that
 dispatches events, etc.), put it on the surrounding frame, not in a Form-3
@@ -471,7 +471,7 @@ dispatches events, etc.), put it on the surrounding frame, not in a Form-3
    :reagent-render      ...})
 
 ;; Right — frame-level init event
-(rf/reg-frame :counter-frame {:on-create [:counter/initialise]})
+(rf/reg-frame :counter-frame {:initial-events [[:counter/initialise]]})
 ```
 
 The frame event is named, registered, queryable, traceable in re-frame-10x,
@@ -528,7 +528,7 @@ event handler triggered by whatever changes the data, not in the view at all.
 | Need | Tool |
 |---|---|
 | Wrap an imperative JS library | **Form-3** with the 5-part shape from §4 |
-| Mount-time app-state side effect | Frame `:on-create` event |
+| Mount-time app-state side effect | Frame `:initial-events` |
 | DOM element handle for an event handler | `:ref` callback on Form-1 |
 | React to data changes | Subscription inside Form-1 |
 | Error boundary | **Form-3** with `:component-did-catch` (no substitute exists) |

--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -604,7 +604,7 @@ Any other key throws `:rf.error/create-class-key-unsupported` at `create-class` 
            :reason          (str "create-class accepts a 7-key cap. "
                                  "Unsupported: " (pr-str unsupported) ". "
                                  "Migrate to the supported keys, restructure "
-                                 "via :on-create / :on-destroy events, or "
+                                 "via :initial-events / :on-destroy events, or "
                                  "switch to the bridge adapter day8/re-frame2-reagent.")
            :keys            (vec unsupported)
            :supported-keys  supported})))
@@ -641,7 +641,7 @@ The CLJS implementation uses `goog.object/extend` + `js/Object.assign` to attach
 
 ### §6.5 `:component-did-catch` integration
 
-This is THE one cap key that re-frame2's `:on-create`/`:on-destroy` events cannot replace — there is no Form-1 alternative for an error boundary, because React's error-boundary contract requires a class component (function components do NOT support `componentDidCatch`). Test coverage critical (per the bead description).
+This is THE one cap key that re-frame2's `:initial-events` / `:on-destroy` events cannot replace — there is no Form-1 alternative for an error boundary, because React's error-boundary contract requires a class component (function components do NOT support `componentDidCatch`). Test coverage critical (per the bead description).
 
 Stage 4 ships these tests:
 1. `error-boundary-catches-render-error`: a child component throws in render; the boundary's `:component-did-catch` fires with `(error, info)`; the boundary re-renders a fallback.
@@ -1145,7 +1145,7 @@ The dropped surfaces (§2.2 list) were audit-confirmed zero-usage across re-com 
 
 | Dropped surface | Migration |
 |---|---|
-| `r/with-let` | Re-frame2: register a `reg-event`-shaped `:on-create` handler; clean up via `:on-destroy`. Reagent-classic: keep using `with-let`. |
+| `r/with-let` | Re-frame2: seed setup via `:initial-events` (a `reg-event`-shaped handler); clean up via `:on-destroy`. Reagent-classic: keep using `with-let`. |
 | `r/cursor` | Re-frame2: define a layer-2 sub. Reagent-classic: keep using `cursor`. |
 | `r/track`, `r/track!` | Re-frame2: define a `reg-sub`. Reagent-classic: keep using `track` / `track!`. |
 | `r/wrap` | Already deprecated in stock Reagent. Re-frame2: dispatch a `reg-event` from the on-change callback. Reagent-classic: keep using `wrap`. |

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -142,7 +142,7 @@
       (let [reason (str "create-class accepts a 7-key cap. "
                         "Unsupported: " (pr-str unsupported) ". "
                         "Migrate to the supported keys, restructure "
-                        "via :on-create / :on-destroy events, or "
+                        "via :initial-events / :on-destroy events, or "
                         "switch to the bridge adapter day8/re-frame2-reagent.")]
         (throw
           (ex-info (str reason " [:rf.error/create-class-key-unsupported]")

--- a/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
@@ -133,7 +133,7 @@
   (test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): each test spins its OWN top-level frame via
     ;; `make-frame` (inside `with-new-frame`); opt out of the ambient
-    ;; `:rf/default` scope so the new frame's `:on-create` drains
+    ;; `:rf/default` scope so the new frame's `:initial-events` drain
     ;; synchronously (top-level boot) rather than being treated as a
     ;; mid-cascade child-frame creation. In-body dispatches run inside the
     ;; `with-new-frame` scope, so they do not rely on the ambient frame.
@@ -146,7 +146,7 @@
 
 ;; EP-0002 (rf2-9o48ih): these tests model a TOP-LEVEL boot. The fixture
 ;; above opts out of the ambient `:rf/default` scope (`:ambient-frame nil`)
-;; so each `make-frame`'s `:on-create` drains synchronously (rather than
+;; so each `make-frame`'s `:initial-events` drain synchronously (rather than
 ;; being treated as a mid-cascade child-frame creation, rf2-cufbh) and the
 ;; post-boot state is observable, as a real top-level `make-frame` boot is.
 
@@ -158,7 +158,7 @@
                          {:initial-events [[:boot/initialise]]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-success}})]
-      ;; The :on-create cofx fires :boot/initialise during make-frame,
+      ;; The :initial-events dispatch :boot/initialise during make-frame,
       ;; which dispatches [:app/boot [:rf.machine/start]]. The synchronous
       ;; drain runs all four canned-success stubs to completion.
       (let [db    (rf/frame-state-value f)

--- a/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
@@ -38,7 +38,7 @@
   (test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): each test spins its OWN top-level frame via
     ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
-    ;; frame's `:on-create` drains synchronously (top-level boot) rather than
+    ;; frame's `:initial-events` drain synchronously (top-level boot) rather than
     ;; being treated as a mid-cascade child-frame creation.
     {:adapter       reagent-adapter/adapter
      :ambient-frame nil}))
@@ -60,8 +60,8 @@
   (get-in (rf/frame-state-value frame) [:rf.db/runtime :rf.runtime/machines :spawned :work/flow [:working]]))
 
 (defn- new-frame
-  "Spin up a fresh test frame. We dispatch :work/flow [:reset] inside the
-   :on-create rather than going through the :app/initialise fanout so the
+  "Spin up a fresh test frame. We dispatch :work/flow [:reset] via
+   :initial-events rather than going through the :app/initialise fanout so the
    test ns doesn't transitively depend on long-running-work.core (which
    pulls in Reagent's DOM-only namespaces and a defonce root-creation).
    Both reach the same end-state: parent machine at :idle with cleared

--- a/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
@@ -51,7 +51,7 @@
   (test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): each test spins its OWN top-level frame via
     ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
-    ;; frame's `:on-create` drains synchronously (top-level boot) rather than
+    ;; frame's `:initial-events` drain synchronously (top-level boot) rather than
     ;; being treated as a mid-cascade child-frame creation.
     {:adapter       reagent-adapter/adapter
      :ambient-frame nil}))

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -103,7 +103,7 @@
   (test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): each helper spins its OWN top-level frame via
     ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
-    ;; frame's `:on-create` drains synchronously (top-level boot) rather than
+    ;; frame's `:initial-events` drain synchronously (top-level boot) rather than
     ;; being treated as a mid-cascade child-frame creation. In-body dispatches
     ;; carry explicit `{:frame f}` or run inside the `with-new-frame` scope.
     {:adapter       reagent-adapter/adapter
@@ -127,7 +127,7 @@
     ;; `:auth.session/token` coeffect — its value rides the dispatch token,
     ;; supplied here exactly as `realworld.core/run` supplies it at the boundary
     ;; (node-side localStorage is absent, so the token is nil). Dispatched
-    ;; explicitly (not via `:on-create`, which does not forward `:rf.cofx`).
+    ;; explicitly (rather than via `:initial-events`).
     (rf/dispatch-sync [:auth/initialise]
                       {:frame f :rf.cofx {:auth.session/token nil}})
     (is (= :idle (rf/compute-sub [:auth/state] (rf/frame-state-value f))))

--- a/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
@@ -59,7 +59,7 @@
   (test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): the test spins its OWN top-level frame via
     ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
-    ;; frame's `:on-create` drains synchronously (top-level boot) rather than
+    ;; frame's `:initial-events` drain synchronously (top-level boot) rather than
     ;; being treated as a mid-cascade child-frame creation.
     {:adapter       reagent-adapter/adapter
      :ambient-frame nil}))
@@ -76,8 +76,8 @@
     ;; the boot dispatch token's :rf.cofx. EP-0017 (rf2-16ck78):
     ;; :todo.storage/todos is now a RECORDABLE+PROVIDED coeffect, so its value
     ;; must ride the token (absent → :rf.error/missing-required-cofx). The boot
-    ;; dispatch is issued explicitly here (not via :on-create, which does not
-    ;; forward :rf.cofx) carrying the empty-localStorage / first-run value: an
+    ;; dispatch is issued explicitly here (rather than via :initial-events)
+    ;; carrying the empty-localStorage / first-run value: an
     ;; empty sorted-map, exactly what the node-side boundary read yields.
     (with-new-frame [f (frame/make-anon-frame-record!
                          {:fx-overrides {:todo.storage/save :rf/no-op}})]

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -132,8 +132,8 @@
   throws rather than synthesising `:rf/default` (Spec 002 §Frame target
   resolution). A non-nil but non-keyword `:frame` emits the distinct
   `:rf.error/bad-frame-provider-arg` and throws (rf2-9kpigo). A
-  frame-CONSTRUCTION / lifecycle opt (`:id` / `:images` / `:initial-db` /
-  `:on-create` / …) is a MISUSE: the owned-frame core emits + throws
+  frame-CONSTRUCTION / lifecycle opt (`:id` / `:images` / `:initial-events`
+  / …) is a MISUSE: the owned-frame core emits + throws
   `:rf.error/frame-provider-existing-lifecycle-opt` pointing the caller at
   the OWNED `frame-provider`, because a scope-only provider neither creates
   nor owns a frame.

--- a/testbeds/drain_depth_trigger/core.cljs
+++ b/testbeds/drain_depth_trigger/core.cljs
@@ -117,7 +117,7 @@
 ;;
 ;; Re-registering the default frame with a new `:drain-depth` updates the
 ;; ceiling on subsequent drains (per [spec/002 §Surgical update]). The
-;; `:on-create` event is NOT re-fired on a surgical update — only the
+;; `:initial-events` are NOT re-dispatched on a surgical update — only the
 ;; depth ceiling changes — so `:depth-reached` survives across edits.
 
 (rf/reg-event ::set-drain-depth

--- a/testbeds/multi_frame/core.cljs
+++ b/testbeds/multi_frame/core.cljs
@@ -204,14 +204,14 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  ;; Register the three frames before any dispatch. `:on-create`
+  ;; Register the three frames before any dispatch. `:initial-events`
   ;; seeds each frame's app-db via the corresponding init handler;
-  ;; the framework runs each frame's `:on-create` against that
-  ;; frame's empty app-db, so the same init handler can be shared
-  ;; across both counter frames.
-  (rf/reg-frame frame-a   {:on-create [::counter-init]})
-  (rf/reg-frame frame-b   {:on-create [::counter-init]})
-  (rf/reg-frame frame-log {:on-create [::log-init]})
+  ;; the framework dispatches each frame's setup events synchronously
+  ;; against that frame's empty app-db, so the same init handler can be
+  ;; shared across both counter frames.
+  (rf/reg-frame frame-a   {:initial-events [[::counter-init]]})
+  (rf/reg-frame frame-b   {:initial-events [[::counter-init]]})
+  (rf/reg-frame frame-log {:initial-events [[::log-init]]})
   ;; EP-0002 (rf2-9o48ih): `root` is a `reg-view`, so its wrapper resolves
   ;; a frame at render time for its injected bindings — it must render
   ;; under a provider. Use a neutral SHELL frame (`:rf/default`) as the

--- a/testbeds/ssr_multi_frame/core.cljs
+++ b/testbeds/ssr_multi_frame/core.cljs
@@ -177,12 +177,12 @@
   (rf/init! reagent-adapter/adapter)
 
   ;; Register the three frames with their initialisers. Each has its
-  ;; own :on-create, but :rf/hydrate (dispatched below) will REPLACE
+  ;; own :initial-events, but :rf/hydrate (dispatched below) will REPLACE
   ;; the resulting app-db with the per-frame payload slice (locked
   ;; :replace-app-db policy).
-  (rf/reg-frame frame-a   {:on-create [::counter-init]})
-  (rf/reg-frame frame-b   {:on-create [::counter-init]})
-  (rf/reg-frame frame-log {:on-create [::log-init]})
+  (rf/reg-frame frame-a   {:initial-events [[::counter-init]]})
+  (rf/reg-frame frame-b   {:initial-events [[::counter-init]]})
+  (rf/reg-frame frame-log {:initial-events [[::log-init]]})
 
   (let [payload (read-server-payload)
         ;; payload shape:


### PR DESCRIPTION
Completes the EP-0027 `:on-create` retirement fleet migration for the surfaces #4865 missed: the **top-level `testbeds/` dir** and the **adapter docs/tests**. LIVE `reg-frame {:on-create [...]}` usages fail loud under EP-0027 (`:rf.error/on-create-retired`), which had reddened the `xray-feature-gate`.

## What changed

**`testbeds/` (live reg-frame opts + comments)**
- `multi_frame/core.cljs` — `reg-frame {:on-create [e]}` → `{:initial-events [[e]]}` (×3 frames) + comment.
- `ssr_multi_frame/core.cljs` — same migration (×3); preserves the `:rf/hydrate` REPLACES-init comment intent.
- `drain_depth_trigger/core.cljs` — comment-only wording → `:initial-events`.

**`implementation/adapters/`** — audit found **no live `reg-frame`/`make-frame`/`frame-provider` `:on-create` opts** in `reagent/test`, `helix/src`, `uix/src`. The hits were comments, docstrings, and one runtime error string:
- `reagent/test/*` — stale lifecycle-drain comments `:on-create` → `:initial-events`. The two cofx-forwarding rationales (todomvc, realworld) were reworded rather than blind-renamed, since `:initial-events` map-form *does* forward `:rf.cofx` (the old `:on-create` did not).
- `helix/src`, `uix/src` — `frame-provider-existing` rejection docstrings now lead with `:initial-events` (aligned to core's own `reject-lifecycle-opts!` docstring; the retired keys are still rejected by the kept `lifecycle-opt-keys` set in core).
- `reagent-slim/src/.../component.cljs` — `create-class` unsupported-key error string `:on-create` → `:initial-events` (kept `:on-destroy` — not retired by EP-0027).
- `reagent-slim/{FORM-3,IMPL-SPEC,DESIGN-RATIONALE}.md` — `with-let`/Form-3 migration guidance: setup → `:initial-events`, teardown stays `:on-destroy`.

**Sanctioned `:on-create` sites left untouched:** core rejection code + `on-create-retired` diagnostic, `spec/009` + `spec/011`, `docs/EP/*`, and the `ssr-ring` handler-construction `:on-create` opt (a separate retained SSR API).

`git grep ':on-create'` over `testbeds/` + `implementation/adapters/` is now **empty**.

## Scope boundary / follow-up

This bead is scope-boxed to `testbeds/` + adapters and may not touch `tools/`. The fleet migration was more incomplete than rf2-7u1wwn realized: the gate is **still red on `tools/xray/testbeds/machine_epochs/core.cljs:630`** (a LIVE `reg-frame :on-create`), plus `tools/story` + `implementation/{core,flows,http,schemas,ssr,ssr-ring,epoch}` + `docs/` comment/docstring residue. Filed **rf2-dlzufg (P1)** with the full inventory and the `tools/xray/spec/*` hot-zone note.

## Quality gates

Run from `implementation/` (node_modules junctioned from the mayor tree for the run, then `cmd /c rmdir`-removed — mayor tree intact):

- `npm run test:cljs` — **GREEN** (7962 tests, 36619 assertions, 0 failures, 0 errors).
- `npm run test:adapter-smokes` — **GREEN** (3 specs, 0 failures; helix/uix docstring + reagent-slim changes compile clean).
- `npm run test:xray-feature-gate` — **14/15 PASS**. The rf2-7u1wwn-fixed `testbeds/multi-frame` (`multi-frame isolation substrate`) now **PASSES**. The single remaining FAIL is `machine-epochs`, blocked by the out-of-scope `tools/xray/testbeds/machine_epochs` `:on-create` — tracked in **rf2-dlzufg**. CI is the merge gate.