### PR TITLE
refactor(examples): state_machine_walkthrough login-form draft to app-db (Pattern-Forms, machine kept)

### DIFF
--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -207,6 +207,38 @@
 (rf/reg-machine :auth.login/flow login-flow)
 
 ;; ============================================================================
+;; FORM DRAFT SLICE — Pattern-Forms §Variations (machine + slice)
+;; ============================================================================
+;;
+;; The machine owns submit/auth STATUS; the slice owns the DRAFT. Form drafts
+;; are application state, so the email/password the user types lives in app-db
+;; — projected via a sub, mutated via an event — never in a view-local atom.
+;; The login form's inputs are CONTROLLED off `:auth.login/draft`; `:on-change`
+;; dispatches `:auth.login/edit-field`, and submit reads the draft back out of
+;; the slice rather than out of the view.
+;;
+;; This walkthrough strips the slice to its single teaching point — the draft —
+;; rather than the full 7-key Pattern-Forms slice (touched / errors /
+;; submit-attempted? / …): the chapter foregrounds the MACHINE, so the slice
+;; carries only what must leave the view. The fuller slice shape lives in
+;; examples/reagent/realworld/auth.cljs.
+
+(def login-form-defaults {:email "" :password ""})
+
+(rf/reg-event :auth.login/initialise-form
+  {:doc "Seed the login draft to empty defaults. The machine spawns itself on
+         its first event; this only owns the draft slice."}
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:auth :login-form :draft] login-form-defaults)}))
+
+(rf/reg-event :auth.login/edit-field
+  {:doc "User changed a single login field. Writes the draft slot in app-db —
+         the controlled input's `:on-change` dispatches this; it NEVER sets
+         view-local state."}
+  (fn [{:keys [db]} [_ field value]]
+    {:db (assoc-in db [:auth :login-form :draft field] value)}))
+
+;; ============================================================================
 ;; SUBSCRIPTIONS — chapter §Registering and running it
 ;; ============================================================================
 
@@ -219,6 +251,12 @@
 ;; `rf/machine-has-tag?` queries in views.cljs (chapter §State tags),
 ;; because discriminating on the snapshot's runtime-projected `:tags` set
 ;; decouples view code from individual state-keyword identity.
+
+(rf/reg-sub :auth.login/draft
+  {:doc "The login form draft — what the user has currently typed. The view's
+         controlled inputs read `:value` off this; submit reads it to hand the
+         creds to the machine."}
+  (fn [db _] (get-in db [:auth :login-form :draft])))
 
 (rf/reg-sub :auth.login/state
   :<- [:rf/machine :auth.login/flow]

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -25,50 +25,57 @@
 ;; VIEWS
 ;; ============================================================================
 
-(reg-view ^{:doc "The login form view. Captures email + password in a plain
-                  atom across renders (Form-2 outer/inner shape) — the inputs
-                  are uncontrolled, so the atom is only read in the submit
-                  handler, never in the render body, and needs no reactivity.
-                  Dispatches :auth.login/flow → :auth.login/submit on submit.
+(reg-view ^{:doc "The login form view. The email + password DRAFT is application
+                  state, so it lives in app-db (the `:auth.login/draft` slice),
+                  NOT a view-local atom — projected via the `:auth.login/draft`
+                  sub, mutated via the `:auth.login/edit-field` event. The inputs
+                  are CONTROLLED: `:value` reads from the draft sub, `:on-change`
+                  DISPATCHES an edit-field event (it never sets view-local state).
+                  Submit reads the draft back out of the sub and hands it to the
+                  machine via :auth.login/flow → :auth.login/submit.
 
-                  View-side discriminators read the machine's runtime-projected
-                  `:tags` set (chapter §State tags) via `rf/machine-has-tag?`, not boolean
-                  state-predicate subs — so adding a new busy-ish state changes no view."}
+                  The machine owns submit/auth STATUS; the slice owns the DRAFT
+                  (Pattern-Forms §Variations: machine + slice). View-side
+                  discriminators read the machine's runtime-projected `:tags` set
+                  (chapter §State tags) via `rf/machine-has-tag?`, not boolean
+                  state-predicate subs — so adding a new busy-ish state changes
+                  no view."}
           login-form []
-  (let [state (atom {:email "" :password ""})]
-    (fn []
-      (let [busy?   @(rf/machine-has-tag? :auth.login/flow :auth/busy)
-            locked? @(rf/machine-has-tag? :auth.login/flow :auth/locked)
-            err     @(subscribe [:auth.login/error])]
-        [:form.login-form
-         {:data-testid "login-form"
-          :on-submit (fn [e]
-                       (.preventDefault e)
-                       (when-not (or busy? locked?)
-                         (dispatch [:auth.login/flow
-                                    [:auth.login/submit @state]])))}
-         [:input  {:type        "email"
-                   :placeholder "Email"
-                   :data-testid "login-email"
-                   :disabled    (or busy? locked?)
-                   :on-change   #(swap! state assoc :email (.. % -target -value))}]
-         [:input  {:type        "password"
-                   :placeholder "Password"
-                   :data-testid "login-password"
-                   :disabled    (or busy? locked?)
-                   :on-change   #(swap! state assoc :password (.. % -target -value))}]
-         [:button {:type "submit"
-                   :data-testid "login-submit"
-                   :disabled (or busy? locked?)}
-          (if busy? "Signing in…" "Sign in")]
-         (when (and err (not locked?))
-           [:div.error-row
-            [:p.error err]
-            [:button {:type "button"
-                      :data-testid "login-dismiss"
-                      :on-click #(dispatch [:auth.login/flow
-                                             [:auth.login/dismiss]])}
-             "Dismiss"]])]))))
+  (let [busy?   @(rf/machine-has-tag? :auth.login/flow :auth/busy)
+        locked? @(rf/machine-has-tag? :auth.login/flow :auth/locked)
+        draft   @(subscribe [:auth.login/draft])
+        err     @(subscribe [:auth.login/error])]
+    [:form.login-form
+     {:data-testid "login-form"
+      :on-submit (fn [e]
+                   (.preventDefault e)
+                   (when-not (or busy? locked?)
+                     (dispatch [:auth.login/flow
+                                [:auth.login/submit draft]])))}
+     [:input  {:type        "email"
+               :placeholder "Email"
+               :data-testid "login-email"
+               :value       (:email draft)
+               :disabled    (or busy? locked?)
+               :on-change   #(dispatch [:auth.login/edit-field :email (.. % -target -value)])}]
+     [:input  {:type        "password"
+               :placeholder "Password"
+               :data-testid "login-password"
+               :value       (:password draft)
+               :disabled    (or busy? locked?)
+               :on-change   #(dispatch [:auth.login/edit-field :password (.. % -target -value)])}]
+     [:button {:type "submit"
+               :data-testid "login-submit"
+               :disabled (or busy? locked?)}
+      (if busy? "Signing in…" "Sign in")]
+     (when (and err (not locked?))
+       [:div.error-row
+        [:p.error err]
+        [:button {:type "button"
+                  :data-testid "login-dismiss"
+                  :on-click #(dispatch [:auth.login/flow
+                                         [:auth.login/dismiss]])}
+         "Dismiss"]])]))
 
 (reg-view ^{:doc "Top banner reflecting the machine's current state. The
                   `data-state` attribute surfaces the state keyword so a
@@ -117,10 +124,15 @@
   ;; so the `reg-view`-injected `dispatch`/`subscribe` (and the login machine
   ;; reads) resolve to it (a no-provider render reads the no-provider sentinel
   ;; and raises :rf.error/no-frame-context). The login machine is
-  ;; self-initialising, so there is no boot `dispatch-sync` to scope here.
+  ;; self-initialising; the form DRAFT slice is not, so it is seeded with one
+  ;; boot `dispatch-sync` scoped to this frame BEFORE first render — the
+  ;; controlled inputs read `:value` off `[:auth :login-form :draft]`, so the
+  ;; slot must exist as empty strings on the first paint (a nil there would make
+  ;; React treat the inputs as uncontrolled).
   (rf/reg-frame :rf/default
     {:doc          "State-machines walkthrough demo frame."
      :fx-overrides {:rf.http/managed :auth.login/canned-failure}})
+  (rf/dispatch-sync [:auth.login/initialise-form] {:frame :rf/default})
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))


### PR DESCRIPTION
@
## What

Refactors the `state_machine_walkthrough` login form so the email/password **draft moves out of a view-local atom and into an app-db slice**, following Pattern-Forms §Variations (machine + slice). The login state **machine is kept** — it still owns submit/auth status; only the draft leaves the view.

## Why

Example view code must not hold form/UI state in view-local atoms or framework hooks. Form drafts are application state: they belong in app-db, projected via subs and mutated via events. Inputs must be **controlled**.

## Changes

**`core.cljc` — form draft slice (machine + slice variation):**
- `:auth.login/initialise-form` event — seeds `[:auth :login-form :draft]` to `{:email "" :password ""}`.
- `:auth.login/edit-field` event — writes a single draft field in app-db (never view-local state).
- `:auth.login/draft` sub — projects the draft for controlled `:value` reads and the submit read.
- The machine (`:auth.login/flow`), its guards/actions/tags, and the `:auth.login/state` / `:auth.login/error` subs are unchanged.

**`views.cljs` — controlled inputs:**
- Dropped the `(atom {:email "" :password ""})` and the Form-2 outer/inner closure; `login-form` is now a Form-1 view reading subs.
- Inputs are **controlled**: `:value` reads from `:auth.login/draft`; `:on-change` **dispatches** `:auth.login/edit-field` (never sets view-local state).
- Submit reads the draft **from the sub** and hands it to the machine via `[:auth.login/flow [:auth.login/submit draft]]`.
- `run` seeds the draft slice with one boot `dispatch-sync` scoped to the `:rf/default` frame before first render, so the controlled inputs see empty strings (not nil) on first paint.

Machine semantics the chapter teaches (lockout path, tags, headless drain tests) are preserved.

## Gates

- `npm run test:cljs` — 7999 tests / 36798 assertions, **0 failures, 0 errors** (incl. the `state-machine-walkthrough-runs-headless` deftest, which drives the machine directly and is untouched by the slice).
- `npm run test:examples-compile` — all 44 example builds compiled with **0 warnings** (`state-machine-walkthrough` clean).
@