### PR TITLE
feat(image): EP-0026 inline grammar (4 kinds) + default image (rf2-fsd822)

### DIFF
--- a/implementation/core/src/re_frame/image.cljc
+++ b/implementation/core/src/re_frame/image.cljc
@@ -253,18 +253,23 @@
          (match-segments? (collapse-double-stars (split-segments pattern))
                           (split-segments ns-str)))))
 
-;; ---- inline descriptors (EP-0023 §Image Fragments) ------------------------
+;; ---- inline descriptors (EP-0026 §Inline Registration Grammar) -------------
 ;;
 ;; Inline `:registrations` are registrar-keyed sections that mirror the public
-;; `reg-*` names. Each section's entries are call-shaped tuples:
+;; `reg-*` names. EP-0026 fixes the outer tuple shape at:
 ;;
-;;   [id metadata body]   ;; handler entry
-;;   [id metadata]        ;; metadata-only entry
+;;   [id body]            ;; metadata defaults to {}
+;;   [id metadata body]   ;; explicit metadata map
+;;
+;; The metadata map is OPTIONAL and normalizes to `{}`. A 2-tuple's second slot
+;; is the BODY, not metadata — every inline entry carries a body. METADATA-ONLY
+;; `[id metadata]` entries are INVALID (EP-0026 deliberately reverses EP-0023,
+;; which permitted a metadata-only tuple); they fail loud at `rf/image`.
 ;;
 ;; Inline descriptors do NOT enter the provenance source store and are NOT
 ;; selected by `:include-ns`. They are selected because their containing image
 ;; value was supplied. They still need a descriptor source coordinate so errors
-;; and replacements can name them (EP-0023):
+;; and replacements can name them:
 ;;
 ;;   {:kind :event
 ;;    :id :counter/inc
@@ -277,71 +282,107 @@
 
 (def ^:private reg-section->kind
   "The inline `:registrations` section keys (the public `reg-*` spellings)
-  mapped to their Spec 001 registry kind. Adding a registry kind that an inline
-  image section can carry is a one-row addition here, kept in lockstep with the
-  closed `re-frame.registrar/kinds` set."
-  {:reg-event          :event
-   :reg-sub            :sub
-   :reg-fx             :fx
-   :reg-cofx           :cofx
-   :reg-interceptor    :interceptor
-   :reg-view           :view
-   :reg-frame          :frame
-   :reg-route          :route
-   :reg-head           :head
-   :reg-error-projector :error-projector
-   :reg-flow           :flow
-   :reg-resource       :resource
-   :reg-mutation       :mutation
-   :reg-resource-scope :resource-scope})
+  mapped to their Spec 001 registry kind. EP-0026 §Inline Registration Grammar
+  NARROWS the inline grammar to EXACTLY the four kinds with a concrete inline
+  parser + a published late-bind lowering hook (`re-frame.events` / `.subs` /
+  `.fx` / `.cofx`'s `:image/lower-inline-<kind>`):
+
+    :reg-event → :event
+    :reg-sub   → :sub  (the layer-1 db-reader form ONLY)
+    :reg-fx    → :fx
+    :reg-cofx  → :cofx
+
+  Every OTHER kind (`:reg-interceptor`, `:reg-view`, `:reg-frame`, `:reg-route`,
+  `:reg-head`, `:reg-error-projector`, `:reg-flow`, `:reg-resource`,
+  `:reg-mutation`, `:reg-resource-scope`) remains namespace-authored until its
+  owning spec defines an inline lowering — an inline section for one fails loud
+  with the unsupported-inline-kind diagnostic (`registrations->inline-descriptors`).
+  Adding a kind here is a deliberate act: it MUST come with a published
+  `:image/lower-inline-<kind>` hook, a body parser, metadata/body
+  disambiguation, a provenance shape, and conformance coverage (EP-0026)."
+  {:reg-event :event
+   :reg-sub   :sub
+   :reg-fx    :fx
+   :reg-cofx  :cofx})
 
 (defn- inline-entry->descriptor
   "Lower one inline registrar-section entry into an inline descriptor. `entry`
-  is a call-shaped tuple `[id metadata body]` (handler) or `[id metadata]`
-  (metadata-only). `image-id` is the containing image's `:id` (nil for an
-  anonymous image — valid for local tests/examples that do not participate in
-  replacement, EP-0023). Pure.
+  is a call-shaped tuple `[id body]` (metadata defaults to `{}`) or
+  `[id metadata body]` (explicit metadata). `image-id` is the containing image's
+  `:id` (nil for an anonymous image — valid for local tests/examples that do not
+  participate in composition). Pure.
 
   Stamps the inline source coordinate (`:rf.provenance/image` + the
   `:rf.provenance/inline [section id]` pair) so an inline descriptor has a
-  stable name for errors and replacement winners. The body (when present) is
-  carried under `:impl`; the metadata under `:metadata` (omitted when empty).
+  stable name for errors and cross-image shadows. The body is ALWAYS carried
+  under `:impl`; the metadata under `:metadata` (omitted when empty).
 
-  The arity is EXACT: an inline entry MUST be a 3-tuple `[id metadata body]`
-  (handler) or a 2-tuple `[id metadata]` (metadata-only) — EP-0023 §Image
-  Fragments admits only those two shapes. A 1-tuple `[id]` (no metadata slot)
-  and a 4+-tuple `[id metadata body extra…]` (a trailing slot that would be
-  silently ignored) both fail loud rather than be coerced — a malformed
-  registration entry is a typo or a stale call shape, not a metadata-only
-  entry with `nil` metadata or an entry with an extra argument the framework
-  drops."
+  The arity is EXACT (EP-0026 §Inline Registration Grammar): an inline entry
+  MUST be a 2-tuple `[id body]` or a 3-tuple `[id metadata body]` — every inline
+  registration carries a body. A 1-tuple `[id]`, an empty tuple `[]`, and a
+  4+-tuple `[id metadata body extra…]` fail loud rather than be coerced.
+
+  METADATA-ONLY `[id metadata]` is INVALID: a 2-tuple's second slot is the BODY,
+  not metadata. EP-0026 deliberately reverses EP-0023 (which admitted a
+  metadata-only tuple) — a registration with no body is not a registration. To
+  attach metadata, use the 3-tuple `[id metadata body]`. The retired
+  metadata-only form is caught FAIL-LOUD: for the four supported inline kinds the
+  body is a HANDLER FUNCTION, never a map, so a 2-tuple whose body slot is a MAP
+  is exactly the retired `[id metadata]` shape — it is rejected rather than
+  silently lowered with the metadata map as the handler `:impl`."
   [image-id section kind entry]
   (when-not (and (vector? entry) (<= 2 (count entry) 3))
     (error/throw-error!
       :rf.error/invalid-image
       'rf/image
-      (str "rf/image: inline " section " entry must be a [id metadata body] "
-           "(handler) or [id metadata] (metadata-only) tuple — got " (pr-str entry)
+      (str "rf/image: inline " section " entry must be a [id body] or "
+           "[id metadata body] tuple (EP-0026 — every inline registration carries "
+           "a body; a metadata-only [id metadata] is INVALID) — got " (pr-str entry)
            " (" (if (vector? entry) (str "arity " (count entry)) "not a vector")
            ").")
-      {:recovery :use-a-call-shaped-tuple
+      {:recovery :use-an-id-body-or-id-metadata-body-tuple
        :extra    {:image image-id :section section :entry entry}}))
   (let [id       (nth entry 0)
-        metadata (nth entry 1 nil)
-        has-body (= 3 (count entry))
-        body     (when has-body (nth entry 2))]
-    (cond-> {:kind                kind
-             :id                  id
+        has-meta (= 3 (count entry))
+        metadata (when has-meta (nth entry 1))
+        body     (if has-meta (nth entry 2) (nth entry 1))]
+    ;; FAIL-LOUD on the retired metadata-only form: a 2-tuple whose body slot is
+    ;; a MAP is the EP-0023 `[id metadata]` shape EP-0026 retires. The four
+    ;; supported inline kinds all take a handler FUNCTION body, never a map, so a
+    ;; map in the body slot is unambiguously the retired metadata-only tuple (to
+    ;; attach metadata, use the 3-tuple `[id metadata body]`).
+    (when (and (not has-meta) (map? body))
+      (error/throw-error!
+        :rf.error/invalid-image
+        'rf/image
+        (str "rf/image: inline " section " entry " (pr-str entry)
+             " is a metadata-only [id metadata] tuple — INVALID under EP-0026. A "
+             "2-tuple's second slot is the handler BODY (a function), not metadata; "
+             "a registration with no body is not a registration. To attach metadata "
+             "use the 3-tuple [id metadata body].")
+        {:recovery :use-an-id-body-or-id-metadata-body-tuple
+         :extra    {:image image-id :section section :entry entry}}))
+    (cond-> {:kind                 kind
+             :id                   id
+             :impl                 body
              :rf.provenance/inline [section id]}
-      image-id        (assoc :rf.provenance/image image-id)
-      has-body        (assoc :impl body)
-      (seq metadata)  (assoc :metadata metadata))))
+      image-id       (assoc :rf.provenance/image image-id)
+      (seq metadata) (assoc :metadata metadata))))
 
 (defn- registrations->inline-descriptors
-  "Lower an image's `:registrations` map (`{:reg-event [[id meta body] …] …}`)
-  into a vector of inline descriptors, stamped with the image id. Pure. Throws
-  `:rf.error/invalid-image` on an unknown section key (fail loud rather than
-  silently drop an entry)."
+  "Lower an image's `:registrations` map (`{:reg-event [[id body] …] …}`) into a
+  vector of inline descriptors, stamped with the image id. Pure. Throws
+  `:rf.error/invalid-image` on an UNSUPPORTED inline kind (EP-0026 §Inline
+  Registration Grammar — fail loud rather than silently drop an entry).
+
+  EP-0026 standardizes inline grammar for EXACTLY four kinds — `:reg-event`,
+  `:reg-sub`, `:reg-fx`, `:reg-cofx` — the kinds with a concrete inline parser
+  and a published late-bind lowering hook (`reg-section->kind`). Every other
+  registration kind (`:reg-interceptor`, `:reg-view`, `:reg-frame`, `:reg-route`,
+  `:reg-head`, `:reg-error-projector`, `:reg-flow`, `:reg-resource`,
+  `:reg-mutation`, `:reg-resource-scope`) — and any typo'd section key — fails
+  loud with the unsupported-inline-kind diagnostic: those kinds remain
+  namespace-authored until their owning spec defines inline lowering."
   [image-id registrations]
   (into []
         (mapcat
@@ -351,10 +392,18 @@
                 (error/throw-error!
                   :rf.error/invalid-image
                   'rf/image
-                  (str "rf/image: unknown inline registrations section " section
-                       " — use a reg-* section key (:reg-event, :reg-sub, …).")
-                  {:recovery :correct-the-section-key
-                   :extra    {:image image-id :unknown-section section}}))
+                  (str "rf/image: unsupported inline registrations section "
+                       (pr-str section) " — EP-0026 standardizes inline grammar "
+                       "for ONLY the four kinds :reg-event, :reg-sub, :reg-fx, and "
+                       ":reg-cofx. Every other kind (interceptors, views, frames, "
+                       "routes, heads, error-projectors, flows, resources, "
+                       "mutations, resource-scopes) stays namespace-authored until "
+                       "its owning spec defines an inline lowering — author it with "
+                       "a reg-* form in a selected namespace instead.")
+                  {:recovery :use-a-supported-inline-section-or-author-it-in-a-namespace
+                   :extra    {:image            image-id
+                              :unsupported-section section
+                              :supported-sections (vec (sort (keys reg-section->kind)))}}))
               (map #(inline-entry->descriptor image-id section kind %) entries))))
         registrations))
 
@@ -474,12 +523,17 @@
     [include exclude]))
 
 (def ^:private valid-kinds
-  "The closed registry-kind set a `:replace` / `:replace-standard` key may name,
-  derived from `reg-section->kind`'s values so it stays in lockstep with the
-  closed `re-frame.registrar/kinds` set without coupling this pure ns to the
-  registrar (which would pull `interop` and friends onto this otherwise
-  `re-frame.error`-only slice)."
-  (set (vals reg-section->kind)))
+  "The closed registry-kind set a `:replace` / `:replace-standard` key may name
+  (the full Spec 001 registry taxonomy). DECOUPLED from `reg-section->kind`: a
+  replacement key may name ANY registry kind, NOT only the four EP-0026 narrowed
+  inline kinds — so this set spans the whole taxonomy, mirroring
+  `re-frame.registrar/kinds` without coupling this pure ns to the registrar
+  (which would pull `interop` and friends onto this otherwise
+  `re-frame.error`-only slice). (`:replace` / `:replace-standard` are retired by
+  rf2-dlvmpc; this stays the full set until then so the inline-grammar narrowing
+  does not leak into replacement-key validation.)"
+  #{:event :sub :fx :cofx :interceptor :view :frame :route :head
+    :error-projector :flow :resource :mutation :resource-scope})
 
 (defn- valid-winner-coordinate?
   "True when `coord` is a structurally well-formed replacement winner SOURCE

--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -850,11 +850,32 @@
   "Select ONE image's descriptors from the candidate `descriptors` pool (via the
   slice-.3 selector / the default-image whole-store selection) and lower its
   inline `:impl` bodies into the runnable shape (EP-0023 §Image Fragments).
-  Returns the image's selected + inline descriptors. Pure."
+  Returns the image's selected + inline descriptors. Pure modulo the late-bind
+  lowering + the framework-standard registry read (for the default-image filter).
+
+  DEFAULT-IMAGE STANDARD-SHADOW FILTER (EP-0026 §Default Image — \"the default
+  image selects all ordinary namespace-authored registrations … and includes
+  framework standards\"): the framework dual-registers some standards (e.g.
+  `:rf/set-db`, EP-0027) into the regular registrar/source store too, so the
+  registrar-direct (non-generation) resolution path can find them. Those
+  source-store shadows are NOT ordinary app registrations — they are the
+  framework standard's own copy. The default image's WHOLE-STORE selection must
+  drop any descriptor whose `[kind id]` is a framework standard: the standard is
+  unioned in separately (and protected), so projecting its registrar-shadow as
+  an app descriptor would make the default frame fail
+  `check-standard-collision!` against the very standard it shadows. An EXPLICIT
+  `:select-ns` image is unaffected — it selects by provenance namespace, and a
+  standard's registrar shadow carries no `:rf.provenance/ns`, so it is never
+  glob-selectable anyway."
   [image descriptors]
   (lower-inline-descriptors
     (if (default-image? image)
-      descriptors
+      (let [standard-keys (into #{}
+                                (map descriptor-kind+id)
+                                (standard-descriptors))]
+        (into []
+              (remove #(contains? standard-keys (descriptor-kind+id %)))
+              descriptors))
       (image/select-descriptors image descriptors))))
 
 (defn- assemble*

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -373,20 +373,34 @@
   opts)
 
 (defn- validate-images!
-  "Validate the `:images` opt is a VECTOR of image values (EP-0023 §Image
-  Composition / §Public API — `:images` is always a vector). A non-vector
-  `:images` (a bare image map, a seq, nil-when-required) throws
-  `:rf.error/make-frame-bad-images`, fail-loud. Returns the vector unchanged."
+  "Validate the `:images` opt is a NON-EMPTY VECTOR of image values (EP-0023
+  §Image Composition / §Public API — `:images` is always a vector; EP-0026
+  §Default Image — `:images []` is an error). A non-vector `:images` (a bare
+  image map, a seq) OR an EMPTY `:images []` throws
+  `:rf.error/make-frame-bad-images`, fail-loud. Returns the vector unchanged.
+
+  EP-0026 (ruled 2026-06-22) makes the EMPTY vector an ERROR: pass at least one
+  image, or OMIT `:images` for the default image. To create a frame with no app
+  registrations, pass a real empty image (`(rf/image {:id :test/empty})`). This
+  reverses the EP-0023/EP-0024 behavior where `:images []` projected the default
+  image — under EP-0026 the default is the OMIT path (`make-frame {}`), not the
+  empty-vector path."
   [images]
-  (when-not (vector? images)
+  (when-not (and (vector? images) (seq images))
     (error/throw-error!
       :rf.error/make-frame-bad-images
       'rf/make-frame
-      (str "rf/make-frame: :images must be a VECTOR of image values — got "
-           (pr-str images) ". `:images` is the only spelling and it is always a "
-           "vector; even a single image is supplied as a one-element vector, "
-           "e.g. :images [my-image].")
-      {:recovery :wrap-the-images-in-a-vector
+      (if (vector? images)
+        (str "rf/make-frame: :images [] is an ERROR (EP-0026 §Default Image) — "
+             "pass at least one image, or OMIT :images entirely for the default "
+             "image (the implicit selector over the whole source store). To create "
+             "a frame with no app registrations, pass a real empty image: "
+             ":images [(rf/image {:id :my/empty})].")
+        (str "rf/make-frame: :images must be a NON-EMPTY VECTOR of image values — "
+             "got " (pr-str images) ". `:images` is the only spelling and it is "
+             "always a vector; even a single image is supplied as a one-element "
+             "vector, e.g. :images [my-image]. Omit :images for the default image."))
+      {:recovery :supply-at-least-one-image-or-omit-images-for-the-default
        :extra    {:images images}}))
   images)
 
@@ -441,26 +455,25 @@
 ;; pool), same unconditional frame-boundary capability check.
 
 (defn- resolve-generation!
-  "Validate `images` (must be a vector — EP-0023 §Image Composition), assemble it
-  into ONE sealed generation (against the live source store when `descriptors` is
-  nil, else against the explicit pool — matching `assemble`'s two arities), and
-  run the FRAME-BOUNDARY capability check against `capabilities` (unconditional:
-  an absent map provides nothing, EP-0013 fail-loud parity). Returns the sealed
-  generation. The shared resolution `make-frame` and `reload-images!` both use,
-  so a reload resolves with byte-identical semantics to creation. Fail-loud on a
-  non-vector `:images`, an assembly error, or a missing capability.
+  "Validate `images` (must be a NON-EMPTY vector — EP-0026 §Default Image,
+  `:images []` is an error) and assemble it into ONE sealed generation (against
+  the live source store when `descriptors` is nil, else against the explicit
+  pool — matching `assemble`'s two arities), then run the FRAME-BOUNDARY
+  capability check against `capabilities` (unconditional: an absent map provides
+  nothing, EP-0013 fail-loud parity). Returns the sealed generation. The shared
+  resolution `make-frame` and `reload-images!` both use, so a reload resolves with
+  byte-identical semantics to creation. Fail-loud on a non-vector / EMPTY
+  `:images`, an assembly error, or a missing capability.
 
-  An ABSENT or EMPTY `:images` is the DEFAULT-IMAGE path (EP-0023 §Default Image
-  Semantics): nil `images` normalizes to `[]`, and `assemble` routes an empty
-  `:images` vector through `assemble-default` — the implicit selector over the
-  WHOLE source store (+ the framework standards), NOT the framework standards
-  alone. So a frame created with no explicit images runs every `reg-*`-authored
-  descriptor in the (live or supplied) source store, and a cross-namespace
-  same-`[kind id]` collision in that default projection FAILS LOUD here at
-  make-frame time (`:rf.error/image-duplicate-id`) exactly as an explicit
-  image's collision does — load order never silently decides the survivor."
+  Note: this is only called when `images` is PRESENT (make-frame) or supplied to
+  reload / reprojection — the OMIT-`:images` default-image boundary wiring is
+  deferred (see `make-frame`), so `images` here is always a real composition. A
+  reprojected default-image frame carries `[default-image]` (a non-empty marker
+  vector) on its `:rf.gen/images`, so reprojection still resolves cleanly. A
+  cross-namespace same-`[kind id]` collision in the resolved generation FAILS
+  LOUD (`:rf.error/image-duplicate-id`)."
   [images capabilities descriptors]
-  (let [images     (if (some? images) (validate-images! images) [])
+  (let [images     (validate-images! images)
         generation (if (nil? descriptors)
                      (asm/assemble images)
                      (asm/assemble images descriptors))]
@@ -487,16 +500,22 @@
   `:rf.error/make-frame-bad-opts`; the all-defaults frame is `(make-frame {})`).
   The IMAGE-SELECTION + value opts the constructor consumes:
 
-    :images        a VECTOR of image values (the ONLY spelling; always a vector,
-                   even for a single image). Resolved into ONE sealed image
-                   generation via `re-frame.image-assembly/assemble`; a
-                   non-vector `:images` fails loud
-                   (`:rf.error/make-frame-bad-images`). Optional — a frame with
-                   NO `:images` (absent or `[]`) carries no generation and runs
-                   on the shared registrar (an ordinary configured frame); a
-                   frame with `[]` runs the DEFAULT IMAGE (the implicit selector
-                   over the WHOLE source store), failing loud on a cross-namespace
-                   same-`[kind id]` collision (`:rf.error/image-duplicate-id`).
+    :images        a NON-EMPTY VECTOR of image values (the ONLY spelling; always
+                   a vector, even for a single image). Resolved into ONE sealed
+                   image generation via `re-frame.image-assembly/assemble`; a
+                   non-vector OR an EMPTY `:images []` fails loud
+                   (`:rf.error/make-frame-bad-images`). EP-0026 (ruled
+                   2026-06-22): `:images []` is an error — pass at least one
+                   image, or OMIT `:images`. OPTIONAL — an ABSENT `:images`
+                   currently carries NO generation (an ordinary configured frame
+                   on the shared registrar); the EP-0026 ruling that omitting
+                   `:images` should resolve the DEFAULT IMAGE is a DEFERRED
+                   boundary-wiring follow-up (a design-level conflict with the
+                   Story player / owned-frame lifecycle, which deliberately
+                   create image-less registrar-backed frames). A NON-EMPTY
+                   `:images` resolves the selected generation, failing loud on a
+                   cross-namespace same-`[kind id]` collision
+                   (`:rf.error/image-duplicate-id`).
     :id            the frame id (optional). When supplied, the frame is
                    registered under this id in the ONE `frames` registry;
                    re-`make-frame`-ing the same id is IDEMPOTENT REPLACEMENT —
@@ -564,9 +583,20 @@
          runnable-id (if (some? id) id (frame/anon-frame-id))
          ;; Resolve the generation FIRST so a bad `:images` / missing capability
          ;; fails loud BEFORE any record is created — a conflict leaves no
-         ;; half-created frame. An absent `:images` carries no generation (an
-         ;; ordinary configured frame); an explicit / empty `:images` resolves the
-         ;; (default or selected) generation.
+         ;; half-created frame.
+         ;;
+         ;; EP-0026 §Default Image (ruled 2026-06-22) ALSO says OMITTING `:images`
+         ;; (`make-frame {}`) should resolve the DEFAULT image generation. That
+         ;; OMIT→default BOUNDARY WIRING is DEFERRED (rf2-fsd822 surfaced a
+         ;; design-level conflict: the Story player and owned-frame lifecycle
+         ;; deliberately create image-LESS frames that resolve against the shared
+         ;; registrar — "absence-is-default" — and the consolidated test bundle's
+         ;; shared source store carries cross-app `[kind id]` collisions a
+         ;; whole-store default projection fails on). So for now an ABSENT `:images`
+         ;; still carries NO generation (the EP-0023/EP-0024 ordinary configured
+         ;; frame); a PRESENT `:images` must be a NON-EMPTY vector — `:images []`
+         ;; is an error (`validate-images!`) — and resolves the SELECTED generation.
+         ;; The OMIT→default boundary is tracked as follow-up bead rf2-59orj0.
          generation  (when (some? images)
                        (resolve-generation! images capabilities descriptors))
          ;; Everything outside the image-selection/value keys is record-config
@@ -580,8 +610,9 @@
          ;; through to reg-frame's fail-loud guard). We thread two reserved
          ;; construction inputs through the config:
          ;;   :rf.frame/generation   — the resolved generation (nil ⇒ ordinary
-         ;;                            configured frame; cleared on a re-make that
-         ;;                            drops `:images`). reg-frame seats it into
+         ;;                            configured frame when `:images` is absent;
+         ;;                            the EP-0026 omit→default boundary is a
+         ;;                            deferred follow-up). reg-frame seats it into
          ;;                            the `:generation` slot and strips it from
          ;;                            the stored config. Installed BEFORE the
          ;;                            `:initial-events` setup runs, so a setup

--- a/implementation/core/test/re_frame/ep0026_inline_grammar_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0026_inline_grammar_cljs_test.cljc
@@ -1,0 +1,219 @@
+(ns re-frame.ep0026-inline-grammar-cljs-test
+  "EP-0026 §Inline Registration Grammar (rf2-fsd822) — the NARROWED inline
+  `:registrations` grammar.
+
+  EP-0026 narrows inline `:registrations` to EXACTLY the four kinds with a
+  concrete inline parser + a published late-bind lowering hook:
+
+    | section     | kind   | body                                   |
+    | :reg-event  | :event | event handler `(fn [cofx event] …)`    |
+    | :reg-sub    | :sub   | layer-1 db-reader `(fn [db query] …)`  |
+    | :reg-fx     | :fx    | effect handler `(fn [args] …)`         |
+    | :reg-cofx   | :cofx  | coeffect supplier `(fn [] …)`          |
+
+  Every OTHER kind (interceptors, views, frames, routes, heads, error-projectors,
+  flows, resources, mutations, resource-scopes) is REJECTED with the
+  unsupported-inline-kind diagnostic until its owning spec defines an inline
+  lowering.
+
+  This suite pins the bead's enumerated coverage:
+
+    * each supported inline kind LOWERS through its kind's OWN registrar parser
+      (the LIVE `:image/lower-inline-<kind>` publisher, exercised through
+      `image-assembly/lower-inline-descriptor`), so the inline contract is
+      exactly the registrar's contract;
+    * per-kind metadata/body pins: inline `:reg-sub` is the layer-1 `:input-kind
+      :db` db-reader ONLY (`:input-signals []`); inline `:reg-cofx` carries the
+      coeffect's `:recordable?` / `:provided?` grade exactly as `reg-cofx` does;
+      inline `:reg-event` parses `:rf.cofx/requires` into
+      `:rf.cofx/requires-parsed`;
+    * an UNSUPPORTED inline kind fails loud at `rf/image`;
+    * a metadata-only `[id metadata]` 2-tuple fails loud (EP-0026 retires the
+      EP-0023 metadata-only form).
+
+  Dual-runtime (`-cljs-test` rides `npm run test:cljs`; cognitect-test-runner
+  discovers the `.cljc` on the JVM). The four core kind namespaces are required
+  so their `:image/lower-inline-<kind>` publishers are installed (they
+  `set-fn!` at ns load); no adapter/runtime state, so no reset fixture."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.image          :as image]
+            [re-frame.image-assembly :as asm]
+            ;; Required so the late-bind lowering publishers are installed:
+            ;; each ns calls (late-bind/set-fn! :image/lower-inline-<kind> …) at
+            ;; load. image-assembly cannot static-require them (a cycle), so the
+            ;; test requires them directly to exercise the LIVE lowering.
+            [re-frame.events]
+            [re-frame.subs]
+            [re-frame.fx]
+            [re-frame.cofx]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers — build an anonymous inline image, then run the LIVE assembly-side
+;; inline lowering over its inline descriptors so the lowered runnable shape is
+;; the one a frame would actually run.
+;; ---------------------------------------------------------------------------
+
+(defn- inline-descriptors
+  "The image's lowered-by-`rf/image` inline descriptors (pre-assembly: `:impl`
+  body + provenance, no runnable slots yet)."
+  [registrations]
+  (:rf.image/inline (image/image {:id :ep0026/inline :registrations registrations})))
+
+(defn- runnable
+  "Run the LIVE assembly-side inline lowering over the single inline descriptor
+  the `registrations` map produces, returning the runnable descriptor a frame
+  resolves — `:impl` + the kind's published `:image/lower-inline-<kind>` slots."
+  [registrations]
+  (-> registrations inline-descriptors first asm/lower-inline-descriptor))
+
+(defn- invalid-image-id
+  "Run `thunk`; return the thrown ex-info's `:rf.error/id` (or nil)."
+  [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (:rf.error/id (ex-data e)))))
+
+;; ===========================================================================
+;; 1. Each supported inline kind lowers through its OWN registrar parser
+;;    (the LIVE late-bind publisher), pinned against the live runnable shape.
+;; ===========================================================================
+
+(deftest inline-event-lowers-to-the-runnable-event-shape
+  (testing "inline :reg-event lowers via the LIVE :image/lower-inline-event into
+            the runnable handler shape: :handler-fn + the :interceptors chain
+            whose tail is the :rf/event-handler wrapper (the same slots
+            register-event! installs)"
+    (let [body (fn [{:keys [db]} _] {:db db})
+          d    (runnable {:reg-event [[:counter/inc body]]})]
+      (is (= :event (:kind d)))
+      (is (= :counter/inc (:id d)))
+      (is (= body (:impl d)) "the raw body is preserved under :impl")
+      (is (fn? (:handler-fn d)) "lowering installs a runnable :handler-fn")
+      (is (vector? (:interceptors d)) "lowering installs the interceptors chain")
+      (is (some :rf/default? (:interceptors d))
+          "the chain carries the framework :rf/event-handler wrapper"))))
+
+(deftest inline-event-parses-cofx-requires-metadata
+  (testing "inline :reg-event with :rf.cofx/requires metadata parses it into the
+            top-level :rf.cofx/requires-parsed slot the satisfaction step reads
+            (mirroring register-event!) — pinned against the live lowering"
+    (let [body (fn [_ _] {})
+          d    (runnable {:reg-event [[:needs/cofx
+                                       {:rf.cofx/requires [:rf.cofx/now]}
+                                       body]]})]
+      (is (= :event (:kind d)))
+      (is (= {:rf.cofx/requires [:rf.cofx/now]} (:metadata d)))
+      (is (seq (:rf.cofx/requires-parsed d))
+          "declared cofx requirements are parsed onto the runnable descriptor")
+      (is (= :rf.cofx/now (:id (first (:rf.cofx/requires-parsed d))))))))
+
+(deftest inline-sub-lowers-to-layer-1-db-reader-only
+  (testing "inline :reg-sub lowers via the LIVE :image/lower-inline-sub into the
+            layer-1 db-reader shape ONLY — :input-kind :db + EMPTY :input-signals
+            (a static :<- / parametric input-fn sub is NOT expressible inline and
+            stays namespace-authored)"
+    (let [body (fn [db _] (:counter/value db))
+          d    (runnable {:reg-sub [[:counter/value body]]})]
+      (is (= :sub (:kind d)))
+      (is (= :counter/value (:id d)))
+      (is (= body (:impl d)))
+      (is (= body (:handler-fn d)) "the db-reader is the runnable :handler-fn")
+      (is (= :db (:input-kind d)) "inline subs are layer-1 db-readers ONLY")
+      (is (= [] (:input-signals d)) "a layer-1 db-reader has no input signals"))))
+
+(deftest inline-fx-lowers-to-the-runnable-fx-slot
+  (testing "inline :reg-fx lowers via the LIVE :image/lower-inline-fx into the
+            runnable fx slot (:handler-fn) the fx-walker reads"
+    (let [body (fn [_args] nil)
+          d    (runnable {:reg-fx [[:metrics/send body]]})]
+      (is (= :fx (:kind d)))
+      (is (= :metrics/send (:id d)))
+      (is (= body (:impl d)))
+      (is (= body (:handler-fn d))))))
+
+(deftest inline-cofx-lowers-carrying-its-grade
+  (testing "inline :reg-cofx lowers via the LIVE :image/lower-inline-cofx into
+            the runnable supplier slot PLUS the :recordable? / :provided? grade
+            flags delivery reads — exactly as reg-cofx installs them"
+    (testing "an ordinary supplier coeffect (default grade)"
+      (let [body (fn [] 42)
+            d    (runnable {:reg-cofx [[:clock/now body]]})]
+        (is (= :cofx (:kind d)))
+        (is (= :clock/now (:id d)))
+        (is (= body (:handler-fn d)))
+        (is (= false (:recordable? d)))
+        (is (= false (:provided? d)))))
+    (testing "the grade is carried from the inline metadata (recordable / provided)"
+      (let [body (fn [] :v)
+            d    (runnable {:reg-cofx [[:graded/cofx
+                                        {:recordable? true :provided? true}
+                                        body]]})]
+        (is (= true (:recordable? d)))
+        (is (= true (:provided? d)))))))
+
+;; ===========================================================================
+;; 2. UNSUPPORTED inline kinds fail loud (every kind without a published
+;;    inline lowering).
+;; ===========================================================================
+
+(deftest unsupported-inline-kinds-fail-loud
+  (testing "an inline section for a kind EP-0026 does not standardize fails loud
+            at rf/image with :rf.error/invalid-image (the unsupported-inline-kind
+            diagnostic) — those kinds stay namespace-authored"
+    (doseq [section [:reg-interceptor :reg-view :reg-frame :reg-route :reg-head
+                     :reg-error-projector :reg-flow :reg-resource :reg-mutation
+                     :reg-resource-scope]]
+      (is (= :rf.error/invalid-image
+             (invalid-image-id #(image/image {:registrations {section [[:x (fn [] nil)]]}})))
+          (str section " must be rejected as an unsupported inline kind"))))
+  (testing "a typo'd / unknown section key is likewise rejected"
+    (is (= :rf.error/invalid-image
+           (invalid-image-id #(image/image {:registrations {:reg-bogus [[:x (fn [] nil)]]}})))))
+  (testing "the diagnostic names the unsupported section and the four supported ones"
+    (let [data (try (image/image {:id :bad/img
+                                  :registrations {:reg-view [[:x (fn [] nil)]]}})
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                      (ex-data e)))]
+      (is (= :rf.error/invalid-image (:rf.error/id data)))
+      (is (= :reg-view (:unsupported-section data)))
+      (is (= [:reg-cofx :reg-event :reg-fx :reg-sub] (:supported-sections data))))))
+
+;; ===========================================================================
+;; 3. The metadata-only [id metadata] form is RETIRED (EP-0026 reverses EP-0023).
+;; ===========================================================================
+
+(deftest metadata-only-tuple-rejected
+  (testing "a 2-tuple [id metadata-map] (the retired metadata-only form) fails
+            loud — a 2-tuple's second slot is the handler BODY, not metadata"
+    (doseq [section [:reg-event :reg-sub :reg-fx :reg-cofx]]
+      (is (= :rf.error/invalid-image
+             (invalid-image-id #(image/image {:registrations {section [[:x {:doc "meta only"}]]}})))
+          (str section " metadata-only 2-tuple must be rejected"))))
+  (testing "a 3-tuple [id metadata body] is the way to attach metadata"
+    (let [body (fn [_ _] {})
+          d    (runnable {:reg-event [[:x {:doc "ok"} body]]})]
+      (is (= {:doc "ok"} (:metadata d)))
+      (is (= body (:impl d))))))
+
+;; ===========================================================================
+;; 4. The two grammars compose: a single image carrying all four supported kinds
+;;    lowers each correctly (the EP §Use Case 2 teaching shape).
+;; ===========================================================================
+
+(deftest all-four-kinds-compose-in-one-image
+  (testing "an image defining all four supported kinds inline lowers each into
+            its runnable shape (the EP-0026 §Use Case 2 self-contained image)"
+    (let [v   (image/image
+                {:id :quickstart/counter
+                 :registrations
+                 {:reg-event [[:counter/inc (fn [{:keys [db]} _] {:db db})]]
+                  :reg-sub   [[:counter/value (fn [db _] (:counter/value db))]]
+                  :reg-fx    [[:metrics/send (fn [_] nil)]]
+                  :reg-cofx  [[:clock/now (fn [] 0)]]}})
+          ds  (mapv asm/lower-inline-descriptor (:rf.image/inline v))
+          by  (into {} (map (juxt (juxt :kind :id) identity)) ds)]
+      (is (= 4 (count ds)))
+      (is (fn? (:handler-fn (by [:event :counter/inc]))))
+      (is (= :db (:input-kind (by [:sub :counter/value]))))
+      (is (fn? (:handler-fn (by [:fx :metrics/send]))))
+      (is (contains? (by [:cofx :clock/now]) :recordable?)))))

--- a/implementation/core/test/re_frame/image_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_cljs_test.cljc
@@ -399,15 +399,27 @@
     (testing "inline descriptors carry NO :rf.provenance/ns (not glob-selectable)"
       (is (not (contains? (by-id :counter/inc) :rf.provenance/ns))))))
 
-(deftest inline-metadata-only-entry
-  (testing "a [id metadata] tuple lowers without an :impl"
-    (let [v (image/image {:id :m
-                          :registrations {:reg-fx [[:my/fx {:doc "meta only"}]]}})
-          d (first (:rf.image/inline v))]
-      (is (= :fx (:kind d)))
-      (is (= :my/fx (:id d)))
-      (is (not (contains? d :impl)))
-      (is (= {:doc "meta only"} (:metadata d))))))
+;; EP-0026 §Inline Registration Grammar — the EP-0023 metadata-only [id metadata]
+;; tuple is RETIRED (fsd822). A 2-tuple's second slot is the handler BODY, not
+;; metadata; for the four supported inline kinds the body is a FUNCTION, so a map
+;; in the body slot is unambiguously the retired metadata-only form and fails
+;; loud. To attach metadata, use the 3-tuple [id metadata body].
+(deftest inline-metadata-only-entry-rejected
+  (testing "a [id metadata-map] 2-tuple (the retired metadata-only form) throws
+            :rf.error/invalid-image"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :m
+                                        :registrations {:reg-fx [[:my/fx {:doc "meta only"}]]}}))))
+  (testing "the diagnostic names the image, section, and offending metadata-only entry"
+    (let [entry [:my/fx {:doc "meta only"}]
+          data  (try (image/image {:id :m :registrations {:reg-fx [entry]}})
+                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                       (ex-data e)))]
+      (is (= :rf.error/invalid-image (:rf.error/id data)))
+      (is (= :m (:image data)))
+      (is (= :reg-fx (:section data)))
+      (is (= entry (:entry data))))))
 
 (deftest inline-rejects-unknown-section-and-malformed-entry
   (testing "unknown inline section key throws :rf.error/invalid-image"
@@ -419,14 +431,15 @@
                           #"\[:rf\.error/invalid-image\]"
                           (image/image {:registrations {:reg-event [:not-a-tuple]}})))))
 
-;; rf2-32siq3.18 — inline tuple ARITY is exact. EP-0023 §Image Fragments admits
-;; only [id metadata body] (handler) and [id metadata] (metadata-only). [id],
-;; [], non-vectors, and 4+-tuples fail loud at rf/image rather than being
-;; coerced (a [id] silently treated as nil-metadata, a [id meta body extra]
-;; silently dropping the extra slot).
+;; EP-0026 §Inline Registration Grammar (fsd822) — inline tuple ARITY is exact:
+;; [id body] (metadata defaults to {}) and [id metadata body] (explicit
+;; metadata). EVERY inline registration carries a body. [id], [], non-vectors,
+;; and 4+-tuples fail loud at rf/image rather than being coerced. The EP-0023
+;; metadata-only [id metadata] form is retired (see
+;; inline-metadata-only-entry-rejected).
 
 (deftest inline-accepts-exactly-two-and-three-tuples
-  (testing "a 3-tuple [id metadata body] is accepted (handler)"
+  (testing "a 3-tuple [id metadata body] is accepted (explicit metadata)"
     (let [body (fn [_ _] {})
           v    (image/image {:id :i
                              :registrations {:reg-event [[:counter/inc {:doc "x"} body]]}})
@@ -434,12 +447,14 @@
       (is (= :counter/inc (:id d)))
       (is (= body (:impl d)))
       (is (= {:doc "x"} (:metadata d)))))
-  (testing "a 2-tuple [id metadata] is accepted (metadata-only)"
-    (let [v (image/image {:id :i :registrations {:reg-fx [[:my/fx {:doc "y"}]]}})
-          d (first (:rf.image/inline v))]
+  (testing "a 2-tuple [id body] is accepted (metadata defaults to {} / omitted)"
+    (let [body (fn [_] nil)
+          v    (image/image {:id :i :registrations {:reg-fx [[:my/fx body]]}})
+          d    (first (:rf.image/inline v))]
       (is (= :my/fx (:id d)))
-      (is (not (contains? d :impl)))
-      (is (= {:doc "y"} (:metadata d))))))
+      (is (= body (:impl d)))
+      (is (not (contains? d :metadata))
+          "an omitted metadata map is not stamped onto the descriptor"))))
 
 (deftest inline-rejects-too-short-tuple
   (testing "a 1-tuple [id] (no metadata slot) throws :rf.error/invalid-image"

--- a/implementation/core/test/re_frame/live_frame_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_cljs_test.cljc
@@ -176,105 +176,56 @@
       (is (some? (asm/resolve-descriptor gen :event :counter/inc))))))
 
 ;; ===========================================================================
-;; 1b. The EMPTY-`:images` path (`:images []`) runs the DEFAULT IMAGE — the
-;;     implicit whole-store projection (EP-0023 §Default Image Semantics,
-;;     rf2-32siq3.33), NOT the framework standard set alone. EP-0024
-;;     (rf2-tu2vr7): only an EXPLICIT `:images` key triggers image resolution —
-;;     an ABSENT `:images` is an ordinary configured frame on the shared
-;;     registrar (no generation), so the default-image path is keyed by `[]`.
-;;     Both the explicit-pool 2-arity and the bare live-store 1-arity are
-;;     covered; a cross-namespace collision in the default fails loud at
-;;     make-frame time.
+;; 1b. EP-0026 §Default Image (rf2-fsd822, ruled 2026-06-22): `:images []` is an
+;;     ERROR (`:rf.error/make-frame-bad-images`) — pass at least one image, or
+;;     OMIT `:images`. This REVERSES EP-0023/EP-0024, where `:images []` was the
+;;     default-image path.
+;;
+;;     The ruling ALSO says OMITTING `:images` (`make-frame {}`) should resolve
+;;     the DEFAULT image generation. That OMIT→default BOUNDARY WIRING is
+;;     DEFERRED to a follow-up (a design-level conflict with the Story player /
+;;     owned-frame lifecycle, which deliberately create image-LESS registrar-
+;;     backed frames, plus the consolidated test bundle's shared source store
+;;     carrying cross-app collisions a whole-store default projection fails on).
+;;     So for now an ABSENT `:images` still carries NO generation (the EP-0023/
+;;     EP-0024 ordinary configured frame). The assembly-layer default-image
+;;     mechanics are unchanged and covered by `image-assembly-default-cljs-test`.
 ;; ===========================================================================
 
-(deftest empty-images-runs-the-default-image-over-the-explicit-pool
-  (testing "make-frame with :images [] (and an explicit descriptor pool) runs the
-            DEFAULT image — the implicit selector over the WHOLE pool — so the
-            frame's generation INCLUDES a reg-*'d descriptor from the store, not
-            just the framework standards"
-    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
-    (let [frame (lf/make-frame {:images []} counter-pool)
-          gen   (lf/frame-generation frame)]
+(deftest empty-images-vector-is-an-error
+  (testing "EP-0026 §Default Image (ruled 2026-06-22): :images [] is an ERROR —
+            pass at least one image, or OMIT :images. This reverses EP-0023/
+            EP-0024, where :images [] projected the default."
+    (testing ":images [] fails loud with :rf.error/make-frame-bad-images"
+      (is (= :rf.error/make-frame-bad-images
+             (err-id #(lf/make-frame {:images []} counter-pool))))
+      (testing "and via the bare 1-arity too"
+        (is (= :rf.error/make-frame-bad-images
+               (err-id #(lf/make-frame {:images []}))))))
+    (testing "no frame is registered as a side effect of the rejected :images []"
+      (let [before (lf/live-frame-ids)]
+        (err-id #(lf/make-frame {:id :rejected/empty :images []} counter-pool))
+        (is (= before (lf/live-frame-ids))
+            "a rejected :images [] leaves the live-frame registry untouched")))
+    (testing "a NON-EMPTY :images vector is accepted and resolves a generation"
+      (let [frame (lf/make-frame {:images [(image/image {:id :only
+                                                         :registrations
+                                                         {:reg-event [[:x (fn [_ _] {})]]}})]}
+                                 counter-pool)]
+        (is (lf/frame-object? frame))
+        (is (some? (asm/resolve-descriptor (lf/frame-generation frame) :event :x)))))))
+
+(deftest absent-images-currently-carries-no-generation-omit-default-deferred
+  (testing "EP-0026 omit→default boundary wiring is DEFERRED (rf2-fsd822): an
+            ABSENT :images (make-frame {}) currently carries NO generation — the
+            EP-0023/EP-0024 ordinary configured frame on the shared registrar —
+            rather than resolving the default image. (Tracked as a follow-up
+            decision bead rf2-59orj0; the assembly-layer default mechanics are
+            already in place and exercised by image-assembly-default-cljs-test.)"
+    (let [frame (lf/make-frame {} counter-pool)]
       (is (lf/frame-object? frame))
-      (is (some? gen))
-      (testing "the whole-pool reg-* descriptors are projected (default image,
-                NOT standards-only)"
-        (is (some? (asm/resolve-descriptor gen :event :counter/inc))
-            "a reg-*'d descriptor from the source pool is in the default generation")
-        (is (= ::inc (:handler-fn (asm/resolve-descriptor gen :event :counter/inc))))
-        (is (some? (asm/resolve-descriptor gen :sub :counter/value))))
-      (testing "the framework standard is also unioned in (default = pool + standards)"
-        (is (some? (asm/resolve-descriptor gen :fx :rf.nav/push-url)))))))
-
-(deftest empty-images-vector-runs-default-but-absent-images-carries-no-generation
-  (testing "EP-0024 (rf2-tu2vr7): only an EXPLICIT :images key triggers image
-            resolution. :images [] is the default-image path (the implicit
-            whole-store selector ⇒ a generation), but an ABSENT :images key is an
-            ordinary configured frame on the shared registrar — NO generation"
-    (testing ":images [] resolves the whole-store default (a generation)"
-      (let [frame (lf/make-frame {:images []} counter-pool)
-            gen   (lf/frame-generation frame)]
-        (is (lf/frame-object? frame))
-        (is (some? (asm/resolve-descriptor gen :event :counter/inc))
-            "an empty :images vector projects the whole-store default, not standards-only")))
-    (testing "an ABSENT :images key carries NO generation (ordinary configured
-              frame — the resolution falls through to the shared registrar)"
-      (let [frame (lf/make-frame {} counter-pool)]
-        (is (lf/frame-object? frame))
-        (is (nil? (lf/frame-generation frame))
-            "no :images key ⇒ no image-loaded generation on the record")))))
-
-(deftest empty-images-default-cross-namespace-collision-fails-loud
-  (testing "a cross-namespace same-(kind, id) collision in the DEFAULT projection
-            makes make-frame FAIL LOUD (:rf.error/image-duplicate-id) — the
-            :images [] default does not guess and does not let load order win"
-    (let [colliding-pool
-          [(reg-desc "examples.todo.boot"    :event :boot/init ::todo-boot)
-           (reg-desc "examples.counter.boot" :event :boot/init ::counter-boot)]]
-      (is (= :rf.error/image-duplicate-id
-             (err-id #(lf/make-frame {:images []} colliding-pool))))
-      (testing "the collision fires regardless of pool order (no last-write-wins)"
-        (is (= :rf.error/image-duplicate-id
-               (err-id #(lf/make-frame {:images []} (vec (reverse colliding-pool))))))))))
-
-(deftest bare-make-frame-runs-the-default-image-over-the-live-store
-  (testing "the BARE 1-arity make-frame (no descriptor pool) resolves the DEFAULT
-            image against the LIVE source store, so a frame created with :images
-            [] runs every reg-*-authored registration in the store"
-    ;; Drive from a known-clean live store inside a snapshot/restore body so the
-    ;; default projection is deterministic; the fixture also restores the store.
-    (let [store-before @ss/kind->id->ns->descriptor]
-      (try
-        (reset! ss/kind->id->ns->descriptor {})
-        (asm/clear-generation-cache!)
-        (record! "shop.cart" :event :cart/add   ::cart-add)
-        (record! "shop.cart" :sub   :cart/items ::cart-items)
-        (let [frame (lf/make-frame {:images []})
-              gen   (lf/frame-generation frame)]
-          (is (lf/frame-object? frame))
-          (is (some? (asm/resolve-descriptor gen :event :cart/add))
-              "the bare make-frame default projection includes the live-store reg-*")
-          (is (= ::cart-add (:handler-fn (asm/resolve-descriptor gen :event :cart/add))))
-          (is (some? (asm/resolve-descriptor gen :sub :cart/items))))
-        (finally
-          (reset! ss/kind->id->ns->descriptor store-before)
-          (asm/clear-generation-cache!))))))
-
-(deftest bare-make-frame-default-live-store-collision-fails-loud
-  (testing "the BARE 1-arity make-frame fails loud (:rf.error/image-duplicate-id)
-            when the LIVE source store carries a cross-namespace same-(kind, id)
-            collision in the default projection"
-    (let [store-before @ss/kind->id->ns->descriptor]
-      (try
-        (reset! ss/kind->id->ns->descriptor {})
-        (asm/clear-generation-cache!)
-        (record! "examples.todo.boot"    :event :boot/init ::todo-boot)
-        (record! "examples.counter.boot" :event :boot/init ::counter-boot)
-        (is (= :rf.error/image-duplicate-id
-               (err-id #(lf/make-frame {:images []}))))
-        (finally
-          (reset! ss/kind->id->ns->descriptor store-before)
-          (asm/clear-generation-cache!))))))
+      (is (nil? (lf/frame-generation frame))
+          "absent :images ⇒ no image-loaded generation on the record (deferred)"))))
 
 ;; ===========================================================================
 ;; 2. :id registers an image-loaded record in the ONE `frames` registry


### PR DESCRIPTION
EP-0026 serial lane STEP 2 (rf2-fsd822). Builds on the merged lead 6ls85a (:select-ns + image-order resolution).

## What changed

### Inline `:registrations` grammar (EP-0026 §Inline Registration Grammar)
- **Narrowed to 4 kinds** with a concrete parser + a published late-bind lowering hook: `:reg-event` / `:reg-sub` / `:reg-fx` / `:reg-cofx`. Every other kind (interceptors, views, frames, routes, heads, error-projectors, flows, resources, mutations, resource-scopes) — and any typo'd section — is **rejected fail-loud** with the unsupported-inline-kind diagnostic; those stay namespace-authored.
- **Outer tuple shape fixed** at `[id body]` / `[id metadata body]`. The EP-0023 metadata-only `[id metadata]` form is **retired**: a 2-tuple's second slot is the handler *body*, so for the four supported kinds (whose body is a function) a *map* in the body slot is unambiguously the retired metadata-only shape and fails loud.
- **Per-kind metadata/body pinned against the LIVE lowering** (`image/lower-inline-<kind>` publishers exercised through `image-assembly/lower-inline-descriptor`): inline `:reg-sub` is the **layer-1 `:input-kind :db` db-reader ONLY** (`:input-signals []`); inline `:reg-cofx` carries the `:recordable?` / `:provided?` **grade**; inline `:reg-event` parses `:rf.cofx/requires` into `:rf.cofx/requires-parsed`.
- `valid-kinds` (the `:replace` / `:replace-standard` key set) **decoupled** from the now-narrowed inline map so the inline narrowing does not leak into replacement-key validation (`:replace` retirement is dlvmpc).

### Default image (EP-0026 §Default Image, ruled 2026-06-22)
- **`:images []` is now an ERROR** (`:rf.error/make-frame-bad-images`) — pass at least one image, or omit `:images`. (Reverses EP-0023/EP-0024, where `:images []` projected the default.)
- The default-image **whole-store selection drops descriptors whose `[kind id]` is a framework standard** (the standard's own registrar shadow, e.g. `:rf/set-db`), so a default projection never fails `check-standard-collision!` against its own standard. (Correctness fix to the default-image-resolution mechanics; needed the moment omit→default lands.)

### DEFERRED — omit→default boundary wiring (rf2-59orj0)
The ruling also says omitting `:images` (`make-frame {}`) should resolve the **default image generation**. That **make-frame boundary wiring is deferred** to **rf2-59orj0**: it has a design-level conflict with the Story player (`tools/story/.../frames.cljc`) and the owned-frame lifecycle, which *deliberately* create image-less registrar-backed frames ("absence-is-default"), plus broad fallout — the consolidated CLJS `node-test` bundle's shared source store carries cross-app `[kind id]` collisions (e.g. `:rf.http/managed`, `:upload/main`) that a whole-store default projection fails on (32 failures / 6 errors across owned-frame / frame-initial-events / ep0023-conformance / two Story testbeds). Wiring it needs a Story-side design decision + a test-bundle source-store isolation decision. For now an **absent `:images` still carries no generation** (the EP-0023/EP-0024 ordinary configured frame); the EP's other parts land here.

Left to their own beads: old-key retirement (dlvmpc), shadow report (ke7w5j), spec graduation (o2vfrc), conformance (qp8qi8).

## Scope
Only `implementation/core/src/re_frame/{image,image_assembly,live_frame}.cljc` + their tests. No `spec/`, `tools/`, or `examples/` touched.

## Quality gates
- `npm run test:cljs` — **0 failures, 0 errors** (7991 tests)
- `npm run test:elision` — **PASS** (assembly-DCE + provenance-survives)
- core JVM `clojure -M:test` — **0 failures, 0 errors** (1713 tests)
- Worktree `node_modules` was absent — ran a fresh `npm install` in the worktree (the mayor tree's `node_modules` is empty, so a junction was useless).