### PR TITLE
docs(migration): reconcile stale sub-machine references (rf2-38ywvj)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -319,9 +319,10 @@
 
 ;; ---- framework-shipped subs -----------------------------------------------
 ;;
-;; Per Spec 005 §Subscribing to machines via sub-machine: the framework
-;; ships `:rf/machine` as the canonical entry point — read a machine's
-;; snapshot with the subscription vector `(subscribe [:rf/machine id])`.
+;; Per Spec 005 §Subscribing to machines via the :rf/machine sub: the
+;; framework ships `:rf/machine` as the canonical entry point — read a
+;; machine's snapshot with the subscription vector `(subscribe [:rf/machine
+;; id])`, or the `sub-machine` read-sugar fn over it.
 ;;
 ;; Registered at the façade (rather than in `re-frame.machines.lifecycle-
 ;; fx`) so the smoke-test fixture's `(require 're-frame.machines :reload)`
@@ -333,7 +334,7 @@
 ;; `db`-position arg is the runtime-db value (Spec 002 §Subscriptions read
 ;; the partition they belong to).
 (subs/reg-runtime-sub :rf/machine
-  {:doc "Subscribe to a machine's current snapshot `{:state <kw> :data <map> :tags <set>}`. Returns nil for an unknown or not-yet-initialised machine. Per Spec 005 §Subscribing to machines via sub-machine."}
+  {:doc "Subscribe to a machine's current snapshot `{:state <kw> :data <map> :tags <set>}`. Returns nil for an unknown or not-yet-initialised machine. Per Spec 005 §Subscribing to machines via the :rf/machine sub."}
   (fn [runtime-db [_ machine-id]]
     (get-in runtime-db (paths/snapshot-path machine-id))))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -31,8 +31,8 @@
        panel chrome.
 
     3. **Active state** — read off `[:rf/machine <id>]` (Spec 005
-       §Subscribing to machines via sub-machine), surfaced on the
-       picker row + in the placeholder's prop summary.
+       §Subscribing to machines via the :rf/machine sub), surfaced on
+       the picker row + in the placeholder's prop summary.
 
     4. **Transition history ribbon** — filter the Xray trace buffer
        to `:rf.machine/transition` events for the selected machine and


### PR DESCRIPTION
Reconciles stale `sub-machine` references now that the `sub-machine` reactive-read sugar fn is back on the `re-frame.core` facade (PR #5056). Implements rf2-2cmcas; runs after the facade bead.

## What changed

**Category A — stale spec-section cross-references (the only genuine staleness).** Three docstrings/comments pointed at the old Spec 005 section name `§Subscribing to machines via sub-machine`, which was renamed to `§Subscribing to machines via the :rf/machine sub`. Corrected to the live name:

- `implementation/machines/src/re_frame/machines.cljc` — the `:rf/machine` `reg-runtime-sub` docstring and the comment block above it. The comment now also notes the re-added `sub-machine` read-sugar fn over the canonical `[:rf/machine id]` vector sub (matching the already-correct reference in `re-frame.core-machines/sub-machine`).
- `tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc` — the active-state panel doc.

**Category B — `sub-machine`-as-fn references: verified accurate, no edits.** Every reference describing `sub-machine` as a fn now correctly describes the re-added `(rf/sub-machine id)` / `(rf/sub-machine id opts)` facade fn that reads the snapshot. Verified and left unchanged:

- `migration/from-re-frame-v1/README.md` (reg-sub-raw lifecycle item, the artefact-split + "what to look for" lists, the exit-action snapshot peek, the parallel-region rewrite example)
- `migration/from-re-frame-v1/async-flow-fx-to-reg-machine.md`
- `skills/re-frame-migration/references/{auto-cross-cutting,breaking-changes,guided-interceptors-subs,sequencing}.md`
- `docs/EP/EP-0002-frame-target-resolution.md` (ambient context-defaulting surface lists — the 1-arity `sub-machine` resolves the ambient frame, so the entries are correct)
- `tools/machines-viz/spec/000-Vision.md`

## Quality gates

- `python -m mkdocs build --strict` from worktree root → **exit 0** (22.3s; docs/EP + migration are in the build).
- `re-frame.machines` JVM load + machines test suite (`clojure -M:test` in the machines artefact) → **845 tests / 2743 assertions, 0 failures, 0 errors** (confirms the docstring edits don't break compilation).
- xray spec: **unchanged because docstring-only** — the edit is a section-name cross-reference correction with no contract/behaviour change; `tools/xray/spec/*` carries no reference to the renamed section.

## Notes for the mayor (out of scope here)

- The `re-frame.core/sub-machine` symbol lives in the **core** artefact (`re-frame.core-machines`, pure sugar over `subscribe`) — sibling of `machine-has-tag?` — not the `day8/re-frame2-machines` artefact. The migration README's artefact-split prose (around L1345/L1364) groups `sub-machine` with the late-binding machines-artefact wrappers; `machine-has-tag?` (the same kind of core sugar) is correctly excluded there. This is a finer packaging-accuracy point, not a missing-fn/wrong-facade issue, and was outside this bead's enumerated targets — flagging in case a follow-up is wanted.