### PR TITLE
fix(core): reset-frame! preserves image generation + adversarial reset tests (rf2-qnk02m, rf2-060di5)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2371,10 +2371,42 @@
   before): no snapshot, no replay tape, no atomicity. Because construction is
   events-only, the recorded script IS the constructed state — there is no
   separate baseline to restore. The other app-db reset verbs
-  (`reset-app-db!` / `replace-app-db!`) are unchanged."
+  (`reset-app-db!` / `replace-app-db!`) are unchanged.
+
+  IMAGE-LOADED FRAMES (EP-0024, rf2-qnk02m). A frame created via
+  `make-frame {:images …}` runs against its OWN resolved image GENERATION (the
+  `:generation` slot), and that generation is the registration namespace its
+  `:initial-events` replay resolves `(kind, id)` against. The stored `:config`
+  carries NEITHER `:images` (consumed by `make-frame` BEFORE `reg-frame` saw it)
+  NOR `:rf.frame/generation` (stripped by `new-frame-record` / the re-reg path
+  into the `:generation` slot). So a naive `(reg-frame id (:config f))` recreated
+  the frame with `:generation` nil — silently DEGRADING an image-loaded frame to
+  registrar resolution: if the image carried INLINE-ONLY registrations (present
+  only in the generation, never the global registrar), the `:initial-events`
+  replay would dispatch events whose handlers no longer resolve, and
+  `dispatch-sync` TRACES-and-recovers an unregistered handler (no throw) — leaving
+  a LIVE frame in a wrong/empty state with NO loud signal.
+
+  Reset replays against the SAME resolved frame definition, so the recreated
+  frame MUST keep the same generation. We SNAPSHOT the live `:generation` BEFORE
+  `destroy-frame!` and re-thread it through the reserved `:rf.frame/generation`
+  construction key, so `new-frame-record` seats it onto the recreated record's
+  `:generation` slot BEFORE the `:initial-events` replay runs — the replay then
+  resolves through the frame's OWN image generation exactly as the original
+  construction did. An ordinary (no-image) frame carries `:generation` nil; the
+  re-thread is a no-op there (nil ⇒ registrar resolution, byte-identical to
+  before)."
   [id]
   (when-let [f (frame id)]
-    (let [config (:config f)]
+    (let [;; Snapshot the resolved image generation BEFORE destroy so the
+          ;; recreated frame keeps the SAME image-derived registrations
+          ;; (rf2-qnk02m). nil for an ordinary configured frame — the re-thread
+          ;; is then a no-op (registrar resolution, unchanged).
+          generation (:generation f)
+          ;; Re-thread the generation via the reserved construction key only when
+          ;; present, so an ordinary frame's config is byte-identical to before.
+          config     (cond-> (:config f)
+                       (some? generation) (assoc :rf.frame/generation generation))]
       (destroy-frame! id)
       (reg-frame id config))))
 

--- a/implementation/core/test/re_frame/frame_initial_events_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_initial_events_cljs_test.cljc
@@ -13,7 +13,10 @@
     * RETIREMENT — a supplied `:on-create` / `:initial-db` fails loud
       (`:rf.error/on-create-retired` / `:rf.error/initial-db-retired`);
     * RESET — `reset-frame!` re-dispatches the recorded `:initial-events`
-      (durable frame config, best-effort, no snapshot);
+      (durable frame config, best-effort, no snapshot); repeated reset is
+      idempotent (rf2-060di5); an IMAGE-loaded frame keeps its resolved image
+      generation across reset, so an INLINE-only registration still resolves on
+      replay (rf2-qnk02m — the silent registrar-degrade guard);
     * RE-REGISTRATION — an idempotent re-`reg-frame` RE-RECORDS but does NOT
       REPLAY the setup (durable app-db preserved);
     * TEARDOWN — a setup step that THROWS at runtime tears down the partial frame
@@ -35,6 +38,7 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core         :as rf]
             [re-frame.frame        :as frame]
+            [re-frame.image        :as image]
             [re-frame.live-frame   :as lf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
@@ -284,6 +288,100 @@
     (frame/reset-frame! :reset/main)
     (is (= 1 (:n (rf/app-db-value :reset/main)))
         "reset-frame! replayed the recorded :initial-events, back to n=1")))
+
+(deftest reset-frame-repeated-reset-is-idempotent
+  (testing "rf2-060di5: reset-frame! is idempotent across repeated resets — reset
+            twice in a row equals one reset, and a reset → mutate → reset returns
+            to the recorded seed. reset is itself a destroy + re-register that
+            re-records its own :initial-events, so a regression that cleared or
+            double-applied the recorded setup during reset would pass the single-
+            reset test but fail HERE."
+    (reg-test-events!)
+    (rf/reg-frame :reset/idem
+      {:initial-events [[:test/set-db {:n 0}]
+                        [:test/inc]]})
+    (is (= 1 (:n (rf/app-db-value :reset/idem))) "construction settled to n=1")
+    ;; Mutate away, then reset TWICE in a row.
+    (rf/dispatch-sync [:test/inc] {:frame :reset/idem})
+    (rf/dispatch-sync [:test/inc] {:frame :reset/idem})
+    (is (= 3 (:n (rf/app-db-value :reset/idem))) "runtime moved it to n=3")
+    (frame/reset-frame! :reset/idem)
+    (let [after-one (:n (rf/app-db-value :reset/idem))]
+      (is (= 1 after-one) "first reset replayed the recorded setup ⇒ n=1")
+      ;; A SECOND reset with no intervening mutation must land on the SAME value —
+      ;; reset re-records its own :initial-events on each re-register, so a
+      ;; double-apply / clear regression would diverge here.
+      (frame/reset-frame! :reset/idem)
+      (is (= after-one (:n (rf/app-db-value :reset/idem)))
+          "a second reset (no intervening mutation) equals the first — idempotent"))
+    ;; reset → mutate → reset returns to the recorded seed.
+    (rf/dispatch-sync [:test/inc] {:frame :reset/idem})
+    (is (= 2 (:n (rf/app-db-value :reset/idem))) "mutated back up to n=2")
+    (frame/reset-frame! :reset/idem)
+    (is (= 1 (:n (rf/app-db-value :reset/idem)))
+        "reset → mutate → reset returns to the recorded seed (n=1) every time")))
+
+(deftest reset-frame-image-loaded-keeps-generation-inline-resolves
+  (testing "rf2-qnk02m (the test that CATCHES the bug): an IMAGE-loaded frame
+            whose image carries INLINE-only registrations — present ONLY in the
+            resolved generation, NEVER the global registrar — must keep its
+            resolved generation across reset-frame!, so the :initial-events replay
+            resolves the INLINE handlers. Before the fix, reset recreated the
+            frame from a :config with :generation stripped + :images consumed, so
+            the frame silently degraded to registrar resolution: the inline-only
+            :counter/seed handler no longer resolved, dispatch-sync TRACED-and-
+            recovered (no throw), and the replay left the frame in a wrong/empty
+            state with NO loud signal."
+    ;; A GLOBAL :counter/seed the cascade would (wrongly) run if it resolved
+    ;; through the global registrar after a generation-losing reset. It writes a
+    ;; DISTINCT marker so a degrade is unambiguous, NOT merely an empty db.
+    (rf/reg-event :counter/seed
+      (fn [_ [_ _new]] {:db {:written-by :global}}))
+    (let [img (image/image
+                {:id :reset/inline-counter
+                 :registrations
+                 ;; INLINE-only handlers — they exist ONLY in the generation, so
+                 ;; resolving them at all PROVES the generation is in force.
+                 {:reg-event [[:counter/seed {:doc "Inline seed (image-only)."}
+                               (fn [_ [_ n]] {:db {:written-by :inline :n n}})]
+                              [:counter/inc {:doc "Inline inc (image-only)."}
+                               (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))})]]}})]
+      ;; Construct the image-loaded frame. Its :initial-events seed + inc both
+      ;; resolve through the INLINE image generation (no explicit pool — inline
+      ;; descriptors are selected because the image was supplied).
+      (lf/make-frame {:id :reset/inline
+                      :images [img]
+                      :initial-events [[:counter/seed 0]
+                                       [:counter/inc]]}
+                     [])
+      ;; Sanity: construction ran the INLINE handlers (the generation is live).
+      (is (some? (frame/frame-generation :reset/inline))
+          "the frame is image-loaded — its record carries a resolved generation")
+      (let [db0 (rf/app-db-value :reset/inline)]
+        (is (= :inline (:written-by db0)) "construction ran the INLINE seed, not the global")
+        (is (= 1 (:n db0)) "the inline seed (n=0) + inline inc ⇒ n=1"))
+      ;; Mutate away from the constructed state via the INLINE inc.
+      (rf/dispatch-sync [:counter/inc] {:frame :reset/inline})
+      (rf/dispatch-sync [:counter/inc] {:frame :reset/inline})
+      (is (= 3 (:n (rf/app-db-value :reset/inline))) "runtime moved it to n=3")
+      ;; THE RESET — the recreated frame MUST keep the image generation.
+      (frame/reset-frame! :reset/inline)
+      ;; (1) the generation survived — the recreated record still carries it.
+      (is (some? (frame/frame-generation :reset/inline))
+          "(1) reset preserved the resolved image generation — the recreated frame
+           is still image-loaded, NOT degraded to a registrar-resolved frame")
+      ;; (2) the :initial-events replay resolved the INLINE handlers, not the
+      ;;     global — the load-bearing assertion that would FAIL on the bug (the
+      ;;     degraded frame would write :global, or leave db empty if the global
+      ;;     traced-and-recovered, never :inline).
+      (let [db (rf/app-db-value :reset/inline)]
+        (is (= :inline (:written-by db))
+            "(2) the replay ran the INLINE :counter/seed — the generation's
+             registration namespace, NOT the global registrar (the bug wrote
+             :global / left the frame in a wrong state with no loud signal)")
+        (is (= 1 (:n db))
+            "the inline seed (n=0) + inline inc replayed correctly ⇒ n=1 — the
+             frame returned to its constructed state through its OWN image")))))
 
 ;; ===========================================================================
 ;; 6. Re-registration — re-records but does NOT replay (durable state preserved)


### PR DESCRIPTION
## Summary

`reset-frame!` (EP-0027 §Reset) lost an image-loaded frame's resolved image **generation**. It re-registered the frame from its stored `:config`, but that config has BOTH `:images` (consumed by `make-frame` before `reg-frame` ever saw it) AND `:rf.frame/generation` (stripped into the `:generation` slot by `new-frame-record`) absent. So the recreated frame got `:generation nil` and silently **degraded to registrar resolution**.

The dangerous case: if the image carried **inline-only** registrations (present only in the generation, never the global registrar), the `:initial-events` replay dispatched events whose handlers no longer resolved — and `dispatch-sync` **traces-and-recovers** an unregistered handler (no throw). The result was a live frame in a wrong/empty state with **no loud signal**.

## Fix chosen: re-thread the resolved generation (not fail-loud)

`reset-frame!` now **snapshots the live `:generation` before `destroy-frame!`** and re-threads it through the reserved `:rf.frame/generation` construction key, so `new-frame-record` seats it onto the recreated record's `:generation` slot **before** the `:initial-events` replay runs. The replay then resolves through the frame's OWN image generation exactly as the original construction did.

This matches the EP-0027 reset contract — *reset replays `:initial-events` against the SAME resolved frame definition*. Re-resolving from `:images` (the bead's option b) is impossible here: `:images` are consumed by `make-frame` and never stored on the frame record, so the already-resolved generation is the only thing available to preserve. Fail-loud (option c) was rejected because reset on an image-loaded frame is a legitimate, well-defined operation once the generation is preserved — there is no reason to refuse it. An ordinary (no-image) frame carries `:generation nil`; the re-thread is a no-op there (registrar resolution, byte-identical to before).

## Tests added (frame_initial_events_cljs_test)

1. **`reset-frame-repeated-reset-is-idempotent`** (rf2-060di5) — reset twice in a row equals one reset; reset → mutate → reset returns to the recorded seed. Guards the double-apply / clear-recording regression class the single-reset test could not catch.
2. **`reset-frame-image-loaded-keeps-generation-inline-resolves`** (rf2-qnk02m) — the test that CATCHES the bug. An image-loaded frame whose image carries inline-only registrations, reset, then asserts (a) the recreated frame still carries a resolved generation and (b) the `:initial-events` replay resolves the INLINE handlers (writes `:inline`), not the global registrar.

**Confirmed the bug-repro test fails without the fix** (temporarily reverted `reset-frame!` to the buggy body): generation resolved to `nil`, `:written-by` was `:global` (registrar degrade), `:n` was `nil` — the exact qnk02m symptom. Restored the fix; all green.

## Quality gates

- `npm run test:cljs` — **7955 tests, 36607 assertions, 0 failures, 0 errors** (new + existing green).
- `clojure -M:test` (JVM core) — **1675 tests, 7290 assertions, 0 failures, 0 errors**.

Touched only `implementation/core` (`frame.cljc` + the core reset/construction test ns). No classification code, no spec/conformance fixtures.
