### PR TITLE
Examples: best-of-both prose (reconcile #4990 voice with prior precision)

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -62,7 +62,9 @@
 ;; dataflow behind.
 ;;
 ;; Helix is plain React, so a view is a `defnc` component that asks for what it
-;; needs out loud. `use-subscribe` is a hook that reads a subscription.
+;; needs out loud — `defnc` directly, since the `reg-view` macro is Reagent-only
+;; (UIx and Helix both read state with `use-subscribe`). `use-subscribe` is a
+;; hook that reads a subscription.
 ;; `dispatch` comes off a `(rf/frame-handle)`: the handle captures the in-scope
 ;; frame as a value, so the closed-over `dispatch` still finds this frame when
 ;; a click fires later — on a stack that no longer has any frame in scope. So

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -2,17 +2,20 @@
   "The login example, rendered through Helix.
 
    A login form, a state machine for the submit/auth lifecycle, schemas
-   guarding the boundaries, and a stubbed HTTP call. The Reagent, UIx,
-   and Helix login examples share all of that — the machine, the
-   schemas, the managed-HTTP surface — and differ only in the view
-   layer. Here the views are Helix `defnc` components that read subs
-   through the adapter's `use-subscribe` hook.
+   guarding the boundaries, and a stubbed HTTP call. Same dataflow,
+   schemas, machine, and HTTP stub as examples/reagent/login and
+   examples/uix/login_uix — the machine, the schemas, the managed-HTTP
+   surface are all substrate-agnostic, and the view layer is the only
+   thing that changes between substrates. Here the views are Helix
+   `defnc` components that read subs through the adapter's `use-subscribe`
+   hook.
 
    The machine's states wear tags — `:auth/busy`, `:auth/authenticated`,
    `:auth/locked` — and the views ask about them with the
    `:rf/machine-has-tag?` framework sub. Keep guessing the password and the
-   fourth wrong try trips the retry guard: the form is replaced by a
-   dead-end locked panel.
+   fourth wrong try trips the retry guard: the flow lands in the terminal
+   `:locked-out` state, and the form is replaced by a dead-end,
+   non-interactive locked-account panel.
 
    The machines guide (docs/machines/concepts.md) and the form recipe
    (docs/guide/how-to/build-a-form.md) cover the two big ideas at
@@ -42,10 +45,10 @@
 ;;
 ;; You might expect this shared half to live in one file the three examples
 ;; require. It deliberately doesn't. Each example is its own self-contained
-;; `:browser` build, and a gate checks that a Helix bundle carries no Reagent
-;; or UIx code — a shared file pulled into all three would blow that apart. So
-;; the lesson here is "one dataflow, three view layers," not "factor out the
-;; common bit." The duplication is on purpose.
+;; `:browser` build, and the bundle-isolation gate proves a Helix bundle
+;; carries no Reagent or UIx code — a shared file pulled into all three would
+;; blow that apart. So the lesson here is "one dataflow, three view layers,"
+;; not "factor out the common bit." The duplication is on purpose.
 
 ;; ============================================================================
 ;; SCHEMAS
@@ -79,9 +82,11 @@
 ;; login request fires.
 ;;
 ;; Second, that trailing `[:? :any]` is the slot for the HTTP reply. When the
-;; managed-HTTP call comes back, the framework tacks the payload on as the last
-;; arg, so a delivered reply reads `[:auth.login/flow [:auth.login/success]
-;; <payload>]` — three elements, not two. Leave the optional slot out and the
+;; managed-HTTP call comes back, the framework appends the payload —
+;; `{:kind ... :value ...}` on success, `{:kind ... :failure ...}` on failure —
+;; as the last arg of the `:on-success` / `:on-failure` event vector, so a
+;; delivered reply reads `[:auth.login/flow [:auth.login/success] <payload>]` —
+;; three top-level elements, not two. Leave the optional slot out and the
 ;; `:cat` rejects every reply, validation fails, and the flow sits in
 ;; `:submitting` forever, wondering where its answer went. See
 ;; docs/guide/how-to/validate-with-schemas.md.

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -17,8 +17,8 @@
        trick is keeping it to exactly one live chain; see the EVENTS block.
      - Per-row dispatch from inside a `defnc` row component.
 
-   The visual identity is shared across all three design-led examples; it
-   lives in examples/_shared/css/style.css."
+   The 'Editorial Warm' visual identity is shared across all three design-led
+   examples; it lives in examples/_shared/css/style.css."
   (:require ["react-dom/client" :as react-dom-client]
             [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -18,7 +18,8 @@
    You'll also spot two sibling files here that have nothing to teach you:
    `bundle-isolation-entry` and `bundle-isolation-fixture`. They exist to
    prove a CI gate, live entirely off to the side, and boot the same app
-   through the shared `boot!` helper below. Read past them."
+   through the shared `boot!` helper below — the entry just hands it a hook
+   that exercises the pure-CLJS SSR path the gate inspects. Read past them."
   (:require [reagent2.dom.client                :as rdc]
             [re-frame.core                      :as rf]
             [re-frame.views]

--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -51,9 +51,10 @@
      `[:boot/staging <staging-key>]`, then signals done. The runtime
      reads a `:spawn-all`'s `:on-child-done` / `:on-child-error` events
      only to track the join — they never reach the parent's `:on` table,
-     and the join-resolution event carries no per-child data. So the
-     payload can't ride the event; it goes through the staging slot, and
-     the parent reads the whole slot once the join resolves.
+     and the synthesised join-resolution event
+     (`:on-all-complete [:boot/deps-ready]`) carries no per-child data. So
+     the payload can't ride the event; it goes through the staging slot,
+     and the parent reads the whole slot once the join resolves.
    - The single `:spawn` in `:configuring` is the exception: its
      completion event *does* reach the parent's `:on` table (only join
      events get intercepted). So the config child carries its payload on

--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -11,7 +11,8 @@
 
    - **App-db slices** sit at fixed app-db paths — `[:boot/staging]` plus
      the four top-level slices (`[:config]`, `[:flags]`, `[:user]`,
-     `[:routes]`). Those attach with `rf/reg-app-schema` on the path.
+     `[:routes]`). Those attach with `rf/reg-app-schema` on the path; an
+     app schema validates the app-db partition only.
    - **Machine `:data`** can't go through `reg-app-schema`, because a
      snapshot lives in runtime-db, not app-db (docs/guide/glossary.md#runtime-db).
      Instead, each machine carries its own `[:schemas :data]` slot on
@@ -143,9 +144,9 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 
-;; A failing app-db schema makes the runtime roll the commit back. Each slot
-;; below starts out nil — the boot machine fills it in later — so every
-;; registration wears a `:maybe` to stay valid through the loading phases.
+;; A failing app-db schema makes the runtime roll the commit back, post-commit.
+;; Each slot below starts out nil — the boot machine fills it in later — so
+;; every registration wears a `:maybe` to stay valid through the loading phases.
 ;; (No machine snapshots here: those validate via the machine's own
 ;; `:schemas {:data ...}` in boot.cljs. A `reg-app-schema` on a snapshot path
 ;; would guard nothing, since snapshots live in runtime-db, not app-db.)

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -26,9 +26,10 @@
 ;; describe the next one. It takes coeffects (which carry the current
 ;; app-db) and the event vector, and returns an effect map. The `{:db …}`
 ;; key just means "make this the new app-db", and the runtime commits it
-;; for you, all at once. Notice the handler never reaches out and pokes
-;; app-db — it only computes a value and hands it back. Pure all the way
-;; down. See `docs/guide/glossary.md#event-handler`.
+;; for you atomically — all at once, no half-applied state. Notice the
+;; handler never reaches out and pokes app-db — it only computes a value
+;; and hands it back. Pure all the way down. See
+;; `docs/guide/glossary.md#event-handler`.
 
 (rf/reg-event :counter/initialise
   (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
@@ -102,8 +103,8 @@
   ;; `init!` tells re-frame2 which reactive substrate to render through —
   ;; here, Reagent. Each adapter ns exports an `adapter` var; you require the
   ;; ns and pass that var. One call, at startup, and you're done. Note it
-  ;; installs the adapter, not a frame — those come later, via the provider.
-  ;; See `docs/guide/glossary.md#init`.
+  ;; installs the adapter for the whole process, not a frame — frames come
+  ;; later, via the provider. See `docs/guide/glossary.md#init`.
   (rf/init! reagent-adapter/adapter)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/linearlite/core.cljs
+++ b/examples/reagent/linearlite/core.cljs
@@ -33,9 +33,9 @@
    - The reply settles the same way every time. A success (`:ok`) commits:
      `:populates` overwrites the optimistic guess with the server's authoritative
      board. A failure (`:error`) rolls back: the recorded value returns and the
-     optimistic change visibly reverts. The verdict reads recorded facts — which
-     write this is, plus each entry's revision when the patch applied — so no
-     wall-clock race decides who wins.
+     optimistic change visibly reverts. The verdict reads recorded facts — the
+     generation-acceptance verdict (which write this is) plus each entry's
+     revision when the patch applied — so no wall-clock race decides who wins.
 
    - Rollback is the thing you actually watch. A 'Fail the next write' toggle
      arms the demo backend to answer the next mutation with a 503. The optimistic

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -37,7 +37,11 @@
 
    In a real codebase you'd split this across login/schema.cljc,
    events.cljs, subs.cljs, views.cljs, and machines.cljs. It lives in one
-   file here so you can read it top to bottom in one sitting."
+   file here so you can read it top to bottom in one sitting.
+
+   Examples are test-free: login's behaviour is covered by the substrate
+   contract suite (`npm run test:cljs`) and the framework gates, not by a
+   test alongside this file."
   ;; This example runs on stock Reagent. It's also the cross-substrate
   ;; reference base — mirrored 1:1 as `login-uix` and `login-helix` — so
   ;; staying on Reagent keeps the three an honest apples-to-apples
@@ -416,7 +420,7 @@
 ;; it's fair to show a field's error). This single event is the *entire* job
 ;; of an input's `:on-change` — it sets no view-local state, because there
 ;; is none. The `:schema` swats away any malformed edit-field vector at the
-;; boundary before the handler sees it.
+;; `:where :event` boundary before the handler sees it.
 (rf/reg-event :auth.login/edit-field
   {:doc    "Controlled-input edit: write one field into the login-form draft
             and mark it touched."

--- a/examples/reagent/login/stories.cljs
+++ b/examples/reagent/login/stories.cljs
@@ -63,7 +63,10 @@
    no function slots anywhere. The view at the heart of each is the
    example's own `login.core/root-view`, named by id. And the canonical
    Story vocabulary installs itself on the first `reg-*` call, so there's no
-   boot step to remember."
+   boot step to remember.
+
+   Examples are test-free: these stories carry no `:script` / `:rf.assert/*`
+   — they're a showcase, not a test surface."
   (:require [re-frame.core :as rf]
             [re-frame.story :as story]
             ;; Source the example's registrations (the machine, schemas,

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -17,8 +17,9 @@
    - **Cancellation that always lands** — whenever the parent leaves
      `:working` (you hit Cancel, the job finishes, the frame is
      destroyed, a timeout fires), one `:rf.machine/destroy` fx tears
-     down every child still standing. Their in-flight timers go down
-     with them, so nothing keeps ticking after the curtain falls.
+     down every child still standing. Their in-flight timers and HTTP
+     requests go down with them, so nothing keeps ticking after the
+     curtain falls.
    - **Live progress** — each child fires a `:progress` event at the
      parent after every chunk. The parent stashes it in
      `:data :progress`, the `:work/progress-fraction` sub recomputes,

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -5,10 +5,10 @@
   That's the whole idea, and it's built on one effect: `:rf.http/managed`.
   You describe a request as data; the runtime owns the rest of its life —
   encode, send, decode, sort the failures, retry, abort. When the answer
-  comes home it arrives as an ordinary event, re-dispatched to the very
-  handler that sent the request. So \"send\" and \"receive\" are two passes
-  through one pure function, and you never go near js/fetch. The HTTP guide
-  has the full contract: docs/resources/http.md.
+  comes home it arrives as an ordinary event, re-dispatched — via default
+  reply addressing — to the very handler that sent the request. So \"send\"
+  and \"receive\" are two passes through one pure function, and you never go
+  near js/fetch. The HTTP guide has the full contract: docs/resources/http.md.
 
   Five buttons walk the whole surface:
 
@@ -329,10 +329,10 @@
 ;; ============================================================================
 ;;
 ;; We keep the React root in an atom and only build it lazily inside `run`,
-;; never at ns-load. That's the mount-isolation rule from examples/TESTING.md:
-;; loading a namespace must have zero DOM side effects, so that two example
-;; namespaces sharing a page can't race each other to call `create-root` on
-;; the same `#app`.
+;; never at ns-load. That's the mount-isolation rule from examples/TESTING.md
+;; §Example mount-isolation convention: loading a namespace must have zero DOM
+;; side effects, so that two example namespaces sharing a page can't race each
+;; other to call `create-root` on the same `#app`.
 
 (defonce react-root (atom nil))
 

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -76,15 +76,17 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
-            ;; Schemas ship as their own artefact. Requiring this ns wires
-            ;; up the hooks the `rf/reg-app-schema` call below leans on.
+            ;; Schemas ship as their own artefact, day8/re-frame2-schemas.
+            ;; Requiring this ns wires up the hooks the `rf/reg-app-schema`
+            ;; call below leans on.
             [re-frame.schemas]
-            ;; Likewise machines: requiring this registers `rf/reg-machine`
-            ;; and the `:rf/machine` / `:rf/machine-has-tag?` subs we use
-            ;; throughout.
+            ;; Likewise machines, from day8/re-frame2-machines: requiring
+            ;; this registers `rf/reg-machine` and the `:rf/machine` /
+            ;; `:rf/machine-has-tag?` subs we use throughout.
             [re-frame.machines]
-            ;; Managed-HTTP. Requiring it registers the `:rf.http/managed`
-            ;; fx (and its family) that the load events dispatch.
+            ;; Managed-HTTP ships in day8/re-frame2-http. Requiring it
+            ;; registers the `:rf.http/managed` fx (and its family) that
+            ;; the load events dispatch.
             [re-frame.http.managed]
             ;; The framework's canned-reply stubs
             ;; (`:rf.http/managed-canned-success` / `-failure`). Our little

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -30,10 +30,10 @@
    New to the terms? docs/guide/glossary.md defines event, subscription,
    app-db, and view; docs/guide/concepts/views.md covers views and hiccup
    in depth."
-  ;; We render through stock Reagent (`reagent.dom.client`). The adapter
-  ;; is the value that teaches re-frame2 how to talk to a given rendering
-  ;; library — swap it and the same app runs on UIx or Helix. See
-  ;; docs/guide/glossary.md#adapter.
+  ;; We render through stock Reagent (`reagent.dom.client` +
+  ;; `re-frame.adapter.reagent`). The adapter is the value that teaches
+  ;; re-frame2 how to talk to a given rendering library — swap it and the
+  ;; same app runs on UIx or Helix. See docs/guide/glossary.md#adapter.
   (:require [reagent.dom.client :as rdc]
             [clojure.string     :as str]
             [re-frame.core      :as rf]
@@ -264,17 +264,19 @@
     (into [:p] (inline-md->hiccup block))))
 
 (defn markdown->hiccup
-  "The whole parser, top level. Split the text on blank lines into blocks,
-   figure out each block's shape (heading? list? paragraph?), and run the
-   inline rules over it. Just enough markdown for the seed content.
+  "The whole pure-CLJS parser, top level. Split the text on blank lines
+   into blocks, figure out each block's shape (heading? list? paragraph?),
+   and run the inline rules over it. Just enough markdown for the seed
+   content.
 
    Returns a vector of block hiccup for the caller to splice into a
-   container. The fiddly detail is the `:key` on each block. React renders
-   these as a list, and it uses keys to decide what moved versus what's
-   new. We key by content (its hash), not by index — index keys would
-   re-key every block below an edit and make React redraw the lot, when
-   all you did was add a sentence. Two identical blocks would collide, so
-   we mix in the position to keep keys unique."
+   container; Reagent renders that vector as a seq of children. The fiddly
+   detail is the `:key` on each block. React renders these as a list, and
+   it uses keys to decide what moved versus what's new. We key by content
+   (its hash), not by index — index keys would re-key every block below an
+   edit and make React redraw the lot, when all you did was add a sentence.
+   Two identical blocks would collide, so we mix in the position to keep
+   keys unique."
   [s]
   (let [blocks (->> (str/split (or s "") #"\r?\n\r?\n")
                     (remove str/blank?))]

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -173,8 +173,9 @@
 ;; interceptor decorates the entire Conduit API at a stroke: the route-caused
 ;; reads (`/articles/feed`, the lists, detail), the writes (favorite / follow /
 ;; comment / settings / save-article), and the auth machine's session-restore
-;; `GET /user`. The auth slice is the single source of truth, and this is the
-;; single place it's read. Nice when one fact lives in exactly one spot.
+;; `GET /user`. No per-call `:request` fn threads the token: the auth slice is
+;; the single source of truth, and this is the single place it's read. Nice when
+;; one fact lives in exactly one spot.
 ;;
 ;; The token is read from `(:frame ctx)` — the frame this cascade is running
 ;; under — rather than a hard-coded id, so the header follows along to a

--- a/examples/reagent/resources_ssr/core.cljc
+++ b/examples/reagent/resources_ssr/core.cljc
@@ -32,9 +32,9 @@
    This drives the real server path, not a stand-in. It drains the blocking
    page resource before rendering (`ssr/drain-blocking-resources!`) and ships
    only the allowed runtime-db projection (`payload-policy/project-runtime-db`)
-   under `:rf/runtime-db` — never the full cache. The app-db slice goes through
-   the same fail-closed allowlist (`apply-policy`) the production Ring host
-   uses. The static `index.html` next to this file carries a pre-baked payload
+   under `:rf/runtime-db` — never the full cache. The `:rf/app-db` slice goes
+   through the same fail-closed allowlist (`apply-policy`) the production Ring
+   host uses. The static `index.html` next to this file carries a pre-baked payload
    so the browser side runs without a Clojure server in the box.
 
    For the full picture see [Resources: SSR and hydration](../../../docs/resources/concepts.md#ssr-and-hydration)

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -17,8 +17,9 @@
    - `:rf.route/id` / `:rf.route/params` — read the active route as subs
    - `route-link` — renders links that drive navigation
    - `:rf/url-requested` — the event a user clicking an anchor fires
-   - `install-history-listener!` — wires up Back/Forward and the first-load
-     URL→state sync, so the address bar and your app-db stay in agreement"
+   - `install-history-listener!` — wires up Back/Forward (popstate) and the
+     first-load URL→state sync, so the address bar and your app-db stay in
+     agreement"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
@@ -183,11 +184,12 @@
   ;; Tell re-frame2 to render through Reagent. Every adapter namespace exports
   ;; an `adapter` var; hand it straight to `init!` and you're done.
   (rf/init! reagent-adapter/adapter)
-  ;; Teach the app to listen to the browser's own navigation. This does two
-  ;; jobs: right now, it syncs the current URL into state (so a deep link or a
-  ;; refresh lands on the right page), and from here on, every Back/Forward
-  ;; finds whichever frame owns the URL and updates its `:rf/route` slice.
-  ;; Idempotent, so hot reload can call it again without complaint.
+  ;; Teach the app to listen to the browser's own navigation (the popstate
+  ;; event). This does two jobs: right now, it syncs the current URL into state
+  ;; (so a deep link or a refresh lands on the right page), and from here on,
+  ;; every Back/Forward resolves whichever frame owns the URL at pop time and
+  ;; updates its `:rf/route` slice. Idempotent, so hot reload can call it again
+  ;; without complaint.
   (rf/install-history-listener!)
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -278,9 +278,11 @@
   "Compute one cell's display value. `visited` is the set of cell ids already on
    the current evaluation path — our cycle guard. If we're asked to evaluate a
    cell that's already on the path, A1 → B1 → A1 has come back to bite us, so we
-   bail with :error/cycle instead of recursing forever. A formula recurses with
-   itself added to the set; a literal parses to a number or stays text; an
-   untouched cell is simply 0."
+   bail with :error/cycle instead of recursing forever. A formula that failed to
+   parse returns its stored `[:error/parse msg]` pair as-is, so the actionable
+   message rides through to the view; a well-formed formula recurses with itself
+   added to the set; a literal parses to a number or stays text; an untouched
+   cell is simply 0."
   [id cells visited]
   (cond
     (visited id)  :error/cycle

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -200,11 +200,11 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-;; One slice sub does the digging; everyone else reads from it. `:drawer/slice`
-;; reaches into app-db once to grab the `:drawer` map, and the subs below chain
-;; off it with `:<-`. So the [:drawer ...] walk happens a single time per app-db
-;; swap, not once per dependent sub — a small habit that keeps a subscription
-;; graph cheap as it grows.
+;; One Layer-2 slice sub does the digging; the Layer-3 readers below all read
+;; from it. `:drawer/slice` reaches into app-db once to grab the `:drawer` map,
+;; and the subs below chain off it with `:<-`. So the [:drawer ...] walk happens
+;; a single time per app-db swap, not once per dependent recompute — a small
+;; habit that keeps a subscription graph cheap as it grows.
 ;; See docs/guide/concepts/subscriptions.md.
 
 (rf/reg-sub :drawer/slice (fn [db _] (:drawer db)))

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -38,12 +38,13 @@
 ;; ============================================================================
 
 ;; A person's `:id` does real work: it's the selection, and it's the React
-;; `:key`. It also lives in app-db forever, which means it has to survive a
-;; replay unchanged — replay a recording and you must get the *same* ids back.
-;; That rules out `(random-uuid)` at the write site (a fresh random number every
-;; time is the opposite of reproducible). So we count instead: a plain `:int`
-;; handed out from a `:next-id` counter that lives in the db, where replay can
-;; see it. See docs/guide/glossary.md#recordable-vs-ambient-coeffects.
+;; `:key`. It also lives in durable app-db (`[:crud :people]`) forever, which
+;; means it has to survive a replay unchanged — replay a recording and you must
+;; get the *same* ids back. That rules out `(random-uuid)` at the write site (a
+;; fresh random number every time is the opposite of reproducible). So we count
+;; instead: a monotonic `:int` handed out from a `:next-id` counter that lives in
+;; the db, where replay can see it.
+;; See docs/guide/glossary.md#recordable-vs-ambient-coeffects.
 (def Person
   [:map
    [:id      :int]

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -176,9 +176,10 @@
       :one-way true
       :return  (and (valid-date? s)
                     (valid-date? r)
-                    ;; ISO dates sort correctly as plain strings — the whole
-                    ;; reason the format is yyyy-mm-dd — so a string compare is
-                    ;; all we need to check return ≥ start.
+                    ;; ISO dates sort correctly as plain strings — that's the
+                    ;; whole reason the format is yyyy-mm-dd — so a plain
+                    ;; lexicographic string compare is all we need to check
+                    ;; return ≥ start.
                     (<= (compare s r) 0)))))
 
 (rf/reg-sub :flight/book-enabled?

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -22,7 +22,8 @@
   (:require [clojure.string :as str]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            ;; Required for its side effect: loading this ns installs the
+            ;; `re-frame.schemas` ships in day8/re-frame2-schemas. Required
+            ;; for its side effect: loading this ns installs the late-bind
             ;; hooks that make `rf/reg-app-schema` resolve. No var from it is
             ;; used directly — it just has to be on the page.
             [re-frame.schemas]

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -32,8 +32,8 @@
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 (def tick-ms
-  "How long, in milliseconds, between one tick and the next. 100ms is smooth
-   enough to look continuous without flooding the loop with events."
+  "Wall-clock delay, in milliseconds, between one tick and the next. 100ms is
+   smooth enough to look continuous without flooding the loop with events."
   100)
 
 ;; ============================================================================

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -166,9 +166,12 @@
 ;; ../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify.)
 ;;
 ;; It's also paranoid in the good way — it fails closed. A payload that isn't a
-;; map, or a slice that's present but malformed, leaves the frame-state exactly
-;; as it was rather than installing garbage. Along the way it tucks the server's
-;; render hash aside for the verify step that follows the first render.
+;; map, or a slice (`:rf/app-db` / `:rf/runtime-db`) that's present but not a
+;; map, leaves the frame-state exactly as it was rather than installing garbage.
+;; (A wholly-absent slice key isn't malformed — that's the no-server-slice
+;; first-load shape, which falls back to the existing partition value.) Along
+;; the way it tucks the server's render hash aside for the verify step that
+;; follows the first render.
 ;;
 ;; This example has no machines and doesn't hydrate a route, so its runtime-db
 ;; slice is empty here — but the shape is the same one a richer app fills in.

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -21,9 +21,9 @@
    - A final `__rf_payload` chunk carrying the canonical full state. The
      deltas are a speed bet; this is the truth, and it wins any tie.
 
-  One artefact, two runtimes: the `:clj` branch is what a Ring server
-  calls per request, the `:cljs` branch is what the page boots once the
-  chunks land.
+  One `.cljc` artefact, two runtimes: the `:clj` branch is what a Ring
+  server calls per request, the `:cljs` branch is what the page boots once
+  the chunks land.
 
   See the [SSR guide — Streaming](../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)."
   (:require [re-frame.core :as rf]
@@ -203,8 +203,8 @@
                               :payload :rf.ssr.payload/whole-app-db}))
            ;; Strip the payload's `:rf/frame-id` before it goes over the
            ;; wire. The two sides don't share a frame id: the server renders
-           ;; under this per-request gensym, the client hydrates a fixed
-           ;; `app-frame` (below). When `ssr/hydrate!` sees a frame-id on the
+           ;; under this per-request gensym frame (`fid`), the client hydrates
+           ;; a fixed `app-frame` (below). When `ssr/hydrate!` sees a frame-id on the
            ;; wire, it checks it against the client's explicit `:frame` and
            ;; fails closed if they differ — which a gensym always would. Send
            ;; no frame-id and the client's explicit target simply stands. (If

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -47,7 +47,8 @@
   (:require [re-frame.core :as rf]
             ;; `re-frame.machines` ships in day8/re-frame2-machines.
             ;; Requiring it is what wires up the machine vocabulary: the
-            ;; `:rf.machine/spawn` / `:rf.machine/destroy` fx and the
+            ;; late-bind hook behind `rf/make-machine-handler`, the
+            ;; `:rf.machine/spawn` / `:rf.machine/destroy` fx, and the
             ;; `:rf/machine` / `:rf/machine-has-tag?` subs you'll see used
             ;; below. Skip the require and they simply aren't there.
             [re-frame.late-bind]
@@ -94,11 +95,12 @@
         (seq (:queue data)))
 
       :current-socket?
-      ;; "Is this from the socket we're actually using right now?" Every
-      ;; inbound event stamps the id of the socket it came from
-      ;; (`:source-socket-id`, the actor's `:rf/self-id`). We let it
-      ;; through only if that matches the live socket — otherwise it's a
-      ;; straggler from a connection we've already replaced, and we drop it.
+      ;; The connection-epoch check: "is this from the socket we're
+      ;; actually using right now?" Every inbound event stamps the id of
+      ;; the socket it came from (`:source-socket-id`, the actor's
+      ;; `:rf/self-id`). We let it through only if that matches the live
+      ;; socket — otherwise it's a straggler from a connection we've
+      ;; already replaced, and we drop it.
       (fn guard-current-socket? [{data :data [_ {:keys [source-socket-id]}] :event}]
         (and (some? (:socket-id data))
              (= source-socket-id (:socket-id data))))}
@@ -274,8 +276,9 @@
                               (dispatch!
                                 [:ws/connection [:ws/-socket-spawned id]]
                                 ;; Tag where this dispatch came from:
-                                ;; `:source :websocket` is the reserved slot
-                                ;; for events that originate at the socket.
+                                ;; `:source :websocket` is the reserved
+                                ;; functional-origin slot for events that
+                                ;; originate at the socket.
                                 {:source :websocket})))}
 
        ;; On the way out, null the :socket-id. The runtime already destroys

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -16,13 +16,43 @@
    - `views.cljs` — the UI that drives the machine and shows its state.
    - `schema.cljs` — Malli schemas for the machine `:data` and app-db.
 
+   The machine features this example puts through their paces:
+
+   - **Hierarchical compound `:active`** parenting `:connecting`,
+     `:authenticating`, `:connected`. The socket-actor `:spawn` is on the
+     parent so it survives the success-path leaf transitions.
+
+   - **`:after` exponential backoff** in `:reconnecting`. Leaving the
+     state cancels the timer, so a backoff from a prior visit can't fire
+     late.
+
+   - **`:always` cascades** — `:reconnecting`'s max-retries guard, and
+     `:connected`'s queue-flush on entry.
+
+   - **`:tags`** — `:websocket/connected`, `:websocket/reconnecting`,
+     `:websocket/failed`, so the view asks tag-shaped questions instead of
+     unfolding the snapshot's hierarchical `:state` vector.
+
+   - **Two staleness defences** — the backoff timer (runtime-cancelled on
+     exit) and the connection-epoch (`:current-socket?` guard against the
+     live `:socket-id`).
+
+   - **Request/reply correlation** — `:in-flight` map, request-id stamp,
+     timeout via `:dispatch-later`, reply-event dispatch on the correlated
+     `:ws/received`.
+
+   - **Reconnect cascade** — exit-from-`:active` clears the `:socket-id`;
+     the runtime destroys the socket actor; the `:reconnecting` `:after`
+     re-enters `:active`, which spawns a fresh one.
+
    For the grammar the machine leans on, see docs/machines/concepts.md;
    for where this example sits among the others, docs/machines/examples.md.
 
    No network required: a small in-process mock server stands in for a
    real endpoint, so the app runs standalone. Its real coverage lives in
-   the CLJS contract tests (`npm run test:cljs`, ns
-   `re-frame.websocket-cljs-test`)."
+   the CLJS substrate contract tests (`npm run test:cljs`, ns
+   `re-frame.websocket-cljs-test`). The example tree is test-free, so
+   `npm run test:adapter-smokes` does not build this example."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -40,9 +70,10 @@
          machine to life in its `:disconnected` start state.
 
          The `:ws.app/*` prefix (rather than a plain `:app/initialise`)
-         is deliberate. Several examples share one test bundle, and a
-         common event key would have them stepping on each other's
-         registrations. Namespacing keeps each example to itself."}
+         is deliberate. Several examples (the realworld + counter
+         examples among them) share one test bundle, and a common event
+         key would have them stepping on each other's registrations.
+         Namespacing keeps each example to itself."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:ws.messages/initialise]]
           [:dispatch [:ws.connection/initialise]]]}))
@@ -52,10 +83,11 @@
 ;; ============================================================================
 ;;
 ;; We hold the React root in an atom and create it lazily inside `run`,
-;; never at ns-load. The reason is mundane but real: several examples
-;; share one `#app` element in the test bundle, and creating roots at
-;; ns-load would race several of them onto the same container. Building it
-;; in `run` keeps loading this namespace free of DOM side effects.
+;; never at ns-load. The reason is mundane but real: several example
+;; namespaces share one `#app` element in the browser-test bundle, and
+;; creating roots at ns-load would race several of them onto the same
+;; container. Building it in `run` keeps loading this namespace free of
+;; DOM side effects.
 
 (defonce react-root (atom nil))
 

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -18,8 +18,8 @@
      - sparklines drawn as inline SVG from plain CLJS arithmetic — no
        chart library
      - two controls that re-derive the view: the filter chips (which
-       cards show) and the range picker (how many points each sparkline
-       draws, plus the header label)
+       cards show) and the range picker (how many trailing points each
+       sparkline draws, plus the header label)
 
    The derivation graph is the concept worth slowing down for; the
    guide glossary has the full picture

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -64,9 +64,9 @@
 ;; framework tacks the reply map (`{:kind ... :value ...}` or
 ;; `{:kind ... :failure ...}`) onto the end of the `:on-success` / `:on-failure`
 ;; vector, so what actually arrives is
-;; `[:auth.login/flow [:auth.login/success] <payload>]` — three elements deep.
-;; Leave off that optional slot and the `:cat` rejects every reply, failing
-;; validation before the handler ever runs. See
+;; `[:auth.login/flow [:auth.login/success] <payload>]` — three top-level
+;; elements, not two. Leave off that optional slot and the `:cat` rejects every
+;; reply, failing validation before the handler ever runs. See
 ;; docs/guide/glossary.md#the-uniform-reply.
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
@@ -225,7 +225,8 @@
     ;; we have to wipe the old `:error` on the way through. If we don't, the
     ;; stale failure message hangs around (the view shows `:auth.login/error`
     ;; whenever it's non-nil) looking for all the world like it belongs to the
-    ;; request now in flight. Same `:clear-error` action the :idle exit uses.
+    ;; request now in flight. Same `:clear-error` action the :idle → :submitting
+    ;; transition uses.
     {:on {:auth.login/dismiss {:target :idle}
           :auth.login/submit  {:target :submitting
                                :action :clear-error}}}


### PR DESCRIPTION
This is a follow-up to #4990. It reconciles each example's prose so we get the best of both: it keeps #4990's friendly senior-dev voice while restoring the technical precision, spec references, and edge-case notes the rewrite dropped along the way. Every change is comment/docstring-only — no code changes — confined entirely to `examples/`.

- examples/helix/counter_helix: #4990's friendly rewrite was strong overall (added glossary/TESTING.md links + pure-function/atomicity precision). One technical detail was lost in the substrate-boundary comment: that `reg-view` is Reagent-only and UIx/Helix both use `use-subscribe`. Folded that back; kept #4990 everywhere else.
- examples/helix/login_helix: Restored precision #4990 dropped while keeping its friendly voice: sibling example paths + substrate-agnostic framing + named terminal :locked-out state in ns docstring; the specific "bundle-isolation gate" name; and the exact reply-payload shapes ({:kind :value}/{:kind :failure}) for the [:? :any] slot.
- examples/helix/process_monitor_helix: Restored the canonical "Editorial Warm" identity name (dropped by #4990) into the ns docstring while keeping #4990's more precise "design-led examples" wording. All other #4990 prose was equal or strictly richer (e.g. "no reg-view in sight", names Reagent/UIx, "installs the adapter ... does not create a frame"), so left unchanged.
- examples/reagent-slim/counter_slim_and_fast: core.cljs: restored the dropped detail that the gate entry hands boot! a hook exercising the pure-CLJS SSR path the gate inspects, keeping #4990's friendly two-file navigation. Entry + fixture already preserved all precision; left unchanged.
- examples/reagent/boot: Restored 3 precision drops from #4990 while keeping its friendly voice: boot.cljs named join event (:on-all-complete [:boot/deps-ready]); schema.cljs "app schema validates app-db partition only" + "post-commit" rollback term. core/views unchanged (#4990 lost nothing; it even fixed a Routes parallelism inaccuracy).
- examples/reagent/counter: Restored two precision points #4990 dropped while keeping its friendly voice: "atomically" (+ "no half-applied state") in the event-handler comment, and the adapter being installed "for the whole process" (not frame-scoped) in the init! comment. All guide refs already preserved.
- examples/reagent/linearlite: Restored the precise term "generation-acceptance verdict" in the ns docstring's reply-settles bullet (PR #4990 had flattened it to "which write this is"), keeping #4990's friendly gloss. All other #4990 prose was equal or richer, left as-is.
- examples/reagent/login: core.cljs: restored test-free coverage note (npm run test:cljs + gates) and `:where :event` boundary specificity. stories.cljs: restored test-free `:script`/`:rf.assert/*` posture line. stories_host.cljs: unchanged — #4990 kept all precision.
- examples/reagent/long_running_work: core.cljs: restored "and HTTP requests" to the cancellation-cascade bullet (#4990 narrowed it to timers only) — the :rf.machine/destroy cascade tears down in-flight HTTP too. Other 3 files: #4990 kept all precision (some added detail); left unchanged.
- examples/reagent/managed_http_counter: Kept #4990's friendlier voice; folded back two dropped precision items: the named "default reply addressing" contract term in the ns docstring, and the precise "§Example mount-isolation convention" section anchor in the MOUNT comment.
- examples/reagent/nine_states: core.cljs: restored the 3 dropped dependency artefact names (day8/re-frame2-schemas, -machines, -http) into the require comments, keeping #4990's friendly voice. stories.cljs + stories_host.cljs: #4990 already best, no precision lost.
- examples/reagent/notebook: #4990's warmer voice was kept throughout (ns/sub/safe-href/mount prose were equal-or-better). Folded back two precision drops: the `re-frame.adapter.reagent` ns ref in the adapter comment, and "pure-CLJS" + "Reagent renders that vector as a seq of children" in the markdown->hiccup docstring.
- examples/reagent/realworld_resources: #4990 was a faithful friendly rewrite preserving precision (all 30+ glossary refs + technical tokens intact; verified by diff). Folded back one dropped detail in core.cljs (per-call `:request`-fn threading note). Other 10 files unchanged.
- examples/reagent/resources_ssr: #4990 was equal-or-better throughout (kept all 8 doc refs, all error keywords, owner/cause + drain + redaction semantics; even added precision). Lone regression: dropped `:rf/` namespace from the app-db key in the ns docstring — restored `:rf/app-db` to match adjacent `:rf/runtime-db`.
- examples/reagent/routing: #4990 already preserved nearly all precision (artefact name, error kw, registries point, TESTING.md ref, url-bound?/route-slice). Folded back the one dropped technical term "popstate" + BEFORE's "resolves URL-owner frame at pop time" precision, keeping the friendly voice.
- examples/reagent/seven_guis/cells: #4990 was equal-or-better almost everywhere (added cell-id/parse-cell-id docstrings, richer collect-deps/commit/value/num-re prose, both glossary links kept). Only loss: evaluate-cell docstring dropped the parse-error return branch; folded it back in the friendly voice.
- examples/reagent/seven_guis/circle_drawer: #4990 mostly improved this file (added warmth + restored detail). Only real drop: the subscriptions comment lost the canonical Layer-2/Layer-3 sub vocabulary. Folded that terminology back into the friendly phrasing; restored "per dependent recompute".
- examples/reagent/seven_guis/crud: Restored two precision losses in the Person :id comment: the concrete durable-path ref `[:crud :people]` and the term "monotonic" (matching the :next-id "deterministic allocator" note), while keeping #4990's friendly voice. All other blocks were already equal/better.
- examples/reagent/seven_guis/flight_booker: #4990 preserved/expanded precision nearly everywhere (require, schema-bind, valid-date docstring, book-enabled :doc all kept accuracy + gained warmth). Only the ISO-compare comment dropped the term "lexicographically"; folded it back while keeping the friendly phrasing.
- examples/reagent/seven_guis/temperature: Folded back dropped package provenance ("re-frame.schemas ships in day8/re-frame2-schemas" + "late-bind hooks") into #4990's friendly require comment. Kept #4990's correct Layer-1/Layer-2 fix (BEFORE mislabeled them Layer-2/3 vs the guide).
- examples/reagent/seven_guis/timer: #4990 was strictly better here (kept gen-token mechanism, schema-frame binding, lazy-root rationale; added divide-by-zero + bidirectional-slider notes). Only restored "Wall-clock" qualifier dropped from the tick-ms docstring.
- examples/reagent/ssr: Restored fail-closed precision in the :rf/hydrate prose: #4990's vague "present but malformed" → "present but not a map", named the :rf/app-db/:rf/runtime-db slice keys, and re-added the absent-key-is-legit-first-load distinction. Kept #4990's friendly voice everywhere else.
- examples/reagent/ssr_streaming: #4990 rewrite kept nearly all precision (all spec/data-attr markers, fail-closed frame-id logic, guide links) and even fixed "three cards"->"four". Restored two dropped tokens: the `fid` binding name in the strip-frame-id comment, and `.cljc` in the ns docstring.
- examples/reagent/websocket: Kept #4990's friendly voice; restored lost precision: connection.cljs got back make-machine-handler hook, "connection-epoch check", "functional-origin" slot; core.cljs got back the concrete feature list + test-free/adapter-smokes note + named examples/browser-test-bundle. Other 3 files already best-of.
- examples/uix/dashboard_uix: #4990's friendly rewrite preserved essentially all precision (glossary/TESTING.md/WAI-ARIA refs, edge cases, correctness; even added (+1,-1) step values). Folded back one dropped detail: "trailing points" in the ns-docstring range-picker bullet (restores the take-last window semantics).
- examples/uix/login_uix: Restored two precision points #4990's friendly rewrite loosened in core.cljs, keeping its voice: "three elements deep"→"three top-level elements, not two"; ":idle exit"→":idle → :submitting transition" (matches Helix twin, fixes wrong "exit" framing).
