### PR TITLE
feat(core): add sub-machine + sub-route reactive read sugar (rf2-jav90x)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1468,14 +1468,27 @@
 ;; messaging surface is the reserved `[:rf.machine/dispatch-to-system
 ;; [system-id event]]` fx tuple; the direct-call FN now lives in
 ;; `re-frame.machines` as an implementation-tier helper. The `sub-machine`
-;; snapshot sugar is REMOVED (rf2-wh7xip — zero adopters); the canonical
-;; machine read is the `[:rf/machine machine-id]` subscription vector.
+;; snapshot read sugar layers OVER the canonical `[:rf/machine machine-id]`
+;; subscription vector (which remains the registered sub) — a plain fn over
+;; `subscribe`, mirroring `machine-has-tag?`, with an `opts` passthrough for
+;; the `{:frame …}` capability.
 
 (def ^{:doc "Subscribe to a machine's `:fsm/tags` containment-bit for
   `tag`. Sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])`
   — returns a reaction whose value is `true` iff the current snapshot's
   `:tags` set contains `tag`. Per Spec 005 §State tags."}
   machine-has-tag?               rf-machines/machine-has-tag?)
+
+(def ^{:doc "Subscribe to a machine's snapshot. Sugar over
+  `(subscribe [:rf/machine machine-id])` — returns a reaction over the
+  snapshot map `{:state :data :tags}` (nil before the machine's first
+  event). The 2-arity `opts` map carries the `{:frame <target>}`
+  capability the underlying subscription vector accepts. The
+  `[:rf/machine machine-id]` vector form remains the canonical registered
+  sub; this is ergonomic read sugar over it. Per Spec 005 §Subscribing to
+  machines via the :rf/machine sub."
+       :arglists '([machine-id] [machine-id opts])}
+  sub-machine                    rf-machines/sub-machine)
 
 ;; ---- resource helpers (Spec 016) ------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -229,3 +229,33 @@
   [machine-id tag]
   (subs/subscribe [:rf/machine-has-tag? machine-id tag]))
 
+(defn sub-machine
+  "Subscribe to a machine's snapshot. Sugar over `(subscribe [:rf/machine
+  machine-id])`. Returns a reaction whose value is the snapshot map
+  `{:state <kw> :data <map> :tags <set>}`, or nil before the machine's
+  first event (not yet initialised).
+
+  The `sub-` prefix is re-frame's subscription-family verb (sibling of
+  `subscribe` / `subscribe-once`); it does NOT denote a child-machine
+  relationship — declarative child-machine binding uses `:spawn`.
+
+  The 1-arity primary form resolves the ambient frame through the carried
+  scope/hold chain, exactly like the bare `(subscribe [:rf/machine
+  machine-id])`. The 2-arity `opts` map carries the same `{:frame
+  <target>}` capability the underlying subscription vector accepts —
+  `<target>` is a frame-id keyword or a live frame object — so a read can
+  target an explicit frame from outside an established scope (async
+  callbacks, tools, tests).
+
+  The `[:rf/machine machine-id]` vector form remains the canonical
+  registered sub; this is ergonomic read sugar over it. Composable with
+  the rest of the sub graph and elides on production builds the same way
+  every framework sub does — the underlying registration is a standard
+  runtime-db `reg-sub`, no new registry. Per Spec 005 §Subscribing to
+  machines via the :rf/machine sub."
+  ([machine-id] (subs/subscribe [:rf/machine machine-id]))
+  ([machine-id opts]
+   (if-let [frame (:frame opts)]
+     (subs/subscribe frame [:rf/machine machine-id])
+     (subs/subscribe [:rf/machine machine-id]))))
+

--- a/implementation/machines/test/re_frame/sub_machine_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/sub_machine_cljs_test.cljs
@@ -1,0 +1,75 @@
+(ns re-frame.sub-machine-cljs-test
+  "CLJS coverage for the `sub-machine` reactive-read sugar — a thin fn over
+  `(subscribe [:rf/machine machine-id])` returning a reaction over the
+  machine's snapshot map `{:state :data :tags}`.
+
+  Concerns covered:
+    - happy path: the sugar reads the post-event snapshot and is value-equal
+      to the canonical `[:rf/machine id]` subscription vector form;
+    - adversarial: an unspawned / unknown machine id yields a nil-snapshot
+      reaction;
+    - adversarial: the `{:frame f}` opts passthrough resolves the snapshot
+      from the named frame, isolated from the ambient default frame.
+
+  ns ends in `-cljs-test` so shadow-cljs's `:node-test` build picks it up.
+  Per Spec 005 §Subscribing to machines via the :rf/machine sub."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; load the optional machines artefact so its `:machines/reg-machine`
+            ;; late-bind hook + the `:rf/machine` runtime-db sub are published
+            ;; before the reg-machine / sub-machine calls below.
+            [re-frame.machines]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(def ^:private toggle-machine
+  "A flat two-state toggle. `:flip` moves off↔on; the off→on edge also runs
+  the `:bump` action so the snapshot's `:data` is observable through the sugar."
+  {:initial :off
+   :data    {:n 0}
+   :actions {:bump (fn [{d :data}] {:data (update d :n inc)})}
+   :states  {:off {:on {:flip {:target :on :action :bump}}}
+             :on  {:on {:flip {:target :off}}}}})
+
+(deftest sub-machine-returns-snapshot-reaction
+  (testing "sub-machine reads the post-event snapshot, value-equal to the
+            canonical [:rf/machine id] subscription vector"
+    (rf/reg-machine :sub/toggle toggle-machine)
+    (rf/dispatch-sync [:sub/toggle [:flip]])
+    (let [snap @(rf/sub-machine :sub/toggle)]
+      (is (= :on (:state snap)) "sugar reads the post-event :state")
+      (is (= 1 (:n (:data snap))) "sugar reads the snapshot's :data")
+      ;; the sugar resolves through the SAME framework sub as the vector form.
+      (is (= @(rf/subscribe [:rf/machine :sub/toggle])
+             @(rf/sub-machine :sub/toggle))
+          "sub-machine value == [:rf/machine id] subscription value"))))
+
+(deftest sub-machine-unspawned-id-nil-snapshot
+  (testing "sub-machine yields a nil snapshot before the machine's first event
+            and for an entirely unknown id (adversarial)"
+    ;; registered but never dispatched → no snapshot in the runtime-db.
+    (rf/reg-machine :sub/never toggle-machine)
+    (is (nil? @(rf/sub-machine :sub/never))
+        "no snapshot before the first event")
+    ;; never even registered → also a nil-snapshot reaction, not an error.
+    (is (nil? @(rf/sub-machine :sub/unknown))
+        "unknown machine id → nil snapshot")))
+
+(deftest sub-machine-frame-opts-passthrough
+  (testing "the {:frame f} opts passthrough resolves the snapshot from the
+            named frame, isolated from the ambient default frame (adversarial)"
+    (rf/reg-frame :sub-machine/f2 {:doc "second frame for the passthrough test"})
+    (rf/reg-machine :sub/scoped toggle-machine)
+    ;; run the machine ONLY in :sub-machine/f2 — the default frame never sees it.
+    (rf/dispatch-sync [:sub/scoped [:flip]] {:frame :sub-machine/f2})
+    (is (= :on (:state @(rf/sub-machine :sub/scoped {:frame :sub-machine/f2})))
+        "{:frame f2} reads the snapshot that ran in f2")
+    (is (= @(rf/subscribe :sub-machine/f2 [:rf/machine :sub/scoped])
+           @(rf/sub-machine :sub/scoped {:frame :sub-machine/f2}))
+        "opts passthrough == the 2-arity frame-targeted vector subscription")
+    (is (nil? @(rf/sub-machine :sub/scoped))
+        "the ambient default frame has no snapshot — frame isolation holds")))

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -115,6 +115,33 @@
 ;; Subs
 (def route-sub-fn               routing-subs/route-sub-fn)
 
+;; Named reactive-read sugar over the canonical `[:rf/route]` subscription
+;; vector. Defined + exported HERE on the `re-frame.routing` façade (NOT
+;; `re-frame.core`) so a non-routing app's production-elision bundle carries
+;; no route keyword strings — the routing bundle-isolation invariant. The
+;; `[:rf/route]` vector form remains the registered sub; this layers over it.
+(defn sub-route
+  "Subscribe to the current route slice. Sugar over `(subscribe [:rf/route])`.
+  Returns a reaction over the slice
+  `{:route-id :params :query :transition :error :fragment :nav-token}`
+  (nil before the first navigation). The route is a per-frame singleton, so
+  the primary form is zero-arity.
+
+  The 1-arity `opts` map carries the same `{:frame <target>}` capability the
+  underlying subscription vector accepts — `<target>` is a frame-id keyword
+  or a live frame object — so a read can target an explicit frame (e.g. a
+  non-default url-bound frame) from outside an established scope. Without
+  `:frame` the read resolves the ambient frame through the carried scope/hold
+  chain, exactly like the bare `(subscribe [:rf/route])`.
+
+  The `[:rf/route]` vector form remains the canonical registered sub; this is
+  ergonomic read sugar over it. Per Spec 012 §Subscriptions."
+  ([] (subs/subscribe [:rf/route]))
+  ([opts]
+   (if-let [frame (:frame opts)]
+     (subs/subscribe frame [:rf/route])
+     (subs/subscribe [:rf/route]))))
+
 ;; EP-0014 slice-5 (rf2-eiiifu): the derivation/process algebra view of
 ;; registered routes (`route-algebra-view`, static) and a frame's live route
 ;; slice (`route-slice-algebra-view`, live). JVM-runnable (the route

--- a/implementation/routing/test/re_frame/sub_route_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/sub_route_cljs_test.cljs
@@ -1,0 +1,70 @@
+(ns re-frame.sub-route-cljs-test
+  "CLJS coverage for the `sub-route` reactive-read sugar — a thin fn over
+  `(subscribe [:rf/route])` returning a reaction over the current route slice.
+  It lives on the `re-frame.routing` façade (NOT `re-frame.core`) per the
+  routing bundle-isolation invariant, so the test reaches it as
+  `routing/sub-route`.
+
+  Concerns covered:
+    - happy path: the sugar reads the active route slice and is value-equal
+      to the canonical `[:rf/route]` subscription vector form;
+    - adversarial: a frame that never navigated yields a nil slice;
+    - adversarial: the `{:frame f}` opts passthrough resolves the slice from
+      the named frame, isolated from the ambient default frame.
+
+  ns ends in `-cljs-test` so shadow-cljs's `:node-test` build picks it up.
+  Per Spec 012 §Subscriptions."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; load the routing artefact so its `:rf/route` reg-sub family, the
+            ;; `:rf.route/*` events, and `sub-route` itself are available.
+            [re-frame.routing :as routing]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn routing/reset-counters!}))
+
+(defn- stub-push-url!
+  "No-op `:rf.nav/push-url` — the real handler touches browser history, which
+  the node-test runtime has no `window` for. Mirrors routing_subs_test.clj."
+  []
+  (rf/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+
+(deftest sub-route-returns-slice-reaction
+  (testing "sub-route reads the active route slice, value-equal to [:rf/route]"
+    (stub-push-url!)
+    (rf/reg-route :route/home {} "/home")
+    (rf/dispatch-sync [:rf.route/transitioned "/home"])
+    (let [slice @(routing/sub-route)]
+      (is (= :route/home (:route-id slice)) "sugar reads the active route-id")
+      ;; the sugar resolves through the SAME framework sub as the vector form.
+      (is (= @(rf/subscribe [:rf/route]) @(routing/sub-route))
+          "sub-route value == [:rf/route] subscription value"))))
+
+(deftest sub-route-nil-before-navigation
+  (testing "sub-route yields a nil slice for a frame that never navigated
+            (adversarial)"
+    (rf/reg-frame :sub-route/fresh {:doc "frame with no navigation"})
+    (is (nil? @(routing/sub-route {:frame :sub-route/fresh}))
+        "no route slice before the first navigation")))
+
+(deftest sub-route-frame-opts-passthrough
+  (testing "the {:frame f} opts passthrough resolves the slice from the named
+            frame, isolated from the ambient default frame (adversarial)"
+    (stub-push-url!)
+    (rf/reg-route :route/alpha {} "/alpha")
+    (rf/reg-route :route/beta  {} "/beta")
+    (rf/reg-frame :sub-route/f2 {:doc "second frame for the passthrough test"})
+    ;; land DIFFERENT routes in the default frame and in :sub-route/f2.
+    (rf/dispatch-sync [:rf.route/transitioned "/alpha"])
+    (rf/dispatch-sync [:rf.route/transitioned "/beta"] {:frame :sub-route/f2})
+    (is (= :route/beta (:route-id @(routing/sub-route {:frame :sub-route/f2})))
+        "{:frame f2} reads f2's route slice")
+    (is (= @(rf/subscribe :sub-route/f2 [:rf/route])
+           @(routing/sub-route {:frame :sub-route/f2}))
+        "opts passthrough == the 2-arity frame-targeted vector subscription")
+    (is (= :route/alpha (:route-id @(routing/sub-route)))
+        "the ambient default frame keeps its own slice — frame isolation holds")))

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -746,6 +746,10 @@
   ;; `re-frame.machines` (already classified below). `machine-has-tag?` (a
   ;; subscription sugar with no owned-ns peer) stays on the façade.
   ["re-frame.core" "machine-has-tag?"]     {:tier :advanced :owner "005" :status "v1"}
+  ;; Named machine-snapshot read sugar over the canonical `[:rf/machine id]`
+  ;; subscription vector — a plain fn over `subscribe`, mirroring
+  ;; `machine-has-tag?` (owner 005, advanced). Re-exported from the façade.
+  ["re-frame.core" "sub-machine"]          {:tier :advanced :owner "005" :status "v1"}
   ["re-frame.core" "frame-ids"]            {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "frame-meta"]           {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "app-db-value"]         {:tier :advanced :owner "002" :status "v1"}
@@ -1028,6 +1032,12 @@
   ["re-frame.routing" "route-ids"]              {:tier :tooling :owner "012" :status "v1"}
   ["re-frame.routing" "route-meta"]             {:tier :tooling :owner "012" :status "v1"}
   ["re-frame.routing" "current-url"]            {:tier :advanced :owner "012" :status "v1"}
+  ;; Named route-slice read sugar over the canonical `[:rf/route]`
+  ;; subscription vector. Routing-façade home (NOT re-frame.core) so a
+  ;; non-routing app carries no route keyword strings in its production
+  ;; bundle — the routing bundle-isolation invariant. Advanced tier like its
+  ;; sibling read surfaces (`match-url` / `route-url`).
+  ["re-frame.routing" "sub-route"]              {:tier :advanced :owner "012" :status "v1"}
   ["re-frame.routing" "reg-route"]              {:tier :implementation :owner "012" :status "v1"}
   ["re-frame.routing" "clear-route"]            {:tier :tooling :owner "012" :status "v1"}
   ["re-frame.routing" "malformed-url?"]         {:tier :implementation :owner "012" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 484,
+ :var-count 486,
  :tier-vocab
  [:front-porch
   :advanced
@@ -181,6 +181,7 @@
   {:namespace "re-frame.core", :var "runtime-db-value", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "sensitive?", :tier :tooling, :kind :fn, :owner "009", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "snapshot-of", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "sub-machine", :tier :advanced, :kind :fn, :owner "005", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "subscribe", :tier :front-porch, :kind :macro, :owner "002", :status "v1 (preserved + extended)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "subscribe*", :tier :implementation, :kind :fn, :owner "002", :status "EP-0024 (internal HoF/macro-reach only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "subscribe-once", :tier :advanced, :kind :fn, :owner "006", :status "v1", :facade? true, :runtime-verified? true}
@@ -282,6 +283,7 @@
   {:namespace "re-frame.routing", :var "save-scroll-position", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "save-scroll-position!", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "scroll-positions-cap", :tier :implementation, :kind :var, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.routing", :var "sub-route", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "url-owner-frame-id", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "app-schema-at", :tier :tooling, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "app-schema-meta-at", :tier :tooling, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
## Summary

Adds thin named reactive-read sugar over the existing runtime-db subscription-vector forms, scoped to the two commissioned runtime-db surfaces:

- sub-machine — read a machine snapshot. Home re-frame.core-machines, re-exported from re-frame.core (mirrors machine-has-tag?). Signatures (sub-machine machine-id) and (sub-machine machine-id opts), delegating to (subscribe [:rf/machine machine-id]). Returns a reaction over the snapshot map {:state :data :tags}, nil before the first event.
- sub-route — read the current route slice. Defined and exported from the re-frame.routing facade (NOT core) to preserve the routing bundle-isolation invariant. Signatures (sub-route) and (sub-route opts), delegating to (subscribe [:rf/route]). Returns a reaction over the route slice.

The [:rf/machine id] / [:rf/route] subscription vectors remain the registered canonical subs; the sugar layers over them. No call sites migrated; selector-recognizer and :<- chained inputs keep the literal vector form.

## opts passthrough note

The brief described the opts arity as delegating to (subscribe query-v opts). The real subscribe 2-arity is frame-first (subscribe frame-id query-v) with no opts-map form, so the opts {:frame target} capability is lowered to the existing frame-first 2-arity (subscribe target query-v); absent :frame it falls through to the ambient 1-arity. This preserves the {:frame f} capability the brief asked for and is correct against subscribe's real signature.

## Manifest

Added classification rows to spec/api-manifest-metadata.edn and regenerated spec/api-manifest.edn:
- [re-frame.core sub-machine] {:tier :advanced :owner 005 :status v1}
- [re-frame.routing sub-route] {:tier :advanced :owner 012 :status v1}

## Quality gates

- api-manifest drift-check: PASS — OK spec/api-manifest.edn in sync (486 public vars). Both new rows present.
- JVM load of re-frame.core / re-frame.core-machines / re-frame.routing: PASS (the manifest generator requires all three on the JVM and regenerated cleanly).
- npm run test:cljs (node-test bundle): PASS — Ran 8012 tests, 36860 assertions, 0 failures, 0 errors. Both new namespaces (re_frame.sub_machine_cljs_test + re_frame.sub_route_cljs_test) confirmed compiled into the bundle.
- New CLJS suites: re-frame.sub-machine-cljs-test (3 deftests) + re-frame.sub-route-cljs-test (3 deftests), each happy-path + adversarial (unspawned/unknown id -> nil snapshot; nil slice before navigation; {:frame f} opts passthrough resolves the right frame, isolated from the ambient default frame).

Full matrix left to CI.
