### PR TITLE
Examples: clarify code comments (positive framing, accurate to the {:id} migration)

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -10,8 +10,8 @@
      - `rf/init!` with the Helix adapter
      - `reg-event` / `reg-sub` (substrate-agnostic)
      - `use-subscribe` hook (Helix idiomatic)
-     - `(:dispatch (rf/frame-handle))` for click handlers (components
-       call dispatch / use-subscribe directly, no auto-injection)
+     - `(:dispatch (rf/frame-handle))` for click handlers — the
+       component reads its own sub and takes its own dispatch
      - The shared frame-context — the same React Context
        object the Reagent and UIx adapters consume
 
@@ -67,16 +67,15 @@
 ;; ABOVE this divider and differ only in what sits BELOW it (Reagent
 ;; `reg-view`, UIx `defui` + `use-subscribe`, Helix `defnc` + `use-subscribe`).
 ;;
-;; `reg-view` (the macro) stays Reagent-only;
-;; Helix users write `defnc` directly. There is no auto
-;; injection — the component calls `use-subscribe` and takes
-;; `dispatch` off a `(rf/frame-handle)` explicitly. The handle
+;; Helix users write `defnc` directly (the `reg-view` macro stays
+;; Reagent-only). The component reads its sub with `use-subscribe`
+;; and takes `dispatch` off a `(rf/frame-handle)` itself. The handle
 ;; captures the render-time frame, so the closed-over `dispatch`
 ;; targets the right frame even from an async callback.
 
 (defnc counter-buttons []
   (let [count    (helix-adapter/use-subscribe [:counter/value])  ;; read: re-renders when :counter/value moves
-        dispatch (:dispatch (rf/frame-handle))]                  ;; write: dispatch off a handle, no auto-injection
+        dispatch (:dispatch (rf/frame-handle))]                  ;; write: take dispatch off the render-time handle
     (d/div
        (d/button {:on-click #(dispatch [:counter/dec])} "-")
        (d/span {:style {:margin "0 1em"} :data-testid "counter-value"} count)
@@ -94,27 +93,22 @@
 
 (defonce react-root (atom nil))
 
-;; The runtime never synthesises a frame from absence — an app must establish
-;; its frame explicitly. `init!` installs the adapter (it does NOT create the
-;; frame); the Helix `frame-provider` does everything else in ONE spot. Given an
-;; `:id`, the provider CREATES the frame on first mount, applies its config, and
-;; runs `:initial-events` exactly once to seed it. On hot reload it REUSES the
-;; existing frame WITHOUT re-seeding, so the count you were looking at survives.
-;; That context is what lets the `use-subscribe` hook and the render-time
-;; `(rf/frame-handle)` capture resolve to the app frame. There is no `:rf/default`
-;; floor: a Helix tree rendered with NO provider observes the no-provider sentinel
-;; and any `use-subscribe` / `frame-handle` raises `:rf.error/no-frame-context`.
-;;
-;; `:rf/default` is an ORDINARY frame id with no framework privilege — a
-;; migration may reach for it out of habit, but the runtime won't infer it.
+;; The frame id this app runs in. `:rf/default` is an ordinary id with no
+;; framework privilege; we just pick it. The provider below builds the frame
+;; under this id and the `use-subscribe` hook + render-time `(rf/frame-handle)`
+;; resolve to it.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the Helix adapter. Pass the adapter spec map directly — no registry.
   (rf/init! helix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
+    ;; The frame lives in one spot: the provider. Given `:id`, it creates the
+    ;; frame on first mount and runs `:initial-events` once to seed it. On hot
+    ;; reload it reuses the existing frame and skips seeding, so the count you
+    ;; were looking at survives.
     (.render @react-root
              ($ helix-adapter/frame-provider {:id app-frame
                                               :initial-events [[:counter/initialise]]}

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -15,8 +15,8 @@
    substrate's hook idiom differs. The terminal `:locked-out` state is
    surfaced as a non-interactive locked-account panel.
 
-   `reg-view` stays Reagent-only; Helix components are plain `defnc`.
-   There is no auto-injection."
+   Views are plain Helix `defnc` components that read subs via
+   `use-subscribe` and take `dispatch` off the frame-handle."
   (:require ["react-dom/client" :as react-dom-client]
             [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]
@@ -326,8 +326,8 @@
 ;; machine's `:submit` boundary enforces.
 (def login-form-defaults {:email "" :password ""})
 
-;; Seed the slice to its standard Pattern-Forms shape. Dispatched once at
-;; boot (from `run`). `:draft` to the empty defaults; `:status :idle`.
+;; Seed the form slice to its standard Pattern-Forms shape: empty `:draft`,
+;; `:status :idle`.
 (rf/reg-event :auth.login/initialise-form
   {:doc "Seed the login-form slice at [:auth :login-form] to its standard
          Pattern-Forms shape (empty draft, :idle status)."}
@@ -341,10 +341,10 @@
                     :touched           #{}
                     :submit-error      nil})}))
 
-;; The user changed a single field. Update `:draft` and add the field to
-;; `:touched`. This is the ONLY thing an input's `:on-change` does — it never
-;; sets view-local state. The `:schema` rejects a malformed edit-field vector
-;; at the `:where :event` boundary.
+;; The user changed a single field. Update `:draft` and mark the field
+;; `:touched`. This is all an input's `:on-change` does — the draft lives in
+;; app-db, not view-local state. The `:schema` rejects a malformed edit-field
+;; vector at the `:where :event` boundary.
 (rf/reg-event :auth.login/edit-field
   {:doc    "Controlled-input edit: write one field into the login-form draft
             and mark it touched."
@@ -459,28 +459,26 @@
 ;; ============================================================================
 ;;
 ;; The Helix view idiom, and the only place this example differs from the
-;; Reagent reference: a view is a plain `defnc`; it reads a subscription
-;; through the adapter's `use-subscribe` hook; and it takes `dispatch` off a
-;; `frame-handle` rather than having it lexically injected (`reg-view` is
-;; Reagent-only — there is no auto-injection here). `:rf/machine-has-tag?`
-;; reads are *ask, don't tell* state-tag queries; `:auth.login/error` is a
-;; named sub. To the call site they're identical — both are just subscriptions.
+;; Reagent reference. A view is a plain `defnc`. It reads a subscription
+;; through the adapter's `use-subscribe` hook, and takes `dispatch` off a
+;; `frame-handle`. `:rf/machine-has-tag?` reads are *ask, don't tell* state-tag
+;; queries; `:auth.login/error` is a named sub. To the call site they're
+;; identical — both are just subscriptions.
 
 (defnc login-form []
   (let [draft    (helix-adapter/use-subscribe [:auth.login/draft])
         busy?    (helix-adapter/use-subscribe [:rf/machine-has-tag?
                                                :auth.login/flow :auth/busy])
         err      (helix-adapter/use-subscribe [:auth.login/error])
-        ;; No global dispatch in re-frame2 — every dispatch goes to a frame.
-        ;; Pull this frame's `dispatch` off the render-time frame-handle; it
-        ;; resolves to `:rf/default` via the provider in `run`.
+        ;; Take `dispatch` off the render-time frame-handle. It resolves to
+        ;; this frame (`:rf/default`) through the provider in `run`. Every
+        ;; dispatch goes to a frame; there is no global dispatch.
         dispatch (:dispatch (rf/frame-handle))]
-    ;; The form holds NO view-local state: there is no `use-state` for the
-    ;; email/password. Each input's `:value` reads the draft from the
-    ;; `:auth.login/draft` sub, and `:on-change` DISPATCHES
-    ;; `:auth.login/edit-field` (it never sets view-local state) — controlled
-    ;; inputs, the Pattern-Forms way. The draft crosses into the machine (and
-    ;; is validated) at the :on-submit dispatch of `:auth.login/submit-form`.
+    ;; Controlled inputs, the Pattern-Forms way: each input's `:value` reads
+    ;; the draft from the `:auth.login/draft` sub, and `:on-change` dispatches
+    ;; `:auth.login/edit-field`. The draft lives in app-db, not in a `use-state`
+    ;; hook. It crosses into the machine (and is validated) at the :on-submit
+    ;; dispatch of `:auth.login/submit-form`.
     (d/form
        {:class "login-form"
         :data-testid "login-form"
@@ -545,25 +543,24 @@
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; Install the adapter spec once, before the first render — no registry.
+  ;; Install the Helix adapter once, before the first render.
   (rf/init! helix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
-    ;; Wrap the render in the Helix `frame-provider` ENSURE shape (`{:id …}`):
-    ;; one spot CREATES `:rf/default` on first mount, applies the frame config
-    ;; (`:doc` + the managed-HTTP `:fx-overrides`), and REUSES the same frame on
-    ;; hot reload WITHOUT re-running setup — so the demo's state survives a
-    ;; reload. No `:initial-events`: the machine handler is self-initialising —
-    ;; its `:initial`/`:data` seed [:rf.runtime/machines :snapshots
-    ;; :auth.login/flow] when the flow first runs (per Spec 005 §Restore
-    ;; semantics), so there is nothing to seed here.
+    ;; One-spot frame setup. The Helix `frame-provider` ENSURE shape (`{:id …}`)
+    ;; creates the `:rf/default` frame on first mount and applies the config
+    ;; below (`:doc`, and `:fx-overrides` routing `:rf.http/managed` to the demo
+    ;; stub). On hot reload it reuses the existing frame and its state, so the
+    ;; demo survives a reload. The machine snapshot needs no seeding: the machine
+    ;; handler is self-initialising — its `:initial`/`:data` seed
+    ;; [:rf.runtime/machines :snapshots :auth.login/flow] when the flow first
+    ;; runs (Spec 005 §Restore semantics).
     ;;
-    ;; The provider also gives the `use-subscribe` hook + the render-time
-    ;; `(rf/frame-handle)` capture in `login-form` a frame to resolve to via
-    ;; React context. With NO provider the tree observes the no-provider
-    ;; sentinel and those reads raise `:rf.error/no-frame-context` (there is no
-    ;; `:rf/default` floor).
+    ;; The provider also scopes the frame into React context, so the
+    ;; `use-subscribe` hook and the `(rf/frame-handle)` capture in `login-form`
+    ;; resolve to it. The provider is required — without it those reads raise
+    ;; `:rf.error/no-frame-context`.
     (.render @react-root
              ($ helix-adapter/frame-provider
                 {:id           :rf/default

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -63,7 +63,7 @@
 ;; ============================================================================
 ;;
 ;; The tick chain is driven by `:dispatch-later`, which has no cancel API.
-;; If `run` / `:process-monitor/initialise` is invoked more than once in the same JS
+;; If `:process-monitor/initialise` is dispatched more than once in the same JS
 ;; runtime (a shadow watch reload, a manual re-init, a future browser wrapper,
 ;; or any harness that calls the entrypoint repeatedly), a naive chain would
 ;; leave the prior chain's ticks still firing — every stale cascade would keep
@@ -232,9 +232,9 @@
       ($ tile {:label "Σ CPU"   :value (str (.toFixed (:cpu totals) 1) "%")})
       ($ tile {:label "Σ MEM"   :value (str (:mem totals) "M")}))))
 
-;; First dispatching view. To dispatch, grab `dispatch` off a frame-handle —
+;; First dispatching view. To dispatch, grab `dispatch` off a frame-handle:
 ;; `(rf/frame-handle)` captures the current frame as a value, so the click
-;; handler dispatches into this app's frame, not some ambient default.
+;; handler dispatches into this app's frame.
 (defnc level-chips []
   (let [active   (helix-adapter/use-subscribe [:process-monitor/level-filter])
         dispatch (:dispatch (rf/frame-handle))]
@@ -300,18 +300,18 @@
                       :entry entry}))))))
 
 (defnc monitor []
-  ;; The recurring tick loop is owned by this component's lifecycle, not by
-  ;; `run`. `(:dispatch (rf/frame-handle))` is captured at render-time so it
-  ;; carries the surrounding frame into the (post-commit) effect body and
-  ;; cleanup — see the Helix adapter README §use-effect. Empty deps ⇒ the
-  ;; effect runs once on mount and the cleanup runs once on unmount.
+  ;; This component owns the recurring tick loop: mount arms it, unmount stops
+  ;; it. `(:dispatch (rf/frame-handle))` is captured at render-time so it carries
+  ;; the surrounding frame into the (post-commit) effect body and cleanup — see
+  ;; the Helix adapter README §use-effect.
   (let [dispatch (:dispatch (rf/frame-handle))]
     (helix-hooks/use-effect
       ;; Empty deps ⇒ run once on mount, clean up once on unmount.
       []
       ;; Mount: (re-)arm the loop. Idempotent — the `:process-monitor/tick-gen`
-      ;; guard retires any chain `run` already started, so exactly one
-      ;; live chain survives, and a hot-reload re-mount re-arms cleanly.
+      ;; guard retires any chain already in flight (from the provider's seed, or
+      ;; a prior mount), so exactly one live chain survives and a hot-reload
+      ;; re-mount re-arms cleanly.
       (dispatch [:process-monitor/initialise])
       ;; Unmount: retire the live chain so it never dispatches into a frame
       ;; that is no longer rendered.
@@ -339,28 +339,26 @@
 ;; This matches the sibling notebook / dashboard_uix mount shape.
 (defonce react-root (atom nil))
 
-;; The runtime never synthesises a frame from absence — an app must establish
-;; its frame explicitly. `init!` installs the adapter (it does NOT create the
-;; frame). The Helix `frame-provider` does the rest in one spot: the `{:id …}`
-;; ENSURE form CREATES the app frame on first mount, then runs `:initial-events`
-;; ONCE to seed it. On hot reload it REUSES the existing frame without
-;; re-seeding. The `use-subscribe` hook and the render-time `(rf/frame-handle)`
-;; capture inside `monitor` (the tick-loop arm/stop dispatches) resolve to that
-;; frame via React context. There is no `:rf/default` floor.
+;; The frame id this app runs under. The Helix `frame-provider` at the render
+;; root (in `run` below) does the frame work in one spot: it creates this frame,
+;; seeds app-db, and scopes the frame into React context. The `use-subscribe`
+;; hook and the render-time `(rf/frame-handle)` capture inside `monitor` (the
+;; tick-loop arm/stop dispatches) resolve to that frame via the context.
 (def app-frame :rf/default)
 
 (defn run []
+  ;; `init!` installs the Helix adapter so re-frame2 knows how to render.
   (rf/init! helix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
-    ;; One-spot frame setup: `{:id app-frame}` ensures the frame exists (creating
-    ;; it on first mount) and `:initial-events` seeds it exactly once. The seed
-    ;; arms the first tick; the `monitor` component's mount `use-effect` re-arms
-    ;; (idempotently, via the `:process-monitor/tick-gen` guard) so the loop is
-    ;; owned by the component lifecycle from then on — unmount stops it (see
-    ;; `:process-monitor/stop`). Reuse-no-reseed on reload keeps the running
-    ;; clock/logs intact across hot reloads.
+    ;; The `frame-provider` is the one spot the frame is set up. `{:id …}`
+    ;; creates the app frame on first mount and runs `:initial-events` once to
+    ;; seed app-db; a hot reload reuses the same frame without re-seeding so the
+    ;; running clock/logs stay intact. The seed arms the first tick; from then on
+    ;; the loop is owned by the `monitor` component lifecycle — its mount
+    ;; `use-effect` re-arms idempotently (the `:process-monitor/tick-gen` guard)
+    ;; and unmount stops it (see `:process-monitor/stop`).
     (.render @react-root
              ($ helix-adapter/frame-provider {:id app-frame
                                               :initial-events [[:process-monitor/initialise]]}

--- a/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
@@ -31,17 +31,9 @@
             [counter-slim-and-fast.bundle-isolation-fixture :as fixture]))
 
 (defn run []
-  ;; Delegate to the ONE canonical boot in `core/boot!` (init the slim adapter,
-  ;; then lazily mount under a `frame-provider {:id …}` that creates + seeds the
-  ;; app frame in one spot). There is no copied boot sequence to drift from
-  ;; `core/run`. The only fixture concern is woven in via the `on-frame`
-  ;; pre-mount hook:
-  ;;
-  ;; Bundle-isolation fixture, not app practice. The static render derefs
-  ;; `[:counter/value]`, so it must run inside a frame scope; `boot!` opens a
-  ;; transient one for the hook (before the client mount). It caches an orphaned
-  ;; reaction with no component to unmount it, so the fixture clears the
-  ;; sub-cache in a `finally`. Because the hook runs before the client mount,
-  ;; the browser mount starts from a clean sub-cache and owns the only live
-  ;; `[:counter/value]` reaction.
+  ;; Run the one canonical boot in `core/boot!`, passing the SSR fixture as
+  ;; its `on-frame` pre-mount hook. `boot!` runs the hook in a transient
+  ;; frame before the client mount; the fixture clears the sub-cache when it
+  ;; finishes, so the browser mount owns the only live `[:counter/value]`
+  ;; reaction. (Mechanics: `fixture/prove-pure-cljs-ssr!` and the docstring.)
   (core/boot! #(fixture/prove-pure-cljs-ssr! [core/counter-app])))

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -21,15 +21,13 @@
    docs/guide/how-to/use-uix-helix-or-slim.md and
    implementation/adapters/reagent-slim/DESIGN-RATIONALE.md §7.
 
-   The slim adapter's bundle-isolation proof is NOT here: it is kept out
-   of this teaching surface entirely, behind the gate-owned entrypoint
-   `counter-slim-and-fast.bundle-isolation-entry` (which the
-   `:examples/counter-slim-and-fast` build uses as its `:init-fn`). That
-   entry boots the SAME app through the shared `boot!` helper below — it
-   does not re-copy the boot sequence — and passes a pre-mount hook that
-   exercises the pure-CLJS SSR path the gate inspects; nothing about that
-   fixture plumbing leaks into this namespace, and the two boot paths
-   cannot drift because there is only one."
+   The slim adapter's bundle-isolation proof lives in its own gate-owned
+   entrypoint, `counter-slim-and-fast.bundle-isolation-entry` (the
+   `:init-fn` of the `:examples/counter-slim-and-fast` build), so this
+   teaching file stays free of fixture plumbing. That entry boots the
+   same app through the shared `boot!` helper below and passes a pre-mount
+   hook that exercises the pure-CLJS SSR path the gate inspects. Because
+   both paths call the one `boot!`, they cannot drift."
   (:require [reagent2.dom.client                :as rdc]
             [re-frame.core                      :as rf]
             [re-frame.views]
@@ -59,12 +57,11 @@
 
 ;; -- Views -------------------------------------------------------------------
 ;;
-;; reg-view is substrate-agnostic — the macro expands to a plain
-;; React-component shape that consults the *active* adapter's
-;; `register-context-provider` / `current-component` seams at render
-;; time. So the very same view form renders through whichever substrate
-;; was installed at boot. With the slim adapter installed (see `boot!`
-;; below), the rendered component reads frame state through
+;; reg-view is substrate-agnostic. The macro expands to a plain
+;; React-component shape that reads through the active adapter at render
+;; time, so the same view form renders on whichever substrate was
+;; installed at boot. Here the slim adapter is installed (see `boot!`
+;; below), so the view reads frame state through
 ;; `reagent2.core/current-component` rather than stock Reagent's.
 
 (reg-view counter-buttons []
@@ -78,54 +75,45 @@
 
 ;; -- Mount -------------------------------------------------------------------
 ;;
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
+;; The React root is held in an atom and created lazily inside `boot!`,
+;; not at ns-load, per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects, so co-required
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 ;; This mirrors the behavioural twin `examples/reagent/counter` — the one
-;; blessed mount shape across the whole example tree. The only intentional
-;; divergence from the twin is the substrate swap (the `reagent2.*` imports
-;; + the slim adapter Var).
+;; blessed mount shape across the example tree. The only divergence from
+;; the twin is the substrate swap (the `reagent2.*` imports + the slim
+;; adapter Var).
 
 (defonce react-root (atom nil))
 
-;; The runtime never synthesises a frame from absence — an app must
-;; establish its frame explicitly. So the boot below does two things in
-;; order: `init!` installs the adapter (it does NOT create the frame),
-;; then the render's `frame-provider {:id app-frame}` does the rest in
-;; one spot — on first mount it CREATES the app frame, applies its
-;; config, and runs `:initial-events` once to seed it (the
-;; `[:counter/initialise]` boot dispatch); thereafter every in-tree
-;; `dispatch`/`subscribe` resolves to that frame. On hot reload the
-;; provider REUSES the existing frame and does NOT re-seed. Matches the
-;; canonical mount in examples/reagent/counter/core.cljs.
+;; The app frame is established in one spot: the `frame-provider {:id
+;; app-frame …}` at the render root below. On first mount the provider
+;; creates the frame, applies its config, and runs `:initial-events`
+;; once to seed it (the `[:counter/initialise]` boot dispatch). From then
+;; on every in-tree `dispatch`/`subscribe` resolves to that frame. On hot
+;; reload the provider reuses the existing frame and skips re-seeding.
+;; Matches the canonical mount in examples/reagent/counter/core.cljs.
 ;;
-;; `:rf/default` is an ORDINARY frame id with no framework privilege — a
-;; migration may reach for it out of habit, but the runtime won't infer
-;; it; you establish it like any other.
+;; `:rf/default` is an ordinary frame id with no special privilege — you
+;; establish it like any other (the runtime won't infer it for you).
 (def app-frame :rf/default)
 
 (defn boot!
-  "The one canonical boot sequence for this example: install the slim
-   adapter, then lazily mount `counter-app` into `#app` under a
-   `frame-provider {:id app-frame …}`. The whole frame is established in
-   that one spot — on first mount the provider CREATES the app frame,
-   applies its config, and runs `:initial-events` once to seed it; on hot
-   reload it REUSES the existing frame and does NOT re-seed.
+  "Boots the example: install the slim adapter, then lazily mount
+   `counter-app` into `#app` under a `frame-provider {:id app-frame …}`.
+   The provider creates and seeds the app frame (see the comment above).
 
-   `boot!` is the single source of truth for the boot so the teaching path
+   This is the single source of truth for the boot. Both the teaching path
    (`run` below) and the gate-owned path
-   (`counter-slim-and-fast.bundle-isolation-entry/run`) cannot drift: both
-   call this fn, so a future EP/API boot change is made in one place.
+   (`counter-slim-and-fast.bundle-isolation-entry/run`) call it, so a
+   future boot change is made in one place and the two paths cannot drift.
 
-   `on-frame` is an optional thunk run in a TRANSIENT frame scope, before
-   the client mount. The teaching `run` passes nothing; only the
-   bundle-isolation entry uses it, to weave its pure-CLJS SSR exercise into
-   a frame scope at the one point its ordering requires. The exercise is a
-   throwaway static render, so it gets its own short-lived frame
-   (`with-new-frame`, auto-destroyed on exit) rather than touching the app
-   frame the provider creates at mount. Keeping the seam here — rather than
-   re-copying the boot in the entry — is what keeps `core` free of fixture
+   `on-frame` is an optional thunk the bundle-isolation entry uses; the
+   teaching `run` passes nothing. It runs once before the client mount,
+   inside its own short-lived frame (`with-new-frame`, auto-destroyed on
+   exit), so the fixture's pre-mount SSR exercise stays clear of the app
+   frame the provider creates at mount. Keeping this seam in `boot!`
+   instead of re-copying the boot is what keeps `core` free of fixture
    plumbing while preventing drift."
   ([] (boot! nil))
   ([on-frame]
@@ -133,9 +121,8 @@
    ;; right here. Same `rf/init!` signature; different adapter Var.
    (rf/init! reagent-slim-adapter/adapter)
    (when on-frame
-     ;; Fixture-only seam: scope the pre-mount SSR exercise to a throwaway
-     ;; frame (destroyed on exit) so it never touches the app frame the
-     ;; provider creates below.
+     ;; Fixture-only seam: run the hook in a throwaway frame (destroyed on
+     ;; exit) so it stays clear of the app frame the provider creates below.
      (rf/with-new-frame [_ (rf/make-frame {})]
        (on-frame)))
    (when (exists? js/document)

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -1,11 +1,11 @@
 (ns boot.core
   "Entry point for the boot example — Pattern-Boot demonstrated.
 
-   `run` wires the Reagent adapter, installs the per-URL canned-HTTP
-   stub override (so the example runs standalone — no backend), and
-   triggers the boot machine via `:boot/initialise`. The render runs
-   immediately; the root view stays on the boot-progress screen until
-   the boot machine reaches `:ready`.
+   `run` installs the Reagent adapter and renders the app under a
+   `frame-provider`. The provider redirects HTTP to a per-URL canned
+   stub (so the example runs standalone — no backend) and seeds the boot
+   machine on first mount. The root view stays on the boot-progress
+   screen until the boot machine reaches `:ready`.
 
    The four mocked endpoints:
      /api/config.json   → static app config (api-base, env, build)
@@ -44,9 +44,10 @@
 ;; ============================================================================
 ;;
 ;; The boot example would normally hit /api/config.json and three more
-;; endpoints; we don't ship a backend, so we override `:rf.http/managed`
-;; on the default frame to a wrapper fx that synthesises the canned
-;; reply per URL substring. Each branch delegates to
+;; endpoints; we don't ship a backend. This section defines the canned
+;; payloads and the `:boot.demo/http-stub` fx that returns one per URL
+;; substring. The provider in `run` wires this stub in as the frame's
+;; `:rf.http/managed` via `:fx-overrides`. Each reply delegates to
 ;; `:rf.http/managed-canned-success` (Spec 014 §Testing) — the same
 ;; reply shape a live server would produce.
 
@@ -129,46 +130,35 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; React root named `react-root` (not `root`) so it does NOT collide
-;; with any `root-view` registered above. Held in an atom and populated
-;; lazily inside `run` rather than at ns-load so multiple example
-;; namespaces co-required by the browser-test bundle don't race
-;; `create-root` calls onto the same shared `#app` element.
+;; The React root, held in an atom and created lazily inside `run`. Doing
+;; it in `run` (not at ns-load) lets several example namespaces share the
+;; browser-test bundle without racing `create-root` onto the same `#app`
+;; element.
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. This example uses `:rf/default` as its app frame id.
-;; `init!` installs the adapter (it does NOT create the frame); the
-;; render root then establishes the frame in one spot via the
-;; `frame-provider` ENSURE form (`{:id app-frame …}`): on first mount
-;; it CREATES the frame, applies the config, and runs `:initial-events`
-;; once; on hot reload it REUSES the existing frame without re-seeding.
-;; Every in-tree `dispatch`/`subscribe` resolves to that frame.
+;; The app frame id. Every in-tree `dispatch`/`subscribe` resolves to
+;; this frame. The render-root `frame-provider` below establishes it
+;; (see `run`). EP-0002: an app must name its frame explicitly; the
+;; runtime never invents one.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the adapter by passing its spec map directly.
   (rf/init! reagent-adapter/adapter)
 
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; ENSURE form: create + configure + seed the app frame in one
-    ;; place. `:fx-overrides` redirects `:rf.http/managed` on the frame
-    ;; so every child loader's GET routes to the per-URL canned stub
-    ;; above (frame-wide; the boot example issues no non-mocked
-    ;; requests, so a blanket override is the right grain).
+    ;; The `frame-provider` below creates, configures, and seeds the app
+    ;; frame in one place (the `{:id …}` ENSURE form):
     ;;
-    ;; `:initial-events` seeds the boot exactly once on first mount.
-    ;; The `:app/boot` machine's :initial state and :data seed
-    ;; `[:rf.runtime/machines :snapshots :app/boot]` (runtime-db) on the
-    ;; eager creation kick (per Spec 005 §When creation happens — eager
-    ;; start vs lazy first event); :boot/initialise fires
-    ;; `[:app/boot [:rf.machine/start]]`, the creation marker that births
-    ;; the machine directly into :configuring and runs its :spawn
-    ;; entry-cascade, starting the boot sequence. On hot reload the frame
-    ;; is reused and the boot does NOT re-run.
+    ;; - `:fx-overrides` redirects `:rf.http/managed` on this frame to the
+    ;;   per-URL canned stub above, so every child loader's GET hits a
+    ;;   canned reply. Frame-wide is the right grain — the boot example
+    ;;   issues no other requests.
+    ;; - `:initial-events` fires `:boot/initialise` once on first mount,
+    ;;   which kicks off the boot machine. On hot reload the frame is
+    ;;   reused and the boot is not re-run.
     (rdc/render @react-root
                 [rf/frame-provider {:id             app-frame
                                     :doc            "Boot example demo frame."

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -19,8 +19,9 @@
 ;; -- Events / subs (the registrar is process-global) -------------------------
 ;;
 ;; Each handler is a pure (coeffects, event-vector) -> effect map fn. It
-;; doesn't perform the change; it returns `{:db …}` ("replace app-db with
-;; this") and the runtime commits it atomically at the end of the cascade.
+;; returns a description of the change — `{:db …}` means "replace app-db
+;; with this" — and the runtime commits it atomically at the end of the
+;; cascade. The handler computes the new value; it never mutates app-db.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -37,16 +38,15 @@
 ;; -- Views -------------------------------------------------------------------
 ;;
 ;; A view is a pure fn from subscription values to hiccup. This one reads
-;; state by dereffing a `subscribe` and dispatches an event on click —
-;; no business logic; the inc/dec live in the handlers above.
+;; state by dereffing a `subscribe` and dispatches an event on click. It
+;; holds no business logic — the inc/dec live in the handlers above.
 ;;
-;; Per Spec 004 §reg-view, the defn-shape macro auto-injects `dispatch`
-;; and `subscribe` as lexical bindings (so they aren't imported here);
-;; both resolve at render time to the frame in scope — see the boot
-;; below, where `frame-provider {:id app-frame}` scopes this tree to the
-;; app frame. The macro also auto-defs a Var named after the supplied
-;; symbol and registers the view under (keyword *ns* sym), so
-;; `counter-app` can reference it directly.
+;; `reg-view` (Spec 004 §reg-view) auto-injects `dispatch` and `subscribe`
+;; as lexical bindings, so they need no require here. Both resolve at
+;; render time to the frame in scope — the `frame-provider` in the boot
+;; below scopes this tree to the app frame. `reg-view` also defs a Var
+;; named after the symbol and registers the view under (keyword *ns* sym),
+;; so `counter-app` can reference `counter-buttons` directly.
 
 (reg-view counter-buttons []
   [:div
@@ -54,9 +54,8 @@
    [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:counter/value])]
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
-;; The root `counter-app` view just renders `counter-buttons`; the boot
-;; in `run` scopes the whole tree to `app-frame` and seeds it via the
-;; provider's `:initial-events`.
+;; The root `counter-app` view just renders `counter-buttons`. The boot in
+;; `run` wraps this tree in the `frame-provider` that establishes the frame.
 
 (reg-view counter-app []
   [counter-buttons])
@@ -70,24 +69,21 @@
 
 (defonce react-root (atom nil))
 
-;; The runtime never synthesises a frame from absence — an app must
-;; establish its frame explicitly. So the boot below does two things in
-;; order: `init!` installs the adapter (it does NOT create the frame),
-;; then the render's `frame-provider {:id app-frame}` does the rest in
-;; one spot — on first mount it CREATES the app frame, applies its
-;; config, and runs `:initial-events` once to seed it; thereafter every
-;; in-tree `dispatch`/`subscribe` resolves to that frame. On hot reload
-;; the provider REUSES the existing frame and does NOT re-seed.
+;; The whole frame lifecycle lives in one spot at the render root: the
+;; `frame-provider {:id app-frame …}` below. On first mount it creates the
+;; app frame, applies its config, and runs `:initial-events` once to seed
+;; app-db. Thereafter every `dispatch`/`subscribe` in the tree resolves to
+;; that frame. On hot reload the provider reuses the existing frame and
+;; skips re-seeding, so the counter keeps its value across re-mounts.
 ;;
-;; `:rf/default` is an ORDINARY frame id with no framework privilege — a
-;; migration may reach for it out of habit, but the runtime won't infer
-;; it; you establish it like any other.
+;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
+;; with no framework privilege — the runtime won't infer it, so we name it
+;; here and hand it to the provider like any other id.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; rf/init! takes the adapter spec map directly. Each adapter
-  ;; ns exports an `adapter` var; consumers require the ns and pass the
-  ;; var explicitly. There is no default-adapter registry.
+  ;; `init!` installs the reactive adapter for the process. Each adapter ns
+  ;; exports an `adapter` var; require the ns and pass that var directly.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -16,8 +16,7 @@
    flow ONLY when the derived value is part of the application's *state*:
 
      - other event handlers read it as plain `app-db` data (here:
-       `:checkout/place-order` reads `[:cart :total]` directly — no
-       subscribe ceremony inside a handler);
+       `:checkout/place-order` reads `[:cart :total]` straight off the db);
      - it should survive SSR hydration / time-travel revert / app-db
        serialisation (sub-cache contents do not survive the wire);
      - the derivation is stable enough to be worth registering.
@@ -32,9 +31,9 @@
       settle in one walk — right after the handler, before the db install.
    3. RUNTIME-TOGGLEABLE DERIVATION — the discount is a feature gate. The
       `:rf.fx/reg-flow` / `:rf.fx/clear-flow` fx register and clear the
-      `:cart/discount-rate` flow from a handler, mid-event. Flows are
-      runtime-registered and runtime-clearable — the derivation can be
-      switched on or off as state changes, not fixed at registration time.
+      `:cart/discount-rate` flow from a handler, mid-event. A flow can be
+      switched on or off as state changes — registered and cleared at
+      runtime, not just at boot.
 
    Demonstrates:
    - `rf/reg-flow`                                  (Spec 013 §Registration shape)
@@ -89,14 +88,13 @@
 ;; single walk, run right after the handler before the db install
 ;; (Spec 013 §Topological sort and cycle detection).
 ;;
-;; `:cart/discount-rate` is NOT registered at boot. When absent, its path
-;; is nil and `:cart/total`'s `:derive` treats it as 0% off. The "Apply
-;; 10% discount" button registers it via `:rf.fx/reg-flow`; "Remove
-;; discount" clears it via `:rf.fx/clear-flow` (which `dissoc-in`s the
-;; path back to nil). While registered it derives a flat 10% off the live
-;; subtotal — a constant rate today, but reading `[:cart :subtotal]` keeps
-;; it honest: a tiered "5% over $50" rule would slot straight in, and the
-;; rate stays fresh as the cart changes without re-registration.
+;; The discount starts off: `:cart/discount-rate` has no flow yet, so its
+;; path is nil and `:cart/total`'s `:derive` treats it as 0% off. The "Apply
+;; 10% discount" button registers the flow via `:rf.fx/reg-flow`; "Remove
+;; discount" clears it via `:rf.fx/clear-flow` (which `dissoc-in`s the path
+;; back to nil). While registered it derives a flat 10% off the live
+;; subtotal. It reads `[:cart :subtotal]` so the rate stays fresh as the cart
+;; changes, and a tiered "5% over $50" rule would slot straight in.
 (rf/reg-flow
   {:id     :cart/total
    :doc    "Subtotal less the active discount. Reads :cart/subtotal's
@@ -159,9 +157,9 @@
 ;; whose ONLY job is to drain: by the time it runs, the new flow is in the
 ;; registry, so the flow transform on that drain materialises
 ;; `[:cart :discount-rate]` (and the dependent `[:cart :total]`) at the
-;; discounted figure. The re-walk is driven by the dispatched event
-;; draining — NOT by `:cart/touch` writing anything (it writes nothing).
-;; This is the spec's own `:wizard/settle` pattern (§Sequencing).
+;; discounted figure. It is the drain itself that drives the re-walk;
+;; `:cart/touch` writes nothing. This is the spec's own `:wizard/settle`
+;; pattern (§Sequencing).
 (rf/reg-event :cart/apply-discount
   {:doc "Engage the 10%-off feature gate by registering a flow that writes
          the discount rate, then nudge a re-walk so :cart/total recomputes."}
@@ -186,12 +184,12 @@
           [:dispatch [:cart/touch]]]}))
 
 ;; No-op drain — Spec 013 §Sequencing's `:wizard/settle` verbatim:
-;; `(fn [{:keys [db]} _] {:db db})`, no schema, dispatched with no args. It
-;; writes NOTHING. Its sole purpose is to make a drain happen on this frame so
-;; the flow transform re-walks with the just-(de)registered discount flow
-;; now visible in the registry — materialising the one-drain-lagged
-;; output. The toggle is the `:rf.fx/reg-flow` / `:rf.fx/clear-flow`
-;; registration itself; this event is the drain that surfaces its effect.
+;; `(fn [{:keys [db]} _] {:db db})`. It returns the db unchanged; its job is
+;; to make one more drain happen on this frame. On that drain the flow
+;; transform re-walks with the just-(de)registered discount flow now visible
+;; in the registry, materialising the one-drain-lagged output. The toggle is
+;; the `:rf.fx/reg-flow` / `:rf.fx/clear-flow` itself; this event is the
+;; drain that surfaces it.
 (rf/reg-event :cart/touch
   {:doc "No-op drain. Exists only to trigger the re-walk that materialises
          the one-event-lagged discount flow output (Spec 013 §Sequencing)."}
@@ -199,9 +197,9 @@
 
 ;; Reading a flow's output inside an event handler — Spec 013 §Sub
 ;; integration (a). The handler reads [:cart :total] as plain `app-db`
-;; data; no subscribe, no special flow accessor. This is the central
-;; reason the total is a flow and not a sub: a sub's value lives in the
-;; view-facing sub-cache and is awkward to read from a handler.
+;; data. This is the central reason the total is a flow and not a sub: a
+;; sub's value lives in the view-facing sub-cache, which a handler can't
+;; easily reach.
 (rf/reg-event :checkout/place-order
   {:doc "Place the order. Reads the materialised :cart/total straight off
          app-db — the flow output IS ordinary application state."}
@@ -229,8 +227,7 @@
 
 (rf/reg-sub :cart/subtotal
   {:doc "Reads the :cart/subtotal flow's output at its :output-path — pattern (b)
-         from Spec 013 §Sub integration. No special flow sub-id; just an
-         app-db read."}
+         from Spec 013 §Sub integration. A plain app-db read, like any sub."}
   (fn [db _] (get-in db [:cart :subtotal])))
 
 (rf/reg-sub :cart/total
@@ -297,21 +294,18 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; EP-0002: the runtime never synthesises a frame from absence. The
-;; `frame-provider` ENSURE shape (`{:id …}`) does the whole job at the render
-;; root in one spot: on first mount it CREATES the frame, then runs its
-;; `:initial-events` ONCE to seed it (here `[:cart/initialise]`); on hot reload
-;; it REUSES the existing frame WITHOUT re-seeding. Wrapping the render also
-;; makes the `reg-view`-injected `dispatch`/`subscribe` resolve to that frame
-;; (a no-provider render reads the no-provider sentinel and raises
-;; :rf.error/no-frame-context). The frame id is `:rf/default` — the same id the
-;; ns-load `with-frame` flow registrations are scoped to above. (Note that
-;; `:rf/default` is an ordinary frame id with no framework privilege; `init!`
-;; never creates it for you, which is why the provider names the id here.)
+;; The `frame-provider` `{:id …}` shape sets up the frame in one spot at the
+;; render root (EP-0002). On first mount it creates the frame and runs its
+;; `:initial-events` once to seed it (here `[:cart/initialise]`); on hot reload
+;; it reuses the existing frame and skips the seed. Wrapping the render also
+;; makes the `reg-view`-injected `dispatch`/`subscribe` resolve to this frame —
+;; a render with no provider raises :rf.error/no-frame-context. The id is
+;; `:rf/default`, the same id the `with-frame` flow registrations use above.
+;; `:rf/default` is just an ordinary frame id, so the provider names it here.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the Reagent adapter so frames render through React.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/infinite_feed/core.cljs
+++ b/examples/reagent/infinite_feed/core.cljs
@@ -4,13 +4,11 @@
 
    The one idea: a load-more / infinite-scroll timeline is ONE growing resource
    the runtime owns. The view reads the merged list passively and dispatches a
-   single CAUSAL `:rf.resource/load-more`; it never threads a cursor and never
-   writes an append reducer. Composed as proper re-frame2: a `reg-resource` with
-   `:infinite true`, owned by the route, read through the PASSIVE infinite
-   subscription family. There is no app-db list slice, no `:loading-more?` flag,
-   no cursor threading, and no append reducer — the runtime owns all of it (that
-   is the whole point of the primitive: without it, an app hand-rolls every one
-   of those by hand).
+   single CAUSAL `:rf.resource/load-more`. The runtime holds the page list, the
+   cursor, the in-flight flag, and the append — so the app writes none of them.
+   Composed as proper re-frame2: a `reg-resource` with `:infinite true`, owned
+   by the route, read through the PASSIVE infinite subscription family. That is
+   the whole point of the primitive — without it, an app hand-rolls all of that.
 
    It teaches, in one cohesive app, the four facts the primitive surfaces:
 
@@ -19,11 +17,11 @@
      ONE cache entry. Route entry ensures PAGE 0; the view reads the merged
      list passively.
    - LOAD-MORE IS A CAUSAL EVENT — the \"Load more\" button dispatches
-     `[:rf.resource/load-more …]`. The view never fetches and never advances
-     a cursor; the runtime derives the next page param from the loaded tail.
-     It carries a `:cause` but NO `:owner` — the ROUTE already owns the feed
-     for its lifetime; load-more extends that one owned entry, it does not
-     mint a second owner (owner keeps alive; cause explains why).
+     `[:rf.resource/load-more …]` and the runtime derives the next page param
+     from the loaded tail. The event carries a `:cause` but NO `:owner`: the
+     ROUTE already owns the feed for its lifetime, so load-more extends that one
+     owned entry rather than minting a second owner (owner keeps it alive; cause
+     explains why it grew).
    - THE TERMINAL IS `nil` — `:next-page-param` returning nil is the single
      end-of-feed signal; the view reads `:has-next-page?` and shows an
      end-of-feed marker instead of the button.
@@ -164,8 +162,8 @@
 ;; cursor-paginated server would produce, so the feed lifecycle (page-0 ensure,
 ;; load-more cursor derivation, in-flight dedupe, the nil terminal) runs end to
 ;; end. It delegates to the framework-shipped `:rf.http/managed-canned-success`
-;; with `:after-ms` so the reply rides framework `:dispatch-later` (tape-
-;; visible, time-travel-safe, NOT raw js/setTimeout). Mirrors
+;; with `:after-ms`, so the reply rides framework `:dispatch-later` and stays
+;; tape-visible and time-travel-safe. Mirrors
 ;; examples/reagent/resources/core.cljs's stub.
 
 (def ^:private total-items 26)
@@ -176,9 +174,8 @@
          {:id i :title (str "Activity item #" (inc i))})))
 
 (def ^:private demo-reply-delay-ms
-  "How long the demo stub defers each canned reply (via the canned-success fx's
-   `:after-ms`, dispatched through `:dispatch-later` — tape-visible, NOT raw
-   js/setTimeout). Small but non-zero so the load-more spinner is observable. A
+  "How long the demo stub defers each canned reply (the canned-success fx's
+   `:after-ms`). Small but non-zero so the load-more spinner is observable. A
    demo-seam knob, not a production value."
   140)
 
@@ -193,12 +190,11 @@
     {:items     items
      :page-info {:next-cursor (when (< next total-items) next)}}))
 
-;; The resource runtime lowers every page fetch onto `:rf.http/managed`; this
-;; override stands in for the backend. It synthesises the per-cursor page and
-;; delegates to `:rf.http/managed-canned-success` (calling it via the registrar
-;; with `:after-ms` so the canned reply rides framework `:dispatch-later`, and
-;; the reply addressing the resource runtime put on the args-map — the PAGE
-;; reply handlers — is preserved).
+;; This override stands in for the backend. It synthesises the per-cursor page,
+;; then hands the rest to `:rf.http/managed-canned-success` via the registrar,
+;; adding `:after-ms` so the reply rides framework `:dispatch-later`. It reuses
+;; the incoming args-map, which keeps the reply addressing (the PAGE reply
+;; handlers the resource runtime set) intact.
 (rf/reg-fx :infinite-feed.demo/http-stub
   {:doc       "Demo override for `:rf.http/managed`: synthesises one enveloped
                page per request cursor so the feed runs standalone, then
@@ -273,12 +269,11 @@
        [:p {:data-testid "feed-skeleton"} "Loading the feed…"]
 
        ;; First load (page 0) failed with no usable data → full error screen.
-       ;; A page-0 FIRST-load failure with no accumulated pages settles the
-       ;; first-load `:error` channel + `:status :error` (Spec 016 §Status
-       ;; semantics — `:error` is reserved for first-load failure), exactly
-       ;; like a scalar resource; it is NOT the `:page-error` load-more channel
-       ;; (which is reserved for a page N>0 failure that keeps the feed). The
-       ;; whole-feed `:refresh-error` channel stays nil here.
+       ;; A page-0 failure with no accumulated pages settles the first-load
+       ;; `:error` channel + `:status :error` (Spec 016 §Status semantics —
+       ;; `:error` is reserved for first-load failure), exactly like a scalar
+       ;; resource. This is a different axis from `:page-error`, which a
+       ;; load-more (page N>0) failure uses while keeping the feed.
        (:error feed)
        [:p.error {:data-testid "feed-error"} "Could not load the feed."]
 
@@ -293,19 +288,19 @@
 
         ;; A LOAD-MORE failure (page N>0 — we have data) keeps every page
         ;; visible and surfaces :page-error — the inline "couldn't load more —
-        ;; retry" affordance (the THIRD error channel, distinct from the
-        ;; first-load :error full-screen above; a load-more failure never
-        ;; collapses the feed).
+        ;; retry" affordance. This is the THIRD error channel: a load-more
+        ;; failure leaves the feed intact, unlike the first-load :error
+        ;; full-screen above.
         (when (:page-error feed)
           [:p.warn {:data-testid "feed-page-error"}
            "Couldn't load more — tap retry."])
 
         ;; The load-more affordance: a spinner while a page is in flight, the
         ;; button while there is a next page, an end-of-feed marker otherwise.
-        ;; The view NEVER advances the cursor — it dispatches one causal event
-        ;; (a `:cause`, NO `:owner`: the route already owns the feed, load-more
-        ;; just extends it) and the runtime derives the next page param from
-        ;; the loaded tail.
+        ;; The button dispatches one causal event and the runtime derives the
+        ;; next page param from the loaded tail. The event carries a `:cause`
+        ;; but no `:owner` — the route already owns the feed, so load-more just
+        ;; extends it.
         (cond
           (:fetching-next? feed)
           [:p {:data-testid "feed-loading-more"} "Loading more…"]
@@ -337,16 +332,15 @@
 ;; ============================================================================
 ;;
 ;; The React root is materialised lazily inside `run` (not at ns-load) per
-;; examples/TESTING.md §Example mount-isolation convention. EP-0002 + EP-0024:
-;; the app establishes its frame in ONE spot — the render-root
-;; `frame-provider {:id …}` ENSURE shape. On first mount it CREATES the
-;; `app-frame`, applies its config (declares `:url-bound? true` so it owns the
-;; browser URL, overrides `:rf.http/managed` with the per-cursor canned stub so
-;; the example runs standalone), and scopes that frame so every in-tree
-;; dispatch/subscribe resolves to it. On hot reload it REUSES the same frame
-;; without re-creating it. There is no separate `reg-frame` step and no boot
-;; seed: route entry's `:resources` plan ensures PAGE 0, so the feed needs no
-;; `:initial-events`.
+;; examples/TESTING.md §Example mount-isolation convention. The app establishes
+;; its frame in ONE spot: the render-root `frame-provider {:id …}` (EP-0002 +
+;; EP-0024). On first mount the provider CREATES the `app-frame` and applies its
+;; config — `:url-bound? true` so the frame owns the browser URL, and the
+;; `:rf.http/managed` override that points page fetches at the canned stub so the
+;; example runs standalone. The provider also scopes that frame, so every in-tree
+;; dispatch/subscribe resolves to it. On hot reload it REUSES the same frame.
+;; The feed itself needs no boot seed: route entry's `:resources` plan ensures
+;; PAGE 0, so the frame carries no `:initial-events`.
 
 (defonce react-root (atom nil))
 
@@ -358,9 +352,8 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; ENSURE shape (EP-0024): CREATE the app frame on first mount with its
-    ;; config, REUSE it on hot reload without re-seeding. The route's
-    ;; `:resources` plan ensures PAGE 0, so there are no `:initial-events`.
+    ;; The provider creates the app frame (with its config) on first mount and
+    ;; reuses it on hot reload. Route entry ensures PAGE 0, so no `:initial-events`.
     (rdc/render @react-root
                 [rf/frame-provider {:id           app-frame
                                     :doc          "Infinite-feed demo frame."

--- a/examples/reagent/linearlite/core.cljs
+++ b/examples/reagent/linearlite/core.cljs
@@ -17,9 +17,9 @@
    - THE WRITE SHOWS IMMEDIATELY — each mutation declares `:optimistic`, the
      EXACT-target twin of `:patches`: `(fn [params] -> {target patch-fn})`. The
      patch runs at PHASE 1.5, before the request lowers, so the new card
-     appears / the title changes / the card moves the instant the user acts.
-     The view never mutates app-db itself — there is NO app-db issue list, no
-     `:saving?` flag, no manual optimistic copy. The runtime owns the cache.
+     appears / the title changes / the card moves the instant the user acts. The
+     runtime owns the cache and shows the optimistic value; the view just reads
+     it. (No app-db issue list, no `:saving?` flag to keep in sync.)
 
    - THE INVERSE IS RUNTIME-RECORDED — the author writes only the FORWARD
      patch. The runtime snapshots each touched entry's whole `:before` value
@@ -39,7 +39,7 @@
      optimistic change paints immediately, the request fails, and the runtime
      rolls the board back to exactly its pre-click state — the new card
      vanishes, the retitled card reverts, the moved card snaps back — with a
-     red banner naming the failure. No manual undo, no app-db bookkeeping.
+     red banner naming the failure. The runtime owns the undo.
 
    The board is read PASSIVELY through `[:rf.resource/data …]` (the resource
    sub family); each in-flight write is watched through the passive
@@ -57,8 +57,7 @@
 
    IDIOMATIC re-frame2. The board is a single managed resource; every write is
    a named `reg-mutation`; the toggle is an ordinary app-db slice driven by an
-   event and read by a sub. NO raw atoms through views, NO frame-ids as view
-   args, no vestigial timing. The example ships no backend, so it overrides
+   event and read by a sub. The example ships no backend, so it overrides
    `:rf.http/managed` with a canned stub (mirroring
    `examples/reagent/infinite_feed/`) that synthesises the board reply and,
    when armed, the 503 — so the whole optimistic lifecycle runs standalone.
@@ -119,9 +118,9 @@
 ;; route ensures it on entry; the view reads it passively. Every optimistic
 ;; write patches THIS one entry's `:data` in place (the exact-target
 ;; `:optimistic` twin of `:patches`), and the success reply re-seeds it with
-;; the server's authoritative board via `:populates`. There is no app-db issue
-;; list — the runtime owns the board value, its freshness, and the snapshot
-;; inverse that makes rollback truthful.
+;; the server's authoritative board via `:populates`. The runtime owns the board
+;; value, its freshness, and the snapshot inverse that makes rollback truthful
+;; (the board lives in the resource cache, not in app-db).
 
 (rf/reg-resource :linearlite/board
   {:doc            "The whole issue board — `{:issues [...]}` — as one managed
@@ -283,9 +282,9 @@
 ;; resources + mutations lower every read/write onto) with a stub that holds
 ;; the canonical board in a closure and synthesises the authoritative reply for
 ;; each read/write. It delegates to the framework-shipped
-;; `:rf.http/managed-canned-success` / `-failure` with `:after-ms` so the reply
-;; rides framework `:dispatch-later` (tape-visible, time-travel-safe, NOT raw
-;; js/setTimeout) — letting the optimistic value paint before the reply lands.
+;; `:rf.http/managed-canned-success` / `-failure` with `:after-ms`, so the reply
+;; rides framework `:dispatch-later` — tape-visible and time-travel-safe (not a
+;; raw js/setTimeout) — and the optimistic value paints before the reply lands.
 ;;
 ;; THE FAILURE SEAM. `fail-next-write?` is read from app-db at request time:
 ;; when armed, the stub answers the next WRITE with a 503 (via
@@ -295,9 +294,8 @@
 
 (def ^:private demo-reply-delay-ms
   "How long the demo stub defers each canned reply (via `:after-ms` →
-   `:dispatch-later` — tape-visible, NOT raw js/setTimeout). Small but non-zero
-   so the optimistic value is visibly painted before the reply lands. A
-   demo-seam knob, not a production value."
+   `:dispatch-later`). Small but non-zero so the optimistic value is visibly
+   painted before the reply lands. A demo-seam knob, not a production value."
   220)
 
 ;; The canonical server board the stub maintains across requests, so a committed
@@ -396,7 +394,7 @@
 ;; failure-seam toggle, the new-issue draft, and the id of the issue being
 ;; inline-retitled. The issue board itself is NOT in app-db (the resource owns
 ;; it). These are ordinary slices: an event writes, a sub reads, the view reads
-;; the sub. No raw atoms, no frame-ids as view args.
+;; the sub.
 
 (reg-event :linearlite/set-fail-next-write
   (fn [db [_ on?]] (assoc db :fail-next-write? on?)))
@@ -421,9 +419,9 @@
 ;;
 ;; Each write is a thin event that dispatches `:rf.mutation/execute` with a
 ;; per-issue (or per-create) instance id, then resets the relevant UI slice.
-;; The view never touches the board — it watches the mutation instance and
-;; reads the board resource passively; the runtime applies the optimistic
-;; patch, sends the request, and commits / rolls back on the reply.
+;; The view watches the mutation instance and reads the board resource
+;; passively; the runtime applies the optimistic patch, sends the request, and
+;; commits / rolls back on the reply.
 
 (reg-event :linearlite/create-issue
   (fn [{:keys [db]} [_ title]]
@@ -604,16 +602,15 @@
 ;; examples/TESTING.md §Example mount-isolation convention. EP-0002: the app
 ;; frame is created, configured, and provided in ONE spot — the render root's
 ;; `frame-provider {:id app-frame …}` ENSURE form. On first mount it creates the
-;; frame under `app-frame`, applies the config (`:url-bound? true` so it owns the
-;; browser URL, and a `:rf.http/managed` override pointing at the canned board
-;; stub so the example runs standalone), and would run any `:initial-events`
-;; once. On hot reload it REUSES the existing frame WITHOUT re-seeding, so app-db
-;; survives the reload. That id is what every in-tree dispatch/subscribe resolves
-;; against — no separate `reg-frame` or `{:frame …}` scope step.
+;; frame under `app-frame` and applies the config: `:url-bound? true` so it owns
+;; the browser URL, and a `:rf.http/managed` override pointing at the canned
+;; board stub so the example runs standalone. On hot reload it reuses that same
+;; frame and keeps its app-db. Every in-tree dispatch/subscribe resolves against
+;; that id (which is why there is no separate `reg-frame` step).
 ;;
-;; There are NO `:initial-events`: the board isn't seeded at boot but ensured on
-;; route entry by the `:linearlite.app/board` route's `:resources` metadata,
-;; driven by the initial URL sync that `rf/install-history-listener!` performs.
+;; The board is seeded by route entry, not at boot: the `:linearlite.app/board`
+;; route's `:resources` metadata ensures it, driven by the initial URL sync
+;; `rf/install-history-listener!` performs — hence no `:initial-events`.
 
 (defonce react-root (atom nil))
 
@@ -625,8 +622,9 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; ENSURE form: create + configure the app frame in one spot. First mount
-    ;; creates it under `app-frame` and applies the config; hot reload reuses it.
+    ;; ENSURE form: the app frame is created and configured in one spot. First
+    ;; mount creates it under `app-frame` and applies the config; hot reload
+    ;; reuses it.
     (rdc/render @react-root
                 [rf/frame-provider {:id           app-frame
                                     :doc          "Linearlite optimistic-board demo frame."

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -664,31 +664,28 @@
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the Reagent adapter. Pass its spec map straight to init!.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; EP-0026: one-spot frame setup via the `frame-provider` ENSURE shape
-    ;; (`{:id …}`). On first mount it CREATES `:rf/default`, applies the
-    ;; config below, and runs `:initial-events` ONCE; on hot reload it REUSES
-    ;; the existing frame WITHOUT re-seeding. No separate `reg-frame` /
-    ;; `with-frame` boot step.
+    ;; EP-0026: one-spot frame setup. The `frame-provider` ENSURE shape
+    ;; (`{:id …}`) creates `:rf/default` on first mount, applies the config
+    ;; below, runs `:initial-events` once, and scopes the frame into React.
+    ;; On hot reload it reuses the existing frame and skips re-seeding.
     ;;
     ;; - `:fx-overrides` routes `:rf.http/managed` to the in-process login
     ;;   stub above so the example runs standalone — no backend required.
     ;; - `:initial-events` seeds the login-form slice to its empty
     ;;   Pattern-Forms shape so the controlled inputs read a real
-    ;;   (empty-string) draft from the first render — an uninitialised draft
-    ;;   would feed React `nil` :values (uncontrolled inputs). The machine is
-    ;;   self-initialising (no seed needed); the SLICE is app-db, so it is
-    ;;   seeded here.
+    ;;   (empty-string) draft from the first render. (An uninitialised draft
+    ;;   would feed React `nil` :values — uncontrolled inputs.) The machine
+    ;;   self-initialises; the SLICE is app-db, so it is seeded here.
     ;;
-    ;; The provider also scopes the frame into React so the
-    ;; `reg-view`-injected `dispatch`/`subscribe` (and the login machine reads)
-    ;; resolve to `:rf/default` via context. With NO provider a `reg-view`
-    ;; reads the no-provider sentinel and those calls raise
-    ;; `:rf.error/no-frame-context` (there is no `:rf/default` floor).
+    ;; The provider scope is what makes the `reg-view`-injected
+    ;; `dispatch`/`subscribe` (and the login machine reads) resolve to
+    ;; `:rf/default`. A `reg-view` rendered with no provider raises
+    ;; `:rf.error/no-frame-context`.
     (rdc/render @react-root
                 [rf/frame-provider {:id             :rf/default
                                     :doc            "Login demo frame."

--- a/examples/reagent/login/stories.cljs
+++ b/examples/reagent/login/stories.cljs
@@ -196,8 +196,7 @@
   ;; the SAME `:auth.login/edit-field` events the controlled inputs fire on
   ;; keystroke, writing into the app-db login-form slice. The machine stays
   ;; `:idle` (no submit yet); the inputs render the seeded draft as their
-  ;; `:value`. (Before the Pattern-Forms refactor the draft lived in a
-  ;; component-local atom and was NOT event-reachable — see the ns docstring.)
+  ;; `:value`.
   (story/reg-variant :story.login/filled
     {:doc        "Both fields filled in, nothing submitted yet — the form
                  mid-edit. The draft was typed into the app-db login-form

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -99,21 +99,19 @@
 
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame),
-;; then `frame-provider {:id app-frame …}` does the rest in one spot: on
-;; first mount it CREATES the app frame, applies its config, and runs
-;; `:initial-events` (the `[:app/initialise]` boot dispatch) ONCE; on hot
-;; reload it REUSES the same frame WITHOUT re-seeding. Every in-tree
-;; `dispatch`/`subscribe` resolves to that frame. Matches the canonical
-;; mount in examples/reagent/counter/core.cljs. The work-bench wrapper's
-;; `r/with-let` cleanup (views.cljs) dispatches `[:work/flow [:cancel]]`
-;; from within render scope, so it resolves to this frame via the provider.
+;; The frame is established in one spot: the `frame-provider {:id app-frame …}`
+;; at the render root below. On first mount it creates the app frame, applies
+;; its config, and runs `:initial-events` (the `[:app/initialise]` boot
+;; dispatch) once; on hot reload it reuses the same frame and skips re-seeding.
+;; Every in-tree `dispatch`/`subscribe` resolves to that frame — including the
+;; work-bench wrapper's `r/with-let` cleanup (views.cljs), which dispatches
+;; `[:work/flow [:cancel]]` from within render scope. Matches the canonical
+;; mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the Reagent adapter, then mount the provider (which establishes
+  ;; the frame — see above).
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -342,21 +342,22 @@
 
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame).
-;; The render root then wraps the tree in a `frame-provider` keyed by
-;; `:id`: that one spot creates the app frame on first mount, applies its
-;; config, runs `:initial-events` once (the `[:counter/initialise]` seed),
-;; and on hot reload reuses the existing frame without re-seeding — so
-;; every in-tree `dispatch`/`subscribe` resolves to the app frame.
-;; `:rf/default` is an ordinary frame id with no framework privilege —
-;; just the name this app chose. Matches the canonical mount in
-;; examples/reagent/counter/core.cljs.
+;; The app establishes its frame explicitly, in one spot: the render
+;; root's `frame-provider {:id app-frame}`. On first mount it creates the
+;; app frame, applies its config, and runs `:initial-events` once (the
+;; `[:counter/initialise]` seed); on hot reload it reuses that frame and
+;; skips the seed. Every in-tree `dispatch`/`subscribe` then resolves to
+;; the app frame.
+;;
+;; `:rf/default` is just the id this app chose — an ordinary frame id with
+;; no framework privilege, so the runtime won't infer it for you. Matches
+;; the canonical mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; `init!` installs the Reagent adapter. Pass the adapter spec map
+  ;; (each adapter ns exports an `adapter` var) directly. It installs the
+  ;; adapter only; the frame-provider below creates the frame.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -730,27 +730,20 @@
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; `init!` installs the Reagent adapter (EP-0002).
   (rf/init! reagent-adapter/adapter)
-  ;; EP-0002: the runtime never synthesises a frame from absence —
-  ;; the app must establish its frame explicitly. `init!` installs the
-  ;; adapter only (it does NOT create the frame).
-  ;;
-  ;; EP-0026: one-spot frame setup via the `frame-provider` ENSURE shape
-  ;; (`{:id …}`). On first mount it CREATES `:rf/default`, applies the config
-  ;; below, and runs `:initial-events` ONCE; on hot reload it REUSES the
-  ;; existing frame WITHOUT re-seeding. Create, seed, and scope-into-React all
-  ;; happen in that one spot — no separate `reg-frame` / `with-frame` boot step.
+  ;; EP-0026: the `frame-provider {:id …}` below is the one spot that owns
+  ;; the frame. On first mount it creates `:rf/default`, applies the config,
+  ;; and runs `:initial-events` once; on hot reload it reuses the existing
+  ;; frame and skips re-seeding. Config:
   ;;
   ;; - `:fx-overrides` routes `:rf.http/managed` to the in-process canned-stub
-  ;;   fxs above so the example runs standalone — no backend required.
+  ;;   fxs above, so the example runs standalone with no backend.
   ;; - `:initial-events` seeds the app via `[:nine-states.app/initialise]`.
   ;;
-  ;; The provider also scopes the frame into React so the `reg-view`-injected
-  ;; `dispatch`/`subscribe` (and `root-view`'s subs) resolve to `:rf/default`
-  ;; via context. With NO provider a `reg-view` reads the no-provider sentinel
-  ;; and those calls raise `:rf.error/no-frame-context`. The frame id is the
-  ;; same `:rf/default` that `reg-app-schema` is scoped to at ns-load above.
+  ;; The provider also scopes the frame into React, so the `reg-view`-injected
+  ;; `dispatch`/`subscribe` (and `root-view`'s subs) resolve to `:rf/default`.
+  ;; This is the same `:rf/default` the `reg-app-schema` above is scoped to.
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))

--- a/examples/reagent/nine_states/stories_host.cljs
+++ b/examples/reagent/nine_states/stories_host.cljs
@@ -61,21 +61,19 @@
 
 ;; -- The live-app frame ----------------------------------------------------
 ;;
-;; The live `#/` surface needs the example's demo HTTP override on its
-;; frame so `:rf.http/managed` routes to the in-process
-;; `:nine-states.http/managed-demo` stub (no backend). This mirrors what
-;; `nine-states.core/run` installs on `:rf/default`; we register it here
-;; so the host owns the full boot (the host does not call
-;; `core/run`, which hardcodes its own stock-Reagent mount lifecycle).
+;; This host owns its own boot; it does not call `core/run` (which carries
+;; its own stock-Reagent mount lifecycle). So it registers the live-app
+;; frame here. The frame gives the live `#/` surface the example's demo HTTP
+;; override, routing `:rf.http/managed` to the in-process
+;; `:nine-states.http/managed-demo` stub (no backend).
 
 (defn- install-live-frame! []
   (rf/reg-frame :rf/default
     {:doc          "Nine-states showcase live-app frame."
      :fx-overrides {:rf.http/managed :nine-states.http/managed-demo}})
-  ;; EP-0002: `init!` installs the adapter only — a frameless
-  ;; `dispatch-sync` raises `:rf.error/no-frame-context`. Run the seed
-  ;; dispatch inside the showcase's `:rf/default` frame scope (symmetric to
-  ;; nine_states.core/run, which wraps its initialise in `with-frame`).
+  ;; Seed the frame. `dispatch-sync` runs inside `with-frame :rf/default` so
+  ;; it targets that frame (a frameless dispatch raises
+  ;; `:rf.error/no-frame-context`, EP-0002).
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:nine-states.app/initialise])))
 
@@ -90,13 +88,11 @@
     " on either surface to open Xray and inspect the fetch cascade."]
    [core/root-view]])
 
-;; EP-0002: the runtime never synthesises a frame from absence,
-;; so the live-app `#/` surface must render under an explicit frame scope. The
-;; Story shell side (`#/stories`) allocates its own per-variant frames; this
-;; wrapper scopes only the live-app surface to the showcase's `:rf/default`
-;; frame so `nine-states-app`'s reg-view-injected dispatch/subscribe (and
-;; `core/root-view`'s subs) resolve. Passed to the shared story-host as the
-;; live-app root view (mirrors counter-with-stories.core).
+;; Scope the live `#/` surface into the showcase's `:rf/default` frame, so
+;; `nine-states-app`'s reg-view-injected dispatch/subscribe (and
+;; `core/root-view`'s subs) resolve to it (EP-0002). The Story shell side
+;; (`#/stories`) allocates its own per-variant frames. Passed to the shared
+;; story-host as the live-app root view (mirrors counter-with-stories.core).
 (defn live-app-root []
   [rf/frame-provider {:frame :rf/default} [nine-states-app]])
 

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -84,13 +84,13 @@
                       docs))))}))
 
 ;; EP-0010 (Causal World Inputs): the new document's id is written into durable
-;; app-db (`:notebook/documents`), so it must be a function of prior frame-state
-;; — never an ambient `(rand-int)` read at the durable-write site (a fresh
-;; event-stream replay would mint a different id, breaking replay determinism).
-;; So we allocate it deterministically from the existing documents, the todomvc
-;; `allocate-next-id` idiom: scan the `doc-N` keyword ids already in app-db and
-;; take max+1. Seeded ids (`:welcome`, `:six-dominoes`, …) carry no `doc-`
-;; prefix, so they don't participate — the first minted id is `:doc-1`.
+;; app-db (`:notebook/documents`), so it is derived from the documents already
+;; there — the todomvc `allocate-next-id` idiom. Scan the `doc-N` keyword ids
+;; in app-db and take max+1. Because the id comes from prior state, replaying
+;; the event stream mints the same id. (Reaching for `(rand-int)` here would
+;; break that: each replay would mint a different id.) Seeded ids (`:welcome`,
+;; `:six-dominoes`, …) carry no `doc-` prefix, so the first minted id is
+;; `:doc-1`.
 (defn- allocate-next-doc-id
   "Deterministic next `:doc-N` id from the existing documents — max prior
    N + 1 (1 when none yet). A pure function of prior app-db state, so it
@@ -347,18 +347,18 @@
 
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame).
-;; The render root then establishes the app frame in ONE spot: the
-;; `frame-provider` `{:id …}` ENSURE form creates the frame on first mount,
-;; runs `:initial-events` once to seed app-db before the first paint, and on
-;; hot reload reuses the same frame WITHOUT re-seeding. Every in-tree
-;; `dispatch`/`subscribe` then resolves to that frame. Matches the canonical
+;; The whole frame is established in one spot — the render root's
+;; `frame-provider {:id app-frame}` below. On first mount it creates the app
+;; frame and runs `:initial-events` once to seed app-db before the first
+;; paint; on hot reload it reuses the same frame and skips the seed. Every
+;; in-tree `dispatch`/`subscribe` then resolves to that frame. `app-frame` is
+;; an ordinary frame id with no framework privilege. Matches the canonical
 ;; mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
+  ;; `init!` installs the Reagent adapter. The frame itself is created by the
+  ;; `frame-provider` in the render call below.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -5,8 +5,9 @@
    - Pulls in every feature namespace (each registers its own events/subs/fx).
    - Defines :app/initialise (the boot event, run via the frame's :initial-events).
    - Defines the root-view that switches on :rf.route/id.
-   - Mounts the React root (the `frame-provider {:id …}` ENSURE form creates +
-     seeds the app frame in one spot) and installs the URL listener.
+   - Mounts the React root. The `frame-provider {:id …}` at the render root
+     creates and seeds the app frame in one spot.
+   - Installs the URL listener.
 
    This is single-file glue; the per-feature work lives in:
      auth.cljs             — login / register / session-restore
@@ -79,11 +80,11 @@
 
 (rf/reg-event :app/initialise
   {:doc "App boot. Fans out to per-feature initialisers. `:auth/initialise` is
-         NOT in this fan-out — it consumes the RECORDABLE-GENERATOR
-         `:auth.session/token` coeffect (EP-0017). The `:dispatch` fx does not
-         forward `:rf.cofx`, so issuing it as a plain boundary dispatch in `run`
-         (rather than through this fan-out) keeps the generated token on its own
-         boot dispatch token, where it is recorded."}
+         kept out of this fan-out and listed as its own `:initial-event` in the
+         frame-provider: it consumes the recordable-generator
+         `:auth.session/token` coeffect (EP-0017), and the `:dispatch` fx does
+         not forward `:rf.cofx`. Running it on its own boot dispatch token is
+         what lets the generated token be recorded."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:articles/initialise]]
           [:dispatch [:article/initialise]]
@@ -104,8 +105,17 @@
 ;; framework folds the declaration into the per-frame elision registry, so any
 ;; off-box egress (Xray/observability capture, an off-box tool, an SSR
 ;; hydration payload) sees the token redacted while on-box rendering keeps the
-;; raw value. (EP-0025 removed the durable `:sensitive {:app-db …}` frame
-;; annotation — a frame is not app-db's definition site.)
+;; raw value. The declaration lives on the event, not the frame: a frame is not
+;; app-db's definition site.
+;;
+;; This app classifies exactly one path. The outbound `Authorization` Bearer
+;; header rides the framework's built-in HTTP carrier denylist (Spec 014
+;; §Privacy, alongside Cookie / X-API-Key / …), so it is redacted off-box with
+;; no app config — the `:sensitive :http :headers` extension is for app-specific
+;; carriers, and this app sends none. The login / register password drafts at
+;; [:auth :login-form] / [:auth :register-form] are transient form state owned
+;; by their registrations, never sent off-box from app-db, so they need no
+;; classification either.
 (rf/reg-event :auth/classify-token
   {:doc "Classifies the durable JWT path [:auth :token] sensitive at frame
          creation (EP-0025 commit-plane classification effect)."}
@@ -437,16 +447,14 @@
           stub    (registrar/handler :fx :rf.http/managed-canned-success)]
       (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))
 
-;; React root named `react-root` (not `root`) so it does NOT collide with
-;; the `root-view` reg-view above. Held in an atom and populated lazily
-;; inside `run` rather than at ns-load. Multiple example namespaces
-;; (this one, nine-states, boot, long-running-work, websocket)
-;; are co-required by the browser-test bundle's wrapper test namespaces
-;; — and the test harness shares a single `#app` mount point. Performing
-;; `create-root` at ns-load would race multiple roots onto the same
-;; container, leaking example-A's mount into example-B's tests (and
-;; emitting React "createRoot called twice" warnings). Mounting only in
-;; `run` keeps ns-load DOM-side-effect-free.
+;; The React root, held in an atom and created lazily inside `run` so that
+;; loading this namespace has no DOM side effects. Several example namespaces
+;; (this one, nine-states, boot, long-running-work, websocket) are co-required
+;; by the browser-test bundle and share a single `#app` mount point; creating
+;; the root at ns-load would race multiple roots onto the same container and
+;; leak one example's mount into another's tests (and emit React "createRoot
+;; called twice" warnings). The name `react-root` keeps it clear of the
+;; `root-view` reg-view above.
 (defonce react-root (atom nil))
 
 ;; ============================================================================
@@ -487,17 +495,16 @@
 ;; window.__conduit_debug__  — CONFORMANCE-CONTRACT SURFACE
 ;; ============================================================================
 ;;
-;; The official RealWorld browser/E2E harness sometimes reads app session state
-;; through a global accessor rather than poking the framework's internals. This
-;; installs `window.__conduit_debug__` with `getToken` / `getAuthState` /
-;; `getCurrentUser`, reading the live `:rf/default` frame's app-db.
+;; The official RealWorld E2E harness reads app session state through a global
+;; accessor. This installs `window.__conduit_debug__` with `getToken` /
+;; `getAuthState` / `getCurrentUser`, each reading the live `:rf/default`
+;; frame's app-db. It exists only so that external suite can introspect this
+;; demo; a production app would not ship it.
 ;;
-;; THIS IS A CONFORMANCE SURFACE, NOT A re-frame2 PATTERN. An unannotated global
-;; token accessor is exactly the anti-pattern that gets copied into real apps
-;; (it bypasses the frame/sub system and leaks the raw JWT to any script on the
-;; page). Real re-frame2 code reads session state through subs under the frame
-;; provider — never a `window.*` global. It exists ONLY so the external suite
-;; can introspect this demo; a production RealWorld app would NOT ship it.
+;; This is a test seam, not a re-frame2 pattern. A global token accessor is the
+;; kind of thing that gets copied into real apps, where it bypasses the
+;; frame/sub system and leaks the raw JWT to any script on the page. Real
+;; re-frame2 code reads session state through subs under the frame provider.
 (defn- install-conduit-debug! [frame-id]
   (when (exists? js/window)
     (set! (.-__conduit_debug__ js/window)
@@ -508,98 +515,64 @@
                :getCurrentUser (fn [] (clj->js (some-> (rf/app-db-value frame-id) :auth :user)))})))
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the Reagent adapter. This is the one frameworky thing that must
+  ;; happen before any frame mounts; everything else here is app wiring.
   (rf/init! reagent-adapter/adapter)
-  ;; Override :rf.http/managed on the default frame so all the realworld
-  ;; feature HTTP calls land on the demo stub (no real backend required).
-  ;; The auth-guard interceptor (registered in routing.cljs via
-  ;; `reg-interceptor` and referenced BY ID per EP-0022 in the provider's
-  ;; `:interceptors` below) is prepended to
-  ;; every event in this frame (Spec 002 §`:interceptors`) — it short-circuits
-  ;; for all non-navigation events and redirects unauthenticated
-  ;; `:rf.route/navigate` to `:requires-auth`-tagged routes to login (Spec
-  ;; 012 §Redirects and guards). This is what makes the `:requires-auth`
-  ;; tags on :realworld.user/settings / :realworld.editor/new / :realworld.editor/edit actually
-  ;; protect those routes.
-  ;; EP-0002: the runtime never synthesises a frame
-  ;; from absence, and URL ownership is an EXPLICIT declaration — this frame
-  ;; carries `:url-bound? true` so it owns the browser URL (Spec 012
-  ;; §Multi-frame routing). The frame is CREATED, configured, and SEEDED in ONE
-  ;; spot: the `frame-provider {:id …}` ENSURE form at the render root below.
-  ;; First mount creates `:rf/default`, applies this config, and runs
-  ;; `:initial-events` once; hot reload REUSES the frame WITHOUT re-seeding
-  ;; (durable app-db survives; `:initial-events` are re-recorded, not replayed).
-  ;; EP-0025 (durable egress classification): the JWT lives at [:auth :token]
-  ;; in app-db, so that path is classified `:sensitive`. Classification rides
-  ;; the commit-plane `:sensitive` effect (`:auth/classify-token`, the FIRST of
-  ;; the frame's `:initial-events` at frame creation, before the session-restore
-  ;; token write and any off-box egress). Projection happens at the trust boundary, so any off-box
-  ;; egress — Xray/observability capture, an off-box tool, an SSR hydration
-  ;; payload — sees the token redacted while on-box rendering (the navbar, the
-  ;; live header the request actually sends) keeps the raw value.
-  ;;
-  ;; The outbound `Authorization` Bearer header is NOT declared here: it is
-  ;; already on the framework's immutable built-in HTTP carrier denylist
-  ;; (Spec 014 §Privacy — alongside Cookie / X-API-Key / …), so it is redacted
-  ;; off-box with no frame config. The `:sensitive :http :headers` extension is
-  ;; for APP-SPECIFIC carriers (e.g. an "X-Tenant-Key"); this app sends none,
-  ;; so it declares no HTTP carriers — over-declaring a built-in would only
-  ;; teach a redundant ritual.
-  ;;
-  ;; We also do NOT classify [:auth :login-form] / [:auth :register-form]: the
-  ;; password draft is transient form state, owned by its registration, not a
-  ;; durable frame fact (and is never sent off-box from app-db). This is the
-  ;; canonical issue-5 case from the EP, surfaced only where the data is real.
-  ;; Register the Bearer-auth interceptor at app boot. Order matters:
-  ;; before the frame's `:initial-events` run, since session-restore will fire
-  ;; authenticated requests as soon as the JWT is hydrated.
+  ;; Register the Bearer-auth interceptor. It reads the JWT from the auth slice
+  ;; and adds the `Authorization` header to outbound :rf.http/managed requests
+  ;; (see bearer-auth-interceptor above). Register it now, before the frame's
+  ;; `:initial-events` run, so it is in place when session-restore fires its
+  ;; first authenticated request.
   (rf/reg-http-interceptor :realworld/bearer-auth
                            {:before bearer-auth-interceptor})
-  ;; The orchestrator serves this example at /realworld/; strip that
-  ;; prefix before the route matcher sees the URL so :realworld/home (path "/")
-  ;; matches. Set before the ENSURE provider renders so the `:initial-events`
-  ;; URL sync (below) and the popstate listener see the stripped URL.
+  ;; The orchestrator serves this example under /realworld/. Strip that prefix
+  ;; so :realworld/home (path "/") matches. Set it before the provider renders,
+  ;; so the initial URL→slice sync and the popstate listener see the stripped
+  ;; URL.
   (routing/set-base-path! "/realworld")
-  ;; Wire the popstate listener for Back/Forward (Spec 012 §popstate drives the
-  ;; URL owner). This example serves from a `/realworld/` sub-path and strips it
-  ;; in `current-url`, so it keeps its own base-path-aware listener rather than
-  ;; the framework's `rf/install-history-listener!`. The listener targets the
-  ;; URL owner resolved AT POP TIME and is idempotent (hot-reload safe). The
-  ;; INITIAL URL→slice sync is seeded once via the frame's `:initial-events`
-  ;; (`:rf.route/handle-url-change` below), which run synchronously at frame
-  ;; creation — so a deep link lands on the right route on first paint without
-  ;; depending on React's render-flush timing.
+  ;; Wire the popstate listener for Back/Forward (Spec 012 §popstate). Because
+  ;; this example strips its `/realworld/` prefix in `current-url`, it uses its
+  ;; own base-path-aware listener (the framework's `rf/install-history-listener!`
+  ;; assumes a root-served app). The listener resolves the URL owner at pop time
+  ;; and is hot-reload safe. The FIRST URL→slice sync is seeded once by the
+  ;; frame's `:initial-events` (`:rf.route/handle-url-change` below), which run
+  ;; at frame creation — so a deep link lands on the right route on first paint.
   (routing/install-router!)
-  ;; Conformance-contract surface — NOT a re-frame2 pattern; see
-  ;; install-conduit-debug! above. The external RealWorld suite may read it.
+  ;; Install the conformance accessor for the external RealWorld suite. This is
+  ;; a test seam, not a re-frame2 pattern — see install-conduit-debug! above.
   (install-conduit-debug! :rf/default)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; ENSURE form: create + configure + seed the app frame in ONE spot. First
-    ;; mount creates `:rf/default`, applies `:url-bound? true` + the demo
-    ;; `:fx-overrides` + the auth-guard interceptor, and runs `:initial-events`
-    ;; once; hot reload reuses it without re-seeding.
+    ;; The frame lives here. `frame-provider {:id …}` creates, configures, and
+    ;; seeds the app frame in one spot at the render root. First mount creates
+    ;; `:rf/default` and applies its config:
+    ;;   - `:url-bound? true` — this frame owns the browser URL (Spec 012).
+    ;;   - `:interceptors [:realworld.routing/auth-guard]` — the guard (defined
+    ;;     in routing.cljs, referenced by id per EP-0022) runs on every event in
+    ;;     the frame. It redirects an unauthenticated `:rf.route/navigate` to a
+    ;;     `:requires-auth` route over to login, which is what makes the
+    ;;     `:requires-auth` tags on settings / new / edit actually protect them.
+    ;;   - `:fx-overrides {:rf.http/managed …}` — route managed HTTP to the demo
+    ;;     stub so the example runs with no backend.
+    ;; First mount also runs `:initial-events` once; hot reload reuses the frame
+    ;; without re-seeding (durable app-db survives).
     ;;
     ;; `:initial-events` run in order at frame creation:
-    ;;   - `:auth/classify-token` — classify the durable JWT path [:auth :token]
-    ;;     `:sensitive` (EP-0025) BEFORE the token is written, so it is redacted
-    ;;     off-box from the first write on.
-    ;;   - `:auth/initialise` — EP-0017 session restore. It declares
-    ;;     `:rf.cofx/requires [:auth.session/token]`, a RECORDABLE GENERATOR
-    ;;     (auth.cljs) whose supplier reads localStorage ONCE at processing-start;
-    ;;     the value rides this setup-step's dispatch token and is recorded, so
-    ;;     replay / epoch-restore re-presents the captured token verbatim rather
-    ;;     than re-reading localStorage. Ordered BEFORE `:app/initialise` so the
-    ;;     token is in app-db before the bearer-auth interceptor fires any
-    ;;     authenticated request. (A unit test stamps `{:rf.cofx …}` at the
-    ;;     dispatch site as a node-side stub; in the browser the generator
-    ;;     supplies the value, so no explicit cofx is needed here.)
+    ;;   - `:auth/classify-token` — classify [:auth :token] `:sensitive` (EP-0025)
+    ;;     before the token is written, so it is redacted off-box from the first
+    ;;     write on.
+    ;;   - `:auth/initialise` — EP-0017 session restore. It pulls the saved JWT
+    ;;     through the `:auth.session/token` recordable generator (auth.cljs),
+    ;;     which reads localStorage once and records the value so replay /
+    ;;     epoch-restore re-present it verbatim. Runs before `:app/initialise` so
+    ;;     the token is in app-db before the bearer-auth interceptor sends any
+    ;;     authenticated request.
     ;;   - `:app/initialise` — fans out to the per-feature initialisers.
-    ;;   - `:rf.route/handle-url-change` — the initial URL→slice sync, computed
-    ;;     once from the base-path-stripped current URL. Ordered LAST so the
-    ;;     auth-guard interceptor sees the restored session when redirecting an
-    ;;     unauthenticated deep link to a `:requires-auth` route.
+    ;;   - `:rf.route/handle-url-change` — the first URL→slice sync, from the
+    ;;     base-path-stripped current URL. Runs last so the auth-guard sees the
+    ;;     restored session when redirecting a deep link to a `:requires-auth`
+    ;;     route.
     (rdc/render @react-root
                 [rf/frame-provider {:id              :rf/default
                                     :doc             "Realworld demo frame."

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -207,12 +207,11 @@
 
     nil))
 
-;; EP-0022: the guard is a REGISTERED interceptor referenced BY ID
-;; (`:realworld.routing/auth-guard`) from the demo frame's `:interceptors`
-;; chain in core.cljs — not an inline value. `reg-interceptor` is a top-level
-;; load-time registration; core.cljs requires this ns, so the descriptor is
-;; registered before the `frame-provider {:id …}` ENSURE form resolves the
-;; reference when it creates the frame.
+;; EP-0022: register the guard as a named interceptor here, then reference it
+;; by id (`:realworld.routing/auth-guard`) from the demo frame's `:interceptors`
+;; in core.cljs. `reg-interceptor` runs at load time, and core.cljs requires
+;; this ns, so the descriptor is in place before the frame-provider creates the
+;; frame and resolves the id.
 (rf/reg-interceptor :realworld.routing/auth-guard
   {:doc "Route-level auth guard (Spec 012 §Redirects and guards): redirect
          unauthenticated users away from `:requires-auth`-tagged routes to
@@ -265,23 +264,20 @@
       (str (.. js/window -location -search)
            (.. js/window -location -hash))))
 
-;; Named handler so the listener install is idempotent: repeated
-;; `install-router!` (shadow hot reload, or a co-required test host
-;; invoking run twice) must not stack duplicate popstate listeners,
-;; mirroring the `when-not @react-root` mount guard. We remove-then-add
-;; the same Var so the registration is deduped even when the Var is
-;; redefined on reload.
+;; A named handler so the listener install is idempotent: repeated
+;; `install-router!` (shadow hot reload, or a co-required test host invoking run
+;; twice) remove-then-add the same Var, so duplicate popstate listeners never
+;; stack — the same idea as the `when-not @react-root` mount guard.
 ;;
-;; EP-0002: the URL-change dispatch is targeted at
-;; the explicitly-declared URL owner resolved AT CALL TIME via
-;; `routing/url-owner-frame-id` (Spec 012 §popstate drives the URL-owner
-;; frame) — NOT a frameless `(rf/dispatch …)`, which would raise
-;; `:rf.error/no-frame-context`. This example serves from a `/realworld/`
-;; sub-path and strips it in `current-url`, so it keeps its own base-path-aware
-;; listener rather than the framework's `rf/install-history-listener!` (which
-;; reads the unstripped browser URL); the owner-targeting is the same contract
-;; that listener implements. The owner is the `:url-bound? true` demo frame
-;; registered in `core/run`.
+;; The URL-change dispatch targets the URL-owner frame, resolved at call time
+;; via `routing/url-owner-frame-id` (Spec 012 §popstate drives the URL owner).
+;; The owner is the `:url-bound? true` demo frame the frame-provider creates in
+;; core.cljs. Targeting it explicitly matters: a bare `(rf/dispatch …)` with no
+;; frame would raise `:rf.error/no-frame-context`. This example uses its own
+;; base-path-aware listener (rather than the framework's
+;; `rf/install-history-listener!`, which reads the unstripped browser URL),
+;; because it serves from a `/realworld/` sub-path and strips it in
+;; `current-url`; the owner-targeting contract is the same either way.
 (defn- on-popstate [_]
   (when-let [owner (routing/url-owner-frame-id)]
     (rf/dispatch [:rf.route/handle-url-change (current-url)] {:frame owner})))

--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -254,12 +254,11 @@
 ;; live in runtime-db and are validated through each machine's `[:schemas :data]`
 ;; (the *Data schemas above), so they do not appear in this app-schema map.
 ;;
-;; EP-0002: reg-app-schemas is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (the app frame `core/run` ensures at its render root via the
-;; `frame-provider {:id :rf/default …}` ENSURE form), so name it here. The
-;; schemas register against the frame-id at ns-load; the frame picks them up
-;; when the ENSURE provider creates it.
+;; EP-0002: reg-app-schemas is frame-local, so it needs a frame in context; a
+;; bare ns-load call would raise :rf.error/no-frame-context. `with-frame` names
+;; the target frame, `:rf/default`, so the schemas register against that id at
+;; load time. The frame-provider in core.cljs creates `:rf/default` at the
+;; render root and picks these schemas up when it does.
 (with-frame :rf/default
  (rf/reg-app-schemas
   {[:auth]                          AuthSlice

--- a/examples/reagent/realworld/ssr.cljc
+++ b/examples/reagent/realworld/ssr.cljc
@@ -37,17 +37,13 @@
    :rf.runtime/machines])
 
 (defn exportable-app-db [app-db]
-  ;; Secrets do not cross the SSR seam. The bearer JWT lives at
-  ;; [:auth :token]; embedding it in server-rendered HTML would leak a
-  ;; live credential into page source (view-source-visible, proxy-logged,
-  ;; CDN-cacheable). Redact it at the payload boundary — the client
-  ;; re-establishes [:auth :token] on hydrate via `:auth/initialise`
-  ;; (auth.cljs), which folds the RECORDABLE-GENERATOR `:auth.session/token`
-  ;; coeffect — a registered supplier reading localStorage at processing-start,
-  ;; recorded onto the boot dispatch token (EP-0017).
-  ;; The durable token slot is thus a function of a recorded boot coeffect, not
-  ;; an ambient write-site read, so dropping it from the payload costs nothing
-  ;; and stays replay-sound.
+  ;; Keep secrets out of the SSR payload. The bearer JWT lives at [:auth :token];
+  ;; embedding it in server-rendered HTML would leak a live credential into page
+  ;; source (view-source-visible, proxy-logged, CDN-cacheable). Redact it at the
+  ;; payload boundary. The client re-establishes [:auth :token] on hydrate via
+  ;; `:auth/initialise` (auth.cljs), which reads it back from localStorage
+  ;; through the `:auth.session/token` recordable-generator coeffect (EP-0017).
+  ;; So dropping the token from the payload costs nothing and stays replay-sound.
   (cond-> (select-keys app-db ssr-app-slice-keys)
     (contains? app-db :auth) (update :auth dissoc :token)))
 
@@ -72,10 +68,9 @@
        (reader/read-string (.-textContent el)))))
 
 #?(:cljs
-   ;; EP-0002: the caller names the frame to hydrate explicitly —
-   ;; no zero-arity `:rf/default` convenience. Under the carried invariant the
-   ;; hydration target is a deliberate choice, not an inferred default; a
-   ;; non-default / multi-frame client must pass its own frame-id.
+   ;; EP-0002: the caller names the frame to hydrate. Making the target explicit
+   ;; lets a non-default or multi-frame client hydrate the right frame by passing
+   ;; its own frame-id.
    (defn hydrate-client! [frame-id]
      (when-let [payload (read-server-payload)]
        (rf/dispatch-sync [:rf/hydrate payload] {:frame frame-id})

--- a/examples/reagent/realworld_resources/routing.cljs
+++ b/examples/reagent/realworld_resources/routing.cljs
@@ -21,16 +21,15 @@
    that path; the dedicated worked demo of resource SSR preload + hydration is
    `examples/reagent/resources_ssr/`.)
 
-   The SESSION-scoped personalised feed is now ALSO a declarative route
-   resource (EP-0016 D3): the home route declares it with `:scope {:from-db
+   The SESSION-scoped personalised feed is a declarative route resource too
+   (EP-0016 D3): the home route declares it with `:scope {:from-db
    :realworld/session}`, a named-resolver reference (see scope.cljs) the runtime
-   resolves against the navigation handler's app-db at route entry — so the
+   resolves against the navigation handler's app-db at route entry. So the
    route owns the feed under its nav-token and releases it on leave, exactly
-   like the public reads. This retires the prior `:home/on-match` event +
-   app-minted lease the variant needed before named scope resolvers existed (a
-   route `:scope` resolver couldn't see app-db, so the feed had to be ensured
-   from an event that could). Logged out, the reference resolves nil and the
-   feed entry is simply not planned (fail-closed — no feed to load).
+   like the public reads — the named resolver lets a route `:scope` derive from
+   app-db, so a session read joins the same declarative route plan as the
+   public ones. Logged out, the reference resolves nil and the feed entry is
+   simply not planned (fail-closed — no feed to load).
 
    The resources artefact LATE-BINDS the `:resources` route-metadata key into
    routing, so loading both `re-frame.resources` and `re-frame.routing` is what
@@ -77,11 +76,11 @@
    ;; The personalised feed — a declarative route resource scoped by the
    ;; named `{:from-db :realworld/session}` resolver (EP-0016 D3). The runtime
    ;; resolves the scope against the navigation handler's app-db at route
-   ;; entry, owns it under the route nav-token, and releases it on leave —
-   ;; replacing the prior `:home/on-match` event + app-minted lease. Logged
-   ;; out the reference resolves nil, so the feed is simply not planned (no
-   ;; scope, no fetch — the feed never leaks across users). The `?page=` flows
-   ;; into params here like every other paginated list.
+   ;; entry, owns it under the route nav-token, and releases it on leave, just
+   ;; like the public reads above. Logged out the reference resolves nil, so
+   ;; the feed is simply not planned (no scope, no fetch — the feed never leaks
+   ;; across users). The `?page=` flows into params here like every other
+   ;; paginated list.
    {:resource  :realworld/feed
     :scope     {:from-db :realworld/session}
     ;; Default to page 1 — the feed subscription reads `(or (:page q) 1)`
@@ -96,8 +95,8 @@
            feed (the official-contract token — NOT `?feed=your`) and `?page=`
            paginates — both flow into the resources' params. `:keep-previous?`
            keeps the prior page visible while the next first-loads (no
-           flicker). The tag filter is its own `/tag/:tag` PATH route below
-           (route-shape conformance — no `?tag=` query)."
+           flicker). The tag filter is its own `/tag/:tag` PATH route below —
+           the tag is a route param, matching the official Conduit route shape."
    :query [:map
            [:feed {:optional true} :string]
            [:page {:optional true} :int]]
@@ -106,10 +105,10 @@
 
 (rf/reg-route :realworld/home-tag
   {:doc   "The tag-filtered article list at the official RealWorld `/tag/:tag`
-           PATH route (replacing the prior `?tag=` query). The
-           active tag is a route PARAM that flows into the articles resource's
-           params, so each tag is a distinct cache entry; `?page=` paginates
-           within it (`/tag/:tag?page=2`). Same three reads as the home route."
+           PATH route. The active tag is a route PARAM that flows into the
+           articles resource's params, so each tag is a distinct cache entry;
+           `?page=` paginates within it (`/tag/:tag?page=2`). Same three reads
+           as the home route."
    :params [:map [:tag :string]]
    :query  [:map [:page {:optional true} :int]]
    :scroll :top

--- a/examples/reagent/realworld_resources/schema.cljs
+++ b/examples/reagent/realworld_resources/schema.cljs
@@ -108,9 +108,10 @@
 
 (def AuthSlice
   "The auth slice. :user holds the current User payload (or nil); :token is
-   the JWT (or nil). :scope-key holds the resource cache scope this session
-   reads under (see realworld-resources.scope). :return-to is the optional
-   post-login bounce-back target stashed by the routing auth-guard."
+   the JWT (or nil). The resource cache scope is derived from :user's :username
+   by the named session resolver (see realworld-resources.scope), not stored
+   here. :return-to is the optional post-login bounce-back target stashed by
+   the routing auth-guard."
   [:map
    [:user      [:maybe User]]
    [:token     [:maybe :string]]

--- a/examples/reagent/resources/core.cljs
+++ b/examples/reagent/resources/core.cljs
@@ -181,7 +181,7 @@
 ;; owner `[:route route-id nav-token]` and ensures it with cause
 ;; `[:route-entry route-id nav-token]`; on route leave it releases the
 ;; owner by token and suppresses any stale reply by generation. The view
-;; never fetches — it only reads.
+;; only reads — the fetch is caused for it.
 
 (rf/reg-route :resources.app/home
   {:doc  "Landing page."} "/")
@@ -502,22 +502,20 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; The React root is materialised lazily inside `run` (not at ns-load) per
-;; examples/TESTING.md §Example mount-isolation convention. The app frame is
-;; CREATED + CONFIGURED in ONE spot — the render-root `frame-provider {:id …}`
-;; (ENSURE shape): it creates the frame on first mount, applies its config
-;; (`:url-bound? true` so it owns the browser URL, plus the HTTP-stub
-;; override), and on hot reload REUSES the same frame WITHOUT re-creating or
-;; re-seeding it. Every in-tree dispatch/subscribe resolves to it. The
-;; framework `install-history-listener!` does the initial URL→slice sync and
-;; popstate handling, targeted at the URL owner.
+;; `run` materialises the React root lazily on first call (the mount-isolation
+;; convention in examples/TESTING.md). The app frame is created + configured in
+;; one spot: the render-root `frame-provider {:id …}` (the ENSURE shape). On
+;; first mount it creates the frame and applies its config — `:url-bound? true`
+;; so the frame owns the browser URL, plus the HTTP-stub override. On hot reload
+;; it reuses that same frame as-is. Every in-tree dispatch/subscribe resolves to
+;; it. `install-history-listener!` does the initial URL→slice sync and popstate
+;; handling, targeted at the URL owner.
 
 (defonce react-root (atom nil))
 
-;; `:rf/default` is an ORDINARY frame id with no framework privilege — `init!`
-;; does not create it. This app earns URL ownership by DECLARING `:url-bound?
-;; true` on the ENSURE `frame-provider` below, not by naming the frame
-;; anything special.
+;; The id this app's frame is created under. `:rf/default` is an ordinary frame
+;; id (it carries no special privilege); URL ownership comes from `:url-bound?
+;; true` on the `frame-provider` below, not from the id.
 (def app-frame :rf/default)
 
 (defn run []
@@ -526,12 +524,11 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; ENSURE shape ({:id …}): create + configure the app frame in this ONE
-    ;; spot, reuse-without-reseed on hot reload. The `:fx-overrides` routes
-    ;; every `:rf.http/managed` resource ensure to the per-URL canned stub
-    ;; above — the example runs standalone with no backend. The override
-    ;; applies frame-wide; this example issues no non-mocked requests, so a
-    ;; blanket override is the right grain.
+    ;; The `frame-provider {:id …}` creates and configures the app frame.
+    ;; `:fx-overrides` routes every `:rf.http/managed` resource ensure to the
+    ;; per-URL canned stub above, so the example runs standalone with no backend.
+    ;; The override applies frame-wide; this example issues no non-mocked
+    ;; requests, so a blanket override is the right grain.
     (rdc/render @react-root
                 [rf/frame-provider {:id           app-frame
                                     :doc          "Resources demo frame."

--- a/examples/reagent/resources_ssr/core.cljc
+++ b/examples/reagent/resources_ssr/core.cljc
@@ -20,9 +20,9 @@
    - On the client the framework `:rf/hydrate` installs the projection into
      the target frame's `:rf.runtime/resources` slice; the hydration reconcile
      orphans the SSR owner, recomputes the reverse indexes from `:entries`,
-     and settles a wire-stripped in-flight entry to a stable status; a fresh
-     hydrated entry renders immediately and does NOT immediately re-fetch
-     (stale / redacted / omitted entries refetch by the hydration plan).
+     and settles a wire-stripped in-flight entry to a stable status. A fresh
+     hydrated entry renders on first paint and serves from the cache (stale /
+     redacted / omitted entries refetch by the hydration plan).
 
    The SSR blocking-drain, the per-entry projection with redaction /
    omission / scoped-key privacy / index omission, and the client hydration
@@ -103,11 +103,9 @@
 ;;
 ;; Two facts ride the ensure. The OWNER `[:ssr request-id nav-token]` is a
 ;; lease: it keeps the entry alive for the duration of THIS server render and
-;; nothing longer (released on teardown; reconciled to an orphan on hydration —
-;; a server render's lease has no business surviving as a live client hold).
+;; nothing longer (released on teardown; reconciled to an orphan on hydration).
 ;; The CAUSE `:ssr-preload` is pure provenance — WHY the fetch happened,
-;; recorded for the trace, affecting no liveness. Owner = lifetime; cause =
-;; explanation.
+;; recorded for the trace. Owner = lifetime; cause = explanation.
 
 (rf/reg-event :rf/server-init
   {:doc       "Per-request server init — preload the page resource."
@@ -126,13 +124,14 @@
 ;; VIEWS — passive reads, server and client alike
 ;; ============================================================================
 ;;
-;; The view reads the resource through a subscription and never fetches — it
-;; doesn't know or care which runtime it is in. `:rf.resource/state` is the
-;; runtime-supplied derivation that turns the cache entry into a view-model
-;; (a status flag + the data). On the server the resource was preloaded; on
-;; the client the hydrated entry is already present, so the first render shows
-;; data without a fetch. Same view code both sides — the SSR/CLJS parity Spec
-;; 011 promises, now over a runtime-managed resource.
+;; The view is a passive reader: it pulls the resource through a subscription
+;; and renders whatever it finds, the same on server and client. (Reading does
+;; not trigger a fetch — the preload/hydration already warmed the cache.)
+;; `:rf.resource/state` is the runtime-supplied derivation that turns the cache
+;; entry into a view-model (a status flag + the data). On the server the
+;; resource was preloaded; on the client the hydrated entry is already present,
+;; so the first render shows data straight away. Same view code both sides —
+;; the SSR/CLJS parity Spec 011 promises, now over a runtime-managed resource.
 
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
   (let [state @(rf/subscribe [:rf.resource/state
@@ -172,13 +171,13 @@
 ;;   1. `ssr/drain-blocking-resources!` settles the `[:ssr …]`-owned blocking
 ;;      ensure (or times it out into a structured first-load failure) BEFORE
 ;;      the render walk, so the render never sees a hung `:loading` skeleton.
-;;   2. `payload-policy/project-runtime-db` projects the runtime-db to the
-;;      SERIALIZABLE allowlist — only the durable `:rf.runtime/resources`
+;;   2. `payload-policy/project-runtime-db` projects the runtime-db down to the
+;;      serializable allowlist — only the durable `:rf.runtime/resources`
 ;;      `:entries`, per-entry redacted (`:sensitive?`) / omitted (`:large?`),
-;;      with the reverse indexes EXCLUDED (recomputed on install). The example
-;;      NEVER serializes the full runtime-db. The app-db slice rides the
-;;      explicit fail-closed allowlist via `apply-policy` (here an empty
-;;      allowlist — the page state is the RESOURCE, not app-db).
+;;      with the reverse indexes dropped (they recompute on install). Ship the
+;;      projection, never the full runtime-db. The app-db slice rides the
+;;      fail-closed allowlist via `apply-policy` (here empty — the page state
+;;      is the resource, so app-db holds nothing of its own).
 
 #?(:clj
    (defn handle-request [request]
@@ -206,14 +205,13 @@
                  ;; resource `:entries`).
                  ;;
                  ;; The page state is the RESOURCE (it rides `:rf/runtime-db`),
-                 ;; so app-db carries nothing of its own — but `:payload` is
-                 ;; FAIL-CLOSED and an empty `[]` allowlist is treated as
-                 ;; MISSING policy (it throws `:rf.error/ssr-missing-payload-
-                 ;; policy`), not as a valid empty allowlist (Spec 011 §`:rf/app-db`
-                 ;; projection). The explicit, valid policy for "ship the whole
-                 ;; (here empty) app-db" is the `:rf.ssr.payload/whole-app-db`
-                 ;; opt-in keyword — it projects the empty app-db to `{}`
-                 ;; cleanly.
+                 ;; so app-db carries nothing of its own. `:payload` is
+                 ;; fail-closed, so name the intent explicitly: the
+                 ;; `:rf.ssr.payload/whole-app-db` opt-in projects the (empty)
+                 ;; app-db to `{}` cleanly. Watch out — a bare empty `[]`
+                 ;; allowlist reads as MISSING policy and throws
+                 ;; `:rf.error/ssr-missing-payload-policy`, not as "ship nothing"
+                 ;; (Spec 011 §`:rf/app-db` projection).
                  policy-opts   {:payload :rf.ssr.payload/whole-app-db}
                  payload       (payload-policy/build-payload
                                  f
@@ -222,26 +220,17 @@
                                  (assoc policy-opts
                                         :runtime-db (payload-policy/project-runtime-db
                                                       final-runtime)))
-                 ;; EP-0002: `build-payload` stamps the per-request
-                 ;; server frame (`f`) as `:rf/frame-id`, but the client
-                 ;; hydrates a FIXED app-frame (`app-frame` → `:rf/default`,
-                 ;; below). `ssr/hydrate!` VALIDATES a present payload
-                 ;; `:rf/frame-id` against the client's explicit `:frame` and
-                 ;; raises `:rf.error/hydration-frame-id-mismatch` only when the
-                 ;; two DISAGREE (Spec 011 §The hydration payload — the frame-id
-                 ;; is validation evidence, not a target resolver). The server's
-                 ;; per-request gensym would never equal the client's fixed
-                 ;; `:rf/default`, so a present stamp here would always conflict;
-                 ;; we therefore DROP it, and an absent `:rf/frame-id` is
-                 ;; explicitly NO conflict (the explicit client target stands).
-                 ;; The static `index.html` next to this file reaches the same
-                 ;; no-conflict outcome by the OTHER valid route: it stamps a
-                 ;; `:rf/frame-id :rf/default` that EQUALS this client target
-                 ;; (present-and-equal is also no conflict — a hand-written
-                 ;; stand-in can pin the matching id, where a live per-request
-                 ;; server cannot). A deployment that wants a frame-id on the
-                 ;; dynamic wire stamps a STABLE id both sides agree on, not a
-                 ;; per-request gensym.
+                 ;; Drop the payload's `:rf/frame-id`. `build-payload` stamps
+                 ;; it with this per-request gensym frame (`f`), but the client
+                 ;; hydrates a fixed app-frame (`:rf/default`, below).
+                 ;; `ssr/hydrate!` checks any present `:rf/frame-id` against the
+                 ;; client's `:frame` and raises
+                 ;; `:rf.error/hydration-frame-id-mismatch` when they differ —
+                 ;; the frame-id is validation evidence, not a hydration target
+                 ;; (Spec 011 §The hydration payload). A per-request gensym can
+                 ;; never equal the client's fixed id, so we drop it; an absent
+                 ;; frame-id is no conflict. (A deployment that wants a frame-id
+                 ;; on the wire stamps a stable id both sides agree on.)
                  payload       (dissoc payload :rf/frame-id)]
              {:status  200
               :headers {"Content-Type" "text/html"}
@@ -268,25 +257,19 @@
 ;; `ssr/hydrate!` reads the payload, dispatch-syncs `[:rf/hydrate payload]`
 ;; (which installs the resource projection into the carried frame's
 ;; `:rf.runtime/resources` slice under the locked :replace-frame-state
-;; policy), and verifies the render hash. A FRESH hydrated entry renders its
-;; data immediately and does NOT immediately re-fetch (Spec 016 §SSR client
-;; hydration); a stale entry would background-refetch by policy.
+;; policy), and verifies the render hash. A fresh hydrated entry renders its
+;; data on first paint and serves it straight from the cache — no duplicate
+;; fetch, which is the whole point of preloading (Spec 016 §SSR client
+;; hydration). A stale entry would background-refetch by policy.
 
 #?(:cljs (defonce react-root (atom nil)))
 
-;; EP-0002: the SSR hydration target is CARRIED — established
-;; explicitly here and threaded through both `ssr/hydrate!` and the root
-;; `frame-provider`. This example uses `:rf/default` as its FIXED client
-;; app-frame. `ssr/hydrate!` validates the payload's `:rf/frame-id` against
-;; this explicit target and raises `:rf.error/hydration-frame-id-mismatch`
-;; only on a present-AND-DIFFERENT value (Spec 011 §The hydration payload).
-;; The two no-conflict shapes both appear in this example: `handle-request`
-;; above DROPS `:rf/frame-id` (its per-request gensym would never equal this
-;; target, so an absent frame-id is the safe shape), while the static
-;; `index.html` next to this file carries `:rf/frame-id :rf/default` — present
-;; AND equal to this target, the other no-conflict case. The frame MUST be
-;; `:client`-platform so the `:rf.ssr/check-*` compatibility-check fxs the
-;; `:rf/hydrate` handler dispatches actually fire.
+;; The fixed client app-frame. The app names its hydration target explicitly
+;; and threads the same id through both `ssr/hydrate!` (where the server state
+;; lands) and the root `frame-provider` (where in-tree dispatch/subscribe
+;; resolve). It must be a `:client`-platform frame so the `:rf.ssr/check-*`
+;; compatibility-check fxs the `:rf/hydrate` handler dispatches actually fire
+;; (Spec 011 §The :rf/hydrate event).
 (def app-frame :rf/default)
 
 #?(:cljs

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -18,10 +18,10 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            ;; Routing ships in day8/re-frame2-routing.
-            ;; Requiring re-frame.routing at app boot is what triggers
-            ;; its load-time hook + reg-sub registrations; without it,
-            ;; rf/reg-route below throws :rf.error/routing-artefact-missing.
+            ;; Routing ships in day8/re-frame2-routing. Requiring it runs
+            ;; its load-time hook and reg-sub registrations, which the
+            ;; `rf/reg-route` calls below depend on. Without this require
+            ;; those calls throw :rf.error/routing-artefact-missing.
             [re-frame.routing]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -48,11 +48,10 @@
 ;; APP DATA
 ;; ============================================================================
 
-;; The articles collection lives under :routing.app/articles-list (not
-;; :routing.app/articles) so it doesn't shadow the `:routing.app/articles`
-;; route-id. The route-registry and reg-sub registries are independent,
-;; but keeping the sub-id + app-db-key separate from the route-id makes
-;; the example easier to scan.
+;; The articles collection lives under :routing.app/articles-list. Route
+;; ids and sub/app-db keys live in separate registries, so a clash is
+;; harmless — but a distinct key (not :routing.app/articles, the route
+;; id) keeps the example easy to scan.
 (rf/reg-event :routing.app/initialise
   (fn [{:keys [db]} _]
     {:db {:routing.app/articles-list
@@ -137,46 +136,32 @@
 ;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
 ;; convention: ns-load must produce no DOM side effects so co-required
 ;; example namespaces don't race `create-root` onto the shared `#app`.
-;; (`reg-view` defs `root-view`, which is what we render.)
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime
-;; never synthesises a frame from absence, and URL ownership is an EXPLICIT
-;; declaration — a frame owns the browser URL only by carrying
-;; `:url-bound? true` (Spec 012 §Multi-frame routing).
-;;
-;; The app frame is created, configured, and seeded in ONE spot: the
-;; `frame-provider {:id …}` ENSURE form at the render root (`init!` installs
-;; only the adapter). On first mount it creates the frame under `app-frame`,
-;; applies the config (`:url-bound? true` so it owns the URL), and runs
-;; `:initial-events` once to seed app-db. On hot reload it REUSES the existing
-;; frame WITHOUT re-seeding (durable app-db survives; `:initial-events` are
-;; re-recorded but not replayed). That id is what every in-tree
-;; `dispatch`/`subscribe` resolves against — no separate `reg-frame` or
-;; scope step.
-;;
-;; The popstate listener is the framework's `rf/install-history-listener!`
-;; (Spec 012 §popstate drives the URL-owner frame) — NOT a hand-rolled
-;; frameless `(rf/dispatch [:rf.route/handle-url-change …])`. It resolves the
-;; URL owner AT POP TIME via `url-owner-frame-id` and dispatches the URL-change
-;; to THAT frame, so Back/Forward restores the owner's `:rf/route` slice. It
-;; also does the initial URL→slice sync and is idempotent (hot-reload safe).
-;; A hand-rolled frameless route dispatch would raise
-;; `:rf.error/no-frame-context`; the framework listener is the canonical,
-;; owner-resolving surface.
+;; The frame id the whole app runs under. `:rf/default` is an ordinary id
+;; with no framework privilege — the runtime won't infer it for you, so you
+;; establish it like any other (the provider in `run` does that). A frame
+;; owns the browser URL by carrying `:url-bound? true`, which this app's
+;; provider sets (EP-0002, Spec 012 §Multi-frame routing).
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the Reagent adapter. Each adapter ns exports an `adapter`
+  ;; var; pass it directly to `init!`.
   (rf/init! reagent-adapter/adapter)
-  ;; Framework popstate listener + initial URL sync, targeted at the URL owner.
+  ;; Install the framework popstate listener. It does the initial
+  ;; URL→state sync now, then on each Back/Forward resolves the URL-owner
+  ;; frame at pop time and updates that frame's `:rf/route` slice. Safe to
+  ;; call again on hot reload.
   (rf/install-history-listener!)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; ENSURE form: create + configure + seed the app frame in one spot.
-    ;; First mount creates it under `app-frame`, applies `:url-bound? true`,
-    ;; and runs `:initial-events` once; hot reload reuses it without re-seeding.
+    ;; The frame provider sets up the app frame in one spot. On first mount
+    ;; it creates the frame under `app-frame`, marks it `:url-bound? true` so
+    ;; it owns the URL, and runs `:initial-events` once to seed app-db. On
+    ;; hot reload it reuses the existing frame and skips the seed. Everything
+    ;; in `root-view` then dispatches and subscribes against this frame.
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :doc "Routing demo frame."

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -84,12 +84,11 @@
    [:selected-id [:maybe :string]]
    [:editing-id  [:maybe :string]]])
 
-;; EP-0002: reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (the id the render root's `frame-provider {:id app-frame}`
-;; creates — see `run`), so name it explicitly here so the schema binds to
-;; the app frame whose commits it validates. Binding is by frame id, so this
-;; ns-load registration is independent of when the frame is created.
+;; Register the app-db schema for the app frame. `reg-app-schema` needs a
+;; frame in scope, so at ns-load — before the provider has mounted — we
+;; name the frame with `with-frame :rf/default` (the id `run`'s provider
+;; uses). Binding is by frame id, so this works no matter when the frame
+;; is created; once it exists, the schema validates its `[:cells]` commits.
 (with-frame :rf/default
   (rf/reg-app-schema [:cells] {:schema CellsState}))
 
@@ -404,20 +403,24 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. The whole frame is established in ONE spot: `init!`
-;; installs the adapter (it does NOT create the frame), then the render
-;; root's `frame-provider {:id app-frame}` does the rest — on first
-;; mount it CREATES the app frame, applies its config, and runs
-;; `:initial-events` once to seed it; thereafter every in-tree
-;; `dispatch`/`subscribe` resolves to that frame. On hot reload the
-;; provider REUSES the existing frame and does NOT re-seed. Matches the
-;; canonical mount in examples/reagent/counter/core.cljs.
+;; The whole frame lives in one spot at the render root: the
+;; `frame-provider {:id app-frame …}` in `run`. On first mount it creates
+;; the app frame, applies its config, and runs `:initial-events` once to
+;; seed app-db. Thereafter every `dispatch`/`subscribe` in the tree
+;; resolves to that frame. On hot reload the provider reuses the existing
+;; frame and skips re-seeding, so the grid keeps its values across
+;; re-mounts. (`init!` below only installs the adapter — the provider, not
+;; `init!`, creates the frame.) Matches the canonical mount in
+;; examples/reagent/counter/core.cljs.
+;;
+;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame
+;; id with no framework privilege; we name it here and hand it to the
+;; provider like any other id.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; `init!` installs the reactive adapter for the process. Each adapter ns
+  ;; exports an `adapter` var; require the ns and pass that var directly.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -2,9 +2,9 @@
   "7GUIs #6 — Circle Drawer.
 
    A canvas. Click to add a circle at the click position with a default
-   diameter. Right-click a circle to open a context menu (Adjust diameter
-   or Delete). 'Adjust diameter' opens a slider in a modal dialog; closing
-   the dialog commits. Undo/Redo buttons step through the history.
+   diameter. Right-click a circle to adjust its diameter: that opens a
+   slider in a modal dialog, and closing the dialog commits the new size.
+   Undo/Redo buttons step through the history.
 
    The 7GUIs page calls this out as a test of *undo/redo*. The classic trap
    is to maintain an ad-hoc undo stack inside the component. The re-frame2
@@ -35,14 +35,13 @@
 ;; SCHEMA
 ;; ============================================================================
 
-;; EP-0010 (Causal World Inputs): a circle's `:id` is written into durable
-;; app-db (`[:drawer :circles]`), so it must be a function of prior frame-state
-;; — never an ambient `(random-uuid)` at the durable-write site (a fresh
-;; event-stream replay would mint different ids). The id is an internal handle
-;; (React `:key` + context-menu target), so we mint it deterministically as a
-;; monotonic `:int` from a db-held counter — the todomvc `allocate-next-id`
-;; idiom — rather than a uuid. Undo/redo snapshot whole `:circles` vectors, so
-;; the ids ride the snapshot and round-trip unchanged.
+;; A circle's `:id` is a monotonic `:int` minted from a db-held counter — the
+;; todomvc `allocate-next-id` idiom. It lands in durable app-db
+;; (`[:drawer :circles]`), so it must be a function of prior frame-state, not
+;; an ambient `(random-uuid)` — replaying the event stream would otherwise mint
+;; different ids (EP-0010 Causal World Inputs). The id is just an internal
+;; handle (React `:key` + context-menu target). Undo/redo snapshot whole
+;; `:circles` vectors, so the ids ride the snapshot and round-trip unchanged.
 (def Circle
   [:map
    [:id      :int]
@@ -61,11 +60,11 @@
    [:undo      [:vector :any]]                  ;; stack of prior :circles values
    [:redo      [:vector :any]]])
 
-;; EP-0002: reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example's app
-;; frame is :rf/default (see `app-frame` / the render root's `frame-provider`
-;; ensure form), so name it explicitly so the schema binds to the app frame
-;; whose commits it validates.
+;; Bind the schema to the app frame so it validates that frame's commits.
+;; `reg-app-schema` is frame-local, and this runs at ns-load before any
+;; provider exists, so name the frame (`:rf/default`, matching the render
+;; root's `frame-provider` below) via `with-frame` rather than relying on a
+;; frame in scope.
 (with-frame :rf/default
   (rf/reg-app-schema [:drawer] {:schema DrawerState}))
 
@@ -74,11 +73,10 @@
 ;; ============================================================================
 ;;
 ;; Captures :circles before the handler runs; pushes the prior value onto :undo
-;; and clears :redo. Events tagged as undoable reference this interceptor BY ID
-;; (`:undoable`) in their :interceptors list (EP-0022 — interceptors are
-;; registered descriptors referenced by keyword, not inline values). Continuous
-;; events (slider drag) opt out by not referencing it; only the *commit* event
-;; uses it.
+;; and clears :redo. An undoable event lists this interceptor BY ID
+;; (`:undoable`) in its :interceptors (EP-0022 — interceptors are registered
+;; descriptors referenced by keyword). Only the *commit* events carry it, so
+;; the continuous slider drag leaves the history alone.
 
 (rf/reg-interceptor :undoable
   {:doc "Snapshot :circles before an undoable handler runs; push the prior
@@ -109,12 +107,12 @@
     {:db (assoc db :drawer {:circles [] :next-id 1 :dialog nil :undo [] :redo []})}))
 
 (rf/reg-event :drawer/add-circle
-  {:doc "Click on canvas. Adds a circle of default radius. The id is minted
-         deterministically from the db-held `:next-id` counter (EP-0010 causal
-         world inputs — a durable id must be a function of prior frame-state,
-         not an ambient `(random-uuid)` read), then the counter is bumped. The
-         counter is NOT in the undoable `:circles` snapshot, so it advances
-         monotonically across undo/redo and never re-mints a live id."
+  {:doc "Click on canvas. Adds a circle of default radius. The id comes from
+         the db-held `:next-id` counter, then the counter is bumped — a durable
+         id is a function of prior frame-state, not an ambient `(random-uuid)`
+         (EP-0010 causal world inputs). The counter lives outside the undoable
+         `:circles` snapshot, so it keeps climbing across undo/redo and never
+         re-mints a live id."
    :interceptors [:undoable]}
   (fn handler-drawer-add-circle [{:keys [db]} [_ x y]]
     {:db (let [id (get-in db [:drawer :next-id])]
@@ -134,8 +132,8 @@
 
 (rf/reg-event :drawer/dialog-drag
   {:doc "Slider movement during the dialog. Updates the draft radius only;
-         the circle itself is not mutated until the dialog commits.
-         Continuous; does NOT push undo."}
+         the circle keeps its size until the dialog commits. Carries no
+         `:undoable`, so the drag adds no history steps."}
   (fn handler-drawer-dialog-drag [{:keys [db]} [_ new-radius]]
     {:db (assoc-in db [:drawer :dialog :draft-radius] new-radius)}))
 
@@ -257,18 +255,21 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame).
-;; The render root then uses the `frame-provider` ENSURE form ({:id …}):
-;; it creates the app frame on first mount, applies its config, runs the
-;; `:initial-events` seed exactly once, and on hot reload reuses the same
-;; frame without re-seeding. Matches the canonical mount in
+;; The whole frame lifecycle lives in one spot at the render root: the
+;; `frame-provider {:id app-frame …}` below. On first mount it creates the
+;; app frame, applies its config, and runs `:initial-events` once to seed
+;; app-db. Thereafter every `dispatch`/`subscribe` in the tree resolves to
+;; that frame. On hot reload the provider reuses the existing frame and
+;; skips re-seeding, so the canvas keeps its circles across re-mounts.
+;;
+;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
+;; with no framework privilege — name it here and hand it to the provider
+;; like any other id. Matches the canonical mount in
 ;; examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; `init!` installs the reactive adapter for the process.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -14,7 +14,7 @@
 
    The whole frame is established in one spot: the render root's
    `frame-provider {:id …}` creates the app frame, configures it, and
-   runs its `:initial-events` seed once (reused, not re-seeded, on reload).
+   runs its `:initial-events` seed once.
 
    Demonstrates:
    - List operations (add / update / delete)              (CP-1)
@@ -59,12 +59,11 @@
                    [:name    :string]
                    [:surname :string]]]])
 
-;; EP-0002: reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (the frame the render-root `frame-provider {:id app-frame}`
-;; establishes), so name it explicitly here so the schema binds to that frame
-;; whose commits it validates. This `with-frame` only sets the frame-context
-;; label for the registration — it does not require the frame to exist yet.
+;; EP-0002: `reg-app-schema` is frame-local, so it needs a frame context at
+;; registration. `with-frame` supplies one: it names the frame this schema
+;; binds to — `:rf/default`, the frame the render-root `frame-provider`
+;; establishes and whose commits this schema validates. The label is enough;
+;; the frame need not exist yet.
 (with-frame :rf/default
   (rf/reg-app-schema [:crud] {:schema CrudState}))
 
@@ -235,20 +234,22 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; EP-0002 / EP-0026: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. So the boot below does two things in order: `init!` installs
-;; the adapter (it does NOT create the frame), then the render's
-;; `frame-provider {:id app-frame}` does the rest in ONE spot — on first
-;; mount it CREATES the app frame, applies its config, and runs
-;; `:initial-events` once to seed it (`:crud/initialise`); thereafter every
-;; in-tree `dispatch`/`subscribe` resolves to that frame. On hot reload the
-;; provider REUSES the existing frame and does NOT re-seed. Matches the
-;; canonical mount in examples/reagent/counter/core.cljs.
+;; The whole frame lifecycle lives in one spot at the render root: the
+;; `frame-provider {:id app-frame …}` below. On first mount it creates the
+;; app frame, applies its config, and runs `:initial-events` once to seed
+;; app-db (`:crud/initialise`). Thereafter every `dispatch`/`subscribe` in
+;; the tree resolves to that frame. On hot reload the provider reuses the
+;; existing frame and skips re-seeding, so the list keeps its rows across
+;; re-mounts.
+;;
+;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
+;; with no framework privilege — the runtime won't infer it, so we name it
+;; here and hand it to the provider like any other id. Matches the canonical
+;; mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; `init!` installs the reactive adapter for the process.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -42,11 +42,11 @@
    [:start-text  :string]                    ;; raw text the user typed; we don't parse until validation
    [:return-text :string]])
 
-;; EP-0002: reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (the frame the render-root `frame-provider {:id …}` creates),
-;; so name it explicitly so the schema binds to the app frame whose commits
-;; it validates.
+;; Bind the schema to the app frame so it validates that frame's commits.
+;; `reg-app-schema` is frame-local and this runs at ns-load, before the
+;; render root's `frame-provider {:id …}` creates the frame — so name the
+;; frame (`:rf/default`, matching that provider) with `with-frame`. Binding
+;; is by id, so the registration is independent of when the frame is created.
 (with-frame :rf/default
   (rf/reg-app-schema [:flight] {:schema FlightState}))
 
@@ -218,18 +218,18 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame).
-;; The render root then uses the `frame-provider` ENSURE form ({:id …}):
-;; it creates the app frame on first mount, applies its config, runs the
-;; `:initial-events` seed exactly once, and on hot reload reuses the same
-;; frame without re-seeding. Matches the canonical mount in
+;; The whole frame lifecycle lives in one spot at the render root: the
+;; `frame-provider {:id app-frame …}` below. On first mount it creates the
+;; app frame, applies its config, and runs `:initial-events` once to seed
+;; app-db. On hot reload it reuses the same frame and skips re-seeding.
+;; `app-frame` is just an id we pick — the runtime won't infer it, so we
+;; name it here and hand it to the provider. Matches the canonical mount in
 ;; examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; `init!` installs the reactive adapter for the process. The adapter ns
+  ;; exports an `adapter` var; require the ns and pass that var directly.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -8,10 +8,10 @@
    classic trap is to wire the two fields to each other directly, which
    creates an update loop or a stale-value race.
 
-   The re-frame2 solution: there is *one source of truth* in app-db, plus
-   *one event* that updates it. Both inputs read from the same source through
-   subscriptions; both write to it through the same event. No bidirectional
-   wiring; the architecture eliminates the trap.
+   The re-frame2 solution: *one source of truth* in app-db, plus *one event*
+   that updates it. Both inputs read from that source through subscriptions
+   and write to it through the same event. The fields never touch each other,
+   so the trap never arises.
 
    Demonstrates:
    - Single source of truth in app-db                    (Goal 7 / application-state)
@@ -45,11 +45,10 @@
    [:input-source [:enum :celsius :fahrenheit]]
    [:typing       :string]])              ;; the literal text the user is typing
 
-;; EP-0002: reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (the id the render root's `frame-provider {:id …}` establishes),
-;; so name it explicitly so the schema binds to the app frame whose commits it
-;; validates.
+;; A schema is frame-local, so it binds inside a frame. The render root's
+;; `frame-provider {:id …}` runs this app in `:rf/default`, so we name that
+;; frame here and register the schema against it. Every commit to its
+;; `[:temp]` slice is then validated.
 (with-frame :rf/default
   (rf/reg-app-schema [:temp] {:schema TempState}))
 
@@ -166,20 +165,21 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. So the boot below does two things in order: `init!` installs
-;; the adapter (it does NOT create the frame), then the render's
-;; `frame-provider {:id app-frame}` does the rest in one spot — on first
-;; mount it CREATES the app frame, applies its config, and runs
-;; `:initial-events` once to seed it; thereafter every in-tree
-;; `dispatch`/`subscribe` resolves to that frame. On hot reload the provider
-;; REUSES the existing frame and does NOT re-seed. Matches the canonical
-;; mount in examples/reagent/counter/core.cljs.
+;; The whole frame lifecycle lives in one spot at the render root: the
+;; `frame-provider {:id app-frame …}` below. On first mount it creates the
+;; app frame, applies its config, and runs `:initial-events` once to seed
+;; app-db. Thereafter every `dispatch`/`subscribe` in the tree resolves to
+;; that frame. On hot reload the provider reuses the existing frame and
+;; skips re-seeding, so the converter keeps its value across re-mounts.
+;;
+;; `app-frame` is just an id we pick. The runtime won't infer it, so we name
+;; it here and hand it to the provider. Matches the canonical mount in
+;; examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; `init!` installs the reactive adapter for the process. Each adapter ns
+  ;; exports an `adapter` var; require the ns and pass that var directly.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -22,9 +22,8 @@
    - Controlled-input slider via dispatch on change       (CP-4)"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
-            ;; rf/reg-app-schema resolves.
+            ;; Loading `re-frame.schemas` (from day8/re-frame2-schemas)
+            ;; registers the hooks that make `rf/reg-app-schema` resolve.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -46,11 +45,10 @@
    [:tick-active? :boolean]             ;; whether a tick is in flight
    [:tick-gen :int]])                   ;; generation token; bumped on Reset to retire stale ticks
 
-;; EP-0002: reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (the id the render root's `frame-provider {:id app-frame}`
-;; ensures — see `run`), so name it explicitly so the schema binds to the app
-;; frame whose commits it validates.
+;; `reg-app-schema` binds the schema to a specific frame, so it needs a frame
+;; in scope. At ns-load there is none, so we name the frame with `with-frame`.
+;; We use `:rf/default` — the same id the render root's `frame-provider` uses
+;; (see `run`) — so the schema lands on the app frame whose commits it validates.
 (with-frame :rf/default
   (rf/reg-app-schema [:timer] {:schema TimerState}))
 
@@ -178,9 +176,8 @@
                                       (js/parseInt (.. % -target -value))])}]
       [:span (.toFixed (/ duration 1000.0) 1) " s"]]
      [:div.row
-      ;; Ordinary `dispatch` — the idiom for every UI event handler.
-      ;; The 0.0 reading is made observable by the :tick-gen generation
-      ;; guard (see EVENTS header note), not by synchronous dispatch.
+      ;; Plain `dispatch`, like every UI handler. The 0.0 reading shows
+      ;; reliably thanks to the :tick-gen generation guard (see EVENTS note).
       [:button {:data-testid "timer-reset"
                 :on-click #(dispatch [:timer/reset])} "Reset"]]]))
 
@@ -194,20 +191,21 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame).
-;; The render root then uses the `frame-provider` ENSURE shape (`{:id …}`):
-;; on first mount it creates the app frame, applies its config, and runs the
-;; `:initial-events` seed ONCE; on hot reload it reuses the existing frame
-;; without re-seeding. Create, seed, and scope-into-React all happen in that
-;; one spot. The frame id is `:rf/default` — the same id the schema block
-;; above scopes its `reg-app-schema` registration to. Matches the canonical
-;; mount in examples/reagent/counter/core.cljs.
+;; The whole frame lifecycle lives in one spot at the render root: the
+;; `frame-provider {:id app-frame …}` below. On first mount it creates the
+;; app frame, applies its config, and runs `:initial-events` once to seed
+;; app-db. Thereafter every `dispatch`/`subscribe` in the tree resolves to
+;; that frame. On hot reload the provider reuses the existing frame and skips
+;; re-seeding, so the timer keeps ticking across re-mounts.
+;;
+;; `app-frame` is just an id we pick. We use `:rf/default` — the same id the
+;; schema block above binds to. Matches the canonical mount in
+;; examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; `init!` installs the reactive adapter for the process. It does not create
+  ;; the frame — the `frame-provider` below does that.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -12,16 +12,16 @@
    :clj branches) and client-side (browser, with :cljs branches).
 
    Demonstrates:
-   - Per-request frame on the server                 (with-frame)
+   - Per-request frame on the server                 (reg-frame + with-frame)
    - :rf/server-init dispatched at frame creation
    - Server-only fx via :platforms #{:server}        (and skipping on the client)
    - Pure hiccup → HTML emitter                       (rf/render-to-string)
    - Hydration payload format                         (:rf/hydration-payload schema)
    - Per-request frame teardown in a `finally`        (rf/destroy-frame!)
    - Framework-owned hydration: the client boots via the `ssr/hydrate!`
-     helper, which dispatches the framework's reserved `:rf/hydrate` event
-     (the app does NOT re-register it). `:rf/hydrate` replaces (not merges)
-     the client frame-state, per the locked :replace-frame-state policy.
+     helper, which dispatches the framework's reserved `:rf/hydrate` event.
+     `:rf/hydrate` replaces (not merges) the client frame-state, per the
+     locked :replace-frame-state policy.
    - data-rf-render-hash structural marker on the root element; `ssr/hydrate!`
      verifies the client render-tree hash against the server's after first
      render and the runtime emits :rf.ssr/hydration-mismatch on disagreement
@@ -81,24 +81,18 @@
 ;; SCHEMA
 ;; ============================================================================
 ;;
-;; EP-0002: `reg-app-schema` is context-required frame-local and
-;; raises `:rf.error/no-frame-context` under no frame scope — so a bare ns-load
-;; registration is wrong, and a naive `with-frame :rf/default`
-;; would bind the schema to the client frame ONLY, leaving the per-request
-;; SERVER frames (where the SSR commits actually validate) unschema'd. SSR has
-;; TWO frame families: the per-request server frame (gensym, in
-;; `handle-request`) and the FIXED client hydration frame (`app-frame` →
-;; `:rf/default`, in `run`). The schema is the same contract for both, so we
-;; hold it as a value and register it explicitly against EACH frame at its
-;; entry point (server: per request; client: at boot) with the `{:frame …}`
-;; override. Holding it as a def also keeps ns-load side-effect-free — the
-;; entry namespace loads without any ambient frame fixture.
-;; `[:maybe …]` because the slice is ABSENT (nil) until `:articles/loaded`
-;; commits — the per-request server frame's `:rf/server-init` commits an
-;; articles-free db first (it only kicks off the managed-HTTP fetch), and the
-;; client frame starts empty before hydration. A bare `[:vector …]` would reject
-;; that legitimate intermediate `nil` and roll the commit back (the
-;; bug was masked precisely because validation never ran on these frames).
+;; Hold the schema as a plain value. SSR has TWO frame families — the
+;; per-request server frame (gensym, in `handle-request`) and the fixed client
+;; hydration frame (`app-frame` → `:rf/default`, in `run`) — and the same
+;; contract applies to both. So each entry point registers it against its own
+;; frame with the `{:frame …}` override (server: per request; client: at boot).
+;; `reg-app-schema` is frame-local: it needs an explicit `:frame`, and holding
+;; the schema as a `def` keeps ns-load free of any ambient frame fixture.
+;; `[:maybe …]` because the slice is nil until `:articles/loaded` commits: the
+;; server's `:rf/server-init` commits an articles-free db first (it only kicks
+;; off the managed-HTTP fetch), and the client frame starts empty before
+;; hydration. A bare `[:vector …]` would reject that legitimate intermediate
+;; nil and roll the commit back.
 (def ArticlesSchema
   [:maybe [:vector [:map
                     [:id    :string]
@@ -110,10 +104,9 @@
 ;; ============================================================================
 ;;
 ;; HTTP requests go via the framework-shipped `:rf.http/managed` (Spec 014).
-;; The example deliberately doesn't register an HTTP-side fx of its own —
-;; the SSR test below uses the `:fx-overrides` seam to redirect
-;; `:rf.http/managed` to a per-frame canned-success stub so the JVM-side
-;; render exercises the full domino loop without real network traffic.
+;; The SSR test below redirects it through the `:fx-overrides` seam to a
+;; per-frame canned-success stub, so the JVM-side render exercises the full
+;; domino loop without real network traffic.
 
 (rf/reg-fx :auth.session/store
   {:doc       "Persist a session token in localStorage."
@@ -133,15 +126,14 @@
    :platforms #{:server}
    :rf.cofx/requires [:rf.server/request]}
   (fn handler-rf-server-init [{:keys [db rf.server/request]} _]
-    ;; `request` is the host-supplied HTTP request map (Ring shape under
-    ;; the bundled adapter); read URL/headers/cookies from here rather
-    ;; than from a positional event arg.
+    ;; `request` is the host-supplied HTTP request map (Ring shape under the
+    ;; bundled adapter); read URL/headers/cookies from it. It arrives via the
+    ;; `:rf.server/request` cofx, not a positional event arg.
     ;;
-    ;; EP-0001: the framework route slice lives in the
-    ;; runtime-db partition at `[:rf.runtime/routing :current]`. This
-    ;; example's render never reads the route slice, so the `:db` write is
-    ;; simply dropped — the server flow only needs to kick off the
-    ;; managed-HTTP article fetch.
+    ;; This handler leaves db unchanged and just kicks off the managed-HTTP
+    ;; article fetch. (A router-driven app would store the matched route here,
+    ;; in the runtime-db partition at `[:rf.runtime/routing :current]` per
+    ;; EP-0001; this article-only render has no route to track.)
     {:db db
      :fx [[:rf.http/managed
            {:request    {:method :get :url "/api/articles"}
@@ -157,23 +149,20 @@
     {:db (assoc db :articles value)}))
 
 ;; HYDRATION IS FRAMEWORK-OWNED. `:rf/hydrate` is a reserved `:rf/*` event
-;; (Conventions §Reserved namespaces) registered by `re-frame.ssr` — the app
-;; MUST NOT re-register it. The framework handler installs a coherent
+;; (Conventions §Reserved namespaces) that `re-frame.ssr` registers; the app
+;; supplies no handler for it. The framework handler installs the whole client
 ;; frame-state in one atomic transition under the locked :replace-frame-state
-;; policy (Spec 011 §The :rf/hydrate event): server is authoritative for the
-;; initial client frame-state, so the payload's :rf/app-db replaces the app-db
-;; partition AND :rf/runtime-db replaces the serializable runtime-db projection
-;; (machine snapshots, route slice, …). It also does work the app must not
-;; reinvent: it validates the payload fail-closed (a non-map payload or a
-;; present-but-non-map :rf/app-db / :rf/runtime-db slice is REJECTED, leaving
-;; the client frame-state untouched), and it stashes the server's
-;; :rf/render-hash under [:rf.runtime/ssr :hydration :server-hash] so
-;; `ssr/verify-hydration!` can drive mismatch detection after the first render.
-;; (This example carries no machines and doesn't hydrate the route, so its
-;; :rf/runtime-db is empty — but the shape is the same one a richer app uses.)
-;; The client `run` below boots via `ssr/hydrate!`, the framework helper that
-;; reads the payload, dispatches `[:rf/hydrate payload]`, and verifies — see
-;; the CLIENT ENTRY POINT section.
+;; policy (Spec 011 §The :rf/hydrate event): the server is authoritative, so
+;; the payload's :rf/app-db replaces the app-db partition and :rf/runtime-db
+;; replaces the serializable runtime-db projection (machine snapshots, route
+;; slice, …). The handler also validates the payload fail-closed (a non-map
+;; payload, or a present-but-non-map :rf/app-db / :rf/runtime-db slice, leaves
+;; the frame-state untouched), and stashes the server's :rf/render-hash under
+;; [:rf.runtime/ssr :hydration :server-hash] for `ssr/verify-hydration!` to
+;; compare after the first render. (This example carries no machines and
+;; doesn't hydrate the route, so its :rf/runtime-db is empty — but the shape is
+;; the one a richer app uses.) The client `run` below drives all this through
+;; `ssr/hydrate!` — see the CLIENT ENTRY POINT section.
 
 ;; ============================================================================
 ;; CLIENT-SIDE INTERACTIVITY EVENTS
@@ -202,16 +191,14 @@
       (if (nil? v) true v))))
 
 ;; reg-view (defn-shape per Spec 004 §reg-view) auto-defs the symbol and
-;; registers under (keyword *ns* sym) — overridden here via
-;; ^{:rf/id ...} so the :pages/articles / :app/root ids the view
-;; callers below use match the registrations.
+;; registers under (keyword *ns* sym). `^{:rf/id ...}` overrides that id so the
+;; :pages/articles / :app/root ids the callers below use match the registrations.
 ;;
-;; Server-side (JVM) the auto-injected `subscribe` in `reg-view` is a
-;; macro-time concept that resolves to (:subscribe (rf/frame-handle)) — a frame-bound
-;; subscribe fn — at runtime. On the JVM render path, deref of a
-;; subscription yields its current value; on the client, deref tracks
-;; the reaction so re-renders fire on app-db changes. Same code, both
-;; sides — that's the SSR/CLJS parity Spec 011 promises.
+;; The `subscribe` injected by `reg-view` resolves to the frame-bound subscribe
+;; fn at runtime. The same view code runs both sides: on the JVM render path,
+;; deref of a subscription yields its current value; on the client, deref tracks
+;; the reaction so re-renders fire on app-db changes. That's the SSR/CLJS parity
+;; Spec 011 promises.
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
   (let [arts         @(subscribe [:articles/slice])
         show-bodies? @(subscribe [:articles/show-bodies?])]
@@ -263,14 +250,11 @@
    (defn handle-request [request]
      (let [fid (keyword "rf.frame" (str (gensym "f")))
            _   (ssr/set-request! fid request)
-           ;; Register the app schema AGAINST THIS per-request server frame
-           ;; BEFORE the `:initial-events` `:rf/server-init` step runs — the
-           ;; per-request frame is where the server-side `:articles` commit
-           ;; actually validates, so the schema must bind here, not only on the
-           ;; client frame. `reg-frame` runs the `:initial-events` cascade
-           ;; synchronously before returning, so the schema must be in place
-           ;; first; we register it under the gensym `fid` and only then create
-           ;; the frame.
+           ;; Register the app schema against this per-request server frame,
+           ;; under the gensym `fid`, BEFORE creating the frame. `reg-frame`
+           ;; runs its `:initial-events` cascade synchronously, so the schema
+           ;; must be in place first to validate the server-side `:articles`
+           ;; commit that `:rf/server-init` kicks off.
            _   (rf/reg-app-schema [:articles] {:schema ArticlesSchema :frame fid})
            f   (rf/reg-frame fid
                  {:doc       "ssr-example per-request frame"
@@ -293,30 +277,17 @@
                  ;; environments (server logs, CDN cache keys) can read it
                  ;; without HTML parsing.
                  render-hash (rf/render-tree-hash hiccup)
-                 ;; EP-0002: the payload DELIBERATELY OMITS
-                 ;; `:rf/frame-id`. The server renders under a per-request
-                 ;; gensym frame (`f`), but the client hydrates a FIXED app-
-                 ;; frame (`app-frame` → `:rf/default`, below). `ssr/hydrate!`
-                 ;; VALIDATES a present payload `:rf/frame-id` against the
-                 ;; client's explicit `:frame` and raises
-                 ;; `:rf.error/hydration-frame-id-mismatch` on disagreement
-                 ;; (Spec 011 §The hydration payload — the frame-id is
-                 ;; validation evidence, NOT a target resolver). Stamping the
-                 ;; server's per-request gensym here would always conflict
-                 ;; with the client's fixed frame; an ABSENT `:rf/frame-id` is
-                 ;; explicitly NO conflict (the explicit client target
-                 ;; stands), so the dynamic server output and the static
-                 ;; `index.html` next to this file agree on the frame-id
-                 ;; question (neither carries one). The hand-written
-                 ;; `index.html` is an ILLUSTRATIVE stand-in, not a byte-exact
-                 ;; capture of this payload: it omits `:rf/render-hash` (it
-                 ;; doesn't recompute the FNV-1a hash) and carries a sample
-                 ;; `:rf.runtime/routing` slice this article-only render never
-                 ;; populates. A deployment that
-                 ;; WANTS the round-trip to carry a frame-id stamps a STABLE
-                 ;; id both sides agree on (or has the client read the
-                 ;; payload's frame-id as its hydration target) — not a
-                 ;; per-request gensym.
+                 ;; The payload omits `:rf/frame-id`. The server renders under
+                 ;; a per-request gensym frame (`f`); the client hydrates its
+                 ;; own fixed app-frame (`app-frame` → `:rf/default`, below).
+                 ;; A payload frame-id is validation evidence, not a hydration
+                 ;; target: `ssr/hydrate!` checks any present `:rf/frame-id`
+                 ;; against the client's explicit `:frame` and raises
+                 ;; `:rf.error/hydration-frame-id-mismatch` if they disagree
+                 ;; (Spec 011 §The hydration payload). An absent id is the
+                 ;; no-conflict shape both this output and the static
+                 ;; `index.html` use. To carry a frame-id, a deployment stamps
+                 ;; a stable id both sides agree on — not a per-request gensym.
                  payload  {:rf/version     1
                            :rf/app-db      final-db        ;; app-db partition
                            :rf/runtime-db  final-runtime   ;; serializable runtime-db projection
@@ -370,17 +341,14 @@
 ;;                :rf.ssr/hydration-mismatch.
 ;; `hydrate!` returns the payload it applied (nil on a client-only load), so
 ;; `run` branches on "was this server-rendered?" without re-reading the DOM.
-;; The app does NOT hand-roll a `read-server-payload` + bare dispatch — that
-;; bypasses the fail-closed validation, the metadata stash, and the verify
-;; step the helper pins.
+;; Going through the helper is what pins the fail-closed validation, the
+;; metadata stash, and the verify step together in the right order.
 
-;; User events live under an app-chosen namespace, NEVER under the
-;; reserved `:rf/*` root (Conventions §Reserved namespaces — user code MUST
-;; NOT register handlers under `:rf/*`). `:rf/hydrate` and `:rf/server-init`
-;; are framework-owned (the runtime / re-frame.ssr register `:rf/hydrate`;
+;; User events live under an app-chosen namespace, never the reserved `:rf/*`
+;; root (Conventions §Reserved namespaces). `:rf/hydrate` is framework-owned;
 ;; `:rf/server-init` is the documented per-request server-init pattern event
-;; the app supplies a body for). This client-only-load bootstrap is a fresh
-;; user invention, so it gets the app's own `:ssr/` namespace.
+;; the app supplies a body for. This client-only-load bootstrap is a fresh user
+;; event, so it gets the app's own `:ssr/` namespace.
 (rf/reg-event :ssr/client-bootstrap
   {:doc "Client-side init that runs even if the server didn't render this page."}
   (fn [{:keys [db]} _] {:db db}))
@@ -391,43 +359,29 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 #?(:cljs (defonce react-root (atom nil)))
 
-;; EP-0002: under the carried-frame invariant the
-;; runtime never synthesises a frame from absence — the SSR hydration target
-;; is CARRIED, established explicitly by the app and threaded through both
-;; `ssr/hydrate!` (the seed target) AND the root `frame-provider` (where every
-;; in-tree `dispatch`/`subscribe` resolves). This example uses `:rf/default`
-;; as its client app-frame id (a migration may pick `:rf/default`, but the
-;; runtime will not infer it). It MUST be a `:client`-platform frame so the
+;; The client app-frame id. The app names its frame explicitly and threads this
+;; id through both `ssr/hydrate!` (the seed target) and the root
+;; `frame-provider` (where every in-tree `dispatch`/`subscribe` resolves). This
+;; example uses `:rf/default`. It must be a `:client`-platform frame so the
 ;; `:rf.ssr/check-*` compatibility-check fxs the `:rf/hydrate` handler
-;; dispatches actually fire (Spec 011 §The :rf/hydrate event — a `:server`-
-;; platform frame skips them). BOTH the static `index.html` payload AND the
-;; dynamic `handle-request` payload above carry NO `:rf/frame-id`: the server
-;; renders under a per-request gensym frame the client can't know ahead of
-;; time, and the client hydrates this FIXED app-frame, so an absent frame-id
-;; is the correct shape (it is NOT a hydration-frame-id conflict — the
-;; explicit `:frame` stands). A present-but-different payload `:rf/frame-id`
-;; — e.g. the server's per-request gensym against this `:rf/default` client
-;; target — WOULD surface a structured `:rf.error/hydration-frame-id-mismatch`
-;; (Spec 011 §The hydration payload), which is exactly why `handle-request`
-;; omits it.
+;; dispatches actually fire (Spec 011 §The :rf/hydrate event — a `:server`
+;; frame skips them). The server payload carries no `:rf/frame-id`, so this
+;; explicit `:frame` is the hydration target (see the `handle-request` note).
 (def app-frame :rf/default)
 
 #?(:cljs
    (defn run []
-     ;; Boot the runtime against the Reagent substrate. Idempotent — the
-     ;; first call installs the adapter; subsequent calls (e.g. shadow-cljs
-     ;; hot reloads) are no-ops. `init!` installs the adapter but does NOT
-     ;; create a frame — EP-0002: the app establishes its frame explicitly
-     ;; (below) and the runtime never synthesises `:rf/default` from absence.
+     ;; Boot the runtime against the Reagent substrate. Idempotent: the first
+     ;; call installs the adapter, hot reloads are no-ops. `init!` installs only
+     ;; the adapter; the app creates its frame itself, in the next step.
      ;;
-     ;; Pass the adapter spec map directly. There is no
-     ;; default-adapter registry — each adapter ns exports an `adapter`
-     ;; var the consumer requires and passes here.
+     ;; Pass the adapter spec map directly — each adapter ns exports an
+     ;; `adapter` var the consumer requires and passes here.
      (rf/init! reagent-adapter/adapter)
-     ;; Establish the carried client app-frame BEFORE hydrating into it.
-     ;; `reg-frame` is a surgical no-op on re-registration (hot-reload Just
-     ;; Works). `:platform :client` makes the hydrate compatibility-check
-     ;; fxs fire (Spec 011 §The :rf/hydrate event).
+     ;; Create the client app-frame, before hydrating into it. `reg-frame` is a
+     ;; no-op on re-registration, so hot-reload just works. `:platform :client`
+     ;; makes the hydrate compatibility-check fxs fire (Spec 011 §The :rf/hydrate
+     ;; event).
      (rf/reg-frame app-frame {:doc      "ssr-example client app-frame"
                               :platform :client})
      ;; Register the app schema AGAINST THE FIXED CLIENT FRAME so
@@ -437,36 +391,25 @@
      ;; the explicit override; `reg-app-schema` is a no-op-safe re-registration
      ;; on hot-reload.
      (rf/reg-app-schema [:articles] {:schema ArticlesSchema :frame app-frame})
-     ;; `ssr/hydrate!` is the framework client-boot helper (Spec 011
-     ;; §Client-side hydration boot helper). It READs the `__rf_payload`
-     ;; script, dispatch-syncs `[:rf/hydrate payload]` to install the
-     ;; server's frame-state into the EXPLICIT `:frame` BEFORE first render
-     ;; (locked :replace-frame-state policy), and — given a `:render-tree-fn`
-     ;; — runs the post-hydrate VERIFY step: it hashes the client render-tree
-     ;; and compares it to the server's :rf/render-hash (stashed by the
-     ;; framework `:rf/hydrate` handler at [:rf.runtime/ssr :hydration
-     ;; :server-hash]), emitting :rf.ssr/hydration-mismatch on disagreement.
-     ;; `:render-tree-fn` must return the SAME *resolved* hiccup tree the
-     ;; server hashed — the server computed `(rf/render-tree-hash
-     ;; ((rf/view :app/root)))`, so we CALL the view fn here, `((rf/view
-     ;; :app/root))`, rather than the vector-wrapped component reference
-     ;; `[(rf/view :app/root)]` we hand Reagent to mount. EP-0002: the
-     ;; hydration target is CARRIED — the same `app-frame` flows to
-     ;; `hydrate!` and the root `frame-provider`. It returns the payload it
-     ;; applied (nil on a client-only first load with no payload script), so
-     ;; we can branch on "was this server-rendered?".
+     ;; Drive READ + HYDRATE + VERIFY through `ssr/hydrate!` (the steps detailed
+     ;; in the CLIENT ENTRY POINT header), against the same `app-frame` the mount
+     ;; below uses. `:render-tree-fn` must return the same resolved hiccup tree
+     ;; the server hashed: the server hashed `((rf/view :app/root))`, so VERIFY
+     ;; CALLS the view fn — `((rf/view :app/root))` — not the vector form
+     ;; `[(rf/view :app/root)]` that Reagent mounts. `hydrate!` returns the
+     ;; payload it applied (nil on a client-only load), so we can branch on "was
+     ;; this server-rendered?".
      (let [payload (ssr/hydrate! {:frame          app-frame
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})]
        (when-not payload
-         ;; Client-only load (no server render): run the app's own
-         ;; bootstrap against the carried frame; the page renders the
-         ;; empty-articles fallback.
+         ;; Client-only load (no server render): run the app's own bootstrap
+         ;; against the app-frame; the page renders the empty-articles fallback.
          (rf/dispatch-sync [:ssr/client-bootstrap] {:frame app-frame})))
      (when (exists? js/document)
        (when-not @react-root
          (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-       ;; Wrap the mount in the carried frame's `frame-provider` so every
-       ;; in-tree `dispatch`/`subscribe` resolves to the hydrated frame.
+       ;; Mount under the app-frame's `frame-provider` so every in-tree
+       ;; `dispatch`/`subscribe` resolves to the hydrated frame.
        (rdc/render @react-root
                    [rf/frame-provider {:frame app-frame}
                     [(rf/view :app/root)]]))))

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -32,22 +32,16 @@
 ;; SCHEMA
 ;; ============================================================================
 ;;
-;; EP-0002: `reg-app-schema` is context-required frame-local and
-;; raises `:rf.error/no-frame-context` under no frame scope — so a bare ns-load
-;; registration is wrong, and a naive `with-frame :rf/default`
-;; would bind the schema to the client frame ONLY, leaving the per-request
-;; SERVER frame (where the SSR commits actually validate) unschema'd. Streaming
-;; SSR has TWO frame families: the per-request server frame (gensym, in
-;; `handle-request`) and the FIXED client hydration frame (`app-frame` →
-;; `:rf/default`, in `run`). The schema is the same contract for both, so we
-;; hold it as a value and register it explicitly against EACH frame at its
-;; entry point with the `{:frame …}` override. Holding it as a def also keeps
-;; ns-load side-effect-free — the entry namespace loads without any ambient
-;; frame fixture.
-;; `[:maybe …]` because the slice is ABSENT (nil) until `:rf/server-init`
-;; seeds it on the server / the client hydrates it — a bare `[:map-of …]` would
-;; reject the legitimate pre-seed `nil` and roll the commit back. (The bug was
-;; masked because validation never actually ran on these frames.)
+;; We hold the schema as a plain value and register it per-frame at each
+;; entry point with the `{:frame …}` override. Streaming SSR runs two frame
+;; families — the per-request server frame (gensym, in `handle-request`) and
+;; the fixed client hydration frame (`app-frame` → `:rf/default`, in `run`)
+;; — and both need the same contract, so each registers it explicitly.
+;; `reg-app-schema` is frame-local (EP-0002), so holding the schema as a def
+;; also keeps ns-load side-effect-free: the namespace loads under no frame.
+;; `[:maybe …]` because the `:cards` slice is nil until `:rf/server-init`
+;; seeds it on the server / the client hydrates it. A bare `[:map-of …]`
+;; would reject that legitimate nil and roll the commit back.
 (def CardsSchema
   [:maybe [:map-of :keyword [:map [:title :string] [:value [:maybe :int]]]]])
 
@@ -186,18 +180,16 @@
                              fid render-hash
                              {:version 1
                               :payload :rf.ssr.payload/whole-app-db}))
-           ;; EP-0002: `streaming-build-final-payload` stamps the
-           ;; per-request server frame (`fid`) as `:rf/frame-id`, but the
-           ;; client hydrates a FIXED app-frame (`app-frame` → `:rf/default`,
-           ;; below). `ssr/hydrate!` VALIDATES a present payload `:rf/frame-id`
-           ;; against the client's explicit `:frame` and raises
-           ;; `:rf.error/hydration-frame-id-mismatch` on disagreement (Spec 011
-           ;; §The hydration payload). The server's per-request gensym would
-           ;; always conflict with the client's fixed frame, so we DROP it —
-           ;; an absent `:rf/frame-id` is explicitly NO conflict (the explicit
-           ;; client target stands), matching the static `index.html` next to
-           ;; this file. A deployment that wants a frame-id on the wire stamps
-           ;; a STABLE id both sides agree on, not a per-request gensym.
+           ;; Drop the payload's `:rf/frame-id`. `streaming-build-final-payload`
+           ;; stamps this per-request server frame (`fid`), but the client
+           ;; hydrates a fixed app-frame (`app-frame` → `:rf/default`, below).
+           ;; `ssr/hydrate!` checks a present `:rf/frame-id` against the client's
+           ;; explicit `:frame` and raises `:rf.error/hydration-frame-id-mismatch`
+           ;; on disagreement (Spec 011 §The hydration payload); the per-request
+           ;; gensym would always disagree. With no frame-id on the wire the
+           ;; client's explicit target stands — matching the static `index.html`
+           ;; next to this file. A deployment that wants a frame-id on the wire
+           ;; stamps a stable id both sides agree on, not a per-request gensym.
            final-payload (dissoc final-payload :rf/frame-id)
            _ (rf/destroy-frame! fid)]
        {:shell shell-html
@@ -260,27 +252,21 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 #?(:cljs (defonce react-root (atom nil)))
 
-;; EP-0002: the SSR hydration target is CARRIED —
-;; established explicitly by the app and threaded through the streaming
-;; `install!`, `ssr/hydrate!`, AND the root `frame-provider`. The runtime
-;; never synthesises a frame from absence. This example uses `:rf/default`
-;; as its client app-frame id; it MUST be a `:client`-platform frame so the
-;; `:rf.ssr/check-*` compatibility-check fxs the `:rf/hydrate` handler
-;; dispatches actually fire (Spec 011 §The :rf/hydrate event). BOTH the static
-;; `index.html` payload AND the dynamic `handle-request` final-payload above
-;; carry NO `:rf/frame-id`: the server renders under a per-request gensym
-;; frame the client can't know ahead of time, and the client hydrates this
-;; FIXED app-frame, so an absent frame-id is the correct shape (it is NOT a
-;; hydration-frame-id conflict — the explicit `:frame` stands). A present-but-
-;; different stamp (the server's per-request gensym against this `:rf/default`
-;; client target) WOULD surface `:rf.error/hydration-frame-id-mismatch` (Spec
-;; 011 §The hydration payload), which is why `handle-request` drops it.
+;; The client app-frame id. The app carries it explicitly — the same id
+;; flows to the streaming `install!`, `ssr/hydrate!`, AND the root
+;; `frame-provider` (EP-0002). This example uses `:rf/default`. It must be a
+;; `:client`-platform frame so the `:rf.ssr/check-*` compatibility-check fxs
+;; the `:rf/hydrate` handler dispatches actually fire (Spec 011 §The
+;; :rf/hydrate event). Both the static `index.html` payload and the dynamic
+;; `handle-request` final-payload carry no `:rf/frame-id`: the server renders
+;; under a per-request gensym frame, the client hydrates this fixed frame, so
+;; an absent frame-id is the right shape — the explicit `:frame` is the target.
 #?(:cljs (def app-frame :rf/default))
 
 #?(:cljs
    (defn run []
-     ;; `init!` installs the adapter but does NOT create a frame — EP-0002:
-     ;; the app establishes its frame explicitly (below).
+     ;; `init!` installs the Reagent adapter. The app then creates its
+     ;; frame explicitly below (init! does not create one — EP-0002).
      (rf/init! reagent-adapter/adapter)
      ;; Establish the carried client app-frame BEFORE installing the
      ;; streaming runtime / hydrating into it. `reg-frame` is a surgical

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -49,10 +49,10 @@
 ;; THE TRANSITION TABLE — chapter §The same flow as a transition table
 ;; ============================================================================
 ;;
-;; Pure data. `:guards` and `:actions` live with the spec — there is no
-;; global registry. References inside `:states` resolve against this
-;; map; cross-machine reuse is via Clojure vars (define a fn, name it
-;; locally in each machine's :guards / :actions).
+;; Pure data. `:guards` and `:actions` live right here in the spec, and the
+;; references inside `:states` resolve against this map. (There is no global
+;; guard/action registry to look them up in.) To reuse a guard or action across
+;; machines, define a fn and name it locally in each machine's :guards / :actions.
 ;;
 ;; This is a near-twin of the login machine in the `login` example
 ;; (examples/reagent/login/core.cljs) — same states, guards, actions, and
@@ -244,13 +244,12 @@
 
 ;; The machine snapshot lives in runtime-db at
 ;; [:rf.runtime/machines :snapshots :auth.login/flow] (per Spec 005).
-;; The framework ships `:rf/machine` as the canonical entry point onto
-;; that path; the two named subs below chain off it to project out the
-;; convenient pieces (current state, last error). The "is it busy / locked?"
-;; questions the view actually asks are NOT here — they live as the
-;; `rf/machine-has-tag?` queries in views.cljs (chapter §State tags),
-;; because discriminating on the snapshot's runtime-projected `:tags` set
-;; decouples view code from individual state-keyword identity.
+;; The framework ships `:rf/machine` as the canonical entry point onto that
+;; path. The two named subs below chain off it to project out the handy pieces:
+;; current state and last error. For the "is it busy / locked?" questions, the
+;; view asks the machine for a tag directly with `rf/machine-has-tag?`
+;; (chapter §State tags) — reading the `:tags` set keeps the view off
+;; individual state keywords.
 
 (rf/reg-sub :auth.login/draft
   {:doc "The login form draft — what the user has currently typed. The view's

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -26,20 +26,20 @@
 ;; ============================================================================
 
 (reg-view ^{:doc "The login form view. The email + password DRAFT is application
-                  state, so it lives in app-db (the `:auth.login/draft` slice),
-                  NOT a view-local atom — projected via the `:auth.login/draft`
-                  sub, mutated via the `:auth.login/edit-field` event. The inputs
-                  are CONTROLLED: `:value` reads from the draft sub, `:on-change`
-                  DISPATCHES an edit-field event (it never sets view-local state).
-                  Submit reads the draft back out of the sub and hands it to the
-                  machine via :auth.login/flow → :auth.login/submit.
+                  state, so it lives in app-db (the `:auth.login/draft` slice):
+                  read via the `:auth.login/draft` sub, written via the
+                  `:auth.login/edit-field` event. The inputs are CONTROLLED —
+                  `:value` reads from the draft sub, `:on-change` dispatches an
+                  edit-field event. Submit reads the draft back out of the sub
+                  and hands it to the machine via :auth.login/flow →
+                  :auth.login/submit.
 
                   The machine owns submit/auth STATUS; the slice owns the DRAFT
                   (Pattern-Forms §Variations: machine + slice). View-side
-                  discriminators read the machine's runtime-projected `:tags` set
-                  (chapter §State tags) via `rf/machine-has-tag?`, not boolean
-                  state-predicate subs — so adding a new busy-ish state changes
-                  no view."}
+                  discriminators ask the machine for a tag via
+                  `rf/machine-has-tag?` (chapter §State tags), reading its
+                  runtime-projected `:tags` set rather than the current state
+                  keyword — so adding a new busy-ish state changes no view."}
           login-form []
   (let [busy?   @(rf/machine-has-tag? :auth.login/flow :auth/busy)
         locked? @(rf/machine-has-tag? :auth.login/flow :auth/locked)
@@ -114,23 +114,24 @@
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the Reagent adapter — pass its spec map straight to init!.
   (rf/init! reagent-adapter/adapter)
-  ;; One spot creates, configures and seeds the app frame: the ENSURE form
-  ;; `frame-provider {:id …}`. On first mount it CREATES the `:rf/default`
-  ;; frame, applies the config, and runs `:initial-events` once; on hot reload
-  ;; it REUSES the same frame WITHOUT re-seeding. The `reg-view`-injected
-  ;; `dispatch`/`subscribe` (and the login machine reads) resolve to it.
+  ;; `frame-provider {:id …}` is the one spot that creates, configures and
+  ;; seeds the app frame. On first mount it creates the `:rf/default` frame,
+  ;; applies the config, and runs `:initial-events` once. On hot reload it
+  ;; reuses that frame and skips re-seeding, so your typed-in draft survives.
+  ;; The `reg-view`-injected `dispatch`/`subscribe` (and the login machine
+  ;; reads) resolve to this frame.
   ;;
-  ;; `:fx-overrides` installs the canned-failure stub so every
-  ;; `:rf.http/managed` request resolves :failure — the chapter's lockout
-  ;; scenario depends on three consecutive failures.
+  ;; `:fx-overrides` swaps `:rf.http/managed` for the canned-failure stub, so
+  ;; every login request fails — the chapter's lockout scenario needs three
+  ;; failures in a row.
   ;;
-  ;; The login machine is self-initialising; the form DRAFT slice is not, so it
-  ;; is seeded via `:initial-events` BEFORE first render — the controlled inputs
-  ;; read `:value` off `[:auth :login-form :draft]`, so the slot must exist as
-  ;; empty strings on the first paint (a nil there would make React treat the
-  ;; inputs as uncontrolled).
+  ;; The login machine spawns itself on its first event. The form DRAFT slice
+  ;; does not, so `:initial-events` seeds it before first render: the controlled
+  ;; inputs read `:value` off `[:auth :login-form :draft]`, and that slot must
+  ;; already hold empty strings (a nil there makes React treat the inputs as
+  ;; uncontrolled).
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -1,13 +1,12 @@
 (ns todomvc.core
   "Entry point: install the adapter, mount the view, ensure-and-seed the frame.
 
-  Demonstrates the boot wiring the other files lean on — `init!` (installs the
-  Reagent adapter; it does NOT create a frame), the `frame-provider {:id …}`
-  ensure form (creates the URL-owning app frame on first mount, with `:url-bound?`
-  so it owns the address bar, and seeds it once via `:initial-events`), and the
-  hash → route adapter that turns a `#/active` URL change into a
-  `:rf.route/handle-url-change` event. \"The URL is an input; navigation is an
-  event.\""
+  Demonstrates the boot wiring the other files lean on — `init!` installs the
+  Reagent adapter; the render root's `frame-provider {:id …}` creates the app
+  frame on first mount, marks it `:url-bound?` so it owns the address bar, and
+  seeds it once via `:initial-events`; and a hash → route adapter turns a
+  `#/active` URL change into a `:rf.route/handle-url-change` event. \"The URL is
+  an input; navigation is an event.\""
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
@@ -38,39 +37,37 @@
 (defn- current-path []
   (hash->path (.. js/window -location -hash)))
 
-;; EP-0002: under the carried invariant the runtime never synthesises a frame
-;; from absence, and URL ownership is an EXPLICIT declaration — the render root's
-;; `frame-provider {:id app-frame …}` ensures the app frame with `:url-bound?
-;; true` so it owns the URL (Spec 012 §Multi-frame routing).
+;; The id of the app frame. The render root's `frame-provider {:id app-frame …}`
+;; creates it with `:url-bound? true`, which is the explicit declaration that
+;; this frame owns the URL (Spec 012 §Multi-frame routing).
 (def app-frame :rf/default)
 
-;; Named handler so the listener install is idempotent: a repeated `boot!`
-;; (a co-required test host invoking `run` twice) must not stack duplicate
-;; `hashchange` listeners. We remove-then-add the same Var so the registration
-;; is deduped even when the Var is redefined on reload.
+;; A named handler keeps the listener install idempotent: `boot!` removes then
+;; re-adds the same Var, so a repeated `run` (e.g. a co-required test host) or a
+;; reload that redefines the Var never stacks duplicate `hashchange` listeners.
 ;;
-;; EP-0002: the URL-change dispatch is targeted at the URL-owning `app-frame`
-;; with an explicit `{:frame app-frame}` — NOT a frameless `(rf/dispatch …)`,
-;; which would raise `:rf.error/no-frame-context`. This example is HASH-based
-;; (`#/active`), so it keeps its own `hashchange` listener rather than the
-;; framework's popstate-driven `rf/install-history-listener!`; targeting the
-;; owner frame is the same contract that listener implements (Spec 012
-;; §popstate drives the URL-owner frame).
+;; The dispatch targets `app-frame` explicitly via `{:frame app-frame}` — that is
+;; the frame that owns the URL. (A frameless `(rf/dispatch …)` would raise
+;; `:rf.error/no-frame-context`.) This example is hash-based (`#/active`), so it
+;; uses its own `hashchange` listener instead of the framework's popstate-driven
+;; `rf/install-history-listener!`; both deliver the URL change to the owner frame
+;; the same way (Spec 012 §popstate drives the URL-owner frame).
 (defn- on-hashchange [_]
   (rf/dispatch [:rf.route/handle-url-change (current-path)] {:frame app-frame}))
 
 ;; ---- Mount -----------------------------------------------------------------
 ;;
-;; The React root is held in a defonce atom and materialised lazily inside
-;; `mount!` (not at ns-load) per examples/TESTING.md §Example mount-isolation:
-;; ns-load must produce no DOM side effects, so co-required example namespaces
-;; don't race `create-root` onto the shared `#app`. `defonce` keeps the root
-;; across hot reloads (React 18 rejects a second `create-root` on a live node),
-;; and `mount!` is `^:dev/after-load` — shadow re-invokes it on every reload to
-;; re-render the (possibly edited) views. The render root's `frame-provider
-;; {:id app-frame …}` ENSURES the frame: it creates and seeds it once on first
-;; mount, then REUSES it on reload WITHOUT re-seeding, so app-db survives the
-;; reload (and the URL listener, installed in `boot!`, survives too).
+;; The React root lives in a `defonce` atom, created lazily on the first
+;; `mount!` rather than at ns-load. Two reasons: ns-load must have no DOM side
+;; effects so co-required example namespaces don't race `create-root` onto the
+;; shared `#app` (examples/TESTING.md §Example mount-isolation), and `defonce`
+;; reuses the one root across hot reloads (React 18 rejects a second
+;; `create-root` on a live node). `mount!` is `^:dev/after-load`, so shadow
+;; re-runs it on every reload to re-render the edited views.
+;;
+;; The render root is a `frame-provider {:id app-frame …}`. On the first mount it
+;; creates the app frame and runs `:initial-events`; on reload it reuses the same
+;; frame without re-seeding, so app-db survives.
 
 (defonce react-root (atom nil))
 
@@ -79,6 +76,10 @@
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
+                ;; `:initial-events` seed the new frame, in order:
+                ;; `[:todo/initialise]` folds the saved todos (from the
+                ;; `:todo.storage/todos` coeffect in db.cljs) into app-db, then
+                ;; `[:rf.route/handle-url-change …]` resolves the initial URL.
                 [rf/frame-provider {:id             app-frame
                                     :doc            "TodoMVC demo frame."
                                     :url-bound?     true
@@ -88,16 +89,10 @@
 
 ;; ---- Boot ------------------------------------------------------------------
 ;;
-;; `boot!` runs once, at shadow's :init-fn, BEFORE the first render. It installs
-;; the adapter (`init!` does NOT create the frame) and installs the `hashchange`
-;; listener. The frame itself is created and seeded by the render root's
-;; `frame-provider {:id app-frame …}` ensure form (see `mount!`): its
-;; `:initial-events` fire once into the freshly-created frame — `[:todo/initialise]`
-;; folds the saved todos (supplied by the registered `:todo.storage/todos`
-;; recordable coeffect in db.cljs) into app-db, then `[:rf.route/handle-url-change …]`
-;; resolves the initial URL. Ensuring + seeding in that one spot removes the
-;; manual `with-frame` / `dispatch-sync` dance and the dispatch-site coeffect
-;; plumbing.
+;; `boot!` runs once at shadow's :init-fn, before the first render. It does two
+;; things: installs the Reagent adapter and installs the `hashchange` listener.
+;; The frame is created and seeded later, by the render root's `frame-provider
+;; {:id app-frame …}` (see `mount!`).
 
 (defn- boot! []
   (rf/init! reagent-adapter/adapter)

--- a/examples/reagent/todomvc/db.cljs
+++ b/examples/reagent/todomvc/db.cljs
@@ -69,9 +69,8 @@
   "Read the saved TodoMVC items from localStorage, normalised to a sorted-map —
    the supplier body for the `:todo.storage/todos` recordable coeffect. nil/empty
    localStorage (first run, or a server with no localStorage) yields an empty
-   sorted-map, so it never clobbers `default-db`'s `(sorted-map)` — which would
-   break allocate-next-id's `(last (keys todos))` max-id invariant once the map
-   promotes to an unordered PersistentHashMap past 8 entries."
+   sorted-map. A sorted-map matters: allocate-next-id picks the max id via
+   `(last (keys todos))`, which only holds while the map stays sorted."
   []
   (or (some-> (.-localStorage js/globalThis)
               (.getItem ls-key)

--- a/examples/reagent/todomvc/views.cljs
+++ b/examples/reagent/todomvc/views.cljs
@@ -17,17 +17,16 @@
     :completed "#/completed"
     "#/"))
 
-;; A CONTROLLED text input, re-frame2 style. `:value` reads a draft sub; every
-;; keystroke dispatches `on-change` (which writes the draft into app-db) — the
-;; input NEVER holds its own value. Enter commits (dispatches `on-commit`),
-;; Escape cancels (dispatches `on-cancel`), and blur commits. There is no DOM
-;; node ref for VALUE and no blur-suppression flag: cancel re-renders the input
-;; away, so the blur that follows has nothing to save.
+;; A CONTROLLED text input, re-frame2 style. `:value` reads a draft sub and every
+;; keystroke dispatches `on-change`, which writes the draft into app-db; the input
+;; never holds its own value. Enter commits (dispatches `on-commit`), Escape
+;; cancels (dispatches `on-cancel`), and blur commits. Cancel re-renders the input
+;; away, so a trailing blur has nothing left to save.
 ;;
-;; `:autofocus?` opts into focusing the input when it first mounts. The edit
-;; input wants this (a row just entered edit mode). It is handled by a bare
-;; `:ref` callback that ONLY calls `.focus()` on the live node — it reads and
-;; writes no value, so the input stays fully controlled by the draft sub.
+;; `:autofocus?` focuses the input when it first mounts — the edit input wants
+;; this, since the row just entered edit mode. A bare `:ref` callback does it by
+;; calling `.focus()` on the live node; it touches focus only, leaving `:value`
+;; bound to the sub.
 (defn todo-input [{:keys [draft on-change on-commit on-cancel autofocus?] :as props}]
   (let [handle-keydown
         (fn [event]
@@ -44,23 +43,21 @@
         :on-key-down handle-keydown
         :on-blur     (fn [_] (on-commit))}
        (when autofocus?
-         ;; Focus-only ref: move the cursor into the freshly-mounted edit input.
-         ;; It touches focus, never the value — `:value` stays bound to the sub.
+         ;; Focus-only ref: move the cursor into the freshly-mounted input.
          {:ref (fn [node] (when node (.focus node)))}))]))
 
 (defn todo-item [dispatch subscribe {:keys [id title completed]}]
-  ;; A plain form-1 fn now that the per-row editing flag lives in app-db: the
-  ;; row reads "am I the editing row?" from a sub keyed by its id, so no
-  ;; component-local atom is needed.
+  ;; A plain form-1 fn. The per-row editing flag lives in app-db, so the row just
+  ;; reads "am I the editing row?" from a sub keyed by its id.
   (let [editing? @(subscribe [:todo.ui/editing? id])]
     [:li {:class (str/join " " (cond-> []
                                  completed (conj "completed")
                                  editing?  (conj "editing")))}
      [:div.view
       ;; Controlled checkbox, re-frame2 style: `:checked` reads the fact from
-      ;; app-db, `:on-click` dispatches the event that changes it, and
-      ;; `:readOnly` silences React's onChange warning (the state round-trips
-      ;; through app-db and the cascade, not through React's own state).
+      ;; app-db and `:on-click` dispatches the event that changes it. The state
+      ;; round-trips through app-db, so `:readOnly` is set to silence React's
+      ;; onChange warning for a checkbox React doesn't itself control.
       [:input.toggle
        {:type "checkbox"
         :checked completed
@@ -129,13 +126,11 @@
          :on-click #(dispatch [:todo/clear-completed])}
         "Clear completed"])]))
 
-;; Sub-views (task-entry, task-list, todo-item, footer-controls) above
-;; are plain Reagent helper fns, not reg-views. They take `dispatch` /
-;; `subscribe` as explicit args because that's the right shape for plain
-;; fns; if they were reg-views they would read both from the surrounding
-;; reg-view scope automatically (Spec 004 §reg-view auto-inject). Plain
-;; fns are the cleanest read for these internal helpers — no need for
-;; per-sub-piece registry slots or auto-defed Vars.
+;; The sub-views above (task-entry, task-list, todo-item, footer-controls) are
+;; plain Reagent helper fns that take `dispatch` / `subscribe` as explicit args —
+;; the clearest shape for internal helpers. `reg-view` is for the root: inside
+;; its body `dispatch` and `subscribe` are auto-injected into scope (Spec 004
+;; §reg-view auto-inject), which is why the root threads them down to the helpers.
 (reg-view root-view []
   (let [todos @(subscribe [:todo/todos])]
     [:<>

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -76,16 +76,15 @@
 
 (defonce react-root (atom nil))
 
-;; EP-0002: under the carried invariant the runtime never
-;; synthesises a frame from absence — an app must establish its frame
-;; explicitly. `init!` installs the adapter (it does NOT create the frame).
-;; The render root then uses the `frame-provider` ENSURE shape (`{:id ...}`):
-;; on first mount it creates the app frame, applies its config, and runs the
-;; `:initial-events` seed ONCE; on hot reload it reuses the existing frame
-;; without re-seeding. Everything — create, seed, and scope-into-React —
-;; happens in that one spot. The frame id is `:rf/default` — the same id
-;; `schema.cljs` scopes its `reg-app-schema` registration to. Matches the
-;; canonical mount in examples/reagent/counter/core.cljs.
+;; The frame lives in one spot: the `frame-provider` at the render root.
+;; `run` calls `init!` to install the adapter, then renders
+;; `[frame-provider {:id ...} ...]`. The provider's `{:id}` shape creates
+;; the app frame on first mount, applies its config, and runs the
+;; `:initial-events` seed once; on hot reload it reuses that frame and
+;; skips the seed. So create, seed, and scope-into-React all happen there.
+;; The frame id is `:rf/default` — the same id `schema.cljs` scopes its
+;; `reg-app-schema` to. Matches the canonical mount in
+;; examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -2,18 +2,16 @@
   "UIx variant of the counter example.
 
    Same dataflow as examples/reagent/counter, rendered through the UIx
-   adapter — React hooks all the way down rather than Reagent's reactive
-   atoms. The point of the example is the substrate boundary: everything
-   above the view layer is byte-for-byte the Reagent counter's, and the
-   only thing that moves is how a component reads state and gets hold of
-   `dispatch`. Demonstrates:
+   adapter — React hooks rather than Reagent's reactive atoms. The point
+   is the substrate boundary: everything above the view layer is the
+   Reagent counter's code verbatim, and the only thing that moves is how
+   a component reads state and gets hold of `dispatch`. Demonstrates:
 
      - `reg-event` / `reg-sub` (substrate-agnostic — identical to Reagent)
      - `rf/init!` with the UIx adapter
      - `use-subscribe` hook (the UIx-idiomatic subscription read)
      - `(:dispatch (rf/frame-handle))` for click handlers — a UIx
-       component reaches for dispatch / use-subscribe explicitly; there
-       is no auto-injection
+       component reads dispatch and subscriptions off explicit calls
      - frame resolution via React context — `use-subscribe` and the
        `frame-handle` capture read the surrounding frame-provider
 
@@ -29,10 +27,10 @@
 ;;
 ;; Each handler is a pure (coeffects, event-vector) -> effect map fn: it
 ;; returns `{:db …}` ("replace app-db with this") and the runtime commits
-;; it atomically at the end of the cascade. This whole block is
-;; byte-for-byte identical to the Reagent and Helix counters — same ids,
-;; same bodies. That sameness IS the cross-substrate parity: the artefact
-;; layer does not know which reactive substrate renders it.
+;; it atomically at the end of the cascade. This whole block is identical
+;; to the Reagent and Helix counters — same ids, same bodies. That
+;; sameness is the cross-substrate parity: events and subs are pure data
+;; and logic, independent of whichever substrate renders the views.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -49,13 +47,12 @@
 ;; -- Views (the only substrate-specific code in this file) -------------------
 ;;
 ;; Everything above is shared with the Reagent and Helix counters; the
-;; substrate boundary is here. `reg-view` (the macro that auto-injects
-;; `dispatch`/`subscribe`) stays Reagent-only — UIx is plain React, so a
-;; component is a `defui` and reaches for what it needs explicitly:
-;; `use-subscribe` reads a sub (a real hook), and `dispatch` comes off a
-;; `(rf/frame-handle)`. The handle is the frame captured as a *value*, so
-;; the closed-over `dispatch` keeps targeting this frame even when a click
-;; fires later — grab it at render time, while the frame is in scope.
+;; substrate boundary is here. UIx is plain React, so a view is a `defui`
+;; component that reads what it needs explicitly: `use-subscribe` is a
+;; hook that reads a subscription, and `dispatch` comes off a
+;; `(rf/frame-handle)`. The handle captures the in-scope frame as a value,
+;; so the closed-over `dispatch` still targets this frame when a click
+;; fires later. Grab it at render time, while the frame is in scope.
 
 (defui counter-buttons []
   (let [count    (uix-adapter/use-subscribe [:counter/value])
@@ -77,26 +74,24 @@
 
 (defonce react-root (atom nil))
 
-;; The runtime never synthesises a frame from absence — an app must establish
-;; its frame explicitly. `init!` installs the adapter (it does NOT create the
-;; frame), and the render is wrapped in `frame-provider` in its ENSURE shape:
-;; `{:id app-frame …}`. That one call creates the app frame on first mount,
-;; applies its config, and runs `:initial-events` ONCE to seed app-db — so the
-;; whole frame lifecycle lives in a single spot at the render root. On hot
-;; reload the provider REUSES the existing frame without re-seeding, so the
-;; counter keeps its current value across `:dev/after-load` re-mounts. That
-;; context is what lets the `use-subscribe` hook and the render-time
-;; `(rf/frame-handle)` capture resolve to the app frame. There is no
-;; `:rf/default` floor: a UIx tree rendered with NO provider observes the
-;; no-provider sentinel and any `use-subscribe` / `frame-handle` raises
-;; `:rf.error/no-frame-context`.
+;; The whole frame lifecycle lives in one spot at the render root: the
+;; `frame-provider {:id app-frame …}` below. On first mount it creates the
+;; app frame, applies its config, and runs `:initial-events` once to seed
+;; app-db. That context is what lets the `use-subscribe` hook and the
+;; render-time `(rf/frame-handle)` capture resolve to the app frame. On hot
+;; reload the provider reuses the existing frame and skips re-seeding, so
+;; the counter keeps its value across re-mounts. (Render a UIx tree with no
+;; provider and `use-subscribe` / `frame-handle` raise
+;; `:rf.error/no-frame-context` — the app must establish its frame.)
 ;;
-;; `:rf/default` is an ORDINARY frame id with no framework privilege — a
-;; migration may reach for it out of habit, but the runtime won't infer it.
+;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
+;; with no framework privilege — the runtime won't infer it, so we name it
+;; here and hand it to the provider like any other id.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; `init!` installs the UIx reactive adapter for the process. Each adapter
+  ;; ns exports an `adapter` var; require the ns and pass that var directly.
   (rf/init! uix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -78,10 +78,10 @@
 ;; EVENTS
 ;; ============================================================================
 
-;; Each handler is pure: (coeffects, event-vector) -> effect map. They move
-;; ONE value in app-db and stop — note that none of them touch a card, a
-;; sparkline, or the grid. Turning "this tag is now off" into "these cards
-;; disappear" is the subscription's job, downstream.
+;; Each handler is pure: (coeffects, event-vector) -> effect map. Each moves
+;; ONE value in app-db and stops. The cards, sparklines, and grid all follow
+;; downstream from the subscription — turning "this tag is now off" into
+;; "these cards disappear" is the subscription's job, not the handler's.
 
 ;; Seed the whole dashboard in one write: the metrics plus the two control
 ;; values (`:active-tags` a set — chips are multi-select; `:range` one id).
@@ -346,24 +346,22 @@
 ;; This matches the sibling notebook / process_monitor_helix mount shape.
 (defonce react-root (atom nil))
 
-;; The runtime never synthesises a frame from absence — an app must establish
-;; its frame explicitly. `init!` installs the adapter (it does NOT create the
-;; frame). The render root then uses the UIx `frame-provider` in its ENSURE
-;; shape — `{:id app-frame …}` — which creates the app frame on first mount,
-;; applies its config, and runs `:initial-events` exactly ONCE to seed app-db;
-;; on hot reload it REUSES the existing frame WITHOUT re-seeding. The provider
-;; scopes that frame into React context so the `use-subscribe` hook and the
-;; render-time `(rf/frame-handle)` capture resolve to it. There is no
-;; `:rf/default` floor: a UIx tree rendered with NO provider observes the
-;; no-provider sentinel and any `use-subscribe` / `frame-handle` raises
-;; `:rf.error/no-frame-context`.
+;; The frame id this app runs under. The `frame-provider` at the render root
+;; (in `run` below) does the frame work: it creates this frame, seeds app-db,
+;; and scopes the frame into React context for `use-subscribe` and
+;; `(rf/frame-handle)`.
 (def app-frame :rf/default)
 
 (defn run []
+  ;; `init!` installs the UIx adapter so re-frame2 knows how to render.
   (rf/init! uix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
+    ;; The `frame-provider` is the one spot the frame is set up. `{:id …}`
+    ;; creates the app frame on first mount and runs `:initial-events` once
+    ;; to seed app-db; a hot reload reuses the same frame without re-seeding.
+    ;; Everything under it reads from this frame.
     (uix-dom/render-root
       ($ uix-adapter/frame-provider {:id app-frame
                                      :initial-events [[:dashboard/initialise]]}

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -16,8 +16,8 @@
    substrate's hook idiom differs. The terminal `:locked-out` state is
    surfaced as a non-interactive locked-account panel.
 
-   `reg-view` stays Reagent-only; UIx components are plain `defui`.
-   There is no auto-injection."
+   UIx views are plain `defui` components: each one reads its subscriptions
+   with the `use-subscribe` hook and pulls `dispatch` off `(rf/frame-handle)`."
   (:require [uix.core :as uix :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core :as rf]
@@ -34,14 +34,11 @@
 ;; SCHEMAS
 ;; ============================================================================
 
-;; The EP-0025 commit-plane `:sensitive` / `:large` classification effects (a
-;; `reg-event` returns them alongside `:db`) are the durable app-db
-;; classification mechanism. The password never lands in app-db (it rides the
-;; machine EVENT-arg schema and the HTTP body), so there is no app-db path to
-;; classify. The managed-HTTP request below
-;; carries `:sensitive? true` to scrub the password off the wire — a
-;; different axis (Spec 014 §Privacy) and the working, observable
-;; redaction. Parity across reagent/login + helix.
+;; Shape of valid login credentials: an email and a min-8 password. The
+;; password only ever rides this event-arg schema and the HTTP body — it is
+;; never written to app-db. The request body that carries it is scrubbed from
+;; traces by `:sensitive? true` on the managed-HTTP request below (Spec 014
+;; §Privacy). Same schema across reagent/login + helix.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
@@ -98,11 +95,10 @@
    [:attempts {:default 0} :int]
    [:error    [:maybe :string]]])
 
-;; Machine snapshots are runtime-db state, not app-db — a `reg-app-schema` on a
-;; machine-snapshot path validates nothing (app schemas validate the app-db
-;; partition only). The machine's own `[:schemas :data]` (attached to the spec map
-;; below) is the live validation surface for `:data`, so no app-schema reg is
-;; needed.
+;; The machine's `:data` is validated by its own `[:schemas :data]` (attached to
+;; the spec map below). Machine snapshots live in runtime-db, not app-db, so a
+;; `reg-app-schema` would not see them — app schemas validate the app-db
+;; partition only.
 
 ;; ============================================================================
 ;; FX
@@ -259,23 +255,12 @@
     {:tags #{:auth/locked}
      :meta {:terminal? true}}}})
 
-;; A machine that ALSO validates its outer event vector. The canonical
-;; surface for registering a machine is `reg-machine` / `reg-machine*`
-;; (Spec 005 §reg-machine — the form tools, examples, and scaffolds default
-;; to). This login flow needs BOTH a live machine `[:schemas :data]` AND an
-;; event-vector `:schema` (`AuthLoginEvent`, the `:where :event` boundary on
-;; the dispatched vector) — the machine + event-vector-schema shape — so it
-;; uses `reg-machine`'s event-`:schema` arity: the optional opts map carries
-;; the event `:schema` alongside the machine spec.
-;;
-;; `reg-machine` is the single registration home: it stamps the `:rf/machine?`
-;; / `:rf/machine` metadata that `(machine-meta :auth.login/flow)` reads (so
-;; the `:where :machine-data` walker resolves the `[:schemas :data]` and it
-;; VALIDATES). EP-0025: durable machine `:data` snapshot-egress classification
-;; is a projection-relative `:sensitive` / `:large` declaration on the machine
-;; spec — NOT a `[:schemas :data]` prop (which now drives only
-;; validation-failure-trace redaction); this machine's `:data` holds no secret,
-;; so it declares none.
+;; Register the machine (Spec 005 §reg-machine). This flow validates on two
+;; surfaces: the machine's `:data` slot via `[:schemas :data]`, and the
+;; dispatched event vector via `:schema` (`AuthLoginEvent`, the `:where :event`
+;; boundary). The opts map carries the event `:schema` alongside the machine
+;; spec, and `reg-machine` stamps the `:rf/machine` metadata that makes the
+;; `[:schemas :data]` validation live.
 (rf/reg-machine :auth.login/flow
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema AuthLoginEvent}
@@ -288,10 +273,9 @@
 ;; The FORM-SLICE events below are the other half of the Pattern-Forms
 ;; "machine + slice" composition (spec/Pattern-Forms.md §Variations). The
 ;; SLICE owns the DRAFT — what the user is currently typing — at the app-db
-;; path [:auth :login-form]; the MACHINE owns submit/auth STATUS. This is the
-;; reason the form refactor exists: a form's draft is APPLICATION STATE, so it
-;; lives in app-db (projected via subs, mutated via events), NOT in a
-;; view-local Reagent atom / framework hook. Inputs are CONTROLLED: `:value`
+;; path [:auth :login-form]; the MACHINE owns submit/auth STATUS. A form's draft
+;; is application state, so it lives in app-db (projected via subs, mutated via
+;; events), not in a view-local atom or hook. Inputs are CONTROLLED: `:value`
 ;; reads the draft sub, `:on-change` dispatches `:auth.login/edit-field`. The
 ;; slice shape + the standard form events mirror the in-repo exemplar
 ;; examples/reagent/realworld/auth.cljs 1:1.
@@ -307,8 +291,8 @@
 ;; machine's `:submit` boundary enforces.
 (def login-form-defaults {:email "" :password ""})
 
-;; Seed the slice to its standard Pattern-Forms shape. Dispatched once at
-;; boot (from `run`). `:draft` to the empty defaults; `:status :idle`.
+;; Seed the slice to its standard Pattern-Forms shape: empty `:draft`,
+;; `:status :idle`. Runs once via the frame-provider's `:initial-events`.
 (rf/reg-event :auth.login/initialise-form
   {:doc "Seed the login-form slice at [:auth :login-form] to its standard
          Pattern-Forms shape (empty draft, :idle status)."}
@@ -430,17 +414,16 @@
 ;; VIEWS  (UIx — defui + use-subscribe)
 ;; ============================================================================
 ;;
-;; This is the whole substrate seam. The Reagent twin registers these with
-;; `reg-view` and gets injected `dispatch`/`subscribe`; UIx has no such
-;; registry, so a view is a plain `defui`, reads a subscription through the
-;; `use-subscribe` hook, and takes `dispatch` off a `(rf/frame-handle)` by
-;; hand. The subscription vectors and event vectors are unchanged — only the
-;; way a React component plugs into them differs.
+;; This is the whole substrate seam. A UIx view is a plain `defui`: it reads
+;; each subscription through the `use-subscribe` hook and gets `dispatch` off
+;; `(rf/frame-handle)`. The Reagent twin instead registers these with `reg-view`
+;; and is handed `dispatch`/`subscribe`. The subscription vectors and event
+;; vectors are identical — only the way a React component plugs into them differs.
 ;;
-;; The form holds NO view-local state: there is no `uix/use-state` for the
-;; email/password. Each input's `:value` reads the draft from the
-;; `:auth.login/draft` sub, and `:on-change` DISPATCHES `:auth.login/edit-field`
-;; (it never sets view-local state) — controlled inputs, the Pattern-Forms way.
+;; The inputs are controlled: each `:value` reads the draft from the
+;; `:auth.login/draft` sub, and `:on-change` dispatches `:auth.login/edit-field`.
+;; The draft lives in app-db, so there is no `uix/use-state` here — the
+;; Pattern-Forms way.
 (defui login-form []
   (let [draft    (uix-adapter/use-subscribe [:auth.login/draft])
         busy?    (uix-adapter/use-subscribe [:rf/machine-has-tag?
@@ -505,29 +488,24 @@
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; Pass the adapter spec map directly — no registry.
+  ;; Install the UIx adapter.
   (rf/init! uix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
-    ;; ONE-SPOT frame setup — the ENSURE `frame-provider` (`{:id …}`): on the
-    ;; first mount it CREATES the `:rf/default` frame, applies the config
-    ;; (`:fx-overrides` redirects `:rf.http/managed` to the demo stub), and runs
-    ;; `:initial-events` ONCE; on hot reload it REUSES the existing frame
-    ;; WITHOUT re-running them. There is no separate `reg-frame` / seed step.
+    ;; One-spot frame setup. The `frame-provider` at the render root owns the
+    ;; frame: on the first mount it creates the `:rf/default` frame, applies the
+    ;; config (`:fx-overrides` redirects `:rf.http/managed` to the demo stub),
+    ;; and runs `:initial-events` once. On hot reload it reuses the existing
+    ;; frame and skips the events. The `:id :rf/default` names the frame that the
+    ;; `use-subscribe` hook and the `(rf/frame-handle)` in `login-form` resolve
+    ;; to — those reads need a provider above them in the tree.
     ;;
-    ;; The MACHINE handler is self-initialising — its `:initial`/`:data` seed
-    ;; [:rf.runtime/machines :snapshots :auth.login/flow] when the flow first
-    ;; runs (per Spec 005 §Restore semantics), so it needs no seeding. The form
-    ;; SLICE is app-db, so it IS seeded via `:initial-events`
-    ;; ([:auth.login/initialise-form]) to its empty Pattern-Forms shape —
-    ;; otherwise the controlled inputs would read a nil draft on the first
-    ;; render (uncontrolled inputs).
-    ;;
-    ;; Providing `:id :rf/default` also makes the `use-subscribe` hook + the
-    ;; render-time `(rf/frame-handle)` capture in `login-form` resolve to
-    ;; `:rf/default`. With NO provider the tree observes the no-provider
-    ;; sentinel and those reads raise `:rf.error/no-frame-context`.
+    ;; `:initial-events` seeds the form SLICE ([:auth.login/initialise-form]) to
+    ;; its empty Pattern-Forms shape, so the controlled inputs read an empty
+    ;; draft (not nil) on the first render. The MACHINE needs no seeding: its
+    ;; `:initial`/`:data` seed [:rf.runtime/machines :snapshots :auth.login/flow]
+    ;; the first time the flow runs (Spec 005 §Restore semantics).
     (uix-dom/render-root
       ($ uix-adapter/frame-provider {:id              :rf/default
                                      :doc             "Login (UIx) demo frame."


### PR DESCRIPTION
Cleans up the code comments left odd by the frame-provider `{:id}` migration — the thing you spotted in todomvc. Three fixes, one agent per example:

1. **Positive, not negative.** Comments now say what the code *does*, not what it isn't doing. (counter dropped *"init! does NOT create the frame"*; a 24-line road-not-taken block on routing's one-line `def` is gone.)
2. **Match the code.** `boot!` no longer narrates the frame — the frame is created + seeded by the render-root `frame-provider` now, so the frame story moved there and `boot!` describes what it actually does (install the adapter, maybe a listener). E.g. todomvc's docstring is now *"init! installs the Reagent adapter; the render root's frame-provider {:id …} creates the app frame on first mount, marks it :url-bound?, seeds it once."*
3. **Simple + easy.** Short, plain, one-idea sentences.

**33 examples** touched. The SSR family and Story hosts kept their *accurate* frame comments (those genuinely still set up the frame) — only the framing was tidied.

Comments + docstrings only; no code, behaviour, build id, or run-command change. Verified: `npm run test:examples-compile` passes (all builds, exit 0).