### PR TITLE
test(core+conformance): EP-0027 fx-path construction guard + :initial-events conformance fixtures (rf2-4rgu6o, rf2-kmk9z4)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -1074,6 +1074,36 @@
                          "    expected: no error (well-formed machine)\n"
                          "    thrown:   " (ex-message thrown)))}))
 
+    ;; EP-0027 construction-engine registration call (rf2-kmk9z4). Pins the
+    ;; CONSTRUCTION fail-loud discriminators (Spec 009 §The thrown-error shape)
+    ;; against the live `reg-frame`. `:config` is the frame-config passed to
+    ;; `reg-frame`; `:expect-error <:rf.error/id>` ⇒ the construction must
+    ;; throw an ex-info whose `:rf.error/id` ex-data slot equals the id (the
+    ;; `:on-create` / `:initial-db` RETIREMENT ids); absent `:expect-error` ⇒
+    ;; a well-formed config that must NOT throw. The frame is destroyed
+    ;; afterward (best-effort) so a control doesn't leak into final-app-db.
+    ;; Mirror of the JVM runner + the `:reg-machine` Mode-B convention.
+    :reg-frame
+    (let [frame-id   (or (:frame-id call) :rf.test/construction)
+          want-error (:expect-error call)
+          thrown     (try (rf/reg-frame frame-id (:config call)) nil
+                          (catch :default e e))
+          _          (try (rf/destroy-frame! frame-id) (catch :default _ nil))]
+      (if want-error
+        (let [got-id (:rf.error/id (ex-data thrown))
+              ok?    (= want-error got-id)]
+          {:passed? ok?
+           :detail  (when-not ok?
+                      (str "reg-frame\n"
+                           "    expected error :rf.error/id: " want-error "\n"
+                           "    actual   error :rf.error/id: " got-id "\n"
+                           "    thrown:                       " (some-> thrown ex-message)))})
+        {:passed? (nil? thrown)
+         :detail  (when (some? thrown)
+                    (str "reg-frame\n"
+                         "    expected: no error (well-formed config)\n"
+                         "    thrown:   " (ex-message thrown)))}))
+
     ;; EP-0012 (rf2-qyb9l1) — CEDN-1 canonical-identity golden ops. Mirror
     ;; of the JVM runner: a fixture pins the FROZEN byte-contract
     ;; (`canonical-bytes`) so an encoder rewrite that changed the bytes
@@ -1379,6 +1409,14 @@
             ;; Mirrors the JVM runner.
             (contains? ev :destroy-frame)
             (rf/destroy-frame! (:destroy-frame ev))
+
+            ;; Harness re-construction step `{:reset-frame <frame-id>}` per
+            ;; Spec 002 §reset-frame! + EP-0027 §Reset (rf2-kmk9z4) — re-run
+            ;; the named frame's recorded `:initial-events` against the
+            ;; current handlers (a destroy + re-register; no snapshot).
+            ;; Mirror of the JVM runner.
+            (contains? ev :reset-frame)
+            (frame/reset-frame! (:reset-frame ev))
 
             ;; Harness re-registration step `{:reg-sub <sub-id> :body
             ;; <body>}` per Cross-Spec Interaction §18 (rf2-qei5a). Mirror

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -1267,6 +1267,39 @@
                          "    expected: no error (well-formed machine)\n"
                          "    thrown:   " (ex-message thrown)))}))
 
+    ;; EP-0027 construction-engine registration call (rf2-kmk9z4). Pins the
+    ;; CONSTRUCTION fail-loud discriminators (Spec 009 §The thrown-error shape)
+    ;; against the live `reg-frame`. `:config` is the frame-config map passed
+    ;; to `reg-frame :rf.test/construction`; `:expect-error <:rf.error/id>` ⇒
+    ;; the construction must throw an ex-info whose `:rf.error/id` ex-data slot
+    ;; equals the id (e.g. the `:on-create` / `:initial-db` RETIREMENT ids);
+    ;; absent `:expect-error` ⇒ a well-formed config that must NOT throw. The
+    ;; frame is destroyed afterward (best-effort) so a well-formed control does
+    ;; not leak into the final-app-db snapshot. Mirror of the `:reg-machine`
+    ;; Mode-B convention.
+    :reg-frame
+    (let [frame-id   (or (:frame-id call) :rf.test/construction)
+          want-error (:expect-error call)
+          thrown     (try (rf/reg-frame frame-id (:config call)) nil
+                          (catch clojure.lang.ExceptionInfo e e)
+                          (catch Throwable e e))
+          _          (try (rf/destroy-frame! frame-id) (catch Throwable _ nil))]
+      (if want-error
+        (let [got-id (when (instance? clojure.lang.ExceptionInfo thrown)
+                       (:rf.error/id (ex-data thrown)))
+              ok?    (= want-error got-id)]
+          {:passed? ok?
+           :detail  (when-not ok?
+                      (str "reg-frame\n"
+                           "    expected error :rf.error/id: " want-error "\n"
+                           "    actual   error :rf.error/id: " got-id "\n"
+                           "    thrown:                       " (some-> thrown ex-message)))})
+        {:passed? (nil? thrown)
+         :detail  (when (some? thrown)
+                    (str "reg-frame\n"
+                         "    expected: no error (well-formed config)\n"
+                         "    thrown:   " (ex-message thrown)))}))
+
     ;; EP-0012 (rf2-qyb9l1) — CEDN-1 canonical-identity golden ops. These
     ;; pin the FROZEN byte-contract (`re-frame.identity/canonical-bytes`)
     ;; cross-host: a fixture asserts the exact token stream a value encodes
@@ -1616,6 +1649,16 @@
             ;; flows-conformance runner's shape (rf2-gmrks).
             (contains? ev :destroy-frame)
             (rf/destroy-frame! (:destroy-frame ev))
+
+            ;; Harness re-construction step `{:reset-frame <frame-id>}` per
+            ;; Spec 002 §reset-frame! + EP-0027 §Reset (rf2-kmk9z4) — re-run
+            ;; the named frame's recorded `:initial-events` against the
+            ;; CURRENT handlers (a destroy + re-register that replays the
+            ;; durable construction config; no snapshot). Used by the
+            ;; `construction-reset-replays-initial-events` fixture to pin the
+            ;; EP-0027 reset contract host-agnostically.
+            (contains? ev :reset-frame)
+            (frame/reset-frame! (:reset-frame ev))
 
             ;; Harness re-registration step `{:reg-sub <sub-id> :body
             ;; <body>}` per Cross-Spec Interaction §18 (rf2-qei5a). The

--- a/implementation/core/test/re_frame/frame_initial_events_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_initial_events_cljs_test.cljc
@@ -22,7 +22,11 @@
     * TEARDOWN — a setup step that THROWS at runtime tears down the partial frame
       (no live half-frame is left) and the error names the `:step-index`;
     * the HANDLER-TIME guard — constructing a frame inside an event handler fails
-      `:rf.error/frame-construction-in-handler`.
+      `:rf.error/frame-construction-in-handler`. The guard keys on
+      `trace/*handler-scope*` being bound, which the router holds across the
+      DIRECT handler body, the `:fx` `:dispatch` re-entry, AND any queued nested
+      dispatch — so construction is forbidden on ALL THREE mid-cascade routes
+      (rf2-4rgu6o pins the `:fx` + nested-dispatch routes, not just the body).
 
   Each fail-loud assertion checks the `:rf.error/id` discriminator, NEVER the
   message bytes (Spec 009 §The thrown-error shape rule 3).
@@ -469,4 +473,74 @@
       (is (= :rf.error/frame-construction-in-handler @caught)
           "a reg-frame inside a handler fails loud")
       (is (nil? (frame/frame :child/in-handler))
+          "no half-registered child frame is left behind"))))
+
+(deftest frame-construction-in-fx-dispatch-re-entry-fails-loud
+  (testing "rf2-4rgu6o: EP-0027 forbids construction on the :fx /
+            nested-dispatch re-entry path too — not just the direct handler
+            BODY. A handler that returns {:fx [[:dispatch [:fx/makes-frame]]]}
+            re-enters the cascade to run :fx/makes-frame; the router keeps
+            *handler-scope* bound across the :fx-driven nested dispatch, so a
+            reg-frame inside :fx/makes-frame must STILL fail loud
+            :rf.error/frame-construction-in-handler. This is the load-bearing
+            case the body-only test (above) does NOT cover: a regression that
+            unbound *handler-scope* around :fx processing / queued nested
+            dispatch would leave THIS path silently allowed (mid-cascade
+            construction re-enabled) while the body-path test stayed green."
+    (reg-test-events!)
+    (let [caught (atom ::not-run)]
+      ;; The nested event that tries to construct a frame. It runs from the
+      ;; queued :dispatch re-entry, NOT directly in the originating handler's
+      ;; body — yet it is still inside the same in-flight cascade.
+      (rf/reg-event :fx/makes-frame
+        (fn [{:keys [db]} _]
+          (reset! caught
+                  (err-id #(rf/reg-frame :child/via-fx
+                             {:initial-events [[:test/set-db {:n 0}]]})))
+          {:db db}))
+      ;; The originating handler emits the construction attempt via :fx
+      ;; :dispatch (the EXPLICITLY forbidden EP-0027 route), so the child
+      ;; reg-frame runs on the queued nested-dispatch re-entry path.
+      (rf/reg-event :handler/fx-makes-frame
+        (fn [{:keys [db]} _]
+          {:db db :fx [[:dispatch [:fx/makes-frame]]]}))
+      (rf/reg-frame :parent/fx {:initial-events [[:test/set-db {}]]})
+      (rf/dispatch-sync [:handler/fx-makes-frame] {:frame :parent/fx})
+      (is (= :rf.error/frame-construction-in-handler @caught)
+          "a reg-frame on the :fx /nested-dispatch re-entry path fails loud —
+           the guard keys on *handler-scope*, which the router keeps bound
+           across :fx-driven nested dispatch (the body-only test would not
+           catch a regression here)")
+      (is (nil? (frame/frame :child/via-fx))
+          "no half-registered child frame is left behind"))))
+
+(deftest frame-construction-in-nested-dispatch-fails-loud
+  (testing "rf2-4rgu6o: a frame constructed inside a NESTED dispatch (a handler
+            that dispatches another event which constructs) must fail loud
+            :rf.error/frame-construction-in-handler. Distinct from the :fx
+            route above: here the parent handler itself emits a [:dispatch …]
+            effect that queues the constructing event for mid-cascade re-entry.
+            Both routes share the same *handler-scope*-keyed guard; pinning
+            both documents that ANY mid-cascade construction (body, :fx, queued
+            nested dispatch) is rejected, so a regression that unbinds the scope
+            marker around queued re-entry turns this RED."
+    (reg-test-events!)
+    (let [caught (atom ::not-run)]
+      ;; The nested event constructs a frame. It runs from the parent handler's
+      ;; queued :dispatch, mid-cascade.
+      (rf/reg-event :nested/makes-frame
+        (fn [{:keys [db]} _]
+          (reset! caught
+                  (err-id #(rf/reg-frame :child/via-nested
+                             {:initial-events [[:test/set-db {:n 0}]]})))
+          {:db db}))
+      ;; The parent handler queues the nested dispatch via the :dispatch effect.
+      (rf/reg-event :nested/parent
+        (fn [{:keys [db]} _]
+          {:db db :fx [[:dispatch [:nested/makes-frame]]]}))
+      (rf/reg-frame :parent/nested {:initial-events [[:test/set-db {}]]})
+      (rf/dispatch-sync [:nested/parent] {:frame :parent/nested})
+      (is (= :rf.error/frame-construction-in-handler @caught)
+          "a reg-frame inside a nested mid-cascade dispatch fails loud")
+      (is (nil? (frame/frame :child/via-nested))
           "no half-registered child frame is left behind"))))

--- a/spec/conformance/fixtures/construction-initial-events-ordered.edn
+++ b/spec/conformance/fixtures/construction-initial-events-ordered.edn
@@ -1,0 +1,42 @@
+;; Conformance fixture: construction/initial-events-ordered
+;; EP-0027 §Construction — a frame's :initial-events drain SYNCHRONOUSLY, in
+;; declaration order, each settling before the next, BEFORE the constructor
+;; returns. By the time the frame is observable its app-db is fully settled.
+;; The seed step (whole-db replace) runs first, then two increments and a
+;; trailing marker write — the final app-db pins the strict ordering.
+
+{:fixture/id           :construction/initial-events-ordered
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/frame :core/trace}
+ :fixture/doc          "Per EP-0027 §Construction: ordered :initial-events run synchronously, in declaration order, each draining before the next, before the constructor returns. The two :ctor/inc steps land after the seed; the trailing :ctor/mark runs last."
+
+ :fixture/registry
+ {:event {:ctor/seed {:doc "Replace app-db wholesale with the seed map."}
+          :ctor/inc  {:doc "Increment :n (implicit-zero start)."}
+          :ctor/mark {:doc "Write a marker last to prove tail ordering."}}}
+
+ :fixture/handlers
+ {:event {:ctor/seed [[:set [] [:event-arg 1]]]
+          :ctor/inc  [[:update [:n] [:fn :inc]]]
+          :ctor/mark [[:set [:marker] :done]]}}
+
+ :fixture/frame-config
+ {:initial-events [[:ctor/seed {:n 0 :log []}]
+                   [:ctor/inc]
+                   [:ctor/inc]
+                   [:ctor/mark]]}
+
+ :fixture/dispatches []
+
+ :fixture/expect
+ ;; n=2 (seed 0, then two incs), :marker landed last, :log untouched by the
+ ;; wholesale seed — the construction cascade fully settled before observation.
+ {:final-app-db {:n 2 :marker :done :log []}
+
+  :trace-emissions
+  ;; The three setup dispatches run in order, then the frame is created.
+  [{:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/seed}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/inc}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/inc}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/mark}}
+   {:operation :rf.frame/created   :tags {:frame :rf/default}}]}}

--- a/spec/conformance/fixtures/construction-reset-replays-initial-events.edn
+++ b/spec/conformance/fixtures/construction-reset-replays-initial-events.edn
@@ -1,0 +1,44 @@
+;; Conformance fixture: construction/reset-replays-initial-events
+;; EP-0027 §Reset (Spec 002 §reset-frame!) — reset-frame! re-dispatches the
+;; frame's RECORDED :initial-events through the CURRENT handlers (a destroy +
+;; re-register of the durable construction config; best-effort, no snapshot).
+;; Construction settles to n=1; runtime mutates it to n=3; reset replays the
+;; recorded seed+inc, returning to n=1.
+
+{:fixture/id           :construction/reset-replays-initial-events
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/frame :core/trace}
+ :fixture/doc          "Per EP-0027 §Reset: reset-frame! re-runs the recorded :initial-events against the current handlers. Construction → n=1; runtime → n=3; the {:reset-frame …} harness step replays the recorded seed+inc back to n=1."
+
+ :fixture/registry
+ {:event {:ctor/seed {:doc "Replace app-db wholesale with the seed map."}
+          :ctor/inc  {:doc "Increment :n."}}}
+
+ :fixture/handlers
+ {:event {:ctor/seed [[:set [] [:event-arg 1]]]
+          :ctor/inc  [[:update [:n] [:fn :inc]]]}}
+
+ :fixture/frame-config
+ {:initial-events [[:ctor/seed {:n 0}]
+                   [:ctor/inc]]}
+
+ :fixture/dispatches
+ ;; Construction left n=1. Mutate away to n=3, then reset replays the recorded
+ ;; setup (seed {:n 0} + one inc ⇒ n=1).
+ [[:ctor/inc]
+  [:ctor/inc]
+  {:reset-frame :rf/default}]
+
+ :fixture/expect
+ ;; After reset the frame is back at its CONSTRUCTED state — n=1, not n=3.
+ {:final-app-db {:n 1}
+
+  :trace-emissions
+  ;; Construction setup, two runtime incs, then the reset re-runs the recorded
+  ;; setup (a fresh :ctor/seed + :ctor/inc) and re-emits :rf.frame/created.
+  [{:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/seed}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/inc}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/inc}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/inc}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/seed}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/inc}}]}}

--- a/spec/conformance/fixtures/construction-retired-keys-fail-loud.edn
+++ b/spec/conformance/fixtures/construction-retired-keys-fail-loud.edn
@@ -1,0 +1,46 @@
+;; Conformance fixture: construction/retired-keys-fail-loud
+;; EP-0027 §Retirement — the legacy construction keys :on-create and :initial-db
+;; are RETIRED. Supplying either to reg-frame fails loud with a stable
+;; discriminator (:rf.error/on-create-retired / :rf.error/initial-db-retired),
+;; never a silent ignore. A conformant host must reject them with the SAME id so
+;; a port can't silently accept the old shape. A well-formed :initial-events
+;; config is the must-NOT-throw control.
+
+{:fixture/id           :construction/retired-keys-fail-loud
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/frame}
+ :fixture/doc          "Per EP-0027 §Retirement: reg-frame with :on-create fails :rf.error/on-create-retired; with :initial-db fails :rf.error/initial-db-retired. A well-formed :initial-events config is the must-not-throw control. Pins the construction fail-loud discriminators host-agnostically (the :reg-frame Mode-B call op, mirror of :reg-machine)."
+
+ :fixture/registry
+ {:event {:ctor/seed {:doc "Seed used by the well-formed control config."}}}
+
+ :fixture/handlers
+ {:event {:ctor/seed [[:set [] [:event-arg 1]]]}}
+
+ :fixture/dispatches []
+
+ :fixture/calls
+ ;; :reg-frame call op — pure construction-registration assertion. :expect-error
+ ;; pins the :rf.error/id the construction must throw; the frame is torn down
+ ;; afterward so no half-frame leaks.
+ [{:call :reg-frame
+   :frame-id :ctor/oc
+   :config {:on-create [:ctor/seed {:n 0}]}
+   :expect-error :rf.error/on-create-retired}
+
+  {:call :reg-frame
+   :frame-id :ctor/idb
+   :config {:initial-db {:n 0}}
+   :expect-error :rf.error/initial-db-retired}
+
+  ;; Control: a well-formed :initial-events config must NOT throw (no
+  ;; :expect-error) — proves the retirement guards reject the LEGACY keys
+  ;; specifically, not all construction.
+  {:call :reg-frame
+   :frame-id :ctor/ok
+   :config {:initial-events [[:ctor/seed {:n 0}]]}}]
+
+ :fixture/expect
+ ;; The construction frames are all torn down by the call op; the runner's
+ ;; :rf/default frame is empty. The contract under test is the call results.
+ {:final-app-db {}}}

--- a/spec/conformance/fixtures/construction-set-db-then-init-event.edn
+++ b/spec/conformance/fixtures/construction-set-db-then-init-event.edn
@@ -1,0 +1,42 @@
+;; Conformance fixture: construction/set-db-then-init-event
+;; EP-0027 §:rf/set-db + §Construction — the framework-standard [:rf/set-db {…}]
+;; event seeds app-db as the FIRST :initial-events step; a FOLLOW-UP init event
+;; in the same construction cascade observes the seeded db (the steps drain in
+;; order, each settling before the next). This pins that :rf/set-db composes as
+;; an ordinary setup step AND that a later step reads what the seed wrote — the
+;; seed is not a separate out-of-band channel.
+
+{:fixture/id           :construction/set-db-then-init-event
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/frame :core/trace}
+ :fixture/doc          "Per EP-0027 §:rf/set-db + §Construction: [:rf/set-db {…}] seeds app-db as the first setup step, then a follow-up init event in the same cascade reads the seeded db. The framework-standard :rf/set-db is re-seeded by init!, so the fixture uses it directly."
+
+ :fixture/registry
+ ;; :rf/set-db is the FRAMEWORK-STANDARD seeding event (re-seeded by init!) — no
+ ;; fixture handler is declared for it; the runner relies on the real one. The
+ ;; follow-up init event reads the seeded value the seed wrote.
+ {:event {:ctor/bump-seeded
+          {:doc "Increment the seeded :n — proves the follow-up step sees the seed."}}}
+
+ :fixture/handlers
+ {:event {:ctor/bump-seeded
+          ;; (update-in db [:n] inc) — :update reads the CURRENT (seeded) :n, so
+          ;; a non-21 result would mean the follow-up did NOT see the seed.
+          [[:update [:n] [:fn :inc]]]}}
+
+ :fixture/frame-config
+ {:initial-events [[:rf/set-db {:n 21 :who :seed}]
+                   [:ctor/bump-seeded]]}
+
+ :fixture/dispatches []
+
+ :fixture/expect
+ ;; The seed wrote {:n 21 :who :seed}; the follow-up step incremented the seeded
+ ;; :n to 22 — proving the second step observed the first step's seeded db (a
+ ;; follow-up that started from an empty db would land on 1, not 22).
+ {:final-app-db {:n 22 :who :seed}
+
+  :trace-emissions
+  [{:operation :rf.event/run-start :tags {:rf.trace/event-id :rf/set-db}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :ctor/bump-seeded}}
+   {:operation :rf.frame/created   :tags {:frame :rf/default}}]}}


### PR DESCRIPTION
Test-only hardening from the EP-0025/EP-0027 cross-review. No production-code change.

## rf2-4rgu6o — handler-time construction guard on the :fx / nested-dispatch path

The EP-0027 handler-time frame-construction guard (`:rf.error/frame-construction-in-handler`) was tested only for a direct `reg-frame` in the handler BODY. EP-0027 also forbids construction on the `:fx` / nested-dispatch re-entry path — the guard keys on `trace/*handler-scope*`, which the router keeps bound across `:fx`-driven nested dispatch AND queued nested dispatch.

Added two adversarial tests to `frame_initial_events_cljs_test.cljc`:
- a frame constructed inside an `:fx [[:dispatch …]]` re-entry must fail loud;
- a frame constructed inside a queued nested dispatch must fail loud.

Both assert `:rf.error/frame-construction-in-handler` and that no half-registered child frame is left behind. **The guard already catches these** (confirmed — the tests pass); they document + lock the behaviour so a regression that unbound `*handler-scope*` around `:fx` (silently re-allowing mid-cascade construction) would turn the test RED. The body-only test would stay green through such a regression.

## rf2-kmk9z4 — EP-0027 construction-engine conformance fixtures

The construction engine had ZERO conformance fixtures (CLJS-unit-only) — a host could diverge on construction semantics and still pass conformance. Added four host-agnostic fixtures under `spec/conformance/fixtures/`:
- `construction-initial-events-ordered.edn` — ordered multi-event `:initial-events` drain in declaration order, settled before the constructor returns.
- `construction-set-db-then-init-event.edn` — the framework-standard `:rf/set-db` seeds app-db as the first step, then a follow-up init event in the same cascade observes the seeded db.
- `construction-reset-replays-initial-events.edn` — `reset-frame!` replays the recorded `:initial-events`.
- `construction-retired-keys-fail-loud.edn` — a retired `:on-create` / `:initial-db` fails loud (`:rf.error/on-create-retired` / `:rf.error/initial-db-retired`), with a well-formed `:initial-events` config as the must-not-throw control.

Two minimal harness ops were added to BOTH the JVM (`conformance_test.clj`) and CLJS (`conformance_corpus_cljs_test.cljs`) corpus runners (mirror of each other, reusing existing patterns):
- a `{:reset-frame <id>}` dispatch op (mirrors the existing `{:destroy-frame …}` op);
- a `:reg-frame` call op with `:expect-error` (mirrors the `:reg-machine` Mode-B convention).

Additive-only: the corpus floor (rf2-3hamsq) is respected (185 → 189 fixtures, none removed). `spec/conformance/README.md` untouched (owned by a later worker). The fixtures pass against the shipped runtime on BOTH harnesses.

## Quality gates

- `npm run test:cljs` (from `implementation/`): **green** — 7957 tests, 36611 assertions, 0 failures/errors (includes the 3 new construction-guard tests + the 4 new fixtures via the compile-time `all-fixtures` macro).
- JVM core conformance `clojure -M:test` (from `implementation/core/`): **green** — 1677 tests, 7294 assertions, 0 failures/errors. A targeted probe confirmed all four new fixtures EXECUTE and PASS on the JVM runner (not silently skipped).
- mkdocs `--strict`: not run — no docs touched.
- node_modules was junctioned from the mayor tree (not a fresh install) and removed (`cmd /c rmdir`) after the gates.

CI is the merge gate.