### PR TITLE
fix(elision): elide ungated dev-only prose + :doc non-literal + directory sentinel

### DIFF
--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -430,9 +430,17 @@
      3-arg `reg-machine` call. Per rf2-wvh95f F2 the `opts` metadata map is the
      canonical Spec 001 MIDDLE slot, so the emitted call is `(reg-machine
      machine-id opts spec)` (opts middle, spec last). `opts-form` is a RUNTIME
-     expression evaluated at the call site (not walked at expansion time); it
-     is forwarded verbatim. The 5-arg form (no opts) emits the bare 2-arg
-     `reg-machine` call, unchanged."
+     expression evaluated at the call site (not walked at expansion time). The
+     5-arg form (no opts) emits the bare 2-arg `reg-machine` call, unchanged.
+
+     Per rf2-tfiutq the opts-form rides `gate-doc-arg` so a LITERAL doc-bearing
+     opts map (`(reg-machine :id {:doc \"…\"} spec)`) DCEs its `:doc` string
+     under `:advanced` + `goog.DEBUG=false` — closing the parity gap with the
+     splice-through `defreg-macro` / `defreg-event-macro` surfaces (which gate
+     every literal doc-bearing arg). A non-literal opts expression (a symbol, a
+     computed map, a `merge` call) passes through unchanged — its `:doc`, if
+     any, still strips from the stored handler-meta via the runtime `register!`
+     strip, but its string bytes are outside the macro's reach."
      ([form-meta ns-sym file machine-id machine]
       (expand-reg-machine form-meta ns-sym file machine-id machine ::no-opts))
      ([form-meta ns-sym file machine-id machine opts-form]
@@ -441,6 +449,9 @@
             stamped     (stamp-machine-spec-expr machine ns-sym file machine-sym)
             inline?     (not (identical? stamped machine-sym))
             no-opts?    (= opts-form ::no-opts)
+            ;; rf2-tfiutq — gate a literal doc-bearing opts map for `:doc`
+            ;; string elision, exactly as the splice-through reg-* surfaces do.
+            opts-form   (if no-opts? opts-form (gate-doc-arg opts-form))
             reg-call    (fn [spec-expr]
                           (if no-opts?
                             `(re-frame.core-machines/reg-machine ~machine-id ~spec-expr)

--- a/implementation/core/test/re_frame/doc_metadata_prod_elision_test.clj
+++ b/implementation/core/test/re_frame/doc_metadata_prod_elision_test.clj
@@ -108,6 +108,16 @@
            (registrar/strip-pure-documentation {:doc "x" :schema :int}))
         "dev: full map retained (identity)")))
 
+;; Note (rf2-tfiutq): the `reg-machine` LITERAL opts-map `:doc` elision lands
+;; here too — but the runtime handler-meta strip rides the SAME single
+;; `register!` chokepoint exercised by `doc-stripped-uniformly-across-reg-
+;; surfaces` above, and the machine surface needs `day8/re-frame2-machines` on
+;; the classpath (absent from this core artefact's `:test` deps). The semantic
+;; strip for `reg-machine` opts therefore lives in the machines artefact
+;; (`re-frame.machine-doc-opts-prod-elision-test`), and the CLJS-bundle `:doc`
+;; STRING absence — the bytes the macro's new `gate-doc-arg` routing DCEs — is
+;; pinned by the elision probe (`rf2-tfiutq-machine-opts-doc-sentinel`).
+
 ;; ---- classification: the elidable set is closed to :doc -----------------
 
 (deftest pure-documentation-keys-is-closed-to-doc

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -67,7 +67,27 @@
             ;; image-loading path (make-frame / assemble / the within-image
             ;; collision check), so those image-assembly fns DCE when unused.
             [re-frame.source-store :as source-store]
-            [re-frame.source-coords :as source-coords]))
+            [re-frame.source-coords :as source-coords]
+            ;; rf2-tfiutq — ungated DIRECT-CALL dev-only diagnostic emits (the
+            ;; ~18 warning/diagnostic sites across resources / routing / machines
+            ;; / ssr-client) elide in production NOT via a call-site
+            ;; `interop/debug-enabled?` gate but via Closure constant-folding the
+            ;; DIRECTLY-CALLED `trace/emit!` / `trace/emit-error!` body to `nil`
+            ;; under :advanced + goog.DEBUG=false, after which the pure
+            ;; `(str …)` / literal-string args are dropped as dead. (Contrast the
+            ;; framework's OWN emit machinery — storage.cljc / registrar.cljc —
+            ;; which captures `emit!` via `(late-bind/get-fn :trace/emit!)`; that
+            ;; INDIRECT identity escapes the fold, so those sites carry an
+            ;; explicit `(when interop/debug-enabled? …)` call-site gate.)
+            ;;
+            ;; The probe previously pinned dev-only prose absence ONLY inside
+            ;; already-gated branches; it never rooted an UNGATED direct-emit site
+            ;; to prove the fold path holds. These touches root one representative
+            ;; direct-emit site per surface so the control build (DEBUG=true)
+            ;; contains the prose and the production build (DEBUG=false) DCEs it —
+            ;; the methodology now has teeth for the direct-call elision path.
+            [re-frame.routing.classification :as routing-classification]
+            [re-frame.machines.lifecycle-fx.traces :as machines-traces]))
 
 ;; ---- trace listener API ---------------------------------------------------
 
@@ -521,7 +541,18 @@
   ;; control bundle; under DEBUG=false the form-source gate DCEs it.
   (rf/reg-event :probe/doc-event
     {:doc "rf2-9wwkcm-doc-elision-sentinel: pure-documentation metadata"}
-    (fn [{:keys [db]} _ev] {:db db})))
+    (fn [{:keys [db]} _ev] {:db db}))
+  ;; rf2-tfiutq — `reg-machine`'s LITERAL opts map carrying `:doc` now rides
+  ;; `gate-doc-arg` (previously forwarded verbatim, so its `:doc` string
+  ;; survived :advanced). The distinctive sentinel rides the literal-opts arm:
+  ;; under DEBUG=true the dev arm keeps the full opts map (with `:doc`); under
+  ;; DEBUG=false the `(if interop/debug-enabled? <full> <stripped>)` gate DCEs
+  ;; the `:doc` string. (The `:rf.probe/doc-machine` registration succeeds —
+  ;; a single-state idle machine — so the opts map is genuinely registered.)
+  (rf/reg-machine :rf.probe/doc-machine
+    {:doc "rf2-tfiutq-machine-opts-doc-sentinel: reg-machine literal opts :doc"}
+    {:initial :idle
+     :states  {:idle {}}}))
 
 ;; ---- rf2-9vx0jk: dev-only :rf.interceptor/override-summary run-start tag ----
 ;;
@@ -633,7 +664,46 @@
 
 ;; ---- entry point ----------------------------------------------------------
 
+;; ---- rf2-tfiutq: ungated DIRECT-CALL dev-only diagnostic emit elision ------
+;;
+;; The ~18 app-facing dev-only warning/diagnostic emits (resources / routing /
+;; machines / ssr-client) call `trace/emit!` / `trace/emit-error!` DIRECTLY on a
+;; runtime DATA branch (`when-some` / `when (seq …)` / `doseq` / a `catch`),
+;; building `(str …)` or literal-string prose, with NO call-site
+;; `interop/debug-enabled?` gate. They still ELIDE in production: under
+;; :advanced + goog.DEBUG=false the directly-called `emit!` / `emit-error!`
+;; body folds to `nil`, Closure inlines the now-no-op call, and the pure prose
+;; args drop as dead. (The framework's OWN emit machinery — storage.cljc,
+;; registrar.cljc — instead captures `emit!` via `(late-bind/get-fn …)`; that
+;; INDIRECT identity escapes the fold, so those sites carry an explicit
+;; `(when interop/debug-enabled? …)` call-site gate. The two paths are NOT
+;; interchangeable: a direct call folds, an indirect-via-registry call does
+;; not.)
+;;
+;; This touch roots one representative direct-emit site per surface (one
+;; `emit!` + `(str …)`, one `emit-error!` + literal-string) so the gated-body
+;; sentinels below pin the FOLD path, not just the require-boundary or the
+;; already-gated branches. Under DEBUG=true the prose lands in the control
+;; bundle; under DEBUG=false the fold DCEs it.
+
+(defn ^:export touch-direct-emit-diagnostics! []
+  ;; routing `advise-query-promotion!` — `emit!` :warning whose `:advice`
+  ;; `(str …)` arg is built on the `(when (seq missing) …)` data branch. A
+  ;; route-meta that classifies an UNPROMOTED `[:query k]` path reaches the
+  ;; emit (the keyword `:query` key never matches the runtime string key, so
+  ;; `unpromoted-query-keys` is non-empty).
+  (routing-classification/advise-query-promotion!
+    :rf.probe/direct-emit-route
+    {:sensitive [[:query "token"]]}
+    #{})
+  ;; machines `emit-destroy-exit-failure!` — `emit-error!` with a literal-string
+  ;; `:reason`, an ungated `defn` body. Calling it directly roots the
+  ;; literal-string emit shape.
+  (machines-traces/emit-destroy-exit-failure!
+    :rf.probe/direct-emit-actor :rf/default {:probe :direct-emit}))
+
 (defn ^:export run []
+  (touch-direct-emit-diagnostics!)
   (touch-trace!)
   (touch-schemas!)
   (touch-registrar!)

--- a/implementation/machines/test/re_frame/machine_doc_opts_prod_elision_test.clj
+++ b/implementation/machines/test/re_frame/machine_doc_opts_prod_elision_test.clj
@@ -1,0 +1,64 @@
+(ns re-frame.machine-doc-opts-prod-elision-test
+  "Per rf2-tfiutq: `reg-machine`'s LITERAL opts-map pure-documentation
+  (`:doc`) production-elision contract — the machines-artefact counterpart of
+  `re-frame.doc-metadata-prod-elision-test` (which pins the splice-through
+  reg-* surfaces but cannot exercise `reg-machine`, since that needs
+  `day8/re-frame2-machines` on the classpath, absent from core's `:test` deps).
+
+  Two halves of the contract:
+
+   1. SEMANTIC handler-meta strip — `(reg-machine :id {:doc \"…\"} spec)`
+      registers under `:event`, funnelling through the single
+      `re-frame.registrar/register!` `strip-pure-documentation` chokepoint, so
+      under the production posture (`interop/debug-enabled?` rebound to false,
+      semantically equivalent to CLJS `:advanced` + `goog.DEBUG=false`)
+      `(rf/handler-meta :event id)` carries no `:doc`; in dev it is retained.
+
+   2. CLJS BUNDLE-string DCE — the macro's `expand-reg-machine` routes a literal
+      doc-bearing opts map through `gate-doc-arg`, emitting an
+      `(if interop/debug-enabled? <full-opts> <opts-without-:doc>)` gate Closure
+      constant-folds, so the user-authored `:doc` STRING bytes DCE from the
+      :advanced bundle (a runtime strip cannot DCE a call-site string). That
+      half is pinned by the elision probe (`scripts/check-elision.cjs`, the
+      `rf2-tfiutq-machine-opts-doc-sentinel` sentinel), not this JVM suite.
+
+  This file pins the SEMANTIC half for the machine surface."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            ;; Side-effect require: loads the machines artefact and publishes the
+            ;; machine-registration late-bind hook `rf/reg-machine` resolves.
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest reg-machine-opts-doc-stripped-under-disabled-debug-gate
+  (testing "Per rf2-tfiutq: a `(reg-machine :id {:doc \"…\"} spec)` literal
+            opts-map `:doc` is stripped from the stored registration metadata
+            in prod, while a load-bearing opts key (`:schema`, the event-vector
+            validator) is retained."
+    (with-redefs [interop/debug-enabled? false]
+      (rf/reg-machine :rf2-tfiutq/prod-machine
+        {:doc "machine opts doc elided" :schema [:tuple :keyword]}
+        {:initial :idle
+         :states  {:idle {}}})
+      (let [meta (rf/handler-meta :event :rf2-tfiutq/prod-machine)]
+        (is (some? meta))
+        (is (not (contains? meta :doc))
+            ":doc absent from machine (event) handler-meta in prod")
+        (is (= [:tuple :keyword] (:schema meta))
+            ":schema retained in prod (load-bearing event-vector validation)")))))
+
+(deftest reg-machine-opts-doc-retained-under-enabled-debug-gate
+  (testing "Per rf2-tfiutq: the dev posture (default gate on) retains the
+            `reg-machine` opts-map `:doc` for tooling / agent inspection."
+    (rf/reg-machine :rf2-tfiutq/dev-machine
+      {:doc "machine opts doc kept in dev"}
+      {:initial :idle
+       :states  {:idle {}}})
+    (let [meta (rf/handler-meta :event :rf2-tfiutq/dev-machine)]
+      (is (= "machine opts doc kept in dev" (:doc meta))
+          ":doc retained in dev for tooling / agent inspection"))))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -506,7 +506,59 @@ const DEV_ONLY_SENTINELS = [
   // the form-source gate DCE the string entirely. The sentinel is distinctive
   // enough that a global grep is unambiguous.
   { source: 're-frame.core/reg-* macros (:doc pure-documentation metadata literal)',
-    sentinel: 'rf2-9wwkcm-doc-elision-sentinel' }
+    sentinel: 'rf2-9wwkcm-doc-elision-sentinel' },
+  // re-frame.core/reg-machine — LITERAL opts-map `:doc` elision (rf2-tfiutq).
+  // The 3-arg `reg-machine` macro (`(reg-machine :id {:doc "…"} spec)`)
+  // previously forwarded its `opts` map VERBATIM into the emitted registration
+  // call, so a literal doc-bearing opts map's `:doc` STRING survived :advanced
+  // (the splice-through `defreg-macro` / `defreg-event-macro` surfaces gate
+  // every literal doc-bearing arg via `gate-doc-args`, but `expand-reg-machine`
+  // bypassed that path). rf2-tfiutq routes the opts-form through `gate-doc-arg`
+  // when it is a literal map, emitting the same
+  // `(if interop/debug-enabled? <full-opts> <opts-without-:doc>)` gate Closure
+  // constant-folds under goog.DEBUG=false. The elision-probe's
+  // `touch-doc-metadata!` registers `:rf.probe/doc-machine` with a literal opts
+  // `:doc`; under DEBUG=true the dev arm keeps the string, under DEBUG=false the
+  // gate DCEs it. The sentinel is the distinctive `:doc` value head.
+  { source: 're-frame.core/reg-machine (literal opts-map :doc elision)',
+    sentinel: 'rf2-tfiutq-machine-opts-doc-sentinel' },
+  // ---- rf2-tfiutq: ungated DIRECT-CALL dev-only diagnostic prose ----------
+  //
+  // The ~18 app-facing dev-only warning/diagnostic emits (resources /
+  // routing / machines / ssr-client) call `trace/emit!` / `trace/emit-error!`
+  // DIRECTLY on a runtime DATA branch (`when-some` / `when (seq …)` /
+  // `doseq` / a `catch`), building `(str …)` or literal-string prose, with
+  // NO call-site `interop/debug-enabled?` gate. They still ELIDE in
+  // production: under :advanced + goog.DEBUG=false the directly-called
+  // `emit!` / `emit-error!` body folds to `nil`, Closure inlines the now-
+  // no-op call, and the pure prose args drop as dead. (Contrast the
+  // framework's OWN emit machinery — storage.cljc / registrar.cljc — which
+  // captures `emit!` via `(late-bind/get-fn :trace/emit!)`; that INDIRECT
+  // identity escapes the fold, so those sites carry an explicit
+  // `(when interop/debug-enabled? …)` call-site gate, pinned by the
+  // keyword-op sentinels above.)
+  //
+  // Before rf2-tfiutq the probe pinned dev-only prose absence ONLY inside
+  // already-gated branches and via the require boundary — it never rooted an
+  // UNGATED direct-emit site, so the FOLD path's production absence was
+  // UNVERIFIED. The elision-probe's `touch-direct-emit-diagnostics!` now
+  // roots one representative direct-emit site per shape:
+  //
+  //   1. routing `advise-query-promotion!` — `emit!` :warning whose `:advice`
+  //      `(str …)` prose is built on the `(when (seq missing) …)` branch.
+  //   2. machines `emit-destroy-exit-failure!` — `emit-error!` with a
+  //      literal-string `:reason`, an ungated `defn` body.
+  //
+  // Under DEBUG=true the prose lands in the control bundle; under
+  // DEBUG=false the fold DCEs it. A regression that defeats the fold — e.g.
+  // a refactor that captures `emit!` into a var / map (escaping its
+  // identity, like the framework's late-bind machinery) — would surface
+  // the prose in production and fail this assertion. The fragments are the
+  // distinctive middle of each prose string, unambiguous under a global grep.
+  { source: 're-frame.routing.classification/advise-query-promotion! (direct emit! :advice prose)',
+    sentinel: 'stays a STRING in the route slice' },
+  { source: 're-frame.machines.lifecycle-fx.traces/emit-destroy-exit-failure! (direct emit-error! :reason prose)',
+    sentinel: 'An :exit action threw during destroy-time cascade' }
   // Note (rf2-7yqn39): the :rf.warning/plain-fn-under-non-default-frame-
   // once warning + its emit helper were RETIRED (EP-0002; superseded by
   // the always-on :rf.error/no-frame-context). There is no longer any
@@ -571,6 +623,26 @@ const PROD_ABSENT_WHEN_UNUSED_SENTINELS = [
   // former check-capabilities! sentinel with the image-capability feature.)
   { source: 're-frame.image-assembly/resolve-within-image (assembly-only, DCE when unused)',
     sentinel: 'is selected from' },
+  // re-frame.late-bind.directory/hooks — the ~150 paragraph-length
+  // `:description` strings in the hook-directory inventory (rf2-tfiutq).
+  // This is plain ungated CLJC DATA — no `interop/debug-enabled?` gate — so
+  // it is NOT kept out of production by goog.DEBUG DCE. It is kept out by
+  // REACHABILITY DCE: the directory is required ONLY by drift/publication
+  // TESTS (`late_bind_drift_test`, the adapter publication suites); ZERO
+  // production src namespace `:require`s it (`re-frame.late-bind` names it in
+  // a docstring only, not a require), so the whole corpus is unreachable from
+  // any production boot path and Closure trims it. The probe deliberately does
+  // NOT require it either, so the `:description` strings must be ABSENT.
+  //
+  // No sentinel guarded that absence before rf2-tfiutq. This pins it (mirroring
+  // the EP-0023 `'is selected from'` image-assembly reachability guard): an
+  // accidental future production `:require` of the directory — or a refactor
+  // that pulls `hooks` into a reachable boot path — would surface this
+  // distinctive `:description` head and fail CI. The fragment is the exact text
+  // of the `:router/dispatch!` row's one-line `:description`, unique under a
+  // global grep across tracked source.
+  { source: 're-frame.late-bind.directory/hooks (:description corpus, DCE when unrequired)',
+    sentinel: 'Enqueue an event for processing by the drain loop' },
 ];
 
 // ----- helpers ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three production-bundle-elision fixes on the shared elision-probe surface (`implementation/scripts/check-elision.cjs` sentinels + `implementation/core/test/re_frame/elision_probe.cljs` probe roots). One worker on one branch because all three share the two coupling files. Refs rf2-7czrms, rf2-7xz70g, rf2-tfiutq.

### 1. Ungated dev-only diagnostic emits — STEP-0 empirical re-evaluation

The ~18 app-facing warning/diagnostic emits (resources / routing / machines / ssr-client) call `trace/emit!` / `trace/emit-error!` **directly** on a runtime data branch (`when-some` / `when (seq …)` / `doseq` / a `catch`), building `(str …)` or literal-string prose, with **no** call-site `interop/debug-enabled?` gate.

**STEP-0 finding (the load-bearing surprise):** I rooted a representative site (routing `advise-query-promotion!` — `emit!` + `(str …)` `:advice`; machines `emit-destroy-exit-failure!` — `emit-error!` + literal string) in the `:advanced` probe and grepped both builds. **The prose is already elided in production:**

| sentinel | control (DEBUG=true) | production (DEBUG=false) |
|---|---|---|
| `stays a STRING in the route slice` | present (1) | **absent (0)** |
| `An :exit action threw during destroy-time cascade` | present (1) | **absent (0)** |

A directly-called `emit!` / `emit-error!` folds its body to `nil` under `goog.DEBUG=false`; Closure inlines the now-no-op call and drops the pure prose args as dead. The bead's stated root cause — `emit!`'s identity escaping into a late-bind registry — applies to the framework's **own** emit machinery (`storage.cljc`, `registrar.cljc`, which capture `emit!` via `(late-bind/get-fn :trace/emit!)` and are **already gated**), **not** to these direct-call sites.

Per the bead's own STEP-0 escape hatch ("if it does NOT survive — already DCE'd — re-evaluate, do not blindly gate"), **no mass-gating was applied** — gating 18 already-elided sites would add redundant noise implying a leak that does not exist (ELEGANCE / CLARITY). Instead I closed the **systemic probe gap** the bead correctly identifies: the probe previously pinned dev-only prose absence only inside *already-gated* branches and via the require boundary — it never rooted an *ungated direct-emit* site, so the fold-path's production absence was unverified. Added two `DEV_ONLY_SENTINELS` + a `touch-direct-emit-diagnostics!` root so the control build exercises the path and a future regression (e.g. capturing `emit!` into a var, escaping its identity like the framework machinery) is caught.

### 2. `:doc` macro-DCE gap on `reg-machine` opts map

`expand-reg-machine` forwarded its `opts-form` **verbatim**, bypassing `gate-doc-args` — so a literal `(reg-machine :id {:doc "…"} spec)` left its `:doc` string bytes in the `:advanced` bundle (the splice-through `defreg-macro` / `defreg-event-macro` surfaces gate every literal doc-bearing arg; `reg-machine` did not). **Fix:** route `opts-form` through `gate-doc-arg` when it is a literal map (the idiomatic shape), emitting the same `(if interop/debug-enabled? <full> <stripped>)` gate Closure folds. A non-literal opts expression (symbol / computed map / `merge`) passes through unchanged — its `:doc` still strips from stored handler-meta via the runtime `register!` strip, but its bytes are outside the macro's reach.

Pinned by: a new `DEV_ONLY` sentinel + probe touch (`rf2-tfiutq-machine-opts-doc-sentinel` — prod absent, control present, confirmed); a JVM handler-meta-strip parity test in the machines artefact (`re-frame.machine-doc-opts-prod-elision-test`); a cross-reference note in the core doc-elision suite (the core `:test` classpath lacks `day8/re-frame2-machines`, so the machine surface's semantic strip test lives in the machines artefact).

### 3. Reachability sentinel for the late-bind directory `:description` corpus

`re-frame.late-bind.directory/hooks` carries ~150 paragraph-length `:description` strings — plain ungated CLJC data, kept out of production **solely by reachability DCE** (verified: zero production src namespace `:require`s the directory; only test files and one docstring mention it). No leak today, but **no sentinel guarded that absence.** Added a `PROD_ABSENT_WHEN_UNUSED_SENTINELS` entry (`Enqueue an event for processing by the drain loop`, the `:router/dispatch!` row's `:description`, unique across tracked source) mirroring the EP-0023 image-assembly reachability guard, so an accidental future production `:require` is caught by CI. Pure test-guard addition — no source change.

## Gate results

- `npm run test:elision` — **PASS**: production 45/45 absent (was 42), control 45/45 present, EP-0023 1/1 provenance-survives + 2/2 assembly-DCE.
- `npm run test:cljs` — **7999 tests / 36798 assertions, 0 failures, 0 errors.**
- machines JVM suite (`clojure -M:test`) — **845 tests / 2743 assertions, 0 failures, 0 errors.**
- core doc-elision JVM test — **5 tests / 27 assertions, 0 failures.**
- new machines doc-opts test — **2 tests / 4 assertions, 0 failures.**

## Files changed

- `implementation/core/src/re_frame/core_reg_macros.cljc` — route `reg-machine` literal opts through `gate-doc-arg` (only production-source change).
- `implementation/scripts/check-elision.cjs` — +2 direct-emit `DEV_ONLY` sentinels, +1 reg-machine opts-`:doc` `DEV_ONLY` sentinel, +1 directory-corpus `PROD_ABSENT_WHEN_UNUSED` sentinel.
- `implementation/core/test/re_frame/elision_probe.cljs` — `touch-direct-emit-diagnostics!` + reg-machine literal-opts `:doc` touch.
- `implementation/machines/test/re_frame/machine_doc_opts_prod_elision_test.clj` — new JVM parity test for the reg-machine opts `:doc` strip.
- `implementation/core/test/re_frame/doc_metadata_prod_elision_test.clj` — cross-reference note pointing at the machines-artefact parity test.