### PR TITLE
docs(routing): make the guide and the API reference cohere

### DIFF
--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -42,7 +42,7 @@ The third positional arg is the URL shape — colon-prefixed segments capture in
 | `:parent` | Another route id; builds a chain readable via `:rf.route/chain`. |
 | `:on-match` | Event vector(s) to dispatch when the route activates. |
 | `:on-error` | Event vector dispatched if any `:on-match` event errors. |
-| `:can-leave` | Guard sub-query run before leaving the route. **Closed boolean contract**: `true` allows the navigation, `false` blocks it; any non-boolean value blocks and emits `:rf.error/can-leave-non-boolean`. The sub name reads positively (`:can-leave`), so `false` means "can NOT leave". See [Guide ch.19 — Navigation blocking](../routing/concepts.md). |
+| `:can-leave` | Guard sub-query run before leaving the route. **Closed boolean contract**: `true` allows the navigation, `false` blocks it; any non-boolean value blocks and emits `:rf.error/can-leave-non-boolean`. The sub name reads positively (`:can-leave`), so `false` means "can NOT leave". See [Routing → Blocking a navigation](../routing/concepts.md#blocking-a-navigation). |
 | `:scroll` | Scroll-restoration behaviour for this route. |
 
 Canonical detail in [The metadata map, in full](../routing/concepts.md#the-metadata-map-in-full) in the routing concept guide.
@@ -353,12 +353,12 @@ The full `:rf/route` slice is `{:id :params :query :transition :error}`. The sta
 | `[:rf.nav/scroll scroll-spec]` | scroll-spec map | `:client` | Restore or set scroll position. |
 | `[:rf.route/with-nav-token {:rf/reply-to <reply-target> :nav-token <token>}]` | universal | universal | Name an async-completion continuation by its canonical `:rf/reply-to` reply target and guard it with a navigation token. On match the target is completed with the `:status :ok` reply map; if the token has been superseded by a later navigation, the completion is suppressed and `:rf.route.nav-token/stale-suppressed` fires. |
 
-The nav-token wrapper is what makes "user navigates away mid-load" safe: the older load's reply carries the stale token, the runtime suppresses it, and you don't see the older page's data overwrite the newer page's state. Full semantics in [Guide ch.19 — Navigation tokens](../routing/concepts.md).
+The nav-token wrapper is what makes "user navigates away mid-load" safe: the older load's reply carries the stale token, the runtime suppresses it, and you don't see the older page's data overwrite the newer page's state. Full semantics in [Routing → Loaders](../routing/concepts.md#loaders-declaring-a-pages-data) (the nav-token "going deeper").
 
 ## See also
 
 - [re-frame.core.md](re-frame.core.md) — the `re-frame.core` facade: the `reg-route` macro's brief row and the `route-link` view.
 - [re-frame.ssr.md](re-frame.ssr.md) — routes participate in SSR; the active route's `:head` registration is what `render-head` looks up.
-- [Guide ch.18 — Routing](../routing/concepts.md) and [Guide ch.19 — Routing reference](../routing/concepts.md) — narrative coverage including nav-token semantics, `:can-leave` flows, query strings, and multi-frame routing.
+- [Routing guide](../routing/index.md) — the narrative side: a [tutorial](../routing/tutorial.md), [concepts](../routing/concepts.md) (nav-token semantics, `:can-leave` flows, query strings, multi-frame routing), and how-to recipes.
 - [Routing glossary](../routing/glossary.md) — the surface vocabulary (navigate, route, loader, route guard, not-found, url-bound?).
 - [Coming from React Router](../routing/coming-from-react-router.md) — the mapping, and where re-frame2 routing diverges.

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -107,7 +107,7 @@ Because routes are registry entries, the route table is *queryable data* — and
 
 ### The metadata map, in full
 
-You've now met the keys you'll reach for daily. The metadata map has thirteen reserved keys in total — the largest registration shape in re-frame2 — but you never learn them as a flat list. They cluster into four groups by *what they control*; pick the group first, then the key. The rest of this page introduces the remaining keys in context, so treat this table as a map of where you're going.
+You've now met the keys you'll reach for daily. The metadata map has thirteen reserved keys in total — the largest registration shape in re-frame2 — but you never learn them as a flat list. They cluster into four groups by *what they control*; pick the group first, then the key. The rest of this page introduces the remaining keys in context, so treat this table as a map of where you're going — and the [API reference](../api/re-frame.routing.md#reg-route) for the canonical, per-key spec.
 
 | Group | Keys | What it controls |
 |---|---|---|
@@ -215,7 +215,7 @@ The current route lives in **runtime-db** — the framework-owned partition besi
 @(rf/subscribe [:rf/pending-navigation]);; the blocked navigation parked by a :can-leave guard, or nil
 ```
 
-Nine subscriptions, every one a plain read — no special routing API in views. `:rf/route` is the whole slice; the rest are projections of it you'll reach for far more often.
+Nine subscriptions, every one a plain read — no special routing API in views. `:rf/route` is the whole slice; the rest are projections of it you'll reach for far more often. The [API reference](../api/re-frame.routing.md#subscriptions) lists each with its return shape.
 
 `:transition` is a tiny state machine the runtime drives for you: `:loading` while a route's loaders drain, `:error` if one fails, `:idle` otherwise. So a global progress bar is just a view over `:rf.route/transition`, and an error banner is a view over `:rf.route/error`. You never wire per-page loading state again — it's a property of the slice, the same on every page:
 

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -5,22 +5,40 @@ A URL is just another input. In most frameworks the router is a parallel system 
 You register routes (`reg-route`) as a table mapping URL patterns to what they need — param/query schemas, a [loader](glossary.md#loader) for the page's data, a [`:can-leave`](glossary.md#route-guard) guard — and read the active route as state.
 
 ```clojure
-(rf/reg-route :article
-  {:path   "/article/:slug"
-   :params {:slug :string}})
+;; A route is data: an id, a metadata map, and a path (the third slot).
+(rf/reg-route :app/article
+  {:params [:map [:id :string]]}
+  "/articles/:id")
 
-@(rf/subscribe [:rf.route/params])     ;; => {:slug "hello"}
-(rf/dispatch [:rf.route/navigate :article {:slug "hello"}])
+;; Read the active route as state; change it by dispatching an event.
+@(rf/subscribe [:rf.route/params])                  ;; => {:id "hello"}
+(rf/dispatch [:rf.route/navigate :app/article {:id "hello"}])
 ```
 
 Because a route's [loader](glossary.md#loader) runs on the server too, routing and [SSR](../ssr/index.md) share one data-fetch story — there's no separate server fetch to keep in sync.
 
 ## In this section
 
-- **[Tutorial: build a routed app](tutorial.md)** — start here. Build a small three-page app one piece at a time: routes, links, dynamic segments, loaders, the 404, the Back button, and a shared layout.
-- **[Concepts](concepts.md)** — the whole model in three moves, then everything a growing app reaches for: query strings, the loading/error transition, navigation blocking, data classification, and routing on the server.
+These pages are the **guide** — read top to bottom to learn routing, or dip in to understand one part. Every signature, event, subscription, and keyword has its canonical home in the separate **[API reference](../api/re-frame.routing.md)**: the guide teaches, the reference is where you look things up.
+
+**Start here**
+
+- **[Tutorial: build a routed app](tutorial.md)** — build a small three-page app one piece at a time: routes, links, dynamic segments, loaders, the 404, the Back button, and a shared layout.
+
+**Understand the model**
+
+- **[Concepts](concepts.md)** — the whole model in three moves, then everything a growing app reaches for: query strings, the loading/error transition, nested layouts, navigation blocking, data classification, and routing on the server.
 - **[Coming from React Router](coming-from-react-router.md)** — the mapping from `createBrowserRouter`, loaders, and the hooks, and where re-frame2 deliberately diverges.
-- **How-to** — task recipes: [guard against unsaved changes](how-to/guard-unsaved-changes.md), and [require sign-in on a route](how-to/require-sign-in-on-a-route.md).
-- **[API](../api/re-frame.routing.md)** — `reg-route`, the `:rf.route/*` events and subscriptions, the URL helpers, the guard protocol.
+
+**Do a task**
+
+- **[Guard against unsaved changes](how-to/guard-unsaved-changes.md)** and **[Require sign-in on a route](how-to/require-sign-in-on-a-route.md)** — focused recipes for the two common navigation-control jobs.
+
+**Look it up**
+
+- **[API reference](../api/re-frame.routing.md)** — `reg-route`, every `:rf.route/*` event and subscription, the URL helpers, and the guard contract, with signatures.
 - **[Glossary](glossary.md)** — the routing vocabulary in one place.
+
+**See it running**
+
 - **[Examples](examples.md)** — worked routing apps you can read end to end.


### PR DESCRIPTION
## What & why

A whole-corpus pass on the routing docs, focused on **coherence between the guide and the API reference** (`docs/api/re-frame.routing.md`). The content is complete and correct; the problem was that the two halves didn't fit together — and the landing page led with a broken example.

## The structural call

The API reference **stays in Core→API**, like every other capability (machines / resources / ssr), reinforced by the #5045 "one document per namespace" reorg. A doc can only live in one nav location, and pulling routing's out would make it the lone exception. So coherence comes from **clear orientation + bidirectional handoffs**, not from moving files. (If you'd actually prefer routing to be self-contained with its reference in the Routing section, that's the one bigger fork — say so and I'll do it across all capabilities for consistency.)

## Changes

- **`index.md` — fix the hero example.** It used `{:path "/article/:slug" :params {:slug :string}}` — but `reg-route`'s path is the **third positional slot** (`:path` inside the metadata is a loud `:rf.error/invalid-route-metadata`), and `:params` must be a Malli schema (`[:map [:slug :string]]`). The landing page's first code contradicted the rest of the docs. Now correct.
- **`index.md` — orienting map.** The flat "In this section" list becomes grouped (Start here / Understand the model / Do a task / Look it up / See it running), stating the split plainly: the section is the **guide**; the API doc is the **reference**.
- **API reference — fix the stale guide handoff.** Four dead "Guide ch.18/ch.19" links (all dumping into `concepts.md`) now resolve to real anchors (blocking, loaders) and to the routing guide index/tutorial.
- **`concepts.md` — add the missing guide→reference handoff.** It never linked to the API doc *once*; its two densest reference tables (route metadata, the route subs) now point at the canonical API reference.

Net: +32 / −14 across three files.

## Verification

- `python -m mkdocs build --strict` → exit 0, no anchor/link warnings
- `check_doc_slugs.py` / `check_readme_links.py` / `check_readme_inventories.py` → exit 0
- api-manifest `doc-api-check` (scans `docs/api/`) → 271 refs in sync, exit 0
