### PR TITLE
docs(machines): deep statechart coverage — 7 new topic pages + expanded core

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -1,0 +1,325 @@
+# Actors: spawning child machines
+
+A machine doesn't have to be a singleton. When a state needs to run some self-contained, asynchronous activity — an HTTP request, a websocket session, a worker grinding through a shard — you can **spawn a child machine** to do it, scoped to that state's lifetime. The child is a full machine instance with its own `:state` and `:data`; we call it an **actor**.
+
+The pattern earns its keep when an activity has a *lifetime that should match a state's lifetime*: start it when you enter the state, and — this is the part that's easy to get wrong by hand — tear it down on **every** way out of the state, including the ones you forgot about. Declare the binding once and the runtime enforces it.
+
+> **Coming from XState?** This is `invoke` (a state-bound child) and `spawn` (a dynamically-created actor) — re-frame2 spells both as **`:spawn`**. The deeper shift: in XState an actor is a living object you `createActor(machine).start()` and hold a reference to, then `.send()` messages. In re-frame2 there is **no actor object**. A spawned actor's *liveness is its snapshot* — a plain value at `[:rf.runtime/machines :snapshots <actor-id>]` in the [frame's runtime-db](glossary.md#snapshot). You address it by `dispatch`-ing to its id, exactly like any other handler, and it reverts with the frame on time-travel. See [Coming from XState](coming-from-xstate.md) for the full delta.
+
+This page assumes you've met the [transition table, guards, actions, tags, and `:after`](concepts.md#guards-and-actions). If not, read [Concepts](concepts.md) first.
+
+---
+
+## Your first spawned actor — declarative `:spawn`
+
+Put a `:spawn` map on a state node. While the machine sits in that state, a child actor of the named machine exists; on any transition out of the state, it's destroyed.
+
+Here's the heart of the [websocket example](../../examples/patterns/websocket/): a connection machine whose `:active` state owns a live socket. The socket is its own machine (`:websocket/socket`), spawned on the `:active` *parent* so one socket spans the connect → authenticate → connected leaves nested inside it.
+
+```clojure
+(rf/reg-machine :ws/connection
+  {:initial :disconnected
+   :data    {:url nil :auth-token nil :socket-id nil}
+   :states
+   {:disconnected
+    {:on {:ws/connect {:target :active :action :record-opts}}}
+
+    :active
+    {:spawn {:machine-id :websocket/socket
+             ;; :data can be a fn — evaluated on entry against the
+             ;; post-action snapshot, so it reads whatever's current.
+             :data       (fn [{snap :snapshot}]
+                           {:url        (-> snap :data :url)
+                            :auth-token (-> snap :data :auth-token)})}
+     :on    {:ws/closed {:target :reconnecting}
+             :ws/fatal  {:target :failed}}
+     ;; ... compound :initial / nested leaves omitted ...
+     }}})
+```
+
+Enter `:active` → the runtime spawns a `:websocket/socket` actor. Leave `:active` by *any* door — `:ws/closed`, `:ws/fatal`, a frame teardown — and the runtime destroys it. The parent never wrote "spawn" or "destroy"; `:spawn` is **registration-time sugar** that rewrites the state's `:entry`/`:exit` into the imperative spawn/destroy effects you'll meet below. From the outside it's indistinguishable from a machine that wired those slots by hand.
+
+> **Mental model.** `:spawn` is XState's `invoke`. The child's lifetime is the state's lifetime. Renamed because "invoke" reads like a synchronous call, whereas what's really created is a child actor's worth of lifecycle.
+
+### The spawn-spec keys
+
+The map under `:spawn` accepts:
+
+| key | what it does |
+|---|---|
+| `:machine-id` **or** `:definition` | which machine to spawn — a registered machine id, or an inline transition table. Supply **exactly one** (both, or neither, is a registration error). |
+| `:data` | initial `:data` for the child — a literal map, or `(fn [{:keys [snapshot event]}] data)` evaluated at entry against the **post-action** snapshot (the transition's own `:action` has already run, so its writes are visible). |
+| `:id-prefix` | base for the gensym'd actor id (`:websocket/socket#0`); defaults to `:machine-id`. |
+| `:start` | an event vector dispatched to the newborn as its first event (see [the synthetic kick-off](#the-synthetic-spawned-event-and-start) below). |
+| `:system-id` | bind the actor to a per-frame **name** so other code can address it without knowing the gensym'd id (see [Messaging](#cross-machine-messaging)). |
+| `:on-spawn` | `(fn [{:keys [data id]}] _)` — an **advisory** observation hook; **its return is dropped** (see [Recording the id](#recording-the-spawned-id)). |
+| `:on-done` | `(fn [{:keys [data result]}] new-data)` — success notification when the child reaches a non-error `:final?` leaf. |
+| `:on-error` | an `:on`-shaped **transition** — fires when the child fails (an `:error?` final leaf, or a thrown action). The parent changes state. |
+| `:fixed-actor-id` | an explicit actor id instead of a gensym, for a per-state singleton actor. |
+
+`:on-done` / `:on-error` are the completion story — they pair with the child declaring a `:final?` leaf. That's covered under [Final states](concepts.md#final-states-when-a-machine-is-done); the [API reference](../api/re-frame.machines.md) lists the exact shapes. Here we focus on the lifecycle: spawn, address, message, and tear down.
+
+> **Divergence to know.** XState lets `invoke` take a vector of children per state; re-frame2 allows **one `:spawn` per state** (use a compound state with one actor per substate, or [`:spawn-all`](#fan-out-and-join-with-spawn-all) for parallelism). XState's `autoForward` is omitted — forward events explicitly with `:fx [[:dispatch [child-id ev]]]`. And there's no `:onSnapshot` — read the child with the `[:rf/machine actor-id]` subscription.
+
+---
+
+## Runtime stamps: how a child knows who it is
+
+When the runtime builds a declaratively-spawned child's initial snapshot, it stamps three framework-reserved keys into the child's `:data` — so the child can address itself and its parent without the parent having to thread that information through:
+
+| key | value |
+|---|---|
+| `:rf/self-id` | the actor's own address (e.g. `:websocket/socket#0`) |
+| `:rf/parent-id` | the parent machine's registration id |
+| `:rf/invoke-id` | the absolute path of the `:spawn`-bearing state node |
+
+The child reads these as ordinary `:data` lookups inside its actions. Here's the socket actor reporting back to its parent on open (simplified from the [websocket example](../../examples/patterns/websocket/)):
+
+```clojure
+(rf/reg-machine :websocket/socket
+  {:initial :opening
+   :data    {:url nil :auth-token nil}
+   :actions
+   {:open-socket
+    (fn [{data :data}]
+      (let [self-id   (:rf/self-id data)       ;; my own address
+            parent-id (:rf/parent-id data)      ;; who spawned me
+            socket    (open-host-socket! self-id (:url data))]
+        (store-socket! self-id socket)
+        ;; Report up to the parent, tagging the message with my socket id.
+        {:fx [[:dispatch [parent-id [:ws/opened {:source-socket-id self-id}]]]]}))}
+   :states
+   {:opening {:entry :open-socket
+              :always [{:target :open}]}
+    :open    {:on {:send {:action :send-via-socket}}}}})
+```
+
+> **This is XState's `sendParent`.** In XState a child can address its parent without being told who it is; here the runtime stamps `:rf/parent-id` and the child reads it. **Caveat:** the stamp is written **only on the declarative `:spawn` / `:spawn-all` path**. A *hand-emitted* `[:rf.machine/spawn …]` (next section) records only `:rf/self-id` — there's no structural parent — so a hand-spawned child must be handed a correspondent address through its `:data`.
+
+---
+
+## The synthetic spawned event, and `:start`
+
+A freshly-spawned actor needs a first nudge. Two ways:
+
+- **No `:start` (the common case).** The runtime dispatches a synthetic `[:rf.machine.spawn/spawned]` into the newborn. The child's initial-state `:entry` cascade fires first regardless, so the **canonical** shape is to do the actor's first work in `:entry` (as `:open-socket` does above). A generic child can also listen for the kick-off explicitly:
+
+  ```clojure
+  ;; A child springing into action the instant it's spawned (no :start needed).
+  ;; The runtime conjures [:rf.machine.spawn/spawned] when there's nothing to :start.
+  :idle {:on {:rf.machine.spawn/spawned :processing}}
+  ```
+
+  Both work; new code prefers `:entry` (it fires for every kick-off mode). An unhandled `:rf.machine.spawn/spawned` is a benign no-op — it's reserved framework lifecycle traffic, exempt from the [unhandled-event trace](concepts.md#one-thing-that-wont-throw-the-unhandled-event).
+
+- **With `:start [:begin url]`.** Hand the child a specific first event payload. The two paths are mutually exclusive — an actor gets the synthetic kick-off *or* your `:start`, never both.
+
+---
+
+## Recording the spawned id
+
+You will reach for `:on-spawn` to "capture the child's id into `:data`" — and it won't work. `:on-spawn` is an **advisory observation hook**: the runtime calls it with `{:data <parent-data> :id <new-id>}` and **drops its return value**. Writing `(assoc data :pending id)` records nothing (and emits a `:rf.warning/on-spawn-return-ignored` in dev). The runtime already tracks the id for you; you don't need `:on-spawn` for destroy to work.
+
+When you *do* need the id addressable by name, the first-class mechanisms (in order of preference):
+
+1. **`:system-id`** — give the spawn a stable name; resolve and message it by that name (see [below](#cross-machine-messaging)). Best when you want a *role* rather than a gensym.
+2. **The `:rf/spawned` `:data` slot** — on every declarative `:spawn`, the runtime binds the new id into the *spawning* machine's own `:data` under `{:rf/spawned {<invoke-id> <actor-id>}}`. A later action reads it: `(get-in data [:rf/spawned [:active]])`. This is the re-frame2 spelling of XState's `const ref = spawn(child)` captured into `context` — except the id rides the revertible snapshot, not a live object.
+3. **Self-dispatch from `:on-spawn`** — since `:on-spawn` *can* fire a side-effecting dispatch (just not return data), have it dispatch a self-event whose ordinary `:action` writes the id. This is the verified [websocket](../../examples/patterns/websocket/) pattern:
+
+```clojure
+:active
+{:spawn {:machine-id :websocket/socket
+         :data       (fn [{snap :snapshot}] {:url (-> snap :data :url)})
+         ;; :on-spawn can't write :data (return dropped), but it CAN
+         ;; fire an event whose transition records the id the normal way.
+         :on-spawn   (fn [{id :id}]
+                       (when-let [dispatch! (re-frame.late-bind/get-fn :router/dispatch!)]
+                         (dispatch! [:ws/connection [:ws/-socket-spawned id]]
+                                    {:source :websocket})))}
+ :on {:ws/-socket-spawned {:action :record-socket-id}}}
+
+;; ... and the ordinary action that does the assoc:
+:record-socket-id (fn [{data :data [_ id] :event}]
+                    {:data (assoc data :socket-id id)})
+```
+
+---
+
+## Cross-machine messaging
+
+There is **one** mechanism: `dispatch` by id. A spawned actor's id is a handler address, so a parent messages a child — and a child messages its parent — the same way:
+
+```clojure
+;; parent → child, or child → parent: same primitive.
+{:fx [[:dispatch [some-machine-id [:some-event payload]]]]}
+```
+
+> **XState splits this into four primitives** — `sendTo(ref, ev)`, `sendParent(ev)`, the implicit reply via the returned child ref, and `system.get(id)`. re-frame2 subsumes all four under `dispatch`-by-id, with `:system-id` supplying the `system.get` analog.
+
+### Addressing by name with `:system-id`
+
+When you don't want to thread the gensym'd id around, name the actor at spawn with `:system-id`, then message it by that name. The canonical action-side surface is the reserved `:rf.machine/dispatch-to-system` fx (a machine action can't read app-db, so it can't look the id up itself):
+
+```clojure
+;; spawn under a role-name:
+:spawn {:machine-id :request/protocol
+        :system-id  :primary-request
+        :data       {:url "/api/foo"}}
+
+;; later, from any action's :fx — message it by name (no-op if unbound):
+{:fx [[:rf.machine/dispatch-to-system [:primary-request [:cancel]]]]}
+```
+
+From a non-action call site you can resolve the id directly with `(re-frame.machines/machine-by-system-id :primary-request)` and `dispatch` to it. The binding lives in the frame's runtime-db, so it reverts with everything else.
+
+### Including a reply address
+
+There's no `sender`/`sendTo`-reply special form — put the reply event *in the request* (the standard re-frame2 reply convention): address the request by name, but put the reply id in the payload so the reply lands in a specific actor rather than whoever currently owns the name.
+
+---
+
+## Imperative spawn and destroy
+
+`:spawn` desugars to two reserved effects you can also emit by hand from any `:fx` vector. They are **fx-ids inside `:fx`**, not top-level effect keys:
+
+```clojure
+;; Spawn from an event handler (e.g. a boot-time bootstrap event):
+(rf/reg-event :session/start-logger
+  (fn [_ _]
+    {:fx [[:rf.machine/spawn {:machine-id :machines/log-shipper
+                              :id-prefix  :logger
+                              :system-id  :logger        ;; address it later by name
+                              :data       {:buffer []}
+                              :start      [:logger/connect]}]]}))
+
+;; Tear it down later:
+(rf/reg-event :session/stop-logger
+  (fn [_ _]
+    {:fx [[:rf.machine/dispatch-to-system [:logger [:logger/flush]]]
+          [:rf.machine/destroy (re-frame.machines/machine-by-system-id :logger)]]}))
+```
+
+`[:rf.machine/spawn <spec>]` and `[:rf.machine/destroy <actor-id>]` are the surface; the [API reference](../api/re-frame.machines.md) documents them in full. Two properties worth internalising:
+
+- **Spawning an unregistered `:machine-id` fails closed.** No snapshot, no id, no `:start` — the spawn rejects with `:rf.error/machine-spawn-unregistered-type`. There is no "spec-less spawn."
+- **Destroy is silently idempotent.** Destroying an already-gone actor is a no-op — no error, no second trace. The actor has exactly one Active → Stopped transition.
+
+For the rare case of spawning from outside a handler (true boot time), wrap the `:rf.machine/spawn` in a one-shot event and `dispatch-sync` it. Inside a machine, prefer declarative `:spawn`; inside an ordinary handler, the imperative fx is the canonical surface.
+
+---
+
+## Cooperative cancellation — teardown on every exit path
+
+This is why `:spawn` is worth using instead of firing an HTTP request from a plain handler: **the child's death is guaranteed on every code path out of its state.** The runtime destroys a spawned actor on *any* of these triggers:
+
+1. **Parent state exit** — any transition out of the `:spawn`-bearing state.
+2. **The parent's `:after` firing** — a wall-clock timeout (next section) is just a state exit.
+3. **`:spawn-all` cancel-on-decision** — surviving siblings are torn down when the join resolves.
+4. **Imperative `[:rf.machine/destroy <id>]`**.
+5. **Frame destroy** — when the [frame is torn down](glossary.md#snapshot) (e.g. the view unmounts), every surviving machine in it is destroyed. This is the "navigating away cleans up the previous screen" guarantee — you don't wire abort calls into route-leave handlers.
+
+### What auto-cancels — and what you wire by hand
+
+The runtime knows how to release exactly **three** framework-managed resource kinds on destroy, by any trigger:
+
+- **In-flight `:rf.http/managed` requests** the actor issued — aborted automatically. The reply path sees `{:kind :rf.http/aborted :reason :actor-destroyed}`. *This is the headline:* an HTTP request issued from inside a spawned actor is bound to that actor's lifetime; a request fired from a plain `reg-event` handler has no such peg and is **not** cancelled. If you want lifetime-bound HTTP, spawn a child that issues it.
+- **Armed `:after` timers** the actor scheduled — cancelled, so a killed worker won't wake up later.
+- **`:rf.resource/*` owner leases** the actor holds.
+
+> **Divergence from XState.** XState's stop-on-exit is total and substrate-agnostic — it cancels *whatever* the actor was doing. re-frame2's auto-cancel is narrower: the three kinds above, the ones the framework manages and so knows how to release. **Anything else** the child holds — a raw `setInterval`, a `js/WebSocket`, a Web Worker, a third-party SDK subscription — you release yourself, in the child's **`:exit` action**. It runs on every destroy cascade, so one line covers all five triggers:
+
+```clojure
+{:connected
+ {:entry :open-socket
+  :exit  :close-socket          ;; runs on EVERY exit, including parent-destroy
+  :on    {:disconnect :idle}}}
+```
+
+The destroy path runs the actor's `:exit` *before* dissociating its snapshot, so cleanup gets to read the final `:data`. There is no `core.async` in this path — close the host handle directly, don't reach for a channel close. (The websocket example keeps its mock socket in a host-side atom and leans on actor-destroy plus a mock that holds no real OS resource; a real `js/WebSocket` would `.close()` in `:exit`.)
+
+The [long-running-work example](../../examples/patterns/long_running_work/) shows the cascade end-to-end: the user hitting **Cancel** dispatches `:cancel`, which leaves the `:working` state, and *that exit* fires a single `:rf.machine/destroy` that takes every still-running child with it — pending `:after` yield-timers and all. The author wrote no per-child teardown.
+
+---
+
+## Wall-clock timeouts — use the parent state's `:after`
+
+"The whole activity must finish within N seconds, spanning any internal retries." There is **no `:timeout-ms` slot** on `:spawn` (it's rejected at registration). The answer is the [`:after`](concepts.md#guards-and-actions) primitive on the `:spawn`-bearing state — one timer mechanism, not two:
+
+```clojure
+{:authenticating
+ {:spawn {:machine-id :rf.http/managed
+          :data       {:request {:method :post :url "/api/login" :body credentials}}}
+  :after {30000 :auth-failed}      ;; wall-clock guard — spans the child's retries
+  :on    {:succeeded      :authenticated
+          :user/cancelled :idle}}}
+```
+
+The timer is anchored to `:authenticating`'s **entry**, so it bounds the child's whole lifetime no matter how many times the child retries internally. When it fires, the state exits and the standard cancellation cascade destroys the in-flight child (aborting its HTTP). Three independent triggers — the user cancels, 30s elapses, or the frame is torn down — all route through the *same* teardown.
+
+> The same guard has a named-intent spelling, `:timeout "PT30S"` + `:on-timeout {:target :auth-failed}` (ISO-8601 durations), which **lowers onto the same `:after` timer**. Use whichever reads better; they're one mechanism. (XState's `"5s"` shorthand isn't accepted — ISO-8601 or integer milliseconds.)
+
+---
+
+## Fan-out and join with `:spawn-all`
+
+When a state needs to spawn **N children in parallel** and resume on a join condition — boot hydration, parallel asset loads, a swarm of workers — use `:spawn-all`. The [long-running-work example](../../examples/patterns/long_running_work/) is the canonical case: one parent coordinator spawns a worker per shard and joins when all are done.
+
+```clojure
+(rf/reg-machine :work/flow
+  {:initial :idle
+   :data    {:progress {}}
+   :states
+   {:idle
+    {:on {:start {:target :working :action :reset-progress}}}
+
+    :working
+    {:spawn-all
+     {:children        [{:id :s1 :machine-id :work/processor :data {:shard :s1 :total 100}}
+                        {:id :s2 :machine-id :work/processor :data {:shard :s2 :total 100}}
+                        {:id :s3 :machine-id :work/processor :data {:shard :s3 :total 100}}]
+      :join            :all                   ;; or :any, {:n N}, {:fn pred}
+      :on-child-done   :work/child-done       ;; keyword each child dispatches on success
+      :on-child-error  :work/child-error      ;; ...and on failure
+      :on-all-complete [:work/all-done]        ;; parent event when :all resolves
+      :on-any-failed   [:work/any-failed]}     ;; parent event when a child fails
+     :on {;; A child checking in — no :target makes it an internal self-transition,
+          ;; so the children aren't re-spawned and aren't torn down.
+          :progress        {:action :record-progress}
+          ;; The join landing back in the parent as an ordinary event:
+          :work/all-done   {:target :complete  :action :stamp-outcome}
+          :work/any-failed {:target :error     :action :stamp-outcome}
+          ;; The user pulling the plug — leaving :working destroys every child:
+          :cancel          {:target :cancelled :action :stamp-outcome}}}
+
+    :complete  {:on {:reset {:target :idle}}}
+    :cancelled {:on {:reset {:target :idle}}}
+    :error     {:on {:reset {:target :idle}}}}})
+```
+
+**The child completion protocol.** Each child is an ordinary machine. When it finishes, its terminal state dispatches the parent's `:on-child-done` keyword, carrying its own `:id`:
+
+```clojure
+;; In the child (:work/processor), at its terminal state:
+:done {:entry (fn [{data :data}]
+                {:fx [[:dispatch [:work/flow [:work/child-done (:shard data)]]]]})}
+```
+
+The runtime intercepts these at the parent's boundary, updates join state, and once the condition resolves, fires the parent event (`:on-all-complete` here) **and** cancels any siblings still in flight (`:cancel-on-decision?` defaults to `true`). The bookkeeping — who's done, who failed, the resolution latch — is **runtime-owned** at `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]`; the parent keeps none of it in `:data`.
+
+A few rules worth knowing:
+
+- **Each child needs a unique `:id`** (the join key) on top of the usual spawn keys. Duplicate ids are a registration error.
+- **Join discriminators:** `:all` (default), `:any`, `{:n N}`, or `{:fn (fn [{:keys [done failed]}] …)}`. `:on-all-complete` is required for `:all`; `:on-some-complete` is required for the partial-success kinds.
+- **An unregistered child type fails the whole join closed** before any join-state is seeded — a child that can never run can never deadlock an `:all` join.
+- **Wall-clock timeout:** same as single `:spawn` — an `:after` on the `:spawn-all`-bearing state. When it fires, the exit cascade cancels every surviving child.
+
+> **Coming from XState:** there's no single XState primitive for this — you'd `invoke` several actors and coordinate `onDone` by hand, or model an explicit parallel region. `:spawn-all` packages the fan-out, the join condition, and the cancel-on-resolution cascade into one declaration.
+
+---
+
+## Further reading
+
+- **Normative spec:** [Spec 005 — State Machines](../../spec/005-StateMachines.md), sections *Spawning — dynamic actors*, *Declarative `:spawn`*, *Cancellation cascade*, and *Spawn-and-join via `:spawn-all`* — the exhaustive contract (ordering, error taxonomy, the runtime spawn registry, the uniform reply envelope).
+- **API:** [`re-frame.machines`](../api/re-frame.machines.md) — `reg-machine`, the reserved `:rf.machine/spawn` / `:rf.machine/destroy` / `:rf.machine/dispatch-to-system` effects, and `machine-by-system-id`.
+- **Sibling guides:** [Concepts](concepts.md) for the transition table and [final states](concepts.md#final-states-when-a-machine-is-done) (the `:on-done` / `:on-error` completion story); [Coming from XState](coming-from-xstate.md) for the actor-vs-handler delta; the [Glossary](glossary.md#spawn); and the runnable [Examples](examples.md).
+- **The broader idea:** these features realise concepts from the statechart and actor-model literature — see the [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) (the parity reference re-frame2 maps behaviour from) and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/) (a sibling Clojure statechart implementation).

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -1,0 +1,251 @@
+# Automatic transitions
+
+Most [transitions](glossary.md#transition) wait for the world: a user clicks, an HTTP reply lands, a timer you wired by hand goes off. An **automatic transition** is one the [machine](glossary.md#machine) takes *on its own*, with no external event — the instant a condition becomes true, or a deadline passes, the [snapshot](glossary.md#snapshot) moves.
+
+These are the statechart features that let a machine *drive itself*: a form that routes the moment it's validated, a splash screen that dismisses after three seconds, a reconnect that backs off and retries, a request that gives up after ten. Without them you reach for the same fragile pattern every time — a `setTimeout` paired with a cancel flag, or a synthetic event you `dispatch` by hand from every place that could enable the next step. re-frame2 turns each of those into one declarative key on a state node.
+
+There are four authoring grammars, and underneath them just **two engines**:
+
+| You want… | Reach for | Fires when | In XState |
+|---|---|---|---|
+| "the instant condition X holds, go to Y" | `:always` | a guard turns true, re-checked after every transition into the state | `always` (SCXML calls it *transient*) |
+| "a decision node that routes on entry and never lingers" | `:type :choice` | entry — first guard-passing candidate wins | a *choice* / transient state |
+| "after N ms in this state, do Z" | `:after` | a wall-clock delay measured from state entry elapses | `after` (delayed transitions) |
+| "this state (or its child) must finish in time" | `:timeout` / `:on-timeout` | a fixed deadline from entry passes | an `after` transition, named |
+
+> **Four grammars, two engines.** `:type :choice` is sugar that **desugars to `:always`**; `:timeout` / `:on-timeout` is sugar that **desugars to `:after`**. So everything on this page runs on one of two mechanisms: the **guard-driven microstep loop** (`:always`, `:choice`) and the **wall-clock timer** (`:after`, `:timeout`). One fact, one mechanism — the extra grammars exist only to *name the author's intent* so tools and diagrams can read it.
+
+Everything below assumes the core loop from the [concepts guide](concepts.md#registering-and-running-it): a machine is registered with `reg-machine`, its transition table is data, a [guard](glossary.md#guard) returns a boolean, an [action](glossary.md#action) returns the data-shaped effect map `{:data … :fx …}` (the `:data` is *merged* into the snapshot, key by key), and the live value is a snapshot `{:state … :data … :tags …}`. New to all that? Read [Guards, actions, tags, and `:after` — the recognition kit](concepts.md#guards-and-actions) first.
+
+## Eventless `:always` — fire the instant a condition holds
+
+`:always` is a state-node key holding a vector of guarded transitions. It is checked **after entry** — and after *any* transition that lands in the state — and the first guard that passes fires immediately, no event required. It answers "the snapshot just changed; if X is now true, move on" without you hand-raising a synthetic event from every action that could enable X.
+
+Here is the canonical shape — a quiz that ends the moment enough answers are correct:
+
+```clojure
+(rf/reg-machine :quiz
+  {:initial :asking
+   :data    {:correct-count 0}
+   :guards  {:enough-correct? (fn [{:keys [data]}] (>= (:correct-count data) 10))}
+   :actions {:count-correct   (fn [{:keys [data]}]
+                                {:data {:correct-count (inc (:correct-count data))}})}
+   :states
+   {:asking {:always [{:guard :enough-correct? :target :winner}]
+             :on     {:answer-correct {:action :count-correct}   ;; no :target — stays :asking
+                      :answer-wrong   {:target :loser}}}
+    :winner {}
+    :loser  {}}})
+```
+
+When you `(rf/dispatch [:quiz [:answer-correct]])`, two things happen inside **one** machine event:
+
+1. `:asking`'s `:answer-correct` transition runs `:count-correct`, which bumps `:correct-count`. There is no `:target`, so this is an internal transition — the snapshot stays at `:asking`.
+2. The runtime immediately re-checks `:asking`'s `:always`. If `:correct-count` has now reached 10, `:enough-correct?` is true and the machine transitions to `:winner`.
+
+External observers see `:asking → :winner` in one step. The "answer counted, still asking" intermediate state is **invisible** — exactly the property `:always` exists to provide.
+
+### The mental model: settle, then commit once
+
+`:always` extends the event [cascade](../core/concepts/events-and-the-cascade.md): after the triggering transition, the runtime runs a **microstep loop** that keeps taking enabled `:always` transitions (and draining any [`:raise`](../api/re-frame.machines.md)d internal events) until it reaches a **fixed point** — no `:always` guard matches and no raised event is pending. Only then does it commit the snapshot, **once, atomically**, and emit the accumulated `:fx`.
+
+This is classic statechart **macrostep** semantics: the externally-observable transition is the *settled* result of an internal cascade of microsteps. Time-travel, [Xray](../core/concepts/observability.md), and undo all see the single committed transition; the inner microsteps ride the trace stream for tools that want them.
+
+> **It runs at birth, too.** The same settle loop runs when the machine first starts. If the [`:initial`](concepts.md#registering-and-running-it) state cascades into a leaf whose `:always` guard already holds, that transition is taken *before* the birth commit — so a transient initial state is settled past, unobserved, on start. (This is also why `:always` lives on a state node, never on the root: the root's cascade entry-point is `:initial`.)
+
+### Ordering, depth, and self-loops
+
+A few rules keep the loop well-behaved — and keep your typos loud at registration time, not on the unlucky dispatch:
+
+- **`:always` settles before the next raised event.** If an action both `:raise`s an event `R` and lands in a state whose `:always` is enabled, the `:always` is taken **first**; `R` is then handled in the post-`:always` state. Raised events otherwise drain FIFO. (This matches XState v5/SCXML exactly.)
+- **Bounded depth.** The loop is capped (default **16** microsteps, configurable as `:always-depth-limit` at frame-config level). A non-converging cycle trips `:rf.error/machine-always-depth-exceeded` and **fails the whole macrostep** — the snapshot is never written, so the transition rolls back atomically. It is a failure, not a silent no-op, so a runaway cycle is distinguishable from an ordinary guard-blocked decline.
+- **No self-target.** An `:always` whose `:target` resolves to its own declaring state is **rejected at `reg-machine` time** (`:rf.error/machine-always-self-loop`) — guarded or not. An eventless transition back into the state you just entered either loops to the depth limit or is a no-op; either way the author meant something else.
+
+> **Looping until a condition clears.** The legitimate "keep going while there's work" shape is a **targetless** guarded `:always` with an `:action` — `{:guard :more? :action :drain-one}`. Its action flips the guard false and the loop settles. That is *not* a self-loop (there's no `:target`), so it's allowed.
+
+### `:always` in the wild
+
+The [WebSocket example](../../examples/patterns/websocket/README.md) uses `:always` for two distinct jobs on two different states:
+
+```clojure
+:reconnecting
+{:always [{:guard :max-retries-exceeded? :target :failed}]   ;; out of retries → give up
+ :after  {…}                                                  ;; otherwise back off and retry
+ :on     {…}}
+
+:connected
+{:entry  :flush-queue-and-resubscribe
+ :always [{:guard :has-queued-messages? :action :flush-queue}]  ;; drain the offline queue on entry
+ :on     {…}}}
+```
+
+Note that `:reconnecting` carries **both** `:always` and `:after` — they're independent state-node slots and coexist freely. And `:connected`'s `:always` is the targetless-action form: its `:flush-queue` action clears the queue, the guard goes false, and the microstep loop settles — no extra state needed.
+
+> **Coming from XState.** XState calls these `always` transitions (SCXML's *transient* transitions); re-frame2 keeps the name `:always`. Same idea, same first-match-wins ordering. `:always` is **not** a substitute for `:after`: `:always` fires on guard *truth*, `:after` fires on elapsed *time*.
+
+## `:type :choice` — a decision node that never lingers
+
+A **choice state** is a routing node: enter it, walk its guarded candidates in order, take the first whose guard passes, and leave — all within the same macrostep, no event needed. It's how you draw "decide which way to go" as an explicit node on the chart.
+
+```clojure
+(rf/reg-machine :submission
+  {:initial :idle
+   :data    {}
+   :guards  {:valid? (fn [{:keys [data]}] (boolean (:form-ok? data)))}
+   :states
+   {:idle     {:on {:submit :checking}}
+    :checking {:type   :choice
+               :choice [{:guard :valid? :target :accepted}
+                        {:target :rejected}]}     ;; unguarded final = the default / else branch
+    :accepted {}
+    :rejected {}}})
+```
+
+Dispatching `[:submission [:submit]]` enters `:checking`, which resolves **immediately**: if `:valid?` passes the machine settles at `:accepted`, otherwise it falls through to the default `:rejected`. External observers never see `:checking` — it's a transient routing node. (A choice state may also be the machine's `:initial` state, in which case it resolves at birth.)
+
+Under the hood, `:type :choice` / `:choice` **desugars to an ordinary state with an `:always` slot** carrying the same candidate vector. The candidate walk, first-guard-pass select, and macrostep settle are all the `:always` machinery you just met — reused, not reinvented. `:choice` exists to *name the intent* so a visualiser renders a decision diamond and validation gives a clearer grammar.
+
+### Divergence: a declarative array, not a `choice` function
+
+> **This is a deliberate departure from XState.** XState lets a choice/transient state's routing be expressed as a `choice` **function**. re-frame2 **rejects that**: a function may never be the edge. `:choice` is a **declarative guarded-candidate array** `[{:guard … :target …}]` — the edge topology stays *data*, so diagrams, model tests, conformance fixtures, and AI tools can read the routing without executing it. A function-valued `:choice` fails loud at registration with `:rf.error/machine-bad-choice`. This is behavioural parity (an immediate routing node) without API-mimicry (the JS function form) — see [Where it diverges](coming-from-xstate.md#where-it-diverges--and-why).
+
+### What the runtime checks
+
+`reg-machine` validates the choice grammar on the raw spec, so a mistake is caught before the machine ever runs:
+
+- `:type :choice` and `:choice` **require each other** — one without the other is meaningless.
+- The `:choice` value **must be a non-empty vector of candidate maps** (not a fn, keyword, or empty vector).
+- The vector **must include an unguarded default** candidate. Without one, a `:checking` entered with every guard failing would have nowhere to go — a stuck transient node. A present default is the only static guarantee the state always resolves.
+- A choice state **only routes** — it may not also declare `:entry`, `:on`, `:after`, `:timeout`, `:spawn`, and so on. (So a choice state can never carry a `:timeout`; the two named-intent grammars don't combine.)
+- A candidate targeting the choice state's own state is a self-loop and is rejected, exactly as for `:always`.
+
+## Delayed `:after` — transition after a wall-clock delay
+
+`:after` is a state-node key mapping a **delay** to a transition. Entering the state arms every timer; leaving the state cancels them. On expiry, the matching transition fires (subject to its guard). It replaces the `dispatch-later`-plus-cancel-flag pattern that sits behind most timeout, debounce, and reconnect bugs.
+
+The simplest case — a splash screen that dismisses itself after three seconds, or sooner if the user skips:
+
+```clojure
+(rf/reg-machine :boot
+  {:initial :splash
+   :states
+   {:splash {:after {3000 :main}        ;; 3000 ms → :main
+             :on    {:skip :main}}       ;; …or the user clicks "skip"
+    :main   {:on {:restart :splash}}}})
+```
+
+`{3000 :main}` is sugar for `{3000 {:target :main}}` — the delay's value uses the **same** transition grammar as an `:on` clause.
+
+### What goes in the `:after` map
+
+Each entry is `<delay> → <transition>`. Both halves take several forms.
+
+**The delay (the key) — three forms:**
+
+- **Integer milliseconds** — `{30000 :timeout}`. The common fixed delay. (Note: a literal `:after` delay is **integer ms only** — not an ISO-8601 string, and *never* the `"5s"` shorthand. Those belong to `:timeout`, below.)
+- **A [subscription](../core/concepts/subscriptions.md) vector** — `[:sub-id & args]`, resolved like any `subscribe`. The canonical form for an **app-state-derived** delay (a user preference, a feature-flag config). It *re-resolves* when its value changes (see below).
+- **A function** — `(fn [{:keys [snapshot]}] ms)`, called **once** at state entry. The escape valve for a delay computed from the machine's own `:data`.
+
+> **Watch the shape.** Guards and actions receive `:data` at the top level of their context map; an `:after` delay-fn instead receives `{:keys [snapshot]}` and reaches *inside* it — `(-> snapshot :data :retry-count)`. The snapshot is the familiar `{:state … :data … :tags …}` value.
+
+**The transition (the value) — identical to an `:on` clause:** a bare keyword (sugar for `{:target kw}`), a full transition map `{:guard … :target … :action … :meta …}`, or a first-guard-pass-wins candidate vector. If a `:guard` is present and false at expiry, the transition is **suppressed** — the timer is "fired and discarded", the snapshot is unchanged, a `:rf.machine.timer/fired` trace records `:fired? false`, and *other in-flight timers keep running*.
+
+```clojure
+;; All three delay forms, on one state node:
+{:loading
+ {:after {30000                        {:target :timeout :guard :no-progress?}   ;; literal ms
+          [:sub :timeout-config :slow] {:target :warn :action :log-slow}          ;; subscription
+          (fn [{:keys [snapshot]}] (* 1000 (-> snapshot :data :retry-count)))
+                                       :retry}                                     ;; local fn
+  :on    {:loaded :ready
+          :failed :error}}}
+```
+
+### One timer per entry, counted from entry
+
+Every `:after` timer counts independently from the moment the machine **enters the state**. A state with `{:after {5000 :warn 30000 :timeout}}` arms *both* timers at entry, concurrently — the 5 s timer is not chained off the 30 s one. Re-entering the state restarts every timer fresh; there's no preserved "elapsed-so-far".
+
+A state can have several triggers racing at once — multiple `:after` timers, the state's `:on` events, an `:always`, a [spawned](glossary.md#spawn) child completing. **Whichever fires first wins**; the resulting state exit cancels the rest as part of the normal exit cascade.
+
+> **A same-tick tie diverges from XState.** When two `:after` timers with different delays happen to fire in the same scheduler tick, the order they reach the router is the *host scheduler's* order — not document order. XState/SCXML resolve simultaneously-enabled transitions by document order; re-frame2 `:after` timers are real host-clock deferred events, so it's "first valid timer to arrive wins; the transition makes the rest stale." Don't rely on declaration order to break a same-tick `:after` tie.
+
+### No cancel flag: epoch-based staleness
+
+re-frame2 ships **no `:cancel-dispatch-later` fx**, and you never write one. Here's why that's safe — and it's the headline reason to prefer `:after` over hand-rolled timers.
+
+Every scheduled timer carries an **epoch** — a per-state-entry counter — captured when it's armed. Leaving the state advances that state's epoch. When a timer eventually fires, the runtime compares the carried epoch against the state's current one:
+
+- **Match** → the state is still the one that armed this timer; fire the transition.
+- **Mismatch** → the state was exited (or re-entered, arming a fresh timer); **silently drop it** and emit a `:rf.machine.timer/stale-after` trace.
+
+So a timer armed on an earlier visit can never "wander in" and fire against a state you've since left. There's nothing to remember and nothing to clean up: the epoch makes a late timer self-cancelling. The epoch is tracked **per scheduling node** (the declaring state's path), so a parent's long `:after` survives a leaf-to-sibling transition underneath it, while the exited leaf's timers go stale — a parent's 30 s hard-timeout ticks happily alongside a child's 5 s progress timeout.
+
+### Delays that track app state
+
+A **subscription-vector** delay re-resolves while it's in flight. If the underlying sub value changes, the runtime cancels the current timer and **restarts from now** with the freshly-resolved delay (it does *not* extend or shorten the running timer — restart-from-now keeps the countdown always reflecting the current value). The epoch mechanism backstops the cancellation, and a paired `:rf.machine.timer/cancelled` (`:reason :on-resolution`) → `:rf.machine.timer/scheduled` shows up on the trace stream.
+
+A **function** delay does **not** re-resolve — it's computed once at entry. If you need a `:data`-derived delay that re-resolves on change, use the subscription form (over a sub that reads the machine's `:data`) and pay the subscription cost; the fn form is the cheap "compute once at entry" valve.
+
+### Worked example: exponential backoff
+
+The WebSocket example's `:reconnecting` state computes its backoff from the retry count, using the function-delay form:
+
+```clojure
+:reconnecting
+{:tags   #{:websocket/reconnecting}
+ :always [{:guard :max-retries-exceeded? :target :failed}]
+ :after  {(fn [{:keys [snapshot]}]
+            (let [{:keys [retries base-ms max-backoff-ms]} (:data snapshot)]
+              (min (* base-ms (Math/pow 2 retries)) max-backoff-ms)))
+          {:target :active}}                       ;; …wait, then retry the connection
+ :on     {:ws/connect {:target :active :action :record-and-reset}
+          …}}
+```
+
+Each visit to `:reconnecting` reads the *current* `:retries` and waits longer than the last (100 ms, 200, 400, … capped at `max-backoff-ms`). The `:always` short-circuits straight to `:failed` once retries are exhausted. And because leaving `:reconnecting` cancels the timer via the epoch mechanism, a backoff armed on an earlier visit can never fire late — no flag, no cleanup. See [`connection.cljs`](../../examples/patterns/websocket/README.md) for the whole machine.
+
+### The clock, SSR, and what `:after` is *not*
+
+`:after` timers go through `re-frame.interop` (`now-ms`, `schedule-after!`, `cancel-scheduled!`) — `setTimeout`/`clearTimeout` on CLJS, a `ScheduledExecutorService` on the JVM. There's no framework-level clock-config API; tests swap the interop layer with the usual fixture patterns. Under SSR, `:after` **no-ops** — the server renders the current `:state` statically and the client re-arms timers after hydration.
+
+`:after` deliberately does **not** include: recurring timers (re-enter the state to re-arm), calendar/wall-clock-time scheduling (it's relative to *entry*, not "9 AM tomorrow"), or pause/resume (transition out and back in).
+
+> **Coming from XState.** XState calls these `after` (delayed) transitions; re-frame2 keeps the name. XState also accepts named-delay maps and a `"5s"` shorthand string — re-frame2's `:after` keys are integer-ms / subscription-vector / fn instead (see the duration note below).
+
+## `:timeout` / `:on-timeout` — a named deadline
+
+A state — or a [`:spawn`](glossary.md#spawn) spec — may declare a `:timeout` duration plus an `:on-timeout` transition. It names a single fact: "this state (or its spawned child) must finish before this time." It reads more clearly than a bare `:after` entry when the intent really is a deadline.
+
+```clojure
+{:states
+ {:waiting
+  {:timeout    "PT5S"                       ;; ISO-8601: 5 seconds
+   :on-timeout {:target :timed-out}}
+
+  :loading
+  {:spawn {:machine-id :fetch-user          ;; XState's `invoke` is re-frame2's `:spawn`
+           :timeout    "PT10S"              ;; the child must finish within 10 s…
+           :on-timeout {:target :timed-out}}}}}  ;; …or we bail
+```
+
+`:timeout` **requires** `:on-timeout` (and vice versa); a lone one of either is a registration error. The pair **desugars to an `:after` entry** keyed by the resolved-ms duration — so entering the state arms it, leaving cancels it, and all the `:after` epoch/staleness/trace machinery drives it unchanged. For a spawn timeout, the timer is anchored to the spawn-bearing state's entry, so it bounds the child's whole lifetime (across any internal retries); when it fires, the exit cascade tears the child down.
+
+`:timeout` and `:after` express different intent and **may coexist** on one state node. (A `:final?` state can't declare a `:timeout` — final means final.)
+
+### Duration grammar: integer-ms or ISO-8601
+
+A `:timeout` duration is **exactly one of**:
+
+- a **positive integer** — literal milliseconds (`5000`); or
+- an **ISO-8601 duration string** — `"PT5S"`, `"PT2M"`, `"PT1H30M"`, `"PT0.5S"`, `"P1D"`, … (the `PnYnMnWnDTnHnMnS` form; case-insensitive; fractional seconds allowed).
+
+> **Divergence from XState.** XState v6 also accepts a readable shorthand like `"10ms"` / `"5s"`. re-frame2 **rejects** it: a `"5s"` / `"10ms"` string — or any other malformed duration (a non-positive integer, a fn, a vector, the bare `"P"`) — fails **loud** at registration with `:rf.error/machine-bad-timeout-duration`. And unlike `:after`, a `:timeout` admits **no** subscription-vector or fn dynamic delays — a timeout is a fixed wall-clock deadline. The integer-ms-or-ISO-8601 rule is the single duration grammar; the shorthand string is gone on purpose.
+
+## Further reading
+
+- **Spec — [005 State Machines](../../spec/005-StateMachines.md)** is the normative contract. The sections behind this page: [Eventless `:always`](../../spec/005-StateMachines.md#eventless-always-transitions), [`:type :choice`](../../spec/005-StateMachines.md#type-choice-transient--choice-states), [Delayed `:after`](../../spec/005-StateMachines.md#delayed-after-transitions), and [`:timeout` / `:on-timeout`](../../spec/005-StateMachines.md#timeout--on-timeout-state--spawn) — for the exhaustive trace-event lists, hierarchy interactions, and the full error taxonomy.
+- **[Machines API](../api/re-frame.machines.md)** — `reg-machine`, the `[:rf/machine …]` subscription, and the reserved `:rf.machine/*` effects, including `[:raise event-vec]`.
+- **[Machines concepts](concepts.md)** and the **[glossary](glossary.md)** for the rest of the model; **[Coming from XState](coming-from-xstate.md)** for the full v6 parity delta.
+- **[WebSocket example](../../examples/patterns/websocket/README.md)** — a runnable machine using `:after` backoff and `:always` cascades together.
+
+These four features realise long-standing statechart ideas — eventless/transient transitions, choice pseudostates, and delayed transitions. For the broader theory they map from, see the [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/).

--- a/docs/machines/coming-from-xstate.md
+++ b/docs/machines/coming-from-xstate.md
@@ -13,28 +13,367 @@ And one thing genuinely shifts:
 
 If you internalise just that last bullet, the table below is mostly vocabulary.
 
+> **Parity reference: the XState v6 direction.** Where this page says "XState," the behavioural baseline is the **v6** design direction (plain guard/action functions over a declarative topology, broader optional schemas, explicit timeouts, choice states, private internal events, event-shaped completion) — not v5's helper-creator API. The posture is *behavioural parity, not API mimicry*: re-frame2 aligns semantics and records each intentional divergence rather than cloning JavaScript runtime shapes. When your training recalls a v5 helper (`assign`, `sendTo`, `raise`, `and`/`or`/`not`/`stateIn`, `setup()`), reach for the data-first re-frame2 form below.
+
 ## The mapping
 
-| XState (v5 / v6) | re-frame2 | Notes |
+Skim this, then read the worked build-up in [The grammar, concept by concept](#the-grammar-concept-by-concept). The exhaustive API contract is the [`re-frame.machines` reference](../api/re-frame.machines.md) — this page teaches; that page enumerates.
+
+| XState (v6 direction) | re-frame2 | Notes |
 |---|---|---|
 | `createMachine({ ... })` / `setup().createMachine()` | a transition-table map passed to [`reg-machine`](concepts.md#registering-and-running-it) | Plain Clojure data. No builder, no fluent API. |
-| `context` (extended state) | [`:data`](concepts.md#the-same-flow-as-a-transition-table) | Same idea. "Context" was already taken (interceptor context, React context). |
+| `context` (extended state) | [`:data`](#context-becomes-data) | Same idea. "Context" was already taken (interceptor context, React context); `:data` tracks FSM / `gen_statem` "state data". |
+| `state.value` | the snapshot's `:state` | Flat → keyword; compound → vector path; parallel → region-name→keyword map. |
 | `states: { idle: { on: { ... } } }` | `:states {:idle {:on {...}}}` | Near-identical shape. `on` → `:on`, target strings → state keywords. |
-| `guard: 'canRetry'` | `:guard :under-retry-limit` | Named; defined once in the spec's [`:guards`](concepts.md#guards-actions-tags-and-after--the-recognition-kit) map. Idiomatic Clojure name (`?`-suffixed predicate), not a JS boolean string. |
-| `actions: assign({...})` / effectful actions | `:action :record-error` returning `{:data ... :fx ...}` | Defined once in [`:actions`](concepts.md#guards-actions-tags-and-after--the-recognition-kit). An action **returns** an [effect map](../core/glossary.md#effect-map) — it doesn't mutate. More below. |
-| `tags: ['busy']` + `state.hasTag('busy')` | `:tags #{:auth/busy}` + `[:rf/machine-has-tag? id :auth/busy]` | A Clojure set; the membership question is a [subscription](../core/glossary.md#subscription). See [state tag](glossary.md#state-tag). |
-| `after: { 5000: 'next' }` | `:after {5000 {:target :next}}` | Same declarative timer; same auto-cancel on exit. ISO-8601 strings (`"PT5S"`) accepted; XState's `"5s"` shorthand is not. |
-| `always: [{ guard, target }]` | `:always [{:guard … :target …}]` | Eventless transitions, same firing rule. |
-| `reenter: true` | `:reenter? true` | External self-transition. Same semantics; Clojure `?`. |
-| `final: true` + `output` | [`:final? true`](concepts.md#final-states-when-a-machine-is-done) + `:output-key` | A finishing leaf reports a value to its parent's `:on-done`. |
-| `invoke: { src: childMachine }` | [`:spawn {:machine-id …}`](glossary.md#spawn) | Start a child on entry, tear down on exit. Renamed; see below. |
-| `raise({ type: ... })` | `:fx [[:raise [:event …]]]` | Loop an event back into *this* machine, atomically, pre-commit. |
+| nested states (`initial` + `states`) | [`:initial` + `:states` on a state node](#compound-nested-states) | Deepest-wins resolution, parent fall-through. Keyword target = sibling; vector target = absolute path. |
+| `guard: 'canRetry'` | `:guard :under-retry-limit` | Named; defined in the spec's [`:guards`](#guards) map. Idiomatic Clojure name (`?`-suffixed predicate), not a JS boolean string. |
+| `actions: assign({...})` / effectful actions | [`:action :record-error`](#actions-assign-and-the-effect-map) returning `{:data ... :fx ...}` | An action **returns** an [effect map](../core/glossary.md#effect-map) — it doesn't mutate. More below. |
 | `setup({ guards, actions })` registry | per-spec `:guards` / `:actions` maps | Each machine carries its own. Cross-machine reuse is an ordinary Clojure var, not a string registry. |
-| TypeScript `types` / v6 `schemas` | [`:schemas {:data …}`](concepts.md#validating-a-machines-data) | A [Malli schema](../core/glossary.md#schema) — but one that **actually runs in dev** and rolls a bad transition back, not erased-at-compile types. |
+| `tags: ['busy']` + `state.hasTag('busy')` | [`:tags #{:auth/busy}`](#tags) + `[:rf/machine-has-tag? id :auth/busy]` | A Clojure set; the membership question is a [subscription](../core/glossary.md#subscription). See [state tag](glossary.md#state-tag). |
+| `after: { 5000: 'next' }` | [`:after {5000 {:target :next}}`](#delayed-transitions-after-and-timeout) | Same declarative timer; same auto-cancel on exit. ISO-8601 strings (`"PT5S"`) accepted; XState's `"5s"` shorthand is **not**. |
+| `always: [{ guard, target }]` | [`:always [{:guard … :target …}]`](#eventless-transitions-always) | Eventless transitions, same firing rule. |
+| state/actor `timeout` / `onTimeout` | [`:timeout`/`:on-timeout`](#delayed-transitions-after-and-timeout) | A named deadline that lowers onto `:after`. ms or ISO-8601; `"5s"` shorthand rejected. |
+| `type: 'choice'` / a `choice` **function** | [`:type :choice` + `:choice [...]`](#choice-states) | A declarative candidate **array**, never a function. See divergence #4. |
+| v6 `internalEvents: [...]` | [`:internal-events #{...}`](#internal-events) | A Clojure **set**, not an array. Private events the machine raises and handles itself. |
+| `reenter: true` | `:reenter? true` | External self-transition. Same semantics; Clojure `?`. |
+| `type: 'parallel'` | [`:type :parallel` + `:regions {...}`](#parallel-states) | Regions, not `states`. `:data` shared, `:tags` unioned, `:state` becomes a region→state map. |
+| `type: 'history'` (`history: 'deep'`) | [`:type :history` (`:deep? true`)](#history-states) | A pseudo-state under a compound's `:states`. Shallow by default. |
+| `type: 'final'` + `output` | [`:final? true`](#final-states-and-output) + `:output-key` | A finishing leaf reports a value to its parent's `:on-done`. `output` is a *key*, not a fn. |
+| `invoke: { src: childMachine }` | [`:spawn {:machine-id …}`](#invoke-becomes-spawn) | Start a child on entry, tear down on exit. Renamed; see below. |
+| `invoke … onError` (a transition) | `:spawn`'s `:on-error` transition + `:error? true` leaf | First-class control flow, not observability-only. |
+| multiple `invoke` per state / fan-out | `:spawn-all` (named children + join + cancel policy) | One `:spawn` per state; fan-out is its own surface. |
+| `raise({ type: ... })` | `:fx [[:raise [:event …]]]` | Loop an event back into *this* machine, atomically, pre-commit. |
+| `sendTo` / `sender` (reply to a request) | the reply event carried in the request vector | No new API; the request names its own reply target. |
+| TypeScript `types` / v6 `schemas` | [`:schemas {:data … :output …}`](#schemas-types-that-actually-run) | A [Malli schema](../core/glossary.md#schema) — but one that **actually runs in dev** and rolls a bad transition back, not erased-at-compile types. |
+| three creation modes (`createActor` / `invoke` / `spawn`) | one mechanism: singleton via `reg-machine`, dynamic via `:spawn` / `[:rf.machine/spawn …]` | Lifetime is the snapshot's presence in [runtime-db](../core/glossary.md#runtime-db), not which constructor you called. |
 | **`createActor(m).start()` → `actor.send(ev)`** | **the machine is an event handler → `(rf/dispatch [machine-id [event]])`** | **The big one.** No actor object; one [`dispatch`](../core/glossary.md#dispatch), one [cascade](../core/glossary.md#event-cascade). |
-| `actor.getSnapshot()` | `@(rf/subscribe [:rf/machine id])` | The [snapshot](glossary.md#snapshot) is a value in [runtime-db](../core/glossary.md#runtime-db), read like any other derived state. |
+| `actor.getSnapshot()` | [`@(rf/subscribe [:rf/machine id])`](#reading-the-snapshot) | The [snapshot](glossary.md#snapshot) is a value in [runtime-db](../core/glossary.md#runtime-db), read like any other derived state. |
 
-A condensed five-row version of this lives at the foot of the [machines concepts page](concepts.md#coming-from-xstate-the-five-row-delta); this one is the long form, and the section below is the part worth your attention.
+A condensed five-row version of this lives at the foot of the [machines concepts page](concepts.md#coming-from-xstate-the-five-row-delta); this one is the long form, and the two sections below — the worked build-up and the *why* essays — are the part worth your attention.
+
+## The grammar, concept by concept
+
+The table is the map; this section is the territory. Each piece below shows the XState shape you know, then the re-frame2 shape it becomes, built from one running example — the login flow from the [machines guide](concepts.md). Every snippet is real API; nothing here is invented.
+
+### The machine definition
+
+In XState you build a machine with `createMachine` — and in v6 a `setup()` registry holds the guards/actions and types:
+
+```js
+import { setup, assign } from 'xstate';
+
+const loginMachine = setup({
+  guards:  { underRetryLimit: ({ context }) => context.attempts < 3 },
+  actions: { /* … */ },
+}).createMachine({
+  initial: 'idle',
+  context: { attempts: 0, error: null },
+  states:  { idle: { on: { SUBMIT: 'submitting' } } /* … */ },
+});
+```
+
+In re-frame2 the definition is *just data* — one map, with its `:guards` and `:actions` tables carried inline, registered with [`reg-machine`](concepts.md#registering-and-running-it):
+
+```clojure
+(rf/reg-machine :auth.login/flow
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
+
+   :guards
+   {:under-retry-limit (fn [{:keys [data]}] (< (:attempts data) 3))}
+
+   :actions
+   {:clear-error  (fn [_] {:data {:error nil}})
+    :issue-request (fn [{[_ creds] :event}] {:fx [[:rf.http/managed { … }]]})
+    :record-error  (fn [{data :data [_ {:keys [failure]}] :event}]
+                     {:data (-> data (update :attempts inc)
+                                     (assoc :error (or (:message failure) "Login failed.")))})
+    :store-session (fn [{[_ {:keys [value]}] :event}]
+                     {:fx [[:auth.session/store {:token (:token value)}]]})}
+
+   :states
+   {:idle        {:on {:auth.login/submit {:target :submitting :action :clear-error}}}
+    :submitting  {:tags  #{:auth/busy}
+                  :entry :issue-request
+                  :on    {:auth.login/success {:target :authed :action :store-session}
+                          :auth.login/failure [{:target :error-shown
+                                                :guard  :under-retry-limit
+                                                :action :record-error}
+                                               {:target :locked-out}]}}
+    :error-shown {:on {:auth.login/dismiss :idle
+                       :auth.login/submit  :submitting}}
+    :authed      {}
+    :locked-out  {}}})
+```
+
+In XState the definition is built by a function call and a `setup()` registry; in re-frame2 it's a literal map with no builder and no global registry — `reg-machine` is sugar over `reg-event`, so the machine *is* an [event handler](../core/glossary.md#event-handler). That single fact (divergence [#1](#1-a-machine-is-an-event-handler-not-an-actor) below) is why you drive it with `dispatch`, not `actor.send`, and why the whole thing being *data* means it [tests on the JVM](#reading-the-snapshot) as pure function calls. Source-coord stamping for tooling is why you reach for the `reg-machine` macro over the plain `reg-machine*` fn — see the [API reference](../api/re-frame.machines.md).
+
+### Context becomes :data
+
+A snapshot is the live value of a machine — the XState `{ value, context }` pair:
+
+```js
+// state.value   === 'submitting'
+// state.context === { attempts: 1, error: null }
+```
+
+```clojure
+;; the re-frame2 snapshot:
+{:state :submitting :data {:attempts 1 :error nil}}
+```
+
+Same split — a discrete `:state` (XState's `state.value`) plus extended memory `:data` (XState's `context`). In XState this slot is `context`; in re-frame2 it is `:data`, because re-frame already spends the word "context" on the interceptor context and React context, and `:data` tracks the FSM / Erlang `gen_statem` "state data" tradition. The divergence is name-only.
+
+### Actions, assign, and the effect map
+
+This is the deepest behavioural shift, so it's worth slowing down. XState's `assign(...)` is an action *creator* that imperatively updates `context`, and an effectful action *runs* its side effect when invoked:
+
+```js
+actions: assign({ attempts: ({ context }) => context.attempts + 1 }),  // the "assign"
+// and, separately, an effectful action that performs a fetch when invoked.
+```
+
+re-frame2 inverts this. An action is a pure function that **returns** the same data-shaped [effect map](../core/glossary.md#effect-map) a `reg-event` handler returns — `:data` (merged into the snapshot) and/or `:fx` (a *description* of work the effects machinery runs):
+
+```clojure
+:record-error
+(fn [{data :data}] {:data (update data :attempts inc)})       ;; this IS the "assign"
+
+:issue-request
+(fn [{[_ creds] :event}]
+  {:fx [[:rf.http/managed {:request    {:method :post :url "/api/login" :body creds}
+                           :on-success [:auth.login/flow [:auth.login/success]]
+                           :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
+```
+
+In XState you reach for the `assign` helper-creator; in re-frame2 returning `{:data ...}` *is* the assignment — there is no `assign`, and no `[:assign {...}]` form (full *why* in divergence [#3](#3-actions-return-effects-they-dont-perform-them) below). XState v6 is itself moving away from `assign`'s special status toward plainer functions, which is roughly where re-frame2 started. Note `:on-success [:auth.login/flow [:auth.login/success]]` above: the HTTP reply lands back *inside the machine* as an ordinary event ([the uniform reply](../core/glossary.md#the-uniform-reply) appends the payload), so a machine and an async surface compose with no `invoke`-promise bridge.
+
+### Guards
+
+A guard is a yes/no test gating a transition. In XState v5 you name it and define it in `setup()`:
+
+```js
+on: { FAILURE: [{ guard: 'underRetryLimit', target: 'errorShown' }, { target: 'lockedOut' }] }
+```
+
+```clojure
+:guards {:under-retry-limit (fn [{:keys [data]}] (< (:attempts data) 3))}
+;; …on the :submitting node:
+:on {:auth.login/failure [{:guard :under-retry-limit :target :error-shown :action :record-error}
+                          {:target :locked-out}]}
+```
+
+Same guarded candidate vector, first-pass-wins — identical to XState's transition array. A guard (like an action) receives **one context map** and destructures what it needs: `(fn [{:keys [data event state meta]}] …)`. **Divergence:** there is no `{and: [...]}` / `stateIn` data combinator (XState v6 dropped the v5 `and`/`or`/`not`/`stateIn` creators, which re-frame2 never had) — a compound condition goes in one *named* function, so the *name* is what a diagram arrow and an AI read; cross-region coordination uses [tags](#tags). A guard or action that needs a host fact (the clock, a random draw) [declares it as a coeffect](concepts.md#guards-and-actions) rather than calling `(js/Date.now)`, so the decision replays identically under time-travel.
+
+### Reading the snapshot
+
+In XState you reach into the actor object; in re-frame2 you subscribe, because the snapshot is a plain value in the frame's [runtime-db](../core/glossary.md#runtime-db):
+
+```js
+const snap = actor.getSnapshot();   // { value, context, tags, … }
+```
+
+```clojure
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => {:state :submitting :data {:attempts 1 :error nil} :tags #{:auth/busy}}
+;;    (nil before the first event; :tags present only when active states declare tags)
+```
+
+`[:rf/machine <id>]` is an ordinary [query vector](../core/glossary.md#query-vector) — chain named projections off it and it joins your [derivation graph](../core/glossary.md#the-derivation-graph) like any sub (divergence [#2](#2-the-snapshot-is-a-value-in-the-frame-not-state-owned-by-an-object) below explains the dividend). Because the whole definition and snapshot are data, the pure transition fn `(machines/machine-transition definition snapshot event)` returns `[next-snapshot effects]` with no frame, DOM, or network — the same value that renders in a browser unit-tests on the JVM ([machines API §`machine-transition`](../api/re-frame.machines.md), worked example at [`examples/.../state_machine_walkthrough/`](../../examples/capabilities/machines/state_machine_walkthrough/)).
+
+### Eventless transitions: always
+
+An eventless (`always`) transition fires the instant its guard becomes true — no event needed:
+
+```js
+resolving: { always: [{ guard: 'isEmpty', target: 'empty' }, { target: 'some' }] }
+```
+
+```clojure
+:resolving {:always [{:guard :empty? :target :empty}
+                     {:target :some}]}
+```
+
+Same firing rule, same microstep semantics: the whole cascade (the seed transition, every `:always` microstep, every raised event) commits **once, atomically** — XState/SCXML macrostep semantics, which re-frame2 matches including the "settle `:always` before dequeuing the next `:raise`" ordering. `:always` is a state-node slot (beside `:on`, `:entry`, `:after`), not a mid-transition key.
+
+### Delayed transitions: after and timeout
+
+A delayed transition fires after a wall-clock delay; entering the state arms the timer, leaving it cancels (a stale timer from a prior visit is detected by epoch and ignored):
+
+```js
+loading: { after: { 5000: 'timeout', 30000: { guard: 'stillLoading', target: 'hardError' } } }
+```
+
+```clojure
+:loading {:after {5000  :timeout
+                  30000 {:guard :still-loading? :target :hard-error}}
+          :on    {:loaded :ready :failed :error}}
+```
+
+`:after`'s value uses the same transition grammar as an `:on` clause, and the delay can be a literal `pos-int?` ms, a subscription vector (app-state-derived), or `(fn [{:keys [snapshot]}] ms)` (computed from this machine's `:data`). XState's named/delayed-actor `timeout` maps to `:timeout` + `:on-timeout`, a named deadline that lowers onto the same `:after` machinery. **Divergence:** durations are integer ms **or** an ISO-8601 string (`"PT5S"`); XState's readable `"5s"` / `"10ms"` shorthand is **rejected** at registration. (Recurring timers and pause/resume are out of scope for v1.)
+
+### Compound (nested) states
+
+A state with its own `:initial` + `:states` is a compound state, exactly as in XState:
+
+```js
+playing: { initial: 'atStart', states: { atStart: { on: { SEEK: 'midTrack' } }, midTrack: {} } }
+```
+
+```clojure
+:playing {:initial :at-start
+          :states  {:at-start  {:on {:seek :mid-track}}
+                    :mid-track {}}}
+```
+
+Same semantics: deepest-wins transition resolution with parent fall-through (an event the leaf doesn't handle bubbles to the compound), and `state.value` for a compound becomes a vector path — the snapshot's `:state` reads `[:playing :mid-track]`. A keyword `:target` names a **sibling**; a vector target is an **absolute path** from the (region) root, for cross-level jumps.
+
+### Parallel states
+
+For orthogonal axes of one domain, XState uses `type: 'parallel'` with sub-`states`; re-frame2 uses `:type :parallel` with `:regions`:
+
+```clojure
+(rf/reg-machine :ui/nine-states
+  {:type    :parallel
+   :data    {:items [] :error nil}                 ;; shared across all regions
+   :guards  {:empty? (fn [{d :data}] (zero? (count (:items d))))}
+   :regions
+   {:data {:initial :nothing
+           :states  {:nothing   {:tags #{:data/idle} :on {:fetch :loading}}
+                     :loading   {:tags #{:data/loading} :on {:loaded :resolving :failed :error}}
+                     :resolving {:always [{:guard :empty? :target :empty} {:target :some}]}
+                     :empty     {:tags #{:data/empty}}
+                     :some      {:tags #{:data/some}}
+                     :error     {:tags #{:data/error}}}}
+    :form {:initial :neutral
+           :states  {:neutral   {:tags #{:form/neutral} :on {:submit-valid :correct}}
+                     :correct   {:tags #{:form/success} :on {:edit :neutral}}}}}})
+```
+
+In XState the parallel node's children sit under `states`; in re-frame2 they sit under `:regions`, each a `{:initial … :states …}` body. The snapshot's `:state` becomes a **region-name → state** map, `:tags` is the **union** across active regions, and `:data` is **shared** (there is no per-region `:data` — if your axes need encapsulated data, that's the substrate telling you to register N separate machines):
+
+```clojure
+@(rf/subscribe [:rf/machine :ui/nine-states])
+;; => {:state {:data :nothing :form :neutral} :data {:items [] :error nil} :tags #{:data/idle :form/neutral}}
+```
+
+Cross-region coordination — one region guarding on another region's active state (XState v5's `stateIn` / SCXML `In()`) — is expressed by predicating on a sibling region's [tag](#tags), not a combinator. (**Deferred:** a region whose own tree is itself `:type :parallel` is rejected in v1.) Worked example: [`examples/patterns/nine_states/`](../../examples/patterns/nine_states/).
+
+### History states
+
+To re-enter a compound at the substate it last occupied, XState declares a `type: 'history'` child; re-frame2 declares a `:type :history` pseudo-state under the compound's `:states`:
+
+```clojure
+{:player
+ {:initial :stopped
+  :states {:stopped {:on {:play [:player :playing :hist]}}   ;; target the pseudo-state to restore
+           :playing {:initial :at-start
+                     :on      {:stop [:player :stopped]}
+                     :states {:hist      {:type :history
+                                          :deep? true              ;; omit => SHALLOW
+                                          :default-target :at-start} ;; omit => compound's :initial
+                              :at-start  {:on {:seek :mid-track}}
+                              :mid-track {}}}}}}
+```
+
+Same concept, idiomatic spelling: XState's `history: 'deep'` becomes `:deep? true` (shallow is the default — a missing `:deep?` reads as shallow), and `:default-target` is the never-yet-entered fallback. The pseudo-state is never an occupiable state — a transition *to* `:hist` resolves to the recorded (or default) leaf, which is what the snapshot records. The recording rides the snapshot's framework-owned `:rf/history` slot, so undo, time-travel, and SSR get history for free — no hand-rolled snapshot-as-value substitute.
+
+### Final states and output
+
+A leaf marked `:final?` terminates the machine; if it was spawned, the parent is notified — the XState `done` / `onDone` pattern:
+
+```clojure
+;; Child — designates its terminal state and what it reports out.
+(rf/reg-machine :auth-flow
+  {:initial :running
+   :states  {:running {:on {:server-ok {:target :done
+                                         :action (fn [{data :data ev :event}]
+                                                   {:data (assoc data :token (second ev))})}}}
+             :done    {:final?     true
+                       :output-key :token}}})       ;; ← this :data value flows to the parent
+
+;; Parent — :on-done reads the child's reported result.
+(rf/reg-machine :login
+  {:initial :idle
+   :states  {:idle           {:on {:submit :authenticating}}
+             :authenticating {:spawn {:machine-id :auth-flow
+                                      :on-done    (fn [{:keys [data result]}] (assoc data :token result))
+                                      :on-error   :idle}}}})    ;; child failed → transition
+```
+
+In XState `output` is a *function* of context; in re-frame2 `:output-key` names a **key** into the child's `:data` (compute it with an `:action` into the final state if you need to — there is no `:output-fn`). **Divergence:** completion is *event-shaped*, not a long-lived `snapshot.output` slot you read later — `:output-key`'s value flows to the parent's `:on-done` as `result` *at the moment of completion*, then the child auto-destroys. A `:final?` leaf may add `:error? true` to be the designated error terminal that drives the parent's `:on-error` **transition** (XState's `invoke onError` as control flow, not observability). And note: a **singleton** machine reaching `:final?` also auto-destroys — "final means final"; omit `:final?` for a persistent terminal state (`:authed` / `:locked-out` above are plain leaves).
+
+### Invoke becomes spawn
+
+Starting a child actor on state entry and tearing it down on exit is XState's `invoke`; in re-frame2 it's `:spawn`:
+
+```clojure
+:authenticating
+{:spawn {:machine-id :http/post
+         :data       (fn [{snap :snapshot}] {:url "/api/login" :body (-> snap :data :credentials)})
+         :system-id  :auth-actor                ;; address the child by role, not gensym'd id
+         :on-done    (fn [{:keys [data result]}] (assoc data :result result))
+         :on-error   :idle}
+ :on    {:auth/cancelled :idle}}
+```
+
+The job is identical; the **name diverges on purpose** — "invoke" reads like a synchronous call, whereas the thing created is a spawned child actor's worth of lifecycle, so the declarative key aligns with the imperative fx `[:rf.machine/spawn …]`. **Divergences to know:** one `:spawn` per state (fan-out is the separate `:spawn-all`, with named children, a `:join` condition, and a `:cancel-on-decision?` policy); no `:onSnapshot` (subscribe to `[:rf/machine <child-id>]` instead); no per-actor mailbox (events route through the one queue); no `autoForward` (forward explicitly via `:fx [[:dispatch [child-id ev]]]`). To address a spawned child from a machine action, emit `[:rf.machine/dispatch-to-system [:auth-actor [:event]]]` — see the [API reference](../api/re-frame.machines.md).
+
+### Choice states
+
+A choice (transient) state routes immediately on entry to the first guard that passes:
+
+```clojure
+:checking {:type   :choice
+           :choice [{:guard :valid? :target :accepted}
+                    {:target :rejected}]}      ;; unguarded final = the default / else branch
+```
+
+In XState v6 a `choice` state's routing can be a `choice`-**function**. re-frame2 **rejects** that: `:choice` is a declarative guarded-candidate **array** — a function may never be the edge (the *why* is divergence [#4](#4-the-transition-topology-stays-data--functions-are-confined-to-guards-and-actions) below; a fn-valued `:choice` fails loud at registration). The array must include an unguarded default so the node always resolves, and a choice state *only routes* (no `:entry` / `:on` / `:after`). It desugars onto `:always` — distinct authoring intent, one mechanism — so external observers never see `:checking`.
+
+### Internal events
+
+A private event the machine raises and handles itself — never part of its public surface:
+
+```clojure
+{:initial :waiting
+ :internal-events #{:tick}                            ;; a SET, not an array
+ :actions {:arm (fn [_] {:fx [[:raise [:tick]]]})}    ;; raised internally…
+ :states  {:waiting {:on {:go {:target :armed :action :arm}}}
+           :armed   {:on {:tick {:target :checking}}} ;; …and handled by an ordinary :on clause
+           :checking {}}}
+```
+
+XState v6's `internalEvents` is an **array**; re-frame2 declares them as a Clojure **set** — membership is the natural shape, order is irrelevant, duplicates are impossible. The `:on {:tick …}` clause is *how* the machine handles the raised event (expected, not a collision); what `:internal-events` adds is the boundary — an *external* `(rf/dispatch [:my/gate [:tick]])` from a view or test is **refused** at the machine dispatch boundary (a benign no-op with an error trace), while the internal `:raise` is handled normally.
+
+### Tags
+
+Once a machine has several "loading-ish" states, views should ask a predicate (*is it busy?*) rather than match exact state names. XState tags a state and asks `state.hasTag('busy')`; re-frame2 tags with a set and asks a subscription:
+
+```clojure
+:submitting {:tags #{:auth/busy} :entry :issue-request :on { … }}
+```
+```clojure
+(when @(rf/machine-has-tag? :auth.login/flow :auth/busy)
+  [spinner])
+```
+
+At every transition the runtime stamps the union of active states' tags onto the snapshot's `:tags`. The framework ships `[:rf/machine-has-tag? <id> <tag>]` — a derived predicate sub that re-renders only when *this* tag's bit flips — and the `rf/machine-has-tag?` sugar over it. Add a fifth busy state later and it's one `:tags` entry, zero view changes (*ask, don't tell*).
+
+### Schemas: types that actually run
+
+XState v6 declares shapes via `setup({ types })` / `schemas`; re-frame2 declares a machine-level `:schemas` map:
+
+```clojure
+(rf/reg-machine :session/auth
+  {:initial :anon
+   :data    {:retries 0 :token nil}
+   :schemas {:data   [:map [:retries :int] [:token [:maybe :string]]]   ;; XState's typed context
+             :output :string}                                            ;; the :output-key payload
+   :states  { … }})
+```
+
+XState's typed context maps to `[:schemas :data]` (re-frame2 calls the slot `:data`, so the schema names exactly what it validates), and `output` maps to `[:schemas :output]`. **Divergence in enforcement:** XState's typed context is compile-time-only and erased at runtime; re-frame2's `[:schemas :data]` is an *actually-running* [Malli](../core/glossary.md#schema) validation in dev — it checks at every macrostep-commit, bootstrap, and spawn, and a violation **rolls the whole cascade back** (`:output` is best-effort fail-loud, since the machine has already finished). Validation is optional and library-agnostic, and DCE's to nothing in production. A visualiser renders the context shape authoritatively from a declared schema instead of inferring it from one sample.
 
 ## Where it diverges — and why
 
@@ -93,19 +432,25 @@ The returned `:data` is merged into the snapshot; the returned `:fx` is a *descr
 
 ### 4. The transition topology stays data — functions are confined to guards and actions
 
-This is the most opinionated divergence, and the most easily missed. In XState you can put functions in a lot of places — and v6 adds a `choice` function for dynamic target selection. re-frame2 draws a hard line: **guards and actions are functions, but the transition topology is not.** Targets, `:always`, `:after`, `:choice` candidates — the *shape of the graph* — must be declarative data. So re-frame2 rejects function-valued transitions, and its [`:type :choice`](concepts.md#when-the-machine-grows) takes a declarative candidate array, not v6's `choice` function. There's also deliberately no `{:and ...}` guard-combinator DSL: compound conditions go in one *named* function.
+This is the most opinionated divergence, and the most easily missed. In XState you can put functions in a lot of places — and v6 adds a `choice` function for dynamic target selection. re-frame2 draws a hard line: **guards and actions are functions, but the transition topology is not.** Targets, `:always`, `:after`, `:choice` candidates — the *shape of the graph* — must be declarative data. So re-frame2 rejects function-valued transitions, and its [`:type :choice`](#choice-states) takes a declarative candidate array, not v6's `choice` function. There's also deliberately no `{:and ...}` guard-combinator DSL: compound conditions go in one *named* function.
 
 **Why:** the spec is the artefact. A machine whose topology is data can be pretty-printed, rendered as a live diagram, diffed in review, and handed whole to an AI with "add a two-factor state" — and the tool sees the entire graph in one form. The moment a target is computed by an opaque function, the diagram has a hole the visualiser can only draw as a shrug, and the AI loses the thread. Names are the same bet: a guard called `:under-retry-limit` renders legibly on the arrow; an inline `{:and [...]}` blob renders as noise. re-frame2 spends a little expressive flexibility to keep the graph *readable by machines other than itself* — which, given that re-frame2 is built AI-first, is the whole point.
 
 ### Two smaller deliberate differences
 
-- **`invoke` → `:spawn`.** Same job — start a child machine on state entry, tear it down on exit, collect its result via `:on-done`. Renamed because "invoke" reads like a synchronous call, whereas the thing actually being created is a spawned child actor's worth of lifecycle. See [spawn](glossary.md#spawn).
-- **Completion is event-shaped.** A finishing child's [`:final? true`](concepts.md#final-states-when-a-machine-is-done) leaf selects a value with `:output-key`, and that value flows to the parent's `:on-done` as `result` — at the moment of completion. There's no long-lived `snapshot.output` slot to read later, the way you'd read XState's `output`. Completion is a thing that *happens* (an event), not a thing that *sits there* (state), which keeps it on the same event rails as everything else.
+- **`invoke` → `:spawn`.** Same job — start a child machine on state entry, tear it down on exit, collect its result via `:on-done`. Renamed because "invoke" reads like a synchronous call, whereas the thing actually being created is a spawned child actor's worth of lifecycle. See [invoke becomes spawn](#invoke-becomes-spawn) and [spawn](glossary.md#spawn).
+- **Completion is event-shaped.** A finishing child's [`:final? true`](#final-states-and-output) leaf selects a value with `:output-key`, and that value flows to the parent's `:on-done` as `result` — at the moment of completion. There's no long-lived `snapshot.output` slot to read later, the way you'd read XState's `output`. Completion is a thing that *happens* (an event), not a thing that *sits there* (state), which keeps it on the same event rails as everything else.
 
 ## What stays loud, what stays quiet
 
 One last alignment, because it trips people who expect re-frame2 to be stricter than it is. An **unknown event is a no-op** — exactly as in XState v5/v6 after strict mode was dropped. Dispatch an event the current state doesn't handle and nothing throws; the snapshot doesn't move; a benign `:rf.machine.event/unhandled-no-op` trace records that it arrived and was dropped.
 
-Almost everything *else* that's wrong [fails loud](../core/glossary.md#fail-loud-not-silent) — a guard referencing an undefined name, a target naming a missing state, a `:schemas` sub-key that isn't real — but at **registration** time, not on the unlucky dispatch that first reaches the bad arrow. And a runaway `:always`/`:raise` cycle (which XState *throws* on) is a bounded, atomically-aborted [error record](../core/glossary.md#error-record), not a hang — deliberately distinct from the silent no-op, because a non-converging loop is a bug you want surfaced.
+Almost everything *else* that's wrong [fails loud](../core/glossary.md#fail-loud-not-silent) — a guard referencing an undefined name, a target naming a missing state, a `:schemas` sub-key that isn't real, a function where a `:choice` array belongs, an `:internal-events` vector instead of a set — but at **registration** time, not on the unlucky dispatch that first reaches the bad arrow. And a runaway `:always`/`:raise` cycle (which XState *throws* on) is a bounded, atomically-aborted [error record](../core/glossary.md#error-record), not a hang — deliberately distinct from the silent no-op, because a non-converging loop is a bug you want surfaced.
 
-For the full grammar — hierarchical states, parallel regions, history, `:timeout`/`:on-timeout`, private `:internal-events` — head back to [the machines guide](concepts.md#when-the-machine-grows), or the normative [Spec 005](../../spec/005-StateMachines.md) and the divergence ledger in the [machine construction guide](../../spec/CP-5-MachineGuide.md).
+## Further reading
+
+- **The narrative guide.** [Machines concepts](concepts.md) builds the same grammar from scratch with a live, editable [turnstile](concepts.md#see-one-run) and the [recognition kit](concepts.md#guards-and-actions). The [machines glossary](glossary.md) is the one-page vocabulary.
+- **The API contract.** [`re-frame.machines`](../api/re-frame.machines.md) — every key, fx, sub, and helper, enumerated (this page deliberately does not restate it).
+- **Worked examples.** [`examples/core/login/`](../../examples/core/login/) (the login flow, wired into a live view), [`examples/.../state_machine_walkthrough/`](../../examples/capabilities/machines/state_machine_walkthrough/) (the same machine tested as pure data), [`examples/patterns/nine_states/`](../../examples/patterns/nine_states/) (parallel regions + tags), and the [boot](../../examples/patterns/boot/) / [websocket](../../examples/patterns/websocket/) lifecycle machines.
+- **The normative spec.** The exhaustive contract and the full divergence ledger live in [Spec 005 §Lessons from xstate](../../spec/005-StateMachines.md#lessons-from-xstate-deliberate-divergences).
+- **The statechart tradition this realises.** re-frame2's machines implement the broader statechart model — see the [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) (the JS reference this page bridges from) and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/) (the same SCXML lineage in another Clojure framework).

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -209,37 +209,142 @@ If the current state has no transition for an event, it's a **silent no-op** —
 
 > **Coming from XState?** This matches XState, which dropped strict mode in v5 and keeps it dropped in the v6 direction: an unknown event is a no-op, not a crash. Almost everything *else* that's wrong (a guard referencing an undefined name, a target naming a missing state) [fails loud](../core/glossary.md#fail-loud-not-silent) — but at *registration* time, not on the unlucky dispatch. More on that fail-loud / silent-no-op split below.
 
-## Guards, actions, tags, and `:after` — the recognition kit
+## Guards and actions
 
-You've seen the core loop. The next four keys are the day-to-day grammar.
+The arrows in the table named two kinds of helper — `:under-retry-limit` (a guard) and `:issue-request` (an action) — and pointed at implementations sitting up top in the `:guards` and `:actions` maps. Those two maps *are* the machine's behaviour. Here's the contract they follow.
 
-**Guards and actions both receive one context map** — `{:data :event :state :meta}` — and destructure whichever keys they need. Note what's *not* in that map: there is no `:db`. (The next section covers why it matters.)
-
-A guard returns a boolean: take this transition, or don't. An action returns the same data-shaped [effect map](../core/glossary.md#effect-map) a `reg-event` handler returns — `{:data ...}`, `:fx`, both, or `nil` (do nothing). The `:data` you return is *merged* into the snapshot's data slot, key by key, last write wins; returning a key as an explicit `nil` *sets* it to `nil` rather than removing it.
-
-A transition's `:guard` and `:action` slot each take exactly one thing: a keyword referencing the machine's own `:guards` / `:actions` map (the usual form), or a bare inline fn. There's no `{:and ...}` combinator DSL for stringing guards together — compound logic goes in one named function instead, so the *name* is what a visualiser or an AI reads off the arrow.
-
-**Tags answer the any-of-many question.** Once a machine has several "loading-ish" states, views stop asking "which exact state?" and start asking a predicate: *is it busy?* A state declares `:tags #{:auth/busy}` (as `:submitting` does above), and at every transition the runtime stamps the union of active states' tags onto the snapshot. The framework ships a derived predicate sub for the containment question — `[:rf/machine-has-tag? <machine-id> <tag>]` — that re-renders only when *this* tag's membership bit flips:
+**Every callback receives one context map and destructures what it needs.** A guard, an action, an `:entry`, an `:exit` — all of them get the *same* single-map argument:
 
 ```clojure
-(when @(rf/subscribe [:rf/machine-has-tag? :auth.login/flow :auth/busy])
-  [spinner])
+{:data  {:attempts 1 :error nil}      ;; the snapshot's :data slot — a plain map
+ :event [:auth.login/failure {...}]   ;; the inbound event vector
+ :state :submitting                   ;; the discrete state keyword
+ :meta  {...}}                        ;; any user :meta on the snapshot
 ```
 
-Add a fifth busy state later and it's one `:tags` entry on the new node — zero view changes. (*Ask, don't tell* — see [state tag](glossary.md#state-tag).) Reach for a plain `case` on `:state` when the question really is "which exact state?".
+Pull out the keys you want and ignore the rest. `data` is already the `:data` slot — you read `(:attempts data)`, never `(get-in snapshot [:data :attempts])`. Note what is *not* in that map: there is no `:db`. A machine callback cannot see [app-db](../core/glossary.md#app-db) at all — only its own data plus the event that woke it. That boundary is load-bearing; **Strict encapsulation** below is the why.
 
-**`:after` is the declarative timer.** A state-node key maps a delay to a transition: enter the state, the timer arms; leave it, the timer cancels. (And if a timer from an earlier visit fires late — after you've already left and come back — the runtime tags each visit and ignores the stale one, so you never get a ghost transition from a previous trip through the state.) No `dispatch-later` to wire, no cancellation flag to remember:
+> **Coming from XState?** This is XState's action/guard argument — `context`, `event` — under re-frame2 spellings: `context` is `:data` (the name "context" is already taken twice over here, by the interceptor context and React context). One uniform map across every slot means there's no positional `(data event)`-vs-`(data id)` shape to mix up — the keys say what they carry.
+
+### A guard is a yes/no gate
+
+A guard returns truthy or falsey: take this transition, or fall through to the next candidate. `:under-retry-limit` answers "attempts left?":
 
 ```clojure
-:reconnecting {:after {5000 {:target :connecting}}     ;; retry in 5s
-               :on    {:net/give-up :failed}}
+:guards
+{:under-retry-limit
+ (fn [{data :data}] (< (:attempts data) 3))}
 ```
 
-That one key replaces the `setTimeout`-plus-cancel-flag pattern behind most reconnect/timeout/debounce bugs. Full grammar in [Spec 005 §Delayed `:after` transitions](../../spec/005-StateMachines.md#delayed-after-transitions).
+You reference it from an arrow by id — `:guard :under-retry-limit` — and the runtime resolves it against this machine's `:guards` map. There is deliberately **no combinator DSL**: no `{:and [...]}`, `{:or [...]}`, `{:not ...}`. Compound logic goes in one ordinary Clojure fn, and if it's worth a name, a named entry in `:guards`:
 
-> **A machine sees only its own `:data`.** Strict encapsulation is locked: actions and guards get `{:state :data :event :meta}` and **never app-db**. That's exactly what lets a machine's whole state ride the frame and roll back with it. Returning `:db` from an action is a hard error (`:rf.error/machine-action-wrote-db` — the offending `:db` key is dropped). To touch a sibling slice, dispatch a named event: `{:fx [[:dispatch [:drawer/apply-radius id radius]]]}`. The reach is forced to be a traced, reusable event rather than a quiet write into someone else's data.
+```clojure
+:guards
+{:ready-to-submit?
+ (fn [{:keys [data]}]
+   (and (email-valid? data) (under-quota? data)))}
+```
 
-> **Gotcha — facts from the world are *declared*, not grabbed.** A guard or action that needs the time (or a random draw) must not call `(js/Date.now)`, because that buries nondeterminism where replay can't reach it — and replay is what makes time-travel and SSR hydration work. Instead, declare the fact as a [coeffect](../core/glossary.md#coeffect) on a *named* entry and destructure it from the context map:
+> **Coming from XState?** XState ships `and` / `or` / `not` / `stateIn` guard combinators (`guard: and(['isAuthed', 'hasQuota'])`). re-frame2 has none — you write the boolean in a fn, and the fn's *name* is what a visualiser or an AI reads off the arrow. This is where XState v6 is heading anyway: it drops the helper creators in favour of plain functions. For `stateIn` specifically, the guard already gets `:state` in its context map (your own machine's active state); the cross-region case is covered in [parallel-states.md](parallel-states.md).
+
+### An action returns effects
+
+An action does the side work a transition performs — but it doesn't *perform* it. It **returns a description of effects**, exactly the way a `reg-event` handler does, and the runtime actions them. `:issue-request` never calls the HTTP client; it returns an `:fx` asking for one. Two small actions from the login flow:
+
+```clojure
+:actions
+{:clear-error  (fn [_] {:data {:error nil}})
+
+ :record-error (fn [{data :data [_ {:keys [failure]}] :event}]
+                 {:data (-> data
+                            (update :attempts inc)
+                            (assoc  :error (or (:message failure) "Login failed.")))})}
+```
+
+The return shape — that `{:data ...}` map — gets a section of its own just below. Like guards, actions are referenced by id (`:action :clear-error`) against the machine's `:actions` map, or written inline.
+
+### Name them, or inline them
+
+Both `:guard` and `:action` accept **either** a keyword (resolved through the `:guards` / `:actions` map) **or** a bare inline fn:
+
+```clojure
+{:on {:auth.login/submit {:guard  (fn [{:keys [data]}] (some? (:email data)))  ;; inline
+                          :target :submitting}}}
+
+{:on {:auth.login/submit {:guard  :ready-to-submit?                            ;; by id — the default
+                          :target :submitting}}}
+```
+
+**Reach for the keyword by default; inline only for a one-line triviality.** The id is a *name* — a stable, reusable handle that trace rows print, that a diagram arrow is labelled with, that a test can stub, that an AI can address and jump to source for. An anonymous closure has none of that. (Inline fns aren't second-class for *tooling* — in dev the `reg-machine` macro co-locates their source text, so a visualiser still renders the body — they're just unnamed.) Compound or reused logic always earns a name.
+
+> **Fail-loud, not silent.** Reference a `:guard` / `:action` keyword the machine's maps don't define and registration throws (`:rf.error/machine-unresolved-guard` / `…-unresolved-action`); a `:target` naming a state not in `:states` is `:rf.error/machine-unresolved-target`. These are caught at `reg-machine` time, not on the unlucky dispatch that first hits the bad arrow — a [fail-loud](../core/glossary.md#fail-loud-not-silent), not silent, posture. The one thing that is genuinely *not* an error is an event the current state has no transition for — that's the silent no-op you met just above.
+
+## The action effect map — `{:data :fx}`
+
+An action returns a two-key map — and **it's the same shape a `reg-event` handler returns**, just scoped to the machine instead of to app-db:
+
+```clojure
+{:data {<updates to the machine's own data>}   ;; cf. reg-event's :db
+ :fx   [[<fx-id> <args>] ...]}                  ;; the standard re-frame fx vector
+```
+
+Both keys are optional; returning `nil` (or `{}`) means "no effects." That symmetry is the point — you already know this shape from [event handlers](../core/glossary.md#event-handler).
+
+**`:data` is a merge, not a replace.** What you return is merged into the snapshot's current `:data`, key by key, last-write-wins. You mention only the keys you're changing:
+
+```clojure
+;; current :data is {:attempts 1 :error nil}
+(fn [{data :data}] {:data {:error "Login failed."}})
+;; → :data becomes {:attempts 1 :error "Login failed."}  — :attempts untouched
+```
+
+One sharp edge: an explicit `nil` **sets** a key to `nil` (the key stays present) — the merge never *removes* keys. `{:data {:error nil}}` leaves `:error` present-and-`nil`; it doesn't drop it. There is no key-removal idiom in a `:data` write.
+
+**`:fx` is the ordinary effects vector** — `:dispatch`, `:rf.http/managed`, your own registered effects, all flow to the normal machinery untouched. Three fx-ids are *machine-only* and intercepted before they get there: `[:raise [...]]` loops an event back into this same machine (atomically, before the transition commits), and `[:rf.machine/spawn ...]` / `[:rf.machine/destroy ...]` are the actor-lifecycle pair. You'll meet all three under [When the machine grows](#when-the-machine-grows); the reference is [`re-frame.machines`](../api/re-frame.machines.md).
+
+> **Gotcha — `:fx` can't read this action's own `:data` write.** The two keys are returned *together*, so at the moment the runtime reads your `:fx` vector the `:data` merge hasn't happened. To act on a freshly-computed value, bind it in a `let` and use the local in both keys:
+>
+> ```clojure
+> (fn [{data :data}]
+>   (let [next-id (inc (:last-id data))]
+>     {:data {:last-id next-id}
+>      :fx   [[:dispatch [:thing/created next-id]]]}))   ;; the local, not (:last-id data)
+> ```
+>
+> Or split the work across two slots — write in the transition `:action`, read in the target state's `:entry`.
+
+When several slots fire in one transition (`:exit` → the transition's `:action` → `:entry`), their `:data` updates merge in that order — a later slot sees the earlier writes — and the `:fx` vectors concatenate left to right.
+
+> **Coming from XState?** A `:data` write *is* XState's `assign` — there's no separate `assign` primitive to call and no array of actions to order. Because an action returns one atomic `{:data :fx}` map, XState v5's "assigns run in declared order, not hoisted ahead" correctness rule is automatic here rather than something the engine must enforce. (v6 removes the `assign` helper creator outright — re-frame2 never had it.)
+
+## Strict encapsulation — a machine sees only its own `:data`
+
+This is the rule hovering over that context map: a guard or action gets `{:data :event :state :meta}` and **never app-db**. It cannot read app-db, and it cannot write it.
+
+> **Why it's locked.** A machine's whole state — its `:state` and its `:data` — lives in one place, the [runtime-db](../core/glossary.md#runtime-db), so it reverts, time-travels, persists, and SSR-hydrates as a single value along with the rest of the [frame](../core/glossary.md#frame). If an action could quietly write some *other* slice of app-db, that change wouldn't live in the snapshot and wouldn't roll back with it. Encapsulation is what keeps a machine's state *all* inside the snapshot.
+
+So how does a machine read or write things outside itself? Two disciplined moves:
+
+**A fact from outside arrives in the event.** Whoever dispatches has the data; they pass it in. The view that knows a circle's current radius puts it in the dispatch, and the action reads it from `:event`:
+
+```clojure
+(rf/dispatch [:drawer/editor [:right-click-circle id radius]])
+```
+
+**A write to a sibling slice goes out as a named event.** An action that needs to touch app-db emits a `:dispatch` fx — so the write becomes a real, traced, reusable event *with a name*, not a quiet reach into someone else's data:
+
+```clojure
+:action (fn [{:keys [data]}]
+          {:fx   [[:dispatch [:drawer/apply-radius (:circle-id data) (:preview-radius data)]]]
+           :data {:circle-id nil :preview-radius nil}})
+```
+
+Two guard-rails enforce the boundary:
+
+- **Returning `:db` is a hard error.** A `:db` key in an action's effect map surfaces `:rf.error/machine-action-wrote-db` and the `:db` key is dropped (the rest of the effects still flow). Fail loud, don't silently let a machine scribble on app-db.
+- **The next state isn't in the return shape either.** An action returns `:data` and `:fx` — never a state keyword. Only the transition's `:target` moves the machine. Callbacks update working memory; they can't nudge the machine into a state the table didn't declare. (This is exactly XState's `assign` invariant.)
+
+> **Gotcha — facts from the world are *declared*, not grabbed.** A guard or action that needs the time (or a random draw) must not call `(js/Date.now)` or `(rand)`: that buries nondeterminism where replay can't reach it, and replay is what makes time-travel and SSR hydration work. Instead, declare the fact as a [coeffect](../core/glossary.md#coeffect) on a *named* entry and read it from the context map's `:rf.cofx` record:
 >
 > ```clojure
 > :guards
@@ -249,9 +354,43 @@ That one key replaces the `setTimeout`-plus-cancel-flag pattern behind most reco
 >         (< (- time-ms (:first-attempt-at data)) 60000))}}
 > ```
 >
-> The fact arrives recorded on the event's causal token (it's a *recordable* coeffect — see [recordable vs ambient coeffects](../core/glossary.md#recordable-vs-ambient-coeffects)), so the decision replays identically under time-travel and SSR hydration. [Effects & coeffects](../core/concepts/effects-and-coeffects.md) has the general mechanism — a coeffect is a fact pulled *into* a handler, the mirror of an effect pushed out.
+> The fact rides the event's causal token (it's a *recordable* coeffect — see [recordable vs ambient coeffects](../core/glossary.md#recordable-vs-ambient-coeffects)), so the decision — and any `:data` it folds in — replays identically. [Effects & coeffects](../core/concepts/effects-and-coeffects.md) has the general mechanism: a coeffect is a fact pulled *into* a handler, the mirror of an effect pushed out.
 
-> **Fail-loud, not silent.** Reference a `:guard`/`:action` keyword the machine's maps don't define and registration throws (`:rf.error/machine-unresolved-guard` / `…-unresolved-action`); a `:target` naming a state that isn't in `:states` is `:rf.error/machine-unresolved-target`. These are caught at `reg-machine` time, not on the unlucky dispatch that first hits the bad arrow. The one thing that's *not* an error is an event the current state has no transition for — that's the **silent no-op** above.
+## The snapshot — `{:state :data :tags}`
+
+A machine's entire live value at any instant is one small map, its [snapshot](glossary.md#snapshot):
+
+```clojure
+{:state :submitting               ;; where we are
+ :data  {:attempts 1 :error nil}  ;; the machine's private memory
+ :tags  #{:auth/busy}}            ;; the active state's tags, projected on (optional)
+```
+
+Three slots do the work:
+
+- **`:state`** — the discrete state. For the flat machines on this page it's a single keyword (`:idle`, `:submitting`). It grows two more shapes as machines do: a **vector path** from root to active leaf once states nest (`[:authenticated :cart :browsing]`), and a **region→state map** for parallel machines (`{:data :loading :form :neutral}`). One slot, read three ways.
+- **`:data`** — the machine's working memory: a plain map, yours to shape, private to this machine (the encapsulation rule above). Optionally schema-checked — see [Validating a machine's `:data`](#validating-a-machines-data).
+- **`:tags`** — a set the runtime *projects* onto the snapshot: the union of every active state's declared `:tags`. `:submitting` declares `:tags #{:auth/busy}`, so while you're there the snapshot carries it. It's how a view asks "is it busy?" rather than "which exact state?".
+
+(A `:meta` slot carries any user metadata; the runtime additionally stamps a closed set of framework-owned `:rf/*` bookkeeping slots inside the snapshot, which you never write to.)
+
+You read the snapshot through the framework's `[:rf/machine <id>]` [subscription](../api/re-frame.machines.md) — it returns the `{:state :data}` value (plus `:tags`), or `nil` before the first event:
+
+```clojure
+@(rf/subscribe [:rf/machine :auth.login/flow])
+;; => {:state :submitting :data {:attempts 1 :error nil} :tags #{:auth/busy}}
+```
+
+Because the snapshot is *just a value* — no functions, no atoms, nothing unprintable in `:data` — it `pr-str` / `read-string` round-trips; and because it lives in [runtime-db](../core/glossary.md#runtime-db) it inherits [time-travel](../core/glossary.md#time-travel), undo, persistence, and SSR hydration for free, exactly as app-db does. That is the quiet dividend of "a machine is just an event handler whose state rides the frame."
+
+> **Coming from XState?** This is `actor.getSnapshot()` — but a *value in your store that you subscribe to*, not a field you pull off a live actor object. There's no actor instance to hold a reference to; the id plus the subscription is the whole handle.
+
+## Tags and timers
+
+Two keys round out the everyday kit, and each has earned a page of its own rather than a paragraph here:
+
+- **Tags** — `:tags #{:auth/busy}` on a state node, read with `@(rf/machine-has-tag? :auth.login/flow :auth/busy)`. This is the *ask-don't-tell* pattern: a view tracks "is it busy?" across any number of states without hard-coding state names, and adding a sixth busy state later is one `:tags` entry with zero view changes. (See [state tag](glossary.md#state-tag).) The deep treatment is in [tags.md](tags.md).
+- **Automatic transitions** — `:after` (a declarative timer: arm on entry, cancel on exit, no `setTimeout` or cancel-flag to wire) and `:always` (an eventless transition that fires the moment a guard turns true). The machine's *automatic* moves — the ones no event drives. See [automatic-transitions.md](automatic-transitions.md).
 
 ## Self-transitions: internal by default, external on demand
 
@@ -448,3 +587,10 @@ The matches go deeper than the renames: run-to-completion, transition tables as 
 **Don't reach for one when:** the "state" is just data (a counter, a list); there are only two stages (a `:loading?` boolean is fine); the lifecycle belongs to server data — fetching, caching, invalidation is what [resources](../resources/concepts.md) already manage, and hand-building that machine re-implements the framework; or you're enforcing a *sequence of operations* rather than a set of states — chained events handle the simple cases.
 
 **Reach for machines when named states are the load-bearing concept — not when named operations are.** [Part 3 of the tutorial](../resources/tutorial/03-auth-and-forms.md) puts a login machine to work in a real app, and [Server state: resources](../resources/concepts.md) covers the one lifecycle you should *not* hand-build as a machine — the framework already runs it for you.
+
+## Further reading
+
+- **The worked example.** Every snippet on this page lives as compiling code in [`examples/capabilities/machines/state_machine_walkthrough/`](../../examples/capabilities/machines/state_machine_walkthrough/) — the full login flow, the canned-HTTP stubs, and the headless pure-transition tests.
+- **The API.** [`re-frame.machines`](../api/re-frame.machines.md) — every fn and keyword surface (`reg-machine`, `machine-transition`, the `[:rf/machine …]` / `[:rf/machine-has-tag? …]` subs, the reserved `:rf.machine/*` fx-ids).
+- **The normative contract.** [Spec 005 — State Machines](../../spec/005-StateMachines.md) is the exhaustive grammar behind everything here: the full transition-table keys, the guard / action context map, the `{:data :fx}` effect map, schema validation, and the snapshot stability invariants.
+- **The wider statechart tradition.** re-frame2's machines realise the same statechart concepts as the [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) (the parity reference — behavioural, not API-level) and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/) in the Clojure world. Both are good background on states, transitions, guards, and hierarchy.

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -1,6 +1,10 @@
 # Machines glossary
 
-re-frame2's optional state-machine capability — modelling a feature's lifecycle as an explicit statechart rather than a scatter of boolean flags. The terms below all live within a [machine](#machine); see [the Machines guide](concepts.md) for the full picture.
+re-frame2's optional state-machine capability — modelling a feature's lifecycle as an explicit statechart rather than a scatter of boolean flags. Every term below lives within a [machine](#machine), and each entry links to the page that teaches it in depth — usually [the Machines guide](concepts.md). Where a term maps from XState (the behavioural parity reference — re-frame2 matches the *behaviour*, not the API), the entry flags it inline (*XState: …*) and calls out any deliberate divergence; [Coming from XState](coming-from-xstate.md) is the full delta.
+
+Grouped by role: [the core loop](#the-core-loop), [state structure](#state-structure), [transitions and timing](#transitions-and-timing), [actors and composition](#actors-and-composition), [tags](#tags), and [the runtime model](#the-runtime-model).
+
+## The core loop
 
 ### **machine**
 
@@ -12,7 +16,22 @@ Its live value is a [snapshot](#snapshot) (the current state plus its `:data`), 
 (rf/reg-machine :auth.login/flow login-flow)
 ```
 
-Related: [Machines](concepts.md).
+Related: [Machines](concepts.md); the [`reg-machine` API](../api/re-frame.machines.md#reg-machine).
+
+### **transition table**
+
+The data a machine *is*: a map with `:initial`, the starting [`:data`](#data), the machine-local [`:guards`](#guard) / [`:actions`](#action) maps, an optional `:schemas`, and the `:states` tree. The event keys under each state's `:on` map are what move it. [`reg-machine`](../api/re-frame.machines.md#reg-machine) compiles this literal map into an ordinary [event handler](../core/glossary.md#event-handler) at registration, so the table is the whole specification — pretty-print it, diff it in review, render it as a diagram, or hand it to an AI in one piece.
+
+```clojure
+{:initial :idle
+ :data    {:attempts 0 :error nil}
+ :guards  {:under-retry-limit (fn [{d :data}] (< (:attempts d) 3))}
+ :actions {:clear-error (fn [_] {:data {:error nil}})}
+ :states  {:idle       {:on {:submit {:target :submitting :action :clear-error}}}
+           :submitting {...}}}
+```
+
+*XState:* the object you pass to `createMachine` — re-frame2 keeps it as plain Clojure data, with no builder or fluent API. See [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
 
 ### **snapshot**
 
@@ -22,28 +41,256 @@ A [machine](#machine)'s live value at any moment — which state it's in, plus i
 @(rf/subscribe [:rf/machine :auth.login/flow])   ;; {:state :authed :data {...}}
 ```
 
-Related: [Machines](concepts.md).
+The snapshot is a plain, printable value (no functions or atoms), so [undo, time-travel](../core/glossary.md#time-travel), persistence, and SSR hydration all work on machines for free. Its `:state` takes one of three forms: a single keyword (flat machine), a vector path (`[:authenticated :cart :browsing]`, a [compound](#compound-state) machine), or a region → state map (a [parallel](#parallel-state) machine).
+
+Related: [Machines](concepts.md); the [`[:rf/machine machine-id]` sub](../api/re-frame.machines.md#rfmachine-machine-id).
+
+### **:data**
+
+A machine's private working memory — the *extended state* that rides alongside the named [state](#state) in every [snapshot](#snapshot). Counters, the in-flight error string, captured credentials: anything that isn't itself a named mode. [Guards](#guard) and [actions](#action) read it from their context map (`{:data …}`); an action *updates* it by returning `{:data …}` (see [action effect map](#action-effect-map)). It must be a printable value so the snapshot round-trips through persistence and time-travel, and a machine sees **only its own** `:data` — never [app-db](../core/glossary.md#app-db).
+
+*XState:* this is XState's **`context`**. re-frame2 renames it because "context" is already overloaded (interceptor context, React context). Taught in [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
 
 ### **state**
 
-One of a [machine](#machine)'s fixed, named, mutually-exclusive modes — `:idle`, `:submitting`, `:authed`. A machine is always in exactly one (or, with parallel regions, one per region).
+One of a [machine](#machine)'s fixed, named, mutually-exclusive modes — `:idle`, `:submitting`, `:authed`. A machine is always in exactly one (or, with [parallel regions](#parallel-state), one per region). A state with no nested `:states` is a *leaf* (or *atomic*) state; one that nests its own `:states` is a [compound state](#compound-state).
 
 ### **transition**
 
-The move from one [state](#state) to another in response to a dispatched [event](../core/glossary.md#event) — optionally gated by a [guard](#guard) and running an [action](#action) on the way. In the transition table it's an entry under a state's `:on` map. Transitions can also be *eventless* (`:always`, taken on entry when its guard passes) or *timed* (`:after`, taken after a delay that auto-cancels when the state exits).
+The move from one [state](#state) to another in response to a dispatched [event](../core/glossary.md#event) — optionally gated by a [guard](#guard) and running an [action](#action) on the way. In the transition table it's an entry under a state's `:on` map. Transitions can also be *eventless* ([`:always`](#eventless-transition-always), taken on entry when its guard passes) or *timed* ([`:after`](#delayed-transition-after), taken after a delay that auto-cancels when the state exits).
 
 ### **guard**
 
-A pure yes/no predicate that decides whether a [transition](#transition) fires. Referenced by name from the table and defined once in the machine's `:guards`, so a visualiser can read the condition right off the arrow.
+A pure yes/no predicate that decides whether a [transition](#transition) fires. Referenced by name from the table and defined once in the machine's `:guards`, so a visualiser can read the condition right off the arrow. It receives the context map `{:data :event :state :meta}` (note: **no** app-db) and returns a boolean. There's no `{:and …}` combinator DSL — compound logic goes in one named function, so the *name* is what tools and AI read off the arrow.
 
 ### **action**
 
-The side work a [transition](#transition) performs: it returns the same `{:data … :fx …}` shape an [event handler](../core/glossary.md#event-handler) returns — updating the machine's own `:data` or firing [effects](../core/glossary.md#effect) — and never writes [app-db](../core/glossary.md#app-db) directly. Defined once in the machine's `:actions`, named from the arrow.
+The side work a [transition](#transition) performs: it returns the same `{:data … :fx …}` shape an [event handler](../core/glossary.md#event-handler) returns — updating the machine's own `:data` or firing [effects](../core/glossary.md#effect) — and never writes [app-db](../core/glossary.md#app-db) directly. Defined once in the machine's `:actions`, named from the arrow. The three action slots a transition can run are the source state's `:exit`, the transition's own `:action`, and the target's `:entry`.
 
-### **state tag**
+### **action effect map**
 
-A label like `:auth/busy` attached to several [machine](#machine) [states](#state); the active state's tags ride on the [snapshot](#snapshot), so a [view](../core/glossary.md#view) can ask "is it busy?" (`machine-has-tag?`) instead of enumerating exact state names — *ask, don't tell*. Add a sixth busy state and no view changes.
+What an [action](#action) returns: the same `{:data … :fx …}` map a [`reg-event`](../core/glossary.md#event-handler) handler returns. `:data` is **merged** into the snapshot key-by-key (last write wins; a key returned as explicit `nil` *sets* it to `nil` rather than removing it); `:fx` is a vector of `[fx-id args]` pairs the runtime actions for you. Returning `nil` does nothing. Because the action *describes* effects rather than performing them, it stays pure, testable, and replayable.
+
+```clojure
+:record-error
+(fn [{data :data [_ {:keys [failure]}] :event}]
+  {:data (-> data (update :attempts inc)
+                  (assoc :error (:message failure)))})
+```
+
+*XState:* replaces both `assign({...})` (now the `:data` return) and effectful actions (now the `:fx` return). v6 is removing `assign`'s special status, moving toward the plain-function shape re-frame2 started from. See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+
+## State structure
+
+### **compound state**
+
+A [state](#state) that nests its own `:states` map plus a required `:initial` substate — a parent mode with child modes (`:authenticated` over `:browsing` / `:checkout`). Entering it cascades down the `:initial` chain to a leaf, and the snapshot's `:state` becomes a **vector path** like `[:authenticated :cart :browsing]`. The runtime resolves an event by walking from the active leaf up to the root — **deepest-wins with parent fallthrough** — so a parent can factor out a transition (`:logout`) that every descendant inherits, while a child can [opt out](#forbidden-transition) or override.
+
+*XState:* a hierarchical / nested state; same `initial`-cascade and bubbling. Listed under [When the machine grows](concepts.md#when-the-machine-grows).
+
+### **parallel state**
+
+A [compound state](#compound-state) declared `:type :parallel` whose children are [regions](#region) that are **all active at once** rather than one-at-a-time. Three orthogonal axes of three states each is three regions, not twenty-seven cross-product states. The snapshot's `:state` becomes a **map** of region-name → that region's state (`{:data :loading :form :neutral :mode :active}`); all regions share one [`:data`](#data) and their [tags](#state-tag) union across regions. When the axes *don't* share data, prefer N separate machines instead.
+
+*XState:* `type: 'parallel'`. See the [nine_states example](../../examples/patterns/nine_states/) and [When the machine grows](concepts.md#when-the-machine-grows).
+
+### **region**
+
+One orthogonal axis of a [parallel state](#parallel-state) — its own independent sub-state-tree, running concurrently with its sibling regions and sharing the machine's single [`:data`](#data). A dispatched [event](../core/glossary.md#event) broadcasts to every region, and each resolves it independently; a region's slice of the snapshot is keyed by its region-name. Cross-region coordination reads another region's [tags](#state-tag) — never reaching into its state directly.
+
+*XState:* the child states of a `parallel` node.
+
+### **final state**
+
+A leaf marked **`:final? true`**: entering it **terminates the machine** — the runtime auto-destroys it, *even a top-level singleton*. It's for "this run is over," not "this is the last screen" — for a state the machine rests in indefinitely (like `:authed`), use an ordinary leaf and **omit** `:final?`. A final leaf can name an [`:output-key`](#on-done-and-output-key) to report a result, and can be flagged `:error? true` as a designated failure terminal.
+
+*XState:* `final: true` (+ `output`). See [Final states](concepts.md#final-states-when-a-machine-is-done).
+
+### **history state**
+
+A `:type :history` **pseudo-state** you target to re-enter a [compound state](#compound-state) at whichever substate was active when you last left it — a paused player resuming mid-track. **Shallow** restores the immediate child; **deep** restores the full nested path; a `:default-target` covers the never-visited-yet case. The recording rides the [snapshot](#snapshot), so it survives undo and SSR hydration for free.
+
+*XState:* `type: 'history'` (`history: 'shallow' | 'deep'`). Listed under [When the machine grows](concepts.md#when-the-machine-grows).
+
+## Transitions and timing
+
+### **self-transition**
+
+A [transition](#transition) back into the state you're already in. re-frame2 follows **internal-by-default**, with three distinct shapes:
+
+- **Targetless** (omit `:target`) — a true internal no-op: the `:action` runs, but `:exit` / `:entry` don't, `:after` timers aren't restarted, [`:spawn`](#spawn) children aren't torn down. The way to mutate `:data` without disturbing anything.
+- **Explicit self-target, no `:reenter?`** — your own `:exit` / `:entry` still don't fire, but a compound **re-resolves its descendants** to `:initial`.
+- **External (`:reenter? true`)** — genuinely exits and re-enters: `:exit` → `:action` → `:entry`, and on a compound the whole subtree restarts (`:after` timers reset, `:spawn` children respawn).
+
+*XState:* `:reenter? true` is XState's `reenter: true`. Watch the divergence from XState v4 / SCXML, where a *targeted* self-transition re-enters by default — re-frame2 does not. See [Self-transitions](concepts.md#self-transitions-internal-by-default-external-on-demand).
+
+### **wildcard transition**
+
+An `:on` entry that matches a *class* of events instead of one id. `:on` resolves **three tiers**, most-specific first: the **exact** id (`:mouse/down`), then the **namespace wildcard** `:ns/*` (`:mouse/*` catches every `mouse`-namespaced event and only those), then the **total wildcard** `:*` (anything). A guard-blocked exact match falls through to the coarser tiers.
+
+```clojure
+:tracking {:on {:mouse/down {:action :begin-drag}    ;; exact wins for :mouse/down
+                :mouse/*    {:action :note-move}      ;; any other :mouse/… event
+                :*          {:action :log-unknown}}}  ;; anything else
+```
+
+*XState:* `:ns/*` is re-frame2's idiom for v5's prefix descriptor (`mouse.*`), expressed on the keyword's `/` boundary. See [Wildcard transitions](concepts.md#wildcard-transitions-handle-a-whole-class-of-events).
+
+### **forbidden transition**
+
+A present `:on` key whose value is the **empty map** (`{:on {:E {}}}`) or **`nil`** — a handler that *consumes* an event and stops the deepest-wins search without changing state. It's how a child [compound state](#compound-state) **opts out** of a transition its parent would otherwise inherit to it. Distinct from an *unhandled* event (which falls through to coarser tiers and up to ancestors): a forbidden block is itself a match, so the search stops there.
+
+*XState:* `on: { LOGOUT: undefined }`. Covered with [wildcards](concepts.md#wildcard-transitions-handle-a-whole-class-of-events).
+
+### **eventless transition (`:always`)**
+
+A state-node key holding a vector of guarded transitions that fire **with no event** — checked on entry (and after any transition landing in the state), first-passing-guard wins. The way to say "the snapshot just changed; if X is now true, move immediately." An `:always` may **not** target its own state (rejected at registration); the fixed-point pattern is a *targetless* guarded `:always` whose `:action` flips the guard.
+
+```clojure
+:checking-form {:always [{:guard :form-valid?   :target :submitting}
+                         {:guard :form-invalid? :target :show-errors}]}
+```
+
+*XState:* `always` (transient transitions); same firing rule. Settled inside the [microstep](#microstep) loop. See [When the machine grows](concepts.md#when-the-machine-grows).
+
+### **delayed transition (`:after`)**
+
+The declarative timer: a state-node key mapping a delay to a transition. Enter the state and the timer arms; leave it and the timer cancels — no `setTimeout`-plus-cancel-flag to wire. A late-firing timer from an earlier visit is ignored (each visit is epoch-tagged), so you never get a ghost transition. The delay is a positive-integer millisecond count, a [subscription](../core/glossary.md#subscription) vector, or a `(fn [snapshot] ms)`.
+
+```clojure
+:reconnecting {:after {5000 {:target :connecting}}   ;; retry in 5s
+               :on    {:net/give-up :failed}}
+```
+
+*XState:* `after: { 5000: 'next' }`; same auto-cancel-on-exit. ISO-8601 strings (`"PT5S"`) are accepted; XState's `"5s"` shorthand is **rejected**. See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+
+### **timeout**
+
+The named-intent spelling of "this state — or its spawned child — must finish before this deadline": a `:timeout` duration paired with an `:on-timeout` transition. It *lowers onto* the same [`:after`](#delayed-transition-after) timer machinery; it just reads as a deadline rather than a general delay. A duration is integer-ms (`5000`) or an ISO-8601 string (`"PT5S"`, `"PT1H30M"`) — `"5s"` is rejected, failing loud at registration.
+
+*XState:* the deadline idiom you'd build by hand from `after`; re-frame2 gives it a name. Listed under [When the machine grows](concepts.md#when-the-machine-grows).
+
+### **choice state**
+
+A `:type :choice` **transient** routing node: enter it and it resolves *immediately* — same step, no event — to the first candidate whose `:guard` passes. It's [`:always`](#eventless-transition-always)'s decision pattern with a name, so a diagram renders an explicit fork. The candidate list is a **declarative array** that must include an unguarded default and must not declare ordinary state keys.
+
+*XState:* a `choice` node — but re-frame2 keeps the routing as **data**, deliberately rejecting v6's `choice`-*function* form so the graph stays readable by tools. See [When the machine grows](concepts.md#when-the-machine-grows).
+
+### **run-to-completion**
+
+The guarantee that a machine processes one event **to a settled, stable configuration before the next event is seen** — every [`:always`](#eventless-transition-always) microstep and every [`:raise`](#raise)d event drains, then the snapshot [commits](#commit) once. External observers (subs, other machines, tools) only ever see the settled state, never a mid-cascade intermediate. A non-converging `:always` / `:raise` loop can't hang the runtime: it's bounded (default depth 16) and aborts atomically with the snapshot unchanged.
+
+*XState:* RTC / SCXML macrostep semantics — matched deliberately. See [microstep](#microstep) and [macrostep](#macrostep).
+
+## Actors and composition
 
 ### **spawn**
 
-A declarative key that starts a *child* machine on entering a [state](#state) and tears it down on leaving; the child reports a result back through `:on-done`. (`:spawn-all` starts several in parallel and joins on completion — re-frame2's spelling of XState's `invoke`.)
+A declarative key that starts a *child* machine on entering a [state](#state) and tears it down on leaving; the child reports a result back through [`:on-done`](#on-done-and-output-key). (`:spawn-all` starts several in parallel and joins on completion — re-frame2's spelling of XState's `invoke`.) Under the hood it's the reserved [`[:rf.machine/spawn …]`](../api/re-frame.machines.md#rfmachinespawn-spawn-spec) [effect](../core/glossary.md#effect); emit that directly from any handler when you need a dynamic count rather than one-child-per-state. The running instance it creates is an [actor](#actor).
+
+*XState:* `invoke: { src: childMachine }`, renamed because the thing created is a spawned child's worth of lifecycle, not a synchronous call. See [When the machine grows](concepts.md#when-the-machine-grows).
+
+### **actor**
+
+A *live machine instance* — a [snapshot](#snapshot) sitting at `[:rf.runtime/machines :snapshots <id>]` in [runtime-db](../core/glossary.md#runtime-db). Two kinds: a long-lived **singleton** (one per `reg-machine` id) and a dynamically **[spawned](#spawn)** child (a per-request protocol machine, a wizard's per-step subprocess). An actor's *liveness IS its snapshot's presence* — there's no parallel registry; destroying it removes the snapshot. Address a spawned actor by its gensym'd id, or by role via a [system-id](#system-id).
+
+*XState:* an actor — but re-frame2 has no `createActor` / actor-ref object; the instance is just a value in the frame, which is why time-travel and SSR extend to it for free. See [Coming from XState](coming-from-xstate.md).
+
+### **spawn-all**
+
+The fan-out sibling of [`:spawn`](#spawn): on entering a state it starts **N children in parallel** and **joins** on their completion, resolving when they've all finished (or on the first failure, with a cooperative cancellation cascade). Used for "spawn a worker per chunk and continue when all return."
+
+*XState:* invoking multiple actors and awaiting them. See the [long_running_work example](../../examples/patterns/long_running_work/) and [When the machine grows](concepts.md#when-the-machine-grows).
+
+### **:on-done and :output-key**
+
+How a finishing child reports back. A [final state](#final-state) names an **`:output-key`** — the slot of its [`:data`](#data) to surface as its result. The parent's [`:spawn`](#spawn) declares **`:on-done`**, a `(fn [{:keys [data result]}] new-data)` that fires the instant the child enters its final state, receiving that value as `result`; the runtime then tears the child down. Completion is **event-shaped** — it *happens* and flows, rather than sitting in a readable `output` slot.
+
+```clojure
+:done {:final? true :output-key :token}             ;; child reports :data's :token
+;; parent:
+:authenticating {:spawn {:machine-id :auth-flow
+                         :on-done (fn [{:keys [data result]}]
+                                    (assoc data :token result))}}
+```
+
+*XState:* `final` `output` + `onDone`; re-frame2 keeps it event-shaped, not a long-lived `snapshot.output`. See [Final states](concepts.md#final-states-when-a-machine-is-done).
+
+### **system-id**
+
+A stable **role name** (`:logger`, `:websocket`, `:retry-coordinator`) bound to a spawned [actor](#actor), so a parent can address its child by *role* instead of by gensym'd id. The canonical action-side surface is the reserved `[:rf.machine/dispatch-to-system [system-id event]]` [effect](../core/glossary.md#effect) — a machine [action](#action) can't read app-db, so the fx tuple is how it messages a named child.
+
+```clojure
+{:fx [[:rf.machine/dispatch-to-system [:logger [:logger/flush]]]]}
+```
+
+See the [`machine-by-system-id`](../api/re-frame.machines.md#re-framemachinesmachine-by-system-id) / [`dispatch-to-system`](../api/re-frame.machines.md#re-framemachinesdispatch-to-system) lookup helpers.
+
+### **:raise**
+
+A reserved, **machine-only** fx-id. Inside an [action](#action)'s `:fx`, `[:raise [:some-event …]]` loops an event back into *this same machine* — **atomically, pre-commit**, drained FIFO through a local queue inside the one handler invocation (it never touches the router queue). Use it when one transition's outcome should immediately drive another, all inside one [macrostep](#macrostep). Contrast `:fx [[:dispatch [self-id …]]]`, which is a *separate*, post-commit [event](../core/glossary.md#event) (its own [epoch](../core/glossary.md#epoch)).
+
+```clojure
+{:actions {:kick (fn [_] {:fx [[:raise [:tick]]]})}}
+```
+
+*XState:* `raise({type: …})`. See [`[:raise event-vec]`](../api/re-frame.machines.md#raise-event-vec) and [When the machine grows](concepts.md#when-the-machine-grows).
+
+### **:internal-events**
+
+A top-level **set** of event ids that are machine *plumbing* — events the machine [`:raise`](#raise)s at itself, not for a view or test to dispatch. An internal `:raise` of one is handled normally; an *external* dispatch is **refused** at the machine's boundary (no transition; a `:rf.error/machine-internal-event-external-dispatch` trace fires).
+
+```clojure
+{:internal-events #{:check-complete}
+ :states {...}}
+```
+
+*XState:* v6's `internalEvents` — spelled as a Clojure **set** (membership is what you're declaring, not order). See [When the machine grows](concepts.md#when-the-machine-grows).
+
+## Tags
+
+### **state tag**
+
+A label like `:auth/busy` attached to several [machine](#machine) [states](#state); the active state's tags ride on the [snapshot](#snapshot), so a [view](../core/glossary.md#view) can ask "is it busy?" ([`machine-has-tag?`](../api/re-frame.machines.md#machine-has-tag)) instead of enumerating exact state names — *ask, don't tell*. Add a sixth busy state and no view changes. Across [parallel regions](#region), every active state's tags union onto the one snapshot.
+
+```clojure
+(when @(rf/subscribe [:rf/machine-has-tag? :auth.login/flow :auth/busy])
+  [spinner])
+```
+
+*XState:* `tags: ['busy']` + `state.hasTag('busy')`; the membership question is a [subscription](../core/glossary.md#subscription). See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+
+## The runtime model
+
+These terms describe *how* a transition actually runs. You can build machines without them, but they're the vocabulary for reasoning about ordering and atomicity — and what the [trace stream](../core/glossary.md#trace-stream) shows you.
+
+### **drain**
+
+The deterministic ordering rules by which a machine's effects compose at four nested levels: within one action's `:fx` (vector order; `:data` lands before `:fx`); across the `:exit` → `:action` → `:entry` slots of one [transition](#transition); within one machine event (the [microstep](#microstep) loop over [`:always`](#eventless-transition-always) and [`:raise`](#raise)); and across the runtime's per-frame queue (FIFO, except machine-originated continuation events leap-frog to the front so a machine settles its [macrostep](#macrostep) before the next external event). The order in the source is the order at runtime — no reordering for "optimisation."
+
+### **microstep**
+
+One iteration of the settle loop *inside* a single machine event: after the resolving transition, the runtime **prefers an enabled [`:always`](#eventless-transition-always)** transition; only when none is enabled does it **dequeue one [`:raise`](#raise)d event** (FIFO). It loops until no `:always` is enabled *and* the raise-queue is empty — the fixed point. Microsteps are **not** separately observable; they're the internal steps that compose one [macrostep](#macrostep). Bounded at depth 16 (`:always-depth-limit` / `:raise-depth-limit`).
+
+*XState:* SCXML §3.13 microstep / `selectEventlessTransitions` — matched deliberately.
+
+### **macrostep**
+
+The whole machine event — the resolving transition plus every [`:always`](#eventless-transition-always) [microstep](#microstep) and every [`:raise`](#raise)d sub-event — seen as **one logical step** from outside: one [commit](#commit), one trace row, one [epoch](../core/glossary.md#epoch). External observers only ever see the post-commit settled [snapshot](#snapshot), never an intermediate. This is what makes a machine [run-to-completion](#run-to-completion).
+
+*XState:* the SCXML macrostep / run-to-completion boundary.
+
+### **commit**
+
+The single, deferred [runtime-db](../core/glossary.md#runtime-db) write that lands a [macrostep](#macrostep)'s settled [snapshot](#snapshot) at `[:rf.runtime/machines :snapshots <id>]` — **once per transition**, no matter how many actions or microsteps fired. It's the boundary at which the [`:schemas :data`](concepts.md#validating-a-machines-data) check runs (a violation rolls the whole transition back) and the point a reading [subscription](../core/glossary.md#subscription) re-fires. (See the general framework [commit](../core/glossary.md#commit).)
+
+### **LCCA (least common compound ancestor)**
+
+Also written **LCA**. For a [transition](#transition) from source path A to target path B inside a [compound state](#compound-state), the LCCA is the deepest state that stays active across the move — it neither exits nor enters. The exit cascade runs `:exit` from A's leaf *up to (not including)* the LCCA (deepest-first); the entry cascade runs `:entry` from just below the LCCA *down to* B's leaf (shallowest-first); the transition `:action` fires once at the boundary. For the common case it's just the longest common prefix of A and B — *except* when B is on A's active path or a descendant the declaring compound names, where it pulls up to a **proper** ancestor so the targeted subtree actually re-resolves. For a flat machine the LCCA is the root, and the rule collapses to plain `:exit` → `:action` → `:entry`.
+
+*XState:* the same LCCA the SCXML algorithm uses to compute exit/entry sets.
+
+## Further reading
+
+- **Normative contract:** [Spec 005 — State Machines](../../spec/005-StateMachines.md) is the exhaustive grammar and semantics behind every term here — snapshot shape, the drain / microstep ordering, the LCCA cascade, final-state and parallel-region rules, and the capability matrix. The [machines concept guide](concepts.md) teaches the model by example; the [`re-frame.machines` API](../api/re-frame.machines.md) is the function-and-keyword reference; [Coming from XState](coming-from-xstate.md) is the full v6 parity delta; the [examples index](examples.md) links the runnable apps.
+- **The broader idea:** re-frame2's machines realise the statechart model taught in the [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) (the behavioural reference re-frame2 tracks) and, in the Clojure world, [Fulcro statecharts](https://fulcrologic.github.io/statecharts/) — both descendants of Harel statecharts and the W3C SCXML algorithm.

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -1,0 +1,501 @@
+# Hierarchical (compound) states
+
+A flat machine is a single list of states, one active at a time. That carries
+most flows. But some states are really a *cluster*: three leaves that share a
+resource, a sub-flow with its own beginning and end, a family of states that
+should all answer the same event the same way. A **compound state** is a state
+that contains its own `:states` map — a little machine nested inside one state
+of the bigger one.
+
+You reach for hierarchy when:
+
+- **Several leaves share a lifecycle or a resource.** A WebSocket's
+  `:connecting → :authenticating → :connected` happy path all ride *one* live
+  socket. They aren't independent states — they're three phases of being
+  *connected*. Nest them under one `:active` parent and the socket spans all
+  three.
+- **You want to factor a transition to a parent.** Every authenticated screen
+  should honour `:logout` the same way. Declare it *once* on the parent; every
+  descendant inherits it (the [parent-fallthrough](#transition-resolution-deepest-wins-with-parent-fallthrough)
+  rule below). No restating, no drift.
+- **A sub-flow has a clear "done."** A checkout collects, submits, confirms —
+  then the outer flow moves on. Mark the sub-flow's terminal leaf and the
+  parent advances automatically (the [done signal](#when-a-sub-flow-finishes-nested-final-states) below).
+
+The grammar recurses and stays additive: a substate is either a **leaf** (no
+`:states`) or another **compound** (has `:states`, and must declare
+`:initial`). Flat machines stay flat — you only pay for hierarchy where you use
+it.
+
+> **In XState** this is a [compound (nested) state](https://stately.ai/docs/parent-states);
+> the behaviour re-frame2 matches is XState v6's, expressed as Clojure data
+> rather than a `createMachine` object. `:data` is XState's `context`; `:spawn`
+> is XState's `invoke`/`spawn`; the snapshot's `{:state :data :tags}` is XState's
+> `snapshot.value` / `.context` / `.tags`.
+
+The canonical worked example is the connection machine in
+[`../../examples/patterns/websocket/`](../../examples/patterns/websocket) — its
+`:active` state parents the three happy-path leaves. The snippets on this page
+are simplified from it. For the flat grammar this builds on, read
+[Concepts](concepts.md) first.
+
+---
+
+## Anatomy of a compound state
+
+Here is the shape, lifted and trimmed from the WebSocket connection machine.
+The three happy-path leaves live *inside* `:active`, because they share the one
+thing they can't do without: the live socket, spawned on the parent.
+
+```clojure
+(rf/reg-machine :ws/connection
+  {:initial :disconnected
+   :data    {:url nil :socket-id nil :queue []}
+
+   :actions
+   {:record-opts (fn [{data :data [_ {:keys [url]}] :event}]
+                   {:data (assoc data :url url)})
+    :send-now    (fn [{data :data [_ msg] :event}]
+                   {:fx [[:dispatch [(:socket-id data) [:send msg]]]]})
+    :enqueue     (fn [{data :data [_ msg] :event}]
+                   {:data (update data :queue conj msg)})}
+
+   :states
+   {:disconnected
+    {:on {:ws/connect {:target :active :action :record-opts}}}
+
+    :active                                   ;; ← compound: the socket's home
+    {:initial :connecting                     ;; required — every compound declares it
+
+     ;; One socket actor, spawned on the PARENT, so it spans all three leaves
+     ;; below without re-spawning on each leaf transition. (See Concepts > :spawn.)
+     :spawn {:machine-id :websocket/socket}
+
+     ;; Transitions every leaf inherits. A leaf may override any of them; what
+     ;; a leaf doesn't handle falls through to here.
+     :on    {:ws/closed     {:target :reconnecting}
+             :ws/send       {:action :enqueue}    ;; default: queue while not yet connected
+             :ws/disconnect {:target :disconnected}}
+
+     :states
+     {:connecting     {:tags #{:ws/connecting}
+                       :on   {:ws/opened {:target :authenticating}}}
+
+      :authenticating {:tags  #{:ws/authenticating}
+                       :on    {:ws/auth-ok     {:target :connected}
+                               :ws/auth-failed {:target [:failed]}}}  ;; ← vector! (root-level)
+
+      :connected      {:tags #{:ws/connected}
+                       :on   {:ws/send {:action :send-now}}}}}        ;; ← overrides parent :ws/send
+
+    :reconnecting {:on {:ws/connect {:target :active}}}
+    :failed       {:on {:ws/connect {:target :active}}}}})
+```
+
+Three things to notice, each expanded below:
+
+1. `:active` declares `:initial :connecting` — entering `:active` lands you in
+   `:connecting`, never in `:active` "bare."
+2. `:ws/auth-failed` targets `[:failed]` (a **vector**), because `:failed` lives
+   at the root, not as a sibling inside `:active`.
+3. `:connected` redeclares `:ws/send` — it **overrides** the parent's default
+   for that one event while it's the active leaf.
+
+---
+
+## The snapshot becomes a path
+
+A flat machine's snapshot `:state` is a single keyword (`:disconnected`). For a
+**compound** machine, `:state` is a **vector path** from the root down to the
+active leaf:
+
+```clojure
+@(rf/subscribe [:rf/machine :ws/connection])
+;; flat-ish state:   {:state :disconnected         :data {…} :tags #{}}
+;; compound state:   {:state [:active :connected]  :data {…} :tags #{:ws/connected}}
+```
+
+`:data` is the machine's extended state — one shared map, not per-state. `:tags`
+is the **union** of the `:tags` sets on every active node along the path. A
+single keyword `:K` read against a hierarchical definition is treated as the
+path `[:K]` (it must name a leaf at the root).
+
+The practical upshot: **views ask about tags, not paths.** Don't unfold the
+`:state` vector in a view to discover "are we connected?" — ask the tag:
+
+```clojure
+(when @(rf/machine-has-tag? :ws/connection :ws/connected)
+  [send-box])
+```
+
+The view doesn't care *which* leaf carries the `:ws/connected` intent, only that
+the tag is present — so you can re-shape the hierarchy later without touching
+the view. (See the [snapshot](glossary.md#snapshot) and
+[state tag](glossary.md#state-tag) glossary entries; the snapshot lives in the
+framework's [runtime-db](../core/glossary.md#runtime-db), read like any other
+[subscription](../core/concepts/subscriptions.md).)
+
+---
+
+## Initial-state cascading
+
+**Every compound state MUST declare `:initial`** — the substate to enter when
+control reaches the compound without a deeper target. Entering a compound
+*cascades down its `:initial` chain* until it reaches a leaf:
+
+```clojure
+{:initial :outer
+ :states  {:outer {:entry   :enter-outer        ;; fires first
+                   :initial :mid
+                   :states  {:mid  {:entry   :enter-mid     ;; then this
+                                    :initial :leaf
+                                    :states  {:leaf {:entry :enter-leaf}}}}}}}
+;; Targeting :outer lands the snapshot at [:outer :mid :leaf].
+;; Entry actions fire shallowest-first: :enter-outer, :enter-mid, :enter-leaf.
+```
+
+So in the WebSocket machine, `{:target :active}` resolves to `[:active :connecting]`,
+and the cascade fires `:active`'s entry slots (including its `:spawn`) and then
+`:connecting`'s — shallowest-first — as the path lengthens.
+
+A compound state *without* `:initial` is a registration error
+(`:rf.error/machine-compound-state-missing-initial`) — it fails loud at
+`reg-machine` time, not on the unlucky dispatch.
+
+> **The initial cascade also runs at birth.** When a machine first comes to
+> life — a singleton on its first dispatched event, or a spawned actor — the
+> whole `:initial` chain's `:entry` actions fire once, shallowest-first, as part
+> of bringing it into existence. A multi-level `:initial` chain runs *every*
+> level's `:entry` at start. (In XState this is `xstate.init` entering the
+> initial state cascade.)
+
+---
+
+## Targets: vector vs keyword
+
+A transition's `:target` admits two forms, and the difference is *where the
+target is resolved from*:
+
+| Form | Means | Example |
+|---|---|---|
+| **Vector** `[:a :b]` | **Absolute path from the root**, no matter where the transition is declared. Unambiguous; the recommended form for cross-level jumps. | `:ws/auth-failed {:target [:failed]}` |
+| **Keyword** `:b` | **Relative — a sibling** of the state that *declares* the transition (resolved against the declaring state's parent's `:states`). | `:ws/opened {:target :authenticating}` |
+
+The "declaring state" is the node that **owns the `:on` map** — not whatever
+leaf the machine happens to sit in at runtime. It's a static rule you can read
+straight off the transition table.
+
+This is exactly the WebSocket gotcha. From inside `:authenticating` (a child of
+`:active`), a bare `:auth-failed {:target :failed}` would resolve to the
+*sibling* `[:active :failed]` — which doesn't exist. The absolute vector
+`[:failed]` says "from the root, please":
+
+```clojure
+:authenticating
+{:on {:ws/auth-ok     {:target :connected}       ;; keyword: sibling inside :active → [:active :connected]
+      :ws/auth-failed {:target [:failed]}}}       ;; vector: root-level [:failed]
+```
+
+A target naming a **compound** state implicitly cascades through its `:initial`
+chain (above). To land on a *specific* leaf inside a compound, name it with a
+vector: `:target [:active :connected]`.
+
+Flat-machine targets you've already written (`{:target :editing}`) are keyword
+form, root-relative — unchanged, because in a flat machine the declaring state's
+parent *is* the root.
+
+> **In XState** an absolute target is written by id —
+> `target: '#connection.failed'`; re-frame2's `[:failed]` vector is the same
+> "absolute from the root" idea. A relative XState target like `target: 'authenticating'`
+> maps to re-frame2's keyword `:authenticating`.
+
+---
+
+## Transition resolution: deepest-wins with parent fallthrough
+
+When an event arrives, the runtime walks the active path **from the leaf up to
+the root**, and the first node that *enables* a transition for the event wins.
+Within each node it tries three descriptor tiers in priority order before moving
+up: the **exact** key, then the namespace wildcard `:ns/*`, then the total
+wildcard `:*`. A guard-blocked candidate is **not** enabled, so it doesn't end
+the search — resolution keeps falling through.
+
+Two consequences make hierarchy pay off:
+
+- **A child overrides a parent.** `:connected` redeclares `:ws/send` to send
+  immediately; while connected, that leaf wins and the parent's "enqueue"
+  default never runs. Same event, different answer depending on where you are.
+- **A parent factors a common transition.** `:active` declares `:ws/closed`,
+  `:ws/disconnect`, and the `:ws/send` default *once*; every leaf that doesn't
+  handle them inherits them. Add a fourth leaf and it inherits them too, for
+  free.
+
+```clojure
+;; While the snapshot is [:active :connected], dispatching :ws/disconnect:
+;;   :connected   — no :ws/disconnect  → keep walking up
+;;   :active       — match!             → {:target :disconnected}
+;; Dispatching :ws/send instead resolves at :connected (override → :send-now).
+```
+
+> **In XState** this is the v5/v6 transition-selection order: a descendant state
+> handles an event in preference to its ancestors, and an ancestor handles what
+> the descendant doesn't. The descriptor tiers (exact, `mouse.*` prefix,
+> catch-all `*`) are XState's too — re-frame2 spells the prefix tier on the
+> keyword's `/` boundary (`:mouse/*`) instead of a dotted string.
+
+### Opting a child OUT of an inherited transition
+
+Sometimes a child needs the *inverse* of inheritance — to **block** a
+factored-to-parent transition while it's active, without replacing it. Because
+the walk stops at the first *enabled* match, a child can declare a matching
+**internal no-op** that consumes the event so the parent is never reached:
+
+```clojure
+:modal {:on {:logout {}            ;; FORBIDDEN: matching internal no-op, halts the walk
+             ;; equivalently:  :logout nil
+             :close  :dashboard}}
+```
+
+While the machine rests in `:modal`, `:logout` resolves *at* `:modal` to a no-op
+and the parent's `:logout` is **not** inherited. Leave `:modal` and it's
+inherited again. Both spellings — the empty map `{}` and a present key with
+`nil` value — normalise to the same blocking no-op.
+
+The block turns entirely on the key being **present**. A child with *no*
+`:logout` entry keeps falling through (absence means "I don't handle this");
+a deliberately-`nil` key blocks (presence means "I consume this here").
+
+> **In XState** this is `on: { LOGOUT: undefined }` — a forbidden transition.
+> `nil` is the natural Clojure analogue of `undefined`.
+
+### Unhandled events are a benign no-op
+
+If *no* level enables a transition for an unknown event, the snapshot is
+unchanged and the runtime emits a benign `:rf.machine.event/unhandled-no-op`
+trace. Nothing throws.
+
+> **In XState** an unhandled event is silently ignored (v5 dropped `strict`
+> mode, and the v6 direction keeps it dropped). re-frame2 matches that runtime
+> behaviour — but **deliberately diverges** on one point: where XState emits
+> *nothing*, re-frame2 keeps the observability trace so a debugger can report
+> that an event arrived and was ignored. Benign is not invisible. To "fail loud
+> on unknown," declare a `:*` wildcard whose action throws.
+
+---
+
+## Entry/exit cascading along the LCA
+
+Moving from one path to another isn't a single hop — it fires a *cascade* of
+`:exit` and `:entry` actions for every state you actually leave and enter. The
+runtime computes the **LCA** (least common compound ancestor — the deepest
+compound state that is a proper ancestor of both the source leaf and the target
+node), then fires three boundaries in order:
+
+1. **Exit cascade** — walk the source path from the leaf back toward the LCA,
+   firing each state's `:exit` action, **deepest-first**. Stop *below* the LCA
+   (you aren't leaving it).
+2. **Transition `:action`** — runs once, at the LCA boundary, between exit and
+   entry.
+3. **Entry cascade** — walk the target path from just below the LCA down to the
+   target node, firing each `:entry` action, **shallowest-first**. If the target
+   is itself compound, keep cascading through its `:initial` chain.
+
+For the common case — source and target in disjoint subtrees — the LCA is simply
+the longest common prefix of the two paths.
+
+Take this auth-flow machine (a compound `:authenticated` over a `:dashboard` /
+`:settings` / `:cart` sub-tree, with `:cart` itself compound):
+
+```clojure
+(rf/reg-machine :shop
+  {:initial :unauthenticated
+   :states
+   {:unauthenticated
+    {:on {:login [:authenticated]}}              ;; vector target — absolute from root
+
+    :authenticated
+    {:initial :dashboard
+     :on      {:logout [:unauthenticated]}       ;; factored to the parent — every descendant inherits
+     :states
+     {:dashboard {:on {:open-settings :settings  ;; keyword target — sibling of :dashboard
+                       :open-cart     :cart}}
+      :settings  {:on {:close :dashboard}}
+      :cart      {:initial :browsing
+                  :on      {:close :dashboard}
+                  :states  {:browsing  {:on {:checkout :paying}}
+                            :paying    {:on {:success :confirmed
+                                             :failure :browsing}}
+                            :confirmed {}}}}}}})
+```
+
+| Event | Source path | Target path | What fires |
+|---|---|---|---|
+| `:login` | `[:unauthenticated]` | `[:authenticated :dashboard]` | Target `[:authenticated]` cascades `:initial :dashboard`. Entry: `:authenticated`, then `:dashboard`. |
+| `:open-cart` | `[:authenticated :dashboard]` | `[:authenticated :cart :browsing]` | Keyword `:cart` = sibling of `:dashboard`; cascades `:initial :browsing`. LCA is `:authenticated`: exit `:dashboard`; enter `:cart`, `:browsing`. |
+| `:checkout` | `[:authenticated :cart :browsing]` | `[:authenticated :cart :paying]` | Sibling hop inside `:cart`. LCA `:cart`: exit `:browsing`; enter `:paying`. |
+| `:logout` | `[:authenticated :cart :paying]` | `[:unauthenticated]` | Deepest-wins walks `:paying` (no match), `:cart` (no), `:authenticated` (match). LCA is the root: exit `:paying → :cart → :authenticated` (deepest-first); enter `:unauthenticated`. |
+
+> **In XState/SCXML** this is the LCCA / `findLCCA` rule (re-frame2 keeps the
+> historical "LCA" name for the section). The generalisation of the flat
+> `exit → action → entry` rule: in a flat machine the path length is 1 and the
+> LCA is always the root.
+
+Remember actions are **pure returns**, not imperative writes: an `:entry` /
+`:exit` / transition `:action` is `(fn [{:keys [data event state]}] effects)`
+returning `{:data … :fx …}`. The `:fx` flow through the ordinary
+[effects cascade](../core/concepts/events-and-the-cascade.md) like any handler's.
+
+---
+
+## When a sub-flow finishes: nested final states
+
+A compound state often *is* a sub-flow with a clear end: collect, submit, paid.
+re-frame2 ships the statechart pattern for "the sub-flow finished, now advance
+the outer flow" first-class — and crucially, **the machine keeps running**.
+
+Mark the sub-flow's terminal leaf `:final? true`. The moment a compound's active
+child becomes that final leaf, the engine raises a synthetic, transitionable
+event `[:rf.machine/done <compound-path>]`, and the compound's **`:on-done`**
+takes it:
+
+```clojure
+(rf/reg-machine :checkout
+  {:initial :flow
+   :states
+   {:flow {:initial :collecting
+           :on-done :next                        ;; ← fires when :flow reaches its :final? child
+           :states  {:collecting {:on {:submit :submitting}}
+                     :submitting {:on {:ok :paid}}
+                     :paid       {:final? true}}} ;; ← embedded final = "sub-flow done"
+    :next {:on {:reset [:flow]}}}})
+```
+
+When `:flow` reaches `[:flow :paid]`, `:on-done :next` advances the machine to
+the sibling `:next` — **in the same macrostep**, no teardown. `:on-done` on a
+compound is an ordinary `:on`-shaped transition spec (a keyword sibling target,
+a vector path, or a full `{:target :guard :action}` / candidate vector), and a
+keyword target resolves as a **sibling of the compound** — the natural "advance
+the outer flow" placement.
+
+> **In XState** `:on-done` on a compound is `onDone`, and re-frame2's
+> `[:rf.machine/done <path>]` is XState's `done.state.<id>` / SCXML's
+> `done.state.id` — the node id rides as the event's single argument so the
+> `:on` table stays keyed on one reserved keyword. The raise lands in the same
+> internal FIFO queue an action's `[:raise …]` uses, drained before the
+> macrostep settles.
+
+There's also a lower-level escape hatch: if the done node declares no `:on-done`,
+the raised `[:rf.machine/done <path>]` walks the active path leaf→root like any
+event, so an **ancestor** can catch it with an explicit
+`:on {:rf.machine/done {:guard … :target …}}` — a guard reads the raised path off
+`:event` to disambiguate *which* node is done.
+
+### Depth decides the meaning — embedded vs whole-machine final
+
+The same `:final?` key means two different things depending on **how deep the
+leaf sits.** This is the one subtlety worth internalising:
+
+| `:final?` leaf placement | Meaning | Effect |
+|---|---|---|
+| **Embedded inside a compound** (path length ≥ 2) | the *compound* is done | raises `[:rf.machine/done <compound>]`; the enclosing `:on-done` advances; **the machine keeps running** |
+| **Direct child of the root** (path length 1) | the *whole machine* is done | **auto-destroys** (a singleton tears itself down; a spawned child notifies its parent — below) |
+
+So you do **not** have to *avoid* `:final?` to keep a machine alive after a
+sub-flow completes — you put the final leaf *inside* the compound. A final leaf
+at the root, by contrast, ends the actor.
+
+> **Deliberate divergence — "final means final."** A *singleton* (top-level,
+> un-spawned) machine that reaches a **root-level** `:final?` leaf
+> auto-destroys. If you want a state the machine rests in indefinitely (an
+> `:authed` end-screen), use an ordinary leaf and **omit `:final?`**. `:final?`
+> is for "this run is over," not "this is the last screen." (XState's top-level
+> final simply stops the actor; re-frame2 tears it down — the snapshot is gone.)
+
+### Reporting a result to a spawning parent: `:output-key`
+
+The *whole-machine* final case is how a **spawned child** reports back. The
+child marks its terminal leaf `:final?` and names the `:data` slot to hand up
+with `:output-key`; the parent's **`:spawn :on-done`** callback receives it as
+`result`:
+
+```clojure
+;; Child: declares its terminal state and what it outputs.
+(rf/reg-machine :auth-flow
+  {:initial :running
+   :data    {}
+   :states
+   {:running {:on {:server-ok {:target :done
+                               :action (fn [{data :data ev :event}]
+                                         {:data (assoc data :token (second ev))})}}}
+    :done    {:final?     true
+              :output-key :token}}})           ;; ← the :data slot reported back
+
+;; Parent: :spawn :on-done reads the child's result, then the child auto-destroys.
+(rf/reg-machine :login
+  {:initial :idle
+   :states
+   {:idle {:on {:submit :authenticating}}
+    :authenticating
+    {:spawn {:machine-id :auth-flow
+             :on-done    (fn [{data :data result :result}]   ;; result = child's :token
+                           (assoc data :token result))}
+     :on    {:auth/cancelled :idle}}}})
+```
+
+Two distinct `:on-done` hooks, then, named the same on purpose because they're
+the same idea at two scopes:
+
+- **`:on-done` on a compound node** — the *transitionable in-machine* signal
+  (`done.state.<compound>`). Advances the outer flow; machine survives.
+- **`:on-done` on a parent's `:spawn` map** — the *actor-teardown notification*
+  `(fn [{:keys [data result]}] new-data)` a parent gets when a spawned child
+  reaches a root-level `:final?` and is then destroyed.
+
+> **In XState** `:final?` is `type: 'final'` and `:output-key` is the final
+> state's `output`. re-frame2 keeps exactly **one** output primitive — there's
+> no `:output-fn` escape hatch. Want a *computed* output? Write a transition
+> `:action` *into* the final state that stashes the computed value at the
+> `:output-key` slot.
+
+### `:final?` constraints
+
+A `:final?` state fails loud at registration if you break these:
+
+- **Leaf-only.** No `:states` / `:initial` on a final state — a compound can't
+  be final; its finality is a leaf *inside* it. (`:rf.error/machine-final-state-compound`)
+- **No further transitions.** No `:on` / `:always` / `:after` / `:spawn` on a
+  final state — final means final. (`:rf.error/machine-final-state-has-transitions`)
+  `:entry` and `:exit` *are* allowed (entry runs in the cascade; exit runs from
+  teardown).
+- **`:output-key` requires `:final?`.** A non-final state declaring
+  `:output-key` is an error (`:rf.error/machine-output-key-without-final`). On a
+  final leaf it's optional — absent, the parent's `result` is `nil`.
+
+(Inside a parallel-region machine, a `:final?` leaf means "*this region* is
+done"; the machine as a whole is done only when *every* region is final.
+Parallel regions are a separate axis — they're for orthogonal concerns that
+*don't* share a sub-tree — covered in [Concepts](concepts.md).)
+
+---
+
+## Further reading
+
+- **Spec** — [Spec 005 §Hierarchical compound states](../../spec/005-StateMachines.md#hierarchical-compound-states)
+  is the normative contract for everything on this page: initial cascading,
+  vector/keyword target resolution, the deepest-wins walk, the LCA cascade, and
+  (in §Final states) the `:final?` / `:on-done` / `:output-key` done-state
+  signal.
+- **API** — [`re-frame.machines`](../api/re-frame.machines.md) for `reg-machine`,
+  the `[:rf/machine …]` / `[:rf/machine-has-tag? …]` subscriptions, and the
+  `:rf.machine/spawn` / `:rf.machine/destroy` effects.
+- **Concepts** — [Machines concepts](concepts.md) for the flat grammar this
+  builds on, and [Coming from XState](coming-from-xstate.md) for the full
+  port-your-intuitions delta.
+- **Example** — the connection machine in
+  [`../../examples/patterns/websocket/`](../../examples/patterns/websocket).
+
+re-frame2's hierarchy realises the classic statechart model: compound states,
+LCA-based entry/exit, and the done-state signal are Harel-statechart concepts
+also realised by [XState's statecharts](https://stately.ai/docs/state-machines-and-statecharts)
+and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/) — the same
+ideas, expressed as re-frame2 data.

--- a/docs/machines/history.md
+++ b/docs/machines/history.md
@@ -1,0 +1,184 @@
+# History states
+
+Some compound states have a memory. A media player you stop and restart should resume *mid-track*, not jump back to the first second. A wizard you step away from and return to should land on the step you left, not step one. A tabbed settings panel should remember which tab — and how far down each tab was scrolled — across a close/reopen. That "resume where I last was" behaviour is what a **history state** gives you, declaratively, for any [compound state](concepts.md#when-the-machine-grows).
+
+Without it you reach for the obvious workaround — stash the last substate in `:data` on the way out, read it back on the way in, and write the wiring to restore it. History states make that pattern a single node in the transition table, and (because the record/restore lives *inside the snapshot*) they ride undo, time-travel, persistence, and SSR for free. This is xstate's history-state concept, shipped first-class in re-frame2 as a `:type :history` node — same idea, idiomatic spelling.
+
+> History only applies to a **compound** state — a state with its own `:states` and `:initial`. If "which tab" or "which step" is a single flat value, just keep it in [`:data`](concepts.md#the-same-flow-as-a-transition-table) like any other state; that is ordinary modelling, not a feature you need to name. History earns its keep when a *non-trivial nested* configuration is worth remembering across a leave/return.
+
+## A history state is a transition *target*, not a state you occupy
+
+The mental model to get right first: a history state is a **pseudo-state**. You declare it under a compound's `:states` map, right alongside the compound's real substates, but the machine *never sits in it*. Its only job is to be the **target of a transition** — and when a transition resolves to it, it stands in for "the substate this compound was in when control last left it." The runtime resolves it to a real leaf, the entry cascade enters *that* leaf, and the [snapshot](glossary.md#snapshot)'s `:state` records the resolved leaf — never the pseudo-state.
+
+So you write `[:player :hist]` as a transition target the same way you'd write any state path, and it resolves to a recorded (or default) configuration instead of to a fixed state.
+
+## A worked example — a media player that resumes
+
+Here is a player with a `:tray` (no disc) and a `:player` compound (disc inserted). The `:player` compound owns a `:type :history` pseudo-state. `:eject` leaves `:player` for `:tray`; `:insert` comes back in *through history*, restoring whatever the player was doing when it was ejected:
+
+```clojure
+(rf/reg-machine :media-player
+  {:initial :tray
+   :states
+   {;; No disc. :insert re-enters :player THROUGH the history pseudo-state.
+    :tray
+    {:on {:insert [:player :hist]}}
+
+    ;; Disc inserted — the compound whose configuration we remember.
+    ;; :eject leaves :player entirely, which is what makes it record.
+    :player
+    {:initial :stopped
+     :on      {:eject :tray}
+     :states
+     {:hist    {:type :history
+                :deep? true                 ;; omit ⇒ SHALLOW (see below)
+                :default-target :stopped}   ;; where the FIRST :insert lands
+      :stopped {:on {:play [:player :playing]}}
+      :playing {:initial :at-start
+                :on      {:stop  [:player :stopped]
+                          :pause [:player :paused]}
+                :states  {:at-start  {:on {:seek :mid-track}}
+                          :mid-track {}}}
+      :paused  {:on {:resume [:player :playing]}}}}}})
+```
+
+A machine **is an event handler** ([this is the load-bearing difference from xstate](coming-from-xstate.md) — there is no actor to `send` to), so you drive it with ordinary dispatched events and read it with an ordinary subscription:
+
+```clojure
+(rf/dispatch [:media-player [:insert]])  ;; :tray → nothing recorded yet → :default-target → [:player :stopped]
+(rf/dispatch [:media-player [:play]])    ;; → [:player :playing :at-start]
+(rf/dispatch [:media-player [:seek]])    ;; → [:player :playing :mid-track]
+(rf/dispatch [:media-player [:eject]])   ;; → :tray   AND records :player's last config
+(rf/dispatch [:media-player [:insert]])  ;; → restores [:player :playing :mid-track] — resumes mid-track
+
+@(rf/subscribe [:rf/machine :media-player])
+;; => {:state      [:player :playing :mid-track]
+;;     :data       {}
+;;     :tags       #{…}   ;; the union of the active states' declared :tags
+;;     :rf/history  {[:player] [:player :playing :mid-track]}}
+```
+
+You wrote no capture code, no "remember the last tab" action. The `[:player :hist]` target does the work.
+
+## The three keys — and nothing else
+
+A `:type :history` pseudo-state carries **exactly** three keys, all owned by the history grammar:
+
+| Key | Value | Meaning |
+|---|---|---|
+| `:type` | `:history` | The discriminator that marks this node as a history pseudo-state rather than a real substate. **Required.** |
+| `:deep?` | boolean | `true` ⇒ **deep** history (restore the full recorded leaf path). `false` or **absent** ⇒ **shallow** (restore the recorded *direct child*, then cascade through *that* child's `:initial` chain). Default is shallow — a missing `:deep?` reads as `false`. |
+| `:default-target` | child keyword *or* absolute vector | Where to land the **first** time the compound is entered, before anything has been recorded. A direct-child keyword (`:stopped`) or an absolute path. **Absent** ⇒ falls back to the owning compound's `:initial`. |
+
+It MUST NOT declare `:on` / `:entry` / `:exit` / `:always` / `:after` / `:spawn` / `:states` / `:initial` / `:tags` / `:final?` — the machine never occupies it, so transition and lifecycle keys are meaningless on it. Any such key is a **registration error** (caught when you `reg-machine`, not on the unlucky dispatch that first reaches it).
+
+## Shallow vs deep — how *much* of the path is restored
+
+This is the one knob that trips people. Take the same player and eject from deep inside — `[:player :playing :mid-track]`:
+
+- **Deep** (`:deep? true`) records the **full leaf path** beneath the compound. On `:insert` it re-enters every level back down to the exact leaf — `[:player :playing :mid-track]`. The player resumes the exact track *and* its mid-track position.
+- **Shallow** (omit `:deep?`) records only the compound's **direct child** — here `:playing`. On `:insert` it restores that child and then cascades through *its* `:initial` chain. So it resumes `[:player :playing :at-start]` — the right top-level branch (we were playing), but its initial inner position, not `:mid-track`.
+
+So the recorded slot differs by kind:
+
+```clojure
+;; after :eject, DEEP:
+:rf/history {[:player] [:player :playing :mid-track]}   ;; full absolute leaf path
+;; after :eject, SHALLOW:
+:rf/history {[:player] :playing}                        ;; just the direct child keyword
+```
+
+Reach for **deep** when the precise nested position matters (resume the exact track and scrub point); **shallow** when only the top-level branch matters (which tab, not the tab's inner scroll).
+
+## Recording happens on exit — the compound must actually be *left*
+
+Recording is automatic and happens on the way **out**: whenever the exit cascade *leaves* a compound that owns a history pseudo-state, the runtime writes that compound's last-active configuration into the snapshot. You never write capture code.
+
+The subtlety — and the reason the example has a separate `:tray` state — is that the owning compound must be **genuinely exited** to record. This is the [W3C SCXML](https://www.w3.org/TR/scxml/#history) / xstate exit-set rule: a `<history>` value is written only for states in the exit set. A transition that merely moves *between two children* of the compound keeps the compound as the [least-common ancestor](concepts.md#when-the-machine-grows) — the compound **survives**, was never left, and so records nothing (there is no "last config" to remember; it is still in one).
+
+That is exactly why `:eject` targets `:tray` (a *sibling of* `:player`, outside it) rather than some inner state: only leaving `:player` puts it in the exit set. A common first mistake is to put the history node on a compound that nothing ever exits — then it silently never records and "restore" always falls to the default. If your history isn't sticking, check that *something leaves the owning compound.*
+
+Symmetrically, the restore transition — which *enters* the compound through `[:player :hist]` — records nothing for that compound; re-entry leaves the recorded slot untouched.
+
+## Restoring — recorded, else default-target, else `:initial`
+
+When a transition resolves to the pseudo-state, the runtime resolves the target leaf in this order:
+
+1. **A valid recording exists** for the compound → restore it (deep = full leaf path; shallow = recorded child then its `:initial` cascade).
+2. **No recording** (the compound was never entered/exited) → resolve the pseudo-state's `:default-target`; if `:default-target` is absent, fall back to the compound's own `:initial` and cascade from there exactly as a first-ever entry would.
+3. **A recording exists but is no longer a valid path** in the current definition — a *dangling recorded path* after a hot reload removed that substate → the runtime discards it and falls back to `:default-target` / `:initial` per (2). It never enters a dead path; this is benign and raises no error.
+
+Once the pseudo-state resolves to a concrete leaf, nothing else about history is special: the standard LCA computation, exit/entry cascade ordering, `:always` settling, and `:after` timer scheduling all apply to the resolved leaf exactly as if you'd written that leaf as a literal `:target`. History is a *target-resolution step*, not a new cascade mechanism.
+
+## The `:rf/history` snapshot slot
+
+The recording lives in a reserved, framework-owned slot at the root of the snapshot — a sibling of the other `:rf/*` runtime slots:
+
+```clojure
+{:state      [:player :stopped]
+ :data       {…}
+ :rf/history {[:player] [:player :playing :mid-track]}}   ;; map: compound decl-path → recorded config
+```
+
+`:rf/history` is a **map**, keyed by the compound's **declaration path** (a vector of keywords) → that compound's recorded configuration (a full leaf path for deep, a direct-child keyword for shallow). It is a map because a machine can own several history-bearing compounds, each recorded independently. The slot is:
+
+- **read-only for you** — the runtime owns it and writes it during the exit cascade; app code MUST NOT write under it;
+- **allocated lazily** — absent until a history-bearing compound is first exited; a machine with no history nodes never carries the key;
+- **EDN-clean** — vectors and keywords only, so it round-trips through `pr-str` / `read-string` like the rest of the snapshot.
+
+Because the recording is *part of the snapshot value* — not a side-table — recorded history rides every path the snapshot rides, with no extra machinery: undo and [time-travel](../core/glossary.md#time-travel) (rewind to an earlier epoch and its `:rf/history` rewinds too, so "rewind, then re-enter the compound" replays deterministically), persistence, and SSR hydration. The snapshot lives in the frame's [runtime-db](../core/glossary.md#runtime-db), the framework's half of state — so, like everything else there, it is just a value that replay can reach.
+
+## Per-region history under `:type :parallel`
+
+Under a [parallel](concepts.md#when-the-machine-grows) machine each region runs an independent state-tree, so **history is per-region**: a history node declared inside a region's compound records and restores *that region's* configuration on the region's own exit cascade, independently of its siblings. The `:rf/history` keys are **region-qualified** — the region name is the head segment of the declaration-path key — so two regions that each declare a history-bearing compound at structurally-identical paths never collide:
+
+```clojure
+;; Two regions, each with a history-bearing :on compound at the same shape.
+;; The region name heads the key, so the recordings stay separate:
+{:rf/history {[:left  :group :on] [:left  :group :on :bright]
+              [:right :group :on] [:right :group :on :dim]}}
+```
+
+Restoring history in one region leaves the others untouched — the same per-region scoping that `:spawn`, `:after`, and `:always` follow under parallel.
+
+## Coming from XState
+
+If you've drawn history states in xstate, the concepts port one-for-one; only the spelling changes (re-frame2 prefers `?`-suffixed booleans and keyword targets). re-frame2 tracks **behavioural parity** with [xstate v6](coming-from-xstate.md), not API mimicry:
+
+| XState (v5 / v6) | re-frame2 | Note |
+|---|---|---|
+| `{ type: 'history' }` | `{:type :history}` | Same pseudo-state. |
+| `history: 'deep'` (default `'shallow'`) | `:deep? true` (default shallow) | A boolean rather than a string; default is shallow in both. |
+| `target: 'someState'` (default when no history) | `:default-target :some-state` | Where the first entry lands before anything is recorded; absent ⇒ the compound's `:initial`. |
+| internal `historyValue` on the actor | the `:rf/history` slot **inside the snapshot** | **The deliberate divergence.** xstate keeps history as internal actor state; re-frame2 keeps it as a revertible value in the frame, which is why undo / time-travel / SSR get history for free. |
+| records on `statesToExit` (SCXML Appendix D) | records only when the owning compound is in the **exit set** | Identical semantic — history means "where this compound was when we *left* it," so the compound must actually be left. |
+
+The one thing to unlearn is *where the memory lives*: there is no actor object holding `historyValue`. The memory is a value in the snapshot, and the snapshot is just data on the frame.
+
+## Why history is first-class, not a snapshot you stash yourself
+
+You *could* hand-roll the equivalent: an `:exit` action that copies the current sub-path into `:data`, an entry that reads it back, plus the bookkeeping to know *which* compound (and, under parallel, *which region*). re-frame2 ships the declarative node instead, for four reasons:
+
+- **Declarative beats hand-rolled.** `{:type :history :deep? true}` is one node an AI agent (or a teammate) reads and writes confidently; the stash-and-restore version is bespoke per machine.
+- **Composition you'd otherwise re-derive.** Per-region history under parallel, deep nesting, and shallow-vs-deep depth all fall out of the grammar plus the existing cascade machinery — the hand-rolled form has to re-implement each, correctly, every time.
+- **Tooling legibility.** A `:type :history` node is visible to the machine inspector, the diagram exporter, and the SCXML / xstate corpus; hand-rolled `:data` shuffling is invisible to all of them.
+- **Parity.** Both SCXML (`<history>`) and xstate (`{type:'history'}`) ship first-class history; matching the shape keeps the conformance corpus and the AI-trained-on-xstate path aligned.
+
+Revertibility is what makes history *cheap* (the recording rides the snapshot), but it's the foundation history is built on, not a reason to skip the feature.
+
+## Gotchas
+
+- **The owning compound must actually be exited** to record. A within-compound sibling move (the compound survives as the LCA) records nothing — give the compound an off-state to leave for (the `:tray` in the example).
+- **The pseudo-state is never in `:state`.** The machine's `:state` is never `[… :hist]`; a transition to `:hist` resolves to a real leaf. Don't `case` on the pseudo-state keyword in views.
+- **History only applies to a compound.** A `:type :history` node at the machine root (or under a `:type :parallel` root with no enclosing compound region) is a registration error — there is no configuration for it to record.
+- **At most one history node per compound.** Deep-vs-shallow is the single node's `:deep?`, not a reason for two nodes. Two history children under one compound is a registration error.
+- **`:default-target` (keyword form) names a *direct child*** of the owning compound, then cascades any `:initial` chain — not an arbitrary sibling elsewhere. Use the vector form for an absolute path. An unresolvable `:default-target` is a registration error.
+
+## Further reading
+
+- [Machines concepts](concepts.md) — the whole transition-table model: states, [guards and actions](concepts.md#guards-and-actions), [snapshots](glossary.md#snapshot), tags, and [where compound/parallel/history sit](concepts.md#when-the-machine-grows).
+- [`re-frame.machines` API](../api/re-frame.machines.md) — [`reg-machine`](../api/re-frame.machines.md#reg-machine), the `[:rf/machine id]` subscription, and the machine effect tuples (the exact signatures, not restated here).
+- [Coming from XState](coming-from-xstate.md) — the full v6 parity delta, including why a machine is an event handler rather than an actor.
+- Normative contract: **Spec 005 §History states** in [`005-StateMachines.md`](../../spec/005-StateMachines.md) — recording/restoring semantics, the dangling-recorded-path policy, the `:rf/history` slot schema, and the `:fsm/history` capability flag.
+
+These features realise the broader statechart history-state concept described in the [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/).

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -20,6 +20,26 @@ You dispatch events to drive the transitions; the snapshot moves, and the views 
 
 ## In this section
 
-- **[Concepts](concepts.md)** — states, transitions, guards, actions, snapshots, tags, spawning: how machines actually work.
+**Start here**
+
+- **[Concepts](concepts.md)** — the core model: states, transitions, guards, actions, the `{:data :fx}` effect map, the snapshot, and testing transitions as pure calls.
+
+**Structuring states**
+
+- **[Hierarchical states](hierarchical-states.md)** — nested compound states, initial cascading, deepest-wins resolution, entry/exit along the LCA, nested final states.
+- **[Parallel states](parallel-states.md)** — `:type :parallel` regions: orthogonal concurrent state, transition broadcast, cross-region coordination via tags.
+
+**Transitions and behaviour**
+
+- **[Automatic transitions](automatic-transitions.md)** — `:always` (eventless), `:type :choice`, `:after` (delayed), and `:timeout`.
+- **[Actors](actors.md)** — `:spawn` / `:spawn-all` child machines, fan-out + join, cooperative cancellation, cross-machine messaging.
+- **[Tags](tags.md)** — semantic state labels, `:rf/machine-has-tag?`, and collapsing many states into one render decision.
+- **[History](history.md)** — `:type :history` (shallow / deep): re-enter a compound state where you left it.
+
+**Tooling and reference**
+
+- **[Inspecting and testing](inspecting-machines.md)** — the Xray Machine Inspector, machine trace events, and pure-transition unit tests.
+- **[Coming from XState](coming-from-xstate.md)** — the XState v6 → re-frame2 mapping, and the deliberate divergences.
 - **[API](../api/re-frame.machines.md)** — `reg-machine`, the machine effects and the `:rf/machine` subscription, `machine-has-tag?`.
 - **[Glossary](glossary.md)** — the machine vocabulary in one place.
+- **[Examples](examples.md)** — runnable worked apps.

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -1,0 +1,238 @@
+# Inspecting and testing machines
+
+A machine in re-frame2 is [just an event handler](concepts.md#registering-and-running-it) whose body interprets a transition table, and whose whole state is a plain value sitting in the frame's runtime-db. That one fact is the theme of this page: there is **no parallel machine runtime** to attach a special debugger to, and **no second store** to mock in a test. You inspect a machine the way you inspect any re-frame2 state — you `subscribe` to it. You watch it the way you watch any event — through Xray and the trace bus. And you test it the way you'd test a pure function — because a transition literally *is* one.
+
+You reach for the tools here in two situations:
+
+- **A flow misbehaves and you need to see *why*.** Which transition fired? Did the guard pass? What did the action write? *Watch* the machine: open Xray's Machine Inspector and read the transition, or drop to the trace stream for the exact guard/action records.
+- **You want fast, headless confidence the table is correct.** *Test* the machine: feed a snapshot and an event to `machine-transition` and assert on what comes back — no frame, no browser, no network, microseconds per case on the JVM.
+
+Four surfaces, building from "read the value" to "prove the logic":
+
+| Surface | Question it answers | Tool |
+|---|---|---|
+| `[:rf/machine id]` subscription | *What state is it in right now?* | `rf/subscribe` |
+| Xray Machine Inspector | *What did this event do to the machine?* / *What's the chart?* | Xray (Dynamic + Static) |
+| `:rf.machine/*` trace events + `handler-meta` | *Did this guard pass? Where is that action defined?* | trace bus / source-jump |
+| `machine-transition` | *Is the table correct?* (headless test) | pure function call |
+
+---
+
+## Read the live snapshot — `[:rf/machine id]`
+
+The canonical window onto a machine is the framework-registered subscription `[:rf/machine machine-id]`. It returns the [snapshot](glossary.md#snapshot) — the whole `{:state :data :tags}` value — and you subscribe to it exactly like anything else:
+
+```clojure
+(let [{:keys [state data tags]} @(rf/subscribe [:rf/machine :auth.login/flow])]
+  [:div
+   [:p "state: " (name state)]            ;; the discrete FSM keyword, e.g. :submitting
+   [:p "attempts: " (:attempts data)]     ;; :data — the machine's private memory
+   (when (contains? tags :auth/busy)      ;; :tags — union of active states' tags
+     [spinner])])
+```
+
+The three keys are the whole user-facing shape:
+
+- **`:state`** — the discrete FSM keyword (`:idle`, `:submitting`, …). For a hierarchical machine it's a path vector (`[:authenticated :cart :browsing]`); for a parallel machine, a region map. This is what XState calls `state.value`.
+- **`:data`** — the machine's extended state: a plain map, distinct from app-db. XState calls this slot `context`; re-frame2 calls it `:data` to avoid the already-overloaded word "context". Read individual fields by destructuring, never `(get-in snapshot [:data …])` from inside a callback.
+- **`:tags`** — the runtime-projected union of every active state's `:tags`. Ask membership questions against it rather than hard-coding state names (see below).
+
+> **The snapshot is `nil` until the first event.** A machine bootstraps itself on the first event addressed to it, so `[:rf/machine id]` reads `nil` before then. A view that renders pre-bootstrap should fall back to the definition's `:initial`:
+>
+> ```clojure
+> (or @(rf/subscribe [:rf/machine :turnstile/flow])
+>     {:state (:initial turnstile) :data (:data turnstile)})
+> ```
+
+### Named projections off the snapshot
+
+`[:rf/machine id]` is the raw value; chain ordinary `reg-sub`s off it to pluck the pieces a view actually wants. This keeps views reading small, named slices instead of re-destructuring the whole snapshot:
+
+```clojure
+(rf/reg-sub :auth.login/state
+  :<- [:rf/machine :auth.login/flow]
+  (fn [machine _] (:state machine)))
+
+(rf/reg-sub :auth.login/error
+  :<- [:rf/machine :auth.login/flow]
+  (fn [machine _] (get-in machine [:data :error])))
+```
+
+A sub that reads a machine this way is an ordinary derivation node — it does not become a "second kind" of subscription.
+
+### Ask by tag, not by state name
+
+Once a machine has several "loading-ish" states, views stop asking *which exact state?* and start asking a predicate — *is it busy?* That's what [state tags](glossary.md#state-tag) are for. The framework ships a derived predicate sub, and `rf/machine-has-tag?` is sugar over it:
+
+```clojure
+;; both equivalent — the sugar form reads best in a view
+(when @(rf/subscribe [:rf/machine-has-tag? :auth.login/flow :auth/busy]) [spinner])
+(when @(rf/machine-has-tag? :auth.login/flow :auth/busy)                  [spinner])
+```
+
+This sub re-renders only when *this* tag's membership bit flips, so adding a fifth busy state later is one `:tags` entry on the new node — zero view changes.
+
+> **Coming from XState.** There you'd call `actor.getSnapshot()` on a live actor object. In re-frame2 there is no actor object — the snapshot is a value living at `[:rf.runtime/machines :snapshots :auth.login/flow]` in runtime-db, read through the ordinary subscription graph. The payoff is that time-travel, undo, persistence, and SSR hydration all extend to machines *for free*, because the snapshot rides the frame like any other state.
+
+See [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id) and [`machine-has-tag?`](../api/re-frame.machines.md) in the API reference.
+
+---
+
+## Watch a transition happen — the Xray Machine Inspector
+
+Your bug is usually not a value; it's a *process* — the wrong transition fired, or the right one didn't. [Xray](../xray/index.md)'s Machine Inspector reads that process. It has two modes, and the trick is knowing which question each answers.
+
+**Dynamic Machine — the transition history.** This tab is *event-coupled*: click an event row in the spine, and it shows what that one epoch did to a machine — the affected machine, the active state **before and after**, the transition that fired, the guards and actions that ran, entry/exit activity, any spawned or destroyed actors, and `:after` timers and their cancellations. It is the black-box recorder for one transition. If the focused epoch touched no machine, the tab stays quiet — that's honest scope, not a failure. Stepping through the epoch spine (with [time-travel](../xray/03-time-travel.md)) replays the machine's history one transition at a time.
+
+**Static Machines — the state-chart on the wall.** This tab is *event-independent*: browse every registered machine id, inspect its topology, read its states and transitions, and compare the definition's shape to the live snapshot. Reach for it when you need the map rather than a single step.
+
+A reliable machine-debugging loop:
+
+1. Reproduce the action.
+2. Click the event row in the spine.
+3. Open **Dynamic Machine** and read the transition before → after.
+4. If the transition is surprising, flip to **Static Machines** and inspect the definition.
+5. Drop to the **Epoch** or **Trace** tab for the exact guard/action records.
+
+That loop keeps you out of the commonest machine trap: staring at the *current* state while forgetting the *event* that moved it there. Because a machine has a small, named state space, Xray can say something a generic logger never could — not "something updated a map" but "this event moved `:door/main` from `:closed` to `:opening`, ran this guard, scheduled this timer, and cancelled that prior branch." That's the difference between seeing state and seeing behavior.
+
+> **Coming from XState.** Stately's inspector and `@statelyai/inspect` attach an observer to a running actor. Xray's Machine Inspector is the re-frame2 counterpart — but it reads the **same trace bus every event handler already uses**, not a machine-special channel. (A note on scope: there is *no* framework-level `machine->xstate-json` or Mermaid export — visualisation exporters live in the separate `re-frame2-machines-viz` library, not the framework.)
+
+The full tour is in [Xray — Machine Inspector](../xray/08-machine-inspector.md).
+
+---
+
+## The trace events a machine emits
+
+Because a machine is an event handler, every guard evaluation, action run, and transition flows through the standard [trace bus](../core/concepts/observability.md) — the same one Xray renders. There's no separate event log to consult. Three machine-specific records (all under the reserved `:rf.machine/*` namespace) are worth recognising:
+
+```clojure
+;; one trace record per user-declared guard call site
+{:operation :rf.machine/guard-evaluated
+ :tags {:actor-id :auth.login/flow             ;; the LIVE instance (a singleton's id == its type)
+        :guard-id :under-retry-limit
+        :input    {:data {:attempts 3} :event [:auth.login/failure {…}]}
+        :state    :submitting                  ;; the active state the guard ran against
+        :outcome  :fail}}                       ;; :pass | :fail | :threw
+
+;; one trace record per user-declared action invocation
+{:operation :rf.machine/action-ran
+ :tags {:actor-id  :auth.login/flow
+        :action-id :issue-request
+        :phase     :entry                       ;; :exit | :transition | :entry | :always | …
+        :input     {:data {…} :event [:auth.login/submit {…}]}
+        :outcome   :ok}}                         ;; the return value, or :ok, or :rf.error/action-threw
+```
+
+A few things to read off these:
+
+- **`:actor-id` is the live instance; `:machine-id` is reserved for the registered *type*.** For a singleton the two coincide; for a [spawned](glossary.md#spawn) actor `:actor-id` is the gensym'd instance id.
+- **`:state` on the guard trace is the source discriminator.** Two states declaring the same event with the same guard are otherwise indistinguishable; the active `:state` tag attributes a block to the right edge.
+- **`:phase` on the action trace** tells cascade actions apart from transition actions — `:exit` / `:entry` for the LCA cascade, `:transition` for an `:on`-driven action, `:always` for an eventless step, and so on.
+
+The headline `:rf.machine/transition` trace additionally carries a structured **`:cascade`** field — the ordered exit → action → entry (+ initial-descent) step sequence that explains *how* the transition reached its after-state. That single field is what powers Xray's before → after rendering, so you rarely need to re-walk the geometry by hand.
+
+You can tap the stream yourself; Xray is just the richest consumer of it:
+
+```clojure
+;; dev-only: print every machine transition the runtime emits (DCE'd in production)
+(rf/register-listener! :trace :my-app/machine-tap
+  (fn [trace-event]
+    (when (= :rf.machine/transition (:operation trace-event))
+      (js/console.log (pr-str (:tags trace-event))))))
+```
+
+The [Trace tab](../xray/04-trace-stream.md) is the UI over exactly this feed.
+
+### Jump from a snapshot to the guard/action source — `handler-meta`
+
+When you've found the guard that blocked a transition and want to *read it*, ask `handler-meta`. Machine guards and actions aren't a registry kind of their own — their dev-only source is derived on demand from the machine's `:event` registration spec — but the addressing is uniform with every other handler kind, keyed by a `[machine-id id]` pair:
+
+```clojure
+(rf/handler-meta :machine-guard [:auth.login/flow :under-retry-limit])
+;; => {:rf/guard-id        :under-retry-limit
+;;     :rf/machine-id      :auth.login/flow
+;;     :rf.handler/source  "(fn [{data :data}] (< (:attempts data) 3))"
+;;     :handler-fn         #<fn>
+;;     :ns … :line … :file …}
+
+(rf/handler-meta :machine-action [:auth.login/flow :issue-request])
+;; => {:rf/action-id :issue-request :rf/machine-id :auth.login/flow
+;;     :rf.handler/source "(fn [{[_ creds] :event}] {:fx [[:rf.http/managed …]]})" …}
+```
+
+This is the surface Xray's focused-transition lens and the re-frame2 pair MCP use to render guard/action source inline under their declared id. (`reg-machine` captures that source at macro-expansion time; the `:source`-bearing slots are dev-only and elide under `:advanced` + `goog.DEBUG=false`.) See [`handler-meta`](../api/re-frame.core.md#handler-meta) for the general contract.
+
+> **Divergence the spec calls out — a guard that throws aborts the macrostep.** This matches XState (which throws on a guard exception): re-frame2 emits one `:rf.machine/guard-evaluated` with `:outcome :threw`, then aborts transition selection — no candidate falls through to a sibling, no transition fires, and the snapshot rolls back **atomically** (nothing reaches runtime-db). A thrown *action* and a runaway `:always`/`:raise` depth-abort converge on the same failed-macrostep semantics. The runtime does not silently demote a thrown guard to a lower-priority candidate — and neither does XState.
+
+---
+
+## Unit-test transitions as pure function calls — `machine-transition`
+
+This is where machines pay you back hardest. A transition is a pure function of *(definition, snapshot, event)*, exposed as `re-frame.machines/machine-transition`. No frame, no browser, no mocks, no clock — table in, snapshot in, event in; result out. These tests run on the JVM in microseconds, which is exactly the testing experience you want for the flows where testing usually gets *hard*.
+
+The return value is a **Result map**. Discriminate it with `result/ok?` / `result/fail?`, and read the post-transition snapshot and emitted effects with the `result/snap` / `result/fx` accessors (or destructure the `::result/snap` / `::result/fx` keys directly):
+
+```clojure
+(ns my-app.login-flow-test
+  (:require [clojure.test :refer [deftest is]]
+            [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]
+            [my-app.login :refer [login-flow]]))   ;; the transition-table value
+
+(deftest login-flow-test
+  ;; happy path: :idle --submit--> :submitting, whose :entry fires the request fx
+  (let [r (machines/machine-transition
+            login-flow
+            {:state :idle :data {:attempts 0 :error nil}}
+            [:auth.login/submit {:email "a@b.com" :password "secret"}])]
+    (is (result/ok? r))
+    (is (= :submitting (:state (result/snap r))))
+    (is (= :rf.http/managed (ffirst (result/fx r)))))   ;; the :issue-request action's fx
+
+  ;; at the retry limit the guard rejects :error-shown, so :locked-out wins
+  (let [r (machines/machine-transition
+            login-flow
+            {:state :submitting :data {:attempts 3 :error nil}}
+            [:auth.login/failure {:failure {:message "bad creds"}}])]
+    (is (= :locked-out (:state (result/snap r))))))
+```
+
+Two things make this pleasant:
+
+- **Effects are asserted as data, not intercepted.** `(result/fx r)` is the ordinary re-frame `:fx` vector the action returned — you check its *shape* (`(ffirst …)` is `:rf.http/managed`) without ever performing the request. The action describes an effect; the test reads the description.
+- **A throwing action is a *failure value*, not an exception out of your test.** A guard or action that throws yields `(result/fail? r)` with `(result/info r)` carrying the diagnostic, so one assertion style covers both the happy and the broken path. (This is the pure-surface face of the atomic-rollback semantics above.)
+
+If the machine is already registered and you want to drive its *registered* definition rather than the raw value, pull it back with `machine-meta`:
+
+```clojure
+(machines/machine-transition (machines/machine-meta :auth.login/flow) snapshot event)
+```
+
+### The same value runs in the browser *and* the JVM
+
+The `login-flow` table above is plain data, so the very same value that renders a live Reagent form also unit-tests headless. The trick is a `.cljc` source file: it compiles under shadow-cljs for the browser demo *and* loads on the JVM for these tests. The worked example at [`examples/capabilities/machines/state_machine_walkthrough/`](../../examples/capabilities/machines/state_machine_walkthrough/) does exactly this — one table, two lives — and its headless scenarios run on every CI pass.
+
+### Three test levels
+
+`machine-transition` is the fastest of three levels that fall out of the machine being a pure factory — no new test primitive needed:
+
+| Level | What you test | Speed | Can't reach |
+|---|---|---|---|
+| **1 — `machine-transition`** | FSM logic, guards, action effect *shapes* | fastest | snapshot/db plumbing, fx integration |
+| **2 — unregistered handler fn** | handler-level wiring, `:data`-to-`:db` lowering | fast | dispatch pipeline, spawn lifecycle |
+| **3 — registered in a test frame** | full integration: trace events, drain, spawn/destroy, cross-actor messaging | slowest | nothing |
+
+Most logic lives at Level 1. Reach for Level 3 only for spawned-actor patterns, where the whole point is that a handler gets registered dynamically and the parent can `dispatch` to it. The contracts for all three are in [Spec 005 §Testing](../../spec/005-StateMachines.md).
+
+> **Coming from XState.** Driving an XState machine in a test means standing up the interpreter (`createActor(machine).start()`, then `actor.send(…)`) or reaching for `@xstate/test`'s model-based harness. re-frame2's `machine-transition` needs neither — it's a bare pure function, so the unit test *is* `(fn definition snapshot event)`. The behavioural contract is identical: *(state, event) → next state + effects*; only the actor object disappears.
+
+See [`machine-transition`](../api/re-frame.machines.md#re-framemachinesmachine-transition) and [`machine-meta`](../api/re-frame.machines.md#re-framemachinesmachine-meta) in the API reference, and the narrative in [Concepts §Testing](concepts.md#testing-transitions-are-pure-function-calls).
+
+---
+
+## Further reading
+
+- **Normative spec** — [Spec 005 — State Machines](../../spec/005-StateMachines.md): §Testing (the three-level pyramid and the pure transition contract), §Trace events — guard evaluations and action runs, and §`:machine-guard` / `:machine-action` handler-meta surfaces are the authoritative source for everything on this page.
+- **Sibling pages** — [Concepts](concepts.md) for the transition table and the recognition kit, [Glossary](glossary.md) for the surface vocabulary, [Coming from XState](coming-from-xstate.md) for the full parity delta, and [`re-frame.machines` API](../api/re-frame.machines.md) for the exhaustive function-by-function contract.
+- **The statechart lineage** — these features realise the broader statechart model: [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) is the behavioural-parity reference (re-frame2 matches XState's *behaviour*, not its API), and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/) is the other prominent Clojure realisation of the same SCXML-derived ideas.

--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -1,0 +1,296 @@
+# Parallel regions
+
+Some lifecycles aren't *one* question — they're several, all live at once. A todos screen is, at the same instant, *somewhere in its fetch* (nothing / loading / empty / some / too-many), *somewhere in its form* (neutral / valid / invalid), and *somewhere in its page mode* (active / archived). Those three axes are **orthogonal**: each moves on its own, and any combination is legal.
+
+Model that as one flat machine and the states multiply — three axes of three states each is `3 × 3 × 3 = 27` cross-product states, most of them named things like `:loading-and-invalid-and-active`. **Parallel regions** keep the axes apart. One machine declares `:type :parallel` and a `:regions` map; each region is a full little state-tree minding one axis; all regions are active simultaneously. Three axes of three states becomes **nine states across three regions**, not twenty-seven flat ones.
+
+> **Coming from XState?** This is XState's `type: 'parallel'` state (and SCXML's `<parallel>`). Same concept, idiomatic spelling: `:type :parallel` plus a `:regions` map keyed by region name. The behaviour is the contract re-frame2 tracks — see [Coming from XState](coming-from-xstate.md) for the full delta, and [the machines guide](concepts.md#when-the-machine-grows) for where this sits among the other grammar extensions.
+
+## When to reach for parallel regions
+
+Reach for them when you have **multiple orthogonal axes of one feature** that share a domain: one form with data / validity / display-mode axes, one connection with auth + lifecycle + request-queue, one widget with display + interaction state. The giveaway is a single conceptual thing whose state is naturally a *tuple* of independent sub-states.
+
+The axes share a single [`:data`](concepts.md#the-same-flow-as-a-transition-table) map *because they're facets of one domain* — they read and write the *same* data, just sliced differently. If your axes are genuinely separate features that share nothing (a websocket connection plus an unrelated auth flow plus a route), that's not parallel regions — that's **N separate machines** colocated in [runtime-db](../core/glossary.md#runtime-db). Per-region `:data` is deliberately **not** supported; if your axes need their own encapsulated data, that's the substrate telling you to register N machines instead. (The full parallel-regions-versus-N-machines trade-off lives in the spec — see Further reading.)
+
+## The shape: one machine, several regions
+
+Here's the canonical three-region machine — the "[Nine States of UI](../../examples/patterns/nine_states)" pattern, trimmed to its bones. Three axes, one declaration:
+
+```clojure
+(rf/reg-machine :ui/nine-states
+  {:type :parallel
+   :data {:items [] :error nil :archived-at nil}     ;; shared across every region
+
+   :guards  {:empty?    (fn [{:keys [data]}] (zero? (count (:items data))))
+             :too-many? (fn [{:keys [data]}] (> (count (:items data)) 7))}
+
+   :actions {:set-items (fn [{data :data [_ {:keys [items]}] :event}]
+                          {:data (assoc data :items (vec items))})}
+
+   :regions
+   {:data {:initial :nothing
+           :states  {:nothing   {:tags #{:data/nothing}
+                                 :on   {:fetch-started :loading}}
+                     :loading   {:tags #{:data/loading}
+                                 :on   {:fetch-succeeded {:target :resolving
+                                                          :action :set-items}}}
+                     :resolving {:always [{:guard :empty?    :target :empty}
+                                          {:guard :too-many? :target :too-many}
+                                          {:target :some}]}
+                     :empty     {:tags #{:data/empty}}
+                     :some      {:tags #{:data/some}}
+                     :too-many  {:tags #{:data/too-many}}}}
+
+    :form {:initial :neutral
+           :states  {:neutral   {:tags #{:form/neutral}
+                                 :on   {:submit-valid   :correct
+                                        :submit-invalid :incorrect}}
+                     :incorrect {:tags #{:form/invalid}}
+                     :correct   {:tags #{:form/success}}}}
+
+    :mode {:initial :active
+           :states  {:active {:tags #{:mode/active}
+                              :on   {:archive :done}}
+                     :done   {:tags #{:mode/done :mode/read-only}}}}}})
+```
+
+Each region body — `:data`, `:form`, `:mode` — is itself an ordinary transition table: its own `:initial`, its own `:states`, with `:on` / `:tags` / `:always` / `:after` / `:spawn` on each node, exactly as a flat machine. The only structural rule at the top: `:type :parallel` is **mutually exclusive** with a root `:initial` / `:states` — you declare *regions* there instead (registration throws `:rf.error/machine-parallel-bad-shape` if you write both).
+
+## The snapshot: `:state` becomes a map
+
+A flat machine's [snapshot](glossary.md#snapshot) `:state` is a single keyword. A parallel machine's `:state` is a **map of region-name → that region's current state**:
+
+```clojure
+;; flat region — the value is a keyword
+{:state {:data :loading :form :neutral :mode :active}
+ :data  {:items [] :error nil :archived-at nil}
+ :tags  #{:data/loading :form/neutral :mode/active}}
+
+;; a COMPOUND region — that region's value is a vector path INSIDE the region
+{:state {:auth [:authenticated :dashboard] :lifecycle :idle} ...}
+```
+
+Three things to read off that snapshot:
+
+- **`:state`** is the per-region map. A flat region contributes a keyword; a compound region (one whose own tree nests sub-states) contributes the in-region vector path.
+- **`:data`** is **shared** — one map, seen and written by every region. There is no per-region `:data` slot, on the region body or in the snapshot.
+- **`:tags`** is the **union** of every active state's tags across every region (covered [below](#tags-compose-across-regions)).
+
+> **Coming from XState?** XState's parallel state value is a nested object, `{ data: 'loading', form: 'neutral', mode: 'active' }`. re-frame2's `:state` map is the same idea in Clojure data, and you read it through one ordinary subscription — `@(rf/subscribe [:rf/machine :ui/nine-states])` — not an `actor.getSnapshot()`. The [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id) sub returns the whole snapshot; named projections chain off it like any other [subscription](../core/concepts/subscriptions.md).
+
+## Each region has its own `:initial`
+
+Every region declares its own `:initial`, just like a flat machine — a region missing `:initial` is a registration-time error. At machine boot the initial snapshot's `:state` is the map of each region's initial cascade: a flat region lands on its `:initial` keyword; a compound region descends its `:initial` chain to a leaf. Each region's `:entry` cascade runs once at boot, and each region's birth `:always` settles independently as part of the initial step.
+
+So immediately after the machine above starts, before any event:
+
+```clojure
+@(rf/subscribe [:rf/machine :ui/nine-states])
+;; => {:state {:data :nothing :form :neutral :mode :active}
+;;     :data  {:items [] :error nil :archived-at nil}
+;;     :tags  #{:data/nothing :form/neutral :mode/active}}
+```
+
+All three regions are alive at their initial states, and the `:tags` set already carries one tag per region.
+
+## Broadcast: one event reaches every region
+
+This is the heart of it. Every event dispatched at a parallel machine is **broadcast to every region**. Each region's *currently-active* state independently decides whether the event matches one of its `:on` keys:
+
+- **The region has a matching transition whose guard passes** → that region transitions (exit cascade → action → entry cascade), and any `:fx` its action returns joins the macrostep.
+- **The region has no matching transition** (or its guard returns false) → that region stays put. No per-region complaint is raised.
+- **No region anywhere handled the event** → the machine consults the [root `:on` fallback](#the-root-on-an-ancestor-fallback), and only if *that* also declines does it emit the benign `:rf.machine.event/unhandled-no-op` trace, exactly once. An unhandled event is a no-op, not an error.
+
+In the nine-states machine, dispatching `:fetch-started` reaches all three regions, but only `:data` lists it, so only `:data` moves:
+
+```clojure
+(rf/dispatch-sync [:ui/nine-states [:fetch-started]])
+;; :data → :loading ; :form and :mode have no :fetch-started, so they hold.
+;; :state {:data :loading :form :neutral :mode :active}
+
+(rf/dispatch-sync [:ui/nine-states [:fetch-succeeded {:items [{:id 1} {:id 2}]}]])
+;; :data handles it: :loading → :resolving (running :set-items), then the
+;; region's own :always cascade reads the now-2 :items and falls through to :some.
+;; :state {:data :some :form :neutral :mode :active}  ·  :data {:items [{:id 1} {:id 2}] ...}
+```
+
+(`dispatch-sync` runs the transition synchronously, so the snapshot is readable on the next line — handy in the REPL and tests; in views you dispatch the usual async way.)
+
+### Shared `:data` flows through each region's action
+
+When *several* regions handle the same event, each one's action runs against the **shared** `:data` — and an [action](glossary.md#action) returns the same data-shaped effect map a `reg-event` handler does, `{:data ... :fx ...}`. The selected transitions apply in **region-declaration order**, so each region's action sees the prior region's `:data` writes:
+
+```clojure
+(rf/reg-machine :ui/example
+  {:type    :parallel
+   :data    {:count 0}
+   :actions {:bump-count (fn [{d :data}] {:data (update d :count inc)})}
+   :regions
+   {:left  {:initial :a
+            :states  {:a {:tags #{:left/a} :on {:reset {:target :a :action :bump-count}}}}}
+    :right {:initial :x
+            :states  {:x {:tags #{:right/x} :on {:reset {:target :x :action :bump-count}}}}}}})
+
+(rf/dispatch-sync [:ui/example [:reset]])
+;; Both regions handle :reset. :bump-count runs ONCE PER REGION against the
+;; shared :data — :count goes 0 → 1 → 2.
+;; => {:state {:left :a :right :x} :data {:count 2} :tags #{:left/a :right/x}}
+```
+
+If you wanted that event to count *once*, you'd register the coordinating action at the parent-machine level, or shape the regions so only one handles it.
+
+> **A subtle, load-bearing rule — selection is order-independent.** The broadcast is **select-then-apply**: every region's enabled transition is *selected* against **one frozen pre-broadcast snapshot** of the configuration, and only *then* are the selected transitions *applied* in declaration order. Declaration order governs only the apply order (action / `:fx` order, `:data` accumulation) — **never** which transitions are selected. Reorder the regions and you get the *same* selected set, and the new configuration is computed **atomically** old→new: no region ever observes an intermediate state where some siblings have moved and others haven't. This matches XState v5 / SCXML, where a parallel macrostep selects against the pre-event configuration. (It matters most for the next section.)
+
+## The root `:on`: an ancestor fallback
+
+A `:type :parallel` machine may declare its **own** `:on` at the root — alongside `:regions`, not instead of them. This is the **ancestor fallback**: the parallel analog of a flat or compound machine's root `:on` fallthrough.
+
+```clojure
+(rf/reg-machine :ui/board
+  {:type :parallel
+   :data {}
+   :regions
+   {:a {:initial :one
+        :states  {:one     {:on {:reset :special}}   ;; region :a handles :reset ITSELF
+                  :two     {}
+                  :special {}}}
+    :b {:initial :one
+        :states  {:one {} :two {}}}}
+   :on {:go-all {:target [[:a :two] [:b :two]]}      ;; no region declares :go-all
+        :reset  {:target [[:a :one] [:b :two]]}}})   ;; region :a DOES declare :reset
+```
+
+The rule has two halves, and the second is the whole point:
+
+**When no region handled the event, the root fires.** Nothing else lists `:go-all`, so the root catches it and moves the regions it targets:
+
+```clojure
+(rf/dispatch-sync [:ui/board [:go-all]])
+;; No region declares :go-all → root ancestor fallback fires.
+;; :state {:a :two :b :two}
+```
+
+**When *any* region handled the event, the root is suppressed *entirely* — atomic, all-or-nothing.** It is *not* "fire the root for the regions that didn't handle it." Region `:a` declares `:reset` locally, so on `:reset` the root transition is dropped wholesale, and regions the root *would* have moved are left untouched:
+
+```clojure
+;; from the initial {:a :one :b :one}:
+(rf/dispatch-sync [:ui/board [:reset]])
+;; :a has a local :reset (:one → :special) → :a competes → the WHOLE root :reset
+;; is suppressed → :b is left UNCHANGED (stays :one), even though the root's :reset
+;; targeted :b → :two.
+;; :state {:a :special :b :one}
+```
+
+That last result is the **non-decomposable** case. A naive broadcast decomposition (region `:a`: `reset → special`; region `:b`: `reset → :two`) would fire both independently and give `{:a :special :b :two}`. The atomic suppression instead leaves `:b` untouched — a coordination a *per-region* `:on` simply cannot express, because per-region transitions have no cross-region suppression.
+
+**Target grammar.** A root `:on` target is one of: **targetless / action-only** (runs `:action` / `:fx`, moves no region); a **single region-qualified target** `[<region> & <in-region-path>]` (e.g. `[:a :two]`, or `[:a :compound :leaf]`); or **multiple** `[[<region> …] [<region> …]]` (e.g. `[[:a :x] [:b :y]]`). A bare-keyword target, or one whose head isn't a declared region, is rejected at registration with `:rf.error/machine-parallel-root-on-bad-target` — a root-only parallel machine has no flat sibling state to land a non-region-qualified target on.
+
+A `:type :parallel` root may also declare its own **`:after`** — the timer-driven twin of the root `:on`. It's scheduled at machine birth, owned by the root (alive for the machine's whole life rather than tied to any one region's lifecycle), and uses the very same region-qualified target grammar.
+
+> **Coming from XState?** This is XState's "[multiple transitions in parallel states](https://stately.ai/docs/state-machines-and-statecharts)" — a transition on the `<parallel>` node targeting one or several regions, `target: ['.a.x', '.b.y']`, which re-frame2 spells `:target [[:a :x] [:b :y]]`. The atomic suppression-when-a-region-competes is XState v5 / SCXML behaviour.
+
+## Coordinating regions: tags as `stateIn`
+
+Orthogonal regions are independent — but sometimes one region's transition should depend on *where a sibling is*. The classic case: a `:checkout` region's `:submit` should only fire when the `:form` region is `:valid`.
+
+In XState you'd write a `stateIn({ form: 'valid' })` guard (SCXML's `In()` predicate). re-frame2 ships the same **behaviour** without a separate combinator (behavioural parity, not API mimicry). When a guard or action runs **inside a region** of a parallel machine, its context map carries two extra cross-region keys alongside the usual `:data` / `:event` / `:state` / `:meta`:
+
+| ctx key | value | use |
+|---|---|---|
+| **`:tags`** | the machine-wide active-configuration tag union | the **coarse** read — a sibling advertises a tag, you ask `(contains? tags :form/valid)`. The idiomatic choice: a tag is a *named* render-state that survives a sibling renaming its internal states. |
+| **`:all-state`** | the full region → active-state map, e.g. `{:form :valid :checkout :idle}` | the **precise** read — `(= :valid (:form all-state))` matches a sibling's discrete state value directly, the literal analog of `stateIn({form: 'valid'})`. |
+
+```clojure
+;; xstate stateIn({form: 'valid'}), as re-frame2's tag substitute: :checkout's
+;; :submit fires only while the :form region advertises :form/valid.
+(rf/reg-machine :ui/checkout
+  {:type   :parallel
+   :data   {}
+   :guards {:form-valid? (fn [{:keys [tags]}] (contains? tags :form/valid))}
+   :regions
+   {:form     {:initial :editing
+               :states  {:editing {:tags #{:form/editing} :on {:complete :valid}}
+                         :valid   {:tags #{:form/valid}}}}
+    :checkout {:initial :idle
+               :states  {:idle       {:on {:submit {:target :submitting
+                                                    :guard  :form-valid?}}}
+                         :submitting {:tags #{:checkout/submitting}}}}}})
+
+(rf/dispatch-sync [:ui/checkout [:submit]])
+;; :form is still :editing → :form/valid is NOT in the union → :submit BLOCKED.
+;; :state stays {:form :editing :checkout :idle}
+
+(rf/dispatch-sync [:ui/checkout [:complete]])   ;; :form → :valid (advertises :form/valid)
+(rf/dispatch-sync [:ui/checkout [:submit]])
+;; :checkout's guard now reads :form/valid in (:tags ctx) → :submit FIRES.
+;; :state → {:form :valid :checkout :submitting}
+```
+
+The precise variant reads the sibling's state value directly:
+
+```clojure
+:guards {:form-is-valid? (fn [{:keys [all-state]}] (= :valid (:form all-state)))}
+```
+
+Prefer the **tag** query: a tag is a named, tool-legible render-state, and it holds up when a sibling region refactors its internal state names.
+
+> **Both keys are frozen.** `:tags` and `:all-state` reflect the **frozen pre-broadcast snapshot** — the sibling configuration as of the *start* of the macrostep. A region's guard never sees a sibling's *same-event* move during selection (regions are genuinely simultaneous), which is exactly why selection is declaration-order-independent. A region reading its *own* state uses `:state` (which does evolve through its own `:always` loop); `:tags` / `:all-state` are the mechanism for reading *siblings*, and they're frozen. These two keys appear **only** for region guards/actions — a flat / compound machine's ctx stays exactly `{:data :event :state :meta}`, because its own `:state` is its `stateIn` substitute.
+
+The two `dispatch-sync` calls above are **separate events**, which is why each `:submit` reads the prior committed config. If you need a *single* event to flip `:form` to `:valid` **and** advance `:checkout` in the same breath, two statechart-idiomatic paths re-couple them — they differ in *when* convergence lands:
+
+- **`:raise` — converges in the SAME macrostep.** `:form`'s `:complete` action returns `:fx [[:raise [:form-valid]]]`; that internal event re-broadcasts across every region (next microstep, still inside the one atomic macrostep), and `:checkout`'s `:on {:form-valid …}` resolves it against the now-`:valid` `:form`. This is the strictly-same-macrostep path.
+- **A guarded `:always` reading the sibling — converges on the NEXT EVENT.** `:checkout` carries `{:always {:target :submitting :guard :form-valid?}}`. A *plain* sibling move doesn't trigger an in-macrostep re-broadcast, so this re-selects against the committed `:form/valid` on the next event delivered — it fires, just one event later.
+
+Both are bounded by the `:always-depth-limit` / `:raise-depth-limit` (default 16), so neither can spin.
+
+## Per-region `:always` / `:after` / `:spawn` — and the `:raise` exception
+
+Each region's state-node keys are **scoped to that region**:
+
+- **`:always`** — the microstep loop runs *per region*. After a region's transition, that region's new state's `:always` entries are checked and settle to *that region's* fixed point; siblings aren't re-evaluated for `:always` on this region's microstep. (That's exactly the `:resolving → :empty | :some | :too-many` cascade in the nine-states `:data` region.)
+- **`:after`** — a timer arms / cancels on *its region's* state entry / exit. A sibling region transitioning does **not** cancel this region's in-flight `:after` timer; each region keeps its own timer epoch.
+- **`:spawn`** — a region's [`:spawn`](glossary.md#spawn)-bearing state starts and tears down child actors bound to *that region's* state; siblings never see the spawn / destroy cascade.
+- **`:entry` / `:exit`** — fire on the region's own transitions, never on a sibling's.
+
+> **`:raise` is the exception — it BROADCASTS.** A `[:raise [:event]]` emitted by any region's action does **not** stay local. It re-enters the parallel machine's single internal-event queue and re-broadcasts across **every** region — exactly as XState / SCXML deliver a `raise`d internal event to the whole machine, every active parallel state included. Each re-broadcast is its own microstep (a fresh frozen sibling view that already reflects the prior microstep's moves, while the in-flight `:data` flows through), the queue drains FIFO, and the whole macrostep — external event + every raised event + every region's `:always` settling — commits **once, atomically**, bounded by the `:raise-depth-limit`.
+
+## Tags compose across regions
+
+A parallel machine's `:tags` is the **union of every active state's tags across every active region** — walk each region's active configuration (root → leaf for compound regions), union the tags, then union across regions. So in the nine-states machine at boot, `:data`'s `:nothing` contributes `#{:data/nothing}`, `:form`'s `:neutral` contributes `#{:form/neutral}`, `:mode`'s `:active` contributes `#{:mode/active}`, and the snapshot's `:tags` is `#{:data/nothing :form/neutral :mode/active}`.
+
+The framework [`machine-has-tag?`](../api/re-frame.machines.md) sub works unchanged — it asks "does the union contain this tag?", and the answer is yes iff *any* active state in *any* region declared it. That's what lets a view disable itself with `@(rf/machine-has-tag? :ui/nine-states :mode/read-only)` without caring which region (or which state of it) carries the read-only intent — *ask, don't tell* ([state tag](glossary.md#state-tag)).
+
+The composed tag union is also what makes the headline payoff work: **collapsing N live axes down to one render decision**. Several tags are live at once, but the page draws one thing, so a plain-data priority table picks the winner:
+
+```clojure
+(def render-priority                       ;; read top to bottom; first match wins
+  [{:tag :mode/done    :render :done}      ;; an archived list trumps everything
+   {:tag :form/success :render :correct}   ;; transient form acknowledgements next
+   {:tag :form/invalid :render :incorrect}
+   {:tag :data/loading :render :loading}   ;; then the resting data axis
+   {:tag :data/nothing :render :nothing}
+   {:tag :data/empty   :render :empty}
+   {:tag :data/some    :render :some}
+   {:tag :data/too-many :render :too-many}])
+
+(rf/reg-sub :ui/render
+  :<- [:rf/machine :ui/nine-states]
+  (fn [snap _]
+    (let [tags (:tags snap)]
+      (some (fn [{:keys [tag render]}] (when (contains? tags tag) render))
+            render-priority))))
+```
+
+The root view's whole branching logic is then a single `case` over `@(rf/subscribe [:ui/render])`. Three regions, nine states, **one** branch site — and the display priorities live in *one* readable table, not scattered across ten views.
+
+## A divergence to know: no nested parallel regions
+
+**Nested parallel regions are not supported in v1.** A region whose own tree declares `:type :parallel` is rejected at registration with `:rf.error/machine-parallel-nested-not-supported`. XState permits arbitrary nesting; re-frame2 does not (yet). Model a would-be two-level cross-product as a flatter set of regions, or — more idiomatically — as multiple top-level parallel-region machines. A region *may* still be a compound (hierarchical) state-tree; it just can't itself be parallel.
+
+## Further reading
+
+- **Normative contract** — [Spec 005 §Parallel regions](../../spec/005-StateMachines.md#parallel-regions) is the exhaustive source: the select-then-apply broadcast model, the root-`:on` / root-`:after` ancestor fallback, the frozen `:tags` / `:all-state` reads, per-region scoping, capability gating, and the registration-error taxonomy.
+- **The machine surface** — the [`re-frame.machines` API](../api/re-frame.machines.md) for `reg-machine`, the [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id) subscription, and `machine-has-tag?`.
+- **The other grammar** — [Machines concepts](concepts.md#when-the-machine-grows) (where parallel regions sit among hierarchy, history, `:after`, `:spawn`, and final states) and [Coming from XState](coming-from-xstate.md).
+- **Runnable code** — the full [Nine States of UI example](../../examples/patterns/nine_states), where this exact machine drives a real managed-HTTP fetch, a form slice, and a read-only archive mode.
+- **The broader idea** — parallel regions realise the orthogonal-region concept from the statechart literature: [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/) cover the same `parallel` / `In()` concepts in their own runtimes.

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -1,0 +1,210 @@
+# State tags
+
+Some questions a view asks aren't "which state is the machine in?" but "is the machine *busy*?" — across `:loading`, `:retrying`, `:reconnecting`, and whatever in-flight state you add next month. A **[state tag](glossary.md#state-tag)** is a semantic label you pin to a state so a view can ask for the *intent* — busy, read-only, terminal — instead of enumerating the exact state names that happen to mean it. *Ask, don't tell.*
+
+Reach for tags when:
+
+- several states share a meaning a view cares about ("any of these is loading-ish"), and you don't want a boolean sub per state;
+- a page's render decision slices across more than one axis (data cardinality × form validity × mode) and you want one decision table instead of an N-way `cond`;
+- a guard in one [parallel region](concepts.md#when-the-machine-grows) needs to know what a *sibling* region is doing without reaching into its private state.
+
+If a label would only ever match exactly one state, skip it — query the state directly with `(= :loading (:state snap))`. Tags earn their keep by matching *many* states with one shared intent.
+
+> **Coming from XState.** re-frame2's `:tags` *are* XState's state `tags` — same name, same concept, a clean convergence. `tags: ['busy']` becomes `:tags #{:busy}` (a Clojure set, not a JS array), and the union rule is identical: any active state carrying the tag puts it in the snapshot's tag set. The one shift to learn is the *query* side. XState reads `state.hasTag('busy')` off a living actor; in re-frame2 a machine is an [event handler](../core/glossary.md#event-handler) with no actor object, so the membership question is a **[subscription](../core/concepts/subscriptions.md)** — `@(rf/machine-has-tag? id :busy)`. The full row-by-row map is in [Coming from XState](coming-from-xstate.md#the-mapping). This page assumes the [machine grammar](concepts.md) — `reg-machine`, the transition table, the `{:state :data}` snapshot — from the concepts chapter.
+
+## Declaring tags on a state
+
+`:tags` is a state-node key whose value is a **set of keywords**. There's no separate registration step — it's just another slot on the state, alongside `:on`, `:entry`, and `:after`:
+
+```clojure
+(rf/reg-machine :todos/loader
+  {:initial :idle
+   :states
+   {:idle     {:on {:fetch :loading}}
+
+    :loading  {:tags #{:data/in-flight}
+               :on   {:ok :ready :fail :retrying}}
+
+    :retrying {:tags #{:data/in-flight}            ;; same intent as :loading
+               :on   {:ok :ready :give-up :error}}
+
+    :ready    {:tags #{:data/ready}}
+    :error    {:tags #{:data/error}}}})
+```
+
+Both `:loading` and `:retrying` wear `:data/in-flight`. A view that wants "show the spinner while a request is in flight" consumes that one tag and never disjoins two state keywords — and the day you add a third in-flight state, it's one `:tags` entry and the view picks it up for free.
+
+Two rules worth pinning down now:
+
+- **Tags label *intent*, not *identity*.** `:tags #{:data/in-flight}` is good; `:tags #{:todos.loader/loading-state}` just re-encodes the state name and earns nothing. Use a per-axis namespace (`:data/…`, `:form/…`, `:mode/…`) so one tag-question can span several states.
+- **The `:rf/*` / `:rf.*/*` namespaces are framework-reserved.** Tag with your own feature prefix — `:auth/busy`, `:cart/dirty`, `:ws/disconnected`. Any unreserved namespace is fair game, dotted forms (`:ui.state/loading`) included.
+
+> **Tags ride on *states*, never on transitions.** `:tags` is a state-node slot only — there is no tag on an `:on` entry, an `:always`, or an `:after`. "Was this transition tagged?" is already answered by the trace vocabulary, so a transition carries no tag. (Adding transition tags later would be non-breaking — but today, tags are not on transitions.)
+
+## The snapshot's `:tags` slot
+
+At every transition the runtime walks the machine's active states, unions their tag sets, and stamps the result onto the [snapshot](glossary.md#snapshot) at `:tags`. The snapshot gains one optional slot:
+
+```clojure
+@(rf/subscribe [:rf/machine :todos/loader])
+;; => {:state :retrying :data {…} :tags #{:data/in-flight}}
+```
+
+How the union is computed depends on the machine's shape:
+
+- **Flat machine** — the single active state's `:tags`.
+- **Compound (hierarchical) machine** — the union along the active path: root → every compound ancestor → leaf.
+- **Parallel machine** — the union across *every* active state in *every* region. (This is what makes tags the cross-region signal in the last section.)
+
+`:tags` is **read-only** for you. It's a pure projection of `:state` — set the state, the tags follow — so an action can't return `:tags` in its `{:data :fx}` effect map; the runtime owns the slot. And when the union is **empty** (no active state declares any tag), the runtime **elides** the key entirely: a tag-free machine carries no `:tags` slot at all, so `(contains? snap :tags)` can be `false` even after the machine has settled. Don't declare an empty `:tags #{}` to "have the slot" — just omit it.
+
+## Querying with `machine-has-tag?`
+
+The framework ships one **derived subscription** for the containment question — *does this machine's snapshot carry this tag?*
+
+```clojure
+;; The query vector …
+@(rf/subscribe [:rf/machine-has-tag? :todos/loader :data/in-flight])   ;; => true | false
+;; … and its sugar, re-exported on the re-frame.core facade:
+@(rf/machine-has-tag? :todos/loader :data/in-flight)                   ;; => true | false
+```
+
+In a view that's all you need to render on intent:
+
+```clojure
+(reg-view spinner-or-list []
+  (if @(rf/machine-has-tag? :todos/loader :data/in-flight)
+    [spinner]
+    [todo-list]))
+```
+
+Because the sub is **derived directly off the snapshot's `:tags` slot** — it reads the containment bit with `get-in` rather than chaining the whole `[:rf/machine id]` snapshot — a view that asks one tag re-renders only when *that bit* flips, not on every `:data` mutation or unrelated transition. It returns `false` for an unknown or not-yet-initialised machine, so there's no nil-guard to write.
+
+Need the whole set rather than one bit? That's the ordinary snapshot read:
+
+```clojure
+(:tags @(rf/subscribe [:rf/machine :todos/loader]))   ;; => #{:data/in-flight}
+```
+
+> **Reading tags inside an event handler.** A snapshot lives in [runtime-db](../core/glossary.md#runtime-db), not app-db, so a handler that needs to branch on a tag reads it from the `:rf.db/runtime` coeffect rather than from `:db`:
+>
+> ```clojure
+> (fn [{rt :rf.db/runtime} _]
+>   (get-in rt [:rf.runtime/machines :snapshots :todos/loader :tags]))
+> ```
+
+## Collapsing many states into one render decision
+
+This is where tags pay off hardest. The [Nine States example](../../examples/patterns/nine_states) models a page as one `:type :parallel` machine with three orthogonal regions — `:data` (request lifecycle + cardinality), `:form` (validation), `:mode` (active / archived). Every state wears a per-axis tag:
+
+```clojure
+;; (excerpt from the three regions) — each state announces its intent
+:loading   {:tags #{:data/loading :data/transient}        :on {…}}
+:empty     {:tags #{:data/empty}                           :on {…}}
+:incorrect {:tags #{:form/invalid}                         :on {…}}
+:correct   {:tags #{:form/success :form/transient}         :on {…}}
+:done      {:tags #{:mode/done :mode/read-only :mode/terminal}}
+```
+
+Three axes run at once, so several tags are live simultaneously — `:data/loading` *and* `:form/invalid` *and* `:mode/active`. The page can only draw one thing, so it needs a tie-breaker. Make it **plain data**: a render-priority table read top to bottom, plus one selector sub that returns the first matching tag's render-model keyword.
+
+```clojure
+(def render-priority
+  [{:tag :mode/done    :render :done}        ;; archived trumps everything
+   {:tag :form/success :render :correct}     ;; transient form acks next
+   {:tag :form/invalid :render :incorrect}
+   {:tag :data/loading :render :loading}     ;; then the data lifecycle
+   {:tag :data/error   :render :error}
+   {:tag :data/empty   :render :empty}
+   {:tag :data/some    :render :some}])
+
+(rf/reg-sub :ui/render
+  :<- [:rf/machine :ui/nine-states]
+  (fn [snap _]
+    (let [tags (:tags snap)]
+      (some (fn [{:keys [tag render]}]
+              (when (contains? tags tag) render))
+            render-priority))))
+```
+
+The root view's entire branching logic is then one `case` — the only place the UI ever forks:
+
+```clojure
+(reg-view root-view []
+  (case @(subscribe [:ui/render])
+    :done      [view-done]
+    :correct   [view-correct]
+    :incorrect [view-incorrect]
+    :loading   [view-loading]
+    :error     [view-error]
+    :empty     [view-empty]
+    :some      [view-some]
+    [:p "(unrecognised state)"]))
+```
+
+Nine states, three regions, one branch site. The priority order is a *product decision* — "an archived page beats a form acknowledgement beats the data bucket" — living in one readable table, not smeared across nine views. Adding a tenth render case is one row in `render-priority` plus one `case` clause; the machine and the other views don't move.
+
+And the controls disable themselves the same ask-don't-tell way — they ask for the *intent*, not the state:
+
+```clojure
+(reg-view new-todo-form []
+  (let [read-only? @(rf/machine-has-tag? :ui/nine-states :mode/read-only)]
+    [:button {:disabled read-only?} "Add"]))
+```
+
+Notice what the form *doesn't* ask: "is the `:mode` region in `:done`?" It asks "is this read-only?" Move `:mode/read-only` onto a different state tomorrow and this view doesn't change a line.
+
+## Tags as a cross-region signal (`stateIn`)
+
+In a parallel machine the tag union spans *all* regions, which makes it the channel one region uses to read what a sibling is doing. This is the classic statechart coordination primitive: a guard in region A predicates on region B's state. XState spells it `stateIn({ form: 'valid' })` (and W3C SCXML has `In(...)`); re-frame2 ships the *behaviour* without a separate `stateIn` operator — a deliberate divergence in the name of behavioural parity, not API mimicry. **A sibling region advertises a tag, and any region's guard reads the tag union off its context map.**
+
+A guard or action running *inside a parallel region* gets two extra keys in its context map, alongside the usual `:data` / `:event` / `:state`:
+
+- **`:tags`** — the machine-wide tag union (the **coarse**, idiomatic `stateIn` substitute);
+- **`:all-state`** — the full `{region → active-state}` map (the **precise** read).
+
+```clojure
+(rf/reg-machine :ui/checkout
+  {:type   :parallel
+   :data   {}
+   :guards {:form-valid? (fn [{:keys [tags]}]              ;; reads a SIBLING region's tag
+                           (contains? tags :form/valid))}
+   :regions
+   {:form     {:initial :editing
+               :states  {:editing {:tags #{:form/editing} :on {:complete :valid}}
+                         :valid   {:tags #{:form/valid}}}}
+    :checkout {:initial :idle
+               :states  {:idle       {:on {:submit {:target :submitting
+                                                    :guard  :form-valid?}}}
+                         :submitting {:tags #{:checkout/submitting}}}}}})
+```
+
+`:checkout`'s `:submit` fires only once the `:form` region has advertised `:form/valid`. The precise variant reads the sibling's state value directly instead:
+
+```clojure
+:guards {:form-valid? (fn [{:keys [all-state]}] (= :valid (:form all-state)))}
+```
+
+Prefer the **tag** form: a tag is a named, tool-legible render-state, and it survives the sibling region renaming its internal states as long as the tag stays put.
+
+Two things to hold onto:
+
+- **A tag is a guard *input*, not a *trigger*.** A tag flipping on does not *fire* anything — there is no "on this tag appearing" transition. The dependent region still moves on its next event (or an eventless `:always`); the guard merely *reads* the sibling's advertised tag when it runs.
+- **These keys are parallel-only, and frozen.** A flat or compound machine's guard/action context is exactly `{:data :event :state :meta}` — no `:tags` / `:all-state`, because a flat machine has no sibling to coordinate with (its own `:state` is its `stateIn`). In a parallel machine both keys reflect the configuration *as of the start of the macrostep*, so every region selects against the same frozen sibling view, independent of region declaration order. The exact same-event convergence paths — `:raise` for same-macrostep coupling, a guarded `:always` for next-event coupling — are spelled out in the spec.
+
+## What tags are *not*
+
+- **Not transition labels.** `:tags` is a state-node slot; transitions carry no tags.
+- **Not an autonomous driver.** A tag appearing never fires a transition by itself — it's read by guards, it doesn't trigger them. For a state change that should follow a `:data` condition on its own, use a guarded eventless `:always`.
+- **Not user-writable.** An action can't return `:tags` in its `{:data :fx}` map — the slot is runtime-owned and derived from `:state`.
+- **Not the `:meta` slot.** A state's `:meta` (e.g. `{:terminal? true}`) is static, tooling-visible metadata; `:tags` is the runtime projection of the *active* configuration. Both can sit on the same state; they are not synonyms.
+- **Not a replacement for `[:rf/machine id]`.** When a view needs the whole snapshot it still subscribes to `:rf/machine`; `machine-has-tag?` is for the predicate-shaped question. Both are first-class.
+
+## Further reading
+
+- [Machines: Concepts](concepts.md#guards-and-actions) — tags in the context of the full recognition kit (guards, actions, `:after`); [when the machine grows](concepts.md#when-the-machine-grows) covers parallel regions.
+- [Coming from XState](coming-from-xstate.md#the-mapping) — the row-by-row XState → re-frame2 mapping, including `tags` and `stateIn`.
+- [`re-frame.machines` API](../api/re-frame.machines.md#machine-has-tag) — the exhaustive contract for the `machine-has-tag?` sugar and the `[:rf/machine-has-tag? …]` / `[:rf/machine …]` subscription vectors.
+- [Nine States example](../../examples/patterns/nine_states) — the render-priority pattern above, complete and runnable.
+- **Normative contract:** [Spec 005 §State tags](../../spec/005-StateMachines.md#state-tags) — the semantic contract, the compound/parallel union rule, the empty-set elision, and the cross-region "tags as `stateIn`" coordination detail (the `:raise` vs `:always` convergence paths).
+- These features realise the broader statechart ideas of state labels and cross-region coordination — see the [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/) for the lineage re-frame2 maps from.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -234,6 +234,13 @@ nav:
   - Machines:
     - machines/index.md
     - "Concepts": machines/concepts.md
+    - "Hierarchical states": machines/hierarchical-states.md
+    - "Parallel states": machines/parallel-states.md
+    - "Automatic transitions": machines/automatic-transitions.md
+    - "Actors": machines/actors.md
+    - "Tags": machines/tags.md
+    - "History": machines/history.md
+    - "Inspecting and testing": machines/inspecting-machines.md
     - "Coming from XState": machines/coming-from-xstate.md
     - "Glossary": machines/glossary.md
     - "Examples": machines/examples.md


### PR DESCRIPTION
`docs/machines/` covered statecharts far too briefly (~644 lines) relative to the 4489-line normative spec 005. This expands it to **~3387 lines** of guide coverage — one page per major statechart capability — grounded in spec 005 + the real machine example apps, with an **XState v6 bridge** throughout (behavioural parity, not API mimicry).

## New pages
- **hierarchical-states.md** — compound/nested states, initial cascading, deepest-wins resolution, entry/exit along the LCA, nested final → done.
- **parallel-states.md** — `:type :parallel` regions, transition broadcast, cross-region coordination via tags-as-stateIn.
- **automatic-transitions.md** — `:always` (eventless), `:type :choice`, `:after` (delayed), `:timeout`/`:on-timeout`.
- **actors.md** — `:spawn` / `:spawn-all` fan-out + join, cooperative cancellation, cross-machine `:dispatch-to-system`.
- **tags.md** — state tags, `:rf/machine-has-tag?`, collapsing many states into one render decision.
- **history.md** — `:type :history` (shallow/deep), the `:rf/history` slot.
- **inspecting-machines.md** — the Xray Machine Inspector, machine trace events, pure-transition unit tests.

## Expanded
- **concepts.md** — deepened guards/actions, the `{:data :fx}` effect map, strict encapsulation, the `{:state :data :tags}` snapshot; demoted the brief recognition-kit to pointers at the new pages.
- **coming-from-xstate.md** — full XState v6 → re-frame2 mapping table + the deliberate divergences.
- **glossary.md** — the full machine vocabulary.

## Grounding
Every code example is drawn from a **real example app** (websocket / nine_states / long_running_work / state_machine_walkthrough) or the spec — no invented API. The two resources you gave — [XState statecharts docs](https://stately.ai/docs/state-machines-and-statecharts) and [Fulcro statecharts](https://fulcrologic.github.io/statecharts/) — are cited as "further reading" on each page (the broader statechart concepts these features realise).

## Plumbing
All 7 new pages wired into the mkdocs nav (Machines section) + the index "In this section". Based on current main (#5045 merged → machine API at `docs/api/re-frame.machines.md`, which the pages link to).

## Verification (local)
`check_doc_slugs` (0 broken targets/anchors — incl. fixing a cross-page anchor after the concepts.md restructure), `check_readme_links`, `check_readme_inventories`, the 3 residue checkers, and the api-manifest JVM gate (concepts.md var references reconcile). `mkdocs --strict` runs in CI (all new pages are in nav, so no orphan-page error).

## Note
The new pages carry inline XState bridge links to `stately.ai/docs/*` pages (mkdocs doesn't validate external URLs; these may need periodic refresh as XState's docs evolve).