### PR TITLE
test(xray-testbeds): make machine_epochs reset-replay + two_frame_isolation assertions signal-bearing (rf2-4279q4)

### DIFF
--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -177,11 +177,16 @@
 ;; the L2 event-row wash, and the issues ribbon signal.
 
 (def AuthSlice [:map [:token :string]])
-;; EP-0002: reg-app-schema is context-required frame-local; a bare ns-load
-;; call raises :rf.error/no-frame-context. This testbed's deck hosts on
-;; :rf/default (see `host-frame` below), so name it explicitly.
-(with-frame :rf/default
-  (rf/reg-app-schema [:auth] {:schema AuthSlice}))
+;; EP-0002: reg-app-schema is context-required frame-local AND requires the
+;; target frame to be LIVE (reg-flow / reg-app-schema reject a non-live
+;; frame). A bare ns-load `(with-frame :rf/default …)` runs at REQUIRE time —
+;; before `run` registers `:rf/default` — so the frame is not yet live and the
+;; registration throws `:rf.error/flow-frame-not-live`. The schema (and the
+;; `:standard-epochs/derived` flow below) are therefore registered from `run`,
+;; AFTER `(rf/reg-frame host-frame {})` makes the frame live. `register-
+;; frame-local-features!` is the single entry point (also reused conceptually
+;; by the two-frame deck, which registers the same features into its own
+;; `:above` / `:below` frames).
 
 ;; ============================================================================
 ;; COEFFECT — :standard-epochs/now  (button #2)
@@ -291,15 +296,28 @@
 ;; changed. Button #5 bumps `:base`; App-db shows `:derived` recompute
 ;; and Trace shows the flow run.
 
-;; EP-0002: reg-flow is context-required frame-local; name the :rf/default
-;; host frame explicitly for this ns-load registration.
-(with-frame :rf/default
-  (rf/reg-flow
-    {:id          :standard-epochs/derived
-     :inputs      [[:base]]
-     :derive      (fn [base] (* 2 (or base 0)))
-     :output-path [:derived]
-     :doc         "Derived = 2 × :base. Recomputes on the post-handler flows pass."}))
+;; The `:standard-epochs/derived` flow is registered from `run` (per the
+;; APP-DB SCHEMA note above) — reg-flow requires a LIVE frame, which only
+;; exists after `(rf/reg-frame host-frame {})`. `register-frame-local-features!`
+;; installs BOTH the flow and the `[:auth]` app-schema into `frame-id`. It is
+;; the single per-frame feature-registration point: the standalone deck calls
+;; it with `:rf/default`; the two-frame deck installs the same features into
+;; its own `:above` / `:below` frames so the flow + schema rungs fire there
+;; too (rf2-4279q4). Run at the TOP LEVEL, AFTER `reg-frame`, never inside a
+;; handler cascade.
+(defn register-frame-local-features!
+  "Register the `:standard-epochs/derived` flow + the `[:auth] :string`
+  app-schema INTO `frame-id` (a live frame). Both are EP-0002 context-required
+  frame-local; the `with-frame` scope names the frame they install into."
+  [frame-id]
+  (rf/with-frame frame-id
+    (rf/reg-flow
+      {:id          :standard-epochs/derived
+       :inputs      [[:base]]
+       :derive      (fn [base] (* 2 (or base 0)))
+       :output-path [:derived]
+       :doc         "Derived = 2 × :base. Recomputes on the post-handler flows pass."})
+    (rf/reg-app-schema [:auth] {:schema AuthSlice})))
 
 ;; ============================================================================
 ;; EVENTS — the button ladder
@@ -835,6 +853,11 @@
   ;; in a `frame-provider-existing` (scope-only — the host frame is
   ;; already `reg-frame`'d; the carried invariant).
   (rf/reg-frame host-frame {})
+  ;; Register the frame-local FLOW + APP-SCHEMA now the host frame is LIVE
+  ;; (reg-flow / reg-app-schema reject a non-live frame, so this cannot run at
+  ;; ns-load). Do it BEFORE the seed dispatch so the `:standard-epochs/derived`
+  ;; flow computes `:derived` on the reset drain's flows pass.
+  (register-frame-local-features! host-frame)
   (rf/with-frame host-frame
     (rf/dispatch-sync [:standard-epochs/reset]))
   (rdc/render react-root [rf/frame-provider-existing {:frame host-frame} [standalone]]))

--- a/tools/xray/testbeds/two_frame_isolation/core.cljs
+++ b/tools/xray/testbeds/two_frame_isolation/core.cljs
@@ -148,42 +148,23 @@
 ;; PER-FRAME FRAME-LOCAL FEATURES — the flow + app-schema rungs
 ;; ============================================================================
 ;;
-;; `standard-epochs.core` registers its `:standard-epochs/derived` reg-flow
-;; and its `[:auth] → [:map [:token :string]]` app-schema under
-;; `(with-frame :rf/default …)` (EP-0002: both are CONTEXT-REQUIRED
-;; FRAME-LOCAL). Those registrations therefore live ONLY in `:rf/default` —
-;; the frame the SINGLE-frame standalone deck mounts on. This two-frame deck
-;; mounts the same ladder in `:above` / `:below` instead, where neither the
-;; flow nor the schema is registered. Without re-registering them per frame
-;; the FLOW rung (step 5) would bump `:base` but NEVER recompute `:derived`
-;; (no flow in this frame), and the APP-SCHEMA rung (step 19) would write
-;; an int into `[:auth :token]` and it would STICK (no schema → no
-;; validation → no rollback) — both rungs INERT in these frames (rf2-4279q4).
+;; `standard-epochs.core`'s `:standard-epochs/derived` reg-flow and its
+;; `[:auth] → [:map [:token :string]]` app-schema are EP-0002 CONTEXT-REQUIRED
+;; FRAME-LOCAL: each lives only in the frame it is registered into. The
+;; standalone deck installs them into `:rf/default` (from its `run`); this
+;; two-frame deck mounts the same ladder in `:above` / `:below` instead, so it
+;; must install the SAME features into BOTH of its frames — otherwise the FLOW
+;; rung (step 5) would bump `:base` but NEVER recompute `:derived` (no flow in
+;; this frame), and the APP-SCHEMA rung (step 19) would write an int into
+;; `[:auth :token]` and it would STICK (no schema → no validation → no
+;; rollback): both rungs INERT in these frames (rf2-4279q4).
 ;;
-;; The cleanest fix is to register the frame-local features in EACH frame the
-;; deck actually mounts on, so the per-frame isolation the deck exists to
-;; prove holds for flows + app-schemas too: a flow recompute / a schema
-;; rollback in one frame is genuinely scoped to that frame's reactive
-;; context. The flow body + schema mirror standard-epochs' (the schema slice
-;; `se/AuthSlice` is reused directly; the flow is the same `:base × 2 →
-;; :derived` declaration).
-
-(defn- register-frame-local-features!
-  "Register the `:standard-epochs/derived` flow + the `[:auth] :string`
-  app-schema INTO `frame-id` so the FLOW (step 5) + APP-SCHEMA (step 19)
-  rungs actually fire when the ladder is driven in that frame. Both are
-  context-required frame-local (EP-0002): the `with-frame` scope names the
-  frame they install into. Run at the TOP LEVEL (from `run`, AFTER the
-  frame is `reg-frame`'d) — never inside a handler cascade."
-  [frame-id]
-  (rf/with-frame frame-id
-    (rf/reg-flow
-      {:id          :standard-epochs/derived
-       :inputs      [[:base]]
-       :derive      (fn [base] (* 2 (or base 0)))
-       :output-path [:derived]
-       :doc         "Derived = 2 × :base (two-frame deck, per-frame). Recomputes on the post-handler flows pass."})
-    (rf/reg-app-schema [:auth] {:schema se/AuthSlice})))
+;; We reuse `standard-epochs.core`'s OWN `register-frame-local-features!`
+;; (same flow body + `se/AuthSlice` schema) so the two frames exercise the
+;; IDENTICAL features the standalone deck does — a drift between the two
+;; surfaces is impossible. The per-frame isolation the deck exists to prove
+;; then holds for flows + app-schemas too: a flow recompute / a schema
+;; rollback in one frame is genuinely scoped to that frame's reactive context.
 
 ;; ============================================================================
 ;; ROOT VIEW — the standard-epochs ladder mounted twice, one per frame-provider
@@ -220,7 +201,17 @@
      ;; isolated.
      [se/root host-frame prefix run-step-event]]))
 
-(reg-view root []
+;; The outer `root` is a PLAIN layout component, NOT a `reg-view`. It owns
+;; no reactive state of its own (no `subscribe` / `dispatch` at this level)
+;; and — by design — belongs to NO single frame: it hosts BOTH the `:above`
+;; and `:below` frame-providers. A `reg-view` stamps the ambient frame onto
+;; its render (calling `current-frame-id`), so mounting one bare at the React
+;; root (`[root]`, outside any frame-provider) raises
+;; `:rf.error/no-frame-context` and the component crashes before the two
+;; frame-cards ever mount. A plain fn carries no such requirement; each
+;; `frame-card` BELOW is a `reg-view` that renders INSIDE its
+;; frame-provider, so it picks up the right frame context there.
+(defn root []
   [:div {:data-testid "two-frame-isolation-root"
          :style {:font-family "system-ui, sans-serif"
                  :padding     "1em"
@@ -274,11 +265,12 @@
   (rf/reg-frame frame-below {:initial-events [[:standard-epochs/reset]]})
   ;; Register the frame-local FLOW + APP-SCHEMA into BOTH frames so the
   ;; step-5 (flow) and step-19 (app-schema) rungs fire here instead of
-  ;; being inert (standard-epochs registers them only in :rf/default —
-  ;; rf2-4279q4). reg-flow / reg-app-schema require a LIVE frame, so this
-  ;; runs AFTER reg-frame. Top-level, never inside a handler cascade.
-  (register-frame-local-features! frame-above)
-  (register-frame-local-features! frame-below)
+  ;; being inert (each is frame-local; the standalone deck installs them in
+  ;; :rf/default — rf2-4279q4). Reuse standard-epochs' OWN registrar so the
+  ;; features match exactly. reg-flow / reg-app-schema require a LIVE frame,
+  ;; so this runs AFTER reg-frame. Top-level, never inside a handler cascade.
+  (se/register-frame-local-features! frame-above)
+  (se/register-frame-local-features! frame-below)
   ;; Re-seed each frame AFTER its flow is registered so the
   ;; `:standard-epochs/derived` flow computes its initial value (:derived =
   ;; 2 × :base) on this drain's flows pass — mirroring the standalone deck,


### PR DESCRIPTION
Fix-forward for **rf2-4279q4**. The earlier merge (`e6c041aa2`) landed the
feature-matrix gate scenario but an **incomplete testbed pair**, leaving the
two-frame Xray surface crashing on load and the new gate scenario red.
This PR completes the two testbed files so the rungs are genuinely
signal-bearing and the gate is green.

## What was broken on `main`

- `standard_epochs/core.cljs` registered its `:standard-epochs/derived`
  flow and `[:auth]` app-schema at **namespace-load** via
  `(with-frame :rf/default ...)`. Both `reg-flow` / `reg-app-schema` reject a
  non-live frame, and ns-load runs *before* `run` registers `:rf/default`, so
  requiring the namespace threw `:rf.error/flow-frame-not-live`.
- `two_frame_isolation/core.cljs`'s outer `root` was a `reg-view` mounted
  bare at the React root (no frame-provider), so its frame stamp raised
  `:rf.error/no-frame-context` and the two frame-cards never mounted.

## The fix

- Move the flow + app-schema registration into a `run`-invoked
  `register-frame-local-features!` (after `reg-frame`, so the frame is live).
  The standalone deck now also computes `:derived` on its seed drain.
- Make the two-frame `root` a plain layout fn (it owns no reactive state and
  belongs to no single frame; each `frame-card` is a `reg-view` inside its own
  provider). Reuse `standard_epochs`' `register-frame-local-features!` to
  install the **same** flow + schema into `:above` / `:below`, so the step-5
  (flow) and step-19 (app-schema) rungs fire + isolate per frame.

The feature-matrix scenario (`scenarios.cjs`) was already complete on `main`
from the prior merge and is unchanged here.

## Signal-bearing assertions (the point of rf2-4279q4)

- **machine_epochs RESTART** (already on `main`): captures the door machine's
  accumulated `:opened-count` (>0) as a baseline, then asserts the restart
  resets it to `0`. `:state` is `:locked` before *and* after, so `:state`
  alone is no-signal; only a real `:initial-events` replay resets
  `:opened-count`, so a no-op restart would leave it >0 and the assertion
  would time out (red) - that is the signal.
- **two_frame_isolation flow (step 5) + app-schema (step 19)**: now exercised
  in **both** `:above` and `:below`. The flow rung asserts `:derived`
  recomputes 2->4 in the driven frame while the other stays put (a flow is
  frame-scoped); the app-schema rung asserts the int write to `[:auth :token]`
  rolls back (token stays "seed-token") in the driven frame only. Both were
  inert before - nothing drove those frames.

## Quality gates

- `npm run test:xray-feature-gate` - green (machine-epochs + two-frame
  scenarios pass with the strengthened assertions).
- `npm run test:cljs` - green.
