### PR TITLE
test(flows): EP-0025 flow-bad-marks validation + flow-mark egress-redaction coverage (rf2-r87zhb, rf2-i6l02n)

### DIFF
--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -20,6 +20,7 @@
     - clear-all / lifecycle interaction with the per-frame registry"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.elision :as elision]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -576,6 +577,195 @@
                              :inputs []
                              :derive (fn [] 42)
                              :output-path   [:k]})))))
+
+;; ---------------------------------------------------------------------------
+;; 1c. validate-flow data-classification well-formedness (EP-0025
+;;     :rf.error/flow-bad-marks)
+;;
+;; EP-0025 lets a `reg-flow` registration carry data-classification keys
+;; describing the SENSITIVITY / SIZE of the flow's OWN output value:
+;; `:sensitive [paths]`, `:large [paths]`, and the `:large?` whole-output size
+;; override (`[[]]` marks the whole output). `validate-flow`'s rejection table
+;; (registry.cljc ~L558-612) fail-CLOSES on a malformed classification shape
+;; rather than silently installing no redaction / large-elision — the worst
+;; failure mode for a SAFETY feature is the author believing a slot is
+;; protected when it is not.
+;;
+;; These rules fire AFTER the core `:id` / `:inputs` / `:derive` /
+;; `:output-path` rules but BEFORE any registry / app-db / elision-declaration
+;; state mutates (`validate-flow` is the first call in `reg-flow`). So a
+;; rejected registration installs NO flow row and NO elision declaration. The
+;; sibling `flow-missing-id` / `flow-bad-id` / `flow-bad-inputs` /
+;; `flow-bad-output` / `flow-bad-path` / `flow-cycle` families are covered
+;; above and in flows_destroy_frame_teardown_test; this block backstops the
+;; EP-0025-added `:rf.error/flow-bad-marks` family, which had ZERO coverage
+;; (rf2-r87zhb). Spec 015:325 names `:rf.error/flow-bad-marks` normatively.
+;;
+;; Branch on the canonical `:rf.error/id` discriminator, never on the
+;; (human-sentence) message string.
+
+(defn- flow-bad-marks? [^Throwable t]
+  (= :rf.error/flow-bad-marks (:rf.error/id (ex-data t))))
+
+(defn- reg-flow-throwing
+  "reg-flow `flow-map`, returning the thrown Throwable (or nil if it did not
+  throw). Centralises the try/catch so each malformation test reads as a
+  single assertion against the canonical id + ex-data shape."
+  [flow-map]
+  (try (rf/reg-flow flow-map) nil
+       (catch Throwable t t)))
+
+(deftest reg-flow-rejects-non-vector-sensitive
+  (testing ":sensitive must be a vector of output subpaths — a non-vector is
+            rejected :rf.error/flow-bad-marks with :bad-key / :bad-value"
+    (let [bad {:secret :leak}                      ; a map, not a vector
+          ex  (reg-flow-throwing {:id          :bad/sensitive-shape
+                                  :inputs      [[:n]]
+                                  :derive      identity
+                                  :output-path [:out]
+                                  :sensitive   bad})]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-marks? ex) "error id is :rf.error/flow-bad-marks")
+      (is (re-find #"\[:rf\.error/flow-bad-marks\]" (ex-message ex))
+          "message carries the [:rf.error/flow-bad-marks] token")
+      (is (= :sensitive (:bad-key (ex-data ex)))
+          "ex-data names the offending key")
+      (is (= bad (:bad-value (ex-data ex)))
+          "ex-data carries the offending value for the diagnostic"))))
+
+(deftest reg-flow-rejects-malformed-sensitive-entry
+  (testing ":sensitive entries must each be a vector of path segments — a bare
+            keyword entry is rejected :rf.error/flow-bad-marks with :bad-entries"
+    ;; [:token] (a bare keyword) is NOT a valid output subpath — a subpath is a
+    ;; vector of scalar keys ([] = whole output). The diagnostic distinguishes
+    ;; "you passed a non-vector" (above) from "one of your entries is malformed".
+    (let [ex (reg-flow-throwing {:id          :bad/sensitive-entry
+                                 :inputs      [[:n]]
+                                 :derive      identity
+                                 :output-path [:out]
+                                 :sensitive   [[:ok] :token]})]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-marks? ex) "error id is :rf.error/flow-bad-marks")
+      (is (= :sensitive (:bad-key (ex-data ex)))
+          "ex-data names the offending key")
+      (is (= [:token] (:bad-entries (ex-data ex)))
+          "only the malformed entry is named — the well-formed [:ok] is fine"))))
+
+(deftest reg-flow-rejects-non-vector-large
+  (testing ":large must be a vector of output subpaths — a non-vector is
+            rejected :rf.error/flow-bad-marks with :bad-key / :bad-value"
+    (let [bad "blob"                               ; a string, not a vector
+          ex  (reg-flow-throwing {:id          :bad/large-shape
+                                  :inputs      [[:n]]
+                                  :derive      identity
+                                  :output-path [:out]
+                                  :large       bad})]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-marks? ex) "error id is :rf.error/flow-bad-marks")
+      (is (= :large (:bad-key (ex-data ex)))
+          "ex-data names the offending key")
+      (is (= bad (:bad-value (ex-data ex)))
+          "ex-data carries the offending value"))))
+
+(deftest reg-flow-rejects-malformed-large-entry
+  (testing ":large entries must each be a vector of path segments — a
+            collection path step is rejected :rf.error/flow-bad-marks"
+    ;; [[:nested]] is a path whose step is itself a vector (not a scalar key),
+    ;; so it is not a valid output subpath.
+    (let [ex (reg-flow-throwing {:id          :bad/large-entry
+                                 :inputs      [[:n]]
+                                 :derive      identity
+                                 :output-path [:out]
+                                 :large       [[:ok] [[:nested]]]})]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-marks? ex) "error id is :rf.error/flow-bad-marks")
+      (is (= :large (:bad-key (ex-data ex)))
+          "ex-data names the offending key")
+      (is (= [[[:nested]]] (:bad-entries (ex-data ex)))
+          "only the malformed entry is named — the well-formed [:ok] is fine"))))
+
+(deftest reg-flow-rejects-boolean-sensitive?-spelling
+  (testing "the boolean :sensitive? spelling is rejected on a flow output
+            (EP-0025) — :rf.error/flow-bad-marks, with :use :sensitive pointing
+            at the correct whole-output spelling :sensitive [[]]"
+    ;; EP-0025 removed flow input→output propagation; the boolean :sensitive?
+    ;; spelling stays rejected (use :sensitive [[]] for a whole-output mark).
+    (let [ex (reg-flow-throwing {:id          :bad/sensitive?-spelling
+                                 :inputs      [[:n]]
+                                 :derive      identity
+                                 :output-path [:out]
+                                 :sensitive?  true})]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-marks? ex) "error id is :rf.error/flow-bad-marks")
+      (is (= :sensitive? (:bad-key (ex-data ex)))
+          "ex-data names the rejected :sensitive? key")
+      (is (= true (:bad-value (ex-data ex)))
+          "ex-data carries the offending boolean value")
+      (is (= :sensitive (:use (ex-data ex)))
+          "ex-data :use points at the correct :sensitive spelling"))))
+
+(deftest reg-flow-rejects-output-sensitivity-propagation-key
+  (testing ":rf.egress/output-sensitivity is removed (EP-0025 — no flow
+            input→output propagation) and rejected :rf.error/flow-bad-marks"
+    (let [ex (reg-flow-throwing {:id                            :bad/output-sensitivity
+                                 :inputs                        [[:n]]
+                                 :derive                        identity
+                                 :output-path                   [:out]
+                                 :rf.egress/output-sensitivity  :inherit})]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-marks? ex) "error id is :rf.error/flow-bad-marks")
+      (is (= :rf.egress/output-sensitivity (:bad-key (ex-data ex)))
+          "ex-data names the removed propagation key")
+      (is (= :inherit (:bad-value (ex-data ex)))
+          "ex-data carries the offending (removed enum) value"))))
+
+(deftest reg-flow-rejects-non-boolean-large?
+  (testing ":large?, when present, must be a boolean — a non-boolean (e.g. 1)
+            is rejected :rf.error/flow-bad-marks with :bad-key / :bad-value"
+    (let [ex (reg-flow-throwing {:id          :bad/large?-shape
+                                 :inputs      [[:n]]
+                                 :derive      identity
+                                 :output-path [:out]
+                                 :large?      1})]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-marks? ex) "error id is :rf.error/flow-bad-marks")
+      (is (= :large? (:bad-key (ex-data ex)))
+          "ex-data names the offending key")
+      (is (= 1 (:bad-value (ex-data ex)))
+          "ex-data carries the offending non-boolean value"))))
+
+(deftest reg-flow-bad-marks-installs-no-flow-row-and-no-elision-declaration
+  (testing "a malformed flow-classification shape is rejected BEFORE any state
+            mutates: no flow row lands in the per-frame registry, and no
+            elision declaration is installed (mirrors
+            reg-flow-against-destroyed-frame-rejects-and-mutates-nothing)"
+    ;; validate-flow is the first call in reg-flow — before frame-id / the
+    ;; swap! that writes the flows row and before write-flow-output-marks!
+    ;; folds the classification declarations into the frame elision registry.
+    ;; So a rejected registration must leave all three surfaces untouched.
+    (let [flows-before     (flows/flows-snapshot)
+          sensitive-before (elision/sensitive-declarations :rf/default)
+          large-before     (elision/declarations :rf/default)
+          ex (reg-flow-throwing {:id          :bad/no-leak
+                                 :inputs      [[:n]]
+                                 :derive      identity
+                                 :output-path [:out]
+                                 ;; both a well-formed AND a malformed mark —
+                                 ;; the malformed one must reject the WHOLE
+                                 ;; registration, installing neither.
+                                 :sensitive   [[:secret]]
+                                 :large       :not-a-vector})]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-marks? ex) "error id is :rf.error/flow-bad-marks")
+      (is (= flows-before (flows/flows-snapshot))
+          "no flow row was installed — the per-frame flows registry is unchanged")
+      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :bad/no-leak))
+          "specifically: the rejected flow id is absent from the registry")
+      (is (= sensitive-before (elision/sensitive-declarations :rf/default))
+          "no :sensitive elision declaration was installed (the well-formed
+           [:secret] mark did not leak past the malformed :large rejection)")
+      (is (= large-before (elision/declarations :rf/default))
+          "no :large elision declaration was installed"))))
 
 (deftest reg-flow-detects-cycles-at-registration
   (testing ":a depends on :b, :b depends on :a — registering the second throws"

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -1179,6 +1179,113 @@
             "before-marker carries :reason :effect")))))
 
 ;; ---------------------------------------------------------------------------
+;; 7c. End-to-end: a REAL reg-flow classification mark REDACTS at egress
+;;     (rf2-i6l02n).
+;;
+;; The wire-elision tests above (computed-trace-elides-large-result / -before,
+;; failed-trace-elides-inputs) and the schema-scope inheritance tests seed the
+;; frame's classification via `install-large!` / `install-sensitive!`, which
+;; write `:source :effect` through `apply-classification-effects` — so the
+;; redaction CAUSE in those tests is a commit-plane effect, never the flow's
+;; OWN registration key. (`flows_destroy_frame_teardown_test` asserts a real
+;; reg-flow `:sensitive` mark is INSTALLED, but never that it REDACTS a value.)
+;;
+;; These tests close the claim-vs-delivery gap for flow-SOURCED classification
+;; end-to-end: a real `reg-flow` carrying a `:sensitive` / `:large?` output
+;; declaration (a `:source :flow` registry write, NOT an effect) drives
+;; redaction on BOTH observation channels —
+;;   (a) the `:rf.flow/computed` `:result` trace slot, and
+;;   (b) the app-db destination slot at `:output-path` through the SAME
+;;       registry (`elision/elide-wire-value`) —
+;; with the marker / declaration source-attributed `:reason :flow` (the large
+;; marker) and `:source :flow` (the sensitive declaration), distinguishing it
+;; from the `:source :effect` helper path the sibling tests exercise.
+;;
+;; Current-main note: the source-scoped clear (rf2-34jrb6) + nested-axis fix
+;; (rf2-izlr7f) are merged; these assert against that behaviour (a flow's claim
+;; is a standing `:source :flow` registry entry).
+
+(deftest reg-flow-large?-output-redacts-at-egress-reason-flow
+  (testing "rf2-i6l02n: a REAL reg-flow :large? whole-output declaration drives
+            redaction on BOTH channels — the :rf.flow/computed :result trace
+            slot carries the :rf.size/large-elided marker with :reason :flow,
+            AND the app-db destination slot projects the marker via the SAME
+            registry (elision/elide-wire-value)"
+    ;; A plain replacing :init handler is safe: a :db return replaces ONLY the
+    ;; app-db partition, so the flow's own :source :flow elision declaration —
+    ;; installed at reg-flow time into the runtime-db partition at
+    ;; [:rf.runtime/elision] — survives for the flow's evaluate-time + egress
+    ;; registry read.
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 1}}))
+    (rf/reg-flow {:id          :payload
+                  :inputs      [[:n]]
+                  :derive      (fn [_] {:bytes "BIG"})
+                  :output-path [:derived :blob]
+                  ;; The flow classifies its OWN whole output large — a
+                  ;; :source :flow registry write, NOT an install-large! effect.
+                  :large?      true})
+    ;; Precondition: the flow's own registration installed the :source :flow
+    ;; declaration (not a helper, not an effect).
+    (is (= :flow (:source (get (elision/declarations :rf/default) [:derived :blob])))
+        "precondition: the reg-flow :large? mark stands as a :source :flow declaration")
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    ;; (a) the trace channel — :rf.flow/computed :result rides elide-wire-value.
+    (let [ev     (last (by-op :rf.flow/computed))
+          result (:result (:tags ev))]
+      (is (some? ev) ":rf.flow/computed fired")
+      (is (elision/marker? result)
+          ":result is replaced by the :rf.size/large-elided marker")
+      (let [marker (:rf.size/large-elided result)]
+        (is (= [:derived :blob] (:path marker))
+            "marker carries the flow's output path")
+        (is (= :flow (:reason marker))
+            "marker carries :reason :flow — source-attributed to the reg-flow
+             declaration, NOT the :reason :effect of the install-large! helper path")))
+    ;; (b) the app-db destination channel — the slot at :output-path projects
+    ;; the marker through the SAME per-frame elision registry.
+    (let [wire (elision/elide-wire-value (frame/frame-app-db-value :rf/default))
+          slot (get-in wire [:derived :blob])]
+      (is (elision/marker? slot)
+          "the app-db destination slot egresses as the large marker")
+      (is (= :flow (:reason (:rf.size/large-elided slot)))
+          "the app-db-slot marker is also :reason :flow (same flow-sourced declaration)"))))
+
+(deftest reg-flow-sensitive-output-redacts-at-egress-source-flow
+  (testing "rf2-i6l02n: a REAL reg-flow :sensitive output declaration drives
+            sensitive redaction on BOTH channels — the :rf.flow/computed
+            :result trace slot redacts to :rf/redacted, AND the app-db
+            destination slot projects :rf/redacted via the SAME registry —
+            from a :source :flow declaration, not the :source :effect helper"
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n "raw-token"}}))
+    (rf/reg-flow {:id          :creds
+                  :inputs      [[:n]]
+                  :derive      (fn [n] {:secret (str "Bearer-" n)})
+                  :output-path [:auth :creds]
+                  ;; The flow classifies the :secret sub-slot of its own output
+                  ;; sensitive — a :source :flow registry write.
+                  :sensitive   [[:secret]]})
+    ;; Precondition: the sensitive sub-slot roots at :output-path ++ [:secret]
+    ;; and is a :source :flow declaration.
+    (is (= :flow (:source (get (elision/sensitive-declarations :rf/default)
+                               [:auth :creds :secret])))
+        "precondition: the reg-flow :sensitive mark stands as a :source :flow declaration")
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    ;; (a) the trace channel — :result's :secret sub-slot redacts (sensitive
+    ;; wins over large; the scalar :rf/redacted sentinel replaces the value).
+    (let [ev     (last (by-op :rf.flow/computed))
+          result (:result (:tags ev))]
+      (is (some? ev) ":rf.flow/computed fired")
+      (is (= privacy/redacted-sentinel (:secret result))
+          ":result's sensitive sub-slot is redacted to :rf/redacted on the trace bus"))
+    ;; (b) the app-db destination channel — the destination sub-slot projects
+    ;; :rf/redacted through the SAME per-frame elision registry.
+    (let [wire (elision/elide-wire-value (frame/frame-app-db-value :rf/default))]
+      (is (= privacy/redacted-sentinel (get-in wire [:auth :creds :secret]))
+          "the app-db destination sub-slot egresses as :rf/redacted (flow-sourced)"))))
+
+;; ---------------------------------------------------------------------------
 ;; 8. `:sensitive?` inheritance on `:rf.flow/*` traces (Spec 013 §`:sensitive?`
 ;;    inheritance, 013-Flows.md:242).
 ;;


### PR DESCRIPTION
Adds EP-0025 flows-classification TEST coverage surfaced by the flows review 3/3 (rf2-f1whlu). Test-only; NO production-code change.

## rf2-r87zhb — `:rf.error/flow-bad-marks` adversarial coverage
The six EP-0025 rejection rules in `implementation/flows/src/re_frame/flows/registry.cljc` (~L558-612) had ZERO test coverage, though `flows_test.clj` covered every other `flow-bad-*` family. Added to `implementation/flows/test/re_frame/flows_test.clj` (new `1c.` block, matching the existing `flow-bad-*` idiom — canonical `:rf.error/id` discriminator, ex-data assertions):

- `reg-flow-rejects-non-vector-sensitive` — `:sensitive` non-vector → `:bad-key`/`:bad-value`
- `reg-flow-rejects-malformed-sensitive-entry` — bad entry → `:bad-entries`
- `reg-flow-rejects-non-vector-large` — `:large` non-vector
- `reg-flow-rejects-malformed-large-entry` — bad entry → `:bad-entries`
- `reg-flow-rejects-boolean-sensitive?-spelling` — `:sensitive?` rejected, `:use :sensitive`
- `reg-flow-rejects-output-sensitivity-propagation-key` — `:rf.egress/output-sensitivity` removed
- `reg-flow-rejects-non-boolean-large?` — `:large?` must be boolean
- `reg-flow-bad-marks-installs-no-flow-row-and-no-elision-declaration` — rejection mutates nothing (no flow row, no elision declaration), mirroring `reg-flow-against-destroyed-frame-rejects-and-mutates-nothing`

## rf2-i6l02n — real flow-mark egress redaction end-to-end
No test asserted that a REAL `reg-flow` classification key (a `:source :flow` write) redacts at egress — existing tests seed via `:source :effect` helpers. Added to `implementation/flows/test/re_frame/flows_trace_test.clj` (new `7c.` block):

- `reg-flow-large?-output-redacts-at-egress-reason-flow` — a real `reg-flow :large?` redacts on BOTH channels (the `:rf.flow/computed :result` trace slot AND the app-db destination slot via `elision/elide-wire-value`), with the marker source-attributed `:reason :flow` (distinguishing it from the `:reason :effect` helper path).
- `reg-flow-sensitive-output-redacts-at-egress-source-flow` — a real `reg-flow :sensitive` output sub-slot redacts to `:rf/redacted` on both channels, from a `:source :flow` declaration.

Asserts against current main (source-scoped clear rf2-34jrb6 + nested-axis fix rf2-izlr7f merged). Did NOT add the rollback-survival tests (rf2-3pglag/yzsims — coupled to the held rollback fix, dispatched separately).

## Quality gates
- `clojure -M:test` (flows JVM suite): 187 tests, 4746 assertions, 0 failures, 0 errors
- `npm run test:cljs` (node CLJS gate): 7970 tests, 36654 assertions, 0 failures, 0 errors
- CI is the merge gate.