### PR TITLE
feat(image): EP-0026 :select-ns selection + image-order resolution (rf2-6ls85a)

### DIFF
--- a/implementation/core/src/re_frame/image.cljc
+++ b/implementation/core/src/re_frame/image.cljc
@@ -400,7 +400,78 @@
   AGAINST the actual selected collisions (does this key really collide? does the
   coordinate name exactly one selected descriptor?) stays the assembly slice's
   fail-loud job."
-  #{:id :include-ns :exclude-ns :registrations :rf.image/requires :replace :replace-standard})
+  #{:id :select-ns :include-ns :exclude-ns :registrations :rf.image/requires :replace :replace-standard})
+
+;; ---- :select-ns — the EP-0026 single-map selection surface -----------------
+;;
+;; EP-0026 §Namespace Selection replaces the EP-0023 sibling `:include-ns` /
+;; `:exclude-ns` keys with ONE `:select-ns {:include … :exclude …}` map. The two
+;; legs reuse the EXACT EP-0023 glob grammar and lower to the same normalized
+;; internal slots (`:rf.image/include-ns` / `:rf.image/exclude-ns`) the pure
+;; selector already runs — `:select-ns` is the authoring surface; the internal
+;; form is unchanged. The selected set is `union(:include) minus union(:exclude)`
+;; with exclusion GLOBAL to the image selection (a namespace matched by any
+;; `:exclude` is never selected, no re-admission), and STRICT include diagnostics:
+;; `:include` is REQUIRED and a zero-match include pattern fails image assembly
+;; (`select-by-include-ns`). `:select-ns` SELECTS, it does not LOAD — it filters
+;; registrations the runtime already knows about by `:rf.provenance/ns`, so it
+;; never forces a require and never defeats dead-code elimination.
+
+(defn- normalize-select-ns
+  "Validate + lower a `:select-ns` map into the `[include-ns exclude-ns]` vectors
+  the pure selector consumes (EP-0026 §Namespace Selection). FAIL-LOUD STRICT
+  diagnostics at `rf/image`:
+
+    * `:select-ns` MUST be a map;
+    * `:include` is REQUIRED, MUST be a NON-EMPTY vector of glob strings;
+    * `:exclude` is optional, defaults to `[]`, MUST be a vector of glob strings
+      when supplied;
+    * no key other than `:include` / `:exclude` is permitted.
+
+  The glob-string element check is shared with the legacy `:include-ns` path (the
+  caller threads its `check-glob-strings!`). Returns `[include exclude]`. Pure
+  (modulo the throw)."
+  [image-id select-ns check-glob-strings!]
+  (when-not (map? select-ns)
+    (error/throw-error!
+      :rf.error/invalid-image
+      'rf/image
+      (str "rf/image: :select-ns must be a map of {:include [globs] :exclude "
+           "[globs]} — got " (pr-str select-ns) ".")
+      {:recovery :use-a-select-ns-map
+       :extra    {:image image-id :received select-ns}}))
+  (doseq [k (keys select-ns)]
+    (when-not (contains? #{:include :exclude} k)
+      (error/throw-error!
+        :rf.error/invalid-image
+        'rf/image
+        (str "rf/image: :select-ns key " (pr-str k) " is unknown — :select-ns "
+             "carries only :include and :exclude.")
+        {:recovery :remove-or-correct-the-select-ns-key
+         :extra    {:image image-id :unknown-key k}})))
+  (let [include (get select-ns :include)
+        exclude (get select-ns :exclude [])]
+    (when-not (and (vector? include) (seq include))
+      (error/throw-error!
+        :rf.error/invalid-image
+        'rf/image
+        (str "rf/image: :select-ns :include is REQUIRED and must be a NON-EMPTY "
+             "vector of namespace-glob strings — got " (pr-str include)
+             ". An image that selects no namespaces should omit :select-ns "
+             "(and may still define inline :registrations).")
+        {:recovery :supply-a-non-empty-include-vector
+         :extra    {:image image-id :include include}}))
+    (when-not (vector? exclude)
+      (error/throw-error!
+        :rf.error/invalid-image
+        'rf/image
+        (str "rf/image: :select-ns :exclude must be a vector of namespace-glob "
+             "strings — got " (pr-str exclude) ".")
+        {:recovery :use-a-glob-string-vector
+         :extra    {:image image-id :exclude exclude}}))
+    (check-glob-strings! :select-ns/include include)
+    (check-glob-strings! :select-ns/exclude exclude)
+    [include exclude]))
 
 (def ^:private valid-kinds
   "The closed registry-kind set a `:replace` / `:replace-standard` key may name,
@@ -491,25 +562,33 @@
                    `:replace-standard` winner) MUST have an `:id`; anonymous
                    images are valid for local tests/examples. BARE structural
                    input key; normalized to the owner-qualified `:rf.image/id`.
-    :include-ns    a vector of namespace-glob strings (EP-0023 grammar). Each
+    :select-ns     the EP-0026 single-map selection surface —
+                   `{:include [globs] :exclude [globs]}`. `:include` is REQUIRED
+                   (a non-empty vector of namespace-glob strings, EP-0023
+                   grammar) and selects registered descriptors by their
+                   `:rf.provenance/ns`; `:exclude` is optional (defaults to `[]`)
+                   and SUBTRACTS — the selected set is
+                   `union(:include) minus union(:exclude)` with exclusion GLOBAL
+                   to the image (a namespace matched by any `:exclude` is never
+                   selected, no re-admission corner case). STRICT include
+                   diagnostics: a zero-match `:include` pattern FAILS LOUD. An
+                   `:exclude` pattern matching nothing is a no-op (a defensive
+                   guard). Exclusion narrows the glob-selected set ONLY, never
+                   the image's own inline `:registrations`. `:select-ns` SELECTS,
+                   it does not LOAD — it filters registrations the runtime
+                   already knows about by provenance, so it never forces a
+                   require and never defeats dead-code elimination. Cannot be
+                   combined with the retired `:include-ns` / `:exclude-ns`
+                   (rf2-dlvmpc). Normalizes to `:rf.image/include-ns` /
+                   `:rf.image/exclude-ns`.
+    :include-ns    (RETIRED by rf2-dlvmpc; superseded by `:select-ns :include`)
+                   a vector of namespace-glob strings (EP-0023 grammar). Each
                    pattern selects registered descriptors by their
                    `:rf.provenance/ns`. Optional (defaults to `[]`).
-    :exclude-ns    a vector of namespace-glob strings (same EP-0023 grammar)
-                   that SUBTRACT from the `:include-ns` selection — a registered
-                   descriptor selected by `:include-ns` is dropped if its
-                   `:rf.provenance/ns` ALSO matches any `:exclude-ns` pattern.
-                   The narrowing knob for a recursive `**` glob that sweeps in
-                   sibling namespaces a frame must not load (e.g. a tool's own
-                   `*-test` namespaces co-registering its ids in a test build —
-                   the EP-0023 §Xray Beside The Target singleton-seating case).
-                   Optional (defaults to `[]`). Unlike `:include-ns`, an
-                   exclude pattern that matches ZERO loaded descriptors is NOT
-                   fail-loud — exclusion is a defensive guard, so a pattern
-                   guarding against a namespace that simply is not loaded in
-                   this build is a no-op, not an error. Applies ONLY to
-                   glob-selected registered descriptors, never to the image's
-                   own inline `:registrations` (those are selected because the
-                   image value was supplied, not by provenance namespace).
+    :exclude-ns    (RETIRED by rf2-dlvmpc; superseded by `:select-ns :exclude`)
+                   a vector of namespace-glob strings (same EP-0023 grammar)
+                   that SUBTRACT from the `:include-ns` selection. Optional
+                   (defaults to `[]`).
     :registrations inline registrar-keyed sections (`{:reg-event [[id meta
                    body] …] :reg-sub [[id meta body] …] …}`). Lowered to inline
                    descriptors. Optional.
@@ -554,13 +633,11 @@
         :rf.error/invalid-image
         'rf/image
         (str "rf/image: unknown image key " k
-             " — use :id, :include-ns, :exclude-ns, :registrations, "
-             ":rf.image/requires, :replace, or :replace-standard.")
+             " — use :id, :select-ns, :registrations, :rf.image/requires, "
+             ":replace, or :replace-standard.")
         {:recovery :remove-or-correct-the-key
          :extra    {:image (:id spec) :unknown-key k}})))
   (let [id         (:id spec)
-        include-ns (vec (get spec :include-ns []))
-        exclude-ns (vec (get spec :exclude-ns []))
         check-glob-strings!
         (fn [slot patterns]
           (doseq [p patterns]
@@ -572,9 +649,31 @@
                      (pr-str p) ". Use \"docs.counter.v2\", \"docs.shared.widgets.*\", "
                      "or \"docs.shared.**\".")
                 {:recovery :use-namespace-glob-strings
-                 :extra    {:image id :bad-pattern p}}))))]
-    (check-glob-strings! :include-ns include-ns)
-    (check-glob-strings! :exclude-ns exclude-ns)
+                 :extra    {:image id :bad-pattern p}}))))
+        ;; EP-0026: `:select-ns {:include … :exclude …}` is the single-map
+        ;; selection surface. When present it is authoritative — and it must
+        ;; NOT be mixed with the legacy sibling `:include-ns` / `:exclude-ns`
+        ;; (an ambiguous double-spelling fails loud; the legacy keys are retired
+        ;; by rf2-dlvmpc). Both lower to the same normalized internal slots.
+        select-ns  (:select-ns spec)
+        [include-ns exclude-ns]
+        (if (contains? spec :select-ns)
+          (do
+            (when (or (contains? spec :include-ns) (contains? spec :exclude-ns))
+              (error/throw-error!
+                :rf.error/invalid-image
+                'rf/image
+                (str "rf/image: :select-ns cannot be combined with :include-ns / "
+                     ":exclude-ns — :select-ns {:include … :exclude …} is the "
+                     "single selection surface. Use :select-ns alone.")
+                {:recovery :use-select-ns-alone
+                 :extra    {:image id}}))
+            (normalize-select-ns id select-ns check-glob-strings!))
+          (let [include-ns (vec (get spec :include-ns []))
+                exclude-ns (vec (get spec :exclude-ns []))]
+            (check-glob-strings! :include-ns include-ns)
+            (check-glob-strings! :exclude-ns exclude-ns)
+            [include-ns exclude-ns]))]
     (doseq [k [:replace :replace-standard]]
       (when-let [m (get spec k)]
         (when-not (map? m)

--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -59,33 +59,35 @@
   source-store generation (+ standard generation), so it invalidates the instant
   any `reg-*` / `forget-*` / `clear-*` bumps the store.
 
+  ## Resolution is IMAGE-ORDER (EP-0026 §Layered Resolution)
+
+  EP-0026 simplifies the EP-0023 surface: composition resolves by explicit IMAGE
+  ORDER — **the later image in `:images` wins** — and an image must resolve
+  cleanly to ONE descriptor per `[kind id]`. So every override is BETWEEN images
+  (a later image SHADOWS an earlier one; the cross-image shadow is reported, not
+  failed — the shadow report is rf2-ke7w5j), and a WITHIN-image `[kind id]`
+  collision is an ERROR. The declared-`:replace`/`:replace-standard` winner model
+  is retired (its key rejection is rf2-dlvmpc).
+
   ## Validation is FAIL-LOUD (the central guarantee)
 
   Every validation failure throws via the central `re-frame.error/throw-error!`
-  with a DISTINCT `:rf.error/id`. The load-bearing rule (EP-0023 §Image
-  Composition): **order must NEVER silently decide which descriptor wins.** A
-  real `(kind, id)` collision among selected descriptors with no declared
-  replacement winner is an ERROR (`:rf.error/image-duplicate-id`), not a
-  last-write. The conditions detected here (the EP §Image Validation list):
+  with a DISTINCT `:rf.error/id`. The conditions detected here:
 
-      duplicate id (same [kind id], differing impl, no declared winner)
+      two images sharing an :id within one :images composition
+        -> :rf.error/image-duplicate-image-id
+      within one image, two SELECTED descriptors for one [kind id] (ambiguous)
         -> :rf.error/image-duplicate-id
+      within one image, an inline entry colliding with a selected one, or two
+        inline entries for one [kind id] (an override must be a LATER image)
+        -> :rf.error/image-within-image-collision
       unsupported registration kind in the image path
         -> :rf.error/image-unsupported-kind
       event references a missing interceptor / resource references a missing
         scope resolver ({:from-db <id>} naming an unselected :resource-scope)
         -> :rf.error/image-missing-reference
-      a :replace / :replace-standard declared for a key with no actual
-        collision (zero or exactly one selected descriptor — stale / typo /
-        an order override, NOT a collision resolution)
-        -> :rf.error/image-replacement-no-collision
-      a :replace / :replace-standard winner that resolves to zero or many
-        selected descriptors (a stale winner source, a typo, an ambiguous coord)
-        -> :rf.error/image-replacement-winner-unresolved
-      composed images declaring DIFFERENT winners for the same [kind id]
-        (a cross-image replacement conflict — order must not decide)
-        -> :rf.error/image-replacement-conflict
-      replacing a non-replaceable framework standard registration
+      a public app descriptor colliding with a framework STANDARD (a standard is
+        protected — not part of app layer order, no public opt-in)
         -> :rf.error/image-standard-replacement-forbidden
       an image-required capability the frame does not supply
         -> :rf.error/image-missing-capability
@@ -339,28 +341,13 @@
   [image]
   (boolean (:rf.image/default? image)))
 
-(defn select-for-images
-  "Run slice-.3's `image/select-descriptors` for EACH image value in `images`
-  against `descriptors` (the source-store pool), returning the concatenated
-  selected descriptors (registered glob-matches + each image's inline
-  descriptors). Order is image order then selector order; collision validation
-  (which makes order irrelevant to the WINNER) runs downstream. Any zero-match
-  `:include-ns` pattern fails loud inside `select-descriptors` (slice .3).
-
-  The DEFAULT image (`default-image?`) is the implicit whole-store selector
-  (EP-0023 §Default Image Semantics): it selects EVERY descriptor in
-  `descriptors` rather than running a glob, with no zero-match fail-loud (an
-  empty store is a valid empty default projection). Every other case routes
-  through the pure `:include-ns`/inline selector unchanged.
-
-  Pure — a function of the image values and the candidate pool."
-  [images descriptors]
-  (into []
-        (mapcat (fn [image]
-                  (if (default-image? image)
-                    descriptors
-                    (image/select-descriptors image descriptors))))
-        images))
+;; EP-0026 §Layered Resolution selects + resolves PER IMAGE (keeping the image
+;; association so a within-image collision is distinguished from a cross-image
+;; shadow), so there is no whole-composition flattening selector — see
+;; `select-and-lower-image` + `assemble*`. The default image (`default-image?`)
+;; selects EVERY descriptor in the pool (no glob, no zero-match fail-loud — an
+;; empty store is a valid empty default projection); every explicit image runs
+;; the pure `:select-ns` selector unchanged.
 
 ;; ---- inline-registration lowering (EP-0023 §Image Fragments) ---------------
 ;;
@@ -458,68 +445,16 @@
                       :coordinate (descriptor-coordinate d)}}))))
   descriptors)
 
-;; ---- replacement winner resolution (EP-0023 §Image Patching And Overrides —
-;;      the .5 seam; the detection + the simple winner rule live here) ---------
-
-(defn matches-coordinate?
-  "True when a selected `descriptor`'s source coordinate matches a declared
-  winner-source coordinate `winner` from a `:replace` / `:replace-standard`
-  map. The winner spelling (EP-0023):
-
-    {:ns \"checkout.story.http\"}                  a registered descriptor
-    {:image :checkout/story :inline [:reg-fx id]}  an inline descriptor
-    {:standard true}                               the framework standard
-
-  Matching is by the descriptor's `descriptor-coordinate`. SLICE .5 SEAM: this
-  is the single point richer winner-source matching plugs into; the first
-  version is exact coordinate equality. Pure."
-  [winner descriptor]
-  (= winner (descriptor-coordinate descriptor)))
-
-(defn resolve-replacement-winner
-  "Given the `colliding` descriptors for one `[kind id]` and a declared `winner`
-  source coordinate, return the single winning descriptor. FAIL-LOUD:
-
-    * a winner that matches ZERO selected descriptors, or MORE THAN ONE, throws
-      `:rf.error/image-replacement-winner-unresolved` (a stale winner source, a
-      typo, or an ambiguous coordinate — EP-0023 §Image Patching: \"the winner
-      source coordinate must identify exactly one selected descriptor\").
-
-  SLICE .5 SEAM: the deep replacement policy (conformance-profile proofs, etc.)
-  extends this; the structural guarantee — exactly one winner or an error — is
-  fixed here. Pure (modulo the throw)."
-  [image-id kind id colliding winner]
-  (let [winners (filterv #(matches-coordinate? winner %) colliding)]
-    (case (count winners)
-      1 (first winners)
-      0 (error/throw-error!
-          :rf.error/image-replacement-winner-unresolved
-          'rf/make-frame
-          (str "rf/image assembly: the replacement winner " (pr-str winner)
-               " declared for " (pr-str [kind id]) " identifies NO selected "
-               "descriptor — a stale winner source, a typo, or a namespace "
-               "that is no longer selected. Selected descriptor coordinates "
-               "for this id: " (pr-str (mapv descriptor-coordinate colliding)) ".")
-          {:recovery :fix-the-replacement-winner-source
-           :extra    {:image image-id
-                      :kind  kind :id id
-                      :winner winner
-                      :selected-coordinates (mapv descriptor-coordinate colliding)}})
-      (error/throw-error!
-        :rf.error/image-replacement-winner-unresolved
-        'rf/make-frame
-        (str "rf/image assembly: the replacement winner " (pr-str winner)
-             " declared for " (pr-str [kind id]) " is AMBIGUOUS — it matches "
-             (count winners) " selected descriptors, so it does not name one "
-             "exact survivor. Make the winner coordinate identify exactly one.")
-        {:recovery :make-the-winner-coordinate-unambiguous
-         :extra    {:image image-id
-                    :kind  kind :id id
-                    :winner winner
-                    :match-count (count winners)}}))))
-
 ;; ---- standard-replacement policy (EP-0023 §Image Patching: \":replace-standard\"
 ;;      — the .5 seam for invariant-coupled conformance) ------------------------
+;;
+;; EP-0026 §Framework Standard Registrations: a PUBLIC app image MUST NOT shadow
+;; a framework standard (the no-shadowing rule is enforced by
+;; `check-standard-collision!`). `standard-replaceable?` remains the predicate the
+;; framework standard OWNER's internal path reads (a public app-facing
+;; standard-replacement hook, if ever wanted, is a separate standards-track
+;; decision — EP-0026 does not add one). It is retained for the standard owner's
+;; internal define/revise path and conformance coverage.
 
 (defn standard-replaceable?
   "True when a framework `standard` descriptor MAY be replaced by an image.
@@ -544,105 +479,84 @@
 (defn- standard-descriptor?
   [d] (boolean (:standard d)))
 
-(defn resolve-collision
-  "Resolve the `colliding` descriptors for one `[kind id]` into the single
-  winning descriptor, honouring the image's declared `:replace` /
-  `:replace-standard` maps. This is the heart of the \"order never silently
-  decides a winner\" guarantee.
+(defn- inline-descriptor?
+  "True when a descriptor is an IMAGE-INLINE descriptor (carries
+  `:rf.provenance/inline`), as opposed to a namespace-selected (registered) or a
+  framework-standard one. Pure."
+  [d] (boolean (:rf.provenance/inline d)))
 
-  Cases (EP-0023 §Image Composition / §Image Patching And Overrides):
+(defn resolve-within-image
+  "Resolve the `colliding` descriptors for one `[kind id]` WITHIN A SINGLE IMAGE
+  into its single descriptor (EP-0026 §Layered Resolution). `colliding` is the
+  post-dedupe distinct set for the `[kind id]` in ONE image's selected + inline
+  descriptors. An image must resolve cleanly to ONE descriptor per `[kind id]`:
+  there is NO within-image winner rule, so any `[kind id]` that resolves two ways
+  is an ERROR. Image order is the only precedence — to override, put the winning
+  registration in a LATER image and compose.
 
-    * After dedupe, exactly ONE descriptor — no collision, it wins.
-    * A genuine collision (≥2 distinct registrations for the same `(kind, id)`)
-      with NO declared winner -> `:rf.error/image-duplicate-id` (NOT a
-      last-write; load order does not decide).
-    * A collision involving a framework STANDARD descriptor with no
-      `:replace-standard` winner -> `:rf.error/image-standard-replacement-forbidden`
-      (a standard must not be shadowed accidentally).
-    * A declared `:replace-standard` winner where the standard is NOT
-      replaceable per policy -> `:rf.error/image-standard-replacement-forbidden`.
-    * A declared `:replace` / `:replace-standard` winner that does not resolve
-      to exactly one selected descriptor -> `:rf.error/image-replacement-winner-unresolved`
-      (via `resolve-replacement-winner`).
+  Cases (EP-0026 §Layered Resolution):
 
-  `replace` / `replace-standard` are `{[kind id] winner-coordinate}` maps from
-  the image spec. Returns the winning descriptor. SLICE .5 deepens the winner
-  policy; the detection + the fail-loud structure are fixed here."
-  [image-id kind id colliding replace replace-standard]
-  (let [k+id            [kind id]
-        has-standard?   (some standard-descriptor? colliding)
-        std-winner      (get replace-standard k+id)
-        app-winner      (get replace k+id)]
-    (cond
-      ;; No real collision: one descriptor (post-dedupe) wins outright.
-      (= 1 (count colliding))
+    * exactly ONE descriptor — it wins outright (the ordinary case).
+    * two **selected** (registered) descriptors for the same `[kind id]`
+      (different source namespaces) — AMBIGUOUS; `:rf.error/image-duplicate-id`.
+      (The same registration selected twice — same source + impl — already
+      deduped, so this is two DISTINCT registrations; the ordinary same-source
+      hot-reload replacement of one namespace's own descriptor is not a
+      collision.)
+    * an **inline** entry colliding with a **selected** one, or two **inline**
+      entries — `:rf.error/image-within-image-collision`. To override a selected
+      registration, define the override in a LATER image; two inline definitions
+      of one `[kind id]` are malformed.
+
+  Returns the single winning descriptor. Pure (modulo the throw)."
+  [image-id kind id colliding]
+  (let [k+id [kind id]]
+    (if (= 1 (count colliding))
       (first colliding)
-
-      ;; A standard is in the collision. It can ONLY be replaced via
-      ;; :replace-standard, and only when policy allows.
-      has-standard?
-      (let [standard (first (filter standard-descriptor? colliding))]
-        (cond
-          (nil? std-winner)
+      (let [any-inline? (some inline-descriptor? colliding)]
+        (if any-inline?
+          ;; An inline entry resolving two ways: either inline-vs-selected (an
+          ;; override must be a LATER image) or two inline entries (malformed).
+          (let [all-inline? (every? inline-descriptor? colliding)]
+            (error/throw-error!
+              :rf.error/image-within-image-collision
+              'rf/make-frame
+              (str "rf/image assembly: id " (pr-str k+id) " resolves "
+                   (count colliding) " ways within image " (pr-str image-id)
+                   " — "
+                   (if all-inline?
+                     (str "TWO inline :registrations entries define it (malformed: "
+                          "an image must define each [kind id] at most once inline)")
+                     (str "an inline :registrations entry collides with a "
+                          ":select-ns-selected registration (an image may carry both "
+                          ":select-ns and :registrations, but they MUST be disjoint)"))
+                   ". An image must resolve cleanly to ONE descriptor per [kind id]; "
+                   "there is no within-image winner rule. To OVERRIDE a selected "
+                   "registration, define the winner in a LATER image and compose — "
+                   "the later image wins and the shadow is reported. "
+                   "Colliding source coordinates: "
+                   (pr-str (mapv descriptor-coordinate colliding)) ".")
+              {:recovery :move-the-override-to-a-later-image-or-deduplicate
+               :extra    {:image image-id :kind kind :id id
+                          :colliding-coordinates (mapv descriptor-coordinate colliding)}}))
+          ;; Two (or more) DISTINCT selected registrations for one [kind id]:
+          ;; ambiguous within this image — narrow :select-ns so only one is
+          ;; selected, or rename the duplicate id.
           (error/throw-error!
-            :rf.error/image-standard-replacement-forbidden
+            :rf.error/image-duplicate-id
             'rf/make-frame
-            (str "rf/image assembly: id " (pr-str k+id) " collides with a "
-                 "FRAMEWORK STANDARD registration. A standard registration must "
-                 "not be shadowed accidentally — declare an explicit "
-                 ":replace-standard winner for it, and the standard must be "
-                 "marked :rf.standard/replaceable?. Standard registrations are "
-                 "non-replaceable by default.")
-            {:recovery :declare-replace-standard-or-rename
+            (str "rf/image assembly: id " (pr-str k+id) " is selected from "
+                 (count colliding) " distinct source namespaces with different "
+                 "implementations within image " (pr-str image-id)
+                 " — image assembly will NOT let selection order decide which one a "
+                 "frame runs. Narrow the :select-ns selection so only one is "
+                 "selected, or rename the duplicate id. (To OVERRIDE one with the "
+                 "other deliberately, put the winner in a LATER image and compose.) "
+                 "Colliding source coordinates: "
+                 (pr-str (mapv descriptor-coordinate colliding)) ".")
+            {:recovery :narrow-the-selection-or-rename-the-id
              :extra    {:image image-id :kind kind :id id
-                        :standard-coordinate (descriptor-coordinate standard)
-                        :colliding-coordinates (mapv descriptor-coordinate colliding)}})
-
-          (not (standard-replaceable? standard))
-          (error/throw-error!
-            :rf.error/image-standard-replacement-forbidden
-            'rf/make-frame
-            (str "rf/image assembly: id " (pr-str k+id) " declares a "
-                 ":replace-standard winner, but the framework standard "
-                 "registration is NOT replaceable"
-                 (if (seq (:rf.standard/requires-conformance standard #{}))
-                   (str " — it is invariant-coupled (:rf.standard/requires-conformance "
-                        (pr-str (:rf.standard/requires-conformance standard))
-                        "), so it is not image-replaceable until a conformance "
-                        "profile proves the invariant is preserved")
-                   " (:rf.standard/replaceable? is false, the default)")
-                 ". Remove the :replace-standard declaration or rename the id.")
-            {:recovery :remove-replace-standard-or-rename
-             :extra    {:image image-id :kind kind :id id
-                        :standard-coordinate (descriptor-coordinate standard)
-                        :colliding-coordinates (mapv descriptor-coordinate colliding)
-                        :requires-conformance
-                        (:rf.standard/requires-conformance standard #{})}})
-
-          :else
-          (resolve-replacement-winner image-id kind id colliding std-winner)))
-
-      ;; Application-owned collision with a declared :replace winner.
-      (some? app-winner)
-      (resolve-replacement-winner image-id kind id colliding app-winner)
-
-      ;; A genuine application-owned collision with NO declared winner —
-      ;; the central fail-loud rule: order must NOT decide the survivor.
-      :else
-      (error/throw-error!
-        :rf.error/image-duplicate-id
-        'rf/make-frame
-        (str "rf/image assembly: id " (pr-str k+id) " is registered by "
-             (count colliding) " distinct sources with different implementations "
-             "and no declared replacement winner — image assembly will NOT let "
-             "load order decide which one a frame runs. Declare a :replace "
-             "winner naming the exact survivor, narrow the :include-ns "
-             "selector so only one is selected, or rename the duplicate id. "
-             "Colliding source coordinates: "
-             (pr-str (mapv descriptor-coordinate colliding)) ".")
-        {:recovery :declare-replace-winner-or-disambiguate
-         :extra    {:image image-id :kind kind :id id
-                    :colliding-coordinates (mapv descriptor-coordinate colliding)}}))))
+                        :colliding-coordinates (mapv descriptor-coordinate colliding)}}))))))
 
 (defn distinct-by-id
   "Group `descriptors` by `[kind id]` and dedupe same-registration descriptors
@@ -668,87 +582,74 @@
       {}
       by-id)))
 
-;; ---- replacement declares a REAL collision only (EP-0023 §Image Validation:
-;;      \"replace names a key with no actual collision -> image assembly error\";
-;;      §Image Patching: \"a replacement declaration for a non-colliding key is an
-;;      image assembly error\") — the .5 winner-policy: a declared winner is for a
-;;      REAL collision, NOT a silent order override ---------------------------
+;; ---- per-image resolution + image-order layering (EP-0026 §Layered
+;;      Resolution) — \"the later image in :images wins\" -----------------------
+;;
+;; EP-0026 replaces the EP-0023 declared-`:replace`/`:replace-standard` winner
+;; model with deterministic IMAGE-ORDER layering. Composition is ordered data:
+;; the later image in `:images` wins. Image order is the ONLY precedence, because
+;; an image must resolve cleanly to ONE descriptor per `[kind id]` (a within-image
+;; collision is an error — `resolve-within-image`). So every override is between
+;; images: a later image SHADOWS an earlier one (the cross-image shadow is
+;; reported, not failed — the shadow report is rf2-ke7w5j). The one cross-image
+;; collision that still fails is an app descriptor colliding with a framework
+;; STANDARD: standards are protected, not part of app layer order.
 
-(defn check-replacement-keys-collide!
-  "Throw `:rf.error/image-replacement-no-collision` for any `:replace` /
-  `:replace-standard` key `[kind id]` that does NOT name a GENUINE selected
-  collision in `distinct-by-id` (the post-dedupe `{[kind id] [descriptor …]}`
-  view). A replacement declaration asserts that a `(kind, id)` collision is
-  INTENTIONAL and names the survivor — so it is only legal where a real
-  collision exists (≥2 distinct registrations for that `(kind, id)`). Two
-  non-collision shapes fail loud here (EP-0023 §Image Patching And Overrides —
-  replacement is fail-loud, NOT a silent order override):
-
-    * the key names a `(kind, id)` with EXACTLY ONE selected descriptor — there
-      is nothing to replace; the declaration is stale or the winner is being
-      used to override selection, not resolve a collision;
-    * the key names a `(kind, id)` with ZERO selected descriptors — a typo or a
-      no-longer-selected id; there is no collision to resolve at all.
-
-  This is the `.5` winner-policy guarantee paired with
-  [[resolve-replacement-winner]]: that fn proves a DECLARED winner names exactly
-  one selected descriptor; THIS fn proves the KEY it is declared for is a real
-  collision. Together they make `:replace` / `:replace-standard` an exact
-  resolution of an intentional collision and never a back-door order override.
-  Runs BEFORE `build-resolver` so a bad declaration fails before any winner is
-  resolved. `replace` / `replace-standard` are `{[kind id] winner}` maps.
-  Returns nil."
-  [image-id distinct-by-id replace replace-standard]
-  (doseq [[which m] [[:replace replace] [:replace-standard replace-standard]]
-          [[kind id] winner] m
-          :let [colliding (get distinct-by-id [kind id] [])
-                n         (count colliding)]
-          :when (< n 2)]
-    (error/throw-error!
-      :rf.error/image-replacement-no-collision
-      'rf/make-frame
-      (str "rf/image assembly: the " which " declaration for " (pr-str [kind id])
-           " names a key with NO actual collision — it selects "
-           (case n 0 "ZERO" "exactly ONE")
-           " descriptor, so there is nothing to replace. A replacement winner "
-           "resolves a REAL `(kind, id)` collision (two or more distinct "
-           "registrations); it is NOT a silent order override. "
-           (case n
-             0 (str "No selected descriptor has id " (pr-str [kind id])
-                    " — fix the typo, select the namespace that registers it, "
-                    "or remove the stale declaration.")
-             (str "Only one descriptor (" (pr-str (descriptor-coordinate (first colliding)))
-                  ") is selected for " (pr-str [kind id])
-                  " — remove the replacement declaration (it overrides nothing) "
-                  "or select the colliding source you meant to replace.")))
-      {:recovery :remove-the-replacement-or-introduce-the-collision
-       :extra    {:image image-id
-                  :which which
-                  :kind  kind :id id
-                  :winner winner
-                  :selected-count n
-                  :selected-coordinates (mapv descriptor-coordinate colliding)}}))
-  nil)
-
-(defn build-resolver
-  "Project the selected `descriptors` (selected + standard) into the sealed
-  `{[kind id] descriptor}` resolver map. Groups by `[kind id]`, dedupes
-  same-registration descriptors, then resolves any genuine collision via
-  `resolve-collision` (honouring `replace` / `replace-standard`). The result is
-  id-disjoint by `(kind, id)` — EVERY collision either deduped, resolved by a
-  declared winner, or threw. FAIL-LOUD: no `[kind id]` resolves ambiguously.
-
-  Returns the resolver map. Order of `descriptors` does NOT affect the winner
-  (it only affects iteration); the winner is decided by dedupe + declared
-  replacement, never by position."
-  [image-id descriptors replace replace-standard]
+(defn resolve-image
+  "Resolve ONE image's selected + inline descriptors into its
+  `{[kind id] descriptor}` map (EP-0026 §Layered Resolution). Groups by
+  `[kind id]`, dedupes same-registration descriptors (the ordinary same-source
+  selection-overlap / hot-reload case), then FAILS LOUD via `resolve-within-image`
+  on any `[kind id]` that still resolves two ways within the image (two selected
+  → ambiguous; inline-vs-selected or two inline → within-image collision). The
+  result is id-disjoint by `[kind id]`. `image-id` names the image in diagnostics.
+  Pure (modulo the throw)."
+  [image-id descriptors]
   (reduce-kv
     (fn [resolver [kind id] distinct-ds]
       (assoc resolver [kind id]
-             (resolve-collision image-id kind id distinct-ds
-                                replace replace-standard)))
+             (resolve-within-image image-id kind id distinct-ds)))
     {}
     (distinct-by-id descriptors)))
+
+(defn check-standard-collision!
+  "FAIL LOUD when an APP descriptor (`app-resolver`'s `[kind id]`) collides with a
+  framework STANDARD's `[kind id]` (EP-0026 §Framework Standard Registrations).
+  Standards are protected: they are not part of ordinary app image layer order,
+  and a public app image MUST NOT shadow one — a standard encodes an execution
+  invariant, so shadowing it is a correctness violation, not an app policy
+  choice. `standard-resolver` is the `{[kind id] standard-descriptor}` base.
+  Returns `app-resolver`. Throws `:rf.error/image-standard-replacement-forbidden`."
+  [app-resolver standard-resolver]
+  (doseq [[k+id app-d] app-resolver
+          :when (contains? standard-resolver k+id)]
+    (let [[kind id] k+id]
+      (error/throw-error!
+        :rf.error/image-standard-replacement-forbidden
+        'rf/make-frame
+        (str "rf/image assembly: id " (pr-str k+id) " collides with a FRAMEWORK "
+             "STANDARD registration. A standard encodes an execution invariant and "
+             "is not an ordinary app extension point — a public app image must not "
+             "shadow it. Rename the app registration's id, or do not select the "
+             "namespace that defines it. App source coordinate: "
+             (pr-str (descriptor-coordinate app-d)) ".")
+        {:recovery :rename-the-app-id-or-deselect-it
+         :extra    {:kind kind :id id
+                    :standard-coordinate {:standard true}
+                    :app-coordinate (descriptor-coordinate app-d)}})))
+  app-resolver)
+
+(defn layer-image-resolvers
+  "Layer per-image `{[kind id] descriptor}` resolvers in IMAGE ORDER — the later
+  image WINS (EP-0026 §Layered Resolution). `image-resolvers` is a seq of the
+  per-image resolvers in `:images` order. A `[kind id]` present in more than one
+  image resolves to the LAST image's descriptor; every earlier definition is
+  shadowed (the cross-image shadow is reported by rf2-ke7w5j, never failed here).
+  Returns the layered `{[kind id] descriptor}` app resolver. Pure — `merge` is
+  left-to-right, so a later resolver's entry overwrites an earlier one, which is
+  exactly the later-image-wins rule."
+  [image-resolvers]
+  (reduce merge {} image-resolvers))
 
 ;; ---- reference validation (EP-0023 §Image Validation: \"event references
 ;;      missing interceptor / resource references missing scope resolver\") ----
@@ -918,106 +819,94 @@
   [images]
   (into #{} (mapcat #(:rf.image/requires % #{})) images))
 
-(defn- merge-replace-maps
-  "Merge the `which` (`:replace` / `:replace-standard`) maps across `images`
-  into one combined `{[kind id] winner}` map, FAILING LOUD on a cross-image
-  CONFLICT: two composed images declaring the SAME `[kind id]` with DIFFERENT
-  winner coordinates (EP-0023 §Image Composition — \"Order must not silently
-  decide which registration wins\"). A bare `(into {} (mapcat …))` would let the
-  later image's winner silently last-merge-win — exactly the order-decides-the-
-  survivor footgun the EP forbids at composition. Identical declarations across
-  images are IDEMPOTENT (no conflict): two images that name the same survivor for
-  the same key agree, so the merge keeps the one shared winner.
+(defn check-unique-image-ids!
+  "FAIL LOUD when two images share an `:id` within one `:images` composition
+  (EP-0026 §Image Keys). The shadow report (rf2-ke7w5j) identifies images by id,
+  so two images sharing an id in one composition is an error — the two ids could
+  not name exactly one image each. Anonymous images (no `:rf.image/id`) are
+  exempt: an absent id is not a shared id. Returns `images`. Throws
+  `:rf.error/image-duplicate-image-id`."
+  [images]
+  (let [ids  (keep :rf.image/id images)
+        dups (->> ids
+                  (frequencies)
+                  (keep (fn [[id n]] (when (> n 1) id)))
+                  (sort))]
+    (when (seq dups)
+      (error/throw-error!
+        :rf.error/image-duplicate-image-id
+        'rf/make-frame
+        (str "rf/image assembly: image id(s) " (pr-str (vec dups))
+             " appear more than once in one :images composition — image ids MUST "
+             "be unique per composition. The shadow report identifies images by "
+             "id, so two images sharing an id could not be told apart. Give each "
+             "image a distinct :id.")
+        {:recovery :give-each-image-a-distinct-id
+         :extra    {:duplicate-image-ids (vec dups)
+                    :image-ids           (vec ids)}})))
+  images)
 
-  `:rf.error/image-replacement-conflict` is the cross-IMAGE counterpart of
-  `:rf.error/image-replacement-winner-unresolved` (which polices a single
-  declaration against the selected descriptors): this polices two images
-  DISAGREEING about the survivor before resolution even begins. `image-id` is the
-  representative image id for diagnostics; the conflict ex-data enumerates the
-  exact disagreeing winners. Returns the merged `{[kind id] winner}` map. Pure
-  (modulo the throw)."
-  [image-id which images]
-  (reduce
-    (fn [merged image]
-      (reduce-kv
-        (fn [acc [kind id :as k+id] winner]
-          (if-let [existing (find acc k+id)]
-            (if (= (val existing) winner)
-              acc                                   ;; idempotent: same winner, no conflict
-              (error/throw-error!
-                :rf.error/image-replacement-conflict
-                'rf/make-frame
-                (str "rf/image assembly: composed images declare CONFLICTING "
-                     (pr-str which) " winners for " (pr-str k+id) " — "
-                     (pr-str (val existing)) " and " (pr-str winner)
-                     ". Image composition must NOT let order silently decide "
-                     "which replacement survives. Two composed images naming "
-                     "DIFFERENT winners for the same (kind, id) is a real "
-                     "conflict: reconcile them to one agreed winner coordinate, "
-                     "or drop the duplicate declaration. (Identical declarations "
-                     "across images are fine — they agree.)")
-                {:recovery :reconcile-the-conflicting-replacement-winners
-                 :extra    {:image  image-id
-                            :which  which
-                            :kind   kind :id id
-                            :winners [(val existing) winner]}}))
-            (assoc acc k+id winner)))
-        merged
-        (get image which {})))
-    {}
-    images))
-
-(defn- replace-maps
-  "Build the two combined `{[kind id] winner}` replacement maps across `images`
-  via `merge-replace-maps`, which FAILS LOUD on a cross-image conflict (two
-  composed images naming DIFFERENT winners for the same key) rather than
-  last-merge-winning — EP-0023 §Image Composition's \"order must not silently
-  decide\" applied to the composition's replacement maps. Identical declarations
-  across images are idempotent. Returns `[replace replace-standard]`."
-  [image-id images]
-  [(merge-replace-maps image-id :replace images)
-   (merge-replace-maps image-id :replace-standard images)])
+(defn- select-and-lower-image
+  "Select ONE image's descriptors from the candidate `descriptors` pool (via the
+  slice-.3 selector / the default-image whole-store selection) and lower its
+  inline `:impl` bodies into the runnable shape (EP-0023 §Image Fragments).
+  Returns the image's selected + inline descriptors. Pure."
+  [image descriptors]
+  (lower-inline-descriptors
+    (if (default-image? image)
+      descriptors
+      (image/select-descriptors image descriptors))))
 
 (defn- assemble*
-  "The PURE assembly pipeline: select → union standards → validate → seal.
-  Returns the sealed generation. `images` is already a normalized vector;
-  `descriptors` is the candidate pool. This is the function the cache wraps —
-  it has no cache awareness, so every cache MISS computes one full generation
-  here (the SSR re-seal the cache exists to avoid). Throws on every fail-loud
-  condition (a throwing input is NOT cached)."
+  "The PURE assembly pipeline (EP-0026 §Layered Resolution): unique-id check →
+  select + resolve PER IMAGE → layer in image order (later wins) over the
+  protected framework-standard base → validate → seal. Returns the sealed
+  generation. `images` is already a normalized vector; `descriptors` is the
+  candidate pool. This is the function the cache wraps — it has no cache
+  awareness, so every cache MISS computes one full generation here (the SSR
+  re-seal the cache exists to avoid). Throws on every fail-loud condition (a
+  throwing input is NOT cached)."
   [images descriptors]
-  (let [;; A representative image id for diagnostics (the first that carries
-        ;; one); collision/winner errors also name exact coordinates.
-        image-id (some :rf.image/id images)
-        ;; Lower every selected INLINE descriptor's `:impl` fn body into its
-        ;; runnable shape (`:handler-fn` + per-kind runtime slots) so the
-        ;; sealed resolver's inline entries route through dispatch / subscribe
-        ;; identically to a `:include-ns`-selected registered descriptor
-        ;; (EP-0023 §Image Fragments — "the same runtime descriptor shape").
-        ;; Registered / standard / metadata-only entries are
-        ;; unchanged; `:impl` + provenance are preserved for collision /
-        ;; replacement / dedupe (all unchanged downstream).
-        selected (lower-inline-descriptors (select-for-images images descriptors))
-        standard (standard-descriptors)
-        all-ds   (into (vec selected) standard)
-        [rep rep-std] (replace-maps image-id images)]
-    ;; (3) Fail loud on any unsupported descriptor kind before sealing.
-    (check-supported-kinds! image-id all-ds)
-    ;; (4) Fail loud on any :replace / :replace-standard declaration for a key
-    ;;     with no real collision — a replacement is for an intentional
-    ;;     collision, never a silent order override. Runs before resolution so
-    ;;     a stale/typo'd declaration fails before any winner is matched.
-    (check-replacement-keys-collide! image-id (distinct-by-id all-ds) rep rep-std)
-    (let [;; (5) Project into the sealed resolver — every collision resolved
-          ;;     by a declared winner or thrown (order never decides).
-          resolver (build-resolver image-id all-ds rep rep-std)]
-      ;; (6) Validate application interceptor references against the sealed set.
-      (check-references! image-id resolver)
-      ;; (7) Seal.
-      {:rf.gen/resolver resolver
-       :rf.gen/images   images
-       :rf.gen/requires (image-requires images)
-       :rf.gen/kinds    (into #{} (map first) (keys resolver))})))
+  ;; (1) Image ids MUST be unique within the composition (EP-0026 §Image Keys).
+  (check-unique-image-ids! images)
+  (let [;; (2) Select + lower PER IMAGE, keeping the image association so a
+        ;;     within-image collision (an error) is distinguished from a
+        ;;     cross-image shadow (later wins). The default image selects the
+        ;;     whole pool; every explicit image runs its :select-ns selection.
+        per-image     (mapv (fn [image]
+                              [image (select-and-lower-image image descriptors)])
+                            images)
+        standard      (standard-descriptors)
+        ;; (3) Fail loud on any unsupported descriptor kind before resolving
+        ;;     (selected + standard).
+        _ (check-supported-kinds! (some :rf.image/id images)
+                                  (into (vec (mapcat second per-image)) standard))
+        ;; (4) Resolve EACH image to its id-disjoint {[kind id] descriptor} map.
+        ;;     Within one image any [kind id] that resolves two ways FAILS LOUD
+        ;;     (resolve-within-image): two selected → ambiguous; inline-vs-selected
+        ;;     or two inline → within-image collision. There is no within-image
+        ;;     winner rule — to override, use a later image.
+        image-resolvers (mapv (fn [[image ds]]
+                                (resolve-image (:rf.image/id image) ds))
+                              per-image)
+        ;; (5) Layer the per-image resolvers in IMAGE ORDER — the later image
+        ;;     wins (the cross-image shadow is reported by rf2-ke7w5j, never
+        ;;     failed). The result is the composed APP resolver.
+        app-resolver  (layer-image-resolvers image-resolvers)
+        ;; (6) Framework standards are PROTECTED: an app [kind id] colliding with
+        ;;     a standard FAILS LOUD (standards are not in app layer order).
+        standard-resolver (into {} (map (fn [d] [(descriptor-kind+id d) d])) standard)
+        _ (check-standard-collision! app-resolver standard-resolver)
+        ;; (7) The sealed resolver is the protected standard base + the layered
+        ;;     app resolver (the app never overwrites a standard — guarded above).
+        resolver      (merge standard-resolver app-resolver)]
+    ;; (8) Validate application interceptor references against the sealed set.
+    (check-references! (some :rf.image/id images) resolver)
+    ;; (9) Seal.
+    {:rf.gen/resolver resolver
+     :rf.gen/images   images
+     :rf.gen/requires (image-requires images)
+     :rf.gen/kinds    (into #{} (map first) (keys resolver))}))
 
 ;; ===========================================================================
 ;; Resolved-generation cache (EP-0023 §Image — "The reference implementation

--- a/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
@@ -342,112 +342,79 @@
         (is (= #{:rf.capability/http} (:rf.gen/requires (asm/assemble [img] pool))))))))
 
 ;; ===========================================================================
-;; SECTION 3 — Replacement policy
-;; (EP-0023 §Image Patching And Overrides / §Image Composition)
+;; SECTION 3 — Layered resolution (EP-0026 §Layered Resolution / §Framework
+;; Standard Registrations — supersedes the EP-0023 :replace policy)
 ;; ===========================================================================
 ;;
-;; A declared :replace / :replace-standard winner resolves a REAL collision and
-;; names EXACTLY ONE survivor; order never decides. A standard is non-replaceable
-;; without opt-in; composed images disagreeing on a winner fail loud.
+;; EP-0026 replaces the EP-0023 declared-:replace/:replace-standard winner model
+;; with deterministic IMAGE-ORDER layering: the later image in :images wins; a
+;; within-image [kind id] collision is an error (an override is always a later
+;; image); a framework standard is protected (a public app image must not shadow
+;; one).
 
-(deftest s3-declared-replace-winner-resolves-an-app-collision
-  (testing "EP-0023 §Image Patching: a declared :replace winner names the exact
-            survivor of a REAL application-owned collision — order does not decide"
-    (let [img  (rf/image {:id :checkout/story
-                          :include-ns ["checkout.core" "checkout.story"]
-                          :replace {[:fx :checkout.http/post]
-                                    {:ns "checkout.story"}}})
-          pool [(reg-desc "checkout.core"  :fx :checkout.http/post ::real)
-                (reg-desc "checkout.story" :fx :checkout.http/post ::story)]
-          gen  (asm/assemble [img] pool)]
-      (is (= ::story (:handler-fn (asm/resolve-descriptor gen :fx :checkout.http/post)))
-          "the declared winner (the story ns) survives the collision")
-      (testing "the SAME pool with the OTHER winner declared survives instead —
-                proving the WINNER, not load order, decides"
-        (let [img2 (rf/image {:id :checkout/prod
-                              :include-ns ["checkout.core" "checkout.story"]
-                              :replace {[:fx :checkout.http/post]
-                                        {:ns "checkout.core"}}})
-              gen2 (asm/assemble [img2] pool)]
-          (is (= ::real (:handler-fn (asm/resolve-descriptor gen2 :fx :checkout.http/post)))))))))
+(deftest s3-later-image-wins-cross-image-override
+  (testing "EP-0026 §Layered Resolution: a [kind id] in two composed images
+            resolves to the LATER image — image order, not the registrar, decides"
+    (let [pool      [(reg-desc "checkout.core" :fx :checkout.http/post ::real)]
+          app-image (rf/image {:id :app/main :select-ns {:include ["checkout.core"]}})
+          doubles   (rf/image {:id :test/doubles
+                               :registrations {:reg-fx [[:checkout.http/post {} ::story]]}})]
+      (is (= ::story (:impl (asm/resolve-descriptor
+                              (asm/assemble [app-image doubles] pool)
+                              :fx :checkout.http/post)))
+          "the later image (doubles) wins")
+      (is (= ::real (:handler-fn (asm/resolve-descriptor
+                                   (asm/assemble [doubles app-image] pool)
+                                   :fx :checkout.http/post)))
+          "reversing the order makes the app image (now last) win"))))
 
-(deftest s3-replace-for-non-colliding-key-fails-loud
-  (testing "EP-0023 §Image Patching: a :replace declared for a key with NO actual
-            collision is :rf.error/image-replacement-no-collision (a stale/typo
-            declaration, NOT a silent order override)"
-    (let [img  (rf/image {:id :app/main
-                          :include-ns ["app.core"]
-                          :replace {[:fx :app/lonely] {:ns "app.core"}}})
-          pool [(reg-desc "app.core" :fx :app/lonely ::only)]]
-      (is (= :rf.error/image-replacement-no-collision
-             (err-id #(asm/assemble [img] pool)))))))
+(deftest s3-within-image-collision-fails-loud
+  (testing "EP-0026 §Layered Resolution: an image must resolve cleanly to ONE
+            descriptor per [kind id]; two SELECTED registrations within one image
+            are ambiguous, and an inline entry colliding with a selected one is a
+            within-image collision (an override must be a later image)"
+    (let [two-selected (rf/image {:id :app/dup
+                                  :select-ns {:include ["app.a" "app.b"]}})
+          pool         [(reg-desc "app.a" :fx :app/post ::a)
+                        (reg-desc "app.b" :fx :app/post ::b)]]
+      (is (= :rf.error/image-duplicate-id
+             (err-id #(asm/assemble [two-selected] pool)))))
+    (let [inline-vs-sel (rf/image {:id :app/clash
+                                   :select-ns {:include ["app.core"]}
+                                   :registrations {:reg-fx [[:checkout.http/post {} ::inline]]}})
+          pool          [(reg-desc "app.core" :fx :checkout.http/post ::sel)]]
+      (is (= :rf.error/image-within-image-collision
+             (err-id #(asm/assemble [inline-vs-sel] pool)))))))
 
-(deftest s3-replace-winner-naming-no-selected-descriptor-fails-loud
-  (testing "EP-0023 §Image Patching: a :replace winner that identifies NO
-            selected descriptor (a stale winner source) is
-            :rf.error/image-replacement-winner-unresolved"
-    (let [img  (rf/image {:id :app/main
-                          :include-ns ["app.a" "app.b"]
-                          :replace {[:fx :app/post] {:ns "app.nowhere"}}})
-          pool [(reg-desc "app.a" :fx :app/post ::a)
-                (reg-desc "app.b" :fx :app/post ::b)]]
-      (is (= :rf.error/image-replacement-winner-unresolved
-             (err-id #(asm/assemble [img] pool)))))))
+(deftest s3-standard-shadowing-forbidden
+  (testing "EP-0026 §Framework Standard Registrations: a public app image must
+            NOT shadow a framework standard — the app/standard collision fails
+            loud (a standard encodes an execution invariant, not an app extension
+            point), and there is no public :replace-standard opt-in"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
+    (let [pool [(reg-desc "product.story" :fx :rf.nav/push-url ::story-nav)]
+          img  (rf/image {:id :story/x :select-ns {:include ["product.story"]}})]
+      (is (= :rf.error/image-standard-replacement-forbidden
+             (err-id #(asm/assemble [img] pool)))))
+    (testing "a standard with no colliding app id is simply unioned in"
+      (asm/clear-standards!)
+      (asm/clear-generation-cache!)
+      (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
+      (let [pool [(reg-desc "app.core" :event :app/boot ::boot)]
+            img  (rf/image {:id :app/main :select-ns {:include ["app.core"]}})
+            gen  (asm/assemble [img] pool)]
+        (is (= ::std-nav (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url))))))))
 
-(deftest s3-standard-replacement-forbidden-without-opt-in
-  (testing "EP-0023 §Image Patching: shadowing a framework STANDARD without
-            :replace-standard is :rf.error/image-standard-replacement-forbidden;
-            a NON-replaceable standard stays forbidden even WITH :replace-standard"
-    (let [pool [(reg-desc "product.story" :fx :rf.nav/push-url ::story-nav)]]
-      (testing "no :replace-standard declared → forbidden (a standard must not be
-                shadowed accidentally)"
-        (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
-        (let [img (rf/image {:id :story/x :include-ns ["product.story"]})]
-          (is (= :rf.error/image-standard-replacement-forbidden
-                 (err-id #(asm/assemble [img] pool))))))
-      (testing "the standard is non-replaceable by default → :replace-standard
-                still forbidden"
-        (asm/clear-standards!)
-        (asm/clear-generation-cache!)
-        (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav}) ;; replaceable? defaults false
-        (let [img (rf/image {:id :story/x :include-ns ["product.story"]
-                             :replace-standard {[:fx :rf.nav/push-url]
-                                                {:ns "product.story"}}})]
-          (is (= :rf.error/image-standard-replacement-forbidden
-                 (err-id #(asm/assemble [img] pool))))))
-      (testing "a REPLACEABLE standard + :replace-standard → the app replacement wins"
-        (asm/clear-standards!)
-        (asm/clear-generation-cache!)
-        (asm/register-standard! :fx :rf.nav/push-url
-                                {:handler-fn ::std-nav :rf.standard/replaceable? true})
-        (let [img (rf/image {:id :story/x :include-ns ["product.story"]
-                             :replace-standard {[:fx :rf.nav/push-url]
-                                                {:ns "product.story"}}})
-              gen (asm/assemble [img] pool)]
-          (is (= ::story-nav
-                 (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url)))))))))
-
-(deftest s3-cross-image-replacement-conflict-fails-loud
-  (testing "EP-0023 §Image Composition: two composed images declaring DIFFERENT
-            :replace winners for the same [kind id] is
-            :rf.error/image-replacement-conflict — composition order must not
-            silently decide the survivor"
-    (let [pool [(reg-desc "checkout.core"  :fx :checkout.http/post ::real)
-                (reg-desc "checkout.story" :fx :checkout.http/post ::story)]
-          img-a (rf/image {:id :compose/a
-                           :include-ns ["checkout.core" "checkout.story"]
-                           :replace {[:fx :checkout.http/post] {:ns "checkout.core"}}})
-          img-b (rf/image {:id :compose/b
-                           :include-ns ["checkout.core" "checkout.story"]
-                           :replace {[:fx :checkout.http/post] {:ns "checkout.story"}}})]
-      (is (= :rf.error/image-replacement-conflict
-             (err-id #(asm/assemble [img-a img-b] pool))))
-      (testing "two images naming the SAME winner agree — idempotent, no conflict"
-        (let [img-c (rf/image {:id :compose/c
-                               :include-ns ["checkout.core" "checkout.story"]
-                               :replace {[:fx :checkout.http/post] {:ns "checkout.story"}}})
-              gen   (asm/assemble [img-b img-c] pool)]
-          (is (= ::story (:handler-fn (asm/resolve-descriptor gen :fx :checkout.http/post)))))))))
+(deftest s3-duplicate-image-id-fails-loud
+  (testing "EP-0026 §Image Keys: two images sharing an :id within one composition
+            fail loud (:rf.error/image-duplicate-image-id) — the shadow report
+            identifies images by id, so a shared id is ambiguous"
+    (let [pool  [(reg-desc "checkout.core"  :fx :checkout.http/post ::real)
+                 (reg-desc "checkout.story" :fx :checkout.http/post ::story)]
+          img-a (rf/image {:id :compose/dup :select-ns {:include ["checkout.core"]}})
+          img-b (rf/image {:id :compose/dup :select-ns {:include ["checkout.story"]}})]
+      (is (= :rf.error/image-duplicate-image-id
+             (err-id #(asm/assemble [img-a img-b] pool)))))))
 
 ;; ===========================================================================
 ;; SECTION 4 — Default-image projection
@@ -967,22 +934,19 @@
           (is (= :rf.error/image-standard-replacement-forbidden
                  (err-id #(asm/assemble [img] pool)))))))))
 
-(deftest s9-replace-standard-of-a-replaceable-standard-takes-effect
-  (testing "EP-0023 §Image Patching And Overrides: a replaceable standard +
-            :replace-standard naming the app survivor actually TAKES EFFECT — the
-            replacement winner resolves through the generation, proving the
-            :replace-standard machinery is live (rf2-32siq3.41)"
-    ;; The fixture cleared the registry; register a REPLACEABLE standard directly
-    ;; (no conformance lock) to prove a declared :replace-standard winner wins.
+(deftest s9-public-app-image-cannot-shadow-a-standard
+  (testing "EP-0026 §Framework Standard Registrations: there is NO public
+            app-facing standard-replacement opt-in — a public app image colliding
+            with a framework standard FAILS LOUD regardless of the standard's
+            internal replaceable? flag (the no-shadowing rule binds public app
+            images; the framework keeps its own internal define/revise path)"
     (asm/register-standard! :fx :rf.nav/push-url
                             {:handler-fn ::std-nav :rf.standard/replaceable? true})
     (let [pool [(reg-desc "product.story" :fx :rf.nav/push-url ::app-nav)]
-          img  (rf/image {:id :i
-                          :include-ns ["product.story"]
-                          :replace-standard {[:fx :rf.nav/push-url] {:ns "product.story"}}})
-          gen  (asm/assemble [img] pool)]
-      (is (= ::app-nav (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url)))
-          "the declared :replace-standard winner replaces the standard in the generation"))))
+          img  (rf/image {:id :i :select-ns {:include ["product.story"]}})]
+      (is (= :rf.error/image-standard-replacement-forbidden
+             (err-id #(asm/assemble [img] pool)))
+          "even a replaceable standard is not shadowable by a public app image"))))
 
 ;; ===========================================================================
 ;; SECTION 10 — Inline (image-loaded) events deliver :rf.cofx/requires

--- a/implementation/core/test/re_frame/ep0026_select_ns_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0026_select_ns_cljs_test.cljc
@@ -1,0 +1,309 @@
+(ns re-frame.ep0026-select-ns-cljs-test
+  "EP-0026 §Namespace Selection / §Layered Resolution / §Image Keys (rf2-6ls85a)
+  — the CORE resolution mechanism the rest of EP-0026 builds on:
+
+    * `:select-ns` as ONE `{:include … :exclude …}` map (not sibling keys),
+      with GLOBAL exclusion and STRICT include diagnostics (a zero-match
+      `:include` pattern FAILS LOUD);
+    * image-order resolution — the LATER image in `:images` WINS;
+    * within ONE image any `[kind id]` that resolves two ways is an ERROR
+      (two selected = ambiguous; inline-vs-selected = override-must-be-later;
+      two inline = malformed);
+    * image ids are UNIQUE per `:images` composition (a duplicate id fails loud);
+    * `:select-ns` SELECTS, it does NOT load (it must not defeat DCE).
+
+  Each fail-loud assertion checks the `:rf.error/id` discriminator, never the
+  message bytes (Spec 009 §The thrown-error shape rule 3). Pure data — no
+  adapter/runtime state. The framework-standard registry IS process state, so a
+  fixture clears it per case. `.cljc` ending `-cljs-test` rides
+  `npm run test:cljs` AND `clojure -M:test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.image          :as image]
+            [re-frame.image-assembly :as asm]))
+
+(use-fixtures :each
+  (fn [t]
+    (asm/clear-standards!)
+    (t)
+    (asm/clear-standards!)))
+
+(defn- reg-desc
+  "A synthetic REGISTERED descriptor authored in `provenance-ns`."
+  [provenance-ns kind id impl]
+  {:rf.provenance/ns provenance-ns
+   :kind             kind
+   :id               id
+   :handler-fn       impl})
+
+(defn- err-id
+  [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (:rf.error/id (ex-data e)))))
+
+(defn- err-data
+  [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (ex-data e))))
+
+;; ===========================================================================
+;; 1. :select-ns — one {:include :exclude} map; global exclusion; strict include
+;; ===========================================================================
+
+(deftest select-ns-normalizes-to-the-internal-slots
+  (testing ":select-ns {:include … :exclude …} lowers to the normalized
+            :rf.image/include-ns / :rf.image/exclude-ns slots"
+    (let [v (image/image {:id :app/main
+                          :select-ns {:include ["app.todo.**" "app.admin.**"]
+                                      :exclude ["app.todo.dev.**"]}})]
+      (is (= ["app.todo.**" "app.admin.**"] (:rf.image/include-ns v)))
+      (is (= ["app.todo.dev.**"] (:rf.image/exclude-ns v)))))
+  (testing ":exclude is optional and defaults to []"
+    (let [v (image/image {:id :app/main :select-ns {:include ["app.**"]}})]
+      (is (= ["app.**"] (:rf.image/include-ns v)))
+      (is (= [] (:rf.image/exclude-ns v))))))
+
+(deftest select-ns-include-is-required-and-non-empty
+  (testing "a :select-ns with NO :include fails loud"
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns {:exclude ["a.**"]}})))))
+  (testing "a :select-ns with an EMPTY :include vector fails loud"
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns {:include []}})))))
+  (testing "a non-vector :include fails loud"
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns {:include "a.**"}})))))
+  (testing "a non-vector :exclude fails loud"
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns {:include ["a.**"] :exclude "b.**"}})))))
+  (testing "an unknown :select-ns key fails loud"
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns {:include ["a.**"] :bogus 1}})))))
+  (testing "a non-map :select-ns fails loud"
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns [:not :a :map]})))))
+  (testing "a non-string include/exclude glob element fails loud"
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns {:include ['a.b]}}))))
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns {:include ["a.b"] :exclude ['c.d]}}))))))
+
+(deftest select-ns-not-combinable-with-legacy-keys
+  (testing ":select-ns cannot be combined with :include-ns / :exclude-ns"
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns {:include ["a.**"]}
+                                  :include-ns ["a.b"]}))))
+    (is (= :rf.error/invalid-image
+           (err-id #(image/image {:id :x :select-ns {:include ["a.**"]}
+                                  :exclude-ns ["a.b"]}))))))
+
+(deftest select-ns-global-exclusion-and-strict-include
+  (let [pool [(reg-desc "app.todo.list"     :event :todo/add ::add)
+              (reg-desc "app.todo.dev.seed" :event :todo/seed ::seed)
+              (reg-desc "app.admin.users"   :event :admin/ban ::ban)]]
+    (testing "include selects the union; exclude is GLOBAL (a namespace matched by
+              any exclude is never selected, regardless of which include caught it)"
+      (let [img (image/image {:id :app/main
+                              :select-ns {:include ["app.todo.**" "app.admin.**"]
+                                          :exclude ["app.todo.dev.**"]}})
+            gen (asm/assemble [img] pool)]
+        (is (contains? (:rf.gen/resolver gen) [:event :todo/add]))
+        (is (contains? (:rf.gen/resolver gen) [:event :admin/ban]))
+        (is (not (contains? (:rf.gen/resolver gen) [:event :todo/seed]))
+            "the excluded dev namespace is dropped even though app.todo.** caught it")))
+    (testing "a zero-match :include pattern FAILS LOUD (strict include diagnostics)"
+      (let [img (image/image {:id :app/main :select-ns {:include ["app.nope.**"]}})]
+        (is (= :rf.error/image-zero-match
+               (err-id #(asm/assemble [img] pool))))))
+    (testing "ONE matching + ONE zero-match include still fails (every pattern must match)"
+      (let [img (image/image {:id :app/main
+                              :select-ns {:include ["app.todo.**" "ghost.**"]}})]
+        (is (= :rf.error/image-zero-match
+               (err-id #(asm/assemble [img] pool))))))
+    (testing "an :exclude pattern matching nothing is a no-op, NOT fail-loud"
+      (let [img (image/image {:id :app/main
+                              :select-ns {:include ["app.todo.list"]
+                                          :exclude ["does.not.exist.**"]}})
+            gen (asm/assemble [img] pool)]
+        (is (contains? (:rf.gen/resolver gen) [:event :todo/add]))))))
+
+;; ===========================================================================
+;; 2. Image-order resolution — the LATER image wins (cross-image override)
+;; ===========================================================================
+
+(deftest later-image-wins-cross-image-override
+  (testing "a [kind id] defined in two composed images resolves to the LATER
+            image's descriptor — image order is the only precedence"
+    (let [pool [(reg-desc "app.checkout" :fx :checkout.http/post ::real)]
+          app-image    (image/image {:id :app/main
+                                     :select-ns {:include ["app.checkout"]}})
+          test-doubles (image/image {:id :test/doubles
+                                     :registrations {:reg-fx [[:checkout.http/post {} ::stub]]}})]
+      (testing "test-doubles composed AFTER app-image wins (the inline stub)"
+        (let [gen (asm/assemble [app-image test-doubles] pool)]
+          (is (= ::stub (:impl (asm/resolve-descriptor gen :fx :checkout.http/post))))))
+      (testing "reversing the order reverses the winner (app-image now last)"
+        (let [gen (asm/assemble [test-doubles app-image] pool)]
+          (is (= ::real (:handler-fn (asm/resolve-descriptor gen :fx :checkout.http/post)))))))))
+
+(deftest cross-image-shadow-does-not-fail-assembly
+  (testing "a later image overriding an earlier one RESOLVES (later wins) — it
+            does NOT fail assembly (a cross-image shadow is reported, not failed)"
+    (let [pool      [(reg-desc "a.core" :event :app/boot ::a-boot)
+                     (reg-desc "b.core" :event :app/boot ::b-boot)]
+          img-a     (image/image {:id :img/a :select-ns {:include ["a.core"]}})
+          img-b     (image/image {:id :img/b :select-ns {:include ["b.core"]}})
+          gen       (asm/assemble [img-a img-b] pool)]
+      (is (= ::b-boot (:handler-fn (asm/resolve-descriptor gen :event :app/boot)))
+          "the later image (img-b) wins; assembly succeeds"))))
+
+(deftest multi-image-chain-last-wins
+  (testing "a chain [base override-a override-b] resolves to the LAST image's
+            descriptor for the shared [kind id]"
+    (let [base  (image/image {:id :base
+                              :registrations {:reg-fx [[:metrics/send {} ::base]]}})
+          ov-a  (image/image {:id :ov/a
+                              :registrations {:reg-fx [[:metrics/send {} ::a]]}})
+          ov-b  (image/image {:id :ov/b
+                              :registrations {:reg-fx [[:metrics/send {} ::b]]}})
+          gen   (asm/assemble [base ov-a ov-b] [])]
+      (is (= ::b (:impl (asm/resolve-descriptor gen :fx :metrics/send)))
+          "the last image in the chain wins"))))
+
+;; ===========================================================================
+;; 3. Within-image collision — every [kind id] resolving two ways is an ERROR
+;; ===========================================================================
+
+(deftest within-image-two-selected-is-ambiguous
+  (testing "two SELECTED descriptors for the same [kind id] (different source
+            namespaces) within ONE image → :rf.error/image-duplicate-id (ambiguous)"
+    (let [pool [(reg-desc "todo.boot"    :event :boot/init ::todo)
+                (reg-desc "counter.boot" :event :boot/init ::counter)]
+          img  (image/image {:id :both
+                             :select-ns {:include ["todo.boot" "counter.boot"]}})]
+      (is (= :rf.error/image-duplicate-id
+             (err-id #(asm/assemble [img] pool))))))
+  (testing "the two-selected ambiguous error is order-independent within the image"
+    (let [a   (reg-desc "todo.boot"    :event :boot/init ::a)
+          b   (reg-desc "counter.boot" :event :boot/init ::b)
+          img (image/image {:id :i :select-ns {:include ["todo.boot" "counter.boot"]}})]
+      (is (= :rf.error/image-duplicate-id (err-id #(asm/assemble [img] [a b]))))
+      (is (= :rf.error/image-duplicate-id (err-id #(asm/assemble [img] [b a])))))))
+
+(deftest within-image-inline-vs-selected-collides
+  (testing "an INLINE entry colliding with a SELECTED registration in ONE image →
+            :rf.error/image-within-image-collision (an override must be a LATER image)"
+    (let [pool [(reg-desc "counter.core" :event :counter/inc ::selected)]
+          img  (image/image {:id :i
+                             :select-ns {:include ["counter.core"]}
+                             :registrations {:reg-event [[:counter/inc {} ::inline]]}})]
+      (is (= :rf.error/image-within-image-collision
+             (err-id #(asm/assemble [img] pool))))))
+  (testing "the recovery names the move-to-a-later-image fix"
+    (let [pool [(reg-desc "counter.core" :event :counter/inc ::selected)]
+          img  (image/image {:id :i
+                             :select-ns {:include ["counter.core"]}
+                             :registrations {:reg-event [[:counter/inc {} ::inline]]}})
+          d    (err-data #(asm/assemble [img] pool))]
+      (is (= :rf.error/image-within-image-collision (:rf.error/id d)))
+      (is (= :move-the-override-to-a-later-image-or-deduplicate (:recovery d))))))
+
+(deftest within-image-two-inline-is-malformed
+  (testing "TWO inline :registrations entries for the same [kind id] in ONE image →
+            :rf.error/image-within-image-collision (malformed: define each once)"
+    (let [img (image/image {:id :i
+                            :registrations {:reg-event [[:counter/inc {} ::a]
+                                                        [:counter/inc {} ::b]]}})]
+      (is (= :rf.error/image-within-image-collision
+             (err-id #(asm/assemble [img] [])))))))
+
+;; ===========================================================================
+;; 4. Image ids unique per :images composition (a duplicate id fails loud)
+;; ===========================================================================
+
+(deftest duplicate-image-id-fails-loud
+  (testing "two images sharing an :id within one :images composition →
+            :rf.error/image-duplicate-image-id"
+    (let [pool [(reg-desc "a.core" :event :a/e ::a)
+                (reg-desc "b.core" :event :b/e ::b)]
+          img1 (image/image {:id :dup :select-ns {:include ["a.core"]}})
+          img2 (image/image {:id :dup :select-ns {:include ["b.core"]}})]
+      (is (= :rf.error/image-duplicate-image-id
+             (err-id #(asm/assemble [img1 img2] pool))))))
+  (testing "the diagnostic names the duplicate id"
+    (let [img1 (image/image {:id :dup :registrations {:reg-fx [[:a {} ::a]]}})
+          img2 (image/image {:id :dup :registrations {:reg-fx [[:b {} ::b]]}})
+          d    (err-data #(asm/assemble [img1 img2] []))]
+      (is (= :rf.error/image-duplicate-image-id (:rf.error/id d)))
+      (is (= [:dup] (:duplicate-image-ids d)))))
+  (testing "distinct ids compose cleanly; ANONYMOUS images (no :id) are exempt"
+    (let [img1 (image/image {:registrations {:reg-fx [[:a {} ::a]]}})
+          img2 (image/image {:registrations {:reg-fx [[:b {} ::b]]}})
+          gen  (asm/assemble [img1 img2] [])]
+      (is (contains? (:rf.gen/resolver gen) [:fx :a]))
+      (is (contains? (:rf.gen/resolver gen) [:fx :b])))))
+
+;; ===========================================================================
+;; 5. Framework standards are protected — an app [kind id] colliding with a
+;;    standard fails loud (standards are not part of app layer order)
+;; ===========================================================================
+
+(deftest app-shadowing-a-standard-fails-loud
+  (testing "an app descriptor with the same [kind id] as a framework STANDARD →
+            :rf.error/image-standard-replacement-forbidden (a standard must not
+            be shadowed by a public app image)"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std})
+    (let [pool [(reg-desc "product.story" :fx :rf.nav/push-url ::app-override)]
+          img  (image/image {:id :i :select-ns {:include ["product.story"]}})]
+      (is (= :rf.error/image-standard-replacement-forbidden
+             (err-id #(asm/assemble [img] pool))))))
+  (testing "an INLINE app entry colliding with a standard also fails loud"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std})
+    (let [img (image/image {:id :i :registrations {:reg-fx [[:rf.nav/push-url {} ::app]]}})]
+      (is (= :rf.error/image-standard-replacement-forbidden
+             (err-id #(asm/assemble [img] []))))))
+  (testing "a standard with NO colliding app id is unioned into the generation"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std})
+    (let [pool [(reg-desc "app.core" :event :app/boot ::boot)]
+          img  (image/image {:id :i :select-ns {:include ["app.core"]}})
+          gen  (asm/assemble [img] pool)]
+      (is (= ::std (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url))))
+      (is (contains? (:rf.gen/resolver gen) [:event :app/boot])))))
+
+;; ===========================================================================
+;; 6. :select-ns SELECTS, it does NOT load — DCE preserved
+;; ===========================================================================
+
+(deftest select-ns-selects-does-not-load
+  (testing ":select-ns only FILTERS the candidate pool by :rf.provenance/ns — it
+            never loads a namespace. A namespace NOT present in the pool is simply
+            not selectable (an include naming only it zero-matches); selection
+            does not conjure descriptors for an unloaded namespace."
+    (let [pool [(reg-desc "loaded.core" :event :a/e ::a)]
+          ;; "unloaded.feature" is NOT in the pool — :select-ns cannot load it.
+          img  (image/image {:id :i :select-ns {:include ["unloaded.feature.**"]}})]
+      (is (= :rf.error/image-zero-match
+             (err-id #(asm/assemble [img] pool)))
+          "an include naming only an unloaded namespace zero-matches — selection
+           never loaded it into existence")))
+  (testing "selection chooses from the descriptors the runtime ALREADY knows
+            about — a loaded sibling is selected, the absent one is not"
+    (let [pool [(reg-desc "loaded.a" :event :a/e ::a)
+                (reg-desc "loaded.b" :event :b/e ::b)]
+          img  (image/image {:id :i :select-ns {:include ["loaded.a"]}})
+          gen  (asm/assemble [img] pool)]
+      (is (contains? (:rf.gen/resolver gen) [:event :a/e]))
+      (is (not (contains? (:rf.gen/resolver gen) [:event :b/e]))
+          "loaded.b exists in the pool but is not selected — and was never loaded
+           by the selection"))))
+
+(deftest select-ns-resolution-is-pure-no-mutation
+  (testing "resolution does NOT mutate the image value or its registrations
+            (EP-0026 §Layered Resolution — resolution must not mutate the image)"
+    (let [pool [(reg-desc "app.core" :event :a/e ::a)]
+          img  (image/image {:id :i :select-ns {:include ["app.core"]}})
+          img-before (into {} img)]
+      (asm/assemble [img] pool)
+      (is (= img-before (into {} img)) "the image value is unchanged after assembly"))))

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -456,11 +456,29 @@
       removed `:rf.error/bad-marks` row). It is therefore DROPPED from this
       allow-list, as `allow-list-stays-honest` requires the moment the row lands.
 
+  EP-0026 IMAGE-API SIMPLIFICATION (rf2-6ls85a — image-order resolution):
+    - `:rf.error/image-within-image-collision` — fired when a single image
+      resolves one `[kind id]` two ways (an inline entry colliding with a
+      `:select-ns`-selected registration, or two inline entries). EP-0026
+      §Layered Resolution: an image must resolve cleanly to one descriptor per
+      `[kind id]`; an override is always a LATER image.
+    - `:rf.error/image-duplicate-image-id` — fired when two images share an `:id`
+      within one `:images` composition (EP-0026 §Image Keys). The shadow report
+      identifies images by id, so a shared id is ambiguous.
+    Both are NEW assembly diagnostics introduced by the EP-0026 image-order
+    resolution. Their Spec 009 §Error event catalogue rows are authored by the
+    EP-0026 spec graduation (rf2-o2vfrc, which owns the hot-zone
+    `spec/009-Instrumentation.md`); held here transitionally until that row
+    lands. `allow-list-stays-honest` forces the co-edit (drop from here) the
+    moment rf2-o2vfrc catalogues them.
+
   `allow-list-stays-honest` fails if any entry becomes catalogued or stops being
   emitted, forcing the co-edit so the list cannot rot into a silent blanket
   suppression."
   #{:rf.error/flow-cycle-extract-invariant
-    :rf.error/unknown-registry-kind})
+    :rf.error/unknown-registry-kind
+    :rf.error/image-within-image-collision
+    :rf.error/image-duplicate-image-id})
 
 ;; ---------------------------------------------------------------------------
 ;; Tests

--- a/implementation/core/test/re_frame/image_assembly_cache_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_assembly_cache_cljs_test.cljc
@@ -188,88 +188,49 @@
       (is (= 2 (asm/cache-size))))))
 
 ;; ===========================================================================
-;; 5. rf2-3sjdmi — two compositions differing ONLY in :replace / :replace-standard
-;;    must NOT cache-collide even when the resolver shape is shared. The key is
-;;    built from the image INPUTS (which carry the replacement maps), NOT from
-;;    :rf.gen/resolver alone.
+;; 5. EP-0026 — two compositions differing ONLY in IMAGE ORDER must NOT
+;;    cache-collide even when the per-image selections are the same. The later
+;;    image wins, so order is part of the resolved generation; the key is built
+;;    from the image VECTOR (which carries order), so distinct orders are distinct
+;;    keys (rf2-6ls85a; the formal select-ns + image-order key leg is rf2-ke7w5j).
 ;; ===========================================================================
 
-(deftest replace-decision-invalidates-even-with-shared-resolver-shape
-  (testing "two images selecting the SAME colliding namespaces but declaring
-            DIFFERENT :replace winners resolve to DIFFERENT descriptors — they
-            must be cached SEPARATELY. A key built from :rf.gen/resolver alone
-            (or the resolver before replacement) would collide; the input-keyed
-            cache does not (rf2-3sjdmi)."
+(deftest image-order-invalidates-even-with-same-selections
+  (testing "two compositions of the SAME two images in DIFFERENT order resolve a
+            shared [kind id] to DIFFERENT descriptors (later wins) — they must be
+            cached SEPARATELY. The image VECTOR carries order, so distinct orders
+            are distinct cache keys."
     (record! "checkout.core"       :fx :checkout.http/post ::real)
     (record! "checkout.story.http" :fx :checkout.http/post ::fake)
-    (let [;; Same selection (the two colliding namespaces) for BOTH images;
-          ;; only the declared :replace winner differs.
-          img-real (image/image
-                     {:id :checkout/use-real
-                      :include-ns ["checkout.core" "checkout.story.http"]
-                      :replace {[:fx :checkout.http/post] {:ns "checkout.core"}}})
-          img-fake (image/image
-                     {:id :checkout/use-fake
-                      :include-ns ["checkout.core" "checkout.story.http"]
-                      :replace {[:fx :checkout.http/post] {:ns "checkout.story.http"}}})
-          gen-real (asm/assemble [img-real])
-          gen-fake (asm/assemble [img-fake])]
-      (is (not (identical? gen-real gen-fake))
-          "distinct :replace decisions → distinct cached generations (no collision)")
-      (is (= ::real (:handler-fn (asm/resolve-descriptor gen-real :fx :checkout.http/post)))
-          "the :replace {:ns checkout.core} image resolves to the REAL impl")
-      (is (= ::fake (:handler-fn (asm/resolve-descriptor gen-fake :fx :checkout.http/post)))
-          "the :replace {:ns checkout.story.http} image resolves to the FAKE impl")
+    (let [img-real (image/image {:id :checkout/real
+                                 :select-ns {:include ["checkout.core"]}})
+          img-fake (image/image {:id :checkout/fake
+                                 :select-ns {:include ["checkout.story.http"]}})
+          gen-ab   (asm/assemble [img-real img-fake])   ;; fake last → fake wins
+          gen-ba   (asm/assemble [img-fake img-real])]  ;; real last → real wins
+      (is (not (identical? gen-ab gen-ba))
+          "distinct image orders → distinct cached generations (no collision)")
+      (is (= ::fake (:handler-fn (asm/resolve-descriptor gen-ab :fx :checkout.http/post)))
+          "[real fake] → the later image (fake) wins")
+      (is (= ::real (:handler-fn (asm/resolve-descriptor gen-ba :fx :checkout.http/post)))
+          "[fake real] → the later image (real) wins")
       (is (= 2 (asm/cache-size))
-          "two distinct compositions occupy two cache slots"))))
+          "two distinct orderings occupy two cache slots"))))
 
-(deftest same-replace-decision-still-hits
-  (testing "the complement: two images with the SAME selection AND the SAME
-            :replace winner DO hit the one cache slot — replacement parity does
-            not over-invalidate"
+(deftest same-composition-still-hits
+  (testing "the complement: the SAME images in the SAME order hit the ONE cache
+            slot — image-order keying does not over-invalidate"
     (record! "checkout.core"       :fx :checkout.http/post ::real)
     (record! "checkout.story.http" :fx :checkout.http/post ::fake)
-    (let [spec     {:id :checkout/story
-                    :include-ns ["checkout.core" "checkout.story.http"]
-                    :replace {[:fx :checkout.http/post] {:ns "checkout.story.http"}}}
-          gen1 (asm/assemble [(image/image spec)])
-          gen2 (asm/assemble [(image/image spec)])]
+    (let [img-real (image/image {:id :checkout/real
+                                 :select-ns {:include ["checkout.core"]}})
+          img-fake (image/image {:id :checkout/fake
+                                 :select-ns {:include ["checkout.story.http"]}})
+          gen1 (asm/assemble [img-real img-fake])
+          gen2 (asm/assemble [img-real img-fake])]
       (is (identical? gen1 gen2)
-          "identical composition incl. the replacement map → one cached object")
+          "identical composition (same images, same order) → one cached object")
       (is (= 1 (asm/cache-size))))))
-
-(deftest replace-standard-decision-invalidates-even-with-shared-resolver-shape
-  (testing "the :replace-standard analogue: a replaceable standard collides with
-            a selected descriptor; the :replace-standard winner is the
-            replacement DECISION and is part of the key — two images differing
-            only there do not cache-collide"
-    (asm/register-standard! :fx :rf.nav/push-url
-                            {:handler-fn ::std :rf.standard/replaceable? true})
-    (record! "product.story" :fx :rf.nav/push-url ::app-override)
-    (let [;; img-default: NO :replace-standard → a standard collision with no
-          ;; declared winner FAILS LOUD, so it is not a cacheable shape. Instead
-          ;; compare two DISTINCT replaceable standards isn't possible with one
-          ;; key; the rf2-3sjdmi point for :replace-standard is that the winner
-          ;; map is in the key. We prove it by: one image with the winner (seals)
-          ;; vs. the SAME selection without it (throws) — different inputs.
-          img-replaced (image/image
-                         {:id :product/story
-                          :include-ns ["product.story"]
-                          :replace-standard {[:fx :rf.nav/push-url] {:ns "product.story"}}})
-          gen-replaced (asm/assemble [img-replaced])]
-      (is (= ::app-override
-             (:handler-fn (asm/resolve-descriptor gen-replaced :fx :rf.nav/push-url)))
-          "the :replace-standard winner is honoured")
-      ;; The SAME selection WITHOUT the :replace-standard winner is a distinct
-      ;; (and fail-loud) composition — a stale cache keyed on the resolver shape
-      ;; would wrongly hand back the replaced generation; the input-keyed cache
-      ;; treats it as a different key and re-runs assembly (which throws).
-      (let [img-noreplace (image/image {:id :product/story
-                                        :include-ns ["product.story"]})]
-        (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
-                     (asm/assemble [img-noreplace]))
-            "without the :replace-standard winner the standard collision FAILS
-             LOUD — the cache did NOT short-circuit to the replaced generation")))))
 
 ;; ===========================================================================
 ;; 6. Fail-loud inputs are NOT cached

--- a/implementation/core/test/re_frame/image_assembly_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_assembly_cljs_test.cljc
@@ -3,24 +3,26 @@
   Overrides — the ASSEMBLY slice (rf2-32siq3.4): resolve image values into a
   SEALED, VALIDATED `[kind id]` generation and fail loud before a frame runs.
 
-  Pins the bead's enumerated coverage:
+  Sections 1-2 + 6-11 pin EP-0023 assembly coverage (projection, dedupe,
+  unsupported kind, references, capabilities, structured diagnostics). Sections
+  3, 3b, 5, 9 are UPDATED to EP-0026 §Layered Resolution (rf2-6ls85a): the
+  EP-0023 declared-`:replace`/`:replace-standard` winner model is replaced by
+  deterministic IMAGE-ORDER layering.
 
-    * successful projection — selected (by `:include-ns`) + inline + framework
-      standard → an immutable `[kind id]` resolver;
-    * duplicate-id collision with no declared winner FAILS LOUD (order never
+  Pins the enumerated coverage:
+
+    * successful projection — selected + inline + framework standard → an
+      immutable `[kind id]` resolver;
+    * within-image duplicate-id collision FAILS LOUD (selection order never
       decides the survivor);
     * dedupe — the same registration selected twice is NOT a collision;
-    * declared `:replace` winner resolves an application-owned collision;
-    * stale / ambiguous replacement winner FAILS LOUD;
-    * `:replace` / `:replace-standard` declared for a key with NO actual
-      collision (zero or exactly one selected descriptor) FAILS LOUD — a
-      replacement resolves an intentional collision, never a silent order
-      override (rf2-32siq3.5 winner policy);
+    * the LATER image wins a cross-image `[kind id]` (EP-0026 image order); a
+      cross-image shadow does NOT fail assembly; a chain resolves to the last;
+    * a within-image `[kind id]` resolving two ways FAILS LOUD (two selected =
+      ambiguous; inline-vs-selected or two inline = within-image collision);
     * unsupported descriptor kind FAILS LOUD;
-    * a framework STANDARD collision without `:replace-standard` FAILS LOUD;
-    * `:replace-standard` on a NON-replaceable standard FAILS LOUD (incl. an
-      invariant-coupled standard);
-    * `:replace-standard` on a replaceable standard succeeds;
+    * a public app image colliding with a framework STANDARD FAILS LOUD (a
+      standard is protected — not part of app layer order, no public opt-in);
     * missing application interceptor reference FAILS LOUD;
     * capability checking (rf2-32siq3.6): missing capability FAILS LOUD; an
       empty/absent `:rf.image/requires` is a no-op; an absent (nil) or empty
@@ -169,175 +171,80 @@
       (is (= ::add (:handler-fn (asm/resolve-descriptor gen :event :cart/add)))))))
 
 (deftest inline-vs-selected-same-id-collides
-  (testing "an inline :counter/inc and a namespace-selected :counter/inc are the
-            same collision class — fail loud without a declared winner"
+  (testing "an inline :counter/inc and a namespace-selected :counter/inc in ONE
+            image is a within-image collision — fail loud
+            (:rf.error/image-within-image-collision); to override, use a later image"
     (let [pool [(reg-desc "counter.core" :event :counter/inc ::selected)]
           img  (image/image
                  {:id :i
-                  :include-ns ["counter.core"]
+                  :select-ns {:include ["counter.core"]}
                   :registrations {:reg-event [[:counter/inc {} ::inline]]}})]
-      (is (= :rf.error/image-duplicate-id
+      (is (= :rf.error/image-within-image-collision
              (assembly-error-id #(asm/assemble [img] pool)))))))
 
 ;; ===========================================================================
-;; 3. Declared :replace winner (the .5 seam — detection + simple winner rule)
+;; 3. Image-order resolution (EP-0026 §Layered Resolution) — the LATER image
+;;    WINS for a cross-image [kind id]; the shadow does NOT fail assembly.
 ;; ===========================================================================
 
-(deftest replace-winner-resolves-application-collision
-  (testing "a declared :replace winner naming one selected descriptor's
-            coordinate resolves the collision to that descriptor"
-    (let [pool [(reg-desc "checkout.core" :fx :checkout.http/post ::real)
-                (reg-desc "checkout.story.http" :fx :checkout.http/post ::fake)]
-          img  (image/image
-                 {:id :checkout/story
-                  :include-ns ["checkout.core" "checkout.story.http"]
-                  :replace {[:fx :checkout.http/post] {:ns "checkout.story.http"}}})
-          gen  (asm/assemble [img] pool)]
-      (is (= ::fake (:handler-fn (asm/resolve-descriptor gen :fx :checkout.http/post)))
-          "the declared winner (the story double) is the survivor, not load order"))))
-
-(deftest replace-winner-to-inline-coordinate
-  (testing "a :replace winner can name an INLINE descriptor coordinate
-            ({:image :inline}) as the survivor of a collision with a selected one"
+(deftest later-image-wins-cross-image-override
+  (testing "a [kind id] in two composed images resolves to the LATER image's
+            descriptor (the test-doubles override image composed after the app image)"
     (let [pool [(reg-desc "checkout.core" :fx :checkout.http/post ::real)]
-          img  (image/image
-                 {:id :checkout/story
-                  :include-ns ["checkout.core"]
-                  :registrations {:reg-fx [[:checkout.http/post {} ::inline-fake]]}
-                  :replace {[:fx :checkout.http/post]
-                            {:image :checkout/story :inline [:reg-fx :checkout.http/post]}}})
-          gen  (asm/assemble [img] pool)]
-      (is (= ::inline-fake
-             (:impl (asm/resolve-descriptor gen :fx :checkout.http/post)))))))
+          app-image    (image/image
+                         {:id :app/main :select-ns {:include ["checkout.core"]}})
+          test-doubles (image/image
+                         {:id :test/doubles
+                          :registrations {:reg-fx [[:checkout.http/post {} ::stub]]}})
+          gen  (asm/assemble [app-image test-doubles] pool)]
+      (is (= ::stub (:impl (asm/resolve-descriptor gen :fx :checkout.http/post)))
+          "the later image (test-doubles) wins — image order, not the registrar"))))
 
-(deftest stale-replace-winner-fails-loud
-  (testing "a :replace winner naming a coordinate that no selected descriptor
-            has (a stale ns, a typo) → :rf.error/image-replacement-winner-unresolved"
-    (let [pool [(reg-desc "checkout.core" :fx :checkout.http/post ::real)
-                (reg-desc "checkout.story.http" :fx :checkout.http/post ::fake)]
-          img  (image/image
-                 {:id :i
-                  :include-ns ["checkout.core" "checkout.story.http"]
-                  :replace {[:fx :checkout.http/post] {:ns "checkout.story.STALE"}}})]
-      (is (= :rf.error/image-replacement-winner-unresolved
-             (assembly-error-id #(asm/assemble [img] pool)))))))
-
-(deftest ambiguous-replace-winner-fails-loud
-  (testing "a :replace winner that matches MORE THAN ONE selected descriptor
-            (two genuine collisions sharing the SAME source coordinate) →
-            :rf.error/image-replacement-winner-unresolved with recovery
-            :make-the-winner-coordinate-unambiguous — the winner must name
-            exactly one survivor, not a set of indistinguishable descriptors"
-    ;; Two distinct registrations authored in the SAME provenance ns with the
-    ;; same (kind, id) but DIFFERENT impls: a genuine collision (not a dedupe),
-    ;; and BOTH carry the coordinate {:ns "checkout.story.http"}. A :ns winner
-    ;; naming that coordinate matches both, so it does NOT name one survivor.
-    (let [pool [(reg-desc "checkout.story.http" :fx :checkout.http/post ::fake-a)
-                (reg-desc "checkout.story.http" :fx :checkout.http/post ::fake-b)]
-          img  (image/image
-                 {:id :i
-                  :include-ns ["checkout.story.http"]
-                  :replace {[:fx :checkout.http/post] {:ns "checkout.story.http"}}})
-          d    (assembly-error-data #(asm/assemble [img] pool))]
-      (is (= :rf.error/image-replacement-winner-unresolved (:rf.error/id d)))
-      (testing "the recovery key is the AMBIGUOUS leg, distinct from the
-                zero-match leg's :fix-the-replacement-winner-source"
-        (is (= :make-the-winner-coordinate-unambiguous (:recovery d)))
-        (is (= 2 (:match-count d)))))))
-
-(deftest anonymous-image-inline-winner-fails-loud
-  (testing "an ANONYMOUS image (no :id) whose INLINE descriptor is named as a
-            replacement winner must FAIL LOUD — an inline winner coordinate
-            (:image <id> :inline …) requires the containing image to carry an
-            :id, so an anonymous image's inline descriptor (coordinate
-            {:image nil …}) can never be the named survivor (EP-0023:
-            an inline winner requires the containing image to have an :id)"
-    ;; A registered descriptor collides with the anonymous image's inline
-    ;; descriptor for the same (kind, id). The :replace names the inline
-    ;; coordinate with a concrete image id, but the anonymous image stamps its
-    ;; inline descriptor with :image nil → the winner matches no descriptor.
+(deftest reversing-image-order-reverses-the-winner
+  (testing "image order is the ONLY precedence: composing the app image LAST makes
+            its selected registration the winner instead"
     (let [pool [(reg-desc "checkout.core" :fx :checkout.http/post ::real)]
-          img  (image/image
-                 {;; NO :id — anonymous image
-                  :include-ns ["checkout.core"]
-                  :registrations {:reg-fx [[:checkout.http/post {} ::inline-fake]]}
-                  :replace {[:fx :checkout.http/post]
-                            {:image :checkout/story :inline [:reg-fx :checkout.http/post]}}})]
-      (is (= :rf.error/image-replacement-winner-unresolved
-             (assembly-error-id #(asm/assemble [img] pool)))
-          "naming an inline coordinate as a winner on an :id-less image fails loud"))))
+          app-image    (image/image
+                         {:id :app/main :select-ns {:include ["checkout.core"]}})
+          test-doubles (image/image
+                         {:id :test/doubles
+                          :registrations {:reg-fx [[:checkout.http/post {} ::stub]]}})
+          gen  (asm/assemble [test-doubles app-image] pool)]
+      (is (= ::real (:handler-fn (asm/resolve-descriptor gen :fx :checkout.http/post)))))))
+
+(deftest cross-image-shadow-does-not-fail-assembly
+  (testing "a later image overriding an earlier one RESOLVES (later wins) and does
+            NOT fail assembly — a cross-image shadow is reported, not failed"
+    (let [pool  [(reg-desc "a.core" :fx :checkout.http/post ::a)
+                 (reg-desc "b.core" :fx :checkout.http/post ::b)]
+          img-a (image/image {:id :img/a :select-ns {:include ["a.core"]}})
+          img-b (image/image {:id :img/b :select-ns {:include ["b.core"]}})
+          gen   (asm/assemble [img-a img-b] pool)]
+      (is (= ::b (:handler-fn (asm/resolve-descriptor gen :fx :checkout.http/post)))))))
 
 ;; ===========================================================================
-;; 3b. Replacement declares a REAL collision only (rf2-32siq3.5 winner policy):
-;;     a :replace / :replace-standard for a key with no actual collision is an
-;;     error — replacement resolves an intentional collision, it is NEVER a
-;;     silent order override. The complement of the winner-unresolved check.
+;; 3b. Within-image disjointness — an image must resolve cleanly to ONE
+;;     descriptor per [kind id] (EP-0026 §Layered Resolution). To override, the
+;;     winner goes in a LATER image; an override within ONE image is an error.
 ;; ===========================================================================
 
-(deftest replace-on-noncolliding-single-selection-fails-loud
-  (testing "a :replace declared for a (kind, id) with exactly ONE selected
-            descriptor (no collision) → :rf.error/image-replacement-no-collision
-            — naming a winner where there is nothing to replace is an order
-            override, not a collision resolution"
-    (let [pool [(reg-desc "checkout.core" :fx :checkout.http/post ::only)]
-          img  (image/image
-                 {:id :i
-                  :include-ns ["checkout.core"]
-                  :replace {[:fx :checkout.http/post] {:ns "checkout.core"}}})]
-      (is (= :rf.error/image-replacement-no-collision
-             (assembly-error-id #(asm/assemble [img] pool)))))))
+(deftest within-image-two-inline-is-malformed
+  (testing "two inline entries for the same [kind id] in ONE image →
+            :rf.error/image-within-image-collision (define each [kind id] once inline)"
+    (let [img (image/image
+                {:id :i
+                 :registrations {:reg-fx [[:checkout.http/post {} ::a]
+                                          [:checkout.http/post {} ::b]]}})]
+      (is (= :rf.error/image-within-image-collision
+             (assembly-error-id #(asm/assemble [img] [])))))))
 
-(deftest replace-on-absent-key-fails-loud
-  (testing "a :replace declared for a (kind, id) that NO selected descriptor has
-            (a typo / a stale id) → :rf.error/image-replacement-no-collision —
-            there is no collision (zero descriptors) to resolve"
+(deftest noncolliding-image-seals-cleanly
+  (testing "the baseline: a single selected registration with no within-image
+            collision seals cleanly to that descriptor"
     (let [pool [(reg-desc "checkout.core" :fx :checkout.http/post ::only)]
-          img  (image/image
-                 {:id :i
-                  :include-ns ["checkout.core"]
-                  :replace {[:fx :checkout.http/TYPO] {:ns "checkout.core"}}})]
-      (is (= :rf.error/image-replacement-no-collision
-             (assembly-error-id #(asm/assemble [img] pool)))))))
-
-(deftest replace-standard-on-noncolliding-key-fails-loud
-  (testing "a :replace-standard declared for a key with no actual collision is
-            ALSO a no-collision error (the non-collision check runs BEFORE the
-            standard-policy guard — there is no real collision to police)"
-    ;; A replaceable standard exists, but the app does NOT select a colliding
-    ;; descriptor — so the standard alone occupies the (kind, id): no collision.
-    (asm/register-standard! :fx :rf.nav/push-url
-                            {:handler-fn ::std :rf.standard/replaceable? true})
-    (let [pool [(reg-desc "product.core" :event :app/boot ::boot)]
-          img  (image/image
-                 {:id :i
-                  :include-ns ["product.core"]
-                  :replace-standard {[:fx :rf.nav/push-url] {:ns "product.core"}}})]
-      (is (= :rf.error/image-replacement-no-collision
-             (assembly-error-id #(asm/assemble [img] pool)))))))
-
-(deftest noncolliding-image-without-replacement-seals-cleanly
-  (testing "the baseline: the SAME single selection with NO :replace declaration
-            seals cleanly — the no-collision error fires ONLY on a spurious
-            replacement declaration, never on an ordinary single registration"
-    (let [pool [(reg-desc "checkout.core" :fx :checkout.http/post ::only)]
-          img  (image/image {:id :i :include-ns ["checkout.core"]})
+          img  (image/image {:id :i :select-ns {:include ["checkout.core"]}})
           gen  (asm/assemble [img] pool)]
       (is (= ::only (:handler-fn (asm/resolve-descriptor gen :fx :checkout.http/post)))))))
-
-(deftest check-replacement-keys-collide-is-callable-directly
-  (testing "the .5 seam fn rejects a non-colliding key and accepts a real
-            collision when called against a post-dedupe distinct-by-id view"
-    (let [real-collision {[:fx :x] [(reg-desc "a" :fx :x ::a)
-                                    (reg-desc "b" :fx :x ::b)]}
-          single         {[:fx :x] [(reg-desc "a" :fx :x ::a)]}]
-      (testing "a real collision passes the key check (returns nil, no throw)"
-        (is (nil? (asm/check-replacement-keys-collide!
-                    :i real-collision {[:fx :x] {:ns "a"}} {}))))
-      (testing "a single (uncollided) selection fails loud"
-        (is (= :rf.error/image-replacement-no-collision
-               (assembly-error-id
-                 #(asm/check-replacement-keys-collide!
-                    :i single {[:fx :x] {:ns "a"}} {}))))))))
 
 ;; ===========================================================================
 ;; 4. Unsupported descriptor kind
@@ -366,50 +273,37 @@
       (is (= :rf.error/image-standard-replacement-forbidden
              (assembly-error-id #(asm/assemble [img] pool)))))))
 
-(deftest replace-standard-on-nonreplaceable-fails-loud
-  (testing "a :replace-standard declaration against a standard that is NOT
-            marked :rf.standard/replaceable? (the default) → forbidden"
-    (asm/register-standard! :fx :rf.nav/push-url
-                            {:handler-fn ::std :rf.standard/replaceable? false})
-    (let [pool [(reg-desc "product.story" :fx :rf.nav/push-url ::app-override)]
-          img  (image/image
-                 {:id :i
-                  :include-ns ["product.story"]
-                  :replace-standard {[:fx :rf.nav/push-url] {:ns "product.story"}}})]
+(deftest inline-app-shadowing-a-standard-fails-loud
+  (testing "an INLINE app entry with the same [kind id] as a framework standard
+            also fails loud — a public app image must not shadow a standard
+            (EP-0026 §Framework Standard Registrations)"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std})
+    (let [img (image/image {:id :i
+                            :registrations {:reg-fx [[:rf.nav/push-url {} ::app]]}})]
       (is (= :rf.error/image-standard-replacement-forbidden
-             (assembly-error-id #(asm/assemble [img] pool)))))))
+             (assembly-error-id #(asm/assemble [img] [])))))))
 
-(deftest replace-standard-on-invariant-coupled-fails-loud
-  (testing "an invariant-coupled standard (:rf.standard/requires-conformance
-            non-empty) is NOT image-replaceable even with :replace-standard +
-            :rf.standard/replaceable? true — the EP keeps :rf.interceptor/path
-            non-replaceable until a conformance profile exists"
-    (asm/register-standard! :interceptor :rf.interceptor/path
-                            {:handler-fn ::path
-                             :rf.standard/replaceable? true
-                             :rf.standard/requires-conformance #{:identical-no-op}})
-    (let [pool [(reg-desc "naive.override" :interceptor :rf.interceptor/path ::naive)]
-          img  (image/image
-                 {:id :i
-                  :include-ns ["naive.override"]
-                  :replace-standard {[:interceptor :rf.interceptor/path]
-                                     {:ns "naive.override"}}})]
+(deftest later-image-cannot-shadow-a-standard
+  (testing "even a LATER image cannot shadow a framework standard — standards are
+            not part of app layer order; the app/standard collision fails loud
+            regardless of image position"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std})
+    (let [pool  [(reg-desc "app.core" :event :app/boot ::boot)]
+          base  (image/image {:id :base :select-ns {:include ["app.core"]}})
+          ovr   (image/image {:id :ovr
+                              :registrations {:reg-fx [[:rf.nav/push-url {} ::app]]}})]
       (is (= :rf.error/image-standard-replacement-forbidden
-             (assembly-error-id #(asm/assemble [img] pool)))))))
+             (assembly-error-id #(asm/assemble [base ovr] pool)))))))
 
-(deftest replace-standard-on-replaceable-succeeds
-  (testing "a :replace-standard against a standard explicitly marked replaceable
-            (no conformance requirement) resolves to the app descriptor"
-    (asm/register-standard! :fx :rf.nav/push-url
-                            {:handler-fn ::std :rf.standard/replaceable? true})
-    (let [pool [(reg-desc "product.story" :fx :rf.nav/push-url ::app-override)]
-          img  (image/image
-                 {:id :i
-                  :include-ns ["product.story"]
-                  :replace-standard {[:fx :rf.nav/push-url] {:ns "product.story"}}})
+(deftest standard-without-app-collision-is-unioned
+  (testing "a framework standard with NO colliding app id is simply unioned into
+            the generation"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std})
+    (let [pool [(reg-desc "product.story" :event :product/open ::open)]
+          img  (image/image {:id :i :select-ns {:include ["product.story"]}})
           gen  (asm/assemble [img] pool)]
-      (is (= ::app-override
-             (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url)))))))
+      (is (= ::std (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url))))
+      (is (contains? (:rf.gen/resolver gen) [:event :product/open])))))
 
 ;; ===========================================================================
 ;; 6. Missing reference (application interceptor)
@@ -543,88 +437,49 @@
            (asm/descriptor-coordinate {:kind :fx :id :x :standard true})))))
 
 ;; ===========================================================================
-;; 9. Cross-image replacement conflicts (rf2-32siq3.19) — two composed images
-;;    declaring DIFFERENT winners for the same [kind id] FAILS LOUD; identical
-;;    declarations across images are idempotent (order must not decide).
+;; 9. Cross-image layering (EP-0026 §Layered Resolution) — the LATER image
+;;    WINS; a chain reports the LAST image as the winner. There is NO cross-image
+;;    conflict (a cross-image shadow resolves and is reported, never failed).
 ;; ===========================================================================
 
-(deftest cross-image-conflicting-replace-fails-loud
-  (testing "two composed images declaring the SAME [kind id] :replace winner
-            with DIFFERENT coordinates → :rf.error/image-replacement-conflict —
-            the later image must NOT silently last-merge-win the winner"
-    (let [pool   [(reg-desc "checkout.core" :fx :checkout.http/post ::real)
-                  (reg-desc "checkout.story.a" :fx :checkout.http/post ::a)
+(deftest two-images-later-wins
+  (testing "two composed images defining the SAME [kind id] resolve to the LATER
+            image — image order is the only precedence (no conflict)"
+    (let [pool   [(reg-desc "checkout.story.a" :fx :checkout.http/post ::a)
                   (reg-desc "checkout.story.b" :fx :checkout.http/post ::b)]
-          img-a  (image/image
-                   {:id :img/a
-                    :include-ns ["checkout.core" "checkout.story.a"]
-                    :replace {[:fx :checkout.http/post] {:ns "checkout.story.a"}}})
-          img-b  (image/image
-                   {:id :img/b
-                    :include-ns ["checkout.story.b"]
-                    :replace {[:fx :checkout.http/post] {:ns "checkout.story.b"}}})]
-      (is (= :rf.error/image-replacement-conflict
-             (assembly-error-id #(asm/assemble [img-a img-b] pool)))))))
+          img-a  (image/image {:id :img/a :select-ns {:include ["checkout.story.a"]}})
+          img-b  (image/image {:id :img/b :select-ns {:include ["checkout.story.b"]}})]
+      (is (= ::b (:handler-fn (asm/resolve-descriptor
+                                (asm/assemble [img-a img-b] pool)
+                                :fx :checkout.http/post)))
+          "img-b wins (last)")
+      (is (= ::a (:handler-fn (asm/resolve-descriptor
+                                (asm/assemble [img-b img-a] pool)
+                                :fx :checkout.http/post)))
+          "reversing order reverses the winner"))))
 
-(deftest cross-image-identical-replace-is-idempotent
-  (testing "two composed images declaring the SAME [kind id] :replace winner
-            with the SAME coordinate AGREE — no conflict; the collision resolves
-            to the agreed winner"
-    (let [pool  [(reg-desc "checkout.core" :fx :checkout.http/post ::real)
-                 (reg-desc "checkout.story" :fx :checkout.http/post ::fake)]
-          img-a (image/image
-                  {:id :img/a
-                   :include-ns ["checkout.core" "checkout.story"]
-                   :replace {[:fx :checkout.http/post] {:ns "checkout.story"}}})
-          img-b (image/image
-                  {:id :img/b
-                   :include-ns ["checkout.story"]
-                   :replace {[:fx :checkout.http/post] {:ns "checkout.story"}}})
-          gen   (asm/assemble [img-a img-b] pool)]
-      (is (= ::fake (:handler-fn (asm/resolve-descriptor gen :fx :checkout.http/post)))
-          "the agreed winner survives; identical cross-image declarations are fine"))))
+(deftest multi-image-chain-last-image-wins
+  (testing "a chain [base override-a override-b] resolves the shared [kind id] to
+            the LAST image's descriptor"
+    (let [base  (image/image {:id :base
+                              :registrations {:reg-fx [[:checkout.http/post {} ::base]]}})
+          ov-a  (image/image {:id :ov/a
+                              :registrations {:reg-fx [[:checkout.http/post {} ::a]]}})
+          ov-b  (image/image {:id :ov/b
+                              :registrations {:reg-fx [[:checkout.http/post {} ::b]]}})
+          gen   (asm/assemble [base ov-a ov-b] [])]
+      (is (= ::b (:impl (asm/resolve-descriptor gen :fx :checkout.http/post)))))))
 
-(deftest cross-image-conflicting-replace-standard-fails-loud
-  (testing "the conflict check also covers :replace-standard — two images naming
-            DIFFERENT standard winners for the same key fail loud"
-    (asm/register-standard! :fx :rf.nav/push-url
-                            {:handler-fn ::std :rf.standard/replaceable? true})
-    (let [pool  [(reg-desc "product.story.a" :fx :rf.nav/push-url ::a)
-                 (reg-desc "product.story.b" :fx :rf.nav/push-url ::b)]
-          img-a (image/image
-                  {:id :img/a
-                   :include-ns ["product.story.a"]
-                   :replace-standard {[:fx :rf.nav/push-url] {:ns "product.story.a"}}})
-          img-b (image/image
-                  {:id :img/b
-                   :include-ns ["product.story.b"]
-                   :replace-standard {[:fx :rf.nav/push-url] {:ns "product.story.b"}}})]
-      (is (= :rf.error/image-replacement-conflict
-             (assembly-error-id #(asm/assemble [img-a img-b] pool)))))))
-
-(deftest replacement-conflict-ex-data-names-both-winners
-  (testing "the conflict diagnostic carries image/which/[kind id]/winners/recovery
-            (rf2-32siq3.26 structured diagnostics)"
-    (let [pool  [(reg-desc "checkout.core" :fx :checkout.http/post ::real)
-                 (reg-desc "checkout.story.a" :fx :checkout.http/post ::a)
-                 (reg-desc "checkout.story.b" :fx :checkout.http/post ::b)]
-          img-a (image/image
-                  {:id :img/a
-                   :include-ns ["checkout.core" "checkout.story.a"]
-                   :replace {[:fx :checkout.http/post] {:ns "checkout.story.a"}}})
-          img-b (image/image
-                  {:id :img/b
-                   :include-ns ["checkout.story.b"]
-                   :replace {[:fx :checkout.http/post] {:ns "checkout.story.b"}}})
+(deftest duplicate-image-id-across-composition-fails-loud
+  (testing "two images sharing an :id within one :images composition →
+            :rf.error/image-duplicate-image-id (the shadow report names images by id)"
+    (let [pool  [(reg-desc "a.core" :fx :checkout.http/post ::a)
+                 (reg-desc "b.core" :fx :checkout.http/post ::b)]
+          img-a (image/image {:id :dup :select-ns {:include ["a.core"]}})
+          img-b (image/image {:id :dup :select-ns {:include ["b.core"]}})
           d     (assembly-error-data #(asm/assemble [img-a img-b] pool))]
-      (is (= :rf.error/image-replacement-conflict (:rf.error/id d)))
-      (is (= :replace (:which d)))
-      (is (= :fx (:kind d)))
-      (is (= :checkout.http/post (:id d)))
-      (is (= #{{:ns "checkout.story.a"} {:ns "checkout.story.b"}}
-             (set (:winners d)))
-          "both disagreeing winner coordinates are named")
-      (is (= :reconcile-the-conflicting-replacement-winners (:recovery d))))))
+      (is (= :rf.error/image-duplicate-image-id (:rf.error/id d)))
+      (is (= [:dup] (:duplicate-image-ids d))))))
 
 ;; ===========================================================================
 ;; 10. Resource → resource-scope resolver reference validation (rf2-32siq3.25)
@@ -738,27 +593,30 @@
       (is (= {:ns "weird.ns"} (:coordinate d)))
       (is (= :correct-the-descriptor-kind (:recovery d))))))
 
-(deftest standard-forbidden-ex-data-names-colliding-coordinates
-  (testing "the standard-replacement-forbidden diagnostic now names every
-            colliding source coordinate alongside the standard coordinate
-            (rf2-32siq3.26)"
+(deftest standard-forbidden-ex-data-names-the-app-coordinate
+  (testing "the standard-replacement-forbidden diagnostic (EP-0026 §Framework
+            Standard Registrations) names the standard coordinate, the app source
+            coordinate, [kind id], and a rename/deselect recovery"
     (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std})
     (let [pool [(reg-desc "product.story" :fx :rf.nav/push-url ::app-override)]
-          img  (image/image {:id :p/img :include-ns ["product.story"]})
+          img  (image/image {:id :p/img :select-ns {:include ["product.story"]}})
           d    (assembly-error-data #(asm/assemble [img] pool))]
       (is (= :rf.error/image-standard-replacement-forbidden (:rf.error/id d)))
-      (is (= :p/img (:image d)))
+      (is (= :fx (:kind d)))
+      (is (= :rf.nav/push-url (:id d)))
       (is (= {:standard true} (:standard-coordinate d)))
-      (is (contains? (set (:colliding-coordinates d)) {:ns "product.story"})
+      (is (= {:ns "product.story"} (:app-coordinate d))
           "the app source colliding with the standard is named")
-      (is (= :declare-replace-standard-or-rename (:recovery d))))))
+      (is (= :rename-the-app-id-or-deselect-it (:recovery d))))))
 
-(deftest duplicate-id-ex-data-names-colliding-coordinates
-  (testing "the duplicate-id diagnostic carries image/[kind id]/colliding source
-            coordinates/recovery (rf2-32siq3.26 — already structured; pinned)"
+(deftest within-image-duplicate-id-ex-data-names-colliding-coordinates
+  (testing "the within-image duplicate-id diagnostic carries image/[kind id]/
+            colliding source coordinates and the narrow-or-rename recovery
+            (EP-0026 §Layered Resolution)"
     (let [pool [(reg-desc "todo.boot"    :event :boot/init ::a)
                 (reg-desc "counter.boot" :event :boot/init ::b)]
-          img  (image/image {:id :both/img :include-ns ["todo.boot" "counter.boot"]})
+          img  (image/image {:id :both/img
+                             :select-ns {:include ["todo.boot" "counter.boot"]}})
           d    (assembly-error-data #(asm/assemble [img] pool))]
       (is (= :rf.error/image-duplicate-id (:rf.error/id d)))
       (is (= :both/img (:image d)))
@@ -766,4 +624,4 @@
       (is (= :boot/init (:id d)))
       (is (= #{{:ns "todo.boot"} {:ns "counter.boot"}}
              (set (:colliding-coordinates d))))
-      (is (= :declare-replace-winner-or-disambiguate (:recovery d))))))
+      (is (= :narrow-the-selection-or-rename-the-id (:recovery d))))))


### PR DESCRIPTION
EP-0026 lead bead **rf2-6ls85a** — the core image-API resolution mechanism the rest of the EP-0026 serial lane builds on (fsd822 / dlvmpc / ke7w5j / o2vfrc / qp8qi8). Implements the accepted contract in `docs/EP/EP-0026-image-api-simplification.md`.

## What this implements

- **`:select-ns` as ONE `{:include :exclude}` map** — the single selection surface, normalized to the internal include/exclude slots. `:include` is required + non-empty; `:exclude` optional/defaults `[]`. **Global exclusion** (`union(:include) minus union(:exclude)`, no re-admission). **Strict include diagnostics**: a zero-match include pattern FAILS LOUD (`:rf.error/image-zero-match`). Cannot be combined with the legacy `:include-ns`/`:exclude-ns` (retired by rf2-dlvmpc).
- **`:select-ns` selects, does NOT load** — it filters the candidate pool by `:rf.provenance/ns`; it never forces a require and never conjures descriptors for an unloaded namespace, so DCE is preserved (elision probe reports assembly-DCE 1/1).
- **Image-order resolution (later image wins)** — replaces the EP-0023 `:replace`/`:replace-standard` winner model. Each image resolves to an id-disjoint `{[kind id] descriptor}` map; images layer in `:images` order, the LATER image winning. A cross-image shadow resolves (later wins) and does **not** fail assembly (the shadow report is rf2-ke7w5j).
- **Within-image collision = error** — any `[kind id]` resolving two ways within ONE image fails loud: two selected = ambiguous (`:rf.error/image-duplicate-id`); inline-vs-selected or two inline = `:rf.error/image-within-image-collision` (an override must be a LATER image).
- **Unique image ids per composition** — two images sharing an `:id` fail loud (`:rf.error/image-duplicate-image-id`).
- **Framework standards protected** — a public app descriptor (selected or inline) colliding with a framework standard fails loud (`:rf.error/image-standard-replacement-forbidden`); standards are not part of app layer order and there is no public opt-in.

Scope held to the resolution + selection grammar: inline-grammar narrowing (fsd822), old-key retirement + capability removal (dlvmpc), the shadow report + cache-key leg (ke7w5j), spec graduation (o2vfrc), and conformance (qp8qi8) are left to their own beads. The two new error ids ride the Spec 009 catalogue allow-list transitionally until rf2-o2vfrc authors their rows.

## Quality gates

- **Core JVM tests** (`clojure -M:test` in `implementation/core`): 1708 tests, 7416 assertions, **0 failures, 0 errors**.
- **CLJS node** (`npm run test:cljs`): 7986 tests, 36734 assertions, **0 failures, 0 errors**.
- **Elision probe** (`npm run test:elision`): PASS — production 42/42 absent, EP-0023 assembly-DCE 1/1 (confirms `:select-ns` does not defeat DCE).

New test file `ep0026_select_ns_cljs_test.cljc` covers select-ns include/exclude, zero-match-include fail, image-order later-wins (+ chain), all three within-image collision kinds, duplicate-image-id fail, standard protection, and select-does-not-load. The EP-0023 assembly / cache / conformance suites were updated from the retired `:replace` model to image-order.