### PR TITLE
Examples: migrate to the one-spot frame-provider {:id} ENSURE form

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -96,15 +96,14 @@
 
 ;; The runtime never synthesises a frame from absence — an app must establish
 ;; its frame explicitly. `init!` installs the adapter (it does NOT create the
-;; frame), `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in the Helix `frame-provider`
-;; — the scope-only provider that threads this already-registered frame's id down
-;; the React tree (the owning `frame-provider` would *create* a frame; we already
-;; own ours). That context is what lets the `use-subscribe` hook and the
-;; render-time `(rf/frame-handle)` capture resolve to the app frame. There is no
-;; `:rf/default` floor: a Helix tree rendered with NO provider observes the
-;; no-provider sentinel and any `use-subscribe` / `frame-handle` raises
-;; `:rf.error/no-frame-context`.
+;; frame); the Helix `frame-provider` does everything else in ONE spot. Given an
+;; `:id`, the provider CREATES the frame on first mount, applies its config, and
+;; runs `:initial-events` exactly once to seed it. On hot reload it REUSES the
+;; existing frame WITHOUT re-seeding, so the count you were looking at survives.
+;; That context is what lets the `use-subscribe` hook and the render-time
+;; `(rf/frame-handle)` capture resolve to the app frame. There is no `:rf/default`
+;; floor: a Helix tree rendered with NO provider observes the no-provider sentinel
+;; and any `use-subscribe` / `frame-handle` raises `:rf.error/no-frame-context`.
 ;;
 ;; `:rf/default` is an ORDINARY frame id with no framework privilege — a
 ;; migration may reach for it out of habit, but the runtime won't infer it.
@@ -113,12 +112,10 @@
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! helix-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:counter/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
     (.render @react-root
-             ($ helix-adapter/frame-provider {:frame app-frame}
+             ($ helix-adapter/frame-provider {:id app-frame
+                                              :initial-events [[:counter/initialise]]}
                 ($ counter-app)))))

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -545,23 +545,28 @@
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the adapter spec once, before the first render — no registry.
   (rf/init! helix-adapter/adapter)
-  (rf/reg-frame :rf/default
-    {:doc          "Login (Helix) demo frame."
-     :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}})
-  ;; No `dispatch-sync` seed here (unlike counter / dashboard): the
-  ;; machine handler is self-initialising — its `:initial`/`:data` seed
-  ;; [:rf.runtime/machines :snapshots :auth.login/flow] when the flow first runs (per
-  ;; Spec 005 §Restore semantics), so no separate :initialise is needed.
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
-    ;; Wrap the render in the Helix `frame-provider` so the `use-subscribe` hook
-    ;; + the render-time `(rf/frame-handle)` capture in `login-form` resolve to
-    ;; `:rf/default` via React context. With NO provider the tree observes the
-    ;; no-provider sentinel and those reads raise `:rf.error/no-frame-context`
-    ;; (there is no `:rf/default` floor).
+    ;; Wrap the render in the Helix `frame-provider` ENSURE shape (`{:id …}`):
+    ;; one spot CREATES `:rf/default` on first mount, applies the frame config
+    ;; (`:doc` + the managed-HTTP `:fx-overrides`), and REUSES the same frame on
+    ;; hot reload WITHOUT re-running setup — so the demo's state survives a
+    ;; reload. No `:initial-events`: the machine handler is self-initialising —
+    ;; its `:initial`/`:data` seed [:rf.runtime/machines :snapshots
+    ;; :auth.login/flow] when the flow first runs (per Spec 005 §Restore
+    ;; semantics), so there is nothing to seed here.
+    ;;
+    ;; The provider also gives the `use-subscribe` hook + the render-time
+    ;; `(rf/frame-handle)` capture in `login-form` a frame to resolve to via
+    ;; React context. With NO provider the tree observes the no-provider
+    ;; sentinel and those reads raise `:rf.error/no-frame-context` (there is no
+    ;; `:rf/default` floor).
     (.render @react-root
-             ($ helix-adapter/frame-provider {:frame :rf/default}
+             ($ helix-adapter/frame-provider
+                {:id           :rf/default
+                 :doc          "Login (Helix) demo frame."
+                 :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}}
                 ($ root-view)))))

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -341,26 +341,27 @@
 
 ;; The runtime never synthesises a frame from absence — an app must establish
 ;; its frame explicitly. `init!` installs the adapter (it does NOT create the
-;; frame), `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in the Helix `frame-provider` so the
-;; `use-subscribe` hook and the render-time `(rf/frame-handle)` capture inside
-;; `monitor` (the tick-loop arm/stop dispatches) resolve to the app frame via
-;; React context. There is no `:rf/default` floor.
+;; frame). The Helix `frame-provider` does the rest in one spot: the `{:id …}`
+;; ENSURE form CREATES the app frame on first mount, then runs `:initial-events`
+;; ONCE to seed it. On hot reload it REUSES the existing frame without
+;; re-seeding. The `use-subscribe` hook and the render-time `(rf/frame-handle)`
+;; capture inside `monitor` (the tick-loop arm/stop dispatches) resolve to that
+;; frame via React context. There is no `:rf/default` floor.
 (def app-frame :rf/default)
 
 (defn run []
   (rf/init! helix-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  ;; Seed synchronously so the very first paint shows a populated UI rather
-  ;; than a flash of empty panes. This also arms the first tick; the `monitor`
-  ;; component's mount `use-effect` re-arms (idempotently, via the
-  ;; `:process-monitor/tick-gen` guard) so the loop is owned by the component
-  ;; lifecycle from then on — unmount stops it (see `:process-monitor/stop`).
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:process-monitor/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
+    ;; One-spot frame setup: `{:id app-frame}` ensures the frame exists (creating
+    ;; it on first mount) and `:initial-events` seeds it exactly once. The seed
+    ;; arms the first tick; the `monitor` component's mount `use-effect` re-arms
+    ;; (idempotently, via the `:process-monitor/tick-gen` guard) so the loop is
+    ;; owned by the component lifecycle from then on — unmount stops it (see
+    ;; `:process-monitor/stop`). Reuse-no-reseed on reload keeps the running
+    ;; clock/logs intact across hot reloads.
     (.render @react-root
-             ($ helix-adapter/frame-provider {:frame app-frame}
+             ($ helix-adapter/frame-provider {:id app-frame
+                                              :initial-events [[:process-monitor/initialise]]}
                 ($ monitor)))))

--- a/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
@@ -17,11 +17,13 @@
 
    The boot is NOT re-copied here: this entry calls the shared
    `counter-slim-and-fast.core/boot!` (the single source of truth for the
-   boot — same adapter, frame, boot dispatch, lazy client mount), so the
-   gate-owned path cannot drift from the teaching `core/run`. The one fixture
-   concern is the `on-frame` pre-mount hook `boot!` accepts: the pure-CLJS
-   `render-to-static-markup` exercise runs under the frame scope, before the
-   client mount, so the static render's orphaned SSR subscription is torn down
+   boot — install the slim adapter, then mount under a
+   `frame-provider {:id …}` that creates + seeds the app frame in one spot),
+   so the gate-owned path cannot drift from the teaching `core/run`. The one
+   fixture concern is the `on-frame` pre-mount hook `boot!` accepts: the
+   pure-CLJS `render-to-static-markup` exercise runs in a TRANSIENT frame
+   scope `boot!` opens for it, before the client mount, so the static
+   render's orphaned SSR subscription is torn down
    (fixture/prove-pure-cljs-ssr! clears the sub-cache) and the browser mount
    owns the only live `[:counter/value]` reaction."
   (:require [re-frame.views]
@@ -30,14 +32,16 @@
 
 (defn run []
   ;; Delegate to the ONE canonical boot in `core/boot!` (init the slim adapter,
-  ;; register the app frame, dispatch the boot event under the frame scope, then
-  ;; lazily mount). There is no copied boot sequence to drift from `core/run`.
-  ;; The only fixture concern is woven in via the `on-frame` pre-mount hook:
+  ;; then lazily mount under a `frame-provider {:id …}` that creates + seeds the
+  ;; app frame in one spot). There is no copied boot sequence to drift from
+  ;; `core/run`. The only fixture concern is woven in via the `on-frame`
+  ;; pre-mount hook:
   ;;
   ;; Bundle-isolation fixture, not app practice. The static render derefs
-  ;; `[:counter/value]`, so it must run inside the frame scope `boot!` opens; it
-  ;; caches an orphaned reaction with no component to unmount it, so the fixture
-  ;; clears the sub-cache in a `finally`. `boot!` runs the hook before the client
-  ;; mount, so the browser mount starts from a clean sub-cache and owns the only
-  ;; live `[:counter/value]` reaction.
+  ;; `[:counter/value]`, so it must run inside a frame scope; `boot!` opens a
+  ;; transient one for the hook (before the client mount). It caches an orphaned
+  ;; reaction with no component to unmount it, so the fixture clears the
+  ;; sub-cache in a `finally`. Because the hook runs before the client mount,
+  ;; the browser mount starts from a clean sub-cache and owns the only live
+  ;; `[:counter/value]` reaction.
   (core/boot! #(fixture/prove-pure-cljs-ssr! [core/counter-app])))

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -90,49 +90,60 @@
 (defonce react-root (atom nil))
 
 ;; The runtime never synthesises a frame from absence — an app must
-;; establish its frame explicitly. `init!` installs the adapter (it does
-;; NOT create the frame), `reg-frame` registers the app frame, the boot
-;; dispatch runs under `with-frame`, and the client render is wrapped in
-;; `frame-provider` so every in-tree `dispatch`/`subscribe`
-;; resolves to the app frame. `frame-provider` is the scope-only
-;; sibling — it provides the ALREADY-registered frame; the lifecycle-owning
-;; `frame-provider` (which would create a frame on mount) is deliberately
-;; not used, since `reg-frame` already established it. Matches the canonical
-;; mount in examples/reagent/counter/core.cljs.
+;; establish its frame explicitly. So the boot below does two things in
+;; order: `init!` installs the adapter (it does NOT create the frame),
+;; then the render's `frame-provider {:id app-frame}` does the rest in
+;; one spot — on first mount it CREATES the app frame, applies its
+;; config, and runs `:initial-events` once to seed it (the
+;; `[:counter/initialise]` boot dispatch); thereafter every in-tree
+;; `dispatch`/`subscribe` resolves to that frame. On hot reload the
+;; provider REUSES the existing frame and does NOT re-seed. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
+;;
+;; `:rf/default` is an ORDINARY frame id with no framework privilege — a
+;; migration may reach for it out of habit, but the runtime won't infer
+;; it; you establish it like any other.
 (def app-frame :rf/default)
 
 (defn boot!
   "The one canonical boot sequence for this example: install the slim
-   adapter, register the app frame, dispatch the boot event under the frame
-   scope, then lazily mount `counter-app` into `#app` under a
-   `frame-provider` (the scope-only sibling — `reg-frame` already
-   created the frame, so the mount only re-scopes into it, not re-creates it).
+   adapter, then lazily mount `counter-app` into `#app` under a
+   `frame-provider {:id app-frame …}`. The whole frame is established in
+   that one spot — on first mount the provider CREATES the app frame,
+   applies its config, and runs `:initial-events` once to seed it; on hot
+   reload it REUSES the existing frame and does NOT re-seed.
 
    `boot!` is the single source of truth for the boot so the teaching path
    (`run` below) and the gate-owned path
    (`counter-slim-and-fast.bundle-isolation-entry/run`) cannot drift: both
    call this fn, so a future EP/API boot change is made in one place.
 
-   `on-frame` is an optional thunk run inside the `with-frame` scope, after
-   the boot dispatch and before the client mount. The teaching `run` passes
-   nothing; only the bundle-isolation entry uses it, to weave its pure-CLJS
-   SSR exercise into the frame scope at the one point its ordering requires.
-   Keeping the seam here — rather than re-copying the boot in the entry — is
-   what keeps `core` free of fixture plumbing while preventing drift."
+   `on-frame` is an optional thunk run in a TRANSIENT frame scope, before
+   the client mount. The teaching `run` passes nothing; only the
+   bundle-isolation entry uses it, to weave its pure-CLJS SSR exercise into
+   a frame scope at the one point its ordering requires. The exercise is a
+   throwaway static render, so it gets its own short-lived frame
+   (`with-new-frame`, auto-destroyed on exit) rather than touching the app
+   frame the provider creates at mount. Keeping the seam here — rather than
+   re-copying the boot in the entry — is what keeps `core` free of fixture
+   plumbing while preventing drift."
   ([] (boot! nil))
   ([on-frame]
    ;; Slim adapter — the difference from `examples/reagent/counter` is
    ;; right here. Same `rf/init!` signature; different adapter Var.
    (rf/init! reagent-slim-adapter/adapter)
-   (rf/reg-frame app-frame {})
-   (rf/with-frame app-frame
-     (rf/dispatch-sync [:counter/initialise])
-     (when on-frame (on-frame)))
+   (when on-frame
+     ;; Fixture-only seam: scope the pre-mount SSR exercise to a throwaway
+     ;; frame (destroyed on exit) so it never touches the app frame the
+     ;; provider creates below.
+     (rf/with-new-frame [_ (rf/make-frame {})]
+       (on-frame)))
    (when (exists? js/document)
      (when-not @react-root
        (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
      (rdc/render @react-root
-                 [rf/frame-provider {:frame app-frame}
+                 [rf/frame-provider {:id app-frame
+                                     :initial-events [[:counter/initialise]]}
                   [counter-app]]))))
 
 (defn run []

--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -416,9 +416,9 @@
   {:doc "Top-level app boot. Fires the :app/boot machine's
          `:rf.machine/start` creation marker to kick the boot sequence
          off — the machine is born directly into `:configuring` and runs
-         its `:spawn` entry-cascade. The app dispatches this event under
-         `with-frame` at boot (see core.cljs); a frame could equally point
-         its `:initial-events` at it."}
+         its `:spawn` entry-cascade. The app seeds this event via the
+         render-root `frame-provider`'s `:initial-events` (see core.cljs),
+         which runs it once on first mount."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:app/boot [:rf.machine/start]]]]}))
 

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -138,41 +138,40 @@
 
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. This example uses `:rf/default` as its app frame id:
-;; `init!` installs the adapter (it does NOT create the frame), `reg-frame`
-;; registers the app frame, the boot dispatch runs under `with-frame`, and
-;; the render is wrapped in a `frame-provider` so every in-tree
-;; `dispatch`/`subscribe` resolves to the app frame.
+;; explicitly. This example uses `:rf/default` as its app frame id.
+;; `init!` installs the adapter (it does NOT create the frame); the
+;; render root then establishes the frame in one spot via the
+;; `frame-provider` ENSURE form (`{:id app-frame …}`): on first mount
+;; it CREATES the frame, applies the config, and runs `:initial-events`
+;; once; on hot reload it REUSES the existing frame without re-seeding.
+;; Every in-tree `dispatch`/`subscribe` resolves to that frame.
 (def app-frame :rf/default)
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
 
-  ;; Override `:rf.http/managed` on the default frame so every child
-  ;; loader's GET routes to the per-URL canned stub above. The
-  ;; override applies frame-wide; the boot example doesn't issue any
-  ;; non-mocked requests, so a blanket override is the right grain.
-  (rf/reg-frame app-frame
-    {:doc          "Boot example demo frame."
-     :fx-overrides {:rf.http/managed :boot.demo/http-stub}})
-
-  ;; Kick the boot under `with-frame` so the boot dispatch resolves to
-  ;; the app frame (a bare dispatch-sync would raise
-  ;; :rf.error/no-frame-context under the carried invariant). The
-  ;; `:app/boot` machine's :initial state and :data seed
-  ;; `[:rf.runtime/machines :snapshots :app/boot]` (runtime-db) on the
-  ;; eager creation kick (per Spec 005 §When creation happens — eager
-  ;; start vs lazy first event); :boot/initialise fires
-  ;; `[:app/boot [:rf.machine/start]]`, the creation marker that births
-  ;; the machine directly into :configuring and runs its :spawn
-  ;; entry-cascade, starting the boot sequence.
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:boot/initialise]))
-
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    ;; ENSURE form: create + configure + seed the app frame in one
+    ;; place. `:fx-overrides` redirects `:rf.http/managed` on the frame
+    ;; so every child loader's GET routes to the per-URL canned stub
+    ;; above (frame-wide; the boot example issues no non-mocked
+    ;; requests, so a blanket override is the right grain).
+    ;;
+    ;; `:initial-events` seeds the boot exactly once on first mount.
+    ;; The `:app/boot` machine's :initial state and :data seed
+    ;; `[:rf.runtime/machines :snapshots :app/boot]` (runtime-db) on the
+    ;; eager creation kick (per Spec 005 §When creation happens — eager
+    ;; start vs lazy first event); :boot/initialise fires
+    ;; `[:app/boot [:rf.machine/start]]`, the creation marker that births
+    ;; the machine directly into :configuring and runs its :spawn
+    ;; entry-cascade, starting the boot sequence. On hot reload the frame
+    ;; is reused and the boot does NOT re-run.
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id             app-frame
+                                    :doc            "Boot example demo frame."
+                                    :fx-overrides   {:rf.http/managed :boot.demo/http-stub}
+                                    :initial-events [[:boot/initialise]]}
                  [boot.views/root-view]])))

--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -181,9 +181,10 @@
 ;; a bare ns-load call under no scope raises `:rf.error/no-frame-context`
 ;; (boot-time namespace loading is NOT a reason to synthesise `:rf/default`,
 ;; per Spec 002 §Frame target resolution). This example's app runs in the
-;; `:rf/default` frame (see `core/run`, which `reg-frame`s it explicitly),
-;; so name the frame explicitly here via `with-frame` — the registrations
-;; carry a frame stamp even though they land at module-load before `init!`.
+;; `:rf/default` frame (see `core/run`, whose render-root `frame-provider`
+;; establishes it via the `{:id …}` ENSURE form), so name the frame
+;; explicitly here via `with-frame` — the registrations carry a frame
+;; stamp even though they land at module-load before `init!`.
 (with-frame :rf/default
   ;; The :spawn-all children stage their payloads into [:boot/staging]
   ;; before signalling completion to the parent. The :enter-hydrating

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -4,6 +4,10 @@
    one subscription, one view, dispatched in a single explicitly-
    established frame.
 
+   The whole frame is established in one spot: the render root's
+   `frame-provider {:id …}` creates the app frame, configures it, and
+   runs its `:initial-events` seed once.
+
    Demonstrates: `reg-event`, `reg-sub`, `reg-view` with frame-bound
    `dispatch`/`subscribe` injection."
   (:require [reagent.dom.client :as rdc]
@@ -39,9 +43,10 @@
 ;; Per Spec 004 §reg-view, the defn-shape macro auto-injects `dispatch`
 ;; and `subscribe` as lexical bindings (so they aren't imported here);
 ;; both resolve at render time to the frame in scope — see the boot
-;; below, which scopes this tree to `app-frame`. The macro also auto-defs
-;; a Var named after the supplied symbol and registers the view under
-;; (keyword *ns* sym), so `counter-app` can reference it directly.
+;; below, where `frame-provider {:id app-frame}` scopes this tree to the
+;; app frame. The macro also auto-defs a Var named after the supplied
+;; symbol and registers the view under (keyword *ns* sym), so
+;; `counter-app` can reference it directly.
 
 (reg-view counter-buttons []
   [:div
@@ -50,8 +55,8 @@
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
 ;; The root `counter-app` view just renders `counter-buttons`; the boot
-;; in `run` scopes the whole tree to `app-frame` and seeds it via
-;; `dispatch-sync`.
+;; in `run` scopes the whole tree to `app-frame` and seeds it via the
+;; provider's `:initial-events`.
 
 (reg-view counter-app []
   [counter-buttons])
@@ -66,15 +71,17 @@
 (defonce react-root (atom nil))
 
 ;; The runtime never synthesises a frame from absence — an app must
-;; establish its frame explicitly. So the boot below does four things in
+;; establish its frame explicitly. So the boot below does two things in
 ;; order: `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in `frame-provider`
-;; so every in-tree `dispatch`/`subscribe` resolves to the app frame.
+;; then the render's `frame-provider {:id app-frame}` does the rest in
+;; one spot — on first mount it CREATES the app frame, applies its
+;; config, and runs `:initial-events` once to seed it; thereafter every
+;; in-tree `dispatch`/`subscribe` resolves to that frame. On hot reload
+;; the provider REUSES the existing frame and does NOT re-seed.
 ;;
 ;; `:rf/default` is an ORDINARY frame id with no framework privilege — a
 ;; migration may reach for it out of habit, but the runtime won't infer
-;; it; you register it like any other.
+;; it; you establish it like any other.
 (def app-frame :rf/default)
 
 (defn run []
@@ -82,12 +89,10 @@
   ;; ns exports an `adapter` var; consumers require the ns and pass the
   ;; var explicitly. There is no default-adapter registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:counter/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:counter/initialise]]}
                  [counter-app]])))

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -297,25 +297,26 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; EP-0002: the runtime never synthesises a frame from absence —
-;; register the app frame explicitly, seed under `with-frame`, and wrap the
-;; render in a `frame-provider` so the `reg-view`-injected `dispatch`/`subscribe`
-;; resolve to it (a no-provider render reads the no-provider sentinel and raises
+;; EP-0002: the runtime never synthesises a frame from absence. The
+;; `frame-provider` ENSURE shape (`{:id …}`) does the whole job at the render
+;; root in one spot: on first mount it CREATES the frame, then runs its
+;; `:initial-events` ONCE to seed it (here `[:cart/initialise]`); on hot reload
+;; it REUSES the existing frame WITHOUT re-seeding. Wrapping the render also
+;; makes the `reg-view`-injected `dispatch`/`subscribe` resolve to that frame
+;; (a no-provider render reads the no-provider sentinel and raises
 ;; :rf.error/no-frame-context). The frame id is `:rf/default` — the same id the
 ;; ns-load `with-frame` flow registrations are scoped to above. (Note that
 ;; `:rf/default` is an ordinary frame id with no framework privilege; `init!`
-;; never creates it for you, which is why `reg-frame` below is explicit.)
+;; never creates it for you, which is why the provider names the id here.)
 (def app-frame :rf/default)
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:cart/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:cart/initialise]]}
                  [cart-app]])))

--- a/examples/reagent/infinite_feed/core.cljs
+++ b/examples/reagent/infinite_feed/core.cljs
@@ -337,11 +337,16 @@
 ;; ============================================================================
 ;;
 ;; The React root is materialised lazily inside `run` (not at ns-load) per
-;; examples/TESTING.md §Example mount-isolation convention. EP-0002: the app
-;; establishes its frame explicitly (`reg-frame`), declares `:url-bound? true`
-;; so it owns the browser URL, overrides `:rf.http/managed` with the per-cursor
-;; canned stub (the example runs standalone), and wraps the render in a
-;; `frame-provider` so every in-tree dispatch/subscribe resolves to it.
+;; examples/TESTING.md §Example mount-isolation convention. EP-0002 + EP-0024:
+;; the app establishes its frame in ONE spot — the render-root
+;; `frame-provider {:id …}` ENSURE shape. On first mount it CREATES the
+;; `app-frame`, applies its config (declares `:url-bound? true` so it owns the
+;; browser URL, overrides `:rf.http/managed` with the per-cursor canned stub so
+;; the example runs standalone), and scopes that frame so every in-tree
+;; dispatch/subscribe resolves to it. On hot reload it REUSES the same frame
+;; without re-creating it. There is no separate `reg-frame` step and no boot
+;; seed: route entry's `:resources` plan ensures PAGE 0, so the feed needs no
+;; `:initial-events`.
 
 (defonce react-root (atom nil))
 
@@ -349,14 +354,16 @@
 
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame
-    {:doc          "Infinite-feed demo frame."
-     :url-bound?   true
-     :fx-overrides {:rf.http/managed :infinite-feed.demo/http-stub}})
   (rf/install-history-listener!)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    ;; ENSURE shape (EP-0024): CREATE the app frame on first mount with its
+    ;; config, REUSE it on hot reload without re-seeding. The route's
+    ;; `:resources` plan ensures PAGE 0, so there are no `:initial-events`.
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id           app-frame
+                                    :doc          "Infinite-feed demo frame."
+                                    :url-bound?   true
+                                    :fx-overrides {:rf.http/managed :infinite-feed.demo/http-stub}}
                  [root-view]])))

--- a/examples/reagent/linearlite/core.cljs
+++ b/examples/reagent/linearlite/core.cljs
@@ -602,10 +602,18 @@
 ;;
 ;; The React root is materialised lazily inside `run` (not at ns-load) per
 ;; examples/TESTING.md §Example mount-isolation convention. EP-0002: the app
-;; establishes its frame explicitly (`reg-frame`), declares `:url-bound? true`
-;; so it owns the browser URL, overrides `:rf.http/managed` with the canned
-;; board stub (the example runs standalone), and wraps the render in a
-;; `frame-provider` so every in-tree dispatch/subscribe resolves to it.
+;; frame is created, configured, and provided in ONE spot — the render root's
+;; `frame-provider {:id app-frame …}` ENSURE form. On first mount it creates the
+;; frame under `app-frame`, applies the config (`:url-bound? true` so it owns the
+;; browser URL, and a `:rf.http/managed` override pointing at the canned board
+;; stub so the example runs standalone), and would run any `:initial-events`
+;; once. On hot reload it REUSES the existing frame WITHOUT re-seeding, so app-db
+;; survives the reload. That id is what every in-tree dispatch/subscribe resolves
+;; against — no separate `reg-frame` or `{:frame …}` scope step.
+;;
+;; There are NO `:initial-events`: the board isn't seeded at boot but ensured on
+;; route entry by the `:linearlite.app/board` route's `:resources` metadata,
+;; driven by the initial URL sync that `rf/install-history-listener!` performs.
 
 (defonce react-root (atom nil))
 
@@ -613,14 +621,15 @@
 
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame
-    {:doc          "Linearlite optimistic-board demo frame."
-     :url-bound?   true
-     :fx-overrides {:rf.http/managed :linearlite.demo/http-stub}})
   (rf/install-history-listener!)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    ;; ENSURE form: create + configure the app frame in one spot. First mount
+    ;; creates it under `app-frame` and applies the config; hot reload reuses it.
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id           app-frame
+                                    :doc          "Linearlite optimistic-board demo frame."
+                                    :url-bound?   true
+                                    :fx-overrides {:rf.http/managed :linearlite.demo/http-stub}}
                  [root-view]])))

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -666,27 +666,32 @@
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  ;; Install the demo override so `:rf.http/managed` calls route to the
-  ;; in-process login stub above. The example runs standalone — no
-  ;; backend required.
-  (rf/reg-frame :rf/default
-    {:doc          "Login demo frame."
-     :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}})
-  ;; Seed the login-form slice to its empty Pattern-Forms shape so the
-  ;; controlled inputs read a real (empty-string) draft from the first render
-  ;; — an uninitialised draft would feed React `nil` :values (uncontrolled
-  ;; inputs). The machine is self-initialising (no seed needed); the SLICE is
-  ;; app-db, so it is seeded explicitly here under the app frame.
-  (rf/with-frame :rf/default
-    (rf/dispatch-sync [:auth.login/initialise-form]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; EP-0002: wrap the render in a `frame-provider` so the
+    ;; EP-0026: one-spot frame setup via the `frame-provider` ENSURE shape
+    ;; (`{:id …}`). On first mount it CREATES `:rf/default`, applies the
+    ;; config below, and runs `:initial-events` ONCE; on hot reload it REUSES
+    ;; the existing frame WITHOUT re-seeding. No separate `reg-frame` /
+    ;; `with-frame` boot step.
+    ;;
+    ;; - `:fx-overrides` routes `:rf.http/managed` to the in-process login
+    ;;   stub above so the example runs standalone — no backend required.
+    ;; - `:initial-events` seeds the login-form slice to its empty
+    ;;   Pattern-Forms shape so the controlled inputs read a real
+    ;;   (empty-string) draft from the first render — an uninitialised draft
+    ;;   would feed React `nil` :values (uncontrolled inputs). The machine is
+    ;;   self-initialising (no seed needed); the SLICE is app-db, so it is
+    ;;   seeded here.
+    ;;
+    ;; The provider also scopes the frame into React so the
     ;; `reg-view`-injected `dispatch`/`subscribe` (and the login machine reads)
-    ;; resolve to `:rf/default` via React context. With NO provider a `reg-view`
+    ;; resolve to `:rf/default` via context. With NO provider a `reg-view`
     ;; reads the no-provider sentinel and those calls raise
     ;; `:rf.error/no-frame-context` (there is no `:rf/default` floor).
     (rdc/render @react-root
-                [rf/frame-provider {:frame :rf/default}
+                [rf/frame-provider {:id             :rf/default
+                                    :doc            "Login demo frame."
+                                    :fx-overrides   {:rf.http/managed :auth.login.demo/managed-stub}
+                                    :initial-events [[:auth.login/initialise-form]]}
                  [root-view]])))

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -102,26 +102,23 @@
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
 ;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in `frame-provider` so
-;; every in-tree `dispatch`/`subscribe` resolves to the app frame (it scopes
-;; the subtree to the frame `reg-frame` already created; it creates nothing).
-;; Matches the
-;; canonical mount in examples/reagent/counter/core.cljs. The work-bench
-;; wrapper's `r/with-let` cleanup (views.cljs) dispatches `[:work/flow
-;; [:cancel]]` from within render scope, so it resolves to this frame via
-;; the provider above.
+;; then `frame-provider {:id app-frame …}` does the rest in one spot: on
+;; first mount it CREATES the app frame, applies its config, and runs
+;; `:initial-events` (the `[:app/initialise]` boot dispatch) ONCE; on hot
+;; reload it REUSES the same frame WITHOUT re-seeding. Every in-tree
+;; `dispatch`/`subscribe` resolves to that frame. Matches the canonical
+;; mount in examples/reagent/counter/core.cljs. The work-bench wrapper's
+;; `r/with-let` cleanup (views.cljs) dispatches `[:work/flow [:cancel]]`
+;; from within render scope, so it resolves to this frame via the provider.
 (def app-frame :rf/default)
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:app/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:app/initialise]]}
                  [views/root-view]])))

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -344,10 +344,12 @@
 
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in a `frame-provider`
-;; so every in-tree `dispatch`/`subscribe` resolves to the app frame.
+;; explicitly. `init!` installs the adapter (it does NOT create the frame).
+;; The render root then wraps the tree in a `frame-provider` keyed by
+;; `:id`: that one spot creates the app frame on first mount, applies its
+;; config, runs `:initial-events` once (the `[:counter/initialise]` seed),
+;; and on hot reload reuses the existing frame without re-seeding — so
+;; every in-tree `dispatch`/`subscribe` resolves to the app frame.
 ;; `:rf/default` is an ordinary frame id with no framework privilege —
 ;; just the name this app chose. Matches the canonical mount in
 ;; examples/reagent/counter/core.cljs.
@@ -356,12 +358,10 @@
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:counter/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:counter/initialise]]}
                  [counter-app]])))

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -136,7 +136,8 @@
 
 ;; EP-0002: reg-app-schema is context-required frame-local; a
 ;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (see `run`/`reg-frame :rf/default`), so name it explicitly.
+;; :rf/default (the same id `run`'s `frame-provider {:id …}` ENSURES), so
+;; name it explicitly here.
 (with-frame :rf/default
   (rf/reg-app-schema [:new-todo] {:schema NewTodoSlice}))
 
@@ -731,22 +732,31 @@
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  ;; Install the demo override so `:rf.http/managed` calls route to the
-  ;; in-process canned-stub fxs above. The example runs standalone — no
-  ;; backend required.
   ;; EP-0002: the runtime never synthesises a frame from absence —
-  ;; register the app frame explicitly, seed under `with-frame`, and wrap the
-  ;; render in a `frame-provider` so the `reg-view`-injected
-  ;; `dispatch`/`subscribe` resolve to it (a no-provider render reads the
-  ;; no-provider sentinel and raises :rf.error/no-frame-context).
-  (rf/reg-frame :rf/default
-    {:doc          "Nine-states demo frame."
-     :fx-overrides {:rf.http/managed :nine-states.http/managed-demo}})
-  (rf/with-frame :rf/default
-    (rf/dispatch-sync [:nine-states.app/initialise]))
+  ;; the app must establish its frame explicitly. `init!` installs the
+  ;; adapter only (it does NOT create the frame).
+  ;;
+  ;; EP-0026: one-spot frame setup via the `frame-provider` ENSURE shape
+  ;; (`{:id …}`). On first mount it CREATES `:rf/default`, applies the config
+  ;; below, and runs `:initial-events` ONCE; on hot reload it REUSES the
+  ;; existing frame WITHOUT re-seeding. Create, seed, and scope-into-React all
+  ;; happen in that one spot — no separate `reg-frame` / `with-frame` boot step.
+  ;;
+  ;; - `:fx-overrides` routes `:rf.http/managed` to the in-process canned-stub
+  ;;   fxs above so the example runs standalone — no backend required.
+  ;; - `:initial-events` seeds the app via `[:nine-states.app/initialise]`.
+  ;;
+  ;; The provider also scopes the frame into React so the `reg-view`-injected
+  ;; `dispatch`/`subscribe` (and `root-view`'s subs) resolve to `:rf/default`
+  ;; via context. With NO provider a `reg-view` reads the no-provider sentinel
+  ;; and those calls raise `:rf.error/no-frame-context`. The frame id is the
+  ;; same `:rf/default` that `reg-app-schema` is scoped to at ns-load above.
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame :rf/default}
+                [rf/frame-provider {:id             :rf/default
+                                    :doc            "Nine-states demo frame."
+                                    :fx-overrides   {:rf.http/managed :nine-states.http/managed-demo}
+                                    :initial-events [[:nine-states.app/initialise]]}
                  [root-view]])))

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -349,23 +349,21 @@
 
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in `frame-provider`
-;; (the frame already exists, so the provider just threads its id down —
-;; it does not create one) so every in-tree `dispatch`/`subscribe`
-;; resolves to the app frame. Matches the canonical mount in
-;; examples/reagent/counter/core.cljs.
+;; explicitly. `init!` installs the adapter (it does NOT create the frame).
+;; The render root then establishes the app frame in ONE spot: the
+;; `frame-provider` `{:id …}` ENSURE form creates the frame on first mount,
+;; runs `:initial-events` once to seed app-db before the first paint, and on
+;; hot reload reuses the same frame WITHOUT re-seeding. Every in-tree
+;; `dispatch`/`subscribe` then resolves to that frame. Matches the canonical
+;; mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:notebook/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:notebook/initialise]]}
                  [notebook]])))

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -3,9 +3,10 @@
 
    Wires the app together:
    - Pulls in every feature namespace (each registers its own events/subs/fx).
-   - Defines :app/initialise (the boot event, dispatched under with-frame).
+   - Defines :app/initialise (the boot event, run via the frame's :initial-events).
    - Defines the root-view that switches on :rf.route/id.
-   - Mounts the React root and installs the URL listener.
+   - Mounts the React root (the `frame-provider {:id …}` ENSURE form creates +
+     seeds the app frame in one spot) and installs the URL listener.
 
    This is single-file glue; the per-feature work lives in:
      auth.cljs             — login / register / session-restore
@@ -512,8 +513,9 @@
   ;; Override :rf.http/managed on the default frame so all the realworld
   ;; feature HTTP calls land on the demo stub (no real backend required).
   ;; The auth-guard interceptor (registered in routing.cljs via
-  ;; `reg-interceptor` and referenced here BY ID per EP-0022) is prepended to
-  ;; every event in this frame (Spec 002 §reg-frame :interceptors) — it short-circuits
+  ;; `reg-interceptor` and referenced BY ID per EP-0022 in the provider's
+  ;; `:interceptors` below) is prepended to
+  ;; every event in this frame (Spec 002 §`:interceptors`) — it short-circuits
   ;; for all non-navigation events and redirects unauthenticated
   ;; `:rf.route/navigate` to `:requires-auth`-tagged routes to login (Spec
   ;; 012 §Redirects and guards). This is what makes the `:requires-auth`
@@ -522,13 +524,16 @@
   ;; EP-0002: the runtime never synthesises a frame
   ;; from absence, and URL ownership is an EXPLICIT declaration — this frame
   ;; carries `:url-bound? true` so it owns the browser URL (Spec 012
-  ;; §Multi-frame routing). The boot dispatch runs under `with-frame` and the
-  ;; render is wrapped in a `frame-provider` below.
+  ;; §Multi-frame routing). The frame is CREATED, configured, and SEEDED in ONE
+  ;; spot: the `frame-provider {:id …}` ENSURE form at the render root below.
+  ;; First mount creates `:rf/default`, applies this config, and runs
+  ;; `:initial-events` once; hot reload REUSES the frame WITHOUT re-seeding
+  ;; (durable app-db survives; `:initial-events` are re-recorded, not replayed).
   ;; EP-0025 (durable egress classification): the JWT lives at [:auth :token]
   ;; in app-db, so that path is classified `:sensitive`. Classification rides
-  ;; the commit-plane `:sensitive` effect (`:auth/classify-token`, run from the
-  ;; frame's `:initial-events` at frame creation, before any boot dispatch or
-  ;; off-box egress). Projection happens at the trust boundary, so any off-box
+  ;; the commit-plane `:sensitive` effect (`:auth/classify-token`, the FIRST of
+  ;; the frame's `:initial-events` at frame creation, before the session-restore
+  ;; token write and any off-box egress). Projection happens at the trust boundary, so any off-box
   ;; egress — Xray/observability capture, an off-box tool, an SSR hydration
   ;; payload — sees the token redacted while on-box rendering (the navbar, the
   ;; live header the request actually sends) keeps the raw value.
@@ -545,44 +550,65 @@
   ;; password draft is transient form state, owned by its registration, not a
   ;; durable frame fact (and is never sent off-box from app-db). This is the
   ;; canonical issue-5 case from the EP, surfaced only where the data is real.
-  (rf/reg-frame :rf/default {:doc             "Realworld demo frame."
-                             :url-bound?      true
-                             :initial-events  [[:auth/classify-token]]
-                             :interceptors    [:realworld.routing/auth-guard]
-                             :fx-overrides    {:rf.http/managed :realworld.demo/http-stub}})
   ;; Register the Bearer-auth interceptor at app boot. Order matters:
-  ;; before :app/initialise dispatches, since session-restore will fire
+  ;; before the frame's `:initial-events` run, since session-restore will fire
   ;; authenticated requests as soon as the JWT is hydrated.
   (rf/reg-http-interceptor :realworld/bearer-auth
                            {:before bearer-auth-interceptor})
   ;; The orchestrator serves this example at /realworld/; strip that
   ;; prefix before the route matcher sees the URL so :realworld/home (path "/")
-  ;; matches.
+  ;; matches. Set before the ENSURE provider renders so the `:initial-events`
+  ;; URL sync (below) and the popstate listener see the stripped URL.
   (routing/set-base-path! "/realworld")
-  (rf/with-frame :rf/default
-    ;; EP-0017: session restore consumes the RECORDABLE-GENERATOR
-    ;; `:auth.session/token` coeffect and folds it into durable [:auth :token].
-    ;; The dispatch is PLAIN — it carries no `:rf.cofx` (a production dispatch
-    ;; never stamps a coeffect; that is a unit-test stub seam). The registered
-    ;; generator (auth.cljs) reads localStorage ONCE at processing-start; its
-    ;; value rides this boot dispatch token as the flat recordable coeffect, so
-    ;; it is recorded and replay / epoch-restore re-presents the captured token
-    ;; verbatim rather than re-reading localStorage then. It is dispatched here
-    ;; directly (not via the `:app/initialise` `:dispatch` fan-out, which does
-    ;; not forward `:rf.cofx`), and BEFORE `:app/initialise` so the token is in
-    ;; app-db before the bearer-auth interceptor fires any authenticated request.
-    (rf/dispatch-sync [:auth/initialise])
-    (rf/dispatch-sync [:app/initialise])
-    ;; install-router! does the initial URL→slice sync (a dispatch-sync) and
-    ;; wires the popstate listener; the sync runs under the frame scope, and
-    ;; the listener captures the URL owner per dispatch (see routing.cljs).
-    (routing/install-router!))
+  ;; Wire the popstate listener for Back/Forward (Spec 012 §popstate drives the
+  ;; URL owner). This example serves from a `/realworld/` sub-path and strips it
+  ;; in `current-url`, so it keeps its own base-path-aware listener rather than
+  ;; the framework's `rf/install-history-listener!`. The listener targets the
+  ;; URL owner resolved AT POP TIME and is idempotent (hot-reload safe). The
+  ;; INITIAL URL→slice sync is seeded once via the frame's `:initial-events`
+  ;; (`:rf.route/handle-url-change` below), which run synchronously at frame
+  ;; creation — so a deep link lands on the right route on first paint without
+  ;; depending on React's render-flush timing.
+  (routing/install-router!)
   ;; Conformance-contract surface — NOT a re-frame2 pattern; see
   ;; install-conduit-debug! above. The external RealWorld suite may read it.
   (install-conduit-debug! :rf/default)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    ;; ENSURE form: create + configure + seed the app frame in ONE spot. First
+    ;; mount creates `:rf/default`, applies `:url-bound? true` + the demo
+    ;; `:fx-overrides` + the auth-guard interceptor, and runs `:initial-events`
+    ;; once; hot reload reuses it without re-seeding.
+    ;;
+    ;; `:initial-events` run in order at frame creation:
+    ;;   - `:auth/classify-token` — classify the durable JWT path [:auth :token]
+    ;;     `:sensitive` (EP-0025) BEFORE the token is written, so it is redacted
+    ;;     off-box from the first write on.
+    ;;   - `:auth/initialise` — EP-0017 session restore. It declares
+    ;;     `:rf.cofx/requires [:auth.session/token]`, a RECORDABLE GENERATOR
+    ;;     (auth.cljs) whose supplier reads localStorage ONCE at processing-start;
+    ;;     the value rides this setup-step's dispatch token and is recorded, so
+    ;;     replay / epoch-restore re-presents the captured token verbatim rather
+    ;;     than re-reading localStorage. Ordered BEFORE `:app/initialise` so the
+    ;;     token is in app-db before the bearer-auth interceptor fires any
+    ;;     authenticated request. (A unit test stamps `{:rf.cofx …}` at the
+    ;;     dispatch site as a node-side stub; in the browser the generator
+    ;;     supplies the value, so no explicit cofx is needed here.)
+    ;;   - `:app/initialise` — fans out to the per-feature initialisers.
+    ;;   - `:rf.route/handle-url-change` — the initial URL→slice sync, computed
+    ;;     once from the base-path-stripped current URL. Ordered LAST so the
+    ;;     auth-guard interceptor sees the restored session when redirecting an
+    ;;     unauthenticated deep link to a `:requires-auth` route.
     (rdc/render @react-root
-                [rf/frame-provider {:frame :rf/default}
+                [rf/frame-provider {:id              :rf/default
+                                    :doc             "Realworld demo frame."
+                                    :url-bound?      true
+                                    :initial-events  [[:auth/classify-token]
+                                                      [:auth/initialise]
+                                                      [:app/initialise]
+                                                      [:rf.route/handle-url-change
+                                                       (routing/current-url)]]
+                                    :interceptors    [:realworld.routing/auth-guard]
+                                    :fx-overrides    {:rf.http/managed :realworld.demo/http-stub}}
                  [root-view]])))

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -128,9 +128,9 @@
 ;; page, stashing the original target under `:return-to` so a post-login
 ;; handler could bounce the user back.
 ;;
-;; It is wired into the demo frame via `reg-frame :interceptors` in
-;; core.cljs (`:interceptors` are "prepended to every event in this
-;; frame", Spec 002 §reg-frame). To keep it cheap and correct it short-
+;; It is wired into the demo frame via the `frame-provider {:id …}`
+;; `:interceptors` in core.cljs (`:interceptors` are "prepended to every
+;; event in this frame", Spec 002 §`:interceptors`). To keep it cheap and correct it short-
 ;; circuits to the unchanged ctx for everything except a navigation
 ;; event, and gates EVERY navigation ENTRY POINT so a `:requires-auth`
 ;; route is unreachable logged-out by ANY access path:
@@ -211,7 +211,8 @@
 ;; (`:realworld.routing/auth-guard`) from the demo frame's `:interceptors`
 ;; chain in core.cljs — not an inline value. `reg-interceptor` is a top-level
 ;; load-time registration; core.cljs requires this ns, so the descriptor is
-;; registered before `reg-frame` resolves the reference.
+;; registered before the `frame-provider {:id …}` ENSURE form resolves the
+;; reference when it creates the frame.
 (rf/reg-interceptor :realworld.routing/auth-guard
   {:doc "Route-level auth guard (Spec 012 §Redirects and guards): redirect
          unauthenticated users away from `:requires-auth`-tagged routes to

--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -256,7 +256,10 @@
 ;;
 ;; EP-0002: reg-app-schemas is context-required frame-local; a
 ;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (see `core/run`'s `reg-frame :rf/default`), so name it here.
+;; :rf/default (the app frame `core/run` ensures at its render root via the
+;; `frame-provider {:id :rf/default …}` ENSURE form), so name it here. The
+;; schemas register against the frame-id at ns-load; the frame picks them up
+;; when the ENSURE provider creates it.
 (with-frame :rf/default
  (rf/reg-app-schemas
   {[:auth]                          AuthSlice

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -66,12 +66,12 @@
   {:doc "App boot. Seeds the form drafts. Session restore (`:auth/initialise`)
          is NOT in this fan-out — it consumes the RECORDABLE-GENERATOR
          `:realworld-resources.session/token` coeffect (EP-0017). The `:dispatch`
-         fx does not forward `:rf.cofx`, so issuing it as a plain boundary
-         dispatch in `run` (rather than through this fan-out) keeps the generated
-         token on its own boot dispatch token, where it is recorded. The page
-         reads (articles, tags, feed, …) are CAUSED by the route's `:resources`
-         metadata on the initial URL→route sync, not from here — that is the
-         point of the variant."}
+         fx does not forward `:rf.cofx`, so `:auth/initialise` rides its OWN
+         `:initial-events` step (a direct boot dispatch, ahead of this one)
+         rather than this fan-out — keeping the generated token on its own boot
+         dispatch token, where it is recorded. The page reads (articles, tags,
+         feed, …) are CAUSED by the route's `:resources` metadata on the initial
+         URL→route sync, not from here — that is the point of the variant."}
   (fn [_ _]
     {:fx [[:dispatch [:auth.login-form/initialise]]
           [:dispatch [:auth.register-form/initialise]]]}))
@@ -227,72 +227,97 @@
 
 (def app-frame :rf/default)
 
+;; EP-0002: `:rf/default` is an ordinary frame id with no framework privilege —
+;; `init!` installs only the adapter and creates no frame. This app earns URL
+;; ownership by DECLARING `:url-bound? true` on the frame below.
+;;
+;; The app frame is created, configured, and seeded in ONE spot: the
+;; `frame-provider {:id …}` ENSURE form at the render root. On first mount it
+;; creates the frame under `app-frame`, applies the config (`:url-bound? true`
+;; so it owns the URL; the auth-guard interceptor referenced BY ID per EP-0022;
+;; the demo `:rf.http/managed` routed through the in-process backend stub so
+;; reads (resources) and writes (mutations) run without a network), and runs
+;; `:initial-events` ONCE — `:auth/classify-token` then session-restore
+;; `:auth/initialise` then form-draft `:app/initialise`, in that order. On hot
+;; reload it REUSES the existing frame WITHOUT re-seeding (durable app-db
+;; survives; `:initial-events` are re-recorded but not replayed). That id is
+;; what every in-tree `dispatch`/`subscribe` resolves against — no separate
+;; `reg-frame` or scope step.
+;;
+;; `:initial-events` ordering carries two constraints:
+;;   - `:auth/classify-token` first — EP-0025 (durable egress classification):
+;;     the JWT lives at [:auth :token] and is a durable, frame-wide sensitive
+;;     fact, so that path is classified `:sensitive` via the commit-plane
+;;     `:sensitive` effect at frame creation, BEFORE any off-box egress.
+;;     Projection happens at the trust boundary, so off-box egress (Xray /
+;;     observability capture, an off-box tool, an SSR hydration payload) never
+;;     sees the raw token, while on-box use keeps it.
+;;   - `:auth/initialise` before `:app/initialise` — EP-0017: session restore
+;;     consumes the RECORDABLE-GENERATOR `:realworld-resources.session/token`
+;;     coeffect and folds it into durable [:auth :token]. The dispatch carries
+;;     no `:rf.cofx` (a production dispatch never stamps a coeffect; that is a
+;;     unit-test stub seam). The registered generator (auth.cljs) reads
+;;     localStorage ONCE at processing-start; its value rides this boot dispatch
+;;     token as the flat recordable coeffect, so it is recorded and replay /
+;;     epoch-restore re-presents the captured token verbatim rather than
+;;     re-reading localStorage then. It is its OWN `:initial-events` step (not
+;;     the `:app/initialise` `:dispatch` fan-out, which does not forward
+;;     `:rf.cofx`), and ahead of `:app/initialise`, so the token is in app-db
+;;     before the bearer-auth interceptor fires any authenticated request.
+;;
+;; The outbound `Authorization` Bearer header (the bearer-auth interceptor,
+;; registered globally in `run` BEFORE the frame's `:initial-events` fire the
+;; session-restore `GET /user`) is NOT classified here — it is already on the
+;; framework's immutable built-in HTTP carrier denylist (Spec 014 §Privacy),
+;; redacted off-box with no frame config. The `:sensitive :http :headers`
+;; extension is for APP-SPECIFIC carriers; this app sends none. The
+;; session-scope KEY ([:auth :user :username]) the scoped resource cache reads
+;; under is identity, not a secret, so it is deliberately NOT classified —
+;; over-redacting would obscure the cache-leak boundary this example shows.
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  ;; EP-0002: the frame is established explicitly, owns the browser URL
-  ;; (`:url-bound? true`), and prepends the auth-guard interceptor — registered
-  ;; in routing.cljs via `reg-interceptor` and referenced here BY ID per
-  ;; EP-0022 — + routes
-  ;; the demo `:rf.http/managed` through the in-process backend stub so reads
-  ;; (resources) and writes (mutations) run without a network.
-  ;; EP-0025 (durable egress classification): the JWT is a durable, frame-wide
-  ;; sensitive fact — it lives at [:auth :token] in app-db, so that path is
-  ;; classified `:sensitive` via the commit-plane `:sensitive` effect
-  ;; (`:auth/classify-token`, run from the frame's `:initial-events` at frame
-  ;; creation). Projection happens at the trust boundary, so off-box egress
-  ;; (Xray / observability capture, an off-box tool, an SSR hydration payload)
-  ;; never sees the raw token, while on-box use keeps it.
-  ;;
-  ;; The outbound `Authorization` Bearer header (the interceptor above) is NOT
-  ;; declared here — it is already on the framework's immutable built-in HTTP
-  ;; carrier denylist (Spec 014 §Privacy), redacted off-box with no frame
-  ;; config. The `:sensitive :http :headers` extension is for APP-SPECIFIC
-  ;; carriers; this app sends none. The session-scope KEY ([:auth :user
-  ;; :username]) that the scoped resource cache reads under is identity, not a
-  ;; secret, so it is deliberately NOT classified — over-redacting would
-  ;; obscure the cache-leak boundary this example exists to show.
-  (rf/reg-frame app-frame
-    {:doc             "RealWorld-on-resources demo frame."
-     :url-bound?      true
-     :initial-events  [[:auth/classify-token]]
-     :interceptors    [:realworld-resources.routing/auth-guard]
-     :fx-overrides    {:rf.http/managed :realworld-resources.demo/http-stub}})
-  ;; Register the Bearer-auth interceptor at app boot, BEFORE :app/initialise
-  ;; dispatches — session-restore fires an authenticated `GET /user` as soon as
-  ;; the JWT is hydrated, so the header must already be wired.
+  ;; Register the Bearer-auth interceptor at app boot, BEFORE the frame's
+  ;; `:initial-events` dispatch — session-restore fires an authenticated
+  ;; `GET /user` as soon as the JWT is hydrated, so the header must already be
+  ;; wired by the time `:auth/initialise` runs at frame creation (below).
   (rf/reg-http-interceptor :realworld/bearer-auth
                            {:before bearer-auth-interceptor})
   ;; The orchestrator serves this example at /realworld-resources/; strip that
   ;; prefix before the matcher sees the URL so :realworld/home (path "/") matches.
+  ;; Set BEFORE install-router!'s initial URL→route sync (below).
   (routing/set-base-path! "/realworld-resources")
-  (rf/with-frame app-frame
-    ;; EP-0017: session restore consumes the RECORDABLE-GENERATOR
-    ;; `:realworld-resources.session/token` coeffect and folds it into durable
-    ;; [:auth :token]. The dispatch is PLAIN — it carries no `:rf.cofx` (a
-    ;; production dispatch never stamps a coeffect; that is a unit-test stub
-    ;; seam). The registered generator (auth.cljs) reads localStorage ONCE at
-    ;; processing-start; its value rides this boot dispatch token as the flat
-    ;; recordable coeffect, so it is recorded and replay / epoch-restore
-    ;; re-presents the captured token verbatim rather than re-reading
-    ;; localStorage then. It is dispatched here directly (not via the
-    ;; `:app/initialise` `:dispatch` fan-out, which does not forward `:rf.cofx`),
-    ;; and BEFORE `:app/initialise` so the token is in app-db before the
-    ;; bearer-auth interceptor fires any authenticated request.
-    (rf/dispatch-sync [:auth/initialise])
-    (rf/dispatch-sync [:app/initialise])
-    ;; The initial URL→route sync (under the frame scope) is what fires the
-    ;; route's `:resources` ensures — server-state loads because the route
-    ;; became active, not because a view asked.
-    (routing/install-router!)
-    ;; Focus/reconnect revalidation: refetch active-and-stale reads when the
-    ;; tab returns or the network reconnects (Spec 016 §Stale and GC; CLJS-only,
-    ;; idempotent). The host signals are never dispatched by hand.
-    (rf/install-revalidation-listeners! app-frame))
-  ;; Conformance-contract surface — NOT a re-frame2 pattern; see
-  ;; install-conduit-debug! above. The external RealWorld suite may read it.
-  (install-conduit-debug! app-frame)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    ;; ENSURE form: create + configure + seed the app frame in one spot. First
+    ;; mount creates it under `app-frame`, applies the config, and runs
+    ;; `:initial-events` once (classify-token → session restore → form drafts);
+    ;; hot reload reuses it without re-seeding. `make-frame` runs synchronously
+    ;; in render, so the frame is live + seeded once this returns.
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame} [root-view]])))
+                [rf/frame-provider {:id              app-frame
+                                    :doc             "RealWorld-on-resources demo frame."
+                                    :url-bound?      true
+                                    :interceptors    [:realworld-resources.routing/auth-guard]
+                                    :fx-overrides    {:rf.http/managed :realworld-resources.demo/http-stub}
+                                    :initial-events  [[:auth/classify-token]
+                                                      [:auth/initialise]
+                                                      [:app/initialise]]}
+                 [root-view]])
+    ;; The frame is now live + session-seeded. These install ONGOING listeners
+    ;; (each doing its initial sync against that frame) — so they run AFTER the
+    ;; render that created it, not before.
+    ;;
+    ;; install-router! installs the popstate handler AND does the initial
+    ;; URL→route sync (under the URL-owner frame), which fires the route's
+    ;; `:resources` ensures — server-state loads because the route became
+    ;; active, not because a view asked. The session token seeded above is
+    ;; already in app-db, so the bearer-auth interceptor decorates those reads.
+    (routing/install-router!)
+    ;; Focus/reconnect revalidation: refetch active-and-stale reads when the tab
+    ;; returns or the network reconnects (Spec 016 §Stale and GC; CLJS-only,
+    ;; idempotent). The host signals are never dispatched by hand.
+    (rf/install-revalidation-listeners! app-frame)
+    ;; Conformance-contract surface — NOT a re-frame2 pattern; see
+    ;; install-conduit-debug! above. The external RealWorld suite may read it.
+    (install-conduit-debug! app-frame)))

--- a/examples/reagent/realworld_resources/routing.cljs
+++ b/examples/reagent/realworld_resources/routing.cljs
@@ -229,9 +229,10 @@
 
 ;; EP-0022: the guard is a REGISTERED interceptor referenced BY ID
 ;; (`:realworld-resources.routing/auth-guard`) from the demo frame's
-;; `:interceptors` chain in core.cljs — not an inline value. `reg-interceptor`
-;; is a top-level load-time registration; core.cljs requires this ns, so the
-;; descriptor is registered before `reg-frame` resolves the reference.
+;; `:interceptors` chain — set in the `frame-provider {:id …}` ENSURE form in
+;; core.cljs, not an inline value. `reg-interceptor` is a top-level load-time
+;; registration; core.cljs requires this ns, so the descriptor is registered
+;; before the provider's config resolves the reference at frame creation.
 (rf/reg-interceptor :realworld-resources.routing/auth-guard
   {:doc "Route-level auth guard (Spec 012 §Redirects and guards): redirect
          unauthenticated users away from `:requires-auth`-tagged routes to

--- a/examples/reagent/realworld_resources/schema.cljs
+++ b/examples/reagent/realworld_resources/schema.cljs
@@ -139,7 +139,10 @@
 ;;
 ;; EP-0002: reg-app-schemas is context-required frame-local; a
 ;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (see core/run's reg-frame :rf/default), so name it here.
+;; :rf/default (the id `core/run`'s `frame-provider {:id :rf/default}` ENSURE
+;; form creates at the render root), so name it here. This is a frame-local
+;; REGISTRATION scoped by id, not a frame-creation/seed — it binds the id at
+;; ns-load; the frame itself is created later when the provider first renders.
 
 (with-frame :rf/default
   (rf/reg-app-schemas

--- a/examples/reagent/resources/core.cljs
+++ b/examples/reagent/resources/core.cljs
@@ -503,10 +503,12 @@
 ;; ============================================================================
 ;;
 ;; The React root is materialised lazily inside `run` (not at ns-load) per
-;; examples/TESTING.md §Example mount-isolation convention. The app
-;; establishes its frame explicitly (`reg-frame`), declares `:url-bound?
-;; true` so it owns the browser URL, and wraps the render in a
-;; `frame-provider` so every in-tree dispatch/subscribe resolves to it. The
+;; examples/TESTING.md §Example mount-isolation convention. The app frame is
+;; CREATED + CONFIGURED in ONE spot — the render-root `frame-provider {:id …}`
+;; (ENSURE shape): it creates the frame on first mount, applies its config
+;; (`:url-bound? true` so it owns the browser URL, plus the HTTP-stub
+;; override), and on hot reload REUSES the same frame WITHOUT re-creating or
+;; re-seeding it. Every in-tree dispatch/subscribe resolves to it. The
 ;; framework `install-history-listener!` does the initial URL→slice sync and
 ;; popstate handling, targeted at the URL owner.
 
@@ -514,23 +516,25 @@
 
 ;; `:rf/default` is an ORDINARY frame id with no framework privilege — `init!`
 ;; does not create it. This app earns URL ownership by DECLARING `:url-bound?
-;; true` on the frame below, not by naming the frame anything special.
+;; true` on the ENSURE `frame-provider` below, not by naming the frame
+;; anything special.
 (def app-frame :rf/default)
 
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  ;; Override `:rf.http/managed` on the app frame so every resource ensure
-  ;; routes to the per-URL canned stub above — the example runs standalone
-  ;; with no backend. The override applies frame-wide; this example issues no
-  ;; non-mocked requests, so a blanket override is the right grain.
-  (rf/reg-frame app-frame
-    {:doc          "Resources demo frame."
-     :url-bound?   true
-     :fx-overrides {:rf.http/managed :resources.demo/http-stub}})
   (rf/install-history-listener!)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    ;; ENSURE shape ({:id …}): create + configure the app frame in this ONE
+    ;; spot, reuse-without-reseed on hot reload. The `:fx-overrides` routes
+    ;; every `:rf.http/managed` resource ensure to the per-URL canned stub
+    ;; above — the example runs standalone with no backend. The override
+    ;; applies frame-wide; this example issues no non-mocked requests, so a
+    ;; blanket override is the right grain.
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id           app-frame
+                                    :doc          "Resources demo frame."
+                                    :url-bound?   true
+                                    :fx-overrides {:rf.http/managed :resources.demo/http-stub}}
                  [root-view]])))

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -143,16 +143,17 @@
 ;; EP-0002: under the carried invariant the runtime
 ;; never synthesises a frame from absence, and URL ownership is an EXPLICIT
 ;; declaration — a frame owns the browser URL only by carrying
-;; `:url-bound? true` (Spec 012 §Multi-frame routing). So the app frame:
-;;   1. is registered explicitly (`init!` installs only the adapter),
-;;   2. declares `:url-bound? true` so it owns the URL, and
-;;   3. seeds its app-db under `with-frame`.
-;; Because the frame is created up-front by `reg-frame`, the render is
-;; wrapped in `frame-provider` (the SCOPE-only member of the
-;; provider family — it provides an already-created frame id through React
-;; context and creates/destroys nothing; contrast the owned `frame-provider`,
-;; which mounts its own frame). That scope is what every in-tree
-;; `dispatch`/`subscribe` resolves against.
+;; `:url-bound? true` (Spec 012 §Multi-frame routing).
+;;
+;; The app frame is created, configured, and seeded in ONE spot: the
+;; `frame-provider {:id …}` ENSURE form at the render root (`init!` installs
+;; only the adapter). On first mount it creates the frame under `app-frame`,
+;; applies the config (`:url-bound? true` so it owns the URL), and runs
+;; `:initial-events` once to seed app-db. On hot reload it REUSES the existing
+;; frame WITHOUT re-seeding (durable app-db survives; `:initial-events` are
+;; re-recorded but not replayed). That id is what every in-tree
+;; `dispatch`/`subscribe` resolves against — no separate `reg-frame` or
+;; scope step.
 ;;
 ;; The popstate listener is the framework's `rf/install-history-listener!`
 ;; (Spec 012 §popstate drives the URL-owner frame) — NOT a hand-rolled
@@ -168,14 +169,17 @@
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {:doc "Routing demo frame." :url-bound? true})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:routing.app/initialise]))
   ;; Framework popstate listener + initial URL sync, targeted at the URL owner.
   (rf/install-history-listener!)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    ;; ENSURE form: create + configure + seed the app frame in one spot.
+    ;; First mount creates it under `app-frame`, applies `:url-bound? true`,
+    ;; and runs `:initial-events` once; hot reload reuses it without re-seeding.
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :doc "Routing demo frame."
+                                    :url-bound? true
+                                    :initial-events [[:routing.app/initialise]]}
                  [root-view]])))

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -86,8 +86,10 @@
 
 ;; EP-0002: reg-app-schema is context-required frame-local; a
 ;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
-;; schema binds to the app frame whose commits it validates.
+;; :rf/default (the id the render root's `frame-provider {:id app-frame}`
+;; creates — see `run`), so name it explicitly here so the schema binds to
+;; the app frame whose commits it validates. Binding is by frame id, so this
+;; ns-load registration is independent of when the frame is created.
 (with-frame :rf/default
   (rf/reg-app-schema [:cells] {:schema CellsState}))
 
@@ -404,22 +406,23 @@
 
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in a `frame-provider` so every
-;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; explicitly. The whole frame is established in ONE spot: `init!`
+;; installs the adapter (it does NOT create the frame), then the render
+;; root's `frame-provider {:id app-frame}` does the rest — on first
+;; mount it CREATES the app frame, applies its config, and runs
+;; `:initial-events` once to seed it; thereafter every in-tree
+;; `dispatch`/`subscribe` resolves to that frame. On hot reload the
+;; provider REUSES the existing frame and does NOT re-seed. Matches the
 ;; canonical mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:cells/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:cells/initialise]]}
                  [cells-grid]])))

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -62,9 +62,10 @@
    [:redo      [:vector :any]]])
 
 ;; EP-0002: reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
-;; schema binds to the app frame whose commits it validates.
+;; bare ns-load call raises :rf.error/no-frame-context. This example's app
+;; frame is :rf/default (see `app-frame` / the render root's `frame-provider`
+;; ensure form), so name it explicitly so the schema binds to the app frame
+;; whose commits it validates.
 (with-frame :rf/default
   (rf/reg-app-schema [:drawer] {:schema DrawerState}))
 
@@ -258,22 +259,21 @@
 
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in a `frame-provider` so every
-;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
-;; canonical mount in examples/reagent/counter/core.cljs.
+;; explicitly. `init!` installs the adapter (it does NOT create the frame).
+;; The render root then uses the `frame-provider` ENSURE form ({:id …}):
+;; it creates the app frame on first mount, applies its config, runs the
+;; `:initial-events` seed exactly once, and on hot reload reuses the same
+;; frame without re-seeding. Matches the canonical mount in
+;; examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:drawer/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:drawer/initialise]]}
                  [drawer-view]])))

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -12,6 +12,10 @@
    re-frame2 approach: the inputs *are* a sub of the selection. Editing
    them dispatches into a 'draft' slice; the list shows committed values.
 
+   The whole frame is established in one spot: the render root's
+   `frame-provider {:id …}` creates the app frame, configures it, and
+   runs its `:initial-events` seed once (reused, not re-seeded, on reload).
+
    Demonstrates:
    - List operations (add / update / delete)              (CP-1)
    - Selection as state, not as React component identity  (P8: low hidden context)
@@ -57,8 +61,10 @@
 
 ;; EP-0002: reg-app-schema is context-required frame-local; a
 ;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
-;; schema binds to the app frame whose commits it validates.
+;; :rf/default (the frame the render-root `frame-provider {:id app-frame}`
+;; establishes), so name it explicitly here so the schema binds to that frame
+;; whose commits it validates. This `with-frame` only sets the frame-context
+;; label for the registration — it does not require the frame to exist yet.
 (with-frame :rf/default
   (rf/reg-app-schema [:crud] {:schema CrudState}))
 
@@ -229,24 +235,25 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
+;; EP-0002 / EP-0026: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in a `frame-provider` so every
-;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; explicitly. So the boot below does two things in order: `init!` installs
+;; the adapter (it does NOT create the frame), then the render's
+;; `frame-provider {:id app-frame}` does the rest in ONE spot — on first
+;; mount it CREATES the app frame, applies its config, and runs
+;; `:initial-events` once to seed it (`:crud/initialise`); thereafter every
+;; in-tree `dispatch`/`subscribe` resolves to that frame. On hot reload the
+;; provider REUSES the existing frame and does NOT re-seed. Matches the
 ;; canonical mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:crud/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id             app-frame
+                                    :initial-events [[:crud/initialise]]}
                  [crud-view]])))

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -44,8 +44,9 @@
 
 ;; EP-0002: reg-app-schema is context-required frame-local; a
 ;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
-;; schema binds to the app frame whose commits it validates.
+;; :rf/default (the frame the render-root `frame-provider {:id …}` creates),
+;; so name it explicitly so the schema binds to the app frame whose commits
+;; it validates.
 (with-frame :rf/default
   (rf/reg-app-schema [:flight] {:schema FlightState}))
 
@@ -219,22 +220,21 @@
 
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in a `frame-provider` so every
-;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
-;; canonical mount in examples/reagent/counter/core.cljs.
+;; explicitly. `init!` installs the adapter (it does NOT create the frame).
+;; The render root then uses the `frame-provider` ENSURE form ({:id …}):
+;; it creates the app frame on first mount, applies its config, runs the
+;; `:initial-events` seed exactly once, and on hot reload reuses the same
+;; frame without re-seeding. Matches the canonical mount in
+;; examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:flight/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:flight/initialise]]}
                  [flight-booker]])))

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -47,8 +47,9 @@
 
 ;; EP-0002: reg-app-schema is context-required frame-local; a
 ;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
-;; schema binds to the app frame whose commits it validates.
+;; :rf/default (the id the render root's `frame-provider {:id …}` establishes),
+;; so name it explicitly so the schema binds to the app frame whose commits it
+;; validates.
 (with-frame :rf/default
   (rf/reg-app-schema [:temp] {:schema TempState}))
 
@@ -167,22 +168,23 @@
 
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in a `frame-provider` so every
-;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
-;; canonical mount in examples/reagent/counter/core.cljs.
+;; explicitly. So the boot below does two things in order: `init!` installs
+;; the adapter (it does NOT create the frame), then the render's
+;; `frame-provider {:id app-frame}` does the rest in one spot — on first
+;; mount it CREATES the app frame, applies its config, and runs
+;; `:initial-events` once to seed it; thereafter every in-tree
+;; `dispatch`/`subscribe` resolves to that frame. On hot reload the provider
+;; REUSES the existing frame and does NOT re-seed. Matches the canonical
+;; mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:temp/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:temp/initialise]]}
                  [temperature-converter]])))

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -48,8 +48,9 @@
 
 ;; EP-0002: reg-app-schema is context-required frame-local; a
 ;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
-;; schema binds to the app frame whose commits it validates.
+;; :rf/default (the id the render root's `frame-provider {:id app-frame}`
+;; ensures — see `run`), so name it explicitly so the schema binds to the app
+;; frame whose commits it validates.
 (with-frame :rf/default
   (rf/reg-app-schema [:timer] {:schema TimerState}))
 
@@ -195,22 +196,23 @@
 
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in a `frame-provider` so every
-;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
-;; canonical mount in examples/reagent/counter/core.cljs.
+;; explicitly. `init!` installs the adapter (it does NOT create the frame).
+;; The render root then uses the `frame-provider` ENSURE shape (`{:id …}`):
+;; on first mount it creates the app frame, applies its config, and runs the
+;; `:initial-events` seed ONCE; on hot reload it reuses the existing frame
+;; without re-seeding. Create, seed, and scope-into-React all happen in that
+;; one spot. The frame id is `:rf/default` — the same id the schema block
+;; above scopes its `reg-app-schema` registration to. Matches the canonical
+;; mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:timer/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:timer/initialise]]}
                  [timer-view]])))

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -116,26 +116,27 @@
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  ;; Install the canned-failure override on the default frame so every
-  ;; `:rf.http/managed` request resolves :failure. The chapter's
-  ;; lockout scenario depends on three consecutive failures.
-  ;; EP-0002: the runtime never synthesises a frame from absence —
-  ;; register the app frame explicitly and wrap the render in a `frame-provider`
-  ;; so the `reg-view`-injected `dispatch`/`subscribe` (and the login machine
-  ;; reads) resolve to it (a no-provider render reads the no-provider sentinel
-  ;; and raises :rf.error/no-frame-context). The login machine is
-  ;; self-initialising; the form DRAFT slice is not, so it is seeded with one
-  ;; boot `dispatch-sync` scoped to this frame BEFORE first render — the
-  ;; controlled inputs read `:value` off `[:auth :login-form :draft]`, so the
-  ;; slot must exist as empty strings on the first paint (a nil there would make
-  ;; React treat the inputs as uncontrolled).
-  (rf/reg-frame :rf/default
-    {:doc          "State-machines walkthrough demo frame."
-     :fx-overrides {:rf.http/managed :auth.login/canned-failure}})
-  (rf/dispatch-sync [:auth.login/initialise-form] {:frame :rf/default})
+  ;; One spot creates, configures and seeds the app frame: the ENSURE form
+  ;; `frame-provider {:id …}`. On first mount it CREATES the `:rf/default`
+  ;; frame, applies the config, and runs `:initial-events` once; on hot reload
+  ;; it REUSES the same frame WITHOUT re-seeding. The `reg-view`-injected
+  ;; `dispatch`/`subscribe` (and the login machine reads) resolve to it.
+  ;;
+  ;; `:fx-overrides` installs the canned-failure stub so every
+  ;; `:rf.http/managed` request resolves :failure — the chapter's lockout
+  ;; scenario depends on three consecutive failures.
+  ;;
+  ;; The login machine is self-initialising; the form DRAFT slice is not, so it
+  ;; is seeded via `:initial-events` BEFORE first render — the controlled inputs
+  ;; read `:value` off `[:auth :login-form :draft]`, so the slot must exist as
+  ;; empty strings on the first paint (a nil there would make React treat the
+  ;; inputs as uncontrolled).
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame :rf/default}
+                [rf/frame-provider {:id              :rf/default
+                                    :doc             "State-machines walkthrough demo frame."
+                                    :fx-overrides    {:rf.http/managed :auth.login/canned-failure}
+                                    :initial-events  [[:auth.login/initialise-form]]}
                  [root-view]])))

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -1,12 +1,13 @@
 (ns todomvc.core
-  "Entry point: install the adapter, register and seed the frame, mount the view.
+  "Entry point: install the adapter, mount the view, ensure-and-seed the frame.
 
   Demonstrates the boot wiring the other files lean on — `init!` (installs the
-  Reagent adapter; it does NOT create a frame), `reg-frame` with `:url-bound?`
-  (this frame owns the address bar) and `:initial-events` (the frame seeds itself
-  at creation), and the hash → route adapter that turns a `#/active` URL change
-  into a `:rf.route/handle-url-change` event. \"The URL is an input; navigation
-  is an event.\""
+  Reagent adapter; it does NOT create a frame), the `frame-provider {:id …}`
+  ensure form (creates the URL-owning app frame on first mount, with `:url-bound?`
+  so it owns the address bar, and seeds it once via `:initial-events`), and the
+  hash → route adapter that turns a `#/active` URL change into a
+  `:rf.route/handle-url-change` event. \"The URL is an input; navigation is an
+  event.\""
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
@@ -38,9 +39,9 @@
   (hash->path (.. js/window -location -hash)))
 
 ;; EP-0002: under the carried invariant the runtime never synthesises a frame
-;; from absence, and URL ownership is an EXPLICIT declaration — the app frame is
-;; registered with `:url-bound? true` so it owns the URL (Spec 012 §Multi-frame
-;; routing), and the render is wrapped in `frame-provider`.
+;; from absence, and URL ownership is an EXPLICIT declaration — the render root's
+;; `frame-provider {:id app-frame …}` ensures the app frame with `:url-bound?
+;; true` so it owns the URL (Spec 012 §Multi-frame routing).
 (def app-frame :rf/default)
 
 ;; Named handler so the listener install is idempotent: a repeated `boot!`
@@ -66,8 +67,10 @@
 ;; don't race `create-root` onto the shared `#app`. `defonce` keeps the root
 ;; across hot reloads (React 18 rejects a second `create-root` on a live node),
 ;; and `mount!` is `^:dev/after-load` — shadow re-invokes it on every reload to
-;; re-render the (possibly edited) views WITHOUT re-running `boot!`, so app-db
-;; and the URL listener survive the reload.
+;; re-render the (possibly edited) views. The render root's `frame-provider
+;; {:id app-frame …}` ENSURES the frame: it creates and seeds it once on first
+;; mount, then REUSES it on reload WITHOUT re-seeding, so app-db survives the
+;; reload (and the URL listener, installed in `boot!`, survives too).
 
 (defonce react-root (atom nil))
 
@@ -76,27 +79,28 @@
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id             app-frame
+                                    :doc            "TodoMVC demo frame."
+                                    :url-bound?     true
+                                    :initial-events [[:todo/initialise]
+                                                     [:rf.route/handle-url-change (current-path)]]}
                  [views/root-view]])))
 
 ;; ---- Boot ------------------------------------------------------------------
 ;;
-;; `boot!` runs once, at shadow's :init-fn. `init!` installs the adapter (it does
-;; NOT create the frame); `reg-frame` registers the URL-owning app frame and
-;; seeds it via `:initial-events`, fired synchronously into the freshly-created
-;; frame: `[:todo/initialise]` folds the saved todos — supplied by the registered
-;; `:todo.storage/todos` recordable coeffect (db.cljs) — into app-db, then
-;; `[:rf.route/handle-url-change …]` resolves the initial URL. Seeding through
-;; `:initial-events` is what removes the manual `with-frame` / `dispatch-sync`
-;; dance and the dispatch-site coeffect plumbing.
+;; `boot!` runs once, at shadow's :init-fn, BEFORE the first render. It installs
+;; the adapter (`init!` does NOT create the frame) and installs the `hashchange`
+;; listener. The frame itself is created and seeded by the render root's
+;; `frame-provider {:id app-frame …}` ensure form (see `mount!`): its
+;; `:initial-events` fire once into the freshly-created frame — `[:todo/initialise]`
+;; folds the saved todos (supplied by the registered `:todo.storage/todos`
+;; recordable coeffect in db.cljs) into app-db, then `[:rf.route/handle-url-change …]`
+;; resolves the initial URL. Ensuring + seeding in that one spot removes the
+;; manual `with-frame` / `dispatch-sync` dance and the dispatch-site coeffect
+;; plumbing.
 
 (defn- boot! []
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame
-    {:doc            "TodoMVC demo frame."
-     :url-bound?     true
-     :initial-events [[:todo/initialise]
-                      [:rf.route/handle-url-change (current-path)]]})
   (doto js/window
     (.removeEventListener "hashchange" on-hashchange)
     (.addEventListener "hashchange" on-hashchange)))

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -78,23 +78,22 @@
 
 ;; EP-0002: under the carried invariant the runtime never
 ;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in a `frame-provider` so every
-;; in-tree `dispatch`/`subscribe` resolves to the app frame. The frame id is
-;; `:rf/default` — the same id `schema.cljs` scopes its `reg-app-schema`
-;; registration to. Matches the canonical mount in
-;; examples/reagent/counter/core.cljs.
+;; explicitly. `init!` installs the adapter (it does NOT create the frame).
+;; The render root then uses the `frame-provider` ENSURE shape (`{:id ...}`):
+;; on first mount it creates the app frame, applies its config, and runs the
+;; `:initial-events` seed ONCE; on hot reload it reuses the existing frame
+;; without re-seeding. Everything — create, seed, and scope-into-React —
+;; happens in that one spot. The frame id is `:rf/default` — the same id
+;; `schema.cljs` scopes its `reg-app-schema` registration to. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:ws.app/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                [rf/frame-provider {:frame app-frame}
+                [rf/frame-provider {:id app-frame
+                                    :initial-events [[:ws.app/initialise]]}
                  [views/root-view]])))

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -79,13 +79,15 @@
 
 ;; The runtime never synthesises a frame from absence — an app must establish
 ;; its frame explicitly. `init!` installs the adapter (it does NOT create the
-;; frame), `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in `frame-provider` — the
-;; scope-only provider that threads this already-registered frame's id down
-;; the React tree (the owning `frame-provider` would *create* a frame; we
-;; already own ours). That context is what lets the `use-subscribe` hook and
-;; the render-time `(rf/frame-handle)` capture resolve to the app frame. There
-;; is no `:rf/default` floor: a UIx tree rendered with NO provider observes the
+;; frame), and the render is wrapped in `frame-provider` in its ENSURE shape:
+;; `{:id app-frame …}`. That one call creates the app frame on first mount,
+;; applies its config, and runs `:initial-events` ONCE to seed app-db — so the
+;; whole frame lifecycle lives in a single spot at the render root. On hot
+;; reload the provider REUSES the existing frame without re-seeding, so the
+;; counter keeps its current value across `:dev/after-load` re-mounts. That
+;; context is what lets the `use-subscribe` hook and the render-time
+;; `(rf/frame-handle)` capture resolve to the app frame. There is no
+;; `:rf/default` floor: a UIx tree rendered with NO provider observes the
 ;; no-provider sentinel and any `use-subscribe` / `frame-handle` raises
 ;; `:rf.error/no-frame-context`.
 ;;
@@ -96,13 +98,11 @@
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! uix-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:counter/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
     (uix-dom/render-root
-      ($ uix-adapter/frame-provider {:frame app-frame}
+      ($ uix-adapter/frame-provider {:id app-frame
+                                     :initial-events [[:counter/initialise]]}
          ($ counter-app))
       @react-root)))

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -348,23 +348,24 @@
 
 ;; The runtime never synthesises a frame from absence — an app must establish
 ;; its frame explicitly. `init!` installs the adapter (it does NOT create the
-;; frame), `reg-frame` registers the app frame, the boot dispatch runs under
-;; `with-frame`, and the render is wrapped in the UIx `frame-provider` so the
-;; `use-subscribe` hook and the render-time `(rf/frame-handle)` capture resolve
-;; to the app frame via React context. There is no `:rf/default` floor: a UIx
-;; tree rendered with NO provider observes the no-provider sentinel and any
-;; `use-subscribe` / `frame-handle` raises `:rf.error/no-frame-context`.
+;; frame). The render root then uses the UIx `frame-provider` in its ENSURE
+;; shape — `{:id app-frame …}` — which creates the app frame on first mount,
+;; applies its config, and runs `:initial-events` exactly ONCE to seed app-db;
+;; on hot reload it REUSES the existing frame WITHOUT re-seeding. The provider
+;; scopes that frame into React context so the `use-subscribe` hook and the
+;; render-time `(rf/frame-handle)` capture resolve to it. There is no
+;; `:rf/default` floor: a UIx tree rendered with NO provider observes the
+;; no-provider sentinel and any `use-subscribe` / `frame-handle` raises
+;; `:rf.error/no-frame-context`.
 (def app-frame :rf/default)
 
 (defn run []
   (rf/init! uix-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:dashboard/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
     (uix-dom/render-root
-      ($ uix-adapter/frame-provider {:frame app-frame}
+      ($ uix-adapter/frame-provider {:id app-frame
+                                     :initial-events [[:dashboard/initialise]]}
          ($ dashboard))
       @react-root)))

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -507,31 +507,31 @@
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! uix-adapter/adapter)
-  (rf/reg-frame :rf/default
-    {:doc          "Login (UIx) demo frame."
-     :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}})
-  ;; The MACHINE handler is self-initialising — its `:initial`/`:data` seed
-  ;; [:rf.runtime/machines :snapshots :auth.login/flow] when the flow first
-  ;; runs (per Spec 005 §Restore semantics), so it needs no :initialise. The
-  ;; form SLICE is app-db, so it IS seeded explicitly here to its empty
-  ;; Pattern-Forms shape — otherwise the controlled inputs would read a nil
-  ;; draft on the first render (uncontrolled inputs).
-  (rf/with-frame :rf/default
-    (rf/dispatch-sync [:auth.login/initialise-form]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
-    ;; Scope the render into the already-created `:rf/default` frame (built by
-    ;; the `reg-frame` above) with the SCOPE-ONLY `frame-provider` —
-    ;; it provides that frame's id to descendants over React context and
-    ;; creates / owns nothing (the lifecycle-owning `frame-provider`, which
-    ;; takes `:id` and constructs a frame, is the other component and is not
-    ;; what's wanted here). The scope makes the `use-subscribe` hook + the
+    ;; ONE-SPOT frame setup — the ENSURE `frame-provider` (`{:id …}`): on the
+    ;; first mount it CREATES the `:rf/default` frame, applies the config
+    ;; (`:fx-overrides` redirects `:rf.http/managed` to the demo stub), and runs
+    ;; `:initial-events` ONCE; on hot reload it REUSES the existing frame
+    ;; WITHOUT re-running them. There is no separate `reg-frame` / seed step.
+    ;;
+    ;; The MACHINE handler is self-initialising — its `:initial`/`:data` seed
+    ;; [:rf.runtime/machines :snapshots :auth.login/flow] when the flow first
+    ;; runs (per Spec 005 §Restore semantics), so it needs no seeding. The form
+    ;; SLICE is app-db, so it IS seeded via `:initial-events`
+    ;; ([:auth.login/initialise-form]) to its empty Pattern-Forms shape —
+    ;; otherwise the controlled inputs would read a nil draft on the first
+    ;; render (uncontrolled inputs).
+    ;;
+    ;; Providing `:id :rf/default` also makes the `use-subscribe` hook + the
     ;; render-time `(rf/frame-handle)` capture in `login-form` resolve to
     ;; `:rf/default`. With NO provider the tree observes the no-provider
-    ;; sentinel and those reads raise `:rf.error/no-frame-context` (there is no
-    ;; `:rf/default` floor).
+    ;; sentinel and those reads raise `:rf.error/no-frame-context`.
     (uix-dom/render-root
-      ($ uix-adapter/frame-provider {:frame :rf/default}
+      ($ uix-adapter/frame-provider {:id              :rf/default
+                                     :doc             "Login (UIx) demo frame."
+                                     :fx-overrides    {:rf.http/managed :auth.login.demo/managed-stub}
+                                     :initial-events  [[:auth.login/initialise-form]]}
          ($ root-view))
       @react-root)))


### PR DESCRIPTION
Migrates every applicable example from the two-step frame setup to the merged provider's **one-spot `{:id}` ENSURE shape**, now that rf2-p9er9a (the collapse) and rf2-59orj0 (omit-`:images` → default image) have both landed.

**Before** (two steps):
```clojure
(rf/reg-frame app-frame {:url-bound? true :initial-events [[…]]})   ; register + configure
[rf/frame-provider {:frame app-frame} [root-view]]                  ; scope into React
```
**After** (one spot):
```clojure
[rf/frame-provider {:id app-frame :url-bound? true :initial-events [[…]]} [root-view]]
```
ENSURE creates the frame on first mount, applies the config, runs `:initial-events` once, and reuses it without re-seeding on hot reload — so app-db survives, same as before.

**30 of 33 migrated**, one agent each. The 3 left on `{:frame}` are deliberate:
- **ssr / ssr_streaming / resources_ssr** — the client seed is the framework hydration handshake (`ssr/hydrate!` with a conditional bootstrap fallback), which `:initial-events` can't express.
- **Story hosts** (`stories_host.cljs`) — they scope an externally-created `:rf/default` the Story player owns.

Folded each example's `reg-frame` config (and any `with-frame` + `dispatch-sync` seed) into the provider; deleted the now-redundant `reg-frame`; updated surrounding comments and cross-references. `init!`, the mount-isolation shape, and ongoing `hashchange` listeners are unchanged. No `:images` added.

Verified: local `npm run test:examples-compile` passes (all builds, exit 0).