### PR TITLE
docs(migration-skill): compile-only breaking items (clear-sub-cache!, interceptor accessors) + React-19 install ERESOLVE note

### DIFF
--- a/skills/re-frame-migration/references/breaking-changes.md
+++ b/skills/re-frame-migration/references/breaking-changes.md
@@ -8,6 +8,7 @@ A one-page index keyed to v1 trigger surfaces. The author asks *"is `X` covered 
 
 - Required rules (M-N) by trigger surface
 - v1 add-on libraries fail to COMPILE on v2 (forced removal/replacement)
+- Compile-only façade removals (public `re-frame.core` symbols that no longer resolve)
 - Opt-in modernisations (O-N) by trigger surface
 - Type A vs Type B at a glance
 - Failure-visibility axis — loud-fail vs silent-fail (orthogonal to Type A/B)
@@ -108,6 +109,19 @@ Confirmed-broken v1 add-ons (each references the removed `re-frame.core/console`
 (Distinct from the **classpath-collision** failure mode in [`setup.md` §Edge cases](setup.md) — a v1-built add-on can also root a transitive `re-frame/re-frame` coord. That is a *separate* breakage; an add-on can hit both. The `console` break here is a **compile error inside the add-on's own source**, not a coord conflict.)
 
 This surface is keyed off dep-/application-level triggers (Maven coords + fx ids), so it pairs with the O-16 / O-17 detection — but the removal/replacement is required, not gated behind the opt-in question.
+
+## Compile-only façade removals — public `re-frame.core` symbols that no longer resolve
+
+A short register of **public v1 `re-frame.core` symbols that simply do not exist on the v2 façade**. They are a pure **compile-only** class: the var does not resolve, so the call site is an *unresolved-symbol compile error* — never a runtime surprise. This is the **loud-fail / march-the-wall** shape (the compiler names the missing symbol; swap it, recompile, repeat — the opposite of the silent-fail register further down). They get their own register because each is a *public* surface an author would not expect to have moved — unlike the off-contract **private**-namespace requires of M-1 — and because the M-rule table is keyed by trigger *surface*, so grepping it does not surface the bare symbol names below.
+
+| Removed public symbol (v1) | What happens in v2 | Replacement | Rule |
+|---|---|---|---|
+| `clear-subscription-cache!` (the no-arg public form) | Gone from `re-frame.core` — unresolved symbol at compile. | `(rf/clear-sub-cache! :rf/default)` — the v2 name takes a **required frame-id** (the v1 zero-arg form is gone; every frame now has its own sub-cache). `:rf/default` is the like-for-like target for code that never addressed frames. Per [`spec/API.md`](../../../spec/API.md#dispatch-and-subscribe) §`clear-sub-cache!`. | **M-1** |
+| `get-coeffect` / `get-effect` | Removed from the `re-frame.core` façade — unresolved symbol at compile. | Inside a `reg-interceptor` `:before`/`:after` fn, **read the context map directly**: `(get-in ctx [:coeffects k])` / `(get-in ctx [:effects k])`. | [`spec/API.md`](../../../spec/API.md) §Removed |
+| `assoc-coeffect` / `assoc-effect` | Removed from the façade — unresolved symbol at compile. | Inside a `reg-interceptor` `:before`/`:after` fn, **write the context map directly**: `(assoc-in ctx [:coeffects k] v)` / `(assoc-in ctx [:effects k] v)`. | [`spec/API.md`](../../../spec/API.md) §Removed |
+| public `->interceptor` (and any inline interceptor **value** in a chain) | No public authoring form — `->interceptor` is internal-only, and EP-0022 chains are reference-only, so an inline value is also rejected. | Author the before/after work with `(rf/reg-interceptor id descriptor)` and reference it by **id** in the event/frame `:interceptors` chain. | **M-21** |
+
+**These accessors are removed, NOT relocated — do not chase a public successor namespace.** The owning-namespace fns (`re-frame.interceptor/get-coeffect`, `…/assoc-effect`, the internal `->interceptor` constructor) **remain framework-internal**. They are off-contract, so a `(:require [re-frame.interceptor …])` reaching for them is itself an **M-1** off-contract-namespace break, not a fix. The supported destination is the direct `get-in` / `assoc-in` context-map access shown above (for the accessors) or a registered interceptor referenced by id (for `->interceptor`). The interceptor-surface shrink that retires `->interceptor` and inline chain values is [M-21](../../../migration/from-re-frame-v1/README.md#m-21-drop-debug-trim-v-on-changes-enrich-after-interceptors); the `clear-subscription-cache!` rename rides [M-1](../../../migration/from-re-frame-v1/README.md) (the private-namespace rule, which folds in this one public rename because every codebase that uses it trips the same mechanical rewrite).
 
 ## Opt-in modernisations (O-rules) by trigger surface
 

--- a/skills/re-frame-migration/references/setup.md
+++ b/skills/re-frame-migration/references/setup.md
@@ -99,6 +99,10 @@ Decide and record the gate outcome before proceeding:
 
 The author then runs `npm install` (or the project's package-manager equivalent) before the first dev build. If the project is already on React 19, leave it alone; do not downgrade.
 
+**Expect `npm install` to ERESOLVE-fail against any JS dep still pinned to a React `<19` peer.** The moment `react`/`react-dom` move to `^19`, npm's resolver rejects the whole tree if *any* remaining JS dependency still declares a `react` peer below 19 — a categorically common case in a view-heavy app (an animation library, a UI-component kit, a date-picker, a chart or drag-and-drop lib, etc., still pinned to `^18`). The install aborts with `npm error ERESOLVE could not resolve` / `peer react@"^18..." from <lib>`, and **the CLJS compile cannot even start without `node_modules`** — so this blocks the post-M-0 compile gate *before any re-frame rule runs*, and it reads like a setup failure rather than the dependency-floor issue it is.
+
+The **interim unblock to reach the compile gate** is `npm install --legacy-peer-deps` (or `--force`): it installs the tree despite the unmet React peer so the build can proceed and the migration sweep can continue. Treat that flag as **scaffolding, not a destination** — the peer-pinned JS deps it papers over are a **real to-do, not resolved**: bump each to a release that admits React 19 (this is the same Check-1 / Check-2 bump work above), so that `npm install` resolves *cleanly without the flag* **and** the library is actually runtime-safe on React 19. Do not leave `--legacy-peer-deps` as the project's permanent state — it silences the resolver, it does not make a React-`<19` library work under React 19; a lib that only *installs* under the flag can still mis-render or throw at runtime. Surface the still-pinned deps as a tracked follow-up alongside the GO decision.
+
 ---
 
 ## The coord swap (M-0)


### PR DESCRIPTION
Two verified re-frame-migration skill gaps, one per commit (disjoint files).

## Issue 1 — compile-only `re-frame.core` façade removals (`references/breaking-changes.md`)

Adds a new "Compile-only façade removals" register surfacing public v1 `re-frame.core` symbols that no longer resolve in v2 — a pure compile-time (unresolved-symbol) class, the loud-fail / march-the-wall shape, distinct from both the silent-fail register and the private-namespace requires of M-1.

Two families, with the exact verified dispositions:

1. **`clear-subscription-cache!` (no-arg public form) → `(rf/clear-sub-cache! :rf/default)`** — removed from `re-frame.core`; the v2 name takes a **required frame-id** (the zero-arg form is gone; each frame has its own sub-cache), and `:rf/default` is the like-for-like target for code that never addressed frames. Cites **M-1** (the private-namespace rule folds in this one public rename — corpus README §M-1 / mapping table). Verified at `migration/from-re-frame-v1/README.md` M-1 (heading L89, mapping L122–123).

2. **Interceptor / context accessors — removed from the façade, NOT relocated:**
   - `get-coeffect` / `get-effect` → inside a `reg-interceptor` `:before`/`:after` fn, read the context map directly: `(get-in ctx [:coeffects k])` / `(get-in ctx [:effects k])`.
   - `assoc-coeffect` / `assoc-effect` → write the context map directly: `(assoc-in ctx [:coeffects k] v)` / `(assoc-in ctx [:effects k] v)`.
   - These have **no M-rule**; they are documented in `spec/API.md` §Removed (owners Spec 001/002). The owning `re-frame.interceptor/*` fns **stay framework-internal** — off-contract — so requiring that namespace to reach them is itself an **M-1** break, not a fix. The entry explicitly tells the agent not to chase a public successor namespace.
   - public **`->interceptor`** (and inline interceptor **values** in a chain) → no public authoring form; author with `(rf/reg-interceptor id descriptor)` referenced by id. Cites **M-21** (corpus README §M-21 — interceptor-surface shrink, EP-0022).

## Issue 2 — React-19 floor-bump ERESOLVE warning (`references/setup.md`)

In the React-19 / Reagent-2 floor-gate section, after the `react`/`react-dom` `^19` bump + `npm install` line: once React moves to 19, `npm install` **ERESOLVE-aborts** against any JS dep still declaring a React `<19` peer (animation libs, UI kits, date-pickers, charts — categories, generic; no lib named as a requirement). Because the CLJS compile needs `node_modules`, this blocks the post-M-0 compile gate before any re-frame rule runs. Interim unblock to reach the compile gate: `npm install --legacy-peer-deps` (or `--force`) — flagged as **scaffolding, not a destination**: the peer-pinned deps are a real to-do (bump to React-19-admitting releases — the Check-1/Check-2 work) for a clean flagless install + runtime-safe React 19; the flag silences the resolver, it does not make a `<19` lib work under 19.

## Verified accessor truth (the key correctness point)

The accessors are **removed from the public `re-frame.core` façade**, not relocated to a public home. Replacement is **direct `get-in`/`assoc-in` context-map access** (accessors) or a **registered interceptor by id** (`->interceptor`) — confirmed against `spec/API.md` §Removed (L995–996) and §Standard interceptors. `clear-subscription-cache!` → `clear-sub-cache!` with a required frame-id confirmed against corpus M-1 (L122–123). Every cited M-id (M-1, M-21) resolves to the right corpus rule.

## Gates (all green locally)

- `check_skill_migration_cites.py` (live + `--self-test`) — all M-id cites resolve consistently
- `check_skill_migration_contract_drift.py` (live + `--self-test`) — no M-11/M-13 drift
- `check_doc_slugs.py` (live + `--self-test`) — no broken links/anchors
- `check_readme_links.py` — no broken README links
- `mkdocs build --strict` — not installed locally (CI-only); `check_doc_slugs` is the link proxy and is green