### PR TITLE
docs(examples): elevate in-code comments + docstrings to the guide voice (code-comment half of the treatment)

### DIFF
--- a/examples/_shared/css/style.css
+++ b/examples/_shared/css/style.css
@@ -20,6 +20,9 @@
  *                     design system exposes one substrate-agnostic token
  *                     vocabulary; every example — including the design-led
  *                     notebook and process-monitor — consumes --ex-* directly.
+ *                     Note the bright/deep accent split below: the bright
+ *                     --ex-accent paints large decorative fills, the --ex-*-deep
+ *                     siblings carry any text or button a human reads (AA-safe).
  *
  * @imports structure.css for layout-only class shapes
  *          (forms, banners, pills, boot, navbar, cards, cells grid,

--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -1,9 +1,11 @@
 (ns counter-helix.core
   "Helix variant of the counter example.
 
-   Exercises the same dataflow as examples/reagent/counter and
-   examples/uix/counter_uix but renders it through the Helix adapter —
-   the React state model is hooks all the way down. Demonstrates:
+   The one idea: the dataflow doesn't know which React-family library
+   draws the pixels. Exercises the SAME events and sub as
+   examples/reagent/counter and examples/uix/counter_uix — only the view
+   and mount change — but renders through the Helix adapter, where the
+   React state model is hooks all the way down. Demonstrates:
 
      - `rf/init!` with the Helix adapter
      - `reg-event` / `reg-sub` (substrate-agnostic)
@@ -73,8 +75,8 @@
 ;; targets the right frame even from an async callback.
 
 (defnc counter-buttons []
-  (let [count    (helix-adapter/use-subscribe [:counter/value])
-        dispatch (:dispatch (rf/frame-handle))]
+  (let [count    (helix-adapter/use-subscribe [:counter/value])  ;; read: re-renders when :counter/value moves
+        dispatch (:dispatch (rf/frame-handle))]                  ;; write: dispatch off a handle, no auto-injection
     (d/div
        (d/button {:on-click #(dispatch [:counter/dec])} "-")
        (d/span {:style {:margin "0 1em"} :data-testid "counter-value"} count)

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -333,12 +333,26 @@
 ;; ============================================================================
 ;; VIEWS  (Helix — defnc + use-subscribe)
 ;; ============================================================================
+;;
+;; The Helix view idiom, and the only place this example differs from the
+;; Reagent reference: a view is a plain `defnc`; it reads a subscription
+;; through the adapter's `use-subscribe` hook; and it takes `dispatch` off a
+;; `frame-handle` rather than having it lexically injected (`reg-view` is
+;; Reagent-only — there is no auto-injection here). `:rf/machine-has-tag?`
+;; reads are *ask, don't tell* state-tag queries; `:auth.login/error` is a
+;; named sub. To the call site they're identical — both are just subscriptions.
 
 (defnc login-form []
   (let [busy?    (helix-adapter/use-subscribe [:rf/machine-has-tag?
                                                :auth.login/flow :auth/busy])
         err      (helix-adapter/use-subscribe [:auth.login/error])
+        ;; No global dispatch in re-frame2 — every dispatch goes to a frame.
+        ;; Pull this frame's `dispatch` off the render-time frame-handle; it
+        ;; resolves to `:rf/default` via the provider in `run`.
         dispatch (:dispatch (rf/frame-handle))
+        ;; Transient pre-submit input lives in component-local use-state — it
+        ;; isn't application state, it's keystrokes in flight. It crosses into
+        ;; the machine (and gets validated) only at the :on-submit dispatch.
         [email    set-email!]    (helix-hooks/use-state "")
         [password set-password!] (helix-hooks/use-state "")]
     (d/form

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -7,10 +7,12 @@
    Demonstrates:
 
      - Helix components (`defnc`) consuming subs via `use-subscribe`
-     - signal-graph subscriptions (filter chips → visible process list,
-       process selection → relevant log slice)
+     - signal-graph subscriptions: two independent inputs (the level-filter
+       chips, the selected process) fold into one derived sub, the visible
+       log slice — pure derivation, recomputed only when an input changes
      - a recurring `:dispatch-later` tick that appends synthetic log
-       lines (`:process-monitor/tick`) — proves a real reactive loop, not a
+       lines (`:process-monitor/tick`), owned by the component lifecycle and
+       kept idempotent by a generation guard — a real reactive loop, not a
        static screenshot
      - per-row dispatch from inside a `defnc` row component
 
@@ -95,6 +97,9 @@
             :process-monitor/level-filter #{:info :warn :error}
             :process-monitor/selected   nil
             :process-monitor/tick-gen   next-gen}
+       ;; Arm the loop by describing the first tick as data — the handler
+       ;; never touches setTimeout; the :dispatch-later effect handler does.
+       ;; The tick carries `next-gen` so it can recognise a retired chain.
        :fx [[:dispatch-later {:ms 1800 :event [:process-monitor/tick next-gen]}]]})))
 
 (rf/reg-event :process-monitor/tick
@@ -164,6 +169,9 @@
 (rf/reg-sub :process-monitor/selected
   (fn [db _] (:process-monitor/selected db)))
 
+;; First derived sub: a pure node hanging off the base subs above. `:<-`
+;; names its inputs; the runtime recomputes it only when an input changes
+;; by `=`, so the tiles don't re-render when an unrelated key moves.
 (rf/reg-sub :process-monitor/totals
   :<- [:process-monitor/processes]
   (fn [processes _]
@@ -173,6 +181,9 @@
      :cpu     (reduce + 0 (map :cpu processes))
      :mem     (reduce + 0 (map :mem processes))}))
 
+;; The signal-graph node: two independent UI inputs (the level filter, the
+;; selected process) plus the raw logs and processes fold into the slice the
+;; log pane shows. The view does no filtering itself — it reads this.
 (rf/reg-sub :process-monitor/visible-logs
   :<- [:process-monitor/logs]
   :<- [:process-monitor/level-filter]
@@ -209,6 +220,9 @@
     (d/div {:class "pm-tile-label"} label)
     (d/div {:class "pm-tile-value"} value)))
 
+;; First sub-reading view. `use-subscribe` is the Helix hook form of
+;; `subscribe`: it returns a plain value (not a reaction) and re-renders this
+;; component when that value changes. Call it at the top of the body.
 (defnc tiles []
   (let [totals (helix-adapter/use-subscribe [:process-monitor/totals])]
     (d/div {:class "pm-tiles"}
@@ -218,6 +232,9 @@
       ($ tile {:label "Σ CPU"   :value (str (.toFixed (:cpu totals) 1) "%")})
       ($ tile {:label "Σ MEM"   :value (str (:mem totals) "M")}))))
 
+;; First dispatching view. To dispatch, grab `dispatch` off a frame-handle —
+;; `(rf/frame-handle)` captures the current frame as a value, so the click
+;; handler dispatches into this app's frame, not some ambient default.
 (defnc level-chips []
   (let [active   (helix-adapter/use-subscribe [:process-monitor/level-filter])
         dispatch (:dispatch (rf/frame-handle))]

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -39,6 +39,11 @@
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- Events / subs (handler registry is app-global) --------------------------
+;;
+;; These four forms are the substrate-agnostic core: pure handlers, a pure
+;; subscription, all over plain data. They are byte-for-byte the stock
+;; counter's, and they survive the substrate swap untouched — only the boot
+;; below changes. That invariance is the whole point of this example.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -55,10 +60,11 @@
 ;; -- Views -------------------------------------------------------------------
 ;;
 ;; reg-view is substrate-agnostic — the macro expands to a plain
-;; React-component shape that consults the active adapter's
+;; React-component shape that consults the *active* adapter's
 ;; `register-context-provider` / `current-component` seams at render
-;; time. With the slim adapter installed (see `run` below), the
-;; rendered component reads frame state through
+;; time. So the very same view form renders through whichever substrate
+;; was installed at boot. With the slim adapter installed (see `boot!`
+;; below), the rendered component reads frame state through
 ;; `reagent2.core/current-component` rather than stock Reagent's.
 
 (reg-view counter-buttons []

--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -84,17 +84,22 @@
 ;; STAGING-SLOT WRITER
 ;; ============================================================================
 ;;
-;; The child loader dispatches this event with its loaded payload
-;; before transitioning into its terminal `:done` state. The boot
-;; machine reads `[:boot/staging <staging-key>]` on the
-;; :hydrating transition to write the loaded values into the
-;; top-level app-db slices.
+;; How does a :spawn-all child hand its payload back to the parent? Not on
+;; the completion event — the runtime intercepts :spawn-all join events for
+;; its own bookkeeping and never feeds them into the parent's :on lookup, so
+;; there is no event to carry data on (see the ns docstring). The canonical
+;; Pattern-Boot answer is a staging slot in app-db: each child loader writes
+;; its payload into `[:boot/staging <staging-key>]` just before signalling
+;; completion, and the parent reads the whole slot once on the :hydrating
+;; transition. Bonus: the loaded data lives in app-db the whole time —
+;; inspectable in pair-tools, snapshottable for SSR — never in-flight-and-
+;; unobservable on an event.
 
 (rf/reg-event :boot/stage-payload
   {:doc "Write a child-loaded payload into the boot machine's
          staging slot. Dispatched by the :boot/loader child's
-         :dispatch-done action just before it fires the join-completion
-         event back to the parent."}
+         :dispatch-done action just before it dispatches the
+         join-completion event back to the parent."}
   (fn handler-boot-stage-payload [{:keys [db]} [_ staging-key payload]]
     {:db (assoc-in db [:boot/staging staging-key] payload)}))
 
@@ -147,7 +152,7 @@
 
     :dispatch-done
     ;; Terminal-state entry. First write the loaded payload into
-    ;; [:boot/staging <staging-key>], then fire the child-completion
+    ;; [:boot/staging <staging-key>], then dispatch the child-completion
     ;; event back to the parent. The completion event carries both the
     ;; child-id AND the loaded payload:
     ;;   - In :configuring (a single :spawn), this event lands in the
@@ -183,10 +188,10 @@
     :loading
     {:entry :begin-fetch
      :on    {:asset/replied
-             ;; Guarded fork on the reply kind. The runtime appends
-             ;; the reply payload as the LAST element of the event
-             ;; vector, so the event arrives as
-             ;; [:asset/replied :success {:kind :success :value ...}]
+             ;; Guarded fork on the reply kind: the first branch whose
+             ;; `:guard` passes wins. The runtime appends the reply payload
+             ;; as the LAST element of the event vector, so the event arrives
+             ;; as [:asset/replied :success {:kind :success :value ...}]
              ;; — we pick the value out from the 3rd-position arg.
              [{:guard (fn [{ev :event}] (= :success (nth ev 1 nil)))
                :target :done

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -1,5 +1,8 @@
 (ns counter.core
-  "A minimal counter against the re-frame2 API.
+  "The smallest possible re-frame2 app — and so the cleanest place to
+   meet the event cascade. One slice of app-db, three event handlers,
+   one subscription, one view, dispatched in a single explicitly-
+   established frame.
 
    Demonstrates: `reg-event`, `reg-sub`, `reg-view` with frame-bound
    `dispatch`/`subscribe` injection."
@@ -9,7 +12,11 @@
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
-;; -- Events / subs (handler registry is app-global) --------------------------
+;; -- Events / subs (the registrar is process-global) -------------------------
+;;
+;; Each handler is a pure (coeffects, event-vector) -> effect map fn. It
+;; doesn't perform the change; it returns `{:db …}` ("replace app-db with
+;; this") and the runtime commits it atomically at the end of the cascade.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -25,13 +32,16 @@
 
 ;; -- Views -------------------------------------------------------------------
 ;;
-;; The `:counter-buttons` view holds the UI. Per Spec 004 §reg-view, the
-;; defn-shape macro auto-injects `dispatch` and `subscribe` as lexical
-;; bindings; both resolve at render time to the frame in scope (the
-;; default frame here).
+;; A view is a pure fn from subscription values to hiccup. This one reads
+;; state by dereffing a `subscribe` and dispatches an event on click —
+;; no business logic; the inc/dec live in the handlers above.
 ;;
-;; reg-view auto-defs a Var named after the supplied symbol and
-;; registers the view under (keyword *ns* sym).
+;; Per Spec 004 §reg-view, the defn-shape macro auto-injects `dispatch`
+;; and `subscribe` as lexical bindings (so they aren't imported here);
+;; both resolve at render time to the frame in scope — see the boot
+;; below, which scopes this tree to `app-frame`. The macro also auto-defs
+;; a Var named after the supplied symbol and registers the view under
+;; (keyword *ns* sym), so `counter-app` can reference it directly.
 
 (reg-view counter-buttons []
   [:div
@@ -39,8 +49,9 @@
    [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:counter/value])]
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
-;; The root `counter-app` view renders `counter-buttons` against the
-;; default frame. Initialisation runs in `run` via `dispatch-sync`.
+;; The root `counter-app` view just renders `counter-buttons`; the boot
+;; in `run` scopes the whole tree to `app-frame` and seeds it via
+;; `dispatch-sync`.
 
 (reg-view counter-app []
   [counter-buttons])
@@ -54,14 +65,16 @@
 
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. This example uses `:rf/default` as its app frame id (a
-;; migration may pick `:rf/default`, but the runtime will not infer it):
-;; `init!` installs the adapter (it does NOT create the frame), `reg-frame`
-;; registers the app frame, the boot dispatch runs under `with-frame`, and
-;; the render is wrapped in a `frame-provider` so every in-tree
-;; `dispatch`/`subscribe` resolves to the app frame.
+;; The runtime never synthesises a frame from absence — an app must
+;; establish its frame explicitly. So the boot below does four things in
+;; order: `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in `frame-provider-existing`
+;; so every in-tree `dispatch`/`subscribe` resolves to the app frame.
+;;
+;; `:rf/default` is an ORDINARY frame id with no framework privilege — a
+;; migration may reach for it out of habit, but the runtime won't infer
+;; it; you register it like any other.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -302,7 +302,9 @@
 ;; render in a `frame-provider` so the `reg-view`-injected `dispatch`/`subscribe`
 ;; resolve to it (a no-provider render reads the no-provider sentinel and raises
 ;; :rf.error/no-frame-context). The frame id is `:rf/default` — the same id the
-;; ns-load `reg-app-schema` is scoped to above.
+;; ns-load `with-frame` flow registrations are scoped to above. (Note that
+;; `:rf/default` is an ordinary frame id with no framework privilege; `init!`
+;; never creates it for you, which is why `reg-frame` below is explicit.)
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/infinite_feed/core.cljs
+++ b/examples/reagent/infinite_feed/core.cljs
@@ -2,13 +2,15 @@
   "Worked example for the EP-0021 INFINITE RESOURCE primitive
    ([Spec 016 §Infinite resources and load-more feeds](../../../spec/016-Resources.md#infinite-resources-and-load-more-feeds)).
 
-   A single growing feed — a load-more / infinite-scroll timeline — composed
-   as proper re-frame2: a `reg-resource` with `:infinite true`, owned by the
-   route, read entirely through the PASSIVE infinite subscription family, with
-   accumulation driven by a CAUSAL `:rf.resource/load-more` event. There is no
-   app-db list slice, no `:loading-more?` flag, no cursor threading, and no
-   append reducer — the runtime owns all of it (that is the whole point of the
-   primitive: without it, an app hand-rolls every one of those by hand).
+   The one idea: a load-more / infinite-scroll timeline is ONE growing resource
+   the runtime owns. The view reads the merged list passively and dispatches a
+   single CAUSAL `:rf.resource/load-more`; it never threads a cursor and never
+   writes an append reducer. Composed as proper re-frame2: a `reg-resource` with
+   `:infinite true`, owned by the route, read through the PASSIVE infinite
+   subscription family. There is no app-db list slice, no `:loading-more?` flag,
+   no cursor threading, and no append reducer — the runtime owns all of it (that
+   is the whole point of the primitive: without it, an app hand-rolls every one
+   of those by hand).
 
    It teaches, in one cohesive app, the four facts the primitive surfaces:
 

--- a/examples/reagent/linearlite/core.cljs
+++ b/examples/reagent/linearlite/core.cljs
@@ -41,7 +41,7 @@
      vanishes, the retitled card reverts, the moved card snaps back — with a
      red banner naming the failure. No manual undo, no app-db bookkeeping.
 
-   The board is read PASSIVELY through `[:rf.resource/value …]` (the resource
+   The board is read PASSIVELY through `[:rf.resource/data …]` (the resource
    sub family); each in-flight write is watched through the passive
    `[:rf.mutation/state {:instance …}]` view-model — including the derived
    `:optimistic?` flag (Rider 1), true while a live optimistic apply is showing

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -1,6 +1,12 @@
 (ns login.core
   "Worked end-to-end example: a login feature using the current re-frame2 API.
 
+   The one idea: a feature's whole lifecycle — idle, submitting, error,
+   success, lockout — modelled as a single state MACHINE rather than a
+   scatter of boolean flags. Five states, named transitions, a `:data`
+   slot for the attempt counter; you are always in exactly one state, and
+   every legal move is readable off the transition table below.
+
    Demonstrates:
    - Feature scaffold (CP-6)              — the :auth.login/* registry slice
    - Schema attachment (CP-8)              — Malli schema for the machine snapshot
@@ -255,10 +261,12 @@
 ;; STATE MACHINE  (CP-5)
 ;; ============================================================================
 ;;
-;; The login flow is a finite state machine. Five states, named events. All
-;; non-trivial guards and actions live in the machine's :guards / :actions
-;; maps and are referenced by keyword from the transition table; resolution
-;; is machine-local (no global registry).
+;; The login flow is a finite state machine. Five states, named events. The
+;; spec map below is INERT DATA — a description of legal moves; its live part
+;; is the snapshot ({:state … :data …}) in runtime-db, read like any derived
+;; state. All non-trivial guards and actions live in the machine's :guards /
+;; :actions maps and are referenced by keyword from the transition table;
+;; resolution is machine-local (no global registry).
 
 ;; The login flow's machine spec.
 (def auth-login-machine
@@ -343,11 +351,16 @@
                                 :action :clear-error}}}
 
       :submitting
-      ;; :auth/busy tag — views query (rf/machine-has-tag? :auth.login/flow
-      ;; :auth/busy) to disable inputs and re-label the submit button
-      ;; while the request is in flight.
+      ;; State tag — *ask, don't tell*. Views query (rf/machine-has-tag?
+      ;; :auth.login/flow :auth/busy) to disable inputs and re-label the
+      ;; submit button, rather than asking "are we exactly :submitting?".
+      ;; Tag a sixth busy-ish state :auth/busy later and no view changes.
       {:tags  #{:auth/busy}
        :entry :issue-request
+       ;; The failure branch is an ORDERED list of candidate transitions:
+       ;; the first whose :guard passes fires. Under the retry limit → show
+       ;; the error and let them retry; otherwise (no guard = fallthrough)
+       ;; → lock the account. The whole retry-then-lockout policy is here.
        :on    {:auth.login/success {:target :authed
                                     :action :store-session}
                :auth.login/failure [{:target :error-shown

--- a/examples/reagent/long_running_work/worker.cljs
+++ b/examples/reagent/long_running_work/worker.cljs
@@ -165,7 +165,9 @@
 
     :processing
     ;; Process one item, then immediately re-evaluate the work via
-    ;; the :always cascade.
+    ;; the :always cascade. :always is an EVENTLESS transition — the
+    ;; runtime takes it on entry with no event needed, so the child
+    ;; flows straight to :checking-done after :process-one runs.
     {:tags  #{:work/running :work/cancellable}
      :entry :process-one
      :always [{:target :checking-done}]}

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -1,8 +1,13 @@
 (ns managed-http-counter.core
   "Managed-HTTP counter — Spec 014 §`:rf.http/managed` example app.
 
-  A counter where each button issues a managed HTTP request and the
-  reply lands back in app-db via the default reply-addressing path.
+  Demonstrates managed HTTP: you describe a request as data and the
+  runtime owns its whole lifecycle (encode, send, decode, classify,
+  retry, abort), then dispatches the result back as an ordinary event.
+  You never touch js/fetch. Each button issues a managed HTTP request
+  and the reply lands back in app-db via the default reply-addressing
+  path — \"send\" and \"receive\" are both just events hitting the same
+  pure handler.
 
   Buttons:
     +1                — GET /api/inc.json (static asset; success path)
@@ -73,11 +78,16 @@
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
-;; -- App-db shape ------------------------------------------------------------
+;; ============================================================================
+;; APP-DB SHAPE
+;; ============================================================================
 ;;
 ;; {:counter/count    <int>           ;; current counter value
-;;  :counter/status   <:idle|:loading|:error>
+;;  :counter/status   <:idle|:loading|:error>   ;; the request lifecycle, visible
 ;;  :counter/error    <failure-map-or-nil>}
+;;
+;; :status is the in-flight lifecycle made visible: :loading while the
+;; runtime works a request, :idle (or :error) once the reply lands.
 ;;
 ;; Per spec/Conventions §Feature-modularity prefix convention every
 ;; app-db slot and sub-id carries the feature prefix; events already do.
@@ -88,13 +98,17 @@
      :counter/status :idle
      :counter/error  nil}}))
 
-;; -- +1 (real round-trip via Fetch) ------------------------------------------
+;; ============================================================================
+;; +1  —  real round-trip via Fetch
+;; ============================================================================
 ;;
-;; The +1 button fires :counter/+1, which issues a real GET to
-;; /api/inc.json. The response body — `{"delta": 1}` — is decoded
-;; as JSON; the default reply-addressing path re-dispatches
-;; [:counter/+1 (assoc msg :rf/reply ...)] to the originating handler,
-;; which branches on (:rf/reply msg) to apply the increment.
+;; The headline path, and the one to read first. One pure handler plays
+;; two roles: the :else branch DESCRIBES a request (returns an
+;; :rf.http/managed effect), and the runtime — after sending the GET to
+;; api/inc.json and decoding the `{"delta": 1}` body — re-dispatches
+;; [:counter/+1 {:rf/reply ...}] back to this same handler, which now
+;; takes the :success branch and applies the increment. The asynchrony
+;; lives in the runtime; the handler stays pure and replayable.
 
 (rf/reg-event :counter/+1
   (fn [{:keys [db]} [_ msg]]
@@ -119,7 +133,12 @@
       {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [(rf.http/get "api/inc.json" {:decode :json})]})))
 
-;; -- Fail (real 404 from http-server) ----------------------------------------
+;; ============================================================================
+;; Fail  —  real 404 from the http-server
+;; ============================================================================
+;;
+;; Same shape as +1, exercising the failure side of the uniform reply.
+;; Branch on :kind, then on the :rf.http/* failure category inside it.
 
 (rf/reg-event :counter/fail
   (fn [{:keys [db]} [_ msg]]
@@ -142,14 +161,17 @@
       {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [(rf.http/get "api/does-not-exist")]})))
 
-;; -- Retry-recover (canned-stub at app level) --------------------------------
+;; ============================================================================
+;; Retry-recover  —  canned-stub at app level
+;; ============================================================================
 ;;
-;; This demonstrates the recovery-after-retry path without needing a
-;; flaky HTTP endpoint. The :counter/recover handler issues
-;; :rf.http/managed redirected to :rf.http/managed-canned-success,
-;; which synthesises a {:kind :success :value {:delta 5}} reply. The
-;; same reply shape would land if the live fx ran the retry policy
-;; against a real endpoint that 503'd once and then 200'd.
+;; Demonstrates the recovery-after-retry path without needing a flaky
+;; endpoint. The handler issues :rf.http/managed-canned-success, which
+;; synthesises a {:kind :success :value {:delta 5}} reply — the exact
+;; shape the live fx would land if its retry policy hit a real endpoint
+;; that 503'd once and then 200'd. The stub seam lets you exercise the
+;; CONTRACT without owning the SERVER; the handler reads identically
+;; either way.
 
 (rf/reg-event :counter/retry-recover
   (fn [{:keys [db]} [_ msg]]
@@ -169,31 +191,26 @@
               :decode  :json
               :value   {:delta 5}}]]})))
 
-;; -- Start long / Cancel: REAL abort of a REAL in-flight request -------------
+;; ============================================================================
+;; Start long / Cancel  —  a REAL abort of a REAL in-flight request
+;; ============================================================================
 ;;
-;; The Spec 014 contract is that an in-flight `:rf.http/managed` request
-;; can be cancelled by `:request-id`: `:rf.http/managed-abort` resolves the
-;; handle in the framework in-flight registry and fires its `:abort-fn`,
-;; which produces a `:rf.http/aborted` reply and clears the registry slot.
+;; Spec 014's abort contract: an in-flight `:rf.http/managed` request is
+;; cancelled by `:request-id` — `:rf.http/managed-abort` resolves the
+;; handle in the framework in-flight registry, fires its `:abort-fn`, and
+;; a `:rf.http/aborted` reply lands back at the issuing handler.
 ;;
-;; To demonstrate THAT contract — not a look-alike — "Start long" records
-;; a genuine request-id-keyed handle in the framework registry (via
-;; `http-registry/record-in-flight!`, the same atom the live transport's
-;; `run-attempt!` records into). The handle's `:abort-fn` dispatches the
-;; canonical `:rf.http/aborted` reply via default reply addressing back to
-;; `:counter/start-long`, then clears the slot. "Cancel" fires the LIVE
-;; `:rf.http/managed-abort` fx, which looks up THAT handle by request-id
-;; and fires its `:abort-fn` — so the cancel path exercises the real abort
-;; semantics, in-flight registry cleanup, and `:rf.http/aborted`
-;; classification end-to-end (visible in Xray / traces).
-;;
-;; Why seed a handle rather than fire a real Fetch: this example serves
-;; only static assets, so a real `:rf.http/managed` GET resolves instantly
-;; (leaving nothing observably in-flight to cancel) or has no slow endpoint
-;; to hang on. Seeding a deterministic pending handle is the proven testbed
-;; pattern — see `tools/xray/testbeds/managed_http/core.cljs`. The seeded
-;; handle is a REAL registry entry resolved by the REAL abort fx; only the
-;; transport (which would otherwise need a backend) is stood in for.
+;; The wrinkle that shaped this code: this example serves only static
+;; assets, so a real `:rf.http/managed` GET resolves INSTANTLY — nothing
+;; stays observably in-flight to cancel. So "Start long" seeds a genuine
+;; request-id-keyed handle directly into the registry (the same atom the
+;; live transport's `run-attempt!` records into), giving a deterministically
+;; pending request; "Cancel" then fires the LIVE `:rf.http/managed-abort`
+;; fx against THAT handle. Only the transport is stood in for — the
+;; registry entry, the abort fx, and the `:rf.http/aborted` classification
+;; are all genuine, visible in Xray / traces. This is the proven
+;; seed-in-flight testbed pattern; see
+;; `tools/xray/testbeds/managed_http/core.cljs`.
 
 (def long-request-id :counter/long)
 
@@ -272,13 +289,23 @@
      ;; A no-op when nothing is in flight (the registry lookup misses).
      :fx [[:rf.http/managed-abort long-request-id]]}))
 
-;; -- Subs --------------------------------------------------------------------
+;; ============================================================================
+;; SUBS
+;; ============================================================================
+;;
+;; Three direct reads of the slice — pure derivations the framework caches
+;; and recomputes only when their input moves. The boring kind, on purpose.
 
 (rf/reg-sub :counter/count  (fn [db _] (:counter/count  db)))
 (rf/reg-sub :counter/status (fn [db _] (:counter/status db)))
 (rf/reg-sub :counter/error  (fn [db _] (:counter/error  db)))
 
-;; -- Views -------------------------------------------------------------------
+;; ============================================================================
+;; VIEWS
+;; ============================================================================
+;;
+;; Pure render from subscription values to hiccup; one dispatch per button.
+;; No business logic here — a view reads derived state and dispatches.
 
 (reg-view counter-view []
   (let [count  @(subscribe [:counter/count])
@@ -302,7 +329,9 @@
 (reg-view counter-app []
   [counter-view])
 
-;; -- Mount -------------------------------------------------------------------
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
 ;;
 ;; The React root is held in an atom and materialised lazily inside `run`
 ;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
@@ -315,9 +344,11 @@
 ;; synthesises a frame from absence — an app must establish its frame
 ;; explicitly. `init!` installs the adapter (it does NOT create the frame),
 ;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in a `frame-provider` so every
-;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
-;; canonical mount in examples/reagent/counter/core.cljs.
+;; `with-frame`, and the render is wrapped in a `frame-provider-existing`
+;; so every in-tree `dispatch`/`subscribe` resolves to the app frame.
+;; `:rf/default` is an ordinary frame id with no framework privilege —
+;; just the name this app chose. Matches the canonical mount in
+;; examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -507,11 +507,15 @@
 
 ;; ---- render-priority + :ui/render selector ----
 ;;
-;; The render-priority table is plain data: a vector of {:tag :render}
-;; pairs consulted in order. The :ui/render sub reads the machine's tag
-;; union and returns the first :render whose :tag is present. This is
-;; the **single** place the page's render priorities live; the root
-;; view's `case` just maps the resolved keyword to a view fn.
+;; This is where the nine states collapse to one keyword. The render
+;; decision is a pure function over the snapshot's tag union, and it
+;; lives in exactly one readable place — no if-tower whose precedence
+;; you reverse-engineer later. The render-priority table is plain data:
+;; a vector of {:tag :render} pairs consulted in order. The :ui/render
+;; sub reads the machine's tag union and returns the first :render whose
+;; :tag is present. This is the **single** place the page's render
+;; priorities live; the root view's `case` just maps the resolved
+;; keyword to a view fn.
 ;;
 ;; Priority rationale: :mode wins outright (the archived view replaces
 ;; everything); :form wins next (the success / inline-error

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -3,21 +3,28 @@
 
      [ documents tree ]  [ markdown editor ]  [ live preview ]
 
-   Proves re-frame2 + Reagent can build a substantive UI. The data-flow
-   is the canonical six dominoes:
+   The point of the example: the same event cascade that drives the
+   counter scales unchanged to a substantive, multi-pane UI. State lives
+   in one app-db, events are the only thing that change it, and the views
+   are pure functions of subscriptions. Reading order, top to bottom:
 
-     - selecting a document         dispatches  [:notebook/select id]
-     - editing the body             dispatches  [:notebook/edit-body text]
-     - the body sub                 derives     parsed-html from the markdown
-     - the preview pane             subscribes  to that derivation
+     - selecting a document   dispatches  [:notebook/select id]
+     - editing the body       dispatches  [:notebook/edit-body text]
+     - the hiccup sub         derives     hiccup from the selected markdown
+     - the preview pane       subscribes  to that derivation
 
-   Distinguished from the canonical login + counter examples by being
-   `reg-view`-based at every layer, exercising multi-pane layout, and
-   leaning into the shared 'Editorial Warm' visual identity from
-   examples/_shared/css/style.css — one shared identity across all
-   three substrates. No state machines, no HTTP — design-led examples
-   exist to prove polished visuals + interaction, not to replay the
-   platform features other examples already cover.
+   The markdown preview is the idea worth noticing: rendering markdown is
+   a pure derivation here (string -> hiccup), exposed as a subscription —
+   it sits in the same subscription graph as everything else, not in a
+   DOM escape hatch.
+
+   Distinguished from the counter + login examples by being `reg-view`-
+   based at every layer, exercising multi-pane layout, and leaning into
+   the shared 'Editorial Warm' visual identity from
+   examples/_shared/css/style.css — one shared identity across all three
+   substrates. No state machines, no HTTP — design-led examples exist to
+   prove polished visuals + interaction, not to replay the platform
+   features other examples already cover.
 
    Markdown rendering is intentionally a tiny pure-CLJS parser (headings,
    bold, italic, links, paragraphs, lists) — keeps the bundle small and
@@ -114,6 +121,9 @@
 (rf/reg-sub :notebook/selected-id
   (fn [db _] (:notebook/selected-id db)))
 
+;; First composed sub: `:<-` names this sub's inputs (other subs), so it
+;; recomputes only when the documents or the selected id actually change.
+;; The downstream subs (`-body`, `-hiccup`) chain off this one in turn.
 (rf/reg-sub :notebook/selected
   :<- [:notebook/documents]
   :<- [:notebook/selected-id]

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -259,6 +259,10 @@
                           :on-failure [:comment/delete-rollback prior]})]]})))
 
 (rf/reg-event :comment/delete-success
+  {:doc "Nothing to do on success: the optimistic delete already removed the
+         comment, so confirming it is a no-op. The handler exists only as the
+         `:on-success` reply target — work happens in `:comment/delete-rollback`
+         when the server says no."}
   (fn [{:keys [db]} _] {:db db}))
 
 (rf/reg-event :comment/delete-rollback

--- a/examples/reagent/resources/core.cljs
+++ b/examples/reagent/resources/core.cljs
@@ -1,6 +1,6 @@
 (ns resources.core
   "Worked example for [Spec 016 Resources](../../../spec/016-Resources.md)
-   (the EP-0003 read-resource MVP). A small server-state app — an articles
+   (the read-resource surface). A small server-state app — an articles
    list and an article detail — demonstrating the resource surface
    composed as proper re-frame2: app-db + events + subs, views passive,
    fetches caused.
@@ -37,7 +37,7 @@
    refetch regardless.
 
    Resources is a POST-V1 optional artefact. The read-resource runtime
-   (EP-0003) provides `reg-resource`, the `:rf.resource/*` passive
+   provides `reg-resource`, the `:rf.resource/*` passive
    subs, route `:resources` metadata, and the causal `:rf.resource/ensure` /
    `:rf.resource/refetch` / `:rf.resource/invalidate-tags` /
    `:rf.resource/release-owner` event bodies. This example covers the READ
@@ -312,7 +312,7 @@
 
 ;; A derived read over the list resource's data — projections are ordinary
 ;; subs LAYERED over the passive `[:rf.resource/data …]` sub (Spec 016 §No
-;; :select key), NOT a resource-local hook. The EP-0004 input-fn is a pure
+;; :select key), NOT a resource-local hook. The sub's input-fn is a pure
 ;; `(fn [query-v])` returning a VECTOR OF QUERY VECTORS — never a deref'd
 ;; subscribe (a deref'd-subscribe input-fn raises
 ;; :rf.error/sub-input-fn-bad-return). The compute fn then receives the
@@ -392,8 +392,8 @@
   (let [state        @(subscribe [:rf.resource/state {:resource :articles/list :params {}}])
         preview-slug @(subscribe [:resources.app/preview-slug])
         reader       @(subscribe [:resources.app/reader])
-        ;; A LAYERED PROJECTION over the list resource (EP-0004 input-fn) — the
-        ;; top article's slug, used by the quick-preview button below.
+        ;; A LAYERED PROJECTION over the list resource (an ordinary input-fn
+        ;; sub) — the top article's slug, used by the quick-preview button below.
         top-slug     @(subscribe [:resources.app/first-slug])]
     [:div
      [:h1 "Articles"]
@@ -484,7 +484,7 @@
 ;; ============================================================================
 ;;
 ;; The React root is materialised lazily inside `run` (not at ns-load) per
-;; examples/TESTING.md §Example mount-isolation convention. EP-0002: the app
+;; examples/TESTING.md §Example mount-isolation convention. The app
 ;; establishes its frame explicitly (`reg-frame`), declares `:url-bound?
 ;; true` so it owns the browser URL, and wraps the render in a
 ;; `frame-provider` so every in-tree dispatch/subscribe resolves to it. The
@@ -493,6 +493,9 @@
 
 (defonce react-root (atom nil))
 
+;; `:rf/default` is an ORDINARY frame id with no framework privilege — `init!`
+;; does not create it. This app earns URL ownership by DECLARING `:url-bound?
+;; true` on the frame below, not by naming the frame anything special.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/resources_ssr/core.cljc
+++ b/examples/reagent/resources_ssr/core.cljc
@@ -73,11 +73,15 @@
 ;; RESOURCE
 ;; ============================================================================
 ;;
-;; The page's server-state, declared once. `:scope :rf.scope/global` is the
-;; explicit auditable claim that this article list is the same for every
-;; user (a user-scoped page would carry a scope resolver; SSR hydration
-;; MUST NEVER cross scopes — request-local frames + serialized scopes must
-;; agree before the client treats hydrated data as usable).
+;; The page's server-state, declared once. You describe WHAT the read is and
+;; HOW to fetch it; the runtime owns the cache, dedupe, and staleness.
+;;
+;; `:scope :rf.scope/global` is the explicit, auditable claim that this article
+;; list is the SAME for every user. Scope is part of the read's cache identity,
+;; so one principal's data can never surface in another's cache — and it is
+;; load-bearing for hydration: the serialized scope and the client's scope must
+;; agree before the client treats hydrated data as usable. SSR hydration MUST
+;; NEVER cross scopes (a user-scoped page would carry a scope resolver instead).
 
 (rf/reg-resource :articles/list
   {:doc            "Recent articles (public, SSR-preloaded)."
@@ -93,13 +97,18 @@
 ;; SERVER-SIDE PRELOAD EVENT
 ;; ============================================================================
 ;;
-;; On the server, `:rf/server-init` (dispatched at per-request frame
-;; creation) ensures the page resource under an SSR owner with cause
-;; `:ssr-preload`. `:blocking?`-style preload means the renderer waits for
-;; the resource to settle before rendering (Spec 016 §SSR §Server route
-;; handling). The `[:ssr request-id nav-token]` owner belongs to THIS server
-;; render and is released on request teardown — it never survives as a live
-;; client lease (it reconciles to an orphan on hydration).
+;; On the server, `:rf/server-init` (dispatched at per-request frame creation)
+;; ensures the page resource — fetch it if the cache is cold — so the render
+;; finds it warm. The renderer then waits for it to settle before rendering
+;; (Spec 016 §SSR §Server route handling).
+;;
+;; Two facts ride the ensure. The OWNER `[:ssr request-id nav-token]` is a
+;; lease: it keeps the entry alive for the duration of THIS server render and
+;; nothing longer (released on teardown; reconciled to an orphan on hydration —
+;; a server render's lease has no business surviving as a live client hold).
+;; The CAUSE `:ssr-preload` is pure provenance — WHY the fetch happened,
+;; recorded for the trace, affecting no liveness. Owner = lifetime; cause =
+;; explanation.
 
 (rf/reg-event :rf/server-init
   {:doc       "Per-request server init — preload the page resource."
@@ -118,10 +127,13 @@
 ;; VIEWS — passive reads, server and client alike
 ;; ============================================================================
 ;;
-;; The view reads the resource passively. On the server the resource was
-;; preloaded; on the client the hydrated entry is already present, so the
-;; first render shows data without a fetch. Same view code both sides —
-;; the SSR/CLJS parity Spec 011 promises, now over a resource.
+;; The view reads the resource through a subscription and never fetches — it
+;; doesn't know or care which runtime it is in. `:rf.resource/state` is the
+;; runtime-supplied derivation that turns the cache entry into a view-model
+;; (a status flag + the data). On the server the resource was preloaded; on
+;; the client the hydrated entry is already present, so the first render shows
+;; data without a fetch. Same view code both sides — the SSR/CLJS parity Spec
+;; 011 promises, now over a runtime-managed resource.
 
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
   (let [state @(rf/subscribe [:rf.resource/state

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -1,16 +1,20 @@
 (ns routing.core
   "Worked example for [Construction Prompt CP-7](../../../spec/Construction-Prompts.md)
    and [Spec 012 Routing](../../../spec/012-Routing.md). A small three-page app:
-   home, articles list, article detail. Demonstrates URL ↔ frame state,
-   navigation as event, route as sub, and route-aware root-view dispatch.
+   home, articles list, article detail.
+
+   The one idea: the URL is application state you read through a subscription,
+   and navigation is just an event. A route is a registration, the active route
+   is a sub, and `root-view` is a `case` over `:rf.route/id`. No router object,
+   no route context to thread through the tree.
 
    This example uses the current runtime routing surface directly:
 
    - `reg-route` for the route table
-   - `:rf.route/navigate` for programmatic navigation
-   - `:rf.route/handle-url-change` for popstate / initial load
-   - `:rf.route/id` and `:rf.route/params` for route reads
-   - `:rf/url-requested` for user-initiated anchor clicks"
+   - `:rf.route/id` and `:rf.route/params` for reading the active route as subs
+   - `route-link` for links that drive navigation
+   - `:rf/url-requested` for user-initiated anchor clicks
+   - `install-history-listener!` for popstate + initial-load URL→state sync"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -95,14 +95,16 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; Three subs:
-;;   :temp/active        — which input is the user editing
-;;   :temp/celsius-text  — what to show in the Celsius input
-;;   :temp/fahrenheit-text — what to show in the Fahrenheit input
+;; Two layers. Three small Layer-2 subs read the slice directly
+;; (:temp/active, :temp/canonical-celsius, :temp/typing); two Layer-3
+;; `-text` subs chain off all three via `:<-` to produce what each input
+;; shows. The view only ever reads the two `-text` subs.
 ;;
-;; The `-text` subs return the user's raw typing for the active input and a
-;; derived value for the inactive one. This is the key insight: a single sub
-;; per field that knows whether to passthrough or derive.
+;; The key insight lives in those `-text` subs: for the input the user is
+;; *currently editing* they pass the raw typing straight through; for the
+;; *other* input they show the derived value. One sub per field that knows
+;; whether to passthrough or derive — which is why partial input like "1."
+;; doesn't round-trip into jitter while your finger's still on the key.
 
 (rf/reg-sub :temp/active
   (fn sub-temp-active [db _] (get-in db [:temp :input-source])))

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -148,6 +148,10 @@
             :decode     :json
             :on-success [:articles/loaded]}]]}))
 
+;; The managed-HTTP `:on-success` target. Pure: it takes the decoded reply
+;; value and DESCRIBES the next app-db; the runtime commits it. This same
+;; handler runs identically on the server (per-request frame) and the client
+;; (post-hydration) — there is nothing platform-specific to gate.
 (rf/reg-event :articles/loaded
   (fn handler-articles-loaded [{:keys [db]} [_ {:keys [value]}]]
     {:db (assoc db :articles value)}))

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -101,6 +101,10 @@
     [:h1 "Dashboard"]
     [:p "Streamed SSR demo — shell renders first, cards stream in."]]
    [:section.cards
+    ;; `:rf/suspense-boundary` marks a streamable subtree: the `:fallback`
+    ;; ships inline in the shell now; the real child subtree streams in as
+    ;; its own chunk when it resolves. The `:id` pairs the incoming chunk
+    ;; with its placeholder on the client — you pick it, it must be unique.
     [:rf/suspense-boundary
      {:id :card.revenue :fallback [:dashboard/card-skeleton :revenue]}
      [:dashboard/card :revenue]]
@@ -167,6 +171,9 @@
                       :failed? failed?}))
                  continuations)
            render-hash (rf/with-frame fid (ssr/render-tree-hash hiccup))
+           ;; The final payload is the canonical full app-db — the correctness
+           ;; lock that the per-card deltas above were only a speed prop for. If
+           ;; a speculative delta ever disagreed with this, this wins.
            ;; Hydration-payload policy is explicit + fail-closed, carried
            ;; by the single `:payload` opt. This example's app-db is
            ;; structurally safe to expose end-to-end (every key the

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -1,23 +1,28 @@
 (ns state-machine-walkthrough.core
-  "Runnable companion to docs/guide/concepts/machines.md.
+  "Runnable companion to docs/machines/concepts.md — the machines chapter as code.
 
-  This is the login-flow chapter as code. Every prose snippet in the
-  machines chapter appears here in the order the chapter introduces it; each section
-  ends with a smoke-test fn that drives the machine through the
-  scenario the chapter describes.
+  The chapter's login flow, laid out so you can read the transition table
+  here in the order the chapter introduces it. The one idea this file makes
+  tangible: a machine is a PURE transition table, so a transition is a pure
+  function call — table in, snapshot in, event in; result out. That is what
+  lets the chapter's four scenarios run headless (see the §SUBSCRIPTIONS note
+  at the bottom for where those tests live).
 
   Why .cljc: the chapter promises 'runs in microseconds on the JVM, no
-  browser, no network.' The same code runs under shadow-cljs node-test
-  for the CLJS surface. The HTTP side is exercised via the framework-
-  shipped `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure`
-  stubs (Spec 014 §Testing) so no real network traffic happens.
+  browser, no network.' The same source compiles under shadow-cljs for the
+  CLJS surface; the :clj branch is what the JVM test (require ...)s. The HTTP
+  side never hits the wire — it is redirected via :fx-overrides to the
+  framework-shipped `:rf.http/managed-canned-success` /
+  `:rf.http/managed-canned-failure` stubs (Spec 014 §Testing).
 
-  Read alongside docs/guide/concepts/machines.md."
+  Read alongside docs/machines/concepts.md."
   (:require [re-frame.core :as rf]
             ;; The Spec 005 state-machine ns lives in the
             ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine and
-            ;; rf/machine-transition resolve.
+            ;; registers its late-bind hooks so `rf/reg-machine` and the
+            ;; framework `:rf/machine` / `:rf/machine-has-tag?` subs resolve.
+            ;; (The pure `machine-transition` fn the headless tests call is
+            ;; owned by re-frame.machines, not the rf/ facade — by design.)
             [re-frame.machines]
             ;; Managed-HTTP ships in day8/re-frame2-http.
             ;; The login flow's `:issue-request` action dispatches
@@ -39,7 +44,7 @@
             [re-frame.registrar :as registrar]))
 
 ;; ============================================================================
-;; THE TRANSITION TABLE — chapter §The same flow as a machine
+;; THE TRANSITION TABLE — chapter §The same flow as a transition table
 ;; ============================================================================
 ;;
 ;; Pure data. `:guards` and `:actions` live with the spec — there is no
@@ -58,10 +63,10 @@
 ;; (this walkthrough runs JVM-headless with `remove-ns` between runs; login
 ;; builds standalone), so the shared name is parallel, not a collision.
 ;; The two examples also differ in what they teach AROUND the machine: `login`
-;; wires it into a live Reagent view; this walkthrough drives it HEADLESSLY
-;; (the sibling core-test ns) to show the pure machine-transition + drain
-;; testing story from docs/guide/concepts/machines.md. Read `login` first for the
-;; UI wiring; read this for the testing progression.
+;; wires it into a live Reagent feature; this walkthrough drives it HEADLESSLY
+;; to show the pure machine-transition + drain testing story from
+;; docs/machines/concepts.md. Read `login` first for the UI wiring; read this
+;; for the testing progression.
 
 (def login-flow
   {:initial :idle
@@ -118,7 +123,7 @@
     :submitting
     ;; :auth/busy tag — views query (rf/machine-has-tag? :auth.login/flow
     ;; :auth/busy) to disable inputs and re-label the submit button
-    ;; while the request is in flight (ch.12 §State tags).
+    ;; while the request is in flight (chapter §State tags).
     {:tags  #{:auth/busy}
      :entry :issue-request
      :on    {:auth.login/success {:target :authed
@@ -147,11 +152,11 @@
      :meta {:terminal? true}}}})
 
 ;; ============================================================================
-;; FX — chapter §Wiring a machine into the rest of re-frame
+;; FX — chapter §Composing with async effects
 ;; ============================================================================
 ;;
 ;; The `:auth.session/store` fx is a stub for the example: it shows the
-;; shape, not real localStorage. The smoke tests below exercise the
+;; shape, not real localStorage. The headless tests exercise the
 ;; managed-HTTP path via the framework-shipped canned-success /
 ;; canned-failure stubs (Spec 014 §Testing), routed in via the
 ;; `:fx-overrides` seam at frame creation.
@@ -164,8 +169,8 @@
 ;; and `:rf.http/managed-canned-failure` fxs that synthesise the canonical reply
 ;; shape. The wrappers below pin the example's specific payloads — both the
 ;; browser demo (views.cljs installs the canned-failure override on the
-;; default frame) and the headless tests (core-test.cljc reads them via
-;; `:fx-overrides`) consume them.
+;; default frame) and the headless tests (the framework JVM deftest reads them
+;; via `:fx-overrides`) consume them, sharing one registration point.
 
 (rf/reg-fx :auth.login/canned-success
   {:doc "Example stub: every `:rf.http/managed` call resolves :success with a
@@ -187,29 +192,30 @@
                              :tags {:message "bad creds" :status 401})))))
 
 ;; ============================================================================
-;; REGISTRATION — chapter §Wiring a machine into the rest of re-frame
+;; REGISTRATION — chapter §Registering and running it
 ;; ============================================================================
 ;;
-;; Two equivalent forms; we use the convenience `reg-machine`. The
-;; longer form `(reg-event machine-id (make-machine-handler m))`
-;; is what reg-machine wraps, and is the form to use when you need
-;; registration metadata (`:doc`, `:interceptors`, ...).
+;; One line. A machine IS an event handler: `reg-machine` is sugar over
+;; `reg-event` whose body interprets the table. The longer form
+;; `(reg-event machine-id (make-machine-handler m))` is what reg-machine
+;; wraps, and is the form to reach for when you need registration metadata
+;; (`:doc`, `:interceptors`, ...).
 
 (rf/reg-machine :auth.login/flow login-flow)
 
 ;; ============================================================================
-;; SUBSCRIPTIONS — chapter §Reading a machine: sub-machine
+;; SUBSCRIPTIONS — chapter §Registering and running it
 ;; ============================================================================
 
 ;; The machine snapshot lives in runtime-db at
 ;; [:rf.runtime/machines :snapshots :auth.login/flow] (per Spec 005).
-;; The framework ships `:rf/machine` as the canonical layer-3 entry
-;; point onto that path (see re-frame.machines §framework-shipped subs);
-;; the named subs below chain off it to project out the convenient
-;; pieces. The "in :submitting?" / "in :authed?" / "in :locked-out?"
-;; predicates live as the `rf/machine-has-tag?` queries in views.cljs
-;; (ch.12 §State tags) — discriminating on the machine's runtime-projected
-;; `:tags` set decouples view code from individual state-keyword identity.
+;; The framework ships `:rf/machine` as the canonical entry point onto
+;; that path; the two named subs below chain off it to project out the
+;; convenient pieces (current state, last error). The "is it busy / locked?"
+;; questions the view actually asks are NOT here — they live as the
+;; `rf/machine-has-tag?` queries in views.cljs (chapter §State tags),
+;; because discriminating on the snapshot's runtime-projected `:tags` set
+;; decouples view code from individual state-keyword identity.
 
 (rf/reg-sub :auth.login/state
   :<- [:rf/machine :auth.login/flow]
@@ -219,8 +225,10 @@
   :<- [:rf/machine :auth.login/flow]
   (fn [machine _] (get-in machine [:data :error])))
 
-;; The chapter's headless tests (pure machine-transition + full-drain
-;; scenarios) live in re-frame.examples-test (implementation/core/test/),
-;; folded inline as the `state-machine-walkthrough-runs-headless` deftest,
-;; keeping this example source pure demonstrative code (the
-;; example tree is test-free). They run on the JVM.
+;; The payoff — see the chapter's §Testing. Because the table is pure data
+;; and `machines/machine-transition` is a pure fn over (table, snapshot,
+;; event), the four scenarios (pure happy-path, pure lockout, drain
+;; happy-path, drain retry-then-lockout) need no frame and no browser. They
+;; live in re-frame.examples-test (implementation/core/test/) as the
+;; `state-machine-walkthrough-runs-headless` deftest — folded there so this
+;; example source stays test-free. JVM, microseconds.

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -2,7 +2,7 @@
   "Browser entry-point for the state-machines walkthrough.
 
   The pure machine, fxs and subs live in `core.cljc` alongside
-  docs/guide/concepts/machines.md; the headless tests live in the framework
+  docs/machines/concepts.md; the headless tests live in the framework
   test tree (the `state-machine-walkthrough-runs-headless` deftest in
   `implementation/core/test/re_frame/examples_test.clj`). This namespace
   is the CLJS-only browser layer: views + Reagent mount + a `run` fn that
@@ -30,8 +30,8 @@
                   :auth.login/flow → :auth.login/submit on submit.
 
                   View-side discriminators read the machine's runtime-projected
-                  `:tags` set (ch.12 §State tags) via `rf/machine-has-tag?`, not boolean
-                  state-predicate subs."}
+                  `:tags` set (chapter §State tags) via `rf/machine-has-tag?`, not boolean
+                  state-predicate subs — so adding a new busy-ish state changes no view."}
           login-form []
   (let [state (atom {:email "" :password ""})]
     (fn []

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -1,4 +1,12 @@
 (ns todomvc.core
+  "Entry point: install the adapter, register and seed the frame, mount the view.
+
+  Demonstrates the boot wiring the other files lean on — `init!` (installs the
+  Reagent adapter; it does NOT create a frame), `reg-frame` with `:url-bound?`
+  (this frame owns the address bar), the recordable boot read that seeds app-db
+  via `:rf.cofx`, and the hash → route adapter that turns a `#/active` URL change
+  into a `:rf.route/handle-url-change` event. \"The URL is an input; navigation
+  is an event.\""
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]

--- a/examples/reagent/todomvc/db.cljs
+++ b/examples/reagent/todomvc/db.cljs
@@ -1,4 +1,11 @@
 (ns todomvc.db
+  "The shape of app-db, and the boot read that fills it.
+
+  Demonstrates: the single source of truth (`default-db` — todos and *nothing
+  else*; the active filter is derived from the route, never stored), and a
+  recordable coeffect (`reg-cofx :todo.storage/todos`) that carries saved todos
+  *in* at boot so the durable write stays replayable instead of reaching for
+  localStorage inside a handler."
   (:require [re-frame.core :as rf]))
 
 ;; The default db carries no `:showing` slot — Spec 012's :route slice owns

--- a/examples/reagent/todomvc/events.cljs
+++ b/examples/reagent/todomvc/events.cljs
@@ -1,4 +1,12 @@
 (ns todomvc.events
+  "The only writers of app-db, plus the routes and the persistence effect.
+
+  Demonstrates: `reg-event` (one pure handler per state change — add, toggle,
+  save, delete, clear-completed, toggle-all; each `(coeffects, event-vector) →
+  effect map`), `reg-fx` (the `:todo.storage/save` effect handler that performs
+  the localStorage write the handlers only *describe* as data), and `reg-route`
+  (the URL as an input — `/`, `/active`, `/completed`, plus the not-found
+  fallback)."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             ;; Routing ships in day8/re-frame2-routing.

--- a/examples/reagent/todomvc/subs.cljs
+++ b/examples/reagent/todomvc/subs.cljs
@@ -1,4 +1,12 @@
 (ns todomvc.subs
+  "The derivation graph the views read.
+
+  Demonstrates: `reg-sub` composed in layers. Some subs read app-db directly
+  (`:todo/sorted-todos`); others combine subs into a derivation graph
+  (`:todo/visible-todos` filters the list against `:todo/showing`,
+  `:todo/footer-counts` folds the tallies). `:todo/showing` derives the active
+  filter from the route id — the filter that app-db deliberately never stores.
+  Pure functions all the way down, recomputed only when an input actually moves."
   (:require [re-frame.core :as rf]))
 
 ;; :todo/showing derives from the active Spec 012 route id. :rf.route/not-found

--- a/examples/reagent/todomvc/views.cljs
+++ b/examples/reagent/todomvc/views.cljs
@@ -1,4 +1,11 @@
 (ns todomvc.views
+  "The TodoMVC markup, as hiccup.
+
+  Demonstrates: `reg-view` for the root (inside its body `subscribe` and
+  `dispatch` are already in scope), plain helper fns for the sub-views (which
+  take `dispatch`/`subscribe` as explicit args — the honest shape for a plain
+  fn), and hiccup as data-as-markup. A view reads derived state and dispatches
+  events on interaction; no business logic lives here."
   (:require [clojure.string :as str]
             [reagent.core :as reagent]
             [re-frame.core :as rf]
@@ -45,14 +52,19 @@
               (save)))})])))
 
 (defn todo-item [dispatch]
-  ;; editing? is local component state by design — matches the canonical TodoMVC; not in app-db so it isn't persisted/inspected (TodoMVC tradeoff).
+  ;; `editing?` is local component state by design — it isn't in app-db, so it
+  ;; isn't persisted or inspected. That's the canonical TodoMVC tradeoff: an
+  ;; ephemeral, per-row UI flag that no other view needs to read.
   (let [editing? (reagent/atom false)]
     (fn [_dispatch {:keys [id title completed]}]
       [:li {:class (str/join " " (cond-> []
                                  completed (conj "completed")
                                  @editing? (conj "editing")))}
        [:div.view
-        ;; React's controlled-checkbox pattern: :on-click mutates app-db, :readOnly silences React's onChange warning, :checked reads from app-db.
+        ;; Controlled checkbox, re-frame2 style: `:checked` reads the fact from
+        ;; app-db, `:on-click` dispatches the event that changes it, and
+        ;; `:readOnly` silences React's onChange warning (the state round-trips
+        ;; through app-db and the cascade, not through React's own state).
         [:input.toggle
          {:type "checkbox"
           :checked completed

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -22,10 +22,11 @@
    independent regions, see `examples/reagent/nine_states/` — Pattern-
    NineStates' canonical worked example.)
 
-   `:fsm/tags` carry the queryable connection-state predicates — the view
-   asks `:websocket/connected?` and `:websocket/reconnecting?` via
-   `rf/machine-has-tag?` without needing to know which leaf carries the
-   `:connected` intent.
+   State tags carry the queryable connection-state predicates — the view
+   asks `:ws/connected?` / `:ws/reconnecting?` (the per-tag subs below,
+   each a `contains?` over the snapshot's `:tags` union — the same
+   containment the framework's `:rf/machine-has-tag?` sub answers)
+   without needing to know which leaf carries the `:connected` intent.
 
    Pattern-StaleDetection composes in twice:
 
@@ -391,6 +392,11 @@
   :<- [:ws/snapshot]
   (fn [snap _] (:state snap)))
 
+;; The per-tag predicate subs: each is a `contains?` over the snapshot's
+;; `:tags` union, so a view asks "is it connected?" rather than matching
+;; the hierarchical `:state` vector. (The framework's `:rf/machine-has-tag?`
+;; sub answers the same containment question; these are the app-named
+;; shorthand the views read.)
 (rf/reg-sub :ws/connecting?
   :<- [:ws/snapshot]
   (fn [snap _] (contains? (:tags snap) :websocket/connecting)))

--- a/examples/reagent/websocket/views.cljs
+++ b/examples/reagent/websocket/views.cljs
@@ -9,16 +9,20 @@
 
    Two things to notice as you read the views:
 
-   1. The status indicator reads `:websocket/connecting`,
-      `:websocket/authenticating`, `:websocket/connected`,
-      `:websocket/reconnecting`, `:websocket/failed` via
-      `rf/machine-has-tag?` — every pill branch is tag-driven. The view
-      doesn't need to know *which* leaf carries the `:connected` intent,
-      only that the tag is present. This is what `:fsm/tags` buys.
+   1. The status indicator branches on the connection machine's state
+      tags — `:websocket/connecting`, `:websocket/authenticating`,
+      `:websocket/connected`, `:websocket/reconnecting`,
+      `:websocket/failed`. It reads them through this example's own
+      per-tag subs (`:ws/connected?` and friends in `connection.cljs`,
+      each a `contains?` over the snapshot's `:tags` union — the same
+      containment question the framework's `:rf/machine-has-tag?` sub
+      answers). Every pill branch is tag-driven, so the view never needs
+      to know *which* leaf carries the `:connected` intent — only that
+      the tag is present. This is what state tags buy: ask, don't tell.
 
-   2. The send form's `disabled` attribute is driven by an explicit
-      :ws/connected? sub (rather than a `:cond` over the snapshot's
-      raw `:state` vector) — same idea, different ergonomics."
+   2. The send form's `disabled` attribute is driven by the explicit
+      `:ws/connected?` sub rather than a `cond` over the snapshot's raw
+      hierarchical `:state` vector — same idea, friendlier ergonomics."
   (:require [re-frame.core :as rf]
             [re-frame.views]
             [websocket.messages]
@@ -29,11 +33,11 @@
 ;; STATUS — the machine's connection state, rendered
 ;; ============================================================================
 
-(reg-view ^{:doc "Reads the connection machine's tag union via
-                  `:rf/machine-has-tag?` and renders a single status
-                  pill. The view's render priority — failed > reconnecting
-                  > connected > connecting > disconnected — collapses
-                  the multi-tag union to one visible word.
+(reg-view ^{:doc "Reads the connection machine's state-tag union (through
+                  this example's per-tag subs) and renders a single
+                  status pill. The view's render priority — failed >
+                  reconnecting > connected > connecting > disconnected —
+                  collapses the multi-tag union to one visible word.
 
                   A sibling `:ws-reconnect-attempts` counter surfaces
                   the machine's `:retries` slot directly — this lets a

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -1,27 +1,38 @@
 (ns counter-uix.core
   "UIx variant of the counter example.
 
-   Exercises the same dataflow as examples/reagent/counter but renders it
-   through the UIx adapter — the React state model is hooks all the way
-   down. Demonstrates:
+   Same dataflow as examples/reagent/counter, rendered through the UIx
+   adapter — React hooks all the way down rather than Reagent's reactive
+   atoms. The point of the example is the substrate boundary: everything
+   above the view layer is byte-for-byte the Reagent counter's, and the
+   only thing that moves is how a component reads state and gets hold of
+   `dispatch`. Demonstrates:
 
+     - `reg-event` / `reg-sub` (substrate-agnostic — identical to Reagent)
      - `rf/init!` with the UIx adapter
-     - `reg-event` / `reg-sub` (substrate-agnostic)
-     - `use-subscribe` hook (UIx idiomatic)
-     - `(:dispatch (rf/frame-handle))` for click handlers (components
-       call dispatch / use-subscribe directly, no auto-injection)
-     - The shared frame-context — the same React Context
-       object the Reagent adapter consumes
+     - `use-subscribe` hook (the UIx-idiomatic subscription read)
+     - `(:dispatch (rf/frame-handle))` for click handlers — a UIx
+       component reaches for dispatch / use-subscribe explicitly; there
+       is no auto-injection
+     - frame resolution via React context — `use-subscribe` and the
+       `frame-handle` capture read the surrounding frame-provider
 
-   Different folder from examples/reagent/counter so the canonical Reagent
-   counter is undisturbed; bundle isolation is verified by the
+   A separate folder from examples/reagent/counter so the canonical
+   Reagent counter is undisturbed; bundle isolation is verified by the
    per-example shadow-cljs builds and the production-elision grep."
   (:require [uix.core :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core    :as rf]
             [re-frame.adapter.uix :as uix-adapter]))
 
-;; -- Events / subs (handler registry is app-global) --------------------------
+;; -- Events / subs (the registrar is process-global) -------------------------
+;;
+;; Each handler is a pure (coeffects, event-vector) -> effect map fn: it
+;; returns `{:db …}` ("replace app-db with this") and the runtime commits
+;; it atomically at the end of the cascade. This whole block is
+;; byte-for-byte identical to the Reagent and Helix counters — same ids,
+;; same bodies. That sameness IS the cross-substrate parity: the artefact
+;; layer does not know which reactive substrate renders it.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -35,14 +46,16 @@
 (rf/reg-sub :counter/value
   (fn [db _query] (:counter/value db)))
 
-;; -- Views -------------------------------------------------------------------
+;; -- Views (the only substrate-specific code in this file) -------------------
 ;;
-;; `reg-view` (the macro) stays Reagent-only;
-;; UIx users write `defui` directly. There is no auto
-;; injection — the component calls `use-subscribe` and takes
-;; `dispatch` off a `(rf/frame-handle)` explicitly. The handle
-;; captures the render-time frame, so the closed-over `dispatch`
-;; targets the right frame even from an async callback.
+;; Everything above is shared with the Reagent and Helix counters; the
+;; substrate boundary is here. `reg-view` (the macro that auto-injects
+;; `dispatch`/`subscribe`) stays Reagent-only — UIx is plain React, so a
+;; component is a `defui` and reaches for what it needs explicitly:
+;; `use-subscribe` reads a sub (a real hook), and `dispatch` comes off a
+;; `(rf/frame-handle)`. The handle is the frame captured as a *value*, so
+;; the closed-over `dispatch` keeps targeting this frame even when a click
+;; fires later — grab it at render time, while the frame is in scope.
 
 (defui counter-buttons []
   (let [count    (uix-adapter/use-subscribe [:counter/value])
@@ -67,11 +80,17 @@
 ;; The runtime never synthesises a frame from absence — an app must establish
 ;; its frame explicitly. `init!` installs the adapter (it does NOT create the
 ;; frame), `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in the UIx `frame-provider` so the
-;; `use-subscribe` hook and the render-time `(rf/frame-handle)` capture resolve
-;; to the app frame via React context. There is no `:rf/default` floor: a UIx
-;; tree rendered with NO provider observes the no-provider sentinel and any
-;; `use-subscribe` / `frame-handle` raises `:rf.error/no-frame-context`.
+;; `with-frame`, and the render is wrapped in `frame-provider-existing` — the
+;; scope-only provider that threads this already-registered frame's id down
+;; the React tree (the owning `frame-provider` would *create* a frame; we
+;; already own ours). That context is what lets the `use-subscribe` hook and
+;; the render-time `(rf/frame-handle)` capture resolve to the app frame. There
+;; is no `:rf/default` floor: a UIx tree rendered with NO provider observes the
+;; no-provider sentinel and any `use-subscribe` / `frame-handle` raises
+;; `:rf.error/no-frame-context`.
+;;
+;; `:rf/default` is an ORDINARY frame id with no framework privilege — a
+;; migration may reach for it out of habit, but the runtime won't infer it.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -3,11 +3,19 @@
    + sparklines + filter chips. Proves re-frame2 + UIx can build a
    substantive UI.
 
+   The one idea: two independent controls each set a single value in
+   app-db, and one `reg-sub` reads both and computes the visible card
+   set as a pure function of them. The whole UI renders that one
+   projection — there is exactly one place where 'what's on screen' is
+   decided.
+
    Demonstrates:
 
-     - UIx components (`defui`) consuming subs via `use-subscribe`
-     - signal-graph subscriptions composing tag + range inputs into one
-       re-derived projection (`:dashboard/visible-metrics`)
+     - `reg-sub` composing inputs: `:dashboard/visible-metrics` derives
+       from three input subscriptions, re-running when either control moves
+     - the derivation graph — base subs read app-db, derived subs read
+       other subs (the `:<-` syntax), views at the leaves
+     - UIx views (`defui`) reading subscriptions via `use-subscribe`
      - inline SVG sparklines computed in pure CLJS — no chart library
      - two re-deriving controls: filter chips (which cards show) and a
        time-range picker (how many trailing points each sparkline draws,
@@ -70,6 +78,13 @@
 ;; EVENTS
 ;; ============================================================================
 
+;; Each handler is pure: (coeffects, event-vector) -> effect map. They move
+;; ONE value in app-db and stop — note that none of them touch a card, a
+;; sparkline, or the grid. Turning "this tag is now off" into "these cards
+;; disappear" is the subscription's job, downstream.
+
+;; Seed the whole dashboard in one write: the metrics plus the two control
+;; values (`:active-tags` a set — chips are multi-select; `:range` one id).
 (rf/reg-event :dashboard/initialise
   (fn [{:keys [db]} _event]
     {:db {:dashboard/metrics      initial-metrics
@@ -98,15 +113,20 @@
 (rf/reg-sub :dashboard/range
   (fn [db _] (:dashboard/range db)))
 
+;; First derived sub: `:<-` declares this sub's input as ANOTHER sub, not
+;; app-db. Here we turn the stored range id into its full record (label,
+;; point count). Base subs above read app-db; these read other subs.
 (rf/reg-sub :dashboard/selected-range
   :<- [:dashboard/range]
   (fn [range-id _]
     (some #(when (= range-id (:id %)) %) ranges)))
 
+;; The heart of the example. One projection of two independent inputs: the
+;; active tag chips decide membership (`filter`); the selected range decides
+;; each sparkline's length (`take-last points`). Changing either input
+;; re-runs this — and ONLY this, plus anything downstream that moved — so the
+;; UI reads "what's on screen" from a single pure function.
 (rf/reg-sub :dashboard/visible-metrics
-  ;; Two re-deriving inputs feed the visible card set: the active tag chips
-  ;; (which metrics show) and the selected range (how many trailing points
-  ;; each sparkline draws). Changing either re-runs this projection.
   :<- [:dashboard/metrics]
   :<- [:dashboard/active-tags]
   :<- [:dashboard/selected-range]

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -1,11 +1,13 @@
 (ns login-uix.core
-  "UIx variant of the login example.
+  "UIx variant of the login example — the same feature, a different substrate.
 
-   Same dataflow, schemas, machine, and HTTP stub as examples/reagent/login,
-   but views are written as UIx `defui` components and consume subs
-   via the `use-subscribe` hook. Demonstrates that the Spec 005 state
-   machine, Spec 010 schemas, and Spec 014 managed-HTTP surfaces are
-   substrate-agnostic — only the view layer differs across substrates.
+   Everything below the views is byte-for-byte the same as
+   examples/reagent/login: the Spec 005 state machine, the Spec 010 schemas,
+   and the Spec 014 managed-HTTP effect. Only the view layer changes idiom —
+   here views are UIx `defui` components that read subscriptions via the
+   `use-subscribe` hook, where the Reagent twin used `reg-view`. The point of
+   the file is to show exactly how narrow the substrate boundary is: the
+   machine, schemas, and effects are substrate-agnostic.
 
    Cross-substrate parity is exercised end-to-end: machine states carry
    Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`, `:auth/locked`)
@@ -302,6 +304,13 @@
 ;; ============================================================================
 ;; VIEWS  (UIx — defui + use-subscribe)
 ;; ============================================================================
+;;
+;; This is the whole substrate seam. The Reagent twin registers these with
+;; `reg-view` and gets injected `dispatch`/`subscribe`; UIx has no such
+;; registry, so a view is a plain `defui`, reads a subscription through the
+;; `use-subscribe` hook, and takes `dispatch` off a `(rf/frame-handle)` by
+;; hand. The subscription vectors and event vectors are unchanged — only the
+;; way a React component plugs into them differs.
 
 (defui login-form []
   (let [busy?    (uix-adapter/use-subscribe [:rf/machine-has-tag?


### PR DESCRIPTION
Companion to **#4965** (which owns the per-example README rewrites). This PR is the **code half** of "give each example the treatment": comments and docstrings across **33 example source files** elevated to the same shared senior-developer teaching voice, terminology aligned to the `docs/` glossaries.

**Surgical:** comment/docstring TEXT only — no code forms, names, arglists, or logic changed (behaviour-preserving; the `examples-compile` gate validates this). +1 CSS comment in `_shared/css/style.css`.

READMEs intentionally excluded — they belong to #4965. Rebased onto current main so the two are conflict-free.