### PR TITLE
fix(ssr): project route slice classification at SSR hydration boundary — stop raw query/params leak (rf2-4xut98)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -335,6 +335,75 @@
     {:frame             frame-id
      :rf.egress/profile :rf.egress/ssr-hydration}))
 
+;; ---- ssr-hydration egress projection of the routing slice (rf2-4xut98) ----
+;;
+;; EP-0025 §Subsystem matrix (`reg-route` row) + Spec 012 §Route data
+;; classification + Spec 015 §SSR: a route declares `:sensitive` / `:large`
+;; paths PROJECTION-RELATIVE to its `{:query … :params …}` current-state
+;; projection (`(rf/reg-route … {:sensitive [[:query :token]]} …)`). At route
+;; activation those declarations are RE-ROOTED under
+;; `[:rf.runtime/routing :current …]` and lowered into the per-frame elision
+;; registry (`re-frame.routing.classification/apply-route-classification`,
+;; `:source :route`) — the SAME `[:rf.runtime/elision …]` slot the
+;; `:rf.egress/ssr-hydration` egress walk reads. But the prior
+;; `project-runtime-db` shipped the routing `:current` slice via a bare
+;; `select-keys`, so a route declaring `:sensitive [[:query :token]]` installed
+;; the registry decl yet serialised the raw `:query` / `:params` value into the
+;; hydration `:rf/runtime-db` payload (the leak rf2-4xut98 names). This mirrors
+;; the IDENTICAL leak class machines fixed under rf2-jm2u63 (snapshots shipped
+;; raw before the `:machines/project-ssr-runtime-db` hook), and the app-db slice
+;; fixed under rf2-bt9kct (`project-app-db-egress` above).
+;;
+;; The routing decls are stored as ABSOLUTE runtime-db paths
+;; (`[:rf.runtime/routing :current :query :token]`), so the slice is walked
+;; through `project-egress` seeded at the offset `:path [:rf.runtime/routing]`:
+;; `elide-wire-value`'s `:path` opt seeds the candidate declaration-coordinate
+;; set, so a value walked under that offset matches the registry's re-rooted
+;; route paths exactly. A `:sensitive` route path redacts to `:rf/redacted`; a
+;; `:large` one elides to the size marker; an unclassified route slice rides
+;; verbatim (the projection is precise, not a blanket scrub) — only the
+;; classified paths are touched.
+
+(defn project-routing-egress
+  "Run the already-allowlisted durable routing `slice` (the `{:current …}`
+  map, the `durable-routing-keys` projection of `:rf.runtime/routing`) through
+  the centralized `:rf.egress/ssr-hydration` egress projection seeded at
+  `frame-id`, so a route's projection-relative `:sensitive` / `:large`
+  classification — lowered into the per-frame elision registry under
+  `[:rf.runtime/routing :current …]` at route activation — redacts / elides the
+  classified `:query` / `:params` value before it serialises into the hydration
+  `:rf/runtime-db` (Spec 012 §Route data classification, Spec 015 §SSR,
+  EP-0025). Mirrors `project-app-db-egress` (app-db slice, rf2-bt9kct) and the
+  machines `:machines/project-ssr-runtime-db` hook (snapshot `:data`, rf2-jm2u63).
+
+  The route decls are stored as ABSOLUTE runtime-db paths
+  (`[:rf.runtime/routing :current :query :token]`), so the walk is seeded at the
+  offset `:path [:rf.runtime/routing]` — `elide-wire-value` seeds the candidate
+  declaration-coordinate set with the offset, so the slice value matches the
+  registry's re-rooted route paths exactly. Defers to
+  `re-frame.projection/project-egress` (over the shared `elide-wire-value`
+  walker) — never a family-private elider.
+
+  No-live-frame ⇒ the slice rides VERBATIM, mirroring the sibling machines
+  snapshot projection (`re-frame.machines.ssr/project-snapshot-data` rides
+  verbatim when `frame-id` is nil). The route classification is a PATH-precise
+  redaction of declared `:query` / `:params` slots — like machines, it is not a
+  fail-closed whole-value scrub: with no live frame there are no route
+  declarations to apply, so the durable route slice (already allowlisted to
+  `:current`) passes through. A real server render always carries the live
+  request frame, so the projection runs against that frame's route declarations.
+  This is why we do NOT hand a kindless slice straight to `project-egress` with
+  a nil frame (which would fail closed and redact the whole `:current` slice to
+  `:rf/redacted`)."
+  [slice frame-id]
+  (if (and (some? frame-id) (some? (frame/frame frame-id)))
+    (projection/project-egress
+      slice
+      {:frame             frame-id
+       :path              [:rf.runtime/routing]
+       :rf.egress/profile :rf.egress/ssr-hydration})
+    slice))
+
 ;; ---- runtime-db projection (EP-0001 rf2-30kzz2) --------------------------
 ;;
 ;; Per Spec 011 §The hydration payload (`:rf/runtime-db`) + §Off-box redaction
@@ -386,7 +455,8 @@
     - `:rf.runtime/routing`  — only the durable `:current` route slice
       (`:pending-navigation` is local-subscribable client state; the
       scroll / nav-token / pending-nav caches are host-side transient
-      state, not runtime-db at all — rf2-1hncp2 / rf2-oosjmh);
+      state, not runtime-db at all — rf2-1hncp2 / rf2-oosjmh), PROJECTED
+      against the frame's route classification (rf2-4xut98 — see below);
     - `:rf.runtime/elision`  — the wire-elision declaration registry;
     - `:rf.runtime/ssr`       — the SSR hydration metadata.
 
@@ -404,7 +474,17 @@
   symmetric with the resource projection's `:ssr/extend-runtime-db-projection`.
   When the machines artefact is absent the hook is unbound and the slice rides
   unchanged (a runtime-db with `:rf.runtime/machines` but no machines artefact
-  loaded cannot carry actor snapshots anyway)."
+  loaded cannot carry actor snapshots anyway).
+
+  rf2-4xut98 — the `:rf.runtime/routing` slice is NOT shipped raw either: the
+  allowlisted durable `:current` route slice is run through
+  `project-routing-egress` under the `:rf.egress/ssr-hydration` boundary, so a
+  route's projection-relative `:sensitive` / `:large` `:query` / `:params`
+  classification (re-rooted under `[:rf.runtime/routing :current …]` into the
+  per-frame elision registry at route activation) redacts / elides before it
+  rides the hydration blob raw — symmetric with the machines snapshot
+  projection and the app-db slice projection. An unclassified route slice rides
+  verbatim (the walk is path-precise)."
   [runtime-db]
   (when (map? runtime-db)
     (let [project-machines (late-bind/get-fn :machines/project-ssr-runtime-db)
@@ -413,13 +493,20 @@
                              (if project-machines
                                (project-machines runtime-db frame-id)
                                (:rf.runtime/machines runtime-db)))
+          ;; Allowlist the durable routing keys (only `:current` rides; the
+          ;; transient `:pending-navigation` / counter siblings stay off the
+          ;; wire — fail-closed), THEN project the surviving slice against the
+          ;; frame's route classification so a `:sensitive` / `:large` query /
+          ;; param redacts / elides (rf2-4xut98) before it serialises raw.
+          routing-allowed  (select-keys (:rf.runtime/routing runtime-db) durable-routing-keys)
+          routing-slice    (when (seq routing-allowed)
+                             (project-routing-egress routing-allowed frame-id))
           slice (cond-> {}
                   (contains? runtime-db :rf.runtime/machines)
                   (assoc :rf.runtime/machines machines-slice)
 
-                  (seq (select-keys (:rf.runtime/routing runtime-db) durable-routing-keys))
-                  (assoc :rf.runtime/routing
-                         (select-keys (:rf.runtime/routing runtime-db) durable-routing-keys))
+                  (some? routing-slice)
+                  (assoc :rf.runtime/routing routing-slice)
 
                   (contains? runtime-db :rf.runtime/elision)
                   (assoc :rf.runtime/elision (:rf.runtime/elision runtime-db))

--- a/implementation/ssr/test/re_frame/ssr_route_slice_projection_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_route_slice_projection_test.clj
@@ -1,0 +1,162 @@
+(ns re-frame.ssr-route-slice-projection-test
+  "rf2-4xut98 — the SSR hydration `:rf/runtime-db` payload must NOT ship a
+  route's classified `:query` / `:params` RAW.
+
+  EP-0025 §Subsystem matrix (`reg-route` row) + Spec 012 §Route data
+  classification + Spec 015 §SSR: a route declares its sensitive / large
+  `:query` / `:params` slots PROJECTION-RELATIVE
+  (`(rf/reg-route :route/oauth-callback {:sensitive [[:query :token]]} …)`).
+  At route activation those declarations are RE-ROOTED under
+  `[:rf.runtime/routing :current …]` and lowered into the per-frame elision
+  registry (`re-frame.routing.classification/apply-route-classification`,
+  `:source :route`). Hydration is a serialized-state egress boundary projected
+  under `:rf.egress/ssr-hydration`. The SSR `:rf/runtime-db` payload ships the
+  durable `:current` route slice so the client reconstitutes the active route —
+  but the prior `project-runtime-db` copied that slice via a bare `select-keys`,
+  so a route whose `:query` / `:params` the frame classifies sensitive / large
+  shipped that value RAW.
+
+  This is the IDENTICAL leak class machines fixed under rf2-jm2u63 (durable
+  snapshots shipped `:data` raw before `:machines/project-ssr-runtime-db`) and
+  app-db fixed under rf2-bt9kct (`project-app-db-egress`). The fix runs the
+  allowlisted routing slice through `project-routing-egress` (the
+  `:rf.egress/ssr-hydration` profile, seeded at the offset
+  `:path [:rf.runtime/routing]` so the registry's absolute re-rooted route paths
+  match), mirroring the machines hook.
+
+  This pins the fix end-to-end on the ACTUAL SSR projection path
+  (`re-frame.ssr.payload-policy/project-runtime-db` →
+  `re-frame.ssr.payload-policy/build-payload`), driving a genuine route
+  `:sensitive` / `:large` declaration through the route classification lowering
+  (`re-frame.routing.classification`, `:source :route`) installed into the live
+  request frame's elision registry. The existing
+  `payload_policy_cljs_test/project-runtime-db-ships-durable-omits-transient`
+  uses a NON-sensitive sample route, so the leak was invisible there — this is
+  the sensitive-route regression that gap called for (rf2-ugoxyv)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            ;; Loading routing publishes the route classification machinery
+            ;; and the routing fxs; the reset fixture reloads it.
+            [re-frame.routing]
+            [re-frame.routing.classification :as route-class]
+            [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.ssr.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+;; ---- the route under test -------------------------------------------------
+;;
+;; An OAuth-callback-shaped route: the `:query :token` carries a live secret
+;; (classify SENSITIVE → redact), the `:params :payload` carries a large blob
+;; (classify LARGE → elide to the size marker), and `:query :return-to` is a
+;; plain navigation breadcrumb (classified by nothing → rides verbatim). The
+;; declaration is PROJECTION-RELATIVE to the route's `{:query … :params …}`
+;; current-state projection, exactly as Spec 012 documents.
+
+(def ^:private route-id :route/oauth-callback)
+
+(def ^:private route-classification
+  {:sensitive [[:query :token]]
+   :large     [[:params :payload]]})
+
+(defn- install-route-classification!
+  "Lower `route-id`'s projection-relative `:sensitive` / `:large` classification
+  (`validate+extract` → `apply-route-classification`, the genuine `:source
+  :route` lowering re-rooting each path under `[:rf.runtime/routing :current
+  …]`) into the LIVE `:rf/default` frame's per-frame elision registry — the same
+  registry the `:rf.egress/ssr-hydration` egress walk reads at SSR projection
+  time. Mirrors the machines test's commit-plane-effect install, but exercises
+  the real route classification path."
+  []
+  (let [lowered (route-class/apply-route-classification
+                  {}
+                  (route-class/validate+extract route-id route-classification))
+        reg     (get lowered :rf.runtime/elision)]
+    ;; Write the lowered route-sourced registry into the live frame's runtime-db
+    ;; partition — the canonical durable home of `[:rf.runtime/elision]`.
+    (elision/swap-elision-slot! :rf/default (constantly reg))))
+
+(defn- runtime-db-with-secret-route
+  "A runtime-db carrying the durable `:current` route slice the SSR hydration
+  payload would ship — a live secret token in `:query`, a large blob in
+  `:params`, plus a plain `:return-to` breadcrumb and the `:route-id`. The
+  transient `:pending-navigation` sibling is included to prove the allowlist
+  still strips it (fail-closed)."
+  []
+  {:rf.runtime/routing
+   {:current            {:route-id  route-id
+                         :query     {:token     "secret-oauth-token"
+                                     :return-to "/dashboard"}
+                         :params    {:payload "huge-callback-blob-value"}}
+    :pending-navigation {:id "pn-1" :reason :can-leave}}})
+
+;; ---- the leak regression (project-runtime-db) -----------------------------
+
+(deftest sensitive-route-query-redacted-in-hydration-projection
+  (testing "a route-declared sensitive :query path is redacted to :rf/redacted
+            in the SSR :rf/runtime-db projection; the large :params path elides;
+            the plain :query sibling rides verbatim; the transient
+            :pending-navigation is stripped"
+    (install-route-classification!)
+    (let [slice   (payload-policy/project-runtime-db (runtime-db-with-secret-route))
+          current (get-in slice [:rf.runtime/routing :current])]
+      (is (= :rf/redacted (get-in current [:query :token]))
+          "route-declared sensitive :query :token redacted in the hydration slice")
+      (is (contains? (get-in current [:params :payload]) :rf.size/large-elided)
+          "route-declared large :params :payload elided to the size marker")
+      (is (= "/dashboard" (get-in current [:query :return-to]))
+          "the unclassified :query sibling rides the wire verbatim")
+      (is (= route-id (:route-id current))
+          ":route-id (durable structural fact) rides verbatim")
+      (is (not (contains? (:rf.runtime/routing slice) :pending-navigation))
+          "transient :pending-navigation is stripped by the durable allowlist")
+      (is (not (.contains (pr-str slice) "secret-oauth-token"))
+          "no raw token survives anywhere in the projected runtime-db slice")
+      (is (not (.contains (pr-str slice) "huge-callback-blob-value"))
+          "no raw large value survives in the projected runtime-db slice"))))
+
+(deftest full-hydration-payload-redacts-route-slice
+  (testing "the full :rf/hydration-payload's :rf/runtime-db carries the
+            redacted/elided route :query / :params, not the raw classified
+            values"
+    (install-route-classification!)
+    (let [rt-slice (payload-policy/project-runtime-db (runtime-db-with-secret-route))
+          payload  (payload-policy/build-payload
+                     :rf/default {:public/page :callback} "h1"
+                     {:version 1 :runtime-db rt-slice})
+          current  (get-in payload [:rf/runtime-db :rf.runtime/routing :current])]
+      (is (= :rf/redacted (get-in current [:query :token])))
+      (is (contains? (get-in current [:params :payload]) :rf.size/large-elided))
+      (is (not (.contains (pr-str payload) "secret-oauth-token"))
+          "the hydration blob the client receives carries no raw secret")
+      (is (not (.contains (pr-str payload) "huge-callback-blob-value"))))))
+
+(deftest unclassified-route-slice-rides-verbatim
+  (testing "a route whose frame declares no classification ships its :current
+            slice verbatim — the projection is precise, not a blanket scrub"
+    ;; No install-route-classification! — the frame carries no route decls.
+    (let [rt      {:rf.runtime/routing
+                   {:current {:route-id :route/home
+                              :query    {:token "still-here"}}}}
+          slice   (payload-policy/project-runtime-db rt)
+          current (get-in slice [:rf.runtime/routing :current])]
+      (is (= "still-here" (get-in current [:query :token]))
+          "an unclassified route query rides the hydration wire verbatim")
+      (is (= :route/home (:route-id current))))))
+
+;; ---- confirm the route classification really reaches the registry ---------
+
+(deftest route-classification-lowers-absolute-rerooted-paths
+  (testing "the route lowering installs ABSOLUTE re-rooted runtime-db paths
+            (`[:rf.runtime/routing :current :query :token]`) into the live
+            frame's elision registry — the path the SSR egress walk matches"
+    (install-route-classification!)
+    (let [reg (get (frame/frame-runtime-db-value :rf/default) :rf.runtime/elision)]
+      (is (contains? (:sensitive-declarations reg)
+                     [:rf.runtime/routing :current :query :token])
+          "sensitive :query :token re-rooted to its absolute runtime-db path")
+      (is (contains? (:declarations reg)
+                     [:rf.runtime/routing :current :params :payload])
+          "large :params :payload re-rooted to its absolute runtime-db path"))))


### PR DESCRIPTION
## Summary

EP-0025 routing review (rf2-oe9o1t, correctness) found a **P1 privacy leak**: the SSR hydration `:rf/runtime-db` payload shipped a route's classified `:query` / `:params` values **RAW** to every hydrating client.

`re-frame.ssr.payload-policy/project-runtime-db` copied the routing `:current` slice via a bare `select-keys` with **no projection step** — while machines snapshots ARE projected (the `:machines/project-ssr-runtime-db` hook, rf2-jm2u63) and the app-db slice IS projected (`project-app-db-egress`, rf2-bt9kct) at the same boundary. A route declaring `:sensitive [[:query :token]]` correctly lowered the re-rooted classification (`[:rf.runtime/routing :current :query :token]`, `:source :route`) into the per-frame elision registry — that registry even rode the wire — but nothing ever **applied** it to the route slice. `:rf.egress/ssr-hydration` is a covered, fail-closed egress boundary (Spec 012 §Route data classification, Spec 015 §SSR, EP-0025 stage 7), so this was a real leak, not fail-open.

## The fix

New `project-routing-egress` runs the allowlisted durable routing slice through `re-frame.projection/project-egress` under the `:rf.egress/ssr-hydration` profile, **mirroring machines** — over the shared `elide-wire-value` walker, never a family-private elider. Because the route decls are stored as absolute re-rooted runtime-db paths, the walk is seeded at the offset `:path [:rf.runtime/routing]` so `elide-wire-value`'s candidate declaration-coordinate seed matches the registry's `[:rf.runtime/routing :current :query :token]` paths exactly.

- A `:sensitive` route path redacts to `:rf/redacted`.
- A `:large` route path elides to the size marker.
- An unclassified route slice rides **verbatim** (path-precise, not a blanket scrub).
- No live frame ⇒ verbatim, mirroring the machines snapshot projection's nil-frame behaviour (a real server render always carries the live request frame; we don't hand a kindless slice to `project-egress` with a nil frame, which would fail closed and redact the whole `:current` slice).

## Tests

New `implementation/ssr/test/re_frame/ssr_route_slice_projection_test.clj` drives a genuine sensitive/large route classification (the real route lowering, `:source :route`, re-rooted paths) installed into the live request frame, through the actual SSR projection path (`project-runtime-db` → `build-payload`), asserting the sensitive `:query :token` redacts, the large `:params :payload` elides, the plain `:query :return-to` sibling rides verbatim, the transient `:pending-navigation` is stripped, and no raw secret survives anywhere in the payload. A non-sensitive route control + a registry-reroot assertion round it out.

The reviewers noted the existing SSR projection test used a **non-sensitive** route, which masked this (rf2-ugoxyv gap). **Confirm-by-revert:** with the bare `select-keys` restored, the new regression fails (raw secrets present in the payload); with the fix, green.

Touches only `implementation/ssr` (payload_policy.cljc + new test). Does not touch `ssr.cljc`'s output-sensitivity propagation engine (held decision rf2-71dr8t) or core.

## Quality gates

- `clojure -M:test` (ssr JVM suite): **363 tests, 1463 assertions, 0 failures, 0 errors** (green)
- `npm run test:cljs`: **7970 tests, 36654 assertions, 0 failures, 0 errors** (green)
- `npm run test:elision` (touched a projection path): **PASS** — production 42/42 absent, control 42/42 present (production stays elided)
- Confirm-by-revert: regression fails on the pre-fix bare `select-keys`, passes with the fix

CI is the merge gate.