### PR TITLE
docs(examples): correct test-surface description + document boot!/mount!/frame-provider shape

### DIFF
--- a/examples/TESTING.md
+++ b/examples/TESTING.md
@@ -15,7 +15,8 @@ see [`../TESTING.md`](../TESTING.md).
 | Command | What it checks | Lives in |
 |---|---|---|
 | `npm run test:examples-compile` | Compiles every declared `:examples/*` shadow-cljs build and fails on any error **or warning**. The build list is derived from `shadow-cljs.edn`, so a newly declared example is swept automatically. | [`implementation/scripts/check-examples-compile.cjs`](../implementation/scripts/check-examples-compile.cjs) |
-| `npm run test:browser` | The shadow-cljs `:browser-test` bundle — every `*-cljs-test` wrapper namespace, including the example wrappers, in one Chromium page. Each wrapper drives its example's headless fixtures. | [`implementation/scripts/serve-and-run-browser-tests.cjs`](../implementation/scripts/serve-and-run-browser-tests.cjs) |
+| `npm run test:cljs` | The shadow-cljs `:node-test` bundle, run on Node. `:ns-regexp` is `cljs-test$`, so it picks up every `*-cljs-test` wrapper — including the **example wrappers**, which require their example's `core` ns and drive its events, subs and fixtures headlessly (no DOM). This is where the example wrappers actually run. | [`implementation/package.json` `test:cljs`](../implementation/package.json) |
+| `npm run test:browser` | The shadow-cljs `:browser-test` bundle in one Chromium page. `:ns-regexp` is narrowed to `-dom-cljs-test$`, so it runs **only** the DOM-dependent wrappers (those that mount real React via `react-dom/client`). The example wrappers do **not** mount the DOM, so they keep the plain `-cljs-test` suffix and run under `test:cljs`, not here. | [`implementation/scripts/serve-and-run-browser-tests.cjs`](../implementation/scripts/serve-and-run-browser-tests.cjs) |
 | `npm run test:script-policy` | Static scanners over the example tree: `check-examples-assets.cjs` (shared stylesheet asset presence + WCAG palette-contrast / focus-ring contracts on each `index.html`) and `check-reagent-slim-boundary.cjs` (the stock Reagent tree never requires `reagent2.*` / the slim adapter). | [`examples/scripts/`](scripts/) |
 
 `test:examples-compile` and the `test:script-policy` scanners add nothing under
@@ -41,14 +42,15 @@ and look when you touch that example's markup, CSS, or dataflow. The
 [`dashboard_uix` accessibility + responsive notes](uix/dashboard_uix/README.md#accessibility--responsive--what-to-copy)
 spell out the shape to look for.
 
-## Convention: defer DOM mount to `run`
+## Convention: example mount-isolation — defer DOM mount to `mount!`
 
-`test:browser` loads every example wrapper into **one** bundle, **one** page,
-sharing **one** `#app` mount point. So an example must not touch the DOM just by
-being loaded:
+The example wrappers all compile into **one** `:node-test` bundle and share **one**
+re-frame registry; the DOM-dependent tests compile into **one** `:browser-test`
+bundle, **one** Chromium page, sharing **one** `#app` mount point. So an example
+must not touch the DOM just by being loaded:
 
 > Do no DOM mount side effects at namespace-load time. Defer `create-root` (or
-> your substrate's equivalent) to the example's `run` fn.
+> your substrate's equivalent) to the example's `mount!` fn.
 
 `run` is the bundle entry point, wired as the `:init-fn` of the example's
 shadow-cljs build in
@@ -56,31 +58,70 @@ shadow-cljs build in
 `:examples/counter` → `:init-fn counter.core/run`). shadow-cljs resolves the symbol
 inside the compiled bundle, so it needs no `^:export`.
 
+A mount at ns-load instead would have a co-required example race `create-root` on
+the same shared `#app`, leaking one example's mount into another's tests. This is
+enforced by code review.
+
+### Boot shape: `boot!`, `mount!`, `frame-provider`
+
+A TodoMVC-style example splits its boot into two fns, called in order by `run`:
+
+- **`boot!`** runs once, before the first render: install the adapter
+  (`rf/init!`) and any host listeners. Listener installs are made idempotent
+  (remove-then-add the same Var) so a repeated `run` or a reload never stacks
+  duplicates.
+- **`mount!`** creates the React root **lazily** on first call (not at ns-load)
+  and renders. The render root is a `frame-provider {:id … :initial-events …}`:
+  on first mount it creates the app frame, applies its config, and runs
+  `:initial-events` once to seed app-db; on a later mount it reuses the frame
+  and skips re-seeding, so state survives.
+
+The React root lives in a `defonce` atom and `mount!` carries `^:dev/after-load`
+— that pair **is the hot-reload requirement**. `defonce` keeps the one root across
+reloads (React rejects a second `create-root` on a live node), and
+`^:dev/after-load` makes shadow re-run `mount!` after each reload so the edited
+views re-render against the surviving root and frame.
+
 The shape every example uses (Reagent shown; UIx and Helix do the same):
 
 ```clojure
-;; ns-load: no DOM side effects. The atom holds the React root once `run` makes it.
+;; ns-load: no DOM side effects. The atom holds the React root once mount! makes it.
 (defonce react-root (atom nil))
 
-;; Bundle entry point — wired as this example's :init-fn in shadow-cljs.edn.
-(defn run []
-  (rf/init! adapter)
-  ;; ... per-example app boot ...
+(def app-frame :rf/default)            ; an id we pick; no framework privilege
+
+;; ^:dev/after-load: shadow re-runs this on every reload. defonce root + lazy
+;; create-root means the root is made once and reused across reloads.
+(defn ^:dev/after-load mount! []
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [root-view])))
+    (rdc/render @react-root
+                ;; frame-provider creates + seeds the frame on first mount,
+                ;; reuses it (no re-seed) on reload.
+                [rf/frame-provider {:id             app-frame
+                                    :initial-events [[:counter/initialise]]}
+                 [counter-app]])))
+
+(defn- boot! []                        ; install adapter + listeners, once
+  (rf/init! reagent-adapter/adapter))
+
+(defn run []                           ; shadow :init-fn — runs once, at page load
+  (boot!)
+  (mount!))
 ```
 
-A mount at ns-load instead would have every example race `create-root` on the same
-shared `#app`, leaking one example's mount into another's tests. This is enforced
-by code review.
+[`examples/reagent/todomvc/core.cljs`](reagent/todomvc/core.cljs) is the fullest
+worked version (it adds an idempotent `hashchange` listener in `boot!` and a
+`:url-bound? true` frame in `mount!`);
+[`examples/reagent/counter/core.cljs`](reagent/counter/core.cljs) is the minimal one.
 
 ## Convention: prefix every registered id
 
-The single `test:browser` bundle also shares the re-frame registries (handlers,
-subs, machines, schemas, …). Two examples that both register `:login` would fight
-over the same slot. So each example **prefixes every id with its own stem**:
+The `:node-test` bundle co-loads every example wrapper, so it shares the re-frame
+registries (handlers, subs, machines, schemas, …) across all of them. Two examples
+that both register `:login` would fight over the same slot. So each example
+**prefixes every id with its own stem**:
 
 - `realworld.core` registers `:auth/login`, `:articles/load`, `:comments/submit`, …
 - `nine-states.core` registers `:nine-states.app/initialise`, `:new-todo/submit`, …
@@ -118,16 +159,24 @@ image, the shared ids must be disambiguated first (distinct `:images` per frame,
 or prefixed stems); a naive co-load fails loud at frame creation rather than
 clobbering silently.
 
-## Adding a browser-test example
+## Adding a tested example
 
-1. **Mount in `run`, not at ns-load** — per the convention above.
+1. **Mount in `mount!`, not at ns-load** — per the convention above.
 2. **Prefix every registered id** with the example's folder stem.
 3. **A wrapper test ns** at
    `implementation/adapters/<substrate>/test/re_frame/<example>_cljs_test.cljs`
-   (the `-cljs-test` suffix is how the `:browser-test` build picks it up). It
-   `:require`s the example's production `core` ns — so its handlers, subs, views,
-   and machines register at ns-load — and drives them with fixtures and canned
-   stubs defined in the wrapper itself. The example source stays test-free.
+   (the `-cljs-test` suffix is how the `:node-test` build picks it up, via its
+   `cljs-test$` regex). It `:require`s the example's production `core` ns — so its
+   handlers, subs, views, and machines register at ns-load — and drives them with
+   fixtures and canned stubs defined in the wrapper itself. It runs headlessly on
+   Node under `test:cljs`, so it must not mount the DOM. The example source stays
+   test-free.
+
+If a wrapper genuinely needs a live React root (a real `react-dom/client` mount),
+give it the `-dom-cljs-test` suffix instead — `:browser-test`'s `-dom-cljs-test$`
+regex then runs it under `test:browser` in Chromium, and `:node-test`'s broader
+`cljs-test$` still matches it too. The example wrappers don't need this; they assert
+against app-db and subs directly.
 
 A standalone `:examples/*` build needs no test wiring at all to get compile
 coverage — declaring it in `shadow-cljs.edn` is enough for `test:examples-compile`


### PR DESCRIPTION
Corrected the test-surface description to the real `-dom-cljs-test$` browser-test narrowing + node-test split, added the hot-reload requirement, documented the `boot!`/`mount!`/`frame-provider {:id …}` boot shape with a cited example; conventions preserved; exception anchors untouched.

## What changed (single file: `examples/TESTING.md`)

- **Test-surface accuracy.** The prior file said `test:browser` loads *every* `*-cljs-test` wrapper into one Chromium page. Ground truth: `:browser-test` is narrowed to `:ns-regexp "-dom-cljs-test$"` (mounts real React via `react-dom/client`), while the example wrappers are plain `*_cljs_test.cljs` and run under `:node-test` (`cljs-test$`) on Node — headlessly, no DOM. The coverage table now has separate `test:cljs` (where the example wrappers actually run) and `test:browser` rows; the id-prefix and mount-isolation reasons are framed against the bundle/page that actually shares the registry/`#app`.
- **Boot shape.** Replaced the stale `run` + `create-root`-only snippet with the current shape: `boot!` (install adapter + listeners, idempotent), `mount!` (lazy `defonce` root + `frame-provider {:id … :initial-events …}` render), `run` = `(boot!) (mount!)`. Cited to `examples/reagent/todomvc/core.cljs` (fullest) and `examples/reagent/counter/core.cljs` (minimal).
- **Hot-reload requirement** now explained: a `defonce` React root + `^:dev/after-load mount!` — reuse the one root across reloads (React rejects a second `create-root` on a live node), re-render edited views.
- Conventions preserved (no ns-load mount; id-prefix discipline). The two parity-exception H4 headings and their inbound anchors (`exception-1--…`, `exception-2--…`) and the `../implementation/adapters/TESTING.md#adding-a-new-adapter-smoke` outbound link are untouched.

## Gates (all green)

- `check_readme_links.py --self-test` + `--ci` — pass (exception anchors + inbound links resolve)
- `check_doc_slugs.py --self-test` + live scan — exit 0, no broken links
- `mkdocs build --strict` — exit 0
- Every code claim (`:browser-test` `-dom-cljs-test$` regex, `:node-test` `cljs-test$` regex, `boot!`/`mount!`/`frame-provider`/`defonce`/`^:dev/after-load`) verified against `implementation/shadow-cljs.edn`, `implementation/package.json`, and the cited example sources.
