### PR TITLE
Examples: comments in the friendly senior-dev voice

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -1,42 +1,45 @@
 (ns counter-helix.core
-  "Counter, rendered with the Helix substrate.
+  "The counter, rendered on the Helix substrate.
 
-   The dataflow doesn't know which React-family library draws the pixels.
-   This counter runs the same events and subscription as the Reagent and
-   UIx counters; only the view and mount change. Here they render through
-   the Helix adapter, whose React state model is hooks all the way down.
-   It shows:
+   The dataflow couldn't care less which React library draws the pixels.
+   This is the same app as the Reagent and UIx counters — same events, same
+   subscription — with exactly one thing changed: how a view reads state and
+   gets hold of `dispatch`. Helix is React with hooks all the way down, so
+   here that part is a `defnc` component and a hook. Put this file beside the
+   other two counters and only the views differ; that seam is the whole point
+   of an adapter.
 
+   What you'll see here:
+
+     - `reg-event` / `reg-sub` — the same on every substrate
      - `rf/init!` with the Helix adapter
-     - `reg-event` / `reg-sub`, which are substrate-agnostic
-     - the `use-subscribe` hook, the Helix-idiomatic way to read a sub
-     - `(:dispatch (rf/frame-handle))` in click handlers — the component
-       reads its own sub and takes its own dispatch
+     - `use-subscribe`, the Helix-idiomatic way to read a subscription
+     - `(:dispatch (rf/frame-handle))` to dispatch from a click handler
 
-   See docs/guide/how-to/use-uix-helix-or-slim.md for the full walkthrough
-   of running one app on UIx or Helix."
+   For the full substrate tour see
+   `docs/guide/how-to/use-uix-helix-or-slim.md`."
   (:require ["react-dom/client" :as react-dom-client]
             [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]
             [re-frame.core      :as rf]
             [re-frame.adapter.helix :as helix-adapter]))
 
-;; ============================================================================
-;; SUBSTRATE-AGNOSTIC LAYER  (events + sub)
-;; ============================================================================
+;; -- Events / subs -----------------------------------------------------------
 ;;
-;; Everything above the SUBSTRATE BOUNDARY below is the dataflow: the events
-;; and the `:counter/value` subscription. It is identical across the Reagent,
-;; UIx, and Helix counters — same `:counter/*` ids, same handler bodies. The
-;; dataflow does not know which substrate renders it; that sameness is the
-;; whole point of the example.
+;; This is where the work happens, and it's all just data. An event handler is
+;; a pure function: hand it the coeffects (which carry the current app-db) and
+;; the event vector, and it hands back an effect map. The `{:db …}` key means
+;; "replace app-db with this value", and the runtime commits it atomically at
+;; the end of the cascade. Not a word about React in here — so this block is
+;; byte-for-byte the same as the Reagent and UIx counters. See
+;; `docs/guide/glossary.md#event-handler`.
 ;;
-;; The three counters do not share this code through a common namespace, on
-;; purpose. Each substrate example is a self-contained `:browser` build, and
-;; a bundle-isolation test proves a Helix bundle carries no Reagent or UIx
-;; code (and vice versa). A shared namespace pulled into all three builds
-;; would break that. The boundary worth learning here is the SUBSTRATE
-;; BOUNDARY below — one dataflow, three view layers.
+;; You might wonder why the three counters retype these handlers instead of
+;; sharing one namespace. It's deliberate. Each example is its own self-
+;; contained build, and a bundle-isolation test checks that a Helix bundle
+;; ships zero Reagent or UIx code (and vice versa). A shared namespace dragged
+;; into all three builds would quietly break that guarantee. The seam worth
+;; learning is the substrate boundary below — one dataflow, three view layers.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -54,20 +57,21 @@
 ;; ──────────────────────────  SUBSTRATE BOUNDARY  ──────────────────────────
 ;; ============================================================================
 ;;
-;; Below this line is the only substrate-specific code in the example: the
-;; Helix views and the mount. The Reagent and UIx counters share every line
-;; above this divider and differ only below it (Reagent `reg-view`, UIx
-;; `defui` + `use-subscribe`, Helix `defnc` + `use-subscribe`).
+;; Everything below this line is the only substrate-specific code in the file:
+;; the Helix views and the mount. Cross the divider and you've left the shared
+;; dataflow behind.
 ;;
-;; Helix users write `defnc` directly; the `reg-view` macro is Reagent-only.
-;; The component reads its sub with `use-subscribe` and takes `dispatch` off
-;; `(rf/frame-handle)` itself. The handle captures the frame in scope at
-;; render time, so the closed-over `dispatch` still targets the right frame
-;; from a click handler that fires later.
+;; Helix is plain React, so a view is a `defnc` component that asks for what it
+;; needs out loud. `use-subscribe` is a hook that reads a subscription.
+;; `dispatch` comes off a `(rf/frame-handle)`: the handle captures the in-scope
+;; frame as a value, so the closed-over `dispatch` still finds this frame when
+;; a click fires later — on a stack that no longer has any frame in scope. So
+;; grab it at render time, while the frame is still around. See
+;; `docs/guide/glossary.md#frame-handle`.
 
 (defnc counter-buttons []
   (let [count    (helix-adapter/use-subscribe [:counter/value])  ;; read: re-renders when :counter/value changes
-        dispatch (:dispatch (rf/frame-handle))]                  ;; write: take dispatch off the render-time handle
+        dispatch (:dispatch (rf/frame-handle))]                  ;; write: dispatch, captured off the render-time handle
     (d/div
        (d/button {:on-click #(dispatch [:counter/dec])} "-")
        (d/span {:style {:margin "0 1em"} :data-testid "counter-value"} count)
@@ -78,29 +82,33 @@
 
 ;; -- Mount -------------------------------------------------------------------
 ;;
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. Loading the namespace must produce no DOM side effects, so that
-;; co-required example namespaces don't race each other to `createRoot` onto
-;; the shared `#app` element.
+;; The React root lives in an atom and gets created lazily inside `run`, never
+;; at ns-load. Loading a namespace must produce zero DOM side effects, so that
+;; co-required example namespaces don't race each other to call `createRoot` on
+;; the one shared `#app` element. See examples/TESTING.md, "mount-isolation".
 
 (defonce react-root (atom nil))
 
-;; The frame id this app runs in. `:rf/default` is an ordinary id with no
-;; framework privilege; we just pick it. The provider below creates the frame
-;; under this id, and the `use-subscribe` hook and render-time
-;; `(rf/frame-handle)` both resolve to it.
+;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
+;; with no special status — the runtime never conjures a frame for you, so we
+;; name one here and hand it to the provider. From there the `use-subscribe`
+;; hook and the render-time `(rf/frame-handle)` both resolve to it. See
+;; `docs/guide/glossary.md#frame-identity-is-carried-not-found`.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Install the Helix adapter. Pass the adapter value directly to init!.
+  ;; `init!` installs the reactive adapter for the process. Each adapter ns
+  ;; exports an `adapter` var; require the ns and pass that var. Call once at
+  ;; startup. See `docs/guide/glossary.md#init`.
   (rf/init! helix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
-    ;; The frame lives in one spot: the provider. Given `:id`, it creates the
-    ;; frame on first mount and runs `:initial-events` once to seed it. On hot
-    ;; reload it reuses the existing frame and skips seeding, so the count you
-    ;; were looking at survives. See docs/guide/concepts/frames.md.
+    ;; The whole frame lifecycle lives in one spot: this provider. The first
+    ;; mount creates the app frame and runs its `:initial-events` once to seed
+    ;; app-db. A later mount under the same `:id` — a hot reload — reuses the
+    ;; live frame and skips the seeding, so the count you were staring at
+    ;; survives the reload. See `docs/guide/concepts/frames.md`.
     (.render @react-root
              ($ helix-adapter/frame-provider {:id app-frame
                                               :initial-events [[:counter/initialise]]}

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -1,20 +1,22 @@
 (ns login-helix.core
-  "Helix variant of the login example.
+  "The login example, rendered through Helix.
 
-   Same dataflow, schemas, machine, and HTTP stub as
-   examples/reagent/login and examples/uix/login_uix; only the views
-   differ. They are Helix `defnc` components that read subs via the
-   adapter's `use-subscribe` hook. The state machine, schemas, and
-   managed-HTTP surfaces are substrate-agnostic — the view layer is the
-   only thing that changes between substrates.
+   A login form, a state machine for the submit/auth lifecycle, schemas
+   guarding the boundaries, and a stubbed HTTP call. The Reagent, UIx,
+   and Helix login examples share all of that — the machine, the
+   schemas, the managed-HTTP surface — and differ only in the view
+   layer. Here the views are Helix `defnc` components that read subs
+   through the adapter's `use-subscribe` hook.
 
-   The machine's states carry state tags (`:auth/busy`,
-   `:auth/authenticated`, `:auth/locked`); views read them via the
-   `:rf/machine-has-tag?` framework sub. The terminal `:locked-out`
-   state shows a non-interactive locked-account panel.
+   The machine's states wear tags — `:auth/busy`, `:auth/authenticated`,
+   `:auth/locked` — and the views ask about them with the
+   `:rf/machine-has-tag?` framework sub. Keep guessing the password and the
+   fourth wrong try trips the retry guard: the form is replaced by a
+   dead-end locked panel.
 
-   See the machines guide (docs/machines/concepts.md) and the form
-   recipe (docs/guide/how-to/build-a-form.md)."
+   The machines guide (docs/machines/concepts.md) and the form recipe
+   (docs/guide/how-to/build-a-form.md) cover the two big ideas at
+   length."
   (:require ["react-dom/client" :as react-dom-client]
             [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]
@@ -23,8 +25,8 @@
             [re-frame.schemas]
             [re-frame.machines]
             [re-frame.http.managed]
-            ;; Registers the canned-success / canned-failure HTTP fx ids the
-            ;; demo stub below delegates to.
+            ;; Brings in the canned-success / canned-failure HTTP fx ids the
+            ;; demo stub below leans on to fake a server.
             [re-frame.http.test-support]
             [re-frame.adapter.helix :as helix-adapter]))
 
@@ -32,56 +34,56 @@
 ;; SUBSTRATE-AGNOSTIC ARTEFACT LAYER  (schemas + fx + machine + subs)
 ;; ============================================================================
 ;;
-;; Everything from here down to the SUBSTRATE BOUNDARY divider — schemas, the
-;; managed-HTTP stub fx, the `:auth.login/flow` machine, and the named subs —
-;; is identical across the Reagent, UIx, and Helix login examples: same ids,
-;; same machine spec, same schemas, same HTTP stub. That sameness is the
-;; cross-substrate parity demonstration. Only the views below the SUBSTRATE
-;; BOUNDARY differ.
+;; Everything from here down to the SUBSTRATE BOUNDARY divider — the schemas,
+;; the HTTP stub, the `:auth.login/flow` machine, the named subs — is identical
+;; across the Reagent, UIx, and Helix login examples. Same ids, same machine,
+;; same schemas, same stub, character for character. That's the point: the
+;; logic of a login flow doesn't care which view library draws it.
 ;;
-;; It is deliberately NOT extracted into a shared namespace. Each substrate
-;; example is a self-contained `:browser` build, and the bundle-isolation gate
-;; proves a Helix bundle carries no Reagent/UIx code. A shared model required
-;; into all three builds would defeat that isolation. The boundary to learn
-;; here is one dataflow with three view layers — not a file-extraction
-;; boundary.
+;; You might expect this shared half to live in one file the three examples
+;; require. It deliberately doesn't. Each example is its own self-contained
+;; `:browser` build, and a gate checks that a Helix bundle carries no Reagent
+;; or UIx code — a shared file pulled into all three would blow that apart. So
+;; the lesson here is "one dataflow, three view layers," not "factor out the
+;; common bit." The duplication is on purpose.
 
 ;; ============================================================================
 ;; SCHEMAS
 ;; ============================================================================
 
-;; The credentials a login submit carries: an email and a password.
+;; What a login submit carries: an email and a password.
 ;;
-;; The password never lands in app-db — it rides the machine's event-arg
-;; schema and the HTTP body only — so there is no app-db path to classify
-;; `:sensitive`. The wire scrub happens instead on the HTTP request below,
-;; via its `:sensitive? true` flag. See
+;; Notice where the password is allowed to go. It rides this event-arg schema
+;; and the HTTP body, and that's it — it never lands in app-db. So there's no
+;; app-db path to tag `:sensitive`; the only thing to scrub is the request on
+;; the wire, which the HTTP call below handles with `:sensitive? true`. See
 ;; docs/guide/how-to/keep-secrets-out-of-traces.md.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
    [:password [:string {:min 8}]]])
 
-;; Schema for the whole `:auth.login/flow` event vector — validated at the
-;; event boundary before the machine handler runs. The `:submit` sub-event is
-;; validated strictly against `Credentials`; the framework-internal sub-events
-;; (`:dismiss`, `:success`, `:failure`) admit a framework-controlled tail.
+;; The shape of the whole `:auth.login/flow` event vector, checked at the event
+;; boundary before the machine ever sees it. A `:submit` must carry valid
+;; `Credentials`; the flow's own internal sub-events (`:dismiss`, `:success`,
+;; `:failure`) get a looser tail since the framework, not the user, builds them.
 ;;
-;; The `:submit` branch is a `:tuple`, not a `:cat`: the outer `:cat` consumes
-;; the nested sub-event vector as a SINGLE element, so the branch must match
-;; that one element AS a vector. A `:cat` branch would apply sequence-regex
-;; semantics, which can silently re-admit a `:submit` whose `Credentials`
-;; failed. With the strict `:tuple`, a short-password or bad-email submit is
-;; rejected at the boundary before the machine transitions or issues the login
-;; HTTP effect.
+;; Two details here are load-bearing and worth a moment.
 ;;
-;; The trailing `[:? :any]` admits the managed-HTTP reply payload. The
-;; framework appends `{:kind ... :value ...}` / `{:kind ... :failure ...}` as
-;; the LAST arg of the `:on-success` / `:on-failure` event vector, so the
-;; delivered reply is `[:auth.login/flow [:auth.login/success] <payload>]` —
-;; three top-level elements. Without the optional trailing slot the `:cat`
-;; rejects every reply, validation fails before the machine handler runs, and
-;; the flow is stranded in `:submitting`. See
+;; First, the `:submit` branch is a `:tuple`, not a `:cat`. The outer `:cat`
+;; hands the whole nested sub-event over as one element, so this branch has to
+;; match that element *as a vector*. Reach for `:cat` instead and you get
+;; sequence-regex matching, which can quietly wave through a `:submit` whose
+;; credentials were garbage. The strict `:tuple` makes a short password or a
+;; bad email bounce at the door — before the machine transitions, before the
+;; login request fires.
+;;
+;; Second, that trailing `[:? :any]` is the slot for the HTTP reply. When the
+;; managed-HTTP call comes back, the framework tacks the payload on as the last
+;; arg, so a delivered reply reads `[:auth.login/flow [:auth.login/success]
+;; <payload>]` — three elements, not two. Leave the optional slot out and the
+;; `:cat` rejects every reply, validation fails, and the flow sits in
+;; `:submitting` forever, wondering where its answer went. See
 ;; docs/guide/how-to/validate-with-schemas.md.
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
@@ -91,19 +93,20 @@
      [:* :any]]]
    [:? :any]])
 
-;; Schema for the machine's `:data` slot — the extended state
-;; `{:attempts ... :error ...}`, NOT the whole `{:state ... :data ...}`
-;; snapshot. It sits under the machine spec's `:schemas` map (attached below)
-;; and the framework validates it at every transition commit and at bootstrap.
-;; See "Validating a machine's `:data`" in docs/machines/concepts.md.
+;; The shape of the machine's `:data` slot — its extended state,
+;; `{:attempts ... :error ...}`. Just the `:data`, mind you, not the whole
+;; `{:state ... :data ...}` snapshot. It hangs off the machine's `:schemas` map
+;; (attached below), and the framework re-checks it every time the machine
+;; commits a transition, plus once at bootstrap. See "Validating a machine's
+;; `:data`" in docs/machines/concepts.md.
 (def AuthLoginData
   [:map
    [:attempts {:default 0} :int]
    [:error    [:maybe :string]]])
 
-;; A machine snapshot lives in runtime-db, not app-db, and app schemas validate
-;; the app-db partition only. So no `reg-app-schema` applies to the snapshot;
-;; the machine's own `:data` schema (attached below) validates it instead.
+;; Why a machine `:data` schema and not a `reg-app-schema`? Because a machine's
+;; snapshot lives in runtime-db, and app schemas only ever look at app-db. The
+;; machine guards its own state with the `:data` schema above.
 
 ;; ============================================================================
 ;; FX
@@ -112,18 +115,19 @@
 (def good-password "correct-horse")
 
 (rf/reg-fx :auth.session/store
-  {:doc       "Persist session token in localStorage. Client only."
+  {:doc       "Stash the session token in localStorage. Browser only."
    :platforms #{:client}}
   (fn fx-auth-session-store [_m {:keys [token]}]
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
 (rf/reg-fx :auth.login.demo/managed-stub
-  {:doc       "Demo override for `:rf.http/managed`. Delegates to the
-               framework's canned-success / canned-failure fxs with
-               `:after-ms`, so the reply is deferred via `:dispatch-later`
-               (50 ms) rather than a raw `js/setTimeout` — it shows up in the
-               trace and is time-travel-safe."
+  {:doc       "A fake server, standing in for `:rf.http/managed` so the demo
+               needs no backend. It hands off to the framework's canned-success
+               / canned-failure fxs with `:after-ms`, so the reply comes back
+               via `:dispatch-later` (after 50 ms) instead of a raw
+               `js/setTimeout`. The win: the round-trip shows up in the trace
+               and survives time-travel, which a bare timeout would not."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -153,15 +157,16 @@
 ;; STATE MACHINE
 ;; ============================================================================
 
-;; The login flow's machine spec. `:schemas` is a top-level key beside `:data`;
-;; its `:data` entry validates the `:data` slot (`{:attempts ... :error ...}`),
-;; not the whole snapshot. It is a named `def` so it can be passed to
-;; `reg-machine` below — the same shape the Reagent and UIx login siblings use.
+;; The login flow itself, written out as a machine spec. `:schemas` sits at the
+;; top level next to `:data`, and its `:data` entry guards the `:data` slot
+;; (`{:attempts ... :error ...}`) — not the whole snapshot. It's a named `def`
+;; purely so we can hand it to `reg-machine` just below; the Reagent and UIx
+;; siblings define theirs the same way.
 (def auth-login-machine
   {:initial :idle
-   ;; `:schemas :data` validates the `:data` slot at every transition commit.
-   ;; This `:data` (`{:attempts :error}`) holds no secret, so the machine
-   ;; declares no `:sensitive` / `:large`.
+   ;; `:schemas :data` re-checks the `:data` slot on every transition commit.
+   ;; This `:data` (`{:attempts :error}`) holds nothing secret, so there's no
+   ;; `:sensitive` or `:large` to declare.
    :schemas {:data AuthLoginData}
    :data    {:attempts 0 :error nil}
 
@@ -176,9 +181,9 @@
     :issue-request
     (fn [{[_ creds] :event}]
       {:fx [[:rf.http/managed
-             ;; `:sensitive? true` redacts the request body (which carries the
-             ;; `:password`) from every HTTP trace event — the per-request wire
-             ;; scrub. See docs/guide/how-to/keep-secrets-out-of-traces.md.
+             ;; `:sensitive? true` is the per-request wire scrub: it keeps the
+             ;; request body — and the `:password` inside it — out of every HTTP
+             ;; trace event. See docs/guide/how-to/keep-secrets-out-of-traces.md.
              {:request    {:method :post
                            :url    "/api/login"
                            :body   creds
@@ -195,11 +200,12 @@
                  (assoc :error (or (:message failure) "Login failed.")))})
 
     :lock-account
-    ;; Fire-and-forget lockout beacon: this POST wants no reply folded back
-    ;; into the machine. `:on-success nil` / `:on-failure nil` silence both
-    ;; reply branches. Omit them and the default would dispatch
-    ;; `[:auth.login/flow {:rf/reply ...}]` — a map in the sub-event slot that
-    ;; `AuthLoginEvent` rejects, stranding noise after lockout.
+    ;; A fire-and-forget lockout beacon: we POST it and don't care what comes
+    ;; back. `:on-success nil` / `:on-failure nil` mute both reply branches.
+    ;; Skip them and the default reply would dispatch `[:auth.login/flow
+    ;; {:rf/reply ...}]` — a map where `AuthLoginEvent` expects a sub-event
+    ;; vector, so it gets rejected and leaves stray noise rattling around after
+    ;; the account is already locked.
     (fn [_]
       {:fx [[:rf.http/managed
              {:request    {:method :post :url "/api/auth/lock"}
@@ -216,10 +222,9 @@
                               :action :clear-error}}}
 
     :submitting
-    ;; :auth/busy tag — views query
-    ;; [:rf/machine-has-tag? :auth.login/flow :auth/busy] to disable
-    ;; inputs and re-label the submit button while the request is in
-    ;; flight.
+    ;; The `:auth/busy` tag. While the request is in flight, the views ask
+    ;; [:rf/machine-has-tag? :auth.login/flow :auth/busy] and use the answer to
+    ;; grey out the inputs and flip the button to "Signing in…".
     {:tags  #{:auth/busy}
      :entry :issue-request
      :on    {:auth.login/success {:target :authed
@@ -231,34 +236,34 @@
                                    :action :lock-account}]}}
 
     :error-shown
-    ;; Direct retry from :error-shown re-enters :submitting and must clear the
-    ;; prior `:error` first — otherwise the obsolete failure message stays
-    ;; visible (the view renders `:auth.login/error` whenever non-nil) as if it
-    ;; still applied to the request now in flight. Same `:clear-error` action as
-    ;; the :idle entry transition.
+    ;; Retrying straight from :error-shown drops back into :submitting, and it
+    ;; has to wipe the old `:error` on the way. The view shows
+    ;; `:auth.login/error` whenever it's non-nil, so a stale message would hang
+    ;; around looking like it belongs to the request you just kicked off. Hence
+    ;; the same `:clear-error` action the :idle → :submitting edge uses.
     {:on {:auth.login/dismiss {:target :idle}
           :auth.login/submit  {:target :submitting
                                :action :clear-error}}}
 
     :authed
-    ;; :auth/authenticated tag — the banner swaps to "Welcome!" once
-    ;; the flow reaches this terminal state.
+    ;; The `:auth/authenticated` tag. Reach this terminal state and the banner
+    ;; swaps over to "Welcome!". You're in.
     {:tags #{:auth/authenticated}
      :meta {:terminal? true}}
 
     :locked-out
-    ;; :auth/locked tag — the flow lands in this terminal state once the retry
-    ;; limit is reached. Views query
-    ;; [:rf/machine-has-tag? :auth.login/flow :auth/locked] to swap the form
-    ;; for a locked-account panel and refuse further submits. A terminal
-    ;; lockout should be visible and non-interactive, not a live form.
+    ;; The `:auth/locked` tag, reached after one too many failed attempts. The
+    ;; views ask [:rf/machine-has-tag? :auth.login/flow :auth/locked] and, when
+    ;; it's true, replace the form with a locked-account panel — no more
+    ;; submits. A dead end should look like one, not a live form that quietly
+    ;; ignores you.
     {:tags #{:auth/locked}
      :meta {:terminal? true}}}})
 
-;; Register the machine. The three-argument arity carries an event `:schema`
-;; in the middle map — the boundary check on the dispatched outer event vector
-;; — alongside the machine spec (the `auth-login-machine` def above). See
-;; "Validating a machine's `:data`" in docs/machines/concepts.md.
+;; Register the machine. The three-arg form puts an event `:schema` in the
+;; middle map — that's the boundary check on the dispatched event vector — next
+;; to the spec itself (`auth-login-machine`, above). See "Validating a
+;; machine's `:data`" in docs/machines/concepts.md.
 (rf/reg-machine :auth.login/flow
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema AuthLoginEvent}
@@ -268,27 +273,28 @@
 ;; FORM SLICE  (substrate-agnostic)
 ;; ============================================================================
 ;;
-;; The form-slice events below are the other half of the "machine + slice"
-;; composition. The SLICE owns the DRAFT — what the user is currently typing —
-;; at the app-db path [:auth :login-form]; the MACHINE owns submit/auth STATUS.
-;; A form's draft is application state, so it lives in app-db (read via subs,
-;; written via events), not in a view-local hook. Inputs are CONTROLLED:
-;; `:value` reads the draft sub, `:on-change` dispatches
-;; `:auth.login/edit-field`. See docs/guide/how-to/build-a-form.md.
+;; Here's the other half of the "machine + slice" pairing. The two split the
+;; work cleanly: the slice owns the DRAFT — whatever the user is typing right
+;; now — at app-db path [:auth :login-form], while the machine owns the
+;; submit/auth STATUS. A half-typed form is still application state, so it lives
+;; in app-db (read through subs, written through events), not in a view-local
+;; hook. That makes every input CONTROLLED: `:value` reads the draft sub, and
+;; `:on-change` dispatches `:auth.login/edit-field`. See
+;; docs/guide/how-to/build-a-form.md.
 ;;
-;; This whole block — slice defaults, form events, and (below) the draft/slice
-;; subs — is part of the substrate-agnostic layer shared identically across
-;; the three login examples. Only the view syntax varies.
+;; Like the machine above, this whole block — the defaults, the events, and the
+;; draft/slice subs further down — is shared verbatim across the three login
+;; examples. Only the view syntax changes.
 
-;; The login form's default (empty) draft. The draft's value shape is
-;; `Credentials` (email regex + min-8 password) — the same schema the
-;; machine's `:submit` boundary enforces.
+;; The empty draft a fresh form starts from. Its value shape is `Credentials`
+;; (email regex, 8-char-minimum password) — the very schema the machine's
+;; `:submit` boundary will hold it to later.
 (def login-form-defaults {:email "" :password ""})
 
-;; Seed the form slice to its standard shape: empty `:draft`, `:status :idle`.
+;; Lay down a fresh form slice: empty `:draft`, `:status :idle`, and the rest.
 (rf/reg-event :auth.login/initialise-form
-  {:doc "Seed the login-form slice at [:auth :login-form] to its standard
-         shape (empty draft, :idle status)."}
+  {:doc "Seed the login-form slice at [:auth :login-form] to its starting
+         shape: empty draft, :idle status."}
   (fn handler-login-form-initialise [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form]
                    {:draft             login-form-defaults
@@ -299,10 +305,10 @@
                     :touched           #{}
                     :submit-error      nil})}))
 
-;; The user changed a single field. Update `:draft` and mark the field
-;; `:touched`. This is all an input's `:on-change` does — the draft lives in
-;; app-db, not view-local state. The `:schema` rejects a malformed edit-field
-;; vector at the event boundary.
+;; The user typed in one field. Write that field into `:draft` and remember it's
+;; been `:touched`. That's the whole job of an input's `:on-change` — the draft
+;; lives in app-db, not in view-local state. The `:schema` turns away any
+;; malformed edit-field vector right at the boundary.
 (rf/reg-event :auth.login/edit-field
   {:doc    "Controlled-input edit: write one field into the login-form draft
             and mark it touched."
@@ -312,20 +318,20 @@
              (assoc-in  [:auth :login-form :draft field] value)
              (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 
-;; Submit. Reads the draft out of the slice, latches `:submit-attempted?`,
-;; flips the slice `:status` to `:submitting`, and dispatches the draft INTO
-;; the machine — the only point the draft crosses into the machine (where it
-;; is validated against `Credentials` at the event boundary). The machine, not
-;; the slice, then owns the in-flight / authed / error / locked status; the
-;; slice `:status` is just a mirror.
+;; Submit. This reads the draft out of the slice, latches `:submit-attempted?`,
+;; flips the slice `:status` to `:submitting`, and dispatches the draft INTO the
+;; machine. That dispatch is the one and only place the draft crosses over —
+;; and crossing over means meeting `Credentials` at the machine's boundary. From
+;; here on the machine owns the real status (in-flight / authed / error /
+;; locked); the slice's `:status` just shadows it.
 ;;
-;; Secret-field hygiene: the handler reads the password off the draft, hands it
-;; to the machine, and CLEARS `[:draft :password]` in the same commit. Once the
-;; request is in flight the secret has done its job, so it does not sit in
-;; durable app-db waiting for the next snapshot or recording. The password's
-;; only off-box path is the HTTP request body (scrubbed by the per-request
-;; `:sensitive? true` flag); it is never written to `:submitted` or the machine
-;; `:data`. See docs/guide/how-to/keep-secrets-out-of-traces.md.
+;; Watch how the password is handled. The handler lifts it off the draft, sends
+;; it to the machine, and CLEARS `[:draft :password]` in the very same commit.
+;; The moment the request is on its way the secret has done its one job, so we
+;; don't leave it lounging in app-db where the next snapshot or recording could
+;; scoop it up. Its only trip off the box is inside the HTTP body (scrubbed by
+;; `:sensitive? true`); it never touches `:submitted` or the machine's `:data`.
+;; See docs/guide/how-to/keep-secrets-out-of-traces.md.
 (rf/reg-event :auth.login/submit-form
   {:doc "Submit the login form: read the draft from the slice, dispatch it
          into the :auth.login/flow machine's :submit sub-event, and clear the
@@ -338,7 +344,7 @@
                (assoc-in [:auth :login-form :draft :password] ""))
        :fx [[:dispatch [:auth.login/flow [:auth.login/submit draft]]]]})))
 
-;; Reset the slice back to its initial (empty, :idle) shape.
+;; Wipe the slice back to its empty, :idle starting shape.
 (rf/reg-event :auth.login/reset-form
   {:doc "Clear the login-form slice back to empty defaults / :idle."}
   (fn handler-login-form-reset [{:keys [db]} _]
@@ -355,12 +361,12 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; The machine snapshot lives in runtime-db. These named subs project out the
-;; convenient pieces by chaining off the framework `:rf/machine` sub. The
-;; "is it busy / authed / locked?" predicates are the `:rf/machine-has-tag?`
-;; framework sub, read directly in the views below.
+;; The machine's snapshot lives in runtime-db, and these named subs pick out the
+;; handy bits by chaining off the framework's `:rf/machine` sub. The yes/no
+;; "busy? authed? locked?" questions don't need their own subs at all — the
+;; views ask `:rf/machine-has-tag?` directly.
 
-;; Read the machine's snapshot through the framework `:rf/machine` sub.
+;; Pull the machine's whole snapshot through the framework `:rf/machine` sub.
 (rf/reg-sub :auth.login/state
   :<- [:rf/machine :auth.login/flow]
   (fn [snapshot _] (:state snapshot)))
@@ -371,11 +377,11 @@
 
 ;; --- Form-slice subs (substrate-agnostic) ----------------------------------
 ;;
-;; The login-form slice lives at app-db [:auth :login-form]. The view reads the
-;; DRAFT through `:auth.login/draft` and binds each input's `:value` to it —
-;; controlled inputs. The per-field-error sub follows the form visibility rule:
-;; show a field's error once it is touched OR a submit has been attempted. See
-;; docs/guide/how-to/build-a-form.md.
+;; The slice sits at app-db [:auth :login-form]. The view reads the DRAFT
+;; through `:auth.login/draft` and ties each input's `:value` to it — that's
+;; what makes them controlled. The per-field-error sub plays by the usual form
+;; rule: don't show a field's error until the user has touched that field or
+;; tried to submit at least once. See docs/guide/how-to/build-a-form.md.
 
 (rf/reg-sub :auth.login/form-slice
   {:doc "The whole login-form slice at [:auth :login-form]."}
@@ -383,15 +389,16 @@
     (get-in db [:auth :login-form])))
 
 (rf/reg-sub :auth.login/draft
-  {:doc "The login-form draft — what the user has currently typed. Each input
-         binds its :value to a field of this map (controlled inputs)."}
+  {:doc "The draft — whatever the user has typed so far. Each input binds its
+         :value to a field of this map, which is what makes them controlled."}
   :<- [:auth.login/form-slice]
   (fn sub-auth-login-draft [slice _]
     (:draft slice)))
 
 (rf/reg-sub :auth.login/field-error
-  {:doc "Per-field validation error for the login form. Reveal a field's error
-         once it is :touched OR once the form has had its first submit click."}
+  {:doc "A field's validation error, but only once the user has earned the
+         right to see it: after touching that field, or after the first submit
+         click."}
   :<- [:auth.login/form-slice]
   (fn sub-auth-login-field-error [slice [_ field]]
     (when (or (:submit-attempted? slice)

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -1,21 +1,24 @@
 (ns process-monitor-helix.core
-  "Helix example — 'Process Monitor'. A terminal-style two-pane layout: a
-   filterable process list on the left, a live log feed on the right, and
-   status tiles across the top.
+  "A terminal-style process monitor, built on Helix. Two panes — a
+   filterable process list on the left, a live log feed on the right — with
+   status tiles across the top. The log pane gains a fresh line every couple
+   of seconds with nobody touching it, which is the fun part: it proves this
+   is a real reactive loop, not a screenshot.
 
-   What it shows:
+   Four things worth watching:
 
-     - Helix components (`defnc`) reading subscriptions via `use-subscribe`
-     - a derivation graph: two UI inputs (the level-filter chips, the
-       selected process) fold into one derived subscription — the visible
-       log slice. It recomputes only when an input changes.
-     - a recurring `:dispatch-later` tick that appends synthetic log lines
-       (`:process-monitor/tick`), driven by the component lifecycle and kept
-       to exactly one live chain by a generation guard
-     - per-row dispatch from inside a `defnc` row component
+     - Helix views (`defnc`) read their slice of state through the
+       `use-subscribe` hook — the React-hooks idiom, no `reg-view` in sight.
+     - A derivation graph at work. Two UI inputs — the level-filter chips and
+       the selected process — fold into one derived subscription, the visible
+       log slice. It recomputes only when an input actually changes.
+     - A self-advancing tick that appends synthetic log lines
+       (`:process-monitor/tick`), driven by the component lifecycle. The
+       trick is keeping it to exactly one live chain; see the EVENTS block.
+     - Per-row dispatch from inside a `defnc` row component.
 
-   The 'Editorial Warm' visual identity comes from
-   examples/_shared/css/style.css, shared across all three substrates."
+   The visual identity is shared across all three design-led examples; it
+   lives in examples/_shared/css/style.css."
   (:require ["react-dom/client" :as react-dom-client]
             [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]
@@ -54,19 +57,24 @@
 ;; EVENTS
 ;; ============================================================================
 ;;
-;; The tick chain is a self-rescheduling `:dispatch-later`. That effect has no
-;; cancel API, so a "generation" counter (`:process-monitor/tick-gen`) keeps the
-;; chain to exactly one live loop:
+;; The tick is a `:dispatch-later` that reschedules itself — a loop with no
+;; off switch, because that effect has no cancel API. Left alone, a hot reload
+;; or a re-mount would just spawn a second chain alongside the first, and now
+;; two loops append lines forever. Not ideal.
 ;;
-;;   - Each scheduled tick carries the generation it was armed under.
-;;   - `:process-monitor/initialise` and `:process-monitor/stop` bump the generation.
-;;   - A tick whose generation no longer matches `db` no-ops: no append, no
-;;     reschedule. So any chain from a previous arm dies on its next fire.
+;; The fix is a generation guard, and it's pleasingly small. A counter,
+;; `:process-monitor/tick-gen`, records which "arming" each chain belongs to:
 ;;
-;; The loop is tied to the `monitor` component lifecycle (see its `use-effect`
-;; below): mount arms it via `:process-monitor/initialise`, unmount stops it via
-;; `:process-monitor/stop`. A re-mount re-arms cleanly; an unmount leaves no chain
-;; dispatching into a frame nobody is rendering.
+;;   - Every scheduled tick carries the generation it was armed under.
+;;   - `:process-monitor/initialise` and `:process-monitor/stop` bump the counter.
+;;   - A tick whose generation no longer matches `db` just declines to act —
+;;     no append, no reschedule. So a chain from an earlier arming quietly
+;;     dies the next time it fires. No cancellation required.
+;;
+;; The loop hangs off the `monitor` component's lifecycle (see its `use-effect`
+;; below): mount arms it via `:process-monitor/initialise`, unmount retires it
+;; via `:process-monitor/stop`. Re-mount and it re-arms cleanly. Unmount and no
+;; chain is left dispatching into a frame nobody is looking at.
 
 (rf/reg-event :process-monitor/initialise
   (fn [{:keys [db]} _event]
@@ -77,20 +85,23 @@
             :process-monitor/level-filter #{:info :warn :error}
             :process-monitor/selected   nil
             :process-monitor/tick-gen   next-gen}
-       ;; Arm the loop by describing the first tick as data — the handler
-       ;; never touches setTimeout, the :dispatch-later effect does. The tick
-       ;; carries `next-gen` so a later arm can retire it.
+       ;; Arm the loop by *describing* the first tick as data. The handler
+       ;; stays pure — it never calls setTimeout; the :dispatch-later effect
+       ;; does the scheduling. The tick carries `next-gen` so a later arming
+       ;; can retire this one.
        :fx [[:dispatch-later {:ms 1800 :event [:process-monitor/tick next-gen]}]]})))
 
 (rf/reg-event :process-monitor/tick
   (fn [{:keys [db]} [_ gen]]
     (if (not= gen (:process-monitor/tick-gen db))
-      ;; Generation no longer matches: this tick belongs to a retired chain.
-      ;; Drop it — no log append, no clock bump, no reschedule.
+      ;; This tick belongs to a retired generation — a chain a newer arming
+      ;; has already superseded. Drop it: no append, no clock bump, no
+      ;; reschedule. Declining to act is how the old chain dies.
       {}
       (let [tick      (:process-monitor/clock db)
             processes (:process-monitor/processes db)
-            ;; Pick a process round-robin for the synthetic log line.
+            ;; Round-robin through the processes so the synthetic feed looks
+            ;; like every service is chattering, not just one.
             process   (nth processes (mod tick (count processes)))
             level     (cond
                         (= :down (:status process))     :error
@@ -108,13 +119,13 @@
                  (update :process-monitor/logs (fn [logs]
                                          (vec (take-last 60 (conj logs new-entry)))))
                  (update :process-monitor/clock inc))
-         ;; Reschedule under the same generation, so the chain continues until
-         ;; a fresher arm retires it.
+         ;; Reschedule under the *same* generation, so this chain keeps going
+         ;; until a fresher arming comes along and retires it.
          :fx [[:dispatch-later {:ms 1800 :event [:process-monitor/tick gen]}]]}))))
 
-;; Stops the loop. Bumps the generation but arms no new tick, so the live
-;; chain's next fire no-ops. Dispatched from the `monitor` component's
-;; `use-effect` cleanup on unmount.
+;; Stops the loop. Bumps the generation but arms nothing new, so the live
+;; chain finds itself stale on its next fire and quietly steps off. The
+;; `monitor` component dispatches this from its `use-effect` cleanup on unmount.
 (rf/reg-event :process-monitor/stop
   (fn [{:keys [db]} _event]
     {:db (update db :process-monitor/tick-gen (fnil inc 0))}))
@@ -147,10 +158,11 @@
 (rf/reg-sub :process-monitor/selected
   (fn [db _] (:process-monitor/selected db)))
 
-;; A derived subscription built on the base subs above. `:<-` names its
-;; inputs; the runtime recomputes it only when an input changes by `=`, so the
-;; tiles don't re-render when an unrelated key moves. See the glossary on the
-;; derivation graph: docs/guide/glossary.md#the-derivation-graph
+;; A derived subscription: it reads other subs rather than app-db directly.
+;; `:<-` names its inputs, and the runtime only recomputes when one of them
+;; changes by `=`. So the tiles sit still while unrelated keys move underneath
+;; — caching you get for free by saying what you depend on. The glossary has
+;; the full picture: docs/guide/glossary.md#the-derivation-graph
 (rf/reg-sub :process-monitor/totals
   :<- [:process-monitor/processes]
   (fn [processes _]
@@ -160,9 +172,11 @@
      :cpu     (reduce + 0 (map :cpu processes))
      :mem     (reduce + 0 (map :mem processes))}))
 
-;; Four inputs (the level filter, the selected process, the raw logs, the
-;; processes) fold into the slice the log pane shows. The view does no
-;; filtering itself — it reads this.
+;; The star of the show. Four inputs fold into the exact slice the log pane
+;; renders: the raw logs, the active levels, the selected process, and the
+;; processes (to map a selection to its pid). Click a chip or a row and this
+;; re-derives; the view never filters anything itself, it just reads the
+;; answer. This is the derivation graph earning its keep.
 (rf/reg-sub :process-monitor/visible-logs
   :<- [:process-monitor/logs]
   :<- [:process-monitor/level-filter]
@@ -181,11 +195,12 @@
 ;; ──────────────────────────  SUBSTRATE BOUNDARY  ──────────────────────────
 ;; ============================================================================
 ;;
-;; Everything above is substrate-agnostic: seed data, events (the tick loop),
-;; and the subs. None of it mentions Helix. Below this divider is the only
-;; substrate-specific code: the `defnc` views and the mount. That is the
-;; boundary the example teaches — app-db + events + subs sit above, the
-;; substrate's view idiom sits below.
+;; Everything above this line is substrate-agnostic: seed data, events (tick
+;; loop and all), and subs. Scan it and you won't find the word Helix once —
+;; it would run unchanged on Reagent or UIx. Below the line is the only
+;; Helix-specific code: the `defnc` views and the mount. That split is the
+;; lesson. The interesting machinery lives in the portable core; the substrate
+;; is just the thin rendering choice you make at the edge.
 
 ;; ============================================================================
 ;; VIEWS (Helix — defnc)
@@ -196,9 +211,9 @@
     (d/div {:class "pm-tile-label"} label)
     (d/div {:class "pm-tile-value"} value)))
 
-;; `use-subscribe` is the Helix hook form of `subscribe`: it returns a plain
-;; value (not a reaction) and re-renders this component when that value
-;; changes. Call it at the top of the body.
+;; `use-subscribe` is `subscribe` in hook clothing. It hands back a plain value
+;; — not a reaction to deref — and re-renders this component whenever that
+;; value changes. Like any React hook, call it at the top of the body.
 (defnc tiles []
   (let [totals (helix-adapter/use-subscribe [:process-monitor/totals])]
     (d/div {:class "pm-tiles"}
@@ -208,9 +223,10 @@
       ($ tile {:label "Σ CPU"   :value (str (.toFixed (:cpu totals) 1) "%")})
       ($ tile {:label "Σ MEM"   :value (str (:mem totals) "M")}))))
 
-;; To dispatch, grab `dispatch` off a frame-handle: `(rf/frame-handle)`
-;; captures the current frame as a value, so the click handler dispatches into
-;; this app's frame. See docs/guide/glossary.md#frame-handle
+;; To dispatch from a view, grab `dispatch` off a frame-handle.
+;; `(rf/frame-handle)` captures the current frame as a value, so the click
+;; handler we close over below still lands in this app's frame when it fires.
+;; See docs/guide/glossary.md#frame-handle
 (defnc level-chips []
   (let [active   (helix-adapter/use-subscribe [:process-monitor/level-filter])
         dispatch (:dispatch (rf/frame-handle))]
@@ -276,18 +292,22 @@
                       :entry entry}))))))
 
 (defnc monitor []
-  ;; This component drives the tick loop: mount arms it, unmount stops it.
-  ;; Capture `(:dispatch (rf/frame-handle))` at render-time so it carries the
-  ;; surrounding frame into the post-commit effect body and cleanup. See the
-  ;; Helix adapter README §use-effect for why the capture goes here.
+  ;; This component owns the tick loop's lifecycle: mount arms it, unmount
+  ;; retires it. We capture `(:dispatch (rf/frame-handle))` here in the `let`,
+  ;; at render-time, while the frame is still in scope. By the time the effect
+  ;; and its cleanup actually run — after commit — that scope is gone, so a
+  ;; dispatch fetched in there would have no frame to land in. Grab it now,
+  ;; close over it, and you're safe. The Helix adapter README §use-effect has
+  ;; the long version.
   (let [dispatch (:dispatch (rf/frame-handle))]
     (helix-hooks/use-effect
       ;; Empty deps ⇒ run once on mount, clean up once on unmount.
       []
-      ;; Mount: arm the loop. The generation guard retires any chain already in
+      ;; Mount: arm the loop. The generation guard retires anything already in
       ;; flight, so a re-mount re-arms cleanly and only one chain stays live.
       (dispatch [:process-monitor/initialise])
-      ;; Unmount: stop the chain so it never dispatches into an unrendered frame.
+      ;; Unmount: stop the chain so it never dispatches into a frame that's no
+      ;; longer on screen.
       (fn cleanup []
         (dispatch [:process-monitor/stop]))))
   (d/div {:class "pm-shell"}
@@ -305,28 +325,31 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. Per examples/TESTING.md §Example mount-isolation, ns-load must
-;; produce no DOM side effects so co-required example namespaces don't race
-;; `createRoot` onto the shared `#app`.
+;; The React root lives in an atom and is created lazily inside `run`, never at
+;; ns-load. The rule (examples/TESTING.md §Example mount-isolation): loading a
+;; namespace must touch no DOM, so that when several examples are required side
+;; by side they don't all race to call `createRoot` on the shared `#app`.
 (defonce react-root (atom nil))
 
-;; The frame id this app runs under. The `frame-provider` in `run` below is the
-;; one spot the frame is set up: it creates the frame, seeds app-db, and scopes
-;; the frame into React context. `use-subscribe` and the `(rf/frame-handle)`
-;; capture in `monitor` resolve to this frame through that context.
+;; The frame this app runs under. The `frame-provider` in `run` is the single
+;; place it's set up — it creates the frame, seeds app-db, and threads the
+;; frame into React context. Everything downstream (`use-subscribe`, the
+;; `(rf/frame-handle)` capture in `monitor`) finds this frame through that
+;; context.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the Helix adapter so re-frame2 knows how to render.
+  ;; `init!` tells re-frame2 which substrate to render through — here, Helix.
+  ;; It installs the adapter and nothing more; it does not create a frame.
   (rf/init! helix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
     ;; `frame-provider` creates the app frame on first mount and runs
-    ;; `:initial-events` once to seed app-db; a hot reload reuses the frame
-    ;; without re-seeding, so the running clock and logs stay intact. From there
-    ;; the `monitor` component owns the loop (see its `use-effect`).
+    ;; `:initial-events` once to seed app-db. A hot reload reuses the existing
+    ;; frame and skips the re-seed, so your running clock and accumulated logs
+    ;; survive the reload — a small mercy while iterating. From here on the
+    ;; `monitor` component owns the loop (see its `use-effect`).
     (.render @react-root
              ($ helix-adapter/frame-provider {:id app-frame
                                               :initial-events [[:process-monitor/initialise]]}

--- a/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
@@ -1,30 +1,29 @@
 (ns counter-slim-and-fast.bundle-isolation-entry
-  "Gate-owned entrypoint for the slim counter — NOT example/app practice.
+  "Gate plumbing for the slim counter — NOT something to copy into an app.
 
-   This namespace exists only to drive the slim adapter's bundle-isolation
-   gate. It is the `:init-fn` of the `:examples/counter-slim-and-fast` build
-   (implementation/shadow-cljs.edn), so the build the gate inspects compiles
-   the pure-CLJS SSR path. The teaching surface `counter-slim-and-fast.core`
-   stays clean of fixture plumbing.
+   If you're here to learn the example, you're in the wrong file: read `run`
+   in `counter-slim-and-fast.core` instead. This namespace exists for one
+   reason, and it's a CI reason. It's the `:init-fn` of the
+   `:examples/counter-slim-and-fast` build (implementation/shadow-cljs.edn),
+   which means the build the bundle-isolation gate inspects compiles in the
+   pure-CLJS SSR path. Keeping that here lets the teaching file stay clean.
+   The gate itself —
+   `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` — owns
+   the real contract.
 
-   A reader studying the example should ignore this file and read `run` in
-   `counter-slim-and-fast.core` instead. The gate that consumes this
-   entrypoint is `implementation/scripts/check-reagent-slim-bundle-isolation.cjs`,
-   which owns the contract details.
-
-   This entry calls the shared `counter-slim-and-fast.core/boot!` rather
-   than re-copying the boot. The one fixture concern is the `on-frame`
-   pre-mount hook `boot!` accepts: the pure-CLJS `render-to-static-markup`
-   exercise runs in a transient frame `boot!` opens for it, before the
-   client mount, so the static render's orphaned SSR subscription is torn
-   down (`fixture/prove-pure-cljs-ssr!` clears the sub-cache) and the
-   browser mount owns the only live `[:counter/value]` reaction."
+   It boots through the shared `counter-slim-and-fast.core/boot!` rather
+   than copy-pasting the boot. The only fixture-specific move is the
+   `on-frame` pre-mount hook `boot!` accepts: `boot!` opens a transient
+   frame, runs the pure-CLJS `render-to-static-markup` exercise in it before
+   the client mounts, then tears it down — `fixture/prove-pure-cljs-ssr!`
+   clears the sub-cache — so the browser mount ends up owning the one live
+   `[:counter/value]` reaction."
   (:require [re-frame.views]
             [counter-slim-and-fast.core                     :as core]
             [counter-slim-and-fast.bundle-isolation-fixture :as fixture]))
 
 (defn run []
-  ;; Boot via `core/boot!`, passing the SSR fixture as its `on-frame`
-  ;; pre-mount hook. See the ns docstring and `fixture/prove-pure-cljs-ssr!`
-  ;; for what the hook does.
+  ;; Same `core/boot!` the example uses, with the SSR fixture handed in as
+  ;; the `on-frame` pre-mount hook. The ns docstring and
+  ;; `fixture/prove-pure-cljs-ssr!` explain what that hook is for.
   (core/boot! #(fixture/prove-pure-cljs-ssr! [core/counter-app])))

--- a/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_fixture.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_fixture.cljs
@@ -1,48 +1,51 @@
 (ns counter-slim-and-fast.bundle-isolation-fixture
-  "Bundle-isolation fixture for the slim counter — NOT example/app practice.
+  "Bundle-isolation fixture for the slim counter — NOT something to copy.
 
-   This namespace exists only to make the slim adapter's pure-CLJS-SSR
-   bundle-isolation contract provable on the advanced bundle. A reader
-   studying the example should ignore it; the teaching surface is
-   `counter-slim-and-fast.core`. This is the example-side half of an
-   adapter-owned CI gate.
+   Another file to read past if you're learning the example; the teaching
+   surface is `counter-slim-and-fast.core`. This is the example-side half
+   of an adapter-owned CI gate, and it has exactly one job: make the slim
+   adapter's pure-CLJS-SSR isolation contract provable on the advanced
+   bundle. The other half — the script that judges the result — is
+   `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` (run via
+   `npm run test:reagent-slim:bundle-isolation`), and it owns the contract.
 
-   The gate that consumes this fixture is
-   `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` (run
-   via `npm run test:reagent-slim:bundle-isolation`). That script owns the
-   contract details.
-
-   What this fixture contributes: it exercises slim's pure-CLJS
-   `render-to-static-markup` at boot so the SSR path is actually compiled
-   into the bundle. That makes the gate's check that `react-dom/server` is
-   absent a real proof — without an exercised SSR path, the absence check
-   would pass against a bundle that does no SSR at all. The host-global
-   write below keeps the exercise alive under `:advanced`. For the two HTML
-   paths slim ships, see docs/guide/how-to/use-uix-helix-or-slim.md."
+   So what does this half actually do? It runs slim's pure-CLJS
+   `render-to-static-markup` at boot, which forces the SSR path to be
+   compiled into the bundle. That's the bit that gives the gate teeth: its
+   real claim is 'react-dom/server is absent', and that's only meaningful if
+   an SSR path is present to be checked against — otherwise you'd be proving
+   the absence of server rendering in a bundle that never renders on the
+   server anyway. The host-global write below keeps the exercise from being
+   optimised away under `:advanced`. For the two HTML paths slim ships, see
+   docs/guide/how-to/use-uix-helix-or-slim.md."
   (:require [reagent2.dom.server :as rds]
             [re-frame.core       :as rf]))
 
 (defn prove-pure-cljs-ssr!
-  "Run slim's pure-CLJS SSR path so the bundle-isolation gate has signal.
-   `hiccup` is the root example view in hiccup form (e.g. `[counter-app]`).
+  "Run slim's pure-CLJS SSR path once, so the bundle-isolation gate has
+   something real to inspect. `hiccup` is the root example view in hiccup
+   form, e.g. `[counter-app]`.
 
-   Mechanics (all fixture concerns, none of which the example needs):
+   Two mechanics are at work, both pure fixture concerns the example itself
+   never has to think about:
 
-     - Keeping it alive under `:advanced`: the rendered markup is written
-       onto the `counterSlimPrerender` host-global. The closure compiler
-       treats writes to extern-shaped `globalThis` properties as side
-       effects, so the `render-to-static-markup` call is not eliminated as
-       dead code. The gate greps for this host-global plus a literal owned
-       by the `reagent2.dom.server` serializer.
+     - Surviving `:advanced`. We write the rendered markup onto the
+       `counterSlimPrerender` host-global. The closure compiler can't prove
+       that a write to an extern-shaped `globalThis` property is harmless,
+       so it treats it as a side effect and leaves the
+       `render-to-static-markup` call standing instead of pruning it as dead
+       code. The gate then greps for that host-global plus a literal only
+       the `reagent2.dom.server` serializer would emit.
 
-     - Sub-cache teardown: `render-to-static-markup` is the pure-CLJS
-       static walker — it calls the view as a plain fn and walks the
-       resulting hiccup, mounting no Reagent component lifecycle. The view
-       derefs a subscription, so the static render builds and caches that
-       reaction in the frame's sub-cache, and nothing auto-unsubscribes it
-       (there is no component to unmount). The `try`/`finally` disposes the
-       orphaned subscription so the client mount owns the only live
-       reaction; `finally` guarantees teardown even if the render throws."
+     - Cleaning up after ourselves. `render-to-static-markup` is slim's
+       pure-CLJS static walker: it calls the view as a plain function and
+       walks the hiccup it returns, with no Reagent component lifecycle in
+       sight. Our view derefs a subscription, so that walk builds and caches
+       a reaction in the frame's sub-cache — and because no component ever
+       mounted, nothing will ever unmount to dispose it. So we do it by
+       hand. The `try`/`finally` disposes that orphaned subscription, which
+       leaves the client mount owning the one live reaction; `finally` makes
+       sure the teardown happens even if the render blows up partway."
   [hiccup]
   (try
     (set! (.-counterSlimPrerender js/globalThis)

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -1,37 +1,39 @@
 (ns counter-slim-and-fast.core
-  "A minimal counter on the reagent-slim substrate.
+  "The counter, again — this time on the reagent-slim substrate.
 
    This is the teaching file: plain, idiomatic re-frame2. The dataflow is
-   the same counter as `examples/reagent/counter` — the same `:counter/*`
-   events and subs. The one difference is the substrate beneath it: the
-   view imports point at `reagent2.*`, and `rf/init!` is given the slim
-   adapter. Picking a substrate is one line; see
-   docs/guide/how-to/use-uix-helix-or-slim.md.
+   exactly the counter from `examples/reagent/counter` — same `:counter/*`
+   events, same sub. What changes is the substrate underneath: the view
+   imports point at `reagent2.*`, and `rf/init!` gets the slim adapter.
+   That's it. Picking a substrate is a one-line decision, and you can read
+   the whole menu in docs/guide/how-to/use-uix-helix-or-slim.md.
 
-   The require below names `re-frame.adapter.reagent-slim` because this
-   monorepo build shares a classpath with the stock adapter and must avoid
-   a namespace clash. A real app picks slim by its `deps.edn` coordinate
-   (`day8/reagent-slim`), not by this import line — see the guide page's
-   coordinate table.
+   One wrinkle in the require below, and it's a monorepo wrinkle, not a
+   re-frame2 one: we name `re-frame.adapter.reagent-slim` directly because
+   this repo shares a classpath with the stock adapter and the two would
+   otherwise collide. Your app won't have that problem — you pick slim by
+   its `deps.edn` coordinate (`day8/reagent-slim`) and require the ordinary
+   adapter namespace. The guide page has the coordinate table.
 
-   The slim adapter's bundle-isolation proof runs from a separate
-   gate-owned entrypoint, `counter-slim-and-fast.bundle-isolation-entry`,
-   so this file carries no fixture plumbing. That entry boots the same app
-   through the shared `boot!` helper below, passing a hook that exercises
-   the pure-CLJS SSR path the gate inspects."
+   You'll also spot two sibling files here that have nothing to teach you:
+   `bundle-isolation-entry` and `bundle-isolation-fixture`. They exist to
+   prove a CI gate, live entirely off to the side, and boot the same app
+   through the shared `boot!` helper below. Read past them."
   (:require [reagent2.dom.client                :as rdc]
             [re-frame.core                      :as rf]
             [re-frame.views]
-            ;; Monorepo-only namespace (see ns docstring): a real app picks
-            ;; slim by its deps coordinate, not by this import.
+            ;; Monorepo-only spelling (see the ns docstring). Your app picks
+            ;; slim by its deps coordinate, not by naming this namespace.
             [re-frame.adapter.reagent-slim      :as reagent-slim-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
-;; -- Events / subs (handler registry is app-global) --------------------------
+;; -- Events / subs (the handler registry is app-global) ----------------------
 ;;
-;; These four forms are the substrate-agnostic core: pure handlers and a pure
-;; subscription over plain data. The substrate swap does not touch them — only
-;; the boot below changes. That invariance is the point of this example.
+;; Here's the quietly remarkable part. These four forms — three pure handlers
+;; and one pure subscription, all over plain data — are byte-for-byte the same
+;; whether you render through Reagent, slim, UIx, or Helix. Swapping the
+;; substrate doesn't touch a single character of them; only the boot changes.
+;; That's the whole pitch of this example, hiding in plain sight.
 ;; See docs/guide/glossary.md for event and subscription.
 
 (rf/reg-event :counter/initialise
@@ -48,9 +50,9 @@
 
 ;; -- Views -------------------------------------------------------------------
 ;;
-;; reg-view is substrate-agnostic. The same view form renders on whichever
-;; substrate was installed at boot, because it reads through the active
-;; adapter at render time. Here that adapter is slim (see `boot!` below).
+;; reg-view doesn't care about the substrate either. The same view form renders
+;; on whichever adapter was installed at boot, because it looks up that adapter
+;; at render time rather than baking one in. Here it finds slim (see `boot!`).
 ;; See docs/guide/concepts/views.md.
 
 (reg-view counter-buttons []
@@ -64,47 +66,50 @@
 
 ;; -- Mount -------------------------------------------------------------------
 ;;
-;; The React root is held in an atom and created lazily inside `boot!`, not
-;; at ns-load. Loading the namespace must produce no DOM side effects, so
-;; that co-required example namespaces don't race `create-root` onto the
-;; shared `#app`. This is the same mount shape as `examples/reagent/counter`.
+;; The React root lives in an atom and is created lazily inside `boot!`, never
+;; at ns-load. The rule is simple: loading this namespace must touch no DOM.
+;; That keeps co-loaded example namespaces from racing each other to call
+;; `create-root` on the shared `#app`. Same mount shape as
+;; `examples/reagent/counter`.
 
 (defonce react-root (atom nil))
 
-;; The app frame is established in one spot: the `frame-provider {:id
+;; The app frame is born in exactly one place: the `frame-provider {:id
 ;; app-frame …}` at the render root below. On first mount the provider
-;; creates the frame, applies its config, and runs `:initial-events` once
-;; to seed it (the `[:counter/initialise]` dispatch). After that every
-;; `dispatch`/`subscribe` resolves to that frame. On hot reload the
-;; provider reuses the existing frame and skips re-seeding.
+;; creates the frame, applies its config, and fires `:initial-events` once
+;; to seed it — that's the `[:counter/initialise]` dispatch. From then on
+;; every `dispatch`/`subscribe` resolves to that frame. Hot reload reuses
+;; the frame already there and skips the re-seed, so your count survives.
 ;;
-;; `:rf/default` is an ordinary frame id with no special privilege — you
-;; establish it like any other; the runtime won't infer it for you.
+;; And `:rf/default` is just a frame id — no magic, no privilege. You
+;; establish it like any other; the runtime will never conjure it for you.
 ;; See docs/guide/concepts/frames.md.
 (def app-frame :rf/default)
 
 (defn boot!
-  "Boots the example: install the slim adapter, then lazily mount
-   `counter-app` into `#app` under a `frame-provider {:id app-frame …}`.
-   The provider creates and seeds the app frame (see the comment above).
+  "Stand the example up. Two steps: install the slim adapter, then lazily
+   mount `counter-app` into `#app` under a `frame-provider {:id app-frame …}`.
+   The provider does the frame work — creates it, seeds it (see the comment
+   just above).
 
-   Both the teaching path (`run` below) and the gate-owned path
-   (`counter-slim-and-fast.bundle-isolation-entry/run`) call this one
-   helper, so the boot is defined in a single place.
+   There's one `boot!` and everyone goes through it. The teaching path
+   (`run`, below) and the gate-owned path
+   (`counter-slim-and-fast.bundle-isolation-entry/run`) both land here, so
+   the boot lives in a single place and can't drift between them.
 
-   `on-frame` is an optional thunk the bundle-isolation entry uses; the
-   teaching `run` passes nothing. When given, it runs once before the
-   client mount inside its own short-lived frame (`with-new-frame`,
-   destroyed on exit), so the fixture's pre-mount SSR exercise stays clear
-   of the app frame the provider creates at mount."
+   `on-frame` is an optional thunk, and you can cheerfully ignore it — only
+   the bundle-isolation entry passes one; `run` does not. When supplied, it
+   runs once just before the client mount, inside its own throwaway frame
+   (`with-new-frame`, torn down on exit). That keeps the fixture's pre-mount
+   SSR poking well away from the real app frame the provider sets up."
   ([] (boot! nil))
   ([on-frame]
-   ;; Slim adapter — this is the difference from `examples/reagent/counter`.
-   ;; Same `rf/init!` signature; different adapter.
+   ;; The slim adapter — this single line is the whole difference from
+   ;; `examples/reagent/counter`. Same `rf/init!`, different adapter.
    (rf/init! reagent-slim-adapter/adapter)
    (when on-frame
-     ;; Fixture-only seam: run the hook in a throwaway frame (destroyed on
-     ;; exit) so it stays clear of the app frame the provider creates below.
+     ;; Fixture-only seam. Run the hook in a throwaway frame (gone on exit)
+     ;; so it never touches the app frame the provider creates below.
      (rf/with-new-frame [_ (rf/make-frame {})]
        (on-frame)))
    (when (exists? js/document)

--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -1,71 +1,77 @@
 (ns boot.boot
-  "Boot the app with one state machine that owns the whole startup graph.
+  "One state machine that owns the whole startup graph.
 
-   See the machines guide for the model — `:spawn` / `:spawn-all`
-   (docs/machines/glossary.md#spawn), states and transitions
-   (docs/machines/glossary.md#state), and the machine snapshot
-   (docs/machines/glossary.md#snapshot).
+   Booting an app is a lifecycle: fetch some config, load the few things
+   the first screen needs, then hand over. That's exactly what a machine
+   is good at, so the whole sequence lives in one place — `:app/boot` —
+   instead of scattered across mount hooks and callback chains. New to
+   the model? The machines guide covers `:spawn` / `:spawn-all`
+   (docs/machines/glossary.md#spawn), states (docs/machines/glossary.md#state),
+   and the snapshot (docs/machines/glossary.md#snapshot).
 
-   The boot machine is `:app/boot`. It runs through four states:
+   Read the four states as a story:
 
-     :configuring   → fetch /config via a single `:spawn`d child loader.
-     :loading-deps  → fan out THREE parallel child loads (routes,
-                      feature flags, initial user) via `:spawn-all`.
-                      The parent advances only when every child is done.
-     :hydrating     → write the loaded payloads into top-level app-db
-                      slices (`:config`, `:flags`, `:user`, `:routes`),
-                      then self-transition to `:ready`.
+     :configuring   → fetch /config first, because everything else needs
+                      it. One `:spawn`d child loader does the GET.
+     :loading-deps  → the parallel step. Three loads (routes, feature
+                      flags, user) don't depend on each other, so
+                      `:spawn-all` runs them at once. The parent waits
+                      for every child to finish.
+     :hydrating     → the loads are done but parked in a staging area.
+                      Copy them into the real top-level app-db slices
+                      (`:config`, `:flags`, `:user`, `:routes`), then
+                      move to `:ready`.
      :ready         → terminal. The main view watches the boot state and
-                      unblocks once it reads `:ready`.
+                      unblocks the moment it reads `:ready`.
 
-   Any child failure transitions the machine to `:failed` (terminal),
-   with the failure recorded in `:data :error`.
+   If any child fails, the machine jumps to `:failed` (terminal) and
+   records the reason in `:data :error`.
 
-   The child loader is the reusable `:boot/loader` machine — one spec,
-   four instances. Each instance carries its own identity (parent-id,
-   child-id, staging-key, URL) in `:data`, planted by the parent's
-   per-child `:data` fn. A `:data` fn receives the parent's snapshot, so
-   a child's URL can depend on values the parent has already loaded.
+   The child loader is its own machine, `:boot/loader` — one spec, four
+   instances, told apart only by the `:data` each was spawned with
+   (parent-id, child-id, staging-key, URL). The parent plants that
+   identity through a per-child `:data` fn, and since a `:data` fn gets
+   handed the parent's snapshot, a child's URL can depend on something
+   the parent already loaded.
 
-   That is how config flows downstream. The `:configuring` config load
-   returns an `:api-base`; the `:promote-staged` action records it into
-   the boot machine's `:data`; the three `:loading-deps` children then
-   read that `:api-base` off the parent's snapshot and build their URLs
-   from it. The boot machine is the only place that reads host config —
-   everything downstream threads it through a snapshot `:data` fn,
-   never reaching into a host global from an action body.
+   That's how config flows downstream without a global. The `:configuring`
+   load returns an `:api-base`; `:promote-staged` records it into the
+   boot machine's own `:data`; the three `:loading-deps` children then
+   read it back off the parent's snapshot and build their URLs from it.
+   The boot machine is the only place that ever reads host config —
+   everything below gets it as plain data, never by reaching into a host
+   global from an action body.
 
    Each child fetches via managed HTTP
-   (docs/resources/glossary.md#managed-http). On success it writes its
-   payload into the boot machine's staging slot at
-   `[:boot/staging <staging-key>]`, then dispatches its completion
-   event back to the parent.
+   (docs/resources/glossary.md#managed-http), then hands its payload back
+   to the parent. How it hands it back depends on the spawn shape, and
+   this is the one genuinely subtle bit:
 
-   Why stage into app-db rather than carry payloads on the join event:
-   the runtime intercepts a `:spawn-all`'s `:on-child-done` /
-   `:on-child-error` events for join bookkeeping only — they are NOT
-   fed into the parent's `:on` lookup, and the synthesised
-   join-resolution event (`:on-all-complete [:boot/deps-ready]`)
-   carries no per-child payload. So each child writes its result into a
-   known app-db slice and the parent reads that slice once the join
-   resolves. The loaded data lives in app-db throughout — inspectable
-   in tools and snapshottable for SSR hydration.
+   - A `:spawn-all` child writes its payload into a staging slot at
+     `[:boot/staging <staging-key>]`, then signals done. The runtime
+     reads a `:spawn-all`'s `:on-child-done` / `:on-child-error` events
+     only to track the join — they never reach the parent's `:on` table,
+     and the join-resolution event carries no per-child data. So the
+     payload can't ride the event; it goes through the staging slot, and
+     the parent reads the whole slot once the join resolves.
+   - The single `:spawn` in `:configuring` is the exception: its
+     completion event *does* reach the parent's `:on` table (only join
+     events get intercepted). So the config child carries its payload on
+     the event, and `:promote-staged` reads it straight off.
 
-   The single `:spawn` in `:configuring` is different: its completion
-   event IS fed into the parent's `:on` lookup (only `:spawn-all` join
-   events are intercepted). So the config child carries its payload on
-   the completion event, and `:promote-staged` reads it from there.
+   Staging through app-db has a nice side benefit: the loaded data sits
+   in app-db the whole time — visible in the pair tools and snapshottable
+   for SSR hydration.
 
-   Start the boot once at app start via `[:app/boot [:rf.machine/start]]`.
+   Kick the boot once at startup with `[:app/boot [:rf.machine/start]]`.
    That creation marker runs the initial-entry cascade and seeds the
-   machine snapshot in runtime-db (docs/guide/glossary.md#runtime-db)."
+   snapshot in runtime-db (docs/guide/glossary.md#runtime-db)."
   (:require [re-frame.core :as rf]
-            ;; State machines ship in a separate artefact. The require
-            ;; registers `rf/reg-machine` and friends.
+            ;; State machines and managed HTTP each ship as their own
+            ;; artefact. These two requires register what the boot needs:
+            ;; `rf/reg-machine` and friends, and the managed-HTTP fx the
+            ;; child loaders fetch through.
             [re-frame.machines]
-            ;; Managed HTTP ships in a separate artefact. The require
-            ;; registers the fx; without it the child loaders can't
-            ;; issue requests.
             [re-frame.http.managed]
             [boot.schema :as schema]))
 
@@ -73,18 +79,16 @@
 ;; STAGING-SLOT WRITER
 ;; ============================================================================
 ;;
-;; A :spawn-all child hands its payload back to the parent through a staging
-;; slot in app-db, not on the completion event (the runtime intercepts
-;; :spawn-all join events and never feeds them into the parent's :on lookup —
-;; see the ns docstring). Each child writes into `[:boot/staging <staging-key>]`
-;; just before signalling completion; the parent reads the whole slot once on
-;; the :hydrating transition. The loaded data sits in app-db the whole time,
-;; inspectable in tools and snapshottable for SSR.
+;; The hand-off slot for :spawn-all children. Each one drops its payload into
+;; `[:boot/staging <staging-key>]` just before signalling done, and the parent
+;; scoops up the whole slot on the way into :hydrating. (Why a slot and not the
+;; event? The ns docstring has the long answer; the short one is that join
+;; events never reach the parent's :on table.)
 
 (rf/reg-event :boot/stage-payload
-  {:doc "Write a child-loaded payload into the boot machine's
-         staging slot. Dispatched by the :boot/loader child's
-         :dispatch-done action just before the completion event."}
+  {:doc "Stash one child-loaded payload in the boot machine's staging
+         slot. The :boot/loader child fires this from its :dispatch-done
+         action, right before the completion event."}
   (fn handler-boot-stage-payload [{:keys [db]} [_ staging-key payload]]
     {:db (assoc-in db [:boot/staging staging-key] payload)}))
 
@@ -92,20 +96,22 @@
 ;; CHILD LOADER MACHINE — :boot/loader
 ;; ============================================================================
 ;;
-;; The reusable child machine. One spec, four instances. Each instance
-;; carries its own `:data` map (`:parent-id`, `:child-id`, `:staging-key`,
-;; `:url`) planted by the parent's per-child `:data` fn. The child spawns in
-;; `:idle`; the runtime synthesises a `:rf.machine.spawn/spawned` event that
-;; moves it to `:loading`, which fires the `:begin-fetch` entry action.
+;; The reusable child: GET a URL, branch on the reply, report back. One spec,
+;; four instances — config, routes, flags, user — distinguished only by the
+;; `:data` (`:parent-id`, `:child-id`, `:staging-key`, `:url`) the parent
+;; plants at spawn. Each instance is born in `:idle`; the runtime drops a
+;; `:rf.machine.spawn/spawned` event into it, which moves it to `:loading` and
+;; fires the `:begin-fetch` entry action. Write the fetch logic once, run it
+;; four times.
 
 (rf/reg-machine :boot/loader
   {:initial :idle
-   ;; Validate each spawned loader's `:data` at spawn time. The loader is
-   ;; only ever spawned (one instance per asset, with a generated id like
-   ;; `:boot/loader#0`), so its snapshot sits at a per-instance path no
-   ;; fixed app-schema can reach. The machine `[:schemas :data]` slot
-   ;; checks `:data` instead. The per-child `:data` fn (see :app/boot below)
-   ;; replaces this base map with the planted identity at spawn.
+   ;; Validate each spawned loader's `:data` at spawn time. A loader is only
+   ;; ever spawned — one instance per asset, with a generated id like
+   ;; `:boot/loader#0` — so its snapshot lands at a per-instance path no fixed
+   ;; app-schema could ever name. The machine's own `[:schemas :data]` slot is
+   ;; the right surface: it checks `:data` directly. (The per-child `:data` fn
+   ;; in :app/boot below swaps this base map for the planted identity.)
    :schemas {:data schema/LoaderData}
    :data    {:parent-id   nil
              :child-id    nil
@@ -116,10 +122,10 @@
 
    :actions
    {:begin-fetch
-    ;; Issue the GET. The reply routes back to THIS child via
-    ;; :rf/self-id, which the spawn fx stamps into :data. The reply lands
-    ;; at the machine's `:asset/replied` event, so the machine branches on
-    ;; success vs failure before forwarding to the parent.
+    ;; Fire the GET. The reply is addressed back to THIS child via
+    ;; :rf/self-id (the spawn fx stamps it into :data), landing as the
+    ;; `:asset/replied` event — so the loader sorts success from failure
+    ;; itself before it ever bothers the parent.
     (fn [{data :data}]
       (let [self-id (:rf/self-id data)]
         {:fx [[:rf.http/managed
@@ -129,47 +135,47 @@
                 :on-failure [self-id [:asset/replied :failure]]}]]}))
 
     :dispatch-done
-    ;; Terminal-state entry. First write the loaded payload into
-    ;; [:boot/staging <staging-key>], then dispatch the completion event
-    ;; back to the parent. The completion event carries both the child-id
-    ;; and the payload:
-    ;;   - In :configuring (a single :spawn), this event lands in the
-    ;;     parent's :on lookup, where :promote-staged reads the payload
-    ;;     off the event to thread `:api-base` into the next phase.
-    ;;   - In :loading-deps (a :spawn-all), the runtime intercepts this
-    ;;     event for join bookkeeping only — it is NOT fed into the
-    ;;     parent's :on lookup. Those payloads reach the parent via the
-    ;;     staging slot read in :enter-hydrating. The event payload is
-    ;;     harmless there.
+    ;; Runs on entering :done. Two steps: stash the payload in the staging
+    ;; slot, then tell the parent we're finished. The done event carries
+    ;; the child-id and payload, but who actually reads that payload depends
+    ;; on the spawn shape:
+    ;;   - Under a single :spawn (config), the event reaches the parent's
+    ;;     :on table, and :promote-staged plucks the payload off it to
+    ;;     thread `:api-base` into the next phase.
+    ;;   - Under a :spawn-all (the deps), the runtime keeps this event for
+    ;;     join bookkeeping and never shows it to the parent's :on table.
+    ;;     Those payloads travel through the staging slot instead, read in
+    ;;     :enter-hydrating. Carrying it on the event too is harmless.
     (fn [{data :data}]
       {:fx [[:dispatch [:boot/stage-payload (:staging-key data) (:payload data)]]
             [:dispatch [(:parent-id data)
                         [:boot/asset-loaded (:child-id data) (:payload data)]]]]})
 
     :dispatch-error
-    ;; Terminal failure-state entry. Forwards the failure to the parent's
-    ;; :on-child-error slot; the parent's :on-any-failed routes it to
-    ;; `:failed`.
+    ;; Runs on entering :failed. Hands the failure up to the parent's
+    ;; :on-child-error slot, where :on-any-failed routes the whole boot to
+    ;; `:failed`. One bad child sinks the boot.
     (fn [{data :data}]
       {:fx [[:dispatch [(:parent-id data)
                         [:boot/asset-failed (:child-id data) (:error data)]]]]})}
 
    :states
-   {;; :idle is the :initial state. The spawn fx synthesises a
-    ;; [:rf.machine.spawn/spawned] event into the new child; :idle's
-    ;; transition picks it up and moves to :loading, which fires the
-    ;; :begin-fetch entry action.
+   {;; :idle is where every loader starts. The runtime drops a
+    ;; [:rf.machine.spawn/spawned] event into the fresh child; this
+    ;; transition catches it and moves to :loading, which kicks off the
+    ;; :begin-fetch entry action. Blink and you'll miss :idle.
     :idle
     {:on {:rf.machine.spawn/spawned :loading}}
 
     :loading
     {:entry :begin-fetch
      :on    {:asset/replied
-             ;; Guarded fork on the reply kind: the first branch whose
-             ;; `:guard` passes wins. The runtime appends the reply payload
-             ;; as the last element of the event vector, so the event arrives
-             ;; as [:asset/replied :success {:kind :success :value ...}]
-             ;; — pick the value out of the 3rd-position arg.
+             ;; A guarded fork on the reply kind — first branch whose
+             ;; `:guard` passes wins, success before failure. The runtime
+             ;; tacks the reply payload onto the end of the event vector,
+             ;; so it arrives as
+             ;; [:asset/replied :success {:kind :success :value ...}]
+             ;; and we read the value out of the 3rd slot.
              [{:guard (fn [{ev :event}] (= :success (nth ev 1 nil)))
                :target :done
                :action (fn [{data :data [_ _ reply] :event}]
@@ -187,10 +193,10 @@
 
 (rf/reg-machine :app/boot
   {:initial :configuring
-   ;; Validate the `:app/boot` snapshot's `:data` slot. `BootData`
-   ;; describes `:data` only. The snapshot lives in runtime-db, so its
-   ;; `[:schemas :data]` slot is the validation surface (not an
-   ;; app-schema), same as the `:boot/loader` child above.
+   ;; Validate the `:app/boot` snapshot's `:data`. Like the loader above,
+   ;; the snapshot lives in runtime-db, so the machine's own
+   ;; `[:schemas :data]` slot is the validation surface — an app-schema
+   ;; can't reach it. `BootData` describes `:data` only.
    :schemas {:data schema/BootData}
    :data    {:phase  :configuring
              :config nil
@@ -205,42 +211,40 @@
       {:data (assoc data :error failure)})
 
     :promote-staged
-    ;; Runs on the :configuring → :loading-deps transition. The config
-    ;; child carried its payload on the `:boot/asset-loaded` completion
-    ;; event (a single :spawn's completion event IS fed into the parent's
-    ;; :on lookup), so this action reads the config off the event and
-    ;; records it into the boot machine's :data. The next phase's `:data`
-    ;; fns then read the loaded `:api-base` and build each child's URL
-    ;; from it. The transition's `:action` runs before the child `:data`
-    ;; fns, so they see the value in the parent's snapshot.
+    ;; Runs on the :configuring → :loading-deps transition, and it's the
+    ;; hinge of the whole config-flows-downstream story. The config child's
+    ;; done event reached us (a single :spawn's event does land in the :on
+    ;; table), so we pull the config off it and stash it in the boot
+    ;; machine's own :data. A transition's `:action` runs before the next
+    ;; state's child `:data` fns, so by the time those three loaders ask for
+    ;; the `:api-base`, it's already sitting in the parent's snapshot.
     (fn [{data :data [_ _child-id config] :event}]
       {:data (assoc data :config config)})
 
     :enter-hydrating
-    ;; Read the staged payloads out of [:boot/staging ...] and write them
-    ;; into the top-level slices the running app's subs read. Self-
-    ;; transitions to `:ready` once the hydration write lands.
+    ;; Scoop the staged payloads out of [:boot/staging ...] and promote them
+    ;; into the top-level slices the live app's subs actually read. Then
+    ;; self-transition to `:ready` once the write lands.
     (fn [{data :data}]
       {:data (assoc data :phase :hydrating)
        :fx   [[:dispatch [:boot/apply-hydration]]]})}
 
    :states
    {;; ---- :configuring — the :initial state; a single :spawn fetches /config
-    ;; The boot machine is born directly into its first work state. The
-    ;; kick `[:app/boot [:rf.machine/start]]` is a creation marker: it runs
-    ;; the initial-entry cascade — here `:configuring`'s `:spawn` — and
-    ;; stops. It is never fed into an `:on` map as a trigger, so there is no
-    ;; `:idle` parking spot: the machine starts working the moment it is
-    ;; kicked.
+    ;; Unlike the loader, the boot machine is born straight into real work.
+    ;; The kick `[:app/boot [:rf.machine/start]]` is a creation marker: it
+    ;; runs the initial-entry cascade — here, :configuring's `:spawn` — and
+    ;; then it's spent. It never acts as an `:on` trigger, so there's no
+    ;; `:idle` waiting room; the machine is working the instant it's kicked.
     :configuring
     {:spawn {:machine-id :boot/loader
-              ;; `:data` admits a function form
-              ;; `(fn [{:keys [snapshot event]}] data)`, so the child's
-              ;; initial :data can depend on the parent's snapshot at the
-              ;; moment of entry. Plant the identity (parent / child /
-              ;; staging-key / URL) here. This first URL is the fixed config
-              ;; endpoint — the source the rest of the boot threads from —
-              ;; so it is a literal, not derived.
+              ;; `:data` accepts a function — `(fn [{:keys [snapshot event]}]
+              ;; data)` — so a child's starting :data can lean on the
+              ;; parent's snapshot at entry. Here we just plant the identity
+              ;; (parent / child / staging-key / URL). This first URL is the
+              ;; fixed config endpoint that the rest of the boot threads
+              ;; from, so it's a literal — there's nothing to derive it from
+              ;; yet.
               :data       (fn boot-config-data [_]
                             {:parent-id   :app/boot
                              :child-id    :config
@@ -255,17 +259,16 @@
     :loading-deps
     {:spawn-all
      {:children
-      ;; Each child is the same :boot/loader machine, distinguished only
-      ;; by its :data slot. Each :data fn reads the parent's `:api-base`
-      ;; (recorded by :promote-staged on the way into this state) and
-      ;; builds the child's URL from it.
+      ;; Three children, all the same :boot/loader, differing only in their
+      ;; :data. Each :data fn reads the `:api-base` that :promote-staged
+      ;; recorded on the way in and builds its child's URL from it.
       [{:id         :routes
         :machine-id :boot/loader
         :data       (fn boot-routes-data [{snap :snapshot}]
-                      ;; The :data fn receives `{:snapshot :event}`. The
-                      ;; snapshot is the parent's value, not app-db.
-                      ;; :promote-staged already ran, so the loaded
-                      ;; `:api-base` is visible here.
+                      ;; A :data fn is handed `{:snapshot :event}`. That
+                      ;; snapshot is the parent's value (not app-db), and
+                      ;; since :promote-staged already ran, the loaded
+                      ;; `:api-base` is right there for the taking.
                       {:parent-id   :app/boot
                        :child-id    :routes
                        :staging-key :routes
@@ -293,21 +296,22 @@
              :boot/deps-failed {:target :failed
                                 :action :record-failure}}}
 
-    ;; ---- :hydrating — applies the loaded payloads into app-db ----------
+    ;; ---- :hydrating — promotes the loaded payloads into app-db ---------
     :hydrating
     {:entry :enter-hydrating
      :on    {:boot/hydrated {:target :ready}}}
 
     ;; ---- :ready / :failed — terminal -------------------------------------
     :ready  {:meta {:terminal? true}}
-    :failed {;; :failed is re-entrant: dispatching `[:app/boot [:boot/restart]]`
-             ;; from the failure screen re-runs the boot from :configuring.
-             ;; Re-boot uses a real event, not the `:rf.machine/start`
-             ;; creation marker — the marker is never fed into an `:on` map,
-             ;; so once the machine exists it is inert. The terminal? meta
-             ;; stays true so visualisers and conformance harnesses see
-             ;; :failed as a terminal state; the re-entry transition is the
-             ;; explicit re-boot, not the default end of the flow.
+    :failed {;; Terminal, but not a dead end. The failure screen's retry
+             ;; button dispatches `[:app/boot [:boot/restart]]`, which runs
+             ;; the boot again from :configuring. Note it's a real event,
+             ;; *not* the `:rf.machine/start` creation marker — that marker
+             ;; only ever kicks a machine to life once, so on an existing
+             ;; machine it's inert; re-boot has to be an ordinary transition.
+             ;; We keep `terminal? true` so visualisers and conformance
+             ;; harnesses still read :failed as terminal; the retry is the
+             ;; explicit way out, not the flow's natural end.
              :meta {:terminal? true}
              :on   {:boot/restart {:target :configuring
                                    :action (fn [{data :data}]
@@ -317,27 +321,27 @@
 ;; HYDRATION PROMOTION
 ;; ============================================================================
 ;;
-;; A plain reg-event does the cross-slice writes the boot machine's
-;; :hydrating action dispatches. Keeping these reads and writes in an
-;; explicit handler (not in the machine's action body) makes the boot trace
-;; one step at a time: `:enter-hydrating` is one trace, this handler another.
+;; The :hydrating action could do these cross-slice writes itself, but it
+;; hands them to a plain reg-event instead — on purpose. Splitting them out
+;; keeps the boot trace readable one step at a time: `:enter-hydrating` is one
+;; entry in the trace, this handler the next, rather than a single opaque blob.
 
 (rf/reg-event :boot/apply-hydration
-  {:doc "Promote every staged child payload at [:boot/staging ...]
-         into the top-level app-db slices the running app reads. Fires
-         :boot/hydrated back at :app/boot to transition from :hydrating
-         to :ready."}
-  ;; The app slices land in app-db (`:db`); the boot machine's snapshot is
-  ;; runtime-db state, so the snapshot mirror below is a `:rf.db/runtime`
-  ;; effect (docs/guide/glossary.md#runtime-db).
+  {:doc "Promote every staged payload at [:boot/staging ...] into the
+         top-level app-db slices the running app reads, then fire
+         :boot/hydrated back at :app/boot so it can finish the trip from
+         :hydrating to :ready."}
+  ;; The app slices go to app-db (`:db`). The snapshot mirror below is a
+  ;; separate `:rf.db/runtime` effect, because a machine snapshot lives in
+  ;; runtime-db, not app-db (docs/guide/glossary.md#runtime-db).
   ;;
-  ;; ADVANCED — runtime-db writes are NOT an everyday-app pattern. This is the
-  ;; only handler in the examples tree that returns a `:rf.db/runtime` effect,
-  ;; deliberately: it teaches the hydration reference shape (mirroring loaded
-  ;; values into a machine snapshot so the snapshot is self-describing for
-  ;; SSR and tools). Ordinary app handlers write app-db via `:db` only and let
-  ;; the machine runtime own its snapshot; reach for `:rf.db/runtime` only
-  ;; when you are intentionally authoring boot/hydration glue.
+  ;; ADVANCED — and genuinely rare. This is the *only* handler in the whole
+  ;; examples tree that writes a `:rf.db/runtime` effect, and it's here to
+  ;; teach one specific shape: mirroring loaded values into a machine snapshot
+  ;; so the snapshot is self-describing for SSR and tools. Everyday handlers
+  ;; write app-db through `:db` and leave the machine runtime to mind its own
+  ;; snapshot. Reach for `:rf.db/runtime` only when you're deliberately writing
+  ;; boot/hydration glue like this.
   (fn handler-boot-apply-hydration [{:keys [db] rt :rf.db/runtime} _]
     (let [staging (:boot/staging db)]
       {:db (-> db
@@ -345,8 +349,8 @@
                (assoc :flags  (:flags staging))
                (assoc :user   (:user staging))
                (assoc :routes (:routes staging)))
-       ;; Mirror the loaded values into the boot machine's :data slice so the
-       ;; snapshot is self-describing for SSR and tools.
+       ;; Mirror the same values into the boot machine's :data so the snapshot
+       ;; stands on its own for SSR and tools.
        :rf.db/runtime (update-in (or rt {})
                                  [:rf.runtime/machines :snapshots :app/boot :data] assoc
                                  :config (:config staging)
@@ -360,12 +364,11 @@
 ;; ============================================================================
 
 (rf/reg-event :boot/initialise
-  {:doc "Top-level app boot. Fires the :app/boot machine's
-         `:rf.machine/start` creation marker to kick the boot off — the
-         machine is born directly into `:configuring` and runs its
-         `:spawn` entry cascade. The app seeds this event via the
-         frame-provider's `:initial-events` (see core.cljs), which runs
-         it once on first mount."}
+  {:doc "The one button that starts everything. It fires the :app/boot
+         machine's `:rf.machine/start` creation marker, which births the
+         machine into `:configuring` and runs its `:spawn` cascade. The
+         frame-provider seeds this via `:initial-events` (see core.cljs),
+         so it runs exactly once, on first mount."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:app/boot [:rf.machine/start]]]]}))
 
@@ -373,8 +376,9 @@
 ;; SUBS — boot-state slots the views read
 ;; ============================================================================
 
-;; Machine snapshots are runtime-db state — read them through the
-;; framework `:rf/machine` sub (docs/machines/glossary.md#snapshot).
+;; A machine snapshot lives in runtime-db, so you reach it through the
+;; framework's `:rf/machine` sub (docs/machines/glossary.md#snapshot). The
+;; small subs below are just convenient slices off that one snapshot.
 (rf/reg-sub :app.boot/snapshot
   :<- [:rf/machine :app/boot]
   (fn [snapshot _] snapshot))

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -1,12 +1,12 @@
 (ns boot.core
-  "Entry point for the boot example.
+  "Entry point for the boot example — mount, trigger, and the fake backend.
 
    `run` installs the Reagent adapter and renders the app under a
    frame-provider (docs/guide/glossary.md#frame-provider). The provider
-   redirects HTTP to a per-URL canned stub (so the example runs
-   standalone — no backend) and seeds the boot machine on first mount.
-   The root view stays on the boot-progress screen until the boot
-   machine reaches `:ready`.
+   does two jobs: it points HTTP at a per-URL canned stub (so the example
+   runs on its own, with no server behind it) and it seeds the boot
+   machine on first mount. Until that machine reaches `:ready`, the root
+   view stays on the boot-progress screen.
 
    The four mocked endpoints:
      /api/config.json   → static app config (api-base, env, build)
@@ -14,23 +14,23 @@
      /api/flags.json    → feature flags
      /api/user.json     → initial user record
 
-   The stub routes by URL substring and delegates to the framework's
-   `:rf.http/managed-canned-success`, so the reply shape matches what a
-   live server would produce (docs/resources/glossary.md#reply-map)."
+   The stub picks a payload by URL substring and hands off to the
+   framework's `:rf.http/managed-canned-success`, so each reply has
+   exactly the shape a real server would send
+   (docs/resources/glossary.md#reply-map)."
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Required for `rf/init!`.
+            ;; The adapter `rf/init!` needs.
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; Managed HTTP ships in a separate artefact. The require
-            ;; registers `:rf.http/managed` and family; without it the
-            ;; child loaders' dispatches would raise :rf.error/no-such-fx.
+            ;; Managed HTTP ships in its own artefact; this require
+            ;; registers `:rf.http/managed` and family. Without it, every
+            ;; child loader's fetch would raise :rf.error/no-such-fx.
             [re-frame.http.managed]
-            ;; This example overrides :rf.http/managed with a per-URL stub
-            ;; that delegates to :rf.http/managed-canned-success (the same
-            ;; reply shape a live server produces). The canned-stub fx ids
-            ;; register from re-frame.http.test-support, so require it here
-            ;; to opt into the canned stubs.
+            ;; The canned-stub fx ids (`:rf.http/managed-canned-success`)
+            ;; live in test-support. We require it because the demo stub
+            ;; below leans on them to fake the backend — same reply shape a
+            ;; live server produces.
             [re-frame.http.test-support]
             [boot.schema]
             [boot.boot]
@@ -40,12 +40,12 @@
 ;; DEMO STUBS — per-URL canned :rf.http/managed override
 ;; ============================================================================
 ;;
-;; The boot fetches /api/config.json and three more endpoints, but no backend
-;; ships with this example. This section defines the canned payloads and the
-;; `:boot.demo/http-stub` fx that returns one per URL substring. The provider
-;; in `run` wires this stub in as the frame's `:rf.http/managed` via
-;; `:fx-overrides`. Each reply delegates to `:rf.http/managed-canned-success`,
-;; the same reply shape a live server produces.
+;; The boot wants to fetch four endpoints, but there's no server here to answer
+;; them — so we fake one. This section holds the canned payloads and the
+;; `:boot.demo/http-stub` fx that picks one by URL substring. The provider in
+;; `run` slots this stub in as the frame's `:rf.http/managed` via
+;; `:fx-overrides`, and each reply rides `:rf.http/managed-canned-success` so
+;; it looks exactly like the real thing.
 
 (def ^:private demo-config
   {:api-base "/api"
@@ -78,38 +78,37 @@
       :else                            {})))
 
 (rf/reg-event :boot.demo/schedule-reply
-  {:doc "Private — dispatched from :boot.demo/http-stub. Uses
-         `:dispatch-later` so framework time controls (time-travel,
-         the `:dispatch-later` override seam) apply to the demo
-         latency. No user dispatches this directly."}
+  {:doc "Internal plumbing, fired by :boot.demo/http-stub. It schedules
+         the reply with `:dispatch-later` rather than a raw timeout, so
+         framework time controls (time-travel, the `:dispatch-later`
+         override seam) cover the fake latency too. Not for direct use."}
   (fn handler-boot-demo-schedule-reply [_ [_ args-map payload]]
     {:fx [[:dispatch-later
            {:ms    60
             :event [:boot.demo/deliver-reply args-map payload]}]]}))
 
 (rf/reg-event :boot.demo/deliver-reply
-  {:doc "Private — fired by the :dispatch-later scheduled in
-         :boot.demo/schedule-reply. Delegates to the framework's
-         `:rf.http/managed-canned-success` with the per-URL canned
-         payload."}
+  {:doc "The other half of the fake latency — fired when the
+         `:dispatch-later` from :boot.demo/schedule-reply comes due. It
+         hands the per-URL payload to the framework's
+         `:rf.http/managed-canned-success`, which completes the request."}
   (fn handler-boot-demo-deliver-reply [_ [_ args-map payload]]
     {:fx [[:rf.http/managed-canned-success (assoc args-map :value payload)]]}))
 
 (rf/reg-fx :boot.demo/http-stub
-  {:doc       "Demo override for `:rf.http/managed`: routes by URL
-               substring to canned boot responses so the example runs
-               standalone without a backend.
+  {:doc       "Our stand-in for `:rf.http/managed`: match the URL by
+               substring, return the matching canned payload, and the
+               example needs no backend at all.
 
-               Dispatches the private :boot.demo/schedule-reply event so
-               the deferred reply rides `:dispatch-later` (60 ms) rather
-               than raw `js/setTimeout`. The delay lets the boot-progress
-               view render the per-phase loading state before the replies
-               land — without it the boot resolves in one drain and the
-               user only ever sees the `:ready` screen. The reply lands
-               via the framework's `:rf.http/managed-canned-success`.
-
-               Framework time controls (time-travel, the
-               `:dispatch-later` override seam) apply automatically."
+               The 60 ms delay is deliberate, not laziness. It dispatches
+               :boot.demo/schedule-reply so the reply rides `:dispatch-later`
+               instead of a raw `js/setTimeout` — which means framework time
+               controls (time-travel, the override seam) cover it for free.
+               And the pause is what lets you actually *watch* the
+               boot-progress screen step through its phases; without it the
+               whole boot resolves in one drain and you'd blink straight to
+               the `:ready` screen. The reply itself lands via the
+               framework's `:rf.http/managed-canned-success`."
    :platforms #{:server :client}}
   (fn fx-managed-boot-demo [frame-ctx args-map]
     (let [url     (-> args-map :request :url)
@@ -122,34 +121,33 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root, held in an atom and created lazily inside `run`. Doing it
-;; in `run` (not at ns-load) lets several example namespaces share the
-;; browser-test bundle without racing `create-root` onto the same `#app`
-;; element.
+;; The React root, kept in an atom and created lazily inside `run`. We create
+;; it there rather than at ns-load so several example namespaces can share one
+;; browser-test bundle without two of them racing `create-root` onto the same
+;; `#app` element.
 (defonce react-root (atom nil))
 
 ;; The app frame id. Every in-tree `dispatch`/`subscribe` resolves to this
-;; frame; the frame-provider below establishes it (see `run`). An app must
-;; name its frame explicitly — the runtime never invents one.
+;; frame, which the frame-provider below stands up. An app always names its
+;; own frame — the runtime never conjures one for you.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Install the adapter by passing its spec map directly.
+  ;; Hand the adapter's spec map straight to `init!`.
   (rf/init! reagent-adapter/adapter)
 
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; The frame-provider creates, configures, and seeds the app frame in
-    ;; one place:
+    ;; One frame-provider does three things — create the frame, configure it,
+    ;; seed it:
     ;;
-    ;; - `:fx-overrides` redirects `:rf.http/managed` on this frame to the
-    ;;   per-URL canned stub above, so every child loader's GET hits a
-    ;;   canned reply. Frame-wide is the right grain — the boot example
-    ;;   issues no other requests.
-    ;; - `:initial-events` fires `:boot/initialise` once on first mount,
-    ;;   which kicks off the boot machine. On hot reload the frame is
-    ;;   reused and the boot is not re-run.
+    ;; - `:fx-overrides` swaps `:rf.http/managed` on this frame for the canned
+    ;;   stub above, so every loader's GET meets a canned reply. Frame-wide is
+    ;;   the right reach here — the boot makes no other requests.
+    ;; - `:initial-events` fires `:boot/initialise` once on first mount to
+    ;;   kick the boot off. A hot reload reuses the frame and leaves the boot
+    ;;   alone, so you don't re-run it on every save.
     (rdc/render @react-root
                 [rf/frame-provider {:id             app-frame
                                     :doc            "Boot example demo frame."

--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -1,35 +1,33 @@
 (ns boot.schema
-  "Malli schemas for the boot example. See schemas in the guide
-   (docs/guide/glossary.md#schema).
+  "Malli schemas for the boot example. New to schemas? The guide has the
+   tour (docs/guide/glossary.md#schema).
 
-   The schemas describe three things: the wire shape each mocked
-   endpoint returns, the boot-machine snapshot's `:data`, and the child
-   loader's `:data`.
+   These schemas cover three things: the wire shape each mocked endpoint
+   returns, the boot machine's snapshot `:data`, and the child loader's
+   `:data`.
 
-   Two kinds of schema surface appear, picked by what each one validates:
+   They attach in two different ways, and the difference is just *where
+   the thing being validated lives*:
 
-   - **App-db slices** — the `[:boot/staging]` slot and the four
-     top-level slices (`[:config]`, `[:flags]`, `[:user]`, `[:routes]`)
-     live at fixed app-db paths, so they attach with `rf/reg-app-schema`
-     on those paths. App schemas validate the app-db partition only.
-   - **Machine `:data`** — both the `:app/boot` machine and the spawned
-     `:boot/loader` child declare a `[:schemas :data]` slot on
-     `reg-machine` (see `boot.cljs`) that validates the snapshot's `:data`.
-     `BootData` describes the `:app/boot` machine's `:data`; `LoaderData`
-     describes each spawned loader's `:data`, validated at spawn time. A
-     spawned loader gets a generated id like `:boot/loader#0`, so its
-     snapshot sits at a per-instance path no fixed `reg-app-schema` could
-     reach. Machine snapshots live in runtime-db, not app-db, so
-     `reg-app-schema` is not the surface for them
-     (docs/guide/glossary.md#runtime-db)."
+   - **App-db slices** sit at fixed app-db paths — `[:boot/staging]` plus
+     the four top-level slices (`[:config]`, `[:flags]`, `[:user]`,
+     `[:routes]`). Those attach with `rf/reg-app-schema` on the path.
+   - **Machine `:data`** can't go through `reg-app-schema`, because a
+     snapshot lives in runtime-db, not app-db (docs/guide/glossary.md#runtime-db).
+     Instead, each machine carries its own `[:schemas :data]` slot on
+     `reg-machine` (see `boot.cljs`). `BootData` validates the `:app/boot`
+     machine's `:data`; `LoaderData` validates each spawned loader's
+     `:data` at spawn time. (A spawned loader gets a generated id like
+     `:boot/loader#0`, so its snapshot lands at a per-instance path no
+     fixed `reg-app-schema` could ever name.)"
   (:require [re-frame.core :as rf]
-            ;; Schemas ship in a separate artefact. The require registers
+            ;; Schemas ship in their own artefact; this require registers
             ;; `rf/reg-app-schema`.
             [re-frame.schemas]
-            ;; The Malli adapter ns publishes the default validator. The
-            ;; require is the CLJS opt-in for Malli validation — without it
-            ;; the default validator soft-passes and no failure trace fires
-            ;; for malformed app-db slices.
+            ;; This one turns Malli validation on. The Malli adapter ns
+            ;; publishes the default validator, and requiring it is the CLJS
+            ;; opt-in — skip it and the validator soft-passes, so a malformed
+            ;; slice slides through with no failure trace.
             [re-frame.schemas.malli])
   (:require-macros [re-frame.core :refer [with-frame]]))
 
@@ -38,8 +36,8 @@
 ;; ============================================================================
 
 (def Config
-  "Static app configuration. In a real app this would arrive from a
-   build-time /config endpoint; here the demo stub synthesises a
+  "Static app configuration. In a real app this rides in from a
+   build-time /config endpoint; here the demo stub makes up a
    plausible payload."
   [:map
    [:api-base    :string]
@@ -48,26 +46,26 @@
    [:title       :string]])
 
 (def Flags
-  "Feature flags. The map is open — apps add their own keys; the
-   schema only fixes the well-known ones."
+  "Feature flags. The map is open on purpose — apps bring their own
+   keys; the schema only pins down the well-known ones."
   [:map
    [:dark-mode?       :boolean]
    [:beta-channel?    :boolean]
    [:onboarding-skip? :boolean]])
 
 (def User
-  "Initial user record. In a real app this would arrive from /user
-   after the session token is restored. Here the demo stub returns
-   a static demo user."
+  "The initial user record. In a real app this arrives from /user once
+   the session token is restored; here the demo stub just returns a
+   fixed demo user."
   [:map
    [:id       :string]
    [:username :string]
    [:email    :string]])
 
 (def Routes
-  "Application route table. In a real app this might be hard-coded;
-   here we fetch it so the boot graph has four parallel dependencies
-   to demonstrate `:spawn-all`."
+  "The app's route table. A real app might hard-code this — we fetch it
+   instead, purely so the boot graph has a fourth dependency and the
+   parallel `:spawn-all` step has something to fan out over."
   [:vector
    [:map
     [:id   :keyword]
@@ -77,16 +75,15 @@
 ;; BOOT-MACHINE :data SHAPE — :app/boot
 ;; ============================================================================
 ;;
-;; The boot machine's snapshot lives in runtime-db. Its `:state` cycles
-;; `:configuring → :loading-deps → :hydrating → :ready` (terminal), with
-;; `:failed` (terminal) reached if any child errors. `:data` carries the
-;; per-phase progress slot and the loaded payloads.
+;; The boot machine's snapshot lives in runtime-db. Its `:state` walks
+;; `:configuring → :loading-deps → :hydrating → :ready` (terminal), branching
+;; to `:failed` (terminal) if any child errors. `:data` carries the current
+;; phase and the loaded payloads.
 ;;
-;; `BootData` describes the `:data` slot only, not the whole
-;; `{:state … :data …}` snapshot. It attaches via the `:app/boot` machine's
+;; `BootData` describes the `:data` slot only — not the whole
+;; `{:state … :data …}` snapshot — and attaches through the machine's
 ;; `[:schemas :data]` slot on `reg-machine` (see `boot.cljs`). Every payload
-;; slot is `:maybe` because they are nil through the staging/loading phases
-;; and only fill on entering `:hydrating`.
+;; slot is `:maybe`, because it's nil right up until `:hydrating` fills it in.
 
 (def BootData
   [:map
@@ -101,42 +98,41 @@
 ;; CHILD LOADER :data SHAPE — :boot/loader (one instance per asset)
 ;; ============================================================================
 ;;
-;; The `:data` slot of the `:boot/loader` child machine. Each loader holds
-;; the parent-id + child-id + staging-key + URL it was spawned with, fetches
-;; once, and dispatches `:boot/asset-loaded` (or `:boot/asset-failed`) back
-;; to its parent on transition into `:done` (or `:failed`). Attached via the
-;; child machine's `[:schemas :data]` slot on `(reg-machine :boot/loader ...)`
-;; in `boot.cljs`; it describes `:data` only and validates each spawned
-;; instance's initial `:data` at spawn time. The per-child `:data` fn (see
-;; :app/boot) plants identity only, so the fetch-result fields below are
-;; optional — they appear later, as the loader moves through `:loading` into
-;; `:done` / `:failed`.
+;; The `:data` of a `:boot/loader` child. Each loader knows the parent-id,
+;; child-id, staging-key, and URL it was spawned with, fetches once, and on
+;; reaching `:done` (or `:failed`) reports `:boot/asset-loaded` (or
+;; `:boot/asset-failed`) back to its parent. It attaches through the child's
+;; `[:schemas :data]` slot on `(reg-machine :boot/loader ...)` in `boot.cljs`,
+;; describing `:data` only and checking each spawned instance at spawn time.
+;; At spawn the parent plants identity and nothing else, so the result fields
+;; below are optional — they show up later, as the loader works through
+;; `:loading` into `:done` / `:failed`.
 
 (def LoaderData
   [:map
-   ;; Identity, planted by the parent's per-child `:data` fn — present from
-   ;; spawn (see :app/boot in boot.cljs).
+   ;; The identity the parent's `:data` fn plants — there from spawn (see
+   ;; :app/boot in boot.cljs).
    [:parent-id   :keyword]
    [:child-id    :keyword]
    [:staging-key :keyword]
    [:url         :string]
-   ;; Filled in only once the fetch replies (the `:asset/replied` action
-   ;; writes :payload or :error). Absent at spawn, so both are optional.
+   ;; Written only once the fetch replies — the `:asset/replied` action sets
+   ;; one of :payload / :error. Nothing at spawn, hence optional.
    [:payload     {:optional true} :any]
    [:error       {:optional true} [:maybe :any]]
-   ;; Address keys the spawn fx stamps into the spawned child's initial
-   ;; :data. Declared optional so the schema documents them; a Malli :map is
-   ;; open, so they'd pass undeclared too.
+   ;; Address keys the spawn fx stamps into the child's initial :data. A Malli
+   ;; :map is open, so they'd pass undeclared anyway — we list them just so
+   ;; the schema names them out loud.
    [:rf/self-id   {:optional true} :any]
    [:rf/parent-id {:optional true} :any]
    [:rf/invoke-id {:optional true} :any]])
 
 (def BootStagingSlice
-  "Shape of `[:boot/staging]` — the per-child hand-off slot the
-   `:spawn-all` children write into and the parent's
-   `:enter-hydrating` action reads from. Each key is optional because
-   the slot is filled incrementally as children complete; once the
-   join resolves all four keys carry their per-child payloads."
+  "Shape of `[:boot/staging]` — the hand-off slot the `:spawn-all`
+   children write into and the parent's `:enter-hydrating` action reads
+   back. Every key is optional because the slot fills in piecemeal, one
+   child at a time; by the moment the join resolves, all four are
+   present and carrying their payloads."
   [:map
    [:config {:optional true} [:maybe Config]]
    [:flags  {:optional true} [:maybe Flags]]
@@ -147,32 +143,27 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 
-;; The runtime rolls back post-commit on a failing app-db schema. The slots
-;; below are nil before the boot machine writes them, so every registration
-;; is wrapped in :maybe to pass during the staging/loading phases.
+;; A failing app-db schema makes the runtime roll the commit back. Each slot
+;; below starts out nil — the boot machine fills it in later — so every
+;; registration wears a `:maybe` to stay valid through the loading phases.
+;; (No machine snapshots here: those validate via the machine's own
+;; `:schemas {:data ...}` in boot.cljs. A `reg-app-schema` on a snapshot path
+;; would guard nothing, since snapshots live in runtime-db, not app-db.)
 
-;; Machine snapshots are runtime-db state, not app-db, so a `reg-app-schema`
-;; on a machine-snapshot path would validate nothing. The `:app/boot`
-;; machine's own `:schemas {:data schema/BootData}` (on `reg-machine` in
-;; boot.cljs) is its snapshot-`:data` surface. The `reg-app-schema` calls
-;; below validate only the app-db slices.
-
-;; `reg-app-schema` is frame-local: a bare ns-load call under no scope
-;; raises `:rf.error/no-frame-context`. This example's app runs in the
-;; `:rf/default` frame (see `core/run`), so name the frame explicitly here
-;; via `with-frame` — the registrations carry a frame stamp even though they
-;; land at module-load before `init!`.
+;; One wrinkle worth knowing: `reg-app-schema` is frame-local, so a bare
+;; ns-load call with no frame in scope raises `:rf.error/no-frame-context`.
+;; This app lives in the `:rf/default` frame (see `core/run`), so we name that
+;; frame explicitly with `with-frame`. The registrations then carry a frame
+;; stamp even though they run at module-load, before `init!`.
 (with-frame :rf/default
-  ;; The :spawn-all children stage their payloads into [:boot/staging]
-  ;; before signalling completion. The :enter-hydrating action reads the
-  ;; staging slot and promotes each payload into the top-level slot below.
-  ;; Registered here so the staging writes are schema-validated like every
-  ;; other slice.
+  ;; The :spawn-all children stage their payloads into [:boot/staging] before
+  ;; signalling done, and :enter-hydrating reads them back out. We register
+  ;; the slot so those staging writes get schema-checked like everything else.
   (rf/reg-app-schema [:boot/staging] {:schema [:maybe BootStagingSlice]})
 
-  ;; The boot machine writes its final payloads into top-level app-db slices
-  ;; on entering `:hydrating`. These are the slices the main app reads via
-  ;; subs once the boot reaches `:ready`.
+  ;; The boot machine promotes its final payloads into these top-level slices
+  ;; on entering `:hydrating` — the very slices the main app reads through subs
+  ;; once the boot hits `:ready`.
   (rf/reg-app-schema [:config] {:schema [:maybe Config]})
   (rf/reg-app-schema [:flags]  {:schema [:maybe Flags]})
   (rf/reg-app-schema [:user]   {:schema [:maybe User]})

--- a/examples/reagent/boot/views.cljs
+++ b/examples/reagent/boot/views.cljs
@@ -1,40 +1,39 @@
 (ns boot.views
-  "Views for the boot example. See views in the guide
-   (docs/guide/glossary.md#view).
+  "Views for the boot example (docs/guide/glossary.md#view).
 
-   The view tree has two halves split by the boot state:
+   The whole view tree pivots on one question — has the boot finished? —
+   and `root-view` is where that fork lives:
 
-   1. **Pre-ready** — while the boot machine is in any non-terminal
-      state, the root renders a `[boot-progress]` screen showing the
-      current phase. The main app view is NOT mounted yet — its
-      subscriptions would read empty slices and have to defend against
-      `nil` everywhere.
+   1. **Not yet** — while the boot machine is in any non-terminal state,
+      we render `[boot-progress]`, a screen that just names the current
+      phase. The main app stays unmounted, which spares it from reading
+      half-empty slices and guarding against `nil` at every turn.
 
-   2. **Post-ready** — once the boot machine reaches `:ready`, the root
-      swaps in `[main-app]`. The main view freely reads `:config`,
-      `:flags`, `:user`, and `:routes` from app-db; the slices are
-      populated and stable.
+   2. **Ready** — once the boot reaches `:ready`, we swap in `[main-app]`.
+      It reads `:config`, `:flags`, `:user`, and `:routes` straight from
+      app-db with no defensiveness, because by now they're all there and
+      not going anywhere.
 
-   The failure path renders `[boot-failed]` (terminal `:failed`), which
-   surfaces the error and offers a retry button. The retry dispatches
-   `[:app/boot [:boot/restart]]` straight back into the boot machine,
-   re-running it from `:configuring`. Re-boot uses a real event, not the
-   `:rf.machine/start` creation marker — the marker is inert once the
-   machine already exists.
+   3. **Failed** — `[boot-failed]` shows the error and a retry button.
+      Retry dispatches `[:app/boot [:boot/restart]]` to run the boot
+      again from `:configuring`. (A real event, note — not the
+      `:rf.machine/start` creation marker, which goes inert the moment
+      the machine exists.)
 
-   Splitting the views by boot state keeps all the loading logic in the
-   boot machine. The alternative — mount the main app and let each
-   sub-view render its own per-phase skeleton — scatters that logic
-   across the whole view tree. Here the views just read `:app.boot/ready?`.
+   Forking here, in one place, is the whole trick. It keeps every scrap
+   of loading logic inside the boot machine. The alternative — mount the
+   main app and let each sub-view paint its own loading skeleton — would
+   smear that logic across the entire tree. Instead the views just ask
+   `:app.boot/ready?` and get on with it.
 
-   The views are intentionally minimal — the goal is to show the boot
-   shape, not a polished UI."
+   The views are deliberately bare. The point is the boot shape, not a
+   pretty UI."
   (:require [re-frame.core :as rf]
             [boot.boot])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
-(reg-view ^{:doc "Pre-ready screen — visible while the boot machine
-                  is in any non-terminal state."}
+(reg-view ^{:doc "The waiting screen — what you see while the boot
+                  machine is still working through its phases."}
           boot-progress []
   (let [state @(subscribe [:app.boot/state])]
     [:div.boot-progress {:data-testid "boot-progress"}
@@ -52,8 +51,8 @@
       ". The main app view does not mount until the boot reaches "
       [:code ":ready"] "."]]))
 
-(reg-view ^{:doc "Terminal :failed screen — surfaces the recorded
-                  error and offers a retry."}
+(reg-view ^{:doc "The :failed screen — shows what went wrong and offers
+                  a retry that re-runs the boot from the top."}
           boot-failed []
   (let [err @(subscribe [:app.boot/error])]
     [:div.boot-failed {:data-testid "boot-failed"}
@@ -68,9 +67,9 @@
                :on-click    #(dispatch [:app/boot [:boot/restart]])}
       "Retry boot"]]))
 
-(reg-view ^{:doc "Post-ready screen — the main app. By the time this
-                  renders, the four boot-loaded slices are populated
-                  in app-db and stable."}
+(reg-view ^{:doc "The main app — the screen the boot was clearing the
+                  way for. By the time it renders, all four loaded slices
+                  are sitting in app-db, populated and stable."}
           main-app []
   (let [config @(subscribe [:app/config])
         flags  @(subscribe [:app/flags])
@@ -98,10 +97,9 @@
        (for [{:keys [id path]} routes]
          ^{:key id} [:li (str id " → " path)])]]]))
 
-(reg-view ^{:doc "Root view — switches on the boot machine's state.
-                  This is the only place in the application that
-                  decides whether to mount the main app vs the
-                  boot-progress screen."}
+(reg-view ^{:doc "The fork in the road. Reads the boot machine's state
+                  and picks one of three screens — and it's the only
+                  place in the app that makes that call."}
           root-view []
   (let [state @(subscribe [:app.boot/state])]
     (cond

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -1,17 +1,18 @@
 (ns counter.core
-  "The smallest possible re-frame2 app. One slice of app-db, three event
-   handlers, one subscription, one view, all running in one frame.
+  "The smallest possible re-frame2 app: a number and two buttons. One slice
+   of app-db, three event handlers, one subscription, one view, one frame.
 
-   This is the cleanest place to meet the event cascade: a click
-   dispatches an event, a handler returns a new app-db, a subscription
-   re-derives, and the view re-renders. See the guide's
-   `docs/guide/concepts/events-and-the-cascade.md`.
+   Small on purpose. With nothing else in the way, you can watch a single
+   click make the whole loop turn. The click dispatches an event, a handler
+   returns a new app-db, the subscription re-derives, and the view
+   re-renders — round and round. That loop is the entire idea of re-frame2;
+   every bigger app is this same shape with more parts bolted on. The guide
+   walks it slowly in `docs/guide/concepts/events-and-the-cascade.md`.
 
-   The frame is set up in one spot — the render root's
-   `frame-provider {:id …}` in `run` below creates the app frame and runs
-   its `:initial-events` seed.
+   The frame is stood up in exactly one place: the `frame-provider` at the
+   render root in `run` below. It names the frame and seeds it once.
 
-   Shows: `reg-event`, `reg-sub`, and `reg-view` with its frame-bound
+   On the menu: `reg-event`, `reg-sub`, and `reg-view` with its frame-bound
    `dispatch`/`subscribe`."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core    :as rf]
@@ -21,11 +22,13 @@
 
 ;; -- Events / subs -----------------------------------------------------------
 ;;
-;; An event handler is a pure function: it takes coeffects (which carry the
-;; current app-db) and the event vector, and returns an effect map. The
-;; `{:db …}` key means "replace app-db with this value". The runtime
-;; commits that value atomically. The handler computes the new value; it
-;; never mutates app-db. See `docs/guide/glossary.md#event-handler`.
+;; An event handler is a pure function with a simple job: read the world,
+;; describe the next one. It takes coeffects (which carry the current
+;; app-db) and the event vector, and returns an effect map. The `{:db …}`
+;; key just means "make this the new app-db", and the runtime commits it
+;; for you, all at once. Notice the handler never reaches out and pokes
+;; app-db — it only computes a value and hands it back. Pure all the way
+;; down. See `docs/guide/glossary.md#event-handler`.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -42,15 +45,18 @@
 ;; -- Views -------------------------------------------------------------------
 ;;
 ;; A view is a pure function from subscription values to hiccup. This one
-;; reads state by dereffing a `subscribe` and dispatches an event on click.
-;; It holds no business logic — the inc/dec live in the handlers above.
+;; deref's a `subscribe` to read the count, and dispatches an event when a
+;; button is clicked. That's it — no logic about what inc/dec mean. The
+;; view asks for state and announces clicks; the handlers above do the
+;; thinking. Keeping those two jobs apart is most of why re-frame2 views
+;; stay easy to reason about.
 ;;
-;; `reg-view` makes `dispatch` and `subscribe` available in the body as
-;; local bindings, so they need no require here. Both resolve at render
-;; time to the frame in scope — the `frame-provider` in `run` below scopes
-;; this tree to the app frame. `reg-view` also defines a Var named after
-;; the symbol, so `counter-app` can reference `counter-buttons` directly.
-;; See `docs/guide/concepts/views.md`.
+;; You'll notice `dispatch` and `subscribe` are used here with no require
+;; and no `rf/` prefix. `reg-view` hands them to you as locals, already
+;; wired to the frame in scope at render time — the `frame-provider` in
+;; `run` below is what puts this tree in a frame. `reg-view` also def's a
+;; Var named for the symbol, which is how `counter-app` can name
+;; `counter-buttons` just below. See `docs/guide/concepts/views.md`.
 
 (reg-view counter-buttons []
   [:div
@@ -58,39 +64,46 @@
    [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:counter/value])]
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
-;; The root `counter-app` view just renders `counter-buttons`. `run` wraps
-;; this tree in the `frame-provider` that establishes the frame.
+;; The root view does nothing but render `counter-buttons`. A touch
+;; ceremonial for one child, but it gives `run` a single tree to wrap in
+;; the `frame-provider` that stands up the frame.
 
 (reg-view counter-app []
   [counter-buttons])
 
 ;; -- Mount -------------------------------------------------------------------
 ;;
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. Loading a namespace must produce no DOM side effects, so that
-;; co-required example namespaces don't race `create-root` onto the shared
-;; `#app`. See examples/TESTING.md, "mount-isolation".
+;; The React root lives in an atom and is created lazily inside `run`, never
+;; at ns-load. The rule: loading a namespace must touch no DOM. Otherwise
+;; two example namespaces that get required together would both lunge for
+;; the shared `#app` element and race to `create-root` on it — and races
+;; are exactly the bug you don't want in your test harness. See
+;; examples/TESTING.md, "mount-isolation".
 
 (defonce react-root (atom nil))
 
-;; The whole frame lifecycle lives in one spot: the `frame-provider {:id
-;; app-frame …}` in `run` below. The first mount creates the app frame and
-;; runs its `:initial-events` once to seed app-db. From then on every
-;; `dispatch`/`subscribe` in the tree resolves to that frame. A later mount
-;; under the same `:id` (a hot reload) reuses the live frame and does not
-;; re-seed, so the counter keeps its value. See
+;; The frame's whole life story fits in one place: the `frame-provider {:id
+;; app-frame …}` in `run` below. First mount creates the frame and runs its
+;; `:initial-events` once to seed app-db. After that, every
+;; `dispatch`/`subscribe` in the tree finds its way home to that frame.
+;; Mount again under the same `:id` — a hot reload, say — and the provider
+;; hands back the frame that's already alive instead of re-seeding, so your
+;; counter doesn't snap back to 5 every time you save. See
 ;; `docs/guide/concepts/frames.md`.
 ;;
-;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
-;; with no special status: the runtime never infers a frame, so we name one
-;; here and hand it to the provider. See
+;; `app-frame` is just an id we picked. `:rf/default` looks special but
+;; isn't — it's an ordinary frame id like any other. The runtime never
+;; guesses which frame you mean, so we name one here and hand it over
+;; explicitly. See
 ;; `docs/guide/glossary.md#frame-identity-is-carried-not-found`.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the reactive adapter for the process. Each adapter ns
-  ;; exports an `adapter` var; require the ns and pass that var. Call once
-  ;; at startup. See `docs/guide/glossary.md#init`.
+  ;; `init!` tells re-frame2 which reactive substrate to render through —
+  ;; here, Reagent. Each adapter ns exports an `adapter` var; you require the
+  ;; ns and pass that var. One call, at startup, and you're done. Note it
+  ;; installs the adapter, not a frame — those come later, via the provider.
+  ;; See `docs/guide/glossary.md#init`.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -2,41 +2,42 @@
   "Worked example for flows. Guide: docs/guide/concepts/flows.md
    (glossary: docs/guide/glossary.md#flow).
 
-   A flow is a registered rule: \"when these app-db paths change, run this
-   pure function and write the result to that app-db path.\" Each flow runs
-   right after the event handler and before the db commit, so the handler's
-   change and the fresh flow output land together in one write.
+   A flow is a standing rule: \"when these app-db paths change, run this pure
+   function and write its result to that app-db path.\" Each flow fires right
+   after the event handler and before the db commit, so the handler's change
+   and the fresh flow output land together in a single write.
 
-   WHY A FLOW AND NOT A SUB?  Most derived values should be SUBSCRIPTIONS.
-   Subs are lighter, live in the per-frame sub-cache, and pay no app-db
-   write. Reach for a flow only when the derived value is part of the
-   application's STATE:
+   So when do you reach for a flow instead of a subscription? Almost never,
+   honestly — most derived values want to be subs. Subs are lighter, live in
+   the per-frame sub-cache, and cost no app-db write. A flow earns its keep
+   only when the derived value is genuinely part of the application's *state*:
 
-     - other event handlers read it as plain app-db data (here:
+     - other event handlers read it as plain app-db data (here
        `:checkout/place-order` reads `[:cart :total]` straight off the db);
-     - it should survive SSR hydration, time-travel restore, and app-db
-       serialisation (sub-cache contents do not survive the wire);
-     - the derivation is stable enough to be worth registering.
+     - it has to survive SSR hydration, time-travel restore, and app-db
+       serialisation (the sub-cache doesn't make it across the wire);
+     - the derivation is stable enough to be worth naming and registering.
 
-   This cart shows three things:
+   This cart is a little three-act play for flows:
 
-   1. MATERIALISED COMPUTED STATE — `:cart/subtotal` sums the line items
-      from `[:cart :items]` and writes the result to `[:cart :subtotal]`.
-   2. A TOPOLOGICAL CASCADE — `:cart/total` reads `[:cart :subtotal]`
-      (another flow's output) plus `[:cart :discount-rate]`. The runtime
-      sorts the two flows so `:cart/subtotal` always runs first; both
-      settle in one walk.
-   3. RUNTIME-TOGGLEABLE DERIVATION — the discount is a feature gate. The
-      `:rf.fx/reg-flow` / `:rf.fx/clear-flow` effects register and clear the
-      `:cart/discount-rate` flow from a handler, while the app runs.
+   1. Computed state, materialised — `:cart/subtotal` sums the line items at
+      `[:cart :items]` and writes the result back to `[:cart :subtotal]`.
+   2. A cascade, sorted for you — `:cart/total` reads `[:cart :subtotal]`
+      (another flow's output) and `[:cart :discount-rate]`. The runtime sees
+      the shared path, sorts the two so `:cart/subtotal` always runs first,
+      and both settle in one walk.
+   3. A derivation you can toggle at runtime — the discount is a feature
+      gate. The `:rf.fx/reg-flow` / `:rf.fx/clear-flow` effects register and
+      clear the `:cart/discount-rate` flow from a handler, mid-flight, while
+      the app is running.
 
-   See the guide for the full registration shape, the topological sort, the
+   The guide has the full registration map, the topological sort, the
    one-event lag, and the failure semantics."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Flows ship in their own artefact. Require re-frame.flows once
-            ;; to register the flow API; without it the reg-flow calls below
-            ;; raise :rf.error/flows-artefact-missing.
+            ;; Flows live in their own artefact, so you opt in. Requiring
+            ;; re-frame.flows once wires up the flow API; leave it out and the
+            ;; reg-flow calls below raise :rf.error/flows-artefact-missing.
             [re-frame.flows]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -46,45 +47,48 @@
 ;; FLOWS
 ;; ============================================================================
 ;;
-;; `:inputs` is a vector of paths to watch (a bare path reads app-db; a path
-;; led by `:rf.db/runtime` reads runtime-db). `:derive` receives the values
-;; at those paths positionally and returns the value written to the app-db
-;; `:output-path`. Full registration map: docs/guide/concepts/flows.md.
+;; A flow registration is just data. `:inputs` lists the paths to watch (a
+;; bare path reads app-db; a path led by `:rf.db/runtime` reads runtime-db).
+;; `:derive` gets the values at those paths, in order, and returns the value
+;; written to `:output-path`. That's the whole contract; the full map is in
+;; docs/guide/concepts/flows.md.
 
 (defn- line-total [{:keys [price qty]}]
   (* price qty))
 
-;; A flow belongs to a frame. `reg-flow` must run inside a frame scope; a
-;; bare call raises :rf.error/no-frame-context. This example runs in the
-;; :rf/default frame, so name it here. (The runtime-toggleable
-;; `:cart/discount-rate` flow is registered later via :rf.fx/reg-flow from a
-;; handler, which carries the dispatching frame automatically.)
+;; Every flow belongs to a frame, so `reg-flow` needs a frame in scope; call
+;; it bare and you'll get :rf.error/no-frame-context for your trouble. This
+;; example lives in the :rf/default frame, so we name it once here. (The
+;; toggleable `:cart/discount-rate` flow comes later, registered via
+;; :rf.fx/reg-flow from inside a handler — that route carries the dispatching
+;; frame along for you, no naming required.)
 ;; See docs/guide/glossary.md#frame-identity-is-carried-not-found.
 (with-frame :rf/default
 
 (rf/reg-flow
   {:id     :cart/subtotal
-   :doc    "Sum of every line item's price × qty. Materialised into app-db
-            so the checkout handler can read it as plain data."
+   :doc    "Every line item's price × qty, summed. Materialised into app-db
+            so the checkout handler can read it as ordinary data."
    :inputs [[:cart :items]]
    :derive (fn [items] (reduce + 0 (map line-total items)))
    :output-path [:cart :subtotal]})
 
-;; `:cart/total` reads ANOTHER flow's output (`[:cart :subtotal]`) plus the
-;; discount rate. The runtime derives the dependency edge from the shared
-;; path and sorts the flows so `:cart/subtotal` always runs before
-;; `:cart/total`; both settle in a single walk.
+;; Here's the cascade. `:cart/total` reads another flow's output
+;; (`[:cart :subtotal]`) alongside the discount rate. The runtime spots that
+;; shared path, works out that `:cart/subtotal` feeds `:cart/total`, and runs
+;; them in that order — both settle in a single walk. You never wire the
+;; ordering by hand; the dependency graph falls out of the paths.
 ;;
-;; The discount starts off: `:cart/discount-rate` has no flow yet, so its
-;; path is nil and this `:derive` treats it as 0% off. The "Apply 10%
-;; discount" button registers the flow; "Remove discount" clears it. While
-;; registered it derives a flat 10% off the live subtotal. It reads
-;; `[:cart :subtotal]`, so the rate stays fresh as the cart changes and a
-;; tiered "5% over $50" rule would slot straight in.
+;; The discount starts switched off. `:cart/discount-rate` has no flow yet,
+;; so its path reads nil and this `:derive` treats that as 0% off. "Apply 10%
+;; discount" registers the flow; "Remove discount" clears it. While it's
+;; live, it derives a flat 10% off the current subtotal. And because it reads
+;; `[:cart :subtotal]`, the rate stays fresh as the cart changes — a tiered
+;; "5% over $50" rule would drop straight in.
 (rf/reg-flow
   {:id     :cart/total
-   :doc    "Subtotal less the active discount. Reads :cart/subtotal's
-            output and the runtime-toggleable discount rate."
+   :doc    "Subtotal less the active discount. Reads :cart/subtotal's output
+            and the discount rate you can toggle at runtime."
    :inputs [[:cart :subtotal] [:cart :discount-rate]]
    :derive (fn [subtotal discount-rate]
              (let [rate (or discount-rate 0)]
@@ -101,15 +105,16 @@
    {:sku "RF2-STKR"  :name "Sticker pack"       :price 500  :qty 3}])
 
 (rf/reg-event :cart/initialise
-  {:doc "Seed the cart. The :cart/subtotal and :cart/total flows fire right
-         after this handler and materialise their outputs in the same write."}
+  {:doc "Seed the cart. The :cart/subtotal and :cart/total flows fire on the
+         heels of this handler and materialise their outputs in the same
+         write — so the totals exist before the first render."}
   (fn handler-cart-initialise [{:keys [db]} _]
     {:db (assoc db :cart {:items seed-items})}))
 
 (rf/reg-event :cart/inc-qty
   {:doc    "Bump a line item's quantity. Touching [:cart :items] re-fires
-            :cart/subtotal (its input changed), which in turn re-fires
-            :cart/total — the cascade settles in one walk."
+            :cart/subtotal (its input just changed), which re-fires
+            :cart/total in turn — the whole cascade settles in one walk."
    :schema [:cat [:= :cart/inc-qty] :string]}
   (fn handler-cart-inc-qty [{:keys [db]} [_ sku]]
     {:db (update-in db [:cart :items]
@@ -130,29 +135,29 @@
                            (= sku (:sku item)) (update :qty #(max 1 (dec %)))))
                        items)))}))
 
-;; Runtime-toggleable derivation. The discount flow is registered / cleared
-;; while the app runs via the two reserved effects. Both carry the
-;; dispatching frame automatically.
+;; Now the toggleable derivation. The discount flow gets registered and
+;; cleared while the app runs, through the two reserved effects — and both
+;; carry the dispatching frame along for you.
 ;;
-;; THE ONE-EVENT LAG: a flow registered via `:rf.fx/reg-flow` first runs on
-;; the NEXT event — its initial output appears one event after registration.
-;; So after registering the discount-rate flow we dispatch a no-op
-;; `:cart/touch` whose only job is to trigger another walk: by the time it
-;; runs, the new flow is in the registry, so that walk materialises
-;; `[:cart :discount-rate]` (and the dependent `[:cart :total]`) at the
-;; discounted figure. `:cart/touch` writes nothing; the walk itself drives
-;; the recompute.
+;; There's one wrinkle worth knowing: the one-event lag. A flow registered
+;; via `:rf.fx/reg-flow` doesn't run during the event that registers it; it
+;; first runs on the *next* event. Its opening output is always one event
+;; behind. So right after registering the discount-rate flow, we dispatch a
+;; do-nothing `:cart/touch`. By the time it runs the new flow is in the
+;; registry, so that walk finally materialises `[:cart :discount-rate]` (and
+;; the `[:cart :total]` that depends on it) at the discounted figure.
+;; `:cart/touch` writes nothing — the walk it triggers does all the work.
 ;; Guide: docs/guide/concepts/flows.md#toggling-a-derivation-at-runtime.
 (rf/reg-event :cart/apply-discount
-  {:doc "Engage the 10%-off feature gate by registering a flow that writes
-         the discount rate, then nudge a re-walk so :cart/total recomputes."}
+  {:doc "Engage the 10%-off feature gate: register a flow that writes the
+         discount rate, then nudge a re-walk so :cart/total recomputes."}
   (fn handler-cart-apply-discount [_ _]
     {:fx [[:rf.fx/reg-flow
            {:id     :cart/discount-rate
-            :doc    "The active discount rate (feature-gated; only present
-                     while the discount is engaged). Reads the live subtotal
-                     so the rule has somewhere to grow; today it is a flat
-                     10% off."
+            :doc    "The active discount rate — feature-gated, so it only
+                     exists while the discount is engaged. It reads the live
+                     subtotal so the rule has room to grow; for now it's a
+                     flat 10% off."
             :inputs [[:cart :subtotal]]
             :derive (fn [_subtotal] 0.10)
             :output-path [:cart :discount-rate]}]
@@ -160,35 +165,38 @@
 
 (rf/reg-event :cart/remove-discount
   {:doc "Disengage the feature gate. `:rf.fx/clear-flow` removes the flow and
-         clears its [:cart :discount-rate] output back to nil, so :cart/total
-         recomputes to the full price on the next walk."}
+         resets its [:cart :discount-rate] output to nil, so :cart/total
+         climbs back to full price on the next walk."}
   (fn handler-cart-remove-discount [_ _]
     {:fx [[:rf.fx/clear-flow :cart/discount-rate]
           [:dispatch [:cart/touch]]]}))
 
-;; No-op event. It returns the db unchanged; its only job is to make one
-;; more walk happen on this frame. On that walk the flows re-run with the
-;; just-(de)registered discount flow now in the registry, materialising the
-;; one-event-lagged output. The toggle is the `:rf.fx/reg-flow` /
-;; `:rf.fx/clear-flow` itself; this event is the walk that surfaces it.
+;; The humble no-op. It hands the db straight back, unchanged; its entire
+;; purpose in life is to make one more walk happen on this frame. On that
+;; walk the flows re-run with the just-(de)registered discount flow now in
+;; the registry, and the one-event-lagged output finally surfaces. The real
+;; work is the `:rf.fx/reg-flow` / `:rf.fx/clear-flow`; this event is just
+;; the walk that makes it show up.
 (rf/reg-event :cart/touch
-  {:doc "No-op. Exists only to trigger the walk that materialises the
+  {:doc "No-op. Exists only to trigger the walk that surfaces the
          one-event-lagged discount flow output."}
   (fn handler-cart-touch [{:keys [db]} _] {:db db}))
 
-;; Reading a flow's output inside an event handler. This handler reads
-;; [:cart :total] as plain app-db data. This is the central reason the total
-;; is a flow and not a sub: a sub's value lives in the view-facing sub-cache,
-;; which a handler can't reach.
+;; And here's the payoff — a handler reading a flow's output. This one reads
+;; [:cart :total] as plain app-db data, and that is the whole reason the
+;; total is a flow and not a sub. A sub's value sits in the view-facing
+;; sub-cache, where a handler simply can't reach it. A flow puts the value in
+;; app-db, where everyone can.
 (rf/reg-event :checkout/place-order
   {:doc "Place the order. Reads the materialised :cart/total straight off
-         app-db — the flow output IS ordinary application state."}
+         app-db — the flow's output is just ordinary application state."}
   (fn handler-checkout-place-order [{:keys [db]} _]
     (let [total (get-in db [:cart :total])]
       {:fx [[:flows.demo/order-placed total]]})))
 
 (rf/reg-fx :flows.demo/order-placed
-  {:doc       "Demo-only confirmation. A real app would POST the order."
+  {:doc       "Demo-only confirmation popup. A real app would POST the order
+               somewhere; we just say hello."
    :platforms #{:client}}
   (fn fx-order-placed [_ total]
     (js/alert (str "Order placed — total $" (.toFixed (/ total 100) 2)))))
@@ -197,25 +205,25 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; Flows publish no framework subs. A flow's output is ordinary application
-;; state at a known path — consumers read it through whatever sub they like
-;; over the flow's `:output-path`. The view below reads the materialised
-;; :subtotal / :total via plain subs.
+;; Flows don't hand you any subs of their own. A flow's output is just
+;; application state at a known path, so you read it through whatever sub you
+;; fancy pointed at the `:output-path`. The view below pulls the materialised
+;; :subtotal / :total through plain, unremarkable subs.
 
 (rf/reg-sub :cart/items
   (fn [db _] (get-in db [:cart :items])))
 
 (rf/reg-sub :cart/subtotal
-  {:doc "Reads the :cart/subtotal flow's output at its :output-path. A plain
-         app-db read, like any sub."}
+  {:doc "Reads the :cart/subtotal flow's output at its :output-path. Nothing
+         special — a plain app-db read, like any other sub."}
   (fn [db _] (get-in db [:cart :subtotal])))
 
 (rf/reg-sub :cart/total
   (fn [db _] (get-in db [:cart :total])))
 
 (rf/reg-sub :cart/discount-active?
-  {:doc "True while the discount feature gate is engaged. The rate flow's
-         output path is nil when the flow is cleared."}
+  {:doc "True while the discount feature gate is engaged. When the flow is
+         cleared its output path reads nil, so a present value means it's on."}
   (fn [db _] (some? (get-in db [:cart :discount-rate]))))
 
 ;; ============================================================================
@@ -268,22 +276,25 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. ns-load must produce no DOM side effects, so co-required example
-;; namespaces don't race `create-root` onto the shared `#app`.
+;; We stash the React root in an atom and create it lazily inside `run`,
+;; never at ns-load. Loading a namespace should touch no DOM, so that two
+;; co-required example namespaces don't both race to slap `create-root` onto
+;; the shared `#app`.
 (defonce react-root (atom nil))
 
-;; `frame-provider` sets up the frame at the render root. On first mount it
+;; `frame-provider` stands the frame up at the render root. On first mount it
 ;; creates the frame and runs its `:initial-events` once to seed it (here
-;; `[:cart/initialise]`); on hot reload it reuses the frame and skips the
-;; seed. Wrapping the render also makes the `reg-view`-injected
-;; `dispatch`/`subscribe` resolve to this frame; a render with no provider
-;; raises :rf.error/no-frame-context. The id is `:rf/default` — an ordinary
-;; frame id, the same one the `with-frame` flow registrations use above.
+;; `[:cart/initialise]`); on hot reload it reuses the frame as-is and skips
+;; the seed, so your live state survives a save. Wrapping the render is also
+;; what lets the `reg-view`-injected `dispatch`/`subscribe` find this frame —
+;; render without a provider and they raise :rf.error/no-frame-context. The
+;; id is `:rf/default`, an ordinary frame id, the very same one the
+;; `with-frame` flow registrations use up top.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Install the Reagent adapter so frames render through React.
+  ;; Tell the runtime to render through Reagent. This picks the substrate; it
+  ;; doesn't create a frame — that's frame-provider's job below.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/infinite_feed/core.cljs
+++ b/examples/reagent/infinite_feed/core.cljs
@@ -1,102 +1,110 @@
 (ns infinite-feed.core
-  "A load-more / infinite-scroll timeline built as one growing resource.
+  "An infinite-scroll timeline — one feed that grows a page at a time.
 
-   The whole idea: the feed is ONE cache entry the runtime owns and grows. The
-   view reads the merged list passively and dispatches a single causal
-   `:rf.resource/load-more`. The runtime holds the page list, the cursor, the
-   in-flight flag, and the append — the app writes none of them. It is a
-   `reg-resource` with `:infinite true`, owned by the route, read through the
-   passive infinite subscription family.
+   Here's the whole idea. The feed is a single cache entry, and the runtime
+   owns it. The view reads the merged list and, when you want more, dispatches
+   one event: `:rf.resource/load-more`. That's it. The runtime keeps the page
+   list, tracks the cursor, flips the in-flight flag, and appends the next page.
+   The app writes none of it. Mechanically it's a `reg-resource` with
+   `:infinite true`, owned by the route, and read through the passive infinite
+   subscription family.
 
-   The how-to walks this exact code, step by step:
+   The how-to walks this exact code, page by page:
    docs/resources/how-to/paginate-a-feed.md (§Load more).
 
-   Four facts the example shows:
+   Four things to notice as you read:
 
-   - ONE FEED, MANY PAGES. `:infinite true` plus a `:next-page-param` function
-     makes the resource a growing ordered sequence of pages held as one cache
-     entry. Route entry ensures page 0; the view reads the merged list.
-   - LOAD-MORE IS A CAUSAL EVENT. The button dispatches
-     `[:rf.resource/load-more …]` and the runtime derives the next page param
-     from the loaded tail. The event carries a `:cause` but no `:owner`: the
-     route already owns the feed, so load-more extends that one owned entry
-     rather than minting a second owner. (Owner keeps it alive; cause explains
-     why it grew — see docs/resources/glossary.md#owner--cause.)
-   - THE TERMINAL IS `nil`. `:next-page-param` returning nil is the single
-     end-of-feed signal. The view reads `:has-next-page?` and shows an
-     end-of-feed marker instead of the button.
-   - THREE ERROR CHANNELS. A load-more failure (page N>0) keeps every
-     accumulated page visible and surfaces `:page-error` while the feed stays
-     `:loaded`. A page-0 first-load failure with no data settles `:error` and
-     `:status :error`. `:error` is for first-load, `:page-error` for load-more,
-     so the view shows the full error screen on one and the inline retry on the
-     other — distinct axes, never conflated.
+   - One feed, many pages. `:infinite true` plus a `:next-page-param` function
+     turns the resource into a growing, ordered run of pages kept as one cache
+     entry. The route ensures page 0; the view reads the merged list and never
+     thinks about pages at all.
+   - Load-more is just an event. The button dispatches `[:rf.resource/load-more
+     …]` and the runtime works out the next page param from the tail it already
+     loaded. The event carries a `:cause` but no `:owner` — the route already
+     owns the feed, so load-more grows that one entry instead of minting a
+     second owner. (Owner keeps it alive; cause explains why it grew. See
+     docs/resources/glossary.md#owner--cause.)
+   - The terminal is `nil`. When `:next-page-param` returns nil, that's the end
+     of the feed — one signal, no flags. The view reads `:has-next-page?` and
+     swaps the button for an end-of-feed marker.
+   - Three error channels, and they don't get crossed. A load-more failure
+     (page N>0) keeps every page you've already scrolled to and surfaces
+     `:page-error` while the feed stays `:loaded`. A page-0 first-load failure
+     with nothing to show settles `:error` with `:status :error`. So `:error`
+     means \"the feed never loaded\" and `:page-error` means \"loading more
+     failed\" — the view shows a full error screen for one and an inline retry
+     for the other. Different questions, different answers.
 
-   The view reads the combined `[:rf.resource/infinite-state …]` view-model —
-   `:items` (the merged flat list, the headline read), `:has-next-page?`,
-   `:fetching-next?`, `:page-error`, `:loading?`, `:has-data?` — and dispatches
-   one causal event. Scope is a fail-closed leak boundary: this feed is public
-   (the same for every viewer), so it carries the explicit `:rf.scope/global`
-   claim. A per-user feed would carry a scope resolver instead. See
-   docs/resources/glossary.md#scope.
+   The view reads one combined view-model, `[:rf.resource/infinite-state …]`:
+   `:items` (the merged flat list — the read you care about most),
+   `:has-next-page?`, `:fetching-next?`, `:page-error`, `:loading?`,
+   `:has-data?`. Then it dispatches one causal event. Scope is the leak
+   boundary, and it fails closed: this feed is public — the same for every
+   viewer — so it makes the explicit `:rf.scope/global` claim. A per-user feed
+   would carry a scope resolver instead. See docs/resources/glossary.md#scope.
 
-   This feed's pages are ENVELOPED — each page is `{:items [...] :page-info
-   {…}}`, not a bare vector — so the resource declares the required
-   `:page->items` accessor. The runtime is loud over guessing: an envelope page
-   with no accessor raises `:rf.error/infinite-missing-page-accessor` at the
-   merge. (Pages that are already bare vectors flatten by identity and need no
-   accessor.)
+   One wrinkle worth flagging: this feed's pages are *enveloped*. Each page is
+   `{:items [...] :page-info {…}}`, not a bare vector, so the resource has to
+   tell the runtime how to dig the rows out — that's the `:page->items`
+   accessor. The runtime would rather shout than guess: an enveloped page with
+   no accessor raises `:rf.error/infinite-missing-page-accessor` right at the
+   merge. (Pages that are already bare vectors flatten by identity, so they need
+   no accessor.)
 
-   The example ships no backend, so it overrides `:rf.http/managed` with a
-   per-cursor canned stub that delegates to the framework-shipped
+   There's no backend here, so the example overrides `:rf.http/managed` with a
+   per-cursor canned stub that hands off to the framework's
    `:rf.http/managed-canned-success` — the same reply shape a live server would
-   produce. Every page fetch exercises a real fetch, in-flight dedupe, stale
-   suppression, and the passive status flow. A small reply delay lets the
-   load-more spinner render before each page lands."
+   send. So every page fetch still runs the real thing: a real fetch, in-flight
+   dedupe, stale-reply suppression, the passive status flow. A small reply delay
+   gives the load-more spinner a moment on screen before each page lands."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.views]
-            ;; Managed HTTP — the built-in resource transport. Loading the ns
-            ;; registers the `:rf.http/managed` fx that each page fetch runs on.
-            ;; See docs/resources/glossary.md#managed-http.
+            ;; Managed HTTP — the built-in transport resources fetch over.
+            ;; Loading it registers the `:rf.http/managed` fx that every page
+            ;; fetch runs on. See docs/resources/glossary.md#managed-http.
             [re-frame.http.managed]
-            ;; The framework-shipped canned-success fx the demo stub delegates
-            ;; to. Requiring it is the explicit opt-in for a demo / test app
-            ;; with no backend.
+            ;; The framework's canned-success fx that our demo stub hands off
+            ;; to. Requiring it is the explicit "yes, this app has no backend"
+            ;; opt-in — handy for demos and tests, deliberately out of the way
+            ;; for real apps.
             [re-frame.http.test-support]
-            ;; Resources. Requiring the ns at app boot wires the registrations
-            ;; (including the infinite sub family); without it `rf/reg-resource`
-            ;; throws :rf.error/resources-artefact-missing.
+            ;; Resources. Requiring it at boot wires up the registrations —
+            ;; including the infinite sub family this view reads. Skip it and
+            ;; `rf/reg-resource` throws :rf.error/resources-artefact-missing.
             [re-frame.resources]
-            ;; Routing. The resources artefact binds its `:resources`
-            ;; route-metadata key into routing, so loading both is what makes a
-            ;; route's `:resources` key accepted. Route entry ensures page 0 of
-            ;; an infinite resource (not the whole accumulation).
+            ;; Routing. The resources artefact teaches routing about the
+            ;; `:resources` route key, so loading both is what lets a route
+            ;; declare its resources. On entry a route ensures page 0 of an
+            ;; infinite feed — just the first page, not the whole pile.
             [re-frame.routing]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
-;; THE INFINITE RESOURCE — one growing feed, pages held as the value
+;; THE INFINITE RESOURCE — one growing feed, its pages held as the value
 ;; ============================================================================
 ;;
-;; An infinite resource is an ordinary resource (identity + scope + request)
-;; with two additions:
+;; An infinite resource is just an ordinary resource (identity + scope +
+;; request) with two extra keys:
 ;;
-;;   :infinite true       makes :next-page-param required;
-;;   :next-page-param     a pure (last-page all-pages) -> next-param-or-nil
-;;                        function. nil is the single terminal signal.
+;;   :infinite true       turns on paging and makes :next-page-param required;
+;;   :next-page-param     a pure (last-page all-pages) -> next-param-or-nil.
+;;                        Return nil and you've reached the end — that's the
+;;                        only end-of-feed signal there is.
 ;;
-;; The :request keeps its (params ctx) shape. For an infinite resource the ctx
-;; (its second arg) carries this page's context:
-;; {:rf.resource/page-param p :rf.resource/page-index i}. Page 0 is fetched
-;; with page-param nil; each load-more passes the derived next cursor.
+;; The :request keeps its familiar (params ctx) shape. The twist: for an
+;; infinite resource that second arg, the ctx, carries the page being fetched —
+;; {:rf.resource/page-param p :rf.resource/page-index i}. Page 0 comes through
+;; with page-param nil; every load-more after that passes the cursor the runtime
+;; derived from the previous page.
 ;;
-;; The page param is NOT part of the feed's cache identity — two load-more
-;; calls extend ONE entry, they do not create two cache keys. Only the identity
-;; params (here: nothing — a single public feed) name the feed; a filter/sort
-;; change yields a DIFFERENT feed instance, not a mutation of this one.
+;; And here's the key bit: the page param is NOT part of the feed's identity.
+;; Two load-more calls grow ONE entry — they don't spawn two cache keys. Only
+;; the identity params name the feed (here there are none — one public feed for
+;; everyone). Change a filter or sort and you get a *different* feed instance,
+;; not a mutation of this one.
 
 (def ^:private page-size 8)
 
@@ -105,33 +113,37 @@
 
    :infinite       true
 
-   ;; The feed-IDENTITY params. This demo has one public feed, so the identity
-   ;; is empty; a real app puts filter/sort/search here (a change → a new feed
-   ;; instance). The per-page cursor is NEVER here — it is the page param.
+   ;; The params that *identify* the feed. This demo has one public feed, so
+   ;; there's nothing to identify — an empty map. A real app would put
+   ;; filter/sort/search here, where any change spins up a fresh feed. Note what
+   ;; doesn't belong here: the per-page cursor. That's the page param, not
+   ;; identity.
    :params-schema  [:map]
 
-   ;; Public feed: the same for every viewer → the explicit global claim. A
-   ;; per-user feed would carry a scope resolver instead.
+   ;; A public feed — same content for every viewer — so it makes the explicit
+   ;; global claim. A per-user feed would carry a scope resolver instead.
    :scope          :rf.scope/global
 
-   ;; The pages are ENVELOPED ({:items … :page-info …}), so the REQUIRED
-   ;; accessor tells the runtime how to flatten each page into the merged
-   ;; `:items` list. (A bare-vector page would need no accessor.)
+   ;; The pages are enveloped — {:items … :page-info …} — so this accessor is
+   ;; required: it tells the runtime how to pull the rows out of each page for
+   ;; the merged `:items` list. (Bare-vector pages wouldn't need it.)
    :page->items    :items
 
-   ;; Derive the NEXT page param from the last loaded page. Returns nil to
-   ;; signal end-of-feed (the single terminal; `:has-next-page?` is then false).
+   ;; Work out the next page param from the page we just loaded. Return nil and
+   ;; the feed is done — `:has-next-page?` flips to false and the button becomes
+   ;; an end-of-feed marker.
    :next-page-param
    (fn [last-page _all-pages]
      (get-in last-page [:page-info :next-cursor]))   ;; nil ⇒ no more pages
 
    :stale-after-ms 60000
    :gc-after-ms    (* 5 60 1000)
-   ;; A feed tag so a write can invalidate the whole feed by tag (coarse but
-   ;; correct). See docs/resources/glossary.md#cache-tag.
+   ;; Tag the feed so a write somewhere can invalidate the whole thing in one
+   ;; stroke — coarse, but exactly right for a timeline. See
+   ;; docs/resources/glossary.md#cache-tag.
    :tags           (fn [_feed-params _data] #{[:feed :timeline]})}
-  ;; :request keeps its (params ctx) shape; the ctx carries this page's context
-  ;; (page-param nil ⇒ first page).
+  ;; :request keeps its (params ctx) shape; the ctx carries the page being
+  ;; fetched (page-param nil means this is the first page).
   (fn [_feed-params {:rf.resource/keys [page-param page-index]}]
     {:request {:method :get
                :url    "/api/timeline"
@@ -140,37 +152,39 @@
      :decode  :json}))
 
 ;; ============================================================================
-;; DEMO BACKEND — per-cursor canned :rf.http/managed override
+;; DEMO BACKEND — a per-cursor canned :rf.http/managed override
 ;; ============================================================================
 ;;
-;; This example ships no server, so it overrides `:rf.http/managed` (the fx
-;; every page fetch runs on) with a stub that synthesises one enveloped page
-;; per cursor. The stub reads the `:cursor` request param (absent ⇒ page 0),
-;; slices the demo dataset, and returns
-;; {:items [...] :page-info {:next-cursor …}} — the same enveloped shape a real
-;; cursor-paginated server would produce, so the feed lifecycle (page-0 ensure,
-;; load-more cursor derivation, in-flight dedupe, the nil terminal) runs end to
-;; end. It delegates to the framework-shipped `:rf.http/managed-canned-success`
-;; with `:after-ms`, so the reply rides framework `:dispatch-later` and stays
-;; visible on the trace tape and safe to time-travel.
+;; There's no server behind this example, so we override `:rf.http/managed` (the
+;; fx every page fetch runs on) with a stub that fakes one enveloped page per
+;; cursor. It reads the `:cursor` request param (missing means page 0), slices
+;; the demo dataset, and returns {:items [...] :page-info {:next-cursor …}} —
+;; the very shape a real cursor-paginated server would send. So the whole feed
+;; lifecycle runs for real: ensuring page 0, deriving the next cursor on
+;; load-more, deduping in-flight fetches, hitting the nil terminal. It hands off
+;; to the framework's `:rf.http/managed-canned-success` with `:after-ms`, which
+;; means the reply travels by `:dispatch-later` — so it shows up on the trace
+;; tape and you can time-travel right through it.
 
 (def ^:private total-items 26)
 
 (def ^:private demo-items
-  "A flat dataset the stub pages over by cursor (the offset of the next row)."
+  "The flat dataset the stub pages over. The cursor is just an offset into this
+   vector — the row the next page should start at."
   (vec (for [i (range total-items)]
          {:id i :title (str "Activity item #" (inc i))})))
 
 (def ^:private demo-reply-delay-ms
-  "How long the demo stub defers each canned reply (the canned-success fx's
-   `:after-ms`). Small but non-zero so the load-more spinner is visible. A demo
-   knob, not a production value."
+  "How long the stub sits on each canned reply before sending it (the
+   canned-success fx's `:after-ms`). Small but non-zero, just enough that the
+   load-more spinner gets a moment on screen. A demo knob — not something you'd
+   ship."
   140)
 
 (defn- demo-page-for-cursor
-  "Synthesise one enveloped page starting at `offset` (the cursor; nil ⇒ 0).
-   The next-cursor is the offset of the following page, or nil at the end —
-   exactly the nil terminal `:next-page-param` reads."
+  "Fake one enveloped page starting at `offset` (the cursor; nil means 0). The
+   next-cursor points at where the following page would start, or nil once we've
+   run out — which is exactly the terminal `:next-page-param` is watching for."
   [cursor]
   (let [offset (or cursor 0)
         items  (->> demo-items (drop offset) (take page-size) vec)
@@ -178,15 +192,16 @@
     {:items     items
      :page-info {:next-cursor (when (< next total-items) next)}}))
 
-;; This override stands in for the backend. It synthesises the per-cursor page,
-;; then hands the rest to `:rf.http/managed-canned-success` via the registrar,
-;; adding `:after-ms` so the reply rides framework `:dispatch-later`. It reuses
-;; the incoming args-map, which keeps the reply addressing (the per-page reply
-;; handlers the resource runtime set up) intact.
+;; This is our stand-in for the backend. It fakes the page for the incoming
+;; cursor, then hands everything else off to `:rf.http/managed-canned-success`
+;; (looked up via the registrar), tacking on `:after-ms` so the reply rides
+;; `:dispatch-later`. It reuses the incoming args-map untouched, which keeps the
+;; reply addressing — the per-page reply handlers the resource runtime set up —
+;; pointing where it should.
 (rf/reg-fx :infinite-feed.demo/http-stub
-  {:doc       "Demo override for `:rf.http/managed`: synthesises one enveloped
-               page per request cursor so the feed runs standalone, then
-               delegates to `:rf.http/managed-canned-success` with `:after-ms`."
+  {:doc       "Demo override for `:rf.http/managed`: fakes one enveloped page
+               per request cursor so the feed runs with no backend, then hands
+               off to `:rf.http/managed-canned-success` with `:after-ms`."
    :platforms #{:client}}
   (fn fx-managed-feed-demo [frame-ctx args-map]
     (let [cursor  (get-in args-map [:request :params :cursor])
@@ -195,36 +210,38 @@
       (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))
 
 ;; ============================================================================
-;; ROUTES — route entry ensures PAGE 0 (the first load), and OWNS the feed
+;; ROUTES — the route owns the feed and ensures page 0 on entry
 ;; ============================================================================
 ;;
-;; A route declares an infinite resource exactly as it declares any resource.
-;; Route entry ensures page 0 under the route's owner; route leave releases it.
-;; Load-more is a user-caused event during the route's lifetime, not a step in
-;; the route's load plan. `:blocking?` blocks on page 0 only.
+;; A route declares an infinite resource the same way it declares any other.
+;; Enter the route and it ensures page 0 under the route's owner; leave and it
+;; releases the feed. Everything after page 0 — every load-more — is a thing the
+;; user did *during* the route's lifetime, not a step in the route's load plan.
+;; `:blocking?` waits on page 0 and nothing more.
 ;; See docs/resources/how-to/paginate-a-feed.md (§Let the route own the feed).
 
 (rf/reg-route :infinite-feed.app/home
   {:doc  "Landing page."} "/")
 
 (rf/reg-route :infinite-feed.app/timeline
-  {:doc   "The feed — ensures PAGE 0 of the infinite :feed/timeline on entry."
+  {:doc   "The feed — ensures page 0 of the infinite :feed/timeline on entry."
    :resources
    [{:resource  :feed/timeline
      :params    (fn [_route] {})
      :blocking? true}]} "/timeline")
 
 (rf/reg-route :rf.route/not-found
-  {:doc  "Fallback for unmatched URLs."} "/_404")
+  {:doc  "Where unmatched URLs land."} "/_404")
 
 ;; ============================================================================
-;; PAGES — passive reads; the runtime owns the accumulation
+;; PAGES — the view just reads; the runtime keeps the pile of pages
 ;; ============================================================================
 ;;
-;; The view is passive: it reads the combined infinite view-model and dispatches
-;; one causal event. The query map is the feed identity (resource + scope +
-;; params) — the same shape the route's `:resources` plan ensured under, so the
-;; sub reads the entry the route owns.
+;; The view stays passive. It reads the combined infinite view-model and
+;; dispatches one causal event — that's the whole job. The query map below is
+;; the feed's identity (resource + scope + params), the same shape the route's
+;; `:resources` plan ensured under, so the sub reads exactly the entry the route
+;; owns.
 
 (def ^:private feed-query
   {:resource :feed/timeline :scope :rf.scope/global :params {}})
@@ -245,47 +262,49 @@
   [:li {:data-testid "feed-row"} title])
 
 (reg-view timeline-page []
-  ;; This route's `:resources` metadata ensured page 0 on entry. The view reads
-  ;; the whole feed view-model passively via `[:rf.resource/infinite-state …]`.
+  ;; The route's `:resources` already ensured page 0 on the way in. All the view
+  ;; does is read the whole feed view-model, passively, through
+  ;; `[:rf.resource/infinite-state …]`.
   (let [feed @(subscribe [:rf.resource/infinite-state feed-query])]
     [:div
      [:h1 "Timeline"]
      (cond
-       ;; First load (page 0), no usable data yet → skeleton.
+       ;; Page 0 is still loading and there's nothing to show yet → skeleton.
        (:loading? feed)
        [:p {:data-testid "feed-skeleton"} "Loading the feed…"]
 
-       ;; First load (page 0) failed with no usable data → full error screen.
-       ;; A page-0 failure with no accumulated pages settles `:error` and
-       ;; `:status :error`, just like a scalar resource. `:error` is for
-       ;; first-load failure; a load-more (page N>0) failure uses `:page-error`
-       ;; instead and keeps the feed. See docs/resources/glossary.md#resource-status.
+       ;; Page 0 failed and left us with nothing → the full error screen. With
+       ;; no pages to fall back on, the feed settles `:error` / `:status :error`,
+       ;; just like a plain scalar resource would. Remember the split: `:error`
+       ;; is a first-load failure; a load-more (page N>0) failure uses
+       ;; `:page-error` and keeps the feed.
+       ;; See docs/resources/glossary.md#resource-status.
        (:error feed)
        [:p.error {:data-testid "feed-error"} "Could not load the feed."]
 
        :else
        [:<>
-        ;; The merged flat list — the headline `:items` read. The runtime
-        ;; concatenates pages in load order and memoises the merge; the view
-        ;; just renders rows.
+        ;; The merged flat list — the `:items` read everything else is here to
+        ;; support. The runtime stitches the pages together in load order and
+        ;; memoises the result; the view just renders the rows.
         (into [:ul {:data-testid "feed-list"}]
               (for [item (:items feed)]
                 ^{:key (:id item)} [feed-row item]))
 
-        ;; A load-more failure (page N>0 — we have data) keeps every page
-        ;; visible and surfaces :page-error — the inline retry. This is the
-        ;; third error channel: a load-more failure leaves the feed intact,
-        ;; unlike the first-load :error full-screen above.
+        ;; The third error channel. A load-more failure (page N>0 — we already
+        ;; have data) keeps every page on screen and raises :page-error for an
+        ;; inline retry. Unlike the first-load :error above, the feed stays put.
         (when (:page-error feed)
           [:p.warn {:data-testid "feed-page-error"}
            "Couldn't load more — tap retry."])
 
-        ;; The load-more affordance: a spinner while a page is in flight, the
-        ;; button while there is a next page, an end-of-feed marker otherwise.
-        ;; The button dispatches one causal event and the runtime derives the
-        ;; next page param from the loaded tail. The event carries a `:cause`
-        ;; but no `:owner` — the route already owns the feed, so load-more just
-        ;; extends it (owner keeps it alive; cause explains why it grew).
+        ;; The load-more affordance, in three moods: a spinner while a page is
+        ;; in flight, the button while there's a next page, an end-of-feed
+        ;; marker once there isn't. The button dispatches one causal event and
+        ;; lets the runtime derive the next page param from the loaded tail. It
+        ;; carries a `:cause` but no `:owner` — the route already owns the feed,
+        ;; so load-more just grows it (owner keeps it alive; cause says why it
+        ;; grew).
         (cond
           (:fetching-next? feed)
           [:p {:data-testid "feed-loading-more"} "Loading more…"]
@@ -316,15 +335,16 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; The React root is created lazily inside `run` (not at ns-load) so a test can
-;; mount the app in its own frame. The app establishes its frame in one spot:
-;; the render-root `frame-provider {:id …}`. On first mount the provider creates
-;; the `app-frame` and applies its config — `:url-bound? true` so the frame owns
-;; the browser URL, and the `:rf.http/managed` override that points page fetches
-;; at the canned stub so the example runs standalone. The provider also scopes
-;; that frame, so every in-tree dispatch/subscribe resolves to it. On hot reload
-;; it reuses the same frame. The feed needs no boot seed: route entry's
-;; `:resources` plan ensures page 0, so the frame carries no `:initial-events`.
+;; The React root is created lazily inside `run`, not at ns-load, so a test can
+;; mount this app in its own frame. There's exactly one place the app stands its
+;; frame up: the render-root `frame-provider {:id …}`. On first mount the
+;; provider creates `app-frame` and applies its config — `:url-bound? true` so
+;; the frame owns the browser URL, and the `:rf.http/managed` override that
+;; aims page fetches at the canned stub so the demo runs on its own. The
+;; provider also scopes the frame, so every dispatch and subscribe inside the
+;; tree resolves to it. Hot reload? It reuses the same frame. And there's no
+;; boot seed to write: route entry's `:resources` plan ensures page 0, so the
+;; frame carries no `:initial-events`.
 ;; See docs/guide/glossary.md#frame-provider.
 
 (defonce react-root (atom nil))
@@ -337,8 +357,9 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; The provider creates the app frame (with its config) on first mount and
-    ;; reuses it on hot reload. Route entry ensures page 0, so no `:initial-events`.
+    ;; The provider creates the app frame (config and all) on first mount and
+    ;; reuses it on hot reload. Route entry ensures page 0, so there's no need
+    ;; for `:initial-events`.
     (rdc/render @react-root
                 [rf/frame-provider {:id           app-frame
                                     :doc          "Infinite-feed demo frame."

--- a/examples/reagent/linearlite/core.cljs
+++ b/examples/reagent/linearlite/core.cljs
@@ -1,78 +1,89 @@
 (ns linearlite.core
-  "A worked example of OPTIMISTIC MUTATION with automatic ROLLBACK.
+  "Optimistic writes, with rollback you don't have to write yourself.
 
-   A small Linearlite-style issue tracker: a board of issues you create,
-   retitle, and move between statuses. Every write applies optimistically — the
-   board updates the instant you click, before the request is sent — and is
-   committed or rolled back when the reply settles. The runtime owns the
-   optimistic apply, the recorded inverse, and the conflict-aware rollback.
+   A small Linearlite-style issue tracker: a board of cards you create, retitle,
+   and move between statuses. The hard part isn't the board — it's that a server
+   write takes time but the user wants the screen to react *now*. So we show the
+   change immediately, before the server has agreed to it, and then either keep
+   it or take it back when the reply lands. That's an optimistic update, and done
+   by hand it's a bug farm. Here the runtime owns the whole move: it applies your
+   change up front, remembers exactly what was there before, and puts it back if
+   the write fails. You write only the forward step.
 
    See the guide: [Optimistic writes commit, roll back, or
    reconcile](../../../docs/resources/concepts.md#optimistic-writes-commit-roll-back-or-reconcile).
 
-   The example shows four things:
+   Four ideas, and they're the whole example:
 
-   - THE WRITE SHOWS IMMEDIATELY. Each mutation declares `:optimistic`, an
-     exact-target forward patch over the board: `(fn [params] -> {target
-     patch-fn})`. The patch runs before the request is sent, so the new card
-     appears / the title changes / the card moves the instant the user acts. The
-     runtime owns the cache and shows the optimistic value; the view just reads
-     it. There is no app-db issue list and no `:saving?` flag to keep in sync.
+   - The write shows immediately, and the view never touches the data. Each
+     mutation declares an `:optimistic` patch — `(fn [params] -> {target
+     patch-fn})`, a forward change aimed at one exact cache entry. It runs before
+     the request is sent, so the new card appears, the title changes, or the card
+     jumps columns the instant the user acts. The runtime holds the cache and
+     hands the view the optimistic value; the view just reads it. There's no
+     app-db issue list and no `:saving?` flag to keep in sync.
 
-   - THE INVERSE IS RECORDED FOR YOU. You write only the forward patch. The
-     runtime snapshots each touched entry's value and its revision at apply
-     time. A rollback restores exactly the entry that existed, so the undo is
-     truthful by construction — never an author-written inverse that can drift.
+   - The inverse is recorded for you. You write only the forward patch. When it
+     applies, the runtime snapshots each touched entry — its value and its
+     revision. A rollback restores exactly the entry that was there, so the undo
+     is correct by construction. No hand-written inverse to drift out of sync
+     with reality, which is precisely the bit hand-rolled optimistic code tends
+     to get subtly wrong.
 
-   - THE REPLY SETTLES DETERMINISTICALLY. An `:ok` reply commits: `:populates`
-     overwrites the optimistic guess with the server's authoritative board. An
-     `:error` reply rolls back: the recorded value is restored and the
-     optimistic change visibly reverts. The verdict keys on recorded facts (the
-     generation-acceptance verdict and a per-entry revision), so there is no
-     wall-clock race.
+   - The reply settles the same way every time. A success (`:ok`) commits:
+     `:populates` overwrites the optimistic guess with the server's authoritative
+     board. A failure (`:error`) rolls back: the recorded value returns and the
+     optimistic change visibly reverts. The verdict reads recorded facts — which
+     write this is, plus each entry's revision when the patch applied — so no
+     wall-clock race decides who wins.
 
-   - ROLLBACK IS WHAT YOU SEE. A 'Fail the next write' toggle arms the demo
-     backend to answer the next mutation with a 503. The optimistic change
-     paints immediately, the request fails, and the runtime rolls the board back
-     to its pre-click state — the new card vanishes, the retitled card reverts,
-     the moved card snaps back.
+   - Rollback is the thing you actually watch. A 'Fail the next write' toggle
+     arms the demo backend to answer the next mutation with a 503. The optimistic
+     change paints, the request fails, and the runtime snaps the board back to
+     its pre-click state: the new card vanishes, the retitled card reverts, the
+     moved card jumps home.
 
    The board is read passively through `[:rf.resource/data …]`. Each in-flight
-   write is watched through `[:rf.mutation/state {:instance …}]`, whose derived
-   `:optimistic?` flag is true while a live optimistic apply is showing, so the
-   board can mark a card as pending.
+   write is watched through `[:rf.mutation/state {:instance …}]`, whose
+   `:optimistic?` flag stays true while that write's optimistic value is still on
+   screen — so a card can wear a 'saving…' badge over the value you're hoping
+   sticks.
 
-   THE CONFLICT POLICY. Each mutation names `:on-conflict :invalidate` (the
-   default). On a failure rollback where a competing write moved the touched
-   entry while ours was in flight, the read path refetches the authoritative
-   value rather than restoring a now-stale inverse. (re-frame2's deliberate
-   divergence from TanStack Query / SWR's unconditional context restore — see
-   the guide section above.)
+   The conflict policy. Each mutation names `:on-conflict :invalidate` (the
+   default). The case it handles: our write fails and wants to roll back, but a
+   competing write already moved the same entry while ours was in flight.
+   Restoring our recorded inverse now would clobber that newer change with stale
+   data, so the read path refetches the authoritative value instead. This is the
+   one place re-frame2 deliberately parts ways with TanStack Query / SWR, which
+   restore captured context unconditionally — see the guide section above.
 
-   IDIOMATIC re-frame2. The board is a single managed resource; every write is a
-   named `reg-mutation`; the toggle is an ordinary app-db slice driven by an
-   event and read by a sub. The example ships no backend, so it overrides
-   `:rf.http/managed` with a canned stub that synthesises the board reply and,
-   when armed, the 503, so the whole optimistic lifecycle runs standalone."
+   Otherwise it's plain re-frame2. The board is a single managed resource; each
+   write is a named `reg-mutation`; the toggle and edit-draft are ordinary app-db
+   slices an event writes and a sub reads. No backend ships with the example, so
+   it overrides `:rf.http/managed` with a canned stub that synthesises the board
+   reply and, when armed, the 503 — and the whole optimistic lifecycle runs
+   standalone."
   (:require [reagent.dom.client :as rdc]
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.views]
-            ;; Managed HTTP: the transport every resource and mutation lowers
-            ;; its read/write onto. Loading the ns registers the
-            ;; `:rf.http/managed` fx. See the guide glossary:
+            ;; Managed HTTP — the one transport every resource and mutation
+            ;; lowers its read/write onto. Loading the ns registers the
+            ;; `:rf.http/managed` fx. Guide:
             ;; ../../../docs/resources/glossary.md#managed-http
             [re-frame.http.managed]
-            ;; The framework's canned-reply fx that the demo stub delegates to.
-            ;; The explicit opt-in for a demo app with no backend.
+            ;; The framework's canned-reply fx. Our demo stub delegates to it
+            ;; instead of hitting a network — the deliberate opt-in for an app
+            ;; that ships no backend.
             [re-frame.http.test-support]
-            ;; Resources. Loading the ns registers `reg-resource` / `reg-mutation`
-            ;; and the `:rf.resource/*` + `:rf.mutation/*` subs; without it those
-            ;; registrations throw.
+            ;; Resources. Loading the ns registers `reg-resource` /
+            ;; `reg-mutation` and the `:rf.resource/*` + `:rf.mutation/*` subs.
+            ;; Skip it and those registrations throw.
             [re-frame.resources]
-            ;; Routing. With resources also loaded, a route's `:resources` key is
-            ;; accepted — route entry ensures the board.
+            ;; Routing. With resources also loaded, a route may carry a
+            ;; `:resources` key — that's how the board route ensures the board on
+            ;; entry.
             [re-frame.routing]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view reg-event reg-sub]]))
@@ -82,8 +93,8 @@
 ;; ============================================================================
 
 (def ^:private statuses
-  "The board columns, in order. An issue moves left to right through these as
-   work progresses; `change-status` is the optimistic move."
+  "The board's columns, left to right. An issue walks across them as work
+   progresses, and `change-status` is the optimistic move that carries it."
   [{:id :backlog     :label "Backlog"}
    {:id :in-progress :label "In Progress"}
    {:id :done        :label "Done"}])
@@ -92,15 +103,16 @@
   (into {} (map (juxt :id :label)) statuses))
 
 ;; ============================================================================
-;; THE RESOURCE — the board is ONE managed server-state read
+;; THE RESOURCE — the whole board is one managed server-state read
 ;; ============================================================================
 ;;
-;; The whole issue board is a single resource entry: `{:issues [...]}`. The
+;; The entire issue board is a single resource entry: `{:issues [...]}`. The
 ;; route ensures it on entry; the view reads it passively. Every optimistic
-;; write patches THIS one entry's `:data` in place, and the success reply
+;; write patches this one entry's `:data` in place, and the success reply
 ;; re-seeds it with the server's authoritative board via `:populates`. The
-;; runtime owns the board value, its freshness, and the recorded inverse that
-;; makes rollback truthful. The board lives in the resource cache, not app-db.
+;; runtime owns the board's value, its freshness, and the recorded inverse that
+;; makes rollback honest. It lives in the resource cache — state you don't own,
+;; kept where state you don't own belongs, never in app-db.
 
 (rf/reg-resource :linearlite/board
   {:doc            "The whole issue board — `{:issues [...]}` — as one managed
@@ -108,69 +120,72 @@
                     place before their request is sent; the success reply
                     re-seeds it with the server's authoritative board."
 
-   ;; One public board in the demo (a real app would scope per-team / per-user
-   ;; and key the team in :params); identity params are empty.
+   ;; One public board in the demo, so the identity params are empty. A real app
+   ;; would scope this per-team or per-user and key the team into :params.
    :params-schema  [:map]
 
-   ;; Public board: the same for every viewer, so the scope is the explicit
-   ;; global claim (there is no implicit default). A per-team board would carry
-   ;; a scope resolver instead. Guide:
+   ;; This board is the same for every viewer, so we make the global claim
+   ;; explicit — there's no implicit default to fall back on. A per-team board
+   ;; would carry a scope resolver here instead. Guide:
    ;; ../../../docs/resources/glossary.md#scope
    :scope          :rf.scope/global
 
    :stale-after-ms 60000
    :gc-after-ms    (* 5 60 1000)
 
-   ;; A board tag so an external change (a server push, say) can invalidate the
-   ;; whole board by tag. The optimistic writes below patch the entry directly
-   ;; and re-seed via `:populates` on commit, so they need no coarse
-   ;; invalidation. Guide: ../../../docs/resources/glossary.md#cache-tag
+   ;; A tag on the board, so something external (a server push, say) can
+   ;; invalidate the whole thing by tag. The optimistic writes below patch the
+   ;; entry directly and re-seed via `:populates` on commit, so they never need
+   ;; this coarser hammer. Guide:
+   ;; ../../../docs/resources/glossary.md#cache-tag
    :tags           (fn [_params _data] #{[:board]})}
   (fn [_params _ctx]
     {:request {:method :get :url "/api/board"}
      :decode  :json}))
 
 ;; ============================================================================
-;; THE EXACT-TARGET — every optimistic write patches THIS key
+;; THE TARGET — the one cache entry every optimistic write aims at
 ;; ============================================================================
 
 (def ^:private board-key
-  "The exact resource target the board lives under: a `{:resource :scope
-   :params}` map, reused as the `:optimistic` and `:populates` key. Empty
-   `:params` means the one public board."
+  "Where the board lives in the cache: a `{:resource :scope :params}` map. We
+   reuse it as both the `:optimistic` patch key and the `:populates` commit key,
+   so every write aims at exactly the same entry. Empty `:params` means the one
+   public board."
   {:resource :linearlite/board :scope :rf.scope/global :params {}})
 
 (def ^:private board-query
-  "The query map the view's `[:rf.resource/data …]` sub reads — the same board
-   identity (resource + scope + params) the route ensured under and the writes
-   patch."
+  "What the view's `[:rf.resource/data …]` sub reads. Same board identity
+   (resource + scope + params) the route ensured under and the writes patch —
+   read and write naming the same place is the whole trick."
   {:resource :linearlite/board :scope :rf.scope/global :params {}})
 
-;; A counter for client-minted optimistic ids. A new issue gets a stable `tmp-N`
-;; id the moment its optimistic card appears, so it has a stable React key before
-;; the server assigns its own. The success reply re-seeds the whole board with
-;; the server's value (carrying the server id), so the temporary id never leaks
-;; past commit; a rollback simply removes the never-committed card.
+;; A counter for client-minted ids. The moment an optimistic card appears it
+;; needs a stable React key, but the server hasn't named the issue yet — so we
+;; hand it a `tmp-N` id to tide it over. On commit the success reply re-seeds the
+;; whole board with the server's value (real id and all), so the temporary id
+;; never outlives the round trip; a rollback just removes the card that never
+;; landed.
 (defonce ^:private optimistic-id-seq (atom 0))
 
 (defn- next-issue-id
-  "Mint the next client-side optimistic id (`tmp-N`)."
+  "Mint the next client-side placeholder id (`tmp-N`)."
   []
   (str "tmp-" (swap! optimistic-id-seq inc)))
 
 (defn- upsert-issue
-  "Add or replace an issue in the board's `:issues` vector by id. Pure — shared
-   by the create + edit forward patches so the optimistic shape is declared
-   once. A new id appends; an existing id is replaced in place (order kept)."
+  "Add an issue to the board's `:issues`, or replace it if its id is already
+   there (keeping its place in line). Pure, and shared by the create + edit
+   forward patches so the optimistic shape is written down once."
   [issues issue]
   (if (some #(= (:id %) (:id issue)) issues)
     (mapv #(if (= (:id %) (:id issue)) issue %) issues)
     (conj (vec issues) issue)))
 
 (defn- patch-issue
-  "Return a board-`:data` patch fn that applies `f` to the issue with `id`,
-   leaving the rest of the board untouched. Forward only — the runtime records
-   the inverse, so this fn never describes how to undo itself."
+  "Build a board-`:data` patch that applies `f` to the issue with `id` and
+   leaves everything else alone. Forward only: the runtime records the inverse,
+   so this never has to describe how to undo itself."
   [id f]
   (fn [data]
     (update data :issues
@@ -179,18 +194,19 @@
                     (or issues []))))))
 
 ;; ============================================================================
-;; THE MUTATIONS — create / edit-title / change-status, all OPTIMISTIC
+;; THE MUTATIONS — create / edit-title / change-status, all optimistic
 ;; ============================================================================
 ;;
-;; Each write declares `:optimistic` (the forward patch over the board entry,
-;; applied before the request), `:populates` (the commit — re-seed the board
-;; with the server's authoritative value on `:ok`), and `:on-conflict
-;; :invalidate` (the default conflict policy). The runtime records the inverse
-;; and each entry's revision itself; the reply settles deterministically.
+;; Each write reads the same three keys. `:optimistic` is the forward patch over
+;; the board entry, applied before the request goes out. `:populates` is the
+;; commit — on `:ok`, re-seed the board with the server's authoritative value.
+;; `:on-conflict :invalidate` is the (default) conflict policy. The runtime fills
+;; in the rest itself: it records the inverse and each entry's revision, and the
+;; reply settles deterministically.
 ;;
-;; Writes do NOT retry (reads retry, writes don't) — a 503 surfaces as `:error`
-;; and rolls the optimistic change back, which is what the demo's 'fail the next
-;; write' toggle exercises.
+;; Writes don't retry — reads do, writes don't. A 503 surfaces as `:error` and
+;; rolls the optimistic change back, which is exactly the arc the demo's 'fail
+;; the next write' toggle puts on display.
 
 (rf/reg-mutation :linearlite/create-issue
   {:doc           "Create an issue (optimistic). POST /api/issues. The new card
@@ -198,9 +214,9 @@
                    it back out."
    :params-schema [:map [:id :string] [:title :string]]
    :scope         :rf.scope/global
-   ;; FORWARD: append a new Backlog card to the board immediately, before the
-   ;; request is sent. `:id` is the client-minted optimistic id so the card has
-   ;; a stable React key before the server assigns one.
+   ;; Forward: append a new Backlog card right away, before the request is sent.
+   ;; `:id` is the client-minted placeholder so the card has a stable React key
+   ;; until the server names it.
    :optimistic    (fn [{:keys [id title]}]
                     {board-key
                      (fn [data]
@@ -209,13 +225,12 @@
                                  (upsert-issue issues
                                                {:id id :title title :status :backlog
                                                 :optimistic? true}))))})
-   ;; COMMIT: the `:ok` reply is the server's whole authoritative board; re-seed
-   ;; the board entry with it, so the temporary id is replaced by the server's
-   ;; and the optimistic flag clears. Same `{:issues …}` envelope the resource
-   ;; stores.
+   ;; Commit: the `:ok` reply is the server's whole authoritative board. Re-seed
+   ;; the entry with it — the placeholder id gives way to the server's, and the
+   ;; optimistic flag clears. Same `{:issues …}` envelope the resource stores.
    :populates     (fn [_params result] {board-key result})
-   ;; ROLLBACK conflict policy (the default): on a contested rollback, the read
-   ;; path refetches rather than restoring a stale inverse.
+   ;; On conflict (the default): if a rollback is contested, refetch rather than
+   ;; restore a now-stale inverse. See the conflict-policy note at the top.
    :on-conflict   :invalidate}
   (fn [{:keys [title]} _ctx]
     {:request {:method :post :url "/api/issues"
@@ -224,8 +239,8 @@
 
 (rf/reg-mutation :linearlite/edit-title
   {:doc           "Retitle an issue (optimistic). PUT /api/issues/:id. The title
-                   changes the instant you commit the edit; a failure reverts
-                   it to the prior title."
+                   changes the instant you save; a failure puts the old one
+                   back."
    :params-schema [:map [:id :string] [:title :string]]
    :scope         :rf.scope/global
    :optimistic    (fn [{:keys [id title]}]
@@ -240,7 +255,7 @@
 (rf/reg-mutation :linearlite/change-status
   {:doc           "Move an issue to another status (optimistic). PUT
                    /api/issues/:id. The card jumps to the new column the instant
-                   you click; a failure snaps it back to its prior column."
+                   you pick it; a failure snaps it home."
    :params-schema [:map [:id :string] [:status :keyword]]
    :scope         :rf.scope/global
    :optimistic    (fn [{:keys [id status]}]
@@ -256,37 +271,39 @@
 ;; DEMO BACKEND — a canned :rf.http/managed override (no server ships)
 ;; ============================================================================
 ;;
-;; This example ships no backend, so it overrides `:rf.http/managed` (the fx
-;; every read/write lowers onto) with a stub that holds the canonical board in a
-;; closure and synthesises the authoritative reply for each read/write. It
-;; delegates to the framework's `:rf.http/managed-canned-success` / `-failure`
-;; with `:after-ms`, so the reply rides framework `:dispatch-later` (not a raw
-;; js/setTimeout — it stays trace-visible and time-travel-safe) and the
-;; optimistic value paints before the reply lands.
+;; There's no server here. So we override `:rf.http/managed` (the fx every
+;; read/write lowers onto) with a small stub that holds the canonical board in a
+;; closure and builds the authoritative reply for each read/write. It delegates
+;; to the framework's `:rf.http/managed-canned-success` / `-failure` with
+;; `:after-ms`, so the reply rides the framework's `:dispatch-later` rather than
+;; a raw js/setTimeout — even the fake latency stays trace-visible and
+;; time-travel-safe — and the optimistic value gets to paint before the reply
+;; arrives.
 ;;
-;; THE FAILURE SEAM. `fail-next-write?` is read from app-db at request time:
-;; when armed, the stub answers the next WRITE with a 503 and disarms, so a
-;; single click drives the whole optimistic-apply → request → rollback arc.
+;; The failure seam. `fail-next-write?` is read from app-db at request time:
+;; when it's armed, the stub answers the next WRITE with a 503 and disarms
+;; itself. One click, and you've driven the whole optimistic-apply → request →
+;; rollback arc.
 
 (def ^:private demo-reply-delay-ms
-  "How long the demo stub defers each canned reply (via `:after-ms` →
-   `:dispatch-later`). Small but non-zero so the optimistic value is visibly
-   painted before the reply lands. A demo-seam knob, not a production value."
+  "How long the demo stub holds each canned reply back (via `:after-ms` →
+   `:dispatch-later`). Small, but not zero — the optimistic value needs a moment
+   on screen before the reply lands, or you'd never see it. A demo knob, not a
+   production value."
   220)
 
-;; The canonical server board the stub maintains across requests, so a committed
-;; write persists into the next read (the stub IS the demo server). A create, a
-;; retitle, and a status move all mutate this atom on a successful write, so the
-;; next board read reflects them.
+;; The canonical server board, kept across requests so a committed write shows up
+;; in the next read. The stub *is* the demo server, and this atom is its
+;; database. A create, a retitle, and a status move each mutate it on success.
 (defonce ^:private demo-board
   (atom {:issues [{:id "srv-1" :title "Wire up the optimistic board" :status :in-progress}
                   {:id "srv-2" :title "Render the three status columns" :status :done}
                   {:id "srv-3" :title "Add the create-issue form"       :status :backlog}]}))
 
 (defn- strip-optimistic
-  "Drop the demo-only `:optimistic?` marker from issues so the AUTHORITATIVE
-   server board the stub returns never carries it (the marker is a view hint
-   the optimistic patch adds; the committed value is clean)."
+  "Scrub the `:optimistic?` marker off every issue. That marker is a view hint
+   the optimistic patch adds locally; the authoritative board the server hands
+   back is the real thing and carries no such tell, so we clean it off here."
   [board]
   (update board :issues (fn [issues] (mapv #(dissoc % :optimistic?) issues))))
 
@@ -294,15 +311,16 @@
   (str "srv-" (inc (count (:issues board)))))
 
 (defn- apply-write!
-  "Mutate the canonical demo board for a successful write, returning the new
-   authoritative board (the `:populates` payload). Routed by method + URL:
-   POST mints a server id for the new issue; PUT patches title and/or status by
-   id from the request body."
+  "Apply a successful write to the canonical demo board and return the new
+   authoritative board — the value that becomes the `:populates` payload. Routed
+   the way a real server would route it, by method + URL: POST mints a fresh
+   server id for the new issue; PUT patches title and/or status by id from the
+   request body."
   [method url body]
   (swap! demo-board
          (fn [board]
            (cond
-             ;; POST /api/issues — create. Mint a server id for the new issue.
+             ;; POST /api/issues — a create. Mint a server id for the new issue.
              (and (= method :post) (str/ends-with? url "/api/issues"))
              (update board :issues
                      (fn [issues]
@@ -326,13 +344,12 @@
   (strip-optimistic @demo-board))
 
 (rf/reg-fx :linearlite.demo/http-stub
-  {:doc       "Demo override for `:rf.http/managed`: maintains the canonical
-               board in a closure and synthesises the authoritative reply for
-               each read/write, delegating to
-               `:rf.http/managed-canned-success` / `-failure` with `:after-ms`.
-               Reads the `:fail-next-write?` app-db flag at request time: when
-               armed, the next WRITE answers a 503 (driving the rollback arc)
-               and disarms."
+  {:doc       "Demo stand-in for `:rf.http/managed`. Holds the canonical board in
+               a closure and builds the authoritative reply for each read/write,
+               delegating to `:rf.http/managed-canned-success` / `-failure` with
+               `:after-ms`. Reads the `:fail-next-write?` app-db flag at request
+               time: when armed, the next WRITE answers a 503 — driving the
+               rollback arc — and disarms itself."
    :platforms #{:client}}
   (fn fx-managed-board-demo [frame-ctx args-map]
     (let [req       (:request args-map)
@@ -341,20 +358,20 @@
           body      (:body req)
           write?    (not= method :get)
           ;; The fx context carries the envelope frame as `:frame`. Read the
-          ;; demo seam flag off that frame's runtime db.
+          ;; fail-next-write flag off that frame's runtime db.
           db        (rf/runtime-db-value (:frame frame-ctx))
           fail?     (and write? (boolean (:fail-next-write? db)))]
       (if fail?
-        ;; Armed failure: answer the WRITE with a 503 so the optimistic apply
-        ;; rolls back. Disarm the seam, then delegate to the canned-failure fx
-        ;; (the reply rides `:after-ms` → `:dispatch-later`).
+        ;; Armed: answer the WRITE with a 503 so the optimistic apply rolls back.
+        ;; Disarm first (it's a one-shot), then hand off to the canned-failure
+        ;; fx — its reply rides `:after-ms` → `:dispatch-later` like any other.
         (let [failure {:kind :rf.http/http-5xx :status 503
                        :message "Simulated server failure (the demo's rollback seam)."}
               stub    (registrar/handler :fx :rf.http/managed-canned-failure)]
           (rf/dispatch [:linearlite/set-fail-next-write false])
           (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :failure failure)))
-        ;; Success: a read returns the current board; a write mutates the
-        ;; canonical board and returns the new authoritative board.
+        ;; Otherwise, success: a read returns the current board; a write mutates
+        ;; the canonical board and returns the new authoritative one.
         (let [payload (if write?
                         (apply-write! method url body)
                         (strip-optimistic @demo-board))
@@ -362,14 +379,14 @@
           (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))))
 
 ;; ============================================================================
-;; APP-DB — the demo seam + the inline title-edit draft (ordinary slices)
+;; APP-DB — the demo toggle + the inline edit draft (ordinary slices)
 ;; ============================================================================
 ;;
-;; The ONLY app-db state this example carries is demo/UI chrome — the
-;; failure-seam toggle, the new-issue draft, and the id of the issue being
-;; inline-retitled. The issue board itself is NOT in app-db (the resource owns
-;; it). These are ordinary slices: an event writes, a sub reads, the view reads
-;; the sub.
+;; The only state app-db carries here is UI chrome: the failure toggle, the
+;; new-issue draft, and the id of the card being inline-retitled. The issue
+;; board itself is *not* in app-db — the resource owns it. These three are
+;; ordinary slices in the usual loop: an event writes, a sub reads, the view
+;; reads the sub.
 
 (reg-event :linearlite/set-fail-next-write
   (fn [db [_ on?]] (assoc db :fail-next-write? on?)))
@@ -390,13 +407,13 @@
 (reg-sub :linearlite/new-issue-draft  (fn [db _] (or (:new-issue-draft db) "")))
 (reg-sub :linearlite/editing          (fn [db _] (:editing db)))
 
-;; --- the write events (dispatch the mutation, watch the instance) -----------
+;; --- the write events (fire the mutation, then get out of the way) ----------
 ;;
-;; Each write is a thin event that dispatches `:rf.mutation/execute` with a
-;; per-issue (or per-create) instance id, then resets the relevant UI slice.
-;; The view watches the mutation instance and reads the board resource
-;; passively; the runtime applies the optimistic patch, sends the request, and
-;; commits / rolls back on the reply.
+;; Each write is a thin event: it dispatches `:rf.mutation/execute` with an
+;; instance id (per-issue, or per-create) and clears whatever UI slice it was
+;; using. That's all it does. The view watches the mutation instance and reads
+;; the board passively; the runtime does the real work — apply the optimistic
+;; patch, send the request, commit or roll back on the reply.
 
 (reg-event :linearlite/create-issue
   (fn [{:keys [db]} [_ title]]
@@ -426,11 +443,12 @@
                        :cause    [:user :linearlite/change-status]}]]]}))
 
 ;; ============================================================================
-;; ROUTES — route entry ensures the board (the route OWNS the read)
+;; ROUTES — entering the route is what ensures the board read
 ;; ============================================================================
 
 (rf/reg-route :linearlite.app/board
-  {:doc   "The issue board — ensures the :linearlite/board resource on entry."
+  {:doc   "The issue board. Entering this route ensures the :linearlite/board
+           resource, so the data is on its way before the view asks for it."
    :resources
    [{:resource  :linearlite/board
      :params    (fn [_route] {})
@@ -467,8 +485,8 @@
      [:button {:type :submit :data-testid "new-issue-submit"} "Add issue"]]))
 
 (reg-view status-picker [{:keys [id status]}]
-  ;; Move the card to another column. Dispatches the optimistic change-status
-  ;; mutation; the card jumps immediately, then commits / rolls back.
+  ;; Pick a new column. This fires the optimistic change-status mutation: the
+  ;; card jumps right away, then commits or rolls back when the reply lands.
   [:select {:data-testid (str "status-" id)
             :value       (name status)
             :on-change   #(dispatch [:linearlite/change-status
@@ -479,9 +497,9 @@
 (reg-view issue-card [{:keys [issue editing]}]
   (let [{:keys [id title status optimistic?]} issue
         editing-this? (= id (:id editing))
-        ;; Watch this card's in-flight writes passively. `:optimistic?` is true
-        ;; while a live optimistic apply is showing; `:error?` flags the last
-        ;; write's failure (the optimistic value has already rolled back).
+        ;; Watch this card's in-flight writes, passively. `:optimistic?` stays
+        ;; true while an optimistic value is on screen; `:error?` flags the last
+        ;; write's failure — by which point the value has already rolled back.
         edit-state    @(subscribe [:rf.mutation/state {:instance [:edit id]}])
         status-state  @(subscribe [:rf.mutation/state {:instance [:status id]}])
         create-state  @(subscribe [:rf.mutation/state {:instance [:create id]}])
@@ -492,7 +510,7 @@
     [:li.issue-card {:data-testid (str "issue-" id)
                      :class       (str (when pending? "pending ") (when errored? "errored"))}
      (if editing-this?
-       ;; Inline retitle: commit dispatches the optimistic edit-title mutation.
+       ;; Inline retitle: saving fires the optimistic edit-title mutation.
        [:form.edit-title {:data-testid (str "edit-form-" id)
                           :on-submit   (fn [e]
                                          (.preventDefault e)
@@ -522,10 +540,12 @@
            ^{:key (:id issue)} [issue-card {:issue issue :editing editing}]))])
 
 (reg-view board-page []
-  ;; The board was ensured by THIS route's `:resources` metadata on entry. The
-  ;; view reads the WHOLE board passively via `[:rf.resource/data …]`; every
-  ;; write patches the runtime cache, so this view re-renders with the
-  ;; optimistic value the instant a write fires, then again on commit/rollback.
+  ;; The route already ensured the board on entry (via its `:resources`
+  ;; metadata), so this view just reads the whole thing passively through
+  ;; `[:rf.resource/data …]`. Every write patches the cache, so the view
+  ;; re-renders with the optimistic value the instant a write fires — and again
+  ;; when it commits or rolls back. The view never has to ask for the data; it
+  ;; just shows whatever's currently there.
   (let [board   @(subscribe [:rf.resource/data board-query])
         state   @(subscribe [:rf.resource/state board-query])
         editing @(subscribe [:linearlite/editing])
@@ -541,11 +561,11 @@
       [fail-toggle]
       [new-issue-form]]
      (cond
-       ;; First load (route entry), no usable board yet → skeleton.
+       ;; First load, nothing to show yet → a skeleton.
        (:loading? state)
        [:p {:data-testid "board-skeleton"} "Loading the board…"]
 
-       ;; First-load failure with no usable board → full error screen.
+       ;; First load failed and we have no board to fall back on → error screen.
        (and (:error state) (not (:has-data? state)))
        [:p.error {:data-testid "board-error"} "Could not load the board."]
 
@@ -572,19 +592,20 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; The React root is materialised lazily inside `run`, not at ns-load, so the
-;; example mounts only in a browser. The app frame is created, configured, and
-;; provided in one spot: the render root's `frame-provider {:id app-frame …}`.
-;; On first mount it creates the frame under `app-frame` and applies the config:
-;; `:url-bound? true` so it owns the browser URL, and a `:rf.http/managed`
-;; override pointing at the canned board stub so the example runs standalone. On
-;; hot reload it reuses that same frame and keeps its app-db. Every in-tree
-;; dispatch and subscribe resolves against that id. Guide:
+;; We build the React root lazily inside `run`, not at ns-load, so the example
+;; only mounts in a browser. The app frame is created, configured, and provided
+;; all in one place: the render root's `frame-provider {:id app-frame …}`. On
+;; first mount it creates the frame under `app-frame` and applies the config —
+;; `:url-bound? true` so the frame owns the browser URL, and a `:rf.http/managed`
+;; override pointing at our canned stub so the whole thing runs standalone. On
+;; hot reload it finds that same frame and keeps its app-db. Every dispatch and
+;; subscribe inside the tree resolves against that id. Guide:
 ;; ../../../docs/routing/glossary.md#url-bound
 ;;
-;; The board is seeded by route entry, not at boot: the `:linearlite.app/board`
-;; route's `:resources` metadata ensures it, driven by the initial URL sync
-;; `rf/install-history-listener!` performs — hence no `:initial-events`.
+;; Notice there are no `:initial-events`. The board isn't seeded at boot — it's
+;; seeded by entering the route. The `:linearlite.app/board` route's `:resources`
+;; metadata ensures it, kicked off by the first URL sync that
+;; `rf/install-history-listener!` performs.
 
 (defonce react-root (atom nil))
 
@@ -596,8 +617,8 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; The app frame is created and configured here. First mount creates it
-    ;; under `app-frame` and applies the config; hot reload reuses it.
+    ;; Frame created and configured right here. First mount builds it under
+    ;; `app-frame` and applies the config; hot reload reuses it.
     (rdc/render @react-root
                 [rf/frame-provider {:id           app-frame
                                     :doc          "Linearlite optimistic-board demo frame."

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -1,60 +1,67 @@
 (ns login.core
-  "Worked end-to-end example: a login feature.
+  "A login feature, end to end.
 
-   The one idea: a feature's whole lifecycle — idle, submitting, error,
-   success, lockout — is modelled as a single state machine rather than a
-   scatter of boolean flags. Five states, named transitions, a `:data`
-   slot for the attempt counter; you are always in exactly one state, and
-   every legal move is readable off the transition table below. See the
-   machines guide (docs/machines/concepts.md) and its glossary
-   (docs/machines/glossary.md).
+   Here's the one idea worth carrying away. A login flow has a life — it
+   sits idle, then it's submitting, then it's an error or a success or
+   (after too many tries) a lockout. The tempting way to track that is a
+   fistful of booleans: `submitting?`, `error?`, `locked?`. Don't. The
+   moment you have three booleans you have eight combinations, most of
+   them nonsense — `submitting? AND locked?` should never happen, yet
+   nothing stops it. So instead we model the whole lifecycle as one state
+   machine. Five states, named transitions, and a tiny `:data` slot for
+   the attempt counter. You are always in exactly one state, and every
+   legal move is right there in the transition table below — no illegal
+   combination is even expressible. See the machines guide
+   (docs/machines/concepts.md) and its glossary (docs/machines/glossary.md).
 
-   It shows how the parts fit together:
-   - State machine — the login flow as a transition table, read like any
-     derived state through a subscription on the machine id.
+   With that idea in hand, here's how the pieces fit:
+
+   - State machine — the login flow as a transition table. Its live value
+     is read like any other derived state: through a subscription on the
+     machine id.
    - State tags — `:auth/busy`, `:auth/authenticated`, `:auth/locked`.
-     Views ask `(rf/machine-has-tag? :auth.login/flow ...)` instead of
-     enumerating exact state names (docs/machines/glossary.md#state-tag).
-     The terminal `:locked-out` state shows as a non-interactive
-     locked-account panel, not a dead-but-enabled form.
+     Views ask a question — `(rf/machine-has-tag? :auth.login/flow ...)` —
+     rather than memorising exact state names
+     (docs/machines/glossary.md#state-tag). The terminal `:locked-out`
+     state becomes a non-interactive panel, not a form that's enabled but
+     secretly dead.
    - Form slice — the email/password draft is an app-db slice at
-     [:auth :login-form]. The slice owns the draft (controlled inputs,
-     no view-local atom); the machine owns submit/auth status. This is
-     the form recipe in docs/guide/how-to/build-a-form.md.
-   - Managed HTTP — `:rf.http/managed` plus a per-app demo stub that
-     resolves the request locally so the example runs without a backend
-     (docs/resources/http.md).
+     [:auth :login-form]. The slice owns the draft (controlled inputs, no
+     view-local atom); the machine owns submit/auth status. That division
+     of labour is the form recipe in docs/guide/how-to/build-a-form.md.
+   - Managed HTTP — `:rf.http/managed`, plus a small per-app demo stub
+     that answers the request locally so the example runs with no backend
+     to point it at (docs/resources/http.md).
    - Schemas, events, subscriptions, registered views — the everyday
      building blocks (docs/guide/glossary.md).
 
-   In a real codebase this single file would split into
-   login/schema.cljc, events.cljs, subs.cljs, views.cljs, machines.cljs.
-   It is kept as one file here for brevity.
-
-   Examples are test-free; login's behaviour is covered by the substrate
-   contract suite (`npm run test:cljs`) and the framework gates."
-  ;; This example runs on stock Reagent (`reagent.dom.client` + the
-  ;; `re-frame.adapter.reagent` adapter). login is the cross-substrate
-  ;; reference base: it is mirrored 1:1 as `login-uix` and `login-helix`,
-  ;; so keeping it on the reference substrate makes the three variants a
-  ;; clean apples-to-apples comparison.
+   In a real codebase you'd split this across login/schema.cljc,
+   events.cljs, subs.cljs, views.cljs, and machines.cljs. It lives in one
+   file here so you can read it top to bottom in one sitting."
+  ;; This example runs on stock Reagent. It's also the cross-substrate
+  ;; reference base — mirrored 1:1 as `login-uix` and `login-helix` — so
+  ;; staying on Reagent keeps the three an honest apples-to-apples
+  ;; comparison.
+  ;;
+  ;; A note on the requires below: re-frame2 ships its bigger features
+  ;; opt-in. You pay for what you use, and you say so by requiring it.
+  ;; Each `re-frame.*` require here is a feature switching itself on.
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            ;; Installs the Malli validator adapter so the machine's
-            ;; `[:schemas :data]` validation resolves. (This example
-            ;; attaches no app-db schema; machine snapshots are
-            ;; runtime-db, not app-db.)
+            ;; Turns on Malli validation, so the machine's `[:schemas :data]`
+            ;; checks have something to run. (No app-db schema in this
+            ;; example — machine snapshots live in runtime-db, not app-db.)
             [re-frame.schemas]
-            ;; Enables state machines: registers the hooks that make
-            ;; `rf/reg-machine` and the `:rf/machine` subscription work.
+            ;; Turns on state machines — the hooks behind `rf/reg-machine`
+            ;; and the `:rf/machine` subscription.
             [re-frame.machines]
-            ;; Registers `:rf.http/managed` and family. Without this
-            ;; require, dispatching `:rf.http/managed` would fail loud.
+            ;; Turns on managed HTTP. Skip this require and the first
+            ;; `:rf.http/managed` dispatch fails loud rather than silently
+            ;; doing nothing — which is exactly what you want.
             [re-frame.http.managed]
-            ;; Registers the canned-success / canned-failure stub fxs the
-            ;; demo stub delegates to. This require is the opt-in
-            ;; (docs/guide/how-to/test-a-cascade.md).
+            ;; Turns on the canned-success / canned-failure stub fxs our
+            ;; demo stub leans on (docs/guide/how-to/test-a-cascade.md).
             [re-frame.http.test-support]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -63,40 +70,50 @@
 ;; SCHEMAS
 ;; ============================================================================
 ;;
-;; Schemas are open by default — they describe a shape without forbidding
-;; extra keys. See docs/guide/how-to/validate-with-schemas.md.
+;; Schemas describe the shape of data. re-frame2's are open by default:
+;; they say what must be present, not what must be absent, so extra keys
+;; are fine. See docs/guide/how-to/validate-with-schemas.md.
 
-;; The submit-event payload — the credentials the view collects from the
-;; form. The regex / min-length checks describe the shape the machine's
-;; submit handler relies on. The password is never written to app-db or
-;; the machine `:data`; its only off-box path is the HTTP request body,
-;; redacted by the `:sensitive? true` flag on the managed-HTTP call in
-;; `:issue-request` below (docs/resources/http.md, "Keeping secrets out
+;; The credentials the form collects — and the payload the submit event
+;; carries. The regex and min-length aren't decoration: they're the
+;; promise the machine's submit handler is allowed to rely on, enforced at
+;; the boundary so a bad email or short password never reaches it.
+;;
+;; Note what's NOT promised here: that the password goes anywhere it
+;; shouldn't. It's never written to app-db or the machine `:data`. Its one
+;; and only trip off the box is the HTTP request body, and even that is
+;; redacted from the trace by `:sensitive? true` on the managed-HTTP call
+;; in `:issue-request` below (docs/resources/http.md, "Keeping secrets out
 ;; of the trace").
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
    [:password [:string {:min 8}]]])
 
-;; Event-vector schema for the :auth.login/flow machine. A malformed
-;; event vector is rejected at the boundary and the handler never runs.
-;; The login form is the user-facing boundary, so the :submit payload is
-;; validated strictly against `Credentials`. The other sub-events
-;; (:dismiss, :success, :failure) come from the machine itself, so their
-;; tail is admitted loosely.
+;; The shape of every event vector dispatched at the :auth.login/flow
+;; machine. Get it wrong and the event is rejected at the boundary — the
+;; handler simply never runs. The trick is that not all sub-events deserve
+;; equal suspicion. The :submit comes straight from a human typing into a
+;; form, so we check its payload strictly against `Credentials`. The
+;; others (:dismiss, :success, :failure) originate inside the machine, so
+;; we trust their tails and wave them through.
 ;;
-;; The :submit branch is a `:tuple`, not a `:cat`: the outer `:cat`
-;; consumes the nested sub-event vector as a single element, so the branch
-;; must match that one element as a vector. A short-password or bad-email
-;; submit is then rejected at the boundary before the machine transitions
-;; or issues the login HTTP request.
+;; Two details earn a word, because they're the kind of thing that's
+;; baffling until someone points at them:
 ;;
-;; The trailing `[:? :any]` admits the managed-HTTP reply: the framework
-;; appends the reply map (`{:kind ... :value ...}` /
-;; `{:kind ... :failure ...}`) as the last arg of the `:on-success` /
-;; `:on-failure` event vector, so a delivered reply has three top-level
-;; elements. Without the optional slot every reply would be rejected and
-;; the flow would strand in `:submitting`.
+;; - The :submit branch is a `:tuple`, not a `:cat`. The outer `:cat`
+;;   treats the nested sub-event vector as one element, so the branch has
+;;   to match that single element *as a vector*. The payoff: a short
+;;   password or bad email is caught here, before the machine moves or
+;;   fires off the login request.
+;;
+;; - The trailing `[:? :any]` is the slot for the HTTP reply. When a
+;;   managed-HTTP call resolves, the framework appends its reply map
+;;   (`{:kind … :value …}` or `{:kind … :failure …}`) as the last arg of
+;;   the `:on-success` / `:on-failure` event — so a delivered reply
+;;   arrives with three top-level elements. Forget the optional slot and
+;;   every reply gets rejected, leaving the flow marooned in `:submitting`
+;;   forever. (Ask me how I know.)
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
@@ -105,61 +122,71 @@
      [:* :any]]]
    [:? :any]])
 
-;; A machine's live value is a snapshot — its current state plus a `:data`
-;; map — held in runtime-db, not app-db (docs/machines/glossary.md#snapshot).
-;; A machine's `[:schemas :data]` validates the `:data` slot only, not the
-;; whole snapshot. So this schema describes the `:data` map (`:attempts` +
-;; `:error`) the machine seeds and the actions evolve; it is attached via
-;; the `[:schemas :data]` slot on the spec below.
+;; A machine's live value is a *snapshot*: its current state plus a small
+;; `:data` map, kept in runtime-db rather than app-db
+;; (docs/machines/glossary.md#snapshot). The `[:schemas :data]` slot
+;; validates that `:data` map and nothing else — not the whole snapshot.
+;; So this schema describes exactly that map: the `:attempts` counter and
+;; the last `:error`, which the machine seeds and its actions nudge along.
+;; We hand it to the machine via the `[:schemas :data]` slot in the spec
+;; below.
 (def AuthLoginData
   [:map
    [:attempts {:default 0} :int]
    [:error    [:maybe :string]]])
 
-;; Snapshots live in runtime-db, so app-db schemas (`reg-app-schema`) do
-;; not apply to them. The machine's own `[:schemas :data]` is the
-;; snapshot-validation surface.
+;; Worth saying plainly, since it trips people up: because snapshots live
+;; in runtime-db, app-db schemas (`reg-app-schema`) never see them. If you
+;; want a snapshot validated, the machine's own `[:schemas :data]` is the
+;; place — there is no other.
 
 ;; ============================================================================
 ;; FX  (managed HTTP + a per-app demo stub)
 ;; ============================================================================
 ;;
-;; HTTP requests go via `:rf.http/managed` (docs/resources/http.md). The
-;; login flow would normally POST `/api/login`, but this example ships no
-;; backend. So we register a demo stub at `:auth.login.demo/managed-stub`
-;; and override `:rf.http/managed` to it on the frame in `run`. The stub
-;; inspects the request body's `:password` and synthesises a success or
-;; failure reply via the framework's canned-success / canned-failure fxs,
-;; so the real reply shape is preserved end to end.
+;; HTTP goes through `:rf.http/managed` (docs/resources/http.md). In a real
+;; app this flow would POST `/api/login` and wait for a server. This
+;; example has no server — so we fake one, carefully.
 ;;
-;; `:auth.session/store` is client-only — localStorage is a browser API.
+;; The plan: register a demo stub at `:auth.login.demo/managed-stub`, then
+;; in `run` override `:rf.http/managed` to point at it for this frame. The
+;; stub peeks at the request body's `:password` and conjures a success or
+;; failure reply using the framework's own canned-success / canned-failure
+;; fxs. The point of going through those fxs rather than hand-rolling a map
+;; is fidelity: the reply has the exact same shape it would coming off a
+;; real wire, so the rest of the flow can't tell the difference.
 
 (def good-password "correct-horse")
 
 (rf/reg-fx :auth.session/store
-  {:doc       "Persist the session token in localStorage. Client only."
+  {:doc       "Stash the session token in localStorage so the login
+                survives a refresh. Client-only — localStorage is a
+                browser thing, so `:platforms` keeps it off the server."
    :platforms #{:client}}
   (fn fx-auth-session-store [_m {:keys [token]}]
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
 (rf/reg-fx :auth.login.demo/managed-stub
-  {:doc       "Demo override for `:rf.http/managed`: routes by URL and
-               request body to canned login responses so the example
-               runs standalone without a backend.
+  {:doc       "Our stand-in backend. It reads the URL and request body and
+               decides, by hand, what the server would have said:
 
-               POST /api/login with `:password good-password` → success
-                 with `{:user {...} :token \"demo-token-123\"}`.
-               POST /api/login otherwise → 401 failure.
-               Anything else (e.g. /api/auth/lock) → empty success.
+               POST /api/login with `:password good-password` → success,
+                 carrying `{:user {...} :token \"demo-token-123\"}`.
+               POST /api/login with anything else            → 401 failure.
+               Anything else (e.g. /api/auth/lock)           → empty success.
 
-               Delegates to the framework's canned-success / canned-failure
-               fxs. The `:after-ms 50` defers the reply by 50 ms (via
-               `:dispatch-later`, so it stays on the tape and is
-               time-travel-safe — not a raw `js/setTimeout`). The delay
-               lets the `:submitting` UI state be visible. The reply
-               reaches the `:auth.login/success` / `:auth.login/failure`
-               sub-events through the `:on-success` / `:on-failure` form."
+               It doesn't build the reply itself; it delegates to the
+               framework's canned-success / canned-failure fxs so the reply
+               is shaped like the real thing. `:after-ms 50` holds the
+               reply back by 50 ms — and crucially does so via
+               `:dispatch-later`, not a raw `js/setTimeout`, so the delay
+               stays on the tape and survives time-travel. Those 50 ms are
+               a courtesy to the reader: just long enough to actually see
+               the `:submitting` state before it resolves. The reply then
+               travels home to the `:auth.login/success` /
+               `:auth.login/failure` sub-events via `:on-success` /
+               `:on-failure`."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -189,45 +216,56 @@
 ;; STATE MACHINE
 ;; ============================================================================
 ;;
-;; The login flow is a finite state machine: five states, named events.
-;; The spec map below is inert data — a description of legal moves. Its
-;; live value is the snapshot ({:state … :data …}) in runtime-db, read
-;; like any derived state. Guards and actions live in the machine's
-;; :guards / :actions maps and are referenced by keyword from the
-;; transition table; resolution is machine-local. See
+;; Here's the heart of it. The login flow is a finite state machine: five
+;; states, transitions with names. The spec map below is just *data* —
+;; inert, a description of which moves are legal, nothing more. It doesn't
+;; run anything by itself. Its live value is the snapshot
+;; ({:state … :data …}) sitting in runtime-db, which you read like any
+;; other derived state.
+;;
+;; A small but lovely property of this layout: guards and actions live in
+;; their own `:guards` / `:actions` maps and the transition table refers to
+;; them by keyword. So the table reads as pure intent — "on failure, if
+;; under-retry-limit, record-error" — and the *how* is looked up
+;; separately. The keywords resolve machine-locally, so two machines can
+;; both have a `:clear-error` and never collide. See
 ;; docs/machines/concepts.md.
 
-;; The login flow's machine spec. The spec carries no :id — the machine's
-;; id is the registration id below.
+;; The spec itself. Notice it carries no `:id` — a spec is reusable data,
+;; and the id is bestowed when we register it, just below.
 (def auth-login-machine
   {:initial :idle
-   ;; `[:schemas :data]` validates the snapshot's `:data` slot. Malformed
-   ;; `:data` (e.g. a non-string `:error`) fails the run loud.
+   ;; This validates the snapshot's `:data` slot on every step. Slip a
+   ;; non-string into `:error` and the run fails loud rather than limping
+   ;; on with corrupt data.
    :schemas {:data AuthLoginData}
    :data    {:attempts 0 :error nil}
 
      :guards
      {:under-retry-limit
-      ;; True if the flow has had fewer than 3 prior failed attempts.
+      ;; The gatekeeper for retries: true while we've had fewer than 3
+      ;; failures. When it goes false, the next failure locks the account.
       (fn [{data :data}]
         (< (:attempts data) 3))}
 
      :actions
      {:clear-error
-      ;; Reset error and prepare to submit.
+      ;; Wipe any stale error before a fresh attempt.
       (fn [_]
         {:data {:error nil}})
 
       :issue-request
-      ;; Issue the login HTTP request. Returns effects, not side-effects.
-      ;; The runtime appends the reply (`{:kind :success :value ...}` /
-      ;; `{:kind :failure :failure ...}`) as the last arg of the
-      ;; :on-success / :on-failure events.
+      ;; Fire off the login request. Note it *returns* effects rather than
+      ;; performing them — the action stays pure; the runtime does the
+      ;; dirty work. When the reply lands, the runtime tacks it onto the
+      ;; end of the :on-success / :on-failure event
+      ;; (`{:kind :success :value …}` / `{:kind :failure :failure …}`).
       (fn [{[_ creds] :event}]
         {:fx [[:rf.http/managed
-               ;; `:sensitive? true` redacts the request body (carrying
-               ;; the password) and all params from every `:rf.http/*`
-               ;; trace event — the wire scrub for this request
+               ;; `:sensitive? true` is the secret-keeper. It scrubs the
+               ;; request body (which is carrying the password) and all
+               ;; params from every `:rf.http/*` trace event, so the
+               ;; password never shows up in Xray or a recording
                ;; (docs/resources/http.md, "Keeping secrets out of the
                ;; trace").
                {:request    {:method :post
@@ -240,18 +278,19 @@
                 :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
 
       :record-error
-      ;; Record the failure into :data and bump the attempt counter.
+      ;; Remember what went wrong (for the UI) and tick the attempt
+      ;; counter up by one (for the retry guard).
       (fn [{data :data [_ {:keys [failure]}] :event}]
         {:data (-> data
                    (update :attempts inc)
                    (assoc :error (or (:message failure) "Login failed.")))})
 
       :lock-account
-      ;; Mark the account as locked after too many failed attempts.
-      ;; Fire-and-forget: the lockout POST wants no reply folded back into
-      ;; the machine, so `:on-success nil` / `:on-failure nil` silence
-      ;; both reply branches. (Without them the default would dispatch a
-      ;; reply event that `AuthLoginEvent` rejects.)
+      ;; Slam the door after too many tries. This one is fire-and-forget:
+      ;; we tell the server to lock the account but don't care to hear back,
+      ;; so `:on-success nil` / `:on-failure nil` mute both reply branches.
+      ;; (Leave them off and the default would dispatch a reply event that
+      ;; `AuthLoginEvent` then rejects — a self-inflicted wound.)
       (fn [_]
         {:fx [[:rf.http/managed
                {:request    {:method :post :url "/api/auth/lock"}
@@ -259,7 +298,7 @@
                 :on-failure nil}]]})
 
       :store-session
-      ;; Persist the session token returned by a successful login.
+      ;; Login worked — squirrel away the token the server handed back.
       (fn [{[_ {:keys [value]}] :event}]
         {:fx [[:auth.session/store {:token (:token value)}]]})}
 
@@ -269,16 +308,19 @@
                                 :action :clear-error}}}
 
       :submitting
-      ;; State tag — ask, don't tell. Views query (rf/machine-has-tag?
-      ;; :auth.login/flow :auth/busy) to disable inputs and re-label the
-      ;; submit button, rather than asking "are we exactly :submitting?".
-      ;; Add another busy state tagged :auth/busy and no view changes.
+      ;; The `:auth/busy` tag is the "ask, don't tell" trick in action. The
+      ;; view asks (rf/machine-has-tag? :auth.login/flow :auth/busy) to
+      ;; disable inputs and relabel the button — it never asks "are we
+      ;; exactly :submitting?". The reward comes later: add a second busy
+      ;; state, tag it :auth/busy too, and the view needs zero changes.
       {:tags  #{:auth/busy}
        :entry :issue-request
-       ;; The failure branch is an ORDERED list of candidate transitions:
-       ;; the first whose :guard passes fires. Under the retry limit → show
-       ;; the error and let them retry; otherwise (no guard = fallthrough)
-       ;; → lock the account. The whole retry-then-lockout policy is here.
+       ;; Read the failure branch top to bottom: it's an *ordered* list of
+       ;; candidates, and the first whose `:guard` passes wins. Still under
+       ;; the retry limit? Show the error and let them try again. Out of
+       ;; tries (the second entry has no guard, so it's the fallthrough)?
+       ;; Lock the account. The entire retry-then-lockout policy lives in
+       ;; these four lines.
        :on    {:auth.login/success {:target :authed
                                     :action :store-session}
                :auth.login/failure [{:target :error-shown
@@ -288,36 +330,36 @@
                                      :action :lock-account}]}}
 
       :error-shown
-      ;; Direct retry from :error-shown re-enters :submitting and must clear the
-      ;; prior `:error` first — otherwise the obsolete failure message stays
-      ;; visible (the view renders `:auth.login/error` whenever non-nil) as if it
-      ;; still applied to the request now in flight. Same `:clear-error` action
-      ;; as the :idle entry transition.
+      ;; Retrying straight from here re-enters :submitting, and it has to
+      ;; clear the old `:error` on the way in. Skip that and the stale
+      ;; failure message lingers on screen (the view shows
+      ;; `:auth.login/error` whenever it's non-nil), looking for all the
+      ;; world like it belongs to the request that's now in flight. Same
+      ;; `:clear-error` we used leaving :idle.
       {:on {:auth.login/dismiss {:target :idle}
             :auth.login/submit  {:target :submitting
                                  :action :clear-error}}}
 
       :authed
-      ;; :auth/authenticated tag — the banner swaps to "Welcome!" once
-      ;; the flow reaches this terminal state.
+      ;; The happy ending. `:terminal?` says the flow stops here; the
+      ;; `:auth/authenticated` tag is what flips the banner to "Welcome!".
       {:tags #{:auth/authenticated}
        :meta {:terminal? true}}
 
       :locked-out
-      ;; :auth/locked tag — after the fourth failed submit the flow lands
-      ;; in this terminal state. Views query
-      ;; (rf/machine-has-tag? :auth.login/flow :auth/locked) to swap the
-      ;; form for a locked-account panel and refuse further submits. A
-      ;; terminal lockout must be visible and non-interactive, not a live
-      ;; form.
+      ;; The unhappy ending. Once the retry guard gives out, the next
+      ;; failure lands here for good. The `:auth/locked` tag lets the view
+      ;; swap the form for a locked-account panel and stop taking submits.
+      ;; A lockout should be plainly visible and inert — never a form
+      ;; that's alive but quietly refuses to do anything.
       {:tags #{:auth/locked}
        :meta {:terminal? true}}}})
 
-;; Register the machine as the `:auth.login/flow` event handler.
-;;
-;; This machine also validates its dispatched event vector, so the opts
-;; map carries the event `:schema` (the boundary on the outer vector)
-;; alongside the machine spec.
+;; And now the spec becomes a machine, registered under :auth.login/flow.
+;; That id is also an event handler id — dispatching at it drives the
+;; machine. Because we also want the incoming event vectors checked, the
+;; opts map carries `:schema` (our `AuthLoginEvent` boundary) right
+;; alongside the spec.
 (rf/reg-machine :auth.login/flow
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema AuthLoginEvent}
@@ -327,33 +369,38 @@
 ;; EVENTS
 ;; ============================================================================
 ;;
-;; The machine handler is self-initialising: its `:initial` state and
-;; `:data` seed the snapshot when the machine first runs. No separate
-;; machine :initialise event is needed.
+;; First, a freebie: the machine needs no `:initialise` event. It's
+;; self-seeding — the first time it runs, its `:initial` state and `:data`
+;; populate the snapshot for you.
 ;;
-;; The form-slice events below are the other half of the "machine + slice"
-;; split. The slice owns the draft — what the user is currently typing —
-;; at app-db [:auth :login-form]; the machine owns submit/auth status. A
-;; form's draft is application state, so it lives in app-db (read via subs,
-;; written via events), not in a view-local atom. Inputs are controlled:
-;; `:value` reads the draft sub, `:on-change` dispatches
-;; `:auth.login/edit-field`. This is the form recipe in
-;; docs/guide/how-to/build-a-form.md.
+;; Everything below is the *other* half of the "machine + slice" division
+;; of labour. The split is the thing to internalise: the slice owns the
+;; draft — the half-typed email and password the user is fiddling with
+;; right now, parked at app-db [:auth :login-form] — while the machine owns
+;; the submit/auth status. Why keep the draft in app-db instead of a tidy
+;; little view-local atom? Because a draft is application state like any
+;; other, and re-frame2 likes its state in one place where subs can read it
+;; and events can write it. So the inputs are *controlled*: `:value` reads
+;; the draft sub, `:on-change` dispatches `:auth.login/edit-field`, and the
+;; round trip through app-db is the only way a character gets on screen.
+;; That's the form recipe in docs/guide/how-to/build-a-form.md.
 ;;
-;; This block — slice defaults, form events, and the draft/slice subs
-;; below — is substrate-agnostic: it is identical across the reagent, uix,
-;; and helix login examples. Only the view syntax differs.
+;; One nice consequence: this whole block — slice defaults, the form
+;; events, and the draft/slice subs further down — is substrate-agnostic.
+;; It's identical across the reagent, uix, and helix login examples. Only
+;; the views speak a different dialect.
 
-;; The login form's default (empty) draft. The draft's value shape is
-;; `Credentials` (email regex + min-8 password) — the same schema the
-;; machine's `:submit` boundary enforces.
+;; The empty draft we start from. Its shape is `Credentials` (email regex,
+;; 8-char password) — the very schema the machine's `:submit` boundary will
+;; later hold it to.
 (def login-form-defaults {:email "" :password ""})
 
-;; Seed the slice to its standard Pattern-Forms shape. Dispatched once at
-;; boot (from `run`). `:draft` to the empty defaults; `:status :idle`.
+;; Lay down the slice in its standard form-recipe shape — empty draft,
+;; `:idle` status, all the bookkeeping fields blank. Dispatched once at
+;; boot (from `run`) so the very first render reads a real draft.
 (rf/reg-event :auth.login/initialise-form
   {:doc "Seed the login-form slice at [:auth :login-form] to its standard
-         Pattern-Forms shape (empty draft, :idle status)."}
+         form-recipe shape (empty draft, :idle status)."}
   (fn handler-login-form-initialise [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form]
                    {:draft             login-form-defaults
@@ -364,10 +411,12 @@
                     :touched           #{}
                     :submit-error      nil})}))
 
-;; The user changed a single field. Update `:draft` and add the field to
-;; `:touched`. This is the ONLY thing an input's `:on-change` does — it never
-;; sets view-local state. The `:schema` rejects a malformed edit-field vector
-;; at the `:where :event` boundary.
+;; A keystroke landed. Write the new value into `:draft` and remember the
+;; user has now touched this field (that `:touched` set decides, later, when
+;; it's fair to show a field's error). This single event is the *entire* job
+;; of an input's `:on-change` — it sets no view-local state, because there
+;; is none. The `:schema` swats away any malformed edit-field vector at the
+;; boundary before the handler sees it.
 (rf/reg-event :auth.login/edit-field
   {:doc    "Controlled-input edit: write one field into the login-form draft
             and mark it touched."
@@ -377,20 +426,22 @@
              (assoc-in  [:auth :login-form :draft field] value)
              (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 
-;; Submit. Reads the draft out of the slice, latches `:submit-attempted?`,
-;; flips the slice `:status` to `:submitting`, and dispatches the draft into
-;; the machine — the only point the draft crosses into the machine (and is
-;; validated against `Credentials` at the event boundary). The machine, not
-;; the slice, then owns the in-flight / authed / error / locked status; the
-;; slice `:status` is a mirror.
+;; Submit. This is the handoff point — the one and only place the draft
+;; crosses from the slice into the machine (and gets checked against
+;; `Credentials` on the way). It reads the draft, latches
+;; `:submit-attempted?`, nudges the slice `:status` to `:submitting`, and
+;; dispatches the draft at the machine. From here on the *machine* owns the
+;; in-flight / authed / error / locked story; the slice `:status` is just a
+;; mirror tagging along.
 ;;
-;; Secret-field hygiene: the handler reads the password off the draft, hands
-;; it to the machine, then clears `[:draft :password]` in the same commit.
-;; Once the request is in flight the secret has done its job, so it does not
-;; sit in app-db waiting for the next snapshot or recorder capture. The
-;; password's only off-box path is the HTTP request body (scrubbed by the
-;; `:sensitive? true` flag); it is never written to `:submitted` or the
-;; machine `:data`. See docs/guide/how-to/add-auth.md.
+;; Now the careful bit — secret-field hygiene. In the same commit that hands
+;; the password to the machine, we blank `[:draft :password]`. The thinking:
+;; once the request is in flight the password has done its one job, and a
+;; secret that lingers in app-db is a secret waiting to be caught in the
+;; next snapshot or recording. So we don't let it linger. Its only sanctioned
+;; trip off the box is the HTTP request body (and `:sensitive? true` scrubs
+;; even that from the trace); it never touches `:submitted` or the machine
+;; `:data`. See docs/guide/how-to/add-auth.md.
 (rf/reg-event :auth.login/submit-form
   {:doc "Submit the login form: read the draft from the slice, dispatch it
          into the :auth.login/flow machine's :submit sub-event, and clear the
@@ -403,7 +454,7 @@
                (assoc-in [:auth :login-form :draft :password] ""))
        :fx [[:dispatch [:auth.login/flow [:auth.login/submit draft]]]]})))
 
-;; Reset the slice back to its initial (empty, :idle) shape.
+;; Wipe the slate — slice back to empty, status back to `:idle`.
 (rf/reg-event :auth.login/reset-form
   {:doc "Clear the login-form slice back to empty defaults / :idle."}
   (fn handler-login-form-reset [{:keys [db]} _]
@@ -420,13 +471,15 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-;; These named subs project the convenient pieces out of the machine
-;; snapshot. The "in :submitting?" / "in :authed?" predicates instead live
-;; as `rf/machine-has-tag?` queries in the views below
-;; (docs/machines/glossary.md#state-tag).
+;; These subs pull the handy bits out of the machine snapshot so views
+;; don't have to. You'll notice there's no "in :submitting?" or "in
+;; :authed?" sub here — those questions are asked with `rf/machine-has-tag?`
+;; in the views instead, which keeps the views from caring about exact state
+;; names (docs/machines/glossary.md#state-tag).
 
-;; Read the snapshot through the framework `:rf/machine` sub — the public
-;; surface for a machine's live value (docs/machines/glossary.md#snapshot).
+;; The snapshot's current state, reached through the framework's
+;; `:rf/machine` sub — the public doorway to a machine's live value
+;; (docs/machines/glossary.md#snapshot).
 (rf/reg-sub :auth.login/state
   {:doc "Current state of the login flow."}
   :<- [:rf/machine :auth.login/flow]
@@ -441,11 +494,13 @@
 
 ;; --- Form-slice subs (substrate-agnostic) ----------------------------------
 ;;
-;; The login-form slice lives at app-db [:auth :login-form]. The view reads
-;; the draft through `:auth.login/draft` and binds each input's `:value` to
-;; it — controlled inputs. The per-field-error sub follows the form
-;; visibility rule (touched OR submit-attempted?). These subs are shared
-;; identically across the three substrate examples.
+;; The slice lives at app-db [:auth :login-form], and these three subs are
+;; how the view gets at it. The draft sub feeds every input's `:value` (the
+;; controlled-input loop), and the field-error sub bakes in the one rule
+;; that matters for forms: don't shout an error at a field the user hasn't
+;; touched yet (or before they've tried to submit). Like the form events,
+;; these subs are byte-identical across the reagent, uix, and helix
+;; examples.
 
 (rf/reg-sub :auth.login/form-slice
   {:doc "The whole login-form slice at [:auth :login-form]."}
@@ -473,18 +528,20 @@
 ;; VIEWS
 ;; ============================================================================
 ;;
-;; `reg-view` injects `dispatch` / `subscribe` as locals inside the view
-;; body, bound to the frame the view renders under — so the same view can
-;; mount in several isolated frames at once (docs/guide/concepts/views.md).
+;; `reg-view` is `defn` with a superpower: inside the body, `dispatch` and
+;; `subscribe` are already in scope, pre-bound to whichever frame the view
+;; is rendering under. No threading a frame argument through every call.
+;; That's also what lets the very same view mount in several isolated frames
+;; at once (docs/guide/concepts/views.md).
 
-;; Controlled-input login form. The form holds no view-local state: there
-;; is no `reagent.core/atom`. Each input's `:value` reads the draft from the
-;; `:auth.login/draft` sub, and `:on-change` dispatches
-;; `:auth.login/edit-field`. Submit dispatches `:auth.login/submit-form`,
-;; which reads the draft from app-db and hands it to the machine. The
-;; in-flight / error state comes from the machine (the `:auth/busy` tag and
-;; the `:auth.login/error` sub) — the slice owns the draft, the machine
-;; owns submit/auth status.
+;; The login form. Read it and notice the absence — there is no
+;; `reagent.core/atom`, no local state hiding anywhere. Each input's
+;; `:value` comes from the `:auth.login/draft` sub; each `:on-change`
+;; dispatches `:auth.login/edit-field`. The submit button dispatches
+;; `:auth.login/submit-form`, which fetches the draft from app-db and feeds
+;; the machine. And "are we busy?" / "what went wrong?" are answered by the
+;; machine — the `:auth/busy` tag and the `:auth.login/error` sub. Slice
+;; owns the draft; machine owns the status; the view just renders them.
 (reg-view ^{:doc "The login form view: email + password + submit button + error display."}
           login-form []
   (let [draft @(subscribe [:auth.login/draft])
@@ -513,16 +570,19 @@
       (if busy? "Signing in…" "Sign in")]
      (when err [:p.error {:data-testid "login-error"} err])]))
 
-;; Terminal lockout panel — rendered once the flow reaches :locked-out
-;; (tagged :auth/locked). The state has no transitions, so the form is
-;; swapped out entirely rather than left enabled-but-dead.
+;; What you see once the flow hits :locked-out (tagged :auth/locked). That
+;; state has no way out, so we replace the form wholesale instead of leaving
+;; a zombie form on screen that takes input and ignores it.
 (reg-view ^{:doc "Locked-account panel shown when the login flow reaches :locked-out."}
           locked-panel []
   [:div.locked {:data-testid "locked-panel"}
    [:h2 "Account locked"]
    [:p "Three failed attempts. Contact support to unlock."]])
 
-(reg-view ^{:doc "Shows the user's logged-in state and a sign-out button."}
+;; The top-level switch. It reads two tags off the machine and shows one of
+;; three faces: a welcome when authed, the locked panel when locked, and the
+;; form the rest of the time.
+(reg-view ^{:doc "Picks what to show by login state: welcome / locked panel / the form."}
           login-banner []
   (let [authed? @(rf/machine-has-tag? :auth.login/flow :auth/authenticated)
         locked? @(rf/machine-has-tag? :auth.login/flow :auth/locked)]
@@ -541,34 +601,40 @@
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 
-;; The React root is held in an atom and created lazily inside `run`, not
-;; at ns-load: loading the namespace must produce no DOM side effects, so
-;; co-required example namespaces don't race `create-root` onto `#app`.
+;; We park the React root in an atom and create it lazily, inside `run` —
+;; never at namespace load. The rule is: requiring a namespace should touch
+;; the DOM exactly zero times. Otherwise, the moment another example
+;; co-requires this one, two `create-root` calls race for `#app` and you get
+;; the kind of bug that only shows up on Tuesdays.
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; Install the Reagent adapter. Pass its spec map straight to init!.
+  ;; Tell re-frame2 to render through Reagent. The adapter is just a spec
+  ;; map; hand it straight to `init!`.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; One-spot frame setup. The `frame-provider` ensure shape (`{:id …}`)
-    ;; creates `:rf/default` on first mount, applies the config below, runs
-    ;; `:initial-events` once, and scopes the frame into React. On hot
-    ;; reload it reuses the existing frame and skips re-seeding.
+    ;; Frame setup, all in one breath. Handing `frame-provider` an `{:id …}`
+    ;; map is the "make sure this frame exists" shape: on first mount it
+    ;; creates `:rf/default`, applies the config below, runs
+    ;; `:initial-events` once, and scopes the frame into React. On hot reload
+    ;; it finds the frame already there and leaves it alone — no double-seed.
     ;; See docs/guide/concepts/frames.md.
     ;;
-    ;; - `:fx-overrides` routes `:rf.http/managed` to the in-process login
-    ;;   stub above so the example runs standalone — no backend required.
-    ;; - `:initial-events` seeds the login-form slice so the controlled
-    ;;   inputs read a real (empty-string) draft from the first render. An
-    ;;   uninitialised draft would feed React `nil` :values — uncontrolled
-    ;;   inputs. The machine self-initialises; the slice is app-db, so it is
-    ;;   seeded here.
+    ;; - `:fx-overrides` is where we swap in our fake backend: it points
+    ;;   `:rf.http/managed` at the in-process stub above, so the example
+    ;;   stands on its own with nothing to connect to.
+    ;; - `:initial-events` seeds the login-form slice *before* the first
+    ;;   render. Skip it and the inputs would read `nil` for their `:value`
+    ;;   on that first paint — and React quietly demotes a `nil`-valued input
+    ;;   to an uncontrolled one, which is a mess to debug later. The machine
+    ;;   seeds itself; the slice is app-db, so we seed it here.
     ;;
-    ;; The provider scope is what makes the injected `dispatch`/`subscribe`
-    ;; (and the machine reads) resolve to `:rf/default`. A `reg-view`
-    ;; rendered with no provider fails loud.
+    ;; And the provider isn't optional scenery: its scope is the reason the
+    ;; views' injected `dispatch`/`subscribe` (and the machine reads) know to
+    ;; talk to `:rf/default`. Render a `reg-view` outside any provider and it
+    ;; fails loud rather than guessing.
     (rdc/render @react-root
                 [rf/frame-provider {:id             :rf/default
                                     :doc            "Login demo frame."

--- a/examples/reagent/login/stories.cljs
+++ b/examples/reagent/login/stories.cljs
@@ -1,19 +1,21 @@
 (ns login.stories
-  "Story showcase for the login worked example.
+  "A Story showcase for the login example.
 
-   The login form's view-states make a natural Story variant set —
-   Story's strength is enumerating one view's states side by side. This
-   file registers one `reg-variant` per reachable state of the example's
-   `:auth.login/flow` machine, so the controls panel flips the page
-   through every state without the reader hand-driving the form. See the
-   Story guide (docs/story/index.md).
+   Story does one thing beautifully: it lines up every state of a single
+   view, side by side, so you can see them all at once instead of clicking
+   your way there one at a time. A login form is a perfect fit, because its
+   states are exactly the machine's states. So this file registers one
+   `reg-variant` per reachable state of `:auth.login/flow`, and the controls
+   panel becomes a remote control that flips the page through the whole flow
+   — no typing into the form required. See the Story guide
+   (docs/story/index.md).
 
    The machine has five states:
 
        :idle → :submitting → {:error-shown | :authed | :locked-out}
 
-   The variants map onto the states a reader actually reaches, each
-   driven through real events:
+   And here are the variants, each one a real, reachable state driven by
+   real events (no faking the snapshot):
 
      :story.login/empty               — fresh `:idle` form.
      :story.login/filled              — a draft typed into the app-db
@@ -29,11 +31,12 @@
      :story.login/success             — `:authed` welcome banner; the
                                         canonical screenshot.
 
-   The auth-submit cascade in Xray
+   Watching the auth-submit cascade in Xray
 
-   Each variant runs in its own frame under `:preset :story`, which
-   redirects `:rf.http/managed` to the framework's canned-success stub.
-   So a real submit runs the full auth cascade end to end:
+   Here's the part that's genuinely fun. Each variant runs in its own frame
+   under `:preset :story`, which quietly redirects `:rf.http/managed` to the
+   framework's canned-success stub. So a submit isn't a mock — it's the real
+   cascade, running end to end:
 
        [:auth.login/flow [:auth.login/submit creds]]   (→ :submitting)
          → machine `:issue-request` action
@@ -42,25 +45,25 @@
                  → [:auth.login/flow [:auth.login/success …]]
                      → :authed
 
-   The whole chain lands on the Epoch tape and the Trace stream, and the
-   `:rf.http/managed` fx shows in the Side Effects panel — pick the
-   `:success` variant, press Ctrl+Shift+C, and watch it light up.
+   Every hop lands on the Epoch tape and the Trace stream, and the
+   `:rf.http/managed` fx surfaces in the Side Effects panel. Pick the
+   `:success` variant, press Ctrl+Shift+C, and watch the whole thing light
+   up like a pinball table.
 
-   Two variants light Xray's Issues ribbon:
-     - `:invalid-credentials` — the malformed `:submit` is rejected by
-       the `Credentials` schema at the event boundary; the handler never
-       runs and an Issue is raised.
+   Two variants deliberately set off Xray's Issues ribbon — because seeing
+   the framework *catch* a mistake is half the lesson:
+     - `:invalid-credentials` — the malformed `:submit` bounces off the
+       `Credentials` schema at the boundary; the handler never runs, and an
+       Issue is raised.
      - `:auth-error` / `:locked-out` — a 401 failure cascade; the
        `:rf.http/managed` request fires (Side Effects) and the
        `:auth.login/failure` follow-on records the error.
 
-   Every variant body is plain data — no fn-slots. The view at the
-   centre of each is the example's own `login.core/root-view`,
-   referenced by id. The canonical Story tags auto-install on the first
-   `reg-*` call, so no explicit boot step is needed.
-
-   Examples are test-free: these stories carry no `:script` /
-   `:rf.assert/*` — they are a showcase, not a test surface."
+   One more thing worth noticing: every variant body below is plain data —
+   no function slots anywhere. The view at the heart of each is the
+   example's own `login.core/root-view`, named by id. And the canonical
+   Story vocabulary installs itself on the first `reg-*` call, so there's no
+   boot step to remember."
   (:require [re-frame.core :as rf]
             [re-frame.story :as story]
             ;; Source the example's registrations (the machine, schemas,
@@ -70,22 +73,22 @@
             [login.core]))
 
 ;; ---------------------------------------------------------------------------
-;; Story-side submit event — the Xray-rich auth-submit cascade.
+;; The story-side submit — our way of triggering the full, Xray-rich cascade.
 ;;
-;; The machine's `:issue-request` action issues a real `:rf.http/managed`
-;; request and routes the reply back through `:auth.login/success` /
-;; `:auth.login/failure`. Each variant frame runs under `:preset :story`,
-;; which redirects `:rf.http/managed` to the framework's canned-success
-;; stub (that stub echoes the request's `:value` slot back as the success
-;; payload).
+;; Recall what the machine does on submit: its `:issue-request` action fires
+;; a real `:rf.http/managed` request and pipes the reply back through
+;; `:auth.login/success` / `:auth.login/failure`. And recall the `:preset
+;; :story` frame redirects `:rf.http/managed` to the framework's
+;; canned-success stub (which just echoes the request's `:value` slot back
+;; as the payload).
 ;;
-;; So this event simply dispatches the real `:auth.login/submit`
-;; sub-event: the same machine action fires the same real
-;; `:rf.http/managed` fx (visible in Xray's Side Effects panel), and the
-;; canned-success stub resolves it — no app-side fx-override needed. The
-;; reply `:value` is nil (the request carries none), but the welcome
-;; banner keys off the `:auth/authenticated` tag, so the cascade lands
-;; cleanly at `:authed`.
+;; Put those together and this event has almost nothing to do: it just
+;; dispatches the real `:auth.login/submit`. Same machine action, same real
+;; fx (right there in Xray's Side Effects panel), and the canned stub
+;; answers it — no app-side override needed. The reply `:value` happens to
+;; be nil (we sent none), but that's fine: the welcome banner keys off the
+;; `:auth/authenticated` tag, not the payload, so the flow still settles
+;; happily at `:authed`.
 ;; ---------------------------------------------------------------------------
 
 (rf/reg-event :login.story/submit
@@ -102,25 +105,27 @@
 ;; ---------------------------------------------------------------------------
 ;; register-all!
 ;;
-;; Every registration lives in one top-level fn so a hot-reload can
-;; re-fire the lot. The fn runs once at namespace load via the trailing
-;; call, so requiring this ns populates the Story registry.
+;; We gather every registration into one top-level fn for a practical
+;; reason: hot-reload can then re-fire the whole set in one go. The trailing
+;; call at the bottom runs it once on load, so merely requiring this ns is
+;; enough to populate the Story registry.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private good-creds
-  "Credentials the demo accepts (mirrors `login.core/good-password`).
-   Only used to shape the submit payload past the `Credentials`
-   boundary schema; the canned-success stub ignores them."
+  "Credentials the demo would accept (they mirror `login.core/good-password`).
+   We only need them to get a submit payload past the `Credentials` boundary
+   schema — once it's through, the canned-success stub doesn't even look at
+   them."
   {:email "ada@example.com" :password "correct-horse"})
 
 (defn register-all!
-  "Register the login example's Story artefacts. Idempotent.
-   The canonical vocabulary auto-installs on the first `reg-*` call
-   — no explicit boot step required."
+  "Register all of the login example's Story artefacts. Safe to call twice —
+   it's idempotent, and the canonical vocabulary installs itself on the first
+   `reg-*` call, so there's no separate boot step to remember."
   []
 
   ;; -------------------------------------------------------------------------
-  ;; reg-tag — a project tag marking the canonical screenshot variant.
+  ;; reg-tag — one project tag, marking which variant is the "hero" shot.
   ;; -------------------------------------------------------------------------
 
   (story/reg-tag :login/canonical
@@ -128,9 +133,9 @@
           screenshot — the `:success` welcome-banner state."})
 
   ;; -------------------------------------------------------------------------
-  ;; reg-story — the parent story. Its `:component` (the example's
-  ;; `root-view`) and `:tags` inherit down to every variant below; the
-  ;; per-state setup lives on the variants.
+  ;; reg-story — the parent. Think of it as the shared backdrop: its
+  ;; `:component` (the example's `root-view`) and `:tags` flow down to every
+  ;; variant, so each variant only has to describe what makes it different.
   ;; -------------------------------------------------------------------------
 
   (story/reg-story :story.login
@@ -141,14 +146,17 @@
      :substrates #{:reagent}})
 
   ;; -------------------------------------------------------------------------
-  ;; reg-variant — the reachable states, each driven through real events;
-  ;; no `:db-seed` / `:sub-overrides`.
+  ;; reg-variant — the reachable states, one per variant. The house style
+  ;; here: drive each into place with real events, never by hand-poking the
+  ;; db (`:db-seed`) or faking subs (`:sub-overrides`). What you see is what
+  ;; the real flow produces.
   ;; -------------------------------------------------------------------------
 
-  ;; Empty — the entry state. The variant fires a no-op
-  ;; `:auth.login/dismiss` so the machine's `:initial` cascade seeds the
-  ;; snapshot; without it the `[:rf.runtime/machines :snapshots
-  ;; :auth.login/flow]` runtime-db slot is nil until the first real event.
+  ;; Empty — the state a user first lands on. The one bit of stage-setting:
+  ;; we fire a harmless `:auth.login/dismiss` to nudge the machine's
+  ;; `:initial` cascade into seeding the snapshot. Without that nudge the
+  ;; `[:rf.runtime/machines :snapshots :auth.login/flow]` slot sits nil until
+  ;; the first real event, and there'd be nothing to render.
   (story/reg-variant :story.login/empty
     {:doc        "Fresh form, nothing typed, no submit clicked — the
                  `:idle` entry state a user lands on. Email + password
@@ -157,11 +165,11 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; Filled — the user has typed into both fields but not yet submitted.
-  ;; The draft is seeded by dispatching the same `:auth.login/edit-field`
-  ;; events the controlled inputs fire on keystroke, writing into the
-  ;; app-db login-form slice. The machine stays `:idle` (no submit yet);
-  ;; the inputs render the seeded draft as their `:value`.
+  ;; Filled — both fields typed, nothing submitted. We get there honestly:
+  ;; by dispatching the very same `:auth.login/edit-field` events a real
+  ;; keystroke fires, which write into the app-db slice. The machine stays
+  ;; `:idle`, and the inputs show the seeded draft as their `:value`. No
+  ;; shortcuts.
   (story/reg-variant :story.login/filled
     {:doc        "Both fields filled in, nothing submitted yet — the form
                  mid-edit. The draft was typed into the app-db login-form
@@ -173,12 +181,13 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; Submitting — a submit is in flight. `force-fx-stub` intercepts the
-  ;; `:rf.http/managed` fx the `:issue-request` action emits: the stub
-  ;; records the call (visible in Side Effects) but resolves NOTHING, so
-  ;; no `:success` / `:failure` follow-on fires and the canvas locks at
-  ;; `:submitting` (`:auth/busy`) — inputs disabled, button reads
-  ;; "Signing in…".
+  ;; Submitting — frozen mid-request, on purpose. The trick is
+  ;; `force-fx-stub`: it catches the `:rf.http/managed` fx that
+  ;; `:issue-request` emits, records it (you'll see it in Side Effects), and
+  ;; then deliberately answers nothing. With no reply, no `:success` /
+  ;; `:failure` ever fires, so the canvas is stuck in `:submitting`
+  ;; (`:auth/busy`) — inputs disabled, button reading "Signing in…". A
+  ;; freeze-frame of the in-flight moment.
   (story/reg-variant :story.login/submitting
     {:doc        "First submit; the HTTP request is in flight. Inputs
                  are disabled and the button reads 'Signing in…'. The
@@ -189,10 +198,10 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; Invalid credentials — a malformed `:submit` (short password, bad
-  ;; email) is rejected by the `Credentials` boundary schema before the
-  ;; handler runs. The machine never transitions out of `:idle`; the
-  ;; rejection raises an Issue that lights Xray's Issues ribbon.
+  ;; Invalid credentials — the schema doing its job. We submit a deliberately
+  ;; bad payload (short password), and the `Credentials` boundary schema
+  ;; turns it away before the handler runs. The machine never leaves `:idle`,
+  ;; and the rejection raises an Issue you can watch light up Xray's ribbon.
   (story/reg-variant :story.login/invalid-credentials
     {:doc        "A malformed submit (too-short password) is rejected at
                  the event-schema boundary — the `:auth.login/flow`
@@ -204,12 +213,12 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; Auth error — the server rejected the credentials. The fx-stub
-  ;; intercepts the real request (recorded in Side Effects), then the
-  ;; variant manually drives the `:auth.login/failure` sub-event the
-  ;; stubbed-out request would otherwise have triggered — the canonical
-  ;; Story shape for pinning a specific terminal state regardless of
-  ;; timing. The machine lands at `:error-shown` with the error surfaced.
+  ;; Auth error — the 401. We stub out the real request (still recorded in
+  ;; Side Effects), then drive the `:auth.login/failure` ourselves — the one
+  ;; the request would have triggered had we let it answer. Driving the
+  ;; outcome by hand is the standard Story move for pinning a precise terminal
+  ;; state without being at the mercy of timing. The flow settles at
+  ;; `:error-shown`, error message and all.
   (story/reg-variant :story.login/auth-error
     {:doc        "Server rejected the credentials. The form is
                  re-enabled and the error message surfaces under the
@@ -225,11 +234,11 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; Locked out — the fourth terminal state. Once the flow has had three
-  ;; prior failed attempts the `:under-retry-limit` guard fails, so the
-  ;; next failure routes to `:locked-out` (and the `:lock-account` action
-  ;; fires a real `:rf.http/managed` lock request). The variant sequences
-  ;; submit → failure four times to exhaust the limit.
+  ;; Locked out — the dead end. After three failures the `:under-retry-limit`
+  ;; guard gives out, so the fourth failure routes to `:locked-out` and fires
+  ;; the `:lock-account` request (a real `:rf.http/managed` call). There's no
+  ;; shortcut to "three strikes already used", so this variant simply walks
+  ;; the path: submit → failure, four times over, until the limit is spent.
   (story/reg-variant :story.login/locked-out
     {:doc        "Too many failed attempts — the `:under-retry-limit`
                  guard fails on the fourth failure and the flow reaches
@@ -253,12 +262,12 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; Success — the canonical screenshot. The full real auth cascade runs
-  ;; through `:login.story/submit`: real submit → `:issue-request` →
-  ;; real `:rf.http/managed` fx → canned-success reply →
-  ;; `:auth.login/success` → `:authed`. Pick this variant + Ctrl+Shift+C
-  ;; to watch the whole cascade light up Xray's Epoch / Trace / Side
-  ;; Effects panels.
+  ;; Success — the hero shot, and the most satisfying one to inspect. The
+  ;; whole real cascade runs through `:login.story/submit`: submit →
+  ;; `:issue-request` → real `:rf.http/managed` fx → canned reply →
+  ;; `:auth.login/success` → `:authed`. Open this one, hit Ctrl+Shift+C, and
+  ;; watch the full chain march across Xray's Epoch / Trace / Side Effects
+  ;; panels.
   (story/reg-variant :story.login/success
     {:doc        "Server accepted the credentials. The form is replaced
                  by the 'Welcome!' banner (`:authed`). The full
@@ -270,11 +279,13 @@
      :substrates #{:reagent}})
 
   ;; -------------------------------------------------------------------------
-  ;; reg-workspace — two layouts over the variant set.
+  ;; reg-workspace — two ways to look at the same set of variants.
   ;;
-  ;; `:grid` pins the states in narrative order for the README
-  ;; screenshot; `:variants-grid` auto-enumerates every variant of the
-  ;; parent story (new variants appear without touching the workspace).
+  ;; The `:grid` one is hand-curated: it pins the states in narrative order
+  ;; for the README screenshot. The `:variants-grid` one is the lazy
+  ;; (read: maintainable) twin — it auto-enumerates every variant of the
+  ;; parent story, so a new variant shows up here on its own without anyone
+  ;; editing this workspace.
   ;; -------------------------------------------------------------------------
 
   (story/reg-workspace :Workspace.login/all-states
@@ -301,5 +312,5 @@
      :columns 3
      :tags    #{:docs}}))
 
-;; Fire the registrations once at namespace load.
+;; And go: register everything, once, the moment this ns loads.
 (register-all!)

--- a/examples/reagent/login/stories_host.cljs
+++ b/examples/reagent/login/stories_host.cljs
@@ -1,67 +1,67 @@
 (ns login.stories-host
-  "Showcase entry point for the login example — the host that wires the
-   live app, the Story shell, and Xray into one page.
+  "The showcase's front door — one page that wires together three things:
+   the live login app, the Story shell, and Xray.
 
-   URL-hash-routed between two surfaces:
+   It's hash-routed between two surfaces, so a single build serves both:
 
    - `#/`        → the live login app (the example's `root-view`).
-   - `#/stories` → the Story shell mounted via
-                   `re-frame.story/mount-shell!`. The reachable
-                   form-state variants + two workspaces show up in the
-                   sidebar; each variant renders in its own isolated
-                   frame.
+   - `#/stories` → the Story shell, mounted via
+                   `re-frame.story/mount-shell!`. The form-state variants
+                   and the two workspaces line the sidebar, and each
+                   variant renders in its own isolated frame.
 
    ## Xray
 
-   The build wires Xray via shadow-cljs's `:devtools {:preloads
-   [day8.re-frame2-xray.preload]}` (see the `:examples/login-with-
-   stories` build in `implementation/shadow-cljs.edn`). Loading the
-   preload attaches the Ctrl+Shift+C keybinding and the trace / epoch
-   collectors. We DISABLE auto-open here (`:rf.xray/auto-open? false`)
-   so the page lands on the live app or the Story shell first; the
-   reader presses Ctrl+Shift+C to open Xray over either surface and
-   drive a submit to watch the `:auth.login/submit` →
-   `:rf.http/managed` → reply cascade light up the Epoch / Trace / Side
-   Effects panels (and the schema-rejection / failure paths light the
-   Issues ribbon).
+   Xray rides in on a shadow-cljs preload (`:devtools {:preloads
+   [day8.re-frame2-xray.preload]}` — see the `:examples/login-with-stories`
+   build in `implementation/shadow-cljs.edn`). The preload quietly bolts on
+   the Ctrl+Shift+C keybinding and the trace / epoch collectors. We turn
+   *off* auto-open here (`:rf.xray/auto-open? false`) on purpose: the page
+   should greet you with the actual app or the shell, not a debugger. When
+   you're curious, Ctrl+Shift+C opens Xray over whichever surface you're on,
+   and a submit lets you watch the `:auth.login/submit` → `:rf.http/managed`
+   → reply cascade roll across the Epoch / Trace / Side Effects panels — or,
+   on the bad-input and failure paths, light up the Issues ribbon.
 
-   ## One adapter
+   ## One adapter for everything
 
-   The host installs the FULL Reagent adapter (`re-frame.adapter.
-   reagent`) — the substrate the Story shell itself renders on. The
-   example's own `core.cljs` already runs on stock Reagent (it is the
-   cross-substrate reference base), so the live app + shell + variant
-   canvases all render on one adapter. `login.core/root-view` is a
-   substrate-agnostic `reg-view`.
+   The host installs the full Reagent adapter (`re-frame.adapter.reagent`) —
+   the substrate the Story shell itself is built on. Happily, the example's
+   `core.cljs` already runs on stock Reagent (it's the cross-substrate
+   reference base), so the live app, the shell, and every variant canvas all
+   share one adapter. `login.core/root-view` is a substrate-agnostic
+   `reg-view`, so it doesn't mind which one.
 
-   ## Elision
+   ## Elision — none of this reaches production
 
-   Compiled under `:advanced` with `:closure-defines
-   {re-frame.story.config/enabled? false}`, every `reg-*` in
-   `login.stories` elides to nil and `mount-shell!` short-circuits —
-   the Story body carries no code into a production bundle. The
-   bundle-isolation gate verifies the Story / Xray sentinel sets stay
-   out of the plain `:examples/login` build."
+   Compile under `:advanced` with `:closure-defines
+   {re-frame.story.config/enabled? false}` and the whole Story layer simply
+   evaporates: every `reg-*` in `login.stories` compiles to nil and
+   `mount-shell!` short-circuits, so not a byte of showcase code rides into a
+   production bundle. That's not a promise on trust, either — the
+   bundle-isolation gate fails the build if any Story or Xray sentinel sneaks
+   into the plain `:examples/login` output."
   (:require [re-frame.core  :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-xray.config :as xray-config]
-            ;; Source the example's registrations (machine / schemas /
-            ;; demo fx / subs / views) and the Story artefacts. Requiring
-            ;; `login.stories` transitively requires `login.core`.
+            ;; Pull in the example's registrations (machine / schemas / demo
+            ;; fx / subs / views) and its Story artefacts. We get `login.core`
+            ;; for free — `login.stories` already requires it.
             [login.core :as core]
             [login.stories]
-            ;; Shared Story-host helper: owns the
-            ;; live-app↔Story-shell hash router + React-root handle.
+            ;; The shared Story-host helper, which owns the fiddly bits: the
+            ;; live-app↔Story-shell hash router and the React-root handle.
             [re-frame.testbed.story-host :as story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- The live-app frame ----------------------------------------------------
 ;;
-;; The live `#/` surface needs the example's demo HTTP override on its
-;; frame so `:rf.http/managed` routes to the in-process
-;; `:auth.login.demo/managed-stub` (no backend). The host owns the full
-;; boot, so it registers the override here rather than calling
-;; `login.core/run` (which runs its own mount lifecycle).
+;; The live `#/` surface needs the same demo-HTTP override the standalone
+;; example uses, so `:rf.http/managed` lands on the in-process
+;; `:auth.login.demo/managed-stub` and not on a backend that isn't there.
+;; Since the host is running its own boot from top to bottom, it sets the
+;; override up itself here rather than calling `login.core/run` (which would
+;; insist on running its own mount lifecycle).
 
 (defn- install-live-frame! []
   (rf/reg-frame :rf/default
@@ -79,37 +79,38 @@
     " on either surface to open Xray and inspect the auth-submit cascade."]
    [core/root-view]])
 
-;; The runtime never invents a frame, so the live-app `#/` surface must
-;; render under an explicit frame scope (docs/guide/concepts/frames.md).
-;; The Story shell side (`#/stories`) allocates its own per-variant
-;; frames; this wrapper scopes only the live-app surface to the
-;; showcase's `:rf/default` frame so `login-app`'s injected
-;; dispatch/subscribe (and `core/root-view`'s subs) resolve.
+;; re-frame2 never conjures a frame for you, so the live `#/` surface has to
+;; be wrapped in one explicitly (docs/guide/concepts/frames.md). The Story
+;; side (`#/stories`) hands out its own per-variant frames and needs no help;
+;; this little wrapper exists only to scope the live surface to the
+;; showcase's `:rf/default` frame, so `login-app`'s injected
+;; dispatch/subscribe (and `core/root-view`'s subs) have a frame to bind to.
 (defn live-app-root []
   [rf/frame-provider {:frame :rf/default} [login-app]])
 
 ;; -- Routing between the live app and the Story shell ----------------------
 ;;
-;; The live-app↔Story-shell hash router and React-root host handle live in
-;; the shared `re-frame.testbed.story-host` helper; `run` hands it
-;; `login-app` as the live-app surface.
+;; We don't hand-roll the router. The live-app↔Story-shell hash routing and
+;; the React-root handle both live in the shared
+;; `re-frame.testbed.story-host` helper; `run` just hands it `login-app` as
+;; the live surface and lets it do the wiring.
 
 (defn ^:export run []
-  ;; Keep Xray's collectors + keybinding installed but do not auto-open
-  ;; the panel — the page lands on the live app / shell first; the
-  ;; reader opens Xray with Ctrl+Shift+C.
+  ;; Leave Xray's collectors and keybinding in place, but don't fling the
+  ;; panel open — the page should land on the app or the shell first, and the
+  ;; reader pops Xray with Ctrl+Shift+C when they want it.
   (xray-config/configure! {:rf.xray/auto-open? false})
   (rf/init! reagent-adapter/adapter)
-  ;; No explicit `(story/install-canonical-vocabulary!)` — the first
-  ;; `reg-*` in `login.stories` (loaded via the require above)
-  ;; auto-installs the canonical Story vocabulary.
+  ;; No `(story/install-canonical-vocabulary!)` call needed: the first
+  ;; `reg-*` over in `login.stories` (loaded via the require above) installs
+  ;; the canonical Story vocabulary for us.
   (install-live-frame!)
-  ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
-  ;; `#/stories` lands on the shell without a manual click-through. The
-  ;; `:source-subdir` opt tells the host this showcase's Story source lives
-  ;; under `examples/reagent`, so the host can resolve the on-disk project
-  ;; root and wire it into Story and Xray. Without it the Story 'open in
-  ;; editor' chips would resolve `login/stories.cljs` against a nil root.
-  ;; The live-app root is frame-scoped via `live-app-root` so the bare `#/`
-  ;; surface mounts under the app frame.
+  ;; Hand off to the shared router so that reloading on `#/stories` lands you
+  ;; back on the shell instead of bouncing to the app. The `:source-subdir`
+  ;; opt is the one thing the helper can't guess: it says this showcase's
+  ;; Story source lives under `examples/reagent`, which lets the host find the
+  ;; on-disk project root and pass it to Story and Xray. Leave it out and the
+  ;; 'open in editor' chips try to resolve `login/stories.cljs` against a nil
+  ;; root — and miss. We pass `live-app-root` (not the bare `login-app`) so
+  ;; the `#/` surface arrives already wrapped in its frame.
   (story-host/mount-with-hash-routing! live-app-root {:source-subdir "examples/reagent"}))

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -1,63 +1,63 @@
 (ns long-running-work.core
-  "Entry point for the long-running-work example.
+  "Run a big job by splitting it across several workers at once.
 
-   The work decomposes into parallel sub-tasks, so it uses the
-   `:spawn-all` shape: one parent coordinator spawns N parallel
-   workers rather than chunking everything through a single machine.
-   See the machines guide's `:spawn` (docs/machines/glossary.md#spawn).
+   The job here is embarrassingly parallel: three independent shards,
+   each chewed through on its own. So instead of one machine grinding
+   the whole thing in sequence, we use the `:spawn-all` shape — a
+   parent coordinator spawns N children, one per shard, and waits for
+   them all. See the machines guide's `:spawn`
+   (docs/machines/glossary.md#spawn).
 
-   What this example demonstrates:
+   What you'll see here:
 
-   - **Declarative spawn-and-join** — one parent coordinator spawns N
-     parallel workers via `:spawn-all` and joins on `:all`. The
-     parent's `:data` holds no per-child bookkeeping; the runtime owns
-     the join state.
-   - **Cooperative cancellation cascade** — leaving the `:working`
-     state (by user `:cancel`, by completion, by frame destroy, by a
-     timeout) fires one `:rf.machine/destroy` fx that tears down every
-     surviving child. Each torn-down child's in-flight timers and HTTP
-     requests go with it.
-   - **Progress reporting** — each child dispatches a `:progress`
-     event back to the parent on every chunk. The parent records it
-     in `:data :progress`, the `:work/progress-fraction` sub
-     recomputes, and the bar updates.
-   - **Parent-unmount cascade** — the component wrapping the
-     work-bench dispatches `[:work/flow [:cancel]]` in its
-     `r/with-let` cleanup. That dispatch is the only point where the
-     UI lifecycle touches the machine; the cascade does the rest.
+   - **Spawn, then join** — the parent spawns N children with one
+     `:spawn-all` declaration and joins on `:all`. It keeps no tally
+     of who's finished; the runtime owns the join state, so the
+     parent's `:data` stays clean.
+   - **Cancellation that always lands** — whenever the parent leaves
+     `:working` (you hit Cancel, the job finishes, the frame is
+     destroyed, a timeout fires), one `:rf.machine/destroy` fx tears
+     down every child still standing. Their in-flight timers go down
+     with them, so nothing keeps ticking after the curtain falls.
+   - **Live progress** — each child fires a `:progress` event at the
+     parent after every chunk. The parent stashes it in
+     `:data :progress`, the `:work/progress-fraction` sub recomputes,
+     and the bar inches forward.
+   - **Unmount = cancel** — the component wrapping the work-bench
+     dispatches `[:work/flow [:cancel]]` from its `r/with-let`
+     cleanup. That single dispatch is the *only* place the UI touches
+     the machine; the cascade handles everything downstream.
 
-   Files:
+   The files, and what each owns:
 
-     core.cljs    mount + boot (this file)
-     worker.cljs  the :work/processor child machine and the
-                  :work/flow parent coordinator (the :spawn-all
-                  declaration is here)
-     views.cljs   UI components — controls, progress bar, shard
-                  breakdown, root, plus the work-bench wrapper whose
-                  with-let cleanup triggers the unmount cascade
-     schema.cljs  malli schemas for the parent + child snapshots
+     core.cljs    mount + boot (you are here)
+     worker.cljs  the two machines — the :work/processor child and the
+                  :work/flow parent coordinator, where the :spawn-all
+                  declaration lives
+     views.cljs   the UI — controls, progress bar, shard breakdown,
+                  root, and the work-bench wrapper whose with-let
+                  cleanup fires the unmount cascade
+     schema.cljs  malli schemas for the parent and child snapshots
 
-   Run from `implementation/`:
+   Run it live, from `implementation/`:
 
      shadow-cljs watch examples/long-running-work
-                                  (iterate against a live browser)
 
-   Headless tests:
+   Run it headless:
 
-     npm run test:browser        (runs every example's cljs-test)"
-  ;; Substrate: stock Reagent (`reagent.dom.client` +
-  ;; `re-frame.adapter.reagent`). The load-bearing teaching point is the
-  ;; `r/with-let` finally-cleanup in views.cljs that fires the `:cancel`
-  ;; cascade on view unmount, built on stock Reagent's
-  ;; `reagent.core/with-let`.
+     npm run test:browser        (covers every example's cljs-test)"
+  ;; Plain Reagent here (`reagent.dom.client` + `re-frame.adapter.reagent`).
+  ;; The trick worth watching is in views.cljs: a `r/with-let`
+  ;; finally-clause that fires the `:cancel` cascade when the view
+  ;; unmounts, riding on Reagent's own `reagent.core/with-let`.
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; Loading re-frame.machines registers the :spawn-all init /
-            ;; spawn / destroy fx handlers and the `:rf/machine` sub.
-            ;; worker.cljs and views.cljs both require this transitively;
-            ;; it's declared explicitly here too so the ns loads cleanly
-            ;; on its own.
+            ;; Requiring re-frame.machines is what installs the machine
+            ;; runtime: the :spawn-all init / spawn / destroy fx handlers
+            ;; and the `:rf/machine` sub. worker.cljs and views.cljs pull
+            ;; it in transitively, but we name it here too so this ns
+            ;; stands up on its own.
             [re-frame.machines]
             [long-running-work.schema]
             [long-running-work.worker]
@@ -67,12 +67,13 @@
 ;; INITIALISATION
 ;; ============================================================================
 ;;
-;; The :app/initialise boot event fans out to the per-feature initialisers.
-;; `:work/initialise` resets the parent flow machine to :idle;
-;; `:ui/initialise` seeds the Show/Hide toggle to true.
+;; One boot event, two jobs to hand out. `:app/initialise` just fans out
+;; to the feature initialisers: `:work/initialise` parks the parent
+;; machine in :idle, and `:ui/initialise` flips the Show/Hide toggle on.
 
 (rf/reg-event :app/initialise
-  {:doc "App boot. Fans out to per-feature initialisers."}
+  {:doc "The boot event. Doesn't do much itself — just hands off to
+         each feature's own initialiser."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:work/initialise]]
           [:dispatch [:ui/initialise]]]}))
@@ -81,28 +82,28 @@
 ;; MOUNT  (client-only)
 ;; ============================================================================
 ;;
-;; The React root is named `react-root` to avoid colliding with
-;; `root-view`. It's held in an atom and created lazily inside `run`,
-;; not at ns-load, so requiring this ns has no DOM side effect. That
-;; lets the headless fixtures require it without a browser, and keeps
-;; co-loaded example namespaces from racing multiple roots onto the
-;; shared `#app` element.
+;; We call the React root `react-root` so it doesn't get confused with
+;; `root-view`. It lives in an atom and is created lazily inside `run`,
+;; never at ns-load — so merely requiring this ns touches no DOM. That
+;; buys two things: the headless fixtures can require it without a
+;; browser, and two co-loaded examples won't race to plant rival roots
+;; on the shared `#app` element.
 
 (defonce react-root (atom nil))
 
-;; The frame is established by the `frame-provider {:id app-frame …}` at
-;; the render root below. On first mount it creates the app frame,
-;; applies its config, and runs `:initial-events` (the `[:app/initialise]`
-;; boot dispatch) once; on hot reload it reuses the same frame and skips
-;; re-seeding. Every in-tree `dispatch`/`subscribe` resolves to that
-;; frame — including the work-bench wrapper's `r/with-let` cleanup
-;; (views.cljs), which dispatches `[:work/flow [:cancel]]` from render
+;; The frame comes from the `frame-provider {:id app-frame …}` at the
+;; render root below. First mount creates the frame, applies its config,
+;; and runs `:initial-events` (our `[:app/initialise]` boot dispatch)
+;; exactly once; a hot reload reuses the same frame and skips the
+;; re-seed. Every `dispatch`/`subscribe` inside the tree finds that
+;; frame — including the work-bench wrapper's `r/with-let` cleanup over
+;; in views.cljs, which dispatches `[:work/flow [:cancel]]` from render
 ;; scope. See the frame glossary (docs/guide/glossary.md#frame).
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Install the Reagent adapter, then mount the provider that
-  ;; establishes the frame (see above).
+  ;; Install the Reagent adapter, then mount the provider that stands
+  ;; the frame up (see above).
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/long_running_work/schema.cljs
+++ b/examples/reagent/long_running_work/schema.cljs
@@ -1,40 +1,39 @@
 (ns long-running-work.schema
-  "Malli schemas for the long-running-work example.
+  "Malli schemas for the two machines in this example.
 
-   Two machines run at runtime: the `:work/flow` parent coordinator and
-   the `:work/processor` child it spawns. Each machine's snapshot lives
-   in runtime-db (docs/guide/glossary.md#runtime-db), not app-db, so it
-   carries its own `:data` schema in its `[:schemas :data]` slot rather
-   than registering an app-db path. The runtime validates that slot
-   after every transition and at spawn time. See the schemas guide's
-   machine section (docs/guide/how-to/validate-with-schemas.md).
+   A machine's snapshot doesn't live in app-db — it lives in runtime-db
+   (docs/guide/glossary.md#runtime-db). So instead of registering an
+   app-db path, each machine carries its own `:data` schema in its
+   `[:schemas :data]` slot, and the runtime checks it after every
+   transition and at spawn time. See the schemas guide's machine
+   section (docs/guide/how-to/validate-with-schemas.md).
 
-   - `:work/flow`       — the parent coordinator, a singleton at the
-                          fixed id `:work/flow`. `FlowData` is attached
-                          via its `[:schemas :data]` slot on `reg-machine`.
-   - `:work/processor`  — the child machine type. Each child is spawned
-                          via `:spawn-all` and gets a runtime-assigned
-                          id (e.g. `:work/processor#0`), so its snapshot
-                          lives at a path that varies per instance —
-                          another reason `[:schemas :data]` (not a fixed
-                          app-db path) is the right surface. `ProcessorData`
-                          is attached via the child's `[:schemas :data]`
-                          slot on `reg-machine` (see `worker.cljs`). It
-                          validates each spawned instance's initial
-                          `:data` at spawn time, so a child spawned with
-                          malformed `:data` never enters the runtime."
+   Two machines, two schemas:
+
+   - `:work/flow`       — the parent coordinator. There's only ever one,
+                          at the fixed id `:work/flow`. `FlowData` rides
+                          on its `[:schemas :data]` slot in `reg-machine`.
+   - `:work/processor`  — the child. Each spawn gets a fresh
+                          runtime-assigned id (`:work/processor#0`,
+                          `#1`, …), so no single app-db path could ever
+                          name them all — which is exactly why
+                          `[:schemas :data]` is the right surface.
+                          `ProcessorData` rides on the child's slot
+                          (see `worker.cljs`) and is checked at spawn
+                          time, so a child built with malformed `:data`
+                          is turned away at the door."
   (:require [re-frame.core :as rf]
-            ;; Loading re-frame.schemas wires up the validator so the
-            ;; machines' `[:schemas :data]` slots are checked at runtime.
+            ;; Requiring re-frame.schemas wires in the validator, so the
+            ;; machines' `[:schemas :data]` slots actually get checked.
             [re-frame.schemas]))
 
 ;; ============================================================================
 ;; SHARD-PROGRESS MAP — the parent's :data :progress slot
 ;; ============================================================================
 ;;
-;; A map of shard-id keyword → items processed (an integer). The parent
-;; updates this on every `:progress` event a child dispatches. The
-;; aggregate-progress sub sums the values and divides by the total.
+;; Just a tally: shard-id → items done so far. The parent bumps an entry
+;; every time a child reports `:progress`, and the aggregate-progress sub
+;; sums the values and divides by the total.
 
 (def ProgressMap
   [:map-of :keyword :int])
@@ -43,7 +42,7 @@
 ;; PARENT SNAPSHOT — :work/flow
 ;; ============================================================================
 ;;
-;; Shape:
+;; The whole snapshot looks like this:
 ;;   {:state    <:idle | :working | :complete | :cancelled | :error>
 ;;    :data     {:total      <int>           ;; items per shard
 ;;               :shards     [<keyword> ...]  ;; which shards are spawned
@@ -51,10 +50,10 @@
 ;;               :outcome    <:complete | :cancelled | :error | nil>}
 ;;    :tags     #{...}}                       ;; runtime-owned union
 
-;; The parent snapshot's `:data` slot. The runtime owns the rest of the
-;; snapshot (`:state`, `:tags`), so the machine `[:schemas :data]` describes
-;; `:data` only. Attached via the `[:schemas :data]` slot on
-;; `(reg-machine :work/flow ...)` in `worker.cljs`.
+;; ...but we only schema-check `:data`. The runtime owns `:state` and
+;; `:tags`, so it isn't our place to describe them. FlowData gets bolted
+;; on via the `[:schemas :data]` slot of `(reg-machine :work/flow ...)`
+;; over in `worker.cljs`.
 (def FlowData
   [:map
    [:total    :int]
@@ -66,25 +65,23 @@
 ;; CHILD :data SHAPE — :work/processor (one instance per shard)
 ;; ============================================================================
 ;;
-;; The child machine's `:data` slot — the working memory each child
-;; carries. The runtime owns the rest of the snapshot (`:state`, the
-;; `:tags` union, the reserved `:rf/*` slots), so the machine
-;; `[:schemas :data]` describes `:data` only. Attached via the
-;; `[:schemas :data]` slot on `(reg-machine :work/processor ...)` in
-;; `worker.cljs`, which validates each spawned instance's initial `:data`
-;; at spawn time. The value here is what the parent's per-child
-;; `:spawn-all` invoke-spec plants (every field below is supplied, so all
-;; are required).
+;; This is a single child's working memory — everything it needs to chew
+;; through its shard. As with the parent, we only describe `:data`; the
+;; runtime owns `:state`, the `:tags` union, and the reserved `:rf/*`
+;; slots. ProcessorData hangs off the `[:schemas :data]` slot of
+;; `(reg-machine :work/processor ...)` in `worker.cljs`, and it's checked
+;; the moment a child spawns. Everything below is required, because the
+;; parent's `:spawn-all` invoke-spec hands every field over on spawn.
 
 (def ProcessorData
   [:map
-   [:shard     :keyword]   ;; the parent-assigned shard id
-   [:total     :int]       ;; items in this shard
-   [:processed :int]       ;; how many done so far
-   [:tick-ms   :int]       ;; ms between chunks (browser yield)
-   ;; Runtime-stamped address keys — the spawn fx stamps these into the
-   ;; spawned child's initial :data. Declared (and optional) so the schema
-   ;; documents them; a Malli :map is open, so they'd pass undeclared too.
+   [:shard     :keyword]   ;; which shard this child owns
+   [:total     :int]       ;; items in that shard
+   [:processed :int]       ;; how many it's finished so far
+   [:tick-ms   :int]       ;; ms it yields to the browser between chunks
+   ;; The runtime stamps a child's own address into its :data on spawn.
+   ;; We list these (optional) so the schema documents them — a Malli
+   ;; :map is open anyway, so they'd sail through undeclared.
    [:rf/self-id   {:optional true} :any]
    [:rf/parent-id {:optional true} :any]
    [:rf/invoke-id {:optional true} :any]])
@@ -93,8 +90,9 @@
 ;; SCHEMA ATTACHMENT
 ;; ============================================================================
 ;;
-;; Both machines attach their `:data` schema via the machine `[:schemas :data]`
-;; slot in `worker.cljs` — `FlowData` on `:work/flow`, `ProcessorData` on
-;; `:work/processor`. There is no `reg-app-schema` here: machine snapshots
-;; live in runtime-db, and `reg-app-schema` validates the app-db partition
-;; only. `[:schemas :data]` is the validation surface for a machine snapshot.
+;; And that's it — both schemas attach over in `worker.cljs` via each
+;; machine's `[:schemas :data]` slot: `FlowData` on `:work/flow`,
+;; `ProcessorData` on `:work/processor`. You won't find a `reg-app-schema`
+;; in this example, and for a reason: that one guards the app-db
+;; partition, but machine snapshots live in runtime-db. For a machine,
+;; `[:schemas :data]` is the surface that does the checking.

--- a/examples/reagent/long_running_work/views.cljs
+++ b/examples/reagent/long_running_work/views.cljs
@@ -1,22 +1,22 @@
 (ns long-running-work.views
-  "Views for the long-running-work example.
+  "The UI for the long-running-work example.
 
-   Three pieces:
+   Three pieces on screen:
 
-   - The control panel: Start / Cancel / Reset / Hide buttons.
-   - The progress bar: aggregate fraction of items done across all
-     shards.
-   - The per-shard breakdown: a small bar per worker, so you can see
-     the three parallel children making independent progress.
+   - A control panel — Start / Cancel / Reset, plus a Hide button.
+   - A progress bar — the overall fraction of items done across every
+     shard.
+   - A per-shard breakdown — one little bar per worker, so you can
+     watch the three children racing along independently.
 
-   The 'Hide' button toggles a wrapper component that mounts and
-   unmounts the work-bench. When the wrapper unmounts, its
-   `r/with-let` cleanup dispatches a `:cancel` event into `:work/flow`.
-   That is how you wire cooperative cancellation to a component
-   lifecycle: a normal dispatch the parent's `:working` state handles
-   by transitioning out, which tears down every spawned child. The
-   worker machines know nothing about React; this one dispatch is the
-   only place the React lifecycle touches them."
+   The interesting one is Hide. It toggles a wrapper that mounts and
+   unmounts the work-bench, and when that wrapper unmounts, its
+   `r/with-let` cleanup dispatches `:cancel` into `:work/flow`. That's
+   the whole recipe for tying cancellation to a component's lifecycle:
+   one ordinary dispatch. The parent's `:working` state handles it by
+   transitioning out, which tears down every child it spawned. The
+   workers, meanwhile, have never heard of React — this single
+   dispatch is the only seam where React's lifecycle reaches them."
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
             [long-running-work.worker])
@@ -26,8 +26,9 @@
 ;; SUB-COMPONENTS
 ;; ============================================================================
 
-(reg-view ^{:doc "Aggregate progress bar. Reads the :work/progress-fraction
-                  sub (0.0 .. 1.0) and draws a div whose width scales."}
+(reg-view ^{:doc "The overall progress bar. Reads :work/progress-fraction
+                  (a number from 0.0 to 1.0) and grows a div's width to
+                  match."}
           progress-bar []
   (let [frac     @(subscribe [:work/progress-fraction])
         done     @(subscribe [:work/items-done])
@@ -54,9 +55,9 @@
                                    "#9e9e9e")
                      :transition "width 60ms linear"}}]]]))
 
-(reg-view ^{:doc "Per-shard breakdown. Three little bars, one per
-                  worker, so the reader can see the parallel children
-                  making independent progress."}
+(reg-view ^{:doc "The per-shard breakdown. One little bar per worker, so
+                  you can watch the parallel children making their own
+                  independent progress."}
           shard-breakdown []
   (let [progress @(subscribe [:work/progress-map])
         total    (-> @(subscribe [:work/flow-data]) :total)]
@@ -81,8 +82,9 @@
                 :data-testid (str "shard-counter-" (name shard-id))}
          (str processed " / " total)]])]))
 
-(reg-view ^{:doc "Status line — shows the parent machine's :state and
-                  the recorded :outcome (the terminal-state badge)."}
+(reg-view ^{:doc "The status line — the parent machine's current :state,
+                  plus its recorded :outcome once it lands in a terminal
+                  state (the little badge at the end)."}
           status-line []
   (let [state   @(subscribe [:work/flow-state])
         outcome @(subscribe [:work/outcome])]
@@ -94,18 +96,19 @@
         [:strong "Outcome: "]
         [:span {:data-testid "outcome-value"} (name outcome)]])]))
 
-(reg-view ^{:doc "Control panel. Start / Cancel / Reset.
+(reg-view ^{:doc "The control panel. Three buttons, three events into
+                  the parent machine:
 
-                  - Start: dispatches [:work/flow [:start]] — parent
-                           transitions :idle → :working, spawns 3
-                           children via :spawn-all.
-                  - Cancel: dispatches [:work/flow [:cancel]] — parent
-                           transitions :working → :cancelled, the
-                           exit cascade emits :rf.machine/destroy for
-                           every surviving child (per the
-                           :spawn-all desugared :exit).
-                  - Reset: dispatches [:work/flow [:reset]] — returns
-                           the parent to :idle with cleared :progress."}
+                  - Start  → [:work/flow [:start]]. The parent goes
+                             :idle → :working and spawns 3 children
+                             via :spawn-all.
+                  - Cancel → [:work/flow [:cancel]]. The parent goes
+                             :working → :cancelled, and leaving :working
+                             fires :rf.machine/destroy at every child
+                             still standing (that's the :spawn-all
+                             :exit cascade at work).
+                  - Reset  → [:work/flow [:reset]]. Back to :idle with
+                             :progress wiped clean."}
           controls []
   (let [running? @(subscribe [:work/running?])
         state    @(subscribe [:work/flow-state])
@@ -126,18 +129,17 @@
       "Reset"]]))
 
 ;; ============================================================================
-;; WORK-BENCH WRAPPER — demonstrates the unmount cascade
+;; WORK-BENCH WRAPPER — where unmount becomes cancellation
 ;; ============================================================================
 
-(reg-view ^{:doc "The work-bench — the demo widget. This is the view
-                  that gets unmounted when the user clicks 'Hide'. Its
-                  `r/with-let` cleanup drives the unmount cascade: on
-                  unmount it dispatches [:work/flow [:cancel]] into the
-                  parent. The parent's :working state's :cancel
-                  transition exits :working, which fires
-                  :rf.machine/destroy for every surviving child, and the
-                  work goes away cleanly. This one dispatch is the only
-                  place the React lifecycle touches the machines."}
+(reg-view ^{:doc "The work-bench — the widget that holds the whole demo,
+                  and the one that vanishes when you click 'Hide'. Watch
+                  its `r/with-let` cleanup: on unmount it dispatches
+                  [:work/flow [:cancel]] into the parent. The parent's
+                  :cancel transition leaves :working, that exit fires
+                  :rf.machine/destroy at every surviving child, and the
+                  work tidies itself away. One dispatch — the single
+                  point where React's lifecycle reaches the machines."}
           work-bench []
   (r/with-let [_ nil]
     [:div.work-bench
@@ -150,9 +152,9 @@
      [controls]
      [progress-bar]
      [shard-breakdown]]
-    ;; Reagent's with-let cleanup runs on component unmount. All it
-    ;; does is dispatch :cancel into the parent machine; the :working
-    ;; :cancel transition takes care of the rest.
+    ;; Reagent runs this finally-clause when the component unmounts.
+    ;; It does one thing — dispatch :cancel at the parent — and the
+    ;; :working state's :cancel transition handles all the rest.
     (finally
       (dispatch [:work/flow [:cancel]]))))
 
@@ -160,12 +162,12 @@
 ;; ROOT VIEW — Show/Hide toggle around the work-bench
 ;; ============================================================================
 ;;
-;; The Show/Hide toggle is an app-db boolean, not part of the
-;; :work/flow machine — the machine has nothing to do with the
-;; component's visibility. The view either renders work-bench or it
-;; doesn't. Click Hide while work is running and the chain is:
+;; Note where the Show/Hide flag lives: a plain boolean in app-db, kept
+;; well away from the :work/flow machine. Visibility is the view's
+;; business, not the machine's — the view simply renders the work-bench
+;; or it doesn't. Hit Hide while a job is running and the dominoes fall:
 ;; component unmounts -> with-let's finally -> dispatch :cancel ->
-;; parent exits :working -> cascade tears every child down.
+;; parent leaves :working -> cascade tears every child down.
 
 (rf/reg-event :ui/initialise
   (fn [{:keys [db]} _]
@@ -178,10 +180,10 @@
 (rf/reg-sub :ui/show-bench?
   (fn [db _] (get-in db [:ui :show-bench?] true)))
 
-(reg-view ^{:doc "Top-level root. A Show/Hide button and the
-                  conditionally-rendered work-bench. Unmounting the
-                  bench is what triggers the cascade — see work-bench
-                  above."}
+(reg-view ^{:doc "The top-level root: a Show/Hide button and the
+                  work-bench, rendered only when shown. Hiding the bench
+                  unmounts it, and that's what kicks off the cascade —
+                  see work-bench above."}
           root-view []
   (let [show? @(subscribe [:ui/show-bench?])]
     [:div.app

--- a/examples/reagent/long_running_work/worker.cljs
+++ b/examples/reagent/long_running_work/worker.cljs
@@ -1,35 +1,36 @@
 (ns long-running-work.worker
-  "The worker + parent-coordinator machines for the long-running-work
-   example.
+  "The two machines that do the actual work: a child and the parent
+   that orchestrates a swarm of them.
 
-   The `:spawn-all` shape: the parent coordinator spawns N children;
-   each child processes its own shard cooperatively, yielding to the
-   browser between chunks via `:after`; children dispatch `:progress`
-   events back to the parent for the UI; on completion each child
-   dispatches the parent's `:on-child-done` keyword. When all N report
-   done the runtime fires the parent's `:on-all-complete`. The user can
-   `:cancel` mid-flight; the parent leaves `:working` and the exit
-   cascade tears down every surviving child via the
-   `:rf.machine/destroy` fx — including any `:after` timers a worker had
-   pending. See the `:spawn` glossary entry
+   Here's the `:spawn-all` shape in one breath. The parent spawns N
+   children. Each child works its own shard, politely handing control
+   back to the browser between chunks via `:after`, and firing
+   `:progress` at the parent so the UI can keep up. When a child
+   finishes it dispatches the parent's `:on-child-done` keyword; once
+   all N have checked in, the runtime fires the parent's
+   `:on-all-complete`. And if the user bails out mid-flight with
+   `:cancel`, the parent leaves `:working` and the exit cascade fires
+   `:rf.machine/destroy` at every child still going — pending `:after`
+   timers and all. See the `:spawn` glossary entry
    (docs/machines/glossary.md#spawn).
 
-   This is how you express:
+   In other words, this is how you say:
 
-     - 'Run N parallel tasks and join on all done.'
-     - 'Show progress.'
-     - 'Cancellation must be reliable on every exit path — including
-        the user navigating away mid-flight.'
+     - 'Run N tasks in parallel and wait for all of them.'
+     - 'Show me how it's going.'
+     - 'And whatever happens — even if the user wanders off
+        mid-job — cancellation has to be airtight.'
 
-   One parent + N children (rather than one big chunked machine)
-   because each shard is independent and parallelisable, and it lets
-   the demo show both the join (`:on-all-complete`) and the
-   cascade-teardown: the `:work/flow` `:cancel` transition leaves the
-   state and that exit fires the per-child destroy."
+   Why a parent plus N children instead of one machine grinding through
+   chunks? Because the shards are independent, so they may as well run
+   at once — and splitting it this way lets the demo show off both
+   halves of the pattern: the join (`:on-all-complete`) and the
+   teardown cascade (`:work/flow`'s `:cancel` leaves `:working`, and
+   that exit destroys every child)."
   (:require [re-frame.core :as rf]
-            ;; Loading re-frame.machines wires up the runtime so
-            ;; rf/reg-machine (called below at ns-load) and the
-            ;; `:rf/machine` / `:rf/machine-has-tag?` subs resolve.
+            ;; Requiring re-frame.machines stands up the runtime, so the
+            ;; rf/reg-machine calls below (they run at ns-load) and the
+            ;; `:rf/machine` / `:rf/machine-has-tag?` subs all resolve.
             [re-frame.machines]
             [long-running-work.schema :as schema]))
 
@@ -38,75 +39,77 @@
 ;; ============================================================================
 
 (def items-per-shard
-  "How many mock items each child processes per shard. Three shards
-   running in parallel at 50ms/item produces a ~5-second job that's
-   long enough to demonstrate progress visibly and short enough to
-   keep the headless test fast."
+  "How many make-believe items each child grinds through. Three shards
+   in parallel at 50ms an item works out to a ~5-second job — long
+   enough that you can actually watch the bars move, short enough that
+   the headless test doesn't drag."
   100)
 
 (def default-tick-ms
-  "Wall-clock delay between chunks for the live UI. The child's
-   `:yielding` state declares `:after {tick-ms :processing}` so the
-   browser gets a render tick between chunks. Lifted to a named const
-   so headless tests can override it via the child's `:data :tick-ms`
-   (set from the parent's per-child invoke-spec :data)."
+  "How long a child pauses between chunks in the live UI. The child's
+   `:yielding` state declares `:after {tick-ms :processing}`, handing
+   the browser a render tick before it grabs the next item. It's a
+   named const so headless tests can dial it down (or to zero) via the
+   child's `:data :tick-ms`, which the parent sets per child on spawn."
   50)
 
 (def parent-id
-  "The parent coordinator machine's registered id. Children hard-code
-   this in their dispatch-back so they can address the parent without
-   any per-child plumbing. For a static `:spawn-all` declaration the
-   parent id is a literal in the parent's own source, so the child can
-   simply name it."
+  "Where a child sends its messages home: the parent's registered id.
+   Children just name it directly, with no per-child plumbing to thread
+   an address through — and they can, because in a static `:spawn-all`
+   the parent's id is a literal sitting right there in its own source."
   :work/flow)
 
 ;; ============================================================================
 ;; THE CHILD MACHINE — :work/processor
 ;; ============================================================================
 ;;
-;; Each child processes its own shard in chunks. One item per
-;; `:processing` entry; one browser-tick yield between chunks via
-;; `:yielding` + `:after`; per-step progress dispatched back to the
-;; parent so the UI's progress bar updates between chunks.
+;; A child works its shard one bite at a time. Each `:processing` entry
+;; handles a single item; then it yields for one browser tick via
+;; `:yielding` + `:after`, and reports `:progress` to the parent on the
+;; way so the bar keeps moving. Rinse and repeat until the shard's done.
 ;;
-;; The state graph:
+;; Here's the loop it walks:
 ;;
-;;     :idle           — initial; on spawn the runtime dispatches
-;;                       [:rf.machine.spawn/spawned], which transitions
-;;                       us to :processing.
-;;     :processing     — entry processes one item, bumps :processed,
-;;                       dispatches :progress to the parent. The :always
-;;                       cascade routes to :checking-done.
-;;     :checking-done  — eventless decision: done? → :done; else
-;;                       → :yielding.
-;;     :yielding       — :after {tick-ms :processing} schedules the
-;;                       next chunk after one browser tick.
-;;     :done           — terminal. :entry dispatches :on-child-done to
-;;                       the parent. The parent's exit cascade tears
-;;                       this child down once :on-all-complete fires.
-;;     :cancelled      — never reached cooperatively: cancellation
-;;                       cascades from the parent via :rf.machine/destroy.
-;;                       Included for shape-completeness / observability.
+;;     :idle           — where it starts. On spawn the runtime sends
+;;                       [:rf.machine.spawn/spawned], which nudges it
+;;                       into :processing.
+;;     :processing     — :entry does one item, bumps :processed, and
+;;                       reports :progress. The :always cascade then
+;;                       carries it to :checking-done with no event.
+;;     :checking-done  — a quick fork, no event needed: finished? →
+;;                       :done; more to do? → :yielding.
+;;     :yielding       — the pause. :after {tick-ms :processing} lines
+;;                       up the next chunk one browser tick later.
+;;     :done           — the end. :entry tells the parent :on-child-done.
+;;                       The parent's exit cascade clears this child away
+;;                       once :on-all-complete fires.
+;;     :cancelled      — a child never actually walks in here:
+;;                       cancellation comes from the parent as a
+;;                       :rf.machine/destroy, not an event routed inward.
+;;                       It's here for completeness, and so tools can see
+;;                       the full shape.
 
 (def processor-machine
-  {:doc "Process one shard of items in chunks. Cooperative yield via
-         `:after` between chunks; progress reported via :progress event
-         to the parent; terminal `:done` state dispatches the parent's
-         :on-child-done keyword (`:work/child-done`)."
+  {:doc "Works one shard, a chunk at a time. Yields to the browser
+         between chunks via `:after`, reports `:progress` to the parent
+         as it goes, and on reaching `:done` tells the parent
+         :on-child-done (`:work/child-done`)."
 
    :initial :idle
 
-   ;; Validates the child's initial `:data` at spawn time, before the
-   ;; snapshot installs. This is how a spawned child's shape is checked:
-   ;; the runtime gives each instance its own id (e.g. `:work/processor#0`),
-   ;; so no fixed app-db path can reach it — the machine `[:schemas :data]`
-   ;; slot validates the spawn regardless of id. (See schema.cljs.)
+   ;; Check the child's initial `:data` at spawn, before the snapshot
+   ;; even installs. This is the trick for validating a spawned child:
+   ;; the runtime hands each one its own id (`:work/processor#0`, …),
+   ;; so no fixed app-db path could ever name it — the machine's
+   ;; `[:schemas :data]` slot validates the spawn whatever the id turns
+   ;; out to be. (See schema.cljs.)
    :schemas {:data schema/ProcessorData}
 
-   ;; The :data is materialised from the parent's per-child invoke-spec
-   ;; :data slot at spawn time (see :work/flow below). :shard is the
-   ;; user-supplied id keyword the parent assigned (`:s1`/`:s2`/`:s3`);
-   ;; :total is the shard size; :tick-ms is the per-chunk yield delay.
+   ;; The parent fills this in per child on spawn, from its invoke-spec
+   ;; :data (see :work/flow below). :shard is the id the parent handed
+   ;; out (`:s1`/`:s2`/`:s3`); :total is the shard size; :tick-ms is the
+   ;; pause between chunks. The values here are just placeholders.
    :data    {:shard     nil
              :total     0
              :processed 0
@@ -114,24 +117,25 @@
 
    :guards
    {:done?
-    ;; Have we processed every item in this shard?
+    ;; Worked through every item in the shard?
     (fn guard-done? [{:keys [data]}]
       (>= (:processed data) (:total data)))
 
     :more-work?
+    ;; Still something left to do?
     (fn guard-more-work? [{:keys [data]}]
       (< (:processed data) (:total data)))}
 
    :actions
    {:process-one
-    ;; Process one item. In a real app this is whatever the per-item
-    ;; computation is (encoding, parsing, indexing, ...). Here we just
-    ;; bump the counter — what the example shows is the yield +
-    ;; progress-reporting + cancellation shape, not the per-item work.
+    ;; Do one item's worth of work. In a real app this would be the
+    ;; actual per-item job — encode a frame, parse a row, index a
+    ;; document. Here we just bump a counter, because the point of the
+    ;; example is the *shape* (yield, report, cancel), not the labour.
     ;;
-    ;; The action also dispatches a :progress event back to the parent
-    ;; so the UI's progress bar updates between chunks. The parent
-    ;; handles :progress as a self-transition that updates :data :progress.
+    ;; It also fires :progress at the parent so the bar moves between
+    ;; chunks. The parent treats :progress as a self-transition that
+    ;; folds the number into :data :progress.
     (fn action-process-one [{:keys [data]}]
       (let [shard         (:shard data)
             new-processed (inc (:processed data))]
@@ -139,68 +143,69 @@
          :fx   [[:dispatch [parent-id [:progress shard new-processed (:total data)]]]]}))
 
     :dispatch-done
-    ;; Terminal action: dispatch the parent's :on-child-done keyword.
-    ;; The runtime intercepts this at the parent's machine boundary and
-    ;; updates the join state. The second arg is the shard id (e.g. :s1)
-    ;; so the parent can tell which child completed.
+    ;; The child's last words: tell the parent :on-child-done. The
+    ;; runtime catches this at the parent's boundary and updates the
+    ;; join. We pass the shard id (e.g. :s1) so the parent knows which
+    ;; child just crossed the line.
     (fn action-dispatch-done [{:keys [data]}]
       (let [shard (:shard data)]
         {:fx [[:dispatch [parent-id [:work/child-done shard]]]]}))}
 
    :states
    {:idle
-    ;; The runtime synthesises [:rf.machine.spawn/spawned] when no explicit
-    ;; :start is supplied; declaring it as an :on entry lets the child
-    ;; auto-kick into :processing on spawn.
+    ;; The runtime conjures [:rf.machine.spawn/spawned] when there's no
+    ;; explicit :start to send. Listening for it here is what lets the
+    ;; child spring into :processing the instant it's spawned.
     {:tags #{:work/idle}
      :on   {:rf.machine.spawn/spawned :processing}}
 
     :processing
-    ;; Process one item, then immediately re-evaluate the work via
-    ;; the :always cascade. :always is an EVENTLESS transition — the
-    ;; runtime takes it on entry with no event needed, so the child
-    ;; flows straight to :checking-done after :process-one runs.
+    ;; Do one item, then take stock again. That second step is the
+    ;; :always cascade — an EVENTLESS transition the runtime follows on
+    ;; entry, no event required. So once :process-one runs, the child
+    ;; slides straight on to :checking-done.
     {:tags  #{:work/running :work/cancellable}
      :entry :process-one
      :always [{:target :checking-done}]}
 
     :checking-done
-    ;; Eventless decision: done → :done; more work → :yielding.
-    ;; :always evaluates first-match-wins; the :done? / :more-work?
-    ;; guards are mutually exclusive so the order doesn't matter
-    ;; semantically.
+    ;; The fork in the road, again eventless: done → :done, otherwise
+    ;; → :yielding. :always takes the first matching branch, but :done?
+    ;; and :more-work? can't both be true, so the order here is just for
+    ;; the reader.
     {:always [{:guard :done?      :target :done}
               {:guard :more-work? :target :yielding}]}
 
     :yielding
-    ;; The browser-yield seam. :after carries a runtime clock-driven
-    ;; delay; the cancellation cascade tears down the in-flight timer on
-    ;; child-destroy, so a worker cancelled mid-yield does NOT resume
-    ;; after the delay elapses.
+    ;; The breather — the one spot where the child steps aside for the
+    ;; browser. :after waits on the runtime clock, and if the child gets
+    ;; destroyed mid-wait, the cascade cancels that pending timer too:
+    ;; a worker killed here will NOT wake up and carry on once the delay
+    ;; runs out.
     ;;
-    ;; The :after key is a (fn [ctx] ms) form: it reads the per-child
-    ;; :tick-ms out of :data so tests and callers can stagger or
-    ;; zero-out the delay.
+    ;; :after is a (fn [ctx] ms) so it can read the child's own :tick-ms
+    ;; out of :data — handy for tests that want to stagger the delays or
+    ;; zero them out entirely.
     {:tags  #{:work/running :work/cancellable :work/yielding}
      :after {(fn after-tick-ms [{snap :snapshot}]
                (or (-> snap :data :tick-ms) default-tick-ms))
              :processing}}
 
     :done
-    ;; Terminal. Dispatch the parent's :on-child-done keyword as the
-    ;; child's last act. The exit cascade then tears the child down
-    ;; once the parent's :on-all-complete fires.
+    ;; Journey's end. The child's parting act is to tell the parent
+    ;; :on-child-done; the exit cascade then sweeps the child away once
+    ;; the parent's :on-all-complete fires.
     {:meta  {:terminal? true}
      :tags  #{:work/done}
      :entry :dispatch-done}
 
     :cancelled
-    ;; Declared but never entered by this example's transitions: the
-    ;; parent cancels a child by tearing it down via the
-    ;; :rf.machine/destroy fx, not by routing a cancel event in. The
-    ;; state stays so the machine's tag union exposes #{:work/cancelled}
-    ;; to tools, and so an app that DOES route cancellation as an in-FSM
-    ;; event has somewhere to land.
+    ;; Defined, but this example never routes a child into it. The
+    ;; parent cancels a child by destroying it with :rf.machine/destroy,
+    ;; not by sending a cancel event inward. We keep the state around for
+    ;; two reasons: so the machine's tags advertise #{:work/cancelled}
+    ;; to tools, and so an app that *does* prefer in-FSM cancellation
+    ;; has a place to land.
     {:meta {:terminal? true}
      :tags #{:work/cancelled}}}})
 
@@ -210,26 +215,27 @@
 ;; THE PARENT COORDINATOR — :work/flow
 ;; ============================================================================
 ;;
-;; Three children, one parent, one declarative :spawn-all entry. The
-;; parent's :data holds no per-child bookkeeping beyond the aggregated
-;; :progress map (the user wants to see it; the runtime doesn't read
-;; it). The join-state map — which children are done, failed, resolved —
-;; is runtime-owned and lives in runtime-db.
+;; One parent, three children, a single `:spawn-all` declaration. The
+;; parent keeps almost nothing of its own — just the aggregated
+;; :progress map, and only because the user likes to watch it (the
+;; runtime never reads it). The real ledger — who's done, who failed,
+;; who's resolved — is the join-state map, and that belongs to the
+;; runtime, tucked away in runtime-db.
 
 (def shards
-  "The shard ids this demo processes in parallel. Three is enough to
-   show the parallelism and the join; small enough to keep the UI
-   readable. Each shard is just a label here — in a real app it would
-   be a chunk of work (a slice of a dataset, a region of an image,
-   ...) the worker knows how to process."
+  "The shards this demo runs in parallel. Three is the sweet spot:
+   enough to show off the parallelism and the join, few enough to keep
+   the UI legible. Here a shard is just a label — in a real app it'd be
+   an actual slice of work (a chunk of a dataset, a region of an image)
+   that the worker knows how to chew on."
   [:s1 :s2 :s3])
 
 (def flow-machine
-  {:doc "Parent coordinator. Spawns one :work/processor per shard via
-         :spawn-all; joins on :all; cancels mid-flight on :cancel
-         or on the parent's :working state being exited by any means
-         (including user-driven unmount → :cancel dispatch from the
-         work-bench view's `r/with-let` finally cleanup)."
+  {:doc "The coordinator. Spawns one :work/processor per shard with
+         :spawn-all, joins on :all, and cancels mid-flight whenever
+         :working is left — whether by an explicit :cancel or by the
+         user hiding the bench (its `r/with-let` cleanup dispatches
+         :cancel for them)."
 
    :initial :idle
 
@@ -238,9 +244,8 @@
              :progress (zipmap shards (repeat 0))
              :outcome  nil}
 
-   ;; Validates the snapshot's :data slot. The snapshot lives in
-   ;; runtime-db, so [:schemas :data] — not an app-schema — is the
-   ;; validation surface.
+   ;; Guards the snapshot's :data. The snapshot lives in runtime-db, so
+   ;; [:schemas :data] — not an app-schema — is what does the checking.
    :schemas {:data schema/FlowData}
 
    :actions
@@ -251,48 +256,48 @@
                     :outcome  nil)})
 
     :record-progress
-    ;; Self-transition action — a child dispatched
+    ;; Filing a child's progress report. A child dispatched, say,
     ;;   [:work/flow [:progress :s1 5 100]]
-    ;; and the parent records the per-shard progress so the view's
-    ;; aggregate-progress sub recomputes.
+    ;; and we drop that count into the right slot, which nudges the
+    ;; view's aggregate-progress sub to recompute.
     (fn action-record-progress [{data :data [_ shard-id processed _total] :event}]
       {:data (assoc-in data [:progress shard-id] processed)})
 
     :stamp-outcome
-    ;; Stamp :outcome on entry to a terminal state so the UI can show
-    ;; "Complete" / "Cancelled" / "Failed" without a separate sub. The
-    ;; action's event payload's first element is the matching
-    ;; transition event keyword (`:work/all-done` / `:cancel`
-    ;; / `:work/any-failed`); we just record it as the outcome.
+    ;; Pin down how it all ended, on the way into a terminal state, so
+    ;; the UI can say "Complete" / "Cancelled" / "Failed" without a sub
+    ;; of its own. The event that brought us here names the ending
+    ;; (`:work/all-done` / `:cancel` / `:work/any-failed`) — we just
+    ;; translate it and record it.
     (fn action-stamp-outcome [{data :data [event-kw & _] :event}]
       {:data (assoc data :outcome
                     (case event-kw
                       :work/all-done    :complete
                       :cancel           :cancelled
                       :work/any-failed  :error
-                      ;; default: keep current
+                      ;; anything else: leave the outcome as it was
                       (:outcome data)))})}
 
    :states
    {:idle
-    ;; Initial state. :start kicks off the work; :reset returns from
-    ;; a terminal state back here.
+    ;; The resting state. :start sets the work going; :reset is how a
+    ;; terminal state finds its way back here.
     {:tags #{:flow/idle}
      :on   {:start {:target :working :action :reset-progress}
             :reset {:target :idle    :action :reset-progress}}}
 
     :working
-    ;; The :spawn-all-bearing state. On entry the runtime seeds the
-    ;; join-state map and spawns one child per entry below. On exit (by
-    ;; ANY transition, including :cancel / :work/all-done) it fires a
-    ;; single :rf.machine/destroy fx that reads the join state and tears
-    ;; every surviving child down.
+    ;; The heart of it — the state that carries :spawn-all. Entering it,
+    ;; the runtime seeds the join-state map and spawns a child for each
+    ;; entry below. Leaving it — by ANY route, :cancel or :work/all-done
+    ;; alike — fires a single :rf.machine/destroy that reads the join
+    ;; state and clears away every child still standing.
     ;;
-    ;; The :progress event is the per-step report from a child. It's an
-    ;; internal self-transition that updates :data :progress. Because
-    ;; :progress is NOT the parent's :on-child-done / :on-child-error
-    ;; keyword, the join machinery doesn't intercept it — the runtime
-    ;; feeds it straight into the parent's :on lookup.
+    ;; The :progress event is just a child checking in. It's an internal
+    ;; self-transition that updates :data :progress — and because
+    ;; :progress isn't the parent's :on-child-done / :on-child-error
+    ;; keyword, the join machinery leaves it alone and the runtime feeds
+    ;; it straight to the parent's :on table.
     {:tags #{:flow/working}
      :spawn-all
      {:children [{:id :s1 :machine-id :work/processor
@@ -302,31 +307,29 @@
                  {:id :s3 :machine-id :work/processor
                   :data {:shard :s3 :total items-per-shard :processed 0 :tick-ms default-tick-ms}}]
       :join             :all
-      ;; The keywords children dispatch back. The runtime intercepts
-      ;; events whose inner-event-id matches these and updates the
-      ;; join state.
+      ;; The keywords a child uses to phone home. The runtime watches
+      ;; for events whose inner id matches these and updates the join.
       :on-child-done    :work/child-done
       :on-child-error   :work/child-error
-      ;; The events the runtime dispatches into the parent when the
-      ;; join resolves. The parent's :on table below handles each.
+      ;; And the events the runtime sends *back* into the parent once
+      ;; the join resolves. The :on table below picks each one up.
       :on-all-complete  [:work/all-done]
       :on-any-failed    [:work/any-failed]}
-     :on    {;; Progress reports — internal self-transition (no :target):
-             ;; the action runs but :exit / :entry do NOT fire, so the
-             ;; :spawn-all entry cascade doesn't re-spawn children and the
-             ;; exit cascade doesn't tear them down. Omit :target to get
-             ;; an internal self-transition.
+     :on    {;; A progress report. Note there's no :target — that makes
+             ;; it an internal self-transition: the action runs, but
+             ;; :exit / :entry stay quiet, so the :spawn-all entry
+             ;; cascade won't re-spawn the children and the exit cascade
+             ;; won't tear them down. (Dropping :target is the whole
+             ;; trick.)
              :progress        {:action :record-progress}
-             ;; Join-resolution events. The runtime dispatches these
-             ;; into the parent when :on-all-complete / :on-any-failed
-             ;; resolve; the parent's transition handles them as
-             ;; ordinary state transitions.
+             ;; The join landing here. The runtime dispatches these the
+             ;; moment :on-all-complete / :on-any-failed resolve, and
+             ;; the parent treats them as plain old transitions.
              :work/all-done   {:target :complete  :action :stamp-outcome}
              :work/any-failed {:target :error     :action :stamp-outcome}
-             ;; Cooperative user-driven cancellation. The transition
-             ;; leaves :working, and that exit fires one
-             ;; :rf.machine/destroy fx that tears down every surviving
-             ;; child.
+             ;; The user pulling the plug. Leaving :working is the part
+             ;; that matters: that exit fires the one :rf.machine/destroy
+             ;; that takes every surviving child with it.
              :cancel          {:target :cancelled :action :stamp-outcome}}}
 
     :complete
@@ -347,8 +350,13 @@
 (rf/reg-machine :work/flow flow-machine)
 
 ;; ============================================================================
-;; SUBSCRIPTIONS — slice readers + aggregate progress
+;; SUBSCRIPTIONS — read the snapshot, then total it up
 ;; ============================================================================
+;;
+;; A little layered chain: the first sub grabs the parent's snapshot,
+;; the next few carve slices out of it, and the last couple do the
+;; arithmetic the progress bar wants. Each one stays small and reads
+;; only from the layer above — the usual subscription-graph shape.
 
 (rf/reg-sub :work/flow-snapshot
   :<- [:rf/machine :work/flow]
@@ -377,8 +385,8 @@
     (reduce + 0 (vals progress))))
 
 (rf/reg-sub :work/progress-fraction
-  {:doc "Aggregate progress, 0.0 .. 1.0. The view's progress bar
-         multiplies by 100 to render."}
+  {:doc "How far along, all up — a number from 0.0 to 1.0. The progress
+         bar multiplies by 100 to turn it into a width."}
   :<- [:work/items-done]
   :<- [:work/total-items]
   (fn [[done total] _]
@@ -399,6 +407,6 @@
 ;; ============================================================================
 
 (rf/reg-event :work/initialise
-  {:doc "Boot the parent machine to its :idle state."}
+  {:doc "Park the parent machine in :idle, ready to go."}
   (fn handler-work-initialise [_ _]
     {:fx [[:dispatch [:work/flow [:reset]]]]}))

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -1,61 +1,63 @@
 (ns managed-http-counter.core
-  "Managed-HTTP counter — a small app built on `:rf.http/managed`.
+  "A counter whose buttons don't add anything locally — each click asks
+  the server what the new count should be.
 
-  You describe a request as data and the runtime owns its whole
-  lifecycle: encode, send, decode, classify failures, retry, abort. It
-  then dispatches the result back as an ordinary event. You never touch
-  js/fetch. Each button issues a request and the reply lands back in
-  app-db through default reply addressing, so \"send\" and \"receive\" are
-  both just events hitting the same pure handler. See the HTTP guide:
-  docs/resources/http.md.
+  That's the whole idea, and it's built on one effect: `:rf.http/managed`.
+  You describe a request as data; the runtime owns the rest of its life —
+  encode, send, decode, sort the failures, retry, abort. When the answer
+  comes home it arrives as an ordinary event, re-dispatched to the very
+  handler that sent the request. So \"send\" and \"receive\" are two passes
+  through one pure function, and you never go near js/fetch. The HTTP guide
+  has the full contract: docs/resources/http.md.
 
-  Buttons:
-    +1             GET api/inc.json — a real success round-trip.
+  Five buttons walk the whole surface:
+
+    +1             GET api/inc.json — a real, successful round-trip.
     Fail           GET api/does-not-exist — a real 404 (:rf.http/http-4xx).
-    Retry-recover  drives the canned-success stub, which synthesises a
-                   success reply with no real request.
-    Start long     seeds a pending in-flight request that stays pending.
+    Retry-recover  the recovery-after-retry path, driven by a canned stub.
+    Start long     a request that genuinely stays in flight.
     Cancel         aborts that request by :request-id.
 
-  +1 and Fail run a real Fetch: the request goes out, the body is decoded
-  (only on 2xx), and the reply lands back in app-db. Retry-recover uses
-  the canned-success stub so the app can show the success/retry contract
-  without a stub HTTP server.
+  +1 and Fail are honest Fetches: the request goes out, the body is decoded
+  (only on a 2xx), and the reply lands back in app-db. Retry-recover would
+  need an endpoint that fails once then succeeds, which is a nuisance to
+  stand up — so it uses a canned-success stub that synthesises the reply
+  the live fx would have produced.
 
-  Start long / Cancel show a real abort. This app serves only static
-  assets, so a real GET resolves instantly and never stays observably
-  in-flight. So \"Start long\" seeds a request-id-keyed handle directly
-  into the framework in-flight registry — the same atom the live transport
-  records into — giving a deterministically pending request. \"Cancel\"
-  then fires the live `:rf.http/managed-abort` fx against that handle: the
-  abort resolves it, fires its `:abort-fn`, and a `:rf.http/aborted` reply
-  lands back at the issuing handler. Only the transport is stood in for;
-  the registry entry, the abort fx, and the aborted classification are all
-  real and visible in Xray and traces.
+  Start long / Cancel are the interesting pair: a real abort of a request
+  that is really in flight. There's a catch, though. This app serves only
+  static assets, so a real GET resolves instantly and never lingers long
+  enough to cancel. The fix is honest: \"Start long\" seeds a request-id-keyed
+  handle straight into the framework's in-flight registry — the very atom
+  the live transport writes into — so we have a deterministically pending
+  request. \"Cancel\" then fires the live `:rf.http/managed-abort` fx at it:
+  the abort resolves the handle, fires its `:abort-fn`, and a
+  `:rf.http/aborted` reply comes home to the issuing handler. Only the
+  transport is stood in for. The registry entry, the abort fx, and the
+  aborted classification are all real — and all visible in Xray and traces.
 
-  This app is the runnable cross-substrate sanity check: the same fx, the
-  same reply shape, end-to-end through Reagent and Fetch."
+  Put plainly: this is the runnable cross-substrate sanity check. The same
+  fx and the same reply shape, end to end, through Reagent and Fetch."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            ;; Managed HTTP ships in its own artefact, day8/re-frame2-http.
-            ;; Requiring re-frame.http.managed once at boot registers
-            ;; `:rf.http/managed` and family; without it, dispatching the
-            ;; fx fails loud with a named "HTTP artefact missing" error.
+            ;; Managed HTTP ships in its own artefact (day8/re-frame2-http).
+            ;; Requiring this once at boot is what registers `:rf.http/managed`
+            ;; and its family — skip it and the first fx dispatch fails loud
+            ;; with a friendly "HTTP artefact missing" error.
             [re-frame.http.managed]
-            ;; The canned-success stub the Retry-recover button uses
-            ;; (`:rf.http/managed-canned-success`) registers here, not in
-            ;; re-frame.http.managed.
+            ;; Home of the canned-success stub the Retry-recover button leans
+            ;; on (`:rf.http/managed-canned-success`). It lives here, in the
+            ;; test-support ns, rather than in re-frame.http.managed proper.
             [re-frame.http.test-support]
-            ;; The "Start long" button seeds a pending in-flight handle
-            ;; directly into the registry. The write seam (`record-in-flight!`)
-            ;; isn't on the public facade, so we reach the registry ns
-            ;; directly — it's the same atom the live transport writes into
-            ;; and the live `:rf.http/managed-abort` fx resolves.
+            ;; "Start long" seeds a pending handle straight into the registry.
+            ;; The write seam (`record-in-flight!`) isn't on the public facade,
+            ;; so we reach for the registry ns directly. It's the same atom the
+            ;; live transport writes into and the live abort fx resolves.
             [re-frame.http.registry :as http-registry]
-            ;; Call-site verb helpers (rf.http/get / post / put / delete /
-            ;; patch / head / options) that build the canonical
-            ;; [:rf.http/managed args-map] vector.
+            ;; The verb helpers (rf.http/get / post / put / delete / patch /
+            ;; head / options). Each builds the canonical
+            ;; [:rf.http/managed args-map] vector so the call site stays a line.
             [re-frame.http :as rf.http]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -64,15 +66,18 @@
 ;; APP-DB SHAPE
 ;; ============================================================================
 ;;
-;; {:counter/count    <int>                     ;; current counter value
-;;  :counter/status   <:idle|:loading|:error>   ;; the request lifecycle
+;; Three slots, and that's the whole of this app's state:
+;;
+;; {:counter/count    <int>                     ;; the number on screen
+;;  :counter/status   <:idle|:loading|:error>   ;; where the request is in its life
 ;;  :counter/error    <failure-map-or-nil>}
 ;;
-;; :status makes the in-flight lifecycle visible: :loading while the
-;; runtime works a request, :idle (or :error) once the reply lands.
+;; :status is what makes the in-flight lifecycle visible: :loading while the
+;; runtime is working a request, then :idle (or :error) once the reply lands.
 ;;
-;; Every app-db slot, sub-id, and event carries a :counter/ feature
-;; prefix, so this app's keys never collide with another feature's.
+;; Every slot, sub-id, and event wears a :counter/ prefix. It's the feature
+;; convention, and it's cheap insurance — this app's keys can't collide with
+;; another feature's.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _ev]
@@ -84,31 +89,34 @@
 ;; +1  —  real round-trip via Fetch
 ;; ============================================================================
 ;;
-;; Read this path first. One pure handler plays two roles. The :else
-;; branch describes a request (it returns an :rf.http/managed effect).
-;; The runtime sends the GET to api/inc.json, decodes the `{"delta": 1}`
-;; body, and re-dispatches [:counter/+1 {:rf/reply ...}] back to this same
-;; handler, which now takes the :success branch and applies the increment.
-;; The asynchrony lives in the runtime; the handler stays pure.
+;; Start here — this is the pattern the whole example turns on. One pure
+;; handler, two jobs. The first time through, the :else branch *describes* a
+;; request and hands back an :rf.http/managed effect. The runtime takes it
+;; from there: GET api/inc.json, decode the `{"delta": 1}` body, and
+;; re-dispatch [:counter/+1 {:rf/reply ...}] right back to this same handler.
+;; Second time through it's the :success branch, which applies the increment.
+;; All the asynchrony lives in the runtime. The handler never stops being a
+;; plain pure function — no callbacks, no promises to babysit.
 
 (rf/reg-event :counter/+1
   (fn [{:keys [db]} [_ msg]]
     (cond
-      ;; Reply branch — increment by the delta the server returned.
+      ;; The reply came back happy — bump the count by the delta the server
+      ;; sent, and settle the UI to :idle.
       (some-> msg :rf/reply :kind (= :success))
       {:db (-> db
                (update :counter/count + (or (:delta (:value (:rf/reply msg))) 1))
                (assoc :counter/status :idle :counter/error nil))}
 
-      ;; Failure branch — record the error.
+      ;; The reply came back unhappy — stash the error so the view can show it.
       (some-> msg :rf/reply :kind (= :failure))
       {:db (-> db
                (assoc :counter/status :error
                       :counter/error  (:failure (:rf/reply msg))))}
 
-      ;; Initial branch — issue the request. `rf.http/get` builds the
-      ;; same `[:rf.http/managed args-map]` vector a hand-written
-      ;; `:method :get` entry would, in one line.
+      ;; No reply yet, so this is the opening move: fire the request.
+      ;; `rf.http/get` builds the same `[:rf.http/managed args-map]` vector a
+      ;; hand-written `:method :get` entry would — just in one tidy line.
       :else
       {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [(rf.http/get "api/inc.json" {:decode :json})]})))
@@ -117,9 +125,10 @@
 ;; Fail  —  real 404 from the http-server
 ;; ============================================================================
 ;;
-;; Same shape as +1, but the failure side of the reply. Branch on the
-;; reply's :kind; on :failure, record the failure map whole — its own
-;; :kind is the :rf.http/* category the view surfaces.
+;; The same handler shape as +1, just walking the failure side of the reply.
+;; We branch on the reply's :kind and, on :failure, keep the whole failure
+;; map. Its own :kind is the :rf.http/* category — exactly what the view
+;; reaches for to tell the user what went wrong.
 
 (rf/reg-event :counter/fail
   (fn [{:keys [db]} [_ msg]]
@@ -128,15 +137,16 @@
       {:db (assoc db :counter/status :error :counter/error (:failure (:rf/reply msg)))}
 
       (some-> msg :rf/reply :kind (= :success))
-      ;; Should not happen — the URL is intentionally 404.
+      ;; We never expect to land here — the URL is a deliberate 404.
       {:db (assoc db :counter/status :idle :counter/error nil)}
 
-      ;; Same `rf.http/get` helper as above. Status is classified before
-      ;; the body is decoded, so a 404 with an HTML or plain-text body is
-      ;; :rf.http/http-4xx (raw body at :body), never :rf.http/decode-failure
-      ;; — even with `:decode :json`. Leaving :decode at its default `:auto`
-      ;; here shows the common case: a JSON endpoint that 404s with a
-      ;; load-balancer HTML page. See docs/resources/http.md.
+      ;; Same `rf.http/get` helper as above, and a worthwhile detail hides in
+      ;; here: status is classified *before* the body is decoded. So a 404 that
+      ;; answers with HTML or plain text is :rf.http/http-4xx (raw body at
+      ;; :body), never :rf.http/decode-failure — even if you'd asked for
+      ;; `:decode :json`. We leave :decode at its `:auto` default to show the
+      ;; everyday case: a JSON endpoint that 404s with a load-balancer's HTML
+      ;; error page. The classification order is in docs/resources/http.md.
       :else
       {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [(rf.http/get "api/does-not-exist")]})))
@@ -145,12 +155,14 @@
 ;; Retry-recover  —  canned-stub at app level
 ;; ============================================================================
 ;;
-;; Shows the recovery-after-retry path without a flaky endpoint. The
-;; handler issues :rf.http/managed-canned-success, which synthesises a
-;; {:kind :success :value {:delta 5}} reply — the exact shape the live fx
-;; lands if its retry policy hits a real endpoint that 503s once then
-;; 200s. The stub lets you exercise the contract without owning a server,
-;; and the handler reads the same either way.
+;; The "it failed, retried, and recovered" path — without needing a flaky
+;; endpoint to make it happen on cue. The handler issues
+;; :rf.http/managed-canned-success, which synthesises a
+;; {:kind :success :value {:delta 5}} reply: the exact shape the live fx
+;; would deliver if its retry policy hit a real endpoint that 503s once and
+;; then 200s. The stub lets you exercise the contract without owning a
+;; server, and — the part that matters — the handler can't tell the
+;; difference. It reads the reply the same way either way.
 
 (rf/reg-event :counter/retry-recover
   (fn [{:keys [db]} [_ msg]]
@@ -162,9 +174,9 @@
 
       :else
       {:db (assoc db :counter/status :loading)
-       ;; The canned-success stub synthesises the reply directly. The
-       ;; request and decode are declared so the call reads like a live
-       ;; retry-recover; the stub short-circuits the network.
+       ;; The stub conjures the reply directly. We still spell out the
+       ;; :request and :decode so the call site reads like the real thing —
+       ;; the stub just quietly skips the trip over the network.
        :fx [[:rf.http/managed-canned-success
              {:request {:method :get :url "api/flaky"}
               :decode  :json
@@ -174,53 +186,60 @@
 ;; Start long / Cancel  —  a REAL abort of a REAL in-flight request
 ;; ============================================================================
 ;;
-;; The abort contract: an in-flight `:rf.http/managed` request is cancelled
-;; by `:request-id`. `:rf.http/managed-abort` resolves the handle in the
-;; framework in-flight registry, fires its `:abort-fn`, and a
-;; `:rf.http/aborted` reply lands back at the issuing handler. See the
-;; abort section of docs/resources/http.md.
+;; The abort contract is simple to state: you cancel an in-flight
+;; `:rf.http/managed` request by its `:request-id`. The
+;; `:rf.http/managed-abort` fx finds the handle in the framework's in-flight
+;; registry, fires its `:abort-fn`, and a `:rf.http/aborted` reply comes home
+;; to the handler that issued the request. The abort section of
+;; docs/resources/http.md has the details.
 ;;
-;; This app serves only static assets, so a real GET resolves instantly
-;; and nothing stays observably in-flight to cancel. So "Start long" seeds
-;; a request-id-keyed handle directly into the registry (the same atom the
-;; live transport writes into), giving a deterministically pending request,
-;; and "Cancel" fires the live `:rf.http/managed-abort` fx against that
-;; handle. Only the transport is stood in for; the registry entry, the
-;; abort fx, and the `:rf.http/aborted` classification are all real and
-;; visible in Xray and traces.
+;; Here's the catch worth being honest about: this app serves only static
+;; assets, so a real GET resolves in a blink and nothing ever lingers
+;; in-flight long enough to cancel. Demoing a cancel against a request that's
+;; already finished would be theatre. So instead, "Start long" seeds a
+;; request-id-keyed handle straight into the registry — the very atom the
+;; live transport writes into — which gives us a request that is genuinely,
+;; deterministically pending. "Cancel" then fires the *live*
+;; `:rf.http/managed-abort` fx at that handle. Only the transport is stood
+;; in for. The registry entry, the abort fx, and the `:rf.http/aborted`
+;; classification are all the real thing — and you can watch them in Xray
+;; and the trace stream.
 
 (def long-request-id :counter/long)
 
-;; A placeholder URL stamped on the seeded in-flight handle, so it reads
-;; naturally in the abort trace and any registry read-out. No Fetch is
-;; issued — the slot is seeded directly so the pending state is deterministic.
+;; A placeholder URL we stamp on the seeded handle purely so it reads
+;; naturally in the abort trace and any registry peek. Nothing fetches it —
+;; the slot is seeded by hand, which is what makes the pending state
+;; deterministic.
 (def long-pending-url "api/long")
 
 (rf/reg-fx :counter/seed-long-request
-  {:doc       "Demo-only fx: record a request-id-keyed in-flight handle in
-               the framework registry whose :abort-fn clears the slot and
-               dispatches the :rf.http/aborted reply back to
-               :counter/start-long — so the live :rf.http/managed-abort fx
-               resolves it end-to-end."
+  {:doc       "Demo-only fx that fakes a request stuck in flight. It records a
+               request-id-keyed handle in the framework registry whose
+               :abort-fn clears the slot and dispatches the :rf.http/aborted
+               reply back to :counter/start-long. That's the whole trick: it
+               lets the live :rf.http/managed-abort fx resolve a real handle
+               end-to-end, with no real request behind it."
    :platforms #{:client}}
   (fn fx-seed-long-request [frame-ctx {:keys [request-id]}]
-    ;; The abort-fn fires later, when the live :rf.http/managed-abort fx
-    ;; resolves this handle, so it has no frame of its own — a bare
-    ;; `rf/dispatch` inside it would raise :rf.error/no-frame-context. A
-    ;; frame's identity is carried, not found, so we capture the fx
-    ;; context's frame here and pass it explicitly on the deferred
-    ;; dispatch. See docs/guide/glossary.md#frame-identity-is-carried-not-found.
+    ;; A small but important wrinkle. The :abort-fn doesn't run now — it runs
+    ;; later, whenever someone aborts this handle, and by then there's no
+    ;; ambient frame around it. A bare `rf/dispatch` in there would raise
+    ;; :rf.error/no-frame-context. In re-frame2 a frame's identity is *carried,
+    ;; not found*, so the fix is to grab the frame from this fx's context right
+    ;; here and hand it to the deferred dispatch ourselves. See
+    ;; docs/guide/glossary.md#frame-identity-is-carried-not-found.
     (let [frame (:frame frame-ctx)]
       (http-registry/record-in-flight!
         request-id nil
         {:url      long-pending-url
-         ;; The abort-fn is the in-flight request's cancellation hook. The
-         ;; live :rf.http/managed-abort handler resolves this handle by
-         ;; request-id and calls this fn with the abort `reason` (`:user`
-         ;; here). We clear the registry slot and dispatch the
-         ;; :rf.http/aborted reply — the exact shape the live transport's
-         ;; abort path emits — back through default reply addressing to
-         ;; :counter/start-long.
+         ;; The :abort-fn is the request's cancellation hook — the thing that
+         ;; actually runs when someone pulls the plug. The live
+         ;; :rf.http/managed-abort handler looks this handle up by request-id
+         ;; and calls us with the abort `reason` (`:user` here). Our two jobs:
+         ;; clear the registry slot, and dispatch the :rf.http/aborted reply —
+         ;; the exact shape the live transport's abort path emits — home to
+         ;; :counter/start-long via default reply addressing.
          :abort-fn (fn [reason]
                      (http-registry/clear-in-flight! request-id)
                      (rf/dispatch [:counter/start-long
@@ -234,9 +253,9 @@
 (rf/reg-event :counter/start-long
   (fn [{:keys [db]} [_ msg]]
     (cond
-      ;; Reply branch — the abort-fn dispatches :rf.http/aborted on
-      ;; cancellation, which lands here via default reply addressing.
-      ;; Record the aborted classification and return the UI to :idle.
+      ;; The reply branch. When Cancel fires, the :abort-fn dispatches
+      ;; :rf.http/aborted, and default reply addressing routes it right back
+      ;; here. We note the aborted classification and ease the UI to :idle.
       (some-> msg :rf/reply :kind (= :failure))
       {:db (assoc db
                   :counter/status :idle
@@ -245,9 +264,9 @@
       (some-> msg :rf/reply :kind (= :success))
       {:db (assoc db :counter/status :idle :counter/error nil)}
 
-      ;; Initial branch — seed a genuine pending in-flight request that
-      ;; the Cancel button aborts for real. The :loading UI state persists
-      ;; until the abort resolves the slot.
+      ;; The opening move: seed a request that's genuinely in flight, ready
+      ;; for Cancel to abort for real. We stay in :loading until that abort
+      ;; resolves the slot.
       :else
       {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [[:counter/seed-long-request {:request-id long-request-id}]]})))
@@ -255,19 +274,21 @@
 (rf/reg-event :counter/cancel
   (fn [{:keys [db]} _]
     {:db db
-     ;; Abort by request-id via the LIVE :rf.http/managed-abort fx. It
-     ;; resolves the seeded handle in the in-flight registry and fires its
-     ;; :abort-fn, which clears the slot and dispatches the
+     ;; Abort by request-id, through the *live* :rf.http/managed-abort fx —
+     ;; no shortcut. It finds the seeded handle in the in-flight registry and
+     ;; fires its :abort-fn, which clears the slot and sends the
      ;; :rf.http/aborted reply back to :counter/start-long (handled above).
-     ;; A no-op when nothing is in flight (the registry lookup misses).
+     ;; If nothing's in flight the registry lookup simply misses, and this is
+     ;; a harmless no-op.
      :fx [[:rf.http/managed-abort long-request-id]]}))
 
 ;; ============================================================================
 ;; SUBS
 ;; ============================================================================
 ;;
-;; Three direct reads of the slice — pure derivations the framework caches
-;; and recomputes only when their input moves. The boring kind, on purpose.
+;; Three plain reads, one per slot. Pure derivations the framework caches and
+;; only recomputes when their input actually moves. Deliberately boring — the
+;; HTTP machinery upstream is where the interesting stuff lives.
 
 (rf/reg-sub :counter/count  (fn [db _] (:counter/count  db)))
 (rf/reg-sub :counter/status (fn [db _] (:counter/status db)))
@@ -277,8 +298,9 @@
 ;; VIEWS
 ;; ============================================================================
 ;;
-;; Pure render from subscription values to hiccup; one dispatch per button.
-;; No business logic here — a view reads derived state and dispatches.
+;; Subscription values in, hiccup out — one dispatch per button. No logic
+;; sneaks in here. A view reads derived state and fires events; that's the
+;; whole contract, and keeping it that thin is what keeps it predictable.
 
 (reg-view counter-view []
   (let [count  @(subscribe [:counter/count])
@@ -306,29 +328,30 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; We keep the React root in an atom and only build it lazily inside `run`,
+;; never at ns-load. That's the mount-isolation rule from examples/TESTING.md:
+;; loading a namespace must have zero DOM side effects, so that two example
+;; namespaces sharing a page can't race each other to call `create-root` on
+;; the same `#app`.
 
 (defonce react-root (atom nil))
 
-;; The app establishes its frame explicitly, in one spot: the render
-;; root's `frame-provider {:id app-frame}`. On first mount it creates the
-;; app frame, applies its config, and runs `:initial-events` once (the
-;; `[:counter/initialise]` seed); on hot reload it reuses that frame and
-;; skips the seed. Every in-tree `dispatch`/`subscribe` then resolves to
-;; the app frame.
+;; The app stands its frame up in exactly one place: the render root's
+;; `frame-provider {:id app-frame}`. On the first mount that provider creates
+;; the frame, applies its config, and runs `:initial-events` once (our
+;; `[:counter/initialise]` seed). On a hot reload it finds the frame already
+;; there, reuses it, and skips the seed. From then on every `dispatch` and
+;; `subscribe` in the tree resolves to this frame.
 ;;
-;; `:rf/default` is just the id this app chose — an ordinary frame id with
-;; no framework privilege, so the runtime won't infer it for you. Matches
-;; the canonical mount in examples/reagent/counter/core.cljs.
+;; `:rf/default` is just the id this app happened to pick — an ordinary frame
+;; id with no special standing, which is why the runtime won't conjure it for
+;; you. Same mount you'll find in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the Reagent adapter. Pass the adapter spec map
-  ;; (each adapter ns exports an `adapter` var) directly. It installs the
-  ;; adapter only; the frame-provider below creates the frame.
+  ;; `init!` installs the Reagent adapter — and only the adapter. You hand it
+  ;; the adapter spec map (every adapter ns exports one as `adapter`). It does
+  ;; not create a frame; that's the frame-provider's job, just below.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -1,12 +1,12 @@
 (ns nine-states.core
-  "Worked example: the **Nine States of UI**, modelled as a single
-   parallel state machine.
+  "The **Nine States of UI** — one small todos list, rendered every way it
+   can possibly be.
 
-   Most apps design only the happy path and leave the other eight states
-   visually undefined. This example renders all nine canonical UI states
-   for one small domain — a **todos list** — using one `:type :parallel`
-   machine with three regions, plus state tags carrying the per-axis
-   intent.
+   Most apps lavish attention on the happy path and quietly forget the
+   other eight states. The empty list, the spinner, the validation error,
+   the frozen archive — they get noticed when a user hits them, not
+   before. This example takes the whole taxonomy seriously and renders all
+   nine, driven by a single `:type :parallel` state machine.
 
    The nine states (the well-known UX taxonomy):
 
@@ -15,75 +15,80 @@
      3. Empty        — fetched, but the result is the empty list.
      4. One          — exactly one todo. Focused single-item layout.
      5. Some         — a small, manageable list.
-     6. Too Many     — overwhelming amount; needs filtering / pagination.
+     6. Too Many     — more than a person wants to scan; needs search / paging.
      7. Incorrect    — invalid form input; per-field validation error.
      8. Correct      — a happy-path success after a valid submit.
      9. Done/Frozen  — terminal state; the mode region is at `:done`.
 
-   The machine declaration carries the whole model in three regions:
+   The trick is that these nine aren't one axis — they're three, running
+   at once. A list can be *loading* while the form is *invalid* while the
+   page is still *active*. So the machine has three parallel regions, each
+   minding its own axis:
 
-     - `:data` region    — six cardinality states (Nothing / Loading /
-                            Empty / One / Some / Too Many) plus an `:error`
-                            branch. An `:always`-cascade picks the
-                            cardinality bucket after a successful fetch.
-     - `:form` region    — three states (Neutral / Incorrect / Correct)
-                            tracking the form lifecycle.
-     - `:mode` region    — two states (Active / Done); `:done` is
+     - `:data` region    — the request-lifecycle / cardinality axis. Six
+                            states (Nothing / Loading / Empty / One / Some /
+                            Too Many) plus an `:error` branch. After a
+                            successful fetch an `:always`-cascade counts the
+                            items and picks the cardinality bucket.
+     - `:form` region    — the form lifecycle: Neutral / Incorrect / Correct.
+     - `:mode` region    — the page lifecycle: Active / Done. `:done` is
                             terminal and read-only.
 
-   Every state carries `:tags` describing its per-axis intent
-   (`:data/loading`, `:form/invalid`, `:mode/done`, ...). One
-   render-priority table in data plus one selector sub (`:ui/render`)
-   collapse the tag union into a single render-model keyword. The root
-   view's `case` over `:ui/render` is the only branch site.
+   Each state wears `:tags` announcing its intent (`:data/loading`,
+   `:form/invalid`, `:mode/done`, ...). Three axes means several tags are
+   live at once — so how does the page decide what to draw? One
+   render-priority table (plain data) plus one selector sub (`:ui/render`)
+   collapse that tag union down to a single keyword, and the root view's
+   `case` over it is the only place the UI ever branches. Nine states, one
+   `case`.
 
    What this example demonstrates:
 
    - **Parallel regions + state tags** — three orthogonal axes in one
-     machine, queried by tag against the active configuration. See the
-     machines guide on [parallel regions]
+     machine, asked by tag rather than by state name. See the machines
+     guide on [parallel regions]
      (../../../docs/machines/concepts.md#when-the-machine-grows) and
      [state tags]
      (../../../docs/machines/concepts.md#guards-actions-tags-and-after--the-recognition-kit).
-   - **Managed-HTTP lifecycle** folded into the `:data` region: the
-     region's state-keyword IS the request status, so a separate
-     `:status` field disappears. See [managed HTTP]
+   - **A managed-HTTP lifecycle** folded right into the `:data` region:
+     the region's state-keyword *is* the request status, so there's no
+     separate `:status` field to keep in sync with it. See [managed HTTP]
      (../../../docs/resources/glossary.md#managed-http) and the
      [resource-status lifecycle]
      (../../../docs/resources/glossary.md#resource-status).
-   - **A form slice** — the `{:draft :errors :touched}` slice carries the
-     form runtime; the form region's state tracks the
-     validation/submission lifecycle. See [Build a form]
+   - **A form slice** — `{:draft :errors :touched}` holds the form's
+     working state in app-db; the form region's state tracks where it is
+     in the validate/submit lifecycle. See [Build a form]
      (../../../docs/guide/how-to/build-a-form.md).
-   - **Inspectability bias** — non-trivial guards and actions are named
-     entries in the machine's `:guards` / `:actions` maps; only trivial
-     transitions use inline fns.
+   - **Inspectability** — guards and actions worth a name get one, as
+     entries in the machine's `:guards` / `:actions` maps. Only the truly
+     trivial transitions stay inline. Future-you, reading a trace, will
+     thank present-you.
    - **Headless tests** — every state has a fixture that drives the
-     machine into that state and asserts against its tags + `:ui/render`,
-     without a browser. The example tree is test-free; the fixtures live
-     in the framework test tree at
+     machine there and checks its tags + `:ui/render`, no browser
+     required. The example tree itself is test-free; the fixtures live in
+     the framework test tree at
      `implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs`.
 
-   The whole example is one file. In a real codebase it would split
-   across schema / events / subs / views / machines files."
+   It all lives in one file so you can read it top to bottom. A real
+   codebase would spread it across schema / events / subs / views /
+   machines files."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            ;; The schema-attachment ns lives in the
-            ;; day8/re-frame2-schemas artefact. Requiring it registers
-            ;; the hooks the `rf/reg-app-schema` calls below need.
+            ;; Schemas ship as their own artefact. Requiring this ns wires
+            ;; up the hooks the `rf/reg-app-schema` call below leans on.
             [re-frame.schemas]
-            ;; The state-machine ns lives in the day8/re-frame2-machines
-            ;; artefact. Requiring it registers the hooks `rf/reg-machine`
-            ;; and the `:rf/machine` / `:rf/machine-has-tag?` subs need.
+            ;; Likewise machines: requiring this registers `rf/reg-machine`
+            ;; and the `:rf/machine` / `:rf/machine-has-tag?` subs we use
+            ;; throughout.
             [re-frame.machines]
-            ;; Managed-HTTP ships in day8/re-frame2-http. Requiring it
-            ;; registers the `:rf.http/managed` fx (and family) the
-            ;; load-todos fx below dispatches.
+            ;; Managed-HTTP. Requiring it registers the `:rf.http/managed`
+            ;; fx (and its family) that the load events dispatch.
             [re-frame.http.managed]
-            ;; Registers the framework canned-stub fxs
-            ;; (`:rf.http/managed-canned-success` / `-failure`). The
-            ;; per-app demo stub below delegates to them.
+            ;; The framework's canned-reply stubs
+            ;; (`:rf.http/managed-canned-success` / `-failure`). Our little
+            ;; per-app demo stub below just delegates to these.
             [re-frame.http.test-support]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -94,9 +99,10 @@
 ;; ============================================================================
 
 (def too-many-threshold
-  "A 'small list' is up to this many items; beyond that we render the
-   'Too Many' UI (search + truncation). Named so the machine's
-   `:too-many?` guard and the test fixtures share one value."
+  "Where 'a manageable list' ends and 'too many' begins. Up to this many
+   items renders plainly; beyond it we switch to the search + truncation
+   UI. It's a named def so the machine's `:too-many?` guard and the test
+   fixtures all agree on the same number."
   7)
 
 (def new-todo-defaults
@@ -108,28 +114,29 @@
 ;; SCHEMAS
 ;; ============================================================================
 ;;
-;; The `:ui/nine-states` machine's `:data` slot is its own self-describing
-;; record (see the machine declaration). The form slice describes only
-;; what the form collects plus per-field validation state — no `:status`
-;; field, because the form region's state-keyword IS the status.
+;; The machine carries its own `:data` shape (see the declaration below), so
+;; the only thing left to describe here is the form slice: what the form
+;; collects plus its per-field validation state. Note there's no `:status`
+;; field — the form region's state-keyword already IS the status.
 
-;; The slice's `:draft` is a bare `:map`, not a stricter "valid submission"
-;; shape. A draft legitimately holds in-progress / invalid input (an empty
-;; title before the user types), so a min-length constraint here would
-;; reject the initial draft write under dev-mode schema validation. The
-;; valid-submission constraint lives in the form's validate fn (see
-;; `validate-new-todo`), not the slice schema — drafts and submissions are
-;; different shapes.
+;; A subtle but important call: `:draft` is a bare `:map`, not the stricter
+;; "this is a valid submission" shape. A draft is meant to hold
+;; in-progress, half-typed, not-yet-valid input — an empty title before the
+;; user types anything is perfectly normal. Put a min-length constraint
+;; here and dev-mode schema validation would reject that very first write.
+;; So validity lives where validity belongs: in the validate fn (see
+;; `validate-new-todo`), not the slice schema. Drafts and submissions are
+;; genuinely different shapes, and conflating them is a classic form bug.
 (def NewTodoSlice
   [:map
    [:draft   :map]
    [:errors  {:default {}} [:map-of :keyword [:vector :string]]]
    [:touched {:default #{}} [:set :keyword]]])
 
-;; `reg-app-schema` is frame-local: it needs a frame in scope, or it
-;; raises `:rf.error/no-frame-context`. This example runs in `:rf/default`
-;; (the same id `run`'s `frame-provider {:id …}` ensures), so name it
-;; explicitly here. See the frames glossary:
+;; `reg-app-schema` is frame-local — it needs a frame in scope or it raises
+;; `:rf.error/no-frame-context`. This example lives in `:rf/default` (the
+;; same id `run`'s `frame-provider {:id …}` sets up), so we name it here.
+;; Frame identity is carried, not magically found; see the frames glossary:
 ;; ../../../docs/guide/glossary.md#frame-identity-is-carried-not-found
 (with-frame :rf/default
   (rf/reg-app-schema [:new-todo] {:schema NewTodoSlice}))
@@ -138,16 +145,21 @@
 ;; RECORDABLE COEFFECTS
 ;; ============================================================================
 ;;
-;; A submitted todo's `:id` is written into durable machine data
-;; (`:data :items`) and used as a React `:key`. A durable id must be a
-;; fact the handler is handed, never an ambient `(random-uuid)` read at
-;; the write site — replaying the event stream would mint a different id
-;; and the snapshot and keys would not reproduce. So the generator is a
-;; *recordable* coeffect: it runs once, the minted value is recorded, and
-;; replay re-presents the same value instead of re-minting. `:new-todo/submit`
-;; declares it via `:rf.cofx/requires` and reads it from the coeffects map,
-;; staying pure and replayable. See the recordable-vs-ambient coeffects
-;; entry: ../../../docs/guide/glossary.md#recordable-vs-ambient-coeffects
+;; Here's a small problem with a tidy solution. A submitted todo needs an
+;; `:id` — it goes into durable machine data and doubles as the React
+;; `:key`. The obvious move is `(random-uuid)` right where we build the
+;; todo. The trouble: that's a side effect hiding inside a "pure" handler.
+;; Replay the event stream and it mints a *different* id every time, so the
+;; snapshot and keys never reproduce. Time-travel quietly breaks.
+;;
+;; The fix is to treat the fresh id like any other fact the handler needs
+;; from the outside world: feed it in as a coeffect. Marking the cofx
+;; `:recordable?` means it runs once for real, the value gets recorded, and
+;; on replay re-frame2 hands back the *same* value instead of minting a new
+;; one. `:new-todo/submit` asks for it via `:rf.cofx/requires` and reads it
+;; out of the coeffects map — pure, and replayable. See the
+;; recordable-vs-ambient coeffects entry:
+;; ../../../docs/guide/glossary.md#recordable-vs-ambient-coeffects
 (rf/reg-cofx :new-todo/todo-id
   {:recordable? true
    :doc "Replayable fresh id for a newly-submitted todo."}
@@ -157,25 +169,25 @@
 ;; FX  (test-friendly stubs)
 ;; ============================================================================
 ;;
-;; A real app would issue one `:rf.http/managed` request and override it at
-;; test time via the frame's `:fx-overrides`. For this self-contained
-;; example we ship one per-app stub that delegates to the framework's
-;; canned-success / canned-failure fxs, so the control panel can drive the
-;; data region into Empty / One / Some / Too Many without a server. See
-;; [managed HTTP](../../../docs/resources/http.md).
+;; A real app fires one `:rf.http/managed` request and swaps in a stub at
+;; test time via the frame's `:fx-overrides`. This example has no server to
+;; talk to, so it ships its own little stub that delegates to the
+;; framework's canned-success / canned-failure fxs. That's what lets the
+;; control panel conjure Empty / One / Some / Too Many on demand, no
+;; backend required. See [managed HTTP](../../../docs/resources/http.md).
 
 (defn- gen-todos [n]
   (vec (for [i (range n)]
          {:id (random-uuid) :title (str "Todo #" (inc i)) :done? false})))
 
 (rf/reg-fx :nine-states.http/managed-demo
-  {:doc       "Demo override for `:rf.http/managed`. Routes by URL:
-               `/api/todos` → success with N synthetic todos (N from
-               `:request :query :n`); `/api/todos/fail` → transport
-               failure. Delegates to the framework's
-               `:rf.http/managed-canned-success` /
-               `:rf.http/managed-canned-failure` so the reply shape
-               matches a real managed request."
+  {:doc       "Demo override for `:rf.http/managed`. A tiny fake server,
+               routing by URL: `/api/todos` succeeds with N synthetic
+               todos (N read from `:request :query :n`); `/api/todos/fail`
+               fails with a transport error. Either way it hands off to the
+               framework's `:rf.http/managed-canned-success` /
+               `:rf.http/managed-canned-failure`, so the reply has exactly
+               the shape a real managed request would produce."
    :platforms #{:client :server}}
   (fn fx-managed-demo [frame-ctx args-map]
     (let [url (-> args-map :request :url str)]
@@ -195,34 +207,37 @@
 ;; THE MACHINE — :ui/nine-states  (one machine, three regions)
 ;; ============================================================================
 ;;
-;; Three orthogonal axes, one declaration:
+;; This is the whole model. Three independent axes, all in one declaration,
+;; each ticking along on its own:
 ;;
-;;   :data — the request-lifecycle / cardinality axis (states 1-6, plus
-;;           an :error branch). After a successful fetch lands in
-;;           :resolving, an :always-cascade picks the cardinality bucket
-;;           by reading :items out of the shared :data.
+;;   :data — the request-lifecycle / cardinality axis (states 1-6, plus an
+;;           :error branch). When a fetch succeeds it lands in :resolving,
+;;           and an :always-cascade counts :items and picks the right
+;;           cardinality bucket. The count decides; we never do.
 ;;
-;;   :form — the Neutral / Incorrect / Correct form lifecycle (states 7
-;;           & 8). Driven by :submit-valid / :submit-invalid / :edit
-;;           events; transitions are pure (the slice's :errors / :touched
-;;           live in app-db, not in the machine's :data).
+;;   :form — the Neutral / Incorrect / Correct lifecycle (states 7 & 8),
+;;           driven by :submit-valid / :submit-invalid / :edit. These
+;;           transitions are pure — the slice's :errors / :touched live in
+;;           app-db, not in the machine's :data.
 ;;
-;;   :mode — the Active / Done axis (state 9). :done is terminal and
-;;           tagged :mode/read-only — the view inspects that tag to
-;;           disable the form and the control buttons.
+;;   :mode — the Active / Done axis (state 9). :done is terminal and wears
+;;           :mode/read-only, which is the tag the view reads to grey out
+;;           the form and the control buttons.
 ;;
-;; With parallel regions the snapshot's :state is a map keyed by region
-;; name; :data is shared across all regions; :tags is the union of every
-;; active state's tag set. See the machines guide:
+;; Because the regions run in parallel, a snapshot's :state is a map keyed
+;; by region name (one current state each), :data is shared across all
+;; three, and :tags is the union of every active state's tags. That union
+;; is the thing the render selector reads. See the machines guide:
 ;; ../../../docs/machines/concepts.md#when-the-machine-grows
 
 (def nine-states-machine
   {:type :parallel
 
-   ;; Shared :data: the data region's :items live here, plus the mode
-   ;; region's :archived-at stamp. Shared rather than per-region because
-   ;; the regions share one domain (when axes don't share data, prefer
-   ;; N separate machines).
+   ;; The machine's shared :data — :items for the data region, plus the
+   ;; mode region's :archived-at stamp. One shared bag rather than
+   ;; per-region pockets because these axes are facets of one domain. (If
+   ;; your axes don't share any data, that's usually a sign you want N
+   ;; separate machines, not one with parallel regions.)
    :data {:items       []
           :error       nil
           :archived-at nil}
@@ -242,8 +257,9 @@
 
    :actions
    {:set-items
-    ;; :fetch-succeeded carries the new items as the action's event
-    ;; payload's second element: [:fetch-succeeded {:items [...]}].
+    ;; The :fetch-succeeded event carries the new items in its second
+    ;; element — [:fetch-succeeded {:items [...]}] — so we pull them
+    ;; straight out of :event.
     (fn action-set-items [{data :data [_ {:keys [items]}] :event}]
       {:data (-> data
                  (assoc :items (vec items))
@@ -263,15 +279,14 @@
     {:initial :nothing
      :states
      {:nothing
-      ;; State 1 — never fetched. The :nothing tag (+ the absent
-      ;; :mode/done) drives the welcome view.
+      ;; State 1 — never fetched. The welcome screen.
       {:tags #{:data/nothing}
        :on   {:fetch-started :loading
               :reset         :nothing}}
 
       :loading
-      ;; State 2 — first fetch in flight. The :data/loading tag drives
-      ;; the spinner view.
+      ;; State 2 — a fetch is in flight. The :data/loading tag is what
+      ;; lights up the spinner.
       {:tags #{:data/loading :data/transient}
        :on   {:fetch-succeeded {:target :resolving
                                 :action :set-items}
@@ -279,8 +294,10 @@
                                 :action :set-error}}}
 
       :resolving
-      ;; Eventless microstep: after :set-items writes :items into
-      ;; :data, the cardinality guards pick a bucket. First match wins.
+      ;; A blink-and-you-miss-it microstep. :set-items has just written the
+      ;; new :items; now the cardinality guards race to claim it and the
+      ;; first match wins. The machine doesn't rest here — :always means it
+      ;; immediately moves on to whichever bucket fits.
       {:always [{:guard :empty?    :target :empty}
                 {:guard :one?      :target :one}
                 {:guard :too-many? :target :too-many}
@@ -323,16 +340,17 @@
               :reset          :neutral}}
 
       :incorrect
-      ;; State 7 — invalid input visible on a touched field. The
-      ;; :form/invalid tag drives the inline error view.
+      ;; State 7 — the user submitted something invalid. The :form/invalid
+      ;; tag drives the inline error message.
       {:tags #{:form/invalid}
        :on   {:submit-valid :correct
               :edit         :neutral
               :reset        :neutral}}
 
       :correct
-      ;; State 8 — happy-path acknowledgement. Transient; the next
-      ;; :edit returns the region to :neutral.
+      ;; State 8 — the brief "nice, that worked" moment. It's transient: as
+      ;; soon as the user edits again, an :edit drops the region back to
+      ;; :neutral.
       {:tags #{:form/success :form/transient}
        :on   {:edit  :neutral
               :reset :neutral}}}}
@@ -348,8 +366,9 @@
               :reset   :active}}
 
       :done
-      ;; State 9 — terminal. :mode/read-only is the tag the form and
-      ;; control panel inspect to disable inputs.
+      ;; State 9 — the end of the line. Once archived there's no event out
+      ;; of here. :mode/read-only is the tag the form and control panel
+      ;; read to disable every input.
       {:tags #{:mode/done :mode/read-only :mode/terminal}}}}}})
 
 (rf/reg-machine :ui/nine-states nine-states-machine)
@@ -358,23 +377,27 @@
 ;; EVENTS — top-level demo wrappers
 ;; ============================================================================
 ;;
-;; The control panel buttons dispatch high-level demo events that
-;; coordinate the form slice's app-db state with broadcasts into the
-;; :ui/nine-states machine. Wrapping them like this — rather than
-;; dispatching the machine directly from the view — keeps the imperative
-;; bits (clear the form, bump app-db) out of the view.
+;; The control-panel buttons dispatch friendly, high-level demo events.
+;; Each one does two things at once: it nudges the form slice in app-db and
+;; it broadcasts into the :ui/nine-states machine. Could the view dispatch
+;; the machine directly? Sure — but then the view would be juggling
+;; "clear the form, bump app-db, poke the machine" itself. Wrapping that up
+;; behind one named event keeps the imperative housekeeping out of the view,
+;; where it doesn't belong.
 
 (rf/reg-event :nine-states.app/initialise
-  {:doc "Seed the form slice + reset the machine to its initial state."}
+  {:doc "Back to square one: seed the form slice and reset the machine to
+         its initial state."}
   (fn handler-app-initialise [{:keys [db]} _]
     {:db (assoc db :new-todo new-todo-defaults)
      :fx [[:dispatch [:ui/nine-states [:reset]]]]}))
 
 (rf/reg-event :nine-states.demo/load
-  {:doc "Drive a synthetic fetch through the demo HTTP stub. The reply
-         folds back via :nine-states.demo/loaded → the machine's
-         :fetch-succeeded event; the :data region's :always-cascade
-         picks the cardinality bucket from the count."}
+  {:doc "Kick off a (synthetic) fetch through the demo HTTP stub. The reply
+         folds back through :nine-states.demo/loaded into the machine's
+         :fetch-succeeded event, and from there the :data region's
+         :always-cascade reads the count and picks the cardinality bucket.
+         Ask for n items, get the matching state."}
   (fn handler-demo-load [_ [_ {:keys [n]}]]
     {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
           [:rf.http/managed
@@ -386,8 +409,8 @@
             :on-failure [:nine-states.demo/load-failed]}]]}))
 
 (rf/reg-event :nine-states.demo/load-with-failure
-  {:doc "Drive a synthetic failing fetch — the :data region lands in
-         :error."}
+  {:doc "Same idea, but the fetch is rigged to fail — the :data region
+         lands in :error."}
   (fn handler-demo-load-with-failure [_ _]
     {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
           [:rf.http/managed
@@ -397,20 +420,23 @@
             :on-failure [:nine-states.demo/load-failed]}]]}))
 
 (rf/reg-event :nine-states.demo/loaded
-  {:doc "Successful fetch. Forwards the items to the machine via
-         :fetch-succeeded; the :always-cascade picks the bucket."}
+  {:doc "The fetch came back. Hand the items to the machine via
+         :fetch-succeeded and let the :always-cascade sort out the bucket."}
   (fn handler-demo-loaded [_ [_ {:keys [value]}]]
     {:fx [[:dispatch [:ui/nine-states [:fetch-succeeded {:items value}]]]]}))
 
 (rf/reg-event :nine-states.demo/load-failed
-  {:doc "Failed fetch. Forwards the failure category to the machine."}
+  {:doc "The fetch fell over. Pass the failure category along to the
+         machine, which routes the :data region to :error."}
   (fn handler-demo-load-failed [_ [_ {:keys [failure]}]]
     {:fx [[:dispatch [:ui/nine-states [:fetch-failed {:failure failure}]]]]}))
 
 ;; ---- form-slice events ----
 
 (defn- validate-new-todo
-  "Pure validator: returns a {field [errors...]} map. Empty when valid."
+  "Pure validator. Hand it a draft, get back a {field [errors...]} map —
+   empty when everything checks out. No app-db, no side effects, just
+   data in and data out, which makes it trivial to unit-test in isolation."
   [{:keys [title]}]
   (cond-> {}
     (or (nil? title) (< (count title) 3))
@@ -420,9 +446,10 @@
     (assoc :title ["Title must be at most 80 characters."])))
 
 (rf/reg-event :new-todo/edit-field
-  {:doc  "User edited a form field. Updates :draft and marks the field
-          touched; broadcasts :edit into the machine so the :form region
-          returns from :correct or :incorrect to :neutral."
+  {:doc  "The user typed in a field. Update the :draft, mark the field as
+          touched (so its errors are allowed to show), and broadcast :edit
+          into the machine — which gently returns the :form region from
+          :correct or :incorrect back to :neutral."
    :schema [:cat [:= :new-todo/edit-field] :keyword :string]}
   (fn handler-new-todo-edit-field [{:keys [db]} [_ field value]]
     {:db (-> db
@@ -431,31 +458,34 @@
      :fx [[:dispatch [:ui/nine-states [:edit]]]]}))
 
 (rf/reg-event :new-todo/submit
-  {:doc "Validate the draft. If invalid → :submit-invalid (the :form
-         region lands in :incorrect). If valid → append to the
-         machine's :data items via :fetch-succeeded, clear the draft,
-         and broadcast :submit-valid (the :form region lands in
-         :correct)."
-   ;; The new todo's durable id comes from a recordable coeffect, never
-   ;; read ambiently at the write site (see the `:new-todo/todo-id`
-   ;; reg-cofx above) — so replay re-presents the same id.
+  {:doc "The submit button. Validate the draft and fork:
+         invalid → :submit-invalid and the :form region lands in
+         :incorrect. Valid → append the new todo to the machine's items
+         (via :fetch-succeeded), clear the draft, and broadcast
+         :submit-valid so the :form region lands in :correct."
+   ;; The new todo's id comes from a recordable coeffect, not a
+   ;; `(random-uuid)` read here at the write site (see the
+   ;; `:new-todo/todo-id` reg-cofx above). That's what keeps replay
+   ;; handing back the same id every time.
    :rf.cofx/requires [:new-todo/todo-id]}
-  ;; The machine snapshot is durable runtime-db state — read it from the
-  ;; `:rf.db/runtime` coeffect.
+  ;; A machine snapshot is durable runtime-db state, so we read it from the
+  ;; `:rf.db/runtime` coeffect rather than from app-db.
   (fn handler-new-todo-submit [{:keys [db] rt :rf.db/runtime new-id :new-todo/todo-id} _]
     (let [draft  (get-in db [:new-todo :draft])
           errors (validate-new-todo draft)
           items  (get-in rt [:rf.runtime/machines :snapshots :ui/nine-states :data :items])]
       (if (seq errors)
-        ;; Incorrect — populate :errors, touch all error fields so they show.
+        ;; Invalid. Stash the errors and mark every offending field as
+        ;; touched, which is what lets those errors actually show.
         {:db (-> db
                  (assoc-in [:new-todo :errors]  errors)
                  (assoc-in [:new-todo :touched] (set (keys errors))))
          :fx [[:dispatch [:ui/nine-states [:submit-invalid]]]]}
-        ;; Correct — append the todo to the machine's items, clear the form.
-        ;; The :data region's lifecycle is the canonical path for changing
-        ;; items: bump through :loading → :resolving so the :always-cascade
-        ;; re-picks the cardinality bucket against the new count.
+        ;; Valid. Append the todo and clear the form. Note we don't quietly
+        ;; poke :items — we go the long way round, through the data region's
+        ;; real lifecycle (:loading → :resolving), so the :always-cascade
+        ;; re-counts and re-picks the cardinality bucket. One canonical path
+        ;; for changing items means one place the cardinality is decided.
         (let [new-items (conj (vec items)
                               {:id     new-id
                                :title  (:title draft)
@@ -480,14 +510,16 @@
 (rf/reg-sub :new-todo/touched :<- [:new-todo/slice] (fn [s _] (:touched s)))
 
 (rf/reg-sub :new-todo/field-error
-  {:doc "Per-field error, only after the user has touched the field."}
+  {:doc "The error for one field — but only once the user has actually
+         touched it. Nobody likes a form that scolds you for leaving a
+         field blank before you've even reached it."}
   :<- [:new-todo/errors]
   :<- [:new-todo/touched]
   (fn sub-new-todo-field-error [[errs touched] [_ field-id]]
     (when (touched field-id)
       (first (get errs field-id)))))
 
-;; The machine's :data items — read straight off the snapshot.
+;; The todos themselves — read straight off the machine's snapshot.
 (rf/reg-sub :todos/items
   :<- [:rf/machine :ui/nine-states]
   (fn sub-todos-items [snap _]
@@ -500,25 +532,30 @@
 
 ;; ---- render-priority + :ui/render selector ----
 ;;
-;; This is where the nine states collapse to one keyword. The render
-;; decision is a pure function over the snapshot's tag union, and it lives
-;; in exactly one readable place. The render-priority table is plain data:
-;; a vector of {:tag :render} pairs consulted in order. The :ui/render sub
-;; reads the machine's tag union and returns the first :render whose :tag
-;; is present. The root view's `case` just maps that keyword to a view fn.
+;; This is the keystone: the spot where three parallel axes collapse into
+;; one render decision. Several tags are live at once, but the page can only
+;; draw one thing, so we need a tie-breaker — and we make it plain data.
 ;;
-;; Priority order: :mode wins outright (the archived view replaces
-;; everything); :form wins next (the success / inline-error
-;; acknowledgement is transient and overlays whatever the :data region is
-;; at); :data picks the cardinality bucket as a fallback.
+;; `render-priority` is just a vector of {:tag :render} pairs read in order.
+;; The :ui/render sub walks it and returns the first :render whose :tag is
+;; present in the snapshot's tag union. That's the whole decision: a pure
+;; function over a data table, living in exactly one readable place. The
+;; root view's `case` does nothing cleverer than map the keyword to a view.
+;;
+;; The order encodes the priority, top to bottom:
+;;   :mode wins outright — once archived, that view replaces everything.
+;;   :form wins next — the success / error acknowledgement is a quick,
+;;     transient overlay on top of whatever the list is doing.
+;;   :data is the fallback — the steady-state cardinality bucket.
 
 (def render-priority
-  [;; mode region — read-only / terminal wins
+  [;; mode region — read-only / terminal trumps all
    {:tag :mode/done       :render :done}
-   ;; form region — transient acknowledgements (Correct/Incorrect)
+   ;; form region — the transient Correct / Incorrect acknowledgements
    {:tag :form/success    :render :correct}
    {:tag :form/invalid    :render :incorrect}
-   ;; data region — error first (also transient), then lifecycle, then cardinality
+   ;; data region — error first (also transient), then loading, then the
+   ;; resting cardinality buckets
    {:tag :data/loading    :render :loading}
    {:tag :data/error      :render :error}
    {:tag :data/nothing    :render :nothing}
@@ -528,10 +565,10 @@
    {:tag :data/too-many   :render :too-many}])
 
 (rf/reg-sub :ui/render
-  {:doc "Resolve the page's render-model keyword by consulting the
-         render-priority table against the machine's tag union. The
-         root view's `case` is the only branch site; everything else
-         reads tags directly."}
+  {:doc "Boil the whole page down to one keyword: walk the render-priority
+         table against the machine's tag union and return the first match.
+         This sub feeds the root view's `case` — the one and only place the
+         UI branches. Everything else just asks the tags directly."}
   :<- [:rf/machine :ui/nine-states]
   (fn sub-ui-render [snap _]
     (let [tags (:tags snap)]
@@ -543,7 +580,7 @@
 ;; VIEWS — one per render-model keyword
 ;; ============================================================================
 
-(reg-view ^{:doc "State 1 — Nothing: blank slate with a 'Get started' CTA."}
+(reg-view ^{:doc "State 1 — Nothing: a blank slate with a 'Get started' nudge."}
           view-nothing []
   [:div.state.state-nothing
    [:h2 "Welcome"]
@@ -555,7 +592,7 @@
   [:div.state.state-loading
    [:p "Loading todos…"]])
 
-(reg-view ^{:doc "Error branch — transport / server failure."}
+(reg-view ^{:doc "Error branch — the fetch failed; apologise and offer a retry."}
           view-error []
   (let [err @(subscribe [:todos/error])]
     [:div.state.state-error
@@ -582,7 +619,8 @@
      [:h2 (str (count todos) " todos")]
      [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))
 
-(reg-view ^{:doc "State 6 — Too Many: search + truncation."}
+(reg-view ^{:doc "State 6 — Too Many: more than anyone wants to scroll, so
+                  show a search box and truncate the rest."}
           view-too-many []
   (let [todos    @(subscribe [:todos/items])
         shown    (take too-many-threshold todos)
@@ -618,13 +656,16 @@
 ;; VIEWS — control panel + form + root
 ;; ============================================================================
 ;;
-;; The form and control panel use `(rf/machine-has-tag? :ui/nine-states
-;; :mode/read-only)` to disable themselves when the :mode region is :done.
-;; Querying by tag is cleaner than querying a specific state: the view
-;; asks "is it read-only?" and doesn't need to know which state of which
-;; region carries that intent. (Ask, don't tell.)
+;; The form and control panel grey themselves out once the page is archived,
+;; using `(rf/machine-has-tag? :ui/nine-states :mode/read-only)`. Notice
+;; what they DON'T ask: "are we in the :done state of the :mode region?"
+;; They ask "is this read-only?" and leave it at that. The view states an
+;; intent and lets the machine decide which state happens to carry it —
+;; ask, don't tell. Move that tag to another state tomorrow and these views
+;; don't change a line.
 
-(reg-view ^{:doc "Form for adding a todo. Drives the form region (states 7 & 8)."}
+(reg-view ^{:doc "The add-a-todo form — the thing that drives the form
+                  region through states 7 (Incorrect) and 8 (Correct)."}
           new-todo-form []
   (let [draft       @(subscribe [:new-todo/draft])
         field-err   @(subscribe [:new-todo/field-error :title])
@@ -642,7 +683,8 @@
      [:button {:type "submit" :disabled read-only?} "Add"]
      (when field-err [:p.error field-err])]))
 
-(reg-view ^{:doc "Buttons to drive the demo into each of the nine states."}
+(reg-view ^{:doc "Your remote control: one button per state, so you can
+                  jump the demo straight to any of the nine."}
           control-panel []
   (let [read-only? @(rf/machine-has-tag? :ui/nine-states :mode/read-only)]
     [:div.control-panel
@@ -669,9 +711,10 @@
                :data-testid "ns-button-archive"
                :disabled read-only?} "9. Archive (Done)"]]))
 
-(reg-view ^{:doc "Root view: one `case` over :ui/render picks exactly one
-                  per-state view; the form and control panel render
-                  alongside."}
+(reg-view ^{:doc "The root view, and the punchline of the whole example: a
+                  single `case` over :ui/render picks exactly one per-state
+                  view. The control panel and form sit alongside it,
+                  always on. Nine states, one branch."}
           root-view []
   [:div.app
    [:h1 "Nine States of UI — todos"]
@@ -696,32 +739,34 @@
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 ;;
-;; The mount happens inside `run`, not at namespace-load time. The
-;; browser-test bundle `:require`s several example namespaces at once. If
-;; each called `rdc/create-root` against `(js/document.getElementById "app")`
-;; at ns-load, they would race to attach a root to the one `#app` element
-;; the harness shares — producing React "createRoot called on the same
-;; container twice" warnings and cross-example leakage. Deferring
-;; `create-root` to `run` keeps ns-load free of DOM side effects, so the
-;; namespaces co-exist in one build cleanly.
+;; The mount lives inside `run`, deliberately not at namespace-load time.
+;; Here's why: the browser-test bundle requires several example namespaces
+;; at once, and they all share one `#app` element. If each grabbed it with
+;; `rdc/create-root` the moment its ns loaded, they'd trample each other —
+;; React's "createRoot called on the same container twice" warning, plus
+;; cross-example leakage. Keeping `create-root` inside `run` means ns-load
+;; has zero DOM side effects, and the namespaces coexist in one build
+;; without a fuss.
 
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; `init!` installs the Reagent adapter.
+  ;; Tell the runtime which substrate to render through. Just the adapter —
+  ;; no frame yet.
   (rf/init! reagent-adapter/adapter)
-  ;; The `frame-provider {:id …}` below owns the frame. On first mount it
-  ;; creates `:rf/default`, applies the config, and runs `:initial-events`
-  ;; once; on hot reload it reuses the existing frame and skips re-seeding.
-  ;; Config:
+  ;; The `frame-provider {:id …}` below is what actually owns the frame. On
+  ;; the first mount it creates `:rf/default`, applies the config, and fires
+  ;; `:initial-events` once; on a hot reload it finds the frame already
+  ;; standing and skips the re-seed. Two config keys do the work:
   ;;
-  ;; - `:fx-overrides` routes `:rf.http/managed` to the in-process canned-stub
-  ;;   fxs above, so the example runs standalone with no backend.
-  ;; - `:initial-events` seeds the app via `[:nine-states.app/initialise]`.
+  ;; - `:fx-overrides` points `:rf.http/managed` at our in-process stub, so
+  ;;   the example runs all on its own with no backend in sight.
+  ;; - `:initial-events` boots the app via `[:nine-states.app/initialise]`.
   ;;
-  ;; The provider also scopes the frame into React, so the `reg-view`-injected
-  ;; `dispatch`/`subscribe` (and `root-view`'s subs) resolve to `:rf/default`.
-  ;; This is the same `:rf/default` the `reg-app-schema` above is scoped to.
+  ;; The provider also scopes the frame into React — that's what lets the
+  ;; `dispatch`/`subscribe` injected into each `reg-view` (and `root-view`'s
+  ;; subs) find `:rf/default`. Same `:rf/default` the `reg-app-schema` up top
+  ;; attached to.
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))

--- a/examples/reagent/nine_states/stories.cljs
+++ b/examples/reagent/nine_states/stories.cljs
@@ -1,67 +1,65 @@
 (ns nine-states.stories
-  "Story showcase for the **Nine States of UI** worked example.
+  "The **Nine States of UI**, as a Story showcase.
 
-   The nine canonical UI states (Nothing / Loading / Empty / One /
-   Some / Too Many / Incorrect / Correct / Done) form a natural Story
-   variant set — Story enumerates a single view's view-states side by
-   side. This file registers one `reg-variant` per render-model keyword
-   the root view `case`s over, so the Story controls panel flips the page
-   through every state without the reader hand-driving the machine.
+   Nine states laid out side by side is exactly what Story is for — it
+   enumerates one view's view-states so you can see them all at once
+   instead of clicking your way to each. So this file registers one
+   `reg-variant` per keyword the root view `case`s over, and the Story
+   controls panel flips the page through every state for you. No
+   hand-driving the machine required.
 
    ## Where the nine come from
 
    `nine-states.core` collapses the `:ui/nine-states` machine's
-   parallel-region tag union into one render-model keyword via the
-   `:ui/render` selector sub (consulting the `render-priority` table).
-   The root view's `case` has exactly ten arms — the nine canonical
-   states plus the `:error` branch. The nine canonical variants below
-   map 1:1 onto the nine canonical render keywords:
+   parallel-region tag union into a single render-model keyword via the
+   `:ui/render` selector (which reads the `render-priority` table). The
+   root view's `case` has ten arms — the nine canonical states plus the
+   `:error` branch — and the nine variants below line up 1:1 with the
+   canonical render keywords:
 
      :nothing :loading :empty :one :some :too-many
      :incorrect :correct :done
 
-   The `:error` branch is the tenth render arm; it lives on a separate
-   `:story.nine-states-lifecycle` story (below) alongside `:loading` /
+   The `:error` branch is the tenth arm. It lives on its own
+   `:story.nine-states-lifecycle` story (below) next to `:loading` and
    `:some`, so the async **load → loading → loaded/error** cascade reads
-   as one lifecycle the reader can step through and inspect in Xray.
-   Keeping it off the canonical nine keeps that set a clean 1:1 with the
-   render keywords.
+   as one walk-through you can step through and inspect in Xray. Parking
+   it there keeps the canonical nine a tidy 1:1 with the render keywords.
 
-   ## Fidelity — reach each state via real events
+   ## Fidelity — reach each state the honest way
 
-   Every variant drives its state through real events into the
-   `:ui/nine-states` machine — the highest-fidelity path, so the Story
-   canvas shows exactly what the live app shows and Xray's Epoch / Trace
-   / Side Effects panels carry the genuine cascade:
+   Every variant arrives at its state by firing real events into the
+   `:ui/nine-states` machine. That's the highest-fidelity path: the Story
+   canvas shows precisely what the live app shows, and Xray's Epoch /
+   Trace / Side Effects panels record the genuine cascade — not a faked
+   end-state.
 
    - Nothing      — `[:nine-states.app/initialise]` (machine `:reset`).
    - Loading       — `[:ui/nine-states [:fetch-started]]` parks the
-                     `:data` region at `:loading` (no reply dispatched).
+                     `:data` region at `:loading` (no reply ever comes).
    - Empty/One/Some/Too Many — the `:nine-states.story/load` cascade
-                     below: a real `:rf.http/managed` fx whose reply
-                     folds back through `:fetch-succeeded`, so the
-                     `:data` region's `:always`-cascade picks the
-                     cardinality bucket from the item count.
-   - Incorrect     — edit a too-short title + submit → `:submit-invalid`.
-   - Correct       — edit a valid title + submit → `:submit-valid`.
-   - Done          — load + archive → the `:mode` region reaches `:done`.
+                     below: a real `:rf.http/managed` fx whose reply folds
+                     back through `:fetch-succeeded`, so the `:data`
+                     region's `:always`-cascade counts the items and picks
+                     the bucket.
+   - Incorrect     — type a too-short title and submit → `:submit-invalid`.
+   - Correct       — type a valid title and submit → `:submit-valid`.
+   - Done          — load, then archive → the `:mode` region reaches `:done`.
 
-   Every state is reachable through an event path, so no `:db-seed` /
-   `:sub-overrides` are needed and the fidelity is uniformly `:event`.
+   Because every state is reachable through events, no variant needs a
+   `:db-seed` or `:sub-overrides`, and the fidelity is uniformly `:event`.
 
    ## Xray-richness — the managed-HTTP cascade
 
-   Story allocates each variant its own frame under `:preset :story`.
-   That preset redirects `:rf.http/managed` to the framework's
-   `:rf.http/managed-canned-success` stub by default — there is no
-   automatic failure branch. A variant that wants the failure path
-   stamps its own
+   Story gives each variant its own frame under `:preset :story`. That
+   preset quietly redirects `:rf.http/managed` to the framework's
+   `:rf.http/managed-canned-success` stub — handy, but it means there's no
+   failure path by default. A variant that wants one stamps its own
    `:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}`,
-   which wins over the preset default (see the lifecycle `…/error`
-   variant below). `:nine-states.story/load` issues a real
-   `:rf.http/managed` request carrying the synthetic todos on the
-   request's `:value` slot (the slot the canned-success stub echoes
-   back), so the full fetch lifecycle runs:
+   which wins over the preset (see the lifecycle `…/error` variant below).
+   `:nine-states.story/load` fires a real `:rf.http/managed` request with
+   the synthetic todos sitting on the request's `:value` slot — the slot
+   the canned-success stub echoes back — so the full lifecycle plays out:
 
        :nine-states.story/load
          → [:ui/nine-states [:fetch-started]]        (→ :loading)
@@ -71,57 +69,58 @@
                  → [:ui/nine-states [:fetch-succeeded …]]
                      → :resolving → :always cardinality bucket
 
-   That whole chain lands on the Epoch tape and the Trace stream, and
-   the `:rf.http/managed` fx shows in the Side Effects panel — so a
-   reader can pick the `:some` or `:error` variant and watch the fetch
-   light up Xray end to end.
+   The whole chain lands on the Epoch tape and the Trace stream, and the
+   `:rf.http/managed` fx shows up in the Side Effects panel. Pick the
+   `:some` or `:error` variant and watch the fetch light up Xray end to
+   end — that's the payoff for driving these through real events.
 
    ## Authoring discipline
 
-   Every variant body is plain data — no fn-slots. The view at the centre
-   of each variant is the example's own `nine-states.core/root-view`,
-   referenced by id. The canonical Story tags auto-install on the first
-   `reg-*` call, so no explicit boot step is needed."
+   Every variant body is plain data — no fn-slots anywhere. The view at
+   the heart of each one is the example's own
+   `nine-states.core/root-view`, referenced by id. And the canonical Story
+   vocabulary installs itself on the first `reg-*` call, so there's no boot
+   step to remember."
   (:require [re-frame.core :as rf]
             [re-frame.story :as story]
-            ;; Source the example's registrations (the machine, the demo
-            ;; events / subs / views, the `:ui/render` selector). The
-            ;; variant bodies below reference its event-ids and the
-            ;; `root-view` view-id as plain keywords; requiring the ns
-            ;; fires every `reg-*` so those ids resolve.
+            ;; Pull in the example's own registrations — the machine, the
+            ;; demo events / subs / views, the `:ui/render` selector. The
+            ;; variant bodies below name its event-ids and `root-view` as
+            ;; plain keywords, and requiring the ns fires every `reg-*` so
+            ;; those keywords actually resolve to something.
             [nine-states.core]))
 
 ;; ---------------------------------------------------------------------------
 ;; Story-side load event — the Xray-rich managed-HTTP cascade
 ;;
-;; The live example's `:nine-states.demo/load` builds its request with
-;; `:query {:n N}` and lets the app's own `:nine-states.http/managed-demo`
-;; fx-override read `:n` to synthesise todos. Inside the Story shell the
-;; per-variant frame runs under `:preset :story`, which redirects
-;; `:rf.http/managed` to the framework's `:rf.http/managed-canned-success`
-;; stub instead — that stub echoes the request's `:value` slot back as the
-;; success payload. So the Story load event puts the synthetic todos
-;; directly on `:value`, keeping the same real `:rf.http/managed` fx
-;; cascade the live app uses (visible in Xray's Side Effects panel) while
-;; staying deterministic under the canned stub.
+;; Same fetch, slightly different plumbing. The live example's
+;; `:nine-states.demo/load` sends `:query {:n N}` and lets the app's
+;; `:nine-states.http/managed-demo` override read `:n` and synthesise the
+;; todos. But inside the Story shell each variant runs under `:preset
+;; :story`, which swaps in the framework's `:rf.http/managed-canned-success`
+;; stub — and that stub doesn't read `:n`; it just echoes back whatever sits
+;; on the request's `:value` slot. So the Story load event puts the
+;; synthetic todos straight on `:value`. Same real `:rf.http/managed`
+;; cascade (still visible in Xray's Side Effects panel), now deterministic
+;; under the canned stub.
 ;; ---------------------------------------------------------------------------
 
 (defn- gen-todos
-  "Synthesise N demo todos. Mirrors the live example's private
-   generator; kept local so the story file does not reach into
-   `nine-states.core`'s implementation namespace."
+  "Conjure up N demo todos. Same shape as the live example's private
+   generator, copied here on purpose so the story file doesn't have to
+   reach into `nine-states.core`'s guts for it."
   [n]
   (vec (for [i (range n)]
          {:id (random-uuid) :title (str "Todo #" (inc i)) :done? false})))
 
 (rf/reg-event :nine-states.story/load
-  {:doc "Story-shell variant of `:nine-states.demo/load`. Drives the
-         same real fetch cascade — `:fetch-started` → `:rf.http/managed`
-         → reply → `:fetch-succeeded` — but carries the synthetic todos
-         on the request's `:value` slot so the `:preset :story` frame's
-         canned-success stub returns them. `n` items lands the `:data`
-         region in the matching cardinality bucket via the
-         `:always`-cascade."}
+  {:doc "The Story-shell twin of `:nine-states.demo/load`. It runs the
+         exact same real fetch cascade — `:fetch-started` →
+         `:rf.http/managed` → reply → `:fetch-succeeded` — but tucks the
+         synthetic todos onto the request's `:value` slot so the `:preset
+         :story` frame's canned-success stub hands them back. Ask for `n`
+         items and the `:always`-cascade drops the `:data` region into the
+         matching cardinality bucket."}
   (fn handler-story-load [_ [_ {:keys [n]}]]
     {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
           [:rf.http/managed
@@ -132,26 +131,26 @@
             :on-failure [:nine-states.demo/load-failed]}]]}))
 
 (rf/reg-event :nine-states.story/load-failing
-  {:doc "Story-shell variant of `:nine-states.demo/load-with-failure`.
-         Drives the same real fetch cascade — `:fetch-started` →
-         `:rf.http/managed` → reply → `:fetch-failed` — into the
-         `:error` branch.
+  {:doc "The Story-shell twin of `:nine-states.demo/load-with-failure`.
+         Same cascade shape — `:fetch-started` → `:rf.http/managed` →
+         reply → `:fetch-failed` — but down the `:error` branch.
 
-         The `:story` preset routes `:rf.http/managed` to the
-         canned-success stub by default, which would take the
-         `:on-success` path. So the error variant stamps its own
-         `:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}`
-         (a variant-owned `:fx-overrides` wins over the preset's), and
-         this same event runs against the canned-failure stub instead —
-         that stub reads the top-level `:kind` / `:tags` slots below,
-         synthesises a failure reply, and dispatches `:on-failure`,
-         landing the `:data` region at `:error`."}
+         There's a wrinkle: the `:story` preset routes `:rf.http/managed`
+         to the canned-SUCCESS stub, which would happily take the
+         `:on-success` path and never fail. So the error variant stamps its
+         own `:fx-overrides {:rf.http/managed
+         :rf.http/managed-canned-failure}` — a variant-owned override beats
+         the preset — and this same event then runs against the
+         canned-failure stub. That stub reads the top-level `:kind` /
+         `:tags` slots below, builds a failure reply, and dispatches
+         `:on-failure`, landing the `:data` region at `:error`."}
   (fn handler-story-load-failing [_ _]
     {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
           [:rf.http/managed
-           ;; The canned-failure stub reads `:kind` / `:tags` from the
-           ;; top level (not a nested `:failure` map), so this failure
-           ;; category carries through to `:nine-states.demo/load-failed`.
+           ;; The canned-failure stub looks for `:kind` / `:tags` at the
+           ;; top level — not inside a nested `:failure` map — so putting
+           ;; the failure category here is what carries it through to
+           ;; `:nine-states.demo/load-failed`.
            {:request    {:method :get :url "/api/todos/fail"}
             :kind       :rf.http/transport
             :tags       {:message "Network unreachable."}
@@ -162,35 +161,36 @@
 ;; ---------------------------------------------------------------------------
 ;; register-all!
 ;;
-;; Every registration lives in one top-level fn so a hot-reload can re-fire
-;; the lot at once. The fn also fires once at namespace load via the
-;; trailing call, so consumers who just `:require` this ns get the
-;; registrations populated.
+;; All the registrations live in one top-level fn so a hot reload can re-run
+;; the whole batch in one go. The trailing call at the bottom of the file
+;; also fires it once at namespace load, so anyone who merely `:require`s
+;; this ns gets a fully-populated set of stories for free.
 ;; ---------------------------------------------------------------------------
 
 (defn register-all!
-  "Register the nine-states example's Story artefacts. Idempotent.
-   The canonical vocabulary auto-installs on the first `reg-*` call
-   — no explicit boot step required."
+  "Register the nine-states example's Story artefacts. Safe to call again
+   — it's idempotent. The canonical vocabulary installs itself on the first
+   `reg-*` call, so there's nothing to boot first."
   []
 
   ;; -------------------------------------------------------------------------
-  ;; reg-tag — a project tag marking the canonical screenshot variant.
+  ;; reg-tag — a project tag that flags the one variant we screenshot.
   ;; -------------------------------------------------------------------------
 
   (story/reg-tag :nine-states/canonical
     {:doc "Marks the variant that ships as the example's canonical
-          screenshot — the `:some` standard-list state."})
+          screenshot — the `:some` standard-list state. The face of the
+          example, so to speak."})
 
   ;; -------------------------------------------------------------------------
   ;; reg-story — the parent story. Its `:component` (the example's
-  ;; `root-view`) and `:tags` inherit down to every variant below; the
-  ;; per-state setup lives on the variants.
+  ;; `root-view`) and `:tags` flow down to every variant below, so the
+  ;; variants only have to spell out their own per-state setup.
   ;; -------------------------------------------------------------------------
 
   (story/reg-story :story.nine-states
     {:doc        "The Nine States of UI — every canonical view-state of
-                 the todos page, driven through the `:ui/nine-states`
+                 the todos page, each driven through the `:ui/nine-states`
                  parallel machine."
      :component  :nine-states.core/root-view
      :tags       #{:dev :docs}
@@ -198,10 +198,10 @@
 
   (story/reg-story :story.nine-states-lifecycle
     {:doc        "The RemoteData fetch lifecycle as a stepped cascade —
-                 load → loading → loaded / error. Kept separate from the
+                 load → loading → loaded / error. Kept apart from the
                  canonical nine so the async path (and its Xray Epoch /
-                 Trace / Side Effects trail) reads as one story the
-                 reader can step through."
+                 Trace / Side Effects trail) reads as one story you can
+                 step through arm by arm."
      :component  :nine-states.core/root-view
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
@@ -209,100 +209,100 @@
   ;; -------------------------------------------------------------------------
   ;; reg-variant — the nine canonical states, one per render keyword.
   ;;
-  ;; Each `:setup` drives the machine to its state through REAL events
-  ;; (fidelity `:event`); no `:db-seed` / `:sub-overrides`.
+  ;; Each `:setup` is just a list of real events that drive the machine to
+  ;; the state in question (so fidelity is `:event` across the board — no
+  ;; `:db-seed`, no `:sub-overrides`, no shortcuts).
   ;; -------------------------------------------------------------------------
 
-  ;; State 1 — Nothing. Initialise the form slice + reset the machine.
+  ;; State 1 — Nothing. Initialise the form slice and reset the machine.
   (story/reg-variant :story.nine-states/nothing
     {:doc        "State 1 — Nothing. Never fetched; the `:data` region
-                 sits at `:nothing`. The blank-slate welcome view with a
-                 'Get started' CTA."
+                 sits at `:nothing`. The blank-slate welcome screen with a
+                 'Get started' nudge."
      :setup      [[:nine-states.app/initialise]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
   ;; State 2 — Loading. `:fetch-started` parks the `:data` region at
-  ;; `:loading`; no reply is dispatched so it stays there for the
-  ;; screenshot.
+  ;; `:loading`, and since no reply is ever sent it stays put — perfect for
+  ;; a screenshot of a spinner that never resolves.
   (story/reg-variant :story.nine-states/loading
     {:doc        "State 2 — Loading. A first fetch is in flight; the
-                 `:data` region is parked at `:loading` (the
-                 `:fetch-started` event with no reply). Spinner view."
+                 `:data` region is parked at `:loading` (a `:fetch-started`
+                 with no reply behind it). The spinner view."
      :setup      [[:nine-states.app/initialise]
                   [:ui/nine-states [:fetch-started]]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; State 3 — Empty. Load zero todos; the `:always`-cascade picks `:empty`.
+  ;; State 3 — Empty. Load zero todos and the `:always`-cascade picks `:empty`.
   (story/reg-variant :story.nine-states/empty
-    {:doc        "State 3 — Empty. Fetched, but the result is the empty
-                 list. The `:always`-cascade picks `:empty` from a
-                 zero count."
+    {:doc        "State 3 — Empty. Fetched, but the result came back empty.
+                 The `:always`-cascade reads a count of zero and picks
+                 `:empty`."
      :setup      [[:nine-states.app/initialise]
                   [:nine-states.story/load {:n 0}]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; State 4 — One. Exactly one todo; the cascade picks `:one`.
+  ;; State 4 — One. Exactly one todo, so the cascade picks `:one`.
   (story/reg-variant :story.nine-states/one
     {:doc        "State 4 — One. Exactly one todo; the focused
-                 single-item layout (`:one` cardinality bucket)."
+                 single-item layout (the `:one` cardinality bucket)."
      :setup      [[:nine-states.app/initialise]
                   [:nine-states.story/load {:n 1}]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; State 5 — Some. A small, manageable list; the canonical screenshot.
+  ;; State 5 — Some. A small, manageable list — and the canonical screenshot.
   (story/reg-variant :story.nine-states/some
-    {:doc        "State 5 — Some. A small, manageable list rendered
-                 plainly (`:some` cardinality bucket). The example's
-                 canonical screenshot."
+    {:doc        "State 5 — Some. A small, manageable list, rendered
+                 plainly (the `:some` cardinality bucket). This is the
+                 example's canonical screenshot."
      :setup      [[:nine-states.app/initialise]
                   [:nine-states.story/load {:n 4}]]
      :tags       #{:dev :docs :nine-states/canonical}
      :substrates #{:reagent}})
 
-  ;; State 6 — Too Many. Beyond the threshold; search + truncation.
+  ;; State 6 — Too Many. Push past the threshold and get search + truncation.
   (story/reg-variant :story.nine-states/too-many
     {:doc        "State 6 — Too Many. More items than the too-many
-                 threshold (7); the view shows search + truncation
-                 (`:too-many` cardinality bucket)."
+                 threshold (7), so the view switches to search +
+                 truncation (the `:too-many` cardinality bucket)."
      :setup      [[:nine-states.app/initialise]
                   [:nine-states.story/load {:n 25}]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; State 7 — Incorrect. A too-short title + submit → `:submit-invalid`.
+  ;; State 7 — Incorrect. Type a too-short title, submit → `:submit-invalid`.
   (story/reg-variant :story.nine-states/incorrect
-    {:doc        "State 7 — Incorrect. A too-short title fails the form
+    {:doc        "State 7 — Incorrect. A too-short title trips the form
                  validator on submit; the `:form` region lands at
-                 `:incorrect` (`:submit-invalid`), showing the inline
-                 per-field error."
+                 `:incorrect` (via `:submit-invalid`) and the inline
+                 per-field error appears."
      :setup      [[:nine-states.app/initialise]
                   [:new-todo/edit-field :title "no"]
                   [:new-todo/submit]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; State 8 — Correct. A valid title + submit → `:submit-valid`.
+  ;; State 8 — Correct. Type a valid title, submit → `:submit-valid`.
   (story/reg-variant :story.nine-states/correct
-    {:doc        "State 8 — Correct. A valid title passes the form
+    {:doc        "State 8 — Correct. A valid title sails through the form
                  validator on submit; the `:form` region lands at
-                 `:correct` (`:submit-valid`), showing the success
-                 acknowledgement."
+                 `:correct` (via `:submit-valid`) and the success
+                 acknowledgement appears."
      :setup      [[:nine-states.app/initialise]
                   [:new-todo/edit-field :title "Buy milk"]
                   [:new-todo/submit]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  ;; State 9 — Done. Load some items, then archive → `:mode` at `:done`.
+  ;; State 9 — Done. Load some items, then archive → `:mode` reaches `:done`.
   (story/reg-variant :story.nine-states/done
-    {:doc        "State 9 — Done. After loading some todos the list is
-                 archived; the `:mode` region reaches the terminal,
-                 read-only `:done` state and the form + controls
-                 disable themselves."
+    {:doc        "State 9 — Done. Load a few todos, then archive: the
+                 `:mode` region reaches its terminal, read-only `:done`
+                 state and the form and controls all grey themselves out."
      :setup      [[:nine-states.app/initialise]
                   [:nine-states.story/load {:n 4}]
                   [:ui/nine-states [:archive {}]]]
@@ -310,13 +310,14 @@
      :substrates #{:reagent}})
 
   ;; -------------------------------------------------------------------------
-  ;; The :error branch — the tenth render arm. Lives on the lifecycle
-  ;; story so the async failure cascade reads alongside :loading / :some.
+  ;; The :error branch — the tenth render arm. It lives on the lifecycle
+  ;; story so the failure cascade reads as a step in a sequence, right
+  ;; alongside :loading and :some.
   ;; -------------------------------------------------------------------------
 
   (story/reg-variant :story.nine-states-lifecycle/loading
     {:doc        "Lifecycle — the in-flight `:loading` step. Same as the
-                 canonical Loading variant, shown here as the first arm
+                 canonical Loading variant, shown here as the opening arm
                  of the fetch cascade."
      :setup      [[:nine-states.app/initialise]
                   [:ui/nine-states [:fetch-started]]]
@@ -325,27 +326,27 @@
 
   (story/reg-variant :story.nine-states-lifecycle/loaded
     {:doc        "Lifecycle — the resolved `:some` step. The full
-                 `:rf.http/managed` cascade runs in `:setup`; pick this
-                 variant and inspect the fetch in Xray's Epoch / Trace /
-                 Side Effects panels."
+                 `:rf.http/managed` cascade runs in `:setup`, so pick this
+                 variant and watch the fetch play out across Xray's Epoch /
+                 Trace / Side Effects panels."
      :setup      [[:nine-states.app/initialise]
                   [:nine-states.story/load {:n 4}]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
   (story/reg-variant :story.nine-states-lifecycle/error
-    {:doc           "Lifecycle — the `:error` branch. This variant stamps
+    {:doc           "Lifecycle — the `:error` branch. This is the one
+                    variant that wants its fetch to fail, so it stamps
                     `:fx-overrides {:rf.http/managed
-                    :rf.http/managed-canned-failure}` so its
-                    `:rf.http/managed` request runs through the canned-
-                    FAILURE stub (overriding the `:story` preset's
-                    canned-success default); `:fetch-failed` then lands
-                    the `:data` region at `:error`. The failure cascade
-                    lights up Xray's Side Effects + Trace panels
-                    alongside the success path."
-     ;; This variant-owned `:fx-overrides` wins over the `:story` preset's
-     ;; canned-success default, giving the failing variant its failure
-     ;; stub — the success variants keep the preset's canned-success.
+                    :rf.http/managed-canned-failure}` to send its
+                    `:rf.http/managed` request through the canned-FAILURE
+                    stub instead of the `:story` preset's success default.
+                    `:fetch-failed` then lands the `:data` region at
+                    `:error`, and the failure cascade lights up Xray's Side
+                    Effects + Trace panels right next to the success path."
+     ;; A variant-owned `:fx-overrides` outranks the `:story` preset's
+     ;; canned-success default — so only this variant gets the failure
+     ;; stub; its siblings keep on succeeding.
      :fx-overrides  {:rf.http/managed :rf.http/managed-canned-failure}
      :setup         [[:nine-states.app/initialise]
                      [:nine-states.story/load-failing]]
@@ -353,11 +354,12 @@
      :substrates    #{:reagent}})
 
   ;; -------------------------------------------------------------------------
-  ;; reg-workspace — two layouts over the canonical nine.
+  ;; reg-workspace — a few different ways to arrange the same variants.
   ;;
-  ;; `:variants-grid` auto-enumerates every variant of the parent story
-  ;; (new variants appear without touching the workspace); `:grid` pins
-  ;; the nine in canonical order for the README screenshot.
+  ;; Two styles on show here. A `:variants-grid` auto-enumerates every
+  ;; variant of its parent story, so new variants just show up — no edit
+  ;; needed. A plain `:grid` pins a hand-picked set in a fixed order, which
+  ;; is what you want for a stable README screenshot.
   ;; -------------------------------------------------------------------------
 
   (story/reg-workspace :Workspace.nine-states/all-states
@@ -376,9 +378,8 @@
      :tags     #{:docs}})
 
   (story/reg-workspace :Workspace.nine-states/auto-grid
-    {:doc     "Auto-enumerated grid — pulls every variant off
-              :story.nine-states. New variants appear here without
-              touching this workspace."
+    {:doc     "The set-it-and-forget-it grid — auto-pulls every variant off
+              :story.nine-states, so new variants land here on their own."
      :layout  :variants-grid
      :for     :story.nine-states
      :columns 3
@@ -394,5 +395,5 @@
      :columns  3
      :tags     #{:docs}}))
 
-;; Fire the registrations once at namespace load.
+;; And fire them once, right now, as the namespace loads.
 (register-all!)

--- a/examples/reagent/nine_states/stories_host.cljs
+++ b/examples/reagent/nine_states/stories_host.cljs
@@ -1,79 +1,80 @@
 (ns nine-states.stories-host
-  "Showcase entry point for the Nine States example — the host that
-   wires the live app, the Story shell, and Xray into one page.
+  "The showcase entry point for the Nine States example — one page that
+   wires together the live app, the Story shell, and Xray.
 
-   URL-hash-routed between two surfaces (mirrors
+   A URL hash routes between two surfaces (the same shape as
    `counter-with-stories.core`):
 
-   - `#/`        → the live Nine States app (the example's `root-view`
-                   plus its control panel + form).
-   - `#/stories` → the Story shell mounted via
+   - `#/`        → the live Nine States app: the example's `root-view`
+                   with its control panel and form.
+   - `#/stories` → the Story shell, mounted via
                    `re-frame.story/mount-shell!`. The nine canonical
-                   state variants + the lifecycle variants + three
-                   workspaces show up in the sidebar; each variant
-                   renders in its own isolated frame.
+                   variants, the lifecycle variants, and three workspaces
+                   all appear in the sidebar, each variant rendering in its
+                   own isolated frame.
 
    ## Xray
 
-   The build wires Xray via shadow-cljs's `:devtools {:preloads
-   [day8.re-frame2-xray.preload]}` (see the `:examples/nine-states-
-   with-stories` build in `implementation/shadow-cljs.edn`). Loading
-   the preload attaches the Ctrl+Shift+C keybinding and the trace /
-   epoch collectors. We DISABLE auto-open here (`:rf.xray/auto-open?
-   false`) so the page lands on the live app or the Story shell first;
-   the reader presses Ctrl+Shift+C to open Xray over either surface and
-   drive a state to watch the `:nine-states.story/load` →
-   `:rf.http/managed` → reply cascade light up the Epoch / Trace / Side
-   Effects panels.
+   The build switches Xray on through shadow-cljs's `:devtools {:preloads
+   [day8.re-frame2-xray.preload]}` (see the
+   `:examples/nine-states-with-stories` build in
+   `implementation/shadow-cljs.edn`). The preload installs the
+   Ctrl+Shift+C keybinding and the trace / epoch collectors. We turn auto-
+   open OFF (`:rf.xray/auto-open? false`) on purpose, so the page greets
+   you with the live app or the Story shell rather than Xray. Press
+   Ctrl+Shift+C over either surface, drive a state, and watch the
+   `:nine-states.story/load` → `:rf.http/managed` → reply cascade light up
+   the Epoch / Trace / Side Effects panels.
 
    ## One adapter
 
-   The host installs the FULL Reagent adapter (`re-frame.adapter.
-   reagent`) — the substrate the Story shell itself renders on. The
-   example's own `core.cljs` also mounts on the stock Reagent adapter for
-   its standalone `:examples/nine-states` build; this showcase host is a
-   separate entry point and runs everything (live app + shell + variant
-   canvases) on one adapter. `nine-states.core/root-view` is a
-   substrate-agnostic `reg-view`, so it renders identically under
-   either.
+   This host installs the full Reagent adapter (`re-frame.adapter.reagent`)
+   — the substrate the Story shell itself renders on — and runs everything
+   on it: live app, shell, and every variant canvas. (The example's own
+   `core.cljs` mounts on the stock Reagent adapter for its standalone
+   `:examples/nine-states` build; this showcase is a separate entry point.)
+   It all works because `nine-states.core/root-view` is a
+   substrate-agnostic `reg-view` — it renders identically either way.
 
    ## Elision
 
    Compiled under `:advanced` with `:closure-defines
    {re-frame.story.config/enabled? false}`, every `reg-*` in
-   `nine-states.stories` elides to nil and `mount-shell!`
-   short-circuits — the Story body carries no code into a production
-   bundle. The bundle-isolation gate verifies the Story / Xray
-   sentinel sets stay out of the plain `:examples/nine-states` build."
+   `nine-states.stories` compiles down to nil and `mount-shell!`
+   short-circuits — not one byte of the Story body rides along into a
+   production bundle. The bundle-isolation gate keeps it honest by checking
+   that the Story / Xray sentinels never show up in the plain
+   `:examples/nine-states` build."
   (:require [re-frame.core  :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-xray.config :as xray-config]
-            ;; Source the example's registrations (machine / schemas /
-            ;; demo events / subs / the `:ui/render` selector / views)
-            ;; and the Story artefacts. Requiring `nine-states.stories`
-            ;; transitively requires `nine-states.core`.
+            ;; Pull in the example's registrations (machine / schemas / demo
+            ;; events / subs / the `:ui/render` selector / views) and the
+            ;; Story artefacts. Requiring `nine-states.stories` drags in
+            ;; `nine-states.core` along with it.
             [nine-states.core :as core]
             [nine-states.stories]
-            ;; Shared Story-host helper: owns the
-            ;; live-app↔Story-shell hash router + React-root handle.
+            ;; The shared Story-host helper — it owns the
+            ;; live-app↔Story-shell hash router and the React-root handle,
+            ;; so we don't have to.
             [re-frame.testbed.story-host :as story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- The live-app frame ----------------------------------------------------
 ;;
-;; This host owns its own boot; it does not call `core/run` (which carries
-;; its own stock-Reagent mount lifecycle). So it registers the live-app
-;; frame here. The frame gives the live `#/` surface the example's demo HTTP
-;; override, routing `:rf.http/managed` to the in-process
-;; `:nine-states.http/managed-demo` stub (no backend).
+;; This host runs its own boot rather than calling `core/run` (which brings
+;; its own stock-Reagent mount lifecycle along). So it stands up the live-app
+;; frame right here, handing the `#/` surface the example's demo HTTP
+;; override — `:rf.http/managed` routed to the in-process
+;; `:nine-states.http/managed-demo` stub, no backend in the loop.
 
 (defn- install-live-frame! []
   (rf/reg-frame :rf/default
     {:doc          "Nine-states showcase live-app frame."
      :fx-overrides {:rf.http/managed :nine-states.http/managed-demo}})
-  ;; Seed the frame. `dispatch-sync` runs inside `with-frame :rf/default` so
-  ;; it targets that frame (a frameless dispatch raises
-  ;; `:rf.error/no-frame-context`).
+  ;; Now seed it. The `with-frame :rf/default` wrapper is what aims the
+  ;; `dispatch-sync` at that frame — dispatch with no frame in scope and
+  ;; you'd get `:rf.error/no-frame-context`.
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:nine-states.app/initialise])))
 
@@ -88,38 +89,41 @@
     " on either surface to open Xray and inspect the fetch cascade."]
    [core/root-view]])
 
-;; Scope the live `#/` surface into the showcase's `:rf/default` frame, so
-;; `nine-states-app`'s reg-view-injected dispatch/subscribe (and
-;; `core/root-view`'s subs) resolve to it. The Story shell side
-;; (`#/stories`) allocates its own per-variant frames. Passed to the shared
-;; story-host as the live-app root view (mirrors counter-with-stories.core).
+;; Wrap the live `#/` surface in the showcase's `:rf/default` frame, so the
+;; dispatch/subscribe injected into `nine-states-app` (and `core/root-view`'s
+;; subs) resolve to it. The Story side (`#/stories`) hands out its own
+;; per-variant frames, so this wrapper is only about the live app. We pass it
+;; to the shared story-host as the live-app root (same as
+;; counter-with-stories.core).
 (defn live-app-root []
   [rf/frame-provider {:frame :rf/default} [nine-states-app]])
 
 ;; -- Routing between the live app and the Story shell ----------------------
 ;;
-;; The live-app↔Story-shell hash router + React-root host handle live in the
-;; shared `re-frame.testbed.story-host` helper; `run`
-;; hands it `nine-states-app` as the live-app surface (mirrors
-;; counter-with-stories.core).
+;; The live-app↔Story-shell hash router and the React-root handle both live
+;; in the shared `re-frame.testbed.story-host` helper, so `run` just hands it
+;; `nine-states-app` as the live-app surface and lets it do the rest (same
+;; as counter-with-stories.core).
 
 (defn ^:export run []
-  ;; Keep Xray's collectors + keybinding installed but do not auto-open
-  ;; the panel — the page lands on the live app / shell first; the
-  ;; reader opens Xray with Ctrl+Shift+C.
+  ;; Keep Xray's collectors and keybinding installed, but don't pop the
+  ;; panel open on load — the page should show the live app / shell first,
+  ;; and the reader opens Xray with Ctrl+Shift+C when they're ready.
   (xray-config/configure! {:rf.xray/auto-open? false})
   (rf/init! reagent-adapter/adapter)
-  ;; No explicit `(story/install-canonical-vocabulary!)` — the first
-  ;; `reg-*` in `nine-states.stories` (loaded via the require above)
-  ;; auto-installs the canonical Story vocabulary.
+  ;; No `(story/install-canonical-vocabulary!)` call needed — the first
+  ;; `reg-*` over in `nine-states.stories` (loaded via the require above)
+  ;; installs the canonical Story vocabulary for us.
   (install-live-frame!)
-  ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
-  ;; `#/stories` lands on the shell without a manual click-through. The
-  ;; `:source-subdir` opt tells the host this showcase's Story source-coords
-  ;; are classpath-relative to `examples/reagent`, so it resolves the on-disk
-  ;; project root and calls `story/configure!` itself (also bridging the root
-  ;; into Xray's slot). Without it the Story 'open in editor' chips would
-  ;; resolve `nine_states/stories.cljs` against a nil root. The live-app root
-  ;; is frame-scoped via `live-app-root` (the `frame-provider` wrapper) so the
-  ;; bare `#/` surface mounts under the app frame.
+  ;; Wire up the live-app↔Story-shell hash router (the shared helper), so
+  ;; reloading `#/stories` lands back on the shell with no manual click.
+  ;; The `:source-subdir` opt is the important bit: it tells the host that
+  ;; this showcase's Story source-coords are classpath-relative to
+  ;; `examples/reagent`, so it can find the on-disk project root, call
+  ;; `story/configure!` itself, and bridge that root into Xray's slot.
+  ;; Leave it off and the Story 'open in editor' chips would try to resolve
+  ;; `nine_states/stories.cljs` against a nil root — and quietly fail. The
+  ;; live-app root is already frame-scoped by `live-app-root` (the
+  ;; `frame-provider` wrapper), so the bare `#/` surface mounts under the
+  ;; app frame.
   (story-host/mount-with-hash-routing! live-app-root {:source-subdir "examples/reagent"}))

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -1,33 +1,39 @@
 (ns notebook.core
-  "Reagent design-led example — 'Notebook'. A three-pane editor:
+  "Notebook — a Reagent example that leans into design. Three panes:
 
-     [ documents tree ]  [ markdown editor ]  [ live preview ]
+     [ documents list ]  [ markdown editor ]  [ live preview ]
 
-   The point of the example: one app-db holds the state, events are the
-   only thing that change it, and the views are pure functions of
-   subscriptions. The same shape scales from a counter to this
-   multi-pane UI unchanged. Reading order, top to bottom:
+   The counter shows the dataflow loop with nothing in the way. This is
+   that same loop with more parts, and the lesson is that it doesn't
+   change shape: one app-db holds the state, events are the only thing
+   that change it, and the views are pure functions of subscriptions.
+   Counter to multi-pane editor, same idea throughout.
 
-     - selecting a document   dispatches  [:notebook/select id]
-     - editing the body       dispatches  [:notebook/edit-body text]
-     - the hiccup sub         derives     hiccup from the selected markdown
-     - the preview pane       subscribes  to that derivation
+   Trace one keystroke through it, top to bottom:
 
-   The idea worth noticing is the markdown preview. Rendering markdown is
-   a pure derivation (string -> hiccup) exposed as a subscription, so it
-   sits in the same subscription graph as everything else — not behind a
-   DOM escape hatch.
+     - picking a document   dispatches  [:notebook/select id]
+     - typing in the editor dispatches  [:notebook/edit-body text]
+     - the hiccup sub       derives     hiccup from the selected markdown
+     - the preview pane      subscribes  to that derivation, and re-renders
 
-   The markdown parser is a tiny pure-CLJS one (headings, bold, italic,
-   inline code, links, paragraphs, ordered + unordered lists). That keeps
-   the bundle small and the example free of an extra npm dependency.
+   The part worth slowing down for is the preview. Rendering markdown is
+   just a pure function, string -> hiccup, so we expose it as a
+   subscription and let it sit in the same graph as everything else. No
+   DOM escape hatch, no `dangerouslySetInnerHTML`, no special case — the
+   preview is a derived value like any other.
 
-   See docs/guide/glossary.md for the terms used below (event,
-   subscription, app-db, view); docs/guide/concepts/views.md covers
-   views and hiccup in depth."
-  ;; Substrate: stock Reagent (`reagent.dom.client` +
-  ;; `re-frame.adapter.reagent`). The adapter is the value that binds
-  ;; re-frame2 to the rendering library; see docs/guide/glossary.md#adapter.
+   The parser itself is a tiny hand-rolled one (headings, bold, italic,
+   inline code, links, paragraphs, ordered + unordered lists). It handles
+   exactly the seed content and not one feature more, which keeps the
+   bundle small and spares us an npm dependency for a demo.
+
+   New to the terms? docs/guide/glossary.md defines event, subscription,
+   app-db, and view; docs/guide/concepts/views.md covers views and hiccup
+   in depth."
+  ;; We render through stock Reagent (`reagent.dom.client`). The adapter
+  ;; is the value that teaches re-frame2 how to talk to a given rendering
+  ;; library — swap it and the same app runs on UIx or Helix. See
+  ;; docs/guide/glossary.md#adapter.
   (:require [reagent.dom.client :as rdc]
             [clojure.string     :as str]
             [re-frame.core      :as rf]
@@ -72,17 +78,19 @@
                         (if (= (:id d) id) (assoc d :body text) d))
                       docs))))}))
 
-;; A new document's id is derived from the documents already in app-db:
-;; scan the `doc-N` keyword ids and take max+1. Deriving the id from prior
-;; state keeps the handler replayable — replaying the event stream mints
-;; the same id. Reaching for `(rand-int)` would break that, since each
-;; replay would mint a different id. Seeded ids (`:welcome`, `:six-dominoes`,
-;; …) carry no `doc-` prefix, so the first minted id is `:doc-1`. See
+;; Where do new ids come from? Not a counter, not a random number — we
+;; read them out of the state we already have. Scan the existing `doc-N`
+;; ids, take the max, add one. The reason is replayability: an event
+;; should be a pure function of (db, event), so replaying the same event
+;; stream lands you in the same place every time. `(rand-int)` would
+;; quietly poison that — every replay would mint a different id. The
+;; seeded docs (`:welcome`, `:six-dominoes`, …) have no `doc-` prefix, so
+;; they're invisible to the scan and the first new id is `:doc-1`. See
 ;; docs/guide/concepts/events-and-the-cascade.md on replayable events.
 (defn- allocate-next-doc-id
-  "Deterministic next `:doc-N` id from the existing documents — max prior
-   N + 1 (1 when none yet). A pure function of prior app-db state, so it
-   replays identically."
+  "Next `:doc-N` id: highest existing N plus one (or 1 when there are
+   none). A pure function of the current documents, so it replays
+   identically — see the note above."
   [documents]
   (let [used-ns (->> documents
                      (keep (fn [{id :id}]
@@ -110,10 +118,12 @@
 (rf/reg-sub :notebook/selected-id
   (fn [db _] (:notebook/selected-id db)))
 
-;; A composed sub: `:<-` names this sub's inputs (other subs), so it
-;; recomputes only when the documents or the selected id actually change.
-;; The downstream subs (`-body`, `-hiccup`) chain off this one in turn.
-;; See docs/guide/concepts/subscriptions.md.
+;; Subs compose. The `:<-` lines wire this sub's inputs to other subs —
+;; here, the documents and the selected id — and the body below is a plain
+;; function of their values. The payoff is that it recomputes only when
+;; one of those inputs actually changes, and the subs downstream (`-body`,
+;; `-hiccup`) chain off this one in the same way. A little graph of pure
+;; derivations. See docs/guide/concepts/subscriptions.md.
 (rf/reg-sub :notebook/selected
   :<- [:notebook/documents]
   :<- [:notebook/selected-id]
@@ -128,49 +138,53 @@
 ;; MARKDOWN — tiny pure parser → hiccup
 ;; ============================================================================
 ;;
-;; The parser emits hiccup (vectors of keywords + child vectors) rather
-;; than raw HTML strings — Reagent renders hiccup natively without the
-;; `dangerouslySetInnerHTML` escape hatch, and the example stays free of
-;; an extra npm dependency.
+;; The trick here is the output: hiccup, not HTML strings. Reagent renders
+;; hiccup natively, so we never reach for `dangerouslySetInnerHTML` — the
+;; markdown becomes ordinary data flowing through the same pipeline as
+;; everything else. Bonus: no markdown library to pull in.
 
 (def ^:private safe-link-schemes
-  "Allowlist of URI schemes a markdown link may carry in the preview.
-   Anything else (notably `javascript:` and `data:`) is treated as
-   unsafe and rendered as inert text rather than a clickable anchor."
+  "The preview renders user-typed markdown, so a link is attacker-typed
+   input. We allowlist rather than blocklist: only these schemes get to
+   be clickable. Everything else — `javascript:`, `data:`, and friends —
+   is shown as plain text. Saying yes to a known-good set is far safer
+   than trying to enumerate every way a link can be hostile."
   #{"http" "https" "mailto"})
 
 (defn- safe-href
-  "Return `href` when it is safe to put on an `:a {:href ...}` in the
-   preview, else nil. Safe = an allowlisted absolute scheme, or a
-   scheme-less link (relative path or `#fragment`). Scheme detection
-   matches a leading `word:` prefix per RFC 3986 §3.1; a `:` that only
-   appears after a `/`, `?` or `#` is part of the path/query/fragment,
-   not a scheme, so such links are scheme-less and allowed."
+  "Decide whether `href` is safe to drop into `:a {:href ...}`; return it
+   if so, nil if not. Two things pass: an allowlisted absolute scheme, and
+   a scheme-less link (a relative path or `#fragment`, which can't run
+   code). The fiddly bit is telling a real scheme from a colon that just
+   happens to sit in a path. Per RFC 3986 §3.1 a scheme is a `word:`
+   prefix at the very start; a `:` that shows up only after a `/`, `?` or
+   `#` belongs to the path/query/fragment, so the link counts as
+   scheme-less and is allowed."
   [href]
   (let [h (str/trim (or href ""))
-        ;; A scheme is `ALPHA *( ALPHA / DIGIT / + / - / . ) :` at the
-        ;; very start. If the first `:` is preceded by a `/`, `?` or `#`
-        ;; it is not a scheme delimiter.
+        ;; Match a scheme — ALPHA then ALPHA/DIGIT/+/-/. — anchored to the
+        ;; start. Anchoring is the whole point: a `:` further in isn't a
+        ;; scheme delimiter and won't match here.
         m      (re-find #"(?i)^([a-z][a-z0-9+.-]*):" h)
         scheme (some-> m second str/lower-case)]
     (cond
       ;; No leading scheme → relative path or fragment → safe.
       (nil? scheme) href
-      ;; Allowlisted absolute scheme → safe.
+      ;; A scheme we trust → safe.
       (contains? safe-link-schemes scheme) href
-      ;; Anything else (javascript:, data:, vbscript:, …) → unsafe.
+      ;; Anything else (javascript:, data:, vbscript:, …) → not on our watch.
       :else nil)))
 
 (defn- split-by-regex
-  "Walk `coll` (a flat seq of strings + hiccup-vectors). For each
-   string element, find non-overlapping matches of `re`; each match
-   produces a hiccup element via `(mk match)`. Return a new flat seq
-   with strings split around matches and matches replaced. Non-string
-   elements (already-parsed hiccup) pass through untouched.
+  "The one moving part the inline parser is built on. Given a flat seq of
+   strings and already-built hiccup vectors, find every match of `re` in
+   the *strings* and replace each with `(mk match)`, leaving the text
+   around them intact. Hiccup vectors are already done, so they ride
+   through untouched — which is how we run several passes in a row without
+   one pass clobbering another's work.
 
-   Loops `re-find` one match at a time and pulls the before/after
-   substrings from the source manually (via `.indexOf` + `subs`),
-   recurring on the remaining tail."
+   It walks one `re-find` at a time, slices the before/after text out of
+   the source by hand (`.indexOf` + `subs`), and recurs on the tail."
   [coll re mk]
   (mapcat
     (fn [x]
@@ -191,22 +205,24 @@
     coll))
 
 (defn- inline-md->hiccup
-  "Parse one paragraph string into a hiccup seq with inline runs
-   (links, bold, italic, code) split out. Output is a flat seq the
-   caller splices into a parent block element. Rules run sequentially;
-   later passes only see plain-text fragments from earlier passes
-   (already-emitted hiccup vectors pass through untouched)."
+  "Turn one block of text into a flat seq of hiccup, pulling out the
+   inline runs — links, bold, italic, code — as it goes. The caller
+   splices the result into a parent element. The passes run one after
+   another, and each only ever sees the plain-text leftovers of the ones
+   before it (the hiccup they emitted just rides along), so a `**bold**`
+   pass can't accidentally chew on the innards of a link it shouldn't
+   touch. Simple rules, layered."
   [s]
   (-> [s]
       (split-by-regex #"\[([^\]]+)\]\(([^)]+)\)"
                       (fn [m]
                         (let [text (nth m 1)]
-                          ;; Sanitize the destination: only allowlisted
-                          ;; schemes (and scheme-less relative links)
-                          ;; become clickable anchors. Disallowed schemes
-                          ;; — `javascript:`, `data:`, … — render as inert
-                          ;; text so the preview never exposes an unsafe
-                          ;; clickable link on this user-controlled surface.
+                          ;; Run the destination past safe-href before
+                          ;; trusting it. A safe link becomes a real
+                          ;; anchor; anything dodgy degrades to plain text,
+                          ;; so a hostile `javascript:` URL in the markdown
+                          ;; renders harmlessly instead of becoming a
+                          ;; clickable trap.
                           (if-let [href (safe-href (nth m 2))]
                             [:a {:href   href
                                  :rel    "noopener noreferrer"
@@ -248,14 +264,17 @@
     (into [:p] (inline-md->hiccup block))))
 
 (defn markdown->hiccup
-  "Tiny pure-CLJS markdown parser: splits on blank lines, dispatches per
-   block-shape, runs inline rules. Sufficient for the example's seed
-   content. Returns a vector of block hiccup that the caller splices
-   into a parent container (Reagent renders this as a seq of children;
-   each block gets a content-derived :key so React preserves block
-   identity across edits that insert/remove/reorder blocks — an index
-   :key would re-key every block below an edit). Identical blocks are
-   disambiguated by their position so the keys stay unique."
+  "The whole parser, top level. Split the text on blank lines into blocks,
+   figure out each block's shape (heading? list? paragraph?), and run the
+   inline rules over it. Just enough markdown for the seed content.
+
+   Returns a vector of block hiccup for the caller to splice into a
+   container. The fiddly detail is the `:key` on each block. React renders
+   these as a list, and it uses keys to decide what moved versus what's
+   new. We key by content (its hash), not by index — index keys would
+   re-key every block below an edit and make React redraw the lot, when
+   all you did was add a sentence. Two identical blocks would collide, so
+   we mix in the position to keep keys unique."
   [s]
   (let [blocks (->> (str/split (or s "") #"\r?\n\r?\n")
                     (remove str/blank?))]
@@ -271,6 +290,13 @@
 ;; ============================================================================
 ;; VIEWS — shared 'Editorial Warm' palette
 ;; ============================================================================
+;;
+;; `reg-view` reads like a `defn`, and it is one — plus it registers the
+;; view and hands you `dispatch` and `subscribe` as ready-to-call locals.
+;; No `rf/` prefix, no frame to thread through; they find the frame in
+;; scope at render time on their own. Each view below just subscribes to
+;; what it needs and dispatches on interaction — pure functions of state,
+;; nothing reaching out to mutate. See docs/guide/concepts/views.md.
 
 (reg-view sidebar []
   (let [docs        @(subscribe [:notebook/documents])
@@ -327,26 +353,29 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; Lazy mount: defer `create-root` to `run` so loading the namespace has no
-;; DOM side effect. Many example namespaces share one DOM in the
-;; `:browser-test` bundle, so a `create-root` at ns-load would race roots
-;; onto the same container. See examples/TESTING.md (mount-isolation
-;; convention).
+;; Loading this namespace touches the DOM exactly never. We hold off on
+;; `create-root` until `run` is called. The reason is the test bundle:
+;; many example namespaces get loaded into one page there, and if each one
+;; grabbed a root the moment it loaded, they'd all fight over the same
+;; container. Defer the mount and they stay out of each other's way. See
+;; examples/TESTING.md (mount-isolation convention).
 
 (defonce react-root (atom nil))
 
-;; The frame is established in one spot: the `frame-provider {:id app-frame}`
-;; in the render call below. On first mount it creates the frame and runs
-;; `:initial-events` once to seed app-db before the first paint; on hot reload
-;; it reuses the same frame and skips the seed. Every in-tree
-;; `dispatch`/`subscribe` then resolves to that frame. `app-frame` is an
-;; ordinary frame id with no special privilege. See
+;; re-frame2 won't conjure a frame for you — an app stands up its own. We
+;; do it in exactly one place: the `frame-provider {:id app-frame}` in the
+;; render call below. First mount creates the frame and fires
+;; `:initial-events` once to seed app-db before anything paints; a hot
+;; reload finds the frame already there and skips the seed. From then on
+;; every `dispatch` and `subscribe` in the tree resolves to it. The name
+;; `:rf/default` is just an id — pick any keyword; it earns no special
+;; privileges for being the only one here. See
 ;; docs/guide/concepts/frames.md.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the Reagent adapter. The frame itself is created by the
-  ;; `frame-provider` in the render call below.
+  ;; One job each: `init!` tells the runtime to render through Reagent. It
+  ;; does not make a frame — the `frame-provider` below does that.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/realworld/article_editor.cljs
+++ b/examples/reagent/realworld/article_editor.cljs
@@ -1,34 +1,35 @@
 (ns realworld.article-editor
   "Article editor for the RealWorld (Conduit) example.
 
-   This namespace shows:
-   - One parallel state machine `:ui/article-editor` with two orthogonal
-     regions (`:mode` x `:lifecycle`). See the machines guide on parallel
-     regions: ../../../docs/machines/concepts.md#when-the-machine-grows.
-   - A form whose draft / errors / touched / submit-error slice lives in
-     app-db (`:editor`); the machine carries only the state vocabulary.
-     `:editor/dirty?` is a draft-vs-baseline sub, not a machine concern.
-     See the forms how-to: ../../../docs/guide/how-to/build-a-form.md.
-   - The view's input-busy and Delete-button visibility are tag queries
+   Create or edit an article — same form, two modes — and along the way this
+   file shows off a state machine, a flow, and tag-driven views all working
+   together. Worth a read for:
+
+   - One parallel state machine `:ui/article-editor`, two orthogonal regions
+     (`:mode` x `:lifecycle`). See the machines guide on parallel regions:
+     ../../../docs/machines/concepts.md#when-the-machine-grows.
+   - A form that splits the work cleanly: the draft / errors / touched /
+     submit-error data lives in an app-db slice (`:editor`), while the machine
+     carries only the state vocabulary. `:editor/dirty?` is just a
+     draft-vs-baseline sub — no machine involved. See the forms how-to:
+     ../../../docs/guide/how-to/build-a-form.md.
+   - The view asking the machine yes/no questions through tag queries
      (`(rf/machine-has-tag? :ui/article-editor :editor/busy)` and
-     `(rf/machine-has-tag? :ui/article-editor :editor/can-delete)`) instead
-     of boolean subs.
-   - The view's root is a `case` over `:article-editor/render`, a selector
-     sub that reads a render-priority table against the machine's tag
-     union."
+     `… :editor/can-delete`) instead of hand-rolled boolean subs.
+   - The view's root: one `case` over `:article-editor/render`, a selector sub
+     that reads a render-priority table against the machine's tag union."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            ;; State machines ship in the re-frame2-machines artefact.
-            ;; Requiring the ns registers its hooks so `rf/reg-machine`
-            ;; (called below) and the `:rf/machine` subs resolve. See the
-            ;; machines guide: ../../../docs/machines/index.md
+            ;; State machines live in their own artefact; we require it to load
+            ;; it, which registers the hooks that make `rf/reg-machine` (below)
+            ;; and the `:rf/machine` subs resolve. See the machines guide:
+            ;; ../../../docs/machines/index.md
             [re-frame.machines]
-            ;; Flows ship in the re-frame2-flows artefact. The editor
-            ;; registers a `:editor/can-submit?` flow (see :editor/initialise
-            ;; below) that materialises "valid AND dirty" into app-db.
-            ;; Requiring the ns registers its hooks so the `:rf.fx/reg-flow`
-            ;; effect resolves. See the flows guide:
-            ;; ../../../docs/guide/concepts/flows.md
+            ;; Flows live in their own artefact too. The editor registers a
+            ;; `:editor/can-submit?` flow (see :editor/initialise below) that
+            ;; keeps "valid AND dirty" materialised in app-db. Requiring the ns
+            ;; registers the hooks behind the `:rf.fx/reg-flow` effect. See the
+            ;; flows guide: ../../../docs/guide/concepts/flows.md
             [re-frame.flows]
             [realworld.schema :as schema]
             [realworld.http :as rh])
@@ -50,9 +51,9 @@
        vec))
 
 (defn editor-slice
-  "The form's app-db slice: draft, baseline, errors, touched,
-   submit-attempted?, submit-error. The machine carries the state
-   vocabulary; this slice carries the data."
+  "The form's app-db slice — draft, baseline, errors, touched,
+   submit-attempted?, submit-error. Division of labour: the machine owns the
+   state vocabulary, this slice owns the data."
   ([] (editor-slice nil blank-draft))
   ([slug baseline]
    {:slug              slug
@@ -74,28 +75,31 @@
 ;; THE FLOW — :editor/can-submit?
 ;; ============================================================================
 ;;
-;; This is the example's worked flow. `:editor/can-submit?` materialises a
-;; derived boolean — "the draft passes validation AND differs from the
-;; loaded baseline" — into app-db at `[:editor :can-submit?]`.
+;; This is the example's worked flow, and it answers a deceptively small
+;; question: should the Submit button be live? `:editor/can-submit?` keeps a
+;; derived boolean — "the draft validates AND differs from the loaded
+;; baseline" — sitting in app-db at `[:editor :can-submit?]`, recomputed
+;; whenever its inputs move.
 ;;
-;; Why a flow and not a sub: the `:editor/submit` handler reads this value
-;; as plain app-db data to gate the submit. A flow keeps the gate as
-;; ordinary state the handler reads with `get-in`; a sub would force the
-;; handler to `subscribe` mid-handler. The submit-button-disabled view
-;; reads the same value through a plain sub over the flow's `:output-path`.
-;; See the flows guide on when a derivation earns app-db:
+;; Why a flow rather than a plain sub? Because `:editor/submit` needs to read
+;; this gate as ordinary app-db data, with a `get-in`. A flow makes the
+;; derived value just another fact in app-db; a sub would drag the handler
+;; into `subscribe`-mid-handler territory, which is exactly the kind of thing
+;; that turns a tidy handler into a knot. And the view that disables the button
+;; reads the very same value through a plain sub over the flow's
+;; `:output-path` — one source of truth, two readers. See the flows guide on
+;; when a derivation earns a place in app-db:
 ;; ../../../docs/guide/concepts/flows.md#when-a-derivation-earns-app-db
 ;;
-;; The flow registers per-frame via `:rf.fx/reg-flow` from
-;; `:editor/initialise` (below), so it binds to whatever frame the app
-;; boots on — the default frame in the browser, and each frame the
-;; headless fixtures create.
+;; The flow registers per-frame via `:rf.fx/reg-flow` from `:editor/initialise`
+;; (below), so it binds to whichever frame the app booted on — the default one
+;; in the browser, or each throwaway frame a headless fixture spins up.
 
 (def can-submit-flow
   {:id     :editor/can-submit?
-   :doc    "True when the editor draft is valid AND dirty (differs from the
-            loaded baseline). Materialised into app-db so the submit
-            handler can read it as plain data."
+   :doc    "True when the editor draft is both valid AND dirty (it differs from
+            the loaded baseline). Kept in app-db so the submit handler can read
+            it as plain data."
    :inputs [[:editor :draft] [:editor :baseline]]
    :derive (fn [draft baseline]
              (and (empty? (validate-draft draft))
@@ -112,22 +116,23 @@
 ;; THE MACHINE — :ui/article-editor  (one machine, two regions)
 ;; ============================================================================
 ;;
-;; The article editor has two orthogonal axes:
+;; Two independent questions about the editor, so two regions:
 ;;
-;;   :mode      — :create (the /editor route, POST to /articles) vs
-;;                :edit (the /editor/:slug route, PUT to /articles/:slug
-;;                and a Delete button). The :edit state also emits the
-;;                :editor/can-delete tag so the view can ask a tag-shaped
-;;                question without inspecting the region directly.
+;;   :mode      — are we creating or editing? :create is the /editor route
+;;                (POST to /articles); :edit is /editor/:slug (PUT to
+;;                /articles/:slug, plus a Delete button). The :edit state also
+;;                lights the :editor/can-delete tag, so the view can ask "show
+;;                the Delete button?" as a tag question instead of reaching into
+;;                the region.
 ;;
-;;   :lifecycle — the form lifecycle: :idle | :loading | :submitting
-;;                | :saved | :error. The :loading and :submitting states
-;;                emit the :editor/busy tag so the view can disable
-;;                inputs without a separate `:submitting?` sub.
+;;   :lifecycle — where the form is in its life: :idle | :loading |
+;;                :submitting | :saved | :error. :loading and :submitting both
+;;                fly the :editor/busy tag, which is how the view greys out the
+;;                inputs without needing a separate `:submitting?` sub.
 ;;
-;; Every event delivered to the machine reaches every region. Region-
-;; distinct event names avoid collisions; each region handles `:reset` as
-;; a self-target.
+;; As always with a parallel machine, every event reaches every region — so the
+;; region event names stay distinct to avoid crosstalk, and each region treats
+;; `:reset` as a self-target.
 
 (def editor-machine
   {:type :parallel
@@ -178,17 +183,17 @@
               :reset            :idle}}
 
       :saved
-      ;; Transient post-submit-success state. The :editor/submit-success
-      ;; handler navigates to the article detail page immediately, so
-      ;; this state is short-lived; included for completeness.
+      ;; A blink-and-you'll-miss-it state. :editor/submit-success navigates
+      ;; straight to the article detail page, so we're barely here — but it's
+      ;; in the table so the lifecycle is honestly complete.
       {:tags #{:lifecycle/saved}
        :on   {:reset :idle}}
 
       :error
-      ;; Load-failed state. Submit-failed returns to :idle so the user
-      ;; can retry; load-failed lands here so the view can show the
-      ;; error banner. The submit-error message lives in the editor
-      ;; slice; this state is the page-level render gate.
+      ;; This is the LOAD-failed state specifically. A submit failure sends you
+      ;; back to :idle to try again; a load failure lands here so the page can
+      ;; raise an error banner. (The actual submit-error message lives in the
+      ;; editor slice — this state is just the page-level render gate.)
       {:tags #{:lifecycle/error}
        :on   {:fetch-started  :loading
               :submit-started :submitting
@@ -201,21 +206,21 @@
 ;; ============================================================================
 
 (rf/reg-event :editor/initialise
-  {:doc "Reset the editor slice + machine, and register the
-         `:editor/can-submit?` flow against the dispatching frame. The
-         flow's first walk fires on the next drain; a fresh editor starts
-         invalid and clean anyway, so the one-event lag carries no stale
-         value."}
+  {:doc "Wipe the editor slice and machine back to a clean start, and register
+         the `:editor/can-submit?` flow against the dispatching frame. The
+         flow's first computation doesn't run until the next drain — but a
+         fresh editor is invalid and clean anyway, so the one-event lag never
+         shows a stale value. The timing works out for free."}
   (fn [{:keys [db]} _]
     {:db (assoc db :editor (editor-slice))
      :fx [[:dispatch [:ui/article-editor [:reset]]]
           [:rf.fx/reg-flow can-submit-flow]]}))
 
 (rf/reg-event :editor/load-article
-  {:doc "Load an existing article into the editor in :edit mode. The
-         data-fetch retry policy applies. Broadcasts `:use-edit` so the
-         :mode region tracks the edit-load and `:fetch-started` so the
-         :lifecycle region advances to :loading."
+  {:doc "Pull an existing article into the editor for editing. The house
+         data-fetch retry policy applies. Broadcasts `:use-edit` so the :mode
+         region flips to edit, and `:fetch-started` so the :lifecycle region
+         moves to :loading while the fetch is out."
    :rf.http/decode-schemas [schema/ArticleResponse]}
   ;; The route lives in runtime-db.
   (fn [{:keys [db] rt :rf.db/runtime} _]
@@ -255,20 +260,20 @@
     {:db (update-in db [:editor :touched] (fnil conj #{}) field)}))
 
 (rf/reg-event :editor/submit
-  {:doc "Save the article (POST for create, PUT for edit). No retry — one
-         submission per click; surface errors so the user can decide
-         whether to retry.
+  {:doc "Save the article — POST to create, PUT to edit. No retry; it's one
+         submission per click, and any error is surfaced so the user gets to
+         decide whether to try again.
 
-         Reads the current `:mode` region's state to decide POST vs PUT.
-         Broadcasts `:submit-started` into the lifecycle region; the
+         It checks the `:mode` region to pick POST vs PUT, broadcasts
+         `:submit-started` into the lifecycle region, and lets the
          `:on-success` / `:on-failure` replies broadcast
          `:submit-succeeded` / `:submit-failed`.
 
-         The guard reads the `:editor/can-submit?` flow output straight off
-         app-db — a derived value the handler consumes as plain data. When
-         the form is unchanged (valid but not dirty) the flow is false and
-         the submit is a no-op; an invalid draft re-runs validation to
-         populate the per-field error map for display."
+         The gate is the `:editor/can-submit?` flow output, read straight off
+         app-db as plain data. Valid-but-unchanged → the flow is false and the
+         whole submit is a harmless no-op; an invalid draft re-runs validation
+         to fill in the per-field error map for display. So the button being
+         disabled and the handler bailing out agree, by construction."
    :rf.http/decode-schemas [schema/ArticleResponse]}
   ;; The machine snapshot lives in runtime-db.
   (fn [{:keys [db] rt :rf.db/runtime} _]
@@ -278,17 +283,18 @@
           can-submit? (get-in db [:editor :can-submit?])
           errors      (validate-draft draft)]
       (cond
-        ;; Valid but unchanged → nothing to save (the submit button is
-        ;; disabled in this state via the :editor/can-submit? sub, so this
-        ;; is the belt-and-braces no-op for programmatic dispatch).
+        ;; Valid but unchanged → nothing to save. The button is already
+        ;; disabled in this state (via the :editor/can-submit? sub), so this
+        ;; branch is the belt-and-braces guard for a programmatic dispatch that
+        ;; sidesteps the button entirely.
         (and (not can-submit?) (empty? errors))
         {}
 
         (seq errors)
-        ;; Client-side validation failure. Flip :submit-attempted? so the
-        ;; per-field error subs reveal every error, even on untouched
-        ;; fields. The whole-form prompt lives in `:errors :_form`;
-        ;; transport failures land in `:submit-error` (the HTTP path).
+        ;; Validation failed on the client. Flip :submit-attempted? so every
+        ;; per-field error shows, even on fields the user never touched. The
+        ;; whole-form prompt sits in `:errors :_form`; transport failures take
+        ;; a different door — `:submit-error`, on the HTTP path.
         {:db (-> db
                  (assoc-in [:editor :submit-attempted?] true)
                  (assoc-in [:editor :errors] (assoc errors :_form "Please fix the highlighted fields."))
@@ -326,17 +332,18 @@
      :fx [[:dispatch [:ui/article-editor [:submit-failed]]]]}))
 
 (rf/reg-event :editor/delete
-  {:doc "Delete the article. No retry — destructive action, one click.
-         Broadcasts `:submit-started` so the lifecycle region advances
-         to :submitting (which carries the :editor/busy tag)."}
+  {:doc "Delete the article. No retry — destructive, one click. Broadcasts
+         `:submit-started` to push the lifecycle region into :submitting (which
+         flies the :editor/busy tag, so the form locks while it's working)."}
   (fn [{:keys [db]} _]
     (let [slug (get-in db [:editor :slug])]
       {:fx [[:dispatch [:ui/article-editor [:submit-started]]]
             [:rf.http/managed
              (rh/request {:method     :delete
                           :path       (str "/articles/" slug)
-                          ;; The delete endpoint returns no body; :auto
-                          ;; handles 204/empty gracefully.
+                          ;; A successful DELETE comes back empty (a 204), so
+                          ;; `:auto` is the right call — it shrugs at an empty
+                          ;; body instead of trying to parse one.
                           :decode     :auto
                           :on-success [:editor/delete-success]
                           :on-failure [:editor/delete-error]})]]})))
@@ -365,9 +372,10 @@
   (fn [editor _] (:submit-error editor)))
 
 (rf/reg-sub :editor/field-error
-  {:doc "Per-field validation error. Reveal every error after the first
-         submit click, or once the field is :touched. See the forms
-         how-to: ../../../docs/guide/how-to/build-a-form.md"}
+  {:doc "The validation error for one field, or nil while we keep mum. Same
+         courtesy as every other form here: nothing shown until the field is
+         touched or the user has tried to submit. See the forms how-to:
+         ../../../docs/guide/how-to/build-a-form.md"}
   :<- [:editor/slice]
   (fn [editor [_ field]]
     (when (or (:submit-attempted? editor)
@@ -375,8 +383,8 @@
       (get-in editor [:errors field]))))
 
 (rf/reg-sub :editor/form-error
-  {:doc "Whole-form prompt (the :_form key under :errors) — populated
-         when a submit attempt failed client-side validation."}
+  {:doc "The one-line, whole-form nudge (the :_form key under :errors) —
+         set when a submit attempt tripped client-side validation."}
   :<- [:editor/slice]
   (fn [editor _]
     (when (:submit-attempted? editor)
@@ -387,12 +395,12 @@
     (not= (:draft editor) (:baseline editor))))
 
 (rf/reg-sub :editor/can-submit?
-  {:doc "Reads the `:editor/can-submit?` flow output at its app-db
-         :output-path. A flow's output is ordinary app-db state, so
-         consumers read it through a plain sub over the path — there is no
-         special flow sub-id. Drives the submit button's disabled
-         attribute. nil until the flow's first walk lands, which
-         `(boolean ...)` normalises to false."}
+  {:doc "Reads the `:editor/can-submit?` flow's output at its app-db
+         :output-path. A flow's output is just ordinary app-db state, so you
+         read it with a plain sub over the path — there's no special
+         flow-sub-id to learn. This one drives the submit button's `:disabled`.
+         It's nil until the flow's first computation lands, which the
+         `(boolean ...)` wrapper tidies into a plain false."}
   (fn [db _]
     (boolean (get-in db [:editor :can-submit?]))))
 
@@ -403,18 +411,17 @@
 
 ;; ---- render-priority + :article-editor/render selector ----
 ;;
-;; The render-priority table is plain data: a vector of {:tag :render}
-;; pairs consulted in order. The `:article-editor/render` sub reads the
-;; machine's tag union and returns the first :render whose :tag is
-;; present. The editor view's `case` over the resolved keyword is the
-;; only branch site.
+;; Same data-driven trick as the home page: a plain vector of {:tag :render}
+;; pairs, read in order. `:article-editor/render` looks at the machine's active
+;; tags and returns the first :render whose :tag is present, and the editor
+;; view's `case` on that keyword is the only place anything branches.
 ;;
-;; Priority rationale: the lifecycle region drives the gate. `:error`
-;; (load-failed) shows the form with the error banner. `:loading`
-;; (edit-mode initial fetch in flight) shows the form with busy inputs.
-;; `:saved` is a transient state immediately followed by navigation;
-;; included so the table is complete. Default is `:editing` — the form
-;; in its normal interactive state.
+;; The order is the policy, and here the lifecycle region calls the shots:
+;; `:error` (load failed) shows the form with an error banner; `:loading`
+;; (edit-mode's opening fetch) shows the form with greyed-out inputs; `:saved`
+;; is the blink-state right before navigation, listed only so the table's
+;; honest. Everything else falls through to `:editing` — the form just being a
+;; form.
 
 (def render-priority
   [{:tag :lifecycle/error      :render :error}
@@ -424,9 +431,9 @@
    {:tag :lifecycle/idle       :render :editing}])
 
 (rf/reg-sub :article-editor/render
-  {:doc "Resolve the editor's render-model keyword by consulting the
-         render-priority table against the `:ui/article-editor` machine's
-         tag union. The root view's `case` is the only branch site."}
+  {:doc "Reduce the `:ui/article-editor` machine's active tags to a single
+         render keyword, via the render-priority table. The root view's `case`
+         on it is the one and only branch site."}
   :<- [:rf/machine :ui/article-editor]
   (fn sub-editor-render [snap _]
     (let [tags (:tags snap)]
@@ -438,9 +445,10 @@
 ;; VIEWS
 ;; ============================================================================
 
-(reg-view ^{:doc "The shared editor form. Rendered by every render-mode;
-                   `:editor/busy` disables inputs, `:editor/can-delete`
-                   shows the Delete button."}
+(reg-view ^{:doc "The one editor form, shared by every render-mode. It leans on
+                   the machine's tags to adapt: `:editor/busy` greys out the
+                   inputs, `:editor/can-delete` reveals the Delete button. One
+                   form, two modes, no duplication."}
           editor-form []
   (let [draft        @(subscribe [:editor/draft])
         title-err    @(subscribe [:editor/field-error :title])
@@ -506,8 +514,9 @@
              :disabled    busy?
              :on-change   #(dispatch [:editor/edit-field :tagList (.. % -target -value)])}]]
           [:button.btn.btn-lg.pull-xs-right.btn-primary
-           ;; Disabled while busy, or while the :editor/can-submit? flow is
-           ;; false (draft invalid or unchanged).
+           ;; Off while a request is in flight, and off while the
+           ;; :editor/can-submit? flow is false (nothing valid or nothing
+           ;; changed to save).
            {:type "submit" :disabled (or busy? (not can-submit?))}
            (if can-delete? "Update Article" "Publish Article")]
           (when can-delete?
@@ -519,31 +528,32 @@
 
 ;; ---- per-render-state subviews ----
 ;;
-;; Every render-mode delegates to `editor-form`; the form's own tag
-;; queries (`:editor/busy`, `:editor/can-delete`) handle the in-form
-;; differences. Keeping them as separate reg-views gives one cheap site to
-;; add render-mode-specific scaffolding (a full-page spinner, a dedicated
-;; load-error layout) without touching the case branch.
+;; Right now every render-mode just delegates to `editor-form`, and the form's
+;; own tag queries (`:editor/busy`, `:editor/can-delete`) sort out the
+;; in-form differences. So why four wrappers that all do the same thing? They
+;; give you one cheap, obvious hook per mode for the day you want
+;; mode-specific scaffolding — a full-page spinner, a bespoke load-error layout
+;; — without having to crack open the `case` branch to do it.
 
-(reg-view ^{:doc "Lifecycle :idle / :submitting — the form in its normal
-                   interactive (or busy) state."}
+(reg-view ^{:doc "Lifecycle :idle / :submitting — the form being a form
+                   (interactive, or busy mid-save)."}
           editor-editing []
   [editor-form])
 
-(reg-view ^{:doc "Lifecycle :loading — edit-mode initial fetch in flight.
-                   Renders the form with disabled inputs (the :editor/busy
+(reg-view ^{:doc "Lifecycle :loading — edit mode's opening fetch is in flight.
+                   The form, with its inputs greyed out (the :editor/busy
                    tag)."}
           editor-loading []
   [editor-form])
 
-(reg-view ^{:doc "Lifecycle :error — load failed. Renders the form with
-                   the submit-error banner."}
+(reg-view ^{:doc "Lifecycle :error — the load failed. The form, with the
+                   submit-error banner up top."}
           editor-error []
   [editor-form])
 
-(reg-view ^{:doc "Lifecycle :saved — transient post-submit-success state.
-                   The :editor/submit-success handler navigates
-                   immediately, so this view is rarely visible."}
+(reg-view ^{:doc "Lifecycle :saved — the blink-state after a successful save.
+                   :editor/submit-success navigates away at once, so you'll
+                   almost never actually see this one."}
           editor-saved []
   [editor-form])
 

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -1,30 +1,35 @@
 (ns realworld.articles
   "Home-page article feeds for the RealWorld (Conduit) example.
 
-   This namespace shows:
-   - One parallel state machine with three orthogonal regions
+   The home page looks simple — a list of articles — but it's juggling three
+   independent questions at once: which feed are you looking at, is a tag
+   filter on, and where is the data in its load. That's a textbook fit for a
+   parallel state machine, and this namespace is the worked example. Worth a
+   read for:
+
+   - One parallel state machine, three orthogonal regions
      (`:feed` x `:filter` x `:data`). See the machines guide on parallel
      regions: ../../../docs/machines/concepts.md#when-the-machine-grows.
-   - A remote-data lifecycle tracked by the `:data` region. The region's
-     state-keyword drives the home-page render decision. The `:articles`
-     and `:feed` slices keep the plain 5-key slice shape so their items
-     live in app-db and favorites.cljs's optimistic updates can scan
-     across slices. The machine's `:data` region tracks the same lifecycle
-     and owns the render decision. See the `:data` region note below.
-   - Route-driven loading: the `/tag/:tag` route filters the list and
-     `?feed=following` switches to the authenticated feed (the official
-     RealWorld contract shapes). Each navigation broadcasts the matching
-     feed-region transition.
-   - Home-page tabs expressed as feed-region transitions.
-   - The home view's root is a `case` over `:articles.home/render`, a
-     selector sub that reads a render-priority table against the machine's
-     tag union.
-   - View reuse across the home page and profile pages."
+   - A remote-data lifecycle tracked by the `:data` region, whose
+     state-keyword drives the whole home-page render decision. The `:articles`
+     and `:feed` slices keep the plain 5-key slice shape so their items live
+     in app-db where favorites.cljs's optimistic updates can reach across and
+     patch them. (More on why the machine and the slice coexist in the `:data`
+     region note below.)
+   - Route-driven loading: `/tag/:tag` filters the list and `?feed=following`
+     switches to the authenticated feed — both the official RealWorld URL
+     shapes. Each navigation broadcasts the matching feed-region transition.
+   - Home-page tabs, expressed as feed-region transitions rather than ad-hoc
+     flags.
+   - The home view's root: a single `case` over `:articles.home/render`, a
+     selector sub that reads a render-priority table against the machine's tag
+     union.
+   - One article card reused across the home page and the profile pages."
   (:require [re-frame.core :as rf]
-            ;; State machines ship in the re-frame2-machines artefact.
-            ;; Requiring the ns registers its hooks so `rf/reg-machine`
-            ;; (called below) and the `:rf/machine` subs resolve. See the
-            ;; machines guide: ../../../docs/machines/index.md
+            ;; State machines live in their own artefact; we require it just to
+            ;; load it, which registers the hooks that make `rf/reg-machine`
+            ;; (below) and the `:rf/machine` subs resolve. See the machines
+            ;; guide: ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld-shared.avatar :as avatar]
             [realworld.schema :as schema]
@@ -38,47 +43,50 @@
 ;; THE MACHINE — :realworld/articles-home  (one machine, three regions)
 ;; ============================================================================
 ;;
-;; The home page has three orthogonal axes:
+;; Three independent questions, three regions. The trick of a parallel machine
+;; is that each axis gets to evolve on its own, instead of being mashed into
+;; one combinatorial blob of states:
 ;;
-;;   :feed   — which feed is rendered (global / your-feed / tag-filtered
-;;             global). The state-keyword tells the view which app-db
-;;             slice's items to read from (`:articles` for :global and
-;;             :tag-feed; `:feed` for :user-feed). Driven by the
-;;             home navigation events: the following toggle rides the
-;;             `?feed=following` query, and the tag filter is the
+;;   :feed   — which feed you're looking at (global / your-feed / tag-filtered
+;;             global). Its state-keyword tells the view which app-db slice to
+;;             read items from (`:articles` for :global and :tag-feed, `:feed`
+;;             for :user-feed). Driven by home navigation: the following toggle
+;;             rides the `?feed=following` query, and the tag filter is the
 ;;             `/tag/:tag` PATH route (`:realworld/home-tag`).
 ;;
-;;   :filter — whether a tag filter is active. Always `:tagged` whenever
-;;             :feed is :tag-feed; tracked as a separate region so views
-;;             that render the filter chip can ask a tag-shaped question
-;;             without inspecting the feed region.
+;;   :filter — is a tag filter on? It's always `:tagged` whenever :feed is
+;;             :tag-feed, but it earns its own region so a view rendering the
+;;             filter chip can ask a tag-shaped question without poking at the
+;;             feed region to infer the answer.
 ;;
-;;   :data   — the data lifecycle for whichever feed is active. The
-;;             region's state-keyword drives the home-page render decision
-;;             (via the render-priority table + the `:articles.home/render`
-;;             selector sub); the view never branches on the slice's
-;;             `:status`. The :resolving eventless microstep picks `:empty`
-;;             or `:some` from the count stored in the machine's `:data`.
+;;   :data   — where the active feed is in its load. This region's
+;;             state-keyword drives the entire home-page render decision (via
+;;             the render-priority table + the `:articles.home/render`
+;;             selector sub), so the view never has to branch on a slice's
+;;             `:status`. The `:resolving` eventless microstep then peeks at
+;;             the count in the machine's `:data` to decide between `:empty`
+;;             and `:some`.
 ;;
-;;             The `:articles` slice keeps the plain 5-key slice shape: its
-;;             article items live in app-db so favorites.cljs's optimistic
-;;             updates can scan across slices, and the slice keeps its
-;;             `:status` field. The machine's `:data` region tracks the
-;;             same lifecycle and owns the render decision. tags.cljs and
-;;             settings.cljs show the other shape, where the lifecycle
-;;             lives entirely in the machine and there is no slice.
+;;             So why keep BOTH a machine region and an `:articles` slice? The
+;;             slice keeps the plain 5-key shape because its article items have
+;;             to live in app-db, where favorites.cljs can reach across slices
+;;             and patch them. The machine's `:data` region tracks the same
+;;             lifecycle and owns the render call. (For the other shape — where
+;;             the lifecycle lives entirely in the machine and there's no slice
+;;             at all — see tags.cljs and settings.cljs.)
 ;;
-;; Every event delivered to the machine reaches every region (the parallel
-;; region broadcast). Region-distinct event names avoid collisions; each
-;; region handles `:reset` as a self-target.
+;; One thing to keep in mind: every event delivered to a parallel machine
+;; reaches every region — that's the broadcast. So the region event names are
+;; kept distinct to avoid crosstalk, and each region treats `:reset` as a
+;; self-target.
 
 (def home-machine
   {:type :parallel
 
-   ;; The machine carries the active feed's item-count (drives the
-   ;; cardinality bucket) plus the latest error map. The items live in
-   ;; app-db slices (`:articles`, `:feed`) so favorites.cljs's optimistic
-   ;; updates can find them across slices.
+   ;; The machine holds just two facts: the active feed's item-count (which
+   ;; picks the empty-vs-some bucket) and the latest error. The articles
+   ;; themselves stay in the app-db slices (`:articles`, `:feed`), where
+   ;; favorites.cljs can find and patch them across slices.
    :data {:count 0 :error nil}
 
    :guards
@@ -120,17 +128,19 @@
               :reset           :nothing}}
 
       :refreshing
-      ;; Reload while prior items remain visible. Tagged :data/some so
-      ;; the render-priority resolves to the `:some` view; the
-      ;; :data/refreshing tag drives the inline refresh indicator.
+      ;; A reload while the previous list is still on screen. Tagged
+      ;; :data/some so render-priority keeps showing the `:some` view (no
+      ;; flicker to a spinner); the :data/refreshing tag lights up the
+      ;; little inline "refreshing" indicator.
       {:tags #{:data/some :data/refreshing :data/transient}
        :on   {:fetch-succeeded {:target :resolving :action :set-count}
               :fetch-failed    {:target :error     :action :set-error}
               :reset           :nothing}}
 
       :resolving
-      ;; Eventless microstep: after :set-count writes the new count,
-      ;; pick the cardinality bucket. First match wins.
+      ;; An eventless microstep — it transitions on its own the instant it's
+      ;; entered. Once :set-count has written the new count, this picks the
+      ;; bucket: empty or not. First matching branch wins.
       {:always [{:guard :empty? :target :empty}
                 {:target :some}]}
 
@@ -170,9 +180,10 @@
               :reset         :global}}
 
       :tag-feed
-      ;; The `/tag/:tag` PATH route. Still reads from the :articles slice;
-      ;; the tag modifies the request URL upstream (the WIRE stays
-      ;; `/articles?tag=…`).
+      ;; The `/tag/:tag` PATH route. Still reads from the :articles slice —
+      ;; the tag only changes the request URL upstream. (The frontend route
+      ;; is `/tag/:tag`, but the WIRE stays `/articles?tag=…`; the two shapes
+      ;; are independent.)
       {:tags #{:feed/tag-feed}
        :on   {:show-global    {:target :global    :action :clear-count}
               :show-user-feed {:target :user-feed :action :clear-count}
@@ -213,24 +224,24 @@
 ;; ============================================================================
 
 (rf/reg-event :articles/load
-  {:doc "Fetch the global articles list, optionally filtered by the active
-         tag (the `/tag/:tag` route param; the wire query stays
-         `/articles?tag=…`). Goes via `:rf.http/managed` with a
-         Malli-decoded response and the standard data-fetch retry policy.
-         The request carries `:request-id :articles/load` so re-issuing it
-         (e.g. the user changes tag mid-load) supersedes the in-flight
-         request and `:articles/cancel` aborts it. See the HTTP guide:
-         ../../../docs/resources/http.md
+  {:doc "Fetch the global articles list, optionally narrowed to the active tag
+         (the `/tag/:tag` route param; on the wire that's still
+         `/articles?tag=…`). Goes out via `:rf.http/managed` with a
+         Malli-decoded response and the house data-fetch retry policy. It
+         carries `:request-id :articles/load`, which buys two things: re-issue
+         it (the user flips to a different tag mid-load) and the new request
+         supersedes the in-flight one, and `:articles/cancel` can abort it
+         outright. See the HTTP guide: ../../../docs/resources/http.md
 
-         Also broadcasts `:fetch-started` into the home machine so the
-         `:data` region advances to `:loading` (or `:refreshing` from
-         `:some`)."
+         It also broadcasts `:fetch-started` into the home machine, nudging the
+         `:data` region to `:loading` (or `:refreshing`, if a list is already
+         showing)."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
-  ;; The route lives in runtime-db. `?page=` (1-indexed, on the route
-  ;; query) becomes the wire's limit/offset window via `rh/paginate-path`.
-  ;; The active tag is a `/tag/:tag` route param; the page is on the query.
-  ;; The wire stays `/articles?tag=…` — the frontend route shape and the
-  ;; API query string are independent.
+  ;; The route lives in runtime-db. The 1-indexed `?page=` off the route query
+  ;; becomes the wire's limit/offset window via `rh/paginate-path`. The active
+  ;; tag is a path param; the page is a query param; and on the wire it all
+  ;; collapses to `/articles?tag=…&limit=…&offset=…`. Frontend route shape and
+  ;; API query string are deliberately independent.
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [current   (get-in rt [:rf.runtime/routing :current])
           tag       (get-in current [:params :tag])
@@ -255,17 +266,18 @@
                           :on-failure [:articles/load-failed]})]]})))
 
 (rf/reg-event :articles/loaded
-  {:doc "Successful fetch. Replace the list and clear any prior error.
-         Receives `{:kind :success :value <ArticlesResponse>}` (the
-         uniform reply map). Folds the new count into the home machine via
-         `:fetch-succeeded`; the `:data` region's `:resolving` `:always`
-         cascade then picks `:empty` or `:some`."
+  {:doc "The fetch came back happy. Swap in the new list and clear any stale
+         error. It arrives as `{:kind :success :value <ArticlesResponse>}` —
+         the same uniform reply shape every managed request returns. Folds the
+         fresh count into the home machine via `:fetch-succeeded`, and the
+         `:data` region's `:resolving` `:always` cascade takes it from there,
+         choosing `:empty` or `:some`."
    :rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
     (let [items (vec (:articles value))
-          ;; `articlesCount` is the grand total (all matching articles),
-          ;; not this page's size — it drives the page count. Fall back to
-          ;; the page size when the server omits it.
+          ;; `articlesCount` is the GRAND total across all matching articles,
+          ;; not the size of this page — it's what the page count is computed
+          ;; from. If the server leaves it out, fall back to this page's size.
           total (or (:articlesCount value) (count items))]
       {:db (-> db
                (assoc-in [:articles :status] :loaded)
@@ -277,10 +289,11 @@
                         [:fetch-succeeded {:items items}]]]]})))
 
 (rf/reg-event :articles/load-failed
-  {:doc "Failed fetch. Keep prior data when present and surface a
-         human-readable error message (projected from the failure map).
-         Folds the failure into the home machine via `:fetch-failed`; the
-         `:data` region advances to `:error`."}
+  {:doc "The fetch failed. Hold on to whatever list was already showing (no
+         point blanking the page over a hiccup) and surface a readable error
+         message, projected from the failure map. Folds the failure into the
+         home machine via `:fetch-failed`, sending the `:data` region to
+         `:error`."}
   (fn [{:keys [db]} [_ {:keys [failure]}]]
     (let [message (rh/failure->message failure)]
       {:db (-> db
@@ -290,8 +303,9 @@
                         [:fetch-failed {:failure message}]]]]})))
 
 (rf/reg-event :articles/cancel
-  {:doc "Abort an in-flight :articles/load — e.g. when the user navigates
-         away from the home page mid-fetch. See the HTTP guide on aborts:
+  {:doc "Abort an in-flight :articles/load — say the user wanders off the home
+         page before it lands. No sense letting a reply arrive for a screen
+         nobody's looking at. See the HTTP guide on aborts:
          ../../../docs/resources/http.md#the-search-box-race-cured"}
   (fn [_ _]
     {:fx [[:rf.http/managed-abort :articles/load]]}))
@@ -317,17 +331,19 @@
 
 ;; ---- render-priority + :articles.home/render selector ----
 ;;
-;; The render-priority table is plain data: a vector of {:tag :render}
-;; pairs consulted in order. The `:articles.home/render` sub reads the
-;; machine's tag union and returns the first :render whose :tag is
-;; present. The home view's `case` over the resolved keyword is the
-;; only branch site; everything else reads tags directly.
+;; "Which view do I show?" is data, not code. The render-priority table is a
+;; plain vector of {:tag :render} pairs, read top to bottom. The
+;; `:articles.home/render` sub looks at the machine's set of active tags and
+;; returns the first :render whose :tag is present. The home view's `case` over
+;; that one resolved keyword is the only place anything branches on render
+;; state — everywhere else just reads tags directly. Want to reorder the
+;; precedence? Reorder the vector; nobody touches the view.
 ;;
-;; Priority rationale: the data region's lifecycle wins outright —
-;; `:loading` (first-load spinner) above `:error` above the cardinality
-;; buckets. `:refreshing` resolves to `:some` (the prior list stays
-;; visible, with an inline refresh indicator the `:some` view renders
-;; via the `:data/refreshing` tag).
+;; The order encodes the priorities: the data lifecycle wins outright —
+;; `:loading` (the first-load spinner) beats `:error` beats the count buckets.
+;; `:refreshing` resolves to `:some` on purpose, so a reload leaves the
+;; existing list up, with just an inline refresh indicator (rendered by the
+;; `:some` view off the `:data/refreshing` tag).
 
 (def render-priority
   [{:tag :data/loading :render :loading}
@@ -337,9 +353,9 @@
    {:tag :data/nothing :render :empty}])
 
 (rf/reg-sub :articles.home/render
-  {:doc "Resolve the home page's render-model keyword by consulting the
-         render-priority table against the machine's tag union. The
-         root view's `case` is the only branch site."}
+  {:doc "Boil the machine's active tags down to a single render keyword, by
+         running them past the render-priority table. The home view's `case`
+         on this keyword is the one and only branch site."}
   :<- [:rf/machine :realworld/articles-home]
   (fn sub-articles-home-render [snap _]
     (let [tags (:tags snap)]
@@ -348,9 +364,9 @@
             render-priority))))
 
 (rf/reg-sub :articles.home/active-articles
-  {:doc "The article list currently rendered by the home view: the
-         `:feed` region's active state-keyword picks which app-db slice
-         to read from."}
+  {:doc "Whichever article list the home view should be showing right now. The
+         `:feed` region's active state decides which app-db slice to pull from
+         — `:feed` for your-feed, `:articles` for everything else."}
   :<- [:rf/machine :realworld/articles-home]
   :<- [:articles/data]
   :<- [:feed/data]
@@ -361,9 +377,10 @@
 
 ;; ---- pagination (official RealWorld limit/offset) ----
 ;;
-;; The page-number control + articles-count read from the SAME `:feed` region
-;; the article list reads from: the active feed's grand `articlesCount` drives
-;; the page count, and the 1-indexed current page rides the route query.
+;; The page-number control reads from the SAME `:feed` region the article list
+;; does, so the two never disagree: the active feed's grand `articlesCount`
+;; sets how many pages there are, and the 1-indexed current page rides along
+;; in the route query.
 
 (rf/reg-sub :articles.home/articles-count
   {:doc "Grand article count for the active home feed (global / user-feed),
@@ -396,7 +413,9 @@
 ;; VIEWS
 ;; ============================================================================
 
-(reg-view ^{:doc "A single article card used across the home page and profile pages."}
+(reg-view ^{:doc "One article card — the little preview tile, reused on both the
+                  home page and the profile pages. Write it once, render it
+                  everywhere."}
           article-preview [{:keys [article]}]
   (let [{:keys [slug title description createdAt favoritesCount author tagList]} article]
     [:div.article-preview
@@ -426,13 +445,14 @@
          ^{:key tag}
          [:li.tag-default.tag-pill.tag-outline tag])]]]))
 
-(reg-view ^{:doc "Official RealWorld page-number control. Renders the
-                  Conduit `.pagination` / `.page-item` / `.page-link` markup
-                  with the active page marked `.active`. Reused by the home
-                  feeds and the profile lists — `on-select` is a 1-arg fn
-                  (page-number → navigation) so each call site routes to its
-                  own `?page=`. A single page renders nothing (the official
-                  client hides the control when there is nothing to page)."}
+(reg-view ^{:doc "The page-number control, Conduit-style. Renders the official
+                  `.pagination` / `.page-item` / `.page-link` markup with the
+                  current page marked `.active`. Shared by the home feeds and
+                  the profile lists: `on-select` is a 1-arg fn (page-number →
+                  navigation), so each caller decides where its own `?page=`
+                  lands. If there's only one page, it draws nothing — same as
+                  the official client, which hides the control when there's
+                  nothing to page through."}
           pagination [{:keys [current-page page-count on-select]}]
   (when (> page-count 1)
     [:nav
@@ -448,27 +468,27 @@
 
 ;; ---- per-render-state subviews ----
 
-(reg-view ^{:doc "Data region :loading — first fetch in flight, no prior items."}
+(reg-view ^{:doc "The :loading view — first fetch in flight, nothing to show
+                  yet. So we show a spinner-ish placeholder."}
           articles-loading []
   [:div.article-preview "Loading articles…"])
 
-(reg-view ^{:doc "Data region :error — fetch failed."}
+(reg-view ^{:doc "The :error view — the fetch didn't make it."}
           articles-error []
   (let [err @(subscribe [:articles/error])
         feed-err @(subscribe [:feed/error])]
     [:div.article-preview.error
      (str "Couldn't load articles: " (pr-str (or err feed-err)))]))
 
-(reg-view ^{:doc "Data region :empty / :nothing — no articles to show. Renders
-                  the official RealWorld `.article-preview.empty-feed-message`
-                  marker the E2E contract asserts on for empty
-                  list states."}
+(reg-view ^{:doc "The :empty / :nothing view — no articles to show. Renders the
+                  official `.article-preview.empty-feed-message` marker that
+                  the RealWorld E2E suite looks for on an empty list."}
           articles-empty []
   [:div.article-preview.empty-feed-message "No articles are here… yet."])
 
-(reg-view ^{:doc "Data region :some — articles to show. Inline refresh
-                  indicator overlays when the :data/refreshing tag is
-                  set (a same-feed reload in flight)."}
+(reg-view ^{:doc "The :some view — we have articles, so list them. If a
+                  same-feed reload is in flight (the :data/refreshing tag),
+                  an inline refresh indicator rides along on top."}
           articles-some []
   (let [articles    @(subscribe [:articles.home/active-articles])
         refreshing? @(rf/machine-has-tag? :realworld/articles-home :data/refreshing)]
@@ -478,7 +498,10 @@
        ^{:key (:slug article)}
        [article-preview {:article article}])]))
 
-(reg-view ^{:doc "Global feed / your feed / tag-filtered home page."}
+(reg-view ^{:doc "The home page itself — global feed, your feed, or a
+                  tag-filtered list, depending on the machine. The banner and
+                  the feed tabs are always here; the middle swaps based on
+                  render-mode."}
           home-page []
   (let [authed?      @(subscribe [:auth/authenticated?])
         selected-tag @(subscribe [:home/selected-tag])

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -1,20 +1,24 @@
 (ns realworld.auth
   "Authentication for the RealWorld (Conduit) example.
 
-   The auth flow is a state machine. Login, register, session restore, and
-   logout are all sub-events routed through one handler:
+   Auth is one of those things that looks like a pile of unrelated buttons —
+   sign in, sign up, restore my session, log out — but is really a single
+   state machine wearing four hats. So that's how it's modelled here: login,
+   register, session restore, and logout are all sub-events fed into one
+   machine through one handler:
 
      (rf/dispatch [:auth/flow [:auth/login creds]])
 
-   The login/register draft slices live under [:auth ...]; the machine
-   snapshot lives in runtime-db at
+   The login and register draft forms live in app-db under [:auth ...]; the
+   machine's own snapshot lives over in runtime-db at
    [:rf.runtime/machines :snapshots :auth/flow]."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            ;; State machines ship in the re-frame2-machines artefact.
-            ;; Requiring the ns registers its hooks so `rf/reg-machine`
-            ;; (called below) and the `:rf/machine` sub resolve. See the
-            ;; machines guide: ../../../docs/machines/index.md
+            ;; State machines live in their own artefact. We require it purely
+            ;; for the side effect of loading it: that registers the hooks that
+            ;; make `rf/reg-machine` (below) and the `:rf/machine` sub resolve
+            ;; to something. No alias needed — we just want it in the room. See
+            ;; the machines guide: ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh])
@@ -24,20 +28,22 @@
 ;; FX / COFX
 ;; ============================================================================
 ;;
-;; One fx for the localStorage seam. Arg shape is `{:token <token-or-nil>}`
-;; — write on truthy, remove on nil. One seam means one fx to mock in
-;; tests, called by the machine's `:store-session` and `:clear-session`
-;; actions with different args.
+;; Talking to localStorage is a side effect, so it gets its own fx — one
+;; little doorway between our pure handlers and the browser's storage. The arg
+;; is `{:token <token-or-nil>}`: a truthy token writes, nil removes. Keeping it
+;; to a single seam means there's exactly one thing to stub in tests; the
+;; machine's `:store-session` and `:clear-session` actions both call it, just
+;; with different args.
 ;;
-;; Conformance-contract surface: the official RealWorld browser/E2E suite
-;; reads the session from `localStorage["jwtToken"]`, so this seam uses
-;; that exact key verbatim — it is NOT namespaced. Conformance is validated
-;; against standalone serving (one app per origin).
+;; One detail that isn't ours to choose: the official RealWorld E2E suite reads
+;; the session straight out of `localStorage["jwtToken"]`, so we use that exact
+;; key, un-namespaced, verbatim. Conformance is checked against standalone
+;; serving (one app per origin), so there's no collision to worry about.
 
 (rf/reg-fx :auth.session/persist
-  {:doc       "Persist (or clear) the JWT in localStorage under the official
-               contract key `jwtToken`. Arg `{:token t}` writes
-               the token when truthy; nil removes the key."
+  {:doc       "Save or clear the JWT in localStorage, under the contract key
+               `jwtToken`. `{:token t}` writes a truthy token; nil removes the
+               key entirely."
    :platforms #{:client}}
   (fn fx-auth-session-persist [_m {:keys [token]}]
     (when-let [ls (.-localStorage js/globalThis)]
@@ -45,39 +51,40 @@
         (.setItem    ls "jwtToken" token)
         (.removeItem ls "jwtToken")))))
 
-;; The saved JWT is read from localStorage at boot and `:auth/initialise`
-;; folds it into durable app-db at [:auth :token]. A durable write must
-;; fold a RECORDED fact, not an ambient `localStorage` read at the write
-;; site — replay and epoch-restore could not reproduce the latter. So the
-;; JWT comes from a recordable coeffect: `:auth.session/token` is a
-;; `:recordable? true` registration whose supplier reads localStorage. The
-;; supplier runs once, its value is recorded onto the causal token, and
-;; replay re-presents the captured token verbatim. See the coeffects guide
-;; on the two grades: ../../../docs/guide/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
+;; At boot we read the saved JWT out of localStorage and `:auth/initialise`
+;; folds it into durable app-db at [:auth :token]. Here's the subtlety: a
+;; durable write has to fold a RECORDED fact, not a live localStorage read
+;; taken in the handler — otherwise replay and epoch-restore, which don't have
+;; your localStorage, can't reproduce it. So the JWT arrives as a recordable
+;; coeffect. `:auth.session/token` is a `:recordable? true` registration whose
+;; supplier reads localStorage; that supplier runs once, its value is recorded
+;; onto the causal token, and from then on replay hands back the captured token
+;; verbatim. See the coeffects guide on the two grades:
+;; ../../../docs/guide/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
 ;;
-;; This is also why `ssr.cljc` may redact [:auth :token] from the hydration
-;; payload — the client re-derives the token through this recorded boot
-;; coeffect, not an ambient write-site read.
+;; It's also why `ssr.cljc` can happily redact [:auth :token] from the
+;; hydration payload: the client doesn't need the server to ship it the token,
+;; it re-derives it through this recorded boot coeffect.
 (defn read-jwt-from-storage
-  "Read the saved JWT from localStorage (or nil) — the supplier body for the
-   `:auth.session/token` recordable coeffect. nil when absent or
-   unavailable (e.g. node, logged-out first run)."
+  "Read the saved JWT out of localStorage, or nil if there isn't one — the
+   supplier behind the `:auth.session/token` recordable coeffect. nil when
+   the key is absent or storage isn't there at all (node, or a logged-out
+   first run)."
   []
   (some-> (.-localStorage js/globalThis)
           (.getItem "jwtToken")))
 
 (rf/reg-cofx :auth.session/token
   {:recordable? true
-   :doc "Recordable coeffect: the saved JWT (or nil), read from
-         localStorage. The supplier runs at the start of the boot dispatch;
-         its value is recorded onto the causal token and re-presented
-         verbatim under replay and epoch-restore — so the durable write
-         that folds it (`:auth/initialise` → [:auth :token]) replays the
-         captured token, never a live localStorage re-read. A handler folds
-         it by declaring `:rf.cofx/requires [:auth.session/token]` and
-         reading it flat. A production dispatch carries no cofx — the
-         supplier is the source; tests pin an exact value via the
-         dispatch-site `:rf.cofx` stub (`{:rf.cofx {:auth.session/token \"…\"}}`)."}
+   :doc "Recordable coeffect: the saved JWT (or nil), read from localStorage.
+         The supplier fires once, at the start of the boot dispatch, and its
+         value is recorded onto the causal token — so the durable write that
+         folds it (`:auth/initialise` → [:auth :token]) replays the captured
+         token rather than re-reading localStorage on every replay. A handler
+         opts in by declaring `:rf.cofx/requires [:auth.session/token]` and
+         reading it flat. Live dispatches carry no cofx — the supplier is the
+         source of truth; tests pin an exact value through the dispatch-site
+         `:rf.cofx` stub (`{:rf.cofx {:auth.session/token \"…\"}}`)."}
   (fn [] (read-jwt-from-storage)))
 
 ;; ============================================================================
@@ -85,16 +92,17 @@
 ;; ============================================================================
 
 (rf/reg-event :auth/store-session
-  {:doc "Store the authenticated session. The JWT has one durable home: the
-         classified `[:auth :token]` path (declared sensitive by
-         `:auth/classify-token` in core.cljs). The User payload is stored at
-         `[:auth :user]` with its `:token` field stripped off (`dissoc`), so
-         the JWT is not duplicated into the unclassified
-         `[:auth :user :token]` slot — a second copy there would ship raw
-         off-box, because classification does not propagate; each path is
-         its own declaration. Views and subs read `:auth/user` for identity
-         (username, bio, image); the bearer-auth interceptor reads the token
-         from `[:auth :token]`. See the keep-secrets how-to:
+  {:doc "Stash the authenticated session. The JWT gets exactly one durable
+         home: the classified `[:auth :token]` path (marked sensitive by
+         `:auth/classify-token` in core.cljs). The User payload goes to
+         `[:auth :user]` — but with its `:token` field `dissoc`'d off first,
+         so the JWT doesn't end up quietly duplicated at the unclassified
+         `[:auth :user :token]`. That second copy would ship raw off-box,
+         because classification doesn't propagate down the tree — each path
+         declares its own sensitivity, so two copies means two declarations,
+         and we'd have forgotten one. Views and subs read `:auth/user` for
+         who-you-are (username, bio, image); the bearer-auth interceptor reads
+         the token from `[:auth :token]`. See the keep-secrets how-to:
          ../../../docs/guide/how-to/keep-secrets-out-of-traces.md"}
   (fn [{:keys [db]} [_ user]]
     {:db (-> db
@@ -108,13 +116,13 @@
         (assoc-in [:auth :token] nil))}))
 
 (rf/reg-event :auth/post-login-redirect
-  {:doc "Bounce the freshly-authenticated user back to the route the auth
-         guard intercepted (`[:auth :return-to]`, set in routing.cljs), or
-         home when there is none. Dispatched by the auth machine's
-         `:store-session` action — a machine action sees no `:db` and emits
-         no `:db`, so the bounce is an ordinary event. Reads and clears the
-         slot in one step so a later plain login can't re-bounce to a stale
-         target."}
+  {:doc "Drop the freshly-signed-in user back where they were headed before
+         the auth guard sent them to login (`[:auth :return-to]`, stashed in
+         routing.cljs), or home if there's no such crumb. The auth machine's
+         `:store-session` action dispatches this — a machine action can't see
+         or emit `:db`, so the redirect rides as an ordinary event. It reads
+         and clears the slot in the same step, so a later ordinary login can't
+         get bounced to a stale target left lying around."}
   (fn [{:keys [db]} _]
     (let [return-to (get-in db [:auth :return-to])]
       {:db (update db :auth dissoc :return-to)
@@ -126,25 +134,24 @@
 ;; AUTH STATE MACHINE
 ;; ============================================================================
 
-;; The auth machine carries a `[:schemas :data]` that validates the
-;; snapshot's `:data` slot. Registering the machine here is what makes that
-;; schema live rather than inert. This machine validates only its `:data`
-;; (no outer event-vector `:schema`), so the opts map carries just `:doc` +
-;; `:rf.http/decode-schemas`.
+;; The machine carries a `[:schemas :data]` that validates its snapshot's
+;; `:data` slot, and registering it here is what brings that schema to life
+;; instead of leaving it as decoration. This one only validates its `:data`
+;; (there's no outer event-vector `:schema`), so the opts map is short: just
+;; `:doc` and `:rf.http/decode-schemas`.
 (rf/reg-machine :auth/flow
-  {:doc "The auth flow: idle → submitting/restoring → authed | error.
-         HTTP requests go via `:rf.http/managed`. Login / register /
-         restore do not retry — one submission per click; a transient
-         error surfaces in `:error` and the user retries."
+  {:doc "The auth flow in one line: idle → submitting/restoring → authed |
+         error. Requests go out via `:rf.http/managed`. Login, register, and
+         restore don't retry — it's one submission per click; a transient
+         failure parks a message in `:error` and the user takes another swing."
    :rf.http/decode-schemas [schema/UserResponse]}
-  ;; The spec map does not carry :id; the id is the surrounding
-  ;; reg-machine id.
+  ;; No :id in the spec map — the id is just the `reg-machine` id above.
   {:initial :idle
    :data    {:error nil}
-   ;; The snapshot lives in runtime-db at
-   ;; [:rf.runtime/machines :snapshots :auth/flow], so its :data shape is
-   ;; validated here via [:schemas :data], not via an app-schema (app
-   ;; schemas validate the app-db partition only).
+   ;; The snapshot lives in runtime-db (at
+   ;; [:rf.runtime/machines :snapshots :auth/flow]), not app-db. App-schemas
+   ;; only police the app-db partition, so the snapshot's :data shape is
+   ;; validated right here via [:schemas :data] instead.
    :schemas {:data schema/AuthFlowData}
    :guards
    {:has-token?
@@ -191,11 +198,10 @@
 
     :store-session
     (fn [{[_ {:keys [value]}] :event}]
-      ;; A machine action sees no `:db` and emits no `:db`, so the
-      ;; post-login bounce-back runs as an ordinary event
-      ;; (`:auth/post-login-redirect`) that reads the guard-stashed
-      ;; `:return-to` slot, navigates there (or home), and clears it. See
-      ;; routing.cljs for where the slot is set.
+      ;; A machine action can't touch `:db`, so the post-login bounce-back is
+      ;; farmed out to an ordinary event (`:auth/post-login-redirect`): it
+      ;; reads the guard-stashed `:return-to` slot, sends you there (or home),
+      ;; and clears it. routing.cljs is where that slot gets set.
       (let [user (:user value)]
         {:data {:error nil}
          :fx [[:dispatch [:auth/store-session user]]
@@ -243,15 +249,17 @@
 (rf/reg-event :auth/initialise
   {:rf.cofx/requires [:auth.session/token]}
   (fn handler-auth-initialise [{:keys [db auth.session/token]} _]
-    ;; Dispatch `:auth/flow [:auth/restore token]` unconditionally — even
-    ;; when `token` is nil. This first delivery spawns the auth machine's
-    ;; snapshot (the machine materialises at `:idle` on its first event), so
-    ;; the navbar's `:auth/state` sub reads `:idle` rather than `nil` from
-    ;; cold boot. The do-we-have-a-token? decision is then the machine's
-    ;; `:idle` `:has-token?` guard: a blank token routes to the no-op
-    ;; `{:target :idle}` branch, a real one kicks `:begin-restore`. Guarding
-    ;; the dispatch here would skip the machine spawn on a no-token boot and
-    ;; split the token decision across two sites.
+    ;; Always fire `:auth/flow [:auth/restore token]`, even when `token` is
+    ;; nil. Why bother restoring nothing? Because that first event is also
+    ;; what spawns the machine's snapshot (a machine materialises at `:idle`
+    ;; on its very first event), so the navbar's `:auth/state` sub reads
+    ;; `:idle` from cold boot instead of an awkward `nil`. The actual
+    ;; do-we-have-a-token? question then belongs to one place — the `:idle`
+    ;; state's `:has-token?` guard: a blank token takes the no-op
+    ;; `{:target :idle}` branch, a real one kicks off `:begin-restore`.
+    ;; Guarding the dispatch up here would skip the machine spawn on a
+    ;; no-token boot AND split that one decision across two sites, which is
+    ;; how subtle bugs are born.
     {:db (assoc db :auth {:user nil
                           :token token})
      :fx [[:dispatch [:auth/flow [:auth/restore token]]]]}))
@@ -325,9 +333,9 @@
   (fn [db _] (get-in db [:auth :token])))
 
 (rf/reg-sub :auth/flow-state
-  {:doc "Current state of the auth machine snapshot."}
-  ;; Machine snapshots live in runtime-db — read them through the
-  ;; `:rf/machine` sub (the public surface), not a raw db path.
+  {:doc "The current auth machine snapshot."}
+  ;; Snapshots live in runtime-db, but you don't go digging for them by path
+  ;; — `:rf/machine` is the front door. Read through it.
   :<- [:rf/machine :auth/flow]
   (fn [snapshot _] snapshot))
 
@@ -358,8 +366,9 @@
   (fn [db _] (get-in db [:auth :login-form])))
 
 (rf/reg-sub :auth.login-form/field-error
-  {:doc "Per-field validation error for the login form. Reveal every error
-         after the first submit click, or once a field is :touched. See the
+  {:doc "The validation error for one login-form field — or nil while we're
+         keeping quiet. The rule of politeness: don't nag about a field until
+         the user has either touched it or hit submit at least once. See the
          forms how-to: ../../../docs/guide/how-to/build-a-form.md"}
   :<- [:auth.login-form/slice]
   (fn [form [_ field]]
@@ -374,9 +383,10 @@
   (fn [db _] (get-in db [:auth :register-form])))
 
 (rf/reg-sub :auth.register-form/field-error
-  {:doc "Per-field validation error for the register form. Reveal every
-         error after the first submit click, or once a field is :touched.
-         See the forms how-to: ../../../docs/guide/how-to/build-a-form.md"}
+  {:doc "The validation error for one register-form field, or nil while we
+         hold our tongue. Same rule as the login form: stay quiet until the
+         field is touched or the user has tried to submit. See the forms
+         how-to: ../../../docs/guide/how-to/build-a-form.md"}
   :<- [:auth.register-form/slice]
   (fn [form [_ field]]
     (when (or (:submit-attempted? form)

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -1,12 +1,17 @@
 (ns realworld.comments
   "Article detail plus comments for the RealWorld (Conduit) example.
 
-   This namespace shows:
+   The article-detail page is where re-frame2's optimistic-update story really
+   earns its keep: post a comment and it appears instantly, delete one and it
+   vanishes instantly, and if the server later disagrees, the change quietly
+   rolls back. Worth a read for:
+
    - `:article` and `:comments` in the plain remote-data slice shape.
    - `:comment-form` in the plain form slice shape.
-   - Route-driven loads reading the current slug from the runtime-db
+   - Route-driven loads that read the current slug off the runtime-db
      coeffect at `[:rf.runtime/routing :current :params :slug]`.
-   - Optimistic post/delete flows that roll back via ordinary events."
+   - Optimistic post / delete flows that roll back through nothing fancier
+     than ordinary events."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [realworld-shared.avatar :as avatar]
@@ -34,22 +39,23 @@
 ;; RECORDABLE COEFFECTS
 ;; ============================================================================
 ;;
-;; The optimistic temp-id is written into durable app-db (the optimistic
-;; card is conj'd into `[:comments :data]`) and used as a join key — it
-;; correlates the optimistic card with its eventual save
-;; (`:comment-form/submit-success`) or rollback
-;; (`:comment-form/submit-error`). A value written durably or used as a
-;; join key must come from a recordable coeffect, not a fresh
-;; `random-uuid` at the write site — otherwise replay mints a different id
-;; and the correlation breaks. So this is a recordable `reg-cofx`: the
-;; supplier runs once, the id is recorded onto the causal token, and replay
-;; re-presents it verbatim. `:comment-form/submit` declares it via
-;; `:rf.cofx/requires` and reads it flat, staying pure and replayable. See
-;; the coeffects guide:
+;; Here's a sneaky one. When you post a comment optimistically, we conj a
+;; temp card into durable app-db at `[:comments :data]` with a made-up id, and
+;; later use that id as a join key to find the card again — to swap in the
+;; saved comment (`:comment-form/submit-success`) or yank it back out
+;; (`:comment-form/submit-error`). The catch: anything written durably or used
+;; as a join key has to be reproducible on replay. A fresh `(random-uuid)`
+;; minted in the handler is the opposite of reproducible — replay would mint a
+;; DIFFERENT id, the join key wouldn't match, and the correlation would quietly
+;; fall apart. So the id comes from a recordable coeffect instead: the supplier
+;; runs once, the id is recorded onto the causal token, and replay hands back
+;; the very same string. `:comment-form/submit` asks for it via
+;; `:rf.cofx/requires` and reads it flat, staying pure and replayable. See the
+;; coeffects guide:
 ;; ../../../docs/guide/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
 (rf/reg-cofx :realworld/temp-comment-id
   {:recordable? true
-   :doc "Replayable optimistic temp-id for a newly-posted comment."}
+   :doc "A replay-safe temp-id for an optimistically-posted comment."}
   (fn [] (str "temp-" (random-uuid))))
 
 ;; ============================================================================
@@ -75,21 +81,23 @@
 ;; ============================================================================
 
 (rf/reg-event :article/load
-  {:doc "Load the article matching
+  {:doc "Load the article named by
          `[:rf.runtime/routing :current :params :slug]` (the route lives in
          runtime-db).
 
-         This handler shows default reply addressing: with no `:on-success`
-         / `:on-failure`, the framework re-dispatches the reply back to this
-         same event id, merging `:rf/reply` into the original message map.
-         The body branches on `(:rf/reply msg)` — one event id, two roles.
-         See the HTTP guide on when request and reply belong together:
+         This one's a little demo of default reply addressing. Leave off
+         `:on-success` / `:on-failure` and the framework loops the reply back
+         to this very same event id, with `:rf/reply` merged into the message.
+         So the handler runs twice for one load — once to send the request,
+         once when the answer comes back — and branches on `(:rf/reply msg)`
+         to tell which hat it's wearing. One event id, two roles. See the HTTP
+         guide on when request and reply belong together:
          ../../../docs/resources/http.md#when-request-and-reply-belong-together"
    :rf.http/decode-schemas [schema/ArticleResponse]
    :rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms] rt :rf.db/runtime} [_ msg]]
     (if-let [reply (:rf/reply msg)]
-      ;; Reply branch — handle success or failure.
+      ;; Reply hat — the answer's back. Success or failure?
       (case (:kind reply)
         :success
         {:db (-> db
@@ -103,8 +111,9 @@
                  (assoc-in [:article :status] :error)
                  (assoc-in [:article :error] (rh/failure->message (:failure reply))))})
 
-      ;; Initial dispatch — issue the managed request. Default reply
-      ;; addressing routes the reply back here.
+      ;; Request hat — first time through, fire the managed request. With no
+      ;; explicit handlers, default reply addressing brings the answer right
+      ;; back to this event.
       (let [slug (get-in rt [:rf.runtime/routing :current :params :slug])]
         {:db (-> db
                  (assoc-in [:article :status]
@@ -123,10 +132,11 @@
 ;; ============================================================================
 
 (rf/reg-event :comments/load
-  {:doc "Load comments for the current article. Uses explicit success /
-         failure handlers (cf. :article/load above, which uses default
-         reply addressing) — both shapes are valid; pick whichever reads
-         best for the handler."
+  {:doc "Load the comments for the current article. This one names explicit
+         success / failure handlers — the opposite choice from :article/load
+         just above, which lets the reply default back to itself. Both styles
+         are perfectly valid; reach for whichever reads more clearly in the
+         handler at hand. Here, separate handlers keep the load logic tidy."
    :rf.http/decode-schemas [schema/CommentsResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [slug (get-in rt [:rf.runtime/routing :current :params :slug])]
@@ -170,13 +180,14 @@
         (update-in [:comment-form :touched] (fnil conj #{}) field))}))
 
 (rf/reg-event :comment-form/submit
-  {:doc "Optimistically post a new comment. No retry — the user clicked
-         once. The temp-id correlates the optimistic UI card with the
-         eventual save / rollback: the partial event vectors in
-         `:on-success` / `:on-failure` pre-populate the correlation arg. The
-         temp-id comes from a recordable coeffect (the
-         `:realworld/temp-comment-id` reg-cofx above), never a fresh
-         `random-uuid` at the write site."
+  {:doc "Post a new comment, optimistically — the card shows up before the
+         server has weighed in. No retry; the user clicked once and means it.
+         The temp-id is the thread that ties the optimistic card to its
+         eventual save or rollback: it's baked into the partial event vectors
+         in `:on-success` / `:on-failure` so the reply knows which card it's
+         talking about. And it comes from the recordable
+         `:realworld/temp-comment-id` coeffect above, never a fresh
+         `random-uuid` here — see that block for the why."
    :rf.http/decode-schemas [schema/CommentResponse]
    :rf.cofx/requires [:realworld/temp-comment-id]}
   (fn [{:keys [db] rt :rf.db/runtime temp-id :realworld/temp-comment-id} _]
@@ -193,12 +204,12 @@
                                  :image     (:image user)
                                  :following false}}]
       (if (str/blank? body)
-        ;; Client-side validation failure. Validation messages live in
-        ;; `:errors` (`:_form` for whole-form, otherwise per-field);
-        ;; `:submit-error` is reserved for transport / non-field HTTP
-        ;; failures. Flip :submit-attempted? so the view's per-field-error
-        ;; sub reveals the :body error even on a fresh, never-:touched
-        ;; textarea.
+        ;; Empty comment — fail it on the client, no round trip needed.
+        ;; Validation messages live in `:errors` (`:_form` for the whole form,
+        ;; otherwise keyed per field); `:submit-error` is kept for transport /
+        ;; non-field HTTP failures, a separate concern. We flip
+        ;; :submit-attempted? so the per-field-error sub will surface the
+        ;; :body error even on a textarea the user never touched.
         {:db (-> db
                  (assoc-in [:comment-form :submit-attempted?] true)
                  (assoc-in [:comment-form :errors] {:body "Comment body is required."})
@@ -223,11 +234,12 @@
     {:db (let [saved (:comment value)]
       (-> db
           (assoc-in [:comment-form] (comment-form-defaults))
-          ;; Replace the optimistic temp card IN PLACE with the saved
-          ;; comment — preserve its position so a confirmed comment does
-          ;; not visibly teleport from where it was appended (the bottom)
-          ;; to the top. Mirrors favorites.cljs/update-article-in-list:
-          ;; map, swap the matching entry, keep order.
+          ;; Swap the optimistic temp card for the saved comment IN PLACE,
+          ;; right where it already sits. If we appended the saved one instead,
+          ;; the comment would visibly jump from the bottom (where it landed
+          ;; optimistically) to the top — a tiny teleport the eye absolutely
+          ;; catches. Same move as favorites.cljs/update-article-in-list: map
+          ;; over, replace the match, keep the order.
           (update-in [:comments :data]
                      (fn [comments]
                        (mapv (fn [comment]
@@ -245,8 +257,9 @@
                   (rh/failure->message failure)))}))
 
 (rf/reg-event :comment/delete
-  {:doc "Optimistically remove a comment, then DELETE. On failure, the
-         rollback handler re-inserts the comment at its original index."}
+  {:doc "Whisk a comment off the screen first, then send the DELETE. If the
+         server says no, the rollback handler slots the comment back in at its
+         original index, as though nothing happened."}
   (fn [{:keys [db] rt :rf.db/runtime} [_ id]]
     (let [slug     (get-in rt [:rf.runtime/routing :current :params :slug])
           comments (vec (get-in db [:comments :data]))
@@ -264,10 +277,11 @@
                           :on-failure [:comment/delete-rollback prior]})]]})))
 
 (rf/reg-event :comment/delete-success
-  {:doc "Nothing to do on success: the optimistic delete already removed the
-         comment, so confirming it is a no-op. The handler exists only as the
-         `:on-success` reply target — work happens in `:comment/delete-rollback`
-         when the server says no."}
+  {:doc "Success means: do nothing, gracefully. The optimistic delete already
+         took the comment off the screen, so there's literally nothing left to
+         do — this handler exists only to give `:on-success` a target to land
+         on. All the real work lives in `:comment/delete-rollback`, for the day
+         the server says no."}
   (fn [{:keys [db]} _] {:db db}))
 
 (rf/reg-event :comment/delete-rollback
@@ -275,11 +289,13 @@
     {:db (if (and (some? index) comment)
       (update-in db [:comments :data]
                  (fn [xs]
-                   ;; Clamp to the CURRENT length: the captured index is from
-                   ;; optimistic-delete time and the list may have shrunk since
-                   ;; (a `:comments/loaded` re-fetch or a concurrent delete).
-                   ;; Without the clamp, `subvec` throws IndexOutOfBounds when
-                   ;; index > (count xs) and the whole event drain dies.
+                   ;; Clamp the re-insert point to the list's CURRENT length.
+                   ;; The index we saved was true at optimistic-delete time, but
+                   ;; the list may have shrunk since — a `:comments/loaded`
+                   ;; re-fetch, or a second delete racing this one. Skip the
+                   ;; clamp and `subvec` throws IndexOutOfBounds the moment
+                   ;; index > (count xs), taking the whole event drain down with
+                   ;; it. A little defensive arithmetic is cheaper than that.
                    (let [xs (vec xs)
                          i  (min (max 0 index) (count xs))]
                      (vec (concat (subvec xs 0 i)
@@ -291,20 +307,21 @@
 ;; ARTICLE-DETAIL SOCIAL CONTROLS
 ;; ============================================================================
 ;;
-;; The official Conduit article page puts contextual controls ON THE DETAIL
-;; PAGE: a non-author viewer can follow/unfollow the AUTHOR; the author sees
-;; Edit Article (→ /editor/:slug) and Delete Article. Logged-out viewers see
-;; neither (the controls are auth-gated like the favorite toggle). The follow
-;; here targets the article's OWN author profile (`[:article :data :author]`),
-;; distinct from profile.cljs's `:profile/follow` which targets the profile-page
-;; banner slice.
+;; Conduit puts a few context-aware buttons right on the article page. If
+;; you're reading someone else's article, you can follow or unfollow the
+;; author; if it's your own, you get Edit Article (→ /editor/:slug) and Delete
+;; Article instead. Logged out, you get neither — these are auth-gated, same as
+;; the favorite toggle. Note the follow here acts on the article's OWN author
+;; (`[:article :data :author]`), which is a different slice from
+;; profile.cljs's `:profile/follow` (that one drives the profile-page banner).
+;; Same gesture, two homes.
 
 (rf/reg-event :article/toggle-follow-author
-  {:doc "Optimistically toggle following the article's author, then POST/DELETE
-         /profiles/:username/follow. On failure the prior flag is restored.
-         Auth-gated (same rationale as :article/toggle-favorite): a logged-out
-         click navigates to login rather than issuing a tokenless write the real
-         Conduit backend would 401."
+  {:doc "Flip following-the-author on or off optimistically, then send the
+         POST/DELETE to /profiles/:username/follow; restore the old flag if it
+         fails. Auth-gated (same reasoning as :article/toggle-favorite): a
+         logged-out click goes to login instead of firing a tokenless write the
+         real Conduit backend would just 401 anyway."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
     (if (nil? (get-in db [:auth :user]))
@@ -333,9 +350,10 @@
     {:db (assoc-in db [:article :data :author :following] previous-following)}))
 
 (rf/reg-event :article/delete
-  {:doc "Delete the current article from the DETAIL page (author only). No
-         retry — destructive, one click. On success navigate home; the editor's
-         own Delete path (article_editor.cljs) remains reachable too."}
+  {:doc "Delete the current article, straight from the DETAIL page (authors
+         only). No retry — it's destructive and it's one click. On success we
+         head home. (The editor has its own Delete path too, in
+         article_editor.cljs; both lead to the same place.)"}
   (fn [{:keys [db]} _]
     (let [slug (get-in db [:article :data :slug])]
       (if (nil? slug)
@@ -370,8 +388,9 @@
   (fn [article _] (:author article)))
 
 (rf/reg-sub :article/own?
-  {:doc "True when the signed-in viewer is the article's author — gates the
-         Edit / Delete controls on the detail page."}
+  {:doc "Is this the reader's own article? True when the signed-in user is the
+         author — which is what reveals the Edit / Delete controls on the
+         detail page."}
   (fn [db _]
     (let [me (get-in db [:auth :user :username])]
       (and me (= me (get-in db [:article :data :author :username]))))))
@@ -394,9 +413,10 @@
   (fn [db _] (:comment-form db)))
 
 (rf/reg-sub :comment-form/field-error
-  {:doc "Per-field validation error for the comment form. Reveal every
-         error after the first submit click, or once the field is :touched.
-         See the forms how-to: ../../../docs/guide/how-to/build-a-form.md"}
+  {:doc "The validation error for one comment-form field, or nil while we stay
+         quiet. Same courtesy as the other forms: no error shown until the
+         field is touched or the user has tried to submit. See the forms
+         how-to: ../../../docs/guide/how-to/build-a-form.md"}
   :<- [:comment-form/slice]
   (fn [form [_ field]]
     (when (or (:submit-attempted? form)
@@ -429,12 +449,12 @@
           :on-click #(dispatch [:comment/delete (:id comment)])}
          [:i.ion-trash-a]])]]))
 
-(reg-view ^{:doc "The article-detail contextual controls: the
-                  author byline plus, per the official Conduit template, the
-                  author's Follow/Unfollow for a non-author viewer OR Edit /
-                  Delete for the author. Logged-out viewers see the byline only.
-                  Rendered twice on the page (banner + footer) like the official
-                  template."}
+(reg-view ^{:doc "The byline-with-buttons strip. Always shows the author; then,
+                  following the official Conduit template, adds Follow/Unfollow
+                  if you're a visitor, or Edit / Delete if the article is yours.
+                  Logged out, it's just the byline. The page renders it twice
+                  (once up top in the banner, once down in the footer), exactly
+                  as the official template does."}
           article-meta []
   (let [article @(subscribe [:article/data])
         author  @(subscribe [:article/author])
@@ -483,12 +503,13 @@
        (= article-status :loading)
        [:div.article-preview "Loading article…"]
 
-       ;; Only surface the error view when there is no article to show. A
-       ;; failed re-fetch (`:status :error`) of an already-loaded article
-       ;; leaves the prior `:data` in place — render it (the `article`
-       ;; branch below) rather than blanking a page the user is reading.
-       ;; Never blank loaded data on a refresh failure. (tags.cljs keeps
-       ;; prior `:tags` visible across a `:fetch-failed` the same way.)
+       ;; Show the error view only when there's no article to fall back on. If
+       ;; a re-fetch of an already-loaded article fails (`:status :error`), the
+       ;; prior `:data` is still sitting there — so render it (via the `article`
+       ;; branch below) instead of yanking the page out from under someone
+       ;; mid-read. The rule: never blank loaded data on a refresh failure.
+       ;; (tags.cljs keeps its prior `:tags` up across a `:fetch-failed` for the
+       ;; same reason.)
        (and article-error (nil? article))
        [:div.article-preview.error
         (str "Couldn't load article: " (pr-str article-error))]
@@ -500,12 +521,13 @@
           [:h1 {:data-testid "article-title"} (:title article)]
           [:p {:data-testid "article-description"} (:description article)]
           [:span.article-controls
-           ;; The official RealWorld article-detail favorite
-           ;; control shows visible "Favorite"/"Unfavorite" text and toggles
-           ;; `.btn-outline-primary` (not favorited) ↔ `.btn-primary`
-           ;; (favorited) — the E2E contract asserts on both. The compact
-           ;; heart-only button on article cards stays `.btn-outline-primary`
-           ;; (that one is correct per the official client).
+           ;; The big favorite button on the detail page spells it out —
+           ;; "Favorite" / "Unfavorite" — and swaps `.btn-outline-primary`
+           ;; (not favorited) for `.btn-primary` (favorited); the E2E suite
+           ;; checks both the text and the class. (The compact heart-only
+           ;; button on the article cards stays `.btn-outline-primary`
+           ;; throughout — that's the official client's behaviour there, not
+           ;; an oversight here.)
            (let [favorited? (:favorited article)]
              [:button.btn.btn-sm
               {:type        "button"

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -1,15 +1,23 @@
 (ns realworld.core
   "Entry point for the RealWorld (Conduit) example.
 
-   Wires the app together:
-   - Pulls in every feature namespace (each registers its own events/subs/fx).
-   - Defines :app/initialise (the boot event, run via the frame's :initial-events).
-   - Defines the root-view that switches on :rf.route/id.
-   - Mounts the React root. The `frame-provider {:id …}` at the render root
-     creates and seeds the app frame in one spot.
-   - Installs the URL listener.
+   This is the assembly line. It pulls in every feature namespace, defines
+   the boot event, picks the page to show based on the current route, and
+   mounts the whole thing into the DOM. Think of it as the spot where all
+   the pieces meet — almost nothing interesting happens here, and that's the
+   point: the interesting work lives in the feature files, and this file
+   just snaps them together.
 
-   This is single-file glue; the per-feature work lives in:
+   What it does, end to end:
+   - Pulls in every feature namespace (each registers its own events/subs/fx).
+   - Defines :app/initialise — the boot event, run via the frame's
+     :initial-events.
+   - Defines the root-view that switches on :rf.route/id to pick the page.
+   - Mounts the React root. One `frame-provider {:id …}` at the render root
+     creates and seeds the app frame in a single place.
+   - Installs the URL listener for Back/Forward.
+
+   The per-feature work lives in:
      auth.cljs             — login / register / session-restore
      articles.cljs         — global feed + home page
      comments.cljs         — article detail + comments
@@ -25,26 +33,25 @@
      http.cljs             — request-builder + retry policy for :rf.http/managed
      ssr.cljc              — hydration payload helper for the RealWorld app
 
-   Every Conduit endpoint goes via `:rf.http/managed`. The demo entry
-   below installs a canned-stub override so the app runs without a network.
-   See the HTTP guide: ../../../docs/resources/http.md"
+   Every Conduit endpoint goes out via `:rf.http/managed`. The demo entry
+   below swaps in a canned-stub override so the app runs with no network at
+   all. See the HTTP guide: ../../../docs/resources/http.md"
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            ;; Managed HTTP ships in the re-frame2-http artefact.
-            ;; Requiring the ns registers the `:rf.http/managed` fx (and
-            ;; family) so dispatching it resolves.
+            ;; Managed HTTP ships in its own artefact. Requiring it registers
+            ;; the `:rf.http/managed` fx (and its family), so dispatching it
+            ;; resolves to something.
             [re-frame.http.managed]
-            ;; The demo routes `:rf.http/managed` through a per-URL stub
-            ;; that delegates to `:rf.http/managed-canned-success`. That
-            ;; canned-stub fx ships in re-frame.http.test-support. A real
-            ;; Conduit backend would drop this require with the demo
-            ;; override.
+            ;; The demo routes `:rf.http/managed` through a per-URL stub that
+            ;; delegates to `:rf.http/managed-canned-success` — a canned-reply
+            ;; fx that ships with the framework's test support. A real Conduit
+            ;; backend would drop both this require and the demo override.
             [re-frame.http.test-support]
-            ;; SSR ships in the re-frame2-ssr artefact. Requiring the ns
-            ;; registers the `:rf/hydrate` handler and the SSR helpers
-            ;; ssr.cljc calls (`rf/render-tree-hash`).
+            ;; SSR ships in its own artefact. Requiring it registers the
+            ;; `:rf/hydrate` handler and the SSR helpers ssr.cljc leans on
+            ;; (`rf/render-tree-hash`).
             [re-frame.ssr]
             [re-frame.adapter.reagent :as reagent-adapter]
             [realworld-shared.avatar :as avatar]
@@ -66,12 +73,14 @@
 ;; ============================================================================
 
 (rf/reg-event :app/initialise
-  {:doc "App boot. Fans out to per-feature initialisers. `:auth/initialise`
-         is kept out of this fan-out and listed as its own `:initial-event`
-         in the frame-provider: it consumes the recordable
-         `:auth.session/token` coeffect, and the `:dispatch` fx does not
-         forward `:rf.cofx`. Running it on its own boot dispatch is what
-         lets the read token be recorded."}
+  {:doc "App boot. This is the conductor's downbeat: it fans out to every
+         feature's own initialiser so each slice gets seeded.
+
+         Notice who's NOT in this list: `:auth/initialise`. It earns its own
+         entry in the frame-provider's `:initial-events` instead, because it
+         consumes the recordable `:auth.session/token` coeffect — and the
+         `:dispatch` fx doesn't forward `:rf.cofx`. Giving it a boot dispatch
+         of its own is what lets the token it reads be recorded for replay."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:articles/initialise]]
           [:dispatch [:article/initialise]]
@@ -85,22 +94,24 @@
           [:dispatch [:auth.login-form/initialise]]
           [:dispatch [:auth.register-form/initialise]]]}))
 
-;; The JWT at [:auth :token] is sensitive. Declare it via the `:sensitive`
-;; classification effect, returned alongside `:db` from an event the frame
-;; runs at creation (`:initial-events`, before any boot dispatch or off-box
-;; egress). Any off-box egress (an observability capture, an off-box tool,
-;; an SSR hydration payload) then sees the token redacted while on-box
-;; rendering keeps the raw value.
+;; The JWT at [:auth :token] is a real credential, so we'd rather it didn't
+;; turn up in a trace export or an SSR payload. The fix is one line: tell the
+;; framework the path is sensitive, via the `:sensitive` classification
+;; effect, returned alongside `:db` from an event the frame runs at creation
+;; (`:initial-events`, before any boot dispatch or any chance to leak off-box).
+;; From then on, anything that leaves the box — an observability capture, an
+;; external tool, a hydration payload — sees the token redacted, while the
+;; running app keeps the raw value it needs.
 ;;
-;; This app classifies exactly one path. The outbound `Authorization`
-;; Bearer header rides the framework's built-in HTTP carrier denylist, so
-;; it is redacted off-box with no app config. The login / register password
-;; drafts at [:auth :login-form] / [:auth :register-form] are transient form
-;; state, never sent off-box from app-db, so they need no classification.
-;; See the keep-secrets how-to:
+;; One path is all this app has to classify by hand. The outbound
+;; `Authorization` Bearer header is already on the framework's built-in HTTP
+;; carrier denylist, so it's redacted off-box with zero config. And the
+;; login / register password drafts at [:auth :login-form] /
+;; [:auth :register-form] are throwaway form state that never leaves app-db,
+;; so there's nothing there to protect. See the keep-secrets how-to:
 ;; ../../../docs/guide/how-to/keep-secrets-out-of-traces.md
 (rf/reg-event :auth/classify-token
-  {:doc "Classifies the durable JWT path [:auth :token] sensitive at frame
+  {:doc "Mark the durable JWT path [:auth :token] sensitive, at frame
          creation."}
   (fn handler-auth-classify-token [{:keys [db]} _]
     {:db db :sensitive [[:auth :token]]}))
@@ -109,10 +120,11 @@
 ;; APP-SHELL VIEWS
 ;; ============================================================================
 
-(reg-view ^{:doc "The site header. Shows different links based on auth state.
-                  Each nav link carries a stable data-testid hook — the
-                  idiomatic way to give UI tests a target that survives
-                  styling churn (no brittle class / text matching)."}
+(reg-view ^{:doc "The site header. Shows one set of links when you're signed
+                  in, another when you're not. Each nav link carries a stable
+                  data-testid hook — the friendly way to give UI tests a
+                  target that survives a CSS redesign, instead of having them
+                  match on classes or button text that drift over time."}
           header []
   (let [authed? @(subscribe [:auth/authenticated?])
         user    @(subscribe [:auth/user])]
@@ -131,9 +143,9 @@
            [rf/route-link {:to :realworld.user/settings :class "nav-link"}
             [:i.ion-gear-a] " Settings"]]
           [:li.nav-item
-           ;; The official RealWorld navbar shows the authenticated
-           ;; user's avatar (`.user-pic`) next to their name; default-avatar
-           ;; covers a nil/empty image.
+           ;; The official RealWorld navbar puts the signed-in user's avatar
+           ;; (`.user-pic`) next to their name; `avatar-src` falls back to a
+           ;; default when the image is nil or empty.
            [rf/route-link {:to :realworld.profile/show
                                 :params {:username (:username user)}
                                 :class "nav-link"
@@ -165,8 +177,11 @@
     [:span.attribution "An interactive learning project from Thinkster."
      " Code & design licensed under MIT."]]])
 
-(reg-view ^{:doc "Renders a confirm dialog when navigation is blocked by a
-                  :can-leave guard. Reads the runtime-db [:rf.runtime/routing :pending-navigation] slot via the `:rf/pending-navigation` sub."}
+(reg-view ^{:doc "The \"are you sure?\" dialog. When a `:can-leave` guard
+                  blocks a navigation (you've got unsaved edits in the
+                  article editor, say), the framework parks the pending nav
+                  and this view pops up to ask. Reads the parked nav from the
+                  `:rf/pending-navigation` sub."}
           pending-nav-dialog []
   (when-let [pending @(subscribe [:rf/pending-navigation])]
     [:div.pending-nav-overlay
@@ -184,7 +199,9 @@
      (when url [:p (str "No route matches: " url)])
      [rf/route-link {:to :realworld/home} "Home"]]))
 
-(reg-view ^{:doc "App-level root. Switches on :rf.route/id to render the active page."}
+(reg-view ^{:doc "The root of the whole tree. One big `case` over
+                  :rf.route/id picks which page to render — the routing
+                  table's way of saying \"you are here, show this\"."}
           root-view []
   [:div.app
    [header]
@@ -210,45 +227,50 @@
 ;; ----------------------------------------------------------------------------
 ;; DEMO STUBS
 ;;
-;; The example would normally hit the hosted Conduit API
-;; (https://api.realworld.show/api — `realworld.http/api-base`), which is
-;; slow and unreliable for a demo. Override `:rf.http/managed` with a small
-;; in-process stub that synthesises the reply shape for the routes the demo
-;; exercises (global feed, tags, profile). Anything else resolves to an
-;; empty-payload success — enough for the app shell + main feed to render.
+;; Out of the box this example talks to no server at all. Normally it would
+;; hit the hosted Conduit API (https://api.realworld.show/api —
+;; `realworld.http/api-base`), but a live backend is slow and flaky for a
+;; demo, and we'd like you to be able to clone-and-run on a plane. So we
+;; override `:rf.http/managed` with a tiny in-process stub that hand-rolls a
+;; plausible reply for the routes the demo actually exercises (global feed,
+;; tags, profile). Anything we didn't bother stubbing just comes back as an
+;; empty success — enough for the shell and the main feed to render.
 ;;
-;; The override delegates to `:rf.http/managed-canned-success` with a
-;; per-URL `:value` payload and an `:after-ms` delay, so the framework
-;; defers the reply via `:dispatch-later` — observable in the trace,
-;; time-travel-safe, not raw `js/setTimeout`. A wrapper fx routes by URL so
-;; the demo doesn't have to know one URL ahead of time.
+;; The override doesn't fake the timing itself. It hands off to the
+;; framework's `:rf.http/managed-canned-success` with a per-URL `:value`
+;; payload and an `:after-ms` delay, so the reply rides out on
+;; `:dispatch-later` — which means it shows up in the trace and survives
+;; time-travel, instead of being an invisible raw `js/setTimeout`. A thin
+;; wrapper fx routes by URL so the demo doesn't have to commit to one URL up
+;; front.
 ;; ----------------------------------------------------------------------------
 
 (def ^:private demo-reply-delay-ms
-  "How long the demo stub defers each canned reply (via the canned-success
-   fx's `:after-ms`, dispatched through `:dispatch-later`). Small but
-   non-zero so the `:loading` UI state is visible in the demo. A demo knob,
-   not a production value."
+  "How long the demo stub sits on each canned reply before delivering it (the
+   canned-success fx's `:after-ms`, routed through `:dispatch-later`). Small
+   but not zero, on purpose — without a beat of delay you'd never see the
+   `:loading` state flash by. A demo knob, not a production value."
   20)
 
-;; A corpus larger than one page (25 articles) so the official
-;; limit/offset pagination is observable in the standalone demo: with the
-;; fixed page size of 10 (`realworld.http/page-size`) that is three pages.
-;; `demo-articles` keeps its hand-written first two cards (so the article
-;; detail / favorites paths see familiar slugs) and pads the rest
-;; programmatically.
+;; Twenty-five articles — deliberately more than one page — so you can
+;; actually watch pagination work in the standalone demo. At the fixed page
+;; size of 10 (`realworld.http/page-size`) that's three pages. The first two
+;; cards are hand-written (so the article-detail and favorites paths land on
+;; familiar slugs); the rest are padded out in a loop, because nobody needs
+;; to read twenty-three more lovingly-crafted fake articles.
 (def ^:private demo-articles
   (into [{:slug "hello-conduit"
           :title "Hello, Conduit"
           :description "A short greeting from the realworld stub."
-          ;; A markdown body so the article-detail page exercises the
-          ;; sanitized CommonMark renderer (realworld-shared.markdown/render —
-          ;; render): headings, bold/italic, inline + fenced code, a safe
-          ;; link, lists, plus full-CommonMark shapes a hand-rolled subset would
-          ;; miss (a table, a nested list). The renderer emits
-          ;; hiccup (never raw HTML), so this is real markup while any injected
-          ;; `<script>` / `javascript:` link in user content degrades to inert
-          ;; escaped text.
+          ;; A deliberately rich markdown body, so the article-detail page
+          ;; gives the sanitized CommonMark renderer
+          ;; (realworld-shared.markdown/render) a real workout: headings,
+          ;; bold/italic, inline + fenced code, a safe link, lists, and the
+          ;; full-CommonMark shapes a hand-rolled subset always forgets — a
+          ;; table, a nested list. The renderer emits hiccup, never raw HTML,
+          ;; which is the whole trick: this renders as genuine markup, while
+          ;; any `<script>` or `javascript:` link smuggled in via user content
+          ;; comes out as inert, escaped text.
           :body (str "# Hello, Conduit\n\n"
                      "This article is served by the demo `:rf.http/managed` "
                      "override and rendered as **markdown** with *emphasis*.\n\n"
@@ -303,17 +325,18 @@
                             :following false}})))
 
 (defn- parse-int-param
-  "Pull an integer query param `k` (e.g. \"limit\") out of a URL string, or
-   nil when absent / unparseable."
+  "Fish an integer query param `k` (e.g. \"limit\") out of a URL string.
+   nil when it's absent or doesn't look like a number."
   [u k]
   (when-let [m (re-find (re-pattern (str "[?&]" k "=(\\d+)")) u)]
     (js/parseInt (second m) 10)))
 
 (defn- page-of
-  "Return the limit/offset window of `articles` for the demo stub, plus the
-   grand `articlesCount` — the canonical Conduit list-response shape. Reads
-   `limit` / `offset` straight off the URL (defaulting to the whole list when
-   absent), so the stub paginates exactly like the real backend."
+  "Slice out one page of `articles` for the demo stub, and report the grand
+   `articlesCount` alongside it — the exact list-response shape Conduit uses.
+   It reads `limit` / `offset` straight off the URL (and shows the whole list
+   when they're missing), so the stub paginates just like the real backend
+   would, and the page-number control downstream can't tell the difference."
   [articles u]
   (let [total  (count articles)
         offset (or (parse-int-param u "offset") 0)
@@ -325,10 +348,10 @@
   ["intro" "demo" "clojure" "re-frame"])
 
 (def ^:private demo-user
-  "Canned `User` payload returned by /users/login, /users (register),
-   and /user (session restore). The auth fixtures submit matching
-   credentials at the login form; the stub doesn't verify the body,
-   it just synthesises the success reply the auth machine expects."
+  "The one user this demo knows about — handed back by /users/login,
+   /users (register), and /user (session restore). The stub doesn't check
+   your password (or anything else in the body); it just plays back the
+   success reply the auth machine is hoping for. Security theatre it is not."
   {:email    "demo@conduit.dev"
    :token    "stub.demo.jwt"
    :username "demo"
@@ -336,10 +359,11 @@
    :image    ""})
 
 (defn- canned-comment
-  "Synthesise a saved Comment reply for POST /articles/:slug/comments.
-   The reply value is `{:comment <Comment>}`; the comments handler patches
-   the optimistic temp card out and inserts this saved row by `:id`. A
-   unique numeric id per call avoids :key collisions across repeat posts."
+  "Fake up the saved-Comment reply for POST /articles/:slug/comments. The
+   reply is `{:comment <Comment>}`; back in comments.cljs the handler swaps
+   the optimistic temp card for this saved row, matching on `:id`. We mint a
+   fresh random id every call so two comments posted in a row don't collide
+   on their React `:key`."
   [body]
   (let [id (+ 1000 (rand-int 100000))]
     {:comment {:id        id
@@ -365,11 +389,11 @@
       (and (= method :post) (str/ends-with? u "/users"))
       {:user demo-user}
 
-      ;; GET /user — current-user session restore. We deliberately do
-      ;; NOT auto-restore here (return empty payload so the schema
-      ;; decode fails into the failure branch and the auth machine
-      ;; falls back to :idle). The auth fixtures rely on the app
-      ;; starting unauthenticated.
+      ;; GET /user — session restore on boot. We return an empty payload on
+      ;; purpose: it fails the schema decode, drops into the failure branch,
+      ;; and the auth machine settles back to :idle. Net effect — the demo
+      ;; always opens logged-out, so you get to click "Sign in" and watch the
+      ;; flow rather than arriving mysteriously authenticated.
       (and (= method :get) (str/ends-with? u "/user"))
       {}
 
@@ -405,53 +429,54 @@
       :else {})))
 
 (rf/reg-fx :realworld.demo/http-stub
-  {:doc       "Demo override for `:rf.http/managed`: routes by URL to
-               canned Conduit-shaped responses so the example runs
-               standalone without a backend.
+  {:doc       "The demo's stand-in for `:rf.http/managed`. It looks at the URL,
+               picks a matching canned Conduit-shaped reply, and lets the
+               example run with no backend in sight.
 
-               Delegates to the framework-shipped
-               `:rf.http/managed-canned-success` with the per-URL canned
-               payload and `:after-ms` (`demo-reply-delay-ms`): the
-               framework defers the reply via `:dispatch-later` —
-               observable in the trace, time-travel-safe, not raw
-               `js/setTimeout`. The delay makes the `:loading` UI state
-               observable."
+               It doesn't reinvent the delivery machinery — it hands the
+               payload to the framework's `:rf.http/managed-canned-success`
+               with `:after-ms` set to `demo-reply-delay-ms`. The framework
+               then defers the reply via `:dispatch-later`, so it shows up in
+               the trace and survives time-travel instead of being a raw
+               `js/setTimeout`. The little delay is what makes the `:loading`
+               state actually visible."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
     (let [payload (demo-payload-for-args args-map)
           stub    (registrar/handler :fx :rf.http/managed-canned-success)]
       (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))
 
-;; The React root, held in an atom and created lazily inside `run` so that
-;; loading this namespace has no DOM side effects. Several example namespaces
-;; (this one, nine-states, boot, long-running-work, websocket) are co-required
-;; by the browser-test bundle and share a single `#app` mount point; creating
-;; the root at ns-load would race multiple roots onto the same container and
-;; leak one example's mount into another's tests (and emit React "createRoot
-;; called twice" warnings). The name `react-root` keeps it clear of the
-;; `root-view` reg-view above.
+;; The React root lives in an atom and gets created lazily inside `run`, so
+;; that merely loading this namespace touches no DOM. That restraint earns
+;; its keep: several example namespaces share a single `#app` mount point in
+;; the browser-test bundle, and creating the root at load time would race two
+;; roots onto the same container — one example's mount bleeding into another's
+;; tests, with React grumbling "createRoot called twice" the whole way. The
+;; name `react-root` (not `root`) keeps it distinct from the `root-view`
+;; above.
 (defonce react-root (atom nil))
 
 ;; ============================================================================
 ;; HTTP REQUEST INTERCEPTOR
 ;; ============================================================================
 ;;
-;; The per-frame request interceptor surface: one `:before` fn injects a
-;; Bearer token from the auth slice, so every outbound `:rf.http/managed`
-;; request that crosses this frame picks the auth header up. Call sites
-;; (`articles.cljs`, `comments.cljs`, ...) don't thread the token per call —
-;; the auth slice is the single source of truth and the interceptor is the
-;; single read site. See the HTTP guide on interceptors:
+;; Stamp the auth token onto every request, in exactly one place. This
+;; `:before` fn reads the JWT from the auth slice and adds the Bearer header,
+;; so every outbound `:rf.http/managed` request that passes through this frame
+;; picks it up automatically. The call sites in articles.cljs, comments.cljs,
+;; and friends never thread a token by hand — the auth slice is the single
+;; source of truth, and this interceptor is the single place that reads it.
+;; The day the token changes, you change it once. See the HTTP guide on
+;; interceptors:
 ;; ../../../docs/resources/http.md#interceptors-stamp-every-request-once
 ;;
-;; The interceptor returns the ctx unchanged when no token is present, so
-;; login / register / public-read endpoints are unaffected.
+;; No token? It hands the ctx straight back, so login, register, and
+;; public-read endpoints sail through unsigned, exactly as they should.
 ;;
-;; This is the one place the Bearer header is written; `rh/request`
-;; composes the request map and leaves the token to this interceptor. The
-;; interceptor reads from `(:frame ctx)` — the frame the cascade runs under
-;; — so the header tracks a non-default or multi-frame mount rather than a
-;; hard-coded `:rf/default`.
+;; It reads the token from `(:frame ctx)` — whichever frame the cascade is
+;; actually running under — rather than a hard-coded `:rf/default`, so the
+;; header still tracks the right session in a non-default or multi-frame
+;; mount.
 
 (defn- bearer-auth-interceptor [ctx]
   (let [token (some-> (rf/app-db-value (:frame ctx))
@@ -464,16 +489,17 @@
 ;; window.__conduit_debug__  — CONFORMANCE-CONTRACT SURFACE
 ;; ============================================================================
 ;;
-;; The official RealWorld E2E harness reads app session state through a global
-;; accessor. This installs `window.__conduit_debug__` with `getToken` /
-;; `getAuthState` / `getCurrentUser`, each reading the live `:rf/default`
-;; frame's app-db. It exists only so that external suite can introspect this
-;; demo; a production app would not ship it.
+;; The official RealWorld E2E suite peeks at session state through a global
+;; accessor, so to be a good conformance citizen we hang one on the window:
+;; `__conduit_debug__` with `getToken` / `getAuthState` / `getCurrentUser`,
+;; each reading the live `:rf/default` frame's app-db. It's here purely so the
+;; external suite can introspect this demo; a real app would never ship it.
 ;;
-;; This is a test seam, not a re-frame2 pattern. A global token accessor is the
-;; kind of thing that gets copied into real apps, where it bypasses the
-;; frame/sub system and leaks the raw JWT to any script on the page. Real
-;; re-frame2 code reads session state through subs under the frame provider.
+;; Treat this as a test seam, not a pattern to copy. A global token accessor
+;; is exactly the sort of thing that quietly migrates into production code,
+;; where it side-steps the frame/sub system and hands the raw JWT to any
+;; script on the page — which is to say, a small disaster. Real re-frame2 code
+;; reads session state through subs, under the frame provider.
 (defn- install-conduit-debug! [frame-id]
   (when (exists? js/window)
     (set! (.-__conduit_debug__ js/window)
@@ -484,67 +510,68 @@
                :getCurrentUser (fn [] (clj->js (some-> (rf/app-db-value frame-id) :auth :user)))})))
 
 (defn run []
-  ;; Install the Reagent adapter. This is the one frameworky thing that must
-  ;; happen before any frame mounts; everything else here is app wiring.
+  ;; Tell re-frame2 to render through Reagent. This is the one genuinely
+  ;; frameworky step, and it has to come before any frame mounts; everything
+  ;; below it is just this app wiring itself up.
   (rf/init! reagent-adapter/adapter)
-  ;; Register the Bearer-auth interceptor. It reads the JWT from the auth
-  ;; slice and adds the `Authorization` header to outbound `:rf.http/managed`
-  ;; requests (see bearer-auth-interceptor above). Register it before the
-  ;; frame's `:initial-events` run, so it is in place when session-restore
-  ;; fires its first authenticated request.
+  ;; Register the Bearer-auth interceptor (defined above) so it stamps the
+  ;; `Authorization` header onto outbound managed requests. Order matters:
+  ;; register it before the frame's `:initial-events` run, so it's already on
+  ;; duty when session-restore fires its first authenticated request.
   (rf/reg-http-interceptor :realworld/bearer-auth
                            {:before bearer-auth-interceptor})
-  ;; The orchestrator serves this example under /realworld/. Strip that
-  ;; prefix so :realworld/home (path "/") matches. Set it before the
-  ;; provider renders, so the initial URL→slice sync and the popstate
-  ;; listener see the stripped URL.
+  ;; The orchestrator serves this example under /realworld/, but the routes
+  ;; are written as if it owned `/`. Strip that prefix so :realworld/home
+  ;; (path "/") still matches. Set it before the provider renders, so the
+  ;; first URL→slice sync and the popstate listener both see the stripped URL.
   (routing/set-base-path! "/realworld")
-  ;; Wire the popstate listener for Back/Forward. Because this example
-  ;; strips its `/realworld/` prefix in `current-url`, it uses its own
-  ;; base-path-aware listener (the framework's
-  ;; `rf/install-history-listener!` assumes a root-served app). The listener
-  ;; resolves the URL owner at pop time and is hot-reload safe. The first
-  ;; URL→slice sync is seeded by the frame's `:initial-events`
-  ;; (`:rf.route/handle-url-change` below), so a deep link lands on the
-  ;; right route on first paint.
+  ;; Wire up Back/Forward. This example rolls its own base-path-aware popstate
+  ;; listener rather than the framework's `rf/install-history-listener!`,
+  ;; which assumes the app owns the root path — and ours doesn't, it's tucked
+  ;; under `/realworld/`. The listener figures out the URL's owning frame at
+  ;; pop time and is safe to call again on hot-reload. The very first
+  ;; URL→slice sync isn't done here though; the frame's `:initial-events`
+  ;; handle it (`:rf.route/handle-url-change` below), so a deep link lands on
+  ;; the right route on the first paint.
   (routing/install-router!)
-  ;; Install the conformance accessor for the external RealWorld suite. This
-  ;; is a test seam, not a re-frame2 pattern — see install-conduit-debug!
-  ;; above.
+  ;; Hang the conformance accessor on the window for the external RealWorld
+  ;; suite. Test seam, not a pattern — see install-conduit-debug! above.
   (install-conduit-debug! :rf/default)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; The frame lives here. `frame-provider {:id …}` creates, configures,
-    ;; and seeds the app frame in one spot at the render root. First mount
-    ;; creates `:rf/default` and applies its config:
+    ;; Here's where the frame is born. A single `frame-provider {:id …}` at
+    ;; the render root creates, configures, and seeds the app frame all in one
+    ;; place. The first mount conjures `:rf/default` and applies its config:
     ;;   - `:url-bound? true` — this frame owns the browser URL.
-    ;;   - `:interceptors [:realworld.routing/auth-guard]` — the guard
-    ;;     (defined in routing.cljs, referenced by id) runs on every event in
-    ;;     the frame. It redirects an unauthenticated navigation to a
-    ;;     `:requires-auth` route over to login — what makes the
-    ;;     `:requires-auth` tags on settings / new / edit actually protect
-    ;;     them.
-    ;;   - `:fx-overrides {:rf.http/managed …}` — route managed HTTP to the
-    ;;     demo stub so the example runs with no backend.
-    ;; First mount also runs `:initial-events` once; hot reload reuses the
-    ;; frame without re-seeding (durable app-db survives).
+    ;;   - `:interceptors [:realworld.routing/auth-guard]` — the guard (defined
+    ;;     in routing.cljs, named here by id) runs on every event in the frame.
+    ;;     It's the bouncer: try to navigate to a `:requires-auth` route while
+    ;;     logged out and it sends you to login instead. This is what gives the
+    ;;     `:requires-auth` tags on settings / new / edit actual teeth.
+    ;;   - `:fx-overrides {:rf.http/managed …}` — point managed HTTP at the
+    ;;     demo stub so the whole thing runs without a backend.
+    ;; First mount also runs `:initial-events` once. A hot reload reuses the
+    ;; existing frame and does NOT re-seed — your durable app-db survives the
+    ;; code swap, which is rather the point.
     ;;
-    ;; `:initial-events` run in order at frame creation:
-    ;;   - `:auth/classify-token` — classify [:auth :token] sensitive before
-    ;;     the token is written, so it is redacted off-box from the first
-    ;;     write on.
-    ;;   - `:auth/initialise` — session restore. It pulls the saved JWT
-    ;;     through the `:auth.session/token` recordable coeffect (auth.cljs),
-    ;;     which reads localStorage once and records the value so replay and
-    ;;     epoch-restore re-present it verbatim. Runs before `:app/initialise`
-    ;;     so the token is in app-db before the bearer-auth interceptor sends
-    ;;     any authenticated request.
-    ;;   - `:app/initialise` — fans out to the per-feature initialisers.
-    ;;   - `:rf.route/handle-url-change` — the first URL→slice sync, from the
-    ;;     base-path-stripped current URL. Runs last so the auth-guard sees
-    ;;     the restored session when redirecting a deep link to a
-    ;;     `:requires-auth` route.
+    ;; `:initial-events` fire in order at frame creation, and the order is
+    ;; load-bearing:
+    ;;   - `:auth/classify-token` — mark [:auth :token] sensitive BEFORE the
+    ;;     token is ever written, so it's redacted off-box from the very first
+    ;;     write. Lock the door before anyone's home.
+    ;;   - `:auth/initialise` — session restore. It pulls the saved JWT through
+    ;;     the `:auth.session/token` recordable coeffect (auth.cljs), which
+    ;;     reads localStorage once and records the value so replay and
+    ;;     epoch-restore play back the exact same token. It runs before
+    ;;     `:app/initialise` so the token is sitting in app-db before the
+    ;;     bearer-auth interceptor needs to send anything authenticated.
+    ;;   - `:app/initialise` — fans out to all the per-feature initialisers.
+    ;;   - `:rf.route/handle-url-change` — the first URL→slice sync, off the
+    ;;     base-path-stripped current URL. Last on purpose: by now the session
+    ;;     is restored, so when the auth-guard considers redirecting a deep
+    ;;     link to a `:requires-auth` route, it's judging a logged-in user
+    ;;     correctly rather than bouncing them by mistake.
     (rdc/render @react-root
                 [rf/frame-provider {:id              :rf/default
                                     :doc             "Realworld demo frame."

--- a/examples/reagent/realworld/favorites.cljs
+++ b/examples/reagent/realworld/favorites.cljs
@@ -1,10 +1,13 @@
 (ns realworld.favorites
   "Favorite/unfavorite actions plus the authenticated user's feed.
 
-   The favorite toggle is shared across the home feed, profile lists, and
-   the article-detail page. The followed-authors feed is its own remote-data
-   slice so the home page can switch between feeds without throwing away
-   already-loaded global articles."
+   One favorite toggle, used in three places — the home feed, the profile
+   lists, and the article-detail page. The catch is that the same article can
+   be on screen in several of those at once, so a favorite has to be patched
+   everywhere it appears; the cross-slice helpers below are what make that
+   tidy. The followed-authors feed gets its own remote-data slice, so flipping
+   between feeds on the home page doesn't throw away global articles you've
+   already loaded."
   (:require [re-frame.core :as rf]
             [realworld.schema :as schema]
             [realworld.http :as rh]))
@@ -53,17 +56,13 @@
     {:db (assoc db :feed (request-slice))}))
 
 (rf/reg-event :feed/load
-  {:doc "Fetch the authenticated user's feed. Carries
-         `:request-id :feed/load` so :feed/cancel can abort an in-flight
-         load when the user navigates away.
-
-         Also broadcasts `:fetch-started` into the home machine so the
-         `:data` region advances to `:loading` (or `:refreshing` from
-         `:some`).
-
-         `?page=` (the home route's 1-indexed page) becomes the wire's
-         limit/offset window via `rh/paginate-path` — the same pagination
-         the global feed uses."
+  {:doc "Fetch the signed-in user's feed. Carries `:request-id :feed/load`, so
+         :feed/cancel can pull the plug if the user wanders off mid-load. Also
+         broadcasts `:fetch-started` into the home machine, nudging the `:data`
+         region to `:loading` (or `:refreshing`, if a list is already up). The
+         home route's 1-indexed `?page=` becomes the wire's limit/offset window
+         via `rh/paginate-path` — the very same pagination the global feed
+         uses."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [page (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)
@@ -84,16 +83,17 @@
                           :on-failure [:feed/load-failed]})]]})))
 
 (rf/reg-event :feed/cancel
-  {:doc "Abort an in-flight :feed/load — e.g. when the user navigates away
-         mid-load. See the HTTP guide on aborts:
+  {:doc "Abort an in-flight :feed/load — say the user leaves before it lands.
+         No point delivering a reply to a screen that's gone. See the HTTP
+         guide on aborts:
          ../../../docs/resources/http.md#the-search-box-race-cured"}
   (fn [_ _]
     {:fx [[:rf.http/managed-abort :feed/load]]}))
 
 (rf/reg-event :feed/loaded
-  {:doc "Successful user-feed fetch. Folds the new count into the home
-         machine via `:fetch-succeeded`; the `:data` region's
-         `:resolving` `:always`-cascade picks `:empty` or `:some`."
+  {:doc "The user-feed fetch came back happy. Folds the new count into the home
+         machine via `:fetch-succeeded`, and the `:data` region's `:resolving`
+         `:always` cascade takes it from there — `:empty` or `:some`."
    :rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
     (let [items (vec (:articles value))
@@ -107,8 +107,8 @@
                         [:fetch-succeeded {:items items}]]]]})))
 
 (rf/reg-event :feed/load-failed
-  {:doc "Failed user-feed fetch. Folds the failure into the home machine
-         via `:fetch-failed`; the `:data` region advances to `:error`."}
+  {:doc "The user-feed fetch didn't make it. Folds the failure into the home
+         machine via `:fetch-failed`, sending the `:data` region to `:error`."}
   (fn [{:keys [db]} [_ {:keys [failure]}]]
     (let [message (rh/failure->message failure)]
       {:db (-> db
@@ -121,39 +121,40 @@
 ;; FAVORITES
 ;; ============================================================================
 ;;
-;; Optimistic rollback shapes across the app. realworld has three
-;; optimistic-with-rollback flows, and they use three different rollback
-;; shapes on purpose — because the thing being rolled back differs:
+;; A short word on why the three optimistic-with-rollback flows in realworld
+;; don't share one rollback helper — because it looks like an obvious DRY
+;; opportunity, and it isn't. The reason is that each one is undoing a
+;; genuinely different shape of change:
 ;;
-;;   - favorite (here): snapshots {:favorited :favoritesCount} and patches
-;;     the article EVERYWHERE it appears (across the :articles / :feed /
-;;     :profile.* slices) via the shared `patch-article-everywhere` /
-;;     `update-article-in-list` helpers below — the cross-slice case.
-;;   - follow (profile.cljs): snapshots a single boolean — one field, one
-;;     slice — so a helper would be heavier than the `assoc-in` it replaces.
-;;   - comment-delete (comments.cljs): snapshots {:index :comment} and
-;;     re-inserts the removed comment at its original position — a positional
-;;     splice the map-and-swap helper here can't express (the entry is gone,
-;;     not present-to-map-over).
+;;   - favorite (here): snapshots {:favorited :favoritesCount} and patches the
+;;     article EVERYWHERE it appears (across the :articles / :feed / :profile.*
+;;     slices), using the shared `patch-article-everywhere` /
+;;     `update-article-in-list` helpers below. This is the cross-slice case.
+;;   - follow (profile.cljs): snapshots a single boolean — one field, one slice.
+;;     A helper here would be more ceremony than the `assoc-in` it'd replace.
+;;   - comment-delete (comments.cljs): snapshots {:index :comment} and slots the
+;;     removed comment back at its original position — a positional splice the
+;;     map-and-swap helper can't even express, because the entry is gone, not
+;;     sitting there waiting to be mapped over.
 ;;
-;; A single shared optimistic helper would have to abstract over "patch a
-;; field across N slices", "flip one boolean", and "re-insert at an index" —
-;; obscuring more than it saves. The shared surface that DOES pay off
-;; (cross-slice article patching) is already factored out below and reused
-;; by `:comment-form/submit-success`'s in-place swap. So: shared where it
-;; helps, distinct where the data shapes genuinely differ — not an oversight.
+;; One shared helper would have to paper over \"patch a field across N slices\",
+;; \"flip one boolean\", and \"re-insert at an index\" all at once — and an
+;; abstraction that vague hides more than it saves. The shared bit that DOES
+;; earn its keep (cross-slice article patching) is factored out below, and
+;; `:comment-form/submit-success` reuses it for its in-place swap. Shared where
+;; it helps, separate where the shapes truly differ — deliberate, not an
+;; oversight.
 
 (rf/reg-event :article/toggle-favorite
-  {:doc "Optimistically flip the favorited flag and bump the count, then
-         POST or DELETE the favorite. On failure the prior state is
-         restored (rollback).
+  {:doc "Flip the favorited flag and nudge the count immediately, then send the
+         POST or DELETE; if it fails, put the old values back (rollback).
 
-         Auth-gated: favoriting requires a session. An unauthenticated
-         click navigates to login instead of issuing a tokenless request
-         that the real Conduit backend would 401 — so there is no
-         optimistic flip-then-rollback flicker for a logged-out user. (The
-         demo stub 200s everything, which would mask the 401; gating here
-         keeps the example correct against the real backend it documents.)"
+         Auth-gated: favoriting needs a session, so a logged-out click goes to
+         login rather than firing a tokenless request the real Conduit backend
+         would 401 — which means no ugly flip-then-rollback flicker for a
+         signed-out user. (Why gate it when the demo stub 200s everything? That
+         friendly stub would happily mask the 401; gating here keeps the
+         example honest against the real backend it's documenting.)"
    :rf.http/decode-schemas [schema/ArticleResponse]}
   (fn [{:keys [db]} [_ slug]]
     (if (nil? (get-in db [:auth :user]))

--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -1,38 +1,40 @@
 (ns realworld.http
   "HTTP helpers for the RealWorld (Conduit) example.
 
-   Every Conduit endpoint goes out via `:rf.http/managed`, the
-   framework-shipped managed HTTP fx. The framework owns transport,
-   decoding, status classification, retry-with-backoff, abort, and reply
-   addressing; the example just composes request maps. See the HTTP guide:
-   ../../../docs/resources/http.md
+   Every Conduit endpoint goes out via `:rf.http/managed`, the framework's
+   managed HTTP fx. That's a deliberately good deal: the framework handles
+   transport, decoding, status classification, retry-with-backoff, abort, and
+   reply addressing, and all this example has to do in return is hand it a
+   request map. See the HTTP guide: ../../../docs/resources/http.md
 
    BACKEND MODES (see this example's README §Running against a real backend):
-   - canned demo stub (DEFAULT) — `core.cljs` overrides `:rf.http/managed` with
-     an in-process per-URL stub, so the app runs with NO network. `api-base` is
-     not contacted; the stub matches on the path suffix.
-   - official hosted API — point `api-base` at the current hosted Conduit API
-     `https://api.realworld.show/api` and drop the demo-stub override.
+   - canned demo stub (DEFAULT) — `core.cljs` overrides `:rf.http/managed`
+     with an in-process per-URL stub, so the app runs with NO network at all.
+     `api-base` is never contacted; the stub matches on the path suffix.
+   - official hosted API — point `api-base` at the hosted Conduit API,
+     `https://api.realworld.show/api`, and drop the demo-stub override.
    - local reference backend — the upstream Node/Postgres backend on
      `http://localhost:3000/api`.
 
-   This namespace ships TWO small helpers on top of `:rf.http/managed`:
+   This namespace adds just two small conveniences on top of
+   `:rf.http/managed`:
 
-   - `request` — build a request map (`{:request {...} :decode ... :retry ...}`)
-     that bakes in the API base URL and JSON content-type. The Bearer token
-     is not read here: auth-header injection is centralised in the
-     `:realworld/bearer-auth` HTTP interceptor (`core.cljs`), which reads the
-     token from the carried frame's auth slice (`(:frame ctx)`) on every
-     request — so the header tracks whichever frame the cascade runs under,
-     not a hard-coded `:rf/default`.
-   - `data-fetch-retry` — the standard retry policy for read-only fetches
-     (transport, 5xx, timeout — not 4xx; the request was valid even when the
-     server is sad).
+   - `request` — builds the request map (`{:request {...} :decode ... :retry
+     ...}`), baking in the API base URL and the JSON content-type so you don't
+     repeat them at every call site. It pointedly does NOT touch the Bearer
+     token: signing requests is the `:realworld/bearer-auth` interceptor's one
+     job (`core.cljs`), and it reads the token from the carried frame on every
+     request — so the header follows whichever frame the cascade is running
+     under, not a hard-coded `:rf/default`.
+   - `data-fetch-retry` — the house retry policy for read-only fetches:
+     transport, 5xx, and timeout, but never 4xx. A 4xx means the request was
+     valid even though the server was unhappy with it, so retrying changes
+     nothing except how long you wait to hear the same no.
 
    The RealWorld spec lives at
-   https://github.com/gothinkster/realworld/tree/main/api. This file
-   registers no fx — the demo entry (`core.cljs`) wires `:rf.http/managed`
-   to a canned-stub override so the app runs without a network."
+   https://github.com/gothinkster/realworld/tree/main/api. This file registers
+   no fx of its own — `core.cljs` is where `:rf.http/managed` gets pointed at
+   the canned stub so the app runs offline."
   (:require [clojure.string]
             [re-frame.core :as rf]))
 
@@ -41,12 +43,12 @@
 ;; ============================================================================
 
 (def api-base
-  "Default API base URL — the current official hosted Conduit API. The DEFAULT
-   run mode overrides `:rf.http/managed` with an in-process canned stub
-   (`core.cljs`), so this base is not actually contacted out of the box; it is
-   the base you keep when you drop the stub to run against the real hosted API.
-   For the local upstream reference backend, set it to
-   `http://localhost:3000/api`. See the README §Running against a real backend."
+  "Where the API lives — the hosted Conduit backend. Out of the box you never
+   reach it: the default run mode swaps `:rf.http/managed` for an in-process
+   canned stub (`core.cljs`). This is the URL that springs back to life the
+   moment you drop the stub to talk to the real hosted API. Pointing at a
+   local upstream backend instead? Use `http://localhost:3000/api`. See the
+   README §Running against a real backend."
   "https://api.realworld.show/api")
 
 (defn full-url [path]
@@ -56,46 +58,52 @@
 ;; PAGINATION (official RealWorld spec — limit/offset query params)
 ;; ============================================================================
 ;;
-;; The Conduit API paginates every article list (global, tag-filtered, the
-;; authenticated feed, and a profile's authored / favorited lists) with two
-;; query params:
+;; Conduit paginates every article list — global, tag-filtered, the
+;; authenticated feed, and a profile's authored / favorited lists — the
+;; classic database way, with two query params:
 ;;
 ;;   ?limit=<page-size>&offset=<rows-to-skip>
 ;;
-;; and returns the GRAND total under `articlesCount` (the count BEFORE the
-;; limit/offset window — how many articles match the query, not how many this
-;; page returned). The canonical Conduit frontend renders a 1-indexed
-;; page-number control and computes the page count as
-;; `(Math.ceil articlesCount / limit)` with a fixed page size of 10. This
-;; example follows that shape: the route carries a 1-indexed `?page=N` (so
-;; back/forward and bookmarking work), and the request builder below converts
-;; it to the wire's 0-based `offset`.
+;; Alongside the page it hands back `articlesCount`: the GRAND total, the
+;; number of articles matching the query BEFORE the limit/offset window — not
+;; the size of this page. That distinction is the whole game, because the page
+;; count comes from the grand total, not from what one page happened to
+;; return. The canonical Conduit frontend draws a 1-indexed page-number
+;; control and works out the page count as `(Math.ceil articlesCount / limit)`
+;; at a fixed page size of 10.
+;;
+;; We mirror that shape, with one ergonomic twist: the ROUTE carries a
+;; human-friendly 1-indexed `?page=N` (so Back/Forward and bookmarking just
+;; work), and the request builder below quietly translates it into the wire's
+;; 0-based `offset`. Humans count from 1; the wire counts from 0; this is the
+;; seam where the two meet.
 
 (def page-size
-  "Articles per page. Matches the canonical Conduit frontend's fixed page
-   size of 10 (the official client hardcodes `Math.ceil(articlesCount / 10)`)."
+  "Articles per page: 10, to match the canonical Conduit frontend (which
+   hardcodes `Math.ceil(articlesCount / 10)`)."
   10)
 
 (defn page->offset
-  "Convert a 1-indexed UI page number to the 0-based `offset` the Conduit
-   API expects (`offset = (page - 1) * limit`). Clamps a stray nil / sub-1
-   page (e.g. a hand-typed `?page=0` URL) to page 1."
+  "Turn a 1-indexed UI page number into the 0-based `offset` the wire wants
+   (`offset = (page - 1) * limit`). A stray nil or sub-1 page — someone
+   hand-typing `?page=0` into the URL bar — is clamped up to page 1, because
+   page zero is not a thing."
   [page]
   (* (dec (max 1 (or page 1))) page-size))
 
 (defn page-count
-  "Total number of pages for `articles-count` items at the fixed `page-size`
-   — `(ceil articles-count / page-size)`, never below 1 (an empty list is
-   still one — empty — page). Mirrors the official frontend's
+  "How many pages `articles-count` items fill at the fixed `page-size`:
+   `(ceil articles-count / page-size)`, but never less than 1 — an empty list
+   is still one page, it's just an empty one. Mirrors the official frontend's
    `Math.ceil(articlesCount / 10)`."
   [articles-count]
   (max 1 (long (js/Math.ceil (/ (or articles-count 0) page-size)))))
 
 (defn paginate-path
-  "Append the `limit` + `offset` query params for `page` (1-indexed) to a
-   list `path`, preserving any params the path already carries (e.g.
-   `/articles?tag=foo` → `/articles?tag=foo&limit=10&offset=20`). The API
-   base is added later by the request builder via `full-url`."
+  "Tack the `limit` + `offset` query params for `page` (1-indexed) onto a list
+   `path`, keeping whatever params the path already has (so
+   `/articles?tag=foo` becomes `/articles?tag=foo&limit=10&offset=20`). The
+   API base gets prepended later, by the request builder via `full-url`."
   [path page]
   (let [sep (if (clojure.string/includes? path "?") "&" "?")]
     (str path sep "limit=" page-size "&offset=" (page->offset page))))
@@ -105,35 +113,41 @@
 ;; ============================================================================
 
 (def data-fetch-retry
-  "Standard retry policy for read-only data fetches (lists, profiles,
-   article detail, comments). Retries transport blips, 5xx, and timeouts
-   — not 4xx (the request shape was valid; retrying won't help). Three
-   attempts total with exponential backoff + jitter."
+  "The house retry policy for read-only fetches — lists, profiles, article
+   detail, comments. It retries the failures that a second try might fix
+   (transport blips, 5xx, timeouts) and leaves 4xx alone, because a rejected
+   request shape doesn't get any more valid the second time you send it.
+   Three attempts total, with exponential backoff and a dash of jitter so a
+   thundering herd doesn't all retry on the same beat."
   {:on           #{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}
    :max-attempts 3
    :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}})
 
-;; Login / register / settings do not retry — one form submission per
-;; click. A 5xx surfaces as an error so the user can retry by clicking
-;; again.
+;; Writes don't get a retry policy. Login, register, and settings are one
+;; submission per click — if the server 5xxs, that surfaces as an error and
+;; the user decides whether to click again. Silently re-POSTing someone's form
+;; behind their back is how you end up with two of everything.
 
 ;; ============================================================================
 ;; REQUEST BUILDER
 ;; ============================================================================
 
 (defn request
-  "Build a `:rf.http/managed` args map for a Conduit endpoint.
+  "Assemble a `:rf.http/managed` args map for a Conduit endpoint, so the call
+   sites can stay short and declarative.
 
-   Required keys: `:method`, `:path`. Other keys are optional and map to the
-   managed-HTTP args map. See the HTTP guide: ../../../docs/resources/http.md
+   The only keys you must supply are `:method` and `:path`. Everything else is
+   optional and passes straight through to the managed-HTTP args map. See the
+   HTTP guide: ../../../docs/resources/http.md
 
-   The Bearer auth header is not injected here — it is added by the
-   frame-wide `:realworld/bearer-auth` HTTP interceptor (`core.cljs`), which
-   reads the token from the carried frame's auth slice on every request.
-   This builder therefore has no `:frame` / `:auth?` concern.
+   You won't find the Bearer header here, and that's by design: the frame-wide
+   `:realworld/bearer-auth` interceptor (`core.cljs`) stamps it on every
+   request from the live auth slice. So this builder has no `:frame` or
+   `:auth?` knob to fuss with — one less thing to remember at the call site.
 
-   Body, if a clj coll, is JSON-encoded (`:request-content-type :json`).
-   Decode defaults to `:json` (RealWorld returns JSON everywhere).
+   A clj collection in `:body` gets JSON-encoded for you
+   (`:request-content-type :json`), and `:decode` defaults to `:json` because
+   RealWorld speaks JSON everywhere.
 
    Example:
      {:fx [[:rf.http/managed
@@ -166,28 +180,31 @@
     out))
 
 ;; ============================================================================
-;; CLOCK — the framework's provided recordable time fact (:rf/time-ms)
+;; CLOCK — the framework's recordable time fact (:rf/time-ms)
 ;; ============================================================================
 ;;
-;; `:loaded-at` is a durable write — it rides epoch-restore, SSR/hydration,
-;; and replay. A durable write must read its wall-clock fact from the causal
-;; token, not from an ambient host read at the write site: replaying the
-;; same reply event must reproduce the same `:loaded-at`, which a fresh
-;; `(.getTime (js/Date.))` at handler-run time cannot guarantee.
+;; Reading the clock is the classic way a "pure" handler quietly stops being
+;; pure. `:loaded-at` is a durable write — it travels through epoch-restore,
+;; SSR/hydration, and replay — and replay only works if re-running the same
+;; reply event lands on the same `:loaded-at` every time. A fresh
+;; `(.getTime (js/Date.))` inside the handler can't promise that: replay it
+;; tomorrow and you get tomorrow's timestamp. So the handler must read the
+;; clock as a recorded fact, not grab it live at the write site.
 ;;
-;; The framework stamps that fact once, at the causal boundary, onto every
-;; dispatch envelope and registers it as the provided recordable coeffect
-;; `:rf/time-ms`. A handler that stamps `:loaded-at` declares
-;; `:rf.cofx/requires [:rf/time-ms]` and reads the value flat:
+;; The framework does the recording for you. It reads the wall clock once, at
+;; the causal boundary, stamps it onto every dispatch envelope, and offers it
+;; back as the recordable coeffect `:rf/time-ms`. A handler that wants to write
+;; a timestamp just asks for it with `:rf.cofx/requires [:rf/time-ms]` and
+;; reads it flat — staying pure, and staying replayable:
 ;;
 ;;     (rf/reg-event :feed/loaded
 ;;       {:rf.cofx/requires [:rf/time-ms]}
 ;;       (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
 ;;         {:db (assoc-in db [:feed :loaded-at] time-ms)}))
 ;;
-;; Tests and replay fixtures supply an exact `:rf/time-ms` via the dispatch
-;; opts (`{:rf.cofx {:rf/time-ms 1781078400123}}`); live code lets the
-;; router stamp it. See the coeffects guide:
+;; In tests and replay fixtures you can pin an exact instant through the
+;; dispatch opts (`{:rf.cofx {:rf/time-ms 1781078400123}}`); live code just
+;; lets the router stamp the real time. See the coeffects guide:
 ;; ../../../docs/guide/concepts/effects-and-coeffects.md#two-grades-ambient-and-recordable
 
 ;; ============================================================================
@@ -195,16 +212,17 @@
 ;; ============================================================================
 
 (defn failure->message
-  "Project a failure map (the inner `:failure` map of an
-   `{:kind :failure :failure {...}}` reply) to a human-readable string.
-   The Conduit API returns `{:errors {:body [\"...\"]}}` shapes for 4xx
-   validation failures; surface those when present, otherwise fall back to a
-   category-driven message."
+  "Turn a failure map (the inner `:failure` of a `{:kind :failure :failure
+   {...}}` reply) into a sentence a human can actually read. Conduit reports
+   4xx validation problems as `{:errors {:body [\"...\"]}}`, so we surface the
+   server's own words when they're there, and fall back to a friendly
+   category-based message when they aren't — because \"Network error — please
+   try again\" beats a stack trace every time."
   [failure]
   (let [body (:body failure)
-        ;; The :body for 4xx/5xx is the raw response text; some Conduit
-        ;; errors come through as plain JSON-shaped failure maps from
-        ;; `:rf.http/accept-failure` paths. Try to surface either.
+        ;; The :body might be raw response text, or it might be a JSON-shaped
+        ;; failure map arriving via the `:rf.http/accept-failure` path. Try to
+        ;; pull a message out of either shape.
         body-msg (cond
                    (and (map? body) (-> body :errors :body first)) (-> body :errors :body first)
                    (and (map? body) (-> body :errors first)) (let [[k v] (first (:errors body))]

--- a/examples/reagent/realworld/profile.cljs
+++ b/examples/reagent/realworld/profile.cljs
@@ -1,33 +1,34 @@
 (ns realworld.profile
   "Profile pages for the RealWorld (Conduit) example.
 
-   This namespace shows:
-   - One parallel state machine `:ui/profile` with two orthogonal regions
+   A profile page is a banner up top and a tabbed list of articles below — two
+   moving parts that happen to load independently, which is exactly why a
+   two-region machine fits. Worth a read for:
+
+   - One parallel state machine `:ui/profile`, two orthogonal regions
      (`:tab` x `:data`). See the machines guide on parallel regions:
      ../../../docs/machines/concepts.md#when-the-machine-grows.
-   - A remote-data lifecycle folded into the `:data` region; the region's
-     state-keyword is the banner's status. The article-list items live in
-     app-db slices (`:profile.articles`, `:profile.favorites`) so
-     favorites.cljs's optimistic updates can find articles across slices.
-   - Tab switching expressed as `:tab` region transitions broadcast from
-     the route's `:on-match`, like the home page's `:home/load` broadcasts
-     its feed-region transition.
-   - The profile view's root is a `case` over `:profile/render`, a selector
-     sub that reads a render-priority table against the machine's tag
-     union.
+   - A remote-data lifecycle folded into the `:data` region, whose
+     state-keyword is the banner's status. The article items themselves live in
+     app-db slices (`:profile.articles`, `:profile.favorites`), within reach of
+     favorites.cljs's cross-slice optimistic updates.
+   - Tab switching as `:tab` region transitions broadcast from the route's
+     `:on-match` — the same move the home page makes with `:home/load`.
+   - The profile view's root: a `case` over `:profile/render`, a selector sub
+     reading a render-priority table against the machine's tag union.
 
-   Three remote-data slices behind the view:
-   - `:profile`             — public banner (username, bio, image, following)
-   - `:profile.articles`    — authored articles
-   - `:profile.favorites`   — favorited articles
+   Three remote-data slices sit behind the view:
+   - `:profile`             — the public banner (username, bio, image, following)
+   - `:profile.articles`    — articles they wrote
+   - `:profile.favorites`   — articles they liked
 
-   Follow/unfollow is optimistic and shared across the banner plus any
-   article cards rendered from the profile routes."
+   Follow/unfollow is optimistic, and shared between the banner and any article
+   cards the profile routes happen to render."
   (:require [re-frame.core :as rf]
-            ;; State machines ship in the re-frame2-machines artefact.
-            ;; Requiring the ns registers its hooks so `rf/reg-machine`
-            ;; (called below) and the `:rf/machine` subs resolve. See the
-            ;; machines guide: ../../../docs/machines/index.md
+            ;; State machines live in their own artefact; we require it to load
+            ;; it, which registers the hooks that make `rf/reg-machine` (below)
+            ;; and the `:rf/machine` subs resolve. See the machines guide:
+            ;; ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld-shared.avatar :as avatar]
             [realworld.schema :as schema]
@@ -38,8 +39,9 @@
 (defn request-slice []
   {:status :idle :data nil :error nil :loaded-at nil :attempt 0})
 
-;; The route lives in runtime-db; `username-from-db` reads it off the
-;; runtime-db value (event handlers pass the `:rf.db/runtime` coeffect).
+;; Which profile are we on? It's in the URL. The route lives in runtime-db, and
+;; `username-from-db` digs the :username param out of it (handlers receive
+;; runtime-db via the `:rf.db/runtime` coeffect).
 (defn username-from-db [runtime-db]
   (get-in runtime-db [:rf.runtime/routing :current :params :username]))
 
@@ -47,24 +49,23 @@
 ;; THE MACHINE — :ui/profile  (one machine, two regions)
 ;; ============================================================================
 ;;
-;; The profile page has two orthogonal axes:
+;; Two independent things about a profile page, so two regions:
 ;;
-;;   :tab    — which list of articles is rendered (authored vs favorited).
-;;             Driven by `:show-articles` / `:show-favorites` broadcasts
-;;             from the route's `:on-match` (see `routing.cljs`'s
-;;             `:realworld.profile/show` and `:realworld.profile/favorites`). The
-;;             state-keyword tells the view which app-db slice's items
-;;             to render.
+;;   :tab    — which article list is showing, authored or favorited. Driven by
+;;             `:show-articles` / `:show-favorites` broadcasts from the route's
+;;             `:on-match` (see `:realworld.profile/show` and
+;;             `:realworld.profile/favorites` in routing.cljs). Its
+;;             state-keyword tells the view which app-db slice to render.
 ;;
-;;   :data   — the data lifecycle for the banner fetch. The slice's
-;;             `:status` field is still set for parity with other slices,
-;;             but the region's state-keyword is the page's render gate. The
-;;             article-list slices keep their slice shape and load
-;;             independently.
+;;   :data   — where the BANNER fetch is in its life. The slice still sets a
+;;             `:status` field for parity with its siblings, but it's this
+;;             region's state-keyword that gates the page render. The two
+;;             article-list slices keep their own slice shape and load on their
+;;             own schedule.
 ;;
-;; Every event delivered to the machine reaches every region. Region-
-;; distinct event names avoid collisions; each region handles `:reset` as a
-;; self-target.
+;; Parallel machine, so the usual deal: every event hits every region, the
+;; region event names stay distinct to avoid crosstalk, and each region treats
+;; `:reset` as a self-target.
 
 (def profile-machine
   {:type :parallel
@@ -100,9 +101,10 @@
               :reset           :nothing}}
 
       :refreshing
-      ;; Reload while prior banner remains visible. Tagged :data/loaded
-      ;; so the render-priority resolves to the `:loaded` view; the
-      ;; :data/refreshing tag could drive an inline indicator.
+      ;; A reload while the banner's still on screen. Tagged :data/loaded so
+      ;; render-priority keeps the `:loaded` view up (no flicker); the
+      ;; :data/refreshing tag is there if a view wants to show a subtle
+      ;; "updating" hint.
       {:tags #{:data/loaded :data/refreshing :data/transient}
        :on   {:fetch-succeeded {:target :loaded :action :clear-error}
               :fetch-failed    {:target :error  :action :set-error}
@@ -155,12 +157,10 @@
 ;; ============================================================================
 
 (rf/reg-event :profile/load
-  {:doc "Load the public profile (username, bio, image, following).
-         Public endpoint; data-fetch retry.
-
-         Broadcasts `:fetch-started` into the `:ui/profile` machine so
-         the `:data` region advances to `:loading` (or `:refreshing`
-         from `:loaded`)."
+  {:doc "Fetch the public profile banner — username, bio, image, following.
+         Public endpoint, so the house data-fetch retry applies. Broadcasts
+         `:fetch-started` into the `:ui/profile` machine, nudging the `:data`
+         region to `:loading` (or `:refreshing`, if a banner's already up)."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [username (username-from-db rt)]
@@ -198,10 +198,10 @@
        :fx [[:dispatch [:ui/profile [:fetch-failed {:failure message}]]]]})))
 
 (rf/reg-event :profile.articles/load
-  {:doc "Load the profile's authored articles. Public; data-fetch retry.
-         Also broadcasts `:show-articles` so the `:ui/profile` :tab
-         region tracks the active tab. `?page=` paginates the list via
-         `rh/paginate-path` (official RealWorld limit/offset)."
+  {:doc "Fetch the articles this user wrote. Public; house retry. Also
+         broadcasts `:show-articles` so the `:ui/profile` :tab region knows
+         which tab is live. `?page=` paginates via `rh/paginate-path` (the
+         official RealWorld limit/offset shape)."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [username (username-from-db rt)
@@ -238,10 +238,10 @@
         (assoc-in [:profile.articles :error] (rh/failure->message failure)))}))
 
 (rf/reg-event :profile.favorites/load
-  {:doc "Load the profile's favorited articles. Public; data-fetch retry.
-         Also broadcasts `:show-favorites` so the `:ui/profile` :tab
-         region tracks the active tab. `?page=` paginates the list via
-         `rh/paginate-path` (official RealWorld limit/offset)."
+  {:doc "Fetch the articles this user favorited. Public; house retry. Also
+         broadcasts `:show-favorites` so the `:ui/profile` :tab region knows
+         which tab is live. `?page=` paginates via `rh/paginate-path` (the
+         official RealWorld limit/offset shape)."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [username (username-from-db rt)
@@ -282,12 +282,11 @@
 ;; ============================================================================
 
 (rf/reg-event :profile/follow
-  {:doc "Optimistically mark the profile as followed; reconcile on reply.
-
-         Auth-gated (same rationale as favorites.cljs/:article/toggle-favorite):
-         following requires a session, so an unauthenticated click navigates
-         to login rather than optimistically flipping `:following` and then
-         rolling back after the real backend 401s."
+  {:doc "Mark the profile followed right away, then reconcile when the reply
+         lands. Auth-gated (same reasoning as
+         favorites.cljs/:article/toggle-favorite): following needs a session,
+         so a logged-out click heads to login instead of flipping `:following`
+         optimistically only to walk it back after the backend 401s."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (if (nil? (get-in db [:auth :user]))
@@ -306,8 +305,8 @@
     {:db (assoc-in db [:profile :data] (:profile value))}))
 
 (rf/reg-event :profile/unfollow
-  {:doc "Optimistically clear the followed flag; reconcile on reply.
-         Auth-gated like `:profile/follow` above."
+  {:doc "Clear the followed flag right away, then reconcile on the reply.
+         Auth-gated, same as `:profile/follow` above."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (if (nil? (get-in db [:auth :user]))
@@ -350,14 +349,14 @@
 
 ;; ---- render-priority + :profile/render selector ----
 ;;
-;; Plain data: a vector of {:tag :render} pairs consulted in order.
-;; The `:profile/render` sub reads the machine's tag union and returns
-;; the first :render whose :tag is present. The view's `case` over
-;; the resolved keyword is the only branch site.
+;; Same data-driven pattern as everywhere else: a plain vector of {:tag :render}
+;; pairs, read in order. `:profile/render` looks at the machine's active tags
+;; and returns the first matching :render, and the view's `case` on that
+;; keyword is the only branch site.
 ;;
-;; Priority rationale: the data region's lifecycle wins outright —
-;; `:loading` (first-load spinner) above `:error` above `:loaded`.
-;; `:refreshing` resolves to `:loaded` (the prior banner stays visible).
+;; The order is the policy: the data lifecycle wins — `:loading` (first-load
+;; spinner) over `:error` over `:loaded`. `:refreshing` resolves to `:loaded`,
+;; so the existing banner stays put during a reload.
 
 (def render-priority
   [{:tag :data/loading :render :loading}
@@ -366,9 +365,9 @@
    {:tag :data/nothing :render :nothing}])
 
 (rf/reg-sub :profile/render
-  {:doc "Resolve the profile page's render-model keyword by consulting
-         the render-priority table against the `:ui/profile` machine's
-         tag union. The root view's `case` is the only branch site."}
+  {:doc "Reduce the `:ui/profile` machine's active tags to one render keyword,
+         via the render-priority table. The root view's `case` on it is the
+         only branch site."}
   :<- [:rf/machine :ui/profile]
   (fn sub-profile-render [snap _]
     (let [tags (:tags snap)]
@@ -377,9 +376,8 @@
             render-priority))))
 
 (rf/reg-sub :profile/current-articles
-  {:doc "The article list currently rendered by the profile view: the
-         `:tab` region's active state-keyword picks which app-db slice
-         to read from."}
+  {:doc "Whichever article list the active tab calls for: the `:tab` region's
+         state picks the app-db slice — favorited vs authored."}
   :<- [:rf/machine :ui/profile]
   :<- [:profile.articles/data]
   :<- [:profile.favorites/data]
@@ -422,10 +420,11 @@
     (rh/page-count total)))
 
 (rf/reg-event :profile/show-page
-  {:doc "Navigate to a 1-indexed pagination page for the active profile tab.
-         Stays on the current profile route (authored vs favorited) and
-         username; changing `?page=` re-fires the route `:on-match`, re-running
-         the tab's load with the new limit/offset window."}
+  {:doc "Jump to a 1-indexed page within the active profile tab. It stays on
+         the same route (authored vs favorited) and the same username — only
+         `?page=` changes. That's enough to re-fire the route `:on-match`,
+         which re-runs the tab's load with the new limit/offset window. The URL
+         is the input; the data follows."}
   (fn [{rt :rf.db/runtime} [_ page]]
     (let [{:keys [route-id params]} (get-in rt [:rf.runtime/routing :current])]
       {:fx [[:dispatch [:rf.route/navigate route-id params {:query {:page page}}]]]})))
@@ -434,22 +433,22 @@
 ;; VIEWS
 ;; ============================================================================
 
-(reg-view ^{:doc "Data region :loading — first banner fetch in flight."}
+(reg-view ^{:doc "The :loading view — first banner fetch in flight."}
           profile-loading []
   [:div.article-preview "Loading profile…"])
 
-(reg-view ^{:doc "Data region :error — banner fetch failed."}
+(reg-view ^{:doc "The :error view — the banner fetch fell over."}
           profile-error []
   (let [err @(subscribe [:profile/error])]
     [:div.article-preview.error
      (str "Couldn't load profile: " (pr-str err))]))
 
-(reg-view ^{:doc "Data region :nothing — pre-fetch placeholder."}
+(reg-view ^{:doc "The :nothing view — the brief placeholder before any fetch."}
           profile-nothing []
   [:div.article-preview "No profile loaded."])
 
-(reg-view ^{:doc "Data region :loaded — banner, tabs, and the active
-                  tab's article list."}
+(reg-view ^{:doc "The :loaded view — the real thing: banner, tabs, and the
+                  active tab's article list."}
           profile-loaded []
   (let [profile      @(subscribe [:profile/data])
         own?         @(subscribe [:profile/own-profile?])

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -1,14 +1,15 @@
 (ns realworld.routing
   "Routes for the RealWorld (Conduit) example.
 
-   This file owns the route table and an app-specific auth guard. The
-   anchor view is the framework-shipped `rf/route-link` (registered at
-   `:route/link`); call sites pass `:class` / `:data-testid` through to
-   the underlying `<a>`. The example uses the current runtime routing
-   surface directly:
+   Two things live here: the route table (the map of URL → what-to-do) and one
+   app-specific auth guard that keeps logged-out visitors out of the private
+   pages. Links are the framework's own `rf/route-link` (registered at
+   `:route/link`); call sites just pass `:class` / `:data-testid` straight
+   through to the underlying `<a>`. Beyond that, the example leans on the
+   framework's routing surface as-is:
 
    - `reg-route`
-   - `rf/route-link` (registered view at `:route/link`)
+   - `rf/route-link` (the registered view at `:route/link`)
    - `:rf.route/navigate`
    - `:rf.route/handle-url-change`
    - `:rf.route/continue` / `:rf.route/cancel`
@@ -16,11 +17,11 @@
    - `:rf/url-requested`"
   (:require [clojure.string]
             [re-frame.core :as rf]
-            ;; Routing ships in the re-frame2-routing artefact. Requiring
-            ;; the ns registers its hooks + subs so the `rf/reg-route` calls
-            ;; below resolve. Aliased so the popstate handler can resolve the
-            ;; URL owner via `routing/url-owner-frame-id`. See the routing
-            ;; guide: ../../../docs/routing/index.md
+            ;; Routing lives in its own artefact. Requiring it registers the
+            ;; hooks and subs that make the `rf/reg-route` calls below resolve.
+            ;; This one IS aliased — the popstate handler needs to call
+            ;; `routing/url-owner-frame-id` directly. See the routing guide:
+            ;; ../../../docs/routing/index.md
             [re-frame.routing :as routing]))
 
 ;; ============================================================================
@@ -28,20 +29,20 @@
 ;; ============================================================================
 
 (rf/reg-route :realworld/home
-  {:doc      "The landing page: global feed and (signed-in) your feed.
+  {:doc      "The landing page — the global feed, plus your feed once you're
+              signed in.
 
-              ROUTE-SHAPE CONFORMANCE. The official RealWorld
-              browser/E2E contract uses `/?feed=following` for the
-              authenticated feed (NOT `?feed=your`) and a PATH-param tag route
-              `/tag/:tag` (NOT `?tag=`). The tag filter therefore lives on its
-              own `:realworld/home-tag` route below; this home route carries
+              A note on URL shapes, because we follow the official contract to
+              the letter: RealWorld uses `/?feed=following` for the
+              authenticated feed (not `?feed=your`) and a PATH-param tag route,
+              `/tag/:tag` (not `?tag=`). That's why the tag filter gets its own
+              `:realworld/home-tag` route below, and this home route carries
               only `?feed=` (the following toggle) and `?page=`.
 
-              `?page=N` is the 1-indexed pagination page for the active feed
-              (official RealWorld limit/offset pagination). It rides the route
-              query so back/forward and bookmarking restore the page; `:int`
-              coercion turns the URL's `\"2\"` into `2`, and `:query-defaults`
-              fills page 1 when the key is absent."
+              `?page=N` is the 1-indexed page for the active feed. It rides the
+              query so Back/Forward and bookmarks restore your spot; `:int`
+              coercion turns the URL's `\"2\"` into a real `2`, and
+              `:query-defaults` fills in page 1 when the key's missing."
    :query    [:map
               [:feed {:optional true} :string]
               [:page {:optional true} :int]]
@@ -50,11 +51,11 @@
    :scroll   :top} "/")
 
 (rf/reg-route :realworld/home-tag
-  {:doc      "The tag-filtered article list at the official RealWorld
-              `/tag/:tag` PATH route. `?page=N` paginates within the tag the
-              same way the home feed does (`/tag/:tag?page=2`);
-              `:query-defaults` fills page 1. Same `:home/load` on-match — it
-              reads the active tag off the route params."
+  {:doc      "The tag-filtered list, at the official `/tag/:tag` PATH route.
+              `?page=N` paginates within the tag exactly as the home feed does
+              (`/tag/:tag?page=2`); `:query-defaults` fills page 1. It shares
+              `:home/load` with the home route — that handler just reads the
+              active tag straight off the route params."
    :params   [:map [:tag :string]]
    :query    [:map [:page {:optional true} :int]]
    :query-defaults {:page 1}
@@ -117,64 +118,66 @@
 ;; AUTH GUARD
 ;; ============================================================================
 ;;
-;; Route-level auth is an interceptor, not a special routing mechanism.
-;; Guards are plain interceptors, so they compose and layer. This one
-;; redirects unauthenticated users away from any route tagged
-;; `:requires-auth` (`:realworld.user/settings`, `:realworld.editor/new`,
-;; `:realworld.editor/edit`) to the login page, stashing the original target
-;; under `:return-to` for a post-login bounce-back. See the routing guide on
+;; Route-level auth isn't a special routing feature — it's just an interceptor.
+;; That's the nice part: because guards are ordinary interceptors, they compose
+;; and stack like anything else. This one watches for navigation toward any
+;; route tagged `:requires-auth` (`:realworld.user/settings`,
+;; `:realworld.editor/new`, `:realworld.editor/edit`), and if you're not signed
+;; in it sends you to login instead — stashing where you were headed under
+;; `:return-to` so you can be bounced back afterward. See the routing guide on
 ;; guards: ../../../docs/routing/concepts.md#blocking-a-navigation
 ;;
-;; It is wired into the demo frame via the `frame-provider` `:interceptors`
-;; in core.cljs. It short-circuits to the unchanged ctx for everything
-;; except a navigation event, and gates every navigation entry point so a
-;; `:requires-auth` route is unreachable logged-out by any access path:
+;; It's wired into the demo frame via `frame-provider`'s `:interceptors` in
+;; core.cljs. For anything that isn't a navigation, it hands the ctx straight
+;; back, untouched. For navigations, it covers EVERY way into a route, so a
+;; protected page can't be reached logged-out by any door:
 ;;
 ;;   - `:rf.route/navigate`          — programmatic nav (the navbar);
 ;;     `(second event)` is the target route id.
-;;   - `:rf/url-requested`           — anchor (`rf/route-link`) click;
+;;   - `:rf/url-requested`           — an anchor (`rf/route-link`) click;
 ;;     the request map carries `:to` (the target route id) + `:params`.
-;;   - `:rf.route/handle-url-change` — URL-bar entry / reload / popstate;
-;;     `(second event)` is a URL string resolved via `rf/match-url`.
+;;   - `:rf.route/handle-url-change` — typing in the URL bar, a reload, a
+;;     popstate; `(second event)` is a URL string, resolved via `rf/match-url`.
 ;;
-;; The guard must gate all three, not just `:rf.route/navigate`: gating
-;; navigate alone fails open on the most common path — a logged-out user
-;; who typed `/settings`, reloaded a protected page, or followed an anchor
-;; would reach the route (and its on-match drain would fire a request the
-;; real backend would 401). `resolve-nav-target` normalises each event to
-;; an `{:id :params}` target so one redirect path handles them all.
+;; Guarding only `:rf.route/navigate` would be a classic fail-open: a
+;; logged-out user who typed `/settings`, reloaded a protected page, or clicked
+;; a link would sail right in — and its on-match drain would fire off a request
+;; the real backend just 401s. So `resolve-nav-target` flattens all three
+;; events down to one `{:id :params}` target, and a single redirect path
+;; handles the lot.
 ;;
-;; The redirect: the `:before` skips the original handler
-;; (`:rf/skip-handler?`) so the protected route's slice never commits and
-;; its on-match drain never fires, then dispatches `:rf.route/navigate
-;; :realworld.auth/login`. The runtime selects the handler from the original
-;; event id before interceptors run, so rewriting `[:coeffects :event]`
-;; across event ids would run the wrong handler — skip-and-dispatch
-;; sidesteps that.
+;; How the redirect works: the `:before` sets `:rf/skip-handler?`, so the
+;; protected route's own handler never runs — its slice never commits and its
+;; on-match drain never fires — and then it dispatches
+;; `:rf.route/navigate :realworld.auth/login`. (Why skip-and-dispatch instead
+;; of just rewriting the event? The runtime picks the handler from the ORIGINAL
+;; event id before interceptors run, so swapping `[:coeffects :event]` to a
+;; different id would still run the first handler. Skipping sidesteps the whole
+;; problem.)
 ;;
-;; Bounce-back (`:return-to`): `:rf.route/navigate` opts (the 3rd arg) are
-;; not persisted by the runtime — the navigate handler reads `:query` /
-;; `:fragment` / `:replace?` / `:scroll` / `:bypass-leave-guard?` and drops
-;; the rest — so an opts-borne `:return-to` would evaporate. Instead the
-;; `:before` stashes the target at `[:auth :return-to]` via a `:db` effect
-;; (committed before the login dispatch's `:fx` runs). The auth machine's
-;; `:store-session` action reads that slot on a successful login, bounces
-;; there (falling back to home), and clears it (auth.cljs).
+;; The bounce-back (`:return-to`) takes a little care. You can't smuggle it
+;; through `:rf.route/navigate`'s opts (the 3rd arg): the navigate handler only
+;; keeps `:query` / `:fragment` / `:replace?` / `:scroll` /
+;; `:bypass-leave-guard?` and drops everything else, so an opts-borne
+;; `:return-to` would just evaporate. Instead the `:before` writes the target
+;; to `[:auth :return-to]` with a `:db` effect (committed before the login
+;; dispatch's `:fx` runs). Later, on a successful login, the auth machine's
+;; `:store-session` action reads that slot, sends you there (or home if it's
+;; empty), and clears it (auth.cljs).
 
 (defn- resolve-nav-target
-  "Normalise a navigation event into its target `{:id <route-id>
-   :params <map>}`, or nil when `event` is not a navigation (so the guard
-   short-circuits). One resolver for all three entry points
-   so the redirect path below is identical regardless of HOW the user
-   reached the route:
+  "Boil any navigation event down to one shape — `{:id <route-id> :params
+   <map>}` — or nil when the event isn't a navigation at all (the guard's cue
+   to step aside). Three different events come in; one tidy target goes out, so
+   the redirect below doesn't care HOW the user got here:
 
      - `:rf.route/navigate`          → `(second event)` is the route id,
-       `(nth event 2)` its path params (programmatic nav).
-     - `:rf/url-requested`           → anchor click; the request map
-       carries `:to` (route id) + `:params`. Falls back to resolving
-       `:url` via `rf/match-url` if `:to` is absent.
-     - `:rf.route/handle-url-change` → URL-bar / reload / popstate; the
-       URL string is resolved to a route via `rf/match-url`."
+       `(nth event 2)` the path params (programmatic nav).
+     - `:rf/url-requested`           → an anchor click; the request map carries
+       `:to` (route id) + `:params`, and falls back to resolving `:url` via
+       `rf/match-url` when `:to` isn't there.
+     - `:rf.route/handle-url-change` → URL bar / reload / popstate; the URL
+       string is matched to a route via `rf/match-url`."
   [[ev-id a b]]
   (case ev-id
     :rf.route/navigate
@@ -193,15 +196,15 @@
 
     nil))
 
-;; Register the guard as a named interceptor here, then reference it by id
-;; (`:realworld.routing/auth-guard`) from the demo frame's `:interceptors`
-;; in core.cljs. `reg-interceptor` runs at load time, and core.cljs requires
-;; this ns, so the descriptor is in place before the frame-provider creates
-;; the frame and resolves the id.
+;; Register the guard as a named interceptor here, then refer to it by id
+;; (`:realworld.routing/auth-guard`) from the demo frame's `:interceptors` in
+;; core.cljs. `reg-interceptor` runs at load time and core.cljs requires this
+;; ns, so the descriptor is sitting ready before the frame-provider ever tries
+;; to resolve the id.
 (rf/reg-interceptor :realworld.routing/auth-guard
-  {:doc "Route-level auth guard: redirect unauthenticated users away from
-         `:requires-auth`-tagged routes to login, stashing the intended
-         target for post-login bounce-back."}
+  {:doc "The route-level auth guard: steer logged-out users away from
+         `:requires-auth` routes to login, and remember where they were going
+         so we can send them back afterward."}
   {:before (fn auth-guard-before [ctx]
              (if-let [{:keys [id params]} (resolve-nav-target
                                             (get-in ctx [:coeffects :event]))]
@@ -209,10 +212,11 @@
                      needs-auth? (boolean (some #{:requires-auth} (:tags route-meta)))
                      logged-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
                  (if (and needs-auth? (not logged-in?))
-                   ;; Skip the original handler (so the protected slice +
-                   ;; on-match never commit), stash the intended target for
-                   ;; post-login bounce-back, and dispatch the login
-                   ;; navigation — the SAME redirect for every entry point.
+                   ;; Three moves: skip the original handler (so the protected
+                   ;; slice and its on-match never commit), remember where they
+                   ;; were headed for the bounce-back, and dispatch the login
+                   ;; navigation. The SAME redirect, whichever door they came
+                   ;; through.
                    (-> ctx
                        (assoc :rf/skip-handler? true)
                        (assoc-in [:effects :db]
@@ -228,10 +232,10 @@
 ;; ROUTER WIRING
 ;; ============================================================================
 
-;; The example may be served from a sub-path (e.g. /realworld/) by a
-;; host that stages many demos side by side; in production it would be
-;; mounted at /. `*base-path*` lets the host strip a prefix before the
-;; route matcher runs. Set via `set-base-path!` in the run fn.
+;; This example might be served from a sub-path — a host staging lots of demos
+;; side by side could mount it at /realworld/ — even though on its own it'd live
+;; at /. `*base-path*` is the little lever that strips that prefix off before
+;; the route matcher ever sees the URL. Set it via `set-base-path!` in `run`.
 (def ^:dynamic *base-path* "")
 
 (defn set-base-path! [s]
@@ -250,20 +254,19 @@
       (str (.. js/window -location -search)
            (.. js/window -location -hash))))
 
-;; A named handler so the listener install is idempotent: repeated
-;; `install-router!` (hot reload, or a co-required test host calling run
-;; twice) remove-then-add the same Var, so duplicate popstate listeners
-;; never stack — the same idea as the `when-not @react-root` mount guard.
+;; A NAMED handler, on purpose, so installing the listener is idempotent. Call
+;; `install-router!` twice — a hot reload, or a co-required test host running
+;; `run` again — and because it's the same Var, the remove-then-add is a no-op
+;; and duplicate popstate listeners never pile up. Same trick as the
+;; `when-not @react-root` mount guard.
 ;;
-;; The URL-change dispatch targets the URL-owner frame, resolved at call
-;; time via `routing/url-owner-frame-id`. The owner is the `:url-bound? true`
-;; demo frame the frame-provider creates in core.cljs. Targeting it
-;; explicitly matters: a bare `(rf/dispatch …)` with no frame would raise
-;; `:rf.error/no-frame-context`. This example uses its own base-path-aware
-;; listener (rather than the framework's `rf/install-history-listener!`,
-;; which reads the unstripped browser URL) because it serves from a
-;; `/realworld/` sub-path; the owner-targeting contract is the same either
-;; way.
+;; The URL-change dispatch is aimed at the frame that OWNS the URL, looked up
+;; at call time via `routing/url-owner-frame-id` — the `:url-bound? true` demo
+;; frame from core.cljs. Aiming matters: a bare `(rf/dispatch …)` with no frame
+;; would raise `:rf.error/no-frame-context`. (And the reason this rolls its own
+;; listener instead of the framework's `rf/install-history-listener!` is the
+;; `/realworld/` sub-path — the framework's version reads the unstripped
+;; browser URL. The owner-targeting contract is identical either way.)
 (defn- on-popstate [_]
   (when-let [owner (routing/url-owner-frame-id)]
     (rf/dispatch [:rf.route/handle-url-change (current-url)] {:frame owner})))

--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -1,24 +1,25 @@
 (ns realworld.schema
   "Malli schemas for the RealWorld (Conduit) example.
 
-   These describe the shape of every wire payload the RealWorld API returns,
-   plus the shape of each app-db slice that holds them. The schemas are
-   registered for path-based validation via `reg-app-schemas`. See the
-   schemas how-to: ../../../docs/guide/how-to/validate-with-schemas.md
+   The shapes, in one place. This file describes every payload the RealWorld
+   API hands back AND the shape of each app-db slice that stores it, so the two
+   never quietly drift apart. The slice schemas get wired up for path-based
+   validation via `reg-app-schemas` at the bottom. See the schemas how-to:
+   ../../../docs/guide/how-to/validate-with-schemas.md
 
    The RealWorld API spec is documented at:
      https://github.com/gothinkster/realworld/tree/main/api
 
-   Wire-shape conventions (from the spec):
-   - Articles, profiles, and users come wrapped under a top-level singular
-     key (`{:article {...}}`, `{:profile {...}}`, `{:user {...}}`); list
-     responses come under the plural key (`{:articles [...]}`, etc.).
+   A few wire conventions, straight from that spec:
+   - Articles, profiles, and users arrive wrapped under a singular top-level
+     key (`{:article {...}}`, `{:profile {...}}`, `{:user {...}}`); lists come
+     under the plural one (`{:articles [...]}`, and so on).
    - Datetimes are ISO-8601 strings.
-   - Authentication tokens are JWT strings, returned as the `:token` field
-     of the `User` payload after login or registration."
+   - Auth tokens are JWT strings, riding in as the `:token` field of the
+     `User` payload after login or registration."
   (:require [re-frame.core :as rf]
-            ;; Schemas ship in the re-frame2-schemas artefact. Requiring
-            ;; the ns registers its hooks so `rf/reg-app-schemas` resolves
+            ;; Schemas live in their own artefact; we require it to load it,
+            ;; which registers the hooks that make `rf/reg-app-schemas` resolve
             ;; at the call site below.
             [re-frame.schemas])
   (:require-macros [re-frame.core :refer [with-frame]]))
@@ -28,17 +29,17 @@
 ;; ============================================================================
 
 (def User
-  "The authenticated user's profile. Returned by /users/login,
+  "The signed-in user, with their credentials. Returned by /users/login,
    /users (register), and /user (current user)."
-  ;; Classify the JWT at the transient slot that introduces it, via the
-  ;; per-slot `:sensitive?` Malli property on the `:decode` schema.
-  ;; `UserResponse` is the `:decode` schema for the login / register /
-  ;; session-restore replies, so this redacts the token out of any off-box
-  ;; capture of the response body. The durable copy at [:auth :token] is
-  ;; classified separately by `:auth/classify-token` (core.cljs) —
-  ;; classification does not propagate, so each surface a secret crosses is
-  ;; declared on its own; the Bearer header is on the framework's built-in
-  ;; carrier denylist. See the keep-secrets how-to:
+  ;; Classify the JWT right at the slot that first carries it, with a per-slot
+  ;; `:sensitive?` Malli property on the `:decode` schema. `UserResponse` is the
+  ;; `:decode` schema for the login / register / session-restore replies, so
+  ;; this is what keeps the token out of any off-box capture of the response
+  ;; body. The DURABLE copy at [:auth :token] is a separate matter, classified
+  ;; by `:auth/classify-token` (core.cljs) — classification doesn't propagate,
+  ;; so every surface a secret touches has to declare it for itself. (The
+  ;; Bearer header gets this for free, via the framework's built-in carrier
+  ;; denylist.) See the keep-secrets how-to:
   ;; ../../../docs/guide/how-to/keep-secrets-out-of-traces.md
   [:map
    [:email    :string]
@@ -83,9 +84,10 @@
 ;; WIRE-RESPONSE WRAPPERS
 ;; ============================================================================
 ;;
-;; The Conduit API wraps every payload in a singular/plural top-level key.
-;; These schemas describe the wire-shape envelope; they are passed as the
-;; `:decode` key to `:rf.http/managed`. See the HTTP guide on `:decode`:
+;; Conduit never hands you a bare object — it always tucks the payload under a
+;; singular or plural top-level key. These schemas describe that envelope, and
+;; they're what you pass as `:decode` to `:rf.http/managed` so the body gets
+;; validated on the way in. See the HTTP guide on `:decode`:
 ;; ../../../docs/resources/http.md#validating-the-body-with-decode
 
 (def UserResponse
@@ -120,19 +122,22 @@
   [:map [:tags [:vector :string]]])
 
 ;; ============================================================================
-;; APP-DB SLICES — remote-data slice shape per resource
+;; APP-DB SLICES — the remote-data slice shape, one per resource
 ;; ============================================================================
 ;;
-;; Every slice that holds remote data follows the same 5-key shape.
+;; Every slice that holds remote data wears the same 5-key shape. Learn it
+;; once, recognise it everywhere.
 
 (def RequestSlice
-  "The standard remote-data lifecycle slice. Generic over the :data type.
+  "The standard remote-data lifecycle slice, generic over whatever `:data` it
+   holds.
 
-   `:articles-count` is the official RealWorld pagination total — the GRAND
-   count of articles matching the query (before the limit/offset window), used
-   to compute the page count. Optional because only the paginated article-list
-   slices (`:articles`, `:feed`, `:profile.articles`, `:profile.favorites`)
-   carry it; single-resource slices (`:article`, `:profile`) never do."
+   `:articles-count` is the RealWorld pagination total — the GRAND count of
+   articles matching the query (before the limit/offset window), which is what
+   the page count is computed from. It's optional because only the paginated
+   list slices (`:articles`, `:feed`, `:profile.articles`,
+   `:profile.favorites`) carry it; the single-resource slices (`:article`,
+   `:profile`) have no use for it."
   [:map
    [:status         [:enum :idle :loading :fetching :loaded :error]]
    [:data           {:default nil} :any]
@@ -143,15 +148,15 @@
    [:stale-after-ms {:optional true} [:maybe :int]]])
 
 (def AuthSlice
-  "The auth slice. :user holds the current :User payload (or nil);
-   :token is the JWT (or nil). The auth machine snapshot itself lives in
+  "The auth slice. :user holds the current :User payload (or nil); :token is
+   the JWT (or nil). The auth machine's own snapshot lives elsewhere — over in
    runtime-db at [:rf.runtime/machines :snapshots :auth/flow].
 
-   :return-to is the optional post-login bounce-back target stashed by the
-   routing auth-guard (routing.cljs) when an unauthenticated user is
-   redirected away from a `:requires-auth` route; `:auth/post-login-redirect`
-   reads and clears it (auth.cljs). Present only between the redirect and the
-   next successful login."
+   :return-to is the breadcrumb: the post-login bounce-back target the routing
+   auth-guard drops here (routing.cljs) when it turns a logged-out user away
+   from a `:requires-auth` route. `:auth/post-login-redirect` reads and clears
+   it (auth.cljs). It only exists for the brief window between that redirect and
+   the next successful login."
   [:map
    [:user      [:maybe User]]
    [:token     [:maybe :string]]
@@ -160,24 +165,24 @@
      [:id     :keyword]
      [:params [:maybe :map]]]]])
 
-;; Machine snapshots live in the runtime-db partition at
-;; [:rf.runtime/machines :snapshots <id>], not in app-db. `reg-app-schema`
-;; validates the app-db partition only, so a machine snapshot's shape is
-;; validated through the machine's own `[:schemas :data]` slot (which
-;; describes the snapshot's `:data` map) rather than an app-schema on a
-;; runtime path. The `*Data` schemas below are attached as `[:schemas :data]`
-;; where each machine is registered (auth.cljs / tags.cljs / settings.cljs).
+;; Machine snapshots aren't app-db — they live in the runtime-db partition at
+;; [:rf.runtime/machines :snapshots <id>]. And `reg-app-schema` only polices
+;; app-db, so you don't validate a snapshot with an app-schema on a runtime
+;; path. Instead each machine carries its own `[:schemas :data]` slot
+;; describing its snapshot's `:data` map, and the `*Data` schemas below are
+;; what get attached there, at each machine's registration site (auth.cljs /
+;; tags.cljs / settings.cljs).
 
 (def AuthFlowData
-  "The `:data` slot of the `:auth/flow` machine snapshot."
+  "The `:data` slot of the `:auth/flow` machine's snapshot."
   [:map
    [:error [:maybe :string]]])
 
 (def TagsData
-  "The `:data` slot of the `:realworld/tags` machine snapshot, where the
-   remote-data lifecycle lives entirely in the machine. The state-keyword
-   is the status enum; `:data` carries the items, error, loaded-at, and
-   attempt fields the slice form would store in the slice itself."
+  "The `:data` slot of the `:realworld/tags` machine's snapshot — the case
+   where the whole remote-data lifecycle lives in the machine. The
+   state-keyword is the status enum, and `:data` here holds the items, error,
+   loaded-at, and attempt that the slice form would otherwise keep in a slice."
   [:map
    [:tags      [:vector :string]]
    [:error     [:maybe :any]]
@@ -185,10 +190,10 @@
    [:attempt   :int]])
 
 (def SettingsFormData
-  "The `:data` slot of the `:settings/form` machine snapshot, where the
-   form lifecycle lives entirely in the machine. The state-keyword is the
-   lifecycle (`:neutral` / `:incorrect` / `:correct` + `:submitting`);
-   `:data` carries the draft + per-field validation state + the projected
+  "The `:data` slot of the `:settings/form` machine's snapshot — the case where
+   the whole FORM lifecycle lives in the machine. The state-keyword is the
+   lifecycle (`:neutral` / `:incorrect` / `:correct` + `:submitting`), and
+   `:data` holds the draft, the per-field validation state, and the projected
    submit-error string."
   [:map
    [:draft        :map]
@@ -209,10 +214,10 @@
    [:submit-error [:maybe :string]]])
 
 (def EditorSlice
-  ;; The state vocabulary (`:mode` = :create/:edit, lifecycle `:status`)
-  ;; lives in the :ui/article-editor machine snapshot (runtime-db), not this
-  ;; app-db slice — see `editor-slice` in article_editor.cljs. The slice
-  ;; carries only the data.
+  ;; The state vocabulary (`:mode` = :create/:edit, the lifecycle `:status`)
+  ;; lives in the :ui/article-editor machine's snapshot over in runtime-db, NOT
+  ;; in this slice — see `editor-slice` in article_editor.cljs. This slice is
+  ;; just the data.
   [:map
    [:slug [:maybe :string]]
    [:draft [:map
@@ -229,8 +234,8 @@
    [:errors :map]
    [:touched [:set :keyword]]
    [:submit-attempted? {:optional true} :boolean]
-   ;; Output of the :editor/can-submit? flow. Optional because the flow's
-   ;; first walk lands one event after :editor/initialise.
+   ;; Where the :editor/can-submit? flow parks its output. Optional because the
+   ;; flow's first computation only lands one event after :editor/initialise.
    [:can-submit? {:optional true} :boolean]
    [:submit-error [:maybe :string]]])
 
@@ -238,22 +243,22 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 ;;
-;; Path-based schema attachment. The framework validates writes to these
-;; paths in development.
+;; Attach schemas to app-db paths, and the framework will validate writes to
+;; those paths in development — a tripwire for the day a handler starts putting
+;; the wrong shape somewhere.
 ;;
-;; This example uses the bulk plural form `rf/reg-app-schemas`: a single
-;; `{path -> schema}` map reads more cleanly than a tower of singular
-;; `reg-app-schema` calls.
+;; We use the bulk plural `rf/reg-app-schemas` here: one `{path -> schema}` map
+;; reads far more cleanly than a tall stack of singular `reg-app-schema` calls.
 ;;
-;; All paths here are app-db paths. Machine snapshots are not app-db — they
-;; live in runtime-db and are validated through each machine's
-;; `[:schemas :data]` (the *Data schemas above), so they do not appear here.
+;; Every path below is an app-db path. Machine snapshots are deliberately
+;; absent — they're runtime-db, not app-db, and get validated through each
+;; machine's own `[:schemas :data]` (the *Data schemas above) instead.
 ;;
-;; `reg-app-schemas` is frame-local, so it needs a frame in context; a bare
-;; ns-load call would raise :rf.error/no-frame-context. `with-frame` names
-;; the target frame, `:rf/default`, so the schemas register against that id
-;; at load time. The frame-provider in core.cljs creates `:rf/default` and
-;; picks these schemas up.
+;; One wrinkle: `reg-app-schemas` is frame-local, so it needs a frame in
+;; context — call it bare at ns-load and you'd get :rf.error/no-frame-context.
+;; `with-frame` names the target, `:rf/default`, so these register against that
+;; frame at load time, ready for the frame-provider in core.cljs to pick up
+;; when it creates `:rf/default`.
 (with-frame :rf/default
  (rf/reg-app-schemas
   {[:auth]                          AuthSlice

--- a/examples/reagent/realworld/settings.cljs
+++ b/examples/reagent/realworld/settings.cljs
@@ -1,38 +1,38 @@
 (ns realworld.settings
   "User settings page for the RealWorld (Conduit) example.
 
-   Here the form's lifecycle lives entirely in a state machine,
-   `:settings/form`, whose state-keyword is the form lifecycle (`:neutral`
-   / `:incorrect` / `:correct` / `:submitting`). The other four forms in
-   realworld (`:auth :login-form`, `:auth :register-form`, `:editor`,
-   `:comment-form`) keep the plain
-   `{:draft :submitted :status :errors :touched :submit-error}` slice
-   shape, so a reader can compare the two shapes side by side. See the
-   forms how-to: ../../../docs/guide/how-to/build-a-form.md
+   This is the form-as-a-machine case. The settings form's whole lifecycle
+   lives inside a state machine, `:settings/form`, whose state-keyword IS the
+   lifecycle (`:neutral` / `:incorrect` / `:correct` / `:submitting`). The
+   other four forms in realworld (`:auth :login-form`, `:auth :register-form`,
+   `:editor`, `:comment-form`) stick with the plain
+   `{:draft :submitted :status :errors :touched :submit-error}` slice, so the
+   two approaches sit side by side for comparison. See the forms how-to:
+   ../../../docs/guide/how-to/build-a-form.md
 
-   The shape:
+   What moving the form into a machine buys (and costs):
 
-   - The form lifecycle (`:neutral` / `:incorrect` / `:correct` +
-     `:submitting`) maps one-to-one onto machine states; the slice's
-     `:status` field is gone because the state-keyword is the status.
-   - The draft, errors, touched, submit-error, submitted, and loaded-at
-     fields live in the machine's `:data` map (no app-db slice).
-   - The slice's `:submitting?` boolean becomes a per-state
-     `:settings/in-flight` tag queried with `rf/machine-has-tag?`.
+   - The lifecycle (`:neutral` / `:incorrect` / `:correct` + `:submitting`)
+     becomes machine states, one for one — the slice's `:status` field is gone,
+     because the state-keyword now IS the status.
+   - The draft, errors, touched, submit-error, submitted, and loaded-at all
+     move into the machine's `:data` map; there's no app-db slice.
+   - The slice's `:submitting?` boolean turns into a per-state
+     `:settings/in-flight` tag, asked with `rf/machine-has-tag?`.
 
-   Logout stays on the auth machine path (`:auth/flow`).
+   Logout stays where it belongs, on the auth machine (`:auth/flow`).
 
-   This form submits eagerly: pressing 'Update Settings' triggers a server
-   roundtrip with no prior client-side validate step. The `:submit-invalid`
-   / `:incorrect` transition exists so the lifecycle is complete; a real
-   app would run a Malli validate against the draft inside `:settings/submit`
-   and dispatch `:submit-invalid` when it returned errors."
+   One honest simplification: this form submits eagerly. Hitting 'Update
+   Settings' goes straight to a server round-trip, with no client-side validate
+   step first. The `:submit-invalid` → `:incorrect` transition is wired up
+   anyway, so the lifecycle is complete and you can see where validation WOULD
+   slot in — a real app would run a Malli validate against the draft inside
+   `:settings/submit` and dispatch `:submit-invalid` when it found problems."
   (:require [re-frame.core :as rf]
-            ;; State machines ship in the re-frame2-machines artefact.
-            ;; Requiring the ns registers its hooks so `rf/reg-machine`
-            ;; (called below) and the `:rf/machine` / `:rf/machine-has-tag?`
-            ;; subs resolve. See the machines guide:
-            ;; ../../../docs/machines/index.md
+            ;; State machines live in their own artefact; we require it to load
+            ;; it, which registers the hooks that make `rf/reg-machine` (below)
+            ;; and the `:rf/machine` / `:rf/machine-has-tag?` subs resolve. See
+            ;; the machines guide: ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh])
@@ -57,11 +57,12 @@
 ;; THE MACHINE — :settings/form  (one region; the form lifecycle)
 ;; ============================================================================
 ;;
-;; The form lifecycle maps one-to-one onto machine states. Compare with the
-;; slice form used by the other four realworld forms:
+;; The form lifecycle becomes machine states, one for one. Hold the two shapes
+;; up next to each other — the slice the other four forms use, and the machine
+;; this one uses:
 ;;
-;;     ;; SLICE FORM (used by :auth :login-form, :auth :register-form, :editor, :comment-form)
-;;     ;; The slice carries an explicit :status keyword.
+;;     ;; SLICE FORM (:auth :login-form, :auth :register-form, :editor, :comment-form)
+;;     ;; A plain map with an explicit :status keyword.
 ;;     {:draft        {...}
 ;;      :submitted    nil
 ;;      :status       :idle | :submitting
@@ -69,29 +70,29 @@
 ;;      :touched      #{}
 ;;      :submit-error nil}
 ;;
-;;     ;; MACHINE FORM (used here)
-;;     ;; The state-keyword IS the lifecycle; the rest lives in :data.
+;;     ;; MACHINE FORM (this file)
+;;     ;; The state-keyword IS the lifecycle; the rest moves into :data.
 ;;     {:state :neutral | :incorrect | :correct | :submitting
 ;;      :data  {:draft {...} :errors {} :touched #{} :submit-error nil
 ;;              :submitted nil :loaded-at nil}
 ;;      :tags  #{...}}
 ;;
-;; The form's load-bearing boolean — `:submitting?` — becomes a tag query
-;; against the active state:
+;; And the form's one load-bearing boolean, `:submitting?`, becomes a tag
+;; question about the current state:
 ;;
 ;;     :submitting?  = (= :submitting status)            ;; slice form
 ;;     :submitting?  = @(rf/machine-has-tag? :settings/form :settings/in-flight)
 ;;
-;; The view doesn't need to know which state-keyword carries the
-;; "in-flight" intent; the tag does.
+;; Same upside as the tags machine: the view never has to know WHICH state
+;; means \"in-flight\". It asks the tag and moves on.
 
 (def settings-form-machine
   {:initial :neutral
    :data    initial-data
    ;; The snapshot lives in runtime-db
-   ;; ([:rf.runtime/machines :snapshots :settings/form]), so its :data shape
-   ;; is validated here via [:schemas :data], not via an app-schema (app
-   ;; schemas validate the app-db partition only).
+   ;; ([:rf.runtime/machines :snapshots :settings/form]), not app-db, so its
+   ;; :data shape is validated right here via [:schemas :data] — an app-schema
+   ;; only sees the app-db partition.
    :schemas {:data schema/SettingsFormData}
 
    :actions
@@ -103,10 +104,10 @@
                  (assoc :loaded-at now))})
 
     :edit-field
-    ;; :edit carries [field value]; touches the field, clears any
-    ;; prior submit-error so a fresh edit doesn't keep the old error
-    ;; banner visible, and drops the per-field error entry for the
-    ;; edited field so the inline error disappears as the user types.
+    ;; :edit carries {field value}. It writes the value, marks the field
+    ;; touched, clears any leftover submit-error (so an old banner doesn't
+    ;; linger while you're fixing things), and drops THIS field's inline error
+    ;; — the red text fades as you type, which is how forms should feel.
     (fn action-edit-field [{data :data [_ {:keys [field value]}] :event}]
       {:data (-> data
                  (assoc-in [:draft field] value)
@@ -115,9 +116,9 @@
                  (assoc :submit-error nil))})
 
     :set-errors
-    ;; :submit-invalid carries the per-field error map. Touch every error
-    ;; field too, so the inline error shows even on fields the user hasn't
-    ;; interacted with yet.
+    ;; :submit-invalid carries the per-field error map. We also mark every
+    ;; errored field touched, so the inline messages appear even on fields the
+    ;; user never got around to filling in.
     (fn action-set-errors [{data :data [_ {:keys [errors]}] :event}]
       {:data (-> data
                  (assoc :errors errors)
@@ -125,9 +126,9 @@
                  (assoc :submit-error nil))})
 
     :begin-submit
-    ;; :submit-valid carries the draft snapshot we just dispatched to
-    ;; the server. Clear :errors and :submit-error so they don't
-    ;; linger from a prior failed attempt.
+    ;; :submit-valid carries the draft snapshot we just sent to the server.
+    ;; Wipe :errors and :submit-error so nothing lingers from a previous failed
+    ;; attempt while this one's in flight.
     (fn action-begin-submit [{data :data [_ {:keys [submitted]}] :event}]
       {:data (-> data
                  (assoc :submitted submitted)
@@ -135,9 +136,9 @@
                  (assoc :submit-error nil))})
 
     :store-user
-    ;; :submit-succeeded carries the server's returned user. Re-seed
-    ;; the draft from the new user so a subsequent edit starts from
-    ;; the freshly-saved state.
+    ;; :submit-succeeded carries the user the server saved. Re-seed the draft
+    ;; from it, so the next edit starts from the freshly-saved values rather
+    ;; than whatever was typed before the save.
     (fn action-store-user [{data :data [_ {:keys [user]}] :event}]
       {:data (-> data
                  (assoc :draft (draft-from-user user))
@@ -157,9 +158,9 @@
 
    :states
    {:neutral
-    ;; The resting state. The form is open; the user hasn't seen a
-    ;; validation error or a success acknowledgement yet (or they
-    ;; have, and a subsequent :edit reset the region to :neutral).
+    ;; The resting state — form open, nothing to report. Either the user hasn't
+    ;; hit a validation error or a success yet, or they did and a later :edit
+    ;; brought things back here. The calm default.
     {:tags #{:settings/neutral}
      :on   {:load           {:target :neutral    :action :seed-from-user}
             :edit           {:target :neutral    :action :edit-field}
@@ -168,9 +169,10 @@
             :reset          {:target :neutral    :action :reset-data}}}
 
     :incorrect
-    ;; Per-field validation error visible on a touched field, OR a
-    ;; server submit-error from the previous attempt. The first :edit
-    ;; clears errors and returns the region to :neutral.
+    ;; Something's wrong and showing: either a per-field validation error on a
+    ;; touched field, or a server submit-error from the last attempt. The first
+    ;; :edit clears the errors and drops back to :neutral — start fixing and the
+    ;; complaints go away.
     {:tags #{:settings/incorrect :form/invalid}
      :on   {:edit           {:target :neutral    :action :edit-field}
             :submit-invalid {:target :incorrect  :action :set-errors}
@@ -178,21 +180,21 @@
             :reset          {:target :neutral    :action :reset-data}}}
 
     :submitting
-    ;; Request in flight. The :settings/in-flight tag drives the
-    ;; disabled state of every form input and the submit button.
-    ;; The :form/transient tag exists so a view that wants to overlay
-    ;; transient acknowledgements (in-flight, success, error) can
-    ;; query one tag instead of three state-keywords.
+    ;; Request in flight. The :settings/in-flight tag is what greys out every
+    ;; input and the submit button while we wait. The :form/transient tag is a
+    ;; convenience: a view that wants to overlay any passing acknowledgement
+    ;; (in-flight, success, error) can watch that one tag instead of OR-ing
+    ;; three state-keywords.
     {:tags #{:settings/submitting :settings/in-flight :form/transient}
      :on   {:submit-succeeded {:target :correct   :action :store-user}
             :submit-failed    {:target :incorrect :action :set-submit-error}
             :reset            {:target :neutral   :action :reset-data}}}
 
     :correct
-    ;; Happy-path acknowledgement. Transient; the next :edit returns
-    ;; the region to :neutral. The slice-form equivalent is
-    ;; `:status :submitted` — there the view typically navigates away
-    ;; (and so does this one, see :settings/submit-succeeded below).
+    ;; The happy-path "saved!" beat. Transient — the next :edit returns to
+    ;; :neutral. In slice form this is `:status :submitted`, where the view
+    ;; usually navigates away on success; this one does too, see
+    ;; :settings/submit-success below.
     {:tags #{:settings/correct :form/success :form/transient}
      :on   {:edit  {:target :neutral :action :edit-field}
             :reset {:target :neutral :action :reset-data}}}}})
@@ -203,19 +205,22 @@
 ;; PUBLIC EVENT API
 ;; ============================================================================
 ;;
-;; Each event fans out to one or more machine broadcasts; views and sibling
-;; namespaces dispatch these names and never touch the machine directly.
+;; These are the front door. Each event translates into one or more machine
+;; broadcasts, and views and sibling namespaces dispatch THESE names — they
+;; never reach past them to poke the machine directly. The machine stays an
+;; implementation detail.
 
 (rf/reg-event :settings/initialise
-  {:doc "Reset the settings-form machine to its initial state.
-         Dispatched from :app/initialise."}
+  {:doc "Reset the settings-form machine to its initial state. Dispatched from
+         :app/initialise at boot."}
   (fn handler-settings-initialise [_ _]
     {:fx [[:dispatch [:settings/form [:reset]]]]}))
 
 (rf/reg-event :settings/load
-  {:doc "Seed the form draft from the currently-authenticated user.
-         Dispatched by the :realworld.user/settings :on-match (see routing.cljs)
-         and by tests after :auth/store-session."
+  {:doc "Fill the form draft from the currently signed-in user, so the page
+         opens pre-populated rather than blank. Dispatched by the
+         :realworld.user/settings :on-match (routing.cljs), and by tests after
+         an :auth/store-session."
    :rf.cofx/requires [:rf/time-ms]}
   (fn handler-settings-load [{:keys [db rf/time-ms]} _]
     (let [user (get-in db [:auth :user])]
@@ -224,20 +229,20 @@
                                 :now  time-ms}]]]]})))
 
 (rf/reg-event :settings/edit-field
-  {:doc  "User edited a form field. Broadcasts :edit into the machine —
-          the :form region returns from :correct / :incorrect to
-          :neutral and updates the draft + :touched."
+  {:doc  "The user changed a field. Broadcasts :edit into the machine, which
+          brings the region back from :correct / :incorrect to :neutral and
+          updates the draft + :touched. Typing settles the form down."
    :schema [:cat [:= :settings/edit-field] :keyword :string]}
   (fn handler-settings-edit-field [_ [_ field value]]
     {:fx [[:dispatch [:settings/form
                       [:edit {:field field :value value}]]]]}))
 
 (rf/reg-event :settings/submit
-  {:doc "Save the user-settings draft. No retry — one submission per click.
-         Broadcasts :submit-valid into the machine (which transitions to
-         :submitting and clears prior errors); on reply,
+  {:doc "Save the settings draft. No retry — one submission per click.
+         Broadcasts :submit-valid into the machine (which moves it to
+         :submitting and clears any prior errors); when the reply lands,
          :settings/submit-success / :settings/submit-error broadcast
-         :submit-succeeded / :submit-failed."
+         :submit-succeeded / :submit-failed in turn."
    :rf.http/decode-schemas [schema/UserResponse]}
   ;; The machine snapshot lives in runtime-db.
   (fn handler-settings-submit [{rt :rf.db/runtime} _]
@@ -255,10 +260,10 @@
                           :on-failure [:settings/submit-error]})]]})))
 
 (rf/reg-event :settings/submit-success
-  {:doc "Server accepted. Folds the new user into the machine's :data
-         via the :store-user action (region lands in :correct), pushes
-         the same user through :auth/store-session, and navigates to
-         the user's profile page."}
+  {:doc "Server said yes. Three things follow: fold the returned user into the
+         machine's :data via :store-user (region lands in :correct), push that
+         same user through :auth/store-session so the rest of the app sees the
+         update, and navigate off to the user's profile page."}
   (fn handler-settings-submit-success [_ [_ {:keys [value]}]]
     (let [user (:user value)]
       {:fx [[:dispatch [:settings/form
@@ -267,10 +272,11 @@
             [:dispatch [:rf.route/navigate :realworld.profile/show {:username (:username user)}]]]})))
 
 (rf/reg-event :settings/submit-error
-  {:doc "Server rejected. Folds a human-readable error message into the
-         machine's :data via the :set-submit-error action; the region
-         lands in :incorrect (the same surface the validation-error
-         path uses, since both render via :submit-error / :errors)."}
+  {:doc "Server said no. Folds a readable error message into the machine's
+         :data via :set-submit-error; the region lands in :incorrect — the very
+         same surface the client-side validation path uses, since both show up
+         through :submit-error / :errors. One place to render \"something's
+         wrong\", however it went wrong."}
   (fn handler-settings-submit-error [_ [_ {:keys [failure]}]]
     {:fx [[:dispatch [:settings/form
                       [:submit-failed {:submit-error (rh/failure->message failure)}]]]]}))
@@ -279,28 +285,27 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; The view consumes plain names (`:settings/draft`,
-;; `:settings/submit-error`); the source is the machine's `:data`.
-;; `:settings/submitting?` is an `rf/machine-has-tag?` query under the hood,
-;; presented to the view as a plain boolean.
+;; The view sees plain, ordinary names (`:settings/draft`,
+;; `:settings/submit-error`), all sourced from the machine's `:data`. And
+;; `:settings/submitting?` is an `rf/machine-has-tag?` query underneath, handed
+;; to the view as a plain boolean — the machine-ness stays behind the curtain.
 
 (rf/reg-sub :settings/draft
-  {:doc "The settings form draft, projected off the machine's :data."}
+  {:doc "The settings-form draft, read out of the machine's :data."}
   :<- [:rf/machine :settings/form]
   (fn sub-settings-draft [snap _]
     (get-in snap [:data :draft])))
 
 (rf/reg-sub :settings/submit-error
-  {:doc "The most recent settings-submit error, projected off the
-         machine's :data."}
+  {:doc "The latest settings-submit error, read out of the machine's :data."}
   :<- [:rf/machine :settings/form]
   (fn sub-settings-submit-error [snap _]
     (get-in snap [:data :submit-error])))
 
 (rf/reg-sub :settings/submitting?
-  {:doc "Tag-shaped read of the form's in-flight intent — stands in for a
-         slice-form `(= :submitting status)` comparison; views see a plain
-         boolean."}
+  {:doc "Is a save in flight? A tag-shaped read of the form's in-flight intent —
+         the machine-form stand-in for a slice's `(= :submitting status)`. Views
+         just see a boolean."}
   :<- [:rf/machine-has-tag? :settings/form :settings/in-flight]
   (fn sub-settings-submitting? [in-flight? _]
     (boolean in-flight?)))

--- a/examples/reagent/realworld/ssr.cljc
+++ b/examples/reagent/realworld/ssr.cljc
@@ -1,22 +1,23 @@
 (ns realworld.ssr
   "RealWorld-specific SSR helpers.
 
-   The generic runtime SSR walkthrough lives in `examples/reagent/ssr/core.cljc`.
-   This namespace is the app-specific bridge:
-   - choose which slices are safe to embed in the hydration payload
-   - preserve the route slice so the client starts from the server route
-   - provide a small client bootstrap helper for `:rf/hydrate`
+   The general how-SSR-works walkthrough lives in
+   `examples/reagent/ssr/core.cljc`. This file is the app-specific half of the
+   story — the part every real app has to write for itself:
+   - decide which slices are safe to ship in the hydration payload
+   - carry the route slice across so the client wakes up on the server's route
+   - offer a small client-side bootstrap for `:rf/hydrate`
 
-   That keeps the reusable SSR mechanics in the generic example while
-   still showing how a larger app would define its own payload boundary."
+   Splitting it this way keeps the reusable SSR machinery in the generic
+   example, while this one shows where a larger app draws its own payload
+   boundary — which is to say, what it's willing to send down the wire."
   (:require [re-frame.core :as rf]
             #?(:cljs [cljs.reader :as reader])))
 
 (def ssr-app-slice-keys
-  "Top-level app-db slices the SSR payload exports. These are application
-  data only — the framework's subsystem trees (routing, machines, elision)
-  live in the separate runtime-db partition and ride the payload under
-  :rf/runtime-db."
+  "The top-level app-db slices the SSR payload ships. Application data only —
+  the framework's own subsystem trees (routing, machines, elision) live in the
+  separate runtime-db partition and travel under :rf/runtime-db instead."
   [:auth
    :articles
    :article
@@ -29,34 +30,36 @@
    :comment-form])
 
 (def ssr-runtime-keys
-  "The serializable **runtime-db** children the SSR payload exports so the
-  client starts from the server's route + machine state. The current-route
-  slice + machine snapshots are durable runtime-db facts; transient runtime
-  state (host handles, in-flight HTTP) is excluded."
+  "The serializable **runtime-db** children the SSR payload ships, so the client
+  resumes on the server's route and machine state. The current route and the
+  machine snapshots are durable facts worth sending; the transient stuff (host
+  handles, in-flight HTTP) is left behind — it wouldn't survive the trip
+  anyway."
   [:rf.runtime/routing
    :rf.runtime/machines])
 
 (defn exportable-app-db [app-db]
-  ;; Keep secrets out of the SSR payload. The bearer JWT lives at
-  ;; [:auth :token]; embedding it in server-rendered HTML would leak a live
-  ;; credential into page source (view-source-visible, proxy-logged,
-  ;; CDN-cacheable). Redact it at the payload boundary. The client
-  ;; re-establishes [:auth :token] on hydrate via `:auth/initialise`
-  ;; (auth.cljs), which reads it back from localStorage through the
-  ;; `:auth.session/token` recordable coeffect. So dropping the token from
-  ;; the payload costs nothing and stays replay-sound.
+  ;; No secrets in the SSR payload — full stop. The bearer JWT sits at
+  ;; [:auth :token], and baking it into server-rendered HTML would spill a live
+  ;; credential into the page source: visible in view-source, logged by
+  ;; proxies, possibly cached by a CDN. So we redact it right at the boundary.
+  ;; And it costs nothing, because the client puts [:auth :token] back on
+  ;; hydrate via `:auth/initialise` (auth.cljs), reading it from localStorage
+  ;; through the `:auth.session/token` recordable coeffect. Dropping it here is
+  ;; free and stays replay-sound.
   (cond-> (select-keys app-db ssr-app-slice-keys)
     (contains? app-db :auth) (update :auth dissoc :token)))
 
 (defn exportable-runtime-db [runtime-db]
-  ;; Project only the durable, serializable runtime-db children — route slice
-  ;; and machine snapshots — so the client resumes from the server's route
-  ;; and any machines mid-flow.
+  ;; Keep only the durable, serializable runtime-db children — the route slice
+  ;; and the machine snapshots — so the client picks up on the server's route
+  ;; with any machines still mid-flow.
   (select-keys runtime-db ssr-runtime-keys))
 
 (defn hydration-payload
-  "Build the two-partition hydration payload from a frame-state value
-  (`{:rf.db/app … :rf.db/runtime …}`, e.g. `(rf/frame-state-value frame-id)`)."
+  "Assemble the two-partition hydration payload from a frame-state value
+  (`{:rf.db/app … :rf.db/runtime …}`, e.g. `(rf/frame-state-value frame-id)`).
+  This is what the server embeds and the client reads back."
   [{:rf.db/keys [app runtime]} render-tree]
   {:rf/version     1
    :rf/app-db      (exportable-app-db app)
@@ -69,9 +72,9 @@
        (reader/read-string (.-textContent el)))))
 
 #?(:cljs
-   ;; The caller names the frame to hydrate. Making the target explicit lets
-   ;; a non-default or multi-frame client hydrate the right frame by passing
-   ;; its own frame-id.
+   ;; The caller names which frame to hydrate. Being explicit about it means a
+   ;; non-default or multi-frame client can hydrate exactly the right frame,
+   ;; just by passing its own frame-id.
    (defn hydrate-client! [frame-id]
      (when-let [payload (read-server-payload)]
        (rf/dispatch-sync [:rf/hydrate payload] {:frame frame-id})

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -1,33 +1,33 @@
 (ns realworld.tags
-  "Popular-tags list plus home-page navigation helpers (the `/tag/:tag`
-   PATH route + the `?feed=` / `?page=` query).
+  "Popular-tags list, plus the home-page navigation helpers (the `/tag/:tag`
+   PATH route and the `?feed=` / `?page=` query).
 
-   Here the popular-tags lifecycle lives entirely in a single-region state
-   machine, `:realworld/tags`, whose state-keyword is the remote-data
-   status. Every other remote-data resource in realworld (`:articles`,
-   `:feed`, `:article`, `:comments`, `:profile`, `:profile.articles`,
-   `:profile.favorites`) keeps the plain 5-key slice shape, so a reader can
-   compare the two shapes side by side. See the machines guide:
+   This file is the deliberate contrast case. The popular-tags lifecycle here
+   lives ENTIRELY inside a single-region state machine, `:realworld/tags`,
+   whose state-keyword IS the remote-data status — no app-db slice at all.
+   Every other remote-data resource in realworld (`:articles`, `:feed`,
+   `:article`, `:comments`, `:profile`, `:profile.articles`,
+   `:profile.favorites`) uses the plain 5-key slice instead, so you can hold
+   the two shapes up side by side and see the trade. See the machines guide:
    ../../../docs/machines/index.md
 
-   The shape:
+   What changes when the machine swallows the lifecycle:
 
-   - The status enum (`:idle :loading :fetching :loaded :error`) maps
-     one-to-one onto machine states; the slice's `:status` field is gone.
-   - The items, error, loaded-at, and attempt fields live in the machine's
-     `:data` map (no app-db slice).
-   - The slice's `:loading?` / `:fetching?` booleans become per-state
-     `:tags` queried with `rf/machine-has-tag?`.
+   - The status enum (`:idle :loading :fetching :loaded :error`) becomes the
+     machine's states, one for one; the slice's `:status` field just vanishes.
+   - The items, error, loaded-at, and attempt all move into the machine's
+     `:data` map — there's no slice left to hold them.
+   - The slice's `:loading?` / `:fetching?` booleans turn into per-state
+     `:tags`, asked with `rf/machine-has-tag?`.
 
-   Routing pieces (`:home/load`, `:home/show-global-feed`, etc.) sit below;
-   they dispatch `:tags/load` so the popular-tags machine fetches when the
-   home route activates."
+   The routing helpers (`:home/load`, `:home/show-global-feed`, …) live down
+   below; they dispatch `:tags/load` so the tags machine fetches whenever the
+   home route lights up."
   (:require [re-frame.core :as rf]
-            ;; State machines ship in the re-frame2-machines artefact.
-            ;; Requiring the ns registers its hooks so `rf/reg-machine`
-            ;; (called below) and the `:rf/machine` / `:rf/machine-has-tag?`
-            ;; subs resolve. See the machines guide:
-            ;; ../../../docs/machines/index.md
+            ;; State machines live in their own artefact; we require it to load
+            ;; it, which registers the hooks that make `rf/reg-machine` (below)
+            ;; and the `:rf/machine` / `:rf/machine-has-tag?` subs resolve. See
+            ;; the machines guide: ../../../docs/machines/index.md
             [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh]))
@@ -36,29 +36,30 @@
 ;; THE MACHINE — :realworld/tags  (one region; the remote-data lifecycle)
 ;; ============================================================================
 ;;
-;; The status enum maps one-to-one onto machine states. Compare with the
-;; slice form used by `:articles`, `:feed`, `:article`, ...:
+;; Here's the same lifecycle, two ways. The status enum becomes machine states,
+;; one for one. Put the slice form (used by `:articles`, `:feed`, `:article`,
+;; …) next to the machine form (used here):
 ;;
-;;     ;; SLICE FORM (used by the other seven remote-data resources)
-;;     ;; The slice carries an explicit :status keyword.
+;;     ;; SLICE FORM (the other seven remote-data resources)
+;;     ;; A plain map with an explicit :status keyword.
 ;;     {:status :loading :data [] :error nil :loaded-at nil :attempt 0}
 ;;
-;;     ;; MACHINE FORM (used here)
-;;     ;; The state-keyword IS the status; the rest lives in :data.
+;;     ;; MACHINE FORM (this file)
+;;     ;; The state-keyword IS the status; everything else moves into :data.
 ;;     {:state :loading :data {:tags [] :error nil :loaded-at nil :attempt 0} :tags #{...}}
 ;;
-;; The two view-load-bearing booleans:
+;; And the two booleans the view actually cares about:
 ;;
-;;     :loading?   = (= status :loading)                        ;; truly empty + in-flight
-;;     :fetching?  = (#{:loading :fetching} status)             ;; any in-flight
+;;     :loading?   = (= status :loading)                        ;; empty AND in-flight
+;;     :fetching?  = (#{:loading :fetching} status)             ;; in-flight, full or not
 ;;
-;; become tag queries against the active state:
+;; turn into tag questions about the current state:
 ;;
 ;;     :loading?   = @(rf/machine-has-tag? :realworld/tags :tags/loading)
 ;;     :fetching?  = @(rf/machine-has-tag? :realworld/tags :tags/in-flight)
 ;;
-;; The view doesn't need to know which state-keyword carries the
-;; "in-flight" intent; the tag does.
+;; The payoff: the view never has to remember WHICH state means \"in-flight\".
+;; It asks for the tag, and the machine keeps that bookkeeping to itself.
 
 (def tags-machine
   {:initial :idle
@@ -66,9 +67,9 @@
              :error    nil
              :loaded-at nil
              :attempt  0}
-   ;; Validates the snapshot's :data slot at every macrostep boundary. The
-   ;; snapshot lives in runtime-db, so this — not an app-schema — is the
-   ;; validation surface.
+   ;; Validates the snapshot's :data at every macrostep boundary. The snapshot
+   ;; lives in runtime-db, not app-db, so THIS is its validation surface — an
+   ;; app-schema would never see it.
    :schemas {:data schema/TagsData}
 
    :actions
@@ -79,7 +80,7 @@
                  (assoc  :error nil))})
 
     :set-tags
-    ;; :fetch-succeeded carries the resolved tags vector under :tags.
+    ;; :fetch-succeeded brings the resolved tags vector along under :tags.
     (fn action-set-tags [{data :data [_ {:keys [tags now]}] :event}]
       {:data (-> data
                  (assoc :tags (vec tags))
@@ -96,40 +97,41 @@
 
    :states
    {:idle
-    ;; Never fetched; or just :reset. The slice's `:status :idle`.
+    ;; Never fetched, or freshly :reset. The slice-form equivalent of
+    ;; `:status :idle`.
     {:tags #{:tags/idle}
      :on   {:fetch-started {:target :loading :action :bump-attempt}
             :reset         {:target :idle    :action :reset-data}}}
 
     :loading
-    ;; First fetch in flight; no prior :tags. The :tags/in-flight tag
-    ;; lights up on both :loading and :fetching so the view doesn't have
-    ;; to disjoin two state-keywords.
+    ;; First fetch in flight, nothing to show yet. The :tags/in-flight tag
+    ;; rides on both :loading and :fetching, so a view asking "is something
+    ;; loading?" doesn't have to OR two state-keywords together.
     {:tags #{:tags/loading :tags/in-flight :tags/transient}
      :on   {:fetch-succeeded {:target :loaded :action :set-tags}
             :fetch-failed    {:target :error  :action :set-error}
             :reset           {:target :idle   :action :reset-data}}}
 
     :fetching
-    ;; Re-fetch in flight while prior :tags are still rendered. Never blank
-    ;; the page; a subtle progress indicator at most. The :tags/loaded tag
-    ;; stays present so the render path that consumes :tags is unaffected.
+    ;; A re-fetch while the old :tags are still on screen. We don't blank the
+    ;; sidebar — a subtle progress hint at most. The :tags/loaded tag stays
+    ;; lit, so whatever renders the tags carries on undisturbed.
     {:tags #{:tags/fetching :tags/in-flight :tags/loaded :tags/transient}
      :on   {:fetch-succeeded {:target :loaded :action :set-tags}
             :fetch-failed    {:target :error  :action :set-error}
             :reset           {:target :idle   :action :reset-data}}}
 
     :loaded
-    ;; Successful fetch settled. A subsequent :fetch-started lands in
-    ;; :fetching (keeps :tags visible during revalidation) rather than
-    ;; :loading (which would blank the sidebar).
+    ;; Settled, with tags in hand. The next :fetch-started goes to :fetching,
+    ;; not :loading — revalidating without yanking the sidebar out from under
+    ;; the reader.
     {:tags #{:tags/loaded}
      :on   {:fetch-started {:target :fetching :action :bump-attempt}
             :reset         {:target :idle     :action :reset-data}}}
 
     :error
-    ;; Most recent fetch failed. Prior :tags (if any) are still in
-    ;; :data; the view can choose to render them or surface :error.
+    ;; The last fetch failed. Any earlier :tags are still sitting in :data, so
+    ;; the view gets to choose: keep showing them, or surface the :error.
     {:tags #{:tags/error}
      :on   {:fetch-started {:target :loading :action :bump-attempt}
             :reset         {:target :idle    :action :reset-data}}}}})
@@ -147,16 +149,15 @@
     {:fx [[:dispatch [:realworld/tags [:reset]]]]}))
 
 ;; ============================================================================
-;; LOAD / LOADED / LOAD-FAILED — the three remote-data lifecycle events,
-;; translated into machine broadcasts.
+;; LOAD / LOADED / LOAD-FAILED — the three lifecycle events, each one just a
+;; broadcast into the machine.
 ;; ============================================================================
 
 (rf/reg-event :tags/load
-  {:doc "Fetch the popular-tags list. Broadcasts `:fetch-started` into
-         the `:realworld/tags` machine; the region picks `:loading` or
-         `:fetching` based on whether prior tags are present (the
-         `:loaded` state has `:fetch-started → :fetching`; everywhere
-         else it goes to `:loading`). Public endpoint; data-fetch retry."
+  {:doc "Fetch the popular-tags list. Broadcasts `:fetch-started` into the
+         `:realworld/tags` machine and lets the machine decide where to land:
+         from `:loaded` it goes to `:fetching` (tags already showing),
+         everywhere else to `:loading`. Public endpoint; house retry."
    :rf.http/decode-schemas [schema/TagsResponse]}
   (fn handler-tags-load [_ _]
     {:fx [[:dispatch [:realworld/tags [:fetch-started]]]
@@ -170,9 +171,9 @@
                         :on-failure [:tags/load-failed]})]]}))
 
 (rf/reg-event :tags/loaded
-  {:doc "Successful tags fetch. Folds the list + a load timestamp into
-         the machine's `:data` via the `:set-tags` action; the region
-         lands in `:loaded`."
+  {:doc "Tags fetch came back happy. Folds the list and a load timestamp into
+         the machine's `:data` via the `:set-tags` action; the region settles
+         in `:loaded`."
    :rf.cofx/requires [:rf/time-ms]}
   (fn handler-tags-loaded [{:keys [rf/time-ms]} [_ {:keys [value]}]]
     {:fx [[:dispatch [:realworld/tags
@@ -180,33 +181,33 @@
                                          :now  time-ms}]]]]}))
 
 (rf/reg-event :tags/load-failed
-  {:doc "Failed tags fetch. Folds a human-readable error message into
-         the machine's `:data` via the `:set-error` action; the region
-         lands in `:error`. Any prior tags remain in `:data` so the
-         view may still render them."}
+  {:doc "Tags fetch fell over. Folds a readable error message into the
+         machine's `:data` via the `:set-error` action; the region lands in
+         `:error`. Any earlier tags stay in `:data`, so the view can keep
+         showing them if it likes."}
   (fn handler-tags-load-failed [_ [_ {:keys [failure]}]]
     {:fx [[:dispatch [:realworld/tags
                       [:fetch-failed {:failure (rh/failure->message failure)}]]]]}))
 
 ;; ============================================================================
-;; SUBSCRIPTIONS — slice-shape readers projected off the machine snapshot
+;; SUBSCRIPTIONS — plain readers projected off the machine snapshot
 ;; ============================================================================
 ;;
-;; The view consumes plain names: `:tags/data` for the items, `:tags/error`
-;; for the error map. There are no `:loading?` / `:fetching?` booleans —
-;; views ask the tag instead:
+;; To the view this looks like any other slice: `:tags/data` for the items,
+;; `:tags/error` for the error. What's missing is the `:loading?` /
+;; `:fetching?` booleans — for those, views ask the machine a tag question:
 ;;
-;;     @(rf/machine-has-tag? :realworld/tags :tags/loading)     ;; truly empty + in-flight
-;;     @(rf/machine-has-tag? :realworld/tags :tags/in-flight)   ;; any in-flight (loading OR fetching)
+;;     @(rf/machine-has-tag? :realworld/tags :tags/loading)     ;; empty AND in-flight
+;;     @(rf/machine-has-tag? :realworld/tags :tags/in-flight)   ;; in-flight, loading OR fetching
 
 (rf/reg-sub :tags/data
-  {:doc "The popular-tags items, projected off the machine's :data."}
+  {:doc "The popular-tags items, read out of the machine's :data."}
   :<- [:rf/machine :realworld/tags]
   (fn sub-tags-data [snap _]
     (get-in snap [:data :tags])))
 
 (rf/reg-sub :tags/error
-  {:doc "The most recent tags-fetch error, projected off the machine's :data."}
+  {:doc "The latest tags-fetch error, read out of the machine's :data."}
   :<- [:rf/machine :realworld/tags]
   (fn sub-tags-error [snap _]
     (get-in snap [:data :error])))
@@ -215,27 +216,28 @@
 ;; HOME-PAGE QUERY HELPERS
 ;; ============================================================================
 ;;
-;; The route-driven part of the home page (route-shape conformance):
-;; - the tag filter is the `/tag/:tag` PATH route (`:realworld/home-tag`); the
-;;   active tag is a route PARAM, not a `?tag=` query.
-;; - `?feed=following` switches the home page to the authenticated feed (the
-;;   official contract value — NOT `?feed=your`).
-;; - navigation is always expressed as `:rf.route/navigate` events.
+;; The route-driven half of the home page, all following the official URL
+;; contract:
+;; - the tag filter is the `/tag/:tag` PATH route (`:realworld/home-tag`), so
+;;   the active tag is a route PARAM, not a `?tag=` query.
+;; - `?feed=following` flips the home page to the authenticated feed — the
+;;   contract's value, NOT `?feed=your`.
+;; - every navigation is a `:rf.route/navigate` event; nothing pokes history
+;;   directly.
 ;;
-;; `:home/load` is dispatched by BOTH the `:realworld/home` and
-;; `:realworld/home-tag` `:on-match`; it broadcasts the per-axis transitions
-;; into the home machine (`:realworld/articles-home`) before kicking the
-;; per-feed fetch.
+;; `:home/load` is the `:on-match` for BOTH `:realworld/home` and
+;; `:realworld/home-tag`. It broadcasts the per-axis transitions into the home
+;; machine (`:realworld/articles-home`), then kicks off the per-feed fetch.
 
-;; The official-contract feed token for the authenticated "Your Feed".
+;; The contract's token for the authenticated "Your Feed".
 (def following-feed-token "following")
 
-;; The route lives in runtime-db; `home-context` reads it off a runtime-db
-;; value (event handlers pass the `:rf.db/runtime` coeffect; the subs below
-;; compose off the public `[:rf.route/params]` / `[:rf.route/query]` subs).
-;; It normalises the two home routes into one `{:tag :feed :page}` context:
-;; the tag comes from the `/tag/:tag` route's params, the feed + page from
-;; the query.
+;; The route lives in runtime-db, and `home-context` reads it off a runtime-db
+;; value (handlers get it via the `:rf.db/runtime` coeffect; the subs below
+;; instead compose off the public `[:rf.route/params]` / `[:rf.route/query]`
+;; subs). Its job: flatten the two home routes into one tidy
+;; `{:tag :feed :page}` — the tag from the `/tag/:tag` route's params, the feed
+;; and page from the query.
 (defn home-context [runtime-db]
   (let [cur   (get-in runtime-db [:rf.runtime/routing :current] {})
         query (:query cur {})]
@@ -244,18 +246,18 @@
      :page (:page query)}))
 
 (rf/reg-event :home/load
-  {:doc "Route :on-match handler for BOTH `:realworld/home` and
-         `:realworld/home-tag`. Reads the normalised home context (the active
-         tag off the `/tag/:tag` route's PATH params, the feed + page off the
-         query) and:
-           - broadcasts the `:feed` region into `:user-feed` / `:tag-feed`
-             / `:global` per `?feed=` and the active tag,
-           - broadcasts the `:filter` region into `:tagged` / `:none`
-             per the active tag,
-           - kicks the per-feed fetch (`:articles/load` or `:feed/load`).
-         Each fetch handler in turn broadcasts `:fetch-started` into the
-         home machine's `:data` region (per articles.cljs and
-         favorites.cljs)."}
+  {:doc "The `:on-match` for BOTH `:realworld/home` and `:realworld/home-tag`.
+         It reads the flattened home context (the active tag off the
+         `/tag/:tag` route's path params, the feed + page off the query) and
+         then conducts three things:
+           - steers the `:feed` region to `:user-feed` / `:tag-feed` / `:global`
+             based on `?feed=` and the tag,
+           - steers the `:filter` region to `:tagged` / `:none` based on the
+             tag,
+           - kicks off the matching fetch (`:articles/load` or `:feed/load`).
+         Each fetch then broadcasts its own `:fetch-started` into the home
+         machine's `:data` region (see articles.cljs and favorites.cljs), so
+         the loading state takes care of itself."}
   (fn [{rt :rf.db/runtime} _]
     (let [{:keys [feed tag]} (home-context rt)
           your-feed? (= following-feed-token feed)
@@ -271,15 +273,16 @@
              your-feed?       (conj [:dispatch [:feed/load]])
              (not your-feed?) (conj [:dispatch [:articles/load]]))})))
 
-;; Switching feed or applying/clearing a tag is a fresh navigation and so
-;; drops any in-flight `?page=` — landing back on page 1, which is the
-;; official Conduit behaviour (the page-number control resets when the feed or
-;; tag changes). Only `:home/show-page` carries the active feed/tag forward.
+;; Switching feed, or applying/clearing a tag, is a fresh navigation — and so
+;; it drops any lingering `?page=` and lands you back on page 1. That's the
+;; official Conduit behaviour: change the feed or the tag and the page-number
+;; control resets. Only `:home/show-page` carries the current feed/tag forward,
+;; because paging shouldn't change what you're paging through.
 ;;
-;; ROUTE-SHAPE CONFORMANCE: the tag filter navigates to the
-;; `/tag/:tag` PATH route (`:realworld/home-tag`), the following feed uses
-;; `?feed=following`. `:home/show-page` re-targets whichever home route is
-;; active (tag route keeps its `:tag` param) so paging stays within the tag.
+;; (URL shapes again: the tag filter navigates to the `/tag/:tag` PATH route
+;; `:realworld/home-tag`, the following feed uses `?feed=following`.
+;; `:home/show-page` re-aims at whichever home route is active — the tag route
+;; keeps its `:tag` param — so paging stays inside the tag.)
 
 (rf/reg-event :home/show-global-feed
   (fn [_ _]
@@ -290,13 +293,13 @@
     {:fx [[:dispatch [:rf.route/navigate :realworld/home {} {:query {:feed following-feed-token}}]]]}))
 
 (rf/reg-event :home/show-page
-  {:doc "Navigate to a 1-indexed pagination page for the active home feed,
-         carrying the current feed / tag forward so paging stays within it. A
-         tag-filtered list re-targets the `/tag/:tag` PATH route with the tag
-         param preserved and `?page=` set; otherwise the home route carries
-         `?feed=` + `?page=`. Changing `?page=` re-fires the active route's
-         `:on-match` (same route, changed query), re-running `:home/load` and
-         the per-feed fetch with the new limit/offset window."}
+  {:doc "Jump to a 1-indexed page of the active home feed, carrying the current
+         feed / tag along so you keep paging the same list. A tag-filtered list
+         re-aims at the `/tag/:tag` route, tag param intact and `?page=` set;
+         otherwise the home route carries `?feed=` + `?page=`. Either way,
+         changing `?page=` re-fires the route's `:on-match` (same route, new
+         query), which re-runs `:home/load` and the fetch with the new
+         limit/offset window. The URL leads; the data follows."}
   (fn [{rt :rf.db/runtime} [_ page]]
     (let [{:keys [tag feed]} (home-context rt)]
       (if tag
@@ -310,17 +313,17 @@
 
 (rf/reg-event :tags/clear-filter
   (fn [_ _]
-    ;; Clearing the tag leaves the `/tag/:tag` route entirely, back to the
-    ;; global feed at `/` (page 1).
+    ;; Dropping the tag means leaving the `/tag/:tag` route altogether — back
+    ;; to the plain global feed at `/`, page 1.
     {:fx [[:dispatch [:rf.route/navigate :realworld/home]]]}))
 
 (rf/reg-sub :home/selected-tag
-  {:doc "The active tag, read from the `/tag/:tag` route's PATH params
-         (a route path param, not a `?tag=` query)."}
+  {:doc "The active tag — read from the `/tag/:tag` route's PATH params, since
+         that's where it lives (a path param, not a `?tag=` query)."}
   :<- [:rf.route/params]
   (fn [params _] (:tag params)))
 
 (rf/reg-sub :home/page
-  {:doc "The 1-indexed home/tag page, off the route query (`?page=`)."}
+  {:doc "The 1-indexed home/tag page, straight off the route query (`?page=`)."}
   :<- [:rf.route/query]
   (fn [query _] (or (:page query) 1)))

--- a/examples/reagent/realworld_resources/article_editor.cljs
+++ b/examples/reagent/realworld_resources/article_editor.cljs
@@ -1,49 +1,52 @@
 (ns realworld-resources.article-editor
   "Create / edit / delete an article — the RealWorld-on-resources editor.
 
-   A form-heavy, flow-bearing page that exercises three things at once:
+   This is the busiest page in the app, and a good one to study because it puts
+   three distinct re-frame2 ideas to work side by side:
 
-   1. The WRITE is a MUTATION. `:realworld/save-article` POSTs `/articles`
-      (create) or PUTs `/articles/:slug` (edit) and declares per-target scoped
+   1. The write is a mutation. `:realworld/save-article` POSTs `/articles` to
+      create or PUTs `/articles/:slug` to edit, and declares per-target scoped
       `:invalidates` descriptors — the global article tags (`[:article slug]` /
       `[:article-list]`) in `:rf.scope/global`, and the session `[:feed]` in
-      `{:from-db :realworld/session}` — so on success the detail read, every list
-      showing the article, AND the session feed refetch with NO further wiring
-      (one mutation reaches both scopes). A `:realworld/delete-article` mutation
-      invalidates the same tags. The write lifecycle is the mutation INSTANCE
-      watched through `[:rf.mutation/state {:instance …}]` — there is no `:status`
-      app-db field.
+      `{:from-db :realworld/session}`. So on success the detail read, every list
+      showing the article, and the session feed all refetch with no further wiring
+      — one mutation reaching across both scopes. `:realworld/delete-article`
+      invalidates the same tags. The write lifecycle is the mutation INSTANCE,
+      watched through `[:rf.mutation/state {:instance …}]`; there's no `:status`
+      field in app-db.
 
-   2. The can-submit gate is a FLOW. `:editor/can-submit?` materialises \"the
-      draft is valid AND differs from the loaded baseline\" into app-db at
-      `[:editor :can-submit?]`. The submit handler reads it as plain data (no
-      mid-handler subscribe); the submit button reads it through a plain sub over
-      the flow's `:output-path`. The flow is registered per-frame from
-      `:editor/initialise` via `:rf.fx/reg-flow` so it binds to whatever frame the
-      app booted on. See the flow glossary:
+   2. The can-submit gate is a flow. `:editor/can-submit?` materialises one
+      derived fact — 'the draft is valid AND differs from the loaded baseline' —
+      into app-db at `[:editor :can-submit?]`. The submit handler then reads it as
+      plain data (no subscribing mid-handler), and the submit button reads the same
+      value through a plain sub over the flow's `:output-path`. The flow is
+      registered per-frame from `:editor/initialise` via `:rf.fx/reg-flow`, so it
+      binds to whatever frame the app booted on. See the flow glossary:
       ../../../docs/guide/glossary.md#flow.
 
    3. A navigation `:can-leave` guard. The editor route declares
-      `:can-leave [:editor/can-leave?]`; a dirty draft blocks navigation away and
-      the app-shell renders a confirm dialog off the `:rf/pending-navigation` sub
-      (see core.cljs). Clean (or saved) drafts leave freely. See route guard:
+      `:can-leave [:editor/can-leave?]`; a dirty draft blocks a navigate-away and
+      the app shell pops a confirm dialog off the `:rf/pending-navigation` sub (see
+      core.cljs). Clean (or just-saved) drafts leave freely. See route guard:
       ../../../docs/routing/glossary.md#route-guard.
 
-   The save / delete SUCCESS continuation (navigate to the saved article, or home
-   on delete) is the mutation's call-site `:reply-to [:editor/replied]` target —
-   the same idiom settings.cljs uses. When the runtime accepts the reply, it
-   dispatches `[:editor/replied reply]` once, AFTER the `:invalidates` staled the
-   lists + feed and the instance settled; the continuation branches save-vs-delete
+   The save / delete success continuation — navigate to the saved article, or home
+   on a delete — is the mutation's call-site `:reply-to [:editor/replied]` target,
+   the very idiom settings.cljs uses. When the runtime accepts the reply it
+   dispatches `[:editor/replied reply]` once, AFTER `:invalidates` staled the lists
+   and feed and the instance settled; the continuation then branches save-vs-delete
    on the reply value. Save and delete share one instance, so they share one
-   continuation. (Only the seed-on-load reaction stays a Form-3 reaction — it
-   watches a RESOURCE read settle, which has no reply-side continuation.) The
-   render bodies are pure functions of subs and never dispatch out of band."
+   continuation. The one exception is the seed-on-load reaction, which stays a
+   Form-3 reaction because it watches a RESOURCE read settle, and a read has no
+   reply-side continuation to hang off. The render bodies, as everywhere here, are
+   pure functions of subs that never dispatch out of band."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.http.managed]
             [re-frame.resources]
-            ;; Flows runtime. Loading the ns publishes the hooks so the
-            ;; `:rf.fx/reg-flow` effect resolves; without it the effect raises.
+            ;; The flows runtime. Loading it publishes the hooks so the
+            ;; `:rf.fx/reg-flow` effect has something to resolve against; without
+            ;; it, the effect raises.
             [re-frame.flows]
             [reagent.core :as r]
             [reagent.ratom :as ratom]
@@ -71,9 +74,9 @@
        vec))
 
 (defn- editor-slice
-  "The form's app-db slice. The draft + baseline (for dirty-detection) + the
-   per-field validation bookkeeping. The submission lifecycle is NOT here — it
-   is the `:editor/save` mutation instance."
+  "The form's app-db slice: the draft, the baseline (for dirty-detection), and the
+   per-field validation bookkeeping. The submission lifecycle is deliberately not
+   here — that's the `:editor/save` mutation instance."
   ([] (editor-slice nil blank-draft))
   ([slug baseline]
    {:slug              slug
@@ -96,30 +99,32 @@
              :tagList     (parse-tag-list (:tagList draft))}})
 
 (def save-instance
-  "The single, stable instance id the editor form watches for the save write."
+  "The one stable instance id the editor form watches for the save write."
   :editor/save)
 
 ;; ============================================================================
 ;; THE FLOW — :editor/can-submit?
 ;; ============================================================================
 ;;
-;; Materialises a derived boolean — \"the draft passes client-side validation AND
-;; differs from the loaded baseline\" — into app-db at `[:editor :can-submit?]`.
-;; WHY A FLOW: the `:editor/submit` handler reads this value as plain app-db data
-;; to gate the submit; a sub would force the handler to subscribe mid-handler. The
-;; submit button reads the same materialised value through a plain sub over the
-;; `:output-path`. See the flow glossary: ../../../docs/guide/glossary.md#flow.
+;; This materialises one derived boolean — 'the draft passes client-side
+;; validation AND differs from the loaded baseline' — into app-db at
+;; `[:editor :can-submit?]`. Why bother with a flow instead of a sub? Because the
+;; `:editor/submit` handler wants to read this value as plain app-db data to gate
+;; the submit, and a sub would force the handler to subscribe mid-handler, which is
+;; awkward. The submit button, meanwhile, reads the very same materialised value
+;; through a plain sub over the `:output-path`. One derived fact, two readers, no
+;; duplication. See the flow glossary: ../../../docs/guide/glossary.md#flow.
 ;;
-;; Registered per-frame via `:rf.fx/reg-flow` from `:editor/initialise` (not at
-;; ns-load) so it binds to whatever frame the app booted on. The flow's first walk
-;; fires on the NEXT drain; a fresh editor starts invalid + clean anyway, so the
-;; one-event lag carries no stale value.
+;; It's registered per-frame via `:rf.fx/reg-flow` from `:editor/initialise` (not
+;; at ns-load), so it binds to whatever frame the app booted on. The flow's first
+;; walk fires on the next drain; a fresh editor starts invalid and clean anyway,
+;; so that one-event lag never carries a stale value.
 
 (def can-submit-flow
   {:id     :editor/can-submit?
-   :doc    "True when the editor draft is valid AND dirty (differs from the
-            loaded baseline). Materialised into app-db so the submit handler
-            reads it as plain data."
+   :doc    "True when the editor draft is both valid AND dirty (differs from the
+            loaded baseline). Materialised into app-db so the submit handler can
+            read it as plain data."
    :inputs [[:editor :draft] [:editor :baseline]]
    :derive (fn [draft baseline]
              (and (empty? (validate-draft draft))
@@ -130,15 +135,15 @@
 ;; THE WRITE — mutations (POST create / PUT edit / DELETE)
 ;; ============================================================================
 ;;
-;; Saving an article invalidates the article detail AND every list/feed that
-;; shows it; the mutation declares those tags once and the runtime refetches the
-;; mounted readers. Create and edit share one mutation: the `:request` switches
-;; POST `/articles` ↔ PUT `/articles/:slug` on whether a `:slug` is present, so
-;; the slug-bearing edit path invalidates its own detail entry too.
+;; Saving an article invalidates the article detail and every list/feed that shows
+;; it. The mutation declares those tags once, and the runtime takes care of
+;; refetching the mounted readers. Create and edit share a single mutation: the
+;; `:request` flips POST `/articles` ↔ PUT `/articles/:slug` on whether a `:slug`
+;; is present, and the slug-bearing edit path invalidates its own detail entry too.
 
 (rf/reg-mutation :realworld/save-article
   {:doc           "Create (POST /articles) or update (PUT /articles/:slug) an
-                   article. Invalidates the detail + lists + feed on success."
+                   article. On success, invalidates the detail + lists + feed."
    :params-schema [:map
                    [:slug  {:optional true} [:maybe :string]]
                    [:title :string]
@@ -146,12 +151,12 @@
                    [:body  :string]
                    [:tagList [:vector :string]]]
    :scope         :rf.scope/global
-   ;; The lists go stale (global scope) so they re-read with the new article;
-   ;; an edit's slug also stales its own detail entry. The create path has no
-   ;; prior slug, so it stales only the lists (the new detail is read fresh on
-   ;; navigate). The session feed lives in the session scope, so it gets its
-   ;; own per-target descriptor naming `{:from-db :realworld/session}` — one
-   ;; mutation reaches both scopes.
+   ;; The lists (global scope) go stale so they re-read with the new article, and
+   ;; an edit's slug also stales its own detail entry. A create has no prior slug,
+   ;; so it stales only the lists — the new detail is read fresh on navigate
+   ;; anyway. The session feed lives in the session scope, so it gets its own
+   ;; per-target descriptor naming `{:from-db :realworld/session}`: one mutation,
+   ;; reaching across both scopes.
    :invalidates   (fn [{:keys [slug]} _result]
                     [{:scope :rf.scope/global
                       :tags  (cond-> #{[:article-list]}
@@ -171,8 +176,8 @@
                    detail + lists + feed."
    :params-schema [:map [:slug :string]]
    :scope         :rf.scope/global
-   ;; Global article tags + the session feed, each in its own scope (see
-   ;; :realworld/save-article above).
+   ;; Global article tags plus the session feed, each in its own scope (same shape
+   ;; as :realworld/save-article above).
    :invalidates   (fn [{:keys [slug]} _result]
                     [{:scope :rf.scope/global
                       :tags  #{[:article slug] [:article-list]}}
@@ -181,8 +186,8 @@
   (fn [{:keys [slug]} _ctx]
     {:request {:method :delete
                :url    (rh/full-url (str "/articles/" slug))}
-     ;; The delete endpoint returns no body; `:auto` handles
-     ;; 204/empty gracefully.
+     ;; The delete endpoint returns no body, and `:auto` takes a 204/empty in its
+     ;; stride.
      :decode  :auto}))
 
 ;; ============================================================================
@@ -190,26 +195,27 @@
 ;; ============================================================================
 
 (rf/reg-event :editor/initialise
-  {:doc "Create-mode entry (`:realworld.editor/new` `:on-match`). Reset the
-         editor slice to a blank draft, clear any prior save instance, and
-         register the `:editor/can-submit?` flow against the dispatching frame."}
+  {:doc "Create-mode entry (`:realworld.editor/new` `:on-match`). Resets the editor
+         slice to a blank draft, clears any leftover save instance, and registers
+         the `:editor/can-submit?` flow against the dispatching frame."}
   (fn [{:keys [db]} _]
     {:db (assoc db :editor (editor-slice))
      :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
           [:rf.fx/reg-flow can-submit-flow]]}))
 
 (rf/reg-event :editor/load-article
-  {:doc "Edit-mode entry (`:realworld.editor/edit` `:on-match`). Seed the draft
+  {:doc "Edit-mode entry (`:realworld.editor/edit` `:on-match`). Seeds the draft
          from the existing article via a one-shot resource ensure under a
-         releaseable lease, register the flow, and clear any prior save
-         instance. The seeded baseline lets the dirty-check fire."}
+         releaseable lease, registers the flow, and clears any leftover save
+         instance. The seeded baseline is what gives the dirty-check something to
+         compare against."}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [slug (get-in rt [:rf.runtime/routing :current :params :slug])]
       {:db (assoc db :editor (editor-slice slug blank-draft))
        :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
             [:rf.fx/reg-flow can-submit-flow]
             ;; Ensure the article read so the editor can seed its baseline from
-            ;; cache (a fresh entry is a cache-hit; otherwise it fetches). The
+            ;; cache — a fresh entry is a cache-hit, otherwise it fetches. The
             ;; lease is released on leave by `:editor/release-article`.
             [:dispatch [:rf.resource/ensure
                         {:resource :realworld/article
@@ -218,18 +224,18 @@
                          :cause    [:route-entry :realworld.editor/edit]}]]]})))
 
 (rf/reg-event :editor/seed-from-article
-  {:doc "Seed the editor draft + baseline from a loaded article. Dispatched by
-         the editor page's Form-3 load reaction when the article read first
-         settles with data (off the render path)."}
+  {:doc "Seed the editor draft + baseline from a loaded article. Dispatched by the
+         editor page's Form-3 load reaction the moment the article read first
+         settles with data, safely off the render path."}
   (fn [{:keys [db]} [_ article]]
     {:db (let [draft (draft-from-article article)]
       (assoc db :editor (editor-slice (:slug article) draft)))}))
 
 (rf/reg-event :editor/release-article
   {:doc "Release the edit-mode article lease (dispatched on unmount). Drops the
-         editor's owner on the article read so it can go inactive / GC. The
-         release path is mandatory for an app-minted lease — event-created owners
-         MUST have a matching release path."}
+         editor's owner on the article read so it can go inactive and eventually
+         GC. This release path isn't optional — an app-minted lease, like any
+         event-created owner, MUST have a matching release."}
   (fn [_ [_ slug]]
     (when slug
       {:fx [[:dispatch [:rf.resource/release-owner
@@ -249,18 +255,19 @@
     {:db (update-in db [:editor :touched] (fnil conj #{}) field)}))
 
 (rf/reg-event :editor/submit
-  {:doc "Save the article. Reads the `:editor/can-submit?` FLOW output straight
-         off app-db — a materialised derived value consumed as plain data, no
-         subscribe ceremony. Valid-and-dirty fires the save mutation; an invalid
-         draft re-runs validation to populate the per-field error map;
+  {:doc "Save the article. Reads the `:editor/can-submit?` FLOW output straight off
+         app-db — a materialised derived value, consumed as plain data, no
+         subscribe ceremony required. Valid-and-dirty fires the save mutation; an
+         invalid draft re-runs validation to fill in the per-field error map; and
          valid-but-unchanged is a no-op."}
   (fn [{:keys [db]} _]
     (let [{:keys [slug draft]} (:editor db)
           can-submit? (get-in db [:editor :can-submit?])
           errors      (validate-draft draft)]
       (cond
-        ;; Valid but unchanged → nothing to save (the button is disabled in this
-        ;; state; this is the belt-and-braces no-op for programmatic dispatch).
+        ;; Valid but unchanged → nothing to save. The button is already disabled in
+        ;; this state; this is just the belt-and-braces no-op for a programmatic
+        ;; dispatch.
         (and (not can-submit?) (empty? errors))
         {}
 
@@ -278,25 +285,25 @@
                                        slug (assoc :slug slug))
                            :instance save-instance
                            ;; The save-success continuation is the call-site
-                           ;; `:reply-to` — not an off-render reaction. The save
-                           ;; and delete writes share one instance, so they share
-                           ;; one continuation that branches on the reply
-                           ;; (`:value` carries the saved Article for a save; a
-                           ;; delete returns no body).
+                           ;; `:reply-to`, not an off-render reaction. Save and
+                           ;; delete share one instance, so they share one
+                           ;; continuation that branches on the reply — `:value`
+                           ;; carries the saved Article for a save; a delete comes
+                           ;; back with no body.
                            :reply-to [:editor/replied]
                            :cause    [:submit :editor/save]}]]]}))))
 
 (rf/reg-event :editor/replied
-  {:doc "The save / delete mutation completion continuation (the `:reply-to`
-         target). Receives the canonical reply map appended as the final arg,
-         observed AFTER the mutation's `:invalidates` staled the lists + feed and
-         the instance settled. On a successful SAVE (`:value` carries the saved
-         `{:article …}`), re-seed the editor from the saved article so the draft
-         is clean — the `:can-leave` guard won't block — clear the instance, and
+  {:doc "The save / delete completion continuation (the `:reply-to` target). It
+         receives the canonical reply map as its final arg, observed AFTER the
+         mutation's `:invalidates` staled the lists and feed and the instance
+         settled. On a successful SAVE (`:value` carries the saved `{:article …}`),
+         re-seed the editor from the saved article so the draft reads as clean —
+         that way the `:can-leave` guard won't block — clear the instance, and
          navigate to the article detail. On a successful DELETE (no `:article` in
-         the reply value), clear the slice + instance and go home. On `:error` the
-         form already shows the error off the instance state; nothing more to
-         do."}
+         the reply value), clear the slice and instance and head home. On `:error`
+         there's nothing to do here; the form already shows it off the instance
+         state."}
   (fn [{:keys [db]} [_ {:keys [status value]}]]
     (cond
       (not= :ok status) {}
@@ -313,10 +320,9 @@
             [:dispatch [:rf.route/navigate :realworld/home]]]})))
 
 (rf/reg-event :editor/delete
-  {:doc "Delete the article (edit mode only). Fires the delete mutation under
-         the same instance the save uses, with the same `:reply-to
-         [:editor/replied]` continuation (which branches save vs delete on the
-         reply value)."}
+  {:doc "Delete the article (edit mode only). Fires the delete mutation under the
+         same instance the save uses, with the same `:reply-to [:editor/replied]`
+         continuation — which branches save-vs-delete on the reply value."}
   (fn [{:keys [db]} _]
     (when-let [slug (get-in db [:editor :slug])]
       {:fx [[:dispatch [:rf.mutation/execute
@@ -335,18 +341,18 @@
 (rf/reg-sub :editor/slug  :<- [:editor/slice] (fn [e _] (:slug e)))
 
 (rf/reg-sub :editor/field-error
-  {:doc "Per-field validation error — revealed after the first submit attempt
-         OR once the field is touched."}
+  {:doc "Per-field validation error — held back until either the first submit
+         attempt or the moment the field is touched, whichever comes first."}
   :<- [:editor/slice]
   (fn [e [_ field]]
     (when (or (:submit-attempted? e) (contains? (:touched e) field))
       (get-in e [:errors field]))))
 
 (rf/reg-sub :editor/can-submit?
-  {:doc "Reads the `:editor/can-submit?` FLOW output at its app-db `:output-path`
-         — a flow's output is ordinary app-db state read through a plain sub.
-         Drives the submit button. nil until the flow's first walk lands, which
-         `(boolean …)` normalises to false."}
+  {:doc "Reads the `:editor/can-submit?` FLOW output at its app-db `:output-path` —
+         a flow's output is just ordinary app-db state, read through a plain sub.
+         Drives the submit button. It's nil until the flow's first walk lands,
+         which `(boolean …)` tidily normalises to false."}
   (fn [db _]
     (boolean (get-in db [:editor :can-submit?]))))
 
@@ -355,9 +361,9 @@
   (fn [e _] (not= (:draft e) (:baseline e))))
 
 (rf/reg-sub :editor/can-leave?
-  {:doc "The route `:can-leave` guard query: a clean (or just-saved) draft leaves
-         freely; a dirty draft blocks and the app shell shows the confirm dialog
-         off `:rf/pending-navigation`. See route guard:
+  {:doc "The route `:can-leave` guard query. A clean (or just-saved) draft leaves
+         freely; a dirty one blocks, and the app shell shows the confirm dialog off
+         `:rf/pending-navigation`. See route guard:
          ../../../docs/routing/glossary.md#route-guard."}
   :<- [:editor/dirty?]
   (fn [dirty? _] (not dirty?)))
@@ -366,15 +372,15 @@
 ;; VIEW  (pure Form-1 render + a Form-3 wrapper holding the editor reactions)
 ;; ============================================================================
 ;;
-;; Same shape as settings.cljs: the render is a pure registered `reg-view` that
-;; never dispatches; the off-render reactions (seed-on-load in edit mode, and
-;; the save/delete-success continuation) live in a Form-3 wrapper's lifecycle
-;; hooks. The frame is captured at render via `rf/frame-handle`, so the
-;; reactions' out-of-render dispatches carry the frame.
+;; Same shape as settings.cljs. The render is a pure registered `reg-view` that
+;; never dispatches; the one off-render reaction it needs (seed-on-load in edit
+;; mode) lives in a Form-3 wrapper's lifecycle hooks. The frame is captured at
+;; render via `rf/frame-handle`, so the reaction's out-of-render dispatch still
+;; carries the right frame.
 
-(reg-view ^{:doc "Pure article-editor form — a function of subs, never
-                   dispatches. The save/delete continuations live in the
-                   `editor-page` Form-3 wrapper."}
+(reg-view ^{:doc "The pure article-editor form — a function of subs, and it never
+                   dispatches. The save/delete continuations live elsewhere, in
+                   the `editor-page` Form-3 wrapper."}
           editor-form-view []
   (let [draft       @(subscribe [:editor/draft])
         slug        @(subscribe [:editor/slug])
@@ -423,8 +429,9 @@
              :on-change #(dispatch [:editor/edit-field :tagList (.. % -target -value)])}]]
           [:button.btn.btn-lg.pull-xs-right.btn-primary
            {:type "submit" :data-testid "editor-submit"
-            ;; Disabled while busy OR while the can-submit? flow is false (draft
-            ;; invalid or unchanged) — the flow's materialised output drives it.
+            ;; Disabled while busy, or while the can-submit? flow is false (draft
+            ;; invalid or unchanged) — the flow's materialised output drives this
+            ;; directly.
             :disabled (or busy? (not can-submit?))}
            (if editing? "Update Article" "Publish Article")]
           (when editing?
@@ -434,16 +441,16 @@
              "Delete Article"])]]]]]]))
 
 (defn editor-page
-  "The article-editor page. A Reagent Form-3 component: the inner render is the
-   pure `editor-form-view`; the mount hook installs ONE off-render reaction that
-   seeds the draft when an edit-mode article read settles with data. (The
-   save/delete SUCCESS continuation is the mutation's `:reply-to
-   [:editor/replied]` target, not an off-render reaction. A reply-side
-   continuation only exists for the mutation write; the seed reaction watches a
-   RESOURCE read settle, which has no reply-to, so it stays a Form-3 reaction.)
-   `rf/frame-handle` is captured here (during render, under the frame-provider),
-   so the reaction's dispatch carries the frame; unmount disposes the reaction
-   and releases the edit-mode article lease."
+  "The article-editor page, a Reagent Form-3 component. The inner render is the
+   pure `editor-form-view`; the mount hook installs exactly one off-render reaction,
+   which seeds the draft when an edit-mode article read settles with data. (Why
+   only one? The save/delete success continuation is the mutation's `:reply-to
+   [:editor/replied]` target, not a reaction — a reply-side continuation only
+   exists for a write. The seed watches a RESOURCE read settle, and a read has no
+   reply-to, so it has to stay a Form-3 reaction.) `rf/frame-handle` is captured
+   here during render, under the frame-provider, so the reaction's dispatch carries
+   the frame; unmount disposes the reaction and releases the edit-mode article
+   lease."
   []
   (let [{:keys [dispatch subscribe]} (rf/frame-handle)
         seeded?   (atom false)
@@ -452,9 +459,10 @@
      {:display-name "realworld-resources.article-editor/editor-page"
       :component-did-mount
       (fn [_this]
-        ;; Edit-mode seed: when the article read first settles with data, seed
-        ;; the draft + baseline (so dirty-detection has a baseline). The
-        ;; load-article event ensured the read under a lease; this only seeds.
+        ;; Edit-mode seed: when the article read first settles with data, copy it
+        ;; into the draft + baseline (so dirty-detection has something to compare
+        ;; against). The load-article event already ensured the read under a lease;
+        ;; this reaction only seeds.
         (reset!
          watcher
          (ratom/run!
@@ -470,7 +478,7 @@
       (fn [_this]
         (when @watcher (ratom/dispose! @watcher))
         (reset! watcher nil)
-        ;; Release the edit-mode article lease if we held one.
+        ;; Release the edit-mode article lease, if we were holding one.
         (when-let [slug @(subscribe [:editor/slug])]
           (dispatch [:editor/release-article slug])))
       :reagent-render

--- a/examples/reagent/realworld_resources/auth.cljs
+++ b/examples/reagent/realworld_resources/auth.cljs
@@ -1,46 +1,51 @@
 (ns realworld-resources.auth
   "Authentication for the RealWorld-on-resources example.
 
-   Auth is a COMMAND + state machine, not a cached read — don't contort login
-   into a read-resource. The POST/GET for login / register / session-restore go
-   via `:rf.http/managed` from the machine's actions; the machine owns the
-   `:idle → :submitting → :authed | :error` lifecycle. See the machines guide:
-   ../../../docs/machines/concepts.md. (Settings UPDATE is the one auth-adjacent
-   WRITE that IS a mutation — it invalidates the profile read — and lives in
-   realworld-resources.mutations.)
+   First, a modelling decision worth dwelling on: auth is a command plus a state
+   machine, not a cached read. It's tempting to bend login into a read-resource
+   so everything's uniform, but resist — login is a one-shot action with a
+   lifecycle, not a value you cache and re-read. The POST/GET for login,
+   register, and session-restore go through `:rf.http/managed` from the machine's
+   actions, and the machine owns the `:idle → :submitting → :authed | :error`
+   lifecycle. See the machines guide: ../../../docs/machines/concepts.md. (The one
+   auth-adjacent write that IS a mutation is the settings update — it invalidates
+   the profile read — and it lives over in realworld-resources.mutations.)
 
-   On LOGOUT the machine clears the session AND clears the session-scoped
-   resource cache: the user's personalised feed is cached under
-   `[:rf.scope/session {:username …}]`, and a logged-out (or next) user must
-   never see it. `:rf.resource/clear-scope` is the causal operation for that. The
-   concrete old scope is resolved with the `rf/resolve-resource-scope` helper
-   against the handler's COEFFECT db (the pre-transition causal input) and the
-   SAME named `:realworld/session` resolver every resource site references — one
-   scope-resolution currency, including teardown. The public `:rf.scope/global`
-   reads (article lists, detail, profiles, tags) are unaffected — they are the
-   same for everyone, so logout leaves them alone.
+   On logout the machine does two things: clears the session, and clears the
+   session-scoped resource cache. The personalised feed is cached under
+   `[:rf.scope/session {:username …}]`, and the next user (or no user) must never
+   lay eyes on the last one's feed. `:rf.resource/clear-scope` is the causal
+   operation for that. The concrete old scope is resolved with the
+   `rf/resolve-resource-scope` helper against the handler's COEFFECT db — the
+   pre-transition value, which still remembers who's logging out — using the same
+   named `:realworld/session` resolver every other site references. One way to
+   resolve a scope, teardown included. The public `:rf.scope/global` reads
+   (article lists, detail, profiles, tags) are untouched: they're the same for
+   everyone, so logout has no reason to disturb them.
 
-   On COLD-BOOT SESSION RESTORE the machine ALSO re-ensures the feed under the
-   freshly-restored principal (`:auth/ensure-session-feed`). A
-   `{:from-db :realworld/session}` subscription re-keys reactively when the
-   principal changes but, being passive, does NOT fetch; restore is the one
-   principal switch with NO route change (the home route was entered logged-out,
-   so the feed was not planned), so without an explicit re-ensure the feed would
-   sit stuck at :idle. The interactive login / logout paths re-enter the route
-   and so need no explicit ensure — see the `:auth/ensure-session-feed` event
-   below for the full rationale."
+   Cold-boot session restore needs one extra nudge, and it's a genuinely subtle
+   one. The machine also re-ensures the feed under the freshly-restored principal
+   (`:auth/ensure-session-feed`). A `{:from-db :realworld/session}` subscription
+   re-keys reactively when the principal changes, but it's passive — re-keying
+   doesn't fetch. Restore is the lone principal switch with no accompanying route
+   change (the home route was entered while logged out, so the feed was never
+   planned), so without an explicit re-ensure the feed would just sit there at
+   :idle, quietly doing nothing. The interactive login / logout paths re-enter the
+   route, so they don't need this — see the `:auth/ensure-session-feed` event
+   below for the full story."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            ;; The state-machine ns. Loading it registers the hooks so
-            ;; rf/reg-machine (below) and the `:rf/machine` framework subs
-            ;; resolve.
+            ;; The state-machine ns. Loading it registers the hooks, so
+            ;; rf/reg-machine (below) and the `:rf/machine` framework subs have
+            ;; something to resolve against.
             [re-frame.machines]
             [re-frame.resources]
             [realworld-resources.http :as rh]
             [realworld-resources.schema :as schema]
-            ;; Required for its side effect: loading it registers the
-            ;; `:realworld/session` resource-scope resolver `:auth/clear-session`
-            ;; resolves via `rf/resolve-resource-scope` below.
+            ;; Pulled in for its side effect: loading it registers the
+            ;; `:realworld/session` resource-scope resolver that
+            ;; `:auth/clear-session` reaches for via `rf/resolve-resource-scope`
+            ;; below.
             [realworld-resources.scope])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -48,20 +53,20 @@
 ;; SESSION PERSISTENCE SEAM
 ;; ============================================================================
 
-;; CONFORMANCE-CONTRACT SURFACE. The official RealWorld
-;; browser/E2E suite reads the session from `localStorage["jwtToken"]` — that
-;; exact key is the contract, so this seam uses it verbatim (NOT namespaced
-;; under `conduit-resources/…`). SAME-ORIGIN CAVEAT: the contract assumes one
-;; RealWorld app per origin. The repo's dev orchestrator serves BOTH variants
-;; from one origin (`/realworld/` + `/realworld-resources/`), so the two
-;; conforming apps share — and clobber — each other's `jwtToken` there. A known
-;; dev-mode artifact, NOT a contract violation: conformance is validated
-;; against STANDALONE serving (one app per origin), which the external suite
-;; does. See the README §RealWorld contract conformance.
+;; Another conformance surface. The official RealWorld browser/E2E suite reads the
+;; session from `localStorage["jwtToken"]` — that exact key IS the contract, so we
+;; use it verbatim rather than namespacing it under `conduit-resources/…` as we
+;; otherwise would. One caveat, since it can bite you locally: the contract
+;; assumes one RealWorld app per origin. The repo's dev orchestrator serves both
+;; variants from a single origin (`/realworld/` and `/realworld-resources/`), so
+;; the two conforming apps share — and cheerfully clobber — each other's
+;; `jwtToken`. That's a dev-mode artifact, not a contract violation: conformance
+;; is validated against standalone serving (one app per origin), which is what the
+;; external suite actually does. See the README §RealWorld contract conformance.
 (rf/reg-fx :realworld-resources.session/persist
   {:doc       "Persist (or clear) the JWT in localStorage under the official
-               contract key `jwtToken`. `{:token t}` writes when
-               truthy; nil removes the key."
+               contract key `jwtToken`. `{:token t}` writes a truthy token; a
+               nil token removes the key."
    :platforms #{:client}}
   (fn [_m {:keys [token]}]
     (when-let [ls (.-localStorage js/globalThis)]
@@ -69,36 +74,37 @@
         (.setItem ls "jwtToken" token)
         (.removeItem ls "jwtToken")))))
 
-;; The saved JWT is a storage world fact that `:auth/initialise` folds into
-;; durable app-db (and that drives session restore). A durable write must fold a
-;; RECORDED fact, not an ambient `localStorage` read at the write site, which
-;; replay / epoch-restore could not reproduce. So the JWT read is a recordable
-;; GENERATOR coeffect: `:realworld-resources.session/token` is a
-;; `:recordable? true` registration whose supplier reads localStorage. The
+;; The saved JWT is a fact from the storage world, and `:auth/initialise` folds it
+;; into durable app-db (which is what drives session restore). Here's the rule
+;; that shapes the next few forms: a durable write has to fold a RECORDED fact,
+;; never an ambient `localStorage` read taken at the write site — because replay
+;; or epoch-restore could never reproduce that ambient read. So the JWT read is a
+;; recordable generator coeffect. `:realworld-resources.session/token` is a
+;; `:recordable? true` registration whose supplier reads localStorage; the
 ;; generator runs at processing-start on the boot dispatch, its value is recorded
-;; onto the causal token, and replay / epoch-restore re-presents the captured
-;; token verbatim rather than re-reading whatever localStorage holds now. See
-;; recordable vs ambient coeffects:
+;; onto the causal token, and replay / epoch-restore later re-presents that exact
+;; captured token rather than re-reading whatever localStorage happens to hold
+;; now. See recordable vs ambient coeffects:
 ;; ../../../docs/guide/glossary.md#recordable-vs-ambient-coeffects.
 (defn read-jwt-from-storage
-  "Read the saved JWT from localStorage (or nil) — the supplier body for the
-   `:realworld-resources.session/token` recordable generator. nil when absent /
-   unavailable."
+  "Read the saved JWT from localStorage, or nil — the supplier body behind the
+   `:realworld-resources.session/token` recordable generator. nil when the token
+   is absent or storage is unavailable."
   []
   (some-> (.-localStorage js/globalThis)
           (.getItem "jwtToken")))
 
 (rf/reg-cofx :realworld-resources.session/token
   {:recordable? true
-   :doc "Recordable GENERATOR coeffect: the saved JWT (or nil), read from
+   :doc "Recordable generator coeffect: the saved JWT (or nil), read from
          localStorage. The registered supplier runs at processing-start on the
          boot dispatch; its value is recorded onto the causal token and
-         re-presented verbatim under replay / epoch-restore — so the durable
-         write that folds it (`:auth/initialise` → [:auth :token]) replays the
-         captured token, never a live localStorage re-read. A handler folds it by
-         declaring `:rf.cofx/requires [:realworld-resources.session/token]` and
-         reading it flat. A production dispatch carries NO cofx — the generator IS
-         the source; tests pin an exact value via the dispatch-site `:rf.cofx`
+         re-presented verbatim under replay / epoch-restore. So the durable write
+         that folds it (`:auth/initialise` → [:auth :token]) replays the captured
+         token, never a fresh localStorage read. A handler folds it by declaring
+         `:rf.cofx/requires [:realworld-resources.session/token]` and reading it
+         flat. A production dispatch carries no cofx at all — the generator is the
+         source; tests pin an exact value through the dispatch-site `:rf.cofx`
          stub seam (`{:rf.cofx {:realworld-resources.session/token \"…\"}}`)."}
   (fn [] (read-jwt-from-storage)))
 
@@ -107,74 +113,75 @@
 ;; ============================================================================
 
 (rf/reg-event :auth/store-session
-  {:doc "Store the authenticated session. The JWT has ONE durable home — the
-         classified `[:auth :token]` path (declared by `:auth/classify-token` in
-         core.cljs). The User payload is stored at `[:auth :user]` with its
-         `:token` field stripped off (`dissoc`), so the JWT is NOT duplicated into
-         the UNCLASSIFIED `[:auth :user :token]` slot — a second durable copy
-         there would ship RAW to every off-box record (classification does not
-         propagate; each path is its own declaration). Views / subs read
-         `:auth/user` for identity (username, bio, image); none of them need the
-         token, which the bearer-auth interceptor reads from the classified
-         `[:auth :token]` path instead."}
+  {:doc "Store the authenticated session. The JWT gets exactly one durable home:
+         the classified `[:auth :token]` path (declared by `:auth/classify-token`
+         in core.cljs). The User payload lands at `[:auth :user]` with its `:token`
+         field stripped off (`dissoc`), so the JWT is not quietly duplicated into
+         the unclassified `[:auth :user :token]` slot. That matters: a second
+         durable copy there would ship raw to every off-box record, because
+         classification doesn't propagate — each path declares its own. Views and
+         subs read `:auth/user` for identity (username, bio, image) and none of
+         them want the token anyway; the bearer-auth interceptor reads it from the
+         classified `[:auth :token]` path."}
   (fn [{:keys [db]} [_ user]]
     {:db (-> db
         (assoc-in [:auth :user] (dissoc user :token))
         (assoc-in [:auth :token] (:token user)))}))
 
 ;; ----------------------------------------------------------------------------
-;; PRINCIPAL-SWITCH RE-ENSURE  (the principal-switch footgun)
+;; PRINCIPAL-SWITCH RE-ENSURE  (a subtle footgun, defused)
 ;; ----------------------------------------------------------------------------
 ;;
-;; A `{:from-db :realworld/session}` resource SUBSCRIPTION re-keys reactively
-;; when the resolver's app-db input (the authenticated `:username`) changes. That
-;; re-key does NOT fetch — subscriptions are passive; the NEW scope's data loads
-;; only when a CAUSE ensures it (route entry / an event-side
-;; `:rf.resource/ensure` / clear-scope). So a principal switch by an app-db WRITE
-;; ALONE — no route change — re-keys the feed sub but never loads it: the feed
-;; sits at :idle indefinitely (fail-closed and safe, but a surprising "feed stuck
-;; loading" trap).
+;; Here's a trap worth understanding, because it's the kind of thing that looks
+;; like a bug at 2am. A `{:from-db :realworld/session}` resource subscription
+;; re-keys reactively when its resolver input (the authenticated `:username`)
+;; changes. But re-keying does NOT fetch — subscriptions are passive. The new
+;; scope's data only loads when a CAUSE ensures it: a route entry, an event-side
+;; `:rf.resource/ensure`, a clear-scope. So if you switch principal by an app-db
+;; write alone, with no route change, the feed sub dutifully re-keys to the new
+;; user and then just... waits, at :idle, forever. Safe and fail-closed, but
+;; mystifying if you didn't expect it.
 ;;
-;; The one place this app switches principal WITHOUT a route change is COLD-BOOT
-;; SESSION RESTORE: the home route is entered logged-out (the
-;; `{:from-db :realworld/session}` feed resolves nil and is NOT planned), THEN the
-;; async `GET /user` lands and `:restore-session` writes the principal — by design
-;; WITHOUT navigating (a deep link must be preserved). The interactive login /
-;; logout paths DO navigate, so the route plan re-ensures the feed for them;
-;; restore is the lone gap.
+;; There's exactly one place this app switches principal without a route change:
+;; cold-boot session restore. The home route is entered while logged out (the
+;; `{:from-db :realworld/session}` feed resolves nil and isn't planned), then the
+;; async `GET /user` lands and `:restore-session` writes the principal — on
+;; purpose without navigating, because a deep link has to survive a refresh. The
+;; interactive login / logout paths DO navigate, so the route plan re-ensures the
+;; feed for them. Restore is the one gap, so restore patches it.
 ;;
-;; So restore does an explicit `:rf.resource/ensure` of the feed under the NEW
+;; It patches it with an explicit `:rf.resource/ensure` of the feed under the new
 ;; session scope (the `{:from-db :realworld/session}` resolves itself against the
-;; post-restore app-db). It rides an app-minted lease `session-feed-owner` so the
-;; feed stays active while signed in (the logged-out route entry attached no route
-;; owner to release later); logout releases the lease alongside its `clear-scope`
-;; — an event-created owner MUST have a matching release path (see owner & cause,
-;; ../../../docs/resources/glossary.md#owner--cause). The `:page` is read from the
-;; live route slice so the ensure hits the SAME cache key the home route / feed
-;; subscription use. Logged out (post-restore-failure) the reference resolves nil
-;; and the runtime fail-closes (no feed to load).
+;; post-restore app-db). The ensure rides an app-minted lease, `session-feed-owner`,
+;; so the feed stays alive for as long as you're signed in — the logged-out route
+;; entry left no route owner to lean on. Logout then releases that lease alongside
+;; its `clear-scope`, because an event-created owner MUST have a matching release
+;; path (see owner & cause, ../../../docs/resources/glossary.md#owner--cause). The
+;; `:page` is read from the live route slice so the ensure lands on the SAME cache
+;; key the home route and feed subscription use. And if you're logged out (a
+;; restore that failed), the reference resolves nil and the runtime fail-closes —
+;; no feed to load, nothing to do.
 
 (def session-feed-owner
-  "The app-minted liveness lease the principal-switch re-ensure attaches to the
-   session feed (a `[:lease …]` owner). Stable across switches; released on
+  "The app-minted liveness lease the principal-switch re-ensure pins on the
+   session feed (a `[:lease …]` owner). Stable across switches, released on
    logout. See owner & cause: ../../../docs/resources/glossary.md#owner--cause."
   [:lease :auth/session-feed])
 
 (rf/reg-event :auth/ensure-session-feed
-  {:doc "Re-ensure the session feed under the CURRENT principal so a principal
+  {:doc "Re-ensure the session feed under the current principal, so a principal
          switch with no route change (cold-boot session restore) actually loads
-         it — the `{:from-db :realworld/session}` re-key alone is passive and does
-         not fetch. Resolves the scope from the post-restore app-db via the
+         it — the `{:from-db :realworld/session}` re-key on its own is passive and
+         won't fetch. It resolves the scope from the post-restore app-db via the
          resource's own `{:from-db :realworld/session}` policy, reads `:page` from
          the live route slice so the ensure hits the SAME cache key the home route
-         + feed subscription use, and attaches the stable `session-feed-owner`
-         lease (released by `:auth/clear-session`). A fresh `:loaded` entry the
-         route already ensured is a cache-hit; a logged-out resolution
-         fail-closes."}
+         and feed subscription use, and pins the stable `session-feed-owner` lease
+         (released later by `:auth/clear-session`). If the route already ensured a
+         fresh `:loaded` entry, this is a cache-hit; logged out, it fail-closes."}
   (fn [{rt :rf.db/runtime} _]
-    ;; Default to page 1 so the ensure hits the SAME `{:page 1}` key the home
-    ;; route + feed subscription use on the canonical no-`?page=` URL — a raw
-    ;; nil would ensure an orphan `{:page nil}` entry.
+    ;; Default to page 1, so the ensure hits the SAME `{:page 1}` key the home
+    ;; route and feed subscription use on the canonical no-`?page=` URL. A raw nil
+    ;; would mint an orphan `{:page nil}` entry that nobody reads.
     (let [page (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)]
       {:fx [[:dispatch [:rf.resource/ensure
                         {:resource :realworld/feed
@@ -184,21 +191,21 @@
 
 (rf/reg-event :auth/clear-session
   {:doc "Clear the auth slice AND drop the session-scoped resource cache. The
-         personalised feed is cached under the session scope; logout MUST clear it
-         (`:rf.resource/clear-scope`) so the next user never reads it. The
+         personalised feed lives under the session scope, and logout has to clear
+         it (`:rf.resource/clear-scope`) so the next user can't read it. The
          concrete old scope is resolved with the pure `rf/resolve-resource-scope`
-         helper against the COEFFECT db (the pre-transition value, by definition
-         still carrying the logging-out user) and the named `:realworld/session`
-         resolver — the same resolver every resource site references. Resolves nil
-         when no user was present (nothing to clear). Public `:rf.scope/global`
-         reads are untouched.
+         helper against the COEFFECT db — the pre-transition value, which by
+         definition still carries the user who's logging out — using the named
+         `:realworld/session` resolver every site shares. It resolves nil when
+         there was no user (nothing to clear). The public `:rf.scope/global` reads
+         are left alone.
 
-         ALSO releases the `session-feed-owner` lease the principal-switch
-         re-ensure (`:auth/ensure-session-feed`) may have attached — an
+         It also releases the `session-feed-owner` lease that the principal-switch
+         re-ensure (`:auth/ensure-session-feed`) may have pinned, because an
          event-created owner MUST have a matching release path. The `clear-scope`
-         removes the entry the lease was on, so the release also keeps the
-         owner-lease lifecycle a readable attach/release pair (no dangling lease in
-         the owner index)."}
+         already removes the entry the lease sat on, so the release is mostly about
+         tidiness — it keeps the lease lifecycle a readable attach/release pair,
+         with no dangling owner left in the index."}
   (fn [{:keys [db]} _]
     (let [old-scope (rf/resolve-resource-scope db :realworld/session)]
       {:db (-> db
@@ -210,14 +217,14 @@
                                          {:scope old-scope :cause :logout}]]))})))
 
 (rf/reg-event :auth/post-login-redirect
-  {:doc "Bounce the user who INTERACTIVELY logged in / registered to the route
-         the auth guard intercepted (`[:auth :return-to]`), or home. Dispatched
-         ONLY by the `:store-session` action (the interactive `:submitting →
-         :authed` transition) — NOT by `:restore-session` (cold-boot
-         session-restore preserves the restored route, never force-navigates).
-         Machine actions can't navigate or read `:db` directly, so this is an
-         ordinary event. Reads AND clears the slot so a later login can't
-         re-bounce."}
+  {:doc "Bounce a user who just interactively logged in or registered to wherever
+         the auth guard intercepted them (`[:auth :return-to]`), or home if there's
+         nothing stashed. Dispatched only by the `:store-session` action (the
+         interactive `:submitting → :authed` transition) — never by
+         `:restore-session`, since cold-boot restore keeps you where you are and
+         must not force a navigation. Machine actions can't navigate or read `:db`
+         directly, so this is an ordinary event. It reads and clears the slot in
+         one move, so a later login can't accidentally bounce you again."}
   (fn [{:keys [db]} _]
     (let [return-to (get-in db [:auth :return-to])]
       {:db (update db :auth dissoc :return-to)
@@ -230,9 +237,9 @@
 ;; ============================================================================
 
 (rf/reg-machine :auth/flow
-  {:doc "The auth flow: idle → submitting/restoring → authed | error. HTTP via
-         :rf.http/managed. Login / register / restore do NOT retry — one
-         submission per click."
+  {:doc "The auth flow: idle → submitting/restoring → authed | error. HTTP goes
+         through :rf.http/managed. Login, register, and restore don't retry —
+         one submission per click, by design."
    :rf.http/decode-schemas [schema/UserResponse]}
   {:initial :idle
    :data    {:error nil}
@@ -273,12 +280,12 @@
 
     :store-session
     (fn [{[_ {:keys [value]}] :event}]
-      ;; INTERACTIVE login / register success: store the session, persist the
-      ;; JWT, AND bounce to the guard-stashed `:return-to` (or home). The bounce
-      ;; is the right behaviour ONLY for an interactive submit — the user just
-      ;; clicked Sign-in from the login page and expects to land somewhere.
-      ;; Machine actions see no `:db` and emit no `:db`, so the session store +
-      ;; bounce-back run as ordinary events.
+      ;; Interactive login / register success: store the session, persist the JWT,
+      ;; and bounce to the guard-stashed `:return-to` (or home). The bounce is the
+      ;; right move only for an interactive submit — the user just clicked Sign-in
+      ;; and is expecting to land somewhere. Machine actions neither see nor emit
+      ;; `:db`, so the session store and the bounce-back both run as ordinary
+      ;; events.
       (let [user (:user value)]
         {:data {:error nil}
          :fx [[:dispatch [:auth/store-session user]]
@@ -287,22 +294,22 @@
 
     :restore-session
     (fn [{[_ {:keys [value]}] :event}]
-      ;; SESSION-RESTORE success (cold boot with a saved JWT): store the session
-      ;; WITHOUT navigating. A logged-in user cold-booting on a deep link
-      ;; (`/article/x`) must stay on that route — restore only re-hydrates the
-      ;; session; it must NOT force-navigate home. Only an INTERACTIVE
-      ;; login/register bounces (`:store-session`). The token is already in app-db
-      ;; + localStorage from `:auth/initialise`; we re-persist defensively in case
-      ;; the server rotated it on `GET /user`.
+      ;; Session-restore success (cold boot with a saved JWT): store the session,
+      ;; but do NOT navigate. Someone cold-booting on a deep link (`/article/x`)
+      ;; needs to stay put — restore re-hydrates the session and nothing more; it
+      ;; must never yank them home. Only an interactive login/register bounces
+      ;; (`:store-session`). The token is already in app-db and localStorage from
+      ;; `:auth/initialise`; we re-persist it defensively, just in case the server
+      ;; rotated it on `GET /user`.
       ;;
-      ;; This is the one PRINCIPAL SWITCH with no route change — the home route
-      ;; was already entered logged-out (the `{:from-db :realworld/session}` feed
-      ;; resolved nil and was not planned), so storing the principal now RE-KEYS
-      ;; the feed sub but, being passive, does not fetch. Re-ensure the feed under
-      ;; the freshly-stored session scope so "Your Feed" actually loads (a no-op
-      ;; cache-hit when the user is not on home / when the route already ensured
-      ;; it). The interactive login / logout paths re-enter the route and need no
-      ;; explicit ensure.
+      ;; This is the one principal switch with no route change. The home route was
+      ;; entered while logged out (the `{:from-db :realworld/session}` feed
+      ;; resolved nil and wasn't planned), so storing the principal now re-keys the
+      ;; feed sub — but, being passive, it won't fetch. So we re-ensure the feed
+      ;; under the freshly-stored session scope, which is what makes 'Your Feed'
+      ;; actually load. It's a harmless cache-hit when you're not on home, or when
+      ;; the route already ensured it. The interactive login / logout paths re-enter
+      ;; the route, so they need no explicit ensure.
       (let [user (:user value)]
         {:data {:error nil}
          :fx [[:dispatch [:auth/store-session user]]
@@ -346,9 +353,9 @@
 (rf/reg-event :auth/initialise
   {:rf.cofx/requires [:realworld-resources.session/token]}
   (fn [{:keys [db realworld-resources.session/token]} _]
-    ;; Dispatch `:auth/restore` UNCONDITIONALLY (even with a nil token) so the
-    ;; machine snapshot spawns at `:idle` from cold boot; the `:has-token?`
-    ;; guard then routes a blank token to the no-op branch.
+    ;; Fire `:auth/restore` unconditionally — even with a nil token — so the
+    ;; machine snapshot spawns at `:idle` from a cold boot. The `:has-token?`
+    ;; guard then quietly routes a blank token to the no-op branch.
     {:db (assoc db :auth {:user nil :token token})
      :fx [[:dispatch [:auth/flow [:auth/restore token]]]]}))
 

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -1,40 +1,45 @@
 (ns realworld-resources.core
-  "Entry point for the RealWorld (Conduit) example. The read surface is
-   RESOURCES (`reg-resource`) and the write surface is MUTATIONS
-   (`reg-mutation`): the framework owns the server-state cache, views read it
-   passively, and a write invalidates the reads it affected. See the resources
-   guide: ../../../docs/resources/concepts.md.
+  "Entry point for the RealWorld (Conduit) example — a full Medium-style blogging
+   app, built to show off how re-frame2 handles server state.
 
-   Wires the app together:
-   - pulls in every feature ns (each registers its resources / mutations /
-     events / subs / views / the auth machine);
-   - installs the demo `:rf.http/managed` backend stub (resources + mutations
-     lower onto managed HTTP, so one stub serves the whole API);
-   - defines `:app/initialise` (the boot fan-out);
-   - defines the app shell + a route switch on `:rf.route/id`;
+   Two ideas carry the whole app. Reads are RESOURCES (`reg-resource`): named,
+   cached server-state the framework owns and your views read passively. Writes
+   are MUTATIONS (`reg-mutation`): they change remote state and invalidate the
+   reads they touched, so the right things refetch on their own. Read here,
+   write there, and the cache keeps itself honest. The resources guide has the
+   full story: ../../../docs/resources/concepts.md.
+
+   This namespace is the wiring closet. It:
+   - pulls in every feature ns (each one registers its own resources / mutations
+     / events / subs / views / the auth machine);
+   - installs a demo `:rf.http/managed` backend stub — since reads and writes
+     both lower onto managed HTTP, one stub serves the entire API;
+   - defines `:app/initialise`, the boot fan-out;
+   - defines the app shell and a route switch on `:rf.route/id`;
    - mounts the React root and installs the URL listener.
 
-   Per-feature work lives in:
-     resources.cljs  — every read as `reg-resource`
-     mutations.cljs  — every write as `reg-mutation` (+ :invalidates / :populates)
-     routing.cljs    — routes with `:resources` metadata + the auth guard
+   The actual features live next door:
+     resources.cljs  — every read, as a `reg-resource`
+     mutations.cljs  — every write, as a `reg-mutation` (+ :invalidates / :populates)
+     routing.cljs    — routes carrying `:resources` metadata + the auth guard
      auth.cljs       — the auth machine (login / register / restore / logout)
-     settings.cljs   — settings as a mutation instance
+     settings.cljs   — settings, modelled as a mutation instance
      scope.cljs      — the fail-closed session cache scope
-     schema.cljs     — Malli wire shapes + the small app-db schemas
+     schema.cljs     — Malli wire shapes + the handful of app-db schemas
      http.cljs       — the demo backend stub + failure projection
      views.cljs      — passive pages + the small UI event glue"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Managed HTTP — the single built-in resource/mutation transport.
+            ;; Managed HTTP — the one built-in transport both resources and
+            ;; mutations lower onto.
             [re-frame.http.managed]
-            ;; The canned-stub fxs the demo backend delegates to. A real Conduit
-            ;; deployment would drop this require.
+            ;; The canned-stub fxs the demo backend leans on. A real Conduit
+            ;; deployment would simply drop this require.
             [re-frame.http.test-support]
-            ;; Resources + mutations runtime.
+            ;; The resources + mutations runtime.
             [re-frame.resources]
-            ;; Routing + machines. Loading routing makes the `:resources` route
-            ;; key available; the auth machine needs machines.
+            ;; Routing + machines. Loading routing unlocks the `:resources` route
+            ;; key; the auth machine needs machines.
             [re-frame.routing]
             [re-frame.machines]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -56,22 +61,25 @@
 ;; ============================================================================
 
 (rf/reg-event :app/initialise
-  {:doc "App boot. Seeds the form drafts. Session restore is its own
-         `:initial-events` step (`:auth/initialise`), not part of this fan-out,
-         so its recordable token coeffect rides its own dispatch. The page reads
-         (articles, tags, feed, …) are caused by the route's `:resources`
-         metadata on the initial URL→route sync, not from here."}
+  {:doc "App boot. Seeds the two form drafts and nothing else. Session restore
+         is deliberately not here — it's its own `:initial-events` step
+         (`:auth/initialise`) so its recordable token coeffect can ride its own
+         dispatch. And the page reads (articles, tags, feed, …) aren't here
+         either: the route's `:resources` metadata pulls those in on the first
+         URL→route sync. Booting an app is mostly about deciding what NOT to do
+         up front."}
   (fn [_ _]
     {:fx [[:dispatch [:auth.login-form/initialise]]
           [:dispatch [:auth.register-form/initialise]]]}))
 
-;; The JWT at [:auth :token] is durable and sensitive. Classify it via the
-;; `:sensitive` effect, returned alongside `:db` from an event the frame runs at
-;; creation (`:initial-events`, before any off-box egress) so the raw token is
-;; redacted from anything that leaves the box. See data classification:
+;; The JWT at [:auth :token] is both durable and sensitive — exactly the kind of
+;; thing you don't want leaking off the box. The `:sensitive` effect marks it as
+;; such. We return it alongside `:db` from an event the frame runs at creation
+;; (`:initial-events`, before anything leaves the box), so the raw token is
+;; redacted from any capture, SSR payload, or trace. See data classification:
 ;; ../../../docs/guide/glossary.md#data-classification.
 (rf/reg-event :auth/classify-token
-  {:doc "Classifies the durable JWT path [:auth :token] sensitive at frame
+  {:doc "Marks the durable JWT path [:auth :token] as sensitive, at frame
          creation."}
   (fn [{:keys [db]} _]
     {:db db :sensitive [[:auth :token]]}))
@@ -96,7 +104,7 @@
                          [:i.ion-gear-a] " Settings"]]
           [:li.nav-item [rf/route-link {:to :realworld.profile/show :params {:username (:username user)}
                                         :class "nav-link" :data-testid "nav-username"}
-                         ;; Official navbar shows the user's avatar
+                         ;; The Conduit navbar shows the user's avatar
                          ;; (`.user-pic`) next to their name.
                          [:img.user-pic {:src (avatar/avatar-src (:image user))}]
                          " " (:username user)]]
@@ -113,11 +121,12 @@
             [:span.attribution "An interactive learning project from Thinkster."
              " Code & design licensed under MIT."]]])
 
-(reg-view ^{:doc "Confirm dialog shown when a `:can-leave` guard blocks a
-                   navigation (e.g. the editor with a dirty draft). Reads the
-                   blocked navigation off the `:rf/pending-navigation` sub; the
-                   buttons continue or cancel the pending nav. See route guard:
-                   ../../../docs/routing/glossary.md#route-guard."}
+(reg-view ^{:doc "The 'you have unsaved changes' dialog. It appears when a
+                   `:can-leave` guard blocks a navigation — typically the editor
+                   refusing to throw away a dirty draft. It reads the blocked
+                   navigation off the `:rf/pending-navigation` sub; the buttons
+                   either wave the navigation through or call it off. See route
+                   guard: ../../../docs/routing/glossary.md#route-guard."}
           pending-nav-dialog []
   (when-let [pending @(subscribe [:rf/pending-navigation])]
     [:div.pending-nav-overlay {:data-testid "pending-nav-dialog"}
@@ -155,19 +164,23 @@
 ;; BEARER-AUTH HTTP INTERCEPTOR
 ;; ============================================================================
 ;;
-;; A single `:before` fn injects the Bearer token from the auth slice, so EVERY
-;; outbound `:rf.http/managed` request that crosses this frame picks the header
-;; up automatically. Resources AND mutations lower onto `:rf.http/managed`, so
-;; this one interceptor decorates the WHOLE Conduit API — the route-caused reads
-;; (`/articles/feed`, the lists, detail), the writes (favorite / follow /
-;; comment / settings / save-article), and the auth machine's session-restore
-;; `GET /user`. No `:request` fn threads the token per-call; the auth slice is
-;; the single source of truth and this is the single read site.
+;; The classic auth chore: every authenticated request needs an
+;; `Authorization: Token <jwt>` header. The tedious way is to thread the token
+;; through every call site. The pleasant way is right here — one `:before` fn
+;; that reads the token from the auth slice and stamps the header on its way out.
 ;;
-;; The token is read from `(:frame ctx)` — the frame the cascade runs under —
-;; not a hard-coded id, so the header tracks a non-default / multi-frame mount.
-;; The interceptor returns ctx unchanged when no token is present, so login /
-;; register / the public (logged-out) reads are unaffected.
+;; Because resources and mutations both lower onto `:rf.http/managed`, this one
+;; interceptor decorates the entire Conduit API at a stroke: the route-caused
+;; reads (`/articles/feed`, the lists, detail), the writes (favorite / follow /
+;; comment / settings / save-article), and the auth machine's session-restore
+;; `GET /user`. The auth slice is the single source of truth, and this is the
+;; single place it's read. Nice when one fact lives in exactly one spot.
+;;
+;; The token is read from `(:frame ctx)` — the frame this cascade is running
+;; under — rather than a hard-coded id, so the header follows along to a
+;; non-default or multi-frame mount. No token present? The interceptor hands ctx
+;; straight back, so login, register, and the public logged-out reads sail
+;; through untouched.
 (defn bearer-auth-interceptor [ctx]
   (let [token (some-> (rf/app-db-value (:frame ctx))
                       :auth :token)]
@@ -179,17 +192,18 @@
 ;; window.__conduit_debug__  — CONFORMANCE-CONTRACT SURFACE
 ;; ============================================================================
 ;;
-;; The official RealWorld browser/E2E harness sometimes reads app session state
-;; through a global accessor. This installs `window.__conduit_debug__` with
-;; `getToken` / `getAuthState` / `getCurrentUser`, reading the live app frame's
-;; app-db.
+;; The official RealWorld browser/E2E harness sometimes peeks at session state
+;; through a global accessor, so we install `window.__conduit_debug__` with
+;; `getToken` / `getAuthState` / `getCurrentUser`, each reading the live app
+;; frame's app-db.
 ;;
-;; THIS IS A CONFORMANCE SURFACE, NOT A re-frame2 PATTERN. An unannotated global
-;; token accessor is the anti-pattern that gets copied into real apps: it
-;; bypasses the frame/sub system and leaks the raw JWT to any script on the
-;; page. Real re-frame2 code reads session state through subs under the frame
-;; provider, never a `window.*` global. This exists only so the external suite
-;; can introspect the demo; a production RealWorld app would not ship it.
+;; A loud warning, because this is the sort of code that gets copy-pasted: this
+;; is a conformance surface, NOT a re-frame2 pattern. A global token accessor
+;; like this is precisely the anti-pattern you don't want in a real app — it
+;; sidesteps the frame/sub system and hands the raw JWT to any script on the
+;; page. Real re-frame2 code reads session state through subs, under the frame
+;; provider, never off a `window.*` global. This exists only so the external test
+;; suite can introspect the demo; a production Conduit app would never ship it.
 (defn- install-conduit-debug! [frame-id]
   (when (exists? js/window)
     (set! (.-__conduit_debug__ js/window)
@@ -206,54 +220,55 @@
 
 (def app-frame :rf/default)
 
-;; `:rf/default` is an ordinary frame id with no framework privilege — `init!`
-;; installs only the adapter and creates no frame. This app earns URL ownership
-;; by declaring `:url-bound? true` on the frame below.
+;; `:rf/default` is just a frame id. It carries no special framework privilege —
+;; `init!` installs the adapter and creates no frame at all. This app earns URL
+;; ownership the honest way: by declaring `:url-bound? true` on the frame below.
 ;;
-;; The app frame is created, configured, and seeded in ONE spot: the
+;; The frame is created, configured, and seeded in exactly one place: the
 ;; `frame-provider {:id …}` ensure form at the render root. On first mount it
-;; creates the frame under `app-frame`, applies the config (`:url-bound? true`
-;; so it owns the URL; the auth-guard interceptor referenced by id; the demo
+;; creates the frame under `app-frame` and applies the config — `:url-bound? true`
+;; so it owns the URL, the auth-guard interceptor referenced by id, and the demo
 ;; `:rf.http/managed` routed through the in-process backend stub so reads and
-;; writes run without a network), and runs `:initial-events` once. Hot reload
-;; reuses the frame without re-seeding (durable app-db survives). That id is what
-;; every in-tree `dispatch`/`subscribe` resolves against.
+;; writes work with no network in sight — then runs `:initial-events` once. A hot
+;; reload reuses the frame and skips the re-seed (durable app-db survives). That
+;; same id is what every in-tree `dispatch` / `subscribe` resolves against.
 ;;
-;; `:initial-events` ordering carries two constraints:
-;;   - `:auth/classify-token` first: the JWT at [:auth :token] is a durable
-;;     sensitive fact, so classify it before any off-box egress (Xray capture,
-;;     an SSR payload) can see the raw token. See data classification:
+;; The order of `:initial-events` matters, for two reasons:
+;;   - `:auth/classify-token` goes first. The JWT at [:auth :token] is a durable
+;;     secret, so we mark it sensitive before anything (an Xray capture, an SSR
+;;     payload) could lay eyes on the raw value. See data classification:
 ;;     ../../../docs/guide/glossary.md#data-classification.
-;;   - `:auth/initialise` before `:app/initialise`: session restore reads the
-;;     saved JWT from a recordable coeffect (auth.cljs) and folds it into durable
-;;     [:auth :token]. It rides its own dispatch (not the `:app/initialise`
-;;     fan-out, which does not forward `:rf.cofx`) and runs first, so the token
-;;     is in app-db before the bearer-auth interceptor fires any authenticated
+;;   - `:auth/initialise` runs before `:app/initialise`. Session restore reads
+;;     the saved JWT from a recordable coeffect (auth.cljs) and folds it into
+;;     durable [:auth :token]. It rides its own dispatch — the `:app/initialise`
+;;     fan-out doesn't forward `:rf.cofx` — and goes first, so the token is in
+;;     app-db before the bearer-auth interceptor fires its first authenticated
 ;;     request.
 ;;
-;; The outbound `Authorization` Bearer header is not classified here — the
-;; framework's built-in HTTP carrier denylist already redacts it off-box. The
-;; session-scope key ([:auth :user :username]) is identity, not a secret, so it
-;; is deliberately not classified — over-redacting would obscure the cache-leak
-;; boundary this example shows.
+;; Two things we deliberately DON'T classify, since under-redacting and
+;; over-redacting are both mistakes. The outbound `Authorization` Bearer header
+;; is already redacted off-box by the framework's built-in HTTP carrier denylist,
+;; so doing it again here would be belt-and-braces noise. And the session-scope
+;; key ([:auth :user :username]) is identity, not a secret — redacting it would
+;; only blur the cache-leak boundary this whole example is here to show.
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  ;; Register the Bearer-auth interceptor at app boot, BEFORE the frame's
-  ;; `:initial-events` dispatch — session-restore fires an authenticated
-  ;; `GET /user` as soon as the JWT is hydrated, so the header must already be
-  ;; wired by the time `:auth/initialise` runs at frame creation (below).
+  ;; Register the bearer-auth interceptor at boot, before the frame's
+  ;; `:initial-events` dispatch. Timing matters: session-restore fires an
+  ;; authenticated `GET /user` the moment the JWT is hydrated, so the header has
+  ;; to be wired up before `:auth/initialise` runs at frame creation (below).
   (rf/reg-http-interceptor :realworld/bearer-auth
                            {:before bearer-auth-interceptor})
-  ;; The orchestrator serves this example at /realworld-resources/; strip that
-  ;; prefix before the matcher sees the URL so :realworld/home (path "/") matches.
-  ;; Set BEFORE install-router!'s initial URL→route sync (below).
+  ;; The dev orchestrator serves this example under /realworld-resources/. Strip
+  ;; that prefix before the matcher sees the URL, so :realworld/home (path "/")
+  ;; still matches. Has to happen before install-router!'s first URL→route sync.
   (routing/set-base-path! "/realworld-resources")
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; Create + configure + seed the app frame in one spot (see the block above).
-    ;; The frame is created synchronously during render, so it is live and seeded
-    ;; once this returns.
+    ;; Create + configure + seed the app frame, all in one place (see the block
+    ;; above). The frame is created synchronously during render, so by the time
+    ;; this call returns it's live and seeded.
     (rdc/render @react-root
                 [rf/frame-provider {:id              app-frame
                                     :doc             "RealWorld-on-resources demo frame."
@@ -264,20 +279,21 @@
                                                       [:auth/initialise]
                                                       [:app/initialise]]}
                  [root-view]])
-    ;; The frame is now live + session-seeded. These install ONGOING listeners
-    ;; (each doing its initial sync against that frame) — so they run AFTER the
-    ;; render that created it, not before.
+    ;; The frame is now live and session-seeded. The next three calls install
+    ;; ongoing listeners, each doing an initial sync against that frame — so they
+    ;; have to run AFTER the render that created it, never before.
     ;;
-    ;; install-router! installs the popstate handler AND does the initial
-    ;; URL→route sync (under the URL-owner frame), which fires the route's
-    ;; `:resources` ensures — server-state loads because the route became
-    ;; active, not because a view asked. The session token seeded above is
-    ;; already in app-db, so the bearer-auth interceptor decorates those reads.
+    ;; install-router! wires up the popstate handler and does the first URL→route
+    ;; sync (under the URL-owning frame). That sync fires the route's `:resources`
+    ;; ensures, which is the heart of the trick: server-state loads because the
+    ;; route became active, not because a view went looking for it. The session
+    ;; token seeded above is already in app-db, so the bearer-auth interceptor
+    ;; decorates those reads on the way out.
     (routing/install-router!)
-    ;; Focus/reconnect revalidation: refetch active-and-stale reads when the tab
-    ;; returns or the network reconnects (idempotent). The host signals are never
-    ;; dispatched by hand.
+    ;; Focus/reconnect revalidation: when the tab comes back or the network
+    ;; reconnects, refetch the reads that are both active and stale. Idempotent,
+    ;; and you never dispatch the host signals by hand.
     (rf/install-revalidation-listeners! app-frame)
-    ;; Conformance-contract surface — NOT a re-frame2 pattern; see
-    ;; install-conduit-debug! above. The external RealWorld suite may read it.
+    ;; The conformance surface — NOT a re-frame2 pattern; see install-conduit-debug!
+    ;; above. The external RealWorld suite may read it.
     (install-conduit-debug! app-frame)))

--- a/examples/reagent/realworld_resources/http.cljs
+++ b/examples/reagent/realworld_resources/http.cljs
@@ -1,47 +1,49 @@
 (ns realworld-resources.http
-  "HTTP helpers + the demo backend stub for the RealWorld-on-resources
-   example.
+  "HTTP helpers and the demo backend stub for the RealWorld-on-resources example.
 
-   Resources and mutations lower onto `:rf.http/managed` — the single built-in
-   resource/mutation transport (../../../docs/resources/glossary.md#managed-http)
-   — so one canned-stub override serves both reads and writes. The stub routes by
-   URL + method to a canned Conduit-shaped reply, deferred via `:after-ms`
-   (`:dispatch-later`, NOT raw `js/setTimeout`) so the runtime's `:loading` UI
-   state is observable and replies stay time-travel-safe.
+   Because resources and mutations both lower onto `:rf.http/managed` — the one
+   built-in transport for either (../../../docs/resources/glossary.md#managed-http)
+   — a single canned-stub override can stand in for the entire API, reads and
+   writes alike. The stub routes by URL + method to a canned Conduit-shaped reply,
+   deferred by `:after-ms` (which rides `:dispatch-later`, not a raw
+   `js/setTimeout`) so the runtime's `:loading` state is actually observable and
+   the replies stay time-travel-safe.
 
-   Two helpers:
-   - `failure->message` — project a `:rf.http/*` failure envelope (the shape
-     resource `:error` / `:refresh-error` and mutation `:error` carry) to a
+   Two helpers live here:
+   - `failure->message` — turn a `:rf.http/*` failure envelope (the shape a
+     resource `:error` / `:refresh-error` and a mutation `:error` carry) into a
      human-readable string.
-   - `install-demo-backend!` — register the stub fx + wire it as the
+   - `install-demo-backend!` — register the stub fx and wire it as the
      `:rf.http/managed` override on the demo frame.
 
-   BACKEND MODES (see this example's README §Running against a real backend):
-   - canned demo stub (DEFAULT) — `core.cljs` overrides `:rf.http/managed` with
-     an in-process per-URL stub, so the app runs with NO network and `api-base`
-     is not contacted (the stub matches on the path suffix).
-   - official hosted API — point `api-base` at `https://api.realworld.show/api`
+   Three ways to point the app at a backend (see the README §Running against a
+   real backend):
+   - canned demo stub (the default) — `core.cljs` overrides `:rf.http/managed`
+     with an in-process per-URL stub, so the app runs with no network at all and
+     `api-base` is never actually contacted (the stub matches on the path suffix).
+   - the official hosted API — point `api-base` at `https://api.realworld.show/api`
      and drop the demo-stub override. The frame-wide `:realworld/bearer-auth`
      interceptor (core.cljs) already attaches the token, so authenticated calls
-     work against the real API.
-   - local reference backend — the upstream Node/Postgres backend on
+     just work against the real API.
+   - a local reference backend — the upstream Node/Postgres backend on
      `http://localhost:3000/api`.
 
-   The RealWorld spec lives at https://github.com/gothinkster/realworld; the
-   current official hosted API is https://api.realworld.show/api; the upstream
-   spec ships a Node/Postgres reference backend on http://localhost:3000/api."
+   For reference: the RealWorld spec lives at
+   https://github.com/gothinkster/realworld, the current official hosted API is
+   https://api.realworld.show/api, and the upstream spec ships a Node/Postgres
+   reference backend on http://localhost:3000/api."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]))
 
 (def api-base
   "Default API base URL — the current official hosted Conduit API. The resource
-   / mutation `:request` fns build full URLs from this; in the DEFAULT run mode
-   the demo stub overrides `:rf.http/managed` and matches on the path suffix, so
-   the base is not actually contacted (a demo-seam knob). Drop the stub to run
-   against the real hosted API, or set it to `http://localhost:3000/api` for the
-   local upstream reference backend. See the README §Running against a real
-   backend."
+   and mutation `:request` fns build full URLs from this. In the default run mode
+   it's effectively a knob you never turn: the demo stub overrides
+   `:rf.http/managed` and matches on the path suffix, so the base is never
+   contacted. Drop the stub to run against the real hosted API, or set this to
+   `http://localhost:3000/api` for the local upstream reference backend. See the
+   README §Running against a real backend."
   "https://api.realworld.show/api")
 
 (defn full-url [path]
@@ -51,18 +53,18 @@
 ;; RETRY POLICY
 ;; ============================================================================
 ;;
-;; Reads retry; writes don't. Each read resource's `:request` returns a
-;; managed-HTTP args map, and `:retry` passes through the resource lowering
-;; unchanged, so a resource arms retry simply by including this policy in its
-;; return. Writes (mutations) stay retry-free — a write's intent is one
-;; submission per click; a 5xx surfaces as `:error` so the user retries
-;; themselves.
+;; Same rule as ever: reads retry, writes don't. A read resource's `:request`
+;; returns a managed-HTTP args map, and `:retry` passes through the resource
+;; lowering untouched — so a resource opts into retry simply by dropping this
+;; policy into its return. Mutations stay retry-free, because a write means one
+;; submission per click; if it 5xxes, that surfaces as `:error` and the user gets
+;; to decide whether to try again.
 
 (def data-fetch-retry
-  "Standard retry policy for read-only data fetches (lists, article detail,
-   comments, profiles, tags, the feed). Retries transport blips, 5xx, and
-   timeouts — NOT 4xx (the request shape was valid; retrying won't help).
-   Three attempts total with exponential backoff + jitter."
+  "The standard retry policy for read-only data fetches — lists, article detail,
+   comments, profiles, tags, the feed. It retries transport blips, 5xx, and
+   timeouts, but not 4xx: the request shape was valid, so retrying would just be
+   wishful thinking. Three attempts total, with exponential backoff + jitter."
   {:on           #{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}
    :max-attempts 3
    :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}})
@@ -72,11 +74,11 @@
 ;; ============================================================================
 
 (defn failure->message
-  "Project a failure envelope (the inner `:failure` map — the shape a resource
-   `:error` / `:refresh-error` and a mutation `:error` carry) to a human-readable
-   string. The Conduit API returns `{:errors {:body [\"...\"]}}` shapes for 4xx
-   validation failures; surface those when present, otherwise fall back to a
-   category-driven message keyed on the closed `:rf.http/*` taxonomy."
+  "Turn a failure envelope — the inner `:failure` map a resource `:error` /
+   `:refresh-error` and a mutation `:error` carry — into something a human can
+   read. The Conduit API hands back `{:errors {:body [\"...\"]}}` shapes for 4xx
+   validation failures, so prefer those when they're present; otherwise fall back
+   to a category-driven message keyed off the closed `:rf.http/*` taxonomy."
   [failure]
   (let [body     (:body failure)
         body-msg (cond
@@ -101,39 +103,39 @@
 ;; DEMO BACKEND STUB
 ;; ============================================================================
 ;;
-;; The example ships without a backend; the demo routes `:rf.http/managed`
+;; The example ships without a backend, so the demo routes `:rf.http/managed`
 ;; through a per-URL stub that delegates to `:rf.http/managed-canned-success`.
-;; The resource / mutation runtime lowers each fetch/write onto
-;; `:rf.http/managed`, so this one override stands in for the whole Conduit API.
+;; Since the resource / mutation runtime lowers every fetch and write onto
+;; `:rf.http/managed`, this one override gets to play the entire Conduit API.
 
 (def ^:private demo-reply-delay-ms
-  "How long the demo stub defers each canned reply (via the canned-success
-   fx's `:after-ms`, dispatched through `:dispatch-later` — observable in the
-   tape, time-travel-safe, NOT raw `js/setTimeout`). Small but non-zero so the
-   `:loading` / `:pending` UI states are observable. A demo-seam knob, not a
-   production value."
+  "How long the demo stub waits before handing back each canned reply (via the
+   canned-success fx's `:after-ms`, dispatched through `:dispatch-later` — so it's
+   visible in the tape and time-travel-safe, not a raw `js/setTimeout`). Small but
+   non-zero, just enough that the `:loading` / `:pending` states are actually
+   visible. A demo knob, not a production value."
   20)
 
-;; A SYNTHESISED article set large enough that the official-size pagination
-;; (`page-size` = 10) spans several pages — so the paginated-resource +
-;; keep-previous behaviour is actually demonstrable in the browser. The first two
-;; carry stable slugs (referenced by the article-detail / mutation paths); the
-;; rest are generated. `demo-favorited` is a SUBSET so the profile
-;; Favorited-Articles tab differs from My Articles, and unfavoriting from the tab
-;; visibly drops the article on the next refetch.
+;; A synthesised article set, sized so the official 10-per-page pagination spans
+;; several pages — otherwise there'd be nothing to page through, and the
+;; paginated-resource + keep-previous behaviour would be impossible to see in the
+;; browser. The first two articles have stable slugs (the article-detail and
+;; mutation paths reference them); the rest are generated. `demo-favorited` is a
+;; deliberate subset, so the profile's Favorited-Articles tab looks different from
+;; My Articles and an unfavorite visibly drops an article on the next refetch.
 (def ^:private demo-article-count 23)
 
 (defn- gen-article [i]
   (let [stable [{:slug "hello-conduit"
                  :title "Hello, Conduit"
                  :description "A short greeting from the realworld-resources stub."
-                 ;; A markdown body so the article-detail page exercises the
-                 ;; sanitized CommonMark renderer (realworld-shared.markdown/
-                 ;; render): headings, bold/italic, inline + fenced code, a safe
-                 ;; link, lists, tables, nested lists. The renderer emits hiccup
-                 ;; (never raw HTML), so this is real markup while any injected
-                 ;; `<script>` / `javascript:` link in user content degrades to
-                 ;; inert escaped text.
+                 ;; A markdown body, so the article-detail page gets to exercise
+                 ;; the sanitized CommonMark renderer (realworld-shared.markdown/
+                 ;; render): headings, bold/italic, inline and fenced code, a safe
+                 ;; link, lists, tables, nested lists. The renderer emits hiccup,
+                 ;; never raw HTML — so this is genuine markup, while any injected
+                 ;; `<script>` or `javascript:` link in user content degrades
+                 ;; harmlessly to inert escaped text.
                  :body (str "# Hello, Conduit\n\n"
                             "This article is served by the demo `:rf.http/managed` "
                             "override that **resources + mutations** lower onto, "
@@ -173,14 +175,16 @@
   (mapv gen-article (range demo-article-count)))
 
 (def ^:private demo-favorited
-  "The favorited subset (every third article) — the profile Favorited tab read."
+  "The favorited subset — every third article. Backs the profile's Favorited tab,
+   and being a subset is the point: it makes that tab visibly different from My
+   Articles."
   (vec (take-nth 3 demo-articles)))
 
 (def ^:private demo-tags ["intro" "demo" "clojure" "re-frame"])
 
 (def ^:private demo-user
-  "Canned User payload for the auth POSTs (/users/login, /users register,
-   /user restore) and the settings PUT (/user)."
+  "The canned User payload — used for the auth POSTs (/users/login, /users
+   register, /user restore) and the settings PUT (/user)."
   {:email "demo@conduit.dev" :token "stub.demo.jwt" :username "demo"
    :bio "Canned demo user." :image ""})
 
@@ -189,20 +193,21 @@
       (first demo-articles)))
 
 ;; --- pagination ---
-;; The Conduit list endpoints page with `limit` / `offset` query params. The
-;; stub honours them so each page is a genuinely distinct slice of the article
-;; set, and always reports the FULL total in `articlesCount` (the pagination
-;; control derives the page count from it). This is what makes the
-;; paginated-resource identity + keep-previous behaviour real in the browser:
-;; page N and page N+1 return different data under distinct cache keys.
+;; The Conduit list endpoints page with `limit` / `offset` query params, and the
+;; stub honours them properly: each page is a genuinely distinct slice of the
+;; article set, and `articlesCount` always reports the full total (the pagination
+;; control works the page count out from it). That honesty is what makes the
+;; paginated-resource identity and keep-previous behaviour real in the browser —
+;; page N and page N+1 really do return different data under distinct cache keys.
 
 (defn- query-int [u k]
   (when-let [m (re-find (re-pattern (str "[?&]" k "=([0-9]+)")) u)]
     (js/parseInt (second m) 10)))
 
 (defn- paged-response
-  "Slice `all` by the `limit` / `offset` in the URL `u` (defaults: whole list),
-   wrapped in the Conduit `{:articles … :articlesCount <full-total>}` envelope."
+  "Slice `all` by the `limit` / `offset` in URL `u` (with no params, the whole
+   list), wrapped in the Conduit `{:articles … :articlesCount <full-total>}`
+   envelope."
   [u all]
   (let [limit  (or (query-int u "limit") (count all))
         offset (or (query-int u "offset") 0)]
@@ -222,19 +227,20 @@
         u      (str (:url req))
         method (or (:method req) :get)]
     (cond
-      ;; --- auth POSTs (the auth machine still issues these via managed HTTP) ---
+      ;; --- auth POSTs (the auth machine issues these through managed HTTP) ---
       (and (= method :post) (str/ends-with? u "/users/login")) {:user demo-user}
       (and (= method :post) (str/ends-with? u "/users"))       {:user demo-user}
 
-      ;; GET /user — session restore. Empty payload → decode fails into the
-      ;; failure branch so the app starts unauthenticated (the demo never
-      ;; auto-restores). PUT /user — settings update (a mutation).
+      ;; GET /user — session restore. We return an empty payload on purpose: the
+      ;; decode fails into the failure branch, so the demo always starts
+      ;; unauthenticated and never auto-restores a session. PUT /user is the
+      ;; settings update (a mutation).
       (and (= method :get) (str/ends-with? u "/user"))  {}
       (and (= method :put) (str/ends-with? u "/user"))  {:user demo-user}
 
       ;; --- write mutations -------------------------------------------------
-      ;; POST /articles — create-article. Echo a full Article built from the
-      ;; submitted body so the editor's save reaction can navigate to its slug.
+      ;; POST /articles — create. Echo back a full Article built from the submitted
+      ;; body, so the editor's save reaction has a slug to navigate to.
       (and (= method :post) (str/ends-with? u "/articles"))
       (let [a (some-> req :body :article)]
         {:article (merge (first demo-articles)
@@ -245,8 +251,8 @@
                           :title (:title a) :description (:description a)
                           :body (:body a) :tagList (vec (:tagList a))})})
 
-      ;; PUT /articles/:slug — update-article. Echo the updated Article keyed by
-      ;; the URL slug, merged with the submitted body.
+      ;; PUT /articles/:slug — update. Echo the updated Article, keyed by the URL
+      ;; slug and merged with the submitted body.
       (and (= method :put) (re-find #"/articles/([^/?]+)$" u))
       (let [slug (second (re-find #"/articles/([^/?]+)$" u))
             a    (some-> req :body :article)]
@@ -254,8 +260,8 @@
                          {:slug slug :title (:title a) :description (:description a)
                           :body (:body a) :tagList (vec (:tagList a))})})
 
-      ;; DELETE /articles/:slug — delete-article. No body (the delete mutation
-      ;; decodes `:auto`, which tolerates 204/empty).
+      ;; DELETE /articles/:slug — delete. No body; the delete mutation decodes
+      ;; `:auto`, which is happy with a 204/empty.
       (and (= method :delete) (re-find #"/articles/([^/?]+)$" u))
       {}
 
@@ -267,8 +273,8 @@
       (and (= method :delete) (re-find #"/articles/[^/]+/comments/[^/]+$" u))
       {}
 
-      ;; POST/DELETE /articles/:slug/favorite — favorite / unfavorite. Echo a
-      ;; full Article so the mutation's :populates can seed the detail entry.
+      ;; POST/DELETE /articles/:slug/favorite — favorite / unfavorite. Echo a full
+      ;; Article so the mutation's :populates can seed the detail entry.
       (re-find #"/articles/([^/]+)/favorite$" u)
       (let [slug (second (re-find #"/articles/([^/]+)/favorite$" u))
             base (demo-article-by-slug slug)]
@@ -282,17 +288,17 @@
         {:profile {:username username :bio "" :image "" :following (= method :post)}})
 
       ;; --- resource reads --------------------------------------------------
-      ;; The feed is empty in the demo (no followed authors), but still a
-      ;; well-formed paged Conduit envelope.
+      ;; The feed is empty in the demo — no followed authors — but it's still a
+      ;; well-formed paged Conduit envelope, not a special case.
       (str/includes? u "/articles/feed")        {:articles [] :articlesCount 0}
       (re-find #"/articles/[^/]+/comments" u)    {:comments []}
       (re-find #"/articles/[^/?]+$" u)           {:article (demo-article-by-slug
                                                             (second (re-find #"/articles/([^/?]+)" u)))}
-      ;; The profile Favorited-Articles tab — a DISTINCT subset so the tab
-      ;; differs from My Articles and unfavoriting visibly drops an item.
+      ;; The profile Favorited-Articles tab — a distinct subset, so the tab differs
+      ;; from My Articles and an unfavorite visibly removes an item.
       (re-find #"[?&]favorited=" u)              (paged-response u demo-favorited)
-      ;; All other list reads (global list, tag-filtered, author) page the full
-      ;; set; `limit` / `offset` make each page a genuinely different slice.
+      ;; Every other list read (global list, tag-filtered, author) pages the full
+      ;; set; `limit` / `offset` carve each page into a genuinely different slice.
       (or (str/ends-with? u "/articles")
           (str/includes? u "/articles?"))        (paged-response u demo-articles)
       (str/includes? u "/tags")                  {:tags demo-tags}
@@ -301,13 +307,13 @@
       :else {})))
 
 (rf/reg-fx :realworld-resources.demo/http-stub
-  {:doc       "Demo override for :rf.http/managed: routes by URL + method to
-               canned Conduit-shaped responses so the example (reads via
-               resources, writes via mutations) runs standalone without a
-               backend. Delegates to the framework-shipped
-               `:rf.http/managed-canned-success` with the per-URL payload +
-               `:after-ms` (the deferred reply rides `:dispatch-later` —
-               tape-visible, time-travel-safe, NOT raw `js/setTimeout`)."
+  {:doc       "The demo override for :rf.http/managed: routes by URL + method to
+               canned Conduit-shaped responses, so the example (reads via
+               resources, writes via mutations) runs standalone with no backend.
+               It delegates to the framework-shipped
+               `:rf.http/managed-canned-success` with the per-URL payload plus
+               `:after-ms` — the deferred reply rides `:dispatch-later`, so it's
+               tape-visible and time-travel-safe, not a raw `js/setTimeout`."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
     (let [payload (demo-payload-for-args args-map)

--- a/examples/reagent/realworld_resources/mutations.cljs
+++ b/examples/reagent/realworld_resources/mutations.cljs
@@ -1,43 +1,47 @@
 (ns realworld-resources.mutations
-  "The MUTATION registry — every RealWorld write as a named, causal write to
-   remote state that invalidates / patches / populates the cached resource reads
-   it affected. See ../../../docs/resources/glossary.md#mutation and
+  "The mutation registry — every write in the app, expressed as a named, causal
+   write to remote state that then invalidates / patches / populates whichever
+   cached reads it touched. See ../../../docs/resources/glossary.md#mutation and
    ../../../docs/resources/how-to/invalidate-after-a-mutation.md.
 
-   A resource is \"a sub you read and a cause you fire\"; a mutation is \"a cause
-   you fire and an instance you watch\". The read→write→invalidate→refetch loop,
+   A handy way to hold the two halves in your head: a resource is 'a sub you read
+   and a cause you fire'; a mutation is 'a cause you fire and an instance you
+   watch'. Put them together and you get the read→write→invalidate→refetch loop,
    end to end.
 
-   Each mutation:
-   - lowers its `:request` through the SAME managed-HTTP transport resources use
-     (the runtime owns reply addressing — the app `:request` MUST NOT supply
-     `:request-id` / `:on-success` / `:on-failure`);
-   - declares `:invalidates` — the resource `:tags` the write makes stale on
-     success (scoped, owner-aware: mounted-and-owned reads refetch, inactive ones
-     go stale). The detail page and any list refetch with NO further wiring;
-   - some also declare `:populates` — seeding the affected resource entry from
-     the write's own reply BEFORE the invalidation, so the change appears
-     immediately without waiting for the refetch round-trip.
+   Every mutation here does the same three-ish things:
+   - it lowers its `:request` through the same managed-HTTP transport the reads
+     use. The runtime owns reply addressing, so your `:request` must not supply
+     `:request-id` / `:on-success` / `:on-failure` — leave those to the framework;
+   - it declares `:invalidates` — the resource `:tags` this write makes stale on
+     success. It's scoped and owner-aware: mounted, owned reads refetch; inactive
+     ones simply go stale. The detail page and any affected list refetch with no
+     further wiring from you;
+   - some also declare `:populates` — seeding the affected entry straight from the
+     write's own reply, before the invalidation, so the change shows up
+     immediately instead of waiting on a refetch round-trip.
 
-   Runtime state is keyed by mutation INSTANCE id (not mutation id), so two
-   concurrent submissions never clobber each other. A view watches an instance
-   through the passive `[:rf.mutation/state {:instance …}]` sub
+   Runtime state is keyed by mutation INSTANCE id, not mutation id, so two
+   submissions in flight at once never step on each other. A view watches an
+   instance through the passive `[:rf.mutation/state {:instance …}]` sub
    (`{:pending? :success? :error? :settled? :result :error :optimistic?}`).
 
-   OPTIMISTIC ROLLBACK (../../../docs/resources/glossary.md#optimistic-update--rollback).
-   The favorite / unfavorite writes below declare `:optimistic-tags` — the heart
-   flips and the count moves on click, BEFORE the request is sent, across every
-   cached read showing that article (the detail, every list, the session feed) in
-   one tag-addressed apply. The runtime records the inverse itself, so the reply
-   settles deterministically: an `:ok` reply COMMITS (the `:populates` seed
-   overwrites the optimistic value with the server's), an `:error` reply ROLLS
-   BACK (the recorded `:before` is restored verbatim — the heart flips back).
-   `:on-conflict :invalidate` (the default) governs a contested rollback: if a
-   concurrent write moved the entry while ours was in flight, the stale inverse is
-   NOT restored — the read path refetches the authoritative value.
+   Optimistic rollback is the fun part
+   (../../../docs/resources/glossary.md#optimistic-update--rollback). The
+   favorite / unfavorite writes below declare `:optimistic-tags`: the heart flips
+   and the count moves the instant you click, before the request is even sent,
+   across every cached read showing that article (the detail, every list, the
+   session feed) in one tag-addressed apply. You only write the forward change —
+   the runtime records the inverse for you, so the reply settles by itself. An
+   `:ok` reply commits (the `:populates` seed overwrites your optimistic guess
+   with the server's truth); an `:error` reply rolls back (the recorded `:before`
+   is restored verbatim and the heart flips back, no apology needed).
+   `:on-conflict :invalidate` (the default) handles the awkward case: if a
+   competing write moved the entry while yours was in flight, the now-stale
+   inverse is NOT restored — the read path just refetches the authoritative value.
 
-   Writes do NOT retry by default; a mutation arms `:retry` only if its
-   `:request` declares it, and none here do."
+   And, as everywhere: writes don't retry by default. A mutation arms `:retry`
+   only if its `:request` asks for it, and none of these do."
   (:require [re-frame.core :as rf]
             [re-frame.http.managed]
             [re-frame.resources]
@@ -48,50 +52,51 @@
 ;; FAVORITE / UNFAVORITE  —  the optimistic write
 ;; ============================================================================
 ;;
-;; Favoriting is the canonical optimistic mutation: a tiny, reversible change (a
-;; boolean flip + a count of one) the user expects to land INSTANTLY. The same
-;; article appears in many cached reads at once — the detail, the home list, an
-;; author's articles, a profile's favorited tab, the session feed — and a
-;; favorite must flip in ALL of them the moment the heart is clicked, then settle
-;; to the server's authoritative value (and flip BACK everywhere if the write
-;; fails).
+;; Favoriting is the textbook optimistic mutation: a tiny, reversible change — a
+;; boolean flip and a count of one — that the user expects to land the instant
+;; they click. The catch is that the same article shows up in a lot of places at
+;; once: the detail page, the home list, an author's articles, a profile's
+;; favorited tab, the session feed. The heart has to flip in all of them
+;; immediately, then settle to whatever the server says — and flip back
+;; everywhere if the write fails. That's a lot to coordinate by hand. So we don't.
 ;;
-;; OPTIMISTIC-TAGS — the tag-addressed forward apply. The author cannot
-;; enumerate every cache key showing this article by hand (lists are paginated,
-;; scopes differ, entries come and go), so the optimistic apply is TAG-ADDRESSED:
-;; it patches every cached entry carrying `[:article slug]` — reusing the SAME
-;; tag index `:invalidates` matches against. One descriptor covers the global
-;; reads (detail + every list), a second covers the session feed via the same
-;; `{:from-db :realworld/session}` resolver the feed resource declares. The
-;; detail stores `{:article …}` and the lists store `{:articles […]}`, so the
-;; patch fn (`apply-fav` below) handles both envelope shapes. The session target
-;; is FAIL-CLOSED: logged out, the resolver returns nil and that target is
-;; silently dropped — an optimistic apply writes the cache, so it has a read's
-;; leak boundary, never an implicit global write.
+;; `:optimistic-tags` is the forward apply, addressed by tag. You can't realistically
+;; list every cache key showing this article — lists are paginated, scopes differ,
+;; entries come and go — so instead of naming keys, you name a tag: patch every
+;; cached entry carrying `[:article slug]`, reusing the very same tag index that
+;; `:invalidates` matches against. One descriptor covers the global reads (detail
+;; plus every list); a second covers the session feed, via the same
+;; `{:from-db :realworld/session}` resolver the feed resource itself uses. The
+;; detail stores `{:article …}` while the lists store `{:articles […]}`, so the
+;; patch fn (`apply-fav`, below) handles both envelope shapes. The session target
+;; is fail-closed: logged out, the resolver returns nil and that target quietly
+;; drops — an optimistic apply writes the cache, so it respects a read's leak
+;; boundary and never sneaks in an implicit global write.
 ;;
-;; THE INVERSE IS RUNTIME-RECORDED — the author writes only the FORWARD patch.
-;; The runtime snapshots each touched entry's `:before` and its `:revision` at
-;; apply time. The reply then settles deterministically:
-;;   - :ok    → COMMIT. `:populates` seeds the detail with the server's full
-;;              Article (the authoritative value overwrites the optimistic one),
-;;              then `:invalidates` refetches the lists / feed to truth.
-;;   - :error → ROLLBACK. The recorded `:before` is restored verbatim — every
-;;              heart flips back, every count returns. No manual undo, no app-db
-;;              bookkeeping.
-;;   - a competing write moved an entry while ours was in flight → `:on-conflict`
-;;              (default `:invalidate`) marks that entry stale and lets the read
-;;              path refetch, rather than restoring a now-stale inverse.
+;; You write only the forward patch; the runtime records the inverse. At apply
+;; time it snapshots each touched entry's `:before` and `:revision`, and from then
+;; on the reply settles itself:
+;;   - :ok    → commit. `:populates` seeds the detail with the server's full
+;;              Article (truth overwrites your optimistic guess), then
+;;              `:invalidates` refetches the lists / feed.
+;;   - :error → rollback. The recorded `:before` goes back verbatim — every heart
+;;              flips back, every count returns. No manual undo, no app-db
+;;              bookkeeping on your side.
+;;   - someone moved an entry while yours was in flight → `:on-conflict` (default
+;;              `:invalidate`) marks that entry stale and lets the read path
+;;              refetch, instead of restoring an inverse that's now out of date.
 ;;
-;; CROSS-SCOPE INVALIDATION IN ONE MUTATION. `:invalidates` is the success-time
-;; counterpart: a vector of PER-TARGET DESCRIPTORS, each naming its own scope.
-;; The global descriptor refetches the article + lists; the session descriptor
-;; refetches the feed via the same resolver. One mutation, two scopes — no
-;; app-level cross-scope patch, no home-page watcher.
+;; One mutation, two scopes. `:invalidates` is the success-time counterpart of the
+;; optimistic apply: a vector of per-target descriptors, each naming its own
+;; scope. The global descriptor refetches the article and lists; the session
+;; descriptor refetches the feed through the same resolver. No app-level
+;; cross-scope patching, no home-page watcher keeping things in sync.
 
 (defn- toggle-article-fav
-  "Toggle one Article map's `:favorited` flag and step `:favoritesCount` by
-   ±1. Pure; clamps the count at zero. Shared by the favorite + unfavorite
-   forward patches so the optimistic shape is declared once."
+  "Flip one Article's `:favorited` flag and nudge `:favoritesCount` by ±1. Pure,
+   and it clamps the count at zero so an over-eager unfavorite can't go negative.
+   Shared by the favorite and unfavorite forward patches, so the optimistic shape
+   is written down exactly once."
   [favorited? article]
   (when article
     (-> article
@@ -99,12 +104,13 @@
         (update :favoritesCount (fn [n] (max 0 (+ (or n 0) (if favorited? 1 -1))))))))
 
 (defn- apply-fav
-  "The FORWARD optimistic patch over ONE cached entry's `:data`, for any read
-   showing this article. Handles both stored shapes: the detail's `{:article
-   …}` envelope and a list's `{:articles […]}` envelope (it edits the matching
-   article in place by slug, leaving the rest untouched). `favorited?` is the
-   desired post-click state. The runtime records the inverse, so this fn never
-   has to describe how to undo itself."
+  "The forward optimistic patch over one cached entry's `:data`, for any read
+   showing this article. It copes with both stored shapes: the detail's
+   `{:article …}` envelope and a list's `{:articles […]}` envelope, editing the
+   matching article in place by slug and leaving everything else alone.
+   `favorited?` is the desired post-click state. Note there's no undo logic here —
+   the runtime records the inverse, so this fn never has to explain how to take
+   itself back."
   [favorited? slug data]
   (cond-> data
     (contains? data :article)
@@ -118,11 +124,11 @@
                     articles)))))
 
 (defn- optimistic-fav-tags
-  "The `:optimistic-tags` plan shared by favorite (`favorited? true`) and
-   unfavorite (`favorited? false`): patch every entry tagged `[:article slug]`
-   in the global scope (detail + lists) AND in the session scope (the feed),
-   the same two scopes `:invalidates` covers. The session target is fail-closed
-   — dropped when logged out."
+  "The `:optimistic-tags` plan, shared by favorite (`favorited? true`) and
+   unfavorite (`favorited? false`): patch every entry tagged `[:article slug]` in
+   the global scope (detail + lists) and in the session scope (the feed) — the
+   same two scopes `:invalidates` covers. The session target is fail-closed, so
+   it's simply dropped when logged out."
   [favorited? slug]
   [{:scope :rf.scope/global
     :tags  #{[:article slug]}
@@ -135,26 +141,25 @@
   {:doc             "Favorite an article (optimistic). POST /articles/:slug/favorite."
    :params-schema   [:map [:slug :string]]
    :scope           :rf.scope/global
-   ;; FORWARD: flip the heart on + bump the count across the detail, every list,
-   ;; and the session feed, immediately on click, before the request is sent.
+   ;; Forward: flip the heart on and bump the count across the detail, every list,
+   ;; and the session feed — immediately on click, before the request goes out.
    :optimistic-tags (fn [{:keys [slug]}] (optimistic-fav-tags true slug))
-   ;; COMMIT: the reply is the full updated Article; seed the detail with it so
-   ;; the authoritative value (the server's exact count) overwrites the
-   ;; optimistic guess. Same `{:article …}` envelope the resource stores, so the
-   ;; populated key reads identically to a fetched one — an authoritative load, so
-   ;; the populated detail key is exempt from this same mutation's `[:article
-   ;; slug]` refetch.
+   ;; Commit: the reply is the full updated Article, so seed the detail with it and
+   ;; let the server's exact count overwrite the optimistic guess. It's the same
+   ;; `{:article …}` envelope the resource stores, so the populated key reads just
+   ;; like a fetched one — and because it's authoritative, it's exempt from this
+   ;; same mutation's `[:article slug]` refetch.
    :populates       (fn [{:keys [slug]} result]
                       {{:resource :realworld/article :params {:slug slug} :scope :rf.scope/global} result})
-   ;; RECONCILE: refetch the lists (global) and the feed (session) to truth.
+   ;; Reconcile: refetch the lists (global) and the feed (session) to truth.
    :invalidates     (fn [{:keys [slug]} _result]
                       [{:scope :rf.scope/global
                         :tags  #{[:article slug] [:article-list]}}
                        {:scope {:from-db :realworld/session}
                         :tags  #{[:feed]}}])
-   ;; ROLLBACK conflict policy (the default, named here to show it): on a failure
-   ;; rollback where a competing write moved a touched entry, refetch it rather
-   ;; than restoring a stale inverse.
+   ;; The conflict policy. It's the default, spelled out here so it's visible: if a
+   ;; failure rollback finds that a competing write already moved a touched entry,
+   ;; refetch it rather than restoring an inverse that's now stale.
    :on-conflict     :invalidate}
   (fn [{:keys [slug]} _ctx]
     {:request {:method :post :url (rh/full-url (str "/articles/" slug "/favorite"))}
@@ -181,16 +186,17 @@
 ;; FOLLOW / UNFOLLOW
 ;; ============================================================================
 ;;
-;; Following changes a profile's `:following` flag, so it invalidates that
-;; profile read; the reply is a full Profile so `:populates` seeds the banner
-;; immediately.
+;; Following flips a profile's `:following` flag, so it invalidates that profile
+;; read. The reply comes back as a full Profile, so `:populates` can seed the
+;; banner right away rather than waiting for the refetch.
 
 (rf/reg-mutation :realworld/follow
   {:doc           "Follow a user. POST /profiles/:username/follow."
    :params-schema [:map [:username :string]]
    :scope         :rf.scope/global
-   ;; Seed the banner from the reply (the whole `{:profile …}` envelope, the
-   ;; `:realworld/profile` resource's stored shape) so it flips immediately.
+   ;; Seed the banner straight from the reply — the whole `{:profile …}` envelope,
+   ;; which is exactly the `:realworld/profile` resource's stored shape — so it
+   ;; flips immediately.
    :populates     (fn [{:keys [username]} result]
                     {{:resource :realworld/profile :params {:username username} :scope :rf.scope/global} result})
    :invalidates   (fn [{:keys [username]} _result] #{[:profile username]})}
@@ -213,11 +219,12 @@
 ;; POST / DELETE COMMENT
 ;; ============================================================================
 ;;
-;; Posting or deleting a comment changes the article's comment collection, so
-;; both invalidate `[:comments slug]`. The mounted article page owns the
-;; comments read, so the list refetches automatically. (No `:populates` — the
+;; Posting or deleting a comment changes the article's comment collection, so both
+;; invalidate `[:comments slug]`. The mounted article page owns the comments read,
+;; so the list refetches on its own. No `:populates` here, on purpose: the
 ;; comments collection is a list the refetch re-reads authoritatively, and the
-;; post reply is a single Comment, not the whole list.)
+;; post reply is a single Comment, not the whole list — so seeding from it would
+;; only give a partial picture.
 
 (rf/reg-mutation :realworld/post-comment
   {:doc           "Post a comment. POST /articles/:slug/comments."
@@ -244,11 +251,12 @@
 ;; SETTINGS UPDATE
 ;; ============================================================================
 ;;
-;; Updating settings PUTs the User and returns the saved User. The example
-;; reads the saved user out of the mutation INSTANCE result (`:rf.mutation/
-;; result`) and pushes it into the auth slice; there is no profile resource
-;; keyed by the current user to populate, so `:invalidates` clears the public
-;; `[:profile username]` read so a later profile visit re-reads the new bio.
+;; Updating settings PUTs the User and gets the saved User back. The continuation
+;; reads that out of the mutation instance result (`:rf.mutation/result`) and
+;; pushes it into the auth slice. There's no profile resource keyed by the current
+;; user to populate, so instead `:invalidates` clears the public
+;; `[:profile username]` read — that way a later visit to your own profile
+;; re-reads the new bio.
 
 (rf/reg-mutation :realworld/update-settings
   {:doc           "Update the current user's settings. PUT /user."

--- a/examples/reagent/realworld_resources/resources.cljs
+++ b/examples/reagent/realworld_resources/resources.cljs
@@ -1,34 +1,36 @@
 (ns realworld-resources.resources
-  "The RESOURCE registry — every RealWorld read as a named, cached,
-   runtime-managed server-state read. See the resources guide:
+  "The resource registry — every read in the app, expressed as a named, cached,
+   framework-managed bit of server-state. See the resources guide:
    ../../../docs/resources/concepts.md; resource glossary:
    ../../../docs/resources/glossary.md#resource.
 
-   Each read is `reg-resource`d once; route entry / events CAUSE the fetch, and
-   views read the runtime cache PASSIVELY through `[:rf.resource/*]` subs. No
-   `:status` / `:loading?` app-db fields exist for these reads — the framework
-   owns the lifecycle.
+   The pattern repeats for every read. You `reg-resource` it once. Something —
+   a route entry, an event — CAUSES the fetch. And your views just read the
+   cache, passively, through `[:rf.resource/*]` subs. Notice what's missing:
+   there are no `:status` or `:loading?` fields in app-db for any of these reads.
+   The framework owns that lifecycle so you don't have to.
 
-   A read's cache identity is `[scope resource-id canonical-params]`. Every
-   variable that changes the remote read lives in `:params` (slug, username,
-   tag); `:scope` is the leak boundary (see realworld-resources.scope,
-   ../../../docs/resources/glossary.md#scope). `:tags` let a WRITE invalidate
-   the right reads (see realworld-resources.mutations) — the
+   A read's cache identity is `[scope resource-id canonical-params]`. Anything
+   that changes the remote read goes in `:params` — slug, username, tag. `:scope`
+   is the leak boundary (see realworld-resources.scope,
+   ../../../docs/resources/glossary.md#scope). And `:tags` are what let a WRITE
+   invalidate the right reads (see realworld-resources.mutations) — that's the
    read→write→invalidate→refetch loop, ../../../docs/resources/glossary.md#invalidate.
 
-   `:stale-after-ms` / `:gc-after-ms` are exercised so the lifecycle is real: a
-   `:loaded` entry goes stale after the window (a re-`ensure` then refetches into
-   `:fetching`, keeping prior data visible — stale-while-revalidate), and an
-   inactive entry (no owner) is GC-eligible after its window. A fresh re-`ensure`
-   of a fresh entry is a cache-hit (no fetch, no dedupe)."
+   The lifecycle here is real, not decorative — `:stale-after-ms` and
+   `:gc-after-ms` are set so you can watch it work. A `:loaded` entry goes stale
+   after its window; a re-`ensure` then refetches into `:fetching` while keeping
+   the old data on screen (that's stale-while-revalidate). An inactive entry —
+   one nobody owns — becomes GC-eligible after its own window. And re-`ensure`-ing
+   a still-fresh entry is just a cache-hit: no fetch, no dedupe, nothing to see."
   (:require [clojure.string]
             [re-frame.core :as rf]
-            ;; Managed HTTP — the single built-in resource/mutation transport.
-            ;; Loading the ns registers the `:rf.http/managed` fx the runtime
-            ;; lowers each ensure/refetch onto.
+            ;; Managed HTTP — the one built-in transport for resources and
+            ;; mutations. Loading the ns registers the `:rf.http/managed` fx the
+            ;; runtime lowers each ensure/refetch onto.
             [re-frame.http.managed]
-            ;; Resources runtime. Requiring the ns at app boot wires the hooks +
-            ;; registrations; without it `rf/reg-resource` throws.
+            ;; The resources runtime. Requiring it at boot wires the hooks and
+            ;; registrations; without it, `rf/reg-resource` has nothing to call.
             [re-frame.resources]
             [realworld-resources.http :as rh]
             [realworld-resources.schema :as schema]))
@@ -38,13 +40,14 @@
 ;; ============================================================================
 
 (def stale-after-ms
-  "Reads go stale after a minute. A re-`ensure` of a stale `:loaded` entry
-   refetches (stale-while-revalidate); a fresh one is a cache-hit."
+  "Reads go stale after a minute. Re-`ensure` a stale `:loaded` entry and it
+   refetches (stale-while-revalidate); re-`ensure` a fresh one and it's a
+   cache-hit."
   60000)
 
 (def gc-after-ms
-  "An inactive entry (no live owner) is GC-eligible five minutes after going
-   inactive."
+  "An inactive entry — one with no live owner — becomes GC-eligible five minutes
+   after it goes quiet."
   (* 5 60 1000))
 
 ;; ============================================================================
@@ -52,63 +55,64 @@
 ;; ============================================================================
 ;;
 ;; The Conduit list endpoints page with `limit` / `offset`; the UI is 1-indexed
-;; and the page size is fixed. The point this exercises: pagination is
-;; DECLARATIVE on resources. The `:page` is just another `:params` key, so page N
-;; and page N+1 are DISTINCT cache entries — back-navigating to a
-;; previously-loaded page is a cache-hit (no fetch), and `:keep-previous?` on the
-;; route entry keeps the prior page visible while the next first-loads (no
-;; flicker). No `:status` / `:loading?` app-db field, no manual page-cache map —
-;; the framework owns it. See ../../../docs/resources/how-to/paginate-a-feed.md.
+;; with a fixed page size. Here's the nice part: pagination is just declarative
+;; on resources. `:page` is another `:params` key and nothing more, so page N and
+;; page N+1 are genuinely different cache entries. Back-navigate to a page you've
+;; already seen and it's a free cache-hit. `:keep-previous?` on the route entry
+;; keeps the current page on screen while the next one loads, so there's no
+;; flicker. No `:status` field, no hand-rolled page-cache map — the framework
+;; carries all of it. See ../../../docs/resources/how-to/paginate-a-feed.md.
 
 (def page-size
-  "The fixed Conduit list page size (the official client's value). The demo
-   stub synthesises enough articles that several pages exist (see
-   realworld-resources.http)."
+  "The fixed Conduit list page size — the official client's value. The demo stub
+   synthesises enough articles that several pages actually exist to page through
+   (see realworld-resources.http)."
   10)
 
 (defn page->limit-offset
-  "Map a 1-indexed `:page` (nil → page 1) to the Conduit `limit` / `offset`
-   query pair. Pure — a page is just another canonical-params key, so this is
-   the only place page math lives."
+  "Turn a 1-indexed `:page` (nil → page 1) into the Conduit `limit` / `offset`
+   query pair. Pure, and the one place page arithmetic lives — a page is just
+   another canonical-params key, so there's no reason to do this maths twice."
   [page]
   (let [p (max 1 (or page 1))]
     {:limit  page-size
      :offset (* (dec p) page-size)}))
 
 (defn- with-pagination
-  "Append the `limit` / `offset` query pair derived from `:page` to a list URL
-   that already carries (or lacks) a query string. Keeps the resource
-   `:request` fns terse while every page stays a distinct cache key."
+  "Tack the `limit` / `offset` pair (derived from `:page`) onto a list URL,
+   whether or not it already has a query string. Keeps the resource `:request`
+   fns short while every page stays its own distinct cache key."
   [url page]
   (let [{:keys [limit offset]} (page->limit-offset page)
         sep (if (clojure.string/includes? url "?") "&" "?")]
     (str url sep "limit=" limit "&offset=" offset)))
 
-;; Reads retry; writes don't. Each read's `:request` returns the shared
-;; `rh/data-fetch-retry` policy in its managed-HTTP args; `:retry` passes through
-;; the resource lowering unchanged, so a transport blip / 5xx / timeout retries
-;; with backoff+jitter (NOT a 4xx — the request shape was valid). Mutations
-;; (writes) stay retry-free. See managed HTTP:
+;; A simple rule runs through all of this: reads retry, writes don't. Each read's
+;; `:request` returns the shared `rh/data-fetch-retry` policy in its managed-HTTP
+;; args, and `:retry` rides through the resource lowering untouched — so a
+;; transport blip, a 5xx, or a timeout retries with backoff + jitter. A 4xx does
+;; not; the request shape was valid, so retrying would just be optimism. Mutations
+;; stay retry-free. See managed HTTP:
 ;; ../../../docs/resources/glossary.md#managed-http.
 
 ;; ============================================================================
 ;; PUBLIC READS — :scope :rf.scope/global (same for every viewer)
 ;; ============================================================================
 ;;
-;; The `:scope :rf.scope/global` here is the explicit, AUDITABLE claim that this
-;; read is identical for every user/tenant/locale. There is NO implicit default —
-;; a missing scope policy fails loud at registration. See scope:
+;; `:scope :rf.scope/global` is an explicit, auditable promise: this read is the
+;; same for every user, tenant, and locale. There's no implicit default to lean
+;; on — leave the scope off and registration fails loudly rather than guessing.
+;; Failing closed beats a silent shared cache. See scope:
 ;; ../../../docs/resources/glossary.md#scope.
 
 (rf/reg-resource :realworld/articles
   {:doc            "The global article list, optionally filtered by `:tag` and
-                    paginated by `:page` (1-indexed). EVERY server-visible
-                    option (the tag AND the page) is in params, so a
-                    tag-filtered list, the unfiltered list, and each page are
-                    DISTINCT cache entries. Back-navigating to a
-                    previously-loaded page is a cache-hit; the route's
-                    `:keep-previous?` keeps the prior page visible while the next
-                    first-loads."
+                    paginated by `:page` (1-indexed). Every server-visible option
+                    — both the tag and the page — lives in params, so the
+                    tag-filtered list, the unfiltered list, and each page are all
+                    distinct cache entries. Back-navigate to a page you've already
+                    loaded and it's a cache-hit; the route's `:keep-previous?`
+                    keeps the prior page on screen while the next loads."
    :params-schema  [:map
                     [:tag  {:optional true} [:maybe :string]]
                     [:page {:optional true} [:maybe :int]]]
@@ -116,7 +120,7 @@
    :scope          :rf.scope/global
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
-   ;; Tag the list identity AND every article it contains, so favoriting an
+   ;; Tag the list itself AND every article in it. That way, favoriting one
    ;; article (which tags `[:article slug]`) invalidates any list showing it.
    :tags           (fn [_params data]
                      (into #{[:article-list]}
@@ -138,8 +142,8 @@
    :scope          :rf.scope/global
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
-   ;; Tag BOTH the per-article identity and the list identity so a save /
-   ;; favorite invalidates the detail and the lists together.
+   ;; Tag both the per-article identity and the list identity, so a save or
+   ;; favorite invalidates the detail page and the lists in one go.
    :tags           (fn [{:keys [slug]} _data] #{[:article slug] [:article-list]})}
   (fn [{:keys [slug]} _ctx]
     {:request {:method :get :url (rh/full-url (str "/articles/" slug))}
@@ -147,9 +151,10 @@
      :retry   rh/data-fetch-retry}))
 
 (rf/reg-resource :realworld/comments
-  {:doc            "Comments for an article (public). A sub-resource of the
-                    article modelled as an ordinary resource whose params carry
-                    the parent identity (the slug)."
+  {:doc            "Comments for an article (public). It's a sub-resource of the
+                    article, but there's nothing special about it — just an
+                    ordinary resource whose params carry the parent's identity
+                    (the slug)."
    :params-schema  [:map [:slug :string]]
    :data-schema    schema/CommentsResponse
    :scope          :rf.scope/global
@@ -175,8 +180,8 @@
      :retry   rh/data-fetch-retry}))
 
 (rf/reg-resource :realworld/author-articles
-  {:doc            "Articles authored by a profile (public). Paginated by
-                    `:page` — each page is a distinct cache entry."
+  {:doc            "Articles a profile has authored (public). Paginated by
+                    `:page`, so each page is its own cache entry."
    :params-schema  [:map
                     [:username :string]
                     [:page {:optional true} [:maybe :int]]]
@@ -196,14 +201,14 @@
      :retry   rh/data-fetch-retry}))
 
 (rf/reg-resource :realworld/favorited-articles
-  {:doc            "Articles a profile has FAVORITED (public). GET
-                    `/articles?favorited=:username` — the backing read for the
-                    profile's Favorited-Articles tab. Paginated by `:page`.
-                    Tags both its own list identity AND every article it
-                    contains, so the existing favorite / unfavorite mutations
-                    (which stale `[:article slug]`) refetch this list with no
-                    extra wiring — favoriting from the tab drops the article
-                    out of it on the next refetch."
+  {:doc            "Articles a profile has favorited (public). GET
+                    `/articles?favorited=:username` — the read behind the
+                    profile's Favorited-Articles tab. Paginated by `:page`. It
+                    tags both its own list identity and every article in it, so
+                    the favorite / unfavorite mutations (which stale
+                    `[:article slug]`) refetch this list for free — unfavorite an
+                    article from the tab and it drops out on the next refetch, no
+                    extra wiring required."
    :params-schema  [:map
                     [:username :string]
                     [:page {:optional true} [:maybe :int]]]
@@ -239,29 +244,32 @@
 ;; SESSION READ — a named `{:from-db …}` scope resolver (whose feed?)
 ;; ============================================================================
 ;;
-;; The authenticated user's personalised feed depends on WHO is asking, so it
-;; carries a session scope rather than `:rf.scope/global`. A named resolver
-;; states that scope ONCE — `reg-resource-scope :realworld/session` (see
-;; scope.cljs) — and the resource declares `:scope {:from-db :realworld/session}`:
-;; a reference the runtime resolves at every site against app-db. The result:
+;; The personalised feed is different from everything above: what it returns
+;; depends on WHO is asking. So it can't be `:rf.scope/global` — it carries a
+;; session scope instead. Rather than wire "who's the viewer?" into every site by
+;; hand, a named resolver states that fact once — `reg-resource-scope
+;; :realworld/session` (see scope.cljs) — and the resource just points at it with
+;; `:scope {:from-db :realworld/session}`, a reference the runtime resolves
+;; against app-db wherever it's used. The payoff:
 ;;   - a `[:rf.resource/state {:resource :realworld/feed :params {…}}]` sub
-;;     resolves the scope ITSELF — no view passes a `:scope` payload — and
-;;     re-keys reactively across login / logout;
-;;   - the home route owns the feed as a declarative `:resources` entry with
+;;     resolves the scope itself — no view ever passes a `:scope` payload — and
+;;     re-keys reactively the moment you log in or out;
+;;   - the home route owns the feed as a plain `:resources` entry carrying
 ;;     `:scope {:from-db :realworld/session}` (routing.cljs);
-;;   - logged out, the reference resolves nil — fail-closed: the sub is the loud
-;;     "scope unresolved" condition, never a silent shared-cache read.
+;;   - logged out, the reference resolves to nil, fail-closed: the sub becomes a
+;;     loud 'scope unresolved' signal, never a quiet read of someone else's cache.
 ;; See the named resolver in scope.cljs and
 ;; ../../../docs/resources/how-to/add-auth.md.
 
 (rf/reg-resource :realworld/feed
   {:doc            "The authenticated user's feed (`/articles/feed`). Session-
-                    scoped via the named `{:from-db :realworld/session}`
-                    resolver: a logged-out user must never see a prior user's
-                    feed from cache, and a login / logout re-keys every live
-                    feed subscription automatically. Paginated by `:page` — the
-                    page rides the params on top of the session scope, so each
-                    (scope, page) is a distinct cache entry."
+                    scoped through the named `{:from-db :realworld/session}`
+                    resolver, which buys two guarantees: a logged-out user never
+                    sees a previous user's feed out of cache, and a login or
+                    logout re-keys every live feed subscription on its own.
+                    Paginated by `:page`, which rides the params on top of the
+                    session scope — so each (scope, page) pair is a distinct cache
+                    entry."
    :params-schema  [:map [:page {:optional true} [:maybe :int]]]
    :data-schema    schema/ArticlesResponse
    :scope          {:from-db :realworld/session}

--- a/examples/reagent/realworld_resources/routing.cljs
+++ b/examples/reagent/realworld_resources/routing.cljs
@@ -2,94 +2,96 @@
   "Routes for the RealWorld-on-resources example. See the routing guide:
    ../../../docs/routing/concepts.md.
 
-   The point of this example: route entry CAUSES the page's server-state to load,
-   declaratively, via `:resources` route metadata. On entry the runtime marks
-   each listed resource active with owner `[:route route-id nav-token]` and
-   ensures it with cause `[:route-entry route-id nav-token]`; on leave it
-   releases the owner by token and suppresses any stale reply by generation. The
-   views never fetch — they read the runtime cache passively.
+   The big idea here is worth saying plainly: entering a route is what causes the
+   page's server-state to load — declaratively, via `:resources` route metadata.
+   No view kicks off a fetch. On entry the runtime marks each listed resource
+   active with owner `[:route route-id nav-token]` and ensures it with cause
+   `[:route-entry route-id nav-token]`; on leave it releases the owner by token
+   and suppresses any straggling reply by generation. The views just read the
+   cache, passively. Navigation is the cause; the data follows.
 
-   `:blocking?` keeps the route transition pending until the resource settles; a
-   non-blocking resource fetches in the background. `:keep-previous?` keeps the
-   prior list visible while a new filter/page first-loads. `:when` makes a
-   resource conditional without sentinel nil params.
+   A few knobs shape how each route resource behaves. `:blocking?` holds the route
+   transition pending until the resource settles; a non-blocking one fetches in
+   the background. `:keep-previous?` keeps the current list on screen while a new
+   filter or page loads. `:when` makes a resource conditional without resorting to
+   sentinel nil params.
 
-   (On the server, the same `:blocking?` flag is the SSR wait point. This example
-   is CLIENT-ONLY; the worked demo of resource SSR preload + hydration is
+   (On the server, that same `:blocking?` flag becomes the SSR wait point. This
+   example is client-only; the worked demo of resource SSR preload + hydration is
    `examples/reagent/resources_ssr/`. See ../../../docs/ssr/concepts.md.)
 
-   The SESSION-scoped personalised feed is a declarative route resource too: the
-   home route declares it with `:scope {:from-db :realworld/session}`, a named
-   resolver reference (see scope.cljs) the runtime resolves against the
-   navigation handler's app-db at route entry. So the route owns the feed under
-   its nav-token and releases it on leave, exactly like the public reads. Logged
-   out, the reference resolves nil and the feed entry is simply not planned
-   (fail-closed — no feed to load).
+   The session-scoped personalised feed is a declarative route resource too — no
+   special-casing. The home route declares it with
+   `:scope {:from-db :realworld/session}`, a named resolver reference (see
+   scope.cljs) the runtime resolves against the navigation handler's app-db at
+   route entry. So the route owns the feed under its nav-token and releases it on
+   leave, exactly like the public reads. Logged out, the reference resolves nil
+   and the feed entry simply isn't planned — fail-closed, nothing to load.
 
-   Loading both `re-frame.resources` and `re-frame.routing` is what makes the
-   `:resources` route-metadata key accepted (resources late-binds it into
-   routing)."
+   One wiring note: loading both `re-frame.resources` and `re-frame.routing` is
+   what gets the `:resources` route-metadata key accepted, since resources
+   late-binds it into routing."
   (:require [clojure.string]
             [re-frame.core :as rf]
-            ;; Routing runtime. Loading the ns triggers its hook + reg-sub
-            ;; registrations; without it the reg-route calls throw. Aliased so
-            ;; the popstate handler resolves the URL owner via
+            ;; The routing runtime. Loading it triggers its hook + reg-sub
+            ;; registrations; without it the reg-route calls have nothing to hook
+            ;; into. Aliased so the popstate handler can resolve the URL owner via
             ;; `routing/url-owner-frame-id`.
             [re-frame.routing :as routing]
             ;; Loading resources is what makes `:resources` route-metadata
-            ;; accepted (the late-bound routing extension).
+            ;; accepted — it's the late-bound routing extension.
             [re-frame.resources]))
 
 ;; ============================================================================
 ;; ROUTES — each declares the server-state its page needs via `:resources`
 ;; ============================================================================
 
-;; The route resources for the home page + its tag-filtered sibling. Both
-;; routes plan the same three reads (global list, popular tags, session feed);
-;; they differ only in WHERE the active tag comes from — the `/tag/:tag` route
-;; reads it from PATH params, the bare home route has none. `home-resources`
-;; takes a `tag-fn` so each route supplies its own tag source.
+;; The route resources for the home page and its tag-filtered sibling. Both routes
+;; plan the same three reads — global list, popular tags, session feed — and
+;; differ in only one spot: where the active tag comes from. The `/tag/:tag` route
+;; pulls it from path params; the bare home route has none. So `home-resources`
+;; takes a `tag-fn` and lets each route hand in its own tag source.
 (defn- home-resources [tag-fn]
   [{:resource  :realworld/articles
-    ;; Route → resource params: the active tag (param or nil) AND `?page=` flow
-    ;; into identity. Every server-visible list option participates in the
-    ;; cache key.
+    ;; Route → resource params: the active tag (a param, or nil) and `?page=`
+    ;; both flow into identity. Every server-visible list option earns a place in
+    ;; the cache key.
     :params    (fn [route] {:tag  (tag-fn route)
-                            ;; Default to page 1 so the canonical no-`?page=`
-                            ;; URL owns the SAME `{:page 1}` key the views
-                            ;; subscribe through (`(or (:page q) 1)`); a raw
-                            ;; nil would mint a `{:page nil}` entry no view
-                            ;; reads, leaving first-page lists permanently
-                            ;; empty.
+                            ;; Default to page 1, so the canonical no-`?page=` URL
+                            ;; owns the SAME `{:page 1}` key the views subscribe
+                            ;; through (`(or (:page q) 1)`). A raw nil would mint a
+                            ;; `{:page nil}` entry no view ever reads, which leaves
+                            ;; first-page lists stubbornly empty.
                             :page (or (get-in route [:query :page]) 1)})
     :blocking? true
     :keep-previous? true}
    {:resource  :realworld/tags
     :params    (fn [_route] {})
     :blocking? false}
-   ;; The personalised feed — a declarative route resource scoped by the named
+   ;; The personalised feed — a declarative route resource, scoped by the named
    ;; `{:from-db :realworld/session}` resolver. The runtime resolves the scope
    ;; against the navigation handler's app-db at route entry, owns it under the
-   ;; route nav-token, and releases it on leave, just like the public reads
-   ;; above. Logged out the reference resolves nil, so the feed is simply not
-   ;; planned (no scope, no fetch — the feed never leaks across users). The
-   ;; `?page=` flows into params here like every other paginated list.
+   ;; route nav-token, and releases it on leave, just like the public reads above.
+   ;; Logged out, the reference resolves nil and the feed simply isn't planned —
+   ;; no scope, no fetch, no chance of one user's feed leaking to another. `?page=`
+   ;; flows into params here like every other paginated list.
    {:resource  :realworld/feed
     :scope     {:from-db :realworld/session}
-    ;; Default to page 1 — the feed subscription reads `(or (:page q) 1)`
-    ;; too, so the route must own `{:page 1}` on the bare URL.
+    ;; Default to page 1 — the feed subscription reads `(or (:page q) 1)` too, so
+    ;; the route has to own `{:page 1}` on the bare URL.
     :params    (fn [route] {:page (or (get-in route [:query :page]) 1)})
     :blocking? false
     :keep-previous? true}])
 
 (rf/reg-route :realworld/home
-  {:doc   "Home: the global article list + popular tags, plus (when signed in)
-           the personalised feed. `?feed=following` switches to the session
-           feed (the official-contract token — NOT `?feed=your`) and `?page=`
-           paginates — both flow into the resources' params. `:keep-previous?`
-           keeps the prior page visible while the next first-loads (no
-           flicker). The tag filter is its own `/tag/:tag` PATH route below —
-           the tag is a route param, matching the official Conduit route shape."
+  {:doc   "Home: the global article list and popular tags, plus the personalised
+           feed when you're signed in. `?feed=following` switches to the session
+           feed (the official-contract token — note it's `following`, not `your`)
+           and `?page=` paginates; both flow into the resources' params.
+           `:keep-previous?` keeps the current page on screen while the next loads,
+           so there's no flicker. The tag filter is its own `/tag/:tag` PATH route
+           below — the tag rides as a route param, matching the official Conduit
+           route shape."
    :query [:map
            [:feed {:optional true} :string]
            [:page {:optional true} :int]]
@@ -97,11 +99,11 @@
    :resources (home-resources (fn [_route] nil))} "/")
 
 (rf/reg-route :realworld/home-tag
-  {:doc   "The tag-filtered article list at the official RealWorld `/tag/:tag`
-           PATH route. The active tag is a route PARAM that flows into the
-           articles resource's params, so each tag is a distinct cache entry;
-           `?page=` paginates within it (`/tag/:tag?page=2`). Same three reads
-           as the home route."
+  {:doc   "The tag-filtered article list, at the official RealWorld `/tag/:tag`
+           PATH route. The active tag is a route param that flows into the
+           articles resource's params, so each tag is its own cache entry; `?page=`
+           paginates within it (`/tag/:tag?page=2`). Same three reads as the home
+           route."
    :params [:map [:tag :string]]
    :query  [:map [:page {:optional true} :int]]
    :scroll :top
@@ -114,37 +116,38 @@
   {:doc "Register page."} "/register")
 
 (rf/reg-route :realworld.user/settings
-  {:doc  "User settings page (requires auth). `:on-match` seeds the settings
-          draft from the authenticated user ONCE on route entry. The settings
-          view is then a pure Form-1 that NEVER dispatches out of band, so a
-          re-render does not re-run the load and clobber in-progress field
-          edits."
+  {:doc  "User settings page (requires auth). `:on-match` seeds the settings draft
+          from the authenticated user once, on route entry. With the load happening
+          there rather than in render, the view stays a pure Form-1 that never
+          dispatches out of band — so a re-render can't re-run the load and stomp
+          on edits you've got in flight."
    :on-match [[:settings/load]]
    :tags #{:requires-auth}} "/settings")
 
 (rf/reg-route :realworld.editor/new
-  {:doc       "Create a new article (requires auth). `:on-match` resets the
-               editor slice + registers the can-submit flow; `:can-leave` blocks
-               a navigate-away while the draft is dirty (see route guard,
+  {:doc       "Create a new article (requires auth). `:on-match` resets the editor
+               slice and registers the can-submit flow; `:can-leave` blocks a
+               navigate-away while the draft is dirty (see route guard,
                ../../../docs/routing/glossary.md#route-guard). No route
-               `:resources` — create starts from a blank draft."
+               `:resources` here — you're starting from a blank draft, so there's
+               nothing to load."
    :tags      #{:requires-auth}
    :on-match  [[:editor/initialise]]
    :can-leave [:editor/can-leave?]} "/editor")
 
 (rf/reg-route :realworld.editor/edit
   {:doc       "Edit an existing article (requires auth). `:on-match` seeds the
-               editor from the article read under a releaseable lease (the
-               editor page's load reaction copies the settled data into the
-               draft + baseline); `:can-leave` blocks a dirty navigate-away."
+               editor from the article read under a releaseable lease — the editor
+               page's load reaction copies the settled data into the draft and
+               baseline. `:can-leave` blocks a dirty navigate-away."
    :params    [:map [:slug :string]]
    :tags      #{:requires-auth}
    :on-match  [[:editor/load-article]]
    :can-leave [:editor/can-leave?]} "/editor/:slug")
 
 (rf/reg-route :realworld.article/show
-  {:doc    "Article detail + its comments. Both load on entry; the comments
-            are a sub-resource keyed by the same slug."
+  {:doc    "Article detail plus its comments. Both load on entry; the comments are
+            a sub-resource keyed by the same slug."
    :params [:map [:slug :string]]
    :scroll :top
    :resources
@@ -158,8 +161,8 @@
      :keep-previous? true}]} "/article/:slug")
 
 (rf/reg-route :realworld.profile/show
-  {:doc    "A user's profile banner + the articles they AUTHORED (the default
-            profile tab). The `?page=` query paginates the authored list."
+  {:doc    "A user's profile banner plus the articles they authored — the default
+            profile tab. The `?page=` query paginates the authored list."
    :params [:map [:username :string]]
    :query  [:map [:page {:optional true} :int]]
    :resources
@@ -174,13 +177,13 @@
      :keep-previous? true}]} "/profile/:username")
 
 (rf/reg-route :realworld.profile/favorites
-  {:doc    "A user's profile banner + the articles they FAVORITED (the second
-            official profile tab — `/profile/:username/favorites`). Same banner
-            read as `:realworld.profile/show`; the list read is the
-            `:realworld/favorited-articles` resource. The `?page=` query
-            paginates it. Favoriting / unfavoriting from this tab invalidates
-            `[:article slug]`, which this list carries, so it refetches and the
-            article drops out on unfavorite."
+  {:doc    "A user's profile banner plus the articles they favorited — the second
+            official profile tab (`/profile/:username/favorites`). Same banner read
+            as `:realworld.profile/show`; the list read is the
+            `:realworld/favorited-articles` resource, and `?page=` paginates it.
+            Favoriting / unfavoriting from this tab invalidates `[:article slug]`,
+            which this list carries — so it refetches, and an unfavorited article
+            drops right out."
    :params [:map [:username :string]]
    :query  [:map [:page {:optional true} :int]]
    :resources
@@ -201,12 +204,13 @@
 ;; AUTH GUARD
 ;; ============================================================================
 ;;
-;; Route-level auth is a plain interceptor. It redirects unauthenticated users
-;; away from any `:requires-auth`-tagged route to login, stashing the intended
-;; target under `[:auth :return-to]` for post-login bounce-back. Gates all three
-;; navigation entry points (programmatic nav, anchor click, URL-bar / popstate)
-;; so a protected route is unreachable logged-out by any path. See route guard:
-;; ../../../docs/routing/glossary.md#route-guard.
+;; Route-level auth turns out to be nothing exotic — just a plain interceptor. It
+;; redirects unauthenticated users away from any `:requires-auth`-tagged route to
+;; login, stashing where they were headed under `[:auth :return-to]` so we can
+;; bounce them back afterward. Crucially it guards all three navigation entry
+;; points — programmatic nav, anchor click, and URL-bar / popstate — so there's no
+;; back door: a protected route is unreachable while logged out, by any path. See
+;; route guard: ../../../docs/routing/glossary.md#route-guard.
 
 (defn- resolve-nav-target [[ev-id a _b]]
   (case ev-id
@@ -220,16 +224,17 @@
                                   {:id route-id :params (or params {})})
     nil))
 
-;; The guard is a REGISTERED interceptor referenced BY ID
+;; The guard is a registered interceptor, referenced by id
 ;; (`:realworld-resources.routing/auth-guard`) from the demo frame's
 ;; `:interceptors` chain — set in the `frame-provider {:id …}` ensure form in
-;; core.cljs, not an inline value. `reg-interceptor` is a top-level load-time
-;; registration; core.cljs requires this ns, so the descriptor is registered
-;; before the provider's config resolves the reference at frame creation.
+;; core.cljs rather than dropped in inline. The timing works out because
+;; `reg-interceptor` is a top-level load-time registration, and core.cljs requires
+;; this ns: the descriptor is registered well before the provider's config goes
+;; looking for it at frame creation.
 (rf/reg-interceptor :realworld-resources.routing/auth-guard
   {:doc "Route-level auth guard: redirect unauthenticated users away from
-         `:requires-auth`-tagged routes to login, stashing the intended target
-         for post-login bounce-back."}
+         `:requires-auth`-tagged routes to login, stashing where they were going
+         for a post-login bounce-back."}
   {:before (fn auth-guard-before [ctx]
              (if-let [{:keys [id params]} (resolve-nav-target (get-in ctx [:coeffects :event]))]
                (let [route-meta  (rf/handler-meta :route id)

--- a/examples/reagent/realworld_resources/schema.cljs
+++ b/examples/reagent/realworld_resources/schema.cljs
@@ -1,22 +1,23 @@
 (ns realworld-resources.schema
   "Malli schemas for the RealWorld-on-resources (Conduit) example.
 
-   These describe the wire payloads the RealWorld API returns. There are no
-   app-db slice schemas for the reads — the cached server-state lives in the
-   framework-owned runtime partition (`:rf.runtime/resources`), not in app-db, so
-   there are no `:articles` / `:article` / `:comments` / `:profile` slice paths to
-   validate. What stays in app-db here is only the small auth slice and the
-   per-form drafts.
+   Mostly these describe the wire payloads the RealWorld API returns. Notice what
+   they DON'T describe: there are no app-db slice schemas for any of the reads.
+   That's because the cached server-state lives in the framework-owned runtime
+   partition (`:rf.runtime/resources`), not in app-db — so there are no
+   `:articles` / `:article` / `:comments` / `:profile` paths in app-db to
+   validate in the first place. All app-db actually holds here is the small auth
+   slice and the per-form drafts.
 
-   The wire shapes double as resource `:data-schema` values and as the `:decode`
-   schemas inside each resource / mutation `:request`. See schema:
-   ../../../docs/guide/glossary.md#schema.
+   The wire shapes pull double duty: they're the resource `:data-schema` values
+   AND the `:decode` schemas inside each resource / mutation `:request`. See
+   schema: ../../../docs/guide/glossary.md#schema.
 
    The RealWorld API spec is documented at:
      https://github.com/gothinkster/realworld/tree/main/api"
   (:require [re-frame.core :as rf]
-            ;; The schemas runtime. Loading the ns registers the hooks so
-            ;; rf/reg-app-schemas resolves at the call site below.
+            ;; The schemas runtime. Loading it registers the hooks, so
+            ;; rf/reg-app-schemas has something to resolve at the call site below.
             [re-frame.schemas])
   (:require-macros [re-frame.core :refer [with-frame]]))
 
@@ -27,14 +28,14 @@
 (def User
   "The authenticated user. Returned by /users/login, /users (register),
    /user (current user), and PUT /user (settings update)."
-  ;; The JWT is classified at the transient slot that introduces it, via the
-  ;; per-slot `:sensitive?` malli property on the `:decode` schema. `UserResponse`
-  ;; is the `:decode` schema for the login / register / restore / settings
-  ;; replies, so this redacts the token out of any off-box capture of the response
-  ;; body. The durable copy at [:auth :token] is classified separately by the
-  ;; `:sensitive` effect in core.cljs (classification does not propagate — each
-  ;; surface is declared on its own). See data classification:
-  ;; ../../../docs/guide/glossary.md#data-classification.
+  ;; The JWT is classified right at the transient slot that introduces it, via a
+  ;; per-slot `:sensitive?` Malli property on the `:decode` schema. Since
+  ;; `UserResponse` is the `:decode` schema for the login / register / restore /
+  ;; settings replies, this one declaration redacts the token from any off-box
+  ;; capture of the response body. The durable copy at [:auth :token] is a
+  ;; separate matter, classified by the `:sensitive` effect in core.cljs —
+  ;; classification doesn't propagate, so each surface declares its own. See data
+  ;; classification: ../../../docs/guide/glossary.md#data-classification.
   [:map
    [:email    :string]
    [:token    {:sensitive? true} :string]
@@ -79,10 +80,10 @@
 ;; WIRE-RESPONSE WRAPPERS
 ;; ============================================================================
 ;;
-;; The Conduit API wraps every payload in a singular/plural top-level key.
-;; These schemas describe the wire envelope; they are passed as `:decode` inside
-;; each resource / mutation `:request` (the resource transport lowers the decode
-;; onto managed HTTP).
+;; The Conduit API wraps every payload in a singular or plural top-level key
+;; (`{:article …}`, `{:articles […]}`, and so on). These schemas describe that
+;; envelope, and they get passed as `:decode` inside each resource / mutation
+;; `:request` — the resource transport lowers the decode onto managed HTTP.
 
 (def UserResponse     [:map [:user User]])
 (def ProfileResponse  [:map [:profile Profile]])
@@ -98,17 +99,18 @@
 ;; APP-DB SLICES — only what app-db still owns
 ;; ============================================================================
 ;;
-;; The cached reads live in runtime-db, not app-db. The only app-db schema is the
-;; auth slice plus the two auth form drafts. (The settings form is a mutation
-;; instance + a small draft slice; the auth machine snapshot lives in runtime-db
-;; and is validated by its own `:data-schema`, not an app-schema.)
+;; With the cached reads living in runtime-db, app-db is left with very little to
+;; validate: just the auth slice and the two auth form drafts. (The settings form
+;; is a mutation instance plus a small draft slice; the auth machine snapshot
+;; lives in runtime-db and is validated by its own `:data-schema`, not an
+;; app-schema.)
 
 (def AuthSlice
-  "The auth slice. :user holds the current User payload (or nil); :token is
-   the JWT (or nil). The resource cache scope is derived from :user's :username
-   by the named session resolver (see realworld-resources.scope), not stored
-   here. :return-to is the optional post-login bounce-back target stashed by
-   the routing auth-guard."
+  "The auth slice. :user holds the current User payload (or nil); :token is the
+   JWT (or nil). The resource cache scope isn't stored here — it's derived from
+   :user's :username by the named session resolver (see
+   realworld-resources.scope). :return-to is the optional post-login bounce-back
+   target the routing auth-guard stashes."
   [:map
    [:user      [:maybe User]]
    [:token     [:maybe :string]]
@@ -118,10 +120,10 @@
      [:params [:maybe :map]]]]])
 
 (def FormSlice
-  "The standard form draft slice for the login / register / settings drafts that
-   live in app-db. The submission lifecycle is a mutation INSTANCE
-   (`:rf.mutation/state`), so this slice carries only the editable draft +
-   touched-field bookkeeping."
+  "The standard form-draft slice, shared by the login / register / settings
+   drafts in app-db. The submission lifecycle isn't here — that's a mutation
+   instance (`:rf.mutation/state`) — so this slice carries only the editable draft
+   plus a little touched-field bookkeeping."
   [:map
    [:draft   :map]
    [:touched [:set :keyword]]
@@ -135,12 +137,12 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 ;;
-;; reg-app-schemas is frame-local: a bare ns-load call with no frame context
-;; fails. This example runs in `:rf/default` (the `frame-provider {:id …}` form
-;; in core.cljs creates it at the render root), so name it here. This is a
-;; frame-local REGISTRATION scoped by id, not a frame-creation/seed — it binds
-;; the id at ns-load; the frame itself is created later when the provider first
-;; renders.
+;; reg-app-schemas is frame-local, so a bare ns-load call with no frame context
+;; would fail. This app runs in `:rf/default` (the `frame-provider {:id …}` form
+;; in core.cljs creates it at the render root), so we name that id here. Worth
+;; being precise about what this is: a frame-local registration scoped by id, not
+;; a frame creation or seed. It binds the id at ns-load; the frame itself doesn't
+;; exist until the provider first renders.
 
 (with-frame :rf/default
   (rf/reg-app-schemas

--- a/examples/reagent/realworld_resources/scope.cljs
+++ b/examples/reagent/realworld_resources/scope.cljs
@@ -1,73 +1,75 @@
 (ns realworld-resources.scope
   "The resource cache SCOPE for this app — the fail-closed leak boundary,
-   expressed as a NAMED resource-scope resolver (`reg-resource-scope`). See
-   scope: ../../../docs/resources/glossary.md#scope, and the worked walkthrough
-   in ../../../docs/resources/how-to/add-auth.md.
+   written as a named resource-scope resolver (`reg-resource-scope`). See scope:
+   ../../../docs/resources/glossary.md#scope, and the worked walkthrough in
+   ../../../docs/resources/how-to/add-auth.md.
 
-   Scope is the cache's tenant / user / permission boundary, and it MUST fail
-   closed: a resource never silently defaults to a shared cache. This example
-   reads two KINDS of server-state, so it demonstrates BOTH scope policies:
+   Scope is the cache's tenant / user / permission boundary, and the cardinal
+   rule is that it fails closed: a resource never silently falls back to a shared
+   cache. This app reads two kinds of server-state, which makes it a nice place to
+   see both scope policies side by side:
 
-   - PUBLIC reads — the global article list, a tag-filtered list, an article's
+   - Public reads — the global article list, a tag-filtered list, an article's
      detail, an author profile, the popular-tags sidebar, an article's comments.
-     These are the same for every viewer, so each resource declares the explicit,
+     These look the same to every viewer, so each resource makes the explicit,
      auditable `:scope :rf.scope/global` claim.
 
-   - SESSION reads — the authenticated user's personalised feed
-     (`/articles/feed`). What that returns depends on WHO is asking, so it carries
+   - Session reads — the authenticated user's personalised feed
+     (`/articles/feed`). What that returns depends on who's asking, so it carries
      a session scope `[:rf.scope/session {:username …}]`. A logged-out user must
-     never see the previous user's feed from cache.
+     never catch a glimpse of the previous user's feed out of cache.
 
    ## One named resolver, every site
 
-   The session/feed seam answers one fact — \"who is the current viewer?\" — and a
-   named resource-scope resolver states that fact ONCE rather than wiring it by
-   hand at every site. `reg-resource-scope :realworld/session` with declared db
-   inputs names that fact once, and every site references it as
+   The whole session/feed seam turns on a single fact — 'who is the current
+   viewer?' — and rather than answer it by hand at every site, a named resolver
+   answers it once. `reg-resource-scope :realworld/session`, with declared db
+   inputs, states that fact a single time, and every site just points at it with
    `{:from-db :realworld/session}`:
 
    - the feed RESOURCE declares `:scope {:from-db :realworld/session}`
-     (resources.cljs), so a subscription resolves the scope itself — no view
-     threads a scope payload, and the sub re-keys reactively across login /
-     logout;
+     (resources.cljs), so a subscription resolves the scope itself — no view ever
+     threads a scope payload, and the sub re-keys reactively across login/logout;
    - the home ROUTE declares the feed as a `:resources` entry with
      `:scope {:from-db :realworld/session}` (routing.cljs) — resolved against the
      navigation handler's app-db at route entry, owned by the nav-token, released
      on leave. No `:on-match` event, no app-minted lease;
    - the favourite / unfavourite MUTATIONS carry a per-target invalidation
      descriptor `{:scope {:from-db :realworld/session} :tags #{[:feed]}}`
-     (mutations.cljs) — one mutation invalidates global article tags AND the
-     session feed, so no app-level cross-scope patch is needed;
+     (mutations.cljs) — so one mutation can invalidate the global article tags AND
+     the session feed, with no app-level cross-scope patching;
    - LOGOUT resolves the concrete old scope with the pure
      `rf/resolve-resource-scope` helper against the coeffect db and clears it
      (auth.cljs).
 
-   `nil` is the fail-closed unresolved condition everywhere: a logged-out
-   subscription is the loud \"scope unresolved\" diagnostic, not a silent shared
-   read; a logged-out route entry / invalidation descriptor resolves nil and does
-   nothing (no feed to reach); logout resolves nil and skips the clear."
+   And everywhere, `nil` is the fail-closed 'unresolved' answer. A logged-out
+   subscription becomes a loud 'scope unresolved' signal rather than a quiet read
+   of shared data; a logged-out route entry or invalidation descriptor resolves
+   nil and simply does nothing (no feed to reach); logout resolves nil and skips
+   the clear. One idea, applied consistently."
   (:require [re-frame.core :as rf]
-            ;; Resources ship `reg-resource-scope`; requiring the ns wires the
-            ;; hooks so the macro resolves.
+            ;; Resources ships `reg-resource-scope`; requiring the ns wires up the
+            ;; hooks so the macro has something to resolve against.
             [re-frame.resources]))
 
 ;; ============================================================================
 ;; THE NAMED SESSION SCOPE RESOLVER
 ;; ============================================================================
 ;;
-;; `reg-resource-scope` registers a PURE resolver under an id; every derived-scope
-;; site references it as `{:from-db :realworld/session}`. The declared `:inputs`
-;; name the single app-db fact that decides the scope — the authenticated user's
-;; `:username` — so the runtime re-resolves the scope only when THAT path changes
-;; (login / logout / account switch), and tooling can explain which fact decides a
-;; resource's identity. `:resolve` is pure: it derives the canonical session-scope
-;; value, or `nil` when logged out (the fail-closed unresolved condition).
+;; `reg-resource-scope` registers a pure resolver under an id, and every
+;; derived-scope site points at it with `{:from-db :realworld/session}`. The
+;; declared `:inputs` name the one app-db fact that decides the scope — the
+;; authenticated user's `:username` — which earns two things: the runtime
+;; re-resolves the scope only when that exact path changes (login, logout, account
+;; switch), and tooling can tell you precisely which fact decides a resource's
+;; identity. `:resolve` is pure: it builds the canonical session-scope value, or
+;; returns `nil` when logged out (the fail-closed 'unresolved' answer).
 
 (rf/reg-resource-scope :realworld/session
   {:doc     "The current session's resource cache scope — the per-user leak
-             boundary made explicit and auditable. Derived from the one app-db
-             fact that decides it (the authenticated user's username); nil when
-             logged out (fail-closed)."
+             boundary, made explicit and auditable. Derived from the single
+             app-db fact that decides it (the authenticated user's username), and
+             nil when logged out (fail-closed)."
    :inputs  {:username [:db [:auth :user :username]]}
    :resolve (fn [{:keys [username]} _ctx]
               (when username
@@ -78,11 +80,11 @@
 ;; ============================================================================
 
 (defn session-scope
-  "The concrete session cache scope for a given user map, or nil when logged
-   out — a plain data value `[:rf.scope/session {:username …}]`. The resource
-   sites use the named `{:from-db :realworld/session}` reference (resolved by
-   the runtime); this helper is kept for the rare site that needs the concrete
-   value in hand (e.g. building a non-resource diagnostic)."
+  "The concrete session cache scope for a given user map, or nil when logged out
+   — just a plain data value, `[:rf.scope/session {:username …}]`. The resource
+   sites all use the named `{:from-db :realworld/session}` reference and let the
+   runtime resolve it; this helper is here for the rare spot that needs the
+   concrete value in hand, like building a non-resource diagnostic."
   [user]
   (when-let [username (:username user)]
     [:rf.scope/session {:username username}]))

--- a/examples/reagent/realworld_resources/settings.cljs
+++ b/examples/reagent/realworld_resources/settings.cljs
@@ -1,35 +1,35 @@
 (ns realworld-resources.settings
   "User-settings page for the RealWorld-on-resources example.
 
-   Settings update is a WRITE, so it is a MUTATION (`:realworld/update-settings`
-   in realworld-resources.mutations): the form fires `:rf.mutation/execute` and
-   watches the instance through `[:rf.mutation/state {:instance …}]` (`:pending?`
-   / `:success?` / `:error?`), with NO app-db submission-status slice to maintain.
-   On success the saved User comes back as the reply value; the continuation
-   pushes it into the auth slice and navigates to the profile, and the mutation's
-   `:invalidates` clears the public profile read so a later visit re-reads the new
-   bio.
+   Updating settings is a write, so it's a mutation (`:realworld/update-settings`
+   over in realworld-resources.mutations). The form fires `:rf.mutation/execute`
+   and watches the instance through `[:rf.mutation/state {:instance …}]`
+   (`:pending?` / `:success?` / `:error?`), with no app-db submission-status slice
+   to keep in sync. On success the saved User comes back as the reply value; the
+   continuation pushes it into the auth slice and navigates to the profile, and
+   the mutation's `:invalidates` clears the public profile read so a later visit
+   re-reads the new bio.
 
-   What stays in app-db is only the editable DRAFT (the live field values) — the
+   The only thing app-db holds is the editable draft — the live field values. The
    lifecycle (`:idle` / `:pending` / `:success` / `:error`) is the mutation
-   instance, not a `:status` field.
+   instance, not a `:status` field you maintain.
 
-   SUCCESS CONTINUATION — a call-site `:reply-to`. The submit passes
-   `:reply-to [:settings/replied]` to `:rf.mutation/execute`; when the runtime
-   ACCEPTS the reply as current (frame + instance + work-id + generation matched),
-   it dispatches `[:settings/replied reply]` exactly once, with the canonical
-   reply map appended — AFTER cache consequences and instance settlement have
-   applied. The continuation reads `(:status reply)` to fold the saved User on
-   `:ok` and surface the error on `:error`. A stale / superseded reply never fires
-   it.
+   The success continuation is a call-site `:reply-to`, and it's worth a beat. The
+   submit passes `:reply-to [:settings/replied]` to `:rf.mutation/execute`; when
+   the runtime accepts the reply as current — frame, instance, work-id, and
+   generation all matched — it dispatches `[:settings/replied reply]` exactly
+   once, with the canonical reply map appended, AFTER the cache consequences and
+   instance settlement have landed. The continuation reads `(:status reply)` to
+   fold in the saved User on `:ok` and surface the error on `:error`. A stale or
+   superseded reply never fires it.
 
-   `:reply-to` is the mutation's reply-side continuation — a CAUSAL EVENT TARGET
-   (an ordinary event through the tape / interceptors / replay), not a callback.
-   It keeps the view a plain Form-1: a pure function of subs that never dispatches
-   out of band. The alternative — an off-render Form-3 `reagent.ratom/run!`
-   reaction watching `[:rf.mutation/state …]` for settlement — pulls a
-   side-effecting reaction into the view; `:reply-to` gives the same settle hook
-   as a declarative, replayable event target. See the reply map:
+   The why behind `:reply-to`: it's a causal event target — an ordinary event,
+   flowing through the tape / interceptors / replay — not a callback. That's what
+   lets the view stay a plain Form-1, a pure function of subs that never dispatches
+   out of band. The alternative would be an off-render Form-3 `reagent.ratom/run!`
+   reaction watching `[:rf.mutation/state …]` for settlement, which drags a
+   side-effecting reaction into the view. `:reply-to` gives you the same settle
+   hook as a declarative, replayable event instead. See the reply map:
    ../../../docs/resources/glossary.md#reply-map."
   (:require [re-frame.core :as rf]
             [re-frame.resources]
@@ -37,8 +37,8 @@
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 (def settings-instance
-  "A single, stable instance id for the settings submission — the form watches
-   exactly this instance."
+  "One stable instance id for the settings submission — the form watches exactly
+   this instance, nothing else."
   :settings/save)
 
 (defn- draft-from-user [user]
@@ -53,11 +53,12 @@
 ;; ============================================================================
 
 (rf/reg-event :settings/load
-  {:doc "Seed the settings draft from the authenticated user. Dispatched ONCE on
-         route entry via the settings route's `:on-match` (the page is
-         auth-guarded, so a user is always present here). Seeding on route entry
-         — not from the view's render — is what keeps the form a pure Form-1: a
-         re-render never re-runs the load, so in-progress field edits survive."}
+  {:doc "Seed the settings draft from the authenticated user. Dispatched once, on
+         route entry, via the settings route's `:on-match` — the page is
+         auth-guarded, so there's always a user here. Doing the seed on route
+         entry rather than in the view's render is exactly what keeps the form a
+         pure Form-1: a re-render never re-runs the load, so edits you've got in
+         flight survive."}
   (fn [{:keys [db]} _]
     {:db (assoc-in db [:settings-form :draft] (draft-from-user (get-in db [:auth :user])))}))
 
@@ -70,9 +71,9 @@
 
 (rf/reg-event :settings/submit
   {:doc "Fire the update-settings mutation with the current draft. The form
-         watches the `:settings/save` instance for pending / error; the success
-         continuation is the call-site `:reply-to [:settings/replied]` target,
-         dispatched once when the reply is accepted."}
+         watches the `:settings/save` instance for pending / error, and the
+         success continuation is the call-site `:reply-to [:settings/replied]`
+         target, dispatched once when the reply is accepted."}
   (fn [{:keys [db]} _]
     (let [draft (get-in db [:settings-form :draft])]
       {:fx [[:dispatch [:rf.mutation/execute
@@ -83,14 +84,14 @@
                          :cause    [:submit :settings/save]}]]]})))
 
 (rf/reg-event :settings/replied
-  {:doc "The update-settings mutation completion continuation (the `:reply-to`
-         target). Receives the canonical reply map appended as the final arg —
-         observed AFTER the mutation's `:invalidates` cleared the public profile
-         read and the instance settled. On `:ok` push the saved User (the reply
-         `:value`) into the auth slice, clear the instance, and navigate to the
-         user's profile. On `:error` the form already shows the error off the
-         instance state — nothing more to do here. Clearing the instance also
-         makes the dispatch idempotent."}
+  {:doc "The update-settings completion continuation (the `:reply-to` target). It
+         receives the canonical reply map as its final arg, observed AFTER the
+         mutation's `:invalidates` cleared the public profile read and the instance
+         settled. On `:ok`, push the saved User (the reply `:value`) into the auth
+         slice, clear the instance, and navigate to the user's profile. On
+         `:error` there's nothing to do here — the form already shows it off the
+         instance state. Clearing the instance also keeps the dispatch
+         idempotent."}
   (fn [_ [_ {:keys [status value]}]]
     (if (= :ok status)
       (let [user (:user value)]
@@ -105,13 +106,13 @@
 ;; VIEW  (pure Form-1 render — never dispatches out of band)
 ;; ============================================================================
 ;;
-;; The render is a normal registered `reg-view` (Form-1): a pure function of subs
-;; that NEVER dispatches. The success continuation is the mutation's `:reply-to`
-;; target, not an off-render reaction — so the view holds no lifecycle hooks at
-;; all.
+;; The render is an ordinary registered `reg-view` (Form-1): a pure function of
+;; subs that never dispatches. Because the success continuation is the mutation's
+;; `:reply-to` target rather than an off-render reaction, the view ends up with no
+;; lifecycle hooks at all — which is rather the point.
 
 (reg-view ^{:doc "The settings form — a pure function of subs. Submit fires the
-                   update-settings mutation; the success continuation is the
+                   update-settings mutation, and the success continuation is the
                    mutation's `:reply-to` target, so this view never dispatches
                    out of band."}
           settings-page []

--- a/examples/reagent/realworld_resources/views.cljs
+++ b/examples/reagent/realworld_resources/views.cljs
@@ -1,30 +1,30 @@
 (ns realworld-resources.views
-  "Views + the small event glue for the RealWorld-on-resources example.
+  "Views and the small event glue for the RealWorld-on-resources example.
 
-   Every page reads its server-state PASSIVELY through `[:rf.resource/*]` subs —
-   no view fetches. The route's `:resources` metadata caused the load. The cond
-   over `:loading?` / `:has-data?` / `:error` / `:fetching?` / `:refresh-error` is
-   the canonical resource render shape:
-   - `:loading?`                         → skeleton (first load, no data)
-   - `:error` AND NOT `:has-data?`       → error (first load failed)
-   - else render `:data`, plus a quiet refresh indicator while `:fetching?`,
-     plus a refresh warning when a background refresh failed (`:refresh-error`,
-     prior data kept).
+   The thing to hold onto across this whole namespace: no view ever fetches. Every
+   page reads its server-state passively, through `[:rf.resource/*]` subs — the
+   route's `:resources` metadata is what caused the load. And rendering a resource
+   follows one canonical shape, a cond over its status:
+   - `:loading?`                   → skeleton (first load, nothing to show yet)
+   - `:error` AND NOT `:has-data?` → error (the first load failed outright)
+   - otherwise                     → render `:data`, plus a quiet refresh indicator
+     while `:fetching?`, plus a warning if a background refresh failed
+     (`:refresh-error`, with the prior data still kept on screen).
    See resource status: ../../../docs/resources/glossary.md#resource-status.
 
-   WRITES fire mutations (`:rf.mutation/execute`) and watch the instance
-   passively (`[:rf.mutation/state {:instance …}]`); the success continuation is
+   Writes fire mutations (`:rf.mutation/execute`) and watch the instance just as
+   passively (`[:rf.mutation/state {:instance …}]`). The success continuation is
    the call-site `:reply-to` event target, dispatched once when the reply is
-   accepted, AFTER the mutation's `:invalidates` refetched the affected reads —
-   the read→write→invalidate→refetch loop, end to end, with NO off-render
-   reactions in this ns.
+   accepted — AFTER the mutation's `:invalidates` refetched the affected reads.
+   That's the read→write→invalidate→refetch loop, end to end, with not a single
+   off-render reaction anywhere in this ns.
 
-   Scope: every page reads through `[:rf.resource/*]` subs that resolve their OWN
-   scope. The public reads carry the sub-resolvable `:rf.scope/global` policy; the
-   session-scoped feed declares `:scope {:from-db :realworld/session}`
+   On scope: every page reads through `[:rf.resource/*]` subs that resolve their
+   own scope. The public reads carry the sub-resolvable `:rf.scope/global` policy;
+   the session-scoped feed declares `:scope {:from-db :realworld/session}`
    (resources.cljs), a named-resolver reference the subscription resolves against
-   app-db and RE-KEYS reactively across login / logout. No view threads a
-   `:scope` payload — the resolver is the single scope-resolution currency."
+   app-db and re-keys reactively across login / logout. No view ever threads a
+   `:scope` payload — the resolver is the one and only place scope gets resolved."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.resources]
@@ -38,21 +38,22 @@
 ;; HOME-PAGE QUERY HELPERS — navigation is events; reads follow the route
 ;; ============================================================================
 ;;
-;; Switching feed / applying a tag is a NAVIGATION (`:rf.route/navigate`); the
-;; route's `:resources` then re-ensure the right reads. The view does not fetch
-;; — it changes the URL and the declarative route plan does the rest. The
+;; Switching feed or applying a tag is a navigation (`:rf.route/navigate`), and the
+;; route's `:resources` then re-ensure the right reads. So the view never fetches —
+;; it just changes the URL, and the declarative route plan handles the rest. The
 ;; personalised feed is one of those route resources, scoped by the named
-;; `{:from-db :realworld/session}` resolver (routing.cljs / resources.cljs) —
-;; so the home page needs no `:on-match` event to ensure it by hand.
+;; `{:from-db :realworld/session}` resolver (routing.cljs / resources.cljs), so the
+;; home page needs no `:on-match` event to ensure it by hand.
 
-;; ROUTE-SHAPE CONFORMANCE: the tag filter is the `/tag/:tag` PATH
-;; route (`:realworld/home-tag`) — the active tag is a route PARAM, not a
-;; `?tag=` query — and the following feed uses `?feed=following` (NOT `your`).
+;; A couple of route-shape details, to match the official Conduit contract: the
+;; tag filter is the `/tag/:tag` PATH route (`:realworld/home-tag`), so the active
+;; tag is a route param rather than a `?tag=` query, and the following feed uses
+;; `?feed=following` (not `your`).
 ;;
-;; Switching feed / tab / tag RESETS pagination to page 1 (a new filter is a
-;; fresh list); paging KEEPS the current feed + tag and only changes `?page=`.
-;; The page lives in the route query, so it flows straight into the resource
-;; params — no page-cache map, no `:status` field.
+;; Switching feed / tab / tag resets pagination to page 1 — a new filter is a fresh
+;; list, after all — while paging keeps the current feed and tag and changes only
+;; `?page=`. The page lives in the route query, so it flows straight into the
+;; resource params: no page-cache map, no `:status` field.
 
 (def following-feed-token "following")
 
@@ -68,11 +69,11 @@
 (rf/reg-event :home/clear-tag
   (fn [_ _] {:fx [[:dispatch [:rf.route/navigate :realworld/home]]]}))
 
-;; Page navigation preserves the active feed + tag (read off the live route)
-;; and swaps only `?page=` — so page N and N+1 share filter but are distinct
-;; cache keys. A tag-filtered page re-targets the `/tag/:tag` PATH route with
-;; the tag param preserved; otherwise the home route carries `?feed=`. Page 1
-;; drops the `?page=` param entirely (the canonical first-page URL).
+;; Paging keeps the active feed and tag (read off the live route) and swaps only
+;; `?page=`, so page N and N+1 share a filter but live under distinct cache keys.
+;; A tag-filtered page re-targets the `/tag/:tag` PATH route with the tag param
+;; preserved; otherwise the home route carries `?feed=`. Page 1 drops the `?page=`
+;; param entirely — that's the canonical first-page URL.
 (rf/reg-event :home/go-to-page
   (fn [{rt :rf.db/runtime} [_ page]]
     (let [current (get-in rt [:rf.runtime/routing :current])
@@ -94,10 +95,11 @@
 ;; FAVORITE / FOLLOW — fire a mutation, watch its instance
 ;; ============================================================================
 ;;
-;; Auth-gated: favoriting / following needs a session, so a logged-out click
-;; navigates to login rather than firing a tokenless write (the real Conduit
-;; backend would 401). One instance id per (verb, slug/username) so concurrent
-;; toggles on different articles don't clobber each other.
+;; These are auth-gated: favoriting and following both need a session, so a
+;; logged-out click bounces to login instead of firing a tokenless write (which
+;; the real Conduit backend would 401 anyway). One instance id per (verb,
+;; slug/username), so toggling two different articles at once doesn't let one
+;; clobber the other.
 
 (rf/reg-event :ui/favorite
   (fn [{:keys [db]} [_ slug favorited?]]
@@ -123,23 +125,23 @@
 ;; ARTICLE-DETAIL SOCIAL CONTROLS
 ;; ----------------------------------------------------------------------------
 ;;
-;; The official Conduit article page carries contextual controls: a non-author
-;; viewer follows/unfollows the AUTHOR; the author sees Edit (→ /editor/:slug)
-;; and Delete. Logged-out viewers see neither. Both the follow continuation and
-;; the delete continuation are call-site `:reply-to` targets — the mutation
-;; reply-side seam, declared at the call site rather than emulated with Form-3
-;; settle reactions on the article page.
+;; The Conduit article page shows different controls depending on who's looking. A
+;; non-author viewer gets Follow/Unfollow for the author; the author gets Edit (→
+;; /editor/:slug) and Delete; a logged-out viewer gets neither. Both the follow and
+;; the delete continuations are call-site `:reply-to` targets — the mutation
+;; reply-side seam, declared right where the write happens, rather than emulated
+;; with Form-3 settle reactions bolted onto the article page.
 
 (rf/reg-event :ui/follow-author
-  {:doc "Follow / unfollow the article author from the detail page. Fires the
-         follow / unfollow mutation; the detail page's embedded `:author` lives in
-         the `[:article slug]` entry (not the `[:profile username]` resource the
-         follow mutation invalidates), so the article is re-staled when the follow
-         SETTLES — by the `:reply-to [:ui/follow-author-replied slug]`
-         continuation, which carries the slug. (Staling eagerly here would refetch
-         before the server processed the follow, so the embedded flag would read
-         its old value; the continuation fires AFTER the accepted reply.)
-         Auth-gated."}
+  {:doc "Follow / unfollow the article author, from the detail page. It fires the
+         follow / unfollow mutation, but there's a wrinkle: the detail page's
+         embedded `:author` lives in the `[:article slug]` entry, not the
+         `[:profile username]` resource the follow mutation invalidates. So the
+         article is re-staled only once the follow SETTLES, by the
+         `:reply-to [:ui/follow-author-replied slug]` continuation (which carries
+         the slug). Staling eagerly here would refetch before the server had even
+         processed the follow, leaving the embedded flag reading its old value —
+         the continuation waits for the accepted reply instead. Auth-gated."}
   (fn [{:keys [db]} [_ slug username following?]]
     (if (nil? (get-in db [:auth :user]))
       {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
@@ -153,11 +155,11 @@
 (rf/reg-event :ui/follow-author-replied
   {:doc "Follow / unfollow completion continuation (the `:reply-to` target). On
          `:ok`, stale the current article so its embedded `:author.following`
-         refetches — the follow mutation invalidates `[:profile username]`, but the
-         detail's embedded author flag lives in the `[:article slug]` entry, which
-         only this call site knows the slug for. The slug rides as a static
-         call-site arg; the reply map is appended after it. Global scope — the
-         article read is `:rf.scope/global`."}
+         refetches. The follow mutation already invalidates `[:profile username]`,
+         but the detail's embedded author flag lives in the `[:article slug]`
+         entry — and only this call site knows the slug. The slug rides along as a
+         static call-site arg, with the reply map appended after it. Global scope,
+         since the article read is `:rf.scope/global`."}
   (fn [_ [_ slug {:keys [status]}]]
     (if (= :ok status)
       {:fx [[:dispatch [:rf.resource/invalidate-tags
@@ -167,8 +169,8 @@
       {})))
 
 (rf/reg-event :ui/delete-article
-  {:doc "Delete the current article from the detail page (author only). Fires
-         the `:realworld/delete-article` mutation with a `:reply-to
+  {:doc "Delete the current article from the detail page (author only). Fires the
+         `:realworld/delete-article` mutation with a `:reply-to
          [:ui/article-deleted]` continuation that navigates home on success."}
   (fn [{:keys [db]} [_ slug]]
     (if (nil? (get-in db [:auth :user]))
@@ -181,11 +183,11 @@
                          :cause    [:click :ui/delete-article slug]}]]]})))
 
 (rf/reg-event :ui/article-deleted
-  {:doc "Delete-article completion continuation (the `:reply-to` target). On
-         `:ok`, clear the delete instance and navigate home — the mutation's
-         `:invalidates` already staled the lists + feed (and the now-gone
-         article's detail) before this fires. The reply carries the `:instance`
-         to clear."}
+  {:doc "Delete-article completion continuation (the `:reply-to` target). On `:ok`,
+         clear the delete instance and head home — by the time this fires, the
+         mutation's `:invalidates` has already staled the lists, the feed, and the
+         now-vanished article's detail. The reply carries the `:instance` to
+         clear."}
   (fn [_ [_ {:keys [status instance]}]]
     (if (= :ok status)
       {:fx [[:dispatch [:rf.mutation/clear {:instance instance}]]
@@ -236,13 +238,13 @@
        [rf/route-link {:to :realworld.profile/show :params {:username (:username author)} :class "author"}
         (:username author)]
        [:span.date createdAt]]
-      ;; OPTIMISTIC favorite. The heart + count already reflect the click — the
-      ;; `:optimistic-tags` apply flipped the cached article before the request
-      ;; left, so `favorited` / `favoritesCount` (read from the resource cache)
-      ;; are already the new values. We DON'T disable the button on `:pending?` —
-      ;; the user sees their change land instantly; a failed write rolls it back.
-      ;; `:optimistic?` marks "showing my optimistic value, not yet confirmed" for
-      ;; a subtle in-flight cue.
+      ;; Optimistic favorite. The heart and count already show the click — the
+      ;; `:optimistic-tags` apply flipped the cached article before the request even
+      ;; left, so `favorited` / `favoritesCount` (read from the resource cache) are
+      ;; already the new values. We deliberately don't disable the button on
+      ;; `:pending?`: the user sees their change land instantly, and a failed write
+      ;; quietly rolls it back. `:optimistic?` means 'showing my optimistic value,
+      ;; not yet confirmed' — just enough for a subtle in-flight cue.
       [:button.btn.btn-outline-primary.btn-sm.pull-xs-right
        {:type "button"
         :data-testid (str "favorite-" slug)
@@ -263,16 +265,17 @@
 ;; PAGINATION CONTROL — official Conduit shape (numbered 1-indexed pages)
 ;; ----------------------------------------------------------------------------
 ;;
-;; Page count is derived from the server's `articlesCount` and the fixed
-;; `page-size` — the view never tracks "how many pages" in app-db; it's a pure
+;; The page count is worked out from the server's `articlesCount` and the fixed
+;; `page-size` — the view never stashes 'how many pages' in app-db, it's purely a
 ;; function of the loaded data. Each page link is a navigation that swaps only
-;; `?page=`, so paging is declarative: the route plan re-ensures the list under
-;; the new page key (a distinct cache entry).
+;; `?page=`, so paging stays declarative: the route plan re-ensures the list under
+;; the new page key, which is a distinct cache entry.
 
 (reg-view ^{:doc "Official-style numbered pagination. `:articles-count` is the
-                  server total (from the resource's `articlesCount`);
-                  `:current-page` is 1-indexed; `:on-page` is called with a page
-                  number to navigate. Renders nothing for a single page."}
+                  server total (from the resource's `articlesCount`),
+                  `:current-page` is 1-indexed, and `:on-page` is called with a
+                  page number to navigate to. Renders nothing when there's only
+                  one page."}
           pagination [{:keys [articles-count current-page on-page]}]
   (let [total-pages (max 1 (js/Math.ceil (/ (or articles-count 0) resources/page-size)))]
     (when (> total-pages 1)
@@ -284,19 +287,20 @@
                               :on-click #(do (.preventDefault %) (on-page p))}
                 p]])))))
 
-(reg-view ^{:doc "Render a list-resource state: skeleton / error / list, with a
-                  background-refresh indicator + warning, the keep-previous
-                  placeholder, and (when `:articles-count` + `:on-page` are
-                  given) numbered pagination.
+(reg-view ^{:doc "Render a list-resource state: skeleton / error / list, complete
+                  with a background-refresh indicator and warning, the
+                  keep-previous placeholder, and — when `:articles-count` and
+                  `:on-page` are supplied — numbered pagination.
 
-                  `:keep-previous?` projection: while a NEW page/filter key
-                  first-loads, the resource state carries `:previous? true` +
-                  `:previous-data` (the prior key's articles). We render those
-                  PLUS a placeholder indicator so the user sees the old page,
-                  not a skeleton, until the new page settles — no flicker."}
+                  The keep-previous bit is the nice touch: while a new page/filter
+                  key first-loads, the resource state carries `:previous? true` and
+                  `:previous-data` (the prior key's articles). We render those, plus
+                  a small placeholder indicator, so the user keeps seeing the old
+                  page rather than a skeleton until the new one settles. No
+                  flicker."}
           article-list [{:keys [state empty-msg current-page on-page]}]
   (cond
-    ;; First-ever load with no usable data AND no previous page to show.
+    ;; First-ever load, with no usable data and no previous page to fall back on.
     (and (:loading? state) (not (:previous? state)))
     [:div.article-preview {:data-testid "list-skeleton"} "Loading articles…"]
 
@@ -305,8 +309,9 @@
      (str "Couldn't load articles: " (rh/failure->message (:error state)))]
 
     :else
-    ;; Prefer this key's own data; fall back to the kept-previous projection
-    ;; while the new page first-loads (no skeleton flash on page change).
+    ;; Prefer this key's own data, but fall back to the kept-previous projection
+    ;; while the new page first-loads — that's what avoids a skeleton flash on a
+    ;; page change.
     (let [data           (or (:data state) (:previous-data state))
           articles       (:articles data)
           articles-count (:articlesCount data)]
@@ -320,8 +325,8 @@
        (if (seq articles)
          (into [:div {:data-testid "article-list"}]
                (for [a articles] ^{:key (:slug a)} [article-preview {:article a}]))
-         ;; The official RealWorld E2E contract asserts the
-         ;; `.empty-feed-message` marker on an empty list state.
+         ;; The official RealWorld E2E contract checks for the
+         ;; `.empty-feed-message` marker on an empty list, so it stays.
          [:div.article-preview.empty-feed-message {:data-testid "list-empty"}
           (or empty-msg "No articles are here… yet.")])
        (when (and on-page articles-count)
@@ -333,29 +338,28 @@
 ;; HOME PAGE
 ;; ============================================================================
 
-(reg-view ^{:doc "The home page — a pure function of subs, never dispatches out
+(reg-view ^{:doc "The home page — a pure function of subs that never dispatches out
                   of band. The personalised feed reads through the named
-                  `{:from-db :realworld/session}` scope resolver: the
-                  subscription resolves its own scope (no `:scope` payload to
-                  thread) and re-keys reactively across login / logout.
-                  Favouriting reflects in Your Feed via the mutation's own
-                  session-scoped invalidation descriptor — no off-render reaction,
-                  no app-level feed patch."}
+                  `{:from-db :realworld/session}` scope resolver: the subscription
+                  resolves its own scope (nothing to thread) and re-keys reactively
+                  across login / logout. A favourite shows up in Your Feed via the
+                  mutation's own session-scoped invalidation descriptor — no
+                  off-render reaction, no app-level feed patching."}
           home-page []
   (let [authed?      @(subscribe [:auth/authenticated?])
         your-feed?   @(subscribe [:home/your-feed?])
         selected-tag @(subscribe [:home/selected-tag])
         page         @(subscribe [:home/page])
         tags-state   @(subscribe [:rf.resource/state {:resource :realworld/tags :params {}}])
-        ;; The global list is keyed by the active `:tag` AND `:page` — the SAME
-        ;; params the route ensured under, so the sub reads the right cache key.
+        ;; The global list is keyed by the active `:tag` and `:page` — the same
+        ;; params the route ensured under, so the sub lands on the right cache key.
         list-state   @(subscribe [:rf.resource/state {:resource :realworld/articles
                                                        :params  {:tag selected-tag :page page}}])
-        ;; The personalised feed: the resource declares `:scope {:from-db
+        ;; The personalised feed. The resource declares `:scope {:from-db
         ;; :realworld/session}`, so the subscription resolves the session scope
-        ;; ITSELF from app-db — no view threads a `:scope` payload. Logged out
-        ;; the resolver yields nil (fail-closed), so we only subscribe when
-        ;; authed; the `:page` matches the route-ensured key.
+        ;; itself from app-db — no view threads a `:scope` payload. Logged out, the
+        ;; resolver yields nil (fail-closed), so we only subscribe when authed; the
+        ;; `:page` matches the route-ensured key.
         feed-state   (when authed?
                        @(subscribe [:rf.resource/state {:resource :realworld/feed
                                                         :params  {:page page}}]))]
@@ -420,11 +424,11 @@
                               :on-click #(dispatch [:comment/delete slug (:id comment)])}
          [:i.ion-trash-a]])]]))
 
-(reg-view ^{:doc "Article-detail contextual controls: the author
-                  byline plus the author's Follow/Unfollow for a non-author
-                  viewer, OR Edit (→ /editor/:slug) + Delete for the author.
-                  Logged-out viewers see the byline only. `article` is the
-                  unwrapped article map; `del-state` the delete instance view."}
+(reg-view ^{:doc "Article-detail contextual controls: the author byline, plus
+                  either Follow/Unfollow on the author (for a non-author viewer) or
+                  Edit (→ /editor/:slug) + Delete (for the author). A logged-out
+                  viewer gets the byline alone. `article` is the unwrapped article
+                  map; `del-state` is the delete instance's view."}
           article-meta [{:keys [article del-state]}]
   (let [author    (:author article)
         username  (:username author)
@@ -461,12 +465,12 @@
         (if (:following author) "Unfollow " "Follow ") username])]))
 
 (reg-view ^{:doc "The article-detail page — a pure function of subs that never
-                  dispatches out of band. The two settle continuations the page
-                  needs are the mutations' own `:reply-to` targets: deleting
-                  fires `:ui/delete-article` → `:reply-to [:ui/article-deleted]`
+                  dispatches out of band. The two settle continuations it needs are
+                  the mutations' own `:reply-to` targets: deleting fires
+                  `:ui/delete-article` → `:reply-to [:ui/article-deleted]`
                   (navigate home), and following the author fires
-                  `:ui/follow-author` → `:reply-to [:ui/follow-author-replied
-                  slug]` (re-stale `[:article slug]` so the embedded author flag
+                  `:ui/follow-author` → `:reply-to [:ui/follow-author-replied slug]`
+                  (re-stale `[:article slug]` so the embedded author flag
                   refetches). No Form-3 wrapper, no off-render reaction."}
           article-page []
   (let [slug          (:slug @(subscribe [:rf.route/params]))
@@ -497,18 +501,19 @@
             (when (:fetching? article-state)
               [:span {:data-testid "article-refreshing"} " (refreshing…)"])
             [:span.article-controls
-             ;; The official RealWorld article-detail favorite control shows
-             ;; visible "Favorite"/"Unfavorite" text and toggles
-             ;; `.btn-outline-primary` ↔ `.btn-primary` on the favorited flag —
-             ;; the E2E contract asserts on both. (The compact heart-only card
-             ;; button stays `.btn-outline-primary`, correct per the official
+             ;; The article-detail favorite control is chattier than the card's:
+             ;; it shows visible "Favorite"/"Unfavorite" text and toggles
+             ;; `.btn-outline-primary` ↔ `.btn-primary` on the favorited flag, and
+             ;; the E2E contract checks both. (The compact heart-only card button
+             ;; stays `.btn-outline-primary` — also correct per the official
              ;; client.)
-             ;; OPTIMISTIC favorite: the label, the
-             ;; `.btn-primary`/`.btn-outline-primary` class, and the count all
-             ;; flip the instant the heart is clicked (the cached article was
-             ;; patched before the request left), then settle to the server's
-             ;; value — or roll back if the write fails. Not disabled on pending:
-             ;; the optimistic value is the truth on screen until settle.
+             ;; And it's optimistic: the label, the
+             ;; `.btn-primary`/`.btn-outline-primary` class, and the count all flip
+             ;; the instant the heart is clicked — the cached article was patched
+             ;; before the request even left — then settle to the server's value,
+             ;; or roll back if the write fails. Not disabled while pending,
+             ;; because the optimistic value is the truth on screen until it
+             ;; settles.
              [:button.btn.btn-sm
               {:type "button" :data-testid "article-favorite"
                :class (cond-> (if favorited "btn-primary" "btn-outline-primary")
@@ -560,19 +565,20 @@
 ;; PROFILE  —  two official tabs: My Articles / Favorited Articles
 ;; ============================================================================
 ;;
-;; The two tabs are two ROUTES (`:realworld.profile/show` for authored,
-;; `:realworld.profile/favorites` for favorited), each declaring its list read
-;; as route `:resources`. The active tab is just the current route id — no tab
-;; state in app-db. The view reads the route id to pick which list resource to
-;; subscribe to, and the page off the route query.
+;; A nice consequence of routing the way we do: the two tabs are simply two routes
+;; (`:realworld.profile/show` for authored, `:realworld.profile/favorites` for
+;; favorited), each declaring its list read as route `:resources`. The active tab
+;; is nothing more than the current route id — there's no tab state in app-db at
+;; all. The view reads the route id to choose which list resource to subscribe to,
+;; and reads the page off the route query.
 
 (rf/reg-sub :profile/favorites-tab? :<- [:rf.route/id]
   (fn [id _] (= id :realworld.profile/favorites)))
 (rf/reg-sub :profile/page :<- [:rf.route/query]
   (fn [q _] (or (:page q) 1)))
 
-;; Page navigation on a profile tab preserves the current route + username and
-;; swaps only `?page=`. Page 1 drops the param (the canonical first-page URL).
+;; Paging within a profile tab keeps the current route and username and swaps only
+;; `?page=`. Page 1 drops the param — the canonical first-page URL.
 (rf/reg-event :profile/go-to-page
   (fn [{rt :rf.db/runtime} [_ page]]
     (let [{:keys [current]} (get rt :rf.runtime/routing)
@@ -586,8 +592,8 @@
         page           @(subscribe [:profile/page])
         current-user   @(subscribe [:auth/user])
         profile-state  @(subscribe [:rf.resource/state {:resource :realworld/profile :params {:username username}}])
-        ;; The active tab picks which list resource (+ params) to read — the
-        ;; SAME (resource, params) the matching route ensured under.
+        ;; The active tab decides which list resource (and params) to read — the
+        ;; same (resource, params) the matching route ensured under.
         list-state     (if favorites?
                          @(subscribe [:rf.resource/state {:resource :realworld/favorited-articles
                                                           :params  {:username username :page page}}])
@@ -623,8 +629,8 @@
           [:div.container
            [:div.row
             [:div.col-xs-12.col-md-10.offset-md-1
-             ;; The two official profile tabs — each a route-link, the active
-             ;; one chosen by the current route id (no app-db tab state).
+             ;; The two profile tabs — each just a route-link, with the active one
+             ;; picked out by the current route id (and no app-db tab state).
              [:div.articles-toggle
               [:ul.nav.nav-pills.outline-active
                [:li.nav-item

--- a/examples/reagent/resources/core.cljs
+++ b/examples/reagent/resources/core.cljs
@@ -3,11 +3,13 @@
    [resources guide](../../../docs/resources/concepts.md) and its
    [glossary](../../../docs/resources/glossary.md).
 
-   The app is a small articles list plus an article detail. It is ordinary
-   re-frame2: app-db, events, subs, passive views. Views never fetch — the
-   fetch is always caused for them.
+   The app is a small articles list plus an article detail. Nothing exotic —
+   it's ordinary re-frame2: app-db, events, subs, passive views. The one habit
+   to notice is that views never fetch. A view just reads; something else
+   always causes the fetch on its behalf.
 
-   It shows four ways a fetch gets caused, all wired into the UI:
+   So who does the causing? Four different things, and the example wires up all
+   four so you can watch each one:
 
    - ROUTE-DRIVEN page load — a route declares `:resources`; entering the
      route ensures them, owned by the route for as long as you stay on it.
@@ -18,44 +20,52 @@
    - MACHINE-OWNED resource  — a machine ensures a resource owned for the
      actor's lifetime, released when the actor is destroyed.
 
-   An owner keeps a cached entry alive; a cause records why a fetch happened.
-   See [owner & cause](../../../docs/resources/glossary.md#owner--cause).
+   Owner and cause are the two ideas to keep straight: an owner keeps a cached
+   entry alive, a cause just records why a fetch happened. Owner = lifetime,
+   cause = explanation. See
+   [owner & cause](../../../docs/resources/glossary.md#owner--cause).
 
    Every resource declares `:scope :rf.scope/global` — this data is public and
-   the same for everyone. Scope is a required, fail-closed leak boundary; a
-   per-user read would carry a scope resolver instead. See
+   the same for everyone. Scope is a required, fail-closed leak boundary, so
+   one user's data can't leak into another's cache; a per-user read would carry
+   a scope resolver instead. There's no default on purpose — forgetting it is
+   an error, not a silent global. See
    [scope](../../../docs/resources/glossary.md#scope).
 
-   The example ships no backend. It overrides the `:rf.http/managed` effect
-   with a per-URL stub that returns canned articles, so every ensure runs a
-   real fetch with real in-flight dedupe and the real status flow. A 120 ms
-   reply delay lets the loading skeleton render before data lands, so
-   first-load and refresh-in-flight are visible. Re-ensuring an entry that is
-   still inside its `:stale-after-ms` window skips the refetch; the manual
-   Refresh forces one regardless.
+   There's no real backend here. Instead the example overrides the
+   `:rf.http/managed` effect with a per-URL stub that returns canned articles —
+   but everything downstream of the wire runs for real: real in-flight dedupe,
+   the real status flow, the works. A small 120 ms reply delay buys us time to
+   actually see the loading skeleton and the refresh-in-flight state, which
+   would otherwise flash past too fast to notice. Re-ensuring an entry that's
+   still inside its `:stale-after-ms` window skips the refetch entirely; the
+   manual Refresh forces one anyway.
 
-   This example covers reads only. Writes — mutations that invalidate reads by
-   tag — are covered in the [resources guide](../../../docs/resources/concepts.md)."
+   This example is reads only. The other half of the story — writes, and how a
+   mutation invalidates reads by tag — lives in the
+   [resources guide](../../../docs/resources/concepts.md)."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.views]
-            ;; Managed HTTP is the transport for resource fetches. Requiring
-            ;; it registers the `:rf.http/managed` effect that each ensure
-            ;; runs onto. See the managed-HTTP glossary entry:
+            ;; Managed HTTP is the transport a resource fetch rides on.
+            ;; Requiring it registers the `:rf.http/managed` effect that every
+            ;; ensure ultimately runs onto. See the managed-HTTP glossary entry:
             ;; ../../../docs/resources/glossary.md#managed-http
             [re-frame.http.managed]
-            ;; The canned-reply stub effects. This example has no backend, so
-            ;; the stub below stands in; requiring this ns registers
-            ;; `:rf.http/managed-canned-success`, which it delegates to.
+            ;; Canned-reply test effects. With no real server, the stub further
+            ;; down stands in for one — and it delegates to the
+            ;; `:rf.http/managed-canned-success` effect this require registers.
             [re-frame.http.test-support]
-            ;; Boots the optional resources artefact. Requiring it at app boot
-            ;; is what makes `rf/reg-resource` work; without it the calls below
-            ;; throw.
+            ;; Resources are an optional artefact, so they only exist if you ask
+            ;; for them. This require is the asking — without it, the
+            ;; `rf/reg-resource` calls below would have nothing to register
+            ;; against and would throw.
             [re-frame.resources]
-            ;; Routing. The resources artefact adds its `:resources` route
-            ;; metadata onto routing, so loading both is what makes a route's
-            ;; `:resources` key accepted.
+            ;; Routing — and, just as importantly, the bridge between the two.
+            ;; The resources artefact teaches routing about the `:resources`
+            ;; route key, so it's loading *both* that makes a route allowed to
+            ;; declare `:resources`.
             [re-frame.routing]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -64,10 +74,12 @@
 ;; RESOURCES — named, cached server-state reads
 ;; ============================================================================
 ;;
-;; A resource is identity + scope + a request. `:params-schema`, `:scope`, and
-;; the request function are all required. `:scope :rf.scope/global` claims this
-;; read is the same for every user. Scope has no default — a missing scope is
-;; an error at registration. See ../../../docs/resources/glossary.md#scope
+;; Boiled down, a resource is just three things: an identity, a scope, and a
+;; request. All three are required — `:params-schema`, `:scope`, and the request
+;; function at the bottom. `:scope :rf.scope/global` is us promising this read
+;; is the same for every user. Scope has no default; leave it off and you get an
+;; error at registration, not a quietly-global cache.
+;; See ../../../docs/resources/glossary.md#scope
 
 (rf/reg-resource :articles/list
   {:doc            "The recent-articles list (public, same for everyone)."
@@ -75,8 +87,8 @@
    :scope          :rf.scope/global
    :stale-after-ms 60000
    :gc-after-ms    (* 5 60 1000)
-   ;; Tags let a write invalidate this list by tag.
-   ;; See ../../../docs/resources/glossary.md#cache-tag
+   ;; Tags are how a future write says "this list is now stale" without naming
+   ;; the list directly. See ../../../docs/resources/glossary.md#cache-tag
    :tags           (fn [_params _data] #{[:article-list]})}
   (fn [_params _ctx]
     {:request {:method :get :url "/api/articles"}
@@ -88,8 +100,9 @@
    :scope          :rf.scope/global
    :stale-after-ms 60000
    :gc-after-ms    (* 5 60 1000)
-   ;; Tag BOTH the per-article identity and the list identity so a save
-   ;; can invalidate the detail and the list relationship together.
+   ;; Two tags, on purpose: the article's own identity AND the list it belongs
+   ;; to. That way saving this article can invalidate both the detail view and
+   ;; the list that mentions it, in one stroke.
    :tags           (fn [{:keys [slug]} _data] #{[:article slug] [:article-list]})}
   (fn [{:keys [slug]} _ctx]
     {:request {:method :get :url (str "/api/articles/" slug)}
@@ -99,13 +112,15 @@
 ;; DEMO BACKEND — a per-URL canned :rf.http/managed override
 ;; ============================================================================
 ;;
-;; There is no server, so this overrides `:rf.http/managed` (the effect every
-;; ensure runs onto) with a stub that builds a canned reply per URL. The two
-;; requests are `GET /api/articles` (the list) and `GET /api/articles/:slug`
-;; (a detail). The stub routes by URL shape and delegates to the shipped
-;; `:rf.http/managed-canned-success`, which returns the same reply shape a real
-;; server would — so the full resource lifecycle (in-flight tracking, dedupe,
-;; reply addressing, status flow) runs for real.
+;; No server, so we fake one — at the lowest honest layer. This overrides
+;; `:rf.http/managed` (the effect every ensure runs onto) with a stub that
+;; builds a canned reply per URL. There are only two URLs in play:
+;; `GET /api/articles` (the list) and `GET /api/articles/:slug` (a detail). The
+;; stub looks at the URL shape, picks the right payload, and hands off to the
+;; shipped `:rf.http/managed-canned-success`, which returns the exact reply
+;; shape a real server would. Because we mock at the wire and not above it, the
+;; whole resource lifecycle — in-flight tracking, dedupe, reply addressing,
+;; status flow — runs for real on top.
 
 (def ^:private demo-articles
   [{:slug "resources-101"  :title "Resources 101: server-state as cached reads"
@@ -116,27 +131,30 @@
     :body "Ensure an entry still inside :stale-after-ms and the runtime skips the refetch."}])
 
 (def ^:private demo-reply-delay-ms
-  "How long the demo stub defers each canned reply. The delay rides the
-   canned-success effect's `:after-ms` (dispatched via `:dispatch-later`, so it
-   is visible in the tape and survives time-travel). Small but non-zero, so the
-   loading skeleton and the refresh-in-flight state are visible. A demo knob,
-   not a production value."
+  "How long the demo stub sits on each canned reply before handing it back. The
+   delay rides the canned-success effect's `:after-ms` (dispatched via
+   `:dispatch-later`), so it shows up in the tape and survives time-travel.
+   Small but deliberately non-zero — long enough that the loading skeleton and
+   the refresh-in-flight state get a moment on screen. Purely a demo knob; a
+   real app has no business injecting latency."
   120)
 
 (defn- demo-payload-for-url [url]
   (let [u (str url)]
     (if-let [slug (second (re-find #"/api/articles/([^/?#]+)" u))]
-      ;; A detail read — /api/articles/:slug.
+      ;; Looks like a detail read — /api/articles/:slug. Find that article, or
+      ;; fall back to a polite "(no such article)" rather than blowing up.
       (or (first (filter #(= slug (:slug %)) demo-articles))
           {:slug slug :title slug :body "(no such article)"})
-      ;; The bare list endpoint — /api/articles.
+      ;; Otherwise it's the bare list endpoint — /api/articles.
       demo-articles)))
 
-;; This override stands in for the backend. It builds the payload for the URL
-;; and hands off to `:rf.http/managed-canned-success`, looked up from the
-;; registrar and called with `:after-ms` so the reply rides `:dispatch-later`
-;; (visible in the tape, survives time-travel). It keeps the args-map intact so
-;; the reply still addresses back to the resource that asked.
+;; This is the override itself — our stand-in backend. It builds the payload for
+;; the URL, looks up the real `:rf.http/managed-canned-success` effect from the
+;; registrar, and calls it with `:after-ms` so the reply rides `:dispatch-later`
+;; (visible in the tape, survives time-travel). The crucial bit: it passes the
+;; args-map through untouched, so the reply still knows which resource asked and
+;; addresses itself back to it.
 (rf/reg-fx :resources.demo/http-stub
   {:doc       "Demo override for `:rf.http/managed`: routes by URL to the canned
                article payloads so the example runs standalone, then delegates
@@ -151,10 +169,12 @@
 ;; ROUTES — entering a route causes its resources to load
 ;; ============================================================================
 ;;
-;; `:resources` route metadata declares what server-state a page needs. On
-;; route entry the runtime ensures each one, owned by the route. On route
-;; leave it releases that owner and drops any late reply. The view only reads;
-;; the fetch is caused for it. See ../../../docs/routing/glossary.md#route
+;; This is the cleanest of the four causers. A route's `:resources` metadata
+;; declares, right next to the URL, what server-state that page needs. Arrive on
+;; the route and the runtime ensures each one, owned by the route itself. Leave,
+;; and it releases that ownership and quietly drops any reply still in flight.
+;; The view does nothing but read — the route does the causing.
+;; See ../../../docs/routing/glossary.md#route
 
 (rf/reg-route :resources.app/home
   {:doc  "Landing page."} "/")
@@ -171,7 +191,8 @@
    :params [:map [:slug :string]]
    :resources
    [{:resource  :article/by-slug
-     ;; Route params → resource params: the URL slug identifies the read.
+     ;; This is where route params become resource params: the slug in the URL
+     ;; is exactly what identifies the article to read.
      :params    (fn [route] {:slug (get-in route [:params :slug])})
      :blocking? true}]} "/articles/:slug")
 
@@ -182,11 +203,12 @@
 ;; EVENT-DRIVEN ENSURE + MANUAL REFRESH
 ;; ============================================================================
 ;;
-;; Not every fetch is route-driven. An event can cause an ensure too — here
-;; under an app-minted `[:lease …]` owner. The app owns that lease: the event
-;; that mints it must have a matching `:rf.resource/release-owner` event, or
-;; the lease pins the entry alive forever. See
-;; ../../../docs/resources/glossary.md#owner--cause
+;; Routes aren't the only thing that can cause a fetch — an event can too. Here
+;; the event mints its own `[:lease …]` owner to keep the entry alive. But with
+;; ownership comes responsibility: whatever mints a lease must also, somewhere,
+;; fire a matching `:rf.resource/release-owner`. Forget that, and the lease pins
+;; the entry alive forever — the cache equivalent of a memory leak.
+;; See ../../../docs/resources/glossary.md#owner--cause
 
 (rf/reg-event :resources.app/preview-opened
   {:doc "Open a lightweight article preview from the list — ensure the
@@ -208,9 +230,10 @@
      :fx [[:dispatch [:rf.resource/release-owner
                       {:owner [:lease :resources.app/preview slug]}]]]}))
 
-;; A manual refresh is a cause, not an owner. Clicking "Refresh" wants fresh
-;; data but does not intend to keep the resource alive — that is the route's
-;; job. So it refetches with a `:cause` and no `:owner`.
+;; A manual refresh is a cause, not an owner — and the distinction is the whole
+;; point. Clicking "Refresh" means "I'd like fresher data", not "keep this alive
+;; for me"; keeping it alive is the route's job, not the button's. So it refetches
+;; with a `:cause` and pointedly no `:owner`.
 (rf/reg-event :resources.app/refresh-articles
   {:doc "Manual refresh of the articles list."}
   (fn [_ _]
@@ -223,26 +246,30 @@
 ;; MACHINE-OWNED RESOURCE
 ;; ============================================================================
 ;;
-;; When a workflow owns a read for its lifetime, model the workflow as a
-;; machine and let it own the resource. The resource is owned by the actor and
-;; released when the actor is destroyed. The machine is the workflow; the
-;; resource runtime handles the cached-read mechanics. This is a tiny reader
-;; machine: it ensures the article it is reading, and that read is released
-;; when the reader stops. See the machines glossary:
+;; Sometimes a whole workflow owns a read for as long as it lives. When that's
+;; the case, model the workflow as a machine and let the machine own the
+;; resource. The read is tied to the actor's lifetime: born when the actor is,
+;; released the moment it's destroyed — no manual bookkeeping. The machine
+;; expresses the workflow; the resource runtime quietly handles the cached-read
+;; mechanics underneath. What follows is about the smallest such machine you
+;; could write: a reader that ensures the one article it's reading, and lets go
+;; of it when it stops. See the machines glossary:
 ;; ../../../docs/machines/glossary.md#machine
 
-;; The UI starts the reader in two steps: birth the actor with the bare
-;; `[:rf.machine/start]` marker, then dispatch a real `[:reader/load slug
-;; instance-id]` event into it. The split is deliberate. The birth cascade runs
-;; `:entry` actions with no event, so an `:entry` action cannot read the slug —
-;; it would arrive nil. A real event dispatched after birth does carry its
-;; args, so the slug and instance-id this workflow owns ride on `:reader/load`.
+;; Starting the reader takes two steps, and the split is on purpose. First we
+;; birth the actor with a bare `[:rf.machine/start]` marker; then we dispatch a
+;; real `[:reader/load slug instance-id]` event into it. Why not do it in one?
+;; Because the birth cascade fires `:entry` actions with no event attached — so
+;; an `:entry` action that reached for the slug would find nil. A genuine event
+;; dispatched *after* birth carries its args just fine, which is how the slug and
+;; instance-id this workflow owns get to ride in on `:reader/load`.
 ;;
-;; The `:reading` state handles `:reader/load` with the `:ensure-article`
-;; action. It reads slug + instance-id from the event, stores them in the
-;; snapshot `:data` (so the owner is self-describing for tools and SSR), and
-;; ensures the article owned by `[:machine machine-id instance-id]`. The
-;; runtime releases that owner when the actor is destroyed.
+;; The `:reading` state handles that `:reader/load` with the `:ensure-article`
+;; action. The action pulls slug + instance-id out of the event, tucks them into
+;; the snapshot `:data` (so the owner is self-describing — handy for tools and
+;; SSR), and ensures the article under the owner `[:machine machine-id
+;; instance-id]`. When the actor is later destroyed, the runtime releases that
+;; owner for us.
 (rf/reg-machine :resources.app/reader
   {:doc     "A reader workflow that owns the article it is reading."
    :initial :reading
@@ -258,20 +285,21 @@
                              :owner    [:machine :resources.app/reader instance-id]
                              :cause    [:machine-action :resources.app/reader.reading]}]]]}))}
    :states
-   ;; `:reader/load` is a targetless transition: it runs `:ensure-article` and
-   ;; stays in `:reading` (no `:target`). The action must ride in an `{:action
-   ;; …}` map — a bare `{:reader/load :ensure-article}` would read
-   ;; `:ensure-article` as a target state and fail to resolve. See
-   ;; ../../../docs/machines/glossary.md#transition
+   ;; `:reader/load` is a targetless transition — it runs `:ensure-article` and
+   ;; stays put in `:reading` (no `:target`). One gotcha worth flagging: the
+   ;; action has to ride inside an `{:action …}` map. Write the tempting shorthand
+   ;; `{:reader/load :ensure-article}` and the machine reads `:ensure-article` as
+   ;; the name of a target *state*, then fails to find one.
+   ;; See ../../../docs/machines/glossary.md#transition
    {:reading {:on {:reader/load {:action :ensure-article}}}}})
 
-;; The UI starts and stops the reader through these two events. Starting births
-;; the actor and then dispatches `[:reader/load slug instance-id]` into it (the
-;; two-step pattern explained on the machine above); the birth cascade runs
-;; first, then the load drives the ensure. It also records the instance-id in
-;; app-db so the view can show the article and a stop button. Stopping destroys
-;; the actor, which releases its resource owner so the entry can GC, and clears
-;; the app-db slice.
+;; These two events are the UI's start and stop buttons for the reader. Start
+;; births the actor, then dispatches `[:reader/load slug instance-id]` into it —
+;; the two-step dance explained on the machine above: birth cascade first, then
+;; the load drives the ensure. It also stashes the instance-id in app-db so the
+;; view knows to show the article panel and a stop button. Stop destroys the
+;; actor — which releases its resource owner, letting the entry GC — and clears
+;; the slice back out of app-db.
 (rf/reg-event :resources.app/start-reader
   {:doc "Start the reader workflow that owns the given article for its lifetime."}
   (fn [{:keys [db]} [_ slug]]
@@ -290,15 +318,17 @@
 ;; APP DATA + READ-MODEL SUBS
 ;; ============================================================================
 ;;
-;; The passive resource subs read the runtime-managed cache. A small derived
-;; sub picks a slug from the list for the "open preview" button.
+;; The resource subs themselves are passive — they read the runtime-managed
+;; cache and nothing more. Below them sits one small derived sub that pulls a
+;; single slug out of the list to feed the "open preview" button.
 
-;; To project over a resource's data, layer an ordinary sub on top of the
-;; passive `[:rf.resource/data …]` sub — there is no resource-local select. The
-;; input-fn is a pure `(fn [query-v])` that returns a vector of query vectors,
-;; never a deref'd subscribe. The compute fn then receives the resolved inputs
-;; positionally: `[[articles] _]`. See
-;; ../../../docs/guide/glossary.md#subscription
+;; Want to compute something *over* a resource's data? There's no resource-local
+;; select — you just layer an ordinary sub on top of the passive
+;; `[:rf.resource/data …]` sub, exactly as you'd layer any sub on any other.
+;; The input-fn is a pure `(fn [query-v])` returning a vector of query vectors
+;; (never a deref'd subscribe), and the compute fn then gets the resolved inputs
+;; back positionally: `[[articles] _]`.
+;; See ../../../docs/guide/glossary.md#subscription
 (rf/reg-sub :resources.app/first-slug
   (fn [_query-v]
     [[:rf.resource/data {:resource :articles/list :params {}}]])
@@ -326,9 +356,10 @@
                        :data-testid "route-link-articles"}
         "See the articles →"]]])
 
-;; EVENT-LEASE preview panel. Mounted only while a preview is open. The detail
-;; it reads was ensured under an app lease by `:resources.app/preview-opened`
-;; and released by `:resources.app/preview-closed`. The panel only reads.
+;; The EVENT-LEASE preview panel. It only exists on screen while a preview is
+;; open. The detail it shows was ensured under an app lease over in
+;; `:resources.app/preview-opened`, and will be released by
+;; `:resources.app/preview-closed`. The panel's whole job is to read and render.
 (reg-view preview-panel [slug]
   (let [state @(subscribe [:rf.resource/state {:resource :article/by-slug
                                                :params  {:slug slug}}])]
@@ -346,9 +377,9 @@
                :on-click    #(dispatch [:resources.app/preview-closed slug])}
       "Close preview"]]))
 
-;; MACHINE-OWNED reader panel — the running reader actor owns this detail for
-;; its lifetime; the panel reads it passively. Stopping destroys the actor and
-;; releases the owner.
+;; The MACHINE-OWNED reader panel. Here the live reader actor owns this detail
+;; for its whole lifetime; the panel just reads it passively. Hit stop and the
+;; actor is destroyed, which is what releases the owner.
 (reg-view reader-panel [slug]
   (let [state @(subscribe [:rf.resource/state {:resource :article/by-slug
                                                :params  {:slug slug}}])]
@@ -368,13 +399,14 @@
       "Stop reader"]]))
 
 (reg-view articles-page []
-  ;; This route's `:resources` metadata ensured the list on entry. The view
-  ;; reads its full state passively.
+  ;; Getting here already ensured the list — that's what this route's
+  ;; `:resources` metadata bought us. All the view has to do now is read the
+  ;; resource's full state, passively.
   (let [state        @(subscribe [:rf.resource/state {:resource :articles/list :params {}}])
         preview-slug @(subscribe [:resources.app/preview-slug])
         reader       @(subscribe [:resources.app/reader])
-        ;; The top article's slug, for the quick-preview button — a sub layered
-        ;; over the list resource.
+        ;; The top article's slug, for the quick-preview button — courtesy of the
+        ;; little sub we layered over the list resource above.
         top-slug     @(subscribe [:resources.app/first-slug])]
     [:div
      [:h1 "Articles"]
@@ -386,17 +418,18 @@
                  :on-click    #(dispatch [:resources.app/preview-opened top-slug])}
         "Quick-preview top article"])
      (cond
-       ;; First load, no usable data yet → skeleton.
+       ;; First load, nothing usable to show yet → skeleton.
        (:loading? state)
        [:p {:data-testid "articles-skeleton"} "Loading articles…"]
 
-       ;; First load failed, no usable data → error.
+       ;; First load fell over and left us with nothing → error.
        (and (:error state) (not (:has-data? state)))
        [:p.error {:data-testid "articles-error"} "Could not load articles."]
 
        :else
        [:<>
-        ;; A background-refresh failure keeps the data and surfaces a warning.
+        ;; A failed *background* refresh is gentler: we keep the data we have and
+        ;; just flag that the refresh didn't take.
         (when (:refresh-error state)
           [:p.warn {:data-testid "articles-refresh-warn"} "Refresh failed; showing last-known data."])
         (into [:ul {:data-testid "articles-list"}]
@@ -407,24 +440,26 @@
                                  :params {:slug slug}
                                  :data-testid (str "route-link-article-" slug)}
                   title]
-                 ;; EVENT-LEASE: open/close a preview under an app lease.
+                 ;; EVENT-LEASE causer: opens a preview held alive by an app lease.
                  " "
                  [:button {:data-testid (str "preview-" slug)
                            :on-click    #(dispatch [:resources.app/preview-opened slug])}
                   "Preview"]
-                 ;; MACHINE-OWNED: spawn a reader that owns this article.
+                 ;; MACHINE-OWNED causer: spawns a reader actor that owns this article.
                  " "
                  [:button {:data-testid (str "read-" slug)
                            :on-click    #(dispatch [:resources.app/start-reader slug])}
                   "Open in reader"]]))
-        ;; The lease + machine read-models render passively when active.
+        ;; The lease and machine panels only appear when their owner is active —
+        ;; passive read-models, mounted on demand.
         (when preview-slug
           [preview-panel preview-slug])
         (when reader
           [reader-panel (:slug reader)])])]))
 
 (reg-view article-detail-page []
-  ;; This route's `:resources` ensured :article/by-slug for the URL slug.
+  ;; Same deal as the list page: arriving here already ensured :article/by-slug
+  ;; for the slug in the URL. The view just reads the result.
   (let [slug  (:slug @(subscribe [:rf.route/params]))
         state @(subscribe [:rf.resource/state {:resource :article/by-slug
                                                :params  {:slug slug}}])]
@@ -464,19 +499,22 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; `run` creates the React root on first call. The `frame-provider {:id …}` at
-;; the render root both creates and configures the app frame: `:url-bound? true`
-;; so the frame owns the browser URL, plus the HTTP-stub override. Every
-;; dispatch and subscribe in the tree resolves to this frame. On hot reload the
-;; same frame is reused. `install-history-listener!` syncs the initial URL and
-;; handles back/forward. See the frame glossary entry:
+;; `run` is the boot sequence. It creates the React root on the first call, then
+;; renders. The interesting piece is the `frame-provider {:id …}` at the root: it
+;; both creates and configures the app frame in one go — `:url-bound? true` so
+;; this frame owns the browser URL, plus the HTTP-stub override. Every dispatch
+;; and subscribe anywhere in the tree resolves to this one frame, and a hot
+;; reload reuses it rather than spinning up a fresh one.
+;; `install-history-listener!` is what syncs the initial URL and wires up the
+;; browser back/forward buttons. See the frame glossary entry:
 ;; ../../../docs/guide/glossary.md#frame
 
 (defonce react-root (atom nil))
 
-;; The id this app's frame is created under. `:rf/default` is an ordinary id
-;; with no special privilege; URL ownership comes from `:url-bound? true` on the
-;; `frame-provider` below, not from the id.
+;; The id this app's frame is created under. Despite the name, `:rf/default`
+;; carries no special privilege — it's just an ordinary id. The URL ownership
+;; comes from `:url-bound? true` on the `frame-provider` below, never from what
+;; the frame happens to be called.
 (def app-frame :rf/default)
 
 (defn run []
@@ -485,11 +523,12 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; The `frame-provider {:id …}` creates and configures the app frame.
-    ;; `:fx-overrides` routes every `:rf.http/managed` resource ensure to the
-    ;; per-URL canned stub above, so the example runs standalone with no backend.
-    ;; The override applies frame-wide; this example issues no non-mocked
-    ;; requests, so a blanket override is the right grain.
+    ;; Here's the frame, created and configured by `frame-provider {:id …}`.
+    ;; `:fx-overrides` is the trick that lets the demo stand alone: it reroutes
+    ;; every `:rf.http/managed` ensure to the per-URL canned stub up above. The
+    ;; override is frame-wide, which is fine here precisely because this example
+    ;; never makes a request we'd actually want to reach the network — a blanket
+    ;; override is the right grain.
     (rdc/render @react-root
                 [rf/frame-provider {:id           app-frame
                                     :doc          "Resources demo frame."

--- a/examples/reagent/resources_ssr/core.cljc
+++ b/examples/reagent/resources_ssr/core.cljc
@@ -1,60 +1,69 @@
 (ns resources-ssr.core
-  "Worked example: SSR over a re-frame2 RESOURCE. A server+client app whose
-   page server-state is a resource. The server renders an article list with
-   the resource preloaded; the client hydrates the resource cache and skips a
-   duplicate fetch for entries that are still fresh.
+  "Server-side rendering over a re-frame2 RESOURCE.
 
-   This is .cljc so the same code runs server-side (JVM, `:clj` branches)
-   and client-side (browser, `:cljs` branches).
+   The page's state is a resource — a live cache the framework owns. The
+   server renders the article list with that resource preloaded, then ships
+   the cache to the client. The client hydrates it and, for anything still
+   fresh, renders on the first paint without re-fetching. That last part is
+   the whole point of preloading: don't make the browser ask for what the
+   server just handed it.
 
-   What the resource SSR contract gives you here:
+   This is `.cljc`, so one file is both halves of the app. The `:clj`
+   branches run on the server (a JVM), the `:cljs` branches run in the
+   browser, and the reader picks the side. Read it top to bottom as one
+   request and its client pickup.
 
-   - The server renders each request in its own frame. A process-global
-     resource cache would leak one user's data into another's.
-   - The page's resource is ensured under an `[:ssr request-id nav-token]`
-     owner with cause `:ssr-preload`. The ensure blocks the render until the
-     read settles.
+   The four things the resource-SSR contract buys you:
+
+   - Each request renders in its own frame. The cache is shared state, so a
+     process-global one would leak one user's articles into another's render.
+     A frame per request keeps every cache private.
+   - The page resource is ensured under an `[:ssr request-id nav-token]`
+     owner with cause `:ssr-preload`, and the ensure blocks the render until
+     the read settles — no half-loaded page goes out the door.
    - Only the allowed resource entries ride the hydration payload (under
-     `:rf/runtime-db`). Host handles and the tag/owner indexes are never
-     serialized; the indexes recompute from `:entries` on install.
-   - On the client the framework `:rf/hydrate` event installs those entries
-     into the target frame's `:rf.runtime/resources` slice. A fresh hydrated
-     entry renders on first paint and serves from the cache. Stale, redacted,
-     or omitted entries refetch.
+     `:rf/runtime-db`). Fetch handles and the tag/owner indexes stay home;
+     the indexes recompute from `:entries` the moment the client installs them.
+   - On the client the framework's `:rf/hydrate` event drops those entries
+     into the frame's `:rf.runtime/resources` slice. A fresh entry renders
+     immediately and serves from cache. Stale, redacted, or omitted entries
+     refetch — because for those the client has nothing usable in hand.
 
-   This example drives the real server path. It drains the blocking page
-   resource before render (`ssr/drain-blocking-resources!`) and serializes
+   This drives the real server path, not a stand-in. It drains the blocking
+   page resource before rendering (`ssr/drain-blocking-resources!`) and ships
    only the allowed runtime-db projection (`payload-policy/project-runtime-db`)
-   into `:rf/runtime-db` — never the full runtime-db. The `:rf/app-db` slice
-   goes through the same fail-closed allowlist (`apply-policy`) the production
-   Ring host uses. The static `index.html` next to this file carries a
-   pre-baked payload so the browser-side `run` works without a Clojure server.
+   under `:rf/runtime-db` — never the full cache. The app-db slice goes through
+   the same fail-closed allowlist (`apply-policy`) the production Ring host
+   uses. The static `index.html` next to this file carries a pre-baked payload
+   so the browser side runs without a Clojure server in the box.
 
    For the full picture see [Resources: SSR and hydration](../../../docs/resources/concepts.md#ssr-and-hydration)
    and [Server-side rendering](../../../docs/ssr/concepts.md).
 
-   Compare with `examples/reagent/ssr/` (plain SSR with a managed-HTTP fetch
-   written into app-db): here the same data is a runtime-managed resource, so
-   identity, scope, staleness, and hydration are the framework's job, and the
-   cache lives in the runtime partition rather than app-db."
+   The sibling `examples/reagent/ssr/` is the simpler cousin: it bakes a
+   fetched list into app-db and hands that frozen value across. Here the data
+   is a runtime-managed resource, so identity, scope, staleness, and hydration
+   are the framework's job, and the cache lives in the runtime partition rather
+   than in app-db."
   (:require [re-frame.core :as rf]
-            ;; Managed HTTP — the resource transport.
+            ;; Managed HTTP — how the resource actually fetches.
             [re-frame.http.managed]
-            ;; Resources artefact: boots the registrations and the SSR
-            ;; projection hook the ssr artefact consults.
+            ;; The resources artefact. Loading it boots the registrations and
+            ;; the SSR projection hook the ssr artefact reaches for.
             [re-frame.resources]
             ;; SSR: render-to-string, the `:rf/hydrate` event, and the
             ;; per-request server effects.
             [re-frame.ssr :as ssr]
-            ;; The hydration-payload assembly the production Ring host uses:
+            ;; The payload assembly the production Ring host uses, so this
+            ;; example builds the wire payload the same way the real thing does:
             ;; the fail-closed app-db allowlist (`apply-policy`) and the
-            ;; runtime-db projection (`project-runtime-db`) that rides only the
-            ;; allowed resource `:entries` onto `:rf/runtime-db` (sensitive
-            ;; data redacted; indexes recompute on install). Server-side only.
+            ;; runtime-db projection (`project-runtime-db`) that ships only the
+            ;; allowed resource `:entries` under `:rf/runtime-db` (sensitive
+            ;; data redacted; indexes rebuilt on install). Server-side only.
             #?(:clj [re-frame.ssr.payload-policy :as payload-policy])
-            ;; The EDN-aware escaper for the payload `<script>` body. A
-            ;; server-provided string carrying `</script>` would otherwise
-            ;; close the envelope, so escape it. Server-side only.
+            ;; The EDN-aware escaper for the payload `<script>` body. A server
+            ;; string that happens to contain `</script>` would otherwise close
+            ;; the envelope early — so we escape it. Server-side only.
             #?(:clj [re-frame.ssr.html-helpers :as html])
             #?(:cljs [reagent.dom.client :as rdc])
             #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
@@ -63,16 +72,18 @@
 ;; RESOURCE
 ;; ============================================================================
 ;;
-;; The page's server-state, declared once. You describe what the read is and
-;; how to fetch it; the runtime owns the cache, dedupe, and staleness.
+;; The page's server-state, declared once. You say what the read is and how to
+;; fetch it; the runtime takes it from there — caching, deduping, and tracking
+;; staleness so you don't have to.
 ;;
-;; `:scope :rf.scope/global` declares that this article list is the same for
-;; every user. Scope is part of the read's cache identity, so one user's data
-;; can never surface in another's cache. It also matters for hydration: the
-;; serialized scope and the client's scope must agree before the client treats
-;; hydrated data as usable, and hydration never crosses scopes. A user-scoped
-;; page would carry a scope resolver instead. See
-;; docs/resources/glossary.md#scope.
+;; `:scope :rf.scope/global` is a claim: this article list is identical for
+;; every user. Scope is part of a read's cache identity, which is what stops
+;; one user's data from ever surfacing in another's cache. It carries through
+;; to hydration too — the serialized scope and the client's scope must agree
+;; before the client trusts hydrated data, and hydration never crosses a scope
+;; boundary. A per-user page would supply a scope resolver here instead; the
+;; global claim is the explicit, checkable statement that this handoff is safe.
+;; See docs/resources/glossary.md#scope.
 
 (rf/reg-resource :articles/list
   {:doc            "Recent articles (public, SSR-preloaded)."
@@ -88,15 +99,16 @@
 ;; SERVER-SIDE PRELOAD EVENT
 ;; ============================================================================
 ;;
-;; `:rf/server-init` runs at per-request frame creation. It ensures the page
-;; resource — fetching it if the cache is cold — so the render finds it warm.
-;; The renderer then waits for it to settle before rendering.
+;; `:rf/server-init` runs when the per-request frame is born. Its one job is to
+;; ensure the page resource — fetch it if the cache is cold — so that by render
+;; time the data is already warm. The renderer then waits for it to settle
+;; before walking the tree.
 ;;
-;; Two facts ride the ensure. The owner `[:ssr request-id nav-token]` is a
-;; lease: it keeps the entry alive for the duration of this server render and
-;; no longer. The cause `:ssr-preload` is provenance — why the fetch happened,
-;; recorded for the trace. Owner = lifetime; cause = explanation. See
-;; docs/resources/glossary.md#owner--cause.
+;; Two things ride along with the ensure, and they answer two different
+;; questions. The owner `[:ssr request-id nav-token]` is a lease — it keeps the
+;; entry alive for exactly this server render and not a moment longer. The
+;; cause `:ssr-preload` is the story for the trace: why this fetch happened.
+;; Owner = how long; cause = why. See docs/resources/glossary.md#owner--cause.
 
 (rf/reg-event :rf/server-init
   {:doc       "Per-request server init — preload the page resource."
@@ -106,8 +118,9 @@
      :fx [[:dispatch [:rf.resource/ensure
                       {:resource :articles/list
                        :params   {}
-                       ;; request-id + nav-token are illustrative here; a
-                       ;; real server threads them from the request frame.
+                       ;; The request-id and nav-token are hard-coded for the
+                       ;; demo; a real server would thread them off the actual
+                       ;; request so each render's lease is genuinely unique.
                        :owner    [:ssr :ssr/req-1 :ssr/nav-1]
                        :cause    :ssr-preload}]]]}))
 
@@ -115,14 +128,14 @@
 ;; VIEWS — passive reads, server and client alike
 ;; ============================================================================
 ;;
-;; The view is a passive reader: it pulls the resource through a subscription
-;; and renders whatever it finds, the same on server and client. Reading does
-;; not trigger a fetch — the preload and hydration already warmed the cache.
-;; `:rf.resource/state` is the runtime-supplied subscription that turns the
-;; cache entry into a view-model (a status flag plus the data). On the server
-;; the resource was preloaded; on the client the hydrated entry is already
-;; present, so the first render shows data straight away. Same view code on
-;; both sides — the "one app, runs twice" promise, now over a managed resource.
+;; The view does the simplest possible thing: it reads the resource through a
+;; subscription and renders whatever's there. Reading never kicks off a fetch —
+;; the preload (server) and the hydration (client) already warmed the cache, so
+;; the data is just sitting there waiting. `:rf.resource/state` is the
+;; runtime's own subscription; it turns a cache entry into a tidy view-model —
+;; a status flag and the data. Either side, the data is present by first render,
+;; so there's no skeleton to flash. The same view code runs on both — the "one
+;; app, runs twice" promise, now over a managed resource.
 ;; See docs/ssr/glossary.md#render-to-string.
 
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
@@ -152,24 +165,28 @@
 ;; SERVER ENTRY POINT
 ;; ============================================================================
 ;;
-;; A per-request frame whose `:initial-events` dispatch `:rf/server-init`, a
-;; drain to settle the blocking page resource, a render to string, and a
-;; hydration payload carrying the allowed resource projection in
-;; `:rf/runtime-db`. The per-request frame is torn down in a `finally` on
-;; every exit path, so a request never leaks a frame.
+;; This is one request, start to finish: mint a per-request frame whose
+;; `:initial-events` fire `:rf/server-init`, drain the blocking page resource,
+;; render to a string, and build a hydration payload carrying the allowed
+;; resource projection under `:rf/runtime-db`. The frame is torn down in a
+;; `finally` on every exit path — success or throw — so a request can never
+;; leak a frame and slowly drown the JVM.
 ;;
-;; Two steps make this the real server path:
+;; Two steps are what make this the real server path rather than a toy:
 ;;
-;;   1. `ssr/drain-blocking-resources!` settles the `[:ssr …]`-owned blocking
-;;      ensure (or times it out into a structured first-load failure) before
-;;      the render walk, so the render never sees a hung `:loading` skeleton.
-;;   2. `payload-policy/project-runtime-db` projects the runtime-db down to the
-;;      serializable allowlist — only the durable `:rf.runtime/resources`
-;;      `:entries`, per-entry redacted (`:sensitive?`) or omitted (`:large?`),
-;;      with the reverse indexes dropped (they recompute on install). Ship the
-;;      projection, never the full runtime-db. The app-db slice rides the
-;;      fail-closed allowlist via `apply-policy` (here empty — the page state
-;;      is the resource, so app-db holds nothing of its own).
+;;   1. `ssr/drain-blocking-resources!` waits for the `[:ssr …]`-owned ensure to
+;;      settle — reach `:loaded`, or time out into a structured first-load
+;;      failure — before we walk the tree. So the render never catches the page
+;;      mid-fetch with a `:loading` skeleton frozen into the HTML.
+;;   2. `payload-policy/project-runtime-db` boils the runtime-db down to just
+;;      what's safe to serialize: the durable `:rf.runtime/resources`
+;;      `:entries`, with `:sensitive?` values redacted, `:large?` values
+;;      omitted, and the reverse indexes dropped (the client rebuilds those
+;;      from `:entries`, so shipping them would be sending data we're about to
+;;      throw away). Ship the projection, never the whole cache. The app-db
+;;      slice rides the fail-closed allowlist via `apply-policy` — empty here,
+;;      because on this page the resource *is* the state and app-db holds
+;;      nothing of its own.
 
 #?(:clj
    (defn handle-request [request]
@@ -181,28 +198,31 @@
                   :initial-events [[:rf/server-init]]})]
        (try
          (rf/with-frame f
-           ;; (1) Settle the blocking page resource before rendering. The
-           ;; `[:ssr …]`-owned ensure dispatched by `:rf/server-init` must reach
-           ;; a terminal status (:loaded / :error) or time out into a settled
-           ;; first-load failure, so the render walk sees real data.
+           ;; (1) Settle the blocking page resource before we render a thing.
+           ;; The `[:ssr …]`-owned ensure that `:rf/server-init` kicked off has
+           ;; to land on a terminal status (:loaded / :error), or time out into
+           ;; a settled first-load failure, so the render walk works with real
+           ;; data instead of an in-flight guess.
            (ssr/drain-blocking-resources! f)
            (let [final-db      (rf/app-db-value f)
-                 final-runtime (rf/runtime-db-value f)   ;; carries :rf.runtime/resources
+                 final-runtime (rf/runtime-db-value f)   ;; this is where :rf.runtime/resources lives
                  hiccup        ((rf/view :app/root))
                  html          (rf/render-to-string hiccup {:doctype? true :emit-hash? true})
                  render-hash   (rf/render-tree-hash hiccup)
-                 ;; (2) Build the payload the way the Ring host does: the
-                 ;; app-db slice through the fail-closed allowlist, and the
-                 ;; runtime-db through the SSR projection (only the allowed
-                 ;; resource `:entries`).
+                 ;; (2) Build the payload exactly the way the Ring host does:
+                 ;; the app-db slice through the fail-closed allowlist, and the
+                 ;; runtime-db through the SSR projection (the allowed resource
+                 ;; `:entries`, and nothing more).
                  ;;
-                 ;; The page state is the resource (it rides `:rf/runtime-db`),
-                 ;; so app-db carries nothing of its own. `:payload` is
-                 ;; fail-closed, so name the intent explicitly: the
-                 ;; `:rf.ssr.payload/whole-app-db` opt-in projects the (empty)
-                 ;; app-db to `{}` cleanly. A bare empty `[]` allowlist instead
-                 ;; reads as a missing policy and throws
-                 ;; `:rf.error/ssr-missing-payload-policy`, not "ship nothing".
+                 ;; The page state is the resource — it rides `:rf/runtime-db` —
+                 ;; so app-db has nothing of its own to send. But the payload
+                 ;; policy is fail-closed by design, so "send nothing" still has
+                 ;; to be said out loud. The `:rf.ssr.payload/whole-app-db`
+                 ;; opt-in projects the empty app-db to `{}` cleanly. A bare `[]`
+                 ;; allowlist would *not* mean "ship nothing" — it reads as a
+                 ;; missing policy and throws
+                 ;; `:rf.error/ssr-missing-payload-policy`. Silence is the one
+                 ;; thing fail-closed won't let you get away with.
                  ;; See docs/ssr/concepts.md#payload--the-fail-closed-allowlist.
                  policy-opts   {:payload :rf.ssr.payload/whole-app-db}
                  payload       (payload-policy/build-payload
@@ -212,17 +232,18 @@
                                  (assoc policy-opts
                                         :runtime-db (payload-policy/project-runtime-db
                                                       final-runtime)))
-                 ;; Drop the payload's `:rf/frame-id`. `build-payload` stamps
-                 ;; it with this per-request gensym frame (`f`), but the client
-                 ;; hydrates a fixed app-frame (`:rf/default`, below).
-                 ;; `ssr/hydrate!` checks any present `:rf/frame-id` against the
-                 ;; client's `:frame` and raises
-                 ;; `:rf.error/hydration-frame-id-mismatch` when they differ —
-                 ;; the frame-id is validation evidence, not a hydration target.
-                 ;; A per-request gensym can never equal the client's fixed id,
-                 ;; so drop it; an absent frame-id is no conflict. A deployment
-                 ;; that wants a frame-id on the wire stamps a stable id both
-                 ;; sides agree on.
+                 ;; Drop the payload's `:rf/frame-id`. `build-payload` stamps it
+                 ;; with this per-request gensym frame (`f`), but the client
+                 ;; hydrates a fixed app-frame (`:rf/default`, below). When a
+                 ;; `:rf/frame-id` *is* present, `ssr/hydrate!` checks it against
+                 ;; the client's `:frame` and raises
+                 ;; `:rf.error/hydration-frame-id-mismatch` if they disagree — so
+                 ;; the frame-id is a sanity check, not a hydration target. Our
+                 ;; gensym could never match the client's fixed id, so leaving it
+                 ;; in would guarantee a false mismatch; dropping it sidesteps
+                 ;; the check entirely (an absent id is no conflict). A
+                 ;; deployment that wants a frame-id on the wire would stamp one
+                 ;; both sides agree on up front.
                  payload       (dissoc payload :rf/frame-id)]
              {:status  200
               :headers {"Content-Type" "text/html"}
@@ -230,10 +251,10 @@
               (str "<!DOCTYPE html><html><head><meta charset='utf-8'/>"
                    "<title>Resources SSR demo</title></head><body>"
                    "<div id='app'>" html "</div>"
-                   ;; Emit the payload `<script>` through the EDN-aware
-                   ;; escaper the production Ring host uses, so a server-
-                   ;; provided string carrying `</script>` can't close the
-                   ;; envelope.
+                   ;; Run the payload `<script>` body through the same EDN-aware
+                   ;; escaper the production Ring host uses, so a server string
+                   ;; that happens to contain `</script>` can't slam the
+                   ;; envelope shut from the inside.
                    "<script id='__rf_payload' type='application/edn'>"
                    (html/escape-edn-script-body (pr-str payload))
                    "</script><script src='/main.js'></script>"
@@ -245,22 +266,24 @@
 ;; CLIENT ENTRY POINT
 ;; ============================================================================
 ;;
-;; `ssr/hydrate!` reads the payload, dispatch-syncs `[:rf/hydrate payload]`
-;; (which installs the resource projection into the carried frame's
-;; `:rf.runtime/resources` slice), and verifies the render hash. A fresh
-;; hydrated entry renders its data on first paint and serves it straight from
-;; the cache — no duplicate fetch, which is the whole point of preloading. A
-;; stale entry would background-refetch by policy. See
-;; docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
+;; The browser's side of the handoff. `ssr/hydrate!` reads the payload,
+;; dispatch-syncs `[:rf/hydrate payload]` to install the resource projection
+;; into the frame's `:rf.runtime/resources` slice, then verifies the render
+;; hash to confirm client and server agree on what the page should look like.
+;; A fresh hydrated entry renders its data on the first paint and serves it
+;; straight from cache — no second fetch, which is exactly what preloading was
+;; for. A stale entry quietly refetches in the background, per its policy.
+;; See docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
 
 #?(:cljs (defonce react-root (atom nil)))
 
-;; The fixed client app-frame. The app names its hydration target explicitly
-;; and threads the same id through both `ssr/hydrate!` (where the server state
-;; lands) and the root `frame-provider` (where in-tree dispatch/subscribe
-;; resolve). It must be a `:client`-platform frame so the `:rf.ssr/check-*`
-;; compatibility-check effects the `:rf/hydrate` handler dispatches actually
-;; fire. See docs/ssr/concepts.md#deploy-drift-checks-come-along-for-free.
+;; The client's one app-frame. The app names its hydration target out loud and
+;; threads the same id through two places: `ssr/hydrate!` (where the server
+;; state lands) and the root `frame-provider` (where in-tree dispatch/subscribe
+;; go looking for their frame). One id, both ends — that's what makes them meet.
+;; It has to be a `:client`-platform frame, or the `:rf.ssr/check-*`
+;; compatibility checks that `:rf/hydrate` fires would simply sit there inert.
+;; See docs/ssr/concepts.md#deploy-drift-checks-come-along-for-free.
 (def app-frame :rf/default)
 
 #?(:cljs

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -1,26 +1,33 @@
 (ns routing.core
-  "A small three-page routing app: home, articles list, article detail.
-   See the [routing guide](../../../docs/routing/concepts.md).
+  "A small three-page routing app: home, an articles list, and an article
+   detail page. See the [routing guide](../../../docs/routing/concepts.md).
 
-   The one idea: the URL is application state you read through a subscription,
-   and navigation is just an event. A route is a registration, the active route
-   is a sub, and `root-view` is a `case` over `:rf.route/id`. No router object,
-   no route context to thread through the tree.
+   Here's the one idea worth taking away: the URL is just application state,
+   and you read it through a subscription. Navigation, then, is just an event.
+   So a route is a registration, the active route is a sub, and `root-view` is
+   a plain `case` over `:rf.route/id` — pick a page by id and render it. No
+   router object to hold, no route context to thread down through the tree.
 
-   The surface this example uses:
+   If you've used a router that hands you an object full of methods, this will
+   feel almost suspiciously quiet. That's the point.
 
-   - `reg-route` for the route table
-   - `:rf.route/id` and `:rf.route/params` to read the active route as subs
-   - `route-link` for links that drive navigation
-   - `:rf/url-requested` for user-initiated anchor clicks
-   - `install-history-listener!` for popstate + initial-load URL→state sync"
+   The pieces of the routing surface this example leans on:
+
+   - `reg-route` — declares the route table, one entry per page
+   - `:rf.route/id` / `:rf.route/params` — read the active route as subs
+   - `route-link` — renders links that drive navigation
+   - `:rf/url-requested` — the event a user clicking an anchor fires
+   - `install-history-listener!` — wires up Back/Forward and the first-load
+     URL→state sync, so the address bar and your app-db stay in agreement"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            ;; Routing ships in the day8/re-frame2-routing artefact. Requiring
-            ;; it registers the route subs the `rf/reg-route` calls below depend
-            ;; on; without this require those calls throw
-            ;; :rf.error/routing-artefact-missing.
+            ;; Routing lives in its own artefact (day8/re-frame2-routing), so
+            ;; you opt into it with a require. The require has a side effect:
+            ;; it registers the route subs that the `rf/reg-route` calls below
+            ;; lean on. Forget it and those calls greet you with
+            ;; :rf.error/routing-artefact-missing — which is the runtime's
+            ;; polite way of saying "you asked for routing but never packed it".
             [re-frame.routing]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -28,6 +35,12 @@
 ;; ============================================================================
 ;; ROUTES
 ;; ============================================================================
+;;
+;; The route table: one `reg-route` per page, each pairing a route id with a
+;; URL pattern. A pattern segment like `:id` is a hole the matcher fills in
+;; and hands back as a param. This is the whole map of the app, written as
+;; data — the kind of thing you can read top-to-bottom and just *know* where
+;; the doors are.
 
 (rf/reg-route :routing.app/home
   {:doc  "Landing page."} "/")
@@ -39,7 +52,8 @@
   {:doc    "Detail page for one article."
    :params [:map [:id :string]]} "/articles/:id")
 
-;; The runtime emits :rf.route/not-found for unmatched URLs.
+;; When a URL matches nothing, the runtime routes to :rf.route/not-found for
+;; you. Register it like any other route and you decide what that page says.
 (rf/reg-route :rf.route/not-found
   {:doc  "Fallback page for unmatched URLs."} "/_404")
 
@@ -47,10 +61,14 @@
 ;; APP DATA
 ;; ============================================================================
 
-;; The articles collection lives under :routing.app/articles-list. Route
-;; ids and sub/app-db keys live in separate registries, so a clash is
-;; harmless — but a distinct key (not :routing.app/articles, the route
-;; id) keeps the example easy to scan.
+;; Now the boring-but-honest part: the actual articles. Routing tells you
+;; *which* page; this is the data the pages render.
+;;
+;; The articles live under :routing.app/articles-list. Route ids and
+;; app-db/sub keys live in separate registries, so naming this key
+;; :routing.app/articles (same as the route) wouldn't actually clash. But
+;; giving it a distinct name keeps the example scannable — "which one's the
+;; route, which one's the data?" should never be a puzzle.
 (rf/reg-event :routing.app/initialise
   (fn [{:keys [db]} _]
     {:db {:routing.app/articles-list
@@ -69,12 +87,18 @@
 ;; PAGES
 ;; ============================================================================
 ;;
-;; Links use `rf/route-link`, the framework view shipped by the routing
-;; artefact. It renders an `<a href=...>`, intercepts plain primary-button
-;; clicks to dispatch `:rf/url-requested`, and defers modifier-key and
-;; middle-click clicks to the browser so open-in-new-tab still works. Any
-;; passthrough HTML attrs on the props map (e.g. `:data-testid`) land on the
-;; underlying `<a>`. See the routing guide, "Linking from views":
+;; One view per page. Links between them use `rf/route-link`, a small view the
+;; routing artefact ships so you don't hand-roll anchors.
+;;
+;; It renders a real `<a href=...>` — so it looks and feels like a normal
+;; link, and the href is even right if someone hovers or copies it. The trick
+;; is in the click: a plain left-click is caught and turned into a
+;; `:rf/url-requested` event (no full page reload), while modifier-clicks and
+;; middle-clicks are waved straight through to the browser, because nobody
+;; likes a link that's forgotten how to open in a new tab. Any extra HTML
+;; attrs you pass (here `:data-testid`) ride along onto the `<a>`.
+;;
+;; See the routing guide, "Linking from views":
 ;; ../../../docs/routing/concepts.md#linking-from-views
 
 (reg-view home-page []
@@ -98,9 +122,10 @@
 (reg-view article-detail-page []
   (let [id      (:id @(subscribe [:rf.route/params]))
         article @(subscribe [:routing.app/article-by-id id])]
-    ;; The back-link is page-chrome shared by both the found and
-    ;; not-found states, so compute only the differing inner content
-    ;; per branch and render the link once.
+    ;; The "← Back" link is the same in both cases — found or not — so it's
+    ;; page chrome, not page content. We let each branch decide only the bit
+    ;; that actually differs (the article, or the apology) and render the link
+    ;; once underneath. Say a thing once.
     [:div
      (if article
        [:<> [:h1 (:title article)]
@@ -119,6 +144,11 @@
                          :data-testid "route-link-home"}
           "Home"]]]))
 
+;; And here's the router, in its entirety. Subscribe to the active route id,
+;; `case` over it, render the matching page. That's it — no <Routes>, no
+;; <Switch>, no nesting. The URL changes, the sub updates, this re-renders the
+;; new page. If you were expecting more machinery, that's the whole trick:
+;; routing is just another sub feeding just another view.
 (reg-view root-view []
   (case @(subscribe [:rf.route/id])
     :routing.app/home           [home-page]
@@ -130,37 +160,45 @@
 ;; MOUNT (+ router wiring)
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; We stash the React root in an atom and create it lazily inside `run`,
+;; rather than at namespace load. The rule (see examples/TESTING.md, the
+;; mount-isolation convention) is that loading a namespace must touch no DOM:
+;; the test harness loads several example namespaces side by side, and if each
+;; eagerly grabbed `#app` they'd trample one another's `create-root`. Lazy
+;; means whoever calls `run` wins the element, and only then.
 (defonce react-root (atom nil))
 
-;; The frame id the whole app runs under. `:rf/default` is an ordinary id
-;; with no framework privilege — the runtime won't infer it for you, so you
-;; establish it like any other (the provider in `run` does that). A frame
-;; owns the browser URL by carrying `:url-bound? true`, which this app's
-;; provider sets. See the routing guide, "The browser is just another event
-;; source": ../../../docs/routing/concepts.md#the-browser-is-just-another-event-source
+;; The id of the one frame this whole app runs under. `:rf/default` looks
+;; special, but it isn't — it's an ordinary id with no secret privileges, and
+;; the runtime won't conjure it for you. You stand it up like any other (the
+;; provider in `run` does exactly that). The one bit of magic worth knowing:
+;; a frame "owns" the browser URL when it carries `:url-bound? true`, and this
+;; app's provider flips that on. That's what connects the address bar to *this*
+;; frame's route state. See the routing guide, "The browser is just another
+;; event source":
+;; ../../../docs/routing/concepts.md#the-browser-is-just-another-event-source
 (def app-frame :rf/default)
 
 (defn run []
-  ;; Install the Reagent adapter. Each adapter ns exports an `adapter`
-  ;; var; pass it directly to `init!`.
+  ;; Tell re-frame2 to render through Reagent. Every adapter namespace exports
+  ;; an `adapter` var; hand it straight to `init!` and you're done.
   (rf/init! reagent-adapter/adapter)
-  ;; Install the framework popstate listener. It does the initial
-  ;; URL→state sync now, then on each Back/Forward resolves the URL-owner
-  ;; frame at pop time and updates that frame's `:rf/route` slice. Safe to
-  ;; call again on hot reload.
+  ;; Teach the app to listen to the browser's own navigation. This does two
+  ;; jobs: right now, it syncs the current URL into state (so a deep link or a
+  ;; refresh lands on the right page), and from here on, every Back/Forward
+  ;; finds whichever frame owns the URL and updates its `:rf/route` slice.
+  ;; Idempotent, so hot reload can call it again without complaint.
   (rf/install-history-listener!)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    ;; The frame provider sets up the app frame in one spot. On first mount
-    ;; it creates the frame under `app-frame`, marks it `:url-bound? true` so
-    ;; it owns the URL, and runs `:initial-events` once to seed app-db. On
-    ;; hot reload it reuses the existing frame and skips the seed. Everything
-    ;; in `root-view` then dispatches and subscribes against this frame.
+    ;; The frame provider is where the app frame actually comes to life — one
+    ;; tidy spot for the whole setup. First mount: it creates the frame under
+    ;; `app-frame`, flips on `:url-bound? true` so this frame owns the URL, and
+    ;; fires `:initial-events` once to seed app-db with our articles. Hot
+    ;; reload: it finds the frame already there and quietly skips the seed, so
+    ;; your edits don't reset the page out from under you. From then on every
+    ;; `dispatch` and `subscribe` inside `root-view` is wired to this frame.
     (rdc/render @react-root
                 [rf/frame-provider {:id app-frame
                                     :doc "Routing demo frame."

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -1,37 +1,41 @@
 (ns seven-guis.cells.core
-  "7GUIs #7 — Cells.
+  "7GUIs #7 — Cells: a tiny spreadsheet.
 
-   A small spreadsheet with cells A1..Z100. Each cell holds either a literal
-   value or a formula. Formulas reference other cells. Changes propagate.
+   A 26×100 grid (A1..Z100). Type a number into a cell, or a formula like
+   `=(+ A1 B2)` that refers to other cells. Edit a cell anyone depends on and
+   the change ripples outward, the way it does in every spreadsheet you've ever
+   used. That ripple is the whole exercise.
 
-   This is a test of change propagation through a dependency graph. Each
-   cell's display value is a subscription (`:cells/value`) parameterised by
-   id, derived purely from the cell map in app-db. The subscription layer
-   handles propagation, so there are no hand-maintained per-cell observers
-   to keep in sync.
+   Here's the trick, and it's a good one: there is no propagation code. We
+   never track who-depends-on-whom or push updates along edges. Each cell's
+   display value is just a subscription — `:cells/value` parameterised by id —
+   that reads the cell map out of app-db and computes a number. The derivation
+   graph does the rippling for us.
 
-   Every `:cells/value` sub takes the whole cell map (`:cells/all-cells`) as
-   its single input. Committing any cell produces a fresh map identity, so
-   every mounted value reaction recomputes — dependent or not. This stays
-   cheap because the evaluator is a pure function over a small grid (26×100),
-   and the subscription layer `=`-dedups each result, so a cell whose value
-   is unchanged does not re-render. See the derivation graph in
-   ../../../../docs/guide/glossary.md#the-derivation-graph.
+   How? Every `:cells/value` reads the *whole* cell map (`:cells/all-cells`) as
+   its one input. Commit any edit and that map gets a fresh identity, so every
+   cell on screen recomputes — dependents and bystanders alike. Sounds
+   wasteful; isn't. The evaluator is a pure function over a small grid, and the
+   subscription layer `=`-dedups every result, so a cell whose value didn't
+   actually move doesn't re-render. We trade a little recompute (cheap) for
+   zero bookkeeping (priceless). The
+   [derivation graph](../../../../docs/guide/glossary.md#the-derivation-graph)
+   has the full story.
 
-   Demonstrates:
-   - Pure derivation of every cell from a single shared input sub
-   - `=`-dedup in the subscription layer avoiding re-render of unchanged cells
-   - Cycles detected via a visited-set walk during evaluation
-   - Typed error markers propagated through arithmetic (never throws)
-   - Open-map cell registry (sparse storage)
-   - Pure parser + evaluator (no eval, no host I/O)
+   What this example shows off:
+   - Every cell derived purely from one shared input sub — no per-cell wiring
+   - `=`-dedup keeping unchanged cells from re-rendering
+   - Cycles (A1 → B1 → A1) caught by a visited-set walk, not a stack overflow
+   - Bad arithmetic turned into typed error markers — the evaluator never throws
+   - A sparse cell registry: only edited cells take up space
+   - A pure parser + evaluator — no `eval`, no host I/O, runs anywhere
 
-   Scope: 26 cols × 100 rows. Formulas of the form '=expr' where expr is a
-   simple S-expression-flavored calculator (numbers, +, -, *, /, cell refs)."
+   The formula language is a tiny parenthesised calculator: numbers, cell refs
+   (A1..Z100), and `+ - * /`, all written prefix inside `()`."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Loading re-frame.schemas registers the hooks that make
-            ;; rf/reg-app-schema resolve.
+            ;; Pulled in for its side effect: loading it wires up the hooks that
+            ;; make `rf/reg-app-schema` actually do something.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -48,14 +52,23 @@
   100)
 
 (def cell-re
-  "Cell-id regex — one capital letter + 1-3 digits (e.g. A1, Z99, A100).
-   The grid is 26 cols × 100 rows, so row 100 cell-ids (A100..Z100) carry
-   three digits and MUST match here, otherwise a formula referencing a
-   row-100 cell parses as #PARSE even though the cell exists in the grid."
+  "Matches a cell id: one capital letter, then 1-3 digits (A1, Z99, A100).
+   The three-digit allowance is load-bearing. Row 100 really exists, so its
+   ids (A100..Z100) need three digits — leave those out and a formula pointing
+   at a perfectly valid row-100 cell would be rejected as #PARSE. Off-by-one
+   errors love a good fencepost."
   #"^[A-Z]\d{1,3}$")
 
-(defn cell-id [col row] (str (char (+ 65 col)) row))
-(defn parse-cell-id [s]
+;; The two directions between a grid coordinate and its name. 65 is the
+;; ASCII code for "A", so column 0 reads as A, column 1 as B, and so on.
+(defn cell-id
+  "Coordinate → name: `(cell-id 0 1)` => \"A1\"."
+  [col row] (str (char (+ 65 col)) row))
+
+(defn parse-cell-id
+  "Name → coordinate: \"A1\" => `[0 1]`. Returns nil for anything that isn't
+   a valid cell id."
+  [s]
   (when (re-matches cell-re s)
     [(- (int (.charAt s 0)) 65) (js/parseInt (subs s 1))]))
 
@@ -63,6 +76,9 @@
 ;; SCHEMA
 ;; ============================================================================
 
+;; What one cell remembers. We keep the raw text alongside the parsed form so
+;; editing shows you exactly what you typed, while the evaluator works from the
+;; pre-parsed AST.
 (def CellEntry
   [:map
    [:raw     :string]                  ;; what the user typed
@@ -76,11 +92,11 @@
    [:selected-id [:maybe :string]]
    [:editing-id  [:maybe :string]]])
 
-;; Register the app-db schema for the app frame. `reg-app-schema` needs a
-;; frame in scope, so `with-frame :rf/default` names the frame `run` mounts.
-;; The schema binds by frame id, so this works at ns-load even though the
-;; frame does not exist yet; once it does, the schema validates its
-;; `[:cells]` commits.
+;; Hand the schema to the frame so every commit under `[:cells]` gets validated.
+;; `reg-app-schema` needs a frame in scope, and `with-frame` supplies one by id
+;; — `:rf/default`, the same name `run` mounts down below. The id is all that's
+;; needed: we can register the schema here at load time, before the frame
+;; actually exists, and it snaps into place once the frame is created.
 (with-frame :rf/default
   (rf/reg-app-schema [:cells] {:schema CellsState}))
 
@@ -88,15 +104,19 @@
 ;; PARSER + EVALUATOR
 ;; ============================================================================
 ;;
-;; Tiny S-expression flavor: '=(+ A1 (* B2 3))'. Pure functions, JVM-runnable.
+;; A formula is a string like '=(+ A1 (* B2 3))'. Turning that into an answer
+;; is two steps: parse the text into an AST, then walk the AST computing a
+;; number. Everything here is a pure function — no `eval`, no DOM, no surprises
+;; — so it runs just as happily on the JVM in a unit test as it does in the
+;; browser.
 
 (def num-re
-  "Full-string numeric grammar: optional sign, integer and/or fractional
-   part, optional exponent. Anchored end-to-end so lax prefixes like
-   \"1abc\" or \"1.2.3\" are rejected — `js/parseFloat` would otherwise
-   silently accept their leading numeric run (\"1abc\" → 1), letting an
-   invalid token/literal evaluate as a number instead of surfacing a
-   parse error / staying text."
+  "Matches a string that is *entirely* a number: optional sign, an integer
+   and/or fractional part, optional exponent. The anchors (`^`…`$`) matter.
+   Without them `js/parseFloat` is too forgiving — it reads \"1abc\" as 1 and
+   \"1.2.3\" as 1.2, happily swallowing the leading numeric run. That would let
+   junk masquerade as a number instead of surfacing as a parse error or staying
+   plain text, so we insist the whole string be numeric or nothing."
   #"^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$")
 
 (defn parse-num
@@ -109,8 +129,10 @@
         (when-not (js/isNaN n) n)))))
 
 (defn tokenise [s]
-  ;; Splits a formula body into tokens. Whitespace-separated; '(' and ')'
-  ;; split out as their own tokens.
+  ;; Chop a formula body into tokens. Tokens are whitespace-separated, and we
+  ;; pad the parens with spaces first so "(+" becomes "( +" — that way "(" and
+  ;; ")" fall out as tokens of their own without anyone needing to write spaces
+  ;; around them.
   (->> (-> s
            (str/replace #"\(" " ( ")
            (str/replace #"\)" " ) ")
@@ -124,9 +146,11 @@
   "=(+ A1 B2) — start with '=', then numbers, cell refs (A1..Z100), and +-*/ inside ().")
 
 (defn parse-tokens [tokens]
-  ;; Returns [ast remaining-tokens] or throws on malformed input. Each
-  ;; ex-info carries the offending token in its data so `parse-formula` can
-  ;; build an actionable, position-aware message.
+  ;; A little recursive-descent parser. Reads one expression off the front of
+  ;; the token list and returns [ast remaining-tokens]; a "(" recurses to gobble
+  ;; a nested list until its ")". Malformed input throws, and each thrown
+  ;; ex-info tucks the offending token into its data so `parse-formula` can point
+  ;; the user right at it.
   (if (empty? tokens)
     [nil tokens]
     (let [[t & more] tokens]
@@ -140,7 +164,8 @@
                                        (recur (conj acc child) rest-toks))))
         ")" (throw (ex-info "an extra ')' has no matching '(' — remove it or add a '('"
                             {:token ")"}))
-        ;; Atom: number, cell ref, or operator symbol.
+        ;; Anything else is a single atom: a number, a cell ref, an operator,
+        ;; or — if it's none of those — a typo we explain.
         (let [num (parse-num t)]
           (cond
             (some? num)                    [num                             more]
@@ -151,15 +176,17 @@
                                                            {:token t}))))))))
 
 (defn parse-error-message
-  "Build an actionable parse-error message for cell `id` (may be nil) whose
-   formula text is `raw`, given the caught exception `e`. Names the cell, shows
-   the formula, points at the offending token where known, and states the
-   expected shape in user terms."
+  "Turn a caught parse exception into a sentence a human can act on. Names the
+   cell `id` (may be nil), echoes the formula `raw`, points at the offending
+   token when we know it, and reminds the user what a good formula looks like.
+   A blank \"#PARSE\" tells you nothing; \"can't parse … token '%'\" tells you
+   where to look."
   [id raw e]
   (let [reason (or (ex-message e) "could not be parsed")
         token  (:token (ex-data e))
-        ;; Token position in the formula body (1-based, after the '='), where
-        ;; the offending token can be located. Best-effort: nil when unknown.
+        ;; Where in the formula the bad token sits, 1-based after the '='. We
+        ;; just find the token's first occurrence — good enough to nudge the
+        ;; eye, and nil if we can't locate it.
         pos    (when (and token (string? raw))
                  (let [i (str/index-of raw token)]
                    (when i (inc i))))]
@@ -169,9 +196,11 @@
          " — " reason ". Expected " formula-shape-hint)))
 
 (defn parse-formula
-  "Parse `raw` (a \"=...\" formula) for cell `id` (used only to make the error
-   message name the cell). Returns the AST on success, or a `[:error/parse msg]`
-   pair carrying an actionable message on failure."
+  "Parse a \"=...\" formula into an AST. `id` is only along for the ride so a
+   failure message can name the cell. Note the return contract: success gives
+   you the AST, failure gives you a `[:error/parse msg]` pair. We don't throw
+   across this boundary — the error becomes a value that rides all the way
+   through evaluation and out to the cell as a tooltip."
   ([raw] (parse-formula nil raw))
   ([id raw]
    (let [body (subs raw 1)]
@@ -196,8 +225,10 @@
   (when (parse-error? ast) (second ast)))
 
 (defn collect-deps [ast]
-  ;; Returns the set of cell ids referenced anywhere in the AST. A parse-error
-  ;; pair (`[:error/parse msg]`) is not an AST and carries no deps.
+  ;; Walk the AST and gather every cell id it mentions. We stash this set on the
+  ;; cell when we commit it — handy for tooling and debugging, even though
+  ;; evaluation doesn't lean on it (the derivation graph already knows the
+  ;; dependencies). A parse-error pair isn't an AST, so it contributes nothing.
   (cond
     (parse-error? ast)    #{}
     (vector? ast)         (apply clojure.set/union (map collect-deps ast))
@@ -207,7 +238,12 @@
 
 (declare evaluate-cell)
 
-(defn evaluate-ast [ast cells visited]
+(defn evaluate-ast
+  "Walk an AST to a value. Numbers are themselves, a cell ref defers to
+   `evaluate-cell`, and a list applies its operator to evaluated args. Errors
+   are values here, not exceptions — they flow upward instead of unwinding the
+   stack."
+  [ast cells visited]
   (cond
     (number? ast) ast
     (nil? ast)    nil
@@ -218,10 +254,9 @@
     (vector? ast)
     (let [[op & args] ast
           vals        (mapv #(evaluate-ast % cells visited) args)]
-      ;; Propagate errors/non-numbers rather than feeding them to the op
-      ;; (which would throw): surface an upstream error marker if one
-      ;; reached us, else :error/type for text-in-arithmetic. `-` and `/`
-      ;; with no args throw an arity error, so guard empty `vals` too.
+      ;; Only do arithmetic if every argument actually came back a number.
+      ;; Feeding text or an error marker to `+` would throw, and so would `-`
+      ;; or `/` with no args at all — hence the `seq` guard too.
       (if (and (seq vals) (every? number? vals))
         (case (str op)
           "+" (apply + vals)
@@ -229,18 +264,24 @@
           "*" (apply * vals)
           "/" (if (some zero? (rest vals)) :error/div-by-zero (apply / vals))
           :error/unknown-op)
-        ;; Surface the first upstream error marker that reached us — a
-        ;; referenced cell's parse-error pair or a keyword error marker — else
-        ;; :error/type for text-in-arithmetic.
+        ;; Something upstream wasn't a number. If a real error reached us — a
+        ;; referenced cell's parse-error pair, or a keyword marker like
+        ;; :error/cycle — pass the first one along unchanged so the original
+        ;; cause survives. Otherwise it's plain text in a sum: :error/type.
         (or (first (filter parse-error? vals))
             (first (filter keyword? vals))
             :error/type)))
 
     :else :error/eval))
 
-(defn evaluate-cell [id cells visited]
-  ;; Returns the cell's display value, :error/cycle, or the parse-error pair
-  ;; `[:error/parse msg]` (the actionable message rides through to the view).
+(defn evaluate-cell
+  "Compute one cell's display value. `visited` is the set of cell ids already on
+   the current evaluation path — our cycle guard. If we're asked to evaluate a
+   cell that's already on the path, A1 → B1 → A1 has come back to bite us, so we
+   bail with :error/cycle instead of recursing forever. A formula recurses with
+   itself added to the set; a literal parses to a number or stays text; an
+   untouched cell is simply 0."
+  [id cells visited]
   (cond
     (visited id)  :error/cycle
     :else
@@ -274,7 +315,9 @@
         (assoc-in [:cells :editing-id]  id))}))
 
 (rf/reg-event :cells/commit
-  {:doc "Commit the user's edit. Parses formulas and stores deps."
+  {:doc "Save the user's edit. Parses any formula up front and stashes the AST
+         and its deps on the cell — so evaluation later is just a walk, never a
+         re-parse. Blank input deletes the cell, keeping the map sparse."
    :schema [:cat [:= :cells/commit] :string :string]}
   (fn handler-cells-commit [{:keys [db]} [_ id raw]]
     {:db (let [formula? (and (string? raw) (str/starts-with? raw "="))
@@ -297,14 +340,15 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; The :cells/value sub is parameterised by id — `(subscribe [:cells/value
-;; "A1"])`. Each cell's display value derives from the full cells map, so
-;; every value reaction recomputes on any edit; the subscription layer
-;; =-dedups the result so only cells whose value actually changed re-render.
+;; This is where the propagation magic actually lives — which is to say,
+;; nowhere special. `:cells/value` is parameterised by id, so a view asks for a
+;; specific cell with `(subscribe [:cells/value "A1"])`. Every such sub reads
+;; the one shared input below and computes from scratch, and `=`-dedup makes
+;; that cheap. No edges, no listeners, no propagation engine.
 
 (rf/reg-sub :cells/all-cells
-  {:doc "The sparse cell map (only edited cells are present). Single input to
-         every cell's value/raw sub."}
+  {:doc "The sparse cell map — only edited cells are present. Every cell's value
+         and raw sub hangs off this one input."}
   (fn sub-cells-all-cells [db _] (get-in db [:cells :cells])))
 
 (rf/reg-sub :cells/raw
@@ -313,10 +357,11 @@
   (fn sub-cells-raw [cells [_ id]] (get-in cells [id :raw] "")))
 
 (rf/reg-sub :cells/value
-  {:doc "Display value of cell `id`. Pure derivation against the full cells map.
-         The evaluator already turns bad input into typed error markers; the
-         try/catch is a defence-in-depth backstop so a value reaction can never
-         throw out of its compute (which would break render of the whole grid)."}
+  {:doc "Display value of cell `id` — a pure derivation over the whole cell map.
+         The evaluator already turns bad input into typed error markers, so this
+         try/catch is belt-and-suspenders: if some unforeseen input ever slips
+         through and throws, one cell shows #EVAL instead of taking the entire
+         grid's render down with it."}
   :<- [:cells/all-cells]
   (fn sub-cells-value [cells [_ id]]
     (try
@@ -335,14 +380,20 @@
 ;; VIEW
 ;; ============================================================================
 
+;; One cell. It has two faces: while you're editing it shows an <input> holding
+;; the raw text; otherwise it shows the computed value. Which face we wear comes
+;; straight from subscriptions, so any edit anywhere just flows back in.
 (reg-view cell-view [id]
   (let [editing-id @(subscribe [:cells/editing-id])
         editing?   (= editing-id id)
         raw        @(subscribe [:cells/raw   id])
         value      @(subscribe [:cells/value id])
-        ;; A parse error rides through as `[:error/parse msg]`; pull out the
-        ;; actionable message to surface on hover.
+        ;; A parse error arrives as `[:error/parse msg]`; pull the message out so
+        ;; we can show it on hover.
         parse-err  (parse-error-text value)
+        ;; Pick what the cell shows. The error markers map to the familiar
+        ;; spreadsheet hash-codes (#CYCLE, #DIV/0, …); anything else is just the
+        ;; value, stringified.
         display    (cond
                      editing?                  raw
                      parse-err                 "#PARSE"
@@ -351,12 +402,12 @@
                      (= value :error/type)     "#TYPE"
                      (= value :error/div-by-zero) "#DIV/0"
                      :else                     (str value))]
-    ;; `data-cell`/`data-cell-input` carry the grid coordinate as a domain
-    ;; attribute; `data-testid` mirrors the cluster's test-hook scheme so the
-    ;; six examples share one selector convention. On a parse error the
-    ;; actionable message rides in `title` (native hover tooltip) and is
-    ;; mirrored to `data-parse-error` so it is inspectable, with an
-    ;; `cell--parse-error` class for styling.
+    ;; The `data-*` attributes are hooks for tests and tooling: `data-cell`
+    ;; tags the coordinate, and `data-testid` follows the same naming the other
+    ;; seven-GUIs examples use, so one selector convention covers them all. When
+    ;; the cell holds a parse error we also stash the message three ways — in
+    ;; `title` for a native hover tooltip, in `data-parse-error` for inspection,
+    ;; and as a class to style it.
     [:td.cell (cond-> {:data-cell   id
                        :data-testid (str "cells-cell-" id)
                        :on-click    #(dispatch [:cells/start-editing id])}
@@ -389,26 +440,29 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. ns-load must produce no DOM side effects, so co-required example
-;; namespaces don't race `create-root` onto the shared `#app`.
+;; We hold the React root in an atom and create it lazily inside `run`, never at
+;; load time. Loading a namespace must not touch the DOM — otherwise several
+;; example namespaces sharing this page would all race to call `create-root` on
+;; the same `#app` element. Once is plenty.
 (defonce react-root (atom nil))
 
-;; The frame lives in one spot: the `frame-provider {:id app-frame …}` in
-;; `run`. On first mount it creates the frame, applies its config, and runs
-;; `:initial-events` once to seed app-db. Thereafter every `dispatch` and
-;; `subscribe` in the tree resolves to that frame. On hot reload the provider
-;; reuses the existing frame and skips re-seeding, so the grid keeps its
-;; values. `init!` (below) only installs the adapter; the provider creates the
-;; frame. See ../../../../docs/guide/glossary.md#frame-provider.
+;; The frame's whole life happens in one place: the `frame-provider` down in
+;; `run`. First mount creates the frame, applies its config, and fires
+;; `:initial-events` once to seed app-db. After that every `dispatch` and
+;; `subscribe` in the tree finds *this* frame. On hot reload the provider reuses
+;; the frame it already made and skips the seeding, so your grid keeps the
+;; values you typed. (`init!` below doesn't make the frame — the provider does.)
+;; The [frame-provider](../../../../docs/guide/glossary.md#frame-provider)
+;; glossary entry has the longer version.
 ;;
-;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
-;; with no framework privilege.
+;; `app-frame` is just an id we chose. `:rf/default` is an ordinary frame id —
+;; no special powers, despite the official-looking name.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the reactive adapter for the process. Each adapter ns
-  ;; exports an `adapter` var; require the ns and pass that var directly.
+  ;; `init!` tells re-frame2 which reactive substrate to render through — here,
+  ;; Reagent. Every adapter namespace exports an `adapter` var; you require the
+  ;; namespace and hand that var straight in.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -1,27 +1,30 @@
 (ns seven-guis.circle-drawer.core
   "7GUIs #6 — Circle Drawer.
 
-   A canvas. Click to add a circle at the click position with a default
-   diameter. Right-click a circle to adjust its diameter: that opens a
-   slider in a modal dialog, and closing the dialog commits the new size.
-   Undo/Redo buttons step through the history.
+   Click on a canvas to drop a circle. Right-click one to resize it: a slider
+   pops up in a modal, and closing the modal commits the new size. Undo and
+   Redo walk back and forth through everything you've done.
 
-   This is the 7GUIs undo/redo test. The undo state lives in app-db, not in
-   a component: an interceptor snapshots app-db before each undoable event,
-   and Undo/Redo events pop/push from the snapshot stacks.
+   This is the 7GUIs undo/redo challenge, and undo is the whole point. The
+   trick is *where* the history lives: not tangled up inside a component, but
+   right in app-db as plain data. An interceptor takes a snapshot before each
+   undoable event, and the Undo/Redo events just pop and push those snapshots.
+   History is state, so it gets to be data like everything else.
 
-   Demonstrates:
-   - Undo / redo via an interceptor plus sibling events
-   - A modal dialog held as state, not as a React component
-   - A continuous slider drag that adds no history steps
-   - A schema-bound list
+   Worth watching here:
+   - Undo / redo built from one interceptor plus a couple of sibling events
+   - A modal dialog kept as state, not as a mounted React component
+   - A continuous slider drag that, cleverly, adds no history steps at all
+   - A schema-bound list, validated on every commit
 
-   This is the primitive pattern. A full undo library (multiple policies,
-   per-slice, max depth) is user or library code, not framework code."
+   What you'll see is the *primitive* pattern — enough to do undo well. A
+   full-featured undo library (per-slice history, depth limits, custom
+   policies) belongs in user or library code. The framework gives you the
+   hook; the rest is yours."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Loading `re-frame.schemas` registers the hooks that make
-            ;; `rf/reg-app-schema` resolve.
+            ;; Pulling in `re-frame.schemas` wires up the hooks that teach
+            ;; `rf/reg-app-schema` how to do its job. Require it, then use it.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -31,13 +34,17 @@
 ;; SCHEMA
 ;; ============================================================================
 
-;; A circle's `:id` is a monotonic `:int` minted from a db-held counter. The id
-;; lands in durable app-db (`[:drawer :circles]`), so it must be a function of
-;; prior state, not an ambient `(random-uuid)` — replaying the event stream
-;; would otherwise mint different ids (see "Recordable vs ambient coeffects" in
-;; docs/guide/glossary.md). The id is just an internal handle: a React `:key`
-;; and a context-menu target. Undo/redo snapshot whole `:circles` vectors, so
-;; the ids ride the snapshot and round-trip unchanged.
+;; Each circle needs an id, and the choice of *what kind* of id is more
+;; interesting than it looks. We use a plain counting `:int`, handed out from a
+;; counter we keep in app-db. Why not just reach for `(random-uuid)`? Because
+;; this id ends up in durable app-db (`[:drawer :circles]`), and anything that
+;; lands in app-db should be a function of prior state. Replay the same event
+;; stream and you must get the same ids back — a random uuid would betray that
+;; the moment you replayed (see "Recordable vs ambient coeffects" in
+;; docs/guide/glossary.md). The id itself is humble: a React `:key` and
+;; something to aim a right-click at. And since undo/redo snapshots whole
+;; `:circles` vectors, the ids simply ride along in the snapshot and come back
+;; unchanged.
 (def Circle
   [:map
    [:id      :int]
@@ -48,19 +55,20 @@
 (def DrawerState
   [:map
    [:circles   [:vector Circle]]
-   [:next-id    :int]                           ;; deterministic id allocator
-   [:dialog    [:maybe [:map
+   [:next-id    :int]                           ;; the next id to hand out — counts up, never repeats
+   [:dialog    [:maybe [:map                    ;; the resize modal, or nil when nothing's open
                         [:circle-id      :int]
                         [:initial-radius pos-int?]
                         [:draft-radius   pos-int?]]]]
-   [:undo      [:vector :any]]                  ;; stack of prior :circles values
-   [:redo      [:vector :any]]])
+   [:undo      [:vector :any]]                  ;; past :circles values, newest on top
+   [:redo      [:vector :any]]])                ;; undone :circles values, waiting for Redo
 
-;; Bind the schema to the app frame so it validates that frame's commits.
-;; `reg-app-schema` is frame-local. This runs at ns-load, before any provider
-;; exists, so name the frame explicitly with `with-frame` rather than relying
-;; on a frame in scope. `:rf/default` matches the render root's
-;; `frame-provider` below.
+;; Now bind the schema to a frame, and from then on every commit to that frame
+;; gets checked against it. Schemas are frame-local — each frame validates its
+;; own. There's a timing wrinkle: this line runs at ns-load, long before any
+;; provider has mounted, so there's no frame "in scope" to pick up implicitly.
+;; We just say which one out loud with `with-frame`. The `:rf/default` here is
+;; the same frame the render root's `frame-provider` names below.
 (with-frame :rf/default
   (rf/reg-app-schema [:drawer] {:schema DrawerState}))
 
@@ -68,22 +76,31 @@
 ;; UNDO INTERCEPTOR
 ;; ============================================================================
 ;;
-;; Captures :circles before the handler runs; pushes the prior value onto :undo
-;; and clears :redo. An undoable event opts in by listing this interceptor's id
-;; (`:undoable`) in its :interceptors. Only the commit events carry it, so the
-;; continuous slider drag leaves the history alone.
+;; Here's the engine room. An interceptor wraps a handler with a :before pass
+;; and an :after pass — think of it as a chance to peek at the world on the way
+;; in and tidy up on the way out. This one remembers what :circles looked like
+;; *before* the handler ran (:before), and if the handler actually changed
+;; things, files that old value onto the :undo stack (:after). Redo gets wiped,
+;; because once you take a new action the future you'd undone-into is gone.
+;;
+;; The clever part is opting in. An event becomes undoable simply by listing
+;; this interceptor's id (`:undoable`) in its :interceptors — nothing more. Only
+;; the events that *commit* a change wear it, which is exactly why dragging the
+;; slider around can stay silent and add no history at all.
 ;; See docs/guide/concepts/interceptors.md.
 
 (rf/reg-interceptor :undoable
   {:doc "Snapshot :circles before an undoable handler runs; push the prior
          value onto :undo and clear :redo when the handler changed it."}
   {:before (fn before [ctx]
-             ;; snapshot taken from coeffects (the pre-handler db).
+             ;; On the way in: stash the old :circles. We read it from coeffects,
+             ;; which is the db as it stands *before* the handler touches it.
              (let [db   (get-in ctx [:coeffects :db])
                    prior (get-in db [:drawer :circles])]
                (assoc-in ctx [:coeffects :prior-circles] prior)))
    :after  (fn after [ctx]
-             ;; if the handler changed db, push the prior value to :undo.
+             ;; On the way out: only bother recording history if the handler
+             ;; actually changed :circles. No change, no undo step.
              (let [prior     (get-in ctx [:coeffects :prior-circles])
                    db-after  (get-in ctx [:effects :db])]
                (if (and db-after (not= prior (get-in db-after [:drawer :circles])))
@@ -97,17 +114,18 @@
 ;; ============================================================================
 
 (rf/reg-event :drawer/initialise
-  {:doc "Seed an empty canvas. `:next-id` is the deterministic id allocator —
-         circles take monotonic int ids starting at 1."}
+  {:doc "Start with a blank canvas. `:next-id` is our id dispenser — the first
+         circle gets 1, and it climbs from there."}
   (fn handler-drawer-initialise [{:keys [db]} _]
     {:db (assoc db :drawer {:circles [] :next-id 1 :dialog nil :undo [] :redo []})}))
 
 (rf/reg-event :drawer/add-circle
-  {:doc "Click on canvas. Adds a circle of default radius. The id comes from
-         the db-held `:next-id` counter, then the counter is bumped — a durable
-         id is a function of prior state, not an ambient `(random-uuid)`. The
-         counter lives outside the undoable `:circles` snapshot, so it keeps
-         climbing across undo/redo and never re-mints a live id."
+  {:doc "You clicked the canvas, so a new circle appears at default size. It
+         takes the next id from `:next-id`, then bumps the counter — that's how
+         the id stays a function of prior state instead of a roll of the dice.
+         The counter sits *outside* the `:circles` snapshot that undo/redo
+         tracks, so it just keeps climbing and can never accidentally reissue an
+         id that's still in use."
    :interceptors [:undoable]}
   (fn handler-drawer-add-circle [{:keys [db]} [_ x y]]
     {:db (let [id (get-in db [:drawer :next-id])]
@@ -116,7 +134,9 @@
           (assoc-in  [:drawer :next-id] (inc id))))}))
 
 (rf/reg-event :drawer/open-dialog
-  {:doc "Right-clicked a circle. Opens the adjust-diameter dialog. Not undoable."}
+  {:doc "You right-clicked a circle, so the resize dialog opens on it. Just
+         opening the dialog changes nothing you'd want to undo, so it skips the
+         interceptor."}
   (fn handler-drawer-open-dialog [{:keys [db]} [_ circle-id]]
     {:db (let [{:keys [radius]} (->> (get-in db [:drawer :circles])
                                 (filter #(= circle-id (:id %)))
@@ -126,17 +146,20 @@
                                       :draft-radius   radius}))}))
 
 (rf/reg-event :drawer/dialog-drag
-  {:doc "Slider movement during the dialog. Updates the draft radius only;
-         the circle keeps its size until the dialog commits. Carries no
-         `:undoable`, so the drag adds no history steps."}
+  {:doc "The slider is moving. We only update the *draft* radius — the circle on
+         screen keeps its real size until you close the dialog and commit. And
+         since this event skips `:undoable`, a frantic slider wiggle leaves the
+         history completely untouched."}
   (fn handler-drawer-dialog-drag [{:keys [db]} [_ new-radius]]
     {:db (assoc-in db [:drawer :dialog :draft-radius] new-radius)}))
 
 (rf/reg-event :drawer/close-dialog
-  {:doc "Dialog closed (committing the new radius). The :circles vector
-         was untouched while the slider moved, so the undoable
-         interceptor's prior-snapshot is exactly the pre-dialog state —
-         the whole edit collapses into a single undo step."
+  {:doc "Closing the dialog is the moment the new radius actually lands. Here's
+         the payoff for keeping the drag draft-only: :circles never changed while
+         the slider moved, so when the interceptor reaches for the 'before'
+         snapshot it finds the state from *before the dialog even opened*. The
+         entire resize — however many slider ticks it took — collapses into one
+         tidy undo step."
    :interceptors [:undoable]}
   (fn handler-drawer-close-dialog [{:keys [db]} _]
     {:db (let [{:keys [circle-id draft-radius]} (get-in db [:drawer :dialog])]
@@ -150,7 +173,8 @@
           (assoc-in [:drawer :dialog] nil)))}))
 
 (rf/reg-event :drawer/undo
-  {:doc "Pop one snapshot from :undo, push current :circles to :redo."}
+  {:doc "Step back. Pop the top snapshot off :undo and restore it, after parking
+         the current :circles on :redo so Redo can bring it back."}
   (fn handler-drawer-undo [{:keys [db]} _]
     {:db (let [{:keys [undo redo circles]} (:drawer db)]
       (if (empty? undo)
@@ -161,7 +185,8 @@
             (update-in [:drawer :redo] (fnil conj []) circles))))}))
 
 (rf/reg-event :drawer/redo
-  {:doc "Pop one snapshot from :redo, push current :circles to :undo."}
+  {:doc "Step forward again — the mirror image of undo. Pop the top of :redo and
+         restore it, parking the current :circles back on :undo."}
   (fn handler-drawer-redo [{:keys [db]} _]
     {:db (let [{:keys [undo redo circles]} (:drawer db)]
       (if (empty? redo)
@@ -175,9 +200,11 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-;; Layer-2 slice sub. The Layer-3 readers below chain off this one via `:<-`,
-;; so the [:drawer ...] traversal happens once per app-db swap (in
-;; `:drawer/slice`) rather than once per dependent recompute.
+;; One slice sub does the digging; everyone else reads from it. `:drawer/slice`
+;; reaches into app-db once to grab the `:drawer` map, and the subs below chain
+;; off it with `:<-`. So the [:drawer ...] walk happens a single time per app-db
+;; swap, not once per dependent sub — a small habit that keeps a subscription
+;; graph cheap as it grows.
 ;; See docs/guide/concepts/subscriptions.md.
 
 (rf/reg-sub :drawer/slice (fn [db _] (:drawer db)))
@@ -244,26 +271,28 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. ns-load must produce no DOM side effects, so co-required example
-;; namespaces don't race `create-root` onto the shared `#app`. See the
-;; mount-isolation convention in examples/TESTING.md.
+;; We hold the React root in an atom and create it lazily inside `run`, never at
+;; ns-load. The rule is that loading a namespace should touch the DOM zero times
+;; — otherwise two example namespaces sharing one page would both lunge for the
+;; same `#app` and race each other to `create-root`. See the mount-isolation
+;; convention in examples/TESTING.md.
 (defonce react-root (atom nil))
 
-;; The whole frame lifecycle lives in one spot at the render root: the
-;; `frame-provider {:id app-frame …}` below. On first mount it creates the
-;; app frame, applies its config, and runs `:initial-events` once to seed
-;; app-db. Thereafter every `dispatch`/`subscribe` in the tree resolves to
-;; that frame. On hot reload the provider reuses the existing frame and skips
-;; re-seeding, so the canvas keeps its circles across re-mounts.
+;; The frame's whole life story happens in one place: the
+;; `frame-provider {:id app-frame …}` down in `run`. On the first mount it
+;; creates the frame, applies its config, and fires `:initial-events` once to
+;; seed app-db. From then on, every `dispatch` and `subscribe` in the tree below
+;; finds its way to that frame. Hot-reload is the nice part — the provider spots
+;; the frame already exists, reuses it, and skips the re-seed, so your circles
+;; survive the reload instead of vanishing.
 ;;
-;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id with
-;; no framework privilege — name it here and hand it to the provider like any
-;; other id. See docs/guide/concepts/frames.md.
+;; `app-frame` is just a name we picked. `:rf/default` carries no special powers;
+;; it's an ordinary frame id, named here and handed to the provider like any
+;; other. See docs/guide/concepts/frames.md.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the reactive adapter for the process.
+  ;; `init!` tells re-frame2 to render through Reagent. One adapter, one process.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -1,30 +1,33 @@
 (ns seven-guis.crud.core
   "7GUIs #5 — CRUD.
 
-   A name list with a prefix filter, two text inputs (surname / name), and
-   three buttons: Create, Update, Delete. Selecting a list entry populates
-   the inputs; Update writes back; Create adds a new row; Delete removes the
-   selected row.
+   A name list, a prefix filter, two text inputs (surname / name), and three
+   buttons: Create, Update, Delete. Click a name and the inputs fill in. Update
+   writes your edits back, Create adds a row, Delete removes the selected one.
+   The classic master/detail screen.
 
-   This is a master/detail interaction. The inputs are a subscription on the
-   selection, not their own React state. Editing them dispatches into a
-   `:draft` slice; the list shows committed values. Selection lives in app-db,
-   so it never falls out of sync with the inputs.
+   The trick that makes it feel solid: the inputs are not their own React state.
+   They're a subscription on a `:draft` slice in app-db, and typing dispatches
+   an edit event. The list shows committed values; the draft holds what you're
+   editing. Because the selection lives in app-db too, the inputs and the
+   highlighted row can never drift out of sync — there's only one source of
+   truth, and both read from it.
 
-   The frame is established in one spot: the render root's
+   The whole frame is set up in one place: the render root's
    `frame-provider {:id …}` creates the app frame, configures it, and runs its
-   `:initial-events` seed once.
+   `:initial-events` seed exactly once.
 
-   Shows:
-   - List operations (add / update / delete)
-   - Selection held as state, not as React component identity
-   - A derived filtered list (a subscription on two other subscriptions)
+   Worth watching here:
+   - List operations — add / update / delete
+   - Selection kept as state, not as React component identity
+   - A filtered list derived from two other subscriptions
    - A schema-bound entity"
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Requiring `re-frame.schemas` wires up schema validation so
-            ;; `rf/reg-app-schema` works. See the guide: docs/guide/how-to/validate-with-schemas.md.
+            ;; Pulling in `re-frame.schemas` switches on schema validation, which
+            ;; is what makes `rf/reg-app-schema` below mean anything. Guide:
+            ;; docs/guide/how-to/validate-with-schemas.md.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -34,11 +37,13 @@
 ;; SCHEMA
 ;; ============================================================================
 
-;; A person's `:id` is written into durable app-db (`[:crud :people]`) and used
-;; as the selection and React `:key`. A durable id must be reproducible on
-;; replay, so it can't come from an ambient `(random-uuid)` read at the write
-;; site. We mint it as a monotonic `:int` from a db-held `:next-id` counter
-;; instead. See docs/guide/glossary.md#recordable-vs-ambient-coeffects.
+;; A person's `:id` does real work: it's the selection, and it's the React
+;; `:key`. It also lives in app-db forever, which means it has to survive a
+;; replay unchanged — replay a recording and you must get the *same* ids back.
+;; That rules out `(random-uuid)` at the write site (a fresh random number every
+;; time is the opposite of reproducible). So we count instead: a plain `:int`
+;; handed out from a `:next-id` counter that lives in the db, where replay can
+;; see it. See docs/guide/glossary.md#recordable-vs-ambient-coeffects.
 (def Person
   [:map
    [:id      :int]
@@ -55,10 +60,11 @@
                    [:name    :string]
                    [:surname :string]]]])
 
-;; Schemas register per frame, so the registration has to name a frame.
-;; `with-frame` supplies that name: `:rf/default`, the frame the render-root
-;; `frame-provider` creates and whose commits this schema validates. The frame
-;; need not exist yet — the name is enough.
+;; A schema belongs to a frame, so registering one has to say which frame.
+;; `with-frame` is how we say it: `:rf/default`, the same frame the render-root
+;; `frame-provider` will create, and the one whose commits this schema then
+;; checks. Note we register against the frame before it exists — the name is all
+;; the machinery needs to hang the schema on.
 ;; See docs/guide/how-to/validate-with-schemas.md.
 (with-frame :rf/default
   (rf/reg-app-schema [:crud] {:schema CrudState}))
@@ -68,9 +74,9 @@
 ;; ============================================================================
 
 (rf/reg-event :crud/initialise
-  {:doc "Seed the list with the 7GUIs reference data. Ids are monotonic ints
-         so a replay reproduces the same people. `:next-id` is the allocator
-         for later Create."}
+  {:doc "Seed the list with the three people from the 7GUIs reference. Their ids
+         are plain counted ints, so a replay rebuilds the exact same list.
+         `:next-id` starts at 4 — the next id Create will hand out."}
   (fn handler-crud-initialise [{:keys [db]} _]
     {:db (assoc db :crud {:people      [{:id 1 :name "Hans"  :surname "Emil"}
                                    {:id 2 :name "Max"   :surname "Mustermann"}
@@ -86,7 +92,8 @@
     {:db (assoc-in db [:crud :filter-text] s)}))
 
 (rf/reg-event :crud/select
-  {:doc "User clicked a list entry. Populates the draft from the selected person."
+  {:doc "User clicked a name in the list. Remember the selection, and copy that
+         person's name/surname into the draft so the inputs show them."
    :schema [:cat [:= :crud/select] :int]}
   (fn handler-crud-select [{:keys [db]} [_ id]]
     {:db (let [people (get-in db [:crud :people])
@@ -104,8 +111,8 @@
     {:db (assoc-in db [:crud :draft :surname] s)}))
 
 (rf/reg-event :crud/create
-  {:doc "Add a new person from the draft, and select the new entry. The id
-         comes from the db-held `:next-id` counter, which is then bumped."}
+  {:doc "Add a new person from the draft and select them. They get the next id
+         from the `:next-id` counter, which we then bump for whoever's after."}
   (fn handler-crud-create [{:keys [db]} _]
     {:db (let [new-id (get-in db [:crud :next-id])
           {:keys [name surname]} (get-in db [:crud :draft])]
@@ -157,10 +164,12 @@
                  people)))))
 
 (rf/reg-sub :crud/can-update?
-  {:doc "True when the selected row is visible under the active filter. A row
-         hidden by the filter must not be actionable, or Update/Delete would
-         touch a row you can't see. This is derived from the filtered list, so
-         the selection is kept and re-enables itself once the filter clears."}
+  {:doc "True when the selected row is actually visible under the current filter.
+         The point: you shouldn't be able to Update or Delete a row you can't
+         see. We don't drop the selection when the filter hides it, though — we
+         just ask the *filtered* list whether the selection is in it. Clear the
+         filter and the row reappears, and the buttons light back up on their
+         own."}
   :<- [:crud/selected-id]
   :<- [:crud/filtered-people]
   (fn sub-crud-can-update? [[id visible-people] _]
@@ -218,26 +227,29 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. ns-load must do no DOM work, so co-required example namespaces
-;; don't race each other onto the shared `#app`. See examples/TESTING.md
-;; (Example mount-isolation).
+;; We stash the React root in an atom and create it lazily inside `run`, never at
+;; ns-load time. The rule: loading this namespace must touch no DOM. Several
+;; example namespaces get required into one test page, and if each grabbed the
+;; shared `#app` on load they'd trample each other. Deferring to `run` keeps them
+;; out of each other's way. See examples/TESTING.md (Example mount-isolation).
 (defonce react-root (atom nil))
 
-;; The frame lifecycle lives in one spot: the `frame-provider {:id app-frame …}`
-;; below. On first mount it creates the frame, applies its config, and runs
-;; `:initial-events` once to seed app-db (`:crud/initialise`). After that, every
-;; `dispatch`/`subscribe` in the tree resolves to that frame. On hot reload the
-;; provider reuses the existing frame and skips re-seeding, so the list keeps its
-;; rows across re-mounts. See docs/guide/glossary.md#frame-provider.
+;; The frame's whole life happens in one place: the `frame-provider {:id app-frame …}`
+;; down in `run`. On the first mount it creates the frame, applies its config,
+;; and fires `:initial-events` once to seed app-db (that's `:crud/initialise`).
+;; From then on, every `dispatch` and `subscribe` in the tree below it lands in
+;; that frame. Hot-reload is the nice part: the provider finds the frame already
+;; there, reuses it, and skips the seed — so your list keeps its rows (and your
+;; edits) across a save. See docs/guide/glossary.md#frame-provider.
 ;;
-;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id with
-;; no special privilege — the runtime won't infer it, so we name it here and hand
-;; it to the provider like any other id.
+;; `app-frame` is just an id we picked. `:rf/default` sounds special but isn't —
+;; it's an ordinary frame id with no privileges. The runtime never conjures a
+;; frame for you, so we name one here and hand it to the provider like any other.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the reactive adapter for the process.
+  ;; `init!` tells the runtime to render through Reagent — once, for the whole
+  ;; process. It picks the substrate; it does not create a frame.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -9,10 +9,12 @@
        (return ≥ start) constraint holds.
      - Clicking Book pops up a confirmation message.
 
-   This task is about constrained UI input: the Book button's enabled state
-   is derived from three other fields. Computing it imperatively after every
-   change risks missing a path. Here it is a subscription, so it is always
-   in sync.
+   This task is really about *derived UI state*. The Book button's
+   enabled-ness depends on three other fields, and the imperative way to keep
+   it correct — recompute it after every keystroke, in every handler — is the
+   kind of thing you get right four times and wrong the fifth. So we don't.
+   We make it a subscription. It recomputes itself whenever its inputs change,
+   and there is no fifth path to forget.
 
    Demonstrates:
    - A schema-bound app-db slice
@@ -21,7 +23,8 @@
    - UI state driven by sub return values"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Require re-frame.schemas to make rf/reg-app-schema available.
+            ;; Loading re-frame.schemas registers its late-bind hooks, which
+            ;; is what makes rf/reg-app-schema resolve below.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -33,17 +36,21 @@
 
 (def date-pattern  #"^\d{4}-\d{2}-\d{2}$")    ;; ISO yyyy-mm-dd
 
+;; The slice stores dates as the raw text the user typed, not as parsed dates.
+;; That's deliberate: someone mid-keystroke at "2026-05-" hasn't typed a date
+;; yet, and we don't want app-db to lie about that. Parsing and validity are
+;; questions we ask later, in the subscriptions.
 (def FlightState
   [:map
    [:trip-type   [:enum :one-way :return]]
-   [:start-text  :string]                    ;; raw text the user typed; we don't parse until validation
+   [:start-text  :string]
    [:return-text :string]])
 
-;; Bind the schema to the app frame so it validates that frame's commits.
-;; `reg-app-schema` is frame-local, so `with-frame` names the target frame
-;; by id. We use `:rf/default` to match the `frame-provider {:id …}` at the
-;; render root. Binding is by id, so this works even though it runs at
-;; ns-load, before the provider creates the frame.
+;; A schema is frame-local, so it binds inside a frame. The render root runs
+;; this app in `:rf/default` (see the `frame-provider {:id …}` below), so we
+;; name that frame here. Binding is by id, which is why this works even though
+;; it runs at ns-load — before the provider has actually created the frame.
+;; From here on, every commit to the `[:flight]` slice is validated.
 (with-frame :rf/default
   (rf/reg-app-schema [:flight] {:schema FlightState}))
 
@@ -54,8 +61,9 @@
 (rf/reg-event :flight/initialise
   {:doc "Seed the flight slice."}
   (fn handler-flight-initialise [{:keys [db]} _]
-    ;; Seed both date fields to a fixed valid ISO date. The 7GUIs task seeds
-    ;; "today"; a constant keeps the example deterministic instead.
+    ;; Both date fields start on the same valid ISO date. The 7GUIs task seeds
+    ;; "today", but a constant keeps the example deterministic — and keeps the
+    ;; tests from failing at midnight.
     {:db (assoc db :flight {:trip-type   :one-way
                        :start-text  "2026-05-06"
                        :return-text "2026-05-06"})}))
@@ -101,6 +109,20 @@
 ;; ============================================================================
 ;; SUBSCRIPTIONS
 ;; ============================================================================
+;;
+;; This is where the example earns its keep. The slice holds three raw fields;
+;; the UI needs answers — is this date valid? should Book be clickable? — and
+;; we compute those as a small chain of subscriptions.
+;;
+;; The base layer (`:flight/trip-type`, `:flight/start-text`,
+;; `:flight/return-text`) just reads the slice. Each sub above it asks one
+;; sharper question by `:<-` chaining off the answers below: is the start date
+;; valid, does return need validating at all, do the two dates make sense
+;; together. `:flight/book-enabled?` sits at the top and ANDs the lot.
+;;
+;; The payoff: the button's enabled-ness is a pure function of state that
+;; recomputes itself. Nothing in the event handlers has to remember to keep it
+;; in sync, because nothing in the event handlers ever touches it.
 
 (rf/reg-sub :flight/trip-type   (fn [db _] (get-in db [:flight :trip-type])))
 (rf/reg-sub :flight/start-text  (fn [db _] (get-in db [:flight :start-text])))
@@ -154,10 +176,15 @@
       :one-way true
       :return  (and (valid-date? s)
                     (valid-date? r)
-                    (<= (compare s r) 0)))))     ;; ISO dates compare lexicographically
+                    ;; ISO dates sort correctly as plain strings — the whole
+                    ;; reason the format is yyyy-mm-dd — so a string compare is
+                    ;; all we need to check return ≥ start.
+                    (<= (compare s r) 0)))))
 
 (rf/reg-sub :flight/book-enabled?
-  {:doc "True when the Book button should be enabled."}
+  {:doc "The keystone sub: Book is clickable only when the start date is
+         valid, the return date is valid (or unused), and the two are in a
+         sensible order. Three smaller answers, ANDed into one."}
   :<- [:flight/start-valid?]
   :<- [:flight/return-valid?]
   :<- [:flight/dates-coherent?]
@@ -207,23 +234,24 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; Hold the React root in an atom and create it lazily inside `run`, not at
-;; ns-load. ns-load must have no DOM side effects so co-required example
-;; namespaces don't race `create-root` onto the shared `#app`. See
-;; examples/TESTING.md, the Example mount-isolation convention.
+;; The React root lives in an atom and is created lazily inside `run`, never at
+;; ns-load. Loading a namespace must do no DOM side effects, so that co-loaded
+;; example namespaces don't race each other to `create-root` onto the shared
+;; `#app`. See examples/TESTING.md, the Example mount-isolation convention.
 (defonce react-root (atom nil))
 
-;; The frame lifecycle lives in one place: the `frame-provider {:id app-frame
-;; …}` at the render root below. On first mount it creates the app frame,
-;; applies its config, and runs `:initial-events` once to seed app-db. On hot
-;; reload it reuses the same frame and skips re-seeding. `app-frame` is just
-;; an id we pick and hand to the provider. See the counter example for the
-;; same mount shape: examples/reagent/counter/core.cljs.
+;; The whole frame lifecycle lives in one place: the `frame-provider {:id
+;; app-frame …}` at the render root below. On first mount it creates the app
+;; frame, applies its config, and runs `:initial-events` once to seed app-db.
+;; On hot reload it reuses the same frame and skips re-seeding, so your
+;; half-filled form survives a save. `app-frame` is just an id we pick and hand
+;; to the provider — the runtime won't guess it for us. Same mount shape as the
+;; counter: examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
 (defn run []
   ;; `init!` installs the reactive adapter for the process. The adapter ns
-  ;; exports an `adapter` var; pass it directly.
+  ;; exports an `adapter` var; pass it straight in.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -1,32 +1,30 @@
 (ns seven-guis.temperature.core
-  "7GUIs #2 — Temperature Converter.
+  "7GUIs #2 — Temperature Converter: two text fields, where typing in either
+   one updates the other through the conversion C = (F - 32) × 5/9.
 
-   Two text fields; entering a value in either updates the other via the
-   conversion C = (F - 32) × 5/9.
+   The 7GUIs page poses this as a test of *bidirectional dataflow*, and the
+   obvious approach is the trap: wire the two fields straight to each other.
+   Do that and they chase each other in circles — an update loop, or a race
+   to show a stale value.
 
-   The 7GUIs page calls this out as a test of *bidirectional dataflow* — the
-   classic trap is to wire the two fields to each other directly, which
-   creates an update loop or a stale-value race.
+   re-frame2 sidesteps the whole thing. Keep *one* canonical temperature in
+   app-db and *one* event that writes it. Both inputs read from that single
+   value through subscriptions and write back through that single event. The
+   fields never speak to each other, so they can't fight. The trap simply
+   never opens.
 
-   The re-frame2 solution: *one source of truth* in app-db, plus *one event*
-   that updates it. Both inputs read from that source through subscriptions
-   and write to it through the same event. The fields never touch each other,
-   so the trap never arises.
-
-   Demonstrates:
-   - Single source of truth in app-db
-   - One event and one subscription chain over a single value
-   - Pure derivation in subscriptions (Celsius ↔ Fahrenheit)
-   - Schema-bound app-db slice
-
-   See docs/guide/concepts/subscriptions.md and the glossary entries for
-   event, subscription, and app-db in docs/guide/glossary.md."
+   That gives us a tidy tour of the basics: a single source of truth, one
+   event and one subscription chain over one value, pure Celsius ↔ Fahrenheit
+   derivation in the subs, and a schema watching the slice. The guide walks
+   subscriptions slowly in `docs/guide/concepts/subscriptions.md`; event,
+   subscription, and app-db each have a glossary entry in
+   `docs/guide/glossary.md`."
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
-            ;; rf/reg-app-schema resolves.
+            ;; Required for its side effect: loading this ns installs the
+            ;; hooks that make `rf/reg-app-schema` resolve. No var from it is
+            ;; used directly — it just has to be on the page.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
@@ -36,22 +34,25 @@
 ;; SCHEMA
 ;; ============================================================================
 ;;
-;; The slice holds a single canonical temperature in Celsius. Fahrenheit is
-;; derived. The `:input-source` field tracks which input the user is currently
-;; editing — it lets the *other* input show a derived value while the active
-;; input shows exactly what the user typed (so partial input like "1." doesn't
-;; round-trip into "1°C → 33.8°F → 33.8°F → 1.0°C" jitter).
+;; One canonical temperature, in Celsius. Fahrenheit is always derived from
+;; it, never stored. The other two fields are about being kind to the person
+;; at the keyboard. `:input-source` remembers which box they're editing, and
+;; `:typing` keeps the exact characters they've typed so far. The field in
+;; focus echoes that raw text back verbatim; the *other* field shows the
+;; derived number. Without this, typing "1." would round-trip through Celsius
+;; and reformat itself to "1.00" while your finger is still on the dot — the
+;; kind of jitter that makes an input feel possessed.
 
 (def TempState
   [:map
-   [:celsius      [:maybe :double]]      ;; canonical value; nil for empty input
+   [:celsius      [:maybe :double]]      ;; canonical value; nil when the box is empty
    [:input-source [:enum :celsius :fahrenheit]]
-   [:typing       :string]])              ;; the literal text the user is typing
+   [:typing       :string]])              ;; the raw characters the user is typing
 
-;; A schema is frame-local, so it binds inside a frame. The render root's
-;; `frame-provider {:id …}` runs this app in `:rf/default`, so we name that
-;; frame here and register the schema against it. Every commit to its
-;; `[:temp]` slice is then validated.
+;; Schemas are frame-local, so registration happens inside a frame. The
+;; `frame-provider` at the render root runs this app in `:rf/default`, so we
+;; name that same frame here and bind the schema to it. From then on, every
+;; commit to the `[:temp]` slice is checked against `TempState`.
 (with-frame :rf/default
   (rf/reg-app-schema [:temp] {:schema TempState}))
 
@@ -60,33 +61,44 @@
 ;; ============================================================================
 
 (rf/reg-event :temp/initialise
-  {:doc "Seed the temperature slice."}
+  {:doc "Seed the slice with a starting value: 0 °C, focus on Celsius."}
   (fn handler-temp-initialise [{:keys [db]} _]
     {:db (assoc db :temp {:celsius 0.0 :input-source :celsius :typing "0"})}))
 
+;; A strict numeric grammar for the inputs: optional sign, an integer and/or
+;; fractional part, optional exponent — anchored end to end. The anchoring is
+;; the point. `js/parseFloat` is famously lax: hand it "1abc" and it shrugs
+;; and returns 1, having quietly ignored the rest. Matching the whole string
+;; means "1abc" and "1.2.3" are rejected outright, so half-garbage never
+;; reaches the canonical value.
 (def num-re
   "Full-string numeric grammar: optional sign, integer and/or fractional
-   part, optional exponent. Anchored end-to-end so lax prefixes like
-   \"1abc\" or \"1.2.3\" are rejected — `js/parseFloat` would otherwise
-   silently accept their leading numeric run (\"1abc\" → 1)."
+   part, optional exponent, anchored end to end (so `js/parseFloat`'s lax
+   prefix-matching can't sneak \"1abc\" through as 1)."
   #"^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$")
 
-(defn parse-num [s]
+(defn parse-num
+  "Parse a field's text into a number, or nil if it isn't a clean one. Trim
+   the whitespace, insist on a full numeric match, then let `parseFloat`
+   finish the job — with a NaN backstop, belt and braces."
+  [s]
   (let [trimmed (str/trim s)]
     (when (re-matches num-re trimmed)
       (let [n (js/parseFloat trimmed)]
         (when-not (js/isNaN n) n)))))
 
 (rf/reg-event :temp/edit-celsius
-  {:doc "User edited the Celsius input."}
+  {:doc "User typed in the Celsius box. It's already our canonical unit, so we
+         store the parsed number straight, and remember the raw keystrokes."}
   (fn handler-temp-edit-celsius [{:keys [db]} [_ raw]]
     {:db (assoc db :temp {:celsius      (parse-num raw)
                      :input-source :celsius
                      :typing       raw})}))
 
 (rf/reg-event :temp/edit-fahrenheit
-  {:doc "User edited the Fahrenheit input. We store Celsius canonically;
-         conversion happens here so the rest of the app reads from one path."}
+  {:doc "User typed in the Fahrenheit box. We convert to Celsius right here, on
+         the way in, so everything downstream reads from the one canonical
+         value and never has to know Fahrenheit existed."}
   (fn handler-temp-edit-fahrenheit [{:keys [db]} [_ raw]]
     {:db (let [f (parse-num raw)
           c (when f (* (- f 32) (/ 5.0 9.0)))]
@@ -98,16 +110,20 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; Two layers. Three small Layer-2 subs read the slice directly
-;; (:temp/active, :temp/canonical-celsius, :temp/typing); two Layer-3
-;; `-text` subs chain off all three via `:<-` to produce what each input
-;; shows. The view only ever reads the two `-text` subs.
+;; A little two-layer graph. Three tiny *extractors* (Layer 1) pluck the raw
+;; fields straight out of the slice: :temp/active, :temp/canonical-celsius,
+;; :temp/typing. Then two *derivations* (Layer 2) chain off all three with
+;; `:<-` to compute what each box should actually display. The view reads only
+;; those two `-text` subs and stays blissfully unaware of the rest.
 ;;
-;; The key insight lives in those `-text` subs: for the input the user is
-;; *currently editing* they pass the raw typing straight through; for the
-;; *other* input they show the derived value. One sub per field that knows
-;; whether to passthrough or derive — which is why partial input like "1."
-;; doesn't round-trip into jitter while your finger's still on the key.
+;; The cleverness all lives in the two `-text` subs, and it's one rule: for
+;; the box you're *currently editing*, hand back your raw keystrokes; for the
+;; *other* box, show the converted value. Each field gets one sub that decides
+;; pass-through vs. derive — which is the whole reason typing "1." doesn't
+;; reformat itself out from under you mid-keystroke.
+;;
+;; For the layers, the equality gate, and the `:<-` arrow in full, see
+;; `docs/guide/concepts/subscriptions.md`.
 
 (rf/reg-sub :temp/active
   (fn sub-temp-active [db _] (get-in db [:temp :input-source])))
@@ -119,7 +135,8 @@
   (fn sub-temp-typing [db _] (get-in db [:temp :typing])))
 
 (rf/reg-sub :temp/celsius-text
-  {:doc "Text to display in the Celsius input."}
+  {:doc "What the Celsius box shows: raw keystrokes while it's the active box,
+         otherwise the canonical value formatted to two places."}
   :<- [:temp/active]
   :<- [:temp/typing]
   :<- [:temp/canonical-celsius]
@@ -129,7 +146,8 @@
       :fahrenheit  (when c (.toFixed (double c) 2)))))
 
 (rf/reg-sub :temp/fahrenheit-text
-  {:doc "Text to display in the Fahrenheit input."}
+  {:doc "What the Fahrenheit box shows: raw keystrokes while it's the active
+         box, otherwise the canonical Celsius converted to °F, two places."}
   :<- [:temp/active]
   :<- [:temp/typing]
   :<- [:temp/canonical-celsius]
@@ -141,8 +159,14 @@
 ;; ============================================================================
 ;; VIEW
 ;; ============================================================================
+;;
+;; And here's the payoff. Two inputs, each reading its `-text` sub for what to
+;; show and dispatching an edit event for what was typed. That's the entire
+;; view — no conversion, no cross-wiring, no peeking at the other field. The
+;; bidirectional "trap" the 7GUIs page warns about never even comes up, because
+;; the fields don't know each other exists.
 
-(reg-view ^{:doc "Two-input temperature converter."}
+(reg-view ^{:doc "Two text inputs, °C and °F, kept in sync through app-db."}
           temperature-converter []
   (let [c-text @(subscribe [:temp/celsius-text])
         f-text @(subscribe [:temp/fahrenheit-text])]
@@ -162,27 +186,34 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and created lazily inside `run`, never at
-;; ns-load. Namespace load must do no DOM side effects, so co-loaded example
-;; namespaces don't race `create-root` onto the shared `#app`. See
-;; examples/TESTING.md "Convention: defer DOM mount to `run`".
+;; The React root lives in an atom and is created lazily inside `run`, never at
+;; ns-load. The rule: loading a namespace must touch no DOM. Otherwise two
+;; example namespaces required together would both grab for the shared `#app`
+;; element and race to `create-root` on it — and a race in your test harness is
+;; precisely the bug you don't want. See examples/TESTING.md, "mount-isolation".
 (defonce react-root (atom nil))
 
-;; The whole frame lifecycle lives in one spot at the render root: the
-;; `frame-provider {:id app-frame …}` below. On first mount it creates the
-;; app frame, applies its config, and runs `:initial-events` once to seed
-;; app-db. Thereafter every `dispatch`/`subscribe` in the tree resolves to
-;; that frame. On hot reload the provider reuses the existing frame and
-;; skips re-seeding, so the converter keeps its value across re-mounts.
+;; The frame's whole life story fits in one place: the `frame-provider {:id
+;; app-frame …}` in `run` below. First mount creates the frame and runs its
+;; `:initial-events` once to seed app-db. After that, every `dispatch` and
+;; `subscribe` in the tree finds its way home to that frame. Mount again under
+;; the same `:id` — a hot reload, say — and the provider hands back the frame
+;; that's already alive instead of re-seeding, so your half-typed temperature
+;; survives the save. See `docs/guide/concepts/frames.md`.
 ;;
-;; `app-frame` is just an id we pick. The runtime won't infer it, so we name
-;; it here and hand it to the provider. Matches the canonical mount in
-;; examples/reagent/counter/core.cljs.
+;; `app-frame` is just an id we picked. `:rf/default` looks special but isn't —
+;; it's an ordinary frame id. The runtime never guesses which frame you mean,
+;; so we name one here and hand it over explicitly, the same way the counter
+;; example does (`examples/reagent/counter/core.cljs`). See
+;; `docs/guide/glossary.md#frame-identity-is-carried-not-found`.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the reactive adapter for the process. Each adapter ns
-  ;; exports an `adapter` var; require the ns and pass that var directly.
+  ;; `init!` tells re-frame2 which reactive substrate to render through — here,
+  ;; Reagent. Each adapter ns exports an `adapter` var; you require the ns and
+  ;; pass that var. One call, at startup. Note it installs the adapter, not a
+  ;; frame — the frame comes later, via the provider below.
+  ;; See `docs/guide/glossary.md#init`.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -1,53 +1,60 @@
 (ns seven-guis.timer.core
   "7GUIs #4 — Timer.
 
-   A progress bar that fills as time elapses, a numeric display of elapsed
-   time, a slider that sets the duration, and a Reset button.
+   A progress bar that fills, the elapsed seconds beside it, a slider to set
+   the duration, and a Reset button. Time itself is the interesting part.
 
-   Rules:
-     - The progress bar fills from 0 to 100% over the duration.
-     - The slider changes the duration on the fly: shrinking it advances the
-       bar to full immediately when elapsed already exceeds duration.
-     - Reset sets elapsed back to zero.
+   The trick: time advances the same way everything else does — through a
+   dispatched event. A periodic `:timer/tick` nudges elapsed-ms forward, so
+   the clock lives *inside* the update loop rather than off to the side
+   mutating state behind the framework's back. No special path for time.
 
-   This is the 7GUIs test of time. A periodic event ticks elapsed time
-   forward through the same dispatch pipeline as every other change, so the
-   timer never lives outside the update model.
+   The rules are simple:
+     - The bar fills from 0 to 100% over the duration.
+     - The slider retargets the duration live: drag it below elapsed and the
+       bar jumps to full; drag it back up and the timer picks up again.
+     - Reset puts elapsed back to zero.
 
-   What it shows:
+   What it shows off:
    - `:dispatch-later` to schedule the next tick
-   - One source of truth: elapsed time lives in app-db
-   - Layered subscriptions deriving the progress percentage
-   - A controlled slider that dispatches on every change
+   - One source of truth: elapsed time is just a number in app-db
+   - Subscriptions layered to derive the progress percentage
+   - A controlled slider that dispatches on every drag
 
    Terms: events, subscriptions, app-db, frames — docs/guide/glossary.md."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Requiring this registers the hooks that make `rf/reg-app-schema` work.
+            ;; Pulling this in registers the hooks that teach the frame how to
+            ;; validate against a schema — that's what makes `rf/reg-app-schema` work.
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 (def tick-ms
-  "Wall-clock delay in milliseconds between successive timer ticks."
+  "How long, in milliseconds, between one tick and the next. 100ms is smooth
+   enough to look continuous without flooding the loop with events."
   100)
 
 ;; ============================================================================
 ;; SCHEMA
 ;; ============================================================================
 
+;; The whole timer is four numbers. That's it — no objects, no timer handle,
+;; nothing hiding outside app-db. This schema spells them out, and the runtime
+;; checks every commit against it.
 (def TimerState
   [:map
-   [:elapsed-ms :int]                  ;; milliseconds since the last reset
-   [:duration-ms :int]                 ;; the slider's current value
-   [:tick-active? :boolean]            ;; whether a tick is in flight
-   [:tick-gen :int]])                  ;; generation token; bumped on Reset to retire stale ticks
+   [:elapsed-ms :int]                  ;; milliseconds counted since the last reset
+   [:duration-ms :int]                 ;; where the slider is parked
+   [:tick-active? :boolean]            ;; is a tick chain currently running?
+   [:tick-gen :int]])                  ;; generation token — the trick for retiring stale ticks (see below)
 
-;; `reg-app-schema` binds the schema to a frame, so it needs a frame in scope.
-;; `with-frame` names one. We use `:rf/default`, the same id the render root's
-;; `frame-provider` uses (see `run`), so the schema lands on the frame whose
-;; commits it validates. Schemas: docs/guide/how-to/validate-with-schemas.md.
+;; A schema belongs to a frame, so we need a frame in scope to register it.
+;; `with-frame` names one. We use `:rf/default` — the same id the render root's
+;; `frame-provider` picks (see `run`) — so the schema guards the very frame
+;; whose commits it's meant to validate. If you want the why and the how of
+;; schemas, that's docs/guide/how-to/validate-with-schemas.md.
 (with-frame :rf/default
   (rf/reg-app-schema [:timer] {:schema TimerState}))
 
@@ -55,23 +62,29 @@
 ;; EVENTS
 ;; ============================================================================
 ;;
-;; The tick chain runs on `:dispatch-later`, which has no cancel API. So we
-;; guard ticks with a generation token. Each tick carries the :tick-gen it was
-;; scheduled under. A handler that wants to retire the in-flight tick bumps
-;; :tick-gen; when that stale tick finally fires its gen no longer matches, so
-;; it no-ops. The handler then schedules a fresh tick under the new generation,
-;; keeping exactly one chain alive.
+;; Here's the wrinkle that shapes everything below. We schedule each tick with
+;; `:dispatch-later`, and `:dispatch-later` is fire-and-forget — there's no
+;; handle to cancel a tick once it's in the air. So how do we ever *stop* a
+;; tick, or start a clean one over the top of it?
 ;;
-;; Reset uses this to show 0.0 reliably: it zeros :elapsed-ms and bumps the
-;; generation, so a tick scheduled just before Reset can't re-increment elapsed
-;; after the zeroing. :timer/set-duration uses it too: when the chain has
-;; already stopped (elapsed reached the old duration) and the user raises the
-;; duration, it bumps the generation and arms one fresh tick — resuming the
-;; chain without a Reset. That is what makes the slider change duration on the
-;; fly even after the timer has finished.
+;; The answer is a generation token, `:tick-gen`. Think of it as a wristband at
+;; a club: every tick is stamped with the generation it was scheduled under,
+;; and when it finally fires it checks whether its stamp still matches the one
+;; in app-db. Want to retire whatever's in flight? Bump `:tick-gen`. The old
+;; tick still goes off — we can't stop that — but its wristband is now stale,
+;; so it quietly does nothing. Then we schedule a fresh tick under the new
+;; generation. Net result: exactly one live chain, ever.
+;;
+;; Two handlers lean on this:
+;;   - Reset bumps the generation so a tick scheduled a moment earlier can't
+;;     sneak elapsed back up after we've zeroed it. The display stays at 0.0.
+;;   - set-duration bumps it to *revive* a finished timer: if the chain already
+;;     stopped and the user drags the duration up, one fresh tick under the new
+;;     generation gets it moving again — no Reset needed. That's the on-the-fly
+;;     slider behaviour the 7GUIs task asks for.
 
 (rf/reg-event :timer/initialise
-  {:doc "Seed the timer slice and start the periodic tick."}
+  {:doc "Set up the timer slice from nothing and kick off the first tick."}
   (fn handler-timer-initialise [{:keys [db]} _]
     {:db (assoc db :timer {:elapsed-ms   0
                            :duration-ms  10000
@@ -80,34 +93,34 @@
      :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick 0]}]]}))
 
 (rf/reg-event :timer/tick
-  {:doc "Advance elapsed by one tick, scheduling the next while still ticking.
-         A tick whose generation no longer matches :tick-gen is dropped."}
+  {:doc "Nudge elapsed forward by one tick and, if there's still road ahead,
+         schedule the next one. A tick carrying a stale generation is ignored."}
   (fn handler-timer-tick [{:keys [db]} [_ gen]]
     (let [{:keys [elapsed-ms duration-ms tick-active? tick-gen]} (:timer db)]
       (if (not= gen tick-gen)
-        ;; Stale tick from a retired generation. Drop it.
+        ;; Wrong wristband — this tick belongs to a retired generation. Ignore it.
         {}
         (let [next-elapsed (min (+ elapsed-ms tick-ms) duration-ms)
               done?        (>= next-elapsed duration-ms)]
           (cond-> {:db (assoc-in db [:timer :elapsed-ms] next-elapsed)}
-            ;; Continue ticking while not done and tick still active.
+            ;; Keep the chain alive only while there's room left and we haven't been stopped.
             (and tick-active? (not done?))
             (assoc :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick gen]}]])))))))
 
 (rf/reg-event :timer/set-duration
-  {:doc "User dragged the slider. Update the duration. If the tick chain had
-         already stopped (elapsed reached the old duration) and the new
-         duration leaves room to advance, re-arm one fresh tick under a
-         bumped generation so it resumes without a Reset. While a chain is
-         still live, just update the duration — the running tick keeps going
-         against the new target."
+  {:doc "The user dragged the slider, so retarget the duration. Two cases. If a
+         tick chain is still running, we just write the new target and let the
+         live tick race toward it. If the chain had already finished but the new
+         duration leaves room to keep going, we revive it with one fresh tick
+         under a bumped generation — see the EVENTS note above for why that bump
+         matters."
    :schema [:cat [:= :timer/set-duration] :int]}
   (fn handler-timer-set-duration [{:keys [db]} [_ ms]]
     (let [{:keys [elapsed-ms duration-ms tick-active? tick-gen]} (:timer db)
-          ;; The chain stops scheduling once elapsed reaches duration.
+          ;; The chain stops scheduling itself the moment elapsed catches duration.
           was-stopped? (>= elapsed-ms duration-ms)
-          ;; Re-arm only when stopped, still active, and the new duration
-          ;; leaves elapsed below target (room to advance).
+          ;; Revive only if it had stopped, is still active, and the new target
+          ;; sits ahead of where we are — i.e. there's actually somewhere to go.
           rearm?       (and was-stopped? tick-active? (> ms elapsed-ms))
           next-gen     (if rearm? (inc tick-gen) tick-gen)
           db'          (cond-> (assoc-in db [:timer :duration-ms] ms)
@@ -116,8 +129,8 @@
         rearm? (assoc :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick next-gen]}]])))))
 
 (rf/reg-event :timer/reset
-  {:doc "User clicked Reset. Zero elapsed, retire any in-flight tick by
-         bumping :tick-gen, and arm a fresh tick under the new generation."}
+  {:doc "Reset was clicked. Zero elapsed, retire whatever tick is in flight by
+         bumping :tick-gen, and start a clean chain under the new generation."}
   (fn handler-timer-reset [{:keys [db]} _]
     (let [next-gen (inc (get-in db [:timer :tick-gen]))]
       {:db (-> db
@@ -129,16 +142,24 @@
 ;; ============================================================================
 ;; SUBSCRIPTIONS
 ;; ============================================================================
+;;
+;; The two base subs just read raw numbers out of app-db. The ones above them
+;; build on those — seconds and percentage are *derived*, never stored. The
+;; `:<-` arrows wire each sub to its inputs, so it recomputes only when an
+;; input actually changes. The view asks for the polished values and stays out
+;; of the arithmetic. Subscriptions: docs/guide/concepts/subscriptions.md.
 
 (rf/reg-sub :timer/elapsed-ms  (fn [db _] (get-in db [:timer :elapsed-ms])))
 (rf/reg-sub :timer/duration-ms (fn [db _] (get-in db [:timer :duration-ms])))
 
+;; Elapsed milliseconds, dressed up as seconds with one decimal for display.
 (rf/reg-sub :timer/elapsed-seconds
   :<- [:timer/elapsed-ms]
   (fn [ms _] (.toFixed (/ ms 1000.0) 1)))
 
 (rf/reg-sub :timer/progress-pct
-  {:doc "Fraction of duration elapsed, clamped to [0, 100]."}
+  {:doc "How far along we are, 0 to 100. A zero duration counts as full —
+         otherwise we'd be dividing by zero, and nobody enjoys that."}
   :<- [:timer/elapsed-ms]
   :<- [:timer/duration-ms]
   (fn [[e d] _]
@@ -178,25 +199,26 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. ns-load must produce no DOM side effects, so co-required example
-;; namespaces don't race `create-root` onto the shared `#app` element.
+;; We stash the React root in an atom and build it lazily inside `run`, never at
+;; ns-load. Loading a namespace shouldn't touch the DOM — if it did, two example
+;; namespaces loaded together would both race to `create-root` the shared `#app`
+;; element, and exactly one of them would win. Lazy keeps that drama away.
 (defonce react-root (atom nil))
 
-;; The frame lifecycle lives in one place: the `frame-provider` below. On first
-;; mount it creates the frame, applies its config, and runs `:initial-events`
-;; once to seed app-db. From then on every `dispatch`/`subscribe` in the tree
-;; resolves to that frame. On hot reload it reuses the existing frame and skips
-;; re-seeding, so the timer keeps ticking across re-mounts.
-;; Frames: docs/guide/concepts/frames.md.
+;; All the frame's lifecycle happens in one spot — the `frame-provider` below.
+;; On first mount it creates the frame, applies its config, and fires
+;; `:initial-events` once to seed app-db. After that, every `dispatch` and
+;; `subscribe` in the tree resolves to this frame. On hot reload it reuses the
+;; frame it already has and skips re-seeding, so the timer keeps right on ticking
+;; while you edit. Frames: docs/guide/concepts/frames.md.
 ;;
-;; `app-frame` is just an id we pick — `:rf/default`, the same id the schema
-;; block above binds to.
+;; `app-frame` is just an id we chose — `:rf/default`, the same one the schema
+;; block up top binds to.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the reactive adapter for the process. It does not create
-  ;; the frame — the `frame-provider` below does that.
+  ;; `init!` tells the runtime to render through the Reagent adapter. That's all
+  ;; it does — it does *not* create a frame. The `frame-provider` below does that.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -1,60 +1,75 @@
 (ns ssr.core
-  "Server-side rendering: one app that runs twice. The server renders a
-   'recent articles' page to HTML; the client hydrates it and stays
-   interactive. See the SSR guide: ../../../docs/ssr/concepts.md.
+  "One app that runs twice. The server renders a 'recent articles' page to
+   HTML so the first paint arrives ready-made; the client then hydrates that
+   same HTML and takes over, fully interactive. The trick is that both runs
+   are the *same code* — the SSR guide tells the longer story:
+   ../../../docs/ssr/concepts.md.
 
-   This is .cljc so the same code runs server-side (JVM, :clj branches) and
-   client-side (browser, :cljs branches). The events, subscriptions, and
-   views are shared — there is no second server-flavoured copy of the app.
+   That's why this file is .cljc and not .cljs. The events, subscriptions,
+   and views are written once and shared. The `#?(:clj …)` / `#?(:cljs …)`
+   reader conditionals carve out the few spots that genuinely differ — the
+   JVM render path on one side, the browser mount on the other. There is no
+   second, server-flavoured copy of the app to keep in sync, which is the
+   whole point.
 
-   What this example shows:
-   - A per-request frame on the server (reg-frame + with-frame).
-   - :rf/server-init, dispatched when the frame is created.
-   - A client-only fx gated with :platforms #{:client} — the server render
-     skips it.
-   - The pure hiccup -> HTML emitter (rf/render-to-string).
-   - The hydration payload the server ships for the client to adopt.
-   - Per-request frame teardown in a `finally` (rf/destroy-frame!).
-   - Framework-owned hydration: the client boots via `ssr/hydrate!`, which
-     dispatches the reserved `:rf/hydrate` event. The app writes no handler
-     for it. `:rf/hydrate` replaces the client frame-state (it does not
-     merge) — the server is authoritative.
-   - A structural render hash. The client recomputes it after its first
-     render and compares against the server's; a disagreement emits
-     :rf.ssr/hydration-mismatch. See ../../../docs/ssr/glossary.md#hydration-mismatch.
+   The tour, in the order you'll meet it below:
+   - A fresh frame per request on the server (reg-frame + with-frame), torn
+     down again when the request is done.
+   - :rf/server-init — the per-request boot event, dispatched as the frame
+     comes up.
+   - A client-only effect, gated with :platforms #{:client}, that the server
+     render simply skips.
+   - The pure hiccup -> HTML emitter, rf/render-to-string. No DOM, just data
+     in and a string out.
+   - The hydration payload: the server's finished state, packed into the page
+     for the client to adopt verbatim.
+   - Hydration the app never has to write. The client boots through
+     `ssr/hydrate!`, which dispatches the reserved `:rf/hydrate` event;
+     re-frame2 owns the handler. `:rf/hydrate` *replaces* the client's
+     frame-state rather than merging into it — on this question the server is
+     the single source of truth.
+   - A structural render hash that catches the classic SSR bug. The client
+     hashes its own first render and compares it to the server's; if they
+     disagree, the runtime emits :rf.ssr/hydration-mismatch. See
+     ../../../docs/ssr/glossary.md#hydration-mismatch.
 
-   To run it: the hand-written `index.html` next to this file ships with
-   pre-rendered HTML inside `<div id='app'>` and a baked
-   `<script id='__rf_payload'>` — the same shape `handle-request` below
-   emits. The browser-side `run` calls `ssr/hydrate!` (read payload ->
-   dispatch `:rf/hydrate` -> verify) and renders against the seeded
-   frame-state."
+   Want to see it live? The hand-written `index.html` beside this file is a
+   frozen snapshot of exactly what `handle-request` below produces: the
+   pre-rendered markup sits in `<div id='app'>`, and the baked
+   `<script id='__rf_payload'>` carries the state. The browser-side `run`
+   reads that payload, hydrates, verifies, and renders on top of the seeded
+   state — no flash, no re-fetch."
   (:require [re-frame.core :as rf]
-            ;; Loading this ns registers the schema hooks so
-            ;; rf/reg-app-schema resolves at the call sites below.
+            ;; A handful of these requires are here purely for their side
+            ;; effect: loading the namespace registers something we lean on
+            ;; later. They look unused; they aren't.
+
+            ;; Wires up the schema hooks, so the rf/reg-app-schema calls below
+            ;; have something to resolve to.
             [re-frame.schemas]
-            ;; Registers the `:rf.http/managed` fx family. This example
-            ;; dispatches `:rf.http/managed` for the article fetch and uses
-            ;; per-frame `:fx-overrides` to redirect it to a canned-success
-            ;; stub during render. Without the require, the override would
-            ;; target an unregistered fx-id.
+            ;; Brings in the `:rf.http/managed` effect we use for the article
+            ;; fetch. During render we don't want a real network call, so we
+            ;; redirect it through the per-frame `:fx-overrides` seam to a
+            ;; canned-success stub. Skip this require and the override would be
+            ;; pointing at an fx-id nobody registered.
             [re-frame.http.managed]
-            ;; Registers the canned-stub fx ids
-            ;; (`:rf.http/managed-canned-success`,
-            ;; `:rf.http/managed-canned-failure`). The example has no real
-            ;; backend, so it drives these stubs via :fx-overrides; this
-            ;; require is the explicit opt-in to the test affordance.
+            ;; The canned stubs themselves (`:rf.http/managed-canned-success`
+            ;; and `-canned-failure`). There's no backend behind this example,
+            ;; so :fx-overrides drives these instead — and pulling in a test
+            ;; affordance is the kind of thing you want to opt into out loud,
+            ;; not by accident.
             [re-frame.http.test-support]
-            ;; Registers the `:rf.server/*` server-only fxs, the `:rf/hydrate`
-            ;; event, the default error projector, and the SSR render/hash
-            ;; hooks the core re-exports below rely on.
+            ;; The SSR machinery: the `:rf.server/*` server-only effects, the
+            ;; framework-owned `:rf/hydrate` event, the default error
+            ;; projector, and the render/hash hooks the calls below ride on.
             [re-frame.ssr :as ssr]
-            ;; The EDN-aware `<script>`-body escaper, used server-side only.
-            ;; The `:clj` `handle-request` drops the `pr-str`'d payload inside
-            ;; a `<script type="application/edn">` body; a server-provided
-            ;; string containing `</script>` would otherwise close the
-            ;; envelope. The escaper rewrites `<` to its reader escape only
-            ;; inside EDN string literals, so the payload still round-trips.
+            ;; Server-side only: a `<script>`-body escaper that understands
+            ;; EDN. `handle-request` drops the payload, `pr-str`'d, inside a
+            ;; `<script type="application/edn">`. If some article body smuggled
+            ;; in the literal text `</script>`, it would slam the envelope shut
+            ;; early. The escaper rewrites `<` to its reader escape, but only
+            ;; inside EDN string literals — so the payload still reads back
+            ;; byte-for-byte on the client.
             #?(:clj [re-frame.ssr.html-helpers :as html])
             #?(:cljs [reagent.dom.client :as rdc])
             #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
@@ -63,18 +78,21 @@
 ;; SCHEMA
 ;; ============================================================================
 ;;
-;; Hold the schema as a plain value. SSR has two frames — the per-request
-;; server frame (a gensym, in `handle-request`) and the fixed client frame
-;; (`app-frame`, in `run`) — and the same contract applies to both. Each entry
-;; point registers it against its own frame with the `{:frame …}` override.
-;; `reg-app-schema` is frame-local, so it needs an explicit `:frame`; holding
-;; the schema as a `def` keeps ns-load free of any ambient frame.
+;; We keep the schema as a plain value, deliberately. SSR juggles two frames —
+;; the throwaway per-request server frame (a gensym, born in `handle-request`)
+;; and the fixed client frame (`app-frame`, in `run`) — and both answer to the
+;; exact same contract. Since `reg-app-schema` is frame-local, each entry point
+;; registers this value against its own frame with the `{:frame …}` override.
+;; Parking the schema in a `def` means namespace-load never has to reach for an
+;; ambient frame that isn't there yet.
 ;;
-;; `[:maybe …]` because the slice is nil until `:articles/loaded` commits. The
-;; server's `:rf/server-init` commits an articles-free db first (it only kicks
-;; off the fetch), and the client frame starts empty before hydration. A bare
-;; `[:vector …]` would reject that legitimate intermediate nil and roll the
-;; commit back. See ../../../docs/guide/glossary.md#schema.
+;; Note the `[:maybe …]` wrapper. The articles slice is legitimately nil for a
+;; beat: the server's `:rf/server-init` commits a db with no articles in it
+;; (all it does is start the fetch), and a fresh client frame is empty until
+;; hydration lands. A bare `[:vector …]` would call that intermediate nil a
+;; violation and roll the commit back — so we tell the schema, up front, that
+;; nil is a fine place to pass through. See
+;; ../../../docs/guide/glossary.md#schema.
 (def ArticlesSchema
   [:maybe [:vector [:map
                     [:id    :string]
@@ -85,14 +103,17 @@
 ;; FX
 ;; ============================================================================
 ;;
-;; HTTP requests go via the framework's `:rf.http/managed` fx. The headless
-;; test redirects it through the `:fx-overrides` seam to a per-frame
-;; canned-success stub, so the JVM render exercises the full event cascade
-;; without real network traffic.
+;; HTTP goes through the framework's `:rf.http/managed` effect. The headless
+;; test swaps it, via the `:fx-overrides` seam, for a per-frame canned-success
+;; stub — so the JVM render runs the whole event cascade end to end without a
+;; single packet leaving the building.
 
+;; Some effects only make sense in a browser. localStorage is the textbook
+;; case: there's no such thing on the server. `:platforms #{:client}` is how
+;; you say so — the server render reaches this effect, shrugs, and moves on.
 (rf/reg-fx :auth.session/store
   {:doc       "Persist a session token in localStorage."
-   :platforms #{:client}}              ;; client-only — the server render skips it
+   :platforms #{:client}}              ;; client-only; the server render skips it
   (fn fx-auth-session-store [_m {:keys [token]}]
     #?(:cljs (when-let [ls (.-localStorage js/globalThis)]
                (.setItem ls "auth/token" token)))))
@@ -102,56 +123,67 @@
 ;; ============================================================================
 
 (rf/reg-event :rf/server-init
-  {:doc       "Per-request server-side initialisation. Reads the request via
-               the :rf.server/request coeffect and kicks off setup. Server
-               only. See ../../../docs/ssr/concepts.md#reading-the-request."
+  {:doc       "Per-request server-side boot. Reads the incoming request through
+               the :rf.server/request coeffect and starts the work the page
+               needs. Server only. See
+               ../../../docs/ssr/concepts.md#reading-the-request."
    :platforms #{:server}
    :rf.cofx/requires [:rf.server/request]}
   (fn handler-rf-server-init [{:keys [db rf.server/request]} _]
-    ;; `request` is the host-supplied HTTP request map (Ring shape under the
-    ;; bundled adapter); read URL/headers/cookies from it. It arrives via the
-    ;; `:rf.server/request` coeffect, declared above, not as an event arg.
+    ;; Where's the request? Not in the event vector — it rides in on the
+    ;; `:rf.server/request` coeffect we declared just above. That's `request`:
+    ;; the host's HTTP request map (Ring-shaped under the bundled adapter), the
+    ;; place you'd read URL, headers, and cookies from.
     ;;
-    ;; This handler leaves db unchanged and just kicks off the article fetch.
-    ;; A router-driven app would store the matched route here; this
-    ;; article-only render has no route to track.
+    ;; This particular handler leaves db alone and just fires off the article
+    ;; fetch. An app with routing would stash the matched route here; a page
+    ;; that only ever shows articles has no route worth remembering.
     {:db db
      :fx [[:rf.http/managed
            {:request    {:method :get :url "/api/articles"}
             :decode     :json
             :on-success [:articles/loaded]}]]}))
 
-;; The `:on-success` target for the article fetch. It takes the decoded reply
-;; value and returns the next app-db; the runtime commits it. The same handler
-;; runs on the server (per-request frame) and the client (post-hydration) —
-;; nothing here is platform-specific.
+;; When the fetch comes back, this is where it lands — the `:on-success` target
+;; from above. It takes the decoded reply and hands back the next app-db, which
+;; the runtime commits. Notice there's nothing server- or client-specific in
+;; here: the very same handler runs on the server's per-request frame and again
+;; on the client after hydration. Write it once.
 (rf/reg-event :articles/loaded
   (fn handler-articles-loaded [{:keys [db]} [_ {:keys [value]}]]
     {:db (assoc db :articles value)}))
 
-;; Hydration is framework-owned. `:rf/hydrate` is a reserved `:rf/*` event that
-;; `re-frame.ssr` registers; the app supplies no handler for it. The framework
-;; handler installs the whole client frame-state in one atomic step, replacing
-;; whatever the client pre-seeded — the server is authoritative. The payload's
-;; app-db replaces the app-db partition; its runtime-db slice (machine
-;; snapshots, route slice) replaces the serializable runtime-db projection. The
-;; handler validates the payload fail-closed: a non-map payload, or a
-;; present-but-non-map slice, leaves the frame-state untouched. It also stashes
-;; the server's render hash for the verify step after the first render. (This
-;; example has no machines and doesn't hydrate the route, so its runtime-db
-;; slice is empty — but the shape is the one a richer app uses.) The client
-;; `run` below drives all of this through `ssr/hydrate!`; see the CLIENT ENTRY
-;; POINT section. Why replace and not merge:
-;; ../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify
+;; You'll notice there's no `reg-event` for hydration here. That's on purpose:
+;; `:rf/hydrate` is a reserved `:rf/*` event that `re-frame.ssr` owns, handler
+;; and all. You dispatch it; the framework does the rest.
+;;
+;; What the framework handler does is install the server's frame-state in one
+;; atomic move — and it *replaces*, it doesn't merge. The payload's app-db
+;; becomes the app-db partition; its runtime-db slice (machine snapshots, route
+;; slice) becomes the serializable runtime-db projection. Whatever the client
+;; had pre-seeded is overwritten, no negotiation. On hydration the server is
+;; the authority, full stop. (Why replace rather than merge is worth the read:
+;; ../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify.)
+;;
+;; It's also paranoid in the good way — it fails closed. A payload that isn't a
+;; map, or a slice that's present but malformed, leaves the frame-state exactly
+;; as it was rather than installing garbage. Along the way it tucks the server's
+;; render hash aside for the verify step that follows the first render.
+;;
+;; This example has no machines and doesn't hydrate a route, so its runtime-db
+;; slice is empty here — but the shape is the same one a richer app fills in.
+;; The client `run` at the bottom drives all of this through `ssr/hydrate!`; the
+;; CLIENT ENTRY POINT section picks up the thread.
 
 ;; ============================================================================
 ;; CLIENT-SIDE INTERACTIVITY EVENTS
 ;; ============================================================================
 ;;
-;; A small interactive surface that proves hydration left the client fully
-;; reactive: clicking "Hide bodies" toggles the body paragraphs in and out
-;; without a full re-render. This slice has no server counterpart, so it is not
-;; in the hydration payload and starts at its default value on the client.
+;; Proof that hydration handed you a *live* app and not a museum piece. Clicking
+;; "Hide bodies" toggles the article paragraphs in and out — a normal reactive
+;; round-trip, no full re-render in sight. This bit of state is purely a client
+;; concern, so it never appears in the hydration payload; it just starts at its
+;; default the moment the client wakes up.
 
 (rf/reg-event :articles/toggle-bodies
   (fn [{:keys [db]} _] {:db (update db :articles/show-bodies? (fnil not true))}))
@@ -164,20 +196,24 @@
 
 (rf/reg-sub :articles/show-bodies?
   (fn [db _]
-    ;; Default is true so the SSR pass renders bodies; the client can hide
-    ;; them post-hydration.
+    ;; Default to true, so the server's render shows the bodies and the page
+    ;; arrives fully fleshed out. Hiding them is a choice the reader makes
+    ;; later, on the client.
     (let [v (:articles/show-bodies? db)]
       (if (nil? v) true v))))
 
-;; reg-view auto-defs the symbol and registers it under (keyword *ns* sym).
-;; `^{:rf/id ...}` overrides that id so the :pages/articles / :app/root ids the
-;; callers below use match the registrations.
+;; A couple of things `reg-view` is doing for us here. It auto-`def`s the
+;; symbol and registers the view under `(keyword *ns* sym)` — so by default the
+;; id tracks the var name. The `^{:rf/id …}` metadata overrides that, pinning
+;; ids the callers below already expect (`:pages/articles`, `:app/root`).
 ;;
-;; The `subscribe` injected by `reg-view` resolves to the frame-bound subscribe
-;; fn at runtime. The same view code runs on both sides: on the JVM render path,
-;; deref of a subscription yields its current value; on the client, deref tracks
-;; the reaction so re-renders fire on app-db changes. That parity is what lets
-;; one view run twice. See ../../../docs/guide/glossary.md#view.
+;; The other gift is `subscribe`: `reg-view` injects it, and it resolves to the
+;; frame-bound subscribe fn at *runtime*. That single detail is what lets one
+;; view run twice. On the JVM render path, deref of a subscription just reads
+;; the current value and returns. On the client, the very same deref registers
+;; a reaction, so the view re-renders whenever app-db changes underneath it.
+;; Same code, two behaviours, picked up from the context. See
+;; ../../../docs/guide/glossary.md#view.
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
   (let [arts         @(subscribe [:articles/slice])
         show-bodies? @(subscribe [:articles/show-bodies?])]
@@ -202,31 +238,36 @@
 ;; SERVER ENTRY POINT
 ;; ============================================================================
 ;;
-;; The server flow, start to finish (../../../docs/ssr/concepts.md#a-request-start-to-finish):
-;;   1. Accept the request.
-;;   2. set-request! populates the per-frame slot the :rf.server/request
-;;      coeffect reads from.
-;;   3. reg-frame; its :initial-events step dispatches :rf/server-init, which
-;;      reads the request via the coeffect.
-;;   4. The runtime drains: HTTP fetches resolve and app-db settles.
-;;   5. Render to a string via the pure hiccup -> HTML emitter.
-;;   6. Serialise the state and ship it in the HTML payload.
-;;   7. destroy-frame! in a `finally`. This is load-bearing for memory hygiene
-;;      on a long-running server: it drops the frame record and fires the
-;;      `:ssr/on-frame-destroyed` hook, which releases the per-frame request
-;;      slot, response accumulator, and error-trace buffer. The `finally` runs
-;;      on both the success and throw paths, so no partially-built frame leaks
-;;      either.
+;; Here's the whole server-side dance, one request from end to end
+;; (../../../docs/ssr/concepts.md#a-request-start-to-finish):
+;;   1. A request arrives.
+;;   2. set-request! drops it into the per-frame slot that the
+;;      :rf.server/request coeffect will read back out.
+;;   3. reg-frame stands up a fresh frame; its :initial-events step fires
+;;      :rf/server-init, which pulls the request via that coeffect.
+;;   4. The runtime drains — the article fetch resolves, app-db settles, and
+;;      everything quiets down.
+;;   5. Render the settled state to a string with the pure hiccup -> HTML
+;;      emitter.
+;;   6. Serialise that same state and tuck it into the HTML as the payload.
+;;   7. destroy-frame!, in a `finally`. This step isn't optional bookkeeping —
+;;      on a server that runs for weeks, it's what stops you leaking a frame
+;;      per request. It drops the frame record and fires
+;;      `:ssr/on-frame-destroyed`, which hands back the request slot, the
+;;      response accumulator, and the error-trace buffer. The `finally` covers
+;;      both the happy path and the throw path, so even a request that blows up
+;;      halfway doesn't strand a half-built frame.
 
 #?(:clj
    (defn handle-request [request]
      (let [fid (keyword "rf.frame" (str (gensym "f")))
            _   (ssr/set-request! fid request)
-           ;; Register the app schema against this per-request server frame,
-           ;; under the gensym `fid`, before creating the frame. `reg-frame`
-           ;; runs its `:initial-events` cascade synchronously, so the schema
-           ;; must be in place first to validate the server-side `:articles`
-           ;; commit that `:rf/server-init` kicks off.
+           ;; Schema first, frame second — order matters. `reg-frame` runs its
+           ;; `:initial-events` cascade synchronously, and that cascade includes
+           ;; the `:articles` commit `:rf/server-init` sets in motion. If the
+           ;; schema weren't already registered against this per-request frame
+           ;; (the gensym `fid`), there'd be nothing to validate that commit
+           ;; against by the time it fires.
            _   (rf/reg-app-schema [:articles] {:schema ArticlesSchema :frame fid})
            f   (rf/reg-frame fid
                  {:doc       "ssr-example per-request frame"
@@ -234,32 +275,35 @@
                   :initial-events [[:rf/server-init]]})]
        (try
          (rf/with-frame f
-           (let [final-db      (rf/app-db-value f)        ;; app-db partition
-                 final-runtime (rf/runtime-db-value f)    ;; runtime-db partition (serializable)
+           (let [final-db      (rf/app-db-value f)        ;; the app-db partition
+                 final-runtime (rf/runtime-db-value f)    ;; the runtime-db partition (serializable)
                  hiccup   ((rf/view :app/root))
-                 ;; render-to-string with :emit-hash? embeds
-                 ;; data-rf-render-hash="<hex>" on the root element. The
-                 ;; client recomputes the hash after its first render and
-                 ;; the runtime emits :rf.ssr/hydration-mismatch on
-                 ;; disagreement.
+                 ;; `:emit-hash?` stamps data-rf-render-hash="<hex>" onto the
+                 ;; root element. That hex string is the tripwire: the client
+                 ;; recomputes the hash after its first render, and if the two
+                 ;; don't match, the runtime raises :rf.ssr/hydration-mismatch
+                 ;; instead of quietly serving a subtly-broken page.
                  html     (rf/render-to-string hiccup
                                                {:doctype?    true
                                                 :emit-hash?  true})
-                 ;; Same hash also lands on the payload so non-DOM
-                 ;; environments (server logs, CDN cache keys) can read it
-                 ;; without HTML parsing.
+                 ;; The same hash also rides in the payload, so something
+                 ;; without a DOM to parse — a server log line, a CDN cache key
+                 ;; — can read it straight.
                  render-hash (rf/render-tree-hash hiccup)
-                 ;; The payload omits `:rf/frame-id`. The server renders under
-                 ;; a per-request gensym frame (`f`); the client hydrates its
-                 ;; own fixed app-frame (`app-frame`, below). A payload frame-id
-                 ;; is validation evidence, not a hydration target: `ssr/hydrate!`
-                 ;; checks any present `:rf/frame-id` against the client's
-                 ;; explicit `:frame` and raises
-                 ;; `:rf.error/hydration-frame-id-mismatch` if they disagree. An
-                 ;; absent id is the no-conflict shape both this output and the
-                 ;; static `index.html` use. To carry a frame-id, a deployment
-                 ;; stamps a stable id both sides agree on — not a per-request
-                 ;; gensym.
+                 ;; You'll notice the payload carries no `:rf/frame-id`, and
+                 ;; that's the intended shape. The server rendered under a
+                 ;; throwaway per-request gensym (`f`); the client hydrates its
+                 ;; own fixed `app-frame` (defined below). The two frames have
+                 ;; nothing to say to each other by name. A `:rf/frame-id` in
+                 ;; the payload isn't a "hydrate into this" instruction — it's
+                 ;; evidence. `ssr/hydrate!` checks any id it finds against the
+                 ;; `:frame` you explicitly pass, and raises
+                 ;; `:rf.error/hydration-frame-id-mismatch` if they disagree.
+                 ;; Leaving it out is the no-argument-to-have-here shape, which
+                 ;; is exactly what this output and the static `index.html`
+                 ;; both use. A deployment that *does* want to carry one stamps
+                 ;; a stable id both sides agree on ahead of time — never a
+                 ;; per-request gensym.
                  payload  {:rf/version     1
                            :rf/app-db      final-db        ;; app-db partition
                            :rf/runtime-db  final-runtime   ;; serializable runtime-db projection
@@ -272,22 +316,23 @@
                    "<title>SSR demo</title>"
                    "</head><body>"
                    "<div id='app'>" html "</div>"
-                   ;; Emit the payload `<script>` through the EDN-aware
-                   ;; `</script>`-escaper, so a server-provided string carrying
-                   ;; `</script>` (round-tripped through app-db) can't close the
-                   ;; envelope. The encoder rewrites a less-than char to its
-                   ;; unicode reader escape only inside EDN string literals, so
-                   ;; the payload still round-trips through the client's
-                   ;; `cljs.reader/read-string` unchanged.
+                   ;; Run the payload through the EDN-aware escaper before it
+                   ;; goes in the `<script>`. If an article body happened to
+                   ;; contain the literal text `</script>` and we wrote it raw,
+                   ;; the browser would close the script element right there and
+                   ;; eat the rest of our state. The escaper sidesteps that by
+                   ;; rewriting `<` to its unicode reader escape — but *only*
+                   ;; inside EDN string literals, so the client's
+                   ;; `cljs.reader/read-string` still reads it back unchanged.
                    "<script id='__rf_payload' type='application/edn'>"
                    (html/escape-edn-script-body (pr-str payload))
                    "</script>"
                    "<script src='/main.js'></script>"
                    "</body></html>")}))
-         ;; Tear the per-request frame down on every exit path. The
-         ;; `:ssr/on-frame-destroyed` hook (fired by destroy-frame!) clears the
-         ;; request slot and the SSR side-channel atoms, so no explicit
-         ;; `clear-request!` is needed here.
+         ;; Whatever happened above — success or exception — the frame goes
+         ;; away here. destroy-frame! fires `:ssr/on-frame-destroyed`, which
+         ;; clears the request slot and the SSR side-channel atoms for us, so
+         ;; there's no separate `clear-request!` to remember.
          (finally
            (rf/destroy-frame! fid))))))
 
@@ -295,96 +340,107 @@
 ;; CLIENT ENTRY POINT
 ;; ============================================================================
 ;;
-;; The client flow is `ssr/hydrate!` — the framework's client-boot helper, the
-;; counterpart of the server render. One call does the three steps, in order:
-;;   1. READ    — the embedded `__rf_payload` `<script>` via the pinned id.
-;;                A malformed payload fails closed (no app-db replacement); a
-;;                missing payload is the client-only first-load shape.
-;;   2. HYDRATE — dispatch-sync `[:rf/hydrate payload]` before the first render.
-;;                The framework handler replaces the frame-state with the server
-;;                slice and stashes the server's render hash for the verify step.
-;;   3. VERIFY  — after the first render, hash the `:render-tree-fn` result and
-;;                compare it to the server hash; a disagreement emits
-;;                :rf.ssr/hydration-mismatch.
-;; `hydrate!` returns the payload it applied (nil on a client-only load), so
-;; `run` can branch on "was this server-rendered?" without re-reading the DOM.
-;; Going through the helper pins the fail-closed validation, the hash stash, and
-;; the verify step together in the right order.
-;; See ../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
+;; On the client, the whole boot is a single call: `ssr/hydrate!`, the mirror
+;; image of the server render. It rolls three steps into one, and the order is
+;; the point:
+;;   1. READ    — pull the embedded `__rf_payload` `<script>` by its pinned id.
+;;                A malformed payload fails closed (nothing replaces app-db); a
+;;                missing one just means "nobody server-rendered this" — a plain
+;;                first load.
+;;   2. HYDRATE — dispatch-sync `[:rf/hydrate payload]`, before the first
+;;                render. The framework handler swaps in the server's slice and
+;;                sets the server's render hash aside for step 3.
+;;   3. VERIFY  — once that first render is on screen, hash the `:render-tree-fn`
+;;                result and hold it up against the server's hash. Disagree and
+;;                you get :rf.ssr/hydration-mismatch.
+;; `hydrate!` hands back the payload it applied (or nil on a plain client load),
+;; which lets `run` answer "was this server-rendered?" without going back to
+;; sniff the DOM. The reason to route through the helper rather than wire these
+;; up yourself: it keeps the fail-closed check, the hash stash, and the verify
+;; locked together in the one correct order. See
+;; ../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
 
-;; User events live under an app-chosen namespace, never the reserved `:rf/*`
-;; root. `:rf/hydrate` is framework-owned; `:rf/server-init` is the documented
-;; per-request server-init pattern the app supplies a body for. This
-;; client-only-load bootstrap is a fresh user event, so it gets the app's own
-;; `:ssr/` namespace.
+;; A quick naming note. App events live under a namespace you pick; the reserved
+;; `:rf/*` root is the framework's. `:rf/hydrate` is framework-owned, and
+;; `:rf/server-init` is the documented per-request boot pattern you fill a body
+;; into. This little bootstrap-for-a-plain-load, though, is your own brand-new
+;; event — so it gets the app's own `:ssr/` namespace, not `:rf/`.
 (rf/reg-event :ssr/client-bootstrap
-  {:doc "Client-side init that runs even if the server didn't render this page."}
+  {:doc "Client-side init that runs even when the server never rendered this page."}
   (fn [{:keys [db]} _] {:db db}))
 
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. ns-load must produce no DOM side effects, so co-required example
-;; namespaces don't race `create-root` onto the shared `#app`.
+;; The React root lives in an atom and gets created lazily inside `run`, never
+;; at namespace-load. The rule is that loading a namespace must not touch the
+;; DOM — so if several example namespaces get required together, none of them
+;; can race the others to slap a `create-root` onto the shared `#app`.
 #?(:cljs (defonce react-root (atom nil)))
 
-;; The client app-frame id. The app names its frame explicitly and threads this
-;; id through both `ssr/hydrate!` (the seed target) and the root
-;; `frame-provider` (where every in-tree `dispatch`/`subscribe` resolves). It
-;; must be a `:client`-platform frame so the compatibility-check fxs the
-;; `:rf/hydrate` handler dispatches actually fire — a `:server` frame skips
-;; them. The server payload carries no `:rf/frame-id`, so this explicit `:frame`
-;; is the hydration target (see the `handle-request` note).
+;; The client's app-frame id. The app names its frame out loud and threads the
+;; very same id through two places: `ssr/hydrate!` (where the server's state
+;; gets seeded) and the root `frame-provider` (where every `dispatch` and
+;; `subscribe` in the tree goes looking for its frame). It has to be a
+;; `:client`-platform frame, because the `:rf/hydrate` handler fires
+;; compatibility-check effects that a `:server` frame would just skip. And since
+;; the server payload carries no `:rf/frame-id`, this explicit `:frame` is the
+;; hydration target, plain and simple (see the note over in `handle-request`).
 (def app-frame :rf/default)
 
 #?(:cljs
    (defn run []
-     ;; Boot the runtime against the Reagent substrate. Idempotent: the first
-     ;; call installs the adapter, hot reloads are no-ops. `init!` installs only
-     ;; the adapter; the app creates its frame itself, in the next step.
-     ;;
-     ;; Pass the adapter spec map directly — each adapter ns exports an
-     ;; `adapter` var the consumer requires and passes here.
+     ;; First, point the runtime at the Reagent substrate. This is safe to call
+     ;; over and over: the first call wires up the adapter, every hot reload
+     ;; after that is a no-op. Note what `init!` does *not* do — it installs the
+     ;; adapter and stops there. Creating a frame is the app's job, next line.
+     ;; (Each adapter namespace exports an `adapter` var; you require it and
+     ;; hand the spec map straight in.)
      (rf/init! reagent-adapter/adapter)
-     ;; Create the client app-frame before hydrating into it. `reg-frame` is a
-     ;; no-op on re-registration, so hot-reload just works. `:platform :client`
-     ;; makes the hydrate compatibility-check fxs fire.
+     ;; Stand up the client app-frame before we hydrate anything into it.
+     ;; Re-registering an existing frame is a no-op, so hot-reload just shrugs
+     ;; and carries on. `:platform :client` is what lets the hydrate
+     ;; compatibility-check effects actually fire.
      (rf/reg-frame app-frame {:doc      "ssr-example client app-frame"
                               :platform :client})
-     ;; Register the app schema against the fixed client frame, so the hydrated
-     ;; `:articles` commit and every post-hydration interactive commit validate
-     ;; on the client too — the counterpart of the per-request registration in
-     ;; `handle-request`. `reg-app-schema` is no-op-safe on hot-reload.
+     ;; Register the schema against this client frame too — the mirror of the
+     ;; per-request registration back in `handle-request`. That way the hydrated
+     ;; `:articles` commit, and every interactive commit the reader triggers
+     ;; afterward, get validated on the client just as they were on the server.
+     ;; (Also no-op-safe on hot-reload.)
      (rf/reg-app-schema [:articles] {:schema ArticlesSchema :frame app-frame})
-     ;; Drive READ + HYDRATE + VERIFY through `ssr/hydrate!`, against the same
-     ;; `app-frame` the mount below uses. `:render-tree-fn` must return the same
-     ;; resolved hiccup tree the server hashed. The server hashed
-     ;; `((rf/view :app/root))`, so VERIFY calls the view fn the same way —
-     ;; `((rf/view :app/root))` — not the vector form `[(rf/view :app/root)]`
-     ;; that Reagent mounts. `hydrate!` returns the payload it applied (nil on a
-     ;; client-only load).
+     ;; One call, all three steps — READ, HYDRATE, VERIFY — against the same
+     ;; `app-frame` the mount below will use. The one subtlety is `:render-tree-fn`:
+     ;; VERIFY has to hash the *exact* tree the server hashed, or it'll cry
+     ;; mismatch over a difference that was never real. The server hashed
+     ;; `((rf/view :app/root))` — the view fn *called* — so we call it the same
+     ;; way here, not the `[(rf/view :app/root)]` vector form Reagent mounts.
+     ;; `hydrate!` returns the payload it applied, or nil on a plain client load.
      (let [payload (ssr/hydrate! {:frame          app-frame
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})]
        (when-not payload
-         ;; Client-only load (no server render): run the app's own bootstrap
-         ;; against the app-frame; the page renders the empty-articles fallback.
+         ;; No payload means no server render — a plain first load. Run the
+         ;; app's own bootstrap against the frame; the page comes up showing the
+         ;; empty-articles fallback.
          (rf/dispatch-sync [:ssr/client-bootstrap] {:frame app-frame})))
      (when (exists? js/document)
        (when-not @react-root
          (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-       ;; Mount under the app-frame's `frame-provider` so every in-tree
-       ;; `dispatch`/`subscribe` resolves to the hydrated frame.
+       ;; Mount inside the app-frame's `frame-provider`, so every `dispatch` and
+       ;; `subscribe` down in the view tree resolves to the frame we just
+       ;; hydrated.
        (rdc/render @react-root
                    [rf/frame-provider {:frame app-frame}
                     [(rf/view :app/root)]]))))
 
-;; The headless tests for this example live in re-frame.examples-test
-;; (implementation/core/test/), so this source stays pure demonstration (the
-;; example tree is test-free). They run on the JVM:
-;;   - `ssr-example-runs-end-to-end` — the full server flow: per-request frame,
-;;     :rf/server-init, the article fetch via a canned stub, render-to-string,
-;;     render-hash.
+;; No tests in this file — and that's deliberate. The example tree stays
+;; test-free so the source reads as pure demonstration; the headless tests that
+;; actually exercise all of the above live next door in re-frame.examples-test
+;; (implementation/core/test/) and run on the JVM. If you're curious what's
+;; covered:
+;;   - `ssr-example-runs-end-to-end` — the whole server flow: per-request frame,
+;;     :rf/server-init, the article fetch through a canned stub,
+;;     render-to-string, render-hash.
 ;;   - `ssr-example-handle-request-tears-down-per-request-frame` and
-;;     `…-tears-down-on-throw` — per-request frame teardown on the success and
-;;     throw paths.
-;;   - `ssr-example-client-hydration-*` — the client hydration path: server-hash
-;;     stash, matching/divergent hash verify, and fail-closed on a malformed
-;;     payload.
+;;     `…-tears-down-on-throw` — proof the frame is torn down on both the happy
+;;     path and the throw path.
+;;   - `ssr-example-client-hydration-*` — the client side: the server-hash
+;;     stash, verify on both a matching and a divergent hash, and fail-closed
+;;     behaviour on a malformed payload.

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -1,21 +1,29 @@
 (ns ssr-streaming.core
-  "Streaming SSR: a dashboard with three slow cards. The shell + header
-  render immediately on the server. Each card then streams its content
-  in as its data resolves, so the browser shows a usable shell within
-  ~50ms while the cards trickle in over ~300ms each.
+  "Streaming SSR — a dashboard that refuses to wait on its slowest part.
 
-  What this example shows:
-   - `:rf/suspense-boundary` — the declarative hiccup marker for a
-     streamable subtree.
-   - Per-card fallback hiccup — `[:div.card.skeleton …]`.
-   - Failure isolation — one card deliberately throws to show a failing
-     boundary stays on its fallback instead of 500-ing the page.
-   - Per-subtree hydration — each chunk's
-     `<script data-rf2-suspense-hydrate>` carries that card's app-db delta.
-   - A final `__rf_payload` chunk with the canonical full state.
+  The page is four cards. The shell and header render instantly on the
+  server, then each card streams in the moment its own data resolves.
+  Picture three slow microservices behind those cards: the browser paints
+  a usable skeleton in ~50ms, and the real numbers trickle in over ~300ms
+  each, instead of the whole page sitting blank until the slowest one
+  answers.
 
-  The `.cljc` split: the `:clj` branch is what a Ring server invokes; the
-  `:cljs` branch is what the page bootstraps once the chunks arrive.
+  Five ideas earn their keep here:
+   - `:rf/suspense-boundary` — one hiccup marker that says \"this region
+     may arrive late.\" That marker IS the whole streaming API.
+   - A `:fallback` to show in the meantime — here a skeleton card.
+   - Failure isolation — one card throws on purpose, to prove a blown
+     boundary stays on its fallback instead of taking the page down with
+     it.
+   - Per-card state — each chunk's `<script data-rf2-suspense-hydrate>`
+     carries that card's app-db delta, so the streamed-in subtree's subs
+     have something to read.
+   - A final `__rf_payload` chunk carrying the canonical full state. The
+     deltas are a speed bet; this is the truth, and it wins any tie.
+
+  One artefact, two runtimes: the `:clj` branch is what a Ring server
+  calls per request, the `:cljs` branch is what the page boots once the
+  chunks land.
 
   See the [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)."
   (:require [re-frame.core :as rf]
@@ -28,17 +36,18 @@
 ;; SCHEMA
 ;; ============================================================================
 ;;
-;; We hold the schema as a plain value and register it per-frame at each
-;; entry point with the `{:frame …}` override. Streaming SSR runs two
-;; frames — the per-request server frame (gensym, in `handle-request`) and
-;; the fixed client hydration frame (`app-frame`, in `run`) — and both need
-;; the same contract, so each registers it explicitly. Schemas are
-;; frame-local, so holding the schema as a plain def keeps ns-load free of
-;; side effects: the namespace loads under no frame.
+;; The contract for the `:cards` slice, kept as a plain value. Why a plain
+;; def and not a registration at the top level? Schemas are frame-local,
+;; and this example runs two frames: a fresh per-request frame on the
+;; server (`handle-request`) and a fixed app-frame on the client (`run`).
+;; Both need this same contract, so each registers it explicitly with a
+;; `{:frame …}` override. Holding the schema as a value lets the namespace
+;; load under no frame at all — ns-load stays free of side effects.
 ;;
-;; `[:maybe …]` because the `:cards` slice is nil until `:rf/server-init`
-;; seeds it on the server, or the client hydrates it. A bare `[:map-of …]`
-;; would reject that legitimate nil and roll the commit back.
+;; The `[:maybe …]` matters: the `:cards` slice is nil until the server
+;; seeds it (`:rf/server-init`) or the client hydrates it. A bare
+;; `[:map-of …]` would reject that perfectly legal nil and roll the commit
+;; back on you.
 ;; See the [schemas guide](../../../docs/guide/how-to/validate-with-schemas.md).
 (def CardsSchema
   [:maybe [:map-of :keyword [:map [:title :string] [:value [:maybe :int]]]]])
@@ -48,10 +57,11 @@
 ;; ============================================================================
 
 (rf/reg-event :rf/server-init
-  {:doc       "Per-request server-side init. A real app would dispatch
-               :rf.http/managed fetches here to load each card's data. This
-               demo seeds three card values synchronously so the whole wire
-               shape can be inspected in one browser request."
+  {:doc       "Per-request server-side init — this is where a card's data
+               comes from. A real app would kick off :rf.http/managed
+               fetches here, one per card. We cheat and seed three values
+               synchronously instead, so the whole wire shape resolves in a
+               single browser request and you can read it in one go."
    :platforms #{:server}}
   (fn [_ _]
     {:db {:cards
@@ -78,10 +88,14 @@
    [:p.value "—"]])
 
 (rf/reg-view ^{:rf/id :dashboard/throwing-card} throwing-card []
-  ;; Failure isolation. This view deliberately throws. The streaming runtime
-  ;; catches it, emits a :rf.ssr/suspense-boundary-failed trace, and ships the
-  ;; fallback HTML in the chunk's place (marked data-rf2-suspense-failed). The
-  ;; page still loads — only this card stays on its fallback. See the
+  ;; The card that fails on purpose, standing in for that one flaky
+  ;; third-party metric service every dashboard seems to have. When this
+  ;; view throws, the streaming runtime catches it inside this one
+  ;; boundary, emits a :rf.ssr/suspense-boundary-failed trace, and ships
+  ;; the fallback HTML in the chunk's slot (marked data-rf2-suspense-failed)
+  ;; with no hydrate delta. The other three cards stream on as if nothing
+  ;; happened. A thrown render takes down exactly one boundary, never the
+  ;; page. See the
   ;; [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary).
   (throw (ex-info "flaky third-party metric service" {})))
 
@@ -91,10 +105,12 @@
     [:h1 "Dashboard"]
     [:p "Streamed SSR demo — shell renders first, cards stream in."]]
    [:section.cards
-    ;; `:rf/suspense-boundary` marks a streamable subtree. The `:fallback`
-    ;; ships inline in the shell now; the real child subtree streams in as
-    ;; its own chunk once it resolves. The `:id` pairs the incoming chunk
-    ;; with its placeholder on the client — you pick it, and it must be unique.
+    ;; Here's the whole trick, four times over. `:rf/suspense-boundary`
+    ;; wraps a region that's allowed to arrive late. The `:fallback` ships
+    ;; inline in the shell right now; the real child renders separately and
+    ;; streams in as its own chunk once it resolves. The `:id` is how the
+    ;; client pairs an arriving chunk with its placeholder — you pick it,
+    ;; and it has to be unique.
     [:rf/suspense-boundary
      {:id :card.revenue :fallback [:dashboard/card-skeleton :revenue]}
      [:dashboard/card :revenue]]
@@ -104,9 +120,11 @@
     [:rf/suspense-boundary
      {:id :card.latency :fallback [:dashboard/card-skeleton :latency]}
      [:dashboard/card :latency]]
-    ;; The failure-path card. Same wire shape; its chunk carries the
-    ;; fallback HTML with `data-rf2-suspense-failed="1"` and no hydrate-delta
-    ;; script.
+    ;; The failure-path card — same marker, same shape as the three above.
+    ;; The only difference shows up on the wire: its chunk carries the
+    ;; fallback HTML stamped `data-rf2-suspense-failed="1"` and no
+    ;; hydrate-delta script. A failure is just another way for a boundary to
+    ;; resolve.
     [:rf/suspense-boundary
      {:id :card.flaky
       :fallback [:dashboard/card-skeleton :flaky]}
@@ -120,22 +138,24 @@
 
 #?(:clj
    (defn handle-request
-     "What a host adapter (re-frame.ssr.ring/stream-handler) would call.
-     This shape is one logical request → one chunked response; the
-     adapter handles the actual Ring wiring and the writer thread. Here
-     we synthesise the steps in-line so the example is JVM-runnable
-     without a live server.
+     "One request in, one chunked response out — what a host adapter
+     (re-frame.ssr.ring/stream-handler) calls. In production the adapter
+     owns the Ring wiring and the writer thread that flushes chunks as
+     they're ready. We do the steps by hand here so the example runs on a
+     bare JVM with no live server in the loop, and so you can see the order
+     the bytes go out in.
 
-     Returns: a map carrying the rendered shell, the per-card chunks
-     in order, and the final payload — the per-chunk byte sequence the
-     streaming adapter would emit in order."
+     Returns a map of the rendered shell, the per-card chunks in order, and
+     the final payload — the same byte sequence the streaming adapter would
+     emit, just collected instead of flushed."
      [_request]
      (let [fid (keyword "rf.frame" (str (gensym "")))
-           ;; Register the app schema against this per-request frame BEFORE
-           ;; creating it. The server-side `:cards` commit validates in this
-           ;; frame, and `reg-frame` runs the `:initial-events` cascade (which
-           ;; fires `:rf/server-init`) synchronously, so the schema must be in
-           ;; place first.
+           ;; A fresh frame per request, identified by a gensym so concurrent
+           ;; requests never collide. Order matters here: register the schema
+           ;; against this frame BEFORE creating it. `reg-frame` fires the
+           ;; `:initial-events` cascade — and therefore `:rf/server-init` and
+           ;; its `:cards` commit — synchronously, so the contract has to be
+           ;; in place by then or the commit validates against nothing.
            _   (rf/reg-app-schema [:cards] {:schema CardsSchema :frame fid})
            _   (rf/reg-frame fid {:doc "ssr-streaming-example frame"
                                   :platform :server
@@ -143,8 +163,11 @@
            hiccup (rf/with-frame fid ((rf/view :dashboard/root)))
            {:keys [shell-html continuations]}
            (rf/with-frame fid (ssr/streaming-render-shell hiccup))
-           ;; Drain each continuation in order, collecting the resolved
-           ;; subtree HTML + per-subtree hydration delta.
+           ;; Render the shell handed us one continuation per boundary —
+           ;; the slow subtrees it deferred. Drain them in order, collecting
+           ;; each resolved subtree's HTML plus its hydration delta. This is
+           ;; the loop the writer thread would run, flushing each chunk the
+           ;; moment it's ready.
            resolved-chunks
            (mapv (fn [entry]
                    (let [{:keys [id html delta failed?]}
@@ -160,28 +183,33 @@
                       :failed? failed?}))
                  continuations)
            render-hash (rf/with-frame fid (ssr/render-tree-hash hiccup))
-           ;; The final payload is the canonical full app-db. The per-card
-           ;; deltas above are a speed prop; this is the correctness lock. If
-           ;; a delta ever disagrees with the payload, the payload wins.
+           ;; The final payload: the canonical, whole app-db. This is the
+           ;; load-bearing idea of the example. Those per-card deltas are a
+           ;; speed bet — they exist only to paint each region early. This
+           ;; payload is the truth, and if a delta ever disagrees with it,
+           ;; the payload wins. You get streaming's latency with a single
+           ;; authoritative hydrate's correctness.
            ;;
-           ;; The `:payload` opt decides what crosses the wire, and it is
-           ;; fail-closed. This demo's app-db is safe to expose whole (every
-           ;; key the dashboard populates is meant for the client), so we opt
-           ;; in with `:rf.ssr.payload/whole-app-db`. Production normally
-           ;; passes an explicit allowlist vector of top-level app-db keys.
+           ;; `:payload` decides what crosses the wire, and it's fail-closed
+           ;; — nothing leaves unless you say so. This demo's app-db is safe
+           ;; to ship whole (every key the dashboard fills is meant for the
+           ;; client), so we opt in with `:rf.ssr.payload/whole-app-db`. Real
+           ;; apps usually pass an explicit allowlist of top-level keys
+           ;; instead.
            final-payload (rf/with-frame fid
                            (ssr/streaming-build-final-payload
                              fid render-hash
                              {:version 1
                               :payload :rf.ssr.payload/whole-app-db}))
-           ;; Drop the payload's `:rf/frame-id`. The builder stamps this
-           ;; per-request frame (`fid`), but the client hydrates a fixed
-           ;; `app-frame` (below). `ssr/hydrate!` checks a present `:rf/frame-id`
-           ;; against the client's explicit `:frame` and fails closed on
-           ;; disagreement, which a per-request gensym always would. With no
-           ;; frame-id on the wire the client's explicit target stands. (A
-           ;; deployment that wants one on the wire stamps a stable id both
-           ;; sides share, not a gensym.) See the
+           ;; Strip the payload's `:rf/frame-id` before it goes over the
+           ;; wire. The two sides don't share a frame id: the server renders
+           ;; under this per-request gensym, the client hydrates a fixed
+           ;; `app-frame` (below). When `ssr/hydrate!` sees a frame-id on the
+           ;; wire, it checks it against the client's explicit `:frame` and
+           ;; fails closed if they differ — which a gensym always would. Send
+           ;; no frame-id and the client's explicit target simply stands. (If
+           ;; you do want one on the wire, share a stable id both sides agree
+           ;; on, not a gensym.) See the
            ;; [SSR guide — hydrate, then verify](../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
            final-payload (dissoc final-payload :rf/frame-id)
            _ (rf/destroy-frame! fid)]
@@ -194,104 +222,108 @@
 ;; CLIENT ENTRY POINT (.cljs branch — browser hydration)
 ;; ============================================================================
 ;;
-;; The streaming hydration sequence on the client:
+;; What the browser sees, in three acts:
 ;;
-;;  1. The first chunk lands. The browser receives the shell, whose slow
-;;     regions are inline `<template data-rf2-suspense-fallback>`
-;;     placeholders. A `<template>`'s content is inert by the HTML spec (its
-;;     `.content` is a detached DocumentFragment, never painted), so the
-;;     skeletons do NOT paint on the raw bytes. They paint when
-;;     `streaming-install!` (step 2) materialises each inert `<template>`
-;;     into a live `<rf-suspense data-rf2-suspense-mount>` mount. The
-;;     `<script src="main.js">` at the end of `<body>` begins downloading.
-;;  2. Resolved-card chunks stream in (Transfer-Encoding: chunked). Each is
-;;     a `<template data-rf2-suspense-resolved=…>…</template>` plus a
-;;     `<script data-rf2-suspense-hydrate=…>…</script>`. The client-side
-;;     streaming runtime (`ssr/streaming-install!`) first materialises the
-;;     inert fallback `<template>`s into live `<rf-suspense>` mounts (the
-;;     skeletons now paint), then swaps each mount's content for the resolved
-;;     subtree in place and merges that subtree's delta into the client
-;;     app-db as the chunk arrives. `run` installs it before the first render
-;;     so it catches chunks already streamed in and any still arriving.
-;;  3. The final `<script id="__rf_payload">` is the canonical full payload.
-;;     `run` dispatches `:rf/hydrate` against it (via `ssr/hydrate!`), which
-;;     replaces the whole client frame-state in one step — the payload's
-;;     app-db plus its serialisable runtime-db slice. The streaming runtime
-;;     auto-disconnects once it sees `__rf_payload`, so no late delta can
-;;     race the canonical replace. The per-card deltas were a speed prop;
-;;     this final replace is the correctness lock.
+;;  1. The shell arrives first. Its slow regions are inline
+;;     `<template data-rf2-suspense-fallback>` placeholders. A `<template>`'s
+;;     content is inert by the HTML spec — its `.content` is a detached
+;;     DocumentFragment that never paints — so the skeletons stay invisible
+;;     on the raw bytes. They only appear once step 2's `streaming-install!`
+;;     materialises each inert `<template>` into a live
+;;     `<rf-suspense data-rf2-suspense-mount>`. Meanwhile the
+;;     `<script src="main.js">` at the foot of `<body>` starts downloading.
+;;  2. The resolved cards stream in (Transfer-Encoding: chunked), each a
+;;     `<template data-rf2-suspense-resolved=…>` plus a matching
+;;     `<script data-rf2-suspense-hydrate=…>`. The client streaming runtime
+;;     (`ssr/streaming-install!`) does two things per chunk: it brings the
+;;     inert fallback `<template>`s to life as `<rf-suspense>` mounts (now
+;;     the skeletons paint), then swaps each mount's content for the resolved
+;;     subtree in place and merges that subtree's delta into app-db. `run`
+;;     installs it before the first render, so it catches chunks that already
+;;     streamed in and any still on the way.
+;;  3. The final `<script id="__rf_payload">` is the canonical full state.
+;;     `run` hands it to `ssr/hydrate!`, which dispatches `:rf/hydrate` and
+;;     replaces the whole client frame-state in one step — app-db plus its
+;;     serialisable runtime-db slice. The runtime auto-disconnects the moment
+;;     it sees `__rf_payload`, so no late delta can race that replace. The
+;;     deltas got each card on screen early; this last step makes the whole
+;;     thing correct.
 ;;
 ;; See the [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)
 ;; and [hydrate, then verify](../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
 ;;
-;; This example boots from a static `index.html` that stands in for the
-;; streaming server — it ships the final resolved state and payload
-;; pre-baked, so the browser runs with no Clojure server in the loop.
-;; Because the streaming runtime is additive, a page whose chunks already
-;; resolved hydrates exactly the same: the install sweep finds no un-swapped
-;; fallback, sees `__rf_payload` already present, and goes straight to the
-;; `ssr/hydrate!` reconciliation. The progressive path (chunk-arrival swap +
-;; delta merge before the final payload) is exercised end-to-end by the
-;; browser acceptance test `re-frame.ssr.streaming-client-dom-cljs-test`.
+;; One honest caveat: this example boots from a hand-written `index.html`
+;; that plays the part of the streaming server, with the resolved chunks and
+;; final payload baked in. No Clojure server runs in the loop. That works
+;; because the streaming runtime is additive — a page whose chunks already
+;; resolved hydrates exactly the same way: the install sweep finds nothing
+;; left to swap, sees `__rf_payload` already there, and goes straight to the
+;; `ssr/hydrate!` reconciliation. The genuinely progressive path (swap on
+;; chunk arrival, merge the delta, then the final payload) is what the
+;; browser acceptance test `re-frame.ssr.streaming-client-dom-cljs-test`
+;; drives end to end.
 
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. ns-load must produce no DOM side effects, so co-required example
-;; namespaces don't race `create-root` onto the shared `#app`. (See the
-;; mount-isolation convention in examples/TESTING.md.)
+;; The React root lives in an atom and gets created lazily inside `run`,
+;; never at ns-load. The rule: loading a namespace must touch no DOM, so
+;; sibling example namespaces loaded alongside this one can't race each other
+;; to `create-root` the shared `#app`. (Mount-isolation convention — see
+;; examples/TESTING.md.)
 #?(:cljs (defonce react-root (atom nil)))
 
-;; The client app-frame id. The app carries it explicitly — the same id
-;; flows to the streaming `install!`, `ssr/hydrate!`, and the root
-;; `frame-provider`. This example uses `:rf/default`. It must be a
-;; `:client`-platform frame so the `:rf.ssr/check-*` compatibility checks the
-;; `:rf/hydrate` handler dispatches actually fire. Neither the static
-;; `index.html` payload nor the `handle-request` payload carries a
-;; `:rf/frame-id`: the server renders under a per-request gensym frame and the
-;; client hydrates this fixed frame, so an absent frame-id is the right shape —
-;; the explicit `:frame` is the target. See
+;; The client's app-frame id, carried explicitly. The same id flows into the
+;; streaming `install!`, into `ssr/hydrate!`, and into the root
+;; `frame-provider` — one source of truth for which frame everything targets.
+;; This example uses `:rf/default`. It has to be a `:client`-platform frame,
+;; or the `:rf.ssr/check-*` compatibility checks that `:rf/hydrate` runs
+;; would never fire. Neither payload (static or `handle-request`) carries a
+;; `:rf/frame-id`, and that's deliberate: the server rendered under a
+;; per-request gensym, the client hydrates this fixed frame, so an absent
+;; frame-id is exactly right — the explicit `:frame` says where to land. See
 ;; [frames](../../../docs/guide/glossary.md#frame-identity-is-carried-not-found).
 #?(:cljs (def app-frame :rf/default))
 
 #?(:cljs
    (defn run []
-     ;; `init!` installs the Reagent adapter. It creates no frame — the app
-     ;; creates its own explicitly below.
+     ;; `init!` installs the Reagent adapter and nothing more — it creates no
+     ;; frame. The app stands up its own, explicitly, just below.
      (rf/init! reagent-adapter/adapter)
-     ;; Establish the carried client app-frame BEFORE installing the streaming
-     ;; runtime and hydrating into it. `reg-frame` is a no-op on
-     ;; re-registration, so hot-reload just works. `:platform :client` makes
-     ;; the hydrate compatibility checks fire.
+     ;; Stand up the client app-frame BEFORE we install streaming or hydrate
+     ;; into it — both need a frame to land in. `reg-frame` is a no-op the
+     ;; second time round, so hot-reload just works. `:platform :client` is
+     ;; what makes the hydrate compatibility checks fire.
      (rf/reg-frame app-frame {:doc      "ssr-streaming-example client app-frame"
                               :platform :client})
-     ;; Register the app schema against this client frame so the `:cards`
-     ;; commits — both the streamed deltas and the final hydrate — validate on
-     ;; the client too. The symmetric counterpart of the registration in
-     ;; `handle-request`.
+     ;; The mirror image of the server registration in `handle-request`:
+     ;; same schema, this frame. With it in place, the `:cards` commits on the
+     ;; client — both the streamed deltas and the final hydrate — validate
+     ;; against the same contract the server used.
      (rf/reg-app-schema [:cards] {:schema CardsSchema :frame app-frame})
-     ;; Install the client-side streaming runtime BEFORE the first render so it
-     ;; catches resolved-subtree chunks as they arrive (and sweeps any already
-     ;; present). It swaps fallbacks and merges per-subtree deltas into the
-     ;; carried frame, then disconnects on `__rf_payload`.
+     ;; Turn on the streaming runtime BEFORE the first render, so it catches
+     ;; resolved-subtree chunks as they arrive (and sweeps up any that already
+     ;; landed). For each one it swaps the fallback for the real subtree and
+     ;; merges that subtree's delta into the frame — then disconnects itself
+     ;; the moment `__rf_payload` shows up.
      (ssr/streaming-install! {:frame app-frame})
-     ;; Reconcile against the canonical payload: read `__rf_payload` and
-     ;; dispatch `:rf/hydrate` into the explicit `:frame`. This is the
-     ;; correctness lock the streamed deltas defer to. Hydrate BEFORE the first
-     ;; render so the initial render runs against the seeded app-db.
-     ;; (`:render-tree-fn` is omitted because this static demo shell carries a
-     ;; placeholder render-hash, so mismatch verification would always warn. A
-     ;; real streaming server stamps the genuine hash, and the host passes
-     ;; `:render-tree-fn` to turn mismatch detection on.)
+     ;; Now reconcile against the canonical payload: read `__rf_payload` and
+     ;; dispatch `:rf/hydrate` into the explicit `:frame`. This is the truth
+     ;; the streamed deltas defer to. Hydrate BEFORE the first render so that
+     ;; render runs against fully seeded app-db, not a half-filled one.
+     ;; (We leave out `:render-tree-fn` because this static demo's shell
+     ;; carries a placeholder render-hash, so mismatch verification would warn
+     ;; every time. A real streaming server stamps the genuine hash and passes
+     ;; `:render-tree-fn` to switch mismatch detection on.)
      (ssr/hydrate! {:frame app-frame})
      (when (exists? js/document)
        (when-not @react-root
          (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-       ;; Wrap the mount in the carried frame's `frame-provider` so every
-       ;; in-tree `dispatch`/`subscribe` resolves to the hydrated frame.
+       ;; Wrap the mount in `frame-provider` so every `dispatch` and
+       ;; `subscribe` inside the tree resolves to the frame we just hydrated.
        (rdc/render @react-root
                    [rf/frame-provider {:frame app-frame}
                     [(rf/view :dashboard/root)]]))))
 
-;; The JVM headless test that exercises the server stream (shell → per-card
-;; resolved chunks → final payload) lives in re-frame.examples-test
-;; (implementation/core/test/), as the `ssr-streaming-example-runs-end-to-end`
-;; deftest. The example tree itself stays test-free.
+;; The JVM headless test that walks the server stream end to end (shell →
+;; per-card resolved chunks → final payload) lives over in
+;; re-frame.examples-test (implementation/core/test/), as the
+;; `ssr-streaming-example-runs-end-to-end` deftest. The example tree itself
+;; stays test-free.

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -1,51 +1,57 @@
 (ns state-machine-walkthrough.core
-  "The machines guide's login flow, as code.
+  "The machines guide's login flow, in working code.
 
-  Read alongside docs/machines/concepts.md — the transition table below is
-  laid out in the order that page introduces it.
+  Read this side by side with docs/machines/concepts.md — the transition
+  table below follows the exact order that page introduces it, so you can
+  scroll the two together.
 
-  The one idea this file makes tangible: a machine is a PURE transition
-  table, so a transition is a pure function call — table in, snapshot in,
-  event in; result out. That is what lets the four scenarios run headless,
-  on the JVM, in microseconds. Those tests live in the framework test tree
-  (see the SUBSCRIPTIONS note at the bottom).
+  Here's the one idea this file makes you feel in your hands: a machine is
+  just a PURE transition table, which means a transition is just a pure
+  function call. Table in, snapshot in, event in; next snapshot out. No
+  hidden state, no clock, no DOM. That purity is the whole payoff — it lets
+  the four login scenarios run headless on the JVM, in microseconds, with
+  no browser anywhere in sight. (Those tests live in the framework test
+  tree; see the SUBSCRIPTIONS note at the bottom for where and why.)
 
-  This is a .cljc so the same source compiles under shadow-cljs for the
-  browser demo and loads on the JVM for the headless tests. The login HTTP
-  request never hits the wire: :fx-overrides redirects it to the canned
-  stubs defined below."
+  This is a .cljc, which is the trick that makes that possible: the very
+  same source compiles under shadow-cljs for the browser demo AND loads on
+  the JVM for the headless tests. The login request never actually touches
+  the network — :fx-overrides quietly swaps it for the canned stubs defined
+  below."
   (:require [re-frame.core :as rf]
-            ;; Loading this ns makes `rf/reg-machine` and the `:rf/machine`
-            ;; / `:rf/machine-has-tag?` subs resolve, and the pure
-            ;; `machine-transition` fn the headless tests call. See
-            ;; docs/machines/glossary.md#machine.
+            ;; Pulls in the machine machinery: `rf/reg-machine`, the
+            ;; `:rf/machine` / `:rf/machine-has-tag?` subs, and the pure
+            ;; `machine-transition` fn that the headless tests call directly.
+            ;; See docs/machines/glossary.md#machine.
             [re-frame.machines]
-            ;; Registers the `:rf.http/managed` fx the login flow's
-            ;; `:issue-request` action dispatches. Tests override it via
+            ;; Registers `:rf.http/managed`, the fx our `:issue-request`
+            ;; action fires to make the login call. Tests intercept it via
             ;; :fx-overrides; see docs/guide/glossary.md#effect.
             [re-frame.http.managed]
-            ;; Registers the canned `:rf.http/managed-canned-*` fxs that the
-            ;; stubs below redirect to.
+            ;; Brings in the canned `:rf.http/managed-canned-*` fxs — the
+            ;; pre-baked replies our stubs below delegate to.
             [re-frame.http.test-support]
-            ;; The stubs below look up the canned fxs through the registrar.
+            ;; ...and those stubs find the canned fxs through the registrar.
             [re-frame.registrar :as registrar]))
 
 ;; ============================================================================
 ;; THE TRANSITION TABLE — guide §The same flow as a transition table
 ;; ============================================================================
 ;;
-;; Pure data. `:guards` and `:actions` live right here in the table, and the
-;; references inside `:states` resolve against this map — there is no global
-;; guard/action registry. To reuse a guard or action across machines, define a
-;; fn and name it locally in each machine's :guards / :actions.
+;; It's all just data. The `:guards` and `:actions` sit right here in the table,
+;; and the names mentioned inside `:states` resolve against this same map —
+;; there's no global guard/action registry off in some other file. Want to reuse
+;; a guard or action across machines? Write the fn once and name it locally in
+;; each machine's :guards / :actions. Locality over magic.
 ;;
-;; The `login` example (examples/reagent/login/core.cljs) builds a near-twin of
-;; this machine — same states, guards, actions, transitions. The two examples
-;; differ in what they teach AROUND the machine. `login` is the full feature
-;; scaffold (Malli schemas, a sensitive-request flag, a password-routing stub)
-;; wired into a live Reagent feature. This walkthrough strips that down to drive
-;; the machine HEADLESSLY, foregrounding the pure-transition testing story. Read
-;; `login` for the UI wiring; read this for the testing progression.
+;; Its near-twin lives next door: the `login` example
+;; (examples/reagent/login/core.cljs) has the same states, guards, actions, and
+;; transitions. What differs is what each example teaches AROUND the machine.
+;; `login` is the full feature scaffold — Malli schemas, a sensitive-request
+;; flag, a password-routing stub — all wired into a living Reagent feature. This
+;; walkthrough strips that away to drive the machine HEADLESSLY and put the
+;; pure-transition testing story centre stage. Read `login` for the UI wiring;
+;; read this one for the testing progression.
 
 (def login-flow
   {:initial :idle
@@ -53,8 +59,10 @@
 
    :guards
    {:under-retry-limit
-    ;; A guard takes one map: {:data ... :event ...}. `data` is the snapshot's
-    ;; :data slot directly. See docs/machines/glossary.md#guard.
+    ;; A guard is a pure yes/no question asked of one map: {:data ... :event ...}.
+    ;; `data` is the snapshot's :data slot, handed to you directly. Say yes here
+    ;; and the transition fires; say no and the machine looks at the next option.
+    ;; See docs/machines/glossary.md#guard.
     (fn [{data :data}]
       (< (:attempts data) 3))}
 
@@ -63,10 +71,11 @@
     (fn [_] {:data {:error nil}})
 
     :issue-request
-    ;; An action returns effects, not side-effects (docs/guide/glossary.md#effect).
-    ;; The `:rf.http/managed` fx issues the request, then dispatches the
-    ;; `:on-success` / `:on-failure` events with the reply appended as the
-    ;; last arg — routing the result back into this machine.
+    ;; An action describes effects; it never performs side-effects itself
+    ;; (docs/guide/glossary.md#effect). Here it asks for the `:rf.http/managed`
+    ;; fx, which makes the request and then dispatches `:on-success` /
+    ;; `:on-failure` with the reply appended as the last arg — looping the
+    ;; result right back into this machine as the next event.
     (fn [{[_ creds] :event}]
       {:fx [[:rf.http/managed
              {:request    {:method :post
@@ -98,9 +107,11 @@
                               :action :clear-error}}}
 
     :submitting
-    ;; :auth/busy tag — the view asks (rf/machine-has-tag? :auth.login/flow
-    ;; :auth/busy) to disable inputs and re-label the submit button while the
-    ;; request is in flight. See docs/machines/glossary.md#state-tag.
+    ;; The :auth/busy tag is how the view knows to dim the inputs and re-label
+    ;; the button while the request is in flight — it asks
+    ;; (rf/machine-has-tag? :auth.login/flow :auth/busy) rather than checking for
+    ;; this exact state by name. Ask what's true, not where you are.
+    ;; See docs/machines/glossary.md#state-tag.
     {:tags  #{:auth/busy}
      :entry :issue-request
      :on    {:auth.login/success {:target :authed
@@ -116,13 +127,14 @@
           :auth.login/submit  {:target :submitting}}}
 
     :authed
-    ;; :auth/authenticated tag — set once the flow reaches this terminal state.
+    ;; Journey's end, happy path. The :auth/authenticated tag rides along once
+    ;; the flow lands here, and :terminal? marks it as a final state.
     {:tags #{:auth/authenticated}
      :meta {:terminal? true}}
 
     :locked-out
-    ;; :auth/locked tag — root-view swaps the form for the locked-out panel
-    ;; when this tag is set.
+    ;; Journey's end, unhappy path. Seeing the :auth/locked tag is the cue for
+    ;; root-view to swap the form out for the locked-out panel.
     {:tags #{:auth/locked}
      :meta {:terminal? true}}}})
 
@@ -130,31 +142,34 @@
 ;; FX — guide §Composing with async effects
 ;; ============================================================================
 ;;
-;; `:auth.session/store` is a stub: it shows the shape, not real localStorage.
-;; The login HTTP request runs through the canned-success / canned-failure
-;; stubs below, swapped in at frame creation via :fx-overrides.
+;; `:auth.session/store` is a stub — it shows you the SHAPE of the effect without
+;; the real localStorage write, which keeps the walkthrough honest and headless.
+;; The login request, meanwhile, runs through the canned stubs below, slotted in
+;; at frame creation via :fx-overrides so no real HTTP ever happens.
 
 (rf/reg-fx :auth.session/store
-  {:doc "Stub: a real implementation would write localStorage."}
+  {:doc "Stub: the real thing would write the session token to localStorage."}
   (fn [_m _args] nil))
 
-;; The framework ships `:rf.http/managed-canned-success` and
-;; `:rf.http/managed-canned-failure` fxs that synthesise the canonical reply
-;; shape. The wrappers below pin this example's specific payloads. Both the
-;; browser demo and the headless tests redirect `:rf.http/managed` to them.
+;; The framework already ships `:rf.http/managed-canned-success` and
+;; `:rf.http/managed-canned-failure` — fxs that fabricate a reply in the
+;; canonical shape. The two thin wrappers below just pin THIS example's
+;; payloads on top. Both the browser demo and the headless tests point
+;; `:rf.http/managed` at them.
 
 (rf/reg-fx :auth.login/canned-success
-  {:doc "Example stub: every `:rf.http/managed` call resolves :success with a
-         canned user/token payload. Delegates to the framework-shipped
-         `:rf.http/managed-canned-success`."}
+  {:doc "Example stub: pretend every login succeeds, handing back a canned
+         user/token. Defers the heavy lifting to the framework-shipped
+         `:rf.http/managed-canned-success` — we just supply the payload."}
   (fn [frame-ctx args-map]
     (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
       (stub frame-ctx (assoc args-map :value {:user  {:id "test-user"}
                                               :token "test-token"})))))
 
 (rf/reg-fx :auth.login/canned-failure
-  {:doc "Example stub: every `:rf.http/managed` call resolves :failure.
-         Delegates to the framework-shipped `:rf.http/managed-canned-failure`."}
+  {:doc "Example stub: pretend every login fails with a 401. Defers to the
+         framework-shipped `:rf.http/managed-canned-failure` — we just supply
+         the failure shape. This is the stub the lockout demo wires in."}
   (fn [frame-ctx args-map]
     (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
       (stub frame-ctx (assoc args-map
@@ -165,10 +180,11 @@
 ;; REGISTRATION — guide §Registering and running it
 ;; ============================================================================
 ;;
-;; One line. A machine IS an event handler: `reg-machine` is sugar over a
-;; `reg-event` whose body interprets the table. Reach for the longer form
-;; `(reg-event machine-id (make-machine-handler m))` when you need registration
-;; metadata (`:doc`, `:interceptors`, ...).
+;; One line — and that's not a simplification, that's the whole truth. A machine
+;; IS an event handler. `reg-machine` is just sugar over a `reg-event` whose body
+;; happens to interpret the table above. When you need registration metadata
+;; (`:doc`, `:interceptors`, ...), drop down to the longer form
+;; `(reg-event machine-id (make-machine-handler m))` — same machine, more knobs.
 
 (rf/reg-machine :auth.login/flow login-flow)
 
@@ -176,29 +192,32 @@
 ;; FORM DRAFT SLICE — docs/guide/how-to/build-a-form.md
 ;; ============================================================================
 ;;
-;; The machine owns submit/auth STATUS; the slice owns the DRAFT. Form drafts
-;; are application state, so the email/password the user types lives in app-db
-;; — read via a sub, written via an event — never in a view-local atom. The
-;; login form's inputs are CONTROLLED off `:auth.login/draft`; `:on-change`
+;; Notice the clean division of labour: the machine owns the submit/auth STATUS,
+;; and this slice owns the DRAFT — the email and password the user is typing.
+;; A draft is just application state, so it belongs in app-db: read through a
+;; sub, written through an event, never stashed in a view-local atom. That's why
+;; the form's inputs are CONTROLLED off `:auth.login/draft` — `:on-change`
 ;; dispatches `:auth.login/edit-field`, and submit reads the draft back out of
-;; the slice rather than out of the view.
+;; the slice instead of reaching into the view.
 ;;
-;; This slice carries just its single teaching point — the draft. The fuller
-;; seven-key form slice (touched / errors / submit-attempted? / …) is built up
-;; in docs/guide/how-to/build-a-form.md and in examples/reagent/realworld/auth.cljs.
+;; We keep this slice deliberately tiny — one teaching point, the draft itself.
+;; The fuller seven-key form slice (touched / errors / submit-attempted? / …) is
+;; built up in docs/guide/how-to/build-a-form.md and in
+;; examples/reagent/realworld/auth.cljs once you want the real thing.
 
 (def login-form-defaults {:email "" :password ""})
 
 (rf/reg-event :auth.login/initialise-form
-  {:doc "Seed the login draft to empty defaults. This owns only the draft slice;
-         the machine spawns itself on its first event."}
+  {:doc "Seed the login draft with empty defaults before first render. This owns
+         only the draft slice — the machine needs no seeding, it spawns itself
+         on its very first event."}
   (fn [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form :draft] login-form-defaults)}))
 
 (rf/reg-event :auth.login/edit-field
-  {:doc "User changed a single login field. Writes the draft slot in app-db —
-         the controlled input's `:on-change` dispatches this; it NEVER sets
-         view-local state."}
+  {:doc "The user touched a single field. We write it straight into the draft
+         slot in app-db. The controlled input's `:on-change` dispatches this —
+         and it NEVER reaches for view-local state, which is rather the point."}
   (fn [{:keys [db]} [_ field value]]
     {:db (assoc-in db [:auth :login-form :draft field] value)}))
 
@@ -206,17 +225,17 @@
 ;; SUBSCRIPTIONS — guide §Registering and running it
 ;; ============================================================================
 
-;; The framework ships `:rf/machine` as the canonical sub onto the machine's
-;; snapshot. The two named subs below chain off it to pull out the handy
-;; pieces: current state and last error. For the "is it busy / locked?"
-;; questions, the view asks the machine for a tag directly with
-;; `rf/machine-has-tag?` — reading the `:tags` set keeps the view off
-;; individual state keywords (docs/machines/glossary.md#state-tag).
+;; `:rf/machine` is the framework's canonical window onto a machine's snapshot —
+;; the whole {:state … :data …} value. The two named subs below chain off it to
+;; pluck out the handy pieces: the current state, and the last error. For the
+;; "busy? locked?" questions the view skips the snapshot and asks the machine for
+;; a tag directly with `rf/machine-has-tag?` — reading the `:tags` set keeps it
+;; from hard-coding individual state keywords (docs/machines/glossary.md#state-tag).
 
 (rf/reg-sub :auth.login/draft
-  {:doc "The login form draft — what the user has currently typed. The view's
-         controlled inputs read `:value` off this; submit reads it to hand the
-         creds to the machine."}
+  {:doc "The login form draft — whatever the user has typed so far. The view's
+         controlled inputs read `:value` off this, and submit reads it one more
+         time to hand the creds over to the machine."}
   (fn [db _] (get-in db [:auth :login-form :draft])))
 
 (rf/reg-sub :auth.login/state
@@ -227,10 +246,12 @@
   :<- [:rf/machine :auth.login/flow]
   (fn [machine _] (get-in machine [:data :error])))
 
-;; The payoff. Because the table is pure data and `machines/machine-transition`
-;; is a pure fn over (table, snapshot, event), the four scenarios (pure
-;; happy-path, pure lockout, drain happy-path, drain retry-then-lockout) need no
-;; frame and no browser — they run on the JVM in microseconds. They live in the
-;; framework test tree as the `state-machine-walkthrough-runs-headless` deftest,
-;; so this example source stays test-free.
+;; And here's where the purity pays off. Because the table is plain data and
+;; `machines/machine-transition` is a pure fn over (table, snapshot, event), the
+;; four scenarios — pure happy-path, pure lockout, drain happy-path, drain
+;; retry-then-lockout — need neither a frame nor a browser. They run on the bare
+;; JVM in microseconds: feed in a snapshot and an event, assert on the snapshot
+;; that comes back. They live in the framework test tree as the
+;; `state-machine-walkthrough-runs-headless` deftest, which is what lets this
+;; example source itself stay blissfully test-free.
 ;; See docs/machines/concepts.md#testing-transitions-are-pure-function-calls.

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -1,14 +1,16 @@
 (ns state-machine-walkthrough.views
-  "Browser entry-point for the state-machines walkthrough.
+  "The browser entry-point for the walkthrough — the part you can actually click.
 
-  The pure machine, fxs and subs live in `core.cljc`. This namespace is the
-  CLJS-only browser layer: views + Reagent mount + a `run` fn that redirects
-  `:rf.http/managed` to the canned-failure stub via per-frame :fx-overrides.
+  All the interesting, portable stuff (the pure machine, the fxs, the subs)
+  lives in `core.cljc`. This namespace is purely the CLJS browser skin on top:
+  the views, the Reagent mount, and a `run` fn that points `:rf.http/managed` at
+  the canned-failure stub through per-frame :fx-overrides.
 
-  The demo runs the lockout scenario: three failed attempts cycle
-  :submitting -> :error-shown -> :idle, then a fourth submit fails the
-  `:under-retry-limit` guard and lands at :locked-out. So the stub fails
-  every request."
+  The demo tells one story — the lockout. Three failed attempts walk the machine
+  round the loop :submitting -> :error-shown -> :idle, and then a fourth submit
+  trips the `:under-retry-limit` guard and the machine settles into :locked-out.
+  For that to play out, every request has to fail, which is exactly why we wire
+  in the canned-FAILURE stub here."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -19,20 +21,24 @@
 ;; VIEWS
 ;; ============================================================================
 
-(reg-view ^{:doc "The login form view. The email + password DRAFT is application
-                  state, so it lives in app-db (the `:auth.login/draft` slice):
-                  read via the `:auth.login/draft` sub, written via the
-                  `:auth.login/edit-field` event. The inputs are CONTROLLED —
-                  `:value` reads from the draft sub, `:on-change` dispatches an
-                  edit-field event. Submit reads the draft back out of the sub
-                  and hands it to the machine via :auth.login/flow →
-                  :auth.login/submit.
+(reg-view ^{:doc "The login form. Two threads of state run through it, and the
+                  whole view is easier to read once you separate them.
 
-                  The machine owns submit/auth STATUS; the slice owns the DRAFT
-                  (docs/guide/how-to/build-a-form.md). To branch on status the
-                  view asks the machine for a tag via `rf/machine-has-tag?`,
-                  reading its `:tags` set rather than the current state keyword —
-                  so adding a new busy state changes no view
+                  Thread one is the DRAFT — the email and password being typed.
+                  That's application state, so it lives in app-db under the
+                  `:auth.login/draft` slice: read through the `:auth.login/draft`
+                  sub, written through the `:auth.login/edit-field` event. The
+                  inputs are CONTROLLED off it — `:value` comes from the sub,
+                  `:on-change` dispatches an edit-field event — and on submit we
+                  read the draft back out of the sub and hand it to the machine
+                  via :auth.login/flow → :auth.login/submit.
+
+                  Thread two is STATUS — busy? locked? — and that belongs to the
+                  machine, not the slice (docs/guide/how-to/build-a-form.md). The
+                  view never asks 'which state are we in?'; it asks 'is this tag
+                  set?' via `rf/machine-has-tag?`. Branch on the `:tags` set, not
+                  on state keywords, and adding a brand-new busy state down the
+                  line touches exactly zero views
                   (docs/machines/glossary.md#state-tag)."}
           login-form []
   (let [busy?   @(rf/machine-has-tag? :auth.login/flow :auth/busy)
@@ -71,9 +77,11 @@
                                          [:auth.login/dismiss]])}
          "Dismiss"]])]))
 
-(reg-view ^{:doc "Top banner reflecting the machine's current state. The
-                  `data-state` attribute surfaces the state keyword so a
-                  test can assert the lockout transition."}
+(reg-view ^{:doc "A little banner up top that names the machine's current state —
+                  handy for watching the transitions happen live. The
+                  `data-state` attribute mirrors the state keyword into the DOM
+                  so a test can assert the lockout transition without squinting
+                  at pixels."}
           status-banner []
   (let [state @(subscribe [:auth.login/state])]
     [:div.banner
@@ -82,7 +90,7 @@
                      :data-state (when state (name state))}
       (if state (name state) "(uninitialised)")]]))
 
-(reg-view ^{:doc "Locked-out terminal panel."}
+(reg-view ^{:doc "The end of the road: what you see once the account locks out."}
           locked-panel []
   [:div.locked {:data-testid "locked-panel"}
    [:h2 "Account locked"]
@@ -101,29 +109,35 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and created lazily inside `run`, never at
-;; ns-load. ns-load must produce no DOM side effects, so co-required examples
-;; don't race `create-root` onto the shared `#app`. See examples/TESTING.md
-;; "Convention: defer DOM mount to `run`".
+;; We stash the React root in an atom and create it lazily inside `run` — never
+;; at ns-load. The rule: loading a namespace must touch no DOM. Otherwise two
+;; examples co-required into one page would both race to `create-root` onto the
+;; shared `#app`, and exactly one would win. See examples/TESTING.md, "Convention:
+;; defer DOM mount to `run`".
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; Install the Reagent adapter — pass its spec map straight to init!.
+  ;; Tell re-frame2 which substrate to render through by handing init! the
+  ;; Reagent adapter's spec map. One call, done.
   (rf/init! reagent-adapter/adapter)
-  ;; `frame-provider {:id …}` creates, configures and seeds the app frame. On
-  ;; first mount it creates the `:rf/default` frame, applies the config, and
-  ;; runs `:initial-events` once. On hot reload it reuses that frame and skips
-  ;; re-seeding, so your typed-in draft survives. The `dispatch`/`subscribe`
-  ;; that `reg-view` injects resolve to this frame.
+  ;; `frame-provider {:id …}` is the do-everything entry point for the frame:
+  ;; it creates it, configures it, and seeds it. First mount creates the
+  ;; `:rf/default` frame, applies the config, and runs `:initial-events` once.
+  ;; A hot reload reuses that same frame and skips the re-seed — which is the
+  ;; small kindness that keeps the draft you'd just typed from vanishing on
+  ;; save. The `dispatch`/`subscribe` that `reg-view` quietly injects into the
+  ;; views all resolve to this frame.
   ;;
-  ;; `:fx-overrides` swaps `:rf.http/managed` for the canned-failure stub, so
-  ;; every login request fails — the lockout scenario needs three failures.
+  ;; `:fx-overrides` redirects `:rf.http/managed` to the canned-FAILURE stub, so
+  ;; every login attempt fails on purpose — the lockout demo can't lock anyone
+  ;; out without three failures to work with.
   ;;
-  ;; The login machine spawns itself on its first event. The form DRAFT slice
-  ;; does not, so `:initial-events` seeds it before first render: the controlled
-  ;; inputs read `:value` off `[:auth :login-form :draft]`, and that slot must
-  ;; already hold empty strings (a nil there makes React treat the inputs as
-  ;; uncontrolled).
+  ;; One subtlety worth pausing on: the machine seeds itself on its first event,
+  ;; but the DRAFT slice does not. So `:initial-events` seeds the draft before
+  ;; the first render. The controlled inputs read `:value` off
+  ;; `[:auth :login-form :draft]`, and that slot has to already hold empty
+  ;; strings — leave a nil there and React decides the inputs are uncontrolled,
+  ;; which is a confusing afternoon you can skip by seeding up front.
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -1,12 +1,14 @@
 (ns todomvc.core
-  "Entry point: install the adapter, mount the view, create and seed the frame.
+  "Where the app comes to life: install the adapter, mount the view, stand up
+  the frame and seed it.
 
-  This is the boot wiring the other files lean on. `init!` installs the Reagent
-  adapter. The render root is a `frame-provider {:id …}`: on first mount it
-  creates the app frame, marks it `:url-bound?` so it owns the address bar, and
-  seeds it once via `:initial-events`. A small hash listener turns a `#/active`
-  URL change into a `:rf.route/handle-url-change` event. The URL is an input;
-  navigation is an event."
+  Everything else leans on this wiring. `init!` picks the reactive substrate
+  (here, Reagent). The render root is a `frame-provider {:id …}`: on first
+  mount it creates the app frame, marks it `:url-bound?` so the frame owns the
+  address bar, and seeds it once via `:initial-events`. A small hash listener
+  turns a `#/active` URL change into a `:rf.route/handle-url-change` event —
+  because in re-frame2 the URL is just an input, and navigation is just an
+  event. See docs/guide/concepts/frames.md."
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
@@ -18,14 +20,15 @@
 
 ;; ---- hash -> path adapter -------------------------------------------------
 ;;
-;; TodoMVC uses hash-based URLs (#/, #/active, #/completed). The router matches
-;; path-strings, so this little adapter strips the '#' and dispatches
-;; :rf.route/handle-url-change. The registered routes in events.cljs then match
-;; the result. See docs/routing/concepts.md#move-2-navigation-is-an-event.
+;; TodoMVC speaks hash URLs (#/, #/active, #/completed), but the router thinks
+;; in path-strings. So this little adapter is the translator between them: drop
+;; the '#', then dispatch :rf.route/handle-url-change with what's left. The
+;; routes in events.cljs match the result.
+;; See docs/routing/concepts.md#move-2-navigation-is-an-event.
 
 (defn- hash->path
-  "Convert window.location.hash (e.g. \"#/active\", \"#/completed\") to a route
-  path. An empty hash maps to \"/\"."
+  "Turn window.location.hash (e.g. \"#/active\", \"#/completed\") into a route
+  path. An empty hash means \"/\"."
   [hash]
   (let [stripped (-> hash
                      (str/replace #"^#" "")
@@ -36,35 +39,37 @@
   (hash->path (.. js/window -location -hash)))
 
 ;; The id of the app frame. The render root creates it with `:url-bound? true`,
-;; which declares that this frame owns the URL.
+;; which is how a frame declares "I own the URL".
 ;; See docs/routing/glossary.md (url-bound?).
 (def app-frame :rf/default)
 
-;; Deliver each URL change to the frame that owns the URL. The dispatch names
-;; `app-frame` explicitly via `{:frame app-frame}`; a frameless `(rf/dispatch …)`
-;; has no frame to resolve against.
+;; Hand each URL change to the frame that owns the URL. The dispatch names
+;; `app-frame` outright via `{:frame app-frame}` — out here, outside the view
+;; tree, there's no ambient frame for a bare `(rf/dispatch …)` to resolve
+;; against.
 ;;
-;; Using a named Var keeps the listener install idempotent: `boot!` removes then
-;; re-adds the same Var, so a repeated `run` or a reload never stacks duplicate
-;; `hashchange` listeners. A hash-based app listens on `hashchange`; a path-based
-;; app would call `rf/install-history-listener!` instead, and the URL change
-;; reaches the owner frame the same way. See
-;; docs/routing/concepts.md#the-browser-is-just-another-event-source.
+;; Why a named Var and not a lambda? So the install stays idempotent. `boot!`
+;; removes then re-adds this exact Var, so a repeated `run` or a hot reload
+;; never quietly stacks up duplicate `hashchange` listeners. (A path-based app
+;; would call `rf/install-history-listener!` instead of listening on
+;; `hashchange`, but the URL change still reaches its owner frame the same way.)
+;; See docs/routing/concepts.md#the-browser-is-just-another-event-source.
 (defn- on-hashchange [_]
   (rf/dispatch [:rf.route/handle-url-change (current-path)] {:frame app-frame}))
 
 ;; ---- Mount -----------------------------------------------------------------
 ;;
 ;; The React root lives in a `defonce` atom, created lazily on the first
-;; `mount!`. The `defonce` reuses the one root across hot reloads, which React
-;; requires (a second `create-root` on a live node is rejected). Creating it in
-;; `mount!` rather than at ns-load keeps namespace load free of DOM side effects.
-;; `mount!` is `^:dev/after-load`, so shadow re-runs it on every reload to
-;; re-render the edited views.
+;; `mount!`. The `defonce` is deliberate: React lets you call `create-root` on a
+;; node exactly once, so we make one root and reuse it across every hot reload.
+;; We also hold off creating it until `mount!` runs, rather than at ns-load,
+;; because loading a namespace should never poke the DOM. And `mount!` is
+;; `^:dev/after-load`, which is shadow's cue to re-run it on each reload so your
+;; edited views actually re-render.
 ;;
-;; The render root is a `frame-provider {:id app-frame …}`. On the first mount it
-;; creates the app frame and runs `:initial-events`; on reload it reuses the same
-;; frame without re-seeding, so app-db survives.
+;; The render root is a `frame-provider {:id app-frame …}`. First mount creates
+;; the app frame and runs `:initial-events`; every reload after that reuses the
+;; same frame and skips the seed, so your todos survive a code change.
 
 (defonce react-root (atom nil))
 
@@ -73,10 +78,10 @@
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
     (rdc/render @react-root
-                ;; `:initial-events` seed the new frame, in order:
-                ;; `[:todo/initialise]` folds the saved todos (from the
-                ;; `:todo.storage/todos` coeffect in db.cljs) into app-db, then
-                ;; `[:rf.route/handle-url-change …]` resolves the initial URL.
+                ;; The seed, in order: `[:todo/initialise]` folds the saved
+                ;; todos (via the `:todo.storage/todos` coeffect in db.cljs)
+                ;; into app-db, then `[:rf.route/handle-url-change …]` resolves
+                ;; whatever URL we landed on.
                 [rf/frame-provider {:id             app-frame
                                     :doc            "TodoMVC demo frame."
                                     :url-bound?     true
@@ -86,10 +91,10 @@
 
 ;; ---- Boot ------------------------------------------------------------------
 ;;
-;; `boot!` runs once at shadow's :init-fn, before the first render. It does two
-;; things: installs the Reagent adapter and installs the `hashchange` listener.
-;; The frame is created and seeded later, by the render root's `frame-provider
-;; {:id app-frame …}` (see `mount!`).
+;; `boot!` runs once at shadow's :init-fn, before the first render, and has just
+;; two jobs: install the Reagent adapter, and wire up the `hashchange` listener.
+;; It deliberately does NOT touch the frame — that's the render root's job, over
+;; in `mount!`.
 
 (defn- boot! []
   (rf/init! reagent-adapter/adapter)

--- a/examples/reagent/todomvc/db.cljs
+++ b/examples/reagent/todomvc/db.cljs
@@ -1,25 +1,26 @@
 (ns todomvc.db
   "The shape of app-db, and the boot read that fills it.
 
-  Demonstrates: the single source of truth (`default-db` holds the todos and the
-  UI state, and nothing else; the active filter is derived from the route, never
-  stored), and a recordable coeffect (`reg-cofx :todo.storage/todos`) whose
-  supplier reads the saved todos in at boot, so the durable write stays
-  replayable instead of reaching for localStorage inside a handler.
-  See docs/guide/glossary.md (coeffect)."
+  Two ideas live here. First, the single source of truth: `default-db` holds
+  the todos and the UI state and nothing else — notably not the active filter,
+  which we derive from the route instead of storing twice. Second, a recordable
+  coeffect (`reg-cofx :todo.storage/todos`) that reads the saved todos in at
+  boot. Routing the storage read through a coeffect keeps the durable write
+  replayable, which a stray localStorage call inside a handler would quietly
+  break. See docs/guide/glossary.md (coeffect)."
   (:require [re-frame.core :as rf]))
 
-;; The default db carries no `:showing` slot. The active filter is derived from
-;; the route: the :showing sub (in subs.cljs) reads :rf.route/id and maps it to
-;; :all/:active/:completed.
+;; Notice there's no `:showing` slot here. The active filter isn't stored — it's
+;; derived: the :showing sub (in subs.cljs) reads :rf.route/id and maps it to
+;; :all/:active/:completed. One fact, one home.
 ;;
-;; The `:ui` slice holds the form/UI state. "Which row is being edited" and the
-;; live input drafts are application state, so they live in app-db, are read via
-;; subs, and are changed only by events. Inputs read `:drafts` for their
-;; `:value` (controlled) and dispatch edit events on `:on-change`. `:editing-id`
-;; names the single row in edit-in-place mode (nil = none). Two draft slots are
-;; enough: one for the new-todo header input, one shared by the single editing
-;; row.
+;; The `:ui` slice is where the form/UI state lives. "Which row is being edited"
+;; and the live input drafts are genuinely application state, so they get the
+;; full treatment: stored in app-db, read via subs, changed only by events.
+;; Inputs read `:drafts` for their `:value` (that's what makes them controlled)
+;; and dispatch edit events on `:on-change`. `:editing-id` names the one row in
+;; edit-in-place mode (nil = nobody's editing). Two draft slots cover it: one
+;; for the new-todo header input, one shared by the single editing row.
 (def default-ui
   {:editing-id nil
    :drafts     {:new "" :edit ""}})
@@ -48,24 +49,27 @@
       (catch :default _
         (sorted-map)))))
 
-;; The saved todos are a fact about the world (storage), and `:todo/initialise`
-;; folds them into durable app-db. A durable write must fold a RECORDED fact, not
-;; a live `localStorage` read at the write site — a live read could not be
-;; reproduced under replay or epoch-restore. So `:todo.storage/todos` is a
-;; RECORDABLE coeffect whose supplier reads localStorage: the supplier runs at
-;; the boot dispatch, its value is recorded onto the event envelope, and replay
-;; re-folds that captured snapshot rather than re-reading localStorage now.
+;; The saved todos are a fact about the world out there (storage), and
+;; `:todo/initialise` folds them into durable app-db. Here's the rule: a durable
+;; write has to fold a RECORDED fact, never a live `localStorage` read taken at
+;; the write site. Why? Because a live read can't be reproduced later under
+;; replay or epoch-restore — the world may have moved on. So `:todo.storage/todos`
+;; is a RECORDABLE coeffect: its supplier reads localStorage at the boot
+;; dispatch, the value gets stamped onto the event envelope, and replay re-folds
+;; that captured snapshot instead of reading localStorage all over again.
 ;;
-;; Registering a supplier with `reg-cofx` is the standard way to make a coeffect
-;; available. See docs/guide/glossary.md (coeffect) and
+;; `reg-cofx` is how you make a coeffect available. See
+;; docs/guide/glossary.md (coeffect) and
 ;; docs/guide/glossary.md#recordable-vs-ambient-coeffects.
 
 (defn read-todos-from-storage
-  "Read the saved TodoMVC items from localStorage, normalised to a sorted-map.
-   This is the supplier body for the `:todo.storage/todos` recordable coeffect.
-   nil/empty localStorage (first run, or a server with no localStorage) yields an
-   empty sorted-map. The sorted-map matters: allocate-next-id picks the max id
-   via `(last (keys todos))`, which only holds while the map stays sorted."
+  "Read the saved TodoMVC items from localStorage into a sorted-map. This is the
+   supplier body behind the `:todo.storage/todos` recordable coeffect.
+
+   nil or empty localStorage (a first run, or a server that has none at all)
+   gives back an empty sorted-map. And the sorted-map isn't incidental:
+   allocate-next-id grabs the highest id with `(last (keys todos))`, which only
+   tells the truth while the map stays sorted."
   []
   (or (some-> (.-localStorage js/globalThis)
               (.getItem ls-key)
@@ -76,8 +80,8 @@
   {:recordable? true
    :doc "Recordable coeffect: the saved TodoMVC items, read from localStorage as
          a sorted-map. The supplier runs at the boot dispatch; its value is
-         recorded onto the event envelope and re-presented verbatim under replay
-         / epoch-restore. A handler folds it into durable app-db by declaring
-         `:rf.cofx/requires [:todo.storage/todos]` and reading it flat — folding
-         a recorded fact, never a live read."}
+         recorded onto the event envelope and handed back verbatim under replay
+         or epoch-restore. To use it, a handler declares
+         `:rf.cofx/requires [:todo.storage/todos]` and reads it straight off the
+         coeffects map — folding a recorded fact, never a live read."}
   (fn [] (read-todos-from-storage)))

--- a/examples/reagent/todomvc/events.cljs
+++ b/examples/reagent/todomvc/events.cljs
@@ -1,32 +1,37 @@
 (ns todomvc.events
-  "The only writers of app-db, plus the routes and the persistence effect.
+  "The only place app-db ever gets written — plus the routes and the one effect
+  that touches the outside world.
 
-  Demonstrates: `reg-event` (one pure handler per state change — add, toggle,
-  save, delete, clear-completed, toggle-all; each `(coeffects, event-vector) →
-  effect map`), `reg-fx` (the `:todo.storage/save` effect handler that performs
-  the localStorage write the handlers only *describe* as data), and `reg-route`
-  (the URL as an input — `/`, `/active`, `/completed`, plus the not-found
-  fallback). See docs/guide/glossary.md (event)."
+  Three things to see here. `reg-event`: one pure handler per state change —
+  add, toggle, save, delete, clear-completed, toggle-all — each a plain
+  `(coeffects, event-vector) → effect map`. `reg-fx`: the `:todo.storage/save`
+  handler that actually performs the localStorage write the event handlers only
+  *describe* as data. And `reg-route`: the URL treated as an input — `/`,
+  `/active`, `/completed`, plus the not-found fallback.
+  See docs/guide/glossary.md (event)."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            ;; Requiring re-frame.routing registers the routing subscriptions and
-            ;; install hook. Without it the `rf/reg-route` calls below throw
-            ;; :rf.error/routing-artefact-missing.
+            ;; Pulling in re-frame.routing registers the routing subscriptions
+            ;; and install hook. Skip it and the `rf/reg-route` calls below throw
+            ;; :rf.error/routing-artefact-missing — a polite reminder you forgot
+            ;; to bring routing along.
             [re-frame.routing]
             [todomvc.db :as db]))
 
 ;; ---- routes ---------------------------------------------------------------
-;; Each route pairs an id with a path the router matches. TodoMVC's URLs are
-;; hash-based (#/, #/active, #/completed); the adapter in core.cljs strips the
-;; leading '#' so these path patterns match.
+;; A route is just an id paired with a path the router knows how to match.
+;; TodoMVC's URLs are hash-based (#/, #/active, #/completed); the adapter in
+;; core.cljs has already stripped the leading '#' by the time we get here, so
+;; these plain path patterns line up.
 ;; See docs/routing/concepts.md#move-2-navigation-is-an-event.
 
 (rf/reg-route :todo/all       {:doc "Show all todos."} "/")
 (rf/reg-route :todo/active    {:doc "Show active todos."} "/active")
 (rf/reg-route :todo/completed {:doc "Show completed todos."} "/completed")
 
-;; The not-found route is required. Unmatched URLs land here; this app treats
-;; them as "show all" so a stray hash never breaks the app.
+;; You must register a not-found route — it's not optional. Any URL that matches
+;; nothing else lands here, and this app just sends it to "show all", so a typo'd
+;; hash is a harmless shrug rather than a broken screen.
 ;; See docs/routing/concepts.md#not-found-is-a-route-you-register.
 (rf/reg-route :rf.route/not-found {:doc "Fallback."} "/_404")
 
@@ -38,7 +43,8 @@
    :fx [[:todo.storage/save (:todos next-db)]]})
 
 (rf/reg-fx :todo.storage/save
-  {:doc       "Persist the TodoMVC items to localStorage."
+  {:doc       "Write the TodoMVC items out to localStorage. This is the one spot
+               that actually touches storage; the handlers just ask for it."
    :platforms #{:client}}
   (fn fx-todo-storage-save [_ todos]
     (when-let [ls (.-localStorage js/globalThis)]
@@ -104,25 +110,29 @@
 
 ;; ---- UI / form state (the `:ui` slice) ------------------------------------
 ;;
-;; These events own the form/UI state. The inputs are CONTROLLED: a view's
-;; `:value` reads a draft sub and its `:on-change` dispatches
-;; `:todo.ui/edit-field` — it never sets view-local state. "Which row is being
-;; edited" is application state, so it lives at `[:ui :editing-id]`, toggled by
-;; `:todo.ui/start-edit` / `:todo.ui/stop-edit`.
+;; These events look after the form/UI state. The inputs are CONTROLLED: a
+;; view's `:value` reads a draft sub, and its `:on-change` dispatches
+;; `:todo.ui/edit-field`. The view never keeps a copy of the text itself.
+;; Likewise, "which row is being edited" is real application state, so it lives
+;; at `[:ui :editing-id]`, flipped on and off by `:todo.ui/start-edit` /
+;; `:todo.ui/stop-edit`.
 ;;
-;; Drafts and editing-id are pure UI. They are NOT persisted, so these handlers
-;; return a plain `{:db ...}` rather than going through `persist-db`. Only the
-;; todo facts themselves (`:todos`) are durable.
+;; Drafts and editing-id are pure UI froth — here one moment, gone the next — so
+;; we don't persist them. That's why these handlers return a plain `{:db ...}`
+;; and skip `persist-db` entirely. Only the todo facts (`:todos`) are worth
+;; saving to disk.
 
 (rf/reg-event :todo.ui/edit-field
-  {:doc "User typed into a controlled input. `which` is `:new` (header input)
-         or `:edit` (the edit-in-place input for the row in `:editing-id`)."}
+  {:doc "The user typed into a controlled input. `which` is `:new` (the header
+         input) or `:edit` (the edit-in-place input for the row in
+         `:editing-id`)."}
   (fn [{:keys [db]} [_ which value]]
     {:db (assoc-in db [:ui :drafts which] value)}))
 
 (rf/reg-event :todo.ui/start-edit
-  {:doc "Enter edit-in-place on a row: record which id is editing and seed the
-         edit draft from that todo's current title."}
+  {:doc "Drop a row into edit-in-place: remember which id is editing, and seed
+         the edit draft with that todo's current title so the box opens
+         pre-filled."}
   (fn [{:keys [db]} [_ id]]
     (let [title (get-in db [:todos id :title] "")]
       {:db (-> db
@@ -130,24 +140,26 @@
                (assoc-in [:ui :drafts :edit] title))})))
 
 (rf/reg-event :todo.ui/stop-edit
-  {:doc "Leave edit-in-place without saving (Escape, or after a save): clear
-         the editing id and the edit draft."}
+  {:doc "Back out of edit-in-place without saving (Escape, or just after a
+         save): forget the editing id and wipe the edit draft."}
   (fn [{:keys [db]} _]
     {:db (-> db
              (assoc-in [:ui :editing-id] nil)
              (assoc-in [:ui :drafts :edit] ""))}))
 
 (rf/reg-event :todo.ui/commit-new
-  {:doc "Save the header input: read the `:new` draft, add the todo (which
-         trims + ignores blanks), then clear the draft for the next entry."}
+  {:doc "Commit the header input: read the `:new` draft, add the todo (the add
+         handler does the trimming and blank-skipping), then clear the draft so
+         it's empty for the next one."}
   (fn [{:keys [db]} _]
     (let [title (get-in db [:ui :drafts :new])]
       {:db (assoc-in db [:ui :drafts :new] "")
        :fx [[:dispatch [:todo/add title]]]})))
 
 (rf/reg-event :todo.ui/commit-edit
-  {:doc "Save the edit-in-place input: read the `:edit` draft, save it onto the
-         editing row (a blank title deletes the todo), then leave edit mode."}
+  {:doc "Commit the edit-in-place input: read the `:edit` draft, save it onto
+         the row being edited (a blank title deletes the todo), then leave edit
+         mode."}
   (fn [{:keys [db]} _]
     (let [id    (get-in db [:ui :editing-id])
           title (get-in db [:ui :drafts :edit])]

--- a/examples/reagent/todomvc/subs.cljs
+++ b/examples/reagent/todomvc/subs.cljs
@@ -1,17 +1,19 @@
 (ns todomvc.subs
-  "The derivation graph the views read.
+  "The derivation graph the views read from.
 
-  Demonstrates: `reg-sub` composed in layers. Some subs read app-db directly
-  (`:todo/sorted-todos`); others combine subs into a derivation graph
+  This is `reg-sub` composed in layers. The bottom layer reads app-db directly
+  (`:todo/sorted-todos`); the layers above stack on top of it
   (`:todo/visible-todos` filters the list against `:todo/showing`,
-  `:todo/footer-counts` folds the tallies). `:todo/showing` derives the active
-  filter from the route id — the filter that app-db deliberately never stores.
-  Pure functions all the way down, recomputed only when an input actually moves.
+  `:todo/footer-counts` adds up the tallies). `:todo/showing` is the neat one —
+  it derives the active filter from the route id, the very filter app-db makes a
+  point of never storing. It's pure functions all the way down, and each one
+  recomputes only when an input it actually depends on moves.
   See docs/guide/glossary.md (subscription)."
   (:require [re-frame.core :as rf]))
 
-;; :todo/showing derives the active filter from the route id. :rf.route/not-found
-;; and an unset route both fall through to :all so the UI defaults sensibly.
+;; :todo/showing turns the route id into the active filter. Both
+;; :rf.route/not-found and an unset route quietly fall through to :all, so the UI
+;; always has a sensible default to show.
 (rf/reg-sub :todo/showing
   :<- [:rf.route/id]
   (fn [route-id _]
@@ -57,9 +59,10 @@
 
 ;; ---- UI / form state projections (the `:ui` slice) ------------------------
 ;;
-;; Views read these instead of holding view-local atoms: `:value` reads a draft
-;; sub, and `:todo.ui/editing?` answers "is THIS row the one being edited?" so a
-;; row renders its controlled edit input only when it owns the editing id.
+;; These are what the views read instead of stashing state in view-local atoms.
+;; `:value` comes from a draft sub, and `:todo.ui/editing?` answers one small
+;; question per row — "am I the one being edited?" — so a row only bothers to
+;; render its controlled edit input when it actually owns the editing id.
 
 (rf/reg-sub :todo.ui/editing-id
   (fn [db _]
@@ -71,6 +74,6 @@
     (= editing-id id)))
 
 (rf/reg-sub :todo.ui/draft
-  {:doc "The live value of a controlled input. `which` is `:new` or `:edit`."}
+  {:doc "The live text inside a controlled input. `which` is `:new` or `:edit`."}
   (fn [db [_ which]]
     (get-in db [:ui :drafts which])))

--- a/examples/reagent/todomvc/views.cljs
+++ b/examples/reagent/todomvc/views.cljs
@@ -1,12 +1,13 @@
 (ns todomvc.views
-  "The TodoMVC markup, as hiccup.
+  "The TodoMVC markup, written as hiccup.
 
-  Demonstrates: `reg-view` for the root (inside its body `subscribe` and
-  `dispatch` are already in scope), plain helper fns for the sub-views (which
-  take `dispatch`/`subscribe` as explicit args — the honest shape for a plain
-  fn), and hiccup as data-as-markup. A view reads derived state and dispatches
-  events on interaction; no business logic lives here.
-  See docs/guide/glossary.md (view)."
+  A few things on show. `reg-view` for the root view — inside its body
+  `subscribe` and `dispatch` are simply in scope, no ceremony. Plain helper fns
+  for the sub-views, which take `dispatch`/`subscribe` as explicit args, because
+  that's the honest shape for an ordinary function. And hiccup throughout, which
+  is really just markup-as-data. The job of a view is small and strict: read
+  derived state, dispatch events when the user does something. No business logic
+  sneaks in here. See docs/guide/glossary.md (view)."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.views])
@@ -18,15 +19,18 @@
     :completed "#/completed"
     "#/"))
 
-;; A CONTROLLED text input. `:value` reads a draft sub. Every keystroke
-;; dispatches `on-change`, which writes the draft into app-db; the input never
-;; holds its own value. Enter commits (dispatches `on-commit`), Escape cancels
-;; (dispatches `on-cancel`), and blur commits. Cancel renders the input away, so
-;; a trailing blur has nothing left to save.
+;; A CONTROLLED text input — the workhorse behind both the header box and the
+;; edit-in-place box. `:value` comes from a draft sub, and every keystroke
+;; dispatches `on-change` to write that draft into app-db. The input itself
+;; never holds the text; app-db does. Enter commits (`on-commit`), Escape
+;; cancels (`on-cancel`), and losing focus commits too. There's a subtle bit
+;; here: cancelling unmounts the input, so the blur that follows finds nothing
+;; left to save. Tidy by accident, and on purpose.
 ;;
-;; `:autofocus?` focuses the input when it first mounts — the edit input wants
-;; this, since the row just entered edit mode. A `:ref` callback calls `.focus()`
-;; on the live node. It touches focus only, leaving `:value` bound to the sub.
+;; `:autofocus?` drops the cursor into the input the moment it mounts — exactly
+;; what the edit box wants, since the row just flipped into edit mode. A `:ref`
+;; callback calls `.focus()` on the real DOM node. It touches focus and nothing
+;; else; `:value` stays bound to the sub.
 (defn todo-input [{:keys [draft on-change on-commit on-cancel autofocus?] :as props}]
   (let [handle-keydown
         (fn [event]
@@ -43,21 +47,22 @@
         :on-key-down handle-keydown
         :on-blur     (fn [_] (on-commit))}
        (when autofocus?
-         ;; Focus-only ref: move the cursor into the freshly-mounted input.
+         ;; Focus-only ref: nudge the cursor into the just-mounted input.
          {:ref (fn [node] (when node (.focus node)))}))]))
 
 (defn todo-item [dispatch subscribe {:keys [id title completed]}]
-  ;; A plain form-1 fn. The per-row editing flag lives in app-db, so the row just
-  ;; reads "am I the editing row?" from a sub keyed by its id.
+  ;; A plain form-1 fn — nothing fancy. The per-row editing flag lives in app-db,
+  ;; so each row just asks a sub keyed by its own id: "am I the one being edited?"
   (let [editing? @(subscribe [:todo.ui/editing? id])]
     [:li {:class (str/join " " (cond-> []
                                  completed (conj "completed")
                                  editing?  (conj "editing")))}
      [:div.view
-      ;; Controlled checkbox, re-frame2 style: `:checked` reads the fact from
-      ;; app-db and `:on-click` dispatches the event that changes it. The state
-      ;; round-trips through app-db, so `:readOnly` is set to silence React's
-      ;; onChange warning for a checkbox React doesn't itself control.
+      ;; A controlled checkbox, re-frame2 style: `:checked` reads the fact out
+      ;; of app-db, and `:on-click` dispatches the event that changes it. Since
+      ;; the state takes the long way round through app-db, we set `:readOnly` to
+      ;; hush React's onChange warning about a checkbox it doesn't get to drive
+      ;; itself.
       [:input.toggle
        {:type "checkbox"
         :checked completed
@@ -86,7 +91,8 @@
      :draft       @(subscribe [:todo.ui/draft :new])
      :on-change   #(dispatch [:todo.ui/edit-field :new %])
      :on-commit   #(dispatch [:todo.ui/commit-new])
-     ;; The header input has nothing to cancel — Escape just clears the draft.
+     ;; The header input isn't editing anything, so there's nothing to cancel —
+     ;; Escape just empties the draft.
      :on-cancel   #(dispatch [:todo.ui/edit-field :new ""])}]])
 
 (defn task-list [dispatch subscribe]
@@ -127,10 +133,11 @@
         "Clear completed"])]))
 
 ;; The sub-views above (task-entry, task-list, todo-item, footer-controls) are
-;; plain Reagent helper fns that take `dispatch` / `subscribe` as explicit args —
-;; the clearest shape for internal helpers. `reg-view` is for the root: inside
-;; its body `dispatch` and `subscribe` are injected into scope, which is why the
-;; root threads them down to the helpers.
+;; plain Reagent helper fns. They take `dispatch` / `subscribe` as explicit args
+;; because that's the clearest shape for an internal helper — what it needs is
+;; right there in the signature. `reg-view` is reserved for the root: inside its
+;; body `dispatch` and `subscribe` arrive in scope for free, which is exactly why
+;; the root is the one threading them down to the helpers below.
 ;; See docs/guide/concepts/views.md.
 (reg-view root-view []
   (let [todos @(subscribe [:todo/todos])]

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -1,51 +1,55 @@
 (ns websocket.connection
-  "The `:ws/connection` connection machine.
+  "The `:ws/connection` machine — the heart of this example.
 
-   This models a WebSocket lifecycle as a state machine. The hierarchy is:
+   A WebSocket lifecycle, drawn as states:
 
      :disconnected
      :active                              ;; compound parent; owns the socket
        :connecting
        :authenticating
        :connected
-     :reconnecting                        ;; :after backoff
-     :failed                              ;; terminal until manual :ws/connect
+     :reconnecting                        ;; backs off, then retries
+     :failed                              ;; given up, until a manual :ws/connect
 
-   Why a compound `:active` rather than parallel regions? The three
-   success-path leaves share one invariant: the live socket actor must
-   outlive all of them. The subscription set, the in-flight map, the queue,
-   and the socket id all belong to one domain (this connection) and ride a
-   single `:data` map. A compound `:active` over a shared `:data` is the
-   right shape. Parallel regions are for axes that do NOT share data.
+   Why nest the three happy-path leaves inside `:active` instead of laying
+   everything out flat? Because they share one thing they can't live
+   without: the live socket. The subscription set, the in-flight requests,
+   the offline queue, the socket id — all of it belongs to *one*
+   connection and rides a single `:data` map. A compound state is how you
+   say 'these share a lifecycle'. (Parallel regions are the opposite tool,
+   for axes that don't share data.)
    See docs/machines/concepts.md#when-the-machine-grows.
 
-   State tags carry the queryable connection-state predicates. The view asks
-   `:ws/connected?` / `:ws/reconnecting?` (the per-tag subs below, each a
-   `contains?` over the snapshot's `:tags` union) without knowing which leaf
-   carries the `:connected` intent. This is what state tags buy: ask, don't
-   tell. See docs/machines/glossary.md#state-tag.
+   The view never matches on state names. Each state carries tags, and the
+   view asks tag-shaped questions — `:ws/connected?`, `:ws/reconnecting?`
+   (the per-tag subs below, each a `contains?` over the snapshot's `:tags`
+   union). It doesn't care which leaf carries the `:connected` intent, only
+   that the tag is present. Ask, don't tell.
+   See docs/machines/glossary.md#state-tag.
 
-   Two staleness defences:
+   Reconnects bring two ways to be fooled by something stale, and we guard
+   against both:
 
-     1. `:after` backoff — the runtime cancels a state's `:after` timer on
-        exit and ignores any timer from a prior `:reconnecting` visit that
-        fires late. See docs/machines/concepts.md#guards-actions-tags-and-after--the-recognition-kit.
+     1. A late backoff timer. Leaving `:reconnecting` cancels its `:after`
+        timer, so a timer armed on an earlier visit can't wander in and
+        fire after we've moved on.
+        See docs/machines/concepts.md#guards-actions-tags-and-after--the-recognition-kit.
 
-     2. Connection epoch — the live `:socket-id` IS the epoch. The
-        `:current-socket?` guard rejects a `:ws/received` from a socket that
-        has since been replaced (a slow message landing post-reconnect).
+     2. A late message. The live `:socket-id` *is* the connection's clock:
+        every inbound event names the socket it came from, and the
+        `:current-socket?` guard drops anything from a socket we've since
+        replaced — the slow message that lands just after a reconnect.
 
-   The socket actor — the thing that owns the JS WebSocket — is
-   `:websocket/socket`, declared in `websocket.messages`. The connection
-   machine spawns it at the `:active` parent level so the actor's lifetime
-   spans `:connecting` -> `:authenticating` -> `:connected` without
-   re-spawning."
+   The thing that actually owns the JS WebSocket is the `:websocket/socket`
+   actor, over in `websocket.messages`. We spawn it on the `:active`
+   *parent*, so one socket spans `:connecting` -> `:authenticating` ->
+   `:connected` without re-spawning on every leaf transition."
   (:require [re-frame.core :as rf]
             ;; `re-frame.machines` ships in day8/re-frame2-machines.
-            ;; Loading the ns publishes the late-bind hooks for
-            ;; `rf/make-machine-handler`, the `:rf.machine/spawn` /
-            ;; `:rf.machine/destroy` fx, and the `:rf/machine` /
-            ;; `:rf/machine-has-tag?` framework subs.
+            ;; Requiring it is what wires up the machine vocabulary: the
+            ;; `:rf.machine/spawn` / `:rf.machine/destroy` fx and the
+            ;; `:rf/machine` / `:rf/machine-has-tag?` subs you'll see used
+            ;; below. Skip the require and they simply aren't there.
             [re-frame.late-bind]
             [re-frame.machines]
             [re-frame.fx]
@@ -56,17 +60,18 @@
 ;; ============================================================================
 
 (def connection-machine
-  "The `:ws/connection` machine spec. Held in a `def` so the schema below
-   (`schema/ConnectionData`) can reference it on `reg-machine`."
+  "The `:ws/connection` machine spec, kept in its own `def` so we can hand
+   it to `reg-machine` below."
     {:initial :disconnected
 
-     ;; `[:schemas :data]` validates the machine's `:data` slot on every
-     ;; transition. App-schemas validate app-db; a machine's `:data` is
-     ;; validated here instead.
+     ;; A machine validates its own `:data` here, on every transition.
+     ;; (App-schemas guard app-db; a machine's `:data` lives in runtime-db,
+     ;; so it gets its own `[:schemas :data]` instead.)
      ;; See docs/machines/concepts.md#validating-a-machines-data.
      :schemas {:data schema/ConnectionData}
 
-     ;; `:data` carries everything that must survive across reconnects.
+     ;; `:data` is the connection's memory — everything that has to survive
+     ;; a reconnect, from the URL down to the in-flight requests.
      :data    {:url            nil
                :auth-token     nil
                :retries        0
@@ -89,9 +94,11 @@
         (seq (:queue data)))
 
       :current-socket?
-      ;; The connection-epoch check. The incoming event carries
-      ;; `:source-socket-id` (the spawned actor's `:rf/self-id`); we drop
-      ;; the event unless that id matches the live socket.
+      ;; "Is this from the socket we're actually using right now?" Every
+      ;; inbound event stamps the id of the socket it came from
+      ;; (`:source-socket-id`, the actor's `:rf/self-id`). We let it
+      ;; through only if that matches the live socket — otherwise it's a
+      ;; straggler from a connection we've already replaced, and we drop it.
       (fn guard-current-socket? [{data :data [_ {:keys [source-socket-id]}] :event}]
         (and (some? (:socket-id data))
              (= source-socket-id (:socket-id data))))}
@@ -105,8 +112,10 @@
                    (assoc :error nil))})
 
       :record-and-reset
-      ;; Compound action — record fresh opts AND zero the retry counter.
-      ;; Used on manual `:ws/connect` from `:reconnecting` / `:failed`.
+      ;; Record fresh connection opts and zero the retry counter in one go.
+      ;; This runs on a *manual* `:ws/connect` out of `:reconnecting` or
+      ;; `:failed` — the user is asking for a clean slate, so we give them
+      ;; one and forget the failed attempts.
       (fn action-record-and-reset [{data :data [_ {:keys [url auth-token]}] :event}]
         {:data (-> data
                    (assoc :url url)
@@ -131,28 +140,31 @@
         {:data (assoc data :error error)})
 
       :record-socket-id
-      ;; Writes the spawned actor's id into `:data`. The `:active` spawn's
-      ;; `:on-spawn` callback fires `[:ws/connection [:ws/-socket-spawned
-      ;; <actor-id>]]` back into this machine; that transition runs this
-      ;; action. (`:on-spawn` is advisory and cannot mutate `:data`, so a
-      ;; self-event is how the id gets recorded.)
+      ;; Stash the spawned actor's id in `:data`. Why a whole action for an
+      ;; assoc? Because `:on-spawn` is advisory — its return value is
+      ;; thrown away, so it can't write `:data` directly. So it does the
+      ;; next best thing: it fires a `[:ws/-socket-spawned <id>]` event
+      ;; back at us, and that transition runs this action, which records
+      ;; the id the ordinary way.
       (fn action-record-socket-id [{data :data [_ id] :event}]
         {:data (assoc data :socket-id id)})
 
       :send-auth
-      ;; Entry action for `:authenticating` — route an `:auth` message
-      ;; into the live socket actor.
+      ;; We've just entered `:authenticating`, so send the credentials:
+      ;; route an `:auth` message into the live socket actor and wait for
+      ;; the server to bless us.
       (fn action-send-auth [{data :data}]
         {:fx [[:dispatch [(:socket-id data)
                           [:send {:type  :auth
                                   :token (:auth-token data)}]]]]})
 
       :flush-queue-and-resubscribe
-      ;; Entry action for `:connected`. Re-issues subscribe messages for
-      ;; every tracked topic (subscriptions survive reconnects) and resets
-      ;; the retry counter. The buffered-message flush is the separate
-      ;; `:always` transition below, which reads the `:queue` this action
-      ;; leaves in place.
+      ;; We're connected at last. Two bits of housekeeping on entry: reset
+      ;; the retry counter (we made it), and re-issue a subscribe for every
+      ;; tracked topic — subscriptions survive reconnects, so the server on
+      ;; the other end of a *new* socket needs telling about them again.
+      ;; The queued-message flush is a separate `:always` step below; this
+      ;; action deliberately leaves the `:queue` untouched for it to find.
       (fn action-on-connected [{data :data}]
         {:data (assoc data :retries 0)
          :fx   (mapv (fn [topic]
@@ -161,8 +173,9 @@
                      (:subscriptions data))})
 
       :flush-queue
-      ;; The `:always` cascade on `:connected`: when entry leaves the
-      ;; queue non-empty, walk it onto the wire and clear it.
+      ;; The `:always` step on `:connected`: if anything piled up in the
+      ;; queue while we were offline, drain it onto the wire now and clear
+      ;; it. Everything the user typed during the outage finally goes out.
       (fn action-flush-queue [{data :data}]
         (let [q (:queue data)]
           {:data (assoc data :queue [])
@@ -175,8 +188,9 @@
         {:data (update data :queue conj msg)})
 
       :send-now
-      ;; `:connected`-leaf override of the parent's `:ws/send`: the
-      ;; message goes straight to the wire instead of queueing.
+      ;; While `:connected`, sending is easy: straight to the wire, no
+      ;; queue. This is the leaf overriding the parent's `:ws/send` (which
+      ;; enqueues) — same event, different answer depending on where we are.
       (fn action-send-now [{data :data [_ msg] :event}]
         {:fx [[:dispatch [(:socket-id data) [:send msg]]]]})
 
@@ -187,19 +201,22 @@
                             [:send {:type :subscribe :topic topic}]]]]})
 
       :register-request
+      ;; A request that expects a reply, in three moves: remember it (drop
+      ;; an `:in-flight` entry so the eventual reply can find its way home),
+      ;; send it (forward the body to the socket), and set a deadline
+      ;; (schedule a timeout so a reply that never comes doesn't leave the
+      ;; slot dangling forever).
       ;; Caller: `[:ws/connection [:ws/request {:request-id ... :body ...
       ;;                                       :reply ... :timeout-ms ...}]]`
-      ;; Record the in-flight entry, forward to the socket, schedule
-      ;; a timeout.
       (fn action-register-request [{data :data [_ {:keys [request-id body reply timeout-ms]
                                             :or   {timeout-ms 30000}}] :event}]
         {:data (assoc-in data [:in-flight request-id]
                          {:reply-event reply :timeout-ms timeout-ms})
          :fx   [[:dispatch [(:socket-id data)
                             [:send (assoc body :request-id request-id)]]]
-                ;; The timeout event carries the live socket-id; the
-                ;; `:current-socket?` guard drops stale timeouts from
-                ;; a prior connection epoch.
+                ;; The timeout event carries the live socket-id too, so the
+                ;; same `:current-socket?` guard quietly discards a timeout
+                ;; left over from a connection we've already moved past.
                 [:dispatch-later
                  {:ms    timeout-ms
                   :event [:ws/connection
@@ -212,10 +229,12 @@
         {:data (update data :in-flight dissoc request-id)})
 
       :receive-message
-      ;; `:ws/received` arrived; the `:current-socket?` guard already
-      ;; cleared us. Branch on `:request-id` in the body: correlated
-      ;; reply → dispatch the registered reply event + clear the slot;
-      ;; server push → dispatch `[:ws/handle-message body]`.
+      ;; A message arrived and the `:current-socket?` guard has already
+      ;; vouched for it. Now, is it a reply we were waiting for, or an
+      ;; out-of-the-blue server push? A `:request-id` in the body tells us:
+      ;; if it's there, fire the reply event we stashed and clear the
+      ;; in-flight slot; if not, it's a push — hand it to
+      ;; `[:ws/handle-message body]`.
       (fn action-receive-message [{data :data [_ {:keys [body]}] :event}]
         (if-let [rid (:request-id body)]
           (let [{:keys [reply-event]} (get-in data [:in-flight rid])]
@@ -232,41 +251,43 @@
             :ws/request {:action :enqueue-message}}}
 
       :active
-      {;; The socket actor is spawned at the parent level so its lifetime
-       ;; spans :connecting -> :authenticating -> :connected. Any
-       ;; transition that leaves :active destroys it.
+      {;; Spawn the socket actor here, on the parent, so one socket lives
+       ;; across :connecting -> :authenticating -> :connected. The instant
+       ;; we leave :active — by any door — the runtime tears it down.
        ;; See docs/machines/concepts.md#when-the-machine-grows.
        :spawn {:machine-id :websocket/socket
-                ;; The child reads URL + auth-token from the parent's
-                ;; `:data` at spawn time. Every re-entry to :active picks
-                ;; up whatever is current.
+                ;; Hand the child the URL and token from our `:data` as it's
+                ;; born. Every fresh entry to :active re-reads whatever's
+                ;; current — so a token refreshed mid-reconnect just rides
+                ;; into the next socket, no extra plumbing.
                 :data       (fn [{snap :snapshot}]
                               {:url        (-> snap :data :url)
                                :auth-token (-> snap :data :auth-token)})
-                ;; `:on-spawn` is advisory: its return is dropped, so the
-                ;; callback cannot mutate the parent's `:data`. To capture
-                ;; the freshly-allocated actor id, the callback fires a
-                ;; `:ws/-socket-spawned` self-event; the matching
-                ;; transition runs `:record-socket-id`, which writes
-                ;; `:socket-id` into `:data` the normal way.
+                ;; `:on-spawn` is advisory — its return value goes nowhere,
+                ;; so it can't write the parent's `:data` itself. It knows
+                ;; the new actor's id, though, and we need that recorded.
+                ;; The trick: fire a `:ws/-socket-spawned` event at
+                ;; ourselves, whose transition runs `:record-socket-id` and
+                ;; writes `:socket-id` the ordinary way.
                 :on-spawn (fn [{id :id}]
                             (when-let [dispatch! (re-frame.late-bind/get-fn :router/dispatch!)]
                               (dispatch!
                                 [:ws/connection [:ws/-socket-spawned id]]
-                                ;; `:source :websocket` is the reserved
-                                ;; functional-origin slot for
-                                ;; websocket-arrived dispatches.
+                                ;; Tag where this dispatch came from:
+                                ;; `:source :websocket` is the reserved slot
+                                ;; for events that originate at the socket.
                                 {:source :websocket})))}
 
-       ;; Exit: clear the stale :socket-id from :data. The runtime
-       ;; destroys the actor automatically on exit; this keeps :data tidy
-       ;; so :current-socket? compares against nil correctly.
+       ;; On the way out, null the :socket-id. The runtime already destroys
+       ;; the actor for us; this just clears the stale id behind it, so
+       ;; :current-socket? has a clean nil to compare against rather than
+       ;; the id of a socket that no longer exists.
        :exit (fn action-clear-socket-id [{data :data}]
                {:data (assoc data :socket-id nil)})
 
-       ;; Parent-level transitions inherited by every leaf (deepest state
-       ;; wins, falling through to the parent).
-       ;; See docs/machines/glossary.md#transition.
+       ;; Transitions every leaf inherits. A leaf can override any of these
+       ;; (deepest state wins); anything it doesn't handle falls through to
+       ;; here. See docs/machines/glossary.md#transition.
        :on    {:ws/closed   {:target :reconnecting
                              :action :bump-retry}
                :ws/fatal    {:target :failed
@@ -275,13 +296,14 @@
                :ws/request  {:action :enqueue-message}
                :ws/refresh-token {:action :refresh-token}
                :ws/disconnect {:target :disconnected}
-               ;; Subscribe-while-connecting just records the intent;
-               ;; the next :connected entry will re-issue.
+               ;; Subscribe before we're fully connected? Just note the
+               ;; topic down; the next :connected entry will actually send
+               ;; the subscribe.
                :ws/subscribe {:action (fn [{data :data [_ topic] :event}]
                                         {:data (update data :subscriptions conj topic)})}
-               ;; Internal: the spawn's `:on-spawn` callback fires this so
-               ;; the machine can record the spawned socket id via a
-               ;; regular action (see `:record-socket-id`).
+               ;; Internal plumbing: the spawn's `:on-spawn` callback fires
+               ;; this so we can record the new socket id through a normal
+               ;; action (see `:record-socket-id`).
                :ws/-socket-spawned {:action :record-socket-id}}
 
        :initial :connecting
@@ -295,10 +317,11 @@
         {:tags  #{:websocket/active :websocket/authenticating}
          :entry :send-auth
          :on    {:ws/auth-ok     {:target :connected}
-                 ;; :failed is a top-level state, not a sibling under
-                 ;; :active. A bare keyword would resolve to [:active
-                 ;; :failed], which does not exist, so the absolute vector
-                 ;; target [:failed] is required.
+                 ;; Note the vector: `[:failed]`, not bare `:failed`.
+                 ;; `:failed` lives at the top level, not under `:active`,
+                 ;; and a bare keyword would be read as the sibling
+                 ;; `[:active :failed]` — which doesn't exist. The absolute
+                 ;; vector says "from the root, please".
                  :ws/auth-failed {:target [:failed]
                                   :action :record-error}}}
 
@@ -308,8 +331,8 @@
          :always [{:guard :has-queued-messages? :action :flush-queue}]
          :on     {:ws/received {:guard  :current-socket?
                                 :action :receive-message}
-                  ;; Override the parent's :ws/send — while :connected
-                  ;; the message goes straight to the wire.
+                  ;; Here we override the parent's :ws/send: connected
+                  ;; means no queue, send it now.
                   :ws/send     {:action :send-now}
                   :ws/request  {:action :register-request}
                   :ws/subscribe {:action :register-subscription}
@@ -319,9 +342,12 @@
       :reconnecting
       {:tags   #{:websocket/reconnecting}
        :always [{:guard :max-retries-exceeded? :target :failed}]
-       ;; Exponential backoff. The delay fn is called once at entry and
-       ;; reads the current retry count. Leaving the state cancels the
-       ;; timer, so a backoff from a prior visit can't fire late.
+       ;; Exponential backoff: wait a little, then a little more, then a
+       ;; lot. The delay fn runs once on entry and reads the current retry
+       ;; count, so each retry waits longer than the last. And because
+       ;; leaving the state cancels the timer, a backoff armed on an
+       ;; earlier visit can never fire late — nothing to remember, nothing
+       ;; to clean up.
        ;; See docs/machines/concepts.md#guards-actions-tags-and-after--the-recognition-kit.
        :after  {(fn delay-backoff-ms [{snap :snapshot}]
                   (let [{:keys [retries base-ms max-backoff-ms]} (:data snap)]
@@ -348,14 +374,15 @@
 ;; MACHINE HANDLER + SUBSCRIPTIONS + INIT EVENT
 ;; ============================================================================
 
-;; `rf/reg-machine` tags the registration `:rf/machine? true`, which is
-;; what declarative `:spawn` looks up to resolve a spawn target. Without
-;; it the spawn-fx silently no-ops.
+;; `reg-machine` marks this registration `:rf/machine? true` — the flag a
+;; declarative `:spawn` looks for when resolving its target. Forget it and
+;; the spawn quietly does nothing, which is a fun afternoon to debug.
 (rf/reg-machine :ws/connection connection-machine)
 
 ;; --- subs -------------------------------------------------------------
-;; A machine snapshot lives in runtime-db; read it through the framework
-;; `:rf/machine` sub. See docs/machines/glossary.md#snapshot.
+;; The machine's snapshot lives in runtime-db, not app-db, so we read it
+;; through the framework `:rf/machine` sub rather than poking at app-db.
+;; See docs/machines/glossary.md#snapshot.
 (rf/reg-sub :ws/snapshot
   :<- [:rf/machine :ws/connection]
   (fn [snapshot _] snapshot))
@@ -364,9 +391,10 @@
   :<- [:ws/snapshot]
   (fn [snap _] (:state snap)))
 
-;; The per-tag predicate subs: each is a `contains?` over the snapshot's
-;; `:tags` union, so a view asks "is it connected?" rather than matching
-;; the hierarchical `:state` vector. See docs/machines/glossary.md#state-tag.
+;; One little yes/no sub per tag. Each is a `contains?` over the
+;; snapshot's `:tags` union, so a view can ask "connected?" and get a
+;; boolean — no unpacking the hierarchical `:state` vector to find out.
+;; See docs/machines/glossary.md#state-tag.
 (rf/reg-sub :ws/connecting?
   :<- [:ws/snapshot]
   (fn [snap _] (contains? (:tags snap) :websocket/connecting)))
@@ -401,11 +429,12 @@
 
 ;; --- init event -------------------------------------------------------
 (rf/reg-event :ws.connection/initialise
-  {:doc "Seed the connection machine into its `:disconnected` initial
-         state. A machine's initial snapshot materialises on its first
-         dispatch."}
+  {:doc "Wake the connection machine up in its `:disconnected` start
+         state. A machine's first snapshot only materialises when it first
+         receives an event, so this gives it a harmless nudge."}
   (fn handler-ws-connection-initialise [_ _]
-    ;; A no-op dispatch through the machine forces the initial snapshot to
-    ;; materialise, so tests can read the `:disconnected` state without
-    ;; first calling `:ws/connect`.
+    ;; `:ws/noop` is a do-nothing event with no transition. Dispatching it
+    ;; is just enough to make the machine materialise its `:disconnected`
+    ;; snapshot, so tests (and the UI) can read the state before anyone
+    ;; clicks Connect.
     {:fx [[:dispatch [:ws/connection [:ws/noop]]]]}))

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -1,43 +1,28 @@
 (ns websocket.core
-  "Entry point for the WebSocket example.
+  "The entry point for the WebSocket example.
 
-   This example models a WebSocket connection as a state machine. It
-   exercises:
+   The big idea: a connection is a question, not a value. You rarely care
+   what's *in* the connection variable — you care which state you're in
+   (connecting, authenticating, connected, dropped, reconnecting, given
+   up) and which events move you between them. That is exactly what a
+   machine is for, so this example models the whole connection lifecycle
+   as one.
 
-   - **Hierarchical compound `:active`** parenting `:connecting`,
-     `:authenticating`, `:connected`. The socket-actor `:spawn` is on the
-     parent so it survives the success-path leaf transitions.
+   This file is just the launchpad. The four interesting files do the
+   real work:
 
-   - **`:after` exponential backoff** in `:reconnecting`. Leaving the
-     state cancels the timer, so a backoff from a prior visit can't fire
-     late.
+   - `connection.cljs` — the `:ws/connection` machine, the heart of it.
+   - `messages.cljs` — the spawned socket actor + a tiny mock server.
+   - `views.cljs` — the UI that drives the machine and shows its state.
+   - `schema.cljs` — Malli schemas for the machine `:data` and app-db.
 
-   - **`:always` cascades** — `:reconnecting`'s max-retries guard, and
-     `:connected`'s queue-flush on entry.
+   For the grammar the machine leans on, see docs/machines/concepts.md;
+   for where this example sits among the others, docs/machines/examples.md.
 
-   - **`:tags`** — `:websocket/connected`, `:websocket/reconnecting`,
-     `:websocket/failed`, so the view asks tag-shaped questions instead of
-     unfolding the snapshot's hierarchical `:state` vector.
-
-   - **Two staleness defences** — the backoff timer (runtime-cancelled on
-     exit) and the connection-epoch (`:current-socket?` guard against the
-     live `:socket-id`).
-
-   - **Request/reply correlation** — `:in-flight` map, request-id stamp,
-     timeout via `:dispatch-later`, reply-event dispatch on the correlated
-     `:ws/received`.
-
-   - **Reconnect cascade** — exit-from-`:active` clears the `:socket-id`;
-     the runtime destroys the socket actor; the `:reconnecting` `:after`
-     re-enters `:active`, which spawns a fresh one.
-
-   See docs/machines/concepts.md for the machine grammar and
-   docs/machines/examples.md for this example's place in the set.
-
-   Coverage lives in the CLJS substrate contract tests (`npm run
-   test:cljs`, ns `re-frame.websocket-cljs-test`); the mock server keeps
-   the app self-contained. The example tree is test-free, so
-   `npm run test:adapter-smokes` does not build this example."
+   No network required: a small in-process mock server stands in for a
+   real endpoint, so the app runs standalone. Its real coverage lives in
+   the CLJS contract tests (`npm run test:cljs`, ns
+   `re-frame.websocket-cljs-test`)."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -51,12 +36,13 @@
 ;; ============================================================================
 
 (rf/reg-event :ws.app/initialise
-  {:doc "App boot. Seeds the messages slice + materialises the
-         connection machine's initial `:disconnected` snapshot.
+  {:doc "Boot the app: seed the messages slice and bring the connection
+         machine to life in its `:disconnected` start state.
 
-         Namespaced under `:ws.app/*` (not `:app/initialise`) so the
-         example can coexist with the realworld + counter examples
-         without re-registering a common event key."}
+         The `:ws.app/*` prefix (rather than a plain `:app/initialise`)
+         is deliberate. Several examples share one test bundle, and a
+         common event key would have them stepping on each other's
+         registrations. Namespacing keeps each example to itself."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:ws.messages/initialise]]
           [:dispatch [:ws.connection/initialise]]]}))
@@ -65,22 +51,25 @@
 ;; MOUNT
 ;; ============================================================================
 ;;
-;; The React root is held in an atom and created lazily inside `run`, not
-;; at ns-load. Several example namespaces share one `#app` element in the
-;; browser-test bundle; creating the root at ns-load would race multiple
-;; roots onto the same container. Creating it in `run` keeps ns-load free
-;; of DOM side effects.
+;; We hold the React root in an atom and create it lazily inside `run`,
+;; never at ns-load. The reason is mundane but real: several examples
+;; share one `#app` element in the test bundle, and creating roots at
+;; ns-load would race several of them onto the same container. Building it
+;; in `run` keeps loading this namespace free of DOM side effects.
 
 (defonce react-root (atom nil))
 
-;; The frame lives in one spot: the `frame-provider` at the render root.
+;; One place owns the frame: the `frame-provider` at the render root.
 ;; `run` installs the adapter, then renders `[frame-provider {:id ...}
-;; ...]`. The provider's `{:id}` shape creates the app frame on first
-;; mount, applies its config, and runs the `:initial-events` seed once; on
-;; hot reload it reuses that frame and skips the seed. So create, seed, and
-;; scope-into-React all happen there. The frame id `:rf/default` matches
-;; the id `schema.cljs` scopes its `reg-app-schema` to.
-;; See docs/guide/concepts/frames.md.
+;; ...]`. Pass the provider an `{:id}` and it does the whole dance for
+;; you — on first mount it creates the frame, applies its config, and
+;; fires the `:initial-events` seed once; on a hot reload it finds the
+;; existing frame and skips the seed. Create, seed, and scope-into-React,
+;; all in one spot.
+;;
+;; The id `:rf/default` is the same one `schema.cljs` scopes its
+;; `reg-app-schema` to — they have to agree, or the schema lands in a
+;; different frame than the app. See docs/guide/concepts/frames.md.
 (def app-frame :rf/default)
 
 (defn run []

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -1,30 +1,30 @@
 (ns websocket.messages
-  "The `:websocket/socket` actor plus outbound/inbound message handling.
+  "The `:websocket/socket` actor, plus the messages flowing in and out.
 
-   This file plays two roles:
+   Two jobs share this file:
 
-   1. **Socket actor (`:websocket/socket`).** The child machine the
-      connection machine spawns on entry to `:active`. Its `:open` state
-      translates `:send` events into wire-level writes and forwards
-      inbound server messages back to the parent. Making the actor own the
-      socket keeps the JS `WebSocket` (a host-side reference, not a value)
-      out of app-db. See docs/machines/glossary.md#spawn.
+   1. **The socket actor (`:websocket/socket`).** The child machine the
+      connection machine spawns on entry to `:active`. Its whole purpose
+      is to own the JS `WebSocket` — a live host-side handle, not a value,
+      and emphatically not something you want sitting in app-db. The actor
+      turns outbound `:send` events into wire writes and relays inbound
+      server messages back up to the parent. See docs/machines/glossary.md#spawn.
 
-   2. **Mock-server bridge.** A small in-process JS `WebSocket`-shaped stub
-      the example uses in place of a real endpoint, so it runs standalone.
-      The stub state lives in the `mock-server-state` atom. The exported
-      fns are the delivery seams: `set-mock-sync!` flips the stub between
-      async (`setTimeout`-deferred) and sync (immediate `dispatch-sync`)
-      delivery; `send-server-push!` and `simulate-disconnect!` push inbound
-      `:received` / disconnect events from view click handlers; and
-      `reset-mock-server!` clears the side-table between tests. Sync mode
-      lets a test observe a full request/reply round-trip without yielding
-      to the JS event loop.
+   2. **A pretend server.** No real endpoint here — a tiny in-process
+      `WebSocket`-shaped stub stands in, so the example runs anywhere with
+      zero network. Its state lives in the `mock-server-state` atom, and a
+      handful of exported fns are the seams you reach for: `set-mock-sync!`
+      flips it between async (`setTimeout`-deferred) and sync
+      (`dispatch-sync`) delivery; `send-server-push!` and
+      `simulate-disconnect!` let view buttons shove events in from outside;
+      `reset-mock-server!` wipes the slate between tests. Sync mode is the
+      tester's friend — it lets a full request/reply round-trip complete
+      without ever yielding to the JS event loop.
 
-   The split is intentional: a real app swaps the bridge for a real
-   `(js/WebSocket. url)` and leaves the actor machine untouched. The
-   pattern — machine owns the actor; actor owns the host-side reference —
-   does not change with the transport."
+   The two halves are kept apart on purpose. Swap the pretend server for a
+   real `(js/WebSocket. url)` and the actor machine doesn't even notice.
+   The shape stays put no matter the transport: the machine owns the actor,
+   the actor owns the host-side handle."
   (:require [re-frame.core :as rf]
             [re-frame.machines]
             [websocket.schema]))
@@ -33,12 +33,12 @@
 ;; HOST-SIDE SOCKET STORE
 ;; ============================================================================
 ;;
-;; The JS `WebSocket` (or its mock stand-in) is a stateful reference. It
-;; cannot live in app-db: it doesn't serialise, it doesn't survive a
-;; time-travel replay, and writing it would defeat re-frame's value
-;; semantics. So it lives in a host-side store keyed by the actor's
-;; `:rf/self-id`, owned by the actor's machine handler. The actor writes
-;; on open and clears on close.
+;; Where do you keep a live socket? Not in app-db. A JS `WebSocket` (or our
+;; mock stand-in) is a mutable handle: it won't serialise, it won't survive
+;; a time-travel replay, and slipping it into app-db would quietly undo
+;; everything re-frame's value semantics buy you. So it lives off to the
+;; side, in this little store keyed by the actor's `:rf/self-id`. The actor
+;; owns it: writes on open, clears on close. app-db only ever sees the id.
 
 (defonce ^:private sockets-by-actor (atom {}))
 
@@ -55,42 +55,43 @@
 ;; MOCK WEBSOCKET SERVER
 ;; ============================================================================
 ;;
-;; A tiny `js/WebSocket`-shaped object for the tests and the example's own
-;; buttons. It supports two interaction shapes:
+;; Just enough `js/WebSocket`-shaped server to make the example feel alive,
+;; for both the tests and the buttons in the UI. It answers in two ways:
 ;;
-;;   (1) Auto-echo replies for outbound `{:type :request ...}`. The server
-;;       echoes a reply on the same socket carrying the original
-;;       `:request-id`, so the connection machine's request-reply
-;;       correlation slot lights up.
+;;   (1) It echoes. Send it an outbound `{:type :request ...}` and it
+;;       replies on the same socket with the original `:request-id` intact,
+;;       which is exactly what the connection machine's request-reply
+;;       correlation needs to find its match.
 ;;
-;;   (2) Manual `(send-server-push! body)` and `(simulate-disconnect!)`
-;;       seams the views call from button handlers.
+;;   (2) It can be poked from the outside, via `(send-server-push! body)`
+;;       and `(simulate-disconnect!)` — the seams the view buttons call.
 ;;
-;; In async mode, inbound deliveries land on the next task tick (via
-;; `js/setTimeout _ 0`, in the `later` helper below) so transport events
-;; fire after the dispatch returns, not inside it.
+;; In async mode, replies don't land in the same breath as the send: the
+;; `later` helper below defers them a tick (`js/setTimeout _ 0`), so
+;; transport events arrive after the dispatch returns, the way a real
+;; network would.
 
 (defonce ^:private mock-server-state (atom {:sockets {} :sync? false}))
 
 (defn set-mock-sync!
-  "Toggle the mock server between async (default, `setTimeout`-deferred)
-   and sync (immediate-delivery) modes. The tests use sync mode so
-   `rf/dispatch-sync` observes the full request/reply round-trip without
-   yielding to the JS event loop."
+  "Flip the mock server between async (the default — `setTimeout`-deferred,
+   like a real network) and sync (replies land immediately). Tests want
+   sync: it lets a single `rf/dispatch-sync` watch a whole request/reply
+   round-trip finish, with no event-loop tick to wait on."
   [sync?]
   (swap! mock-server-state assoc :sync? sync?))
 
 (defn reset-mock-server!
-  "Clear every stored mock socket, so each test starts with a fresh
-   mock-server side-table. Without this the `:sockets` map accumulates
-   across tests and `send-server-push!` delivers N copies of every push."
+  "Forget every stored mock socket, so each test opens on a clean server.
+   Skip this and the `:sockets` map quietly piles up across tests, until
+   `send-server-push!` is cheerfully delivering N copies of every push."
   []
   (swap! mock-server-state assoc :sockets {}))
 
 (defn- later
-  "Run `f` synchronously in sync mode; via `setTimeout` otherwise. This is
-   the only knob that separates sync mode (the tests) from the
-   browser-driven example (async, `setTimeout`-deferred)."
+  "Run `f` now (sync mode) or on the next tick via `setTimeout` (async).
+   This one tiny fork is the whole difference between the tests' world and
+   the browser's: sync for tests, deferred-like-a-network for the example."
   [f]
   (if (:sync? @mock-server-state)
     (f)
@@ -100,40 +101,40 @@
   (str "mock-socket-" (random-uuid)))
 
 (defn- deliver-to-actor!
-  "Dispatch an inbound transport event into the spawned actor. The actor's
-   machine handler translates the event into a parent-bound
-   `[:ws/connection [:ws/<kind> ...]]` dispatch.
+  "Hand an inbound transport event to the spawned actor, which will turn it
+   into a parent-bound `[:ws/connection [:ws/<kind> ...]]` dispatch.
 
-   In async mode this fires from a detached `setTimeout` callback, which
-   carries no ambient frame; a bare `rf/dispatch` here would raise
-   `:rf.error/no-frame-context`. So the caller captures its frame's
-   `dispatch` and threads it in. A captured `dispatch` carries the frame
-   across the async boundary.
-   See docs/guide/glossary.md#frame-handle."
+   There's a subtlety in async mode: this runs from a detached
+   `setTimeout` callback, which has no ambient frame, so a bare
+   `rf/dispatch` would throw `:rf.error/no-frame-context`. The fix is to
+   capture the frame's `dispatch` back where a frame *was* in scope and
+   thread it in here — a captured `dispatch` carries its frame across the
+   async gap. See docs/guide/glossary.md#frame-handle."
   [dispatch actor-id kind payload]
   (when actor-id
     (dispatch [actor-id [kind payload]])))
 
 (defn- mock-encode-auth-reply [token]
-  ;; A real server would validate the JWT; the mock accepts any
-  ;; non-empty token and rejects the rest.
+  ;; A real server would actually verify the JWT. Our mock has lower
+  ;; standards: any non-empty string is welcome, everything else is shown
+  ;; the door.
   (if (and (string? token) (pos? (count token)))
     {:type :auth-ok}
     {:type :auth-failed :reason "Empty token"}))
 
 (defn mock-socket-for-actor
-  "Returns a function that opens a fresh mock socket bound to the
-   actor's id. The returned :send fn handles every outbound message
-   the actor produces; the mock auto-routes `:auth` (→ `:auth-ok`)
-   and `:request` (→ correlated reply via the `:type :reply` echo)."
+  "Open a fresh mock socket bound to this actor's id, and return its handle.
+   The handle's `:send` fn fields every outbound message the actor makes;
+   the mock knows how to answer two of them — `:auth` (→ `:auth-ok`) and
+   `:request` (→ a correlated `:type :reply` echo)."
   [actor-id _url _auth-token]
   (let [id   (next-mock-socket-id)
         open? (atom true)
-        ;; This fn runs inside the actor's `:open-socket` action, so it has
-        ;; a frame in scope. Capture that frame's `dispatch` now and thread
-        ;; it into every (async, `later`-deferred) inbound delivery below;
-        ;; the detached `setTimeout` callback has no frame of its own.
-        ;; See docs/guide/glossary.md#frame-handle.
+        ;; We're inside the actor's `:open-socket` action right now, which
+        ;; means a frame is in scope — but the deferred deliveries below
+        ;; fire from a bare `setTimeout` callback, long after it's gone.
+        ;; So grab the frame's `dispatch` here, while we still can, and
+        ;; carry it into each delivery. See docs/guide/glossary.md#frame-handle.
         dispatch (:dispatch (rf/frame-handle))]
     (swap! mock-server-state assoc-in [:sockets id]
            {:actor-id actor-id
@@ -144,17 +145,17 @@
               (when @open?
                 (case (:type msg)
                   :auth
-                  ;; Auth — produce :auth-ok / :auth-failed on the same
-                  ;; channel on the next task tick (via `later`).
+                  ;; Auth: reply :auth-ok or :auth-failed on the same
+                  ;; channel, a tick later (via `later`).
                   (later
                     #(deliver-to-actor! dispatch actor-id :received
                                         (mock-encode-auth-reply (:token msg))))
 
                   :request
-                  ;; Auto-echo: the mock server treats every :request as
-                  ;; a "please reply with what I sent + :ok"; the
-                  ;; request-id round-trips so the connection machine's
-                  ;; request-reply correlation lights up.
+                  ;; Every :request gets the same treatment: "here's your
+                  ;; stuff back, plus :ok". The original :request-id rides
+                  ;; along, which is the whole point — that's how the
+                  ;; connection machine pairs this reply with its request.
                   (later
                     #(deliver-to-actor! dispatch actor-id :received
                                         {:type       :reply
@@ -163,17 +164,17 @@
                                          :echo       (dissoc msg :request-id)}))
 
                   :subscribe
-                  ;; The mock acks subscribes with one synthetic push so
-                  ;; the example demonstrates server-pushed events
-                  ;; arriving after the subscribe round-trip.
+                  ;; Ack a subscribe with one synthetic push, so you can
+                  ;; watch a server-pushed event show up right after the
+                  ;; subscribe round-trip — the shape a real feed would use.
                   (later
                     #(deliver-to-actor! dispatch actor-id :received
                                         {:type :push
                                          :topic (:topic msg)
                                          :note  "subscribed"}))
 
-                  ;; Default: no-op (the example doesn't model fire-and-
-                  ;; forget app-level sends beyond the cases above).
+                  ;; Anything else: shrug. The example doesn't bother with
+                  ;; fire-and-forget sends beyond the cases above.
                   nil)))
      :close (fn mock-close []
               (reset! open? false)
@@ -181,18 +182,18 @@
               (later
                 #(deliver-to-actor! dispatch actor-id :closed {:code 1000})))}))
 
-;; Exposed seams the views (and the tests) use to drive the mock without
-;; dispatching through the actor.
+;; The seams below let the views (and tests) poke the mock server from
+;; outside, without pretending to be the actor.
 
 (defn- deliver-external!
-  "Variant of `deliver-to-actor!` for callers outside a running cascade
-   (test bodies, view click handlers). In sync mode it uses
-   `dispatch-sync` so the chain runs to fixed point before returning; in
-   async mode it uses the queued `dispatch`.
+  "Like `deliver-to-actor!`, but for callers standing outside a running
+   cascade — test bodies and view click handlers. In sync mode it reaches
+   for `dispatch-sync`, so the whole chain settles before it returns; in
+   async mode the plain queued `dispatch` does.
 
-   A view click handler fires outside any frame scope, so the caller
-   supplies a frame-bound `dispatch` / `dispatch-sync` pair (from a
-   captured `(rf/frame-handle)`). A bare `rf/dispatch` here would raise
+   A click handler fires with no frame in scope, so the caller passes in a
+   frame-bound `dispatch` / `dispatch-sync` pair (from a captured
+   `(rf/frame-handle)`) — a bare `rf/dispatch` here would raise
    `:rf.error/no-frame-context`. See docs/guide/glossary.md#frame-handle."
   [{:keys [dispatch dispatch-sync]} actor-id kind payload]
   (when actor-id
@@ -201,12 +202,11 @@
       (dispatch      [actor-id [kind payload]]))))
 
 (defn send-server-push!
-  "Deliver a synthetic server push to every live mock socket. Drives the
-   inbound translation path from the 'Trigger server push' button and the
-   tests.
+  "Push a made-up server message to every live mock socket — the inbound
+   path the 'Trigger server push' button (and the tests) exercise.
 
-   `handle` is a `(rf/frame-handle)` bundle carrying the caller's frame, so
-   the deferred dispatch carries a frame across the click-handler / async
+   `handle` is a `(rf/frame-handle)` bundle holding the caller's frame, so
+   the deferred dispatch can carry it across the click-handler / async
    boundary. See docs/guide/glossary.md#frame-handle."
   [handle body]
   (doseq [[_ {:keys [actor-id open?]}] (:sockets @mock-server-state)]
@@ -214,9 +214,10 @@
       (deliver-external! handle actor-id :received body))))
 
 (defn simulate-disconnect!
-  "Force every live mock socket closed, triggering the reconnect cascade
-   in the parent. Drives the 'Drop connection' button. `handle` is the
-   caller's `(rf/frame-handle)` bundle (see `send-server-push!`)."
+  "Yank every live mock socket closed and let the parent's reconnect
+   cascade take it from there — this is what the 'Drop connection' button
+   does. `handle` is the caller's `(rf/frame-handle)` bundle (see
+   `send-server-push!`)."
   [handle]
   (doseq [[_ {:keys [actor-id open?]}] (:sockets @mock-server-state)]
     (when @open?
@@ -227,26 +228,26 @@
 ;; THE SOCKET ACTOR — :websocket/socket
 ;; ============================================================================
 ;;
-;; A small machine. `:opening` opens the host-side socket on entry and
-;; transitions immediately to `:open`, where it stays for the lifetime of
-;; the connection. The parent's `:spawn` destroys this actor on any exit
-;; from `:active`, which handles cleanup.
+;; A small machine with a simple life. `:opening` opens the host-side
+;; socket on entry, then immediately steps to `:open`, where it spends the
+;; rest of its days. Cleanup isn't its problem: leaving `:active` upstairs
+;; destroys this actor, and that's that.
 ;;
-;; The actor reads the runtime-stamped `:rf/self-id` to tag its own
-;; dispatches and `:rf/parent-id` to address dispatches back to the
-;; parent. The runtime stamps both keys into a spawned actor's `:data`.
+;; Two ids do the talking. The runtime stamps `:rf/self-id` and
+;; `:rf/parent-id` into a spawned actor's `:data`; the actor tags its own
+;; messages with the first and addresses the parent with the second.
 
 (def socket-actor-machine
-  "The `:websocket/socket` actor machine spec. Held in a `def` so the
-   `reg-machine` registration below can reference it."
+  "The `:websocket/socket` actor spec, in its own `def` so `reg-machine`
+   below can point at it."
     {:initial :opening
      :data    {:url        nil
                :auth-token nil}
 
      :actions
      {:open-socket
-      ;; Entry action — instantiate the host-side mock socket and
-      ;; report `:opened` back to the parent.
+      ;; On entry: stand up the host-side mock socket, stash it, and tell
+      ;; the parent we're `:opened`.
       (fn action-open-socket [{data :data}]
         (let [self-id   (:rf/self-id data)
               parent-id (:rf/parent-id data)
@@ -254,16 +255,16 @@
                                                (:url data)
                                                (:auth-token data))]
           (store-socket! self-id socket)
-          ;; Report `:opened` to the parent as a `:dispatch` fx, not a bare
-          ;; `(rf/dispatch ...)` from inside the action body. A `:dispatch`
-          ;; fx inherits the cascade's frame; a bare dispatch from an
-          ;; action body runs outside any frame scope and raises
-          ;; `:rf.error/no-frame-context`.
+          ;; Notice we report `:opened` as a `:dispatch` *fx*, not a bare
+          ;; `(rf/dispatch ...)` in the action body. The fx inherits the
+          ;; cascade's frame; a raw dispatch from in here would run with no
+          ;; frame at all and raise `:rf.error/no-frame-context`. Effects,
+          ;; not side effects.
           {:fx [[:dispatch [parent-id [:ws/opened {:source-socket-id self-id}]]]]}))
 
       :send-via-socket
-      ;; The parent dispatches `[<actor-id> [:send body]]` for every
-      ;; outbound message; we route through the host-side `:send`.
+      ;; The parent sends us `[<actor-id> [:send body]]` for each outbound
+      ;; message; we just hand the body to the host-side socket's `:send`.
       (fn action-send-via-socket [{data :data [_ body] :event}]
         (let [self-id (:rf/self-id data)]
           (when-let [socket (get-socket self-id)]
@@ -271,15 +272,16 @@
         nil)
 
       :forward-received
-      ;; The server's reply arrives via `[<actor-id> [:received body]]`.
-      ;; Forward it to the parent stamped with the socket id, so
-      ;; `:current-socket?` can drop messages from a torn-down socket.
+      ;; Something came in from the server, via `[<actor-id> [:received
+      ;; body]]`. Pass it up to the parent, stamped with our socket id —
+      ;; that stamp is what lets `:current-socket?` reject leftovers from a
+      ;; socket that's since been torn down.
       (fn action-forward-received [{data :data [_ body] :event}]
         (let [self-id   (:rf/self-id data)
               parent-id (:rf/parent-id data)
-              ;; Branch on body's :type: :auth-ok / :auth-failed land on
-              ;; the parent as their own events; everything else lands as
-              ;; :ws/received with the body in tow.
+              ;; Sort by `:type`: auth results (`:auth-ok` / `:auth-failed`)
+              ;; reach the parent as their own dedicated events; everything
+              ;; else goes up as `:ws/received` with the body riding along.
               ev        (case (:type body)
                           :auth-ok     [:ws/auth-ok {:source-socket-id self-id}]
                           :auth-failed [:ws/auth-failed
@@ -301,13 +303,13 @@
 
      :states
      {:opening
-      ;; The initial state's `:entry` runs once as the actor comes to
-      ;; life. We open the host-side socket here and transition straight
-      ;; to `:open` via the `:always` slot once the socket is stored.
+      ;; The first moment of the actor's life. `:entry` runs once: open the
+      ;; host-side socket, store it, and then `:always` carries us straight
+      ;; on to `:open`.
       ;;
-      ;; The actor may also receive `:send` from the parent's `:send-auth`
-      ;; entry action before its own entry has settled, so `:opening`
-      ;; handles `:send` too, picking up the just-stored socket.
+      ;; There's a small race to cover. The parent's `:send-auth` can fire a
+      ;; `:send` at us before we've even settled into `:open`, so `:opening`
+      ;; handles `:send` too — by then the socket is stored, so it just works.
       {:entry :open-socket
        :always [{:target :open}]
        :on    {:send       {:target :open
@@ -324,30 +326,31 @@
                        :action :forward-closed}}}
 
       :closed
-      ;; Terminal. The parent's exit-from-:active cascade destroys this
-      ;; actor; this state just absorbs any late events.
+      ;; The end of the line. The parent's exit-from-:active is about to
+      ;; destroy this actor anyway; until it does, this state just quietly
+      ;; soaks up any stragglers.
       {}}})
 
 ;; ============================================================================
 ;; REGISTRATIONS
 ;; ============================================================================
 
-;; The socket actor the connection machine spawns. `rf/reg-machine` tags
-;; the registration `:rf/machine? true`, which the spawn-fx needs to
-;; resolve the spawn target.
+;; Register the actor the connection machine spawns. As before,
+;; `reg-machine` is what flips on `:rf/machine? true` — the flag the spawn
+;; needs to find its target.
 (rf/reg-machine :websocket/socket socket-actor-machine)
 
-;; The connection machine dispatches [:ws/handle-message body] for every
-;; received message (correlated reply or server push); this handler folds
-;; it into app-db for the views.
+;; For every message that comes in — a correlated reply or a server push —
+;; the connection machine dispatches `[:ws/handle-message body]`, and this
+;; handler is where it lands in app-db for the views to read.
 (rf/reg-event :ws/handle-message
-  {:doc "Translate an inbound `:ws/received` body into an app-db write.
-         Records the message in the [:messages :received] log + stashes
-         the latest correlated reply at [:messages :last-reply] when
-         applicable. Each message is stamped with a monotonic `:rx-seq`
-         so the inbox view can give every <li> a stable React :key —
-         server pushes carry no `:request-id`, so position can't be used
-         as identity once the newest-first list grows."}
+  {:doc "Fold an inbound message into app-db. It joins the
+         [:messages :received] log, and if it's a correlated reply it also
+         lands at [:messages :last-reply]. Each one gets a monotonic
+         `:rx-seq` stamp on the way in — that's the inbox's stable React
+         `:key`. (Server pushes carry no `:request-id`, so we can't lean
+         on identity from the wire, and list position shifts as new
+         messages arrive at the top.)"}
   (fn handler-ws-handle-message [{:keys [db]} [_ body]]
     {:db (let [rx-seq (get-in db [:messages :rx-count] 0)]
       (-> db
@@ -360,40 +363,41 @@
 
 ;; --- app-level events -------------------------------------------------
 (rf/reg-event :ws.app/send
-  {:doc "Submit the form's draft as an outbound message."}
+  {:doc "Send the form's current draft, and clear the input."}
   (fn handler-app-send [{:keys [db]} [_ body]]
     {:db (assoc-in db [:messages :draft] "")
      :fx [[:dispatch [:ws/connection [:ws/send {:type :note :body body}]]]]}))
 
-;; The request-id is a durable correlation fact: it is written into the
-;; connection machine's :in-flight slot and the eventual reply is matched
-;; against it. A durable id must be a recorded fact, never an ambient
-;; `(random-uuid)` read at the handler write site — otherwise replay mints
-;; a different id and the correlation no longer matches the recorded
-;; request. So the generator is a recordable `reg-cofx`: it runs at
-;; context-assembly, its id is recorded on the event's causal token, and
-;; replay re-presents it verbatim. `:ws.app/request` declares it via
-;; `:rf.cofx/requires` and reads it from the coeffects map.
+;; The request-id is a fact the system has to *remember*: it's written into
+;; the machine's :in-flight slot, and the reply that eventually comes back
+;; is matched against it. So it can't be conjured with a bare
+;; `(random-uuid)` at the handler — replay would mint a fresh one, it
+;; wouldn't match the recorded request, and the correlation would silently
+;; fall apart. The fix is to make the id a *recordable* coeffect: a
+;; `reg-cofx` that runs at context-assembly, gets written onto the event's
+;; causal token, and is replayed back verbatim. `:ws.app/request` asks for
+;; it via `:rf.cofx/requires` and reads it from the coeffects map.
 ;; See docs/guide/glossary.md#recordable-vs-ambient-coeffects.
 (rf/reg-cofx :ws.app/request-id
   {:recordable? true
-   :doc "Replayable correlation id for an outbound request-reply."}
+   :doc "A replayable correlation id for one request-reply round-trip."}
   (fn [] (random-uuid)))
 
 (rf/reg-event :ws.app/request
-  {:doc "Issue a request-reply via the connection machine's correlation
-         slot. The reply lands at [:messages :last-reply] once the mock
-         server echoes back. The correlation id comes from the
-         `:ws.app/request-id` recordable coeffect, never minted ambiently,
-         so replay re-presents the same id.
+  {:doc "Fire off a request and expect a reply back. It goes through the
+         connection machine's correlation slot; when the mock server
+         echoes, the reply turns up at [:messages :last-reply]. The
+         correlation id comes from the `:ws.app/request-id` recordable
+         coeffect (never minted on the spot), so a replay reuses the same
+         id and the reply still finds its request.
 
-         This is app-level correlation, not a framework reply envelope.
-         re-frame2 does not ship a managed WebSocket, so a per-message
-         request/reply over the open socket is correlation the app owns: a
-         per-message `:request-id`, a registered `:reply` event target, and
-         the connection machine's `:in-flight` map. The wire `:request-id`
-         is app-level protocol correlation, deliberately separate from the
-         framework's own reply vocabulary."
+         Worth being clear: this is *the app's* request/reply, not a
+         framework feature. re-frame2 ships no managed WebSocket, so
+         per-message correlation over an open socket is yours to build —
+         here, from a `:request-id`, a registered `:reply` target, and the
+         machine's `:in-flight` map. The wire `:request-id` is your own
+         protocol detail, kept deliberately separate from anything the
+         framework does."
    :rf.cofx/requires [:ws.app/request-id]}
   (fn handler-app-request [{rid :ws.app/request-id} [_ body]]
     {:fx [[:dispatch [:ws/connection
@@ -404,17 +408,17 @@
                                     :timeout-ms 5000}]]]]}))
 
 (rf/reg-event :ws.app/request-reply
-  {:doc "Reply event fired by the connection machine's :register-request
-         flow once the correlated reply lands. The arg is the app's own
-         reply body (the server echo) — the app-level correlation shape
-         (see :ws.app/request)."}
+  {:doc "The reply finally arrived. The connection machine fires this once
+         the correlated reply lands, handing us the app's reply body (the
+         server's echo). We just file it at [:messages :last-reply].
+         See :ws.app/request for the correlation it completes."}
   (fn handler-app-request-reply [{:keys [db]} [_ body]]
     {:db (assoc-in db [:messages :last-reply] body)}))
 
 (rf/reg-event :ws.app/subscribe-demo
-  {:doc "Demo subscription — the mock server acks with a synthetic
-         server push so the app demonstrates the subscribe-then-push
-         shape."}
+  {:doc "Subscribe to a demo topic. The mock server acks with a synthetic
+         push, so you get to watch the subscribe-then-push shape play out
+         end to end."}
   (fn handler-app-subscribe-demo [_ _]
     {:fx [[:dispatch [:ws/connection [:ws/subscribe :demo-topic]]]]}))
 

--- a/examples/reagent/websocket/schema.cljs
+++ b/examples/reagent/websocket/schema.cljs
@@ -1,23 +1,23 @@
 (ns websocket.schema
-  "Malli schemas for the WebSocket example.
+  "Malli schemas for the WebSocket example — the shapes we promise to hold.
 
-   Two slices are described:
+   Two slices get described here:
 
-   - The `:ws/connection` machine's `:data` map: `:url`, `:auth-token`,
-     retry counters, `:socket-id` (the address of the currently-live
-     socket actor), `:subscriptions`, the offline send `:queue`, and the
-     request-reply `:in-flight` map. Attached as the machine's
-     `[:schemas :data]` (see `connection.cljs`) — a machine's `:data` is
-     validated there, not via an app-schema.
+   - The `:ws/connection` machine's `:data` map: the URL and token, the
+     retry counters, `:socket-id` (who the live socket actor is),
+     `:subscriptions`, the offline `:queue`, and the `:in-flight` map of
+     awaited replies. It hangs off the machine as `[:schemas :data]` (see
+     `connection.cljs`), because a machine validates its own `:data` —
+     there's no app-schema involved.
      See docs/machines/concepts.md#validating-a-machines-data.
 
-   - The `:messages` slice in app-db. The app records every received
-     message at `[:messages :received]` so the UI can list them; the form
-     draft lives at `[:messages :draft]`."
+   - The `:messages` slice in app-db: every message that arrives is logged
+     at `[:messages :received]` for the UI to list, and the form's draft
+     sits at `[:messages :draft]`."
   (:require [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
-            ;; Loading the ns here registers its late-bind hooks so
-            ;; rf/reg-app-schema resolves at the call sites below.
+            ;; Requiring it wires up the hooks that make `rf/reg-app-schema`
+            ;; resolve at the call site below — no require, no schema.
             [re-frame.schemas])
   (:require-macros [re-frame.core :refer [with-frame]]))
 
@@ -26,8 +26,8 @@
 ;; ============================================================================
 
 (def InFlightEntry
-  "Per request-reply correlation entry: the registered reply event and
-   the timeout window."
+  "One outstanding request, waiting for its reply: which event to fire when
+   it lands, and how long we're willing to wait."
   [:map
    [:reply-event {:optional true} [:maybe [:vector :any]]]
    [:timeout-ms  :int]])
@@ -41,17 +41,17 @@
    [:max-retries    :int]
    [:base-ms        :int]
    [:max-backoff-ms :int]
-   ;; The currently-live socket actor's id (allocated by the runtime at
-   ;; :spawn time; cleared on exit from :active). The connection-epoch:
-   ;; the live socket-id IS the epoch.
+   ;; Who the live socket actor is right now. The runtime hands us this id
+   ;; at :spawn time and we null it on exit from :active. It doubles as the
+   ;; connection's clock — the live socket-id *is* the epoch.
    [:socket-id      [:maybe :any]]
    [:subscriptions  [:set :any]]
    [:queue          [:vector :any]]
    [:in-flight      [:map-of :any InFlightEntry]]
    [:error          [:maybe :any]]
-   ;; Runtime-stamped framework keys. The runtime writes these into a
-   ;; spawned actor's initial :data; optional here because the parent
-   ;; machine never receives them, only spawned actors do.
+   ;; Framework keys the runtime stamps into a *spawned* actor's :data.
+   ;; Optional, because the parent machine never gets them — only the
+   ;; children the runtime spawns do.
    [:rf/self-id     {:optional true} :any]
    [:rf/parent-id   {:optional true} :any]
    [:rf/invoke-id  {:optional true} :any]])
@@ -60,15 +60,17 @@
 ;; APP-DB SLICES
 ;; ============================================================================
 ;;
-;; The app — separate from the connection machine — keeps a record of
-;; every received message plus a draft for the outbound form.
+;; This is the app's own memory, quite separate from the connection
+;; machine: a log of every message that came in, plus the draft the user
+;; is typing.
 
 (def Message
-  "Wire-shape of one message — either a server push (no :request-id) or a
-   correlated reply. The example uses a tiny ad-hoc envelope; the shape is
-   wire-format-agnostic. `:rx-seq` is a UI-assigned monotonic
-   receive-sequence stamped by :ws/handle-message so the inbox can give
-   each row a stable React :key (it is not part of the wire body)."
+  "One message, as it sits in the log — either a server push (no
+   :request-id) or a correlated reply. The envelope is a tiny ad-hoc thing;
+   nothing here cares about the wire format. The one local addition is
+   `:rx-seq`, a monotonic counter :ws/handle-message stamps on arrival so
+   the inbox can give each row a stable React :key. It's ours, not the
+   server's."
   [:map
    [:type :keyword]
    [:body {:optional true} :any]
@@ -78,27 +80,27 @@
 (def MessagesSlice
   [:map
    [:draft    :string]
-   ;; Received-message log: newest-first so the view renders top-down.
+   ;; The inbox log, newest-first, so the view just renders top-down.
    [:received [:vector Message]]
-   ;; Last correlated reply, landed via :ws.app/request-reply (or via
-   ;; :ws/handle-message for server pushes) — handy for the request-reply
-   ;; round-trip view and the test assertion.
+   ;; The most recent correlated reply (set by :ws.app/request-reply, or by
+   ;; :ws/handle-message for server pushes) — handy for the round-trip view
+   ;; and a convenient thing for a test to assert on.
    [:last-reply [:maybe :any]]
-   ;; Monotonic counter feeding each message's stable :rx-seq.
+   ;; The ticking source for each message's :rx-seq stamp.
    [:rx-count :int]])
 
 ;; ============================================================================
 ;; SCHEMA REGISTRATIONS
 ;; ============================================================================
 
-;; Only the app-db `:messages` slice gets an app-schema. A machine snapshot
-;; is runtime-db, not app-db, so an `reg-app-schema` on a snapshot path
-;; would validate nothing; the connection machine's own `[:schemas :data]`
-;; covers that instead.
+;; Only `:messages` gets an app-schema here, and that's on purpose. A
+;; machine's snapshot lives in runtime-db, not app-db, so pointing
+;; `reg-app-schema` at a snapshot path would validate precisely nothing —
+;; the machine's own `[:schemas :data]` is what guards that.
 ;;
-;; `reg-app-schema` is frame-local and needs a frame in scope; a bare
-;; ns-load call raises :rf.error/no-frame-context. This example runs in the
-;; :rf/default frame, so name it explicitly.
-;; See docs/guide/glossary.md#frame-handle.
+;; One wrinkle: `reg-app-schema` is frame-local, so it needs a frame in
+;; scope. Call it bare at ns-load and you get :rf.error/no-frame-context.
+;; This example lives in the :rf/default frame, so we name that frame
+;; explicitly. See docs/guide/glossary.md#frame-handle.
 (with-frame :rf/default
   (rf/reg-app-schema [:messages]                   {:schema MessagesSlice}))

--- a/examples/reagent/websocket/views.cljs
+++ b/examples/reagent/websocket/views.cljs
@@ -1,27 +1,25 @@
 (ns websocket.views
-  "Views for the WebSocket example.
+  "The UI for the WebSocket example.
 
-   The UI is minimal so the connection machine is the visible thing: a
-   status indicator driven by the machine's tag union, a
-   connect/disconnect/drop trio of buttons, a send form, a
-   subscribe-and-request demo trio, and a scrolling list of received
-   messages.
+   Kept deliberately plain, so the connection machine is the thing your eye
+   lands on: a status pill driven by the machine's tags, a
+   connect/drop/disconnect trio, a send form, a subscribe-and-request demo
+   trio, and a scrolling inbox of what's arrived.
 
-   Two things to notice:
+   Two things worth watching for:
 
-   1. The status indicator branches on the connection machine's state
-      tags — `:websocket/connecting`, `:websocket/authenticating`,
+   1. The status pill never matches on state names. It reads tags —
+      `:websocket/connecting`, `:websocket/authenticating`,
       `:websocket/connected`, `:websocket/reconnecting`,
-      `:websocket/failed`. It reads them through this example's per-tag
-      subs (`:ws/connected?` and friends in `connection.cljs`, each a
-      `contains?` over the snapshot's `:tags` union). The view never needs
-      to know which leaf carries the `:connected` intent, only that the
-      tag is present: ask, don't tell.
-      See docs/machines/glossary.md#state-tag.
+      `:websocket/failed` — through this example's per-tag subs
+      (`:ws/connected?` and friends in `connection.cljs`, each a
+      `contains?` over the snapshot's `:tags` union). It doesn't care which
+      leaf carries the `:connected` intent, only that the tag is there.
+      Ask, don't tell. See docs/machines/glossary.md#state-tag.
 
-   2. The send form's `disabled` attribute is driven by the `:ws/connected?`
-      sub rather than a `cond` over the raw hierarchical `:state` vector —
-      same idea, friendlier ergonomics."
+   2. The send form disables itself off the `:ws/connected?` sub, not a
+      `cond` picking apart the raw `:state` vector. Same answer, far nicer
+      to read."
   (:require [re-frame.core :as rf]
             [re-frame.views]
             [websocket.messages]
@@ -32,17 +30,17 @@
 ;; STATUS — the machine's connection state, rendered
 ;; ============================================================================
 
-(reg-view ^{:doc "Reads the connection machine's state-tag union (through
-                  this example's per-tag subs) and renders a single status
-                  pill. The render priority — failed > reconnecting >
-                  connected > connecting > disconnected — collapses the
-                  multi-tag union to one visible word.
+(reg-view ^{:doc "Reads the machine's tag union (via this example's per-tag
+                  subs) and boils it down to one status word. A state can
+                  carry several tags at once, so a priority order —
+                  failed > reconnecting > connected > connecting >
+                  disconnected — decides which word wins.
 
-                  A sibling `:ws-reconnect-attempts` counter shows the
-                  machine's `:retries` slot directly, so a test can assert
-                  the reconnect counter advanced after a Drop click without
-                  having to catch the transient RECONNECTING window in the
-                  pill text."}
+                  Next to it sits a plain `:ws-reconnect-attempts` counter
+                  showing `:retries` directly. That's there for the tests:
+                  the RECONNECTING window can flash by too fast for a test
+                  to catch in the pill, but the counter just sits there
+                  showing it happened."}
           status-pill []
   (let [connected?      @(subscribe [:ws/connected?])
         authenticating? @(subscribe [:ws/authenticating?])
@@ -61,10 +59,10 @@
        :else           [:span.pill.disconnected   "DISCONNECTED"])
      (when err
        [:span.error {:data-testid "ws-error"} (str " — " (pr-str err))])
-     ;; Always-visible counter, independent of the pill's transient
-     ;; RECONNECTING window. A test asserts this advances after a Drop
-     ;; click, proving the reconnect machinery ran even when the cascade
-     ;; resolves too fast for the pill to catch.
+     ;; This counter is always on screen, no matter what the pill is doing.
+     ;; A test leans on it: it advances after a Drop, proving the reconnect
+     ;; machinery ran even when the cascade resolves too fast for the pill
+     ;; to ever show RECONNECTING.
      [:span.reconnect-attempts {:data-testid "ws-reconnect-attempts"}
       (str retries)]]))
 
@@ -72,22 +70,22 @@
 ;; LIFECYCLE BUTTONS
 ;; ============================================================================
 
-(reg-view ^{:doc "Connect / Drop (simulated transport error) / Disconnect
-                  (clean) — the three lifecycle actions the user can
-                  drive from the UI. The 'Drop' button calls into the
-                  mock-server seam to simulate a transport error;
-                  watch the status pill cascade through RECONNECTING
-                  → CONNECTING → AUTHENTICATING → CONNECTED."}
+(reg-view ^{:doc "The three lifecycle buttons: Connect, Drop (fake a
+                  transport error), and Disconnect (a clean goodbye). Drop
+                  is the fun one — it reaches into the mock-server seam to
+                  kill the socket, then sit back and watch the pill walk
+                  itself home: RECONNECTING → CONNECTING → AUTHENTICATING →
+                  CONNECTED, all on its own."}
           lifecycle-buttons []
   (let [connected?    @(subscribe [:ws/connected?])
         reconnecting? @(subscribe [:ws/reconnecting?])
         failed?       @(subscribe [:ws/failed?])
         any-active?   (or connected? reconnecting?)
-        ;; The Drop button calls a module-level mock-server seam that
-        ;; dispatches outside any render scope. Capture this view's frame
-        ;; handle at render time and hand it to the seam so the deferred
-        ;; dispatch carries the frame; a bare dispatch would raise
-        ;; :rf.error/no-frame-context.
+        ;; Drop calls a mock-server seam that ends up dispatching from
+        ;; outside any render scope. So we grab this view's frame handle now,
+        ;; while we're rendering and a frame is in scope, and pass it along —
+        ;; the deferred dispatch rides the frame in. Without it, a bare
+        ;; dispatch out there would raise :rf.error/no-frame-context.
         ;; See docs/guide/glossary.md#frame-handle.
         handle        (rf/frame-handle)]
     [:div.lifecycle
@@ -111,11 +109,11 @@
 ;; SEND FORM
 ;; ============================================================================
 
-(reg-view ^{:doc "Outbound message form. When :connected the message
-                  goes straight to the wire; while disconnected /
-                  reconnecting / connecting it's enqueued and flushed
-                  on the next :connected entry — the `Queued: N` text
-                  on the right tracks that."}
+(reg-view ^{:doc "The message form. Connected? Your message goes straight
+                  out. Not yet — disconnected, reconnecting, connecting?
+                  It's queued instead, to be flushed the moment you next
+                  reach :connected. The `Queued: N` text on the right is
+                  that backlog, counting down to zero."}
           send-form []
   (let [draft       @(subscribe [:messages/draft])
         connected?  @(subscribe [:ws/connected?])
@@ -141,18 +139,17 @@
 ;; SUBSCRIBE + REQUEST + SERVER-PUSH DEMO
 ;; ============================================================================
 
-(reg-view ^{:doc "Buttons that drive the three special-shaped paths:
-                  subscribe (subscriptions survive reconnects + the
-                  mock acks with a synthetic push), request-reply
-                  correlation, and 'trigger server push' (server →
-                  client server-pushed event)."}
+(reg-view ^{:doc "Three buttons for the three trickier paths: subscribe
+                  (the topic survives reconnects, and the mock acks with a
+                  synthetic push), request-reply (fire a request, watch the
+                  correlated reply come back), and 'trigger server push'
+                  (a message arriving server → client, unprompted)."}
           demo-buttons []
   (let [connected?  @(subscribe [:ws/connected?])
         last-reply  @(subscribe [:messages/last-reply])
-        ;; The server-push button calls a module-level mock-server seam
-        ;; that dispatches outside any render scope. Capture this view's
-        ;; frame handle and pass it so the deferred dispatch carries the
-        ;; frame (see `lifecycle-buttons`).
+        ;; Same story as `lifecycle-buttons`: the server-push button
+        ;; dispatches from outside the render, so capture the frame handle
+        ;; here and hand it along.
         handle      (rf/frame-handle)]
     [:div.demo-buttons
      [:button {:data-testid "ws-subscribe"
@@ -180,9 +177,10 @@
 ;; INBOX
 ;; ============================================================================
 
-(reg-view ^{:doc "Scrolling list of inbound messages — newest first.
-                  Every server push and every correlated reply is
-                  logged via :ws/handle-message into [:messages :received]."}
+(reg-view ^{:doc "The inbox: everything that's arrived, newest at the top.
+                  Server pushes and correlated replies alike all flow
+                  through :ws/handle-message into [:messages :received],
+                  and land here."}
           inbox []
   (let [msgs @(subscribe [:messages/received])]
     [:div.inbox

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -2,11 +2,13 @@
   "The counter, rendered on the UIx substrate.
 
    UIx is plain React with hooks, so this is the same app as the Reagent
-   counter with one thing changed: how a view reads state and gets hold of
-   `dispatch`. Everything above the view layer — the events and the
-   subscription — is substrate-agnostic and looks the same on any substrate.
+   counter with exactly one thing changed: how a view reads state and gets
+   hold of `dispatch`. Everything above the view layer — the events and the
+   subscription — knows nothing about React, so it reads the same on every
+   substrate. Put this file beside the Reagent counter and only the views
+   differ; that seam is the whole point of an adapter.
 
-   Shows:
+   What you'll see here:
 
      - `reg-event` / `reg-sub` — the same on every substrate
      - `rf/init!` with the UIx adapter
@@ -24,11 +26,12 @@
 
 ;; -- Events / subs -----------------------------------------------------------
 ;;
-;; An event handler is a pure function from coeffects (which carry the
-;; current app-db) and the event vector to an effect map. The `{:db …}` key
-;; means "replace app-db with this value"; the runtime commits it atomically
-;; at the end of the cascade. This block is pure data and logic with no
-;; mention of React, so it is identical on every substrate. See
+;; This is where the work happens, and it's all just data. An event handler
+;; is a pure function: hand it the coeffects (which carry the current app-db)
+;; and the event vector, and it hands back an effect map. The `{:db …}` key
+;; means "replace app-db with this value", and the runtime commits it
+;; atomically at the end of the cascade. Not a word about React in here — so
+;; this block is byte-for-byte the same on every substrate. See
 ;; `docs/guide/glossary.md#event-handler`.
 
 (rf/reg-event :counter/initialise
@@ -45,13 +48,14 @@
 
 ;; -- Views (the only substrate-specific code in this file) -------------------
 ;;
-;; UIx is plain React, so a view is a `defui` component that reads what it
-;; needs explicitly. `use-subscribe` is a hook that reads a subscription.
-;; `dispatch` comes off a `(rf/frame-handle)`: the handle captures the
-;; in-scope frame as a value, so the closed-over `dispatch` still targets
-;; this frame when a click fires later, on a stack with no frame in scope.
-;; Grab it at render time, while the frame is in scope. See
-;; `docs/guide/glossary.md#frame-handle`.
+;; Here's the one thing UIx does differently. It's plain React, so a view is
+;; a `defui` component that asks for what it needs out loud: `use-subscribe`
+;; is a hook that reads a subscription, and `dispatch` comes off a
+;; `(rf/frame-handle)`. The handle grabs the in-scope frame and freezes it
+;; into a value, so the `dispatch` we close over still knows which frame to
+;; target when a click fires much later — by which point we're deep in an
+;; event handler with no frame in scope to ask. So grab it at render time,
+;; while the frame is still around. See `docs/guide/glossary.md#frame-handle`.
 
 (defui counter-buttons []
   (let [count    (uix-adapter/use-subscribe [:counter/value])
@@ -66,33 +70,37 @@
 
 ;; -- Mount -------------------------------------------------------------------
 ;;
-;; The React root is held in an atom and created lazily inside `run`, not at
-;; ns-load. Loading a namespace must produce no DOM side effects, so that
-;; co-required example namespaces don't race `create-root` onto the shared
-;; `#app`. See examples/TESTING.md, "mount-isolation".
+;; The React root lives in an atom and is created lazily inside `run`, never
+;; at ns-load. The rule is that loading a namespace touches no DOM — so when
+;; several example namespaces get co-required, they don't all elbow each
+;; other trying to `create-root` onto the same shared `#app`. See
+;; examples/TESTING.md, "mount-isolation".
 
 (defonce react-root (atom nil))
 
-;; The whole frame lifecycle lives in one spot: the `frame-provider {:id
-;; app-frame …}` in `run` below. The first mount creates the app frame and
-;; runs its `:initial-events` once to seed app-db. From then on the
-;; `use-subscribe` hook and the render-time `(rf/frame-handle)` capture
-;; resolve to that frame. A later mount under the same `:id` (a hot reload)
-;; reuses the live frame and does not re-seed, so the counter keeps its
-;; value. Render a UIx tree with no provider and `use-subscribe` /
-;; `frame-handle` raise `:rf.error/no-frame-context` — the app must
-;; establish its frame. See `docs/guide/concepts/frames.md`.
+;; The whole frame lifecycle lives in one spot — the `frame-provider {:id
+;; app-frame …}` down in `run`. The first mount creates the app frame and
+;; runs its `:initial-events` once to seed app-db. After that, every
+;; `use-subscribe` hook and every render-time `(rf/frame-handle)` resolves to
+;; that frame. Mount again under the same `:id` — which is what a hot reload
+;; does — and it reuses the live frame without re-seeding, so the counter
+;; holds onto whatever you'd clicked it up to. Forget the provider entirely
+;; and `use-subscribe` / `frame-handle` raise `:rf.error/no-frame-context`:
+;; the runtime won't conjure a frame for you, so the app has to stand one up.
+;; See `docs/guide/concepts/frames.md`.
 ;;
-;; `app-frame` is just an id we pick. `:rf/default` is an ordinary frame id
-;; with no special status: the runtime never infers a frame, so we name one
-;; here and hand it to the provider. See
+;; `app-frame` is just an id we picked. `:rf/default` looks special but
+;; isn't — it's an ordinary frame id like any other. The runtime never
+;; guesses which frame you mean, so we name one here and hand it to the
+;; provider. See
 ;; `docs/guide/glossary.md#frame-identity-is-carried-not-found`.
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the reactive adapter for the process. Each adapter ns
-  ;; exports an `adapter` var; require the ns and pass that var. Call once
-  ;; at startup. See `docs/guide/glossary.md#init`.
+  ;; `init!` tells the runtime which reactive substrate to render through —
+  ;; once, for the whole process. Every adapter ns exports an `adapter` var;
+  ;; require the ns and hand that var over. Call it once at startup and
+  ;; forget about it. See `docs/guide/glossary.md#init`.
   (rf/init! uix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -1,26 +1,28 @@
 (ns dashboard-uix.core
-  "UIx design-led example — an analytics dashboard: a grid of metric
-   cards with sparklines and filter chips.
+  "A UIx analytics dashboard — a grid of metric cards with sparklines,
+   filter chips, and a time-range picker. Looks busy; it isn't.
 
-   The one idea: two independent controls each set a single value in
-   app-db, and one `reg-sub` reads both and computes the visible card
-   set as a pure function of them. The whole UI renders that one
-   projection — there is exactly one place where 'what's on screen' is
-   decided.
+   The whole app turns on one idea. Two controls each write a single
+   value into app-db, and one `reg-sub` reads both and computes the
+   visible card set as a pure function of them. So there's exactly one
+   place where 'what's on screen' gets decided, and everything you see
+   is just that one answer, rendered.
 
-   Demonstrates:
+   What to look at:
 
-     - `reg-sub` composing inputs: `:dashboard/visible-metrics` derives
-       from three input subscriptions, re-running when either control moves
+     - `:dashboard/visible-metrics` — one derived sub fed by three
+       inputs, re-running whenever a control moves
      - the derivation graph — base subs read app-db, derived subs read
-       other subs (the `:<-` syntax), views at the leaves
-     - UIx views (`defui`) reading subscriptions via `use-subscribe`
-     - inline SVG sparklines computed in pure CLJS — no chart library
-     - two re-deriving controls: filter chips (which cards show) and a
-       time-range picker (how many trailing points each sparkline draws,
-       plus the header label)
+       other subs (that's the `:<-` syntax), views sit at the leaves
+     - UIx views (`defui`) pulling subscriptions in through `use-subscribe`
+     - sparklines drawn as inline SVG from plain CLJS arithmetic — no
+       chart library
+     - two controls that re-derive the view: the filter chips (which
+       cards show) and the range picker (how many points each sparkline
+       draws, plus the header label)
 
-   The derivation graph is the core concept here; see the guide glossary
+   The derivation graph is the concept worth slowing down for; the
+   guide glossary has the full picture
    (../../../docs/guide/glossary.md#the-derivation-graph).
 
    The shared visual identity comes from examples/_shared/css/style.css."
@@ -34,11 +36,11 @@
 ;; ============================================================================
 
 (def initial-metrics
-  ;; Each metric carries a 14-point sparkline series. Numbers are
-  ;; hand-tuned for visual variety, not computed from real data.
+  ;; Six metrics, each carrying a 14-point sparkline series. The numbers
+  ;; are hand-tuned to look interesting, not pulled from anything real.
   ;;
-  ;; Values are bare integers: CLJS has no underscore-grouping (1_000)
-  ;; literal syntax.
+  ;; They're written as bare integers because CLJS has no
+  ;; underscore-grouping (1_000) literal — you read 142375 the hard way.
   [{:id :revenue   :label "Revenue"       :value 142375 :unit "$" :delta  0.084 :tag :money
     :series [108 112 117 121 119 124 128 132 130 135 138 140 142 142]}
    {:id :signups   :label "New signups"   :value 1286   :unit ""  :delta  0.121 :tag :money
@@ -58,10 +60,10 @@
    {:id :usage :label "Usage"}])
 
 (def ranges
-  ;; Time-range options. `:points` is how many of each metric's 14-point
-  ;; series the range windows in to (the last N) — so picking a range
-  ;; re-derives both the header label and every sparkline. Capped at the
-  ;; 14 points the seed data carries.
+  ;; The two time-range options. `:points` is the window: how many of the
+  ;; 14 points each sparkline keeps (the last N). Pick a range and you
+  ;; re-derive both the header label and every sparkline at once. Capped
+  ;; at 14, since that's all the seed data carries.
   [{:id :w7  :label "7 days"  :points 7}
    {:id :w14 :label "14 days" :points 14}])
 
@@ -69,12 +71,14 @@
 ;; EVENTS
 ;; ============================================================================
 
-;; Each handler is pure: (coeffects, event-vector) -> effect map. Each moves
-;; ONE value in app-db and stops. Turning "this tag is now off" into "these
-;; cards disappear" is the subscription's job, not the handler's.
+;; Three handlers, all pure: (coeffects, event-vector) -> effect map. Each
+;; one moves a SINGLE value in app-db and then stops. Notice what they don't
+;; do: turning "this tag is now off" into "these cards disappear" is the
+;; subscription's job, not the handler's. The handler just records the fact.
 
-;; Seed the whole dashboard in one write: the metrics plus the two control
-;; values (`:active-tags` a set — chips are multi-select; `:range` one id).
+;; Seed the whole dashboard in one write — the metrics, plus the two control
+;; values: `:active-tags` is a set (chips are multi-select) and `:range` is a
+;; single id.
 (rf/reg-event :dashboard/initialise
   (fn [{:keys [db]} _event]
     {:db {:dashboard/metrics      initial-metrics
@@ -103,19 +107,22 @@
 (rf/reg-sub :dashboard/range
   (fn [db _] (:dashboard/range db)))
 
-;; First derived sub: `:<-` declares this sub's input as ANOTHER sub, not
-;; app-db. Here we turn the stored range id into its full record (label,
-;; point count). Base subs above read app-db; these read other subs.
+;; Our first derived sub, and the place to meet `:<-`. It declares this
+;; sub's input as ANOTHER sub rather than app-db. The base subs above read
+;; app-db directly; from here on, subs read other subs. This one's job is
+;; small: take the stored range id and look up its full record (label,
+;; point count).
 (rf/reg-sub :dashboard/selected-range
   :<- [:dashboard/range]
   (fn [range-id _]
     (some #(when (= range-id (:id %)) %) ranges)))
 
-;; The heart of the example. One projection of two independent inputs: the
-;; active tag chips decide membership (`filter`); the selected range decides
-;; each sparkline's length (`take-last points`). Changing either input
-;; re-runs this — and ONLY this, plus anything downstream that moved — so the
-;; UI reads "what's on screen" from a single pure function.
+;; This is the heart of the example — the one function the whole UI reads to
+;; learn what's on screen. It folds two unrelated inputs into one answer: the
+;; active chips decide which cards belong (`filter`), and the selected range
+;; decides how long each sparkline is (`take-last points`). Move either
+;; control and the framework re-runs this — and only this, plus whatever
+;; downstream actually changed. One pure function, one source of truth.
 (rf/reg-sub :dashboard/visible-metrics
   :<- [:dashboard/metrics]
   :<- [:dashboard/active-tags]
@@ -130,12 +137,12 @@
 ;; ============================================================================
 
 (defn- sparkline-path
-  "Return an SVG <path> `d` string for the series, normalised into a
-   100×30 viewBox. Pure — used by `sparkline` below.
+  "Turn a series of numbers into an SVG <path> `d` string, scaled to fit a
+   100×30 viewBox. Pure in, pure out; `sparkline` below draws it.
 
-   Why polyline-via-path: a single <path d=\"M…L…L…\"> renders crisper
-   than <polyline> when the viewBox is small and the stroke is hair-thin
-   (the renderer doesn't anti-alias every vertex twice)."
+   Why a <path> and not a <polyline>: at this tiny size with a hair-thin
+   stroke, one `M…L…L…` path renders noticeably crisper. The renderer
+   isn't anti-aliasing every vertex twice, and your eye can tell."
   [series]
   (let [n     (count series)
         lo    (apply min series)
@@ -154,11 +161,11 @@
 ;; ============================================================================
 
 (defui sparkline [{:keys [series id]}]
-  ;; The card's <header> eyebrow, value, and label already carry the
-  ;; metric's name and value as text, so the sparkline only restates that
-  ;; visually. Mark it `aria-hidden="true"` so a screen reader skips it
-  ;; rather than announcing a nameless graphic on every card; the
-  ;; accessible name lives on the surrounding text.
+  ;; This graphic is decorative, so we hide it from assistive tech with
+  ;; `aria-hidden="true"`. The card's eyebrow, value, and label already say
+  ;; the metric's name and number in text; the sparkline only restates that
+  ;; visually. Left visible, a screen reader would announce a nameless
+  ;; graphic on every card — noise. The accessible name lives in the text.
   ($ :svg.dash-sparkline
      {:viewBox "0 0 100 30"
       :preserveAspectRatio "none"
@@ -173,19 +180,20 @@
                :vector-effect "non-scaling-stroke"})))
 
 (defui delta-badge [{:keys [delta good-when-positive?]}]
-  ;; The arrow follows the *good/bad* reading, not the raw sign, so a
-  ;; green badge never shows a downward arrow (and vice versa). For a
-  ;; down-is-good metric (latency, errors) a fall reads as ▲ green.
+  ;; The arrow points the way the news points, not the way the number does.
+  ;; So a green badge never shows a downward arrow, and vice versa. For a
+  ;; metric where down is good (latency, errors), a drop reads as ▲ green —
+  ;; which is exactly how a human would want to read it.
   (let [good? (if good-when-positive? (pos? delta) (neg? delta))
         pct   (-> delta (* 100) Math/abs (.toFixed 1))]
     ($ :span {:class (str "dash-delta " (if good? "is-good" "is-bad"))}
        (if good? "▲ " "▼ ") pct "%")))
 
 (defn- format-value
-  "Render a metric value for display. Integers are grouped with thousands
-   separators (`142375` → `142,375`); fractional values get two decimals
-   (`3.8` → `3.80`). `.toLocaleString` / `.toFixed` are zero-dependency
-   JS interop — no number-formatting library."
+  "Make a metric value presentable. Whole numbers get thousands separators
+   (`142375` → `142,375`); fractional ones get two decimals (`3.8` →
+   `3.80`). Both come free from JS interop — `.toLocaleString` and
+   `.toFixed` — so there's no number-formatting library to pull in."
   [value]
   (if (integer? value)
     (.toLocaleString value "en-US")
@@ -193,8 +201,8 @@
 
 (defui metric-card [{:keys [metric]}]
   (let [{:keys [id label value unit delta tag series]} metric
-        ;; `$` renders before the value (a prefix unit); `ms` / `%` render
-        ;; after. The flag names the placement, decoupled from the tag.
+        ;; Currency sits before the number ($142,375); everything else sits
+        ;; after (24 ms, 0.42 %). The flag just names where the unit goes.
         prefix-unit? (= "$" unit)
         perf?        (= :perf tag)]
     ($ :article.dash-card
@@ -214,12 +222,12 @@
        ($ sparkline {:series series :id id}))))
 
 (defui filter-chips []
-  ;; MULTI-select toggles: any subset of tags can be on at once. Each chip
-  ;; is a real <button> carrying `aria-pressed` — the value assistive tech
-  ;; reads as the on/off state (the `is-on` CSS class is presentation only).
-  ;; The chips share a `role="group"` with an `aria-label` so a screen
-  ;; reader announces them as one labelled set of toggles, not three loose
-  ;; buttons.
+  ;; These are MULTI-select toggles — any subset of tags can be on at once.
+  ;; Each chip is a real <button> carrying `aria-pressed`, which is the
+  ;; state assistive tech actually reads; the `is-on` CSS class is just
+  ;; paint. Wrapping the row in a `role="group"` with an `aria-label` lets a
+  ;; screen reader announce one labelled set of toggles instead of three
+  ;; loose buttons.
   (let [active-tags (uix-adapter/use-subscribe [:dashboard/active-tags])
         dispatch    (:dispatch (rf/frame-handle))]
     ($ :div.dash-chips {:role "group" :aria-label "Filter metrics by category"}
@@ -235,10 +243,10 @@
               label))))))
 
 (defn- radio-key->step
-  "Map a keydown event's key to the radio-group navigation step, or nil
-   when the key is not a navigation key. The WAI-ARIA radio-group pattern
-   moves selection on the four arrow keys: Right/Down advance, Left/Up
-   retreat (both axes, because the group can wrap either way)."
+  "Read a keydown into a navigation step (+1, -1) for the radio group, or
+   nil if the key isn't one we steer with. The WAI-ARIA radio-group pattern
+   moves selection on all four arrows: Right/Down go forward, Left/Up go
+   back. Both axes, because the group wraps either way."
   [k]
   (case k
     ("ArrowRight" "ArrowDown") 1
@@ -246,22 +254,23 @@
     nil))
 
 (defui range-picker []
-  ;; SINGLE-select mode control: exactly one range is active. This is the
-  ;; real WAI-ARIA radio-group idiom — not just the roles, but the
-  ;; keyboard contract a radio group promises:
+  ;; Where the chips were multi-select, this is SINGLE-select: exactly one
+  ;; range is active. So it's a radio group — and we do the real WAI-ARIA
+  ;; idiom, not just the roles but the keyboard contract a radio group
+  ;; quietly promises:
   ;;
-  ;;   - `role="radiogroup"` on the row, `role="radio"` + `aria-checked`
-  ;;     on each chip, so it announces as a one-of-N choice.
-  ;;   - ROVING TABINDEX: exactly the checked radio is in the tab order
-  ;;     (`tabIndex 0`); the rest are `tabIndex -1`. Tab lands on the
-  ;;     selection, not on each chip in turn.
-  ;;   - ARROW-KEY NAVIGATION: Left/Up and Right/Down move the selection
-  ;;     (with wrap). Per the pattern, selection FOLLOWS focus in a radio
-  ;;     group, so an arrow both dispatches the range change and moves
-  ;;     DOM focus to the newly-selected chip.
+  ;;   - `role="radiogroup"` on the row, plus `role="radio"` + `aria-checked`
+  ;;     on each chip, so the whole thing announces as a one-of-N choice.
+  ;;   - ROVING TABINDEX: only the checked radio is in the tab order
+  ;;     (`tabIndex 0`), the rest are `tabIndex -1`. Tab lands on the current
+  ;;     selection, not on every chip in turn.
+  ;;   - ARROW-KEY NAVIGATION: Left/Up and Right/Down move the selection,
+  ;;     with wrap. The catch is that in a radio group selection FOLLOWS
+  ;;     focus, so an arrow has to do two things at once — dispatch the range
+  ;;     change AND move DOM focus to the chip it just picked.
   ;;
-  ;; The `is-on` class stays presentation-only — `aria-checked` is the
-  ;; state assistive tech reads.
+  ;; As with the chips, `is-on` is paint only; `aria-checked` is the state
+  ;; assistive tech reads.
   (let [active-range-id (uix-adapter/use-subscribe [:dashboard/range])
         dispatch        (:dispatch (rf/frame-handle))
         n               (count ranges)
@@ -273,9 +282,9 @@
                           (let [idx (mod idx n)
                                 {:keys [id]} (nth ranges idx)]
                             (dispatch [:dashboard/set-range id])
-                            ;; Selection follows focus: move DOM focus to
-                            ;; the chip we just selected so the visible
-                            ;; focus ring tracks the radio state.
+                            ;; Selection follows focus, so move the DOM focus
+                            ;; onto the chip we just picked — that keeps the
+                            ;; visible focus ring sitting on the live radio.
                             (when (exists? js/document)
                               (some-> (js/document.querySelector
                                         (str "[data-testid=\"dashboard-range-"
@@ -288,8 +297,8 @@
              ($ :button {:key id
                          :type "button"
                          :role "radio"
-                         ;; Roving tabindex: only the checked radio is
-                         ;; tabbable; arrows move within the group.
+                         ;; Roving tabindex in one line: only the checked
+                         ;; radio is tabbable; arrows do the rest.
                          :tabIndex (if (= idx active-idx) 0 -1)
                          :class (str "dash-chip " (when on? "is-on"))
                          :aria-checked (if on? "true" "false")
@@ -327,27 +336,29 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`,
-;; not at ns-load. ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`
-;; (examples/TESTING.md, Example mount-isolation convention).
+;; We stash the React root in an atom and create it lazily inside `run`,
+;; never at ns-load. The rule: loading this namespace must touch no DOM, so
+;; that other example namespaces loaded alongside it don't race each other
+;; to `create-root` onto the shared `#app` node (examples/TESTING.md,
+;; Example mount-isolation convention).
 (defonce react-root (atom nil))
 
-;; The frame id this app runs under. The `frame-provider` in `run` creates
-;; this frame, seeds its app-db, and scopes it into React context so
-;; `use-subscribe` and `(rf/frame-handle)` resolve to it. See the guide
-;; glossary (../../../docs/guide/glossary.md#frame-provider).
+;; The id of the frame this app lives in. The `frame-provider` down in `run`
+;; creates it, seeds its app-db, and scopes it into React context — which is
+;; how `use-subscribe` and `(rf/frame-handle)` find it. The guide glossary
+;; covers frame-provider (../../../docs/guide/glossary.md#frame-provider).
 (def app-frame :rf/default)
 
 (defn run []
-  ;; `init!` installs the UIx adapter so re-frame2 knows how to render.
+  ;; `init!` installs the UIx adapter — this is how re-frame2 learns which
+  ;; substrate to render through.
   (rf/init! uix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
-    ;; `{:id …}` creates the app frame on first mount and runs
-    ;; `:initial-events` once to seed app-db. A hot reload reuses the same
-    ;; frame without re-seeding.
+    ;; Passing `{:id …}` creates the app frame on the first mount and fires
+    ;; `:initial-events` once to seed app-db. Save and hot-reload, and it
+    ;; reuses the same frame untouched — no re-seeding, so your state sticks.
     (uix-dom/render-root
       ($ uix-adapter/frame-provider {:id app-frame
                                      :initial-events [[:dashboard/initialise]]}

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -1,20 +1,21 @@
 (ns login-uix.core
-  "UIx variant of the login example — the same feature on a different substrate.
+  "A login flow, rendered through UIx. The same feature lives on Reagent and
+   Helix too, and that's exactly the point of this file: watch how little has
+   to change to move between them.
 
-   Everything below the views is substrate-agnostic and identical to
-   examples/reagent/login: the login state machine, the schemas, and the
-   managed-HTTP effect. Only the view layer differs. Here views are UIx
-   `defui` components that read subscriptions with the `use-subscribe` hook;
-   the Reagent twin uses `reg-view`. The file shows how narrow the substrate
-   boundary is — the machine, schemas, and effects don't change at all.
+   Everything below the views — the state machine, the schemas, the
+   managed-HTTP effect — is substrate-agnostic and byte-for-byte the same as
+   examples/reagent/login. Only the views differ. Here a view is a UIx `defui`
+   that reads subscriptions through the `use-subscribe` hook; the Reagent twin
+   reaches for `reg-view`. Same data, different doorway.
 
-   The machine's states carry tags (`:auth/busy`, `:auth/authenticated`,
-   `:auth/locked`), and views read them via the `:rf/machine-has-tag?`
-   framework sub. The terminal `:locked-out` state renders a non-interactive
-   locked-account panel.
+   The machine tags a few of its states — `:auth/busy`, `:auth/authenticated`,
+   `:auth/locked` — and views ask about them through the `:rf/machine-has-tag?`
+   framework sub. When the flow finally gives up, the terminal `:locked-out`
+   state swaps the form for a dead-end locked-account panel.
 
-   For the substrate-boundary mechanics — `use-subscribe`, `frame-handle`,
-   `frame-provider`, and what stays the same across React wrappers — see
+   For the boundary mechanics — `use-subscribe`, `frame-handle`,
+   `frame-provider`, and what stays put across React wrappers — see
    docs/guide/how-to/use-uix-helix-or-slim.md."
   (:require [uix.core :as uix :refer [$ defui]]
             [uix.dom  :as uix-dom]
@@ -23,8 +24,9 @@
             [re-frame.schemas]
             [re-frame.machines]
             [re-frame.http.managed]
-            ;; :fx-overrides redirect :rf.http/managed to :rf.http/managed-canned-*;
-            ;; the canned-stub fx ids register from re-frame.http.test-support.
+            ;; Required for its side effect: it registers the canned-success /
+            ;; canned-failure fx ids our demo stub leans on. Without this here,
+            ;; those ids wouldn't exist and the stub would have nothing to call.
             [re-frame.http.test-support]
             [re-frame.adapter.uix :as uix-adapter]))
 
@@ -32,39 +34,40 @@
 ;; SCHEMAS
 ;; ============================================================================
 
-;; Shape of valid login credentials: an email and a min-8 password. The
-;; password only ever rides this event-arg schema and the HTTP body — it is
-;; never written to app-db. The request body that carries it is scrubbed from
-;; traces by `:sensitive? true` on the managed-HTTP request below
-;; (docs/guide/how-to/keep-secrets-out-of-traces.md). Same schema across
-;; reagent/login + helix.
+;; What valid credentials look like: an email and a password of at least 8
+;; characters. The password is a careful little traveller — it rides only this
+;; schema and the HTTP body, and is never written to app-db. The request body
+;; that carries it gets scrubbed from traces by `:sensitive? true` on the
+;; managed-HTTP request below (docs/guide/how-to/keep-secrets-out-of-traces.md).
+;; The same schema guards reagent/login and helix.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
    [:password [:string {:min 8}]]])
 
-;; Outer event-vector schema for the :auth.login/flow machine handler. The
-;; :submit sub-event is validated STRICTLY against `Credentials`;
-;; framework-internal sub-events (:dismiss, :success, :failure) admit a
-;; framework-controlled tail.
+;; The schema for the whole event vector the :auth.login/flow machine handles.
+;; It earns its keep by validating credentials at the door: a `:submit` is
+;; checked strictly against `Credentials`, while the framework's own sub-events
+;; (:dismiss, :success, :failure) get a more relaxed welcome.
 ;;
-;; The :submit branch is a `:tuple` (NOT `:cat`): the outer `:cat` consumes
-;; the nested sub-event vector as a SINGLE element, so the branch must match
-;; that one element AS a vector. A `:cat` branch applies sequence-regex
-;; semantics and would re-admit a `:submit` whose `Credentials` failed. With
-;; the strict `:tuple`, a short-password or bad-email submit is rejected at
-;; the `:where :event` boundary BEFORE the machine transitions or issues the
-;; login HTTP effect (docs/guide/how-to/validate-with-schemas.md, §"Put a
-;; schema on the event too").
+;; One subtlety worth pausing on: the :submit branch is a `:tuple`, not a
+;; `:cat`. The outer `:cat` swallows the nested sub-event as a single element,
+;; so the branch has to match that element *as a vector*. A `:cat` here would
+;; apply sequence-regex semantics and quietly wave through a `:submit` whose
+;; `Credentials` had already failed — exactly the leak we're trying to plug.
+;; With the strict `:tuple`, a short password or a bad email bounces off the
+;; `:where :event` boundary before the machine transitions or fires off the
+;; login request (docs/guide/how-to/validate-with-schemas.md, §"Put a schema
+;; on the event too").
 ;;
-;; The trailing `[:? :any]` admits the managed-HTTP reply payload. The
-;; framework appends the reply map (`{:kind ... :value ...}` /
-;; `{:kind ... :failure ...}`) as the LAST arg of the explicit `:on-success`
-;; / `:on-failure` event vector, so the delivered reply is
-;; `[:auth.login/flow [:auth.login/success] <payload>]` — three top-level
-;; elements. Without the optional trailing slot the `:cat` rejects every
-;; reply and the boundary validation fails before the machine handler runs.
-;; See docs/guide/glossary.md#the-uniform-reply.
+;; The trailing `[:? :any]` is there to catch the managed-HTTP reply. The
+;; framework tacks the reply map (`{:kind ... :value ...}` or
+;; `{:kind ... :failure ...}`) onto the end of the `:on-success` / `:on-failure`
+;; vector, so what actually arrives is
+;; `[:auth.login/flow [:auth.login/success] <payload>]` — three elements deep.
+;; Leave off that optional slot and the `:cat` rejects every reply, failing
+;; validation before the handler ever runs. See
+;; docs/guide/glossary.md#the-uniform-reply.
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
@@ -73,29 +76,30 @@
      [:* :any]]]
    [:? :any]])
 
-;; The machine's `[:schemas :data]` validates the machine's `:data` slot ONLY —
-;; the user-domain extended state `{:attempts ... :error ...}` — NOT the whole
-;; `{:state ... :data ...}` snapshot. It sits as a top-level key on the machine
-;; spec map beside `:data`, and the framework checks it after every transition
-;; and at boot, emitting `:rf.error/schema-validation-failure :where
-;; :machine-data` and rolling the macrostep back on a violation. The `:state`
-;; slot is validated structurally at registration (an unknown target fails
-;; registration), so it is not this schema's job. See
-;; docs/guide/how-to/validate-with-schemas.md (the machine `:data` schema).
+;; This schema watches the machine's `:data` slot — the user-domain extended
+;; state `{:attempts ... :error ...}` — and nothing else. It does not see the
+;; whole `{:state ... :data ...}` snapshot; just the `:data` half. Hang it on
+;; the machine spec map (as `[:schemas :data]`, below) and the framework
+;; re-checks it after every transition and at boot. A violation raises
+;; `:rf.error/schema-validation-failure :where :machine-data` and rolls the
+;; macrostep back, so a bad `:data` value never sticks. The `:state` slot looks
+;; after itself — an unknown target state fails at registration — so it's not
+;; this schema's concern. See docs/guide/how-to/validate-with-schemas.md (the
+;; machine `:data` schema).
 (def AuthLoginData
   [:map
    [:attempts {:default 0} :int]
    [:error    [:maybe :string]]])
 
-;; The machine's `:data` is validated by its own `[:schemas :data]` (attached to
-;; the spec map below). Machine snapshots live in runtime-db, not app-db, so a
-;; `reg-app-schema` would not see them — app schemas validate the app-db
-;; partition only.
+;; Why a dedicated machine schema and not a `reg-app-schema`? Because machine
+;; snapshots live in runtime-db, not app-db, and app schemas only ever look at
+;; the app-db partition. A `reg-app-schema` would simply never see this data.
 
 ;; ============================================================================
 ;; FX
 ;; ============================================================================
 
+;; The one password the fake server accepts. Anything else gets a 401.
 (def good-password "correct-horse")
 
 (rf/reg-fx :auth.session/store
@@ -106,12 +110,13 @@
       (.setItem ls "auth/token" token))))
 
 (rf/reg-fx :auth.login.demo/managed-stub
-  {:doc       "Demo override for `:rf.http/managed`. Delegates to the
-               framework-shipped canned-success / canned-failure fxs with
-               `:after-ms`, so the framework defers the reply via
-               `:dispatch-later` (50 ms): observable in the tape and
-               time-travel-safe, NOT a raw `js/setTimeout`. Same stub as the
-               Reagent and Helix examples."
+  {:doc       "A fake login server, so the demo runs with no backend. Stands in
+               for `:rf.http/managed` and hands off to the framework's own
+               canned-success / canned-failure fxs with `:after-ms` set, so the
+               reply comes back through `:dispatch-later` after 50 ms. That
+               little delay is deliberate: a `:dispatch-later` shows up in the
+               tape and survives time-travel, where a raw `js/setTimeout` would
+               do neither. Same stub the Reagent and Helix examples use."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -141,9 +146,9 @@
 ;; STATE MACHINE
 ;; ============================================================================
 
-;; The login flow's machine spec. `[:schemas :data]` validates the `:data`
-;; slot (`{:attempts ... :error ...}`), NOT the whole snapshot — see the note
-;; on `AuthLoginData` above.
+;; The login flow itself, as a state machine. `[:schemas :data]` keeps an eye
+;; on the `:data` slot (`{:attempts ... :error ...}`) — just that slot, not the
+;; whole snapshot — as the note on `AuthLoginData` above explains.
 (def auth-login-machine
   {:initial :idle
    :data    {:attempts 0 :error nil}
@@ -160,10 +165,10 @@
     :issue-request
     (fn [{[_ creds] :event}]
       {:fx [[:rf.http/managed
-             ;; `:sensitive? true` redacts the request body (which carries the
-             ;; `:password`) from every `:rf.http/*` trace event — the
-             ;; per-request wire scrub. See
-             ;; docs/guide/how-to/keep-secrets-out-of-traces.md.
+             ;; `:sensitive? true` is the per-request wire scrub: it redacts
+             ;; this request body — which is carrying the `:password` — from
+             ;; every `:rf.http/*` trace event, so the secret never lands in the
+             ;; tape. See docs/guide/how-to/keep-secrets-out-of-traces.md.
              {:request    {:method :post
                            :url    "/api/login"
                            :body   creds
@@ -180,12 +185,12 @@
                  (assoc :error (or (:message failure) "Login failed.")))})
 
     :lock-account
-    ;; Fire-and-forget telemetry beacon: the lockout POST wants no reply
-    ;; folded back into the machine. `:on-success nil` / `:on-failure nil`
-    ;; silence both reply branches. Without them the default reply target
-    ;; would dispatch `[:auth.login/flow {:rf/reply ...}]` — a map in the
-    ;; sub-event slot that `AuthLoginEvent` rejects, stranding noise after
-    ;; lockout. See docs/resources/glossary.md#managed-http.
+    ;; A fire-and-forget telemetry beacon: we POST the lockout and don't care
+    ;; what comes back. `:on-success nil` / `:on-failure nil` hush both reply
+    ;; branches. Leave them out and the default reply would dispatch
+    ;; `[:auth.login/flow {:rf/reply ...}]` — a map where `AuthLoginEvent`
+    ;; expects a sub-event, so it gets rejected, leaving stray noise rattling
+    ;; around after lockout. See docs/resources/glossary.md#managed-http.
     (fn [_]
       {:fx [[:rf.http/managed
              {:request    {:method :post :url "/api/auth/lock"}
@@ -202,10 +207,9 @@
                               :action :clear-error}}}
 
     :submitting
-    ;; :auth/busy tag — views query
-    ;; [:rf/machine-has-tag? :auth.login/flow :auth/busy] to disable
-    ;; inputs and re-label the submit button while the request is in
-    ;; flight.
+    ;; The :auth/busy tag is how the view knows a request is in flight. It asks
+    ;; [:rf/machine-has-tag? :auth.login/flow :auth/busy] and, while that's
+    ;; true, disables the inputs and relabels the submit button.
     {:tags  #{:auth/busy}
      :entry :issue-request
      :on    {:auth.login/success {:target :authed
@@ -217,36 +221,36 @@
                                    :action :lock-account}]}}
 
     :error-shown
-    ;; Direct retry from :error-shown re-enters :submitting and must clear the
-    ;; prior `:error` first — otherwise the obsolete failure message stays
-    ;; visible (the view renders `:auth.login/error` whenever non-nil) as if it
-    ;; still applied to the request now in flight. Same `:clear-error` action as
-    ;; the :idle entry transition.
+    ;; Retrying straight from :error-shown drops us back into :submitting, and
+    ;; we have to wipe the old `:error` on the way through. If we don't, the
+    ;; stale failure message hangs around (the view shows `:auth.login/error`
+    ;; whenever it's non-nil) looking for all the world like it belongs to the
+    ;; request now in flight. Same `:clear-error` action the :idle exit uses.
     {:on {:auth.login/dismiss {:target :idle}
           :auth.login/submit  {:target :submitting
                                :action :clear-error}}}
 
     :authed
-    ;; :auth/authenticated tag — the banner swaps to "Welcome!" once
-    ;; the flow reaches this terminal state.
+    ;; Journey's end, the happy way. The :auth/authenticated tag tells the
+    ;; banner to swap over to "Welcome!" once the flow lands here.
     {:tags #{:auth/authenticated}
      :meta {:terminal? true}}
 
     :locked-out
-    ;; :auth/locked tag — after the fourth failed submit the flow lands
-    ;; in this terminal state. Views query
-    ;; [:rf/machine-has-tag? :auth.login/flow :auth/locked] to swap the
-    ;; form for a locked-account panel and refuse further submits. A
-    ;; terminal lockout must be visible and non-interactive, not a live
-    ;; form.
+    ;; Journey's end, the unhappy way. After one failed submit too many the
+    ;; flow comes to rest here, tagged :auth/locked. The view asks
+    ;; [:rf/machine-has-tag? :auth.login/flow :auth/locked] and, when it's
+    ;; true, retires the form for a locked-account panel that takes no more
+    ;; submits. A dead end should look like one — visible and inert, not a form
+    ;; that's quietly stopped working.
     {:tags #{:auth/locked}
      :meta {:terminal? true}}}})
 
-;; Register the machine. This flow validates on two surfaces: the machine's
-;; `:data` slot via `[:schemas :data]`, and the dispatched event vector via
-;; `:schema` (`AuthLoginEvent`, the `:where :event` boundary). The opts map
-;; carries the event `:schema` alongside the machine spec. See
-;; docs/machines/glossary.md#machine.
+;; Register the machine. Notice it's guarded on two fronts: `[:schemas :data]`
+;; watches the `:data` slot from the inside, and `:schema` (our
+;; `AuthLoginEvent`) checks every dispatched event vector at the `:where :event`
+;; boundary from the outside. The opts map carries that event `:schema`
+;; alongside the spec. See docs/machines/glossary.md#machine.
 (rf/reg-machine :auth.login/flow
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema AuthLoginEvent}
@@ -256,31 +260,34 @@
 ;; FORM SLICE  (the form pattern — substrate-agnostic)
 ;; ============================================================================
 ;;
-;; The FORM-SLICE events below are the other half of the "machine + slice"
-;; form pattern. The SLICE owns the DRAFT — what the user is currently typing —
-;; at the app-db path [:auth :login-form]; the MACHINE owns submit/auth STATUS.
-;; A form's draft is application state, so it lives in app-db (projected via
-;; subs, mutated via events), not in a view-local atom or hook. Inputs are
-;; CONTROLLED: `:value` reads the draft sub, `:on-change` dispatches
-;; `:auth.login/edit-field`. The recipe — slice shape, the seven standard form
-;; events, the touched-or-submitted error-visibility rule — is in
-;; docs/guide/how-to/build-a-form.md.
+;; A login form is really two jobs wearing one coat, and we split them
+;; cleanly. The slice owns the draft — whatever the user is typing right now —
+;; at the app-db path [:auth :login-form]. The machine (above) owns the status:
+;; are we submitting, did it work, are we locked out. That's the "machine +
+;; slice" form pattern.
 ;;
-;; This whole block — slice defaults + form events + (below) the draft/slice
-;; subs — is the SUBSTRATE-AGNOSTIC layer: it is identical across
-;; examples/reagent/login, examples/uix/login_uix, and
-;; examples/helix/login_helix. Only the view syntax varies across the three.
+;; The draft is application state like any other, so it lives in app-db — read
+;; through subs, changed through events — never squirrelled away in a view-local
+;; atom or hook. The inputs are controlled: each `:value` reads the draft sub,
+;; each `:on-change` dispatches `:auth.login/edit-field`. The full recipe (slice
+;; shape, the seven standard form events, the touched-or-submitted rule for when
+;; to show errors) lives in docs/guide/how-to/build-a-form.md.
+;;
+;; Everything from here down to the subs — slice defaults, form events, the
+;; draft/slice subs — is the substrate-agnostic layer. It's identical across
+;; examples/reagent/login, examples/uix/login_uix, and examples/helix/login_helix.
+;; Only the view syntax tells the three apart.
 
-;; The login form's default (empty) draft. The draft's value shape is
-;; `Credentials` (email regex + min-8 password) — the same schema the
-;; machine's `:submit` boundary enforces.
+;; An empty draft to start from. Its shape is `Credentials` (email regex +
+;; min-8 password) — the very same schema the machine's `:submit` boundary
+;; enforces, so the form and the machine agree on what "valid" means.
 (def login-form-defaults {:email "" :password ""})
 
-;; Seed the slice to its standard shape: empty `:draft`, `:status :idle`.
-;; Runs once via the frame-provider's `:initial-events`.
+;; Lay down the slice in its starting shape: empty `:draft`, `:status :idle`,
+;; and the rest. Fires once, via the frame-provider's `:initial-events`.
 (rf/reg-event :auth.login/initialise-form
-  {:doc "Seed the login-form slice at [:auth :login-form] to its standard
-         shape (empty draft, :idle status)."}
+  {:doc "Seed the login-form slice at [:auth :login-form] to its starting shape
+         (empty draft, :idle status)."}
   (fn handler-login-form-initialise [{:keys [db]} _]
     {:db (assoc-in db [:auth :login-form]
                    {:draft             login-form-defaults
@@ -291,10 +298,10 @@
                     :touched           #{}
                     :submit-error      nil})}))
 
-;; The user changed a single field. Update `:draft` and add the field to
-;; `:touched`. This is the ONLY thing an input's `:on-change` does — it never
-;; sets view-local state. The `:schema` rejects a malformed edit-field vector
-;; at the `:where :event` boundary.
+;; The user touched a field. Write the new value into `:draft` and remember the
+;; field is now `:touched`. This is the whole job of an input's `:on-change` —
+;; it never reaches for view-local state. The `:schema` turns away any
+;; malformed edit-field vector at the `:where :event` boundary.
 (rf/reg-event :auth.login/edit-field
   {:doc    "Controlled-input edit: write one field into the login-form draft
             and mark it touched."
@@ -304,25 +311,25 @@
              (assoc-in  [:auth :login-form :draft field] value)
              (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 
-;; Submit. Reads the draft out of the slice, latches `:submit-attempted?`,
-;; flips the slice `:status` to `:submitting`, and dispatches the draft INTO
-;; the machine — the only point the draft crosses into the machine (and is
-;; validated against `Credentials` at the machine's `:where :event` boundary).
-;; The machine, not the slice, then owns the in-flight / authed / error /
-;; locked status; the slice `:status` mirror keeps the slice a conformant
-;; form-pattern shape.
+;; Submit. Pull the draft out of the slice, latch `:submit-attempted?`, flip the
+;; slice `:status` to `:submitting`, and hand the draft to the machine. That
+;; hand-off is the single place the draft ever crosses into the machine, and the
+;; machine's `:where :event` boundary checks it against `Credentials` on the way
+;; in. From there the machine — not the slice — owns the real story: in flight,
+;; authed, errored, locked. The slice's `:status` is just a mirror, kept around
+;; so the slice stays a tidy form-pattern shape.
 ;;
-;; Secret-field hygiene: the handler reads the password off the draft and hands
-;; it to the machine, then CLEARS `[:draft :password]` in the same commit —
-;; once the request is in flight the secret has done its job, so it does not
-;; sit in durable app-db waiting for the next snapshot / recorder capture. The
-;; password's only off-box path is the HTTP request body (scrubbed by the
-;; per-request `:sensitive? true` flag); it is never written to `:submitted` or
-;; the machine `:data`. See docs/guide/how-to/keep-secrets-out-of-traces.md.
+;; And a word on the password. We read it off the draft, give it to the machine,
+;; then clear `[:draft :password]` in the very same commit. Once the request is
+;; on its way the secret has done its job, and there's no reason to leave it
+;; sitting in app-db where the next snapshot or recording would scoop it up. Its
+;; only trip off the box is inside the HTTP request body (scrubbed by that
+;; `:sensitive? true` flag), and it's never written to `:submitted` or the
+;; machine's `:data`. See docs/guide/how-to/keep-secrets-out-of-traces.md.
 (rf/reg-event :auth.login/submit-form
-  {:doc "Submit the login form: read the draft from the slice, dispatch it
-         into the :auth.login/flow machine's :submit sub-event, and clear the
-         password out of the draft (secret-field hygiene)."}
+  {:doc "Submit the login form: read the draft from the slice, hand it to the
+         :auth.login/flow machine's :submit sub-event, and clear the password
+         out of the draft (secret-field hygiene)."}
   (fn handler-login-form-submit [{:keys [db]} _]
     (let [draft (get-in db [:auth :login-form :draft])]
       {:db (-> db
@@ -331,7 +338,7 @@
                (assoc-in [:auth :login-form :draft :password] ""))
        :fx [[:dispatch [:auth.login/flow [:auth.login/submit draft]]]]})))
 
-;; Reset the slice back to its initial (empty, :idle) shape.
+;; Wipe the slate: put the slice back to its empty, :idle starting shape.
 (rf/reg-event :auth.login/reset-form
   {:doc "Clear the login-form slice back to empty defaults / :idle."}
   (fn handler-login-form-reset [{:keys [db]} _]
@@ -348,13 +355,14 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 ;;
-;; The machine snapshot lives in runtime-db. These named subs project out the
-;; convenient pieces. The "in :submitting?" / "in :authed?" predicates live as
-;; the `:rf/machine-has-tag?` framework sub in views below — see
+;; The machine keeps its snapshot in runtime-db; these named subs reach in and
+;; pick out the pieces a view actually wants. The "are we busy?" / "are we in?"
+;; style questions don't need their own subs — views ask the
+;; `:rf/machine-has-tag?` framework sub directly, further down. See
 ;; docs/machines/glossary.md#state-tag.
 
-;; Machine snapshots are durable runtime-db state — read them through the
-;; framework `:rf/machine` sub.
+;; The whole snapshot is durable runtime-db state; the framework `:rf/machine`
+;; sub is the way in. We layer on top of it to read just the current state.
 (rf/reg-sub :auth.login/state
   :<- [:rf/machine :auth.login/flow]
   (fn [snapshot _] (:state snapshot)))
@@ -365,28 +373,30 @@
 
 ;; --- Form-slice subs (substrate-agnostic) ----------------------------------
 ;;
-;; The login-form slice lives at app-db [:auth :login-form]. The view reads
-;; the DRAFT through `:auth.login/draft` and binds each input's `:value` to it
-;; — controlled inputs. The per-field-error sub follows the form-pattern
-;; error-visibility rule (touched OR submit-attempted?). These subs are part of
-;; the layer shared identically across the three substrate examples.
+;; The slice sits at app-db [:auth :login-form]. The view reads the draft
+;; through `:auth.login/draft` and pins each input's `:value` to it — that's
+;; what makes them controlled. The per-field-error sub follows the form
+;; pattern's rule for when an error is allowed to show: once the field is
+;; touched, or once the user has tried to submit. Like the events above, these
+;; subs are shared verbatim across the three substrate examples.
 
 (rf/reg-sub :auth.login/form-slice
-  {:doc "The whole login-form slice at [:auth :login-form]."}
+  {:doc "The whole login-form slice at [:auth :login-form] — the root the other
+         form subs branch off."}
   (fn sub-auth-login-form-slice [db _]
     (get-in db [:auth :login-form])))
 
 (rf/reg-sub :auth.login/draft
-  {:doc "The login-form draft — what the user has currently typed. Each input
-         binds its :value to a field of this map (controlled inputs)."}
+  {:doc "The draft — what the user has typed so far. Each input binds its :value
+         to a field of this map, which is what makes the inputs controlled."}
   :<- [:auth.login/form-slice]
   (fn sub-auth-login-draft [slice _]
     (:draft slice)))
 
 (rf/reg-sub :auth.login/field-error
-  {:doc "Per-field validation error for the login form. Reveal a field's error
-         once it is :touched OR once the form has had its first submit click.
-         See docs/guide/how-to/build-a-form.md, step 3."}
+  {:doc "A field's validation error — but only when it's polite to show one:
+         once the field has been touched, or once the user has taken their first
+         run at submitting. See docs/guide/how-to/build-a-form.md, step 3."}
   :<- [:auth.login/form-slice]
   (fn sub-auth-login-field-error [slice [_ field]]
     (when (or (:submit-attempted? slice)
@@ -397,16 +407,18 @@
 ;; VIEWS  (UIx — defui + use-subscribe)
 ;; ============================================================================
 ;;
-;; This is the whole substrate seam. A UIx view is a plain `defui`: it reads
-;; each subscription through the `use-subscribe` hook and gets `dispatch` off
-;; `(rf/frame-handle)`. The Reagent twin instead registers these with `reg-view`
-;; and is handed `dispatch`/`subscribe`. The subscription vectors and event
-;; vectors are identical — only the way a React component plugs into them differs.
-;; See docs/guide/how-to/use-uix-helix-or-slim.md.
+;; Here, at last, is the substrate seam — and it's a thin one. A UIx view is
+;; just a `defui`: it reads each subscription through the `use-subscribe` hook
+;; and gets `dispatch` off `(rf/frame-handle)`. The Reagent twin registers the
+;; same views with `reg-view` and is simply handed `dispatch`/`subscribe`. The
+;; subscription vectors and event vectors don't change one character between
+;; them; all that differs is how a React component reaches the wires. See
+;; docs/guide/how-to/use-uix-helix-or-slim.md.
 ;;
-;; The inputs are controlled: each `:value` reads the draft from the
-;; `:auth.login/draft` sub, and `:on-change` dispatches `:auth.login/edit-field`.
-;; The draft lives in app-db, so there is no `uix/use-state` here.
+;; The inputs are controlled: each `:value` reads the draft from
+;; `:auth.login/draft`, and `:on-change` dispatches `:auth.login/edit-field`.
+;; The draft lives in app-db, which is exactly why you won't find a
+;; `uix/use-state` anywhere in here.
 (defui login-form []
   (let [draft    (uix-adapter/use-subscribe [:auth.login/draft])
         busy?    (uix-adapter/use-subscribe [:rf/machine-has-tag?
@@ -436,9 +448,9 @@
           (if busy? "Signing in…" "Sign in"))
        (when err ($ :p.error {:data-testid "login-error"} err)))))
 
-;; Terminal lockout panel — rendered once the flow reaches :locked-out
-;; (tagged :auth/locked). The state has no transitions, so the form is
-;; swapped out entirely rather than left enabled-but-dead.
+;; The dead-end panel, shown once the flow reaches :locked-out (tagged
+;; :auth/locked). That state has nowhere left to go, so we swap the form out
+;; for this rather than leave a form on screen that no longer does anything.
 (defui locked-panel []
   ($ :div.locked {:data-testid "locked-panel"}
      ($ :h2 "Account locked")
@@ -464,31 +476,34 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is held in an atom and materialised lazily inside `run`
-;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
-;; convention: ns-load must produce no DOM side effects so co-required
-;; example namespaces don't race `create-root` onto the shared `#app`.
+;; We stash the React root in an atom and only build it lazily inside `run`,
+;; never at namespace load. The reason (examples/TESTING.md §Example
+;; mount-isolation convention): loading a namespace must touch no DOM, so two
+;; example namespaces loaded side by side can't both race to call `create-root`
+;; on the shared `#app`.
 (defonce react-root (atom nil))
 
 (defn run []
-  ;; Install the UIx adapter.
+  ;; Tell the runtime to render through UIx. (This installs the adapter; it does
+  ;; not create a frame — the frame-provider below does that.)
   (rf/init! uix-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
-    ;; One-spot frame setup. The `frame-provider` at the render root owns the
-    ;; frame: on the first mount it creates the `:rf/default` frame, applies the
-    ;; config (`:fx-overrides` redirects `:rf.http/managed` to the demo stub),
-    ;; and runs `:initial-events` once. On hot reload it reuses the existing
-    ;; frame and skips the events. The `:id :rf/default` names the frame that the
-    ;; `use-subscribe` hook and the `(rf/frame-handle)` in `login-form` resolve
-    ;; to — those reads need a provider above them in the tree.
+    ;; Frame setup, all in one spot. The `frame-provider` at the render root
+    ;; owns the frame: on the first mount it creates the `:rf/default` frame,
+    ;; applies the config (`:fx-overrides` points `:rf.http/managed` at our demo
+    ;; stub), and runs `:initial-events` once. On a hot reload it finds the frame
+    ;; already there, reuses it, and skips the events. The `:id :rf/default`
+    ;; names the frame that `use-subscribe` and the `(rf/frame-handle)` inside
+    ;; `login-form` resolve against — which is why those calls need a provider
+    ;; somewhere above them in the tree.
     ;;
-    ;; `:initial-events` seeds the form SLICE ([:auth.login/initialise-form]) to
-    ;; its empty shape, so the controlled inputs read an empty draft (not nil) on
-    ;; the first render. The MACHINE needs no seeding: its `:initial`/`:data`
-    ;; seed the snapshot in runtime-db the first time the flow runs (see
-    ;; docs/machines/glossary.md#snapshot).
+    ;; `:initial-events` seeds the form slice ([:auth.login/initialise-form]) to
+    ;; its empty shape, so the controlled inputs read an empty draft — not nil —
+    ;; on that first render. The machine asks for nothing here: its `:initial`
+    ;; and `:data` seed the snapshot in runtime-db the first time the flow runs
+    ;; (see docs/machines/glossary.md#snapshot).
     (uix-dom/render-root
       ($ uix-adapter/frame-provider {:id              :rf/default
                                      :doc             "Login (UIx) demo frame."


### PR DESCRIPTION
Final pass on the example comments: brings every example's comments + docstrings into the established guide **voice** — a friendly senior developer who explains simply and progressively, with the occasional dry Steve-Yegge-ish aside — while preserving the recent gains:

- **Simple + direct** (warmth, not length)
- **No historical cruft** (no EP/bead tags, no before/after narration)
- **Guide over spec** (references point at `docs/guide` + glossaries)

One agent per example, **76 files**; comments + docstrings only — no code, behaviour, build id, or run-command change.

Two things the login agent surfaced, worth a look:
- **Accuracy fix:** the `login-banner` docstring claimed a "sign-out button" that doesn't exist — it's a three-way switch (welcome / locked / form). Corrected to match the code.
- **Dropped boilerplate:** removed "examples are test-free / covered by suites" paragraphs from two `login` docstrings as project-meta, not reader-help. Easy to restore if you'd rather keep them.

Verified: `npm run test:examples-compile` passes (all builds, exit 0).