### PR TITLE
fix(examples): realworld session-token cofx is a recordable generator, not provided-at-dispatch

### DIFF
--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -56,42 +56,42 @@
 
 ;; EP-0017: the saved JWT is read from localStorage at boot and
 ;; `:auth/initialise` folds it into durable app-db ([:auth :token]). A durable
-;; write must be a function of prior frame-state plus the causal token — not of
-;; an ambient `localStorage` read at the write site (which replay/epoch-restore
-;; could not reproduce). So `:auth.session/token` is registered RECORDABLE +
-;; PROVIDED (EP-0017 §2, the `:rf/time-ms` shape): it carries NO generator — its
-;; value is STAMPED onto the boot dispatch token by its owner
-;; (`realworld.core/run`, reading the host once at the boundary), recorded with
-;; the token, and re-presented verbatim under replay / epoch-restore. This
-;; closes the determinism hole the ambient grade left open: replay re-folds the
-;; captured token, never a live re-read of localStorage.
+;; write must fold a RECORDED fact, not an ambient `localStorage` read at the
+;; write site (which replay / epoch-restore could not reproduce). The JWT is an
+;; APP-OWNED world-read that feeds durable state, so the canonical shape is a
+;; recordable GENERATOR (cofx.md §Decision tree): `:auth.session/token` is a
+;; `:recordable? true` registration whose value-returning supplier reads
+;; localStorage. The generator runs at processing-start on the boot dispatch,
+;; its value is recorded onto the causal token, and replay / epoch-restore
+;; re-presents the captured token verbatim rather than re-reading whatever
+;; localStorage holds now. (PROVIDED — no generator, value stamped at a boundary
+;; — is reserved for facts the app cannot supply itself, e.g. an SSR server
+;; stamp; a JWT the app can read straight from the host is not one of those.)
 ;;
 ;; This is also why `ssr.cljc` may redact [:auth :token] from the hydration
 ;; payload — the client re-derives the durable token slot through this RECORDED
 ;; boot coeffect, not an ambient write-site read.
 (defn read-jwt-from-storage
-  "Host-boundary read of the saved JWT from localStorage (or nil). Called from
-   `realworld.core/run` so the value is STAMPED onto the boot dispatch token's
-   `:rf.cofx` as a recordable causal fact rather than being read ambiently in a
-   durable handler. nil when absent / unavailable (e.g. node, logged-out first
-   run)."
+  "Read the saved JWT from localStorage (or nil) — the supplier body for the
+   `:auth.session/token` recordable generator. nil when absent / unavailable
+   (e.g. node, logged-out first run)."
   []
   (some-> (.-localStorage js/globalThis)
           (.getItem "jwtToken")))
 
 (rf/reg-cofx :auth.session/token
   {:recordable? true
-   :provided?   true
-   :doc "Recordable, PROVIDED coeffect (EP-0017 §2): the saved JWT (or nil)
-         read from localStorage. It has NO generator — its value is stamped
-         onto the boot dispatch token by `realworld.core/run` (the host read
-         happens ONCE there), recorded with the token, and re-presented verbatim
-         under replay / epoch-restore. A handler that folds it into durable
-         app-db declares `:rf.cofx/requires [:auth.session/token]` and reads it
-         flat; absent from the token it is `:rf.error/missing-required-cofx`
-         (the boot dispatch always supplies it). Tests / replay supply the value
-         directly on the dispatch token —
-         `{:rf.cofx {:auth.session/token \"…\"}}` — never re-register a supplier."})
+   :doc "Recordable GENERATOR coeffect (EP-0017): the saved JWT (or nil), read
+         from localStorage. The registered supplier runs at processing-start on
+         the boot dispatch; its value is recorded onto the causal token and
+         re-presented verbatim under replay / epoch-restore — so the durable
+         write that folds it (`:auth/initialise` → [:auth :token]) replays the
+         captured token, never a live localStorage re-read. A handler folds it
+         by declaring `:rf.cofx/requires [:auth.session/token]` and reading it
+         flat. A production dispatch carries NO cofx — the generator IS the
+         source; tests pin an exact value via the dispatch-site `:rf.cofx` stub
+         seam (`{:rf.cofx {:auth.session/token \"…\"}}`)."}
+  (fn [] (read-jwt-from-storage)))
 
 ;; ============================================================================
 ;; SUPPORT EVENTS

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -78,13 +78,11 @@
 
 (rf/reg-event :app/initialise
   {:doc "App boot. Fans out to per-feature initialisers. `:auth/initialise` is
-         NOT in this fan-out — it consumes the RECORDABLE+PROVIDED
-         `:auth.session/token` coeffect, whose value the host boundary
-         (`run`) reads ONCE and stamps onto a dedicated boot dispatch token
-         (EP-0017). The `:dispatch` fx does not forward `:rf.cofx`
-         (it only inherits the cascade-propagated keys), so the session-restore
-         boot dispatch is issued directly at the boundary in `run`, where the
-         supplied token rides the token and is recorded."}
+         NOT in this fan-out — it consumes the RECORDABLE-GENERATOR
+         `:auth.session/token` coeffect (EP-0017). The `:dispatch` fx does not
+         forward `:rf.cofx`, so issuing it as a plain boundary dispatch in `run`
+         (rather than through this fan-out) keeps the generated token on its own
+         boot dispatch token, where it is recorded."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:articles/initialise]]
           [:dispatch [:article/initialise]]
@@ -561,19 +559,18 @@
   ;; matches.
   (routing/set-base-path! "/realworld")
   (rf/with-frame :rf/default
-    ;; EP-0017: session restore consumes the RECORDABLE+PROVIDED
+    ;; EP-0017: session restore consumes the RECORDABLE-GENERATOR
     ;; `:auth.session/token` coeffect and folds it into durable [:auth :token].
-    ;; The host read happens ONCE here at the boundary; its value rides this
-    ;; boot dispatch token as the flat recordable coeffect, so it is recorded
-    ;; and replay / epoch-restore re-presents the captured token verbatim rather
-    ;; than re-reading localStorage then. It is dispatched directly at the
-    ;; boundary (not via the `:app/initialise` `:dispatch` fan-out, which does
+    ;; The dispatch is PLAIN — it carries no `:rf.cofx` (a production dispatch
+    ;; never stamps a coeffect; that is a unit-test stub seam). The registered
+    ;; generator (auth.cljs) reads localStorage ONCE at processing-start; its
+    ;; value rides this boot dispatch token as the flat recordable coeffect, so
+    ;; it is recorded and replay / epoch-restore re-presents the captured token
+    ;; verbatim rather than re-reading localStorage then. It is dispatched here
+    ;; directly (not via the `:app/initialise` `:dispatch` fan-out, which does
     ;; not forward `:rf.cofx`), and BEFORE `:app/initialise` so the token is in
-    ;; app-db before the bearer-auth interceptor fires any authenticated
-    ;; request. Tests / replay supply the value the same way — never by
-    ;; re-registering an ambient supplier.
-    (rf/dispatch-sync [:auth/initialise]
-                      {:rf.cofx {:auth.session/token (auth/read-jwt-from-storage)}})
+    ;; app-db before the bearer-auth interceptor fires any authenticated request.
+    (rf/dispatch-sync [:auth/initialise])
     (rf/dispatch-sync [:app/initialise])
     ;; install-router! does the initial URL→slice sync (a dispatch-sync) and
     ;; wires the popstate listener; the sync runs under the frame scope, and

--- a/examples/reagent/realworld/ssr.cljc
+++ b/examples/reagent/realworld/ssr.cljc
@@ -42,8 +42,9 @@
   ;; live credential into page source (view-source-visible, proxy-logged,
   ;; CDN-cacheable). Redact it at the payload boundary — the client
   ;; re-establishes [:auth :token] on hydrate via `:auth/initialise`
-  ;; (auth.cljs), which folds the RECORDABLE+PROVIDED `:auth.session/token`
-  ;; coeffect the boot boundary stamps from localStorage (EP-0017).
+  ;; (auth.cljs), which folds the RECORDABLE-GENERATOR `:auth.session/token`
+  ;; coeffect — a registered supplier reading localStorage at processing-start,
+  ;; recorded onto the boot dispatch token (EP-0017).
   ;; The durable token slot is thus a function of a recorded boot coeffect, not
   ;; an ambient write-site read, so dropping it from the payload costs nothing
   ;; and stays replay-sound.

--- a/examples/reagent/realworld_resources/auth.cljs
+++ b/examples/reagent/realworld_resources/auth.cljs
@@ -71,42 +71,42 @@
         (.setItem ls "jwtToken" token)
         (.removeItem ls "jwtToken")))))
 
-;; EP-0017 (recordable coeffects): the saved JWT is a STORAGE world
-;; fact that `:auth/initialise` folds into durable app-db (and that drives
-;; session restore). A durable write must be a function of prior frame-state
-;; plus the causal token — not of an ambient `localStorage` read at the write
-;; site, which replay/epoch-restore could not reproduce. So
-;; `:realworld-resources.session/token` is registered RECORDABLE + PROVIDED
-;; (EP-0017 §2, the `:rf/time-ms` shape): it carries NO generator — its value is
-;; STAMPED onto the boot dispatch token by its owner
-;; (`realworld-resources.core/run`, reading the host once at the boundary),
-;; recorded with the token, and re-presented verbatim under replay /
-;; epoch-restore. This closes the determinism hole the ambient grade left open:
-;; replay re-folds the captured token, never a live re-read of localStorage.
+;; EP-0017 (recordable coeffects): the saved JWT is a STORAGE world fact that
+;; `:auth/initialise` folds into durable app-db (and that drives session
+;; restore). A durable write must fold a RECORDED fact, not an ambient
+;; `localStorage` read at the write site, which replay / epoch-restore could not
+;; reproduce. The JWT is an APP-OWNED world-read that feeds durable state, so the
+;; canonical shape is a recordable GENERATOR (cofx.md §Decision tree):
+;; `:realworld-resources.session/token` is a `:recordable? true` registration
+;; whose value-returning supplier reads localStorage. The generator runs at
+;; processing-start on the boot dispatch, its value is recorded onto the causal
+;; token, and replay / epoch-restore re-presents the captured token verbatim
+;; rather than re-reading whatever localStorage holds now. (PROVIDED — no
+;; generator, value stamped at a boundary — is reserved for facts the app cannot
+;; supply itself, e.g. an SSR server stamp; a JWT the app reads from the host is
+;; not one of those.)
 (defn read-jwt-from-storage
-  "Host-boundary read of the saved JWT from localStorage (or nil). Called from
-   `realworld-resources.core/run` so the value is STAMPED onto the boot dispatch
-   token's `:rf.cofx` as a recordable causal fact rather than being read
-   ambiently in a durable handler. nil when absent / unavailable."
+  "Read the saved JWT from localStorage (or nil) — the supplier body for the
+   `:realworld-resources.session/token` recordable generator. nil when absent /
+   unavailable."
   []
   (some-> (.-localStorage js/globalThis)
           (.getItem "jwtToken")))
 
 (rf/reg-cofx :realworld-resources.session/token
   {:recordable? true
-   :provided?   true
-   :doc "Recordable, PROVIDED coeffect (EP-0017 §2): the saved JWT (or nil)
-         read from localStorage. It has NO generator — its value is stamped
-         onto the boot dispatch token by `realworld-resources.core/run` (the
-         host read happens ONCE there), recorded with the token, and
-         re-presented verbatim under replay / epoch-restore. A handler that
-         folds it into durable app-db declares
-         `:rf.cofx/requires [:realworld-resources.session/token]` and reads it
-         flat; absent from the token it is `:rf.error/missing-required-cofx`
-         (the boot dispatch always supplies it). Tests / replay supply the value
-         directly on the dispatch token —
-         `{:rf.cofx {:realworld-resources.session/token \"…\"}}` — never
-         re-register a supplier."})
+   :doc "Recordable GENERATOR coeffect (EP-0017): the saved JWT (or nil), read
+         from localStorage. The registered supplier runs at processing-start on
+         the boot dispatch; its value is recorded onto the causal token and
+         re-presented verbatim under replay / epoch-restore — so the durable
+         write that folds it (`:auth/initialise` → [:auth :token]) replays the
+         captured token, never a live localStorage re-read. A handler folds it
+         by declaring `:rf.cofx/requires [:realworld-resources.session/token]`
+         and reading it flat. A production dispatch carries NO cofx — the
+         generator IS the source; tests pin an exact value via the dispatch-site
+         `:rf.cofx` stub seam
+         (`{:rf.cofx {:realworld-resources.session/token \"…\"}}`)."}
+  (fn [] (read-jwt-from-storage)))
 
 ;; ============================================================================
 ;; SESSION SUPPORT EVENTS

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -64,14 +64,14 @@
 
 (rf/reg-event :app/initialise
   {:doc "App boot. Seeds the form drafts. Session restore (`:auth/initialise`)
-         is NOT in this fan-out — it consumes the RECORDABLE+PROVIDED
-         `:realworld-resources.session/token` coeffect, whose value the host
-         boundary (`run`) reads ONCE and stamps onto a dedicated boot dispatch
-         token (EP-0017). The `:dispatch` fx does not forward
-         `:rf.cofx`, so that boot dispatch is issued directly at the boundary in
-         `run`. The page reads (articles, tags, feed, …) are CAUSED by the
-         route's `:resources` metadata on the initial URL→route sync, not from
-         here — that is the point of the variant."}
+         is NOT in this fan-out — it consumes the RECORDABLE-GENERATOR
+         `:realworld-resources.session/token` coeffect (EP-0017). The `:dispatch`
+         fx does not forward `:rf.cofx`, so issuing it as a plain boundary
+         dispatch in `run` (rather than through this fan-out) keeps the generated
+         token on its own boot dispatch token, where it is recorded. The page
+         reads (articles, tags, feed, …) are CAUSED by the route's `:resources`
+         metadata on the initial URL→route sync, not from here — that is the
+         point of the variant."}
   (fn [_ _]
     {:fx [[:dispatch [:auth.login-form/initialise]]
           [:dispatch [:auth.register-form/initialise]]]}))
@@ -266,18 +266,19 @@
   ;; prefix before the matcher sees the URL so :realworld/home (path "/") matches.
   (routing/set-base-path! "/realworld-resources")
   (rf/with-frame app-frame
-    ;; EP-0017: session restore consumes the RECORDABLE+PROVIDED
+    ;; EP-0017: session restore consumes the RECORDABLE-GENERATOR
     ;; `:realworld-resources.session/token` coeffect and folds it into durable
-    ;; [:auth :token]. The host read happens ONCE here at the boundary; its
-    ;; value rides this boot dispatch token as the flat recordable coeffect, so
-    ;; it is recorded and replay / epoch-restore re-presents the captured token
-    ;; verbatim rather than re-reading localStorage then. It is dispatched
-    ;; directly at the boundary (not via the `:app/initialise` `:dispatch`
-    ;; fan-out, which does not forward `:rf.cofx`), and BEFORE `:app/initialise`
-    ;; so the token is in app-db before the bearer-auth interceptor fires any
-    ;; authenticated request. Tests / replay supply the value the same way.
-    (rf/dispatch-sync [:auth/initialise]
-                      {:rf.cofx {:realworld-resources.session/token (auth/read-jwt-from-storage)}})
+    ;; [:auth :token]. The dispatch is PLAIN — it carries no `:rf.cofx` (a
+    ;; production dispatch never stamps a coeffect; that is a unit-test stub
+    ;; seam). The registered generator (auth.cljs) reads localStorage ONCE at
+    ;; processing-start; its value rides this boot dispatch token as the flat
+    ;; recordable coeffect, so it is recorded and replay / epoch-restore
+    ;; re-presents the captured token verbatim rather than re-reading
+    ;; localStorage then. It is dispatched here directly (not via the
+    ;; `:app/initialise` `:dispatch` fan-out, which does not forward `:rf.cofx`),
+    ;; and BEFORE `:app/initialise` so the token is in app-db before the
+    ;; bearer-auth interceptor fires any authenticated request.
+    (rf/dispatch-sync [:auth/initialise])
     (rf/dispatch-sync [:app/initialise])
     ;; The initial URL→route sync (under the frame scope) is what fires the
     ;; route's `:resources` ensures — server-state loads because the route

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -143,21 +143,23 @@
     (is (nil? (rf/compute-sub [:auth/user] (rf/frame-state-value f))))))
 
 (defn- session-token-cofx-shape-test []
-  ;; EP-0017 cofx contract (rf2-16ck78) — the :auth.session/token cofx is a
-  ;; RECORDABLE + PROVIDED fact: it carries NO generator (its value is stamped
-  ;; onto the boot dispatch token by `realworld.core/run`, which reads the host
-  ;; once at the boundary), is recorded with the token, and replay re-presents
-  ;; the captured value verbatim rather than re-reading localStorage. The
-  ;; contract under test: the registration carries the provided-recordable grade
-  ;; and NO supplier fn (a declaring handler receives the supplied value FLAT
-  ;; under `:auth.session/token` via `:rf.cofx/requires`).
+  ;; EP-0017 cofx contract — the :auth.session/token cofx is a RECORDABLE
+  ;; GENERATOR: the saved JWT is an APP-OWNED world-read that feeds durable
+  ;; state, so the app registers a value-returning supplier (reading localStorage)
+  ;; rather than stamping the value at the dispatch site (cofx.md §Decision tree).
+  ;; The generator runs at processing-start on the boot dispatch, its value is
+  ;; recorded onto the causal token, and replay re-presents the captured value
+  ;; verbatim. The contract under test: the registration is recordable, is NOT
+  ;; provided (it has a generator), and carries a supplier fn (the localStorage
+  ;; read). A declaring handler receives the generated value FLAT under
+  ;; `:auth.session/token` via `:rf.cofx/requires`.
   (let [cofx-meta (registrar/handler-meta :cofx :auth.session/token)]
     (is (true? (:recordable? cofx-meta))
         "the cofx is recordable — its value rides the recorded token")
-    (is (true? (:provided? cofx-meta))
-        "the cofx is provided — its owner stamps the value; no generator")
-    (is (nil? (:handler-fn cofx-meta))
-        "a provided recordable fact carries no supplier fn — the boundary stamps it")))
+    (is (not (:provided? cofx-meta))
+        "the cofx is NOT provided — it is generator-backed (the app supplies it)")
+    (is (fn? (:handler-fn cofx-meta))
+        "a recordable generator carries a value-returning supplier fn")))
 
 (defn- login-failure-test []
   (reg-canned-failure! :realworld.test/login-failure
@@ -926,7 +928,7 @@
     (login-happy-path-test))
   (testing "login failure surfaces error and dismiss returns to :idle"
     (login-failure-test))
-  (testing ":auth.session/token cofx assoc-shape regression guard (rf2-gg4dz)"
+  (testing ":auth.session/token is a recordable generator (not provided-at-dispatch)"
     (session-token-cofx-shape-test)))
 
 (deftest realworld-articles-feed

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -409,3 +409,23 @@
       (is (= "alice" (:username (rf/compute-sub [:auth/user] (state-value f))))
           "the session user is stored")
       (is (true? (rf/compute-sub [:auth/authenticated?] (state-value f)))))))
+
+;; ============================================================================
+;; 7. SESSION-TOKEN COFX SHAPE — recordable generator (not provided-at-dispatch)
+;; ============================================================================
+
+(deftest session-token-cofx-is-a-recordable-generator
+  (testing "examples/reagent/realworld_resources — the saved JWT is an app-owned
+            world-read that feeds durable [:auth :token], so it is a recordable
+            GENERATOR (a `:recordable? true` reg-cofx whose supplier reads
+            localStorage), NOT a provided fact stamped at the dispatch site
+            (cofx.md §Decision tree). The generator runs at processing-start, is
+            recorded onto the causal token, and replay re-presents the captured
+            value verbatim."
+    (let [cofx-meta (registrar/handler-meta :cofx :realworld-resources.session/token)]
+      (is (true? (:recordable? cofx-meta))
+          "the cofx is recordable — its value rides the recorded token")
+      (is (not (:provided? cofx-meta))
+          "the cofx is NOT provided — it is generator-backed (the app supplies it)")
+      (is (fn? (:handler-fn cofx-meta))
+          "a recordable generator carries a value-returning supplier fn"))))


### PR DESCRIPTION
## The drift

Both `examples/reagent/realworld` and `examples/reagent/realworld_resources` registered the JWT `localStorage` read as a recordable **PROVIDED** coeffect (no generator) for an **app-owned world-read that feeds durable app-db** `[:auth :token]` (folded by `:auth/initialise`), and `core/run` stamped the value at the **production dispatch site**:

```clojure
(rf/dispatch-sync [:auth/initialise]
                  {:rf.cofx {:auth.session/token (auth/read-jwt-from-storage)}})
```

This is the exact drift todomvc carried and #4968 fixed. Per the ruled doctrine, the corrected `cofx.md` skill, and the glossary:

- an app-owned world-read feeding durable state is a recordable **GENERATOR** (`{:recordable? true}` + a value-returning supplier);
- **PROVIDED** is reserved for boundary/SSR facts the app cannot supply itself (e.g. an SSR server stamp);
- a **production dispatch carries no cofx** — the dispatch-site `:rf.cofx` opt is a unit-test-stub-only seam.

`cofx.md` already **names** `examples/reagent/realworld` as shipping the generator shape (§Canonical mini-example, line 121) — so the doc said generator while the code shipped provided. This makes the code match the doc.

## The fix (mirrors #4968), in each example

1. Re-register the cofx as a **recordable generator** — `(rf/reg-cofx <id> {:recordable? true} (fn [] (read-jwt-from-storage)))`; the `localStorage` read moves into the supplier fn; **`:provided?` dropped**.
2. Replace the stamped boot dispatch in `core.cljs` `run` with a plain `(rf/dispatch-sync [:auth/initialise])` — no cofx on the production dispatch. The registered generator runs at processing-start, is recorded onto the boot token, and replays verbatim.
3. The handler keeps declaring `:rf.cofx/requires [<id>]` and reads the value flat (unchanged).
4. Refreshed the cofx + boot docstrings/comments — and the one stale `realworld/ssr.cljc` comment — to describe the generator shape in the house teaching voice (terminology per the docs glossary: `reg-cofx`, recordable, generator).

Affected ids: `:auth.session/token` (realworld), `:realworld-resources.session/token` (realworld_resources).

## Test update

The realworld shape test `session-token-cofx-shape-test` previously **locked in the provided grade**. It now asserts the **recordable-generator** shape (recordable, **not** provided, carries a value-returning supplier fn). Added a symmetric `session-token-cofx-is-a-recordable-generator` deftest for `realworld_resources` (which had no shape-asserting test). The dispatch-site `{:rf.cofx {... nil}}` stubs in the test fixtures stay — that is the legitimate test-only stub seam pinning the recordable fact node-side.

## Gates

- `npm run test:cljs` — **8000 tests / 36801 assertions / 0 failures, 0 errors** (incl. both updated/added shape tests).
- `npm run test:examples-compile` — **all 44 example builds, 0 warnings** (`realworld` 313 files / `realworld-resources` 300 files, both clean).