### PR TITLE
docs(api): complete review — /spec-free (CLJS corpus only), better examples, with-frame placement

### DIFF
--- a/docs/core/api/01-core.md
+++ b/docs/core/api/01-core.md
@@ -55,7 +55,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-sub id ?metadata input-fn? computation-fn)
   ```
-- **Description**: "Computed view over `app-db` and other subs." `reg-sub` supports **three input-production modes** — every subscription has an *input query-vector producer*: a layer-1 app-db reader has no producer, `:<-` is the literal producer, and a parametric `input-fn` is the query-parametric producer. The optional first fn is a v2 **`input-fn`** — a *pure* function from the outer `query-v` to a **vector of query vectors**; it is **not** a v1 reaction-returning signal fn (it must not call `subscribe`, deref `app-db`, dispatch, or perform IO, and it must not return live reactions). The runtime resolves each returned query vector in the *same frame* as the outer subscription. This is the only sub-registration form in v2 — `reg-sub-raw` is gone (see the [migration reference](../../../migration/from-re-frame-v1/README.md) for the replacement guidance). Full contract, input grammar, and error ids: [spec API §`reg-sub` input-production modes](../../../spec/API.md#reg-sub-input-production-modes) and [spec 006 — Reactive Substrate](../../../spec/006-ReactiveSubstrate.md). The teaching walkthrough is [Guide ch.05 §Three ways a sub names its inputs](../concepts/subscriptions.md).
+- **Description**: "Computed view over `app-db` and other subs." `reg-sub` supports **three input-production modes** — every subscription has an *input query-vector producer*: a layer-1 app-db reader has no producer, `:<-` is the literal producer, and a parametric `input-fn` is the query-parametric producer. The optional first fn is a v2 **`input-fn`** — a *pure* function from the outer `query-v` to a **vector of query vectors**; it is **not** a v1 reaction-returning signal fn (it must not call `subscribe`, deref `app-db`, dispatch, or perform IO, and it must not return live reactions). The runtime resolves each returned query vector in the *same frame* as the outer subscription. This is the only sub-registration form in v2 — `reg-sub-raw` is gone (see the [migration reference](../../../migration/from-re-frame-v1/README.md) for the replacement guidance). The full input grammar, the three input-production modes, and the error ids live in the [Subscriptions concept guide](../concepts/subscriptions.md). The teaching walkthrough is [Guide ch.05 §Three ways a sub names its inputs](../concepts/subscriptions.md).
 
 | Mode | Form | Where the inputs come from |
 |---|---|---|
@@ -163,7 +163,7 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (make-frame opts) ; → live frame value
   ```
-- **Description**: The **single public constructor** for a live frame. It accepts image-selection options *and* frame-configuration options in **one** call and **returns the live frame value** — one frame value backed by one registry. Useful for per-mount lifecycles — devcards, modal stacks, multiple live instances of a widget, dynamic tabs, tests, and the SSR per-request frame pattern. The `reg-frame` named path is the front-porch surface; `make-frame` is the advanced per-instance one. Opts: the image-selection keys `:images` (always a vector — the assembled registration set the frame resolves against), `:id` (optional — registers the frame in the one process-local live-frame registry; a duplicate live id is **idempotent replacement** that preserves durable state on re-mount, not a blanket fail-loud — irreconcilable conflicts still fail loud), `:capabilities`, `:adapter` — **and**, in the same call, the frame-configuration keys `:initial-events` (a vector of event vectors dispatched into the new frame at creation — seed `app-db` with `[[:rf/set-db {…}]]`), `:fx-overrides`, `:platform`, `:ssr`, `:doc`, `:preset`, `:tags`. A frame created **without** an `:id` bypasses the registry — a direct local reference for tests and harnesses. **Route by id, not by value:** the frame value's representation is not an app-facing contract — read its id via the one accessor `rf/frame-value->id` and pass the **id** to `dispatch` / `subscribe` / providers / tools. Lifecycle is the caller's responsibility — pair a direct `make-frame` with a `destroy-frame!` in the `:finally` of `r/with-let`, or use the UI-owned `rf/frame-provider` boundary (below) for view-owned lifetimes. See [spec/002 §Per-instance frames](../../../spec/002-Frames.md#per-instance-frames--make-frame-the-ep-0023-object-constructor) and [EP-0024](../../EP/EP-0024-unified-frame-identity-and-lifecycle.md).
+- **Description**: The **single public constructor** for a live frame. It accepts image-selection options *and* frame-configuration options in **one** call and **returns the live frame value** — one frame value backed by one registry. Useful for per-mount lifecycles — devcards, modal stacks, multiple live instances of a widget, dynamic tabs, tests, and the SSR per-request frame pattern. The `reg-frame` named path is the front-porch surface; `make-frame` is the advanced per-instance one. Opts: the image-selection keys `:images` (always a vector — the assembled registration set the frame resolves against), `:id` (optional — registers the frame in the one process-local live-frame registry; a duplicate live id is **idempotent replacement** that preserves durable state on re-mount, not a blanket fail-loud — irreconcilable conflicts still fail loud), `:capabilities`, `:adapter` — **and**, in the same call, the frame-configuration keys `:initial-events` (a vector of event vectors dispatched into the new frame at creation — seed `app-db` with `[[:rf/set-db {…}]]`), `:fx-overrides`, `:platform`, `:ssr`, `:doc`, `:preset`, `:tags`. A frame created **without** an `:id` bypasses the registry — a direct local reference for tests and harnesses. **Route by id, not by value:** the frame value's representation is not an app-facing contract — read its id via the one accessor `rf/frame-value->id` and pass the **id** to `dispatch` / `subscribe` / providers / tools. Lifecycle is the caller's responsibility — pair a direct `make-frame` with a `destroy-frame!` in the `:finally` of `r/with-let`, or use the UI-owned `rf/frame-provider` boundary (below) for view-owned lifetimes. See the [Frames concept guide](../concepts/frames.md#when-you-want-more-than-one) and [EP-0024](../../EP/EP-0024-unified-frame-identity-and-lifecycle.md).
 - **Example**:
   ```clojure
   ;; A component that OWNS a frame lifetime uses the UI-owned provider,
@@ -247,7 +247,7 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
 
 ### See also
 
-- [02 — Views](02-views.md) for `reg-view*` in detail, the `view` lookup form, and the substrate-agnostic ergonomic surface (`capture-frame`, `with-frame`, `frame-provider`).
+- [02 — Views](02-views.md) for `reg-view*` in detail, the `view` lookup form, and the substrate-agnostic ergonomic surface (`capture-frame`, `frame-provider`).
 - [03 — Effects and interceptors](03-effects.md) for what the `reg-event` handler's return value can carry.
 - [12 — Registrar](12-registrar.md) for the read-side of the registrar — `registrations`, `handler-ids`, `handler-meta`.
 
@@ -340,13 +340,13 @@ These are the two verbs that drive the cascade. `dispatch` says "an event happen
   (unsubscribe query-v) → nil
   (unsubscribe query-v opts) → nil
   ```
-- **Description**: Decrement the cache ref-count for a query. When the count hits zero, the entry is disposed **synchronously** (per Spec 006 §Reference counting and disposal). Most callers don't reach for this directly — Reagent / UIx / Helix adapters wire it on unmount. Target a non-ambient frame via `{:frame …}`.
+- **Description**: Decrement the cache ref-count for a query. When the count hits zero, the entry is disposed **synchronously** — see [Subscriptions](../concepts/subscriptions.md). Most callers don't reach for this directly — Reagent / UIx / Helix adapters wire it on unmount. Target a non-ambient frame via `{:frame …}`.
 
 ### Reading a machine's snapshot
 
 Subscribe to `[:rf/machine machine-id]` for a reaction over the machine's `{:state :data}` snapshot. See [04 — Machines](../../machines/api.md).
 
-**The `opts` map.** `dispatch` and `subscribe` accept a uniform opts map: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. Envelope shape and semantics live in [002 §Routing: the dispatch envelope](../../../spec/002-Frames.md#routing-the-dispatch-envelope). The most common pattern is `(rf/dispatch [::save x] {:frame :todo})` to target a non-default frame.
+**The `opts` map.** `dispatch` and `subscribe` accept a uniform opts map: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. Envelope shape and semantics live in the [event-envelope glossary entry](../glossary.md#event-envelope). The most common pattern is `(rf/dispatch [::save x] {:frame :todo})` to target a non-default frame.
 
 ### Canonical event-vector shape
 
@@ -356,11 +356,11 @@ The runtime tolerates several shapes; the linter nudges new code toward one:
 - `[<id> <single-scalar>]` — single-arg events
 - `[<id> {<k> <v>}]` — multi-arg events as a single map payload (the canonical form for two-or-more args)
 
-Variadic `[<id> a b c]` is tolerated, but the map form is the one to reach for in new code — it survives field-additions without breaking callers and reads at the call site. See [Conventions §Canonical event-vector shape](../../../spec/Conventions.md#canonical-event-vector-shape-best-practice).
+Variadic `[<id> a b c]` is tolerated, but the map form is the one to reach for in new code — it survives field-additions without breaking callers and reads at the call site. See [Events and the cascade — an event is a fact](../concepts/events-and-the-cascade.md#an-event-is-a-fact).
 
 ### Standard events
 
-The framework ships a small, fixed set of standard `:rf/*` events you can dispatch like any other. They are framework-owned: the `:rf/*` single-root namespace is reserved ([Conventions §Reserved namespaces](../../../spec/Conventions.md#reserved-namespaces-framework-owned)), so re-registering one with `reg-event` is a loud reserved-id collision (`:rf.error/reserved-event-id`) rather than a silent shadow.
+The framework ships a small, fixed set of standard `:rf/*` events you can dispatch like any other. They are framework-owned: the `:rf/*` single-root namespace is reserved for the framework, so re-registering one with `reg-event` is a loud reserved-id collision (`:rf.error/reserved-event-id`) rather than a silent shadow.
 
 #### `:rf/set-db`
 
@@ -400,9 +400,37 @@ The two compose: the named-target fx ultimately dispatches, so the same trace st
 
 ## Frames: the scoping primitive
 
-A frame is the scoping unit for `app-db`, the event queue, and the cascade. Most apps have exactly one frame. You establish it at your root with the merged `rf/frame-provider`, which takes one of two config shapes (see [EP-0024](../../../spec/002-Frames.md#the-multi-frame-surface--choose-by-intent)): scope an already-registered frame into the React tree with `[rf/frame-provider {:frame :app} …]` (or, for non-React lexical regions, `(rf/with-frame :app …)`), or let `[rf/frame-provider {:id :app …} …]` **ensure** the frame — it creates it on first mount, reuses it without re-seeding on remount, and provides its id to descendants (no destroy-on-unmount). `init!` does **not** create one for you — frame identity is carried, not synthesised from absence (see [EP-0002](../../../spec/002-Frames.md#frame-target-resolution--the-carried-invariant)). Apps that need isolation between subsystems — embedded widgets, multi-tab pair tools, the SSR per-request runtime — register additional frames and dispatch / subscribe against them via `{:frame :other}` (the frame **id** is the public routing address).
+A frame is the scoping unit for `app-db`, the event queue, and the cascade. Most apps have exactly one frame. You establish it at your root with the merged `rf/frame-provider`, which takes one of two config shapes (see the [frame-provider glossary entry](../glossary.md#frame-provider)): scope an already-registered frame into the React tree with `[rf/frame-provider {:frame :app} …]` (or, for non-React lexical regions, `(rf/with-frame :app …)`), or let `[rf/frame-provider {:id :app …} …]` **ensure** the frame — it creates it on first mount, reuses it without re-seeding on remount, and provides its id to descendants (no destroy-on-unmount). `init!` does **not** create one for you — frame identity is carried, not synthesised from absence (see [Frame identity is carried, not found](../glossary.md#frame-identity-is-carried-not-found)). Apps that need isolation between subsystems — embedded widgets, multi-tab pair tools, the SSR per-request runtime — register additional frames and dispatch / subscribe against them via `{:frame :other}` (the frame **id** is the public routing address).
 
 `reg-frame` and `make-frame` are rowed in **Registration** above. The two read-side surfaces — `frame-ids` and `frame-meta` — are defined in [12 — Registrar](12-registrar.md) alongside the rest of the registrar-query surface (`registrations`, `handler-meta`).
+
+### `with-frame` / `with-new-frame`
+
+- **Kind**: macros (a sibling pair)
+- **Signatures**:
+  ```clojure
+  (with-frame :keyword body)        ;; pin *current-frame* to an existing frame-id
+  (with-new-frame [sym expr] body)  ;; eval expr, bind id to sym, run, destroy on exit
+  ```
+- **Description**: The two **lexical** (non-React) frame-scoping macros — the regions that aren't a view tree, chiefly tests, the REPL, and SSR. `with-frame` pins `*current-frame*` to an **existing** frame-id for the dynamic extent of `body`, creating and destroying nothing; it is the lexical counterpart to the `rf/frame-provider` `{:frame …}` SCOPE shape (a dynamic var cannot cross React's render boundary, which is why the provider exists for the view tree). `with-new-frame` evaluates `expr`, binds the resulting frame-id to `sym`, runs `body` in that frame's dynamic context, and **destroys the frame on exit** — the throwaway-frame form for one-off harnesses. Each rejects the other's argument shape at compile time: a vector binding handed to `with-frame`, or a bare keyword handed to `with-new-frame`, fails at macroexpand.
+- **Example**:
+  ```clojure
+  ;; Pin form — bind *current-frame* to an existing id for the body (most common)
+  (rf/with-frame :todo
+    (rf/dispatch-sync [:todo/add {:text "milk"}]))
+
+  ;; Pin to a computed id — pass the keyword directly, no extra binding
+  (let [chosen (pick-frame-id route)]
+    (rf/with-frame chosen
+      (rf/dispatch-sync [:todo/clear-completed])))
+
+  ;; Eval-bind-run-destroy — a throwaway frame for one test, torn down on exit.
+  ;; Body runs in f's dynamic context, so bare dispatch-sync targets it.
+  (rf/with-new-frame [f (rf/make-frame {:images [todo-image]})]
+    (rf/dispatch-sync [:rf/set-db {:todos []}])         ;; seed via a setup dispatch
+    (rf/dispatch-sync [:todo/add {:text "milk"}])
+    (is (= 1 (count (:todos (rf/app-db-value f))))))    ;; frame destroyed on exit
+  ```
 
 ## Runtime configuration: `configure`
 
@@ -414,7 +442,7 @@ Process-level data knobs live behind `(rf/configure! {<key> <opts>})`. The vocab
 | `:trace-buffer` | `{:cascades-retained N}` | `{:cascades-retained 50}` | v1 (dev-only) | The dev-only per-frame trace ring's cascade-slot count. 0 disables retention (the surface stays live). An opts map without a usable `:cascades-retained` (e.g. the retired `{:depth N}` shape) is a no-op that emits a `:rf.warning/trace-buffer-unrecognised-opts` trace. |
 | `:elision` | `{:rf.size/threshold-bytes N}` | `{:rf.size/threshold-bytes 16384}` | v1 | The size threshold above which `elide-wire-value` substitutes a `:rf.size/large-elided` marker. 0 disables runtime auto-detect (only declared / schema entries elide). See [11 — Instrumentation](11-instrumentation.md). |
 
-> **No `:sub-cache` knob.** There is no `:sub-cache {:grace-period-ms N}` key — sub-cache disposal is synchronous on derefer-count → 0 (see [Spec 006 §Reference counting and disposal](../../../spec/006-ReactiveSubstrate.md#reference-counting-and-disposal)).
+> **No `:sub-cache` knob.** There is no `:sub-cache {:grace-period-ms N}` key — sub-cache disposal is synchronous on derefer-count → 0 (see [Subscriptions — lifecycle](../concepts/subscriptions.md#lifecycle-a-sub-exists-only-while-something-watches-it)).
 
 SSR error-projection policy (`:public-error-id`, `:dev-error-detail?`) is **not** a `configure` key — it's per-frame metadata on the frame's `:ssr` map, because different frames in the same process can carry different projector settings.
 

--- a/docs/core/api/02-views.md
+++ b/docs/core/api/02-views.md
@@ -9,7 +9,7 @@ There are **two registration lanes**, and you almost certainly want only one of 
 
 If you're not sure, you're an application author: use the app-facing lane and skip the tooling lane entirely.
 
-This chapter also covers the substrate-agnostic ergonomic surface (`capture-frame`, `with-frame`, `with-new-frame`, `frame-provider`), and points at the per-adapter chapters for the substrate-specific hooks. If you want the Reagent vs UIx vs Helix conventions, see [13 — Lifecycle](13-lifecycle.md) and [14 — Adapters](14-adapters.md).
+This chapter also covers the substrate-agnostic ergonomic surface (`capture-frame`, `frame-provider`), and points at the per-adapter chapters for the substrate-specific hooks. If you want the Reagent vs UIx vs Helix conventions, see [13 — Lifecycle](13-lifecycle.md) and [14 — Adapters](14-adapters.md).
 
 The view-authoring surfaces in this chapter live in `re-frame.core`:
 
@@ -58,12 +58,16 @@ The macro accepts three shapes for the same registration. They produce the same 
 (rf/reg-view cart-line
   "One row in the cart table; receives a normalised item map."
   [item]
-  [:tr ...])
+  [:tr
+    [:td (:name item)]
+    [:td (:qty item)]])
 
 ;; With explicit id via metadata — useful when the symbol shouldn't drive the id
 ;; (e.g. you want a stable id across rename, or you're matching an external contract).
 (rf/reg-view ^{:rf/id :cart/line} cart-line [item]
-  [:tr ...])
+  [:tr
+    [:td (:name item)]
+    [:td (:qty item)]])
 ```
 
 In all three cases the symbol `cart-line` is `def`-ed so you can write `[cart-line item]` from sibling code. The macro also injects `dispatch` and `subscribe` as lexical bindings so you can call them without the `rf/` prefix inside the body; the `rf/` prefix is conventional.
@@ -118,7 +122,7 @@ A tool's own chrome — Story's panel grid, Xray's inspector views — is regist
 
 ## The substrate-agnostic ergonomic surface
 
-These surfaces work the same across Reagent, UIx, and Helix. They're how views interact with the running app without being tied to any single substrate's idiom. They sort into three intents: **scope or ensure a frame** (`frame-provider`, `with-frame`, `with-new-frame`), **hold** (`capture-frame` — the one public carry primitive), and **override** (the `{:frame …}` opt, rowed in [01 — Core](01-core.md)). The full design lives at [Spec 002 §The multi-frame surface](../../../spec/002-Frames.md#the-multi-frame-surface--choose-by-intent).
+These surfaces work the same across Reagent, UIx, and Helix. They're how views interact with the running app without being tied to any single substrate's idiom. They sort into three intents: **scope or ensure a frame** (`frame-provider`), **hold** (`capture-frame` — the one public carry primitive), and **override** (the `{:frame …}` opt, rowed in [01 — Core](01-core.md)). The lexical (non-React) frame-scoping macros `with-frame` / `with-new-frame` are rowed in [01 — Core §Frames](01-core.md#frames-the-scoping-primitive), not here — they scope tests and SSR, not view authoring. The full design lives in the [Frames concept guide](../concepts/frames.md#when-you-want-more-than-one).
 
 ### `frame-provider`
 
@@ -131,16 +135,22 @@ These surfaces work the same across Reagent, UIx, and Helix. They're how views i
 - **Description**: One component, two config shapes chosen by the prop map.
   - **`{:frame existing-id}` — SCOPE.** "Children inside this provider see `:todo` as their current frame." Scopes a React subtree to a frame that **already exists** (created by `make-frame` / `reg-frame`, a tool runtime, or an enclosing `frame-provider`); creates / refreshes / destroys nothing. **Fails loud** (`:rf.error/frame-provider-frame-absent`) when the named frame is absent. `:frame` must be a keyword — a `nil` `:frame` is `:rf.error/no-frame-context`, a non-keyword `:frame` is `:rf.error/bad-frame-provider-arg`. The scope-into-React counterpart to `with-frame` (which a dynamic var cannot serve across React's render boundary).
   - **`{:id the-id …}` — ENSURE.** Creates the frame if absent (via `make-frame`, taking the same constructor opts: `:id` / `:images` / record-config incl. `:initial-events`), **reuses it without re-seeding** if present (an idempotent re-mount preserves durable state and does not replay `:initial-events`), and provides its id to descendants. There is **no destroy-on-unmount**. Reach for it when a view should bring its own frame into being for as long as it is mounted (comparison pages, Story canvases, embedded widgets). `:id` is required and must be a keyword (`:rf.error/ensure-frame-provider-missing-id` otherwise). True ownership — tearing the frame down when the component unmounts — stays explicit: `make-frame` + `destroy-frame!` inside a `create-class`.
-
-### `with-frame` / `with-new-frame`
-
-- **Kind**: macros (sibling pair)
-- **Signatures**:
+- **Example**:
   ```clojure
-  (with-frame :keyword body)        ;; pin to an existing frame-id
-  (with-new-frame [sym expr] body)  ;; eval, bind, run, destroy on exit
+  ;; SCOPE — :todo already exists (reg-frame / make-frame / a tool runtime, or an
+  ;; enclosing provider). This subtree just renders against it; nothing is created
+  ;; or destroyed, and an absent :todo fails loud.
+  (rf/reg-view todo-page []
+    [rf/frame-provider {:frame :todo}
+     [todo-list]])
+
+  ;; ENSURE — bring the :todo frame into being for as long as this subtree is
+  ;; mounted: created on first mount from the listed images, reused without
+  ;; re-seeding on remount, never torn down on unmount.
+  (rf/reg-view todo-widget []
+    [rf/frame-provider {:id :todo :images [todo-image]}
+     [todo-list]])
   ```
-- **Description**: `with-frame` pins `*current-frame*` to an existing frame-id; the frame is not created or destroyed. `with-new-frame` evals `expr`, binds the resulting id to `sym`, runs body in that frame's dynamic context, and destroys the frame on exit. Each rejects the other's argument shape at compile time. Documented in [002 §with-frame and with-new-frame](../../../spec/002-Frames.md#with-frame-and-with-new-frame).
 
 ### `capture-frame`
 
@@ -165,7 +175,7 @@ These surfaces work the same across Reagent, UIx, and Helix. They're how views i
 
 ### When to reach for `capture-frame`
 
-The verbs `dispatch` and `subscribe` read the current frame ambiently (dynamic var → React context) at call time. That's fine when the call sits *inside* an established scope — inside a render, an event handler, a sub computation, a `with-frame` block. It breaks when the call sits *outside* that scope — a Promise callback, a `setTimeout`, a WebSocket `onmessage`, an IntersectionObserver. By the time the callback fires, the ambient scope has unwound, the token carries no frame stamp, and a bare `(rf/dispatch [::foo])` fails loudly with `:rf.error/no-frame-context` — the runtime never synthesises `:rf/default` from absence; frame identity is *carried*, not *found* (see [EP-0002](../../../spec/002-Frames.md#frame-target-resolution--the-carried-invariant)).
+The verbs `dispatch` and `subscribe` read the current frame ambiently (dynamic var → React context) at call time. That's fine when the call sits *inside* an established scope — inside a render, an event handler, a sub computation, a `with-frame` block. It breaks when the call sits *outside* that scope — a Promise callback, a `setTimeout`, a WebSocket `onmessage`, an IntersectionObserver. By the time the callback fires, the ambient scope has unwound, the token carries no frame stamp, and a bare `(rf/dispatch [::foo])` fails loudly with `:rf.error/no-frame-context` — the runtime never synthesises `:rf/default` from absence; frame identity is *carried*, not *found* (see [Frame identity is carried, not found](../glossary.md#frame-identity-is-carried-not-found)).
 
 The fix is to capture the frame *at the point you have it* and carry it as a value with **`capture-frame`**: build the operation bundle inside a render body or under `with-frame`, store it, and invoke its `:dispatch` / `:subscribe` ops from any later async context.
 
@@ -176,27 +186,7 @@ The fix is to capture the frame *at the point you have it* and carry it as a val
     (js/setTimeout #(dispatch [::tick]) 1000)))  ;; fires :tool even after with-frame unwinds
 ```
 
-Full async-boundary contract (the four routing patterns and the React click-handler case): [Spec 002 §React click-handler routing](../../../spec/002-Frames.md#react-click-handler-routing--the-canonical-pattern).
-
-### `with-frame` and `with-new-frame` — the sibling pair
-
-```clojure
-;; Pin form — most common: bind *current-frame* to an existing id
-(rf/with-frame :todo
-  (rf/dispatch [::add-item ...]))
-
-;; Pin to a computed id — pass the keyword directly, no extra binding
-(let [chosen (compute-frame-id ...)]
-  (rf/with-frame chosen
-    (rf/dispatch [::action chosen])))
-
-;; Eval-bind-run-destroy form — create a throwaway frame for the body
-(rf/with-new-frame [f (rf/make-frame {:images [test-image]})]
-  (rf/dispatch-sync [:test/initialise])   ;; seed via a setup dispatch
-  (rf/dispatch [::action f]))   ;; frame destroyed on exit
-```
-
-Full semantics in [002 §with-frame and with-new-frame](../../../spec/002-Frames.md#with-frame-and-with-new-frame).
+Full async-boundary contract (the four routing patterns and the React click-handler case): [Frames — the async boundary](../concepts/frames.md#the-async-boundary-capture-the-frame).
 
 ## Reagent: the default substrate
 
@@ -218,7 +208,7 @@ Annotation is gated on `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`
 
 The JVM SSR emitter mirrors the same contract so server-rendered HTML can be clicked back to the source position before any hydration happens.
 
-Full contract: [Spec 006 §Source-coord annotation](../../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory) and [Spec 011 §Source-coord annotation under SSR](../../../spec/011-SSR.md#source-coord-annotation-under-ssr).
+Full contract: the [Observability concept guide](../concepts/observability.md) covers how source-coord annotations power click-to-source in Xray, and the [SSR API chapter](../../ssr/api.md) covers the server-rendered counterpart that survives until hydration.
 
 ## See also
 

--- a/docs/core/api/03-effects.md
+++ b/docs/core/api/03-effects.md
@@ -21,24 +21,24 @@ Closed: **`:db` + `:fx` only**. That's the entire effect-map vocabulary in v2.
 
 If you remember v1's `:dispatch` / `:dispatch-later` / `:dispatch-n` at the top level of the effect map, those don't exist any more — they're inside `:fx`. The migration is mechanical; see [MIGRATION §M-8](../../../migration/from-re-frame-v1/README.md). The closed shape is what lets the conformance harness validate handler outputs across implementations.
 
-Full schema: [Spec-Schemas §`:rf/effect-map`](../../../spec/Spec-Schemas.md#rfeffect-map).
+The closed `:db` + `:fx` shape above is the entire `:rf/effect-map` schema — see the [effect map](../glossary.md#effect-map) glossary entry for the two reserved keys in plain language.
 
 ## Standard `:fx` entries
 
 Anything in `:fx` is a `[fx-id args]` pair. The runtime looks up `fx-id` in the `:fx` registrar and runs the registered handler against `args`. User code registers its own fx-ids via `reg-fx`; a small set of fx-ids is framework-reserved.
 
-| `[fx-id args]` | Args | Status | Spec | Intuition |
-|---|---|---|---|---|
-| `[:dispatch event-vec]` | event vector | v1 | 002 | "Schedule this event on the same queue." Async — runs after the current cascade completes. |
-| `[:dispatch-later {:ms ms :event event-vec}]` | options map | v1 | 002 | "Schedule this event after N ms." |
-| `[:rf.http/managed args-map]` | per `:rf.fx/managed-args` | v1 (optional) | 014 | The canonical managed-HTTP fx. See [07 — HTTP](../../resources/http-api.md). |
-| `[:rf.nav/push-url url-string]` | URL string | v1 | 012 | Navigate. See [06 — Routing](../../routing/api.md). |
-| `[:raise event-vec]` | event vector | v1 | 005 | **Machine-only.** Inside a machine action's `:fx`, routes the event back into the same machine atomically and pre-commit. Unbound outside machine actions. |
-| `[:rf.machine/spawn spawn-spec]` | per `:rf.fx/spawn-args` | v1 | 005 | Spawn a dynamic machine actor — see [04 — Machines](../../machines/api.md). |
-| `[:rf.machine/destroy actor-id]` | actor id (keyword) | v1 | 005 | Destroy a dynamic machine actor — see [04 — Machines](../../machines/api.md). |
-| `[:rf.fx/reg-flow flow-map]` | flow map | v1 | 013 | Register a flow at runtime via `:fx`. See [05 — Flows](05-flows.md). |
-| `[:rf.fx/clear-flow id]` | id | v1 | 013 | Clear a registered flow at runtime via `:fx`. |
-| `[:http args]` | impl-specific | — | — | User-registered via `reg-fx`. The legacy un-managed shape; new code uses `:rf.http/managed`. |
+| `[fx-id args]` | Args | Status | Intuition |
+|---|---|---|---|
+| `[:dispatch event-vec]` | event vector | v1 | "Schedule this event on the same queue." Async — runs after the current cascade completes. |
+| `[:dispatch-later {:ms ms :event event-vec}]` | options map | v1 | "Schedule this event after N ms." |
+| `[:rf.http/managed args-map]` | per `:rf.fx/managed-args` | v1 (optional) | The canonical managed-HTTP fx. See [07 — HTTP](../../resources/http-api.md). |
+| `[:rf.nav/push-url url-string]` | URL string | v1 | Navigate. See [06 — Routing](../../routing/api.md). |
+| `[:raise event-vec]` | event vector | v1 | **Machine-only.** Inside a machine action's `:fx`, routes the event back into the same machine atomically and pre-commit. Unbound outside machine actions. |
+| `[:rf.machine/spawn spawn-spec]` | per `:rf.fx/spawn-args` | v1 | Spawn a dynamic machine actor — see [04 — Machines](../../machines/api.md). |
+| `[:rf.machine/destroy actor-id]` | actor id (keyword) | v1 | Destroy a dynamic machine actor — see [04 — Machines](../../machines/api.md). |
+| `[:rf.fx/reg-flow flow-map]` | flow map | v1 | Register a flow at runtime via `:fx`. See [05 — Flows](05-flows.md). |
+| `[:rf.fx/clear-flow id]` | id | v1 | Clear a registered flow at runtime via `:fx`. |
+| `[:http args]` | impl-specific | — | User-registered via `reg-fx`. The legacy un-managed shape; new code uses `:rf.http/managed`. |
 
 SSR-side server-only fx (`:rf.server/set-status`, `:rf.server/set-header`, `:rf.server/redirect`, etc.) are rowed in [09 — SSR](../../ssr/api.md). Their `:platforms` metadata gates them off the client.
 
@@ -93,7 +93,7 @@ There is no standard `unwrap` interceptor in v2 (the v1 value is removed; a stal
 ```clojure
 (rf/reg-event :foo/update
   (fn [cofx {:keys [id new-value]}]           ;; second arg IS the payload map
-    ...))
+    {:db (assoc-in (:db cofx) [:foo id] new-value)}))
 
 ;; You wrote: (rf/dispatch [:foo/update {:id 1 :new-value "x"}])
 ```
@@ -111,7 +111,8 @@ The handler's second argument is the payload map directly — no interceptor req
 
 (rf/reg-event ::save-cart
   {:interceptors [:log-on-error]}                ;; reference by id
-  (fn [cofx _] ...))
+  (fn [cofx _]
+    {:db (assoc (:db cofx) :cart/saving? true)}))
 ```
 
 Register the interceptor once with `reg-interceptor`, then reference it **by id** from the `:interceptors` vector. The `:before` / `:after` fns receive and return the context map; `{:before :after}` is the entire behaviour vocabulary, and every standard interceptor is just a registered interceptor with specific behaviour baked in.
@@ -157,7 +158,7 @@ Most tests reach for `with-fx-overrides` because it scopes the swap to the test 
 
 ### `:fx-overrides` asymmetry
 
-At the pattern level (`(rf/dispatch event {:fx-overrides {:my/fx :other-fx-id}})`) the override value is an **id** — the registry name of another fx handler. The CLJS reference implementation **also** accepts a **fn** value (`{:my/fx (fn [args] ...)}`) for ergonomic test wiring. The asymmetry is documented: ports that don't ship fn-valued overrides remain pattern-conformant. See [002 §`:fx-overrides`](../../../spec/002-Frames.md#fx-overrides--replace-fx-handlers).
+At the pattern level (`(rf/dispatch event {:fx-overrides {:my/fx :other-fx-id}})`) the override value is an **id** — the registry name of another fx handler. The CLJS reference implementation **also** accepts a **fn** value (`{:my/fx (fn [args] ...)}`) for ergonomic test wiring. The asymmetry is deliberate: ports that don't ship fn-valued overrides remain pattern-conformant.
 
 ## See also
 

--- a/docs/core/api/05-flows.md
+++ b/docs/core/api/05-flows.md
@@ -4,7 +4,7 @@ A flow is a piece of derived state. You declare its inputs (a vector of frame-st
 
 Flows replace v1's `on-changes` interceptor — same compute-on-input-change semantics, registered in the runtime rather than wired into individual events. They also replace much of what `enrich` did. The point: derived state is now a *registered, named, observable, restorable* thing, not a closure hidden behind an interceptor.
 
-The normative source is [013-Flows.md](../../../spec/013-Flows.md).
+See the [Flows concept guide](../concepts/flows.md) for the conceptual companion to this reference.
 
 This chapter spans `re-frame.core` (the `reg-flow` macro) and `re-frame.flows` (`clear-flow`):
 
@@ -63,26 +63,26 @@ read. Outputs stay `app-db`-only.
    :output-path [:nav :on-checkout?]})                               ;; app-db output
 ```
 
-`:inputs` is a **positional vector** of frame-state paths; the values at those paths arrive as positional args to `:derive` in the same order (a map-keyed `:inputs` form is a deferred design option per [Spec 013 §Open questions](../../../spec/013-Flows.md#open-questions), not v1). Each path reads against the pending frame-state's two partitions — a **bare** path reads `app-db`, and a path led by `:rf.db/runtime` reads `runtime-db` (see [Spec 013 §Input partition](../../../spec/013-Flows.md#input-partition--bare--app-db-rfdbruntime---runtime-db)). The shape is data — no fn registration with a separate id, no interceptor wiring, no closure capture. The conformance harness validates flows by walking the registered data and applying it to a synthesised frame-state.
+`:inputs` is a **positional vector** of frame-state paths; the values at those paths arrive as positional args to `:derive` in the same order (a map-keyed `:inputs` form is a deferred design option, not v1). Each path reads against the pending frame-state's two partitions — a **bare** path reads `app-db`, and a path led by `:rf.db/runtime` reads `runtime-db`. The shape is data — no fn registration with a separate id, no interceptor wiring, no closure capture. The conformance harness validates flows by walking the registered data and applying it to a synthesised frame-state.
 
 ### The flow map
 
 | Key | Required | Notes |
 |---|---|---|
 | `:id` | yes | The registry key. Use a namespaced keyword. |
-| `:inputs` | yes | A vector of frame-state path vectors. Read positionally; the value at each path is passed to `:derive` in order. A bare path reads `app-db`; a path led by `:rf.db/runtime` reads `runtime-db` (see [Spec 013 §Input partition](../../../spec/013-Flows.md#input-partition--bare--app-db-rfdbruntime---runtime-db)). |
+| `:inputs` | yes | A vector of frame-state path vectors. Read positionally; the value at each path is passed to `:derive` in order. A bare path reads `app-db`; a path led by `:rf.db/runtime` reads `runtime-db`. |
 | `:derive` | yes | `(fn [in-1 in-2 ...] new-output)`. Pure; receives the input values positionally; called every time inputs change; must be deterministic. |
 | `:output-path` | yes | Where to write the output in `app-db`. |
 | `:doc` | no | One-sentence what-and-why; surfaces in tooling. |
-| `:schema` | no | Malli schema for the **output value**. Validated on every recompute in dev (and elided in production, like all schema validation). On failure the runtime emits `:rf.error/schema-validation-failure :where :flow-output` — **observational**: the output is still written (a flow output is materialised state downstream already reads), the trace surfaces the producer bug. Routes through the registered validator, so an app without the schemas artefact pays nothing. See [Spec 013 §Flow output validation](../../../spec/013-Flows.md#flow-output-validation). |
+| `:schema` | no | Malli schema for the **output value**. Validated on every recompute in dev (and elided in production, like all schema validation). On failure the runtime emits `:rf.error/schema-validation-failure :where :flow-output` — **observational**: the output is still written (a flow output is materialised state downstream already reads), the trace surfaces the producer bug. Routes through the registered validator, so an app without the schemas artefact pays nothing. |
 
 ### Frame-scoping
 
-The `:flow` registrar slot is **last-registration-wins across frames** — registering the same id against multiple frames shares one registrar slot keyed by `flow-id` only. For full per-frame discovery read the encapsulated runtime registry via the public snapshot accessor `re-frame.flows/flows-snapshot` (it returns the `{frame-id {flow-id flow-map}}` shape) — **not** the private `@re-frame.flows/flows` atom, which is an implementation detail behind the snapshot contract. The per-frame runtime registry is the source of truth for evaluation. See [013 §Frame-scoping](../../../spec/013-Flows.md#frame-scoping).
+The `:flow` registrar slot is **last-registration-wins across frames** — registering the same id against multiple frames shares one registrar slot keyed by `flow-id` only. For full per-frame discovery read the encapsulated runtime registry via the public snapshot accessor `re-frame.flows/flows-snapshot` (it returns the `{frame-id {flow-id flow-map}}` shape) — **not** the private `@re-frame.flows/flows` atom, which is an implementation detail behind the snapshot contract. The per-frame runtime registry is the source of truth for evaluation.
 
 ### Frame-destroy teardown
 
-`destroy-frame!` releases every per-frame piece of flow state — registry slot, `last-inputs` rows, registrar entries for ids the destroyed frame was last owner of. Sibling frames' state is preserved. See [013 §Frame-destroy teardown](../../../spec/013-Flows.md#frame-destroy-teardown).
+`destroy-frame!` releases every per-frame piece of flow state — registry slot, `last-inputs` rows, registrar entries for ids the destroyed frame was last owner of. Sibling frames' state is preserved.
 
 ## Runtime registration via `:fx`
 
@@ -99,29 +99,31 @@ The signature mirrors `reg-flow` / `clear-flow` exactly — same opts, same retu
 
 > A flow registered with `:rf.fx/reg-flow` **does not compute its initial output during that event.** It first fires on the **next** drain on the same frame.
 
-This is the single least-obvious flow behaviour, so it is worth internalising before you reach for `:rf.fx/reg-flow`. The reason is structural: the `:fx` walk is the *last* drain stage, and it runs **after** the flow transform has already evaluated this event's flows (see [Spec 013 §Drain integration](../../../spec/013-Flows.md#drain-integration)). The newly-registered flow simply was not in the registry when the transform walked, so it has nothing to compute on *this* event. It computes on the next drain on that frame.
+This is the single least-obvious flow behaviour, so it is worth internalising before you reach for `:rf.fx/reg-flow`. The reason is structural: the `:fx` walk is the *last* drain stage, and it runs **after** the flow transform has already evaluated this event's flows. The newly-registered flow simply was not in the registry when the transform walked, so it has nothing to compute on *this* event. It computes on the next drain on that frame.
 
 In the common case the lag is invisible — you register a flow in an `:enter`-style handler and the user's next interaction materialises the output. When you genuinely need the initial value *now*, dispatch a follow-up no-op event from the same handler to re-trigger the drain (the flow is in the registry by the time that dispatched event drains):
 
 ```clojure
 (rf/reg-event :wizard/enter-step-2
   (fn [_ _]
-    {:fx [[:rf.fx/reg-flow {:id     :step-2/computed
-                            :inputs [[:step-2 :foo] [:step-2 :bar]]
-                            :derive (fn [foo bar] (compute foo bar))
-                            :output-path [:step-2 :result]}]
+    ;; Step 2 wants a running order total derived from the quantity and
+    ;; unit price the user entered back on step 1.
+    {:fx [[:rf.fx/reg-flow {:id          :wizard/order-total
+                            :inputs      [[:wizard :qty] [:wizard :unit-price]]
+                            :derive      (fn [qty unit-price] (* qty unit-price))
+                            :output-path [:wizard :order-total]}]
           [:dispatch [:wizard/settle]]]}))   ;; flow computes on THIS drain
 
 (rf/reg-event :wizard/settle (fn [{:keys [db]} _] {:db db}))   ;; no-op; exists only to drain
 ```
 
-This is an explicit step — not a hidden one — and most apps never need it. There is a one-event lag before a flow recomputes, which preserves the one-install-per-event invariant. See [Spec 013 §Sequencing — the one-event lag](../../../spec/013-Flows.md#sequencing--the-one-event-lag).
+This is an explicit step — not a hidden one — and most apps never need it. There is a one-event lag before a flow recomputes, which preserves the one-install-per-event invariant.
 
 ## Failure semantics
 
 **Production-survivable.** A throw inside a flow's `:derive` fn surfaces as `:rf.error/flow-eval-exception` on the **always-on error-emit substrate** — registered `register-error-listener!` callbacks fire under CLJS `:advanced` + `goog.DEBUG=false`. The error is *not* trace-only; production deployments catch it.
 
-See [Spec 013 §Failure semantics](../../../spec/013-Flows.md#failure-semantics) rule 4 and [Spec 009 §Production builds](../../../spec/009-Instrumentation.md#production-builds-zero-overhead-zero-code).
+See [Report errors in production](../how-to/report-errors-in-production.md) for wiring the always-on error listeners that catch these in a deployed app.
 
 ## Flow vs sub: when to reach for which
 
@@ -134,5 +136,5 @@ A useful rule: if you find yourself writing `(reg-sub ::derived-total (fn [...])
 
 - [01 — Core](01-core.md) — `reg-flow` and `clear-flow` rowed in registration / clearing.
 - [03 — Effects and interceptors](03-effects.md) — `[:rf.fx/reg-flow ...]` rowed in `:fx` entries.
-- [Spec 013 — Flows](../../../spec/013-Flows.md) — the normative source.
+- [Flows: derived values your handlers can read](../concepts/flows.md) — the conceptual companion to this reference.
 - [Migration reference](../../../migration/from-re-frame-v1/README.md) — `on-changes` (replaced by flows) and `enrich` (replaced by flows / schemas).

--- a/docs/core/api/08-schemas.md
+++ b/docs/core/api/08-schemas.md
@@ -4,7 +4,7 @@ Schemas in re-frame2 are *Malli schemas attached to `app-db` paths*. You registe
 
 Schemas describe **shape and validation**. Durable `app-db` data classification is *not* a schema concern (see [EP-0025](../../EP/EP-0025-data-classification.md)): a schema must not be a second route to classify an `app-db` path the **event** already owns (the event is `app-db`'s definition site — see below). Where a schema *is* the owner's natural surface — a machine's `:data`, a resource's data/params, an HTTP response body's `:decode` slots — per-slot `:sensitive?` / `:large?` Malli props remain the one-and-only classification route for that owner's data. The full three-owner model (commit-plane classification effects for durable `app-db`; per-slot schema props for owner-local schema'd data; registration metadata for transient payloads) lives in [Guide ch.23 — Privacy and large things](../how-to/keep-secrets-out-of-traces.md).
 
-This chapter covers the registration macros (rowed in [01 — Core](01-core.md), summarised here), the introspection surface in `re-frame.schemas`, the validator-extension seams (`set-schema-validator!` etc.), and the boundary-validation interceptor. For the canonical contracts, see [010-Schemas.md](../../../spec/010-Schemas.md), [015-Data-Classification.md](../../../spec/015-Data-Classification.md), and [Privacy.md](../../../spec/Privacy.md).
+This chapter covers the registration macros (rowed in [01 — Core](01-core.md), summarised here), the introspection surface in `re-frame.schemas`, the validator-extension seams (`set-schema-validator!` etc.), and the boundary-validation interceptor. For the working guides, see [Validate with schemas](../how-to/validate-with-schemas.md) and [Keep secrets out of traces](../how-to/keep-secrets-out-of-traces.md).
 
 This chapter spans `re-frame.core` (the `reg-app-schema` / `reg-app-schemas` macros) and `re-frame.schemas` (schema introspection):
 
@@ -42,6 +42,7 @@ This chapter spans `re-frame.core` (the `reg-app-schema` / `reg-app-schemas` mac
 - **Example**:
   ```clojure
   (rf/reg-app-schemas
+    ;; AuthState and ArticlesState are Malli schemas you define elsewhere
     {[:auth]     AuthState
      [:articles] ArticlesState})
   ```
@@ -49,7 +50,7 @@ This chapter spans `re-frame.core` (the `reg-app-schema` / `reg-app-schemas` mac
 
 The path-keyed-not-id-keyed asymmetry is principled. Paths are first-class in `get-in` / `assoc-in` / `update-in`; schemas-at-paths matches the dataflow grain; the lookup site (`app-schema-at [:user]`) reads the same way the write site (`(assoc-in db [:user] ...)`) reads. Spelling it as `(reg-app-schema :user/schema {:schema schema})` would have shifted the registration's id away from the dataflow grain.
 
-See [Conventions §`reg-*` return-value rule](../../../spec/Conventions.md#reg--return-value-convention) for the wider convention this row participates in.
+See [01 — Core › Registration](01-core.md#registration) for the `reg-*` return-value convention this row participates in.
 
 ## Introspection
 
@@ -165,11 +166,12 @@ Durable `app-db` data classification is **event-owned** — a `reg-event` handle
 - `:clear-sensitive` — un-classify the listed paths' sensitive marking when their ownership ends.
 - `:clear-large` — un-classify the listed paths' large marking when their ownership ends.
 
-Composition: sensitive-drop wins; full teaching in [Guide ch.23](../how-to/keep-secrets-out-of-traces.md), normative in spec 009/015.
+Composition: sensitive-drop wins; full teaching in [Keep secrets out of traces](../how-to/keep-secrets-out-of-traces.md).
 
 ## See also
 
 - [01 — Core](01-core.md) — `reg-app-schema` / `reg-app-schemas` rowed in registration.
 - [03 — Effects and interceptors](03-effects.md) — `validate-at-boundary-interceptor` rowed in the interceptor table.
 - [11 — Instrumentation](11-instrumentation.md) — `project-egress` / `elide-wire-value` and the trace-surface privacy posture.
-- [Spec 010 — Schemas](../../../spec/010-Schemas.md), [015-Data-Classification.md](../../../spec/015-Data-Classification.md), [Privacy.md](../../../spec/Privacy.md), [Security.md](../../../spec/Security.md).
+- [Validate with schemas](../how-to/validate-with-schemas.md) — the working guide to schemas at `app-db` paths.
+- [Keep secrets out of traces](../how-to/keep-secrets-out-of-traces.md) — data classification, sensitivity, and large values.

--- a/docs/core/api/10-testing.md
+++ b/docs/core/api/10-testing.md
@@ -16,7 +16,7 @@ The surface lives across **three namespaces** because the three concerns separat
           [re-frame.test-helpers :as th])
 ```
 
-For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` compatibility), see [008-Testing.md](../../../spec/008-Testing.md).
+For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` compatibility), see the how-to guides [Test an event handler](../how-to/test-an-event-handler.md) and [Test a full cascade](../how-to/test-a-cascade.md).
 
 ## Runtime-state assertions (`re-frame.test-support`)
 
@@ -58,7 +58,7 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   (poll-until pred)
   (poll-until pred opts)
   ```
-- **Description**: Bounded-deadline poll. JVM: synchronous — returns the truthy value, throws `ex-info` carrying `:rf.error/id` `:rf.error/poll-until-timeout` (the canonical discriminator, per Spec 009) on timeout. CLJS: returns a `js/Promise` resolving with the truthy value or rejecting on timeout. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
+- **Description**: Bounded-deadline poll. JVM: synchronous — returns the truthy value, throws `ex-info` carrying `:rf.error/id` `:rf.error/poll-until-timeout` (the canonical discriminator) on timeout. CLJS: returns a `js/Promise` resolving with the truthy value or rejecting on timeout. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
 
 ### `with-fx-overrides`
 
@@ -111,7 +111,7 @@ The pattern: fresh registrar, register the handler, dispatch synchronously, asse
 
 ## View assertions (`re-frame.test-helpers`)
 
-The view-assertion surface treats a view as what it is — a function that returns hiccup — and walks the returned hiccup data structure. **JVM-runnable. No JSDOM. No React. No `act()`.** Pairs with `render-to-string` (the HTML-string view-test path per [Spec 011](../../../spec/011-SSR.md)): hiccup-walk for structure / handler assertions, `render-to-string` for HTML-markup assertions.
+The view-assertion surface treats a view as what it is — a function that returns hiccup — and walks the returned hiccup data structure. **JVM-runnable. No JSDOM. No React. No `act()`.** Pairs with `render-to-string` (the HTML-string view-test path; see [`render-to-string`](../../ssr/api.md#render-to-string)): hiccup-walk for structure / handler assertions, `render-to-string` for HTML-markup assertions.
 
 ### `expand-tree`
 
@@ -254,12 +254,12 @@ No JSDOM; no `act()`; no JSON serialisation; no DOM walk. The hiccup is data; th
 
 ## Multi-frame testing
 
-Tests targeting multiple frames reach for the same surfaces with explicit frame opts: `dispatch-sync` accepts a frame in its envelope, `subscribe-once` accepts a frame in its second arity, and `compute-sub` works against any `app-db` value. For driving a machine through `machine-transition` and asserting on the resulting snapshot, see [04 — Machines](../../machines/api.md) (the `re-frame.machines/machine-transition` worked example).
+Tests targeting multiple frames reach for the same surfaces with explicit frame opts: `dispatch-sync` accepts a frame in its envelope, `subscribe-once` accepts a frame in its second arity, and `compute-sub` works against any `app-db` value. To scope a block of test code to a particular frame, use the frame-scoping macros `with-frame` (pin an existing frame-id) and `with-new-frame` (create a throwaway frame, run the body, destroy it on exit) — both rowed in [01 — Core §Frames](01-core.md#frames-the-scoping-primitive). For driving a machine through `machine-transition` and asserting on the resulting snapshot, see [04 — Machines](../../machines/api.md) (the `re-frame.machines/machine-transition` worked example).
 
 ## See also
 
-- [01 — Core](01-core.md) — `dispatch-sync`, `subscribe-once`, `make-frame`, `with-frame` rowed in dispatch / registration.
+- [01 — Core](01-core.md) — `dispatch-sync`, `subscribe-once`, `make-frame` rowed in dispatch / registration; `with-frame` / `with-new-frame` in the Frames section.
 - [03 — Effects and interceptors](03-effects.md) — `with-fx-overrides` and the precedence rules.
 - [07 — HTTP](../../resources/http-api.md) — HTTP test stubs (`with-managed-request-stubs`, canned-reply fx).
 - [12 — Registrar](12-registrar.md) — `registrations`, `handler-meta`, `sub-topology` for tests that introspect what's registered.
-- [Spec 008 — Testing](../../../spec/008-Testing.md) — the normative source.
+- [Test an event handler](../how-to/test-an-event-handler.md) and [Test a full cascade](../how-to/test-a-cascade.md) — the practical how-to guides for the testing surface.

--- a/docs/core/api/11-instrumentation.md
+++ b/docs/core/api/11-instrumentation.md
@@ -28,6 +28,17 @@ Record shape: `{:event :event-id :frame :time :outcome :elapsed-ms}`. The `:even
   ```
 - **Description**: Receive one event-record per processed event. Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`.
 
+```clojure
+;; Always-on: one record per processed event → a hosted metrics back-end.
+;; The public facade is `register-listener!` on the always-on `:events` stream.
+(rf/register-listener! :events :my-app.monitors/datadog
+  (fn [{:keys [event-id frame outcome elapsed-ms]}]
+    (datadog/timing "rf.event.elapsed_ms" elapsed-ms
+                    {:event   (str event-id)
+                     :frame   (str frame)
+                     :outcome (str outcome)})))
+```
+
 ### `unregister-event-listener!`
 
 - **Kind**: function
@@ -41,13 +52,13 @@ Record shape: `{:event :event-id :frame :time :outcome :elapsed-ms}`. The `:even
 
 Sibling of the event-emit surface above. Runs through the always-on error-emit substrate. Survives `:advanced` + `goog.DEBUG=false`. Intended consumers are hosted error monitors (Sentry, Honeybadger, Rollbar).
 
-This corpus-wide listener delivers one record per **every catalogued production-reachable runtime `:rf.error/*`** — handler / interceptor / cofx exceptions, flow exceptions, fx / reserved-fx exceptions, reactive- and `compute-sub`-resolution exceptions, the invalid-operation categories `:rf.error/frame-destroyed`, `:rf.error/no-such-handler`, `:rf.error/no-such-sub`, the bounded `:rf.error/frame-teardown-failed` report, **and** the six promoted SSR non-event categories (the frameless-tolerant `dispatch-error-record!` path). (Registration-time / dev-only-validation categories stay dev-trace-only — see [009 §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue).) It is the single error-observability surface; recovery is the framework's typed per-category default, not app-steerable — there is no per-frame `:on-error` recovery policy.
+This corpus-wide listener delivers one record per **every catalogued production-reachable runtime `:rf.error/*`** — handler / interceptor / cofx exceptions, flow exceptions, fx / reserved-fx exceptions, reactive- and `compute-sub`-resolution exceptions, the invalid-operation categories `:rf.error/frame-destroyed`, `:rf.error/no-such-handler`, `:rf.error/no-such-sub`, the bounded `:rf.error/frame-teardown-failed` report, **and** the six promoted SSR non-event categories (the frameless-tolerant `dispatch-error-record!` path). (Registration-time / dev-only-validation categories stay dev-trace-only.) It is the single error-observability surface; recovery is the framework's typed per-category default, not app-steerable — there is no per-frame `:on-error` recovery policy.
 
 The listener payload is a **union of three record shapes** — the per-event record, plus two non-event records that ride the general `dispatch-error-record!` helper (the non-event sibling of `dispatch-on-error!`):
 
 1. **Per-event error record** — `{:error :event :event-id :frame :time :exception :elapsed-ms}` (plus `:source-coord` when the failing handler was registered via the public macro path). One per production-reachable per-event `:rf.error/*` (handler / interceptor / cofx / sub / fx / flow failures). Fanned out by `dispatch-on-error!`. The `:event` slot is passed through `elide-wire-value` once before fan-out (same redaction posture as event-emit).
-2. **Frame-teardown report** — `{:error :rf.error/frame-teardown-failed :frame :hook-failures :reason :recovery :time}`. One bounded record per frame destroy whose best-effort cleanup hooks threw (see [009 §Observability channels and the promotion criterion](../../../spec/009-Instrumentation.md#observability-channels-and-the-promotion-criterion)). It is frame-keyed and carries a `:hook-failures` vector **instead of** the per-event `:event` / `:event-id` / `:exception` / `:elapsed-ms` slots.
-3. **Promoted SSR non-event records** — the six SSR categories on the always-on axis: `:rf.error/ssr-render-failed`, `:rf.error/ssr-streaming-writer-failed`, `:rf.error/malformed-hydration-payload` (incl. the pre-frame **frameless** parse sub-path, which carries `:frame nil`), `:rf.error/ssr-head-resolution-failed`, `:rf.error/sanitised-on-projection`, and `:rf.error/ssr-ring-error-view-failed`. Each is a flat union record `{:error :frame :time …category keys…}` carrying its own slots (`:exception` / `:phase` / `:reason` / `:projector-id` / `:ex-class` / …) and either a server `:frame` or `:frame nil` (the frameless hydration-parse path). Production-reachable on a long-lived JVM SSR host where the dev trace is `-Dre-frame.debug=false`-elided. The recoverable-degradation and post-commit members are **non-projecting** — they affect what off-box shippers see, never the wire outcome. See [009 §What IS available in production](../../../spec/009-Instrumentation.md#what-is-available-in-production) for the full enumeration and the projecting/non-projecting caveats.
+2. **Frame-teardown report** — `{:error :rf.error/frame-teardown-failed :frame :hook-failures :reason :recovery :time}`. One bounded record per frame destroy whose best-effort cleanup hooks threw. It is frame-keyed and carries a `:hook-failures` vector **instead of** the per-event `:event` / `:event-id` / `:exception` / `:elapsed-ms` slots.
+3. **Promoted SSR non-event records** — the six SSR categories on the always-on axis: `:rf.error/ssr-render-failed`, `:rf.error/ssr-streaming-writer-failed`, `:rf.error/malformed-hydration-payload` (incl. the pre-frame **frameless** parse sub-path, which carries `:frame nil`), `:rf.error/ssr-head-resolution-failed`, `:rf.error/sanitised-on-projection`, and `:rf.error/ssr-ring-error-view-failed`. Each is a flat union record `{:error :frame :time …category keys…}` carrying its own slots (`:exception` / `:phase` / `:reason` / `:projector-id` / `:ex-class` / …) and either a server `:frame` or `:frame nil` (the frameless hydration-parse path). Production-reachable on a long-lived JVM SSR host where the dev trace is `-Dre-frame.debug=false`-elided. The recoverable-degradation and post-commit members are **non-projecting** — they affect what off-box shippers see, never the wire outcome.
 
 Listener bodies MUST branch on `(:error record)` (or otherwise tolerate a record with no top-level `:event` / `:event-id` / `:exception`) rather than assuming the per-event shape — a generic shipper that maps `(:error record)` to the alert name and forwards the rest handles every arm. Per-listener exceptions are isolated — a buggy listener cannot block siblings or the cascade.
 
@@ -60,6 +71,21 @@ Listener bodies MUST branch on `(:error record)` (or otherwise tolerate a record
   ```
 - **Description**: Receive one error-record per catalogued production-reachable runtime `:rf.error/*` event (the broad surface — including frame-destroyed / no-such-handler / no-such-sub / sub-exception, not just handler exceptions). Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`.
 
+```clojure
+;; Always-on production error monitoring — survives :advanced + goog.DEBUG=false.
+;; The public facade is `register-listener!` on the always-on `:errors` stream.
+;; Register it only in a real production build (the substrate fires in dev too).
+(rf/register-listener! :errors :my-app.monitors/sentry
+  (fn [record]
+    ;; The payload is a union — branch on (:error record); never assume :exception.
+    (let [ctx (clj->js {:tags  {:category (str (:error record))
+                                :frame    (str (:frame record))}
+                        :extra {:event (pr-str (:event record))}})] ;; already wire-elided
+      (if-let [ex (:exception record)]
+        (Sentry/captureException ex ctx)
+        (Sentry/captureMessage (str (:error record)) ctx)))))
+```
+
 ### `unregister-error-listener!`
 
 - **Kind**: function
@@ -71,7 +97,7 @@ Listener bodies MUST branch on `(:error record)` (or otherwise tolerate a record
 
 ## Tracing (dev-only)
 
-The rich-detail trace surface. **Dev-only — elided in production via Closure DCE under `:advanced` + `goog.DEBUG=false`.** See [009 §Tracing](../../../spec/009-Instrumentation.md) for emit semantics and synchronous listener delivery.
+The rich-detail trace surface. **Dev-only — elided in production via Closure DCE under `:advanced` + `goog.DEBUG=false`.** See [Observability: one wire, every tool](../concepts/observability.md#one-wire-the-trace-stream) for emit semantics and synchronous listener delivery.
 
 ### `register-listener!`
 
@@ -164,7 +190,7 @@ Event-handler registration accepts a `:rf.trace/no-emit? true` metadata flag. Wh
 |---|---|---|---|---|
 | `:rf.trace/no-emit?` | `reg-event` metadata map | boolean | `false` | When `true`, suppresses all trace + event-emit emissions inside the handler's scope. |
 
-Used by framework-internal bookkeeping handlers (Xray, Story, re-frame2-pair-mcp, story-mcp) that would otherwise saturate the trace stream. The `:rf.trace/*` namespace is framework-owned (per [Conventions §Reserved namespaces](../../../spec/Conventions.md#reserved-namespaces-framework-owned)).
+Used by framework-internal bookkeeping handlers (Xray, Story, re-frame2-pair-mcp, story-mcp) that would otherwise saturate the trace stream. The `:rf.trace/*` namespace is framework-owned.
 
 ## Epoch history (Tool-Pair)
 
@@ -265,7 +291,7 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```clojure
   (project-egress record-or-value opts)
   ```
-- **Description**: The public, record-level boundary primitive — **the required step before any off-box sink**. Dispatches on a record's `:kind` (`:rf.observe/handled-event` / `:rf.observe/error`) to a per-kind projector, falling back to walking a kindless input as a tree-shaped value (the direct-read path); each tree-shaped slot is delegated to `elide-wire-value` against the frame's classification. `opts` carries `:rf.egress/profile` (the closed six-member enum), `:frame`, `:path`, and the advanced `:rf.size/*` overrides (which compose on top of the profile — the override wins). An unknown profile throws `:rf.error/unknown-egress-profile`. **Fail-closed**: a tree slot projects only when the frame is known — there is no `:rf/default` synthesis. To project a derived tree (rendered hiccup, a resolved `:effective-args` map, a snapshot body), wrap it in a `:rf.observe/derived-tree` record; `project-egress` path-walks each slot (a re-keyed value ships raw — the fail-open default). Per Spec 015 §Projection.
+- **Description**: The public, record-level boundary primitive — **the required step before any off-box sink**. Dispatches on a record's `:kind` (`:rf.observe/handled-event` / `:rf.observe/error`) to a per-kind projector, falling back to walking a kindless input as a tree-shaped value (the direct-read path); each tree-shaped slot is delegated to `elide-wire-value` against the frame's classification. `opts` carries `:rf.egress/profile` (the closed six-member enum), `:frame`, `:path`, and the advanced `:rf.size/*` overrides (which compose on top of the profile — the override wins). An unknown profile throws `:rf.error/unknown-egress-profile`. **Fail-closed**: a tree slot projects only when the frame is known — there is no `:rf/default` synthesis. To project a derived tree (rendered hiccup, a resolved `:effective-args` map, a snapshot body), wrap it in a `:rf.observe/derived-tree` record; `project-egress` path-walks each slot (a re-keyed value ships raw — the fail-open default).
 
 ```clojure
 ;; Verify what an off-box sink will receive before wiring it.
@@ -281,7 +307,7 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
 
 ## Frame-owned observability sinks
 
-The normal production observability story (Spec 015 §Frame-owned observability sink policy). An app declares a sink under a frame's `:observability` config and registers the concrete sink fn against that sink id here. The runtime routes one handled-event record per processed event, and one error record per `:rf.error/*` site, through `project-egress` (under the frame's classification + the sink's egress profile) to the declared sinks. **Sinks consume already-projected records — there is no sink-local redaction.** The framework ships no Datadog / Sentry client (that is an app / integration-library concern); these two verbs are the registration seam.
+The normal production observability story. An app declares a sink under a frame's `:observability` config and registers the concrete sink fn against that sink id here. The runtime routes one handled-event record per processed event, and one error record per `:rf.error/*` site, through `project-egress` (under the frame's classification + the sink's egress profile) to the declared sinks. **Sinks consume already-projected records — there is no sink-local redaction.** The framework ships no Datadog / Sentry client (that is an app / integration-library concern); these two verbs are the registration seam.
 
 This is parallel to (and the production-normal home of) the advanced corpus-wide `register-listener!` / `register-event-listener!` / `register-error-listener!` surfaces above: the sink routing is frame-scoped and profile-projected, where the corpus-wide listeners are cross-frame and raw.
 
@@ -335,13 +361,14 @@ The DOM `data-rf2-source-coord` injection contract is documented in [02 — View
 
 ## The error contract
 
-Errors are emitted as structured trace events with `:op-type :error` (or `:warning` / `:info` / `:fx` / `:flow` / `:frame`) and a per-category `:operation` keyword. The complete normative catalogue — every `:rf.error/*`, `:rf.warning/*`, `:rf.fx/*`, `:rf.cofx/*`, `:rf.ssr/*`, `:rf.epoch/*`, `:rf.flow/*`, `:rf.http/*`, `:rf.http.interceptor/*`, `:rf.frame/*`, and `:rf.route.nav-token/*` event the runtime emits — lives at [009 §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue) (single source of truth for category names, `:op-type` discriminator, trigger conditions, default `:recovery`, and `:tags` payload keys).
+Errors are emitted as structured trace events with `:op-type :error` (or `:warning` / `:info` / `:fx` / `:flow` / `:frame`) and a per-category `:operation` keyword. The complete normative catalogue — every `:rf.error/*`, `:rf.warning/*`, `:rf.fx/*`, `:rf.cofx/*`, `:rf.ssr/*`, `:rf.epoch/*`, `:rf.flow/*`, `:rf.http/*`, `:rf.http.interceptor/*`, `:rf.frame/*`, and `:rf.route.nav-token/*` event the runtime emits — is the single source of truth for category names, `:op-type` discriminator, trigger conditions, default `:recovery`, and `:tags` payload keys.
 
-Per-category Malli `:tags` schemas are canonicalised at [Spec-Schemas §Per-category `:tags` schemas](../../../spec/Spec-Schemas.md#per-category-tags-schemas) — one schema per catalogue row.
+Per-category Malli `:tags` schemas are canonical — one schema per catalogue row.
 
 ## See also
 
 - [01 — Core](01-core.md) — the `:trace-buffer`, `:epoch-history`, `:elision` configure keys.
 - [08 — Schemas](08-schemas.md) — the registration side of the elision posture.
-- [Spec 009 — Instrumentation](../../../spec/009-Instrumentation.md) — the normative source.
-- [Tool-Pair](../../../spec/Tool-Pair.md) — how the epoch buffer, trace bus, and source-coord annotations compose into the pair-shaped tools.
+- [Observability: one wire, every tool](../concepts/observability.md) — the concept guide: trace stream, buffer, epoch history, and production telemetry.
+- [Errors: dossiers, not log lines](../concepts/errors.md) — the error-contract concept guide.
+- [Debug with Xray](../how-to/debug-with-xray.md) — how the epoch buffer, trace bus, and source-coord annotations power the pair-shaped tools.

--- a/docs/core/api/12-registrar.md
+++ b/docs/core/api/12-registrar.md
@@ -42,7 +42,7 @@ The registrar-query surface lives in `re-frame.core`:
   ```
 - **Description**: "What did `reg-*` stamp at this id?" View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`) per `:rf/source-coord-meta`; pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup.
 
-`kind` is one of `:event`, `:sub`, `:fx`, `:cofx`, `:view`, `:flow`, `:route`, `:head`, `:error-projector`. App-db schemas are **not** a registrar kind; look them up via `(app-schema-meta-at path)` instead. The full list lives in [001-Vision §Registry model](../../../spec/000-Vision.md).
+`kind` is one of `:event`, `:sub`, `:fx`, `:cofx`, `:view`, `:flow`, `:route`, `:head`, `:error-projector`. App-db schemas are **not** a registrar kind; look them up via `(app-schema-meta-at path)` instead. The [registrar](../glossary.md#registrar) glossary entry covers the one-table-per-process model these kinds share.
 
 ## Machines
 
@@ -129,7 +129,7 @@ Defined in [10 — Testing](10-testing.md#compute-sub) — the cache-bypassing p
 
 ## Behaviour against destroyed frames
 
-The pair-tool surfaces all share a common behaviour against destroyed frames, documented at [Tool-Pair §Surface behaviour against destroyed frames](../../../spec/Tool-Pair.md#surface-behaviour-against-destroyed-frames):
+The pair-tool surfaces all share a common behaviour against destroyed frames:
 
 - `app-db-value` → `nil`
 - `epoch-history` → `[]`

--- a/docs/core/api/13-lifecycle.md
+++ b/docs/core/api/13-lifecycle.md
@@ -5,7 +5,7 @@ This chapter is about the surfaces that bring a re-frame2 process up and take it
 | Lane | Who owns it | The surfaces | Where it's documented |
 |---|---|---|---|
 | **Application boot** | App authors | `init!`, then explicit `reg-frame` / `make-frame` + `frame-provider`; `configure!` to tune | [Application boot](#application-boot) (below) |
-| **Frame startup** | App authors (per frame) | `reg-frame` / `make-frame` and the `:initial-events` the new frame runs | [01 — Core §Frames](01-core.md#frames-the-scoping-primitive), [Pattern — Boot](../../../spec/Pattern-Boot.md) |
+| **Frame startup** | App authors (per frame) | `reg-frame` / `make-frame` and the `:initial-events` the new frame runs | [01 — Core §Frames](01-core.md#frames-the-scoping-primitive), [Boot and mount an app](../how-to/boot-and-mount-an-app.md) |
 | **Adapter-author internals** | Adapter authors | `install-adapter!`, `destroy-adapter!`, `current-adapter`, `current-adapter-spec`, `adapter-disposed?`, the adapter-spec map | [For adapter authors](#for-adapter-authors) (below) |
 
 An app author learns one boot sentence — **install an adapter with `init!`, then create your frame(s) explicitly** — and nothing else. The adapter-author surfaces (install / dispose / inspect, and the spec-map slots) are *not* peer choices beside `init!`; they sit one layer down and an ordinary app never touches them. The frame-startup lane is a third thing again: it's about what a *single frame* does when it comes alive (`:initial-events`), independent of which substrate the process installed. Keep the three apart and the lifecycle reads cleanly.
@@ -27,7 +27,7 @@ This is the only lane an app author needs. It has exactly two steps: install the
 ;; …then establish it at your root with `frame-provider` (see the bootstrap pattern below).
 ```
 
-Step 2's `:initial-events` is the seam into the **frame-startup** lane — the events a new frame runs at creation (a vector of event vectors, dispatched in order). For trivial apps it seeds app-db (e.g. `[[:rf/set-db {…}]]`); for real apps it's the head of a boot sequence ([Pattern — Boot](../../../spec/Pattern-Boot.md) is the canonical recipe, from chained events up to a dedicated boot state machine). The frames concept guide walks the whole app-boot shape end to end: [Frames: isolated worlds](../concepts/frames.md).
+Step 2's `:initial-events` is the seam into the **frame-startup** lane — the events a new frame runs at creation (a vector of event vectors, dispatched in order). For trivial apps it seeds app-db (e.g. `[[:rf/set-db {…}]]`); for real apps it's the head of a boot sequence — from chained events up to a dedicated boot state machine (see [Boot and mount an app](../how-to/boot-and-mount-an-app.md)). The frames concept guide walks the whole app-boot shape end to end: [Frames: isolated worlds](../concepts/frames.md).
 
 ### `init!`
 
@@ -36,7 +36,7 @@ Step 2's `:initial-events` is the seam into the **frame-startup** lane — the e
   ```clojure
   (init! adapter-map)
   ```
-- **Description**: The idempotent boot. Required arg: the adapter spec map. Each adapter ns exports an `adapter` Var; consumers require the ns and pass the Var, e.g. `(rf/init! reagent/adapter)`. Calling `(init!)` with no args raises a language-level `ArityException` at compile / load time, so the missing-adapter mistake surfaces before runtime. Calling `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime. `init!` installs adapters and runtime capabilities only; it does **not** create or guarantee any frame (see [EP-0002](../../../spec/002-Frames.md#frame-target-resolution--the-carried-invariant)) — you register your app frame explicitly (`reg-frame`) and establish it at your root.
+- **Description**: The idempotent boot. Required arg: the adapter spec map. Each adapter ns exports an `adapter` Var; consumers require the ns and pass the Var, e.g. `(rf/init! reagent/adapter)`. Calling `(init!)` with no args raises a language-level `ArityException` at compile / load time, so the missing-adapter mistake surfaces before runtime. Calling `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime. `init!` installs adapters and runtime capabilities only; it does **not** create or guarantee any frame (see [Frames: isolated worlds](../concepts/frames.md#the-one-rule-frame-identity-is-carried-not-found)) — you register your app frame explicitly (`reg-frame`) and establish it at your root.
 - **Example**:
   ```clojure
   (:require [re-frame.adapter.reagent :as reagent-adapter])
@@ -49,16 +49,16 @@ After `init!`, create your frame(s) — that's the next subsection.
 
 ## Frame startup — the second boot step
 
-`init!` installs host capability and creates **no** frame; frame ownership is always explicit (see [EP-0002](../../../spec/002-Frames.md#frame-target-resolution--the-carried-invariant)). So the app author's second move is to create the frame and establish it at the root:
+`init!` installs host capability and creates **no** frame; frame ownership is always explicit. So the app author's second move is to create the frame and establish it at the root:
 
 - **`reg-frame`** / **`make-frame`** create a frame atomically and run its `:initial-events` synchronously — the frame's startup lifecycle. Both are rowed in [01 — Core §Frames](01-core.md#frames-the-scoping-primitive).
 - **`frame-provider`** establishes a created frame at a point in the view tree, so every bare `dispatch` / `subscribe` underneath resolves against it.
 
-The `:initial-events` are where the frame's own startup logic lives — seed app-db for a trivial app (`[[:rf/set-db {…}]]`), or kick a boot sequence for a real one. That sequence is its own pattern, not a lifecycle surface: see [Pattern — Boot](../../../spec/Pattern-Boot.md) for the chained-events and boot-state-machine forms, and [Frames: isolated worlds](../concepts/frames.md) for the app-author narrative (including why `init!` doesn't create a frame for you).
+The `:initial-events` are where the frame's own startup logic lives — seed app-db for a trivial app (`[[:rf/set-db {…}]]`), or kick a boot sequence for a real one. That sequence is its own pattern, not a lifecycle surface: see [Boot and mount an app](../how-to/boot-and-mount-an-app.md) for the boot-sequence forms (chained events through a boot state machine), and [Frames: isolated worlds](../concepts/frames.md) for the app-author narrative (including why `init!` doesn't create a frame for you).
 
 ## For adapter authors
 
-Everything below is the **adapter-author lane**. An ordinary app never calls these — `init!` (above) drives them for you. Reach here only when you are *writing* a substrate adapter or a custom boot pipeline, or building tooling that has to inspect the install slot. The per-substrate surface tables live in [14 — Adapters](14-adapters.md); the normative contract is [Spec 006 — Reactive Substrate](../../../spec/006-ReactiveSubstrate.md).
+Everything below is the **adapter-author lane**. An ordinary app never calls these — `init!` (above) drives them for you. Reach here only when you are *writing* a substrate adapter or a custom boot pipeline, or building tooling that has to inspect the install slot. The per-substrate surface tables live in [14 — Adapters](14-adapters.md).
 
 ### `install-adapter!`
 
@@ -134,7 +134,7 @@ These two states surface as different errors because they have different recover
 | Never installed | `(current-adapter)` returns `nil`; `(adapter-disposed?)` returns `false` | Call `(rf/init! adapter)`. |
 | Disposed | `(current-adapter)` returns `nil`; `(adapter-disposed?)` returns `true` | A new `(rf/init! adapter)` is required. Tooling that observed the previous install needs to re-attach. |
 
-The two states share the "no current adapter" surface but answer different questions about the process's history. Per [006 §Disposed-vs-never-installed](../../../spec/006-ReactiveSubstrate.md#disposed-vs-never-installed).
+The two states share the "no current adapter" surface but answer different questions about the process's history.
 
 ## Configuration (application-boot lane)
 
@@ -151,7 +151,7 @@ Back in the app-author lane: the `configure` fn is application boot's adjacent s
 
 The three configuration surfaces — `configure`, the `set-!` / `install-!` setters (`set-schema-validator!`, etc.), and per-frame metadata — are separate. Each answers a different question: `configure` for data knobs (depth, threshold, grace period); the setters for hook-shaped pluggability (which validator to use, which printer); per-frame metadata for frame-scoped overrides (which projector, which `:fx-overrides`).
 
-See [Conventions §Configuration surfaces](../../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata).
+See [Configure dev and production builds](../how-to/configure-dev-and-prod.md#4-the-dev-knobs-three-buckets-one-rule) for the three buckets in practice.
 
 ## Bootstrap pattern
 
@@ -183,11 +183,11 @@ App-boot and frame-startup lanes (what app authors read):
 
 - [01 — Core](01-core.md) — `reg-frame` / `make-frame` / `configure` rowed in registration and configuration.
 - [Frames: isolated worlds](../concepts/frames.md) — the app-boot narrative, and why `init!` doesn't create a frame.
-- [Pattern — Boot](../../../spec/Pattern-Boot.md) — the `:initial-events` boot sequence, from chained events to a boot state machine.
+- [Boot and mount an app](../how-to/boot-and-mount-an-app.md) — the `:initial-events` boot sequence, from chained events to a boot state machine.
 - [counter example](https://github.com/day8/re-frame2/tree/main/examples/core/counter) — the minimal `init!` + `reg-frame` + `frame-provider` boot.
 
 Adapter-author lane (what substrate authors read):
 
 - [14 — Adapters](14-adapters.md) — per-substrate surface tables.
 - [02 — Views](02-views.md) — adapter-side surfaces (UIx / Helix hooks, the shared React Context).
-- [Spec 006 — Reactive Substrate](../../../spec/006-ReactiveSubstrate.md) — the normative adapter contract.
+- [Use UIx, Helix, or reagent-slim](../how-to/use-uix-helix-or-slim.md) — narrative coverage of choosing and wiring an adapter.

--- a/docs/core/api/14-adapters.md
+++ b/docs/core/api/14-adapters.md
@@ -38,7 +38,7 @@ The slim variant is bundle-isolated — the `npm run test:reagent-slim:bundle-is
 
 ## The UIx adapter
 
-UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-uix`). The hook is named `use-subscribe` (matching the React/UIx idiom); there is no auto-injection — UIx components call the hook and `(rf/capture-frame)` directly. The full decision set lives at [Spec 006 §CLJS reference: UIx as alternative substrate](../../../spec/006-ReactiveSubstrate.md#cljs-reference-uix-as-alternative-substrate).
+UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-uix`). The hook is named `use-subscribe` (matching the React/UIx idiom); there is no auto-injection — UIx components call the hook and `(rf/capture-frame)` directly. The full decision set lives in [Use UIx, Helix, or reagent-slim](../how-to/use-uix-helix-or-slim.md).
 
 ### `uix-adapter/adapter`
 
@@ -110,7 +110,7 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   ```
 - **Description**: Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR.
 
-UIx users register their views by Var (the React-component idiom) or with `rf/reg-view*` if they want registry-keyed view addressing — `reg-view` (the Reagent macro) does **not** cover UIx. See [Spec 006 §CLJS reference: UIx as alternative substrate](../../../spec/006-ReactiveSubstrate.md#cljs-reference-uix-as-alternative-substrate).
+UIx users register their views by Var (the React-component idiom) or with `rf/reg-view*` if they want registry-keyed view addressing — `reg-view` (the Reagent macro) does **not** cover UIx.
 
 ```clojure
 (:require [re-frame.core :as rf]
@@ -200,11 +200,26 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   ```
 - **Description**: Install a render-tree → HTML fn. Parity with the Reagent and UIx adapters' late-bind seam.
 
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.adapter.helix :as helix-adapter]
+          [helix.core :refer [defnc]]
+          [helix.dom :as d])
+
+(rf/init! helix-adapter/adapter)
+
+(defnc cart-row [{:keys [item]}]
+  (let [count (helix-adapter/use-subscribe [:cart/count])]
+    (d/tr
+      (d/td (:name item))
+      (d/td count))))
+```
+
 The duplication between UIx and Helix is intentional — both expose the same hooks-first idiom; both decisions sets transfer; both surfaces are structurally identical. The two adapters are separate artefacts because the *underlying React-substrate libraries* are separate, not because the re-frame2 contract differs between them.
 
 ## The shared React Context
 
-The `frame-provider` in all three adapters (Reagent, UIx, Helix) consumes the **same** `createContext` object, factored into `re-frame.adapter.context` (a CLJS-only file in core). There is exactly one Context, not three, so a mixed-substrate app composes: a Reagent `frame-provider` can wrap a UIx subtree; a Helix subtree can be wrapped by a UIx provider; the chain composes across substrate boundaries. See [Spec 006 §CLJS reference: UIx as alternative substrate](../../../spec/006-ReactiveSubstrate.md#cljs-reference-uix-as-alternative-substrate).
+The `frame-provider` in all three adapters (Reagent, UIx, Helix) consumes the **same** `createContext` object, factored into `re-frame.adapter.context` (a CLJS-only file in core). There is exactly one Context, not three, so a mixed-substrate app composes: a Reagent `frame-provider` can wrap a UIx subtree; a Helix subtree can be wrapped by a UIx provider; the chain composes across substrate boundaries.
 
 ## DOM source-coord annotations
 
@@ -230,5 +245,5 @@ There's a fourth adapter — Plain Atom — that ships in core and exists for tw
 
 - [02 — Views](02-views.md) — the substrate-agnostic ergonomic surface (`capture-frame`, `with-frame`, `with-new-frame`, `frame-provider`).
 - [13 — Lifecycle](13-lifecycle.md) — `init!`, `install-adapter!`, `destroy-adapter!`, `current-adapter`, `adapter-disposed?`.
-- [Spec 006 — Reactive Substrate](../../../spec/006-ReactiveSubstrate.md) — the adapter contract.
+- [Adapter (glossary)](../glossary.md#adapter) — the substrate seam, defined.
 - [Guide ch.21 — Adapters](../how-to/use-uix-helix-or-slim.md) — narrative coverage with worked examples.

--- a/docs/core/api/README.md
+++ b/docs/core/api/README.md
@@ -2,7 +2,7 @@
 
 This is the human-facing API reference for the ClojureScript implementation of re-frame2. It's organised by **what you're trying to do** rather than by alphabetical surface listing. Each chapter opens with a paragraph on what the surface is *for* — the problem it solves, the shape of the contract — and only then drops into the function tables.
 
-If you want the dense, single-page contract — every signature, every status, every cross-reference — the [normative reference](../../../spec/API.md) is still where that lives. This guide is the same surface, walked through by topic, with intuition notes attached.
+Every row here is the real, callable surface — every signature, every status, every cross-reference, with an intuition note attached. The reference is split into self-contained chapters, so you can land on any one from a search result and get the call shape without reading the rest.
 
 ## What's a "canonical" API?
 
@@ -41,7 +41,7 @@ The dependency direction is one-way: adapters and feature artefacts depend on co
 
 ## The chapters
 
-The reference is divided into sixteen chapters. Each is independent — you can land on any of them from a search result and get something useful without reading the others.
+The reference is divided into fifteen chapters. Each is independent — you can land on any of them from a search result and get something useful without reading the others.
 
 The first three are foundational — **Core** (registration, dispatch, subscribe), **Views** (the view registry and the substrate-agnostic ergonomic surface), **Effects and interceptors** (the effect map, the standard interceptors, the context plumbing).
 
@@ -49,12 +49,12 @@ The next six cover feature domains: **State machines**, **Flows**, **Routing**, 
 
 The next four cover the operational surfaces: **Testing**, **Instrumentation** (listeners, tracing, epoch, performance), **Registrar** (the query API tools build against), **Lifecycle** (adapter install / dispose, `configure`).
 
-Then **Adapters** (the per-substrate surfaces — Reagent, UIx, Helix), a **Removed / not shipped** chapter that says what's gone and what to use instead, and a closing **Resources** chapter (the optional, post-v1 declarative server-state surface).
+Then **Adapters** (the per-substrate surfaces — Reagent, UIx, Helix), and a closing **Resources** chapter (the optional, post-v1 declarative server-state surface).
 
 Story (variants, workspaces, snapshot identity) is a separate shipped tool with its own top-level [Story API](../../story/api/index.md) section — it is not a chapter in this framework reference.
 
-## When to reach for the spec instead
+## When to reach for the concept guides
 
-The chapters here are organised for readers; the [normative API reference](../../../spec/API.md) is organised for completeness. If you're looking for *every* row at once — a `Ctrl-F` target across the full surface — that's where you want to be. If you're writing a new app and want to know which surfaces *exist* in a given domain, you want a chapter here.
+The chapters here are organised around the *surface* — the signatures, the statuses, the call shapes you reach for while writing code. They answer "what exists, and how do I call it?"
 
-The normative spec docs (`002-Frames.md`, `005-StateMachines.md`, etc.) own the *why* — the design rationale, the alternatives considered, the dispositions. The chapters here cite those when they matter, and stay quiet otherwise.
+The [concept guides](../concepts/index.md) own the *why* — the design rationale, the mental models, the alternatives considered. When a chapter's intuition note isn't enough and you want to understand why a surface is shaped the way it is, that's where to go. The chapters here cite the relevant guide when it matters, and stay quiet otherwise.

--- a/docs/machines/api.md
+++ b/docs/machines/api.md
@@ -8,7 +8,7 @@ This chapter covers the registration surface (the `reg-machine` / `defmachine` m
 
 > **Facade surface.** Only `reg-machine` / `defmachine` and the `machine-has-tag?` subscription sugar are `re-frame.core` facade exports. The plain-fn registration / engine / query helpers (`reg-machine*`, `make-machine-handler`, `machine-transition`, `machines`, `machine-meta`, `machine-by-system-id`) and the `dispatch-to-system` fn live in their owned namespace `re-frame.machines` — reach them as `re-frame.machines/<name>`, not `rf/<name>`. The canonical action-side cross-machine messaging surface is the reserved `[:rf.machine/dispatch-to-system [system-id event]]` fx tuple. `re-frame.machines` is the `day8/re-frame2-machines` artefact.
 
-For the full treatment — the capability matrix and the underlying model — see [005-StateMachines.md](../../spec/005-StateMachines.md).
+For the full treatment — the underlying model, the recognition kit, and the rationale behind the capability subset — see the [machines concept guide](concepts.md).
 
 This chapter spans `re-frame.core` (the `reg-machine` / `defmachine` macros) and `re-frame.machines` (the engine, query, and transition surfaces):
 
@@ -62,7 +62,7 @@ This chapter spans `re-frame.core` (the `reg-machine` / `defmachine` macros) and
         [next-snap effects] (machines/machine-transition definition snapshot [:login {:user "alice"}])]
     (is (= :authenticating (:state next-snap)))
     (is (= "alice" (get-in next-snap [:data :credentials :user])))
-    (is (= [[:rf.http/managed ...]] (:fx effects))))
+    (is (= :rf.http/managed (ffirst (:fx effects)))))
   ```
 
 ### A minimal machine
@@ -70,18 +70,36 @@ This chapter spans `re-frame.core` (the `reg-machine` / `defmachine` macros) and
 ```clojure
 (rf/reg-machine :session
   {:initial :anonymous
-   :states  {:anonymous     {:on {:login {:target :authenticating
-                                          :data   (fn [data event]
-                                                    (assoc data :credentials (second event)))}}}
-             :authenticating {:after  {500 {:target :timeout}}
-                              :entry  [{:fx [[:rf.http/managed {...}]]}]
-                              :on     {:auth-ok   {:target :authenticated}
-                                       :auth-fail {:target :anonymous}}}
-             :authenticated {:on {:logout {:target :anonymous}}}
-             :timeout       {:on {:retry {:target :anonymous}}}}})
+   :data    {:credentials nil}
 
-;; The machine IS an event handler — dispatch at its id.
-(rf/dispatch [:session [:login {:user "alice" :pass "..."}]])
+   :actions
+   {:capture-credentials
+    ;; Remember who's signing in so the snapshot carries it through the flow.
+    (fn [{[_ creds] :event}]
+      {:data {:credentials creds}})
+
+    :issue-auth
+    ;; Fire the login request; the reply loops back as :auth-ok / :auth-fail.
+    (fn [{[_ creds] :event}]
+      {:fx [[:rf.http/managed
+             {:request    {:method :post :url "/api/login" :body creds
+                           :request-content-type :json :sensitive? true}
+              :decode     :json
+              :on-success [:session [:auth-ok]]
+              :on-failure [:session [:auth-fail]]}]]})}
+
+   :states
+   {:anonymous      {:on {:login {:target :authenticating
+                                  :action :capture-credentials}}}
+    :authenticating {:entry :issue-auth
+                     :after {500 {:target :timeout}}      ;; ms — auth taking too long
+                     :on    {:auth-ok   {:target :authenticated}
+                             :auth-fail {:target :anonymous}}}
+    :authenticated  {:on {:logout {:target :anonymous}}}
+    :timeout        {:on {:retry  {:target :anonymous}}}}})
+
+;; The machine IS an event handler — dispatch a wrapped event at its id.
+(rf/dispatch [:session [:login {:user "alice" :pass "correct-horse"}]])
 ```
 
 The snapshot lives at `[:rf.runtime/machines :snapshots :session]` in the frame's **runtime-db** partition (not app-db). The shape is `{:state :anonymous :data {...}}` (plus framework-managed slots for `:after` timer epochs and tags). Read it via the `[:rf/machine machine-id]` subscription vector, or directly with `subscribe-once`.
@@ -138,11 +156,11 @@ The canonical machine read is the framework-registered subscription vector `[:rf
 
 ### Standard registered subs (machines)
 
-| Sub | Returns | Spec |
-|---|---|---|
-| `[:rf/machine <machine-id>]` | The machine's snapshot `{:state :data}` (or `nil` if not yet initialised) | 005 |
+| Sub | Returns |
+|---|---|
+| `[:rf/machine <machine-id>]` | The machine's snapshot `{:state :data}` (or `nil` if not yet initialised) |
 
-This subscription vector is the canonical machine read — see [005 §Subscribing to machines](../../spec/005-StateMachines.md#subscribing-to-machines-via-the-rfmachine-sub).
+This subscription vector is the canonical machine read — the [machines concept guide](concepts.md#registering-and-running-it) walks through subscribing to a snapshot and chaining named projections off it.
 
 ## Cross-machine messaging
 
@@ -154,7 +172,7 @@ The action-side way one machine addresses its spawned child actor by *role* (`:l
 {:fx [[:rf.machine/dispatch-to-system [:logger [:logger/flush]]]]}
 ```
 
-It resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and dispatches `event` to the bound actor; no-op when the `system-id` is unbound. This is the surface to reach for — a **machine action** can't read app-db and its `:on-spawn` return is dropped, so the fx form is the spec-blessed way an action sends a message to a named actor. See [The actor-lifecycle fx](#the-actor-lifecycle-fx) and [005 §Named addressing via `:system-id`](../../spec/005-StateMachines.md).
+It resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and dispatches `event` to the bound actor; no-op when the `system-id` is unbound. This is the surface to reach for — a **machine action** can't read app-db and its `:on-spawn` return is dropped, so the fx form is the canonical way an action sends a message to a named actor. See [The actor-lifecycle fx](#the-actor-lifecycle-fx) below and [spawn](glossary.md#spawn) in the machines glossary.
 
 When a child actor spawns under a parent, the parent's `:data` often gets the child's id stamped via `:on-spawn`; naming by `system-id` lets the parent address the child by role without threading that id.
 
@@ -170,12 +188,12 @@ When a child actor spawns under a parent, the parent's `:data` often gets the ch
 
 ## The actor-lifecycle fx
 
-| `[fx-id args]` | Args | Status | Spec | Intuition |
-|---|---|---|---|---|
-| `[:rf.machine/spawn spawn-spec]` | spawn-spec map (per `:rf.fx/spawn-args`) | v1 | 005 | "Spawn a dynamic actor instance." Args carry `:machine-id` (the definition to instantiate), `:id-prefix`, `:data` (initial), `:on-spawn` (event dispatched with the gensym'd id), and `:start` (events to deliver immediately). Emitted from any event handler's `:fx` (including machine actions and the `:spawn` desugar). |
-| `[:rf.machine/destroy actor-id]` | actor id (keyword) | v1 | 005 | "Tear down this actor." Runs the actor's `:exit` action, dissociates `[:rf.runtime/machines :snapshots <actor-id>]` (in runtime-db), and clears the actor's event-handler registration. Symmetric counterpart to `:rf.machine/spawn`. |
-| `[:rf.machine/dispatch-to-system [system-id event]]` | 2-element pair `[system-id event-vector]` | v1 | 005 | "Message my spawned child actor by name." Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and dispatches `event` to the bound actor; no-op when unbound. The action-side counterpart to the `dispatch-to-system` fn. Args ride as a single 2-element pair (the fx contract is a `[fx-id args]` pair). |
-| `[:raise event-vec]` | event vector | v1 | 005 | **Machine-only.** Inside a machine action's `:fx`, routes the event back into the same machine atomically and pre-commit. Unbound outside machine actions. |
+| `[fx-id args]` | Args | Status | Intuition |
+|---|---|---|---|
+| `[:rf.machine/spawn spawn-spec]` | spawn-spec map (per `:rf.fx/spawn-args`) | v1 | "Spawn a dynamic actor instance." Args carry `:machine-id` (the definition to instantiate), `:id-prefix`, `:data` (initial), `:on-spawn` (event dispatched with the gensym'd id), and `:start` (events to deliver immediately). Emitted from any event handler's `:fx` (including machine actions and the `:spawn` desugar). |
+| `[:rf.machine/destroy actor-id]` | actor id (keyword) | v1 | "Tear down this actor." Runs the actor's `:exit` action, dissociates `[:rf.runtime/machines :snapshots <actor-id>]` (in runtime-db), and clears the actor's event-handler registration. Symmetric counterpart to `:rf.machine/spawn`. |
+| `[:rf.machine/dispatch-to-system [system-id event]]` | 2-element pair `[system-id event-vector]` | v1 | "Message my spawned child actor by name." Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and dispatches `event` to the bound actor; no-op when unbound. The action-side counterpart to the `dispatch-to-system` fn. Args ride as a single 2-element pair (the fx contract is a `[fx-id args]` pair). |
+| `[:raise event-vec]` | event vector | v1 | **Machine-only.** Inside a machine action's `:fx`, routes the event back into the same machine atomically and pre-commit. Unbound outside machine actions. |
 
 ### Spawn pattern
 
@@ -208,11 +226,11 @@ Machines support **final states** — leaf states marked `:final?` that auto-des
 
 The pattern: a spawn-shaped sub-process completes, the parent receives the result through `:on-done`, the framework destroys the child. No manual `:rf.machine/destroy` needed.
 
-See [005 §Final states](../../spec/005-StateMachines.md#final-states-final--on-done--output-key).
+See [Final states: when a machine is done](concepts.md#final-states-when-a-machine-is-done) in the machines concept guide.
 
 ## Machine-tooling exports (JVM)
 
-The shipped machine-tooling exports live in `re-frame.machines` and are JVM-only (Xray + conformance consume them directly; no `re-frame.core` facade export). They render the machine *algebra view* that Xray / re-frame-pair navigate — there is **no** framework-level `machine->xstate-json`, `machine->mermaid`, or Stately bridge (those are owned by the separate `day8/re-frame2-machines-viz` library; see [Spec 005 §Future](../../spec/005-StateMachines.md) and the [Machines-Viz design rationale](../../tools/machines-viz/spec/DESIGN-RATIONALE.md)).
+The shipped machine-tooling exports live in `re-frame.machines` and are JVM-only (Xray + conformance consume them directly; no `re-frame.core` facade export). They render the machine *algebra view* that Xray / re-frame-pair navigate — there is **no** framework-level `machine->xstate-json`, `machine->mermaid`, or Stately bridge (those are owned by the separate `day8/re-frame2-machines-viz` library).
 
 ### `re-frame.machines/machine-algebra-view`
 
@@ -234,7 +252,7 @@ The shipped machine-tooling exports live in `re-frame.machines` and are JVM-only
 
 ### Post-v1 / future surfaces (not shipped)
 
-The following are **not** part of the shipped v1 surface — they are forward-pointers in [Spec 005 §Future](../../spec/005-StateMachines.md), owned by the post-v1 `day8/re-frame2-machines` and `day8/re-frame2-machines-viz` libraries:
+The following are **not** part of the shipped v1 surface — they are forward-pointers, owned by the post-v1 `day8/re-frame2-machines` and `day8/re-frame2-machines-viz` libraries:
 
 - `machine->mermaid` / `machine->xstate-json` — diagram/JSON exporters, owned by `day8/re-frame2-machines-viz` (Machines-Viz), not the framework.
 - `:child-machine` — a possible future declarative state-scoped child-machine binding (desugaring to entry/exit `:rf.machine/spawn` / `:rf.machine/destroy`). Pure sugar over the v1 surface; not yet shipped. Use the imperative `:spawn` / `:destroy` cycle today.
@@ -243,11 +261,13 @@ The v1 foundation covers the machine-as-event-handler primitive (`reg-machine` o
 
 ## Capability matrix
 
-The v1 transition-table grammar covers a specific subset of Statechart capabilities — sequencing, `:after` timers, internal-vs-external transitions, guards, action lists, hierarchical states, parallel regions where the framework's epoch model can tolerate them, and final-state semantics. The exact subset and its rationale lives at [005 §Capability matrix](../../spec/005-StateMachines.md#capability-matrix); the schema shape is [Spec-Schemas §`:rf/transition-table`](../../spec/Spec-Schemas.md#rftransition-table).
+The v1 transition-table grammar covers a specific subset of Statechart capabilities — sequencing, `:after` timers, internal-vs-external transitions, guards, action lists, hierarchical states, parallel regions where the framework's epoch model can tolerate them, and final-state semantics. The exact subset and its rationale are covered in the [machines concept guide](concepts.md); the transition-table shape itself is shown in [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
 
 ## See also
 
 - [01 — Core](../core/api/01-core.md) — `reg-machine` rowed in registration.
 - [08 — Schemas](../core/api/08-schemas.md) — machines declare schemas for their `:data` slot the same way ordinary handlers do.
 - [11 — Instrumentation](../core/api/11-instrumentation.md) — machine snapshots are part of the epoch buffer; transitions emit trace events.
-- [Spec 005 — State Machines](../../spec/005-StateMachines.md) — the normative source.
+- [Machines concept guide](concepts.md) — the narrative walkthrough: the transition table, guards, actions, tags, `:after`, final states, and when to reach for a machine.
+- [Machines glossary](glossary.md) — the surface vocabulary in one place.
+- [Coming from XState](coming-from-xstate.md) — the v6 parity delta for XState users.

--- a/docs/resources/api.md
+++ b/docs/resources/api.md
@@ -2,7 +2,7 @@
 
 A resource is a named, cached read of remote state — re-frame2's answer to TanStack Query / RTK Query / SWR / `re-frame-query`, re-expressed in the model: **views read server state passively through subscriptions; route entry, events, and machines *cause* it to fetch; the cache lives in the framework-owned runtime partition, not `app-db`.** You register a resource once with a scope policy, a params schema, and a request; after that the runtime owns identity, cache scope, staleness, dedupe, invalidation, GC, in-flight ownership, SSR hydration, and the metadata Xray reads.
 
-Resources are an **optional, post-v1 capability** — they ship in `day8/re-frame2-resources` (`re-frame.resources`), require `day8/re-frame2-http` for the transport, and are wired by one `(:require [re-frame.resources])` at app boot. An app that omits the artefact sees the `reg-resource` wrapper throw a clean `:rf.error/resources-artefact-missing`. This chapter covers the registration shape, the events, the subs, and introspection. The tutorial is [Guide ch.27 — Server-state and resources](concepts.md); the normative source is [016-Resources.md](../../spec/016-Resources.md).
+Resources are an **optional, post-v1 capability** — they ship in `day8/re-frame2-resources` (`re-frame.resources`), require `day8/re-frame2-http` for the transport, and are wired by one `(:require [re-frame.resources])` at app boot. An app that omits the artefact sees the `reg-resource` wrapper throw a clean `:rf.error/resources-artefact-missing`. This chapter covers the registration shape, the events, the subs, and introspection. The tutorial is [Guide ch.27 — Server-state and resources](concepts.md).
 
 > **Scope is HTTP-only.** The first public-beta surface is **landed and complete**: the read-resource MVP, **mutations** (`reg-mutation` / `:rf.mutation/execute`, the causal-write counterpart — see [Mutations](#mutations)), **focus/reconnect active-stale revalidation** (`:rf.resource/window-focused` / `:rf.resource/network-reconnected` + the `install-revalidation-listeners!` / `remove-revalidation-listeners!` host-listener fns — see [Revalidation](#focusreconnect-revalidation)), and **active-owner polling** (`:poll-interval-ms` — see [Polling](#polling)). **GraphQL is deferred** to a later slice. See [Guide ch.27 §What's deferred](concepts.md).
 
@@ -21,7 +21,7 @@ The resource surfaces are on the `re-frame.core` facade (`reg-resource` / `reg-m
   ```clojure
   (reg-resource resource-id metadata request-fn)
   ```
-- **Description**: Register a resource as data. The `metadata` is the MIDDLE registration-metadata map (the **required, fail-closed `:scope` policy**, `:params-schema`, `:doc`, …); the `request-fn` (which returns the [Spec 014](../../spec/014-HTTPRequests.md) managed-HTTP args map) is the THIRD value slot. A non-map `metadata` is rejected loudly with `:rf.error/invalid-resource-spec`. Validates the reconstructed spec — the **required, fail-closed `:scope` policy** first, then `:params-schema` — and writes a `:resource`-kind registrar entry. Returns `resource-id`. (The stored introspection spec from `resource-meta` reconstructs `:request` onto the metadata map.)
+- **Description**: Register a resource as data. The `metadata` is the MIDDLE registration-metadata map (the **required, fail-closed `:scope` policy**, `:params-schema`, `:doc`, …); the `request-fn` (which returns the [managed-HTTP args map](http-api.md)) is the THIRD value slot. A non-map `metadata` is rejected loudly with `:rf.error/invalid-resource-spec`. Validates the reconstructed spec — the **required, fail-closed `:scope` policy** first, then `:params-schema` — and writes a `:resource`-kind registrar entry. Returns `resource-id`. (The stored introspection spec from `resource-meta` reconstructs `:request` onto the metadata map.)
 - **In the wild**: see the [examples](#examples-and-cross-references) below.
 
 ### The resource spec
@@ -41,7 +41,7 @@ The resource surfaces are on the `re-frame.core` facade (`reg-resource` / `reg-m
    :tags           (fn [{:keys [slug]} _data] #{[:article slug]})
    :sensitive?     false}
 
-  ;; REQUIRED request fn (third positional arg) — returns a Spec 014 managed-HTTP args map
+  ;; REQUIRED request fn (third positional arg) — returns a managed-HTTP args map
   (fn [{:keys [slug]} _ctx]
     {:request {:method :get :url (str "/api/articles/" slug)}
      :decode  :app/article}))
@@ -53,9 +53,9 @@ The resource surfaces are on the `re-frame.core` facade (`reg-resource` / `reg-m
 |---|---|
 | `:params-schema` | Validates and canonicalizes params (the resource's identity). |
 | `:scope` | The scope **policy** — `:rf.scope/global`, a resolver, or `:rf.scope/from-caller`. **Required, fail-closed** — no policy is a loud `:rf.error/resource-missing-scope-policy`. There is no implicit default; a user-scoped read must say so. |
-| request fn (3rd positional arg) | For `:transport :rf.http/managed`, returns a [Spec 014](../../spec/014-HTTPRequests.md) args map. MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the scoped key + generation (rejected if present). |
+| request fn (3rd positional arg) | For `:transport :rf.http/managed`, returns a [managed-HTTP args map](http-api.md). MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the scoped key + generation (rejected if present). |
 
-These three (`:params-schema`, `:scope`, request fn) are the registration gate — a `reg-resource` missing any of them throws. `:data-schema` is **not** part of the gate; per [Spec 016 §Resource registration spec](../../spec/016-Resources.md) it is optional (it validates successful data when present, but the registration gate does not enforce it).
+These three (`:params-schema`, `:scope`, request fn) are the registration gate — a `reg-resource` missing any of them throws. `:data-schema` is **not** part of the gate; it is optional — it validates successful data when present, but the registration gate does not enforce it.
 
 **Optional keys**: `:doc`, `:data-schema` (validates successful data when present / transport decode supports it — not enforced by the registration gate), `:transport` (initial scope: `:rf.http/managed`), `:stale-after-ms`, `:gc-after-ms`, `:poll-interval-ms` (the active-owner poll interval — see [Polling](#polling)), `:infinite` + the infinite-only keys (`:next-page-param`, `:prev-page-param`, `:page->items`, `:initial-page-param`, `:page-data-schema`, `:refetch` — see [Infinite resources](#infinite-resources)), `:tags`, `:sensitive?` / `:large?` / schema-based classification.
 
@@ -171,7 +171,7 @@ A resource may declare an optional **`:poll-interval-ms`** policy: while an entr
   (fn [_ _ctx] {:request {:method :get :url "/notifications/unread"} :decode :json}))
 ```
 
-Semantics (per [016 §Polling](../../spec/016-Resources.md#polling)):
+Semantics (per [Guide ch.27 §Polling](concepts.md#polling-keep-this-fresh-every-n-ms)):
 
 - **Positive integer ms; non-positive / absent = no polling.** The poll timer is the third member of the freshness-timer family (beside `:stale-after-ms` / `:gc-after-ms`).
 - **Unconditional active-owner tick.** A tick refetches **by the interval**, not gated on `:stale?` — the consumer asked for "re-read every N ms". `:stale-after-ms` stays the orthogonal focus/route-entry knob. (Structural sharing keeps views quiet when an unchanged response comes back.)
@@ -184,7 +184,7 @@ A "just polling" view with no natural route/machine owner needs an app-minted `[
 
 ### Infinite resources
 
-An **infinite resource** is the load-more / infinite-scroll feed counterpart of TanStack Query's `useInfiniteQuery` / SWR's `useSWRInfinite` (see [EP-0021](../EP/EP-0021-infinite-resources.md); normative source [016 §Infinite resources and load-more feeds](../../spec/016-Resources.md#infinite-resources-and-load-more-feeds)). It is a resource registered with `:infinite true` plus a pure `:next-page-param`; the user accumulates pages (1, then 1+2, then 1+2+3) rendered as one growing list, with the *next* page param derived from the last page's data. Numbered / cursor pagination (`:keep-previous?` + per-page entries) is untouched and orthogonal — an app picks per feed.
+An **infinite resource** is the load-more / infinite-scroll feed counterpart of TanStack Query's `useInfiniteQuery` / SWR's `useSWRInfinite` (see [EP-0021](../EP/EP-0021-infinite-resources.md); tutorial in [Guide ch.27 §Infinite feeds](concepts.md#infinite-feeds-accumulate-pages-with-infinite)). It is a resource registered with `:infinite true` plus a pure `:next-page-param`; the user accumulates pages (1, then 1+2, then 1+2+3) rendered as one growing list, with the *next* page param derived from the last page's data. Numbered / cursor pagination (`:keep-previous?` + per-page entries) is untouched and orthogonal — an app picks per feed.
 
 ```clojure
 (rf/reg-resource :feed/timeline
@@ -256,7 +256,7 @@ Status invariants: `:loading` = first load, no usable data; `:fetching` = refres
 
 ## Mutations
 
-A **mutation** is the causal-WRITE counterpart of a resource: a named write to remote state that, on success, invalidates / patches / populates cached resource reads. The write lowers through the **same** `:rf.http/managed` transport as resources, and the runtime owns reply addressing + stale-suppression (work-id + generation) exactly as for reads. Runtime state is keyed by mutation **instance** id, so concurrent submissions of the same mutation never clobber each other. The tutorial is [Guide ch.27 §Mutations](concepts.md); the normative source is [016-Resources.md §Mutations](../../spec/016-Resources.md#mutations-first-public-beta-gate).
+A **mutation** is the causal-WRITE counterpart of a resource: a named write to remote state that, on success, invalidates / patches / populates cached resource reads. The write lowers through the **same** `:rf.http/managed` transport as resources, and the runtime owns reply addressing + stale-suppression (work-id + generation) exactly as for reads. Runtime state is keyed by mutation **instance** id, so concurrent submissions of the same mutation never clobber each other. The tutorial is [Guide ch.27 §Mutations](concepts.md).
 
 ### `reg-mutation`
 
@@ -265,18 +265,24 @@ A **mutation** is the causal-WRITE counterpart of a resource: a named write to r
   ```clojure
   (reg-mutation mutation-id metadata request-fn)
   ```
-- **Description**: Register a mutation as data under `mutation-id`. The `metadata` is the MIDDLE registration-metadata map (`:params-schema`, `:invalidates`, `:patches`, `:doc`, …); the `request-fn` (the [Spec 014](../../spec/014-HTTPRequests.md) managed-HTTP write) is the THIRD value slot. A non-map `metadata` is rejected loudly with `:rf.error/invalid-mutation-spec`. Validates the reconstructed spec and writes a `:mutation`-kind registrar entry (the causal-write counterpart of `:resource`). Returns `mutation-id`. An app that omits the resources artefact sees the wrapper throw `:rf.error/resources-artefact-missing`. (The stored introspection spec from `mutation-meta` reconstructs `:request` onto the metadata map.)
+- **Description**: Register a mutation as data under `mutation-id`. The `metadata` is the MIDDLE registration-metadata map (`:params-schema`, `:invalidates`, `:patches`, `:doc`, …); the `request-fn` (the [managed-HTTP write](http-api.md)) is the THIRD value slot. A non-map `metadata` is rejected loudly with `:rf.error/invalid-mutation-spec`. Validates the reconstructed spec and writes a `:mutation`-kind registrar entry (the causal-write counterpart of `:resource`). Returns `mutation-id`. An app that omits the resources artefact sees the wrapper throw `:rf.error/resources-artefact-missing`. (The stored introspection spec from `mutation-meta` reconstructs `:request` onto the metadata map.)
 
 ```clojure
 (rf/reg-mutation :article/save
   {:params-schema :app/article          ;; REQUIRED — validates + canonicalizes params
    :invalidates  (fn [{:keys [slug]} _result] #{[:article slug] [:article-list]})
-   :patches      (fn [params result] {scoped-key (fn [old result] (merge old result))})
-   :populates    (fn [params result] {scoped-key result})
+   ;; :patches / :populates key a cached entry by its resource descriptor and
+   ;; apply on success BEFORE invalidation — patch transforms the entry's data,
+   ;; populate seeds it straight from the reply.
+   :patches      (fn [{:keys [slug]} result]
+                   {{:resource :article/by-slug :params {:slug slug} :scope :rf.scope/global}
+                    (fn [old] (merge old result))})
+   :populates    (fn [{:keys [slug]} result]
+                   {{:resource :article/by-slug :params {:slug slug} :scope :rf.scope/global} result})
    :scope        :rf.scope/global       ;; the cache scope invalidation/patch defaults to
    :invalidate-timing :after-success}   ;; | :before-request | :after-failure | :after-settle
 
-  ;; REQUIRED request fn (third positional arg) — a Spec 014 managed-HTTP write
+  ;; REQUIRED request fn (third positional arg) — a managed-HTTP write
   (fn [{:keys [slug] :as article} _ctx]
     {:request {:method :put :url (str "/api/articles/" slug) :body article}
      :decode  :app/article}))
@@ -287,15 +293,15 @@ A **mutation** is the causal-WRITE counterpart of a resource: a named write to r
 | Key | Notes |
 |---|---|
 | `:params-schema` | Validates and canonicalizes the write's params. |
-| request fn (3rd positional arg) | Returns a [Spec 014](../../spec/014-HTTPRequests.md) managed-HTTP args map (the write). MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the instance + generation (rejected if present). **Write retries are OPT-IN** and live in this returned args map's own `:retry` (see the note below) — never a `reg-mutation` spec key. |
+| request fn (3rd positional arg) | Returns a [managed-HTTP args map](http-api.md) (the write). MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the instance + generation (rejected if present). **Write retries are OPT-IN** and live in this returned args map's own `:retry` (see the note below) — never a `reg-mutation` spec key. |
 
 **Optional keys**: `:invalidates` (`(fn [params result] → #{tag …})` — the tags made stale on success, composed with `:rf.resource/invalidate-tags`, scoped), `:patches` / `:populates` (controlled resource-entry transforms / seeds applied on success **before** invalidation, keyed by scoped key, via the same durable entry shape + structural sharing the read path uses), `:scope` (the cache scope the invalidation / patch / populate targets), `:invalidate-timing` (`:after-success` (default) | `:before-request` | `:after-failure` | `:after-settle`), `:transport`, `:doc`.
 
-> **`:retry` is NOT a `reg-mutation` spec key.** Write retries are opt-in and ride the [Spec 014](../../spec/014-HTTPRequests.md) managed-HTTP args your `:request` fn returns — put `:retry {…}` in *that* map. The runtime passes the `:request` args through to the transport unchanged and does **not** read or enforce a spec-level `:retry`; there is no `reg-mutation`-level retry to arm. (Reads inherit the same discipline — see [Guide ch.10 §Retry](http.md): re-issuing a non-idempotent write because a reply was merely slow is the double-write bug, so retry stays explicit and per-request.)
+> **`:retry` is NOT a `reg-mutation` spec key.** Write retries are opt-in and ride the [managed-HTTP args](http-api.md) your `:request` fn returns — put `:retry {…}` in *that* map. The runtime passes the `:request` args through to the transport unchanged and does **not** read or enforce a spec-level `:retry`; there is no `reg-mutation`-level retry to arm. (Reads inherit the same discipline — see [Guide ch.10 §Retry](http.md): re-issuing a non-idempotent write because a reply was merely slow is the double-write bug, so retry stays explicit and per-request.)
 
 > **Mutation `:scope` is not fail-closed.** Unlike a resource read — whose `:scope` is **required** and fails closed — a mutation's `:scope` is optional and resolves payload `:scope` → spec `:scope` → `:rf.scope/global`. The scope decides which cache scope the success-time invalidate / patch / populate targets, so it **MUST match the scope of the resources the write changes**: a write against user/tenant/locale-scoped entries that omits `:scope` invalidates the `[:rf.scope/global]` cache instead and silently misses the scoped entries (stale reads, no error). Pass `:scope` on `[:rf.mutation/execute …]` when the principal is known only at the call site; the `:rf.scope/from-caller` *policy* is a resource-read concept, not a mutation one.
 
-**Optimistic keys** (see [EP-0019](../EP/EP-0019-optimistic-mutation-rollback.md) and [spec/016 §Optimistic mutations](../../spec/016-Resources.md#optimistic-mutations)): `:optimistic` is a registration-level forward plan (the twin of `:patches`) applied **before** the server confirms; `:optimistic-tags` is its tag-addressed twin for cross-view consistency; `:on-conflict` (`:invalidate` default | `:force`) decides the contested-rollback policy. The **inverse is runtime-recorded** — the author supplies no `:rollback` registration key; the runtime snapshots each touched entry (with its `:revision`) on the instance row's `:patch-summary` `:rollback` slot and settles via the commit/rollback/reconcile protocol.
+**Optimistic keys** (see [EP-0019](../EP/EP-0019-optimistic-mutation-rollback.md) and [Guide ch.27 §Optimistic writes](concepts.md#optimistic-writes-commit-roll-back-or-reconcile)): `:optimistic` is a registration-level forward plan (the twin of `:patches`) applied **before** the server confirms; `:optimistic-tags` is its tag-addressed twin for cross-view consistency; `:on-conflict` (`:invalidate` default | `:force`) decides the contested-rollback policy. The **inverse is runtime-recorded** — the author supplies no `:rollback` registration key; the runtime snapshots each touched entry (with its `:revision`) on the instance row's `:patch-summary` `:rollback` slot and settles via the commit/rollback/reconcile protocol.
 
 ### `clear-mutation`
 
@@ -347,7 +353,7 @@ A failure settles `:error` — there is **no `:refresh-error` analogue** (a writ
 
 ## Introspection and projection (tool/test lane)
 
-These direct functions are the **tool/test projection lane** — not an app-read API. `resource-meta` / `mutation-meta` project the **registration** (the registered spec); `resource-state` / `resources` / `mutation-state` / `mutations` project **runtime state** (the live entries) as a one-shot, non-reactive snapshot at an explicit frame. They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. **App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#subscriptions-passive)**, never through these functions, which do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [Guide ch.27 §Three lanes](concepts.md#three-lanes--registering-causing-projecting) and the [Spec 016 lane table](../../spec/016-Resources.md#public-api).
+These direct functions are the **tool/test projection lane** — not an app-read API. `resource-meta` / `mutation-meta` project the **registration** (the registered spec); `resource-state` / `resources` / `mutation-state` / `mutations` project **runtime state** (the live entries) as a one-shot, non-reactive snapshot at an explicit frame. They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. **App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#subscriptions-passive)**, never through these functions, which do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [Guide ch.27 §Three lanes](concepts.md#three-lanes--registering-causing-projecting).
 
 `:frame` is an explicit, app-registered frame id ([EP-0002](../EP/EP-0002-frame-target-resolution.md) — no ambient `:rf/default` fallback; a frameless call with no resolvable context fails closed).
 
@@ -416,7 +422,7 @@ Resource cache lives **only** at `:rf.runtime/resources` inside the runtime-db p
 ## Examples and cross-references
 
 - [Guide ch.27 — Server-state and resources](concepts.md) — the tutorial.
-- [Spec 016 — Resources](../../spec/016-Resources.md) — the normative contract.
+- [Glossary](glossary.md) — the resources and server-state vocabulary in one place.
 - [EP-0003 — Resource Queries](../EP/EP-0003-resource-queries.md) — rationale and prior-art benchmark.
 - [Migration: re-frame-query → resources](../../migration/from-re-frame-v1/re-frame-query-to-resources.md) — moving off `shipclojure/re-frame-query` or a hand-rolled Pattern-RemoteData cache.
 - [07 — HTTP](http-api.md) — the `:rf.http/managed` transport and the `:rf.http/*` failure taxonomy.

--- a/docs/resources/http-api.md
+++ b/docs/resources/http-api.md
@@ -2,9 +2,9 @@
 
 Managed HTTP is the answer to "I want my app to talk to a server, but I don't want to write a custom fx-handler every time, and I want retries / cancellation / timeouts / decode / failure-classification to be the framework's problem, not mine." `:rf.http/managed` is one fx-id that takes one args map and gives you back one reply event with one closed taxonomy of failure kinds.
 
-You don't get this for free — Spec 014 is an **optional capability**. Implementations ship it (the CLJS reference does, on Fetch in the browser and `java.net.http.HttpClient` on the JVM); ports that omit it must not reuse the `:rf.http/*` namespace for anything else. If you're using the CLJS reference, you have it; if you're vendoring a port that doesn't, you're back to writing your own.
+You don't get this for free — managed HTTP is an **optional capability**. Implementations ship it (the CLJS reference does, on Fetch in the browser and `java.net.http.HttpClient` on the JVM); ports that omit it must not reuse the `:rf.http/*` namespace for anything else. If you're using the CLJS reference, you have it; if you're vendoring a port that doesn't, you're back to writing your own.
 
-This chapter covers the canonical fx, the verb helpers, the test stubs, the request-interceptor surface, and the closed failure taxonomy. The normative source — args map, decode pipeline, retry semantics, reply addressing — lives at [014-HTTPRequests.md](../../spec/014-HTTPRequests.md).
+This chapter covers the canonical fx, the verb helpers, the test stubs, the request-interceptor surface, and the closed failure taxonomy. The conceptual walkthrough — args map, decode pipeline, retry semantics, reply addressing — is [Guide ch.10 — HTTP: the managed request](http.md).
 
 The verb helpers live in `re-frame.http`; the `:rf.http/managed` fx is keyword-addressed (used in an event's `:fx`):
 
@@ -18,7 +18,7 @@ The verb helpers live in `re-frame.http`; the `:rf.http/managed` fx is keyword-a
 ### `[:rf.http/managed args-map]`
 
 - **Kind**: fx
-- **Args**: per [014 §The args map](../../spec/014-HTTPRequests.md#the-args-map) and `:rf.fx/managed-args`
+- **Args**: per [Guide ch.10 §The request is a map](http.md#the-request-is-a-map) and `:rf.fx/managed-args`
 - **Description**: The one fx-id. Args carry the request envelope, decode policy, accept fn, retry policy, timeout, success / failure target events, request-id (for abort), and optional abort-signal.
 - **In the wild**: [managed_http_counter](https://github.com/day8/re-frame2/tree/main/examples/core/managed_http_counter) · [realworld](https://github.com/day8/re-frame2/tree/main/examples/real-apps/realworld_http)
 
@@ -41,6 +41,9 @@ The verb helpers live in `re-frame.http`; the `:rf.http/managed` fx is keyword-a
 (rf/reg-event :cart/loaded
   (fn [{:keys [db]} [_ {:keys [rf/reply]}]]
     {:db (assoc-in db [:cart :items] (:value reply))}))
+
+(rf/reg-sub :cart/items
+  (fn [db _] (get-in db [:cart :items])))
 ```
 
 That's enough to issue a request, decode the JSON reply, and dispatch the result back. Retries, timeouts, schema validation, abort, decode customisation, accept-fn refinement — all of those are optional keys in the args map; you reach for them when the problem asks for them.
@@ -137,11 +140,11 @@ Every reply lands under `:rf/reply` in the dispatched event's payload map. Two s
                       :tags  {...}}}}
 ```
 
-**Default reply addressing** dispatches `[<originating-event-id> (assoc original-msg :rf/reply ...)]` back to the same handler — your `:cart/load` handler sees the reply at `:rf/reply`. **Explicit `:on-success` / `:on-failure`** targets append the reply payload as the last event-vector arg — your `:cart/loaded` handler sees `[:cart/loaded {:rf/reply ...}]`. Both shapes detailed in [014 §Reply addressing](../../spec/014-HTTPRequests.md#reply-addressing).
+**Default reply addressing** dispatches `[<originating-event-id> (assoc original-msg :rf/reply ...)]` back to the same handler — your `:cart/load` handler sees the reply at `:rf/reply`. **Explicit `:on-success` / `:on-failure`** targets append the reply payload as the last event-vector arg — your `:cart/loaded` handler sees `[:cart/loaded {:rf/reply ...}]`. Both shapes detailed in [Guide ch.10 §Reading the reply](http.md#reading-the-reply-correctly).
 
 ## Failure categories (closed set)
 
-Eight failure `:kind` values, all reserved under `:rf.http/*`. The set is closed — ports that ship Spec 014 deliver exactly these eight categories, and your handler's failure switch can be exhaustive.
+Eight failure `:kind` values, all reserved under `:rf.http/*`. The set is closed — ports that ship managed HTTP deliver exactly these eight categories, and your handler's failure switch can be exhaustive.
 
 | `:kind` | Meaning |
 |---|---|
@@ -154,7 +157,7 @@ Eight failure `:kind` values, all reserved under `:rf.http/*`. The set is closed
 | `:rf.http/accept-failure` | `:accept` returned `{:failure user-map}`. |
 | `:rf.http/aborted` | Request aborted via `:request-id` or `:abort-signal`. |
 
-See [014 §Failure categories](../../spec/014-HTTPRequests.md#failure-categories-closed-set) for tags-by-kind.
+See [Guide ch.10 §Failures are a closed set](http.md#failures-are-a-closed-set) for tags-by-kind.
 
 ## Request-interceptor middleware
 
@@ -193,7 +196,7 @@ Sometimes you want to inject behaviour into every request — adding an auth hea
              (assoc resp :elapsed-ms (- (js/Date.now) (::started ctx))))})
 ```
 
-The `:before` runs before the request is dispatched to the platform's HTTP client; the `:after` runs after the response is built and BEFORE `:on-success` / `:on-failure` fire. If either throws, the corresponding side is not delivered (request: not dispatched; response: reply suppressed) and `:rf.error/http-interceptor-failed` fires with `:frame`, `:interceptor-id`, `:url`, `:cause`, and `:phase`. See [014 §Middleware](../../spec/014-HTTPRequests.md#middleware).
+The `:before` runs before the request is dispatched to the platform's HTTP client; the `:after` runs after the response is built and BEFORE `:on-success` / `:on-failure` fire. If either throws, the corresponding side is not delivered (request: not dispatched; response: reply suppressed) and `:rf.error/http-interceptor-failed` fires with `:frame`, `:interceptor-id`, `:url`, `:cause`, and `:phase`. See [Guide ch.10 §Interceptors](http.md#interceptors-stamp-every-request-once).
 
 ## Testing: stubbed responses
 
@@ -257,11 +260,11 @@ All the test-support surfaces live in `re-frame.http.test-support`. One namespac
 
 ## Schema-reflection metadata
 
-Handlers may declare `:rf.http/decode-schemas [<schema> ...]` in their `reg-event` metadata-map; pair tools and generators read it via `(rf/handler-meta :event id)`. Optional, never enforced — pure metadata for tooling. See [014 §Schema reflection](../../spec/014-HTTPRequests.md#schema-reflection-optional-ergonomic).
+Handlers may declare `:rf.http/decode-schemas [<schema> ...]` in their `reg-event` metadata-map; pair tools and generators read it via `(rf/handler-meta :event id)`. Optional, never enforced — pure metadata for tooling. See [08 — Schemas](../core/api/08-schemas.md).
 
 ## Privacy and classification
 
-HTTP is the canonical privacy surface in any app: passwords ride request bodies, auth tokens ride request headers, PII rides response bodies. The framework keeps these off its own observability wire — traces, off-box records, SSR payloads — without you writing a `beforeSend` scrub. Four declaration surfaces cooperate, none of them a process-global mutation. The normative source is [014 §Privacy](../../spec/014-HTTPRequests.md#privacy); the model end-to-end is [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
+HTTP is the canonical privacy surface in any app: passwords ride request bodies, auth tokens ride request headers, PII rides response bodies. The framework keeps these off its own observability wire — traces, off-box records, SSR payloads — without you writing a `beforeSend` scrub. Four declaration surfaces cooperate, none of them a process-global mutation. The conceptual walkthrough is [Guide ch.10 §Keeping secrets out of the trace](http.md#keeping-secrets-out-of-the-trace); the model end-to-end is [keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
 
 | Surface | What it covers | Where declared |
 |---|---|---|
@@ -325,4 +328,4 @@ The denylists and `:sensitive?` flag cover request carriers; the **response body
 - [10 — Testing](../core/api/10-testing.md) — patterns for combining HTTP stubs with `dispatch-sequence`.
 - [11 — Instrumentation](../core/api/11-instrumentation.md) — `project-egress`, the wire-boundary walker, and the observability-sink surface.
 - [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md) — the full classification + projection model.
-- [Spec 014 — HTTP Requests](../../spec/014-HTTPRequests.md) — the normative source (incl. §Privacy).
+- [Guide ch.10 — HTTP: the managed request](http.md) — the conceptual walkthrough (incl. §Keeping secrets out of the trace).

--- a/docs/routing/api.md
+++ b/docs/routing/api.md
@@ -4,7 +4,7 @@ Routes in re-frame2 are *data*. You register a route with a path and metadata �
 
 The point isn't novelty — every SPA framework has a router. The point is that **routing-as-state** means the router is debuggable with the same tools that debug everything else. Time-travel works. The trace bus sees navigation. Tests dispatch `:rf.route/navigate` like any other event. There's no special "router debug mode" because the router doesn't have its own mode.
 
-This chapter covers the registration shape, the dispatch / sub / fx surface, and the helpers that map URLs to/from route ids. For nav-token semantics, `:can-leave` flows, query strings, and multi-frame routing, see [Guide ch.19 — Routing reference](concepts.md). The normative source is [012-Routing.md](../../spec/012-Routing.md).
+This chapter covers the registration shape, the dispatch / sub / fx surface, and the helpers that map URLs to/from route ids. For nav-token semantics, `:can-leave` flows, query strings, and multi-frame routing, see [Guide ch.19 — Routing reference](concepts.md).
 
 The `reg-route` macro is on the `re-frame.core` facade; the rest of the routing surface lives in `re-frame.routing`:
 
@@ -40,7 +40,7 @@ The third positional arg is the URL shape — colon-prefixed segments capture in
 | Key | Notes |
 |---|---|
 | `:doc` | Free-form description; pair tools read this. |
-| `:params` | Schemas for path segments (per [Spec-Schemas](../../spec/Spec-Schemas.md)). |
+| `:params` | Schemas for path segments. |
 | `:query` | Schemas for query-string keys. |
 | `:query-defaults` | Default values for query keys absent from the URL. |
 | `:query-retain` | Keys to preserve across navigations to other routes. |
@@ -51,7 +51,7 @@ The third positional arg is the URL shape — colon-prefixed segments capture in
 | `:can-leave` | Guard sub-query run before leaving the route. **Closed boolean contract**: `true` allows the navigation, `false` blocks it; any non-boolean value blocks and emits `:rf.error/can-leave-non-boolean`. The sub name reads positively (`:can-leave`), so `false` means "can NOT leave". See [Guide ch.19 — Navigation blocking](concepts.md). |
 | `:scroll` | Scroll-restoration behaviour for this route. |
 
-Canonical detail in [012-Routing.md](../../spec/012-Routing.md); the metadata schema is [Spec-Schemas §`:rf/route-metadata`](../../spec/Spec-Schemas.md#rfroute-metadata).
+Canonical detail in [The metadata map, in full](concepts.md#the-metadata-map-in-full) in the routing concept guide.
 
 ## URL helpers
 
@@ -104,37 +104,37 @@ Modifier-key clicks (cmd / ctrl / shift / alt) and middle-button clicks defer to
 
 Anchors carrying **native-handling attributes** are never intercepted — even on a plain left-click — because their DOM semantics must win: a `:target` other than `_self` (`_blank` / `_parent` / `_top` / a named frame) opens the href outside the current document, and `:download` instructs the browser to save the resource. A `route-link` rendered as `{:target "_blank"}` or `{:download "report.pdf"}` therefore behaves as the equivalent plain `<a>` would. To get SPA interception, omit those attributes (or use `:target "_self"`).
 
-Detailed semantics in [012-Routing.md §Linking from views](../../spec/012-Routing.md#linking-from-views--plain-anchor-semantics).
+Detailed semantics in [Linking from views](concepts.md#linking-from-views) in the routing concept guide.
 
 ## Events
 
 These are the standard events the runtime dispatches (or you dispatch) around routing.
 
-| Event | Notes | Spec |
-|---|---|---|
-| `:rf.route/navigate` | Navigate to a registered route. Args: `{:to :route-id :params {...} :query {...}}`. | 012 |
-| `:rf.route/handle-url-change` | URL-change handler for popstate / initial load / SSR (default scroll `:restore`). Co-equal sibling of `:rf.route/transitioned` — same slice-rewrite logic, not a delegate. Override for custom URL-change handling. | 012 |
-| `:rf.route/transitioned` | URL-change handler for forward navigation — a link click or programmatic push (default scroll `:top`). The runtime dispatches this; you read it. | 012 |
-| `:rf/url-requested` | The user clicked a framework-owned link. `route-link` synthesises this event; you usually let the default handler take it. | 012 |
-| `:rf.route/navigation-blocked` | A `:can-leave` guard rejected a navigation. The pending nav slot in `app-db` carries the rejected navigation. | 012 |
-| `:rf.route/continue` | User-dispatched event proceeding a blocked navigation — "yes, leave the page." | 012 |
-| `:rf.route/cancel` | User-dispatched event abandoning a blocked navigation — "stay here, drop the pending nav." | 012 |
+| Event | Notes |
+|---|---|
+| `:rf.route/navigate` | Navigate to a registered route. Args: `{:to :route-id :params {...} :query {...}}`. |
+| `:rf.route/handle-url-change` | URL-change handler for popstate / initial load / SSR (default scroll `:restore`). Co-equal sibling of `:rf.route/transitioned` — same slice-rewrite logic, not a delegate. Override for custom URL-change handling. |
+| `:rf.route/transitioned` | URL-change handler for forward navigation — a link click or programmatic push (default scroll `:top`). The runtime dispatches this; you read it. |
+| `:rf/url-requested` | The user clicked a framework-owned link. `route-link` synthesises this event; you usually let the default handler take it. |
+| `:rf.route/navigation-blocked` | A `:can-leave` guard rejected a navigation. The pending nav slot in `app-db` carries the rejected navigation. |
+| `:rf.route/continue` | User-dispatched event proceeding a blocked navigation — "yes, leave the page." |
+| `:rf.route/cancel` | User-dispatched event abandoning a blocked navigation — "stay here, drop the pending nav." |
 
 ## Subscriptions
 
 The full `:rf/route` slice is `{:id :params :query :transition :error}`. The standard subs are projections of that slice plus a couple of conveniences.
 
-| Sub | Returns | Spec |
-|---|---|---|
-| `:rf/route` | The full `:rf/route` slice `{:id :params :query :transition :error}` | 012 |
-| `:rf.route/id` | Current route id | 012 |
-| `:rf.route/params` | Current path params | 012 |
-| `:rf.route/query` | Current query params | 012 |
-| `:rf.route/transition` | `:idle` / `:loading` / `:error` | 012 |
-| `:rf.route/error` | Current error map (when `:transition = :error`) | 012 |
-| `:rf.route/fragment` | Current URL fragment (string or `nil`) | 012 |
-| `:rf.route/chain` | Vector of route ids from parent-most to current (per `:parent` links) | 012 |
-| `:rf/pending-navigation` | The pending-nav slot (per `:rf/pending-navigation` schema) when a navigation is blocked; `nil` otherwise | 012 |
+| Sub | Returns |
+|---|---|
+| `:rf/route` | The full `:rf/route` slice `{:id :params :query :transition :error}` |
+| `:rf.route/id` | Current route id |
+| `:rf.route/params` | Current path params |
+| `:rf.route/query` | Current query params |
+| `:rf.route/transition` | `:idle` / `:loading` / `:error` |
+| `:rf.route/error` | Current error map (when `:transition = :error`) |
+| `:rf.route/fragment` | Current URL fragment (string or `nil`) |
+| `:rf.route/chain` | Vector of route ids from parent-most to current (per `:parent` links) |
+| `:rf/pending-navigation` | The pending-nav slot (per `:rf/pending-navigation` schema) when a navigation is blocked; `nil` otherwise |
 
 ## Fx
 
@@ -152,4 +152,5 @@ The nav-token wrapper is what makes "user navigates away mid-load" safe: the old
 - [01 — Core](../core/api/01-core.md) — `reg-route` rowed in registration.
 - [SSR API](../ssr/api.md) — routes participate in SSR; the active route's `:head` registration is what `render-head` looks up.
 - [Guide ch.18 — Routing](concepts.md) and [Guide ch.19 — Routing reference](concepts.md) — narrative coverage including nav-token semantics, `:can-leave` flows, query strings, and multi-frame routing.
-- [Spec 012 — Routing](../../spec/012-Routing.md) — the normative source.
+- [Routing glossary](glossary.md) — the surface vocabulary (navigate, route, loader, route guard, not-found, url-bound?).
+- [Coming from React Router](coming-from-react-router.md) — the mapping, and where re-frame2 routing diverges.

--- a/docs/ssr/api.md
+++ b/docs/ssr/api.md
@@ -6,7 +6,7 @@ This works because the framework was designed around immutable data and an expli
 
 This chapter covers the rendering primitives (`render-to-string`, the streaming triple, the structural-hash), the head model (`reg-head`, `active-head`, `render-head`), the per-request response accumulator and its server-only fx, the error-projection seam (`reg-error-projector`, `project-error`), and the `:platforms` metadata that gates fx execution by active platform.
 
-The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces live in `re-frame.ssr` (artefact `day8/re-frame2-ssr`); the Ring host-adapter lives in `re-frame.ssr.ring`. The implementation ships in a separate artefact — you add `day8/re-frame2-ssr` to your deps and require the namespace to get the full surface. For convenience, a curated set of the rendering and head primitives is **re-exported from `re-frame.core` as late-bound wrappers** (`render-to-string`, `render-tree-hash`, `project-error`, `render-head`, `active-head`, `head-model->html`, `head-snapshot`): these resolve to the `re-frame.ssr` implementation at call time when the artefact is on the classpath, and throw a clear "SSR not loaded" error otherwise. So apps that already `(:require [re-frame.core :as rf])` can call `rf/render-to-string` directly; the host-adapter surface (`re-frame.ssr.ring`) and the per-request `:rf.server/*` fx are **not** re-exported — require `re-frame.ssr` / `re-frame.ssr.ring` for those. The two registration macros `reg-head` and `reg-error-projector` are also `re-frame.core` facade exports (rowed in [01 — Core](../core/api/01-core.md)).
+The conceptual walkthrough is [Server-side rendering — the tutorial](concepts.md). The SSR surfaces live in `re-frame.ssr` (artefact `day8/re-frame2-ssr`); the Ring host-adapter lives in `re-frame.ssr.ring`. The implementation ships in a separate artefact — you add `day8/re-frame2-ssr` to your deps and require the namespace to get the full surface. For convenience, a curated set of the rendering and head primitives is **re-exported from `re-frame.core` as late-bound wrappers** (`render-to-string`, `render-tree-hash`, `project-error`, `render-head`, `active-head`, `head-model->html`, `head-snapshot`): these resolve to the `re-frame.ssr` implementation at call time when the artefact is on the classpath, and throw a clear "SSR not loaded" error otherwise. So apps that already `(:require [re-frame.core :as rf])` can call `rf/render-to-string` directly; the host-adapter surface (`re-frame.ssr.ring`) and the per-request `:rf.server/*` fx are **not** re-exported — require `re-frame.ssr` / `re-frame.ssr.ring` for those. The two registration macros `reg-head` and `reg-error-projector` are also `re-frame.core` facade exports (rowed in [01 — Core](../core/api/01-core.md)).
 
 The render/head primitives are re-exported on the `re-frame.core` facade; the full SSR surface and the Ring host adapter live in their own namespaces:
 
@@ -75,7 +75,7 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
   (streaming-render-continuation frame-id entry)
     → {:id :html :delta :failed?}
   ```
-- **Description**: Drain one continuation against `frame-id`'s app-db. Snapshots before-db / after-db and computes the per-subtree delta. Catches throws and surfaces the original fallback HTML inline (per [011 §Failure semantics — inline fallback](../../spec/011-SSR.md#failure-semantics--inline-fallback)).
+- **Description**: Drain one continuation against `frame-id`'s app-db. Snapshots before-db / after-db and computes the per-subtree delta. Catches throws and surfaces the original fallback HTML inline.
 
 ### `streaming-build-final-payload`
 
@@ -148,39 +148,39 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
 
 ## Standard SSR events
 
-| Event | What it does | Spec |
-|---|---|---|
-| `:rf/server-init` | Per-request server-side initialisation. Reads request cofx; dispatches setup events. `:platforms #{:server}`. | 011 |
-| `:rf/hydrate` | Seed the client-side `app-db` from the server-supplied payload. Runs once on client bootstrap. | 011 |
+| Event | What it does |
+|---|---|
+| `:rf/server-init` | Per-request server-side initialisation. Reads request cofx; dispatches setup events. `:platforms #{:server}`. |
+| `:rf/hydrate` | Seed the client-side `app-db` from the server-supplied payload. Runs once on client bootstrap. |
 
 ## Standard SSR fx (server-only)
 
 All server-only — `:platforms #{:server}`. These build the response accumulator that the host adapter turns into the HTTP response.
 
-| Fx | Args | Spec |
-|---|---|---|
-| `[:rf.server/set-status int]` | per `:rf.fx.server/set-status-args` | 011 |
-| `[:rf.server/set-header {:name :value}]` | per `:rf.fx.server/set-header-args` | 011 |
-| `[:rf.server/append-header {:name :value}]` | per `:rf.fx.server/append-header-args` | 011 |
-| `[:rf.server/set-cookie :rf.server/cookie]` | structured cookie map | 011 |
-| `[:rf.server/delete-cookie {:name ?:path ?:domain}]` | — | 011 |
-| `[:rf.server/redirect {:location ?:status}]` | default `:status 302`; truncates HTML. **Caller-trusted** `:location`. | 011 |
-| `[:rf.server/safe-redirect {:location ?:relative-only? ?:allow}]` | The caller-untrusted variant — parses `:location`, rejects `javascript:` / `data:` / `vbscript:` schemes, and enforces `:relative-only?` / `:allow` allowlist before setting `:redirect`. Open-redirect mitigation for attacker-controlled `?next=` strings. | 011 |
+| Fx | Args |
+|---|---|
+| `[:rf.server/set-status int]` | per `:rf.fx.server/set-status-args` |
+| `[:rf.server/set-header {:name :value}]` | per `:rf.fx.server/set-header-args` |
+| `[:rf.server/append-header {:name :value}]` | per `:rf.fx.server/append-header-args` |
+| `[:rf.server/set-cookie :rf.server/cookie]` | structured cookie map |
+| `[:rf.server/delete-cookie {:name ?:path ?:domain}]` | — |
+| `[:rf.server/redirect {:location ?:status}]` | default `:status 302`; truncates HTML. **Caller-trusted** `:location`. |
+| `[:rf.server/safe-redirect {:location ?:relative-only? ?:allow}]` | The caller-untrusted variant — parses `:location`, rejects `javascript:` / `data:` / `vbscript:` schemes, and enforces `:relative-only?` / `:allow` allowlist before setting `:redirect`. Open-redirect mitigation for attacker-controlled `?next=` strings. |
 
 ## Standard SSR subs
 
-| Sub | Returns | Spec |
-|---|---|---|
-| `:rf/head` | The head model for the active route (resolved via `active-head` against the subscribed frame) | 011 |
-| `:rf/public-error` | The sanitised public-error projection when an error page is being rendered; `nil` otherwise | 011 |
+| Sub | Returns |
+|---|---|
+| `:rf/head` | The head model for the active route (resolved via `active-head` against the subscribed frame) |
+| `:rf/public-error` | The sanitised public-error projection when an error page is being rendered; `nil` otherwise |
 
-The current request's **response accumulator** (status / headers / cookies / redirect) is *not* a registered subscription. It lives in a framework-private side-channel atom keyed by frame-id and is read exclusively by the runtime via `re-frame.ssr/get-response` (per [011 §Response storage substrate](../../spec/011-SSR.md#response-storage-substrate)); the host adapter consumes the resolved value to build the wire response.
+The current request's **response accumulator** (status / headers / cookies / redirect) is *not* a registered subscription. It lives in a framework-private side-channel atom keyed by frame-id and is read exclusively by the runtime via `re-frame.ssr/get-response`; the host adapter consumes the resolved value to build the wire response.
 
 ## Standard SSR cofx
 
-| Cofx | Returns | Spec |
-|---|---|---|
-| `:rf.server/request` | The active HTTP request map. | 011 |
+| Cofx | Returns |
+|---|---|
+| `:rf.server/request` | The active HTTP request map. |
 
 ## `:platforms` metadata on `reg-fx`
 
@@ -194,7 +194,7 @@ The current request's **response accumulator** (status / headers / cookies / red
 
 Skipped fx emit a `:rf.fx/skipped-on-platform` trace event so debug tools see the gate firing. The cofx side has a mirror trace event, `:rf.cofx/skipped-on-platform`.
 
-Detail in [011 §`:platforms` metadata on `reg-fx`](../../spec/011-SSR.md#platforms-metadata-on-reg-fx).
+Detail in [the SSR tutorial §`:platforms`](concepts.md).
 
 ## Per-frame error-projection policy
 
@@ -218,17 +218,17 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
 
 The companion `project-error` accessor is rowed above in [§Rendering primitives](#project-error) — same signature; same job. Apply the active projector for the named frame.
 
-Full rationale: [Conventions §Configuration surfaces](../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata) bucket 3 and [011 §Server error projection](../../spec/011-SSR.md#server-error-projection).
+Full rationale: [the SSR tutorial §When the server throws](concepts.md#when-the-server-throws).
 
 ## Hydration
 
 The server-rendered HTML carries a `__rf_payload` chunk that the client deserialises into `app-db` on bootstrap. The structural-hash from `render-tree-hash` is captured at render time and checked at hydration; a mismatch between the server-render hash and the client-render hash surfaces **`:rf.ssr/hydration-mismatch`** (in `:hard-error` mode it also throws; otherwise it warns and re-renders client-side) rather than silently mounting a broken DOM. This is distinct from the two payload-provenance checks the reference `:rf/hydrate` handler runs — `:rf.ssr/version-mismatch` (the payload was produced by a different framework version) and `:rf.ssr/schema-digest-mismatch` (the app's schema set drifted since the payload was built); those guard payload compatibility, while `:rf.ssr/hydration-mismatch` guards the render-tree structural hash.
 
-The hydration payload shape lives at [Spec-Schemas §`:rf/hydration-payload`](../../spec/Spec-Schemas.md#rfhydration-payload).
+The hydration payload is the `__rf_payload` chunk seeded into `app-db` on bootstrap — see [the SSR tutorial §The client side](concepts.md#the-client-side-hydrate-then-verify).
 
 ## See also
 
 - [01 — Core](../core/api/01-core.md) — `reg-head` / `reg-error-projector` rowed in registration.
 - [Routing API](../routing/api.md) — routes opt into head models via `:head` metadata.
 - [11 — Instrumentation](../core/api/11-instrumentation.md) — the SSR-specific trace events live in the error catalogue.
-- [Spec 011 — SSR](../../spec/011-SSR.md) — the normative source.
+- [Server-side rendering — the tutorial](concepts.md) — the conceptual walkthrough.


### PR DESCRIPTION
A complete review of the API reference docs (16 files), continuing from **#5028** (which finished the **dedup** workstream — the 01-core "Registrars owned by other chapters" index + cross-file pointer rows). This covers the remaining three workstreams.

## ② /spec-free — only cross-reference this corpus
Removed **every** reference to the `/spec` tree from the API docs (was **116 links** + dedicated `Spec` table-columns + bare "Spec NNN" prose):
- Links repointed to the CLJS corpus — other API chapters, **concept guides** (`docs/core/concepts/*`), **how-tos** (`docs/core/how-to/*`), and the **glossaries** (`docs/*/glossary.md`) — or rephrased to stand alone where no doc-set target fit.
- Removed the dedicated **`Spec` column** from 9 tables (fx entries; machine subs + actor-lifecycle fx; routing events + subs; SSR events/fx/subs/cofx).
- Every new anchor verified — `check_doc_slugs` green.

## ③ Better examples
Realistic, idiomatic, runnable, consistent with the `examples/` apps:
- reg-flow toy wizard → an order-total flow; non-idiomatic minimal machine → canonical `:guards`/`:actions` + a runnable `machine-transition` test.
- Added production-monitoring listener examples (Datadog `:events` / Sentry `:errors`, via the public `register-listener!` facade), a **Helix** component example, completed the managed-HTTP request→store→read loop, fixed placeholder mutation/cart-row examples.

## ④ Placement (flagged for your sign-off)
- **Moved `with-frame` / `with-new-frame` out of 02-views** into **01-core's "Frames: the scoping primitive"** — they're frame-scoping primitives used in tests and SSR, not view-authoring — with a 10-testing cross-ref.
- Added the missing **`frame-provider` example** in 02-views (both SCOPE `{:frame}` and ENSURE `{:id}` shapes).

## Also
Fixed README chapter-inventory staleness from #5028's removal of `15-removed` (sixteen→**fifteen** chapters; dropped the "Removed / not shipped chapter" reference).

## ⚠️ One decision left for you — EP references
The mandate was "/spec". The docs still contain **22 `EP-NNNN` links** (e.g. `[EP-0024](../../EP/…)`) — these point at **`docs/EP/`**, a sibling of these docs, **not** `/spec/`, so I left them as in-corpus cross-references. **If you want EP references stripped too, say so and I'll do a follow-up pass.**

## Verification (local)
`check_doc_slugs`, `check_readme_links`, the three residue checkers, and the **api-manifest JVM gate** (53 tests, 0 failures — `docs/core/api` references reconcile against the manifest). `mkdocs --strict` runs in CI.