### PR TITLE
fix(core): EP-0025 machine-error exception-data nil-frame fail-closed (rf2-xmnlvc)

### DIFF
--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -695,13 +695,19 @@
 
   EP-0025 (rf2-398kql): the \"machine declares ANY `:sensitive`\" decision now
   consults the FRAME's snapshot-path classification (the sole app-db mechanism)
-  unioned with any author `:event` registration classification."
+  unioned with any author `:event` registration classification.
+
+  A nil / unresolvable frame FAILS CLOSED (redacts) — matching the sibling
+  `project-flow-failed-tags` and Spec 015 §Failure-posture (unknown frame =>
+  fail closed). `:exception-data` is author-shaped `ex-data` that cannot be
+  path-walked safely, so a nil frame redacts the WHOLE slot."
   [tags frame-id]
   (let [machine-id (or (:actor-id tags) (:machine-id tags))
         author     (classification-when :event machine-id)
         frame-mk   (frame-snapshot-classification frame-id machine-id)]
     (if (and (contains? tags :exception-data)
-             (or (seq (:sensitive author)) (seq (:sensitive frame-mk))))
+             (or (nil? frame-id)
+                 (seq (:sensitive author)) (seq (:sensitive frame-mk))))
       (redact-exception-data-slot tags)
       tags)))
 

--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -161,9 +161,16 @@
 
   Note: the emit site does NOT stamp `:sensitive?` here — the production
   bug rf2-md2wn0 hinges on that. The flag is decided downstream by marks
-  projection, and the top-level hoist must lift it from `:tags`."
+  projection, and the top-level hoist must lift it from `:tags`.
+
+  Carries an explicit `:frame :rf/default` — a KNOWN (non-nil) frame — so
+  the projector takes the resolved-frame branch and these precision fixtures
+  exercise the non-redacting plain-machine path (rf2-xmnlvc: with the
+  nil-frame fail-closed arm a missing `:frame` now redacts; the nil-frame
+  regression below intentionally omits it)."
   [id-key machine-id]
   {id-key             machine-id
+   :frame             :rf/default
    :action-id         :do/thing
    :state-path        [:running]
    :event             [machine-id [:tick]]
@@ -264,6 +271,32 @@
       (is (some? out) "the machine-action-exception trace was delivered")
       (is (map? (:exception-data tags)) ":exception-data verbatim (no marks)")
       (is (not (:sensitive? out)) "no top-level :sensitive? stamp"))))
+
+(deftest machine-exception-data-redacted-for-nil-frame
+  (testing "rf2-xmnlvc — a machine-action-exception whose trace carries NO
+            :frame (nil / unresolvable frame) FAILS CLOSED: :exception-data is
+            elided to :rf/redacted and the TOP-LEVEL :sensitive? flag is
+            hoisted — matching the sibling project-flow-failed-tags and Spec
+            015 §Failure-posture (unknown frame => fail closed). Even a PLAIN
+            machine (no author :sensitive mark) redacts here, because the
+            author-shaped :exception-data cannot be path-walked safely without
+            a resolved frame. Confirm-by-revert: dropping the (nil? frame-id)
+            arm in project-machine-error-tags makes this RED — the sentinel
+            leaks raw."
+    (declare-machine-marks!)
+    (let [tags-no-frame (dissoc (machine-action-exception-tags
+                                  :actor-id plain-machine-id)
+                                :frame)
+          out           (emit-machine-action-exception tags-no-frame)
+          tags          (:tags out)]
+      (is (some? out) "the machine-action-exception trace was delivered")
+      (is (nil? (:frame tags)) "the trace carries no resolvable :frame")
+      (is (= :rf/redacted (:exception-data tags))
+          ":exception-data redacted (fail-closed on a nil frame)")
+      (is (true? (:sensitive? out)) "top-level :sensitive? hoisted")
+      (is (not (contains-sentinel? out))
+          (str "the sentinel leaked into the nil-frame exception trace: "
+               (pr-str tags))))))
 
 ;; ---------------------------------------------------------------------------
 ;; SITE 1 — :actor-id PREFERRED branch (rf2-sxmeqs).


### PR DESCRIPTION
## What

`project-machine-error-tags` in `implementation/core/src/re_frame/classification.cljc` did **not** fail closed on a nil/unresolvable frame, while its sibling `project-flow-failed-tags` does. With a nil `:frame`, the machine-error projector consulted only the author / frame-mk `:sensitive` sets, so a machine declaring no author `:sensitive` whose trace carried a nil `:frame` shipped `:exception-data` **raw**.

Per Spec 015 §Failure-posture (unknown frame => fail closed) — and to match the sibling, which already shares the `redact-exception-data-slot` tail — Mike ruled **(a) fix the asymmetry**.

## Change

- **`project-machine-error-tags`**: add the `(nil? frame-id)` fail-closed arm so `:exception-data` redacts to `:rf/redacted` (whole slot) and top-level `:sensitive?` hoists when the frame is nil. `:exception-data` is author-shaped `ex-data` that cannot be path-walked safely without a resolved frame, so the whole slot is redacted (the same posture the sibling takes).
- **Tests** (`implementation/security/.../error_slot_egress_security_cljs_test.cljc`): give the precision fixtures (`machine-action-exception-tags`) an explicit `:frame :rf/default` — a known, non-nil frame — so they still exercise the **known-frame non-redacting** plain-machine path. Add `machine-exception-data-redacted-for-nil-frame` asserting `:exception-data => :rf/redacted` + top-level `:sensitive?` hoisted on a frameless trace.

Confirm-by-revert: dropping the `(nil? frame-id)` arm makes the new nil-frame test go **RED** (the sentinel leaks raw into `:exception-data`, `:exception-data` is not redacted, `:sensitive?` not hoisted) — verified locally.

Scope: only `project-machine-error-tags` + its test. Did NOT touch `project-sub-tags` (rf2-mtzv5m, just merged) or spec/009 (rf2-a9fol5, pending).

## Quality gates

- `npm run test:cljs` — **green** (7987 tests, 36739 assertions, 0 failures, 0 errors); includes the security egress namespace.
- `npm run test:elision` (production elision probe) — **green** (`PASS elision: production 42/42 absent; control 42/42 present`).
- JVM core classification + elision (`clojure -M:test` on `re-frame.classification-effects-cljs-test`, `re-frame.frame-classification-cljs-test`, `re-frame.elision-test`) — **green** (82 tests, 242 assertions, 0 failures).
- JVM security egress namespace SITE 1 (machine) tests — **green**, including the new nil-frame regression. (4 pre-existing SITE 2 navigate/route failures under the JVM runner are unrelated to this change — Malli late-bind env quirk, identical on `origin/main` baseline; SITE 2 is unaffected by this fix.)

CI is the merge gate.