### PR TITLE
fix(core): EP-0025 classification privacy-correctness — nested-axis suppression + source-aware set/drop (rf2-izlr7f, rf2-p4spo4, rf2-7bsyza)

### DIFF
--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -210,10 +210,31 @@
   [v path]
   (elision/->marker v path {:reason :classification}))
 
+(defn- strict-prefix?
+  "True when path `a` is a STRICT prefix of `b` — `b` is `a` extended by at
+  least one further segment (so `b` is a descendant slot under `a`)."
+  [a b]
+  (let [na (count a)]
+    (and (> (count b) na)
+         (= a (subvec b 0 na)))))
+
+(defn- large-shadows-sensitive?
+  "True when the large-marked path `p` has ANY sensitive path strictly below it
+  in `sensitive-set` — a `:large`-marked subtree containing a `:sensitive`
+  descendant. Per Spec 015 §No-propagation (L338, a normative MUST) such a
+  subtree REDACTS (descend + redact the descendant) rather than emitting a
+  size-preview marker that would leak `:bytes` / `:type` (and, off-box with
+  digests on, a SHA-256 digest computed over a subtree that contains the
+  secret — a brute-force oracle)."
+  [p sensitive-set]
+  (boolean (some #(strict-prefix? p %) sensitive-set)))
+
 (defn- walk-with-paths
   "Walk `v` and substitute sentinels at the declared paths. Paths in
   `sensitive-paths` and `large-paths` are rooted at `v`. Sensitive wins over
-  large at the same path.
+  large at the same path; a large-marked subtree containing a sensitive
+  descendant descends-and-redacts rather than emitting a size marker
+  (nested-axis suppression — rf2-izlr7f).
 
   No-op early-exit: when both path sets are empty, returns `v` unchanged.
   Shares the map/vec/set/seq recursion skeleton with the schema-first elision
@@ -228,6 +249,13 @@
         {:decide  (fn [path v]
                     (cond
                       (contains? sensitive-set path) privacy/redacted-sentinel
+                      ;; NESTED-AXIS SUPPRESSION (rf2-izlr7f): a large-marked
+                      ;; node that shadows a sensitive descendant descends so
+                      ;; the descendant redacts in place — no size marker.
+                      (and (contains? large-set path)
+                           (large-shadows-sensitive? path sensitive-set))
+                      elision/walk-recur
+
                       (contains? large-set path)     (large-marker v path)
                       :else                          elision/walk-recur))
          :map-key (fn [path k] (conj path k))

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -755,6 +755,34 @@
   [decl-paths sensitive-tbl]
   (boolean (some #(contains? sensitive-tbl %) decl-paths)))
 
+(defn- strict-prefix?
+  "True when declaration-coordinate path `a` is a STRICT prefix of `b` — `b`
+  is `a` extended by at least one further segment. Both are full declaration
+  coordinates in the SAME space (`:large` and `:sensitive` decls share it),
+  so a strict-prefix test answers \"is `b` a descendant slot under `a`?\"."
+  [a b]
+  (let [na (count a)]
+    (and (> (count b) na)
+         (= a (subvec b 0 na)))))
+
+(defn- large-keys-shadowing-sensitive
+  "The subset of `:large` declaration keys that have a `:sensitive` declaration
+  strictly BELOW them — a `:large`-marked subtree that contains a `:sensitive`
+  descendant. Per Spec 015 §No-propagation (L338) + EP-0025 §Egress-rules
+  (a normative MUST): such a subtree REDACTS rather than showing a size preview
+  (the `:rf.size/large-elided` marker leaks `:bytes` / `:type` and — off-box,
+  digests on — a SHA-256 digest computed over a subtree that contains the
+  secret, a brute-force oracle). The walker uses this set to look ahead at a
+  large-matched node: if the matched large coordinate shadows a sensitive
+  descendant, sensitive DOMINATES and the walker descends-and-redacts instead
+  of emitting the marker. Pure function of the two declaration tables; computed
+  once per walk and carried in `ctx`."
+  [large-tbl sensitive-tbl]
+  (let [s-keys (keys sensitive-tbl)]
+    (into #{}
+          (filter (fn [lk] (some #(strict-prefix? lk %) s-keys)))
+          (keys large-tbl))))
+
 ;; The wire walker's traversal state is the pair `[path decl-paths]` — the
 ;; concrete runtime path (drives marker `:path` / `:handle` + the unschema'd-
 ;; large warning) and the forked candidate declaration-coordinate set (drives
@@ -773,6 +801,7 @@
   [ctx]
   (let [large-tbl     (:large ctx)
         sensitive-tbl (:sensitive ctx)
+        shadow-set    (:large-shadows-s ctx)
         decl-prefixes (:decl-prefixes ctx)
         include-lg?   (:include-large? ctx)
         include-s?    (:include-sensitive? ctx)
@@ -785,6 +814,26 @@
          (cond
            (and sensitive? (not include-s?))
            privacy/redacted-sentinel
+
+           ;; NESTED-AXIS SUPPRESSION (rf2-izlr7f): a `:large`-matched node
+           ;; whose matched large coordinate shadows a `:sensitive` descendant
+           ;; must NOT emit the size marker — sensitive DOMINATES. Fall through
+           ;; to `walk-recur` so the walker descends and redacts the sensitive
+           ;; descendant in place (Spec 015 §No-propagation L338, a normative
+           ;; MUST). Emitting the marker here would leak `:bytes` / `:type` and
+           ;; (off-box, digests on) a SHA-256 digest over a subtree that
+           ;; contains the secret — a brute-force oracle. Gated on
+           ;; `(not include-s?)`: the suppression exists to let the sensitive
+           ;; descendant redact on descent, so it only applies when sensitive
+           ;; redaction is in force (a caller that opted OUT of sensitive
+           ;; redaction has waived it; the large axis is then orthogonal). Only
+           ;; fires when a sensitive descendant actually exists under a large
+           ;; match, so the ordinary same-path / no-nesting large case is
+           ;; unchanged.
+           (and large-decl (not include-lg?) (not include-s?)
+                (seq shadow-set)
+                (some #(contains? shadow-set %) decl-paths))
+           walk-recur
 
            (and large-decl (not include-lg?))
            (if (marker? v)
@@ -847,6 +896,11 @@
         ctx       {:frame-id           frame-id
                    :large              large
                    :sensitive          sensitive
+                   ;; The subset of `:large` keys that shadow a `:sensitive`
+                   ;; descendant — drives the nested-axis suppression look-ahead
+                   ;; (Spec 015 §No-propagation L338, a normative MUST). Empty in
+                   ;; the common case (no nested classification).
+                   :large-shadows-s    (large-keys-shadowing-sensitive large sensitive)
                    ;; Prefix set of every declared path — bounds the forked
                    ;; candidate decl-path set as the walker descends maps.
                    ;; Empty when nothing is declared ⇒ the fork

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -299,8 +299,17 @@
   commit transition (a partition-write alongside `:db`).
 
   Each SET key (`:sensitive` / `:large`) adds `{:source :effect}` declarations
-  for its paths to the axis slot (`:sensitive-declarations` / `:declarations`);
-  each CLEAR key (`:clear-sensitive` / `:clear-large`) removes ONLY the
+  for its paths to the axis slot (`:sensitive-declarations` / `:declarations`)
+  WITHOUT clobbering a foreign-source standing entry: the registry is
+  one-entry-per-path-per-axis, so a SET on a path another owner already claims
+  (`:source :flow` / `:machine` / `:route` / a subsystem declaration) leaves
+  that owner standing rather than overwriting it to `:source :effect`
+  (rf2-p4spo4). Were it to overwrite, the later source-scoped CLEAR would
+  dissoc the entry and silently un-redact a path the other owner still
+  classifies — a privacy fail-open. The egress read needs only presence, so a
+  doubly-claimed path stays redacted and the SET is a no-op on it; only a free
+  or already-effect-owned slot is (re)stamped `:source :effect`.
+  Each CLEAR key (`:clear-sensitive` / `:clear-large`) removes ONLY the
   effect's OWN contribution to its paths from the axis slot. A clear is
   SOURCE-SCOPED: it dissocs a path only when the standing entry is
   `:source :effect` (the effect's own declaration); a path also claimed by
@@ -340,7 +349,26 @@
                     paths   (map #(vec (path/normalize-concrete %)) (get effects k))
                     cur     (get reg slot)
                     updated (if set?
-                              (reduce (fn [m p] (assoc m p {:source :effect})) (or cur {}) paths)
+                              ;; NON-CLOBBERING set (rf2-p4spo4): the registry is
+                              ;; one-entry-per-path-per-axis, so an effect SET on a
+                              ;; path ALSO claimed by another owner (`:source :flow`
+                              ;; from a reg-flow output, `:source :machine`,
+                              ;; `:source :route`, or a subsystem declaration) must
+                              ;; NOT overwrite that owner's provenance. If it did,
+                              ;; the later SOURCE-SCOPED clear below would see
+                              ;; `:source :effect`, dissoc the entry, and silently
+                              ;; un-redact a path the other owner still classifies —
+                              ;; a privacy fail-open. The egress read needs only
+                              ;; PRESENCE, so leaving the foreign owner standing
+                              ;; keeps the path redacted while preserving the source
+                              ;; the clear must honour. Only a free or already-
+                              ;; effect-owned slot is (re)stamped `:source :effect`.
+                              (reduce (fn [m p]
+                                        (let [src (:source (get m p))]
+                                          (if (or (nil? src) (= :effect src))
+                                            (assoc m p {:source :effect})
+                                            m)))
+                                      (or cur {}) paths)
                               ;; SOURCE-SCOPED clear (rf2-34jrb6): remove a path
                               ;; only when ITS standing entry is the effect's own
                               ;; (`:source :effect`). A path also claimed by a

--- a/implementation/core/test/re_frame/classification_effects_cljs_test.cljc
+++ b/implementation/core/test/re_frame/classification_effects_cljs_test.cljc
@@ -191,38 +191,42 @@
             path; a path ALSO claimed by another source (e.g. a reg-flow output
             under :source :flow) stays classified — the clear must not silently
             un-redact a path another owner still considers sensitive (a privacy
-            fail-open). rf2-34jrb6."
+            fail-open). rf2-34jrb6 + rf2-p4spo4.
+
+            This exercises the REAL cross-event path with NO artificial
+            re-assertion of the flow mark: the flow claim is installed ONCE up
+            front, then a LATER, unrelated event does SET+CLEAR on the same
+            path. Because the SET is non-clobbering (rf2-p4spo4) the flow's
+            :source survives the SET, so the source-scoped clear refuses to
+            dissoc it. Manually re-installing the flow mark between the SET and
+            the CLEAR (the prior papering pattern) is GONE — a live reg-flow
+            does NOT re-fold between two unrelated events, so that re-assertion
+            masked the SET-clobber bug."
     ;; A flow (another source) declares [:user :token] sensitive in the SAME
     ;; per-frame elision registry slot the effects write. reg-flow lives in a
     ;; separate artefact, so simulate its registry write directly via the shared
     ;; swap-elision-slot! seam (the exact slot + shape reg-flow installs:
-    ;; {:source :flow :flow-id …}).
+    ;; {:source :flow :flow-id …}). Installed ONCE — it is never re-asserted.
     (elision/swap-elision-slot! :rf/default
       (fn [reg]
         (assoc-in reg [:sensitive-declarations [:user :token]]
                   {:source :flow :flow-id :token-watch})))
     (is (= :flow (:source (get (sensitive-decls) [:user :token])))
         "the flow-sourced declaration is standing in the registry")
-    ;; An effect ALSO classifies the same path — collapses to ONE registry entry
-    ;; per path, now stamped :source :effect (the SET is the later write).
+    ;; A LATER, unrelated event ALSO classifies the same path via an effect SET.
+    ;; The NON-CLOBBERING set must leave the flow's :source standing (the
+    ;; registry is one-entry-per-path-per-axis; presence is what egress needs).
     (rf/reg-event :effect-classify-token
       (fn [{:keys [db]} _]
         {:db (assoc-in db [:user :token] "Bearer secret-xyz")
          :sensitive [[:user :token]]}))
     (rf/dispatch-sync [:effect-classify-token])
-    (is (= :effect (:source (get (sensitive-decls) [:user :token])))
-        "the same-path effect SET overwrote the entry to :source :effect")
-    ;; The effect now CLEARS the path. Source-scoped clear removes the effect's
-    ;; own contribution — but the path is STILL claimed by the flow, so it must
-    ;; remain classified and the value must stay REDACTED at egress.
-    ;; Re-install the flow declaration after the effect SET overwrote it (the
-    ;; collapse-to-one-entry means the flow's mark must be re-asserted; a live
-    ;; reg-flow would re-fold on its own lifecycle — here we model the standing
-    ;; flow claim).
-    (elision/swap-elision-slot! :rf/default
-      (fn [reg]
-        (assoc-in reg [:sensitive-declarations [:user :token]]
-                  {:source :flow :flow-id :token-watch})))
+    (is (= :flow (:source (get (sensitive-decls) [:user :token])))
+        "the same-path effect SET did NOT clobber the flow's :source (rf2-p4spo4)")
+    ;; A still-later event CLEARS the path. The source-scoped clear sees
+    ;; :source :flow (NOT :effect) and refuses to dissoc — the path stays
+    ;; classified and the value stays REDACTED. No flow mark is re-asserted
+    ;; between the SET and the CLEAR: this is the real operational sequence.
     (rf/reg-event :effect-clear-token
       (fn [{:keys [db]} _] {:db db :clear-sensitive [[:user :token]]}))
     (rf/dispatch-sync [:effect-clear-token])

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -333,6 +333,73 @@
   (is (= {:source :effect}
          (get (elision/declarations) [:root :a :b :c]))))
 
+;; rf2-izlr7f — NESTED-AXIS SUPPRESSION (the highest-priority EP-0025 egress
+;; review finding). A `:large`-marked subtree containing a `:sensitive`
+;; DESCENDANT must REDACT, not emit a size/digest marker (Spec 015
+;; §No-propagation L338 + EP-0025 §Egress-rules — a normative MUST). Before the
+;; fix both walkers emitted the `:large` marker the moment the node matched
+;; `:large`, leaking `:bytes` / `:type` and (digests on) a SHA-256 digest
+;; computed over the subtree CONTAINING the secret — a brute-force oracle.
+
+(deftest nested-axis-large-over-sensitive-redacts-not-marks
+  (testing "a :large [[:a]] subtree with a :sensitive [[:a :b]] descendant
+            REDACTS the descendant and emits NO large marker / digest over it
+            (rf2-izlr7f) — the off-box-tool floor with digests ON is the
+            verified leak scenario"
+    (install-class! [[:a :b]] [[:a]])
+    (let [secret "TOP-SECRET-TOKEN-do-not-egress"
+          input  {:a {:b secret :c "public"}}
+          ;; The off-box-tool floor: digests ON, sensitive redaction in force
+          ;; (NOT opted out). This is the exact opts that triggered the leak.
+          out    (rf/elide-wire-value input {:rf.size/include-digests? true})]
+      ;; The sensitive descendant is REDACTED in place …
+      (is (= :rf/redacted (get-in out [:a :b]))
+          "the :sensitive descendant under the :large subtree is redacted")
+      ;; … and NO large marker (which would carry :bytes / :type / :digest)
+      ;; is emitted for the large-marked subtree.
+      (is (not (elision/marker? (get out :a)))
+          "NO :rf.size/large-elided marker is emitted over the large subtree")
+      (is (map? (get out :a))
+          "the large node descended to a plain map (walk-recur), not a marker")
+      ;; The non-sensitive sibling rides through verbatim (precision).
+      (is (= "public" (get-in out [:a :c]))
+          "the unmarked sibling rides egress verbatim")
+      ;; The load-bearing privacy assertion: NEITHER the raw secret NOR a digest
+      ;; over the secret-containing subtree appears anywhere in the wire output.
+      (is (not (.contains (pr-str out) secret))
+          "the raw secret does not leak")
+      (is (not (.contains (pr-str out) "sha256"))
+          "NO SHA-256 digest (a brute-force oracle over the secret) leaks")
+      (is (not (.contains (pr-str out) ":bytes"))
+          "NO :bytes length marker leaks"))))
+
+(deftest nested-axis-whole-value-large-over-sensitive-descendant-redacts
+  (testing "the whole-value :large [[]] case with a :sensitive [[:b]] descendant
+            also descends-and-redacts (the root large match shadows the
+            descendant) — rf2-izlr7f"
+    (install-class! [[:b]] [[]])
+    (let [secret "ROOT-LEVEL-SECRET"
+          out    (rf/elide-wire-value {:b secret :other "ok"}
+                                      {:rf.size/include-digests? true})]
+      (is (= :rf/redacted (get out :b))
+          "the sensitive descendant under the whole-value large mark is redacted")
+      (is (not (elision/marker? out))
+          "no whole-value large marker is emitted")
+      (is (= "ok" (get out :other)) "the unmarked sibling rides verbatim")
+      (is (not (.contains (pr-str out) secret)) "the raw secret does not leak")
+      (is (not (.contains (pr-str out) "sha256")) "no digest leaks"))))
+
+(deftest nested-axis-large-without-sensitive-descendant-still-marks
+  (testing "the ordinary large case is UNCHANGED: a :large subtree with NO
+            sensitive descendant still emits the size marker (the suppression
+            is gated on an actual sensitive descendant) — rf2-izlr7f regression
+            guard"
+    (install-class! [[:other :token]] [[:a]])
+    (let [out (rf/elide-wire-value {:a {:b "x" :c "y"}}
+                                   {:rf.size/include-digests? true})]
+      (is (elision/marker? (get out :a))
+          "a large subtree with no sensitive descendant still emits its marker"))))
+
 (deftest clear-large-effect-removes-declaration
   ;; EP-0025: the commit-plane classification effects are additive per axis;
   ;; a path is un-classified by the `:clear-large` effect (the set/unset

--- a/implementation/core/test/re_frame/projection_cljs_test.cljc
+++ b/implementation/core/test/re_frame/projection_cljs_test.cljc
@@ -20,7 +20,9 @@
   `clojure -M:test` runner both pick it up. Plain CLJC; no DOM dependency."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.string :as string]
             [re-frame.core :as rf]
+            [re-frame.classification :as classification]
             [re-frame.elision :as elision]
             [re-frame.error :as error]
             [re-frame.frame :as frame]
@@ -189,6 +191,60 @@
       (is (redacted? (:secret out)) "the both-marked path is :rf/redacted")
       (is (not (large-marker? (:secret out)))
           "NO large marker is emitted — no path/size/digest can leak"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-izlr7f — NESTED-AXIS SUPPRESSION on the PATH walker
+;; (`classification/redact-with-paths` -> `walk-with-paths`). This walker
+;; handles event arg-maps, sub outputs, fx args, cofx values. A :large path
+;; containing a :sensitive descendant must descend-and-redact, never emit a
+;; size marker (Spec 015 §No-propagation L338, a normative MUST).
+;; ---------------------------------------------------------------------------
+
+(deftest path-walker-nested-large-over-sensitive-descendant-redacts
+  (testing "redact-with-paths: a :large [[:a]] subtree with a :sensitive
+            [[:a :b]] descendant REDACTS the descendant and emits NO large
+            marker over the subtree (rf2-izlr7f)"
+    (let [secret "PATH-WALKER-SECRET"
+          out    (classification/redact-with-paths
+                   {:a {:b secret :c "public"}}
+                   [[:a :b]]   ;; sensitive
+                   [[:a]])]    ;; large (ancestor)
+      (is (redacted? (get-in out [:a :b]))
+          "the sensitive descendant is redacted")
+      (is (not (large-marker? (get out :a)))
+          "NO large marker over the large subtree")
+      (is (= "public" (get-in out [:a :c]))
+          "the unmarked sibling rides verbatim")
+      (is (not (string/includes? (pr-str out) secret))
+          "the raw secret does not leak"))))
+
+(deftest path-walker-whole-value-large-over-sensitive-descendant-redacts
+  (testing "redact-with-paths: the whole-value :large [[]] case with a
+            :sensitive [[:b]] descendant descends-and-redacts (the common
+            sub :large? output + registration :sensitive path scenario the bead
+            names) — rf2-izlr7f"
+    (let [secret "WHOLE-VALUE-LARGE-SECRET"
+          out    (classification/redact-with-paths
+                   {:b secret :other "ok"}
+                   [[:b]]   ;; sensitive descendant
+                   [[]])]   ;; whole-value large
+      (is (redacted? (get out :b))
+          "the sensitive descendant under whole-value large is redacted")
+      (is (not (large-marker? out))
+          "NO whole-value large marker is emitted (it would carry the digest)")
+      (is (= "ok" (get out :other)) "the unmarked sibling rides verbatim")
+      (is (not (string/includes? (pr-str out) secret)) "the raw secret does not leak"))))
+
+(deftest path-walker-large-without-sensitive-descendant-still-marks
+  (testing "redact-with-paths: a :large path with NO sensitive descendant still
+            emits the marker (suppression gated on an actual descendant) —
+            rf2-izlr7f regression guard"
+    (let [out (classification/redact-with-paths
+                {:a {:b "x"}}
+                [[:elsewhere]]   ;; sensitive, NOT under [:a]
+                [[:a]])]         ;; large
+      (is (large-marker? (get out :a))
+          "a large path with no sensitive descendant still emits its marker"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Delegation to elide-wire-value — the walker, not a reimplemented walk.

--- a/implementation/machines/src/re_frame/machines/classification.cljc
+++ b/implementation/machines/src/re_frame/machines/classification.cljc
@@ -166,9 +166,21 @@
   (`{:sensitive [paths] :large [paths]}`) on a base elision-registry value
   `reg`. SET writes `{:source :machine}` at each axis slot
   (`:sensitive-declarations` / `:declarations` — the SAME slots the four
-  commit-plane effects and `reg-flow` outputs populate); DROP
-  dissocs exactly the named absolute paths (other-sourced entries survive).
-  An emptied axis slot is pruned. Returns the new registry value."
+  commit-plane effects and `reg-flow` outputs populate) WITHOUT clobbering a
+  foreign-source standing entry (the registry is one-entry-per-path-per-axis;
+  an app-effect / flow / route claim on the SAME absolute path is left
+  standing — same posture as the commit-plane SET, rf2-p4spo4); DROP is
+  SOURCE-SCOPED — it dissocs a named absolute path ONLY when its standing entry
+  is the machine's own (`:source :machine`). A path ALSO claimed by another
+  source (Spec 015 L149 explicitly permits an app to additionally classify a
+  subsystem absolute path from a handler effect, `:source :effect`) is LEFT
+  INTACT, so an actor teardown never silently un-redacts a path another owner
+  still classifies (a privacy fail-open). Mirrors the effect clear
+  (`re-frame.elision/apply-classification-effects`, source-scoped) and the
+  route lowering (`re-frame.routing.classification/without-route-sourced`,
+  which filters `:source :route`) — the sibling subsystems' source-scoped
+  drops (rf2-7bsyza). An emptied axis slot is pruned. Returns the new registry
+  value."
   [reg actor-id decls set?]
   (reduce
     (fn [reg [axis slot]]
@@ -178,8 +190,22 @@
           (let [abs (map #(absolute-snapshot-path actor-id %) paths)
                 cur (get reg slot)
                 updated (if set?
-                          (reduce (fn [m p] (assoc m p {:source :machine})) (or cur {}) abs)
-                          (apply dissoc (or cur {}) abs))]
+                          (reduce (fn [m p]
+                                    ;; Do NOT overwrite a foreign-source entry —
+                                    ;; only write the machine claim into a free
+                                    ;; or already-machine-owned slot.
+                                    (let [src (:source (get m p))]
+                                      (if (or (nil? src) (= :machine src))
+                                        (assoc m p {:source :machine})
+                                        m)))
+                                  (or cur {}) abs)
+                          ;; SOURCE-SCOPED drop: remove a path only when its
+                          ;; standing entry is the machine's own.
+                          (reduce (fn [m p]
+                                    (if (= :machine (:source (get m p)))
+                                      (dissoc m p)
+                                      m))
+                                  (or cur {}) abs))]
             (if (seq updated)
               (assoc reg slot updated)
               (dissoc reg slot))))))

--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -490,3 +490,60 @@
              :data      {}
              :states    {:idle {}}}))
         "a non-vector :sensitive axis is rejected at registration")))
+
+;; ---- (5) SOURCE-SCOPED teardown (rf2-7bsyza) ------------------------------
+;; The machine destroy drop must be source-scoped, like the effect clear
+;; (`re-frame.elision/apply-classification-effects`) and the route lowering
+;; (`re-frame.routing.classification/without-route-sourced`). Spec 015 L149
+;; permits an app to ADDITIONALLY classify a subsystem absolute snapshot path
+;; from a handler effect (`:source :effect`). If a machine teardown blanket-
+;; dissoc'd the path it would un-redact the app's still-standing classification
+;; — a privacy fail-open. The drop must remove only the machine's OWN
+;; `:source :machine` contribution.
+
+(deftest machine-destroy-is-source-scoped-does-not-un-redact-app-effect-claim
+  (testing "rf2-7bsyza — when an app ALSO classifies a machine's absolute
+            snapshot path via a handler effect (:source :effect), destroying
+            the actor drops only the machine's own :source :machine entry; the
+            app's :source :effect claim SURVIVES and the value stays REDACTED
+            at egress (no fail-open)."
+    (let [mid       :rf.machine-redaction/coupled-singleton
+          abs-token [:rf.runtime/machines :snapshots mid :data :token]]
+      (rf/reg-machine mid
+        {:sensitive [[:data :token]]
+         :initial   :anon
+         :data      {:token nil :retries 0}
+         :states    {:anon {:on {:login :authed}} :authed {}}})
+      ;; The APP additionally classifies the SAME absolute snapshot path from a
+      ;; handler effect — Spec 015 L149 explicitly permits this. It lands first
+      ;; under :source :effect.
+      (rf/reg-event :rf.machine-redaction/app-classify-token
+        (fn [{:keys [db]} _]
+          {:db db :sensitive [abs-token]}))
+      (rf/dispatch-sync [:rf.machine-redaction/app-classify-token])
+      (is (= :effect (get-in (snapshot-elision-reg)
+                             [:sensitive-declarations abs-token :source]))
+          "precondition: the app's :source :effect classification is standing")
+      ;; Booting the singleton lowers the machine declaration at the SAME path.
+      ;; The machine SET must NOT clobber the app's :source :effect claim.
+      (rf/dispatch-sync [mid [:rf.machine/noop]])
+      (is (= :effect (get-in (snapshot-elision-reg)
+                             [:sensitive-declarations abs-token :source]))
+          "the machine SET did NOT clobber the app's :source :effect claim")
+      ;; Destroy the actor. The DROP must be source-scoped — it must NOT remove
+      ;; the app's :source :effect entry.
+      (rf/reg-event :rf.machine-redaction/destroy-coupled
+        (fn [_ _] {:fx [[:rf.machine/destroy mid]]}))
+      (rf/dispatch-sync [:rf.machine-redaction/destroy-coupled])
+      (let [reg (snapshot-elision-reg)]
+        (is (contains? (:sensitive-declarations reg) abs-token)
+            "the path is STILL classified after destroy — the app's claim survives")
+        (is (= :effect (get-in reg [:sensitive-declarations abs-token :source]))
+            "the surviving entry is the app's :source :effect, not the machine's"))
+      ;; And egress still redacts — the fail-open is sealed.
+      (let [out  (classification/project-trace-event (machine-transition-event mid))
+            tags (:tags out)]
+        (is (= :rf/redacted (get-in tags [:after :data :token]))
+            "the value stays REDACTED at egress — the teardown did not un-redact it")
+        (is (not (.contains (pr-str out) "secret-jwt"))
+            "no secret leaks through the post-destroy egress")))))

--- a/spec/conformance/fixtures/data-classification-nested-large-over-sensitive-redacts.edn
+++ b/spec/conformance/fixtures/data-classification-nested-large-over-sensitive-redacts.edn
@@ -1,0 +1,68 @@
+;; Conformance fixture: data-classification/nested-large-over-sensitive-redacts
+;;
+;; Per Spec 015 §No-propagation (L338) + EP-0025 §Egress-rules (a normative
+;; MUST): a `:large`-marked subtree that CONTAINS a `:sensitive` DESCENDANT
+;; REDACTS the descendant rather than showing a size preview. The
+;; `:rf.size/large-elided` marker a naive walker would emit at the large
+;; ancestor leaks `:bytes` / `:type` and (off-box, digests on) a SHA-256
+;; digest computed over a subtree that CONTAINS the secret — a brute-force
+;; oracle. Sensitive DOMINATES nested under large, just as it does at the same
+;; path (the sibling `sensitive-wins-over-large.edn` fixture).
+;;
+;; The OBSERVABLE seam is the t1 `:rf.event/db-pending` trace event (same emit
+;; + projection path as the sibling sensitive / large / sensitive-wins
+;; fixtures — projected through `re-frame.elision/elide-wire-value`). The
+;; large-marked ancestor `[:a]` descends to a PLAIN map; its `:sensitive`
+;; descendant `[:a :b]` elides to the bare `:rf/redacted` sentinel; the
+;; unmarked sibling `[:a :c]` rides egress verbatim. The assertion pins the
+;; EXACT projected `:rf.event/db` value, which by construction proves NO large
+;; marker leaked at `[:a]` (a `{:rf.size/large-elided …}` map would fail the
+;; literal `=`).
+;;
+;; Mirrors the unit-level
+;; `re-frame.elision-test/nested-axis-large-over-sensitive-redacts-not-marks`
+;; (schema-first walker) and
+;; `re-frame.projection-cljs-test/path-walker-nested-large-over-sensitive-
+;; descendant-redacts` (path walker) deftests, lifted to the host-agnostic
+;; corpus through the runtime's emit-time projection chokepoint. rf2-izlr7f.
+;;
+;; Harness note: `:fixture/app-marks` declares `[:a]` :large and `[:a :b]`
+;; :sensitive via two ordered `add-marks` ops. Capability
+;; `:data-classification/marks`.
+
+{:fixture/id           :data-classification/nested-large-over-sensitive-redacts
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/trace
+                         :data-classification/marks}
+ :fixture/doc          "A :large-marked subtree [:a] containing a :sensitive descendant [:a :b] REDACTS the descendant in place and emits NO :rf.size/large-elided marker (which would leak path / size / type / digest over the secret-containing subtree) at [:a] in the t1 :rf.event/db-pending trace event. The non-sensitive sibling [:a :c] rides egress verbatim. Sensitive dominates nested under large (Spec 015 §No-propagation, a normative MUST)."
+
+ :fixture/registry
+ {:event {:dc/store {:doc "Writes a large-marked subtree carrying a sensitive descendant + a plain sibling into app-db."}}}
+
+ :fixture/handlers
+ {:event {:dc/store [[:set [:a :b] "TOP-SECRET-TOKEN"]
+                     [:set [:a :c] "public"]]}}
+
+ ;; Declare [:a] :large (the ancestor subtree) and [:a :b] :sensitive (a
+ ;; strict descendant) — two ordered add-marks ops. The nested-axis
+ ;; suppression must fire regardless of declaration order.
+ :fixture/app-marks
+ [{:add-marks {[:a] :large}}
+  {:add-marks {[:a :b] :sensitive}}]
+
+ :fixture/frame-config
+ {:initial-events [[:dc/store]]}
+
+ :fixture/dispatches
+ [[:dc/store]]
+
+ :fixture/expect
+ ;; The committed app-db is the RAW value — redaction is trace-egress only.
+ {:final-app-db {:a {:b "TOP-SECRET-TOKEN" :c "public"}}
+
+  ;; The load-bearing assertion: the large ancestor [:a] is a PLAIN map (NOT a
+  ;; large marker), its sensitive descendant [:a :b] is the bare :rf/redacted
+  ;; sentinel, and the unmarked sibling [:a :c] rides raw.
+  :trace-emissions
+  [{:operation :rf.event/db-pending
+    :tags      {:rf.event/db {:a {:b :rf/redacted :c "public"}}}}]}}


### PR DESCRIPTION
Three coupled EP-0025 PRIVACY-CORRECTNESS defects from the deep review, all real fail-open leaks on the elision / classification / machines surface. Smallest-risk-first commits; each fix carries a regression test that fails without it (verified by temporary revert).

## rf2-izlr7f (P2, SECURITY) — nested-axis suppression

Spec 015 §No-propagation L338 + EP-0025 §Egress-rules are a normative MUST: a `:large`-marked subtree containing a `:sensitive` DESCENDANT must REDACT, not show a size preview. Neither walker implemented it — both emitted the `:large` marker the moment a node matched `:large`, with no look-ahead.

VERIFIED LEAK: `:large [[:a]]` + `:sensitive [[:a :b]]` over `{:a {:b SECRET :c public}}` emitted `:rf.size/large-elided` leaking `:bytes`/`:type` and (off-box-tool profile, digests ON) a SHA-256 DIGEST computed over the subtree CONTAINING the secret — a brute-force oracle. Leaks through every consumer of the shared walker.

FIX: both walkers look ahead at a `:large`-matched node — if any `:sensitive` decl is a STRICT descendant of the matched large coordinate, sensitive DOMINATES and the walker descends-and-redacts (`walk-recur`) instead of emitting the marker.
- schema-first wire walker (`elision.cljc` `walk-decider`): a precomputed `large-keys-shadowing-sensitive` set in `ctx`, gated on `(not include-s?)`.
- path walker (`classification.cljc` `walk-with-paths`): a strict-prefix test against the sensitive-set.

Both gate on an ACTUAL sensitive descendant, so the ordinary same-path / no-nesting large case is unchanged. New host-agnostic conformance fixture pins the db-pending trace-egress seam (JVM + CLJS).

## rf2-p4spo4 (P2) — non-clobbering classification SET

`apply-classification-effects` SET arm unconditionally stamped `{:source :effect}`, clobbering an existing flow/machine/route entry's provenance in the one-entry-per-path-per-axis registry. A later source-scoped `:clear-*` then saw `:source :effect`, dissoc'd the entry, and silently un-redacted a path the other owner still classifies — the value shipped RAW (privacy fail-open). SET is now non-clobbering: it (re)stamps `:source :effect` only into a free or already-effect-owned slot. The papering acceptance test (which manually re-installed the flow mark between the SET and the CLEAR) is rewritten to exercise the REAL cross-event path with no re-assertion — it fails without the fix.

## rf2-7bsyza (P2) — source-scoped machine teardown drop

Machine `apply-decls` DROP path dissoc'd snapshot paths unconditionally, ignoring `:source` — contradicting its own docstring and diverging from the sibling source-scoped drops (effect clear, route lowering). Spec 015 L149 permits an app to ALSO classify a subsystem absolute snapshot path from a handler effect; an actor teardown then un-redacted that app-`:source :effect` path. DROP is now source-scoped (removes only `:source :machine`); the SET arm is also made non-clobbering for the same registry-collapse reason. New cross-source teardown regression test fails without the fix.

## Quality gates

- rf2-izlr7f — nested-axis suppression
- rf2-p4spo4 — non-clobbering classification SET
- rf2-7bsyza — source-scoped machine teardown drop

All green locally:
- `npm run test:cljs` — 7973 tests / 36663 assertions, 0 failures (includes the new conformance fixture + classification/projection/elision on the node runtime)
- `npm run test:elision` — PASS, production 42/42 absent (new code stays production-elided)
- JVM core full suite — 1698 tests / 7362 assertions, 0 failures (conformance corpus + elision + projection + classification)
- JVM machines full suite — 785 tests / 2586 assertions, 0 failures
- `npm run test:security` — 91 tests / 657 assertions, 0 failures; JVM security artefact — 90 tests / 650 assertions, 0 failures

CI is the merge gate.