### PR TITLE
fix(ci): extend doc-guide-check + doc-api-check to scan capability docs dirs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,6 +64,10 @@ on:
       # the tools/** entry above.)
       - 'skills/**'
       - 'docs/guide/**'
+      # Per-capability CONCEPT docs (rf2-earvtz): the #4961 reorg moved each
+      # capability's concept doc to docs/<cap>/concepts.md; doc-guide-check now
+      # scans them, so a PR touching only one must run the api-manifest job.
+      - 'docs/*/concepts.md'
       # Human-doc API-reference projection surfaces (rf2-vzupmg): the three
       # API-reference trees the doc-api-check scans are manifest projections
       # too; a PR touching them must run the api-manifest job's doc-api-check
@@ -73,6 +77,10 @@ on:
       - 'spec/Privacy.md'
       - 'docs/api/**'
       - 'docs/story/api/**'
+      # Per-capability API docs (rf2-earvtz): the #4961 reorg moved each
+      # capability's API reference to docs/<cap>/api.md; doc-api-check now scans
+      # them, so a PR touching only one must run the api-manifest job.
+      - 'docs/*/api.md'
   # PR trigger is intentionally UNFILTERED (see REQUIRED-CHECK SHAPE
   # above). The lint surface is re-applied job-side via the `detect` job.
   pull_request:
@@ -144,14 +152,18 @@ jobs:
               # The skills + doc-guide are secondary manifest projections
               # (rf2-gkp0t): a var rename there is caught by the api-manifest
               # job's skills-check / doc-guide-check. A pure-skills or
-              # pure-doc-guide PR must still run the drift-check.
-              skills/*|docs/guide/*)
+              # pure-doc-guide PR must still run the drift-check. The
+              # per-capability concept docs (docs/<cap>/concepts.md from the
+              # #4961 reorg) are scanned by doc-guide-check now too (rf2-earvtz).
+              skills/*|docs/guide/*|docs/*/concepts.md)
                 lint_surface=true ;;
               # The three human-doc API-reference trees are manifest
               # projections too (rf2-vzupmg): a removed/renamed public surface
               # named there is caught by the api-manifest job's doc-api-check.
-              # A pure-doc PR touching them must still run the drift-check.
-              spec/Privacy.md|docs/api/*|docs/story/api/*)
+              # A pure-doc PR touching them must still run the drift-check. The
+              # per-capability API docs (docs/<cap>/api.md from the #4961 reorg)
+              # are scanned by doc-api-check now too (rf2-earvtz).
+              spec/Privacy.md|docs/api/*|docs/story/api/*|docs/*/api.md)
                 lint_surface=true ;;
             esac
           done <<< "$files"

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
@@ -19,6 +19,14 @@
   `(rf/<var>` / `(story/<var>` reference must resolve to a manifest row, so a
   reference to a renamed / removed / never-manifested public surface goes RED.
 
+  CAPABILITY API DOCS (rf2-earvtz). The #4961 docs reorg moved each
+  capability's API REFERENCE out of the flat `docs/api/` tree into
+  per-capability `docs/<cap>/api.md` files (machines / resources / routing /
+  ssr). Those API docs are the same projection class — they name public vars
+  in call position — and so are scanned here via the `docs/*/api.md` glob
+  (which auto-covers a future capability dir). Without this, a removed /
+  renamed public surface named in a moved API doc would slip through CI.
+
   SCOPE — call-position discipline (same as doc-guide / skills checks).
   References are anchored on the leading `(` so the `:rf/*` reserved keyword
   namespace is excluded (a bare `rf/<token>` sweep would drown in
@@ -134,6 +142,15 @@
                                 (proj/require-markdown-files
                                   label (apply proj/repo-file segs)))
                               dir-surfaces)
+        ;; Per-capability API docs (rf2-earvtz). The #4961 docs reorg moved
+        ;; each capability's API reference out of the flat docs/api/ tree into
+        ;; docs/<cap>/api.md (machines/resources/routing/ssr). The
+        ;; docs/*/api.md glob folds those moved files back under this gate's
+        ;; scan so a removed/renamed public surface named there goes RED; it
+        ;; auto-covers a future capability dir with no gate edit, and fails
+        ;; loudly (require-*) if the layout moves again.
+        cap-api-files (proj/require-capability-doc-files
+                        "docs/*/api.md" "api.md")
         ;; spec/Privacy.md — a single EXPECTED file; fail loud if it moves.
         privacy-file  (apply proj/repo-file privacy-file-segs)
         _             (when-not (.isFile ^java.io.File privacy-file)
@@ -144,7 +161,7 @@
                                       "against a non-existent surface; reconcile "
                                       "the path.")
                                  {:file (str privacy-file)})))
-        files         (cons privacy-file dir-files)
+        files         (concat [privacy-file] dir-files cap-api-files)
         references    (references-in-files files)
         var-problems  (reconcile {:references    references
                                   :manifest-vars manifest-vars
@@ -155,7 +172,7 @@
         kw-problems   (proj/keyword-drift-problems-over-files files)
         problems      (concat var-problems kw-problems)]
     (proj/report-with-floor!
-      "spec/Privacy.md + docs/api/ + docs/story/api/"
+      "spec/Privacy.md + docs/api/ + docs/story/api/ + docs/*/api.md"
       (count references) min-references problems)))
 
 (defn -main [& _]

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
@@ -7,6 +7,14 @@
   no longer resolves. This check extracts every call-position `(rf/<var>`
   reference and asserts each resolves to a manifest `re-frame.core` row.
 
+  CAPABILITY CONCEPT DOCS (rf2-earvtz). The #4961 docs reorg moved each
+  capability's CONCEPT doc out of the flat `docs/guide/` tree into
+  per-capability `docs/<cap>/concepts.md` files (machines / resources /
+  routing / ssr). Those concept docs teach the same worked code and so are
+  scanned by this gate alongside `docs/guide/` — the `docs/*/concepts.md`
+  glob folds them in (and auto-covers a future capability dir). Without this,
+  a broken `(rf/<var>` reference in a moved concept doc would slip through CI.
+
   SCOPE — same call-position discipline as the skills check (anchor on the
   leading `(` so the `:rf/*` reserved keyword namespace is excluded, not
   swept in as bogus var references).
@@ -88,7 +96,17 @@
         dir          (proj/repo-file "docs" "guide")
         ;; require-markdown-files (rf2-utvst): fail loudly if docs/guide/
         ;; moves or is renamed, rather than silently checking zero files.
-        files        (proj/require-markdown-files "docs/guide/" dir)
+        guide-files  (proj/require-markdown-files "docs/guide/" dir)
+        ;; Per-capability CONCEPT docs (rf2-earvtz). The #4961 docs reorg moved
+        ;; each capability's concept doc out of the flat docs/guide/ tree into
+        ;; docs/<cap>/concepts.md (machines/resources/routing/ssr). The
+        ;; docs/*/concepts.md glob folds those moved files back under this
+        ;; gate's scan so a broken `(rf/<var>` reference in them goes RED; it
+        ;; auto-covers a future capability dir with no gate edit, and fails
+        ;; loudly (require-*) if the layout moves again.
+        concept-files (proj/require-capability-doc-files
+                        "docs/*/concepts.md" "concepts.md")
+        files        (concat guide-files concept-files)
         references   (for [file files
                            ref  (proj/alias-call-references "rf" (proj/numbered-lines file))]
                        (assoc ref :file (proj/repo-relative file)))
@@ -103,7 +121,8 @@
         ;; reintroduction goes RED here too.
         kw-problems  (proj/keyword-drift-problems-over-files files)
         problems     (concat var-problems kw-problems)]
-    (proj/report-with-floor! "docs/guide/" (count references) min-references problems)))
+    (proj/report-with-floor! "docs/guide/ + docs/*/concepts.md"
+                             (count references) min-references problems)))
 
 (defn -main [& _]
   (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
@@ -123,6 +123,54 @@
                {:label label :dir (str dir)}))))
   (markdown-files dir))
 
+(defn require-capability-doc-files
+  "Resolve the per-capability documentation files named `filename` (e.g.
+   `\"concepts.md\"`, `\"api.md\"`) that live as immediate children of the
+   capability directories directly under `docs/` — i.e. the `docs/*/<filename>`
+   glob (`docs/machines/concepts.md`, `docs/routing/api.md`, …).
+
+   THE SHAPE (rf2-earvtz). The #4961 docs reorg moved each capability's
+   CONCEPT and API reference out of the flat `docs/guide/` and `docs/api/`
+   trees into per-capability directories `docs/<cap>/{concepts,api}.md`. The
+   doc-guide / doc-api projection gates scanned only the old flat trees, so
+   the moved files went UNSCANNED — a broken `(rf/<var>` reference in them
+   would slip through CI. This resolves the moved files by glob so the gates
+   cover them, and AUTO-COVERS future capability dirs (a new
+   `docs/<cap>/concepts.md` is picked up with no gate edit).
+
+   SCOPE DISCIPLINE. The glob is anchored on a SINGLE path segment between
+   `docs/` and the filename, so it matches ONLY immediate-child capability
+   files. It never sweeps in the flat trees the gates already own
+   (`docs/guide/` / `docs/api/` are directories, not `docs/api.md` files) nor
+   nested API trees (`docs/story/api/` is a directory; `docs/story/api.md`
+   does not exist). The match excludes directories defensively.
+
+   NON-VACUOUS FLOOR (rf2-utvst discipline, mirroring
+   `require-markdown-files`). These capability files are an EXPECTED surface
+   today, so a zero-match result — a further reorg that renames or relocates
+   them — throws loudly rather than silently scanning nothing and turning the
+   gate into a vacuous green. `label` names the surface for the error.
+
+   Returns the matched files as an `io/file` seq, sorted by path for
+   deterministic reporting."
+  [label filename]
+  (let [docs-dir (repo-file "docs")
+        matches  (when (.isDirectory ^java.io.File docs-dir)
+                   (->> (.listFiles ^java.io.File docs-dir)
+                        (filter #(.isDirectory ^java.io.File %))
+                        (map #(io/file % filename))
+                        (filter #(.isFile ^java.io.File %))
+                        (sort-by #(.getPath ^java.io.File %))))]
+    (when (empty? matches)
+      (throw (ex-info
+               (format (str "%s: no capability doc files matched docs/*/%s — the "
+                            "projection gate cannot run against a non-existent "
+                            "surface (a moved/renamed capability-doc layout would "
+                            "otherwise pass vacuously). Reconcile the surface path.")
+                       label filename)
+               {:label label :glob (str "docs/*/" filename)})))
+    matches))
+
 ;; ---------------------------------------------------------------------------
 ;; Reference extraction.
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The #4961 docs reorg moved each capability's **concept** doc to `docs/<cap>/concepts.md` and its **API** reference to `docs/<cap>/api.md`, out of the flat `docs/guide/` and `docs/api/` trees. Two CI projection gates had now-stale scan roots:

- **doc-guide-check** scanned only `docs/guide/`.
- **doc-api-check** scanned only `spec/Privacy.md` + `docs/api/` + `docs/story/api/`.

Both still PASSED but no longer validated the **moved** docs — a broken `(rf/<var>` reference in a capability `concepts.md` / `api.md` would slip through CI while both gates stayed green.

## Change — new scan roots per gate

A new shared helper `projection/require-capability-doc-files` globs `docs/*/<filename>` (immediate-child capability files only) and returns the matched files, **failing loudly** (the existing `rf2-utvst` non-vacuous floor, mirroring `require-markdown-files`) if a future reorg relocates them so the gate can never pass vacuously.

| Gate | Before | After (added) |
|------|--------|---------------|
| **doc-guide-check** | `docs/guide/` | `+ docs/*/concepts.md` |
| **doc-api-check** | `spec/Privacy.md + docs/api/ + docs/story/api/` | `+ docs/*/api.md` |

### Glob vs explicit four-dir list — chose **glob**, here's why

`docs/*/concepts.md` and `docs/*/api.md` were verified to match **exactly** the four capability files (`machines` / `resources` / `routing` / `ssr`) and nothing else:

- `docs/guide/` and `docs/api/` are **directories**, not `docs/<x>.md` files — the flat trees the gates already own are not double-scanned.
- `docs/story/` has no top-level `api.md` (its API reference is the `docs/story/api/` directory, already covered separately).

The glob is more elegant than a hardcoded four-dir list and **auto-covers a future capability dir** (a new `docs/<cap>/concepts.md` is picked up with no gate edit), while the `require-*` floor keeps it non-vacuous. The lint.yml `push` paths + `detect` classifier were extended with `docs/*/concepts.md` / `docs/*/api.md` so a PR touching only a capability doc still runs the api-manifest job.

## Empirical verification

**Dirs/files found** (this branch): `docs/{machines,resources,routing,ssr}/` each carry **both** `concepts.md` and `api.md` — all four match each glob.

**Gates green as-is** (after wiring):
- `doc-guide-check` → OK, **680** public-var references (up from the ~504 pre-reorg guide count — the four `concepts.md` files are now scanned).
- `doc-api-check` → OK, **178** references (up from ~50 across the original three trees — the four `api.md` files are now scanned).

**Bogus-ref FAIL proof** (the gates genuinely scan the moved docs):
- Appended `(rf/does-not-exist :bogus/probe)` to `docs/machines/concepts.md` → `doc-guide-check` **FAILED** (exit 1): `docs/machines/concepts.md:453  rf/does-not-exist  no re-frame.core manifest row`. Reverted.
- Appended the same to `docs/routing/api.md` → `doc-api-check` **FAILED** (exit 1): `docs/routing/api.md:151  rf/does-not-exist  no manifest row (renamed / removed / never-manifested public surface)`. Reverted.

**Self-tests**: `clojure -M:test` in `implementation/scripts/api-manifest/` → **53 tests / 105 assertions, 0 failures, 0 errors** (including the `live-doc-guide-reconciles-clean` / `live-doc-api-reconciles-clean` end-to-end smokes now exercising the widened roots).

`lint.yml` validated as well-formed YAML. No doc content changed — only gate scan coverage + workflow triggers — so mkdocs is unaffected.

## Out of scope

No doc-content rewrites, no reorg changes, no edits to `docs/guide/` or `docs/api/` content. Gate scan coverage only.

rf2-earvtz