### PR TITLE
fix(examples): drop dead re-frame.http.test-support require from resources_ssr

### DIFF
--- a/examples/reagent/resources_ssr/core.cljc
+++ b/examples/reagent/resources_ssr/core.cljc
@@ -44,7 +44,6 @@
   (:require [re-frame.core :as rf]
             ;; Managed HTTP — the single built-in resource transport.
             [re-frame.http.managed]
-            [re-frame.http.test-support]
             ;; Resources artefact (boots the registrations + the LATE-BOUND
             ;; SSR projection hook the ssr artefact consults).
             [re-frame.resources]


### PR DESCRIPTION
## What

Remove the unused `[re-frame.http.test-support]` require from `examples/reagent/resources_ssr/core.cljc` (`:require` ~line 47). It carried no alias and was never referenced anywhere in the example body — no alias use, no fully-qualified call.

## Why it's safe to drop

The canned-success/failure stub fxs (`:rf.http/managed-canned-success`, `:rf.http/managed-canned-failure`) that this namespace registers are NOT registered by the example body. They are registered by the JVM test fixture, which does its own `(require 're-frame.http.test-support :reload)` in its `:once` fixture (`implementation/core/test/re_frame/examples_test.clj`) independently of the example. The shipped example uses the real transport (`re-frame.http.managed`); the JVM tests redirect it to the canned stub via per-frame `:fx-overrides`. So the require in the example body is dead — nothing in the example's own runnable path depends on it.

## Gates

- `npm run test:cljs` — PASS (7999 tests / 36798 assertions, 0 failures, 0 errors). resources_ssr + SSR contract tests stay green; the JVM fixture still registers its stub independently.
- `npm run test:examples-compile` — PASS. All 44 example builds compiled with zero warnings, including `:examples/resources-ssr` (216 files, 215 compiled, 0 warnings) — the example still compiles without the require.