### PR TITLE
fix(schemas): hot-reload schema-violation fail-closed on opaque schema + stale-bridge comments (rf2-kzghnz)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -647,6 +647,17 @@
 ;; redaction posture so the hot-reload trace never re-leaks a credential.
 ;; rf2-qe237 — refer to the canonical core def rather than a local copy so
 ;; the keyword can never drift across artefacts.
+;;
+;; rf2-u9bjgr / rf2-kzghnz — the sensitivity decision below ALSO fails CLOSED
+;; on an OPAQUE schema (a compiled `m/schema` object the pure-data walker
+;; cannot introspect): `schema-has-sensitive?` returns false on an opaque
+;; value even though Malli may honour a `{:sensitive? true}` slot inside it for
+;; the violation. Without the fail-closed arm a hot-reload violation against an
+;; opaque schema carrying a sensitive slot leaked `:mismatching-value` verbatim
+;; — the SAME asymmetry the `:rf.error/schema-validation-failure` redactor
+;; closed for the validate-*! egress (`re-frame.schemas.validate`, the
+;; `(or schema-has-sensitive? schema-opaque?)` posture). This is the redaction
+;; half of the same fail-closed posture for the hot-reload egress edge.
 (def ^:private redacted-sentinel privacy/redacted-sentinel)
 
 (defn- maybe-emit-schema-violation!
@@ -675,7 +686,16 @@
                            (catch #?(:clj Throwable :cljs :default) _ true))]
         (when-not passes?
           (when-let [emit! (late-bind/get-fn :trace/emit!)]
-            (let [sensitive? (walker/schema-has-sensitive? new-schema)]
+            ;; rf2-u9bjgr / rf2-kzghnz — fail CLOSED on an OPAQUE schema. The
+            ;; pure-data walker cannot see a `{:sensitive? true}` slot inside a
+            ;; compiled `m/schema` value, so `schema-has-sensitive?` alone would
+            ;; return false and `:mismatching-value` would egress the live value
+            ;; verbatim — the asymmetry the validate-*! redactor already closes
+            ;; (`re-frame.schemas.validate` uses the same
+            ;; `(or schema-has-sensitive? schema-opaque?)` posture). A bare
+            ;; keyword is provably flag-free and is NOT opaque (`schema-opaque?`).
+            (let [sensitive? (or (walker/schema-has-sensitive? new-schema)
+                                 (walker/schema-opaque? new-schema))]
               (emit! :warning :rf.schema/violation
                      {:path               path
                       :pre-reload-schema  prior-schema
@@ -709,8 +729,16 @@
 ;;
 ;; The schema's `{:sensitive? true}` slot prop still drives
 ;; schema-validation-failure-trace redaction (`re-frame.schemas.validate`),
-;; and the per-slot extractors still serve the machine `:data-schema` bridge
-;; (EP-0005) — both consult the schema directly, never this registry.
+;; and the per-slot extractors still serve their surviving owner-local
+;; consumers (the resource `:data-schema` classification, the HTTP body-privacy
+;; projector, story-mcp's tool-egress projector) — each consults the schema
+;; directly, never this registry. The machine `:data-schema`→MARKS redaction
+;; bridge (EP-0005) is NOT among them: EP-0025 (rf2-398kql) reversed it —
+;; durable machine `:data` classification now rides the SAME commit-plane
+;; classification effects as every other app-db path, not a schema→marks walk.
+;; (The machine `:data-schema` still VALIDATES and its props still drive the
+;; machine-data validation-FAILURE-trace redactor — only the schema→marks
+;; CLASSIFICATION bridge is gone; see `re-frame.schemas.walker` ns-doc.)
 
 ;; ---- app-db schema registration -------------------------------------------
 

--- a/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
@@ -11,15 +11,27 @@
 
   EP-0015 §8 (rf2-d2r3um): `reg-app-schema` NO LONGER populates the
   durable elision registry from `:large?` / `:sensitive?` per-slot flags —
-  durable app-db egress classification is frame-owned
-  (`re-frame.frame-classification`, exercised in the core/ssr suites).
-  Schema `:sensitive?` still drives THIS file's hot-reload-trace redaction
+  durable app-db egress classification rides the EP-0025 commit-plane
+  classification effects (a `reg-event` returns `:sensitive` / `:large`
+  alongside `:db`; `re-frame.elision/apply-classification-effects`,
+  `:source :effect`, exercised in the core/ssr suites). It is NOT installed
+  by `re-frame.frame-classification` anymore — EP-0025 retired the durable
+  app-db classification install there (a `reg-frame` `:sensitive {:app-db …}`
+  block / a `:large` frame key now fail loud with
+  `:rf.error/bad-frame-classification`). Schema `:sensitive?` still drives
+  THIS file's hot-reload-trace redaction
   (`violation-redacts-mismatching-value-when-new-schema-sensitive`),
   consulting the schema directly rather than any elision-registry feed.
 
   The effect is gated on `interop/debug-enabled?` and DCE'd in
   production; the JVM test build is always dev-enabled."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            ;; rf2-u9bjgr / rf2-kzghnz — compiled `m/schema` objects exercise
+            ;; the opaque-schema fail-closed redaction arm of the hot-reload
+            ;; `:rf.schema/violation` path. Malli is on the schemas test
+            ;; classpath (the artefact deps on metosin/malli).
+            [malli.core :as m]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.schemas :as schemas]
@@ -128,6 +140,46 @@
         ;; `trace/build-event`.
         (is (true? sensitive?) ":sensitive? hoisted to top level")
         (is (= [:token] (:path tags)) "structural :path is kept")))))
+
+(deftest violation-redacts-mismatching-value-when-new-schema-opaque-and-sensitive
+  (testing "rf2-u9bjgr / rf2-kzghnz — when the NEW (re-registered) schema is
+            a COMPILED / OPAQUE m/schema object carrying a {:sensitive? true}
+            slot, the hot-reload violation FAILS CLOSED: the pure-data walker
+            cannot see the per-slot flag, so the path must redact
+            :mismatching-value to :rf/redacted anyway, never leaking the live
+            value. Mirrors the validate-*! opaque fail-closed posture
+            (schemas_sensitive_test/app-db-validation-opaque-schema-fails-closed)."
+    (let [secret "OPAQUE-HOTRELOAD-SECRET-kzghnz"]
+      ;; Original schema is a plain (walkable) vector form; the live value is a
+      ;; credential string. Re-register the SAME path with a COMPILED opaque
+      ;; schema that (a) differs from the prior schema (so the change-gate
+      ;; fires), (b) the live value fails (so a violation fires), and (c)
+      ;; declares its slot {:sensitive? true} — a flag Malli honours for
+      ;; validation but the walker cannot introspect through the opaque value.
+      (rf/reg-app-schema [:token] {:schema :int})
+      (set-app-db! {:token secret})
+      (let [violations (capture :rf.schema/violation
+                         (fn []
+                           (rf/reg-app-schema
+                             [:token]
+                             {:schema (m/schema [:int {:sensitive? true}])})))]
+        (is (= 1 (count violations)) "exactly one violation trace")
+        (let [{:keys [sensitive? tags] :as ev} (first violations)]
+          ;; FAIL CLOSED: the opaque schema cannot be walked, so the path must
+          ;; redact regardless of what schema-has-sensitive? can see.
+          (is (= :rf/redacted (:mismatching-value tags))
+              "opaque schema fails closed: live value scrubbed to :rf/redacted")
+          (is (true? sensitive?) ":sensitive? hoisted to top level (fail-closed stamp)")
+          (is (= [:token] (:path tags)) "structural :path is kept")
+          (is (not (str/includes? (pr-str ev) secret))
+              "the secret survives nowhere in the opaque hot-reload violation trace"))))))
+
+;; CONFIRM-BY-REVERT (rf2-kzghnz): reverting the fail-closed arm to the bare
+;; `(walker/schema-has-sensitive? new-schema)` (dropping the
+;; `(or … (walker/schema-opaque? new-schema))`) makes `sensitive?` false for
+;; the opaque schema above, `:mismatching-value` then ships `secret` verbatim,
+;; the `:rf/redacted` and `not str/includes? secret` assertions both fail, and
+;; the violation egresses the credential — the leak this test pins closed.
 
 (deftest violation-is-per-frame
   (testing "rf2-ee38b.6 — the violation check reads the live app-db of


### PR DESCRIPTION
## Summary

Implements rf2-kzghnz (schemas, EP-0025 surface).

**P2 correctness (rf2-u9bjgr).** The hot-reload `:rf.schema/violation` egress in `maybe-emit-schema-violation!` (`re-frame.schemas.storage`) was NOT fail-closed on an OPAQUE schema. It derived `sensitive?` from `walker/schema-has-sensitive?` alone, which returns `false` on a compiled/opaque `m/schema` object the pure-data walker cannot introspect. A hot-reload validation failure against an opaque schema carrying a `{:sensitive? true}` slot (which Malli honours for validation) therefore leaked the live `app-db` value verbatim under `:mismatching-value` — the SAME asymmetry the `:rf.error/schema-validation-failure` redactor already closed for the `validate-*!` egress. Fix: redact fail-closed when the schema is opaque, mirroring the `(or schema-has-sensitive? schema-opaque?)` posture in `re-frame.schemas.validate`. A bare keyword is provably flag-free and stays non-opaque.

**P3 cleanup (rf2-398kql / EP-0005).** Corrected two stale comments naming the REMOVED machine `:data-schema`→marks bridge as a live extractor consumer / pointing durable app-db classification at the deleted `re-frame.frame-classification` install path:
- `storage.cljc` — the "per-slot extractors still serve the machine `:data-schema` bridge (EP-0005)" comment now lists only the surviving owner-local consumers (resource `:data-schema`, HTTP body-privacy, story-mcp tool-egress) and notes the machine bridge is reversed under EP-0025 (the commit-plane classification effects).
- `schemas_reg_side_effects_test` docstring — the "durable app-db egress classification is frame-owned (`re-frame.frame-classification`)" claim now points at the EP-0025 commit-plane classification effects, noting `re-frame.frame-classification` retired the durable app-db install (a `:sensitive {:app-db …}` block / `:large` frame key now fail loud).

**Test (confirm-by-revert).** New `violation-redacts-mismatching-value-when-new-schema-opaque-and-sensitive`: re-registers a path with a compiled opaque `{:sensitive? true}` schema the live value fails, asserts `:mismatching-value` = `:rf/redacted`, `:sensitive?` stamped, and the secret egresses nowhere. Confirmed by revert — dropping the `(or … schema-opaque?)` arm flips three assertions red (the leak), restoring it greens them.

## Quality gates

- JVM schemas (`clojure -M:test`): 322 tests, 18866 assertions, 0 failures / 0 errors (side-effects ns: 7 tests incl. the new one).
- `npm run test:cljs`: 7976 tests, 36682 assertions, 0 failures / 0 errors.
- `npm run test:elision` (touched an egress path): PASS — production 42/42 absent, control 42/42 present, EP-0023 provenance + assembly-DCE green.

Touched only `implementation/schemas` (src + its test). CI is the merge gate.

node_modules note: the worktree had no `node_modules` and the mayor tree's was empty, so the junction was useless — removed it and ran a fresh `npm install` in the worktree for the CLJS/elision gates.