### PR TITLE
Fold API into Core, consolidate v1 migration under Core, drop EP from Home

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,20 +157,6 @@ nav:
   - Home:
     - index.md
     - "ClojureScript for non-Clojurians": cljs/index.md
-    - Migration:
-      - "From re-frame v1": migration/from-re-frame-v1/README.md
-      - "async-flow-fx → reg-machine": migration/from-re-frame-v1/async-flow-fx-to-reg-machine.md
-      - "http-fx → managed HTTP": migration/from-re-frame-v1/http-fx-to-managed-http.md
-      - "re-frame-query → resources": migration/from-re-frame-v1/re-frame-query-to-resources.md
-      - "Observability logging sweep": migration/from-re-frame-v1/observability-logging-sweep.md
-      - "clj-new → deps-new template": migration/from-clj-new-template/README.md
-    - EP:
-      - EP/README.md
-      - "EP-0001 Frame App/Runtime Partitions": EP/EP-0001-frame-partitions.md
-      - "EP-0002 Explicit Frame Target Resolution": EP/EP-0002-frame-target-resolution.md
-      - "EP-0003 Resource Queries": EP/EP-0003-resource-queries.md
-      - "EP-0004 Parametric Subscription Inputs": EP/EP-0004-subscription-inputs.md
-      - "EP-0005 Machine :data Schema": EP/EP-0005-machine-data-schema.md
 
   - Core:
     # navigation.indexes: the section label IS the Guide overview page (no
@@ -215,9 +201,30 @@ nav:
       - "Resources vs TanStack/RTK/SWR": guide/explanation/resources-vs-query-libraries.md
       - "One graph: derivations and algebra views": guide/derivations-and-algebra-views.md
       - "Where should this value live?": guide/where-state-lives.md
-    - "From re-frame v1": guide/25-from-re-frame-v1.md
+    - "From re-frame v1":
+      - guide/25-from-re-frame-v1.md
+      - "Migration rules": migration/from-re-frame-v1/README.md
+      - "async-flow-fx → reg-machine": migration/from-re-frame-v1/async-flow-fx-to-reg-machine.md
+      - "http-fx → managed HTTP": migration/from-re-frame-v1/http-fx-to-managed-http.md
+      - "re-frame-query → resources": migration/from-re-frame-v1/re-frame-query-to-resources.md
+      - "Observability logging sweep": migration/from-re-frame-v1/observability-logging-sweep.md
+      - "clj-new → deps-new template": migration/from-clj-new-template/README.md
     - "Reference index": guide/reference.md
     - "Glossary": guide/glossary.md
+    - "API":
+      - api/README.md
+      - "01 — Core": api/01-core.md
+      - "02 — Views": api/02-views.md
+      - "03 — Effects": api/03-effects.md
+      - "05 — Flows": api/05-flows.md
+      - "08 — Schemas": api/08-schemas.md
+      - "10 — Testing": api/10-testing.md
+      - "11 — Instrumentation": api/11-instrumentation.md
+      - "12 — Registrar": api/12-registrar.md
+      - "13 — Lifecycle": api/13-lifecycle.md
+      - "14 — Adapters": api/14-adapters.md
+      - "15 — Removed": api/15-removed.md
+      - "Normative reference": spec/API.md
 
   - Machines:
     - machines/index.md
@@ -316,22 +323,6 @@ nav:
     - re-frame2-xray: skills/re-frame2-xray.md
     - re-frame2-pair: skills/re-frame2-pair.md
     - re-frame2-pair-retro: skills/re-frame2-pair-retro.md
-
-  - API:
-    # Section label IS the API overview page (navigation.indexes, rf2-qgpkm).
-    - api/README.md
-    - "01 — Core": api/01-core.md
-    - "02 — Views": api/02-views.md
-    - "03 — Effects": api/03-effects.md
-    - "05 — Flows": api/05-flows.md
-    - "08 — Schemas": api/08-schemas.md
-    - "10 — Testing": api/10-testing.md
-    - "11 — Instrumentation": api/11-instrumentation.md
-    - "12 — Registrar": api/12-registrar.md
-    - "13 — Lifecycle": api/13-lifecycle.md
-    - "14 — Adapters": api/14-adapters.md
-    - "15 — Removed": api/15-removed.md
-    - "Normative reference": spec/API.md
 
 markdown_extensions:
   - meta


### PR DESCRIPTION
Three nav refinements to the docs reorganization — all **nav-only**, no files moved:

1. **API → Core.** The top-level API tab was really the *core* API reference (the per-capability API pages already live in their own tabs), so it's now an "API" section under Core.

2. **v1 migration consolidated under Core.** Core's "From re-frame v1" was a single narrative chapter; the Home/Migration corpus is the detailed M-rule reference plus per-tool guides. They're complementary registers, not duplicates — so they're consolidated under Core's "From re-frame v1": the chapter as the section overview, the rule reference and migration guides beneath it. The Home/Migration section is removed.

3. **EP removed from Home.** The EP docs were already mostly orphaned (25 of 31 not nav'd); the Home/EP section is removed. The pages still build, so the 12 cross-links from api/resources/story keep resolving.

Verified locally: `mkdocs build --strict` clean, and the doc-slug check run the CI way (with `docs/spec/` unstaged) clean.