### PR TITLE
fix(examples): resources machine-owned reader loads the intended article

### DIFF
--- a/examples/reagent/resources/core.cljs
+++ b/examples/reagent/resources/core.cljs
@@ -258,14 +258,22 @@
 ;; the cached-read mechanics. A tiny reader machine: it ensures the article
 ;; on entry, and the resource is released when the instance is destroyed.
 
-;; The reader is started by the UI with `[:resources.app/reader
-;; [:rf.machine/start slug instance-id]]` — the creation marker carries the
-;; slug + instance-id this workflow owns. The `:reading` `:entry` action runs
-;; once on the initial-entry cascade: it reads slug + instance-id from the
-;; start `:event`, assigns them into the snapshot `:data` (so the owner is
-;; self-describing for tools / SSR), and ensures the article under a
-;; `[:machine machine-id instance-id]` owner (Spec 016 §Machine-owned
-;; resource). The runtime releases that owner when the actor is destroyed.
+;; The reader is started by the UI in two steps: BIRTH the actor with the bare
+;; `[:rf.machine/start]` creation marker, then dispatch a real first event
+;; `[:reader/load slug instance-id]` INTO the live actor. The split is
+;; deliberate and idiomatic: the framework's initial-entry cascade synthesises
+;; the birth `:entry` actions with NO event (it threads only the bare start
+;; marker), so an `:entry` action cannot read args off the start marker — they
+;; would arrive nil. A real event dispatched after birth DOES thread its args,
+;; so the slug + instance-id this workflow owns ride on `:reader/load`.
+;;
+;; The `:reading` state handles `:reader/load` with the `:ensure-article`
+;; action (a targetless internal transition — no `:target`, so the actor stays
+;; in `:reading`): it reads slug + instance-id from the load `:event`, assigns them into the
+;; snapshot `:data` (so the owner is self-describing for tools / SSR), and
+;; ensures the article under a `[:machine machine-id instance-id]` owner (Spec
+;; 016 §Machine-owned resource). The runtime releases that owner when the actor
+;; is destroyed.
 (rf/reg-machine :resources.app/reader
   {:doc     "A reader workflow that owns the article it is reading."
    :initial :reading
@@ -281,21 +289,32 @@
                              :owner    [:machine :resources.app/reader instance-id]
                              :cause    [:machine-action :resources.app/reader.reading]}]]]}))}
    :states
-   {:reading {:entry :ensure-article}}})
+   ;; `:reader/load` is a TARGETLESS internal transition (a candidate map with
+   ;; an `:action` ref and no `:target`): the actor stays in `:reading` and
+   ;; runs `:ensure-article`. A bare `{:reader/load :ensure-article}` would read
+   ;; `:ensure-article` as a sibling-state TARGET (and fail to resolve), so the
+   ;; action ref must ride inside the `{:action …}` candidate map.
+   {:reading {:on {:reader/load {:action :ensure-article}}}}})
 
-;; The UI starts/stops the reader through these events. Starting fires the
-;; `[:rf.machine/start slug instance-id]` creation marker (which runs the
-;; reader's `:reading` entry → ensure) and records the active instance-id in
-;; app-db so the view can read the machine-owned article + offer a stop
-;; affordance. Stopping emits the reserved `[:rf.machine/destroy …]` fx,
-;; which runs the actor's `:exit` cascade and releases its `[:machine …]`
-;; resource owner so the entry can GC, then clears the slice.
+;; The UI starts/stops the reader through these events. Starting BIRTHS the
+;; actor with the bare `[:rf.machine/start]` marker, then dispatches the real
+;; `[:reader/load slug instance-id]` event into it — that event (unlike the
+;; birth marker) threads its args, so the `:reading` `:reader/load` action
+;; reads the slug + instance-id and ensures the article under the
+;; `[:machine … instance-id]` owner. The two dispatches order naturally: the
+;; start marker's birth cascade runs first, then the load event drives the
+;; ensure on the now-live actor. The event also records the active instance-id
+;; in app-db so the view can read the machine-owned article + offer a stop
+;; affordance. Stopping emits the reserved `[:rf.machine/destroy …]` fx, which
+;; runs the actor's `:exit` cascade and releases its `[:machine …]` resource
+;; owner so the entry can GC, then clears the slice.
 (rf/reg-event :resources.app/start-reader
   {:doc "Start the reader workflow that owns the given article for its lifetime."}
   (fn [{:keys [db]} [_ slug]]
     (let [instance-id (str "reader-" slug)]
       {:db (assoc db :resources.app/reader {:slug slug :instance-id instance-id})
-       :fx [[:dispatch [:resources.app/reader [:rf.machine/start slug instance-id]]]]})))
+       :fx [[:dispatch [:resources.app/reader [:rf.machine/start]]]
+            [:dispatch [:resources.app/reader [:reader/load slug instance-id]]]]})))
 
 (rf/reg-event :resources.app/stop-reader
   {:doc "Destroy the reader actor — releases its machine-owned resource."}


### PR DESCRIPTION
## The bug

In `examples/reagent/resources/core.cljs`, the machine-owned-resource pattern never loaded the intended article — it ensured a `nil`-slug entry under a `nil`-instance owner, while the reader panel subscribed the *real* slug. The two never met, so the reader showed nothing.

### Root cause: start-marker args don't reach the birth `:entry` cascade

`:resources.app/start-reader` dispatched `[:resources.app/reader [:rf.machine/start slug instance-id]]`, appending `slug`/`instance-id` onto the machine **creation marker**, and the `:reading {:entry :ensure-article}` action read them via `(let [[_ slug instance-id] event] …)`.

But the framework birth path threads only the **bare** `[:rf.machine/start]` marker into the initial-entry cascade: `lifecycle_fx/registration` `maybe-boot` calls `apply-initial-entry-cascade` with **no event**, and `run-initial-cascade` runs `bootstrap-step` with no trigger. So at runtime the `:entry` action's `:event` is the synthetic bare start marker — `slug` and `instance-id` are **nil**.

Net: the machine ensured `:article/by-slug {:slug nil}` under owner `[:machine :resources.app/reader nil]`, while the panel subscribed `[:rf.resource/state … {:slug real-slug}]` — a *different* (idle) entry than the machine ensured.

Passing args on the start marker was the example's mistake, not a framework gap: every established example and the `actor_resource_lease_release` + `resources_machine_owner_release` contract tests dispatch the **bare** `[:rf.machine/start]` and never rely on start-marker args. No framework code was changed.

## The fix (example only)

Two-step, idiomatic-singleton birth + parameterise:

1. `:resources.app/start-reader` now **births** the actor with the bare `[:rf.machine/start]` marker, then dispatches a **real** first event `[:reader/load slug instance-id]` into the now-live actor. Unlike the birth marker, a real event threads its args through `route-inner-event` to the inner `[:reader/load slug instance-id]`.
2. `:reading` handles it via a **targetless internal transition** — `{:on {:reader/load {:action :ensure-article}}}` (the `:action` ref rides inside the candidate map; a bare `{:reader/load :ensure-article}` would mis-read `:ensure-article` as a sibling-state *target* and fail registration validation). The `:ensure-article` action reads `slug`/`instance-id` from that event's vector, assigns them into `:data` (self-describing snapshot for tools/SSR), and ensures `:article/by-slug {:slug real-slug}` under owner `[:machine :resources.app/reader instance-id]`.

This mirrors the canonical machine-owned pattern in `resources_machine_owner_release_cljs_test` (`:entry` reads slug from `:data`), adapted for a *dynamic per-click* slug that a singleton's static `:data` cannot carry — so the real first event delivers it.

### Why approach (b) over (a)

`build-initial-snapshot` seeds `:data` statically from `(:data machine)` at birth; a singleton has no per-start `:data` initialiser and the start event's args don't thread into birth. So carrying the dynamic slug purely via `reg-machine :data` (approach a) can't work for a singleton restarted per article. Dispatching a real load event after birth (approach b) is the mechanism the framework actually supports for parameterising an owned actor at birth.

## Verification

The ensured entry's params `{:slug real-slug}` now match the reader panel's subscription params `{:slug real-slug}` — same real slug, same owner instance-id. The machine-owned resource pattern loads the intended article.

## Gates

- `npm run test:examples-compile` — PASS (all 44 example builds compiled, 0 warnings; `[:examples/resources]` clean).
- `npm run test:cljs` — PASS (7999 tests, 36798 assertions, 0 failures, 0 errors; resources namespace registers + loads clean — the prior registration-time validation throw is gone).