### PR TITLE
docs(api): one-home-per-surface ownership cleanup + per-chapter require blocks

### DIFF
--- a/docs/core/api/01-core.md
+++ b/docs/core/api/01-core.md
@@ -4,6 +4,12 @@ The Core chapter is what you `:require` from `re-frame.core` to make an app exis
 
 If you read only one chapter of this reference, this is the one to read. Everything in the other chapters builds on these five clusters.
 
+The surfaces in this chapter live in `re-frame.core`:
+
+```clojure
+(:require [re-frame.core :as rf])
+```
+
 ## Registration
 
 This is the surface every re-frame2 app touches. You're answering "what events can my app handle, what data can it subscribe to, what side effects can it action, what state can it inject as coeffects?" Every entry is a registration of a named handler into the frame's registrar.
@@ -177,16 +183,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   (reg-view sym [args] body+)
   ```
   (plus shape-variants — see [02 — Views](02-views.md))
-- **Description**: `defn`-shape view registration. Auto-defs the symbol; auto-derives an id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. See [02 — Views](02-views.md).
-- **Example**:
-  ```clojure
-  (rf/reg-view counter-buttons []
-    [:div
-     [:button {:on-click #(dispatch [:counter/dec])} "-"]
-     [:span @(subscribe [:counter/value])]
-     [:button {:on-click #(dispatch [:counter/inc])} "+"]])
-  ```
-- **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/core/counter)
+- `defn`-shape view registration. Full contract in [02 — Views](02-views.md).
 
 ### `reg-view*`
 
@@ -196,7 +193,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   (reg-view* id render-fn)
   (reg-view* id metadata render-fn)
   ```
-- **Description**: Plain-fn surface beneath `reg-view`. No auto-def, no auto-inject, no compile check. Use for computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var.
+- Plain-fn surface beneath `reg-view`. Full contract in [02 — Views](02-views.md).
 
 ### `reg-machine`
 
@@ -205,16 +202,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-machine machine-id machine-spec)
   ```
-- **Description**: Registers a state machine as an event handler (the machine *is* the handler — the body comes from `make-machine-handler`). Walks the literal spec form at expansion time and stamps per-element source coords for click-to-source navigation. See [04 — Machines](../../machines/api.md).
-- **Example**:
-  ```clojure
-  (rf/reg-machine :auth.login/flow
-    {:initial :idle
-     :states  {:idle      {:on {:submit :submitting}}
-               :submitting {:on {:ok :done :err :idle}}
-               :done      {}}})
-  ```
-- **In the wild**: [state_machine_walkthrough](https://github.com/day8/re-frame2/tree/main/examples/capabilities/machines/state_machine_walkthrough)
+- Registers a state machine as an event handler. Re-exported on the `re-frame.core` facade; full grammar (transitions, `:spawn`/`:regions`, snapshot shape) in [04 — Machines](../../machines/api.md).
 
 > **`reg-machine*` is not a core facade export.** The plain-fn machine-registration surface lives in `re-frame.machines` (`re-frame.machines/reg-machine*`), not `re-frame.core`. Only the `reg-machine` / `defmachine` macros are on the `re-frame.core` facade. See [04 — Machines](../../machines/api.md#re-framemachinesreg-machine).
 
@@ -226,13 +214,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   (reg-app-schema path {:schema schema})
   (reg-app-schema path {:schema schema :frame frame})
   ```
-- **Description**: "Declare the Malli schema for this `app-db` path." **Path is the registration id** — the only `reg-*` keyed by path rather than keyword, because schemas-at-paths matches the dataflow grain. The schema rides the metadata map under `:schema`; the optional frame target rides `:frame`. See [08 — Schemas](08-schemas.md).
-- **Example**:
-  ```clojure
-  (rf/reg-app-schema [:cells]
-    {:schema [:map [:cells/grid [:map-of :keyword :string]]]})
-  ```
-- **In the wild**: [7GUIs](https://github.com/day8/re-frame2/tree/main/examples/core/seven_guis)
+- Declare the Malli schema for an `app-db` path (path is the registration id). Re-exported on the `re-frame.core` facade; full contract in [08 — Schemas](08-schemas.md).
 
 ### `reg-app-schemas`
 
@@ -241,15 +223,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-app-schemas {path-1 schema-1, ...})
   ```
-- **Description**: Bulk plural form for feature-modular apps that register 5–20 paths together. Each entry routes through the singular form and is stamped with this call's source-coords.
-- **Example**:
-  ```clojure
-  (rf/reg-app-schemas
-    {[:auth]     AuthState
-     [:articles] ArticlesState
-     [:profile]  ProfileState})
-  ```
-- **In the wild**: [realworld](https://github.com/day8/re-frame2/tree/main/examples/real-apps/realworld_http)
+- Bulk plural form of `reg-app-schema`. Re-exported on the `re-frame.core` facade; full contract in [08 — Schemas](08-schemas.md).
 
 ### `reg-flow`
 
@@ -259,15 +233,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   (reg-flow flow)
   (reg-flow flow opts)
   ```
-- **Description**: Register a derived flow — `{:id :inputs :derive :output-path}` — that auto-recomputes when its inputs change and writes the result into `:output-path` in `app-db`. `:inputs` is a positional vector of `app-db` paths; the values arrive as positional args to `:derive`. See [05 — Flows](05-flows.md).
-- **Example**:
-  ```clojure
-  (rf/reg-flow
-    {:id     :cart/total
-     :inputs [[:cart :items]]
-     :derive (fn [items] (reduce + (map :price items)))
-     :output-path [:cart :total]})
-  ```
+- Register a derived flow that auto-recomputes and writes to an `app-db` path. Re-exported on the `re-frame.core` facade; full contract in [05 — Flows](05-flows.md).
 
 ### `reg-route`
 
@@ -276,14 +242,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-route id metadata path)
   ```
-- **Description**: Register a route as data: the path is the third positional arg; the metadata map carries `:params`, `:query`, `:on-match`, `:on-error`, `:can-leave`. See [06 — Routing](../../routing/api.md).
-- **Example**:
-  ```clojure
-  (rf/reg-route :route/home
-    {:on-match [[:home/load]]}
-    "/")
-  ```
-- **In the wild**: [routing](https://github.com/day8/re-frame2/tree/main/examples/capabilities/routing/routing)
+- Registers a route as data. Re-exported on the `re-frame.core` facade; full route-metadata grammar in [06 — Routing](../../routing/api.md).
 
 ### `reg-head`
 
@@ -292,13 +251,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-head id ?metadata head-fn)
   ```
-- **Description**: SSR: register a `(fn [db route] head-model)` keyed by id; routes opt-in via `:head` metadata. See [09 — SSR](../../ssr/api.md).
-- **Example**:
-  ```clojure
-  (rf/reg-head :app/head
-    (fn [db _route]
-      {:title (str "MyApp — " (:page-title db))}))
-  ```
+- SSR: register a head-model fn keyed by id. Re-exported on the `re-frame.core` facade; full contract in [09 — SSR](../../ssr/api.md).
 
 ### `reg-error-projector`
 
@@ -307,7 +260,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-error-projector id ?metadata projector-fn)
   ```
-- **Description**: SSR: register a `(fn [trace-event] :rf/public-error)`; named per-frame via the frame's `:ssr {:public-error-id ...}` metadata.
+- SSR: register a trace-event → public-error projector, named per-frame via `:ssr {:public-error-id …}`. Re-exported on the `re-frame.core` facade; full contract in [09 — SSR](../../ssr/api.md).
 
 ### Clearing registrations
 
@@ -339,15 +292,6 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (clear-fx id)
   ```
 - **Description**: "Forget this fx."
-
-#### `clear-flow`
-
-- **Signature**:
-  ```clojure
-  (clear-flow id)
-  (clear-flow id opts)
-  ```
-- **Description**: Deregisters the flow from the named frame and `dissoc-in`s its `:output-path` from that frame's `app-db` only. See [05 — Flows](05-flows.md).
 
 #### `destroy-frame!`
 
@@ -472,7 +416,7 @@ These are the two verbs that drive the cascade. `dispatch` says "an event happen
 
 ### Reading a machine's snapshot
 
-To read a machine's snapshot, subscribe to the canonical `[:rf/machine machine-id]` vector — `@(rf/subscribe [:rf/machine machine-id])` yields a reaction over `{:state :data}` (or `nil` if uninitialised). See [04 — Machines](../../machines/api.md).
+Subscribe to `[:rf/machine machine-id]` for a reaction over the machine's `{:state :data}` snapshot. See [04 — Machines](../../machines/api.md).
 
 **The `opts` map.** `dispatch` and `subscribe` accept a uniform opts map: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. Envelope shape and semantics live in [002 §Routing: the dispatch envelope](../../../spec/002-Frames.md#routing-the-dispatch-envelope). The most common pattern is `(rf/dispatch [::save x] {:frame :todo})` to target a non-default frame.
 
@@ -517,7 +461,7 @@ The family has two sub-shapes that look alike on first read but answer different
 
 **Stamping pair** (`dispatch` / `dispatch*` and `dispatch-sync` / `dispatch-sync*`). The pair-shape question is "do you want call-site stamping or not?" The macro captures source coords for `:rf.trace/call-site`; the `*` fn-form skips the stamping for HoF composition. Both route through the same dispatcher.
 
-**Named-target addressing** (the `[:rf.machine/dispatch-to-system [system-id event]]` fx, per [04 — Machines](../../machines/api.md)). The question is "do you have a `:system-id` instead of a target machine-id?" The fx resolves through the per-frame `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and then dispatches. It's *not* a different kind of dispatch — it's named-addressing on top of the same dispatcher. (This is **not** a `re-frame.core` facade verb: the direct-call fn `re-frame.machines/dispatch-to-system` was demoted to an implementation-tier helper in the machines artefact — the fx tuple is the canonical surface.)
+**Named-target addressing** (the `[:rf.machine/dispatch-to-system [system-id event]]` fx). The question is "do you have a `:system-id` instead of a target machine-id?" It's *not* a different kind of dispatch — it's named-addressing on top of the same dispatcher. (This is **not** a `re-frame.core` facade verb: the direct-call fn `re-frame.machines/dispatch-to-system` was demoted to an implementation-tier helper in the machines artefact — the fx tuple is the canonical surface.) For `:system-id` resolution, see [04 — Machines](../../machines/api.md).
 
 The two compose: the named-target fx ultimately dispatches, so the same trace stamping fires on the resulting event.
 

--- a/docs/core/api/02-views.md
+++ b/docs/core/api/02-views.md
@@ -11,6 +11,12 @@ If you're not sure, you're an application author: use the app-facing lane and sk
 
 This chapter also covers the substrate-agnostic ergonomic surface (`capture-frame`, `with-frame`, `with-new-frame`, `frame-provider`), and points at the per-adapter chapters for the substrate-specific hooks. If you want the Reagent vs UIx vs Helix conventions, see [13 — Lifecycle](13-lifecycle.md) and [14 — Adapters](14-adapters.md).
 
+The view-authoring surfaces in this chapter live in `re-frame.core`:
+
+```clojure
+(:require [re-frame.core :as rf])
+```
+
 ## App-facing view registration
 
 This is the lane for application authors. You register a view with `reg-view`, render it by Var reference, and that's the whole story for the 80% case. The view registry that backs this is what `[my-view "arg"]` resolves against: every view you register lives in it, keyed by id (a keyword, conventionally `(keyword *ns* sym)` so the view's id matches its symbol).
@@ -194,109 +200,15 @@ Full semantics in [002 §with-frame and with-new-frame](../../../spec/002-Frames
 
 ## Reagent: the default substrate
 
-The CLJS reference implementation ships against Reagent as the default substrate. There's no separate `re-frame.adapter.reagent` namespace to require — `re-frame.core` includes the Reagent adapter inline, because that's the historical default and the path of least surprise for re-frame v1 migrators.
+The CLJS reference implementation ships against Reagent as the default substrate. There's no separate `re-frame.adapter.reagent` namespace to require — `re-frame.core` includes the Reagent adapter inline, because that's the historical default and the path of least surprise for re-frame v1 migrators. The common case needs no explicit adapter wiring.
 
 Reagent views are plain Clojure functions returning hiccup; re-frame2's `reg-view` macro is the typed sugar over `defn` + `reg-view*`. Form-2 (a fn that returns a fn) and Form-3 (`create-class`) are both supported; the wrapping the macro emits is transparent to either pattern.
 
-The adapter spec map — the value `(rf/init!)` consumes — lives at `re-frame.adapter.reagent/adapter` (Reagent-full) or `re-frame.adapter.reagent-slim/adapter` (Reagent without the React server-rendering tax, for SSR pipelines).
-
-```clojure
-(:require [re-frame.adapter.reagent :as reagent])
-
-(rf/init! reagent/adapter)
-```
+For the adapter value, the `reagent-slim` spec map (Reagent without the React server-rendering tax, for SSR pipelines), and the `init!` wiring, see [14 — Adapters](14-adapters.md).
 
 ## UIx and Helix: hooks-shaped substrates
 
-UIx and Helix expose React's hooks model directly. The re-frame2 adapter for each ships in its own artefact (`day8/re-frame2-uix`, `day8/re-frame2-helix`) and exposes a small, parallel surface — the same shape across both, because the Helix decisions transfer the UIx decisions one-for-one.
-
-In the entries below, `<adapter>` stands for the adapter namespace alias the consumer chose at require — typically `uix-adapter` or `helix-adapter`.
-
-### `<adapter>/adapter`
-
-- **Kind**: Var (map)
-- **Signature**:
-  ```clojure
-  {:make-state-container …
-   :render …
-   :dispose-adapter! …}
-  ```
-- **Description**: The adapter spec passed to `(rf/init! ...)`.
-- **Example**:
-  ```clojure
-  (:require [re-frame.adapter.uix :as uix-adapter])
-
-  (rf/init! uix-adapter/adapter)
-  ```
-- **In the wild**: [counter_uix](https://github.com/day8/re-frame2/tree/main/examples/substrates/uix/counter) · [counter_helix](https://github.com/day8/re-frame2/tree/main/examples/substrates/helix/counter)
-
-### `<adapter>/use-subscribe`
-
-- **Kind**: hook (function)
-- **Signature**:
-  ```clojure
-  (use-subscribe query-v) → value
-  (use-subscribe frame-kw query-v) → value
-  ```
-- **Description**: The hook-shaped read. Matches the React/UIx/Helix idiom; there's no auto-injection — components call the hook and `(rf/capture-frame)` directly.
-- **Example**:
-  ```clojure
-  (let [count    (uix-adapter/use-subscribe [:count])
-        {:keys [dispatch]} (rf/capture-frame)]
-    ($ :button {:on-click #(dispatch [:inc])} count))
-  ```
-- **In the wild**: [counter_uix](https://github.com/day8/re-frame2/tree/main/examples/substrates/uix/counter) · [counter_helix](https://github.com/day8/re-frame2/tree/main/examples/substrates/helix/counter)
-
-### `<adapter>/use-current-frame`
-
-- **Kind**: hook (function)
-- **Signature**:
-  ```clojure
-  (use-current-frame) → frame-kw
-  ```
-- **Description**: "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks.
-
-### `<adapter>/frame-provider`
-
-- **Kind**: component (function — one component, two config shapes)
-- **Signatures**:
-  ```clojure
-  ($ frame-provider {:frame :session} child-1 child-2)                  ;; SCOPE an existing frame
-  ($ frame-provider {:id :session :images [session-image]} child-1 child-2)  ;; ENSURE create-if-absent / reuse
-  ```
-- **Description**: The component-shaped equivalent of Reagent's merged `frame-provider`, dispatched on the prop map: `{:frame …}` scopes an existing frame (failing loud if absent), `{:id …}` ensures a named frame (create-if-absent / reuse-no-reseed / provide id, no destroy-on-unmount). Children ride the idiomatic `$` trailing-args channel — pass them after the prop map. The underlying React Context (`re-frame.adapter.context`) is **shared** across all three substrates, so a mixed-substrate app's provider chain composes across substrate boundaries.
-
-### `<adapter>/wrap-view`
-
-- **Kind**: function
-- **Signature**:
-  ```clojure
-  (wrap-view id metadata user-fn) → wrapped fn
-  ```
-- **Description**: Adapter-side source-coord annotation. Most UIx / Helix users register through `reg-view*` and let the adapter wrap; `wrap-view` is exposed for code-gen and library scaffolding.
-
-### `<adapter>/flush-views!`
-
-- **Kind**: function
-- **Signature**:
-  ```clojure
-  (flush-views!)
-  (flush-views! f)
-  ```
-- **Description**: Wraps React's `act()` for tests. Drain queued state updates before assertions.
-
-### `<adapter>/set-hiccup-emitter!`
-
-- **Kind**: function
-- **Signature**:
-  ```clojure
-  (set-hiccup-emitter! f)
-  ```
-- **Description**: Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR.
-
-The UIx / Helix adapters do **not** support `reg-view` (the macro is Reagent-specific in its `defn`-shape rewriting). For UIx and Helix the app-facing lane *is* native components plus the adapter hooks — most application views need no view registration at all, because UIx and Helix components compose by Var reference like ordinary React components. `reg-view*` is the tooling/host lane here too: reach for it only when something needs registry-keyed view addressing (a tool hosting the view by id, a code-gen pipeline).
-
-See [14 — Adapters](14-adapters.md) for the per-substrate detail.
+UIx and Helix are hooks-shaped substrates: instead of the inline Reagent default, you mount through an explicit adapter and read subscriptions through a hook. The per-substrate surface — `adapter`, `use-subscribe`, `use-current-frame`, `frame-provider`, `wrap-view`, `flush-views!`, `set-hiccup-emitter!` — lives in [14 — Adapters](14-adapters.md), which documents each substrate's namespace (`re-frame.adapter.uix` / `re-frame.adapter.helix`) and hook signatures.
 
 ## DOM source-coord annotations
 

--- a/docs/core/api/03-effects.md
+++ b/docs/core/api/03-effects.md
@@ -4,6 +4,12 @@ The effect map is what an event handler returns. The interceptor chain is what r
 
 This chapter covers what an `:fx` map can carry (`:db`, `:fx`, the standard fx-ids), what an interceptor is and the public authoring surface (`reg-interceptor`), the one framework-standard interceptor reference (`[:rf.interceptor/path <path-vector>]`), the pre-built `validate-at-boundary-interceptor`, and the override surfaces that let tests and tools swap fx behaviour at runtime (`with-fx-overrides`, the per-call `:fx-overrides` opt). Coeffects are *not* delivered by an interceptor in v2 — a handler declares the world facts it needs with `:rf.cofx/requires` registration metadata and the runtime supplies them (see [01 — Core §`reg-cofx`](01-core.md#reg-cofx) and [Guide — Effects and coeffects](../concepts/effects-and-coeffects.md)). v1's `inject-cofx` interceptor is removed; so are the v1 `path` / `unwrap` value constructors (see [15 — Removed](15-removed.md)).
 
+The surfaces in this chapter live in `re-frame.core`:
+
+```clojure
+(:require [re-frame.core :as rf])
+```
+
 ## The effect map: closed shape
 
 Closed: **`:db` + `:fx` only**. That's the entire effect-map vocabulary in v2.
@@ -28,8 +34,8 @@ Anything in `:fx` is a `[fx-id args]` pair. The runtime looks up `fx-id` in the 
 | `[:rf.http/managed args-map]` | per `:rf.fx/managed-args` | v1 (optional) | 014 | The canonical managed-HTTP fx. See [07 — HTTP](../../resources/http-api.md). |
 | `[:rf.nav/push-url url-string]` | URL string | v1 | 012 | Navigate. See [06 — Routing](../../routing/api.md). |
 | `[:raise event-vec]` | event vector | v1 | 005 | **Machine-only.** Inside a machine action's `:fx`, routes the event back into the same machine atomically and pre-commit. Unbound outside machine actions. |
-| `[:rf.machine/spawn spawn-spec]` | per `:rf.fx/spawn-args` | v1 | 005 | Spawn a dynamic actor instance whose snapshot lives at `[:rf.runtime/machines :snapshots <gensym'd-id>]` (in runtime-db). See [04 — Machines](../../machines/api.md). |
-| `[:rf.machine/destroy actor-id]` | actor id (keyword) | v1 | 005 | Symmetric counterpart to `:rf.machine/spawn`. Runs the actor's `:exit` action, dissociates `[:rf.runtime/machines :snapshots <id>]` (in runtime-db), clears its event-handler registration. |
+| `[:rf.machine/spawn spawn-spec]` | per `:rf.fx/spawn-args` | v1 | 005 | Spawn a dynamic machine actor — see [04 — Machines](../../machines/api.md). |
+| `[:rf.machine/destroy actor-id]` | actor id (keyword) | v1 | 005 | Destroy a dynamic machine actor — see [04 — Machines](../../machines/api.md). |
 | `[:rf.fx/reg-flow flow-map]` | flow map | v1 | 013 | Register a flow at runtime via `:fx`. See [05 — Flows](05-flows.md). |
 | `[:rf.fx/clear-flow id]` | id | v1 | 013 | Clear a registered flow at runtime via `:fx`. |
 | `[:http args]` | impl-specific | — | — | User-registered via `reg-fx`. The legacy un-managed shape; new code uses `:rf.http/managed`. |
@@ -67,7 +73,7 @@ The public interceptor-authoring surface is **`reg-interceptor`**, and event / f
   ```clojure
   validate-at-boundary-interceptor
   ```
-- **Description**: A **pre-built interceptor value**, not a fn (interceptor `:id` is `:rf.schema/at-boundary`). Add it to a `reg-event` metadata map's `:interceptors` vector for production-boundary schema validation. **Do not call it as a fn** — it has no fn arity; invoking `(rf/validate-at-boundary-interceptor ...)` raises `ArityException`.
+- Pre-built schema-validation interceptor value for the production boundary — full contract in [08 — Schemas](08-schemas.md).
 
 ### The `:rf.interceptor/path` reference: focus on a slice
 

--- a/docs/core/api/05-flows.md
+++ b/docs/core/api/05-flows.md
@@ -6,6 +6,13 @@ Flows replace v1's `on-changes` interceptor — same compute-on-input-change sem
 
 The normative source is [013-Flows.md](../../../spec/013-Flows.md).
 
+This chapter spans `re-frame.core` (the `reg-flow` macro) and `re-frame.flows` (`clear-flow`):
+
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.flows :as flows])
+```
+
 ## The flow surface
 
 ### `reg-flow`

--- a/docs/core/api/08-schemas.md
+++ b/docs/core/api/08-schemas.md
@@ -6,6 +6,13 @@ Schemas describe **shape and validation**. Durable `app-db` data classification 
 
 This chapter covers the registration macros (rowed in [01 — Core](01-core.md), summarised here), the introspection surface in `re-frame.schemas`, the validator-extension seams (`set-schema-validator!` etc.), and the boundary-validation interceptor. For the canonical contracts, see [010-Schemas.md](../../../spec/010-Schemas.md), [015-Data-Classification.md](../../../spec/015-Data-Classification.md), and [Privacy.md](../../../spec/Privacy.md).
 
+This chapter spans `re-frame.core` (the `reg-app-schema` / `reg-app-schemas` macros) and `re-frame.schemas` (schema introspection):
+
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.schemas :as schemas])
+```
+
 ## Registration
 
 ### `reg-app-schema`
@@ -151,36 +158,14 @@ The pattern: dev-time validation runs at every commit by default; production-tim
 
 ## Data classification
 
-Schemas describe shape; **classification of durable `app-db` data is event-owned**, not schema-attached. The `app-db` path is yours at an absolute path you own, so you classify it by returning a **commit-plane classification effect** from a `reg-event` handler — alongside `:db`, in the same event. There are four, one per axis-and-direction:
+Durable `app-db` data classification is **event-owned** — a `reg-event` handler returns a commit-plane classification effect alongside `:db`, in the same event. There are four, one per axis-and-direction:
 
-```clojure
-(rf/reg-event :app/init
-  (fn [{:keys [db]} _]
-    {:db              (assoc db :auth {})
-     :sensitive       [[:auth :token]
-                       [:tenant :partner-api-key]]   ;; classify sensitive
-     :large           [[:documents :csv-upload]]}))  ;; classify large
-;;   :clear-sensitive / :clear-large un-classify a path when its ownership ends.
+- `:sensitive` — classify the listed `app-db` paths as sensitive (redacted at the wire boundary).
+- `:large` — classify the listed `app-db` paths as large (size-elided at the wire boundary).
+- `:clear-sensitive` — un-classify the listed paths' sensitive marking when their ownership ends.
+- `:clear-large` — un-classify the listed paths' large marking when their ownership ends.
 
-;; Wire the init event at frame creation; the classification is in place
-;; before any off-box egress. The frame owns only the :observability sink
-;; policy now — durable app-db paths and HTTP carriers do NOT live on it.
-(rf/reg-frame :app/main
-  {:initial-events [[:app/init]]})
-
-;; App-specific HTTP carrier names ride the :rf.http/managed registration.
-(rf/reg-fx :rf.http/managed
-  {:carriers {:headers ["X-Honeycomb-Team"]}}
-  re-frame.http.managed/managed-handler)
-```
-
-A `reg-frame` / `make-frame` config carrying `:sensitive` or `:large` **fails loud at registration**. There is likewise **no** schema-attached or imperative-mark route to classify a durable `app-db` path; the event is `app-db`'s definition site, and that is the one route. (Schema `:sensitive?` / `:large?` props remain the route for *owner-local schema'd* data — machine `:data`, resource data/params, HTTP response bodies — see [04 — Machines](../../machines/api.md), [16 — Resources](../../resources/api.md), [07 — HTTP](../../resources/http-api.md).) Transient payloads (event args, sub/flow outputs, the `:rf.http/managed` `:carriers` block) are classified by the registration that introduces the shape.
-
-The full teaching of the three owners, the two projection primitives, and the egress profiles lives in [Guide ch.23 — Privacy and large things](../how-to/keep-secrets-out-of-traces.md). For the framework-internal egress primitives (`project-egress`, `elide-wire-value`) consumed by tools and sinks, see [11 — Instrumentation](11-instrumentation.md).
-
-### Composition rule
-
-When both classifications match the same slot (`:sensitive?` AND `:large?`), **sensitive drop wins** — the size marker is suppressed because it would leak `:path` / `:bytes` / `:digest` information from a sensitive slot. The composition rule is normative; per [009 §Size elision in traces](../../../spec/009-Instrumentation.md#size-elision-in-traces) and [015 §Projection](../../../spec/015-Data-Classification.md).
+Composition: sensitive-drop wins; full teaching in [Guide ch.23](../how-to/keep-secrets-out-of-traces.md), normative in spec 009/015.
 
 ## See also
 

--- a/docs/core/api/10-testing.md
+++ b/docs/core/api/10-testing.md
@@ -4,11 +4,17 @@ The testing surface is structured around one premise: **the framework's discipli
 
 The surface lives across **three namespaces** because the three concerns separate cleanly:
 
-- `re-frame.core` — the production primitives that double as testing entry points (`make-frame`, `with-frame`, `dispatch-sync`, `with-fx-overrides`, `app-db-value`, `snapshot-of`, `compute-sub`, `machine-transition`, `sub-topology`).
+- `re-frame.core` — the production primitives that double as testing entry points (`make-frame`, `with-frame`, `dispatch-sync`, `with-fx-overrides`, `app-db-value`, `snapshot-of`, `compute-sub`, `sub-topology`).
 - `re-frame.test-support` — the test-only fixture machinery and test-flavoured helpers. **Runtime-state axis**: registrar, frames, `app-db`, drain.
 - `re-frame.test-helpers` — the view-assertion helpers (hiccup-walk + the `testid` authoring helper). **View-tree axis**: hiccup data, testids, attached handlers.
 
 `re-frame.test-support` does **not** re-export from `re-frame.core` — a test file requires both `[re-frame.core :as rf]` and `[re-frame.test-support :as ts]`, and additionally `[re-frame.test-helpers :as th]` for view-assertion tests. The seam between the three namespaces is deliberate: production code never picks up test-flavoured assertion machinery by accident.
+
+```clojure
+(:require [re-frame.core         :as rf]
+          [re-frame.test-support :as ts]
+          [re-frame.test-helpers :as th])
+```
 
 For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` compatibility), see [008-Testing.md](../../../spec/008-Testing.md).
 
@@ -61,7 +67,7 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   ```clojure
   (with-fx-overrides {fx-id -> override, …} body+)
   ```
-- **Description**: Rowed in [03 — Effects and interceptors](03-effects.md). Lexical-scope fx override; the most common test surface for "stub THIS fx within THIS block." Lives in `re-frame.core` but is rowed here for discoverability.
+- **Description**: Lexical-scope fx override (`re-frame.core`) — the common "stub THIS fx within THIS block" test surface. Full contract + precedence in [03 — Effects and interceptors](03-effects.md).
 
 ### `compute-sub`
 
@@ -251,18 +257,9 @@ The view-assertion surface treats a view as what it is — a function that retur
 
 No JSDOM; no `act()`; no JSON serialisation; no DOM walk. The hiccup is data; the assertions walk data.
 
-## Multi-frame and machine testing
+## Multi-frame testing
 
-Tests targeting multiple frames or machines reach for the same surfaces with explicit frame opts. `dispatch-sync` accepts a frame in its envelope; `subscribe-once` accepts a frame in its second arity; `compute-sub` works against any `app-db` value (so you can drive a machine through `machine-transition` and assert on the resulting snapshot directly).
-
-```clojure
-(let [definition (rf/machine-meta :session)
-      snapshot   {:state :anonymous :data {}}
-      [next-snap effects] (rf/machine-transition definition snapshot [:login {:user "alice"}])]
-  (is (= :authenticating (:state next-snap)))
-  (is (= "alice" (get-in next-snap [:data :credentials :user])))
-  (is (= [[:rf.http/managed ...]] (:fx effects))))
-```
+Tests targeting multiple frames reach for the same surfaces with explicit frame opts: `dispatch-sync` accepts a frame in its envelope, `subscribe-once` accepts a frame in its second arity, and `compute-sub` works against any `app-db` value. For driving a machine through `machine-transition` and asserting on the resulting snapshot, see [04 — Machines](../../machines/api.md) (the `re-frame.machines/machine-transition` worked example).
 
 ## See also
 

--- a/docs/core/api/11-instrumentation.md
+++ b/docs/core/api/11-instrumentation.md
@@ -6,6 +6,13 @@ This is the load-bearing surface for the pair-shape architecture — every tool 
 
 This chapter covers the event-emit listener surface, the error-emit listener surface, the dev-only tracing surface, the epoch buffer (time-travel), the performance instrumentation gate, the source-coord annotation contract, the wire-boundary elision walker, and the error contract.
 
+This chapter spans `re-frame.core` (trace / egress) and `re-frame.epoch` (time-travel):
+
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.epoch :as epoch])
+```
+
 ## Event-emit (always-on, production-survivable)
 
 A minimal always-on listener surface that survives `:advanced` + `goog.DEBUG=false` and delivers one tight record per processed event. The intended consumers are hosted observability back-ends (Datadog, Honeycomb, Sentry, …). **Parallel to (not a fallback for) the dev-only trace surface; per-event only — no per-sub, per-fx, or per-`:rf.event/db-changed` records.**
@@ -324,9 +331,7 @@ See [08 — Schemas §Data classification](08-schemas.md#data-classification) fo
 
 ## DOM source-coord annotations
 
-Every adapter whose host has a DOM-attribute concept (Reagent / UIx / Helix on the browser) injects `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. Format and exemptions live in [Spec 006 §Source-coord annotation](../../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory).
-
-The annotation is gated on `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production `:advanced` builds elide the attribute via dead-code elimination — there is no DOM-bytes cost in shipped bundles. The JVM SSR emitter mirrors the contract per [Spec 011 §Source-coord annotation under SSR](../../../spec/011-SSR.md#source-coord-annotation-under-ssr).
+The DOM `data-rf2-source-coord` injection contract is documented in [02 — Views §DOM source-coord annotations](02-views.md#dom-source-coord-annotations) (instrumentation only consumes the resolved coords).
 
 ## The error contract
 

--- a/docs/core/api/12-registrar.md
+++ b/docs/core/api/12-registrar.md
@@ -6,6 +6,12 @@ This chapter is the read-side surface. The write-side surface is `reg-*` / `clea
 
 Everything here is **JVM-runnable** except `sub-cache` (which holds live `Reaction` objects in CLJS).
 
+The registrar-query surface lives in `re-frame.core`:
+
+```clojure
+(:require [re-frame.core :as rf])
+```
+
 ## Handlers
 
 ### `registrations`
@@ -40,27 +46,7 @@ Everything here is **JVM-runnable** except `sub-cache` (which holds live `Reacti
 
 ## Machines
 
-These are derived views over the event registrar — a machine is registered as an event handler with `:rf/machine? true`, so `(machines)` is just `(registrations :event)` filtered by that flag. They're rowed here separately because tools reach for them often enough that the convenience is worth it.
-
-### `machines`
-
-- **Kind**: function
-- **Signature**:
-  ```clojure
-  (machines) → seq of machine-ids
-  ```
-- **Description**: Enumerate registered machines.
-
-### `machine-meta`
-
-- **Kind**: function
-- **Signature**:
-  ```clojure
-  (machine-meta machine-id) → registration-metadata map
-  ```
-- **Description**: Transition table, doc, schemas. Equivalent to `(handler-meta :event machine-id)`.
-
-See [04 — Machines](../../machines/api.md) for the rest of the machine surface (subscription helpers, system-id reverse lookup, etc).
+Machine registrar queries (`machines`, `machine-meta`) live in `re-frame.machines` — see [04 — Machines](../../machines/api.md).
 
 ## Frames
 
@@ -144,7 +130,7 @@ The schema-introspection surfaces are rowed in [08 — Schemas](08-schemas.md). 
   ```clojure
   (compute-sub query-v db)
   ```
-- **Description**: Pure sub computation against an `app-db` value. Use in tests; use in agent tooling that wants to evaluate subs against an artificial state.
+- Pure sub computation against an `app-db` value — full contract in [10 — Testing](10-testing.md).
 
 (Cross-rowed in [10 — Testing](10-testing.md).)
 

--- a/docs/core/api/13-lifecycle.md
+++ b/docs/core/api/13-lifecycle.md
@@ -10,6 +10,12 @@ This chapter is about the surfaces that bring a re-frame2 process up and take it
 
 An app author learns one boot sentence — **install an adapter with `init!`, then create your frame(s) explicitly** — and nothing else. The adapter-author surfaces (install / dispose / inspect, and the spec-map slots) are *not* peer choices beside `init!`; they sit one layer down and an ordinary app never touches them. The frame-startup lane is a third thing again: it's about what a *single frame* does when it comes alive (`:initial-events`), independent of which substrate the process installed. Keep the three apart and the lifecycle reads cleanly.
 
+The lifecycle surfaces in this chapter live in `re-frame.core`:
+
+```clojure
+(:require [re-frame.core :as rf])
+```
+
 ## Application boot
 
 This is the only lane an app author needs. It has exactly two steps: install the substrate adapter once, then create your app's frame(s) explicitly. Frame creation is always under your control — `init!` creates none.

--- a/docs/core/api/14-adapters.md
+++ b/docs/core/api/14-adapters.md
@@ -6,6 +6,14 @@ This chapter is the per-substrate surface reference. The substrate-agnostic ergo
 
 Architecturally, the dependency direction is one-way: the adapter artefacts depend on `re-frame.core`; `re-frame.core` does not depend on any adapter. That's why UIx and Helix surfaces live in `re-frame.adapter.uix` / `re-frame.adapter.helix` rather than being re-exported from core — apps require the adapter they want and pass its `adapter` Var into `init!`.
 
+Each substrate has its own adapter namespace — require the one for your substrate:
+
+```clojure
+(:require [re-frame.adapter.uix    :as uix-adapter]    ; UIx
+          [re-frame.adapter.helix  :as helix-adapter]  ; Helix
+          [re-frame.adapter.reagent :as reagent-adapter]) ; Reagent (the inline default)
+```
+
 ## The Reagent adapter
 
 The CLJS reference's default substrate. Reagent ships in `re-frame.adapter.reagent` (full) and `re-frame.adapter.reagent-slim` (without the React server-rendering tax, for SSR pipelines that don't want to ship `react-dom/server`).
@@ -200,9 +208,7 @@ The `frame-provider` in all three adapters (Reagent, UIx, Helix) consumes the **
 
 ## DOM source-coord annotations
 
-Every adapter whose host has a DOM-attribute concept (all three — Reagent / UIx / Helix on the browser) injects `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. Format and exemptions (Fragments, non-DOM roots) are documented in [Spec 006 §Source-coord annotation](../../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory).
-
-Annotation is gated on `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production `:advanced` builds elide the attribute via dead-code elimination — there is no DOM-bytes cost in shipped bundles. The JVM SSR emitter mirrors the contract per [Spec 011 §Source-coord annotation under SSR](../../../spec/011-SSR.md#source-coord-annotation-under-ssr).
+Adapters inject `data-rf2-source-coord` on every registered view's root element; the contract is documented in [02 — Views §DOM source-coord annotations](02-views.md#dom-source-coord-annotations).
 
 ## The Plain Atom adapter
 

--- a/docs/core/api/README.md
+++ b/docs/core/api/README.md
@@ -30,6 +30,7 @@ The core surfaces live in `re-frame.core`. Per-feature artefacts ship their own 
 | `re-frame.schemas` | `day8/re-frame2-schemas` | Schema introspection (the registration macros live in `re-frame.core`). |
 | `re-frame.http` | `day8/re-frame2-http` | HTTP verb helpers `get` / `post` / `put` / `delete` / `patch` / `head` / `options`. |
 | `re-frame.machines` | `day8/re-frame2-machines` | Direct machine surface (the `reg-machine` macro is re-exported through `re-frame.core`). |
+| `re-frame.routing` | `day8/re-frame2-routing` | Routing — `reg-route` (re-exported through `re-frame.core`), navigation, URL helpers, the `:rf/route` slice, `:can-leave`. |
 | `re-frame.ssr` | `day8/re-frame2-ssr` | Server-side rendering — `render-to-string`, streaming, head model, error projection. |
 | `re-frame.ssr.ring` | `day8/re-frame2-ssr-ring` | Ring host-adapter for SSR. |
 | `re-frame.epoch` | `day8/re-frame2-epoch` | Time-travel surfaces — `epoch-history`, `restore-epoch!`, `replace-app-db!`. Re-exported through `re-frame.core` via late-bind. |

--- a/docs/machines/api.md
+++ b/docs/machines/api.md
@@ -10,6 +10,13 @@ This chapter covers the registration surface (the `reg-machine` / `defmachine` m
 
 For the full treatment — the capability matrix and the underlying model — see [005-StateMachines.md](../../spec/005-StateMachines.md).
 
+This chapter spans `re-frame.core` (the `reg-machine` / `defmachine` macros) and `re-frame.machines` (the engine, query, and transition surfaces):
+
+```clojure
+(:require [re-frame.core     :as rf]
+          [re-frame.machines :as machines])
+```
+
 ## Registration
 
 ### `reg-machine`
@@ -48,6 +55,15 @@ For the full treatment — the capability matrix and the underlying model — se
   (re-frame.machines/machine-transition definition snapshot event) → [next-snapshot effects]
   ```
 - **Description**: The pure transition fn. Given a machine definition, a current snapshot, and an event, returns the next snapshot and the effect map. JVM-runnable; the conformance harness uses this as its primary test surface for machine behaviour.
+- **Worked example** — drive a transition and assert on the snapshot (JVM-runnable, no live frame needed):
+  ```clojure
+  (let [definition          (machines/machine-meta :session)
+        snapshot            {:state :anonymous :data {}}
+        [next-snap effects] (machines/machine-transition definition snapshot [:login {:user "alice"}])]
+    (is (= :authenticating (:state next-snap)))
+    (is (= "alice" (get-in next-snap [:data :credentials :user])))
+    (is (= [[:rf.http/managed ...]] (:fx effects))))
+  ```
 
 ### A minimal machine
 

--- a/docs/resources/api.md
+++ b/docs/resources/api.md
@@ -6,6 +6,12 @@ Resources are an **optional, post-v1 capability** — they ship in `day8/re-fram
 
 > **Scope is HTTP-only.** The first public-beta surface is **landed and complete**: the read-resource MVP, **mutations** (`reg-mutation` / `:rf.mutation/execute`, the causal-write counterpart — see [Mutations](#mutations)), **focus/reconnect active-stale revalidation** (`:rf.resource/window-focused` / `:rf.resource/network-reconnected` + the `install-revalidation-listeners!` / `remove-revalidation-listeners!` host-listener fns — see [Revalidation](#focusreconnect-revalidation)), and **active-owner polling** (`:poll-interval-ms` — see [Polling](#polling)). **GraphQL is deferred** to a later slice. See [Guide ch.27 §What's deferred](concepts.md).
 
+The resource surfaces are on the `re-frame.core` facade (`reg-resource` / `reg-mutation`); the events and subscriptions are keyword-addressed:
+
+```clojure
+(:require [re-frame.core :as rf])
+```
+
 ## Registration
 
 ### `reg-resource`

--- a/docs/resources/http-api.md
+++ b/docs/resources/http-api.md
@@ -6,6 +6,13 @@ You don't get this for free — Spec 014 is an **optional capability**. Implemen
 
 This chapter covers the canonical fx, the verb helpers, the test stubs, the request-interceptor surface, and the closed failure taxonomy. The normative source — args map, decode pipeline, retry semantics, reply addressing — lives at [014-HTTPRequests.md](../../spec/014-HTTPRequests.md).
 
+The verb helpers live in `re-frame.http`; the `:rf.http/managed` fx is keyword-addressed (used in an event's `:fx`):
+
+```clojure
+(:require [re-frame.http :as rf.http]
+          [re-frame.core :as rf])
+```
+
 ## The canonical fx
 
 ### `[:rf.http/managed args-map]`

--- a/docs/routing/api.md
+++ b/docs/routing/api.md
@@ -6,6 +6,13 @@ The point isn't novelty — every SPA framework has a router. The point is that 
 
 This chapter covers the registration shape, the dispatch / sub / fx surface, and the helpers that map URLs to/from route ids. For nav-token semantics, `:can-leave` flows, query strings, and multi-frame routing, see [Guide ch.19 — Routing reference](concepts.md). The normative source is [012-Routing.md](../../spec/012-Routing.md).
 
+The `reg-route` macro is on the `re-frame.core` facade; the rest of the routing surface lives in `re-frame.routing`:
+
+```clojure
+(:require [re-frame.core    :as rf]
+          [re-frame.routing :as routing])
+```
+
 ## Registration
 
 ### `reg-route`

--- a/docs/ssr/api.md
+++ b/docs/ssr/api.md
@@ -6,7 +6,15 @@ This works because the framework was designed around immutable data and an expli
 
 This chapter covers the rendering primitives (`render-to-string`, the streaming triple, the structural-hash), the head model (`reg-head`, `active-head`, `render-head`), the per-request response accumulator and its server-only fx, the error-projection seam (`reg-error-projector`, `project-error`), and the `:platforms` metadata that gates fx execution by active platform.
 
-The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces live in `re-frame.ssr` (artefact `day8/re-frame2-ssr`); the Ring host-adapter lives in `re-frame.ssr.ring`. The implementation ships in a separate artefact — you add `day8/re-frame2-ssr` to your deps and require the namespace to get the full surface. For convenience, a curated set of the rendering and head primitives is **re-exported from `re-frame.core` as late-bound wrappers** (`render-to-string`, `render-tree-hash`, `project-error`, `render-head`, `active-head`, `head-model->html`, `head-snapshot`): these resolve to the `re-frame.ssr` implementation at call time when the artefact is on the classpath, and throw a clear "SSR not loaded" error otherwise. So apps that already `(:require [re-frame.core :as rf])` can call `rf/render-to-string` directly; the host-adapter surface (`re-frame.ssr.ring`) and the per-request `:rf.server/*` fx are **not** re-exported — require `re-frame.ssr` / `re-frame.ssr.ring` for those.
+The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces live in `re-frame.ssr` (artefact `day8/re-frame2-ssr`); the Ring host-adapter lives in `re-frame.ssr.ring`. The implementation ships in a separate artefact — you add `day8/re-frame2-ssr` to your deps and require the namespace to get the full surface. For convenience, a curated set of the rendering and head primitives is **re-exported from `re-frame.core` as late-bound wrappers** (`render-to-string`, `render-tree-hash`, `project-error`, `render-head`, `active-head`, `head-model->html`, `head-snapshot`): these resolve to the `re-frame.ssr` implementation at call time when the artefact is on the classpath, and throw a clear "SSR not loaded" error otherwise. So apps that already `(:require [re-frame.core :as rf])` can call `rf/render-to-string` directly; the host-adapter surface (`re-frame.ssr.ring`) and the per-request `:rf.server/*` fx are **not** re-exported — require `re-frame.ssr` / `re-frame.ssr.ring` for those. The two registration macros `reg-head` and `reg-error-projector` are also `re-frame.core` facade exports (rowed in [01 — Core](../core/api/01-core.md)).
+
+The render/head primitives are re-exported on the `re-frame.core` facade; the full SSR surface and the Ring host adapter live in their own namespaces:
+
+```clojure
+(:require [re-frame.core    :as rf]
+          [re-frame.ssr     :as ssr]
+          [re-frame.ssr.ring :as ssr.ring])
+```
 
 ## Rendering primitives
 


### PR DESCRIPTION
Audited all 15 API docs against **`spec/Ownership.md`** (the canonical "where does X live" matrix) and fixed content that broke its *reference, don't redefine* rule — plus added the require block you asked for at the top of every chapter.

## Ownership fixes
- **01-core**: the 7 re-exported cross-artefact registration macros (`reg-machine`/`reg-route`/`reg-head`/`reg-error-projector`/`reg-flow`/`reg-app-schema`/`-schemas`) and `reg-view`/`reg-view*` were *re-defining* contracts owned by other chapters → pruned each to a **pointer row** (Kind + Signature + one-liner + link). The registration list stays discoverable; the full contract lives once, in its home.
- **01-core**: **removed `clear-flow`** — not a `re-frame.core` surface at all (home is `re-frame.flows`; in 05-flows). The one true interloper.
- **01-core**: "Reading a machine's snapshot" + the `dispatch-to-system` reverse-index mechanics → pointers (machines owns them).
- **02-views**: ~88 lines of per-substrate adapter surface (UIx/Helix) + Reagent adapter-spec detail were duplicates of 14-adapters → collapsed to orientation + pointer.
- **DOM source-coord annotations** was triplicated (02-views/11/14) → 02-views canonical, the other two point to it.
- **12-registrar**: the `## Machines` rows duplicated machines/api.md and aren't core → pointer; `compute-sub` → pointer (10-testing canonical).
- **10-testing → machines/api.md**: **moved** the machine-transition worked test example to the machines chapter (which had the surface row but no example), fixed to `re-frame.machines/` namespacing. Also fixed a real error — 10-testing listed `machine-transition` as a `re-frame.core` primitive (it's `re-frame.machines`).
- **08-schemas**: data-classification teaching (dup of how-to ch.23) → the four commit-plane effect rows + pointer.
- **03-effects**: `validate-at-boundary-interceptor` → pointer (08 canonical); machine `:fx` rows trimmed of internals.
- **README**: added the missing `re-frame.routing` namespace row.

Capability files (machines/resources/routing/ssr) + 05-flows/13-lifecycle/15-removed were already in-domain — they only gained require blocks.

## Require blocks
Every chapter now opens with the `(:require …)` for the surfaces it documents, using house aliases (`rf` / `machines` / `schemas` / `rf.http` / `ssr` / `routing` / `flows` / `uix-adapter` / `helix-adapter` / `ts` / `th` / `epoch`), derived from the api-manifest namespace homes (most primary macros are facade-exported on `re-frame.core`; secondary/introspection surfaces carry their own namespace).

## Verification (local)
`check_doc_slugs`, the three residue checkers, README links, and the **api-manifest JVM gate** (53 tests, 0 failures; `docs/core/api/` references reconcile against the manifest). `mkdocs --strict` runs in CI.

## Not included
This is content-ownership only. The heading-hierarchy change (symbols → `##`, "On this page" index) we discussed is a separate follow-up.