### PR TITLE
fix(xray): local-render egress fail-closed on nil frame — stop ambient-frame raw leak (rf2-cra0nq)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -690,9 +690,19 @@ the picker / focus selects). The contract — the shared seam
   and the inline `← was X` annotation never reconstructs the redacted
   content.
 - **Fail-closed.** An unreachable observed frame (nil / destroyed /
-  never-registered) projects WITHOUT a `:frame` opt so the underlying
-  `elide-wire-value` walker takes its frameless redact-whole branch —
-  redacting the entire value rather than shipping it raw under no policy.
+  never-registered) is stamped with a **non-nil dead-frame sentinel** as the
+  `:frame` opt — an id that can never resolve to a live frame — so the
+  underlying `elide-wire-value` walker takes its **unresolvable-frame**
+  redact-whole branch, redacting the entire value rather than shipping it raw
+  under no policy. The sentinel is stamped, **not** omitted: an absent / nil
+  `:frame` opt would let the walker fall through to the **ambient**
+  dynamically-bound frame (`frame/resolve-current-frame`) and ship
+  value-bearing fields RAW under that borrowed frame's (possibly empty)
+  policy — the exact ambient-borrow leak this seam abolishes (rf2-cra0nq,
+  mirroring the off-box derivation-graph fix rf2-udkj69). Under the
+  `:rf.egress/local-raw` opt-in (explicit `:rf.size/include-sensitive? true`)
+  the walker ships the value raw even under the sentinel — the operator has
+  deliberately waived redaction.
 
 Revealing sensitive values is **not** a process-global toggle. Per
 [Spec 015 §Cross-tool visibility grain](../../../spec/015-Data-Classification.md#cross-tool-visibility-grain)

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
@@ -535,11 +535,22 @@
   partitions, absent reserved keys, empty registries, absent before-images)."
   ([app-db runtime-db] (current-state-sections app-db runtime-db no-diff))
   ([app-db runtime-db before]
-   (let [app-db        (or app-db {})
-         runtime-db    (or runtime-db {})
+   (let [;; Egress fail-closed (rf2-cra0nq): when the section model is fed a
+         ;; value the local-render seam redacted WHOLE (an unreachable /
+         ;; nil observed frame ⇒ the `:rf/redacted` sentinel, NOT a map),
+         ;; there is no decomposable structure — treat it as the empty
+         ;; partition rather than iterate the scalar sentinel (which would
+         ;; throw). Mirrors the existing nil-safety; a whole-redacted value
+         ;; carries no user-domain content to show.
+         demap         (fn [v] (if (map? v) v {}))
+         app-db        (demap (or app-db {}))
+         runtime-db    (demap (or runtime-db {}))
          diff?         (and (some? before) (not= no-diff before))
-         app-before    (if diff? (or (:app before) {}) no-diff)
-         runtime-before (if diff? (or (:runtime before) {}) no-diff)
+         ;; A whole-redacted pre-image (rf2-cra0nq) is likewise non-map —
+         ;; `demap` it so the diff-mode user-domain / runtime walks see an
+         ;; empty pre-image (everything reads `:added`) rather than throw.
+         app-before    (if diff? (demap (or (:app before) {})) no-diff)
+         runtime-before (if diff? (demap (or (:runtime before) {})) no-diff)
          before-area   (fn [area-id]
                          (if diff?
                            (let [path (get runtime-areas area-id)

--- a/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
@@ -53,17 +53,24 @@
 
   ## Fail-closed (the silent-leak this seam abolishes)
 
-  `rf/project-egress` delegates to `rf/elide-wire-value`, which treats a
-  carried `:frame` opt as a KNOWN frame even when that id names no LIVE
-  frame — applying an empty (identity) policy that would ship the value
-  RAW under no policy. The local-render default must not do that. So this
-  seam first checks the named frame is LIVE (`rf/frame-ids`); when it is
-  not (nil id, a destroyed / never-registered frame), it projects WITHOUT a
-  `:frame` opt so the underlying walker takes its own frameless fail-closed
-  branch and redacts the whole value to `:rf/redacted` rather than borrow
-  another frame's marks. (Under `:rf.egress/local-raw`'s explicit
+  `rf/project-egress` delegates to `rf/elide-wire-value`, which resolves its
+  governing frame as `(or (:frame opts) (frame/resolve-current-frame))` — so
+  a nil `:frame` opt (or no `:frame` at all) falls through to the AMBIENT
+  dynamically-bound frame, applying THAT frame's (possibly empty) policy and
+  shipping value-bearing fields RAW under a borrowed scope. The local-render
+  default must not do that. So this seam first checks the named frame is LIVE
+  (`rf/frame-ids`); when it is not (nil id, a destroyed / never-registered
+  frame), it stamps a DEAD-FRAME SENTINEL as the `:frame` opt — a non-nil id
+  that can never resolve to a live frame — so the underlying walker takes its
+  UNRESOLVABLE-FRAME fail-closed branch (`frame/frame` returns nil for it)
+  and redacts the whole value to `:rf/redacted` rather than borrow the
+  ambient frame's marks. Stamping the sentinel (NOT omitting `:frame`) is the
+  point: an absent / nil `:frame` opt is exactly the ambient-borrow path this
+  seam abolishes (rf2-cra0nq, mirroring the off-box derivation-graph fix
+  rf2-udkj69). (Under `:rf.egress/local-raw`'s explicit
   `:rf.size/include-sensitive? true` opt-out the walker ships the value
-  raw even frameless — the operator has explicitly asked for it.)
+  raw even under the dead-frame sentinel — the operator has explicitly asked
+  for it; the opt-out branch precedes the fail-closed redact.)
 
   ## The edn-inspector renders the sentinels natively
 
@@ -96,6 +103,25 @@
   explicit operator act, never a process-global toggle."
   :rf.egress/local-raw)
 
+(def ^:private dead-frame-sentinel
+  "A frame id that can NEVER resolve to a live frame, stamped as the `:frame`
+  opt to FAIL CLOSED a nil / unreachable egress frame WITHOUT borrowing the
+  ambient scope.
+
+  `rf/elide-wire-value` resolves its governing frame as `(or (:frame opts)
+  (frame/resolve-current-frame))` — so a nil `:frame` opt (or no `:frame` at
+  all) falls through to the AMBIENT dynamically-bound frame, applying that
+  frame's (possibly empty) policy and shipping value-bearing fields RAW. An
+  unreachable but NON-nil `:frame` opt instead takes the unresolvable-frame
+  fail-closed branch (`frame/frame` returns nil ⇒ whole value redacted to
+  `:rf/redacted`, unless the caller explicitly waived sensitive redaction).
+  We therefore stamp this sentinel as the `:frame` opt when no live governing
+  frame is known, so the walker fails closed on its own dead-frame branch
+  rather than resolving an ambient frame. The keyword is namespaced into this
+  panel so it can never collide with a real frame id. Mirrors the off-box
+  derivation-graph fix (rf2-udkj69); applied to local-render by rf2-cra0nq."
+  ::no-egress-frame)
+
 (defn local-render-profile
   "Resolve the egress profile a local panel render should project under,
   given the per-(tool,frame) `raw?` grain. `true` ⇒ the trusted-local
@@ -110,10 +136,17 @@
 
   - **profile** — `local-render-profile` resolves the named boundary from
     the per-(tool,frame) `raw?` grain (default `:rf.egress/local-redacted`).
-  - **`:frame frame-id`** — only when the frame is LIVE (`rf/frame-ids`).
-    A nil / unreachable frame is OMITTED so the underlying walker fails
-    closed (redacts the whole value) rather than borrow another frame's
-    policy.
+  - **`:frame`** — ALWAYS stamped: the named `frame-id` when it is LIVE
+    (`rf/frame-ids`); otherwise (nil id, a destroyed / never-registered
+    frame) the `dead-frame-sentinel`. We must NOT omit / leave `:frame` nil
+    for an unreachable frame: an absent / nil `:frame` opt lets the walker
+    fall through to the AMBIENT dynamically-bound frame
+    (`frame/resolve-current-frame`) and ship value-bearing fields RAW under
+    that borrowed frame's policy — the exact ambient-borrow leak this seam
+    abolishes (rf2-cra0nq, mirroring rf2-udkj69). The sentinel is a non-nil
+    id that resolves to no live frame, so the walker takes its
+    unresolvable-frame fail-closed branch (redact the whole value) rather
+    than borrow another frame's policy.
   - **`:rf.size/include-large? true`** — the on-box 'keep large' override
     (EP-0015 §10: `local-redacted` *suppresses sensitive display*; the
     local operator IS entitled to large values — Xray's own size-bounding
@@ -127,10 +160,19 @@
   over the runtime frame registry."
   ([frame-id] (local-render-opts frame-id false))
   ([frame-id raw?]
-   (cond-> {:rf.egress/profile      (local-render-profile raw?)
-            :rf.size/include-large? true}
-     (and (some? frame-id) (contains? (rf/frame-ids) frame-id))
-     (assoc :frame frame-id))))
+   ;; A reachable (live) frame governs egress under its own policy; a nil /
+   ;; unreachable frame stamps the dead-frame sentinel as the `:frame` opt so
+   ;; `rf/elide-wire-value` takes its unresolvable-frame FAIL-CLOSED branch
+   ;; (whole value ⇒ `:rf/redacted`). We must NOT leave the `:frame` opt
+   ;; absent / nil here: that frameless path lets the walker fall through to
+   ;; the AMBIENT dynamically-bound frame (`frame/resolve-current-frame`) and
+   ;; ship value-bearing fields RAW under that frame's policy — the exact
+   ;; ambient-borrow leak this seam abolishes (rf2-cra0nq, mirroring
+   ;; rf2-udkj69).
+   (let [reachable? (and (some? frame-id) (contains? (rf/frame-ids) frame-id))]
+     {:rf.egress/profile      (local-render-profile raw?)
+      :rf.size/include-large? true
+      :frame                  (if reachable? frame-id dead-frame-sentinel)})))
 
 ;; ---------------------------------------------------------------------------
 ;; The projection seam.

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
@@ -266,6 +266,28 @@
       (is (= {:counter 5 :user {:name "ada"}} (:top model))
           ":top is the user-domain app-db (runtime-db is the areas' source)"))))
 
+(deftest current-state-sections-tolerates-whole-redacted-value
+  (testing "rf2-cra0nq — when the local-render egress redacts the WHOLE value
+            (an unreachable / nil observed frame fails closed to the
+            `:rf/redacted` sentinel, a scalar — NOT a map), the section model
+            treats it as the empty partition rather than iterating the scalar
+            (which would throw). The model is still a non-nil, well-formed
+            section map with an empty TOP + no areas"
+    (let [model (h/current-state-sections :rf/redacted :rf/redacted)]
+      (is (some? model) "a whole-redacted value yields a non-nil model")
+      (is (= {} (:top model))
+          "a whole-redacted app-db has no decomposable user-domain content")
+      (is (= [] (:areas model))
+          "a whole-redacted runtime-db contributes no reserved areas")))
+  (testing "diff mode tolerates a whole-redacted pre-image too — the redacted
+            before-image is treated as empty (everything reads :added), never
+            throws"
+    (let [model (h/current-state-sections {:counter 1} {}
+                                          {:app :rf/redacted :runtime :rf/redacted})]
+      (is (some? model))
+      (is (= {:counter 1} (:top model))
+          "a present value still decomposes; only the redacted pre-image is empties"))))
+
 (deftest current-state-sections-enumerates-only-populated-areas
   (testing "rf2-jcdvo — :areas contains ONLY populated runtime
             subsystems (read from runtime-db); empty / absent subsystems

--- a/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
@@ -29,7 +29,11 @@
     4. **`:rf.egress/local-raw` opt-in** — the per-(tool,frame) trusted-local
        grain reveals the sensitive slot (an explicit operator act).
     5. **fail-closed** — an unreachable observed frame redacts the WHOLE value
-       under the redacted default rather than ship it raw.
+       under the redacted default rather than ship it raw; the unreachable /
+       nil frame is stamped with a NON-NIL dead-frame sentinel (not omitted),
+       and (5b) a nil / unreachable observed frame still redacts EVEN WHEN an
+       ambient frame is dynamically bound — it must NOT borrow that ambient
+       frame's policy and leak the secret (rf2-cra0nq, mirroring rf2-udkj69).
     6. **end-to-end** — the App-DB Diff section model sub
        (`:rf.xray/app-db-state`) redacts a sensitive app-db slot, so what the
        panel hands the edn-inspector is already projected."
@@ -158,13 +162,63 @@
   (testing "a nil observed frame likewise fails closed"
     (is (= :rf/redacted (local-render/local-render-value app-db-value nil))))
   (testing "the live frame is carried as the :frame opt; an unreachable one is
-            omitted so the walker fails closed"
+            stamped with a NON-NIL dead-frame sentinel (NOT omitted / nil) so
+            the walker takes its unresolvable-frame fail-closed branch rather
+            than fall through to the ambient frame (rf2-cra0nq)"
     (is (= secure-frame (:frame (local-render/local-render-opts secure-frame))))
-    (is (not (contains? (local-render/local-render-opts :app/does-not-exist) :frame)))
+    (let [unreachable-opts (local-render/local-render-opts :app/does-not-exist)
+          nil-opts         (local-render/local-render-opts nil)]
+      (is (contains? unreachable-opts :frame)
+          "an unreachable frame MUST still stamp :frame (a sentinel), never omit it")
+      (is (some? (:frame unreachable-opts))
+          "the stamped :frame is NON-NIL — a nil/absent :frame borrows the ambient frame")
+      (is (not= :app/does-not-exist (:frame unreachable-opts))
+          "the stamped :frame is a sentinel, not the unreachable id itself")
+      (is (contains? nil-opts :frame)
+          "a nil frame-id MUST stamp the sentinel, not leave :frame nil/absent")
+      (is (some? (:frame nil-opts))
+          "the nil-frame :frame opt is the NON-NIL sentinel"))
     (is (= :rf.egress/local-redacted
            (:rf.egress/profile (local-render/local-render-opts secure-frame))))
     (is (true? (:rf.size/include-large? (local-render/local-render-opts secure-frame)))
         "the keep-large overlay is always present")))
+
+;; ---------------------------------------------------------------------------
+;; 5b. THE AMBIENT-BORROW ARM — fail-closed EVEN WHEN an ambient frame is bound
+;;     (rf2-cra0nq, mirroring the off-box derivation-graph fix rf2-udkj69).
+;;
+;; The §5 arm runs under the fixture's `:ambient-frame nil`, so the absent-:frame
+;; path resolves NO frame and trivially fails closed — it never exercised the
+;; ambient-BORROW leak. Here we dynamically bind an ambient frame (`:app/plain`,
+;; which declares NO sensitive policy, so a borrow WOULD ship the token RAW) and
+;; assert a nil / unreachable observed frame still redacts the whole value rather
+;; than borrow `:app/plain`'s empty policy and leak the secret.
+;; ---------------------------------------------------------------------------
+
+(deftest local-render-fails-closed-under-bound-ambient-frame
+  (rf/with-frame plain-frame
+    (is (some? (frame/resolve-current-frame))
+        "PRECONDITION — an ambient frame IS dynamically bound, so an absent /
+         nil :frame opt WOULD resolve it (the borrow this arm forbids)")
+    (testing "a NIL observed frame redacts the whole value, NOT shipping it raw
+              under the borrowed ambient :app/plain (empty) policy (rf2-cra0nq)"
+      (let [rendered (local-render/local-render-value app-db-value nil)]
+        (is (= :rf/redacted rendered)
+            "nil frame ⇒ whole-value redact, never the borrowed-ambient identity walk")
+        (is (not= "secret-session-jwt-abc123" (get-in rendered [:auth :token]))
+            "the session token must NOT ride through under the borrowed ambient frame")))
+    (testing "an UNREACHABLE observed frame likewise redacts under a bound ambient"
+      (is (= :rf/redacted
+             (local-render/local-render-value app-db-value :app/does-not-exist))
+          "destroyed / never-registered frame fails closed, never borrows ambient"))
+    (testing "the LOCAL-RAW opt-in still ships raw even with the sentinel — the
+              operator has explicitly waived redaction (the opt-out branch precedes
+              the fail-closed redact); the sentinel never over-redacts a deliberate
+              raw request"
+      (is (= "secret-session-jwt-abc123"
+             (get-in (local-render/local-render-value app-db-value nil true)
+                     [:auth :token]))
+          ":rf.egress/local-raw includes-sensitive? ⇒ identity walk even frameless"))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6. end-to-end — the App-DB Diff section-model derivation redacts a sensitive


### PR DESCRIPTION
## What

The on-box local-render egress seam (`tools/xray/.../panels/local-render`) handled a nil / unreachable observed frame by **OMITTING** the `:frame` opt. That lets `rf/elide-wire-value` resolve its governing frame as `(or (:frame opts) (frame/resolve-current-frame))` and fall through to the **AMBIENT** dynamically-bound frame — shipping value-bearing fields RAW under that borrowed frame's (possibly empty) policy. This is the exact ambient-borrow leak the off-box derivation-graph egress fixed in **rf2-udkj69**, which was never applied to local-render.

## The fix (mirrors rf2-udkj69)

`local-render-opts` now **ALWAYS** stamps `:frame`:
- the **live** frame when reachable (`rf/frame-ids`);
- a non-nil **`dead-frame-sentinel`** (`::no-egress-frame`) when nil / destroyed / never-registered.

A non-nil-but-unreachable `:frame` opt makes `elide-wire-value` take its **unresolvable-frame fail-closed branch** (`frame/frame` returns nil ⇒ whole value redacted to `:rf/redacted`) rather than borrow the ambient frame. Under `:rf.egress/local-raw` the explicit `:rf.size/include-sensitive? true` opt-out still ships raw (the operator's deliberate act — the opt-out branch precedes the fail-closed redact). This is a direct mirror of `redact-graph-for-egress`'s `dead-frame-sentinel` in `derivation_graph_helpers.cljc`.

## Consumer robustness

The fail-closed sentinel the egress now correctly produces flows into the `:rf.xray/app-db-state` sub (which redacts the whole observed app-db under the observed frame). The App-DB section model `current-state-sections` now treats a whole-redacted (`:rf/redacted` scalar) value / pre-image as the **empty partition** rather than iterating the scalar (which threw, surfacing as the `composite-subs-non-throwing-on-empty-frame` smoke failing on a fresh frame). Mirrors the existing nil-safety.

## Tests + confirm-by-revert

- New ambient-borrow arm `local-render-fails-closed-under-bound-ambient-frame`: binds an ambient `:app/plain` frame (no sensitive policy, so a borrow WOULD leak) and asserts a nil / unreachable observed frame still redacts the whole value — the session token never rides through under the borrowed frame. (The prior fail-closed arm ran under `:ambient-frame nil`, so it never exercised the borrow.)
- `local-render-opts` assertions updated: an unreachable / nil frame must stamp a **non-nil sentinel** (`contains? :frame` + `some?`), not omit it.
- New `current-state-sections-tolerates-whole-redacted-value` arm pins the consumer robustness.
- **Confirm-by-revert**: with the buggy omit-`:frame` impl restored (tests intact), the ambient-borrow arm FAILS — `(get-in rendered [:auth :token])` returns the raw `"secret-session-jwt-abc123"` under the borrowed ambient `:app/plain`, and the `local-render-opts` assertions show `:frame` absent/nil. Fix restored → green.

## Spec

`tools/xray/spec/004-App-DB-Diff.md` §On-box local-render egress policy — the "Fail-closed" bullet was updated from the buggy "projects WITHOUT a `:frame` opt" to the dead-frame-sentinel mechanism + the ambient-borrow it prevents (rf2-cra0nq, mirroring rf2-udkj69).

## Quality gates

- `clojure -M:test` (tools/xray JVM): **1217 tests, 5643 assertions, 0 failures, 0 errors** (includes the new `.cljc` arms).
- `npm run test:cljs`: **7978 tests, 36696 assertions, 0 failures, 0 errors**.
- `npm run test:xray-feature-gate` (browser, nightly-full sweep): **15 scenarios, 0 failures, 13 matrix rows**.

Surface: `tools/xray` only (5 files). CI is the merge gate.