### PR TITLE
fix(pair-mcp+epoch): close off-box egress leaks — include-sensitive parse + await-render/cascade-summary projection (rf2-66ippe, rf2-6klf02)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -2343,42 +2343,68 @@
     (when (seq picks) picks)))
 
 (defn- redact-sensitive-event-vector
-  "Egress guard for the cascade-summary `:event-vector` slot.
+  "Egress guard for the cascade-summary `:event-vector` slot — the
+  fail-closed projection the framework's `projected-record` applies to a
+  record's `:trigger-event` slot (rf2-nm611o,
+  `epoch/tool_pair.cljc` §`elide-trigger-event-slot`), reproduced here
+  because the cascade-summary rides OUTSIDE the wire-path projection.
 
   The `:event-vector` slot copies the epoch's RAW `:trigger-event` — the
-  original dispatch vector, e.g. `[:auth/login {:password \"hunter2\"}]`.
-  When the source epoch is declared sensitive (`:rf.epoch/sensitive?
-  true`) that raw payload MUST NOT cross the off-box egress boundary
-  under the default privacy posture: `cascade-summary` is the ONE place
-  the trigger-event leaves the runtime verbatim, and the consuming MCP
-  tools (`restore-epoch` passes the runtime map through verbatim;
+  original dispatch vector, e.g. `[:auth/login {:password \"hunter2\"}]`
+  or `[:login \"topsecret\"]`. The event ARGS are registration-owned
+  transient payloads (Spec 015 §151 §Registration-owned transient
+  classification) — the SAME class as the `:effects` `:args` slot — NOT
+  rooted at the frame's app-db, so the app-db-path classification walker
+  cannot prove ANY of them safe. A secret carried IN the event vector
+  therefore rides off-box verbatim regardless of whether the epoch is
+  declared `:rf.epoch/sensitive?`: the old guard keyed redaction to the
+  `:rf.epoch/sensitive?` rollup ALONE, so a NON-declared trigger-event
+  (`[:login \"topsecret\"]` with no declared-sensitive db slot) leaked
+  the password off-box (rf2-6klf02). `cascade-summary` is the ONE place
+  the trigger-event leaves the runtime, and the consuming MCP tools
+  (`restore-epoch` passes the runtime map through verbatim;
   `dispatch-dry-run` deliberately does NOT walk `:cascade-summary`,
   treating it as a counts-only projection) trust this projection to be
-  already-safe. The wire-path elision walker scrubs dispatch-dry-run's
-  `:db-state-after-simulation` / `:would-fire-effects`, but the
-  cascade-summary `:event-vector` rides outside that walk — so this guard
-  redacts it here, otherwise a restore / dry-run of a sensitive historical
-  epoch would ship the raw event payload even under
-  `--allow-sensitive-reads` OFF.
+  already-safe.
 
-  Fail-closed: when the epoch is sensitive AND the raw-state gate is OFF
-  (the published-build default — the MCP server flips it to OFF the
-  moment a state-emitting tool first fires unless the operator launched
-  with `--allow-sensitive-reads`), the slot redacts to the `:rf/redacted`
-  sentinel — the SAME sentinel the wire-path `elide-wire-value` walker
-  substitutes for a declared-sensitive slot. The redaction is keyed to
-  the epoch-level `:rf.epoch/sensitive?` rollup rather than per-value
-  elision because the trigger-event is not addressed by an app-db path
-  the `[:rf.runtime/elision]` registry (in runtime-db) can classify — its
-  sensitivity is a property of the epoch, not of a declared-sensitive db slot.
+  Fail-closed (gate OFF — the published-build default; the MCP server
+  flips `raw-state-config` to OFF the moment a state-emitting tool first
+  fires unless the operator launched with `--allow-sensitive-reads`):
+  the head `<event-id>` keyword (a non-payload summary — the SAME value
+  the record carries in its `:event-id` slot) is RETAINED while every
+  positional / map arg is replaced with the `:rf/redacted` sentinel, so
+  `[:login \"topsecret\"]` egresses as `[:login :rf/redacted]` and
+  `[:auth/login {:password p}]` as `[:auth/login :rf/redacted]`. A
+  consumer still sees WHICH event ran, never its args. This matches
+  `elide-trigger-event-slot` exactly — the fail-close fires on EVERY
+  epoch (sensitive or not), because the args are unprovable regardless.
+  A degenerate non-vector / empty slot (or a value a `:redact-fn` already
+  scalarised) redacts wholesale to `:rf/redacted` — nothing safe to
+  expose.
 
   Raw only on opt-in: when the gate is ON the operator deliberately
-  asked for raw reads, so the verbatim trigger-event rides through. A
-  non-sensitive epoch is never redacted regardless of the gate."
+  asked for raw reads (the cascade-summary's equivalent of the
+  `:include-event-args? true` trusted-local opt), so the verbatim
+  trigger-event rides through.
+
+  `sensitive?` is the epoch's `:rf.epoch/sensitive?` rollup — retained in
+  the signature because callers thread it, but the args fail closed
+  whether or not it is set (it governs only the cascade-summary's
+  `:sensitive?` annotation slot, not this redaction). Idempotent: a
+  second pass over an already-projected `[<id> :rf/redacted …]`
+  re-redacts the (already-`:rf/redacted`) tail to the same sentinels.
+  Nil-preserving."
   [trigger-event sensitive?]
-  (if (and sensitive? (not (:allow-raw-state? @raw-state-config)))
-    :rf/redacted
-    trigger-event))
+  (cond
+    ;; Gate ON ⇒ the operator opted into raw reads; ship verbatim.
+    (:allow-raw-state? @raw-state-config) trigger-event
+    (nil? trigger-event)                  trigger-event
+    ;; The canonical shape: retain the head event-id, fail-close the args.
+    (and (vector? trigger-event) (seq trigger-event))
+    (into [(first trigger-event)]
+          (repeat (dec (count trigger-event)) :rf/redacted))
+    ;; Degenerate non-vector / empty slot — nothing safe to expose.
+    :else :rf/redacted))
 
 (defn cascade-summary
   "Project an assembled `:rf/epoch-record` into the compact wire shape
@@ -2411,10 +2437,14 @@
                :subs-recomputed (count (or sub-runs []))
                :renders         (count (or renders []))}
         event-id      (assoc :event-id event-id)
-        ;; The raw trigger-event is redacted to `:rf/redacted` when the
-        ;; epoch is sensitive and the raw-state gate is OFF (fail-closed
-        ;; default) — see `redact-sensitive-event-vector`. Raw only on
-        ;; opt-in.
+        ;; The trigger-event's ARGS fail closed off-box under the OFF
+        ;; gate (head event-id retained, args → `:rf/redacted`) for EVERY
+        ;; epoch — the event args are registration-owned transient
+        ;; payloads the app-db classification walker cannot prove safe,
+        ;; so a secret carried IN the vector redacts whether or not the
+        ;; epoch is declared sensitive (rf2-nm611o / rf2-6klf02). Raw only
+        ;; on the operator's `--allow-sensitive-reads` opt-in. See
+        ;; `redact-sensitive-event-vector`.
         trigger-event (assoc :event-vector
                              (redact-sensitive-event-vector trigger-event sensitive?))
         transitions   (assoc :machine-transitions transitions)

--- a/skills/re-frame2-pair/tests/runtime/cascade_summary_redaction_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/cascade_summary_redaction_test.clj
@@ -15,14 +15,23 @@
 ;;;; the raw event payload (auth tokens, passwords, …) even under
 ;;;; `--allow-sensitive-reads` OFF.
 ;;;;
-;;;; THE MECHANISM: `redact-sensitive-event-vector` redacts the slot to
-;;;; `:rf/redacted` when the source epoch is `:rf.epoch/sensitive? true`
-;;;; AND the runtime raw-state gate is OFF (the published-build default —
-;;;; the MCP server signals `configure-raw-state! {:allow-raw-state?
-;;;; false}` before restore-epoch / dispatch-dry-run build the summary).
-;;;; Fail-closed: gate OFF redacts; gate ON (operator opted in via
-;;;; `--allow-sensitive-reads`) ships the raw vector. A non-sensitive
-;;;; epoch is never redacted.
+;;;; THE MECHANISM (rf2-nm611o / rf2-6klf02): `redact-sensitive-event-vector`
+;;;; FAILS CLOSED on the trigger-event ARGS — the SAME projection the
+;;;; framework's `projected-record` applies to a record's `:trigger-event`
+;;;; slot (`epoch/tool_pair.cljc` §`elide-trigger-event-slot`). The event
+;;;; args are registration-owned transient payloads the app-db
+;;;; classification walker cannot prove safe, so under the OFF gate (the
+;;;; published-build default — the MCP server signals `configure-raw-state!
+;;;; {:allow-raw-state? false}` before restore-epoch / dispatch-dry-run
+;;;; build the summary) the head event-id is RETAINED while every arg is
+;;;; replaced with `:rf/redacted`: `[:login "topsecret"]` egresses as
+;;;; `[:login :rf/redacted]`. The fail-close fires on EVERY epoch —
+;;;; sensitive or NOT — because a secret carried IN the dispatch vector is
+;;;; unprovable regardless of whether the epoch is declared
+;;;; `:rf.epoch/sensitive?` (the old guard keyed redaction to the rollup
+;;;; alone, so a non-declared trigger-event leaked — rf2-6klf02). Gate ON
+;;;; (operator opted in via `--allow-sensitive-reads`) ships the raw
+;;;; vector. A degenerate non-vector / empty slot redacts wholesale.
 ;;;;
 ;;;; Why a parallel implementation lives here:
 ;;;;
@@ -61,13 +70,21 @@
 (def ^:private raw-state-config (atom {:allow-raw-state? true}))
 
 (defn- redact-sensitive-event-vector
-  "Mirror of the egress guard. Redacts the raw trigger-event to
-  `:rf/redacted` when the epoch is sensitive AND the raw-state gate is
-  OFF (fail-closed). Raw only on opt-in; non-sensitive never redacts."
+  "Mirror of the egress guard (rf2-nm611o fail-closed shape). Under the
+  OFF gate the head event-id is RETAINED while every arg is replaced with
+  `:rf/redacted` — for EVERY epoch, sensitive or not (the args are
+  registration-owned transient payloads the classification walker cannot
+  prove safe). Gate ON ships the raw vector (operator opt-in). A
+  degenerate non-vector / empty / nil slot redacts wholesale / passes
+  through nil."
   [trigger-event sensitive?]
-  (if (and sensitive? (not (:allow-raw-state? @raw-state-config)))
-    :rf/redacted
-    trigger-event))
+  (cond
+    (:allow-raw-state? @raw-state-config) trigger-event
+    (nil? trigger-event)                  trigger-event
+    (and (vector? trigger-event) (seq trigger-event))
+    (into [(first trigger-event)]
+          (repeat (dec (count trigger-event)) :rf/redacted))
+    :else :rf/redacted))
 
 (defn- db-diff-summary
   [db-before db-after]
@@ -144,8 +161,10 @@
    :db-after  {:auth {:user "ada"}}
    :effects   [{:fx-id :http}]})
 
-;; A NON-sensitive epoch — an ordinary cart-add. The trigger-event is
-;; safe to surface verbatim regardless of the gate.
+;; A NON-sensitive epoch — an ordinary cart-add carrying NO secret. The
+;; head + args are safe; under gate OFF the args still fail closed (the
+;; walker can't prove ANY trigger-event arg safe), so the projected shape
+;; keeps the head and redacts the (innocuous) arg. Gate ON rides verbatim.
 (def benign-cart-epoch
   {:epoch-id 7
    :event-id :cart/add
@@ -153,6 +172,22 @@
    :frame :rf/default
    :db-before {:cart {}}
    :db-after  {:cart {:items 1}}
+   :effects   []})
+
+;; rf2-6klf02 — a NON-declared sensitive epoch whose trigger-event carries
+;; a secret POSITIONALLY in the dispatch vector. The framework did NOT
+;; stamp `:rf.epoch/sensitive?` (no declared-sensitive db slot matched —
+;; the secret lives only in the event args, which the app-db classification
+;; walker cannot see). The old guard, keyed to the `:rf.epoch/sensitive?`
+;; rollup alone, shipped this raw off-box — the leak this bead closes.
+(def undeclared-secret-login-epoch
+  {:epoch-id 99
+   :event-id :login
+   :trigger-event [:login "topsecret"]
+   :frame :rf/default
+   ;; NB: NO :rf.epoch/sensitive? — the secret is non-declared.
+   :db-before {}
+   :db-after  {:auth {:ok true}}
    :effects   []})
 
 ;; ---------------------------------------------------------------------------
@@ -170,20 +205,39 @@
 
 (deftest sensitive-event-vector-redacted-by-default-in-cascade-summary
   ;; THE bug. Gate OFF (the published-build default once the MCP server
-  ;; signals it) — the sensitive trigger-event MUST redact, not leak.
+  ;; signals it) — the sensitive trigger-event MUST fail closed, not leak.
+  ;; rf2-nm611o shape: head event-id retained, every arg :rf/redacted.
   (with-gate false
     (fn []
       (let [summary (cascade-summary sensitive-login-epoch)]
         (testing "the raw password never appears on the wire"
-          (is (= :rf/redacted (:event-vector summary))
-              ":event-vector redacts to :rf/redacted for a sensitive epoch under gate OFF")
+          (is (= [:auth/login :rf/redacted] (:event-vector summary))
+              ":event-vector fails closed — head retained, arg redacted (gate OFF)")
           (is (not= [:auth/login {:username "ada" :password "hunter2"}]
                     (:event-vector summary))
               "the raw trigger-event MUST NOT ride the wire")
           (is (not (clojure.string/includes? (pr-str summary) "hunter2"))
-              "the password literal appears NOWHERE in the projected summary"))
+              "the password literal appears NOWHERE in the projected summary")
+          (is (not (clojure.string/includes? (pr-str summary) "ada"))
+              "the username literal also appears nowhere — every arg redacts"))
         (testing "the sensitivity is still annotated for the consumer"
           (is (true? (:sensitive? summary))))))))
+
+(deftest undeclared-secret-event-vector-fails-closed-in-cascade-summary
+  ;; rf2-6klf02 — THE leak this bead closes. An epoch NOT stamped
+  ;; `:rf.epoch/sensitive?` whose trigger-event carries a secret in its
+  ;; args MUST still fail closed off-box: the old guard keyed redaction to
+  ;; the rollup alone, so a non-declared trigger-event shipped the secret
+  ;; raw. The args are unprovable regardless of the epoch's sensitivity.
+  (with-gate false
+    (fn []
+      (let [summary (cascade-summary undeclared-secret-login-epoch)]
+        (is (= [:login :rf/redacted] (:event-vector summary))
+            ":event-vector fails closed even for a NON-declared-sensitive epoch")
+        (is (not (clojure.string/includes? (pr-str summary) "topsecret"))
+            "the non-declared positional secret appears NOWHERE on the wire")
+        (is (nil? (:sensitive? summary))
+            "the epoch was not declared sensitive — no :sensitive? annotation, yet args still redact")))))
 
 (deftest sensitive-event-vector-redacted-by-default-in-restore-cascade-summary
   ;; restore-epoch's projection — same gate, same redaction. RED before
@@ -193,8 +247,8 @@
     (fn []
       (let [extras  (restore-cascade-summary sensitive-login-epoch)
             summary (:cascade-summary extras)]
-        (is (= :rf/redacted (:event-vector summary))
-            "restore-epoch's :event-vector redacts for a sensitive target epoch under gate OFF")
+        (is (= [:auth/login :rf/redacted] (:event-vector summary))
+            "restore-epoch's :event-vector fails closed (head retained, arg redacted) under gate OFF")
         (is (true? (:sensitive? summary))
             "restore-cascade-summary annotates :sensitive? true")
         (is (not (clojure.string/includes? (pr-str extras) "hunter2"))
@@ -204,17 +258,25 @@
 ;; Negative guards — the redaction must NOT over-fire.
 ;; ---------------------------------------------------------------------------
 
-(deftest benign-event-vector-rides-verbatim-regardless-of-gate
-  ;; A non-sensitive epoch's trigger-event is safe — it must ride
-  ;; verbatim whether the gate is ON or OFF.
-  (doseq [gate [true false]]
-    (with-gate gate
-      (fn []
-        (let [summary (cascade-summary benign-cart-epoch)]
-          (is (= [:cart/add {:sku "x"}] (:event-vector summary))
-              (str "benign :event-vector rides verbatim (gate=" gate ")"))
-          (is (nil? (:sensitive? summary))
-              "a non-sensitive epoch carries no :sensitive? slot"))))))
+(deftest benign-event-vector-rides-verbatim-on-opt-in-fails-closed-by-default
+  ;; A non-sensitive epoch's trigger-event args are STILL unprovable, so
+  ;; under gate OFF they fail closed (head retained) — the fail-close is
+  ;; uniform across sensitive and non-sensitive epochs. Gate ON (operator
+  ;; opted in) rides the full vector verbatim.
+  (with-gate false
+    (fn []
+      (let [summary (cascade-summary benign-cart-epoch)]
+        (is (= [:cart/add :rf/redacted] (:event-vector summary))
+            "gate OFF fails closed even for a benign epoch — head retained, arg redacted")
+        (is (nil? (:sensitive? summary))
+            "a non-sensitive epoch carries no :sensitive? slot"))))
+  (with-gate true
+    (fn []
+      (let [summary (cascade-summary benign-cart-epoch)]
+        (is (= [:cart/add {:sku "x"}] (:event-vector summary))
+            "gate ON rides the benign :event-vector verbatim (operator opted in)")
+        (is (nil? (:sensitive? summary))
+            "a non-sensitive epoch carries no :sensitive? slot")))))
 
 (deftest sensitive-event-vector-rides-verbatim-on-explicit-opt-in
   ;; Gate ON (operator launched with --allow-sensitive-reads) — the raw

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -203,14 +203,33 @@ and all three are now gated:
   `re-frame.core/projected-record` server-side under the OFF default,
   gated by the `:include-sensitive` two-key opt-in (the launch flag
   AND the per-call arg) — identical to `trace-window` / `watch-epochs`
-  / `snapshot :epochs`.
-- The DEFAULT cascade-summary `:event-vector` (the raw
-  `:trigger-event`) redacts to `:rf/redacted` for a sensitive epoch.
-  `dispatch` issues `configure-raw-state!` (`raw-state/signal-runtime!`)
-  between the preload probe and the dispatch eval — the same prelude
-  every state-emitting tool wears — so the runtime's `raw-state-config`
-  flips out of its permissive `{:allow-raw-state? true}` default and
-  the redaction fires. Before rf2-8fin7.3 `dispatch` was the lone
+  / `snapshot :epochs`. This projection runs on BOTH transports of the
+  epoch-bearing modes: the synchronous (non-await) path AND the
+  `await-render` path (where an explicit `trace` still resolves to
+  `dispatch-and-collect`'s raw `:epoch`) — the await-render epoch
+  projects the same way, so it never crosses the wire un-projected
+  (rf2-6klf02). The `:include-sensitive` arg parses through the safe
+  `args/parse-bool-arg` (the cross-MCP accept-shape parser), so a string
+  `"false"` over the JSON wire stays FALSE — it never fail-opens to a raw
+  read under `--allow-sensitive-reads` (rf2-66ippe).
+- The cascade-summary `:event-vector` (the raw `:trigger-event`) FAILS
+  CLOSED on its ARGS for EVERY epoch under the OFF default — the head
+  `<event-id>` keyword is retained while every positional / map arg
+  redacts to `:rf/redacted`, so `[:login "topsecret"]` egresses as
+  `[:login :rf/redacted]`. This is the same projection the framework's
+  `projected-record` applies to a record's `:trigger-event` slot
+  (rf2-nm611o, `epoch/tool_pair.cljc` §`elide-trigger-event-slot`): the
+  event args are registration-owned transient payloads the app-db
+  classification walker cannot prove safe, so a secret carried IN the
+  vector redacts whether or not the epoch is declared
+  `:rf.epoch/sensitive?`. Keying the redaction to the
+  `:rf.epoch/sensitive?` rollup ALONE leaked a non-declared
+  trigger-event's secret off-box (rf2-6klf02). `dispatch` issues
+  `configure-raw-state!` (`raw-state/signal-runtime!`) between the
+  preload probe and the dispatch eval — the same prelude every
+  state-emitting tool wears — so the runtime's `raw-state-config` flips
+  out of its permissive `{:allow-raw-state? true}` default and the
+  fail-close fires. Before rf2-8fin7.3 `dispatch` was the lone
   state-emitting tool that never signalled, so a FIRST-in-session
   sensitive dispatch shipped its raw event vector off-box even under
   the OFF gate. Posture parity with `dispatch-dry-run`.
@@ -704,11 +723,19 @@ off-box read surfaces above — and `dispatch-dry-run`'s egress slots
    `:would-fire-effects[*].args`) return the `:rf/redacted` sentinel;
    sensitive trace events / epochs are stripped from streaming
    payloads. The `:cascade-summary` `:event-vector` slot — which copies
-   the epoch's raw `:trigger-event` — is likewise redacted to
-   `:rf/redacted` when the source epoch is `:rf.epoch/sensitive? true`
-   (rf2-6nks4). This redaction is applied SERVER-SIDE inside the runtime
-   projection (`restore-cascade-summary` / `cascade-summary`), keyed to
-   the epoch-level sensitivity rollup rather than per-value elision — the
+   the epoch's raw `:trigger-event` — FAILS CLOSED on its ARGS: the head
+   `<event-id>` keyword is retained while every arg redacts to
+   `:rf/redacted` (`[:login "topsecret"]` → `[:login :rf/redacted]`),
+   for EVERY epoch — sensitive or not (rf2-6nks4 + rf2-nm611o +
+   rf2-6klf02). The event args are registration-owned transient payloads
+   the app-db classification walker cannot prove safe, so a secret carried
+   IN the dispatch vector redacts regardless of the epoch's
+   `:rf.epoch/sensitive?` rollup — keying it to the rollup alone leaked a
+   non-declared trigger-event's secret (rf2-6klf02). This is the same
+   projection `projected-record` applies to a record's `:trigger-event`
+   slot (`epoch/tool_pair.cljc` §`elide-trigger-event-slot`). It is
+   applied SERVER-SIDE inside the runtime projection
+   (`restore-cascade-summary` / `cascade-summary`) because the
    trigger-event is not addressed by an app-db path the elision registry
    classifies. It therefore covers `restore-epoch`, `dispatch-dry-run`
    (whose `:cascade-summary` is otherwise NOT walked, being a counts-only

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -112,19 +112,30 @@
   the wire, gated on `raw-state-allowed?` + the `:include-sensitive`
   two-key opt-in — sensitive leaves land as
   `:rf/redacted`, large slots elide, the cascade stays structurally
-  useful.
+  useful. This projection runs on BOTH transports of the epoch-bearing
+  modes: the synchronous (non-await) path wraps the bare runtime call,
+  and the `:await-render` path wraps the runtime call INSIDE the
+  render-settle Promise (`render-settle-form`). Under `:await-render`
+  an explicit `:trace` still resolves to `dispatch-and-collect` (the raw
+  `:epoch`), so the await transport projects the SAME way the non-await
+  one does — an await-render epoch never crosses the wire unprojected
+  (rf2-6klf02).
 
   Path 3 is closed by issuing `raw-state/signal-runtime!` between the
   preload probe and the dispatch eval (the snapshot / get-path /
   dispatch-dry-run prelude shape). The runtime's cascade-summary
-  redacts the `:event-vector` only when `(not (:allow-raw-state?
-  @raw-state-config))`, and `raw-state-config` DEFAULTS to
-  `{:allow-raw-state? true}` — it flips to the server's gate state ONLY
-  when a tool signals. Signalling before the dispatch eval means even a
-  first-in-session sensitive dispatch runs with the runtime at the
-  server's gate state, so its raw event vector redacts to `:rf/redacted`
-  under the OFF gate. Posture parity with `dispatch-dry-run`
-  (signal-runtime! + projected egress, same gate)."
+  FAILS CLOSED on the `:event-vector` args only when `(not
+  (:allow-raw-state? @raw-state-config))`, and `raw-state-config`
+  DEFAULTS to `{:allow-raw-state? true}` — it flips to the server's gate
+  state ONLY when a tool signals. Signalling before the dispatch eval
+  means even a first-in-session dispatch runs with the runtime at the
+  server's gate state, so its event-vector ARGS redact under the OFF
+  gate — the head event-id is retained, every arg becomes `:rf/redacted`
+  (`[:login \"pw\"]` → `[:login :rf/redacted]`), for EVERY epoch whether
+  or not it is declared `:rf.epoch/sensitive?` (the args are
+  registration-owned transient payloads the classification walker cannot
+  prove safe — rf2-nm611o / rf2-6klf02). Posture parity with
+  `dispatch-dry-run` (signal-runtime! + projected egress, same gate)."
   (:require [cljs.reader]
             [clojure.string :as str]
             [re-frame2-pair-mcp.tools.args :as args]
@@ -275,20 +286,43 @@
   `event-vec` + `opts-form` are the dispatch payload. Emits a form whose
   synchronous return is a `js/Promise` resolving to the dispatch envelope
   merged with `{:settled? true}` once the substrate has flushed + the
-  next paint is scheduled."
-  [fn-sym event-vec opts-form]
-  (str
-    "(js/Promise."
-    "  (fn [resolve# _reject#]"
-    "    (let [result# " (ef/emit (ef/rt-call fn-sym event-vec opts-form))
-    "          done#   (fn [] (resolve# (if (map? result#)"
-    "                                     (assoc result# :settled? true)"
-    "                                     {:settled? true :result result#})))]"
-    "      (re-frame.interop/after-render"
-    "        (fn []"
-    "          (if (exists? js/requestAnimationFrame)"
-    "            (js/requestAnimationFrame (fn [_#] (done#)))"
-    "            (done#)))))))"))
+  next paint is scheduled.
+
+  `epoch-bearing?` is true when the resolved `mode` is `:trace`
+  (`dispatch-and-collect`) — under `:await-render` the runtime fn is
+  forced synchronous, and an explicit `:trace` still selects
+  `dispatch-and-collect`, which returns the RAW assembled `:epoch`
+  (`:db-before` / `:db-after` / `:trigger-event` / `:trace-events`). On
+  that path the result MUST route through the framework's off-box
+  projection (`re-frame.core/projected-record` via
+  `egress/project-dispatch-result-src`) APP-SIDE before it crosses the
+  wire — exactly as the NON-await `:trace` / `:settle` path does
+  (`dispatch-tool` below). Without it the await-render epoch shipped raw,
+  re-leaking the very sensitive / large app-db material the non-await
+  path elides (rf2-6klf02). The projection wraps `result#` (the runtime
+  return) BEFORE the `{:settled? true}` merge, so the settle confirmation
+  rides on the already-projected envelope. The sync / queued consequence
+  shapes carry no raw app-db, so `epoch-bearing?` is false and the bare
+  runtime call rides unwrapped (matching the non-await default). `incl?`
+  threads the resolved `:include-sensitive` opt-in INTO the projection
+  (app-db sensitive axis only) — never a projection bypass."
+  [fn-sym event-vec opts-form epoch-bearing? incl?]
+  (let [call-src (ef/emit (ef/rt-call fn-sym event-vec opts-form))
+        result-src (if epoch-bearing?
+                     (egress/project-dispatch-result-src call-src incl?)
+                     call-src)]
+    (str
+      "(js/Promise."
+      "  (fn [resolve# _reject#]"
+      "    (let [result# " result-src
+      "          done#   (fn [] (resolve# (if (map? result#)"
+      "                                     (assoc result# :settled? true)"
+      "                                     {:settled? true :result result#})))]"
+      "      (re-frame.interop/after-render"
+      "        (fn []"
+      "          (if (exists? js/requestAnimationFrame)"
+      "            (js/requestAnimationFrame (fn [_#] (done#)))"
+      "            (done#)))))))")))
 
 (defn dispatch-tool [conn args]
   (let [event-str    (wire/arg args :event)
@@ -394,8 +428,22 @@
         ;; only). The orthogonal fx-args / runtime-db / large axes and the
         ;; app `:redact-fn` stay fail-closed regardless of
         ;; `:include-sensitive` (Security.md §Off-box egress).
+        ;;
+        ;; Use the established `args/parse-bool-arg` (the cross-MCP
+        ;; accept-shape parser) rather than a raw `(boolean (wire/arg …))`
+        ;; coercion. Over the JSON-MCP wire the arg can arrive as the
+        ;; STRING `"false"`, which is truthy in CLJS — a bare `boolean`
+        ;; would coerce a caller's explicit `include-sensitive "false"`
+        ;; to TRUE under `--allow-sensitive-reads`, threading
+        ;; `{:include-sensitive? true}` into `projected-record` and
+        ;; lifting the app-db sensitive axis the operator just declined.
+        ;; `parse-bool-arg` reads `"false"`/`"no"`/`"0"` as false (and
+        ;; defaults absent/unrecognised to the table's `false`), so the
+        ;; sensitive opt-in is honoured only on a genuine truthy value —
+        ;; the same safe parse `dispatch-dry-run` already uses for this
+        ;; arg.
         incl?        (if (raw-state/raw-state-allowed?)
-                       (boolean (wire/arg args :include-sensitive))
+                       (args/parse-bool-arg args :include-sensitive)
                        false)
         [tag payload] (parse-event-edn event-str)]
     (cond
@@ -473,8 +521,17 @@
         (if await-render?
           ;; Render-settle path. The form's synchronous return is a
           ;; Promise; await it through the shared mailbox so
-          ;; `dispatch → observe` is one deterministic step.
-          (let [settle-form (render-settle-form fn-sym event-vec opts-form)
+          ;; `dispatch → observe` is one deterministic step. When the
+          ;; resolved mode is epoch-bearing (`:trace` under await-render
+          ;; selects `dispatch-and-collect`, which returns the RAW
+          ;; `:epoch`), the settle form projects the result through
+          ;; `projected-record` APP-SIDE before egress — the SAME off-box
+          ;; redaction the non-await `:trace` / `:settle` path applies
+          ;; (rf2-6klf02). The consequence shapes (`:sync` / `:queued`)
+          ;; carry no raw app-db, so they ride unwrapped.
+          (let [settle-form (render-settle-form fn-sym event-vec opts-form
+                                                (contains? #{:trace :settle} mode)
+                                                incl?)
                 mailbox-id  (await-promise/mailbox-key)
                 wrapped     (await-promise/wrap-form settle-form mailbox-id)]
             ;; The signalled prelude flips the boot-gate posture BEFORE

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
@@ -436,6 +436,58 @@
                    (raw-state/set-allow-raw-state! false)
                    (done)))))))
 
+(deftest trace-include-sensitive-string-false-stays-false-no-leak
+  ;; rf2-66ippe — the include-sensitive arg MUST parse through the
+  ;; safe `args/parse-bool-arg`, not a raw `(boolean (wire/arg …))`
+  ;; coercion. Over the JSON-MCP wire the value can arrive as the STRING
+  ;; "false", which is TRUTHY in CLJS — a bare `boolean` would coerce a
+  ;; caller's explicit decline to TRUE under --allow-sensitive-reads,
+  ;; threading `:include-sensitive? true` into projected-record and
+  ;; lifting the app-db sensitive axis the operator just declined. The
+  ;; fix: "false" stays false ⇒ the projection runs (epoch still routes
+  ;; through projected-record) but WITHOUT the sensitive opt — sensitive
+  ;; app-db leaves stay :rf/redacted.
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true :epoch-id 7}
+            (fn []
+              ;; Gate ON so the per-call arg is consulted at all.
+              (raw-state/set-allow-raw-state! true)
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:list/toggle]" :trace true
+                                           :include-sensitive "false"})))
+          (.then (fn [_]
+                   (let [form @captured]
+                     (is (str/includes? form "dispatch-and-collect"))
+                     (is (str/includes? form "projected-record")
+                         "the epoch STILL routes through projected-record (never a raw bypass)")
+                     (is (str/includes? form ":rf.egress/profile :rf.egress/off-box-tool")
+                         "the off-box-tool boundary is named")
+                     (is (not (str/includes? form ":include-sensitive? true"))
+                         "string \"false\" stays FALSE — the sensitive axis is NOT lifted (rf2-66ippe: no raw boolean fail-open)"))
+                   (raw-state/set-allow-raw-state! false)
+                   (done)))))))
+
+(deftest trace-include-sensitive-string-true-lifts-axis
+  ;; The positive control: the genuine truthy STRING "true" DOES thread
+  ;; the sensitive opt — `parse-bool-arg` reads it as true. Pins that the
+  ;; safe parse isn't over-strict (it still honours the documented
+  ;; string-true accept shape, the same one dispatch-dry-run honours).
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true :epoch-id 7}
+            (fn []
+              (raw-state/set-allow-raw-state! true)
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:list/toggle]" :trace true
+                                           :include-sensitive "true"})))
+          (.then (fn [_]
+                   (let [form @captured]
+                     (is (str/includes? form ":include-sensitive? true")
+                         "string \"true\" lifts the app-db sensitive axis (accept-shape parity)"))
+                   (raw-state/set-allow-raw-state! false)
+                   (done)))))))
+
 (deftest sync-mode-does-not-project
   ;; The default sync consequence (dispatch-consequence!) carries no raw
   ;; app-db — it returns :db-changed? / :changed-paths / :effects-fired,
@@ -1113,6 +1165,109 @@
                    (let [edn (read-result-text r)]
                      (is (= :rf.error/dispatch-await-render-timeout (:reason edn)))
                      (is (= 60 (:timeout-ms edn))))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-6klf02 — the :await-render + :trace path MUST project the epoch
+;; off-box, exactly as the non-await :trace / :settle path does. Under
+;; await-render an explicit :trace still resolves to dispatch-and-collect
+;; (the RAW :epoch); the render-settle Promise wraps the runtime call, and
+;; that wrap previously emitted the BARE runtime call — so the raw epoch
+;; shipped off-box un-projected (the leak). The fix routes the await-render
+;; result through `projected-record` (egress/project-dispatch-result-src)
+;; INSIDE the settle form, the same redaction the non-await path applies.
+;; ---------------------------------------------------------------------------
+
+(deftest await-render-trace-projects-epoch-off-box-when-gate-off
+  ;; THE leak. Gate OFF (the published default) + :await-render :trace ⇒
+  ;; the await wrap form MUST route the dispatch-and-collect :epoch through
+  ;; the framework's off-box projection before it crosses the wire. Before
+  ;; the fix the wrap form was the bare `(rt/dispatch-and-collect …)` call
+  ;; with NO projection — the raw db-before/db-after/trigger-event shipped
+  ;; off-box.
+  (async done
+    (let [wrap-form*  (atom nil)
+          read-count* (atom 0)]
+      (-> (with-staged-mailbox-eval!
+            {:wrap-form* wrap-form* :read-count* read-count*
+             :pending-polls 0
+             :resolved {:ok? true :epoch-id 9 :frame :rf/default :settled? true
+                        :epoch {:frame :rf/default}}}
+            (fn []
+              (raw-state/set-allow-raw-state! false)
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:list/toggle]"
+                                           :await-render true :trace true})))
+          (.then (fn [_]
+                   (let [form @wrap-form*]
+                     (is (string? form))
+                     (is (str/includes? form "dispatch-and-collect")
+                         "await-render :trace still routes to the raw-epoch dispatch-and-collect")
+                     (is (str/includes? form "re-frame.core/projected-record")
+                         "gate OFF ⇒ the await-render :epoch routes through projected-record (rf2-6klf02)")
+                     (is (str/includes? form ":rf.egress/profile :rf.egress/off-box-tool")
+                         "the await-render epoch projects under the off-box-tool boundary")
+                     (is (str/includes? form "re-frame.interop/after-render")
+                         "the render-settle flush is intact — projection composes with the settle")
+                     (is (str/includes? form ":settled? true")
+                         "the settle form still merges :settled? true (over the projected envelope)"))
+                   (raw-state/set-allow-raw-state! false)
+                   (done)))))))
+
+(deftest await-render-trace-include-sensitive-routes-through-projection
+  ;; Gate ON + :include-sensitive true on the await-render :trace path does
+  ;; NOT bypass the projection — it threads `{:include-sensitive? true}`
+  ;; INTO projected-record (app-db sensitive axis only), exactly like the
+  ;; non-await path. fx-args / runtime-db stay fail-closed.
+  (async done
+    (let [wrap-form*  (atom nil)
+          read-count* (atom 0)]
+      (-> (with-staged-mailbox-eval!
+            {:wrap-form* wrap-form* :read-count* read-count*
+             :pending-polls 0
+             :resolved {:ok? true :epoch-id 9 :frame :rf/default :settled? true
+                        :epoch {:frame :rf/default}}}
+            (fn []
+              (raw-state/set-allow-raw-state! true)
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:list/toggle]"
+                                           :await-render true :trace true
+                                           :include-sensitive true})))
+          (.then (fn [_]
+                   (let [form @wrap-form*]
+                     (is (str/includes? form "projected-record")
+                         "include-sensitive STILL projects — never a raw bypass on the await path")
+                     (is (str/includes? form ":include-sensitive? true")
+                         "the app-db sensitive axis is threaded INTO the projection")
+                     (is (not (str/includes? form ":include-fx-args?"))
+                         "fx-args axis is NOT lifted by include-sensitive (orthogonal)")
+                     (is (not (str/includes? form ":include-runtime-db?"))
+                         "runtime-db axis is NOT lifted by include-sensitive (orthogonal)"))
+                   (raw-state/set-allow-raw-state! false)
+                   (done)))))))
+
+(deftest await-render-plain-does-not-project
+  ;; The control: a plain :await-render (no :trace) routes to
+  ;; dispatch-consequence!, which carries no raw app-db — so its wrap form
+  ;; must NOT wrap the call in projected-record (the projection is for the
+  ;; epoch-bearing :trace path only).
+  (async done
+    (let [wrap-form*  (atom nil)
+          read-count* (atom 0)]
+      (-> (with-staged-mailbox-eval!
+            {:wrap-form* wrap-form* :read-count* read-count*
+             :pending-polls 0
+             :resolved {:ok? true :epoch-id 9 :frame :rf/default :settled? true}}
+            (fn []
+              (raw-state/set-allow-raw-state! false)
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:counter/inc]" :await-render true})))
+          (.then (fn [_]
+                   (let [form @wrap-form*]
+                     (is (str/includes? form "dispatch-consequence!")
+                         "plain await-render forces the sync consequence surface")
+                     (is (not (str/includes? form "projected-record"))
+                         "the consequence carries no raw app-db — no projection wrap"))
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes two coupled off-box-egress leaks on the pair-mcp / epoch surface (combined to avoid a self-conflict on `dispatch.cljs`).

## rf2-66ippe — include-sensitive raw-boolean fail-open

`dispatch.cljs` coerced the `:include-sensitive` arg with a raw `(boolean (wire/arg …))`. Over the JSON-MCP wire the value can arrive as the STRING `"false"`, which is truthy in CLJS — so an explicit decline coerced to TRUE under `--allow-sensitive-reads`, threading `{:include-sensitive? true}` into `projected-record` and lifting the app-db sensitive axis the operator just declined (leaking raw sensitive app-db off-box via the projected `:trace`/`:settle` epoch).

**Fix:** route through the established `args/parse-bool-arg` (the cross-MCP accept-shape parser `dispatch-dry-run` already uses for this same arg) so `"false"`/`"no"`/`"0"` stay false and absent/unrecognised defaults to the table's `false`. The epoch still ALWAYS routes through `projected-record`; only a genuine truthy value lifts the sensitive axis.

**Tests:** `trace-include-sensitive-string-false-stays-false-no-leak` (string `"false"` ⇒ projection still runs, `:include-sensitive? true` NOT emitted) + `trace-include-sensitive-string-true-lifts-axis` (positive control — accept-shape parity).

## rf2-6klf02 — two off-box epoch leaks

**(1) cascade-summary `:event-vector` leaked non-declared trigger-event secrets.** `redact-sensitive-event-vector` keyed redaction to the `:rf.epoch/sensitive?` rollup ALONE, so a non-declared trigger-event carrying a secret in its args (e.g. `[:login "topsecret"]` with no declared-sensitive db slot) shipped raw off-box. Aligned to the framework's fail-closed `:trigger-event` projection (rf2-nm611o, `epoch/tool_pair.cljc` §`elide-trigger-event-slot`): under the OFF gate the head event-id is retained and every arg redacts to `:rf/redacted`, for EVERY epoch (the args are registration-owned transient payloads the classification walker cannot prove safe). Gate ON ships verbatim.

**(2) `:await-render` + `:trace` egressed the RAW epoch un-projected.** `render-settle-form` wrapped the bare runtime call, bypassing the `projected-record` projection the non-await `:trace`/`:settle` path applies. Routed the await-render result through `egress/project-dispatch-result-src` inside the settle form, so the await transport projects the SAME way the non-await one does. `:include-sensitive` routes THROUGH the projection (app-db sensitive axis only — never a bypass); plain await-render consequence stays unwrapped.

**Tests:** `undeclared-secret-event-vector-fails-closed-in-cascade-summary` (bb mirror) + `await-render-trace-projects-epoch-off-box-when-gate-off` / `await-render-trace-include-sensitive-routes-through-projection` / `await-render-plain-does-not-project`. Existing sensitive/restore cascade-summary tests updated to the new fail-closed-args shape.

Spec `003-Tool-Catalogue.md` updated for both contracts.

## Quality gates

All green (junctioned node_modules from the mayor tree — absent in the fresh worktree):

- `rf2-66ippe` — pair-mcp server-test (1128 tests / 3785 assertions, 0 failures); mcp-conformance ALL GREEN; `npm run test:cljs` (7976 tests, 0 failures)
- `rf2-6klf02` — epoch JVM suite `clojure -M:test` (376 tests / 1504 assertions, 0 failures); bb cascade-summary mirror (8 tests / 26 assertions, 0 failures); pair-mcp server-test + mcp-conformance + test:cljs (as above)

CI is the merge gate.