### PR TITLE
feat(image): EP-0026 cross-image shadow report + rf/frame-shadows (rf2-ke7w5j)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1711,6 +1711,56 @@
   (-> (resolve-live-frame-object frame-target 'rf/frame-generation)
       (live-frame/frame-resolution-generation)))
 
+(defn frame-shadows
+  "Return the cross-image SHADOW REPORT for the image composition a live frame is
+  running (EP-0026 §Shadow Report, rf2-ke7w5j) — the data the programmer reads to
+  see exactly what a LATER image overrode in an EARLIER one. The public accessor
+  for the report a frame's resolved generation carries at `:rf.gen/shadows`.
+
+  `frame-target` is a REGISTERED frame id (keyword, looked up in the process-local
+  live-frame registry) OR a direct live frame VALUE (`rf/make-frame`'s return
+  value) — the same target shapes `rf/frame-generation` / `rf/reload-images!`
+  accept.
+
+  Returns a FLAT vector, one entry per cross-image shadow — three keys, nothing
+  else (no winner descriptor, image index, tier, source namespace, or scope tag):
+
+    [{:registration [kind id]    ;; the shadowed registration
+      :image        <defined-in> ;; the image id the LOSER was defined in
+      :shadowed-by  <winner>}    ;; the image id of the FINAL live winner
+     …]
+
+  An EMPTY vector when no later image shadowed an earlier one (the common
+  deliberate-no-override case — `(empty? (rf/frame-shadows frame))` asserts
+  nothing was overridden). For a shadow CHAIN — `[base override-a override-b]`
+  defining one `[kind id]` — every loser names the FINAL winner (`override-b`),
+  not the immediate predecessor, so an assertion never walks a chain. Every shadow
+  is cross-image (a within-image collision is an error, not a resolved winner), so
+  the two image ids name exactly one image each.
+
+  This is the EP-0026 model that REPLACED the retired `:replace` /
+  `:replace-standard` declared-winner keys: define the winner in a later image,
+  image order decides, and read this report to assert on (or log / ignore) what
+  each later image shadowed. A tool wanting fuller detail (source namespace, etc.)
+  reads the live registration's `:rf.provenance/*` via the `:frame` arity of
+  `rf/registrations` / `rf/handler-meta`.
+
+  FAILS LOUD (`:rf.error/frame-no-generation`) when `frame-target` does not
+  resolve to a live frame carrying a generation: NO nil-as-default, NO fallback to
+  the default/realm registrar — a shadow-report read needs a live EP-0023 frame
+  (the same contract as `rf/frame-generation`). Per Spec 002 §The public registrar
+  query API; EP-0026 §Shadow Report."
+  [frame-target]
+  ;; Resolve the live frame object FIRST (fail-loud on a non-live target, exactly
+  ;; like `rf/frame-generation`), then read the shadow report off its sealed
+  ;; generation. The `:rf.gen/shadows` key is read directly so the façade keeps
+  ;; its existing load edges (it requires `re-frame.live-frame`, not
+  ;; `re-frame.image-assembly`); `live-frame/frame-shadows` is the equivalent
+  ;; internal accessor.
+  (-> (resolve-live-frame-object frame-target 'rf/frame-shadows)
+      (live-frame/frame-resolution-generation)
+      (:rf.gen/shadows)))
+
 (defn registrations
   "Return all ids registered under `kind` with their metadata — the
   introspection workhorse used by tools, agents, and storybook resolution.

--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -20,10 +20,14 @@
 
       {:rf.gen/resolver  {[kind id] descriptor, …}   ;; the sealed [kind id] map
        :rf.gen/images    [<normalized image value> …]
-       :rf.gen/kinds     #{kind …}}                   ;; kinds present, for tools
+       :rf.gen/kinds     #{kind …}                    ;; kinds present, for tools
+       :rf.gen/shadows   [{:registration [kind id]    ;; the cross-image shadow
+                           :image        <defined-in> ;; report (EP-0026, rf2-ke7w5j)
+                           :shadowed-by  <winner>} …]}
 
   (EP-0026, rf2-dlvmpc, retired `:rf.gen/requires` with the image-capability
-  feature; the shadow report `:rf.gen/shadows` is rf2-ke7w5j.)
+  feature; the shadow report `:rf.gen/shadows` is rf2-ke7w5j — a flat list, one
+  entry per cross-image shadow, naming the loser image + the FINAL winner.)
 
   `:rf.gen/resolver` is the heart: a map from a `[kind id]` pair to exactly ONE
   descriptor. After selection + declared replacements the map is id-disjoint by
@@ -638,6 +642,86 @@
   [image-resolvers]
   (reduce merge {} image-resolvers))
 
+;; ---- the cross-image SHADOW REPORT (EP-0026 §Shadow Report, rf2-ke7w5j) ----
+;;
+;; When a later image shadows an earlier image's registration, composition
+;; RECORDS it. EP-0026 §Shadow Report fixes the entry at EXACTLY three keys —
+;; nothing else (no winner descriptor, image index, tier, source namespace, or
+;; scope tag):
+;;
+;;   {:registration [kind id]   ;; the shadowed registration's [kind id]
+;;    :image        <defined-in>;; the image id the LOSER was defined in
+;;    :shadowed-by  <winner>}   ;; the image id of the FINAL live winner
+;;
+;; Every shadow is CROSS-IMAGE — it names two DISTINCT images — because within
+;; one image a `[kind id]` collision is an ERROR rather than a resolved winner
+;; (resolve-within-image). There is no within-image case and no scope tag.
+;;
+;; CHAINS report the FINAL winner per loser (EP-0026 §Shadow Report). For one
+;; `[kind id]` defined in `[base override-a override-b]` (image order), the LAST
+;; image (`override-b`) is the live winner; BOTH earlier definitions are losers,
+;; and EACH is `:shadowed-by override-b` — the immediate predecessor is never
+;; named, so an assertion never has to walk a chain. Two earlier images both
+;; shadowed by the same later one is TWO entries.
+;;
+;; Images are named by their composition-unique id (check-unique-image-ids!), so
+;; the two ids name exactly one image each. The standard base is NOT part of app
+;; layer order and never appears here (an app shadowing a standard fails loud —
+;; check-standard-collision!).
+
+(defn shadow-report
+  "Build the cross-image SHADOW REPORT for an ordered seq of per-image
+  `[image-id resolver]` pairs (EP-0026 §Shadow Report, rf2-ke7w5j). Each
+  `resolver` is one image's id-disjoint `{[kind id] descriptor}` map; the pairs
+  are in `:images` ORDER (later wins). For every `[kind id]` defined in MORE
+  THAN ONE image, the LAST image is the live winner and every EARLIER image is a
+  loser; the report carries one flat entry per loser:
+
+    {:registration [kind id] :image <loser-image-id> :shadowed-by <winner-image-id>}
+
+  CHAINS name the FINAL winner for every loser (not the immediate predecessor),
+  so an assertion never walks a chain. A `[kind id]` defined in exactly one image
+  contributes no entry. Entries are ordered by registration `[kind id]` then by
+  the loser's image position, for a stable, deterministic report. Pure — a
+  function of the ordered per-image resolvers only.
+
+  Only CROSS-IMAGE shadows appear (a within-image collision is an error, not a
+  resolved winner — resolve-within-image), so there is no within-image case and
+  no scope tag. The protected framework-standard base is not part of app layer
+  order and never appears (an app shadowing a standard fails loud)."
+  [image-id+resolvers]
+  ;; For each [kind id], collect the ORDERED vector of image-ids that define it
+  ;; (image order). A [kind id] in >1 image is a shadow chain: the LAST id is the
+  ;; winner; every earlier id is a loser shadowed by that final winner.
+  (let [;; image-id -> position in :images order (the loser-ordering tie-break).
+        image-pos  (into {}
+                         (map-indexed (fn [i [image-id _]] [image-id i]))
+                         image-id+resolvers)
+        defined-in (reduce
+                     (fn [acc [image-id resolver]]
+                       (reduce-kv
+                         (fn [m k+id _descriptor]
+                           (update m k+id (fnil conj []) image-id))
+                         acc
+                         resolver))
+                     {}
+                     image-id+resolvers)]
+    (->> defined-in
+         (filter (fn [[_k+id image-ids]] (> (count image-ids) 1)))
+         (mapcat (fn [[k+id image-ids]]
+                   (let [winner (peek image-ids)]
+                     (for [loser (pop image-ids)]
+                       {:registration k+id
+                        :image        loser
+                        :shadowed-by  winner}))))
+         ;; Deterministic order: by registration [kind id] (printed form, so the
+         ;; [kind id] tuples sort portably across the JVM and JS), then by the
+         ;; loser's image position. The report is unordered data — this only makes
+         ;; it stable for diffs + tests.
+         (sort-by (juxt #(pr-str (:registration %))
+                        #(get image-pos (:image %))))
+         (vec))))
+
 ;; ---- reference validation (EP-0023 §Image Validation: \"event references
 ;;      missing interceptor / resource references missing scope resolver\") ----
 
@@ -860,6 +944,14 @@
         ;;     wins (the cross-image shadow is reported by rf2-ke7w5j, never
         ;;     failed). The result is the composed APP resolver.
         app-resolver  (layer-image-resolvers image-resolvers)
+        ;; (5b) Build the cross-image SHADOW REPORT from the ordered per-image
+        ;;      resolvers (EP-0026 §Shadow Report, rf2-ke7w5j): one flat entry
+        ;;      per shadowed [kind id], naming the loser image + the FINAL winner.
+        ;;      Pairs image ids with their resolvers in :images order.
+        shadows       (shadow-report (map (fn [image resolver]
+                                            [(:rf.image/id image) resolver])
+                                          images
+                                          image-resolvers))
         ;; (6) Framework standards are PROTECTED: an app [kind id] colliding with
         ;;     a standard FAILS LOUD (standards are not in app layer order).
         standard-resolver (into {} (map (fn [d] [(descriptor-kind+id d) d])) standard)
@@ -872,7 +964,8 @@
     ;; (9) Seal.
     {:rf.gen/resolver resolver
      :rf.gen/images   images
-     :rf.gen/kinds    (into #{} (map first) (keys resolver))}))
+     :rf.gen/kinds    (into #{} (map first) (keys resolver))
+     :rf.gen/shadows  shadows}))
 
 ;; ===========================================================================
 ;; Resolved-generation cache (EP-0023 §Image — "The reference implementation
@@ -1175,3 +1268,13 @@
   "The set of kinds present in a sealed `generation`'s resolver. Tools use this."
   [generation]
   (:rf.gen/kinds generation))
+
+(defn generation-shadows
+  "The cross-image SHADOW REPORT carried on a sealed `generation` (EP-0026
+  §Shadow Report, rf2-ke7w5j) — the flat `[{:registration [kind id] :image
+  <defined-in> :shadowed-by <winner>}]` list, one entry per cross-image shadow,
+  naming the loser image + the FINAL winner. An empty vector when no later image
+  shadowed an earlier one (the common deliberate-no-override case). The public
+  `rf/frame-shadows` accessor + the `reload-images!` report read this. Pure."
+  [generation]
+  (:rf.gen/shadows generation))

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -190,6 +190,19 @@
   [frame-target]
   (frame/frame-generation (frame/frame-value->id frame-target)))
 
+(defn frame-shadows
+  "The cross-image SHADOW REPORT for the image composition a frame target is
+  running (EP-0026 §Shadow Report, rf2-ke7w5j). The flat `[{:registration
+  [kind id] :image <defined-in> :shadowed-by <winner>}]` list a frame's resolved
+  generation carries at `:rf.gen/shadows` — one entry per cross-image shadow,
+  naming the loser image + the FINAL winner. Accepts a frame VALUE or a frame id
+  (it reads the record's generation via `frame-generation`). An EMPTY vector when
+  the frame ran a composition with no cross-image overrides; nil when the target
+  names no image-loaded frame (an ordinary configured frame, or an
+  unknown/destroyed one). Pure."
+  [frame-target]
+  (some-> (frame-generation frame-target) (asm/generation-shadows)))
+
 (defn live-frame
   "Return the live frame VALUE for a frame id when that frame is currently
   IMAGE-LOADED (its `frames` record carries a resolved generation), or nil
@@ -747,9 +760,18 @@
 
   Returns the reload REPORT:
 
-    {:rf.frame/frame  <frame value for the reloaded frame>
-     :rf.reload/diff  {:added #{[kind id] …} :changed #{…}
-                       :removed #{…} :retained #{…}}}
+    {:rf.frame/frame   <frame value for the reloaded frame>
+     :rf.reload/diff   {:added #{[kind id] …} :changed #{…}
+                        :removed #{…} :retained #{…}}
+     :rf.reload/shadows [{:registration [kind id] :image <defined-in>
+                          :shadowed-by <winner>} …]}
+
+  `:rf.reload/shadows` is the NEW generation's cross-image SHADOW REPORT
+  (EP-0026 §Shadow Report, rf2-ke7w5j) — the flat list naming the loser image +
+  the FINAL winner for every cross-image override the reloaded composition
+  resolved (empty when none). It mirrors the `:rf.gen/shadows` the new generation
+  carries, so a hot reload that changes the override set surfaces it in the
+  report alongside the `[kind id]` diff.
 
   The generation lives on the ONE `frames` record, updated IN PLACE, so the id
   keeps naming the same live context (now running the new generation) and every
@@ -767,8 +789,9 @@
          old-generation (frame/frame-generation id)
          new-generation (resolve-generation! images descriptors)]
      (swap-frame-generation! id new-generation)
-     {:rf.frame/frame (frame/make-frame-value {:id id :runnable-id id})
-      :rf.reload/diff (generation-diff old-generation new-generation)})))
+     {:rf.frame/frame    (frame/make-frame-value {:id id :runnable-id id})
+      :rf.reload/diff    (generation-diff old-generation new-generation)
+      :rf.reload/shadows (asm/generation-shadows new-generation)})))
 
 ;; ===========================================================================
 ;; Source-store reprojection (EP-0023 §Default Image Semantics / §Hot Reload,

--- a/implementation/core/test/re_frame/ep0026_retirements_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0026_retirements_cljs_test.cljc
@@ -92,8 +92,9 @@
           "the image value no longer carries an :rf.image/requires slot"))))
 
 (deftest sealed-generation-carries-no-requires-slot
-  (testing "EP-0026 removed :rf.gen/requires — a sealed generation carries only
-            :rf.gen/resolver / :rf.gen/images / :rf.gen/kinds"
+  (testing "EP-0026 removed :rf.gen/requires — a sealed generation carries
+            :rf.gen/resolver / :rf.gen/images / :rf.gen/kinds (+ the additive
+            :rf.gen/shadows report, rf2-ke7w5j), but no :rf.gen/requires"
     (let [pool [{:rf.provenance/ns "a.b" :kind :event :id :foo/x :handler-fn (fn [_ _])}]
           img  (image/image {:id :app/main :select-ns {:include ["a.b"]}})
           gen  (asm/assemble [img] pool)]

--- a/implementation/core/test/re_frame/facade_frame_read_cljs_test.cljc
+++ b/implementation/core/test/re_frame/facade_frame_read_cljs_test.cljc
@@ -223,6 +223,62 @@
       (is (= (lf/frame-generation green-obj)      (rf/frame-generation green-obj))))))
 
 ;; ===========================================================================
+;; 3b. frame-shadows — the public cross-image SHADOW REPORT accessor (EP-0026
+;;     §Shadow Report, rf2-ke7w5j). Returns the flat [{:registration [kind id]
+;;     :image <defined-in> :shadowed-by <winner>}] list a frame's composition
+;;     resolved.
+;; ===========================================================================
+
+;; An override image composed AFTER blue-img: it re-defines blue's
+;; [:event :counter/inc] inline, so the composition shadows it (later wins).
+(def ^:private blue-override
+  (image/image {:id :blue/override
+                :registrations {:reg-event [[:counter/inc (fn [_ _] {})]]}}))
+
+(deftest frame-shadows-returns-the-report
+  (testing "rf/frame-shadows returns the cross-image SHADOW REPORT for the frame's
+            composition — one flat entry per override, naming the loser image + the
+            FINAL winner (rf2-ke7w5j)"
+    (let [_frame (rf/make-frame {:id :blue/main :images [blue-img blue-override]} blue-pool)]
+      (is (= [{:registration [:event :counter/inc]
+               :image        :blue/img
+               :shadowed-by  :blue/override}]
+             (rf/frame-shadows :blue/main))
+          "the override image shadowed blue's selected :counter/inc — reported by id")
+      (testing "the live winner is the override image's descriptor"
+        (let [m (rf/handler-meta {:frame :blue/main :kind :event :id :counter/inc})]
+          (is (not= ::blue-inc (:handler-fn m))
+              "blue's selected handler was shadowed by the later inline override"))))))
+
+(deftest frame-shadows-empty-when-no-override
+  (testing "a frame with no cross-image override returns an EMPTY report — the
+            common case (nothing was shadowed); reads via a direct frame OBJECT too"
+    (let [_named (rf/make-frame {:id :blue/main :images [blue-img]} blue-pool)
+          obj    (rf/make-frame {:images [green-img]} green-pool)]
+      (is (= [] (rf/frame-shadows :blue/main))
+          "no override image ⇒ empty shadow report")
+      ;; A no-id frame value resolves through its own generation.
+      (is (= [] (rf/frame-shadows obj))
+          "frame-shadows accepts a direct frame value, like frame-generation"))))
+
+(deftest frame-shadows-matches-the-generation-shadows
+  (testing "rf/frame-shadows is the :rf.gen/shadows the frame's sealed generation
+            carries — the public accessor reads the same data"
+    (let [_frame (rf/make-frame {:id :blue/main :images [blue-img blue-override]} blue-pool)
+          gen    (rf/frame-generation :blue/main)]
+      (is (= (:rf.gen/shadows gen) (rf/frame-shadows :blue/main)))
+      (is (contains? gen :rf.gen/shadows)
+          "the sealed generation carries the :rf.gen/shadows report key"))))
+
+(deftest frame-shadows-fails-loud-on-unresolvable-target
+  (testing "rf/frame-shadows fails loud (:rf.error/frame-no-generation) when the
+            target names no live frame — the same contract as rf/frame-generation"
+    (is (= :rf.error/frame-no-generation
+           (err-id #(rf/frame-shadows :nope/missing))))
+    (is (= :rf.error/frame-no-generation
+           (err-id #(rf/frame-shadows "not-a-frame"))))))
+
+;; ===========================================================================
 ;; 4. FAIL-LOUD — both ruled cases
 ;; ===========================================================================
 

--- a/implementation/core/test/re_frame/image_assembly_cache_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_assembly_cache_cljs_test.cljc
@@ -235,6 +235,57 @@
       (is (= 1 (asm/cache-size))))))
 
 ;; ===========================================================================
+;; 5b. rf2-ke7w5j — the resolved-generation cache key MUST include the
+;;     :select-ns SELECTION. Two images with the SAME id but a DIFFERENT
+;;     :select-ns (so a different selected descriptor set) are DIFFERENT
+;;     compositions and must NOT cache-collide. The :select-ns lowers to the
+;;     normalized :rf.image/include-ns / :rf.image/exclude-ns slots, which ride
+;;     the image VALUE — and the ordered image vector IS the key's image leg, so
+;;     a different selection is a different key by value.
+;; ===========================================================================
+
+(deftest select-ns-selection-is-part-of-the-key
+  (testing "two images differing ONLY in their :select-ns :include selection are
+            distinct compositions → distinct cache slots, distinct generations
+            (selection is part of the key — rf2-ke7w5j)"
+    (record! "shop.cart"  :event :cart/add  ::cart)
+    (record! "shop.admin" :event :admin/ban ::admin)
+    (let [img-cart  (image/image {:id :shop/main :select-ns {:include ["shop.cart"]}})
+          img-admin (image/image {:id :shop/main :select-ns {:include ["shop.admin"]}})
+          gen-cart  (asm/assemble [img-cart])
+          gen-admin (asm/assemble [img-admin])]
+      (is (not (identical? gen-cart gen-admin))
+          "a different :select-ns selection is a different key → no cache collision")
+      (is (contains? (:rf.gen/resolver gen-cart)  [:event :cart/add]))
+      (is (not (contains? (:rf.gen/resolver gen-cart) [:event :admin/ban]))
+          "the cart selection resolves ONLY the cart namespace")
+      (is (contains? (:rf.gen/resolver gen-admin) [:event :admin/ban]))
+      (is (not (contains? (:rf.gen/resolver gen-admin) [:event :cart/add]))
+          "the admin selection resolves ONLY the admin namespace")
+      (is (= 2 (asm/cache-size))
+          "two distinct selections occupy two cache slots"))))
+
+(deftest exclude-ns-selection-is-part-of-the-key
+  (testing "two images with the same :include but a DIFFERENT :exclude resolve
+            DIFFERENT descriptor sets → distinct cache slots (the exclude leg is
+            part of the selection key — rf2-ke7w5j)"
+    (record! "app.feature"     :event :feature/run ::run)
+    (record! "app.feature.dev" :event :dev/probe   ::probe)
+    (let [img-all (image/image {:id :app/main
+                                :select-ns {:include ["app.feature.**" "app.feature"]}})
+          img-prod (image/image {:id :app/main
+                                 :select-ns {:include ["app.feature.**" "app.feature"]
+                                             :exclude ["app.feature.dev.**" "app.feature.dev"]}})
+          gen-all  (asm/assemble [img-all])
+          gen-prod (asm/assemble [img-prod])]
+      (is (not (identical? gen-all gen-prod))
+          "a different :exclude is a different key → no cache collision")
+      (is (contains? (:rf.gen/resolver gen-all) [:event :dev/probe]))
+      (is (not (contains? (:rf.gen/resolver gen-prod) [:event :dev/probe]))
+          "the excluded dev namespace is dropped from the prod generation")
+      (is (= 2 (asm/cache-size))))))
+
+;; ===========================================================================
 ;; 6. Fail-loud inputs are NOT cached
 ;; ===========================================================================
 

--- a/implementation/core/test/re_frame/image_assembly_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_assembly_cljs_test.cljc
@@ -396,6 +396,91 @@
       (is (= [:dup] (:duplicate-image-ids d))))))
 
 ;; ===========================================================================
+;; 9b. Cross-image SHADOW REPORT (EP-0026 §Shadow Report, rf2-ke7w5j) — a flat
+;;     [{:registration [kind id] :image <defined-in> :shadowed-by <winner>}]
+;;     list on :rf.gen/shadows; chains name the FINAL winner per loser.
+;; ===========================================================================
+
+(deftest no-cross-image-shadow-empty-report
+  (testing "a single image, or composed images with disjoint [kind id]s, carries
+            an EMPTY :rf.gen/shadows report (nothing was overridden)"
+    (let [pool  [(reg-desc "a.core" :fx :a/post ::a)
+                 (reg-desc "b.core" :fx :b/post ::b)]
+          img-a (image/image {:id :img/a :select-ns {:include ["a.core"]}})
+          img-b (image/image {:id :img/b :select-ns {:include ["b.core"]}})]
+      (testing "single image — no shadows"
+        (is (= [] (asm/generation-shadows (asm/assemble [img-a] pool)))))
+      (testing "composed images with no shared [kind id] — no shadows"
+        (is (= [] (asm/generation-shadows (asm/assemble [img-a img-b] pool))))))))
+
+(deftest shadow-report-shape-one-entry-per-override
+  (testing "one later image overriding one earlier registration produces ONE flat
+            entry — exactly :registration / :image / :shadowed-by, nothing else"
+    (let [pool  [(reg-desc "checkout.core" :fx :checkout.http/post ::real)]
+          app   (image/image {:id :app/main :select-ns {:include ["checkout.core"]}})
+          dbls  (image/image {:id :test/doubles
+                              :registrations {:reg-fx [[:checkout.http/post {} ::stub]]}})
+          gen   (asm/assemble [app dbls] pool)
+          report (asm/generation-shadows gen)]
+      (is (= [{:registration [:fx :checkout.http/post]
+               :image        :app/main
+               :shadowed-by  :test/doubles}]
+             report)
+          "the shadow report names the loser image + the winner image — EP-0026 shape")
+      (testing "each entry carries EXACTLY the three keys (no scope tag, no
+                winner/loser descriptors)"
+        (is (= #{:registration :image :shadowed-by}
+               (set (keys (first report)))))))))
+
+(deftest shadow-report-final-winner-chain
+  (testing "a chain [base override-a override-b] reports the FINAL winner for EVERY
+            loser — base and override-a are BOTH :shadowed-by override-b, not the
+            immediate predecessor (EP-0026 §Shadow Report)"
+    (let [base  (image/image {:id :base
+                              :registrations {:reg-fx [[:checkout.http/post {} ::base]]}})
+          ov-a  (image/image {:id :ov/a
+                              :registrations {:reg-fx [[:checkout.http/post {} ::a]]}})
+          ov-b  (image/image {:id :ov/b
+                              :registrations {:reg-fx [[:checkout.http/post {} ::b]]}})
+          gen   (asm/assemble [base ov-a ov-b] [])
+          report (asm/generation-shadows gen)]
+      (testing "the live winner is the last image"
+        (is (= ::b (:impl (asm/resolve-descriptor gen :fx :checkout.http/post)))))
+      (testing "TWO loser entries, each naming the FINAL winner :ov/b"
+        (is (= [{:registration [:fx :checkout.http/post] :image :base  :shadowed-by :ov/b}
+                {:registration [:fx :checkout.http/post] :image :ov/a  :shadowed-by :ov/b}]
+               report))))))
+
+(deftest shadow-report-two-losers-of-the-same-winner
+  (testing "if two earlier images are both shadowed by the same later one for
+            DIFFERENT [kind id]s, that is two entries (one per shadowed registration)"
+    (let [pool  [(reg-desc "a.core" :fx  :pay/post ::a-pay)
+                 (reg-desc "b.core" :sub :pay/total ::b-total)]
+          img-a (image/image {:id :img/a :select-ns {:include ["a.core"]}})
+          img-b (image/image {:id :img/b :select-ns {:include ["b.core"]}})
+          dbls  (image/image {:id :test/doubles
+                              :registrations {:reg-fx  [[:pay/post {} ::stub-post]]
+                                              :reg-sub [[:pay/total (fn [_ _] 0)]]}})
+          report (asm/generation-shadows (asm/assemble [img-a img-b dbls] pool))]
+      (is (= [{:registration [:fx :pay/post]   :image :img/a :shadowed-by :test/doubles}
+              {:registration [:sub :pay/total] :image :img/b :shadowed-by :test/doubles}]
+             report)))))
+
+(deftest cross-image-shadow-does-not-fail-and-is-reported
+  (testing "a cross-image shadow RESOLVES (later wins) AND is recorded in the
+            report — it never fails assembly (EP-0026 Acceptance Bar 2)"
+    (let [pool  [(reg-desc "a.core" :fx :checkout.http/post ::a)
+                 (reg-desc "b.core" :fx :checkout.http/post ::b)]
+          img-a (image/image {:id :img/a :select-ns {:include ["a.core"]}})
+          img-b (image/image {:id :img/b :select-ns {:include ["b.core"]}})
+          gen   (asm/assemble [img-a img-b] pool)]    ;; must not throw
+      (is (= ::b (:handler-fn (asm/resolve-descriptor gen :fx :checkout.http/post))))
+      (is (= [{:registration [:fx :checkout.http/post]
+               :image        :img/a
+               :shadowed-by  :img/b}]
+             (asm/generation-shadows gen))))))
+
+;; ===========================================================================
 ;; 10. Resource → resource-scope resolver reference validation (rf2-32siq3.25)
 ;;     A :resource descriptor whose spec's :scope is {:from-db <id>} references a
 ;;     :resource-scope resolver that MUST be selected into the generation.

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -215,6 +215,24 @@
       (is (contains? (:changed diff) [:event :counter/inc])
           ":counter/inc survives with a different impl → changed"))))
 
+(deftest reload-report-carries-the-shadow-report
+  (testing "the reload report carries :rf.reload/shadows — the NEW generation's
+            cross-image SHADOW REPORT (EP-0026 §Shadow Report, rf2-ke7w5j)"
+    (let [override (image/image {:id :counter/override
+                                 :registrations {:reg-event [[:counter/inc (fn [_ _] {})]]}})
+          frame    (lf/make-frame {:id :counter/main :images [img]} pool-v1)
+          ;; Reload to a composition where a later override image shadows img's
+          ;; selected :counter/inc.
+          report   (lf/reload-images! :counter/main {:images [img override]} pool-v1)]
+      (testing "the pre-reload composition had no shadows; post-reload one entry"
+        (is (= [{:registration [:event :counter/inc]
+                 :image        :counter/img
+                 :shadowed-by  :counter/override}]
+               (:rf.reload/shadows report))))
+      (testing "it mirrors the new generation's :rf.gen/shadows"
+        (is (= (:rf.reload/shadows report)
+               (lf/frame-shadows :counter/main)))))))
+
 ;; ===========================================================================
 ;; 4. Reload is FRAME-TARGETED — it does not move a sibling frame
 ;; ===========================================================================

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -343,21 +343,14 @@
   ;; `(rf/set-x!)` / `(rf/install-x!)` are `<x>` placeholders in the
   ;; config-shape syntax table, not real vars.
   "set-x!"       #{"docs/guide/24-config-and-safety.md"}
-  "install-x!"   #{"docs/guide/24-config-and-safety.md"}
-  ;; EP-0026 (rf2-dlvmpc / rf2-ke7w5j): `frame-shadows` is the SPEC-AHEAD
-  ;; shadow-report accessor — the cross-image override report a frame exposes
-  ;; (`:rf.gen/shadows` + the `rf/frame-shadows` accessor). It is NOT a removed
-  ;; surface: it is the planned-but-unshipped read whose impl is bead
-  ;; rf2-ke7w5j (OPEN), so there is no live `re-frame.core` var to introspect
-  ;; and no honest manifest row yet — the same spec-ahead-of-impl posture as the
-  ;; `:api-md-known-unmanifested` entries. The Images concept page teaches it as
-  ;; the data the programmer reads to see what a later image overrode (the
-  ;; EP-0026 composition-resolves-by-image-order model that REPLACED the retired
-  ;; `:replace` / `:replace-standard` declared-winner keys). Allowlisted ONLY in
-  ;; that one teaching page; a `(rf/frame-shadows …)` anywhere else in the guide
-  ;; is RED. When rf2-ke7w5j ships the live var, the regenerated manifest carries
-  ;; it and this entry is deleted.
-  "frame-shadows" #{"docs/guide/concepts/images.md"}}
+  "install-x!"   #{"docs/guide/24-config-and-safety.md"}}
+  ;; EP-0026 (rf2-ke7w5j): the temporary `frame-shadows` spec-ahead allowlist
+  ;; entry was REMOVED here when rf2-ke7w5j shipped the live `rf/frame-shadows`
+  ;; var. It is now a real manifested var (see the
+  ;; ["re-frame.core" "frame-shadows"] classification row + the regenerated
+  ;; spec/api-manifest.edn), so the doc-guide-check resolves a
+  ;; `(rf/frame-shadows …)` mention to that manifest row — no exemption needed,
+  ;; and the honesty-ratchet would flag a stale allowlist entry for a now-live var.
   ;; EP-0025: `add-marks` / `set-marks` (and the whole `re-frame.marks` ns) are
   ;; removed. The privacy guide was rewritten to the commit-plane-effects model
   ;; (docs/guide/how-to/keep-secrets-out-of-traces.md) and no longer names the
@@ -732,6 +725,24 @@
   ;; matching the registrar query family). Status `EP-0023` (proposal-stage; the
   ;; row exists ahead of the spec/API.md projection EP-0023 graduates separately).
   ["re-frame.core" "frame-generation"]     {:tier :tooling :owner "002" :status "EP-0023"}
+  ;; EP-0026 (rf2-ke7w5j): `frame-shadows` is the public CROSS-IMAGE SHADOW
+  ;; REPORT accessor — return the flat `[{:registration [kind id] :image
+  ;; <defined-in> :shadowed-by <winner>}]` list a live frame's composition
+  ;; resolved (one entry per cross-image override, naming the loser image + the
+  ;; FINAL winner). FACADE-EXPORT CLASSIFICATION (diff-time facade rule): this is
+  ;; the EP-0026 replacement for the retired `:replace` / `:replace-standard`
+  ;; declared-winner keys — composition resolves by image order and the
+  ;; programmer READS this report to assert on / log / ignore what each later
+  ;; image shadowed. It is a primary user-facing surface (the EP names it the
+  ;; accessor in §Shadow Report + the Use-Cases), so it belongs on the public
+  ;; `re-frame.core` façade, not an internal-only reach. Tier `:tooling` (a READ,
+  ;; not a constructor/mutator — the SAME classification as its sibling
+  ;; `frame-generation`, which it reads a single key off; UNLIKE `make-frame` /
+  ;; `image` / `reload-images!` which are `:advanced`). Owner 002 (Frames —
+  ;; EP-0023/EP-0026's frame/image normative home, matching the registrar query
+  ;; family). Status `EP-0026` (proposal-stage; the row exists ahead of the
+  ;; spec/API.md projection EP-0026 graduates separately under rf2-o2vfrc).
+  ["re-frame.core" "frame-shadows"]        {:tier :tooling :owner "002" :status "EP-0026"}
   ;; rf2-wad2fl: the machine QUERY / handler-build / pure-engine helpers
   ;; (`machines`, `machine-meta`, `machine-by-system-id`, `machine-transition`,
   ;; `make-machine-handler`) are no longer façade exports — reach them through

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 485,
+ :var-count 486,
  :tier-vocab
  [:front-porch
   :advanced
@@ -114,6 +114,7 @@
   {:namespace "re-frame.core", :var "frame-meta", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "frame-provider", :tier :front-porch, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? false}
   {:namespace "re-frame.core", :var "frame-provider-existing", :tier :front-porch, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? false}
+  {:namespace "re-frame.core", :var "frame-shadows", :tier :tooling, :kind :fn, :owner "002", :status "EP-0026", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "frame-state-value", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "frame-value->id", :tier :advanced, :kind :fn, :owner "002", :status "EP-0024", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "group-cascades", :tier :tooling, :kind :fn, :owner "009", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
EP-0026 serial-lane STEP 4 (after 6ls85a + fsd822 + dlvmpc). Implements rf2-ke7w5j only.

## What this lands

**Cross-image SHADOW REPORT (EP-0026 §Shadow Report).** A flat list, one entry per cross-image shadow:

```clojure
[{:registration [kind id] :image <defined-in> :shadowed-by <winner>}]
```

- Chains report the **FINAL** winner per loser, never the immediate predecessor — `[base override-a override-b]` ⇒ both `base` and `override-a` are `:shadowed-by override-b`, so an assertion never walks a chain.
- Three keys, nothing else: no scope tag, no winner/loser descriptors. Every shadow is cross-image (a within-image collision is an error, not a resolved winner).
- Exposed on the sealed generation as `:rf.gen/shadows`, via `re-frame.image-assembly/generation-shadows`, and the public `rf/frame-shadows` facade accessor. Reflected in the `reload-images!` report as `:rf.reload/shadows` and surfaced through the `frame-generation` read (rf2-wkw8na) since that returns the whole generation.

**`rf/frame-shadows` shipped as a real public var.** Fail-loud on a non-live target (same contract as `rf/frame-generation`); accepts a frame value or id.

**Cache key.** The resolved-generation cache key already includes the `:select-ns` selection (`:include`/`:exclude` lower to the normalized image slots that ride the image value) and image order (the ordered normalized image vector is the key's image leg). Added tests pinning that a different selection or order is a cache miss.

**Facade-export classification (diff-time rule).** `rf/frame-shadows` classified `:tooling` / owner `002` / status `EP-0026` — a READ (like its sibling `frame-generation`), the EP-0026 replacement for the retired `:replace`/`:replace-standard` declared-winner keys; justification recorded inline in `spec/api-manifest-metadata.edn`.

**Manifest honesty-ratchet.** Added the `["re-frame.core" "frame-shadows"]` classification row, regenerated `spec/api-manifest.edn` (now carries the live var), and **removed** the temporary `"frame-shadows" #{"docs/guide/concepts/images.md"}` entry from `:doc-guide-known-unmanifested-scoped` (no longer a spec-ahead allowlist case — it's a live manifested var).

Out of scope (own beads): spec graduation (o2vfrc), conformance (qp8qi8). Xray/Pair generation readers were left unchanged — they project specific keys and do not surface `:rf.gen/shadows` today (additive key is harmless); surfacing it is separate Xray feature work.

## Quality gates

- core JVM suite: 1712 tests, 0 failures, 0 errors
- `npm run test:cljs`: 7995 tests, 0 failures, 0 errors
- `npm run test:elision`: PASS (42/42 absent; EP-0023 provenance + assembly-DCE)
- `npm run test:bundle-isolation`: PASS (prod-path touched)
- manifest `gen --check`: in sync (486 vars; frame-shadows now IN the manifest, allowlist entry GONE)
- projection checks green: doc-guide-check, api-md-check, doc-api-check, skills-check, story-spec-check, xray-spec-check; api-manifest unit tests (53)

node_modules note: the worktree's node_modules was absent and the mayor tree's copy was incomplete (missing react), so a fresh `npm install` ran in the worktree (package-lock.json unchanged). Any junction would be `cmd /c rmdir`'d before worktree removal.

CI is the merge gate.