### PR TITLE
chore(test): rename stale re-frame.marks -> re-frame.classification in comments (rf2-sewspo)

### DIFF
--- a/implementation/core/test/re_frame/cofx_envelope_test.clj
+++ b/implementation/core/test/re_frame/cofx_envelope_test.clj
@@ -816,7 +816,7 @@
                                ;; :wi/note dispatched event — a deterministic
                                ;; single emit per run. The event vector rides
                                ;; under (:rf.event/v :tags) as [event-id args]
-                               ;; (re-frame.marks §project-event-tags).
+                               ;; (re-frame.classification §project-event-tags).
                                (when (and (nil? @seen)
                                           (= :rf.event (:op-type ev))
                                           (= :rf.event/dispatched (:operation ev))

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -309,7 +309,7 @@
   ;; user render-args reach the production bundle — that absence rides the
   ;; existing `rf.view/rendered` sentinel (same gated body). (The
   ;; `:rf.view/render-args` slot KEYWORD itself legitimately survives via
-  ;; the always-reachable `re-frame.marks/project-trace-event` chokepoint,
+  ;; the always-reachable `re-frame.classification/project-trace-event` chokepoint,
   ;; same as `:rf.event/db` — so no keyword sentinel is added for it.)
   (rf/reg-view* :probe/render-args
     {:ns 're-frame.elision-probe :file "probe.cljs" :line 1 :column 1}
@@ -542,7 +542,7 @@
 ;; NOTE (parallels rf2-rpgq8 `:rf.view/render-args`): NO keyword sentinel for
 ;; `:rf.interceptor/override-summary` is added in check-elision.cjs, because the
 ;; keyword literal LEGITIMATELY survives in production via the always-reachable
-;; marks chokepoint `re-frame.marks/project-trace-event` (the fail-closed
+;; marks chokepoint `re-frame.classification/project-trace-event` (the fail-closed
 ;; `(contains? tags :rf.interceptor/override-summary)` branch). The privacy
 ;; guarantee is that the VALUES (the id/count summary) are constructed only in
 ;; the gated emit path and never reach the production bundle. The distinctive

--- a/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
@@ -23,7 +23,7 @@
   tag — the bulk walk roots that nested db at
   `[<i> :tags :rf.event/db ...]`, so `[:auth :password]` never matches.
 
-  DEFENCE-IN-DEPTH note (verified against `re-frame.marks/project-db-tags`,
+  DEFENCE-IN-DEPTH note (verified against `re-frame.classification/project-db-tags`,
   rf2-6773q): when the frame HAS elision declarations, the t1/t2
   `:rf.event/db` tag is ALSO redacted at EMIT time, so the on-ring trace
   already carries `:rf/redacted` for frame-declared paths. The egress
@@ -117,7 +117,7 @@
   (testing "the live router's t1/t2 :rf.event/db-pending trace carries the
             FULL pending db under :rf.event/db — and for a frame WITH
             elision declarations, that nested tag is redacted at EMIT time
-            (re-frame.marks/project-db-tags, rf2-6773q), so the on-ring
+            (re-frame.classification/project-db-tags, rf2-6773q), so the on-ring
             trace already shows :rf/redacted at [:auth :password]. The
             egress re-root then keeps it redacted (idempotent) and covers
             the not-emit-redacted shapes (pinned by the unit tests)"

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -1583,7 +1583,7 @@
 
 (deftest sub-run-row-threads-large-marker
   (testing "rf2-at60h — the whole-output `:large?` stamp that
-            `re-frame.marks/project-sub-tags` writes onto a `:rf.sub/run`
+            `re-frame.classification/project-sub-tags` writes onto a `:rf.sub/run`
             trace tag (when the sub's output is marked large but its raw
             value is left in place for the on-box ring) is threaded onto
             the structured `:sub-runs` row as `:large?`, so the off-box

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -280,7 +280,7 @@ const DEV_ONLY_SENTINELS = [
   // (`rf.view/render"`) so it matches ONLY the `:rf.view/render` op
   // keyword and NOT the longer `:rf.view/render-args` slot keyword
   // (rf2-rpgq8) that legitimately survives in production via the
-  // always-reachable `re-frame.marks/project-trace-event` chokepoint.
+  // always-reachable `re-frame.classification/project-trace-event` chokepoint.
   // A bare `view/render` substring would superstring-collide with
   // `rf.view/render-args` and fire a false production-leak positive.
   { source: 're-frame.views/reg-view* frame-aware-view (rf.view/render)',
@@ -307,7 +307,7 @@ const DEV_ONLY_SENTINELS = [
   //
   // NOTE — we deliberately do NOT add a `rf.view/render-args` keyword
   // sentinel: the keyword literal LEGITIMATELY survives in production via
-  // `re-frame.marks/project-trace-event` (the always-reachable marks
+  // `re-frame.classification/project-trace-event` (the always-reachable marks
   // chokepoint, gated at the trace/emit! CALL site, not internally), the
   // same way `:rf.event/db` / `:rf.cofx/value` / `:rf.sub/run` keyword
   // literals survive there. The privacy guarantee is that the VALUES never
@@ -322,7 +322,7 @@ const DEV_ONLY_SENTINELS = [
   // SAME precedent as `:rf.view/render-args` above: we deliberately do NOT add
   // a keyword sentinel for it. The `:rf.interceptor/override-summary` keyword
   // literal LEGITIMATELY survives in production via the always-reachable marks
-  // chokepoint `re-frame.marks/project-trace-event` (the fail-closed
+  // chokepoint `re-frame.classification/project-trace-event` (the fail-closed
   // `(contains? tags :rf.interceptor/override-summary)` projection branch),
   // exactly like `:rf.event/db` / `:rf.view/render-args` / `:rf.cofx/value`.
   // A keyword sentinel here would be a false production-leak positive.


### PR DESCRIPTION
Follow-up from the rf2-b1jbvf stale-prose sweep. The umbrella sweep corrected spec/docs prose + named code comments but deliberately left out-of-scope test-file and script comments still naming the removed `re-frame.marks` namespace. The namespace was removed by EP-0025; the fns now live in `re-frame.classification`.

Comment-only rename `re-frame.marks` -> `re-frame.classification` at the 9 sites across 5 files (rf2-sewspo lists each):
- `implementation/core/test/re_frame/cofx_envelope_test.clj:819` (project-event-tags)
- `implementation/core/test/re_frame/elision_probe.cljs:312,545` (project-trace-event)
- `implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj:26,120` (project-db-tags)
- `implementation/epoch/test/re_frame/epoch_test.clj:1586` (project-sub-tags)
- `implementation/scripts/check-elision.cjs:283,310,325` (project-trace-event)

The actual code was already correct; this is comments only, no behavior change.

## Verification of fn homes
All four fns confirmed to live in `implementation/core/src/re_frame/classification.cljc`:
- `project-trace-event` — public (`defn`, line 769)
- `project-event-tags` — private (`defn-`, line 341)
- `project-sub-tags` — private (`defn-`, line 396)
- `project-db-tags` — private (`defn-`, line 447)

## Quality gates
- git-grep-clean: zero remaining `re-frame.marks` references in the 5 touched files (exit 1 / no matches).
- `node --check implementation/scripts/check-elision.cjs` — passed.
- Reader-parse of all 4 edited Clojure files (clojure CLI) — all read clean (28 / 15 / 31 / 165 top-level forms, no exception).
- Diff is purely comment/docstring text (9 lines, 9 insertions / 9 deletions). No code changed.
- CI is the merge gate.