### PR TITLE
fix(story): reconcile variant classification shape + fail-loud validation (rf2-7c6ecy)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -687,21 +687,27 @@
 ;;
 ;; The EP-0025-compliant Story surface is FRAME-CREATION classification: a
 ;; variant declares its sensitive / large app-db paths at registration via
-;; the `:sensitive` / `:large` slots on the variant body (a flat vector of
-;; `:rf/path`s per axis) — and the Story runtime applies them through the
-;; commit-plane `:sensitive` / `:large` classification effects at frame
-;; creation (an init classify step, `:source :effect`), so the redaction is
-;; live from creation onward. (EP-0025 removed the durable `:sensitive` /
-;; `:large {:app-db …}` *frame annotation* — a frame is not app-db's
-;; definition site — so the runtime no longer threads the declaration onto
-;; the `reg-frame` config; it rides the commit-plane effect instead.)
+;; the `:sensitive` / `:large` slots on the variant body. Each slot is a MAP
+;; keyed by carrier — the app-db paths live under `:app-db` (a vector of
+;; `:rf/path`s), matching the framework's `reg-frame` `:sensitive` /
+;; `:large` carrier-keyed form (spec/Conventions.md §Privacy; the framework's
+;; `re-frame.core/reg-frame` uses the same `{:app-db [[:auth :token]] :http …}`
+;; owner shape). The Story runtime lowers the `:app-db` paths into the variant
+;; frame's elision registry through the commit-plane `:sensitive` / `:large`
+;; classification effects at frame creation (an init classify step,
+;; `:source :effect`), so the redaction is live from creation onward.
+;; (EP-0025 removed the durable `:sensitive` / `:large {:app-db …}` *frame
+;; annotation* — a frame is not app-db's definition site — so the runtime no
+;; longer threads the declaration onto the `reg-frame` config; it rides the
+;; commit-plane effect instead. A `:sensitive` block MAY also carry `:http`
+;; carriers, which are not app-db classification and stay on the frame config.)
 ;;
 ;;     (story/reg-variant :story.auth/login-form
 ;;       {:component login-form
 ;;        :args      {:user/email "ada@example.com"
 ;;                    :user/password "•••••"}
-;;        :sensitive [[:user :password] [:auth :token]]
-;;        :large     [[:docs :csv-upload]]})
+;;        :sensitive {:app-db [[:user :password] [:auth :token]]}
+;;        :large     {:app-db [[:docs :csv-upload]]}})
 ;;
 ;; This drives every local-redacted Story surface (assertion redaction, the
 ;; trace buffer, the recorder, DOM capture) with NO public post-creation

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -62,6 +62,13 @@
             ;; pure registry-write seam directly (same artefact as
             ;; `re-frame.frame` above; bundle-isolated from production).
             [re-frame.elision          :as elision]
+            ;; EP-0025 fail-loud: a variant's lowered classification effects are
+            ;; validated through the SAME pure validator the router's
+            ;; commit-plane boundary uses (`elision/classification-effect-defect`)
+            ;; and a defect is raised via the canonical thrown-error builder, so
+            ;; a malformed declaration FAILS LOUD pre-commit rather than crashing
+            ;; inside `apply-classification-effects` / `allocate!`.
+            [re-frame.error            :as rf-error]
             [re-frame.story.config     :as config]
             [re-frame.story.decorators :as decorators]
             [re-frame.story.error      :as story-error]
@@ -575,10 +582,33 @@
   those effects performs. Runs right after `make-frame` and BEFORE the
   lifecycle / init events, so a classified path is already redacted in any
   trace the variant's setup emits. No-op when the variant declares no app-db
-  classification."
+  classification.
+
+  EP-0025 fail-loud: the lowered effects are validated through the SAME pure
+  validator the router's FINAL-effects commit-plane boundary uses
+  (`elision/classification-effect-defect`) BEFORE `apply-classification-effects`
+  touches the registry. A malformed declaration (a non-vector `:app-db`, or a
+  path that is not a valid concrete `:rf/path`) raises
+  `:rf.error/classification-effect-shape` pre-commit — no partial registry
+  write — rather than crashing later inside `apply-classification-effects` /
+  `allocate!`. This mirrors the router's pre-commit abort
+  (`router/emit-classification-effect-shape!`) so the variant-declaration and
+  effect-return paths reject malformed classification identically."
   [variant-id v-body]
   (let [effects (->classification-effects v-body)]
     (when (seq effects)
+      (when-let [defect (elision/classification-effect-defect effects)]
+        (rf-error/throw-error!
+          :rf.error/classification-effect-shape
+          'rf.story/apply-variant-classification!
+          (str "re-frame2-story: variant " variant-id
+               " declares a malformed `:sensitive` / `:large` classification — "
+               (:reason defect)
+               ". Each axis is a carrier-keyed map whose `:app-db` value is a "
+               "vector of concrete `:rf/path`s "
+               "(e.g. `:sensitive {:app-db [[:auth :token]]}`).")
+          {:recovery :fix-the-variant-classification-shape
+           :extra    (assoc defect :variant-id variant-id)}))
       (frame/swap-runtime-db! variant-id
         (fn [rt] (elision/apply-classification-effects rt effects))))))
 

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -902,23 +902,40 @@
     ;; with variant-first, then story-level, then chrome toolbar.
     [:viewport              {:optional true} ViewportSlot]
     [:background            {:optional true} BackgroundSlot]
-    ;; EP-0015 frame-owned durable classification. A variant
-    ;; declares which of ITS app-db paths are sensitive / large at frame
-    ;; creation, the SAME owner model the framework's `reg-frame` uses
-    ;; (`{:app-db [[:auth :token]] :http {...}}`). The runtime threads these
-    ;; straight onto the variant's `reg-frame` config (`frames/variant-
-    ;; frame-config`), so the framework's `re-frame.frame-classification`
-    ;; validates + installs them atomically as part of frame creation —
-    ;; BEFORE `:initial-events`. Classification is owned at frame creation, not
-    ;; mutated post-creation (spec/015 §Frame-owned durable classification).
+    ;; EP-0025 frame-owned durable classification. A variant declares which
+    ;; of ITS app-db paths are sensitive / large at frame creation, the SAME
+    ;; carrier-keyed owner model the framework's `reg-frame` uses
+    ;; (`{:app-db [[:auth :token]] :http {...}}`). EP-0025 removed the durable
+    ;; frame annotation: the runtime no longer threads these onto the
+    ;; variant's `reg-frame` config — instead it lowers the `:app-db` paths
+    ;; into the variant frame's elision registry as commit-plane
+    ;; classification effects right after frame creation, BEFORE the lifecycle
+    ;; / init events (`frames/apply-variant-classification!` →
+    ;; `re-frame.elision/apply-classification-effects`, `:source :effect`).
+    ;; Classification is owned at frame creation, not mutated post-creation
+    ;; (spec/015 §Frame-owned durable classification; spec/Conventions.md
+    ;; §Privacy).
     ;;
-    ;; Loose `:map` here on purpose: the framework's frame-classification
-    ;; layer owns the rigorous shape validation (malformed paths, unknown
-    ;; keys, non-string HTTP carriers all FAIL LOUDLY at `reg-frame` time —
-    ;; spec/015 §Frame-owned durable classification, fail-fast). Story does
-    ;; not fork that validation — one source of truth.
-    [:sensitive             {:optional true} [:map-of :keyword :any]]
-    [:large                 {:optional true} [:map-of :keyword :any]]
+    ;; The slot is a CARRIER-KEYED MAP — app-db paths under `:app-db`, with an
+    ;; optional `:http` carrier block (the `:sensitive` axis only) that stays
+    ;; on the frame config (HTTP carriers are not app-db classification). The
+    ;; `:app-db` value is a vector-of-paths; we keep it `[:vector :any]` here
+    ;; on purpose — the rigorous per-path `:rf/path` shape validation is owned
+    ;; ONCE by the framework's commit-plane validator
+    ;; (`re-frame.elision/classification-effect-defect`), which
+    ;; `apply-variant-classification!` routes through so a malformed path
+    ;; FAILS LOUD pre-commit with `:rf.error/classification-effect-shape`.
+    ;; Story does not fork that path validation — one source of truth. The
+    ;; carrier-keyed MAP shape here (vs a bare vector) catches the most common
+    ;; authoring slip — a flat `[[:auth :token]]` vector instead of
+    ;; `{:app-db [[:auth :token]]}` — at reg-variant with a clear schema error
+    ;; rather than silently dropping the declaration at lowering.
+    [:sensitive             {:optional true}
+     [:map {:closed false}
+      [:app-db {:optional true} [:vector :any]]]]
+    [:large                 {:optional true}
+     [:map {:closed false}
+      [:app-db {:optional true} [:vector :any]]]]
     ;; EP-0023 §Stories — "behavior variant -> image". A variant declares the
     ;; IMAGE(s) (the `rf/image` registration-set values) its frame resolves
     ;; behaviour against, so two variants reuse the SAME global event/sub id

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -1661,3 +1661,106 @@
     (is (fn? @#'story/lifecycle-state))
     (is (fn? @#'story/variant-frames))
     (is (fn? @#'story/variant-frame?))))
+
+;; ===========================================================================
+;; VARIANT-BODY CLASSIFICATION (rf2-7c6ecy)
+;; ===========================================================================
+;;
+;; EP-0025: a variant declares its sensitive / large app-db paths on its body
+;; via the carrier-keyed NESTED form `:sensitive {:app-db [[:auth :token]]}`
+;; (the SAME owner shape `reg-frame` uses; spec/Conventions.md §Privacy). The
+;; runtime lowers the `:app-db` paths into the variant frame's elision
+;; registry as EP-0025 commit-plane classification effects right after
+;; `make-frame`, BEFORE the lifecycle / init events
+;; (`frames/apply-variant-classification!`, `:source :effect`).
+;;
+;; Two coupled defects this section guards against (the two were a three-way
+;; doc/schema/lowering shape mismatch + a missing fail-loud validation):
+;;
+;;   1. POSITIVE — a documented (NESTED) variant classification actually
+;;      classifies: the declared path REDACTS to `:rf/redacted` at wire
+;;      egress. (Before the doc reconciliation an author following the
+;;      docstring's FLAT example wrote `:sensitive [[:auth :token]]`, which
+;;      the schema REJECTED and the lowering silently DROPPED.)
+;;   2. NEGATIVE — a MALFORMED variant classification (a NESTED-but-bad
+;;      `:app-db` payload that the loose schema admits) is routed through the
+;;      SAME fail-loud commit-plane validator the router uses
+;;      (`elision/classification-effect-defect`), so it FAILS LOUD pre-commit
+;;      with `:rf.error/classification-effect-shape` rather than crashing
+;;      inside `apply-classification-effects` / `allocate!`. The run records a
+;;      failed `:rf.error/exception` assertion carrying that error id.
+
+(deftest variant-classification-nested-form-redacts-at-egress
+  (testing "rf2-7c6ecy POSITIVE — a documented NESTED variant `:sensitive`
+            declaration (`{:app-db [[:auth :token]]}`) lowers into the variant
+            frame's elision registry and REDACTS the path at wire egress"
+    (rf/reg-event :auth/login-7c6ecy
+      (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] "BEARER-secret-7c6ecy")}))
+    (story/reg-variant :story.classif/sensitive
+      {:events    [[:auth/login-7c6ecy]]
+       :sensitive {:app-db [[:auth :token]]}})
+    (let [r (async/deref-blocking (story/run-variant :story.classif/sensitive) 5000)]
+      (is (= :ready (:lifecycle r))
+          "the variant runs to :ready — classification did not abort the run")
+      (is (= "BEARER-secret-7c6ecy" (get-in (rf/app-db-value :story.classif/sensitive)
+                                            [:auth :token]))
+          "the raw value is in app-db (classification is path-based, not value mutation)")
+      ;; Wire egress over the frame's app-db substitutes the classified path.
+      (let [walked (rf/elide-wire-value (rf/app-db-value :story.classif/sensitive)
+                                        {:frame :story.classif/sensitive})]
+        (is (= :rf/redacted (get-in walked [:auth :token]))
+            "the documented NESTED :sensitive declaration redacts the path at egress")))
+    (story/destroy-variant! :story.classif/sensitive)))
+
+(deftest variant-classification-large-nested-form-elides-at-egress
+  (testing "rf2-7c6ecy POSITIVE — a documented NESTED variant `:large`
+            declaration (`{:app-db [[:docs :blob]]}`) elides the path to the
+            `:rf.size/large-elided` marker at wire egress"
+    (rf/reg-event :docs/upload-7c6ecy
+      (fn [{:keys [db]} _] {:db (assoc-in db [:docs :blob] (apply str (repeat 2048 "x")))}))
+    (story/reg-variant :story.classif/large
+      {:events [[:docs/upload-7c6ecy]]
+       :large  {:app-db [[:docs :blob]]}})
+    (let [r (async/deref-blocking (story/run-variant :story.classif/large) 5000)]
+      (is (= :ready (:lifecycle r)))
+      (let [walked  (rf/elide-wire-value (rf/app-db-value :story.classif/large)
+                                         {:frame :story.classif/large})
+            elided  (get-in walked [:docs :blob])]
+        (is (and (map? elided) (contains? elided :rf.size/large-elided))
+            "the documented NESTED :large declaration elides the path to the
+             `:rf.size/large-elided` marker at egress")))
+    (story/destroy-variant! :story.classif/large)))
+
+(deftest variant-classification-malformed-fails-loud-pre-commit
+  (testing "rf2-7c6ecy NEGATIVE — a MALFORMED variant classification (a
+            NESTED-but-bad `:app-db` payload the loose schema admits) FAILS
+            LOUD pre-commit through `elision/classification-effect-defect`,
+            recorded as a failed `:rf.error/classification-effect-shape`
+            assertion rather than crashing `allocate!`"
+    (rf/reg-event :noop-7c6ecy (fn [{:keys [db]} _] {:db db}))
+    ;; `:app-db` is a vector (passes the schema) whose entry is NOT a valid
+    ;; concrete :rf/path — a non-sequential scalar. The framework's pure
+    ;; commit-plane validator rejects it; the variant path now routes through
+    ;; that SAME validator pre-commit.
+    (story/reg-variant :story.classif/bad
+      {:events    [[:noop-7c6ecy]]
+       :sensitive {:app-db [42]}})
+    (let [r (async/deref-blocking (story/run-variant :story.classif/bad) 5000)
+          assertion (->> (:assertions r)
+                         (filter #(= :rf.error/exception (:assertion %)))
+                         last)]
+      (is (= :error (:lifecycle r))
+          "the malformed classification aborts the run pre-commit")
+      (is (some? assertion)
+          "a structured failure assertion is recorded (no uncaught crash)")
+      (is (= :rf.error/classification-effect-shape
+             (-> assertion :error :data :rf.error/id))
+          "the failure routes through the SAME fail-loud id the router's
+           commit-plane boundary uses")
+      ;; Fail-loud is PRE-commit: the bad path must NOT have been written into
+      ;; the elision registry (no partial commit).
+      (let [reg (frame/frame-runtime-db-value :story.classif/bad)]
+        (is (not (contains? (get-in reg [:rf.runtime/elision :sensitive-declarations])
+                            [42]))
+            "the malformed path did not land in the elision registry (no partial commit)")))
+    (story/destroy-variant! :story.classif/bad)))


### PR DESCRIPTION
Fixes the two coupled EP-0025 defects in `rf2-7c6ecy` (P1) on the Story variant-body `:sensitive` / `:large` classification surface.

## What was wrong

1. **Shape mismatch (silent drop / rejection).** Three surfaces disagreed on the variant-body classification shape:
   - the authoring docstring in `re-frame.story` (`story.cljc`) taught a **FLAT** form `:sensitive [[:auth :token]]`;
   - the schema (`schemas.cljc`) and the lowering (`frames/->classification-effects`) expected a **NESTED**, carrier-keyed form `:sensitive {:app-db [[:auth :token]]}`.
   A doc-following author got a `:closed`-schema rejection at `reg-variant` or a silent drop at lowering — the path never classified.
2. **Fail-loud bypass.** `apply-variant-classification!` wrote straight to the elision registry without the EP-0025 validator. A malformed declaration (a non-`:rf/path` `:app-db` entry the loose schema admitted) crashed with a raw `:rf.error/bad-path` deep inside `apply-classification-effects` / `allocate!` instead of the prescribed pre-commit abort.

## The fix

- **Shape reconciled to the NESTED form** — the one the spec (`000-Vision`, `API.md`, `Conventions.md`, `015-Test-Coverage`), the lowering, and the existing passing tests already use. The only diverger — the `story.cljc` authoring docstring — is corrected to NESTED. The schema is tightened from `[:map-of :keyword :any]` to a carrier-keyed map (`:app-db` vector), so the common flat-vector slip is caught at `reg-variant` with a clear error rather than silently dropped. Rigorous per-path `:rf/path` validation stays single-sourced at the framework's commit-plane validator.
- **Fail-loud routed** — `apply-variant-classification!` now runs the lowered effects through `re-frame.elision/classification-effect-defect` (the SAME pure validator the router's FINAL-effects boundary uses) BEFORE the registry write, raising `:rf.error/classification-effect-shape` pre-commit (no partial write). The run orchestrator projects it as a failed assertion.

## Tests (`tools/story/test/re_frame/story_runtime_test.clj`)

- **Positive:** a documented NESTED `:sensitive` / `:large` variant classification redacts (`:rf/redacted`) / elides (`:rf.size/large-elided`) the declared path at wire egress.
- **Negative:** a malformed NESTED classification fails loud pre-commit with `:rf.error/classification-effect-shape`; the bad path never lands in the elision registry.
- **Confirm-by-revert:** reverting the fail-loud routing flips the recorded failure id from `:rf.error/classification-effect-shape` to the raw `:rf.error/bad-path` crash the bead describes — the negative test catches it.

## Quality gates

- Story JVM suite (`clojure -M:test` in `tools/story`): **1708 tests / 6333 assertions, 0 failures, 0 errors**.
- CLJS node suite (`npm run test:cljs` from `implementation/`): **7976 tests / 36682 assertions, 0 failures, 0 errors**.
- No `tools/story/spec/*` markdown changed (the spec already taught the NESTED form; now doc + schema + lowering agree), so no `mkdocs --strict` run required.
- Boundary respected: only `tools/story` (`story.cljc`, `frames.cljc`, `schemas.cljc` + the JVM test) touched.
- CI is the merge gate.