### PR TITLE
docs(machines): correctness + completeness review pass

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -14,7 +14,7 @@ This page assumes you've met the [transition table, guards, actions, tags, and `
 
 Put a `:spawn` map on a state node. While the machine sits in that state, a child actor of the named machine exists; on any transition out of the state, it's destroyed.
 
-Here's the heart of the [websocket example](../../examples/patterns/websocket/): a connection machine whose `:active` state owns a live socket. The socket is its own machine (`:websocket/socket`), spawned on the `:active` *parent* so one socket spans the connect → authenticate → connected leaves nested inside it.
+Here's the heart of the [websocket example](../../examples/patterns/websocket/): a connection machine whose `:active` state owns a live socket. The socket is its own machine (`:websocket/socket`), spawned on the `:active` *parent* so one socket spans the `:connecting` → `:authenticating` → `:connected` leaves nested inside it.
 
 ```clojure
 (rf/reg-machine :ws/connection
@@ -39,7 +39,7 @@ Here's the heart of the [websocket example](../../examples/patterns/websocket/):
 
 Enter `:active` → the runtime spawns a `:websocket/socket` actor. Leave `:active` by *any* door — `:ws/closed`, `:ws/fatal`, a frame teardown — and the runtime destroys it. The parent never wrote "spawn" or "destroy"; `:spawn` is **registration-time sugar** that rewrites the state's `:entry`/`:exit` into the imperative spawn/destroy effects you'll meet below. From the outside it's indistinguishable from a machine that wired those slots by hand.
 
-> **Mental model.** `:spawn` is XState's `invoke`. The child's lifetime is the state's lifetime. Renamed because "invoke" reads like a synchronous call, whereas what's really created is a child actor's worth of lifecycle.
+> **Mental model.** `:spawn` is XState's `invoke`. The child's lifetime is the state's lifetime. Renamed because "invoke" reads like a synchronous call, when what you create is a child actor with its own lifecycle.
 
 ### The spawn-spec keys
 
@@ -174,7 +174,7 @@ From a non-action call site you can resolve the id directly with `(re-frame.mach
 
 ### Including a reply address
 
-There's no `sender`/`sendTo`-reply special form — put the reply event *in the request* (the standard re-frame2 reply convention): address the request by name, but put the reply id in the payload so the reply lands in a specific actor rather than whoever currently owns the name.
+There's no `sender`/`sendTo`-reply special form. Put the reply event *in the request* (the standard re-frame2 reply convention): address the request by name, but carry the reply id in the payload, so the reply lands in a specific actor rather than whoever currently owns the name.
 
 ---
 
@@ -237,7 +237,7 @@ The runtime knows how to release exactly **three** framework-managed resource ki
 
 The destroy path runs the actor's `:exit` *before* dissociating its snapshot, so cleanup gets to read the final `:data`. There is no `core.async` in this path — close the host handle directly, don't reach for a channel close. (The websocket example keeps its mock socket in a host-side atom and leans on actor-destroy plus a mock that holds no real OS resource; a real `js/WebSocket` would `.close()` in `:exit`.)
 
-The [long-running-work example](../../examples/patterns/long_running_work/) shows the cascade end-to-end: the user hitting **Cancel** dispatches `:cancel`, which leaves the `:working` state, and *that exit* fires a single `:rf.machine/destroy` that takes every still-running child with it — pending `:after` yield-timers and all. The author wrote no per-child teardown.
+The [long-running-work example](../../examples/patterns/long_running_work/) shows the cascade end-to-end: the user hitting **Cancel** dispatches `:cancel`, which leaves the `:working` state, and *that exit* fires a `:rf.machine/destroy` for every still-running child — pending `:after` yield-timers and all. The author wrote no per-child teardown.
 
 ---
 
@@ -310,6 +310,7 @@ A few rules worth knowing:
 
 - **Each child needs a unique `:id`** (the join key) on top of the usual spawn keys. Duplicate ids are a registration error.
 - **Join discriminators:** `:all` (default), `:any`, `{:n N}`, or `{:fn (fn [{:keys [done failed]}] …)}`. `:on-all-complete` is required for `:all`; `:on-some-complete` is required for the partial-success kinds.
+- **Cancel-on-decision defaults to `true`** — when the join resolves, surviving siblings are torn down. Set `:cancel-on-decision? false` for a non-cancelling join (e.g. an analytics fan-out where each child is independently valuable): siblings run to completion and their late results still fold into the join-state, firing no further parent event.
 - **An unregistered child type fails the whole join closed** before any join-state is seeded — a child that can never run can never deadlock an `:all` join.
 - **Wall-clock timeout:** same as single `:spawn` — an `:after` on the `:spawn-all`-bearing state. When it fires, the exit cascade cancels every surviving child.
 

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -58,7 +58,7 @@ This is classic statechart **macrostep** semantics: the externally-observable tr
 A few rules keep the loop well-behaved — and keep your typos loud at registration time, not on the unlucky dispatch:
 
 - **`:always` settles before the next raised event.** If an action both `:raise`s an event `R` and lands in a state whose `:always` is enabled, the `:always` is taken **first**; `R` is then handled in the post-`:always` state. Raised events otherwise drain FIFO. (This matches XState v5/SCXML exactly.)
-- **Bounded depth.** The loop is capped (default **16** microsteps, configurable as `:always-depth-limit` at frame-config level). A non-converging cycle trips `:rf.error/machine-always-depth-exceeded` and **fails the whole macrostep** — the snapshot is never written, so the transition rolls back atomically. It is a failure, not a silent no-op, so a runaway cycle is distinguishable from an ordinary guard-blocked decline.
+- **Bounded depth.** The loop is capped (default **16** microsteps, configurable per machine via `:always-depth-limit`). A non-converging cycle trips `:rf.error/machine-always-depth-exceeded` and **fails the whole macrostep** — the snapshot is never written, so the transition rolls back atomically. It is a failure, not a silent no-op, so a runaway cycle is distinguishable from an ordinary guard-blocked decline.
 - **No self-target.** An `:always` whose `:target` resolves to its own declaring state is **rejected at `reg-machine` time** (`:rf.error/machine-always-self-loop`) — guarded or not. An eventless transition back into the state you just entered either loops to the depth limit or is a no-op; either way the author meant something else.
 
 > **Looping until a condition clears.** The legitimate "keep going while there's work" shape is a **targetless** guarded `:always` with an `:action` — `{:guard :more? :action :drain-one}`. Its action flips the guard false and the loop settles. That is *not* a self-loop (there's no `:target`), so it's allowed.
@@ -79,7 +79,7 @@ The [WebSocket example](../../examples/patterns/websocket/README.md) uses `:alwa
  :on     {…}}}
 ```
 
-Note that `:reconnecting` carries **both** `:always` and `:after` — they're independent state-node slots and coexist freely. And `:connected`'s `:always` is the targetless-action form: its `:flush-queue` action clears the queue, the guard goes false, and the microstep loop settles — no extra state needed.
+`:reconnecting` carries **both** `:always` and `:after` — they're independent state-node slots and coexist freely. And `:connected`'s `:always` is the targetless-action form: its `:flush-queue` action clears the queue, the guard goes false, and the microstep loop settles — no extra state needed.
 
 > **Coming from XState.** XState calls these `always` transitions (SCXML's *transient* transitions); re-frame2 keeps the name `:always`. Same idea, same first-match-wins ordering. `:always` is **not** a substitute for `:after`: `:always` fires on guard *truth*, `:after` fires on elapsed *time*.
 
@@ -142,7 +142,7 @@ Each entry is `<delay> → <transition>`. Both halves take several forms.
 
 **The delay (the key) — three forms:**
 
-- **Integer milliseconds** — `{30000 :timeout}`. The common fixed delay. (Note: a literal `:after` delay is **integer ms only** — not an ISO-8601 string, and *never* the `"5s"` shorthand. Those belong to `:timeout`, below.)
+- **Integer milliseconds** — `{30000 :timeout}`. The common fixed delay. (Note: a literal `:after` delay is **integer ms only** — not an ISO-8601 string, and *never* the `"5s"` shorthand. ISO-8601 durations belong to `:timeout`, below; the `"5s"` shorthand re-frame2 rejects everywhere.)
 - **A [subscription](../core/concepts/subscriptions.md) vector** — `[:sub-id & args]`, resolved like any `subscribe`. The canonical form for an **app-state-derived** delay (a user preference, a feature-flag config). It *re-resolves* when its value changes (see below).
 - **A function** — `(fn [{:keys [snapshot]}] ms)`, called **once** at state entry. The escape valve for a delay computed from the machine's own `:data`.
 
@@ -171,7 +171,7 @@ A state can have several triggers racing at once — multiple `:after` timers, t
 
 ### No cancel flag: epoch-based staleness
 
-re-frame2 ships **no `:cancel-dispatch-later` fx**, and you never write one. Here's why that's safe — and it's the headline reason to prefer `:after` over hand-rolled timers.
+re-frame2 ships **no `:cancel-dispatch-later` fx**, and you never write one. That's safe — and the headline reason to prefer `:after` over hand-rolled timers.
 
 Every scheduled timer carries an **epoch** — a per-state-entry counter — captured when it's armed. Leaving the state advances that state's epoch. When a timer eventually fires, the runtime compares the carried epoch against the state's current one:
 
@@ -202,7 +202,7 @@ The WebSocket example's `:reconnecting` state computes its backoff from the retr
           …}}
 ```
 
-Each visit to `:reconnecting` reads the *current* `:retries` and waits longer than the last (100 ms, 200, 400, … capped at `max-backoff-ms`). The `:always` short-circuits straight to `:failed` once retries are exhausted. And because leaving `:reconnecting` cancels the timer via the epoch mechanism, a backoff armed on an earlier visit can never fire late — no flag, no cleanup. See [`connection.cljs`](../../examples/patterns/websocket/README.md) for the whole machine.
+Each visit to `:reconnecting` reads the *current* `:retries` and waits longer than the last (200 ms, 400, 800, … capped at `max-backoff-ms`). The `:always` short-circuits straight to `:failed` once retries are exhausted. And because leaving `:reconnecting` cancels the timer via the epoch mechanism, a backoff armed on an earlier visit can never fire late — no flag, no cleanup. See [`connection.cljs`](../../examples/patterns/websocket/README.md) for the whole machine.
 
 ### The clock, SSR, and what `:after` is *not*
 

--- a/docs/machines/coming-from-xstate.md
+++ b/docs/machines/coming-from-xstate.md
@@ -2,7 +2,7 @@
 
 If you've built statecharts with [XState](https://stately.ai/docs) — v5, or the v6 alpha — most of your mental model ports straight across. re-frame2's [machines](concepts.md) borrow XState's grammar on purpose: transition tables as data, guards, actions, tags, delayed transitions, final states, run-to-completion, internal-by-default self-transitions. You can read a re-frame2 machine spec on day one and a re-frame2 author can read yours. The *behaviour* is the contract re-frame2 tracks; what changes is the *expression* and one piece of *plumbing*.
 
-So let's be honest about the split up front. Two things transfer almost untouched:
+Two things transfer almost untouched:
 
 - **The statechart itself.** States, nested states, parallel regions, guards on transitions, entry/exit actions, `after` timers, final states, history — same concepts, idiomatic spelling. If you can draw it, you can write it.
 - **The semantics you rely on.** Run-to-completion, internal-vs-external self-transitions, eventless (`always`) transitions firing on guard flips, an unknown event being a no-op rather than a crash. re-frame2 matches XState here deliberately, including the v5/v6 drop of strict mode.
@@ -23,7 +23,7 @@ Skim this, then read the worked build-up in [The grammar, concept by concept](#t
 |---|---|---|
 | `createMachine({ ... })` / `setup().createMachine()` | a transition-table map passed to [`reg-machine`](concepts.md#registering-and-running-it) | Plain Clojure data. No builder, no fluent API. |
 | `context` (extended state) | [`:data`](#context-becomes-data) | Same idea. "Context" was already taken (interceptor context, React context); `:data` tracks FSM / `gen_statem` "state data". |
-| `state.value` | the snapshot's `:state` | Flat → keyword; compound → vector path; parallel → region-name→keyword map. |
+| `state.value` | the snapshot's `:state` | Flat → keyword; compound → vector path; parallel → region-name→state map (each region's value is itself a keyword or path). |
 | `states: { idle: { on: { ... } } }` | `:states {:idle {:on {...}}}` | Near-identical shape. `on` → `:on`, target strings → state keywords. |
 | nested states (`initial` + `states`) | [`:initial` + `:states` on a state node](#compound-nested-states) | Deepest-wins resolution, parent fall-through. Keyword target = sibling; vector target = absolute path. |
 | `guard: 'canRetry'` | `:guard :under-retry-limit` | Named; defined in the spec's [`:guards`](#guards) map. Idiomatic Clojure name (`?`-suffixed predicate), not a JS boolean string. |
@@ -126,7 +126,7 @@ Same split — a discrete `:state` (XState's `state.value`) plus extended memory
 
 ### Actions, assign, and the effect map
 
-This is the deepest behavioural shift, so it's worth slowing down. XState's `assign(...)` is an action *creator* that imperatively updates `context`, and an effectful action *runs* its side effect when invoked:
+This is the deepest behavioural shift. XState's `assign(...)` is an action *creator* that imperatively updates `context`, and an effectful action *runs* its side effect when invoked:
 
 ```js
 actions: assign({ attempts: ({ context }) => context.attempts + 1 }),  // the "assign"
@@ -301,7 +301,7 @@ A leaf marked `:final?` terminates the machine; if it was spawned, the parent is
                                       :on-error   :idle}}}})    ;; child failed → transition
 ```
 
-In XState `output` is a *function* of context; in re-frame2 `:output-key` names a **key** into the child's `:data` (compute it with an `:action` into the final state if you need to — there is no `:output-fn`). **Divergence:** completion is *event-shaped*, not a long-lived `snapshot.output` slot you read later — `:output-key`'s value flows to the parent's `:on-done` as `result` *at the moment of completion*, then the child auto-destroys. A `:final?` leaf may add `:error? true` to be the designated error terminal that drives the parent's `:on-error` **transition** (XState's `invoke onError` as control flow, not observability). And note: a **singleton** machine reaching `:final?` also auto-destroys — "final means final"; omit `:final?` for a persistent terminal state (`:authed` / `:locked-out` above are plain leaves).
+In XState `output` is a *function* of context; in re-frame2 `:output-key` names a **key** into the child's `:data` (compute it with an `:action` into the final state if you need to — there is no `:output-fn`). **Divergence:** completion is *event-shaped*, not a long-lived `snapshot.output` slot you read later — `:output-key`'s value flows to the parent's `:on-done` as `result` *at the moment of completion*, then the child auto-destroys. A `:final?` leaf may add `:error? true` to be the designated error terminal that drives the parent's `:on-error` **transition** (XState's `invoke onError` as control flow, not observability). And a **singleton** machine reaching `:final?` also auto-destroys — "final means final"; omit `:final?` for a persistent terminal state (`:authed` / `:locked-out` above are plain leaves).
 
 ### Invoke becomes spawn
 
@@ -407,7 +407,7 @@ re-frame2 already has exactly one of those — the [event cascade](../core/gloss
 
 **Why:** because the machine's entire state is *just a value riding the frame*, everything the frame can do, the machine gets for nothing. [Time-travel](../core/glossary.md#time-travel), undo, persistence, and SSR hydration all work on machines with zero extra code — rewind the frame and the machine rewinds with it. An actor that owns its own mutable state can't be rolled back by an outside force without a bespoke serialization story; a value in a database rolls back by definition. This is the quiet dividend of refusing to make the machine an object: it can't hide state where replay can't reach.
 
-That same refusal is why an action **sees only `{:state :data :event :meta}` and never app-db** — and why returning `:db` from an action is a hard error. State that escaped into app-db wouldn't ride the snapshot, and the free rollback would silently develop a hole. To touch a sibling slice you [`dispatch`](../core/glossary.md#dispatch) a named event; the reach becomes a traced, reusable event instead of a quiet cross-write.
+That same refusal is why an action sees **only the snapshot, event, and any declared coeffects (`:data` / `:state` / `:event` / `:meta` / `:rf.cofx`) — never app-db**, and why returning `:db` from an action is a hard error. State that escaped into app-db wouldn't ride the snapshot, and the free rollback would silently develop a hole. To touch a sibling slice you [`dispatch`](../core/glossary.md#dispatch) a named event; the reach becomes a traced, reusable event instead of a quiet cross-write.
 
 ### 3. Actions return effects; they don't perform them
 

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -128,7 +128,7 @@ Registering the table is one line:
 (rf/reg-machine :auth.login/flow login-flow)
 ```
 
-And here's where people brace for a new runtime concept. There isn't one. **A machine *is* an event handler.** Its live value at any moment — which state it's in, plus its `:data` — is one small map called its **[snapshot](glossary.md#snapshot)**. [`reg-machine`](../core/glossary.md#registration) is sugar over `reg-event` whose body interprets the table: look up the current snapshot, compute the transition, write the new snapshot back, return the action's [effects](../core/glossary.md#effect). That one line is exactly equivalent to:
+And here's where people brace for a new runtime concept. There isn't one. **A machine *is* an event handler.** Its live value at any moment — which state it's in, plus its `:data` — is one small map called its **[snapshot](glossary.md#snapshot)**. [`reg-machine`](../core/glossary.md#registration) is sugar over `reg-event` whose body interprets the table: look up the current snapshot, compute the transition, write the new snapshot back, return the action's [effects](../core/glossary.md#effect). Under the sugar it's an ordinary event handler whose body comes from `make-machine-handler` (plus the registration metadata that lets tooling recognise it as a machine):
 
 ```clojure
 ;; make-machine-handler lives in re-frame.machines
@@ -160,7 +160,7 @@ That's the whole loop: register the table, dispatch wrapped events into it, subs
 
 ### Composing with async effects
 
-It's worth pausing on the async wiring in `:issue-request`, because it shows off something quietly excellent: an HTTP reply lands back *inside* the machine as just another event, with no glue code in between.
+The async wiring in `:issue-request` shows off something quietly excellent: an HTTP reply lands back *inside* the machine as just another event, no glue code in between.
 
 Look at the `:on-success` value: `[:auth.login/flow [:auth.login/success]]`. That's the same wrapped shape you dispatch by hand — the machine id `:auth.login/flow` outside, the inner event `[:auth.login/success]` inside — but written one element short on purpose. When the request returns, [managed HTTP](../resources/http.md) *appends* its reply payload to that inner event, so what actually arrives is `[:auth.login/success {:kind :success :value v}]` — exactly the event `:store-session` destructures. That's [the uniform reply](../resources/http.md) at work: a managed async surface completes by dispatching an event, so a machine and an async [effect](../core/glossary.md#effect) compose with no adapter layer.
 
@@ -344,7 +344,7 @@ Two guard-rails enforce the boundary:
 - **Returning `:db` is a hard error.** A `:db` key in an action's effect map surfaces `:rf.error/machine-action-wrote-db` and the `:db` key is dropped (the rest of the effects still flow). Fail loud, don't silently let a machine scribble on app-db.
 - **The next state isn't in the return shape either.** An action returns `:data` and `:fx` — never a state keyword. Only the transition's `:target` moves the machine. Callbacks update working memory; they can't nudge the machine into a state the table didn't declare. (This is exactly XState's `assign` invariant.)
 
-> **Gotcha — facts from the world are *declared*, not grabbed.** A guard or action that needs the time (or a random draw) must not call `(js/Date.now)` or `(rand)`: that buries nondeterminism where replay can't reach it, and replay is what makes time-travel and SSR hydration work. Instead, declare the fact as a [coeffect](../core/glossary.md#coeffect) on a *named* entry and read it from the context map's `:rf.cofx` record:
+> **Gotcha — facts from the world are *declared*, not grabbed.** A guard or action that needs the time (or a random draw) must not call `(js/Date.now)` or `(rand)`: that buries nondeterminism where replay can't reach it, and replay is what makes time-travel and SSR hydration work. Instead, declare the fact as a [coeffect](../core/glossary.md#coeffect) on a *named* entry with `:rf.cofx/requires`, and the framework threads it into the context map:
 >
 > ```clojure
 > :guards

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -69,7 +69,7 @@ The side work a [transition](#transition) performs: it returns the same `{:data 
 
 ### **action effect map**
 
-What an [action](#action) returns: the same `{:data … :fx …}` map a [`reg-event`](../core/glossary.md#event-handler) handler returns. `:data` is **merged** into the snapshot key-by-key (last write wins; a key returned as explicit `nil` *sets* it to `nil` rather than removing it); `:fx` is a vector of `[fx-id args]` pairs the runtime actions for you. Returning `nil` does nothing. Because the action *describes* effects rather than performing them, it stays pure, testable, and replayable.
+What an [action](#action) returns: the same `{:data … :fx …}` map a [`reg-event`](../core/glossary.md#event-handler) handler returns. `:data` is **merged** into the snapshot key-by-key (last write wins; a key returned as explicit `nil` *sets* it to `nil` rather than removing it); `:fx` is a vector of `[fx-id args]` pairs the runtime performs for you. Returning `nil` does nothing. Because the action *describes* effects rather than performing them, it stays pure, testable, and replayable.
 
 ```clojure
 :record-error
@@ -90,7 +90,7 @@ A [state](#state) that nests its own `:states` map plus a required `:initial` su
 
 ### **parallel state**
 
-A [compound state](#compound-state) declared `:type :parallel` whose children are [regions](#region) that are **all active at once** rather than one-at-a-time. Three orthogonal axes of three states each is three regions, not twenty-seven cross-product states. The snapshot's `:state` becomes a **map** of region-name → that region's state (`{:data :loading :form :neutral :mode :active}`); all regions share one [`:data`](#data) and their [tags](#state-tag) union across regions. When the axes *don't* share data, prefer N separate machines instead.
+A machine declared `:type :parallel` at its root, holding a **`:regions`** map (not `:states`) — the [regions](#region) are **all active at once** rather than one-at-a-time. Three orthogonal axes of three states each is three regions, not twenty-seven cross-product states. The snapshot's `:state` becomes a **map** of region-name → that region's state (`{:data :loading :form :neutral :mode :active}`); all regions share one [`:data`](#data) and their [tags](#state-tag) union across regions. When the axes *don't* share data, prefer N separate machines instead.
 
 *XState:* `type: 'parallel'`. See the [nine_states example](../../examples/patterns/nine_states/) and [When the machine grows](concepts.md#when-the-machine-grows).
 
@@ -155,14 +155,14 @@ A state-node key holding a vector of guarded transitions that fire **with no eve
 
 ### **delayed transition (`:after`)**
 
-The declarative timer: a state-node key mapping a delay to a transition. Enter the state and the timer arms; leave it and the timer cancels — no `setTimeout`-plus-cancel-flag to wire. A late-firing timer from an earlier visit is ignored (each visit is epoch-tagged), so you never get a ghost transition. The delay is a positive-integer millisecond count, a [subscription](../core/glossary.md#subscription) vector, or a `(fn [snapshot] ms)`.
+The declarative timer: a state-node key mapping a delay to a transition. Enter the state and the timer arms; leave it and the timer cancels — no `setTimeout`-plus-cancel-flag to wire. A late-firing timer from an earlier visit is ignored (each visit is epoch-tagged), so you never get a ghost transition. The delay is a positive-integer millisecond count, a [subscription](../core/glossary.md#subscription) vector, or a `(fn [{:keys [snapshot]}] ms)`.
 
 ```clojure
 :reconnecting {:after {5000 {:target :connecting}}   ;; retry in 5s
                :on    {:net/give-up :failed}}
 ```
 
-*XState:* `after: { 5000: 'next' }`; same auto-cancel-on-exit. ISO-8601 strings (`"PT5S"`) are accepted; XState's `"5s"` shorthand is **rejected**. See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
+*XState:* `after: { 5000: 'next' }`; same auto-cancel-on-exit. (ISO-8601 durations and the `"5s"`-shorthand rejection belong to [`:timeout`](#timeout), not `:after` — an `:after` key is an ms int, a sub vector, or a fn.) See [Guards, actions, tags, and `:after`](concepts.md#guards-and-actions).
 
 ### **timeout**
 

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -165,9 +165,8 @@ A compound state *without* `:initial` is a registration error
 > **The initial cascade also runs at birth.** When a machine first comes to
 > life — a singleton on its first dispatched event, or a spawned actor — the
 > whole `:initial` chain's `:entry` actions fire once, shallowest-first, as part
-> of bringing it into existence. A multi-level `:initial` chain runs *every*
-> level's `:entry` at start. (In XState this is `xstate.init` entering the
-> initial state cascade.)
+> of bringing it into existence — *every* level along the chain, not just the
+> leaf. (In XState this is `xstate.init` entering the initial state cascade.)
 
 ---
 
@@ -330,7 +329,7 @@ Take this auth-flow machine (a compound `:authenticated` over a `:dashboard` /
 
 | Event | Source path | Target path | What fires |
 |---|---|---|---|
-| `:login` | `[:unauthenticated]` | `[:authenticated :dashboard]` | Target `[:authenticated]` cascades `:initial :dashboard`. Entry: `:authenticated`, then `:dashboard`. |
+| `:login` | `[:unauthenticated]` | `[:authenticated :dashboard]` | LCA is the root: exit `:unauthenticated`. Target `[:authenticated]` cascades `:initial :dashboard`, so entry is `:authenticated`, then `:dashboard`. |
 | `:open-cart` | `[:authenticated :dashboard]` | `[:authenticated :cart :browsing]` | Keyword `:cart` = sibling of `:dashboard`; cascades `:initial :browsing`. LCA is `:authenticated`: exit `:dashboard`; enter `:cart`, `:browsing`. |
 | `:checkout` | `[:authenticated :cart :browsing]` | `[:authenticated :cart :paying]` | Sibling hop inside `:cart`. LCA `:cart`: exit `:browsing`; enter `:paying`. |
 | `:logout` | `[:authenticated :cart :paying]` | `[:unauthenticated]` | Deepest-wins walks `:paying` (no match), `:cart` (no), `:authenticated` (match). LCA is the root: exit `:paying → :cart → :authenticated` (deepest-first); enter `:unauthenticated`. |
@@ -340,7 +339,7 @@ Take this auth-flow machine (a compound `:authenticated` over a `:dashboard` /
 > `exit → action → entry` rule: in a flat machine the path length is 1 and the
 > LCA is always the root.
 
-Remember actions are **pure returns**, not imperative writes: an `:entry` /
+Actions are **pure returns**, not imperative writes: an `:entry` /
 `:exit` / transition `:action` is `(fn [{:keys [data event state]}] effects)`
 returning `{:data … :fx …}`. The `:fx` flow through the ordinary
 [effects cascade](../core/concepts/events-and-the-cascade.md) like any handler's.
@@ -351,7 +350,7 @@ returning `{:data … :fx …}`. The `:fx` flow through the ordinary
 
 A compound state often *is* a sub-flow with a clear end: collect, submit, paid.
 re-frame2 ships the statechart pattern for "the sub-flow finished, now advance
-the outer flow" first-class — and crucially, **the machine keeps running**.
+the outer flow" first-class — and **the machine keeps running**.
 
 Mark the sub-flow's terminal leaf `:final? true`. The moment a compound's active
 child becomes that final leaf, the engine raises a synthetic, transitionable
@@ -463,8 +462,8 @@ A `:final?` state fails loud at registration if you break these:
 
 - **Leaf-only.** No `:states` / `:initial` on a final state — a compound can't
   be final; its finality is a leaf *inside* it. (`:rf.error/machine-final-state-compound`)
-- **No further transitions.** No `:on` / `:always` / `:after` / `:spawn` on a
-  final state — final means final. (`:rf.error/machine-final-state-has-transitions`)
+- **No further transitions.** No `:on` / `:always` / `:after` / `:spawn` /
+  `:spawn-all` on a final state — final means final. (`:rf.error/machine-final-state-has-transitions`)
   `:entry` and `:exit` *are* allowed (entry runs in the cascade; exit runs from
   teardown).
 - **`:output-key` requires `:final?`.** A non-final state declaring

--- a/docs/machines/history.md
+++ b/docs/machines/history.md
@@ -54,8 +54,9 @@ A machine **is an event handler** ([this is the load-bearing difference from xst
 @(rf/subscribe [:rf/machine :media-player])
 ;; => {:state      [:player :playing :mid-track]
 ;;     :data       {}
-;;     :tags       #{…}   ;; the union of the active states' declared :tags
-;;     :rf/history  {[:player] [:player :playing :mid-track]}}
+;;     :rf/history {[:player] [:player :playing :mid-track]}}
+;; (no :tags key here — this machine declares no tags, and an empty tag
+;;  union is omitted from the snapshot rather than stored as #{})
 ```
 
 You wrote no capture code, no "remember the last tab" action. The `[:player :hist]` target does the work.
@@ -70,7 +71,7 @@ A `:type :history` pseudo-state carries **exactly** three keys, all owned by the
 | `:deep?` | boolean | `true` ⇒ **deep** history (restore the full recorded leaf path). `false` or **absent** ⇒ **shallow** (restore the recorded *direct child*, then cascade through *that* child's `:initial` chain). Default is shallow — a missing `:deep?` reads as `false`. |
 | `:default-target` | child keyword *or* absolute vector | Where to land the **first** time the compound is entered, before anything has been recorded. A direct-child keyword (`:stopped`) or an absolute path. **Absent** ⇒ falls back to the owning compound's `:initial`. |
 
-It MUST NOT declare `:on` / `:entry` / `:exit` / `:always` / `:after` / `:spawn` / `:states` / `:initial` / `:tags` / `:final?` — the machine never occupies it, so transition and lifecycle keys are meaningless on it. Any such key is a **registration error** (caught when you `reg-machine`, not on the unlucky dispatch that first reaches it).
+It MUST NOT declare `:on` / `:entry` / `:exit` / `:always` / `:after` / `:spawn` / `:spawn-all` / `:states` / `:initial` / `:tags` / `:final?` — the machine never occupies it, so transition and lifecycle keys are meaningless on it. Any such key is a **registration error** (caught when you `reg-machine`, not on the unlucky dispatch that first reaches it).
 
 ## Shallow vs deep — how *much* of the path is restored
 
@@ -94,7 +95,7 @@ Reach for **deep** when the precise nested position matters (resume the exact tr
 
 Recording is automatic and happens on the way **out**: whenever the exit cascade *leaves* a compound that owns a history pseudo-state, the runtime writes that compound's last-active configuration into the snapshot. You never write capture code.
 
-The subtlety — and the reason the example has a separate `:tray` state — is that the owning compound must be **genuinely exited** to record. This is the [W3C SCXML](https://www.w3.org/TR/scxml/#history) / xstate exit-set rule: a `<history>` value is written only for states in the exit set. A transition that merely moves *between two children* of the compound keeps the compound as the [least-common ancestor](concepts.md#when-the-machine-grows) — the compound **survives**, was never left, and so records nothing (there is no "last config" to remember; it is still in one).
+The owning compound must be **genuinely exited** to record. This is the [W3C SCXML](https://www.w3.org/TR/scxml/#history) / xstate exit-set rule: a `<history>` value is written only for states in the exit set. A transition that merely moves *between two children* of the compound keeps the compound as the [least-common ancestor](concepts.md#when-the-machine-grows) — the compound **survives**, was never left, and so records nothing (there is no "last config" to remember; it is still in one).
 
 That is exactly why `:eject` targets `:tray` (a *sibling of* `:player`, outside it) rather than some inner state: only leaving `:player` puts it in the exit set. A common first mistake is to put the history node on a compound that nothing ever exits — then it silently never records and "restore" always falls to the default. If your history isn't sticking, check that *something leaves the owning compound.*
 
@@ -134,9 +135,10 @@ Under a [parallel](concepts.md#when-the-machine-grows) machine each region runs 
 
 ```clojure
 ;; Two regions, each with a history-bearing :on compound at the same shape.
-;; The region name heads the key, so the recordings stay separate:
-{:rf/history {[:left  :group :on] [:left  :group :on :bright]
-              [:right :group :on] [:right :group :on :dim]}}
+;; The region name heads the KEY (so recordings stay separate); the recorded
+;; VALUE is that region's own within-region path:
+{:rf/history {[:left  :group :on] [:group :on :bright]
+              [:right :group :on] [:group :on :dim]}}
 ```
 
 Restoring history in one region leaves the others untouched — the same per-region scoping that `:spawn`, `:after`, and `:always` follow under parallel.

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -34,7 +34,7 @@ The canonical window onto a machine is the framework-registered subscription `[:
 The three keys are the whole user-facing shape:
 
 - **`:state`** — the discrete FSM keyword (`:idle`, `:submitting`, …). For a hierarchical machine it's a path vector (`[:authenticated :cart :browsing]`); for a parallel machine, a region map. This is what XState calls `state.value`.
-- **`:data`** — the machine's extended state: a plain map, distinct from app-db. XState calls this slot `context`; re-frame2 calls it `:data` to avoid the already-overloaded word "context". Read individual fields by destructuring, never `(get-in snapshot [:data …])` from inside a callback.
+- **`:data`** — the machine's extended state: a plain map, distinct from app-db. XState calls this slot `context`; re-frame2 calls it `:data` to avoid the already-overloaded word "context". Read the fields a view needs by destructuring (above) or through a named projection sub (below).
 - **`:tags`** — the runtime-projected union of every active state's `:tags`. Ask membership questions against it rather than hard-coding state names (see below).
 
 > **The snapshot is `nil` until the first event.** A machine bootstraps itself on the first event addressed to it, so `[:rf/machine id]` reads `nil` before then. A view that renders pre-bootstrap should fall back to the definition's `:initial`:
@@ -46,7 +46,7 @@ The three keys are the whole user-facing shape:
 
 ### Named projections off the snapshot
 
-`[:rf/machine id]` is the raw value; chain ordinary `reg-sub`s off it to pluck the pieces a view actually wants. This keeps views reading small, named slices instead of re-destructuring the whole snapshot:
+`[:rf/machine id]` is the raw value; chain ordinary `reg-sub`s off it so a view reads a small, named slice instead of re-destructuring the whole snapshot:
 
 ```clojure
 (rf/reg-sub :auth.login/state

--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -1,6 +1,6 @@
 # Parallel regions
 
-Some lifecycles aren't *one* question — they're several, all live at once. A todos screen is, at the same instant, *somewhere in its fetch* (nothing / loading / empty / some / too-many), *somewhere in its form* (neutral / valid / invalid), and *somewhere in its page mode* (active / archived). Those three axes are **orthogonal**: each moves on its own, and any combination is legal.
+Some lifecycles aren't *one* question — they're several, all live at once. A todos screen is *somewhere in its fetch* (nothing / loading / empty / some / too-many), *somewhere in its form* (neutral / valid / invalid), and *somewhere in its page mode* (active / archived). Those three axes are **orthogonal**: each moves on its own, and any combination is legal.
 
 Model that as one flat machine and the states multiply — three axes of three states each is `3 × 3 × 3 = 27` cross-product states, most of them named things like `:loading-and-invalid-and-active`. **Parallel regions** keep the axes apart. One machine declares `:type :parallel` and a `:regions` map; each region is a full little state-tree minding one axis; all regions are active simultaneously. Three axes of three states becomes **nine states across three regions**, not twenty-seven flat ones.
 
@@ -10,7 +10,7 @@ Model that as one flat machine and the states multiply — three axes of three s
 
 Reach for them when you have **multiple orthogonal axes of one feature** that share a domain: one form with data / validity / display-mode axes, one connection with auth + lifecycle + request-queue, one widget with display + interaction state. The giveaway is a single conceptual thing whose state is naturally a *tuple* of independent sub-states.
 
-The axes share a single [`:data`](concepts.md#the-same-flow-as-a-transition-table) map *because they're facets of one domain* — they read and write the *same* data, just sliced differently. If your axes are genuinely separate features that share nothing (a websocket connection plus an unrelated auth flow plus a route), that's not parallel regions — that's **N separate machines** colocated in [runtime-db](../core/glossary.md#runtime-db). Per-region `:data` is deliberately **not** supported; if your axes need their own encapsulated data, that's the substrate telling you to register N machines instead. (The full parallel-regions-versus-N-machines trade-off lives in the spec — see Further reading.)
+The axes share a single [`:data`](concepts.md#the-same-flow-as-a-transition-table) map *because they're facets of one domain* — they read and write the *same* data, just sliced differently. If your axes are genuinely separate features that share nothing (a websocket connection plus an unrelated auth flow plus a route), that's not parallel regions — that's **N separate machines** colocated in [runtime-db](../core/glossary.md#runtime-db). Per-region `:data` is deliberately **not** supported; if your axes need encapsulated data, that's the substrate telling you to register N machines instead. (The full parallel-regions-versus-N-machines trade-off lives in the spec — see Further reading.)
 
 ## The shape: one machine, several regions
 
@@ -260,7 +260,7 @@ A parallel machine's `:tags` is the **union of every active state's tags across 
 
 The framework [`machine-has-tag?`](../api/re-frame.machines.md) sub works unchanged — it asks "does the union contain this tag?", and the answer is yes iff *any* active state in *any* region declared it. That's what lets a view disable itself with `@(rf/machine-has-tag? :ui/nine-states :mode/read-only)` without caring which region (or which state of it) carries the read-only intent — *ask, don't tell* ([state tag](glossary.md#state-tag)).
 
-The composed tag union is also what makes the headline payoff work: **collapsing N live axes down to one render decision**. Several tags are live at once, but the page draws one thing, so a plain-data priority table picks the winner:
+The composed tag union also delivers the headline payoff: **collapsing N live axes down to one render decision**. Several tags are live at once, but the page draws one thing, so a plain-data priority table picks the winner:
 
 ```clojure
 (def render-priority                       ;; read top to bottom; first match wins
@@ -281,7 +281,7 @@ The composed tag union is also what makes the headline payoff work: **collapsing
             render-priority))))
 ```
 
-The root view's whole branching logic is then a single `case` over `@(rf/subscribe [:ui/render])`. Three regions, nine states, **one** branch site — and the display priorities live in *one* readable table, not scattered across ten views.
+The root view then branches with a single `case` over `@(rf/subscribe [:ui/render])`. Three regions, nine states, **one** branch site — and the display priorities live in *one* readable table, not scattered across ten views.
 
 ## A divergence to know: no nested parallel regions
 

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -34,7 +34,7 @@ If a label would only ever match exactly one state, skip it — query the state 
 
 Both `:loading` and `:retrying` wear `:data/in-flight`. A view that wants "show the spinner while a request is in flight" consumes that one tag and never disjoins two state keywords — and the day you add a third in-flight state, it's one `:tags` entry and the view picks it up for free.
 
-Two rules worth pinning down now:
+Two rules:
 
 - **Tags label *intent*, not *identity*.** `:tags #{:data/in-flight}` is good; `:tags #{:todos.loader/loading-state}` just re-encodes the state name and earns nothing. Use a per-axis namespace (`:data/…`, `:form/…`, `:mode/…`) so one tag-question can span several states.
 - **The `:rf/*` / `:rf.*/*` namespaces are framework-reserved.** Tag with your own feature prefix — `:auth/busy`, `:cart/dirty`, `:ws/disconnected`. Any unreserved namespace is fair game, dotted forms (`:ui.state/loading`) included.
@@ -109,7 +109,7 @@ This is where tags pay off hardest. The [Nine States example](../../examples/pat
 Three axes run at once, so several tags are live simultaneously — `:data/loading` *and* `:form/invalid` *and* `:mode/active`. The page can only draw one thing, so it needs a tie-breaker. Make it **plain data**: a render-priority table read top to bottom, plus one selector sub that returns the first matching tag's render-model keyword.
 
 ```clojure
-(def render-priority
+(def render-priority             ;; excerpt — the runnable example carries all ten rows
   [{:tag :mode/done    :render :done}        ;; archived trumps everything
    {:tag :form/success :render :correct}     ;; transient form acks next
    {:tag :form/invalid :render :incorrect}
@@ -156,9 +156,9 @@ Notice what the form *doesn't* ask: "is the `:mode` region in `:done`?" It asks 
 
 ## Tags as a cross-region signal (`stateIn`)
 
-In a parallel machine the tag union spans *all* regions, which makes it the channel one region uses to read what a sibling is doing. This is the classic statechart coordination primitive: a guard in region A predicates on region B's state. XState spells it `stateIn({ form: 'valid' })` (and W3C SCXML has `In(...)`); re-frame2 ships the *behaviour* without a separate `stateIn` operator — a deliberate divergence in the name of behavioural parity, not API mimicry. **A sibling region advertises a tag, and any region's guard reads the tag union off its context map.**
+In a parallel machine the tag union spans *all* regions, which makes it the channel one region uses to read what a sibling is doing. This is the classic statechart coordination primitive: a guard in region A predicates on region B's state. XState spells it `stateIn({ form: 'valid' })` (and W3C SCXML has `In(...)`); re-frame2 ships the *behaviour* without a separate `stateIn` operator — a deliberate divergence for behavioural parity, not API mimicry. **A sibling region advertises a tag, and any region's guard reads the tag union off its context map.**
 
-A guard or action running *inside a parallel region* gets two extra keys in its context map, alongside the usual `:data` / `:event` / `:state`:
+A guard or action running *inside a parallel region* gets two extra keys in its context map, alongside the usual `:data` / `:event` / `:state` / `:meta`:
 
 - **`:tags`** — the machine-wide tag union (the **coarse**, idiomatic `stateIn` substitute);
 - **`:all-state`** — the full `{region → active-state}` map (the **precise** read).


### PR DESCRIPTION
Adversarial per-page review of the machines/statechart docs (the deep coverage merged in #5047), checked against spec 005 + the implementation + the example apps. **The docs held up well** — the fixes were subtle over-claims and missing caveats, not invented API.

## Correctness fixes
- **concepts.md** — softened "`reg-machine` is *exactly equivalent* to `reg-event` + `make-machine-handler`": `reg-machine` also stamps `:rf/machine?` / `:rf/machine` metadata + source-coords that a bare `reg-event` doesn't, so a machine registered the bare way is invisible to `(rf/machines)` / `(rf/machine-meta)` / visualisers. Also corrected the `:rf.cofx/requires` read-path prose to match its code sample (named entry, not the bare `:rf.cofx` record).
- **hierarchical-states.md** — added the missing **LCA exit row** in the worked transition table; added `:spawn-all` to the `:final?`-state forbidden-keys list (the spec rejects it at registration).
- Smaller fixes + missing caveats filled across the other pages.

## Prose
Verbose / indirect passages tightened to lead with the fact (simple, direct).

## Completeness
Gaps too large to fit their page without ballooning it (child-failure `:on-error` routing, all-regions-final parallel-root `:on-done`, capability-gating keywords) were **flagged in the review** rather than force-fit — each is already covered by that page's Further-reading spec pointer.

## Verification (local)
`check_doc_slugs` (0 broken), `check_readme_links`, the 3 residue checkers, and the api-manifest JVM gate (concepts.md var references reconcile — 678 refs). `mkdocs --strict` runs in CI.