### PR TITLE
docs(api): per-symbol usage audit — examples, real signatures, NOT-USED markers

### DIFF
--- a/docs/core/api/01-core.md
+++ b/docs/core/api/01-core.md
@@ -202,6 +202,11 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (clear-event id)
   ```
 - **Description**: "Forget this event-handler." No-arg clears the whole `:event` registry.
+- **Example**:
+  ```clojure
+  (rf/clear-event :counter/inc)   ;; forget one handler
+  (rf/clear-event)                ;; forget every registered :event
+  ```
 
 #### `clear-sub`
 
@@ -211,6 +216,11 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (clear-sub id)
   ```
 - **Description**: "Forget this sub." Note: this is the registrar-side clear (the inverse of `reg-sub`). The runtime cache decrement is `unsubscribe` (see below).
+- **Example**:
+  ```clojure
+  (rf/clear-sub :counter/value)   ;; forget one sub registration
+  (rf/clear-sub)                  ;; forget every registered :sub
+  ```
 
 #### `clear-fx`
 
@@ -220,6 +230,11 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (clear-fx id)
   ```
 - **Description**: "Forget this fx."
+- **Example**:
+  ```clojure
+  (rf/clear-fx :app/scroll-to-top)   ;; forget one fx
+  (rf/clear-fx)                      ;; forget every registered :fx
+  ```
 
 #### `destroy-frame!`
 
@@ -228,6 +243,14 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (destroy-frame! frame-id)
   ```
 - **Description**: The normative teardown boundary. Per-feature artefacts (flows, machines, schemas, SSR, epoch) hang their frame-scoped cleanup off this single call.
+- **Example**:
+  ```clojure
+  ;; SSR per-request frame — torn down in a finally, success or exception.
+  (try
+    (render-request fid)
+    (finally
+      (rf/destroy-frame! fid)))
+  ```
 
 #### `reset-frame!`
 
@@ -236,6 +259,12 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (reset-frame! frame-id)
   ```
 - **Description**: Atomic `destroy-frame!` + `reg-frame` with the **same config** — a full frame replace (opt-in). It tears the frame down through the normative `destroy-frame!` boundary (running `:on-destroy`, releasing per-feature resources) and re-registers it fresh, so machine snapshots, the route slice, flows, and `app-db` are all rebuilt from the registered config. Use sparingly. To wipe just the `app-db` partition while keeping live runtime-db (machines / routes / SSR survive), reach for `reset-app-db!` ([11 — Instrumentation](11-instrumentation.md)) instead. There is **no** `:initial-db` config key to restore from — seeding `app-db` is itself an ordinary, traceable event, `[:rf/set-db {…}]` (see [Standard events](#standard-events) below).
+- **Example**:
+  ```clojure
+  ;; Full frame replace (destroy + re-reg with the SAME config).
+  ;; Must run OUTSIDE any handler cascade — e.g. a restart button's :on-click.
+  (rf/reset-frame! :app/main)
+  ```
 
 #### `clear-sub-cache!`
 
@@ -244,6 +273,11 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (clear-sub-cache! frame-id?)
   ```
 - **Description**: Force-clear the sub-cache for a frame (or all frames). Tests; rarely needed in app code.
+- **Example**:
+  ```clojure
+  (rf/clear-sub-cache! :app/main)   ;; evict one frame's cached subs
+  (rf/clear-sub-cache!)             ;; current frame (test / REPL teardown)
+  ```
 
 ### See also
 
@@ -281,6 +315,11 @@ These are the two verbs that drive the cascade. `dispatch` says "an event happen
   (dispatch* event opts)
   ```
 - **Description**: Fn variant of `dispatch`. Compose through `map` / `comp` / `partial`; skips call-site stamping.
+- **Example**:
+  ```clojure
+  ;; A plain fn value — pass it through a HoF where the dispatch macro can't sit.
+  (run! rf/dispatch* events)
+  ```
 
 ### `dispatch-sync`
 
@@ -306,6 +345,12 @@ These are the two verbs that drive the cascade. `dispatch` says "an event happen
   (dispatch-sync* event opts)
   ```
 - **Description**: Fn variant of `dispatch-sync`.
+- **Example**:
+  ```clojure
+  ;; Fn-form — drive a sequence of events synchronously from runner / test code.
+  (doseq [evec events]
+    (rf/dispatch-sync* evec {:frame :app/main}))
+  ```
 
 ### `subscribe`
 
@@ -331,6 +376,12 @@ These are the two verbs that drive the cascade. `dispatch` says "an event happen
   (subscribe-once query-v opts) → value
   ```
 - **Description**: One-shot read: subscribe, deref, immediately unsubscribe. Use in handler bodies, machine actions, REPL — anywhere you want the *current* value without the reactive plumbing. Not for views. Target a non-ambient frame via `{:frame …}`.
+- **Example**:
+  ```clojure
+  ;; One-shot read of the current value — no reactive handle retained.
+  (let [articles (rf/subscribe-once [:articles])]
+    (count articles))
+  ```
 
 ### `unsubscribe`
 
@@ -341,6 +392,13 @@ These are the two verbs that drive the cascade. `dispatch` says "an event happen
   (unsubscribe query-v opts) → nil
   ```
 - **Description**: Decrement the cache ref-count for a query. When the count hits zero, the entry is disposed **synchronously** — see [Subscriptions](../concepts/subscriptions.md). Most callers don't reach for this directly — Reagent / UIx / Helix adapters wire it on unmount. Target a non-ambient frame via `{:frame …}`.
+- **Example**:
+  ```clojure
+  ;; Manual ref-count pairing (tests / REPL) — balances an explicit subscribe.
+  (let [r (rf/subscribe [:counter/value])]
+    @r
+    (rf/unsubscribe [:counter/value]))
+  ```
 
 ### Reading a machine's snapshot
 

--- a/docs/core/api/02-views.md
+++ b/docs/core/api/02-views.md
@@ -99,6 +99,23 @@ This is the lane for **tools, dynamic hosts, and library code** — not applicat
     - **You don't want a Var.** Inside a `let` or a closure, or when the view is a one-off built from configuration data.
     - **You're writing a Form-3 component.** Reagent's `create-class` wraps a map of lifecycle methods around a render-fn; the call shape is `(rf/reg-view* :id (r/create-class {...}))`. This is the one app-facing reason to touch the starred form.
     - **You're consumer-side library code.** Libraries that ship registered views (a charting library, a table widget) often want to register without imposing a `def` on the consumer's namespace.
+- **Example**:
+  ```clojure
+  ;; Computed id — the id isn't a literal symbol at the call site
+  ;; (a plugin host or code-gen pipeline that holds the id in data).
+  (defn register-panel! [view-id render-fn]
+    (rf/reg-view* view-id render-fn))
+
+  ;; Form-3 — create-class isn't defn-shaped, so it registers through the
+  ;; starred form. Capture the frame at render so the lifecycle callbacks
+  ;; dispatch to the captured frame.
+  (rf/reg-view* :editor/page
+    (fn [_]
+      (let [{:keys [dispatch]} (rf/capture-frame)]
+        (r/create-class
+          {:component-did-mount (fn [_] (dispatch [:editor/mounted]))
+           :reagent-render      (fn [] [editor-form-view])}))))
+  ```
 - **Note**: The `*` follows Clojure's own `let` / `let*`, `fn` / `fn*` idiom — the un-starred form is the macro shorthand; the starred form is the underlying primitive. Inside a `reg-view*` body there's no auto-injected `dispatch` / `subscribe`; capture a `(rf/capture-frame)` at render and use its ops if the view needs frame-bound dispatch.
 
 ### `view`

--- a/docs/core/api/03-effects.md
+++ b/docs/core/api/03-effects.md
@@ -147,6 +147,14 @@ The runtime supports three ways to swap fx behaviour without touching the handle
   (with-fx-overrides {fx-id -> override, …} body+)
   ```
 - **Description**: "For the duration of this body, every `dispatch` / `dispatch-sync` merges this fx-overrides map into its envelope." Lexical scope; composes with `with-frame`.
+- **Example**:
+  ```clojure
+  ;; Swap the real managed-HTTP fx for a canned-failure stub for the test body —
+  ;; every dispatch inside inherits the override; it unwinds when the body exits.
+  (rf/with-fx-overrides {:rf.http/managed :auth.login/canned-failure}
+    (rf/dispatch-sync [:auth.login/submit {:email "x@y.z" :password "wrong"}])
+    (rf/dispatch-sync [:auth.login/submit {:email "x@y.z" :password "wrong"}]))
+  ```
 
 The three scopes compose with a clear precedence:
 

--- a/docs/core/api/05-flows.md
+++ b/docs/core/api/05-flows.md
@@ -34,6 +34,11 @@ This chapter spans `re-frame.core` (the `reg-flow` macro) and `re-frame.flows` (
   (clear-flow id opts)
   ```
 - **Description**: Deregister the flow from the named frame and `dissoc-in` its `:output-path` from that frame's `app-db` only. Sibling frames' state is preserved.
+- **Example**:
+  ```clojure
+  ;; Deregister :cart/subtotal; clears [:cart :subtotal] in this frame's app-db.
+  (flows/clear-flow :cart/subtotal)
+  ```
 
 ### A minimal flow
 
@@ -94,6 +99,14 @@ Sometimes you want to register or clear a flow from inside an event handler — 
 | `[:rf.fx/clear-flow id]` | flow id | v1 | Clear a registered flow at runtime via `:fx`. |
 
 The signature mirrors `reg-flow` / `clear-flow` exactly — same opts, same return semantics. Use whichever surface matches your call site.
+
+```clojure
+;; Clear a runtime-registered flow from inside a handler — e.g. disengaging a
+;; feature gate. The flow's :output-path is dissoc'd from this frame's app-db.
+(rf/reg-event :cart/remove-discount
+  (fn [_ _]
+    {:fx [[:rf.fx/clear-flow :cart/discount-rate]]}))
+```
 
 ### The one-event lag — the least-obvious thing about flows
 

--- a/docs/core/api/08-schemas.md
+++ b/docs/core/api/08-schemas.md
@@ -65,6 +65,15 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schemas {:frame frame-id})
   ```
 - **Description**: "Hand me every registered schema-at-path for this frame." Returns `{path schema}`. Tools and agents walk this to enumerate the app's schema surface.
+- **Example**:
+  ```clojure
+  ;; every registered schema-at-path for the default frame
+  (schemas/app-schemas)
+  ;; => {[:user] [:map [:id :uuid]]}
+
+  ;; scope the walk to one frame
+  (schemas/app-schemas {:frame :rf/default})
+  ```
 
 ### `app-schema-at`
 
@@ -75,6 +84,14 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schema-at path {:frame frame-id})
   ```
 - **Description**: "Schema for this exact path." Returns the schema value or `nil`.
+- **Example**:
+  ```clojure
+  (schemas/app-schema-at [:user])
+  ;; => [:map [:id :uuid]]
+
+  ;; frame-scoped lookup; nil when nothing is registered at the path
+  (schemas/app-schema-at [:articles] {:frame :tenant/a})
+  ```
 
 ### `app-schema-meta-at`
 
@@ -85,6 +102,13 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schema-meta-at path opts-or-frame-id)
   ```
 - **Description**: "Full registration-metadata map for this path." Returns `:path`, `:schema`, `:frame`, plus source-coords (`:ns` / `:line` / `:file`) and the rest of `:rf/registration-metadata`. Pair tools and 10x reach for this when they need the registration anchor for click-back-to-code. The lighter `app-schema-at` is the right call when only the schema value is needed.
+- **Example**:
+  ```clojure
+  ;; the registration anchor — schema value plus source coords for click-back
+  (schemas/app-schema-meta-at [:user])
+  ;; => {:path [:user] :schema [:map [:id :uuid]]
+  ;;     :frame :rf/default :ns "my.app.schema" :line 12 :file "..."}
+  ```
 
 ### `app-schemas-digest`
 
@@ -95,6 +119,13 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schemas-digest {:frame frame-id}) → string
   ```
 - **Description**: "Single hash over the frame's whole schema surface." Used by SSR hydration compatibility checks and by tools that want to know "has the schema corpus changed?" without diffing schema-by-schema.
+- **Example**:
+  ```clojure
+  ;; one stable hash over the whole frame's schema surface
+  (schemas/app-schemas-digest)
+
+  (schemas/app-schemas-digest {:frame :rf/default})
+  ```
 
 ### Validator-extension seams
 
@@ -108,6 +139,15 @@ The default validator ships Malli's `validate` / `explain` pair. These seams let
   (set-schema-validator! validate-fn)
   ```
 - **Description**: "Install the validator the framework uses at every dev-time schema-validation site." Swaps ONLY the validator; `nil` disables validation entirely. The default ships Malli's pair; this seam is for apps that want to swap to a different validator without forking the framework. To install the validator/explainer/printer together, use `set-schema-fns!`.
+- **Example**:
+  ```clojure
+  ;; install an app's own validator (same shape as malli.core/validate:
+  ;; (fn [schema value] truthy?))
+  (schemas/set-schema-validator! my-validate)
+
+  ;; nil disables dev-time validation entirely
+  (schemas/set-schema-validator! nil)
+  ```
 
 #### `set-schema-fns!`
 
@@ -117,6 +157,12 @@ The default validator ships Malli's `validate` / `explain` pair. These seams let
   (set-schema-fns! {:validate validate-fn :explain explain-fn :print print-fn})
   ```
 - **Description**: "Atomically install any subset of the validator / explainer / printer bundle from a single map." The honest bundle setter — named for what it sets, not just the validator. Each key is optional; an absent key leaves the existing registration in place, and a `nil` `:print` coerces to the default EDN canonicaliser. The one-call substitute-Malli boot pattern, so the three fns never drift mid-boot.
+- **Example**:
+  ```clojure
+  ;; install validator + explainer together (e.g. a clojure.spec or Zod port)
+  (schemas/set-schema-fns! {:validate my-validate
+                            :explain  my-explain})
+  ```
 
 #### `set-schema-explainer!`
 
@@ -126,6 +172,11 @@ The default validator ships Malli's `validate` / `explain` pair. These seams let
   (set-schema-explainer! explain-fn)
   ```
 - **Description**: "Install the explainer the framework uses to enrich `:rf.error/schema-validation-failure` traces' `:explain` key." Companion to `set-schema-validator!`.
+- **Example**:
+  ```clojure
+  ;; enrich :rf.error/schema-validation-failure traces with a custom explanation
+  (schemas/set-schema-explainer! my-explain)
+  ```
 
 #### `set-schema-printer!`
 
@@ -135,6 +186,11 @@ The default validator ships Malli's `validate` / `explain` pair. These seams let
   (set-schema-printer! print-fn)
   ```
 - **Description**: "Install the schema-print companion the digest pipeline hashes." `(fn [schema-value] canonical-string)`. Must be pure and deterministic across runtimes. `nil` falls back to the default EDN canonicaliser, so the digest is never undefined. Parallel to the validator / explainer setters: non-Malli ports register their own serialiser so cross-runtime digest comparison reflects their port's contract.
+- **Example**:
+  ```clojure
+  ;; a non-Malli port registers its own canonical schema serialiser
+  (schemas/set-schema-printer! (fn [schema] (pr-str schema)))
+  ```
 
 The three setters answer three different questions: validation correctness (`validator`), human-readable failure messages (`explainer`), and stable canonical printing for digest (`printer`). Most apps use the defaults; ports and apps swap them selectively.
 
@@ -165,6 +221,26 @@ Durable `app-db` data classification is **event-owned** — a `reg-event` handle
 - `:large` — classify the listed `app-db` paths as large (size-elided at the wire boundary).
 - `:clear-sensitive` — un-classify the listed paths' sensitive marking when their ownership ends.
 - `:clear-large` — un-classify the listed paths' large marking when their ownership ends.
+
+```clojure
+;; classify durable app-db paths from the same event that writes them
+(rf/reg-event :user/sign-in
+  (fn [{:keys [db]} [_ token]]
+    {:db        (assoc-in db [:user :token] token)
+     :sensitive [[:user :token]]}))      ;; redacted at the wire boundary
+
+(rf/reg-event :docs/load-csv
+  (fn [{:keys [db]} [_ rows]]
+    {:db    (assoc-in db [:docs :csv] rows)
+     :large [[:docs :csv]]}))            ;; size-elided at the wire boundary
+
+;; un-classify when each path's ownership ends
+(rf/reg-event :user/sign-out
+  (fn [{:keys [db]} _]
+    {:db              (update db :user dissoc :token)
+     :clear-sensitive [[:user :token]]
+     :clear-large     [[:docs :csv]]}))
+```
 
 Composition: sensitive-drop wins; full teaching in [Keep secrets out of traces](../how-to/keep-secrets-out-of-traces.md).
 

--- a/docs/core/api/10-testing.md
+++ b/docs/core/api/10-testing.md
@@ -29,6 +29,16 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   (dispatch-sequence events opts)
   ```
 - **Description**: "Run this list of events end-to-end against the current frame." `opts`: `:after-each (fn [db ev] ...)` for between-event assertions, `:frame` for non-default targets. Returns the final `app-db`.
+- **Example**:
+  ```clojure
+  ;; Run a list of events end-to-end; returns the final app-db.
+  (ts/dispatch-sequence [[:counter/inc] [:counter/inc] [:counter/dec]])
+
+  ;; :after-each observes committed state between events.
+  (let [seen (atom [])]
+    (ts/dispatch-sequence [[:counter/inc] [:counter/inc]]
+                          {:after-each (fn [db ev] (swap! seen conj [(:n db) ev]))}))
+  ```
 
 ### `assert-path-equals`
 
@@ -49,6 +59,13 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   (assert-db-equals expected-db opts)
   ```
 - **Description**: Full-db sync assertion. Mismatch fires a `clojure.test/is`-style failure. Companion to `assert-path-equals`; reach for it when the whole-db identity matters.
+- **Example**:
+  ```clojure
+  (rf/dispatch-sync [:counter/init])
+  (ts/assert-db-equals {:n 0})
+  ;; against a non-default frame:
+  (ts/assert-db-equals {:n 4} {:frame :checkout})
+  ```
 
 ### `poll-until`
 
@@ -59,6 +76,16 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   (poll-until pred opts)
   ```
 - **Description**: Bounded-deadline poll. JVM: synchronous — returns the truthy value, throws `ex-info` carrying `:rf.error/id` `:rf.error/poll-until-timeout` (the canonical discriminator) on timeout. CLJS: returns a `js/Promise` resolving with the truthy value or rejecting on timeout. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
+- **Example**:
+  ```clojure
+  ;; JVM — synchronous; returns the truthy value (throws on timeout).
+  (ts/poll-until #(= 2 (:n (rf/app-db-value :rf/default)))
+                 {:label "counter reached 2"})
+
+  ;; CLJS — returns a js/Promise; compose with cljs.test/async.
+  (-> (ts/poll-until #(= 3 (:n (rf/app-db-value :rf/default))))
+      (.then (fn [_] (done))))
+  ```
 
 ### `with-fx-overrides`
 
@@ -72,6 +99,11 @@ Defined in [03 — Effects and interceptors](03-effects.md#with-fx-overrides) �
   (compute-sub query-v db)
   ```
 - **Description**: Pure sub computation against an `app-db` *value*. No cache, no reactivity — just walk the sub graph and return the value. JVM-runnable. Use in tests where you want "what would this sub return given this db?" without setting up frames.
+- **Example**:
+  ```clojure
+  ;; What would this sub compute for this db value? No frame, no cache.
+  (rf/compute-sub [:login/state] db)
+  ```
 
 ### Snapshot the registrar; restore after
 
@@ -79,23 +111,53 @@ These are the fixture primitives. The pattern is "snapshot the registrar before 
 
 #### `snapshot-registrar`
 
-- **Signature**: per docstring
+- **Signature**:
+  ```clojure
+  (snapshot-registrar) → snapshot
+  ```
 - **Description**: Capture the current registrar state.
+- **Example**:
+  ```clojure
+  ;; Capture before a test mutates registrations; roll back on the way out.
+  (let [snap (ts/snapshot-registrar)]
+    ;; ... test body registers extra handlers / subs ...
+    (ts/restore-registrar! snap))
+  ```
 
 #### `restore-registrar!`
 
-- **Signature**: per docstring
+- **Signature**:
+  ```clojure
+  (restore-registrar! snapshot) → nil
+  ```
 - **Description**: Restore a previously captured registrar state.
+- **Example**:
+  ```clojure
+  ;; `snap` was captured earlier via `snapshot-registrar`.
+  (ts/restore-registrar! snap)
+  ```
 
 #### `with-fresh-registrar`
 
-- **Signature**: per docstring
+- **Signature**:
+  ```clojure
+  (with-fresh-registrar body-fn) → any
+  ```
 - **Description**: The composed macro — snapshot + body + restore. Most tests reach for this rather than the lower-level primitives.
 
 #### `make-reset-runtime-fixture`
 
-- **Signature**: per docstring
+- **Signature**:
+  ```clojure
+  (make-reset-runtime-fixture)
+  (make-reset-runtime-fixture opts) → fixture-fn
+  ```
 - **Description**: Build a `clojure.test` fixture that resets the runtime between tests. Pair with `use-fixtures :each`.
+- **Example**:
+  ```clojure
+  (use-fixtures :each
+    (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  ```
 
 ### A typical test
 
@@ -130,6 +192,11 @@ The view-assertion surface treats a view as what it is — a function that retur
   (attrs node) → map
   ```
 - **Description**: Return the attrs map of a hiccup node, or `nil`.
+- **Example**:
+  ```clojure
+  (th/attrs [:div {:k 1} "child"])   ; => {:k 1}
+  (th/attrs [:div "child"])          ; => nil
+  ```
 
 ### `children`
 
@@ -139,6 +206,11 @@ The view-assertion surface treats a view as what it is — a function that retur
   (children node) → vector
   ```
 - **Description**: Return everything after the tag (and optional attrs map).
+- **Example**:
+  ```clojure
+  (th/children [:div {:k 1} "a" "b"])  ; => ["a" "b"]
+  (th/children [:div "a" "b"])         ; => ["a" "b"]
+  ```
 
 ### `text-content`
 
@@ -166,6 +238,12 @@ The view-assertion surface treats a view as what it is — a function that retur
   (find-by-attr tree attr val) → node
   ```
 - **Description**: First hiccup node whose attrs map carries `attr == val`, or `nil`. Generic over the attribute keyword — `:data-testid`, `:id`, `:data-test`, custom.
+- **Example**:
+  ```clojure
+  ;; Generic over the attribute keyword.
+  (th/find-by-attr tree :data-test "submit")
+  (th/find-by-attr tree :id        "login")
+  ```
 
 ### `find-all-by-attr`
 
@@ -175,6 +253,10 @@ The view-assertion surface treats a view as what it is — a function that retur
   (find-all-by-attr tree attr val) → vector
   ```
 - **Description**: Every matching node, in depth-first order.
+- **Example**:
+  ```clojure
+  (th/find-all-by-attr tree :data-test "row")  ; => every matching node
+  ```
 
 ### `find-by-attr-prefix`
 
@@ -184,6 +266,11 @@ The view-assertion surface treats a view as what it is — a function that retur
   (find-by-attr-prefix tree attr prefix) → vector
   ```
 - **Description**: Every node whose `attr` value (a string) STARTS with `prefix`. Non-string attr values do not match.
+- **Example**:
+  ```clojure
+  ;; Matches "row-1", "row-2", … — non-string attr values never match.
+  (th/find-by-attr-prefix tree :data-test "row-")
+  ```
 
 ### `find-by-testid`
 
@@ -202,6 +289,10 @@ The view-assertion surface treats a view as what it is — a function that retur
   (find-all-by-testid tree test-id) → vector
   ```
 - **Description**: Convenience over `find-all-by-attr` keyed on `:data-testid`.
+- **Example**:
+  ```clojure
+  (th/find-all-by-testid tree "cart-row")  ; => vector of every match
+  ```
 
 ### `find-by-testid-prefix`
 
@@ -211,6 +302,11 @@ The view-assertion surface treats a view as what it is — a function that retur
   (find-by-testid-prefix tree prefix) → vector
   ```
 - **Description**: Convenience over `find-by-attr-prefix` keyed on `:data-testid`.
+- **Example**:
+  ```clojure
+  ;; Matches "item-1", "item-2", …
+  (th/find-by-testid-prefix tree "item-")
+  ```
 
 ### `invoke-handler`
 
@@ -220,6 +316,11 @@ The view-assertion surface treats a view as what it is — a function that retur
   (invoke-handler node event-key & args) → any
   ```
 - **Description**: Find the handler under `event-key` on `node` and call it with `args`. Returns the handler's return value. **Throws** when the node has no attrs map or no handler is registered — the throwing failure mode is deliberate (a missing handler is almost always a test bug).
+- **Example**:
+  ```clojure
+  (let [btn (th/find-by-testid tree "counter-inc")]
+    (th/invoke-handler btn :on-click))   ; calls the attached :on-click
+  ```
 
 ### `testid`
 

--- a/docs/core/api/11-instrumentation.md
+++ b/docs/core/api/11-instrumentation.md
@@ -47,6 +47,7 @@ Record shape: `{:event :event-id :frame :time :outcome :elapsed-ms}`. The `:even
   (unregister-event-listener! id) → nil
   ```
 - **Description**: The inverse.
+- **Example**: `(rf/unregister-listener! :events :my-app.monitors/datadog)`
 
 ## Error-emit (always-on, production-survivable)
 
@@ -94,6 +95,7 @@ Listener bodies MUST branch on `(:error record)` (or otherwise tolerate a record
   (unregister-error-listener! id) → nil
   ```
 - **Description**: The inverse.
+- **Example**: `(rf/unregister-listener! :errors :my-app.monitors/sentry)`
 
 ## Tracing (dev-only)
 
@@ -108,6 +110,13 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```
 - **Description**: "Receive every trace event the runtime emits." Synchronous delivery; the callback returns before the next trace event is processed.
 
+```clojure
+;; Dev-only: tap every trace event the runtime emits (DCE'd in production).
+(rf/register-listener! :trace :my-app/trace-tap
+  (fn [trace-event]
+    (js/console.log (:op-type trace-event) (:operation trace-event))))
+```
+
 ### `unregister-listener!`
 
 - **Kind**: function
@@ -116,6 +125,7 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   (unregister-listener! key) → nil
   ```
 - **Description**: The inverse.
+- **Example**: `(rf/unregister-listener! :trace :my-app/trace-tap)`
 
 ### `emit-trace-event!`
 
@@ -126,15 +136,32 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```
 - **Description**: "Emit a custom trace event." Use sparingly — the framework emits the load-bearing events; custom emission is for app-specific cross-cutting concerns the framework can't know about.
 
+```clojure
+;; App-specific cross-cutting emission: op-type, operation, tags.
+(rf/emit-trace-event! :event :rf.probe/touched {:source :probe})
+```
+
 ### `re-frame.interop/debug-enabled?`
 
 - **Kind**: Var (`^boolean`)
 - **Description**: **CLJS:** alias of `goog.DEBUG` — constant-folded by Closure under `:advanced`, so `:advanced` + `goog.DEBUG=false` builds DCE every `(when interop/debug-enabled? ...)` branch. **JVM:** a `def` read ONCE at ns-load from the Java system property `-Dre-frame.debug` (winning on conflict) or the environment variable `RE_FRAME_DEBUG`; defaults `true` (dev parity). Accepts the conventional false-y vocabulary case-insensitively (`false`, `0`, `no`, `off`, empty string) with whitespace trimmed; anything else leaves the flag at `true`. SSR / webhook receivers / long-running JVMs facing untrusted input MUST set the gate `false` explicitly.
 
+```clojure
+;; Dev-only diagnostic — the whole branch DCEs under :advanced + goog.DEBUG=false.
+(when re-frame.interop/debug-enabled?
+  (js/console.warn "machine transition rejected"))
+```
+
 ### `re-frame.performance/enabled?`
 
 - **Kind**: Var (`^boolean`)
 - **Description**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}` to bracket event dispatch / sub recompute / fx walk / view render in `performance.mark` + `performance.measure` calls (User-Timing entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`). **Compile-time only** — not a `(rf/configure! ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` + default the bracket DCEs and shipped binaries carry zero User-Timing instrumentation. CLJS-only — JVM is a no-op.
+
+```clojure
+;; Compile-time gate — the User-Timing bracket DCEs unless flipped on.
+(when re-frame.performance/enabled?
+  (js/performance.mark "rf:event:start"))
+```
 
 ### `trace-buffer`
 
@@ -146,6 +173,13 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```
 - **Description**: "What's in the ring right now?" Reads the buffer non-destructively. Pair tools and Xray use this for post-mortem inspection.
 
+```clojure
+;; Post-mortem: read a frame's cascade-keyed ring (oldest-first).
+(rf/trace-buffer :app/main)
+;; `{:flat true}` returns raw trace events instead of cascade bundles.
+(rf/trace-buffer :app/main {:flat true})
+```
+
 ### `clear-trace-buffer!`
 
 - **Kind**: function
@@ -154,6 +188,11 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   (clear-trace-buffer!) → nil
   ```
 - **Description**: Empty the ring.
+
+```clojure
+;; Empty one frame's ring (e.g. between tool sessions).
+(rf/clear-trace-buffer! :app/main)
+```
 
 ### `(rf/configure! {:trace-buffer …})`
 
@@ -173,6 +212,11 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```
 - **Description**: Pure data projection of a list of trace events into per-cascade records `{:dispatch-id :event :handler :fx :effects :subs :renders :other}`, sorted by emission order. JVM-runnable. Re-exported from `re-frame.trace.projection`.
 
+```clojure
+;; Project a flat trace-event list into per-cascade records.
+(rf/group-cascades (rf/trace-buffer :app/main {:flat true}))
+```
+
 ### `domino-bucket`
 
 - **Kind**: function
@@ -181,6 +225,11 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   (domino-bucket trace-event) → #{:event :handler :fx :effect :sub :render :other}
   ```
 - **Description**: Classify a raw trace event into the six-domino slot used by `group-cascades`. Pure.
+
+```clojure
+;; Classify a raw trace event into its domino slot.
+(rf/domino-bucket {:op-type :rf.view :operation :rf.view/render})  ;; => :render
+```
 
 ### Trace-emission opt-out
 
@@ -191,6 +240,14 @@ Event-handler registration accepts a `:rf.trace/no-emit? true` metadata flag. Wh
 | `:rf.trace/no-emit?` | `reg-event` metadata map | boolean | `false` | When `true`, suppresses all trace + event-emit emissions inside the handler's scope. |
 
 Used by framework-internal bookkeeping handlers (Xray, Story, re-frame2-pair-mcp, story-mcp) that would otherwise saturate the trace stream. The `:rf.trace/*` namespace is framework-owned.
+
+```clojure
+;; A high-frequency handler that would otherwise flood the trace stream.
+(rf/reg-event :my-app/pointer-moved
+  {:rf.trace/no-emit? true}
+  (fn [{:keys [db]} [_ x y]]
+    {:db (assoc db :pointer [x y])}))
+```
 
 ## Epoch history (Tool-Pair)
 
@@ -205,6 +262,12 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```
 - **Description**: Returns `[]` for an unknown / destroyed frame.
 
+```clojure
+;; All recorded epochs for a frame, oldest-first; peek the latest.
+(rf/epoch-history :app/main)
+(last (rf/epoch-history :app/main))
+```
+
 ### `restore-epoch!`
 
 - **Kind**: function
@@ -213,6 +276,12 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   (restore-epoch! frame-id epoch-id) → boolean
   ```
 - **Description**: Restore the frame's whole **frame-state** — both the app-db and runtime-db partitions — to the named epoch's `:frame-state-after`, reinstalled in one atomic write (so machine snapshots, the route slice, and other runtime-db material rewind alongside app-db, not just the application slice). Returns `true` on success; `false` for an unknown / destroyed frame (and emits `:rf.error/no-such-handler` of kind `:frame`).
+
+```clojure
+;; Time-travel: rewind a frame's whole frame-state to a recorded epoch.
+(let [target (last (rf/epoch-history :app/main))]
+  (rf/restore-epoch! :app/main (:epoch-id target)))
+```
 
 ### `replace-app-db!`
 
@@ -223,6 +292,11 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```
 - **Description**: Pair-tool write surface (state injection). Direct write to `app-db` — bypasses the cascade. Returns `true` on success.
 
+```clojure
+;; State injection — direct app-db write (bypasses the cascade).
+(rf/replace-app-db! :app/main {:counter 0})
+```
+
 ### `register-epoch-listener!`
 
 - **Kind**: function
@@ -232,6 +306,13 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```
 - **Description**: Process-global assembled-epoch listener. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace.
 
+```clojure
+;; Observe each assembled epoch as frames settle.
+(rf/register-epoch-listener! :my-app/epoch-watch
+  (fn [record]
+    (js/console.log (:frame record) (:epoch-id record))))
+```
+
 ### `unregister-epoch-listener!`
 
 - **Kind**: function
@@ -240,6 +321,7 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   (unregister-epoch-listener! key)
   ```
 - **Description**: The inverse.
+- **Example**: `(rf/unregister-epoch-listener! :my-app/epoch-watch)`
 
 ### `(rf/configure! {:epoch-history …})`
 
@@ -279,6 +361,13 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   (elide-wire-value v opts) → v or an elision-marker substitution
   ```
 - **Description**: Walk `v` consulting `[:rf.runtime/elision :sensitive-declarations]` and `[:rf.runtime/elision :declarations]` of the named frame's **runtime-db** — the per-frame registry written by the commit-plane classification effects. Redaction is strictly **path-based**: substitute `:rf/redacted` at each declared sensitive path and `:rf.size/large-elided` markers at each declared large path. There is **no value-match** arm — a secret re-keyed off its classified path is **not** chased by value; it ships raw, the **fail-open** default (to redact it, classify the destination path). When the frame carries no declarations the value passes through unchanged.
+
+```clojure
+;; Low-level value walker — markers substituted per the frame's classification.
+(rf/elide-wire-value slice {:frame :rf/default})
+;; Path-scoped: walk one query-vector's value against its declared paths.
+(rf/elide-wire-value query-map {:query-v [:rf.route/query] :frame :rf/default})
+```
 
 > **No value-match or schema-prop elision surfaces.** `redact-derived-slots`, `populate-elision-from-schemas!`, and `populate-sensitive-from-schemas!` are not on the facade or in `re-frame.elision`. Use the path-based surfaces: classify durable `app-db` paths with the commit-plane effects (a `reg-event` returning `:sensitive` / `:large` alongside `:db`), and project a derived tree (rendered hiccup, a resolved `:effective-args` map, a snapshot body) with **`project-egress`** under a `:rf.observe/derived-tree` record — it path-walks each tree slot through `elide-wire-value` against the frame's registry.
 
@@ -341,6 +430,7 @@ This is parallel to (and the production-normal home of) the advanced corpus-wide
   (unregister-observability-sink! sink-id) → nil
   ```
 - **Description**: Drop the observability sink registered under `sink-id`. Returns nil.
+- **Example**: `(rf/unregister-observability-sink! :my-app.sinks/datadog)`
 
 See [08 — Schemas §Data classification](08-schemas.md#data-classification) for the declaration side — durable `app-db` classification is event-owned (a `reg-event` returns the commit-plane `:sensitive` / `:large` effects alongside `:db`), and per-slot `:sensitive?` / `:large?` schema props own machine `:data` / resource / HTTP-body classification.
 
@@ -354,6 +444,12 @@ See [08 — Schemas §Data classification](08-schemas.md#data-classification) fo
   (sensitive? trace-event) → boolean
   ```
 - **Description**: True iff `trace-event` is a map carrying `:sensitive? true` at the top level (not under `:tags`). The framework-published predicate every consumer composes against — replaces per-consumer reimplementations of the same five-token check.
+
+```clojure
+(rf/sensitive? {:sensitive? true})   ;; => true
+;; Drop sensitive events when forwarding from a flat trace read.
+(remove rf/sensitive? (rf/trace-buffer :app/main {:flat true}))
+```
 
 ## DOM source-coord annotations
 

--- a/docs/core/api/12-registrar.md
+++ b/docs/core/api/12-registrar.md
@@ -24,6 +24,15 @@ The registrar-query surface lives in `re-frame.core`:
   ```
 - **Description**: **Use when you want metadata.** Walk the registrar with the full metadata map per id — source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. Optional `pred-fn` filters by the metadata map.
 
+```clojure
+;; the full {id metadata} map for a kind — source coords, :doc, :rf/sensitive, ...
+(rf/registrations :event)
+;; => {:counter/inc {:ns my-app.events :line 12 :file "my_app/events.cljs"} ...}
+
+;; frame-targeted (EP-0023): only the ids that frame's image carries
+(rf/registrations {:frame :tenants/acme :kind :sub})
+```
+
 ### `handler-ids`
 
 - **Kind**: function
@@ -33,6 +42,17 @@ The registrar-query surface lives in `re-frame.core`:
   ```
 - **Description**: **Use when you only need to enumerate.** Canonical alias for `(-> (registrations kind) keys set)`. Saves both the metadata-map allocations and the `keys` walk — meaningful at scale (completion lists, existence checks, set-shaped intersections).
 
+```clojure
+;; the id set under a kind (no metadata-map allocations)
+(rf/handler-ids :event)                            ;; => #{:counter/inc :counter/reset}
+
+;; existence check
+(contains? (rf/handler-ids :event) :counter/inc)   ;; => true
+
+;; frame-targeted: only the ids that frame's image carries
+(rf/handler-ids {:frame :blue/main :kind :event})  ;; => #{:counter/inc}
+```
+
 ### `handler-meta`
 
 - **Kind**: function
@@ -41,6 +61,16 @@ The registrar-query surface lives in `re-frame.core`:
   (handler-meta kind id) → registration-metadata map
   ```
 - **Description**: "What did `reg-*` stamp at this id?" View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`) per `:rf/source-coord-meta`; pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup.
+
+```clojure
+;; what reg-* stamped at this id — source coords (:ns / :line / :column / :file)
+(rf/handler-meta :sub :counter/value)
+;; => {:ns my-app.subs :line 8 :column 1 :file "my_app/subs.cljs"}
+
+;; a route guard reading the matched route's registered :tags
+(let [route-meta (rf/handler-meta :route id)]
+  (boolean (some #{:requires-auth} (:tags route-meta))))
+```
 
 `kind` is one of `:event`, `:sub`, `:fx`, `:cofx`, `:view`, `:flow`, `:route`, `:head`, `:error-projector`. App-db schemas are **not** a registrar kind; look them up via `(app-schema-meta-at path)` instead. The [registrar](../glossary.md#registrar) glossary entry covers the one-table-per-process model these kinds share.
 
@@ -60,6 +90,14 @@ Machine registrar queries (`machines`, `machine-meta`) live in `re-frame.machine
   ```
 - **Description**: "What frames exist?" The optional prefix filters by namespace — `(rf/frame-ids :rf.story/)` for tool-owned frames.
 
+```clojure
+;; all live (non-destroyed) frame ids — a set
+(rf/frame-ids)              ;; => #{:rf/default :tenants/acme :tenants/globex}
+
+;; filter by namespace prefix (a string): ids whose namespace starts with it
+(rf/frame-ids "tenants")   ;; => #{:tenants/acme :tenants/globex}
+```
+
 ### `frame-meta`
 
 - **Kind**: function
@@ -68,6 +106,15 @@ Machine registrar queries (`machines`, `machine-meta`) live in `re-frame.machine
   (frame-meta frame-id)
   ```
 - **Description**: "What did `reg-frame` / `make-frame` stamp at this frame?" Returns the metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings.
+
+```clojure
+;; the effective (post-preset-expansion) metadata for a frame
+(rf/frame-meta :tenants/acme)
+;; => {:id :tenants/acme :doc "..." :fx-overrides {...} :ssr {...}}
+
+;; read one stamped slot
+(:fx-overrides (rf/frame-meta :tenants/acme))
+```
 
 ### `app-db-value`
 
@@ -78,6 +125,15 @@ Machine registrar queries (`machines`, `machine-meta`) live in `re-frame.machine
   ```
 - **Description**: "What's the current `app-db` value for this frame?" Returns the deref'd `app-db` map (a plain value, not the container) — `nil` for an unknown / destroyed frame. The internal container accessor is `re-frame.frame/app-db-container`; app and tool code want the value, so reach for `app-db-value`.
 
+```clojure
+;; the deref'd app-db value (plain map; nil for an unknown / destroyed frame)
+(rf/app-db-value :rf/default)
+;; => {:user {:id 7} :counts {:hits 3}}
+
+;; SSR: read the settled app-db for the request frame
+(rf/app-db-value request-frame)
+```
+
 ### `snapshot-of`
 
 - **Kind**: function
@@ -87,6 +143,15 @@ Machine registrar queries (`machines`, `machine-meta`) live in `re-frame.machine
   (snapshot-of path opts)
   ```
 - **Description**: "What's at this path in `app-db` right now?" Convenience over `app-db-value` + `get-in`.
+
+```clojure
+;; value at a path in the active frame's app-db
+(rf/snapshot-of [:user :id])          ;; => 7
+(rf/snapshot-of [:counts])            ;; => {:hits 3}
+
+;; target a specific frame via opts
+(rf/snapshot-of [:n] {:frame :left})  ;; => 11
+```
 
 ## Sub graph
 
@@ -99,6 +164,19 @@ Machine registrar queries (`machines`, `machine-meta`) live in `re-frame.machine
   ```
 - **Description**: Static dependency graph from `:<-` declarations. Pure data over the registrar; `:inputs` always present (empty for layer-1 subs); the per-entry `:doc` / `:ns` / `:line` / `:file` keys are present when registration carries them.
 
+```clojure
+;; static dependency graph over the registrar (JVM-runnable). Lives in
+;; re-frame.subs.tooling — the rf core facade alias was removed.
+(require '[re-frame.subs.tooling :as subs-tooling])
+
+(subs-tooling/sub-topology)
+;; => {:n   {:input-kind :db     :inputs []}
+;;     :sum {:input-kind :static :inputs [[:a] [:b]]}}
+
+;; a parametric (input-fn) sub reports the :parametric sentinel
+(:inputs ((subs-tooling/sub-topology) :article/page))   ;; => :parametric
+```
+
 ### `sub-cache`
 
 - **Kind**: function
@@ -107,6 +185,19 @@ Machine registrar queries (`machines`, `machine-meta`) live in `re-frame.machine
   (sub-cache frame-id) → live cache state
   ```
 - **Description**: The runtime cache. CLJS-only because it holds live `Reaction` objects; on JVM there are no reactions to hold. Tools that walk the cache for tab labels / counts in Xray go through this.
+
+```clojure
+;; the runtime cache snapshot — CLJS-only (nil on the JVM). Lives in
+;; re-frame.subs.tooling as sub-cache-snapshot — the rf core facade alias
+;; was removed.
+(require '[re-frame.subs.tooling :as subs-tooling])
+
+(subs-tooling/sub-cache-snapshot :rf/default)
+;; => {[:n]     {:value 7     :ref-count 2 :input-kind :db :realized-inputs []}
+;;     [:name*] {:value "ada" :ref-count 1 :input-kind :db :realized-inputs []}}
+
+(subs-tooling/sub-cache-snapshot :no-such-frame)   ;; => nil
+```
 
 The split — `sub-topology` JVM-runnable, `sub-cache` CLJS-only — is principled. Topology is a static property of the registration; the cache is a runtime property of the sub graph. Tools that want the design-time picture (linter, doc generator, conformance harness) reach for `sub-topology`; tools that want the runtime picture (Xray's sub-cache tab) reach for `sub-cache`.
 

--- a/docs/core/api/13-lifecycle.md
+++ b/docs/core/api/13-lifecycle.md
@@ -68,6 +68,12 @@ Everything below is the **adapter-author lane**. An ordinary app never calls the
   (install-adapter! adapter-map)
   ```
 - **Description**: Must be called before any frame is created. **Lower-level than `init!`**; ordinary apps call `init!` instead. Use it when you're writing a custom boot pipeline that has additional steps between adapter-install and first-frame creation.
+- **Example**:
+  ```clojure
+  (rf/install-adapter! reagent/adapter)   ;; seat the substrate (lower-level than init!)
+  ;; …custom boot steps between adapter-install and first-frame creation…
+  (rf/reg-frame :app/main {:initial-events [[:app/boot]]})
+  ```
 
 ### `destroy-adapter!`
 
@@ -77,6 +83,11 @@ Everything below is the **adapter-author lane**. An ordinary app never calls the
   (destroy-adapter!)
   ```
 - **Description**: Tear down the installed adapter. Calls the adapter spec's `:dispose-adapter!` fn (if present), clears the install slot so a new adapter can install, and flips the `adapter-disposed?` breadcrumb. Symmetric with `install-adapter!` and with `destroy-frame!` — same `destroy-` verb-cluster (lifecycle boundary).
+- **Example**:
+  ```clojure
+  (rf/destroy-adapter!)        ;; tear down the current substrate, clear the install slot
+  (rf/init! reagent/adapter)   ;; …then install a fresh adapter (e.g. a test fixture or hot-reload swap)
+  ```
 
 The adapter-spec **map key** `:dispose-adapter!` is an internal contract slot adapters implement; ignore it unless you're authoring an adapter.
 
@@ -104,6 +115,10 @@ These reads answer "what's installed right now?" — for tooling and adapter-aut
   (current-adapter) → discriminator keyword
   ```
 - **Description**: "What substrate am I on?" Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/helix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. For predicate / branch code.
+- **Example**:
+  ```clojure
+  (rf/current-adapter)   ;; => :rf.adapter/reagent   (nil when no adapter is installed)
+  ```
 
 #### `current-adapter-spec`
 
@@ -113,6 +128,10 @@ These reads answer "what's installed right now?" — for tooling and adapter-aut
   (current-adapter-spec) → installed adapter spec map
   ```
 - **Description**: "Give me the adapter fns to call." The value passed to `(rf/init! ...)`, or `nil` when no adapter is installed. Use for tools / routing / identity checks across the install / dispose lifecycle. For the discriminator keyword, use `current-adapter`.
+- **Example**:
+  ```clojure
+  (rf/current-adapter-spec)   ;; => the adapter spec map passed to (rf/init! …), or nil when none
+  ```
 
 #### `adapter-disposed?`
 
@@ -122,6 +141,14 @@ These reads answer "what's installed right now?" — for tooling and adapter-aut
   (adapter-disposed?) → boolean
   ```
 - **Description**: "Was the adapter torn down?" Returns `true` iff the most recent lifecycle event was a successful `destroy-adapter!` and no subsequent `install-adapter!` has fired. `false` for never-installed (fresh process) AND after a fresh install. Read-only — the breadcrumb is owned by the install / destroy pair. Use to distinguish `:rf.error/no-adapter-installed` (fresh process) from `:rf.error/adapter-disposed` (torn down).
+- **Example**:
+  ```clojure
+  (rf/adapter-disposed?)       ;; => false  (fresh process — never installed)
+  (rf/destroy-adapter!)
+  (rf/adapter-disposed?)       ;; => true   (torn down, no reinstall yet)
+  (rf/init! reagent/adapter)
+  (rf/adapter-disposed?)       ;; => false  (a fresh install clears the breadcrumb)
+  ```
 
 The split between `current-adapter` (keyword) and `current-adapter-spec` (map) is principled. The keyword is for switch-like code that branches on substrate identity. The spec map is for code that needs to call adapter fns or compare adapter identity across reinstalls.
 
@@ -145,9 +172,15 @@ Back in the app-author lane: the `configure` fn is application boot's adjacent s
 - **Kind**: function
 - **Signature**:
   ```clojure
-  (configure key opts)
+  (configure! config-map)
   ```
 - **Description**: Runtime config. One of three orthogonal configuration surfaces — `configure` for process-level data knobs; `set-!` / `install-!` for adapter-pluggable hooks; per-frame metadata for frame-scoped overrides. The vocabulary of keys lives in [01 — Core §Configure keys](01-core.md#runtime-configuration-configure).
+- **Example**:
+  ```clojure
+  (rf/configure! {:epoch-history {:depth 100}
+                  :trace-buffer  {:cascades-retained 25}
+                  :elision       {:rf.size/threshold-bytes 8192}})
+  ```
 
 The three configuration surfaces — `configure`, the `set-!` / `install-!` setters (`set-schema-validator!`, etc.), and per-frame metadata — are separate. Each answers a different question: `configure` for data knobs (depth, threshold, grace period); the setters for hook-shaped pluggability (which validator to use, which printer); per-frame metadata for frame-scoped overrides (which projector, which `:fx-overrides`).
 

--- a/docs/core/api/14-adapters.md
+++ b/docs/core/api/14-adapters.md
@@ -72,6 +72,8 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   ```
 - **Description**: "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks.
 
+> **NOT USED** — no call sites found in `implementation/`, `examples/`, or `tools/`.
+
 ### `uix-adapter/frame-provider`
 
 - **Kind**: UIx component (function — one component, two config shapes)
@@ -81,6 +83,13 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   ($ uix-adapter/frame-provider {:id :session :images [session-image]} child…)   ;; ENSURE create-if-absent / reuse
   ```
 - **Description**: The UIx-shaped merged frame provider, dispatched on the prop map: `{:frame …}` scopes an already-created frame (fails loud if absent), `{:id …}` ensures a named frame (create-if-absent / reuse-no-reseed, `make-frame` opts, no destroy-on-unmount). Children ride the idiomatic `$` trailing-args channel — pass them after the prop map, exactly as for any other UIx component (no `:children` prop-map key).
+- **Example**:
+  ```clojure
+  ;; ENSURE shape at the render root: create the frame on first mount, seed it
+  ;; once via :initial-events, reuse (no re-seed) on hot-reload re-mount.
+  ($ uix-adapter/frame-provider {:id :app :initial-events [[:counter/initialise]]}
+     ($ counter-app))
+  ```
 
 ### `uix-adapter/wrap-view`
 
@@ -90,6 +99,14 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   (wrap-view id metadata user-fn) → wrapped fn
   ```
 - **Description**: Adapter-side source-coord injection. Most users register through `reg-view*`; `wrap-view` is for code-gen and library scaffolding.
+- **Example**:
+  ```clojure
+  ;; Code-gen / scaffolding seam: wrap a component head so its root DOM element
+  ;; carries data-rf2-source-coord (dev only; elided in production builds).
+  (def wrapped-row
+    (uix-adapter/wrap-view ::row {:line 42 :column 7}
+                           (fn [_props] ($ :div "row"))))
+  ```
 
 ### `uix-adapter/flush-views!`
 
@@ -100,6 +117,12 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   (flush-views! f)
   ```
 - **Description**: Wraps React's `act()` for tests.
+- **Example**:
+  ```clojure
+  ;; Test-only: flush pending renders synchronously, returns nil.
+  (uix-adapter/flush-views!)               ;; 0-arity: drain queued renders + effects
+  (uix-adapter/flush-views! (fn [] nil))   ;; 1-arity: run the thunk inside act()
+  ```
 
 ### `uix-adapter/set-hiccup-emitter!`
 
@@ -109,6 +132,13 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   (set-hiccup-emitter! f)
   ```
 - **Description**: Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR.
+- **Example**:
+  ```clojure
+  ;; SSR: install a render-tree → HTML emitter (normally wired for you by
+  ;; requiring re-frame.ssr). Pass nil to reset.
+  (uix-adapter/set-hiccup-emitter! (fn [tree _opts] (str tree)))
+  (uix-adapter/set-hiccup-emitter! nil)
+  ```
 
 UIx users register their views by Var (the React-component idiom) or with `rf/reg-view*` if they want registry-keyed view addressing — `reg-view` (the Reagent macro) does **not** cover UIx.
 
@@ -162,6 +192,8 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   ```
 - **Description**: "What frame am I in?"
 
+> **NOT USED** — no call sites found in `implementation/`, `examples/`, or `tools/`.
+
 ### `helix-adapter/frame-provider`
 
 - **Kind**: Helix component (function — one component, two config shapes)
@@ -171,6 +203,13 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   ($ helix-adapter/frame-provider {:id :session :images [session-image]} child…)   ;; ENSURE create-if-absent / reuse
   ```
 - **Description**: The Helix-shaped merged frame provider, dispatched on the prop map: `{:frame …}` scopes an already-created frame (fails loud if absent), `{:id …}` ensures a named frame (create-if-absent / reuse-no-reseed, `make-frame` opts, no destroy-on-unmount). Children ride the idiomatic `$` trailing-args channel — pass them after the prop map, exactly as for any other Helix component (no `:children` prop-map key).
+- **Example**:
+  ```clojure
+  ;; ENSURE shape at the render root: create the frame on first mount, seed it
+  ;; once via :initial-events, reuse (no re-seed) on hot-reload re-mount.
+  ($ helix-adapter/frame-provider {:id :app :initial-events [[:counter/initialise]]}
+     ($ counter-app))
+  ```
 
 ### `helix-adapter/wrap-view`
 
@@ -180,6 +219,14 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   (wrap-view id metadata user-fn) → wrapped fn
   ```
 - **Description**: Adapter-side source-coord injection.
+- **Example**:
+  ```clojure
+  ;; Code-gen / scaffolding seam: wrap a component head so its root DOM element
+  ;; carries data-rf2-source-coord (dev only; elided in production builds).
+  (def wrapped-row
+    (helix-adapter/wrap-view ::row {:line 42 :column 7}
+                             (fn [_props] (d/div "row"))))
+  ```
 
 ### `helix-adapter/flush-views!`
 
@@ -190,6 +237,12 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   (flush-views! f)
   ```
 - **Description**: Wraps React's `act()` for tests.
+- **Example**:
+  ```clojure
+  ;; Test-only: flush pending renders synchronously, returns nil.
+  (helix-adapter/flush-views!)               ;; 0-arity: drain queued renders + effects
+  (helix-adapter/flush-views! (fn [] nil))   ;; 1-arity: run the thunk inside act()
+  ```
 
 ### `helix-adapter/set-hiccup-emitter!`
 
@@ -199,6 +252,13 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   (set-hiccup-emitter! f)
   ```
 - **Description**: Install a render-tree → HTML fn. Parity with the Reagent and UIx adapters' late-bind seam.
+- **Example**:
+  ```clojure
+  ;; SSR: install a render-tree → HTML emitter (normally wired for you by
+  ;; requiring re-frame.ssr). Pass nil to reset.
+  (helix-adapter/set-hiccup-emitter! (fn [tree _opts] (str tree)))
+  (helix-adapter/set-hiccup-emitter! nil)
+  ```
 
 ```clojure
 (:require [re-frame.core :as rf]

--- a/docs/machines/api.md
+++ b/docs/machines/api.md
@@ -37,6 +37,14 @@ This chapter spans `re-frame.core` (the `reg-machine` / `defmachine` macros) and
   (re-frame.machines/reg-machine* machine-id machine-spec)
   ```
 - **Description**: Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data.
+- **Example**:
+  ```clojure
+  ;; Same effect as the macro, minus the source-coord walking.
+  (machines/reg-machine* :traffic-light
+    {:initial :red
+     :states  {:red   {:on {:go {:target :green}}}
+               :green {:on {:go {:target :red}}}}})
+  ```
 
 ### `re-frame.machines/make-machine-handler`
 
@@ -46,6 +54,15 @@ This chapter spans `re-frame.core` (the `reg-machine` / `defmachine` macros) and
   (re-frame.machines/make-machine-handler spec) → event-handler fn
   ```
 - **Description**: Compiles a transition table into the event-handler fn that `reg-machine` would register. Useful when you want to inspect the compiled fn or compose it manually.
+- **Example**:
+  ```clojure
+  ;; Build the handler fn without registering it (e.g. to inspect or compose it).
+  (def handler
+    (machines/make-machine-handler
+      {:initial :idle
+       :states  {:idle    {:on {:start {:target :running}}}
+                 :running {}}}))
+  ```
 
 ### `re-frame.machines/machine-transition`
 
@@ -125,6 +142,12 @@ The canonical machine read is the framework-registered subscription vector `[:rf
   (re-frame.machines/machines) → seq of machine-ids
   ```
 - **Description**: "What machines have been registered?" Derived view over `(registrations :event)` filtered by `:rf/machine? true`.
+- **Example**:
+  ```clojure
+  ;; Every registered machine-id (the registry, not a frame's live snapshots).
+  (machines/machines)                              ;; → (:session :auth.login/flow …)
+  (contains? (set (machines/machines)) :session)
+  ```
 
 ### `re-frame.machines/machine-meta`
 
@@ -134,6 +157,13 @@ The canonical machine read is the framework-registered subscription vector `[:rf
   (re-frame.machines/machine-meta machine-id) → registration-metadata map
   ```
 - **Description**: "What did `reg-machine` stamp at this machine's id?" Returns the transition table, doc, schemas, and the per-element source-coords. Equivalent to `(handler-meta :event machine-id)`.
+- **Example**:
+  ```clojure
+  ;; The registered spec back out — table, doc, schemas, source-coords.
+  (machines/machine-meta :session)
+  ;; …or read just the declared :data schema:
+  (get-in (machines/machine-meta :session) [:schemas :data])
+  ```
 
 ### `re-frame.machines/machine-by-system-id`
 
@@ -144,6 +174,12 @@ The canonical machine read is the framework-registered subscription vector `[:rf
   (re-frame.machines/machine-by-system-id system-id frame-id)
   ```
 - **Description**: Reverse-lookup: given a `system-id`, what's the spawned machine bound to it? Returns the spawned-machine id or `nil`.
+- **Example**:
+  ```clojure
+  ;; Resolve a :system-id-bound actor, then address it directly.
+  (when-let [actor (machines/machine-by-system-id :notifier)]
+    (rf/dispatch [actor [:notify "hello"]]))
+  ```
 
 ### `machine-has-tag?`
 
@@ -153,6 +189,12 @@ The canonical machine read is the framework-registered subscription vector `[:rf
   (machine-has-tag? machine-id tag) → reaction
   ```
 - **Description**: Sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])`. Reactive predicate over the machine's snapshot's `:tags` set. Use in views to render conditionally on state-tag membership.
+- **Example**:
+  ```clojure
+  ;; Ask by state-tag, not exact state name — disable inputs while a request is in flight.
+  (let [busy? @(rf/machine-has-tag? :auth.login/flow :auth/busy)]
+    [:button {:disabled busy?} "Sign in"])
+  ```
 
 ### Standard registered subs (machines)
 
@@ -185,6 +227,11 @@ When a child actor spawns under a parent, the parent's `:data` often gets the ch
   (re-frame.machines/dispatch-to-system system-id event frame-id)
   ```
 - **Description**: The direct-call twin of the fx above — sugar over `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`, no-op when the `system-id` is unbound. The two-arity form resolves the frame from the carried scope it runs under; the three-arity form names the frame explicitly — there is no `:rf/default` fallback, and looking up under no scope raises `:rf.error/no-frame-context`. This is an implementation-tier helper; new app code should emit the `[:rf.machine/dispatch-to-system [system-id event]]` fx instead.
+- **Example**:
+  ```clojure
+  ;; Implementation-tier direct call (prefer the fx in app code); no-op when unbound.
+  (machines/dispatch-to-system :logger [:logger/flush])
+  ```
 
 ## The actor-lifecycle fx
 
@@ -194,6 +241,12 @@ When a child actor spawns under a parent, the parent's `:data` often gets the ch
 | `[:rf.machine/destroy actor-id]` | actor id (keyword) | v1 | "Tear down this actor." Runs the actor's `:exit` action, dissociates `[:rf.runtime/machines :snapshots <actor-id>]` (in runtime-db), and clears the actor's event-handler registration. Symmetric counterpart to `:rf.machine/spawn`. |
 | `[:rf.machine/dispatch-to-system [system-id event]]` | 2-element pair `[system-id event-vector]` | v1 | "Message my spawned child actor by name." Resolves `system-id` through the emitting frame's `[:rf.runtime/machines :system-ids]` reverse index (in runtime-db) and dispatches `event` to the bound actor; no-op when unbound. The action-side counterpart to the `dispatch-to-system` fn. Args ride as a single 2-element pair (the fx contract is a `[fx-id args]` pair). |
 | `[:raise event-vec]` | event vector | v1 | **Machine-only.** Inside a machine action's `:fx`, routes the event back into the same machine atomically and pre-commit. Unbound outside machine actions. |
+
+**`:raise`** — inside a machine action, route an event back into the same machine (atomic, pre-commit):
+
+```clojure
+{:actions {:kick (fn [_] {:fx [[:raise [:tick]]]})}}
+```
 
 ### Spawn pattern
 
@@ -212,6 +265,14 @@ When a child actor spawns under a parent, the parent's `:data` often gets the ch
 (rf/reg-event :session/logger-spawned
   (fn [{:keys [db]} [_ logger-id]]
     {:db (assoc-in db [:session :logger] logger-id)}))
+```
+
+Tear the actor down with the symmetric `:rf.machine/destroy` — it runs the actor's `:exit`, clears its snapshot, and drops its event-handler registration:
+
+```clojure
+(rf/reg-event :session/stop-logger
+  (fn [{:keys [db]} _]
+    {:fx [[:rf.machine/destroy (get-in db [:session :logger])]]}))
 ```
 
 ## Final states and `:on-done`
@@ -237,18 +298,31 @@ The shipped machine-tooling exports live in `re-frame.machines` and are JVM-only
 - **Kind**: function (owned by `re-frame.machines`, JVM-only — not a `re-frame.core` facade export)
 - **Signature**:
   ```clojure
-  (re-frame.machines/machine-algebra-view definition) → algebra-view map
+  (re-frame.machines/machine-algebra-view) → {machine-id node}
+  (re-frame.machines/machine-algebra-view machine-id) → node (or nil)
   ```
-- **Description**: The static algebra view over a machine *definition* — the structure Xray's machine inspector and the docs/visualisation lane read. JVM-only.
+- **Description**: The static algebra view over a machine *definition* — the structure Xray's machine inspector and the docs/visualisation lane read. JVM-only. The zero-arity form returns `{machine-id node}` for every registered machine (`{}` when none); the one-arity form returns the single node for `machine-id`, or `nil` if it is not registered.
+- **Example**:
+  ```clojure
+  ;; The whole registry, keyed by machine-id — or one node (nil if unregistered).
+  (machines/machine-algebra-view)
+  (machines/machine-algebra-view :upload/main)
+  ```
 
 ### `re-frame.machines/machine-instance-algebra-view`
 
 - **Kind**: function (owned by `re-frame.machines`, JVM-only — not a `re-frame.core` facade export)
 - **Signature**:
   ```clojure
-  (re-frame.machines/machine-instance-algebra-view definition snapshot) → algebra-view map
+  (re-frame.machines/machine-instance-algebra-view) → {actor-id node}
+  (re-frame.machines/machine-instance-algebra-view frame-id) → {actor-id node}
   ```
-- **Description**: The algebra view for a live machine *instance* — definition plus current snapshot, so the view can highlight the active state. JVM-only.
+- **Description**: The algebra view for a live machine *instance* — definition plus current snapshot, so the view can highlight the active state. JVM-only. The zero-arity form reads the ambient current frame; the one-arity form names a `frame-id`. Returns `{actor-id node}` (one node per live snapshot — singletons and spawned actors), `{}` for a frame with no live machines, and `nil` for a missing/destroyed frame or in production builds.
+- **Example**:
+  ```clojure
+  ;; Live nodes — one per machine snapshot in the frame (singletons + spawned actors).
+  (machines/machine-instance-algebra-view :rf/default)
+  ```
 
 ### Post-v1 / future surfaces (not shipped)
 

--- a/docs/resources/api.md
+++ b/docs/resources/api.md
@@ -82,6 +82,11 @@ There is no `[:rf.scope/global]` fallthrough. Event resolution precedence: paylo
   ```
 - **Description**: Remove a registered resource. A **registration-lifecycle** operation — NOT the normal cache-invalidation API (for data lifecycle use `:rf.resource/invalidate-tags` / `:rf.resource/remove` / `:rf.resource/clear-scope`). Also disposes the resource-runtime state for the id in each affected frame (release owner indexes, cancel timers/host handles, abort in-flight where possible, suppress late replies by generation, remove tag-index rows, emit a trace). Returns `resource-id`.
 
+```clojure
+;; deregister a resource (registration-lifecycle — e.g. on hot-reload / teardown)
+(rf/clear-resource :feed/timeline)
+```
+
 ## Events (map payloads)
 
 Resource events take a **map payload**, not a positional argument vector.
@@ -107,11 +112,27 @@ Resource events take a **map payload**, not a positional argument vector.
 - **Payload**: `{:resource :scope :params :owner :cause}`
 - **Description**: Force a refresh. May force a new generation — a still-in-flight prior request is marked superseded, aborted when possible, otherwise suppressed by work-id + generation. A manual refresh is usually a `:cause`, not an `:owner`.
 
+```clojure
+;; a "Refresh" button — a :cause, pointedly no :owner (the route keeps it alive)
+[:rf.resource/refetch
+ {:resource :articles/list
+  :params   {}
+  :cause    [:manual :resources.app/refresh-articles]}]
+```
+
 ### `[:rf.resource/invalidate-tags {…}]`
 
 - **Kind**: event
 - **Payload**: `{:scope :tags :cause}`
 - **Description**: Mark entries whose tags intersect `:tags` stale; refetch entries with active owners; leave inactive entries stale or GC-eligible. **Scoped by default** — a cross-scope invalidation must opt in explicitly and is visible in Xray. On a successful load an entry's tags are *replaced* with the new data's tags.
+
+```clojure
+;; after a write settles, stale the reads carrying these tags
+[:rf.resource/invalidate-tags
+ {:scope :rf.scope/global
+  :tags  #{[:article "welcome"]}
+  :cause [:follow-author-detail-sync "welcome"]}]
+```
 
 ### `[:rf.resource/release-owner {…}]`
 
@@ -119,11 +140,25 @@ Resource events take a **map payload**, not a positional argument vector.
 - **Payload**: `{:owner …}`
 - **Description**: Release an owner lease. Aborts in-flight work only when no remaining owner needs it. App-minted leases (`[:lease …]`) MUST have a matching release path — an orphaned lease pins an entry alive (Xray lints it).
 
+```clojure
+;; the matching release for an app-minted [:lease …] owner
+[:rf.resource/release-owner
+ {:owner [:lease :preview "welcome"]}]
+```
+
 ### `[:rf.resource/clear-scope {…}]`
 
 - **Kind**: event
 - **Payload**: `{:scope :cause}`
 - **Description**: Causal scope teardown. Removes/marks-unusable every entry in the scope, releases owners, aborts in-flight requests with no owner outside the scope, suppresses late replies by scope + generation, emits explanatory trace rows. Required on logout / account / tenant / permission / locale / impersonation change.
+
+```clojure
+;; logout / tenant-switch — drop a whole scope's cache so the next principal
+;; can never read the last one's data
+[:rf.resource/clear-scope
+ {:scope [:rf.scope/session {:user-id "u-42"}]
+  :cause :logout}]
+```
 
 ### `[:rf.resource/remove {…}]`
 
@@ -131,11 +166,28 @@ Resource events take a **map payload**, not a positional argument vector.
 - **Payload**: `{:resource :scope :params}`
 - **Description**: Remove a single resource instance's cache entry.
 
+```clojure
+;; drop one cached instance, keyed by its scoped resource key
+[:rf.resource/remove
+ {:resource :article/by-slug
+  :scope    :rf.scope/global
+  :params   {:slug "welcome"}}]
+```
+
 ### `[:rf.resource/load-more {…}]`
 
 - **Kind**: event (infinite resources only — see [Infinite resources](#infinite-resources))
 - **Payload**: `{:resource :scope :params :cause}` — **ownerless** (carries a `:cause`, never an `:owner`)
 - **Description**: Extend an `:infinite` feed by one page. Computes the next page param from the entry's tail via `:next-page-param`, fetches that page through the same managed transport, and appends it to the feed's accumulated page vector (the feed stays `:loaded`; the pages stay visible — a load-more in flight is the derived `:fetching-next?` sub, distinct from a whole-feed `:fetching?` refresh). A load-more with no next page (`:next-page-param` → `nil`) is a no-op trace; a load-more while a page fetch is already in flight dedupes. A supplied `:owner` is warn-and-ignored — the route (or whatever first-loaded the feed) already owns the one feed entry, and load-more never changes the active-owner set.
+
+```clojure
+;; the "Load more" button — ownerless; carries a :cause, never an :owner
+[:rf.resource/load-more
+ {:resource :feed/timeline
+  :scope    :rf.scope/global
+  :params   {}
+  :cause    [:user :feed/load-more]}]
+```
 
 ### Focus/reconnect revalidation
 
@@ -146,6 +198,13 @@ Active-stale revalidation is expressed as **resource events**, never subscriptio
 - **Kind**: event (no payload)
 - **Description**: Scan the frame's active-owner stale entries and refetch them by policy. The refetch carries cause `:focus` (window-focused) or `:reconnect` (network-reconnected) — **never an owner** (it creates no liveness); generation + stale-suppression protect any late reply. Dispatch these directly only when driving revalidation yourself; ordinarily the host listeners below dispatch them.
 
+```clojure
+;; no payload — dispatch directly only when driving revalidation yourself
+;; (ordinarily the host listeners below dispatch these for you)
+[:rf.resource/window-focused]
+[:rf.resource/network-reconnected]
+```
+
 #### `install-revalidation-listeners!` / `remove-revalidation-listeners!`
 
 - **Kind**: function (post-v1 lib)
@@ -155,6 +214,14 @@ Active-stale revalidation is expressed as **resource events**, never subscriptio
   (remove-revalidation-listeners!  frame-id)   ;; → nil
   ```
 - **Description**: `install-revalidation-listeners!` wires three host `window` listeners for `frame-id` — `focus` and `visibilitychange`-to-visible → `[:rf.resource/window-focused]`, and `online` → `[:rf.resource/network-reconnected]` — each dispatched at `frame-id`. Idempotent (re-installing replaces, never stacks — hot-reload safe); CLJS-only (the JVM/SSR arm is a no-op). Listeners are recorded in a host side table and cancelled on frame destroy via the single `:resources/on-frame-destroyed!` hook. `remove-revalidation-listeners!` tears them down (useful for test isolation and single-page hosts that rotate which frame owns revalidation); a no-op when none is installed.
+
+```clojure
+;; at boot, after the frame is live: wire focus / visibility / online revalidation
+(rf/install-revalidation-listeners! :rf/default)
+
+;; tear them down (test isolation, or when another frame takes over revalidation)
+(rf/remove-revalidation-listeners! :rf/default)
+```
 
 > **Internal replies — do not dispatch.** `:rf.resource.internal/succeeded` / `…/failed` / `…/aborted` / `…/stale-fired` / `…/gc-fired` / `…/poll-fired` / `…/stale-suppressed` are framework-internal and carry the verification payload (`:work/id`, `:resource/key`, `:scope`, `:generation`, `:rf.frame/id`). User code MUST NOT dispatch them; success/failure verify frame + work id + generation before writing (the mandatory stale-suppression boundary). (`:rf.resource.internal/stale-fired` is the stale-timer re-check tick — it arms the stale transition, not a fetch; `:rf.resource.internal/poll-fired` is the poll-timer re-check tick — it refetches an active-owner entry by the interval.)
 
@@ -312,6 +379,11 @@ A **mutation** is the causal-WRITE counterpart of a resource: a named write to r
   ```
 - **Description**: Remove a registered mutation — a **registration-lifecycle** operation, NOT a form-error reset. For the causal runtime-instance reset use the `[:rf.mutation/clear …]` event. Returns `mutation-id`.
 
+```clojure
+;; deregister a mutation (registration-lifecycle — NOT the runtime-instance reset)
+(rf/clear-mutation :article/save)
+```
+
 ### Events (map payloads)
 
 #### `[:rf.mutation/execute {…}]`
@@ -334,6 +406,11 @@ A **mutation** is the causal-WRITE counterpart of a resource: a named write to r
 - **Kind**: event
 - **Payload**: `{:instance …}`
 - **Description**: The **causal** reset of a runtime mutation instance — clears its row and best-effort aborts in-flight work. Distinct from `clear-mutation` (which removes the *registration*).
+
+```clojure
+;; reset one runtime instance's row (e.g. in a completion continuation)
+[:rf.mutation/clear {:instance :form/save-1}]
+```
 
 ### Subscriptions (passive)
 
@@ -366,6 +443,12 @@ These direct functions are the **tool/test projection lane** — not an app-read
   ```
 - **Description**: The registered resource's spec (`:params-schema`, `:data-schema`, `:request`, `:scope`, `:transport`, `:stale-after-ms`, `:gc-after-ms`, `:poll-interval-ms`, `:tags`, `:doc`, source coords).
 
+```clojure
+;; tool/test lane: read a registered resource's spec back
+(rf/resource-meta :article/by-slug)
+;; => {:scope :rf.scope/global :params-schema [...] :request #fn ... :doc "…"}
+```
+
 ### `resource-state`
 
 - **Kind**: function (post-v1 lib)
@@ -374,6 +457,15 @@ These direct functions are the **tool/test projection lane** — not an app-read
   (resource-state {:resource … :scope … :params … :frame …}) → entry or nil
   ```
 - **Description**: A resource instance's durable runtime entry for an explicit-frame target, resolving the scoped key the same way a subscription does. nil when no entry exists.
+
+```clojure
+;; the live durable entry for one scoped key, at an explicit frame
+(rf/resource-state {:resource :article/by-slug
+                    :scope    :rf.scope/global
+                    :params   {:slug "welcome"}
+                    :frame    :rf/default})
+;; => entry map, or nil when no entry exists
+```
 
 ### `resources`
 
@@ -385,6 +477,11 @@ These direct functions are the **tool/test projection lane** — not an app-read
   ```
 - **Description**: Resource introspection for a frame target — the static registry (every registered id) plus, with `:frame`, the live per-frame resource-instance entries. The `:entries` map is keyed on the CEDN-1 byte `key-id` string (the same key the runtime storage / SSR wire use; it cannot collapse CEDN-distinct sequential-params entries the way an `=`-keyed scoped-key vector would). Each entry carries its kind-preserving scoped-resource-key `[scope resource-id params]` under `:resource/key` for destructure / scope-and-resource filtering.
 
+```clojure
+(rf/resources)                      ;; => {:resource-ids [...] :entries {}}  (static registry only)
+(rf/resources {:frame :rf/default}) ;; => {:resource-ids [...] :entries {<key-id> <entry>}}
+```
+
 ### `mutation-meta`
 
 - **Kind**: function (post-v1 lib)
@@ -393,6 +490,11 @@ These direct functions are the **tool/test projection lane** — not an app-read
   (mutation-meta mutation-id) → spec-map or nil
   ```
 - **Description**: The registered mutation's spec map (`:request`, `:params-schema`, `:invalidates`, `:patches`, `:populates`, `:scope`, `:invalidate-timing`, `:transport`, `:doc`, source coords), or nil.
+
+```clojure
+(rf/mutation-meta :article/save)
+;; => {:request #fn ... :params-schema :app/article :invalidates #fn ... :scope :rf.scope/global …}
+```
 
 ### `mutation-state`
 
@@ -403,6 +505,12 @@ These direct functions are the **tool/test projection lane** — not an app-read
   ```
 - **Description**: A mutation **instance**'s durable runtime row (`{:status :result :error …}`) for an explicit-frame target, or nil. The frame is carried explicitly (see [EP-0002](../EP/EP-0002-frame-target-resolution.md)).
 
+```clojure
+;; one mutation INSTANCE's runtime row, at an explicit frame
+(rf/mutation-state {:instance :form/save-1 :frame :rf/default})
+;; => {:status … :result … :error …}, or nil
+```
+
 ### `mutations`
 
 - **Kind**: function (post-v1 lib)
@@ -412,6 +520,11 @@ These direct functions are the **tool/test projection lane** — not an app-read
   (mutations {:frame …}) → {:mutation-ids [...] :instances {<instance-id> <row>}}
   ```
 - **Description**: Mutation introspection for a frame target — the registered mutation ids plus, with `:frame`, the live per-frame mutation-instance table (Xray groups instances under their registered mutation id).
+
+```clojure
+(rf/mutations {:frame :rf/default})
+;; => {:mutation-ids [...] :instances {<instance-id> <row>}}
+```
 
 Xray exposes the same shapes plus the tool accessors (`list-resources`, `list-resource-instances`, `get-resource-state`, `get-resource-history`, `list-resource-invalidations`), the route/resource graph, the work-ledger table, and the **scope audit surface** (the standing enumeration of every `:rf.scope/global` resource). Tool accessors prefer summaries over raw values; params/scopes get the same privacy/size elision as data.
 

--- a/docs/resources/http-api.md
+++ b/docs/resources/http-api.md
@@ -27,6 +27,12 @@ The verb helpers live in `re-frame.http`; the `:rf.http/managed` fx is keyword-a
 - **Kind**: fx
 - **Args**: request-id
 - **Description**: Abort the in-flight request with the given `:request-id`. The aborted request's reply fires with `{:rf/reply {:kind :failure :failure {:kind :rf.http/aborted ...}}}`.
+- **Example**:
+  ```clojure
+  (rf/reg-event :request/abort
+    (fn [_ [_ request-id]]
+      {:fx [[:rf.http/managed-abort request-id]]}))
+  ```
 
 ### A minimal request
 
@@ -69,6 +75,13 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/post url args)
   ```
 - **Description**: POST. Pass `:body` in `args`.
+- **Example**:
+  ```clojure
+  {:fx [(rf.http/post "/api/items"
+                      {:request    {:body {:title "new"}
+                                    :request-content-type :json}
+                       :on-success [:items/created]})]}
+  ```
 
 ### `re-frame.http/put`
 
@@ -78,6 +91,13 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/put url args)
   ```
 - **Description**: PUT.
+- **Example**:
+  ```clojure
+  {:fx [(rf.http/put "/api/items/42"
+                     {:request    {:body {:title "updated"}
+                                   :request-content-type :json}
+                      :request-id [:item :update 42]})]}
+  ```
 
 ### `re-frame.http/delete`
 
@@ -87,6 +107,11 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/delete url args)
   ```
 - **Description**: DELETE.
+- **Example**:
+  ```clojure
+  {:fx [(rf.http/delete "/api/items/42"
+                        {:on-failure [:item/delete-failed]})]}
+  ```
 
 ### `re-frame.http/patch`
 
@@ -96,6 +121,13 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/patch url args)
   ```
 - **Description**: PATCH.
+- **Example**:
+  ```clojure
+  {:fx [(rf.http/patch "/api/items/42"
+                       {:request    {:body {:done true}
+                                     :request-content-type :json}
+                        :on-success [:items/patched]})]}
+  ```
 
 ### `re-frame.http/head`
 
@@ -105,6 +137,11 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/head url args)
   ```
 - **Description**: HEAD.
+- **Example**:
+  ```clojure
+  {:fx [(rf.http/head "/api/items"
+                      {:on-success [:items/exists?]})]}
+  ```
 
 ### `re-frame.http/options`
 
@@ -114,6 +151,10 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/options url args)
   ```
 - **Description**: OPTIONS.
+- **Example**:
+  ```clojure
+  {:fx [(rf.http/options "/api/items")]}
+  ```
 
 The verb helpers live in `re-frame.http` — users `(:require [re-frame.http :as rf.http])` alongside `re-frame.core`. The namespace ships in `day8/re-frame2-http`, the same artefact as the fx itself, so loading the helpers and the fx is a single dep decision.
 
@@ -182,6 +223,10 @@ Sometimes you want to inject behaviour into every request — adding an auth hea
   (clear-http-interceptor frame id)
   ```
 - **Description**: Unregister an interceptor by id. The single-arity `(clear-http-interceptor id)` resolves the frame from the carried scope it runs under; the two-arity `(clear-http-interceptor frame id)` names the frame explicitly. Either form raises `:rf.error/no-frame-context` when the frame is absent (single-arity under no scope, or two-arity passed `nil`) — it never clears against a synthesised `:rf/default`.
+- **Example**:
+  ```clojure
+  (rf/clear-http-interceptor :auth-header)
+  ```
 
 ```clojure
 (rf/reg-http-interceptor :auth/inject
@@ -206,11 +251,29 @@ Tests want to drive the cascade without hitting the network. The test-support su
 
 - **Kind**: fx
 - **Description**: Synthesise the canonical success reply directly into `:fx`. Useful for "stub THIS request inline" patterns. Registered at load of `re-frame.http.test-support`.
+- **Example**:
+  ```clojure
+  (rf/reg-event :counter/retry-recover
+    (fn [_ _]
+      {:fx [[:rf.http/managed-canned-success
+             {:request {:method :get :url "api/flaky"}
+              :decode  :json
+              :value   {:delta 5}}]]}))
+  ```
 
 ### `[:rf.http/managed-canned-failure {:kind <:rf.http/*> :tags {...}}]`
 
 - **Kind**: fx
 - **Description**: Synthesise the canonical failure reply directly into `:fx`.
+- **Example**:
+  ```clojure
+  (rf/reg-event :flaky/load
+    (fn [_ _]
+      {:fx [[:rf.http/managed-canned-failure
+             {:on-failure [:flaky/load-error]
+              :kind       :rf.http/http-5xx
+              :tags       {:status 503 :status-text "Service Unavailable"}}]]}))
+  ```
 
 ### `with-managed-request-stubs`
 
@@ -229,6 +292,15 @@ Tests want to drive the cascade without hitting the network. The test-support su
   (with-managed-request-stubs* route-map body-fn)
   ```
 - **Description**: Plain-fn surface beneath the macro. Use for computed route-maps or non-literal bodies. Like the macro, it installs the `:rf.http/managed` override for `body-fn`'s dynamic extent, so dispatches inside auto-route with no manual `:fx-overrides`.
+- **Example**:
+  ```clojure
+  ;; Computed route-map / non-literal body — use the fn form.
+  (rf/with-managed-request-stubs*
+    {[:get "/articles"] {:reply {:ok [:hello :world]}}}
+    (fn []
+      ;; No manual :fx-overrides — auto-routes by method + URL.
+      (rf/dispatch-sync [:articles/list])))
+  ```
 
 ### `re-frame.http.test-support/install-managed-request-stubs!`
 
@@ -238,6 +310,15 @@ Tests want to drive the cascade without hitting the network. The test-support su
   (install-managed-request-stubs! route-map)
   ```
 - **Description**: Lower-level than `with-managed-request-stubs`: registers the `:rf.http/managed-test-stub` fx that persists until `uninstall-managed-request-stubs!`. Use when stubs span multiple `deftest`s. Unlike the wrapper, this does NOT install the `:rf.http/managed` override — dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it. **Not a `re-frame.core` façade export** — call it through its home namespace `re-frame.http.test-support`.
+- **Example**:
+  ```clojure
+  ;; Stubs that span several deftests — install once, route via :fx-overrides.
+  (re-frame.http.test-support/install-managed-request-stubs!
+    {[:get "/api/cart"] {:reply {:ok [{:id 1 :name "widget"}]}}})
+
+  (rf/dispatch-sync [:cart/load]
+                    {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+  ```
 
 ### `re-frame.http.test-support/uninstall-managed-request-stubs!`
 
@@ -247,6 +328,10 @@ Tests want to drive the cascade without hitting the network. The test-support su
   (uninstall-managed-request-stubs!)
   ```
 - **Description**: Drop installed stubs; restore real-request routing. Idempotent. **Not a `re-frame.core` façade export** — call it through its home namespace `re-frame.http.test-support`.
+- **Example**:
+  ```clojure
+  (re-frame.http.test-support/uninstall-managed-request-stubs!)
+  ```
 
 All the test-support surfaces live in `re-frame.http.test-support`. One namespace; same artefact (`day8/re-frame2-http`) as the production code. The ergonomic `with-managed-request-stubs` macro is re-exported on the `re-frame.core` façade; the raw `install`/`uninstall` pair is reached only through the home namespace.
 

--- a/docs/routing/api.md
+++ b/docs/routing/api.md
@@ -63,6 +63,15 @@ Canonical detail in [The metadata map, in full](concepts.md#the-metadata-map-in-
   (match-url url) → {:route-id :params :query :validation-failed?} or nil
   ```
 - **Description**: "What route does this URL match?" Pure — JVM-runnable; useful for server-side rendering and tests.
+- **Example**:
+  ```clojure
+  ;; with (rf/reg-route :user/show {} "/users/:id") registered:
+  (routing/match-url "/users/42")
+  ;; => {:route-id :user/show, :params {:id "42"}, :query {}, :fragment nil}
+
+  ;; nil when no route matches:
+  (routing/match-url "/no/such/path")  ;; => nil
+  ```
 
 ### `route-url`
 
@@ -73,6 +82,14 @@ Canonical detail in [The metadata map, in full](concepts.md#the-metadata-map-in-
   (route-url route-id path-params query-params) → URL string
   ```
 - **Description**: "Render this route to a URL." The inverse of `match-url`. Pure; JVM-runnable.
+- **Example**:
+  ```clojure
+  ;; with (rf/reg-route :user/show {} "/users/:id") registered:
+  (routing/route-url :user/show {:id 42})            ;; => "/users/42"
+
+  ;; query params are appended and percent-encoded:
+  (routing/route-url :search {} {:q "hello world"})  ;; => "/search?q=hello%20world"
+  ```
 
 ### `route-link`
 

--- a/docs/ssr/api.md
+++ b/docs/ssr/api.md
@@ -42,6 +42,14 @@ The render/head primitives are re-exported on the `re-frame.core` facade; the fu
   (render-tree-hash render-tree) → 32-bit FNV-1a structural hash (lowercase hex)
   ```
 - **Description**: A deterministic structural fingerprint of a render tree. Same canonical-EDN representation produces the same hash on JVM and CLJS. Used by the hydration compatibility check — if the server's hash doesn't match the client's hash, hydration is unsafe.
+- **Example**:
+  ```clojure
+  ;; Capture the hash at render time; it rides the hydration payload as
+  ;; :rf/render-hash and is re-checked client-side after the first render.
+  (let [hiccup      ((rf/view :app/root))
+        render-hash (rf/render-tree-hash hiccup)]
+    {:rf/render-hash render-hash})
+  ```
 
 ### `project-error`
 
@@ -51,6 +59,13 @@ The render/head primitives are re-exported on the `re-frame.core` facade; the fu
   (project-error frame-id trace-event) → :rf/public-error
   ```
 - **Description**: Apply the active error-projector (selected by the frame's `:ssr {:public-error-id ...}` metadata) for the named frame. This is the seam between "internal error trace event with full diagnostic detail" and "client-safe public-error projection."
+- **Example**:
+  ```clojure
+  ;; Turn an internal error-trace event into the frame's client-safe
+  ;; public-error projection (host adapter / error-page render path).
+  (ssr/project-error :rf/default trace-event)
+  ;; => {:status 404 :code :not-found :message "Page not found"}
+  ```
 
 ### Streaming render
 
@@ -65,6 +80,14 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
     → {:shell-html "..." :continuations [{:id :subtree} ...]}
   ```
 - **Description**: Walk the tree once; at each `:rf/suspense-boundary` emit a `<template …suspense-fallback>` placeholder and record a continuation. Returns the shell-html (ready to flush) and the continuations to drain.
+- **Example**:
+  ```clojure
+  ;; Host adapter: render the shell to flush immediately, keep the continuations.
+  (let [{:keys [shell-html continuations]}
+        (rf/with-frame fid (ssr/streaming-render-shell hiccup))]
+    ;; flush shell-html now; drain `continuations` as each subtree settles
+    shell-html)
+  ```
 - **In the wild**: [ssr_streaming](https://github.com/day8/re-frame2/tree/main/examples/capabilities/ssr/ssr_streaming)
 
 ### `streaming-render-continuation`
@@ -76,6 +99,15 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
     → {:id :html :delta :failed?}
   ```
 - **Description**: Drain one continuation against `frame-id`'s app-db. Snapshots before-db / after-db and computes the per-subtree delta. Catches throws and surfaces the original fallback HTML inline.
+- **Example**:
+  ```clojure
+  ;; Drain each deferred boundary against fid's app-db, emitting its chunk.
+  (doseq [entry continuations]
+    (let [{:keys [id html delta failed?]}
+          (rf/with-frame fid (ssr/streaming-render-continuation fid entry))]
+      ;; flush this subtree's resolved HTML + hydrate-delta as the next chunk
+      ))
+  ```
 
 ### `streaming-build-final-payload`
 
@@ -86,6 +118,13 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
     → canonical :rf/hydration-payload
   ```
 - **Description**: Called after all continuations drain to populate the `__rf_payload` final chunk.
+- **Example**:
+  ```clojure
+  ;; After every continuation drains, build the canonical __rf_payload chunk.
+  (rf/with-frame fid
+    (ssr/streaming-build-final-payload
+      fid render-hash {:version 1 :payload :rf.ssr.payload/whole-app-db}))
+  ```
 
 The streaming surface is host-adapter territory — the SSR-aware host (`re-frame.ssr.ring` or equivalent) wires it. Most app code interacts via the host adapter and never touches `streaming-render-*` directly.
 
@@ -117,6 +156,13 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
   (render-head head-id opts) → :rf/head-model
   ```
 - **Description**: Evaluate the registered head-fn for `head-id`. Returns a head-model.
+- **Example**:
+  ```clojure
+  ;; Evaluate the head-fn registered under :app/head against frame f's app-db
+  ;; + active route. The long form and frame-id shorthand are equivalent:
+  (rf/render-head :app/head {:frame f})   ;; => {:title "MyApp — …" :meta [...]}
+  (rf/render-head :app/head f)
+  ```
 
 ### `active-head`
 
@@ -126,6 +172,12 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
   (active-head frame-id) → :rf/head-model
   ```
 - **Description**: Resolve the head-model for the currently active route in the named frame. Head rendering is a frame-scoped read (it reads the frame's route slice and app-db), so the frame is **carried, not ambient**: the no-arg form is gone, and a `nil` `frame-id` raises `:rf.error/no-frame-context` rather than resolving against a synthesised `:rf/default`. Sub-shape: `[:rf/head]` subscribes to this.
+- **Example**:
+  ```clojure
+  ;; Resolve the head-model for frame f's active route (via the route's :head).
+  ;; The Ring host adapter uses this, then head-model->html, to render <head>.
+  (rf/active-head f)   ;; => {:title "Article 42"}
+  ```
 
 ### `head-model->html`
 
@@ -136,6 +188,14 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
   (head-model->html head-model {:wrap? bool}) → inner-head HTML string
   ```
 - **Description**: Render a head-model to its HTML representation. `:wrap?` controls whether `<head>` tags are emitted (default: false, so the result can be composed into a larger shell).
+- **Example**:
+  ```clojure
+  (rf/head-model->html
+    {:title "Hello"
+     :meta  [{:name "description" :content "A summary"}]
+     :link  [{:rel "canonical" :href "https://example.com/x"}]})
+  ;; => "<title>Hello</title><meta name=\"description\" content=\"A summary\"/>…"
+  ```
 
 ### `head-snapshot`
 
@@ -145,6 +205,12 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
   (head-snapshot frame-id) → {head-id → :rf/head-model}
   ```
 - **Description**: Read the per-frame snapshot of last-produced head-models. Returns `{}` for a frame that has never seen a `render-head` call. Useful for tests, introspection, and tools. Re-exported as `rf/head-snapshot`.
+- **Example**:
+  ```clojure
+  ;; After one or more render-head calls, read the per-frame snapshot:
+  (rf/render-head :app/head {:frame f})
+  (rf/head-snapshot f)   ;; => {:app/head {:title "…"}}
+  ```
 
 ## Standard SSR events
 
@@ -152,6 +218,23 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
 |---|---|
 | `:rf/server-init` | Per-request server-side initialisation. Reads request cofx; dispatches setup events. `:platforms #{:server}`. |
 | `:rf/hydrate` | Seed the client-side `app-db` from the server-supplied payload. Runs once on client bootstrap. |
+
+- **Example**:
+  ```clojure
+  ;; :rf/server-init — registered by the app; fired from the per-request frame's
+  ;; :initial-events as it boots, dispatching the setup work the page needs.
+  (rf/reg-event :rf/server-init
+    {:platforms #{:server}}
+    (fn [{:keys [db]} _]
+      {:db db
+       :fx [[:rf.http/managed {:request    {:method :get :url "/api/articles"}
+                               :decode     :json
+                               :on-success [:articles/loaded]}]]}))
+
+  ;; :rf/hydrate — framework-owned; dispatched on the client (usually via
+  ;; ssr/hydrate!) to seed app-db from the payload before the first render.
+  (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
+  ```
 
 ## Standard SSR fx (server-only)
 
@@ -167,12 +250,45 @@ All server-only — `:platforms #{:server}`. These build the response accumulato
 | `[:rf.server/redirect {:location ?:status}]` | default `:status 302`; truncates HTML. **Caller-trusted** `:location`. |
 | `[:rf.server/safe-redirect {:location ?:relative-only? ?:allow}]` | The caller-untrusted variant — parses `:location`, rejects `javascript:` / `data:` / `vbscript:` schemes, and enforces `:relative-only?` / `:allow` allowlist before setting `:redirect`. Open-redirect mitigation for attacker-controlled `?next=` strings. |
 
+- **Example**:
+  ```clojure
+  ;; Shape the HTTP response from a server-side handler. Every :rf.server/* fx
+  ;; is :platforms #{:server}, so the client render skips them.
+  (rf/reg-event :app/respond
+    {:platforms #{:server}}
+    (fn [{:keys [db]} _]
+      {:db db
+       :fx [[:rf.server/set-status    200]
+            [:rf.server/set-header    {:name "X-Foo" :value "first"}]
+            [:rf.server/append-header {:name "Set-Cookie" :value "a=1"}]
+            [:rf.server/set-cookie    {:name      "session"
+                                       :value     "abc123"
+                                       :max-age   3600
+                                       :http-only true
+                                       :same-site :lax
+                                       :path      "/"}]
+            [:rf.server/delete-cookie {:name "stale-session" :path "/"}]]}))
+
+  ;; Redirects — caller-trusted vs caller-untrusted (e.g. an attacker-supplied
+  ;; ?next= param). safe-redirect parses + allowlists before setting :redirect.
+  (rf/reg-event :auth/bounce
+    {:platforms #{:server}}
+    (fn [{:keys [db]} _]
+      {:db db
+       :fx [[:rf.server/redirect      {:status 302 :location "/login"}]
+            [:rf.server/safe-redirect {:location "/dashboard" :relative-only? true}]]}))
+  ```
+
 ## Standard SSR subs
 
 | Sub | Returns |
 |---|---|
 | `:rf/head` | The head model for the active route (resolved via `active-head` against the subscribed frame) |
 | `:rf/public-error` | The sanitised public-error projection when an error page is being rendered; `nil` otherwise |
+
+> **NOT USED** — `:rf/head` is never subscribed (no `[:rf/head]` call sites, and no `reg-sub :rf/head`) in `implementation/`, `examples/`, or `tools/`.
+>
+> **NOT USED** — `:rf/public-error` is never subscribed (no `[:rf/public-error]` call sites, and no `reg-sub :rf/public-error`) in `implementation/`, `examples/`, or `tools/`. The `:rf/public-error` *map shape* is produced by `project-error`; only the **sub** is unused.
 
 The current request's **response accumulator** (status / headers / cookies / redirect) is *not* a registered subscription. It lives in a framework-private side-channel atom keyed by frame-id and is read exclusively by the runtime via `re-frame.ssr/get-response`; the host adapter consumes the resolved value to build the wire response.
 
@@ -181,6 +297,17 @@ The current request's **response accumulator** (status / headers / cookies / red
 | Cofx | Returns |
 |---|---|
 | `:rf.server/request` | The active HTTP request map. |
+
+- **Example**:
+  ```clojure
+  ;; A server handler declares the requirement, then reads the request FLAT
+  ;; under :rf.server/request (Ring-shaped under the bundled adapter).
+  (rf/reg-event :app/server-init
+    {:platforms        #{:server}
+     :rf.cofx/requires [:rf.server/request]}
+    (fn [{:rf.server/keys [request] :keys [db]} _]
+      {:db (assoc db :method (:request-method request))}))
+  ```
 
 ## `:platforms` metadata on `reg-fx`
 


### PR DESCRIPTION
Reviewed **every symbol** in the 15 symbol-bearing API docs (`docs/core/api/*` + the standalone `machines`/`routing`/`resources`/`http`/`ssr` api docs) against its **actual usage** in `implementation/`, `examples/`, and `tools/`. One agent per file (workflow fan-out).

## Added examples (~978 lines, 15 files)
For every symbol that lacked an example, added 1–2 short ones **drawn from a real call site** found in the codebase — e.g. `clear-event`/`clear-sub`/`clear-fx`/`destroy-frame!`/`reset-frame!` (core tests), `subscribe-once` (ssr-ring tests), `dispatch*` (playground), `reg-view*` Form-3 (realworld_resources), `with-fx-overrides` (examples_test), the managed-HTTP + test surfaces, machine/routing/ssr surfaces, etc. Existing examples were left untouched (gap-fill only).

## Fixed placeholder signatures
The four `- **Signature**: per docstring` entries in `10-testing.md` now carry the **real arglist**, each verified against `re-frame.test-support` source:

| Symbol | Now documented as |
|---|---|
| `snapshot-registrar` | `(snapshot-registrar) → snapshot` |
| `restore-registrar!` | `(restore-registrar! snapshot) → nil` |
| `with-fresh-registrar` | `(with-fresh-registrar body-fn) → any` |
| `make-reset-runtime-fixture` | `(make-reset-runtime-fixture)` / `(make-reset-runtime-fixture opts) → fixture-fn` |

## ⚠️ Marked NOT USED — 4 symbols (your review)
No call sites found anywhere in `implementation/`, `examples/`, or `tools/`:

- **`re-frame.adapter.uix/use-current-frame`** (14-adapters)
- **`re-frame.adapter.helix/use-current-frame`** (14-adapters)
- **the `[:rf/head]` sub** (ssr) — never subscribed; no `reg-sub :rf/head`
- **the `[:rf/public-error]` sub** (ssr) — never subscribed (the `:rf/public-error` *map shape* IS produced by `project-error`; only the **sub** is unused)

These carry a `> **NOT USED** — …` marker in the doc as a review signal. They may be legit consumer-facing API (unused only *in-repo*) or candidates for removal — your call. Say the word and I'll strip the markers (or the symbols).

## Verification (local)
`check_doc_slugs`, `check_readme_links`, the three residue checkers, and the **api-manifest JVM gate** (53 tests, 0 failures — every var reference in the new examples resolves against the manifest). `mkdocs --strict` runs in CI.