### PR TITLE
Examples: simplify comments — drop historical cruft, point to the guide over the spec

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -1,24 +1,20 @@
 (ns counter-helix.core
-  "Helix variant of the counter example.
+  "Counter, rendered with the Helix substrate.
 
-   The one idea: the dataflow doesn't know which React-family library
-   draws the pixels. Exercises the SAME events and sub as
-   examples/reagent/counter and examples/uix/counter_uix — only the view
-   and mount change — but renders through the Helix adapter, where the
-   React state model is hooks all the way down. Demonstrates:
+   The dataflow doesn't know which React-family library draws the pixels.
+   This counter runs the same events and subscription as the Reagent and
+   UIx counters; only the view and mount change. Here they render through
+   the Helix adapter, whose React state model is hooks all the way down.
+   It shows:
 
      - `rf/init!` with the Helix adapter
-     - `reg-event` / `reg-sub` (substrate-agnostic)
-     - `use-subscribe` hook (Helix idiomatic)
-     - `(:dispatch (rf/frame-handle))` for click handlers — the
-       component reads its own sub and takes its own dispatch
-     - The shared frame-context — the same React Context
-       object the Reagent and UIx adapters consume
+     - `reg-event` / `reg-sub`, which are substrate-agnostic
+     - the `use-subscribe` hook, the Helix-idiomatic way to read a sub
+     - `(:dispatch (rf/frame-handle))` in click handlers — the component
+       reads its own sub and takes its own dispatch
 
-   Different folder from examples/reagent/counter and
-   examples/uix/counter_uix so all three canonical counters are
-   undisturbed; bundle isolation is verified by the per-example
-   shadow-cljs builds and the production-elision grep."
+   See docs/guide/how-to/use-uix-helix-or-slim.md for the full walkthrough
+   of running one app on UIx or Helix."
   (:require ["react-dom/client" :as react-dom-client]
             [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]
@@ -26,25 +22,21 @@
             [re-frame.adapter.helix :as helix-adapter]))
 
 ;; ============================================================================
-;; SUBSTRATE-AGNOSTIC ARTEFACT LAYER  (events + sub)
+;; SUBSTRATE-AGNOSTIC LAYER  (events + sub)
 ;; ============================================================================
 ;;
-;; Everything above the SUBSTRATE BOUNDARY divider below is the artefact
-;; layer: events and the `:counter/value` sub. It is written exactly once
-;; per *meaning* and is byte-for-byte IDENTICAL across the Reagent, UIx, and
-;; Helix counters — same `:counter/*` ids, same handler bodies. That sameness
-;; is deliberate and load-bearing: the id-identity *is* the cross-substrate
-;; parity demonstration (examples/TESTING.md §Exception 2). The artefact layer
-;; does not know — and must not know — which reactive substrate renders it.
+;; Everything above the SUBSTRATE BOUNDARY below is the dataflow: the events
+;; and the `:counter/value` subscription. It is identical across the Reagent,
+;; UIx, and Helix counters — same `:counter/*` ids, same handler bodies. The
+;; dataflow does not know which substrate renders it; that sameness is the
+;; whole point of the example.
 ;;
-;; It is NOT extracted into a shared namespace on purpose. Each substrate
-;; example is a self-contained `:browser` build, and `npm run
-;; test:bundle-isolation` greps each released bundle to prove a Helix
-;; `main.js` carries no Reagent/UIx code (and vice versa). A shared model
-;; namespace required into all three builds would defeat that isolation and
-;; the parity claim it underwrites. The boundary you should learn from this
-;; example is the SUBSTRATE BOUNDARY below — same dataflow, three view layers
-;; — not a file-extraction boundary.
+;; The three counters do not share this code through a common namespace, on
+;; purpose. Each substrate example is a self-contained `:browser` build, and
+;; a bundle-isolation test proves a Helix bundle carries no Reagent or UIx
+;; code (and vice versa). A shared namespace pulled into all three builds
+;; would break that. The boundary worth learning here is the SUBSTRATE
+;; BOUNDARY below — one dataflow, three view layers.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -62,19 +54,19 @@
 ;; ──────────────────────────  SUBSTRATE BOUNDARY  ──────────────────────────
 ;; ============================================================================
 ;;
-;; Below this line is the only substrate-specific code in this example: the
-;; Helix views + the mount. The Reagent and UIx counters share every line
-;; ABOVE this divider and differ only in what sits BELOW it (Reagent
-;; `reg-view`, UIx `defui` + `use-subscribe`, Helix `defnc` + `use-subscribe`).
+;; Below this line is the only substrate-specific code in the example: the
+;; Helix views and the mount. The Reagent and UIx counters share every line
+;; above this divider and differ only below it (Reagent `reg-view`, UIx
+;; `defui` + `use-subscribe`, Helix `defnc` + `use-subscribe`).
 ;;
-;; Helix users write `defnc` directly (the `reg-view` macro stays
-;; Reagent-only). The component reads its sub with `use-subscribe`
-;; and takes `dispatch` off a `(rf/frame-handle)` itself. The handle
-;; captures the render-time frame, so the closed-over `dispatch`
-;; targets the right frame even from an async callback.
+;; Helix users write `defnc` directly; the `reg-view` macro is Reagent-only.
+;; The component reads its sub with `use-subscribe` and takes `dispatch` off
+;; `(rf/frame-handle)` itself. The handle captures the frame in scope at
+;; render time, so the closed-over `dispatch` still targets the right frame
+;; from a click handler that fires later.
 
 (defnc counter-buttons []
-  (let [count    (helix-adapter/use-subscribe [:counter/value])  ;; read: re-renders when :counter/value moves
+  (let [count    (helix-adapter/use-subscribe [:counter/value])  ;; read: re-renders when :counter/value changes
         dispatch (:dispatch (rf/frame-handle))]                  ;; write: take dispatch off the render-time handle
     (d/div
        (d/button {:on-click #(dispatch [:counter/dec])} "-")
@@ -86,21 +78,21 @@
 
 ;; -- Mount -------------------------------------------------------------------
 ;;
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `createRoot` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. Loading the namespace must produce no DOM side effects, so that
+;; co-required example namespaces don't race each other to `createRoot` onto
+;; the shared `#app` element.
 
 (defonce react-root (atom nil))
 
 ;; The frame id this app runs in. `:rf/default` is an ordinary id with no
-;; framework privilege; we just pick it. The provider below builds the frame
-;; under this id and the `use-subscribe` hook + render-time `(rf/frame-handle)`
-;; resolve to it.
+;; framework privilege; we just pick it. The provider below creates the frame
+;; under this id, and the `use-subscribe` hook and render-time
+;; `(rf/frame-handle)` both resolve to it.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Install the Helix adapter. Pass the adapter spec map directly — no registry.
+  ;; Install the Helix adapter. Pass the adapter value directly to init!.
   (rf/init! helix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
@@ -108,7 +100,7 @@
     ;; The frame lives in one spot: the provider. Given `:id`, it creates the
     ;; frame on first mount and runs `:initial-events` once to seed it. On hot
     ;; reload it reuses the existing frame and skips seeding, so the count you
-    ;; were looking at survives.
+    ;; were looking at survives. See docs/guide/concepts/frames.md.
     (.render @react-root
              ($ helix-adapter/frame-provider {:id app-frame
                                               :initial-events [[:counter/initialise]]}

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -2,21 +2,19 @@
   "Helix variant of the login example.
 
    Same dataflow, schemas, machine, and HTTP stub as
-   examples/reagent/login and examples/uix/login_uix, but views are
-   written as Helix `defnc` components and consume subs via the
-   `use-subscribe` hook. Demonstrates that the Spec 005 state machine,
-   Spec 010 schemas, and Spec 014 managed-HTTP surfaces are
-   substrate-agnostic — only the view layer differs across substrates.
+   examples/reagent/login and examples/uix/login_uix; only the views
+   differ. They are Helix `defnc` components that read subs via the
+   adapter's `use-subscribe` hook. The state machine, schemas, and
+   managed-HTTP surfaces are substrate-agnostic — the view layer is the
+   only thing that changes between substrates.
 
-   Cross-substrate parity is exercised end-to-end: machine states carry
-   Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`, `:auth/locked`)
-   and views read them via the `:rf/machine-has-tag?` framework sub —
-   same tag taxonomy as the state-machines walkthrough, only the
-   substrate's hook idiom differs. The terminal `:locked-out` state is
-   surfaced as a non-interactive locked-account panel.
+   The machine's states carry state tags (`:auth/busy`,
+   `:auth/authenticated`, `:auth/locked`); views read them via the
+   `:rf/machine-has-tag?` framework sub. The terminal `:locked-out`
+   state shows a non-interactive locked-account panel.
 
-   Views are plain Helix `defnc` components that read subs via
-   `use-subscribe` and take `dispatch` off the frame-handle."
+   See the machines guide (docs/machines/concepts.md) and the form
+   recipe (docs/guide/how-to/build-a-form.md)."
   (:require ["react-dom/client" :as react-dom-client]
             [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]
@@ -25,8 +23,8 @@
             [re-frame.schemas]
             [re-frame.machines]
             [re-frame.http.managed]
-            ;; :fx-overrides redirect :rf.http/managed to :rf.http/managed-canned-*;
-            ;; the canned-stub fx ids register from re-frame.http.test-support.
+            ;; Registers the canned-success / canned-failure HTTP fx ids the
+            ;; demo stub below delegates to.
             [re-frame.http.test-support]
             [re-frame.adapter.helix :as helix-adapter]))
 
@@ -35,65 +33,56 @@
 ;; ============================================================================
 ;;
 ;; Everything from here down to the SUBSTRATE BOUNDARY divider — schemas, the
-;; managed-HTTP stub fx, the `:auth.login/flow` state machine, and the named
-;; subs — is the artefact layer. It is in semantic + id parity across the
-;; Reagent, UIx, and Helix login examples: the same `:auth.login/*` ids, the
-;; same machine spec (a named `auth-login-machine` def passed to `reg-machine`
-;; in all three), the same schemas, and the same `:auth.login.demo/managed-stub`
-;; — the registered shapes are identical; only the per-file explanatory
-;; comments differ. That sameness is deliberate and load-bearing — the
-;; id-identity *is* the cross-substrate parity demonstration
-;; (examples/TESTING.md §Exception 2). It is NOT
-;; extracted into a shared namespace on purpose: each substrate example is a
-;; self-contained `:browser` build, and `npm run test:bundle-isolation` proves
-;; a Helix bundle carries no Reagent/UIx code (and vice versa). A shared model
-;; required into all three builds would defeat that isolation and the parity
-;; claim it underwrites. The boundary to learn here is the SUBSTRATE BOUNDARY
-;; below — one dataflow, three view layers — not a file-extraction boundary.
+;; managed-HTTP stub fx, the `:auth.login/flow` machine, and the named subs —
+;; is identical across the Reagent, UIx, and Helix login examples: same ids,
+;; same machine spec, same schemas, same HTTP stub. That sameness is the
+;; cross-substrate parity demonstration. Only the views below the SUBSTRATE
+;; BOUNDARY differ.
+;;
+;; It is deliberately NOT extracted into a shared namespace. Each substrate
+;; example is a self-contained `:browser` build, and the bundle-isolation gate
+;; proves a Helix bundle carries no Reagent/UIx code. A shared model required
+;; into all three builds would defeat that isolation. The boundary to learn
+;; here is one dataflow with three view layers — not a file-extraction
+;; boundary.
 
 ;; ============================================================================
 ;; SCHEMAS
 ;; ============================================================================
 
-;; The EP-0025 commit-plane `:sensitive` / `:large` classification effects (a
-;; `reg-event` returns them alongside `:db`) are the durable app-db
-;; classification mechanism. The password never lands in app-db (it rides the
-;; machine EVENT-arg schema and the HTTP body), so there is no app-db path to
-;; classify. The managed-HTTP request below
-;; carries `:sensitive? true` to scrub the password off the wire — a
-;; different axis (Spec 014 §Privacy) and the working, observable
-;; redaction. Parity across reagent/login + uix.
+;; The credentials a login submit carries: an email and a password.
+;;
+;; The password never lands in app-db — it rides the machine's event-arg
+;; schema and the HTTP body only — so there is no app-db path to classify
+;; `:sensitive`. The wire scrub happens instead on the HTTP request below,
+;; via its `:sensitive? true` flag. See
+;; docs/guide/how-to/keep-secrets-out-of-traces.md.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
    [:password [:string {:min 8}]]])
 
-;; Outer event-vector schema for the :auth.login/flow machine handler —
-;; see examples/reagent/login for the full rationale. The :submit
-;; sub-event is validated STRICTLY against `Credentials`; framework-internal
-;; sub-events (:dismiss, :success, :failure) admit a framework-controlled
-;; tail.
+;; Schema for the whole `:auth.login/flow` event vector — validated at the
+;; event boundary before the machine handler runs. The `:submit` sub-event is
+;; validated strictly against `Credentials`; the framework-internal sub-events
+;; (`:dismiss`, `:success`, `:failure`) admit a framework-controlled tail.
 ;;
-;; The :submit branch is a `:tuple` (NOT `:cat`): the outer `:cat` consumes
+;; The `:submit` branch is a `:tuple`, not a `:cat`: the outer `:cat` consumes
 ;; the nested sub-event vector as a SINGLE element, so the branch must match
 ;; that one element AS a vector. A `:cat` branch would apply sequence-regex
-;; semantics and — paired with a permissive `[:vector :any]` fallback —
-;; silently re-admit a `:submit` whose `Credentials` failed (the original
-;; bug: malformed submit payloads passed the `:where :event` boundary). With
-;; the strict `:tuple` and no `[:vector :any]` escape hatch, a short-password
-;; or bad-email submit is rejected at the boundary BEFORE the machine
-;; transitions or issues the login HTTP effect (Spec 010 §Validation order
-;; step 1, recovery `:no-recovery`).
+;; semantics, which can silently re-admit a `:submit` whose `Credentials`
+;; failed. With the strict `:tuple`, a short-password or bad-email submit is
+;; rejected at the boundary before the machine transitions or issues the login
+;; HTTP effect.
 ;;
-;; The trailing `[:? :any]` admits the managed-HTTP reply payload (Spec
-;; 014 §Reply addressing): the framework appends `{:kind ... :value ...}`
-;; / `{:kind ... :failure ...}` as the LAST arg of the explicit
-;; `:on-success` / `:on-failure` event vector, so the delivered reply is
-;; `[:auth.login/flow [:auth.login/success] <payload>]` — three top-level
-;; elements. Without the optional trailing slot the `:cat` rejects every
-;; reply with `:malli.core/input-remaining`, the boundary validation
-;; fails BEFORE the machine handler runs, and the flow is stranded in
-;; `:submitting`.
+;; The trailing `[:? :any]` admits the managed-HTTP reply payload. The
+;; framework appends `{:kind ... :value ...}` / `{:kind ... :failure ...}` as
+;; the LAST arg of the `:on-success` / `:on-failure` event vector, so the
+;; delivered reply is `[:auth.login/flow [:auth.login/success] <payload>]` —
+;; three top-level elements. Without the optional trailing slot the `:cat`
+;; rejects every reply, validation fails before the machine handler runs, and
+;; the flow is stranded in `:submitting`. See
+;; docs/guide/how-to/validate-with-schemas.md.
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
@@ -102,25 +91,19 @@
      [:* :any]]]
    [:? :any]])
 
-;; The machine's `[:schemas :data]` validates the machine's `:data` slot ONLY —
-;; the user-domain extended state `{:attempts ... :error ...}` — NOT the whole
-;; `{:state ... :data ...}` snapshot. Per Spec 005 §Schema validation and Spec
-;; 010 §Machine data schema, `[:schemas :data]` sits as a top-level key on the
-;; machine spec beside `:data`, and the framework validates it at every
-;; macrostep-commit boundary + at bootstrap (`:where :machine-data`). The same
-;; `[:schemas :data]` shape as examples/reagent/login + examples/uix/login_uix —
-;; the artefact layer is in semantic + id parity across the three substrates
-;; (see the divider above).
+;; Schema for the machine's `:data` slot — the extended state
+;; `{:attempts ... :error ...}`, NOT the whole `{:state ... :data ...}`
+;; snapshot. It sits under the machine spec's `:schemas` map (attached below)
+;; and the framework validates it at every transition commit and at bootstrap.
+;; See "Validating a machine's `:data`" in docs/machines/concepts.md.
 (def AuthLoginData
   [:map
    [:attempts {:default 0} :int]
    [:error    [:maybe :string]]])
 
-;; Machine snapshots are runtime-db state, not app-db — a `reg-app-schema` on a
-;; machine-snapshot path validates nothing (app schemas validate the app-db
-;; partition only). The machine's own `[:schemas :data]` (attached below) is the
-;; snapshot-validation surface, so no app-schema reg applies to the login
-;; snapshot.
+;; A machine snapshot lives in runtime-db, not app-db, and app schemas validate
+;; the app-db partition only. So no `reg-app-schema` applies to the snapshot;
+;; the machine's own `:data` schema (attached below) validates it instead.
 
 ;; ============================================================================
 ;; FX
@@ -136,14 +119,11 @@
       (.setItem ls "auth/token" token))))
 
 (rf/reg-fx :auth.login.demo/managed-stub
-  {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
-               to the Reagent and UIx examples' stub — delegates straight
-               to the framework-shipped canned-success / canned-failure
-               fxs with `:after-ms`, so the framework defers the reply via
-               `:dispatch-later` (50 ms) — observable in the tape,
-               time-travel-safe, NOT raw `js/setTimeout`. The `:after-ms`
-               parameter carries the schedule-reply → `:dispatch-later` →
-               deliver-reply chain as one arg on the canned effect."
+  {:doc       "Demo override for `:rf.http/managed`. Delegates to the
+               framework's canned-success / canned-failure fxs with
+               `:after-ms`, so the reply is deferred via `:dispatch-later`
+               (50 ms) rather than a raw `js/setTimeout` — it shows up in the
+               trace and is time-travel-safe."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -173,22 +153,15 @@
 ;; STATE MACHINE
 ;; ============================================================================
 
-;; The login flow's machine spec. `[:schemas :data]` is a TOP-LEVEL key on the
-;; spec map (Spec 005 §Schema validation) — it validates the `:data` slot
-;; (`{:attempts ... :error ...}`), NOT the whole snapshot. Factored into a
-;; named `def` (then passed to `reg-machine` below) so the machine spec sits
-;; in the same artefact-layer shape as the Reagent and UIx login siblings —
-;; same registry ids, same machine spec, same schemas + HTTP stub.
+;; The login flow's machine spec. `:schemas` is a top-level key beside `:data`;
+;; its `:data` entry validates the `:data` slot (`{:attempts ... :error ...}`),
+;; not the whole snapshot. It is a named `def` so it can be passed to
+;; `reg-machine` below — the same shape the Reagent and UIx login siblings use.
 (def auth-login-machine
   {:initial :idle
-   ;; Spec 005 §Schema validation — `[:schemas :data]` validates the snapshot's
-   ;; `:data` slot (not the whole snapshot) at the `:where :machine-data`
-   ;; boundary. This `:data` (`{:attempts :error}`) holds no secret, so the
-   ;; machine declares no `:sensitive` / `:large`. (EP-0025: durable machine
-   ;; `:data` snapshot redaction is a projection-relative `:sensitive` / `:large`
-   ;; declaration on the `reg-machine` spec — NOT a `[:schemas :data]` prop, which
-   ;; now drives only validation-failure-trace redaction.) Parity with
-   ;; reagent/login + uix.
+   ;; `:schemas :data` validates the `:data` slot at every transition commit.
+   ;; This `:data` (`{:attempts :error}`) holds no secret, so the machine
+   ;; declares no `:sensitive` / `:large`.
    :schemas {:data AuthLoginData}
    :data    {:attempts 0 :error nil}
 
@@ -203,11 +176,9 @@
     :issue-request
     (fn [{[_ creds] :event}]
       {:fx [[:rf.http/managed
-             ;; Spec 014 §Privacy (per-request `:sensitive?`): `:sensitive? true`
-             ;; redacts the request body (carrying the `:password`) from every
-             ;; `:rf.http/*` trace event — the coarse per-request wire scrub, a
-             ;; distinct surface from EP-0025 path classification (see
-             ;; examples/reagent/login for the full rationale).
+             ;; `:sensitive? true` redacts the request body (which carries the
+             ;; `:password`) from every HTTP trace event — the per-request wire
+             ;; scrub. See docs/guide/how-to/keep-secrets-out-of-traces.md.
              {:request    {:method :post
                            :url    "/api/login"
                            :body   creds
@@ -224,13 +195,11 @@
                  (assoc :error (or (:message failure) "Login failed.")))})
 
     :lock-account
-    ;; Fire-and-forget telemetry beacon (Spec 014 §Reply addressing
-    ;; "Silenced"): the lockout POST wants no reply folded back into the
-    ;; machine. `:on-success nil` / `:on-failure nil` silence both reply
-    ;; branches explicitly — without them the omitted-target default
-    ;; (co-located addressing) would dispatch
-    ;; `[:auth.login/flow {:rf/reply ...}]`, a map in the sub-event slot
-    ;; that `AuthLoginEvent` rejects, stranding noise after lockout.
+    ;; Fire-and-forget lockout beacon: this POST wants no reply folded back
+    ;; into the machine. `:on-success nil` / `:on-failure nil` silence both
+    ;; reply branches. Omit them and the default would dispatch
+    ;; `[:auth.login/flow {:rf/reply ...}]` — a map in the sub-event slot that
+    ;; `AuthLoginEvent` rejects, stranding noise after lockout.
     (fn [_]
       {:fx [[:rf.http/managed
              {:request    {:method :post :url "/api/auth/lock"}
@@ -278,59 +247,48 @@
      :meta {:terminal? true}}
 
     :locked-out
-    ;; :auth/locked tag — after the fourth failed submit the flow lands
-    ;; in this terminal state. Views query
-    ;; [:rf/machine-has-tag? :auth.login/flow :auth/locked] to swap the
-    ;; form for a locked-account panel and refuse further submits — same
-    ;; tag + locked-panel pattern as the state-machines walkthrough. A
-    ;; terminal lockout must be visible and non-interactive, not a live
-    ;; form.
+    ;; :auth/locked tag — the flow lands in this terminal state once the retry
+    ;; limit is reached. Views query
+    ;; [:rf/machine-has-tag? :auth.login/flow :auth/locked] to swap the form
+    ;; for a locked-account panel and refuse further submits. A terminal
+    ;; lockout should be visible and non-interactive, not a live form.
     {:tags #{:auth/locked}
      :meta {:terminal? true}}}})
 
-;; The machine + event-vector-schema shape: `reg-machine`'s event-`:schema`
-;; arity carries the event `:schema` (the `:where :event` boundary on the
-;; dispatched outer vector) alongside the machine spec. `reg-machine` is the
-;; single registration home — it stamps the `:rf/machine?` / `:rf/machine`
-;; metadata and (for a machine carrying a `[:schemas :data]`) bridges its redaction
-;; marks. The machine spec is the named `auth-login-machine` def above — the
-;; same def-then-register shape the Reagent and UIx login siblings use.
+;; Register the machine. The three-argument arity carries an event `:schema`
+;; in the middle map — the boundary check on the dispatched outer event vector
+;; — alongside the machine spec (the `auth-login-machine` def above). See
+;; "Validating a machine's `:data`" in docs/machines/concepts.md.
 (rf/reg-machine :auth.login/flow
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema AuthLoginEvent}
   auth-login-machine)
 
 ;; ============================================================================
-;; FORM SLICE  (Pattern-Forms — substrate-agnostic)
+;; FORM SLICE  (substrate-agnostic)
 ;; ============================================================================
 ;;
-;; The FORM-SLICE events below are the other half of the Pattern-Forms
-;; "machine + slice" composition (spec/Pattern-Forms.md §Variations). The
-;; SLICE owns the DRAFT — what the user is currently typing — at the app-db
-;; path [:auth :login-form]; the MACHINE owns submit/auth STATUS. This is the
-;; reason the form refactor exists: a form's draft is APPLICATION STATE, so it
-;; lives in app-db (projected via subs, mutated via events), NOT in a
-;; view-local Reagent atom / framework hook. Inputs are CONTROLLED: `:value`
-;; reads the draft sub, `:on-change` dispatches `:auth.login/edit-field`. The
-;; slice shape + the standard form events mirror the in-repo exemplar
-;; examples/reagent/realworld/auth.cljs 1:1.
+;; The form-slice events below are the other half of the "machine + slice"
+;; composition. The SLICE owns the DRAFT — what the user is currently typing —
+;; at the app-db path [:auth :login-form]; the MACHINE owns submit/auth STATUS.
+;; A form's draft is application state, so it lives in app-db (read via subs,
+;; written via events), not in a view-local hook. Inputs are CONTROLLED:
+;; `:value` reads the draft sub, `:on-change` dispatches
+;; `:auth.login/edit-field`. See docs/guide/how-to/build-a-form.md.
 ;;
-;; This whole block — slice defaults + form events + (below) the draft/slice
-;; subs — is the SUBSTRATE-AGNOSTIC artefact layer: it is byte-identical
-;; across examples/reagent/login, examples/uix/login_uix, and
-;; examples/helix/login_helix (Spec 006 §Adapter shipping convention Decision
-;; 7). Only the view syntax varies across the three.
+;; This whole block — slice defaults, form events, and (below) the draft/slice
+;; subs — is part of the substrate-agnostic layer shared identically across
+;; the three login examples. Only the view syntax varies.
 
 ;; The login form's default (empty) draft. The draft's value shape is
 ;; `Credentials` (email regex + min-8 password) — the same schema the
 ;; machine's `:submit` boundary enforces.
 (def login-form-defaults {:email "" :password ""})
 
-;; Seed the form slice to its standard Pattern-Forms shape: empty `:draft`,
-;; `:status :idle`.
+;; Seed the form slice to its standard shape: empty `:draft`, `:status :idle`.
 (rf/reg-event :auth.login/initialise-form
   {:doc "Seed the login-form slice at [:auth :login-form] to its standard
-         Pattern-Forms shape (empty draft, :idle status)."}
+         shape (empty draft, :idle status)."}
   (fn handler-login-form-initialise [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form]
                    {:draft             login-form-defaults
@@ -344,7 +302,7 @@
 ;; The user changed a single field. Update `:draft` and mark the field
 ;; `:touched`. This is all an input's `:on-change` does — the draft lives in
 ;; app-db, not view-local state. The `:schema` rejects a malformed edit-field
-;; vector at the `:where :event` boundary.
+;; vector at the event boundary.
 (rf/reg-event :auth.login/edit-field
   {:doc    "Controlled-input edit: write one field into the login-form draft
             and mark it touched."
@@ -356,20 +314,18 @@
 
 ;; Submit. Reads the draft out of the slice, latches `:submit-attempted?`,
 ;; flips the slice `:status` to `:submitting`, and dispatches the draft INTO
-;; the machine — the only point the draft crosses into the machine (and is
-;; validated against `Credentials` at the machine's `:where :event` boundary).
-;; The machine, not the slice, then owns the in-flight / authed / error /
-;; locked status; the slice `:status` mirror keeps the slice a conformant
-;; Pattern-Forms shape.
+;; the machine — the only point the draft crosses into the machine (where it
+;; is validated against `Credentials` at the event boundary). The machine, not
+;; the slice, then owns the in-flight / authed / error / locked status; the
+;; slice `:status` is just a mirror.
 ;;
-;; Secret-field hygiene (skills/re-frame2/patterns/forms.md §Auth): the
-;; handler reads the password off the draft and hands it to the machine, then
-;; CLEARS `[:draft :password]` in the same commit — once the request is in
-;; flight the secret has done its job, so it does not sit in durable app-db
-;; waiting for the next snapshot / recorder capture. The password's only
-;; off-box path is the HTTP request body (scrubbed by the per-request
-;; `:sensitive? true` flag); it is never written to `:submitted` or the
-;; machine `:data`.
+;; Secret-field hygiene: the handler reads the password off the draft, hands it
+;; to the machine, and CLEARS `[:draft :password]` in the same commit. Once the
+;; request is in flight the secret has done its job, so it does not sit in
+;; durable app-db waiting for the next snapshot or recording. The password's
+;; only off-box path is the HTTP request body (scrubbed by the per-request
+;; `:sensitive? true` flag); it is never written to `:submitted` or the machine
+;; `:data`. See docs/guide/how-to/keep-secrets-out-of-traces.md.
 (rf/reg-event :auth.login/submit-form
   {:doc "Submit the login form: read the draft from the slice, dispatch it
          into the :auth.login/flow machine's :submit sub-event, and clear the
@@ -399,14 +355,12 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; The machine snapshot lives at [:rf.runtime/machines :snapshots :auth.login/flow] (per
-;; Spec 005). These named subs project out the convenient pieces. The
-;; "in :submitting?" / "in :authed?" predicates live as the
-;; `:rf/machine-has-tag?` framework sub in views below (per Spec 005
-;; §State tags).
+;; The machine snapshot lives in runtime-db. These named subs project out the
+;; convenient pieces by chaining off the framework `:rf/machine` sub. The
+;; "is it busy / authed / locked?" predicates are the `:rf/machine-has-tag?`
+;; framework sub, read directly in the views below.
 
-;; Machine snapshots are durable runtime-db state — read them through the
-;; framework `:rf/machine` sub.
+;; Read the machine's snapshot through the framework `:rf/machine` sub.
 (rf/reg-sub :auth.login/state
   :<- [:rf/machine :auth.login/flow]
   (fn [snapshot _] (:state snapshot)))
@@ -415,13 +369,13 @@
   :<- [:rf/machine :auth.login/flow]
   (fn [snapshot _] (get-in snapshot [:data :error])))
 
-;; --- Form-slice subs (Pattern-Forms; substrate-agnostic) -------------------
+;; --- Form-slice subs (substrate-agnostic) ----------------------------------
 ;;
-;; The login-form slice lives at app-db [:auth :login-form]. The view reads
-;; the DRAFT through `:auth.login/draft` and binds each input's `:value` to it
-;; — controlled inputs. The per-field-error sub follows the Pattern-Forms
-;; visibility rule (touched OR submit-attempted?). These subs are part of the
-;; byte-identical artefact layer shared across the three substrate examples.
+;; The login-form slice lives at app-db [:auth :login-form]. The view reads the
+;; DRAFT through `:auth.login/draft` and binds each input's `:value` to it —
+;; controlled inputs. The per-field-error sub follows the form visibility rule:
+;; show a field's error once it is touched OR a submit has been attempted. See
+;; docs/guide/how-to/build-a-form.md.
 
 (rf/reg-sub :auth.login/form-slice
   {:doc "The whole login-form slice at [:auth :login-form]."}
@@ -436,9 +390,8 @@
     (:draft slice)))
 
 (rf/reg-sub :auth.login/field-error
-  {:doc "Per-field validation error for the login form. Per Pattern-Forms
-         §Error visibility: reveal a field's error once it is :touched OR once
-         the form has had its first submit click."}
+  {:doc "Per-field validation error for the login form. Reveal a field's error
+         once it is :touched OR once the form has had its first submit click."}
   :<- [:auth.login/form-slice]
   (fn sub-auth-login-field-error [slice [_ field]]
     (when (or (:submit-attempted? slice)
@@ -474,8 +427,8 @@
         ;; this frame (`:rf/default`) through the provider in `run`. Every
         ;; dispatch goes to a frame; there is no global dispatch.
         dispatch (:dispatch (rf/frame-handle))]
-    ;; Controlled inputs, the Pattern-Forms way: each input's `:value` reads
-    ;; the draft from the `:auth.login/draft` sub, and `:on-change` dispatches
+    ;; Controlled inputs: each input's `:value` reads the draft from the
+    ;; `:auth.login/draft` sub, and `:on-change` dispatches
     ;; `:auth.login/edit-field`. The draft lives in app-db, not in a `use-state`
     ;; hook. It crosses into the machine (and is validated) at the :on-submit
     ;; dispatch of `:auth.login/submit-form`.
@@ -536,10 +489,9 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `createRoot` onto the shared `#app`.
+;; Hold the React root in an atom and create it lazily inside `run`, not at
+;; ns-load. Loading the namespace must produce no DOM side effects, so that
+;; co-loaded example namespaces don't race `createRoot` onto the shared `#app`.
 (defonce react-root (atom nil))
 
 (defn run []
@@ -548,14 +500,13 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
-    ;; One-spot frame setup. The Helix `frame-provider` ENSURE shape (`{:id …}`)
-    ;; creates the `:rf/default` frame on first mount and applies the config
-    ;; below (`:doc`, and `:fx-overrides` routing `:rf.http/managed` to the demo
+    ;; Frame setup in one spot. The `frame-provider`'s `{:id …}` shape creates
+    ;; the `:rf/default` frame on first mount and applies the config below
+    ;; (`:doc`, and `:fx-overrides` routing `:rf.http/managed` to the demo
     ;; stub). On hot reload it reuses the existing frame and its state, so the
-    ;; demo survives a reload. The machine snapshot needs no seeding: the machine
-    ;; handler is self-initialising — its `:initial`/`:data` seed
-    ;; [:rf.runtime/machines :snapshots :auth.login/flow] when the flow first
-    ;; runs (Spec 005 §Restore semantics).
+    ;; demo survives a reload. The machine snapshot needs no seeding: it
+    ;; self-initialises from the spec's `:initial`/`:data` when the flow first
+    ;; runs.
     ;;
     ;; The provider also scopes the frame into React context, so the
     ;; `use-subscribe` hook and the `(rf/frame-handle)` capture in `login-form`

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -1,29 +1,21 @@
 (ns process-monitor-helix.core
-  "Helix design-led example — 'Process Monitor'. Terminal-style two-pane
-   layout: filterable process list on the left + live log feed on the
-   right, with status tiles across the top. Proves re-frame2 + Helix can
-   build a substantive UI.
+  "Helix example — 'Process Monitor'. A terminal-style two-pane layout: a
+   filterable process list on the left, a live log feed on the right, and
+   status tiles across the top.
 
-   Demonstrates:
+   What it shows:
 
-     - Helix components (`defnc`) consuming subs via `use-subscribe`
-     - signal-graph subscriptions: two independent inputs (the level-filter
-       chips, the selected process) fold into one derived sub, the visible
-       log slice — pure derivation, recomputed only when an input changes
-     - a recurring `:dispatch-later` tick that appends synthetic log
-       lines (`:process-monitor/tick`), owned by the component lifecycle and
-       kept idempotent by a generation guard — a real reactive loop, not a
-       static screenshot
+     - Helix components (`defnc`) reading subscriptions via `use-subscribe`
+     - a derivation graph: two UI inputs (the level-filter chips, the
+       selected process) fold into one derived subscription — the visible
+       log slice. It recomputes only when an input changes.
+     - a recurring `:dispatch-later` tick that appends synthetic log lines
+       (`:process-monitor/tick`), driven by the component lifecycle and kept
+       to exactly one live chain by a generation guard
      - per-row dispatch from inside a `defnc` row component
 
-   No HTTP, no state machines — design-led examples prove polished
-   visuals + interaction, not platform features other examples already
-   cover. Distinct shape from the Reagent 'Notebook' (3-pane editor)
-   and UIx 'Atlas' dashboard (cards + sparklines).
-
-   The shared 'Editorial Warm' visual identity comes from
-   examples/_shared/css/style.css — one identity across all three
-   substrates."
+   The 'Editorial Warm' visual identity comes from
+   examples/_shared/css/style.css, shared across all three substrates."
   (:require ["react-dom/client" :as react-dom-client]
             [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]
@@ -62,31 +54,19 @@
 ;; EVENTS
 ;; ============================================================================
 ;;
-;; The tick chain is driven by `:dispatch-later`, which has no cancel API.
-;; If `:process-monitor/initialise` is dispatched more than once in the same JS
-;; runtime (a shadow watch reload, a manual re-init, a future browser wrapper,
-;; or any harness that calls the entrypoint repeatedly), a naive chain would
-;; leave the prior chain's ticks still firing — every stale cascade would keep
-;; appending log entries and incrementing `:process-monitor/clock`, corrupting the
-;; visible cadence and clock. To stay idempotent — exactly one live tick per
-;; interval regardless of re-init churn — each scheduled tick carries the
-;; `:process-monitor/tick-gen` it was armed under. `:process-monitor/initialise` bumps the
-;; generation, so any in-flight tick from a retired chain no-ops when it
-;; eventually fires. This mirrors the 7GUIs timer's `:tick-gen` guard
-;; (examples/reagent/seven_guis/timer), the local precedent for the same
-;; cancel-less `:dispatch-later` constraint.
+;; The tick chain is a self-rescheduling `:dispatch-later`. That effect has no
+;; cancel API, so a "generation" counter (`:process-monitor/tick-gen`) keeps the
+;; chain to exactly one live loop:
 ;;
-;; The generation guard handles *re-init* (a fresh `:process-monitor/initialise`
-;; retires the prior chain). It does not, on its own, handle *teardown*:
-;; unmounting or replacing the React root without a following initialise
-;; would leave the last live chain dispatching into a frame nobody is
-;; rendering, silently mutating app-db forever. So the loop is tied to the
-;; Helix component lifecycle (see the `monitor` `use-effect` below): mount
-;; arms it via `:process-monitor/initialise`, unmount retires it via `:process-monitor/stop`.
-;; `:process-monitor/stop` simply bumps `:process-monitor/tick-gen` *without* rescheduling, so
-;; the in-flight tick no-ops when it lands and the chain dies. Repeated
-;; mount/unmount (e.g. a hot-reload teardown) therefore leaves at most one
-;; live tick chain, and a teardown leaves none.
+;;   - Each scheduled tick carries the generation it was armed under.
+;;   - `:process-monitor/initialise` and `:process-monitor/stop` bump the generation.
+;;   - A tick whose generation no longer matches `db` no-ops: no append, no
+;;     reschedule. So any chain from a previous arm dies on its next fire.
+;;
+;; The loop is tied to the `monitor` component lifecycle (see its `use-effect`
+;; below): mount arms it via `:process-monitor/initialise`, unmount stops it via
+;; `:process-monitor/stop`. A re-mount re-arms cleanly; an unmount leaves no chain
+;; dispatching into a frame nobody is rendering.
 
 (rf/reg-event :process-monitor/initialise
   (fn [{:keys [db]} _event]
@@ -98,15 +78,15 @@
             :process-monitor/selected   nil
             :process-monitor/tick-gen   next-gen}
        ;; Arm the loop by describing the first tick as data — the handler
-       ;; never touches setTimeout; the :dispatch-later effect handler does.
-       ;; The tick carries `next-gen` so it can recognise a retired chain.
+       ;; never touches setTimeout, the :dispatch-later effect does. The tick
+       ;; carries `next-gen` so a later arm can retire it.
        :fx [[:dispatch-later {:ms 1800 :event [:process-monitor/tick next-gen]}]]})))
 
 (rf/reg-event :process-monitor/tick
   (fn [{:keys [db]} [_ gen]]
     (if (not= gen (:process-monitor/tick-gen db))
-      ;; Stale tick from a retired generation (a later initialise bumped
-      ;; :process-monitor/tick-gen). Drop it: no log append, no clock bump, no reschedule.
+      ;; Generation no longer matches: this tick belongs to a retired chain.
+      ;; Drop it — no log append, no clock bump, no reschedule.
       {}
       (let [tick      (:process-monitor/clock db)
             processes (:process-monitor/processes db)
@@ -128,15 +108,13 @@
                  (update :process-monitor/logs (fn [logs]
                                          (vec (take-last 60 (conj logs new-entry)))))
                  (update :process-monitor/clock inc))
-         ;; Reschedule under the same generation, so the chain continues
-         ;; while a fresher initialise can still retire it.
+         ;; Reschedule under the same generation, so the chain continues until
+         ;; a fresher arm retires it.
          :fx [[:dispatch-later {:ms 1800 :event [:process-monitor/tick gen]}]]}))))
 
-;; Teardown counterpart to `:process-monitor/initialise`. Bumping `:process-monitor/tick-gen`
-;; without arming a fresh tick retires the live chain: the next scheduled
-;; `:process-monitor/tick` carries a now-stale generation and no-ops. Dispatched from
-;; the `monitor` component's `use-effect` cleanup on unmount, so the loop
-;; never outlives the rendered root.
+;; Stops the loop. Bumps the generation but arms no new tick, so the live
+;; chain's next fire no-ops. Dispatched from the `monitor` component's
+;; `use-effect` cleanup on unmount.
 (rf/reg-event :process-monitor/stop
   (fn [{:keys [db]} _event]
     {:db (update db :process-monitor/tick-gen (fnil inc 0))}))
@@ -169,9 +147,10 @@
 (rf/reg-sub :process-monitor/selected
   (fn [db _] (:process-monitor/selected db)))
 
-;; First derived sub: a pure node hanging off the base subs above. `:<-`
-;; names its inputs; the runtime recomputes it only when an input changes
-;; by `=`, so the tiles don't re-render when an unrelated key moves.
+;; A derived subscription built on the base subs above. `:<-` names its
+;; inputs; the runtime recomputes it only when an input changes by `=`, so the
+;; tiles don't re-render when an unrelated key moves. See the glossary on the
+;; derivation graph: docs/guide/glossary.md#the-derivation-graph
 (rf/reg-sub :process-monitor/totals
   :<- [:process-monitor/processes]
   (fn [processes _]
@@ -181,9 +160,9 @@
      :cpu     (reduce + 0 (map :cpu processes))
      :mem     (reduce + 0 (map :mem processes))}))
 
-;; The signal-graph node: two independent UI inputs (the level filter, the
-;; selected process) plus the raw logs and processes fold into the slice the
-;; log pane shows. The view does no filtering itself — it reads this.
+;; Four inputs (the level filter, the selected process, the raw logs, the
+;; processes) fold into the slice the log pane shows. The view does no
+;; filtering itself — it reads this.
 (rf/reg-sub :process-monitor/visible-logs
   :<- [:process-monitor/logs]
   :<- [:process-monitor/level-filter]
@@ -202,14 +181,11 @@
 ;; ──────────────────────────  SUBSTRATE BOUNDARY  ──────────────────────────
 ;; ============================================================================
 ;;
-;; Everything above is the substrate-agnostic artefact layer: seed data,
-;; events (the tick loop), and the signal-graph subs. None of it mentions
-;; Helix. Below this divider is the only substrate-specific code: the `defnc`
-;; views + the mount. Unlike the counter/login pair, this design-led example
-;; is NOT a cross-substrate parity twin — its dataflow is its own (the Reagent
-;; notebook + UIx dashboard are different apps, not the same dataflow through a
-;; different substrate). The boundary it teaches is still the same: app-db +
-;; events + subs sit above, the substrate's view idiom sits below.
+;; Everything above is substrate-agnostic: seed data, events (the tick loop),
+;; and the subs. None of it mentions Helix. Below this divider is the only
+;; substrate-specific code: the `defnc` views and the mount. That is the
+;; boundary the example teaches — app-db + events + subs sit above, the
+;; substrate's view idiom sits below.
 
 ;; ============================================================================
 ;; VIEWS (Helix — defnc)
@@ -220,9 +196,9 @@
     (d/div {:class "pm-tile-label"} label)
     (d/div {:class "pm-tile-value"} value)))
 
-;; First sub-reading view. `use-subscribe` is the Helix hook form of
-;; `subscribe`: it returns a plain value (not a reaction) and re-renders this
-;; component when that value changes. Call it at the top of the body.
+;; `use-subscribe` is the Helix hook form of `subscribe`: it returns a plain
+;; value (not a reaction) and re-renders this component when that value
+;; changes. Call it at the top of the body.
 (defnc tiles []
   (let [totals (helix-adapter/use-subscribe [:process-monitor/totals])]
     (d/div {:class "pm-tiles"}
@@ -232,9 +208,9 @@
       ($ tile {:label "Σ CPU"   :value (str (.toFixed (:cpu totals) 1) "%")})
       ($ tile {:label "Σ MEM"   :value (str (:mem totals) "M")}))))
 
-;; First dispatching view. To dispatch, grab `dispatch` off a frame-handle:
-;; `(rf/frame-handle)` captures the current frame as a value, so the click
-;; handler dispatches into this app's frame.
+;; To dispatch, grab `dispatch` off a frame-handle: `(rf/frame-handle)`
+;; captures the current frame as a value, so the click handler dispatches into
+;; this app's frame. See docs/guide/glossary.md#frame-handle
 (defnc level-chips []
   (let [active   (helix-adapter/use-subscribe [:process-monitor/level-filter])
         dispatch (:dispatch (rf/frame-handle))]
@@ -300,21 +276,18 @@
                       :entry entry}))))))
 
 (defnc monitor []
-  ;; This component owns the recurring tick loop: mount arms it, unmount stops
-  ;; it. `(:dispatch (rf/frame-handle))` is captured at render-time so it carries
-  ;; the surrounding frame into the (post-commit) effect body and cleanup — see
-  ;; the Helix adapter README §use-effect.
+  ;; This component drives the tick loop: mount arms it, unmount stops it.
+  ;; Capture `(:dispatch (rf/frame-handle))` at render-time so it carries the
+  ;; surrounding frame into the post-commit effect body and cleanup. See the
+  ;; Helix adapter README §use-effect for why the capture goes here.
   (let [dispatch (:dispatch (rf/frame-handle))]
     (helix-hooks/use-effect
       ;; Empty deps ⇒ run once on mount, clean up once on unmount.
       []
-      ;; Mount: (re-)arm the loop. Idempotent — the `:process-monitor/tick-gen`
-      ;; guard retires any chain already in flight (from the provider's seed, or
-      ;; a prior mount), so exactly one live chain survives and a hot-reload
-      ;; re-mount re-arms cleanly.
+      ;; Mount: arm the loop. The generation guard retires any chain already in
+      ;; flight, so a re-mount re-arms cleanly and only one chain stays live.
       (dispatch [:process-monitor/initialise])
-      ;; Unmount: retire the live chain so it never dispatches into a frame
-      ;; that is no longer rendered.
+      ;; Unmount: stop the chain so it never dispatches into an unrendered frame.
       (fn cleanup []
         (dispatch [:process-monitor/stop]))))
   (d/div {:class "pm-shell"}
@@ -332,18 +305,16 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `createRoot` onto the shared `#app`.
-;; This matches the sibling notebook / dashboard_uix mount shape.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. Per examples/TESTING.md §Example mount-isolation, ns-load must
+;; produce no DOM side effects so co-required example namespaces don't race
+;; `createRoot` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; The frame id this app runs under. The Helix `frame-provider` at the render
-;; root (in `run` below) does the frame work in one spot: it creates this frame,
-;; seeds app-db, and scopes the frame into React context. The `use-subscribe`
-;; hook and the render-time `(rf/frame-handle)` capture inside `monitor` (the
-;; tick-loop arm/stop dispatches) resolve to that frame via the context.
+;; The frame id this app runs under. The `frame-provider` in `run` below is the
+;; one spot the frame is set up: it creates the frame, seeds app-db, and scopes
+;; the frame into React context. `use-subscribe` and the `(rf/frame-handle)`
+;; capture in `monitor` resolve to this frame through that context.
 (def app-frame :rf/default)
 
 (defn run []
@@ -352,13 +323,10 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
-    ;; The `frame-provider` is the one spot the frame is set up. `{:id …}`
-    ;; creates the app frame on first mount and runs `:initial-events` once to
-    ;; seed app-db; a hot reload reuses the same frame without re-seeding so the
-    ;; running clock/logs stay intact. The seed arms the first tick; from then on
-    ;; the loop is owned by the `monitor` component lifecycle — its mount
-    ;; `use-effect` re-arms idempotently (the `:process-monitor/tick-gen` guard)
-    ;; and unmount stops it (see `:process-monitor/stop`).
+    ;; `frame-provider` creates the app frame on first mount and runs
+    ;; `:initial-events` once to seed app-db; a hot reload reuses the frame
+    ;; without re-seeding, so the running clock and logs stay intact. From there
+    ;; the `monitor` component owns the loop (see its `use-effect`).
     (.render @react-root
              ($ helix-adapter/frame-provider {:id app-frame
                                               :initial-events [[:process-monitor/initialise]]}

--- a/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
@@ -1,39 +1,30 @@
 (ns counter-slim-and-fast.bundle-isolation-entry
   "Gate-owned entrypoint for the slim counter — NOT example/app practice.
 
-   This namespace exists ONLY to drive the slim adapter's bundle-isolation
+   This namespace exists only to drive the slim adapter's bundle-isolation
    gate. It is the `:init-fn` of the `:examples/counter-slim-and-fast` build
-   (implementation/shadow-cljs.edn), so the build it inspects compiles the
-   pure-CLJS SSR path the gate's non-vacuity contract (Contract 4) requires —
-   while the teaching surface `counter-slim-and-fast.core` stays clean of any
-   fixture plumbing.
+   (implementation/shadow-cljs.edn), so the build the gate inspects compiles
+   the pure-CLJS SSR path. The teaching surface `counter-slim-and-fast.core`
+   stays clean of fixture plumbing.
 
-   A reader studying the example should ignore this file and `run` in
-   `counter-slim-and-fast.core` instead. The two halves of the gate machinery
-   live together here and in `counter-slim-and-fast.bundle-isolation-fixture`;
-   the contract narrative + sentinel methodology are owned by the gate at
-   `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` and the
-   slim adapter's IMPL-SPEC §1.4 + §1.8 + §8 — deliberately not duplicated.
+   A reader studying the example should ignore this file and read `run` in
+   `counter-slim-and-fast.core` instead. The gate that consumes this
+   entrypoint is `implementation/scripts/check-reagent-slim-bundle-isolation.cjs`,
+   which owns the contract details.
 
-   The boot is NOT re-copied here: this entry calls the shared
-   `counter-slim-and-fast.core/boot!` (the single source of truth for the
-   boot — install the slim adapter, then mount under a
-   `frame-provider {:id …}` that creates + seeds the app frame in one spot),
-   so the gate-owned path cannot drift from the teaching `core/run`. The one
-   fixture concern is the `on-frame` pre-mount hook `boot!` accepts: the
-   pure-CLJS `render-to-static-markup` exercise runs in a TRANSIENT frame
-   scope `boot!` opens for it, before the client mount, so the static
-   render's orphaned SSR subscription is torn down
-   (fixture/prove-pure-cljs-ssr! clears the sub-cache) and the browser mount
-   owns the only live `[:counter/value]` reaction."
+   This entry calls the shared `counter-slim-and-fast.core/boot!` rather
+   than re-copying the boot. The one fixture concern is the `on-frame`
+   pre-mount hook `boot!` accepts: the pure-CLJS `render-to-static-markup`
+   exercise runs in a transient frame `boot!` opens for it, before the
+   client mount, so the static render's orphaned SSR subscription is torn
+   down (`fixture/prove-pure-cljs-ssr!` clears the sub-cache) and the
+   browser mount owns the only live `[:counter/value]` reaction."
   (:require [re-frame.views]
             [counter-slim-and-fast.core                     :as core]
             [counter-slim-and-fast.bundle-isolation-fixture :as fixture]))
 
 (defn run []
-  ;; Run the one canonical boot in `core/boot!`, passing the SSR fixture as
-  ;; its `on-frame` pre-mount hook. `boot!` runs the hook in a transient
-  ;; frame before the client mount; the fixture clears the sub-cache when it
-  ;; finishes, so the browser mount owns the only live `[:counter/value]`
-  ;; reaction. (Mechanics: `fixture/prove-pure-cljs-ssr!` and the docstring.)
+  ;; Boot via `core/boot!`, passing the SSR fixture as its `on-frame`
+  ;; pre-mount hook. See the ns docstring and `fixture/prove-pure-cljs-ssr!`
+  ;; for what the hook does.
   (core/boot! #(fixture/prove-pure-cljs-ssr! [core/counter-app])))

--- a/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_fixture.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_fixture.cljs
@@ -2,54 +2,47 @@
   "Bundle-isolation fixture for the slim counter — NOT example/app practice.
 
    This namespace exists only to make the slim adapter's pure-CLJS-SSR
-   bundle-isolation contract (S3-005) provable on the advanced bundle. A
-   reader studying the example should ignore it; the teaching surface is
-   `counter-slim-and-fast.core`. The plumbing here is the example-side
-   half of an adapter-owned CI gate.
+   bundle-isolation contract provable on the advanced bundle. A reader
+   studying the example should ignore it; the teaching surface is
+   `counter-slim-and-fast.core`. This is the example-side half of an
+   adapter-owned CI gate.
 
    The gate that consumes this fixture is
-   `implementation/scripts/check-reagent-slim-bundle-isolation.cjs`
-   (the `cljs-reagent-slim-bundle-isolation` CI job, run via
-   `npm run test:reagent-slim:bundle-isolation`). That script is the
-   single source of truth for the sentinel methodology and the four
-   contracts; the contract narrative lives there and in the slim
-   adapter's IMPL-SPEC §1.4 + §1.8 + §8 — it is deliberately not
-   duplicated into the example source.
+   `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` (run
+   via `npm run test:reagent-slim:bundle-isolation`). That script owns the
+   contract details.
 
-   What this fixture contributes to the gate: it exercises the slim's
-   pure-CLJS `render-to-static-markup` at boot so the SSR path is
-   actually compiled into the bundle. That makes Contract 3
-   (`react-dom/server` is absent) a NON-vacuous proof — without an
-   exercised SSR path, the absence check would pass against a bundle
-   that does no SSR at all. The host-global write below is the DCE
-   anchor that keeps the exercise alive under `:advanced`."
+   What this fixture contributes: it exercises slim's pure-CLJS
+   `render-to-static-markup` at boot so the SSR path is actually compiled
+   into the bundle. That makes the gate's check that `react-dom/server` is
+   absent a real proof — without an exercised SSR path, the absence check
+   would pass against a bundle that does no SSR at all. The host-global
+   write below keeps the exercise alive under `:advanced`. For the two HTML
+   paths slim ships, see docs/guide/how-to/use-uix-helix-or-slim.md."
   (:require [reagent2.dom.server :as rds]
             [re-frame.core       :as rf]))
 
 (defn prove-pure-cljs-ssr!
-  "Compile-and-run the slim's pure-CLJS SSR path so the bundle-isolation
-   gate's non-vacuity contract has signal. `hiccup` is the root example
-   view in hiccup form (e.g. `[counter-app]`).
+  "Run slim's pure-CLJS SSR path so the bundle-isolation gate has signal.
+   `hiccup` is the root example view in hiccup form (e.g. `[counter-app]`).
 
    Mechanics (all fixture concerns, none of which the example needs):
 
-     - DCE anchor: the rendered markup is written onto the
-       `counterSlimPrerender` host-global. The closure compiler treats
-       writes to extern-shaped `globalThis` properties as side effects,
-       so the `render-to-static-markup` call survives `:advanced` (a no-op
-       like `js/console.log` would be elided). The gate greps for this
-       host-global plus a `reagent2.dom.server` serializer-owned literal.
+     - Keeping it alive under `:advanced`: the rendered markup is written
+       onto the `counterSlimPrerender` host-global. The closure compiler
+       treats writes to extern-shaped `globalThis` properties as side
+       effects, so the `render-to-static-markup` call is not eliminated as
+       dead code. The gate greps for this host-global plus a literal owned
+       by the `reagent2.dom.server` serializer.
 
      - Sub-cache teardown: `render-to-static-markup` is the pure-CLJS
-       static walker — it invokes the view as a plain fn and walks the
-       resulting hiccup, mounting NO Reagent component lifecycle. The view
+       static walker — it calls the view as a plain fn and walks the
+       resulting hiccup, mounting no Reagent component lifecycle. The view
        derefs a subscription, so the static render builds and caches that
-       reaction in the frame's sub-cache with ref-count 1, and nothing
-       auto-unsubscribes it (there is no component to unmount). Left as-is
-       this fixture would leak a headless reaction into the live runtime.
-       The `try`/`finally` disposes the orphaned SSR subscription so the
-       client mount owns the only live reaction; `finally` guarantees
-       teardown even if the static render throws."
+       reaction in the frame's sub-cache, and nothing auto-unsubscribes it
+       (there is no component to unmount). The `try`/`finally` disposes the
+       orphaned subscription so the client mount owns the only live
+       reaction; `finally` guarantees teardown even if the render throws."
   [hiccup]
   (try
     (set! (.-counterSlimPrerender js/globalThis)

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -1,47 +1,38 @@
 (ns counter-slim-and-fast.core
-  "A minimal counter mounted on the day8/reagent-slim rewrite.
+  "A minimal counter on the reagent-slim substrate.
 
-   The dataflow is identical to `examples/reagent/counter` — the same
-   six dominoes, the same `:counter/*` events and subs. The only
-   intentional divergence is the substrate beneath: every user-facing
-   Reagent import points at `reagent2.*` instead of stock `reagent.*`,
-   and `(rf/init!)` is called with the slim adapter Var. Read this file
-   as the teaching example — it is plain, idiomatic re-frame2 with
-   nothing but the example's own dataflow.
+   This is the teaching file: plain, idiomatic re-frame2. The dataflow is
+   the same counter as `examples/reagent/counter` — the same `:counter/*`
+   events and subs. The one difference is the substrate beneath it: the
+   view imports point at `reagent2.*`, and `rf/init!` is given the slim
+   adapter. Picking a substrate is one line; see
+   docs/guide/how-to/use-uix-helix-or-slim.md.
 
-   IN-TREE NAMESPACE vs PUBLISHED ABI: the require below is the *in-tree*
-   namespace `re-frame.adapter.reagent-slim`, used only because the
-   unrenamed monorepo build shares a classpath with the stock adapter and
-   must avoid an ns clash. The PUBLISHED `day8/reagent-slim` jar ships the
-   adapter Var at the canonical, stock-identical `re-frame.adapter.reagent`
-   (renamed at publication). An adopter therefore wires
-   `(rf/init! re-frame.adapter.reagent/adapter)` exactly as for stock —
-   slim is selected by deps coordinate, not by import line. Do not
-   cargo-cult the in-tree `-slim` namespace into a published app. See
-   docs/guide/how-to/use-uix-helix-or-slim.md and
-   implementation/adapters/reagent-slim/DESIGN-RATIONALE.md §7.
+   The require below names `re-frame.adapter.reagent-slim` because this
+   monorepo build shares a classpath with the stock adapter and must avoid
+   a namespace clash. A real app picks slim by its `deps.edn` coordinate
+   (`day8/reagent-slim`), not by this import line — see the guide page's
+   coordinate table.
 
-   The slim adapter's bundle-isolation proof lives in its own gate-owned
-   entrypoint, `counter-slim-and-fast.bundle-isolation-entry` (the
-   `:init-fn` of the `:examples/counter-slim-and-fast` build), so this
-   teaching file stays free of fixture plumbing. That entry boots the
-   same app through the shared `boot!` helper below and passes a pre-mount
-   hook that exercises the pure-CLJS SSR path the gate inspects. Because
-   both paths call the one `boot!`, they cannot drift."
+   The slim adapter's bundle-isolation proof runs from a separate
+   gate-owned entrypoint, `counter-slim-and-fast.bundle-isolation-entry`,
+   so this file carries no fixture plumbing. That entry boots the same app
+   through the shared `boot!` helper below, passing a hook that exercises
+   the pure-CLJS SSR path the gate inspects."
   (:require [reagent2.dom.client                :as rdc]
             [re-frame.core                      :as rf]
             [re-frame.views]
-            ;; In-tree namespace (see ns docstring): published adopters
-            ;; require the canonical `re-frame.adapter.reagent` instead.
+            ;; Monorepo-only namespace (see ns docstring): a real app picks
+            ;; slim by its deps coordinate, not by this import.
             [re-frame.adapter.reagent-slim      :as reagent-slim-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- Events / subs (handler registry is app-global) --------------------------
 ;;
-;; These four forms are the substrate-agnostic core: pure handlers, a pure
-;; subscription, all over plain data. They are byte-for-byte the stock
-;; counter's, and they survive the substrate swap untouched — only the boot
-;; below changes. That invariance is the whole point of this example.
+;; These four forms are the substrate-agnostic core: pure handlers and a pure
+;; subscription over plain data. The substrate swap does not touch them — only
+;; the boot below changes. That invariance is the point of this example.
+;; See docs/guide/glossary.md for event and subscription.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -57,12 +48,10 @@
 
 ;; -- Views -------------------------------------------------------------------
 ;;
-;; reg-view is substrate-agnostic. The macro expands to a plain
-;; React-component shape that reads through the active adapter at render
-;; time, so the same view form renders on whichever substrate was
-;; installed at boot. Here the slim adapter is installed (see `boot!`
-;; below), so the view reads frame state through
-;; `reagent2.core/current-component` rather than stock Reagent's.
+;; reg-view is substrate-agnostic. The same view form renders on whichever
+;; substrate was installed at boot, because it reads through the active
+;; adapter at render time. Here that adapter is slim (see `boot!` below).
+;; See docs/guide/concepts/views.md.
 
 (reg-view counter-buttons []
   [:div
@@ -75,27 +64,23 @@
 
 ;; -- Mount -------------------------------------------------------------------
 ;;
-;; The React root is held in an atom and created lazily inside `boot!`,
-;; not at ns-load, per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects, so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
-;; This mirrors the behavioural twin `examples/reagent/counter` — the one
-;; blessed mount shape across the example tree. The only divergence from
-;; the twin is the substrate swap (the `reagent2.*` imports + the slim
-;; adapter Var).
+;; The React root is held in an atom and created lazily inside `boot!`, not
+;; at ns-load. Loading the namespace must produce no DOM side effects, so
+;; that co-required example namespaces don't race `create-root` onto the
+;; shared `#app`. This is the same mount shape as `examples/reagent/counter`.
 
 (defonce react-root (atom nil))
 
 ;; The app frame is established in one spot: the `frame-provider {:id
 ;; app-frame …}` at the render root below. On first mount the provider
-;; creates the frame, applies its config, and runs `:initial-events`
-;; once to seed it (the `[:counter/initialise]` boot dispatch). From then
-;; on every in-tree `dispatch`/`subscribe` resolves to that frame. On hot
-;; reload the provider reuses the existing frame and skips re-seeding.
-;; Matches the canonical mount in examples/reagent/counter/core.cljs.
+;; creates the frame, applies its config, and runs `:initial-events` once
+;; to seed it (the `[:counter/initialise]` dispatch). After that every
+;; `dispatch`/`subscribe` resolves to that frame. On hot reload the
+;; provider reuses the existing frame and skips re-seeding.
 ;;
 ;; `:rf/default` is an ordinary frame id with no special privilege — you
-;; establish it like any other (the runtime won't infer it for you).
+;; establish it like any other; the runtime won't infer it for you.
+;; See docs/guide/concepts/frames.md.
 (def app-frame :rf/default)
 
 (defn boot!
@@ -103,22 +88,19 @@
    `counter-app` into `#app` under a `frame-provider {:id app-frame …}`.
    The provider creates and seeds the app frame (see the comment above).
 
-   This is the single source of truth for the boot. Both the teaching path
-   (`run` below) and the gate-owned path
-   (`counter-slim-and-fast.bundle-isolation-entry/run`) call it, so a
-   future boot change is made in one place and the two paths cannot drift.
+   Both the teaching path (`run` below) and the gate-owned path
+   (`counter-slim-and-fast.bundle-isolation-entry/run`) call this one
+   helper, so the boot is defined in a single place.
 
    `on-frame` is an optional thunk the bundle-isolation entry uses; the
-   teaching `run` passes nothing. It runs once before the client mount,
-   inside its own short-lived frame (`with-new-frame`, auto-destroyed on
-   exit), so the fixture's pre-mount SSR exercise stays clear of the app
-   frame the provider creates at mount. Keeping this seam in `boot!`
-   instead of re-copying the boot is what keeps `core` free of fixture
-   plumbing while preventing drift."
+   teaching `run` passes nothing. When given, it runs once before the
+   client mount inside its own short-lived frame (`with-new-frame`,
+   destroyed on exit), so the fixture's pre-mount SSR exercise stays clear
+   of the app frame the provider creates at mount."
   ([] (boot! nil))
   ([on-frame]
-   ;; Slim adapter — the difference from `examples/reagent/counter` is
-   ;; right here. Same `rf/init!` signature; different adapter Var.
+   ;; Slim adapter — this is the difference from `examples/reagent/counter`.
+   ;; Same `rf/init!` signature; different adapter.
    (rf/init! reagent-slim-adapter/adapter)
    (when on-frame
      ;; Fixture-only seam: run the hook in a throwaway frame (destroyed on

--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -1,83 +1,71 @@
 (ns boot.boot
-  "Pattern-Boot: the canonical re-frame2 application boot shape.
+  "Boot the app with one state machine that owns the whole startup graph.
 
-   The boot machine owns the initialisation graph. It runs through
-   four states:
+   See the machines guide for the model — `:spawn` / `:spawn-all`
+   (docs/machines/glossary.md#spawn), states and transitions
+   (docs/machines/glossary.md#state), and the machine snapshot
+   (docs/machines/glossary.md#snapshot).
 
-     :configuring   → fetch the mock /config endpoint via a single
-                      `:spawn`d child loader machine.
+   The boot machine is `:app/boot`. It runs through four states:
+
+     :configuring   → fetch /config via a single `:spawn`d child loader.
      :loading-deps  → fan out THREE parallel child loads (routes,
-                      feature flags, initial user) via `:spawn-all`;
-                      the parent reaches the next state only when
-                      EVERY child reports done.
-     :hydrating     → applies the four loaded payloads into top-level
-                      app-db slices (`:config`, `:flags`, `:user`,
-                      `:routes`) via the `:enter-hydrating` action.
-                      Self-transitions to `:ready` once the writes
-                      land.
-     :ready         → terminal. The main view subscribes to the boot
-                      state and unblocks once it reads `:ready`.
+                      feature flags, initial user) via `:spawn-all`.
+                      The parent advances only when every child is done.
+     :hydrating     → write the loaded payloads into top-level app-db
+                      slices (`:config`, `:flags`, `:user`, `:routes`),
+                      then self-transition to `:ready`.
+     :ready         → terminal. The main view watches the boot state and
+                      unblocks once it reads `:ready`.
 
-   On any child failure the boot machine transitions to `:failed`
-   (terminal) with the failure payload recorded in `:data :error`.
+   Any child failure transitions the machine to `:failed` (terminal),
+   with the failure recorded in `:data :error`.
 
-   The boot machine itself is `:app/boot`; the child loader is the
-   reusable `:boot/loader` machine — one spec, four instances spawned
-   with different `:data`. Each instance's identity (parent-id,
-   child-id, staging-key, URL) is planted via the `:data` fn-form on
-   the per-child invoke-spec — Pattern-AsyncEffect mechanism 2 (the
-   spawn-spec `:data` fn reads the parent's post-action snapshot).
+   The child loader is the reusable `:boot/loader` machine — one spec,
+   four instances. Each instance carries its own identity (parent-id,
+   child-id, staging-key, URL) in `:data`, planted by the parent's
+   per-child `:data` fn. A `:data` fn receives the parent's snapshot, so
+   a child's URL can depend on values the parent has already loaded.
 
-   The boot also demonstrates mechanism 3 → mechanism 2 end-to-end:
-   the `:configuring` config load returns an `:api-base`; the
-   `:promote-staged` action records it into the boot machine's own
-   `:data` on the `:configuring → :loading-deps` transition; the
-   three `:loading-deps` children then read that promoted `:api-base`
-   off the parent's snapshot (mechanism 2) and thread it into their
-   own URLs. This is the canonical Pattern-Boot parameter shape (see
-   Pattern-Boot §Parameters): the boot machine is the only place that
-   reads host config; everything downstream threads it via a snapshot
-   `:data` fn — nothing reaches into a host global from an action body.
+   That is how config flows downstream. The `:configuring` config load
+   returns an `:api-base`; the `:promote-staged` action records it into
+   the boot machine's `:data`; the three `:loading-deps` children then
+   read that `:api-base` off the parent's snapshot and build their URLs
+   from it. The boot machine is the only place that reads host config —
+   everything downstream threads it through a snapshot `:data` fn,
+   never reaching into a host global from an action body.
 
-   Each child fetches via `:rf.http/managed` and, on success, writes
-   its payload into the boot machine's staging slot at
-   `[:boot/staging <staging-key>]` before dispatching its
-   child-completion event back to the parent.
+   Each child fetches via managed HTTP
+   (docs/resources/glossary.md#managed-http). On success it writes its
+   payload into the boot machine's staging slot at
+   `[:boot/staging <staging-key>]`, then dispatches its completion
+   event back to the parent.
 
-   Why a staging slot rather than threading the `:spawn-all` payloads
-   through the join-event: per Spec 005, the runtime intercepts the
-   parent's `:on-child-done` / `:on-child-error` events for join
-   bookkeeping ONLY — they are NOT fed into the parent's `:on` lookup.
-   The join-resolution event the runtime synthesises
-   (`:on-all-complete [:boot/deps-ready]`) carries no per-child
-   payload. So the canonical Pattern-Boot shape for a `:spawn-all`
-   that needs to thread loaded data into the parent is: each child
-   writes its result into a known app-db slice, the parent reads
-   that slice on the join-resolved transition. This keeps the
-   loaded data in app-db throughout — inspectable in pair-tools
-   and snapshottable for SSR hydration.
+   Why stage into app-db rather than carry payloads on the join event:
+   the runtime intercepts a `:spawn-all`'s `:on-child-done` /
+   `:on-child-error` events for join bookkeeping only — they are NOT
+   fed into the parent's `:on` lookup, and the synthesised
+   join-resolution event (`:on-all-complete [:boot/deps-ready]`)
+   carries no per-child payload. So each child writes its result into a
+   known app-db slice and the parent reads that slice once the join
+   resolves. The loaded data lives in app-db throughout — inspectable
+   in tools and snapshottable for SSR hydration.
 
-   The single `:spawn` in `:configuring` is different: its
-   child-completion event IS fed into the parent's `:on` lookup (only
-   `:spawn-all` join events are intercepted). The config child
-   therefore carries its loaded payload on the completion event, and
-   the `:promote-staged` action reads it from there to thread the
-   `:api-base` into the next phase (mechanism 3 → mechanism 2 above).
+   The single `:spawn` in `:configuring` is different: its completion
+   event IS fed into the parent's `:on` lookup (only `:spawn-all` join
+   events are intercepted). So the config child carries its payload on
+   the completion event, and `:promote-staged` reads it from there.
 
-   Trigger boot once at app start via `[:app/boot [:rf.machine/start]]`.
-   The machine comes alive on that eager creation kick (per Spec 005
-   §When creation happens — eager start vs lazy first event): the
-   `:initial` state and `:data` seed `[:rf.runtime/machines :snapshots :app/boot]` (runtime-db) when
-   the dispatch lands."
+   Start the boot once at app start via `[:app/boot [:rf.machine/start]]`.
+   That creation marker runs the initial-entry cascade and seeds the
+   machine snapshot in runtime-db (docs/guide/glossary.md#runtime-db)."
   (:require [re-frame.core :as rf]
-            ;; Spec 005 state-machine ns ships in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so `rf/reg-machine` and
-            ;; `rf/make-machine-handler` resolve at ns-load.
+            ;; State machines ship in a separate artefact. The require
+            ;; registers `rf/reg-machine` and friends.
             [re-frame.machines]
-            ;; `:rf.http/managed` ships in day8/re-frame2-http. Loading
-            ;; the ns registers the fx; without it, the child loaders
-            ;; can't issue requests.
+            ;; Managed HTTP ships in a separate artefact. The require
+            ;; registers the fx; without it the child loaders can't
+            ;; issue requests.
             [re-frame.http.managed]
             [boot.schema :as schema]))
 
@@ -85,22 +73,18 @@
 ;; STAGING-SLOT WRITER
 ;; ============================================================================
 ;;
-;; How does a :spawn-all child hand its payload back to the parent? Not on
-;; the completion event — the runtime intercepts :spawn-all join events for
-;; its own bookkeeping and never feeds them into the parent's :on lookup, so
-;; there is no event to carry data on (see the ns docstring). The canonical
-;; Pattern-Boot answer is a staging slot in app-db: each child loader writes
-;; its payload into `[:boot/staging <staging-key>]` just before signalling
-;; completion, and the parent reads the whole slot once on the :hydrating
-;; transition. Bonus: the loaded data lives in app-db the whole time —
-;; inspectable in pair-tools, snapshottable for SSR — never in-flight-and-
-;; unobservable on an event.
+;; A :spawn-all child hands its payload back to the parent through a staging
+;; slot in app-db, not on the completion event (the runtime intercepts
+;; :spawn-all join events and never feeds them into the parent's :on lookup —
+;; see the ns docstring). Each child writes into `[:boot/staging <staging-key>]`
+;; just before signalling completion; the parent reads the whole slot once on
+;; the :hydrating transition. The loaded data sits in app-db the whole time,
+;; inspectable in tools and snapshottable for SSR.
 
 (rf/reg-event :boot/stage-payload
   {:doc "Write a child-loaded payload into the boot machine's
          staging slot. Dispatched by the :boot/loader child's
-         :dispatch-done action just before it dispatches the
-         join-completion event back to the parent."}
+         :dispatch-done action just before the completion event."}
   (fn handler-boot-stage-payload [{:keys [db]} [_ staging-key payload]]
     {:db (assoc-in db [:boot/staging staging-key] payload)}))
 
@@ -108,25 +92,20 @@
 ;; CHILD LOADER MACHINE — :boot/loader
 ;; ============================================================================
 ;;
-;; The reusable child machine. One spec, four instances. Each
-;; instance carries its own `:data` map (`:parent-id`, `:child-id`,
-;; `:staging-key`, `:url`) planted by the parent's per-child
-;; `:spawn` / `:spawn-all`-child `:data` slot (fn-form per
-;; Spec 005 §Spec-spec keys). The child machine spawns in `:idle`
-;; and the runtime-synthesised `:rf.machine.spawn/spawned` event
-;; transitions it to `:loading`, which fires the entry-cascade's
-;; `:begin-fetch` action.
+;; The reusable child machine. One spec, four instances. Each instance
+;; carries its own `:data` map (`:parent-id`, `:child-id`, `:staging-key`,
+;; `:url`) planted by the parent's per-child `:data` fn. The child spawns in
+;; `:idle`; the runtime synthesises a `:rf.machine.spawn/spawned` event that
+;; moves it to `:loading`, which fires the `:begin-fetch` entry action.
 
 (rf/reg-machine :boot/loader
   {:initial :idle
-   ;; Validates each spawned loader's initial `:data` at spawn time,
-   ;; before the snapshot installs (Spec 005 §Schema validation
-   ;; §Spawn-time validation). The loader is only ever spawned (one
-   ;; instance per asset, gensym'd id e.g. `:boot/loader#0`), so its
-   ;; snapshot lives at a per-instance path no fixed `reg-app-schema`
-   ;; can reach — the machine `[:schemas :data]` slot is the mechanism that
-   ;; boundary-checks the spawn. The per-child `:data` fn (see :app/boot
-   ;; below) replaces this base map with the planted identity at spawn.
+   ;; Validate each spawned loader's `:data` at spawn time. The loader is
+   ;; only ever spawned (one instance per asset, with a generated id like
+   ;; `:boot/loader#0`), so its snapshot sits at a per-instance path no
+   ;; fixed app-schema can reach. The machine `[:schemas :data]` slot
+   ;; checks `:data` instead. The per-child `:data` fn (see :app/boot below)
+   ;; replaces this base map with the planted identity at spawn.
    :schemas {:data schema/LoaderData}
    :data    {:parent-id   nil
              :child-id    nil
@@ -137,12 +116,10 @@
 
    :actions
    {:begin-fetch
-    ;; Issue the GET. The reply addressing routes back to THIS child
-    ;; (self-dispatch via :rf/self-id, which the spawn fx stamps
-    ;; into :data per Spec 005 §Spec-spec keys — always present).
-    ;; The reply lands at the FSM's `:asset/replied` inner event so
-    ;; the FSM branches on success vs failure before forwarding to
-    ;; the parent.
+    ;; Issue the GET. The reply routes back to THIS child via
+    ;; :rf/self-id, which the spawn fx stamps into :data. The reply lands
+    ;; at the machine's `:asset/replied` event, so the machine branches on
+    ;; success vs failure before forwarding to the parent.
     (fn [{data :data}]
       (let [self-id (:rf/self-id data)]
         {:fx [[:rf.http/managed
@@ -153,36 +130,35 @@
 
     :dispatch-done
     ;; Terminal-state entry. First write the loaded payload into
-    ;; [:boot/staging <staging-key>], then dispatch the child-completion
-    ;; event back to the parent. The completion event carries both the
-    ;; child-id AND the loaded payload:
+    ;; [:boot/staging <staging-key>], then dispatch the completion event
+    ;; back to the parent. The completion event carries both the child-id
+    ;; and the payload:
     ;;   - In :configuring (a single :spawn), this event lands in the
-    ;;     parent's :on lookup, where the :promote-staged action reads
-    ;;     the payload off the event to thread `:api-base` into the
-    ;;     next phase (mechanism 3 → mechanism 2).
+    ;;     parent's :on lookup, where :promote-staged reads the payload
+    ;;     off the event to thread `:api-base` into the next phase.
     ;;   - In :loading-deps (a :spawn-all), the runtime intercepts this
-    ;;     event for join bookkeeping ONLY — it is NOT fed into the
-    ;;     parent's :on lookup (per Spec 005). Those payloads reach the
-    ;;     parent via the staging slot the parent reads in
-    ;;     :enter-hydrating. The event payload is harmless there.
+    ;;     event for join bookkeeping only — it is NOT fed into the
+    ;;     parent's :on lookup. Those payloads reach the parent via the
+    ;;     staging slot read in :enter-hydrating. The event payload is
+    ;;     harmless there.
     (fn [{data :data}]
       {:fx [[:dispatch [:boot/stage-payload (:staging-key data) (:payload data)]]
             [:dispatch [(:parent-id data)
                         [:boot/asset-loaded (:child-id data) (:payload data)]]]]})
 
     :dispatch-error
-    ;; Terminal failure-state entry. Forwards the failure to the
-    ;; parent's :on-child-error slot; the parent's :on-any-failed
-    ;; routes it onward to `:failed`.
+    ;; Terminal failure-state entry. Forwards the failure to the parent's
+    ;; :on-child-error slot; the parent's :on-any-failed routes it to
+    ;; `:failed`.
     (fn [{data :data}]
       {:fx [[:dispatch [(:parent-id data)
                         [:boot/asset-failed (:child-id data) (:error data)]]]]})}
 
    :states
-   {;; :idle is the FSM's :initial. The spawn-fx synthesises a
-    ;; [:rf.machine.spawn/spawned] event into the new actor if no :start is
-    ;; supplied — :idle's transition picks it up and moves to :loading,
-    ;; which fires the entry-cascade's :begin-fetch action.
+   {;; :idle is the :initial state. The spawn fx synthesises a
+    ;; [:rf.machine.spawn/spawned] event into the new child; :idle's
+    ;; transition picks it up and moves to :loading, which fires the
+    ;; :begin-fetch entry action.
     :idle
     {:on {:rf.machine.spawn/spawned :loading}}
 
@@ -191,9 +167,9 @@
      :on    {:asset/replied
              ;; Guarded fork on the reply kind: the first branch whose
              ;; `:guard` passes wins. The runtime appends the reply payload
-             ;; as the LAST element of the event vector, so the event arrives
+             ;; as the last element of the event vector, so the event arrives
              ;; as [:asset/replied :success {:kind :success :value ...}]
-             ;; — we pick the value out from the 3rd-position arg.
+             ;; — pick the value out of the 3rd-position arg.
              [{:guard (fn [{ev :event}] (= :success (nth ev 1 nil)))
                :target :done
                :action (fn [{data :data [_ _ reply] :event}]
@@ -211,13 +187,10 @@
 
 (rf/reg-machine :app/boot
   {:initial :configuring
-   ;; Validates the `:app/boot` snapshot's `:data` slot at the
-   ;; `:where :machine-data` boundary (Spec 010 §Per-step recovery,
-   ;; row 7 — machine `:data` + Spec 005 §Schema validation). `BootData`
-   ;; describes `:data` only —
-   ;; the singleton's snapshot is runtime-db, so its `[:schemas :data]` (not
-   ;; an `reg-app-schema`) is the snapshot-validation surface, symmetric
-   ;; with the `:boot/loader` child above.
+   ;; Validate the `:app/boot` snapshot's `:data` slot. `BootData`
+   ;; describes `:data` only. The snapshot lives in runtime-db, so its
+   ;; `[:schemas :data]` slot is the validation surface (not an
+   ;; app-schema), same as the `:boot/loader` child above.
    :schemas {:data schema/BootData}
    :data    {:phase  :configuring
              :config nil
@@ -232,53 +205,42 @@
       {:data (assoc data :error failure)})
 
     :promote-staged
-    ;; Runs on the :configuring → :loading-deps transition. The single
-    ;; config child carried its loaded payload on the
-    ;; `:boot/asset-loaded` completion event (a single :spawn's
-    ;; completion event IS fed into the parent's :on lookup — only
-    ;; :spawn-all join events are intercepted), so this action reads
-    ;; the config straight off the event and records it into the boot
-    ;; machine's own :data slot. The next phase's spawn-spec `:data`
-    ;; fns then thread host config (here, the loaded `:api-base`) into
-    ;; each child's URL. This is the canonical Pattern-Boot parameter
-    ;; shape: mechanism 3 (boot reads host config) → mechanism 2 (the
-    ;; spawn-spec `:data` fn reads the parent's post-action snapshot).
-    ;; The :data fn-form sees the value because the transition's
-    ;; `:action` runs before the spawn-spec `:data` fn materialises
-    ;; (Spec 005 §Spec-spec keys — the snapshot is post-action).
+    ;; Runs on the :configuring → :loading-deps transition. The config
+    ;; child carried its payload on the `:boot/asset-loaded` completion
+    ;; event (a single :spawn's completion event IS fed into the parent's
+    ;; :on lookup), so this action reads the config off the event and
+    ;; records it into the boot machine's :data. The next phase's `:data`
+    ;; fns then read the loaded `:api-base` and build each child's URL
+    ;; from it. The transition's `:action` runs before the child `:data`
+    ;; fns, so they see the value in the parent's snapshot.
     (fn [{data :data [_ _child-id config] :event}]
       {:data (assoc data :config config)})
 
     :enter-hydrating
-    ;; Read all the staged payloads out of [:boot/staging ...] and
-    ;; write them into the canonical top-level slices the running
-    ;; app's subs read. Self-transitions to `:ready` once the
-    ;; hydration write lands.
+    ;; Read the staged payloads out of [:boot/staging ...] and write them
+    ;; into the top-level slices the running app's subs read. Self-
+    ;; transitions to `:ready` once the hydration write lands.
     (fn [{data :data}]
       {:data (assoc data :phase :hydrating)
        :fx   [[:dispatch [:boot/apply-hydration]]]})}
 
    :states
    {;; ---- :configuring — the :initial state; a single :spawn fetches /config
-    ;; Per Pattern-Boot the boot machine is BORN directly into its first
-    ;; work state. The init-kick `[:app/boot [:rf.machine/start]]` is a
-    ;; PURE creation marker (Spec 005 §Synthetic creation marker —
-    ;; `[:rf.machine/start]`): it
-    ;; runs the initial-entry cascade — here `:configuring`'s `:spawn` —
-    ;; and STOPS; it is NEVER fed into an `:on` map as a trigger. So there
-    ;; is no `:idle` parking spot and no start-marker transition: the
-    ;; machine starts working the moment it is kicked.
+    ;; The boot machine is born directly into its first work state. The
+    ;; kick `[:app/boot [:rf.machine/start]]` is a creation marker: it runs
+    ;; the initial-entry cascade — here `:configuring`'s `:spawn` — and
+    ;; stops. It is never fed into an `:on` map as a trigger, so there is no
+    ;; `:idle` parking spot: the machine starts working the moment it is
+    ;; kicked.
     :configuring
     {:spawn {:machine-id :boot/loader
-              ;; Per Spec 005 §Spec-spec keys, `:data` admits a
-              ;; function form `(fn [{:keys [snapshot event]}] data)`
-              ;; so the child's initial :data can depend on the
-              ;; parent's snapshot at the moment of entry. We plant the
-              ;; identity (parent / child / staging-key / URL) here —
-              ;; mechanism 2 (parameter passing via the spawn-spec
-              ;; :data fn). This first URL is the host-fixed config
-              ;; endpoint — the mechanism-3 SOURCE the rest of the boot
-              ;; threads from, so it is a literal, not derived.
+              ;; `:data` admits a function form
+              ;; `(fn [{:keys [snapshot event]}] data)`, so the child's
+              ;; initial :data can depend on the parent's snapshot at the
+              ;; moment of entry. Plant the identity (parent / child /
+              ;; staging-key / URL) here. This first URL is the fixed config
+              ;; endpoint — the source the rest of the boot threads from —
+              ;; so it is a literal, not derived.
               :data       (fn boot-config-data [_]
                             {:parent-id   :app/boot
                              :child-id    :config
@@ -293,23 +255,17 @@
     :loading-deps
     {:spawn-all
      {:children
-      ;; Each child is the same :boot/loader machine, distinguished
-      ;; only by its :data slot. The :data fn-form reads the
-      ;; parent's promoted `:api-base` (recorded into the parent's
-      ;; :data by the :promote-staged action on the
-      ;; :configuring → :loading-deps transition) and threads it into
-      ;; each child's URL. This demonstrates the canonical
-      ;; Pattern-Boot parameter shape end-to-end: mechanism 3 (boot
-      ;; reads host config) → mechanism 2 (the spawn-spec :data fn
-      ;; reads the parent's post-action snapshot).
+      ;; Each child is the same :boot/loader machine, distinguished only
+      ;; by its :data slot. Each :data fn reads the parent's `:api-base`
+      ;; (recorded by :promote-staged on the way into this state) and
+      ;; builds the child's URL from it.
       [{:id         :routes
         :machine-id :boot/loader
         :data       (fn boot-routes-data [{snap :snapshot}]
-                      ;; The :data fn receives the unified
-                      ;; context-map `{:snapshot :event}` — the
-                      ;; snapshot is the PARENT's post-action value,
-                      ;; not app-db. `:promote-staged` already ran, so
-                      ;; the loaded `:api-base` is visible here.
+                      ;; The :data fn receives `{:snapshot :event}`. The
+                      ;; snapshot is the parent's value, not app-db.
+                      ;; :promote-staged already ran, so the loaded
+                      ;; `:api-base` is visible here.
                       {:parent-id   :app/boot
                        :child-id    :routes
                        :staging-key :routes
@@ -344,17 +300,14 @@
 
     ;; ---- :ready / :failed — terminal -------------------------------------
     :ready  {:meta {:terminal? true}}
-    :failed {;; Per Pattern-Boot §Re-boot semantics, :failed is
-             ;; re-entrant — dispatching the explicit re-entry event
-             ;; `[:app/boot [:boot/restart]]` from the failure screen
-             ;; re-runs the boot from :configuring. Re-boot uses a REAL
-             ;; event, NOT the `:rf.machine/start` creation marker: the
-             ;; marker is a pure init-kick that is never fed into an `:on`
-             ;; map (Spec 005 §Synthetic creation marker), so once the
-             ;; machine exists a start marker is inert. The terminal? meta is still true so
-             ;; visualisers / conformance harnesses see :failed as a
-             ;; terminal state; the re-entry transition is the explicit
-             ;; re-boot, not the default end of the flow.
+    :failed {;; :failed is re-entrant: dispatching `[:app/boot [:boot/restart]]`
+             ;; from the failure screen re-runs the boot from :configuring.
+             ;; Re-boot uses a real event, not the `:rf.machine/start`
+             ;; creation marker — the marker is never fed into an `:on` map,
+             ;; so once the machine exists it is inert. The terminal? meta
+             ;; stays true so visualisers and conformance harnesses see
+             ;; :failed as a terminal state; the re-entry transition is the
+             ;; explicit re-boot, not the default end of the flow.
              :meta {:terminal? true}
              :on   {:boot/restart {:target :configuring
                                    :action (fn [{data :data}]
@@ -364,33 +317,27 @@
 ;; HYDRATION PROMOTION
 ;; ============================================================================
 ;;
-;; A plain reg-event does the cross-slice writes the boot
-;; machine's :hydrating action dispatches. Keeping the cross-slice
-;; reads / writes in an explicit handler (not inside the machine's
-;; action body) makes the boot trace one-step inspectable: the
-;; machine's `:enter-hydrating` action is one trace; the
-;; :boot/apply-hydration handler is another.
+;; A plain reg-event does the cross-slice writes the boot machine's
+;; :hydrating action dispatches. Keeping these reads and writes in an
+;; explicit handler (not in the machine's action body) makes the boot trace
+;; one step at a time: `:enter-hydrating` is one trace, this handler another.
 
 (rf/reg-event :boot/apply-hydration
   {:doc "Promote every staged child payload at [:boot/staging ...]
-         into the canonical top-level app-db slices the running app
-         reads. Fires :boot/hydrated back at :app/boot to transition
-         from :hydrating to :ready."}
-  ;; EP-0001: the app slices land in app-db (`:db`); the boot
-  ;; machine's snapshot is durable runtime-db state, so the snapshot mirror
-  ;; is a `:rf.db/runtime` effect (the reference handler is framework-shaped
-  ;; example code — emitting the reserved runtime-db effect is in-bounds,
-  ;; decision #4).
+         into the top-level app-db slices the running app reads. Fires
+         :boot/hydrated back at :app/boot to transition from :hydrating
+         to :ready."}
+  ;; The app slices land in app-db (`:db`); the boot machine's snapshot is
+  ;; runtime-db state, so the snapshot mirror below is a `:rf.db/runtime`
+  ;; effect (docs/guide/glossary.md#runtime-db).
   ;;
   ;; ADVANCED — runtime-db writes are NOT an everyday-app pattern. This is the
-  ;; ONLY handler in the whole examples tree that returns a `:rf.db/runtime`
-  ;; effect, and deliberately so: it teaches the hydration REFERENCE shape
-  ;; (mirroring loaded values into a machine snapshot so the snapshot is
-  ;; self-describing for SSR / tools). Ordinary app handlers write app-db via
-  ;; `:db` only and let the machine runtime own its own snapshot; reach for a
-  ;; `:rf.db/runtime` effect only when you are intentionally authoring
-  ;; framework-shaped boot/hydration glue, with the reserved-key contract
-  ;; (Conventions §Reserved app-db keys / runtime-db) clearly in view.
+  ;; only handler in the examples tree that returns a `:rf.db/runtime` effect,
+  ;; deliberately: it teaches the hydration reference shape (mirroring loaded
+  ;; values into a machine snapshot so the snapshot is self-describing for
+  ;; SSR and tools). Ordinary app handlers write app-db via `:db` only and let
+  ;; the machine runtime own its snapshot; reach for `:rf.db/runtime` only
+  ;; when you are intentionally authoring boot/hydration glue.
   (fn handler-boot-apply-hydration [{:keys [db] rt :rf.db/runtime} _]
     (let [staging (:boot/staging db)]
       {:db (-> db
@@ -399,7 +346,7 @@
                (assoc :user   (:user staging))
                (assoc :routes (:routes staging)))
        ;; Mirror the loaded values into the boot machine's :data slice so the
-       ;; snapshot is self-describing for SSR / tools / pair-tools inspection.
+       ;; snapshot is self-describing for SSR and tools.
        :rf.db/runtime (update-in (or rt {})
                                  [:rf.runtime/machines :snapshots :app/boot :data] assoc
                                  :config (:config staging)
@@ -414,11 +361,11 @@
 
 (rf/reg-event :boot/initialise
   {:doc "Top-level app boot. Fires the :app/boot machine's
-         `:rf.machine/start` creation marker to kick the boot sequence
-         off — the machine is born directly into `:configuring` and runs
-         its `:spawn` entry-cascade. The app seeds this event via the
-         render-root `frame-provider`'s `:initial-events` (see core.cljs),
-         which runs it once on first mount."}
+         `:rf.machine/start` creation marker to kick the boot off — the
+         machine is born directly into `:configuring` and runs its
+         `:spawn` entry cascade. The app seeds this event via the
+         frame-provider's `:initial-events` (see core.cljs), which runs
+         it once on first mount."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:app/boot [:rf.machine/start]]]]}))
 
@@ -426,8 +373,8 @@
 ;; SUBS — boot-state slots the views read
 ;; ============================================================================
 
-;; EP-0001: machine snapshots are durable runtime-db state — read
-;; them through the framework `:rf/machine` sub.
+;; Machine snapshots are runtime-db state — read them through the
+;; framework `:rf/machine` sub (docs/machines/glossary.md#snapshot).
 (rf/reg-sub :app.boot/snapshot
   :<- [:rf/machine :app/boot]
   (fn [snapshot _] snapshot))

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -1,11 +1,12 @@
 (ns boot.core
-  "Entry point for the boot example — Pattern-Boot demonstrated.
+  "Entry point for the boot example.
 
    `run` installs the Reagent adapter and renders the app under a
-   `frame-provider`. The provider redirects HTTP to a per-URL canned
-   stub (so the example runs standalone — no backend) and seeds the boot
-   machine on first mount. The root view stays on the boot-progress
-   screen until the boot machine reaches `:ready`.
+   frame-provider (docs/guide/glossary.md#frame-provider). The provider
+   redirects HTTP to a per-URL canned stub (so the example runs
+   standalone — no backend) and seeds the boot machine on first mount.
+   The root view stays on the boot-progress screen until the boot
+   machine reaches `:ready`.
 
    The four mocked endpoints:
      /api/config.json   → static app config (api-base, env, build)
@@ -13,27 +14,23 @@
      /api/flags.json    → feature flags
      /api/user.json     → initial user record
 
-   The stub fx routes by URL substring and delegates to the
-   framework-shipped `:rf.http/managed-canned-success` per Spec 014
-   §Testing, so the canonical reply shape is preserved."
+   The stub routes by URL substring and delegates to the framework's
+   `:rf.http/managed-canned-success`, so the reply shape matches what a
+   live server would produce (docs/resources/glossary.md#reply-map)."
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Required for `rf/init!`.
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; Managed-HTTP ships in day8/re-frame2-http. The require
-            ;; triggers its fx registrations (:rf.http/managed and
-            ;; family) at app boot; without it, the child loaders'
-            ;; managed-HTTP dispatches would raise :rf.error/no-such-fx.
+            ;; Managed HTTP ships in a separate artefact. The require
+            ;; registers `:rf.http/managed` and family; without it the
+            ;; child loaders' dispatches would raise :rf.error/no-such-fx.
             [re-frame.http.managed]
-            ;; This example overrides :rf.http/managed with a per-URL
-            ;; stub that delegates to :rf.http/managed-canned-success
-            ;; (the same reply shape a live server would produce). The
-            ;; canned-stub fx ids register from
-            ;; re-frame.http.test-support, NOT from re-frame.http.managed.
-            ;; This example IS a test/demo affordance (no real backend
-            ;; ships with it), so requiring the test-support ns is
-            ;; correct — it's the explicit opt-in for the canned stubs.
+            ;; This example overrides :rf.http/managed with a per-URL stub
+            ;; that delegates to :rf.http/managed-canned-success (the same
+            ;; reply shape a live server produces). The canned-stub fx ids
+            ;; register from re-frame.http.test-support, so require it here
+            ;; to opt into the canned stubs.
             [re-frame.http.test-support]
             [boot.schema]
             [boot.boot]
@@ -43,13 +40,12 @@
 ;; DEMO STUBS — per-URL canned :rf.http/managed override
 ;; ============================================================================
 ;;
-;; The boot example would normally hit /api/config.json and three more
-;; endpoints; we don't ship a backend. This section defines the canned
-;; payloads and the `:boot.demo/http-stub` fx that returns one per URL
-;; substring. The provider in `run` wires this stub in as the frame's
-;; `:rf.http/managed` via `:fx-overrides`. Each reply delegates to
-;; `:rf.http/managed-canned-success` (Spec 014 §Testing) — the same
-;; reply shape a live server would produce.
+;; The boot fetches /api/config.json and three more endpoints, but no backend
+;; ships with this example. This section defines the canned payloads and the
+;; `:boot.demo/http-stub` fx that returns one per URL substring. The provider
+;; in `run` wires this stub in as the frame's `:rf.http/managed` via
+;; `:fx-overrides`. Each reply delegates to `:rf.http/managed-canned-success`,
+;; the same reply shape a live server produces.
 
 (def ^:private demo-config
   {:api-base "/api"
@@ -82,11 +78,10 @@
       :else                            {})))
 
 (rf/reg-event :boot.demo/schedule-reply
-  {:doc "Private — entered via dispatch from :boot.demo/http-stub. Uses
-         `:dispatch-later` so framework time controls (Tool-Pair
-         time-travel, the documented `:dispatch-later` nil-override
-         seam) apply to the demo latency. No user dispatches this
-         directly."}
+  {:doc "Private — dispatched from :boot.demo/http-stub. Uses
+         `:dispatch-later` so framework time controls (time-travel,
+         the `:dispatch-later` override seam) apply to the demo
+         latency. No user dispatches this directly."}
   (fn handler-boot-demo-schedule-reply [_ [_ args-map payload]]
     {:fx [[:dispatch-later
            {:ms    60
@@ -94,7 +89,7 @@
 
 (rf/reg-event :boot.demo/deliver-reply
   {:doc "Private — fired by the :dispatch-later scheduled in
-         :boot.demo/schedule-reply. Delegates to the framework-shipped
+         :boot.demo/schedule-reply. Delegates to the framework's
          `:rf.http/managed-canned-success` with the per-URL canned
          payload."}
   (fn handler-boot-demo-deliver-reply [_ [_ args-map payload]]
@@ -105,19 +100,16 @@
                substring to canned boot responses so the example runs
                standalone without a backend.
 
-               Dispatches into the private :boot.demo/schedule-reply
-               event so the deferred reply rides framework
-               `:dispatch-later` (60 ms) rather than raw
-               `js/setTimeout`. The delay lets the boot-progress view
-               render the per-phase loading state before the replies
-               land — without it, the boot resolves in one drain and
-               the user only ever sees the `:ready` screen. The reply
-               itself lands via the framework-shipped
-               `:rf.http/managed-canned-success` (Spec 014 §Testing).
+               Dispatches the private :boot.demo/schedule-reply event so
+               the deferred reply rides `:dispatch-later` (60 ms) rather
+               than raw `js/setTimeout`. The delay lets the boot-progress
+               view render the per-phase loading state before the replies
+               land — without it the boot resolves in one drain and the
+               user only ever sees the `:ready` screen. The reply lands
+               via the framework's `:rf.http/managed-canned-success`.
 
-               Framework time controls (Tool-Pair time-travel, the
-               documented `:dispatch-later` nil-override seam) apply
-               automatically."
+               Framework time controls (time-travel, the
+               `:dispatch-later` override seam) apply automatically."
    :platforms #{:server :client}}
   (fn fx-managed-boot-demo [frame-ctx args-map]
     (let [url     (-> args-map :request :url)
@@ -130,16 +122,15 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root, held in an atom and created lazily inside `run`. Doing
-;; it in `run` (not at ns-load) lets several example namespaces share the
+;; The React root, held in an atom and created lazily inside `run`. Doing it
+;; in `run` (not at ns-load) lets several example namespaces share the
 ;; browser-test bundle without racing `create-root` onto the same `#app`
 ;; element.
 (defonce react-root (atom nil))
 
-;; The app frame id. Every in-tree `dispatch`/`subscribe` resolves to
-;; this frame. The render-root `frame-provider` below establishes it
-;; (see `run`). EP-0002: an app must name its frame explicitly; the
-;; runtime never invents one.
+;; The app frame id. Every in-tree `dispatch`/`subscribe` resolves to this
+;; frame; the frame-provider below establishes it (see `run`). An app must
+;; name its frame explicitly — the runtime never invents one.
 (def app-frame :rf/default)
 
 (defn run []
@@ -149,8 +140,8 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; The `frame-provider` below creates, configures, and seeds the app
-    ;; frame in one place (the `{:id …}` ENSURE form):
+    ;; The frame-provider creates, configures, and seeds the app frame in
+    ;; one place:
     ;;
     ;; - `:fx-overrides` redirects `:rf.http/managed` on this frame to the
     ;;   per-URL canned stub above, so every child loader's GET hits a

--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -1,45 +1,35 @@
 (ns boot.schema
-  "Malli schemas for the boot example.
+  "Malli schemas for the boot example. See schemas in the guide
+   (docs/guide/glossary.md#schema).
 
-   The example demonstrates Pattern-Boot: a single boot state machine
-   owns the initialisation graph. Three parallel sub-fetches (config,
-   feature flags, initial user) run via `:spawn-all`; the boot
-   machine reaches `:ready` only when every child reports done. The
-   schemas describe the wire shape returned by each mocked endpoint,
-   the boot-machine snapshot itself, and the child loader's `:data`.
+   The schemas describe three things: the wire shape each mocked
+   endpoint returns, the boot-machine snapshot's `:data`, and the child
+   loader's `:data`.
 
-   Two schema surfaces appear here, picked by what each schema validates
-   (Spec 010 §Per-step recovery, row 7 — machine `:data` +
-   Spec 005 §Schema validation):
+   Two kinds of schema surface appear, picked by what each one validates:
 
    - **App-db slices** — the `[:boot/staging]` slot and the four
      top-level slices (`[:config]`, `[:flags]`, `[:user]`, `[:routes]`)
-     live at fixed app-db paths, so they are attached with
-     `rf/reg-app-schema` on those paths; app schemas validate the app-db
-     partition ONLY.
-   - **Machine `:data`** — both the singleton `:app/boot` machine and the
-     spawned `:boot/loader` child declare a top-level `[:schemas :data]` on
-     `reg-machine` (see `boot.cljs`) that validates the snapshot's `:data`
-     slot at the `:where :machine-data` boundary. `BootData` describes the
-     `:app/boot` machine's `:data`; `LoaderData` describes each spawned
-     loader's `:data` (validated at spawn time, before the snapshot
-     installs — Spec 005 §Schema validation §Spawn-time validation —
-     since a spawned loader's gensym'd id, e.g. `:boot/loader#0`, lives at
-     a per-instance path no fixed `reg-app-schema` could reach). Machine
-     snapshots are runtime-db, not app-db, so `reg-app-schema` is NOT the
-     surface for them."
+     live at fixed app-db paths, so they attach with `rf/reg-app-schema`
+     on those paths. App schemas validate the app-db partition only.
+   - **Machine `:data`** — both the `:app/boot` machine and the spawned
+     `:boot/loader` child declare a `[:schemas :data]` slot on
+     `reg-machine` (see `boot.cljs`) that validates the snapshot's `:data`.
+     `BootData` describes the `:app/boot` machine's `:data`; `LoaderData`
+     describes each spawned loader's `:data`, validated at spawn time. A
+     spawned loader gets a generated id like `:boot/loader#0`, so its
+     snapshot sits at a per-instance path no fixed `reg-app-schema` could
+     reach. Machine snapshots live in runtime-db, not app-db, so
+     `reg-app-schema` is not the surface for them
+     (docs/guide/glossary.md#runtime-db)."
   (:require [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
-            ;; rf/reg-app-schema resolves at the call sites below.
+            ;; Schemas ship in a separate artefact. The require registers
+            ;; `rf/reg-app-schema`.
             [re-frame.schemas]
-            ;; The CLJS default validator routes through the
-            ;; late-bind hook `:schemas/malli-validate`, which the
-            ;; `re-frame.schemas.malli` adapter ns publishes at load
-            ;; time. The require is the canonical CLJS opt-in for
-            ;; Malli validation — without it, the default validator
-            ;; soft-passes per Spec 010 §Recommended soft-pass and
-            ;; no failure trace fires for malformed app-db slices.
+            ;; The Malli adapter ns publishes the default validator. The
+            ;; require is the CLJS opt-in for Malli validation — without it
+            ;; the default validator soft-passes and no failure trace fires
+            ;; for malformed app-db slices.
             [re-frame.schemas.malli])
   (:require-macros [re-frame.core :refer [with-frame]]))
 
@@ -87,19 +77,16 @@
 ;; BOOT-MACHINE :data SHAPE — :app/boot
 ;; ============================================================================
 ;;
-;; The boot machine lives in runtime-db at
-;; [:rf.runtime/machines :snapshots :app/boot]. Its `:state` cycles
+;; The boot machine's snapshot lives in runtime-db. Its `:state` cycles
 ;; `:configuring → :loading-deps → :hydrating → :ready` (terminal), with
 ;; `:failed` (terminal) reached if any child errors. `:data` carries the
 ;; per-phase progress slot and the loaded payloads.
 ;;
-;; `BootData` describes the `:data` SLOT only (Spec 005 §Schema
-;; validation — the machine `[:schemas :data]` validates `:data`, not the whole
-;; `{:state … :data …}` snapshot and not an app-db path). It is attached
-;; via the `:app/boot` machine's top-level `[:schemas :data]` on `reg-machine`
-;; (see `boot.cljs`) and validates at the `:where :machine-data` boundary.
-;; Every payload slot is `:maybe` because they are nil through the
-;; staging/loading phases and only fill on entering `:hydrating`.
+;; `BootData` describes the `:data` slot only, not the whole
+;; `{:state … :data …}` snapshot. It attaches via the `:app/boot` machine's
+;; `[:schemas :data]` slot on `reg-machine` (see `boot.cljs`). Every payload
+;; slot is `:maybe` because they are nil through the staging/loading phases
+;; and only fill on entering `:hydrating`.
 
 (def BootData
   [:map
@@ -114,36 +101,32 @@
 ;; CHILD LOADER :data SHAPE — :boot/loader (one instance per asset)
 ;; ============================================================================
 ;;
-;; The `:data` slot of the generic `:boot/loader` child machine. Each
-;; loader holds the parent-id + child-id + staging-key + URL it was
-;; spawned with, fetches once, and dispatches `:boot/asset-loaded` (or
-;; `:boot/asset-failed`) back to its parent on transition into `:done`
-;; (or `:failed`). Attached via the child machine's `[:schemas :data]` slot on
-;; `(reg-machine :boot/loader ...)` in `boot.cljs` — the runtime owns
-;; the surrounding snapshot, so the machine `[:schemas :data]` describes `:data`
-;; only (Spec 005 §Schema validation) and validates each spawned
-;; instance's initial `:data` at spawn time, regardless of its gensym'd
-;; id. The per-child `:data` fn (see :app/boot) plants identity only, so
-;; the fetch-result fields below are optional — they appear later, as
-;; the loader transitions through `:loading` into `:done` / `:failed`.
+;; The `:data` slot of the `:boot/loader` child machine. Each loader holds
+;; the parent-id + child-id + staging-key + URL it was spawned with, fetches
+;; once, and dispatches `:boot/asset-loaded` (or `:boot/asset-failed`) back
+;; to its parent on transition into `:done` (or `:failed`). Attached via the
+;; child machine's `[:schemas :data]` slot on `(reg-machine :boot/loader ...)`
+;; in `boot.cljs`; it describes `:data` only and validates each spawned
+;; instance's initial `:data` at spawn time. The per-child `:data` fn (see
+;; :app/boot) plants identity only, so the fetch-result fields below are
+;; optional — they appear later, as the loader moves through `:loading` into
+;; `:done` / `:failed`.
 
 (def LoaderData
   [:map
-   ;; Identity, planted by the parent's per-child spawn-spec `:data` fn —
-   ;; present from spawn (see :app/boot in boot.cljs).
+   ;; Identity, planted by the parent's per-child `:data` fn — present from
+   ;; spawn (see :app/boot in boot.cljs).
    [:parent-id   :keyword]
    [:child-id    :keyword]
    [:staging-key :keyword]
    [:url         :string]
    ;; Filled in only once the fetch replies (the `:asset/replied` action
-   ;; writes :payload or :error). Absent at spawn — the per-child `:data`
-   ;; fn plants identity only — so both are optional.
+   ;; writes :payload or :error). Absent at spawn, so both are optional.
    [:payload     {:optional true} :any]
    [:error       {:optional true} [:maybe :any]]
-   ;; Runtime-stamped address keys — the spawn fx stamps these into the
-   ;; spawned actor's initial :data (Spec 005 §Reserved snapshot-internal
-   ;; keys). Optional + declared so the schema documents them; a Malli
-   ;; :map is open, so they'd pass undeclared too.
+   ;; Address keys the spawn fx stamps into the spawned child's initial
+   ;; :data. Declared optional so the schema documents them; a Malli :map is
+   ;; open, so they'd pass undeclared too.
    [:rf/self-id   {:optional true} :any]
    [:rf/parent-id {:optional true} :any]
    [:rf/invoke-id {:optional true} :any]])
@@ -164,38 +147,32 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 
-;; The runtime rolls back post-commit on a failing app-db schema. The
-;; slots below are absent (nil) before the boot machine writes them;
-;; every registration is wrapped in :maybe so the validator passes
-;; during the staging/loading phases.
+;; The runtime rolls back post-commit on a failing app-db schema. The slots
+;; below are nil before the boot machine writes them, so every registration
+;; is wrapped in :maybe to pass during the staging/loading phases.
 
-;; EP-0001: machine snapshots are runtime-db state, not app-db —
-;; an `reg-app-schema` on a machine-snapshot path validates nothing (app
-;; schemas validate the app-db partition only, Mike ruling #11). The
-;; `:app/boot` machine's own `:schemas {:data schema/BootData}` (attached on
-;; `reg-machine` in boot.cljs) is the snapshot-`:data` validation surface,
-;; so no app-schema reg applies to the boot machine snapshot. The
-;; `reg-app-schema` calls below validate only the app-db slices.
+;; Machine snapshots are runtime-db state, not app-db, so a `reg-app-schema`
+;; on a machine-snapshot path would validate nothing. The `:app/boot`
+;; machine's own `:schemas {:data schema/BootData}` (on `reg-machine` in
+;; boot.cljs) is its snapshot-`:data` surface. The `reg-app-schema` calls
+;; below validate only the app-db slices.
 
-;; EP-0002: `reg-app-schema` is context-required frame-local —
-;; a bare ns-load call under no scope raises `:rf.error/no-frame-context`
-;; (boot-time namespace loading is NOT a reason to synthesise `:rf/default`,
-;; per Spec 002 §Frame target resolution). This example's app runs in the
-;; `:rf/default` frame (see `core/run`, whose render-root `frame-provider`
-;; establishes it via the `{:id …}` ENSURE form), so name the frame
-;; explicitly here via `with-frame` — the registrations carry a frame
-;; stamp even though they land at module-load before `init!`.
+;; `reg-app-schema` is frame-local: a bare ns-load call under no scope
+;; raises `:rf.error/no-frame-context`. This example's app runs in the
+;; `:rf/default` frame (see `core/run`), so name the frame explicitly here
+;; via `with-frame` — the registrations carry a frame stamp even though they
+;; land at module-load before `init!`.
 (with-frame :rf/default
   ;; The :spawn-all children stage their payloads into [:boot/staging]
-  ;; before signalling completion to the parent. The :enter-hydrating
-  ;; action reads the staging slot and promotes each payload into the
-  ;; canonical top-level slot below. Registered here so the staging
-  ;; writes are schema-validated like every other slice.
+  ;; before signalling completion. The :enter-hydrating action reads the
+  ;; staging slot and promotes each payload into the top-level slot below.
+  ;; Registered here so the staging writes are schema-validated like every
+  ;; other slice.
   (rf/reg-app-schema [:boot/staging] {:schema [:maybe BootStagingSlice]})
 
-  ;; The boot machine writes its final payloads into top-level app-db
-  ;; slices on entering `:hydrating`. These are the slices the main app
-  ;; reads via subs once the boot reaches `:ready`.
+  ;; The boot machine writes its final payloads into top-level app-db slices
+  ;; on entering `:hydrating`. These are the slices the main app reads via
+  ;; subs once the boot reaches `:ready`.
   (rf/reg-app-schema [:config] {:schema [:maybe Config]})
   (rf/reg-app-schema [:flags]  {:schema [:maybe Flags]})
   (rf/reg-app-schema [:user]   {:schema [:maybe User]})

--- a/examples/reagent/boot/views.cljs
+++ b/examples/reagent/boot/views.cljs
@@ -1,37 +1,34 @@
 (ns boot.views
-  "Views for the boot example.
+  "Views for the boot example. See views in the guide
+   (docs/guide/glossary.md#view).
 
    The view tree has two halves split by the boot state:
 
    1. **Pre-ready** — while the boot machine is in any non-terminal
       state, the root renders a `[boot-progress]` screen showing the
       current phase. The main app view is NOT mounted yet — its
-      subscriptions would read empty slices and have to defend
-      against `nil` everywhere.
+      subscriptions would read empty slices and have to defend against
+      `nil` everywhere.
 
-   2. **Post-ready** — once the boot machine reaches `:ready`, the
-      root swaps in `[main-app]`. The main view freely reads
-      `:config`, `:flags`, `:user`, and `:routes` from app-db; the
-      slices are populated and stable.
+   2. **Post-ready** — once the boot machine reaches `:ready`, the root
+      swaps in `[main-app]`. The main view freely reads `:config`,
+      `:flags`, `:user`, and `:routes` from app-db; the slices are
+      populated and stable.
 
-   The failure path renders `[boot-failed]` (terminal `:failed`),
-   which surfaces the error and offers a retry button. The retry
-   dispatches `[:app/boot [:boot/restart]]` directly back into the boot
-   machine — re-running the boot from `:configuring` is supported
-   per Pattern-Boot §Re-boot semantics (the example treats `:failed`
-   as a re-entrant target rather than terminal-with-reload). Re-boot
-   uses a REAL re-entry event, not the `:rf.machine/start` creation
-   marker — the marker is a pure init-kick and is inert once the
+   The failure path renders `[boot-failed]` (terminal `:failed`), which
+   surfaces the error and offers a retry button. The retry dispatches
+   `[:app/boot [:boot/restart]]` straight back into the boot machine,
+   re-running it from `:configuring`. Re-boot uses a real event, not the
+   `:rf.machine/start` creation marker — the marker is inert once the
    machine already exists.
 
-   Why split the views by boot state: the alternative — mount the
-   main app and let each sub-view render a per-phase loading
-   skeleton — scatters boot logic across the whole view tree. The
-   Pattern-Boot canonical shape consolidates that loading state into
-   the boot machine; the views simply read `:app.boot/ready?`.
+   Splitting the views by boot state keeps all the loading logic in the
+   boot machine. The alternative — mount the main app and let each
+   sub-view render its own per-phase skeleton — scatters that logic
+   across the whole view tree. Here the views just read `:app.boot/ready?`.
 
-   The views are intentionally minimal — the goal is to demonstrate
-   the Pattern-Boot shape, not a polished UI."
+   The views are intentionally minimal — the goal is to show the boot
+   shape, not a polished UI."
   (:require [re-frame.core :as rf]
             [boot.boot])
   (:require-macros [re-frame.core :refer [reg-view]]))

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -1,27 +1,31 @@
 (ns counter.core
-  "The smallest possible re-frame2 app — and so the cleanest place to
-   meet the event cascade. One slice of app-db, three event handlers,
-   one subscription, one view, dispatched in a single explicitly-
-   established frame.
+  "The smallest possible re-frame2 app. One slice of app-db, three event
+   handlers, one subscription, one view, all running in one frame.
 
-   The whole frame is established in one spot: the render root's
-   `frame-provider {:id …}` creates the app frame, configures it, and
-   runs its `:initial-events` seed once.
+   This is the cleanest place to meet the event cascade: a click
+   dispatches an event, a handler returns a new app-db, a subscription
+   re-derives, and the view re-renders. See the guide's
+   `docs/guide/concepts/events-and-the-cascade.md`.
 
-   Demonstrates: `reg-event`, `reg-sub`, `reg-view` with frame-bound
-   `dispatch`/`subscribe` injection."
+   The frame is set up in one spot — the render root's
+   `frame-provider {:id …}` in `run` below creates the app frame and runs
+   its `:initial-events` seed.
+
+   Shows: `reg-event`, `reg-sub`, and `reg-view` with its frame-bound
+   `dispatch`/`subscribe`."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core    :as rf]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
-;; -- Events / subs (the registrar is process-global) -------------------------
+;; -- Events / subs -----------------------------------------------------------
 ;;
-;; Each handler is a pure (coeffects, event-vector) -> effect map fn. It
-;; returns a description of the change — `{:db …}` means "replace app-db
-;; with this" — and the runtime commits it atomically at the end of the
-;; cascade. The handler computes the new value; it never mutates app-db.
+;; An event handler is a pure function: it takes coeffects (which carry the
+;; current app-db) and the event vector, and returns an effect map. The
+;; `{:db …}` key means "replace app-db with this value". The runtime
+;; commits that value atomically. The handler computes the new value; it
+;; never mutates app-db. See `docs/guide/glossary.md#event-handler`.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -37,16 +41,16 @@
 
 ;; -- Views -------------------------------------------------------------------
 ;;
-;; A view is a pure fn from subscription values to hiccup. This one reads
-;; state by dereffing a `subscribe` and dispatches an event on click. It
-;; holds no business logic — the inc/dec live in the handlers above.
+;; A view is a pure function from subscription values to hiccup. This one
+;; reads state by dereffing a `subscribe` and dispatches an event on click.
+;; It holds no business logic — the inc/dec live in the handlers above.
 ;;
-;; `reg-view` (Spec 004 §reg-view) auto-injects `dispatch` and `subscribe`
-;; as lexical bindings, so they need no require here. Both resolve at
-;; render time to the frame in scope — the `frame-provider` in the boot
-;; below scopes this tree to the app frame. `reg-view` also defs a Var
-;; named after the symbol and registers the view under (keyword *ns* sym),
-;; so `counter-app` can reference `counter-buttons` directly.
+;; `reg-view` makes `dispatch` and `subscribe` available in the body as
+;; local bindings, so they need no require here. Both resolve at render
+;; time to the frame in scope — the `frame-provider` in `run` below scopes
+;; this tree to the app frame. `reg-view` also defines a Var named after
+;; the symbol, so `counter-app` can reference `counter-buttons` directly.
+;; See `docs/guide/concepts/views.md`.
 
 (reg-view counter-buttons []
   [:div
@@ -54,36 +58,39 @@
    [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:counter/value])]
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
-;; The root `counter-app` view just renders `counter-buttons`. The boot in
-;; `run` wraps this tree in the `frame-provider` that establishes the frame.
+;; The root `counter-app` view just renders `counter-buttons`. `run` wraps
+;; this tree in the `frame-provider` that establishes the frame.
 
 (reg-view counter-app []
   [counter-buttons])
 
 ;; -- Mount -------------------------------------------------------------------
 ;;
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. Loading a namespace must produce no DOM side effects, so that
+;; co-required example namespaces don't race `create-root` onto the shared
+;; `#app`. See examples/TESTING.md, "mount-isolation".
 
 (defonce react-root (atom nil))
 
-;; The whole frame lifecycle lives in one spot at the render root: the
-;; `frame-provider {:id app-frame …}` below. On first mount it creates the
-;; app frame, applies its config, and runs `:initial-events` once to seed
-;; app-db. Thereafter every `dispatch`/`subscribe` in the tree resolves to
-;; that frame. On hot reload the provider reuses the existing frame and
-;; skips re-seeding, so the counter keeps its value across re-mounts.
+;; The whole frame lifecycle lives in one spot: the `frame-provider {:id
+;; app-frame …}` in `run` below. The first mount creates the app frame and
+;; runs its `:initial-events` once to seed app-db. From then on every
+;; `dispatch`/`subscribe` in the tree resolves to that frame. A later mount
+;; under the same `:id` (a hot reload) reuses the live frame and does not
+;; re-seed, so the counter keeps its value. See
+;; `docs/guide/concepts/frames.md`.
 ;;
 ;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
-;; with no framework privilege — the runtime won't infer it, so we name it
-;; here and hand it to the provider like any other id.
+;; with no special status: the runtime never infers a frame, so we name one
+;; here and hand it to the provider. See
+;; `docs/guide/glossary.md#frame-identity-is-carried-not-found`.
 (def app-frame :rf/default)
 
 (defn run []
   ;; `init!` installs the reactive adapter for the process. Each adapter ns
-  ;; exports an `adapter` var; require the ns and pass that var directly.
+  ;; exports an `adapter` var; require the ns and pass that var. Call once
+  ;; at startup. See `docs/guide/glossary.md#init`.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -1,76 +1,65 @@
 (ns flows.core
-  "Worked example for [Spec 013 — Flows](../../../spec/013-Flows.md).
+  "Worked example for flows. Guide: docs/guide/concepts/flows.md
+   (glossary: docs/guide/glossary.md#flow).
 
-   A flow is a *registered, runtime-toggleable computed-state declaration
-   that materialises its output into `app-db`*. It says: \"when these
-   `app-db` paths change, run this pure function and write the result to
-   that `app-db` path.\" Flows evaluate automatically right after the event
-   handler — as the outermost `:after`, transforming the pending `:db`
-   effect before it installs into `app-db` — in topological order over
-   their static input/output graph.
+   A flow is a registered rule: \"when these app-db paths change, run this
+   pure function and write the result to that app-db path.\" Each flow runs
+   right after the event handler and before the db commit, so the handler's
+   change and the fresh flow output land together in one write.
 
-   WHY A FLOW AND NOT A SUB?  This is the load-bearing question Spec 013
-   §When (and when not) to use a flow answers, and the whole point of this
-   example. Most derived values should be SUBSCRIPTIONS — they are lighter,
-   live in the per-frame sub-cache, and pay no `app-db` write. Reach for a
-   flow ONLY when the derived value is part of the application's *state*:
+   WHY A FLOW AND NOT A SUB?  Most derived values should be SUBSCRIPTIONS.
+   Subs are lighter, live in the per-frame sub-cache, and pay no app-db
+   write. Reach for a flow only when the derived value is part of the
+   application's STATE:
 
-     - other event handlers read it as plain `app-db` data (here:
+     - other event handlers read it as plain app-db data (here:
        `:checkout/place-order` reads `[:cart :total]` straight off the db);
-     - it should survive SSR hydration / time-travel revert / app-db
+     - it should survive SSR hydration, time-travel restore, and app-db
        serialisation (sub-cache contents do not survive the wire);
      - the derivation is stable enough to be worth registering.
 
-   This cart demonstrates three things Spec 013 calls out:
+   This cart shows three things:
 
-   1. MATERIALISED COMPUTED STATE — `:cart/subtotal` derives the line-item
-      sum from `[:cart :items]` and writes it to `[:cart :subtotal]`.
+   1. MATERIALISED COMPUTED STATE — `:cart/subtotal` sums the line items
+      from `[:cart :items]` and writes the result to `[:cart :subtotal]`.
    2. A TOPOLOGICAL CASCADE — `:cart/total` reads `[:cart :subtotal]`
       (another flow's output) plus `[:cart :discount-rate]`. The runtime
       sorts the two flows so `:cart/subtotal` always runs first; both
-      settle in one walk — right after the handler, before the db install.
+      settle in one walk.
    3. RUNTIME-TOGGLEABLE DERIVATION — the discount is a feature gate. The
-      `:rf.fx/reg-flow` / `:rf.fx/clear-flow` fx register and clear the
-      `:cart/discount-rate` flow from a handler, mid-event. A flow can be
-      switched on or off as state changes — registered and cleared at
-      runtime, not just at boot.
+      `:rf.fx/reg-flow` / `:rf.fx/clear-flow` effects register and clear the
+      `:cart/discount-rate` flow from a handler, while the app runs.
 
-   Demonstrates:
-   - `rf/reg-flow`                                  (Spec 013 §Registration shape)
-   - flow-reads-flow topological cascade            (Spec 013 §Topological sort)
-   - `:rf.fx/reg-flow` / `:rf.fx/clear-flow`        (Spec 013 §Dynamic toggle via fx)
-   - reading a flow's output inside an event handler (Spec 013 §Sub integration (a))
-   - reading a flow's output via a plain sub over its `:output-path`  (Spec 013 §Sub integration (b))"
+   See the guide for the full registration shape, the topological sort, the
+   one-event lag, and the failure semantics."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Flows ship in day8/re-frame2-flows. Requiring re-frame.flows
-            ;; here is what publishes the artefact's late-bind hooks
-            ;; (`:flows/reg-flow` etc.) so the `rf/reg-flow` calls below
-            ;; resolve; without it they raise
-            ;; :rf.error/flows-artefact-missing. (Same require-to-register
-            ;; convention the schemas / machines / routing examples use.)
+            ;; Flows ship in their own artefact. Require re-frame.flows once
+            ;; to register the flow API; without it the reg-flow calls below
+            ;; raise :rf.error/flows-artefact-missing.
             [re-frame.flows]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ============================================================================
-;; FLOWS  (Spec 013 §Registration shape)
+;; FLOWS
 ;; ============================================================================
 ;;
-;; `:inputs` is a vector of frame-state paths (a bare path reads app-db; a
-;; path led by `:rf.db/runtime` reads runtime-db); `:derive` receives the
-;; values at those paths positionally and returns the value written to the
-;; app-db `:output-path`.
+;; `:inputs` is a vector of paths to watch (a bare path reads app-db; a path
+;; led by `:rf.db/runtime` reads runtime-db). `:derive` receives the values
+;; at those paths positionally and returns the value written to the app-db
+;; `:output-path`. Full registration map: docs/guide/concepts/flows.md.
 
 (defn- line-total [{:keys [price qty]}]
   (* price qty))
 
-;; EP-0002: reg-flow is context-required frame-local; a bare
-;; ns-load call raises :rf.error/no-frame-context. This example runs in the
-;; :rf/default frame, so name it explicitly here. (The runtime-toggleable
-;; `:cart/discount-rate` flow is registered later via :rf.fx/reg-flow, which
-;; inherits the cascade frame — see the discount button handler.)
+;; A flow belongs to a frame. `reg-flow` must run inside a frame scope; a
+;; bare call raises :rf.error/no-frame-context. This example runs in the
+;; :rf/default frame, so name it here. (The runtime-toggleable
+;; `:cart/discount-rate` flow is registered later via :rf.fx/reg-flow from a
+;; handler, which carries the dispatching frame automatically.)
+;; See docs/guide/glossary.md#frame-identity-is-carried-not-found.
 (with-frame :rf/default
 
 (rf/reg-flow
@@ -82,19 +71,16 @@
    :output-path [:cart :subtotal]})
 
 ;; `:cart/total` reads ANOTHER flow's output (`[:cart :subtotal]`) plus the
-;; (optionally-registered) discount rate. The runtime derives the
-;; dependency edge from the path overlap and topologically sorts so
-;; `:cart/subtotal` always runs before `:cart/total` — both settle in a
-;; single walk, run right after the handler before the db install
-;; (Spec 013 §Topological sort and cycle detection).
+;; discount rate. The runtime derives the dependency edge from the shared
+;; path and sorts the flows so `:cart/subtotal` always runs before
+;; `:cart/total`; both settle in a single walk.
 ;;
 ;; The discount starts off: `:cart/discount-rate` has no flow yet, so its
-;; path is nil and `:cart/total`'s `:derive` treats it as 0% off. The "Apply
-;; 10% discount" button registers the flow via `:rf.fx/reg-flow`; "Remove
-;; discount" clears it via `:rf.fx/clear-flow` (which `dissoc-in`s the path
-;; back to nil). While registered it derives a flat 10% off the live
-;; subtotal. It reads `[:cart :subtotal]` so the rate stays fresh as the cart
-;; changes, and a tiered "5% over $50" rule would slot straight in.
+;; path is nil and this `:derive` treats it as 0% off. The "Apply 10%
+;; discount" button registers the flow; "Remove discount" clears it. While
+;; registered it derives a flat 10% off the live subtotal. It reads
+;; `[:cart :subtotal]`, so the rate stays fresh as the cart changes and a
+;; tiered "5% over $50" rule would slot straight in.
 (rf/reg-flow
   {:id     :cart/total
    :doc    "Subtotal less the active discount. Reads :cart/subtotal's
@@ -116,9 +102,7 @@
 
 (rf/reg-event :cart/initialise
   {:doc "Seed the cart. The :cart/subtotal and :cart/total flows fire right
-         after THIS event's handler (before the db install) and materialise
-         their outputs — a newly-registered flow's first walk always
-         recomputes."}
+         after this handler and materialise their outputs in the same write."}
   (fn handler-cart-initialise [{:keys [db]} _]
     {:db (assoc db :cart {:items seed-items})}))
 
@@ -146,20 +130,19 @@
                            (= sku (:sku item)) (update :qty #(max 1 (dec %)))))
                        items)))}))
 
-;; Runtime-toggleable derivation (Spec 013 §Dynamic toggle via fx). The
-;; discount flow is registered / cleared mid-event via the two reserved
-;; fx-ids. Both route to the dispatching frame automatically.
+;; Runtime-toggleable derivation. The discount flow is registered / cleared
+;; while the app runs via the two reserved effects. Both carry the
+;; dispatching frame automatically.
 ;;
-;; SEQUENCING NOTE (Spec 013 §Sequencing — the one-event lag): a flow
-;; registered via `:rf.fx/reg-flow` first runs on the NEXT drain — its
-;; initial output appears one event after registration. So after
-;; registering the discount-rate flow we dispatch a no-op `:cart/touch`
-;; whose ONLY job is to drain: by the time it runs, the new flow is in the
-;; registry, so the flow transform on that drain materialises
+;; THE ONE-EVENT LAG: a flow registered via `:rf.fx/reg-flow` first runs on
+;; the NEXT event — its initial output appears one event after registration.
+;; So after registering the discount-rate flow we dispatch a no-op
+;; `:cart/touch` whose only job is to trigger another walk: by the time it
+;; runs, the new flow is in the registry, so that walk materialises
 ;; `[:cart :discount-rate]` (and the dependent `[:cart :total]`) at the
-;; discounted figure. It is the drain itself that drives the re-walk;
-;; `:cart/touch` writes nothing. This is the spec's own `:wizard/settle`
-;; pattern (§Sequencing).
+;; discounted figure. `:cart/touch` writes nothing; the walk itself drives
+;; the recompute.
+;; Guide: docs/guide/concepts/flows.md#toggling-a-derivation-at-runtime.
 (rf/reg-event :cart/apply-discount
   {:doc "Engage the 10%-off feature gate by registering a flow that writes
          the discount rate, then nudge a re-walk so :cart/total recomputes."}
@@ -176,30 +159,27 @@
           [:dispatch [:cart/touch]]]}))
 
 (rf/reg-event :cart/remove-discount
-  {:doc "Disengage the feature gate. `:rf.fx/clear-flow` removes the flow
-         AND dissoc-in's its [:cart :discount-rate] output back to nil, so
-         :cart/total recomputes to the full price on the next walk."}
+  {:doc "Disengage the feature gate. `:rf.fx/clear-flow` removes the flow and
+         clears its [:cart :discount-rate] output back to nil, so :cart/total
+         recomputes to the full price on the next walk."}
   (fn handler-cart-remove-discount [_ _]
     {:fx [[:rf.fx/clear-flow :cart/discount-rate]
           [:dispatch [:cart/touch]]]}))
 
-;; No-op drain — Spec 013 §Sequencing's `:wizard/settle` verbatim:
-;; `(fn [{:keys [db]} _] {:db db})`. It returns the db unchanged; its job is
-;; to make one more drain happen on this frame. On that drain the flow
-;; transform re-walks with the just-(de)registered discount flow now visible
-;; in the registry, materialising the one-drain-lagged output. The toggle is
-;; the `:rf.fx/reg-flow` / `:rf.fx/clear-flow` itself; this event is the
-;; drain that surfaces it.
+;; No-op event. It returns the db unchanged; its only job is to make one
+;; more walk happen on this frame. On that walk the flows re-run with the
+;; just-(de)registered discount flow now in the registry, materialising the
+;; one-event-lagged output. The toggle is the `:rf.fx/reg-flow` /
+;; `:rf.fx/clear-flow` itself; this event is the walk that surfaces it.
 (rf/reg-event :cart/touch
-  {:doc "No-op drain. Exists only to trigger the re-walk that materialises
-         the one-event-lagged discount flow output (Spec 013 §Sequencing)."}
+  {:doc "No-op. Exists only to trigger the walk that materialises the
+         one-event-lagged discount flow output."}
   (fn handler-cart-touch [{:keys [db]} _] {:db db}))
 
-;; Reading a flow's output inside an event handler — Spec 013 §Sub
-;; integration (a). The handler reads [:cart :total] as plain `app-db`
-;; data. This is the central reason the total is a flow and not a sub: a
-;; sub's value lives in the view-facing sub-cache, which a handler can't
-;; easily reach.
+;; Reading a flow's output inside an event handler. This handler reads
+;; [:cart :total] as plain app-db data. This is the central reason the total
+;; is a flow and not a sub: a sub's value lives in the view-facing sub-cache,
+;; which a handler can't reach.
 (rf/reg-event :checkout/place-order
   {:doc "Place the order. Reads the materialised :cart/total straight off
          app-db — the flow output IS ordinary application state."}
@@ -217,17 +197,17 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; Flows publish ZERO framework subs (Spec 013 §Sub integration). A flow's
-;; output is "ordinary application state with a known producer" — consumers
-;; read it through whatever sub they prefer over the flow's `:output-path`. The
-;; view below reads the materialised :subtotal / :total via plain subs.
+;; Flows publish no framework subs. A flow's output is ordinary application
+;; state at a known path — consumers read it through whatever sub they like
+;; over the flow's `:output-path`. The view below reads the materialised
+;; :subtotal / :total via plain subs.
 
 (rf/reg-sub :cart/items
   (fn [db _] (get-in db [:cart :items])))
 
 (rf/reg-sub :cart/subtotal
-  {:doc "Reads the :cart/subtotal flow's output at its :output-path — pattern (b)
-         from Spec 013 §Sub integration. A plain app-db read, like any sub."}
+  {:doc "Reads the :cart/subtotal flow's output at its :output-path. A plain
+         app-db read, like any sub."}
   (fn [db _] (get-in db [:cart :subtotal])))
 
 (rf/reg-sub :cart/total
@@ -288,20 +268,18 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. ns-load must produce no DOM side effects, so co-required example
+;; namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; The `frame-provider` `{:id …}` shape sets up the frame in one spot at the
-;; render root (EP-0002). On first mount it creates the frame and runs its
-;; `:initial-events` once to seed it (here `[:cart/initialise]`); on hot reload
-;; it reuses the existing frame and skips the seed. Wrapping the render also
-;; makes the `reg-view`-injected `dispatch`/`subscribe` resolve to this frame —
-;; a render with no provider raises :rf.error/no-frame-context. The id is
-;; `:rf/default`, the same id the `with-frame` flow registrations use above.
-;; `:rf/default` is just an ordinary frame id, so the provider names it here.
+;; `frame-provider` sets up the frame at the render root. On first mount it
+;; creates the frame and runs its `:initial-events` once to seed it (here
+;; `[:cart/initialise]`); on hot reload it reuses the frame and skips the
+;; seed. Wrapping the render also makes the `reg-view`-injected
+;; `dispatch`/`subscribe` resolve to this frame; a render with no provider
+;; raises :rf.error/no-frame-context. The id is `:rf/default` — an ordinary
+;; frame id, the same one the `with-frame` flow registrations use above.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/infinite_feed/core.cljs
+++ b/examples/reagent/infinite_feed/core.cljs
@@ -1,113 +1,102 @@
 (ns infinite-feed.core
-  "Worked example for the EP-0021 INFINITE RESOURCE primitive
-   ([Spec 016 §Infinite resources and load-more feeds](../../../spec/016-Resources.md#infinite-resources-and-load-more-feeds)).
+  "A load-more / infinite-scroll timeline built as one growing resource.
 
-   The one idea: a load-more / infinite-scroll timeline is ONE growing resource
-   the runtime owns. The view reads the merged list passively and dispatches a
-   single CAUSAL `:rf.resource/load-more`. The runtime holds the page list, the
-   cursor, the in-flight flag, and the append — so the app writes none of them.
-   Composed as proper re-frame2: a `reg-resource` with `:infinite true`, owned
-   by the route, read through the PASSIVE infinite subscription family. That is
-   the whole point of the primitive — without it, an app hand-rolls all of that.
+   The whole idea: the feed is ONE cache entry the runtime owns and grows. The
+   view reads the merged list passively and dispatches a single causal
+   `:rf.resource/load-more`. The runtime holds the page list, the cursor, the
+   in-flight flag, and the append — the app writes none of them. It is a
+   `reg-resource` with `:infinite true`, owned by the route, read through the
+   passive infinite subscription family.
 
-   It teaches, in one cohesive app, the four facts the primitive surfaces:
+   The how-to walks this exact code, step by step:
+   docs/resources/how-to/paginate-a-feed.md (§Load more).
 
-   - ONE FEED, MANY PAGES — `:infinite true` plus a `:next-page-param`
-     derivation makes the resource a growing ordered page sequence held as
-     ONE cache entry. Route entry ensures PAGE 0; the view reads the merged
-     list passively.
-   - LOAD-MORE IS A CAUSAL EVENT — the \"Load more\" button dispatches
+   Four facts the example shows:
+
+   - ONE FEED, MANY PAGES. `:infinite true` plus a `:next-page-param` function
+     makes the resource a growing ordered sequence of pages held as one cache
+     entry. Route entry ensures page 0; the view reads the merged list.
+   - LOAD-MORE IS A CAUSAL EVENT. The button dispatches
      `[:rf.resource/load-more …]` and the runtime derives the next page param
-     from the loaded tail. The event carries a `:cause` but NO `:owner`: the
-     ROUTE already owns the feed for its lifetime, so load-more extends that one
-     owned entry rather than minting a second owner (owner keeps it alive; cause
-     explains why it grew).
-   - THE TERMINAL IS `nil` — `:next-page-param` returning nil is the single
-     end-of-feed signal; the view reads `:has-next-page?` and shows an
+     from the loaded tail. The event carries a `:cause` but no `:owner`: the
+     route already owns the feed, so load-more extends that one owned entry
+     rather than minting a second owner. (Owner keeps it alive; cause explains
+     why it grew — see docs/resources/glossary.md#owner--cause.)
+   - THE TERMINAL IS `nil`. `:next-page-param` returning nil is the single
+     end-of-feed signal. The view reads `:has-next-page?` and shows an
      end-of-feed marker instead of the button.
-   - THE THREE ERROR CHANNELS — a LOAD-MORE failure (page N>0) keeps every
-     accumulated page visible and surfaces `:page-error` (\"couldn't load more —
-     retry\") while the feed stays `:loaded` (the third channel). A PAGE 0
-     FIRST-load failure with no accumulated pages settles the first-load
-     `:error` channel + `:status :error` (Spec 016 reserves `:error` for
-     first-load, `:page-error` for load-more), so the view shows the full error
-     screen on `:error` and the inline retry on `:page-error` — distinct axes,
-     never conflated.
+   - THREE ERROR CHANNELS. A load-more failure (page N>0) keeps every
+     accumulated page visible and surfaces `:page-error` while the feed stays
+     `:loaded`. A page-0 first-load failure with no data settles `:error` and
+     `:status :error`. `:error` is for first-load, `:page-error` for load-more,
+     so the view shows the full error screen on one and the inline retry on the
+     other — distinct axes, never conflated.
 
    The view reads the combined `[:rf.resource/infinite-state …]` view-model —
    `:items` (the merged flat list, the headline read), `:has-next-page?`,
    `:fetching-next?`, `:page-error`, `:loading?`, `:has-data?` — and dispatches
-   one causal event. Scope is the fail-closed leak boundary: this feed is
-   public (the same for every viewer), so it carries the explicit, auditable
-   `:rf.scope/global` claim (a per-user feed would carry a scope resolver).
+   one causal event. Scope is a fail-closed leak boundary: this feed is public
+   (the same for every viewer), so it carries the explicit `:rf.scope/global`
+   claim. A per-user feed would carry a scope resolver instead. See
+   docs/resources/glossary.md#scope.
 
    This feed's pages are ENVELOPED — each page is `{:items [...] :page-info
-   {…}}`, not a bare vector — so the resource declares the REQUIRED
-   `:page->items` accessor (`:items`). The runtime is loud over guessing: a
-   non-vector page with no accessor raises `:rf.error/infinite-missing-page-
-   accessor` at the merge. (A feed whose pages are already bare vectors needs
-   no accessor — they flatten by identity.)
+   {…}}`, not a bare vector — so the resource declares the required
+   `:page->items` accessor. The runtime is loud over guessing: an envelope page
+   with no accessor raises `:rf.error/infinite-missing-page-accessor` at the
+   merge. (Pages that are already bare vectors flatten by identity and need no
+   accessor.)
 
    The example ships no backend, so it overrides `:rf.http/managed` with a
    per-cursor canned stub that delegates to the framework-shipped
-   `:rf.http/managed-canned-success` (Spec 014 §Testing — the same reply shape
-   a live server would produce), so every page fetch exercises a REAL fetch,
-   in-flight dedupe, generation/stale suppression, and the passive status flow.
-   A small reply delay lets the load-more spinner render before each page
-   lands. The example tree is test-free; the example-specific
-   composition coverage lives in
-   `implementation/adapters/reagent/test/re_frame/infinite_feed_example_cljs_test.cljs`,
-   and the infinite-resource runtime contract is pinned in
-   `implementation/resources/test/`."
+   `:rf.http/managed-canned-success` — the same reply shape a live server would
+   produce. Every page fetch exercises a real fetch, in-flight dedupe, stale
+   suppression, and the passive status flow. A small reply delay lets the
+   load-more spinner render before each page lands."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.views]
-            ;; Managed HTTP ships in day8/re-frame2-http — the single
-            ;; built-in resource transport (Spec 016 §Transport). Loading
-            ;; the ns registers the `:rf.http/managed` fx the resource
-            ;; runtime lowers each page fetch onto.
+            ;; Managed HTTP — the built-in resource transport. Loading the ns
+            ;; registers the `:rf.http/managed` fx that each page fetch runs on.
+            ;; See docs/resources/glossary.md#managed-http.
             [re-frame.http.managed]
-            ;; The framework-shipped canned-success fx the demo stub
-            ;; delegates to (Spec 014 §Testing). Requiring it is the explicit
-            ;; opt-in for a demo / test app with no backend.
+            ;; The framework-shipped canned-success fx the demo stub delegates
+            ;; to. Requiring it is the explicit opt-in for a demo / test app
+            ;; with no backend.
             [re-frame.http.test-support]
-            ;; Resources ship in day8/re-frame2-resources. Requiring the ns at
-            ;; app boot wires the late-bind hooks + registrations (including
-            ;; the infinite sub family); without it `rf/reg-resource` throws
-            ;; :rf.error/resources-artefact-missing.
+            ;; Resources. Requiring the ns at app boot wires the registrations
+            ;; (including the infinite sub family); without it `rf/reg-resource`
+            ;; throws :rf.error/resources-artefact-missing.
             [re-frame.resources]
-            ;; Routing ships in day8/re-frame2-routing. The resources artefact
-            ;; LATE-BINDS its `:resources` route-metadata extension into
-            ;; routing, so loading both is what makes a route's `:resources`
-            ;; key accepted (Spec 016 §Route integration). Route entry ensures
-            ;; PAGE 0 of an infinite resource (not the whole accumulation).
+            ;; Routing. The resources artefact binds its `:resources`
+            ;; route-metadata key into routing, so loading both is what makes a
+            ;; route's `:resources` key accepted. Route entry ensures page 0 of
+            ;; an infinite resource (not the whole accumulation).
             [re-frame.routing]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
-;; THE INFINITE RESOURCE — one growing feed, pages held as the durable value
+;; THE INFINITE RESOURCE — one growing feed, pages held as the value
 ;; ============================================================================
 ;;
 ;; An infinite resource is an ordinary resource (identity + scope + request)
-;; with two additions (Spec 016 §Registration — :infinite):
+;; with two additions:
 ;;
-;;   :infinite true           selects the infinite slice + makes
-;;                            :next-page-param REQUIRED;
-;;   :next-page-param         a PURE (last-page all-pages) -> next-param-or-nil
-;;                            derivation. nil is the SINGLE terminal signal.
+;;   :infinite true       makes :next-page-param required;
+;;   :next-page-param     a pure (last-page all-pages) -> next-param-or-nil
+;;                        function. nil is the single terminal signal.
 ;;
-;; The :request keeps its settled (params ctx) shape — for an infinite resource
-;; the RESERVED ctx (its second arg) carries the resolved page context for THIS
-;; page: {:rf.resource/page-param p :rf.resource/page-index i} (R8 — no new
-;; arity). Page 0 is fetched with page-param nil; each load-more passes the
-;; derived next cursor.
+;; The :request keeps its (params ctx) shape. For an infinite resource the ctx
+;; (its second arg) carries this page's context:
+;; {:rf.resource/page-param p :rf.resource/page-index i}. Page 0 is fetched
+;; with page-param nil; each load-more passes the derived next cursor.
 ;;
 ;; The page param is NOT part of the feed's cache identity — two load-more
 ;; calls extend ONE entry, they do not create two cache keys. Only the identity
 ;; params (here: nothing — a single public feed) name the feed; a filter/sort
-;; change would yield a DIFFERENT feed instance, not a mutation of this one.
+;; change yields a DIFFERENT feed instance, not a mutation of this one.
 
 (def ^:private page-size 8)
 
@@ -121,8 +110,8 @@
    ;; instance). The per-page cursor is NEVER here — it is the page param.
    :params-schema  [:map]
 
-   ;; Public feed: the same for every viewer → the explicit, auditable global
-   ;; claim. A per-user feed would carry a scope resolver instead.
+   ;; Public feed: the same for every viewer → the explicit global claim. A
+   ;; per-user feed would carry a scope resolver instead.
    :scope          :rf.scope/global
 
    ;; The pages are ENVELOPED ({:items … :page-info …}), so the REQUIRED
@@ -138,11 +127,11 @@
 
    :stale-after-ms 60000
    :gc-after-ms    (* 5 60 1000)
-   ;; A feed tag so a write could invalidate the whole feed by tag (coarse,
-   ;; correct — R4); item-in-feed patching is the deferred optimistic axis.
+   ;; A feed tag so a write can invalidate the whole feed by tag (coarse but
+   ;; correct). See docs/resources/glossary.md#cache-tag.
    :tags           (fn [_feed-params _data] #{[:feed :timeline]})}
-  ;; :request keeps its (params ctx) shape; the RESERVED ctx carries the
-  ;; resolved page context for THIS page (page-param nil ⇒ first page).
+  ;; :request keeps its (params ctx) shape; the ctx carries this page's context
+  ;; (page-param nil ⇒ first page).
   (fn [_feed-params {:rf.resource/keys [page-param page-index]}]
     {:request {:method :get
                :url    "/api/timeline"
@@ -154,17 +143,16 @@
 ;; DEMO BACKEND — per-cursor canned :rf.http/managed override
 ;; ============================================================================
 ;;
-;; This example ships no server, so it overrides `:rf.http/managed` (the fx the
-;; resource runtime lowers every page fetch onto) with a stub that synthesises
-;; one enveloped page per cursor. The stub reads the `:cursor` request param
-;; (absent ⇒ page 0), slices the demo dataset, and returns
-;; {:items [...] :page-info {:next-cursor …}} — the SAME enveloped shape a real
+;; This example ships no server, so it overrides `:rf.http/managed` (the fx
+;; every page fetch runs on) with a stub that synthesises one enveloped page
+;; per cursor. The stub reads the `:cursor` request param (absent ⇒ page 0),
+;; slices the demo dataset, and returns
+;; {:items [...] :page-info {:next-cursor …}} — the same enveloped shape a real
 ;; cursor-paginated server would produce, so the feed lifecycle (page-0 ensure,
 ;; load-more cursor derivation, in-flight dedupe, the nil terminal) runs end to
 ;; end. It delegates to the framework-shipped `:rf.http/managed-canned-success`
 ;; with `:after-ms`, so the reply rides framework `:dispatch-later` and stays
-;; tape-visible and time-travel-safe. Mirrors
-;; examples/reagent/resources/core.cljs's stub.
+;; visible on the trace tape and safe to time-travel.
 
 (def ^:private total-items 26)
 
@@ -175,8 +163,8 @@
 
 (def ^:private demo-reply-delay-ms
   "How long the demo stub defers each canned reply (the canned-success fx's
-   `:after-ms`). Small but non-zero so the load-more spinner is observable. A
-   demo-seam knob, not a production value."
+   `:after-ms`). Small but non-zero so the load-more spinner is visible. A demo
+   knob, not a production value."
   140)
 
 (defn- demo-page-for-cursor
@@ -193,8 +181,8 @@
 ;; This override stands in for the backend. It synthesises the per-cursor page,
 ;; then hands the rest to `:rf.http/managed-canned-success` via the registrar,
 ;; adding `:after-ms` so the reply rides framework `:dispatch-later`. It reuses
-;; the incoming args-map, which keeps the reply addressing (the PAGE reply
-;; handlers the resource runtime set) intact.
+;; the incoming args-map, which keeps the reply addressing (the per-page reply
+;; handlers the resource runtime set up) intact.
 (rf/reg-fx :infinite-feed.demo/http-stub
   {:doc       "Demo override for `:rf.http/managed`: synthesises one enveloped
                page per request cursor so the feed runs standalone, then
@@ -210,11 +198,11 @@
 ;; ROUTES — route entry ensures PAGE 0 (the first load), and OWNS the feed
 ;; ============================================================================
 ;;
-;; A route declares an infinite resource exactly as any resource (Spec 016
-;; §Route integration). Route entry ensures PAGE 0 under the
-;; `[:route route-id nav-token]` owner; route leave releases it. Load-more is a
-;; user-caused event during the route's lifetime, NOT a route plan step.
-;; `:blocking?` blocks on page 0 only.
+;; A route declares an infinite resource exactly as it declares any resource.
+;; Route entry ensures page 0 under the route's owner; route leave releases it.
+;; Load-more is a user-caused event during the route's lifetime, not a step in
+;; the route's load plan. `:blocking?` blocks on page 0 only.
+;; See docs/resources/how-to/paginate-a-feed.md (§Let the route own the feed).
 
 (rf/reg-route :infinite-feed.app/home
   {:doc  "Landing page."} "/")
@@ -233,9 +221,9 @@
 ;; PAGES — passive reads; the runtime owns the accumulation
 ;; ============================================================================
 ;;
-;; The view is PASSIVE: it reads the combined infinite view-model and dispatches
-;; ONE causal event. The query map is the feed identity (resource + scope +
-;; params) — the SAME shape the route's `:resources` plan ensured under, so the
+;; The view is passive: it reads the combined infinite view-model and dispatches
+;; one causal event. The query map is the feed identity (resource + scope +
+;; params) — the same shape the route's `:resources` plan ensured under, so the
 ;; sub reads the entry the route owns.
 
 (def ^:private feed-query
@@ -257,9 +245,8 @@
   [:li {:data-testid "feed-row"} title])
 
 (reg-view timeline-page []
-  ;; The infinite resource was ensured (PAGE 0) by THIS route's `:resources`
-  ;; metadata on entry. The view reads the WHOLE feed view-model passively via
-  ;; `[:rf.resource/infinite-state …]`.
+  ;; This route's `:resources` metadata ensured page 0 on entry. The view reads
+  ;; the whole feed view-model passively via `[:rf.resource/infinite-state …]`.
   (let [feed @(subscribe [:rf.resource/infinite-state feed-query])]
     [:div
      [:h1 "Timeline"]
@@ -269,28 +256,26 @@
        [:p {:data-testid "feed-skeleton"} "Loading the feed…"]
 
        ;; First load (page 0) failed with no usable data → full error screen.
-       ;; A page-0 failure with no accumulated pages settles the first-load
-       ;; `:error` channel + `:status :error` (Spec 016 §Status semantics —
-       ;; `:error` is reserved for first-load failure), exactly like a scalar
-       ;; resource. This is a different axis from `:page-error`, which a
-       ;; load-more (page N>0) failure uses while keeping the feed.
+       ;; A page-0 failure with no accumulated pages settles `:error` and
+       ;; `:status :error`, just like a scalar resource. `:error` is for
+       ;; first-load failure; a load-more (page N>0) failure uses `:page-error`
+       ;; instead and keeps the feed. See docs/resources/glossary.md#resource-status.
        (:error feed)
        [:p.error {:data-testid "feed-error"} "Could not load the feed."]
 
        :else
        [:<>
         ;; The merged flat list — the headline `:items` read. The runtime
-        ;; concatenates pages in load order + memoises the merge; the view
+        ;; concatenates pages in load order and memoises the merge; the view
         ;; just renders rows.
         (into [:ul {:data-testid "feed-list"}]
               (for [item (:items feed)]
                 ^{:key (:id item)} [feed-row item]))
 
-        ;; A LOAD-MORE failure (page N>0 — we have data) keeps every page
-        ;; visible and surfaces :page-error — the inline "couldn't load more —
-        ;; retry" affordance. This is the THIRD error channel: a load-more
-        ;; failure leaves the feed intact, unlike the first-load :error
-        ;; full-screen above.
+        ;; A load-more failure (page N>0 — we have data) keeps every page
+        ;; visible and surfaces :page-error — the inline retry. This is the
+        ;; third error channel: a load-more failure leaves the feed intact,
+        ;; unlike the first-load :error full-screen above.
         (when (:page-error feed)
           [:p.warn {:data-testid "feed-page-error"}
            "Couldn't load more — tap retry."])
@@ -300,7 +285,7 @@
         ;; The button dispatches one causal event and the runtime derives the
         ;; next page param from the loaded tail. The event carries a `:cause`
         ;; but no `:owner` — the route already owns the feed, so load-more just
-        ;; extends it.
+        ;; extends it (owner keeps it alive; cause explains why it grew).
         (cond
           (:fetching-next? feed)
           [:p {:data-testid "feed-loading-more"} "Loading more…"]
@@ -331,16 +316,16 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; The React root is materialised lazily inside `run` (not at ns-load) per
-;; examples/TESTING.md §Example mount-isolation convention. The app establishes
-;; its frame in ONE spot: the render-root `frame-provider {:id …}` (EP-0002 +
-;; EP-0024). On first mount the provider CREATES the `app-frame` and applies its
-;; config — `:url-bound? true` so the frame owns the browser URL, and the
-;; `:rf.http/managed` override that points page fetches at the canned stub so the
-;; example runs standalone. The provider also scopes that frame, so every in-tree
-;; dispatch/subscribe resolves to it. On hot reload it REUSES the same frame.
-;; The feed itself needs no boot seed: route entry's `:resources` plan ensures
-;; PAGE 0, so the frame carries no `:initial-events`.
+;; The React root is created lazily inside `run` (not at ns-load) so a test can
+;; mount the app in its own frame. The app establishes its frame in one spot:
+;; the render-root `frame-provider {:id …}`. On first mount the provider creates
+;; the `app-frame` and applies its config — `:url-bound? true` so the frame owns
+;; the browser URL, and the `:rf.http/managed` override that points page fetches
+;; at the canned stub so the example runs standalone. The provider also scopes
+;; that frame, so every in-tree dispatch/subscribe resolves to it. On hot reload
+;; it reuses the same frame. The feed needs no boot seed: route entry's
+;; `:resources` plan ensures page 0, so the frame carries no `:initial-events`.
+;; See docs/guide/glossary.md#frame-provider.
 
 (defonce react-root (atom nil))
 
@@ -353,7 +338,7 @@
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     ;; The provider creates the app frame (with its config) on first mount and
-    ;; reuses it on hot reload. Route entry ensures PAGE 0, so no `:initial-events`.
+    ;; reuses it on hot reload. Route entry ensures page 0, so no `:initial-events`.
     (rdc/render @react-root
                 [rf/frame-provider {:id           app-frame
                                     :doc          "Infinite-feed demo frame."

--- a/examples/reagent/linearlite/core.cljs
+++ b/examples/reagent/linearlite/core.cljs
@@ -1,97 +1,78 @@
 (ns linearlite.core
-  "Flagship worked example for the EP-0019 OPTIMISTIC MUTATION + ROLLBACK
-   primitive ([Spec 016 §Optimistic mutations](../../../spec/016-Resources.md#optimistic-mutations)).
+  "A worked example of OPTIMISTIC MUTATION with automatic ROLLBACK.
 
-   A small Linearlite-class issue tracker — a board of issues you CREATE,
-   RETITLE, and move between statuses — where every write applies
-   OPTIMISTICALLY: the board updates the instant you click, BEFORE the request
-   is sent, and is deterministically COMMITTED or ROLLED BACK when the reply
-   settles. This is the write counterpart of `examples/reagent/infinite_feed/`'s
-   read-side load-more dogfood: there the runtime owned the page accumulation;
-   here the runtime owns the optimistic apply, the recorded snapshot inverse,
-   the per-entry revision token, and the conflict-aware rollback.
+   A small Linearlite-style issue tracker: a board of issues you create,
+   retitle, and move between statuses. Every write applies optimistically — the
+   board updates the instant you click, before the request is sent — and is
+   committed or rolled back when the reply settles. The runtime owns the
+   optimistic apply, the recorded inverse, and the conflict-aware rollback.
 
-   It dogfoods, in one cohesive app, the four facts the optimistic primitive
-   surfaces ([EP-0019](../../../docs/EP/EP-0019-optimistic-mutation-rollback.md)):
+   See the guide: [Optimistic writes commit, roll back, or
+   reconcile](../../../docs/resources/concepts.md#optimistic-writes-commit-roll-back-or-reconcile).
 
-   - THE WRITE SHOWS IMMEDIATELY — each mutation declares `:optimistic`, the
-     EXACT-target twin of `:patches`: `(fn [params] -> {target patch-fn})`. The
-     patch runs at PHASE 1.5, before the request lowers, so the new card
+   The example shows four things:
+
+   - THE WRITE SHOWS IMMEDIATELY. Each mutation declares `:optimistic`, an
+     exact-target forward patch over the board: `(fn [params] -> {target
+     patch-fn})`. The patch runs before the request is sent, so the new card
      appears / the title changes / the card moves the instant the user acts. The
      runtime owns the cache and shows the optimistic value; the view just reads
-     it. (No app-db issue list, no `:saving?` flag to keep in sync.)
+     it. There is no app-db issue list and no `:saving?` flag to keep in sync.
 
-   - THE INVERSE IS RUNTIME-RECORDED — the author writes only the FORWARD
-     patch. The runtime snapshots each touched entry's whole `:before` value
-     (verbatim, by structural sharing) and its `:revision` at apply time. The
-     author never describes how to undo a change; the inverse is truthful by
-     construction (the exact entry that existed, never a reconstruction).
+   - THE INVERSE IS RECORDED FOR YOU. You write only the forward patch. The
+     runtime snapshots each touched entry's value and its revision at apply
+     time. A rollback restores exactly the entry that existed, so the undo is
+     truthful by construction — never an author-written inverse that can drift.
 
-   - THE REPLY SETTLES DETERMINISTICALLY — an accepted `:ok` reply COMMITS
-     (`:populates` overwrites the optimistic guess with the server's
-     authoritative board), an accepted `:error` reply ROLLS BACK (the recorded
-     `:before` is restored verbatim — the optimistic change visibly reverts).
-     There is no wall-clock race: the verdict keys on the work-id + generation
-     acceptance and the per-entry revision, both canonical recorded facts.
+   - THE REPLY SETTLES DETERMINISTICALLY. An `:ok` reply commits: `:populates`
+     overwrites the optimistic guess with the server's authoritative board. An
+     `:error` reply rolls back: the recorded value is restored and the
+     optimistic change visibly reverts. The verdict keys on recorded facts (the
+     generation-acceptance verdict and a per-entry revision), so there is no
+     wall-clock race.
 
-   - ROLLBACK IS WHAT YOU SEE — the demo's headline. A 'Fail the next write'
-     toggle arms the demo backend to answer the next mutation with a 503. The
-     optimistic change paints immediately, the request fails, and the runtime
-     rolls the board back to exactly its pre-click state — the new card
-     vanishes, the retitled card reverts, the moved card snaps back — with a
-     red banner naming the failure. The runtime owns the undo.
+   - ROLLBACK IS WHAT YOU SEE. A 'Fail the next write' toggle arms the demo
+     backend to answer the next mutation with a 503. The optimistic change
+     paints immediately, the request fails, and the runtime rolls the board back
+     to its pre-click state — the new card vanishes, the retitled card reverts,
+     the moved card snaps back.
 
-   The board is read PASSIVELY through `[:rf.resource/data …]` (the resource
-   sub family); each in-flight write is watched through the passive
-   `[:rf.mutation/state {:instance …}]` view-model — including the derived
-   `:optimistic?` flag (Rider 1), true while a live optimistic apply is showing
-   between phase 1.5 and settle, so the board can mark a card 'pending, showing
-   your optimistic value'.
+   The board is read passively through `[:rf.resource/data …]`. Each in-flight
+   write is watched through `[:rf.mutation/state {:instance …}]`, whose derived
+   `:optimistic?` flag is true while a live optimistic apply is showing, so the
+   board can mark a card as pending.
 
    THE CONFLICT POLICY. Each mutation names `:on-conflict :invalidate` (the
-   default, named here for the dogfood): on a failure rollback where a competing
-   write moved the touched entry while ours was in flight, the read path is the
-   recovery authority — the runtime refetches the authoritative value rather
-   than restoring a now-stale inverse (re-frame2's deliberate divergence from
-   TanStack/SWR's unconditional context restore).
+   default). On a failure rollback where a competing write moved the touched
+   entry while ours was in flight, the read path refetches the authoritative
+   value rather than restoring a now-stale inverse. (re-frame2's deliberate
+   divergence from TanStack Query / SWR's unconditional context restore — see
+   the guide section above.)
 
-   IDIOMATIC re-frame2. The board is a single managed resource; every write is
-   a named `reg-mutation`; the toggle is an ordinary app-db slice driven by an
+   IDIOMATIC re-frame2. The board is a single managed resource; every write is a
+   named `reg-mutation`; the toggle is an ordinary app-db slice driven by an
    event and read by a sub. The example ships no backend, so it overrides
-   `:rf.http/managed` with a canned stub (mirroring
-   `examples/reagent/infinite_feed/`) that synthesises the board reply and,
-   when armed, the 503 — so the whole optimistic lifecycle runs standalone.
-
-   The example tree is test-free; the example-specific composition
-   coverage (optimistic-apply, success-commit, failure-rollback) lives in
-   `implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs`,
-   and the optimistic-mutation runtime contract is pinned in
-   `implementation/resources/test/`."
+   `:rf.http/managed` with a canned stub that synthesises the board reply and,
+   when armed, the 503, so the whole optimistic lifecycle runs standalone."
   (:require [reagent.dom.client :as rdc]
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.views]
-            ;; Managed HTTP ships in day8/re-frame2-http — the single built-in
-            ;; resource/mutation transport (Spec 016 §Transport). Loading the
-            ;; ns registers the `:rf.http/managed` fx the resource + mutation
-            ;; runtime lowers each read/write onto.
+            ;; Managed HTTP: the transport every resource and mutation lowers
+            ;; its read/write onto. Loading the ns registers the
+            ;; `:rf.http/managed` fx. See the guide glossary:
+            ;; ../../../docs/resources/glossary.md#managed-http
             [re-frame.http.managed]
-            ;; The framework-shipped canned-success fx the demo stub delegates
-            ;; to (Spec 014 §Testing) — the explicit opt-in for a demo app with
-            ;; no backend.
+            ;; The framework's canned-reply fx that the demo stub delegates to.
+            ;; The explicit opt-in for a demo app with no backend.
             [re-frame.http.test-support]
-            ;; Resources ship in day8/re-frame2-resources. Requiring the ns at
-            ;; app boot wires the late-bind hooks + registrations (the resource
-            ;; sub family AND the mutation runtime + `:rf.mutation/*` subs);
-            ;; without it `rf/reg-resource` / `rf/reg-mutation` throw
-            ;; :rf.error/resources-artefact-missing.
+            ;; Resources. Loading the ns registers `reg-resource` / `reg-mutation`
+            ;; and the `:rf.resource/*` + `:rf.mutation/*` subs; without it those
+            ;; registrations throw.
             [re-frame.resources]
-            ;; Routing ships in day8/re-frame2-routing. The resources artefact
-            ;; LATE-BINDS its `:resources` route-metadata extension into
-            ;; routing, so loading both is what makes a route's `:resources`
-            ;; key accepted (Spec 016 §Route integration). Route entry ensures
-            ;; the board on entry.
+            ;; Routing. With resources also loaded, a route's `:resources` key is
+            ;; accepted — route entry ensures the board.
             [re-frame.routing]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view reg-event reg-sub]]))
@@ -101,8 +82,8 @@
 ;; ============================================================================
 
 (def ^:private statuses
-  "The board columns, in order. A Linearlite-style issue moves left→right
-   through these as work progresses; `change-status` is the optimistic move."
+  "The board columns, in order. An issue moves left to right through these as
+   work progresses; `change-status` is the optimistic move."
   [{:id :backlog     :label "Backlog"}
    {:id :in-progress :label "In Progress"}
    {:id :done        :label "Done"}])
@@ -116,11 +97,10 @@
 ;;
 ;; The whole issue board is a single resource entry: `{:issues [...]}`. The
 ;; route ensures it on entry; the view reads it passively. Every optimistic
-;; write patches THIS one entry's `:data` in place (the exact-target
-;; `:optimistic` twin of `:patches`), and the success reply re-seeds it with
-;; the server's authoritative board via `:populates`. The runtime owns the board
-;; value, its freshness, and the snapshot inverse that makes rollback truthful
-;; (the board lives in the resource cache, not in app-db).
+;; write patches THIS one entry's `:data` in place, and the success reply
+;; re-seeds it with the server's authoritative board via `:populates`. The
+;; runtime owns the board value, its freshness, and the recorded inverse that
+;; makes rollback truthful. The board lives in the resource cache, not app-db.
 
 (rf/reg-resource :linearlite/board
   {:doc            "The whole issue board — `{:issues [...]}` — as one managed
@@ -132,18 +112,19 @@
    ;; and key the team in :params); identity params are empty.
    :params-schema  [:map]
 
-   ;; Public board: the same for every viewer → the explicit, auditable global
-   ;; claim (Spec 016 §Scope resolution — there is no implicit default). A
-   ;; per-team board would carry a scope resolver instead.
+   ;; Public board: the same for every viewer, so the scope is the explicit
+   ;; global claim (there is no implicit default). A per-team board would carry
+   ;; a scope resolver instead. Guide:
+   ;; ../../../docs/resources/glossary.md#scope
    :scope          :rf.scope/global
 
    :stale-after-ms 60000
    :gc-after-ms    (* 5 60 1000)
 
-   ;; A board tag so a write COULD invalidate the whole board by tag. The
-   ;; optimistic writes below patch the entry directly (immediate) and re-seed
-   ;; via :populates on commit, so they need no coarse invalidation; the tag is
-   ;; kept so a future server-push / external change can stale the board.
+   ;; A board tag so an external change (a server push, say) can invalidate the
+   ;; whole board by tag. The optimistic writes below patch the entry directly
+   ;; and re-seed via `:populates` on commit, so they need no coarse
+   ;; invalidation. Guide: ../../../docs/resources/glossary.md#cache-tag
    :tags           (fn [_params _data] #{[:board]})}
   (fn [_params _ctx]
     {:request {:method :get :url "/api/board"}
@@ -154,23 +135,22 @@
 ;; ============================================================================
 
 (def ^:private board-key
-  "The single map-form exact resource target the board lives under — the same
-   `{:resource :scope :params}` shape the route ensured it under, reused as the
-   `:optimistic` / `:populates` key. (Empty :params ⇒ the one public board.)"
+  "The exact resource target the board lives under: a `{:resource :scope
+   :params}` map, reused as the `:optimistic` and `:populates` key. Empty
+   `:params` means the one public board."
   {:resource :linearlite/board :scope :rf.scope/global :params {}})
 
 (def ^:private board-query
-  "The query map the view's `[:rf.resource/data …]` sub reads — the board
-   identity (resource + scope + params), the SAME identity the route ensured
-   under and the writes patch."
+  "The query map the view's `[:rf.resource/data …]` sub reads — the same board
+   identity (resource + scope + params) the route ensured under and the writes
+   patch."
   {:resource :linearlite/board :scope :rf.scope/global :params {}})
 
-;; A monotone counter for client-minted optimistic ids (a demo seam). A NEW
-;; issue gets a stable `tmp-N` id the moment its optimistic card appears, so it
-;; has a stable React key before the server assigns its own. The success reply
-;; re-seeds the whole board with the server's value (carrying the server id), so
-;; the temporary id never leaks past commit; a rollback simply removes the
-;; never-committed card.
+;; A counter for client-minted optimistic ids. A new issue gets a stable `tmp-N`
+;; id the moment its optimistic card appears, so it has a stable React key before
+;; the server assigns its own. The success reply re-seeds the whole board with
+;; the server's value (carrying the server id), so the temporary id never leaks
+;; past commit; a rollback simply removes the never-committed card.
 (defonce ^:private optimistic-id-seq (atom 0))
 
 (defn- next-issue-id
@@ -189,8 +169,8 @@
 
 (defn- patch-issue
   "Return a board-`:data` patch fn that applies `f` to the issue with `id`,
-   leaving the rest of the board untouched. The runtime records the inverse, so
-   this fn never describes how to undo itself."
+   leaving the rest of the board untouched. Forward only — the runtime records
+   the inverse, so this fn never describes how to undo itself."
   [id f]
   (fn [data]
     (update data :issues
@@ -202,16 +182,15 @@
 ;; THE MUTATIONS — create / edit-title / change-status, all OPTIMISTIC
 ;; ============================================================================
 ;;
-;; Each write declares `:optimistic` (the exact-target forward patch over the
-;; board entry, applied at phase 1.5 before the request), `:populates` (the
-;; commit — re-seed the board with the server's authoritative value on :ok),
-;; and `:on-conflict :invalidate` (the default rollback conflict policy, named
-;; for the dogfood). The runtime records the snapshot inverse + each entry's
-;; revision itself; the reply settles deterministically (commit / rollback).
+;; Each write declares `:optimistic` (the forward patch over the board entry,
+;; applied before the request), `:populates` (the commit — re-seed the board
+;; with the server's authoritative value on `:ok`), and `:on-conflict
+;; :invalidate` (the default conflict policy). The runtime records the inverse
+;; and each entry's revision itself; the reply settles deterministically.
 ;;
-;; Writes do NOT retry (reads-retry / writes-don't, Spec 014) — a 503 surfaces
-;; as `:error` and rolls the optimistic change back, which is exactly the
-;; behaviour the demo's 'fail the next write' toggle exhibits.
+;; Writes do NOT retry (reads retry, writes don't) — a 503 surfaces as `:error`
+;; and rolls the optimistic change back, which is what the demo's 'fail the next
+;; write' toggle exercises.
 
 (rf/reg-mutation :linearlite/create-issue
   {:doc           "Create an issue (optimistic). POST /api/issues. The new card
@@ -219,9 +198,9 @@
                    it back out."
    :params-schema [:map [:id :string] [:title :string]]
    :scope         :rf.scope/global
-   ;; FORWARD: append a new Backlog card to the board immediately (phase 1.5).
-   ;; `:id` is the client-minted optimistic id so the card has a stable React
-   ;; key before the server assigns one.
+   ;; FORWARD: append a new Backlog card to the board immediately, before the
+   ;; request is sent. `:id` is the client-minted optimistic id so the card has
+   ;; a stable React key before the server assigns one.
    :optimistic    (fn [{:keys [id title]}]
                     {board-key
                      (fn [data]
@@ -230,14 +209,13 @@
                                  (upsert-issue issues
                                                {:id id :title title :status :backlog
                                                 :optimistic? true}))))})
-   ;; COMMIT: the :ok reply is the server's whole authoritative board; re-seed
-   ;; the board entry with it (Spec 016 §Populate is an authoritative load), so
-   ;; the temporary id is replaced by the server's and the optimistic flag
-   ;; clears. Same `{:issues …}` envelope the resource stores.
+   ;; COMMIT: the `:ok` reply is the server's whole authoritative board; re-seed
+   ;; the board entry with it, so the temporary id is replaced by the server's
+   ;; and the optimistic flag clears. Same `{:issues …}` envelope the resource
+   ;; stores.
    :populates     (fn [_params result] {board-key result})
-   ;; ROLLBACK conflict policy (the default, named for the dogfood): on a
-   ;; contested rollback, the read path refetches rather than restoring a stale
-   ;; inverse.
+   ;; ROLLBACK conflict policy (the default): on a contested rollback, the read
+   ;; path refetches rather than restoring a stale inverse.
    :on-conflict   :invalidate}
   (fn [{:keys [title]} _ctx]
     {:request {:method :post :url "/api/issues"
@@ -279,18 +257,16 @@
 ;; ============================================================================
 ;;
 ;; This example ships no backend, so it overrides `:rf.http/managed` (the fx
-;; resources + mutations lower every read/write onto) with a stub that holds
-;; the canonical board in a closure and synthesises the authoritative reply for
-;; each read/write. It delegates to the framework-shipped
-;; `:rf.http/managed-canned-success` / `-failure` with `:after-ms`, so the reply
-;; rides framework `:dispatch-later` — tape-visible and time-travel-safe (not a
-;; raw js/setTimeout) — and the optimistic value paints before the reply lands.
+;; every read/write lowers onto) with a stub that holds the canonical board in a
+;; closure and synthesises the authoritative reply for each read/write. It
+;; delegates to the framework's `:rf.http/managed-canned-success` / `-failure`
+;; with `:after-ms`, so the reply rides framework `:dispatch-later` (not a raw
+;; js/setTimeout — it stays trace-visible and time-travel-safe) and the
+;; optimistic value paints before the reply lands.
 ;;
 ;; THE FAILURE SEAM. `fail-next-write?` is read from app-db at request time:
-;; when armed, the stub answers the next WRITE with a 503 (via
-;; `:rf.http/managed-canned-failure`) and disarms — so a single click drives
-;; the whole optimistic-apply → request → rollback arc the demo headlines.
-;; Mirrors examples/reagent/infinite_feed/core.cljs's per-request stub.
+;; when armed, the stub answers the next WRITE with a 503 and disarms, so a
+;; single click drives the whole optimistic-apply → request → rollback arc.
 
 (def ^:private demo-reply-delay-ms
   "How long the demo stub defers each canned reply (via `:after-ms` →
@@ -299,9 +275,9 @@
   220)
 
 ;; The canonical server board the stub maintains across requests, so a committed
-;; write persists into the next read (the stub IS the demo server). A NEW write
-;; minting a server id, a retitle, and a status move all mutate this atom on a
-;; successful write so the next board read reflects them.
+;; write persists into the next read (the stub IS the demo server). A create, a
+;; retitle, and a status move all mutate this atom on a successful write, so the
+;; next board read reflects them.
 (defonce ^:private demo-board
   (atom {:issues [{:id "srv-1" :title "Wire up the optimistic board" :status :in-progress}
                   {:id "srv-2" :title "Render the three status columns" :status :done}
@@ -364,9 +340,8 @@
           url       (str (:url req))
           body      (:body req)
           write?    (not= method :get)
-          ;; The fx context carries the envelope frame as `:frame` (EP-0002 —
-          ;; the same stamp the canned-stub bodies read). Read the demo seam
-          ;; flag off that frame's runtime db.
+          ;; The fx context carries the envelope frame as `:frame`. Read the
+          ;; demo seam flag off that frame's runtime db.
           db        (rf/runtime-db-value (:frame frame-ctx))
           fail?     (and write? (boolean (:fail-next-write? db)))]
       (if fail?
@@ -504,9 +479,8 @@
 (reg-view issue-card [{:keys [issue editing]}]
   (let [{:keys [id title status optimistic?]} issue
         editing-this? (= id (:id editing))
-        ;; Watch this card's in-flight writes passively. `:optimistic?` (the
-        ;; derived Rider-1 flag) is true while a live optimistic apply is
-        ;; showing between phase 1.5 and settle; `:error?` flags the last
+        ;; Watch this card's in-flight writes passively. `:optimistic?` is true
+        ;; while a live optimistic apply is showing; `:error?` flags the last
         ;; write's failure (the optimistic value has already rolled back).
         edit-state    @(subscribe [:rf.mutation/state {:instance [:edit id]}])
         status-state  @(subscribe [:rf.mutation/state {:instance [:status id]}])
@@ -598,15 +572,15 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; The React root is materialised lazily inside `run` (not at ns-load) per
-;; examples/TESTING.md §Example mount-isolation convention. EP-0002: the app
-;; frame is created, configured, and provided in ONE spot — the render root's
-;; `frame-provider {:id app-frame …}` ENSURE form. On first mount it creates the
-;; frame under `app-frame` and applies the config: `:url-bound? true` so it owns
-;; the browser URL, and a `:rf.http/managed` override pointing at the canned
-;; board stub so the example runs standalone. On hot reload it reuses that same
-;; frame and keeps its app-db. Every in-tree dispatch/subscribe resolves against
-;; that id (which is why there is no separate `reg-frame` step).
+;; The React root is materialised lazily inside `run`, not at ns-load, so the
+;; example mounts only in a browser. The app frame is created, configured, and
+;; provided in one spot: the render root's `frame-provider {:id app-frame …}`.
+;; On first mount it creates the frame under `app-frame` and applies the config:
+;; `:url-bound? true` so it owns the browser URL, and a `:rf.http/managed`
+;; override pointing at the canned board stub so the example runs standalone. On
+;; hot reload it reuses that same frame and keeps its app-db. Every in-tree
+;; dispatch and subscribe resolves against that id. Guide:
+;; ../../../docs/routing/glossary.md#url-bound
 ;;
 ;; The board is seeded by route entry, not at boot: the `:linearlite.app/board`
 ;; route's `:resources` metadata ensures it, driven by the initial URL sync
@@ -622,9 +596,8 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; ENSURE form: the app frame is created and configured in one spot. First
-    ;; mount creates it under `app-frame` and applies the config; hot reload
-    ;; reuses it.
+    ;; The app frame is created and configured here. First mount creates it
+    ;; under `app-frame` and applies the config; hot reload reuses it.
     (rdc/render @react-root
                 [rf/frame-provider {:id           app-frame
                                     :doc          "Linearlite optimistic-board demo frame."

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -1,175 +1,102 @@
 (ns login.core
-  "Worked end-to-end example: a login feature using the current re-frame2 API.
+  "Worked end-to-end example: a login feature.
 
    The one idea: a feature's whole lifecycle — idle, submitting, error,
-   success, lockout — modelled as a single state MACHINE rather than a
+   success, lockout — is modelled as a single state machine rather than a
    scatter of boolean flags. Five states, named transitions, a `:data`
    slot for the attempt counter; you are always in exactly one state, and
-   every legal move is readable off the transition table below.
+   every legal move is readable off the transition table below. See the
+   machines guide (docs/machines/concepts.md) and its glossary
+   (docs/machines/glossary.md).
 
-   Demonstrates:
-   - Feature scaffold (CP-6)              — the :auth.login/* registry slice
-   - Schema attachment (CP-8)              — Malli schema for the machine snapshot
-   - Event handlers (CP-1)                 — pure (state, event) → effects
-   - Subscriptions (CP-2)                  — pure derivations off the machine snapshot
-   - Managed HTTP (Spec 014)                — :rf.http/managed plus a per-app
-                                                demo stub that resolves the
-                                                request locally so the example
-                                                runs without a backend.
-   - Registered view (CP-4)                — Var reference (canonical); the
-                                              login form is a CONTROLLED
-                                              Pattern-Forms view — its draft
-                                              lives in app-db at
-                                              [:auth :login-form], read via the
-                                              :auth.login/draft sub, mutated via
-                                              the :auth.login/edit-field event
-                                              (no view-local atom)
-   - Form slice (Pattern-Forms)            — the email/password draft as an
-                                              app-db slice ([:auth :login-form]);
-                                              the SLICE owns the draft, the
-                                              MACHINE owns submit/auth status
-   - State machine (CP-5)                  — login flow as a transition table
-                                              read via [:rf.runtime/machines :snapshots :auth.login/flow]
-   - State tags (Spec 005 §State tags)     — :auth/busy on :submitting,
-                                              :auth/authenticated on :authed,
-                                              :auth/locked on :locked-out.
-                                              Views query them via
-                                              `(rf/machine-has-tag? :auth.login/flow ...)`
-                                              instead of boolean-discriminator
-                                              subs. The terminal :locked-out
-                                              state (reached after the fourth
-                                              failed submit) is surfaced as a
-                                              non-interactive locked-account
-                                              panel rather than a dead-but-enabled
-                                              form.
-   - Open-map idiom                        — every shape on the wire is an open map
+   It shows how the parts fit together:
+   - State machine — the login flow as a transition table, read like any
+     derived state through a subscription on the machine id.
+   - State tags — `:auth/busy`, `:auth/authenticated`, `:auth/locked`.
+     Views ask `(rf/machine-has-tag? :auth.login/flow ...)` instead of
+     enumerating exact state names (docs/machines/glossary.md#state-tag).
+     The terminal `:locked-out` state shows as a non-interactive
+     locked-account panel, not a dead-but-enabled form.
+   - Form slice — the email/password draft is an app-db slice at
+     [:auth :login-form]. The slice owns the draft (controlled inputs,
+     no view-local atom); the machine owns submit/auth status. This is
+     the form recipe in docs/guide/how-to/build-a-form.md.
+   - Managed HTTP — `:rf.http/managed` plus a per-app demo stub that
+     resolves the request locally so the example runs without a backend
+     (docs/resources/http.md).
+   - Schemas, events, subscriptions, registered views — the everyday
+     building blocks (docs/guide/glossary.md).
 
-   Test-free per the examples policy (no inline test fn, no sibling
-   `test/` tree): the login flow this file wires is a near-twin of the
-   `:auth.login/flow` machine the sibling `state_machine_walkthrough`
-   example exercises headlessly — the
-   `state-machine-walkthrough-runs-headless` deftest in
-   `implementation/core/test/re_frame/examples_test.clj` drives the
-   happy-path / retry-then-lockout / pure machine-transition scenarios. The walkthrough
-   registers its OWN parallel `:auth.login/flow` variant (same states,
-   guards, actions; like this file it tags `:locked-out` with
-   `:auth/locked` and renders a dedicated locked-account panel). That is a
-   deliberate pedagogical variant, not the literal same registration:
-   a machine id is a per-frame registry key, never a global handle, so
-   two examples may name-share without colliding (and they never co-load
-   — the walkthrough runs JVM-headless with `remove-ns` between runs;
-   login builds standalone). Broader login contract coverage lives in
-   the substrate contract suite (`npm run test:cljs`) and the framework
-   gates (see `examples/README.md`).
+   In a real codebase this single file would split into
+   login/schema.cljc, events.cljs, subs.cljs, views.cljs, machines.cljs.
+   It is kept as one file here for brevity.
 
-   In a real codebase, this single file would be split per CP-6 conventions:
-     login/schema.cljc | events.cljs | subs.cljs | views.cljs |
-     machines.cljs | events_test.cljs
-
-   Kept as a single file here for brevity."
-  ;; Substrate note: this example runs on STOCK Reagent
-  ;; (`reagent.dom.client` + the `re-frame.adapter.reagent` adapter), like
-  ;; the rest of the `examples/reagent/` catalogue. login is the canonical
-  ;; cross-substrate base — it is mirrored 1:1 as `login-uix` and
-  ;; `login-helix` (Spec 006 §Adapter shipping convention Decision 7), so
-  ;; keeping it on the reference substrate makes the three substrate
-  ;; variants a clean apples-to-apples comparison. (`counter` /
-  ;; `counter_slim_and_fast` are the dedicated stock-vs-slim contrast pair;
-  ;; the slim build is the only one that mounts `reagent-slim`, and it
-  ;; lives under `examples/reagent-slim/`.)
+   Examples are test-free; login's behaviour is covered by the substrate
+   contract suite (`npm run test:cljs`) and the framework gates."
+  ;; This example runs on stock Reagent (`reagent.dom.client` + the
+  ;; `re-frame.adapter.reagent` adapter). login is the cross-substrate
+  ;; reference base: it is mirrored 1:1 as `login-uix` and `login-helix`,
+  ;; so keeping it on the reference substrate makes the three variants a
+  ;; clean apples-to-apples comparison.
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            ;; The Spec 010 schema surface lives in the
-            ;; day8/re-frame2-schemas artefact. Requiring the ns here
-            ;; installs its Malli validator adapter so the machine's
-            ;; `[:schemas :data]` validation (the `:where :machine-data`
-            ;; boundary, configured on the `reg-machine` spec below)
-            ;; resolves. (This example attaches no app-db schema — there
-            ;; is no `reg-app-schema` call; machine snapshots are
-            ;; runtime-db, not app-db. See :182-186 + :405-412 below.)
+            ;; Installs the Malli validator adapter so the machine's
+            ;; `[:schemas :data]` validation resolves. (This example
+            ;; attaches no app-db schema; machine snapshots are
+            ;; runtime-db, not app-db.)
             [re-frame.schemas]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine
-            ;; (called below at ns-load) and the `:rf/machine` framework
-            ;; sub resolve.
+            ;; Enables state machines: registers the hooks that make
+            ;; `rf/reg-machine` and the `:rf/machine` subscription work.
             [re-frame.machines]
-            ;; Managed-HTTP ships in day8/re-frame2-http.
-            ;; Requiring re-frame.http.managed at app boot triggers its
-            ;; load-time fx registrations (`:rf.http/managed` and
-            ;; family); without it, dispatching `:rf.http/managed`
-            ;; (used below) would fail with :rf.error/no-such-fx.
+            ;; Registers `:rf.http/managed` and family. Without this
+            ;; require, dispatching `:rf.http/managed` would fail loud.
             [re-frame.http.managed]
-            ;; This demo redirects :rf.http/managed to the canned
-            ;; stubs via :fx-overrides (no real backend ships with the
-            ;; example). The canned-stub fx ids
-            ;; (`:rf.http/managed-canned-success`,
-            ;; `:rf.http/managed-canned-failure`) register from
-            ;; re-frame.http.test-support, not re-frame.http.managed —
-            ;; the test-support require is the explicit opt-in.
+            ;; Registers the canned-success / canned-failure stub fxs the
+            ;; demo stub delegates to. This require is the opt-in
+            ;; (docs/guide/how-to/test-a-cascade.md).
             [re-frame.http.test-support]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
-;; SCHEMAS  (CP-8)
+;; SCHEMAS
 ;; ============================================================================
 ;;
-;; Open by default. The snapshot schema describes the shape of
-;; [:rf.runtime/machines :snapshots :auth.login/flow] in runtime-db (NOT
-;; app-db — per [005 §Where snapshots live]; see :136-138 below). It does not
-;; carry :closed true — this isn't a system boundary.
+;; Schemas are open by default — they describe a shape without forbidding
+;; extra keys. See docs/guide/how-to/validate-with-schemas.md.
 
-;; The submit-event payload — the credentials map the view collects from
-;; the form. Open by default; the regex/min-length checks describe the
-;; shape the inner handler relies on.
-;;
-;; The EP-0025 commit-plane `:sensitive` / `:large` classification effects (a
-;; `reg-event` returns them alongside `:db`) are the durable app-db
-;; data-classification mechanism. `Credentials` is the machine's EVENT-arg
-;; schema (it rides `AuthLoginEvent` via the machine's event `:schema`); the
-;; password is never written to durable app-db or the machine `:data` slot, so
-;; there is no app-db path to classify for it.
-;;
-;; The password's real off-box egress path is the HTTP request body — redacted
-;; by the per-request `:sensitive? true` flag on the managed-HTTP call in
-;; `:issue-request` below (Spec 014 §Privacy, a different axis from app-db
-;; classification). That carrier-level flag is the working, observable
-;; redaction for this login flow.
+;; The submit-event payload — the credentials the view collects from the
+;; form. The regex / min-length checks describe the shape the machine's
+;; submit handler relies on. The password is never written to app-db or
+;; the machine `:data`; its only off-box path is the HTTP request body,
+;; redacted by the `:sensitive? true` flag on the managed-HTTP call in
+;; `:issue-request` below (docs/resources/http.md, "Keeping secrets out
+;; of the trace").
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
    [:password [:string {:min 8}]]])
 
-;; Outer event-vector schema for the :auth.login/flow machine handler.
-;; The login form is the canonical user-facing boundary, so we validate
-;; the :submit payload STRICTLY against `Credentials`. Other sub-events
-;; (:dismiss, :success, :failure) are dispatched internally by the
-;; machine — their inner shape is framework-controlled, so we admit a
-;; framework-controlled tail. Per Spec 010 §Validation order step 1: a
-;; malformed event vector is rejected at the boundary; the handler is NOT
-;; invoked (recovery: :no-recovery).
+;; Event-vector schema for the :auth.login/flow machine. A malformed
+;; event vector is rejected at the boundary and the handler never runs.
+;; The login form is the user-facing boundary, so the :submit payload is
+;; validated strictly against `Credentials`. The other sub-events
+;; (:dismiss, :success, :failure) come from the machine itself, so their
+;; tail is admitted loosely.
 ;;
-;; The :submit branch is a `:tuple` (NOT `:cat`): the outer `:cat` consumes
-;; the nested sub-event vector as a SINGLE element, so the branch must match
-;; that one element AS a vector. A `:cat` branch would apply sequence-regex
-;; semantics and — paired with a permissive `[:vector :any]` fallback —
-;; silently re-admit a `:submit` whose `Credentials` failed (the original
-;; bug: malformed submit payloads passed the `:where :event` boundary). With
-;; the strict `:tuple` and no `[:vector :any]` escape hatch, a short-password
-;; or bad-email submit is rejected at the boundary BEFORE the machine
-;; transitions or issues the login HTTP effect.
+;; The :submit branch is a `:tuple`, not a `:cat`: the outer `:cat`
+;; consumes the nested sub-event vector as a single element, so the branch
+;; must match that one element as a vector. A short-password or bad-email
+;; submit is then rejected at the boundary before the machine transitions
+;; or issues the login HTTP request.
 ;;
-;; The trailing `[:? :any]` admits the managed-HTTP reply payload (Spec
-;; 014 §Reply addressing): the framework appends `{:kind ... :value ...}`
-;; / `{:kind ... :failure ...}` as the LAST arg of the explicit
-;; `:on-success` / `:on-failure` event vector, so the delivered reply is
-;; `[:auth.login/flow [:auth.login/success] <payload>]` — three top-level
-;; elements. Without the optional trailing slot the `:cat` rejects every
-;; reply with `:malli.core/input-remaining`, the boundary validation
-;; fails BEFORE the machine handler runs, and the flow is stranded in
-;; `:submitting`.
+;; The trailing `[:? :any]` admits the managed-HTTP reply: the framework
+;; appends the reply map (`{:kind ... :value ...}` /
+;; `{:kind ... :failure ...}`) as the last arg of the `:on-success` /
+;; `:on-failure` event vector, so a delivered reply has three top-level
+;; elements. Without the optional slot every reply would be rejected and
+;; the flow would strand in `:submitting`.
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
@@ -178,39 +105,32 @@
      [:* :any]]]
    [:? :any]])
 
-;; The login flow's runtime state lives in the machine snapshot at
-;; [:rf.runtime/machines :snapshots :auth.login/flow] (runtime-db, NOT
-;; app-db — per [005 §Where snapshots live]). Per Spec 010 §Machine data
-;; schema + Spec 005 §Schema validation, a machine declares a top-level
-;; `[:schemas :data]` that validates the snapshot's `:data` SLOT only — not
-;; the whole `{:state … :data …}` snapshot, and not an app-db path. So
-;; this schema describes the `:data` map (`:attempts` + `:error`) the
-;; machine seeds and the actions evolve; it is attached via the machine's
-;; `[:schemas :data]` slot on the `reg-machine` spec below and
-;; validates at the `:where :machine-data` boundary.
+;; A machine's live value is a snapshot — its current state plus a `:data`
+;; map — held in runtime-db, not app-db (docs/machines/glossary.md#snapshot).
+;; A machine's `[:schemas :data]` validates the `:data` slot only, not the
+;; whole snapshot. So this schema describes the `:data` map (`:attempts` +
+;; `:error`) the machine seeds and the actions evolve; it is attached via
+;; the `[:schemas :data]` slot on the spec below.
 (def AuthLoginData
   [:map
    [:attempts {:default 0} :int]
    [:error    [:maybe :string]]])
 
-;; EP-0001: machine snapshots are runtime-db state, not app-db —
-;; an `reg-app-schema` on a machine-snapshot path validates nothing (app
-;; schemas validate the app-db partition only, Mike ruling #11). The
-;; machine's own `[:schemas :data]` (attached below) is the snapshot-validation
-;; surface, so no app-schema reg applies to the login SNAPSHOT.
+;; Snapshots live in runtime-db, so app-db schemas (`reg-app-schema`) do
+;; not apply to them. The machine's own `[:schemas :data]` is the
+;; snapshot-validation surface.
 
 ;; ============================================================================
-;; FX  (Spec 014 + per-app demo stub)
+;; FX  (managed HTTP + a per-app demo stub)
 ;; ============================================================================
 ;;
-;; HTTP requests go via the framework-shipped `:rf.http/managed` (Spec 014).
-;; The example demo would normally hit `/api/login`, which we don't ship —
-;; instead we register a per-app demo stub at `:auth.login.demo/managed-stub`
-;; and override `:rf.http/managed` to it on the default frame in `run`. The
-;; stub inspects the request body's `:password` and synthesises either a
-;; success or failure reply via the framework-shipped canned-success /
-;; canned-failure fxs (Spec 014 §Testing) so the canonical reply shape is
-;; preserved end-to-end.
+;; HTTP requests go via `:rf.http/managed` (docs/resources/http.md). The
+;; login flow would normally POST `/api/login`, but this example ships no
+;; backend. So we register a demo stub at `:auth.login.demo/managed-stub`
+;; and override `:rf.http/managed` to it on the frame in `run`. The stub
+;; inspects the request body's `:password` and synthesises a success or
+;; failure reply via the framework's canned-success / canned-failure fxs,
+;; so the real reply shape is preserved end to end.
 ;;
 ;; `:auth.session/store` is client-only — localStorage is a browser API.
 
@@ -224,7 +144,7 @@
       (.setItem ls "auth/token" token))))
 
 (rf/reg-fx :auth.login.demo/managed-stub
-  {:doc       "Demo override for `:rf.http/managed`: routes by URL +
+  {:doc       "Demo override for `:rf.http/managed`: routes by URL and
                request body to canned login responses so the example
                runs standalone without a backend.
 
@@ -233,19 +153,13 @@
                POST /api/login otherwise → 401 failure.
                Anything else (e.g. /api/auth/lock) → empty success.
 
-               Delegates straight to the framework-shipped canned-success
-               / canned-failure fxs (Spec 014 §Testing) with `:after-ms`
-               the framework defers the reply via
-               `:dispatch-later` (50 ms) — observable in the tape,
-               time-travel-safe, NOT raw `js/setTimeout`. The delay lets
-               the `:submitting` UI state be observable; the reply shape
-               (`{:kind :success :value ...}` / `{:kind :failure
-               :failure ...}`) reaches the inner `:auth.login/success` /
-               `:auth.login/failure` sub-events via the explicit
-               `:on-success` / `:on-failure` form. The
-               schedule-reply → `:dispatch-later` → deliver-reply chain
-               is expressed as one `:after-ms` parameter (the delay is a
-               parameter of the same canned effect, not a new fx)."
+               Delegates to the framework's canned-success / canned-failure
+               fxs. The `:after-ms 50` defers the reply by 50 ms (via
+               `:dispatch-later`, so it stays on the tape and is
+               time-travel-safe — not a raw `js/setTimeout`). The delay
+               lets the `:submitting` UI state be visible. The reply
+               reaches the `:auth.login/success` / `:auth.login/failure`
+               sub-events through the `:on-success` / `:on-failure` form."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -272,28 +186,23 @@
           (stub frame-ctx (assoc args-map :after-ms 50 :value {})))))))
 
 ;; ============================================================================
-;; STATE MACHINE  (CP-5)
+;; STATE MACHINE
 ;; ============================================================================
 ;;
-;; The login flow is a finite state machine. Five states, named events. The
-;; spec map below is INERT DATA — a description of legal moves; its live part
-;; is the snapshot ({:state … :data …}) in runtime-db, read like any derived
-;; state. All non-trivial guards and actions live in the machine's :guards /
-;; :actions maps and are referenced by keyword from the transition table;
-;; resolution is machine-local (no global registry).
+;; The login flow is a finite state machine: five states, named events.
+;; The spec map below is inert data — a description of legal moves. Its
+;; live value is the snapshot ({:state … :data …}) in runtime-db, read
+;; like any derived state. Guards and actions live in the machine's
+;; :guards / :actions maps and are referenced by keyword from the
+;; transition table; resolution is machine-local. See
+;; docs/machines/concepts.md.
 
-;; The login flow's machine spec.
+;; The login flow's machine spec. The spec carries no :id — the machine's
+;; id is the registration id below.
 (def auth-login-machine
-  ;; Per Spec 005 §Where snapshots live: the spec map does NOT carry :id;
-  ;; the machine's id is the surrounding registration id.
   {:initial :idle
-   ;; Spec 005 §Schema validation — `[:schemas :data]` validates the
-   ;; snapshot's `:data` slot (not the whole snapshot) at the
-   ;; `:where :machine-data` boundary. The macrostep walker resolves it
-   ;; via `(machine-meta :auth.login/flow)`; the `reg-machine` event-`:schema`
-   ;; arity below stamps the machine metadata that makes it live. Malformed
-   ;; `:data` (e.g. a non-string `:error`) fails the run with
-   ;; `:rf.error/schema-validation-failure :where :machine-data`.
+   ;; `[:schemas :data]` validates the snapshot's `:data` slot. Malformed
+   ;; `:data` (e.g. a non-string `:error`) fails the run loud.
    :schemas {:data AuthLoginData}
    :data    {:attempts 0 :error nil}
 
@@ -311,18 +220,16 @@
 
       :issue-request
       ;; Issue the login HTTP request. Returns effects, not side-effects.
-      ;; Spec 014 reply: explicit :on-success / :on-failure events have the
-      ;; reply payload (`{:kind :success :value ...}` / `{:kind :failure
-      ;; :failure ...}`) appended as their last arg by the runtime.
+      ;; The runtime appends the reply (`{:kind :success :value ...}` /
+      ;; `{:kind :failure :failure ...}`) as the last arg of the
+      ;; :on-success / :on-failure events.
       (fn [{[_ creds] :event}]
         {:fx [[:rf.http/managed
-               ;; Spec 014 §Privacy (per-request `:sensitive?`): `:sensitive? true`
-               ;; on the request redacts the request body (carrying the
-               ;; `:password`) and all params from every `:rf.http/*` trace event
-               ;; — the password's real off-box egress path. This is the coarse
-               ;; per-request privacy flag (a wire scrub for THIS request), a
-               ;; distinct surface from EP-0025 path classification; both keep the
-               ;; password off the observability wire for the login flow.
+               ;; `:sensitive? true` redacts the request body (carrying
+               ;; the password) and all params from every `:rf.http/*`
+               ;; trace event — the wire scrub for this request
+               ;; (docs/resources/http.md, "Keeping secrets out of the
+               ;; trace").
                {:request    {:method :post
                              :url    "/api/login"
                              :body   creds
@@ -341,13 +248,10 @@
 
       :lock-account
       ;; Mark the account as locked after too many failed attempts.
-      ;; Fire-and-forget telemetry beacon (Spec 014 §Reply addressing
-      ;; "Silenced"): the lockout POST wants no reply folded back into the
-      ;; machine. `:on-success nil` / `:on-failure nil` silence both reply
-      ;; branches explicitly — without them the omitted-target default
-      ;; (co-located addressing) would dispatch
-      ;; `[:auth.login/flow {:rf/reply ...}]`, a map in the sub-event slot
-      ;; that `AuthLoginEvent` rejects, stranding noise after lockout.
+      ;; Fire-and-forget: the lockout POST wants no reply folded back into
+      ;; the machine, so `:on-success nil` / `:on-failure nil` silence
+      ;; both reply branches. (Without them the default would dispatch a
+      ;; reply event that `AuthLoginEvent` rejects.)
       (fn [_]
         {:fx [[:rf.http/managed
                {:request    {:method :post :url "/api/auth/lock"}
@@ -365,10 +269,10 @@
                                 :action :clear-error}}}
 
       :submitting
-      ;; State tag — *ask, don't tell*. Views query (rf/machine-has-tag?
+      ;; State tag — ask, don't tell. Views query (rf/machine-has-tag?
       ;; :auth.login/flow :auth/busy) to disable inputs and re-label the
       ;; submit button, rather than asking "are we exactly :submitting?".
-      ;; Tag a sixth busy-ish state :auth/busy later and no view changes.
+      ;; Add another busy state tagged :auth/busy and no view changes.
       {:tags  #{:auth/busy}
        :entry :issue-request
        ;; The failure branch is an ORDERED list of candidate transitions:
@@ -403,8 +307,7 @@
       ;; :auth/locked tag — after the fourth failed submit the flow lands
       ;; in this terminal state. Views query
       ;; (rf/machine-has-tag? :auth.login/flow :auth/locked) to swap the
-      ;; form for a locked-account panel and refuse further submits — same
-      ;; tag + locked-panel pattern as the state-machines walkthrough. A
+      ;; form for a locked-account panel and refuse further submits. A
       ;; terminal lockout must be visible and non-interactive, not a live
       ;; form.
       {:tags #{:auth/locked}
@@ -412,49 +315,34 @@
 
 ;; Register the machine as the `:auth.login/flow` event handler.
 ;;
-;; This machine ALSO validates its dispatched event VECTOR (against
-;; `AuthLoginEvent`), so it uses `reg-machine`'s event-`:schema` arity:
-;; the optional opts map carries the event `:schema` (the
-;; `:where :event` boundary on the dispatched outer vector) alongside the
-;; machine spec. `reg-machine` is the blessed registration home — it stamps
-;; the `:rf/machine?` / `:rf/machine` metadata that `(machine-meta
-;; :auth.login/flow)` reads, so the `:where :machine-data` walker resolves the
-;; `[:schemas :data]` and it VALIDATES. (EP-0025: durable machine `:data`
-;; snapshot-egress classification is a projection-relative `:sensitive` /
-;; `:large` declaration on the machine spec — this machine's `:data` holds no
-;; secret, so it declares none. The `[:schemas :data]` prop drives only
-;; validation-failure-trace redaction, not snapshot egress.)
+;; This machine also validates its dispatched event vector, so the opts
+;; map carries the event `:schema` (the boundary on the outer vector)
+;; alongside the machine spec.
 (rf/reg-machine :auth.login/flow
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema AuthLoginEvent}
   auth-login-machine)
 
 ;; ============================================================================
-;; EVENTS  (CP-1)
+;; EVENTS
 ;; ============================================================================
 ;;
-;; The machine handler (registered above as :auth.login/flow via reg-machine)
-;; is self-initialising: its `:initial` state and
-;; `:data` seed [:rf.runtime/machines :snapshots :auth.login/flow] when the machine first runs.
-;; No separate machine :initialise event is required (per [005 §Restore
-;; semantics]).
+;; The machine handler is self-initialising: its `:initial` state and
+;; `:data` seed the snapshot when the machine first runs. No separate
+;; machine :initialise event is needed.
 ;;
-;; The FORM-SLICE events below are the other half of the Pattern-Forms
-;; "machine + slice" composition (spec/Pattern-Forms.md §Variations). The
-;; SLICE owns the DRAFT — what the user is currently typing — at the app-db
-;; path [:auth :login-form]; the MACHINE owns submit/auth STATUS. This is the
-;; reason the form refactor exists: a form's draft is APPLICATION STATE, so it
-;; lives in app-db (projected via subs, mutated via events), NOT in a
-;; view-local Reagent atom / framework hook. Inputs are CONTROLLED: `:value`
-;; reads the draft sub, `:on-change` dispatches `:auth.login/edit-field`. The
-;; slice shape + the standard form events mirror the in-repo exemplar
-;; examples/reagent/realworld/auth.cljs 1:1.
+;; The form-slice events below are the other half of the "machine + slice"
+;; split. The slice owns the draft — what the user is currently typing —
+;; at app-db [:auth :login-form]; the machine owns submit/auth status. A
+;; form's draft is application state, so it lives in app-db (read via subs,
+;; written via events), not in a view-local atom. Inputs are controlled:
+;; `:value` reads the draft sub, `:on-change` dispatches
+;; `:auth.login/edit-field`. This is the form recipe in
+;; docs/guide/how-to/build-a-form.md.
 ;;
-;; This whole block — slice defaults + form events + (below) the draft/slice
-;; subs — is the SUBSTRATE-AGNOSTIC artefact layer: it is byte-identical
-;; across examples/reagent/login, examples/uix/login_uix, and
-;; examples/helix/login_helix (Spec 006 §Adapter shipping convention Decision
-;; 7). Only the view syntax varies across the three.
+;; This block — slice defaults, form events, and the draft/slice subs
+;; below — is substrate-agnostic: it is identical across the reagent, uix,
+;; and helix login examples. Only the view syntax differs.
 
 ;; The login form's default (empty) draft. The draft's value shape is
 ;; `Credentials` (email regex + min-8 password) — the same schema the
@@ -490,21 +378,19 @@
              (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 
 ;; Submit. Reads the draft out of the slice, latches `:submit-attempted?`,
-;; flips the slice `:status` to `:submitting`, and dispatches the draft INTO
+;; flips the slice `:status` to `:submitting`, and dispatches the draft into
 ;; the machine — the only point the draft crosses into the machine (and is
-;; validated against `Credentials` at the machine's `:where :event` boundary).
-;; The machine, not the slice, then owns the in-flight / authed / error /
-;; locked status; the slice `:status` mirror keeps the slice a conformant
-;; Pattern-Forms shape.
+;; validated against `Credentials` at the event boundary). The machine, not
+;; the slice, then owns the in-flight / authed / error / locked status; the
+;; slice `:status` is a mirror.
 ;;
-;; Secret-field hygiene (skills/re-frame2/patterns/forms.md §Auth): the
-;; handler reads the password off the draft and hands it to the machine, then
-;; CLEARS `[:draft :password]` in the same commit — once the request is in
-;; flight the secret has done its job, so it does not sit in durable app-db
-;; waiting for the next snapshot / recorder capture. The password's only
-;; off-box path is the HTTP request body (scrubbed by the per-request
+;; Secret-field hygiene: the handler reads the password off the draft, hands
+;; it to the machine, then clears `[:draft :password]` in the same commit.
+;; Once the request is in flight the secret has done its job, so it does not
+;; sit in app-db waiting for the next snapshot or recorder capture. The
+;; password's only off-box path is the HTTP request body (scrubbed by the
 ;; `:sensitive? true` flag); it is never written to `:submitted` or the
-;; machine `:data`.
+;; machine `:data`. See docs/guide/how-to/add-auth.md.
 (rf/reg-event :auth.login/submit-form
   {:doc "Submit the login form: read the draft from the slice, dispatch it
          into the :auth.login/flow machine's :submit sub-event, and clear the
@@ -531,16 +417,16 @@
                     :submit-error      nil})}))
 
 ;; ============================================================================
-;; SUBSCRIPTIONS  (CP-2)
+;; SUBSCRIPTIONS
 ;; ============================================================================
 
-;; The machine snapshot lives at [:rf.runtime/machines :snapshots :auth.login/flow] (per
-;; Spec 005). These named subs project out the convenient pieces. The
-;; "in :submitting?" and "in :authed?" predicates live as the
-;; `rf/machine-has-tag?` queries in views below (per Spec 005 §State tags).
+;; These named subs project the convenient pieces out of the machine
+;; snapshot. The "in :submitting?" / "in :authed?" predicates instead live
+;; as `rf/machine-has-tag?` queries in the views below
+;; (docs/machines/glossary.md#state-tag).
 
-;; EP-0001: machine snapshots are durable runtime-db state — read
-;; them through the framework `:rf/machine` sub (the public surface).
+;; Read the snapshot through the framework `:rf/machine` sub — the public
+;; surface for a machine's live value (docs/machines/glossary.md#snapshot).
 (rf/reg-sub :auth.login/state
   {:doc "Current state of the login flow."}
   :<- [:rf/machine :auth.login/flow]
@@ -553,13 +439,13 @@
   (fn sub-auth-login-error [snapshot _]
     (get-in snapshot [:data :error])))
 
-;; --- Form-slice subs (Pattern-Forms; substrate-agnostic) -------------------
+;; --- Form-slice subs (substrate-agnostic) ----------------------------------
 ;;
 ;; The login-form slice lives at app-db [:auth :login-form]. The view reads
-;; the DRAFT through `:auth.login/draft` and binds each input's `:value` to it
-;; — controlled inputs. The per-field-error sub follows the Pattern-Forms
-;; visibility rule (touched OR submit-attempted?). These subs are part of the
-;; byte-identical artefact layer shared across the three substrate examples.
+;; the draft through `:auth.login/draft` and binds each input's `:value` to
+;; it — controlled inputs. The per-field-error sub follows the form
+;; visibility rule (touched OR submit-attempted?). These subs are shared
+;; identically across the three substrate examples.
 
 (rf/reg-sub :auth.login/form-slice
   {:doc "The whole login-form slice at [:auth :login-form]."}
@@ -574,9 +460,9 @@
     (:draft slice)))
 
 (rf/reg-sub :auth.login/field-error
-  {:doc "Per-field validation error for the login form. Per Pattern-Forms
-         §Error visibility: reveal a field's error once it is :touched OR once
-         the form has had its first submit click."}
+  {:doc "Per-field validation error for the login form. Reveal a field's
+         error once it is :touched OR once the form has had its first
+         submit click (docs/guide/how-to/build-a-form.md)."}
   :<- [:auth.login/form-slice]
   (fn sub-auth-login-field-error [slice [_ field]]
     (when (or (:submit-attempted? slice)
@@ -584,23 +470,21 @@
       (first (get-in slice [:errors field])))))
 
 ;; ============================================================================
-;; VIEWS  (CP-4)
+;; VIEWS
 ;; ============================================================================
 ;;
-;; Var-reference style (canonical per [004 §How registered views are used in
-;; hiccup]). `reg-view` auto-injects `dispatch` / `subscribe` as lexical
-;; bindings inside the view body — they are the ops of a frame-handle the
-;; macro captures at render time, so they stay bound to the render-time
-;; frame (no ambient lookup, survives async callbacks).
+;; `reg-view` injects `dispatch` / `subscribe` as locals inside the view
+;; body, bound to the frame the view renders under — so the same view can
+;; mount in several isolated frames at once (docs/guide/concepts/views.md).
 
-;; Controlled-input login form (Pattern-Forms). The form holds NO view-local
-;; state: there is no `reagent.core/atom`. Each input's `:value` reads the
-;; draft from the `:auth.login/draft` sub, and `:on-change` DISPATCHES
-;; `:auth.login/edit-field` (it never sets view-local state). Submit dispatches
-;; `:auth.login/submit-form`, which reads the draft from app-db and hands it to
-;; the machine. The in-flight / error state comes from the machine (the
-;; `:auth/busy` tag + the `:auth.login/error` sub) — the slice owns the draft,
-;; the machine owns submit/auth status.
+;; Controlled-input login form. The form holds no view-local state: there
+;; is no `reagent.core/atom`. Each input's `:value` reads the draft from the
+;; `:auth.login/draft` sub, and `:on-change` dispatches
+;; `:auth.login/edit-field`. Submit dispatches `:auth.login/submit-form`,
+;; which reads the draft from app-db and hands it to the machine. The
+;; in-flight / error state comes from the machine (the `:auth/busy` tag and
+;; the `:auth.login/error` sub) — the slice owns the draft, the machine
+;; owns submit/auth status.
 (reg-view ^{:doc "The login form view: email + password + submit button + error display."}
           login-form []
   (let [draft @(subscribe [:auth.login/draft])
@@ -657,10 +541,9 @@
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not
+;; at ns-load: loading the namespace must produce no DOM side effects, so
+;; co-required example namespaces don't race `create-root` onto `#app`.
 (defonce react-root (atom nil))
 
 (defn run []
@@ -669,23 +552,23 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; EP-0026: one-spot frame setup. The `frame-provider` ENSURE shape
-    ;; (`{:id …}`) creates `:rf/default` on first mount, applies the config
-    ;; below, runs `:initial-events` once, and scopes the frame into React.
-    ;; On hot reload it reuses the existing frame and skips re-seeding.
+    ;; One-spot frame setup. The `frame-provider` ensure shape (`{:id …}`)
+    ;; creates `:rf/default` on first mount, applies the config below, runs
+    ;; `:initial-events` once, and scopes the frame into React. On hot
+    ;; reload it reuses the existing frame and skips re-seeding.
+    ;; See docs/guide/concepts/frames.md.
     ;;
     ;; - `:fx-overrides` routes `:rf.http/managed` to the in-process login
     ;;   stub above so the example runs standalone — no backend required.
-    ;; - `:initial-events` seeds the login-form slice to its empty
-    ;;   Pattern-Forms shape so the controlled inputs read a real
-    ;;   (empty-string) draft from the first render. (An uninitialised draft
-    ;;   would feed React `nil` :values — uncontrolled inputs.) The machine
-    ;;   self-initialises; the SLICE is app-db, so it is seeded here.
+    ;; - `:initial-events` seeds the login-form slice so the controlled
+    ;;   inputs read a real (empty-string) draft from the first render. An
+    ;;   uninitialised draft would feed React `nil` :values — uncontrolled
+    ;;   inputs. The machine self-initialises; the slice is app-db, so it is
+    ;;   seeded here.
     ;;
-    ;; The provider scope is what makes the `reg-view`-injected
-    ;; `dispatch`/`subscribe` (and the login machine reads) resolve to
-    ;; `:rf/default`. A `reg-view` rendered with no provider raises
-    ;; `:rf.error/no-frame-context`.
+    ;; The provider scope is what makes the injected `dispatch`/`subscribe`
+    ;; (and the machine reads) resolve to `:rf/default`. A `reg-view`
+    ;; rendered with no provider fails loud.
     (rdc/render @react-root
                 [rf/frame-provider {:id             :rf/default
                                     :doc            "Login demo frame."

--- a/examples/reagent/login/stories.cljs
+++ b/examples/reagent/login/stories.cljs
@@ -1,29 +1,23 @@
 (ns login.stories
-  "Story showcase for the **login** worked example.
+  "Story showcase for the login worked example.
 
-   The login form's view-states form a natural Story VARIANT SET —
-   Story's core strength is enumerating a single view's view-states
-   side by side. This file registers one `reg-variant` per reachable
-   state of the example's `:auth.login/flow` machine so the Story
-   controls panel flips the page through every state without the
-   reader hand-driving the form.
+   The login form's view-states make a natural Story variant set —
+   Story's strength is enumerating one view's states side by side. This
+   file registers one `reg-variant` per reachable state of the example's
+   `:auth.login/flow` machine, so the controls panel flips the page
+   through every state without the reader hand-driving the form. See the
+   Story guide (docs/story/index.md).
 
-   ## The variant set — grounded in the example's real machine
-
-   `login.core` models the login flow as the five-state
-   `:auth.login/flow` machine (`spec/005`):
+   The machine has five states:
 
        :idle → :submitting → {:error-shown | :authed | :locked-out}
 
-   The variants below map onto the states a reader actually reaches,
-   driven through REAL events (fidelity `:event`) — the bead's
-   highest-fidelity requirement, mirroring the nine_states showcase:
+   The variants map onto the states a reader actually reaches, each
+   driven through real events:
 
      :story.login/empty               — fresh `:idle` form.
      :story.login/filled              — a draft typed into the app-db
-                                        login-form slice via real
-                                        `:auth.login/edit-field` events;
-                                        still `:idle`, nothing submitted.
+                                        login-form slice; still `:idle`.
      :story.login/submitting          — request in flight, `:submitting`
                                         (`:auth/busy`), inputs disabled.
      :story.login/invalid-credentials — a malformed `:submit` rejected
@@ -31,29 +25,15 @@
                                         Xray's Issues ribbon.
      :story.login/auth-error          — `:error-shown` after a 401.
      :story.login/locked-out          — `:locked-out` after the retry
-                                        limit is exceeded (the example's
-                                        distinctive fourth terminal
-                                        state — no testbed counterpart).
+                                        limit is exceeded.
      :story.login/success             — `:authed` welcome banner; the
                                         canonical screenshot.
 
-   ### The `:filled` variant is event-reachable now
+   The auth-submit cascade in Xray
 
-   The bead's conceptual list names a `filled` state. Since the login
-   form was refactored to Pattern-Forms, the email/password DRAFT lives
-   in app-db at `[:auth :login-form]` (NOT a component-local Reagent
-   atom), mutated by the `:auth.login/edit-field` event. A Story
-   `:setup` drives EVENTS — so `:filled` is now honestly reachable at
-   fidelity `:event` by dispatching real edit-field events to seed the
-   draft, exactly the way a user's keystrokes would. No synthetic
-   `:db-seed` is needed; the variant below stays event-honest.
-
-   ## Xray-richness — the auth-submit cascade
-
-   Story allocates each variant its own frame under `:preset :story`
-   (spec/002 §Frame presets), which redirects `:rf.http/managed` to
-   the framework-shipped `:rf.http/managed-canned-success` stub. So a
-   real submit runs the FULL auth cascade end to end:
+   Each variant runs in its own frame under `:preset :story`, which
+   redirects `:rf.http/managed` to the framework's canned-success stub.
+   So a real submit runs the full auth cascade end to end:
 
        [:auth.login/flow [:auth.login/submit creds]]   (→ :submitting)
          → machine `:issue-request` action
@@ -62,33 +42,25 @@
                  → [:auth.login/flow [:auth.login/success …]]
                      → :authed
 
-   That whole chain lands on the Epoch tape + the Trace stream, and the
+   The whole chain lands on the Epoch tape and the Trace stream, and the
    `:rf.http/managed` fx shows in the Side Effects panel — pick the
-   `:success` variant, press Ctrl+Shift+C, and watch the submit cascade
-   light up Xray end to end.
+   `:success` variant, press Ctrl+Shift+C, and watch it light up.
 
-   Two variants light Xray's Issues ribbon (the bead's failure-path
-   requirement):
+   Two variants light Xray's Issues ribbon:
      - `:invalid-credentials` — the malformed `:submit` is rejected by
-       the `Credentials` schema at the event boundary (`:no-recovery`);
-       the handler never runs and an Issue is raised.
+       the `Credentials` schema at the event boundary; the handler never
+       runs and an Issue is raised.
      - `:auth-error` / `:locked-out` — a 401 failure cascade; the
        `:rf.http/managed` request fires (Side Effects) and the
        `:auth.login/failure` follow-on records the error.
 
-   ## Authoring discipline
+   Every variant body is plain data — no fn-slots. The view at the
+   centre of each is the example's own `login.core/root-view`,
+   referenced by id. The canonical Story tags auto-install on the first
+   `reg-*` call, so no explicit boot step is needed.
 
-   Per spec/007 §Variants every variant body is plain data — no
-   fn-slots. The view at the centre of each variant is the example's
-   own `login.core/root-view`, referenced by id. The canonical Story
-   tags auto-install on the first `reg-*` call, so no
-   explicit boot step is needed.
-
-   This is a parallel SHOWCASE to the gate-side `login_form` testbed
-   (`tools/story/testbeds/login_form`), which stays the fixture for
-   Story's own tests. Examples are test-free: these
-   stories carry NO `:script` / `:rf.assert/*` — they are a showcase,
-   not a test surface."
+   Examples are test-free: these stories carry no `:script` /
+   `:rf.assert/*` — they are a showcase, not a test surface."
   (:require [re-frame.core :as rf]
             [re-frame.story :as story]
             ;; Source the example's registrations (the machine, schemas,
@@ -100,24 +72,20 @@
 ;; ---------------------------------------------------------------------------
 ;; Story-side submit event — the Xray-rich auth-submit cascade.
 ;;
-;; The live example's machine `:issue-request` action issues a real
-;; `:rf.http/managed` request to `/api/login` and routes the reply back
-;; through `:auth.login/success` / `:auth.login/failure`. In the live
-;; `#/` app, `login.core/run` redirects `:rf.http/managed` to the demo
-;; stub. Inside the Story shell each variant frame runs under
-;; `:preset :story`, which redirects `:rf.http/managed` to the
-;; framework-shipped `:rf.http/managed-canned-success` stub instead —
-;; that stub echoes the request's `:value` slot back as the success
-;; payload (Spec 014 §Testing).
+;; The machine's `:issue-request` action issues a real `:rf.http/managed`
+;; request and routes the reply back through `:auth.login/success` /
+;; `:auth.login/failure`. Each variant frame runs under `:preset :story`,
+;; which redirects `:rf.http/managed` to the framework's canned-success
+;; stub (that stub echoes the request's `:value` slot back as the success
+;; payload).
 ;;
-;; So this Story submit event simply dispatches the real
-;; `:auth.login/submit` sub-event: the SAME machine action fires the
-;; SAME real `:rf.http/managed` fx (visible in Xray's Side Effects
-;; panel), and the canned-success stub resolves it deterministically —
-;; no app-side fx-override required. The success reply's `:value` is the
-;; stub's echo of the (absent) request `:value`, i.e. nil; the welcome
-;; banner keys off the `:auth/authenticated` tag, not the value, so the
-;; cascade lands cleanly at `:authed`.
+;; So this event simply dispatches the real `:auth.login/submit`
+;; sub-event: the same machine action fires the same real
+;; `:rf.http/managed` fx (visible in Xray's Side Effects panel), and the
+;; canned-success stub resolves it — no app-side fx-override needed. The
+;; reply `:value` is nil (the request carries none), but the welcome
+;; banner keys off the `:auth/authenticated` tag, so the cascade lands
+;; cleanly at `:authed`.
 ;; ---------------------------------------------------------------------------
 
 (rf/reg-event :login.story/submit
@@ -134,11 +102,9 @@
 ;; ---------------------------------------------------------------------------
 ;; register-all!
 ;;
-;; Wrap every registration in a top-level fn so a hot-reload could
-;; re-fire the lot after a clear-all!. The fn fires once at namespace
-;; load via the trailing call, so consumers who just `:require` this ns
-;; get the side-table populated. (No test fixture — examples are
-;; test-free.)
+;; Every registration lives in one top-level fn so a hot-reload can
+;; re-fire the lot. The fn runs once at namespace load via the trailing
+;; call, so requiring this ns populates the Story registry.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private good-creds
@@ -175,8 +141,8 @@
      :substrates #{:reagent}})
 
   ;; -------------------------------------------------------------------------
-  ;; reg-variant — the reachable states, each driven through REAL events
-  ;; (fidelity `:event`); no `:db-seed` / `:sub-overrides`.
+  ;; reg-variant — the reachable states, each driven through real events;
+  ;; no `:db-seed` / `:sub-overrides`.
   ;; -------------------------------------------------------------------------
 
   ;; Empty — the entry state. The variant fires a no-op
@@ -192,11 +158,10 @@
      :substrates #{:reagent}})
 
   ;; Filled — the user has typed into both fields but not yet submitted.
-  ;; Event-honest at fidelity `:event`: the draft is seeded by dispatching
-  ;; the SAME `:auth.login/edit-field` events the controlled inputs fire on
-  ;; keystroke, writing into the app-db login-form slice. The machine stays
-  ;; `:idle` (no submit yet); the inputs render the seeded draft as their
-  ;; `:value`.
+  ;; The draft is seeded by dispatching the same `:auth.login/edit-field`
+  ;; events the controlled inputs fire on keystroke, writing into the
+  ;; app-db login-form slice. The machine stays `:idle` (no submit yet);
+  ;; the inputs render the seeded draft as their `:value`.
   (story/reg-variant :story.login/filled
     {:doc        "Both fields filled in, nothing submitted yet — the form
                  mid-edit. The draft was typed into the app-db login-form
@@ -225,9 +190,8 @@
      :substrates #{:reagent}})
 
   ;; Invalid credentials — a malformed `:submit` (short password, bad
-  ;; email) is rejected by the `Credentials` boundary schema BEFORE the
-  ;; handler runs (Spec 010 §Validation order step 1; recovery
-  ;; `:no-recovery`). The machine never transitions out of `:idle`; the
+  ;; email) is rejected by the `Credentials` boundary schema before the
+  ;; handler runs. The machine never transitions out of `:idle`; the
   ;; rejection raises an Issue that lights Xray's Issues ribbon.
   (story/reg-variant :story.login/invalid-credentials
     {:doc        "A malformed submit (too-short password) is rejected at
@@ -261,12 +225,11 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; Locked out — the example's distinctive fourth terminal state. Once
-  ;; the flow has had three prior failed attempts the `:under-retry-limit`
-  ;; guard fails, so the next failure routes to `:locked-out` (and the
-  ;; `:lock-account` action fires a real `:rf.http/managed` lock request).
-  ;; The variant sequences submit → failure four times to exhaust the
-  ;; limit. No testbed counterpart — unique to this example's machine.
+  ;; Locked out — the fourth terminal state. Once the flow has had three
+  ;; prior failed attempts the `:under-retry-limit` guard fails, so the
+  ;; next failure routes to `:locked-out` (and the `:lock-account` action
+  ;; fires a real `:rf.http/managed` lock request). The variant sequences
+  ;; submit → failure four times to exhaust the limit.
   (story/reg-variant :story.login/locked-out
     {:doc        "Too many failed attempts — the `:under-retry-limit`
                  guard fails on the fourth failure and the flow reaches

--- a/examples/reagent/login/stories_host.cljs
+++ b/examples/reagent/login/stories_host.cljs
@@ -2,8 +2,7 @@
   "Showcase entry point for the login example — the host that wires the
    live app, the Story shell, and Xray into one page.
 
-   URL-hash-routed between two surfaces (mirrors
-   `nine-states.stories-host`):
+   URL-hash-routed between two surfaces:
 
    - `#/`        → the live login app (the example's `root-view`).
    - `#/stories` → the Story shell mounted via
@@ -60,10 +59,9 @@
 ;;
 ;; The live `#/` surface needs the example's demo HTTP override on its
 ;; frame so `:rf.http/managed` routes to the in-process
-;; `:auth.login.demo/managed-stub` (no backend). This mirrors what
-;; `login.core/run` installs on `:rf/default`; we register it here so
-;; the host owns the full boot (the host does not call `core/run`,
-;; which hardcodes its own mount lifecycle).
+;; `:auth.login.demo/managed-stub` (no backend). The host owns the full
+;; boot, so it registers the override here rather than calling
+;; `login.core/run` (which runs its own mount lifecycle).
 
 (defn- install-live-frame! []
   (rf/reg-frame :rf/default
@@ -81,22 +79,20 @@
     " on either surface to open Xray and inspect the auth-submit cascade."]
    [core/root-view]])
 
-;; EP-0002: the runtime never synthesises a frame from absence,
-;; so the live-app `#/` surface must render under an explicit frame scope. The
-;; Story shell side (`#/stories`) allocates its own per-variant frames; this
-;; wrapper scopes only the live-app surface to the showcase's `:rf/default`
-;; frame so `login-app`'s reg-view-injected dispatch/subscribe (and
-;; `core/root-view`'s subs) resolve. Passed to the shared story-host as the
-;; live-app root view (mirrors counter-with-stories.core).
+;; The runtime never invents a frame, so the live-app `#/` surface must
+;; render under an explicit frame scope (docs/guide/concepts/frames.md).
+;; The Story shell side (`#/stories`) allocates its own per-variant
+;; frames; this wrapper scopes only the live-app surface to the
+;; showcase's `:rf/default` frame so `login-app`'s injected
+;; dispatch/subscribe (and `core/root-view`'s subs) resolve.
 (defn live-app-root []
   [rf/frame-provider {:frame :rf/default} [login-app]])
 
 ;; -- Routing between the live app and the Story shell ----------------------
 ;;
-;; The live-app↔Story-shell hash router + React-root host handle live in the
-;; shared `re-frame.testbed.story-host` helper; `run`
-;; hands it `login-app` as the live-app surface (mirrors
-;; nine-states.stories-host).
+;; The live-app↔Story-shell hash router and React-root host handle live in
+;; the shared `re-frame.testbed.story-host` helper; `run` hands it
+;; `login-app` as the live-app surface.
 
 (defn ^:export run []
   ;; Keep Xray's collectors + keybinding installed but do not auto-open
@@ -110,12 +106,10 @@
   (install-live-frame!)
   ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
   ;; `#/stories` lands on the shell without a manual click-through. The
-  ;; `:source-subdir` opt tells the host this showcase's Story
-  ;; source-coords are classpath-relative to `examples/reagent`, so the host
-  ;; resolves the on-disk project-root (build-env define or `?checkout-root=`
-  ;; override, cross-platform) and calls `story/configure!` itself — that
-  ;; also bridges the root into Xray's slot. Without it the Story 'open in
-  ;; editor' chips would resolve `login/stories.cljs` against a nil root. The
-  ;; live-app root is frame-scoped via `live-app-root` (the `frame-provider`
-  ;; wrapper) so the bare `#/` surface mounts under the app frame.
+  ;; `:source-subdir` opt tells the host this showcase's Story source lives
+  ;; under `examples/reagent`, so the host can resolve the on-disk project
+  ;; root and wire it into Story and Xray. Without it the Story 'open in
+  ;; editor' chips would resolve `login/stories.cljs` against a nil root.
+  ;; The live-app root is frame-scoped via `live-app-root` so the bare `#/`
+  ;; surface mounts under the app frame.
   (story-host/mount-with-hash-routing! live-app-root {:source-subdir "examples/reagent"}))

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -1,28 +1,29 @@
 (ns long-running-work.core
   "Entry point for the long-running-work example.
 
-   What this example demonstrates (per Pattern-LongRunningWork's
-   :spawn-all shape — the spec/Pattern-LongRunningWork.md guidance
-   when the work decomposes into parallel sub-tasks rather than a
-   single chunked machine):
+   The work decomposes into parallel sub-tasks, so it uses the
+   `:spawn-all` shape: one parent coordinator spawns N parallel
+   workers rather than chunking everything through a single machine.
+   See the machines guide's `:spawn` (docs/machines/glossary.md#spawn).
+
+   What this example demonstrates:
 
    - **Declarative spawn-and-join** — one parent coordinator spawns N
-     parallel workers via `:spawn-all` and joins on `:all`. No
-     per-child bookkeeping in the parent's `:data` — the runtime
-     owns the join state in runtime-db at `[:rf.runtime/machines :spawned :work/flow [:working]]`.
-   - **Cooperative cancellation cascade** — exiting the `:working`
-     state (by user `:cancel`, by `:on-all-complete`, by frame
-     destroy, by `:after`) fires one `:rf.machine/destroy` fx whose
-     handler tears down every surviving child. Each torn-down child's
-     in-flight `:after` timers / HTTP requests go with it (per Spec
-     005 §Cancellation cascade).
+     parallel workers via `:spawn-all` and joins on `:all`. The
+     parent's `:data` holds no per-child bookkeeping; the runtime owns
+     the join state.
+   - **Cooperative cancellation cascade** — leaving the `:working`
+     state (by user `:cancel`, by completion, by frame destroy, by a
+     timeout) fires one `:rf.machine/destroy` fx that tears down every
+     surviving child. Each torn-down child's in-flight timers and HTTP
+     requests go with it.
    - **Progress reporting** — each child dispatches a `:progress`
-     event back to the parent on every chunk; the parent's internal
-     self-transition updates `:data :progress`; the view's
-     `:work/progress-fraction` sub recomputes and the bar updates.
-   - **Parent-unmount cascade** — the React component wrapping the
+     event back to the parent on every chunk. The parent records it
+     in `:data :progress`, the `:work/progress-fraction` sub
+     recomputes, and the bar updates.
+   - **Parent-unmount cascade** — the component wrapping the
      work-bench dispatches `[:work/flow [:cancel]]` in its
-     `r/with-let` cleanup. The dispatch is the only point where the
+     `r/with-let` cleanup. That dispatch is the only point where the
      UI lifecycle touches the machine; the cascade does the rest.
 
    Files:
@@ -43,28 +44,20 @@
 
    Headless tests:
 
-     npm run test:browser        (runs every example's cljs-test;
-                                  includes long-running-work-cljs-test
-                                  under implementation/adapters/reagent/test/
-                                  re_frame/long_running_work_cljs_test.cljs)"
-  ;; Substrate note: STOCK Reagent (`reagent.dom.client` +
-  ;; `re-frame.adapter.reagent`), like the rest of the
-  ;; `examples/reagent/` catalogue. This example's load-bearing teaching
-  ;; point is the `r/with-let` finally-cleanup in views.cljs that fires the
-  ;; `:cancel` cascade on view unmount, on stock Reagent's
-  ;; `reagent.core/with-let`. (counter / counter_slim_and_fast is the
-  ;; dedicated stock-vs-slim contrast pair; the slim build is the only one
-  ;; that mounts `reagent-slim`, and it lives under `examples/reagent-slim/`.)
+     npm run test:browser        (runs every example's cljs-test)"
+  ;; Substrate: stock Reagent (`reagent.dom.client` +
+  ;; `re-frame.adapter.reagent`). The load-bearing teaching point is the
+  ;; `r/with-let` finally-cleanup in views.cljs that fires the `:cancel`
+  ;; cascade on view unmount, built on stock Reagent's
+  ;; `reagent.core/with-let`.
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; re-frame.machines ships in day8/re-frame2-machines.
-            ;; Loading the ns registers the :spawn-all init / spawn /
-            ;; destroy fx handlers and the framework `:rf/machine` sub.
-            ;; Both worker.cljs (the :work/flow + :work/processor
-            ;; registrations) and views.cljs (the work-bench wrapper)
-            ;; transitively require this — declared explicitly here
-            ;; for the smoke-load story.
+            ;; Loading re-frame.machines registers the :spawn-all init /
+            ;; spawn / destroy fx handlers and the `:rf/machine` sub.
+            ;; worker.cljs and views.cljs both require this transitively;
+            ;; it's declared explicitly here too so the ns loads cleanly
+            ;; on its own.
             [re-frame.machines]
             [long-running-work.schema]
             [long-running-work.worker]
@@ -85,33 +78,31 @@
           [:dispatch [:ui/initialise]]]}))
 
 ;; ============================================================================
-;; MOUNT  (CLJS reference; client-only)
+;; MOUNT  (client-only)
 ;; ============================================================================
 ;;
-;; React root is `react-root` (avoid colliding with `root-view`).
-;; Held in an atom and populated lazily inside `run` rather than at
-;; ns-load. Multiple example namespaces are co-required by the
-;; browser-test bundle's wrapper test namespaces; an ns-load
-;; `create-root` would race multiple roots onto the shared `#app`
-;; element. Keeping `create-root` inside `run` makes ns-load DOM-
-;; side-effect-free; the headless fixtures can `:require` this ns under
-;; :node-test / JVM smoke / cljs-test without touching the DOM.
+;; The React root is named `react-root` to avoid colliding with
+;; `root-view`. It's held in an atom and created lazily inside `run`,
+;; not at ns-load, so requiring this ns has no DOM side effect. That
+;; lets the headless fixtures require it without a browser, and keeps
+;; co-loaded example namespaces from racing multiple roots onto the
+;; shared `#app` element.
 
 (defonce react-root (atom nil))
 
-;; The frame is established in one spot: the `frame-provider {:id app-frame …}`
-;; at the render root below. On first mount it creates the app frame, applies
-;; its config, and runs `:initial-events` (the `[:app/initialise]` boot
-;; dispatch) once; on hot reload it reuses the same frame and skips re-seeding.
-;; Every in-tree `dispatch`/`subscribe` resolves to that frame — including the
-;; work-bench wrapper's `r/with-let` cleanup (views.cljs), which dispatches
-;; `[:work/flow [:cancel]]` from within render scope. Matches the canonical
-;; mount in examples/reagent/counter/core.cljs.
+;; The frame is established by the `frame-provider {:id app-frame …}` at
+;; the render root below. On first mount it creates the app frame,
+;; applies its config, and runs `:initial-events` (the `[:app/initialise]`
+;; boot dispatch) once; on hot reload it reuses the same frame and skips
+;; re-seeding. Every in-tree `dispatch`/`subscribe` resolves to that
+;; frame — including the work-bench wrapper's `r/with-let` cleanup
+;; (views.cljs), which dispatches `[:work/flow [:cancel]]` from render
+;; scope. See the frame glossary (docs/guide/glossary.md#frame).
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Install the Reagent adapter, then mount the provider (which establishes
-  ;; the frame — see above).
+  ;; Install the Reagent adapter, then mount the provider that
+  ;; establishes the frame (see above).
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/long_running_work/schema.cljs
+++ b/examples/reagent/long_running_work/schema.cljs
@@ -1,45 +1,31 @@
 (ns long-running-work.schema
   "Malli schemas for the long-running-work example.
 
-   The example shows Pattern-LongRunningWork's `:spawn-all` shape:
-   a parent coordinator machine spawns N child workers in parallel,
-   each child reports progress back to the parent via dispatch, and
-   the parent's :spawn-all-bearing state is exited (by `:complete`,
-   `:cancel`, or unmount) which cascades a teardown to every surviving
-   child.
+   Two machines run at runtime: the `:work/flow` parent coordinator and
+   the `:work/processor` child it spawns. Each machine's snapshot lives
+   in runtime-db (docs/guide/glossary.md#runtime-db), not app-db, so it
+   carries its own `:data` schema in its `[:schemas :data]` slot rather
+   than registering an app-db path. The runtime validates that slot
+   after every transition and at spawn time. See the schemas guide's
+   machine section (docs/guide/how-to/validate-with-schemas.md).
 
-   Two machines run at runtime. Machine snapshots live in the framework's
-   runtime-db partition at `[:rf.runtime/machines :snapshots <id>]`, NOT in
-   app-db — and `reg-app-schema` validates the app-db partition only (EP-0001,
-   Mike ruling #11). So both machines validate their snapshot's `:data` via the
-   machine's own `[:schemas :data]` slot, the surface the runtime addresses for
-   runtime-db-resident snapshots:
-
-   - `:work/flow`       — the parent coordinator, a singleton at the fixed
-                          id `:work/flow`. `FlowData` is attached via its
-                          `[:schemas :data]` slot on `reg-machine`.
-   - `:work/processor`  — the child machine type. Each child is
-                          spawned via `:spawn-all` and gets a gensym'd
-                          id (e.g. `:work/processor#0`) assigned by the
-                          runtime at spawn time, so its snapshot lives
-                          at an UNKNOWN runtime-db path that varies per
-                          instance — another reason `[:schemas :data]` (not a
-                          fixed path) is the right surface. `ProcessorData`
-                          is attached via the
-                          child machine's `[:schemas :data]` slot on `reg-machine`
-                          (see `worker.cljs`), which validates each spawned
-                          instance's initial `:data` at spawn time, before
-                          the snapshot installs (Spec 005 §Schema
-                          validation §Spawn-time validation) — so a child
-                          spawned with malformed `:data` never enters the
-                          runtime, regardless of its gensym'd id.
-
-   Both shapes are boundary-validated in development (Spec 010 §Per-step
-   recovery row 7 — `:where :machine-data` for the child)."
+   - `:work/flow`       — the parent coordinator, a singleton at the
+                          fixed id `:work/flow`. `FlowData` is attached
+                          via its `[:schemas :data]` slot on `reg-machine`.
+   - `:work/processor`  — the child machine type. Each child is spawned
+                          via `:spawn-all` and gets a runtime-assigned
+                          id (e.g. `:work/processor#0`), so its snapshot
+                          lives at a path that varies per instance —
+                          another reason `[:schemas :data]` (not a fixed
+                          app-db path) is the right surface. `ProcessorData`
+                          is attached via the child's `[:schemas :data]`
+                          slot on `reg-machine` (see `worker.cljs`). It
+                          validates each spawned instance's initial
+                          `:data` at spawn time, so a child spawned with
+                          malformed `:data` never enters the runtime."
   (:require [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so the
-            ;; machines' `[:schemas :data]` slots are validated at runtime.
+            ;; Loading re-frame.schemas wires up the validator so the
+            ;; machines' `[:schemas :data]` slots are checked at runtime.
             [re-frame.schemas]))
 
 ;; ============================================================================
@@ -65,10 +51,10 @@
 ;;               :outcome    <:complete | :cancelled | :error | nil>}
 ;;    :tags     #{...}}                       ;; runtime-owned union
 
-;; The parent snapshot's `:data` slot. The surrounding snapshot (`:state`,
-;; `:tags`) is runtime-owned; the machine `[:schemas :data]` describes `:data`
-;; only (Spec 005 §Schema validation). Attached via the `[:schemas :data]` slot
-;; on `(reg-machine :work/flow ...)` in `worker.cljs`.
+;; The parent snapshot's `:data` slot. The runtime owns the rest of the
+;; snapshot (`:state`, `:tags`), so the machine `[:schemas :data]` describes
+;; `:data` only. Attached via the `[:schemas :data]` slot on
+;; `(reg-machine :work/flow ...)` in `worker.cljs`.
 (def FlowData
   [:map
    [:total    :int]
@@ -80,14 +66,15 @@
 ;; CHILD :data SHAPE — :work/processor (one instance per shard)
 ;; ============================================================================
 ;;
-;; The child machine's `:data` slot — the user-domain working memory the
-;; child carries. The runtime owns the surrounding snapshot (`:state`, the
-;; `:tags` union, the reserved `:rf/*` slots), so the machine `[:schemas :data]`
-;; describes `:data` ONLY (Spec 005 §Schema validation). Attached via the
-;; `[:schemas :data]` slot on `(reg-machine :work/processor ...)` in `worker.cljs`,
-;; which validates each spawned instance's initial `:data` at spawn time —
-;; the value here is what the parent's per-child `:spawn-all` invoke-spec
-;; plants (every field below is supplied, so all are required).
+;; The child machine's `:data` slot — the working memory each child
+;; carries. The runtime owns the rest of the snapshot (`:state`, the
+;; `:tags` union, the reserved `:rf/*` slots), so the machine
+;; `[:schemas :data]` describes `:data` only. Attached via the
+;; `[:schemas :data]` slot on `(reg-machine :work/processor ...)` in
+;; `worker.cljs`, which validates each spawned instance's initial `:data`
+;; at spawn time. The value here is what the parent's per-child
+;; `:spawn-all` invoke-spec plants (every field below is supplied, so all
+;; are required).
 
 (def ProcessorData
   [:map
@@ -96,9 +83,8 @@
    [:processed :int]       ;; how many done so far
    [:tick-ms   :int]       ;; ms between chunks (browser yield)
    ;; Runtime-stamped address keys — the spawn fx stamps these into the
-   ;; spawned actor's initial :data (Spec 005 §Reserved snapshot-internal
-   ;; keys). Optional + declared so the schema documents them; a Malli
-   ;; :map is open, so they'd pass undeclared too.
+   ;; spawned child's initial :data. Declared (and optional) so the schema
+   ;; documents them; a Malli :map is open, so they'd pass undeclared too.
    [:rf/self-id   {:optional true} :any]
    [:rf/parent-id {:optional true} :any]
    [:rf/invoke-id {:optional true} :any]])
@@ -110,6 +96,5 @@
 ;; Both machines attach their `:data` schema via the machine `[:schemas :data]`
 ;; slot in `worker.cljs` — `FlowData` on `:work/flow`, `ProcessorData` on
 ;; `:work/processor`. There is no `reg-app-schema` here: machine snapshots
-;; live in the runtime-db partition, and `reg-app-schema` validates the
-;; app-db partition only (EP-0001, Mike ruling #11). `[:schemas :data]` is the
-;; snapshot-validation surface for runtime-db-resident machine state.
+;; live in runtime-db, and `reg-app-schema` validates the app-db partition
+;; only. `[:schemas :data]` is the validation surface for a machine snapshot.

--- a/examples/reagent/long_running_work/views.cljs
+++ b/examples/reagent/long_running_work/views.cljs
@@ -6,20 +6,17 @@
    - The control panel: Start / Cancel / Reset / Hide buttons.
    - The progress bar: aggregate fraction of items done across all
      shards.
-   - The per-shard breakdown: small bar per worker so the reader can
-     see the three parallel children making independent progress.
+   - The per-shard breakdown: a small bar per worker, so you can see
+     the three parallel children making independent progress.
 
-   The 'Hide' button toggles a wrapper component that mounts /
+   The 'Hide' button toggles a wrapper component that mounts and
    unmounts the work-bench. When the wrapper unmounts, its
-   `r/with-let` cleanup fires a `:cancel` event into `:work/flow`.
-   This is the canonical 're-frame2 way' to wire cooperative
-   cancellation to a React lifecycle boundary: a registered event
-   that the parent's :working state handles by transitioning out,
-   triggering the standard exit cascade (which destroys every
-   spawned child). The worker machines themselves are
-   lifecycle-agnostic — they don't know anything about React. The
-   one place the React lifecycle peeks through is this single
-   dispatch in the wrapper's cleanup."
+   `r/with-let` cleanup dispatches a `:cancel` event into `:work/flow`.
+   That is how you wire cooperative cancellation to a component
+   lifecycle: a normal dispatch the parent's `:working` state handles
+   by transitioning out, which tears down every spawned child. The
+   worker machines know nothing about React; this one dispatch is the
+   only place the React lifecycle touches them."
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
             [long-running-work.worker])
@@ -132,20 +129,15 @@
 ;; WORK-BENCH WRAPPER — demonstrates the unmount cascade
 ;; ============================================================================
 
-(reg-view ^{:doc "The work-bench — the actual demo widget. This is the
-                  view that *gets unmounted* when the user clicks
-                  'Hide'. Its `r/with-let` cleanup is the load-bearing
-                  hook for the unmount cascade: on unmount, it
-                  dispatches [:work/flow [:cancel]] into the parent
-                  machine. The parent's :working state's :cancel
-                  transition exits :working, the :spawn-all
-                  desugared :exit fires :rf.machine/destroy for every
-                  surviving child, and the work goes away cleanly.
-
-                  The worker machines themselves don't know anything
-                  about React — they're host-agnostic. The only
-                  place the React lifecycle peeks through is this
-                  one dispatch in the cleanup."}
+(reg-view ^{:doc "The work-bench — the demo widget. This is the view
+                  that gets unmounted when the user clicks 'Hide'. Its
+                  `r/with-let` cleanup drives the unmount cascade: on
+                  unmount it dispatches [:work/flow [:cancel]] into the
+                  parent. The parent's :working state's :cancel
+                  transition exits :working, which fires
+                  :rf.machine/destroy for every surviving child, and the
+                  work goes away cleanly. This one dispatch is the only
+                  place the React lifecycle touches the machines."}
           work-bench []
   (r/with-let [_ nil]
     [:div.work-bench
@@ -158,10 +150,9 @@
      [controls]
      [progress-bar]
      [shard-breakdown]]
-    ;; Reagent's with-let cleanup runs on component unmount. The
-    ;; only thing this needs to do is dispatch :cancel into the
-    ;; parent flow machine; the machine's :working :cancel
-    ;; transition takes care of the rest.
+    ;; Reagent's with-let cleanup runs on component unmount. All it
+    ;; does is dispatch :cancel into the parent machine; the :working
+    ;; :cancel transition takes care of the rest.
     (finally
       (dispatch [:work/flow [:cancel]]))))
 
@@ -169,13 +160,12 @@
 ;; ROOT VIEW — Show/Hide toggle around the work-bench
 ;; ============================================================================
 ;;
-;; The Show/Hide toggle is an *app-db boolean*, not part of the
-;; :work/flow machine. The machine has nothing to do with the
-;; component's visibility. The view either renders work-bench (which
-;; on mount activates the worker pipeline once the user clicks
-;; Start) or it doesn't. When the user clicks Hide while work is
-;; running, the component unmounts → with-let's finally → dispatch
-;; :cancel → parent exits :working → cascade tears every child down.
+;; The Show/Hide toggle is an app-db boolean, not part of the
+;; :work/flow machine — the machine has nothing to do with the
+;; component's visibility. The view either renders work-bench or it
+;; doesn't. Click Hide while work is running and the chain is:
+;; component unmounts -> with-let's finally -> dispatch :cancel ->
+;; parent exits :working -> cascade tears every child down.
 
 (rf/reg-event :ui/initialise
   (fn [{:keys [db]} _]

--- a/examples/reagent/long_running_work/worker.cljs
+++ b/examples/reagent/long_running_work/worker.cljs
@@ -2,36 +2,34 @@
   "The worker + parent-coordinator machines for the long-running-work
    example.
 
-   Pattern-LongRunningWork's `:spawn-all`-shape: the parent coordinator
-   spawns N children via :spawn-all; each child processes its own shard
-   cooperatively (yielding to the browser between chunks via `:after`);
-   children dispatch `:progress` events back to the parent for UI; on
-   completion each child dispatches the parent's `:on-child-done`
-   keyword. When all N report done the runtime fires the parent's
-   `:on-all-complete`. The user can `:cancel` mid-flight; the parent
-   transitions out of `:working` and the standard exit cascade tears
-   down every surviving child via `:rf.machine/destroy` fx — including
-   any in-flight `:after` timers a worker had pending.
+   The `:spawn-all` shape: the parent coordinator spawns N children;
+   each child processes its own shard cooperatively, yielding to the
+   browser between chunks via `:after`; children dispatch `:progress`
+   events back to the parent for the UI; on completion each child
+   dispatches the parent's `:on-child-done` keyword. When all N report
+   done the runtime fires the parent's `:on-all-complete`. The user can
+   `:cancel` mid-flight; the parent leaves `:working` and the exit
+   cascade tears down every surviving child via the
+   `:rf.machine/destroy` fx — including any `:after` timers a worker had
+   pending. See the `:spawn` glossary entry
+   (docs/machines/glossary.md#spawn).
 
-   This is the canonical re-frame2 expression of:
+   This is how you express:
 
      - 'Run N parallel tasks and join on all done.'
      - 'Show progress.'
-     - 'Cancellation must be reliable on EVERY exit path —
-        including the user navigating away mid-flight.'
+     - 'Cancellation must be reliable on every exit path — including
+        the user navigating away mid-flight.'
 
-   Why one parent + N children rather than one big chunked machine: each
-   shard is independent, parallelisable, and lets the demo show *both*
-   join semantics (`:on-all-complete`) AND the cascade-teardown contract
-   (`:cancel-on-decision?` defaults to true; `:work/flow` `:cancel`
-   transition exits the state and the desugared :exit fires the
-   per-child destroy)."
+   One parent + N children (rather than one big chunked machine)
+   because each shard is independent and parallelisable, and it lets
+   the demo show both the join (`:on-all-complete`) and the
+   cascade-teardown: the `:work/flow` `:cancel` transition leaves the
+   state and that exit fires the per-child destroy."
   (:require [re-frame.core :as rf]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine
-            ;; (called below at ns-load) and the `:rf/machine` /
-            ;; `:rf/machine-has-tag?` framework subs resolve.
+            ;; Loading re-frame.machines wires up the runtime so
+            ;; rf/reg-machine (called below at ns-load) and the
+            ;; `:rf/machine` / `:rf/machine-has-tag?` subs resolve.
             [re-frame.machines]
             [long-running-work.schema :as schema]))
 
@@ -57,9 +55,9 @@
 (def parent-id
   "The parent coordinator machine's registered id. Children hard-code
    this in their dispatch-back so they can address the parent without
-   any per-child plumbing. Per Spec 005 §Child completion protocol:
-   for static `:spawn-all` declarations the parent-id is a literal
-   in the parent's source, so the child simply hard-codes it."
+   any per-child plumbing. For a static `:spawn-all` declaration the
+   parent id is a literal in the parent's own source, so the child can
+   simply name it."
   :work/flow)
 
 ;; ============================================================================
@@ -99,12 +97,10 @@
    :initial :idle
 
    ;; Validates the child's initial `:data` at spawn time, before the
-   ;; snapshot installs (Spec 005 §Schema validation §Spawn-time
-   ;; validation). This is how a spawned child's shape is boundary-
-   ;; checked: the runtime addresses each instance by a gensym'd id
-   ;; (e.g. `:work/processor#0`), so no fixed `reg-app-schema` path can
-   ;; reach it — the machine `[:schemas :data]` slot validates the spawn
-   ;; regardless of id. (See schema.cljs ns docstring.)
+   ;; snapshot installs. This is how a spawned child's shape is checked:
+   ;; the runtime gives each instance its own id (e.g. `:work/processor#0`),
+   ;; so no fixed app-db path can reach it — the machine `[:schemas :data]`
+   ;; slot validates the spawn regardless of id. (See schema.cljs.)
    :schemas {:data schema/ProcessorData}
 
    ;; The :data is materialised from the parent's per-child invoke-spec
@@ -129,15 +125,13 @@
    :actions
    {:process-one
     ;; Process one item. In a real app this is whatever the per-item
-    ;; computation is (encoding, parsing, indexing, ...). For this
-    ;; demo we just bump the counter — the load-bearing thing the
-    ;; example shows is the yield + progress-reporting + cancellation
-    ;; shape, not the per-item work.
+    ;; computation is (encoding, parsing, indexing, ...). Here we just
+    ;; bump the counter — what the example shows is the yield +
+    ;; progress-reporting + cancellation shape, not the per-item work.
     ;;
-    ;; The action also dispatches a :progress event back to the
-    ;; parent so the UI's progress bar updates between chunks. The
-    ;; parent's :on map handles :progress as a self-transition with
-    ;; an action that updates :data :progress.
+    ;; The action also dispatches a :progress event back to the parent
+    ;; so the UI's progress bar updates between chunks. The parent
+    ;; handles :progress as a self-transition that updates :data :progress.
     (fn action-process-one [{:keys [data]}]
       (let [shard         (:shard data)
             new-processed (inc (:processed data))]
@@ -146,11 +140,9 @@
 
     :dispatch-done
     ;; Terminal action: dispatch the parent's :on-child-done keyword.
-    ;; The runtime intercepts the event at the parent's machine
-    ;; boundary and updates the join state at
-    ;;   [:rf.runtime/machines :spawned :work/flow [:working] :done]
-    ;; The second-position arg is the user-supplied shard id (e.g.
-    ;; :s1) so the parent can address which child completed.
+    ;; The runtime intercepts this at the parent's machine boundary and
+    ;; updates the join state. The second arg is the shard id (e.g. :s1)
+    ;; so the parent can tell which child completed.
     (fn action-dispatch-done [{:keys [data]}]
       (let [shard (:shard data)]
         {:fx [[:dispatch [parent-id [:work/child-done shard]]]]}))}
@@ -181,16 +173,14 @@
               {:guard :more-work? :target :yielding}]}
 
     :yielding
-    ;; The canonical browser-yield seam. :after carries a runtime
-    ;; clock-driven delay; the standard cancellation cascade (the
-    ;; parent's `:exit` action) tears down the in-flight timer on
-    ;; child-destroy, so a worker cancelled mid-yield does NOT
-    ;; resume after the delay elapses.
+    ;; The browser-yield seam. :after carries a runtime clock-driven
+    ;; delay; the cancellation cascade tears down the in-flight timer on
+    ;; child-destroy, so a worker cancelled mid-yield does NOT resume
+    ;; after the delay elapses.
     ;;
-    ;; The :after key is a (fn [{:keys [snapshot]}] ms) form per Spec
-    ;; 005 §Value shape (unified context-map) — reads the per-child
-    ;; :tick-ms out of :data so tests / callers can
-    ;; stagger or zero-out the delay.
+    ;; The :after key is a (fn [ctx] ms) form: it reads the per-child
+    ;; :tick-ms out of :data so tests and callers can stagger or
+    ;; zero-out the delay.
     {:tags  #{:work/running :work/cancellable :work/yielding}
      :after {(fn after-tick-ms [{snap :snapshot}]
                (or (-> snap :data :tick-ms) default-tick-ms))
@@ -205,13 +195,12 @@
      :entry :dispatch-done}
 
     :cancelled
-    ;; Declared but never entered by the example's transitions: in this
-    ;; example the parent cancels the child by tearing it down via the
-    ;; :rf.machine/destroy fx (Spec 005 §Cancellation cascade), not by
-    ;; routing a cancel event in. The state stays in the spec so the
-    ;; machine's tag union exposes #{:work/cancelled} to tools (snapshot
-    ;; inspectors, conformance harnesses), and so an app that DOES route
-    ;; cancellation as an in-FSM event has somewhere to land.
+    ;; Declared but never entered by this example's transitions: the
+    ;; parent cancels a child by tearing it down via the
+    ;; :rf.machine/destroy fx, not by routing a cancel event in. The
+    ;; state stays so the machine's tag union exposes #{:work/cancelled}
+    ;; to tools, and so an app that DOES route cancellation as an in-FSM
+    ;; event has somewhere to land.
     {:meta {:terminal? true}
      :tags #{:work/cancelled}}}})
 
@@ -222,11 +211,10 @@
 ;; ============================================================================
 ;;
 ;; Three children, one parent, one declarative :spawn-all entry. The
-;; parent has no per-child bookkeeping in :data beyond the aggregated
+;; parent's :data holds no per-child bookkeeping beyond the aggregated
 ;; :progress map (the user wants to see it; the runtime doesn't read
-;; it). The :children / :done / :failed / :resolved? join-state map
-;; lives in runtime-db under [:rf.runtime/machines :spawned :work/flow [:working]] — runtime
-;; owned per Spec 005 §Spawn-id tracking.
+;; it). The join-state map — which children are done, failed, resolved —
+;; is runtime-owned and lives in runtime-db.
 
 (def shards
   "The shard ids this demo processes in parallel. Three is enough to
@@ -250,9 +238,9 @@
              :progress (zipmap shards (repeat 0))
              :outcome  nil}
 
-   ;; Validates the snapshot's :data slot. The snapshot lives in runtime-db
-   ;; ([:rf.runtime/machines :snapshots :work/flow]), so [:schemas :data] — not
-   ;; an app-schema — is the validation surface (EP-0001, Mike ruling #11).
+   ;; Validates the snapshot's :data slot. The snapshot lives in
+   ;; runtime-db, so [:schemas :data] — not an app-schema — is the
+   ;; validation surface.
    :schemas {:data schema/FlowData}
 
    :actions
@@ -294,20 +282,17 @@
             :reset {:target :idle    :action :reset-progress}}}
 
     :working
-    ;; The :spawn-all-bearing state. On entry the runtime emits one
-    ;; :rf.machine/spawn-all-init fx (seeds the join-state map) plus
-    ;; N :rf.machine/spawn fxs (one per child). On exit (by ANY
-    ;; transition including :cancel / :work/all-done), the runtime
-    ;; emits a single :rf.machine/destroy fx carrying :rf/spawn-all
-    ;; true; the destroy fx handler reads the join-state's :children
-    ;; map and tears each surviving child down.
+    ;; The :spawn-all-bearing state. On entry the runtime seeds the
+    ;; join-state map and spawns one child per entry below. On exit (by
+    ;; ANY transition, including :cancel / :work/all-done) it fires a
+    ;; single :rf.machine/destroy fx that reads the join state and tears
+    ;; every surviving child down.
     ;;
-    ;; The :progress event is the per-step report from a child. It's
-    ;; a self-transition (same target :working) with an action that
-    ;; updates :data :progress. Because :progress is NOT the parent's
-    ;; :on-child-done / :on-child-error keyword, it is NOT intercepted
-    ;; by the :spawn-all join machinery — the runtime feeds it
-    ;; straight into the parent's :on lookup.
+    ;; The :progress event is the per-step report from a child. It's an
+    ;; internal self-transition that updates :data :progress. Because
+    ;; :progress is NOT the parent's :on-child-done / :on-child-error
+    ;; keyword, the join machinery doesn't intercept it — the runtime
+    ;; feeds it straight into the parent's :on lookup.
     {:tags #{:flow/working}
      :spawn-all
      {:children [{:id :s1 :machine-id :work/processor
@@ -319,19 +304,18 @@
       :join             :all
       ;; The keywords children dispatch back. The runtime intercepts
       ;; events whose inner-event-id matches these and updates the
-      ;; join-state at [:rf.runtime/machines :spawned :work/flow [:working]].
+      ;; join state.
       :on-child-done    :work/child-done
       :on-child-error   :work/child-error
       ;; The events the runtime dispatches into the parent when the
       ;; join resolves. The parent's :on table below handles each.
       :on-all-complete  [:work/all-done]
       :on-any-failed    [:work/any-failed]}
-     :on    {;; Progress reports — INTERNAL self-transition (no :target):
+     :on    {;; Progress reports — internal self-transition (no :target):
              ;; the action runs but :exit / :entry do NOT fire, so the
-             ;; :spawn-all entry cascade does not re-spawn children and
-             ;; the exit cascade does not tear them down. Per Spec 005
-             ;; §Transitions §Internal vs external self-transitions: omit
-             ;; :target for internal-self.
+             ;; :spawn-all entry cascade doesn't re-spawn children and the
+             ;; exit cascade doesn't tear them down. Omit :target to get
+             ;; an internal self-transition.
              :progress        {:action :record-progress}
              ;; Join-resolution events. The runtime dispatches these
              ;; into the parent when :on-all-complete / :on-any-failed
@@ -340,9 +324,8 @@
              :work/all-done   {:target :complete  :action :stamp-outcome}
              :work/any-failed {:target :error     :action :stamp-outcome}
              ;; Cooperative user-driven cancellation. The transition
-             ;; exits :working; the desugared :spawn-all exit fires
-             ;; one :rf.machine/destroy fx with :rf/spawn-all true;
-             ;; the destroy fx handler tears down every surviving
+             ;; leaves :working, and that exit fires one
+             ;; :rf.machine/destroy fx that tears down every surviving
              ;; child.
              :cancel          {:target :cancelled :action :stamp-outcome}}}
 

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -1,80 +1,61 @@
 (ns managed-http-counter.core
-  "Managed-HTTP counter — Spec 014 §`:rf.http/managed` example app.
+  "Managed-HTTP counter — a small app built on `:rf.http/managed`.
 
-  Demonstrates managed HTTP: you describe a request as data and the
-  runtime owns its whole lifecycle (encode, send, decode, classify,
-  retry, abort), then dispatches the result back as an ordinary event.
-  You never touch js/fetch. Each button issues a managed HTTP request
-  and the reply lands back in app-db via the default reply-addressing
-  path — \"send\" and \"receive\" are both just events hitting the same
-  pure handler.
+  You describe a request as data and the runtime owns its whole
+  lifecycle: encode, send, decode, classify failures, retry, abort. It
+  then dispatches the result back as an ordinary event. You never touch
+  js/fetch. Each button issues a request and the reply lands back in
+  app-db through default reply addressing, so \"send\" and \"receive\" are
+  both just events hitting the same pure handler. See the HTTP guide:
+  docs/resources/http.md.
 
   Buttons:
-    +1                — GET api/inc.json (static asset; success path)
-    Fail              — GET api/does-not-exist (404 → :rf.http/http-4xx)
-    Retry-recover     — :rf.http/managed-canned-success at app level
-                        (the canned-stub seam synthesises a retry-success
-                        reply — no real request is issued)
-    Start long        — seeds a GENUINE in-flight request handle in the
-                        framework registry (a request that stays pending,
-                        deterministically — no real long-running endpoint)
-    Cancel            — :rf.http/managed-abort by :request-id, which
-                        resolves the seeded handle through the LIVE abort
-                        path → real :rf.http/aborted reply
+    +1             GET api/inc.json — a real success round-trip.
+    Fail           GET api/does-not-exist — a real 404 (:rf.http/http-4xx).
+    Retry-recover  drives the canned-success stub, which synthesises a
+                   success reply with no real request.
+    Start long     seeds a pending in-flight request that stays pending.
+    Cancel         aborts that request by :request-id.
 
-  The +1 and Fail buttons exercise a REAL round-trip: Fetch hits the
-  static file (or 404s), the response body is decoded (only on 2xx), and
-  the reply lands back in app-db. The Retry-recover button exercises the
-  canned-stub seam, which lets the app demonstrate the success/retry
-  contract without needing a stub HTTP server.
+  +1 and Fail run a real Fetch: the request goes out, the body is decoded
+  (only on 2xx), and the reply lands back in app-db. Retry-recover uses
+  the canned-success stub so the app can show the success/retry contract
+  without a stub HTTP server.
 
-  Start long / Cancel exercise the REAL abort contract: \"Start long\"
-  records a genuine request-id-keyed handle in the framework in-flight
-  registry (the same atom the live transport's `run-attempt!` records
-  into), whose `:abort-fn` dispatches the canonical `:rf.http/aborted`
-  reply and clears the registry slot. \"Cancel\" fires the LIVE
-  `:rf.http/managed-abort` fx, which resolves that handle by `:request-id`
-  and fires its `:abort-fn` — so the cancel path exercises the actual
-  abort semantics, in-flight registry cleanup, and aborted classification
-  end-to-end. Seeding a deterministic pending handle (rather than a real
-  Fetch against a static dev-http server, which resolves instantly leaving
-  nothing observably in-flight) is the proven testbed pattern — see
-  `tools/xray/testbeds/managed_http/core.cljs`.
+  Start long / Cancel show a real abort. This app serves only static
+  assets, so a real GET resolves instantly and never stays observably
+  in-flight. So \"Start long\" seeds a request-id-keyed handle directly
+  into the framework in-flight registry — the same atom the live transport
+  records into — giving a deterministically pending request. \"Cancel\"
+  then fires the live `:rf.http/managed-abort` fx against that handle: the
+  abort resolves it, fires its `:abort-fn`, and a `:rf.http/aborted` reply
+  lands back at the issuing handler. Only the transport is stood in for;
+  the registry entry, the abort fx, and the aborted classification are all
+  real and visible in Xray and traces.
 
-  This example is intentionally minimal — the heavy contract testing
-  lives in the JVM smoke (re-frame.http-managed-test) and the
-  conformance fixtures (spec/conformance/fixtures/
-  http-managed-*.edn). The example itself is the runnable
-  cross-substrate sanity check: the same fx, the same reply shape,
-  end-to-end through Reagent and Fetch."
+  This app is the runnable cross-substrate sanity check: the same fx, the
+  same reply shape, end-to-end through Reagent and Fetch."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            ;; Managed-HTTP ships in day8/re-frame2-http.
-            ;; Requiring re-frame.http.managed at app boot is what
-            ;; triggers its load-time fx registrations (`:rf.http/managed`
-            ;; and family) and publishes the late-bind hooks; without
-            ;; it, dispatching `:rf.http/managed` would fail with
-            ;; :rf.error/no-such-fx.
+            ;; Managed HTTP ships in its own artefact, day8/re-frame2-http.
+            ;; Requiring re-frame.http.managed once at boot registers
+            ;; `:rf.http/managed` and family; without it, dispatching the
+            ;; fx fails loud with a named "HTTP artefact missing" error.
             [re-frame.http.managed]
-            ;; The Retry-recover button drives :rf.http/managed-canned-success
-            ;; (the canned-success stub). The canned-stub fx ids register from
-            ;; re-frame.http.test-support, not re-frame.http.managed.
+            ;; The canned-success stub the Retry-recover button uses
+            ;; (`:rf.http/managed-canned-success`) registers here, not in
+            ;; re-frame.http.managed.
             [re-frame.http.test-support]
-            ;; The "Start long" demo seeds a genuine in-flight request
-            ;; handle directly into the framework registry so the slot
-            ;; persists deterministically (a real Fetch against a static
-            ;; dev-http server resolves instantly, leaving nothing
-            ;; observably in-flight to cancel). The index-write seam
-            ;; (`record-in-flight!`) is not re-exported from
-            ;; re-frame.http.managed (only the read-side snapshots +
-            ;; clear/abort are), so we reach the registry ns directly —
-            ;; the same atom the live transport's `run-attempt!` records
-            ;; into, which the live `:rf.http/managed-abort` fx resolves.
+            ;; The "Start long" button seeds a pending in-flight handle
+            ;; directly into the registry. The write seam (`record-in-flight!`)
+            ;; isn't on the public facade, so we reach the registry ns
+            ;; directly — it's the same atom the live transport writes into
+            ;; and the live `:rf.http/managed-abort` fx resolves.
             [re-frame.http.registry :as http-registry]
-            ;; Call-site helpers (rf.http/get / post / put / delete /
-            ;; patch / head / options) that synthesise the canonical
-            ;; [:rf.http/managed args-map] envelope.
+            ;; Call-site verb helpers (rf.http/get / post / put / delete /
+            ;; patch / head / options) that build the canonical
+            ;; [:rf.http/managed args-map] vector.
             [re-frame.http :as rf.http]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -83,15 +64,15 @@
 ;; APP-DB SHAPE
 ;; ============================================================================
 ;;
-;; {:counter/count    <int>           ;; current counter value
-;;  :counter/status   <:idle|:loading|:error>   ;; the request lifecycle, visible
+;; {:counter/count    <int>                     ;; current counter value
+;;  :counter/status   <:idle|:loading|:error>   ;; the request lifecycle
 ;;  :counter/error    <failure-map-or-nil>}
 ;;
-;; :status is the in-flight lifecycle made visible: :loading while the
+;; :status makes the in-flight lifecycle visible: :loading while the
 ;; runtime works a request, :idle (or :error) once the reply lands.
 ;;
-;; Per spec/Conventions §Feature-modularity prefix convention every
-;; app-db slot and sub-id carries the feature prefix; events already do.
+;; Every app-db slot, sub-id, and event carries a :counter/ feature
+;; prefix, so this app's keys never collide with another feature's.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _ev]
@@ -103,13 +84,12 @@
 ;; +1  —  real round-trip via Fetch
 ;; ============================================================================
 ;;
-;; The headline path, and the one to read first. One pure handler plays
-;; two roles: the :else branch DESCRIBES a request (returns an
-;; :rf.http/managed effect), and the runtime — after sending the GET to
-;; api/inc.json and decoding the `{"delta": 1}` body — re-dispatches
-;; [:counter/+1 {:rf/reply ...}] back to this same handler, which now
-;; takes the :success branch and applies the increment. The asynchrony
-;; lives in the runtime; the handler stays pure and replayable.
+;; Read this path first. One pure handler plays two roles. The :else
+;; branch describes a request (it returns an :rf.http/managed effect).
+;; The runtime sends the GET to api/inc.json, decodes the `{"delta": 1}`
+;; body, and re-dispatches [:counter/+1 {:rf/reply ...}] back to this same
+;; handler, which now takes the :success branch and applies the increment.
+;; The asynchrony lives in the runtime; the handler stays pure.
 
 (rf/reg-event :counter/+1
   (fn [{:keys [db]} [_ msg]]
@@ -126,10 +106,9 @@
                (assoc :counter/status :error
                       :counter/error  (:failure (:rf/reply msg))))}
 
-      ;; Initial branch — issue the request. The `rf.http/get`
-      ;; helper synthesises the same `[:rf.http/managed args-map]`
-      ;; envelope a hand-written `:method :get` entry would; the
-      ;; call-site reads as one line of intent.
+      ;; Initial branch — issue the request. `rf.http/get` builds the
+      ;; same `[:rf.http/managed args-map]` vector a hand-written
+      ;; `:method :get` entry would, in one line.
       :else
       {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [(rf.http/get "api/inc.json" {:decode :json})]})))
@@ -138,9 +117,9 @@
 ;; Fail  —  real 404 from the http-server
 ;; ============================================================================
 ;;
-;; Same shape as +1, exercising the failure side of the uniform reply.
-;; Branch on the reply's :kind; on :failure, record the failure map
-;; wholesale — its own :kind is the :rf.http/* category the view surfaces.
+;; Same shape as +1, but the failure side of the reply. Branch on the
+;; reply's :kind; on :failure, record the failure map whole — its own
+;; :kind is the :rf.http/* category the view surfaces.
 
 (rf/reg-event :counter/fail
   (fn [{:keys [db]} [_ msg]]
@@ -152,13 +131,12 @@
       ;; Should not happen — the URL is intentionally 404.
       {:db (assoc db :counter/status :idle :counter/error nil)}
 
-      ;; Same `rf.http/get` helper as above. Per Spec 014
-      ;; §Classification order, status-check fires before decode — so
-      ;; even with `:decode :json`, a 404 with an HTML or plain-text
-      ;; body classifies as :rf.http/http-4xx (the raw body lands at
-      ;; :body), not :rf.http/decode-failure. Leaving :decode at the
-      ;; default `:auto` here exercises the common case: a JSON
-      ;; endpoint that 404s with a load-balancer HTML page.
+      ;; Same `rf.http/get` helper as above. Status is classified before
+      ;; the body is decoded, so a 404 with an HTML or plain-text body is
+      ;; :rf.http/http-4xx (raw body at :body), never :rf.http/decode-failure
+      ;; — even with `:decode :json`. Leaving :decode at its default `:auto`
+      ;; here shows the common case: a JSON endpoint that 404s with a
+      ;; load-balancer HTML page. See docs/resources/http.md.
       :else
       {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [(rf.http/get "api/does-not-exist")]})))
@@ -167,13 +145,12 @@
 ;; Retry-recover  —  canned-stub at app level
 ;; ============================================================================
 ;;
-;; Demonstrates the recovery-after-retry path without needing a flaky
-;; endpoint. The handler issues :rf.http/managed-canned-success, which
-;; synthesises a {:kind :success :value {:delta 5}} reply — the exact
-;; shape the live fx would land if its retry policy hit a real endpoint
-;; that 503'd once and then 200'd. The stub seam lets you exercise the
-;; CONTRACT without owning the SERVER; the handler reads identically
-;; either way.
+;; Shows the recovery-after-retry path without a flaky endpoint. The
+;; handler issues :rf.http/managed-canned-success, which synthesises a
+;; {:kind :success :value {:delta 5}} reply — the exact shape the live fx
+;; lands if its retry policy hits a real endpoint that 503s once then
+;; 200s. The stub lets you exercise the contract without owning a server,
+;; and the handler reads the same either way.
 
 (rf/reg-event :counter/retry-recover
   (fn [{:keys [db]} [_ msg]]
@@ -185,9 +162,9 @@
 
       :else
       {:db (assoc db :counter/status :loading)
-       ;; The canned-success stub synthesises the reply per Spec 014
-       ;; §Testing. The retry policy is declared so user code reads
-       ;; the same as a live retry-recover; the stub short-circuits.
+       ;; The canned-success stub synthesises the reply directly. The
+       ;; request and decode are declared so the call reads like a live
+       ;; retry-recover; the stub short-circuits the network.
        :fx [[:rf.http/managed-canned-success
              {:request {:method :get :url "api/flaky"}
               :decode  :json
@@ -197,59 +174,53 @@
 ;; Start long / Cancel  —  a REAL abort of a REAL in-flight request
 ;; ============================================================================
 ;;
-;; Spec 014's abort contract: an in-flight `:rf.http/managed` request is
-;; cancelled by `:request-id` — `:rf.http/managed-abort` resolves the
-;; handle in the framework in-flight registry, fires its `:abort-fn`, and
-;; a `:rf.http/aborted` reply lands back at the issuing handler.
+;; The abort contract: an in-flight `:rf.http/managed` request is cancelled
+;; by `:request-id`. `:rf.http/managed-abort` resolves the handle in the
+;; framework in-flight registry, fires its `:abort-fn`, and a
+;; `:rf.http/aborted` reply lands back at the issuing handler. See the
+;; abort section of docs/resources/http.md.
 ;;
-;; The wrinkle that shaped this code: this example serves only static
-;; assets, so a real `:rf.http/managed` GET resolves INSTANTLY — nothing
-;; stays observably in-flight to cancel. So "Start long" seeds a genuine
-;; request-id-keyed handle directly into the registry (the same atom the
-;; live transport's `run-attempt!` records into), giving a deterministically
-;; pending request; "Cancel" then fires the LIVE `:rf.http/managed-abort`
-;; fx against THAT handle. Only the transport is stood in for — the
-;; registry entry, the abort fx, and the `:rf.http/aborted` classification
-;; are all genuine, visible in Xray / traces. This is the proven
-;; seed-in-flight testbed pattern; see
-;; `tools/xray/testbeds/managed_http/core.cljs`.
+;; This app serves only static assets, so a real GET resolves instantly
+;; and nothing stays observably in-flight to cancel. So "Start long" seeds
+;; a request-id-keyed handle directly into the registry (the same atom the
+;; live transport writes into), giving a deterministically pending request,
+;; and "Cancel" fires the live `:rf.http/managed-abort` fx against that
+;; handle. Only the transport is stood in for; the registry entry, the
+;; abort fx, and the `:rf.http/aborted` classification are all real and
+;; visible in Xray and traces.
 
 (def long-request-id :counter/long)
 
-;; A placeholder URL stamped on the seeded in-flight handle (for the abort
-;; trace + any registry read-out). Same-origin so it reads naturally; no
-;; live Fetch is issued — the slot is seeded directly so the pending state
-;; is deterministic.
+;; A placeholder URL stamped on the seeded in-flight handle, so it reads
+;; naturally in the abort trace and any registry read-out. No Fetch is
+;; issued — the slot is seeded directly so the pending state is deterministic.
 (def long-pending-url "api/long")
 
 (rf/reg-fx :counter/seed-long-request
-  {:doc       "Demo-only fx: record a genuine request-id-keyed in-flight
-               handle in the framework registry whose :abort-fn dispatches
-               the canonical :rf.http/aborted reply (addressed back to
-               :counter/start-long) and clears the slot — so the LIVE
-               :rf.http/managed-abort fx resolves it end-to-end. Mirrors
-               the proven seed-in-flight pattern in
-               tools/xray/testbeds/managed_http/core.cljs."
+  {:doc       "Demo-only fx: record a request-id-keyed in-flight handle in
+               the framework registry whose :abort-fn clears the slot and
+               dispatches the :rf.http/aborted reply back to
+               :counter/start-long — so the live :rf.http/managed-abort fx
+               resolves it end-to-end."
    :platforms #{:client}}
   (fn fx-seed-long-request [frame-ctx {:keys [request-id]}]
-    ;; EP-0002: the abort-fn fires later (when the LIVE
-    ;; :rf.http/managed-abort fx resolves this handle), so it carries no
-    ;; ambient frame of its own — a bare `rf/dispatch` inside it would raise
-    ;; :rf.error/no-frame-context. Capture the fx-context's frame and pass it
-    ;; explicitly on the deferred dispatch (Spec 002 §async fx capture the
-    ;; frame — the same `{:frame (:frame frame-ctx)}` pattern the boot example
-    ;; uses for its deferred reply).
+    ;; The abort-fn fires later, when the live :rf.http/managed-abort fx
+    ;; resolves this handle, so it has no frame of its own — a bare
+    ;; `rf/dispatch` inside it would raise :rf.error/no-frame-context. A
+    ;; frame's identity is carried, not found, so we capture the fx
+    ;; context's frame here and pass it explicitly on the deferred
+    ;; dispatch. See docs/guide/glossary.md#frame-identity-is-carried-not-found.
     (let [frame (:frame frame-ctx)]
       (http-registry/record-in-flight!
         request-id nil
         {:url      long-pending-url
-         ;; The abort-fn IS the in-flight request's cancellation hook. The
+         ;; The abort-fn is the in-flight request's cancellation hook. The
          ;; live :rf.http/managed-abort handler resolves this handle by
          ;; request-id and calls this fn with the abort `reason` (`:user`
-         ;; here). We clear the registry slot and dispatch the canonical
+         ;; here). We clear the registry slot and dispatch the
          ;; :rf.http/aborted reply — the exact shape the live transport's
-         ;; abort path emits (Spec 014 §Failure categories) — back through
-         ;; default reply addressing to :counter/start-long.
+         ;; abort path emits — back through default reply addressing to
+         ;; :counter/start-long.
          :abort-fn (fn [reason]
                      (http-registry/clear-in-flight! request-id)
                      (rf/dispatch [:counter/start-long

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -2,13 +2,13 @@
   "Worked example: the **Nine States of UI**, modelled as a single
    parallel state machine.
 
-   Most apps only design the happy path and leave the eight other states
-   visually undefined. This example demonstrates all nine canonical UI
-   states for a single small domain — a **todos list** — using one
-   `:type :parallel` machine with three regions, plus `:fsm/tags` to
-   carry the per-axis intent.
+   Most apps design only the happy path and leave the other eight states
+   visually undefined. This example renders all nine canonical UI states
+   for one small domain — a **todos list** — using one `:type :parallel`
+   machine with three regions, plus state tags carrying the per-axis
+   intent.
 
-   The nine states (per the well-known UX taxonomy):
+   The nine states (the well-known UX taxonomy):
 
      1. Nothing      — never fetched; the data region is at `:nothing`.
      2. Loading      — first fetch in flight; the data region is at `:loading`.
@@ -20,77 +20,70 @@
      8. Correct      — a happy-path success after a valid submit.
      9. Done/Frozen  — terminal state; the mode region is at `:done`.
 
-   The machine declaration carries the **whole** model:
+   The machine declaration carries the whole model in three regions:
 
      - `:data` region    — six cardinality states (Nothing / Loading /
                             Empty / One / Some / Too Many) plus an `:error`
                             branch. An `:always`-cascade picks the
                             cardinality bucket after a successful fetch.
      - `:form` region    — three states (Neutral / Incorrect / Correct)
-                            mirroring Pattern-Forms' lifecycle.
+                            tracking the form lifecycle.
      - `:mode` region    — two states (Active / Done); `:done` is
                             terminal and read-only.
 
    Every state carries `:tags` describing its per-axis intent
-   (`:data/loading`, `:form/invalid`, `:mode/done`, ...). One render-priority
-   table in data + one selector sub (`:ui/render`) collapse the tag
-   union into a single render-model keyword. The root view's `case`
-   over `:ui/render` replaces what the legacy variant did with nine
-   boolean discriminator subs + a priority `cond`.
+   (`:data/loading`, `:form/invalid`, `:mode/done`, ...). One
+   render-priority table in data plus one selector sub (`:ui/render`)
+   collapse the tag union into a single render-model keyword. The root
+   view's `case` over `:ui/render` is the only branch site.
 
    What this example demonstrates:
 
-   - **Parallel regions + tags** (`spec/Pattern-NineStates.md`,
-     `spec/005-StateMachines.md` §Parallel regions / §State tags) —
-     three orthogonal axes in one machine, with tag-shaped queries
-     against the active configuration.
-   - **Pattern-RemoteData**-shaped lifecycle (`spec/Pattern-RemoteData.md`)
-     — folded into the `:data` region; the region's state-keyword IS
-     the status, so the slice's separate `:status` field disappears.
-   - **Pattern-Forms** (`spec/Pattern-Forms.md`) — the
-     `{:draft :errors :touched}` slice carries the form
-     runtime; the form region's state tracks the validation/submission
-     lifecycle.
-   - **Inspectability bias** — non-trivial guards / actions are named
+   - **Parallel regions + state tags** — three orthogonal axes in one
+     machine, queried by tag against the active configuration. See the
+     machines guide on [parallel regions]
+     (../../../docs/machines/concepts.md#when-the-machine-grows) and
+     [state tags]
+     (../../../docs/machines/concepts.md#guards-actions-tags-and-after--the-recognition-kit).
+   - **Managed-HTTP lifecycle** folded into the `:data` region: the
+     region's state-keyword IS the request status, so a separate
+     `:status` field disappears. See [managed HTTP]
+     (../../../docs/resources/glossary.md#managed-http) and the
+     [resource-status lifecycle]
+     (../../../docs/resources/glossary.md#resource-status).
+   - **A form slice** — the `{:draft :errors :touched}` slice carries the
+     form runtime; the form region's state tracks the
+     validation/submission lifecycle. See [Build a form]
+     (../../../docs/guide/how-to/build-a-form.md).
+   - **Inspectability bias** — non-trivial guards and actions are named
      entries in the machine's `:guards` / `:actions` maps; only trivial
      transitions use inline fns.
-   - **Headless tests** — every state has a fixture that drives `app-db`
-     into that state and asserts against tags + `:ui/render`. Browserless
-     via `compute-sub` / `dispatch-sync`. The example tree is test-free;
-     the fixtures live in the framework test tree at
-     `implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs`
-     (ns `re-frame.nine-states-cljs-test`).
+   - **Headless tests** — every state has a fixture that drives the
+     machine into that state and asserts against its tags + `:ui/render`,
+     without a browser. The example tree is test-free; the fixtures live
+     in the framework test tree at
+     `implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs`.
 
-   Layout follows the single-file style of `examples/reagent/login/core.cljs`
-   and `examples/reagent/seven_guis/circle_drawer/core.cljs`. In a real
-   codebase this would split per CP-6 conventions across schema / events /
-   subs / views / machines files."
+   The whole example is one file. In a real codebase it would split
+   across schema / events / subs / views / machines files."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            ;; The Spec 010 schema-attachment ns lives in
-            ;; the day8/re-frame2-schemas artefact. Loading the ns
-            ;; here registers its late-bind hooks so the
-            ;; rf/reg-app-schema calls below resolve.
+            ;; The schema-attachment ns lives in the
+            ;; day8/re-frame2-schemas artefact. Requiring it registers
+            ;; the hooks the `rf/reg-app-schema` calls below need.
             [re-frame.schemas]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine
-            ;; (called below at ns-load) and the `:rf/machine` /
-            ;; `:rf/machine-has-tag?` framework subs resolve.
+            ;; The state-machine ns lives in the day8/re-frame2-machines
+            ;; artefact. Requiring it registers the hooks `rf/reg-machine`
+            ;; and the `:rf/machine` / `:rf/machine-has-tag?` subs need.
             [re-frame.machines]
-            ;; Managed-HTTP ships in day8/re-frame2-http.
-            ;; Requiring re-frame.http.managed at app boot triggers its
-            ;; load-time fx registrations (`:rf.http/managed` and
-            ;; family); without it, dispatching `:rf.http/managed`
-            ;; (used below in the load-todos fx) would fail with
-            ;; :rf.error/no-such-fx.
+            ;; Managed-HTTP ships in day8/re-frame2-http. Requiring it
+            ;; registers the `:rf.http/managed` fx (and family) the
+            ;; load-todos fx below dispatches.
             [re-frame.http.managed]
             ;; Registers the framework canned-stub fxs
-            ;; (:rf.http/managed-canned-success / -failure). The per-app
-            ;; demo stub below (:nine-states.http/managed-demo, the
-            ;; :fx-overrides target for :rf.http/managed) delegates to
-            ;; them, so without this require those lookups would miss.
+            ;; (`:rf.http/managed-canned-success` / `-failure`). The
+            ;; per-app demo stub below delegates to them.
             [re-frame.http.test-support]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -101,10 +94,9 @@
 ;; ============================================================================
 
 (def too-many-threshold
-  "A 'small list' is up to TOO-MANY-THRESHOLD items; beyond that we render
-   the 'Too Many' UI (search + truncation). Lifted to a named const so
-   the machine's :too-many? guard and the test fixtures reference the
-   same value."
+  "A 'small list' is up to this many items; beyond that we render the
+   'Too Many' UI (search + truncation). Named so the machine's
+   `:too-many?` guard and the test fixtures share one value."
   7)
 
 (def new-todo-defaults
@@ -113,66 +105,64 @@
    :touched  #{}})
 
 ;; ============================================================================
-;; SCHEMAS  (Spec 010)
+;; SCHEMAS
 ;; ============================================================================
 ;;
-;; The :ui/nine-states machine's `:data` slot is its own self-documenting
+;; The `:ui/nine-states` machine's `:data` slot is its own self-describing
 ;; record (see the machine declaration). The form slice describes only
-;; what the form *collects* + per-field validation state — no `:status`
+;; what the form collects plus per-field validation state — no `:status`
 ;; field, because the form region's state-keyword IS the status.
 
-;; NOTE the slice's `:draft` is a bare `:map`, NOT a stricter
-;; "valid submission" shape: a form draft legitimately holds
-;; in-progress / invalid input (an empty title before the user types),
-;; so a min-length constraint here would reject the initial draft write
-;; under dev-mode schema validation. The valid-submission constraint
-;; lives in the form's validate fn (see `validate-new-todo`), not the
-;; slice schema — drafts and submissions are different shapes.
+;; The slice's `:draft` is a bare `:map`, not a stricter "valid submission"
+;; shape. A draft legitimately holds in-progress / invalid input (an empty
+;; title before the user types), so a min-length constraint here would
+;; reject the initial draft write under dev-mode schema validation. The
+;; valid-submission constraint lives in the form's validate fn (see
+;; `validate-new-todo`), not the slice schema — drafts and submissions are
+;; different shapes.
 (def NewTodoSlice
   [:map
    [:draft   :map]
    [:errors  {:default {}} [:map-of :keyword [:vector :string]]]
    [:touched {:default #{}} [:set :keyword]]])
 
-;; EP-0002: reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (the same id `run`'s `frame-provider {:id …}` ENSURES), so
-;; name it explicitly here.
+;; `reg-app-schema` is frame-local: it needs a frame in scope, or it
+;; raises `:rf.error/no-frame-context`. This example runs in `:rf/default`
+;; (the same id `run`'s `frame-provider {:id …}` ensures), so name it
+;; explicitly here. See the frames glossary:
+;; ../../../docs/guide/glossary.md#frame-identity-is-carried-not-found
 (with-frame :rf/default
   (rf/reg-app-schema [:new-todo] {:schema NewTodoSlice}))
 
 ;; ============================================================================
-;; RECORDABLE COEFFECTS  (EP-0017)
+;; RECORDABLE COEFFECTS
 ;; ============================================================================
 ;;
-;; A submitted todo's `:id` is written into durable machine runtime-data
-;; (`:data :items`) and used as a React `:key` / join handle. Per EP-0010 a
-;; durable id must be a FOLDED FACT, never an ambient `(random-uuid)` read at
-;; the write site (a fresh-event-stream replay would mint a different id and the
-;; snapshot/keys would not reproduce). The EP-0017 authoring surface for an
-;; app-owned generator is a RECORDABLE `reg-cofx`: the generator runs at
-;; processing-start, the minted value is recorded onto the causal token, and
-;; replay re-presents it verbatim (mint-policy `:strict` re-feeds the recorded
-;; value instead of re-minting). `:new-todo/submit` DECLARES it via
-;; `:rf.cofx/requires` and reads it flat from the coeffects map — the handler
-;; stays pure and replayable. A uuid is valid EDN (`#uuid`), so it is a legal
-;; recordable value, recorded onto the token verbatim (matching the
-;; `gen-todos` seed-data id type).
+;; A submitted todo's `:id` is written into durable machine data
+;; (`:data :items`) and used as a React `:key`. A durable id must be a
+;; fact the handler is handed, never an ambient `(random-uuid)` read at
+;; the write site — replaying the event stream would mint a different id
+;; and the snapshot and keys would not reproduce. So the generator is a
+;; *recordable* coeffect: it runs once, the minted value is recorded, and
+;; replay re-presents the same value instead of re-minting. `:new-todo/submit`
+;; declares it via `:rf.cofx/requires` and reads it from the coeffects map,
+;; staying pure and replayable. See the recordable-vs-ambient coeffects
+;; entry: ../../../docs/guide/glossary.md#recordable-vs-ambient-coeffects
 (rf/reg-cofx :new-todo/todo-id
   {:recordable? true
-   :doc "Replayable fresh id for a newly-submitted todo (EP-0017)."}
+   :doc "Replayable fresh id for a newly-submitted todo."}
   (fn [] (random-uuid)))
 
 ;; ============================================================================
 ;; FX  (test-friendly stubs)
 ;; ============================================================================
 ;;
-;; Real apps would issue a single `:rf.http/managed` request (Spec 014) and
-;; override at test time via the id-valued seam (per Spec 002). For this
-;; self-contained example we ship one per-app stub that delegates to the
-;; framework-shipped canned-success / canned-failure fxs (Spec 014 §Testing)
-;; so the control panel can drive the data region into Empty / One / Some /
-;; Too Many without a server.
+;; A real app would issue one `:rf.http/managed` request and override it at
+;; test time via the frame's `:fx-overrides`. For this self-contained
+;; example we ship one per-app stub that delegates to the framework's
+;; canned-success / canned-failure fxs, so the control panel can drive the
+;; data region into Empty / One / Some / Too Many without a server. See
+;; [managed HTTP](../../../docs/resources/http.md).
 
 (defn- gen-todos [n]
   (vec (for [i (range n)]
@@ -182,10 +172,10 @@
   {:doc       "Demo override for `:rf.http/managed`. Routes by URL:
                `/api/todos` → success with N synthetic todos (N from
                `:request :query :n`); `/api/todos/fail` → transport
-               failure. Delegates to the framework-shipped
+               failure. Delegates to the framework's
                `:rf.http/managed-canned-success` /
-               `:rf.http/managed-canned-failure` per Spec 014 §Testing
-               so the canonical reply shape is preserved."
+               `:rf.http/managed-canned-failure` so the reply shape
+               matches a real managed request."
    :platforms #{:client :server}}
   (fn fx-managed-demo [frame-ctx args-map]
     (let [url (-> args-map :request :url str)]
@@ -212,26 +202,27 @@
 ;;           :resolving, an :always-cascade picks the cardinality bucket
 ;;           by reading :items out of the shared :data.
 ;;
-;;   :form — Pattern-Forms' Neutral / Incorrect / Correct lifecycle
-;;           (states 7 & 8). Driven by :submit-valid / :submit-invalid /
-;;           :edit events; transitions are pure (the slice's :errors /
-;;           :touched live in app-db, not in the machine's :data).
+;;   :form — the Neutral / Incorrect / Correct form lifecycle (states 7
+;;           & 8). Driven by :submit-valid / :submit-invalid / :edit
+;;           events; transitions are pure (the slice's :errors / :touched
+;;           live in app-db, not in the machine's :data).
 ;;
 ;;   :mode — the Active / Done axis (state 9). :done is terminal and
 ;;           tagged :mode/read-only — the view inspects that tag to
 ;;           disable the form and the control buttons.
 ;;
-;; Per Spec 005 §Parallel regions the snapshot's :state is a map keyed
-;; by region name; :data is shared across all regions; :tags is the
-;; union of every active state's tag set.
+;; With parallel regions the snapshot's :state is a map keyed by region
+;; name; :data is shared across all regions; :tags is the union of every
+;; active state's tag set. See the machines guide:
+;; ../../../docs/machines/concepts.md#when-the-machine-grows
 
 (def nine-states-machine
   {:type :parallel
 
-   ;; Shared :data: the data region's :items live here, plus the
-   ;; mode region's :archived-at stamp. Shared rather than per-region
-   ;; because the regions share a domain (per Spec 005 §When to reach
-   ;; for parallel regions); see the rewrite design doc §9.4.
+   ;; Shared :data: the data region's :items live here, plus the mode
+   ;; region's :archived-at stamp. Shared rather than per-region because
+   ;; the regions share one domain (when axes don't share data, prefer
+   ;; N separate machines).
    :data {:items       []
           :error       nil
           :archived-at nil}
@@ -267,7 +258,7 @@
       {:data (assoc data :archived-at (or now 0))})}
 
    :regions
-   {;; ---- :data region — Pattern-RemoteData lifecycle + cardinality ----
+   {;; ---- :data region — managed-HTTP lifecycle + cardinality ----
     :data
     {:initial :nothing
      :states
@@ -320,7 +311,7 @@
        :on   {:fetch-started :loading
               :reset         :nothing}}}}
 
-    ;; ---- :form region — Pattern-Forms lifecycle ----
+    ;; ---- :form region — form lifecycle ----
     :form
     {:initial :neutral
      :states
@@ -369,9 +360,9 @@
 ;;
 ;; The control panel buttons dispatch high-level demo events that
 ;; coordinate the form slice's app-db state with broadcasts into the
-;; :ui/nine-states machine. Splitting them out (rather than dispatching
-;; the machine directly) keeps the imperative bits (clear the form,
-;; bump app-db) out of the view.
+;; :ui/nine-states machine. Wrapping them like this — rather than
+;; dispatching the machine directly from the view — keeps the imperative
+;; bits (clear the form, bump app-db) out of the view.
 
 (rf/reg-event :nine-states.app/initialise
   {:doc "Seed the form slice + reset the machine to its initial state."}
@@ -445,12 +436,12 @@
          machine's :data items via :fetch-succeeded, clear the draft,
          and broadcast :submit-valid (the :form region lands in
          :correct)."
-   ;; EP-0017: the new todo's durable id is FOLDED from a recordable
-   ;; coeffect, never read ambiently at the write site (see the
-   ;; `:new-todo/todo-id` reg-cofx above) — replay re-presents it.
+   ;; The new todo's durable id comes from a recordable coeffect, never
+   ;; read ambiently at the write site (see the `:new-todo/todo-id`
+   ;; reg-cofx above) — so replay re-presents the same id.
    :rf.cofx/requires [:new-todo/todo-id]}
-  ;; EP-0001: the machine snapshot is durable runtime-db state —
-  ;; read it from the `:rf.db/runtime` coeffect.
+  ;; The machine snapshot is durable runtime-db state — read it from the
+  ;; `:rf.db/runtime` coeffect.
   (fn handler-new-todo-submit [{:keys [db] rt :rf.db/runtime new-id :new-todo/todo-id} _]
     (let [draft  (get-in db [:new-todo :draft])
           errors (validate-new-todo draft)
@@ -510,20 +501,16 @@
 ;; ---- render-priority + :ui/render selector ----
 ;;
 ;; This is where the nine states collapse to one keyword. The render
-;; decision is a pure function over the snapshot's tag union, and it
-;; lives in exactly one readable place — no if-tower whose precedence
-;; you reverse-engineer later. The render-priority table is plain data:
-;; a vector of {:tag :render} pairs consulted in order. The :ui/render
-;; sub reads the machine's tag union and returns the first :render whose
-;; :tag is present. This is the **single** place the page's render
-;; priorities live; the root view's `case` just maps the resolved
-;; keyword to a view fn.
+;; decision is a pure function over the snapshot's tag union, and it lives
+;; in exactly one readable place. The render-priority table is plain data:
+;; a vector of {:tag :render} pairs consulted in order. The :ui/render sub
+;; reads the machine's tag union and returns the first :render whose :tag
+;; is present. The root view's `case` just maps that keyword to a view fn.
 ;;
-;; Priority rationale: :mode wins outright (the archived view replaces
+;; Priority order: :mode wins outright (the archived view replaces
 ;; everything); :form wins next (the success / inline-error
-;; acknowledgement is transient and overlays whatever the :data
-;; region happens to be at); :data picks the cardinality bucket as a
-;; fallback.
+;; acknowledgement is transient and overlays whatever the :data region is
+;; at); :data picks the cardinality bucket as a fallback.
 
 (def render-priority
   [;; mode region — read-only / terminal wins
@@ -568,7 +555,7 @@
   [:div.state.state-loading
    [:p "Loading todos…"]])
 
-(reg-view ^{:doc "Error branch — transport / server failure (Pattern-RemoteData :error)."}
+(reg-view ^{:doc "Error branch — transport / server failure."}
           view-error []
   (let [err @(subscribe [:todos/error])]
     [:div.state.state-error
@@ -632,10 +619,10 @@
 ;; ============================================================================
 ;;
 ;; The form and control panel use `(rf/machine-has-tag? :ui/nine-states
-;; :mode/read-only)` to disable themselves when the :mode region is
-;; :done. Querying by tag is cleaner than querying a specific state
-;; (`:ui.state/done?`): the view doesn't need to know *which* state of
-;; which region carries the read-only intent.
+;; :mode/read-only)` to disable themselves when the :mode region is :done.
+;; Querying by tag is cleaner than querying a specific state: the view
+;; asks "is it read-only?" and doesn't need to know which state of which
+;; region carries that intent. (Ask, don't tell.)
 
 (reg-view ^{:doc "Form for adding a todo. Drives the form region (states 7 & 8)."}
           new-todo-form []
@@ -709,33 +696,24 @@
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 ;;
-;; The mount is performed inside `run` rather than at namespace-load
-;; time. Examples are also `:require`'d by the browser-test bundle
-;; (`re-frame.nine-states-cljs-test`) — which also requires sibling
-;; examples like `realworld.core`. If both namespaces called
-;; `rdc/create-root` against `(js/document.getElementById "app")` at
-;; ns-load time, every required example would race to attach a root to
-;; the same `#app` element shared by the test harness, producing
-;; React warnings ("createRoot is being called on the same container
-;; twice") and example-A side effects leaking into example-B's tests.
-;;
-;; Deferring `create-root` to `run` keeps ns-load DOM-side-effect-free,
-;; so multiple example namespaces can co-exist in one CLJS build (the
-;; browser test runner) without stepping on each other's mount points.
-;; The headless fixtures live in the framework test tree at
-;; `implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs`
-;; (the example tree is test-free) and run in any CLJS host
-;; without touching React.
+;; The mount happens inside `run`, not at namespace-load time. The
+;; browser-test bundle `:require`s several example namespaces at once. If
+;; each called `rdc/create-root` against `(js/document.getElementById "app")`
+;; at ns-load, they would race to attach a root to the one `#app` element
+;; the harness shares — producing React "createRoot called on the same
+;; container twice" warnings and cross-example leakage. Deferring
+;; `create-root` to `run` keeps ns-load free of DOM side effects, so the
+;; namespaces co-exist in one build cleanly.
 
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; `init!` installs the Reagent adapter (EP-0002).
+  ;; `init!` installs the Reagent adapter.
   (rf/init! reagent-adapter/adapter)
-  ;; EP-0026: the `frame-provider {:id …}` below is the one spot that owns
-  ;; the frame. On first mount it creates `:rf/default`, applies the config,
-  ;; and runs `:initial-events` once; on hot reload it reuses the existing
-  ;; frame and skips re-seeding. Config:
+  ;; The `frame-provider {:id …}` below owns the frame. On first mount it
+  ;; creates `:rf/default`, applies the config, and runs `:initial-events`
+  ;; once; on hot reload it reuses the existing frame and skips re-seeding.
+  ;; Config:
   ;;
   ;; - `:fx-overrides` routes `:rf.http/managed` to the in-process canned-stub
   ;;   fxs above, so the example runs standalone with no backend.

--- a/examples/reagent/nine_states/stories.cljs
+++ b/examples/reagent/nine_states/stories.cljs
@@ -3,38 +3,36 @@
 
    The nine canonical UI states (Nothing / Loading / Empty / One /
    Some / Too Many / Incorrect / Correct / Done) form a natural Story
-   VARIANT SET — Story's core strength is enumerating a single view's
-   view-states side by side. This file registers one `reg-variant`
-   per render-model keyword the root view `case`s over, so the Story
-   controls panel flips the page through every state without the
-   reader hand-driving the machine.
+   variant set — Story enumerates a single view's view-states side by
+   side. This file registers one `reg-variant` per render-model keyword
+   the root view `case`s over, so the Story controls panel flips the page
+   through every state without the reader hand-driving the machine.
 
    ## Where the nine come from
 
    `nine-states.core` collapses the `:ui/nine-states` machine's
-   parallel-region tag union into ONE render-model keyword via the
-   `:ui/render` selector sub (consulting the `render-priority`
-   table). The root view's `case` has exactly ten arms — the nine
-   canonical states plus the `:error` branch. The nine canonical
-   variants below map 1:1 onto the nine canonical render keywords:
+   parallel-region tag union into one render-model keyword via the
+   `:ui/render` selector sub (consulting the `render-priority` table).
+   The root view's `case` has exactly ten arms — the nine canonical
+   states plus the `:error` branch. The nine canonical variants below
+   map 1:1 onto the nine canonical render keywords:
 
      :nothing :loading :empty :one :some :too-many
      :incorrect :correct :done
 
-   The `:error` branch is the tenth render arm; it lives on a
-   SEPARATE `:story.nine-states-lifecycle` story (below) alongside
-   `:loading`/`:some` so the async **load → loading → loaded/error**
-   cascade reads as one lifecycle the reader can step through and
-   inspect in Xray (the bead's Xray-rich requirement). Keeping it off
-   the canonical nine keeps that set a clean 1:1 with the render
-   keywords.
+   The `:error` branch is the tenth render arm; it lives on a separate
+   `:story.nine-states-lifecycle` story (below) alongside `:loading` /
+   `:some`, so the async **load → loading → loaded/error** cascade reads
+   as one lifecycle the reader can step through and inspect in Xray.
+   Keeping it off the canonical nine keeps that set a clean 1:1 with the
+   render keywords.
 
    ## Fidelity — reach each state via real events
 
-   Every variant drives its state through REAL events into the
-   `:ui/nine-states` machine — the highest-fidelity path, so the
-   Story canvas shows exactly what the live app shows and Xray's
-   Epoch / Trace / Side Effects panels carry the genuine cascade:
+   Every variant drives its state through real events into the
+   `:ui/nine-states` machine — the highest-fidelity path, so the Story
+   canvas shows exactly what the live app shows and Xray's Epoch / Trace
+   / Side Effects panels carry the genuine cascade:
 
    - Nothing      — `[:nine-states.app/initialise]` (machine `:reset`).
    - Loading       — `[:ui/nine-states [:fetch-started]]` parks the
@@ -48,26 +46,22 @@
    - Correct       — edit a valid title + submit → `:submit-valid`.
    - Done          — load + archive → the `:mode` region reaches `:done`.
 
-   NO `:db-seed` / `:sub-overrides` are needed: every state is
-   reachable through an event path, so the fidelity is uniformly
-   `:event` (Story's controls panel + the Xray cascade tell the
-   truth on their own — no synthetic seeding to disclose).
+   Every state is reachable through an event path, so no `:db-seed` /
+   `:sub-overrides` are needed and the fidelity is uniformly `:event`.
 
    ## Xray-richness — the managed-HTTP cascade
 
-   Story allocates each variant its own frame under `:preset :story`
-   (spec/002 §Frame presets). The preset's contract is a SUCCESS stub
-   by DEFAULT: it redirects `:rf.http/managed` to the framework-shipped
-   `:rf.http/managed-canned-success` stub only (frame.cljc
-   `preset-expansion` — there is no automatic canned-failure branch).
-   A variant that wants the FAILURE path stamps its own
+   Story allocates each variant its own frame under `:preset :story`.
+   That preset redirects `:rf.http/managed` to the framework's
+   `:rf.http/managed-canned-success` stub by default — there is no
+   automatic failure branch. A variant that wants the failure path
+   stamps its own
    `:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}`,
-   which wins over the preset default (the variant-owned `:fx-overrides`
-   replaces the preset's in the frame-config merge — see the lifecycle
-   `…/error` variant below). `:nine-states.story/load` issues a real
+   which wins over the preset default (see the lifecycle `…/error`
+   variant below). `:nine-states.story/load` issues a real
    `:rf.http/managed` request carrying the synthetic todos on the
    request's `:value` slot (the slot the canned-success stub echoes
-   back), so the FULL fetch lifecycle runs:
+   back), so the full fetch lifecycle runs:
 
        :nine-states.story/load
          → [:ui/nine-states [:fetch-started]]        (→ :loading)
@@ -77,23 +71,22 @@
                  → [:ui/nine-states [:fetch-succeeded …]]
                      → :resolving → :always cardinality bucket
 
-   That whole chain lands on the Epoch tape + the Trace stream, and
+   That whole chain lands on the Epoch tape and the Trace stream, and
    the `:rf.http/managed` fx shows in the Side Effects panel — so a
-   reader can pick the `:some` or `:error` variant and watch the
-   RemoteData fetch light up Xray end to end.
+   reader can pick the `:some` or `:error` variant and watch the fetch
+   light up Xray end to end.
 
    ## Authoring discipline
 
-   Per spec/007 §Variants every variant body is plain data — no
-   fn-slots. The view at the centre of each variant is the example's
-   own `nine-states.core/root-view`, referenced by id. The canonical
-   Story tags auto-install on the first `reg-*` call, so
-   no explicit boot step is needed."
+   Every variant body is plain data — no fn-slots. The view at the centre
+   of each variant is the example's own `nine-states.core/root-view`,
+   referenced by id. The canonical Story tags auto-install on the first
+   `reg-*` call, so no explicit boot step is needed."
   (:require [re-frame.core :as rf]
             [re-frame.story :as story]
-            ;; Source the example's registrations (the machine, the
-            ;; demo events/subs/views, the `:ui/render` selector). The
-            ;; variant bodies below reference its event-ids + the
+            ;; Source the example's registrations (the machine, the demo
+            ;; events / subs / views, the `:ui/render` selector). The
+            ;; variant bodies below reference its event-ids and the
             ;; `root-view` view-id as plain keywords; requiring the ns
             ;; fires every `reg-*` so those ids resolve.
             [nine-states.core]))
@@ -105,13 +98,12 @@
 ;; `:query {:n N}` and lets the app's own `:nine-states.http/managed-demo`
 ;; fx-override read `:n` to synthesise todos. Inside the Story shell the
 ;; per-variant frame runs under `:preset :story`, which redirects
-;; `:rf.http/managed` to the framework-shipped `:rf.http/managed-canned-
-;; success` stub instead — that stub echoes the request's `:value` slot
-;; back as the success payload (Spec 014 §Testing). So the Story load
-;; event puts the synthetic todos directly on `:value`, keeping the SAME
-;; real `:rf.http/managed` fx cascade the live app uses (visible in
-;; Xray's Side Effects panel) while staying deterministic under the
-;; canned stub — no app-side fx-override required.
+;; `:rf.http/managed` to the framework's `:rf.http/managed-canned-success`
+;; stub instead — that stub echoes the request's `:value` slot back as the
+;; success payload. So the Story load event puts the synthetic todos
+;; directly on `:value`, keeping the same real `:rf.http/managed` fx
+;; cascade the live app uses (visible in Xray's Side Effects panel) while
+;; staying deterministic under the canned stub.
 ;; ---------------------------------------------------------------------------
 
 (defn- gen-todos
@@ -145,24 +137,21 @@
          `:rf.http/managed` → reply → `:fetch-failed` — into the
          `:error` branch.
 
-         The `:story` preset's default fx-override routes
-         `:rf.http/managed` to the canned-SUCCESS stub (frame.cljc
-         `preset-expansion`), which would take the `:on-success` path.
-         The error VARIANT therefore stamps its own
+         The `:story` preset routes `:rf.http/managed` to the
+         canned-success stub by default, which would take the
+         `:on-success` path. So the error variant stamps its own
          `:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}`
-         (a variant-owned `:fx-overrides` wins over the preset's via the
-         frame-config merge in `expand-preset`), so this same event runs
-         against the canned-FAILURE stub instead — that stub reads the
-         top-level `:kind`/`:tags` slots below, synthesises a failure
-         reply, and dispatches `:on-failure`, landing the `:data` region
-         at `:error`."}
+         (a variant-owned `:fx-overrides` wins over the preset's), and
+         this same event runs against the canned-failure stub instead —
+         that stub reads the top-level `:kind` / `:tags` slots below,
+         synthesises a failure reply, and dispatches `:on-failure`,
+         landing the `:data` region at `:error`."}
   (fn handler-story-load-failing [_ _]
     {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
           [:rf.http/managed
-           ;; `:kind`/`:tags` are the slots `emit-canned-failure!` reads
-           ;; (NOT a nested `:failure` map — the stub ignores that), so
-           ;; the synthesised failure carries this category through to
-           ;; `:nine-states.demo/load-failed`.
+           ;; The canned-failure stub reads `:kind` / `:tags` from the
+           ;; top level (not a nested `:failure` map), so this failure
+           ;; category carries through to `:nine-states.demo/load-failed`.
            {:request    {:method :get :url "/api/todos/fail"}
             :kind       :rf.http/transport
             :tags       {:message "Network unreachable."}
@@ -173,11 +162,10 @@
 ;; ---------------------------------------------------------------------------
 ;; register-all!
 ;;
-;; Wrap every registration in a top-level fn so a test fixture (none
-;; here — examples are test-free) or a hot-reload could
-;; re-fire the lot after a clear-all!. The fn fires once at namespace
-;; load via the trailing call, so consumers who just `:require` this ns
-;; get the side-table populated.
+;; Every registration lives in one top-level fn so a hot-reload can re-fire
+;; the lot at once. The fn also fires once at namespace load via the
+;; trailing call, so consumers who just `:require` this ns get the
+;; registrations populated.
 ;; ---------------------------------------------------------------------------
 
 (defn register-all!
@@ -355,10 +343,9 @@
                     the `:data` region at `:error`. The failure cascade
                     lights up Xray's Side Effects + Trace panels
                     alongside the success path."
-     ;; Variant-owned `:fx-overrides` win over the `:story` preset's
-     ;; canned-success default (frame-config merge in `expand-preset`),
-     ;; so this is the explicit failure-fx-override the failing variant
-     ;; needs — the success variants keep the preset's canned-success.
+     ;; This variant-owned `:fx-overrides` wins over the `:story` preset's
+     ;; canned-success default, giving the failing variant its failure
+     ;; stub — the success variants keep the preset's canned-success.
      :fx-overrides  {:rf.http/managed :rf.http/managed-canned-failure}
      :setup         [[:nine-states.app/initialise]
                      [:nine-states.story/load-failing]]

--- a/examples/reagent/nine_states/stories_host.cljs
+++ b/examples/reagent/nine_states/stories_host.cljs
@@ -73,7 +73,7 @@
      :fx-overrides {:rf.http/managed :nine-states.http/managed-demo}})
   ;; Seed the frame. `dispatch-sync` runs inside `with-frame :rf/default` so
   ;; it targets that frame (a frameless dispatch raises
-  ;; `:rf.error/no-frame-context`, EP-0002).
+  ;; `:rf.error/no-frame-context`).
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:nine-states.app/initialise])))
 
@@ -90,7 +90,7 @@
 
 ;; Scope the live `#/` surface into the showcase's `:rf/default` frame, so
 ;; `nine-states-app`'s reg-view-injected dispatch/subscribe (and
-;; `core/root-view`'s subs) resolve to it (EP-0002). The Story shell side
+;; `core/root-view`'s subs) resolve to it. The Story shell side
 ;; (`#/stories`) allocates its own per-variant frames. Passed to the shared
 ;; story-host as the live-app root view (mirrors counter-with-stories.core).
 (defn live-app-root []
@@ -115,12 +115,11 @@
   (install-live-frame!)
   ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
   ;; `#/stories` lands on the shell without a manual click-through. The
-  ;; `:source-subdir` opt tells the host this showcase's Story
-  ;; source-coords are classpath-relative to `examples/reagent`, so the host
-  ;; resolves the on-disk project-root (build-env define or `?checkout-root=`
-  ;; override, cross-platform) and calls `story/configure!` itself — that
-  ;; also bridges the root into Xray's slot. Without it the Story 'open in
-  ;; editor' chips would resolve `nine_states/stories.cljs` against a nil root.
-  ;; The live-app root is frame-scoped via `live-app-root` (the `frame-provider`
-  ;; wrapper) so the bare `#/` surface mounts under the app frame.
+  ;; `:source-subdir` opt tells the host this showcase's Story source-coords
+  ;; are classpath-relative to `examples/reagent`, so it resolves the on-disk
+  ;; project root and calls `story/configure!` itself (also bridging the root
+  ;; into Xray's slot). Without it the Story 'open in editor' chips would
+  ;; resolve `nine_states/stories.cljs` against a nil root. The live-app root
+  ;; is frame-scoped via `live-app-root` (the `frame-provider` wrapper) so the
+  ;; bare `#/` surface mounts under the app frame.
   (story-host/mount-with-hash-routing! live-app-root {:source-subdir "examples/reagent"}))

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -1,44 +1,33 @@
 (ns notebook.core
-  "Reagent design-led example — 'Notebook'. Three-pane editorial layout:
+  "Reagent design-led example — 'Notebook'. A three-pane editor:
 
      [ documents tree ]  [ markdown editor ]  [ live preview ]
 
-   The point of the example: the same event cascade that drives the
-   counter scales unchanged to a substantive, multi-pane UI. State lives
-   in one app-db, events are the only thing that change it, and the views
-   are pure functions of subscriptions. Reading order, top to bottom:
+   The point of the example: one app-db holds the state, events are the
+   only thing that change it, and the views are pure functions of
+   subscriptions. The same shape scales from a counter to this
+   multi-pane UI unchanged. Reading order, top to bottom:
 
      - selecting a document   dispatches  [:notebook/select id]
      - editing the body       dispatches  [:notebook/edit-body text]
      - the hiccup sub         derives     hiccup from the selected markdown
      - the preview pane       subscribes  to that derivation
 
-   The markdown preview is the idea worth noticing: rendering markdown is
-   a pure derivation here (string -> hiccup), exposed as a subscription —
-   it sits in the same subscription graph as everything else, not in a
+   The idea worth noticing is the markdown preview. Rendering markdown is
+   a pure derivation (string -> hiccup) exposed as a subscription, so it
+   sits in the same subscription graph as everything else — not behind a
    DOM escape hatch.
 
-   Distinguished from the counter + login examples by being `reg-view`-
-   based at every layer, exercising multi-pane layout, and leaning into
-   the shared 'Editorial Warm' visual identity from
-   examples/_shared/css/style.css — one shared identity across all three
-   substrates. No state machines, no HTTP — design-led examples exist to
-   prove polished visuals + interaction, not to replay the platform
-   features other examples already cover.
+   The markdown parser is a tiny pure-CLJS one (headings, bold, italic,
+   inline code, links, paragraphs, ordered + unordered lists). That keeps
+   the bundle small and the example free of an extra npm dependency.
 
-   Markdown rendering is intentionally a tiny pure-CLJS parser (headings,
-   bold, italic, inline code, links, paragraphs, ordered + unordered
-   lists) — keeps the bundle small and the example free of an extra npm
-   dependency."
-  ;; Substrate note: STOCK Reagent (`reagent.dom.client` +
-  ;; `re-frame.adapter.reagent`), like the rest of the `examples/reagent/`
-  ;; catalogue. notebook is the Reagent member of the three-substrate
-  ;; design-led trio (alongside `dashboard-uix` and
-  ;; `process-monitor-helix`), so it sits on the reference Reagent
-  ;; substrate to keep the trio comparable. (counter /
-  ;; counter_slim_and_fast is the dedicated stock-vs-slim contrast pair;
-  ;; the slim build is the only one that mounts `reagent-slim`, and it
-  ;; lives under `examples/reagent-slim/`.)
+   See docs/guide/glossary.md for the terms used below (event,
+   subscription, app-db, view); docs/guide/concepts/views.md covers
+   views and hiccup in depth."
+  ;; Substrate: stock Reagent (`reagent.dom.client` +
+  ;; `re-frame.adapter.reagent`). The adapter is the value that binds
+  ;; re-frame2 to the rendering library; see docs/guide/glossary.md#adapter.
   (:require [reagent.dom.client :as rdc]
             [clojure.string     :as str]
             [re-frame.core      :as rf]
@@ -62,7 +51,7 @@
     :body  "### Patterns shipped with re-frame2\n\n- Pattern-Boot — application initialisation as a state machine.\n- Pattern-WebSocket — connection machine with backoff + queue-flush.\n- Pattern-LongRunningWork — :spawn-all spawn-and-join.\n- Pattern-Managed-HTTP — declarative HTTP with cancellation.\n\nEach has a worked example under `examples/reagent/`."}])
 
 ;; ============================================================================
-;; EVENTS  (CP-1)
+;; EVENTS
 ;; ============================================================================
 
 (rf/reg-event :notebook/initialise
@@ -83,18 +72,17 @@
                         (if (= (:id d) id) (assoc d :body text) d))
                       docs))))}))
 
-;; EP-0010 (Causal World Inputs): the new document's id is written into durable
-;; app-db (`:notebook/documents`), so it is derived from the documents already
-;; there — the todomvc `allocate-next-id` idiom. Scan the `doc-N` keyword ids
-;; in app-db and take max+1. Because the id comes from prior state, replaying
-;; the event stream mints the same id. (Reaching for `(rand-int)` here would
-;; break that: each replay would mint a different id.) Seeded ids (`:welcome`,
-;; `:six-dominoes`, …) carry no `doc-` prefix, so the first minted id is
-;; `:doc-1`.
+;; A new document's id is derived from the documents already in app-db:
+;; scan the `doc-N` keyword ids and take max+1. Deriving the id from prior
+;; state keeps the handler replayable — replaying the event stream mints
+;; the same id. Reaching for `(rand-int)` would break that, since each
+;; replay would mint a different id. Seeded ids (`:welcome`, `:six-dominoes`,
+;; …) carry no `doc-` prefix, so the first minted id is `:doc-1`. See
+;; docs/guide/concepts/events-and-the-cascade.md on replayable events.
 (defn- allocate-next-doc-id
   "Deterministic next `:doc-N` id from the existing documents — max prior
    N + 1 (1 when none yet). A pure function of prior app-db state, so it
-   replays identically (EP-0010)."
+   replays identically."
   [documents]
   (let [used-ns (->> documents
                      (keep (fn [{id :id}]
@@ -113,7 +101,7 @@
           (assoc :notebook/selected-id id)))}))
 
 ;; ============================================================================
-;; SUBSCRIPTIONS  (CP-2)
+;; SUBSCRIPTIONS
 ;; ============================================================================
 
 (rf/reg-sub :notebook/documents
@@ -122,9 +110,10 @@
 (rf/reg-sub :notebook/selected-id
   (fn [db _] (:notebook/selected-id db)))
 
-;; First composed sub: `:<-` names this sub's inputs (other subs), so it
+;; A composed sub: `:<-` names this sub's inputs (other subs), so it
 ;; recomputes only when the documents or the selected id actually change.
 ;; The downstream subs (`-body`, `-hiccup`) chain off this one in turn.
+;; See docs/guide/concepts/subscriptions.md.
 (rf/reg-sub :notebook/selected
   :<- [:notebook/documents]
   :<- [:notebook/selected-id]
@@ -179,10 +168,9 @@
    with strings split around matches and matches replaced. Non-string
    elements (already-parsed hiccup) pass through untouched.
 
-   Robust to the (count parts) ≠ (count matches) ± 1 trap that
-   bit the first pass: we loop `re-find` one match at a time and pull
-   the before/after substrings from the source manually (via
-   `.indexOf` + `subs`), recurring on the remaining tail."
+   Loops `re-find` one match at a time and pulls the before/after
+   substrings from the source manually (via `.indexOf` + `subs`),
+   recurring on the remaining tail."
   [coll re mk]
   (mapcat
     (fn [x]
@@ -281,7 +269,7 @@
   (fn [body _] (markdown->hiccup body)))
 
 ;; ============================================================================
-;; VIEWS  (CP-4) — shared 'Editorial Warm' palette
+;; VIEWS — shared 'Editorial Warm' palette
 ;; ============================================================================
 
 (reg-view sidebar []
@@ -339,21 +327,21 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; Lazy mount: defer `create-root` to `run` so ns-load is DOM-side-effect-free.
-;; This is the mount-isolation convention documented at
-;; [examples/TESTING.md §Example mount-isolation convention] — multiple example
-;; namespaces co-exist in the `:browser-test` bundle and share one DOM, so a
-;; ns-load `create-root` would race roots onto the same container.
+;; Lazy mount: defer `create-root` to `run` so loading the namespace has no
+;; DOM side effect. Many example namespaces share one DOM in the
+;; `:browser-test` bundle, so a `create-root` at ns-load would race roots
+;; onto the same container. See examples/TESTING.md (mount-isolation
+;; convention).
 
 (defonce react-root (atom nil))
 
-;; The whole frame is established in one spot — the render root's
-;; `frame-provider {:id app-frame}` below. On first mount it creates the app
-;; frame and runs `:initial-events` once to seed app-db before the first
-;; paint; on hot reload it reuses the same frame and skips the seed. Every
-;; in-tree `dispatch`/`subscribe` then resolves to that frame. `app-frame` is
-;; an ordinary frame id with no framework privilege. Matches the canonical
-;; mount in examples/reagent/counter/core.cljs.
+;; The frame is established in one spot: the `frame-provider {:id app-frame}`
+;; in the render call below. On first mount it creates the frame and runs
+;; `:initial-events` once to seed app-db before the first paint; on hot reload
+;; it reuses the same frame and skips the seed. Every in-tree
+;; `dispatch`/`subscribe` then resolves to that frame. `app-frame` is an
+;; ordinary frame id with no special privilege. See
+;; docs/guide/concepts/frames.md.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/realworld/article_editor.cljs
+++ b/examples/reagent/realworld/article_editor.cljs
@@ -1,36 +1,34 @@
 (ns realworld.article-editor
   "Article editor for the RealWorld (Conduit) example.
 
-   This sketch demonstrates:
-   - Pattern-NineStates — one parallel state machine `:ui/article-editor`
-     with two orthogonal regions (`:mode` x `:lifecycle`) replacing the
-     prior mode-flag + lifecycle-status shape.
-   - Pattern-Forms — the draft / errors / touched / submit-error slice
-     still lives in app-db (`:editor`); the machine carries only the
-     state vocabulary. `:editor/dirty?` is a draft-vs-baseline sub, not
-     a state-machine concern.
+   This namespace shows:
+   - One parallel state machine `:ui/article-editor` with two orthogonal
+     regions (`:mode` x `:lifecycle`). See the machines guide on parallel
+     regions: ../../../docs/machines/concepts.md#when-the-machine-grows.
+   - A form whose draft / errors / touched / submit-error slice lives in
+     app-db (`:editor`); the machine carries only the state vocabulary.
+     `:editor/dirty?` is a draft-vs-baseline sub, not a machine concern.
+     See the forms how-to: ../../../docs/guide/how-to/build-a-form.md.
    - The view's input-busy and Delete-button visibility are tag queries
      (`(rf/machine-has-tag? :ui/article-editor :editor/busy)` and
-     `(rf/machine-has-tag? :ui/article-editor :editor/can-delete)`) rather than
-     boolean discriminator subs.
-   - The view's root is a `case` over `:article-editor/render`, a
-     selector sub that consults a render-priority table against the
-     machine's tag union (per Pattern-NineStates §4)."
+     `(rf/machine-has-tag? :ui/article-editor :editor/can-delete)`) instead
+     of boolean subs.
+   - The view's root is a `case` over `:article-editor/render`, a selector
+     sub that reads a render-priority table against the machine's tag
+     union."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine (called
-            ;; below at ns-load) and the `:rf/machine` framework subs
-            ;; resolve.
+            ;; State machines ship in the re-frame2-machines artefact.
+            ;; Requiring the ns registers its hooks so `rf/reg-machine`
+            ;; (called below) and the `:rf/machine` subs resolve. See the
+            ;; machines guide: ../../../docs/machines/index.md
             [re-frame.machines]
-            ;; Flows (Spec 013) ship in day8/re-frame2-flows. The editor
+            ;; Flows ship in the re-frame2-flows artefact. The editor
             ;; registers a `:editor/can-submit?` flow (see :editor/initialise
-            ;; below) that materialises form-validity-AND-dirty into app-db.
-            ;; Loading the ns here publishes the artefact's late-bind hooks
-            ;; (`:flows/reg-flow` etc.) so the `:rf.fx/reg-flow` effect
-            ;; resolves; without it the effect raises
-            ;; :rf.error/flows-artefact-missing.
+            ;; below) that materialises "valid AND dirty" into app-db.
+            ;; Requiring the ns registers its hooks so the `:rf.fx/reg-flow`
+            ;; effect resolves. See the flows guide:
+            ;; ../../../docs/guide/concepts/flows.md
             [re-frame.flows]
             [realworld.schema :as schema]
             [realworld.http :as rh])
@@ -52,9 +50,9 @@
        vec))
 
 (defn editor-slice
-  "The form's app-db slice. Holds Pattern-Forms shape (draft, baseline,
-   errors, touched, submit-attempted?, submit-error). The machine
-   carries the state vocabulary; this slice carries the data."
+  "The form's app-db slice: draft, baseline, errors, touched,
+   submit-attempted?, submit-error. The machine carries the state
+   vocabulary; this slice carries the data."
   ([] (editor-slice nil blank-draft))
   ([slug baseline]
    {:slug              slug
@@ -73,29 +71,25 @@
     (str/blank? body)        (assoc :body "Body is required.")))
 
 ;; ============================================================================
-;; THE FLOW — :editor/can-submit?  (Spec 013 §Flows)
+;; THE FLOW — :editor/can-submit?
 ;; ============================================================================
 ;;
-;; This is RealWorld's worked Spec 013 flow — the `-flows` artefact in the
-;; example's "composes core + -schemas + -machines + -routing + -flows +
-;; -http" claim. `:editor/can-submit?` materialises a derived boolean —
-;; "the draft passes client-side validation AND differs from the loaded
-;; baseline" — into app-db at `[:editor :can-submit?]`.
+;; This is the example's worked flow. `:editor/can-submit?` materialises a
+;; derived boolean — "the draft passes validation AND differs from the
+;; loaded baseline" — into app-db at `[:editor :can-submit?]`.
 ;;
-;; WHY A FLOW HERE (Spec 013 §When (and when not) to use a flow): the
-;; `:editor/submit` handler reads this value as plain app-db data to gate
-;; the submit, exactly the "other event handlers read the value" criterion.
-;; A sub would force the handler to `subscribe` mid-handler (awkward and
-;; non-idiomatic); the flow keeps the gate as ordinary state the handler
-;; reads with `get-in`. The submit-button-disabled view still reads it
-;; through a plain sub over the flow's `:output-path` (Spec 013 §Sub integration).
+;; Why a flow and not a sub: the `:editor/submit` handler reads this value
+;; as plain app-db data to gate the submit. A flow keeps the gate as
+;; ordinary state the handler reads with `get-in`; a sub would force the
+;; handler to `subscribe` mid-handler. The submit-button-disabled view
+;; reads the same value through a plain sub over the flow's `:output-path`.
+;; See the flows guide on when a derivation earns app-db:
+;; ../../../docs/guide/concepts/flows.md#when-a-derivation-earns-app-db
 ;;
-;; The flow is registered per-frame via `:rf.fx/reg-flow` from
-;; `:editor/initialise` (below) rather than at ns-load, so it registers
-;; against whatever frame the app boots on — the default frame in the
-;; browser, and each per-test `make-frame` frame in the headless fixtures
-;; (Spec 013 §Dynamic toggle via fx §Frame routing). Registering at ns-load
-;; would bind it only to `(current-frame-id)` and miss the test frames.
+;; The flow registers per-frame via `:rf.fx/reg-flow` from
+;; `:editor/initialise` (below), so it binds to whatever frame the app
+;; boots on — the default frame in the browser, and each frame the
+;; headless fixtures create.
 
 (def can-submit-flow
   {:id     :editor/can-submit?
@@ -126,15 +120,14 @@
 ;;                :editor/can-delete tag so the view can ask a tag-shaped
 ;;                question without inspecting the region directly.
 ;;
-;;   :lifecycle — Pattern-Forms lifecycle: :idle | :loading | :submitting
+;;   :lifecycle — the form lifecycle: :idle | :loading | :submitting
 ;;                | :saved | :error. The :loading and :submitting states
 ;;                emit the :editor/busy tag so the view can disable
 ;;                inputs without a separate `:submitting?` sub.
 ;;
-;; Per Spec 005 §Transition broadcast: every event delivered to the
-;; machine is broadcast to every region. Region-distinct event names
-;; below avoid collisions; `:reset` is handled by every region as a
-;; self-target.
+;; Every event delivered to the machine reaches every region. Region-
+;; distinct event names avoid collisions; each region handles `:reset` as
+;; a self-target.
 
 (def editor-machine
   {:type :parallel
@@ -158,7 +151,7 @@
               :use-edit   :edit
               :reset      :create}}}}
 
-    ;; ---- :lifecycle region — Pattern-Forms lifecycle ----
+    ;; ---- :lifecycle region — the form lifecycle ----
     :lifecycle
     {:initial :idle
      :states
@@ -209,22 +202,22 @@
 
 (rf/reg-event :editor/initialise
   {:doc "Reset the editor slice + machine, and register the
-         `:editor/can-submit?` flow against the dispatching frame (Spec
-         013 §Dynamic toggle via fx). The flow's first walk fires on the
-         NEXT drain (Spec 013 §Sequencing); a fresh editor starts invalid
-         + clean anyway, so the one-event lag carries no stale value."}
+         `:editor/can-submit?` flow against the dispatching frame. The
+         flow's first walk fires on the next drain; a fresh editor starts
+         invalid and clean anyway, so the one-event lag carries no stale
+         value."}
   (fn [{:keys [db]} _]
     {:db (assoc db :editor (editor-slice))
      :fx [[:dispatch [:ui/article-editor [:reset]]]
           [:rf.fx/reg-flow can-submit-flow]]}))
 
 (rf/reg-event :editor/load-article
-  {:doc "Load an existing article into the editor in :edit mode.
-         data-fetch retry policy applies (Spec 014). Broadcasts
-         `:use-edit` so the :mode region tracks the edit-load and
-         `:fetch-started` so the :lifecycle region advances to :loading."
+  {:doc "Load an existing article into the editor in :edit mode. The
+         data-fetch retry policy applies. Broadcasts `:use-edit` so the
+         :mode region tracks the edit-load and `:fetch-started` so the
+         :lifecycle region advances to :loading."
    :rf.http/decode-schemas [schema/ArticleResponse]}
-  ;; EP-0001: the route slice is durable routing runtime-db state.
+  ;; The route lives in runtime-db.
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [slug (get-in rt [:rf.runtime/routing :current :params :slug])]
       {:db (assoc db :editor (editor-slice slug blank-draft))
@@ -262,27 +255,26 @@
     {:db (update-in db [:editor :touched] (fnil conj #{}) field)}))
 
 (rf/reg-event :editor/submit
-  {:doc "Save the article (POST for create, PUT for edit). NO retry — the
-         user's intent is one submission per click; surface errors so the
-         user can decide whether to retry (Spec 014).
+  {:doc "Save the article (POST for create, PUT for edit). No retry — one
+         submission per click; surface errors so the user can decide
+         whether to retry.
 
          Reads the current `:mode` region's state to decide POST vs PUT.
          Broadcasts `:submit-started` into the lifecycle region; the
          `:on-success` / `:on-failure` replies broadcast
          `:submit-succeeded` / `:submit-failed`.
 
-         The guard reads the `:editor/can-submit?` FLOW output straight off
-         app-db (Spec 013 §Sub integration (a)) — a materialised derived
-         value the handler consumes as plain data with no subscribe
-         ceremony. When the form is unchanged (valid but not dirty) the
-         flow is false and the submit is a no-op; an invalid draft re-runs
-         validation to populate the per-field error map for display."
+         The guard reads the `:editor/can-submit?` flow output straight off
+         app-db — a derived value the handler consumes as plain data. When
+         the form is unchanged (valid but not dirty) the flow is false and
+         the submit is a no-op; an invalid draft re-runs validation to
+         populate the per-field error map for display."
    :rf.http/decode-schemas [schema/ArticleResponse]}
-  ;; EP-0001: the machine snapshot is durable runtime-db state.
+  ;; The machine snapshot lives in runtime-db.
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [{:keys [slug draft]} (:editor db)
           mode        (get-in rt [:rf.runtime/machines :snapshots :ui/article-editor :state :mode])
-          ;; Materialised flow output — read as plain app-db data.
+          ;; Flow output — read as plain app-db data.
           can-submit? (get-in db [:editor :can-submit?])
           errors      (validate-draft draft)]
       (cond
@@ -293,12 +285,10 @@
         {}
 
         (seq errors)
-        ;; Client-side validation failure. Flip :submit-attempted? so
-        ;; per-field error subs (Pattern-Forms §Error visibility)
-        ;; reveal every error even on untouched fields, without the
-        ;; prior workaround of re-touching every error field.
-        ;; Whole-form prompt lives in `:errors :_form`; transport-shape
-        ;; failures still land in `:submit-error` (the HTTP path).
+        ;; Client-side validation failure. Flip :submit-attempted? so the
+        ;; per-field error subs reveal every error, even on untouched
+        ;; fields. The whole-form prompt lives in `:errors :_form`;
+        ;; transport failures land in `:submit-error` (the HTTP path).
         {:db (-> db
                  (assoc-in [:editor :submit-attempted?] true)
                  (assoc-in [:editor :errors] (assoc errors :_form "Please fix the highlighted fields."))
@@ -375,9 +365,9 @@
   (fn [editor _] (:submit-error editor)))
 
 (rf/reg-sub :editor/field-error
-  {:doc "Per-field validation error. Per Pattern-Forms §Error
-         visibility: reveal every error after the first submit click,
-         OR once the field is :touched."}
+  {:doc "Per-field validation error. Reveal every error after the first
+         submit click, or once the field is :touched. See the forms
+         how-to: ../../../docs/guide/how-to/build-a-form.md"}
   :<- [:editor/slice]
   (fn [editor [_ field]]
     (when (or (:submit-attempted? editor)
@@ -397,13 +387,12 @@
     (not= (:draft editor) (:baseline editor))))
 
 (rf/reg-sub :editor/can-submit?
-  {:doc "Reads the `:editor/can-submit?` FLOW output at its app-db :output-path
-         (Spec 013 §Sub integration (b)). No special flow sub-id — a flow's
-         output is ordinary app-db state and consumers read it through a
-         plain sub over the path. Drives the submit button's disabled
-         attribute. nil until the flow's first walk lands — the walk runs
-         right after the handler, before the db install (Spec 013
-         §Sequencing) — which `(boolean ...)` normalises to false."}
+  {:doc "Reads the `:editor/can-submit?` flow output at its app-db
+         :output-path. A flow's output is ordinary app-db state, so
+         consumers read it through a plain sub over the path — there is no
+         special flow sub-id. Drives the submit button's disabled
+         attribute. nil until the flow's first walk lands, which
+         `(boolean ...)` normalises to false."}
   (fn [db _]
     (boolean (get-in db [:editor :can-submit?]))))
 
@@ -449,8 +438,8 @@
 ;; VIEWS
 ;; ============================================================================
 
-(reg-view ^{:doc "The shared editor form. Rendered by every render-mode
-                   today; `:editor/busy` disables inputs, `:editor/can-delete`
+(reg-view ^{:doc "The shared editor form. Rendered by every render-mode;
+                   `:editor/busy` disables inputs, `:editor/can-delete`
                    shows the Delete button."}
           editor-form []
   (let [draft        @(subscribe [:editor/draft])
@@ -517,9 +506,8 @@
              :disabled    busy?
              :on-change   #(dispatch [:editor/edit-field :tagList (.. % -target -value)])}]]
           [:button.btn.btn-lg.pull-xs-right.btn-primary
-           ;; Disabled while busy OR while the :editor/can-submit? flow is
-           ;; false (draft invalid or unchanged) — the flow's materialised
-           ;; output drives the button state.
+           ;; Disabled while busy, or while the :editor/can-submit? flow is
+           ;; false (draft invalid or unchanged).
            {:type "submit" :disabled (or busy? (not can-submit?))}
            (if can-delete? "Update Article" "Publish Article")]
           (when can-delete?
@@ -531,34 +519,30 @@
 
 ;; ---- per-render-state subviews ----
 ;;
-;; All render-modes delegate to `editor-form` today; the form's own
-;; tag queries (`:editor/busy`, `:editor/can-delete`) handle the in-form
-;; differences. Splitting them out as separate reg-views keeps the
-;; pattern shape consistent and gives a single
-;; cheap site to introduce render-mode-specific scaffolding (a
-;; full-page spinner, a dedicated load-error layout) without rewriting
-;; the case branch.
+;; Every render-mode delegates to `editor-form`; the form's own tag
+;; queries (`:editor/busy`, `:editor/can-delete`) handle the in-form
+;; differences. Keeping them as separate reg-views gives one cheap site to
+;; add render-mode-specific scaffolding (a full-page spinner, a dedicated
+;; load-error layout) without touching the case branch.
 
 (reg-view ^{:doc "Lifecycle :idle / :submitting — the form in its normal
                    interactive (or busy) state."}
           editor-editing []
   [editor-form])
 
-(reg-view ^{:doc "Lifecycle :loading — edit-mode initial fetch in
-                   flight. Today renders the form with disabled inputs
-                   (via the :editor/busy tag); the form-only render is
-                   pixel-equivalent to the prior behaviour."}
+(reg-view ^{:doc "Lifecycle :loading — edit-mode initial fetch in flight.
+                   Renders the form with disabled inputs (the :editor/busy
+                   tag)."}
           editor-loading []
   [editor-form])
 
-(reg-view ^{:doc "Lifecycle :error — load failed. Renders the form
-                   with the submit-error banner; pixel-equivalent to
-                   the prior behaviour."}
+(reg-view ^{:doc "Lifecycle :error — load failed. Renders the form with
+                   the submit-error banner."}
           editor-error []
   [editor-form])
 
-(reg-view ^{:doc "Lifecycle :saved — transient post-submit-success
-                   state. The :editor/submit-success handler navigates
+(reg-view ^{:doc "Lifecycle :saved — transient post-submit-success state.
+                   The :editor/submit-success handler navigates
                    immediately, so this view is rarely visible."}
           editor-saved []
   [editor-form])

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -1,32 +1,30 @@
 (ns realworld.articles
   "Home-page article feeds for the RealWorld (Conduit) example.
 
-   This sketch demonstrates:
-   - Pattern-NineStates — one parallel state machine with three orthogonal
-     regions (`:feed` × `:filter` × `:data`) replacing the prior multi-axis
-     state-in-separate-slices shape.
-   - Pattern-RemoteData lifecycle tracked by the `:data` region; the
-     region's state-keyword drives the home-page render decision. This is
-     a deliberate hybrid: unlike the full machine-form fold in `tags.cljs`,
-     the `:articles`/`:feed` slices stay in the standard 5-key slice form
-     (keeping their `:status` field) so the items live in app-db and
-     favorites.cljs's optimistic-update paths can scan across slices. See
-     the `:data` region note below.
-   - route-driven loading — the `/tag/:tag` PATH route filters the list and
-     `?feed=following` switches to the authenticated feed (official RealWorld
-     contract shapes); every navigation broadcasts the
-     corresponding feed-region transition.
-   - home-page tabs expressed as feed-region state transitions.
+   This namespace shows:
+   - One parallel state machine with three orthogonal regions
+     (`:feed` x `:filter` x `:data`). See the machines guide on parallel
+     regions: ../../../docs/machines/concepts.md#when-the-machine-grows.
+   - A remote-data lifecycle tracked by the `:data` region. The region's
+     state-keyword drives the home-page render decision. The `:articles`
+     and `:feed` slices keep the plain 5-key slice shape so their items
+     live in app-db and favorites.cljs's optimistic updates can scan
+     across slices. The machine's `:data` region tracks the same lifecycle
+     and owns the render decision. See the `:data` region note below.
+   - Route-driven loading: the `/tag/:tag` route filters the list and
+     `?feed=following` switches to the authenticated feed (the official
+     RealWorld contract shapes). Each navigation broadcasts the matching
+     feed-region transition.
+   - Home-page tabs expressed as feed-region transitions.
    - The home view's root is a `case` over `:articles.home/render`, a
-     selector sub that consults a render-priority table against the
-     machine's tag union (per Pattern-NineStates §4).
-   - view reuse across the home page and profile pages."
+     selector sub that reads a render-priority table against the machine's
+     tag union.
+   - View reuse across the home page and profile pages."
   (:require [re-frame.core :as rf]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine (called
-            ;; below at ns-load) and the `:rf/machine` framework subs
-            ;; resolve.
+            ;; State machines ship in the re-frame2-machines artefact.
+            ;; Requiring the ns registers its hooks so `rf/reg-machine`
+            ;; (called below) and the `:rf/machine` subs resolve. See the
+            ;; machines guide: ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld-shared.avatar :as avatar]
             [realworld.schema :as schema]
@@ -55,40 +53,32 @@
 ;;             that render the filter chip can ask a tag-shaped question
 ;;             without inspecting the feed region.
 ;;
-;;   :data   — Pattern-NineStates' data lifecycle for whichever feed is
-;;             active. The region's state-keyword is what drives the
-;;             home-page *render decision* (via the render-priority table
-;;             + the `:articles.home/render` selector sub) — the view
-;;             never branches on the slice's `:status`. The :resolving
-;;             eventless microstep picks `:empty` or `:some` from the
-;;             count stamped into the machine's shared `:data`.
+;;   :data   — the data lifecycle for whichever feed is active. The
+;;             region's state-keyword drives the home-page render decision
+;;             (via the render-priority table + the `:articles.home/render`
+;;             selector sub); the view never branches on the slice's
+;;             `:status`. The :resolving eventless microstep picks `:empty`
+;;             or `:some` from the count stored in the machine's `:data`.
 ;;
-;;             Note this is a deliberate HYBRID, not the full machine-form
-;;             fold used by `tags.cljs`/`settings.cljs` (where the slice —
-;;             and its `:status` — genuinely disappears). Here the
-;;             `:articles` slice stays in the standard 5-key slice form
-;;             (the slice-form half of the README's "two shapes
-;;             side-by-side" comparison): the article items live in
-;;             app-db so favorites.cljs's optimistic-update paths can scan
-;;             across slices, and the slice keeps its `:status` field
-;;             (required by `schema/RequestSlice`, asserted by the unit
-;;             tests). The machine's `:data` region tracks the same
-;;             lifecycle independently and is the single source of the
-;;             render decision.
+;;             The `:articles` slice keeps the plain 5-key slice shape: its
+;;             article items live in app-db so favorites.cljs's optimistic
+;;             updates can scan across slices, and the slice keeps its
+;;             `:status` field. The machine's `:data` region tracks the
+;;             same lifecycle and owns the render decision. tags.cljs and
+;;             settings.cljs show the other shape, where the lifecycle
+;;             lives entirely in the machine and there is no slice.
 ;;
-;; Per Spec 005 §Transition broadcast: every event delivered to the
-;; machine is broadcast to every region. Region-distinct event names
-;; below avoid collisions; the `:reset` event is handled by every
-;; region as a self-target.
+;; Every event delivered to the machine reaches every region (the parallel
+;; region broadcast). Region-distinct event names avoid collisions; each
+;; region handles `:reset` as a self-target.
 
 (def home-machine
   {:type :parallel
 
    ;; The machine carries the active feed's item-count (drives the
-   ;; cardinality bucket) plus the latest error map. The items
-   ;; themselves still live in app-db slices (`:articles`, `:feed`) so
-   ;; the optimistic-update paths in favorites.cljs continue to find
-   ;; them across slices.
+   ;; cardinality bucket) plus the latest error map. The items live in
+   ;; app-db slices (`:articles`, `:feed`) so favorites.cljs's optimistic
+   ;; updates can find them across slices.
    :data {:count 0 :error nil}
 
    :guards
@@ -113,7 +103,7 @@
       {:data (assoc data :count 0 :error nil)})}
 
    :regions
-   {;; ---- :data region — Pattern-NineStates lifecycle ----
+   {;; ---- :data region — the data lifecycle ----
     :data
     {:initial :nothing
      :states
@@ -224,24 +214,23 @@
 
 (rf/reg-event :articles/load
   {:doc "Fetch the global articles list, optionally filtered by the active
-         tag (the `/tag/:tag` route's PATH param, read off the route params;
-         the WIRE query stays `/articles?tag=…`). Uses :rf.http/managed
-         (Spec 014) with a Malli-decoded response and the standard
-         data-fetch retry policy.
-         The request is tagged with `:request-id :articles/load` so a
-         re-issue (e.g., user changes tag mid-load) supersedes the prior
-         in-flight request and an `:articles/cancel` fx aborts cleanly.
+         tag (the `/tag/:tag` route param; the wire query stays
+         `/articles?tag=…`). Goes via `:rf.http/managed` with a
+         Malli-decoded response and the standard data-fetch retry policy.
+         The request carries `:request-id :articles/load` so re-issuing it
+         (e.g. the user changes tag mid-load) supersedes the in-flight
+         request and `:articles/cancel` aborts it. See the HTTP guide:
+         ../../../docs/resources/http.md
 
          Also broadcasts `:fetch-started` into the home machine so the
          `:data` region advances to `:loading` (or `:refreshing` from
          `:some`)."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
-  ;; EP-0001: the route slice is durable routing runtime-db state.
-  ;; `?page=` (1-indexed, durable on the route query) becomes the wire's
-  ;; limit/offset window via `rh/paginate-path` (official RealWorld pagination).
-  ;; The active tag is a `/tag/:tag` route PARAM, read off the route params,
-  ;; with the page read off the query. The WIRE stays `/articles?tag=…` — the
-  ;; frontend route shape and the API query string are independent.
+  ;; The route lives in runtime-db. `?page=` (1-indexed, on the route
+  ;; query) becomes the wire's limit/offset window via `rh/paginate-path`.
+  ;; The active tag is a `/tag/:tag` route param; the page is on the query.
+  ;; The wire stays `/articles?tag=…` — the frontend route shape and the
+  ;; API query string are independent.
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [current   (get-in rt [:rf.runtime/routing :current])
           tag       (get-in current [:params :tag])
@@ -267,16 +256,16 @@
 
 (rf/reg-event :articles/loaded
   {:doc "Successful fetch. Replace the list and clear any prior error.
-         Receives `{:kind :success :value <ArticlesResponse>}` from
-         Spec 014's reply-addressing. Folds the new count into the home
-         machine via `:fetch-succeeded`; the `:data` region's
-         `:resolving` `:always`-cascade picks `:empty` or `:some`."
+         Receives `{:kind :success :value <ArticlesResponse>}` (the
+         uniform reply map). Folds the new count into the home machine via
+         `:fetch-succeeded`; the `:data` region's `:resolving` `:always`
+         cascade then picks `:empty` or `:some`."
    :rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
     (let [items (vec (:articles value))
-          ;; `articlesCount` is the GRAND total (all matching articles), not
-          ;; this page's size — it drives the page-count. Fall back to the
-          ;; page size when the server omits it (older backends).
+          ;; `articlesCount` is the grand total (all matching articles),
+          ;; not this page's size — it drives the page count. Fall back to
+          ;; the page size when the server omits it.
           total (or (:articlesCount value) (count items))]
       {:db (-> db
                (assoc-in [:articles :status] :loaded)
@@ -289,9 +278,9 @@
 
 (rf/reg-event :articles/load-failed
   {:doc "Failed fetch. Keep prior data when present and surface a
-         human-readable error message (projected from the Spec 014
-         failure map). Folds the failure into the home machine via
-         `:fetch-failed`; the `:data` region advances to `:error`."}
+         human-readable error message (projected from the failure map).
+         Folds the failure into the home machine via `:fetch-failed`; the
+         `:data` region advances to `:error`."}
   (fn [{:keys [db]} [_ {:keys [failure]}]]
     (let [message (rh/failure->message failure)]
       {:db (-> db
@@ -301,8 +290,9 @@
                         [:fetch-failed {:failure message}]]]]})))
 
 (rf/reg-event :articles/cancel
-  {:doc "Abort an in-flight :articles/load. Useful when the user navigates
-         away from the home page mid-fetch (Spec 014 §Aborts)."}
+  {:doc "Abort an in-flight :articles/load — e.g. when the user navigates
+         away from the home page mid-fetch. See the HTTP guide on aborts:
+         ../../../docs/resources/http.md#the-search-box-race-cured"}
   (fn [_ _]
     {:fx [[:rf.http/managed-abort :articles/load]]}))
 
@@ -320,11 +310,10 @@
 (rf/reg-sub :articles/error      :<- [:articles/slice] (fn [s _] (:error s)))
 (rf/reg-sub :articles/count      :<- [:articles/slice] (fn [s _] (:articles-count s 0)))
 
-;; The `:tags/data` sub is defined in `realworld.tags`. The
-;; popular-tags lifecycle is the :data-region machine variant of
-;; Pattern-RemoteData — items are projected off the `:realworld/tags`
-;; machine's `:data`, with no separate app-db slice. The home view's
-;; sidebar below consumes `:tags/data`.
+;; The `:tags/data` sub is defined in `realworld.tags`, where the
+;; popular-tags lifecycle lives entirely in a machine: items are read off
+;; the `:realworld/tags` machine's `:data`, with no app-db slice. The home
+;; view's sidebar below consumes `:tags/data`.
 
 ;; ---- render-priority + :articles.home/render selector ----
 ;;

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -1,21 +1,20 @@
 (ns realworld.auth
   "Authentication for the RealWorld (Conduit) example.
 
-   The auth flow is implemented as a re-frame2 state machine. Login,
-   register, session restore, and logout are all sub-events routed through
-   one handler:
+   The auth flow is a state machine. Login, register, session restore, and
+   logout are all sub-events routed through one handler:
 
      (rf/dispatch [:auth/flow [:auth/login creds]])
 
-   Pattern-Forms owns the login/register draft slices under [:auth ...];
-   the machine snapshot itself lives in runtime-db at [:rf.runtime/machines :snapshots :auth/flow]."
+   The login/register draft slices live under [:auth ...]; the machine
+   snapshot lives in runtime-db at
+   [:rf.runtime/machines :snapshots :auth/flow]."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine
-            ;; (called below at ns-load) and the `:rf/machine` framework
-            ;; sub resolve.
+            ;; State machines ship in the re-frame2-machines artefact.
+            ;; Requiring the ns registers its hooks so `rf/reg-machine`
+            ;; (called below) and the `:rf/machine` sub resolve. See the
+            ;; machines guide: ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh])
@@ -26,22 +25,14 @@
 ;; ============================================================================
 ;;
 ;; One fx for the localStorage seam. Arg shape is `{:token <token-or-nil>}`
-;; — write on truthy, remove on nil. Halving the registrar entries keeps
-;; the localStorage edge a single seam: one fx to mock in tests, one fx
-;; for the machine's `:store-session` and `:clear-session` actions to
-;; call with different args.
+;; — write on truthy, remove on nil. One seam means one fx to mock in
+;; tests, called by the machine's `:store-session` and `:clear-session`
+;; actions with different args.
 ;;
-;; CONFORMANCE-CONTRACT SURFACE. The official RealWorld
-;; browser/E2E suite reads the session from `localStorage["jwtToken"]` — that
-;; exact key is the contract, so this seam uses it verbatim (it is NOT
-;; namespaced under `conduit/…`). SAME-ORIGIN CAVEAT: the contract assumes one
-;; RealWorld app per origin. The repo's dev orchestrator serves BOTH the
-;; managed-HTTP and the resources variant from a single origin (at
-;; `/realworld/` and `/realworld-resources/`), so the two conforming apps share
-;; — and clobber — each other's `jwtToken` there. That is a known dev-mode
-;; artifact, NOT a contract violation: conformance is validated against
-;; STANDALONE serving (one app per origin), which the external suite does
-;; anyway. See the README §RealWorld contract conformance.
+;; Conformance-contract surface: the official RealWorld browser/E2E suite
+;; reads the session from `localStorage["jwtToken"]`, so this seam uses
+;; that exact key verbatim — it is NOT namespaced. Conformance is validated
+;; against standalone serving (one app per origin).
 
 (rf/reg-fx :auth.session/persist
   {:doc       "Persist (or clear) the JWT in localStorage under the official
@@ -54,43 +45,39 @@
         (.setItem    ls "jwtToken" token)
         (.removeItem ls "jwtToken")))))
 
-;; EP-0017: the saved JWT is read from localStorage at boot and
-;; `:auth/initialise` folds it into durable app-db ([:auth :token]). A durable
-;; write must fold a RECORDED fact, not an ambient `localStorage` read at the
-;; write site (which replay / epoch-restore could not reproduce). The JWT is an
-;; APP-OWNED world-read that feeds durable state, so the canonical shape is a
-;; recordable GENERATOR (cofx.md §Decision tree): `:auth.session/token` is a
-;; `:recordable? true` registration whose value-returning supplier reads
-;; localStorage. The generator runs at processing-start on the boot dispatch,
-;; its value is recorded onto the causal token, and replay / epoch-restore
-;; re-presents the captured token verbatim rather than re-reading whatever
-;; localStorage holds now. (PROVIDED — no generator, value stamped at a boundary
-;; — is reserved for facts the app cannot supply itself, e.g. an SSR server
-;; stamp; a JWT the app can read straight from the host is not one of those.)
+;; The saved JWT is read from localStorage at boot and `:auth/initialise`
+;; folds it into durable app-db at [:auth :token]. A durable write must
+;; fold a RECORDED fact, not an ambient `localStorage` read at the write
+;; site — replay and epoch-restore could not reproduce the latter. So the
+;; JWT comes from a recordable coeffect: `:auth.session/token` is a
+;; `:recordable? true` registration whose supplier reads localStorage. The
+;; supplier runs once, its value is recorded onto the causal token, and
+;; replay re-presents the captured token verbatim. See the coeffects guide
+;; on the two grades: ../../../docs/guide/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
 ;;
 ;; This is also why `ssr.cljc` may redact [:auth :token] from the hydration
-;; payload — the client re-derives the durable token slot through this RECORDED
-;; boot coeffect, not an ambient write-site read.
+;; payload — the client re-derives the token through this recorded boot
+;; coeffect, not an ambient write-site read.
 (defn read-jwt-from-storage
   "Read the saved JWT from localStorage (or nil) — the supplier body for the
-   `:auth.session/token` recordable generator. nil when absent / unavailable
-   (e.g. node, logged-out first run)."
+   `:auth.session/token` recordable coeffect. nil when absent or
+   unavailable (e.g. node, logged-out first run)."
   []
   (some-> (.-localStorage js/globalThis)
           (.getItem "jwtToken")))
 
 (rf/reg-cofx :auth.session/token
   {:recordable? true
-   :doc "Recordable GENERATOR coeffect (EP-0017): the saved JWT (or nil), read
-         from localStorage. The registered supplier runs at processing-start on
-         the boot dispatch; its value is recorded onto the causal token and
-         re-presented verbatim under replay / epoch-restore — so the durable
-         write that folds it (`:auth/initialise` → [:auth :token]) replays the
-         captured token, never a live localStorage re-read. A handler folds it
-         by declaring `:rf.cofx/requires [:auth.session/token]` and reading it
-         flat. A production dispatch carries NO cofx — the generator IS the
-         source; tests pin an exact value via the dispatch-site `:rf.cofx` stub
-         seam (`{:rf.cofx {:auth.session/token \"…\"}}`)."}
+   :doc "Recordable coeffect: the saved JWT (or nil), read from
+         localStorage. The supplier runs at the start of the boot dispatch;
+         its value is recorded onto the causal token and re-presented
+         verbatim under replay and epoch-restore — so the durable write
+         that folds it (`:auth/initialise` → [:auth :token]) replays the
+         captured token, never a live localStorage re-read. A handler folds
+         it by declaring `:rf.cofx/requires [:auth.session/token]` and
+         reading it flat. A production dispatch carries no cofx — the
+         supplier is the source; tests pin an exact value via the
+         dispatch-site `:rf.cofx` stub (`{:rf.cofx {:auth.session/token \"…\"}}`)."}
   (fn [] (read-jwt-from-storage)))
 
 ;; ============================================================================
@@ -98,17 +85,17 @@
 ;; ============================================================================
 
 (rf/reg-event :auth/store-session
-  {:doc "Store the authenticated session. The JWT has ONE durable home — the
-         classified `[:auth :token]` path (EP-0025 commit-plane `:sensitive`
-         effect, declared by `:auth/classify-token` in core.cljs). The User
-         payload is stored at `[:auth :user]` with its `:token` field stripped
-         off (`dissoc`), so the JWT is NOT duplicated into the UNCLASSIFIED
-         `[:auth :user :token]` slot — a second durable copy there would ship
-         RAW to every off-box record (classification does not propagate; each
-         path is its own declaration). Views / subs read `:auth/user` for
-         identity (username, bio, image); none of them need the token, which
-         the bearer-auth interceptor reads from the classified `[:auth :token]`
-         path instead."}
+  {:doc "Store the authenticated session. The JWT has one durable home: the
+         classified `[:auth :token]` path (declared sensitive by
+         `:auth/classify-token` in core.cljs). The User payload is stored at
+         `[:auth :user]` with its `:token` field stripped off (`dissoc`), so
+         the JWT is not duplicated into the unclassified
+         `[:auth :user :token]` slot — a second copy there would ship raw
+         off-box, because classification does not propagate; each path is
+         its own declaration. Views and subs read `:auth/user` for identity
+         (username, bio, image); the bearer-auth interceptor reads the token
+         from `[:auth :token]`. See the keep-secrets how-to:
+         ../../../docs/guide/how-to/keep-secrets-out-of-traces.md"}
   (fn [{:keys [db]} [_ user]]
     {:db (-> db
         (assoc-in [:auth :user] (dissoc user :token))
@@ -124,10 +111,10 @@
   {:doc "Bounce the freshly-authenticated user back to the route the auth
          guard intercepted (`[:auth :return-to]`, set in routing.cljs), or
          home when there is none. Dispatched by the auth machine's
-         `:store-session` action — machine actions can't navigate or read
-         `:db` directly (Spec 005 §Hard-disallow `:db`), so the bounce is an
-         ordinary event. Reads AND clears the slot in one step so a later
-         plain login can't re-bounce to a stale target."}
+         `:store-session` action — a machine action sees no `:db` and emits
+         no `:db`, so the bounce is an ordinary event. Reads and clears the
+         slot in one step so a later plain login can't re-bounce to a stale
+         target."}
   (fn [{:keys [db]} _]
     (let [return-to (get-in db [:auth :return-to])]
       {:db (update db :auth dissoc :return-to)
@@ -139,30 +126,25 @@
 ;; AUTH STATE MACHINE
 ;; ============================================================================
 
-;; `reg-machine` is the single registration home.
-;; The auth machine carries a `[:schemas :data]` (validating the snapshot's
-;; `:data` slot); registering it here stamps the `:rf/machine?` /
-;; `:rf/machine` metadata that makes the `[:schemas :data]` LIVE (`(machine-meta
-;; :auth/flow)` reads it, the `:where :machine-data` walker resolves it) AND
-;; bridges its redaction marks — both in one place. The metadata is what makes
-;; the `[:schemas :data]` enforced rather than inert. This
-;; machine validates only its `:data` (no outer event-vector `:schema`), so
-;; the opts map carries just `:doc` + `:rf.http/decode-schemas`.
+;; The auth machine carries a `[:schemas :data]` that validates the
+;; snapshot's `:data` slot. Registering the machine here is what makes that
+;; schema live rather than inert. This machine validates only its `:data`
+;; (no outer event-vector `:schema`), so the opts map carries just `:doc` +
+;; `:rf.http/decode-schemas`.
 (rf/reg-machine :auth/flow
   {:doc "The auth flow: idle → submitting/restoring → authed | error.
-         HTTP requests go via :rf.http/managed (Spec 014). Login /
-         register / restore deliberately do NOT retry — the user's
-         intent is one submission per click; a transient error surfaces
-         in `:error` and the user retries themselves."
+         HTTP requests go via `:rf.http/managed`. Login / register /
+         restore do not retry — one submission per click; a transient
+         error surfaces in `:error` and the user retries."
    :rf.http/decode-schemas [schema/UserResponse]}
-  ;; Per Spec 005 §Where snapshots live: spec map does NOT carry :id;
-  ;; the id is the surrounding reg-machine id.
+  ;; The spec map does not carry :id; the id is the surrounding
+  ;; reg-machine id.
   {:initial :idle
    :data    {:error nil}
-   ;; Snapshot :data validation. The snapshot lives in runtime-db
-   ;; ([:rf.runtime/machines :snapshots :auth/flow]), so its :data shape is
-   ;; validated here via [:schemas :data] — not via an app-schema (EP-0001,
-   ;; Mike ruling #11: app schemas validate the app-db partition only).
+   ;; The snapshot lives in runtime-db at
+   ;; [:rf.runtime/machines :snapshots :auth/flow], so its :data shape is
+   ;; validated here via [:schemas :data], not via an app-schema (app
+   ;; schemas validate the app-db partition only).
    :schemas {:data schema/AuthFlowData}
    :guards
    {:has-token?
@@ -209,11 +191,11 @@
 
     :store-session
     (fn [{[_ {:keys [value]}] :event}]
-      ;; Per Spec 005 §Hard-disallow `:db`, a machine action sees no
-      ;; `:db` and emits no `:db`; the post-login bounce-back therefore
-      ;; runs as an ordinary event (`:auth/post-login-redirect`) that
-      ;; reads the guard-stashed `:return-to` slot, navigates there (or
-      ;; home), and clears it. See routing.cljs for where the slot is set.
+      ;; A machine action sees no `:db` and emits no `:db`, so the
+      ;; post-login bounce-back runs as an ordinary event
+      ;; (`:auth/post-login-redirect`) that reads the guard-stashed
+      ;; `:return-to` slot, navigates there (or home), and clears it. See
+      ;; routing.cljs for where the slot is set.
       (let [user (:user value)]
         {:data {:error nil}
          :fx [[:dispatch [:auth/store-session user]]
@@ -261,17 +243,15 @@
 (rf/reg-event :auth/initialise
   {:rf.cofx/requires [:auth.session/token]}
   (fn handler-auth-initialise [{:keys [db auth.session/token]} _]
-    ;; ITEM 8: we dispatch `:auth/flow [:auth/restore token]`
-    ;; UNCONDITIONALLY — even when `token` is nil — on purpose. This first
-    ;; delivery is what spawns the auth machine's snapshot (the machine
-    ;; materialises at `:idle` on its first event), so the navbar's
-    ;; `:auth/state` sub reads `:idle` rather than `nil` from cold boot.
-    ;; The do-we-have-a-token? decision is then made by the machine's
+    ;; Dispatch `:auth/flow [:auth/restore token]` unconditionally — even
+    ;; when `token` is nil. This first delivery spawns the auth machine's
+    ;; snapshot (the machine materialises at `:idle` on its first event), so
+    ;; the navbar's `:auth/state` sub reads `:idle` rather than `nil` from
+    ;; cold boot. The do-we-have-a-token? decision is then the machine's
     ;; `:idle` `:has-token?` guard: a blank token routes to the no-op
     ;; `{:target :idle}` branch, a real one kicks `:begin-restore`. Guarding
-    ;; the dispatch here would skip the machine spawn on a no-token boot —
-    ;; the guard stays where it belongs (one source of truth for the
-    ;; token decision, in the machine).
+    ;; the dispatch here would skip the machine spawn on a no-token boot and
+    ;; split the token decision across two sites.
     {:db (assoc db :auth {:user nil
                           :token token})
      :fx [[:dispatch [:auth/flow [:auth/restore token]]]]}))
@@ -346,9 +326,8 @@
 
 (rf/reg-sub :auth/flow-state
   {:doc "Current state of the auth machine snapshot."}
-  ;; EP-0001: machine snapshots are durable runtime-db state —
-  ;; read them through the framework `:rf/machine` sub (the public surface)
-  ;; rather than a raw db path.
+  ;; Machine snapshots live in runtime-db — read them through the
+  ;; `:rf/machine` sub (the public surface), not a raw db path.
   :<- [:rf/machine :auth/flow]
   (fn [snapshot _] snapshot))
 
@@ -379,9 +358,9 @@
   (fn [db _] (get-in db [:auth :login-form])))
 
 (rf/reg-sub :auth.login-form/field-error
-  {:doc "Per-field validation error for the login form. Per
-         Pattern-Forms §Error visibility: reveal every error after the
-         first submit click, OR once a field is :touched."}
+  {:doc "Per-field validation error for the login form. Reveal every error
+         after the first submit click, or once a field is :touched. See the
+         forms how-to: ../../../docs/guide/how-to/build-a-form.md"}
   :<- [:auth.login-form/slice]
   (fn [form [_ field]]
     (when (or (:submit-attempted? form)
@@ -395,9 +374,9 @@
   (fn [db _] (get-in db [:auth :register-form])))
 
 (rf/reg-sub :auth.register-form/field-error
-  {:doc "Per-field validation error for the register form. Per
-         Pattern-Forms §Error visibility: reveal every error after the
-         first submit click, OR once a field is :touched."}
+  {:doc "Per-field validation error for the register form. Reveal every
+         error after the first submit click, or once a field is :touched.
+         See the forms how-to: ../../../docs/guide/how-to/build-a-form.md"}
   :<- [:auth.register-form/slice]
   (fn [form [_ field]]
     (when (or (:submit-attempted? form)

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -1,11 +1,12 @@
 (ns realworld.comments
   "Article detail plus comments for the RealWorld (Conduit) example.
 
-   This sketch keeps the current re-frame2 API surface explicit:
-   - `:article` and `:comments` use the standard Pattern-RemoteData shape.
-   - `:comment-form` uses the standard Pattern-Forms slice shape.
-   - Route-driven loads read the current slug from the runtime-db coeffect at `[:rf.runtime/routing :current :params :slug]`.
-   - Post/delete flows are optimistic and roll back via ordinary events."
+   This namespace shows:
+   - `:article` and `:comments` in the plain remote-data slice shape.
+   - `:comment-form` in the plain form slice shape.
+   - Route-driven loads reading the current slug from the runtime-db
+     coeffect at `[:rf.runtime/routing :current :params :slug]`.
+   - Optimistic post/delete flows that roll back via ordinary events."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [realworld-shared.avatar :as avatar]
@@ -30,23 +31,25 @@
   (str (article-path slug) "/comments"))
 
 ;; ============================================================================
-;; RECORDABLE COEFFECTS  (EP-0017)
+;; RECORDABLE COEFFECTS
 ;; ============================================================================
 ;;
-;; The optimistic temp-id is written into durable app-db (the optimistic card is
-;; conj'd into `[:comments :data]`) AND used as a join key — it correlates the
-;; optimistic card with its eventual save (`:comment-form/submit-success`) or
-;; rollback (`:comment-form/submit-error`). Per EP-0010 a value that is written
-;; durably OR used as a join key MUST be folded from a recordable coeffect, not
-;; read ambiently at the write site — otherwise replay mints a different id and
-;; the correlation no longer matches. The EP-0017 authoring surface is a
-;; RECORDABLE `reg-cofx`: the generator runs at context-assembly, the minted id
-;; is recorded onto the causal token, and replay re-presents it verbatim.
-;; `:comment-form/submit` DECLARES it via `:rf.cofx/requires` and reads it flat
-;; from the coeffects map — the handler stays pure and replayable.
+;; The optimistic temp-id is written into durable app-db (the optimistic
+;; card is conj'd into `[:comments :data]`) and used as a join key — it
+;; correlates the optimistic card with its eventual save
+;; (`:comment-form/submit-success`) or rollback
+;; (`:comment-form/submit-error`). A value written durably or used as a
+;; join key must come from a recordable coeffect, not a fresh
+;; `random-uuid` at the write site — otherwise replay mints a different id
+;; and the correlation breaks. So this is a recordable `reg-cofx`: the
+;; supplier runs once, the id is recorded onto the causal token, and replay
+;; re-presents it verbatim. `:comment-form/submit` declares it via
+;; `:rf.cofx/requires` and reads it flat, staying pure and replayable. See
+;; the coeffects guide:
+;; ../../../docs/guide/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
 (rf/reg-cofx :realworld/temp-comment-id
   {:recordable? true
-   :doc "Replayable optimistic temp-id for a newly-posted comment (EP-0017)."}
+   :doc "Replayable optimistic temp-id for a newly-posted comment."}
   (fn [] (str "temp-" (random-uuid))))
 
 ;; ============================================================================
@@ -72,14 +75,16 @@
 ;; ============================================================================
 
 (rf/reg-event :article/load
-  {:doc "Load the article matching `[:rf.runtime/routing :current :params :slug]`
-         (EP-0001: the route slice is durable runtime-db state).
+  {:doc "Load the article matching
+         `[:rf.runtime/routing :current :params :slug]` (the route lives in
+         runtime-db).
 
-         This handler demonstrates Spec 014's *default reply addressing*:
-         no `:on-success` / `:on-failure` is supplied, so the framework
-         re-dispatches the reply back to this same event id with
-         `:rf/reply` merged into the original message map. The handler
-         body branches on `(:rf/reply msg)` — one event id, two roles."
+         This handler shows default reply addressing: with no `:on-success`
+         / `:on-failure`, the framework re-dispatches the reply back to this
+         same event id, merging `:rf/reply` into the original message map.
+         The body branches on `(:rf/reply msg)` — one event id, two roles.
+         See the HTTP guide on when request and reply belong together:
+         ../../../docs/resources/http.md#when-request-and-reply-belong-together"
    :rf.http/decode-schemas [schema/ArticleResponse]
    :rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms] rt :rf.db/runtime} [_ msg]]
@@ -119,9 +124,9 @@
 
 (rf/reg-event :comments/load
   {:doc "Load comments for the current article. Uses explicit success /
-         failure handlers (cf. :article/load above which uses default
-         reply addressing) — both shapes are valid Spec 014; pick whichever
-         reads best for the handler."
+         failure handlers (cf. :article/load above, which uses default
+         reply addressing) — both shapes are valid; pick whichever reads
+         best for the handler."
    :rf.http/decode-schemas [schema/CommentsResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [slug (get-in rt [:rf.runtime/routing :current :params :slug])]
@@ -165,12 +170,13 @@
         (update-in [:comment-form :touched] (fnil conj #{}) field))}))
 
 (rf/reg-event :comment-form/submit
-  {:doc "Optimistically post a new comment. NO retry — the user clicked
+  {:doc "Optimistically post a new comment. No retry — the user clicked
          once. The temp-id correlates the optimistic UI card with the
-         eventual save / rollback (Spec 014 - explicit on-success/on-failure
-         where the partial event vector pre-populates correlation args). The
-         temp-id is FOLDED from a recordable coeffect (EP-0017 — see the
-         `:realworld/temp-comment-id` reg-cofx above), never minted ambiently."
+         eventual save / rollback: the partial event vectors in
+         `:on-success` / `:on-failure` pre-populate the correlation arg. The
+         temp-id comes from a recordable coeffect (the
+         `:realworld/temp-comment-id` reg-cofx above), never a fresh
+         `random-uuid` at the write site."
    :rf.http/decode-schemas [schema/CommentResponse]
    :rf.cofx/requires [:realworld/temp-comment-id]}
   (fn [{:keys [db] rt :rf.db/runtime temp-id :realworld/temp-comment-id} _]
@@ -187,13 +193,12 @@
                                  :image     (:image user)
                                  :following false}}]
       (if (str/blank? body)
-        ;; Client-side validation failure. Per Pattern-Forms
-        ;; §:submit-error vs :errors: validation messages live in
+        ;; Client-side validation failure. Validation messages live in
         ;; `:errors` (`:_form` for whole-form, otherwise per-field);
-        ;; `:submit-error` is reserved for transport / non-field
-        ;; HTTP failures. Flip :submit-attempted? so the view's
-        ;; per-field-error sub reveals the :body error even on a
-        ;; fresh, never-:touched textarea.
+        ;; `:submit-error` is reserved for transport / non-field HTTP
+        ;; failures. Flip :submit-attempted? so the view's per-field-error
+        ;; sub reveals the :body error even on a fresh, never-:touched
+        ;; textarea.
         {:db (-> db
                  (assoc-in [:comment-form :submit-attempted?] true)
                  (assoc-in [:comment-form :errors] {:body "Comment body is required."})
@@ -389,9 +394,9 @@
   (fn [db _] (:comment-form db)))
 
 (rf/reg-sub :comment-form/field-error
-  {:doc "Per-field validation error for the comment form. Per
-         Pattern-Forms §Error visibility: reveal every error after the
-         first submit click, OR once the field is :touched."}
+  {:doc "Per-field validation error for the comment form. Reveal every
+         error after the first submit click, or once the field is :touched.
+         See the forms how-to: ../../../docs/guide/how-to/build-a-form.md"}
   :<- [:comment-form/slice]
   (fn [form [_ field]]
     (when (or (:submit-attempted? form)
@@ -478,13 +483,12 @@
        (= article-status :loading)
        [:div.article-preview "Loading article…"]
 
-       ;; Only surface the error view when there is NO article to show.
-       ;; A failed RE-fetch (`:status :error`) of an already-loaded
-       ;; article leaves the prior `:data` in place — render it (the
-       ;; `article` branch below) rather than blanking a page the user is
-       ;; reading. Pattern-RemoteData: never blank loaded data on a
-       ;; refresh failure. (cf. tags.cljs, where the machine keeps prior
-       ;; `:tags` visible across a `:fetch-failed`.)
+       ;; Only surface the error view when there is no article to show. A
+       ;; failed re-fetch (`:status :error`) of an already-loaded article
+       ;; leaves the prior `:data` in place — render it (the `article`
+       ;; branch below) rather than blanking a page the user is reading.
+       ;; Never blank loaded data on a refresh failure. (tags.cljs keeps
+       ;; prior `:tags` visible across a `:fetch-failed` the same way.)
        (and article-error (nil? article))
        [:div.article-preview.error
         (str "Couldn't load article: " (pr-str article-error))]

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -16,48 +16,35 @@
      article_editor.cljs   — create / edit / delete article
      profile.cljs          — public profile routes
      favorites.cljs        — favorite toggle + your-feed slice
-     tags.cljs             — popular-tags machine (:data-region
-                             machine variant of Pattern-RemoteData) +
-                             home-page query helpers
-     settings.cljs         — user settings page (:form-region machine
-                             variant of Pattern-Forms)
+     tags.cljs             — popular-tags machine (lifecycle held entirely
+                             in a machine) + home-page query helpers
+     settings.cljs         — user settings page (form lifecycle held in a
+                             machine)
      routing.cljs          — route registrations + router wiring
      schema.cljs           — Malli schemas for the example slices
      http.cljs             — request-builder + retry policy for :rf.http/managed
      ssr.cljc              — hydration payload helper for the RealWorld app
 
-   This is the canonical Spec 014 (`:rf.http/managed`) demo. Every
-   Conduit endpoint goes via the framework-shipped managed-HTTP fx;
-   the demo entry below installs a canned-stub override so the CLJS
-   test fixtures (in the framework test tree at
-   `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`;
-   the example tree is test-free) run without a network."
+   Every Conduit endpoint goes via `:rf.http/managed`. The demo entry
+   below installs a canned-stub override so the app runs without a network.
+   See the HTTP guide: ../../../docs/resources/http.md"
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            ;; Managed-HTTP ships in day8/re-frame2-http.
-            ;; Requiring re-frame.http.managed at app boot is what
-            ;; triggers its load-time fx registrations (`:rf.http/managed`
-            ;; and family) and publishes the late-bind hooks; without
-            ;; it, dispatching `:rf.http/managed` would fail with
-            ;; :rf.error/no-such-fx. RealWorld is the canonical Spec 014
-            ;; demo so the require is mandatory here.
+            ;; Managed HTTP ships in the re-frame2-http artefact.
+            ;; Requiring the ns registers the `:rf.http/managed` fx (and
+            ;; family) so dispatching it resolves.
             [re-frame.http.managed]
-            ;; RealWorld ships without a backend; the demo routes
-            ;; :rf.http/managed through a per-URL stub that delegates
-            ;; to :rf.http/managed-canned-success. The canned-stub fx
-            ;; ids register from re-frame.http.test-support, which the
-            ;; demo opts in to here. A real Conduit backend deployment
-            ;; would drop this require alongside the demo override.
+            ;; The demo routes `:rf.http/managed` through a per-URL stub
+            ;; that delegates to `:rf.http/managed-canned-success`. That
+            ;; canned-stub fx ships in re-frame.http.test-support. A real
+            ;; Conduit backend would drop this require with the demo
+            ;; override.
             [re-frame.http.test-support]
-            ;; SSR ships in day8/re-frame2-ssr. Requiring
-            ;; re-frame.ssr at app boot publishes the late-bind hooks
-            ;; (`:ssr/render-tree-hash` etc.) and registers the
-            ;; `:rf/hydrate` handler — the RealWorld ssr.cljc helper
-            ;; calls `rf/render-tree-hash` and dispatches
-            ;; `:rf/hydrate`. Without the require those calls raise
-            ;; :rf.error/ssr-artefact-missing.
+            ;; SSR ships in the re-frame2-ssr artefact. Requiring the ns
+            ;; registers the `:rf/hydrate` handler and the SSR helpers
+            ;; ssr.cljc calls (`rf/render-tree-hash`).
             [re-frame.ssr]
             [re-frame.adapter.reagent :as reagent-adapter]
             [realworld-shared.avatar :as avatar]
@@ -79,12 +66,12 @@
 ;; ============================================================================
 
 (rf/reg-event :app/initialise
-  {:doc "App boot. Fans out to per-feature initialisers. `:auth/initialise` is
-         kept out of this fan-out and listed as its own `:initial-event` in the
-         frame-provider: it consumes the recordable-generator
-         `:auth.session/token` coeffect (EP-0017), and the `:dispatch` fx does
-         not forward `:rf.cofx`. Running it on its own boot dispatch token is
-         what lets the generated token be recorded."}
+  {:doc "App boot. Fans out to per-feature initialisers. `:auth/initialise`
+         is kept out of this fan-out and listed as its own `:initial-event`
+         in the frame-provider: it consumes the recordable
+         `:auth.session/token` coeffect, and the `:dispatch` fx does not
+         forward `:rf.cofx`. Running it on its own boot dispatch is what
+         lets the read token be recorded."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:articles/initialise]]
           [:dispatch [:article/initialise]]
@@ -98,27 +85,23 @@
           [:dispatch [:auth.login-form/initialise]]
           [:dispatch [:auth.register-form/initialise]]]}))
 
-;; Durable app-db classification (EP-0025): the JWT at [:auth :token] is
-;; sensitive — declare it via the commit-plane `:sensitive` classification
-;; effect, returned alongside `:db` from an event the frame runs at creation
-;; (`:initial-events`, before any boot dispatch or off-box egress). The
-;; framework folds the declaration into the per-frame elision registry, so any
-;; off-box egress (Xray/observability capture, an off-box tool, an SSR
-;; hydration payload) sees the token redacted while on-box rendering keeps the
-;; raw value. The declaration lives on the event, not the frame: a frame is not
-;; app-db's definition site.
+;; The JWT at [:auth :token] is sensitive. Declare it via the `:sensitive`
+;; classification effect, returned alongside `:db` from an event the frame
+;; runs at creation (`:initial-events`, before any boot dispatch or off-box
+;; egress). Any off-box egress (an observability capture, an off-box tool,
+;; an SSR hydration payload) then sees the token redacted while on-box
+;; rendering keeps the raw value.
 ;;
-;; This app classifies exactly one path. The outbound `Authorization` Bearer
-;; header rides the framework's built-in HTTP carrier denylist (Spec 014
-;; §Privacy, alongside Cookie / X-API-Key / …), so it is redacted off-box with
-;; no app config — the `:sensitive :http :headers` extension is for app-specific
-;; carriers, and this app sends none. The login / register password drafts at
-;; [:auth :login-form] / [:auth :register-form] are transient form state owned
-;; by their registrations, never sent off-box from app-db, so they need no
-;; classification either.
+;; This app classifies exactly one path. The outbound `Authorization`
+;; Bearer header rides the framework's built-in HTTP carrier denylist, so
+;; it is redacted off-box with no app config. The login / register password
+;; drafts at [:auth :login-form] / [:auth :register-form] are transient form
+;; state, never sent off-box from app-db, so they need no classification.
+;; See the keep-secrets how-to:
+;; ../../../docs/guide/how-to/keep-secrets-out-of-traces.md
 (rf/reg-event :auth/classify-token
   {:doc "Classifies the durable JWT path [:auth :token] sensitive at frame
-         creation (EP-0025 commit-plane classification effect)."}
+         creation."}
   (fn handler-auth-classify-token [{:keys [db]} _]
     {:db db :sensitive [[:auth :token]]}))
 
@@ -227,29 +210,25 @@
 ;; ----------------------------------------------------------------------------
 ;; DEMO STUBS
 ;;
-;; The realworld example would normally hit the hosted Conduit API
+;; The example would normally hit the hosted Conduit API
 ;; (https://api.realworld.show/api — `realworld.http/api-base`), which is
-;; unreliable for headless smoke and slow for a demo. Override
-;; :rf.http/managed with a small in-process stub that synthesises the
-;; canonical Spec 014 reply shape for the routes the demo actually
-;; exercises (global feed, tags, profile). Anything not covered resolves
-;; to an empty-payload success — enough for the app shell + main feed
-;; to render.
+;; slow and unreliable for a demo. Override `:rf.http/managed` with a small
+;; in-process stub that synthesises the reply shape for the routes the demo
+;; exercises (global feed, tags, profile). Anything else resolves to an
+;; empty-payload success — enough for the app shell + main feed to render.
 ;;
-;; The override delegates straight to :rf.http/managed-canned-success
-;; with a per-URL :value payload and an `:after-ms` delay so
-;; the framework defers the reply via `:dispatch-later` — observable in
-;; the tape, time-travel-safe, NOT raw `js/setTimeout`. This is the same
-;; shape Spec 014 §Testing documents — just routed by URL inspection in a
-;; wrapper fx so the demo doesn't have to know one URL ahead of time.
+;; The override delegates to `:rf.http/managed-canned-success` with a
+;; per-URL `:value` payload and an `:after-ms` delay, so the framework
+;; defers the reply via `:dispatch-later` — observable in the trace,
+;; time-travel-safe, not raw `js/setTimeout`. A wrapper fx routes by URL so
+;; the demo doesn't have to know one URL ahead of time.
 ;; ----------------------------------------------------------------------------
 
 (def ^:private demo-reply-delay-ms
   "How long the demo stub defers each canned reply (via the canned-success
-   fx's `:after-ms`, dispatched through `:dispatch-later` — observable in
-   the tape, time-travel-safe, NOT raw `js/setTimeout`). Small but non-zero
-   so the `:loading` UI state is observable in the standalone demo. A
-   demo-seam knob, not a production value."
+   fx's `:after-ms`, dispatched through `:dispatch-later`). Small but
+   non-zero so the `:loading` UI state is visible in the demo. A demo knob,
+   not a production value."
   20)
 
 ;; A corpus larger than one page (25 articles) so the official
@@ -358,10 +337,9 @@
 
 (defn- canned-comment
   "Synthesise a saved Comment reply for POST /articles/:slug/comments.
-   The Spec 014 reply value is `{:comment <Comment>}`; the comments
-   handler patches the optimistic temp card out and inserts this saved
-   row by `:id`. A unique numeric id per call avoids :key collisions
-   when the spec posts more than once."
+   The reply value is `{:comment <Comment>}`; the comments handler patches
+   the optimistic temp card out and inserts this saved row by `:id`. A
+   unique numeric id per call avoids :key collisions across repeat posts."
   [body]
   (let [id (+ 1000 (rand-int 100000))]
     {:comment {:id        id
@@ -378,12 +356,12 @@
         u      (str (:url req))
         method (or (:method req) :get)]
     (cond
-      ;; /users/login (POST) — Spec User wire shape.
+      ;; /users/login (POST) — the User wire shape.
       (and (= method :post) (str/ends-with? u "/users/login"))
       {:user demo-user}
 
-      ;; /users (POST, register) — Spec User wire shape. Must precede
-      ;; the bare /users (GET, current user) clause.
+      ;; /users (POST, register) — the User wire shape. Must precede the
+      ;; bare /users (GET, current user) clause.
       (and (= method :post) (str/ends-with? u "/users"))
       {:user demo-user}
 
@@ -427,20 +405,17 @@
       :else {})))
 
 (rf/reg-fx :realworld.demo/http-stub
-  {:doc       "Demo override for :rf.http/managed: routes by URL to
+  {:doc       "Demo override for `:rf.http/managed`: routes by URL to
                canned Conduit-shaped responses so the example runs
                standalone without a backend.
 
-               Delegates straight to the framework-shipped
-               `:rf.http/managed-canned-success` (Spec 014 §Testing) with
-               the per-URL canned payload and `:after-ms`
-               (`demo-reply-delay-ms`): the framework defers the
-               reply via `:dispatch-later` —
-               observable in the tape, time-travel-safe, NOT raw
-               `js/setTimeout`. The delay lets the `:loading` UI state be
-               observable; `:after-ms` expresses the schedule-reply
-               → `:dispatch-later` → deliver-reply chain as one
-               parameter of the same canned effect."
+               Delegates to the framework-shipped
+               `:rf.http/managed-canned-success` with the per-URL canned
+               payload and `:after-ms` (`demo-reply-delay-ms`): the
+               framework defers the reply via `:dispatch-later` —
+               observable in the trace, time-travel-safe, not raw
+               `js/setTimeout`. The delay makes the `:loading` UI state
+               observable."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
     (let [payload (demo-payload-for-args args-map)
@@ -458,31 +433,25 @@
 (defonce react-root (atom nil))
 
 ;; ============================================================================
-;; HTTP REQUEST INTERCEPTOR — Spec 014 §Middleware
+;; HTTP REQUEST INTERCEPTOR
 ;; ============================================================================
 ;;
-;; Demonstrates the per-frame request interceptor surface: a single
-;; `:before` fn injects a Bearer token from the auth slice, so every
-;; outbound :rf.http/managed request that crosses this frame picks the
-;; auth header up automatically. With this pattern, individual call
-;; sites (`articles.cljs`, `comments.cljs`, ...) don't need to thread
-;; the token through the request builder per-call — the auth slice is
-;; the single source of truth and the interceptor is the single read
-;; site.
+;; The per-frame request interceptor surface: one `:before` fn injects a
+;; Bearer token from the auth slice, so every outbound `:rf.http/managed`
+;; request that crosses this frame picks the auth header up. Call sites
+;; (`articles.cljs`, `comments.cljs`, ...) don't thread the token per call —
+;; the auth slice is the single source of truth and the interceptor is the
+;; single read site. See the HTTP guide on interceptors:
+;; ../../../docs/resources/http.md#interceptors-stamp-every-request-once
 ;;
-;; The interceptor returns the ctx unchanged when no token is present,
-;; so login / register / public-read endpoints are unaffected (an
-;; unauthenticated user has no token to send).
+;; The interceptor returns the ctx unchanged when no token is present, so
+;; login / register / public-read endpoints are unaffected.
 ;;
-;; SINGLE SOURCE OF TRUTH: this is the ONE place the Bearer
-;; header is written. `realworld.http/request` composes the request map and
-;; leaves the token to this interceptor. Centralising the read here keeps the
-;; example carried-frame-correct: the interceptor reads from `(:frame ctx)`
-;; (the frame the cascade actually runs under, EP-0002), so the
-;; header tracks a non-default / multi-frame mount rather than a hard-coded
-;; `:rf/default`. One read site is the recommended production shape — wiring the
-;; token into `rh/request` as well would hard-code `:rf/default` and bypass the
-;; carried invariant.
+;; This is the one place the Bearer header is written; `rh/request`
+;; composes the request map and leaves the token to this interceptor. The
+;; interceptor reads from `(:frame ctx)` — the frame the cascade runs under
+;; — so the header tracks a non-default or multi-frame mount rather than a
+;; hard-coded `:rf/default`.
 
 (defn- bearer-auth-interceptor [ctx]
   (let [token (some-> (rf/app-db-value (:frame ctx))
@@ -518,61 +487,64 @@
   ;; Install the Reagent adapter. This is the one frameworky thing that must
   ;; happen before any frame mounts; everything else here is app wiring.
   (rf/init! reagent-adapter/adapter)
-  ;; Register the Bearer-auth interceptor. It reads the JWT from the auth slice
-  ;; and adds the `Authorization` header to outbound :rf.http/managed requests
-  ;; (see bearer-auth-interceptor above). Register it now, before the frame's
-  ;; `:initial-events` run, so it is in place when session-restore fires its
-  ;; first authenticated request.
+  ;; Register the Bearer-auth interceptor. It reads the JWT from the auth
+  ;; slice and adds the `Authorization` header to outbound `:rf.http/managed`
+  ;; requests (see bearer-auth-interceptor above). Register it before the
+  ;; frame's `:initial-events` run, so it is in place when session-restore
+  ;; fires its first authenticated request.
   (rf/reg-http-interceptor :realworld/bearer-auth
                            {:before bearer-auth-interceptor})
-  ;; The orchestrator serves this example under /realworld/. Strip that prefix
-  ;; so :realworld/home (path "/") matches. Set it before the provider renders,
-  ;; so the initial URL→slice sync and the popstate listener see the stripped
-  ;; URL.
+  ;; The orchestrator serves this example under /realworld/. Strip that
+  ;; prefix so :realworld/home (path "/") matches. Set it before the
+  ;; provider renders, so the initial URL→slice sync and the popstate
+  ;; listener see the stripped URL.
   (routing/set-base-path! "/realworld")
-  ;; Wire the popstate listener for Back/Forward (Spec 012 §popstate). Because
-  ;; this example strips its `/realworld/` prefix in `current-url`, it uses its
-  ;; own base-path-aware listener (the framework's `rf/install-history-listener!`
-  ;; assumes a root-served app). The listener resolves the URL owner at pop time
-  ;; and is hot-reload safe. The FIRST URL→slice sync is seeded once by the
-  ;; frame's `:initial-events` (`:rf.route/handle-url-change` below), which run
-  ;; at frame creation — so a deep link lands on the right route on first paint.
+  ;; Wire the popstate listener for Back/Forward. Because this example
+  ;; strips its `/realworld/` prefix in `current-url`, it uses its own
+  ;; base-path-aware listener (the framework's
+  ;; `rf/install-history-listener!` assumes a root-served app). The listener
+  ;; resolves the URL owner at pop time and is hot-reload safe. The first
+  ;; URL→slice sync is seeded by the frame's `:initial-events`
+  ;; (`:rf.route/handle-url-change` below), so a deep link lands on the
+  ;; right route on first paint.
   (routing/install-router!)
-  ;; Install the conformance accessor for the external RealWorld suite. This is
-  ;; a test seam, not a re-frame2 pattern — see install-conduit-debug! above.
+  ;; Install the conformance accessor for the external RealWorld suite. This
+  ;; is a test seam, not a re-frame2 pattern — see install-conduit-debug!
+  ;; above.
   (install-conduit-debug! :rf/default)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; The frame lives here. `frame-provider {:id …}` creates, configures, and
-    ;; seeds the app frame in one spot at the render root. First mount creates
-    ;; `:rf/default` and applies its config:
-    ;;   - `:url-bound? true` — this frame owns the browser URL (Spec 012).
-    ;;   - `:interceptors [:realworld.routing/auth-guard]` — the guard (defined
-    ;;     in routing.cljs, referenced by id per EP-0022) runs on every event in
-    ;;     the frame. It redirects an unauthenticated `:rf.route/navigate` to a
-    ;;     `:requires-auth` route over to login, which is what makes the
-    ;;     `:requires-auth` tags on settings / new / edit actually protect them.
-    ;;   - `:fx-overrides {:rf.http/managed …}` — route managed HTTP to the demo
-    ;;     stub so the example runs with no backend.
-    ;; First mount also runs `:initial-events` once; hot reload reuses the frame
-    ;; without re-seeding (durable app-db survives).
+    ;; The frame lives here. `frame-provider {:id …}` creates, configures,
+    ;; and seeds the app frame in one spot at the render root. First mount
+    ;; creates `:rf/default` and applies its config:
+    ;;   - `:url-bound? true` — this frame owns the browser URL.
+    ;;   - `:interceptors [:realworld.routing/auth-guard]` — the guard
+    ;;     (defined in routing.cljs, referenced by id) runs on every event in
+    ;;     the frame. It redirects an unauthenticated navigation to a
+    ;;     `:requires-auth` route over to login — what makes the
+    ;;     `:requires-auth` tags on settings / new / edit actually protect
+    ;;     them.
+    ;;   - `:fx-overrides {:rf.http/managed …}` — route managed HTTP to the
+    ;;     demo stub so the example runs with no backend.
+    ;; First mount also runs `:initial-events` once; hot reload reuses the
+    ;; frame without re-seeding (durable app-db survives).
     ;;
     ;; `:initial-events` run in order at frame creation:
-    ;;   - `:auth/classify-token` — classify [:auth :token] `:sensitive` (EP-0025)
-    ;;     before the token is written, so it is redacted off-box from the first
+    ;;   - `:auth/classify-token` — classify [:auth :token] sensitive before
+    ;;     the token is written, so it is redacted off-box from the first
     ;;     write on.
-    ;;   - `:auth/initialise` — EP-0017 session restore. It pulls the saved JWT
-    ;;     through the `:auth.session/token` recordable generator (auth.cljs),
-    ;;     which reads localStorage once and records the value so replay /
-    ;;     epoch-restore re-present it verbatim. Runs before `:app/initialise` so
-    ;;     the token is in app-db before the bearer-auth interceptor sends any
-    ;;     authenticated request.
+    ;;   - `:auth/initialise` — session restore. It pulls the saved JWT
+    ;;     through the `:auth.session/token` recordable coeffect (auth.cljs),
+    ;;     which reads localStorage once and records the value so replay and
+    ;;     epoch-restore re-present it verbatim. Runs before `:app/initialise`
+    ;;     so the token is in app-db before the bearer-auth interceptor sends
+    ;;     any authenticated request.
     ;;   - `:app/initialise` — fans out to the per-feature initialisers.
     ;;   - `:rf.route/handle-url-change` — the first URL→slice sync, from the
-    ;;     base-path-stripped current URL. Runs last so the auth-guard sees the
-    ;;     restored session when redirecting a deep link to a `:requires-auth`
-    ;;     route.
+    ;;     base-path-stripped current URL. Runs last so the auth-guard sees
+    ;;     the restored session when redirecting a deep link to a
+    ;;     `:requires-auth` route.
     (rdc/render @react-root
                 [rf/frame-provider {:id              :rf/default
                                     :doc             "Realworld demo frame."

--- a/examples/reagent/realworld/favorites.cljs
+++ b/examples/reagent/realworld/favorites.cljs
@@ -1,10 +1,10 @@
 (ns realworld.favorites
   "Favorite/unfavorite actions plus the authenticated user's feed.
 
-   The favorite toggle is shared across the home feed, profile lists,
-   and the article-detail page. The followed-authors feed is a distinct
-   Pattern-RemoteData slice so the home page can switch between feeds
-   without throwing away already-loaded global articles."
+   The favorite toggle is shared across the home feed, profile lists, and
+   the article-detail page. The followed-authors feed is its own remote-data
+   slice so the home page can switch between feeds without throwing away
+   already-loaded global articles."
   (:require [re-frame.core :as rf]
             [realworld.schema :as schema]
             [realworld.http :as rh]))
@@ -53,18 +53,17 @@
     {:db (assoc db :feed (request-slice))}))
 
 (rf/reg-event :feed/load
-  {:doc "Fetch the authenticated user's feed. Tagged with
+  {:doc "Fetch the authenticated user's feed. Carries
          `:request-id :feed/load` so :feed/cancel can abort an in-flight
-         load when the user navigates away (Spec 014 §Aborts).
+         load when the user navigates away.
 
          Also broadcasts `:fetch-started` into the home machine so the
          `:data` region advances to `:loading` (or `:refreshing` from
          `:some`).
 
-         `?page=` (the home route's 1-indexed pagination page, durable
-         runtime-db routing state) becomes the wire's limit/offset window via
-         `rh/paginate-path` — the same official RealWorld pagination the global
-         feed uses."
+         `?page=` (the home route's 1-indexed page) becomes the wire's
+         limit/offset window via `rh/paginate-path` — the same pagination
+         the global feed uses."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [page (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)
@@ -85,8 +84,9 @@
                           :on-failure [:feed/load-failed]})]]})))
 
 (rf/reg-event :feed/cancel
-  {:doc "Abort an in-flight :feed/load. Useful when the user navigates
-         away mid-load (Spec 014 §Aborts)."}
+  {:doc "Abort an in-flight :feed/load — e.g. when the user navigates away
+         mid-load. See the HTTP guide on aborts:
+         ../../../docs/resources/http.md#the-search-box-race-cured"}
   (fn [_ _]
     {:fx [[:rf.http/managed-abort :feed/load]]}))
 
@@ -121,9 +121,9 @@
 ;; FAVORITES
 ;; ============================================================================
 ;;
-;; Optimistic rollback shapes across the app (ITEM 5). realworld
-;; has three optimistic-with-rollback flows and they DELIBERATELY use three
-;; different rollback shapes — because the thing being rolled back differs:
+;; Optimistic rollback shapes across the app. realworld has three
+;; optimistic-with-rollback flows, and they use three different rollback
+;; shapes on purpose — because the thing being rolled back differs:
 ;;
 ;;   - favorite (here): snapshots {:favorited :favoritesCount} and patches
 ;;     the article EVERYWHERE it appears (across the :articles / :feed /

--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -1,11 +1,11 @@
 (ns realworld.http
   "HTTP helpers for the RealWorld (Conduit) example.
 
-   This is the canonical Spec 014 demo. Every Conduit endpoint goes
-   out via `:rf.http/managed` — the framework-shipped managed
-   HTTP fx. The framework owns transport, decoding, status classification,
-   retry-with-backoff, abort, and reply addressing; the example just
-   composes request maps.
+   Every Conduit endpoint goes out via `:rf.http/managed`, the
+   framework-shipped managed HTTP fx. The framework owns transport,
+   decoding, status classification, retry-with-backoff, abort, and reply
+   addressing; the example just composes request maps. See the HTTP guide:
+   ../../../docs/resources/http.md
 
    BACKEND MODES (see this example's README §Running against a real backend):
    - canned demo stub (DEFAULT) — `core.cljs` overrides `:rf.http/managed` with
@@ -19,27 +19,20 @@
    This namespace ships TWO small helpers on top of `:rf.http/managed`:
 
    - `request` — build a request map (`{:request {...} :decode ... :retry ...}`)
-     that bakes in the API base URL and JSON content-type. The Bearer token is
-     NOT read here: auth-header injection is centralised in the
+     that bakes in the API base URL and JSON content-type. The Bearer token
+     is not read here: auth-header injection is centralised in the
      `:realworld/bearer-auth` HTTP interceptor (`core.cljs`), which reads the
-     token from the CARRIED frame's auth slice (`(:frame ctx)`) on every
-     request — so the header tracks whichever frame the cascade runs under, not
-     a hard-coded `:rf/default` (the carried invariant, EP-0002).
-     A single source of truth is the recommended production shape; this example
-     follows it.
-   - `data-fetch-retry` — the standard retry policy used for read-only
-     fetches (transport, 5xx, timeout — not 4xx; the user's request was
-     valid even when the server is sad).
+     token from the carried frame's auth slice (`(:frame ctx)`) on every
+     request — so the header tracks whichever frame the cascade runs under,
+     not a hard-coded `:rf/default`.
+   - `data-fetch-retry` — the standard retry policy for read-only fetches
+     (transport, 5xx, timeout — not 4xx; the request was valid even when the
+     server is sad).
 
-   The RealWorld spec lives at https://github.com/gothinkster/realworld/tree/main/api.
-   The current official hosted API is https://api.realworld.show/api; locally
-   the spec ships a Node + Postgres reference backend on
-   http://localhost:3000/api. This file does not register any fx — the demo
-   entry (`core.cljs`) wires
-   `:rf.http/managed` to a canned-stub override so the CLJS test fixtures
-   (in the framework test tree at
-   `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`;
-   the example tree is test-free) run without a network."
+   The RealWorld spec lives at
+   https://github.com/gothinkster/realworld/tree/main/api. This file
+   registers no fx — the demo entry (`core.cljs`) wires `:rf.http/managed`
+   to a canned-stub override so the app runs without a network."
   (:require [clojure.string]
             [re-frame.core :as rf]))
 
@@ -108,7 +101,7 @@
     (str path sep "limit=" page-size "&offset=" (page->offset page))))
 
 ;; ============================================================================
-;; RETRY POLICIES (Spec 014 §Retry and backoff)
+;; RETRY POLICIES
 ;; ============================================================================
 
 (def data-fetch-retry
@@ -120,25 +113,24 @@
    :max-attempts 3
    :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}})
 
-;; Login / register / settings deliberately do NOT retry — the user's
-;; intent is to submit one form once. A 5xx surfaces as an error so the
-;; user can retry by clicking again.
+;; Login / register / settings do not retry — one form submission per
+;; click. A 5xx surfaces as an error so the user can retry by clicking
+;; again.
 
 ;; ============================================================================
 ;; REQUEST BUILDER
 ;; ============================================================================
 
 (defn request
-  "Build a Spec 014 `:rf.http/managed` args map for a Conduit endpoint.
+  "Build a `:rf.http/managed` args map for a Conduit endpoint.
 
-   Required keys: `:method`, `:path`. Other keys are optional and
-   correspond to the Spec 014 args map (see spec/014-HTTPRequests.md).
+   Required keys: `:method`, `:path`. Other keys are optional and map to the
+   managed-HTTP args map. See the HTTP guide: ../../../docs/resources/http.md
 
-   The Bearer auth header is NOT injected here — it is added by the
-   frame-wide `:realworld/bearer-auth` HTTP interceptor (`core.cljs`),
-   which reads the token from the carried frame's auth slice on every
-   request (the single source of truth, carried-frame-correct). This
-   builder therefore has no `:frame` / `:auth?` concern.
+   The Bearer auth header is not injected here — it is added by the
+   frame-wide `:realworld/bearer-auth` HTTP interceptor (`core.cljs`), which
+   reads the token from the carried frame's auth slice on every request.
+   This builder therefore has no `:frame` / `:auth?` concern.
 
    Body, if a clj coll, is JSON-encoded (`:request-content-type :json`).
    Decode defaults to `:json` (RealWorld returns JSON everywhere).
@@ -178,38 +170,36 @@
 ;; ============================================================================
 ;;
 ;; `:loaded-at` is a durable write — it rides epoch-restore, SSR/hydration,
-;; and replay. Per the World-Input Rule (Spec 002 §Recordable coeffects), a
-;; durable write MUST read its wall-clock fact from the causal token, not from
-;; an ambient host read at the write site: replaying the same reply event must
-;; reproduce the same `:loaded-at`, which a fresh `(.getTime (js/Date.))` at
-;; handler-run time cannot guarantee.
+;; and replay. A durable write must read its wall-clock fact from the causal
+;; token, not from an ambient host read at the write site: replaying the
+;; same reply event must reproduce the same `:loaded-at`, which a fresh
+;; `(.getTime (js/Date.))` at handler-run time cannot guarantee.
 ;;
 ;; The framework stamps that fact once, at the causal boundary, onto every
-;; dispatch envelope as `:rf.cofx {:rf/time-ms ...}` (EP-0017), and registers
-;; it as the one PROVIDED recordable coeffect (`:rf/time-ms`). A handler that
-;; stamps `:loaded-at` declares `:rf.cofx/requires [:rf/time-ms]` and reads the
-;; `time-ms` value FLAT from its coeffects map (EP-0017 §4):
+;; dispatch envelope and registers it as the provided recordable coeffect
+;; `:rf/time-ms`. A handler that stamps `:loaded-at` declares
+;; `:rf.cofx/requires [:rf/time-ms]` and reads the value flat:
 ;;
 ;;     (rf/reg-event :feed/loaded
 ;;       {:rf.cofx/requires [:rf/time-ms]}
 ;;       (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
 ;;         {:db (assoc-in db [:feed :loaded-at] time-ms)}))
 ;;
-;; Tests, SSR hydration, and replay fixtures supply an exact `:rf/time-ms` via
-;; the dispatch opts (`{:rf.cofx {:rf/time-ms 1781078400123}}`); live code lets
-;; the router stamp it. The app declares no clock cofx of its own — the
-;; framework-provided `:rf/time-ms` is the one home for wall-clock time (EP-0017).
+;; Tests and replay fixtures supply an exact `:rf/time-ms` via the dispatch
+;; opts (`{:rf.cofx {:rf/time-ms 1781078400123}}`); live code lets the
+;; router stamp it. See the coeffects guide:
+;; ../../../docs/guide/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
 
 ;; ============================================================================
 ;; FAILURE PROJECTION
 ;; ============================================================================
 
 (defn failure->message
-  "Project a Spec 014 failure map (the inner `:failure` map of an
+  "Project a failure map (the inner `:failure` map of an
    `{:kind :failure :failure {...}}` reply) to a human-readable string.
    The Conduit API returns `{:errors {:body [\"...\"]}}` shapes for 4xx
-   validation failures; surface those when present, otherwise fall back
-   to a category-driven message."
+   validation failures; surface those when present, otherwise fall back to a
+   category-driven message."
   [failure]
   (let [body (:body failure)
         ;; The :body for 4xx/5xx is the raw response text; some Conduit

--- a/examples/reagent/realworld/profile.cljs
+++ b/examples/reagent/realworld/profile.cljs
@@ -1,21 +1,20 @@
 (ns realworld.profile
   "Profile pages for the RealWorld (Conduit) example.
 
-   This sketch demonstrates:
-   - Pattern-NineStates — one parallel state machine `:ui/profile` with
-     two orthogonal regions (`:tab` × `:data`) replacing the prior
-     cross-axis sub + priority `cond` shape.
-   - Pattern-RemoteData lifecycle folded into the `:data` region; the
-     region's state-keyword IS the banner's status. The article-list
-     items still live in app-db slices (`:profile.articles`,
-     `:profile.favorites`) so the optimistic-update paths in
-     favorites.cljs continue to find articles across slices.
-   - Tab switching expressed as `:tab` region transitions broadcast
-     from the route's `:on-match` (just like the home page's
-     `:home/load` broadcasts the feed-region transition).
-   - The profile view's root is a `case` over `:profile/render`, a
-     selector sub that consults a render-priority table against the
-     machine's tag union (per Pattern-NineStates §4).
+   This namespace shows:
+   - One parallel state machine `:ui/profile` with two orthogonal regions
+     (`:tab` x `:data`). See the machines guide on parallel regions:
+     ../../../docs/machines/concepts.md#when-the-machine-grows.
+   - A remote-data lifecycle folded into the `:data` region; the region's
+     state-keyword is the banner's status. The article-list items live in
+     app-db slices (`:profile.articles`, `:profile.favorites`) so
+     favorites.cljs's optimistic updates can find articles across slices.
+   - Tab switching expressed as `:tab` region transitions broadcast from
+     the route's `:on-match`, like the home page's `:home/load` broadcasts
+     its feed-region transition.
+   - The profile view's root is a `case` over `:profile/render`, a selector
+     sub that reads a render-priority table against the machine's tag
+     union.
 
    Three remote-data slices behind the view:
    - `:profile`             — public banner (username, bio, image, following)
@@ -25,11 +24,10 @@
    Follow/unfollow is optimistic and shared across the banner plus any
    article cards rendered from the profile routes."
   (:require [re-frame.core :as rf]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine (called
-            ;; below at ns-load) and the `:rf/machine` framework subs
-            ;; resolve.
+            ;; State machines ship in the re-frame2-machines artefact.
+            ;; Requiring the ns registers its hooks so `rf/reg-machine`
+            ;; (called below) and the `:rf/machine` subs resolve. See the
+            ;; machines guide: ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld-shared.avatar :as avatar]
             [realworld.schema :as schema]
@@ -40,9 +38,8 @@
 (defn request-slice []
   {:status :idle :data nil :error nil :loaded-at nil :attempt 0})
 
-;; EP-0001: the route slice is durable routing runtime-db state —
-;; `username-from-db` reads it off the runtime-db value (event handlers pass the
-;; `:rf.db/runtime` coeffect).
+;; The route lives in runtime-db; `username-from-db` reads it off the
+;; runtime-db value (event handlers pass the `:rf.db/runtime` coeffect).
 (defn username-from-db [runtime-db]
   (get-in runtime-db [:rf.runtime/routing :current :params :username]))
 
@@ -59,22 +56,21 @@
 ;;             state-keyword tells the view which app-db slice's items
 ;;             to render.
 ;;
-;;   :data   — Pattern-NineStates' data lifecycle for the banner fetch.
-;;             The slice's `:status` field is still set for parity with
-;;             other slices, but the region's state-keyword IS the
-;;             page's render gate. The article-list slices keep their
-;;             slice shape and load independently.
+;;   :data   — the data lifecycle for the banner fetch. The slice's
+;;             `:status` field is still set for parity with other slices,
+;;             but the region's state-keyword is the page's render gate. The
+;;             article-list slices keep their slice shape and load
+;;             independently.
 ;;
-;; Per Spec 005 §Transition broadcast: every event delivered to the
-;; machine is broadcast to every region. Region-distinct event names
-;; below avoid collisions; `:reset` is handled by every region as a
+;; Every event delivered to the machine reaches every region. Region-
+;; distinct event names avoid collisions; each region handles `:reset` as a
 ;; self-target.
 
 (def profile-machine
   {:type :parallel
 
-   ;; The banner's latest error map. The profile/article items
-   ;; themselves still live in app-db slices.
+   ;; The banner's latest error map. The profile/article items live in
+   ;; app-db slices.
    :data {:error nil}
 
    :actions
@@ -87,7 +83,7 @@
       {:data (assoc data :error nil)})}
 
    :regions
-   {;; ---- :data region — Pattern-NineStates lifecycle for the banner ----
+   {;; ---- :data region — the data lifecycle for the banner ----
     :data
     {:initial :nothing
      :states

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -16,13 +16,11 @@
    - `:rf/url-requested`"
   (:require [clojure.string]
             [re-frame.core :as rf]
-            ;; Routing ships in day8/re-frame2-routing.
-            ;; Requiring re-frame.routing here triggers its load-time
-            ;; hook + reg-sub registrations; without it, the rf/reg-route
-            ;; calls below throw :rf.error/routing-artefact-missing.
-            ;; Aliased so the popstate handler can resolve the URL owner via
-            ;; `routing/url-owner-frame-id` (Spec 012 §popstate drives the
-            ;; URL-owner frame) — the EP-0002 owner-targeted dispatch.
+            ;; Routing ships in the re-frame2-routing artefact. Requiring
+            ;; the ns registers its hooks + subs so the `rf/reg-route` calls
+            ;; below resolve. Aliased so the popstate handler can resolve the
+            ;; URL owner via `routing/url-owner-frame-id`. See the routing
+            ;; guide: ../../../docs/routing/index.md
             [re-frame.routing :as routing]))
 
 ;; ============================================================================
@@ -53,11 +51,10 @@
 
 (rf/reg-route :realworld/home-tag
   {:doc      "The tag-filtered article list at the official RealWorld
-              `/tag/:tag` PATH route (replacing the prior
-              `?tag=` query). `?page=N` paginates within the tag the same way
-              the home feed does (`/tag/:tag?page=2`); `:query-defaults` fills
-              page 1. Same `:home/load` on-match — it reads the active tag off
-              the route params now rather than the query."
+              `/tag/:tag` PATH route. `?page=N` paginates within the tag the
+              same way the home feed does (`/tag/:tag?page=2`);
+              `:query-defaults` fills page 1. Same `:home/load` on-match — it
+              reads the active tag off the route params."
    :params   [:map [:tag :string]]
    :query    [:map [:page {:optional true} :int]]
    :query-defaults {:page 1}
@@ -120,60 +117,49 @@
 ;; AUTH GUARD
 ;; ============================================================================
 ;;
-;; Per Spec 012 §Redirects and guards: route-level auth is an interceptor,
-;; not a special routing mechanism. Guards are plain interceptors; they
-;; compose, and multiple guards can layer. This one redirects
-;; unauthenticated users away from any route tagged `:requires-auth`
-;; (`:realworld.user/settings`, `:realworld.editor/new`, `:realworld.editor/edit`) to the login
-;; page, stashing the original target under `:return-to` so a post-login
-;; handler could bounce the user back.
+;; Route-level auth is an interceptor, not a special routing mechanism.
+;; Guards are plain interceptors, so they compose and layer. This one
+;; redirects unauthenticated users away from any route tagged
+;; `:requires-auth` (`:realworld.user/settings`, `:realworld.editor/new`,
+;; `:realworld.editor/edit`) to the login page, stashing the original target
+;; under `:return-to` for a post-login bounce-back. See the routing guide on
+;; guards: ../../../docs/routing/concepts.md#blocking-a-navigation
 ;;
-;; It is wired into the demo frame via the `frame-provider {:id …}`
-;; `:interceptors` in core.cljs (`:interceptors` are "prepended to every
-;; event in this frame", Spec 002 §`:interceptors`). To keep it cheap and correct it short-
-;; circuits to the unchanged ctx for everything except a navigation
-;; event, and gates EVERY navigation ENTRY POINT so a `:requires-auth`
-;; route is unreachable logged-out by ANY access path:
+;; It is wired into the demo frame via the `frame-provider` `:interceptors`
+;; in core.cljs. It short-circuits to the unchanged ctx for everything
+;; except a navigation event, and gates every navigation entry point so a
+;; `:requires-auth` route is unreachable logged-out by any access path:
 ;;
 ;;   - `:rf.route/navigate`          — programmatic nav (the navbar);
-;;     `(second event)` IS the target route id.
+;;     `(second event)` is the target route id.
 ;;   - `:rf/url-requested`           — anchor (`rf/route-link`) click;
 ;;     the request map carries `:to` (the target route id) + `:params`.
 ;;   - `:rf.route/handle-url-change` — URL-bar entry / reload / popstate;
-;;     `(second event)` is a URL string resolved to a route via
-;;     `rf/match-url`.
+;;     `(second event)` is a URL string resolved via `rf/match-url`.
 ;;
-;; The guard MUST gate all three entry points, not just `:rf.route/navigate`:
-;; gating navigate alone would FAIL OPEN on the most common access path — a
-;; logged-out user who typed `/settings`, reloaded a protected page, or followed
-;; an anchor would reach the route (and the on-match drain would then fire a
-;; request the real Conduit backend would 401). Gating all three closes that
-;; gap — `resolve-nav-target` normalises each event to an `{:id :params}`
-;; target so ONE redirect path handles them all.
+;; The guard must gate all three, not just `:rf.route/navigate`: gating
+;; navigate alone fails open on the most common path — a logged-out user
+;; who typed `/settings`, reloaded a protected page, or followed an anchor
+;; would reach the route (and its on-match drain would fire a request the
+;; real backend would 401). `resolve-nav-target` normalises each event to
+;; an `{:id :params}` target so one redirect path handles them all.
 ;;
-;; The redirect: the `:before` SKIPS the original handler (`:rf/skip-
-;; handler?`) so the protected route's slice never commits and its
-;; on-match drain never fires, then dispatches `:rf.route/navigate
-;; :realworld.auth/login` itself. This is the same login navigation the
-;; programmatic path produced, but it works uniformly for ALL three
-;; events — the runtime selects the handler from the ORIGINAL event id
-;; before interceptors run, so rewriting `[:coeffects :event]` across
-;; event ids (e.g. feeding a route-id to `:rf.route/handle-url-change`'s
-;; URL slot) would run the wrong handler. Skip-and-dispatch sidesteps
-;; that entirely.
+;; The redirect: the `:before` skips the original handler
+;; (`:rf/skip-handler?`) so the protected route's slice never commits and
+;; its on-match drain never fires, then dispatches `:rf.route/navigate
+;; :realworld.auth/login`. The runtime selects the handler from the original
+;; event id before interceptors run, so rewriting `[:coeffects :event]`
+;; across event ids would run the wrong handler — skip-and-dispatch
+;; sidesteps that.
 ;;
-;; Bounce-back (`:return-to`). The headline of an auth guard is returning
-;; the user to where they were headed once they sign in. `:rf.route/navigate`
-;; opts (the 3rd arg) are NOT persisted by the runtime — the navigate
-;; handler reads `:query` / `:fragment` / `:replace?` / `:scroll` /
-;; `:bypass-leave-guard?` from opts and drops everything else (Spec 012
-;; §Navigation is an event), so an opts-borne `:return-to` would silently
-;; evaporate. We therefore stash the original target in `app-db` instead:
-;; the `:before` writes it to `[:auth :return-to]` via a `:db` effect
-;; (committed before the login dispatch's `:fx` runs, so the redirect's
-;; slice merge preserves it). The auth machine's `:store-session` action
-;; reads that slot on a successful login and bounces there (falling back
-;; to home), then clears it (auth.cljs).
+;; Bounce-back (`:return-to`): `:rf.route/navigate` opts (the 3rd arg) are
+;; not persisted by the runtime — the navigate handler reads `:query` /
+;; `:fragment` / `:replace?` / `:scroll` / `:bypass-leave-guard?` and drops
+;; the rest — so an opts-borne `:return-to` would evaporate. Instead the
+;; `:before` stashes the target at `[:auth :return-to]` via a `:db` effect
+;; (committed before the login dispatch's `:fx` runs). The auth machine's
+;; `:store-session` action reads that slot on a successful login, bounces
+;; there (falling back to home), and clears it (auth.cljs).
 
 (defn- resolve-nav-target
   "Normalise a navigation event into its target `{:id <route-id>
@@ -207,15 +193,15 @@
 
     nil))
 
-;; EP-0022: register the guard as a named interceptor here, then reference it
-;; by id (`:realworld.routing/auth-guard`) from the demo frame's `:interceptors`
+;; Register the guard as a named interceptor here, then reference it by id
+;; (`:realworld.routing/auth-guard`) from the demo frame's `:interceptors`
 ;; in core.cljs. `reg-interceptor` runs at load time, and core.cljs requires
-;; this ns, so the descriptor is in place before the frame-provider creates the
-;; frame and resolves the id.
+;; this ns, so the descriptor is in place before the frame-provider creates
+;; the frame and resolves the id.
 (rf/reg-interceptor :realworld.routing/auth-guard
-  {:doc "Route-level auth guard (Spec 012 §Redirects and guards): redirect
-         unauthenticated users away from `:requires-auth`-tagged routes to
-         login, stashing the intended target for post-login bounce-back."}
+  {:doc "Route-level auth guard: redirect unauthenticated users away from
+         `:requires-auth`-tagged routes to login, stashing the intended
+         target for post-login bounce-back."}
   {:before (fn auth-guard-before [ctx]
              (if-let [{:keys [id params]} (resolve-nav-target
                                             (get-in ctx [:coeffects :event]))]
@@ -265,19 +251,19 @@
            (.. js/window -location -hash))))
 
 ;; A named handler so the listener install is idempotent: repeated
-;; `install-router!` (shadow hot reload, or a co-required test host invoking run
-;; twice) remove-then-add the same Var, so duplicate popstate listeners never
-;; stack — the same idea as the `when-not @react-root` mount guard.
+;; `install-router!` (hot reload, or a co-required test host calling run
+;; twice) remove-then-add the same Var, so duplicate popstate listeners
+;; never stack — the same idea as the `when-not @react-root` mount guard.
 ;;
-;; The URL-change dispatch targets the URL-owner frame, resolved at call time
-;; via `routing/url-owner-frame-id` (Spec 012 §popstate drives the URL owner).
-;; The owner is the `:url-bound? true` demo frame the frame-provider creates in
-;; core.cljs. Targeting it explicitly matters: a bare `(rf/dispatch …)` with no
-;; frame would raise `:rf.error/no-frame-context`. This example uses its own
-;; base-path-aware listener (rather than the framework's
-;; `rf/install-history-listener!`, which reads the unstripped browser URL),
-;; because it serves from a `/realworld/` sub-path and strips it in
-;; `current-url`; the owner-targeting contract is the same either way.
+;; The URL-change dispatch targets the URL-owner frame, resolved at call
+;; time via `routing/url-owner-frame-id`. The owner is the `:url-bound? true`
+;; demo frame the frame-provider creates in core.cljs. Targeting it
+;; explicitly matters: a bare `(rf/dispatch …)` with no frame would raise
+;; `:rf.error/no-frame-context`. This example uses its own base-path-aware
+;; listener (rather than the framework's `rf/install-history-listener!`,
+;; which reads the unstripped browser URL) because it serves from a
+;; `/realworld/` sub-path; the owner-targeting contract is the same either
+;; way.
 (defn- on-popstate [_]
   (when-let [owner (routing/url-owner-frame-id)]
     (rf/dispatch [:rf.route/handle-url-change (current-url)] {:frame owner})))

--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -3,8 +3,8 @@
 
    These describe the shape of every wire payload the RealWorld API returns,
    plus the shape of each app-db slice that holds them. The schemas are
-   registered with re-frame2 via `reg-app-schemas` (the bulk plural form)
-   for path-based validation per Spec 010.
+   registered for path-based validation via `reg-app-schemas`. See the
+   schemas how-to: ../../../docs/guide/how-to/validate-with-schemas.md
 
    The RealWorld API spec is documented at:
      https://github.com/gothinkster/realworld/tree/main/api
@@ -17,9 +17,9 @@
    - Authentication tokens are JWT strings, returned as the `:token` field
      of the `User` payload after login or registration."
   (:require [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
-            ;; rf/reg-app-schemas resolves at the call site below.
+            ;; Schemas ship in the re-frame2-schemas artefact. Requiring
+            ;; the ns registers its hooks so `rf/reg-app-schemas` resolves
+            ;; at the call site below.
             [re-frame.schemas])
   (:require-macros [re-frame.core :refer [with-frame]]))
 
@@ -30,16 +30,16 @@
 (def User
   "The authenticated user's profile. Returned by /users/login,
    /users (register), and /user (current user)."
-  ;; EP-0025 / Spec 015: the JWT is classified at the transient slot that
-  ;; introduces it, via the per-slot `:sensitive?` malli property on the
-  ;; `:decode` schema (the transient-response-body route — the one schema-prop
-  ;; route that survives). `UserResponse` is the `:decode` schema for the login
-  ;; / register / session-restore replies, so this redacts the token out of any
-  ;; off-box capture of the response body. The durable copy at [:auth :token]
-  ;; is classified separately by the `:auth/classify-token` commit-plane
-  ;; `:sensitive` effect (core.cljs) — classification does not propagate, so
-  ;; each surface a secret crosses is declared on its own; the Bearer header is
-  ;; on the framework's built-in carrier denylist.
+  ;; Classify the JWT at the transient slot that introduces it, via the
+  ;; per-slot `:sensitive?` Malli property on the `:decode` schema.
+  ;; `UserResponse` is the `:decode` schema for the login / register /
+  ;; session-restore replies, so this redacts the token out of any off-box
+  ;; capture of the response body. The durable copy at [:auth :token] is
+  ;; classified separately by `:auth/classify-token` (core.cljs) —
+  ;; classification does not propagate, so each surface a secret crosses is
+  ;; declared on its own; the Bearer header is on the framework's built-in
+  ;; carrier denylist. See the keep-secrets how-to:
+  ;; ../../../docs/guide/how-to/keep-secrets-out-of-traces.md
   [:map
    [:email    :string]
    [:token    {:sensitive? true} :string]
@@ -85,7 +85,8 @@
 ;;
 ;; The Conduit API wraps every payload in a singular/plural top-level key.
 ;; These schemas describe the wire-shape envelope; they are passed as the
-;; `:decode` key to `:rf.http/managed` per Spec 014 §Schema-driven decode.
+;; `:decode` key to `:rf.http/managed`. See the HTTP guide on `:decode`:
+;; ../../../docs/resources/http.md#validating-the-body-with-decode
 
 (def UserResponse
   "POST /users/login, POST /users (register), GET /user."
@@ -119,11 +120,10 @@
   [:map [:tags [:vector :string]]])
 
 ;; ============================================================================
-;; APP-DB SLICES — Pattern-RemoteData shape per resource
+;; APP-DB SLICES — remote-data slice shape per resource
 ;; ============================================================================
 ;;
-;; Every slice that holds remote data follows the standard 5-key shape from
-;; spec/Pattern-RemoteData.md.
+;; Every slice that holds remote data follows the same 5-key shape.
 
 (def RequestSlice
   "The standard remote-data lifecycle slice. Generic over the :data type.
@@ -160,13 +160,13 @@
      [:id     :keyword]
      [:params [:maybe :map]]]]])
 
-;; Machine snapshots live in the framework-owned **runtime-db** partition at
-;; [:rf.runtime/machines :snapshots <id>], NOT in app-db. `reg-app-schema`
-;; validates the app-db partition only (EP-0001, Mike ruling #11), so a machine
-;; snapshot's shape is validated through the machine's own `[:schemas :data]` slot
-;; (which describes the snapshot's `:data` map) rather than an app-schema on a
-;; runtime path. The `*Data` schemas below are attached as `[:schemas :data]` where
-;; each machine is registered (auth.cljs / tags.cljs / settings.cljs).
+;; Machine snapshots live in the runtime-db partition at
+;; [:rf.runtime/machines :snapshots <id>], not in app-db. `reg-app-schema`
+;; validates the app-db partition only, so a machine snapshot's shape is
+;; validated through the machine's own `[:schemas :data]` slot (which
+;; describes the snapshot's `:data` map) rather than an app-schema on a
+;; runtime path. The `*Data` schemas below are attached as `[:schemas :data]`
+;; where each machine is registered (auth.cljs / tags.cljs / settings.cljs).
 
 (def AuthFlowData
   "The `:data` slot of the `:auth/flow` machine snapshot."
@@ -174,11 +174,10 @@
    [:error [:maybe :string]]])
 
 (def TagsData
-  "The `:data` slot of the `:realworld/tags` machine snapshot — the
-   :data-region machine variant of Pattern-RemoteData. The
-   state-keyword IS the Pattern-RemoteData status enum; `:data` carries
-   the items, error, loaded-at, and attempt fields that the slice form
-   would store in the slice itself."
+  "The `:data` slot of the `:realworld/tags` machine snapshot, where the
+   remote-data lifecycle lives entirely in the machine. The state-keyword
+   is the status enum; `:data` carries the items, error, loaded-at, and
+   attempt fields the slice form would store in the slice itself."
   [:map
    [:tags      [:vector :string]]
    [:error     [:maybe :any]]
@@ -186,11 +185,11 @@
    [:attempt   :int]])
 
 (def SettingsFormData
-  "The `:data` slot of the `:settings/form` machine snapshot — the
-   :form-region machine variant of Pattern-Forms. The state-keyword
-   IS the form lifecycle (`:neutral` / `:incorrect` / `:correct`
-   + `:submitting`); `:data` carries the draft + per-field
-   validation state + the projected submit-error string."
+  "The `:data` slot of the `:settings/form` machine snapshot, where the
+   form lifecycle lives entirely in the machine. The state-keyword is the
+   lifecycle (`:neutral` / `:incorrect` / `:correct` + `:submitting`);
+   `:data` carries the draft + per-field validation state + the projected
+   submit-error string."
   [:map
    [:draft        :map]
    [:submitted    [:maybe :map]]
@@ -210,10 +209,10 @@
    [:submit-error [:maybe :string]]])
 
 (def EditorSlice
-  ;; NOTE: the state vocabulary (`:mode` = :create/:edit, lifecycle `:status`)
-  ;; lives in the :ui/article-editor machine snapshot (runtime-db), NOT this
-  ;; app-db slice — see `editor-slice` in article_editor.cljs (:54-67), whose
-  ;; map never carries `:mode`/`:status`. The slice carries only the data.
+  ;; The state vocabulary (`:mode` = :create/:edit, lifecycle `:status`)
+  ;; lives in the :ui/article-editor machine snapshot (runtime-db), not this
+  ;; app-db slice — see `editor-slice` in article_editor.cljs. The slice
+  ;; carries only the data.
   [:map
    [:slug [:maybe :string]]
    [:draft [:map
@@ -230,10 +229,8 @@
    [:errors :map]
    [:touched [:set :keyword]]
    [:submit-attempted? {:optional true} :boolean]
-   ;; Materialised output of the :editor/can-submit? flow (Spec 013).
-   ;; Optional because the flow's first walk (right after the handler,
-   ;; before the db install) lands one event after :editor/initialise
-   ;; (Spec 013 §Sequencing).
+   ;; Output of the :editor/can-submit? flow. Optional because the flow's
+   ;; first walk lands one event after :editor/initialise.
    [:can-submit? {:optional true} :boolean]
    [:submit-error [:maybe :string]]])
 
@@ -241,24 +238,22 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 ;;
-;; Path-based schema attachment per Spec 010. The framework validates writes
-;; to these paths in development.
+;; Path-based schema attachment. The framework validates writes to these
+;; paths in development.
 ;;
-;; This example uses the bulk plural form `rf/reg-app-schemas`:
-;; a feature-modular app declares 5–20 schemas in one place, so a single
+;; This example uses the bulk plural form `rf/reg-app-schemas`: a single
 ;; `{path -> schema}` map reads more cleanly than a tower of singular
-;; `reg-app-schema` calls. Source-coords for the bulk call stamp every
-;; registered entry.
-
-;; All paths here are app-db paths. Machine snapshots are NOT app-db — they
-;; live in runtime-db and are validated through each machine's `[:schemas :data]`
-;; (the *Data schemas above), so they do not appear in this app-schema map.
+;; `reg-app-schema` calls.
 ;;
-;; EP-0002: reg-app-schemas is frame-local, so it needs a frame in context; a
-;; bare ns-load call would raise :rf.error/no-frame-context. `with-frame` names
-;; the target frame, `:rf/default`, so the schemas register against that id at
-;; load time. The frame-provider in core.cljs creates `:rf/default` at the
-;; render root and picks these schemas up when it does.
+;; All paths here are app-db paths. Machine snapshots are not app-db — they
+;; live in runtime-db and are validated through each machine's
+;; `[:schemas :data]` (the *Data schemas above), so they do not appear here.
+;;
+;; `reg-app-schemas` is frame-local, so it needs a frame in context; a bare
+;; ns-load call would raise :rf.error/no-frame-context. `with-frame` names
+;; the target frame, `:rf/default`, so the schemas register against that id
+;; at load time. The frame-provider in core.cljs creates `:rf/default` and
+;; picks these schemas up.
 (with-frame :rf/default
  (rf/reg-app-schemas
   {[:auth]                          AuthSlice

--- a/examples/reagent/realworld/settings.cljs
+++ b/examples/reagent/realworld/settings.cljs
@@ -1,47 +1,38 @@
 (ns realworld.settings
   "User settings page for the RealWorld (Conduit) example.
 
-   This namespace demonstrates the **`:form-region` machine variant** of
-   Pattern-Forms: the settings form's lifecycle is modelled as a single
-   state machine — `:settings/form` — whose state-keyword IS the form
-   lifecycle (`:neutral` / `:incorrect` / `:correct` / `:submitting`).
-   The other four forms in realworld (`:auth :login-form`,
-   `:auth :register-form`, `:editor`, `:comment-form`) stay in the
-   original `{:draft :submitted :status :errors :touched :submit-error}`
-   slice form, so the two shapes sit side-by-side and a reader can
-   compare. The README's §'Pattern-Forms — two shapes side-by-side'
-   has the worked comparison plus a 'when to choose each' note.
+   Here the form's lifecycle lives entirely in a state machine,
+   `:settings/form`, whose state-keyword is the form lifecycle (`:neutral`
+   / `:incorrect` / `:correct` / `:submitting`). The other four forms in
+   realworld (`:auth :login-form`, `:auth :register-form`, `:editor`,
+   `:comment-form`) keep the plain
+   `{:draft :submitted :status :errors :touched :submit-error}` slice
+   shape, so a reader can compare the two shapes side by side. See the
+   forms how-to: ../../../docs/guide/how-to/build-a-form.md
 
    The shape:
 
-   - The Pattern-Forms lifecycle (`:neutral` / `:incorrect` / `:correct`
-     + `:submitting`) maps **one-to-one** onto machine states; the
-     slice's `:status` field disappears because the region's
-     state-keyword IS the status.
+   - The form lifecycle (`:neutral` / `:incorrect` / `:correct` +
+     `:submitting`) maps one-to-one onto machine states; the slice's
+     `:status` field is gone because the state-keyword is the status.
    - The draft, errors, touched, submit-error, submitted, and loaded-at
-     fields live in the machine's shared `:data` map (no separate
-     app-db slice).
-   - The slice's `:submitting?` derived boolean sub collapses into a
-     per-state `:settings/in-flight` tag queried with `rf/machine-has-tag?`.
+     fields live in the machine's `:data` map (no app-db slice).
+   - The slice's `:submitting?` boolean becomes a per-state
+     `:settings/in-flight` tag queried with `rf/machine-has-tag?`.
 
-   Logout stays on the existing auth machine path (`:auth/flow`).
+   Logout stays on the auth machine path (`:auth/flow`).
 
-   ---
-   Production-shape note. Realworld is a worked sketch, and this form
-   keeps the example's existing eager-submit behaviour (the user
-   pressing 'Update Settings' triggers a server roundtrip without a
-   prior client-side validate step). The `:submit-invalid` /
-   `:incorrect` transition exists in the machine so the lifecycle is
-   complete, and the headless tests exercise it via direct broadcasts —
-   in a real app you'd run a Malli validate against the draft inside
-   `:settings/submit` and dispatch `:submit-invalid` when it returned
-   errors, matching Pattern-Forms' §Standard events table."
+   This form submits eagerly: pressing 'Update Settings' triggers a server
+   roundtrip with no prior client-side validate step. The `:submit-invalid`
+   / `:incorrect` transition exists so the lifecycle is complete; a real
+   app would run a Malli validate against the draft inside `:settings/submit`
+   and dispatch `:submit-invalid` when it returned errors."
   (:require [re-frame.core :as rf]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine (called
-            ;; below at ns-load) and the `:rf/machine` /
-            ;; `:rf/machine-has-tag?` framework subs resolve.
+            ;; State machines ship in the re-frame2-machines artefact.
+            ;; Requiring the ns registers its hooks so `rf/reg-machine`
+            ;; (called below) and the `:rf/machine` / `:rf/machine-has-tag?`
+            ;; subs resolve. See the machines guide:
+            ;; ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh])
@@ -63,11 +54,11 @@
    :loaded-at    nil})
 
 ;; ============================================================================
-;; THE MACHINE — :settings/form  (one region; Pattern-Forms lifecycle)
+;; THE MACHINE — :settings/form  (one region; the form lifecycle)
 ;; ============================================================================
 ;;
-;; The Pattern-Forms lifecycle maps one-to-one onto machine states.
-;; Compare with the slice form used by the other four realworld forms:
+;; The form lifecycle maps one-to-one onto machine states. Compare with the
+;; slice form used by the other four realworld forms:
 ;;
 ;;     ;; SLICE FORM (used by :auth :login-form, :auth :register-form, :editor, :comment-form)
 ;;     ;; The slice carries an explicit :status keyword.
@@ -85,23 +76,22 @@
 ;;              :submitted nil :loaded-at nil}
 ;;      :tags  #{...}}
 ;;
-;; Pattern-Forms' load-bearing boolean — `:submitting?` — becomes a
-;; tag-shaped query against the active state:
+;; The form's load-bearing boolean — `:submitting?` — becomes a tag query
+;; against the active state:
 ;;
 ;;     :submitting?  = (= :submitting status)            ;; slice form
 ;;     :submitting?  = @(rf/machine-has-tag? :settings/form :settings/in-flight)
 ;;
 ;; The view doesn't need to know which state-keyword carries the
-;; "in-flight" intent; the tag does. That is the load-bearing
-;; pedagogical move.
+;; "in-flight" intent; the tag does.
 
 (def settings-form-machine
   {:initial :neutral
    :data    initial-data
-   ;; Snapshot :data validation. The snapshot lives in runtime-db
-   ;; ([:rf.runtime/machines :snapshots :settings/form]), so its :data shape is
-   ;; validated here via [:schemas :data] — not via an app-schema (EP-0001,
-   ;; Mike ruling #11: app schemas validate the app-db partition only).
+   ;; The snapshot lives in runtime-db
+   ;; ([:rf.runtime/machines :snapshots :settings/form]), so its :data shape
+   ;; is validated here via [:schemas :data], not via an app-schema (app
+   ;; schemas validate the app-db partition only).
    :schemas {:data schema/SettingsFormData}
 
    :actions
@@ -125,10 +115,9 @@
                  (assoc :submit-error nil))})
 
     :set-errors
-    ;; :submit-invalid carries the per-field error map. We also touch
-    ;; every error field so the inline error shows even on fields the
-    ;; user hasn't yet interacted with (per Pattern-Forms §Error
-    ;; visibility — submit-attempted reveals all errors).
+    ;; :submit-invalid carries the per-field error map. Touch every error
+    ;; field too, so the inline error shows even on fields the user hasn't
+    ;; interacted with yet.
     (fn action-set-errors [{data :data [_ {:keys [errors]}] :event}]
       {:data (-> data
                  (assoc :errors errors)
@@ -214,9 +203,8 @@
 ;; PUBLIC EVENT API
 ;; ============================================================================
 ;;
-;; Event names stay the same as the slice-form version so views and
-;; sibling namespaces (auth.cljs) need no change. Each one fans out to
-;; one or more machine broadcasts.
+;; Each event fans out to one or more machine broadcasts; views and sibling
+;; namespaces dispatch these names and never touch the machine directly.
 
 (rf/reg-event :settings/initialise
   {:doc "Reset the settings-form machine to its initial state.
@@ -245,14 +233,13 @@
                       [:edit {:field field :value value}]]]]}))
 
 (rf/reg-event :settings/submit
-  {:doc "Save the user-settings draft. NO retry — single user-initiated
-         submission per click (Spec 014). Broadcasts :submit-valid into
-         the machine (which transitions to :submitting and clears
-         prior errors); on reply, :settings/submit-success /
-         :settings/submit-error broadcast :submit-succeeded /
-         :submit-failed."
+  {:doc "Save the user-settings draft. No retry — one submission per click.
+         Broadcasts :submit-valid into the machine (which transitions to
+         :submitting and clears prior errors); on reply,
+         :settings/submit-success / :settings/submit-error broadcast
+         :submit-succeeded / :submit-failed."
    :rf.http/decode-schemas [schema/UserResponse]}
-  ;; EP-0001: the machine snapshot is durable runtime-db state.
+  ;; The machine snapshot lives in runtime-db.
   (fn handler-settings-submit [{rt :rf.db/runtime} _]
     (let [draft (get-in rt [:rf.runtime/machines :snapshots :settings/form :data :draft])]
       {:fx [[:dispatch [:settings/form
@@ -292,12 +279,10 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; The view consumes the same names a slice-form reader would
-;; (`:settings/draft`, `:settings/submit-error`); only the source
-;; changed. The `:settings/submitting?` boolean stays for backward
-;; compatibility with the view and tests — internally it's now an
-;; `rf/machine-has-tag?` query (a tag-shaped read) instead of a slice-field
-;; comparison.
+;; The view consumes plain names (`:settings/draft`,
+;; `:settings/submit-error`); the source is the machine's `:data`.
+;; `:settings/submitting?` is an `rf/machine-has-tag?` query under the hood,
+;; presented to the view as a plain boolean.
 
 (rf/reg-sub :settings/draft
   {:doc "The settings form draft, projected off the machine's :data."}
@@ -313,9 +298,9 @@
     (get-in snap [:data :submit-error])))
 
 (rf/reg-sub :settings/submitting?
-  {:doc "Tag-shaped read of the form's in-flight intent — a tag query
-         standing in for a slice-form `(= :submitting status)` comparison;
-         views see a plain boolean."}
+  {:doc "Tag-shaped read of the form's in-flight intent — stands in for a
+         slice-form `(= :submitting status)` comparison; views see a plain
+         boolean."}
   :<- [:rf/machine-has-tag? :settings/form :settings/in-flight]
   (fn sub-settings-submitting? [in-flight? _]
     (boolean in-flight?)))

--- a/examples/reagent/realworld/ssr.cljc
+++ b/examples/reagent/realworld/ssr.cljc
@@ -13,10 +13,10 @@
             #?(:cljs [cljs.reader :as reader])))
 
 (def ssr-app-slice-keys
-  "Top-level **app-db** slices the SSR payload exports. These are
-  application data only — the framework-owned subsystem trees (routing,
-  machines, elision) live in the separate runtime-db partition, not here
-  (EP-0001 two-partition frame), and ride the payload under :rf/runtime-db."
+  "Top-level app-db slices the SSR payload exports. These are application
+  data only — the framework's subsystem trees (routing, machines, elision)
+  live in the separate runtime-db partition and ride the payload under
+  :rf/runtime-db."
   [:auth
    :articles
    :article
@@ -37,13 +37,14 @@
    :rf.runtime/machines])
 
 (defn exportable-app-db [app-db]
-  ;; Keep secrets out of the SSR payload. The bearer JWT lives at [:auth :token];
-  ;; embedding it in server-rendered HTML would leak a live credential into page
-  ;; source (view-source-visible, proxy-logged, CDN-cacheable). Redact it at the
-  ;; payload boundary. The client re-establishes [:auth :token] on hydrate via
-  ;; `:auth/initialise` (auth.cljs), which reads it back from localStorage
-  ;; through the `:auth.session/token` recordable-generator coeffect (EP-0017).
-  ;; So dropping the token from the payload costs nothing and stays replay-sound.
+  ;; Keep secrets out of the SSR payload. The bearer JWT lives at
+  ;; [:auth :token]; embedding it in server-rendered HTML would leak a live
+  ;; credential into page source (view-source-visible, proxy-logged,
+  ;; CDN-cacheable). Redact it at the payload boundary. The client
+  ;; re-establishes [:auth :token] on hydrate via `:auth/initialise`
+  ;; (auth.cljs), which reads it back from localStorage through the
+  ;; `:auth.session/token` recordable coeffect. So dropping the token from
+  ;; the payload costs nothing and stays replay-sound.
   (cond-> (select-keys app-db ssr-app-slice-keys)
     (contains? app-db :auth) (update :auth dissoc :token)))
 
@@ -68,8 +69,8 @@
        (reader/read-string (.-textContent el)))))
 
 #?(:cljs
-   ;; EP-0002: the caller names the frame to hydrate. Making the target explicit
-   ;; lets a non-default or multi-frame client hydrate the right frame by passing
+   ;; The caller names the frame to hydrate. Making the target explicit lets
+   ;; a non-default or multi-frame client hydrate the right frame by passing
    ;; its own frame-id.
    (defn hydrate-client! [frame-id]
      (when-let [payload (read-server-payload)]

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -2,47 +2,42 @@
   "Popular-tags list plus home-page navigation helpers (the `/tag/:tag`
    PATH route + the `?feed=` / `?page=` query).
 
-   This namespace demonstrates the **`:data-region` machine variant** of
-   Pattern-RemoteData: the popular-tags lifecycle is modelled
-   as a single-region state machine — `:realworld/tags` — whose
-   state-keyword IS the Pattern-RemoteData status. Every other
-   remote-data resource in realworld (`:articles`, `:feed`, `:article`,
-   `:comments`, `:profile`, `:profile.articles`, `:profile.favorites`)
-   stays in the original 5-key slice form, so the two shapes sit
-   side-by-side and a reader can compare. The README's
-   §'Pattern-RemoteData — two shapes side-by-side' has the worked
-   comparison plus a 'when to choose each' note.
+   Here the popular-tags lifecycle lives entirely in a single-region state
+   machine, `:realworld/tags`, whose state-keyword is the remote-data
+   status. Every other remote-data resource in realworld (`:articles`,
+   `:feed`, `:article`, `:comments`, `:profile`, `:profile.articles`,
+   `:profile.favorites`) keeps the plain 5-key slice shape, so a reader can
+   compare the two shapes side by side. See the machines guide:
+   ../../../docs/machines/index.md
 
    The shape:
 
-   - The Pattern-RemoteData status enum (`:idle :loading :fetching
-     :loaded :error`) maps **one-to-one** onto machine states; the
-     slice's `:status` field disappears.
-   - The items, error, loaded-at, and attempt fields live in the
-     machine's shared `:data` map (no separate app-db slice).
-   - The slice's `:loading?` / `:fetching?` derived boolean subs
-     collapse into per-state `:tags` queried with `rf/machine-has-tag?`.
+   - The status enum (`:idle :loading :fetching :loaded :error`) maps
+     one-to-one onto machine states; the slice's `:status` field is gone.
+   - The items, error, loaded-at, and attempt fields live in the machine's
+     `:data` map (no app-db slice).
+   - The slice's `:loading?` / `:fetching?` booleans become per-state
+     `:tags` queried with `rf/machine-has-tag?`.
 
-   Routing pieces (`:home/load`, `:home/show-global-feed`, etc.) sit
-   below — they dispatch `:tags/load` so the popular-tags machine fetches
-   when the home route activates."
+   Routing pieces (`:home/load`, `:home/show-global-feed`, etc.) sit below;
+   they dispatch `:tags/load` so the popular-tags machine fetches when the
+   home route activates."
   (:require [re-frame.core :as rf]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/reg-machine (called
-            ;; below at ns-load) and the `:rf/machine` / `:rf/machine-has-tag?`
-            ;; framework subs resolve.
+            ;; State machines ship in the re-frame2-machines artefact.
+            ;; Requiring the ns registers its hooks so `rf/reg-machine`
+            ;; (called below) and the `:rf/machine` / `:rf/machine-has-tag?`
+            ;; subs resolve. See the machines guide:
+            ;; ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh]))
 
 ;; ============================================================================
-;; THE MACHINE — :realworld/tags  (one region; Pattern-RemoteData lifecycle)
+;; THE MACHINE — :realworld/tags  (one region; the remote-data lifecycle)
 ;; ============================================================================
 ;;
-;; The Pattern-RemoteData status enum maps one-to-one onto machine
-;; states. Compare with the slice form used by `:articles`,
-;; `:feed`, `:article`, ...:
+;; The status enum maps one-to-one onto machine states. Compare with the
+;; slice form used by `:articles`, `:feed`, `:article`, ...:
 ;;
 ;;     ;; SLICE FORM (used by the other seven remote-data resources)
 ;;     ;; The slice carries an explicit :status keyword.
@@ -52,19 +47,18 @@
 ;;     ;; The state-keyword IS the status; the rest lives in :data.
 ;;     {:state :loading :data {:tags [] :error nil :loaded-at nil :attempt 0} :tags #{...}}
 ;;
-;; Pattern-RemoteData's two view-load-bearing booleans:
+;; The two view-load-bearing booleans:
 ;;
 ;;     :loading?   = (= status :loading)                        ;; truly empty + in-flight
 ;;     :fetching?  = (#{:loading :fetching} status)             ;; any in-flight
 ;;
-;; become tag-shaped queries against the active state:
+;; become tag queries against the active state:
 ;;
 ;;     :loading?   = @(rf/machine-has-tag? :realworld/tags :tags/loading)
 ;;     :fetching?  = @(rf/machine-has-tag? :realworld/tags :tags/in-flight)
 ;;
 ;; The view doesn't need to know which state-keyword carries the
-;; "in-flight" intent; the tag does. That is the load-bearing
-;; pedagogical move.
+;; "in-flight" intent; the tag does.
 
 (def tags-machine
   {:initial :idle
@@ -72,9 +66,9 @@
              :error    nil
              :loaded-at nil
              :attempt  0}
-   ;; Validates the snapshot's :data slot at every macrostep boundary.
-   ;; The snapshot lives in runtime-db, so this — not an app-schema — is
-   ;; the validation surface (EP-0001, Mike ruling #11).
+   ;; Validates the snapshot's :data slot at every macrostep boundary. The
+   ;; snapshot lives in runtime-db, so this — not an app-schema — is the
+   ;; validation surface.
    :schemas {:data schema/TagsData}
 
    :actions
@@ -117,10 +111,9 @@
             :reset           {:target :idle   :action :reset-data}}}
 
     :fetching
-    ;; Re-fetch in flight while prior :tags are still rendered. Per
-    ;; Pattern-RemoteData: never blank the page; a subtle progress
-    ;; indicator at most. The :tags/loaded tag stays present so the
-    ;; render path that consumes :tags is unaffected.
+    ;; Re-fetch in flight while prior :tags are still rendered. Never blank
+    ;; the page; a subtle progress indicator at most. The :tags/loaded tag
+    ;; stays present so the render path that consumes :tags is unaffected.
     {:tags #{:tags/fetching :tags/in-flight :tags/loaded :tags/transient}
      :on   {:fetch-succeeded {:target :loaded :action :set-tags}
             :fetch-failed    {:target :error  :action :set-error}
@@ -154,8 +147,8 @@
     {:fx [[:dispatch [:realworld/tags [:reset]]]]}))
 
 ;; ============================================================================
-;; LOAD / LOADED / LOAD-FAILED — the three lifecycle events from
-;; Pattern-RemoteData, translated into machine broadcasts.
+;; LOAD / LOADED / LOAD-FAILED — the three remote-data lifecycle events,
+;; translated into machine broadcasts.
 ;; ============================================================================
 
 (rf/reg-event :tags/load
@@ -199,9 +192,9 @@
 ;; SUBSCRIPTIONS — slice-shape readers projected off the machine snapshot
 ;; ============================================================================
 ;;
-;; The view consumes the same names a slice-form reader would: `:tags/data`
-;; for the items, `:tags/error` for the error map. There are no `:loading?` /
-;; `:fetching?` booleans — views ask the tag instead:
+;; The view consumes plain names: `:tags/data` for the items, `:tags/error`
+;; for the error map. There are no `:loading?` / `:fetching?` booleans —
+;; views ask the tag instead:
 ;;
 ;;     @(rf/machine-has-tag? :realworld/tags :tags/loading)     ;; truly empty + in-flight
 ;;     @(rf/machine-has-tag? :realworld/tags :tags/in-flight)   ;; any in-flight (loading OR fetching)
@@ -237,12 +230,12 @@
 ;; The official-contract feed token for the authenticated "Your Feed".
 (def following-feed-token "following")
 
-;; EP-0001: the route slice is durable routing runtime-db state —
-;; `home-context` reads it off a runtime-db value (event handlers pass the
-;; `:rf.db/runtime` coeffect; the subs below compose off the public
-;; `[:rf.route/params]` / `[:rf.route/query]` framework subs). It normalises
-;; the two home routes into one `{:tag :feed :page}` context: the tag comes
-;; from the `/tag/:tag` route's params, the feed + page from the query.
+;; The route lives in runtime-db; `home-context` reads it off a runtime-db
+;; value (event handlers pass the `:rf.db/runtime` coeffect; the subs below
+;; compose off the public `[:rf.route/params]` / `[:rf.route/query]` subs).
+;; It normalises the two home routes into one `{:tag :feed :page}` context:
+;; the tag comes from the `/tag/:tag` route's params, the feed + page from
+;; the query.
 (defn home-context [runtime-db]
   (let [cur   (get-in runtime-db [:rf.runtime/routing :current] {})
         query (:query cur {})]
@@ -302,8 +295,8 @@
          tag-filtered list re-targets the `/tag/:tag` PATH route with the tag
          param preserved and `?page=` set; otherwise the home route carries
          `?feed=` + `?page=`. Changing `?page=` re-fires the active route's
-         `:on-match` (Spec 012 — same route, changed query), re-running
-         `:home/load` and the per-feed fetch with the new limit/offset window."}
+         `:on-match` (same route, changed query), re-running `:home/load` and
+         the per-feed fetch with the new limit/offset window."}
   (fn [{rt :rf.db/runtime} [_ page]]
     (let [{:keys [tag feed]} (home-context rt)]
       (if tag

--- a/examples/reagent/realworld_resources/article_editor.cljs
+++ b/examples/reagent/realworld_resources/article_editor.cljs
@@ -1,59 +1,49 @@
 (ns realworld-resources.article-editor
   "Create / edit / delete an article — the RealWorld-on-resources editor.
 
-   This is the form-heavy, flow-bearing page the focused `resources/` demo never
-   shows: the resources-variant counterpart of the `:rf.http/managed` sibling's
-   `realworld/article_editor.cljs`. It exercises three things at once:
+   A form-heavy, flow-bearing page that exercises three things at once:
 
    1. The WRITE is a MUTATION. `:realworld/save-article` POSTs `/articles`
       (create) or PUTs `/articles/:slug` (edit) and declares per-target scoped
-      `:invalidates` descriptors (EP-0016 D2) — the global article tags
-      (`[:article slug]` / `[:article-list]`) in `:rf.scope/global`, and the
-      session `[:feed]` in `{:from-db :realworld/session}` — so on success the
-      detail read, every list showing the article, AND the session feed refetch
-      with NO further wiring (the read→write→invalidate→refetch loop, end to
-      end; one mutation reaches both scopes). A `:realworld/delete-article`
-      mutation invalidates the same tags. The write
-      lifecycle is the mutation INSTANCE watched through `[:rf.mutation/state
-      {:instance …}]` — there is no `:status` app-db field.
+      `:invalidates` descriptors — the global article tags (`[:article slug]` /
+      `[:article-list]`) in `:rf.scope/global`, and the session `[:feed]` in
+      `{:from-db :realworld/session}` — so on success the detail read, every list
+      showing the article, AND the session feed refetch with NO further wiring
+      (one mutation reaches both scopes). A `:realworld/delete-article` mutation
+      invalidates the same tags. The write lifecycle is the mutation INSTANCE
+      watched through `[:rf.mutation/state {:instance …}]` — there is no `:status`
+      app-db field.
 
-   2. The can-submit gate is a SPEC 013 FLOW. `:editor/can-submit?` materialises
-      \"the draft is valid AND differs from the loaded baseline\" into app-db at
+   2. The can-submit gate is a FLOW. `:editor/can-submit?` materialises \"the
+      draft is valid AND differs from the loaded baseline\" into app-db at
       `[:editor :can-submit?]`. The submit handler reads it as plain data (no
       mid-handler subscribe); the submit button reads it through a plain sub over
-      the flow's `:output-path` (Spec 013 §Sub integration). The flow is registered
-      per-frame from `:editor/initialise` via `:rf.fx/reg-flow` so it binds to
-      whatever frame the app booted on.
+      the flow's `:output-path`. The flow is registered per-frame from
+      `:editor/initialise` via `:rf.fx/reg-flow` so it binds to whatever frame the
+      app booted on. See the flow glossary:
+      ../../../docs/guide/glossary.md#flow.
 
    3. A navigation `:can-leave` guard. The editor route declares
       `:can-leave [:editor/can-leave?]`; a dirty draft blocks navigation away and
-      the app-shell renders a confirm dialog off the `:rf/pending-navigation`
-      sub (see core.cljs). Clean (or saved) drafts leave freely.
+      the app-shell renders a confirm dialog off the `:rf/pending-navigation` sub
+      (see core.cljs). Clean (or saved) drafts leave freely. See route guard:
+      ../../../docs/routing/glossary.md#route-guard.
 
-   The save / delete SUCCESS continuation (navigate to the saved article, or
-   home on delete) is the mutation's call-site `:reply-to [:editor/replied]`
-   target (EP-0016 D1) — the same idiom settings.cljs uses. When the runtime
-   accepts the reply, it dispatches `[:editor/replied reply]` once, AFTER the
-   `:invalidates` staled the lists + feed and the instance settled; the
-   continuation branches save-vs-delete on the reply value. Save and delete
-   share one instance, so they share one continuation. (Only the seed-on-load
-   reaction stays a Form-3 reaction — it watches a RESOURCE read settle, which
-   has no reply-side continuation.) The render bodies are pure functions of subs
-   and never dispatch out of band.
-
-   Contrast the sibling: its editor models the SAME page with Pattern-NineStates
-   (a parallel `:mode` × `:lifecycle` machine) + a managed-HTTP write whose
-   `:on-success` carries the continuation for free. Here the lifecycle IS the
-   mutation instance, the mode is the route, and the continuation is the
-   `:reply-to` target — the resources-variant expression of the same shapes."
+   The save / delete SUCCESS continuation (navigate to the saved article, or home
+   on delete) is the mutation's call-site `:reply-to [:editor/replied]` target —
+   the same idiom settings.cljs uses. When the runtime accepts the reply, it
+   dispatches `[:editor/replied reply]` once, AFTER the `:invalidates` staled the
+   lists + feed and the instance settled; the continuation branches save-vs-delete
+   on the reply value. Save and delete share one instance, so they share one
+   continuation. (Only the seed-on-load reaction stays a Form-3 reaction — it
+   watches a RESOURCE read settle, which has no reply-side continuation.) The
+   render bodies are pure functions of subs and never dispatch out of band."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.http.managed]
             [re-frame.resources]
-            ;; Flows ship in day8/re-frame2-flows (Spec 013). Loading the ns
-            ;; publishes its late-bind hooks so the `:rf.fx/reg-flow` effect
-            ;; resolves; without it the effect raises
-            ;; :rf.error/flows-artefact-missing.
+            ;; Flows runtime. Loading the ns publishes the hooks so the
+            ;; `:rf.fx/reg-flow` effect resolves; without it the effect raises.
             [re-frame.flows]
             [reagent.core :as r]
             [reagent.ratom :as ratom]
@@ -110,21 +100,20 @@
   :editor/save)
 
 ;; ============================================================================
-;; THE FLOW — :editor/can-submit?  (Spec 013 §Flows)
+;; THE FLOW — :editor/can-submit?
 ;; ============================================================================
 ;;
-;; Materialises a derived boolean — \"the draft passes client-side validation
-;; AND differs from the loaded baseline\" — into app-db at `[:editor
-;; :can-submit?]`. WHY A FLOW (Spec 013 §When to use a flow): the
-;; `:editor/submit` handler reads this value as plain app-db data to gate the
-;; submit (the \"other event handlers read the value\" criterion); a sub would
-;; force the handler to subscribe mid-handler. The submit button reads the same
-;; materialised value through a plain sub over the `:output-path`.
+;; Materialises a derived boolean — \"the draft passes client-side validation AND
+;; differs from the loaded baseline\" — into app-db at `[:editor :can-submit?]`.
+;; WHY A FLOW: the `:editor/submit` handler reads this value as plain app-db data
+;; to gate the submit; a sub would force the handler to subscribe mid-handler. The
+;; submit button reads the same materialised value through a plain sub over the
+;; `:output-path`. See the flow glossary: ../../../docs/guide/glossary.md#flow.
 ;;
 ;; Registered per-frame via `:rf.fx/reg-flow` from `:editor/initialise` (not at
-;; ns-load) so it binds to whatever frame the app booted on (Spec 013 §Dynamic
-;; toggle via fx). The flow's first walk fires on the NEXT drain; a fresh editor
-;; starts invalid + clean anyway, so the one-event lag carries no stale value.
+;; ns-load) so it binds to whatever frame the app booted on. The flow's first walk
+;; fires on the NEXT drain; a fresh editor starts invalid + clean anyway, so the
+;; one-event lag carries no stale value.
 
 (def can-submit-flow
   {:id     :editor/can-submit?
@@ -161,8 +150,8 @@
    ;; an edit's slug also stales its own detail entry. The create path has no
    ;; prior slug, so it stales only the lists (the new detail is read fresh on
    ;; navigate). The session feed lives in the session scope, so it gets its
-   ;; own per-target descriptor naming `{:from-db :realworld/session}`
-   ;; (EP-0016 D2) — one mutation reaches both scopes.
+   ;; own per-target descriptor naming `{:from-db :realworld/session}` — one
+   ;; mutation reaches both scopes.
    :invalidates   (fn [{:keys [slug]} _result]
                     [{:scope :rf.scope/global
                       :tags  (cond-> #{[:article-list]}
@@ -182,8 +171,8 @@
                    detail + lists + feed."
    :params-schema [:map [:slug :string]]
    :scope         :rf.scope/global
-   ;; Global article tags + the session feed, each in its own scope (EP-0016
-   ;; D2 — see :realworld/save-article above).
+   ;; Global article tags + the session feed, each in its own scope (see
+   ;; :realworld/save-article above).
    :invalidates   (fn [{:keys [slug]} _result]
                     [{:scope :rf.scope/global
                       :tags  #{[:article slug] [:article-list]}}
@@ -203,8 +192,7 @@
 (rf/reg-event :editor/initialise
   {:doc "Create-mode entry (`:realworld.editor/new` `:on-match`). Reset the
          editor slice to a blank draft, clear any prior save instance, and
-         register the `:editor/can-submit?` flow against the dispatching frame
-         (Spec 013 §Dynamic toggle via fx)."}
+         register the `:editor/can-submit?` flow against the dispatching frame."}
   (fn [{:keys [db]} _]
     {:db (assoc db :editor (editor-slice))
      :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
@@ -240,8 +228,8 @@
 (rf/reg-event :editor/release-article
   {:doc "Release the edit-mode article lease (dispatched on unmount). Drops the
          editor's owner on the article read so it can go inactive / GC. The
-         release path is mandatory for an app-minted lease (Spec 016 §Active
-         owners — event-created owners MUST have a matching release path)."}
+         release path is mandatory for an app-minted lease — event-created owners
+         MUST have a matching release path."}
   (fn [_ [_ slug]]
     (when slug
       {:fx [[:dispatch [:rf.resource/release-owner
@@ -262,10 +250,10 @@
 
 (rf/reg-event :editor/submit
   {:doc "Save the article. Reads the `:editor/can-submit?` FLOW output straight
-         off app-db (Spec 013 §Sub integration (a)) — a materialised derived
-         value consumed as plain data, no subscribe ceremony. Valid-and-dirty
-         fires the save mutation; an invalid draft re-runs validation to
-         populate the per-field error map; valid-but-unchanged is a no-op."}
+         off app-db — a materialised derived value consumed as plain data, no
+         subscribe ceremony. Valid-and-dirty fires the save mutation; an invalid
+         draft re-runs validation to populate the per-field error map;
+         valid-but-unchanged is a no-op."}
   (fn [{:keys [db]} _]
     (let [{:keys [slug draft]} (:editor db)
           can-submit? (get-in db [:editor :can-submit?])
@@ -290,25 +278,25 @@
                                        slug (assoc :slug slug))
                            :instance save-instance
                            ;; The save-success continuation is the call-site
-                           ;; `:reply-to` (EP-0016 D1) — not an off-render
-                           ;; reaction. The save and delete writes share one
-                           ;; instance, so they share one continuation that
-                           ;; branches on the reply (`:value` carries the saved
-                           ;; Article for a save; a delete returns no body).
+                           ;; `:reply-to` — not an off-render reaction. The save
+                           ;; and delete writes share one instance, so they share
+                           ;; one continuation that branches on the reply
+                           ;; (`:value` carries the saved Article for a save; a
+                           ;; delete returns no body).
                            :reply-to [:editor/replied]
                            :cause    [:submit :editor/save]}]]]}))))
 
 (rf/reg-event :editor/replied
   {:doc "The save / delete mutation completion continuation (the `:reply-to`
-         target, EP-0016 D1). Receives the canonical reply map appended as the
-         final arg, observed AFTER the mutation's `:invalidates` staled the
-         lists + feed and the instance settled (phase 6). On a successful SAVE
-         (`:value` carries the saved `{:article …}`), re-seed the editor from
-         the saved article so the draft is clean — the `:can-leave` guard won't
-         block — clear the instance, and navigate to the article detail. On a
-         successful DELETE (no `:article` in the reply value), clear the slice
-         + instance and go home. On `:error` the form already shows the error
-         off the instance state; nothing more to do."}
+         target). Receives the canonical reply map appended as the final arg,
+         observed AFTER the mutation's `:invalidates` staled the lists + feed and
+         the instance settled. On a successful SAVE (`:value` carries the saved
+         `{:article …}`), re-seed the editor from the saved article so the draft
+         is clean — the `:can-leave` guard won't block — clear the instance, and
+         navigate to the article detail. On a successful DELETE (no `:article` in
+         the reply value), clear the slice + instance and go home. On `:error` the
+         form already shows the error off the instance state; nothing more to
+         do."}
   (fn [{:keys [db]} [_ {:keys [status value]}]]
     (cond
       (not= :ok status) {}
@@ -348,7 +336,7 @@
 
 (rf/reg-sub :editor/field-error
   {:doc "Per-field validation error — revealed after the first submit attempt
-         OR once the field is touched (Pattern-Forms §Error visibility)."}
+         OR once the field is touched."}
   :<- [:editor/slice]
   (fn [e [_ field]]
     (when (or (:submit-attempted? e) (contains? (:touched e) field))
@@ -356,9 +344,9 @@
 
 (rf/reg-sub :editor/can-submit?
   {:doc "Reads the `:editor/can-submit?` FLOW output at its app-db `:output-path`
-         (Spec 013 §Sub integration (b)) — a flow's output is ordinary app-db
-         state read through a plain sub. Drives the submit button. nil until the
-         flow's first walk lands, which `(boolean …)` normalises to false."}
+         — a flow's output is ordinary app-db state read through a plain sub.
+         Drives the submit button. nil until the flow's first walk lands, which
+         `(boolean …)` normalises to false."}
   (fn [db _]
     (boolean (get-in db [:editor :can-submit?]))))
 
@@ -367,9 +355,10 @@
   (fn [e _] (not= (:draft e) (:baseline e))))
 
 (rf/reg-sub :editor/can-leave?
-  {:doc "The route `:can-leave` guard query (Spec 012 §Redirects and guards): a
-         clean (or just-saved) draft leaves freely; a dirty draft blocks and the
-         app shell shows the confirm dialog off `:rf/pending-navigation`."}
+  {:doc "The route `:can-leave` guard query: a clean (or just-saved) draft leaves
+         freely; a dirty draft blocks and the app shell shows the confirm dialog
+         off `:rf/pending-navigation`. See route guard:
+         ../../../docs/routing/glossary.md#route-guard."}
   :<- [:editor/dirty?]
   (fn [dirty? _] (not dirty?)))
 
@@ -449,10 +438,9 @@
    pure `editor-form-view`; the mount hook installs ONE off-render reaction that
    seeds the draft when an edit-mode article read settles with data. (The
    save/delete SUCCESS continuation is the mutation's `:reply-to
-   [:editor/replied]` target, EP-0016 D1, not an off-render reaction. A
-   reply-side continuation only exists for the mutation write; the seed reaction
-   watches a RESOURCE read settle, which has no reply-to, so it stays a Form-3
-   reaction.)
+   [:editor/replied]` target, not an off-render reaction. A reply-side
+   continuation only exists for the mutation write; the seed reaction watches a
+   RESOURCE read settle, which has no reply-to, so it stays a Form-3 reaction.)
    `rf/frame-handle` is captured here (during render, under the frame-provider),
    so the reaction's dispatch carries the frame; unmount disposes the reaction
    and releases the edit-mode article lease."

--- a/examples/reagent/realworld_resources/auth.cljs
+++ b/examples/reagent/realworld_resources/auth.cljs
@@ -1,41 +1,39 @@
 (ns realworld-resources.auth
   "Authentication for the RealWorld-on-resources example.
 
-   Auth is a COMMAND + state machine, not a cached read (Spec 016 §Scope: do
-   not contort login into a read-resource) — the bead's recommended shape. The
-   POST/GET for login / register / session-restore go via `:rf.http/managed`
-   from the machine's actions; the machine owns the `:idle → :submitting →
-   :authed | :error` lifecycle. (Settings UPDATE is the one auth-adjacent WRITE
-   that IS a mutation — it invalidates the profile read — and lives in
+   Auth is a COMMAND + state machine, not a cached read — don't contort login
+   into a read-resource. The POST/GET for login / register / session-restore go
+   via `:rf.http/managed` from the machine's actions; the machine owns the
+   `:idle → :submitting → :authed | :error` lifecycle. See the machines guide:
+   ../../../docs/machines/concepts.md. (Settings UPDATE is the one auth-adjacent
+   WRITE that IS a mutation — it invalidates the profile read — and lives in
    realworld-resources.mutations.)
 
    On LOGOUT the machine clears the session AND clears the session-scoped
-   resource cache: the user's personalised feed is cached under `[:rf.scope/
-   session {:username …}]`, and a logged-out (or next) user must never see it.
-   `:rf.resource/clear-scope` is the causal operation for exactly that (Spec
-   016 §clear-scope is causal). The concrete old scope is resolved with the
-   `rf/resolve-resource-scope` helper against the handler's COEFFECT db
-   (the pre-transition causal input) and the SAME named `:realworld/session`
-   resolver every resource site references (EP-0016 D3) — one scope-resolution
-   currency, including teardown. The public `:rf.scope/global` reads (article
-   lists, detail, profiles, tags) are unaffected — they are the same for
-   everyone, so logout leaves them alone.
+   resource cache: the user's personalised feed is cached under
+   `[:rf.scope/session {:username …}]`, and a logged-out (or next) user must
+   never see it. `:rf.resource/clear-scope` is the causal operation for that. The
+   concrete old scope is resolved with the `rf/resolve-resource-scope` helper
+   against the handler's COEFFECT db (the pre-transition causal input) and the
+   SAME named `:realworld/session` resolver every resource site references — one
+   scope-resolution currency, including teardown. The public `:rf.scope/global`
+   reads (article lists, detail, profiles, tags) are unaffected — they are the
+   same for everyone, so logout leaves them alone.
 
    On COLD-BOOT SESSION RESTORE the machine ALSO re-ensures the feed under the
    freshly-restored principal (`:auth/ensure-session-feed`). A
    `{:from-db :realworld/session}` subscription re-keys reactively when the
-   principal changes but, being passive, does NOT fetch (Spec 016 §A `{:from-db
-   …}` subscription re-keys); restore is the one principal switch with NO route
-   change (the home route was entered logged-out, so the feed was not planned),
-   so without an explicit re-ensure the feed would sit stuck at :idle. The
-   interactive login / logout paths re-enter the route and so need no explicit
-   ensure — see the `:auth/ensure-session-feed` event below for the full
-   rationale."
+   principal changes but, being passive, does NOT fetch; restore is the one
+   principal switch with NO route change (the home route was entered logged-out,
+   so the feed was not planned), so without an explicit re-ensure the feed would
+   sit stuck at :idle. The interactive login / logout paths re-enter the route
+   and so need no explicit ensure — see the `:auth/ensure-session-feed` event
+   below for the full rationale."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            ;; The Spec 005 state-machine ns lives in day8/re-frame2-machines.
-            ;; Loading the ns registers its late-bind hooks so rf/reg-machine
-            ;; (below) and the `:rf/machine` framework subs resolve.
+            ;; The state-machine ns. Loading it registers the hooks so
+            ;; rf/reg-machine (below) and the `:rf/machine` framework subs
+            ;; resolve.
             [re-frame.machines]
             [re-frame.resources]
             [realworld-resources.http :as rh]
@@ -71,20 +69,17 @@
         (.setItem ls "jwtToken" token)
         (.removeItem ls "jwtToken")))))
 
-;; EP-0017 (recordable coeffects): the saved JWT is a STORAGE world fact that
-;; `:auth/initialise` folds into durable app-db (and that drives session
-;; restore). A durable write must fold a RECORDED fact, not an ambient
-;; `localStorage` read at the write site, which replay / epoch-restore could not
-;; reproduce. The JWT is an APP-OWNED world-read that feeds durable state, so the
-;; canonical shape is a recordable GENERATOR (cofx.md §Decision tree):
-;; `:realworld-resources.session/token` is a `:recordable? true` registration
-;; whose value-returning supplier reads localStorage. The generator runs at
-;; processing-start on the boot dispatch, its value is recorded onto the causal
-;; token, and replay / epoch-restore re-presents the captured token verbatim
-;; rather than re-reading whatever localStorage holds now. (PROVIDED — no
-;; generator, value stamped at a boundary — is reserved for facts the app cannot
-;; supply itself, e.g. an SSR server stamp; a JWT the app reads from the host is
-;; not one of those.)
+;; The saved JWT is a storage world fact that `:auth/initialise` folds into
+;; durable app-db (and that drives session restore). A durable write must fold a
+;; RECORDED fact, not an ambient `localStorage` read at the write site, which
+;; replay / epoch-restore could not reproduce. So the JWT read is a recordable
+;; GENERATOR coeffect: `:realworld-resources.session/token` is a
+;; `:recordable? true` registration whose supplier reads localStorage. The
+;; generator runs at processing-start on the boot dispatch, its value is recorded
+;; onto the causal token, and replay / epoch-restore re-presents the captured
+;; token verbatim rather than re-reading whatever localStorage holds now. See
+;; recordable vs ambient coeffects:
+;; ../../../docs/guide/glossary.md#recordable-vs-ambient-coeffects.
 (defn read-jwt-from-storage
   "Read the saved JWT from localStorage (or nil) — the supplier body for the
    `:realworld-resources.session/token` recordable generator. nil when absent /
@@ -95,17 +90,16 @@
 
 (rf/reg-cofx :realworld-resources.session/token
   {:recordable? true
-   :doc "Recordable GENERATOR coeffect (EP-0017): the saved JWT (or nil), read
-         from localStorage. The registered supplier runs at processing-start on
-         the boot dispatch; its value is recorded onto the causal token and
+   :doc "Recordable GENERATOR coeffect: the saved JWT (or nil), read from
+         localStorage. The registered supplier runs at processing-start on the
+         boot dispatch; its value is recorded onto the causal token and
          re-presented verbatim under replay / epoch-restore — so the durable
          write that folds it (`:auth/initialise` → [:auth :token]) replays the
-         captured token, never a live localStorage re-read. A handler folds it
-         by declaring `:rf.cofx/requires [:realworld-resources.session/token]`
-         and reading it flat. A production dispatch carries NO cofx — the
-         generator IS the source; tests pin an exact value via the dispatch-site
-         `:rf.cofx` stub seam
-         (`{:rf.cofx {:realworld-resources.session/token \"…\"}}`)."}
+         captured token, never a live localStorage re-read. A handler folds it by
+         declaring `:rf.cofx/requires [:realworld-resources.session/token]` and
+         reading it flat. A production dispatch carries NO cofx — the generator IS
+         the source; tests pin an exact value via the dispatch-site `:rf.cofx`
+         stub seam (`{:rf.cofx {:realworld-resources.session/token \"…\"}}`)."}
   (fn [] (read-jwt-from-storage)))
 
 ;; ============================================================================
@@ -114,16 +108,15 @@
 
 (rf/reg-event :auth/store-session
   {:doc "Store the authenticated session. The JWT has ONE durable home — the
-         classified `[:auth :token]` path (EP-0025 commit-plane `:sensitive`
-         effect, declared by `:auth/classify-token` in core.cljs). The User
-         payload is stored at `[:auth :user]` with its `:token` field stripped
-         off (`dissoc`), so the JWT is NOT duplicated into the UNCLASSIFIED
-         `[:auth :user :token]` slot — a second durable copy there would ship
-         RAW to every off-box record (classification does not propagate; each
-         path is its own declaration). Views / subs read `:auth/user` for
-         identity (username, bio, image); none of them need the token, which
-         the bearer-auth interceptor reads from the classified `[:auth :token]`
-         path instead."}
+         classified `[:auth :token]` path (declared by `:auth/classify-token` in
+         core.cljs). The User payload is stored at `[:auth :user]` with its
+         `:token` field stripped off (`dissoc`), so the JWT is NOT duplicated into
+         the UNCLASSIFIED `[:auth :user :token]` slot — a second durable copy
+         there would ship RAW to every off-box record (classification does not
+         propagate; each path is its own declaration). Views / subs read
+         `:auth/user` for identity (username, bio, image); none of them need the
+         token, which the bearer-auth interceptor reads from the classified
+         `[:auth :token]` path instead."}
   (fn [{:keys [db]} [_ user]]
     {:db (-> db
         (assoc-in [:auth :user] (dissoc user :token))
@@ -134,53 +127,50 @@
 ;; ----------------------------------------------------------------------------
 ;;
 ;; A `{:from-db :realworld/session}` resource SUBSCRIPTION re-keys reactively
-;; when the resolver's app-db input (the authenticated `:username`) changes
-;; (Spec 016 §A `{:from-db …}` subscription re-keys). BY DESIGN that re-key does
-;; NOT fetch — subscriptions are passive; the NEW scope's data loads only when a
-;; CAUSE ensures it (route entry / an event-side `:rf.resource/ensure` /
-;; clear-scope). So a principal switch by an app-db WRITE ALONE — no route
-;; change — re-keys the feed sub but never loads it: the feed sits at :idle
-;; indefinitely (fail-closed and safe, but a surprising "feed stuck loading"
-;; DX trap).
+;; when the resolver's app-db input (the authenticated `:username`) changes. That
+;; re-key does NOT fetch — subscriptions are passive; the NEW scope's data loads
+;; only when a CAUSE ensures it (route entry / an event-side
+;; `:rf.resource/ensure` / clear-scope). So a principal switch by an app-db WRITE
+;; ALONE — no route change — re-keys the feed sub but never loads it: the feed
+;; sits at :idle indefinitely (fail-closed and safe, but a surprising "feed stuck
+;; loading" trap).
 ;;
-;; The one place this app switches principal WITHOUT a route change is
-;; COLD-BOOT SESSION RESTORE: the home route is entered logged-out (the
-;; `{:from-db :realworld/session}` feed resolves nil and is NOT planned), THEN
-;; the async `GET /user` lands and `:restore-session` writes the principal — by
-;; design WITHOUT navigating (a deep link must be preserved). The interactive
-;; login / logout paths DO navigate (`:auth/post-login-redirect` / logout's
-;; `:rf.route/navigate :realworld/home`), so the route plan re-ensures the feed
-;; for them; restore is the lone gap.
+;; The one place this app switches principal WITHOUT a route change is COLD-BOOT
+;; SESSION RESTORE: the home route is entered logged-out (the
+;; `{:from-db :realworld/session}` feed resolves nil and is NOT planned), THEN the
+;; async `GET /user` lands and `:restore-session` writes the principal — by design
+;; WITHOUT navigating (a deep link must be preserved). The interactive login /
+;; logout paths DO navigate, so the route plan re-ensures the feed for them;
+;; restore is the lone gap.
 ;;
-;; The fix is the bead's recommended shape: an explicit `:rf.resource/ensure`
-;; of the feed under the NEW session scope (the `{:from-db :realworld/session}`
-;; resolves itself against the post-restore app-db). It rides an app-minted
-;; lease `session-feed-owner` so the feed stays active while signed in (the
-;; logged-out route entry attached no route owner to release later); logout
-;; releases the lease alongside its `clear-scope` (Spec 016 §Active owners —
-;; an event-created owner MUST have a matching release path). The `:page` is
-;; read from the live route slice so the ensure hits the SAME cache key the
-;; home route / feed subscription use. Logged out (post-restore-failure) the
-;; reference resolves nil and the runtime fail-closes (no feed to load).
+;; So restore does an explicit `:rf.resource/ensure` of the feed under the NEW
+;; session scope (the `{:from-db :realworld/session}` resolves itself against the
+;; post-restore app-db). It rides an app-minted lease `session-feed-owner` so the
+;; feed stays active while signed in (the logged-out route entry attached no route
+;; owner to release later); logout releases the lease alongside its `clear-scope`
+;; — an event-created owner MUST have a matching release path (see owner & cause,
+;; ../../../docs/resources/glossary.md#owner--cause). The `:page` is read from the
+;; live route slice so the ensure hits the SAME cache key the home route / feed
+;; subscription use. Logged out (post-restore-failure) the reference resolves nil
+;; and the runtime fail-closes (no feed to load).
 
 (def session-feed-owner
-  "The app-minted liveness lease the principal-switch re-ensure attaches to
-   the session feed (a `[:lease …]` owner, Spec 016 §Active owners). Stable
-   across switches; released on logout."
+  "The app-minted liveness lease the principal-switch re-ensure attaches to the
+   session feed (a `[:lease …]` owner). Stable across switches; released on
+   logout. See owner & cause: ../../../docs/resources/glossary.md#owner--cause."
   [:lease :auth/session-feed])
 
 (rf/reg-event :auth/ensure-session-feed
   {:doc "Re-ensure the session feed under the CURRENT principal so a principal
-         switch with no route change (cold-boot session restore) actually
-         loads it — the `{:from-db :realworld/session}` re-key alone is passive
-         and does not fetch (Spec 016 §A `{:from-db …}` subscription re-keys /
-         the principal-switch footgun). Resolves the scope from the post-restore
-         app-db via the resource's own `{:from-db :realworld/session}` policy,
-         reads `:page` from the live route slice so the ensure hits the SAME
-         cache key the home route + feed subscription use, and attaches the
-         stable `session-feed-owner` lease (released by `:auth/clear-session`).
-         A fresh `:loaded` entry the route already ensured is a cache-hit; a
-         logged-out resolution fail-closes."}
+         switch with no route change (cold-boot session restore) actually loads
+         it — the `{:from-db :realworld/session}` re-key alone is passive and does
+         not fetch. Resolves the scope from the post-restore app-db via the
+         resource's own `{:from-db :realworld/session}` policy, reads `:page` from
+         the live route slice so the ensure hits the SAME cache key the home route
+         + feed subscription use, and attaches the stable `session-feed-owner`
+         lease (released by `:auth/clear-session`). A fresh `:loaded` entry the
+         route already ensured is a cache-hit; a logged-out resolution
+         fail-closes."}
   (fn [{rt :rf.db/runtime} _]
     ;; Default to page 1 so the ensure hits the SAME `{:page 1}` key the home
     ;; route + feed subscription use on the canonical no-`?page=` URL — a raw
@@ -194,23 +184,21 @@
 
 (rf/reg-event :auth/clear-session
   {:doc "Clear the auth slice AND drop the session-scoped resource cache. The
-         personalised feed is cached under the session scope (Spec 016
-         §Scope); logout MUST clear it (`:rf.resource/clear-scope`) so the next
-         user never reads it. The concrete old scope is resolved with the pure
-         `rf/resolve-resource-scope` helper against the COEFFECT db (the
-         pre-transition value, by definition still carrying the logging-out
-         user) and the named `:realworld/session` resolver (EP-0016 D3) — the
-         same resolver every resource site references. Resolves nil when no user
-         was present (nothing to clear). Public `:rf.scope/global` reads are
-         untouched.
+         personalised feed is cached under the session scope; logout MUST clear it
+         (`:rf.resource/clear-scope`) so the next user never reads it. The
+         concrete old scope is resolved with the pure `rf/resolve-resource-scope`
+         helper against the COEFFECT db (the pre-transition value, by definition
+         still carrying the logging-out user) and the named `:realworld/session`
+         resolver — the same resolver every resource site references. Resolves nil
+         when no user was present (nothing to clear). Public `:rf.scope/global`
+         reads are untouched.
 
          ALSO releases the `session-feed-owner` lease the principal-switch
-         re-ensure (`:auth/ensure-session-feed`) may have attached
-         — an event-created owner MUST have a matching release path (Spec 016
-         §Active owners). The `clear-scope` removes the entry the lease was on,
-         so the release is belt-and-braces, but it keeps the owner-lease
-         lifecycle a readable attach/release pair (no dangling lease in the
-         owner index)."}
+         re-ensure (`:auth/ensure-session-feed`) may have attached — an
+         event-created owner MUST have a matching release path. The `clear-scope`
+         removes the entry the lease was on, so the release also keeps the
+         owner-lease lifecycle a readable attach/release pair (no dangling lease in
+         the owner index)."}
   (fn [{:keys [db]} _]
     (let [old-scope (rf/resolve-resource-scope db :realworld/session)]
       {:db (-> db
@@ -227,9 +215,9 @@
          ONLY by the `:store-session` action (the interactive `:submitting →
          :authed` transition) — NOT by `:restore-session` (cold-boot
          session-restore preserves the restored route, never force-navigates).
-         Machine actions can't navigate or read `:db` directly (Spec 005), so
-         this is an ordinary event. Reads AND clears the slot so a later login
-         can't re-bounce."}
+         Machine actions can't navigate or read `:db` directly, so this is an
+         ordinary event. Reads AND clears the slot so a later login can't
+         re-bounce."}
   (fn [{:keys [db]} _]
     (let [return-to (get-in db [:auth :return-to])]
       {:db (update db :auth dissoc :return-to)
@@ -243,8 +231,8 @@
 
 (rf/reg-machine :auth/flow
   {:doc "The auth flow: idle → submitting/restoring → authed | error. HTTP via
-         :rf.http/managed (Spec 014). Login / register / restore do NOT retry —
-         one submission per click."
+         :rf.http/managed. Login / register / restore do NOT retry — one
+         submission per click."
    :rf.http/decode-schemas [schema/UserResponse]}
   {:initial :idle
    :data    {:error nil}
@@ -286,11 +274,11 @@
     :store-session
     (fn [{[_ {:keys [value]}] :event}]
       ;; INTERACTIVE login / register success: store the session, persist the
-      ;; JWT, AND bounce to the guard-stashed `:return-to` (or home). The
-      ;; bounce is the right behaviour ONLY for an interactive submit — the
-      ;; user just clicked Sign-in from the login page and expects to land
-      ;; somewhere. Machine actions see no `:db` and emit no `:db` (Spec 005),
-      ;; so the session store + bounce-back run as ordinary events.
+      ;; JWT, AND bounce to the guard-stashed `:return-to` (or home). The bounce
+      ;; is the right behaviour ONLY for an interactive submit — the user just
+      ;; clicked Sign-in from the login page and expects to land somewhere.
+      ;; Machine actions see no `:db` and emit no `:db`, so the session store +
+      ;; bounce-back run as ordinary events.
       (let [user (:user value)]
         {:data {:error nil}
          :fx [[:dispatch [:auth/store-session user]]
@@ -299,22 +287,22 @@
 
     :restore-session
     (fn [{[_ {:keys [value]}] :event}]
-      ;; SESSION-RESTORE success (cold boot with a saved JWT): store the
-      ;; session WITHOUT navigating. A logged-in user cold-booting on a deep
-      ;; link (`/article/x`) must stay on that route — restore only re-hydrates
-      ;; the session; it must NOT force-navigate home (the bug this action
-      ;; fixes). Only an INTERACTIVE login/register bounces (`:store-session`).
-      ;; The token is already in app-db + localStorage from `:auth/initialise`;
-      ;; we re-persist defensively in case the server rotated it on `GET /user`.
+      ;; SESSION-RESTORE success (cold boot with a saved JWT): store the session
+      ;; WITHOUT navigating. A logged-in user cold-booting on a deep link
+      ;; (`/article/x`) must stay on that route — restore only re-hydrates the
+      ;; session; it must NOT force-navigate home. Only an INTERACTIVE
+      ;; login/register bounces (`:store-session`). The token is already in app-db
+      ;; + localStorage from `:auth/initialise`; we re-persist defensively in case
+      ;; the server rotated it on `GET /user`.
       ;;
-      ;; This is the one PRINCIPAL SWITCH with no route change — the
-      ;; home route was already entered logged-out (the `{:from-db
-      ;; :realworld/session}` feed resolved nil and was not planned), so storing
-      ;; the principal now RE-KEYS the feed sub but, being passive, does not
-      ;; fetch. Re-ensure the feed under the freshly-stored session scope so
-      ;; "Your Feed" actually loads (a no-op cache-hit when the user is not on
-      ;; home / when the route already ensured it). The interactive login /
-      ;; logout paths re-enter the route and need no explicit ensure.
+      ;; This is the one PRINCIPAL SWITCH with no route change — the home route
+      ;; was already entered logged-out (the `{:from-db :realworld/session}` feed
+      ;; resolved nil and was not planned), so storing the principal now RE-KEYS
+      ;; the feed sub but, being passive, does not fetch. Re-ensure the feed under
+      ;; the freshly-stored session scope so "Your Feed" actually loads (a no-op
+      ;; cache-hit when the user is not on home / when the route already ensured
+      ;; it). The interactive login / logout paths re-enter the route and need no
+      ;; explicit ensure.
       (let [user (:user value)]
         {:data {:error nil}
          :fx [[:dispatch [:auth/store-session user]]

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -1,8 +1,9 @@
 (ns realworld-resources.core
-  "Entry point for the RealWorld-on-resources (Conduit) example — a sibling of
-   `examples/reagent/realworld/` that expresses the read surface as EP-0003 (Spec
-   016) RESOURCES and the write surface as MUTATIONS, rather than hand-rolled
-   `:rf.http/managed` Pattern-RemoteData slices.
+  "Entry point for the RealWorld (Conduit) example. The read surface is
+   RESOURCES (`reg-resource`) and the write surface is MUTATIONS
+   (`reg-mutation`): the framework owns the server-state cache, views read it
+   passively, and a write invalidates the reads it affected. See the resources
+   guide: ../../../docs/resources/concepts.md.
 
    Wires the app together:
    - pulls in every feature ns (each registers its resources / mutations /
@@ -22,26 +23,18 @@
      scope.cljs      — the fail-closed session cache scope
      schema.cljs     — Malli wire shapes + the small app-db schemas
      http.cljs       — the demo backend stub + failure projection
-     views.cljs      — passive pages + the small UI event glue
-
-   The resources + mutations runtime (EP-0003) backs this example, which runs
-   live. The example tree is test-free; resource/mutation contract coverage
-   lives in `implementation/resources/test/` and the conformance fixtures.
-
-   For the `:rf.http/managed` counterpart (schema-driven decode, retry/abort,
-   the classification order, optimistic rollback against managed HTTP), see the
-   sibling `examples/reagent/realworld/` — the canonical Spec 014 demo."
+     views.cljs      — passive pages + the small UI event glue"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Managed HTTP — the single built-in resource/mutation transport.
             [re-frame.http.managed]
-            ;; The canned-stub fxs the demo backend delegates to (Spec 014
-            ;; §Testing). A real Conduit deployment would drop this require.
+            ;; The canned-stub fxs the demo backend delegates to. A real Conduit
+            ;; deployment would drop this require.
             [re-frame.http.test-support]
-            ;; Resources + mutations runtime (day8/re-frame2-resources).
+            ;; Resources + mutations runtime.
             [re-frame.resources]
-            ;; Routing + machines artefacts (late-bind the `:resources` route
-            ;; key + the auth machine).
+            ;; Routing + machines. Loading routing makes the `:resources` route
+            ;; key available; the auth machine needs machines.
             [re-frame.routing]
             [re-frame.machines]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -63,28 +56,23 @@
 ;; ============================================================================
 
 (rf/reg-event :app/initialise
-  {:doc "App boot. Seeds the form drafts. Session restore (`:auth/initialise`)
-         is NOT in this fan-out — it consumes the RECORDABLE-GENERATOR
-         `:realworld-resources.session/token` coeffect (EP-0017). The `:dispatch`
-         fx does not forward `:rf.cofx`, so `:auth/initialise` rides its OWN
-         `:initial-events` step (a direct boot dispatch, ahead of this one)
-         rather than this fan-out — keeping the generated token on its own boot
-         dispatch token, where it is recorded. The page reads (articles, tags,
-         feed, …) are CAUSED by the route's `:resources` metadata on the initial
-         URL→route sync, not from here — that is the point of the variant."}
+  {:doc "App boot. Seeds the form drafts. Session restore is its own
+         `:initial-events` step (`:auth/initialise`), not part of this fan-out,
+         so its recordable token coeffect rides its own dispatch. The page reads
+         (articles, tags, feed, …) are caused by the route's `:resources`
+         metadata on the initial URL→route sync, not from here."}
   (fn [_ _]
     {:fx [[:dispatch [:auth.login-form/initialise]]
           [:dispatch [:auth.register-form/initialise]]]}))
 
-;; Durable app-db classification (EP-0025): the JWT at [:auth :token] is
-;; sensitive — declare it via the commit-plane `:sensitive` effect, returned
-;; alongside `:db` from an event the frame runs at creation (`:initial-events`,
-;; before any boot dispatch or off-box egress). EP-0025 removed the durable
-;; `:sensitive {:app-db …}` frame annotation; a frame is not app-db's
-;; definition site.
+;; The JWT at [:auth :token] is durable and sensitive. Classify it via the
+;; `:sensitive` effect, returned alongside `:db` from an event the frame runs at
+;; creation (`:initial-events`, before any off-box egress) so the raw token is
+;; redacted from anything that leaves the box. See data classification:
+;; ../../../docs/guide/glossary.md#data-classification.
 (rf/reg-event :auth/classify-token
   {:doc "Classifies the durable JWT path [:auth :token] sensitive at frame
-         creation (EP-0025 commit-plane classification effect)."}
+         creation."}
   (fn [{:keys [db]} _]
     {:db db :sensitive [[:auth :token]]}))
 
@@ -127,9 +115,9 @@
 
 (reg-view ^{:doc "Confirm dialog shown when a `:can-leave` guard blocks a
                    navigation (e.g. the editor with a dirty draft). Reads the
-                   blocked navigation off the `:rf/pending-navigation` sub
-                   (Spec 012 §Redirects and guards); the buttons continue or
-                   cancel the pending nav."}
+                   blocked navigation off the `:rf/pending-navigation` sub; the
+                   buttons continue or cancel the pending nav. See route guard:
+                   ../../../docs/routing/glossary.md#route-guard."}
           pending-nav-dialog []
   (when-let [pending @(subscribe [:rf/pending-navigation])]
     [:div.pending-nav-overlay {:data-testid "pending-nav-dialog"}
@@ -164,31 +152,22 @@
    [footer]])
 
 ;; ============================================================================
-;; BEARER-AUTH HTTP INTERCEPTOR  (Spec 014 §Middleware)
+;; BEARER-AUTH HTTP INTERCEPTOR
 ;; ============================================================================
 ;;
-;; The cross-cutting decoration the resources/mutations variant was missing
-;; (fable.md F4): a single `:before` fn injects the Bearer token from the auth
-;; slice, so EVERY outbound `:rf.http/managed` request that crosses this frame
-;; picks the header up automatically. Resources AND mutations lower onto
-;; `:rf.http/managed`, so this one interceptor decorates the WHOLE Conduit API
-;; — the route-caused reads (`/articles/feed`, the lists, detail), the writes
-;; (favorite / follow / comment / settings / save-article), and the auth
-;; machine's session-restore `GET /user`. No `:request` fn threads the token
-;; per-call; the auth slice is the single source of truth and this is the
-;; single read site.
+;; A single `:before` fn injects the Bearer token from the auth slice, so EVERY
+;; outbound `:rf.http/managed` request that crosses this frame picks the header
+;; up automatically. Resources AND mutations lower onto `:rf.http/managed`, so
+;; this one interceptor decorates the WHOLE Conduit API — the route-caused reads
+;; (`/articles/feed`, the lists, detail), the writes (favorite / follow /
+;; comment / settings / save-article), and the auth machine's session-restore
+;; `GET /user`. No `:request` fn threads the token per-call; the auth slice is
+;; the single source of truth and this is the single read site.
 ;;
-;; CARRIED-FRAME-CORRECT (EP-0002): the token is read from
-;; `(:frame ctx)` — the frame the cascade actually runs under — not a
-;; hard-coded `:rf/default`, so the header tracks a non-default / multi-frame
-;; mount. The interceptor returns ctx unchanged when no token is present, so
-;; login / register / the public reads (logged-out) are unaffected.
-
-;; Public (not `defn-`) so a headless fixture can wire it into a test frame
-;; and assert the decoration. The sibling's route guard takes the other route:
-;; it is a `reg-interceptor` descriptor referenced BY ID
-;; (`:realworld-resources.routing/auth-guard`, EP-0022) rather than a var. The
-;; example tree stays test-free; the visibility is the only concession.
+;; The token is read from `(:frame ctx)` — the frame the cascade runs under —
+;; not a hard-coded id, so the header tracks a non-default / multi-frame mount.
+;; The interceptor returns ctx unchanged when no token is present, so login /
+;; register / the public (logged-out) reads are unaffected.
 (defn bearer-auth-interceptor [ctx]
   (let [token (some-> (rf/app-db-value (:frame ctx))
                       :auth :token)]
@@ -206,11 +185,11 @@
 ;; app-db.
 ;;
 ;; THIS IS A CONFORMANCE SURFACE, NOT A re-frame2 PATTERN. An unannotated global
-;; token accessor is exactly the anti-pattern that gets copied into real apps
-;; (it bypasses the frame/sub system and leaks the raw JWT to any script on the
-;; page). Real re-frame2 code reads session state through subs under the frame
-;; provider — never a `window.*` global. It exists ONLY so the external suite
-;; can introspect this demo; a production RealWorld app would NOT ship it.
+;; token accessor is the anti-pattern that gets copied into real apps: it
+;; bypasses the frame/sub system and leaks the raw JWT to any script on the
+;; page. Real re-frame2 code reads session state through subs under the frame
+;; provider, never a `window.*` global. This exists only so the external suite
+;; can introspect the demo; a production RealWorld app would not ship it.
 (defn- install-conduit-debug! [frame-id]
   (when (exists? js/window)
     (set! (.-__conduit_debug__ js/window)
@@ -227,53 +206,36 @@
 
 (def app-frame :rf/default)
 
-;; EP-0002: `:rf/default` is an ordinary frame id with no framework privilege —
-;; `init!` installs only the adapter and creates no frame. This app earns URL
-;; ownership by DECLARING `:url-bound? true` on the frame below.
+;; `:rf/default` is an ordinary frame id with no framework privilege — `init!`
+;; installs only the adapter and creates no frame. This app earns URL ownership
+;; by declaring `:url-bound? true` on the frame below.
 ;;
 ;; The app frame is created, configured, and seeded in ONE spot: the
-;; `frame-provider {:id …}` ENSURE form at the render root. On first mount it
+;; `frame-provider {:id …}` ensure form at the render root. On first mount it
 ;; creates the frame under `app-frame`, applies the config (`:url-bound? true`
-;; so it owns the URL; the auth-guard interceptor referenced BY ID per EP-0022;
-;; the demo `:rf.http/managed` routed through the in-process backend stub so
-;; reads (resources) and writes (mutations) run without a network), and runs
-;; `:initial-events` ONCE — `:auth/classify-token` then session-restore
-;; `:auth/initialise` then form-draft `:app/initialise`, in that order. On hot
-;; reload it REUSES the existing frame WITHOUT re-seeding (durable app-db
-;; survives; `:initial-events` are re-recorded but not replayed). That id is
-;; what every in-tree `dispatch`/`subscribe` resolves against — no separate
-;; `reg-frame` or scope step.
+;; so it owns the URL; the auth-guard interceptor referenced by id; the demo
+;; `:rf.http/managed` routed through the in-process backend stub so reads and
+;; writes run without a network), and runs `:initial-events` once. Hot reload
+;; reuses the frame without re-seeding (durable app-db survives). That id is what
+;; every in-tree `dispatch`/`subscribe` resolves against.
 ;;
 ;; `:initial-events` ordering carries two constraints:
-;;   - `:auth/classify-token` first — EP-0025 (durable egress classification):
-;;     the JWT lives at [:auth :token] and is a durable, frame-wide sensitive
-;;     fact, so that path is classified `:sensitive` via the commit-plane
-;;     `:sensitive` effect at frame creation, BEFORE any off-box egress.
-;;     Projection happens at the trust boundary, so off-box egress (Xray /
-;;     observability capture, an off-box tool, an SSR hydration payload) never
-;;     sees the raw token, while on-box use keeps it.
-;;   - `:auth/initialise` before `:app/initialise` — EP-0017: session restore
-;;     consumes the RECORDABLE-GENERATOR `:realworld-resources.session/token`
-;;     coeffect and folds it into durable [:auth :token]. The dispatch carries
-;;     no `:rf.cofx` (a production dispatch never stamps a coeffect; that is a
-;;     unit-test stub seam). The registered generator (auth.cljs) reads
-;;     localStorage ONCE at processing-start; its value rides this boot dispatch
-;;     token as the flat recordable coeffect, so it is recorded and replay /
-;;     epoch-restore re-presents the captured token verbatim rather than
-;;     re-reading localStorage then. It is its OWN `:initial-events` step (not
-;;     the `:app/initialise` `:dispatch` fan-out, which does not forward
-;;     `:rf.cofx`), and ahead of `:app/initialise`, so the token is in app-db
-;;     before the bearer-auth interceptor fires any authenticated request.
+;;   - `:auth/classify-token` first: the JWT at [:auth :token] is a durable
+;;     sensitive fact, so classify it before any off-box egress (Xray capture,
+;;     an SSR payload) can see the raw token. See data classification:
+;;     ../../../docs/guide/glossary.md#data-classification.
+;;   - `:auth/initialise` before `:app/initialise`: session restore reads the
+;;     saved JWT from a recordable coeffect (auth.cljs) and folds it into durable
+;;     [:auth :token]. It rides its own dispatch (not the `:app/initialise`
+;;     fan-out, which does not forward `:rf.cofx`) and runs first, so the token
+;;     is in app-db before the bearer-auth interceptor fires any authenticated
+;;     request.
 ;;
-;; The outbound `Authorization` Bearer header (the bearer-auth interceptor,
-;; registered globally in `run` BEFORE the frame's `:initial-events` fire the
-;; session-restore `GET /user`) is NOT classified here — it is already on the
-;; framework's immutable built-in HTTP carrier denylist (Spec 014 §Privacy),
-;; redacted off-box with no frame config. The `:sensitive :http :headers`
-;; extension is for APP-SPECIFIC carriers; this app sends none. The
-;; session-scope KEY ([:auth :user :username]) the scoped resource cache reads
-;; under is identity, not a secret, so it is deliberately NOT classified —
-;; over-redacting would obscure the cache-leak boundary this example shows.
+;; The outbound `Authorization` Bearer header is not classified here — the
+;; framework's built-in HTTP carrier denylist already redacts it off-box. The
+;; session-scope key ([:auth :user :username]) is identity, not a secret, so it
+;; is deliberately not classified — over-redacting would obscure the cache-leak
+;; boundary this example shows.
 (defn run []
   (rf/init! reagent-adapter/adapter)
   ;; Register the Bearer-auth interceptor at app boot, BEFORE the frame's
@@ -289,11 +251,9 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; ENSURE form: create + configure + seed the app frame in one spot. First
-    ;; mount creates it under `app-frame`, applies the config, and runs
-    ;; `:initial-events` once (classify-token → session restore → form drafts);
-    ;; hot reload reuses it without re-seeding. `make-frame` runs synchronously
-    ;; in render, so the frame is live + seeded once this returns.
+    ;; Create + configure + seed the app frame in one spot (see the block above).
+    ;; The frame is created synchronously during render, so it is live and seeded
+    ;; once this returns.
     (rdc/render @react-root
                 [rf/frame-provider {:id              app-frame
                                     :doc             "RealWorld-on-resources demo frame."
@@ -315,8 +275,8 @@
     ;; already in app-db, so the bearer-auth interceptor decorates those reads.
     (routing/install-router!)
     ;; Focus/reconnect revalidation: refetch active-and-stale reads when the tab
-    ;; returns or the network reconnects (Spec 016 §Stale and GC; CLJS-only,
-    ;; idempotent). The host signals are never dispatched by hand.
+    ;; returns or the network reconnects (idempotent). The host signals are never
+    ;; dispatched by hand.
     (rf/install-revalidation-listeners! app-frame)
     ;; Conformance-contract surface — NOT a re-frame2 pattern; see
     ;; install-conduit-debug! above. The external RealWorld suite may read it.

--- a/examples/reagent/realworld_resources/http.cljs
+++ b/examples/reagent/realworld_resources/http.cljs
@@ -2,18 +2,17 @@
   "HTTP helpers + the demo backend stub for the RealWorld-on-resources
    example.
 
-   Resources and mutations lower onto `:rf.http/managed` (Spec 016 §Transport:
-   managed HTTP is the single built-in resource/mutation transport), so the
-   SAME canned-stub override the `:rf.http/managed` sibling uses serves both
-   reads and writes here. The stub routes by URL + method to a canned
-   Conduit-shaped reply, deferred via `:after-ms` (`:dispatch-later`, NOT raw
-   `js/setTimeout`) so the runtime's `:loading` UI state is observable and
-   replies stay time-travel-safe.
+   Resources and mutations lower onto `:rf.http/managed` — the single built-in
+   resource/mutation transport (../../../docs/resources/glossary.md#managed-http)
+   — so one canned-stub override serves both reads and writes. The stub routes by
+   URL + method to a canned Conduit-shaped reply, deferred via `:after-ms`
+   (`:dispatch-later`, NOT raw `js/setTimeout`) so the runtime's `:loading` UI
+   state is observable and replies stay time-travel-safe.
 
    Two helpers:
-   - `failure->message` — project a Spec 014 `:rf.http/*` failure envelope (the
-     shape resource `:error` / `:refresh-error` and mutation `:error` carry) to
-     a human-readable string.
+   - `failure->message` — project a `:rf.http/*` failure envelope (the shape
+     resource `:error` / `:refresh-error` and mutation `:error` carry) to a
+     human-readable string.
    - `install-demo-backend!` — register the stub fx + wire it as the
      `:rf.http/managed` override on the demo frame.
 
@@ -49,15 +48,15 @@
   (str api-base path))
 
 ;; ============================================================================
-;; RETRY POLICY (Spec 014 §Retry and backoff)
+;; RETRY POLICY
 ;; ============================================================================
 ;;
-;; Reads retry / writes don't (Spec 014). Each read resource's `:request`
-;; returns a Spec 014 managed-HTTP args map, and `:retry` passes through the
-;; resource lowering UNCHANGED (Spec 016 §Transport), so a resource arms retry
-;; simply by including this policy in its return. Writes (mutations) stay
-;; retry-free — a write's intent is one submission per click; a 5xx surfaces
-;; as `:error` so the user retries themselves.
+;; Reads retry; writes don't. Each read resource's `:request` returns a
+;; managed-HTTP args map, and `:retry` passes through the resource lowering
+;; unchanged, so a resource arms retry simply by including this policy in its
+;; return. Writes (mutations) stay retry-free — a write's intent is one
+;; submission per click; a 5xx surfaces as `:error` so the user retries
+;; themselves.
 
 (def data-fetch-retry
   "Standard retry policy for read-only data fetches (lists, article detail,
@@ -73,12 +72,11 @@
 ;; ============================================================================
 
 (defn failure->message
-  "Project a Spec 014 failure envelope (the inner `:failure` map — the shape a
-   resource `:error` / `:refresh-error` and a mutation `:error` carry) to a
-   human-readable string. The Conduit API returns `{:errors {:body [\"...\"]}}`
-   shapes for 4xx validation failures; surface those when present, otherwise
-   fall back to a category-driven message keyed on the closed `:rf.http/*`
-   taxonomy."
+  "Project a failure envelope (the inner `:failure` map — the shape a resource
+   `:error` / `:refresh-error` and a mutation `:error` carry) to a human-readable
+   string. The Conduit API returns `{:errors {:body [\"...\"]}}` shapes for 4xx
+   validation failures; surface those when present, otherwise fall back to a
+   category-driven message keyed on the closed `:rf.http/*` taxonomy."
   [failure]
   (let [body     (:body failure)
         body-msg (cond
@@ -103,11 +101,10 @@
 ;; DEMO BACKEND STUB
 ;; ============================================================================
 ;;
-;; The realworld example ships without a backend; the demo routes
-;; `:rf.http/managed` through a per-URL stub that delegates to
-;; `:rf.http/managed-canned-success` (Spec 014 §Testing). The resource /
-;; mutation runtime lowers each fetch/write onto `:rf.http/managed`, so this
-;; one override stands in for the whole Conduit API.
+;; The example ships without a backend; the demo routes `:rf.http/managed`
+;; through a per-URL stub that delegates to `:rf.http/managed-canned-success`.
+;; The resource / mutation runtime lowers each fetch/write onto
+;; `:rf.http/managed`, so this one override stands in for the whole Conduit API.
 
 (def ^:private demo-reply-delay-ms
   "How long the demo stub defers each canned reply (via the canned-success
@@ -119,11 +116,11 @@
 
 ;; A SYNTHESISED article set large enough that the official-size pagination
 ;; (`page-size` = 10) spans several pages — so the paginated-resource +
-;; keep-previous dogfood is actually demonstrable in the browser. The first
-;; two carry the original stable slugs (referenced by the article-detail /
-;; mutation paths); the rest are generated. `demo-favorited` is a SUBSET so the
-;; profile Favorited-Articles tab differs from My Articles, and unfavoriting
-;; from the tab visibly drops the article on the next refetch.
+;; keep-previous behaviour is actually demonstrable in the browser. The first two
+;; carry stable slugs (referenced by the article-detail / mutation paths); the
+;; rest are generated. `demo-favorited` is a SUBSET so the profile
+;; Favorited-Articles tab differs from My Articles, and unfavoriting from the tab
+;; visibly drops the article on the next refetch.
 (def ^:private demo-article-count 23)
 
 (defn- gen-article [i]
@@ -132,12 +129,11 @@
                  :description "A short greeting from the realworld-resources stub."
                  ;; A markdown body so the article-detail page exercises the
                  ;; sanitized CommonMark renderer (realworld-shared.markdown/
-                 ;; render): headings, bold/italic, inline + fenced
-                 ;; code, a safe link, lists, plus full-CommonMark shapes the old
-                 ;; hand-rolled subset could not do (a table, a nested list).
-                 ;; The renderer emits hiccup (never raw HTML), so this is real
-                 ;; markup while any injected `<script>` / `javascript:` link in
-                 ;; user content degrades to inert escaped text.
+                 ;; render): headings, bold/italic, inline + fenced code, a safe
+                 ;; link, lists, tables, nested lists. The renderer emits hiccup
+                 ;; (never raw HTML), so this is real markup while any injected
+                 ;; `<script>` / `javascript:` link in user content degrades to
+                 ;; inert escaped text.
                  :body (str "# Hello, Conduit\n\n"
                             "This article is served by the demo `:rf.http/managed` "
                             "override that **resources + mutations** lower onto, "
@@ -309,10 +305,9 @@
                canned Conduit-shaped responses so the example (reads via
                resources, writes via mutations) runs standalone without a
                backend. Delegates to the framework-shipped
-               `:rf.http/managed-canned-success` (Spec 014 §Testing) with the
-               per-URL payload + `:after-ms` (the deferred reply rides
-               `:dispatch-later` — tape-visible, time-travel-safe, NOT raw
-               `js/setTimeout`)."
+               `:rf.http/managed-canned-success` with the per-URL payload +
+               `:after-ms` (the deferred reply rides `:dispatch-later` —
+               tape-visible, time-travel-safe, NOT raw `js/setTimeout`)."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
     (let [payload (demo-payload-for-args args-map)

--- a/examples/reagent/realworld_resources/mutations.cljs
+++ b/examples/reagent/realworld_resources/mutations.cljs
@@ -1,21 +1,20 @@
 (ns realworld-resources.mutations
   "The MUTATION registry — every RealWorld write as a named, causal write to
-   remote state that invalidates / patches / populates the cached resource
-   reads it affected (Spec 016 §Mutations, EP-0003 §Mutations).
+   remote state that invalidates / patches / populates the cached resource reads
+   it affected. See ../../../docs/resources/glossary.md#mutation and
+   ../../../docs/resources/how-to/invalidate-after-a-mutation.md.
 
-   This is the half the focused `examples/reagent/resources/` lifecycle demo
-   does NOT show: the read→write→invalidate→refetch loop end-to-end in a full
-   app. A resource is \"a sub you read and a cause you fire\"; a mutation is
-   \"a cause you fire and an instance you watch\".
+   A resource is \"a sub you read and a cause you fire\"; a mutation is \"a cause
+   you fire and an instance you watch\". The read→write→invalidate→refetch loop,
+   end to end.
 
    Each mutation:
-   - lowers its `:request` through the SAME managed-HTTP transport resources
-     use (the runtime owns reply addressing — the app `:request` MUST NOT
-     supply `:request-id` / `:on-success` / `:on-failure`);
+   - lowers its `:request` through the SAME managed-HTTP transport resources use
+     (the runtime owns reply addressing — the app `:request` MUST NOT supply
+     `:request-id` / `:on-success` / `:on-failure`);
    - declares `:invalidates` — the resource `:tags` the write makes stale on
-     success, fed straight into `:rf.resource/invalidate-tags`
-     (scoped, owner-aware: mounted-and-owned reads refetch, inactive ones go
-     stale). The detail page and any list refetch with NO further wiring;
+     success (scoped, owner-aware: mounted-and-owned reads refetch, inactive ones
+     go stale). The detail page and any list refetch with NO further wiring;
    - some also declare `:populates` — seeding the affected resource entry from
      the write's own reply BEFORE the invalidation, so the change appears
      immediately without waiting for the refetch round-trip.
@@ -25,20 +24,20 @@
    through the passive `[:rf.mutation/state {:instance …}]` sub
    (`{:pending? :success? :error? :settled? :result :error :optimistic?}`).
 
-   OPTIMISTIC ROLLBACK (Spec 016 §Optimistic mutations, EP-0019). The
-   favorite / unfavorite writes below declare `:optimistic-tags` — the heart
+   OPTIMISTIC ROLLBACK (../../../docs/resources/glossary.md#optimistic-update--rollback).
+   The favorite / unfavorite writes below declare `:optimistic-tags` — the heart
    flips and the count moves on click, BEFORE the request is sent, across every
-   cached read showing that article (the detail, every list, the session feed)
-   in one tag-addressed apply. The runtime records the inverse itself, so the
-   reply settles deterministically: an `:ok` reply COMMITS (the `:populates`
-   seed overwrites the optimistic value with the server's), an `:error` reply
-   ROLLS BACK (the recorded `:before` is restored verbatim — the heart flips
-   back). `:on-conflict :invalidate` (the default) governs a contested rollback:
-   if a concurrent write moved the entry while ours was in flight, the stale
-   inverse is NOT restored — the read path refetches the authoritative value.
+   cached read showing that article (the detail, every list, the session feed) in
+   one tag-addressed apply. The runtime records the inverse itself, so the reply
+   settles deterministically: an `:ok` reply COMMITS (the `:populates` seed
+   overwrites the optimistic value with the server's), an `:error` reply ROLLS
+   BACK (the recorded `:before` is restored verbatim — the heart flips back).
+   `:on-conflict :invalidate` (the default) governs a contested rollback: if a
+   concurrent write moved the entry while ours was in flight, the stale inverse is
+   NOT restored — the read path refetches the authoritative value.
 
-   Writes do NOT retry by default (reads-retry / writes-don't, Spec 014); a
-   mutation arms `:retry` only if its `:request` declares it, and none here do."
+   Writes do NOT retry by default; a mutation arms `:retry` only if its
+   `:request` declares it, and none here do."
   (:require [re-frame.core :as rf]
             [re-frame.http.managed]
             [re-frame.resources]
@@ -46,49 +45,48 @@
             [realworld-resources.schema :as schema]))
 
 ;; ============================================================================
-;; FAVORITE / UNFAVORITE  —  the optimistic write (EP-0019)
+;; FAVORITE / UNFAVORITE  —  the optimistic write
 ;; ============================================================================
 ;;
-;; Favoriting is the canonical optimistic mutation: a tiny, reversible change
-;; (a boolean flip + a count of one) the user expects to land INSTANTLY. The
-;; same article appears in many cached reads at once — the detail, the home
-;; list, an author's articles, a profile's favorited tab, the session feed —
-;; and a favorite must flip in ALL of them the moment the heart is clicked,
-;; then settle to the server's authoritative value (and flip BACK everywhere if
-;; the write fails).
+;; Favoriting is the canonical optimistic mutation: a tiny, reversible change (a
+;; boolean flip + a count of one) the user expects to land INSTANTLY. The same
+;; article appears in many cached reads at once — the detail, the home list, an
+;; author's articles, a profile's favorited tab, the session feed — and a
+;; favorite must flip in ALL of them the moment the heart is clicked, then settle
+;; to the server's authoritative value (and flip BACK everywhere if the write
+;; fails).
 ;;
-;; OPTIMISTIC-TAGS — the tag-addressed forward apply (Spec 016 §Optimistic
-;; mutations). The author cannot enumerate every cache key showing this article
-;; by hand (lists are paginated, scopes differ, entries come and go), so the
-;; optimistic apply is TAG-ADDRESSED: it patches every cached entry carrying
-;; `[:article slug]` — reusing the SAME tag index `:invalidates` matches
-;; against. One descriptor covers the global reads (detail + every list), a
-;; second covers the session feed via the same `{:from-db :realworld/session}`
-;; resolver the feed resource declares. The detail stores `{:article …}` and
-;; the lists store `{:articles […]}`, so the patch fn (`apply-fav` below)
-;; handles both envelope shapes. The session target is FAIL-CLOSED: logged out,
-;; the resolver returns nil and that target is silently dropped — an optimistic
-;; apply writes the cache, so it has a read's leak boundary, never an implicit
-;; global write.
+;; OPTIMISTIC-TAGS — the tag-addressed forward apply. The author cannot
+;; enumerate every cache key showing this article by hand (lists are paginated,
+;; scopes differ, entries come and go), so the optimistic apply is TAG-ADDRESSED:
+;; it patches every cached entry carrying `[:article slug]` — reusing the SAME
+;; tag index `:invalidates` matches against. One descriptor covers the global
+;; reads (detail + every list), a second covers the session feed via the same
+;; `{:from-db :realworld/session}` resolver the feed resource declares. The
+;; detail stores `{:article …}` and the lists store `{:articles […]}`, so the
+;; patch fn (`apply-fav` below) handles both envelope shapes. The session target
+;; is FAIL-CLOSED: logged out, the resolver returns nil and that target is
+;; silently dropped — an optimistic apply writes the cache, so it has a read's
+;; leak boundary, never an implicit global write.
 ;;
 ;; THE INVERSE IS RUNTIME-RECORDED — the author writes only the FORWARD patch.
-;; The runtime snapshots each touched entry's `:before` (verbatim, by reference)
-;; and its `:revision` at apply time. The reply then settles deterministically:
+;; The runtime snapshots each touched entry's `:before` and its `:revision` at
+;; apply time. The reply then settles deterministically:
 ;;   - :ok    → COMMIT. `:populates` seeds the detail with the server's full
 ;;              Article (the authoritative value overwrites the optimistic one),
 ;;              then `:invalidates` refetches the lists / feed to truth.
 ;;   - :error → ROLLBACK. The recorded `:before` is restored verbatim — every
-;;              heart flips back, every count returns. No manual undo, no
-;;              app-db bookkeeping.
+;;              heart flips back, every count returns. No manual undo, no app-db
+;;              bookkeeping.
 ;;   - a competing write moved an entry while ours was in flight → `:on-conflict`
 ;;              (default `:invalidate`) marks that entry stale and lets the read
 ;;              path refetch, rather than restoring a now-stale inverse.
 ;;
-;; CROSS-SCOPE INVALIDATION IN ONE MUTATION (EP-0016 D2). `:invalidates` is the
-;; success-time counterpart: a vector of PER-TARGET DESCRIPTORS, each naming its
-;; own scope. The global descriptor refetches the article + lists; the session
-;; descriptor refetches the feed via the same resolver. One mutation, two
-;; scopes — no app-level cross-scope patch, no home-page watcher.
+;; CROSS-SCOPE INVALIDATION IN ONE MUTATION. `:invalidates` is the success-time
+;; counterpart: a vector of PER-TARGET DESCRIPTORS, each naming its own scope.
+;; The global descriptor refetches the article + lists; the session descriptor
+;; refetches the feed via the same resolver. One mutation, two scopes — no
+;; app-level cross-scope patch, no home-page watcher.
 
 (defn- toggle-article-fav
   "Toggle one Article map's `:favorited` flag and step `:favoritesCount` by
@@ -138,14 +136,14 @@
    :params-schema   [:map [:slug :string]]
    :scope           :rf.scope/global
    ;; FORWARD: flip the heart on + bump the count across the detail, every list,
-   ;; and the session feed, immediately on click (phase 1.5, before the request).
+   ;; and the session feed, immediately on click, before the request is sent.
    :optimistic-tags (fn [{:keys [slug]}] (optimistic-fav-tags true slug))
    ;; COMMIT: the reply is the full updated Article; seed the detail with it so
    ;; the authoritative value (the server's exact count) overwrites the
    ;; optimistic guess. Same `{:article …}` envelope the resource stores, so the
-   ;; populated key reads identically to a fetched one (Spec 016 §Populate is an
-   ;; authoritative load — the populated detail key is exempt from this same
-   ;; mutation's `[:article slug]` refetch).
+   ;; populated key reads identically to a fetched one — an authoritative load, so
+   ;; the populated detail key is exempt from this same mutation's `[:article
+   ;; slug]` refetch.
    :populates       (fn [{:keys [slug]} result]
                       {{:resource :realworld/article :params {:slug slug} :scope :rf.scope/global} result})
    ;; RECONCILE: refetch the lists (global) and the feed (session) to truth.
@@ -154,9 +152,9 @@
                         :tags  #{[:article slug] [:article-list]}}
                        {:scope {:from-db :realworld/session}
                         :tags  #{[:feed]}}])
-   ;; ROLLBACK conflict policy (the default, named here for the dogfood): on a
-   ;; failure rollback where a competing write moved a touched entry, refetch it
-   ;; rather than restoring a stale inverse.
+   ;; ROLLBACK conflict policy (the default, named here to show it): on a failure
+   ;; rollback where a competing write moved a touched entry, refetch it rather
+   ;; than restoring a stale inverse.
    :on-conflict     :invalidate}
   (fn [{:keys [slug]} _ctx]
     {:request {:method :post :url (rh/full-url (str "/articles/" slug "/favorite"))}

--- a/examples/reagent/realworld_resources/resources.cljs
+++ b/examples/reagent/realworld_resources/resources.cljs
@@ -1,42 +1,34 @@
 (ns realworld-resources.resources
   "The RESOURCE registry — every RealWorld read as a named, cached,
-   runtime-managed server-state read (Spec 016 §Public API / §Resource
-   registration spec).
+   runtime-managed server-state read. See the resources guide:
+   ../../../docs/resources/concepts.md; resource glossary:
+   ../../../docs/resources/glossary.md#resource.
 
-   This is the half of the example that expresses as resources what the
-   `:rf.http/managed` sibling hand-rolls as Pattern-RemoteData slices
-   (`{:status :data :error :loaded-at :attempt}` per read). Here each read is
-   `reg-resource`d once;
-   route entry / events CAUSE the fetch, and views read the runtime cache
-   PASSIVELY through `[:rf.resource/*]` subs. No `:status` / `:loading?`
-   app-db fields exist for these reads — the framework owns the lifecycle.
+   Each read is `reg-resource`d once; route entry / events CAUSE the fetch, and
+   views read the runtime cache PASSIVELY through `[:rf.resource/*]` subs. No
+   `:status` / `:loading?` app-db fields exist for these reads — the framework
+   owns the lifecycle.
 
-   Identity = `[scope resource-id canonical-params]` (Spec 016 §Resource
-   identity). Every variable that changes the remote read lives in `:params`
-   (slug, username, tag); `:scope` is the leak boundary (see
-   realworld-resources.scope). `:tags` let a WRITE invalidate the right reads
-   (see realworld-resources.mutations) — that is the read→write→invalidate→
-   refetch loop this whole variant exists to show.
+   A read's cache identity is `[scope resource-id canonical-params]`. Every
+   variable that changes the remote read lives in `:params` (slug, username,
+   tag); `:scope` is the leak boundary (see realworld-resources.scope,
+   ../../../docs/resources/glossary.md#scope). `:tags` let a WRITE invalidate
+   the right reads (see realworld-resources.mutations) — the
+   read→write→invalidate→refetch loop, ../../../docs/resources/glossary.md#invalidate.
 
-   `:stale-after-ms` / `:gc-after-ms` are exercised so the lifecycle is real:
-   a `:loaded` entry goes stale after the window (a re-`ensure` then refetches
-   into `:fetching`, keeping prior data visible — stale-while-revalidate), and
-   an inactive entry (no owner) is GC-eligible after its window. A fresh
-   re-`ensure` is a cache-hit (no fetch, no dedupe) — `:rf.resource/cache-hit`.
-
-   Resources is a POST-V1 optional artefact; the read-resource runtime +
-   mutations (EP-0003) back this example, so all of it runs live. The example
-   tree is test-free."
+   `:stale-after-ms` / `:gc-after-ms` are exercised so the lifecycle is real: a
+   `:loaded` entry goes stale after the window (a re-`ensure` then refetches into
+   `:fetching`, keeping prior data visible — stale-while-revalidate), and an
+   inactive entry (no owner) is GC-eligible after its window. A fresh re-`ensure`
+   of a fresh entry is a cache-hit (no fetch, no dedupe)."
   (:require [clojure.string]
             [re-frame.core :as rf]
-            ;; Managed HTTP ships in day8/re-frame2-http — the single built-in
-            ;; resource/mutation transport (Spec 016 §Transport). Loading the
-            ;; ns registers the `:rf.http/managed` fx the runtime lowers each
-            ;; ensure/refetch onto.
+            ;; Managed HTTP — the single built-in resource/mutation transport.
+            ;; Loading the ns registers the `:rf.http/managed` fx the runtime
+            ;; lowers each ensure/refetch onto.
             [re-frame.http.managed]
-            ;; Resources ship in day8/re-frame2-resources. Requiring the ns at
-            ;; app boot wires the late-bind hooks + registrations; without it,
-            ;; `rf/reg-resource` throws :rf.error/resources-artefact-missing.
+            ;; Resources runtime. Requiring the ns at app boot wires the hooks +
+            ;; registrations; without it `rf/reg-resource` throws.
             [re-frame.resources]
             [realworld-resources.http :as rh]
             [realworld-resources.schema :as schema]))
@@ -52,22 +44,21 @@
 
 (def gc-after-ms
   "An inactive entry (no live owner) is GC-eligible five minutes after going
-   inactive (Spec 016 §Stale and GC scheduling)."
+   inactive."
   (* 5 60 1000))
 
 ;; ============================================================================
 ;; PAGINATION — every server-visible list parameter lives in `:params`
 ;; ============================================================================
 ;;
-;; The Conduit list endpoints page with `limit` / `offset`; the UI is
-;; 1-indexed and the page size is fixed (Spec 016 §Paginated and previous
-;; data). The headline this exercises: pagination is DECLARATIVE on resources.
-;; The `:page` is just another `:params` key, so page N and page N+1 are
-;; DISTINCT cache entries (canonical-params identity) — back-navigating to a
-;; previously-loaded page is a cache-hit (no fetch), and `:keep-previous?` on
-;; the route entry keeps the prior page visible while the next first-loads
-;; (no flicker). No `:status` / `:loading?` app-db field, no manual page-cache
-;; map — the framework owns it.
+;; The Conduit list endpoints page with `limit` / `offset`; the UI is 1-indexed
+;; and the page size is fixed. The point this exercises: pagination is
+;; DECLARATIVE on resources. The `:page` is just another `:params` key, so page N
+;; and page N+1 are DISTINCT cache entries — back-navigating to a
+;; previously-loaded page is a cache-hit (no fetch), and `:keep-previous?` on the
+;; route entry keeps the prior page visible while the next first-loads (no
+;; flicker). No `:status` / `:loading?` app-db field, no manual page-cache map —
+;; the framework owns it. See ../../../docs/resources/how-to/paginate-a-feed.md.
 
 (def page-size
   "The fixed Conduit list page size (the official client's value). The demo
@@ -93,32 +84,31 @@
         sep (if (clojure.string/includes? url "?") "&" "?")]
     (str url sep "limit=" limit "&offset=" offset)))
 
-;; Reads retry / writes don't (Spec 014). Each read's `:request` returns the
-;; shared `rh/data-fetch-retry` policy in its managed-HTTP args; `:retry`
-;; passes through the resource lowering UNCHANGED (Spec 016 §Transport), so a
-;; transport blip / 5xx / timeout retries with backoff+jitter (NOT a 4xx — the
-;; request shape was valid). Mutations (writes) stay retry-free.
+;; Reads retry; writes don't. Each read's `:request` returns the shared
+;; `rh/data-fetch-retry` policy in its managed-HTTP args; `:retry` passes through
+;; the resource lowering unchanged, so a transport blip / 5xx / timeout retries
+;; with backoff+jitter (NOT a 4xx — the request shape was valid). Mutations
+;; (writes) stay retry-free. See managed HTTP:
+;; ../../../docs/resources/glossary.md#managed-http.
 
 ;; ============================================================================
 ;; PUBLIC READS — :scope :rf.scope/global (same for every viewer)
 ;; ============================================================================
 ;;
-;; The `:scope :rf.scope/global` here is the explicit, AUDITABLE claim that
-;; this read is identical for every user/tenant/locale (Spec 016 §Scope
-;; resolution). There is NO implicit default — a missing scope policy is a
-;; loud :rf.error/resource-missing-scope-policy at registration. Xray
-;; enumerates every `:rf.scope/global` resource as the standing
-;; security-review list.
+;; The `:scope :rf.scope/global` here is the explicit, AUDITABLE claim that this
+;; read is identical for every user/tenant/locale. There is NO implicit default —
+;; a missing scope policy fails loud at registration. See scope:
+;; ../../../docs/resources/glossary.md#scope.
 
 (rf/reg-resource :realworld/articles
   {:doc            "The global article list, optionally filtered by `:tag` and
                     paginated by `:page` (1-indexed). EVERY server-visible
                     option (the tag AND the page) is in params, so a
                     tag-filtered list, the unfiltered list, and each page are
-                    DISTINCT cache entries (Spec 016 §Paginated and previous
-                    data). Back-navigating to a previously-loaded page is a
-                    cache-hit; the route's `:keep-previous?` keeps the prior
-                    page visible while the next first-loads."
+                    DISTINCT cache entries. Back-navigating to a
+                    previously-loaded page is a cache-hit; the route's
+                    `:keep-previous?` keeps the prior page visible while the next
+                    first-loads."
    :params-schema  [:map
                     [:tag  {:optional true} [:maybe :string]]
                     [:page {:optional true} [:maybe :int]]]
@@ -159,8 +149,7 @@
 (rf/reg-resource :realworld/comments
   {:doc            "Comments for an article (public). A sub-resource of the
                     article modelled as an ordinary resource whose params carry
-                    the parent identity (Spec 016 §Sub-resources are ordinary
-                    resources)."
+                    the parent identity (the slug)."
    :params-schema  [:map [:slug :string]]
    :data-schema    schema/CommentsResponse
    :scope          :rf.scope/global
@@ -251,22 +240,19 @@
 ;; ============================================================================
 ;;
 ;; The authenticated user's personalised feed depends on WHO is asking, so it
-;; carries a session scope rather than `:rf.scope/global`. EP-0016 names that
-;; scope ONCE — `reg-resource-scope :realworld/session` (see scope.cljs) — and
-;; the resource declares `:scope {:from-db :realworld/session}`: a derived-scope
-;; REFERENCE the runtime resolves at every site against app-db.
-;;
-;; This is the EP-0016 idiom — naming the scope once, rather than `:rf.scope/
-;; from-caller` hand-wiring (a route ensuring the feed from an event and every
-;; view threading a `:session/scope` payload). The result:
+;; carries a session scope rather than `:rf.scope/global`. A named resolver
+;; states that scope ONCE — `reg-resource-scope :realworld/session` (see
+;; scope.cljs) — and the resource declares `:scope {:from-db :realworld/session}`:
+;; a reference the runtime resolves at every site against app-db. The result:
 ;;   - a `[:rf.resource/state {:resource :realworld/feed :params {…}}]` sub
 ;;     resolves the scope ITSELF — no view passes a `:scope` payload — and
-;;     re-keys reactively across login / logout (Spec 016 §A `{:from-db …}`
-;;     subscription re-keys when the resolver's inputs change);
+;;     re-keys reactively across login / logout;
 ;;   - the home route owns the feed as a declarative `:resources` entry with
 ;;     `:scope {:from-db :realworld/session}` (routing.cljs);
-;;   - logged out, the reference resolves nil — fail-closed: the sub is the
-;;     loud "scope unresolved" condition, never a silent shared-cache read.
+;;   - logged out, the reference resolves nil — fail-closed: the sub is the loud
+;;     "scope unresolved" condition, never a silent shared-cache read.
+;; See the named resolver in scope.cljs and
+;; ../../../docs/resources/how-to/add-auth.md.
 
 (rf/reg-resource :realworld/feed
   {:doc            "The authenticated user's feed (`/articles/feed`). Session-

--- a/examples/reagent/realworld_resources/routing.cljs
+++ b/examples/reagent/realworld_resources/routing.cljs
@@ -1,46 +1,40 @@
 (ns realworld-resources.routing
-  "Routes for the RealWorld-on-resources example.
+  "Routes for the RealWorld-on-resources example. See the routing guide:
+   ../../../docs/routing/concepts.md.
 
-   The headline of this variant: route entry CAUSES the page's server-state to
-   load, declaratively, via `:resources` route metadata (Spec 016 §Route
-   integration). On entry the runtime marks each listed resource active with
-   owner `[:route route-id nav-token]` and ensures it with cause
-   `[:route-entry route-id nav-token]`; on leave it releases the owner by token
-   and suppresses any stale reply by generation. The views never fetch — they
-   read the runtime cache passively.
+   The point of this example: route entry CAUSES the page's server-state to load,
+   declaratively, via `:resources` route metadata. On entry the runtime marks
+   each listed resource active with owner `[:route route-id nav-token]` and
+   ensures it with cause `[:route-entry route-id nav-token]`; on leave it
+   releases the owner by token and suppresses any stale reply by generation. The
+   views never fetch — they read the runtime cache passively.
 
-   `:blocking?` keeps the route transition pending until the resource settles;
-   a non-blocking resource fetches in the background. `:keep-previous?` keeps
-   the prior list visible while a new filter/page first-loads. `:when` makes a
+   `:blocking?` keeps the route transition pending until the resource settles; a
+   non-blocking resource fetches in the background. `:keep-previous?` keeps the
+   prior list visible while a new filter/page first-loads. `:when` makes a
    resource conditional without sentinel nil params.
 
-   (On the server, the same `:blocking?` flag is the SSR wait point — the route
-   plan drains blocking resources before rendering, then serialises the resource
-   partition for the client to hydrate without refetching, Spec 016 §SSR and
-   hydration over Spec 011. This example is CLIENT-ONLY and does NOT exercise
-   that path; the dedicated worked demo of resource SSR preload + hydration is
-   `examples/reagent/resources_ssr/`.)
+   (On the server, the same `:blocking?` flag is the SSR wait point. This example
+   is CLIENT-ONLY; the worked demo of resource SSR preload + hydration is
+   `examples/reagent/resources_ssr/`. See ../../../docs/ssr/concepts.md.)
 
-   The SESSION-scoped personalised feed is a declarative route resource too
-   (EP-0016 D3): the home route declares it with `:scope {:from-db
-   :realworld/session}`, a named-resolver reference (see scope.cljs) the runtime
-   resolves against the navigation handler's app-db at route entry. So the
-   route owns the feed under its nav-token and releases it on leave, exactly
-   like the public reads — the named resolver lets a route `:scope` derive from
-   app-db, so a session read joins the same declarative route plan as the
-   public ones. Logged out, the reference resolves nil and the feed entry is
-   simply not planned (fail-closed — no feed to load).
+   The SESSION-scoped personalised feed is a declarative route resource too: the
+   home route declares it with `:scope {:from-db :realworld/session}`, a named
+   resolver reference (see scope.cljs) the runtime resolves against the
+   navigation handler's app-db at route entry. So the route owns the feed under
+   its nav-token and releases it on leave, exactly like the public reads. Logged
+   out, the reference resolves nil and the feed entry is simply not planned
+   (fail-closed — no feed to load).
 
-   The resources artefact LATE-BINDS the `:resources` route-metadata key into
-   routing, so loading both `re-frame.resources` and `re-frame.routing` is what
-   makes the key accepted (Spec 012 rejects unknown bare route-metadata keys
-   otherwise)."
+   Loading both `re-frame.resources` and `re-frame.routing` is what makes the
+   `:resources` route-metadata key accepted (resources late-binds it into
+   routing)."
   (:require [clojure.string]
             [re-frame.core :as rf]
-            ;; Routing ships in day8/re-frame2-routing. Loading the ns triggers
-            ;; its hook + reg-sub registrations; without it the reg-route calls
-            ;; throw :rf.error/routing-artefact-missing. Aliased so the popstate
-            ;; handler resolves the URL owner via `routing/url-owner-frame-id`.
+            ;; Routing runtime. Loading the ns triggers its hook + reg-sub
+            ;; registrations; without it the reg-route calls throw. Aliased so
+            ;; the popstate handler resolves the URL owner via
+            ;; `routing/url-owner-frame-id`.
             [re-frame.routing :as routing]
             ;; Loading resources is what makes `:resources` route-metadata
             ;; accepted (the late-bound routing extension).
@@ -59,7 +53,7 @@
   [{:resource  :realworld/articles
     ;; Route → resource params: the active tag (param or nil) AND `?page=` flow
     ;; into identity. Every server-visible list option participates in the
-    ;; cache key (Spec 016 §Paginated and previous data).
+    ;; cache key.
     :params    (fn [route] {:tag  (tag-fn route)
                             ;; Default to page 1 so the canonical no-`?page=`
                             ;; URL owns the SAME `{:page 1}` key the views
@@ -73,14 +67,13 @@
    {:resource  :realworld/tags
     :params    (fn [_route] {})
     :blocking? false}
-   ;; The personalised feed — a declarative route resource scoped by the
-   ;; named `{:from-db :realworld/session}` resolver (EP-0016 D3). The runtime
-   ;; resolves the scope against the navigation handler's app-db at route
-   ;; entry, owns it under the route nav-token, and releases it on leave, just
-   ;; like the public reads above. Logged out the reference resolves nil, so
-   ;; the feed is simply not planned (no scope, no fetch — the feed never leaks
-   ;; across users). The `?page=` flows into params here like every other
-   ;; paginated list.
+   ;; The personalised feed — a declarative route resource scoped by the named
+   ;; `{:from-db :realworld/session}` resolver. The runtime resolves the scope
+   ;; against the navigation handler's app-db at route entry, owns it under the
+   ;; route nav-token, and releases it on leave, just like the public reads
+   ;; above. Logged out the reference resolves nil, so the feed is simply not
+   ;; planned (no scope, no fetch — the feed never leaks across users). The
+   ;; `?page=` flows into params here like every other paginated list.
    {:resource  :realworld/feed
     :scope     {:from-db :realworld/session}
     ;; Default to page 1 — the feed subscription reads `(or (:page q) 1)`
@@ -122,19 +115,19 @@
 
 (rf/reg-route :realworld.user/settings
   {:doc  "User settings page (requires auth). `:on-match` seeds the settings
-          draft from the authenticated user ONCE on route entry — the same
-          route-entry seam the `:rf.http/managed` sibling uses (its settings
-          route also `:on-match [[:settings/load]]`). The settings view is then
-          a pure Form-1 that NEVER dispatches out of band, so a re-render can no
-          longer re-run the load and clobber in-progress field edits."
+          draft from the authenticated user ONCE on route entry. The settings
+          view is then a pure Form-1 that NEVER dispatches out of band, so a
+          re-render does not re-run the load and clobber in-progress field
+          edits."
    :on-match [[:settings/load]]
    :tags #{:requires-auth}} "/settings")
 
 (rf/reg-route :realworld.editor/new
   {:doc       "Create a new article (requires auth). `:on-match` resets the
                editor slice + registers the can-submit flow; `:can-leave` blocks
-               a navigate-away while the draft is dirty (Spec 012 §Redirects and
-               guards). No route `:resources` — create starts from a blank draft."
+               a navigate-away while the draft is dirty (see route guard,
+               ../../../docs/routing/glossary.md#route-guard). No route
+               `:resources` — create starts from a blank draft."
    :tags      #{:requires-auth}
    :on-match  [[:editor/initialise]]
    :can-leave [:editor/can-leave?]} "/editor")
@@ -187,7 +180,7 @@
             `:realworld/favorited-articles` resource. The `?page=` query
             paginates it. Favoriting / unfavoriting from this tab invalidates
             `[:article slug]`, which this list carries, so it refetches and the
-            article drops out on unfavorite (Spec 016 §Mutations)."
+            article drops out on unfavorite."
    :params [:map [:username :string]]
    :query  [:map [:page {:optional true} :int]]
    :resources
@@ -205,14 +198,15 @@
   {:doc "Fallback when no other route matches."} "/_404")
 
 ;; ============================================================================
-;; AUTH GUARD  (Spec 012 §Redirects and guards)
+;; AUTH GUARD
 ;; ============================================================================
 ;;
 ;; Route-level auth is a plain interceptor. It redirects unauthenticated users
 ;; away from any `:requires-auth`-tagged route to login, stashing the intended
-;; target under `[:auth :return-to]` for post-login bounce-back. Gates all
-;; three navigation entry points (programmatic nav, anchor click, URL-bar /
-;; popstate) so a protected route is unreachable logged-out by any path.
+;; target under `[:auth :return-to]` for post-login bounce-back. Gates all three
+;; navigation entry points (programmatic nav, anchor click, URL-bar / popstate)
+;; so a protected route is unreachable logged-out by any path. See route guard:
+;; ../../../docs/routing/glossary.md#route-guard.
 
 (defn- resolve-nav-target [[ev-id a _b]]
   (case ev-id
@@ -226,16 +220,16 @@
                                   {:id route-id :params (or params {})})
     nil))
 
-;; EP-0022: the guard is a REGISTERED interceptor referenced BY ID
+;; The guard is a REGISTERED interceptor referenced BY ID
 ;; (`:realworld-resources.routing/auth-guard`) from the demo frame's
-;; `:interceptors` chain — set in the `frame-provider {:id …}` ENSURE form in
+;; `:interceptors` chain — set in the `frame-provider {:id …}` ensure form in
 ;; core.cljs, not an inline value. `reg-interceptor` is a top-level load-time
 ;; registration; core.cljs requires this ns, so the descriptor is registered
 ;; before the provider's config resolves the reference at frame creation.
 (rf/reg-interceptor :realworld-resources.routing/auth-guard
-  {:doc "Route-level auth guard (Spec 012 §Redirects and guards): redirect
-         unauthenticated users away from `:requires-auth`-tagged routes to
-         login, stashing the intended target for post-login bounce-back."}
+  {:doc "Route-level auth guard: redirect unauthenticated users away from
+         `:requires-auth`-tagged routes to login, stashing the intended target
+         for post-login bounce-back."}
   {:before (fn auth-guard-before [ctx]
              (if-let [{:keys [id params]} (resolve-nav-target (get-in ctx [:coeffects :event]))]
                (let [route-meta  (rf/handler-meta :route id)
@@ -253,7 +247,7 @@
                ctx))})
 
 ;; ============================================================================
-;; ROUTER WIRING  (base-path-aware, like the :rf.http/managed sibling)
+;; ROUTER WIRING  (base-path-aware)
 ;; ============================================================================
 
 (def ^:dynamic *base-path* "")

--- a/examples/reagent/realworld_resources/schema.cljs
+++ b/examples/reagent/realworld_resources/schema.cljs
@@ -1,24 +1,22 @@
 (ns realworld-resources.schema
   "Malli schemas for the RealWorld-on-resources (Conduit) example.
 
-   These describe the wire payloads the RealWorld API returns. Unlike the
-   `:rf.http/managed` sibling (`examples/reagent/realworld/`), this variant
-   does NOT register Pattern-RemoteData app-db slice schemas for the reads —
-   the cached server-state lives in the framework-owned runtime partition
-   (`:rf.runtime/resources`), not in app-db, so there are no `:articles` /
-   `:article` / `:comments` / `:profile` slice paths to validate. What stays
-   in app-db here is only the small auth slice and the per-form drafts.
+   These describe the wire payloads the RealWorld API returns. There are no
+   app-db slice schemas for the reads — the cached server-state lives in the
+   framework-owned runtime partition (`:rf.runtime/resources`), not in app-db, so
+   there are no `:articles` / `:article` / `:comments` / `:profile` slice paths to
+   validate. What stays in app-db here is only the small auth slice and the
+   per-form drafts.
 
-   The wire shapes double as resource `:data-schema` values and as the
-   `:decode` schemas inside each resource / mutation `:request` (Spec 014
-   §Schema-driven decode lowered through the resource transport).
+   The wire shapes double as resource `:data-schema` values and as the `:decode`
+   schemas inside each resource / mutation `:request`. See schema:
+   ../../../docs/guide/glossary.md#schema.
 
    The RealWorld API spec is documented at:
      https://github.com/gothinkster/realworld/tree/main/api"
   (:require [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas. Loading
-            ;; the ns registers its late-bind hooks so rf/reg-app-schemas
-            ;; resolves at the call site below.
+            ;; The schemas runtime. Loading the ns registers the hooks so
+            ;; rf/reg-app-schemas resolves at the call site below.
             [re-frame.schemas])
   (:require-macros [re-frame.core :refer [with-frame]]))
 
@@ -29,14 +27,14 @@
 (def User
   "The authenticated user. Returned by /users/login, /users (register),
    /user (current user), and PUT /user (settings update)."
-  ;; EP-0025 / Spec 015: the JWT is classified at the transient slot that
-  ;; introduces it, via the per-slot `:sensitive?` malli property on the
-  ;; `:decode` schema (the transient-response-body route) — `UserResponse` is
-  ;; the `:decode` schema for the login / register / restore / settings replies,
-  ;; so this redacts the token out of any off-box capture of the response body.
-  ;; The durable copy at [:auth :token] is classified separately by the
-  ;; commit-plane `:sensitive` effect in core.cljs (classification does not
-  ;; propagate — each surface is declared on its own).
+  ;; The JWT is classified at the transient slot that introduces it, via the
+  ;; per-slot `:sensitive?` malli property on the `:decode` schema. `UserResponse`
+  ;; is the `:decode` schema for the login / register / restore / settings
+  ;; replies, so this redacts the token out of any off-box capture of the response
+  ;; body. The durable copy at [:auth :token] is classified separately by the
+  ;; `:sensitive` effect in core.cljs (classification does not propagate — each
+  ;; surface is declared on its own). See data classification:
+  ;; ../../../docs/guide/glossary.md#data-classification.
   [:map
    [:email    :string]
    [:token    {:sensitive? true} :string]
@@ -82,9 +80,9 @@
 ;; ============================================================================
 ;;
 ;; The Conduit API wraps every payload in a singular/plural top-level key.
-;; These schemas describe the wire envelope; they are passed as `:decode`
-;; inside each resource / mutation `:request` (Spec 014 §Schema-driven decode,
-;; which the resource transport lowers onto managed HTTP).
+;; These schemas describe the wire envelope; they are passed as `:decode` inside
+;; each resource / mutation `:request` (the resource transport lowers the decode
+;; onto managed HTTP).
 
 (def UserResponse     [:map [:user User]])
 (def ProfileResponse  [:map [:profile Profile]])
@@ -100,11 +98,10 @@
 ;; APP-DB SLICES — only what app-db still owns
 ;; ============================================================================
 ;;
-;; In the resources variant the cached reads live in runtime-db, not app-db.
-;; The only app-db schema is the auth slice plus the two auth form drafts.
-;; (The settings form here is a mutation instance + a small draft slice;
-;; the auth machine snapshot lives in runtime-db and is validated by its own
-;; `:data-schema`, not an app-schema — EP-0001 Mike ruling #11.)
+;; The cached reads live in runtime-db, not app-db. The only app-db schema is the
+;; auth slice plus the two auth form drafts. (The settings form is a mutation
+;; instance + a small draft slice; the auth machine snapshot lives in runtime-db
+;; and is validated by its own `:data-schema`, not an app-schema.)
 
 (def AuthSlice
   "The auth slice. :user holds the current User payload (or nil); :token is
@@ -121,10 +118,10 @@
      [:params [:maybe :map]]]]])
 
 (def FormSlice
-  "The standard Pattern-Forms draft slice for the login / register / settings
-   drafts that still live in app-db. (Submission lifecycle moves to a mutation
-   INSTANCE — `:rf.mutation/state` — for the settings form, so the slice here
-   carries only the editable draft + touched-field bookkeeping.)"
+  "The standard form draft slice for the login / register / settings drafts that
+   live in app-db. The submission lifecycle is a mutation INSTANCE
+   (`:rf.mutation/state`), so this slice carries only the editable draft +
+   touched-field bookkeeping."
   [:map
    [:draft   :map]
    [:touched [:set :keyword]]
@@ -138,12 +135,12 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 ;;
-;; EP-0002: reg-app-schemas is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; :rf/default (the id `core/run`'s `frame-provider {:id :rf/default}` ENSURE
-;; form creates at the render root), so name it here. This is a frame-local
-;; REGISTRATION scoped by id, not a frame-creation/seed — it binds the id at
-;; ns-load; the frame itself is created later when the provider first renders.
+;; reg-app-schemas is frame-local: a bare ns-load call with no frame context
+;; fails. This example runs in `:rf/default` (the `frame-provider {:id …}` form
+;; in core.cljs creates it at the render root), so name it here. This is a
+;; frame-local REGISTRATION scoped by id, not a frame-creation/seed — it binds
+;; the id at ns-load; the frame itself is created later when the provider first
+;; renders.
 
 (with-frame :rf/default
   (rf/reg-app-schemas

--- a/examples/reagent/realworld_resources/scope.cljs
+++ b/examples/reagent/realworld_resources/scope.cljs
@@ -1,45 +1,39 @@
 (ns realworld-resources.scope
-  "The resource cache SCOPE for this app — the fail-closed leak boundary
-   (Spec 016 §Scope resolution), expressed as a NAMED resource-scope resolver
-   (Spec 016 §Named resource-scope resolvers — `reg-resource-scope`, EP-0016
-   Decision 3).
+  "The resource cache SCOPE for this app — the fail-closed leak boundary,
+   expressed as a NAMED resource-scope resolver (`reg-resource-scope`). See
+   scope: ../../../docs/resources/glossary.md#scope, and the worked walkthrough
+   in ../../../docs/resources/how-to/add-auth.md.
 
    Scope is the cache's tenant / user / permission boundary, and it MUST fail
    closed: a resource never silently defaults to a shared cache. This example
    reads two KINDS of server-state, so it demonstrates BOTH scope policies:
 
    - PUBLIC reads — the global article list, a tag-filtered list, an article's
-     detail, an author profile, the popular-tags sidebar, an article's
-     comments. These are the same for every viewer, so each resource declares
-     the explicit, auditable `:scope :rf.scope/global` claim.
+     detail, an author profile, the popular-tags sidebar, an article's comments.
+     These are the same for every viewer, so each resource declares the explicit,
+     auditable `:scope :rf.scope/global` claim.
 
-   - SESSION reads — the authenticated user's personalised feed (`/articles/
-     feed`). What that returns depends on WHO is asking, so it carries a
-     session scope `[:rf.scope/session {:username …}]`. A logged-out user must
+   - SESSION reads — the authenticated user's personalised feed
+     (`/articles/feed`). What that returns depends on WHO is asking, so it carries
+     a session scope `[:rf.scope/session {:username …}]`. A logged-out user must
      never see the previous user's feed from cache.
 
-   ## One named resolver, every site (the EP-0016 idiom)
+   ## One named resolver, every site
 
-   The session/feed seam answers one fact — \"who is the current viewer?\" — and
-   a named resource-scope resolver states that fact ONCE rather than wiring it
-   by hand at every site. Hand-wiring would mean: the feed resource declaring
-   `:rf.scope/from-caller`, the home route ensuring it from an event (a route
-   `:scope` resolver can't see app-db), every view threading a `:session/scope`
-   value onto its subscription payload, and a favourite toggle needing an extra
-   explicit session-scoped invalidation because a global-scope mutation can't
-   reach the session feed — four hand-wired seams for one fact.
-
-   `reg-resource-scope :realworld/session` with declared db inputs names that
-   fact once, and every site references it as `{:from-db :realworld/session}`:
+   The session/feed seam answers one fact — \"who is the current viewer?\" — and a
+   named resource-scope resolver states that fact ONCE rather than wiring it by
+   hand at every site. `reg-resource-scope :realworld/session` with declared db
+   inputs names that fact once, and every site references it as
+   `{:from-db :realworld/session}`:
 
    - the feed RESOURCE declares `:scope {:from-db :realworld/session}`
      (resources.cljs), so a subscription resolves the scope itself — no view
      threads a scope payload, and the sub re-keys reactively across login /
-     logout (Spec 016 §A `{:from-db …}` subscription re-keys);
-   - the home ROUTE declares the feed as a `:resources` entry with `:scope
-     {:from-db :realworld/session}` (routing.cljs) — resolved against the
-     navigation handler's app-db at route entry, owned by the nav-token,
-     released on leave. No `:on-match` event, no app-minted lease;
+     logout;
+   - the home ROUTE declares the feed as a `:resources` entry with
+     `:scope {:from-db :realworld/session}` (routing.cljs) — resolved against the
+     navigation handler's app-db at route entry, owned by the nav-token, released
+     on leave. No `:on-match` event, no app-minted lease;
    - the favourite / unfavourite MUTATIONS carry a per-target invalidation
      descriptor `{:scope {:from-db :realworld/session} :tags #{[:feed]}}`
      (mutations.cljs) — one mutation invalidates global article tags AND the
@@ -50,26 +44,24 @@
 
    `nil` is the fail-closed unresolved condition everywhere: a logged-out
    subscription is the loud \"scope unresolved\" diagnostic, not a silent shared
-   read; a logged-out route entry / invalidation descriptor resolves nil and
-   does nothing (no feed to reach); logout resolves nil and skips the clear."
+   read; a logged-out route entry / invalidation descriptor resolves nil and does
+   nothing (no feed to reach); logout resolves nil and skips the clear."
   (:require [re-frame.core :as rf]
-            ;; Resources ship `reg-resource-scope` (and the `:resource-scope`
-            ;; registrar kind it writes); requiring the ns wires the late-bind
+            ;; Resources ship `reg-resource-scope`; requiring the ns wires the
             ;; hooks so the macro resolves.
             [re-frame.resources]))
 
 ;; ============================================================================
-;; THE NAMED SESSION SCOPE RESOLVER  (EP-0016 D3)
+;; THE NAMED SESSION SCOPE RESOLVER
 ;; ============================================================================
 ;;
-;; `reg-resource-scope` registers a PURE resolver under an id; every derived-
-;; scope site references it as `{:from-db :realworld/session}`. The declared
-;; `:inputs` name the single app-db fact that decides the scope — the
-;; authenticated user's `:username` — so the runtime re-resolves the scope only
-;; when THAT path changes (login / logout / account switch), and tooling can
-;; explain which fact decides a resource's identity. `:resolve` is pure: it
-;; derives the canonical session-scope value, or `nil` when logged out (the
-;; fail-closed unresolved condition).
+;; `reg-resource-scope` registers a PURE resolver under an id; every derived-scope
+;; site references it as `{:from-db :realworld/session}`. The declared `:inputs`
+;; name the single app-db fact that decides the scope — the authenticated user's
+;; `:username` — so the runtime re-resolves the scope only when THAT path changes
+;; (login / logout / account switch), and tooling can explain which fact decides a
+;; resource's identity. `:resolve` is pure: it derives the canonical session-scope
+;; value, or `nil` when logged out (the fail-closed unresolved condition).
 
 (rf/reg-resource-scope :realworld/session
   {:doc     "The current session's resource cache scope — the per-user leak

--- a/examples/reagent/realworld_resources/settings.cljs
+++ b/examples/reagent/realworld_resources/settings.cljs
@@ -3,42 +3,34 @@
 
    Settings update is a WRITE, so it is a MUTATION (`:realworld/update-settings`
    in realworld-resources.mutations): the form fires `:rf.mutation/execute` and
-   watches the instance through `[:rf.mutation/state {:instance …}]`
-   (`:pending?` / `:success?` / `:error?`), with NO app-db submission-status
-   slice to maintain. On success the saved User comes back as the reply value;
-   the continuation pushes it into the auth slice and navigates to the profile,
-   and the mutation's `:invalidates` clears the public profile read so a later
-   visit re-reads the new bio.
+   watches the instance through `[:rf.mutation/state {:instance …}]` (`:pending?`
+   / `:success?` / `:error?`), with NO app-db submission-status slice to maintain.
+   On success the saved User comes back as the reply value; the continuation
+   pushes it into the auth slice and navigates to the profile, and the mutation's
+   `:invalidates` clears the public profile read so a later visit re-reads the new
+   bio.
 
-   What stays in app-db is only the editable DRAFT (the live field values) —
-   the lifecycle (`:idle` / `:pending` / `:success` / `:error`) is the mutation
+   What stays in app-db is only the editable DRAFT (the live field values) — the
+   lifecycle (`:idle` / `:pending` / `:success` / `:error`) is the mutation
    instance, not a `:status` field.
 
-   SUCCESS CONTINUATION — a call-site `:reply-to` (EP-0016 D1). The submit
-   passes `:reply-to [:settings/replied]` to `:rf.mutation/execute`; when the
-   runtime ACCEPTS the reply as current (frame + instance + work-id +
-   generation matched), it dispatches `[:settings/replied reply]` exactly once,
-   with the canonical reply map appended — AFTER cache consequences and
-   instance settlement have applied (Spec 016 §Mutation completion
-   continuations, phase 6). The continuation reads `(:status reply)` to fold
-   the saved User on `:ok` and surface the error on `:error`. A stale /
-   superseded reply never fires it (the mandatory stale-suppression boundary,
-   inherited for free).
+   SUCCESS CONTINUATION — a call-site `:reply-to`. The submit passes
+   `:reply-to [:settings/replied]` to `:rf.mutation/execute`; when the runtime
+   ACCEPTS the reply as current (frame + instance + work-id + generation matched),
+   it dispatches `[:settings/replied reply]` exactly once, with the canonical
+   reply map appended — AFTER cache consequences and instance settlement have
+   applied. The continuation reads `(:status reply)` to fold the saved User on
+   `:ok` and surface the error on `:error`. A stale / superseded reply never fires
+   it.
 
-   `:reply-to` is the mutation's reply-side continuation — a CAUSAL EVENT
-   TARGET (an ordinary event through the tape / interceptors / replay), not a
-   callback. It keeps the view a plain Form-1: a pure function of subs that
-   never dispatches out of band. The alternative — an off-render Form-3
-   `reagent.ratom/run!` reaction watching `[:rf.mutation/state …]` for
-   settlement — pulls a side-effecting reaction into the view; `:reply-to`
-   gives the same settle hook as a declarative, replayable event target.
-
-   Compare the `:rf.http/managed` sibling (`examples/reagent/realworld/`): its
-   settings submit gets the continuation via the request's `:on-success
-   [:settings/submit-success]`. A mutation deliberately gives up the request's
-   reply-side dispatch (the runtime owns reply addressing for stale-
-   suppression); `:reply-to` restores an equivalent — and stale-safe —
-   continuation seam on the mutation surface."
+   `:reply-to` is the mutation's reply-side continuation — a CAUSAL EVENT TARGET
+   (an ordinary event through the tape / interceptors / replay), not a callback.
+   It keeps the view a plain Form-1: a pure function of subs that never dispatches
+   out of band. The alternative — an off-render Form-3 `reagent.ratom/run!`
+   reaction watching `[:rf.mutation/state …]` for settlement — pulls a
+   side-effecting reaction into the view; `:reply-to` gives the same settle hook
+   as a declarative, replayable event target. See the reply map:
+   ../../../docs/resources/glossary.md#reply-map."
   (:require [re-frame.core :as rf]
             [re-frame.resources]
             [realworld-resources.http :as rh])
@@ -79,8 +71,8 @@
 (rf/reg-event :settings/submit
   {:doc "Fire the update-settings mutation with the current draft. The form
          watches the `:settings/save` instance for pending / error; the success
-         continuation is the call-site `:reply-to [:settings/replied]` target
-         (EP-0016 D1), dispatched once when the reply is accepted."}
+         continuation is the call-site `:reply-to [:settings/replied]` target,
+         dispatched once when the reply is accepted."}
   (fn [{:keys [db]} _]
     (let [draft (get-in db [:settings-form :draft])]
       {:fx [[:dispatch [:rf.mutation/execute
@@ -92,13 +84,13 @@
 
 (rf/reg-event :settings/replied
   {:doc "The update-settings mutation completion continuation (the `:reply-to`
-         target). Receives the canonical reply map appended as the final arg
-         (EP-0016 D1) — observed AFTER the mutation's `:invalidates` cleared the
-         public profile read and the instance settled. On `:ok` push the saved
-         User (the reply `:value`) into the auth slice, clear the instance, and
-         navigate to the user's profile. On `:error` the form already shows the
-         error off the instance state — nothing more to do here. Clearing the
-         instance also makes the dispatch idempotent."}
+         target). Receives the canonical reply map appended as the final arg —
+         observed AFTER the mutation's `:invalidates` cleared the public profile
+         read and the instance settled. On `:ok` push the saved User (the reply
+         `:value`) into the auth slice, clear the instance, and navigate to the
+         user's profile. On `:error` the form already shows the error off the
+         instance state — nothing more to do here. Clearing the instance also
+         makes the dispatch idempotent."}
   (fn [_ [_ {:keys [status value]}]]
     (if (= :ok status)
       (let [user (:user value)]
@@ -113,10 +105,10 @@
 ;; VIEW  (pure Form-1 render — never dispatches out of band)
 ;; ============================================================================
 ;;
-;; The render is a normal registered `reg-view` (Form-1): a pure function of
-;; subs that NEVER dispatches (Spec 004 §View antipatterns). The success
-;; continuation is the mutation's `:reply-to` target (EP-0016 D1), not an
-;; off-render reaction — so the view holds no lifecycle hooks at all.
+;; The render is a normal registered `reg-view` (Form-1): a pure function of subs
+;; that NEVER dispatches. The success continuation is the mutation's `:reply-to`
+;; target, not an off-render reaction — so the view holds no lifecycle hooks at
+;; all.
 
 (reg-view ^{:doc "The settings form — a pure function of subs. Submit fires the
                    update-settings mutation; the success continuation is the

--- a/examples/reagent/realworld_resources/views.cljs
+++ b/examples/reagent/realworld_resources/views.cljs
@@ -1,31 +1,30 @@
 (ns realworld-resources.views
   "Views + the small event glue for the RealWorld-on-resources example.
 
-   Every page reads its server-state PASSIVELY through `[:rf.resource/*]` subs
-   (Spec 016 §Subscriptions) — no view fetches. The route's `:resources`
-   metadata caused the load. The cond over `:loading?` / `:has-data?` /
-   `:error` / `:fetching?` / `:refresh-error` is the canonical resource render
-   shape:
+   Every page reads its server-state PASSIVELY through `[:rf.resource/*]` subs —
+   no view fetches. The route's `:resources` metadata caused the load. The cond
+   over `:loading?` / `:has-data?` / `:error` / `:fetching?` / `:refresh-error` is
+   the canonical resource render shape:
    - `:loading?`                         → skeleton (first load, no data)
    - `:error` AND NOT `:has-data?`       → error (first load failed)
    - else render `:data`, plus a quiet refresh indicator while `:fetching?`,
      plus a refresh warning when a background refresh failed (`:refresh-error`,
      prior data kept).
+   See resource status: ../../../docs/resources/glossary.md#resource-status.
 
    WRITES fire mutations (`:rf.mutation/execute`) and watch the instance
    passively (`[:rf.mutation/state {:instance …}]`); the success continuation is
-   the call-site `:reply-to` event target (EP-0016 D1), dispatched once when the
-   reply is accepted, AFTER the mutation's `:invalidates` refetched the affected
-   reads — the read→write→invalidate→refetch loop, end to end, plus a stale-safe
-   reply-side continuation, with NO off-render reactions in this ns.
+   the call-site `:reply-to` event target, dispatched once when the reply is
+   accepted, AFTER the mutation's `:invalidates` refetched the affected reads —
+   the read→write→invalidate→refetch loop, end to end, with NO off-render
+   reactions in this ns.
 
-   Scope: every page reads through `[:rf.resource/*]` subs that resolve their
-   OWN scope. The public reads carry the sub-resolvable `:rf.scope/global`
-   policy; the session-scoped feed declares `:scope {:from-db :realworld/session}`
+   Scope: every page reads through `[:rf.resource/*]` subs that resolve their OWN
+   scope. The public reads carry the sub-resolvable `:rf.scope/global` policy; the
+   session-scoped feed declares `:scope {:from-db :realworld/session}`
    (resources.cljs), a named-resolver reference the subscription resolves against
-   app-db and RE-KEYS reactively across login / logout (Spec 016 §A `{:from-db
-   …}` subscription re-keys). No view threads a `:scope` payload — the resolver
-   is the single scope-resolution currency."
+   app-db and RE-KEYS reactively across login / logout. No view threads a
+   `:scope` payload — the resolver is the single scope-resolution currency."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.resources]
@@ -127,20 +126,20 @@
 ;; The official Conduit article page carries contextual controls: a non-author
 ;; viewer follows/unfollows the AUTHOR; the author sees Edit (→ /editor/:slug)
 ;; and Delete. Logged-out viewers see neither. Both the follow continuation and
-;; the delete continuation are call-site `:reply-to` targets (EP-0016 D1) —
-;; the mutation reply-side seam, declared at the call site rather than emulated
-;; with Form-3 settle reactions on the article page.
+;; the delete continuation are call-site `:reply-to` targets — the mutation
+;; reply-side seam, declared at the call site rather than emulated with Form-3
+;; settle reactions on the article page.
 
 (rf/reg-event :ui/follow-author
   {:doc "Follow / unfollow the article author from the detail page. Fires the
-         follow / unfollow mutation; the detail page's embedded `:author` lives
-         in the `[:article slug]` entry (not the `[:profile username]` resource
-         the follow mutation invalidates), so the article is re-staled when the
-         follow SETTLES — by the `:reply-to [:ui/follow-author-replied slug]`
-         continuation, which carries the slug. (Staling eagerly here would
-         refetch before the server processed the follow, so the embedded flag
-         would read its old value; the continuation fires AFTER the accepted
-         reply.) Auth-gated."}
+         follow / unfollow mutation; the detail page's embedded `:author` lives in
+         the `[:article slug]` entry (not the `[:profile username]` resource the
+         follow mutation invalidates), so the article is re-staled when the follow
+         SETTLES — by the `:reply-to [:ui/follow-author-replied slug]`
+         continuation, which carries the slug. (Staling eagerly here would refetch
+         before the server processed the follow, so the embedded flag would read
+         its old value; the continuation fires AFTER the accepted reply.)
+         Auth-gated."}
   (fn [{:keys [db]} [_ slug username following?]]
     (if (nil? (get-in db [:auth :user]))
       {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
@@ -152,14 +151,13 @@
                          :cause    [:click :ui/follow-author username]}]]]})))
 
 (rf/reg-event :ui/follow-author-replied
-  {:doc "Follow / unfollow completion continuation (the `:reply-to` target,
-         EP-0016 D1). On `:ok`, stale the current article so its embedded
-         `:author.following` refetches — the follow mutation invalidates
-         `[:profile username]`, but the detail's embedded author flag lives in
-         the `[:article slug]` entry, which only this call site knows the slug
-         for. The slug rides as a static call-site arg; the reply map is
-         appended after it. Global scope — the article read is
-         `:rf.scope/global`."}
+  {:doc "Follow / unfollow completion continuation (the `:reply-to` target). On
+         `:ok`, stale the current article so its embedded `:author.following`
+         refetches — the follow mutation invalidates `[:profile username]`, but the
+         detail's embedded author flag lives in the `[:article slug]` entry, which
+         only this call site knows the slug for. The slug rides as a static
+         call-site arg; the reply map is appended after it. Global scope — the
+         article read is `:rf.scope/global`."}
   (fn [_ [_ slug {:keys [status]}]]
     (if (= :ok status)
       {:fx [[:dispatch [:rf.resource/invalidate-tags
@@ -238,13 +236,13 @@
        [rf/route-link {:to :realworld.profile/show :params {:username (:username author)} :class "author"}
         (:username author)]
        [:span.date createdAt]]
-      ;; OPTIMISTIC favorite (EP-0019). The heart + count already reflect the
-      ;; click — the `:optimistic-tags` apply flipped the cached article before
-      ;; the request left, so `favorited` / `favoritesCount` (read from the
-      ;; resource cache) are already the new values. We DON'T disable the button
-      ;; on `:pending?` — the user sees their change land instantly; a failed
-      ;; write rolls it back. `:optimistic?` marks "showing my optimistic value,
-      ;; not yet confirmed" for a subtle in-flight cue.
+      ;; OPTIMISTIC favorite. The heart + count already reflect the click — the
+      ;; `:optimistic-tags` apply flipped the cached article before the request
+      ;; left, so `favorited` / `favoritesCount` (read from the resource cache)
+      ;; are already the new values. We DON'T disable the button on `:pending?` —
+      ;; the user sees their change land instantly; a failed write rolls it back.
+      ;; `:optimistic?` marks "showing my optimistic value, not yet confirmed" for
+      ;; a subtle in-flight cue.
       [:button.btn.btn-outline-primary.btn-sm.pull-xs-right
        {:type "button"
         :data-testid (str "favorite-" slug)
@@ -295,8 +293,7 @@
                   first-loads, the resource state carries `:previous? true` +
                   `:previous-data` (the prior key's articles). We render those
                   PLUS a placeholder indicator so the user sees the old page,
-                  not a skeleton, until the new page settles — no flicker
-                  (Spec 016 §Paginated and previous data)."}
+                  not a skeleton, until the new page settles — no flicker."}
           article-list [{:keys [state empty-msg current-page on-page]}]
   (cond
     ;; First-ever load with no usable data AND no previous page to show.
@@ -340,10 +337,10 @@
                   of band. The personalised feed reads through the named
                   `{:from-db :realworld/session}` scope resolver: the
                   subscription resolves its own scope (no `:scope` payload to
-                  thread) and re-keys reactively across login / logout (Spec 016
-                  §A `{:from-db …}` subscription re-keys). Favouriting reflects
-                  in Your Feed via the mutation's own session-scoped invalidation
-                  descriptor — no off-render reaction, no app-level feed patch."}
+                  thread) and re-keys reactively across login / logout.
+                  Favouriting reflects in Your Feed via the mutation's own
+                  session-scoped invalidation descriptor — no off-render reaction,
+                  no app-level feed patch."}
           home-page []
   (let [authed?      @(subscribe [:auth/authenticated?])
         your-feed?   @(subscribe [:home/your-feed?])
@@ -351,8 +348,7 @@
         page         @(subscribe [:home/page])
         tags-state   @(subscribe [:rf.resource/state {:resource :realworld/tags :params {}}])
         ;; The global list is keyed by the active `:tag` AND `:page` — the SAME
-        ;; params the route ensured under, so the sub reads the right cache key
-        ;; (Spec 016 §Paginated and previous data).
+        ;; params the route ensured under, so the sub reads the right cache key.
         list-state   @(subscribe [:rf.resource/state {:resource :realworld/articles
                                                        :params  {:tag selected-tag :page page}}])
         ;; The personalised feed: the resource declares `:scope {:from-db
@@ -466,13 +462,12 @@
 
 (reg-view ^{:doc "The article-detail page — a pure function of subs that never
                   dispatches out of band. The two settle continuations the page
-                  needs are the mutations' own `:reply-to` targets (EP-0016
-                  D1): deleting fires `:ui/delete-article` → `:reply-to
-                  [:ui/article-deleted]` (navigate home), and following the
-                  author fires `:ui/follow-author` → `:reply-to
-                  [:ui/follow-author-replied slug]` (re-stale `[:article slug]`
-                  so the embedded author flag refetches). No Form-3 wrapper, no
-                  off-render reaction."}
+                  needs are the mutations' own `:reply-to` targets: deleting
+                  fires `:ui/delete-article` → `:reply-to [:ui/article-deleted]`
+                  (navigate home), and following the author fires
+                  `:ui/follow-author` → `:reply-to [:ui/follow-author-replied
+                  slug]` (re-stale `[:article slug]` so the embedded author flag
+                  refetches). No Form-3 wrapper, no off-render reaction."}
           article-page []
   (let [slug          (:slug @(subscribe [:rf.route/params]))
         current-user  @(subscribe [:auth/user])
@@ -502,13 +497,13 @@
             (when (:fetching? article-state)
               [:span {:data-testid "article-refreshing"} " (refreshing…)"])
             [:span.article-controls
-             ;; The official RealWorld article-detail favorite
-             ;; control shows visible "Favorite"/"Unfavorite" text and toggles
+             ;; The official RealWorld article-detail favorite control shows
+             ;; visible "Favorite"/"Unfavorite" text and toggles
              ;; `.btn-outline-primary` ↔ `.btn-primary` on the favorited flag —
              ;; the E2E contract asserts on both. (The compact heart-only card
              ;; button stays `.btn-outline-primary`, correct per the official
              ;; client.)
-             ;; OPTIMISTIC favorite (EP-0019): the label, the
+             ;; OPTIMISTIC favorite: the label, the
              ;; `.btn-primary`/`.btn-outline-primary` class, and the count all
              ;; flip the instant the heart is clicked (the cached article was
              ;; patched before the request left), then settle to the server's

--- a/examples/reagent/resources/core.cljs
+++ b/examples/reagent/resources/core.cljs
@@ -1,92 +1,73 @@
 (ns resources.core
-  "Worked example for [Spec 016 Resources](../../../spec/016-Resources.md)
-   (the read-resource surface). A small server-state app — an articles
-   list and an article detail — demonstrating the resource surface
-   composed as proper re-frame2: app-db + events + subs, views passive,
-   fetches caused.
+  "A worked example of resources — named, cached server-state reads. See the
+   [resources guide](../../../docs/resources/concepts.md) and its
+   [glossary](../../../docs/resources/glossary.md).
 
-   It teaches, in one cohesive app, four causal patterns:
+   The app is a small articles list plus an article detail. It is ordinary
+   re-frame2: app-db, events, subs, passive views. Views never fetch — the
+   fetch is always caused for them.
 
-   - ROUTE-DRIVEN page load — a route declares `:resources`; route entry
-     ensures them under a `[:route route-id nav-token]` owner.
-   - EVENT-DRIVEN ensure     — an event ensures a resource under an
-     app-minted `[:lease …]` owner with a matching release path.
-   - MANUAL refresh          — a button dispatches `:rf.resource/refetch`
-     with a `:cause` (NOT an owner — a refresh keeps nothing alive).
-   - MACHINE-OWNED resource  — a machine action ensures under a
-     `[:machine machine-id instance-id]` owner (released on actor destroy).
+   It shows four ways a fetch gets caused, all wired into the UI:
 
-   Views read everything through the PASSIVE `[:rf.resource/*]` subs; no
-   view fetches. Scope is the fail-closed leak boundary — this example
-   reads public, non-user-specific data, so each resource declares the
-   explicit, auditable `:rf.scope/global` claim (a user/tenant-scoped read
-   would carry a scope resolver instead).
+   - ROUTE-DRIVEN page load — a route declares `:resources`; entering the
+     route ensures them, owned by the route for as long as you stay on it.
+   - EVENT-DRIVEN ensure     — an event ensures a resource under an app-minted
+     `[:lease …]` owner, with a matching release event.
+   - MANUAL refresh          — a button refetches with a `:cause` and no owner
+     (a refresh wants fresh data but keeps nothing alive).
+   - MACHINE-OWNED resource  — a machine ensures a resource owned for the
+     actor's lifetime, released when the actor is destroyed.
 
-   All four patterns are WIRED INTO THE UI and run live. The articles page
-   carries a Refresh button (manual cause), a per-row Preview toggle (event
-   lease ensure/release), and an Open-in-reader button (machine-owned ensure);
-   route entry drives the list + detail loads. The example ships no backend,
-   so it overrides `:rf.http/managed` with a per-URL canned stub that
-   delegates to the framework-shipped `:rf.http/managed-canned-success`
-   (Spec 014 §Testing) — the same reply shape a live server would produce, so
-   every ensure exercises a REAL fetch, in-flight dedupe, and the passive
-   status flow (a 120 ms delay lets the loading skeleton render before the
-   reply lands, so first-load and refresh-in-flight are observable). A repeat
-   ensure of an entry still inside its `:stale-after-ms` window FRESH-SKIPS
-   (no refetch — `:rf.resource/cache-hit`); the manual Refresh forces a
-   refetch regardless.
+   An owner keeps a cached entry alive; a cause records why a fetch happened.
+   See [owner & cause](../../../docs/resources/glossary.md#owner--cause).
 
-   Resources is a POST-V1 optional artefact. The read-resource runtime
-   provides `reg-resource`, the `:rf.resource/*` passive
-   subs, route `:resources` metadata, and the causal `:rf.resource/ensure` /
-   `:rf.resource/refetch` / `:rf.resource/invalidate-tags` /
-   `:rf.resource/release-owner` event bodies. This example covers the READ
-   side only; mutations (`reg-mutation` / `:rf.mutation/execute`) are covered
-   in the guide (docs/resources/concepts.md §Writes invalidate by tag —
-   causally) and the migration walkthrough. GraphQL is a deferred later phase. The
-   example tree is test-free; resource-contract coverage lives in
-   `implementation/resources/test/` and the conformance fixtures."
+   Every resource declares `:scope :rf.scope/global` — this data is public and
+   the same for everyone. Scope is a required, fail-closed leak boundary; a
+   per-user read would carry a scope resolver instead. See
+   [scope](../../../docs/resources/glossary.md#scope).
+
+   The example ships no backend. It overrides the `:rf.http/managed` effect
+   with a per-URL stub that returns canned articles, so every ensure runs a
+   real fetch with real in-flight dedupe and the real status flow. A 120 ms
+   reply delay lets the loading skeleton render before data lands, so
+   first-load and refresh-in-flight are visible. Re-ensuring an entry that is
+   still inside its `:stale-after-ms` window skips the refetch; the manual
+   Refresh forces one regardless.
+
+   This example covers reads only. Writes — mutations that invalidate reads by
+   tag — are covered in the [resources guide](../../../docs/resources/concepts.md)."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.views]
-            ;; Managed HTTP ships in day8/re-frame2-http — the single
-            ;; built-in resource transport (Spec 016 §Transport). Loading
-            ;; the ns registers the `:rf.http/managed` fx the resource
-            ;; runtime lowers each ensure onto.
+            ;; Managed HTTP is the transport for resource fetches. Requiring
+            ;; it registers the `:rf.http/managed` effect that each ensure
+            ;; runs onto. See the managed-HTTP glossary entry:
+            ;; ../../../docs/resources/glossary.md#managed-http
             [re-frame.http.managed]
-            ;; This example ships no backend, so it overrides
-            ;; `:rf.http/managed` with a per-URL canned stub that delegates
-            ;; to the framework-shipped `:rf.http/managed-canned-success`
-            ;; (Spec 014 §Testing — the same reply shape a live server would
-            ;; produce). The canned-stub fx ids register from
-            ;; re-frame.http.test-support, NOT from re-frame.http.managed;
-            ;; requiring it is the explicit opt-in for a test/demo app.
+            ;; The canned-reply stub effects. This example has no backend, so
+            ;; the stub below stands in; requiring this ns registers
+            ;; `:rf.http/managed-canned-success`, which it delegates to.
             [re-frame.http.test-support]
-            ;; Resources ship in day8/re-frame2-resources. Requiring the
-            ;; ns at app boot wires the late-bind hooks + registrations;
-            ;; without it, `rf/reg-resource` below throws
-            ;; :rf.error/resources-artefact-missing.
+            ;; Boots the optional resources artefact. Requiring it at app boot
+            ;; is what makes `rf/reg-resource` work; without it the calls below
+            ;; throw.
             [re-frame.resources]
-            ;; Routing ships in day8/re-frame2-routing. The resources
-            ;; artefact LATE-BINDS its `:resources` route-metadata
-            ;; extension into routing, so loading both is what makes a
-            ;; route's `:resources` key accepted (Spec 016 §Route
-            ;; integration).
+            ;; Routing. The resources artefact adds its `:resources` route
+            ;; metadata onto routing, so loading both is what makes a route's
+            ;; `:resources` key accepted.
             [re-frame.routing]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
-;; RESOURCES — the registry of named, cached server-state reads
+;; RESOURCES — named, cached server-state reads
 ;; ============================================================================
 ;;
-;; A resource is identity + scope + a request. `:params-schema`, `:scope`,
-;; and `:request` are REQUIRED (Spec 016 §Resource registration spec). The
-;; `:scope :rf.scope/global` here is the explicit, AUDITABLE claim that this
-;; read is the same for every user/tenant/locale — there is NO implicit
-;; default; a missing scope policy is a loud
-;; :rf.error/resource-missing-scope-policy at registration.
+;; A resource is identity + scope + a request. `:params-schema`, `:scope`, and
+;; the request function are all required. `:scope :rf.scope/global` claims this
+;; read is the same for every user. Scope has no default — a missing scope is
+;; an error at registration. See ../../../docs/resources/glossary.md#scope
 
 (rf/reg-resource :articles/list
   {:doc            "The recent-articles list (public, same for everyone)."
@@ -94,8 +75,8 @@
    :scope          :rf.scope/global
    :stale-after-ms 60000
    :gc-after-ms    (* 5 60 1000)
-   ;; Tags let a write invalidate this list by tag
-   ;; (`:rf.resource/invalidate-tags {:tags #{[:article-list]}}`).
+   ;; Tags let a write invalidate this list by tag.
+   ;; See ../../../docs/resources/glossary.md#cache-tag
    :tags           (fn [_params _data] #{[:article-list]})}
   (fn [_params _ctx]
     {:request {:method :get :url "/api/articles"}
@@ -115,17 +96,16 @@
      :decode  :json}))
 
 ;; ============================================================================
-;; DEMO BACKEND — per-URL canned :rf.http/managed override
+;; DEMO BACKEND — a per-URL canned :rf.http/managed override
 ;; ============================================================================
 ;;
-;; This example ships no server, so it overrides `:rf.http/managed` (the fx the
-;; resource runtime lowers every ensure onto) with a stub that synthesises the
-;; canned reply per URL. The two resource requests are `GET /api/articles`
-;; (the list) and `GET /api/articles/:slug` (a detail); the stub routes by URL
-;; shape and delegates to the framework-shipped
-;; `:rf.http/managed-canned-success` (Spec 014 §Testing) — the same reply shape
-;; a live server would produce, so the resource lifecycle (in-flight tracking,
-;; dedupe, reply addressing, status flow) is exercised end to end.
+;; There is no server, so this overrides `:rf.http/managed` (the effect every
+;; ensure runs onto) with a stub that builds a canned reply per URL. The two
+;; requests are `GET /api/articles` (the list) and `GET /api/articles/:slug`
+;; (a detail). The stub routes by URL shape and delegates to the shipped
+;; `:rf.http/managed-canned-success`, which returns the same reply shape a real
+;; server would — so the full resource lifecycle (in-flight tracking, dedupe,
+;; reply addressing, status flow) runs for real.
 
 (def ^:private demo-articles
   [{:slug "resources-101"  :title "Resources 101: server-state as cached reads"
@@ -136,11 +116,11 @@
     :body "Ensure an entry still inside :stale-after-ms and the runtime skips the refetch."}])
 
 (def ^:private demo-reply-delay-ms
-  "How long the demo stub defers each canned reply (via the canned-success
-   fx's `:after-ms`, dispatched through `:dispatch-later` — observable in the
-   tape, time-travel-safe, NOT raw `js/setTimeout`). Small but non-zero so the
-   `:loading` skeleton + `:fetching?` refresh states are observable. A
-   demo-seam knob, not a production value."
+  "How long the demo stub defers each canned reply. The delay rides the
+   canned-success effect's `:after-ms` (dispatched via `:dispatch-later`, so it
+   is visible in the tape and survives time-travel). Small but non-zero, so the
+   loading skeleton and the refresh-in-flight state are visible. A demo knob,
+   not a production value."
   120)
 
 (defn- demo-payload-for-url [url]
@@ -152,19 +132,15 @@
       ;; The bare list endpoint — /api/articles.
       demo-articles)))
 
-;; The resource runtime lowers every ensure onto `:rf.http/managed`; this
-;; override stands in for the backend. It synthesises the per-URL payload and
-;; delegates to the framework-shipped `:rf.http/managed-canned-success`
-;; (Spec 014 §Testing) — calling it directly via the registrar with `:after-ms`
-;; so the canned reply rides framework `:dispatch-later` (tape-visible,
-;; time-travel-safe, NOT raw `js/setTimeout`) and the reply addressing the
-;; resource runtime put on the args-map is preserved. Mirrors
-;; `examples/reagent/realworld_resources/http.cljs`.
+;; This override stands in for the backend. It builds the payload for the URL
+;; and hands off to `:rf.http/managed-canned-success`, looked up from the
+;; registrar and called with `:after-ms` so the reply rides `:dispatch-later`
+;; (visible in the tape, survives time-travel). It keeps the args-map intact so
+;; the reply still addresses back to the resource that asked.
 (rf/reg-fx :resources.demo/http-stub
-  {:doc       "Demo override for `:rf.http/managed`: routes by URL to the
-               canned article payloads so the example runs standalone, then
-               delegates to `:rf.http/managed-canned-success` with `:after-ms`
-               (the deferred reply rides `:dispatch-later`)."
+  {:doc       "Demo override for `:rf.http/managed`: routes by URL to the canned
+               article payloads so the example runs standalone, then delegates
+               to `:rf.http/managed-canned-success` with `:after-ms`."
    :platforms #{:client}}
   (fn fx-managed-resources-demo [frame-ctx args-map]
     (let [payload (demo-payload-for-url (-> args-map :request :url))
@@ -172,16 +148,13 @@
       (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))
 
 ;; ============================================================================
-;; ROUTES — route entry CAUSES the page's resources to load
+;; ROUTES — entering a route causes its resources to load
 ;; ============================================================================
 ;;
-;; The `:resources` route metadata (Spec 016 §Route integration) is the
-;; declarative, machine-readable answer to "what server-state does this
-;; page need?" On route entry the runtime marks each resource active with
-;; owner `[:route route-id nav-token]` and ensures it with cause
-;; `[:route-entry route-id nav-token]`; on route leave it releases the
-;; owner by token and suppresses any stale reply by generation. The view
-;; only reads — the fetch is caused for it.
+;; `:resources` route metadata declares what server-state a page needs. On
+;; route entry the runtime ensures each one, owned by the route. On route
+;; leave it releases that owner and drops any late reply. The view only reads;
+;; the fetch is caused for it. See ../../../docs/routing/glossary.md#route
 
 (rf/reg-route :resources.app/home
   {:doc  "Landing page."} "/")
@@ -209,11 +182,11 @@
 ;; EVENT-DRIVEN ENSURE + MANUAL REFRESH
 ;; ============================================================================
 ;;
-;; Not every fetch is route-driven. An event can CAUSE an ensure too — here
-;; under an app-minted `[:lease …]` owner. App leases are app-authoritative
-;; (Spec 016 §Release authority is per owner kind): the event that mints a
-;; lease MUST have a matching `:rf.resource/release-owner` path, or the
-;; lease pins the entry alive (Xray lints an orphaned lease).
+;; Not every fetch is route-driven. An event can cause an ensure too — here
+;; under an app-minted `[:lease …]` owner. The app owns that lease: the event
+;; that mints it must have a matching `:rf.resource/release-owner` event, or
+;; the lease pins the entry alive forever. See
+;; ../../../docs/resources/glossary.md#owner--cause
 
 (rf/reg-event :resources.app/preview-opened
   {:doc "Open a lightweight article preview from the list — ensure the
@@ -235,10 +208,9 @@
      :fx [[:dispatch [:rf.resource/release-owner
                       {:owner [:lease :resources.app/preview slug]}]]]}))
 
-;; A MANUAL refresh is a CAUSE, not an owner (Spec 016 §Causes explain why
-;; work happened): clicking "Refresh" wants fresh data but does NOT intend
-;; to keep the resource alive — that's the route's job. So it dispatches
-;; `:rf.resource/refetch` with `:cause` and omits `:owner`.
+;; A manual refresh is a cause, not an owner. Clicking "Refresh" wants fresh
+;; data but does not intend to keep the resource alive — that is the route's
+;; job. So it refetches with a `:cause` and no `:owner`.
 (rf/reg-event :resources.app/refresh-articles
   {:doc "Manual refresh of the articles list."}
   (fn [_ _]
@@ -251,29 +223,26 @@
 ;; MACHINE-OWNED RESOURCE
 ;; ============================================================================
 ;;
-;; When a workflow OWNS a read for its lifetime, model the workflow as a
-;; machine and let it own the resource under `[:machine machine-id
-;; instance-id]` (released on actor destroy — Spec 016 §Release authority).
-;; The machine stays the semantic workflow; the resource runtime handles
-;; the cached-read mechanics. A tiny reader machine: it ensures the article
-;; on entry, and the resource is released when the instance is destroyed.
+;; When a workflow owns a read for its lifetime, model the workflow as a
+;; machine and let it own the resource. The resource is owned by the actor and
+;; released when the actor is destroyed. The machine is the workflow; the
+;; resource runtime handles the cached-read mechanics. This is a tiny reader
+;; machine: it ensures the article it is reading, and that read is released
+;; when the reader stops. See the machines glossary:
+;; ../../../docs/machines/glossary.md#machine
 
-;; The reader is started by the UI in two steps: BIRTH the actor with the bare
-;; `[:rf.machine/start]` creation marker, then dispatch a real first event
-;; `[:reader/load slug instance-id]` INTO the live actor. The split is
-;; deliberate and idiomatic: the framework's initial-entry cascade synthesises
-;; the birth `:entry` actions with NO event (it threads only the bare start
-;; marker), so an `:entry` action cannot read args off the start marker — they
-;; would arrive nil. A real event dispatched after birth DOES thread its args,
-;; so the slug + instance-id this workflow owns ride on `:reader/load`.
+;; The UI starts the reader in two steps: birth the actor with the bare
+;; `[:rf.machine/start]` marker, then dispatch a real `[:reader/load slug
+;; instance-id]` event into it. The split is deliberate. The birth cascade runs
+;; `:entry` actions with no event, so an `:entry` action cannot read the slug —
+;; it would arrive nil. A real event dispatched after birth does carry its
+;; args, so the slug and instance-id this workflow owns ride on `:reader/load`.
 ;;
 ;; The `:reading` state handles `:reader/load` with the `:ensure-article`
-;; action (a targetless internal transition — no `:target`, so the actor stays
-;; in `:reading`): it reads slug + instance-id from the load `:event`, assigns them into the
-;; snapshot `:data` (so the owner is self-describing for tools / SSR), and
-;; ensures the article under a `[:machine machine-id instance-id]` owner (Spec
-;; 016 §Machine-owned resource). The runtime releases that owner when the actor
-;; is destroyed.
+;; action. It reads slug + instance-id from the event, stores them in the
+;; snapshot `:data` (so the owner is self-describing for tools and SSR), and
+;; ensures the article owned by `[:machine machine-id instance-id]`. The
+;; runtime releases that owner when the actor is destroyed.
 (rf/reg-machine :resources.app/reader
   {:doc     "A reader workflow that owns the article it is reading."
    :initial :reading
@@ -289,25 +258,20 @@
                              :owner    [:machine :resources.app/reader instance-id]
                              :cause    [:machine-action :resources.app/reader.reading]}]]]}))}
    :states
-   ;; `:reader/load` is a TARGETLESS internal transition (a candidate map with
-   ;; an `:action` ref and no `:target`): the actor stays in `:reading` and
-   ;; runs `:ensure-article`. A bare `{:reader/load :ensure-article}` would read
-   ;; `:ensure-article` as a sibling-state TARGET (and fail to resolve), so the
-   ;; action ref must ride inside the `{:action …}` candidate map.
+   ;; `:reader/load` is a targetless transition: it runs `:ensure-article` and
+   ;; stays in `:reading` (no `:target`). The action must ride in an `{:action
+   ;; …}` map — a bare `{:reader/load :ensure-article}` would read
+   ;; `:ensure-article` as a target state and fail to resolve. See
+   ;; ../../../docs/machines/glossary.md#transition
    {:reading {:on {:reader/load {:action :ensure-article}}}}})
 
-;; The UI starts/stops the reader through these events. Starting BIRTHS the
-;; actor with the bare `[:rf.machine/start]` marker, then dispatches the real
-;; `[:reader/load slug instance-id]` event into it — that event (unlike the
-;; birth marker) threads its args, so the `:reading` `:reader/load` action
-;; reads the slug + instance-id and ensures the article under the
-;; `[:machine … instance-id]` owner. The two dispatches order naturally: the
-;; start marker's birth cascade runs first, then the load event drives the
-;; ensure on the now-live actor. The event also records the active instance-id
-;; in app-db so the view can read the machine-owned article + offer a stop
-;; affordance. Stopping emits the reserved `[:rf.machine/destroy …]` fx, which
-;; runs the actor's `:exit` cascade and releases its `[:machine …]` resource
-;; owner so the entry can GC, then clears the slice.
+;; The UI starts and stops the reader through these two events. Starting births
+;; the actor and then dispatches `[:reader/load slug instance-id]` into it (the
+;; two-step pattern explained on the machine above); the birth cascade runs
+;; first, then the load drives the ensure. It also records the instance-id in
+;; app-db so the view can show the article and a stop button. Stopping destroys
+;; the actor, which releases its resource owner so the entry can GC, and clears
+;; the app-db slice.
 (rf/reg-event :resources.app/start-reader
   {:doc "Start the reader workflow that owns the given article for its lifetime."}
   (fn [{:keys [db]} [_ slug]]
@@ -326,16 +290,15 @@
 ;; APP DATA + READ-MODEL SUBS
 ;; ============================================================================
 ;;
-;; The PASSIVE resource subs read the runtime-managed cache. A small derived
-;; app sub picks a slug from the list for the "open preview" affordance.
+;; The passive resource subs read the runtime-managed cache. A small derived
+;; sub picks a slug from the list for the "open preview" button.
 
-;; A derived read over the list resource's data — projections are ordinary
-;; subs LAYERED over the passive `[:rf.resource/data …]` sub (Spec 016 §No
-;; :select key), NOT a resource-local hook. The sub's input-fn is a pure
-;; `(fn [query-v])` returning a VECTOR OF QUERY VECTORS — never a deref'd
-;; subscribe (a deref'd-subscribe input-fn raises
-;; :rf.error/sub-input-fn-bad-return). The compute fn then receives the
-;; resolved input values positionally: `[[articles] _]`.
+;; To project over a resource's data, layer an ordinary sub on top of the
+;; passive `[:rf.resource/data …]` sub — there is no resource-local select. The
+;; input-fn is a pure `(fn [query-v])` that returns a vector of query vectors,
+;; never a deref'd subscribe. The compute fn then receives the resolved inputs
+;; positionally: `[[articles] _]`. See
+;; ../../../docs/guide/glossary.md#subscription
 (rf/reg-sub :resources.app/first-slug
   (fn [_query-v]
     [[:rf.resource/data {:resource :articles/list :params {}}]])
@@ -363,10 +326,9 @@
                        :data-testid "route-link-articles"}
         "See the articles →"]]])
 
-;; EVENT-LEASE preview panel — reads the lease-ensured detail passively.
-;; Mounted only while a preview slug is open; the lease ensure was dispatched
-;; by `:resources.app/preview-opened` under `[:lease :resources.app/preview
-;; slug]` and released by `:resources.app/preview-closed`.
+;; EVENT-LEASE preview panel. Mounted only while a preview is open. The detail
+;; it reads was ensured under an app lease by `:resources.app/preview-opened`
+;; and released by `:resources.app/preview-closed`. The panel only reads.
 (reg-view preview-panel [slug]
   (let [state @(subscribe [:rf.resource/state {:resource :article/by-slug
                                                :params  {:slug slug}}])]
@@ -406,13 +368,13 @@
       "Stop reader"]]))
 
 (reg-view articles-page []
-  ;; The articles list resource was ensured by THIS route's `:resources`
-  ;; metadata on entry. The view reads its full view-model passively.
+  ;; This route's `:resources` metadata ensured the list on entry. The view
+  ;; reads its full state passively.
   (let [state        @(subscribe [:rf.resource/state {:resource :articles/list :params {}}])
         preview-slug @(subscribe [:resources.app/preview-slug])
         reader       @(subscribe [:resources.app/reader])
-        ;; A LAYERED PROJECTION over the list resource (an ordinary input-fn
-        ;; sub) — the top article's slug, used by the quick-preview button below.
+        ;; The top article's slug, for the quick-preview button — a sub layered
+        ;; over the list resource.
         top-slug     @(subscribe [:resources.app/first-slug])]
     [:div
      [:h1 "Articles"]
@@ -502,20 +464,19 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; `run` materialises the React root lazily on first call (the mount-isolation
-;; convention in examples/TESTING.md). The app frame is created + configured in
-;; one spot: the render-root `frame-provider {:id …}` (the ENSURE shape). On
-;; first mount it creates the frame and applies its config — `:url-bound? true`
-;; so the frame owns the browser URL, plus the HTTP-stub override. On hot reload
-;; it reuses that same frame as-is. Every in-tree dispatch/subscribe resolves to
-;; it. `install-history-listener!` does the initial URL→slice sync and popstate
-;; handling, targeted at the URL owner.
+;; `run` creates the React root on first call. The `frame-provider {:id …}` at
+;; the render root both creates and configures the app frame: `:url-bound? true`
+;; so the frame owns the browser URL, plus the HTTP-stub override. Every
+;; dispatch and subscribe in the tree resolves to this frame. On hot reload the
+;; same frame is reused. `install-history-listener!` syncs the initial URL and
+;; handles back/forward. See the frame glossary entry:
+;; ../../../docs/guide/glossary.md#frame
 
 (defonce react-root (atom nil))
 
-;; The id this app's frame is created under. `:rf/default` is an ordinary frame
-;; id (it carries no special privilege); URL ownership comes from `:url-bound?
-;; true` on the `frame-provider` below, not from the id.
+;; The id this app's frame is created under. `:rf/default` is an ordinary id
+;; with no special privilege; URL ownership comes from `:url-bound? true` on the
+;; `frame-provider` below, not from the id.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/resources_ssr/core.cljc
+++ b/examples/reagent/resources_ssr/core.cljc
@@ -1,69 +1,60 @@
 (ns resources-ssr.core
-  "Worked example for [Spec 016 §SSR and hydration](../../../spec/016-Resources.md)
-   over [Spec 011 SSR](../../../spec/011-SSR.md). A server+client app whose
-   page server-state is a re-frame2 RESOURCE: the server renders an article
-   list with the resource preloaded; the client hydrates the resource cache
-   and avoids a duplicate immediate fetch for fresh entries.
+  "Worked example: SSR over a re-frame2 RESOURCE. A server+client app whose
+   page server-state is a resource. The server renders an article list with
+   the resource preloaded; the client hydrates the resource cache and skips a
+   duplicate fetch for entries that are still fresh.
 
    This is .cljc so the same code runs server-side (JVM, `:clj` branches)
    and client-side (browser, `:cljs` branches).
 
-   Demonstrates the resource SSR contract (Spec 016 §SSR and hydration):
+   What the resource SSR contract gives you here:
 
-   - SSR uses a REQUEST-LOCAL frame (a process-global resource cache would
-     leak data between users) — the per-request `handle-request` frame.
+   - The server renders each request in its own frame. A process-global
+     resource cache would leak one user's data into another's.
    - The page's resource is ensured under an `[:ssr request-id nav-token]`
-     owner with cause `:ssr-preload`, BLOCKING the render until it settles.
-   - Only the ALLOWED resource projection is serialized into the hydration
-     payload (`:rf/runtime-db`); host handles + the tag/owner indexes are
-     never serialized (the indexes recompute from `:entries` on install).
-   - On the client the framework `:rf/hydrate` installs the projection into
-     the target frame's `:rf.runtime/resources` slice; the hydration reconcile
-     orphans the SSR owner, recomputes the reverse indexes from `:entries`,
-     and settles a wire-stripped in-flight entry to a stable status. A fresh
-     hydrated entry renders on first paint and serves from the cache (stale /
-     redacted / omitted entries refetch by the hydration plan).
+     owner with cause `:ssr-preload`. The ensure blocks the render until the
+     read settles.
+   - Only the allowed resource entries ride the hydration payload (under
+     `:rf/runtime-db`). Host handles and the tag/owner indexes are never
+     serialized; the indexes recompute from `:entries` on install.
+   - On the client the framework `:rf/hydrate` event installs those entries
+     into the target frame's `:rf.runtime/resources` slice. A fresh hydrated
+     entry renders on first paint and serves from the cache. Stale, redacted,
+     or omitted entries refetch.
 
-   The SSR blocking-drain, the per-entry projection with redaction /
-   omission / scoped-key privacy / index omission, and the client hydration
-   reconcile + refetch plan are all runtime behaviour (EP-0003). This
-   example drives the actual server path: it DRAINS the blocking page
+   This example drives the real server path. It drains the blocking page
    resource before render (`ssr/drain-blocking-resources!`) and serializes
-   only the ALLOWED runtime-db projection (`payload-policy/project-runtime-db`)
-   into `:rf/runtime-db` — NEVER the full runtime-db. The `:rf/app-db` slice is
-   projected through the explicit fail-closed allowlist (`apply-policy`) the
-   real Ring host uses. The example tree is test-free; the static
-   `index.html` next to this file carries a pre-baked payload for the runnable
-   browser-side `run` (no Clojure server ships with the example), exactly as
-   the sibling `examples/reagent/ssr/` does for plain SSR.
+   only the allowed runtime-db projection (`payload-policy/project-runtime-db`)
+   into `:rf/runtime-db` — never the full runtime-db. The `:rf/app-db` slice
+   goes through the same fail-closed allowlist (`apply-policy`) the production
+   Ring host uses. The static `index.html` next to this file carries a
+   pre-baked payload so the browser-side `run` works without a Clojure server.
+
+   For the full picture see [Resources: SSR and hydration](../../../docs/resources/concepts.md#ssr-and-hydration)
+   and [Server-side rendering](../../../docs/ssr/concepts.md).
 
    Compare with `examples/reagent/ssr/` (plain SSR with a managed-HTTP fetch
-   written into app-db): here the same data is a runtime-managed RESOURCE, so
-   identity / scope / staleness / hydration are the framework's job, and the
+   written into app-db): here the same data is a runtime-managed resource, so
+   identity, scope, staleness, and hydration are the framework's job, and the
    cache lives in the runtime partition rather than app-db."
   (:require [re-frame.core :as rf]
-            ;; Managed HTTP — the single built-in resource transport.
+            ;; Managed HTTP — the resource transport.
             [re-frame.http.managed]
-            ;; Resources artefact (boots the registrations + the LATE-BOUND
-            ;; SSR projection hook the ssr artefact consults).
+            ;; Resources artefact: boots the registrations and the SSR
+            ;; projection hook the ssr artefact consults.
             [re-frame.resources]
-            ;; SSR ships in day8/re-frame2-ssr — render-to-string, the
-            ;; `:rf/hydrate` event, and the per-request server fxs. The
-            ;; resources artefact late-binds its runtime-db projection into
-            ;; the SSR `project-runtime-db` allowlist (Spec 016 §SSR).
+            ;; SSR: render-to-string, the `:rf/hydrate` event, and the
+            ;; per-request server effects.
             [re-frame.ssr :as ssr]
-            ;; The hydration-payload assembly the real Ring host uses: the
-            ;; fail-closed app-db allowlist (`apply-policy`) + the SSR
-            ;; runtime-db projection (`project-runtime-db`) that rides ONLY the
-            ;; allowed resource `:entries` onto `:rf/runtime-db` (redacted /
-            ;; omitted per the resource's classification; indexes recompute on
-            ;; install). Server-side only — `handle-request` (`:clj`) uses it.
+            ;; The hydration-payload assembly the production Ring host uses:
+            ;; the fail-closed app-db allowlist (`apply-policy`) and the
+            ;; runtime-db projection (`project-runtime-db`) that rides only the
+            ;; allowed resource `:entries` onto `:rf/runtime-db` (sensitive
+            ;; data redacted; indexes recompute on install). Server-side only.
             #?(:clj [re-frame.ssr.payload-policy :as payload-policy])
-            ;; The EDN-aware `<script>`-body escaper the production Ring host
-            ;; uses (`re-frame.ssr.ring.shell/payload-script-tag` →
-            ;; `escape-edn-script-body`). Server-side only — a server-provided
-            ;; string carrying `</script>` would otherwise close the payload
-            ;; `<script>` envelope (security audit 2026-05-14 §P1).
+            ;; The EDN-aware escaper for the payload `<script>` body. A
+            ;; server-provided string carrying `</script>` would otherwise
+            ;; close the envelope, so escape it. Server-side only.
             #?(:clj [re-frame.ssr.html-helpers :as html])
             #?(:cljs [reagent.dom.client :as rdc])
             #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
@@ -72,15 +63,16 @@
 ;; RESOURCE
 ;; ============================================================================
 ;;
-;; The page's server-state, declared once. You describe WHAT the read is and
-;; HOW to fetch it; the runtime owns the cache, dedupe, and staleness.
+;; The page's server-state, declared once. You describe what the read is and
+;; how to fetch it; the runtime owns the cache, dedupe, and staleness.
 ;;
-;; `:scope :rf.scope/global` is the explicit, auditable claim that this article
-;; list is the SAME for every user. Scope is part of the read's cache identity,
-;; so one principal's data can never surface in another's cache — and it is
-;; load-bearing for hydration: the serialized scope and the client's scope must
-;; agree before the client treats hydrated data as usable. SSR hydration MUST
-;; NEVER cross scopes (a user-scoped page would carry a scope resolver instead).
+;; `:scope :rf.scope/global` declares that this article list is the same for
+;; every user. Scope is part of the read's cache identity, so one user's data
+;; can never surface in another's cache. It also matters for hydration: the
+;; serialized scope and the client's scope must agree before the client treats
+;; hydrated data as usable, and hydration never crosses scopes. A user-scoped
+;; page would carry a scope resolver instead. See
+;; docs/resources/glossary.md#scope.
 
 (rf/reg-resource :articles/list
   {:doc            "Recent articles (public, SSR-preloaded)."
@@ -96,16 +88,15 @@
 ;; SERVER-SIDE PRELOAD EVENT
 ;; ============================================================================
 ;;
-;; On the server, `:rf/server-init` (dispatched at per-request frame creation)
-;; ensures the page resource — fetch it if the cache is cold — so the render
-;; finds it warm. The renderer then waits for it to settle before rendering
-;; (Spec 016 §SSR §Server route handling).
+;; `:rf/server-init` runs at per-request frame creation. It ensures the page
+;; resource — fetching it if the cache is cold — so the render finds it warm.
+;; The renderer then waits for it to settle before rendering.
 ;;
-;; Two facts ride the ensure. The OWNER `[:ssr request-id nav-token]` is a
-;; lease: it keeps the entry alive for the duration of THIS server render and
-;; nothing longer (released on teardown; reconciled to an orphan on hydration).
-;; The CAUSE `:ssr-preload` is pure provenance — WHY the fetch happened,
-;; recorded for the trace. Owner = lifetime; cause = explanation.
+;; Two facts ride the ensure. The owner `[:ssr request-id nav-token]` is a
+;; lease: it keeps the entry alive for the duration of this server render and
+;; no longer. The cause `:ssr-preload` is provenance — why the fetch happened,
+;; recorded for the trace. Owner = lifetime; cause = explanation. See
+;; docs/resources/glossary.md#owner--cause.
 
 (rf/reg-event :rf/server-init
   {:doc       "Per-request server init — preload the page resource."
@@ -125,13 +116,14 @@
 ;; ============================================================================
 ;;
 ;; The view is a passive reader: it pulls the resource through a subscription
-;; and renders whatever it finds, the same on server and client. (Reading does
-;; not trigger a fetch — the preload/hydration already warmed the cache.)
-;; `:rf.resource/state` is the runtime-supplied derivation that turns the cache
-;; entry into a view-model (a status flag + the data). On the server the
-;; resource was preloaded; on the client the hydrated entry is already present,
-;; so the first render shows data straight away. Same view code both sides —
-;; the SSR/CLJS parity Spec 011 promises, now over a runtime-managed resource.
+;; and renders whatever it finds, the same on server and client. Reading does
+;; not trigger a fetch — the preload and hydration already warmed the cache.
+;; `:rf.resource/state` is the runtime-supplied subscription that turns the
+;; cache entry into a view-model (a status flag plus the data). On the server
+;; the resource was preloaded; on the client the hydrated entry is already
+;; present, so the first render shows data straight away. Same view code on
+;; both sides — the "one app, runs twice" promise, now over a managed resource.
+;; See docs/ssr/glossary.md#render-to-string.
 
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
   (let [state @(rf/subscribe [:rf.resource/state
@@ -160,20 +152,20 @@
 ;; SERVER ENTRY POINT
 ;; ============================================================================
 ;;
-;; Mirrors examples/reagent/ssr/ — a per-request frame whose `:initial-events`
-;; dispatch `:rf/server-init`, a DRAIN to settle the blocking page resource,
-;; a render to string, and a hydration payload carrying the ALLOWED resource
-;; projection in `:rf/runtime-db`. The per-request frame is torn down in a
-;; `finally` on every exit path (memory hygiene).
+;; A per-request frame whose `:initial-events` dispatch `:rf/server-init`, a
+;; drain to settle the blocking page resource, a render to string, and a
+;; hydration payload carrying the allowed resource projection in
+;; `:rf/runtime-db`. The per-request frame is torn down in a `finally` on
+;; every exit path, so a request never leaks a frame.
 ;;
-;; Two steps make this the canonical server path (EP-0003):
+;; Two steps make this the real server path:
 ;;
 ;;   1. `ssr/drain-blocking-resources!` settles the `[:ssr …]`-owned blocking
-;;      ensure (or times it out into a structured first-load failure) BEFORE
+;;      ensure (or times it out into a structured first-load failure) before
 ;;      the render walk, so the render never sees a hung `:loading` skeleton.
 ;;   2. `payload-policy/project-runtime-db` projects the runtime-db down to the
 ;;      serializable allowlist — only the durable `:rf.runtime/resources`
-;;      `:entries`, per-entry redacted (`:sensitive?`) / omitted (`:large?`),
+;;      `:entries`, per-entry redacted (`:sensitive?`) or omitted (`:large?`),
 ;;      with the reverse indexes dropped (they recompute on install). Ship the
 ;;      projection, never the full runtime-db. The app-db slice rides the
 ;;      fail-closed allowlist via `apply-policy` (here empty — the page state
@@ -189,7 +181,7 @@
                   :initial-events [[:rf/server-init]]})]
        (try
          (rf/with-frame f
-           ;; (1) settle the blocking page resource before rendering — the
+           ;; (1) Settle the blocking page resource before rendering. The
            ;; `[:ssr …]`-owned ensure dispatched by `:rf/server-init` must reach
            ;; a terminal status (:loaded / :error) or time out into a settled
            ;; first-load failure, so the render walk sees real data.
@@ -199,19 +191,19 @@
                  hiccup        ((rf/view :app/root))
                  html          (rf/render-to-string hiccup {:doctype? true :emit-hash? true})
                  render-hash   (rf/render-tree-hash hiccup)
-                 ;; (2) build the canonical payload the way the Ring host does:
-                 ;; the app-db slice through the fail-closed allowlist, and
-                 ;; the runtime-db through the SSR projection (only the allowed
+                 ;; (2) Build the payload the way the Ring host does: the
+                 ;; app-db slice through the fail-closed allowlist, and the
+                 ;; runtime-db through the SSR projection (only the allowed
                  ;; resource `:entries`).
                  ;;
-                 ;; The page state is the RESOURCE (it rides `:rf/runtime-db`),
+                 ;; The page state is the resource (it rides `:rf/runtime-db`),
                  ;; so app-db carries nothing of its own. `:payload` is
                  ;; fail-closed, so name the intent explicitly: the
                  ;; `:rf.ssr.payload/whole-app-db` opt-in projects the (empty)
-                 ;; app-db to `{}` cleanly. Watch out — a bare empty `[]`
-                 ;; allowlist reads as MISSING policy and throws
-                 ;; `:rf.error/ssr-missing-payload-policy`, not as "ship nothing"
-                 ;; (Spec 011 §`:rf/app-db` projection).
+                 ;; app-db to `{}` cleanly. A bare empty `[]` allowlist instead
+                 ;; reads as a missing policy and throws
+                 ;; `:rf.error/ssr-missing-payload-policy`, not "ship nothing".
+                 ;; See docs/ssr/concepts.md#payload--the-fail-closed-allowlist.
                  policy-opts   {:payload :rf.ssr.payload/whole-app-db}
                  payload       (payload-policy/build-payload
                                  f
@@ -226,11 +218,11 @@
                  ;; `ssr/hydrate!` checks any present `:rf/frame-id` against the
                  ;; client's `:frame` and raises
                  ;; `:rf.error/hydration-frame-id-mismatch` when they differ —
-                 ;; the frame-id is validation evidence, not a hydration target
-                 ;; (Spec 011 §The hydration payload). A per-request gensym can
-                 ;; never equal the client's fixed id, so we drop it; an absent
-                 ;; frame-id is no conflict. (A deployment that wants a frame-id
-                 ;; on the wire stamps a stable id both sides agree on.)
+                 ;; the frame-id is validation evidence, not a hydration target.
+                 ;; A per-request gensym can never equal the client's fixed id,
+                 ;; so drop it; an absent frame-id is no conflict. A deployment
+                 ;; that wants a frame-id on the wire stamps a stable id both
+                 ;; sides agree on.
                  payload       (dissoc payload :rf/frame-id)]
              {:status  200
               :headers {"Content-Type" "text/html"}
@@ -239,8 +231,7 @@
                    "<title>Resources SSR demo</title></head><body>"
                    "<div id='app'>" html "</div>"
                    ;; Emit the payload `<script>` through the EDN-aware
-                   ;; `</script>`-escaper the production Ring host uses
-                   ;; (security audit 2026-05-14 §P1) so a server-
+                   ;; escaper the production Ring host uses, so a server-
                    ;; provided string carrying `</script>` can't close the
                    ;; envelope.
                    "<script id='__rf_payload' type='application/edn'>"
@@ -256,11 +247,11 @@
 ;;
 ;; `ssr/hydrate!` reads the payload, dispatch-syncs `[:rf/hydrate payload]`
 ;; (which installs the resource projection into the carried frame's
-;; `:rf.runtime/resources` slice under the locked :replace-frame-state
-;; policy), and verifies the render hash. A fresh hydrated entry renders its
-;; data on first paint and serves it straight from the cache — no duplicate
-;; fetch, which is the whole point of preloading (Spec 016 §SSR client
-;; hydration). A stale entry would background-refetch by policy.
+;; `:rf.runtime/resources` slice), and verifies the render hash. A fresh
+;; hydrated entry renders its data on first paint and serves it straight from
+;; the cache — no duplicate fetch, which is the whole point of preloading. A
+;; stale entry would background-refetch by policy. See
+;; docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
 
 #?(:cljs (defonce react-root (atom nil)))
 
@@ -268,8 +259,8 @@
 ;; and threads the same id through both `ssr/hydrate!` (where the server state
 ;; lands) and the root `frame-provider` (where in-tree dispatch/subscribe
 ;; resolve). It must be a `:client`-platform frame so the `:rf.ssr/check-*`
-;; compatibility-check fxs the `:rf/hydrate` handler dispatches actually fire
-;; (Spec 011 §The :rf/hydrate event).
+;; compatibility-check effects the `:rf/hydrate` handler dispatches actually
+;; fire. See docs/ssr/concepts.md#deploy-drift-checks-come-along-for-free.
 (def app-frame :rf/default)
 
 #?(:cljs

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -1,27 +1,26 @@
 (ns routing.core
-  "Worked example for [Construction Prompt CP-7](../../../spec/Construction-Prompts.md)
-   and [Spec 012 Routing](../../../spec/012-Routing.md). A small three-page app:
-   home, articles list, article detail.
+  "A small three-page routing app: home, articles list, article detail.
+   See the [routing guide](../../../docs/routing/concepts.md).
 
    The one idea: the URL is application state you read through a subscription,
    and navigation is just an event. A route is a registration, the active route
    is a sub, and `root-view` is a `case` over `:rf.route/id`. No router object,
    no route context to thread through the tree.
 
-   This example uses the current runtime routing surface directly:
+   The surface this example uses:
 
    - `reg-route` for the route table
-   - `:rf.route/id` and `:rf.route/params` for reading the active route as subs
+   - `:rf.route/id` and `:rf.route/params` to read the active route as subs
    - `route-link` for links that drive navigation
    - `:rf/url-requested` for user-initiated anchor clicks
    - `install-history-listener!` for popstate + initial-load URL→state sync"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            ;; Routing ships in day8/re-frame2-routing. Requiring it runs
-            ;; its load-time hook and reg-sub registrations, which the
-            ;; `rf/reg-route` calls below depend on. Without this require
-            ;; those calls throw :rf.error/routing-artefact-missing.
+            ;; Routing ships in the day8/re-frame2-routing artefact. Requiring
+            ;; it registers the route subs the `rf/reg-route` calls below depend
+            ;; on; without this require those calls throw
+            ;; :rf.error/routing-artefact-missing.
             [re-frame.routing]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -70,14 +69,13 @@
 ;; PAGES
 ;; ============================================================================
 ;;
-;; Links use `rf/route-link` — the registered view at `:route/link` shipped
-;; by `day8/re-frame2-routing`. Per Spec 012 §Linking from views and the
-;; API.md `route-link` row, the framework view renders an `<a href=...>`,
-;; intercepts plain primary-button clicks to dispatch `:rf/url-requested`,
-;; and defers modifier-key / auxiliary-button (middle-click) clicks to the
-;; browser so the native open-in-new-tab affordance is preserved. Any
-;; passthrough HTML attrs on the props map (e.g. `:data-testid`) land
-;; on the underlying `<a>`.
+;; Links use `rf/route-link`, the framework view shipped by the routing
+;; artefact. It renders an `<a href=...>`, intercepts plain primary-button
+;; clicks to dispatch `:rf/url-requested`, and defers modifier-key and
+;; middle-click clicks to the browser so open-in-new-tab still works. Any
+;; passthrough HTML attrs on the props map (e.g. `:data-testid`) land on the
+;; underlying `<a>`. See the routing guide, "Linking from views":
+;; ../../../docs/routing/concepts.md#linking-from-views
 
 (reg-view home-page []
   [:div
@@ -142,7 +140,8 @@
 ;; with no framework privilege — the runtime won't infer it for you, so you
 ;; establish it like any other (the provider in `run` does that). A frame
 ;; owns the browser URL by carrying `:url-bound? true`, which this app's
-;; provider sets (EP-0002, Spec 012 §Multi-frame routing).
+;; provider sets. See the routing guide, "The browser is just another event
+;; source": ../../../docs/routing/concepts.md#the-browser-is-just-another-event-source
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -4,42 +4,34 @@
    A small spreadsheet with cells A1..Z100. Each cell holds either a literal
    value or a formula. Formulas reference other cells. Changes propagate.
 
-   The 7GUIs page calls this out as a test of *change propagation through
-   a dependency graph*. The classic trap is hand-rolled per-cell observers
-   that go stale (correctness bugs). The re-frame2 approach leans on the
-   reaction layer instead: each cell's display value is a registered
-   subscription (`:cells/value`) parameterised by id, derived purely from
-   `app-db`'s cell map.
+   This is a test of change propagation through a dependency graph. Each
+   cell's display value is a subscription (`:cells/value`) parameterised by
+   id, derived purely from the cell map in app-db. The subscription layer
+   handles propagation, so there are no hand-maintained per-cell observers
+   to keep in sync.
 
-   How propagation actually works here: every `:cells/value` sub takes the
-   whole cell map (`:cells/all-cells`) as its single input, so committing
-   ANY cell produces a fresh map identity and recomputes EVERY mounted
-   value reaction — dependent or not. This is the recompute-everything
-   shape, but it stays cheap because (a) the evaluator is a pure function
-   and the grid is small (26×100), and (b) the reaction layer `=`-dedups
-   each computed value, so a cell whose result is unchanged does not
-   re-render. The win is correctness for free: there are no hand-maintained
-   per-cell dependency edges to keep in sync. (True per-cell propagation —
-   a signal keyed on each referenced id rather than the whole map — is a
-   larger change and not warranted at this scale.)
+   Every `:cells/value` sub takes the whole cell map (`:cells/all-cells`) as
+   its single input. Committing any cell produces a fresh map identity, so
+   every mounted value reaction recomputes — dependent or not. This stays
+   cheap because the evaluator is a pure function over a small grid (26×100),
+   and the subscription layer `=`-dedups each result, so a cell whose value
+   is unchanged does not re-render. See the derivation graph in
+   ../../../../docs/guide/glossary.md#the-derivation-graph.
 
    Demonstrates:
    - Pure derivation of every cell from a single shared input sub
-   - Reaction-layer `=`-dedup avoiding re-render of unchanged cells
+   - `=`-dedup in the subscription layer avoiding re-render of unchanged cells
    - Cycles detected via a visited-set walk during evaluation
    - Typed error markers propagated through arithmetic (never throws)
    - Open-map cell registry (sparse storage)
    - Pure parser + evaluator (no eval, no host I/O)
 
    Scope: 26 cols × 100 rows. Formulas of the form '=expr' where expr is a
-   simple S-expression-flavored calculator (numbers, +, -, *, /, cell refs).
-   Excel-style infix is left for a future iteration; the shape of the
-   solution doesn't change."
+   simple S-expression-flavored calculator (numbers, +, -, *, /, cell refs)."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
-            ;; rf/reg-app-schema resolves.
+            ;; Loading re-frame.schemas registers the hooks that make
+            ;; rf/reg-app-schema resolve.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -85,10 +77,10 @@
    [:editing-id  [:maybe :string]]])
 
 ;; Register the app-db schema for the app frame. `reg-app-schema` needs a
-;; frame in scope, so at ns-load — before the provider has mounted — we
-;; name the frame with `with-frame :rf/default` (the id `run`'s provider
-;; uses). Binding is by frame id, so this works no matter when the frame
-;; is created; once it exists, the schema validates its `[:cells]` commits.
+;; frame in scope, so `with-frame :rf/default` names the frame `run` mounts.
+;; The schema binds by frame id, so this works at ns-load even though the
+;; frame does not exist yet; once it does, the schema validates its
+;; `[:cells]` commits.
 (with-frame :rf/default
   (rf/reg-app-schema [:cells] {:schema CellsState}))
 
@@ -307,8 +299,8 @@
 ;;
 ;; The :cells/value sub is parameterised by id — `(subscribe [:cells/value
 ;; "A1"])`. Each cell's display value derives from the full cells map, so
-;; every value reaction recomputes on any edit; the reaction layer =-dedups
-;; the result so only cells whose value actually changed re-render.
+;; every value reaction recomputes on any edit; the subscription layer
+;; =-dedups the result so only cells whose value actually changed re-render.
 
 (rf/reg-sub :cells/all-cells
   {:doc "The sparse cell map (only edited cells are present). Single input to
@@ -397,25 +389,21 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. ns-load must produce no DOM side effects, so co-required example
+;; namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
-;; The whole frame lives in one spot at the render root: the
-;; `frame-provider {:id app-frame …}` in `run`. On first mount it creates
-;; the app frame, applies its config, and runs `:initial-events` once to
-;; seed app-db. Thereafter every `dispatch`/`subscribe` in the tree
-;; resolves to that frame. On hot reload the provider reuses the existing
-;; frame and skips re-seeding, so the grid keeps its values across
-;; re-mounts. (`init!` below only installs the adapter — the provider, not
-;; `init!`, creates the frame.) Matches the canonical mount in
-;; examples/reagent/counter/core.cljs.
+;; The frame lives in one spot: the `frame-provider {:id app-frame …}` in
+;; `run`. On first mount it creates the frame, applies its config, and runs
+;; `:initial-events` once to seed app-db. Thereafter every `dispatch` and
+;; `subscribe` in the tree resolves to that frame. On hot reload the provider
+;; reuses the existing frame and skips re-seeding, so the grid keeps its
+;; values. `init!` (below) only installs the adapter; the provider creates the
+;; frame. See ../../../../docs/guide/glossary.md#frame-provider.
 ;;
-;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame
-;; id with no framework privilege; we name it here and hand it to the
-;; provider like any other id.
+;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
+;; with no framework privilege.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -6,26 +6,22 @@
    slider in a modal dialog, and closing the dialog commits the new size.
    Undo/Redo buttons step through the history.
 
-   The 7GUIs page calls this out as a test of *undo/redo*. The classic trap
-   is to maintain an ad-hoc undo stack inside the component. The re-frame2
-   approach: an interceptor that snapshots app-db before each undoable event,
-   and Undo/Redo events that pop/push from the snapshot stacks.
+   This is the 7GUIs undo/redo test. The undo state lives in app-db, not in
+   a component: an interceptor snapshots app-db before each undoable event,
+   and Undo/Redo events pop/push from the snapshot stacks.
 
    Demonstrates:
-   - Undo / redo via interceptor + sibling event           (CP-3 / interceptors)
-   - Modal dialog as state, not as React component identity (P8: low hidden context)
-   - Continuous slider drag without history pollution      (interceptor opt-out)
-   - Schema-bound list                                     (CP-8)
+   - Undo / redo via an interceptor plus sibling events
+   - A modal dialog held as state, not as a React component
+   - A continuous slider drag that adds no history steps
+   - A schema-bound list
 
-   Note: a full undo library (multi-policy, per-slice, max-depth, etc.)
-   would naturally live in user/library space (cf. re-frame-undo today).
-   This example shows the canonical primitive pattern; productionising it is
-   library work, not framework work."
+   This is the primitive pattern. A full undo library (multiple policies,
+   per-slice, max depth) is user or library code, not framework code."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
-            ;; rf/reg-app-schema resolves.
+            ;; Loading `re-frame.schemas` registers the hooks that make
+            ;; `rf/reg-app-schema` resolve.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -35,13 +31,13 @@
 ;; SCHEMA
 ;; ============================================================================
 
-;; A circle's `:id` is a monotonic `:int` minted from a db-held counter — the
-;; todomvc `allocate-next-id` idiom. It lands in durable app-db
-;; (`[:drawer :circles]`), so it must be a function of prior frame-state, not
-;; an ambient `(random-uuid)` — replaying the event stream would otherwise mint
-;; different ids (EP-0010 Causal World Inputs). The id is just an internal
-;; handle (React `:key` + context-menu target). Undo/redo snapshot whole
-;; `:circles` vectors, so the ids ride the snapshot and round-trip unchanged.
+;; A circle's `:id` is a monotonic `:int` minted from a db-held counter. The id
+;; lands in durable app-db (`[:drawer :circles]`), so it must be a function of
+;; prior state, not an ambient `(random-uuid)` — replaying the event stream
+;; would otherwise mint different ids (see "Recordable vs ambient coeffects" in
+;; docs/guide/glossary.md). The id is just an internal handle: a React `:key`
+;; and a context-menu target. Undo/redo snapshot whole `:circles` vectors, so
+;; the ids ride the snapshot and round-trip unchanged.
 (def Circle
   [:map
    [:id      :int]
@@ -52,7 +48,7 @@
 (def DrawerState
   [:map
    [:circles   [:vector Circle]]
-   [:next-id    :int]                           ;; deterministic id allocator (EP-0010)
+   [:next-id    :int]                           ;; deterministic id allocator
    [:dialog    [:maybe [:map
                         [:circle-id      :int]
                         [:initial-radius pos-int?]
@@ -61,10 +57,10 @@
    [:redo      [:vector :any]]])
 
 ;; Bind the schema to the app frame so it validates that frame's commits.
-;; `reg-app-schema` is frame-local, and this runs at ns-load before any
-;; provider exists, so name the frame (`:rf/default`, matching the render
-;; root's `frame-provider` below) via `with-frame` rather than relying on a
-;; frame in scope.
+;; `reg-app-schema` is frame-local. This runs at ns-load, before any provider
+;; exists, so name the frame explicitly with `with-frame` rather than relying
+;; on a frame in scope. `:rf/default` matches the render root's
+;; `frame-provider` below.
 (with-frame :rf/default
   (rf/reg-app-schema [:drawer] {:schema DrawerState}))
 
@@ -73,10 +69,10 @@
 ;; ============================================================================
 ;;
 ;; Captures :circles before the handler runs; pushes the prior value onto :undo
-;; and clears :redo. An undoable event lists this interceptor BY ID
-;; (`:undoable`) in its :interceptors (EP-0022 — interceptors are registered
-;; descriptors referenced by keyword). Only the *commit* events carry it, so
-;; the continuous slider drag leaves the history alone.
+;; and clears :redo. An undoable event opts in by listing this interceptor's id
+;; (`:undoable`) in its :interceptors. Only the commit events carry it, so the
+;; continuous slider drag leaves the history alone.
+;; See docs/guide/concepts/interceptors.md.
 
 (rf/reg-interceptor :undoable
   {:doc "Snapshot :circles before an undoable handler runs; push the prior
@@ -101,18 +97,17 @@
 ;; ============================================================================
 
 (rf/reg-event :drawer/initialise
-  {:doc "Seed an empty canvas. `:next-id` is the deterministic id allocator
-         (EP-0010) — circles take monotonic int ids starting at 1."}
+  {:doc "Seed an empty canvas. `:next-id` is the deterministic id allocator —
+         circles take monotonic int ids starting at 1."}
   (fn handler-drawer-initialise [{:keys [db]} _]
     {:db (assoc db :drawer {:circles [] :next-id 1 :dialog nil :undo [] :redo []})}))
 
 (rf/reg-event :drawer/add-circle
   {:doc "Click on canvas. Adds a circle of default radius. The id comes from
          the db-held `:next-id` counter, then the counter is bumped — a durable
-         id is a function of prior frame-state, not an ambient `(random-uuid)`
-         (EP-0010 causal world inputs). The counter lives outside the undoable
-         `:circles` snapshot, so it keeps climbing across undo/redo and never
-         re-mints a live id."
+         id is a function of prior state, not an ambient `(random-uuid)`. The
+         counter lives outside the undoable `:circles` snapshot, so it keeps
+         climbing across undo/redo and never re-mints a live id."
    :interceptors [:undoable]}
   (fn handler-drawer-add-circle [{:keys [db]} [_ x y]]
     {:db (let [id (get-in db [:drawer :next-id])]
@@ -180,10 +175,10 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-;; Layer-2 slice sub. The Layer-3 readers below chain off this one via
-;; `:<-`, so the [:drawer ...] traversal happens once per app-db swap
-;; (in `:drawer/slice`) rather than once per dependent recompute. Matches
-;; the realworld layering pattern (`:articles/slice → :articles/data → ...`).
+;; Layer-2 slice sub. The Layer-3 readers below chain off this one via `:<-`,
+;; so the [:drawer ...] traversal happens once per app-db swap (in
+;; `:drawer/slice`) rather than once per dependent recompute.
+;; See docs/guide/concepts/subscriptions.md.
 
 (rf/reg-sub :drawer/slice (fn [db _] (:drawer db)))
 
@@ -249,23 +244,22 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. ns-load must produce no DOM side effects, so co-required example
+;; namespaces don't race `create-root` onto the shared `#app`. See the
+;; mount-isolation convention in examples/TESTING.md.
 (defonce react-root (atom nil))
 
 ;; The whole frame lifecycle lives in one spot at the render root: the
 ;; `frame-provider {:id app-frame …}` below. On first mount it creates the
 ;; app frame, applies its config, and runs `:initial-events` once to seed
 ;; app-db. Thereafter every `dispatch`/`subscribe` in the tree resolves to
-;; that frame. On hot reload the provider reuses the existing frame and
-;; skips re-seeding, so the canvas keeps its circles across re-mounts.
+;; that frame. On hot reload the provider reuses the existing frame and skips
+;; re-seeding, so the canvas keeps its circles across re-mounts.
 ;;
-;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
-;; with no framework privilege — name it here and hand it to the provider
-;; like any other id. Matches the canonical mount in
-;; examples/reagent/counter/core.cljs.
+;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id with
+;; no framework privilege — name it here and hand it to the provider like any
+;; other id. See docs/guide/concepts/frames.md.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -6,27 +6,25 @@
    the inputs; Update writes back; Create adds a new row; Delete removes the
    selected row.
 
-   The 7GUIs page calls this out as a test of *master/detail interaction*.
-   The classic trap is to keep the inputs as their own React state, separate
-   from the list — they fall out of sync when selection changes. The
-   re-frame2 approach: the inputs *are* a sub of the selection. Editing
-   them dispatches into a 'draft' slice; the list shows committed values.
+   This is a master/detail interaction. The inputs are a subscription on the
+   selection, not their own React state. Editing them dispatches into a
+   `:draft` slice; the list shows committed values. Selection lives in app-db,
+   so it never falls out of sync with the inputs.
 
-   The whole frame is established in one spot: the render root's
-   `frame-provider {:id …}` creates the app frame, configures it, and
-   runs its `:initial-events` seed once.
+   The frame is established in one spot: the render root's
+   `frame-provider {:id …}` creates the app frame, configures it, and runs its
+   `:initial-events` seed once.
 
-   Demonstrates:
-   - List operations (add / update / delete)              (CP-1)
-   - Selection as state, not as React component identity  (P8: low hidden context)
-   - Derived filtered list                                 (CP-2 with :<-)
-   - Schema-bound entity                                   (CP-8)"
+   Shows:
+   - List operations (add / update / delete)
+   - Selection held as state, not as React component identity
+   - A derived filtered list (a subscription on two other subscriptions)
+   - A schema-bound entity"
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
-            ;; rf/reg-app-schema resolves.
+            ;; Requiring `re-frame.schemas` wires up schema validation so
+            ;; `rf/reg-app-schema` works. See the guide: docs/guide/how-to/validate-with-schemas.md.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -36,13 +34,11 @@
 ;; SCHEMA
 ;; ============================================================================
 
-;; EP-0010 (Causal World Inputs): a person's `:id` is written into durable
-;; app-db (`[:crud :people]`) and used as the selection / React `:key`, so it
-;; must be a function of prior frame-state — never an ambient `(random-uuid)` at
-;; the durable-write site (an event-stream replay would mint different ids). The
-;; id is an internal handle, so we mint it deterministically as a monotonic
-;; `:int` from a db-held `:next-id` counter — the todomvc `allocate-next-id`
-;; idiom, matching sibling 7GUIs `circle_drawer` — rather than a uuid.
+;; A person's `:id` is written into durable app-db (`[:crud :people]`) and used
+;; as the selection and React `:key`. A durable id must be reproducible on
+;; replay, so it can't come from an ambient `(random-uuid)` read at the write
+;; site. We mint it as a monotonic `:int` from a db-held `:next-id` counter
+;; instead. See docs/guide/glossary.md#recordable-vs-ambient-coeffects.
 (def Person
   [:map
    [:id      :int]
@@ -52,18 +48,18 @@
 (def CrudState
   [:map
    [:people       [:vector Person]]
-   [:next-id      :int]                      ;; deterministic id allocator (EP-0010)
+   [:next-id      :int]                      ;; deterministic id allocator
    [:filter-text  :string]
    [:selected-id  [:maybe :int]]
    [:draft        [:map
                    [:name    :string]
                    [:surname :string]]]])
 
-;; EP-0002: `reg-app-schema` is frame-local, so it needs a frame context at
-;; registration. `with-frame` supplies one: it names the frame this schema
-;; binds to — `:rf/default`, the frame the render-root `frame-provider`
-;; establishes and whose commits this schema validates. The label is enough;
-;; the frame need not exist yet.
+;; Schemas register per frame, so the registration has to name a frame.
+;; `with-frame` supplies that name: `:rf/default`, the frame the render-root
+;; `frame-provider` creates and whose commits this schema validates. The frame
+;; need not exist yet — the name is enough.
+;; See docs/guide/how-to/validate-with-schemas.md.
 (with-frame :rf/default
   (rf/reg-app-schema [:crud] {:schema CrudState}))
 
@@ -72,10 +68,9 @@
 ;; ============================================================================
 
 (rf/reg-event :crud/initialise
-  {:doc "Seed the list with the 7GUIs reference data. Ids are deterministic
-         monotonic ints (EP-0010) so a fresh-event-stream replay reproduces
-         the same durable people. `:next-id` is the allocator for subsequent
-         Create."}
+  {:doc "Seed the list with the 7GUIs reference data. Ids are monotonic ints
+         so a replay reproduces the same people. `:next-id` is the allocator
+         for later Create."}
   (fn handler-crud-initialise [{:keys [db]} _]
     {:db (assoc db :crud {:people      [{:id 1 :name "Hans"  :surname "Emil"}
                                    {:id 2 :name "Max"   :surname "Mustermann"}
@@ -109,11 +104,8 @@
     {:db (assoc-in db [:crud :draft :surname] s)}))
 
 (rf/reg-event :crud/create
-  {:doc "Add a new person from the draft. Selects the new entry. The id is
-         minted deterministically from the db-held `:next-id` counter (EP-0010
-         causal world inputs — a durable id must be a function of prior
-         frame-state, not an ambient `(random-uuid)` read), then the counter is
-         bumped."}
+  {:doc "Add a new person from the draft, and select the new entry. The id
+         comes from the db-held `:next-id` counter, which is then bumped."}
   (fn handler-crud-create [{:keys [db]} _]
     {:db (let [new-id (get-in db [:crud :next-id])
           {:keys [name surname]} (get-in db [:crud :draft])]
@@ -165,12 +157,10 @@
                  people)))))
 
 (rf/reg-sub :crud/can-update?
-  {:doc "Update/Delete are enabled only when the selected row is *visible*
-         under the active filter. A selection hidden by the filter must not
-         be actionable — Update/Delete would otherwise touch an invisible row.
-         This is the master/detail edge the 7GUIs CRUD task is meant to model:
-         the answer is derived state (a sub of the filtered list), so the
-         selection is preserved and re-enables itself when the filter clears."}
+  {:doc "True when the selected row is visible under the active filter. A row
+         hidden by the filter must not be actionable, or Update/Delete would
+         touch a row you can't see. This is derived from the filtered list, so
+         the selection is kept and re-enables itself once the filter clears."}
   :<- [:crud/selected-id]
   :<- [:crud/filtered-people]
   (fn sub-crud-can-update? [[id visible-people] _]
@@ -228,24 +218,22 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. ns-load must do no DOM work, so co-required example namespaces
+;; don't race each other onto the shared `#app`. See examples/TESTING.md
+;; (Example mount-isolation).
 (defonce react-root (atom nil))
 
-;; The whole frame lifecycle lives in one spot at the render root: the
-;; `frame-provider {:id app-frame …}` below. On first mount it creates the
-;; app frame, applies its config, and runs `:initial-events` once to seed
-;; app-db (`:crud/initialise`). Thereafter every `dispatch`/`subscribe` in
-;; the tree resolves to that frame. On hot reload the provider reuses the
-;; existing frame and skips re-seeding, so the list keeps its rows across
-;; re-mounts.
+;; The frame lifecycle lives in one spot: the `frame-provider {:id app-frame …}`
+;; below. On first mount it creates the frame, applies its config, and runs
+;; `:initial-events` once to seed app-db (`:crud/initialise`). After that, every
+;; `dispatch`/`subscribe` in the tree resolves to that frame. On hot reload the
+;; provider reuses the existing frame and skips re-seeding, so the list keeps its
+;; rows across re-mounts. See docs/guide/glossary.md#frame-provider.
 ;;
-;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
-;; with no framework privilege — the runtime won't infer it, so we name it
-;; here and hand it to the provider like any other id. Matches the canonical
-;; mount in examples/reagent/counter/core.cljs.
+;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id with
+;; no special privilege — the runtime won't infer it, so we name it here and hand
+;; it to the provider like any other id.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -9,22 +9,19 @@
        (return ≥ start) constraint holds.
      - Clicking Book pops up a confirmation message.
 
-   This task tests *constrained UI input*: the Book button's enabled state is
-   a derived property of three other fields. The classic trap is to compute
-   it imperatively after every change and forget a path. The re-frame2
-   approach: enabled-state is a sub.
+   This task is about constrained UI input: the Book button's enabled state
+   is derived from three other fields. Computing it imperatively after every
+   change risks missing a path. Here it is a subscription, so it is always
+   in sync.
 
    Demonstrates:
-   - Schema-bound app-db slice                            (CP-8)
-   - Multiple events for distinct user intents            (CP-1)
-   - Layered subs with :<- chains                          (CP-2)
-   - Conditional UI driven by sub return values           (CP-4)
-   - Smoke test exercising the constraint surface         (CP-1 checklist)"
+   - A schema-bound app-db slice
+   - One event per distinct user intent
+   - Layered subs built with :<- chains
+   - UI state driven by sub return values"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
-            ;; rf/reg-app-schema resolves.
+            ;; Require re-frame.schemas to make rf/reg-app-schema available.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -43,10 +40,10 @@
    [:return-text :string]])
 
 ;; Bind the schema to the app frame so it validates that frame's commits.
-;; `reg-app-schema` is frame-local and this runs at ns-load, before the
-;; render root's `frame-provider {:id …}` creates the frame — so name the
-;; frame (`:rf/default`, matching that provider) with `with-frame`. Binding
-;; is by id, so the registration is independent of when the frame is created.
+;; `reg-app-schema` is frame-local, so `with-frame` names the target frame
+;; by id. We use `:rf/default` to match the `frame-provider {:id …}` at the
+;; render root. Binding is by id, so this works even though it runs at
+;; ns-load, before the provider creates the frame.
 (with-frame :rf/default
   (rf/reg-app-schema [:flight] {:schema FlightState}))
 
@@ -57,9 +54,8 @@
 (rf/reg-event :flight/initialise
   {:doc "Seed the flight slice."}
   (fn handler-flight-initialise [{:keys [db]} _]
-    ;; Seed both date fields to a fixed valid ISO date. The original 7GUIs
-    ;; spec seeds "today"; we use a constant so the example is
-    ;; deterministic (and not silently wrong on any given day).
+    ;; Seed both date fields to a fixed valid ISO date. The 7GUIs task seeds
+    ;; "today"; a constant keeps the example deterministic instead.
     {:db (assoc db :flight {:trip-type   :one-way
                        :start-text  "2026-05-06"
                        :return-text "2026-05-06"})}))
@@ -111,13 +107,12 @@
 (rf/reg-sub :flight/return-text (fn [db _] (get-in db [:flight :return-text])))
 
 (defn valid-date?
-  "True when `s` is a real ISO `yyyy-mm-dd` calendar date. The regex
-   alone only checks shape, so it would accept impossible dates like
-   `2026-99-99`, `2026-00-00`, or `2026-02-31`. We round-trip the
-   parsed fields through a UTC `js/Date` and require every component to
-   come back unchanged — this rejects out-of-range months/days and is
-   leap-year-correct (e.g. `2025-02-29` overflows to March and fails,
-   `2024-02-29` round-trips and passes)."
+  "True when `s` is a real ISO `yyyy-mm-dd` calendar date. The regex only
+   checks shape, so it accepts impossible dates like `2026-99-99` or
+   `2026-02-31`. To reject those, parse the fields, round-trip them through a
+   UTC `js/Date`, and require every component to come back unchanged. This is
+   leap-year-correct: `2025-02-29` overflows to March and fails, `2024-02-29`
+   round-trips and passes."
   [s]
   (let [s (or s "")]
     (boolean
@@ -126,9 +121,9 @@
               m  (js/parseInt (subs s 5 7) 10)
               d  (js/parseInt (subs s 8 10) 10)
               dt (js/Date. 0)]
-          ;; setUTCFullYear avoids the legacy 0-99 → 1900-1999 mapping
-          ;; that the `js/Date.UTC` two-digit-year rule applies, so
-          ;; four-digit years like 0026 round-trip honestly.
+          ;; Use setUTCFullYear, not js/Date.UTC: the latter maps years
+          ;; 0-99 to 1900-1999, which would corrupt four-digit years
+          ;; like 0026.
           (.setUTCFullYear dt y (dec m) d)
           (and (= y (.getUTCFullYear dt))
                (= (dec m) (.getUTCMonth dt))
@@ -212,24 +207,23 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; Hold the React root in an atom and create it lazily inside `run`, not at
+;; ns-load. ns-load must have no DOM side effects so co-required example
+;; namespaces don't race `create-root` onto the shared `#app`. See
+;; examples/TESTING.md, the Example mount-isolation convention.
 (defonce react-root (atom nil))
 
-;; The whole frame lifecycle lives in one spot at the render root: the
-;; `frame-provider {:id app-frame …}` below. On first mount it creates the
-;; app frame, applies its config, and runs `:initial-events` once to seed
-;; app-db. On hot reload it reuses the same frame and skips re-seeding.
-;; `app-frame` is just an id we pick — the runtime won't infer it, so we
-;; name it here and hand it to the provider. Matches the canonical mount in
-;; examples/reagent/counter/core.cljs.
+;; The frame lifecycle lives in one place: the `frame-provider {:id app-frame
+;; …}` at the render root below. On first mount it creates the app frame,
+;; applies its config, and runs `:initial-events` once to seed app-db. On hot
+;; reload it reuses the same frame and skips re-seeding. `app-frame` is just
+;; an id we pick and hand to the provider. See the counter example for the
+;; same mount shape: examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   ;; `init!` installs the reactive adapter for the process. The adapter ns
-  ;; exports an `adapter` var; require the ns and pass that var directly.
+  ;; exports an `adapter` var; pass it directly.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -14,10 +14,13 @@
    so the trap never arises.
 
    Demonstrates:
-   - Single source of truth in app-db                    (Goal 7 / application-state)
-   - Event + sub composition over a single value          (CP-1, CP-2)
-   - Pure derivation in subs (Celsius ↔ Fahrenheit)        (CP-2)
-   - Schema-bound app-db slice                            (CP-8)"
+   - Single source of truth in app-db
+   - One event and one subscription chain over a single value
+   - Pure derivation in subscriptions (Celsius ↔ Fahrenheit)
+   - Schema-bound app-db slice
+
+   See docs/guide/concepts/subscriptions.md and the glossary entries for
+   event, subscription, and app-db in docs/guide/glossary.md."
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
@@ -159,10 +162,10 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, never at
+;; ns-load. Namespace load must do no DOM side effects, so co-loaded example
+;; namespaces don't race `create-root` onto the shared `#app`. See
+;; examples/TESTING.md "Convention: defer DOM mount to `run`".
 (defonce react-root (atom nil))
 
 ;; The whole frame lifecycle lives in one spot at the render root: the

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -6,32 +6,31 @@
 
    Rules:
      - The progress bar fills from 0 to 100% over the duration.
-     - The slider changes the duration on the fly: shrinking it should
-       advance the bar past the threshold immediately if elapsed > duration.
+     - The slider changes the duration on the fly: shrinking it advances the
+       bar to full immediately when elapsed already exceeds duration.
      - Reset sets elapsed back to zero.
 
-   The 7GUIs page calls this out as a test of *concurrency / time*. The
-   classic trap is to handle the timer outside the framework's update model,
-   creating races. The re-frame2 approach: a periodic event ticks elapsed
-   time forward through the same dispatch pipeline as everything else.
+   This is the 7GUIs test of time. A periodic event ticks elapsed time
+   forward through the same dispatch pipeline as every other change, so the
+   timer never lives outside the update model.
 
-   Demonstrates:
-   - `:dispatch-later` for timer ticks                    (CP-1, effect-map)
-   - One source of truth (elapsed)                        (state-in-app-db)
-   - Layered subs for derived progress %                   (CP-2)
-   - Controlled-input slider via dispatch on change       (CP-4)"
+   What it shows:
+   - `:dispatch-later` to schedule the next tick
+   - One source of truth: elapsed time lives in app-db
+   - Layered subscriptions deriving the progress percentage
+   - A controlled slider that dispatches on every change
+
+   Terms: events, subscriptions, app-db, frames — docs/guide/glossary.md."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Loading `re-frame.schemas` (from day8/re-frame2-schemas)
-            ;; registers the hooks that make `rf/reg-app-schema` resolve.
+            ;; Requiring this registers the hooks that make `rf/reg-app-schema` work.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 (def tick-ms
-  "Wall-clock delay between successive timer ticks. Kebab-case per the
-   sibling `examples/reagent/long_running_work` convention."
+  "Wall-clock delay in milliseconds between successive timer ticks."
   100)
 
 ;; ============================================================================
@@ -40,15 +39,15 @@
 
 (def TimerState
   [:map
-   [:elapsed-ms :int]                  ;; how long since the last reset
-   [:duration-ms :int]                  ;; the slider's current value
-   [:tick-active? :boolean]             ;; whether a tick is in flight
-   [:tick-gen :int]])                   ;; generation token; bumped on Reset to retire stale ticks
+   [:elapsed-ms :int]                  ;; milliseconds since the last reset
+   [:duration-ms :int]                 ;; the slider's current value
+   [:tick-active? :boolean]            ;; whether a tick is in flight
+   [:tick-gen :int]])                  ;; generation token; bumped on Reset to retire stale ticks
 
-;; `reg-app-schema` binds the schema to a specific frame, so it needs a frame
-;; in scope. At ns-load there is none, so we name the frame with `with-frame`.
-;; We use `:rf/default` — the same id the render root's `frame-provider` uses
-;; (see `run`) — so the schema lands on the app frame whose commits it validates.
+;; `reg-app-schema` binds the schema to a frame, so it needs a frame in scope.
+;; `with-frame` names one. We use `:rf/default`, the same id the render root's
+;; `frame-provider` uses (see `run`), so the schema lands on the frame whose
+;; commits it validates. Schemas: docs/guide/how-to/validate-with-schemas.md.
 (with-frame :rf/default
   (rf/reg-app-schema [:timer] {:schema TimerState}))
 
@@ -56,21 +55,20 @@
 ;; EVENTS
 ;; ============================================================================
 ;;
-;; The tick chain is driven by `:dispatch-later`, which has no cancel API.
-;; To avoid a race where Reset zeros :elapsed-ms but a previously-scheduled
-;; tick lands ~milliseconds later and re-increments it (causing the DOM to
-;; never observably show 0.0), each tick carries the :tick-gen value it was
-;; scheduled with. Reset bumps :tick-gen, so any in-flight tick from the
-;; previous generation no-ops when it eventually fires. Reset also schedules
-;; a fresh tick under the new generation, so the chain continues. This
-;; generation guard makes the 0.0 reading correct regardless of dispatch
-;; timing — Reset uses ordinary `dispatch`, like every other UI handler.
+;; The tick chain runs on `:dispatch-later`, which has no cancel API. So we
+;; guard ticks with a generation token. Each tick carries the :tick-gen it was
+;; scheduled under. A handler that wants to retire the in-flight tick bumps
+;; :tick-gen; when that stale tick finally fires its gen no longer matches, so
+;; it no-ops. The handler then schedules a fresh tick under the new generation,
+;; keeping exactly one chain alive.
 ;;
-;; :timer/set-duration reuses the same generation mechanism: when the tick
-;; chain has already stopped (elapsed reached the old duration) and the
-;; user raises the duration, the handler bumps :tick-gen and arms one fresh
-;; tick — resuming the chain without a Reset. This is what makes "the slider
-;; changes the duration on the fly" hold after completion.
+;; Reset uses this to show 0.0 reliably: it zeros :elapsed-ms and bumps the
+;; generation, so a tick scheduled just before Reset can't re-increment elapsed
+;; after the zeroing. :timer/set-duration uses it too: when the chain has
+;; already stopped (elapsed reached the old duration) and the user raises the
+;; duration, it bumps the generation and arms one fresh tick — resuming the
+;; chain without a Reset. That is what makes the slider change duration on the
+;; fly even after the timer has finished.
 
 (rf/reg-event :timer/initialise
   {:doc "Seed the timer slice and start the periodic tick."}
@@ -82,12 +80,12 @@
      :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick 0]}]]}))
 
 (rf/reg-event :timer/tick
-  {:doc "Advance elapsed by one tick. Schedules the next tick if still ticking.
-         Stale ticks (gen != current :tick-gen) are dropped — see header note."}
+  {:doc "Advance elapsed by one tick, scheduling the next while still ticking.
+         A tick whose generation no longer matches :tick-gen is dropped."}
   (fn handler-timer-tick [{:keys [db]} [_ gen]]
     (let [{:keys [elapsed-ms duration-ms tick-active? tick-gen]} (:timer db)]
       (if (not= gen tick-gen)
-        ;; Stale tick from a retired generation (Reset bumped :tick-gen). Drop it.
+        ;; Stale tick from a retired generation. Drop it.
         {}
         (let [next-elapsed (min (+ elapsed-ms tick-ms) duration-ms)
               done?        (>= next-elapsed duration-ms)]
@@ -97,22 +95,19 @@
             (assoc :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick gen]}]])))))))
 
 (rf/reg-event :timer/set-duration
-  {:doc "User dragged the slider. Update the duration, and — if the tick
-         chain had already stopped because elapsed reached the *old*
-         duration — re-arm it under a bumped generation so a longer
-         duration resumes ticking without a Reset. Bumping :tick-gen
-         retires any still-pending tick, so exactly one chain runs.
-         If a chain is still live (elapsed < old duration) we just
-         update the duration; the running tick keeps going against the
-         new target."
+  {:doc "User dragged the slider. Update the duration. If the tick chain had
+         already stopped (elapsed reached the old duration) and the new
+         duration leaves room to advance, re-arm one fresh tick under a
+         bumped generation so it resumes without a Reset. While a chain is
+         still live, just update the duration — the running tick keeps going
+         against the new target."
    :schema [:cat [:= :timer/set-duration] :int]}
   (fn handler-timer-set-duration [{:keys [db]} [_ ms]]
     (let [{:keys [elapsed-ms duration-ms tick-active? tick-gen]} (:timer db)
-          ;; The chain stops scheduling once elapsed reaches duration
-          ;; (see :timer/tick's `done?`). Detect that stopped state.
+          ;; The chain stops scheduling once elapsed reaches duration.
           was-stopped? (>= elapsed-ms duration-ms)
-          ;; Re-arm only when stopped, still active, and the new
-          ;; duration leaves elapsed below target (room to advance).
+          ;; Re-arm only when stopped, still active, and the new duration
+          ;; leaves elapsed below target (room to advance).
           rearm?       (and was-stopped? tick-active? (> ms elapsed-ms))
           next-gen     (if rearm? (inc tick-gen) tick-gen)
           db'          (cond-> (assoc-in db [:timer :duration-ms] ms)
@@ -176,8 +171,6 @@
                                       (js/parseInt (.. % -target -value))])}]
       [:span (.toFixed (/ duration 1000.0) 1) " s"]]
      [:div.row
-      ;; Plain `dispatch`, like every UI handler. The 0.0 reading shows
-      ;; reliably thanks to the :tick-gen generation guard (see EVENTS note).
       [:button {:data-testid "timer-reset"
                 :on-click #(dispatch [:timer/reset])} "Reset"]]]))
 
@@ -185,22 +178,20 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. ns-load must produce no DOM side effects, so co-required example
+;; namespaces don't race `create-root` onto the shared `#app` element.
 (defonce react-root (atom nil))
 
-;; The whole frame lifecycle lives in one spot at the render root: the
-;; `frame-provider {:id app-frame …}` below. On first mount it creates the
-;; app frame, applies its config, and runs `:initial-events` once to seed
-;; app-db. Thereafter every `dispatch`/`subscribe` in the tree resolves to
-;; that frame. On hot reload the provider reuses the existing frame and skips
+;; The frame lifecycle lives in one place: the `frame-provider` below. On first
+;; mount it creates the frame, applies its config, and runs `:initial-events`
+;; once to seed app-db. From then on every `dispatch`/`subscribe` in the tree
+;; resolves to that frame. On hot reload it reuses the existing frame and skips
 ;; re-seeding, so the timer keeps ticking across re-mounts.
+;; Frames: docs/guide/concepts/frames.md.
 ;;
-;; `app-frame` is just an id we pick. We use `:rf/default` — the same id the
-;; schema block above binds to. Matches the canonical mount in
-;; examples/reagent/counter/core.cljs.
+;; `app-frame` is just an id we pick — `:rf/default`, the same id the schema
+;; block above binds to.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -1,78 +1,60 @@
 (ns ssr.core
-  "Worked example for [Construction Prompt CP-9](../../../spec/Construction-Prompts.md)
-   and [Spec 011 SSR & Hydration](../../../spec/011-SSR.md). A small server+client app:
-   server renders a 'recent articles' page; client hydrates and remains
-   interactive.
+  "Server-side rendering: one app that runs twice. The server renders a
+   'recent articles' page to HTML; the client hydrates it and stays
+   interactive. See the SSR guide: ../../../docs/ssr/concepts.md.
 
-   Per [011-SSR.md](../../../spec/011-SSR.md): SSR is part of the target
-   architecture, not a future concession. View pure-fn requirement,
-   id-valued override seam, hydration via :rf/hydrate.
+   This is .cljc so the same code runs server-side (JVM, :clj branches) and
+   client-side (browser, :cljs branches). The events, subscriptions, and
+   views are shared — there is no second server-flavoured copy of the app.
 
-   This is .cljc so the same code can be evaluated server-side (JVM, with
-   :clj branches) and client-side (browser, with :cljs branches).
+   What this example shows:
+   - A per-request frame on the server (reg-frame + with-frame).
+   - :rf/server-init, dispatched when the frame is created.
+   - A client-only fx gated with :platforms #{:client} — the server render
+     skips it.
+   - The pure hiccup -> HTML emitter (rf/render-to-string).
+   - The hydration payload the server ships for the client to adopt.
+   - Per-request frame teardown in a `finally` (rf/destroy-frame!).
+   - Framework-owned hydration: the client boots via `ssr/hydrate!`, which
+     dispatches the reserved `:rf/hydrate` event. The app writes no handler
+     for it. `:rf/hydrate` replaces the client frame-state (it does not
+     merge) — the server is authoritative.
+   - A structural render hash. The client recomputes it after its first
+     render and compares against the server's; a disagreement emits
+     :rf.ssr/hydration-mismatch. See ../../../docs/ssr/glossary.md#hydration-mismatch.
 
-   Demonstrates:
-   - Per-request frame on the server                 (reg-frame + with-frame)
-   - :rf/server-init dispatched at frame creation
-   - Server-only fx via :platforms #{:server}        (and skipping on the client)
-   - Pure hiccup → HTML emitter                       (rf/render-to-string)
-   - Hydration payload format                         (:rf/hydration-payload schema)
-   - Per-request frame teardown in a `finally`        (rf/destroy-frame!)
-   - Framework-owned hydration: the client boots via the `ssr/hydrate!`
-     helper, which dispatches the framework's reserved `:rf/hydrate` event.
-     `:rf/hydrate` replaces (not merges) the client frame-state, per the
-     locked :replace-frame-state policy.
-   - data-rf-render-hash structural marker on the root element; `ssr/hydrate!`
-     verifies the client render-tree hash against the server's after first
-     render and the runtime emits :rf.ssr/hydration-mismatch on disagreement
-
-   Runnable form: the hand-written `index.html` next to this
-   file ships with pre-rendered HTML inside `<div id='app'>` and a pre-
-   baked `<script id='__rf_payload'>` — exactly the shape `handle-request`
-   below would emit if a real Clojure server were sitting in front. The
-   browser-side `run` calls `ssr/hydrate!` (read payload → dispatch
-   `:rf/hydrate` → verify) and renders against the now-seeded frame-state."
+   To run it: the hand-written `index.html` next to this file ships with
+   pre-rendered HTML inside `<div id='app'>` and a baked
+   `<script id='__rf_payload'>` — the same shape `handle-request` below
+   emits. The browser-side `run` calls `ssr/hydrate!` (read payload ->
+   dispatch `:rf/hydrate` -> verify) and renders against the seeded
+   frame-state."
   (:require [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
+            ;; Loading this ns registers the schema hooks so
             ;; rf/reg-app-schema resolves at the call sites below.
             [re-frame.schemas]
-            ;; Managed-HTTP ships in day8/re-frame2-http.
-            ;; Loading the ns here registers the `:rf.http/managed` fx
-            ;; family — the SSR worked example dispatches
-            ;; `:rf.http/managed` for the article-list fetch and uses
-            ;; per-frame `:fx-overrides` to redirect to a canned-success
-            ;; stub during render. Without the require, the override
-            ;; would target an unregistered fx-id.
+            ;; Registers the `:rf.http/managed` fx family. This example
+            ;; dispatches `:rf.http/managed` for the article fetch and uses
+            ;; per-frame `:fx-overrides` to redirect it to a canned-success
+            ;; stub during render. Without the require, the override would
+            ;; target an unregistered fx-id.
             [re-frame.http.managed]
-            ;; The canned-stub fx ids
+            ;; Registers the canned-stub fx ids
             ;; (`:rf.http/managed-canned-success`,
-            ;; `:rf.http/managed-canned-failure`) register from
-            ;; re-frame.http.test-support, NOT re-frame.http.managed.
-            ;; The SSR demo drives the canned stubs via :fx-overrides
-            ;; and is a test/demo affordance (no Conduit backend ships
-            ;; with the example), so the test-support require is the
-            ;; explicit opt-in.
+            ;; `:rf.http/managed-canned-failure`). The example has no real
+            ;; backend, so it drives these stubs via :fx-overrides; this
+            ;; require is the explicit opt-in to the test affordance.
             [re-frame.http.test-support]
-            ;; SSR ships in day8/re-frame2-ssr. Loading
-            ;; the ns here registers the seven `:rf.server/*` server-only
-            ;; fxs, the `:rf/hydrate` event, and the
-            ;; `:rf.ssr/default-error-projector`, and publishes the
-            ;; late-bind hooks (`:ssr/render-tree-hash`,
-            ;; `:ssr/render-to-string`, `:ssr/reg-error-projector`,
-            ;; `:ssr/project-error`). Without the require the four core
-            ;; re-exports raise `:rf.error/ssr-artefact-missing`.
+            ;; Registers the `:rf.server/*` server-only fxs, the `:rf/hydrate`
+            ;; event, the default error projector, and the SSR render/hash
+            ;; hooks the core re-exports below rely on.
             [re-frame.ssr :as ssr]
-            ;; The EDN-aware `<script>`-body escaper the production Ring
-            ;; host uses (`re-frame.ssr.ring.shell/payload-script-tag` →
-            ;; `escape-edn-script-body`). Server-side only — the `:clj`
-            ;; `handle-request` drops the `pr-str`'d payload inside a
-            ;; `<script type="application/edn">` body and a server-provided
+            ;; The EDN-aware `<script>`-body escaper, used server-side only.
+            ;; The `:clj` `handle-request` drops the `pr-str`'d payload inside
+            ;; a `<script type="application/edn">` body; a server-provided
             ;; string containing `</script>` would otherwise close the
-            ;; envelope (security audit 2026-05-14 §P1). It lives
-            ;; in the SSR artefact (`re-frame.ssr.html-helpers`), so it ships
-            ;; with the same `day8/re-frame2-ssr` dep the example already
-            ;; requires above.
+            ;; envelope. The escaper rewrites `<` to its reader escape only
+            ;; inside EDN string literals, so the payload still round-trips.
             #?(:clj [re-frame.ssr.html-helpers :as html])
             #?(:cljs [reagent.dom.client :as rdc])
             #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
@@ -81,18 +63,18 @@
 ;; SCHEMA
 ;; ============================================================================
 ;;
-;; Hold the schema as a plain value. SSR has TWO frame families — the
-;; per-request server frame (gensym, in `handle-request`) and the fixed client
-;; hydration frame (`app-frame` → `:rf/default`, in `run`) — and the same
-;; contract applies to both. So each entry point registers it against its own
-;; frame with the `{:frame …}` override (server: per request; client: at boot).
-;; `reg-app-schema` is frame-local: it needs an explicit `:frame`, and holding
-;; the schema as a `def` keeps ns-load free of any ambient frame fixture.
-;; `[:maybe …]` because the slice is nil until `:articles/loaded` commits: the
+;; Hold the schema as a plain value. SSR has two frames — the per-request
+;; server frame (a gensym, in `handle-request`) and the fixed client frame
+;; (`app-frame`, in `run`) — and the same contract applies to both. Each entry
+;; point registers it against its own frame with the `{:frame …}` override.
+;; `reg-app-schema` is frame-local, so it needs an explicit `:frame`; holding
+;; the schema as a `def` keeps ns-load free of any ambient frame.
+;;
+;; `[:maybe …]` because the slice is nil until `:articles/loaded` commits. The
 ;; server's `:rf/server-init` commits an articles-free db first (it only kicks
-;; off the managed-HTTP fetch), and the client frame starts empty before
-;; hydration. A bare `[:vector …]` would reject that legitimate intermediate
-;; nil and roll the commit back.
+;; off the fetch), and the client frame starts empty before hydration. A bare
+;; `[:vector …]` would reject that legitimate intermediate nil and roll the
+;; commit back. See ../../../docs/guide/glossary.md#schema.
 (def ArticlesSchema
   [:maybe [:vector [:map
                     [:id    :string]
@@ -103,14 +85,14 @@
 ;; FX
 ;; ============================================================================
 ;;
-;; HTTP requests go via the framework-shipped `:rf.http/managed` (Spec 014).
-;; The SSR test below redirects it through the `:fx-overrides` seam to a
-;; per-frame canned-success stub, so the JVM-side render exercises the full
-;; domino loop without real network traffic.
+;; HTTP requests go via the framework's `:rf.http/managed` fx. The headless
+;; test redirects it through the `:fx-overrides` seam to a per-frame
+;; canned-success stub, so the JVM render exercises the full event cascade
+;; without real network traffic.
 
 (rf/reg-fx :auth.session/store
   {:doc       "Persist a session token in localStorage."
-   :platforms #{:client}}              ;; client-only — server SSR skips this
+   :platforms #{:client}}              ;; client-only — the server render skips it
   (fn fx-auth-session-store [_m {:keys [token]}]
     #?(:cljs (when-let [ls (.-localStorage js/globalThis)]
                (.setItem ls "auth/token" token)))))
@@ -120,59 +102,56 @@
 ;; ============================================================================
 
 (rf/reg-event :rf/server-init
-  {:doc       "Per-request server-side initialisation. Reads the request
-               via the :rf.server/request cofx (Spec 011 §Request storage
-               substrate), dispatches setup events. Server only."
+  {:doc       "Per-request server-side initialisation. Reads the request via
+               the :rf.server/request coeffect and kicks off setup. Server
+               only. See ../../../docs/ssr/concepts.md#reading-the-request."
    :platforms #{:server}
    :rf.cofx/requires [:rf.server/request]}
   (fn handler-rf-server-init [{:keys [db rf.server/request]} _]
     ;; `request` is the host-supplied HTTP request map (Ring shape under the
     ;; bundled adapter); read URL/headers/cookies from it. It arrives via the
-    ;; `:rf.server/request` cofx, not a positional event arg.
+    ;; `:rf.server/request` coeffect, declared above, not as an event arg.
     ;;
-    ;; This handler leaves db unchanged and just kicks off the managed-HTTP
-    ;; article fetch. (A router-driven app would store the matched route here,
-    ;; in the runtime-db partition at `[:rf.runtime/routing :current]` per
-    ;; EP-0001; this article-only render has no route to track.)
+    ;; This handler leaves db unchanged and just kicks off the article fetch.
+    ;; A router-driven app would store the matched route here; this
+    ;; article-only render has no route to track.
     {:db db
      :fx [[:rf.http/managed
            {:request    {:method :get :url "/api/articles"}
             :decode     :json
             :on-success [:articles/loaded]}]]}))
 
-;; The managed-HTTP `:on-success` target. Pure: it takes the decoded reply
-;; value and DESCRIBES the next app-db; the runtime commits it. This same
-;; handler runs identically on the server (per-request frame) and the client
-;; (post-hydration) — there is nothing platform-specific to gate.
+;; The `:on-success` target for the article fetch. It takes the decoded reply
+;; value and returns the next app-db; the runtime commits it. The same handler
+;; runs on the server (per-request frame) and the client (post-hydration) —
+;; nothing here is platform-specific.
 (rf/reg-event :articles/loaded
   (fn handler-articles-loaded [{:keys [db]} [_ {:keys [value]}]]
     {:db (assoc db :articles value)}))
 
-;; HYDRATION IS FRAMEWORK-OWNED. `:rf/hydrate` is a reserved `:rf/*` event
-;; (Conventions §Reserved namespaces) that `re-frame.ssr` registers; the app
-;; supplies no handler for it. The framework handler installs the whole client
-;; frame-state in one atomic transition under the locked :replace-frame-state
-;; policy (Spec 011 §The :rf/hydrate event): the server is authoritative, so
-;; the payload's :rf/app-db replaces the app-db partition and :rf/runtime-db
-;; replaces the serializable runtime-db projection (machine snapshots, route
-;; slice, …). The handler also validates the payload fail-closed (a non-map
-;; payload, or a present-but-non-map :rf/app-db / :rf/runtime-db slice, leaves
-;; the frame-state untouched), and stashes the server's :rf/render-hash under
-;; [:rf.runtime/ssr :hydration :server-hash] for `ssr/verify-hydration!` to
-;; compare after the first render. (This example carries no machines and
-;; doesn't hydrate the route, so its :rf/runtime-db is empty — but the shape is
-;; the one a richer app uses.) The client `run` below drives all this through
-;; `ssr/hydrate!` — see the CLIENT ENTRY POINT section.
+;; Hydration is framework-owned. `:rf/hydrate` is a reserved `:rf/*` event that
+;; `re-frame.ssr` registers; the app supplies no handler for it. The framework
+;; handler installs the whole client frame-state in one atomic step, replacing
+;; whatever the client pre-seeded — the server is authoritative. The payload's
+;; app-db replaces the app-db partition; its runtime-db slice (machine
+;; snapshots, route slice) replaces the serializable runtime-db projection. The
+;; handler validates the payload fail-closed: a non-map payload, or a
+;; present-but-non-map slice, leaves the frame-state untouched. It also stashes
+;; the server's render hash for the verify step after the first render. (This
+;; example has no machines and doesn't hydrate the route, so its runtime-db
+;; slice is empty — but the shape is the one a richer app uses.) The client
+;; `run` below drives all of this through `ssr/hydrate!`; see the CLIENT ENTRY
+;; POINT section. Why replace and not merge:
+;; ../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify
 
 ;; ============================================================================
 ;; CLIENT-SIDE INTERACTIVITY EVENTS
 ;; ============================================================================
 ;;
-;; A small interactive surface so we can verify that hydration left the
-;; client fully reactive — clicking "Hide bodies" must toggle the body
-;; paragraphs in/out without a full re-render. The slice has no server
-;; correspondent, so it lives outside the SSR payload's authoritative
-;; slice and starts at its default value on the client.
+;; A small interactive surface that proves hydration left the client fully
+;; reactive: clicking "Hide bodies" toggles the body paragraphs in and out
+;; without a full re-render. This slice has no server counterpart, so it is not
+;; in the hydration payload and starts at its default value on the client.
 
 (rf/reg-event :articles/toggle-bodies
   (fn [{:keys [db]} _] {:db (update db :articles/show-bodies? (fnil not true))}))
@@ -190,15 +169,15 @@
     (let [v (:articles/show-bodies? db)]
       (if (nil? v) true v))))
 
-;; reg-view (defn-shape per Spec 004 §reg-view) auto-defs the symbol and
-;; registers under (keyword *ns* sym). `^{:rf/id ...}` overrides that id so the
-;; :pages/articles / :app/root ids the callers below use match the registrations.
+;; reg-view auto-defs the symbol and registers it under (keyword *ns* sym).
+;; `^{:rf/id ...}` overrides that id so the :pages/articles / :app/root ids the
+;; callers below use match the registrations.
 ;;
 ;; The `subscribe` injected by `reg-view` resolves to the frame-bound subscribe
-;; fn at runtime. The same view code runs both sides: on the JVM render path,
+;; fn at runtime. The same view code runs on both sides: on the JVM render path,
 ;; deref of a subscription yields its current value; on the client, deref tracks
-;; the reaction so re-renders fire on app-db changes. That's the SSR/CLJS parity
-;; Spec 011 promises.
+;; the reaction so re-renders fire on app-db changes. That parity is what lets
+;; one view run twice. See ../../../docs/guide/glossary.md#view.
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
   (let [arts         @(subscribe [:articles/slice])
         show-bodies? @(subscribe [:articles/show-bodies?])]
@@ -223,35 +202,28 @@
 ;; SERVER ENTRY POINT
 ;; ============================================================================
 ;;
-;; The server flow:
-;;   1. Accept request.
-;;   2. set-request! populates the per-frame slot for the :rf.server/request
-;;      cofx (Spec 011 §Request storage substrate).
-;;   3. reg-frame; the :initial-events step dispatches :rf/server-init
-;;      (which reads the request via the cofx).
-;;   4. Drain settles (HTTP fetches resolve via :rf.http/managed; the JVM
-;;      transport uses java.net.http.HttpClient under the hood).
-;;   5. Render to string via the pure hiccup → HTML emitter.
-;;   6. Serialise app-db; ship in the HTML.
-;;   7. destroy-frame! in a `finally` — per Spec 011 §Per-request frame
-;;      teardown contract every per-request server frame ends with
-;;      `destroy-frame!`. This is load-bearing for memory hygiene on a
-;;      long-running server: it drops the frame record AND fires the
-;;      `:ssr/on-frame-destroyed` hook, which releases the per-frame
-;;      request slot + response accumulator + error-trace buffer (all
-;;      frame-id-keyed side-channel atoms). Without it, every request
-;;      leaks a frame + a request entry. The `finally` runs on BOTH the
-;;      success and throw paths (e.g. a render or fetch error), so no
-;;      partially-built frame leaks either. This mirrors `ssr_streaming`'s
-;;      `handle-request` and the bundled `re-frame.ssr.ring` host adapter,
-;;      which both tear the frame down on every exit path.
+;; The server flow, start to finish (../../../docs/ssr/concepts.md#a-request-start-to-finish):
+;;   1. Accept the request.
+;;   2. set-request! populates the per-frame slot the :rf.server/request
+;;      coeffect reads from.
+;;   3. reg-frame; its :initial-events step dispatches :rf/server-init, which
+;;      reads the request via the coeffect.
+;;   4. The runtime drains: HTTP fetches resolve and app-db settles.
+;;   5. Render to a string via the pure hiccup -> HTML emitter.
+;;   6. Serialise the state and ship it in the HTML payload.
+;;   7. destroy-frame! in a `finally`. This is load-bearing for memory hygiene
+;;      on a long-running server: it drops the frame record and fires the
+;;      `:ssr/on-frame-destroyed` hook, which releases the per-frame request
+;;      slot, response accumulator, and error-trace buffer. The `finally` runs
+;;      on both the success and throw paths, so no partially-built frame leaks
+;;      either.
 
 #?(:clj
    (defn handle-request [request]
      (let [fid (keyword "rf.frame" (str (gensym "f")))
            _   (ssr/set-request! fid request)
            ;; Register the app schema against this per-request server frame,
-           ;; under the gensym `fid`, BEFORE creating the frame. `reg-frame`
+           ;; under the gensym `fid`, before creating the frame. `reg-frame`
            ;; runs its `:initial-events` cascade synchronously, so the schema
            ;; must be in place first to validate the server-side `:articles`
            ;; commit that `:rf/server-init` kicks off.
@@ -279,15 +251,15 @@
                  render-hash (rf/render-tree-hash hiccup)
                  ;; The payload omits `:rf/frame-id`. The server renders under
                  ;; a per-request gensym frame (`f`); the client hydrates its
-                 ;; own fixed app-frame (`app-frame` → `:rf/default`, below).
-                 ;; A payload frame-id is validation evidence, not a hydration
-                 ;; target: `ssr/hydrate!` checks any present `:rf/frame-id`
-                 ;; against the client's explicit `:frame` and raises
-                 ;; `:rf.error/hydration-frame-id-mismatch` if they disagree
-                 ;; (Spec 011 §The hydration payload). An absent id is the
-                 ;; no-conflict shape both this output and the static
-                 ;; `index.html` use. To carry a frame-id, a deployment stamps
-                 ;; a stable id both sides agree on — not a per-request gensym.
+                 ;; own fixed app-frame (`app-frame`, below). A payload frame-id
+                 ;; is validation evidence, not a hydration target: `ssr/hydrate!`
+                 ;; checks any present `:rf/frame-id` against the client's
+                 ;; explicit `:frame` and raises
+                 ;; `:rf.error/hydration-frame-id-mismatch` if they disagree. An
+                 ;; absent id is the no-conflict shape both this output and the
+                 ;; static `index.html` use. To carry a frame-id, a deployment
+                 ;; stamps a stable id both sides agree on — not a per-request
+                 ;; gensym.
                  payload  {:rf/version     1
                            :rf/app-db      final-db        ;; app-db partition
                            :rf/runtime-db  final-runtime   ;; serializable runtime-db projection
@@ -301,23 +273,21 @@
                    "</head><body>"
                    "<div id='app'>" html "</div>"
                    ;; Emit the payload `<script>` through the EDN-aware
-                   ;; `</script>`-escaper the production Ring host uses
-                   ;; (security audit 2026-05-14 §P1): a server-
-                   ;; provided string carrying `</script>` (round-tripped
-                   ;; through app-db) can't close the envelope. The encoder
-                   ;; rewrites a less-than char to its unicode reader escape
-                   ;; ONLY inside EDN string literals, so the payload still
-                   ;; round-trips through the client's `cljs.reader/read-string`
-                   ;; unchanged.
+                   ;; `</script>`-escaper, so a server-provided string carrying
+                   ;; `</script>` (round-tripped through app-db) can't close the
+                   ;; envelope. The encoder rewrites a less-than char to its
+                   ;; unicode reader escape only inside EDN string literals, so
+                   ;; the payload still round-trips through the client's
+                   ;; `cljs.reader/read-string` unchanged.
                    "<script id='__rf_payload' type='application/edn'>"
                    (html/escape-edn-script-body (pr-str payload))
                    "</script>"
                    "<script src='/main.js'></script>"
                    "</body></html>")}))
-         ;; Tear the per-request frame down on EVERY exit path. The
-         ;; `:ssr/on-frame-destroyed` hook (fired by destroy-frame!)
-         ;; clears the request slot + the SSR side-channel atoms, so no
-         ;; explicit `clear-request!` is needed here.
+         ;; Tear the per-request frame down on every exit path. The
+         ;; `:ssr/on-frame-destroyed` hook (fired by destroy-frame!) clears the
+         ;; request slot and the SSR side-channel atoms, so no explicit
+         ;; `clear-request!` is needed here.
          (finally
            (rf/destroy-frame! fid))))))
 
@@ -325,48 +295,44 @@
 ;; CLIENT ENTRY POINT
 ;; ============================================================================
 ;;
-;; The client flow is `ssr/hydrate!` — the framework's client-boot helper,
-;; the symmetric counterpart of the server-side render pipeline (Spec 011
-;; §Client flow / §Client-side hydration boot helper). One call fuses the
-;; three steps the spec mandates, in order:
+;; The client flow is `ssr/hydrate!` — the framework's client-boot helper, the
+;; counterpart of the server render. One call does the three steps, in order:
 ;;   1. READ    — the embedded `__rf_payload` `<script>` via the pinned id.
-;;                A malformed payload fails CLOSED (no app-db replacement) and
-;;                a missing payload is the client-only first-load shape.
-;;   2. HYDRATE — dispatch-sync `[:rf/hydrate payload]` BEFORE first render.
-;;                The framework handler *replaces* the frame-state with the
-;;                server slice (locked :replace-frame-state policy) and stashes
-;;                the server's :rf/render-hash for the verify step.
-;;   3. VERIFY  — after first render, hash the `:render-tree-fn` result and
+;;                A malformed payload fails closed (no app-db replacement); a
+;;                missing payload is the client-only first-load shape.
+;;   2. HYDRATE — dispatch-sync `[:rf/hydrate payload]` before the first render.
+;;                The framework handler replaces the frame-state with the server
+;;                slice and stashes the server's render hash for the verify step.
+;;   3. VERIFY  — after the first render, hash the `:render-tree-fn` result and
 ;;                compare it to the server hash; a disagreement emits
 ;;                :rf.ssr/hydration-mismatch.
 ;; `hydrate!` returns the payload it applied (nil on a client-only load), so
-;; `run` branches on "was this server-rendered?" without re-reading the DOM.
-;; Going through the helper is what pins the fail-closed validation, the
-;; metadata stash, and the verify step together in the right order.
+;; `run` can branch on "was this server-rendered?" without re-reading the DOM.
+;; Going through the helper pins the fail-closed validation, the hash stash, and
+;; the verify step together in the right order.
+;; See ../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
 
 ;; User events live under an app-chosen namespace, never the reserved `:rf/*`
-;; root (Conventions §Reserved namespaces). `:rf/hydrate` is framework-owned;
-;; `:rf/server-init` is the documented per-request server-init pattern event
-;; the app supplies a body for. This client-only-load bootstrap is a fresh user
-;; event, so it gets the app's own `:ssr/` namespace.
+;; root. `:rf/hydrate` is framework-owned; `:rf/server-init` is the documented
+;; per-request server-init pattern the app supplies a body for. This
+;; client-only-load bootstrap is a fresh user event, so it gets the app's own
+;; `:ssr/` namespace.
 (rf/reg-event :ssr/client-bootstrap
   {:doc "Client-side init that runs even if the server didn't render this page."}
   (fn [{:keys [db]} _] {:db db}))
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. ns-load must produce no DOM side effects, so co-required example
+;; namespaces don't race `create-root` onto the shared `#app`.
 #?(:cljs (defonce react-root (atom nil)))
 
 ;; The client app-frame id. The app names its frame explicitly and threads this
 ;; id through both `ssr/hydrate!` (the seed target) and the root
-;; `frame-provider` (where every in-tree `dispatch`/`subscribe` resolves). This
-;; example uses `:rf/default`. It must be a `:client`-platform frame so the
-;; `:rf.ssr/check-*` compatibility-check fxs the `:rf/hydrate` handler
-;; dispatches actually fire (Spec 011 §The :rf/hydrate event — a `:server`
-;; frame skips them). The server payload carries no `:rf/frame-id`, so this
-;; explicit `:frame` is the hydration target (see the `handle-request` note).
+;; `frame-provider` (where every in-tree `dispatch`/`subscribe` resolves). It
+;; must be a `:client`-platform frame so the compatibility-check fxs the
+;; `:rf/hydrate` handler dispatches actually fire — a `:server` frame skips
+;; them. The server payload carries no `:rf/frame-id`, so this explicit `:frame`
+;; is the hydration target (see the `handle-request` note).
 (def app-frame :rf/default)
 
 #?(:cljs
@@ -378,27 +344,23 @@
      ;; Pass the adapter spec map directly — each adapter ns exports an
      ;; `adapter` var the consumer requires and passes here.
      (rf/init! reagent-adapter/adapter)
-     ;; Create the client app-frame, before hydrating into it. `reg-frame` is a
+     ;; Create the client app-frame before hydrating into it. `reg-frame` is a
      ;; no-op on re-registration, so hot-reload just works. `:platform :client`
-     ;; makes the hydrate compatibility-check fxs fire (Spec 011 §The :rf/hydrate
-     ;; event).
+     ;; makes the hydrate compatibility-check fxs fire.
      (rf/reg-frame app-frame {:doc      "ssr-example client app-frame"
                               :platform :client})
-     ;; Register the app schema AGAINST THE FIXED CLIENT FRAME so
-     ;; the hydrated `:articles` commit + every post-hydration interactive
-     ;; commit validate on the client too — the symmetric counterpart of the
-     ;; per-request registration in `handle-request`. `{:frame app-frame}` is
-     ;; the explicit override; `reg-app-schema` is a no-op-safe re-registration
-     ;; on hot-reload.
+     ;; Register the app schema against the fixed client frame, so the hydrated
+     ;; `:articles` commit and every post-hydration interactive commit validate
+     ;; on the client too — the counterpart of the per-request registration in
+     ;; `handle-request`. `reg-app-schema` is no-op-safe on hot-reload.
      (rf/reg-app-schema [:articles] {:schema ArticlesSchema :frame app-frame})
-     ;; Drive READ + HYDRATE + VERIFY through `ssr/hydrate!` (the steps detailed
-     ;; in the CLIENT ENTRY POINT header), against the same `app-frame` the mount
-     ;; below uses. `:render-tree-fn` must return the same resolved hiccup tree
-     ;; the server hashed: the server hashed `((rf/view :app/root))`, so VERIFY
-     ;; CALLS the view fn — `((rf/view :app/root))` — not the vector form
-     ;; `[(rf/view :app/root)]` that Reagent mounts. `hydrate!` returns the
-     ;; payload it applied (nil on a client-only load), so we can branch on "was
-     ;; this server-rendered?".
+     ;; Drive READ + HYDRATE + VERIFY through `ssr/hydrate!`, against the same
+     ;; `app-frame` the mount below uses. `:render-tree-fn` must return the same
+     ;; resolved hiccup tree the server hashed. The server hashed
+     ;; `((rf/view :app/root))`, so VERIFY calls the view fn the same way —
+     ;; `((rf/view :app/root))` — not the vector form `[(rf/view :app/root)]`
+     ;; that Reagent mounts. `hydrate!` returns the payload it applied (nil on a
+     ;; client-only load).
      (let [payload (ssr/hydrate! {:frame          app-frame
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})]
        (when-not payload
@@ -414,16 +376,15 @@
                    [rf/frame-provider {:frame app-frame}
                     [(rf/view :app/root)]]))))
 
-;; The JVM-runnable headless tests for this example live in
-;; re-frame.examples-test (implementation/core/test/), keeping this example
-;; source pure demonstrative code (the example tree is test-free).
-;; They run on the JVM:
-;;   - `ssr-example-runs-end-to-end` — the full server flow (per-request
-;;     frame → :rf/server-init → managed-HTTP via a canned stub →
-;;     render-to-string → render-hash).
-;;   - `ssr-example-handle-request-tears-down-per-request-frame` +
-;;     `…-tears-down-on-throw` — per-request frame teardown on both the
-;;     success and throw paths.
-;;   - `ssr-example-client-hydration-*` — the client hydration path against
-;;     the framework-owned :rf/hydrate: server-hash stash, matching/divergent
-;;     hash verify, and fail-closed on a malformed payload.
+;; The headless tests for this example live in re-frame.examples-test
+;; (implementation/core/test/), so this source stays pure demonstration (the
+;; example tree is test-free). They run on the JVM:
+;;   - `ssr-example-runs-end-to-end` — the full server flow: per-request frame,
+;;     :rf/server-init, the article fetch via a canned stub, render-to-string,
+;;     render-hash.
+;;   - `ssr-example-handle-request-tears-down-per-request-frame` and
+;;     `…-tears-down-on-throw` — per-request frame teardown on the success and
+;;     throw paths.
+;;   - `ssr-example-client-hydration-*` — the client hydration path: server-hash
+;;     stash, matching/divergent hash verify, and fail-closed on a malformed
+;;     payload.

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -1,27 +1,23 @@
 (ns ssr-streaming.core
-  "Worked example for Spec 011 §Streaming SSR.
+  "Streaming SSR: a dashboard with three slow cards. The shell + header
+  render immediately on the server. Each card then streams its content
+  in as its data resolves, so the browser shows a usable shell within
+  ~50ms while the cards trickle in over ~300ms each.
 
-  A dashboard with three slow cards: the page's shell + header render
-  immediately on the server, then each card streams its content as its
-  data fetch resolves. The browser shows a usable shell within ~50ms
-  while the cards trickle in over ~300ms each.
+  What this example shows:
+   - `:rf/suspense-boundary` — the declarative hiccup marker for a
+     streamable subtree.
+   - Per-card fallback hiccup — `[:div.card.skeleton …]`.
+   - Failure isolation — one card deliberately throws to show a failing
+     boundary stays on its fallback instead of 500-ing the page.
+   - Per-subtree hydration — each chunk's
+     `<script data-rf2-suspense-hydrate>` carries that card's app-db delta.
+   - A final `__rf_payload` chunk with the canonical full state.
 
-  Demonstrates:
-   - `:rf/suspense-boundary` hiccup marker — declarative
-   - Per-card fallback hiccup — `[:div.card.skeleton …]`
-   - Inline-fallback failure semantics — one card deliberately throws
-     to show the failure path doesn't 500 the page
-   - Hydration interleaved per subtree — each chunk's
-     `<script data-rf2-suspense-hydrate>` carries the per-card app-db
-     delta
-   - Final `__rf_payload` arrives last with the canonical full state
+  The `.cljc` split: the `:clj` branch is what a Ring server invokes; the
+  `:cljs` branch is what the page bootstraps once the chunks arrive.
 
-  The .cljc shape mirrors `examples/reagent/ssr/core.cljc`: server
-  branch in `:clj`, browser branch in `:cljs`. The :clj branch is
-  what a Ring server would invoke; the :cljs branch is what the page
-  bootstraps after the chunks arrive.
-
-  Per [Spec 011 §Streaming SSR](../../../spec/011-SSR.md#streaming-ssr)."
+  See the [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)."
   (:require [re-frame.core :as rf]
             [re-frame.schemas]
             [re-frame.ssr :as ssr]
@@ -33,15 +29,17 @@
 ;; ============================================================================
 ;;
 ;; We hold the schema as a plain value and register it per-frame at each
-;; entry point with the `{:frame …}` override. Streaming SSR runs two frame
-;; families — the per-request server frame (gensym, in `handle-request`) and
-;; the fixed client hydration frame (`app-frame` → `:rf/default`, in `run`)
-;; — and both need the same contract, so each registers it explicitly.
-;; `reg-app-schema` is frame-local (EP-0002), so holding the schema as a def
-;; also keeps ns-load side-effect-free: the namespace loads under no frame.
+;; entry point with the `{:frame …}` override. Streaming SSR runs two
+;; frames — the per-request server frame (gensym, in `handle-request`) and
+;; the fixed client hydration frame (`app-frame`, in `run`) — and both need
+;; the same contract, so each registers it explicitly. Schemas are
+;; frame-local, so holding the schema as a plain def keeps ns-load free of
+;; side effects: the namespace loads under no frame.
+;;
 ;; `[:maybe …]` because the `:cards` slice is nil until `:rf/server-init`
-;; seeds it on the server / the client hydrates it. A bare `[:map-of …]`
+;; seeds it on the server, or the client hydrates it. A bare `[:map-of …]`
 ;; would reject that legitimate nil and roll the commit back.
+;; See the [schemas guide](../../../docs/guide/how-to/validate-with-schemas.md).
 (def CardsSchema
   [:maybe [:map-of :keyword [:map [:title :string] [:value [:maybe :int]]]]])
 
@@ -50,11 +48,10 @@
 ;; ============================================================================
 
 (rf/reg-event :rf/server-init
-  {:doc       "Per-request server-side init. In a real app the cards' data
-               loads would dispatch :rf.http/managed fetches against three
-               microservices; here we synchronously seed three card values
-               of varying sizes so the demo's wire shape can be inspected
-               in a single browser request."
+  {:doc       "Per-request server-side init. A real app would dispatch
+               :rf.http/managed fetches here to load each card's data. This
+               demo seeds three card values synchronously so the whole wire
+               shape can be inspected in one browser request."
    :platforms #{:server}}
   (fn [_ _]
     {:db {:cards
@@ -81,12 +78,11 @@
    [:p.value "—"]])
 
 (rf/reg-view ^{:rf/id :dashboard/throwing-card} throwing-card []
-  ;; Demonstrate Spec 011 §Failure semantics — inline fallback. This view
-  ;; deliberately throws; the streaming runtime catches it inside
-  ;; render-continuation, emits :rf.ssr/suspense-boundary-failed on the
-  ;; trace bus, and ships the fallback HTML in the resolved-chunk
-  ;; position (with data-rf2-suspense-failed marker). The PAGE still
-  ;; loads — only the failing card stays in its fallback state.
+  ;; Failure isolation. This view deliberately throws. The streaming runtime
+  ;; catches it, emits a :rf.ssr/suspense-boundary-failed trace, and ships the
+  ;; fallback HTML in the chunk's place (marked data-rf2-suspense-failed). The
+  ;; page still loads — only this card stays on its fallback. See the
+  ;; [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary).
   (throw (ex-info "flaky third-party metric service" {})))
 
 (rf/reg-view ^{:rf/id :dashboard/root} root-view []
@@ -95,10 +91,10 @@
     [:h1 "Dashboard"]
     [:p "Streamed SSR demo — shell renders first, cards stream in."]]
    [:section.cards
-    ;; `:rf/suspense-boundary` marks a streamable subtree: the `:fallback`
+    ;; `:rf/suspense-boundary` marks a streamable subtree. The `:fallback`
     ;; ships inline in the shell now; the real child subtree streams in as
-    ;; its own chunk when it resolves. The `:id` pairs the incoming chunk
-    ;; with its placeholder on the client — you pick it, it must be unique.
+    ;; its own chunk once it resolves. The `:id` pairs the incoming chunk
+    ;; with its placeholder on the client — you pick it, and it must be unique.
     [:rf/suspense-boundary
      {:id :card.revenue :fallback [:dashboard/card-skeleton :revenue]}
      [:dashboard/card :revenue]]
@@ -108,9 +104,9 @@
     [:rf/suspense-boundary
      {:id :card.latency :fallback [:dashboard/card-skeleton :latency]}
      [:dashboard/card :latency]]
-    ;; The failure-path demonstrator card. Same wire shape; the
-    ;; chunk carries the fallback HTML with `data-rf2-suspense-failed="1"`
-    ;; and no hydrate-delta script.
+    ;; The failure-path card. Same wire shape; its chunk carries the
+    ;; fallback HTML with `data-rf2-suspense-failed="1"` and no hydrate-delta
+    ;; script.
     [:rf/suspense-boundary
      {:id :card.flaky
       :fallback [:dashboard/card-skeleton :flaky]}
@@ -135,12 +131,11 @@
      streaming adapter would emit in order."
      [_request]
      (let [fid (keyword "rf.frame" (str (gensym "")))
-           ;; Register the app schema AGAINST THIS per-request server frame
-           ;; BEFORE the `:initial-events` `:rf/server-init` step runs — the
-           ;; per-request frame is where the server-side `:cards` commit
-           ;; actually validates, so the schema must bind here. `reg-frame` runs
-           ;; the `:initial-events` cascade synchronously before returning, so the
-           ;; schema must be in place first; register under `fid`, then create.
+           ;; Register the app schema against this per-request frame BEFORE
+           ;; creating it. The server-side `:cards` commit validates in this
+           ;; frame, and `reg-frame` runs the `:initial-events` cascade (which
+           ;; fires `:rf/server-init`) synchronously, so the schema must be in
+           ;; place first.
            _   (rf/reg-app-schema [:cards] {:schema CardsSchema :frame fid})
            _   (rf/reg-frame fid {:doc "ssr-streaming-example frame"
                                   :platform :server
@@ -165,31 +160,29 @@
                       :failed? failed?}))
                  continuations)
            render-hash (rf/with-frame fid (ssr/render-tree-hash hiccup))
-           ;; The final payload is the canonical full app-db — the correctness
-           ;; lock that the per-card deltas above were only a speed prop for. If
-           ;; a speculative delta ever disagreed with this, this wins.
-           ;; Hydration-payload policy is explicit + fail-closed, carried
-           ;; by the single `:payload` opt. This example's app-db is
-           ;; structurally safe to expose end-to-end (every key the
-           ;; dashboard handlers populate is intended for the client), so
-           ;; we opt in with `:payload :rf.ssr.payload/whole-app-db`. A
-           ;; real production deployment would normally pass `:payload`
-           ;; with an explicit vector allowlist of top-level app-db keys.
+           ;; The final payload is the canonical full app-db. The per-card
+           ;; deltas above are a speed prop; this is the correctness lock. If
+           ;; a delta ever disagrees with the payload, the payload wins.
+           ;;
+           ;; The `:payload` opt decides what crosses the wire, and it is
+           ;; fail-closed. This demo's app-db is safe to expose whole (every
+           ;; key the dashboard populates is meant for the client), so we opt
+           ;; in with `:rf.ssr.payload/whole-app-db`. Production normally
+           ;; passes an explicit allowlist vector of top-level app-db keys.
            final-payload (rf/with-frame fid
                            (ssr/streaming-build-final-payload
                              fid render-hash
                              {:version 1
                               :payload :rf.ssr.payload/whole-app-db}))
-           ;; Drop the payload's `:rf/frame-id`. `streaming-build-final-payload`
-           ;; stamps this per-request server frame (`fid`), but the client
-           ;; hydrates a fixed app-frame (`app-frame` → `:rf/default`, below).
-           ;; `ssr/hydrate!` checks a present `:rf/frame-id` against the client's
-           ;; explicit `:frame` and raises `:rf.error/hydration-frame-id-mismatch`
-           ;; on disagreement (Spec 011 §The hydration payload); the per-request
-           ;; gensym would always disagree. With no frame-id on the wire the
-           ;; client's explicit target stands — matching the static `index.html`
-           ;; next to this file. A deployment that wants a frame-id on the wire
-           ;; stamps a stable id both sides agree on, not a per-request gensym.
+           ;; Drop the payload's `:rf/frame-id`. The builder stamps this
+           ;; per-request frame (`fid`), but the client hydrates a fixed
+           ;; `app-frame` (below). `ssr/hydrate!` checks a present `:rf/frame-id`
+           ;; against the client's explicit `:frame` and fails closed on
+           ;; disagreement, which a per-request gensym always would. With no
+           ;; frame-id on the wire the client's explicit target stands. (A
+           ;; deployment that wants one on the wire stamps a stable id both
+           ;; sides share, not a gensym.) See the
+           ;; [SSR guide — hydrate, then verify](../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
            final-payload (dissoc final-payload :rf/frame-id)
            _ (rf/destroy-frame! fid)]
        {:shell shell-html
@@ -201,100 +194,93 @@
 ;; CLIENT ENTRY POINT (.cljs branch — browser hydration)
 ;; ============================================================================
 ;;
-;; Streaming hydration shape (per Spec 011 §Streaming SSR — Client-side
-;; hydration semantics):
+;; The streaming hydration sequence on the client:
 ;;
-;;  1. First chunk lands — the browser receives the shell, whose slow
+;;  1. The first chunk lands. The browser receives the shell, whose slow
 ;;     regions are inline `<template data-rf2-suspense-fallback>`
-;;     placeholders. A `<template>`'s content is INERT by the HTML spec
-;;     (its `.content` is a detached DocumentFragment, never painted), so
-;;     the skeletons do NOT paint on the raw bytes; they paint when
+;;     placeholders. A `<template>`'s content is inert by the HTML spec (its
+;;     `.content` is a detached DocumentFragment, never painted), so the
+;;     skeletons do NOT paint on the raw bytes. They paint when
 ;;     `streaming-install!` (step 2) materialises each inert `<template>`
-;;     into a live, visible `<rf-suspense data-rf2-suspense-mount>` mount.
-;;     The `<script src="main.js">` reference at the end of `<body>`
-;;     begins downloading.
-;;  2. Resolved-card chunks stream in via Transfer-Encoding: chunked.
-;;     Each one is `<template data-rf2-suspense-resolved=…>…</template>`
-;;     plus `<script data-rf2-suspense-hydrate=…>…</script>`. The
-;;     client-side streaming runtime (`ssr/streaming-install!`, per
-;;     Spec 011 §Streaming SSR — client-side hydration semantics) first
-;;     materialises the inert fallback `<template>`s into live
-;;     `<rf-suspense>` mounts (the skeletons now paint), then swaps each
-;;     mount's content for the resolved subtree in-place and merges the
-;;     per-subtree delta into the client app-db AS each chunk arrives —
-;;     progressive hydration, before the final payload. `run` installs it
-;;     below before the first render so it catches both chunks that
-;;     already streamed in and any still arriving.
-;;  3. The final `<script id="__rf_payload">` is the canonical full
-;;     payload; `run` dispatches `:rf/hydrate` against it (via
-;;     `ssr/hydrate!`), which runs :replace-frame-state semantics (the
-;;     payload's `:rf/app-db` + serialisable runtime-db slice replace the
-;;     whole client frame-state in one step) — the
-;;     per-card deltas were progressive-render speed props; the final
-;;     payload is the correctness lock. The streaming runtime
+;;     into a live `<rf-suspense data-rf2-suspense-mount>` mount. The
+;;     `<script src="main.js">` at the end of `<body>` begins downloading.
+;;  2. Resolved-card chunks stream in (Transfer-Encoding: chunked). Each is
+;;     a `<template data-rf2-suspense-resolved=…>…</template>` plus a
+;;     `<script data-rf2-suspense-hydrate=…>…</script>`. The client-side
+;;     streaming runtime (`ssr/streaming-install!`) first materialises the
+;;     inert fallback `<template>`s into live `<rf-suspense>` mounts (the
+;;     skeletons now paint), then swaps each mount's content for the resolved
+;;     subtree in place and merges that subtree's delta into the client
+;;     app-db as the chunk arrives. `run` installs it before the first render
+;;     so it catches chunks already streamed in and any still arriving.
+;;  3. The final `<script id="__rf_payload">` is the canonical full payload.
+;;     `run` dispatches `:rf/hydrate` against it (via `ssr/hydrate!`), which
+;;     replaces the whole client frame-state in one step — the payload's
+;;     app-db plus its serialisable runtime-db slice. The streaming runtime
 ;;     auto-disconnects once it sees `__rf_payload`, so no late delta can
-;;     race the canonical replace.
+;;     race the canonical replace. The per-card deltas were a speed prop;
+;;     this final replace is the correctness lock.
 ;;
-;; This worked example boots from a static `index.html` that stands in
-;; for the streaming server (it ships the final resolved state + the
-;; final payload pre-baked, so the browser runs without a Clojure server
-;; in the loop). Because the streaming runtime is additive, a page whose
-;; chunks already resolved hydrates exactly the same: the install sweep
-;; finds no un-swapped fallback, sees `__rf_payload` already present, and
-;; goes straight to the `ssr/hydrate!` reconciliation. The runtime's
-;; progressive path (chunk-arrival swap + delta merge before the final
-;; payload) is exercised end-to-end by the browser acceptance test
-;; `re-frame.ssr.streaming-client-dom-cljs-test`.
+;; See the [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)
+;; and [hydrate, then verify](../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
+;;
+;; This example boots from a static `index.html` that stands in for the
+;; streaming server — it ships the final resolved state and payload
+;; pre-baked, so the browser runs with no Clojure server in the loop.
+;; Because the streaming runtime is additive, a page whose chunks already
+;; resolved hydrates exactly the same: the install sweep finds no un-swapped
+;; fallback, sees `__rf_payload` already present, and goes straight to the
+;; `ssr/hydrate!` reconciliation. The progressive path (chunk-arrival swap +
+;; delta merge before the final payload) is exercised end-to-end by the
+;; browser acceptance test `re-frame.ssr.streaming-client-dom-cljs-test`.
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. ns-load must produce no DOM side effects, so co-required example
+;; namespaces don't race `create-root` onto the shared `#app`. (See the
+;; mount-isolation convention in examples/TESTING.md.)
 #?(:cljs (defonce react-root (atom nil)))
 
 ;; The client app-frame id. The app carries it explicitly — the same id
-;; flows to the streaming `install!`, `ssr/hydrate!`, AND the root
-;; `frame-provider` (EP-0002). This example uses `:rf/default`. It must be a
-;; `:client`-platform frame so the `:rf.ssr/check-*` compatibility-check fxs
-;; the `:rf/hydrate` handler dispatches actually fire (Spec 011 §The
-;; :rf/hydrate event). Both the static `index.html` payload and the dynamic
-;; `handle-request` final-payload carry no `:rf/frame-id`: the server renders
-;; under a per-request gensym frame, the client hydrates this fixed frame, so
-;; an absent frame-id is the right shape — the explicit `:frame` is the target.
+;; flows to the streaming `install!`, `ssr/hydrate!`, and the root
+;; `frame-provider`. This example uses `:rf/default`. It must be a
+;; `:client`-platform frame so the `:rf.ssr/check-*` compatibility checks the
+;; `:rf/hydrate` handler dispatches actually fire. Neither the static
+;; `index.html` payload nor the `handle-request` payload carries a
+;; `:rf/frame-id`: the server renders under a per-request gensym frame and the
+;; client hydrates this fixed frame, so an absent frame-id is the right shape —
+;; the explicit `:frame` is the target. See
+;; [frames](../../../docs/guide/glossary.md#frame-identity-is-carried-not-found).
 #?(:cljs (def app-frame :rf/default))
 
 #?(:cljs
    (defn run []
-     ;; `init!` installs the Reagent adapter. The app then creates its
-     ;; frame explicitly below (init! does not create one — EP-0002).
+     ;; `init!` installs the Reagent adapter. It creates no frame — the app
+     ;; creates its own explicitly below.
      (rf/init! reagent-adapter/adapter)
-     ;; Establish the carried client app-frame BEFORE installing the
-     ;; streaming runtime / hydrating into it. `reg-frame` is a surgical
-     ;; no-op on re-registration (hot-reload Just Works). `:platform :client`
-     ;; makes the hydrate compatibility-check fxs fire.
+     ;; Establish the carried client app-frame BEFORE installing the streaming
+     ;; runtime and hydrating into it. `reg-frame` is a no-op on
+     ;; re-registration, so hot-reload just works. `:platform :client` makes
+     ;; the hydrate compatibility checks fire.
      (rf/reg-frame app-frame {:doc      "ssr-streaming-example client app-frame"
                               :platform :client})
-     ;; Register the app schema AGAINST THE FIXED CLIENT FRAME so
-     ;; the progressively-merged + finally-hydrated `:cards` commits validate on
-     ;; the client too — the symmetric counterpart of the per-request
-     ;; registration in `handle-request`. `{:frame app-frame}` is the explicit
-     ;; override; re-registration is a no-op-safe on hot-reload.
+     ;; Register the app schema against this client frame so the `:cards`
+     ;; commits — both the streamed deltas and the final hydrate — validate on
+     ;; the client too. The symmetric counterpart of the registration in
+     ;; `handle-request`.
      (rf/reg-app-schema [:cards] {:schema CardsSchema :frame app-frame})
-     ;; Install the client-side streaming runtime BEFORE the first render
-     ;; so it catches resolved-subtree chunks as they arrive (and sweeps
-     ;; any already present). It swaps fallbacks + merges per-subtree
-     ;; deltas progressively into the carried frame, then disconnects on
-     ;; `__rf_payload`.
+     ;; Install the client-side streaming runtime BEFORE the first render so it
+     ;; catches resolved-subtree chunks as they arrive (and sweeps any already
+     ;; present). It swaps fallbacks and merges per-subtree deltas into the
+     ;; carried frame, then disconnects on `__rf_payload`.
      (ssr/streaming-install! {:frame app-frame})
-     ;; Reconcile against the canonical payload: read `__rf_payload` +
-     ;; dispatch `:rf/hydrate` (:replace-frame-state) into the EXPLICIT `:frame`.
-     ;; The deltas were speculative; this is the correctness lock.
-     ;; (`:render-tree-fn` is omitted — the static demo shell carries a
-     ;; placeholder render-hash, so hash-mismatch verification would always
-     ;; warn here; a real streaming server stamps the genuine hash and a host
-     ;; then passes `:render-tree-fn` to enable mismatch detection.) Hydrate
-     ;; BEFORE first render so the initial render runs against the seeded
-     ;; app-db.
+     ;; Reconcile against the canonical payload: read `__rf_payload` and
+     ;; dispatch `:rf/hydrate` into the explicit `:frame`. This is the
+     ;; correctness lock the streamed deltas defer to. Hydrate BEFORE the first
+     ;; render so the initial render runs against the seeded app-db.
+     ;; (`:render-tree-fn` is omitted because this static demo shell carries a
+     ;; placeholder render-hash, so mismatch verification would always warn. A
+     ;; real streaming server stamps the genuine hash, and the host passes
+     ;; `:render-tree-fn` to turn mismatch detection on.)
      (ssr/hydrate! {:frame app-frame})
      (when (exists? js/document)
        (when-not @react-root
@@ -305,9 +291,7 @@
                    [rf/frame-provider {:frame app-frame}
                     [(rf/view :dashboard/root)]]))))
 
-;; The JVM-runnable headless test that exercises the server stream
-;; (shell → per-card resolved chunks → final payload) lives in
-;; re-frame.examples-test (implementation/core/test/), folded inline as
-;; the `ssr-streaming-example-runs-end-to-end` deftest,
-;; keeping this example source pure demonstrative code (the example tree
-;; is test-free). It runs on the JVM.
+;; The JVM headless test that exercises the server stream (shell → per-card
+;; resolved chunks → final payload) lives in re-frame.examples-test
+;; (implementation/core/test/), as the `ssr-streaming-example-runs-end-to-end`
+;; deftest. The example tree itself stays test-free.

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -1,75 +1,51 @@
 (ns state-machine-walkthrough.core
-  "Runnable companion to docs/machines/concepts.md — the machines chapter as code.
+  "The machines guide's login flow, as code.
 
-  The chapter's login flow, laid out so you can read the transition table
-  here in the order the chapter introduces it. The one idea this file makes
-  tangible: a machine is a PURE transition table, so a transition is a pure
-  function call — table in, snapshot in, event in; result out. That is what
-  lets the chapter's four scenarios run headless (see the §SUBSCRIPTIONS note
-  at the bottom for where those tests live).
+  Read alongside docs/machines/concepts.md — the transition table below is
+  laid out in the order that page introduces it.
 
-  Why .cljc: the chapter promises 'runs in microseconds on the JVM, no
-  browser, no network.' The same source compiles under shadow-cljs for the
-  CLJS surface; the :clj branch is what the JVM test (require ...)s. The HTTP
-  side never hits the wire — it is redirected via :fx-overrides to this
-  example's `:auth.login/canned-success` / `:auth.login/canned-failure`
-  wrapper fxs below, which delegate to the framework-shipped
-  `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure`
-  stubs (Spec 014 §Testing).
+  The one idea this file makes tangible: a machine is a PURE transition
+  table, so a transition is a pure function call — table in, snapshot in,
+  event in; result out. That is what lets the four scenarios run headless,
+  on the JVM, in microseconds. Those tests live in the framework test tree
+  (see the SUBSCRIPTIONS note at the bottom).
 
-  Read alongside docs/machines/concepts.md."
+  This is a .cljc so the same source compiles under shadow-cljs for the
+  browser demo and loads on the JVM for the headless tests. The login HTTP
+  request never hits the wire: :fx-overrides redirects it to the canned
+  stubs defined below."
   (:require [re-frame.core :as rf]
-            ;; The Spec 005 state-machine ns lives in the
-            ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so `rf/reg-machine` and the
-            ;; framework `:rf/machine` / `:rf/machine-has-tag?` subs resolve.
-            ;; (The pure `machine-transition` fn the headless tests call is
-            ;; owned by re-frame.machines, not the rf/ facade — by design.)
+            ;; Loading this ns makes `rf/reg-machine` and the `:rf/machine`
+            ;; / `:rf/machine-has-tag?` subs resolve, and the pure
+            ;; `machine-transition` fn the headless tests call. See
+            ;; docs/machines/glossary.md#machine.
             [re-frame.machines]
-            ;; Managed-HTTP ships in day8/re-frame2-http.
-            ;; The login flow's `:issue-request` action dispatches
-            ;; `:rf.http/managed` (overridden in tests via `:fx-overrides`
-            ;; to the framework-shipped canned stubs). Loading the ns here
-            ;; registers the `:rf.http/managed` fx family so the override
-            ;; mechanism can target a real fx-id.
+            ;; Registers the `:rf.http/managed` fx the login flow's
+            ;; `:issue-request` action dispatches. Tests override it via
+            ;; :fx-overrides; see docs/guide/glossary.md#effect.
             [re-frame.http.managed]
-            ;; :fx-overrides into :rf.http/managed-canned-* relies on
-            ;; those fx ids being registered. Registration lives in
-            ;; re-frame.http.test-support.
+            ;; Registers the canned `:rf.http/managed-canned-*` fxs that the
+            ;; stubs below redirect to.
             [re-frame.http.test-support]
-            ;; The canned-failure / canned-success stubs below delegate
-            ;; to the framework-shipped `:rf.http/managed-canned-*` fxs
-            ;; via the registrar so the example demo (views.cljs) and
-            ;; the headless tests (the `state-machine-walkthrough-runs-headless`
-            ;; deftest in implementation/core/test/re_frame/examples_test.clj)
-            ;; can share one registration point.
+            ;; The stubs below look up the canned fxs through the registrar.
             [re-frame.registrar :as registrar]))
 
 ;; ============================================================================
-;; THE TRANSITION TABLE — chapter §The same flow as a transition table
+;; THE TRANSITION TABLE — guide §The same flow as a transition table
 ;; ============================================================================
 ;;
-;; Pure data. `:guards` and `:actions` live right here in the spec, and the
-;; references inside `:states` resolve against this map. (There is no global
-;; guard/action registry to look them up in.) To reuse a guard or action across
-;; machines, define a fn and name it locally in each machine's :guards / :actions.
+;; Pure data. `:guards` and `:actions` live right here in the table, and the
+;; references inside `:states` resolve against this map — there is no global
+;; guard/action registry. To reuse a guard or action across machines, define a
+;; fn and name it locally in each machine's :guards / :actions.
 ;;
-;; This is a near-twin of the login machine in the `login` example
-;; (examples/reagent/login/core.cljs) — same states, guards, actions, and
-;; transitions, and both tag `:locked-out` with `:auth/locked` and render a
-;; dedicated lockout panel that branches on that tag (here the root-view in
-;; views.cljs; there the login-banner). The two register the id
-;; `:auth.login/flow` independently — a machine id is a per-frame registry key,
-;; not a global handle, and the two never co-load (this walkthrough runs
-;; JVM-headless with `remove-ns` between runs; login builds standalone), so the
-;; shared name is parallel, not a collision.
-;; Where the two examples diverge is what they teach AROUND the machine:
-;; `login` is the full feature scaffold (Malli event/`:data` schemas, a
-;; `:sensitive?` request flag, a password-routing demo stub) wired into a live
-;; Reagent feature; this walkthrough strips that down to drive the machine
-;; HEADLESSLY, foregrounding the pure machine-transition + drain testing story
-;; from docs/machines/concepts.md. Read `login` first for the UI wiring; read
-;; this for the testing progression.
+;; The `login` example (examples/reagent/login/core.cljs) builds a near-twin of
+;; this machine — same states, guards, actions, transitions. The two examples
+;; differ in what they teach AROUND the machine. `login` is the full feature
+;; scaffold (Malli schemas, a sensitive-request flag, a password-routing stub)
+;; wired into a live Reagent feature. This walkthrough strips that down to drive
+;; the machine HEADLESSLY, foregrounding the pure-transition testing story. Read
+;; `login` for the UI wiring; read this for the testing progression.
 
 (def login-flow
   {:initial :idle
@@ -77,9 +53,8 @@
 
    :guards
    {:under-retry-limit
-    ;; 2-arity is canonical: (fn [{data :data event :event}] ...). `data` is the
-    ;; snapshot's :data slot directly — pulling it from a snapshot
-    ;; wrapper is the runtime's job.
+    ;; A guard takes one map: {:data ... :event ...}. `data` is the snapshot's
+    ;; :data slot directly. See docs/machines/glossary.md#guard.
     (fn [{data :data}]
       (< (:attempts data) 3))}
 
@@ -88,11 +63,10 @@
     (fn [_] {:data {:error nil}})
 
     :issue-request
-    ;; Returns effects, not side-effects. The `:rf.http/managed` fx
-    ;; (Spec 014) issues the request; the framework dispatches the
-    ;; explicit `:on-success` / `:on-failure` events with the reply
-    ;; payload appended as the last arg, so the inner sub-event lands
-    ;; back in this machine via :auth.login/flow's machine-id routing.
+    ;; An action returns effects, not side-effects (docs/guide/glossary.md#effect).
+    ;; The `:rf.http/managed` fx issues the request, then dispatches the
+    ;; `:on-success` / `:on-failure` events with the reply appended as the
+    ;; last arg — routing the result back into this machine.
     (fn [{[_ creds] :event}]
       {:fx [[:rf.http/managed
              {:request    {:method :post
@@ -124,9 +98,9 @@
                               :action :clear-error}}}
 
     :submitting
-    ;; :auth/busy tag — views query (rf/machine-has-tag? :auth.login/flow
-    ;; :auth/busy) to disable inputs and re-label the submit button
-    ;; while the request is in flight (chapter §State tags).
+    ;; :auth/busy tag — the view asks (rf/machine-has-tag? :auth.login/flow
+    ;; :auth/busy) to disable inputs and re-label the submit button while the
+    ;; request is in flight. See docs/machines/glossary.md#state-tag.
     {:tags  #{:auth/busy}
      :entry :issue-request
      :on    {:auth.login/success {:target :authed
@@ -142,43 +116,37 @@
           :auth.login/submit  {:target :submitting}}}
 
     :authed
-    ;; :auth/authenticated tag — views query
-    ;; (rf/machine-has-tag? :auth.login/flow :auth/authenticated) once the
-    ;; flow reaches this terminal state.
+    ;; :auth/authenticated tag — set once the flow reaches this terminal state.
     {:tags #{:auth/authenticated}
      :meta {:terminal? true}}
 
     :locked-out
-    ;; :auth/locked tag — root-view swaps the form for the locked-out
-    ;; panel when (rf/machine-has-tag? :auth.login/flow :auth/locked) is true.
+    ;; :auth/locked tag — root-view swaps the form for the locked-out panel
+    ;; when this tag is set.
     {:tags #{:auth/locked}
      :meta {:terminal? true}}}})
 
 ;; ============================================================================
-;; FX — chapter §Composing with async effects
+;; FX — guide §Composing with async effects
 ;; ============================================================================
 ;;
-;; The `:auth.session/store` fx is a stub for the example: it shows the
-;; shape, not real localStorage. The headless tests exercise the
-;; managed-HTTP path via the framework-shipped canned-success /
-;; canned-failure stubs (Spec 014 §Testing), routed in via the
-;; `:fx-overrides` seam at frame creation.
+;; `:auth.session/store` is a stub: it shows the shape, not real localStorage.
+;; The login HTTP request runs through the canned-success / canned-failure
+;; stubs below, swapped in at frame creation via :fx-overrides.
 
 (rf/reg-fx :auth.session/store
   {:doc "Stub: a real implementation would write localStorage."}
   (fn [_m _args] nil))
 
-;; Per Spec 014 §Testing, the framework ships `:rf.http/managed-canned-success`
-;; and `:rf.http/managed-canned-failure` fxs that synthesise the canonical reply
-;; shape. The wrappers below pin the example's specific payloads — both the
-;; browser demo (views.cljs installs the canned-failure override on the
-;; default frame) and the headless tests (the framework JVM deftest reads them
-;; via `:fx-overrides`) consume them, sharing one registration point.
+;; The framework ships `:rf.http/managed-canned-success` and
+;; `:rf.http/managed-canned-failure` fxs that synthesise the canonical reply
+;; shape. The wrappers below pin this example's specific payloads. Both the
+;; browser demo and the headless tests redirect `:rf.http/managed` to them.
 
 (rf/reg-fx :auth.login/canned-success
   {:doc "Example stub: every `:rf.http/managed` call resolves :success with a
          canned user/token payload. Delegates to the framework-shipped
-         `:rf.http/managed-canned-success` per Spec 014 §Testing."}
+         `:rf.http/managed-canned-success`."}
   (fn [frame-ctx args-map]
     (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
       (stub frame-ctx (assoc args-map :value {:user  {:id "test-user"}
@@ -186,8 +154,7 @@
 
 (rf/reg-fx :auth.login/canned-failure
   {:doc "Example stub: every `:rf.http/managed` call resolves :failure.
-         Delegates to the framework-shipped `:rf.http/managed-canned-failure`
-         per Spec 014 §Testing."}
+         Delegates to the framework-shipped `:rf.http/managed-canned-failure`."}
   (fn [frame-ctx args-map]
     (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
       (stub frame-ctx (assoc args-map
@@ -195,39 +162,36 @@
                              :tags {:message "bad creds" :status 401})))))
 
 ;; ============================================================================
-;; REGISTRATION — chapter §Registering and running it
+;; REGISTRATION — guide §Registering and running it
 ;; ============================================================================
 ;;
-;; One line. A machine IS an event handler: `reg-machine` is sugar over
-;; `reg-event` whose body interprets the table. The longer form
-;; `(reg-event machine-id (make-machine-handler m))` is what reg-machine
-;; wraps, and is the form to reach for when you need registration metadata
-;; (`:doc`, `:interceptors`, ...).
+;; One line. A machine IS an event handler: `reg-machine` is sugar over a
+;; `reg-event` whose body interprets the table. Reach for the longer form
+;; `(reg-event machine-id (make-machine-handler m))` when you need registration
+;; metadata (`:doc`, `:interceptors`, ...).
 
 (rf/reg-machine :auth.login/flow login-flow)
 
 ;; ============================================================================
-;; FORM DRAFT SLICE — Pattern-Forms §Variations (machine + slice)
+;; FORM DRAFT SLICE — docs/guide/how-to/build-a-form.md
 ;; ============================================================================
 ;;
 ;; The machine owns submit/auth STATUS; the slice owns the DRAFT. Form drafts
 ;; are application state, so the email/password the user types lives in app-db
-;; — projected via a sub, mutated via an event — never in a view-local atom.
-;; The login form's inputs are CONTROLLED off `:auth.login/draft`; `:on-change`
+;; — read via a sub, written via an event — never in a view-local atom. The
+;; login form's inputs are CONTROLLED off `:auth.login/draft`; `:on-change`
 ;; dispatches `:auth.login/edit-field`, and submit reads the draft back out of
 ;; the slice rather than out of the view.
 ;;
-;; This walkthrough strips the slice to its single teaching point — the draft —
-;; rather than the full 7-key Pattern-Forms slice (touched / errors /
-;; submit-attempted? / …): the chapter foregrounds the MACHINE, so the slice
-;; carries only what must leave the view. The fuller slice shape lives in
-;; examples/reagent/realworld/auth.cljs.
+;; This slice carries just its single teaching point — the draft. The fuller
+;; seven-key form slice (touched / errors / submit-attempted? / …) is built up
+;; in docs/guide/how-to/build-a-form.md and in examples/reagent/realworld/auth.cljs.
 
 (def login-form-defaults {:email "" :password ""})
 
 (rf/reg-event :auth.login/initialise-form
-  {:doc "Seed the login draft to empty defaults. The machine spawns itself on
-         its first event; this only owns the draft slice."}
+  {:doc "Seed the login draft to empty defaults. This owns only the draft slice;
+         the machine spawns itself on its first event."}
   (fn [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form :draft] login-form-defaults)}))
 
@@ -239,17 +203,15 @@
     {:db (assoc-in db [:auth :login-form :draft field] value)}))
 
 ;; ============================================================================
-;; SUBSCRIPTIONS — chapter §Registering and running it
+;; SUBSCRIPTIONS — guide §Registering and running it
 ;; ============================================================================
 
-;; The machine snapshot lives in runtime-db at
-;; [:rf.runtime/machines :snapshots :auth.login/flow] (per Spec 005).
-;; The framework ships `:rf/machine` as the canonical entry point onto that
-;; path. The two named subs below chain off it to project out the handy pieces:
-;; current state and last error. For the "is it busy / locked?" questions, the
-;; view asks the machine for a tag directly with `rf/machine-has-tag?`
-;; (chapter §State tags) — reading the `:tags` set keeps the view off
-;; individual state keywords.
+;; The framework ships `:rf/machine` as the canonical sub onto the machine's
+;; snapshot. The two named subs below chain off it to pull out the handy
+;; pieces: current state and last error. For the "is it busy / locked?"
+;; questions, the view asks the machine for a tag directly with
+;; `rf/machine-has-tag?` — reading the `:tags` set keeps the view off
+;; individual state keywords (docs/machines/glossary.md#state-tag).
 
 (rf/reg-sub :auth.login/draft
   {:doc "The login form draft — what the user has currently typed. The view's
@@ -265,10 +227,10 @@
   :<- [:rf/machine :auth.login/flow]
   (fn [machine _] (get-in machine [:data :error])))
 
-;; The payoff — see the chapter's §Testing. Because the table is pure data
-;; and `machines/machine-transition` is a pure fn over (table, snapshot,
-;; event), the four scenarios (pure happy-path, pure lockout, drain
-;; happy-path, drain retry-then-lockout) need no frame and no browser. They
-;; live in re-frame.examples-test (implementation/core/test/) as the
-;; `state-machine-walkthrough-runs-headless` deftest — folded there so this
-;; example source stays test-free. JVM, microseconds.
+;; The payoff. Because the table is pure data and `machines/machine-transition`
+;; is a pure fn over (table, snapshot, event), the four scenarios (pure
+;; happy-path, pure lockout, drain happy-path, drain retry-then-lockout) need no
+;; frame and no browser — they run on the JVM in microseconds. They live in the
+;; framework test tree as the `state-machine-walkthrough-runs-headless` deftest,
+;; so this example source stays test-free.
+;; See docs/machines/concepts.md#testing-transitions-are-pure-function-calls.

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -1,20 +1,14 @@
 (ns state-machine-walkthrough.views
   "Browser entry-point for the state-machines walkthrough.
 
-  The pure machine, fxs and subs live in `core.cljc` alongside
-  docs/machines/concepts.md; the headless tests live in the framework
-  test tree (the `state-machine-walkthrough-runs-headless` deftest in
-  `implementation/core/test/re_frame/examples_test.clj`). This namespace
-  is the CLJS-only browser layer: views + Reagent mount + a `run` fn that
-  installs a per-frame `:fx-overrides` redirecting `:rf.http/managed`
-  to the canned-failure stub registered in `core.cljc`.
+  The pure machine, fxs and subs live in `core.cljc`. This namespace is the
+  CLJS-only browser layer: views + Reagent mount + a `run` fn that redirects
+  `:rf.http/managed` to the canned-failure stub via per-frame :fx-overrides.
 
-  Why canned-failure: the chapter's headline scenario is the lockout
-  flow — three failed attempts that cycle :submitting → :error-shown
-  → :idle, then a fourth submit that fails the `:under-retry-limit`
-  guard and lands at `:locked-out`. That path is exactly what the
-  `state-machine-walkthrough-runs-headless` deftest walks through,
-  so the stub needs to fail every request."
+  The demo runs the lockout scenario: three failed attempts cycle
+  :submitting -> :error-shown -> :idle, then a fourth submit fails the
+  `:under-retry-limit` guard and lands at :locked-out. So the stub fails
+  every request."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -35,11 +29,11 @@
                   :auth.login/submit.
 
                   The machine owns submit/auth STATUS; the slice owns the DRAFT
-                  (Pattern-Forms §Variations: machine + slice). View-side
-                  discriminators ask the machine for a tag via
-                  `rf/machine-has-tag?` (chapter §State tags), reading its
-                  runtime-projected `:tags` set rather than the current state
-                  keyword — so adding a new busy-ish state changes no view."}
+                  (docs/guide/how-to/build-a-form.md). To branch on status the
+                  view asks the machine for a tag via `rf/machine-has-tag?`,
+                  reading its `:tags` set rather than the current state keyword —
+                  so adding a new busy state changes no view
+                  (docs/machines/glossary.md#state-tag)."}
           login-form []
   (let [busy?   @(rf/machine-has-tag? :auth.login/flow :auth/busy)
         locked? @(rf/machine-has-tag? :auth.login/flow :auth/locked)
@@ -107,25 +101,23 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, never at
+;; ns-load. ns-load must produce no DOM side effects, so co-required examples
+;; don't race `create-root` onto the shared `#app`. See examples/TESTING.md
+;; "Convention: defer DOM mount to `run`".
 (defonce react-root (atom nil))
 
 (defn run []
   ;; Install the Reagent adapter — pass its spec map straight to init!.
   (rf/init! reagent-adapter/adapter)
-  ;; `frame-provider {:id …}` is the one spot that creates, configures and
-  ;; seeds the app frame. On first mount it creates the `:rf/default` frame,
-  ;; applies the config, and runs `:initial-events` once. On hot reload it
-  ;; reuses that frame and skips re-seeding, so your typed-in draft survives.
-  ;; The `reg-view`-injected `dispatch`/`subscribe` (and the login machine
-  ;; reads) resolve to this frame.
+  ;; `frame-provider {:id …}` creates, configures and seeds the app frame. On
+  ;; first mount it creates the `:rf/default` frame, applies the config, and
+  ;; runs `:initial-events` once. On hot reload it reuses that frame and skips
+  ;; re-seeding, so your typed-in draft survives. The `dispatch`/`subscribe`
+  ;; that `reg-view` injects resolve to this frame.
   ;;
   ;; `:fx-overrides` swaps `:rf.http/managed` for the canned-failure stub, so
-  ;; every login request fails — the chapter's lockout scenario needs three
-  ;; failures in a row.
+  ;; every login request fails — the lockout scenario needs three failures.
   ;;
   ;; The login machine spawns itself on its first event. The form DRAFT slice
   ;; does not, so `:initial-events` seeds it before first render: the controlled

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -1,12 +1,12 @@
 (ns todomvc.core
-  "Entry point: install the adapter, mount the view, ensure-and-seed the frame.
+  "Entry point: install the adapter, mount the view, create and seed the frame.
 
-  Demonstrates the boot wiring the other files lean on — `init!` installs the
-  Reagent adapter; the render root's `frame-provider {:id …}` creates the app
-  frame on first mount, marks it `:url-bound?` so it owns the address bar, and
-  seeds it once via `:initial-events`; and a hash → route adapter turns a
-  `#/active` URL change into a `:rf.route/handle-url-change` event. \"The URL is
-  an input; navigation is an event.\""
+  This is the boot wiring the other files lean on. `init!` installs the Reagent
+  adapter. The render root is a `frame-provider {:id …}`: on first mount it
+  creates the app frame, marks it `:url-bound?` so it owns the address bar, and
+  seeds it once via `:initial-events`. A small hash listener turns a `#/active`
+  URL change into a `:rf.route/handle-url-change` event. The URL is an input;
+  navigation is an event."
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
@@ -16,18 +16,16 @@
             [todomvc.subs]
             [todomvc.views :as views]))
 
-;; ---- hash → Spec 012 path adapter -----------------------------------------
+;; ---- hash -> path adapter -------------------------------------------------
 ;;
-;; TodoMVC uses hash-based URLs (#/, #/active, #/completed); the Spec 012
-;; runtime routes path-strings. This tiny host-adapter strips the '#' and
-;; dispatches :rf.route/handle-url-change so the registered routes in
-;; events.cljs match cleanly. Per Spec 012 §URL changes are events, the
-;; runtime updates the runtime-db [:rf.runtime/routing :current] slice from
-;; there.
+;; TodoMVC uses hash-based URLs (#/, #/active, #/completed). The router matches
+;; path-strings, so this little adapter strips the '#' and dispatches
+;; :rf.route/handle-url-change. The registered routes in events.cljs then match
+;; the result. See docs/routing/concepts.md#move-2-navigation-is-an-event.
 
 (defn- hash->path
-  "Convert window.location.hash (e.g. \"#/active\", \"#/completed\") to a
-  Spec 012 path. An empty hash maps to \"/\"."
+  "Convert window.location.hash (e.g. \"#/active\", \"#/completed\") to a route
+  path. An empty hash maps to \"/\"."
   [hash]
   (let [stripped (-> hash
                      (str/replace #"^#" "")
@@ -37,33 +35,32 @@
 (defn- current-path []
   (hash->path (.. js/window -location -hash)))
 
-;; The id of the app frame. The render root's `frame-provider {:id app-frame …}`
-;; creates it with `:url-bound? true`, which is the explicit declaration that
-;; this frame owns the URL (Spec 012 §Multi-frame routing).
+;; The id of the app frame. The render root creates it with `:url-bound? true`,
+;; which declares that this frame owns the URL.
+;; See docs/routing/glossary.md (url-bound?).
 (def app-frame :rf/default)
 
-;; A named handler keeps the listener install idempotent: `boot!` removes then
-;; re-adds the same Var, so a repeated `run` (e.g. a co-required test host) or a
-;; reload that redefines the Var never stacks duplicate `hashchange` listeners.
+;; Deliver each URL change to the frame that owns the URL. The dispatch names
+;; `app-frame` explicitly via `{:frame app-frame}`; a frameless `(rf/dispatch …)`
+;; has no frame to resolve against.
 ;;
-;; The dispatch targets `app-frame` explicitly via `{:frame app-frame}` — that is
-;; the frame that owns the URL. (A frameless `(rf/dispatch …)` would raise
-;; `:rf.error/no-frame-context`.) This example is hash-based (`#/active`), so it
-;; uses its own `hashchange` listener instead of the framework's popstate-driven
-;; `rf/install-history-listener!`; both deliver the URL change to the owner frame
-;; the same way (Spec 012 §popstate drives the URL-owner frame).
+;; Using a named Var keeps the listener install idempotent: `boot!` removes then
+;; re-adds the same Var, so a repeated `run` or a reload never stacks duplicate
+;; `hashchange` listeners. A hash-based app listens on `hashchange`; a path-based
+;; app would call `rf/install-history-listener!` instead, and the URL change
+;; reaches the owner frame the same way. See
+;; docs/routing/concepts.md#the-browser-is-just-another-event-source.
 (defn- on-hashchange [_]
   (rf/dispatch [:rf.route/handle-url-change (current-path)] {:frame app-frame}))
 
 ;; ---- Mount -----------------------------------------------------------------
 ;;
 ;; The React root lives in a `defonce` atom, created lazily on the first
-;; `mount!` rather than at ns-load. Two reasons: ns-load must have no DOM side
-;; effects so co-required example namespaces don't race `create-root` onto the
-;; shared `#app` (examples/TESTING.md §Example mount-isolation), and `defonce`
-;; reuses the one root across hot reloads (React 18 rejects a second
-;; `create-root` on a live node). `mount!` is `^:dev/after-load`, so shadow
-;; re-runs it on every reload to re-render the edited views.
+;; `mount!`. The `defonce` reuses the one root across hot reloads, which React
+;; requires (a second `create-root` on a live node is rejected). Creating it in
+;; `mount!` rather than at ns-load keeps namespace load free of DOM side effects.
+;; `mount!` is `^:dev/after-load`, so shadow re-runs it on every reload to
+;; re-render the edited views.
 ;;
 ;; The render root is a `frame-provider {:id app-frame …}`. On the first mount it
 ;; creates the app frame and runs `:initial-events`; on reload it reuses the same

--- a/examples/reagent/todomvc/db.cljs
+++ b/examples/reagent/todomvc/db.cljs
@@ -1,24 +1,25 @@
 (ns todomvc.db
   "The shape of app-db, and the boot read that fills it.
 
-  Demonstrates: the single source of truth (`default-db` — todos and *nothing
-  else*; the active filter is derived from the route, never stored), and a
-  recordable coeffect (`reg-cofx :todo.storage/todos`) whose registered supplier
-  reads the saved todos *in* at boot, so the durable write stays replayable
-  instead of reaching for localStorage inside a handler."
+  Demonstrates: the single source of truth (`default-db` holds the todos and the
+  UI state, and nothing else; the active filter is derived from the route, never
+  stored), and a recordable coeffect (`reg-cofx :todo.storage/todos`) whose
+  supplier reads the saved todos in at boot, so the durable write stays
+  replayable instead of reaching for localStorage inside a handler.
+  See docs/guide/glossary.md (coeffect)."
   (:require [re-frame.core :as rf]))
 
-;; The default db carries no `:showing` slot — Spec 012's :route slice owns
-;; that fact. The :showing sub (in subs.cljs) derives :all/:active/:completed
-;; from :rf.route/id.
+;; The default db carries no `:showing` slot. The active filter is derived from
+;; the route: the :showing sub (in subs.cljs) reads :rf.route/id and maps it to
+;; :all/:active/:completed.
 ;;
-;; The `:ui` slice holds the form/UI state TodoMVC used to keep in view-local
-;; atoms. It is APPLICATION state — "which row is being edited" and the live
-;; input drafts — so it lives in app-db, is projected via subs, and is mutated
-;; only by events. Inputs read `:drafts` for their `:value` (controlled) and
-;; dispatch edit events on `:on-change`; `:editing-id` names the single row in
-;; edit-in-place mode (nil = none). Two draft slots are enough: one for the
-;; new-todo header input, one shared by the single editing row.
+;; The `:ui` slice holds the form/UI state. "Which row is being edited" and the
+;; live input drafts are application state, so they live in app-db, are read via
+;; subs, and are changed only by events. Inputs read `:drafts` for their
+;; `:value` (controlled) and dispatch edit events on `:on-change`. `:editing-id`
+;; names the single row in edit-in-place mode (nil = none). Two draft slots are
+;; enough: one for the new-todo header input, one shared by the single editing
+;; row.
 (def default-ui
   {:editing-id nil
    :drafts     {:new "" :edit ""}})
@@ -47,30 +48,24 @@
       (catch :default _
         (sorted-map)))))
 
-;; localStorage is deliberate — see README; the Spec-014 :rf.http/managed demo
-;; lives with realworld.
+;; The saved todos are a fact about the world (storage), and `:todo/initialise`
+;; folds them into durable app-db. A durable write must fold a RECORDED fact, not
+;; a live `localStorage` read at the write site — a live read could not be
+;; reproduced under replay or epoch-restore. So `:todo.storage/todos` is a
+;; RECORDABLE coeffect whose supplier reads localStorage: the supplier runs at
+;; the boot dispatch, its value is recorded onto the event envelope, and replay
+;; re-folds that captured snapshot rather than re-reading localStorage now.
 ;;
-;; EP-0017 (recordable coeffects): the saved todos are a STORAGE world fact, and
-;; `:todo/initialise` folds them into durable app-db. A durable write must fold a
-;; RECORDED fact, not an ambient `localStorage` read at the write site (which
-;; replay / epoch-restore could not reproduce). So `:todo.storage/todos` is a
-;; registered RECORDABLE coeffect whose supplier reads localStorage: the supplier
-;; runs at the boot dispatch, its value is recorded onto the causal token, and
-;; replay re-folds that captured snapshot rather than re-reading whatever
-;; localStorage holds now.
-;;
-;; Registering the supplier is the canonical coeffect shape — the Glossary's
-;; "make a coeffect available by registering a supplier with reg-cofx". (The
-;; value-stamped-at-the-dispatch-site PROVIDED form — `:provided? true`, no
-;; supplier — is reserved for boundary facts the app can't read itself, e.g. an
-;; SSR server that stamps the session the client can't see.)
+;; Registering a supplier with `reg-cofx` is the standard way to make a coeffect
+;; available. See docs/guide/glossary.md (coeffect) and
+;; docs/guide/glossary.md#recordable-vs-ambient-coeffects.
 
 (defn read-todos-from-storage
-  "Read the saved TodoMVC items from localStorage, normalised to a sorted-map —
-   the supplier body for the `:todo.storage/todos` recordable coeffect. nil/empty
-   localStorage (first run, or a server with no localStorage) yields an empty
-   sorted-map. A sorted-map matters: allocate-next-id picks the max id via
-   `(last (keys todos))`, which only holds while the map stays sorted."
+  "Read the saved TodoMVC items from localStorage, normalised to a sorted-map.
+   This is the supplier body for the `:todo.storage/todos` recordable coeffect.
+   nil/empty localStorage (first run, or a server with no localStorage) yields an
+   empty sorted-map. The sorted-map matters: allocate-next-id picks the max id
+   via `(last (keys todos))`, which only holds while the map stays sorted."
   []
   (or (some-> (.-localStorage js/globalThis)
               (.getItem ls-key)
@@ -79,10 +74,10 @@
 
 (rf/reg-cofx :todo.storage/todos
   {:recordable? true
-   :doc "Recordable coeffect (EP-0017): the saved TodoMVC items, read from
-         localStorage as a sorted-map. The registered supplier runs at the boot
-         dispatch; its value is recorded onto the causal token and re-presented
-         verbatim under replay / epoch-restore. A handler folds it into durable
-         app-db by declaring `:rf.cofx/requires [:todo.storage/todos]` and
-         reading it flat — folding a recorded fact, never an ambient read."}
+   :doc "Recordable coeffect: the saved TodoMVC items, read from localStorage as
+         a sorted-map. The supplier runs at the boot dispatch; its value is
+         recorded onto the event envelope and re-presented verbatim under replay
+         / epoch-restore. A handler folds it into durable app-db by declaring
+         `:rf.cofx/requires [:todo.storage/todos]` and reading it flat — folding
+         a recorded fact, never a live read."}
   (fn [] (read-todos-from-storage)))

--- a/examples/reagent/todomvc/events.cljs
+++ b/examples/reagent/todomvc/events.cljs
@@ -6,29 +6,28 @@
   effect map`), `reg-fx` (the `:todo.storage/save` effect handler that performs
   the localStorage write the handlers only *describe* as data), and `reg-route`
   (the URL as an input — `/`, `/active`, `/completed`, plus the not-found
-  fallback)."
+  fallback). See docs/guide/glossary.md (event)."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            ;; Routing ships in day8/re-frame2-routing.
-            ;; Requiring re-frame.routing here triggers its load-time
-            ;; hook + reg-sub registrations; without it, the rf/reg-route
-            ;; calls below throw :rf.error/routing-artefact-missing.
+            ;; Requiring re-frame.routing registers the routing subscriptions and
+            ;; install hook. Without it the `rf/reg-route` calls below throw
+            ;; :rf.error/routing-artefact-missing.
             [re-frame.routing]
             [todomvc.db :as db]))
 
-;; ---- routes (Spec 012) ----------------------------------------------------
-;; TodoMVC's canonical URLs are hash-based (#/, #/active, #/completed). Spec
-;; 012 routes match path-strings, so the host-adapter (core.cljs) strips the
-;; leading '#' (and optional '!') from the URL hash before dispatching
-;; :rf.route/handle-url-change. The result is a Spec 012 path the registered
-;; routes match exactly.
+;; ---- routes ---------------------------------------------------------------
+;; Each route pairs an id with a path the router matches. TodoMVC's URLs are
+;; hash-based (#/, #/active, #/completed); the adapter in core.cljs strips the
+;; leading '#' so these path patterns match.
+;; See docs/routing/concepts.md#move-2-navigation-is-an-event.
 
 (rf/reg-route :todo/all       {:doc "Show all todos."} "/")
 (rf/reg-route :todo/active    {:doc "Show active todos."} "/active")
 (rf/reg-route :todo/completed {:doc "Show completed todos."} "/completed")
 
-;; Required by Spec 012 §Route-not-found. Unmatched URLs land here; we treat
+;; The not-found route is required. Unmatched URLs land here; this app treats
 ;; them as "show all" so a stray hash never breaks the app.
+;; See docs/routing/concepts.md#not-found-is-a-route-you-register.
 (rf/reg-route :rf.route/not-found {:doc "Fallback."} "/_404")
 
 (defn- allocate-next-id [todos]
@@ -105,15 +104,15 @@
 
 ;; ---- UI / form state (the `:ui` slice) ------------------------------------
 ;;
-;; These events own the form/UI state that TodoMVC used to keep in view-local
-;; atoms. The inputs are CONTROLLED: a view's `:value` reads a draft sub and its
-;; `:on-change` dispatches `:todo.ui/edit-field` — it never sets view-local
-;; state. "Which row is being edited" is application state, so it lives at
-;; `[:ui :editing-id]`, toggled by `:todo.ui/start-edit` / `:todo.ui/stop-edit`.
+;; These events own the form/UI state. The inputs are CONTROLLED: a view's
+;; `:value` reads a draft sub and its `:on-change` dispatches
+;; `:todo.ui/edit-field` — it never sets view-local state. "Which row is being
+;; edited" is application state, so it lives at `[:ui :editing-id]`, toggled by
+;; `:todo.ui/start-edit` / `:todo.ui/stop-edit`.
 ;;
-;; Drafts and editing-id are pure UI — they are NOT persisted (no localStorage
-;; write), so these handlers return a plain `{:db ...}` rather than going through
-;; `persist-db`. Only the todo facts themselves (`:todos`) are durable.
+;; Drafts and editing-id are pure UI. They are NOT persisted, so these handlers
+;; return a plain `{:db ...}` rather than going through `persist-db`. Only the
+;; todo facts themselves (`:todos`) are durable.
 
 (rf/reg-event :todo.ui/edit-field
   {:doc "User typed into a controlled input. `which` is `:new` (header input)
@@ -148,8 +147,7 @@
 
 (rf/reg-event :todo.ui/commit-edit
   {:doc "Save the edit-in-place input: read the `:edit` draft, save it onto the
-         editing row (a blank title deletes the todo, same as before), then
-         leave edit mode."}
+         editing row (a blank title deletes the todo), then leave edit mode."}
   (fn [{:keys [db]} _]
     (let [id    (get-in db [:ui :editing-id])
           title (get-in db [:ui :drafts :edit])]

--- a/examples/reagent/todomvc/subs.cljs
+++ b/examples/reagent/todomvc/subs.cljs
@@ -6,10 +6,11 @@
   (`:todo/visible-todos` filters the list against `:todo/showing`,
   `:todo/footer-counts` folds the tallies). `:todo/showing` derives the active
   filter from the route id — the filter that app-db deliberately never stores.
-  Pure functions all the way down, recomputed only when an input actually moves."
+  Pure functions all the way down, recomputed only when an input actually moves.
+  See docs/guide/glossary.md (subscription)."
   (:require [re-frame.core :as rf]))
 
-;; :todo/showing derives from the active Spec 012 route id. :rf.route/not-found
+;; :todo/showing derives the active filter from the route id. :rf.route/not-found
 ;; and an unset route both fall through to :all so the UI defaults sensibly.
 (rf/reg-sub :todo/showing
   :<- [:rf.route/id]

--- a/examples/reagent/todomvc/views.cljs
+++ b/examples/reagent/todomvc/views.cljs
@@ -5,7 +5,8 @@
   `dispatch` are already in scope), plain helper fns for the sub-views (which
   take `dispatch`/`subscribe` as explicit args — the honest shape for a plain
   fn), and hiccup as data-as-markup. A view reads derived state and dispatches
-  events on interaction; no business logic lives here."
+  events on interaction; no business logic lives here.
+  See docs/guide/glossary.md (view)."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.views])
@@ -17,16 +18,15 @@
     :completed "#/completed"
     "#/"))
 
-;; A CONTROLLED text input, re-frame2 style. `:value` reads a draft sub and every
-;; keystroke dispatches `on-change`, which writes the draft into app-db; the input
-;; never holds its own value. Enter commits (dispatches `on-commit`), Escape
-;; cancels (dispatches `on-cancel`), and blur commits. Cancel re-renders the input
-;; away, so a trailing blur has nothing left to save.
+;; A CONTROLLED text input. `:value` reads a draft sub. Every keystroke
+;; dispatches `on-change`, which writes the draft into app-db; the input never
+;; holds its own value. Enter commits (dispatches `on-commit`), Escape cancels
+;; (dispatches `on-cancel`), and blur commits. Cancel renders the input away, so
+;; a trailing blur has nothing left to save.
 ;;
 ;; `:autofocus?` focuses the input when it first mounts — the edit input wants
-;; this, since the row just entered edit mode. A bare `:ref` callback does it by
-;; calling `.focus()` on the live node; it touches focus only, leaving `:value`
-;; bound to the sub.
+;; this, since the row just entered edit mode. A `:ref` callback calls `.focus()`
+;; on the live node. It touches focus only, leaving `:value` bound to the sub.
 (defn todo-input [{:keys [draft on-change on-commit on-cancel autofocus?] :as props}]
   (let [handle-keydown
         (fn [event]
@@ -129,8 +129,9 @@
 ;; The sub-views above (task-entry, task-list, todo-item, footer-controls) are
 ;; plain Reagent helper fns that take `dispatch` / `subscribe` as explicit args —
 ;; the clearest shape for internal helpers. `reg-view` is for the root: inside
-;; its body `dispatch` and `subscribe` are auto-injected into scope (Spec 004
-;; §reg-view auto-inject), which is why the root threads them down to the helpers.
+;; its body `dispatch` and `subscribe` are injected into scope, which is why the
+;; root threads them down to the helpers.
+;; See docs/guide/concepts/views.md.
 (reg-view root-view []
   (let [todos @(subscribe [:todo/todos])]
     [:<>

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -1,9 +1,7 @@
 (ns websocket.connection
-  "The `:ws/connection` connection machine — the canonical Pattern-WebSocket
-   worked example.
+  "The `:ws/connection` connection machine.
 
-   This is a faithful realisation of `spec/Pattern-WebSocket.md` §Worked
-   example. The hierarchy is:
+   This models a WebSocket lifecycle as a state machine. The hierarchy is:
 
      :disconnected
      :active                              ;; compound parent; owns the socket
@@ -13,37 +11,35 @@
      :reconnecting                        ;; :after backoff
      :failed                              ;; terminal until manual :ws/connect
 
-   Why a compound `:active` rather than parallel regions? Pattern-WebSocket
-   §The connection state machine describes a hierarchical machine: the three
-   success-path leaves share one critical invariant — the live socket actor
-   must outlive all of them. The subscription set + the in-flight map + the
-   queue + the socket id all belong to *one* domain (this connection) and
-   ride a single `:data` map, so the **shared-:data + compound `:active`**
-   shape is the right one here. Parallel regions are for axes that *don't*
-   share data; for that case see `examples/reagent/nine_states/` —
-   Pattern-NineStates' canonical worked example.
+   Why a compound `:active` rather than parallel regions? The three
+   success-path leaves share one invariant: the live socket actor must
+   outlive all of them. The subscription set, the in-flight map, the queue,
+   and the socket id all belong to one domain (this connection) and ride a
+   single `:data` map. A compound `:active` over a shared `:data` is the
+   right shape. Parallel regions are for axes that do NOT share data.
+   See docs/machines/concepts.md#when-the-machine-grows.
 
-   State tags carry the queryable connection-state predicates — the view
-   asks `:ws/connected?` / `:ws/reconnecting?` (the per-tag subs below,
-   each a `contains?` over the snapshot's `:tags` union — the same
-   containment the framework's `:rf/machine-has-tag?` sub answers)
-   without needing to know which leaf carries the `:connected` intent.
+   State tags carry the queryable connection-state predicates. The view asks
+   `:ws/connected?` / `:ws/reconnecting?` (the per-tag subs below, each a
+   `contains?` over the snapshot's `:tags` union) without knowing which leaf
+   carries the `:connected` intent. This is what state tags buy: ask, don't
+   tell. See docs/machines/glossary.md#state-tag.
 
-   Pattern-StaleDetection composes in twice:
+   Two staleness defences:
 
-     1. `:after` backoff — the runtime's built-in `:after`-epoch
-        invariant drops stale timers from prior `:reconnecting` visits.
+     1. `:after` backoff — the runtime cancels a state's `:after` timer on
+        exit and ignores any timer from a prior `:reconnecting` visit that
+        fires late. See docs/machines/concepts.md#guards-actions-tags-and-after--the-recognition-kit.
 
-     2. Connection epoch — the live `:socket-id` IS the epoch; the
-        `:current-socket?` guard rejects `:ws/received` from a
-        socket that has since been replaced (a slow `:message` event
-        landing post-reconnect).
+     2. Connection epoch — the live `:socket-id` IS the epoch. The
+        `:current-socket?` guard rejects a `:ws/received` from a socket that
+        has since been replaced (a slow message landing post-reconnect).
 
-   The socket actor itself — the thing that owns the JS WebSocket — is
+   The socket actor — the thing that owns the JS WebSocket — is
    `:websocket/socket`, declared in `websocket.messages`. The connection
-   machine invokes it at the `:active` parent level so the actor's
-   lifetime spans `:connecting` → `:authenticating` → `:connected`
-   without re-spawning."
+   machine spawns it at the `:active` parent level so the actor's lifetime
+   spans `:connecting` -> `:authenticating` -> `:connected` without
+   re-spawning."
   (:require [re-frame.core :as rf]
             ;; `re-frame.machines` ships in day8/re-frame2-machines.
             ;; Loading the ns publishes the late-bind hooks for
@@ -58,27 +54,18 @@
 ;; ============================================================================
 ;; CONNECTION MACHINE — :ws/connection
 ;; ============================================================================
-;;
-;; Read this side-by-side with spec/Pattern-WebSocket.md §Worked example
-;; — connection machine. The structural choices are documented there;
-;; this file is a runnable, app-shaped version that the views can
-;; drive.
 
 (def connection-machine
-  "Spec for the `:ws/connection` machine. Held in a `def` so the spec is
-   readable side-by-side with `spec/Pattern-WebSocket.md` and so the
-   `[:schemas :data]` (attached on `reg-machine` below) can reference it."
+  "The `:ws/connection` machine spec. Held in a `def` so the schema below
+   (`schema/ConnectionData`) can reference it on `reg-machine`."
     {:initial :disconnected
 
-     ;; Spec 010 §Machine data schema — `[:schemas :data]` validates the
-     ;; snapshot's `:data` SLOT (not the whole `{:state … :data …}`
-     ;; snapshot) at the `:where :machine-data` boundary. The runtime
-     ;; owns the surrounding snapshot, so this is the snapshot-`:data`
-     ;; validation surface, symmetric with the boot/login siblings
-     ;; (EP-0001, Mike ruling #11 — app-schemas validate app-db only).
+     ;; `[:schemas :data]` validates the machine's `:data` slot on every
+     ;; transition. App-schemas validate app-db; a machine's `:data` is
+     ;; validated here instead.
+     ;; See docs/machines/concepts.md#validating-a-machines-data.
      :schemas {:data schema/ConnectionData}
 
-     ;; Pattern-WebSocket §Worked example — the connection machine's
      ;; `:data` carries everything that must survive across reconnects.
      :data    {:url            nil
                :auth-token     nil
@@ -102,10 +89,9 @@
         (seq (:queue data)))
 
       :current-socket?
-      ;; Pattern-WebSocket §The connection state machine — the
-      ;; **connection-epoch** check. The incoming event carries
-      ;; `:source-socket-id` (the spawned actor's `:rf/self-id`);
-      ;; we drop the event unless that id matches the live socket.
+      ;; The connection-epoch check. The incoming event carries
+      ;; `:source-socket-id` (the spawned actor's `:rf/self-id`); we drop
+      ;; the event unless that id matches the live socket.
       (fn guard-current-socket? [{data :data [_ {:keys [source-socket-id]}] :event}]
         (and (some? (:socket-id data))
              (= source-socket-id (:socket-id data))))}
@@ -145,11 +131,11 @@
         {:data (assoc data :error error)})
 
       :record-socket-id
-      ;; `:on-spawn` is advisory only — it cannot mutate :data. The
-      ;; :active state's :entry dispatches
-      ;; `[:ws/connection [:ws/-socket-spawned <actor-id>]]` via the
-      ;; `:on-spawn` advisory callback's side-effect; this action
-      ;; captures the id user-side.
+      ;; Writes the spawned actor's id into `:data`. The `:active` spawn's
+      ;; `:on-spawn` callback fires `[:ws/connection [:ws/-socket-spawned
+      ;; <actor-id>]]` back into this machine; that transition runs this
+      ;; action. (`:on-spawn` is advisory and cannot mutate `:data`, so a
+      ;; self-event is how the id gets recorded.)
       (fn action-record-socket-id [{data :data [_ id] :event}]
         {:data (assoc data :socket-id id)})
 
@@ -162,15 +148,11 @@
                                   :token (:auth-token data)}]]]]})
 
       :flush-queue-and-resubscribe
-      ;; Entry action for `:connected`. Two jobs:
-      ;;   (1) re-issue subscribe messages for every tracked topic
-      ;;       (subscriptions survive reconnects);
-      ;;   (2) flush every message buffered while disconnected.
-      ;; The state machine's `:on-connected` from the spec is split
-      ;; this way for readability — the `:always` guarded transition
-      ;; reads the post-action `:queue`, so this action only handles
-      ;; the resubscribe + retry-reset side; the queue-flush side
-      ;; rides on the `:always` cascade below.
+      ;; Entry action for `:connected`. Re-issues subscribe messages for
+      ;; every tracked topic (subscriptions survive reconnects) and resets
+      ;; the retry counter. The buffered-message flush is the separate
+      ;; `:always` transition below, which reads the `:queue` this action
+      ;; leaves in place.
       (fn action-on-connected [{data :data}]
         {:data (assoc data :retries 0)
          :fx   (mapv (fn [topic]
@@ -179,9 +161,8 @@
                      (:subscriptions data))})
 
       :flush-queue
-      ;; Per the spec's `:always` cascade on `:connected`: when the
-      ;; entry leaves the queue non-empty, walk it onto the wire and
-      ;; clear it.
+      ;; The `:always` cascade on `:connected`: when entry leaves the
+      ;; queue non-empty, walk it onto the wire and clear it.
       (fn action-flush-queue [{data :data}]
         (let [q (:queue data)]
           {:data (assoc data :queue [])
@@ -251,45 +232,41 @@
             :ws/request {:action :enqueue-message}}}
 
       :active
-      {;; The socket actor is invoked at the parent level — its
-       ;; lifetime spans :connecting → :authenticating → :connected.
-       ;; Any transition that leaves :active destroys it.
+      {;; The socket actor is spawned at the parent level so its lifetime
+       ;; spans :connecting -> :authenticating -> :connected. Any
+       ;; transition that leaves :active destroys it.
+       ;; See docs/machines/concepts.md#when-the-machine-grows.
        :spawn {:machine-id :websocket/socket
-                ;; Mechanism 2 from Pattern-AsyncEffect §Parameter
-                ;; passing — the child reads URL + auth-token from
-                ;; the parent's :data at spawn time. Every re-entry
-                ;; to :active picks up whatever is current.
+                ;; The child reads URL + auth-token from the parent's
+                ;; `:data` at spawn time. Every re-entry to :active picks
+                ;; up whatever is current.
                 :data       (fn [{snap :snapshot}]
                               {:url        (-> snap :data :url)
                                :auth-token (-> snap :data :auth-token)})
-                ;; `:on-spawn` is advisory only — its return is dropped,
-                ;; so the callback CANNOT mutate the parent's `:data`.
-                ;; We use the late-bind
-                ;; `:router/dispatch!` hook from inside the callback to
-                ;; fire a self-event back into this machine; the
-                ;; matching `:on :ws/-socket-spawned` transition runs
-                ;; `:record-socket-id` which writes :socket-id into the
-                ;; parent's `:data` via the standard action contract.
+                ;; `:on-spawn` is advisory: its return is dropped, so the
+                ;; callback cannot mutate the parent's `:data`. To capture
+                ;; the freshly-allocated actor id, the callback fires a
+                ;; `:ws/-socket-spawned` self-event; the matching
+                ;; transition runs `:record-socket-id`, which writes
+                ;; `:socket-id` into `:data` the normal way.
                 :on-spawn (fn [{id :id}]
                             (when-let [dispatch! (re-frame.late-bind/get-fn :router/dispatch!)]
                               (dispatch!
                                 [:ws/connection [:ws/-socket-spawned id]]
-                                ;; Closed-enum
-                                ;; functional-origin axis is `:source`
-                                ;; — `:websocket` is the reserved app-
-                                ;; level slot for websocket-arrived
-                                ;; dispatches.
+                                ;; `:source :websocket` is the reserved
+                                ;; functional-origin slot for
+                                ;; websocket-arrived dispatches.
                                 {:source :websocket})))}
 
-       ;; Exit cascade — clear the stale :socket-id from :data. The
-       ;; runtime destroys the actor automatically (declarative :spawn's
-       ;; desugar emits :rf.machine/destroy on exit); this keeps :data
-       ;; tidy so :current-socket? compares against nil correctly.
+       ;; Exit: clear the stale :socket-id from :data. The runtime
+       ;; destroys the actor automatically on exit; this keeps :data tidy
+       ;; so :current-socket? compares against nil correctly.
        :exit (fn action-clear-socket-id [{data :data}]
                {:data (assoc data :socket-id nil)})
 
-       ;; Parent-level transitions inherited by every leaf, per Spec 005
-       ;; §Transition resolution — deepest-wins with parent fallthrough.
+       ;; Parent-level transitions inherited by every leaf (deepest state
+       ;; wins, falling through to the parent).
+       ;; See docs/machines/glossary.md#transition.
        :on    {:ws/closed   {:target :reconnecting
                              :action :bump-retry}
                :ws/fatal    {:target :failed
@@ -302,12 +279,9 @@
                ;; the next :connected entry will re-issue.
                :ws/subscribe {:action (fn [{data :data [_ topic] :event}]
                                         {:data (update data :subscriptions conj topic)})}
-               ;; Framework-internal: the `:on-spawn` advisory callback
-               ;; dispatches this so the machine can record the spawned
-               ;; socket id into its `:data` via a regular action.
-               ;; `:on-spawn`'s return is dropped; this self-event is
-               ;; the supported mechanism for observing the freshly-
-               ;; allocated actor id user-side.
+               ;; Internal: the spawn's `:on-spawn` callback fires this so
+               ;; the machine can record the spawned socket id via a
+               ;; regular action (see `:record-socket-id`).
                :ws/-socket-spawned {:action :record-socket-id}}
 
        :initial :connecting
@@ -321,11 +295,10 @@
         {:tags  #{:websocket/active :websocket/authenticating}
          :entry :send-auth
          :on    {:ws/auth-ok     {:target :connected}
-                 ;; :failed is a TOP-LEVEL state, not a sibling of
-                 ;; :authenticating under :active — a bare keyword would
-                 ;; resolve to [:active :failed] (which does not exist), so
-                 ;; the absolute vector target [:failed] is required
-                 ;; (transition-target validation rejects the bare keyword).
+                 ;; :failed is a top-level state, not a sibling under
+                 ;; :active. A bare keyword would resolve to [:active
+                 ;; :failed], which does not exist, so the absolute vector
+                 ;; target [:failed] is required.
                  :ws/auth-failed {:target [:failed]
                                   :action :record-error}}}
 
@@ -346,10 +319,10 @@
       :reconnecting
       {:tags   #{:websocket/reconnecting}
        :always [{:guard :max-retries-exceeded? :target :failed}]
-       ;; Exponential backoff, computed at state entry from the current
-       ;; retry count. Spec 005 §Value shape — fn-form delay called
-       ;; once at entry. The :after epoch invariant guarantees a
-       ;; transition out makes the in-flight backoff stale.
+       ;; Exponential backoff. The delay fn is called once at entry and
+       ;; reads the current retry count. Leaving the state cancels the
+       ;; timer, so a backoff from a prior visit can't fire late.
+       ;; See docs/machines/concepts.md#guards-actions-tags-and-after--the-recognition-kit.
        :after  {(fn delay-backoff-ms [{snap :snapshot}]
                   (let [{:keys [retries base-ms max-backoff-ms]} (:data snap)]
                     (min (* base-ms (Math/pow 2 retries))
@@ -372,19 +345,17 @@
                                  :action :reset-retries}}}}})
 
 ;; ============================================================================
-;; MACHINE HANDLER + SUBSCRIPTIONS + INIT EVENT  (ns-load — the production-app idiom)
+;; MACHINE HANDLER + SUBSCRIPTIONS + INIT EVENT
 ;; ============================================================================
 
-;; Use `rf/reg-machine` (not `reg-event` + `make-machine-handler`) so
-;; the registration metadata carries `:rf/machine? true` — declarative
-;; `:spawn` resolves the spawn target via this metadata, and without it
-;; the spawn-fx silently no-ops (the spawned actor's handler never
-;; registers, and its snapshot is never written).
+;; `rf/reg-machine` tags the registration `:rf/machine? true`, which is
+;; what declarative `:spawn` looks up to resolve a spawn target. Without
+;; it the spawn-fx silently no-ops.
 (rf/reg-machine :ws/connection connection-machine)
 
 ;; --- subs -------------------------------------------------------------
-;; EP-0001: machine snapshots are durable runtime-db state — read
-;; them through the framework `:rf/machine` sub.
+;; A machine snapshot lives in runtime-db; read it through the framework
+;; `:rf/machine` sub. See docs/machines/glossary.md#snapshot.
 (rf/reg-sub :ws/snapshot
   :<- [:rf/machine :ws/connection]
   (fn [snapshot _] snapshot))
@@ -395,9 +366,7 @@
 
 ;; The per-tag predicate subs: each is a `contains?` over the snapshot's
 ;; `:tags` union, so a view asks "is it connected?" rather than matching
-;; the hierarchical `:state` vector. (The framework's `:rf/machine-has-tag?`
-;; sub answers the same containment question; these are the app-named
-;; shorthand the views read.)
+;; the hierarchical `:state` vector. See docs/machines/glossary.md#state-tag.
 (rf/reg-sub :ws/connecting?
   :<- [:ws/snapshot]
   (fn [snap _] (contains? (:tags snap) :websocket/connecting)))
@@ -433,9 +402,10 @@
 ;; --- init event -------------------------------------------------------
 (rf/reg-event :ws.connection/initialise
   {:doc "Seed the connection machine into its `:disconnected` initial
-         state — the lazy initial materialises on the first dispatch."}
+         state. A machine's initial snapshot materialises on its first
+         dispatch."}
   (fn handler-ws-connection-initialise [_ _]
-    ;; A no-op dispatch through the machine forces snapshot
-    ;; materialisation so the headless tests can read the initial
-    ;; :disconnected state without first calling `:ws/connect`.
+    ;; A no-op dispatch through the machine forces the initial snapshot to
+    ;; materialise, so tests can read the `:disconnected` state without
+    ;; first calling `:ws/connect`.
     {:fx [[:dispatch [:ws/connection [:ws/noop]]]]}))

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -1,36 +1,38 @@
 (ns websocket.core
-  "Entry point for the Pattern-WebSocket worked example.
+  "Entry point for the WebSocket example.
 
-   This is the canonical re-frame2 example for spec/Pattern-WebSocket.md.
-   Every key piece of the pattern is exercised:
+   This example models a WebSocket connection as a state machine. It
+   exercises:
 
    - **Hierarchical compound `:active`** parenting `:connecting`,
-     `:authenticating`, `:connected` — the socket-actor `:spawn` is
-     anchored on the parent so it survives the success-path leaf
-     transitions.
+     `:authenticating`, `:connected`. The socket-actor `:spawn` is on the
+     parent so it survives the success-path leaf transitions.
 
-   - **`:after` exponential backoff** in `:reconnecting`, with the
-     epoch invariant taking care of stale timers from prior visits.
+   - **`:after` exponential backoff** in `:reconnecting`. Leaving the
+     state cancels the timer, so a backoff from a prior visit can't fire
+     late.
 
    - **`:always` cascades** — `:reconnecting`'s max-retries guard, and
      `:connected`'s queue-flush on entry.
 
    - **`:tags`** — `:websocket/connected`, `:websocket/reconnecting`,
-     `:websocket/failed` so the view asks tag-shaped questions instead
-     of unfolding the snapshot's hierarchical `:state` vector.
+     `:websocket/failed`, so the view asks tag-shaped questions instead of
+     unfolding the snapshot's hierarchical `:state` vector.
 
-   - **Pattern-StaleDetection composed twice** — once for the backoff
-     timer (runtime built-in), once for the connection-epoch
-     (`:current-socket?` guard against the live `:socket-id`).
+   - **Two staleness defences** — the backoff timer (runtime-cancelled on
+     exit) and the connection-epoch (`:current-socket?` guard against the
+     live `:socket-id`).
 
-   - **Request/reply correlation** — `:in-flight` map, request-id
-     stamp, timeout via `:dispatch-later`, reply-event dispatch on
-     the correlated `:ws/received`.
+   - **Request/reply correlation** — `:in-flight` map, request-id stamp,
+     timeout via `:dispatch-later`, reply-event dispatch on the correlated
+     `:ws/received`.
 
-   - **Reconnect cascade** — exit-from-`:active` clears the
-     `:socket-id`; the runtime destroys the socket actor; the
-     `:reconnecting` `:after` re-enters `:active` which spawns a
-     fresh one.
+   - **Reconnect cascade** — exit-from-`:active` clears the `:socket-id`;
+     the runtime destroys the socket actor; the `:reconnecting` `:after`
+     re-enters `:active`, which spawns a fresh one.
+
+   See docs/machines/concepts.md for the machine grammar and
+   docs/machines/examples.md for this example's place in the set.
 
    Coverage lives in the CLJS substrate contract tests (`npm run
    test:cljs`, ns `re-frame.websocket-cljs-test`); the mock server keeps
@@ -63,28 +65,22 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; React root held in an atom and populated lazily inside `run` rather
-;; than at ns-load. Multiple example namespaces co-required by the
-;; browser-test bundle's wrapper test namespaces share a single
-;; `#app` element; running `create-root` at ns-load would race multiple
-;; roots onto the same container and leak example-A's mount into
-;; example-B's tests. Mounting in `run` keeps ns-load DOM-side-effect-free.
-;; The headless fixtures live in the framework test tree at
-;; `implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs`
-;; (the example tree is test-free) and run in any CLJS host
-;; without React.
+;; The React root is held in an atom and created lazily inside `run`, not
+;; at ns-load. Several example namespaces share one `#app` element in the
+;; browser-test bundle; creating the root at ns-load would race multiple
+;; roots onto the same container. Creating it in `run` keeps ns-load free
+;; of DOM side effects.
 
 (defonce react-root (atom nil))
 
 ;; The frame lives in one spot: the `frame-provider` at the render root.
-;; `run` calls `init!` to install the adapter, then renders
-;; `[frame-provider {:id ...} ...]`. The provider's `{:id}` shape creates
-;; the app frame on first mount, applies its config, and runs the
-;; `:initial-events` seed once; on hot reload it reuses that frame and
-;; skips the seed. So create, seed, and scope-into-React all happen there.
-;; The frame id is `:rf/default` — the same id `schema.cljs` scopes its
-;; `reg-app-schema` to. Matches the canonical mount in
-;; examples/reagent/counter/core.cljs.
+;; `run` installs the adapter, then renders `[frame-provider {:id ...}
+;; ...]`. The provider's `{:id}` shape creates the app frame on first
+;; mount, applies its config, and runs the `:initial-events` seed once; on
+;; hot reload it reuses that frame and skips the seed. So create, seed, and
+;; scope-into-React all happen there. The frame id `:rf/default` matches
+;; the id `schema.cljs` scopes its `reg-app-schema` to.
+;; See docs/guide/concepts/frames.md.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -1,36 +1,29 @@
 (ns websocket.messages
-  "The `:websocket/socket` actor + outbound/inbound message handling
-   for the Pattern-WebSocket example.
+  "The `:websocket/socket` actor plus outbound/inbound message handling.
 
    This file plays two roles:
 
-   1. **Socket actor (`:websocket/socket`).** The spawned child the
-      connection machine `:spawn`s on entry to `:active`. The actor
-      is itself a state machine — its `:open` state translates `:send`
-      events into wire-level writes and forwards inbound server
-      messages back to the parent connection machine. Pattern-WebSocket
-      §The connection state machine names this as a child actor
-      explicitly so the JS `WebSocket` (which is a host-side reference,
-      not a value) lives outside `app-db`.
+   1. **Socket actor (`:websocket/socket`).** The child machine the
+      connection machine spawns on entry to `:active`. Its `:open` state
+      translates `:send` events into wire-level writes and forwards
+      inbound server messages back to the parent. Making the actor own the
+      socket keeps the JS `WebSocket` (a host-side reference, not a value)
+      out of app-db. See docs/machines/glossary.md#spawn.
 
-   2. **Mock-server bridge.** A small in-process JS `WebSocket`-shaped
-      stub the example uses when no real WebSocket endpoint is
-      available — keeps the example standalone for the headless tests
-      (in the framework test tree at
-      `implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs`;
-      the example tree is test-free). The stub state lives in
-      the `mock-server-state` atom; plain exported fns are the delivery
-      seams — `set-mock-sync!` flips the stub between async (`setTimeout`-
-      deferred) and sync (immediate `dispatch-sync`) delivery, `send-server-push!`
-      and `simulate-disconnect!` push inbound `:received` / disconnect
-      events from view click handlers, and `reset-mock-server!` clears
-      the side-table between tests. Sync mode lets the headless tests
-      observe a full request/reply round-trip without yielding to the
-      JS event loop.
+   2. **Mock-server bridge.** A small in-process JS `WebSocket`-shaped stub
+      the example uses in place of a real endpoint, so it runs standalone.
+      The stub state lives in the `mock-server-state` atom. The exported
+      fns are the delivery seams: `set-mock-sync!` flips the stub between
+      async (`setTimeout`-deferred) and sync (immediate `dispatch-sync`)
+      delivery; `send-server-push!` and `simulate-disconnect!` push inbound
+      `:received` / disconnect events from view click handlers; and
+      `reset-mock-server!` clears the side-table between tests. Sync mode
+      lets a test observe a full request/reply round-trip without yielding
+      to the JS event loop.
 
-   The split is intentional: production apps swap the bridge for a real
-   `(js/WebSocket. url)` and leave the actor machine untouched. The
-   pattern (machine-owns-the-actor; actor-owns-the-host-side-reference)
+   The split is intentional: a real app swaps the bridge for a real
+   `(js/WebSocket. url)` and leaves the actor machine untouched. The
+   pattern — machine owns the actor; actor owns the host-side reference —
    does not change with the transport."
   (:require [re-frame.core :as rf]
             [re-frame.machines]
@@ -41,11 +34,11 @@
 ;; ============================================================================
 ;;
 ;; The JS `WebSocket` (or its mock stand-in) is a stateful reference. It
-;; cannot live in `app-db` — it doesn't serialise, it doesn't survive a
-;; Tool-Pair epoch replay, and writing it would defeat re-frame's value
-;; semantics. The canonical answer is a host-side weak store keyed by
-;; the actor's `:rf/self-id`, owned by the actor's machine handler. The
-;; actor's `:on-spawn` writes; the actor's `:on-destroy` clears.
+;; cannot live in app-db: it doesn't serialise, it doesn't survive a
+;; time-travel replay, and writing it would defeat re-frame's value
+;; semantics. So it lives in a host-side store keyed by the actor's
+;; `:rf/self-id`, owned by the actor's machine handler. The actor writes
+;; on open and clears on close.
 
 (defonce ^:private sockets-by-actor (atom {}))
 
@@ -62,44 +55,42 @@
 ;; MOCK WEBSOCKET SERVER
 ;; ============================================================================
 ;;
-;; Implements a tiny `js/WebSocket`-shaped object for the headless tests
-;; and the example's own buttons. Supports two interaction shapes:
+;; A tiny `js/WebSocket`-shaped object for the tests and the example's own
+;; buttons. It supports two interaction shapes:
 ;;
-;;   (1) Auto-echo replies for outbound `{:type :request ...}`. The
-;;       server immediately echoes a reply on the same socket carrying
-;;       the original `:request-id` so the connection machine's
-;;       request-reply correlation slot lights up.
+;;   (1) Auto-echo replies for outbound `{:type :request ...}`. The server
+;;       echoes a reply on the same socket carrying the original
+;;       `:request-id`, so the connection machine's request-reply
+;;       correlation slot lights up.
 ;;
 ;;   (2) Manual `(send-server-push! body)` and `(simulate-disconnect!)`
 ;;       seams the views call from button handlers.
 ;;
-;; The mock is deliberately synchronous-ish: inbound deliveries land on
-;; the next task tick (via `js/setTimeout _ 0`, in the `later` helper
-;; below) so transport events fire after the dispatch returns, not inside
-;; it.
+;; In async mode, inbound deliveries land on the next task tick (via
+;; `js/setTimeout _ 0`, in the `later` helper below) so transport events
+;; fire after the dispatch returns, not inside it.
 
 (defonce ^:private mock-server-state (atom {:sockets {} :sync? false}))
 
 (defn set-mock-sync!
   "Toggle the mock server between async (default, `setTimeout`-deferred)
-   and sync (immediate-delivery) modes. Sync mode is used by the
-   headless tests so `rf/dispatch-sync` observes the full
-   request/reply round-trip without yielding to the JS event loop."
+   and sync (immediate-delivery) modes. The tests use sync mode so
+   `rf/dispatch-sync` observes the full request/reply round-trip without
+   yielding to the JS event loop."
   [sync?]
   (swap! mock-server-state assoc :sync? sync?))
 
 (defn reset-mock-server!
-  "Clear every stored mock socket. Used by the headless test fixture
-   to ensure each test starts with a fresh mock-server side-table —
-   without this, the `:sockets` map accumulates across tests and
-   `send-server-push!` delivers N copies of every push."
+  "Clear every stored mock socket, so each test starts with a fresh
+   mock-server side-table. Without this the `:sockets` map accumulates
+   across tests and `send-server-push!` delivers N copies of every push."
   []
   (swap! mock-server-state assoc :sockets {}))
 
 (defn- later
-  "Run `f` synchronously in mock-sync mode; via `setTimeout` otherwise.
-   This is the only knob that separates headless-test mode (sync) from
-   the browser-driven example (async, `setTimeout`-deferred)."
+  "Run `f` synchronously in sync mode; via `setTimeout` otherwise. This is
+   the only knob that separates sync mode (the tests) from the
+   browser-driven example (async, `setTimeout`-deferred)."
   [f]
   (if (:sync? @mock-server-state)
     (f)
@@ -109,18 +100,16 @@
   (str "mock-socket-" (random-uuid)))
 
 (defn- deliver-to-actor!
-  "Dispatch an inbound transport event into the spawned actor. The
-   actor's machine handler translates the event into a parent-bound
+  "Dispatch an inbound transport event into the spawned actor. The actor's
+   machine handler translates the event into a parent-bound
    `[:ws/connection [:ws/<kind> ...]]` dispatch.
 
-   EP-0002: inbound deliveries fire from the mock transport's
-   `later` callback — a detached `setTimeout` in async (browser) mode that
-   carries NO ambient frame, so a bare `rf/dispatch` here would raise
-   `:rf.error/no-frame-context`. The caller (`mock-socket-for-actor`) is
-   created inside the `:open-socket` action — i.e. under the actor's drain
-   frame — so it captures that frame's `dispatch` operation and threads it in
-   here. Passing the captured `dispatch` honours the carried invariant across
-   the async boundary (Spec 002 §frame-handle)."
+   In async mode this fires from a detached `setTimeout` callback, which
+   carries no ambient frame; a bare `rf/dispatch` here would raise
+   `:rf.error/no-frame-context`. So the caller captures its frame's
+   `dispatch` and threads it in. A captured `dispatch` carries the frame
+   across the async boundary.
+   See docs/guide/glossary.md#frame-handle."
   [dispatch actor-id kind payload]
   (when actor-id
     (dispatch [actor-id [kind payload]])))
@@ -140,12 +129,11 @@
   [actor-id _url _auth-token]
   (let [id   (next-mock-socket-id)
         open? (atom true)
-        ;; EP-0002: this fn runs inside the `:open-socket` action
-        ;; — i.e. under the actor's drain frame — so capture that frame's
-        ;; `dispatch` now and thread it into every (async, `later`-deferred)
-        ;; inbound delivery below. The detached `setTimeout` callback carries
-        ;; no ambient frame; the captured operation does (Spec 002
-        ;; §frame-handle).
+        ;; This fn runs inside the actor's `:open-socket` action, so it has
+        ;; a frame in scope. Capture that frame's `dispatch` now and thread
+        ;; it into every (async, `later`-deferred) inbound delivery below;
+        ;; the detached `setTimeout` callback has no frame of its own.
+        ;; See docs/guide/glossary.md#frame-handle.
         dispatch (:dispatch (rf/frame-handle))]
     (swap! mock-server-state assoc-in [:sockets id]
            {:actor-id actor-id
@@ -193,21 +181,19 @@
               (later
                 #(deliver-to-actor! dispatch actor-id :closed {:code 1000})))}))
 
-;; Exposed seams the views (and the headless tests) use to drive the
-;; mock without dispatching through the actor.
+;; Exposed seams the views (and the tests) use to drive the mock without
+;; dispatching through the actor.
 
 (defn- deliver-external!
-  "Sync-mode-aware variant of `deliver-to-actor!` for callers OUTSIDE
-   a running drain (i.e. test bodies, view click handlers). In sync
-   mode it uses `dispatch-sync` so the chain runs to fixed point
-   before returning; in async mode it falls back to the queued
-   `dispatch`.
+  "Variant of `deliver-to-actor!` for callers outside a running cascade
+   (test bodies, view click handlers). In sync mode it uses
+   `dispatch-sync` so the chain runs to fixed point before returning; in
+   async mode it uses the queued `dispatch`.
 
-   EP-0002: a view click handler fires outside React render
-   scope and outside any drain, so the caller must supply a frame-bound
-   `dispatch` / `dispatch-sync` pair (the operations a `reg-view`-injected
-   `dispatch` / a captured `(rf/frame-handle)` provides). A bare ambient
-   `rf/dispatch` here would raise `:rf.error/no-frame-context`."
+   A view click handler fires outside any frame scope, so the caller
+   supplies a frame-bound `dispatch` / `dispatch-sync` pair (from a
+   captured `(rf/frame-handle)`). A bare `rf/dispatch` here would raise
+   `:rf.error/no-frame-context`. See docs/guide/glossary.md#frame-handle."
   [{:keys [dispatch dispatch-sync]} actor-id kind payload]
   (when actor-id
     (if (:sync? @mock-server-state)
@@ -215,24 +201,22 @@
       (dispatch      [actor-id [kind payload]]))))
 
 (defn send-server-push!
-  "Deliver a synthetic server push to every live mock socket. Used by
-   the headless tests and the example's 'Trigger server push' button
-   to demonstrate the inbound translation path.
+  "Deliver a synthetic server push to every live mock socket. Drives the
+   inbound translation path from the 'Trigger server push' button and the
+   tests.
 
-   `handle` is a `(rf/frame-handle)` operation bundle carrying the caller's
-   frame (the view passes its injected handle; tests pass an explicit one) —
-   EP-0002 requires the deferred dispatch carry a frame across the
-   click-handler / async boundary."
+   `handle` is a `(rf/frame-handle)` bundle carrying the caller's frame, so
+   the deferred dispatch carries a frame across the click-handler / async
+   boundary. See docs/guide/glossary.md#frame-handle."
   [handle body]
   (doseq [[_ {:keys [actor-id open?]}] (:sockets @mock-server-state)]
     (when @open?
       (deliver-external! handle actor-id :received body))))
 
 (defn simulate-disconnect!
-  "Force every live mock socket closed, triggering the reconnect
-   cascade in the parent. Used by the 'Drop connection' button. `handle`
-   is the caller's `(rf/frame-handle)` operation bundle (see
-   `send-server-push!`)."
+  "Force every live mock socket closed, triggering the reconnect cascade
+   in the parent. Drives the 'Drop connection' button. `handle` is the
+   caller's `(rf/frame-handle)` bundle (see `send-server-push!`)."
   [handle]
   (doseq [[_ {:keys [actor-id open?]}] (:sockets @mock-server-state)]
     (when @open?
@@ -243,20 +227,18 @@
 ;; THE SOCKET ACTOR — :websocket/socket
 ;; ============================================================================
 ;;
-;; A small two-state machine. `:opening` opens the host-side socket on
-;; entry, transitions to `:open` once the transport reports ready, and
-;; stays there for the lifetime of the connection. The parent's
-;; `:spawn` destroys this actor on any exit from `:active`, which
-;; takes care of cleanup.
+;; A small machine. `:opening` opens the host-side socket on entry and
+;; transitions immediately to `:open`, where it stays for the lifetime of
+;; the connection. The parent's `:spawn` destroys this actor on any exit
+;; from `:active`, which handles cleanup.
 ;;
-;; The actor uses the runtime-stamped `:rf/self-id` to address
-;; dispatches back to the parent's `:rf/parent-id`. The framework
-;; reserves both keys under `:data :rf/*` for spawned actors.
+;; The actor reads the runtime-stamped `:rf/self-id` to tag its own
+;; dispatches and `:rf/parent-id` to address dispatches back to the
+;; parent. The runtime stamps both keys into a spawned actor's `:data`.
 
 (def socket-actor-machine
-  "Spec for the `:websocket/socket` actor machine — held in a `def` so
-   the spec reads cleanly and the `reg-machine` registration below can
-   reference it."
+  "The `:websocket/socket` actor machine spec. Held in a `def` so the
+   `reg-machine` registration below can reference it."
     {:initial :opening
      :data    {:url        nil
                :auth-token nil}
@@ -272,14 +254,11 @@
                                                (:url data)
                                                (:auth-token data))]
           (store-socket! self-id socket)
-          ;; Report `:opened` to the parent as a `:dispatch` fx (NOT
-          ;; via `(rf/dispatch ...)` from inside the action body) so
-          ;; the framework routes through the running drain's frame.
-          ;; Important under the EP-0002 carried invariant:
-          ;; a `:dispatch` fx inherits the cascade's frame, whereas a bare
-          ;; `(rf/dispatch ...)` from inside an action body runs outside
-          ;; any frame scope and raises `:rf.error/no-frame-context` — it
-          ;; does NOT silently fall back to `:rf/default`.
+          ;; Report `:opened` to the parent as a `:dispatch` fx, not a bare
+          ;; `(rf/dispatch ...)` from inside the action body. A `:dispatch`
+          ;; fx inherits the cascade's frame; a bare dispatch from an
+          ;; action body runs outside any frame scope and raises
+          ;; `:rf.error/no-frame-context`.
           {:fx [[:dispatch [parent-id [:ws/opened {:source-socket-id self-id}]]]]}))
 
       :send-via-socket
@@ -292,15 +271,15 @@
         nil)
 
       :forward-received
-      ;; The mock server's reply arrives via `[<actor-id> [:received body]]`.
-      ;; Forward into the parent with the connection-epoch stamp so
+      ;; The server's reply arrives via `[<actor-id> [:received body]]`.
+      ;; Forward it to the parent stamped with the socket id, so
       ;; `:current-socket?` can drop messages from a torn-down socket.
       (fn action-forward-received [{data :data [_ body] :event}]
         (let [self-id   (:rf/self-id data)
               parent-id (:rf/parent-id data)
-              ;; Branch on body's :type. :auth-ok / :auth-failed land
-              ;; on the parent as their own events; everything else
-              ;; lands as :ws/received with the body in tow.
+              ;; Branch on body's :type: :auth-ok / :auth-failed land on
+              ;; the parent as their own events; everything else lands as
+              ;; :ws/received with the body in tow.
               ev        (case (:type body)
                           :auth-ok     [:ws/auth-ok {:source-socket-id self-id}]
                           :auth-failed [:ws/auth-failed
@@ -322,16 +301,13 @@
 
      :states
      {:opening
-      ;; Per Spec 005 §Initial-state `:entry` fires on machine bootstrap:
-      ;; the initial-state's `:entry` action runs once as part of
-      ;; bringing the actor to life. We open the host-side socket on
-      ;; bootstrap and transition immediately to `:open` via the
-      ;; `:always` slot once the socket is stored.
+      ;; The initial state's `:entry` runs once as the actor comes to
+      ;; life. We open the host-side socket here and transition straight
+      ;; to `:open` via the `:always` slot once the socket is stored.
       ;;
-      ;; The actor may also receive `:send` from the parent's
-      ;; `:send-auth` entry-action before its own bootstrap entry has
-      ;; settled — the `:send` override here picks up the just-stored
-      ;; host-side socket as soon as it lands.
+      ;; The actor may also receive `:send` from the parent's `:send-auth`
+      ;; entry action before its own entry has settled, so `:opening`
+      ;; handles `:send` too, picking up the just-stored socket.
       {:entry :open-socket
        :always [{:target :open}]
        :on    {:send       {:target :open
@@ -348,24 +324,22 @@
                        :action :forward-closed}}}
 
       :closed
-      ;; Terminal: the parent's exit-from-:active cascade destroys this
-      ;; actor; we don't need to do anything except absorb late events.
+      ;; Terminal. The parent's exit-from-:active cascade destroys this
+      ;; actor; this state just absorbs any late events.
       {}}})
 
 ;; ============================================================================
-;; REGISTRATIONS  (ns-load — the production-app idiom)
+;; REGISTRATIONS
 ;; ============================================================================
 
-;; The socket actor — Pattern-WebSocket §The connection state machine
-;; names this as the child actor the parent invokes. Use `rf/reg-machine`
-;; so the registration metadata carries `:rf/machine? true` (required
-;; by the spawn-fx's `resolve-spawn-machine` lookup).
+;; The socket actor the connection machine spawns. `rf/reg-machine` tags
+;; the registration `:rf/machine? true`, which the spawn-fx needs to
+;; resolve the spawn target.
 (rf/reg-machine :websocket/socket socket-actor-machine)
 
-;; Server-pushed events — Pattern-WebSocket §Server-pushed events.
-;; The connection machine dispatches [:ws/handle-message body] for
-;; every received message (correlated or server-pushed); this
-;; handler folds it into app-db for the views.
+;; The connection machine dispatches [:ws/handle-message body] for every
+;; received message (correlated reply or server push); this handler folds
+;; it into app-db for the views.
 (rf/reg-event :ws/handle-message
   {:doc "Translate an inbound `:ws/received` body into an app-db write.
          Records the message in the [:messages :received] log + stashes
@@ -391,38 +365,35 @@
     {:db (assoc-in db [:messages :draft] "")
      :fx [[:dispatch [:ws/connection [:ws/send {:type :note :body body}]]]]}))
 
-;; EP-0017: the request-id is a DURABLE correlation fact — it is written into
-;; the connection machine's :in-flight slot and the eventual reply is matched
-;; against it. A durable id must be a FOLDED FACT, never an ambient
-;; `(random-uuid)` read at the handler write site — otherwise replay mints a
-;; different id and the correlation no longer matches the recorded request.
-;; The app-owned generator is a RECORDABLE `reg-cofx`: the generator runs at
-;; context-assembly, the minted id is recorded onto the causal token, and
-;; replay re-presents it verbatim. `:ws.app/request` DECLARES it via
-;; `:rf.cofx/requires` and reads it flat from the coeffects map.
+;; The request-id is a durable correlation fact: it is written into the
+;; connection machine's :in-flight slot and the eventual reply is matched
+;; against it. A durable id must be a recorded fact, never an ambient
+;; `(random-uuid)` read at the handler write site — otherwise replay mints
+;; a different id and the correlation no longer matches the recorded
+;; request. So the generator is a recordable `reg-cofx`: it runs at
+;; context-assembly, its id is recorded on the event's causal token, and
+;; replay re-presents it verbatim. `:ws.app/request` declares it via
+;; `:rf.cofx/requires` and reads it from the coeffects map.
+;; See docs/guide/glossary.md#recordable-vs-ambient-coeffects.
 (rf/reg-cofx :ws.app/request-id
   {:recordable? true
-   :doc "Replayable correlation id for an outbound request-reply (EP-0017)."}
+   :doc "Replayable correlation id for an outbound request-reply."}
   (fn [] (random-uuid)))
 
 (rf/reg-event :ws.app/request
-  {:doc "Issue a request-reply via the connection machine's
-         correlation slot. The reply lands at [:messages :last-reply]
-         once the mock server echoes back. The correlation id is folded
-         from the `:ws.app/request-id` recordable coeffect (EP-0017),
-         never minted ambiently — replay re-presents the same id.
+  {:doc "Issue a request-reply via the connection machine's correlation
+         slot. The reply lands at [:messages :last-reply] once the mock
+         server echoes back. The correlation id comes from the
+         `:ws.app/request-id` recordable coeffect, never minted ambiently,
+         so replay re-presents the same id.
 
-         APP-LEVEL correlation, NOT the EP-0011 uniform reply envelope.
-         re-frame2 deliberately does not ship a managed
-         WebSocket (Pattern-WebSocket / Managed-Effects §WebSocket), so a
-         per-message request/reply over the open socket is a
-         Pattern-AsyncEffect interaction whose correlation the app owns:
-         a per-message `:request-id`, a registered `:reply` event target,
-         and the connection machine's `:in-flight` map. This is the
-         spec-blessed app/library convention — it is intentionally NOT the
-         framework's `:rf/reply-to` + reply-map vocabulary (property 9 is
-         exempt for the WebSocket surface). The wire `:request-id` is
-         app-level protocol correlation, not the EP-0011 `:work/id`."
+         This is app-level correlation, not a framework reply envelope.
+         re-frame2 does not ship a managed WebSocket, so a per-message
+         request/reply over the open socket is correlation the app owns: a
+         per-message `:request-id`, a registered `:reply` event target, and
+         the connection machine's `:in-flight` map. The wire `:request-id`
+         is app-level protocol correlation, deliberately separate from the
+         framework's own reply vocabulary."
    :rf.cofx/requires [:ws.app/request-id]}
   (fn handler-app-request [{rid :ws.app/request-id} [_ body]]
     {:fx [[:dispatch [:ws/connection
@@ -435,9 +406,8 @@
 (rf/reg-event :ws.app/request-reply
   {:doc "Reply event fired by the connection machine's :register-request
          flow once the correlated reply lands. The arg is the app's own
-         reply BODY (the server echo), not an EP-0011 reply map — this is
-         the app-level Pattern-WebSocket correlation shape, outside the
-         uniform reply envelope (see :ws.app/request)."}
+         reply body (the server echo) — the app-level correlation shape
+         (see :ws.app/request)."}
   (fn handler-app-request-reply [{:keys [db]} [_ body]]
     {:db (assoc-in db [:messages :last-reply] body)}))
 

--- a/examples/reagent/websocket/schema.cljs
+++ b/examples/reagent/websocket/schema.cljs
@@ -1,21 +1,19 @@
 (ns websocket.schema
-  "Malli schemas for the WebSocket example (Pattern-WebSocket worked
-   example).
+  "Malli schemas for the WebSocket example.
 
    Two slices are described:
 
-   - The `:ws/connection` machine's `:data` map. Pattern-WebSocket §The
-     connection state machine — the canonical fields used by the
-     connection lifecycle: `:url`, `:auth-token`, retry counters,
-     `:socket-id` (the address of the currently-live socket actor),
-     `:subscriptions`, the offline send `:queue`, and the request-reply
-     `:in-flight` map. Attached as the `:ws/connection` machine's
-     `[:schemas :data]` (see `connection.cljs`) — the snapshot-`:data`
-     validation surface, symmetric with the boot/login siblings.
+   - The `:ws/connection` machine's `:data` map: `:url`, `:auth-token`,
+     retry counters, `:socket-id` (the address of the currently-live
+     socket actor), `:subscriptions`, the offline send `:queue`, and the
+     request-reply `:in-flight` map. Attached as the machine's
+     `[:schemas :data]` (see `connection.cljs`) — a machine's `:data` is
+     validated there, not via an app-schema.
+     See docs/machines/concepts.md#validating-a-machines-data.
 
-   - The `:messages` slice in app-db. The running app records every
-     received message in `[:messages :received]` so the UI can list
-     them; the form draft lives at `[:messages :draft]`."
+   - The `:messages` slice in app-db. The app records every received
+     message at `[:messages :received]` so the UI can list them; the form
+     draft lives at `[:messages :draft]`."
   (:require [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
@@ -26,9 +24,6 @@
 ;; ============================================================================
 ;; CONNECTION MACHINE :data SHAPE
 ;; ============================================================================
-;;
-;; Mirrors the worked example in spec/Pattern-WebSocket.md §Worked example
-;; — the same fields, the same defaults.
 
 (def InFlightEntry
   "Per request-reply correlation entry: the registered reply event and
@@ -46,19 +41,17 @@
    [:max-retries    :int]
    [:base-ms        :int]
    [:max-backoff-ms :int]
-   ;; The currently-live socket actor's id (gensym'd by the runtime at
-   ;; :spawn time; cleared on exit from :active). Pattern-StaleDetection's
-   ;; connection-epoch idiom — the live socket-id IS the epoch.
+   ;; The currently-live socket actor's id (allocated by the runtime at
+   ;; :spawn time; cleared on exit from :active). The connection-epoch:
+   ;; the live socket-id IS the epoch.
    [:socket-id      [:maybe :any]]
    [:subscriptions  [:set :any]]
    [:queue          [:vector :any]]
    [:in-flight      [:map-of :any InFlightEntry]]
    [:error          [:maybe :any]]
-   ;; Runtime-managed stamps — see
-   ;; implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
-   ;; (the `stamp-framework-data` fn, which stamps these framework-reserved
-   ;; keys into the spawned actor's initial :data). Optional because the
-   ;; parent machine never receives them — only spawned actors do.
+   ;; Runtime-stamped framework keys. The runtime writes these into a
+   ;; spawned actor's initial :data; optional here because the parent
+   ;; machine never receives them, only spawned actors do.
    [:rf/self-id     {:optional true} :any]
    [:rf/parent-id   {:optional true} :any]
    [:rf/invoke-id  {:optional true} :any]])
@@ -67,13 +60,13 @@
 ;; APP-DB SLICES
 ;; ============================================================================
 ;;
-;; The running app — separate from the connection machine — keeps a
-;; record of every received message + a draft for the outbound form.
+;; The app — separate from the connection machine — keeps a record of
+;; every received message plus a draft for the outbound form.
 
 (def Message
-  "Wire-shape of one message — either a server push (no :request-id) or
-   a correlated reply. The example uses a tiny ad-hoc envelope; the
-   pattern is wire-format-agnostic. `:rx-seq` is a UI-assigned monotonic
+  "Wire-shape of one message — either a server push (no :request-id) or a
+   correlated reply. The example uses a tiny ad-hoc envelope; the shape is
+   wire-format-agnostic. `:rx-seq` is a UI-assigned monotonic
    receive-sequence stamped by :ws/handle-message so the inbox can give
    each row a stable React :key (it is not part of the wire body)."
   [:map
@@ -87,25 +80,25 @@
    [:draft    :string]
    ;; Received-message log: newest-first so the view renders top-down.
    [:received [:vector Message]]
-   ;; Last correlated reply landed via :ws.app/request-reply (or via
+   ;; Last correlated reply, landed via :ws.app/request-reply (or via
    ;; :ws/handle-message for server pushes) — handy for the request-reply
-   ;; round-trip view + the headless test assertion.
+   ;; round-trip view and the test assertion.
    [:last-reply [:maybe :any]]
    ;; Monotonic counter feeding each message's stable :rx-seq.
    [:rx-count :int]])
 
 ;; ============================================================================
-;; SCHEMA REGISTRATIONS  (ns-load — the production-app idiom)
+;; SCHEMA REGISTRATIONS
 ;; ============================================================================
 
-;; EP-0001: machine snapshots are runtime-db state, not app-db —
-;; an `reg-app-schema` on a machine-snapshot path validates nothing (app
-;; schemas validate the app-db partition only, Mike ruling #11). The
-;; machine's own `[:schemas :data]` is the snapshot-validation surface; no
-;; app-schema reg is wired on the snapshot path.
+;; Only the app-db `:messages` slice gets an app-schema. A machine snapshot
+;; is runtime-db, not app-db, so an `reg-app-schema` on a snapshot path
+;; would validate nothing; the connection machine's own `[:schemas :data]`
+;; covers that instead.
 ;;
-;; EP-0002: reg-app-schema is context-required frame-local; a
-;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
-;; the :rf/default frame, so name it explicitly here.
+;; `reg-app-schema` is frame-local and needs a frame in scope; a bare
+;; ns-load call raises :rf.error/no-frame-context. This example runs in the
+;; :rf/default frame, so name it explicitly.
+;; See docs/guide/glossary.md#frame-handle.
 (with-frame :rf/default
   (rf/reg-app-schema [:messages]                   {:schema MessagesSlice}))

--- a/examples/reagent/websocket/views.cljs
+++ b/examples/reagent/websocket/views.cljs
@@ -1,28 +1,27 @@
 (ns websocket.views
-  "Views for the Pattern-WebSocket example.
+  "Views for the WebSocket example.
 
-   The UI is intentionally minimal so the connection-machine drama is
-   the visible thing: a status indicator driven by the machine's tag
-   union, a connect/disconnect/drop trio of buttons, a send form, a
+   The UI is minimal so the connection machine is the visible thing: a
+   status indicator driven by the machine's tag union, a
+   connect/disconnect/drop trio of buttons, a send form, a
    subscribe-and-request demo trio, and a scrolling list of received
    messages.
 
-   Two things to notice as you read the views:
+   Two things to notice:
 
    1. The status indicator branches on the connection machine's state
       tags — `:websocket/connecting`, `:websocket/authenticating`,
       `:websocket/connected`, `:websocket/reconnecting`,
-      `:websocket/failed`. It reads them through this example's own
-      per-tag subs (`:ws/connected?` and friends in `connection.cljs`,
-      each a `contains?` over the snapshot's `:tags` union — the same
-      containment question the framework's `:rf/machine-has-tag?` sub
-      answers). Every pill branch is tag-driven, so the view never needs
-      to know *which* leaf carries the `:connected` intent — only that
-      the tag is present. This is what state tags buy: ask, don't tell.
+      `:websocket/failed`. It reads them through this example's per-tag
+      subs (`:ws/connected?` and friends in `connection.cljs`, each a
+      `contains?` over the snapshot's `:tags` union). The view never needs
+      to know which leaf carries the `:connected` intent, only that the
+      tag is present: ask, don't tell.
+      See docs/machines/glossary.md#state-tag.
 
-   2. The send form's `disabled` attribute is driven by the explicit
-      `:ws/connected?` sub rather than a `cond` over the snapshot's raw
-      hierarchical `:state` vector — same idea, friendlier ergonomics."
+   2. The send form's `disabled` attribute is driven by the `:ws/connected?`
+      sub rather than a `cond` over the raw hierarchical `:state` vector —
+      same idea, friendlier ergonomics."
   (:require [re-frame.core :as rf]
             [re-frame.views]
             [websocket.messages]
@@ -34,16 +33,16 @@
 ;; ============================================================================
 
 (reg-view ^{:doc "Reads the connection machine's state-tag union (through
-                  this example's per-tag subs) and renders a single
-                  status pill. The view's render priority — failed >
-                  reconnecting > connected > connecting > disconnected —
-                  collapses the multi-tag union to one visible word.
+                  this example's per-tag subs) and renders a single status
+                  pill. The render priority — failed > reconnecting >
+                  connected > connecting > disconnected — collapses the
+                  multi-tag union to one visible word.
 
-                  A sibling `:ws-reconnect-attempts` counter surfaces
-                  the machine's `:retries` slot directly — this lets a
-                  test assert the reconnect counter advanced after a
-                  Drop click without relying on catching the transient
-                  RECONNECTING window in the pill text."}
+                  A sibling `:ws-reconnect-attempts` counter shows the
+                  machine's `:retries` slot directly, so a test can assert
+                  the reconnect counter advanced after a Drop click without
+                  having to catch the transient RECONNECTING window in the
+                  pill text."}
           status-pill []
   (let [connected?      @(subscribe [:ws/connected?])
         authenticating? @(subscribe [:ws/authenticating?])
@@ -62,11 +61,10 @@
        :else           [:span.pill.disconnected   "DISCONNECTED"])
      (when err
        [:span.error {:data-testid "ws-error"} (str " — " (pr-str err))])
-     ;; Always-visible counter (independent of the pill's transient
-     ;; RECONNECTING window). The spec asserts this advances after a
-     ;; Drop click — proves the reconnect machinery actually ran rather
-     ;; than vacuously passing when the cascade resolves too fast for
-     ;; the pill to catch.
+     ;; Always-visible counter, independent of the pill's transient
+     ;; RECONNECTING window. A test asserts this advances after a Drop
+     ;; click, proving the reconnect machinery ran even when the cascade
+     ;; resolves too fast for the pill to catch.
      [:span.reconnect-attempts {:data-testid "ws-reconnect-attempts"}
       (str retries)]]))
 
@@ -85,12 +83,12 @@
         reconnecting? @(subscribe [:ws/reconnecting?])
         failed?       @(subscribe [:ws/failed?])
         any-active?   (or connected? reconnecting?)
-        ;; EP-0002: the Drop button calls a module-level
-        ;; mock-server seam that dispatches outside any drain / render scope.
-        ;; Capture this view's frame handle at render time and hand it to the
-        ;; seam so the deferred dispatch carries the frame (Spec 002
-        ;; §frame-handle) — a bare ambient dispatch would raise
+        ;; The Drop button calls a module-level mock-server seam that
+        ;; dispatches outside any render scope. Capture this view's frame
+        ;; handle at render time and hand it to the seam so the deferred
+        ;; dispatch carries the frame; a bare dispatch would raise
         ;; :rf.error/no-frame-context.
+        ;; See docs/guide/glossary.md#frame-handle.
         handle        (rf/frame-handle)]
     [:div.lifecycle
      [:button {:data-testid "ws-connect"
@@ -151,10 +149,10 @@
           demo-buttons []
   (let [connected?  @(subscribe [:ws/connected?])
         last-reply  @(subscribe [:messages/last-reply])
-        ;; EP-0002: the server-push button calls a module-level
-        ;; mock-server seam that dispatches outside any drain / render scope.
-        ;; Capture this view's frame handle and pass it so the deferred
-        ;; dispatch carries the frame (see `lifecycle-buttons`).
+        ;; The server-push button calls a module-level mock-server seam
+        ;; that dispatches outside any render scope. Capture this view's
+        ;; frame handle and pass it so the deferred dispatch carries the
+        ;; frame (see `lifecycle-buttons`).
         handle      (rf/frame-handle)]
     [:div.demo-buttons
      [:button {:data-testid "ws-subscribe"
@@ -202,11 +200,11 @@
 (reg-view ^{:doc "Root view of the websocket example app."}
           root-view []
   [:div.app
-   [:h1 "Pattern-WebSocket — connection machine"]
+   [:h1 "WebSocket — connection machine"]
    [:p.muted
-    "A worked example of the canonical re-frame2 WebSocket lifecycle "
-    "(see spec/Pattern-WebSocket.md). The transport is a tiny in-process "
-    "mock server — no network required."]
+    "A worked example of a re-frame2 WebSocket lifecycle modelled as a "
+    "state machine. The transport is a tiny in-process mock server — no "
+    "network required."]
    [status-pill]
    [lifecycle-buttons]
    [:hr]

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -1,36 +1,35 @@
 (ns counter-uix.core
-  "UIx variant of the counter example.
+  "The counter, rendered on the UIx substrate.
 
-   Same dataflow as examples/reagent/counter, rendered through the UIx
-   adapter — React hooks rather than Reagent's reactive atoms. The point
-   is the substrate boundary: everything above the view layer is the
-   Reagent counter's code verbatim, and the only thing that moves is how
-   a component reads state and gets hold of `dispatch`. Demonstrates:
+   UIx is plain React with hooks, so this is the same app as the Reagent
+   counter with one thing changed: how a view reads state and gets hold of
+   `dispatch`. Everything above the view layer — the events and the
+   subscription — is substrate-agnostic and looks the same on any substrate.
 
-     - `reg-event` / `reg-sub` (substrate-agnostic — identical to Reagent)
+   Shows:
+
+     - `reg-event` / `reg-sub` — the same on every substrate
      - `rf/init!` with the UIx adapter
-     - `use-subscribe` hook (the UIx-idiomatic subscription read)
-     - `(:dispatch (rf/frame-handle))` for click handlers — a UIx
-       component reads dispatch and subscriptions off explicit calls
-     - frame resolution via React context — `use-subscribe` and the
-       `frame-handle` capture read the surrounding frame-provider
+     - `use-subscribe`, the UIx-idiomatic way to read a subscription
+     - `(:dispatch (rf/frame-handle))` to dispatch from a click handler
+     - the frame-provider, which scopes the app frame to the view subtree
+       so `use-subscribe` and `frame-handle` resolve to it
 
-   A separate folder from examples/reagent/counter so the canonical
-   Reagent counter is undisturbed; bundle isolation is verified by the
-   per-example shadow-cljs builds and the production-elision grep."
+   For the full substrate tour see
+   `docs/guide/how-to/use-uix-helix-or-slim.md`."
   (:require [uix.core :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core    :as rf]
             [re-frame.adapter.uix :as uix-adapter]))
 
-;; -- Events / subs (the registrar is process-global) -------------------------
+;; -- Events / subs -----------------------------------------------------------
 ;;
-;; Each handler is a pure (coeffects, event-vector) -> effect map fn: it
-;; returns `{:db …}` ("replace app-db with this") and the runtime commits
-;; it atomically at the end of the cascade. This whole block is identical
-;; to the Reagent and Helix counters — same ids, same bodies. That
-;; sameness is the cross-substrate parity: events and subs are pure data
-;; and logic, independent of whichever substrate renders the views.
+;; An event handler is a pure function from coeffects (which carry the
+;; current app-db) and the event vector to an effect map. The `{:db …}` key
+;; means "replace app-db with this value"; the runtime commits it atomically
+;; at the end of the cascade. This block is pure data and logic with no
+;; mention of React, so it is identical on every substrate. See
+;; `docs/guide/glossary.md#event-handler`.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -46,13 +45,13 @@
 
 ;; -- Views (the only substrate-specific code in this file) -------------------
 ;;
-;; Everything above is shared with the Reagent and Helix counters; the
-;; substrate boundary is here. UIx is plain React, so a view is a `defui`
-;; component that reads what it needs explicitly: `use-subscribe` is a
-;; hook that reads a subscription, and `dispatch` comes off a
-;; `(rf/frame-handle)`. The handle captures the in-scope frame as a value,
-;; so the closed-over `dispatch` still targets this frame when a click
-;; fires later. Grab it at render time, while the frame is in scope.
+;; UIx is plain React, so a view is a `defui` component that reads what it
+;; needs explicitly. `use-subscribe` is a hook that reads a subscription.
+;; `dispatch` comes off a `(rf/frame-handle)`: the handle captures the
+;; in-scope frame as a value, so the closed-over `dispatch` still targets
+;; this frame when a click fires later, on a stack with no frame in scope.
+;; Grab it at render time, while the frame is in scope. See
+;; `docs/guide/glossary.md#frame-handle`.
 
 (defui counter-buttons []
   (let [count    (uix-adapter/use-subscribe [:counter/value])
@@ -67,31 +66,33 @@
 
 ;; -- Mount -------------------------------------------------------------------
 ;;
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; The React root is held in an atom and created lazily inside `run`, not at
+;; ns-load. Loading a namespace must produce no DOM side effects, so that
+;; co-required example namespaces don't race `create-root` onto the shared
+;; `#app`. See examples/TESTING.md, "mount-isolation".
 
 (defonce react-root (atom nil))
 
-;; The whole frame lifecycle lives in one spot at the render root: the
-;; `frame-provider {:id app-frame …}` below. On first mount it creates the
-;; app frame, applies its config, and runs `:initial-events` once to seed
-;; app-db. That context is what lets the `use-subscribe` hook and the
-;; render-time `(rf/frame-handle)` capture resolve to the app frame. On hot
-;; reload the provider reuses the existing frame and skips re-seeding, so
-;; the counter keeps its value across re-mounts. (Render a UIx tree with no
-;; provider and `use-subscribe` / `frame-handle` raise
-;; `:rf.error/no-frame-context` — the app must establish its frame.)
+;; The whole frame lifecycle lives in one spot: the `frame-provider {:id
+;; app-frame …}` in `run` below. The first mount creates the app frame and
+;; runs its `:initial-events` once to seed app-db. From then on the
+;; `use-subscribe` hook and the render-time `(rf/frame-handle)` capture
+;; resolve to that frame. A later mount under the same `:id` (a hot reload)
+;; reuses the live frame and does not re-seed, so the counter keeps its
+;; value. Render a UIx tree with no provider and `use-subscribe` /
+;; `frame-handle` raise `:rf.error/no-frame-context` — the app must
+;; establish its frame. See `docs/guide/concepts/frames.md`.
 ;;
 ;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
-;; with no framework privilege — the runtime won't infer it, so we name it
-;; here and hand it to the provider like any other id.
+;; with no special status: the runtime never infers a frame, so we name one
+;; here and hand it to the provider. See
+;; `docs/guide/glossary.md#frame-identity-is-carried-not-found`.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the UIx reactive adapter for the process. Each adapter
-  ;; ns exports an `adapter` var; require the ns and pass that var directly.
+  ;; `init!` installs the reactive adapter for the process. Each adapter ns
+  ;; exports an `adapter` var; require the ns and pass that var. Call once
+  ;; at startup. See `docs/guide/glossary.md#init`.
   (rf/init! uix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -1,7 +1,6 @@
 (ns dashboard-uix.core
-  "UIx design-led example — 'Analytics Dashboard'. A grid of metric cards
-   + sparklines + filter chips. Proves re-frame2 + UIx can build a
-   substantive UI.
+  "UIx design-led example — an analytics dashboard: a grid of metric
+   cards with sparklines and filter chips.
 
    The one idea: two independent controls each set a single value in
    app-db, and one `reg-sub` reads both and computes the visible card
@@ -21,15 +20,10 @@
        time-range picker (how many trailing points each sparkline draws,
        plus the header label)
 
-   No HTTP, no state machines — design-led examples exist to prove
-   polished visuals + interaction, not to replay platform features
-   other examples already cover. Distinct shape from the Reagent
-   'Notebook' (3-pane editor) and Helix 'Process Monitor' (terminal
-   log viewer) — three different substantive UIs, one per substrate.
+   The derivation graph is the core concept here; see the guide glossary
+   (../../../docs/guide/glossary.md#the-derivation-graph).
 
-   The shared 'Editorial Warm' visual identity comes from
-   examples/_shared/css/style.css — one identity across all three
-   substrates."
+   The shared visual identity comes from examples/_shared/css/style.css."
   (:require [uix.core :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core            :as rf]
@@ -41,12 +35,10 @@
 
 (def initial-metrics
   ;; Each metric carries a 14-point sparkline series. Numbers are
-  ;; hand-tuned for visual variety; nothing here is computed from a real
-  ;; source — the example proves dataflow + render, not analytics
-  ;; correctness.
+  ;; hand-tuned for visual variety, not computed from real data.
   ;;
-  ;; CLJS doesn't support Clojure's underscore-grouping (1_000) literal
-  ;; syntax; values are bare integers.
+  ;; Values are bare integers: CLJS has no underscore-grouping (1_000)
+  ;; literal syntax.
   [{:id :revenue   :label "Revenue"       :value 142375 :unit "$" :delta  0.084 :tag :money
     :series [108 112 117 121 119 124 128 132 130 135 138 140 142 142]}
    {:id :signups   :label "New signups"   :value 1286   :unit ""  :delta  0.121 :tag :money
@@ -69,8 +61,7 @@
   ;; Time-range options. `:points` is how many of each metric's 14-point
   ;; series the range windows in to (the last N) — so picking a range
   ;; re-derives both the header label and every sparkline. Capped at the
-  ;; 14 points the seed data actually carries; we don't fabricate history
-  ;; we don't have.
+  ;; 14 points the seed data carries.
   [{:id :w7  :label "7 days"  :points 7}
    {:id :w14 :label "14 days" :points 14}])
 
@@ -79,9 +70,8 @@
 ;; ============================================================================
 
 ;; Each handler is pure: (coeffects, event-vector) -> effect map. Each moves
-;; ONE value in app-db and stops. The cards, sparklines, and grid all follow
-;; downstream from the subscription — turning "this tag is now off" into
-;; "these cards disappear" is the subscription's job, not the handler's.
+;; ONE value in app-db and stops. Turning "this tag is now off" into "these
+;; cards disappear" is the subscription's job, not the handler's.
 
 ;; Seed the whole dashboard in one write: the metrics plus the two control
 ;; values (`:active-tags` a set — chips are multi-select; `:range` one id).
@@ -165,12 +155,10 @@
 
 (defui sparkline [{:keys [series id]}]
   ;; The card's <header> eyebrow, value, and label already carry the
-  ;; metric's name + current value as text, so the sparkline is a
-  ;; decorative restatement of that information for assistive tech.
-  ;; `aria-hidden="true"` (rather than a generic `role="img"`
-  ;; `aria-label="sparkline"`) keeps a screen reader from announcing a
-  ;; nameless graphic on every card — the accessible name lives on the
-  ;; surrounding text, which is where the information actually is.
+  ;; metric's name and value as text, so the sparkline only restates that
+  ;; visually. Mark it `aria-hidden="true"` so a screen reader skips it
+  ;; rather than announcing a nameless graphic on every card; the
+  ;; accessible name lives on the surrounding text.
   ($ :svg.dash-sparkline
      {:viewBox "0 0 100 30"
       :preserveAspectRatio "none"
@@ -339,17 +327,16 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
-;; This matches the sibling notebook / process_monitor_helix mount shape.
+;; The React root is held in an atom and materialised lazily inside `run`,
+;; not at ns-load. ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`
+;; (examples/TESTING.md, Example mount-isolation convention).
 (defonce react-root (atom nil))
 
-;; The frame id this app runs under. The `frame-provider` at the render root
-;; (in `run` below) does the frame work: it creates this frame, seeds app-db,
-;; and scopes the frame into React context for `use-subscribe` and
-;; `(rf/frame-handle)`.
+;; The frame id this app runs under. The `frame-provider` in `run` creates
+;; this frame, seeds its app-db, and scopes it into React context so
+;; `use-subscribe` and `(rf/frame-handle)` resolve to it. See the guide
+;; glossary (../../../docs/guide/glossary.md#frame-provider).
 (def app-frame :rf/default)
 
 (defn run []
@@ -358,10 +345,9 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
-    ;; The `frame-provider` is the one spot the frame is set up. `{:id …}`
-    ;; creates the app frame on first mount and runs `:initial-events` once
-    ;; to seed app-db; a hot reload reuses the same frame without re-seeding.
-    ;; Everything under it reads from this frame.
+    ;; `{:id …}` creates the app frame on first mount and runs
+    ;; `:initial-events` once to seed app-db. A hot reload reuses the same
+    ;; frame without re-seeding.
     (uix-dom/render-root
       ($ uix-adapter/frame-provider {:id app-frame
                                      :initial-events [[:dashboard/initialise]]}

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -1,23 +1,21 @@
 (ns login-uix.core
-  "UIx variant of the login example — the same feature, a different substrate.
+  "UIx variant of the login example — the same feature on a different substrate.
 
-   Everything below the views carries the same ids and the same registered
-   shapes as examples/reagent/login: the Spec 005 state machine, the Spec 010
-   schemas, and the Spec 014 managed-HTTP effect. Only the view layer changes idiom —
-   here views are UIx `defui` components that read subscriptions via the
-   `use-subscribe` hook, where the Reagent twin used `reg-view`. The point of
-   the file is to show exactly how narrow the substrate boundary is: the
-   machine, schemas, and effects are substrate-agnostic.
+   Everything below the views is substrate-agnostic and identical to
+   examples/reagent/login: the login state machine, the schemas, and the
+   managed-HTTP effect. Only the view layer differs. Here views are UIx
+   `defui` components that read subscriptions with the `use-subscribe` hook;
+   the Reagent twin uses `reg-view`. The file shows how narrow the substrate
+   boundary is — the machine, schemas, and effects don't change at all.
 
-   Cross-substrate parity is exercised end-to-end: machine states carry
-   Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`, `:auth/locked`)
-   and views read them via the `:rf/machine-has-tag?` framework sub —
-   same tag taxonomy as the state-machines walkthrough, only the
-   substrate's hook idiom differs. The terminal `:locked-out` state is
-   surfaced as a non-interactive locked-account panel.
+   The machine's states carry tags (`:auth/busy`, `:auth/authenticated`,
+   `:auth/locked`), and views read them via the `:rf/machine-has-tag?`
+   framework sub. The terminal `:locked-out` state renders a non-interactive
+   locked-account panel.
 
-   UIx views are plain `defui` components: each one reads its subscriptions
-   with the `use-subscribe` hook and pulls `dispatch` off `(rf/frame-handle)`."
+   For the substrate-boundary mechanics — `use-subscribe`, `frame-handle`,
+   `frame-provider`, and what stays the same across React wrappers — see
+   docs/guide/how-to/use-uix-helix-or-slim.md."
   (:require [uix.core :as uix :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core :as rf]
@@ -37,39 +35,36 @@
 ;; Shape of valid login credentials: an email and a min-8 password. The
 ;; password only ever rides this event-arg schema and the HTTP body — it is
 ;; never written to app-db. The request body that carries it is scrubbed from
-;; traces by `:sensitive? true` on the managed-HTTP request below (Spec 014
-;; §Privacy). Same schema across reagent/login + helix.
+;; traces by `:sensitive? true` on the managed-HTTP request below
+;; (docs/guide/how-to/keep-secrets-out-of-traces.md). Same schema across
+;; reagent/login + helix.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
    [:password [:string {:min 8}]]])
 
-;; Outer event-vector schema for the :auth.login/flow machine handler —
-;; see examples/reagent/login for the full rationale. The :submit
-;; sub-event is validated STRICTLY against `Credentials`; framework-internal
-;; sub-events (:dismiss, :success, :failure) admit a framework-controlled
-;; tail.
+;; Outer event-vector schema for the :auth.login/flow machine handler. The
+;; :submit sub-event is validated STRICTLY against `Credentials`;
+;; framework-internal sub-events (:dismiss, :success, :failure) admit a
+;; framework-controlled tail.
 ;;
 ;; The :submit branch is a `:tuple` (NOT `:cat`): the outer `:cat` consumes
 ;; the nested sub-event vector as a SINGLE element, so the branch must match
-;; that one element AS a vector. A `:cat` branch would apply sequence-regex
-;; semantics and — paired with a permissive `[:vector :any]` fallback —
-;; silently re-admit a `:submit` whose `Credentials` failed (the original
-;; bug: malformed submit payloads passed the `:where :event` boundary). With
-;; the strict `:tuple` and no `[:vector :any]` escape hatch, a short-password
-;; or bad-email submit is rejected at the boundary BEFORE the machine
-;; transitions or issues the login HTTP effect (Spec 010 §Validation order
-;; step 1, recovery `:no-recovery`).
+;; that one element AS a vector. A `:cat` branch applies sequence-regex
+;; semantics and would re-admit a `:submit` whose `Credentials` failed. With
+;; the strict `:tuple`, a short-password or bad-email submit is rejected at
+;; the `:where :event` boundary BEFORE the machine transitions or issues the
+;; login HTTP effect (docs/guide/how-to/validate-with-schemas.md, §"Put a
+;; schema on the event too").
 ;;
-;; The trailing `[:? :any]` admits the managed-HTTP reply payload (Spec
-;; 014 §Reply addressing): the framework appends `{:kind ... :value ...}`
-;; / `{:kind ... :failure ...}` as the LAST arg of the explicit
-;; `:on-success` / `:on-failure` event vector, so the delivered reply is
+;; The trailing `[:? :any]` admits the managed-HTTP reply payload. The
+;; framework appends the reply map (`{:kind ... :value ...}` /
+;; `{:kind ... :failure ...}`) as the LAST arg of the explicit `:on-success`
+;; / `:on-failure` event vector, so the delivered reply is
 ;; `[:auth.login/flow [:auth.login/success] <payload>]` — three top-level
 ;; elements. Without the optional trailing slot the `:cat` rejects every
-;; reply with `:malli.core/input-remaining`, the boundary validation
-;; fails BEFORE the machine handler runs, and the flow is stranded in
-;; `:submitting`.
+;; reply and the boundary validation fails before the machine handler runs.
+;; See docs/guide/glossary.md#the-uniform-reply.
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
@@ -80,16 +75,13 @@
 
 ;; The machine's `[:schemas :data]` validates the machine's `:data` slot ONLY —
 ;; the user-domain extended state `{:attempts ... :error ...}` — NOT the whole
-;; `{:state ... :data ...}` snapshot. Per Spec 005 §Schema validation
-;; (005-StateMachines.md:182, :200, :429-435) and Spec 010
-;; (010-Schemas.md:52, :162, :178): `[:schemas :data]` sits as a top-level key on
-;; the machine spec map beside `:data`, and the framework validates it at every
-;; macrostep-commit boundary + at bootstrap, emitting
-;; `:rf.error/schema-validation-failure :where :machine-data` and rolling back
-;; the cascade on a violation. The snapshot's `:state` slot is validated
-;; structurally at registration time (an unknown target fails registration),
-;; so it is NOT this schema's job — describing the whole snapshot here would
-;; be the wrong shape for the slot the framework actually validates.
+;; `{:state ... :data ...}` snapshot. It sits as a top-level key on the machine
+;; spec map beside `:data`, and the framework checks it after every transition
+;; and at boot, emitting `:rf.error/schema-validation-failure :where
+;; :machine-data` and rolling the macrostep back on a violation. The `:state`
+;; slot is validated structurally at registration (an unknown target fails
+;; registration), so it is not this schema's job. See
+;; docs/guide/how-to/validate-with-schemas.md (the machine `:data` schema).
 (def AuthLoginData
   [:map
    [:attempts {:default 0} :int]
@@ -114,14 +106,12 @@
       (.setItem ls "auth/token" token))))
 
 (rf/reg-fx :auth.login.demo/managed-stub
-  {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
-               to the Reagent and Helix examples' stub — delegates straight
-               to the framework-shipped canned-success / canned-failure
-               fxs with `:after-ms`, so the framework defers the reply via
-               `:dispatch-later` (50 ms) — observable in the tape,
-               time-travel-safe, NOT raw `js/setTimeout`. The `:after-ms`
-               parameter carries the schedule-reply → `:dispatch-later` →
-               deliver-reply chain as one arg on the canned effect."
+  {:doc       "Demo override for `:rf.http/managed`. Delegates to the
+               framework-shipped canned-success / canned-failure fxs with
+               `:after-ms`, so the framework defers the reply via
+               `:dispatch-later` (50 ms): observable in the tape and
+               time-travel-safe, NOT a raw `js/setTimeout`. Same stub as the
+               Reagent and Helix examples."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -151,9 +141,9 @@
 ;; STATE MACHINE
 ;; ============================================================================
 
-;; The login flow's machine spec. `[:schemas :data]` is the machine-level
-;; schema map's data entry (Spec 005 §Schema validation) — it validates the
-;; `:data` slot (`{:attempts ... :error ...}`), NOT the whole snapshot.
+;; The login flow's machine spec. `[:schemas :data]` validates the `:data`
+;; slot (`{:attempts ... :error ...}`), NOT the whole snapshot — see the note
+;; on `AuthLoginData` above.
 (def auth-login-machine
   {:initial :idle
    :data    {:attempts 0 :error nil}
@@ -170,11 +160,10 @@
     :issue-request
     (fn [{[_ creds] :event}]
       {:fx [[:rf.http/managed
-             ;; Spec 014 §Privacy (per-request `:sensitive?`): `:sensitive? true`
-             ;; redacts the request body (carrying the `:password`) from every
-             ;; `:rf.http/*` trace event — the coarse per-request wire scrub, a
-             ;; distinct surface from EP-0025 path classification (see
-             ;; examples/reagent/login for the full rationale).
+             ;; `:sensitive? true` redacts the request body (which carries the
+             ;; `:password`) from every `:rf.http/*` trace event — the
+             ;; per-request wire scrub. See
+             ;; docs/guide/how-to/keep-secrets-out-of-traces.md.
              {:request    {:method :post
                            :url    "/api/login"
                            :body   creds
@@ -191,13 +180,12 @@
                  (assoc :error (or (:message failure) "Login failed.")))})
 
     :lock-account
-    ;; Fire-and-forget telemetry beacon (Spec 014 §Reply addressing
-    ;; "Silenced"): the lockout POST wants no reply folded back into the
-    ;; machine. `:on-success nil` / `:on-failure nil` silence both reply
-    ;; branches explicitly — without them the omitted-target default
-    ;; (co-located addressing) would dispatch
-    ;; `[:auth.login/flow {:rf/reply ...}]`, a map in the sub-event slot
-    ;; that `AuthLoginEvent` rejects, stranding noise after lockout.
+    ;; Fire-and-forget telemetry beacon: the lockout POST wants no reply
+    ;; folded back into the machine. `:on-success nil` / `:on-failure nil`
+    ;; silence both reply branches. Without them the default reply target
+    ;; would dispatch `[:auth.login/flow {:rf/reply ...}]` — a map in the
+    ;; sub-event slot that `AuthLoginEvent` rejects, stranding noise after
+    ;; lockout. See docs/resources/glossary.md#managed-http.
     (fn [_]
       {:fx [[:rf.http/managed
              {:request    {:method :post :url "/api/auth/lock"}
@@ -248,54 +236,51 @@
     ;; :auth/locked tag — after the fourth failed submit the flow lands
     ;; in this terminal state. Views query
     ;; [:rf/machine-has-tag? :auth.login/flow :auth/locked] to swap the
-    ;; form for a locked-account panel and refuse further submits — same
-    ;; tag + locked-panel pattern as the state-machines walkthrough. A
+    ;; form for a locked-account panel and refuse further submits. A
     ;; terminal lockout must be visible and non-interactive, not a live
     ;; form.
     {:tags #{:auth/locked}
      :meta {:terminal? true}}}})
 
-;; Register the machine (Spec 005 §reg-machine). This flow validates on two
-;; surfaces: the machine's `:data` slot via `[:schemas :data]`, and the
-;; dispatched event vector via `:schema` (`AuthLoginEvent`, the `:where :event`
-;; boundary). The opts map carries the event `:schema` alongside the machine
-;; spec, and `reg-machine` stamps the `:rf/machine` metadata that makes the
-;; `[:schemas :data]` validation live.
+;; Register the machine. This flow validates on two surfaces: the machine's
+;; `:data` slot via `[:schemas :data]`, and the dispatched event vector via
+;; `:schema` (`AuthLoginEvent`, the `:where :event` boundary). The opts map
+;; carries the event `:schema` alongside the machine spec. See
+;; docs/machines/glossary.md#machine.
 (rf/reg-machine :auth.login/flow
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema AuthLoginEvent}
   auth-login-machine)
 
 ;; ============================================================================
-;; FORM SLICE  (Pattern-Forms — substrate-agnostic)
+;; FORM SLICE  (the form pattern — substrate-agnostic)
 ;; ============================================================================
 ;;
-;; The FORM-SLICE events below are the other half of the Pattern-Forms
-;; "machine + slice" composition (spec/Pattern-Forms.md §Variations). The
-;; SLICE owns the DRAFT — what the user is currently typing — at the app-db
-;; path [:auth :login-form]; the MACHINE owns submit/auth STATUS. A form's draft
-;; is application state, so it lives in app-db (projected via subs, mutated via
-;; events), not in a view-local atom or hook. Inputs are CONTROLLED: `:value`
-;; reads the draft sub, `:on-change` dispatches `:auth.login/edit-field`. The
-;; slice shape + the standard form events mirror the in-repo exemplar
-;; examples/reagent/realworld/auth.cljs 1:1.
+;; The FORM-SLICE events below are the other half of the "machine + slice"
+;; form pattern. The SLICE owns the DRAFT — what the user is currently typing —
+;; at the app-db path [:auth :login-form]; the MACHINE owns submit/auth STATUS.
+;; A form's draft is application state, so it lives in app-db (projected via
+;; subs, mutated via events), not in a view-local atom or hook. Inputs are
+;; CONTROLLED: `:value` reads the draft sub, `:on-change` dispatches
+;; `:auth.login/edit-field`. The recipe — slice shape, the seven standard form
+;; events, the touched-or-submitted error-visibility rule — is in
+;; docs/guide/how-to/build-a-form.md.
 ;;
 ;; This whole block — slice defaults + form events + (below) the draft/slice
-;; subs — is the SUBSTRATE-AGNOSTIC artefact layer: it is byte-identical
-;; across examples/reagent/login, examples/uix/login_uix, and
-;; examples/helix/login_helix (Spec 006 §Adapter shipping convention Decision
-;; 7). Only the view syntax varies across the three.
+;; subs — is the SUBSTRATE-AGNOSTIC layer: it is identical across
+;; examples/reagent/login, examples/uix/login_uix, and
+;; examples/helix/login_helix. Only the view syntax varies across the three.
 
 ;; The login form's default (empty) draft. The draft's value shape is
 ;; `Credentials` (email regex + min-8 password) — the same schema the
 ;; machine's `:submit` boundary enforces.
 (def login-form-defaults {:email "" :password ""})
 
-;; Seed the slice to its standard Pattern-Forms shape: empty `:draft`,
-;; `:status :idle`. Runs once via the frame-provider's `:initial-events`.
+;; Seed the slice to its standard shape: empty `:draft`, `:status :idle`.
+;; Runs once via the frame-provider's `:initial-events`.
 (rf/reg-event :auth.login/initialise-form
   {:doc "Seed the login-form slice at [:auth :login-form] to its standard
-         Pattern-Forms shape (empty draft, :idle status)."}
+         shape (empty draft, :idle status)."}
   (fn handler-login-form-initialise [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form]
                    {:draft             login-form-defaults
@@ -325,16 +310,15 @@
 ;; validated against `Credentials` at the machine's `:where :event` boundary).
 ;; The machine, not the slice, then owns the in-flight / authed / error /
 ;; locked status; the slice `:status` mirror keeps the slice a conformant
-;; Pattern-Forms shape.
+;; form-pattern shape.
 ;;
-;; Secret-field hygiene (skills/re-frame2/patterns/forms.md §Auth): the
-;; handler reads the password off the draft and hands it to the machine, then
-;; CLEARS `[:draft :password]` in the same commit — once the request is in
-;; flight the secret has done its job, so it does not sit in durable app-db
-;; waiting for the next snapshot / recorder capture. The password's only
-;; off-box path is the HTTP request body (scrubbed by the per-request
-;; `:sensitive? true` flag); it is never written to `:submitted` or the
-;; machine `:data`.
+;; Secret-field hygiene: the handler reads the password off the draft and hands
+;; it to the machine, then CLEARS `[:draft :password]` in the same commit —
+;; once the request is in flight the secret has done its job, so it does not
+;; sit in durable app-db waiting for the next snapshot / recorder capture. The
+;; password's only off-box path is the HTTP request body (scrubbed by the
+;; per-request `:sensitive? true` flag); it is never written to `:submitted` or
+;; the machine `:data`. See docs/guide/how-to/keep-secrets-out-of-traces.md.
 (rf/reg-event :auth.login/submit-form
   {:doc "Submit the login form: read the draft from the slice, dispatch it
          into the :auth.login/flow machine's :submit sub-event, and clear the
@@ -364,11 +348,10 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; The machine snapshot lives at [:rf.runtime/machines :snapshots :auth.login/flow] (per
-;; Spec 005). These named subs project out the convenient pieces. The
-;; "in :submitting?" / "in :authed?" predicates live as the
-;; `:rf/machine-has-tag?` framework sub in views below (per Spec 005
-;; §State tags).
+;; The machine snapshot lives in runtime-db. These named subs project out the
+;; convenient pieces. The "in :submitting?" / "in :authed?" predicates live as
+;; the `:rf/machine-has-tag?` framework sub in views below — see
+;; docs/machines/glossary.md#state-tag.
 
 ;; Machine snapshots are durable runtime-db state — read them through the
 ;; framework `:rf/machine` sub.
@@ -380,13 +363,13 @@
   :<- [:rf/machine :auth.login/flow]
   (fn [snapshot _] (get-in snapshot [:data :error])))
 
-;; --- Form-slice subs (Pattern-Forms; substrate-agnostic) -------------------
+;; --- Form-slice subs (substrate-agnostic) ----------------------------------
 ;;
 ;; The login-form slice lives at app-db [:auth :login-form]. The view reads
 ;; the DRAFT through `:auth.login/draft` and binds each input's `:value` to it
-;; — controlled inputs. The per-field-error sub follows the Pattern-Forms
-;; visibility rule (touched OR submit-attempted?). These subs are part of the
-;; byte-identical artefact layer shared across the three substrate examples.
+;; — controlled inputs. The per-field-error sub follows the form-pattern
+;; error-visibility rule (touched OR submit-attempted?). These subs are part of
+;; the layer shared identically across the three substrate examples.
 
 (rf/reg-sub :auth.login/form-slice
   {:doc "The whole login-form slice at [:auth :login-form]."}
@@ -401,9 +384,9 @@
     (:draft slice)))
 
 (rf/reg-sub :auth.login/field-error
-  {:doc "Per-field validation error for the login form. Per Pattern-Forms
-         §Error visibility: reveal a field's error once it is :touched OR once
-         the form has had its first submit click."}
+  {:doc "Per-field validation error for the login form. Reveal a field's error
+         once it is :touched OR once the form has had its first submit click.
+         See docs/guide/how-to/build-a-form.md, step 3."}
   :<- [:auth.login/form-slice]
   (fn sub-auth-login-field-error [slice [_ field]]
     (when (or (:submit-attempted? slice)
@@ -419,11 +402,11 @@
 ;; `(rf/frame-handle)`. The Reagent twin instead registers these with `reg-view`
 ;; and is handed `dispatch`/`subscribe`. The subscription vectors and event
 ;; vectors are identical — only the way a React component plugs into them differs.
+;; See docs/guide/how-to/use-uix-helix-or-slim.md.
 ;;
 ;; The inputs are controlled: each `:value` reads the draft from the
 ;; `:auth.login/draft` sub, and `:on-change` dispatches `:auth.login/edit-field`.
-;; The draft lives in app-db, so there is no `uix/use-state` here — the
-;; Pattern-Forms way.
+;; The draft lives in app-db, so there is no `uix/use-state` here.
 (defui login-form []
   (let [draft    (uix-adapter/use-subscribe [:auth.login/draft])
         busy?    (uix-adapter/use-subscribe [:rf/machine-has-tag?
@@ -502,10 +485,10 @@
     ;; to — those reads need a provider above them in the tree.
     ;;
     ;; `:initial-events` seeds the form SLICE ([:auth.login/initialise-form]) to
-    ;; its empty Pattern-Forms shape, so the controlled inputs read an empty
-    ;; draft (not nil) on the first render. The MACHINE needs no seeding: its
-    ;; `:initial`/`:data` seed [:rf.runtime/machines :snapshots :auth.login/flow]
-    ;; the first time the flow runs (Spec 005 §Restore semantics).
+    ;; its empty shape, so the controlled inputs read an empty draft (not nil) on
+    ;; the first render. The MACHINE needs no seeding: its `:initial`/`:data`
+    ;; seed the snapshot in runtime-db the first time the flow runs (see
+    ;; docs/machines/glossary.md#snapshot).
     (uix-dom/render-root
       ($ uix-adapter/frame-provider {:id              :rf/default
                                      :doc             "Login (UIx) demo frame."


### PR DESCRIPTION
Sweeps every example's comments and docstrings — one agent per example — with three aims:

1. **Simple + direct** — short, plain, one-idea sentences; lead with the point.
2. **No historical cruft** — removed `EP-NNNN` / `rf2-XXXXX` provenance tags, "before the refactor / used to / now that / no longer" narration, and migration stories. The comments describe what *is*, not how it got here.
3. **Point to the guide, not the spec** — re-pointed spec citations (`Spec 012`, `../../../spec/…`) to the human guide and glossaries (`docs/guide/glossary.md`, `docs/routing/…`, `docs/machines/…`, etc.) with verified anchors, since these are human-facing examples.

**76 files** — spec-refs and cruft live throughout each example (schema / routing / auth / http / views), not just `core`. Comments + docstrings only; no code, behaviour, build id, or run-command change.

Verified: `npm run test:examples-compile` passes (all builds, exit 0).