### PR TITLE
fix(core): EP-0025 rollback atomicity — unwind same-event classification effects, restore dropped flow marks (rf2-5lo1fk +4)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -119,6 +119,78 @@
     :else
     runtime-db))
 
+(defn ^:no-doc restore-elision-slot
+  "EP-0025 SOURCE-AWARE rollback restore for the per-frame elision registry.
+
+  Used by the router's post-commit schema-rollback arm. A rejected `:db`
+  unwinds with the WHOLE frame-state transition (both partitions back to the
+  pre-handler value). Per Spec 015 §84 a classification `walks back atomically
+  with the frame on a revert` — but only the IN-BAND classification this event
+  produced: the four commit-plane classification effects write
+  `{:source :effect}` marks (`apply-classification-effects`), and those MUST
+  unwind. The OTHER sources are written OUT-OF-BAND by long-lived subsystems —
+  `reg-flow` outputs (`:source :flow`), machine actor spawns
+  (`:source :machine`), route activation (`:source :route`) — and a
+  declaration one of those LOWERED during the rejected event may LEGITIMATELY
+  survive the rollback (the actor / route registration is not the
+  schema-rejected `:db` effect).
+
+  The base is `pre-reg` — the per-frame elision registry as it was at
+  chain-start, BEFORE the cascade ran (the `[:rf.runtime/elision]` sub-tree of
+  the chain-start `runtime-before` runtime-db, captured by reference in the
+  router's `assemble-initial-ctx`, so it is a true PRE-CASCADE snapshot at no
+  copy cost). Restoring to that base alone already:
+
+    - UNWINDS in-band `:source :effect` marks the rejected event added
+      (rf2-5lo1fk) — they were not in the pre-cascade snapshot, so they are
+      gone; and
+    - RESTORES an out-of-band `:source :flow` mark a mid-drain reentrant
+      `reg-flow` output-path MOVE dropped (rf2-o6rsi2) — the OLD path's
+      `:source :flow` entry is still in the pre-cascade snapshot, so it comes
+      back (the live registry had already dropped it; carrying live forward
+      would leak — a privacy fail-open on revert).
+
+  But the base alone would also drop an out-of-band declaration LOWERED
+  DURING the event (a `:source :machine` / `:source :route` mark from an actor
+  spawn / route activation inside the rejected event, or the NEW-path
+  `:source :flow` mark from a reentrant move) — those are absent from the
+  pre-cascade snapshot yet legitimately survive. So OVERLAY the LIVE
+  out-of-band entries (`:source` ≠ `:effect`) onto the pre-cascade base: this
+  re-adds the during-event subsystem-lowered marks WITHOUT re-adding the
+  in-band `:source :effect` marks (the only sourced kind that must unwind).
+  Privacy posture stays fail-safe-toward-redaction: a kept mark over a value
+  the rolled-back db no longer holds redacts nothing (harmless); a dropped one
+  risks raw egress.
+
+  `pre-reg` / `live-reg` are the `[:rf.runtime/elision]` registry maps (each
+  may be nil). Returns the restored registry map (or nil when both axes empty)
+  — the caller folds it onto `runtime-before` via `write-elision-slot`.
+  Pure."
+  [pre-reg live-reg]
+  (let [;; Per axis slot (`:sensitive-declarations` / `:declarations`): start
+        ;; from the pre-cascade entries, then overlay the LIVE OUT-OF-BAND
+        ;; (`:source` ≠ `:effect`) entries. The pre-cascade base unwinds in-band
+        ;; `:source :effect` and restores a dropped old-path `:source :flow`;
+        ;; the overlay re-adds during-event subsystem-lowered survivors.
+        restore-axis
+        (fn [slot]
+          (let [pre  (get pre-reg slot)
+                live (get live-reg slot)
+                out-of-band-live (reduce-kv
+                                   (fn [m path decl]
+                                     (if (= :effect (:source decl))
+                                       m
+                                       (assoc m path decl)))
+                                   {}
+                                   (or live {}))
+                merged (merge (or pre {}) out-of-band-live)]
+            (not-empty merged)))
+        s (restore-axis :sensitive-declarations)
+        l (restore-axis :declarations)]
+    (cond-> nil
+      s (assoc :sensitive-declarations s)
+      l (assoc :declarations l))))
+
 (defn ^:no-doc reconcile-runtime-db-effect
   "Reconcile the durable elision registry across a whole-value
   `:rf.db/runtime` partition commit.

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1223,8 +1223,9 @@
             ;; A whole-value `:rf.db/runtime` effect REPLACES the
             ;; runtime-db partition (decision #5), but the elision declaration
             ;; registry at `[:rf.runtime/elision]` is a CROSS-CUTTING durable
-            ;; subsystem child written OUT-OF-BAND by `reg-flow` / the EP-0025 classification effects /
-            ;; frame-classification — not by the event returning the effect. An
+            ;; subsystem child written OUT-OF-BAND by `reg-flow` outputs /
+            ;; the EP-0025 classification effects / machine + route subsystem
+            ;; declarations — not by the event returning the effect. An
             ;; effect that seeds an unrelated subsystem (e.g.
             ;; `:rf.runtime/routing`) and omits `:rf.runtime/elision` would
             ;; otherwise drop the registry on commit, silently losing every
@@ -1235,26 +1236,32 @@
             ;;
             ;; Privacy fail-open: reconcile against the LIVE
             ;; runtime-db read AT COMMIT, NOT the chain-start `runtime-before`
-            ;; snapshot. The flow drain's `refresh-flow-output-declarations!`
-            ;; writes propagated output-sensitivity marks straight into the
-            ;; LIVE runtime-db `[:rf.runtime/elision]` slot DURING the `:after`
-            ;; chain (after `runtime-before` was captured by reference in
-            ;; `assemble-initial-ctx`). When the handler ALSO returns a
-            ;; `:rf.db/runtime` effect, reconciling against the STALE snapshot
-            ;; carries the PRE-refresh registry forward and the commit overwrites
-            ;; the just-written mark — so a flow-derived sensitive path egresses
-            ;; RAW for one commit (until the next drain re-propagates). Reading
-            ;; the live runtime-db here picks up the refreshed marks: the
-            ;; registry the reconcile preserves is the freshest one, not the
-            ;; one captured before the drain ran. (The whole-frame-install /
-            ;; deliberate-clear path is unaffected — an effect that carries
-            ;; `:rf.runtime/elision` is still honoured verbatim.) `runtime-before`
-            ;; remains the rollback target below — rollback must restore the
-            ;; PRE-handler state, so it correctly stays the chain-start snapshot.
-            ;; Read the LIVE runtime-db whenever a runtime-db OR a
-            ;; classification effect commits — both need the freshest registry
-            ;; (the flow drain may have just written propagated marks; see the
-            ;; reconcile fail-open note above) as their base.
+            ;; snapshot. Under the post-EP-0025 model flows install their output
+            ;; declarations at `reg-flow` REGISTRATION time, not during the
+            ;; `:after` drain (the drain-time `refresh-flow-output-declarations!`
+            ;; propagation engine the old rationale cited was REMOVED by
+            ;; EP-0025 — there is no input→output sensitivity propagation). But
+            ;; an out-of-band subsystem write to `[:rf.runtime/elision]` can
+            ;; STILL land DURING this cascade, AFTER `runtime-before` was
+            ;; captured by reference in `assemble-initial-ctx`: a handler (or an
+            ;; `:after` interceptor) may call `reg-flow` reentrantly to MOVE an
+            ;; output-path (rewriting the live registry's flow marks), or a
+            ;; machine actor spawn / route activation may lower a subsystem mark
+            ;; mid-cascade. When the handler ALSO returns a `:rf.db/runtime`
+            ;; effect, reconciling against the STALE chain-start snapshot would
+            ;; carry the PRE-cascade registry forward and the commit would
+            ;; overwrite those just-written out-of-band marks — so the path
+            ;; egresses RAW for one commit (until the subsystem re-asserts it).
+            ;; Reading the live runtime-db here picks up the freshest
+            ;; out-of-band marks as the reconcile / classification base. (The
+            ;; whole-frame-install / deliberate-clear path is unaffected — an
+            ;; effect that carries `:rf.runtime/elision` is still honoured
+            ;; verbatim.) `runtime-before` remains the rollback target below, but
+            ;; the rollback restore is SOURCE-AWARE
+            ;; (`elision/restore-elision-slot`), not a verbatim carry-live — see
+            ;; the rollback arm. Read the LIVE runtime-db whenever a runtime-db
+            ;; OR a classification effect commits — both need the freshest
+            ;; out-of-band registry as their base.
             live-runtime-db (when (or rt-effect? class-effect?)
                               (frame/frame-runtime-db-value frame))
             ;; The reconciled runtime-db partition value (only when a
@@ -1343,30 +1350,58 @@
             ;; listeners see the restored state. The schema-failure error
             ;; trace already fired between the forward and rollback commits.
             ;;
-            ;; Privacy fail-safe (forward/rollback symmetry, rf2-qzs1y9): the
-            ;; forward commit above reconciles the runtime-db effect against the
-            ;; LIVE runtime-db so flow-written elision marks ([:rf.runtime/elision])
-            ;; propagated during the `:after` drain SURVIVE the commit. The
-            ;; rollback target `runtime-before` is the chain-start snapshot
-            ;; captured by reference BEFORE the drain ran, so it predates those
-            ;; marks. Restoring it verbatim would silently DISCARD the
-            ;; flow-written elision declarations — the very marks the forward
-            ;; path takes care to preserve — and a flow-derived sensitive path
-            ;; would egress RAW until the next successful drain re-propagated.
-            ;; The elision registry is CROSS-CUTTING durable subsystem state
-            ;; written OUT-OF-BAND (`reg-flow` / the EP-0025 classification effects / frame-
-            ;; classification), NOT part of the transactional handler effect the
-            ;; schema rejected — so it must NOT be unwound with the rejected db.
-            ;; Carry the LIVE registry (the freshest flow-propagated marks, as
-            ;; preserved by the forward reconcile and still resident on the
-            ;; container) forward onto the restored `runtime-before`, mirroring
-            ;; the forward path. A stale declaration for a path the rolled-back
-            ;; db no longer contains is harmless (it redacts nothing); dropping a
-            ;; live one risks raw egress — fail safe toward redaction.
-            (let [live-elision (get (frame/frame-runtime-db-value frame)
+            ;; EP-0025 SOURCE-AWARE elision restore (rf2-5lo1fk / rf2-fwejwc /
+            ;; rf2-o6rsi2). The `[:rf.runtime/elision]` registry is durable
+            ;; framework state that several sources write at DIFFERENT planes:
+            ;;
+            ;;   - IN-BAND, by THIS event: the four commit-plane classification
+            ;;     effects (`:sensitive` / `:large` / `:clear-sensitive` /
+            ;;     `:clear-large`) the rejected handler returned, applied just
+            ;;     above as `{:source :effect}` marks. Per Spec 015 §84 a
+            ;;     classification `walks back atomically with the frame on a
+            ;;     revert`, so these MUST unwind with the rejected `:db`.
+            ;;   - OUT-OF-BAND, by long-lived subsystems: `reg-flow` outputs
+            ;;     (`:source :flow`), machine actor spawns (`:source :machine`),
+            ;;     route activation (`:source :route`). These are NOT the
+            ;;     transactional handler effect the schema rejected. Under the
+            ;;     post-EP-0025 model flows install their output declarations at
+            ;;     `reg-flow` REGISTRATION time, never during the `:after` drain
+            ;;     (`flows.cljc` `write-flow-output-marks!` /
+            ;;     `flows/registry.cljc` `fold-flow-declarations`) — there is no
+            ;;     drain-time propagation engine to protect (the removed
+            ;;     `refresh-flow-output-declarations!` mechanism the old
+            ;;     rationale here cited). A pre-existing `:source :flow` mark is
+            ;;     already in the chain-start snapshot and survives a verbatim
+            ;;     restore; a mark a subsystem LOWERED DURING this event (an
+            ;;     actor spawn / route activation inside the rejected event, or
+            ;;     a reentrant `reg-flow` output-path move's NEW path) is the
+            ;;     ONLY legitimate during-event out-of-band write and may
+            ;;     survive.
+            ;;
+            ;; Carrying the WHOLE live registry forward (the old source-blind
+            ;; behaviour) is wrong in BOTH directions: it over-preserves an
+            ;; in-band `:source :effect` mark (rf2-5lo1fk) AND under-restores a
+            ;; `:source :flow` mark a mid-drain reentrant `reg-flow`
+            ;; output-path move DROPPED — the live registry already lost the old
+            ;; path, so preserving-live still leaks it (rf2-o6rsi2). The correct
+            ;; target is the PRE-CASCADE registry — the `[:rf.runtime/elision]`
+            ;; sub-tree of the chain-start `runtime-before` (captured by
+            ;; reference BEFORE the cascade ran), the symmetric mirror of the
+            ;; `last-inputs` / `abandoned-paths` pre-cascade snapshots restored
+            ;; below — overlaid with the LIVE out-of-band entries so the
+            ;; during-event subsystem-lowered survivors are kept while the
+            ;; in-band `:source :effect` marks unwind
+            ;; (`elision/restore-elision-slot`). Privacy posture stays fail-safe
+            ;; toward redaction: a kept mark over a value the rolled-back db no
+            ;; longer holds redacts nothing (harmless); a dropped one risks raw
+            ;; egress.
+            (let [pre-elision  (get runtime-before :rf.runtime/elision)
+                  live-elision (get (frame/frame-runtime-db-value frame)
                                     :rf.runtime/elision)
+                  restored-elision (elision/restore-elision-slot
+                                     pre-elision live-elision)
                   runtime-restore (elision/write-elision-slot runtime-before
-                                                              live-elision)
+                                                              restored-elision)
                   rb-changed (frame/replace-frame-state!
                                frame
                                {frame/app-partition-key     db-before

--- a/implementation/core/test/re_frame/partitioned_commit_test.clj
+++ b/implementation/core/test/re_frame/partitioned_commit_test.clj
@@ -29,6 +29,13 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
+            ;; Load the flows artefact so the rollback-survivor tests below can
+            ;; register REAL `reg-flow` outputs (which install `:source :flow`
+            ;; elision marks at registration time) and exercise the
+            ;; source-aware rollback restore (rf2-5lo1fk / rf2-o6rsi2 /
+            ;; rf2-yzsims). Requiring it publishes the `:flows/*` late-bind
+            ;; hooks the drain + rollback paths consult.
+            [re-frame.flows]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
@@ -384,63 +391,182 @@
       (is (= {:rf.runtime/machines {:m :pre}} (rf/runtime-db-value :pc/rb))
           "runtime-db ALSO rolled back — the whole transition unwinds coherently"))))
 
-;; rf2-qzs1y9 — forward/rollback symmetry for flow-written elision marks.
+;; EP-0025 SOURCE-AWARE rollback restore — rf2-5lo1fk / rf2-fwejwc /
+;; rf2-o6rsi2 / rf2-3pglag / rf2-yzsims.
 ;;
-;; The forward commit reconciles the runtime-db effect against the LIVE
-;; runtime-db so an elision mark a flow's `:after`-chain drain wrote into
-;; `[:rf.runtime/elision]` (AFTER the chain-start `runtime-before` snapshot was
-;; captured by reference) SURVIVES the commit. The post-commit schema-validation
-;; ROLLBACK must mirror that care: it restores the pre-handler `runtime-before`,
-;; which predates the in-drain mark — restoring it verbatim would silently
-;; DISCARD the flow-written elision declaration, and a flow-derived sensitive
-;; path would egress RAW until the next successful drain re-propagated. We model
-;; the flow's in-drain `refresh-flow-output-declarations!` write with `add-marks`
-;; from an `:after` interceptor — both reach the SAME `[:rf.runtime/elision]`
-;; slot via `elision/swap-elision-slot!`, the exact out-of-band write the
-;; forward-path comment names, running in-chain after `runtime-before` is fixed.
-(deftest schema-rollback-preserves-flow-written-elision-marks
-  (testing "a post-commit schema rollback PRESERVES an elision mark written
-            out-of-band during the :after chain (the mark the forward path
-            preserves) — forward/rollback symmetry (rf2-qzs1y9)"
-    (when (late-bind/get-fn :schemas/validate-app-schema!)
-      (rf/reg-frame :pc/rb-elision {:doc "rb-elision"})
-      ;; seed a coherent pre-handler frame-state with NO elision registry — the
-      ;; mark must be born DURING the chain, so it is absent from `runtime-before`.
-      (rf/replace-frame-state! :pc/rb-elision {:rf.db/app {:n 0}
+;; The post-commit schema-rollback arm restores the per-frame elision registry
+;; SOURCE-AWARE, not by carrying the whole LIVE registry forward. Per Spec 015
+;; §84 a classification `walks back atomically with the frame on a revert`, but
+;; only the IN-BAND classification the rejected event produced:
+;;
+;;   - an in-band `:source :effect` mark (a `:sensitive` / `:large`
+;;     commit-plane classification effect the rejected handler returned) MUST
+;;     UNWIND with the rejected `:db` (rf2-5lo1fk);
+;;   - an out-of-band `:source :flow` / `:source :machine` / `:source :route`
+;;     mark — written at `reg-flow` registration time, or lowered by a subsystem
+;;     during the event — MAY legitimately SURVIVE the rollback;
+;;   - a `:source :flow` mark a mid-drain reentrant `reg-flow` output-path MOVE
+;;     dropped from the LIVE registry is RESTORED to its pre-cascade old path
+;;     (rf2-o6rsi2) — a privacy fail-open the old carry-live behaviour caused.
+;;
+;; The base is the PRE-CASCADE registry (the `[:rf.runtime/elision]` sub-tree of
+;; the chain-start `runtime-before`), overlaid with the LIVE out-of-band
+;; entries. (rf2-3pglag note: the old version of the next test FAKED a flow with
+;; a `:source :effect` write and asserted it SURVIVED — which pinned the
+;; rf2-5lo1fk bug. It is rewritten below: a real `:source :effect`
+;; classification UNWINDS; a real `:source :flow` mark SURVIVES.)
+
+(deftest schema-rollback-unwinds-in-band-effect-keeps-flow-mark
+  (testing "a post-commit schema rollback UNWINDS the rejected event's in-band
+            :source :effect classification (rf2-5lo1fk) while a real
+            :source :flow mark (installed at reg-flow time, pre-existing the
+            rejected event) SURVIVES (rf2-3pglag)"
+    (when (and (late-bind/get-fn :schemas/validate-app-schema!)
+               (late-bind/get-fn :flows/run-flows-on-db))
+      (rf/reg-frame :pc/rb-srcaware {:doc "rb-srcaware"})
+      ;; Seed a coherent pre-handler app-db that PASSES the schema below, so the
+      ;; rollback target is `{:n 0}` (the rejected `{:n -5}` unwinds to it).
+      (rf/replace-frame-state! :pc/rb-srcaware {:rf.db/app {:n 0}
                                                :rf.db/runtime {}})
-      (is (= {} (elision/sensitive-declarations :pc/rb-elision))
-          "precondition: no flow-written sensitive declaration before dispatch")
+      ;; A REAL flow whose output is classified sensitive. `reg-flow` installs
+      ;; the `{:source :flow}` mark at REGISTRATION time, so it is present in
+      ;; `runtime-before` (the chain-start snapshot) and must survive a rollback.
+      (rf/reg-flow {:id          :creds
+                    :inputs      [[:n]]
+                    :derive      (fn [n] {:secret n})
+                    :output-path [:derived :creds]
+                    :sensitive   [[:secret]]}
+                   {:frame :pc/rb-srcaware})
+      (is (= {:source :flow :flow-id :creds}
+             (get (elision/sensitive-declarations :pc/rb-srcaware)
+                  [:derived :creds :secret]))
+          "precondition: the :source :flow mark is installed at reg-flow time")
       ;; app schema demanding :n stay a non-negative int — the bad handler
       ;; violates it, forcing the post-commit rollback.
-      (rf/with-frame :pc/rb-elision
+      (rf/with-frame :pc/rb-srcaware
         (rf/reg-app-schema [] {:schema [:map [:n [:int {:min 0}]]]}))
-      ;; An :after interceptor that writes a sensitive elision declaration into
-      ;; the LIVE runtime-db — the stand-in for a flow drain installing an
-      ;; output classification mid-chain. It runs after `runtime-before` was
-      ;; captured, so the declaration exists ONLY in the live runtime-db, never
-      ;; in the snapshot. EP-0025: the imperative add-marks API is removed, so we
-      ;; write directly through the kept elision registry (`:source :effect`).
-      (rf/reg-interceptor* :pc/flow-mark-writer
+      ;; The rejected handler returns BOTH an invalid :db AND an in-band
+      ;; commit-plane :sensitive classification effect (`:source :effect`). The
+      ;; schema rejects :db → the whole transition rolls back; the in-band
+      ;; classification MUST unwind with it.
+      (rf/reg-event :pc/bad-with-effect
+        {:doc "schema-violating handler returning an in-band classification effect"}
+        (fn [_ _]
+          {:db        {:n -5}                            ;; violates the schema → rollback
+           :sensitive [[:another-secret]]}))             ;; in-band :source :effect mark
+      (rf/dispatch-sync [:pc/bad-with-effect] {:frame :pc/rb-srcaware})
+      (is (= {:n 0} (rf/app-db-value :pc/rb-srcaware))
+          "app-db rolled back to the pre-handler value (the schema rejection held)")
+      ;; rf2-5lo1fk: the in-band :source :effect classification UNWINDS with the
+      ;; rejected db (before the fix the source-blind carry-live PRESERVED it).
+      (is (not (contains? (elision/sensitive-declarations :pc/rb-srcaware)
+                          [:another-secret]))
+          "the rejected event's in-band :source :effect classification UNWINDS on rollback (rf2-5lo1fk)")
+      ;; rf2-3pglag: the pre-existing :source :flow mark SURVIVES the rollback.
+      (is (= {:source :flow :flow-id :creds}
+             (get (elision/sensitive-declarations :pc/rb-srcaware)
+                  [:derived :creds :secret]))
+          "the pre-existing :source :flow mark SURVIVES the rollback (rf2-3pglag)"))))
+
+;; rf2-yzsims — positive rollback-survivor coverage for genuine out-of-band
+;; sources LOWERED DURING the rejected event, plus the rf2-o6rsi2 reentrant
+;; reg-flow output-path MOVE case (old-path mark restored).
+
+(deftest schema-rollback-keeps-subsystem-mark-lowered-during-event
+  (testing "a :source :machine declaration lowered DURING the rejected event
+            (the only legitimate during-event out-of-band write under the
+            post-EP-0025 model) SURVIVES the rollback while the rejected :db
+            unwinds (rf2-yzsims)"
+    (when (late-bind/get-fn :schemas/validate-app-schema!)
+      (rf/reg-frame :pc/rb-subsys {:doc "rb-subsys"})
+      (rf/replace-frame-state! :pc/rb-subsys {:rf.db/app {:n 0}
+                                              :rf.db/runtime {}})
+      (is (= {} (elision/sensitive-declarations :pc/rb-subsys))
+          "precondition: no subsystem mark before dispatch")
+      (rf/with-frame :pc/rb-subsys
+        (rf/reg-app-schema [] {:schema [:map [:n [:int {:min 0}]]]}))
+      ;; An :after interceptor models a subsystem (machine actor spawn / route
+      ;; activation) lowering a declaration into the LIVE registry DURING the
+      ;; event — out-of-band (`:source :machine`), after `runtime-before` was
+      ;; captured. This is the load-bearing positive case the source-aware
+      ;; restore preserves.
+      (rf/reg-interceptor* :pc/subsystem-mark-writer
         {:after (fn [ctx]
-                  (elision/swap-elision-slot! :pc/rb-elision
+                  (elision/swap-elision-slot! :pc/rb-subsys
                     (fn [reg]
-                      (assoc-in reg [:sensitive-declarations [:secret]]
-                                {:source :effect})))
+                      (assoc-in reg [:sensitive-declarations [:actor :token]]
+                                {:source :machine :machine-id :door})))
                   ctx)})
-      (rf/reg-event :pc/bad-elision
-        {:doc "schema-violating handler that triggers the rollback"
-         :interceptors [:pc/flow-mark-writer]}
+      (rf/reg-event :pc/bad-subsys
+        {:doc "schema-violating handler; the interceptor lowers a subsystem mark"
+         :interceptors [:pc/subsystem-mark-writer]}
         (fn [_ _]
           {:db {:n -5}}))                                ;; violates the schema → rollback
-      (rf/dispatch-sync [:pc/bad-elision] {:frame :pc/rb-elision})
-      (is (= {:n 0} (rf/app-db-value :pc/rb-elision))
-          "app-db rolled back to the pre-handler value (the schema rejection held)")
-      ;; THE REGRESSION: before the fix the rollback restored `runtime-before`
-      ;; verbatim and this declaration was gone, so `[:secret]` would egress RAW.
-      (is (= {[:secret] {:source :effect}}
-             (elision/sensitive-declarations :pc/rb-elision))
-          "the flow-written elision mark SURVIVES the rollback — the rollback
-           mirrors the forward path's privacy fail-safe (rf2-qzs1y9)"))))
+      (rf/dispatch-sync [:pc/bad-subsys] {:frame :pc/rb-subsys})
+      (is (= {:n 0} (rf/app-db-value :pc/rb-subsys))
+          "app-db rolled back to the pre-handler value")
+      (is (= {:source :machine :machine-id :door}
+             (get (elision/sensitive-declarations :pc/rb-subsys) [:actor :token]))
+          "the during-event out-of-band :source :machine mark SURVIVES the rollback (rf2-yzsims)"))))
+
+(deftest schema-rollback-restores-moved-flow-old-path-mark
+  (testing "a reentrant reg-flow output-path MOVE inside a schema-rejected
+            event drops the OLD-path :source :flow mark from the LIVE registry;
+            the source-aware rollback RESTORES it from the pre-cascade snapshot
+            (rf2-o6rsi2) — a privacy fail-open the old carry-live caused"
+    (when (and (late-bind/get-fn :schemas/validate-app-schema!)
+               (late-bind/get-fn :flows/run-flows-on-db))
+      (rf/reg-frame :pc/rb-move {:doc "rb-move"})
+      ;; Seed a coherent pre-handler app-db that PASSES the schema below.
+      (rf/replace-frame-state! :pc/rb-move {:rf.db/app {:n 0}
+                                            :rf.db/runtime {}})
+      ;; A real flow whose sensitive output sits at the OLD path. The mark is
+      ;; installed at reg-flow time, so it is in the chain-start snapshot.
+      (rf/reg-flow {:id          :mover
+                    :inputs      [[:n]]
+                    :derive      (fn [n] {:secret n})
+                    :output-path [:old :creds]
+                    :sensitive   [[:secret]]}
+                   {:frame :pc/rb-move})
+      (is (= {:source :flow :flow-id :mover}
+             (get (elision/sensitive-declarations :pc/rb-move)
+                  [:old :creds :secret]))
+          "precondition: the OLD-path :source :flow mark is installed")
+      (rf/with-frame :pc/rb-move
+        (rf/reg-app-schema [] {:schema [:map [:n [:int {:min 0}]]]}))
+      ;; An :after interceptor MOVES the flow's output-path mid-cascade (a
+      ;; reentrant reg-flow), so the LIVE registry drops the OLD-path mark and
+      ;; installs a NEW-path one — BEFORE the post-commit schema rejection.
+      (rf/reg-interceptor* :pc/flow-mover
+        {:after (fn [ctx]
+                  (rf/reg-flow {:id          :mover
+                                :inputs      [[:n]]
+                                :derive      (fn [n] {:secret n})
+                                :output-path [:new :creds]
+                                :sensitive   [[:secret]]}
+                               {:frame :pc/rb-move})
+                  ctx)})
+      (rf/reg-event :pc/bad-move
+        {:doc "schema-violating handler; the interceptor moves the flow output-path"
+         :interceptors [:pc/flow-mover]}
+        (fn [_ _]
+          {:db {:n -5}}))                                ;; violates the schema → rollback
+      (rf/dispatch-sync [:pc/bad-move] {:frame :pc/rb-move})
+      (is (= {:n 0} (rf/app-db-value :pc/rb-move))
+          "app-db rolled back to the pre-handler value")
+      ;; rf2-o6rsi2: the OLD-path mark is restored from the pre-cascade snapshot
+      ;; (the live registry had dropped it; the rolled-back db still holds the
+      ;; old output value, so dropping the mark would leak it RAW).
+      (is (= {:source :flow :flow-id :mover}
+             (get (elision/sensitive-declarations :pc/rb-move)
+                  [:old :creds :secret]))
+          "the dropped OLD-path :source :flow mark is RESTORED on rollback (rf2-o6rsi2)")
+      ;; The NEW-path mark — lowered out-of-band during the event — legitimately
+      ;; survives too (the flow now declares it; harmless over the rolled-back db).
+      (is (= {:source :flow :flow-id :mover}
+             (get (elision/sensitive-declarations :pc/rb-move)
+                  [:new :creds :secret]))
+          "the NEW-path out-of-band :source :flow mark survives (during-event subsystem write)"))))
 
 ;; rf2-wfy2kq (P1 DATA-CORRUPTION) — the post-commit schema rollback must
 ;; restore the FULL prior app-db, not a path-focused SLICE.


### PR DESCRIPTION
## Summary

One coherent fix on the commit-plane rollback path in `implementation/core/src/re_frame/router.cljc`. On a post-commit app-db schema rejection the rollback arm previously carried the **whole live** elision registry forward onto the restored `runtime-before`, **source-blind**. That single root cause produced three coupled findings:

- **rf2-5lo1fk (P1)** — an in-band `:source :effect` classification the rejected handler returned SURVIVED the rollback (atomicity violation; Spec 015 §84: a classification walks back atomically with the frame on a revert).
- **rf2-fwejwc (P2, root cause)** — the preservation was source-blind and its rationale cited the **removed** drain-time `refresh-flow-output-declarations!` propagation engine. Comment block rewritten to the post-EP-0025 model (flows install output declarations at `reg-flow` time, never during the drain).
- **rf2-o6rsi2 (P2)** — a reentrant `reg-flow` output-path MOVE inside a schema-rejected event dropped the OLD-path `:source :flow` mark from the live registry; carry-live never restored it (privacy fail-open on revert).

## Design — pre-cascade snapshot + source-aware restore

The chain-start `runtime-before` (the `:rf.db/runtime` coeffect captured **by reference** in `assemble-initial-ctx`, before the cascade ran) already holds the **pre-cascade** `[:rf.runtime/elision]` registry — the symmetric mirror of the existing `last-inputs` / `abandoned-paths` pre-cascade snapshots, at no copy cost.

New pure helper `elision/restore-elision-slot` restores **source-aware**:
- **base = pre-cascade registry** → unwinds in-band `:source :effect` marks (5lo1fk) AND restores a dropped old-path `:source :flow` mark (o6rsi2);
- **overlay = LIVE out-of-band entries** (`:source` ≠ `:effect`) → keeps `:source :flow` / `:source :machine` / `:source :route` marks lowered during the event (the only legitimate during-event out-of-band writes under the new model).

Forward commit path is unchanged; only the rollback restore changes. Fail-safe-toward-redaction posture preserved.

## Per-bead resolution
- **rf2-5lo1fk** — in-band `:source :effect` now unwinds with the rejected `:db`.
- **rf2-fwejwc** — restore is source-aware; stale `refresh-flow-output-declarations!` rationale (forward + rollback comment blocks) replaced with the post-EP-0025 model.
- **rf2-o6rsi2** — pre-cascade snapshot restores the dropped old-path `:source :flow` mark.
- **rf2-3pglag** — the old `schema-rollback-preserves-flow-written-elision-marks` test (which faked a flow via `:source :effect` and asserted it survived — pinning the bug) rewritten: a real `:source :effect` classification UNWINDS; a real `reg-flow` `:source :flow` mark SURVIVES.
- **rf2-yzsims** — added a positive survivor test for a `:source :machine` mark lowered during the event, plus the o6rsi2 reentrant-move old-path restore.

**Confirm-by-revert:** with the old carry-live behaviour, the unwind assertion (5lo1fk) and the old-path-restore assertion (o6rsi2) FAIL; the during-event survivor (yzsims) passes under both (it pins the SURVIVE direction the fix must not regress).

## Quality gates
- rf2-5lo1fk — core JVM `clojure -M:test` (1696 tests, 0 fail) incl. partitioned-commit + classification + conformance ✅
- rf2-fwejwc — flows JVM `clojure -M:test` (177 tests, 0 fail) incl. flows-rollback-dirty-check + teardown + trace ✅
- rf2-o6rsi2 — `npm run test:cljs` (7973 tests, 0 fail) ✅
- rf2-3pglag — `npm run test:elision` (production 42/42 absent; control 42/42 present) — the rollback restore is pure data, no projection symbols leaked ✅
- rf2-yzsims — confirm-by-revert verified on the 5lo1fk + o6rsi2 assertions ✅

CI is the merge gate.