### PR TITLE
docs(routing): drop bottom-of-page "See also" sections from the how-tos

### DIFF
--- a/docs/routing/how-to/guard-unsaved-changes.md
+++ b/docs/routing/how-to/guard-unsaved-changes.md
@@ -90,9 +90,3 @@ Because the whole flow is events and a subscription, the test needs no browser, 
 That's the payoff of a guard that's *state*, not a side effect: every branch — blocked, confirmed, cancelled, bypassed — is a dispatch and an assertion.
 
 > **For JavaScript developers.** This replaces React Router's `useBlocker` / `usePrompt` and the old `beforeunload` hack, with two upgrades: the guard is a *subscription* (declarative, derived from state), and the pending navigation is *state you render from*, so your confirm dialog is a normal view rather than an imperative blocker object you drive by hand.
-
-## See also
-
-- [Concepts → Blocking a navigation](../concepts.md#blocking-a-navigation) — the same flow in the reference narrative, plus the `:rf.route/navigation-blocked` trace.
-- [Require sign-in on a route](require-sign-in-on-a-route.md) — the other navigation-control recipe: redirecting *into* a route instead of blocking the way *out*.
-- [Build a form](../../core/how-to/build-a-form.md) — where the draft/saved slice this guard checks comes from.

--- a/docs/routing/how-to/require-sign-in-on-a-route.md
+++ b/docs/routing/how-to/require-sign-in-on-a-route.md
@@ -86,14 +86,4 @@ Register the guard once, then name it by id in the frame's `:interceptors`. It s
    :interceptors [:app/auth-guard]})    ;; reference the registered guard by id
 ```
 
-That's the routing half done: protected routes are tagged, all three entry points are gated, and a logged-out reader is bounced to `/login`.
-
-## Where to go from here
-
-This page deliberately stops at the route boundary. The full recipe — the login form, persisting the token, decorating requests with it, **bouncing the reader back to where they were headed** after login, and a logout that clears the departing session's cached data — is [Add authentication](../../core/how-to/add-auth.md) (its step 4 is this guard, with the return-to bounce-back wired in). For the auth state machine once login/restore start coordinating, see [Machines](../../machines/concepts.md).
-
-## See also
-
-- [Concepts → Routes are queryable data](../concepts.md#routes-are-queryable-data) — the tag-and-read pattern this recipe is built on.
-- [Guard against unsaved changes](guard-unsaved-changes.md) — the other navigation-control recipe: blocking the way *out* of a route.
-- [Add authentication](../../core/how-to/add-auth.md) — the complete auth flow this guard slots into.
+That's the routing half done: protected routes are tagged, all three entry points are gated, and a logged-out reader is bounced to `/login`. The rest of the auth flow — the login form, the token, logout — is [Add authentication](../../core/how-to/add-auth.md), whose route guard is exactly this one.


### PR DESCRIPTION
Removes the trailing `## See also` / `## Where to go from here` link-list sections from the two routing how-tos. mkdocs' footer prev/next + the section index already handle wayfinding; the pages keep inline cross-links where they're contextual. The require-sign-in page keeps its one-line closing (this is the routing half; the rest is Add authentication) as inline prose.

**Scope:** routing how-tos only. The same `## See also` convention is uniform across **every API reference doc** (`docs/api/*`) and the xray/story API docs (~25 more files) — left untouched pending your call on whether to sweep site-wide.

Verified: `mkdocs build --strict` (exit 0), check_doc_slugs / check_readme_links / check_readme_inventories (exit 0).