### PR TITLE
docs(migration-skill): front-load the mechanical global renames as a pre-pass before the file-partitioned fan-out

### DIFF
--- a/skills/re-frame-migration/references/orchestrating-a-large-migration.md
+++ b/skills/re-frame-migration/references/orchestrating-a-large-migration.md
@@ -24,6 +24,26 @@ A silent fix is an out-of-bounds edit waiting to happen — the surface may belo
 
 Make it an explicit line in every unit's deliverable: **"no un-inventoried trigger surfaces left unreported in my files."** A unit isn't done when its listed rules are applied — it's done when its files carry no v1 surface the orchestrator hasn't been told about.
 
+## Wave 0.5 — the mechanical global pre-pass
+
+The completeness gate hands you the **whole** changed surface up front. Before you partition it (§1), front-load the part of the sweep that is **dominantly mechanical**: run the high-frequency, context-independent global renames across the **entire tree first**, as one reviewable, low-risk commit. The file-partitioned fan-out (§1, §4) then rebases off that commit and does the judgment-heavy per-area work on top. This is ordinary large-refactor practice — mechanical codemods first, judgment work second — and it is exactly what the dep-coord swap ([M-0](breaking-changes.md#required-m-rules-by-trigger-surface)) and the off-contract-require rewrite ([M-1](auto-call-site-rewrites.md#m-1--off-contract-re-frame-namespace-requires)) already do ahead of everything else.
+
+**The pre-pass is sequential — it is NOT a concurrent rule-family worker, so it does not contradict §1.** §1 correctly forbids concurrent rule-family workers: M-70 and M-8 sites co-habit `events.cljs`, so a "one worker per rule" split collides there. The pre-pass is the opposite shape — it commits **once**, and the fan-out rebases off that single commit exactly as it already rebases off M-0 / M-1. One commit lands tree-wide, then the file-partition runs on top; no two workers ever hold the same file at the same time. The pre-pass composes with one-file-one-owner — it does not weaken it.
+
+**The selection criterion.** A rule belongs in the pre-pass when it is **dominantly mechanical** (a closed rename / codemod, not a judgment call), **high-frequency** (it fires at many sites across many files), and **context-independent** (the rewrite is the same everywhere — it does not turn on what the surrounding code means). Classify any rule against those three; for a typical v1 app the qualifiers are:
+
+- **[M-73](auto-call-site-rewrites.md#m-73--one-event-registration-form-reg-event)** — the `reg-event-db` / `reg-event-fx` → `reg-event` consolidation. The most pervasive call-site rule of all, universal to every v1 app: everything registers events. The pure `reg-event-fx` → `reg-event` rename and the simple `reg-event-db` → `{:db BODY}` reshape are the deterministic codemod.
+- **[M-23](auto-call-site-rewrites.md#m-23--re-framealpha-removal-mechanical-half)** — for alpha-namespace apps, `re-frame.alpha`'s `sub` → `subscribe` (and the per-kind `reg` → `reg-*` rewrites).
+- **[M-20](breaking-changes.md#required-m-rules-by-trigger-surface)** — the closed framework-keyword rename table (`:re-frame/*` / `:machine/*` / … collapse onto the single `:rf/*` root).
+- **[M-51](breaking-changes.md#required-m-rules-by-trigger-surface)** — the unary → binary `reg-fx` handler arity bump (`(fn [args] …)` → `(fn [_ args] …)`).
+
+**Carve out the context-dependent halves, or the pre-pass manufactures anti-shapes.** Two of these rules ride a judgment call; the pre-pass takes only the mechanical bulk and leaves the carve-out **flagged for the owning unit**:
+
+- **M-23's signal-fn carve-out → [M-71](guided-interceptors-subs.md#m-71--the-v1-signal-function-reg-sub-form-3-arity--v2-input-fns).** A `sub` at an ordinary call site becomes `subscribe`, but a `sub` **inside a `reg-sub` signal/input fn** becomes a bare query **vector** (`[:x id]`), not a `subscribe` call — swapping it to `subscribe` registers clean and then throws at first materialization. The pre-pass leaves those for M-71's reshape (the unit that owns the subs file). Both halves are written up in [`auto-call-site-rewrites.md` §M-23](auto-call-site-rewrites.md#m-23--re-framealpha-removal-mechanical-half).
+- **M-73's non-mechanical half.** The pure rename and the simple `reg-event-db` reshape are codemod-able; a `reg-event-db` body that can evaluate to `nil`, a complex / multi-arity `reg-event-db`, and every `reg-event-ctx` are **not** — the codemod flags them rather than rewriting (see [`auto-call-site-rewrites.md` §M-73](auto-call-site-rewrites.md#m-73--one-event-registration-form-reg-event)). The pre-pass runs the codemod and carries those flags to the owning unit; it never guesses the intended reading.
+
+Front-loading these **shrinks the convergence gate.** Distributed across the fan-out instead, a high-frequency rename leaks: a site one unit misses — or a whole rename a feature/view epic never thinks about (dozens of scattered alpha `sub` → `subscribe` sites, plus the M-71 signal-fn carve-out, all living in subs files split from the running view epic) — surfaces **late and all together** at the single all-or-nothing compile gate (§5), enlarging exactly the gate the partition exists to keep small. Run as a pre-pass, the fan-out starts from a tree already globally consistent on the mechanical axis, so the gate carries only the judgment-heavy residue, not a long tail of mechanical leftovers.
+
 Five parts, in the order you apply them.
 
 ## 1. One-file-one-owner — the collision-free partition

--- a/skills/re-frame-migration/references/sequencing.md
+++ b/skills/re-frame-migration/references/sequencing.md
@@ -47,6 +47,8 @@ Use the sweep order below for whatever the compile surfaces.
 
 The M-rule numbering in [`MIGRATION.md`](../../../migration/from-re-frame-v1/README.md) *is* the sweep order. Walk them low-to-high. Later rules sometimes depend on earlier ones being resolved (M-1 surfaces private-namespace requires; M-15's seeding rewrite assumes the M-1 fix has run; M-21's `on-changes` rewrite assumes the flows artefact M-30 has been added).
 
+**Large migrations front-load the mechanical globals as a pre-pass.** When the sweep is big enough to fan out, the dominantly-mechanical, high-frequency, context-independent global renames here (M-73, M-23, M-20, M-51) run first as one tree-wide commit, ahead of the file-partitioned fan-out, so they don't surface as scattered leftovers at the convergence gate — the per-rule order below is unchanged, only its *staging*. See [`orchestrating-a-large-migration.md` §Wave 0.5](orchestrating-a-large-migration.md#wave-05--the-mechanical-global-pre-pass).
+
 ### Group 1 — Coord and private namespaces (foundation)
 
 | Order | Rule | Why first |


### PR DESCRIPTION
## The gap

`orchestrating-a-large-migration.md` schedules the Phase-3 sweep as a purely **file-partitioned** fan-out (§1 one-file-one-owner; §4 wave sequencing by id-publication; §5 single all-or-nothing compile gate). It never recommends running the dominantly-mechanical, high-frequency, context-independent call-site renames as a single codebase-wide **pre-pass before** the fan-out.

The consequence: those renames get distributed across per-feature units, and any site a unit misses — or a whole high-frequency rename a feature/view epic never thinks about — surfaces **late and all together** at the single convergence gate, enlarging exactly the gate the partition exists to keep small. (Observed: dozens of scattered alpha `sub` → `subscribe` sites plus the signal-fn carve-out, all living in subs files split from the running view epic, surfacing together.)

## The distinction (does NOT contradict §1)

The methodology **correctly** rejects *concurrent* rule-family workers (§1: two rules co-habit `events.cljs`, so two rule-family workers collide there). A **sequential** mechanical pre-pass is a different shape: it commits **once**, and the file-partitioned fan-out rebases off it — exactly like the dep-coord swap / off-contract-require rewrite already do — so it never collides. The added phase states this explicitly so it reads as consistent with, not a rewrite of, §1.

## What the PR adds

- **A new "Wave 0.5 — the mechanical global pre-pass" phase** in `orchestrating-a-large-migration.md`, between the Phase-0a completeness gate and the §1–§5 fan-out machinery. It states the generic **selection criterion** (dominantly mechanical + high-frequency + context-independent global rename) so a reader can classify any rule, names the qualifiers, carves out the context-dependent halves, and notes the pre-pass **shrinks the convergence gate**. §1/§4/§5 are left intact.
- **A one-line pointer in `sequencing.md`** noting the large case front-loads the mechanical globals as a pre-pass (per-rule order unchanged, only its staging).

## Verified M-ids (each resolves to the right rule)

- **M-73** — `reg-event-db` / `reg-event-fx` → `reg-event` consolidation (the single most pervasive call-site rule, universal to every v1 app).
- **M-23** — alpha `sub` → `subscribe` (alpha-namespace apps).
- **M-20** — closed framework-keyword rename table → the single `:rf/*` root.
- **M-51** — unary → binary `reg-fx` handler arity bump.
- **M-71** — the signal-fn carve-out (a `sub` inside a `reg-sub` signal/input fn becomes a query vector, not `subscribe`).

(Note: the migration README carries two `### M-73.` headings — event-registration and machine-identity; the cite links target the event-registration anchor specifically.)

## Carve-out caveat

The pre-pass handles the mechanical bulk; the context-dependent halves stay flagged for the owning unit — **M-23's signal-fn carve-out → M-71**, and **M-73's non-mechanical half** (nil-capable / complex `reg-event-db` and every `reg-event-ctx`, which the codemod flags rather than rewrites). Both are cross-referenced to `auto-call-site-rewrites.md` / `guided-interceptors-subs.md`.

## Gates (all green)

- `check_doc_slugs.py` (self-test + live: no broken links)
- `check_skill_migration_cites.py` (self-test + live: all M-id cites resolve, incl. M-73/M-23/M-20/M-51/M-71)
- `check_skill_migration_contract_drift.py` (self-test + live: no M-11/M-13 drift)
- `check_readme_links.py` + `check_readme_inventories.py` (clean)
- skills manifest projection (`api-manifest.skills-check`: in sync)
- mkdocs is CI-only locally; `check_doc_slugs` is the proxy and passed.