### PR TITLE
docs(routing): add how-to recipes (unsaved-changes guard, require sign-in)

### DIFF
--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -101,7 +101,7 @@ Because routes are registry entries, the route table is *queryable data* — and
 ;; (rf/handler-meta :route route-id) returns the metadata, :tags and all.
 ```
 
-[Add authentication](../core/how-to/add-auth.md) walks through it end to end.
+[Require sign-in on a route](how-to/require-sign-in-on-a-route.md) is the routing-focused recipe; [Add authentication](../core/how-to/add-auth.md) walks through the whole auth flow end to end.
 
 > **For JavaScript developers.** This is the inverse of React Router's `<Route>` JSX tree, where each route is a *component* and you read it by being rendered inside it. Here a route is a *data row* you can `get`, `filter`, and `map` over from anywhere — auth guards, breadcrumb generators, sitemap builders, and analytics all just query the same table.
 
@@ -386,7 +386,7 @@ When the guard blocks, the runtime also dispatches `:rf.route/navigation-blocked
 
 > **Gotcha — the guard sub is strict.** `:can-leave` is a **boolean** contract: `true` allows, `false` blocks. Return anything else (a nil, a map, a truthy non-boolean) and the runtime **blocks the navigation** *and* emits `:rf.error/can-leave-non-boolean` — it fails closed (deny the leave) and fails loud (raise), never open. Keep the guard sub returning a real `true`/`false`.
 
-The payoff is that the entire flow is testable with zero DOM. Dispatch the navigate, assert the pending slot filled (`@(subscribe [:rf/pending-navigation])`), dispatch `:rf.route/continue`, assert it went through — no browser, no `beforeunload`, no flaky modal automation. The editor routes in [examples/real-apps/realworld_resources](../../examples/real-apps/realworld_resources) show the shape.
+The payoff is that the entire flow is testable with zero DOM. Dispatch the navigate, assert the pending slot filled (`@(subscribe [:rf/pending-navigation])`), dispatch `:rf.route/continue`, assert it went through — no browser, no `beforeunload`, no flaky modal automation. The editor routes in [examples/real-apps/realworld_resources](../../examples/real-apps/realworld_resources) show the shape, and [Guard against unsaved changes](how-to/guard-unsaved-changes.md) is the step-by-step recipe.
 
 ## Not found is a route you register
 

--- a/docs/routing/how-to/guard-unsaved-changes.md
+++ b/docs/routing/how-to/guard-unsaved-changes.md
@@ -1,0 +1,98 @@
+# Guard against unsaved changes
+
+A reader is half-way through editing an article, clicks a link, and loses the lot. The fix is an "are you sure? you have unsaved changes" prompt — the one navigation interaction every editor needs.
+
+In re-frame2 this is a [route guard](../glossary.md#route-guard): a route declares `:can-leave`, the runtime *blocks* the navigation when the guard says no, and the blocked navigation parks in state your prompt renders from. The whole flow is data — a subscription and two events — so it tests with zero DOM. We'll build it in four steps, then make it pass.
+
+> **The shape in one line.** `:can-leave` is a boolean sub (`true` = leaving is fine); a `false` parks the attempt in `:rf/pending-navigation`; your dialog renders from that slot and resolves it with `:rf.route/continue` or `:rf.route/cancel`.
+
+## 1. Write the "is it safe to leave?" sub
+
+The guard is an ordinary [subscription](../../core/concepts/subscriptions.md) that answers one yes/no question. Read it positively: **`true` means leaving is fine.** Here, leaving is fine when the editor's draft matches what was last saved (nothing unsaved to lose):
+
+```clojure
+(rf/reg-sub :editor/can-leave?
+  (fn [db _]
+    (= (get-in db [:editor :draft])
+       (get-in db [:editor :saved]))))   ;; true when clean ⇒ safe to leave
+```
+
+> **Gotcha — the contract is a strict boolean.** `true` allows, `false` blocks. Return anything else — a `nil`, a map, a truthy non-boolean — and the runtime **blocks the navigation** *and* emits `:rf.error/can-leave-non-boolean`. It fails closed (deny the leave) and fails loud (raise), never open. Keep the sub returning a real `true`/`false`.
+
+## 2. Declare the guard on the route
+
+Name that sub in the route's `:can-leave`. From now on the runtime consults it before *any* navigation away from this route:
+
+```clojure
+(rf/reg-route :app/article-editor
+  {:params    [:map [:id :string]]
+   :can-leave [:editor/can-leave?]}        ;; the sub from step 1
+  "/articles/:id/edit")
+```
+
+When the guard returns `false`, nothing happens to the URL or to state — the navigation simply doesn't commit. Instead the attempt is parked, and the runtime also dispatches `:rf.route/navigation-blocked` (with a matching trace) so you can react beyond the dialog — a toast, an analytics ping.
+
+## 3. Render the prompt from the pending slot
+
+The blocked navigation lands in `:rf/pending-navigation`. Subscribe to it: when it's non-`nil`, a navigation is waiting on the reader's decision, so render your dialog. There's no imperative `window.confirm`, no `beforeunload` — it's an ordinary [view](../../core/concepts/views.md) over state:
+
+```clojure
+(rf/reg-view leave-guard-dialog []
+  (when-let [pending @(subscribe [:rf/pending-navigation])]
+    [:div.modal
+     [:p "You have unsaved changes. Leave anyway?"]
+     [:button {:on-click #(dispatch [:rf.route/cancel])}   "Stay"]
+     [:button {:on-click #(dispatch [:rf.route/continue])} "Discard & leave"]]))
+```
+
+The reader's choice is itself a dispatch:
+
+- `:rf.route/continue` — proceed with the parked navigation (it commits now).
+- `:rf.route/cancel` — drop it; stay put.
+
+Mount `leave-guard-dialog` once near your root view and it covers every guarded route — it renders nothing until something is pending.
+
+## 4. Add a "save, then leave" path
+
+A "Save & close" button should leave *without* the prompt — the changes aren't being discarded, they're being saved. Save first, then navigate with `:bypass-leave-guard?` so this one navigation skips the guard:
+
+```clojure
+(rf/reg-event :editor/save-and-close
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:editor :saved] (get-in db [:editor :draft]))   ;; now clean
+     :fx [[:dispatch [:rf.route/navigate :app/article
+                      {:id (get-in db [:editor :id])}
+                      {:bypass-leave-guard? true}]]]}))               ;; skip the prompt
+```
+
+Saving makes the draft and saved snapshots equal, so the guard would pass anyway — but `:bypass-leave-guard?` makes the intent explicit and is the right tool whenever you *know* it's safe to leave.
+
+## Test it with zero DOM
+
+Because the whole flow is events and a subscription, the test needs no browser, no `beforeunload`, no flaky modal automation:
+
+```clojure
+;; Land on the editor and make the draft dirty.
+(rf/dispatch-sync [:rf.route/navigate :app/article-editor {:id "intro"}])
+(rf/dispatch-sync [:editor/edit-field :title "changed"])   ;; draft ≠ saved
+
+;; Try to leave — it should be blocked and parked, not committed.
+(rf/dispatch-sync [:rf.route/navigate :app/home])
+(is (= :app/article-editor @(rf/subscribe [:rf.route/id])))     ;; still here
+(is (some?                  @(rf/subscribe [:rf/pending-navigation])))  ;; parked
+
+;; The reader confirms — now it goes through.
+(rf/dispatch-sync [:rf.route/continue])
+(is (= :app/home @(rf/subscribe [:rf.route/id])))
+(is (nil?        @(rf/subscribe [:rf/pending-navigation])))
+```
+
+That's the payoff of a guard that's *state*, not a side effect: every branch — blocked, confirmed, cancelled, bypassed — is a dispatch and an assertion.
+
+> **For JavaScript developers.** This replaces React Router's `useBlocker` / `usePrompt` and the old `beforeunload` hack, with two upgrades: the guard is a *subscription* (declarative, derived from state), and the pending navigation is *state you render from*, so your confirm dialog is a normal view rather than an imperative blocker object you drive by hand.
+
+## See also
+
+- [Concepts → Blocking a navigation](../concepts.md#blocking-a-navigation) — the same flow in the reference narrative, plus the `:rf.route/navigation-blocked` trace.
+- [Require sign-in on a route](require-sign-in-on-a-route.md) — the other navigation-control recipe: redirecting *into* a route instead of blocking the way *out*.
+- [Build a form](../../core/how-to/build-a-form.md) — where the draft/saved slice this guard checks comes from.

--- a/docs/routing/how-to/require-sign-in-on-a-route.md
+++ b/docs/routing/how-to/require-sign-in-on-a-route.md
@@ -1,0 +1,99 @@
+# Require sign-in on a route
+
+Some pages — a settings screen, an admin dashboard — should open only for signed-in users. In re-frame2 there's no special "protected route" primitive: a route is [queryable data](../concepts.md#routes-are-queryable-data), so you *tag* the routes that need a session and let an ordinary [interceptor](../../core/concepts/interceptors.md) read the tag and redirect. Data plus a step that reads it — no router machinery.
+
+This page is the **routing half** of auth: tag a route, gate it, bounce the reader to login. The surrounding system — the login form, the token that requests carry, logout — is [Add authentication](../../core/how-to/add-auth.md), which embeds this same guard in the full picture. Start here for the route mechanics; go there for the whole flow.
+
+> **The one mistake to avoid.** There are *three* ways into a route, and a guard that gates only one fails **open** on the most common path — a logged-out reader who types the URL or reloads the page walks straight in. Steps 2–3 are about gating all three.
+
+## 1. Tag the protected routes
+
+Mark the routes that need a session with a `:tag`. Tags are free-form data — the framework attaches no meaning to `:requires-auth`; *you* do, in the guard:
+
+```clojure
+(rf/reg-route :app/login    {} "/login")
+(rf/reg-route :app/settings {:tags #{:requires-auth}} "/settings")
+(rf/reg-route :app/admin    {:tags #{:requires-auth}} "/admin")
+```
+
+The tag is now readable off the route table from anywhere: `(rf/handler-meta :route :app/settings)` returns the metadata, `:tags` and all. That's the whole "which routes are protected?" query — no registry to hand-maintain.
+
+## 2. Know the three navigation entry points
+
+A reader reaches a route three different ways, each a different event:
+
+| Event | How it's triggered |
+|---|---|
+| `:rf.route/navigate` | A programmatic push — `(dispatch [:rf.route/navigate …])`. |
+| `:rf/url-requested` | A `route-link` click. |
+| `:rf.route/handle-url-change` | The URL bar, a reload, Back/Forward (popstate). |
+
+Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out reader pasting `/settings` into the address bar, or reloading a protected page, never goes through `navigate`. So the guard normalises **all three** to one "where are we headed?" target, then decides once:
+
+```clojure
+;; Adapted from examples/real-apps/realworld_http/routing.cljs
+(defn- nav-target
+  "Normalise any navigation event to {:id <route-id> :params <map>}, or nil for
+   a non-navigation event (the guard then short-circuits)."
+  [[ev-id a b]]
+  (case ev-id
+    :rf.route/navigate          {:id a :params (or b {})}
+    :rf/url-requested           (let [{:keys [to params url]} a]
+                                  (cond
+                                    to  {:id to :params (or params {})}
+                                    url (when-let [{:keys [route-id params]} (routing/match-url url)]
+                                          {:id route-id :params (or params {})})))
+    :rf.route/handle-url-change (when-let [{:keys [route-id params]} (routing/match-url a)]
+                                  {:id route-id :params (or params {})})
+    nil))
+```
+
+`routing/match-url` is pure (it lives in `re-frame.routing`, not on the `rf/` facade) — it turns a URL string into a match map, or `nil` when nothing resolves, so a garbage URL short-circuits the guard rather than crashing it.
+
+## 3. Redirect with skip-and-dispatch
+
+Now the guard itself: one interceptor, registered once, that runs `:before` every event. For a navigation toward a `:requires-auth` route with no signed-in user, it **skips** the original handler (so the protected route never commits and its loaders never fire) and dispatches the login navigation instead:
+
+```clojure
+(rf/reg-interceptor :app/auth-guard
+  {:doc "Redirect logged-out readers away from :requires-auth routes."}
+  {:before
+   (fn [ctx]
+     (if-let [{:keys [id]} (nav-target (get-in ctx [:coeffects :event]))]
+       (let [needs-auth? (contains? (:tags (rf/handler-meta :route id)) :requires-auth)
+             signed-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
+         (if (and needs-auth? (not signed-in?))
+           (-> ctx
+               (assoc :rf/skip-handler? true)                    ;; protected route never commits
+               (assoc-in [:effects :fx]
+                         [[:dispatch [:rf.route/navigate :app/login]]]))
+           ctx))
+       ctx))})              ;; not a navigation ⇒ pass through untouched
+```
+
+Two reads do the work, both pure: `rf/handler-meta` pulls the route's `:tags`, and the `:db` in `:coeffects` says whether anyone's signed in. `:rf/skip-handler?` is the public short-circuit primitive — set it in a `:before` and the original handler is skipped.
+
+> **Gotcha — redirect, don't rewrite.** The runtime picks the handler from the *original* event id, so editing the event in `:before` would just run the wrong handler. Skip the original and dispatch a fresh navigation, as above.
+
+## 4. Attach the guard to the frame
+
+Register the guard once, then name it by id in the frame's `:interceptors`. It short-circuits in a single `case` for every non-navigation event, so the cost on ordinary traffic is negligible:
+
+```clojure
+(rf/reg-frame :rf/default
+  {:doc          "The app frame."
+   :url-bound?   true
+   :interceptors [:app/auth-guard]})    ;; reference the registered guard by id
+```
+
+That's the routing half done: protected routes are tagged, all three entry points are gated, and a logged-out reader is bounced to `/login`.
+
+## Where to go from here
+
+This page deliberately stops at the route boundary. The full recipe — the login form, persisting the token, decorating requests with it, **bouncing the reader back to where they were headed** after login, and a logout that clears the departing session's cached data — is [Add authentication](../../core/how-to/add-auth.md) (its step 4 is this guard, with the return-to bounce-back wired in). For the auth state machine once login/restore start coordinating, see [Machines](../../machines/concepts.md).
+
+## See also
+
+- [Concepts → Routes are queryable data](../concepts.md#routes-are-queryable-data) — the tag-and-read pattern this recipe is built on.
+- [Guard against unsaved changes](guard-unsaved-changes.md) — the other navigation-control recipe: blocking the way *out* of a route.
+- [Add authentication](../../core/how-to/add-auth.md) — the complete auth flow this guard slots into.

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -20,6 +20,7 @@ Because a route's [loader](glossary.md#loader) runs on the server too, routing a
 - **[Tutorial: build a routed app](tutorial.md)** — start here. Build a small three-page app one piece at a time: routes, links, dynamic segments, loaders, the 404, the Back button, and a shared layout.
 - **[Concepts](concepts.md)** — the whole model in three moves, then everything a growing app reaches for: query strings, the loading/error transition, navigation blocking, data classification, and routing on the server.
 - **[Coming from React Router](coming-from-react-router.md)** — the mapping from `createBrowserRouter`, loaders, and the hooks, and where re-frame2 deliberately diverges.
+- **How-to** — task recipes: [guard against unsaved changes](how-to/guard-unsaved-changes.md), and [require sign-in on a route](how-to/require-sign-in-on-a-route.md).
 - **[API](../api/re-frame.routing.md)** — `reg-route`, the `:rf.route/*` events and subscriptions, the URL helpers, the guard protocol.
 - **[Glossary](glossary.md)** — the routing vocabulary in one place.
 - **[Examples](examples.md)** — worked routing apps you can read end to end.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -268,6 +268,9 @@ nav:
     - "Tutorial: build a routed app": routing/tutorial.md
     - "Concepts": routing/concepts.md
     - "Coming from React Router": routing/coming-from-react-router.md
+    - "How-to":
+      - "Guard against unsaved changes": routing/how-to/guard-unsaved-changes.md
+      - "Require sign-in on a route": routing/how-to/require-sign-in-on-a-route.md
     - "Glossary": routing/glossary.md
     - "Examples": routing/examples.md
 


### PR DESCRIPTION
## What & why

Follow-up to #5046. Routing had **no how-to section**, unlike Core and Resources — so the two most common navigation-control tasks lived only buried inside the dense concepts page, with no discoverable task-oriented entry point.

This adds a routing `how-to/` (mirroring the Resources two-recipe shape) for exactly those tasks.

## Changes

- **New `routing/how-to/guard-unsaved-changes.md`** — the `:can-leave` "are you sure? unsaved changes" flow as a step-by-step recipe: write the dirty-check sub → declare it on the route → render the prompt from `:rf/pending-navigation` → a "save & bypass" path → and a **zero-DOM test** of all four branches (blocked / confirmed / cancelled / bypassed).
- **New `routing/how-to/require-sign-in-on-a-route.md`** — the **routing half** of auth: tag the route, gate **all three** navigation entry points (the failure-open trap if you only guard `:rf.route/navigate`), redirect with skip-and-dispatch. Deliberately *not* a duplicate of `core/how-to/add-auth.md` — it cross-links there for the full system (login, token, logout, bounce-back) and stays focused on the route mechanics.
- Wired both into the nav (after Coming-from-React-Router) and the index; added discoverability cross-links from `concepts.md`'s blocking + auth sections.

## Stacking

This PR is **stacked on `docs-routing-onramp` (#5046)** — its base is that branch, so the diff here is *only* the how-to changes. When #5046 merges, GitHub auto-retargets this to `main` and CI runs. **Merge #5046 first.**

## Verification (local)

- `python -m mkdocs build --strict` → exit 0, no warnings
- `check_doc_slugs.py` / `check_readme_links.py` / `check_readme_inventories.py` → all exit 0

(CI won't register checks while the base is a non-`main` branch — expected for a stacked PR; it'll run after retarget.)
