### PR TITLE
ci(docs): extend api-doc drift-check to spec/Privacy + docs/api + docs/story/api (rf2-vzupmg)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,6 +64,15 @@ on:
       # the tools/** entry above.)
       - 'skills/**'
       - 'docs/guide/**'
+      # Human-doc API-reference projection surfaces (rf2-vzupmg): the three
+      # API-reference trees the doc-api-check scans are manifest projections
+      # too; a PR touching them must run the api-manifest job's doc-api-check
+      # so a removed/renamed public surface goes RED. (spec/Privacy.md rides
+      # the spec/ entries the classifier already lights; the push filter
+      # names it explicitly for the same reason API.md is named above.)
+      - 'spec/Privacy.md'
+      - 'docs/api/**'
+      - 'docs/story/api/**'
   # PR trigger is intentionally UNFILTERED (see REQUIRED-CHECK SHAPE
   # above). The lint surface is re-applied job-side via the `detect` job.
   pull_request:
@@ -137,6 +146,12 @@ jobs:
               # job's skills-check / doc-guide-check. A pure-skills or
               # pure-doc-guide PR must still run the drift-check.
               skills/*|docs/guide/*)
+                lint_surface=true ;;
+              # The three human-doc API-reference trees are manifest
+              # projections too (rf2-vzupmg): a removed/renamed public surface
+              # named there is caught by the api-manifest job's doc-api-check.
+              # A pure-doc PR touching them must still run the drift-check.
+              spec/Privacy.md|docs/api/*|docs/story/api/*)
                 lint_surface=true ;;
             esac
           done <<< "$files"
@@ -359,6 +374,17 @@ jobs:
       - name: Assert docs/guide/ projection matches the manifest
         working-directory: implementation/scripts/api-manifest
         run: clojure -M -m re-frame.api-manifest.doc-guide-check
+
+      # Human-doc API-reference projection drift-check (rf2-vzupmg). Extends
+      # the call-position discipline to the three human-facing API-reference
+      # trees the keystone + the checks above left uncovered:
+      # spec/Privacy.md + docs/api/** + docs/story/api/**. Goes RED on a
+      # call-position `(rf/<var>` / `(story/<var>` reference to a renamed /
+      # removed / never-manifested public surface (the EP-graduation
+      # doc-drift class that previously passed every CI check).
+      - name: Assert spec/Privacy + docs/api + docs/story/api projection matches the manifest
+        working-directory: implementation/scripts/api-manifest
+        run: clojure -M -m re-frame.api-manifest.doc-api-check
 
       # Pure-reconciler regression contracts (rf2-4v79f). The `:test` alias
       # carries the unit tests that lock the reconcilers the check-mains

--- a/docs/api/03-effects.md
+++ b/docs/api/03-effects.md
@@ -2,7 +2,7 @@
 
 The effect map is what an event handler returns. The interceptor chain is what runs before and after the handler. Together they're the load-bearing trick that makes re-frame2 a *pattern* — handlers stay pure (they return descriptions of effects, not the effects themselves), and the runtime actions those descriptions against the real world at exactly one point. That separation is why the trace bus, time-travel, and effect-overrides all work; if handlers fired effects directly, none of those would compose.
 
-This chapter covers what an `:fx` map can carry (`:db`, `:fx`, the standard fx-ids), what an interceptor is and the surface for building one (`->interceptor`), the ergonomic interceptors v2 ships (`path`, `unwrap`, the pre-built `validate-at-boundary-interceptor`), and the override surfaces that let tests and tools swap fx behaviour at runtime (`with-fx-overrides`, the per-call `:fx-overrides` opt). Coeffects are *not* delivered by an interceptor in v2 — a handler declares the world facts it needs with `:rf.cofx/requires` registration metadata and the runtime supplies them (see [01 — Core §`reg-cofx`](01-core.md#reg-cofx) and [Guide — Effects and coeffects](../guide/concepts/effects-and-coeffects.md)). v1's `inject-cofx` interceptor is removed; see [15 — Removed](15-removed.md).
+This chapter covers what an `:fx` map can carry (`:db`, `:fx`, the standard fx-ids), what an interceptor is and the public authoring surface (`reg-interceptor`), the one framework-standard interceptor reference (`[:rf.interceptor/path <path-vector>]`), the pre-built `validate-at-boundary-interceptor`, and the override surfaces that let tests and tools swap fx behaviour at runtime (`with-fx-overrides`, the per-call `:fx-overrides` opt). Coeffects are *not* delivered by an interceptor in v2 — a handler declares the world facts it needs with `:rf.cofx/requires` registration metadata and the runtime supplies them (see [01 — Core §`reg-cofx`](01-core.md#reg-cofx) and [Guide — Effects and coeffects](../guide/concepts/effects-and-coeffects.md)). v1's `inject-cofx` interceptor is removed; so are the v1 `path` / `unwrap` value constructors (see [15 — Removed](15-removed.md)).
 
 ## The effect map: closed shape
 
@@ -40,25 +40,16 @@ SSR-side server-only fx (`:rf.server/set-status`, `:rf.server/set-header`, `:rf.
 
 The interceptor chain wraps the handler. Every interceptor has a `:before` (runs before the handler) and / or `:after` (runs after the handler). The runtime threads a context map — the **ctx** — through the chain, and the chain composes deterministically. Interceptors are how you add cross-cutting behaviour (validation, focus-on-path, logging) without writing it into every handler.
 
-The v2 standard-interceptor surface is **two specific helpers** (`path`, `unwrap`) plus the pre-built `validate-at-boundary-interceptor` and the `->interceptor` primitive. The principle is: keep helpers that do specific, non-trivial work; drop helpers that are just `(->interceptor :before f)` with no other logic. Five v1 interceptors are removed (`debug`, `trim-v`, `on-changes`, `enrich`, `after`); so is `inject-cofx` — coeffect delivery is now declared with `:rf.cofx/requires`, not injected by an interceptor (see [01 — Core §`reg-cofx`](01-core.md#reg-cofx) and [15 — Removed](15-removed.md)).
+Under [EP-0022](../EP/EP-0022-registered-interceptors.md) the public interceptor-authoring surface is **`reg-interceptor`**, and event / frame `:interceptors` chains carry interceptor **references** (a bare keyword id, or `[id arg]` for a parameterised factory) — never inline interceptor values. The framework ships exactly **one** standard interceptor — `[:rf.interceptor/path <path-vector>]` — referenced, not constructed. There is **no** public `path` value constructor and **no** standard `unwrap`: the v1 `path` / `unwrap` value forms are removed (a stale `rf/path` / `rf/unwrap` call raises the always-loud `:rf.error/path-removed` / `:rf.error/unwrap-removed`); the canonical replacements are the `:rf.interceptor/path` reference and handler-payload destructuring (the map-payload form). Five v1 interceptors are also removed (`debug`, `trim-v`, `on-changes`, `enrich`, `after`); so is `inject-cofx` — coeffect delivery is now declared with `:rf.cofx/requires`, not injected by an interceptor (see [01 — Core §`reg-cofx`](01-core.md#reg-cofx) and [15 — Removed](15-removed.md)).
 
-### `path`
+### `[:rf.interceptor/path <path-vector>]`
 
-- **Kind**: function
-- **Signature**:
+- **Kind**: interceptor **reference** (the one standard interceptor; the canonical `:factory` consumer)
+- **Form**:
   ```clojure
-  (path & path)
+  {:interceptors [[:rf.interceptor/path [:cart :items]]]}
   ```
-- **Description**: Focus the handler on an `app-db` sub-slice. `:before` rewrites the `:db` cofx to `(get-in db path)`; `:after` splices the result back into the parent. The handler sees and returns a sub-tree, not the full db.
-
-### `unwrap`
-
-- **Kind**: Var (interceptor value)
-- **Signature**:
-  ```clojure
-  unwrap
-  ```
-- **Description**: Assert `[id payload-map]` event shape; replace the `:event` coeffect with just the payload map; restore on `:after`. Sugar over the canonical map-payload form (per [MIGRATION §M-19](../../migration/from-re-frame-v1/README.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in)).
+- **Description**: Focus the handler on an `app-db` sub-slice. `:before` stages the focused slice as `:db` — `(get-in db path)`; `:after` widens the returned slice back into full app-db. The handler sees and returns a sub-tree, not the full db. Preserves the frame-commit `identical?` no-op (an unchanged focused slice widens back to the original app-db object, not an `assoc-in` allocation). A non-vector / malformed path arg raises `:rf.error/path-interceptor-bad-path`.
 
 ### `reg-interceptor`
 
@@ -78,27 +69,30 @@ The v2 standard-interceptor surface is **two specific helpers** (`path`, `unwrap
   ```
 - **Description**: A **pre-built interceptor value**, not a fn (interceptor `:id` is `:rf.schema/at-boundary`). Add it to a `reg-event` metadata map's `:interceptors` vector for production-boundary schema validation. **Do not call it as a fn** — it has no fn arity; invoking `(rf/validate-at-boundary-interceptor ...)` raises `ArityException`.
 
-### The `path` interceptor: focus on a slice
+### The `:rf.interceptor/path` reference: focus on a slice
 
 ```clojure
 (rf/reg-event :cart/add-item
-  {:interceptors [(rf/path [:cart :items])]}
+  {:interceptors [[:rf.interceptor/path [:cart :items]]]}   ;; a REFERENCE, not a value
   (fn [{:keys [db]} {:keys [item]}]
     {:db (conj db item)}))                     ;; the handler sees and returns the slice (as :db)
 ```
 
-The `:before` rewrites `(:db cofx)` to `(get-in db [:cart :items])`. The handler returns the new slice. The `:after` splices it back with `(assoc-in db [:cart :items] result)`. A handler that focuses on a slice with `path` and also needs auxiliary world facts declares those facts with `:rf.cofx/requires` — the slice arrives via the interceptor, the facts via the coeffect declaration (see [01 — Core §`reg-cofx`](01-core.md#reg-cofx)).
+The chain entry is the **reference** `[:rf.interceptor/path [:cart :items]]`, not a constructed value — there is no public `path` fn (it's removed; a stale `rf/path` call raises `:rf.error/path-removed`). The `:before` stages `(:db cofx)` as `(get-in db [:cart :items])`. The handler returns the new slice. The `:after` widens it back with `(assoc-in db [:cart :items] result)`, preserving the commit `identical?` no-op when the slice is unchanged. A handler that focuses on a slice and also needs auxiliary world facts declares those facts with `:rf.cofx/requires` — the slice arrives via the interceptor reference, the facts via the coeffect declaration (see [01 — Core §`reg-cofx`](01-core.md#reg-cofx)).
 
-### The `unwrap` interceptor
+### Payload destructuring: the replacement for v1 `unwrap`
+
+There is no standard `unwrap` interceptor in v2 (the v1 value is removed; a stale `rf/unwrap` raises `:rf.error/unwrap-removed`). The canonical way to receive a payload map directly is the **map-payload call shape** — destructure the handler's payload argument:
 
 ```clojure
 (rf/reg-event :foo/update
-  {:interceptors [rf/unwrap]}
-  (fn [cofx {:keys [id new-value]}]           ;; :event coeffect is the payload map
+  (fn [cofx {:keys [id new-value]}]           ;; second arg IS the payload map
     ...))
+
+;; You wrote: (rf/dispatch [:foo/update {:id 1 :new-value "x"}])
 ```
 
-You wrote `(rf/dispatch [:foo/update {:id 1 :new-value "x"}])`; the handler receives the payload map directly under `:event` instead of the full vector. Sugar — it's not load-bearing — but it composes cleanly with the canonical map-payload form.
+The handler's second argument is the payload map directly — no interceptor required (per [MIGRATION §M-19](../../migration/from-re-frame-v1/README.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in)). For genuine chain-wide event reshaping, register a project-specific interceptor with `reg-interceptor` and reference it by id.
 
 ### Building custom interceptors with `reg-interceptor`
 

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
@@ -1,0 +1,162 @@
+(ns re-frame.api-manifest.doc-api-check
+  "Human-doc API-reference projection check (rf2-vzupmg).
+
+  THE GAP THIS CLOSES. The keystone manifest drift-check (rf2-3nbl5.2) and
+  its `spec/API.md` projection (`api-md-check`) plus the four secondary
+  projection checks (`doc-guide-check`, `story-spec-check`, `xray-spec-check`,
+  `skills-check`) between them scan `spec/API.md`, `docs/guide/**`, the two
+  tool API specs, and `skills/`. They do NOT scan the three human-facing API
+  REFERENCE trees:
+
+    * `spec/Privacy.md`   — the EP-0015 cross-artefact privacy inventory;
+    * `docs/api/**`       — the per-chapter human API reference;
+    * `docs/story/api/**` — the Story human API reference.
+
+  EP-0025 stale prose slipped into exactly those trees and passed EVERY CI
+  check because nothing reconciled their public-var references against the
+  manifest. This check extends the SAME call-position discipline the
+  doc-guide check uses to those three trees: every call-position
+  `(rf/<var>` / `(story/<var>` reference must resolve to a manifest row, so a
+  reference to a renamed / removed / never-manifested public surface goes RED.
+
+  SCOPE — call-position discipline (same as doc-guide / skills checks).
+  References are anchored on the leading `(` so the `:rf/*` reserved keyword
+  namespace is excluded (a bare `rf/<token>` sweep would drown in
+  `:rf/default`, `:rf.cofx/requires`, `:rf.egress/*`, etc.). Two alias forms
+  are extracted, because these reference trees mix them:
+
+    * `(rf/<var>`     — the conventional `re-frame.core` alias, used across
+                        all three trees;
+    * `(story/<var>`  — the `re-frame.story` alias, used in the Story API
+                        reference (`docs/story/api/**`).
+
+  RESOLUTION LATITUDE. A reference resolves when its bare var name is carried
+  by ANY manifest row — the same bare-name latitude the secondary projection
+  checks take (`projection/index-by-var-name`). This is correct here: the
+  API reference legitimately names vars across several public namespaces
+  (`re-frame.core`, `re-frame.story`, `re-frame.machines`, …) under the `rf`
+  alias, and a REMOVED var has no manifest row in ANY namespace, so it is
+  still caught. (The keystone + api-md-check already pin namespace-exact
+  classification; this projection only asks `does this name still exist as a
+  public surface?`.)
+
+  REMOVAL-NOTE / TOMBSTONE TOLERANCE. Mirroring how `api-md-check` tolerates
+  `spec/API.md` removal notes and how `doc-guide-check` file-scopes removed
+  names, the `docs/api/15-removed.md` tombstone register names removed
+  surfaces by design. Its removed names appear as bare back-ticked
+  identifiers (`` `add-marks` ``, `` `reg-sub-raw` ``), NOT as call-position
+  `(rf/<var>` forms, so the call-position scope already excludes them. The
+  file-scoped `:doc-api-known-unmanifested-scoped` sidecar allowlist exists
+  for the rare legitimate call-position mention of a removed name in approved
+  tombstone / migration prose; a call-position reference to a removed name in
+  any OTHER file is RED (it leaked into live reference prose).
+
+  KEYWORD-DRIFT GUARDS. The EP-0017 / EP-0011 / EP-0015 keyword-drift guards
+  (`projection/keyword-drift-problems-over-files`) are folded in over the same
+  scanned files — `spec/Privacy.md` is the EP-0015 privacy surface, so a
+  reintroduced retired `:rf.egress/*` profile keyword goes RED here too."
+  (:require [re-frame.api-manifest.gen :as gen]
+            [re-frame.api-manifest.projection :as proj]))
+
+;; The reference trees scanned. Each is an EXPECTED surface (it exists today
+;; and is owned), so it uses `require-markdown-files` — a moved / renamed
+;; tree fails loudly rather than turning the gate into a vacuous green.
+;;
+;; `spec/Privacy.md` is a single file, not a directory; it is handled
+;; separately below (a `require`-style existence assertion).
+(def ^:private dir-surfaces
+  "[[label repo-relative-dir-segs] ...] — directory reference trees."
+  [["docs/api/"       ["docs" "api"]]
+   ["docs/story/api/" ["docs" "story" "api"]]])
+
+(def ^:private privacy-file-segs ["spec" "Privacy.md"])
+
+(def ^:private min-references
+  "Non-vacuous floor (rf2-utvst-style). The three trees together carry ~50
+   call-position references today (docs/api ~35, spec/Privacy ~22,
+   docs/story/api ~15). This floor sits well below that combined live count,
+   so it trips only on a near-total collapse (a tree moved/renamed, the
+   `(alias/<var>` extraction broke, the alias convention changed) — never on
+   ordinary content churn. It is the aggregate floor across all three trees."
+  20)
+
+(defn reconcile
+  "Pure reconciler (extracted so the file-scoped allowlist contract is
+   unit-testable with synthetic inputs). Returns the seq of problem maps for
+   the supplied call-position references.
+
+   `references`  — `[{:var :line :raw :file} ...]` (`:file` repo-relative).
+   `manifest-vars` — set of bare var names ANY manifest row carries (a name
+                     in this set still names a live public surface).
+   `scoped-allow`— `{removed-name -> #{approved repo-relative file paths}}`
+                   (the `:doc-api-known-unmanifested-scoped` sidecar key).
+
+   A reference resolves (no problem) when its var is carried by some manifest
+   row, OR its var is on the scoped allowlist AND its file is in that name's
+   approved-file set. A reference to a scoped removed name in a NON-approved
+   file is flagged as a removed-API leak into live reference prose; an unknown
+   name with no manifest row and no scope entry is flagged as an unresolved
+   reference."
+  [{:keys [references manifest-vars scoped-allow]}]
+  (keep (fn [{:keys [var line raw file]}]
+          (cond
+            (contains? manifest-vars var) nil
+            (contains? scoped-allow var)
+            (when-not (contains? (get scoped-allow var) file)
+              {:file file :line line :raw raw
+               :detail (format (str "removed API named outside its approved "
+                                    "removal/migration file(s) %s — live API "
+                                    "reference prose must not call removed APIs")
+                               (vec (sort (get scoped-allow var))))})
+            :else
+            {:file file :line line :raw raw
+             :detail "no manifest row (renamed / removed / never-manifested public surface)"}))
+        references))
+
+(defn- references-in-files
+  "Extract both `(rf/<var>` and `(story/<var>` call-position references from
+   `files` (io/file seq), each tagged with its repo-relative `:file`."
+  [files]
+  (for [file  files
+        alias ["rf" "story"]
+        ref   (proj/alias-call-references alias (proj/numbered-lines file))]
+    (assoc ref :file (proj/repo-relative file))))
+
+(defn check!
+  []
+  (let [rows          (proj/manifest-rows)
+        ;; Resolution target: bare var names ANY manifest row carries. A
+        ;; removed surface has no row in ANY namespace, so it is still caught.
+        manifest-vars (set (map :var rows))
+        scoped-allow  (or (:doc-api-known-unmanifested-scoped (gen/read-sidecar)) {})
+        ;; Directory trees — fail loud if a tree moves/renames (rf2-utvst).
+        dir-files     (mapcat (fn [[label segs]]
+                                (proj/require-markdown-files
+                                  label (apply proj/repo-file segs)))
+                              dir-surfaces)
+        ;; spec/Privacy.md — a single EXPECTED file; fail loud if it moves.
+        privacy-file  (apply proj/repo-file privacy-file-segs)
+        _             (when-not (.isFile ^java.io.File privacy-file)
+                        (throw (ex-info
+                                 (str "spec/Privacy.md: expected file is missing — "
+                                      (proj/repo-relative privacy-file)
+                                      ". The privacy projection gate cannot run "
+                                      "against a non-existent surface; reconcile "
+                                      "the path.")
+                                 {:file (str privacy-file)})))
+        files         (cons privacy-file dir-files)
+        references    (references-in-files files)
+        var-problems  (reconcile {:references    references
+                                  :manifest-vars manifest-vars
+                                  :scoped-allow  scoped-allow})
+        ;; Keyword-drift guards (EP-0017/EP-0011/EP-0015): spec/Privacy.md is
+        ;; the EP-0015 surface, so a reintroduced retired `:rf.egress/*`
+        ;; profile keyword goes RED here alongside any var-resolution drift.
+        kw-problems   (proj/keyword-drift-problems-over-files files)
+        problems      (concat var-problems kw-problems)]
+    (proj/report-with-floor!
+      "spec/Privacy.md + docs/api/ + docs/story/api/"
+      (count references) min-references problems)))
+
+(defn -main [& _]
+  (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_api_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_api_check_test.clj
@@ -1,0 +1,87 @@
+(ns re-frame.api-manifest.doc-api-check-test
+  "Regression tests for the human-doc API-reference projection check
+  (rf2-vzupmg).
+
+  THE GAP. The keystone manifest drift-check and its existing projection
+  checks scan spec/API.md, docs/guide/**, the two tool API specs, and
+  skills/ — but NOT the three human-facing API-reference trees
+  (spec/Privacy.md, docs/api/**, docs/story/api/**). EP-0025 stale prose
+  slipped into exactly those trees and passed every CI check. This check
+  extends the same call-position discipline to them.
+
+  THE CONTRACT these tests pin (through the pure `reconcile` reconciler with
+  synthetic references, plus a live smoke that the committed trees reconcile
+  clean):
+    * a live manifest var resolves anywhere (no problem);
+    * an unknown / removed name with no manifest row is flagged;
+    * a file-scoped removed name is silenced ONLY in its approved file(s),
+      and RED elsewhere (mirroring :doc-guide-known-unmanifested-scoped)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.api-manifest.doc-api-check :as c]
+            [re-frame.api-manifest.gen :as gen]))
+
+(def ^:private manifest-vars
+  ;; A small synthetic stand-in spanning several namespaces, exercising the
+  ;; bare-name latitude: `configure!` lives on re-frame.story, `machine-meta`
+  ;; on re-frame.machines, the rest on re-frame.core — all resolve by name.
+  #{"reg-event" "reg-sub" "dispatch" "configure!" "reg-story" "machine-meta"})
+
+(def ^:private scoped-allow
+  {"reg-sub-raw" #{"docs/api/15-removed.md"}})
+
+(defn- problems-for [references]
+  (c/reconcile {:references references
+                :manifest-vars manifest-vars
+                :scoped-allow scoped-allow}))
+
+(deftest live-manifest-var-resolves-anywhere
+  (testing "a live manifest var resolves in any reference tree with no problem"
+    (is (empty? (problems-for
+                  [{:var "reg-event" :line 13 :raw "rf/reg-event"
+                    :file "docs/api/01-core.md"}
+                   {:var "configure!" :line 7 :raw "story/configure!"
+                    :file "docs/story/api/registration.md"}
+                   {:var "machine-meta" :line 259 :raw "rf/machine-meta"
+                    :file "docs/api/10-testing.md"}
+                   {:var "reg-event" :line 88 :raw "rf/reg-event"
+                    :file "spec/Privacy.md"}])))))
+
+(deftest removed-name-with-no-manifest-row-is-red
+  (testing "a removed / renamed / never-manifested name in live reference
+            prose is flagged"
+    (let [probs (problems-for
+                  [{:var "path" :line 85 :raw "rf/path"
+                    :file "docs/api/03-effects.md"}])]
+      (is (= 1 (count probs)))
+      (is (= "docs/api/03-effects.md" (:file (first probs))))
+      (is (re-find #"no manifest row" (:detail (first probs)))))))
+
+(deftest scoped-removed-name-silenced-only-in-approved-file
+  (testing "a scoped removed name is silenced in its approved tombstone file"
+    (is (empty? (problems-for
+                  [{:var "reg-sub-raw" :line 26 :raw "rf/reg-sub-raw"
+                    :file "docs/api/15-removed.md"}]))))
+  (testing "the SAME scoped removed name in a NON-approved live reference file
+            is RED — it leaked into live reference prose"
+    (let [probs (problems-for
+                  [{:var "reg-sub-raw" :line 50 :raw "rf/reg-sub-raw"
+                    :file "docs/api/01-core.md"}])]
+      (is (= 1 (count probs)))
+      (is (= "docs/api/01-core.md" (:file (first probs))))
+      (is (re-find #"removed API named outside its approved" (:detail (first probs)))))))
+
+(deftest live-doc-api-reconciles-clean
+  (testing "the committed spec/Privacy.md + docs/api + docs/story/api
+            reconcile against the committed manifest with zero problems
+            (the CI contract — #4887/#4888 cleaned these trees + this PR
+            corrected the residual path/unwrap drift the gate surfaced)"
+    (is (true? (c/check!))
+        "live drift: a human-doc API-reference tree names a removed/renamed public surface")))
+
+(deftest scoped-allowlist-sidecar-key-is-present-and-a-map
+  (testing "the committed sidecar carries the file-scoped allowlist key as a
+            map (empty today; the tombstone uses bare-backtick names, not
+            call-position forms, so no entry is needed)"
+    (let [scoped (:doc-api-known-unmanifested-scoped (gen/read-sidecar))]
+      (is (map? scoped)
+          "the scoped allowlist must be a {name -> #{files}} map"))))

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -351,6 +351,32 @@
   "add-marks"    #{"docs/guide/23-privacy-and-large-things.md"}
   "set-marks"    #{"docs/guide/23-privacy-and-large-things.md"}}
 
+ ;; Human-doc API-reference call-position `(rf/<var>` / `(story/<var>`
+ ;; references the manifest does not carry (rf2-vzupmg). The doc-api
+ ;; projection check (re-frame.api-manifest.doc-api-check) scans the three
+ ;; human-facing API-reference trees the keystone + existing projection
+ ;; checks left uncovered — spec/Privacy.md + docs/api/** + docs/story/api/**
+ ;; — and goes RED on a call-position reference to a renamed / removed /
+ ;; never-manifested public surface.
+ ;;
+ ;; Same FILE-SCOPED shape as :doc-guide-known-unmanifested-scoped: each entry
+ ;; maps a removed name to the set of repo-relative file paths where a
+ ;; call-position mention is approved (a removal/tombstone register naming the
+ ;; old API as the left-hand side of old→new migration guidance). A
+ ;; call-position reference to the name OUTSIDE those files is RED (it leaked
+ ;; into live reference prose).
+ ;;
+ ;; EMPTY TODAY. docs/api/15-removed.md — the tombstone register — names
+ ;; removed surfaces as bare back-ticked identifiers (`add-marks`,
+ ;; `reg-sub-raw`, `path`), NOT as call-position `(rf/<var>` forms, so the
+ ;; call-position scope already excludes them with no allowlist entry needed.
+ ;; The `path` / `unwrap` removed value constructors (EP-0022) were corrected
+ ;; in the live docs/api/03-effects.md chapter to the canonical
+ ;; `[:rf.interceptor/path …]` reference + map-payload destructuring model in
+ ;; the same change (the gate doing its job), rather than allowlisted.
+ :doc-api-known-unmanifested-scoped
+ {}
+
  ;; --------------------------------------------------------------------------
  ;; JVM-introspected classification — keyed ["namespace" "var"].
  ;; --------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extends the public-API manifest drift-check to cover the three human-facing **API-reference** trees it previously did not scan:

- `spec/Privacy.md` — the EP-0015 cross-artefact privacy inventory
- `docs/api/**` — the per-chapter human API reference
- `docs/story/api/**` — the Story human API reference

### Root cause (cross-review, completeness lens)

The keystone manifest drift-check (rf2-3nbl5.2) + its `spec/API.md` projection (`api-md-check`) and the four secondary projection checks (`doc-guide-check`, `story-spec-check`, `xray-spec-check`, `skills-check`) between them scan `spec/API.md`, `docs/guide/**`, the two tool API specs, and `skills/`. They do **not** scan the three API-reference trees above. EP-0025 stale prose slipped into exactly those trees and **passed every CI check** because nothing reconciled their public-var references against the manifest.

### The extension

New check `re-frame.api-manifest.doc-api-check`, modeled exactly on `doc-guide-check`:

- Extracts every **call-position** `(rf/<var>` and `(story/<var>` reference from the three trees (the leading `(` excludes the `:rf/*` reserved-keyword namespace — same scope discipline as doc-guide/skills).
- Resolves each by **bare name against any manifest namespace** (`re-frame.core`, `re-frame.story`, `re-frame.machines`, …) — the same latitude the secondary checks use. A removed surface has no manifest row in any namespace, so it is still caught.
- Folds in the **EP-0017 / EP-0011 / EP-0015 keyword-drift guards** over the same files (`spec/Privacy.md` is the EP-0015 surface — a reintroduced retired `:rf.egress/*` profile keyword goes RED here too).
- **Non-vacuous floor** + `require-markdown-files` / a `spec/Privacy.md` existence assertion: a moved/renamed tree fails loud, never a vacuous green.
- **Removal-note tolerance**: new file-scoped `:doc-api-known-unmanifested-scoped` sidecar allowlist (mirrors `:doc-guide-known-unmanifested-scoped`). Empty today — `docs/api/15-removed.md`'s tombstone names removed surfaces as bare back-ticked identifiers, **not** call-position forms, so the call-position scope already excludes them.

Wired as a new step in the `lint.yml` `api-manifest` job, and extended the push path filter + the `detect`-job classifier so a pure-doc PR touching those trees runs the drift-check. A regression test pins the reconciler (live-resolves / removed-flagged / file-scoped) plus a live-clean smoke.

### Residual drift the new gate surfaced — and fixed (the gate doing its job)

`docs/api/03-effects.md` still taught the removed **EP-0022 `path` / `unwrap` VALUE constructors** as live standard interceptors, with worked `(rf/path [:cart :items])` and `[rf/unwrap]` examples and `### path` / `### unwrap` reference rows. Both are removed (throwing `^:no-doc` stubs raising `:rf.error/path-removed` / `:rf.error/unwrap-removed`, no manifest row — per `spec/API.md` §797–805 and `spec/api-manifest-metadata.edn`). #4887/#4888 cleaned the other dirs but this chapter retained the stale teaching.

Corrected the chapter to the canonical model: `[:rf.interceptor/path <path-vector>]` **reference** (the one standard interceptor) + **map-payload destructuring** as the `unwrap` replacement. No `(rf/path` / `(rf/unwrap` call-anchored forms remain in any scanned tree.

## Quality gates

| Gate | Result |
|---|---|
| `doc-api-check` on main | **green** — 178 references reconciled (floor 20) |
| full `:test` alias | **53 tests / 105 assertions, 0 failures** (incl. new `doc_api_check_test`) |
| `doc-guide-check` + `api-md-check` | still green (unaffected) |
| `check_doc_slugs.py` | exit 0 (heading renames broke no inbound links) |
| `mkdocs build --strict` | exit 0 |
| `lint.yml` YAML | valid (`yaml.safe_load`) |
| negative control | **RED** on an injected `(rf/reg-sub-raw` — gate is non-vacuous |

CI is the merge gate.