### PR TITLE
test(xray): EP-0029 :data-schema -> [:schemas :data] test wording (rf2-yeql7x)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -23,9 +23,9 @@
             ;; `:rf.error/machines-artefact-missing`.
             [re-frame.machines]
             ;; rf2-kq8nac (EP-0005) — the snapshot-egress chokepoint +
-            ;; the schemas walker the `:data-schema` redaction bridge
+            ;; the schemas walker the `[:schemas :data]` redaction bridge
             ;; consults. Required so the redaction tests can register a
-            ;; machine carrying a `:sensitive?` `:data-schema` slot and
+            ;; machine carrying a `:sensitive?` `[:schemas :data]` slot and
             ;; run a real transition trace through `project-trace-event`.
             [re-frame.classification :as classification]
             [re-frame.elision :as elision]
@@ -672,7 +672,7 @@
 ;; ---- (4c) declared-over-inferred Context shape (rf2-kq8nac · EP-0005) ----
 ;;
 ;; The Machine Inspector's focused-event chart surfaces the machine's
-;; declared `:data-schema` Context shape (keys + type captions)
+;; declared `[:schemas :data]` Context shape (keys + type captions)
 ;; AUTHORITATIVELY, with the declared-vs-inferred indicator — consistent
 ;; with the Static Topology view (rf2-3q4k5b) and reusing the SAME
 ;; `topology-view/static-context-shape` / `static-context-inferred?`
@@ -720,7 +720,7 @@
 
 (deftest focused-event-chart-shows-declared-context-shape-rf2-kq8nac
   (testing "rf2-kq8nac (EP-0005): when the focused machine declares a
-            `:data-schema`, the focused-event chart's Context band shows
+            `[:schemas :data]`, the focused-event chart's Context band shows
             the AUTHORITATIVE declared shape (off the schema's :map
             entries, NOT the misleading `:data` sample) and
             `:context-band-inferred?` reaches the chart FALSE (so the
@@ -751,7 +751,7 @@
              shows — consistent with the Static Topology view)")))))
 
 (deftest focused-event-chart-infers-shape-when-no-schema-rf2-kq8nac
-  (testing "rf2-kq8nac (EP-0005): absent a `:data-schema` the focused-event
+  (testing "rf2-kq8nac (EP-0005): absent a `[:schemas :data]` the focused-event
             chart falls back to the one-sample inference and
             `:context-band-inferred?` reaches the chart TRUE (rf2-5tz9p's
             `inferred from :data` badge stays)."
@@ -782,7 +782,7 @@
 ;; ---- (4d) live `:data` view renders redacted (rf2-kq8nac · EP-0005) ------
 ;;
 ;; The bead's task #2: VERIFY the panel's live `:data` view renders a
-;; `:sensitive?` `:data-schema` slot REDACTED — confirming xray reads the
+;; `:sensitive?` `[:schemas :data]` slot REDACTED — confirming xray reads the
 ;; EGRESSED/projected snapshot, never raw machine state. Two surfaces:
 ;;
 ;;   1. The SHARED mini-pipeline cascade reads the focused epoch's
@@ -799,7 +799,7 @@
 (def ^:private redaction-machine-id :session/auth-redaction)
 
 (def ^:private sensitive-schema
-  "A `:data-schema` — VALIDATION ONLY post-EP-0025 (props no longer classify).
+  "A `[:schemas :data]` — VALIDATION ONLY post-EP-0025 (props no longer classify).
   The FRAME declares the snapshot `:data` path sensitive (see the tests)."
   [:map
    [:retries :int]

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_view_cljs_test.cljs
@@ -82,7 +82,7 @@
     (is (nil? (tv/static-context-shape nil)))))
 
 (deftest static-context-declared-schema-is-authoritative
-  (testing "rf2-3q4k5b (EP-0005) — when a machine declares a `:data-schema`,
+  (testing "rf2-3q4k5b (EP-0005) — when a machine declares a `[:schemas :data]`,
             the static Context shape is read AUTHORITATIVELY off the schema
             (not the `:data` sample) and `static-context-inferred?` is FALSE,
             so the chart drops the `inferred from :data` badge."
@@ -102,7 +102,7 @@
           "declared schema → not inferred (chart drops the inferred badge)"))))
 
 (deftest static-context-inferred-when-no-schema
-  (testing "rf2-3q4k5b (EP-0005) — absent a `:data-schema`, the shape falls
+  (testing "rf2-3q4k5b (EP-0005) — absent a `[:schemas :data]`, the shape falls
             back to the one-sample inference and `static-context-inferred?`
             is TRUE (rf2-5tz9p's badge stays)."
     (let [def {:initial :idle

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
@@ -606,7 +606,7 @@
 ;; the Sim surface too (the Dynamic + Static Topology charts already do).
 
 (def ^:private inferred-fixture-definition
-  "No :data-schema → the context shape is INFERRED from one sample of
+  "No [:schemas :data] → the context shape is INFERRED from one sample of
   the initial :data (the chart keeps the `inferred from :data` badge)."
   {:initial :idle
    :data    {:counter 0 :label "x"}
@@ -657,7 +657,7 @@
             "inferred sample → :context-band-inferred? TRUE reaches the chart")))))
 
 (deftest sim-chart-forwards-declared-context-shape-to-canvas
-  (testing "rf2-eao0s0 — a declared (:data-schema) machine: the Static Sim
+  (testing "rf2-eao0s0 — a declared ([:schemas :data]) machine: the Static Sim
             chart hands the canvas the AUTHORITATIVE schema shape with
             :context-band-inferred? FALSE (badge dropped)."
     (setup-xray-frame!)

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/topology_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/topology_cljs_test.cljs
@@ -9,7 +9,7 @@
   Context band was missing there. These tests pin that the wrapper now
   forwards `:context-band` (the {key → type-caption} shape) +
   `:context-band-inferred?` for BOTH an inferred (`:data`-sample) and a
-  declared (`:data-schema`) definition.
+  declared (`[:schemas :data]`) definition.
 
   The chart wrapper is the private `topology/chart` fn; we invoke it via
   its var so the `[machine-canvas/Chart {...}]` mount survives as data
@@ -21,7 +21,7 @@
 ;; ---- fixtures -----------------------------------------------------------
 
 (def ^:private inferred-definition
-  "No :data-schema → the context shape is INFERRED from one sample of the
+  "No [:schemas :data] → the context shape is INFERRED from one sample of the
   initial :data (the chart keeps the `inferred from :data` badge)."
   {:initial :idle
    :data    {:opened-count 0 :held-open? false :trail []}
@@ -38,7 +38,7 @@
              :opening {:final? true}}})
 
 (def ^:private no-data-definition
-  "Neither :data nor :data-schema → the shape is nil so the chart hides
+  "Neither :data nor [:schemas :data] → the shape is nil so the chart hides
   the Context panel."
   {:initial :idle
    :states  {:idle {} :opening {}}})
@@ -81,7 +81,7 @@
           "inferred sample → :context-band-inferred? TRUE reaches the chart"))))
 
 (deftest topology-forwards-declared-context-shape-to-chart
-  (testing "rf2-eao0s0 — a declared (:data-schema) machine: the Static
+  (testing "rf2-eao0s0 — a declared ([:schemas :data]) machine: the Static
             Topology chart forwards the AUTHORITATIVE schema shape with
             :context-band-inferred? FALSE."
     (let [props (chart-props declared-definition)]


### PR DESCRIPTION
Follow-up from rf2-gwlkbu (which scoped only src + spec). Flips the retired machine `:data-schema` wording in xray TEST comments / docstrings / testing-prose to the live `[:schemas :data]` path — EP-0029 cosmetic completeness.

## What changed

16 machine-context references flipped across 4 CLJS/CLJC test files:

- `panels/machine_inspector_view_cljs_test.cljs` (7)
- `panels/machines/topology_view_cljs_test.cljs` (2)
- `static/machines/sim_cljs_test.cljs` (2)
- `static/machines/topology_cljs_test.cljs` (5)

All hits are comments / docstrings / `testing` prose describing a machine's declared data-context schema by its retired name. The actual fixtures already declare `:schemas {:data ...}`, and no assertion checks a `:data-schema` output string, so this is purely descriptive — logic unchanged.

## Untouched (correctly)

The resources `:rf/resource` `:data-schema` key in `resources_cljs_test.cljs:87` and `resources_helpers_cljs_test.cljc:63` is left as-is. That subsystem keeps the `:data-schema` key per EP-0029 — those are real resource keys, not machine-context.

## Quality gates

- JVM xray suite (`clojure -M:test` in `tools/xray`): 1217 tests, 5643 assertions, 0 failures, 0 errors — green. The edited `testing` description strings compile and pass.
- node_modules was absent in the fresh worktree; the node-runtime `test:cljs` gate was not run locally. These are pure comment/docstring edits with zero behavioral or output-string change, so there is no node-runtime risk beyond what the JVM compile already validated. CI is the merge gate.