### PR TITLE
docs+test: document positional-arg payload egress limitation as known fail-open (rf2-5n2clp option a)

### DIFF
--- a/docs/guide/how-to/keep-secrets-out-of-traces.md
+++ b/docs/guide/how-to/keep-secrets-out-of-traces.md
@@ -76,9 +76,11 @@ Values that flow *through* the cascade — event args, fx/cofx values, a subscri
 
 The handler body sees `password` verbatim, because handlers need real values to do their work. Only the *observable shadow* is projected: the dispatched-event trace and the HTTP record ship `:password` as `:rf/redacted`. Paths index into the registration's primary shape — the event arg-map, the fx-input map, the sub output; an empty path `[[]]` marks the whole shape, and a mark at a missing slot is a silent no-op (payload shapes evolve).
 
-!!! tip "Prefer the map payload for sensitive args — positional args are not path-addressable"
+!!! warning "Positional args are not path-addressable — a secret in one egresses RAW"
 
-    A path like `[:password]` reaches into the event's **arg-map** (`[:auth/sign-in {:password "…"}]`). A positionally-passed secret (`[:auth/sign-in "alice" "hunter2"]`) has no stable named path to classify, so the registration mark can't name it cleanly. When an event carries a secret, pass a map payload and classify the key.
+    A path like `[:password]` reaches into the event's **arg-map** (`[:auth/sign-in {:password "…"}]`), so the registration mark can name it. A positionally-passed secret (`[:auth/sign-in "alice" "hunter2"]`) has **no** stable named path: a positional index is not path-addressable, so there is nothing for `:sensitive` to classify. Under the fail-open contract that means the secret is **not redacted at egress** — it ships RAW into every trace and error sink (the dispatched-event trace, `:event/db-changed`, and the `:event` slot of a `:rf.error/handler-exception` record). This is a known structural limitation, not a bug: redaction is path-based, and only the arg-map (`(second event)`) is reachable by a path.
+
+    **When an event carries a secret, pass a map payload and classify the key** — `[:auth/sign-in {:user "alice" :token "hunter2"}]` with `{:sensitive [[:token]]}` on the registration. The positional form is fine for non-sensitive args; reserve it for data you would not mind seeing in a trace.
 
 The `:auth/signed-in` handler then stores the response token at `[:auth :token]` — the path step 1 classified. Note the boundary of fail-open: the **HTTP reply** is redacted by its `:decode` schema (a transient payload), and the **durable copy** in app-db is redacted by step 1's path classification. Those are two separate declarations for the same secret on two different surfaces; there is no propagation that carries one to the other. Classify each surface the secret crosses.
 

--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -271,7 +271,17 @@
 (defn- redact-event-vec
   "Redact a `[event-id arg-map]` vector. Classification paths index into the
   arg-map (the second element). Per Spec 015 §Event handlers — paths are rooted
-  at the arg-map; whole-arg substitution uses `[[]]`."
+  at the arg-map; whole-arg substitution uses `[[]]`.
+
+  SECURITY-RELEVANT — POSITIONAL ARGS EGRESS RAW. Only `(second event)` (the
+  arg-map) is path-redactable; the remaining positional args are spread through
+  unchanged. A secret carried in a POSITIONAL event arg — e.g.
+  `[:auth/login \"user\" \"secret-token\"]` — has no declarable `:sensitive`
+  path (a positional index is not path-addressable), so it passes through RAW
+  into every trace and error sink. This is a KNOWN STRUCTURAL LIMITATION of the
+  fail-open EP-0025 model (unclassified ⇒ ships raw), not a bug. PREFER THE MAP
+  PAYLOAD FORM for sensitive args — `[:auth/login {:token \"…\"}]` — then
+  classify the path so it redacts at egress."
   [event sensitive-paths large-paths]
   (cond
     (or (nil? event) (not (vector? event))) event

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -134,7 +134,19 @@
 
 (defn redact-event
   "Redact the given payload paths in a conventional event vector.
-  Non-map payload shapes pass through unchanged."
+
+  Only the map payload form `[id {…} …]` is path-redactable: path-based
+  redaction is map-key oriented, and only `(second event)` is scrubbed.
+
+  SECURITY-RELEVANT — POSITIONAL ARGS EGRESS RAW. A secret carried in a
+  POSITIONAL event arg — e.g. `[:auth/login \"user\" \"secret-token\"]` —
+  is NOT redactable here and passes through unchanged into every trace and
+  error sink (`:event/*`, `:event/db-changed`, `:rf.error/handler-exception`).
+  A positional index has no declarable `:sensitive` path, so the fail-open
+  EP-0025 model (unclassified ⇒ ships raw) cannot reach it. This is a KNOWN
+  STRUCTURAL LIMITATION, not a bug. PREFER THE MAP PAYLOAD FORM for events
+  carrying sensitive args — `[:auth/login {:user \"user\" :token \"…\"}]` —
+  then classify the `:token` path so it redacts at egress."
   [event paths]
   (if (and (vector? event)
            (>= (count event) 2)

--- a/implementation/security/test/re_frame/security/classification_fail_open_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/classification_fail_open_security_cljs_test.cljc
@@ -128,3 +128,50 @@
       (is (= secret (get-in wire [:auth :token]))
           "the unclassified path ships raw — fail-open on omission")
       (is (contains-secret? wire)))))
+
+;; ---------------------------------------------------------------------------
+;; 4. A secret in a POSITIONAL EVENT ARG ships RAW through `redact-event`
+;;    (the event-payload egress edge of the SAME fail-open contract — rf2-5n2clp
+;;    option (a): document + test the limitation as KNOWN, EXPECTED behavior).
+;; ---------------------------------------------------------------------------
+;;
+;; `privacy/redact-event` is the path-based event-vector redactor that feeds
+;; `:rf/redacted-event` → every `:event/*` trace, `:event/db-changed`, and the
+;; `:event` slot of a `:rf.error/handler-exception` record. It is map-key
+;; oriented: only `(second event)` — the arg-map — is path-addressable. A
+;; positional index has NO declarable `:sensitive` path, so a secret carried in
+;; a positional arg is structurally unreachable by the redactor and egresses
+;; RAW. This is a KNOWN STRUCTURAL LIMITATION of the EP-0025 fail-open model,
+;; not a bug; the test pins it so it is VISIBLE + tested rather than a silent
+;; false sense of safety, and so a future change cannot quietly regress it.
+;; The remediation is authorial: PREFER THE MAP PAYLOAD FORM for sensitive
+;; args (the positive half, exercised below for contrast).
+
+(deftest positional-event-arg-ships-raw
+  (testing "a secret in a POSITIONAL event arg passes through redact-event
+            UNCHANGED — positional indices are not path-addressable, so the
+            path-based redactor cannot reach them (KNOWN fail-open limitation)"
+    ;; A path declared at `[:token]` indexes into the arg-map. With a positional
+    ;; payload there IS no arg-map at that slot, so redaction is a no-op and the
+    ;; secret survives RAW in the redacted event vector.
+    (let [positional-event [:auth/login "alice" secret]
+          redacted         (privacy/redact-event positional-event [[:token]])]
+      (is (= positional-event redacted)
+          "the positional-arg event passes through redact-event unchanged")
+      (is (= secret (nth redacted 2))
+          "the secret survives RAW in the positional slot — fail-open: a
+           positional index is not path-redactable")
+      (is (contains-secret? redacted)
+          "the secret egresses RAW through redact-event (the documented
+           positional-arg limitation — prefer the map payload form)")))
+
+  (testing "the MAP payload form of the same event IS path-redactable — the
+            authorial remediation: carry sensitive args in the arg-map and
+            classify the path"
+    (let [map-event [:auth/login {:user "alice" :token secret}]
+          redacted  (privacy/redact-event map-event [[:token]])]
+      (is (= privacy/redacted-sentinel (get-in redacted [1 :token]))
+          "the classified arg-map path redacts to :rf/redacted")
+      (is (not (contains-secret? redacted))
+          "no raw secret survives when the secret rides a classified arg-map
+           path — the recommended shape for sensitive args"))))

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -787,6 +787,7 @@ Why the canonical form is `[<id> <map>]`:
 - **Refactor stability.** Adding a field is one key, not a coordinated edit across every call site.
 - **Generator-amenable.** AI scaffolds (per [Construction-Prompts §CP-1](Construction-Prompts.md#cp-1-add-an-event-handler)) emit the map form; round-tripping through the spec preserves it.
 - **`unwrap` sugar.** The optional `unwrap` interceptor (per [API §Standard interceptors](API.md#standard-interceptors)) assumes this exact shape — handlers using it destructure the payload directly: `(fn [_ {:keys [...]}] ...)`.
+- **Redactable at egress.** Trace/error redaction is path-based, and a path can only address the arg-map (`(second event)`). A secret in a **positional** arg is not path-addressable, so under the fail-open EP-0025 model it ships RAW into every trace/error sink — prefer the map payload form for sensitive args, then classify the path (per [015-Data-Classification §Registration-owned transient classification](015-Data-Classification.md#registration-owned-transient-classification) and [docs/guide §keep-secrets-out-of-traces](../docs/guide/how-to/keep-secrets-out-of-traces.md)).
 
 Cross-refs: [002 §Routing — canonical call shapes table](002-Frames.md#routing-the-dispatch-envelope), [Construction-Prompts §CP-1 — Call-shape convention](Construction-Prompts.md#cp-1-add-an-event-handler), [MIGRATION §M-19](../migration/from-re-frame-v1/README.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in).
 


### PR DESCRIPTION
Implements **rf2-5n2clp option (a)** — document + test the positional-arg event-payload egress limitation as KNOWN, EXPECTED fail-open behavior. No redaction LOGIC is changed (docstrings + docs + a test only).

## The limitation (verified)

`privacy/redact-event` (and `classification/redact-event-vec`) are path-based and map-key oriented: only `(second event)` — the arg-map — is path-addressable. A secret carried in a POSITIONAL event arg — e.g. `[:auth/login "user" "secret-token"]` — has no declarable `:sensitive` path, so it passes through UNCHANGED into `:rf/redacted-event` and from there into every `:event/*` trace, `:event/db-changed`, and the `:event` slot of a `:rf.error/handler-exception` record. This is the EP-0025 fail-open model working as designed (an unclassified path ships raw); a positional-arg secret is an INSTANCE of that accepted posture — a KNOWN STRUCTURAL LIMITATION, not a bug. It was previously SILENT; this PR makes it explicit + tested.

## Changes

- **Docstrings escalated** — `redact-event` (`privacy.cljc`) and `redact-event-vec` (`classification.cljc`): the bland "passes through unchanged" note becomes a SECURITY-RELEVANT warning stating plainly that a positional-arg secret egresses RAW to every trace/error sink, with the map-payload remediation. Calm, hygiene-not-security framing, consistent with EP-0025.
- **Guide note** — `docs/guide/how-to/keep-secrets-out-of-traces.md`: the existing positional-arg tip is promoted to a warning that states the egress consequence directly (the secret ships RAW; it is *not redacted at egress*) and shows the map-payload-+-classify fix.
- **Conventions cross-ref** — `spec/Conventions.md` (canonical event-vector shape): a "Redactable at egress" bullet noting positional args are accepted by boundary validators but not path-redactable; prefer the map payload form for sensitive data, cross-linking Spec 015 + the how-to.
- **Test (pins the limitation as KNOWN)** — `classification_fail_open_security_cljs_test.cljc` gains `positional-event-arg-ships-raw`: asserts a secret in a positional arg passes through `redact-event` UNCHANGED (raw passthrough), plus a contrast case showing the MAP payload form redacts to `:rf/redacted`. Documents the limitation as expected fail-open so it is visible + tested, never silently regressed into a false sense of safety.

## Scope note

**Option (a) only** — (b) lint-escalation (flag positional-payload events on a frame declaring any `:sensitive` path) and (c) extended positional-index redaction remain an open operator decision. They are additive and reversible; doing (a) does not foreclose them.

## Quality gates

- `npm run test:cljs` — **PASS** (7953 tests / 36594 assertions, 0 failures, 0 errors). The new positional-arg test asserts RAW passthrough and is green.
- `npm run test:security` (focused security build) — **PASS** (91 tests / 657 assertions, 0 failures, 0 errors).
- `python -m mkdocs build --strict` — **PASS** (exit 0; no new warnings on the edited guide/Conventions files; pre-existing INFO relative-link notices unrelated to this change).
- `python scripts/check_doc_slugs.py` — **PASS** (exit 0).
- No redaction-logic change — function bodies untouched; only docstrings + docs + the test changed.

node_modules was junctioned from the mayor tree for the build (worktree had none); the junction will be removed before handoff.