### PR TITLE
refactor(core): EP-0025 classification cleanup + source-aware clear fix (rf2-34jrb6 +4)

### DIFF
--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -197,18 +197,6 @@
   [kind id]
   (normalise-classification (registrar/handler-meta kind id)))
 
-(defn clear-classification!
-  "No-op retained for test-isolation directory symmetry — production code never
-  calls this. Returns nil.
-
-  EP-0025: the author-sourced classification lives in the registrar (rf2-ehexnw),
-  which the test-isolation runtime fixture already snapshot/restores; the
-  per-frame app-db classification lives in the frame's runtime-db elision
-  registry, reset by the same fixture's frame teardown. There is no separate
-  side-table left to clear here."
-  []
-  nil)
-
 ;; ---- emit-time projection ------------------------------------------------
 
 (defn large-marker
@@ -413,7 +401,17 @@
 (defn- frame-has-declarations?
   "True when `frame-id` carries any elision declaration (sensitive or large).
   Cheap registry read used to gate the full-db walk so the no-classification
-  common case stays reference-preserving."
+  common case stays reference-preserving.
+
+  rf2-wcvv6h: on a CLASSIFIED frame this gate re-reads the registry that the
+  downstream `elide-wire-value` walk reads again (a few extra `get-in` reads
+  per db-bearing trace event). The gate read is INTENTIONALLY kept separate
+  rather than threading pre-resolved tables into the walk: `elide-wire-value`
+  is the public egress surface whose fail-closed contract keys off `frame-id`
+  live-frame resolution (not the registry tables), so folding the tables down
+  would spread that contract across call sites for no production gain — the
+  whole projection path is dev/JVM-only (DCE-elided in production CLJS). The
+  explicit gate stays readable as-is; clarity wins over a dev-only read count."
   [frame-id]
   (boolean (or (seq (elision/sensitive-declarations frame-id))
                (seq (elision/declarations frame-id)))))
@@ -758,55 +756,60 @@
     (let [operation (:operation event)
           tags      (:tags event)
           frame-id  (:frame tags)
-          tags'     (cond-> tags
-                      (and (map? tags) (contains? tags :rf.event/v))
-                      (project-event-tags :rf.event/v)
+          ;; `tags` is shape-invariant through the threading — every per-kind
+          ;; projector returns a map, so the type never becomes non-map. Hoist
+          ;; the one `(map? tags)` guard here so each branch below reads as just
+          ;; its real per-kind predicate (the slot `contains?` / `operation =`
+          ;; test). A non-map `tags` no-ops the chain.
+          tags'     (if-not (map? tags)
+                      tags
+                      (cond-> tags
+                        (contains? tags :rf.event/v)
+                        (project-event-tags :rf.event/v)
 
-                      (and (map? tags) (contains? tags :event))
-                      (project-event-tags :event)
+                        (contains? tags :event)
+                        (project-event-tags :event)
 
-                      (and (map? tags) (= :rf.fx/handled operation))
-                      (project-fx-tags)
+                        (= :rf.fx/handled operation)
+                        (project-fx-tags)
 
-                      (and (map? tags) (contains? tags :rf.event/coeffects))
-                      (project-cofx-map-slot :rf.event/coeffects)
+                        (contains? tags :rf.event/coeffects)
+                        (project-cofx-map-slot :rf.event/coeffects)
 
-                      (and (map? tags) (contains? tags :rf.event/cofx))
-                      (project-cofx-map-slot :rf.event/cofx)
+                        (contains? tags :rf.event/cofx)
+                        (project-cofx-map-slot :rf.event/cofx)
 
-                      (and (map? tags) (contains? tags :rf.event/db))
-                      (project-db-tags frame-id)
+                        (contains? tags :rf.event/db)
+                        (project-db-tags frame-id)
 
-                      (and (map? tags) (contains? tags :rf.view/render-args))
-                      (project-view-rendered-tags frame-id)
+                        (contains? tags :rf.view/render-args)
+                        (project-view-rendered-tags frame-id)
 
-                      (and (map? tags) (or (= :rf.cofx/run operation)
-                                           (= :rf.cofx/generated operation)))
-                      (project-cofx-run-tags)
+                        (or (= :rf.cofx/run operation)
+                            (= :rf.cofx/generated operation))
+                        (project-cofx-run-tags)
 
-                      (and (map? tags) (= :rf.sub/run operation))
-                      (project-sub-tags frame-id)
+                        (= :rf.sub/run operation)
+                        (project-sub-tags frame-id)
 
-                      (and (map? tags) (machine-op? operation))
-                      (project-machine-tags frame-id)
+                        (machine-op? operation)
+                        (project-machine-tags frame-id)
 
-                      (and (map? tags)
-                           (contains? tags :rf.interceptor/override-summary))
-                      (project-override-summary-tags)
+                        (contains? tags :rf.interceptor/override-summary)
+                        (project-override-summary-tags)
 
-                      (and (map? tags) (= :rf.flow/failed operation))
-                      (project-flow-failed-tags)
+                        (= :rf.flow/failed operation)
+                        (project-flow-failed-tags)
 
-                      (and (map? tags)
-                           (not= :rf.flow/failed operation)
-                           (contains? tags :exception-data))
-                      (project-machine-error-tags frame-id)
+                        (and (not= :rf.flow/failed operation)
+                             (contains? tags :exception-data))
+                        (project-machine-error-tags frame-id)
 
-                      (and (map? tags) (contains? tags :offending-value))
-                      (project-machine-wrote-db-tags)
+                        (contains? tags :offending-value)
+                        (project-machine-wrote-db-tags)
 
-                      (and (map? tags) (resource-failure-op? operation))
-                      (project-resource-error-tags))]
+                        (resource-failure-op? operation)
+                        (project-resource-error-tags)))]
       (assoc event :tags tags'))))
 
 ;; ---- late-bind hook registration ----------------------------------------
@@ -819,4 +822,3 @@
 (late-bind/set-fn! :classification/project-trace-event project-trace-event)
 (late-bind/set-fn! :classification/redact-event-by-registration redact-event-by-registration)
 (late-bind/set-fn! :classification/registration-classification registration-classification)
-(late-bind/set-fn! :classification/clear-classification! clear-classification!)

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -300,14 +300,23 @@
 
   Each SET key (`:sensitive` / `:large`) adds `{:source :effect}` declarations
   for its paths to the axis slot (`:sensitive-declarations` / `:declarations`);
-  each CLEAR key (`:clear-sensitive` / `:clear-large`) DISSOCs its paths from
-  the axis slot. The two axes are INDEPENDENT — clearing one never touches the
-  other's slot — and clearing removes only the named paths (other-sourced
-  entries for an unnamed path survive). Within one effect map, a SET on an axis
-  applies before its own CLEAR is irrelevant (a handler returns at most one of
-  each axis's set/clear), but if both an axis SET and that axis's CLEAR name
-  the same path, the CLEAR wins (last-write per axis). An empty/absent axis
-  slot is pruned (dissoc'd) rather than left as `{}` (matching
+  each CLEAR key (`:clear-sensitive` / `:clear-large`) removes ONLY the
+  effect's OWN contribution to its paths from the axis slot. A clear is
+  SOURCE-SCOPED: it dissocs a path only when the standing entry is
+  `:source :effect` (the effect's own declaration); a path also claimed by
+  another source (`:source :flow` from a `reg-flow` output, `:source :machine`,
+  `:source :route`, or a subsystem projection declaration) is LEFT INTACT, so
+  the clear can never silently un-redact a path another owner still classifies
+  (a privacy fail-open). This mirrors `re-frame.flows.registry/drop-flow-sourced`,
+  which likewise removes only its own `:source :flow` entries. The two axes are
+  INDEPENDENT — clearing one never touches the other's slot — and clearing
+  removes only the named paths (other-sourced entries for an unnamed path
+  survive). Within one effect map, a SET on an axis applies before its own
+  CLEAR (a handler returns at most one of each axis's set/clear), so if both an
+  axis SET and that axis's CLEAR name the same path the CLEAR wins (the SET
+  stamped it `:source :effect`, so the source-scoped clear removes the
+  effect's own just-written entry). An empty/absent axis slot is pruned
+  (dissoc'd) rather than left as `{}` (matching
   `write-elision-slot`). Assumes `effects` already passed
   `validate-classification-effects!` (paths are valid concrete `:rf/path`s);
   normalizes each to its canonical vector form here so the stored decl key
@@ -332,7 +341,18 @@
                     cur     (get reg slot)
                     updated (if set?
                               (reduce (fn [m p] (assoc m p {:source :effect})) (or cur {}) paths)
-                              (apply dissoc (or cur {}) paths))]
+                              ;; SOURCE-SCOPED clear (rf2-34jrb6): remove a path
+                              ;; only when ITS standing entry is the effect's own
+                              ;; (`:source :effect`). A path also claimed by a
+                              ;; flow / machine / route / subsystem source is
+                              ;; left intact, so a clear never un-redacts a path
+                              ;; another owner still classifies (privacy fail-open).
+                              (reduce (fn [m p]
+                                        (if (= :effect (:source (get m p)))
+                                          (dissoc m p)
+                                          m))
+                                      (or cur {})
+                                      paths))]
                 (if (seq updated)
                   (assoc reg slot updated)
                   (dissoc reg slot)))))
@@ -449,11 +469,10 @@
 (defn- marker-opts
   "The `->marker` option map for a declared-`:large` node — derived from the
   matched `large-decl` (its `:hint` / `:source`) and the walk `ctx` (its
-  `:as-of-epoch` / `:include-digests?`). Single source for the BYTE-IDENTICAL
-  4-key option map the path-based walker (`walk`) and the value-match large
-  collector (`collect-large-markers!`) each pass to `->marker`.
-  Both call sites carry the same `:as-of-epoch` / `:include-digests?` keys on
-  their respective `ctx`, so the marker is identical whichever arm emits it."
+  `:as-of-epoch` / `:include-digests?`). The 4-key option map the path-based
+  wire walker (`walk-decider`) passes to `->marker`. The `:source` / `:hint`
+  stay genuinely multi-valued across the flow / effect / schema declaration
+  sources, so the lookup is real even with a single caller."
   [large-decl ctx]
   {:hint             (:hint large-decl)
    :reason           (:source large-decl)
@@ -694,31 +713,6 @@
                 (conj! acc c)))
             (transient #{})
             decl-paths)))
-
-(defn- reduce-indexed-forks
-  "Descend a POSITIONAL container `coll` (a vector OR a seq), tracking an
-  integer element index `i` from 0 and forking the candidate
-  declaration-coordinate set through that index via `fork-index-paths`. For
-  each element this threads an accumulator by calling
-  `(step acc element i forked-decl-paths)`, where `forked-decl-paths` is
-  `(fork-index-paths decl-paths i decl-prefixes)`. Returns the final `acc`.
-
-  This is the single home for the 'descend a positional container tracking an
-  integer index, forking decl-paths via fork-index-paths' micro-shape used by
-  the large-value collector (`collect-large-markers!`'s vector / seq branches).
-  The path-based wire walker forks the same shape through the shared
-  `walk-tree` skeleton's `:index` decider arm (`walk-decider`). `reduce`
-  iterates a vector in index order, so the vector and seq cases share one
-  traversal; the volatile index reproduces the per-element `(conj path i)`
-  exactly. The caller owns `acc`'s identity (a transient `[raw marker]`
-  accumulator for the collector) and what `step` does with each element."
-  [coll decl-paths decl-prefixes step acc]
-  (let [idx (volatile! -1)]
-    (reduce (fn [a x]
-              (let [i (vswap! idx inc)]
-                (step a x i (fork-index-paths decl-paths i decl-prefixes))))
-            acc
-            coll)))
 
 (defn- decl-match
   "Test the candidate declaration-coordinate set against a declaration

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -201,7 +201,7 @@
    ;; `interop/debug-enabled?` and is gated at the trace/emit! call sites, so the
    ;; late-bind hop keeps the lookup off the always-on registration path:
    ;;   :classification/registration-classification,
-   ;;   :classification/project-trace-event, :classification/clear-classification!.
+   ;;   :classification/project-trace-event.
    ;; ALWAYS-ON production survivor still reached through the indirection:
    ;;   :classification/redact-event-by-registration (the production egress redactor).
    ;; `re-frame.classification/validate-classification!` is reached by DIRECT
@@ -222,10 +222,6 @@
     :producer-ns 're-frame.classification
     :design-bead "rf2-qe6v1u"
     :description "ALWAYS-ON (NOT a DCE seam, rf2-eq7m0x — the registration classification is populated in production too; only the emit-time TRACE projection is dev-gated): apply an event handler's REGISTRATION-OWNED :sensitive / :large classification to a [event-id arg-map] vector (EP-0015 — event args are registration-owned transient payloads). Consumed by re-frame.projection for the :rf.observe/error / handled-event :event slot."}
-   {:key         :classification/clear-classification!
-    :producer-ns 're-frame.classification
-    :design-bead "rf2-vw7f5"
-    :description "No-op retained for test-isolation directory symmetry — the author classification lives in the registrar (snapshot/restored by the runtime fixture); there is no side-table to clear."}
 
    ;; ---- re-frame.frame-classification (EP-0015 §3 HTTP carriers + §9 observability) ----
    ;; `re-frame.frame/reg-frame` consults these to validate the frame-owned

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -327,11 +327,7 @@
    {:hook :epoch/clear-history!            :phase :post-dispose}
    {:hook :epoch/clear-epoch-listeners!          :phase :post-dispose}
    {:hook :epoch/reset-config!             :phase :post-dispose}
-   {:hook :adapter/clear-warn-once-caches! :phase :post-dispose}
-   ;; EP-0025 — classification is derived from the registrar (no side-table)
-   ;; and the per-frame elision registry (reset by frame teardown), so this is
-   ;; a no-op retained for directory symmetry. There is no propagation table.
-   {:hook :classification/clear-classification! :phase :post-dispose}])
+   {:hook :adapter/clear-warn-once-caches! :phase :post-dispose}])
 
 (defn- run-reset-hooks!
   "Driver: fire every `reset-hook-table` row whose `:phase` matches and

--- a/implementation/core/test/re_frame/classification_effects_cljs_test.cljc
+++ b/implementation/core/test/re_frame/classification_effects_cljs_test.cljc
@@ -182,6 +182,73 @@
         "the cleared large path is removed")))
 
 ;; ---------------------------------------------------------------------------
+;; 2b. SOURCE-SCOPED clear (rf2-34jrb6) — a clear removes only the effect's own
+;;     contribution; a path ALSO claimed by another source stays redacted
+;; ---------------------------------------------------------------------------
+
+(deftest clear-sensitive-is-source-scoped-does-not-un-redact-another-source
+  (testing ":clear-sensitive removes only the effect's OWN declaration for a
+            path; a path ALSO claimed by another source (e.g. a reg-flow output
+            under :source :flow) stays classified — the clear must not silently
+            un-redact a path another owner still considers sensitive (a privacy
+            fail-open). rf2-34jrb6."
+    ;; A flow (another source) declares [:user :token] sensitive in the SAME
+    ;; per-frame elision registry slot the effects write. reg-flow lives in a
+    ;; separate artefact, so simulate its registry write directly via the shared
+    ;; swap-elision-slot! seam (the exact slot + shape reg-flow installs:
+    ;; {:source :flow :flow-id …}).
+    (elision/swap-elision-slot! :rf/default
+      (fn [reg]
+        (assoc-in reg [:sensitive-declarations [:user :token]]
+                  {:source :flow :flow-id :token-watch})))
+    (is (= :flow (:source (get (sensitive-decls) [:user :token])))
+        "the flow-sourced declaration is standing in the registry")
+    ;; An effect ALSO classifies the same path — collapses to ONE registry entry
+    ;; per path, now stamped :source :effect (the SET is the later write).
+    (rf/reg-event :effect-classify-token
+      (fn [{:keys [db]} _]
+        {:db (assoc-in db [:user :token] "Bearer secret-xyz")
+         :sensitive [[:user :token]]}))
+    (rf/dispatch-sync [:effect-classify-token])
+    (is (= :effect (:source (get (sensitive-decls) [:user :token])))
+        "the same-path effect SET overwrote the entry to :source :effect")
+    ;; The effect now CLEARS the path. Source-scoped clear removes the effect's
+    ;; own contribution — but the path is STILL claimed by the flow, so it must
+    ;; remain classified and the value must stay REDACTED at egress.
+    ;; Re-install the flow declaration after the effect SET overwrote it (the
+    ;; collapse-to-one-entry means the flow's mark must be re-asserted; a live
+    ;; reg-flow would re-fold on its own lifecycle — here we model the standing
+    ;; flow claim).
+    (elision/swap-elision-slot! :rf/default
+      (fn [reg]
+        (assoc-in reg [:sensitive-declarations [:user :token]]
+                  {:source :flow :flow-id :token-watch})))
+    (rf/reg-event :effect-clear-token
+      (fn [{:keys [db]} _] {:db db :clear-sensitive [[:user :token]]}))
+    (rf/dispatch-sync [:effect-clear-token])
+    (is (contains? (sensitive-decls) [:user :token])
+        "the path is STILL classified — the flow's claim survives the effect clear")
+    (is (= :flow (:source (get (sensitive-decls) [:user :token])))
+        "the surviving entry is the flow's, not the effect's")
+    (let [wire (elision/elide-wire-value (frame/frame-app-db-value :rf/default))]
+      (is (= privacy/redacted-sentinel (get-in wire [:user :token]))
+          "the value stays REDACTED at egress — the clear did not un-redact it"))))
+
+(deftest clear-sensitive-removes-effect-sourced-entry-when-sole-claimant
+  (testing "when the effect is the SOLE source for a path, the source-scoped
+            clear removes it (no other-source entry shields it) — the ordinary
+            set/unset case is unchanged. rf2-34jrb6."
+    (rf/reg-event :effect-only-classify
+      (fn [{:keys [db]} _] {:db db :sensitive [[:only :effect]]}))
+    (rf/dispatch-sync [:effect-only-classify])
+    (is (= :effect (:source (get (sensitive-decls) [:only :effect]))))
+    (rf/reg-event :effect-only-clear
+      (fn [{:keys [db]} _] {:db db :clear-sensitive [[:only :effect]]}))
+    (rf/dispatch-sync [:effect-only-clear])
+    (is (not (contains? (sensitive-decls) [:only :effect]))
+        "an effect-sourced path with no other claimant is removed by its clear")))
+
+;; ---------------------------------------------------------------------------
 ;; 3. axes independent — sensitive vs large clears do not cross
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
@@ -58,7 +58,6 @@
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.frame :as frame]
-            [re-frame.classification :as classification]
             ;; The low-level plumbing helper, exercised ONLY in the labelled
             ;; narrow plumbing test below — NOT as a stand-in for the public
             ;; EP-0015 boundary.
@@ -69,11 +68,7 @@
 
 (use-fixtures :each
   (ts/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     ;; EP-0025: classification is derived from the registrar + the per-frame
-     ;; elision registry (reset by frame teardown), so this is a no-op kept for
-     ;; directory symmetry.
-     :init-fn (fn [] (classification/clear-classification!))}))
+    {:adapter plain-atom/adapter}))
 
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-PUBLIC-PROFILE-DO-NOT-SHIP")
 


### PR DESCRIPTION
Five coordinated changes on the EP-0025 classification surface (`classification` / `elision` / `late_bind/directory` / `test_support` + tests), from the cross-review. One bug fix + four cleanups; behaviour changes ONLY for the bug.

## What changed

- **rf2-34jrb6 (BUG, P3 hardening).** `:clear-sensitive` / `:clear-large` were source-blind: the clear arm of `apply-classification-effects` did `(apply dissoc cur paths)`, removing a path's whole single-entry registry record regardless of which source wrote it. A path ALSO declared by another source (a `reg-flow` output under `:source :flow`, a machine, a route, or a subsystem) was silently un-redacted → raw egress (a privacy fail-open). The clear is now **source-scoped**: it removes a path only when its standing entry is `:source :effect` (the effect's own contribution); a path another source still claims is left intact. Mirrors `re-frame.flows.registry/drop-flow-sourced`. SET-then-CLEAR-in-one-event still resolves to cleared (the SET stamps `:source :effect`, so the source-scoped clear removes its own just-written entry). Two focused tests added.

- **rf2-3xj0ng.** Deleted the no-op `clear-classification!` seam across all four coordinated sites (the fn with a `nil` body, the `set-fn!` registration, the late-bind directory row, the reset-hook-table row) plus its two test call sites. Post-EP-0025 vestigial indirection — classification is derived from the registrar + per-frame elision registry, both reset elsewhere. Zero behaviour change.

- **rf2-vyayep.** Deleted dead `reduce-indexed-forks` (zero call sites repo-wide post value-match purge; sole consumer `collect-large-markers!` was removed). Trimmed the stale "two call sites" claim in the `marker-opts` docstring to its single live caller.

- **rf2-hv2tm5.** Hoisted one `(map? tags)` guard above the `project-trace-event` `cond->` so each of the 14 branches reads as just its real per-kind predicate instead of re-testing `(and (map? tags) …)`. `tags` is shape-invariant through the threading; no behaviour change.

- **rf2-wcvv6h (OPTIONAL).** **Skipped the fold** — folding the `frame-has-declarations?` gate read into a single resolved-tables walk would spread `elide-wire-value`'s fail-closed egress contract (keyed off `frame-id` live-frame resolution, not the tables) across call sites for a dev-only read-count gain. Recorded the one-line note on `frame-has-declarations?` per the bead's "record a note" acceptance leg. No change.

## Quality gates

- **rf2-34jrb6** — `npm run test:cljs` (7955 tests / 36601 assertions, 0 fail) + JVM core (1675 / 7281, 0 fail) + JVM security (90 / 650, 0 fail); focused classification-effects ns: 12 tests / 38 assertions (2 new source-aware-clear tests).
- **rf2-3xj0ng** — `git grep clear-classification!` → ZERO references after deletion; gates green.
- **rf2-vyayep** — `git grep reduce-indexed-forks` / `collect-large-markers` → only the deleted def / a stale docstring mention before edit, none after; `fork-index-paths` + `marker-opts` confirmed still live (one caller each).
- **rf2-hv2tm5** — `npm run test:cljs` + JVM core green; no behaviour change.
- **rf2-wcvv6h** — no code change; note recorded.
- **Production elision probe** — `npm run test:elision` PASS (production 42/42 absent, control 42/42 present). The classification/projection changes stay production-DCE-elided.

CI is the merge gate.