### PR TITLE
docs: remove the trailing 'Where to go next' and 'Further reading' sections

### DIFF
--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -278,18 +278,3 @@ Here's the payoff. A transition is a pure function of *(table, snapshot, event)*
 ```
 
 Feed in a snapshot and an event; assert on the snapshot that comes back. The result is a value — destructure `::result/snap` and `::result/fx`, or discriminate with `result/ok?` / `result/fail?` (a throwing action surfaces as a *failure value*, not an exception out of your test). These run on the JVM in microseconds, which is exactly the testing experience you want for the flows where testing usually gets hard.
-
-## Where to go next
-
-You've built the whole everyday surface — a table, a guard, actions and their `{:data :fx}`, an async call that loops its reply home, a view per state, and a pure-function test — each met on its own. From here:
-
-- **[Concepts](concepts.md)** — the same model end to end, plus the parts a richer flow reaches for: the snapshot in full, self / wildcard / final transitions, strict encapsulation, validating `:data` with a schema, and the XState delta.
-- **[Hierarchical states](hierarchical-states.md)** — a compound state with sub-states (an `:authenticated` super-state over `:browsing` / `:checkout`).
-- **[Parallel states](parallel-states.md)** — several orthogonal axes active at once, sharing one `:data`.
-- **[Automatic transitions](automatic-transitions.md)** — `:after` timers in full, and `:always` (fire the moment a guard turns true).
-- **[Actors](actors.md)** — machines that aren't singletons: spawn a child on entry, tear it down on exit.
-- **[History](history.md)** — re-enter a compound at the substate you left.
-- **[Tags](tags.md)** — the ask-don't-tell pattern in depth.
-- **[Inspecting and testing](inspecting-machines.md)** — watch a machine live in Xray, and the headless test surface in full.
-- **[API reference](../api/re-frame.machines.md)** — every fn, subscription, and keyword surface, with signatures.
-- **[Examples](examples.md)** — the runnable login machine you just sketched, plus more.

--- a/docs/routing/tutorial.md
+++ b/docs/routing/tutorial.md
@@ -213,12 +213,3 @@ Now `@(subscribe [:rf.route/chain])` returns the active route's ancestry, **root
 **What you see:** on `/articles/intro`, the article renders inside the `← All articles` section nav, under the site header — and every article detail page shares that frame with no copy-paste. Plain `/articles` (no parent above it) shows the bare list; `/` shows the home page. Note the split: truly *global* chrome (the `My Site` header) is just rendered in the root view — you only reach for the chain when a shell wraps a *subtree*.
 
 > **Coming from React Router?** This is the job `<Outlet/>` does there. The trade is deliberate: instead of a routing-specific render slot, you compose plain Clojure with the `case`/`reduce` you'd write for any conditional view. It's the one place routing asks a little more of you — and the only routing-specific piece is the one `:rf.route/chain` read. [Concepts → Nested layouts](concepts.md#nested-layouts) has the reference version.
-
-## Where to go next
-
-You've now built the whole everyday surface: routes, links, dynamic segments, loaders, the 404, Back/Forward, and a nested layout — each met on its own. From here:
-
-- **[Concepts](concepts.md)** — the same model end to end, plus the parts a growing app reaches for: query strings and retained global state, the loading/error `:transition` machine, blocking a navigation ("unsaved changes?"), keeping tokens off the wire, and routing on the server.
-- **[Coming from React Router](coming-from-react-router.md)** — the full mapping, and the handful of deliberate divergences.
-- **[Examples](examples.md)** — the complete app you just sketched, plus routing under real load in the RealWorld clone.
-- **[API reference](../api/re-frame.routing.md)** — every event, subscription, and helper, with signatures.


### PR DESCRIPTION
Trims redundant trailing sections from the guide pages — the left nav + Material's prev/next footer already carry onward navigation.

- **"Where to go next"** — removed from the 2 tutorial pages (`docs/machines/tutorial.md`, `docs/routing/tutorial.md`); the only two in the docs.
- **"Further reading"** — removed from all 10 `docs/machines/` guide pages.

Each page now ends on its own final content beat.

**One consequence (flagged):** the **Fulcro statecharts** citations lived only in the machines "Further reading" sections, so they're removed, along with the per-page spec pointers. The **inline XState bridges** ("in XState this is X; in re-frame2 it's Y") remain throughout the machine pages, so the XState parity framing is preserved. Say the word if you want Fulcro/spec pointers kept somewhere.

`check_doc_slugs` green (no page linked into a removed anchor); `mkdocs --strict` runs in CI.