### PR TITLE
docs(examples): reconcile counter/notebook/dashboard_uix boot prose to frame-provider ensure form

### DIFF
--- a/examples/reagent/counter/README.md
+++ b/examples/reagent/counter/README.md
@@ -65,15 +65,13 @@ changes. That seam is the whole point of the
 
 re-frame2 never creates a frame for you. An app must stand its frame up
 itself, and this counter is the smallest place to watch that happen end
-to end. Four steps, all in `run`:
+to end. Two steps, all in `run`:
 
 ```clojure
 (rf/init! reagent-adapter/adapter)              ;; install the adapter (NOT a frame)
-(rf/reg-frame app-frame {})                     ;; register the app's frame
-(rf/with-frame app-frame
-  (rf/dispatch-sync [:counter/initialise]))     ;; boot it: seed app-db, synchronously
 (rdc/render @react-root
-  [rf/frame-provider {:frame app-frame} ;; scope the frame to the view tree
+  [rf/frame-provider {:id app-frame             ;; stand the frame up: create + seed
+                      :initial-events [[:counter/initialise]]}
    [counter-app]])
 ```
 
@@ -82,17 +80,15 @@ Each step does one job:
 - [`init!`](../../../docs/guide/glossary.md#init) tells the runtime which
   [substrate](../../../docs/guide/glossary.md#substrate) to render
   through, and nothing else. It does not create a frame.
-- `reg-frame` registers the app's frame. The example names it
+- [`frame-provider`](../../../docs/guide/glossary.md#frame-provider) wraps
+  the view tree and stands the frame up. Given `:id`, it *ensures* a named
+  frame — creating it on the first mount and reusing it untouched on a hot
+  reload, never re-seeding — and runs `:initial-events` once on creation
+  to seed `app-db` before the first render. The example names the frame
   `:rf/default`, but that name has no special meaning — you ask for it
-  like any other.
-- The boot dispatch runs inside `with-frame`, so it lands in the right
-  frame. It uses
-  [`dispatch-sync`](../../../docs/guide/glossary.md#dispatch-sync) — the
-  synchronous sibling of `dispatch` — so `app-db` is seeded *before* the
-  first render, not a tick later.
-- `frame-provider` wraps the view tree. That's what lets the
-  `dispatch` and `subscribe` calls inside the views find their frame
-  instead of raising `:rf.error/no-frame-context`.
+  like any other. Wrapping the tree is also what lets the `dispatch` and
+  `subscribe` calls inside the views find their frame instead of raising
+  `:rf.error/no-frame-context`.
 
 If you're coming from re-frame v1, this is the thing to notice: there's
 no global, implicit app any more. The payoff is that frames are

--- a/examples/reagent/notebook/README.md
+++ b/examples/reagent/notebook/README.md
@@ -130,16 +130,18 @@ One note on the substrate choice: this is **stock Reagent**
 (`reagent.dom.client` + `re-frame.adapter.reagent`), not reagent-slim.
 That keeps the trio on the reference substrate for each adapter.
 
-The mount is the ordinary re-frame2 boot, in four steps.
+The mount is the ordinary re-frame2 boot, in two steps.
 [`init!`](../../../docs/guide/glossary.md#init) installs the Reagent
-[adapter](../../../docs/guide/glossary.md#adapter).
-[`reg-frame`](../../../docs/guide/glossary.md#registration) registers the
-app [frame](../../../docs/guide/glossary.md#frame). A
-[`dispatch-sync`](../../../docs/guide/glossary.md#dispatch-sync) seeds
-the [app-db](../../../docs/guide/glossary.md#app-db) before the first
-paint. Then the tree renders inside a `frame-provider`, so
-every `dispatch`/`subscribe` in the tree resolves to that frame. Render
-with no provider and those calls raise `:rf.error/no-frame-context` —
+[adapter](../../../docs/guide/glossary.md#adapter). Then the tree renders
+inside a [`frame-provider`](../../../docs/guide/glossary.md#frame-provider)
+given `{:id app-frame :initial-events [[:notebook/initialise]]}`: the
+`:id` stands the app [frame](../../../docs/guide/glossary.md#frame) up —
+creating it on the first mount, reusing it untouched on a hot reload — and
+`:initial-events` fires once on creation to seed the
+[app-db](../../../docs/guide/glossary.md#app-db) before the first paint.
+With the tree inside the provider, every `dispatch`/`subscribe` resolves
+to that frame; render with no provider and those calls raise
+`:rf.error/no-frame-context` —
 [identity is carried, not found](../../../docs/guide/glossary.md#frame-identity-is-carried-not-found),
 even for a three-pane toy.
 

--- a/examples/uix/dashboard_uix/README.md
+++ b/examples/uix/dashboard_uix/README.md
@@ -100,14 +100,17 @@ the dataflow stays the star.
 
 The mount is the ordinary re-frame2 boot.
 [`init!`](../../../docs/guide/glossary.md#init) installs the UIx adapter.
-[`reg-frame`](../../../docs/guide/glossary.md#registration) registers the
-app [frame](../../../docs/guide/glossary.md#frame). A
-[`dispatch-sync`](../../../docs/guide/glossary.md#dispatch-sync) seeds
-the [app-db](../../../docs/guide/glossary.md#app-db) before the first
-paint. Then the tree renders inside a `frame-provider`, so every
-`use-subscribe` and `capture-frame` resolves to that frame through React
-context. Render with *no* provider and the hooks raise
-`:rf.error/no-frame-context` — [identity is carried, not
+Then the tree renders inside a
+[`frame-provider`](../../../docs/guide/glossary.md#frame-provider) given
+`{:id app-frame :initial-events [[:dashboard/initialise]]}`: the `:id`
+stands the app [frame](../../../docs/guide/glossary.md#frame) up —
+creating it on the first mount, reusing it untouched on a hot reload — and
+`:initial-events` fires once on creation to seed the
+[app-db](../../../docs/guide/glossary.md#app-db) before the first paint.
+With the tree inside the provider, every `use-subscribe` and
+`capture-frame` resolves to that frame through React context; render with
+*no* provider and the hooks raise `:rf.error/no-frame-context` —
+[identity is carried, not
 found](../../../docs/guide/glossary.md#frame-identity-is-carried-not-found),
 even here.
 


### PR DESCRIPTION
## What

Three example READMEs taught the **old** multi-call frame boot, but each example's `core.cljs` `run` actually stands the frame up in one place with the **ensure** form — `frame-provider {:id app-frame :initial-events [[…/initialise]]}` (key `:id`, seeding via `:initial-events`, no `reg-frame` / `with-frame` / `dispatch-sync`). This reconciles the READMEs to what the code does. **Prose/comments only — no code change.**

- **`examples/reagent/counter/README.md`** — rewrote the fenced ```clojure``` block under "Why this shape" to the single `frame-provider {:id app-frame :initial-events [[:counter/initialise]]}` call, and collapsed the four per-step bullets to two. Updated the count "Four steps" → "Two steps" (heading + bullets) so the claim stays internally consistent.
- **`examples/reagent/notebook/README.md`** — rewrote the "ordinary re-frame2 boot, in four steps" prose to the `:id` / `:initial-events` mechanism `notebook/core.cljs` uses; now "two steps".
- **`examples/uix/dashboard_uix/README.md`** — same fix against `dashboard_uix/core.cljs`.
- Dropped the now-unused `dispatch-sync` glossary link from all three; link `frame-provider` instead.

## Inventory count

The "Four steps" count is **not** registered in the inventory gate (`scripts/check_readme_inventories.py` only checks the testbeds/implementation/examples layout maps and the story-mcp/pair-mcp tool counts — the counter README is not in its registry). The change Four→Two is therefore not gate-protected, but I kept the heading, the fenced block, and the bullet list mutually consistent (two steps, two bullets) regardless.

## Gates (all green)

- `scripts/check_readme_inventories.py` (self-test + full) — pass
- `scripts/check_readme_links.py` (self-test + full) — pass
- `scripts/check_doc_slugs.py` (self-test + full) — pass
- `npm run test:examples-compile` — all 44 example builds compiled, 0 warnings
- `git grep -nE 'reg-frame|with-frame|dispatch-sync' -- 'examples/**/README.md'` — no stale boot references remain