### PR TITLE
todomvc: cofx is a registered supplier; boot via :initial-events

### DIFF
--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -3,8 +3,8 @@
 
   Demonstrates the boot wiring the other files lean on — `init!` (installs the
   Reagent adapter; it does NOT create a frame), `reg-frame` with `:url-bound?`
-  (this frame owns the address bar), the recordable boot read that seeds app-db
-  via `:rf.cofx`, and the hash → route adapter that turns a `#/active` URL change
+  (this frame owns the address bar) and `:initial-events` (the frame seeds itself
+  at creation), and the hash → route adapter that turns a `#/active` URL change
   into a `:rf.route/handle-url-change` event. \"The URL is an input; navigation
   is an event.\""
   (:require [clojure.string :as str]
@@ -12,16 +12,9 @@
             [re-frame.core :as rf]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [todomvc.db :as db]
             [todomvc.events]
             [todomvc.subs]
             [todomvc.views :as views]))
-
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
-(defonce react-root (atom nil))
 
 ;; ---- hash → Spec 012 path adapter -----------------------------------------
 ;;
@@ -44,19 +37,16 @@
 (defn- current-path []
   (hash->path (.. js/window -location -hash)))
 
-;; EP-0002: under the carried invariant the runtime
-;; never synthesises a frame from absence, and URL ownership is an EXPLICIT
-;; declaration — the app frame is registered with `:url-bound? true` so it owns
-;; the URL (Spec 012 §Multi-frame routing), seeds under `with-frame`, and the
-;; render is wrapped in a `frame-provider`.
+;; EP-0002: under the carried invariant the runtime never synthesises a frame
+;; from absence, and URL ownership is an EXPLICIT declaration — the app frame is
+;; registered with `:url-bound? true` so it owns the URL (Spec 012 §Multi-frame
+;; routing), and the render is wrapped in `frame-provider-existing`.
 (def app-frame :rf/default)
 
-;; Named handler so the listener install is idempotent: repeated `run`
-;; (shadow hot reload, or a co-required test host invoking run twice)
-;; must not stack duplicate hashchange listeners, mirroring the
-;; `when-not @react-root` mount guard below. We remove-then-add the same
-;; Var so the registration is deduped even when the Var is redefined on
-;; reload.
+;; Named handler so the listener install is idempotent: a repeated `boot!`
+;; (a co-required test host invoking `run` twice) must not stack duplicate
+;; `hashchange` listeners. We remove-then-add the same Var so the registration
+;; is deduped even when the Var is redefined on reload.
 ;;
 ;; EP-0002: the URL-change dispatch is targeted at the URL-owning `app-frame`
 ;; with an explicit `{:frame app-frame}` — NOT a frameless `(rf/dispatch …)`,
@@ -68,28 +58,49 @@
 (defn- on-hashchange [_]
   (rf/dispatch [:rf.route/handle-url-change (current-path)] {:frame app-frame}))
 
-(defn run []
-  ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {:doc "TodoMVC demo frame." :url-bound? true})
-  (rf/with-frame app-frame
-    ;; EP-0017: `:todo/initialise` DECLARES the
-    ;; `:todo.storage/todos` RECORDABLE+PROVIDED cofx (db.cljs) via
-    ;; `:rf.cofx/requires` and folds it into durable app-db. The host read
-    ;; happens ONCE here at the boundary; its value rides the boot dispatch
-    ;; token as the flat recordable coeffect, so it is recorded and replay /
-    ;; epoch-restore re-presents the captured snapshot verbatim rather than
-    ;; re-reading whatever localStorage holds then. Tests / replay supply the
-    ;; value the same way — `{:rf.cofx {:todo.storage/todos …}}` — never by
-    ;; re-registering an ambient supplier.
-    (rf/dispatch-sync [:todo/initialise]
-                      {:rf.cofx {:todo.storage/todos (db/read-todos-from-storage)}})
-    (rf/dispatch-sync [:rf.route/handle-url-change (current-path)]))
-  (.removeEventListener js/window "hashchange" on-hashchange)
-  (.addEventListener js/window "hashchange" on-hashchange)
+;; ---- Mount -----------------------------------------------------------------
+;;
+;; The React root is held in a defonce atom and materialised lazily inside
+;; `mount!` (not at ns-load) per examples/TESTING.md §Example mount-isolation:
+;; ns-load must produce no DOM side effects, so co-required example namespaces
+;; don't race `create-root` onto the shared `#app`. `defonce` keeps the root
+;; across hot reloads (React 18 rejects a second `create-root` on a live node),
+;; and `mount!` is `^:dev/after-load` — shadow re-invokes it on every reload to
+;; re-render the (possibly edited) views WITHOUT re-running `boot!`, so app-db
+;; and the URL listener survive the reload.
+
+(defonce react-root (atom nil))
+
+(defn ^:dev/after-load mount! []
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
                 [rf/frame-provider-existing {:frame app-frame}
                  [views/root-view]])))
+
+;; ---- Boot ------------------------------------------------------------------
+;;
+;; `boot!` runs once, at shadow's :init-fn. `init!` installs the adapter (it does
+;; NOT create the frame); `reg-frame` registers the URL-owning app frame and
+;; seeds it via `:initial-events`, fired synchronously into the freshly-created
+;; frame: `[:todo/initialise]` folds the saved todos — supplied by the registered
+;; `:todo.storage/todos` recordable coeffect (db.cljs) — into app-db, then
+;; `[:rf.route/handle-url-change …]` resolves the initial URL. Seeding through
+;; `:initial-events` is what removes the manual `with-frame` / `dispatch-sync`
+;; dance and the dispatch-site coeffect plumbing.
+
+(defn- boot! []
+  (rf/init! reagent-adapter/adapter)
+  (rf/reg-frame app-frame
+    {:doc            "TodoMVC demo frame."
+     :url-bound?     true
+     :initial-events [[:todo/initialise]
+                      [:rf.route/handle-url-change (current-path)]]})
+  (doto js/window
+    (.removeEventListener "hashchange" on-hashchange)
+    (.addEventListener "hashchange" on-hashchange)))
+
+(defn run []          ; shadow :init-fn — runs once, at page load
+  (boot!)
+  (mount!))

--- a/examples/reagent/todomvc/db.cljs
+++ b/examples/reagent/todomvc/db.cljs
@@ -3,9 +3,9 @@
 
   Demonstrates: the single source of truth (`default-db` — todos and *nothing
   else*; the active filter is derived from the route, never stored), and a
-  recordable coeffect (`reg-cofx :todo.storage/todos`) that carries saved todos
-  *in* at boot so the durable write stays replayable instead of reaching for
-  localStorage inside a handler."
+  recordable coeffect (`reg-cofx :todo.storage/todos`) whose registered supplier
+  reads the saved todos *in* at boot, so the durable write stays replayable
+  instead of reaching for localStorage inside a handler."
   (:require [re-frame.core :as rf]))
 
 ;; The default db carries no `:showing` slot — Spec 012's :route slice owns
@@ -34,35 +34,31 @@
       (catch :default _
         (sorted-map)))))
 
-;; localStorage is deliberate — see README. The Spec-014 :rf.http/managed demo lives with realworld.
+;; localStorage is deliberate — see README; the Spec-014 :rf.http/managed demo
+;; lives with realworld.
 ;;
-;; EP-0017 (recordable coeffects): the saved todos are a STORAGE
-;; world fact, and `:todo/initialise` folds them into durable app-db. A durable
-;; write must be a function of prior frame-state plus the causal token — not of
-;; an ambient `localStorage` read at the write site (which replay/restore could
-;; not reproduce). So the host-boundary boot read happens once, in
-;; `todomvc.core/run`, and rides the boot dispatch token as the flat RECORDABLE
-;; coeffect `:rf.cofx {:todo.storage/todos …}`.
+;; EP-0017 (recordable coeffects): the saved todos are a STORAGE world fact, and
+;; `:todo/initialise` folds them into durable app-db. A durable write must fold a
+;; RECORDED fact, not an ambient `localStorage` read at the write site (which
+;; replay / epoch-restore could not reproduce). So `:todo.storage/todos` is a
+;; registered RECORDABLE coeffect whose supplier reads localStorage: the supplier
+;; runs at the boot dispatch, its value is recorded onto the causal token, and
+;; replay re-folds that captured snapshot rather than re-reading whatever
+;; localStorage holds now.
 ;;
-;; `:todo.storage/todos` is therefore registered RECORDABLE + PROVIDED
-;; (EP-0017 §2, the `:rf/time-ms` shape): it carries NO generator — its value is
-;; STAMPED onto the boot dispatch token by its owner (`todomvc.core/run`,
-;; reading the host once at the boundary), recorded with the token, and
-;; re-presented verbatim under replay / epoch-restore. This closes the
-;; determinism hole the ambient grade left open: replay re-folds the captured
-;; snapshot, never a live re-read of whatever localStorage holds now.
-;;
-;; The boundary read (`read-todos-from-storage`) always coerces to a
-;; `(sorted-map)`: a nil (empty / absent localStorage, first run) would
-;; otherwise clobber default-db's `(sorted-map)` and break allocate-next-id's
-;; `(last (keys todos))` = max-id invariant once the map promotes to an
-;; unordered PersistentHashMap (>8 entries).
+;; Registering the supplier is the canonical coeffect shape — the Glossary's
+;; "make a coeffect available by registering a supplier with reg-cofx". (The
+;; value-stamped-at-the-dispatch-site PROVIDED form — `:provided? true`, no
+;; supplier — is reserved for boundary facts the app can't read itself, e.g. an
+;; SSR server that stamps the session the client can't see.)
+
 (defn read-todos-from-storage
-  "Host-boundary read of the saved TodoMVC items from localStorage, normalised
-   to a sorted-map. Called from `todomvc.core/run` so the value is STAMPED onto
-   the boot dispatch token's `:rf.cofx` as a recordable causal fact rather than
-   being read ambiently in a durable handler. nil/empty localStorage (first
-   run, or node with no localStorage) yields an empty sorted-map."
+  "Read the saved TodoMVC items from localStorage, normalised to a sorted-map —
+   the supplier body for the `:todo.storage/todos` recordable coeffect. nil/empty
+   localStorage (first run, or a server with no localStorage) yields an empty
+   sorted-map, so it never clobbers `default-db`'s `(sorted-map)` — which would
+   break allocate-next-id's `(last (keys todos))` max-id invariant once the map
+   promotes to an unordered PersistentHashMap past 8 entries."
   []
   (or (some-> (.-localStorage js/globalThis)
               (.getItem ls-key)
@@ -71,15 +67,10 @@
 
 (rf/reg-cofx :todo.storage/todos
   {:recordable? true
-   :provided?   true
-   :doc "Recordable, PROVIDED coeffect (EP-0017 §2): the saved TodoMVC items,
-         read from localStorage as a sorted-map. It has NO generator — its
-         value is stamped onto the boot dispatch token by `todomvc.core/run`
-         (the host-boundary read happens ONCE there), recorded with the token,
-         and re-presented verbatim under replay / epoch-restore. A handler that
-         folds it into durable app-db declares
-         `:rf.cofx/requires [:todo.storage/todos]` and reads it flat; absent
-         from the token it is `:rf.error/missing-required-cofx` (the boot
-         dispatch always supplies it). Tests / replay supply the value directly
-         on the dispatch token — `{:rf.cofx {:todo.storage/todos (sorted-map …)}}`
-         — never re-register a supplier."})
+   :doc "Recordable coeffect (EP-0017): the saved TodoMVC items, read from
+         localStorage as a sorted-map. The registered supplier runs at the boot
+         dispatch; its value is recorded onto the causal token and re-presented
+         verbatim under replay / epoch-restore. A handler folds it into durable
+         app-db by declaring `:rf.cofx/requires [:todo.storage/todos]` and
+         reading it flat — folding a recorded fact, never an ambient read."}
+  (fn [] (read-todos-from-storage)))

--- a/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
@@ -14,12 +14,11 @@
    COLD-BOOT ID-ALLOCATION REGRESSION (rf2-mzqd4.1)
    ------------------------------------------------
    `:todo/initialise` declares the `:todo.storage/todos` cofx (EP-0017
-   `:rf.cofx/requires`), now a RECORDABLE+PROVIDED fact (rf2-16ck78): its
-   value rides the boot dispatch token, supplied by the host boundary
-   (`db/read-todos-from-storage`), which reads `js/globalThis.localStorage`
-   via `some->`. Node has no localStorage, so the boundary read exercises the
+   `:rf.cofx/requires`), a RECORDABLE coeffect whose registered supplier
+   (`db/read-todos-from-storage`) reads `js/globalThis.localStorage` via
+   `some->`. Node has no localStorage, so the supplier exercises the
    EMPTY-localStorage / first-run path: `some->` short-circuits to nil and the
-   boundary coerces it to an empty `(sorted-map)`. Before the coercion fix, a
+   supplier coerces it to an empty `(sorted-map)`. Before the coercion fix, a
    nil clobbered default-db's `(sorted-map)`, leaving `:todos` nil. The first
    `:todo/add` then built a PLAIN PersistentArrayMap (not a sorted-map); once
    it promoted to an unordered PersistentHashMap (>8 entries),
@@ -27,7 +26,7 @@
    a new add could reuse an existing id and `assoc-in` would silently
    OVERWRITE a todo.
 
-   The boundary read coerces to `(sorted-map)` when localStorage is empty, so
+   The supplier coerces to `(sorted-map)` when localStorage is empty, so
    `:todos` is ALWAYS a sorted-map and the id-allocation invariant holds.
    This test cold-boots with no localStorage and adds well past the
    8-entry ArrayMap→HashMap promotion threshold, asserting: every add
@@ -71,22 +70,18 @@
   (testing "cold boot with empty localStorage keeps :todos a sorted-map so
             allocate-next-id never collides past the ArrayMap→HashMap
             promotion threshold (rf2-mzqd4.1)"
-    ;; Cold boot mirroring todomvc.core/run, which reads the host ONCE at the
-    ;; boundary (`db/read-todos-from-storage`) and SUPPLIES the saved todos on
-    ;; the boot dispatch token's :rf.cofx. EP-0017 (rf2-16ck78):
-    ;; :todo.storage/todos is now a RECORDABLE+PROVIDED coeffect, so its value
-    ;; must ride the token (absent → :rf.error/missing-required-cofx). The boot
-    ;; dispatch is issued explicitly here (rather than via :initial-events)
-    ;; carrying the empty-localStorage / first-run value: an
-    ;; empty sorted-map, exactly what the node-side boundary read yields.
+    ;; Cold boot exactly as todomvc.core/boot! does it: the frame seeds itself
+    ;; via `:initial-events [[:todo/initialise]]`, which folds in the saved todos
+    ;; supplied by the registered `:todo.storage/todos` recordable coeffect
+    ;; (db.cljs). The supplier reads `js/globalThis.localStorage`; node has none,
+    ;; so it exercises the empty / first-run path and coerces nil to an empty
+    ;; `(sorted-map)`. No manual `:rf.cofx` supply — the registered generator
+    ;; provides the fact, which is the whole point of the EP-0017 generator shape.
     (with-new-frame [f (frame/make-anon-frame-record!
-                         {:fx-overrides {:todo.storage/save :rf/no-op}})]
-      (rf/dispatch-sync [:todo/initialise]
-                        {:frame   f
-                         :rf.cofx {:todo.storage/todos (sorted-map)}})
-
+                         {:fx-overrides   {:todo.storage/save :rf/no-op}
+                          :initial-events [[:todo/initialise]]})]
       ;; The invariant the whole bug hinges on: :todos must be a
-      ;; sorted-map immediately after init, NOT nil.
+      ;; sorted-map immediately after boot, NOT nil.
       (is (sorted? (todos f))
           ":todos must be a sorted-map after cold-boot init, not nil")
       (is (= 0 (count (todos f)))


### PR DESCRIPTION
Following the discussion of todomvc's coeffect shape: per [the Glossary](docs/guide/glossary.md#coeffect), *"you make a coeffect available by registering a supplier for it with `reg-cofx`"* — declaring the world rather than reading it inside the handler. todomvc's `:todo.storage/todos` was the recordable-**provided** form (no supplier; the value stamped onto the boot dispatch's `:rf.cofx`), which reads the world at the *dispatch site* instead of in a registered supplier — a holdover from before EP-0017 recordable generators shipped (2026-06-14, now exercised in websocket / realworld / nine_states).

## Changes

- **`db.cljs`** — `:todo.storage/todos` is now a registered recordable **generator**: `(reg-cofx … {:recordable? true} (fn [] (read-todos-from-storage)))`. The supplier reads localStorage; its value is recorded onto the causal token and re-presented verbatim under replay / epoch-restore. (The PROVIDED form stays the right tool for boundary facts the app *can't* supply itself — e.g. an SSR server-stamped session.)
- **`core.cljs`** — boot seeds the frame via `reg-frame :initial-events [[:todo/initialise] [:rf.route/handle-url-change …]]`. Because the generator supplies the cofx, the manual `with-frame` + two `dispatch-sync` calls + the dispatch-site `:rf.cofx` plumbing are all gone. `run` splits into `boot!` (once, at `:init-fn`) + `mount!` (`^:dev/after-load`), so a hot reload re-renders the views without re-running `boot!` — app-db and the URL listener survive (the example previously had no after-load hook, so view edits didn't re-render until a dispatch).
- **`todomvc_cljs_test`** — the cold-boot test now boots via `:initial-events` and lets the registered generator supply the cofx (no manual `:rf.cofx`), so it verifies *both* changes. 36 assertions, the id-allocation invariant intact.

## Verified locally

`shadow-cljs compile examples/todomvc` (171 files, 0 warnings) + focused `todomvc-cljs-test` (36 assertions, 0 failures).

Resolves rf2-32i8pr. Also implements the ruling on the held boot-read determinism question **rf2-16ck78** (provided → registered generator). The matching skill fix (`cofx.md` still marks generators "slice B" and shows this read as ambient) is tracked separately as **rf2-6fjjs8**.