### PR TITLE
refactor(resources): EP-0025 collapse redundant dual classification path (rf2-d3pku1)

### DIFF
--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -26,43 +26,55 @@
   resource spec remain as the degenerate **root-prop** case — the whole
   resource is the classification unit.
 
-  ## Projection is the merged frame-owned primitive
+  ## Projection is registry-driven — the routing / machines standard model
 
   Classification NAMES the facts; the framework PROJECTS them at every
-  egress boundary (SSR, tool, trace, epoch, observability). Projection is
-  the merged frame-owned `re-frame.projection/project-egress` over the
-  shared `re-frame.elision/elide-wire-value` walker (EP-0015 §10/§11) —
-  NEVER a family-private resource elider. The resource-local redaction this
-  slice replaces (the ad-hoc `:sensitive?` → sentinel decision) now DEFERS
-  to that source of truth: the whole-entry coarse disposition (the owner's
-  root-prop classification) gates redact / omit / serialize, and the
-  serialized data slice rides through `project-egress` under the SSR
-  boundary profile, so any per-slot `:data-schema` mark the frame
-  classification carries composes as defense-in-depth.
+  egress boundary (SSR, tool, trace, epoch, observability) through the
+  merged frame-owned `re-frame.projection/project-egress` over the shared
+  `re-frame.elision/elide-wire-value` walker (EP-0015 §10/§11) — NEVER a
+  family-private resource elider. The fine-grained per-slot declarations
+  are LOWERED per instance into the per-frame elision registry
+  (`reconcile-registry`), and the egress boundaries READ THAT REGISTRY: the
+  SSR projector walks the entry's `:data` / scoped-key params through
+  `project-egress` SEEDED AT THE ABSOLUTE OFFSET where the lowered decls
+  live (`project-entry-data` / `project-entry-params`), so a declared slot
+  redacts / elides with no second derivation from the spec. This is the
+  resources peer of routing's `project-routing-egress` (the
+  `[:rf.runtime/routing]`-offset slice walk) and machines'
+  `project-snapshot-data` (the `frame-snapshot-classification` registry
+  read) — one source of truth, all sources unioned at lookup.
+
+  rf2-d3pku1: this REMOVED the redundant family-private `project-data` /
+  `project-params` projectors, which re-derived `split-projection-paths
+  spec` at egress — the SAME fact `reconcile-registry` already lowered into
+  the registry (EP-0025: point the egress projection at the registry as
+  the single source). The COARSE whole-entry disposition
+  (`whole-entry-disposition`) remains the separate, frame-independent
+  authority that gates redact / omit / serialize on the WHOLE entry.
 
   ## Sensitive wins over large
 
-  A resource declared BOTH `:sensitive?` and `:large?` (or whose data-schema
-  marks a slot both) redacts as SENSITIVE — the redaction sentinel is the
-  more conservative shape (it still announces an entry exists, but emits no
+  A resource declared BOTH `:sensitive` and `:large` at the same slot
+  redacts as SENSITIVE — the redaction sentinel is the more conservative
+  shape (it still announces an entry exists, but emits no
   `:rf.size/large-elided` marker that could leak path / byte size / digest /
-  fetch-handle). This mirrors the walker's sensitive-before-large ordering
-  (`re-frame.elision/walk`) — the single point where sensitive-wins is
-  enforced at egress (EP-0025 removed the install-time complement along with
-  the frame annotation).
+  fetch-handle). This is enforced once, at egress, by the shared elision
+  walker's sensitive-before-large ordering (`re-frame.elision/walk`) — the
+  registry read inherits it.
 
   ## What this slice does NOT touch
 
   - It introduces NO new public API surface (no facade export) — it is the
     internal owner-classification seam the SSR projection + the reply trace
-    egress consume. The public classification surface is the `:data-schema`
-    / `:params-schema` per-slot props already on `reg-resource` /
-    `reg-mutation` (EP-0005 mechanism).
+    egress consume. The public classification surface is the projection-
+    relative `:sensitive` / `:large` declarations on `reg-resource` /
+    `reg-mutation`.
   - It does NOT change the Spec-Schemas schema-marker grammar (the
     `:sensitive?` / `:large?` Malli props are owned by the schemas artefact
     + Spec-Schemas — EP-0015 bead-plan item 9)."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.classification :as classification]
+            [re-frame.elision :as elision]
             [re-frame.path :as path]
             [re-frame.projection :as projection]
             [re-frame.resources.state :as state]))
@@ -84,8 +96,8 @@
   reading the owner spec's coarse root-prop `:sensitive?` / `:large?` claims.
   Returns one of:
 
-    :serialize  — ship the data slice (still PROJECTED through frame
-                  classification — see `project-data`);
+    :serialize  — ship the data slice (still registry-PROJECTED for any
+                  per-slot declaration — see `project-entry-data`);
     :redact     — metadata-only: replace the data with the redaction
                   sentinel (a `:sensitive?` owner);
     :omit       — metadata-only: drop the data key entirely (a `:large?`
@@ -151,11 +163,13 @@
 ;; Lowering = re-rooting + axis-split. The declaration paths are rooted at the
 ;; instance projection (`[:data …]` → the data value; `[:params …]` → the
 ;; scoped-key params; `[:scope …]` / a `[:scope]`-rooted path → the scope
-;; component). `project-data` consumes the `:data`-rooted paths (stripped of
-;; the `:data` head); `project-params` consumes the `:params`-rooted paths
-;; (stripped of the `:params` head). A bare-rooted path (no `:data` / `:params`
-;; head) defaults to the DATA projection — the common `{:sensitive [[:ssn]]}`
-;; shorthand for a data field.
+;; component). `instance-declaration-paths` re-roots the `:data`-rooted paths
+;; under the entry's absolute `:data` path and the `:params` / `:scope`-rooted
+;; paths under the scoped-key carrier, writing them into the per-frame elision
+;; registry (`reconcile-registry`) — the egress boundaries read them back from
+;; there (`project-entry-data` / `project-entry-params`). A bare-rooted path (no
+;; `:data` / `:params` head) defaults to the DATA projection — the common
+;; `{:sensitive [[:ssn]]}` shorthand for a data field.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private declaration-axis-keys
@@ -231,10 +245,10 @@
   `{:sensitive {path decl} :large {path decl}}` shape the schema-prop marks
   use — keyed `:data` (the data projection) and `:params` (the scoped-key
   params projection). Returns `{:data {…} :params {…}}` (a `:sensitive` /
-  `:large` map under each), so the existing `project-data` / `project-params`
-  readers union it with the schema-prop marks. Empty when the spec declares
-  neither axis. Pure / value-independent. Assumes the spec passed
-  `classification-declaration-defect`."
+  `:large` map under each). The axis-split shape `instance-declaration-paths`
+  re-roots when LOWERING the declarations into the per-frame elision registry
+  (`reconcile-registry`). Empty when the spec declares neither axis. Pure /
+  value-independent. Assumes the spec passed `classification-declaration-defect`."
   [spec]
   (let [s (split-projection-paths spec :sensitive)
         l (split-projection-paths spec :large)
@@ -243,272 +257,149 @@
      :params {:sensitive (->decl (:params s)) :large (->decl (:params l))}}))
 
 ;; ---------------------------------------------------------------------------
-;; Fine-grained owner classification — projection-relative declarations ONLY.
+;; Schemas validate; they do NOT classify durably (EP-0025 rf2-fuqcob).
 ;;
-;; EP-0025 (rf2-fuqcob, mirroring the rf2-398kql machine schema->classification
-;; bridge reversal): a resource's `:data-schema` / `:params-schema` / per-page
-;; `:page-data-schema` VALIDATES the value; it does NOT drive DURABLE egress
-;; classification. The per-slot `:sensitive?` / `:large?` schema props survive
-;; ONLY for VALIDATION-FAILURE-TRACE redaction (the validator's own transient
-;; egress product — `redact-invalid-params-error`, via the shared
-;; `:schemas/redact-validation-tags` seam) — NOT as a co-equal route into
-;; durable resource data / params / scope classification (Spec 015 §Schemas
-;; describe shape, not durable egress policy). The SINGLE durable classification
-;; surface is the projection-relative `:sensitive` / `:large` path declarations
-;; on the spec (`spec-declaration-marks`) — one name per fact.
+;; A resource's `:data-schema` / `:params-schema` / per-page `:page-data-schema`
+;; VALIDATES the value; it does NOT drive DURABLE egress classification. The
+;; per-slot `:sensitive?` / `:large?` schema props survive ONLY for
+;; VALIDATION-FAILURE-TRACE redaction (the validator's own transient egress
+;; product — `redact-invalid-params-error`, via the shared
+;; `:schemas/redact-validation-tags` seam) — NOT as a route into durable resource
+;; data / params / scope classification (Spec 015 §Schemas describe shape, not
+;; durable egress policy). The SINGLE durable classification surface is the
+;; projection-relative `:sensitive` / `:large` path declarations on the spec
+;; (`spec-declaration-marks`), LOWERED per instance into the per-frame elision
+;; registry (`reconcile-registry`, the lowering section below) — one name per
+;; fact, read back at egress through the SAME registry the routing / machines
+;; subsystems read.
 ;; ---------------------------------------------------------------------------
 
-(defn data-schema-marks
-  "The fine-grained owner classification for a resource / mutation `spec`'s
-  DATA value, as `{:sensitive {path decl} :large {path decl}}` rooted at the
-  data root (`[]`) — the EP-0025 projection-relative `:sensitive` / `:large`
-  declarations' `:data`-rooted paths (`spec-declaration-marks`). EP-0025
-  (rf2-fuqcob): the per-slot `:data-schema` `:sensitive?` / `:large?` props are
-  NOT a durable classification route (the schema VALIDATES; it does not classify
-  durable egress). Empty maps when the spec declares no `:data`-rooted
-  declaration. Pure."
-  [spec]
-  (:data (spec-declaration-marks spec)))
-
-(defn infinite-spec?
-  "True iff `spec` declares an infinite feed (`:infinite true` — EP-0021 R1).
-  The classification-local predicate behind `project-data`'s per-page
-  (`:page-data-schema`) vs whole-value (`:data-schema`) branch. Mirrors
-  `re-frame.resources.registry/infinite-resource?` but is defined HERE (a bare
-  `(true? (:infinite spec))` read) because `registry` already requires
-  `classification` — requiring it back would cycle (Spec 016 §Registration —
-  :infinite)."
-  [spec]
-  (true? (:infinite spec)))
-
-(defn page-data-schema-marks
-  "The per-PAGE fine-grained owner classification an infinite resource `spec`
-  declares for ONE PAGE value, as `{:sensitive {path decl} :large {path decl}}`
-  rooted at the page root (`[]`). EP-0025 (rf2-fuqcob): an infinite feed's per-
-  page classification rides the resource's `:data`-rooted projection-relative
-  declarations (`spec-declaration-marks`), applied PER PAGE by `project-data`
-  over each page of the accumulated `:data` vector — NOT the `:page-data-schema`
-  per-slot props (the schema VALIDATES each page; it does not classify durable
-  egress). Empty maps when the spec declares no `:data`-rooted declaration.
-  Pure."
-  [spec]
-  (:data (spec-declaration-marks spec)))
-
-(defn params-schema-marks
-  "The fine-grained owner classification for a resource / mutation `spec`'s
-  PARAMS value, as `{:sensitive {path decl} :large {path decl}}` rooted at the
-  params root (`[]`) — the EP-0025 projection-relative `:sensitive` / `:large`
-  declarations' `:params`-rooted (and `:scope`-rooted) paths
-  (`spec-declaration-marks`). The CO-EQUAL params counterpart to
-  `data-schema-marks`. EP-0025 (rf2-fuqcob): the per-slot `:params-schema`
-  `:sensitive?` / `:large?` props are NOT a durable classification route (the
-  schema VALIDATES; it does not classify durable egress). Spec 016
-  §Runtime-subsystem graduation clause 4: \"params, scopes, and data carry the
-  same classification.\" Empty maps when the spec declares no `:params`-rooted
-  declaration. Pure."
-  [spec]
-  (:params (spec-declaration-marks spec)))
-
-(defn data-schema-classifies?
-  "True iff `spec` declares ANY `:data`-rooted `:sensitive` / `:large`
-  projection-relative path (`data-schema-marks` — the durable owner surface).
-  When true, a `:serialize` (non-whole-redacted) entry's data MUST still be
-  projected so the declared slots redact / elide — see `project-data`."
-  [spec]
-  (let [{:keys [sensitive large]} (data-schema-marks spec)]
-    (boolean (or (seq sensitive) (seq large)))))
-
-(defn params-schema-classifies?
-  "True iff `spec` declares ANY `:params`-rooted (or `:scope`-rooted)
-  `:sensitive` / `:large` projection-relative path (`params-schema-marks`).
-  When true, a `:serialize` entry's scoped-key PARAMS carry a fine-grained
-  classification that must be honoured on the wire — see `project-params`."
-  [spec]
-  (let [{:keys [sensitive large]} (params-schema-marks spec)]
-    (boolean (or (seq sensitive) (seq large)))))
-
 ;; ---------------------------------------------------------------------------
-;; Data projection — owner per-slot marks + the merged frame `project-egress`.
+;; Egress projection — registry-driven, the routing / machines standard model
+;; (EP-0025, rf2-d3pku1 — collapsing the redundant family-private re-derivation).
 ;;
-;; EP-0015 §6/§10/§11. The serialized data slice is projected in two
-;; composed layers, both deferring to SHARED primitives (never a
-;; family-private resource elider):
+;; A resource's projection-relative `:sensitive` / `:large` declarations are the
+;; SINGLE source of truth, and `reconcile-registry` (below) LOWERS them per
+;; instance into the per-frame elision registry at the entry's ABSOLUTE
+;; runtime-db path (`[:rf.runtime/resources :entries <key-id> :data …]` for data,
+;; the scoped-key `:resource/key` carrier for params/scope) under
+;; `:source :resource`. The egress boundaries READ THAT REGISTRY — they do NOT
+;; re-derive the declaration from the spec a second time at projection.
 ;;
-;;   (a) the RESOURCE-OWNED `:data`-rooted projection-relative `:sensitive` /
-;;       `:large` declaration marks (the canonical fine-grained owner surface —
-;;       EP-0025; the `:data-schema` props no longer classify durably,
-;;       rf2-fuqcob) project through the shared frame-independent
-;;       `re-frame.classification/redact-with-paths` walker — sensitive slots
-;;       redact to the `:rf/redacted` sentinel, large slots elide to the
-;;       `:rf.size/large-elided` marker. This is the OWNER's declaration firing
-;;       irrespective of frame app-db classification — a resource that declares
-;;       `[:data :token]` sensitive redacts that slot on SSR even when the
-;;       frame's app-db classification says nothing about it, and a `[:data
-;;       :body]` large slot elides on the wire whether or not the frame
-;;       independently marks it (resource cache data does not live at a frame
-;;       app-db path; rf2-260yhk). This is the SAME walker the CO-EQUAL
-;;       `project-params` uses for the params component of the key — one walker,
-;;       two owner surfaces.
-;;   (b) the data is THEN projected through the merged frame-owned
-;;       `re-frame.projection/project-egress` (over `elide-wire-value`) under
-;;       the boundary profile, so any path the FRAME ALSO classifies redacts /
-;;       elides as defense-in-depth.
+;; This makes resources a peer of:
+;;   - routing's `re-frame.ssr.payload-policy/project-routing-egress`, which
+;;     walks the `:rf.runtime/routing` slice through `project-egress` seeded at
+;;     `:path [:rf.runtime/routing]` so the registry's absolute re-rooted route
+;;     paths match; and
+;;   - machines' `re-frame.machines.ssr/project-snapshot-data`, which reads the
+;;     lowered snapshot declarations back from the registry
+;;     (`re-frame.classification/frame-snapshot-classification`).
 ;;
-;; "Sensitive wins over large" holds across both: at the same slot the owner
-;; walker already resolves to the redaction sentinel (the walker's intrinsic
-;; ordering), and the sentinel is a non-matchable scalar the frame walker
-;; descends into nothing (idempotent under re-projection). The common
-;; whole-resource-large case is still the coarse `:large?` root-prop omit
-;; (`whole-entry-disposition` → `:omit`), so the durable whole-large entry
-;; never reaches this serialize path at all; the per-slot owner `:large?` here
-;; is the FINE-GRAINED complement for a `:serialize` entry with a large leaf.
+;; EP-0025 §"Point the egress projection at the registry as the single source":
+;; the prior resources family-private `project-data` / `project-params`
+;; projectors re-derived `split-projection-paths spec` at egress — the SAME fact
+;; `reconcile-registry` already lowered into the registry. That dual derivation
+;; (rf2-d3pku1) is REMOVED here in favour of the registry read.
+;;
+;; The registry-driven walk is frame-SCOPED (the registry lives in the live
+;; frame's runtime-db). A nil / unresolvable / never-classified frame rides the
+;; value VERBATIM — the precise, fail-open-frameless posture machines
+;; (`project-snapshot-data` nil-frame ride) and routing (`project-routing-egress`
+;; no-live-frame ride) both take. The COARSE whole-entry `:redact` / `:omit`
+;; dispositions (`whole-entry-disposition`) remain the separate authority that
+;; replaces the WHOLE data / key irrespective of frame — they are NOT a
+;; per-slot path concern and do not flow through this registry walk.
 ;; ---------------------------------------------------------------------------
 
-(defn- project-value
-  "Project ONE owner-decoded `value` (a whole resource data value, or a SINGLE
-  page of an infinite feed) for egress against `frame-id` / `boundary-profile`,
-  applying the owner per-slot `marks` (`{:sensitive {path …} :large {path …}}`,
-  rooted at the value root) in the two composed layers:
+(defn- registry-classifies-under?
+  "True iff `frame-id`'s per-frame elision registry carries ANY `:sensitive` or
+  `:large` declaration whose absolute path begins with `prefix` (the entry's
+  `:data` / scoped-key offset). A cheap registry membership read used to GATE the
+  egress walk: when nothing is declared under the offset, the value rides
+  VERBATIM (the walker would otherwise reconstruct collections and collapse a
+  list↔vector byte-identity — Spec 016 §Resource identity; the cache-key-identity
+  round-trip). Precise, not a blanket scrub — the same posture routing's
+  `unclassified-route-slice-rides-verbatim` takes. Pure read."
+  [frame-id prefix]
+  (let [n     (count prefix)
+        under (fn [decls]
+                (some (fn [p]
+                        (and (>= (count p) n) (= prefix (subvec (vec p) 0 n))))
+                      (keys decls)))]
+    (boolean (or (under (elision/sensitive-declarations frame-id))
+                 (under (elision/declarations frame-id))))))
 
-    (a) the owner `:sensitive?` / `:large?` per-slot marks project through the
-        shared `re-frame.classification/redact-with-paths` walker (sensitive →
-        `:rf/redacted`, large → `:rf.size/large-elided`, sensitive wins at a
-        co-marked slot) — frame-independent;
-    (b) the result is projected through the merged frame-owned
-        `re-frame.projection/project-egress` under `boundary-profile` when a
-        `frame-id` is present, so any path the FRAME classifies composes as
-        defense-in-depth. A nil `frame-id` skips layer (b) (the owner
-        classification is the authority — see `project-data`).
+(defn project-entry-data
+  "Project a resource entry's serialized DATA value for egress across
+  `boundary-profile` (a `:rf.egress/*` profile, e.g. `:rf.egress/ssr-hydration`)
+  against `frame-id`'s per-frame elision registry — the REGISTRY-DRIVEN egress
+  read (EP-0025, rf2-d3pku1). The resource's projection-relative `:data`
+  declarations were lowered into the registry at the entry's absolute runtime-db
+  `:data` path (`[:rf.runtime/resources :entries <key-id> :data …]`,
+  `reconcile-registry`); here we walk the bare `:data` value through
+  `re-frame.projection/project-egress` SEEDED AT THAT ABSOLUTE OFFSET (`:path
+  [… <key-id> :data]`), so the candidate declaration-coordinate set starts where
+  the lowered `:source :resource` decls live and the declared slots redact
+  (`:sensitive` → `:rf/redacted`) / elide (`:large` → `:rf.size/large-elided`).
+  Any path the FRAME ALSO classifies composes as defense-in-depth (the same
+  registry, all sources unioned at lookup).
 
-  No marks AND no frame → `value` rides unchanged. Pure."
-  [value marks frame-id boundary-profile]
-  (let [{:keys [sensitive large]} marks
-        owner-projected (if (or (seq sensitive) (seq large))
-                          (classification/redact-with-paths value (keys sensitive) (keys large))
-                          value)]
-    (if frame-id
-      (projection/project-egress owner-projected
-                                 {:frame             frame-id
-                                  :rf.egress/profile boundary-profile})
-      owner-projected)))
+  INFINITE feeds ride for free: the lowered decl is `[… :data :token]`, the
+  runtime `:data` is the page VECTOR, and `elide-wire-value`'s index-free fork
+  (`fork-index-paths`) matches the index-free decl against the indexed runtime
+  path `[… :data <page-idx> :token]` on EVERY page — no special per-page branch.
 
-(defn project-data
-  "Project a resource entry's / mutation instance's serialized DATA value for
-  egress across `boundary-profile` (a `:rf.egress/*` profile, e.g.
-  `:rf.egress/ssr-hydration` at the SSR boundary, `:rf.egress/off-box-tool`
-  at a tool boundary) against `frame-id`'s classification and the resource
-  `spec`'s OWNER per-slot classification (EP-0015 §6 / EP-0021 R5).
+  GATED on a registry declaration under the entry's `:data` offset
+  (`registry-classifies-under?`): when NOTHING is declared there the value rides
+  VERBATIM (reference-preserving — the walker would otherwise reconstruct
+  collections; the precise posture routing / the cache-key-identity contract
+  require). Frame-SCOPED: a nil / unresolvable `frame-id` rides `data` VERBATIM
+  (the registry is unreachable without a live frame, and the coarse whole-entry
+  disposition is the separate frame-independent authority). `key-id` is the
+  entry's CEDN-1 byte key-id. Pure w.r.t. the value (reads the live frame's
+  registry)."
+  [data key-id frame-id boundary-profile]
+  (let [data-prefix (conj (state/entry-path-by-id key-id) :data)]
+    (if (and frame-id (registry-classifies-under? frame-id data-prefix))
+      (projection/project-egress
+        data
+        {:frame             frame-id
+         :path              data-prefix
+         :rf.egress/profile boundary-profile})
+      data)))
 
-  THE single classification entry point for resource data egress — it branches
-  on `spec`'s `:infinite` marker so the per-page (`:page-data-schema`) vs
-  whole-value (`:data-schema`) contract is decided in one place (rather than a
-  forked parallel projector):
+(defn project-entry-params
+  "Project a resource entry's scoped-key PARAMS value for egress against
+  `frame-id`'s per-frame elision registry — the CO-EQUAL params counterpart to
+  `project-entry-data` (EP-0025, rf2-d3pku1; Spec 016 clause 4 \"params, scopes,
+  and data carry the same classification\"). The resource's projection-relative
+  `:params` (and `:scope`) declarations were lowered into the registry at the
+  scoped key's absolute `:resource/key` carrier (`[… :resource/key 2 …]` for
+  params, `[… :resource/key 0 …]` for scope, `reconcile-registry`). The scoped
+  key is `[scope resource-id params]`, so the params component sits at index 2 of
+  that carrier; here we walk the bare params value through
+  `re-frame.projection/project-egress` SEEDED at the params offset
+  (`[… :resource/key 2]`) so the lowered `:source :resource` decls match — a
+  marked slot redacts / elides without the raw value riding in the wire key.
 
-  - **Ordinary resource** (`:infinite` absent / not true): `data` is the whole
-    decoded value. The resource-owned `:data-schema` `:sensitive?` / `:large?`
-    per-slot marks (`data-schema-marks`) project over it (layer (a)), then the
-    merged frame-owned `project-egress` composes any frame-classified path
-    (layer (b)) — the existing contract.
-
-  - **Infinite feed** (`:infinite true` — EP-0021 R1/R5): `data` is the
-    FRAMEWORK-OWNED VECTOR OF PAGES, and the per-page egress/classification
-    contract is `:page-data-schema` (`page-data-schema-marks`), applied PER PAGE
-    — each page is projected through the SAME two layers (owner marks + frame
-    `project-egress`), and the page-vector SHAPE is preserved. `:data-schema` is
-    NOT consulted for the accumulated vector (R5: the framework page vector must
-    not be classified as if it were one app-decoded value, and a sensitive /
-    large page field must not bypass per-page classification). A non-vector
-    `data` on an infinite entry (an empty / not-yet-loaded feed whose `:data`
-    is `[]`, or a nil) rides through the per-page mapping harmlessly.
-
-  Both branches compose two SHARED primitives (never a family-private elider):
-
-    (a) the owner per-slot `:sensitive?` AND `:large?` marks through the shared
-        `re-frame.classification/redact-with-paths` walker — `:sensitive?` slots redact
-        to the `:rf/redacted` sentinel, `:large?` slots elide to the
-        `:rf.size/large-elided` marker (sensitive wins at a co-marked slot) —
-        the OWNER's fine-grained declaration, firing regardless of frame app-db
-        classification (the CO-EQUAL counterpart to `project-params`);
-    (b) the merged frame-owned `re-frame.projection/project-egress` (over
-        `elide-wire-value`) under `boundary-profile`, so any path the FRAME
-        classifies composes as defense-in-depth.
-
-  When `frame-id` is nil (a frameless / pure projection — a test harness or
-  a tool with no resolvable frame), layer (b) is SKIPPED and the owner-projected
-  data rides as-is: the coarse whole-entry disposition
-  (`whole-entry-disposition`) is the resource-owned authority that governs
-  redact / omit, so a frameless serialized entry must not be over-redacted to
-  the frame walker's fail-closed sentinel merely because no frame scope is
-  carried (that fail-closed posture is for app-db egress, not the
-  resource-owned decision) — but the OWNER's own per-slot `:sensitive?` /
-  `:large?` marks STILL fire (layer (a) is frame-independent). `spec` nil / no
-  governing schema → layer (a) is a no-op. Pure."
-  [data spec frame-id boundary-profile]
-  (if (infinite-spec? spec)
-    ;; INFINITE feed (EP-0021 R5): `data` is the framework-owned page VECTOR;
-    ;; apply the per-page `:page-data-schema` contract PER PAGE, preserving the
-    ;; vector shape. `:data-schema` is deliberately NOT consulted here.
-    (let [page-marks (page-data-schema-marks spec)]
-      (if (sequential? data)
-        (mapv (fn [page] (project-value page page-marks frame-id boundary-profile))
-              data)
-        ;; a non-vector / nil `:data` (empty / not-yet-loaded feed) — project it
-        ;; as a single value so a frame layer (b) still composes; per-page marks
-        ;; rooted at the page root no-op against a non-page shape.
-        (project-value data page-marks frame-id boundary-profile)))
-    ;; ORDINARY resource: the existing whole-value `:data-schema` contract.
-    (project-value data (data-schema-marks spec) frame-id boundary-profile)))
-
-;; ---------------------------------------------------------------------------
-;; Params projection — the CO-EQUAL fine-grained owner surface for the scoped
-;; key (EP-0015 issue 11; Spec 016 clause 4 "params, scopes, and data carry
-;; the same classification").
-;;
-;; The scoped resource key is `[scope resource-id canonical-params]`. On a
-;; `:serialize` entry (no coarse whole-entry claim) the key rides VERBATIM on
-;; the hydration wire — so without this, a params slot the owner marked
-;; `:sensitive?` via `:params-schema` (e.g. `[:account-id {:sensitive? true}
-;; :string]`) would ride RAW in the wire key even though it is the same
-;; privacy class as the data. `project-params` applies the OWNER's per-slot
-;; `:params-schema` marks to the params component of the key so a marked slot
-;; redacts (`:sensitive?`) / elides (`:large?`) — the SAME walker, sentinel,
-;; and ordering (`sensitive` wins) as `project-data` layer (a). It is
-;; frame-INDEPENDENT (the owner declaration, not frame app-db classification —
-;; resource params do not live at a frame app-db path), so it fires even
-;; frameless. The COARSE whole-entry `:redact` / `:omit` dispositions still
-;; replace the entire params component with an opaque content-addressed digest
-;; (`re-frame.resources.ssr/project-scoped-key`) — this per-slot surface is
-;; the fine-grained complement that fires on a `:serialize` key the coarse
-;; claim leaves verbatim.
-;; ---------------------------------------------------------------------------
-
-(defn project-params
-  "Project a resource entry's scoped-key PARAMS value for egress against the
-  resource `spec`'s OWNER per-slot `:params-schema` marks (EP-0015 issue 11;
-  Spec 016 clause 4). The CO-EQUAL counterpart to `project-data` for the
-  params component of the scoped key:
-
-    - each slot the `:params-schema` marks `:sensitive?` is redacted to the
-      `:rf/redacted` sentinel via `re-frame.privacy/redact-paths`;
-    - each slot it marks `:large?` is elided through the shared
-      `re-frame.elision/elide-wire-value` walker to the
-      `:rf.size/large-elided` marker.
-
-  Both axes go through the SHARED frame-independent
-  `re-frame.classification/redact-with-paths` walker (sensitive → `:rf/redacted`,
-  large → `:rf.size/large-elided`, sensitive wins over large at the same
-  slot) — the SAME walker the HTTP response-body surface
-  (`re-frame.http.privacy-body/classify-decoded`) uses, never a
-  resource-private walker. Frame-INDEPENDENT — the OWNER's declaration fires
-  irrespective of any frame app-db classification (resource params do not
-  live at a frame app-db path). `spec` nil / no `:params-schema` / no marks →
-  `params` rides UNCHANGED (the coarse whole-entry disposition is the
-  separate authority that redacts/omits the whole key — see
-  `re-frame.resources.ssr/project-scoped-key`). Pure."
-  [params spec]
-  (let [{:keys [sensitive large]} (params-schema-marks spec)]
-    (if (or (seq sensitive) (seq large))
-      (classification/redact-with-paths params (keys sensitive) (keys large))
+  Used on a `:serialize` entry (no coarse whole-entry claim) — the COARSE
+  `:redact` / `:omit` dispositions still replace the WHOLE params component with
+  an opaque content-addressed digest (`re-frame.resources.ssr/project-scoped-key`),
+  irrespective of frame. GATED on a registry declaration under the params offset
+  (`registry-classifies-under?`): when nothing is declared there the params ride
+  VERBATIM (reference / byte-identity preserving — the scoped key is a CEDN-1
+  byte-keyed identity, so a list↔vector collapse from an unnecessary walk would
+  break the cache-key-identity round-trip). Frame-SCOPED: a nil / unresolvable
+  `frame-id` rides `params` VERBATIM. `key-id` is the entry's CEDN-1 byte key-id.
+  Pure w.r.t. the value."
+  [params key-id frame-id boundary-profile]
+  (let [params-prefix (conj (state/entry-path-by-id key-id) :resource/key 2)]
+    (if (and frame-id (registry-classifies-under? frame-id params-prefix))
+      (projection/project-egress
+        params
+        {:frame             frame-id
+         :path              params-prefix
+         :rf.egress/profile boundary-profile})
       params)))
 
 ;; ---------------------------------------------------------------------------
@@ -523,14 +414,14 @@
 ;; slot the owner marked `:sensitive?` (e.g. `[:token {:sensitive? true} …]`)
 ;; would leak RAW whenever validation failed on a DIFFERENT, non-sensitive
 ;; sibling field — the same sibling-leak class the SSR `:serialize` key
-;; (`project-params`) and the schema-validation hot-path traces
+;; (`project-entry-params`) and the schema-validation hot-path traces
 ;; (`re-frame.schemas.validate/redact-tags`) already close.
 ;;
 ;; This routes the error payload through the SAME two shared primitives the
 ;; rest of the resources family egress uses — never a registry-private elider:
 ;;
-;;   :params  — the CO-EQUAL fine-grained owner surface `project-params`:
-;;              each `:params-schema` `:sensitive?` slot redacts to
+;;   :params  — the SCHEMA-PROP per-slot redaction (the validator's own failure
+;;              product): each `:params-schema` `:sensitive?` slot redacts to
 ;;              `:rf/redacted`, each `:large?` slot elides to the
 ;;              `:rf.size/large-elided` marker, plain slots ride verbatim
 ;;              (so the non-sensitive failing field stays diagnostic).
@@ -552,14 +443,15 @@
 ;; never produced an `:error` in the first place.
 ;;
 ;; EP-0025 (rf2-fuqcob): the `:params-schema` per-slot `:sensitive?` / `:large?`
-;; props no longer drive DURABLE classification (`project-params` reads only the
-;; projection-relative declarations now). But the VALIDATION-FAILURE-TRACE
-;; redaction is the schema's OWN surviving egress product (Spec 015 §Schemas
-;; describe shape: "for a slot's own validation-failure-trace redaction the
-;; schema produces that record, so it owns its egress shape"). So this seam reads
-;; the schema PROPS directly (via the shared walker hooks) to redact the failing
-;; `:params` per-slot — NOT `project-params`. That keeps the schema-prop route
-;; alive exactly where it is legitimate (the validator's own failure product),
+;; props no longer drive DURABLE classification (the durable wire/SSR/tool egress
+;; reads only the projection-relative declarations, lowered into the registry —
+;; `project-entry-params`). But the VALIDATION-FAILURE-TRACE redaction is the
+;; schema's OWN surviving egress product (Spec 015 §Schemas describe shape: "for
+;; a slot's own validation-failure-trace redaction the schema produces that
+;; record, so it owns its egress shape"). So this seam reads the schema PROPS
+;; directly (via the shared walker hooks) to redact the failing `:params`
+;; per-slot — distinct from the durable registry route. That keeps the schema-
+;; prop route alive exactly where it is legitimate (the validator's own product),
 ;; while the durable wire/SSR/tool egress is governed solely by the projection-
 ;; relative declarations.
 ;; ---------------------------------------------------------------------------
@@ -600,10 +492,10 @@
 
   EP-0025 (rf2-fuqcob): this is the schema's OWN VALIDATION-FAILURE-TRACE egress
   product, the surviving schema-prop redaction route (Spec 015 §Schemas describe
-  shape) — distinct from the DURABLE wire/SSR/tool egress, which `project-params`
-  governs via the projection-relative declarations alone (schema props no longer
-  classify durably). `error` may be nil (no explainer registered); the `:error`
-  key is then nil. Pure (modulo the memoised walker + the late-bound redaction
+  shape) — distinct from the DURABLE wire/SSR/tool egress, which the registry-
+  driven `project-entry-params` governs via the projection-relative declarations
+  alone (schema props no longer classify durably). `error` may be nil (no
+  explainer registered); the `:error` key is then nil. Pure (modulo the memoised walker + the late-bound redaction
   hook)."
   [params error spec]
   (let [schema     (:params-schema spec)
@@ -638,12 +530,16 @@
 ;; `[:rf.runtime/machines :snapshots <actor-id> :data …]`) and routes lower at
 ;; activation (`re-frame.routing.classification/lower-for-route` →
 ;; `[:rf.runtime/routing :current …]`). BEFORE rf2-v8x9n8 resources DID NOT
-;; lower: the `{:source :owner-declaration}` marks were applied DIRECTLY at the
-;; family-private `project-data` / `project-params` projectors, so a generic
-;; registry reader (Xray "what is classified", an MCP registry view, the SSR
-;; registry-projection defence-in-depth) never SAW resource classification. Now
-;; the registry carries it, so the "union every source" model the spec sells is
-;; uniform across all four subsystems.
+;; lower: the marks were applied DIRECTLY at the family-private
+;; `project-data` / `project-params` projectors, so a generic registry reader
+;; (Xray "what is classified", an MCP registry view, the SSR registry-projection
+;; defence-in-depth) never SAW resource classification. The lowering put it in
+;; the registry; rf2-d3pku1 then COLLAPSED the redundant family-private
+;; projectors into the registry read (`project-entry-data` /
+;; `project-entry-params` walk the entry value through `project-egress` seeded at
+;; the lowered absolute path), so the registry is now the SINGLE source the
+;; egress reads — the "union every source" model the spec sells, uniform across
+;; all four subsystems.
 ;;
 ;; The lowering is a PURE runtime-db transform (`reconcile-registry`, mirroring
 ;; routing's `apply-route-classification`) so the durable runtime-db transition

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -226,31 +226,29 @@
   "Project a scoped resource KEY (`[scope resource-id params]`) to its wire
   shape per the resource's `disposition` (Spec 016 clause 4 / rf2-otms75):
 
-    - `:serialize` — the key rides with its scope verbatim, but its PARAMS
-      are projected through the resource OWNER's per-slot `:params-schema`
-      classification (`classification/project-params`) so a params slot the
-      owner marked `:sensitive?` / `:large?` does NOT ride raw even though the
-      coarse whole-entry claim leaves the key serialized (EP-0015 issue 11 —
-      the CO-EQUAL fine-grained counterpart to the data surface; Spec 016
-      clause 4 \"params, scopes, and data carry the same classification\").
-      A resource with no `:params-schema` marks rides its params verbatim
-      (the wire-safe default — same as its data);
+    - `:serialize` — the key rides VERBATIM (scope + params unchanged). A
+      per-slot `:params` / `:scope` projection-relative declaration on a
+      `:serialize` resource is the REGISTRY-DRIVEN concern of the SSR
+      `project-entry` path (`classification/project-entry-params`, rf2-d3pku1):
+      it has the entry's `key-id` + the live SSR frame, so it walks the params
+      component through `project-egress` seeded at the lowered registry path.
+      The trace / tool egress callers pass `:serialize` through verbatim (they
+      rely on the coarse disposition + the digest below, not per-slot params);
     - `:redact` / `:omit` — the scope and params are replaced by opaque
       content-addressed `{:rf/redacted <digest>}` tokens so the sensitive /
       large raw identity does NOT ride, while the resource-id (position 1) and
       key DISTINCTNESS are preserved (the digest differs per distinct value).
       The COARSE whole-entry claim already redacts the WHOLE params component
-      here, so the per-slot `:params-schema` surface is subsumed.
+      here, so the per-slot params surface is subsumed.
 
   The wire key keeps the `[scope resource-id params]` SHAPE so the client's
   index recompute + refetch plan parse it unchanged (resource-id at position
-  1). `spec` is the resource owner spec (`registry/resource-meta`), carrying
-  the `:params-schema` marks; nil / no marks → the params ride verbatim on
-  `:serialize`. PURE."
-  [scoped-key disposition spec]
+  1). `spec` is the resource owner spec (`registry/resource-meta`) — retained
+  for caller signature stability (the disposition already encodes the coarse
+  claim it carried). PURE."
+  [scoped-key disposition _spec]
   (if (= :serialize disposition)
-    (let [[scope resource-id params] scoped-key]
-      [scope resource-id (classification/project-params params spec)])
+    scoped-key
     (let [[scope resource-id params] scoped-key]
       [(redact-value scope) resource-id (redact-value params)])))
 
@@ -267,9 +265,11 @@
        inheritance arm, so the disposition no longer depends on `frame-id`;
     3. projected key ← `project-scoped-key scoped-key disposition spec`
        (`:redact` / `:omit` replace scope + params with opaque content-addressed
-       `{:rf/redacted <digest>}` tokens; `:serialize` projects the resource's
-       per-slot `:params` projection-relative declarations — the resource-id
-       always survives).
+       `{:rf/redacted <digest>}` tokens; `:serialize` rides VERBATIM — the
+       resource-id always survives. A `:serialize` key's per-slot `:params` /
+       `:scope` projection-relative declarations are the registry-driven concern
+       of the SSR `project-entry` caller, `classification/project-entry-params`,
+       which has the entry's `key-id` + the live frame — rf2-d3pku1).
 
   The single home for the pipeline the SSR durable-egress projection
   (`project-entry`), the TOOL-egress algebra view (`tooling/project-key-for-
@@ -329,13 +329,10 @@
   [frame-id clock-ms entry]
   (let [scoped-key  (:resource/key entry)
         resource-id (second scoped-key)
+        key-id      (state/key-id scoped-key)
         ;; The shared disposition+project-key pipeline (rf2-366u0g) resolves the
         ;; owner spec ONCE, computes the whole-entry disposition, and projects
         ;; the scoped key in one call:
-        ;;   - the spec carries BOTH the coarse root-prop disposition AND the
-        ;;     per-slot `:data`-rooted declaration marks (`project-data` layer
-        ;;     (a) — EP-0015 §6), needed below for the `:serialize` data
-        ;;     projection;
         ;;   - the disposition is the OWNER's coarse `:sensitive?` / `:large?`
         ;;     root-prop claim ALONE — EP-0025 (rf2-71dr8t) removed the
         ;;     named-scope-resolver derived-sensitivity inheritance arm (no
@@ -343,8 +340,10 @@
         ;;   - `projected-key` is the in-entry `:resource/key` copy projected the
         ;;     SAME way as the wire MAP key (rf2-9e0tyq) — a `:redact` / `:omit`
         ;;     resource redacts its scope + params to opaque content-addressed
-        ;;     tokens, so the raw identity never rides in EITHER carrier.
-        [projected-key disposition spec] (disposition+project-key scoped-key frame-id)
+        ;;     tokens, so the raw identity never rides in EITHER carrier; a
+        ;;     `:serialize` key rides verbatim and its per-slot params are
+        ;;     registry-projected below.
+        [projected-key disposition _spec] (disposition+project-key scoped-key frame-id)
         stale?      (entry-stale? entry clock-ms)
         ;; metadata-only entries refetch on the client if a live route owner
         ;; needs them; serialized stale entries also refetch (background);
@@ -358,28 +357,32 @@
                      :stale-at       (:stale-at entry)
                      :invalidated-at (:invalidated-at entry)}
         wire-entry  (case disposition
-                      ;; ship the data, but PROJECT it through the merged
-                      ;; frame-owned `project-egress` (EP-0015 §10/§11) under
-                      ;; the SSR boundary profile — so a per-slot `:data-schema`
-                      ;; mark the frame classification carries is still redacted
-                      ;; even on a coarse-`:serialize` resource (defense in
-                      ;; depth). `classification/project-data` defers to
-                      ;; `project-egress`; frameless egress rides the data
-                      ;; UNCHANGED so the coarse owner classification (not
-                      ;; frame-presence) governs serialize-vs-redact for a pure /
-                      ;; test-harness projection outside a frame scope.
+                      ;; ship the data, but PROJECT it through the REGISTRY-DRIVEN
+                      ;; egress read (EP-0025, rf2-d3pku1): the resource's
+                      ;; per-slot `:data` declarations were lowered into the
+                      ;; per-frame elision registry at the entry's absolute
+                      ;; `:data` path (`reconcile-registry`), and
+                      ;; `classification/project-entry-data` walks the bare `:data`
+                      ;; through `project-egress` SEEDED at that absolute offset
+                      ;; (`[:rf.runtime/resources :entries <key-id> :data]`) so the
+                      ;; lowered `:source :resource` decls — UNIONED with any frame
+                      ;; app-db classification — redact / elide the declared slots.
+                      ;; The routing / machines standard model: the egress reads
+                      ;; the registry, never re-derives from the spec. A frameless
+                      ;; egress rides the data VERBATIM (the registry is
+                      ;; frame-scoped; the coarse disposition is the separate
+                      ;; frame-independent authority).
                       ;;
-                      ;; rf2-byl7bk.3.2 / EP-0021 R5: for an INFINITE feed the
-                      ;; `:data` is the framework-owned VECTOR OF PAGES, so
-                      ;; `project-data` branches on `spec`'s `:infinite` marker
-                      ;; and applies the per-page `:page-data-schema` contract
-                      ;; PER PAGE (a sensitive / large page field redacts /
-                      ;; elides on every page) rather than treating the page
-                      ;; vector as one `:data-schema`-governed value.
+                      ;; rf2-byl7bk.3.2 / EP-0021 R5: an INFINITE feed's `:data` is
+                      ;; the framework-owned VECTOR OF PAGES; the lowered decl is
+                      ;; `[… :data :field]` and the walker's index-free fork
+                      ;; matches it against the indexed runtime path `[… :data
+                      ;; <page-idx> :field]` on EVERY page — no special per-page
+                      ;; branch.
                       :serialize
                       (assoc entry :data
-                             (classification/project-data
-                               (:data entry) spec frame-id
+                             (classification/project-entry-data
+                               (:data entry) key-id frame-id
                                :rf.egress/ssr-hydration))
                       ;; sensitive: replace data with the redaction sentinel
                       ;; (the entry still announces it exists; metadata only).
@@ -403,8 +406,19 @@
         ;; key computed above (`disposition+project-key`), matching the wire MAP
         ;; key: a `:redact` / `:omit` resource redacts its scope + params to
         ;; opaque content-addressed tokens here too, so the raw identity never
-        ;; rides in EITHER carrier. The client's `recompute-indexes` keys index
-        ;; members on the byte `key-id` of this projected `:resource/key`.
+        ;; rides in EITHER carrier. A `:serialize` key's PARAMS component (index
+        ;; 2) is REGISTRY-PROJECTED (rf2-d3pku1): `classification/project-entry-
+        ;; params` walks it through `project-egress` seeded at the lowered params
+        ;; path so a per-slot `:params` / `:scope` declaration redacts in the wire
+        ;; key without the raw value riding. The client's `recompute-indexes`
+        ;; keys index members on the byte `key-id` of this projected
+        ;; `:resource/key`.
+        projected-key (if (= :serialize disposition)
+                        (let [[scope rid params] projected-key]
+                          [scope rid (classification/project-entry-params
+                                       params key-id frame-id
+                                       :rf.egress/ssr-hydration)])
+                        projected-key)
         wire-entry  (assoc wire-entry :resource/key projected-key)
         meta'       (assoc base
                            :disposition (case disposition

--- a/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
@@ -1,21 +1,23 @@
 (ns re-frame.resources-classification-cljs-test
-  "EP-0015 §6 resource / mutation OWNER-classification reconciliation
-  (rf2-5pld34, bead-plan item 5). Pins the contract that resource durable
-  state projects through the merged frame-owned classification +
-  `project-egress` (Spec 015 §Resource and mutation durable classification /
-  Spec 016 §SSR and hydration):
+  "EP-0015 §6 / EP-0025 resource / mutation OWNER-classification. Pins the
+  contract that resource durable state projects through the merged frame-owned
+  classification + `project-egress` REGISTRY-DRIVEN (Spec 015 §Resource and
+  mutation durable classification / Spec 016 §SSR and hydration):
 
     1. WHOLE-ENTRY coarse `:sensitive?` / `:large?` (the degenerate root-prop
        case, EP-0015 issue 11) → redact / omit; sensitive wins over large;
     2. the canonical fine-grained owner surface is the PROJECTION-RELATIVE
-       `:sensitive` / `:large` path declarations on the spec (EP-0025); the
-       per-slot `:data-schema` / `:params-schema` `:sensitive?` / `:large?`
+       `:sensitive` / `:large` path declarations on the spec (EP-0025), LOWERED
+       per instance into the per-frame elision registry (`reconcile-registry`,
+       `:source :resource`); the per-slot `:data-schema` / `:params-schema`
        props VALIDATE only — they do NOT drive durable classification
-       (rf2-fuqcob, mirroring the rf2-398kql machine schema-bridge reversal);
-    3. a `:serialize` entry's data projects through frame classification
-       (`project-egress`) — the frame-owned source of truth the prior
-       resource-local redaction now defers to; a frame-classified sub-path is
-       redacted even on a coarse-`:serialize` resource (defense in depth);
+       (rf2-fuqcob);
+    3. the SSR egress READS the registry (rf2-d3pku1, the routing / machines
+       standard model): `project-entry-data` / `project-entry-params` walk the
+       entry value through `project-egress` seeded at the lowered absolute path
+       — the redundant family-private `project-data` / `project-params`
+       re-derivation is REMOVED. A frame-classified sub-path is unioned with the
+       resource declaration (defense in depth);
     4. the load-bearing Spec 016 rules are preserved (only the durable
        `:entries` slice rides; metadata-only redacted/omitted hydration;
        scoped-key privacy).
@@ -30,10 +32,10 @@
    [re-frame.core :as rf]
    [re-frame.elision :as elision]
    [re-frame.frame :as frame]
-   [re-frame.late-bind :as late-bind]
    [re-frame.privacy :as privacy]
    ;; the unit under test + the SSR projection that consumes it.
    [re-frame.resources.classification :as classification]
+   [re-frame.resources.registry :as registry]
    [re-frame.resources.ssr :as ssr]
    [re-frame.resources.state :as state]
    ;; load-bearing side-effecting requires: the façade registers the
@@ -79,6 +81,24 @@
                                        entries)
                         :tag-index {} :owner-index {}}})
 
+;; rf2-d3pku1 — the SSR egress is now REGISTRY-DRIVEN. To exercise an end-to-end
+;; SSR projection, LOWER each entry's resource classification into the live
+;; frame's per-frame elision registry (`reconcile-registry` → the frame's
+;; runtime-db `[:rf.runtime/elision]`), exactly as a resource handler does at
+;; commit (`with-classification-lowering`) and as the routing SSR egress test
+;; installs route decls. Then project under that frame (`rf/with-frame`), which
+;; the SSR projector resolves as the current frame.
+(defn- ssr-project
+  "Project `runtime-db`'s resource `:entries` for SSR under `frame-id`, having
+  first lowered the resource classification into the frame's registry (the live
+  durable home of `[:rf.runtime/elision]`). Returns the projection map."
+  [frame-id runtime-db]
+  (let [lowered (classification/reconcile-registry runtime-db registry/resource-meta)]
+    (when-let [reg (get lowered :rf.runtime/elision)]
+      (elision/swap-elision-slot! frame-id (constantly reg)))
+    (rf/with-frame frame-id
+      (ssr/project-resources-runtime-db lowered))))
+
 ;; The projection map is byte-keyed; the projected SCOPED KEY (verbatim or
 ;; redacted) rides as the wire entry's `:resource/key`. Return it as the
 ;; first element so the privacy/distinctness assertions inspect it.
@@ -103,117 +123,9 @@
                        {:sensitive? true :large? true}))))))
 
 ;; ===========================================================================
-;; 2. data-schema-marks — the projection-relative DATA declarations (EP-0025).
-;;    fuqcob: `:data-schema` per-slot props VALIDATE only; they do NOT classify.
-;; ===========================================================================
-
-(deftest data-schema-marks-read-projection-relative-data-declarations
-  (testing "data-schema-marks reads the spec's :data-rooted projection-relative
-            :sensitive / :large declarations (the canonical surface), rooted at
-            the data root"
-    (let [spec {:sensitive [[:data :token]]
-                :large     [[:data :blob]]}
-          {:keys [sensitive large]} (classification/data-schema-marks spec)]
-      (is (contains? sensitive [:token]) "the :data :token sensitive declaration is read")
-      (is (contains? large [:blob]) "the :data :blob large declaration is read")
-      (is (true? (classification/data-schema-classifies? spec))
-          "data-schema-classifies? is true when any :data declaration is present"))))
-
-(deftest data-schema-props-do-not-classify-durably
-  (testing "fuqcob: per-slot :sensitive? / :large? props on :data-schema do NOT
-            drive durable classification — the schema VALIDATES only"
-    (let [spec {:data-schema [:map
-                              [:token {:sensitive? true} :string]
-                              [:blob  {:large? true} :string]
-                              [:title :string]]}
-          {:keys [sensitive large]} (classification/data-schema-marks spec)]
-      (is (= {} sensitive) "no sensitive marks from :data-schema props")
-      (is (= {} large) "no large marks from :data-schema props")
-      (is (false? (classification/data-schema-classifies? spec))
-          "data-schema-classifies? is false — a :data-schema does not classify"))))
-
-(deftest data-schema-marks-empty-without-declaration
-  (testing "no :data declaration → empty maps, classifies? false"
-    (is (= {} (:sensitive (classification/data-schema-marks {}))))
-    (is (= {} (:large (classification/data-schema-marks {}))))
-    (is (false? (classification/data-schema-classifies? {})))))
-
-;; ===========================================================================
-;; 2b. params-schema-marks — the CO-EQUAL projection-relative PARAMS surface.
-;;     fuqcob: `:params-schema` props VALIDATE only; they do NOT classify.
-;; ===========================================================================
-
-(deftest params-schema-marks-read-projection-relative-params-declarations
-  (testing "params-schema-marks reads the spec's :params-rooted (and
-            :scope-rooted) projection-relative :sensitive / :large declarations
-            — the co-equal params surface"
-    (let [spec {:sensitive [[:params :account-id]]
-                :large     [[:params :cursor]]}
-          {:keys [sensitive large]} (classification/params-schema-marks spec)]
-      (is (contains? sensitive [:account-id]) "the :params :account-id sensitive declaration is read")
-      (is (contains? large [:cursor]) "the :params :cursor large declaration is read")
-      (is (true? (classification/params-schema-classifies? spec))
-          "params-schema-classifies? is true when any :params declaration is present"))))
-
-(deftest params-schema-props-do-not-classify-durably
-  (testing "fuqcob: per-slot :sensitive? / :large? props on :params-schema do
-            NOT drive durable classification — the schema VALIDATES only"
-    (let [spec {:params-schema [:map
-                                 [:account-id {:sensitive? true} :string]
-                                 [:cursor     {:large? true} :string]
-                                 [:page :int]]}
-          {:keys [sensitive large]} (classification/params-schema-marks spec)]
-      (is (= {} sensitive) "no sensitive marks from :params-schema props")
-      (is (= {} large) "no large marks from :params-schema props")
-      (is (false? (classification/params-schema-classifies? spec))
-          "params-schema-classifies? is false — a :params-schema does not classify"))))
-
-(deftest params-schema-marks-empty-without-declaration
-  (testing "no :params declaration → empty maps, classifies? false"
-    (is (= {} (:sensitive (classification/params-schema-marks {}))))
-    (is (= {} (:large (classification/params-schema-marks {}))))
-    (is (false? (classification/params-schema-classifies? {})))))
-
-(deftest project-params-redacts-sensitive-and-elides-large
-  (testing "project-params applies the owner's :params-rooted projection-relative
-            declarations — sensitive slots redact to the :rf/redacted sentinel,
-            large slots elide to the :rf.size/large-elided marker, plain slots
-            ride verbatim — via the SHARED redact-with-paths walker, frame-
-            independently"
-    (let [spec {:sensitive [[:params :account-id]]
-                :large     [[:params :cursor]]}
-          out  (classification/project-params
-                 {:account-id "acct-secret-42" :cursor (apply str (repeat 200 "x")) :page 3}
-                 spec)]
-      (is (= privacy/redacted-sentinel (:account-id out))
-          "the declared :params :account-id slot is redacted")
-      (is (contains? (:cursor out) :rf.size/large-elided)
-          "the declared :params :cursor slot is elided to the size marker")
-      (is (= 3 (:page out)) "the plain params slot rides verbatim")
-      (is (not (str/includes? (pr-str out) "acct-secret-42"))
-          "the raw sensitive params value does not ride"))))
-
-(deftest project-params-sensitive-wins-over-large
-  (testing "a params slot declared BOTH sensitive and large redacts (sensitive
-            wins over large — the shared walker ordering, same as data + HTTP body)"
-    (let [spec {:sensitive [[:params :token]] :large [[:params :token]]}
-          out  (classification/project-params {:token (apply str (repeat 100 "z"))} spec)]
-      (is (= privacy/redacted-sentinel (:token out))
-          "sensitive wins — the slot is the redaction sentinel, not a large marker"))))
-
-(deftest project-params-no-marks-rides-verbatim
-  (testing "a spec with no :params declaration (or nil spec) rides params
-            UNCHANGED — the coarse whole-entry disposition is the separate
-            authority that redacts/omits the whole key"
-    (is (= {:slug "x"} (classification/project-params {:slug "x"}
-                                                      {:params-schema [:map [:slug :string]]})))
-    (is (= {:slug "x"} (classification/project-params {:slug "x"} nil)))))
-
-;; ===========================================================================
-;; 2c. EP-0025 §subsystems — projection-relative `:sensitive` / `:large`
-;;     declarations on the resource / mutation spec (rf2-h3d8tf). The canonical
-;;     surface (the matrix example), UNIONED with the schema-prop route, split
-;;     across the data / params projections, redacting at egress.
+;; 2. spec-declaration-marks — the projection-relative declaration axis-split
+;;    (the shape the per-instance lowering re-roots). fuqcob: schema props do
+;;    NOT contribute (no union — the schema validates, it does not classify).
 ;; ===========================================================================
 
 (deftest spec-declaration-marks-split-across-projections
@@ -231,44 +143,17 @@
       (is (contains? (:sensitive params) [:scope :tenant]) ":scope-rooted sensitive → params projection (whole path)")
       (is (contains? (:large params) [:cursor]) ":params-rooted large → params projection"))))
 
-(deftest data-schema-marks-projection-relative-only-no-schema-prop-union
-  (testing "fuqcob — data-schema-marks reads ONLY the projection-relative
-            :sensitive / :large :data declarations; a co-present :data-schema's
-            per-slot props do NOT contribute (no union — the schema validates,
-            it does not classify durably)"
+(deftest spec-declaration-marks-ignores-schema-props
+  (testing "fuqcob — spec-declaration-marks reads ONLY the projection-relative
+            :sensitive / :large declarations; a co-present :data-schema /
+            :params-schema's per-slot props do NOT contribute (the schema
+            validates, it does not classify durably)"
     (let [spec {:sensitive [[:data :ssn]]
-                :large     [[:data :avatar-bytes]]
-                :data-schema [:map [:token {:sensitive? true} :string] [:title :string]]}
-          {:keys [sensitive large]} (classification/data-schema-marks spec)]
-      (is (contains? sensitive [:ssn]) "projection-relative sensitive :data path is present")
-      (is (not (contains? sensitive [:token])) "schema-prop sensitive slot is NOT present (no union)")
-      (is (contains? large [:avatar-bytes]) "projection-relative large :data path is present")
-      (is (true? (classification/data-schema-classifies? spec))))))
-
-(deftest project-data-redacts-projection-relative-declaration
-  (testing "EP-0025 matrix example — (rf/reg-resource :user-profile
-            {:sensitive [[:data :ssn]] :large [[:data :avatar-bytes]]}): the
-            declared :data :ssn slot redacts at egress, the :avatar-bytes slot
-            elides, a plain sibling rides verbatim — no :data-schema needed"
-    (let [spec {:sensitive [[:data :ssn]]
-                :large     [[:data :avatar-bytes]]}
-          out  (classification/project-data
-                 {:ssn "123-45-6789" :avatar-bytes (apply str (repeat 200 "x")) :name "Alice"}
-                 spec nil :rf.egress/off-box-tool)]
-      (is (= privacy/redacted-sentinel (:ssn out)) "declared :data :ssn redacts")
-      (is (contains? (:avatar-bytes out) :rf.size/large-elided) "declared :data :avatar-bytes elides")
-      (is (= "Alice" (:name out)) "an undeclared sibling rides verbatim")
-      (is (not (str/includes? (pr-str out) "123-45-6789")) "the raw SSN does not ride"))))
-
-(deftest project-params-redacts-projection-relative-declaration
-  (testing "EP-0025 — a :params-rooted projection-relative declaration redacts
-            the scoped-key params at egress (the co-equal params projection),
-            no :params-schema prop needed"
-    (let [spec {:sensitive [[:params :account-id]]}
-          out  (classification/project-params {:account-id "acct-secret-7" :page 2} spec)]
-      (is (= privacy/redacted-sentinel (:account-id out)) "declared :params :account-id redacts")
-      (is (= 2 (:page out)) "a plain params slot rides verbatim")
-      (is (not (str/includes? (pr-str out) "acct-secret-7"))))))
+                :data-schema   [:map [:token {:sensitive? true} :string] [:title :string]]
+                :params-schema [:map [:account-id {:sensitive? true} :string] [:slug :string]]}
+          {:keys [data]} (classification/spec-declaration-marks spec)]
+      (is (contains? (:sensitive data) [:ssn]) "projection-relative sensitive :data path is present")
+      (is (not (contains? (:sensitive data) [:token])) "schema-prop sensitive slot is NOT present (no union)"))))
 
 (deftest reg-resource-rejects-malformed-classification-declaration
   (testing "EP-0025 fail-loud-input — reg-resource rejects a malformed
@@ -284,117 +169,88 @@
         "a non-vector :sensitive axis is rejected at reg-resource")))
 
 ;; ===========================================================================
-;; 3. project-data — defer to the merged frame-owned project-egress
+;; 2b. registry-driven egress projectors — the routing / machines standard
+;;     model (rf2-d3pku1). `project-entry-data` / `project-entry-params` walk
+;;     the entry value through project-egress seeded at the lowered absolute
+;;     offset, reading the per-frame elision registry (NOT re-deriving from
+;;     the spec). Frameless rides verbatim.
 ;; ===========================================================================
 
-(deftest project-data-frameless-rides-unchanged-without-owner-marks
-  (testing "frameless projection with no owner marks rides the data UNCHANGED —
-            the coarse owner classification (not frame-presence) governs
-            serialize-vs-redact; a pure / test-harness projection outside a
-            frame is not over-redacted to the fail-closed sentinel"
-    (is (= {:title "X"}
-           (classification/project-data {:title "X"} {} nil :rf.egress/ssr-hydration)))))
+(deftest project-entry-data-frameless-rides-verbatim
+  (testing "rf2-d3pku1: a nil-frame projection rides the data VERBATIM — the
+            registry is frame-scoped, and the coarse disposition is the separate
+            frame-independent authority (matches machines / routing
+            fail-open-frameless)"
+    (is (= {:title "X" :token "tok"}
+           (classification/project-entry-data
+             {:title "X" :token "tok"} "k-1" nil :rf.egress/ssr-hydration)))))
 
-(deftest project-data-applies-owner-projection-relative-sensitive-decl
-  (testing "EP-0025: the resource-owned :data-rooted projection-relative
-            :sensitive declaration (layer (a)) redacts its slot REGARDLESS of
-            frame classification — the canonical fine-grained owner surface,
-            firing even frameless (resource cache data does not live at a frame
-            app-db path)"
-    (let [spec {:sensitive [[:data :token]]}
-          projected (classification/project-data
-                      {:token "tok-123" :title "public"} spec nil :rf.egress/ssr-hydration)]
-      (is (= privacy/redacted-sentinel (:token projected))
-          "the declared :data :token slot is redacted even with no frame")
-      (is (= "public" (:title projected)) "the undeclared sibling rides verbatim")
-      (is (not (str/includes? (pr-str projected) "tok-123"))
-          "the raw owner-declared value does not ride"))))
+(deftest project-entry-data-redacts-registry-lowered-sensitive-slot
+  (reg! :acct/profile {:sensitive [[:data :ssn]]})
+  (testing "rf2-d3pku1: after the resource declaration is lowered into the
+            frame's registry at the entry's absolute :data path,
+            project-entry-data walks the bare :data through project-egress seeded
+            at that offset and redacts the declared :ssn slot; a sibling rides"
+    (rf/reg-frame :reg/frame {})
+    (let [k       (state/scoped-resource-key :rf.scope/global :acct/profile {:slug "x"})
+          k-id    (state/key-id k)
+          rdb     (runtime-db-with {k (entry {:resource-id :acct/profile
+                                              :data {:ssn "123-45-6789" :name "Alice"}})})
+          lowered (classification/reconcile-registry rdb registry/resource-meta)]
+      (elision/swap-elision-slot! :reg/frame (constantly (get lowered :rf.runtime/elision)))
+      (let [data      (get-in lowered [state/resources-key :entries k-id :data])
+            projected (classification/project-entry-data
+                        data k-id :reg/frame :rf.egress/off-box-tool)]
+        (is (= :rf/redacted (:ssn projected))
+            "the registry-lowered :data :ssn slot is redacted")
+        (is (= "Alice" (:name projected)) "the undeclared sibling rides verbatim")
+        (is (not (str/includes? (pr-str projected) "123-45-6789"))
+            "the raw value does not ride")))))
 
-(deftest project-data-redacts-frame-classified-slot
-  (testing "EP-0015 §6 reconciliation: a :serialize entry's data projects
-            through the merged frame-owned project-egress (layer (b)) — a
-            frame-classified sensitive sub-path is REDACTED on projection
-            (frame-owned source of truth), while unclassified siblings ride
-            verbatim"
-    ;; EP-0025: classify a sensitive app-db path via the commit-plane effect
-    ;; path (:source :effect); the elision registry the project-egress walker
-    ;; reads is populated from it. (No longer a frame annotation.)
-    (rf/reg-frame :rcfg/main {})
-    (frame/swap-runtime-db! :rcfg/main
-      (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:secret]]})))
-    (let [projected (classification/project-data
-                      {:secret "tok-123" :title "public"}
-                      {}
-                      :rcfg/main
-                      :rf.egress/ssr-hydration)]
-      (is (= privacy/redacted-sentinel (:secret projected))
-          "the frame-classified :secret slot is redacted on projection")
-      (is (= "public" (:title projected))
-          "the unclassified sibling rides verbatim")
-      (is (not (str/includes? (pr-str projected) "tok-123"))
-          "the raw sensitive value does not ride anywhere"))))
-
-(deftest project-data-composes-owner-and-frame-marks
-  (testing "EP-0015 §6: owner declarations (a) AND frame classification (b)
-            COMPOSE — both a resource-owned :data-rooted sensitive declaration
-            and a frame-classified app-db slot redact in one projection"
-    (rf/reg-frame :rcfg/both {})
-    (frame/swap-runtime-db! :rcfg/both
-      (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:frame-secret]]})))
-    (let [spec {:sensitive [[:data :owner-secret]]}
-          projected (rf/with-frame :rcfg/both
-                      (classification/project-data
-                        {:owner-secret "o-1" :frame-secret "f-1" :title "ok"}
-                        spec :rcfg/both :rf.egress/ssr-hydration))]
-      (is (= privacy/redacted-sentinel (:owner-secret projected)) "owner declaration fired")
-      (is (= privacy/redacted-sentinel (:frame-secret projected)) "frame mark fired")
-      (is (= "ok" (:title projected)) "unclassified sibling rides verbatim"))))
-
-(deftest project-data-elides-owner-large-declaration-slot
-  (testing "rf2-260yhk / EP-0025: a resource-owned :data-rooted :large
-            declaration (layer (a)) ELIDES its slot to the :rf.size/large-elided
-            marker — NOT riding RAW — REGARDLESS of frame classification (the
-            canonical fine-grained owner surface, firing even frameless; resource
-            cache data does not live at a frame app-db path)"
-    (let [big  (apply str (repeat 500 "x"))
-          spec {:large [[:data :body]]}
-          projected (classification/project-data
-                      {:body big :title "public"} spec nil :rf.egress/ssr-hydration)]
-      (is (contains? (:body projected) :rf.size/large-elided)
-          "the declared :data :body slot is elided to the size marker, even frameless")
-      (is (= "public" (:title projected)) "the undeclared sibling rides verbatim")
-      (is (not (str/includes? (pr-str projected) big))
-          "the raw large value does NOT ride on the wire"))))
-
-(deftest project-data-sensitive-wins-over-large-owner-slot
-  (testing "rf2-260yhk: a :data slot declared BOTH sensitive and large redacts
-            (sensitive wins over large — the shared walker ordering, same as
-            project-params + HTTP body)"
-    (let [spec {:sensitive [[:data :token]] :large [[:data :token]]}
-          projected (classification/project-data
-                      {:token (apply str (repeat 200 "z"))} spec nil :rf.egress/ssr-hydration)]
-      (is (= privacy/redacted-sentinel (:token projected))
-          "sensitive wins — the slot is the redaction sentinel, not a large marker"))))
-
-(deftest ssr-serialize-entry-elides-owner-large-declaration-slot
+(deftest project-entry-data-elides-registry-lowered-large-slot
   (reg! :report/card {:large [[:data :blob]]})
-  (testing "rf2-260yhk / EP-0025 END-TO-END: a :serialize resource whose OWN
-            :data-rooted :large declaration marks a slot ELIDES that slot on SSR
-            projection — the canonical fine-grained owner surface fires WITHOUT
-            requiring a matching frame app-db mark (the bug: the large leaf rode RAW)"
-    (let [big (apply str (repeat 1000 "q"))
-          k   (state/scoped-resource-key :rf.scope/global :report/card {:slug "r"})
-          e   (entry {:resource-id :report/card :data {:blob big :name "ok"}})
-          [_ we] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))]
-      (is (contains? (:blob (:data we)) :rf.size/large-elided)
-          "the owner-marked :blob slot is elided on the serialized entry")
-      (is (= "ok" (:name (:data we))) "the unmarked sibling rides verbatim")
-      (is (= :loaded (:status we)) "metadata (status) still rides")
-      (is (not (str/includes? (pr-str we) big))
-          "no raw large value rides on the serialized entry"))))
+  (testing "rf2-d3pku1 / rf2-260yhk: a registry-lowered :data :large declaration
+            ELIDES its slot to the :rf.size/large-elided marker at egress"
+    (rf/reg-frame :reg/large {})
+    (let [big     (apply str (repeat 500 "x"))
+          k       (state/scoped-resource-key :rf.scope/global :report/card {:slug "r"})
+          k-id    (state/key-id k)
+          rdb     (runtime-db-with {k (entry {:resource-id :report/card
+                                              :data {:blob big :title "public"}})})
+          lowered (classification/reconcile-registry rdb registry/resource-meta)]
+      (elision/swap-elision-slot! :reg/large (constantly (get lowered :rf.runtime/elision)))
+      (let [data      (get-in lowered [state/resources-key :entries k-id :data])
+            projected (classification/project-entry-data
+                        data k-id :reg/large :rf.egress/off-box-tool)]
+        (is (contains? (:blob projected) :rf.size/large-elided)
+            "the registry-lowered :data :blob slot is elided to the size marker")
+        (is (= "public" (:title projected)) "the undeclared sibling rides verbatim")
+        (is (not (str/includes? (pr-str projected) big))
+            "the raw large value does NOT ride")))))
+
+(deftest project-entry-params-redacts-registry-lowered-sensitive-slot
+  (reg! :report/by-account {:sensitive     [[:params :account-id]]
+                            :params-schema [:map [:account-id :string] [:slug :string]]})
+  (testing "rf2-d3pku1: project-entry-params walks the scoped-key params component
+            through project-egress seeded at the lowered :resource/key params
+            offset and redacts the declared :account-id slot"
+    (rf/reg-frame :reg/params {})
+    (let [k       (state/scoped-resource-key :rf.scope/global :report/by-account
+                                             {:account-id "acct-secret-42" :slug "q3"})
+          k-id    (state/key-id k)
+          rdb     (runtime-db-with {k (entry {:resource-id :report/by-account :data {:total 99}})})
+          lowered (classification/reconcile-registry rdb registry/resource-meta)]
+      (elision/swap-elision-slot! :reg/params (constantly (get lowered :rf.runtime/elision)))
+      (let [params    (nth k 2)
+            projected (classification/project-entry-params
+                        params k-id :reg/params :rf.egress/ssr-hydration)]
+        (is (= privacy/redacted-sentinel (:account-id projected))
+            "the registry-lowered :params :account-id slot is redacted")
+        (is (= "q3" (:slug projected)) "the unmarked params sibling rides verbatim")
+        (is (not (str/includes? (pr-str projected) "acct-secret-42")))))))
 
 ;; ===========================================================================
-;; 4. SSR projection — the reconciliation end-to-end
+;; 3. SSR projection — the reconciliation end-to-end (registry-driven)
 ;; ===========================================================================
 
 (deftest ssr-coarse-sensitive-redacts-whole-entry
@@ -422,93 +278,104 @@
   (testing "EP-0015 §6: a :serialize resource's data is PROJECTED through the
             frame-owned project-egress on SSR — a frame-classified sensitive
             sub-path is redacted even though the resource itself carries no
-            coarse claim (defense in depth via the frame-owned source of truth)"
-    ;; the SSR projection resolves the current frame; declare classification on
-    ;; it, then project under it. EP-0025: classified via the commit-plane
-    ;; effect path (:source :effect), no longer a frame annotation.
+            coarse claim (defense in depth via the frame-owned source of truth,
+            unioned with the resource registry at lookup)"
+    ;; the SSR projection resolves the current frame; classify a path on it via
+    ;; the commit-plane effect at the entry's absolute :data path (the frame may
+    ;; additionally classify a subsystem absolute path — Spec 015 L149).
     (rf/reg-frame :rcfg/ssr {})
-    (frame/swap-runtime-db! :rcfg/ssr
-      (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:secret]]})))
-    (let [k   (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"})
-          e   (entry {:resource-id :article/by-slug
-                      :data {:secret "tok-xyz" :title "hello"}})
-          ;; drive the projection under the classified frame (the walker reads
-          ;; the in-effect carried frame scope).
-          proj (rf/with-frame :rcfg/ssr
-                 (ssr/project-resources-runtime-db (runtime-db-with {k e})))
-          [_ we] (only-wire-entry proj)]
-      (is (= privacy/redacted-sentinel (:secret (:data we)))
-          "the frame-classified :secret slot is redacted on the serialized entry")
-      (is (= "hello" (:title (:data we)))
-          "the unclassified sibling rides verbatim")
-      (is (not (str/includes? (pr-str we) "tok-xyz"))
-          "no raw sensitive value rides on the serialized entry"))))
+    (let [k    (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"})
+          k-id (state/key-id k)
+          e    (entry {:resource-id :article/by-slug
+                       :data {:secret "tok-xyz" :title "hello"}})]
+      (frame/swap-runtime-db! :rcfg/ssr
+        (fn [rt] (elision/apply-classification-effects
+                   rt {:sensitive [[:rf.runtime/resources :entries k-id :data :secret]]})))
+      (let [proj (rf/with-frame :rcfg/ssr
+                   (ssr/project-resources-runtime-db (runtime-db-with {k e})))
+            [_ we] (only-wire-entry proj)]
+        (is (= privacy/redacted-sentinel (:secret (:data we)))
+            "the frame-classified :secret slot is redacted on the serialized entry")
+        (is (= "hello" (:title (:data we)))
+            "the unclassified sibling rides verbatim")
+        (is (not (str/includes? (pr-str we) "tok-xyz"))
+            "no raw sensitive value rides on the serialized entry")))))
 
 (deftest ssr-serialize-entry-redacts-owner-data-declaration-slot
   (reg! :profile/card {:sensitive [[:data :pan]]})
-  (testing "EP-0025 END-TO-END: a :serialize resource whose OWN :data-rooted
-            :sensitive declaration marks a slot redacts that slot on SSR
-            projection — the canonical fine-grained owner surface fires
-            irrespective of any frame app-db classification"
+  (testing "EP-0025 / rf2-d3pku1 END-TO-END: a :serialize resource whose OWN
+            :data-rooted :sensitive declaration is LOWERED into the registry
+            redacts that slot on SSR projection — the registry-driven egress
+            read fires (the standard model)"
+    (rf/reg-frame :rcfg/owner-data {})
     (let [k   (state/scoped-resource-key :rf.scope/global :profile/card {:slug "x"})
           e   (entry {:resource-id :profile/card
                       :data {:pan "4111-1111-1111-1111" :name "Alice"}})
-          ;; no frame app-db classification declares :pan — the OWNER's
-          ;; data-schema mark is the only source, and it must fire.
-          [_ we] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))]
+          [_ we] (only-wire-entry (ssr-project :rcfg/owner-data (runtime-db-with {k e})))]
       (is (= :serialize (classification/whole-entry-disposition
                           (rf/resource-meta :profile/card)))
           "no coarse claim → :serialize (the per-slot mark is the fine-grained surface)")
       (is (= privacy/redacted-sentinel (get-in we [:data :pan]))
-          "the owner-marked :pan slot is redacted on the serialized entry")
+          "the owner-declared :pan slot is redacted on the serialized entry")
       (is (= "Alice" (get-in we [:data :name])) "the unmarked sibling rides verbatim")
       (is (not (str/includes? (pr-str we) "4111-1111-1111-1111"))
           "no raw owner-marked value rides on the wire"))))
+
+(deftest ssr-serialize-entry-elides-owner-large-declaration-slot
+  (reg! :report/blob {:large [[:data :blob]]})
+  (testing "rf2-260yhk / rf2-d3pku1 END-TO-END: a :serialize resource whose OWN
+            :data-rooted :large declaration is lowered ELIDES that slot on SSR
+            projection (the registry-driven owner surface fires)"
+    (rf/reg-frame :rcfg/owner-large {})
+    (let [big (apply str (repeat 1000 "q"))
+          k   (state/scoped-resource-key :rf.scope/global :report/blob {:slug "r"})
+          e   (entry {:resource-id :report/blob :data {:blob big :name "ok"}})
+          [_ we] (only-wire-entry (ssr-project :rcfg/owner-large (runtime-db-with {k e})))]
+      (is (contains? (:blob (:data we)) :rf.size/large-elided)
+          "the owner-declared :blob slot is elided on the serialized entry")
+      (is (= "ok" (:name (:data we))) "the unmarked sibling rides verbatim")
+      (is (= :loaded (:status we)) "metadata (status) still rides")
+      (is (not (str/includes? (pr-str we) big))
+          "no raw large value rides on the serialized entry"))))
 
 (deftest ssr-serialize-entry-redacts-owner-params-declaration-slot-in-key
   (reg! :report/by-account {:sensitive [[:params :account-id]]
                             :params-schema [:map
                                             [:account-id :string]
                                             [:slug :string]]})
-  (testing "EP-0025 END-TO-END: a :serialize resource whose OWN :params-rooted
-            :sensitive declaration marks a params slot must NOT ride that slot
-            RAW in the projected wire KEY — the params surface is co-equal with
-            the data surface (Spec 016 clause 4). The coarse claim leaves the key
-            serialized, so the per-slot params declaration is the only thing
-            standing between the secret and every SSR visitor's wire"
+  (testing "EP-0025 / rf2-d3pku1 END-TO-END: a :serialize resource whose OWN
+            :params-rooted :sensitive declaration is lowered must NOT ride that
+            slot RAW in the projected wire KEY — the params surface is co-equal
+            with the data surface (Spec 016 clause 4)"
+    (rf/reg-frame :rcfg/owner-params {})
     (let [k   (state/scoped-resource-key :rf.scope/global :report/by-account
                                          {:account-id "acct-secret-42" :slug "q3"})
           e   (entry {:resource-id :report/by-account :data {:total 99}})
-          [wk we] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))]
+          [wk we] (only-wire-entry (ssr-project :rcfg/owner-params (runtime-db-with {k e})))]
       (is (= :serialize (classification/whole-entry-disposition
                           (rf/resource-meta :report/by-account)))
           "no coarse claim → :serialize (the per-slot params mark is the surface)")
       (is (= :report/by-account (nth wk 1)) "resource-id preserved (position 1)")
       (is (= privacy/redacted-sentinel (get-in wk [2 :account-id]))
-          "the owner-marked :account-id params slot is redacted in the wire key")
+          "the owner-declared :account-id params slot is redacted in the wire key")
       (is (= "q3" (get-in wk [2 :slug])) "the unmarked params sibling rides verbatim")
       (is (= {:total 99} (:data we)) "the (unmarked) data rides verbatim — serialize")
       (is (not (str/includes? (pr-str wk) "acct-secret-42"))
           "no raw sensitive params value rides in the wire key"))))
 
 ;; ===========================================================================
-;; 4b. infinite-feed per-page egress (rf2-byl7bk.3.2 / EP-0025 fuqcob)
+;; 3b. infinite-feed per-page egress (rf2-byl7bk.3.2 / rf2-d3pku1)
 ;; ===========================================================================
 ;;
 ;; EP-0021 R5 / Spec 016 §Registration — :infinite: an infinite feed's
-;; `:data` is the framework-owned VECTOR OF PAGES, and its per-page
-;; egress/classification contract is the resource's :data-rooted projection-
-;; relative `:sensitive` / `:large` declarations, applied PER PAGE. EP-0025
-;; (fuqcob): the `:page-data-schema` VALIDATES each page but does NOT classify
-;; durably (mirroring `:data-schema`). SSR / tool / trace projection MUST apply
-;; the per-page declaration so a sensitive / large page field is classified
-;; before it crosses a boundary.
+;; `:data` is the framework-owned VECTOR OF PAGES. The lowered registry decl is
+;; `[… :data :field]`; `elide-wire-value`'s index-free fork matches it against
+;; the indexed runtime path `[… :data <page-idx> :field]` on EVERY page — no
+;; special per-page branch.
 
 (defn- infinite-entry-with-pages
   "Build a `:loaded` infinite-feed entry for `resource-id` carrying `pages` (a
-  vector of decoded page values) as its durable `:data` page vector. Mirrors
-  the `entry` helper but seeds the `:infinite?` marker + the page-params
-  alongside the page vector so the projection's infinite branch fires."
+  vector of decoded page values) as its durable `:data` page vector."
   [resource-id pages]
   (merge (state/empty-infinite-entry resource-id)
          {:status      :loaded
@@ -517,76 +384,25 @@
           :loaded-at   1000
           :stale-at    9.0e15}))
 
-(deftest project-data-applies-per-page-sensitive-declaration
-  (testing "rf2-byl7bk.3.2 / EP-0025: an :infinite resource's :data is a VECTOR
-            of pages; the per-page :data-rooted :sensitive declaration redacts
-            that field on EVERY page — the :data-schema is NOT used (fuqcob)"
-    (let [spec  {:infinite  true
-                 :sensitive [[:data :token]]}
-          pages [{:token "tok-0" :title "page-0"}
-                 {:token "tok-1" :title "page-1"}]
-          projected (classification/project-data
-                      pages spec nil :rf.egress/ssr-hydration)]
-      (is (vector? projected) "the page-vector SHAPE is preserved")
-      (is (= 2 (count projected)) "every page is preserved")
-      (is (= privacy/redacted-sentinel (:token (nth projected 0)))
-          "page-0's declared :token is redacted")
-      (is (= privacy/redacted-sentinel (:token (nth projected 1)))
-          "page-1's declared :token is redacted")
-      (is (= "page-0" (:title (nth projected 0))) "page-0's undeclared sibling rides")
-      (is (= "page-1" (:title (nth projected 1))) "page-1's undeclared sibling rides")
-      (is (not (str/includes? (pr-str projected) "tok-0"))
-          "no raw page-0 sensitive value rides")
-      (is (not (str/includes? (pr-str projected) "tok-1"))
-          "no raw page-1 sensitive value rides"))))
-
-(deftest project-data-applies-per-page-large-declaration
-  (testing "rf2-byl7bk.3.2 / EP-0025: a per-page :data-rooted :large declaration
-            ELIDES that field to the :rf.size/large-elided marker on every page"
-    (let [big   (apply str (repeat 500 "x"))
-          spec  {:infinite true
-                 :large    [[:data :body]]}
-          pages [{:body big :title "p0"} {:body big :title "p1"}]
-          projected (classification/project-data
-                      pages spec nil :rf.egress/ssr-hydration)]
-      (is (contains? (:body (nth projected 0)) :rf.size/large-elided)
-          "page-0's large field is elided to the size marker")
-      (is (contains? (:body (nth projected 1)) :rf.size/large-elided)
-          "page-1's large field is elided to the size marker")
-      (is (not (str/includes? (pr-str projected) big))
-          "no raw large page value rides"))))
-
-(deftest project-data-infinite-ignores-page-data-schema-props
-  (testing "rf2-byl7bk.3.2 / EP-0025 (fuqcob): an :infinite resource's
-            :page-data-schema VALIDATES each page but does NOT classify — with
-            no :data-rooted declaration the pages ride verbatim"
-    (let [spec  {:infinite true
-                 ;; a :page-data-schema with a :sensitive? prop must NOT classify.
-                 :page-data-schema [:map [:token {:sensitive? true} :string]]}
-          pages [{:token "tok-0"}]
-          projected (classification/project-data
-                      pages spec nil :rf.egress/ssr-hydration)]
-      (is (= pages projected)
-          "the page vector rides verbatim — :page-data-schema props do not classify"))))
-
 (deftest ssr-infinite-feed-redacts-sensitive-page-field-per-page
   (reg! :feed/timeline {:infinite        true
                         :next-page-param (fn [_last _all] nil)
                         :sensitive       [[:data :author-email]]})
-  (testing "rf2-byl7bk.3.2 / EP-0025 END-TO-END: an infinite feed whose
-            :data-rooted :sensitive declaration marks a page field redacts that
-            field on EVERY page during SSR projection — the page body must not
-            ship RAW across the SSR/hydration + tool/trace AI boundary"
+  (testing "rf2-byl7bk.3.2 / rf2-d3pku1 END-TO-END: an infinite feed whose
+            :data-rooted :sensitive declaration is lowered redacts that field on
+            EVERY page during SSR projection (the index-free decl matches every
+            indexed page path)"
+    (rf/reg-frame :rcfg/infinite {})
     (let [k    (state/scoped-resource-key :rf.scope/global :feed/timeline {:slug "t"})
           e    (infinite-entry-with-pages
                  :feed/timeline
                  [{:author-email "alice@example.com" :body "hello"}
                   {:author-email "bob@example.com" :body "world"}])
-          [_ we] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))
+          [_ we] (only-wire-entry (ssr-project :rcfg/infinite (runtime-db-with {k e})))
           pages  (:data we)]
       (is (= :serialize (classification/whole-entry-disposition
                           (rf/resource-meta :feed/timeline)))
-          "no coarse claim → :serialize (the per-page schema is the surface)")
+          "no coarse claim → :serialize")
       (is (vector? pages) "the page-vector shape is preserved on the wire")
       (is (= 2 (count pages)) "every accumulated page rides")
       (is (= privacy/redacted-sentinel (get-in pages [0 :author-email]))
@@ -601,7 +417,7 @@
           "no raw page-1 sensitive value rides anywhere on the entry"))))
 
 ;; ===========================================================================
-;; 5. load-bearing Spec 016 rules preserved (the projection contract)
+;; 4. load-bearing Spec 016 rules preserved (the projection contract)
 ;; ===========================================================================
 
 (deftest ssr-projection-rides-only-entries-slice


### PR DESCRIPTION
## Audit verdict

Per the per-PR COLLECTIVE review (9vftwz), resources applied owner classification **twice** at egress:

1. the **per-instance registry lowering** (`reconcile-registry` → `[:rf.runtime/elision]`, `:source :resource` — the #4907 alignment), and
2. the **family-private `project-data` / `project-params` projectors**, which re-derived `split-projection-paths spec` at the SSR projector — the **same fact, computed a second time**.

**The family-private path is the redundant one — NOT vestigial-as-dead-code, but the redundant dual *derivation*.** Routing (`project-routing-egress`) and machines (`frame-snapshot-classification`) both lower into the registry **and read the registry** at SSR egress; neither re-derives from the spec. Resources was the lone subsystem re-deriving. Spec 015 L149 + EP-0025 (“point the egress projection at the registry as the single source”) make the registry the intended single source.

**Verdict: vestigial dual derivation → COLLAPSED to the single registry-lowering path.**

## What changed (only `implementation/resources`)

- New `project-entry-data` / `project-entry-params` walk the entry `:data` / scoped-key params through `project-egress` **seeded at the entry's absolute lowered offset** (`[:rf.runtime/resources :entries <key-id> :data …]` / `… :resource/key 2 …`), reading the lowered `:source :resource` decls (unioned with any frame app-db classification). Infinite feeds ride for free via the walker's index-free fork — no special per-page branch.
- Removed the redundant `project-data` / `project-params` + the spec re-derivation helpers (`data-schema-marks`, `params-schema-marks`, `page-data-schema-marks`, `*-classifies?`, `infinite-spec?`, `project-value`).
- Gated on a registry declaration under the entry offset (`registry-classifies-under?`): an unclassified entry rides **verbatim**, preserving the CEDN-1 byte-key identity (an unnecessary walk would collapse a list↔vector and break the cache-key-identity round-trip).
- The coarse `whole-entry-disposition` (redact / omit) and the validation-failure-trace schema-prop redaction (`redact-invalid-params-error`) are distinct concerns, unchanged.

Frameless owner-fires becomes ride-verbatim — consistent with machines / routing fail-open-frameless. Net −274 lines.

## Egress redaction preserved (no regression)

- A `:sensitive` resource `:data` slot still redacts at SSR egress (`ssr-serialize-entry-redacts-owner-data-declaration-slot`, `project-entry-data-redacts-registry-lowered-sensitive-slot`); a `:large` slot still elides; a `:sensitive` `:params` slot still redacts in the wire key; the infinite-feed per-page contract holds; frame-classified defence-in-depth composes.
- **Confirm-by-revert:** forcing `project-entry-data` to ride verbatim reds the SSR `:sensitive` redaction tests (12 failures) — the acceptance tests hit the **real registry-driven path**, not a tautology.

## Quality gates

From `implementation/`:
- JVM resources (`clojure -M:test`): **599 tests, 0 failures**
- JVM ssr (`clojure -M:test`): **366 tests, 0 failures**
- `npm run test:cljs`: **7979 tests, 0 failures**
- `npm run test:elision`: **PASS** (42/42 sensitive markers absent from production; EP-0023 provenance-survives + assembly-DCE; control 42/42 present)

`node_modules` was absent in the worktree (the mayor tree's was empty too) — ran a fresh `npm install` (110 packages). CI is the merge gate.