### PR TITLE
fix(spec): Conventions §Artefact-tiers — add re-frame2-resources (016) row

### DIFF
--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -1398,11 +1398,11 @@ re-frame2 ships as **multiple Maven artefacts**. A user picks the artefacts thei
 
 ### Artefact tiers
 
-The CLJS reference's published artefact set partitions across three tiers.
+The CLJS reference's artefact set partitions across three tiers (the per-feature tier additionally enumerates post-v1 artefacts, tagged inline, so it stays the complete capability list).
 
 **Core** — `day8/re-frame2`. The always-needed surface: registry, drain, fx, dispatch, subscribe, frame-provider, trace.
 
-**Per-feature** — `day8/re-frame2-<feature-id>`. Optional capabilities. The feature-id matches the spec topic:
+**Per-feature** — `day8/re-frame2-<feature-id>`. Optional capabilities. The feature-id matches the spec topic. Rows tagged **(post-v1)** name an artefact whose contract is settled and whose coordinate is fixed, but which ships after v1 — they are listed here so this table stays the single complete per-feature enumeration:
 
 | Artefact | Spec | Feature |
 |---|---|---|
@@ -1413,6 +1413,9 @@ The CLJS reference's published artefact set partitions across three tiers.
 | `re-frame2-ssr` | [011](011-SSR.md) | SSR & hydration |
 | `re-frame2-schemas` | [010](010-Schemas.md) | Malli schema layer |
 | `re-frame2-epoch` | [Tool-Pair](Tool-Pair.md) | Tool-Pair epoch surfaces |
+| `re-frame2-resources` **(post-v1)** | [016](016-Resources.md) | Resources / declarative server-state — the richest per-feature artefact: it alone contributes three runtime subsystems (`:rf.runtime/resources` / `:rf.runtime/work-ledger` / `:rf.runtime/mutations`) and three registrar kinds (`:resource` / `:mutation` / `:resource-scope`) |
+
+Other post-v1 per-feature artefacts follow this same convention as their coordinates settle — e.g. Stories ([007](007-Stories.md)) is a post-v1 capability without a fixed artefact coordinate yet, so it earns a row here once one is assigned.
 
 **Per-adapter** — `day8/re-frame2-<adapter>`. Each adapter implements the [Spec 006 substrate contract](006-ReactiveSubstrate.md) for one rendering substrate:
 


### PR DESCRIPTION
## The drift

`spec/Conventions.md` §"Artefact tiers" — the per-feature table — is the canonical "what are the per-feature optional-capability artefacts" enumeration (machines / flows / routing / http / ssr / schemas / epoch). It **omitted re-frame2-resources (Spec 016)**, even though resources is treated as a named per-feature artefact in every other location:

- `spec/README.md` Capability layer lists 016-Resources as an optional capability.
- `spec/Ownership.md` names `day8/re-frame2-resources` (post-v1 optional artefact) on the 016 row.
- `spec/Conventions.md` reserved-keys tables already mark `:rf.runtime/resources` + `:rf.runtime/work-ledger` + `:rf.runtime/mutations` as the post-v1 Resources artefact.
- `spec/001-Registration.md` marks the `:resource` registry kind late-bound by `day8/re-frame2-resources`.

So the table — the single complete per-feature enumeration — was the one place out of step.

## Resolution — bead's preferred option (a)

The table caption says the CLJS reference's *published* artefact set; resources is post-v1 (not yet published). Rather than leave it out (which keeps the table incomplete) I took the bead's preferred **option (a): include post-v1 artefacts with an explicit "(post-v1)" annotation** so the table stays the single complete enumeration.

Changes (5 insertions / 2 deletions, table-only):

- **New row** `re-frame2-resources` **(post-v1)** → [016](spec/016-Resources.md), annotated as the richest per-feature artefact: it alone contributes three runtime subsystems (`:rf.runtime/resources` / `:rf.runtime/work-ledger` / `:rf.runtime/mutations`) and three registrar kinds (`:resource` / `:mutation` / `:resource-scope`). Facts cross-checked against Ownership's 016 row and 001-Registration's `:resource` / `:mutation` / `:resource-scope` rows.
- **Caption tweak** — dropped "published" (no longer strictly accurate with a post-v1 row) and added a short clause noting the per-feature tier additionally enumerates post-v1 artefacts, tagged inline.
- **Per-feature note** — one line explaining the (post-v1) convention and that other post-v1 capabilities follow it as their coordinates settle.

## Stories (007) stays a note

007-Stories is also post-v1, but unlike resources it has **no fixed artefact coordinate** in Ownership (just "post-v1"). Under option (a) Stories would need a coordinate decision first — out of scope here. So resources gets the annotated row; Stories is covered by the one-line note (*"e.g. Stories (007) is a post-v1 capability without a fixed artefact coordinate yet, so it earns a row here once one is assigned"*) — no Stories coordinate invented.

## Secondary (glossary) — skipped

I skipped the optional "optional capability = per-feature artefact" glossary line. The equivalence is not a triangulation the reader is forced to make at this point in the doc, and adding it would read as gold-plating on a hot-zone surgical edit. The new note already ties "post-v1 capability" → "earns a row," which is the only place the equivalence was load-bearing for this change.

## Out of scope (untouched)

The downstream count inconsistencies (setup-skill "ten artefacts", "6 per-feature splits" phrasing in late-bind / bundle-isolation) are separate beads — not chased here.

## Gate results

Ran the doc/spec gates the repo wires for `spec/` changes (per `.github/workflows/docs.yml`), all **PASS**:

- `check_doc_slugs.py` (link target + anchor validator) — self-test + live: PASS
- `check_runtime_subsystem_grading.py` — self-test + live: PASS
- `check_inject_cofx_residue.py` — self-test + live: PASS
- `check_retired_composition_vocab.py` — self-test + live: PASS
- `check_retired_image_keys.py` — self-test + live: PASS
- `check_ep_status_sync.py` — PASS
- Staged `spec/` → `docs/spec` then `mkdocs build --strict` — **PASS** (exit 0; only pre-existing INFO-level relative-link notes about `examples/` and `the-mayor-method/`, none from this edit; no WARNING fired).

Table-only edit; no CLJS / spec-conformance gate keys off Conventions table content.

Refs: rf2-9ck5il
