### PR TITLE
docs(guide): drop the glossary's "Not:" synonym lists

### DIFF
--- a/docs/guide/glossary.md
+++ b/docs/guide/glossary.md
@@ -1,6 +1,6 @@
 # Glossary
 
-Welcome to the lost-and-found. This is the page you keep open in a second tab — the one you flick to when a doc says "the cascade" or "a coeffect" and you want the one-line truth without re-reading a whole chapter. Every entry gives you the canonical word (re-frame2 is fussy about names, on purpose), a plain-English definition, a tiny snippet so you can see it in the wild, and a link to where it's taught for real. The snippets here are illustrative, not runnable — read them as sketches. Where a term has tempting synonyms we'd rather you didn't use, we say so; the right word saves you a future argument.
+Welcome to the lost-and-found. This is the page you keep open in a second tab — the one you flick to when a doc says "the cascade" or "a coeffect" and you want the one-line truth without re-reading a whole chapter. Every entry gives you the canonical word (re-frame2 is fussy about names, on purpose), a plain-English definition, a tiny snippet so you can see it in the wild, and a link to where it's taught for real. The snippets here are illustrative, not runnable — read them as sketches.
 
 ## The objects
 
@@ -18,7 +18,7 @@ See [Views](concepts/views.md). (Keep distinct from **substrate**, the layer.)
 {:cart {:items [{:sku "BK-1" :qty 2}]} :user/name "Ada"}
 ```
 
-See [app-db](concepts/app-db.md). Not: the database, the atom, the store.
+See [app-db](concepts/app-db.md).
 
 **coeffect** — A declared input the framework injects into a handler so the handler can stay pure; the world enters only through these.
 
@@ -28,7 +28,7 @@ See [app-db](concepts/app-db.md). Not: the database, the atom, the store.
   (fn [{:keys [now db]} _] ...))
 ```
 
-See [Effects & Coeffects](concepts/effects-and-coeffects.md). The key-form is `cofx`. Not: world fact, input fact, inputs-from-the-world.
+See [Effects & Coeffects](concepts/effects-and-coeffects.md). The key-form is `cofx`.
 
 **effect** — A described side-effect returned as data and run by the runtime, never performed by the handler itself.
 
@@ -36,7 +36,7 @@ See [Effects & Coeffects](concepts/effects-and-coeffects.md). The key-form is `c
 {:fx [[:http {:url "/api/cart" :method :post}]]}
 ```
 
-See [Effects & Coeffects](concepts/effects-and-coeffects.md). Reserve `fx` for the `:fx` key / fx-id. Not: instruction, side-effect-as-data (as a headword).
+See [Effects & Coeffects](concepts/effects-and-coeffects.md). Reserve `fx` for the `:fx` key / fx-id.
 
 **effect map** — The whole `{:db … :fx …}` value a handler returns; the closed top-level key set for app code is `#{:db :fx}`.
 
@@ -45,7 +45,7 @@ See [Effects & Coeffects](concepts/effects-and-coeffects.md). Reserve `fx` for t
  :fx [[:dispatch [:cart/track-open]]]}
 ```
 
-See [Events & the cascade](concepts/events-and-the-cascade.md). Singular: **effect map**. Not: effects map, the return value.
+See [Events & the cascade](concepts/events-and-the-cascade.md). Singular: **effect map**.
 
 **epoch** — The before/after state record one cascade leaves behind; the unit of time-travel.
 
@@ -53,7 +53,7 @@ See [Events & the cascade](concepts/events-and-the-cascade.md). Singular: **effe
 ;; one dispatch = one cascade = one epoch (the record)
 ```
 
-See [Observability](concepts/observability.md). Not: the moment, before/after record (as a name); and it is not "the cascade" (that's the run).
+See [Observability](concepts/observability.md).
 
 **error record / `:rf.error/*` category** — A failure surfaced as a structured map keyed by a reserved category keyword; branch on the category, never the human-readable `:reason`.
 
@@ -61,7 +61,7 @@ See [Observability](concepts/observability.md). Not: the moment, before/after re
 {:rf.error/category :rf.error/no-frame-context :reason "no frame in scope"}
 ```
 
-See [Errors](concepts/errors.md). Not: dossier, graph fact (fine as flavor, never the headword).
+See [Errors](concepts/errors.md).
 
 **event** — An inert data vector — a fact that something happened, shaped `[id]`, `[id scalar]`, or `[id {map}]`.
 
@@ -69,7 +69,7 @@ See [Errors](concepts/errors.md). Not: dossier, graph fact (fine as flavor, neve
 [:cart/add-item {:sku "BK-1" :qty 1}]
 ```
 
-See [Events & the cascade](concepts/events-and-the-cascade.md). Not: instruction, command, callback, message.
+See [Events & the cascade](concepts/events-and-the-cascade.md).
 
 **flow** — A pure derivation materialised *into* app-db so handlers can read it as plain state.
 
@@ -80,7 +80,7 @@ See [Events & the cascade](concepts/events-and-the-cascade.md). Not: instruction
    :output-path [:cart :total]})
 ```
 
-See [Flows](concepts/flows.md). Not: materialized view (JS aside only), "on-changes grown up".
+See [Flows](concepts/flows.md).
 
 **frame** — One isolated, running instance of your app, with its own app-db, event queue, and subscription cache.
 
@@ -88,7 +88,7 @@ See [Flows](concepts/flows.md). Not: materialized view (JS aside only), "on-chan
 (rf/reg-frame :app {:initial-events [[:rf/set-db {}]]})
 ```
 
-See [Frames](concepts/frames.md). Frames isolate **state, not registrations**. Not: isolated world / instance / runtime context (these are glosses — pick one).
+See [Frames](concepts/frames.md). Frames isolate **state, not registrations**.
 
 **image** — The selected, sealed set of registrations a frame resolves against; its resolved result is a **generation**.
 
@@ -96,7 +96,7 @@ See [Frames](concepts/frames.md). Frames isolate **state, not registrations**. N
 ;; a frame resolves its handlers against a fixed image; the resolved set is a generation
 ```
 
-See [Images](concepts/images.md). Use **image** for the source, **generation** for the resolved set. Not: source store, catalogue, registration pool.
+See [Images](concepts/images.md). Use **image** for the source, **generation** for the resolved set.
 
 **interceptor** — A named, by-id `context → context` decorator that wraps a handler.
 
@@ -105,7 +105,7 @@ See [Images](concepts/images.md). Use **image** for the source, **generation** f
   {:before (fn [ctx] ...) :after (fn [ctx] ctx)})
 ```
 
-See [Interceptors](concepts/interceptors.md). Not: middleware. (Inline interceptors are banned anyway.)
+See [Interceptors](concepts/interceptors.md).
 
 **machine** — A state machine registered as an event handler via `reg-machine`; its live value is a **snapshot**.
 
@@ -113,7 +113,7 @@ See [Interceptors](concepts/interceptors.md). Not: middleware. (Inline intercept
 (rf/reg-machine :auth.login/flow login-flow)
 ```
 
-See [Machines](concepts/machines.md). Not: actor object, FSM-as-second-system.
+See [Machines](concepts/machines.md).
 
 **mutation** — A declared server-state write whose cache consequences (what it invalidates) are declared once on the registration.
 
@@ -129,7 +129,7 @@ See [Server state](concepts/server-state.md). The reply field is `:value`; the i
 (rf/reg-resource :article {:scope :rf.scope/global} request-fn)
 ```
 
-See [Server state](concepts/server-state.md). "Server state" is the category, not the noun. Not: server cache, query.
+See [Server state](concepts/server-state.md). "Server state" is the category, not the noun.
 
 **runtime-db** — The framework-owned state partition beside app-db (machine snapshots, route slice, resource cache, mutation status); read-don't-write for app code.
 
@@ -137,7 +137,7 @@ See [Server state](concepts/server-state.md). "Server state" is the category, no
 [:rf.db/runtime :rf.runtime/machines :auth.login/flow]   ;; a snapshot's address
 ```
 
-See [app-db](concepts/app-db.md). Paths: `:rf.db/runtime`, children `:rf.runtime/*`. Not: runtime partition/cache/state, "framework-managed state map".
+See [app-db](concepts/app-db.md). Paths: `:rf.db/runtime`, children `:rf.runtime/*`.
 
 **subscription** — A named, registered, pure, cached, read-only derivation of state.
 
@@ -145,7 +145,7 @@ See [app-db](concepts/app-db.md). Paths: `:rf.db/runtime`, children `:rf.runtime
 (rf/reg-sub :cart/count (fn [db _] (count (:items (:cart db)))))
 ```
 
-See [Subscriptions](concepts/subscriptions.md). Casual "sub" is fine; not as a headword. Not: query, selector, derived view/read, "named question".
+See [Subscriptions](concepts/subscriptions.md). Casual "sub" is fine; not as a headword.
 
 **substrate** — The React-family rendering layer your app runs on (Reagent / UIx / Helix / reagent-slim).
 
@@ -153,7 +153,7 @@ See [Subscriptions](concepts/subscriptions.md). Casual "sub" is fine; not as a h
 ;; "substrate" = the layer; the value you pass to init! is the adapter
 ```
 
-See [Views](concepts/views.md). Not: renderer, "the React layer" (as a coined term).
+See [Views](concepts/views.md).
 
 **view** — A pure render function from subscription values to hiccup.
 
@@ -161,7 +161,7 @@ See [Views](concepts/views.md). Not: renderer, "the React layer" (as a coined te
 (rf/reg-view :cart-badge (fn [] [:span.badge @(rf/subscribe [:cart/count])]))
 ```
 
-See [Views](concepts/views.md). Use "component" for React-analogy callouts only. Not: component (generally).
+See [Views](concepts/views.md). Use "component" for React-analogy callouts only.
 
 ## The processes
 
@@ -171,7 +171,7 @@ See [Views](concepts/views.md). Use "component" for React-analogy callouts only.
 ;; the :db you return is staged; it's committed once, at the end, atomically
 ```
 
-See [Events & the cascade](concepts/events-and-the-cascade.md). Not: the install, macrostep commit.
+See [Events & the cascade](concepts/events-and-the-cascade.md).
 
 **dispatch** — Send an event into a frame; returns immediately and never mutates inline.
 
@@ -179,7 +179,7 @@ See [Events & the cascade](concepts/events-and-the-cascade.md). Not: the install
 (rf/dispatch [:cart/add-item {:sku "BK-1"}])
 ```
 
-See [Events & the cascade](concepts/events-and-the-cascade.md). Not: fire, trigger, raise.
+See [Events & the cascade](concepts/events-and-the-cascade.md).
 
 **drain / run-to-completion** — The runtime drains the whole event queue to a fixed point before subscriptions recompute and views render.
 
@@ -187,7 +187,7 @@ See [Events & the cascade](concepts/events-and-the-cascade.md). Not: fire, trigg
 ;; all queued events run to completion, THEN subs recompute, THEN views render
 ```
 
-See [Events & the cascade](concepts/events-and-the-cascade.md). Hyphenate **run-to-completion** consistently. Not: settle (OK only for the end-state), macrostep.
+See [Events & the cascade](concepts/events-and-the-cascade.md). Hyphenate **run-to-completion** consistently.
 
 **elide** — Compile dev-only code out of production via one flag (`goog.DEBUG` / `-Dre-frame.debug`).
 
@@ -195,7 +195,7 @@ See [Events & the cascade](concepts/events-and-the-cascade.md). Hyphenate **run-
 ;; goog.DEBUG=false removes the dev trace surface and schema checks
 ```
 
-See [Observability](concepts/observability.md). Name DCE once, then use **elide**. Not: DCE'd, compiled-away, evaporate, stripped.
+See [Observability](concepts/observability.md). Name DCE once, then use **elide**.
 
 **the event cascade** — The fixed, ordered run one dispatch sets off: handler → effect map → effects → derivations → view → DOM.
 
@@ -203,7 +203,7 @@ See [Observability](concepts/observability.md). Name DCE once, then use **elide*
 ;; dispatch → handler → effect map → effects → derivations → view → DOM
 ```
 
-See [Events & the cascade](concepts/events-and-the-cascade.md). Reserve "the loop" for the whole repeating machine, "the six dominoes" for the first-contact mnemonic, "epoch" for the record. Not: the loop (for one run), the pipeline.
+See [Events & the cascade](concepts/events-and-the-cascade.md). Reserve "the loop" for the whole repeating machine, "the six dominoes" for the first-contact mnemonic, "epoch" for the record.
 
 **invalidate** — A mutation declares, as data on its registration, which cached reads it makes stale.
 
@@ -212,7 +212,7 @@ See [Events & the cascade](concepts/events-and-the-cascade.md). Reserve "the loo
                 {:tags #{[:article slug]}})}     ;; declared once, on the mutation
 ```
 
-See [Server state](concepts/server-state.md). Not: "bust the cache", imperative call-site invalidation.
+See [Server state](concepts/server-state.md).
 
 **navigate** — Change the route by dispatching navigation; the URL is an input, the route is a sub.
 
@@ -220,7 +220,7 @@ See [Server state](concepts/server-state.md). Not: "bust the cache", imperative 
 (rf/dispatch [:rf.route/navigate :article {:id "abc"}])
 ```
 
-See [Routing](concepts/routing.md). Not: route-to, go-to (as an API).
+See [Routing](concepts/routing.md).
 
 **project (egress)** — Run a value through redaction before it leaves the app, via `project-egress`; direct reads are not auto-projected.
 
@@ -228,7 +228,7 @@ See [Routing](concepts/routing.md). Not: route-to, go-to (as an API).
 (rf/project-egress value {:frame :app/main :path [:auth]})  ;; redacts at the sink
 ```
 
-See [Keep secrets out of traces](how-to/keep-secrets-out-of-traces.md). Not: scrub, sanitise-at-sink.
+See [Keep secrets out of traces](how-to/keep-secrets-out-of-traces.md).
 
 **the reg-\* registrars** — The boot-time registration calls that name your handlers and machinery: `reg-event`, `reg-sub`, `reg-view`, `reg-fx`, `reg-cofx`, `reg-interceptor`, `reg-machine`, `reg-flow`, `reg-resource`, `reg-mutation`, `reg-route`, `reg-app-schema`.
 
@@ -244,7 +244,7 @@ See [Events & the cascade](concepts/events-and-the-cascade.md). There is **one**
 @(rf/subscribe [:cart/count])
 ```
 
-See [Subscriptions](concepts/subscriptions.md). Not: "query out", "the read side" (as a name).
+See [Subscriptions](concepts/subscriptions.md).
 
 ## The big ideas
 
@@ -278,7 +278,7 @@ See [Frames](concepts/frames.md).
 ;; image (the source) resolves to a generation (the sealed result a frame uses)
 ```
 
-See [Images](concepts/images.md). Not: "sealed generation/result", "a new build of the recipe".
+See [Images](concepts/images.md).
 
 **The four homes (where state lives)** — Subscription → flow → resource → machine: pick the cheapest that fits, decided by the where-state-lives router. Every other concept defers here for "which one do I use?".
 
@@ -318,4 +318,4 @@ See [Managed HTTP](concepts/http.md).
 ;; open Xray to step through epochs, inspect app-db, and read the cascade
 ```
 
-See [Debug with Xray](how-to/debug-with-xray.md). Not: "time-travel debugger", "in-app inspection panel" (as competing glosses).
+See [Debug with Xray](how-to/debug-with-xray.md).


### PR DESCRIPTION
The glossary's per-entry **`Not: x, y`** notes were find-and-replace scaffolding from the coherence pass that leaked into the reader-facing page. They added little for readers, and several actively misled — the list "banned" terms the guide *deliberately* uses as analogies in its own callouts (Flow's "materialized view" and "on-changes grown up" both appear in `For JavaScript developers` / `From re-frame v1` callouts) — and naming a wrong term tends to plant it.

A glossary entry is complete with **canonical term + definition + example + home-link**; the "you might call this X elsewhere" job is already done, better, by the callouts on the teaching pages.

- Removed all 28 `Not:` clauses.
- Removed the now-dangling intro sentence that advertised them.
- **Kept** the genuinely-useful per-entry guidance that preceded each note (e.g. "Singular: **effect map**", "Frames isolate **state, not registrations**", the loop/dominoes/epoch reservations).

Verification: only `glossary.md` changed; 0 broken links, slug-check passes, doc-guide-check in sync (794 refs).